### PR TITLE
Remove PartitionSelector insertion for DML operation

### DIFF
--- a/src/backend/gporca/data/dxl/minidump/DeleteMismatchedDistribution.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DeleteMismatchedDistribution.mdp
@@ -19,18 +19,17 @@
     ---------------------------------------------------------------------------------------------------------------------------------
      Delete  (cost=0.00..862.03 rows=1 width=1)
        ->  Result  (cost=0.00..862.00 rows=1 width=26)
-             ->  Partition Selector for pt2  (cost=0.00..862.00 rows=1 width=22)
-                   ->  Explicit Redistribute Motion 4:4  (slice2; segments: 4)  (cost=0.00..862.00 rows=1 width=22)
-                         ->  Hash EXISTS Join  (cost=0.00..862.00 rows=1 width=22)
-                               Hash Cond: public.pt2.i = r.b
-                               ->  Redistribute Motion 4:4  (slice1; segments: 4)  (cost=0.00..431.00 rows=1 width=22)
-                                     Hash Key: public.pt2.i
-                                     ->  Sequence  (cost=0.00..431.00 rows=1 width=22)
-                                           ->  Partition Selector for pt2 (dynamic scan id: 1)  (cost=10.00..100.00 rows=25 width=4)
-                                                 Partitions selected: 5 (out of 5)
-                                           ->  Dynamic Table Scan on pt2 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=22)
-                               ->  Hash  (cost=431.00..431.00 rows=1 width=4)
-                                     ->  Table Scan on r  (cost=0.00..431.00 rows=1 width=4)
+             ->  Explicit Redistribute Motion 4:4  (slice2; segments: 4)  (cost=0.00..862.00 rows=1 width=22)
+                   ->  Hash EXISTS Join  (cost=0.00..862.00 rows=1 width=22)
+                         Hash Cond: public.pt2.i = r.b
+                         ->  Redistribute Motion 4:4  (slice1; segments: 4)  (cost=0.00..431.00 rows=1 width=22)
+                               Hash Key: public.pt2.i
+                               ->  Sequence  (cost=0.00..431.00 rows=1 width=22)
+                                     ->  Partition Selector for pt2 (dynamic scan id: 1)  (cost=10.00..100.00 rows=25 width=4)
+                                           Partitions selected: 5 (out of 5)
+                                     ->  Dynamic Table Scan on pt2 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=22)
+                         ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+                               ->  Table Scan on r  (cost=0.00..431.00 rows=1 width=4)
      Optimizer status: PQO version 3.83.0
     (15 rows)
   ]]>
@@ -341,7 +340,7 @@
     <dxl:Plan Id="0" SpaceSize="40">
       <dxl:DMLDelete Columns="0,1,2" ActionCol="24" CtidCol="3" SegmentIdCol="9">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="862.025900" Rows="1.000000" Width="1"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.025894" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -371,7 +370,7 @@
         </dxl:TableDescriptor>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="862.000509" Rows="1.000000" Width="26"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.000503" Rows="1.000000" Width="26"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="i">
@@ -395,9 +394,9 @@
           </dxl:ProjList>
           <dxl:Filter/>
           <dxl:OneTimeFilter/>
-          <dxl:PartitionSelector RelationMdid="6.24803.1.0" PartitionLevels="1" ScanId="0">
+          <dxl:RoutedDistributeMotion SegmentIdCol="9" InputSegments="0,1,2,3" OutputSegments="0,1,2,3">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="862.000502" Rows="1.000000" Width="22"/>
+              <dxl:Cost StartupCost="0" TotalCost="862.000497" Rows="1.000000" Width="22"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="i">
@@ -416,26 +415,11 @@
                 <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
-            <dxl:PartEqFilters>
-              <dxl:PartEqFilterElems>
-                <dxl:Ident ColId="2" ColName="k" TypeMdid="0.23.1.0"/>
-              </dxl:PartEqFilterElems>
-            </dxl:PartEqFilters>
-            <dxl:PartFilters>
-              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-            </dxl:PartFilters>
-            <dxl:ResidualFilter>
-              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-            </dxl:ResidualFilter>
-            <dxl:PropagationExpression>
-              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
-            </dxl:PropagationExpression>
-            <dxl:PrintableFilter>
-              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-            </dxl:PrintableFilter>
-            <dxl:RoutedDistributeMotion SegmentIdCol="9" InputSegments="0,1,2,3" OutputSegments="0,1,2,3">
+            <dxl:Filter/>
+            <dxl:SortingColumnList/>
+            <dxl:HashJoin JoinType="In">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="862.000497" Rows="1.000000" Width="22"/>
+                <dxl:Cost StartupCost="0" TotalCost="862.000480" Rows="1.000000" Width="22"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="i">
@@ -455,10 +439,16 @@
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:SortingColumnList/>
-              <dxl:HashJoin JoinType="In">
+              <dxl:JoinFilter/>
+              <dxl:HashCondList>
+                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                  <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+                  <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
+                </dxl:Comparison>
+              </dxl:HashCondList>
+              <dxl:RedistributeMotion InputSegments="0,1,2,3" OutputSegments="0,1,2,3">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="862.000480" Rows="1.000000" Width="22"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000052" Rows="1.000000" Width="22"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="i">
@@ -478,16 +468,15 @@
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
-                <dxl:JoinFilter/>
-                <dxl:HashCondList>
-                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                <dxl:SortingColumnList/>
+                <dxl:HashExprList>
+                  <dxl:HashExpr>
                     <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-                    <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
-                  </dxl:Comparison>
-                </dxl:HashCondList>
-                <dxl:RedistributeMotion InputSegments="0,1,2,3" OutputSegments="0,1,2,3">
+                  </dxl:HashExpr>
+                </dxl:HashExprList>
+                <dxl:Sequence>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000052" Rows="1.000000" Width="22"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000006" Rows="1.000000" Width="22"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="0" Alias="i">
@@ -506,14 +495,28 @@
                       <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:SortingColumnList/>
-                  <dxl:HashExprList>
-                    <dxl:HashExpr>
-                      <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-                    </dxl:HashExpr>
-                  </dxl:HashExprList>
-                  <dxl:Sequence>
+                  <dxl:PartitionSelector RelationMdid="6.24803.1.0" PartitionLevels="1" ScanId="1">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="10" TotalCost="100" Rows="100" Width="4"/>
+                    </dxl:Properties>
+                    <dxl:ProjList/>
+                    <dxl:PartEqFilters>
+                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                    </dxl:PartEqFilters>
+                    <dxl:PartFilters>
+                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                    </dxl:PartFilters>
+                    <dxl:ResidualFilter>
+                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                    </dxl:ResidualFilter>
+                    <dxl:PropagationExpression>
+                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                    </dxl:PropagationExpression>
+                    <dxl:PrintableFilter>
+                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                    </dxl:PrintableFilter>
+                  </dxl:PartitionSelector>
+                  <dxl:DynamicTableScan PartIndexId="1">
                     <dxl:Properties>
                       <dxl:Cost StartupCost="0" TotalCost="431.000006" Rows="1.000000" Width="22"/>
                     </dxl:Properties>
@@ -534,92 +537,49 @@
                         <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
                     </dxl:ProjList>
-                    <dxl:PartitionSelector RelationMdid="6.24803.1.0" PartitionLevels="1" ScanId="1">
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="10" TotalCost="100" Rows="100" Width="4"/>
-                      </dxl:Properties>
-                      <dxl:ProjList/>
-                      <dxl:PartEqFilters>
-                        <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                      </dxl:PartEqFilters>
-                      <dxl:PartFilters>
-                        <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                      </dxl:PartFilters>
-                      <dxl:ResidualFilter>
-                        <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                      </dxl:ResidualFilter>
-                      <dxl:PropagationExpression>
-                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                      </dxl:PropagationExpression>
-                      <dxl:PrintableFilter>
-                        <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                      </dxl:PrintableFilter>
-                    </dxl:PartitionSelector>
-                    <dxl:DynamicTableScan PartIndexId="1">
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000006" Rows="1.000000" Width="22"/>
-                      </dxl:Properties>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="0" Alias="i">
-                          <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="1" Alias="j">
-                          <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="2" Alias="k">
-                          <dxl:Ident ColId="2" ColName="k" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="3" Alias="ctid">
-                          <dxl:Ident ColId="3" ColName="ctid" TypeMdid="0.27.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="9" Alias="gp_segment_id">
-                          <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
-                      <dxl:Filter/>
-                      <dxl:TableDescriptor Mdid="6.24803.1.0" TableName="pt2">
-                        <dxl:Columns>
-                          <dxl:Column ColId="0" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
-                          <dxl:Column ColId="1" Attno="2" ColName="j" TypeMdid="0.23.1.0" ColWidth="4"/>
-                          <dxl:Column ColId="2" Attno="3" ColName="k" TypeMdid="0.23.1.0" ColWidth="4"/>
-                          <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                          <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                          <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                          <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                          <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                          <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                          <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                        </dxl:Columns>
-                      </dxl:TableDescriptor>
-                    </dxl:DynamicTableScan>
-                  </dxl:Sequence>
-                </dxl:RedistributeMotion>
-                <dxl:TableScan>
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000023" Rows="1.000000" Width="4"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="11" Alias="b">
-                      <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:TableDescriptor Mdid="6.24827.1.0" TableName="r">
-                    <dxl:Columns>
-                      <dxl:Column ColId="11" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                      <dxl:Column ColId="14" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="15" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="16" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="17" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="18" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="19" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                    </dxl:Columns>
-                  </dxl:TableDescriptor>
-                </dxl:TableScan>
-              </dxl:HashJoin>
-            </dxl:RoutedDistributeMotion>
-          </dxl:PartitionSelector>
+                    <dxl:Filter/>
+                    <dxl:TableDescriptor Mdid="6.24803.1.0" TableName="pt2">
+                      <dxl:Columns>
+                        <dxl:Column ColId="0" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="1" Attno="2" ColName="j" TypeMdid="0.23.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="2" Attno="3" ColName="k" TypeMdid="0.23.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                        <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      </dxl:Columns>
+                    </dxl:TableDescriptor>
+                  </dxl:DynamicTableScan>
+                </dxl:Sequence>
+              </dxl:RedistributeMotion>
+              <dxl:TableScan>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000023" Rows="1.000000" Width="4"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="11" Alias="b">
+                    <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:TableDescriptor Mdid="6.24827.1.0" TableName="r">
+                  <dxl:Columns>
+                    <dxl:Column ColId="11" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                    <dxl:Column ColId="14" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="15" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="16" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="17" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="18" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="19" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:TableScan>
+            </dxl:HashJoin>
+          </dxl:RoutedDistributeMotion>
         </dxl:Result>
       </dxl:DMLDelete>
     </dxl:Plan>

--- a/src/backend/gporca/data/dxl/minidump/Insert-Parquet-Partitioned-SortDisabled.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Insert-Parquet-Partitioned-SortDisabled.mdp
@@ -4,7 +4,7 @@
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
       <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
-      <dxl:CTEConfig CTEInliningCutoff="0"/> 
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="101013,102001,102002,102003,102024,102025,102115,102116,102117,102119,102144,103001,103018,103027,103033"/>
     </dxl:OptimizerConfig>
@@ -231,7 +231,7 @@
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:DMLInsert Columns="0,1" ActionCol="9" CtidCol="0" SegmentIdCol="0">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.023471" Rows="1.000000" Width="12"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.023465" Rows="1.000000" Width="12"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -253,7 +253,7 @@
         </dxl:TableDescriptor>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.000034" Rows="1.000000" Width="12"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000028" Rows="1.000000" Width="12"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -268,9 +268,9 @@
           </dxl:ProjList>
           <dxl:Filter/>
           <dxl:OneTimeFilter/>
-          <dxl:PartitionSelector RelationMdid="6.1319741.1.1" PartitionLevels="1" ScanId="0">
+          <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000028" Rows="1.000000" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="12"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -280,51 +280,21 @@
                 <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
-            <dxl:PartEqFilters>
-              <dxl:PartEqFilterElems>
-                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-              </dxl:PartEqFilterElems>
-            </dxl:PartEqFilters>
-            <dxl:PartFilters>
-              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-            </dxl:PartFilters>
-            <dxl:ResidualFilter>
-              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-            </dxl:ResidualFilter>
-            <dxl:PropagationExpression>
-              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
-            </dxl:PropagationExpression>
-            <dxl:PrintableFilter>
-              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-            </dxl:PrintableFilter>
-            <dxl:TableScan>
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000010" Rows="1.000000" Width="12"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="0" Alias="a">
-                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="1" Alias="b">
-                  <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:TableDescriptor Mdid="6.1095673.1.1" TableName="r">
-                <dxl:Columns>
-                  <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                  <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                  <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                </dxl:Columns>
-              </dxl:TableDescriptor>
-            </dxl:TableScan>
-          </dxl:PartitionSelector>
+            <dxl:Filter/>
+            <dxl:TableDescriptor Mdid="6.1095673.1.1" TableName="r">
+              <dxl:Columns>
+                <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
         </dxl:Result>
       </dxl:DMLInsert>
     </dxl:Plan>

--- a/src/backend/gporca/data/dxl/minidump/InsertMismatchedDistrubution-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InsertMismatchedDistrubution-2.mdp
@@ -267,7 +267,7 @@ explain insert into pt2 select * from r;
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:DMLInsert Columns="0,1,2" ActionCol="10" CtidCol="0" SegmentIdCol="0">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.031317" Rows="1.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.031309" Rows="1.000000" Width="16"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -297,7 +297,7 @@ explain insert into pt2 select * from r;
         </dxl:TableDescriptor>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.000067" Rows="1.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000059" Rows="1.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -315,9 +315,9 @@ explain insert into pt2 select * from r;
           </dxl:ProjList>
           <dxl:Filter/>
           <dxl:OneTimeFilter/>
-          <dxl:PartitionSelector RelationMdid="6.1695223.1.1" PartitionLevels="1" ScanId="0">
+          <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000059" Rows="1.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000051" Rows="1.000000" Width="16"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -330,26 +330,16 @@ explain insert into pt2 select * from r;
                 <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
-            <dxl:PartEqFilters>
-              <dxl:PartEqFilterElems>
-                <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
-              </dxl:PartEqFilterElems>
-            </dxl:PartEqFilters>
-            <dxl:PartFilters>
-              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-            </dxl:PartFilters>
-            <dxl:ResidualFilter>
-              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-            </dxl:ResidualFilter>
-            <dxl:PropagationExpression>
-              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
-            </dxl:PropagationExpression>
-            <dxl:PrintableFilter>
-              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-            </dxl:PrintableFilter>
-            <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
+            <dxl:Filter/>
+            <dxl:SortingColumnList/>
+            <dxl:HashExprList>
+              <dxl:HashExpr>
+                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:HashExpr>
+            </dxl:HashExprList>
+            <dxl:TableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000051" Rows="1.000000" Width="16"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000012" Rows="1.000000" Width="16"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">
@@ -363,45 +353,22 @@ explain insert into pt2 select * from r;
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:SortingColumnList/>
-              <dxl:HashExprList>
-                <dxl:HashExpr>
-                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                </dxl:HashExpr>
-              </dxl:HashExprList>
-              <dxl:TableScan>
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000012" Rows="1.000000" Width="16"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="0" Alias="a">
-                    <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="1" Alias="b">
-                    <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="2" Alias="c">
-                    <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:TableDescriptor Mdid="6.1695445.1.1" TableName="r">
-                  <dxl:Columns>
-                    <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-                    <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
-                    <dxl:Column ColId="2" Attno="3" ColName="c" TypeMdid="0.23.1.0"/>
-                    <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                    <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                    <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                    <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                    <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                    <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                    <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                  </dxl:Columns>
-                </dxl:TableDescriptor>
-              </dxl:TableScan>
-            </dxl:RedistributeMotion>
-          </dxl:PartitionSelector>
+              <dxl:TableDescriptor Mdid="6.1695445.1.1" TableName="r">
+                <dxl:Columns>
+                  <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="2" Attno="3" ColName="c" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                  <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                  <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                  <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                  <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                  <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                  <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:TableScan>
+          </dxl:RedistributeMotion>
         </dxl:Result>
       </dxl:DMLInsert>
     </dxl:Plan>

--- a/src/backend/gporca/data/dxl/minidump/InsertMismatchedDistrubution.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InsertMismatchedDistrubution.mdp
@@ -11,7 +11,7 @@ explain insert into pt2 select * from r;
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
       <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
-      <dxl:CTEConfig CTEInliningCutoff="0"/> 
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="2">
         <dxl:CostParams>
@@ -267,7 +267,7 @@ explain insert into pt2 select * from r;
     <dxl:Plan Id="0" SpaceSize="2">
       <dxl:DMLInsert Columns="0,1,2" ActionCol="10" CtidCol="0" SegmentIdCol="0">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.031292" Rows="1.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.031284" Rows="1.000000" Width="16"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -297,7 +297,7 @@ explain insert into pt2 select * from r;
         </dxl:TableDescriptor>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.000042" Rows="1.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000034" Rows="1.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -315,9 +315,9 @@ explain insert into pt2 select * from r;
           </dxl:ProjList>
           <dxl:Filter/>
           <dxl:OneTimeFilter/>
-          <dxl:PartitionSelector RelationMdid="6.1695223.1.1" PartitionLevels="1" ScanId="0">
+          <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000034" Rows="1.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000012" Rows="1.000000" Width="16"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -330,55 +330,22 @@ explain insert into pt2 select * from r;
                 <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
-            <dxl:PartEqFilters>
-              <dxl:PartEqFilterElems>
-                <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
-              </dxl:PartEqFilterElems>
-            </dxl:PartEqFilters>
-            <dxl:PartFilters>
-              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-            </dxl:PartFilters>
-            <dxl:ResidualFilter>
-              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-            </dxl:ResidualFilter>
-            <dxl:PropagationExpression>
-              <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
-            </dxl:PropagationExpression>
-            <dxl:PrintableFilter>
-              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-            </dxl:PrintableFilter>
-            <dxl:TableScan>
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000012" Rows="1.000000" Width="16"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="0" Alias="a">
-                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="1" Alias="b">
-                  <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="2" Alias="c">
-                  <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:TableDescriptor Mdid="6.1695445.1.1" TableName="r">
-                <dxl:Columns>
-                  <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="2" Attno="3" ColName="c" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                  <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                  <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                </dxl:Columns>
-              </dxl:TableDescriptor>
-            </dxl:TableScan>
-          </dxl:PartitionSelector>
+            <dxl:Filter/>
+            <dxl:TableDescriptor Mdid="6.1695445.1.1" TableName="r">
+              <dxl:Columns>
+                <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="2" Attno="3" ColName="c" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
         </dxl:Result>
       </dxl:DMLInsert>
     </dxl:Plan>

--- a/src/backend/gporca/data/dxl/minidump/LeftJoin-With-Pred-On-Inner2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LeftJoin-With-Pred-On-Inner2.mdp
@@ -4,7 +4,7 @@
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
       <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
-      <dxl:CTEConfig CTEInliningCutoff="0"/> 
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="7000" Rank="7001"/>
       <dxl:TraceFlags Value="101013,102001,102002,102003,102144,103001,103027,103033"/>
     </dxl:OptimizerConfig>

--- a/src/backend/gporca/data/dxl/minidump/UpdateDistKeyMismatchedDistribution.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdateDistKeyMismatchedDistribution.mdp
@@ -18,21 +18,20 @@
                                                              QUERY PLAN
     -----------------------------------------------------------------------------------------------------------------------------
      Update  (cost=0.00..1324057.85 rows=1 width=1)
-       ->  Partition Selector for pt2  (cost=0.00..1324057.79 rows=1 width=30)
-             ->  Redistribute Motion 4:4  (slice2; segments: 4)  (cost=0.00..1324057.79 rows=1 width=26)
-                   Hash Key: public.pt2.i
-                   ->  Split  (cost=0.00..1324057.79 rows=1 width=26)
-                         ->  Result  (cost=0.00..1324057.79 rows=1 width=26)
-                               ->  Sequence  (cost=0.00..431.00 rows=1 width=22)
-                                     ->  Partition Selector for pt2 (dynamic scan id: 1)  (cost=10.00..100.00 rows=25 width=4)
-                                           Partitions selected: 5 (out of 5)
-                                     ->  Dynamic Table Scan on pt2 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=22)
-                               SubPlan 1
-                                 ->  Result  (cost=0.00..431.00 rows=1 width=4)
-                                       Filter: $0 = r.b
-                                       ->  Materialize  (cost=0.00..431.00 rows=1 width=8)
-                                             ->  Broadcast Motion 4:4  (slice1; segments: 4)  (cost=0.00..431.00 rows=1 width=8)
-                                                   ->  Table Scan on r  (cost=0.00..431.00 rows=1 width=8)
+       ->  Redistribute Motion 4:4  (slice2; segments: 4)  (cost=0.00..1324057.79 rows=1 width=26)
+             Hash Key: public.pt2.i
+             ->  Split  (cost=0.00..1324057.79 rows=1 width=26)
+                   ->  Result  (cost=0.00..1324057.79 rows=1 width=26)
+                         ->  Sequence  (cost=0.00..431.00 rows=1 width=22)
+                               ->  Partition Selector for pt2 (dynamic scan id: 1)  (cost=10.00..100.00 rows=25 width=4)
+                                     Partitions selected: 5 (out of 5)
+                               ->  Dynamic Table Scan on pt2 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=22)
+                         SubPlan 1
+                           ->  Result  (cost=0.00..431.00 rows=1 width=4)
+                                 Filter: $0 = r.b
+                                 ->  Materialize  (cost=0.00..431.00 rows=1 width=8)
+                                       ->  Broadcast Motion 4:4  (slice1; segments: 4)  (cost=0.00..431.00 rows=1 width=8)
+                                             ->  Table Scan on r  (cost=0.00..431.00 rows=1 width=8)
      Optimizer status: PQO version 3.83.0
     (17 rows)  ]]>
   </dxl:Comment>
@@ -305,7 +304,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:DMLUpdate Columns="0,1,2" ActionCol="21" CtidCol="3" SegmentIdCol="9" PreserveOids="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1324057.842941" Rows="1.000000" Width="1"/>
+          <dxl:Cost StartupCost="0" TotalCost="1324057.842928" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -333,9 +332,9 @@
             <dxl:Column ColId="31" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
-        <dxl:PartitionSelector RelationMdid="6.24803.1.0" PartitionLevels="1" ScanId="0">
+        <dxl:RedistributeMotion InputSegments="0,1,2,3" OutputSegments="0,1,2,3">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1324057.792160" Rows="2.000000" Width="26"/>
+            <dxl:Cost StartupCost="0" TotalCost="1324057.792147" Rows="2.000000" Width="26"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="i">
@@ -357,26 +356,16 @@
               <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
-          <dxl:PartEqFilters>
-            <dxl:PartEqFilterElems>
-              <dxl:Ident ColId="2" ColName="k" TypeMdid="0.23.1.0"/>
-            </dxl:PartEqFilterElems>
-          </dxl:PartEqFilters>
-          <dxl:PartFilters>
-            <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-          </dxl:PartFilters>
-          <dxl:ResidualFilter>
-            <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-          </dxl:ResidualFilter>
-          <dxl:PropagationExpression>
-            <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
-          </dxl:PropagationExpression>
-          <dxl:PrintableFilter>
-            <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-          </dxl:PrintableFilter>
-          <dxl:RedistributeMotion InputSegments="0,1,2,3" OutputSegments="0,1,2,3">
+          <dxl:Filter/>
+          <dxl:SortingColumnList/>
+          <dxl:HashExprList>
+            <dxl:HashExpr>
+              <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+            </dxl:HashExpr>
+          </dxl:HashExprList>
+          <dxl:Split DeleteColumns="0,1,2" InsertColumns="20,1,2" ActionCol="21" CtidCol="3" SegmentIdCol="9" PreserveOids="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1324057.792147" Rows="2.000000" Width="26"/>
+              <dxl:Cost StartupCost="0" TotalCost="1324057.792106" Rows="2.000000" Width="26"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="i">
@@ -395,19 +384,12 @@
                 <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
               <dxl:ProjElem ColId="21" Alias="ColRef_0021">
-                <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.23.1.0"/>
+                <dxl:DMLAction/>
               </dxl:ProjElem>
             </dxl:ProjList>
-            <dxl:Filter/>
-            <dxl:SortingColumnList/>
-            <dxl:HashExprList>
-              <dxl:HashExpr>
-                <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-              </dxl:HashExpr>
-            </dxl:HashExprList>
-            <dxl:Split DeleteColumns="0,1,2" InsertColumns="20,1,2" ActionCol="21" CtidCol="3" SegmentIdCol="9" PreserveOids="false">
+            <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1324057.792106" Rows="2.000000" Width="26"/>
+                <dxl:Cost StartupCost="0" TotalCost="1324057.792093" Rows="1.000000" Width="26"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="i">
@@ -419,19 +401,99 @@
                 <dxl:ProjElem ColId="2" Alias="k">
                   <dxl:Ident ColId="2" ColName="k" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
+                <dxl:ProjElem ColId="20" Alias="i">
+                  <dxl:SubPlan TypeMdid="0.23.1.0" SubPlanType="ScalarSubPlan">
+                    <dxl:TestExpr/>
+                    <dxl:ParamList>
+                      <dxl:Param ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+                    </dxl:ParamList>
+                    <dxl:Result>
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000552" Rows="4.000000" Width="4"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="12" Alias="c">
+                          <dxl:Ident ColId="12" ColName="c" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter>
+                        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                          <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+                          <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
+                        </dxl:Comparison>
+                      </dxl:Filter>
+                      <dxl:OneTimeFilter/>
+                      <dxl:Materialize Eager="false">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000486" Rows="4.000000" Width="8"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="11" Alias="b">
+                            <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="12" Alias="c">
+                            <dxl:Ident ColId="12" ColName="c" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:BroadcastMotion InputSegments="0,1,2,3" OutputSegments="0,1,2,3">
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000478" Rows="4.000000" Width="8"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="11" Alias="b">
+                              <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="12" Alias="c">
+                              <dxl:Ident ColId="12" ColName="c" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:SortingColumnList/>
+                          <dxl:TableScan>
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="0" TotalCost="431.000023" Rows="1.000000" Width="8"/>
+                            </dxl:Properties>
+                            <dxl:ProjList>
+                              <dxl:ProjElem ColId="11" Alias="b">
+                                <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="12" Alias="c">
+                                <dxl:Ident ColId="12" ColName="c" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                            </dxl:ProjList>
+                            <dxl:Filter/>
+                            <dxl:TableDescriptor Mdid="6.24827.1.0" TableName="r">
+                              <dxl:Columns>
+                                <dxl:Column ColId="11" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="12" Attno="3" ColName="c" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                                <dxl:Column ColId="14" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="15" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="16" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="17" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="18" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="19" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                              </dxl:Columns>
+                            </dxl:TableDescriptor>
+                          </dxl:TableScan>
+                        </dxl:BroadcastMotion>
+                      </dxl:Materialize>
+                    </dxl:Result>
+                  </dxl:SubPlan>
+                </dxl:ProjElem>
                 <dxl:ProjElem ColId="3" Alias="ctid">
                   <dxl:Ident ColId="3" ColName="ctid" TypeMdid="0.27.1.0"/>
                 </dxl:ProjElem>
                 <dxl:ProjElem ColId="9" Alias="gp_segment_id">
                   <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
-                <dxl:ProjElem ColId="21" Alias="ColRef_0021">
-                  <dxl:DMLAction/>
-                </dxl:ProjElem>
               </dxl:ProjList>
-              <dxl:Result>
+              <dxl:Filter/>
+              <dxl:OneTimeFilter/>
+              <dxl:Sequence>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1324057.792093" Rows="1.000000" Width="26"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000006" Rows="1.000000" Width="22"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="i">
@@ -443,87 +505,6 @@
                   <dxl:ProjElem ColId="2" Alias="k">
                     <dxl:Ident ColId="2" ColName="k" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
-                  <dxl:ProjElem ColId="20" Alias="i">
-                    <dxl:SubPlan TypeMdid="0.23.1.0" SubPlanType="ScalarSubPlan">
-                      <dxl:TestExpr/>
-                      <dxl:ParamList>
-                        <dxl:Param ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-                      </dxl:ParamList>
-                      <dxl:Result>
-                        <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="431.000552" Rows="4.000000" Width="4"/>
-                        </dxl:Properties>
-                        <dxl:ProjList>
-                          <dxl:ProjElem ColId="12" Alias="c">
-                            <dxl:Ident ColId="12" ColName="c" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
-                        </dxl:ProjList>
-                        <dxl:Filter>
-                          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                            <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-                            <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
-                          </dxl:Comparison>
-                        </dxl:Filter>
-                        <dxl:OneTimeFilter/>
-                        <dxl:Materialize Eager="false">
-                          <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="431.000486" Rows="4.000000" Width="8"/>
-                          </dxl:Properties>
-                          <dxl:ProjList>
-                            <dxl:ProjElem ColId="11" Alias="b">
-                              <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="12" Alias="c">
-                              <dxl:Ident ColId="12" ColName="c" TypeMdid="0.23.1.0"/>
-                            </dxl:ProjElem>
-                          </dxl:ProjList>
-                          <dxl:Filter/>
-                          <dxl:BroadcastMotion InputSegments="0,1,2,3" OutputSegments="0,1,2,3">
-                            <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="431.000478" Rows="4.000000" Width="8"/>
-                            </dxl:Properties>
-                            <dxl:ProjList>
-                              <dxl:ProjElem ColId="11" Alias="b">
-                                <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
-                              </dxl:ProjElem>
-                              <dxl:ProjElem ColId="12" Alias="c">
-                                <dxl:Ident ColId="12" ColName="c" TypeMdid="0.23.1.0"/>
-                              </dxl:ProjElem>
-                            </dxl:ProjList>
-                            <dxl:Filter/>
-                            <dxl:SortingColumnList/>
-                            <dxl:TableScan>
-                              <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="431.000023" Rows="1.000000" Width="8"/>
-                              </dxl:Properties>
-                              <dxl:ProjList>
-                                <dxl:ProjElem ColId="11" Alias="b">
-                                  <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
-                                </dxl:ProjElem>
-                                <dxl:ProjElem ColId="12" Alias="c">
-                                  <dxl:Ident ColId="12" ColName="c" TypeMdid="0.23.1.0"/>
-                                </dxl:ProjElem>
-                              </dxl:ProjList>
-                              <dxl:Filter/>
-                              <dxl:TableDescriptor Mdid="6.24827.1.0" TableName="r">
-                                <dxl:Columns>
-                                  <dxl:Column ColId="11" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
-                                  <dxl:Column ColId="12" Attno="3" ColName="c" TypeMdid="0.23.1.0" ColWidth="4"/>
-                                  <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                                  <dxl:Column ColId="14" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                                  <dxl:Column ColId="15" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                                  <dxl:Column ColId="16" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                                  <dxl:Column ColId="17" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                                  <dxl:Column ColId="18" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                                  <dxl:Column ColId="19" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                                </dxl:Columns>
-                              </dxl:TableDescriptor>
-                            </dxl:TableScan>
-                          </dxl:BroadcastMotion>
-                        </dxl:Materialize>
-                      </dxl:Result>
-                    </dxl:SubPlan>
-                  </dxl:ProjElem>
                   <dxl:ProjElem ColId="3" Alias="ctid">
                     <dxl:Ident ColId="3" ColName="ctid" TypeMdid="0.27.1.0"/>
                   </dxl:ProjElem>
@@ -531,9 +512,28 @@
                     <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:OneTimeFilter/>
-                <dxl:Sequence>
+                <dxl:PartitionSelector RelationMdid="6.24803.1.0" PartitionLevels="1" ScanId="1">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="10" TotalCost="100" Rows="100" Width="4"/>
+                  </dxl:Properties>
+                  <dxl:ProjList/>
+                  <dxl:PartEqFilters>
+                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                  </dxl:PartEqFilters>
+                  <dxl:PartFilters>
+                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                  </dxl:PartFilters>
+                  <dxl:ResidualFilter>
+                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                  </dxl:ResidualFilter>
+                  <dxl:PropagationExpression>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                  </dxl:PropagationExpression>
+                  <dxl:PrintableFilter>
+                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                  </dxl:PrintableFilter>
+                </dxl:PartitionSelector>
+                <dxl:DynamicTableScan PartIndexId="1">
                   <dxl:Properties>
                     <dxl:Cost StartupCost="0" TotalCost="431.000006" Rows="1.000000" Width="22"/>
                   </dxl:Properties>
@@ -554,69 +554,26 @@
                       <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
-                  <dxl:PartitionSelector RelationMdid="6.24803.1.0" PartitionLevels="1" ScanId="1">
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="10" TotalCost="100" Rows="100" Width="4"/>
-                    </dxl:Properties>
-                    <dxl:ProjList/>
-                    <dxl:PartEqFilters>
-                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                    </dxl:PartEqFilters>
-                    <dxl:PartFilters>
-                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                    </dxl:PartFilters>
-                    <dxl:ResidualFilter>
-                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                    </dxl:ResidualFilter>
-                    <dxl:PropagationExpression>
-                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                    </dxl:PropagationExpression>
-                    <dxl:PrintableFilter>
-                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                    </dxl:PrintableFilter>
-                  </dxl:PartitionSelector>
-                  <dxl:DynamicTableScan PartIndexId="1">
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000006" Rows="1.000000" Width="22"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="0" Alias="i">
-                        <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="1" Alias="j">
-                        <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="2" Alias="k">
-                        <dxl:Ident ColId="2" ColName="k" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="3" Alias="ctid">
-                        <dxl:Ident ColId="3" ColName="ctid" TypeMdid="0.27.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="9" Alias="gp_segment_id">
-                        <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:Filter/>
-                    <dxl:TableDescriptor Mdid="6.24803.1.0" TableName="pt2">
-                      <dxl:Columns>
-                        <dxl:Column ColId="0" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="1" Attno="2" ColName="j" TypeMdid="0.23.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="2" Attno="3" ColName="k" TypeMdid="0.23.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                        <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                      </dxl:Columns>
-                    </dxl:TableDescriptor>
-                  </dxl:DynamicTableScan>
-                </dxl:Sequence>
-              </dxl:Result>
-            </dxl:Split>
-          </dxl:RedistributeMotion>
-        </dxl:PartitionSelector>
+                  <dxl:Filter/>
+                  <dxl:TableDescriptor Mdid="6.24803.1.0" TableName="pt2">
+                    <dxl:Columns>
+                      <dxl:Column ColId="0" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="1" Attno="2" ColName="j" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="2" Attno="3" ColName="k" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                      <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    </dxl:Columns>
+                  </dxl:TableDescriptor>
+                </dxl:DynamicTableScan>
+              </dxl:Sequence>
+            </dxl:Result>
+          </dxl:Split>
+        </dxl:RedistributeMotion>
       </dxl:DMLUpdate>
     </dxl:Plan>
   </dxl:Thread>

--- a/src/backend/gporca/data/dxl/minidump/UpdateDroppedCols.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdateDroppedCols.mdp
@@ -249,7 +249,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:DMLUpdate Columns="0,1" ActionCol="10" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.086136" Rows="1.000000" Width="1"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.086114" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -273,9 +273,9 @@
             <dxl:Column ColId="19" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
-        <dxl:PartitionSelector RelationMdid="6.224805.1.1" PartitionLevels="1" ScanId="0">
+        <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.000198" Rows="2.000000" Width="22"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000176" Rows="2.000000" Width="22"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="b">
@@ -294,26 +294,16 @@
               <dxl:Ident ColId="10" ColName="ColRef_0010" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
-          <dxl:PartEqFilters>
-            <dxl:PartEqFilterElems>
-              <dxl:Ident ColId="1" ColName="c" TypeMdid="0.23.1.0"/>
-            </dxl:PartEqFilterElems>
-          </dxl:PartEqFilters>
-          <dxl:PartFilters>
-            <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-          </dxl:PartFilters>
-          <dxl:ResidualFilter>
-            <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-          </dxl:ResidualFilter>
-          <dxl:PropagationExpression>
-            <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
-          </dxl:PropagationExpression>
-          <dxl:PrintableFilter>
-            <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-          </dxl:PrintableFilter>
-          <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
+          <dxl:Filter/>
+          <dxl:SortingColumnList/>
+          <dxl:HashExprList>
+            <dxl:HashExpr>
+              <dxl:Ident ColId="0" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:HashExpr>
+          </dxl:HashExprList>
+          <dxl:Split DeleteColumns="0,1" InsertColumns="9,1" ActionCol="10" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000176" Rows="2.000000" Width="22"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000107" Rows="2.000000" Width="22"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="b">
@@ -329,19 +319,12 @@
                 <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
               <dxl:ProjElem ColId="10" Alias="ColRef_0010">
-                <dxl:Ident ColId="10" ColName="ColRef_0010" TypeMdid="0.23.1.0"/>
+                <dxl:DMLAction/>
               </dxl:ProjElem>
             </dxl:ProjList>
-            <dxl:Filter/>
-            <dxl:SortingColumnList/>
-            <dxl:HashExprList>
-              <dxl:HashExpr>
-                <dxl:Ident ColId="0" ColName="b" TypeMdid="0.23.1.0"/>
-              </dxl:HashExpr>
-            </dxl:HashExprList>
-            <dxl:Split DeleteColumns="0,1" InsertColumns="9,1" ActionCol="10" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
+            <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000107" Rows="2.000000" Width="22"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000085" Rows="1.000000" Width="22"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="b">
@@ -350,19 +333,21 @@
                 <dxl:ProjElem ColId="1" Alias="c">
                   <dxl:Ident ColId="1" ColName="c" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
+                <dxl:ProjElem ColId="9" Alias="b">
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="3"/>
+                </dxl:ProjElem>
                 <dxl:ProjElem ColId="2" Alias="ctid">
                   <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
                 </dxl:ProjElem>
                 <dxl:ProjElem ColId="8" Alias="gp_segment_id">
                   <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
-                <dxl:ProjElem ColId="10" Alias="ColRef_0010">
-                  <dxl:DMLAction/>
-                </dxl:ProjElem>
               </dxl:ProjList>
-              <dxl:Result>
+              <dxl:Filter/>
+              <dxl:OneTimeFilter/>
+              <dxl:Sequence>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000085" Rows="1.000000" Width="22"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000074" Rows="1.000000" Width="22"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="b">
@@ -371,9 +356,6 @@
                   <dxl:ProjElem ColId="1" Alias="c">
                     <dxl:Ident ColId="1" ColName="c" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
-                  <dxl:ProjElem ColId="9" Alias="b">
-                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="3"/>
-                  </dxl:ProjElem>
                   <dxl:ProjElem ColId="2" Alias="ctid">
                     <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
                   </dxl:ProjElem>
@@ -381,9 +363,28 @@
                     <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:OneTimeFilter/>
-                <dxl:Sequence>
+                <dxl:PartitionSelector RelationMdid="6.224805.1.1" PartitionLevels="1" ScanId="1">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="10" TotalCost="100" Rows="100" Width="4"/>
+                  </dxl:Properties>
+                  <dxl:ProjList/>
+                  <dxl:PartEqFilters>
+                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                  </dxl:PartEqFilters>
+                  <dxl:PartFilters>
+                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                  </dxl:PartFilters>
+                  <dxl:ResidualFilter>
+                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                  </dxl:ResidualFilter>
+                  <dxl:PropagationExpression>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                  </dxl:PropagationExpression>
+                  <dxl:PrintableFilter>
+                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                  </dxl:PrintableFilter>
+                </dxl:PartitionSelector>
+                <dxl:DynamicTableScan PartIndexId="1">
                   <dxl:Properties>
                     <dxl:Cost StartupCost="0" TotalCost="431.000074" Rows="1.000000" Width="22"/>
                   </dxl:Properties>
@@ -401,70 +402,30 @@
                       <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
-                  <dxl:PartitionSelector RelationMdid="6.224805.1.1" PartitionLevels="1" ScanId="1">
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="10" TotalCost="100" Rows="100" Width="4"/>
-                    </dxl:Properties>
-                    <dxl:ProjList/>
-                    <dxl:PartEqFilters>
-                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                    </dxl:PartEqFilters>
-                    <dxl:PartFilters>
-                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                    </dxl:PartFilters>
-                    <dxl:ResidualFilter>
-                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                    </dxl:ResidualFilter>
-                    <dxl:PropagationExpression>
+                  <dxl:Filter>
+                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                      <dxl:Ident ColId="0" ColName="b" TypeMdid="0.23.1.0"/>
                       <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                    </dxl:PropagationExpression>
-                    <dxl:PrintableFilter>
-                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                    </dxl:PrintableFilter>
-                  </dxl:PartitionSelector>
-                  <dxl:DynamicTableScan PartIndexId="1">
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000074" Rows="1.000000" Width="22"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="0" Alias="b">
-                        <dxl:Ident ColId="0" ColName="b" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="1" Alias="c">
-                        <dxl:Ident ColId="1" ColName="c" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="2" Alias="ctid">
-                        <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="8" Alias="gp_segment_id">
-                        <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:Filter>
-                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                        <dxl:Ident ColId="0" ColName="b" TypeMdid="0.23.1.0"/>
-                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                      </dxl:Comparison>
-                    </dxl:Filter>
-                    <dxl:TableDescriptor Mdid="6.224805.1.1" TableName="p">
-                      <dxl:Columns>
-                        <dxl:Column ColId="0" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
-                        <dxl:Column ColId="1" Attno="3" ColName="c" TypeMdid="0.23.1.0"/>
-                        <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                        <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                        <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                        <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                        <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                        <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                        <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                      </dxl:Columns>
-                    </dxl:TableDescriptor>
-                  </dxl:DynamicTableScan>
-                </dxl:Sequence>
-              </dxl:Result>
-            </dxl:Split>
-          </dxl:RedistributeMotion>
-        </dxl:PartitionSelector>
+                    </dxl:Comparison>
+                  </dxl:Filter>
+                  <dxl:TableDescriptor Mdid="6.224805.1.1" TableName="p">
+                    <dxl:Columns>
+                      <dxl:Column ColId="0" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+                      <dxl:Column ColId="1" Attno="3" ColName="c" TypeMdid="0.23.1.0"/>
+                      <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                      <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                      <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                      <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                      <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                      <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                      <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                    </dxl:Columns>
+                  </dxl:TableDescriptor>
+                </dxl:DynamicTableScan>
+              </dxl:Sequence>
+            </dxl:Result>
+          </dxl:Split>
+        </dxl:RedistributeMotion>
       </dxl:DMLUpdate>
     </dxl:Plan>
   </dxl:Thread>

--- a/src/backend/gporca/data/dxl/minidump/UpdateNoDistKeyMismatchedDistribution.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdateNoDistKeyMismatchedDistribution.mdp
@@ -19,20 +19,19 @@
                                                              QUERY PLAN
     -----------------------------------------------------------------------------------------------------------------------------
      Update  (cost=0.00..1324057.85 rows=1 width=1)
-       ->  Partition Selector for pt2  (cost=0.00..1324057.79 rows=1 width=30)
-             ->  Explicit Redistribute Motion 4:4  (slice2; segments: 4)  (cost=0.00..1324057.79 rows=1 width=26)
-                   ->  Split  (cost=0.00..1324057.79 rows=1 width=26)
-                         ->  Result  (cost=0.00..1324057.79 rows=1 width=26)
-                               ->  Sequence  (cost=0.00..431.00 rows=1 width=22)
-                                     ->  Partition Selector for pt2 (dynamic scan id: 1)  (cost=10.00..100.00 rows=25 width=4)
-                                           Partitions selected: 5 (out of 5)
-                                     ->  Dynamic Table Scan on pt2 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=22)
-                               SubPlan 1
-                                 ->  Result  (cost=0.00..431.00 rows=1 width=4)
-                                       Filter: $0 = r.b
-                                       ->  Materialize  (cost=0.00..431.00 rows=1 width=8)
-                                             ->  Broadcast Motion 4:4  (slice1; segments: 4)  (cost=0.00..431.00 rows=1 width=8)
-                                                   ->  Table Scan on r  (cost=0.00..431.00 rows=1 width=8)
+       ->  Explicit Redistribute Motion 4:4  (slice2; segments: 4)  (cost=0.00..1324057.79 rows=1 width=26)
+             ->  Split  (cost=0.00..1324057.79 rows=1 width=26)
+                   ->  Result  (cost=0.00..1324057.79 rows=1 width=26)
+                         ->  Sequence  (cost=0.00..431.00 rows=1 width=22)
+                               ->  Partition Selector for pt2 (dynamic scan id: 1)  (cost=10.00..100.00 rows=25 width=4)
+                                     Partitions selected: 5 (out of 5)
+                               ->  Dynamic Table Scan on pt2 (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=22)
+                         SubPlan 1
+                           ->  Result  (cost=0.00..431.00 rows=1 width=4)
+                                 Filter: $0 = r.b
+                                 ->  Materialize  (cost=0.00..431.00 rows=1 width=8)
+                                       ->  Broadcast Motion 4:4  (slice1; segments: 4)  (cost=0.00..431.00 rows=1 width=8)
+                                             ->  Table Scan on r  (cost=0.00..431.00 rows=1 width=8)
      Optimizer status: PQO version 3.83.0
     (16 rows)
   ]]>
@@ -306,7 +305,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:DMLUpdate Columns="0,1,2" ActionCol="21" CtidCol="3" SegmentIdCol="9" PreserveOids="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1324057.842941" Rows="1.000000" Width="1"/>
+          <dxl:Cost StartupCost="0" TotalCost="1324057.842928" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -334,9 +333,9 @@
             <dxl:Column ColId="31" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
-        <dxl:PartitionSelector RelationMdid="6.24803.1.0" PartitionLevels="1" ScanId="0">
+        <dxl:RoutedDistributeMotion SegmentIdCol="9" InputSegments="0,1,2,3" OutputSegments="0,1,2,3">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1324057.792160" Rows="2.000000" Width="26"/>
+            <dxl:Cost StartupCost="0" TotalCost="1324057.792147" Rows="2.000000" Width="26"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="i">
@@ -358,26 +357,11 @@
               <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
-          <dxl:PartEqFilters>
-            <dxl:PartEqFilterElems>
-              <dxl:Ident ColId="2" ColName="k" TypeMdid="0.23.1.0"/>
-            </dxl:PartEqFilterElems>
-          </dxl:PartEqFilters>
-          <dxl:PartFilters>
-            <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-          </dxl:PartFilters>
-          <dxl:ResidualFilter>
-            <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-          </dxl:ResidualFilter>
-          <dxl:PropagationExpression>
-            <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
-          </dxl:PropagationExpression>
-          <dxl:PrintableFilter>
-            <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-          </dxl:PrintableFilter>
-          <dxl:RoutedDistributeMotion SegmentIdCol="9" InputSegments="0,1,2,3" OutputSegments="0,1,2,3">
+          <dxl:Filter/>
+          <dxl:SortingColumnList/>
+          <dxl:Split DeleteColumns="0,1,2" InsertColumns="0,20,2" ActionCol="21" CtidCol="3" SegmentIdCol="9" PreserveOids="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1324057.792147" Rows="2.000000" Width="26"/>
+              <dxl:Cost StartupCost="0" TotalCost="1324057.792106" Rows="2.000000" Width="26"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="i">
@@ -396,14 +380,12 @@
                 <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
               <dxl:ProjElem ColId="21" Alias="ColRef_0021">
-                <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.23.1.0"/>
+                <dxl:DMLAction/>
               </dxl:ProjElem>
             </dxl:ProjList>
-            <dxl:Filter/>
-            <dxl:SortingColumnList/>
-            <dxl:Split DeleteColumns="0,1,2" InsertColumns="0,20,2" ActionCol="21" CtidCol="3" SegmentIdCol="9" PreserveOids="false">
+            <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1324057.792106" Rows="2.000000" Width="26"/>
+                <dxl:Cost StartupCost="0" TotalCost="1324057.792093" Rows="1.000000" Width="26"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="i">
@@ -415,19 +397,99 @@
                 <dxl:ProjElem ColId="2" Alias="k">
                   <dxl:Ident ColId="2" ColName="k" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
+                <dxl:ProjElem ColId="20" Alias="j">
+                  <dxl:SubPlan TypeMdid="0.23.1.0" SubPlanType="ScalarSubPlan">
+                    <dxl:TestExpr/>
+                    <dxl:ParamList>
+                      <dxl:Param ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+                    </dxl:ParamList>
+                    <dxl:Result>
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000552" Rows="4.000000" Width="4"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="12" Alias="c">
+                          <dxl:Ident ColId="12" ColName="c" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter>
+                        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                          <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+                          <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
+                        </dxl:Comparison>
+                      </dxl:Filter>
+                      <dxl:OneTimeFilter/>
+                      <dxl:Materialize Eager="false">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000486" Rows="4.000000" Width="8"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="11" Alias="b">
+                            <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="12" Alias="c">
+                            <dxl:Ident ColId="12" ColName="c" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:BroadcastMotion InputSegments="0,1,2,3" OutputSegments="0,1,2,3">
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000478" Rows="4.000000" Width="8"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="11" Alias="b">
+                              <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="12" Alias="c">
+                              <dxl:Ident ColId="12" ColName="c" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:SortingColumnList/>
+                          <dxl:TableScan>
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="0" TotalCost="431.000023" Rows="1.000000" Width="8"/>
+                            </dxl:Properties>
+                            <dxl:ProjList>
+                              <dxl:ProjElem ColId="11" Alias="b">
+                                <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="12" Alias="c">
+                                <dxl:Ident ColId="12" ColName="c" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                            </dxl:ProjList>
+                            <dxl:Filter/>
+                            <dxl:TableDescriptor Mdid="6.24827.1.0" TableName="r">
+                              <dxl:Columns>
+                                <dxl:Column ColId="11" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="12" Attno="3" ColName="c" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                                <dxl:Column ColId="14" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="15" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="16" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="17" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="18" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="19" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                              </dxl:Columns>
+                            </dxl:TableDescriptor>
+                          </dxl:TableScan>
+                        </dxl:BroadcastMotion>
+                      </dxl:Materialize>
+                    </dxl:Result>
+                  </dxl:SubPlan>
+                </dxl:ProjElem>
                 <dxl:ProjElem ColId="3" Alias="ctid">
                   <dxl:Ident ColId="3" ColName="ctid" TypeMdid="0.27.1.0"/>
                 </dxl:ProjElem>
                 <dxl:ProjElem ColId="9" Alias="gp_segment_id">
                   <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
-                <dxl:ProjElem ColId="21" Alias="ColRef_0021">
-                  <dxl:DMLAction/>
-                </dxl:ProjElem>
               </dxl:ProjList>
-              <dxl:Result>
+              <dxl:Filter/>
+              <dxl:OneTimeFilter/>
+              <dxl:Sequence>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1324057.792093" Rows="1.000000" Width="26"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000006" Rows="1.000000" Width="22"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="i">
@@ -439,87 +501,6 @@
                   <dxl:ProjElem ColId="2" Alias="k">
                     <dxl:Ident ColId="2" ColName="k" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
-                  <dxl:ProjElem ColId="20" Alias="j">
-                    <dxl:SubPlan TypeMdid="0.23.1.0" SubPlanType="ScalarSubPlan">
-                      <dxl:TestExpr/>
-                      <dxl:ParamList>
-                        <dxl:Param ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-                      </dxl:ParamList>
-                      <dxl:Result>
-                        <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="431.000552" Rows="4.000000" Width="4"/>
-                        </dxl:Properties>
-                        <dxl:ProjList>
-                          <dxl:ProjElem ColId="12" Alias="c">
-                            <dxl:Ident ColId="12" ColName="c" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
-                        </dxl:ProjList>
-                        <dxl:Filter>
-                          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                            <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-                            <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
-                          </dxl:Comparison>
-                        </dxl:Filter>
-                        <dxl:OneTimeFilter/>
-                        <dxl:Materialize Eager="false">
-                          <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="431.000486" Rows="4.000000" Width="8"/>
-                          </dxl:Properties>
-                          <dxl:ProjList>
-                            <dxl:ProjElem ColId="11" Alias="b">
-                              <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="12" Alias="c">
-                              <dxl:Ident ColId="12" ColName="c" TypeMdid="0.23.1.0"/>
-                            </dxl:ProjElem>
-                          </dxl:ProjList>
-                          <dxl:Filter/>
-                          <dxl:BroadcastMotion InputSegments="0,1,2,3" OutputSegments="0,1,2,3">
-                            <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="431.000478" Rows="4.000000" Width="8"/>
-                            </dxl:Properties>
-                            <dxl:ProjList>
-                              <dxl:ProjElem ColId="11" Alias="b">
-                                <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
-                              </dxl:ProjElem>
-                              <dxl:ProjElem ColId="12" Alias="c">
-                                <dxl:Ident ColId="12" ColName="c" TypeMdid="0.23.1.0"/>
-                              </dxl:ProjElem>
-                            </dxl:ProjList>
-                            <dxl:Filter/>
-                            <dxl:SortingColumnList/>
-                            <dxl:TableScan>
-                              <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="431.000023" Rows="1.000000" Width="8"/>
-                              </dxl:Properties>
-                              <dxl:ProjList>
-                                <dxl:ProjElem ColId="11" Alias="b">
-                                  <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
-                                </dxl:ProjElem>
-                                <dxl:ProjElem ColId="12" Alias="c">
-                                  <dxl:Ident ColId="12" ColName="c" TypeMdid="0.23.1.0"/>
-                                </dxl:ProjElem>
-                              </dxl:ProjList>
-                              <dxl:Filter/>
-                              <dxl:TableDescriptor Mdid="6.24827.1.0" TableName="r">
-                                <dxl:Columns>
-                                  <dxl:Column ColId="11" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
-                                  <dxl:Column ColId="12" Attno="3" ColName="c" TypeMdid="0.23.1.0" ColWidth="4"/>
-                                  <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                                  <dxl:Column ColId="14" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                                  <dxl:Column ColId="15" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                                  <dxl:Column ColId="16" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                                  <dxl:Column ColId="17" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                                  <dxl:Column ColId="18" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                                  <dxl:Column ColId="19" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                                </dxl:Columns>
-                              </dxl:TableDescriptor>
-                            </dxl:TableScan>
-                          </dxl:BroadcastMotion>
-                        </dxl:Materialize>
-                      </dxl:Result>
-                    </dxl:SubPlan>
-                  </dxl:ProjElem>
                   <dxl:ProjElem ColId="3" Alias="ctid">
                     <dxl:Ident ColId="3" ColName="ctid" TypeMdid="0.27.1.0"/>
                   </dxl:ProjElem>
@@ -527,9 +508,28 @@
                     <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:OneTimeFilter/>
-                <dxl:Sequence>
+                <dxl:PartitionSelector RelationMdid="6.24803.1.0" PartitionLevels="1" ScanId="1">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="10" TotalCost="100" Rows="100" Width="4"/>
+                  </dxl:Properties>
+                  <dxl:ProjList/>
+                  <dxl:PartEqFilters>
+                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                  </dxl:PartEqFilters>
+                  <dxl:PartFilters>
+                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                  </dxl:PartFilters>
+                  <dxl:ResidualFilter>
+                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                  </dxl:ResidualFilter>
+                  <dxl:PropagationExpression>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                  </dxl:PropagationExpression>
+                  <dxl:PrintableFilter>
+                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                  </dxl:PrintableFilter>
+                </dxl:PartitionSelector>
+                <dxl:DynamicTableScan PartIndexId="1">
                   <dxl:Properties>
                     <dxl:Cost StartupCost="0" TotalCost="431.000006" Rows="1.000000" Width="22"/>
                   </dxl:Properties>
@@ -550,69 +550,26 @@
                       <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
-                  <dxl:PartitionSelector RelationMdid="6.24803.1.0" PartitionLevels="1" ScanId="1">
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="10" TotalCost="100" Rows="100" Width="4"/>
-                    </dxl:Properties>
-                    <dxl:ProjList/>
-                    <dxl:PartEqFilters>
-                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                    </dxl:PartEqFilters>
-                    <dxl:PartFilters>
-                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                    </dxl:PartFilters>
-                    <dxl:ResidualFilter>
-                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                    </dxl:ResidualFilter>
-                    <dxl:PropagationExpression>
-                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                    </dxl:PropagationExpression>
-                    <dxl:PrintableFilter>
-                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                    </dxl:PrintableFilter>
-                  </dxl:PartitionSelector>
-                  <dxl:DynamicTableScan PartIndexId="1">
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000006" Rows="1.000000" Width="22"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="0" Alias="i">
-                        <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="1" Alias="j">
-                        <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="2" Alias="k">
-                        <dxl:Ident ColId="2" ColName="k" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="3" Alias="ctid">
-                        <dxl:Ident ColId="3" ColName="ctid" TypeMdid="0.27.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="9" Alias="gp_segment_id">
-                        <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:Filter/>
-                    <dxl:TableDescriptor Mdid="6.24803.1.0" TableName="pt2">
-                      <dxl:Columns>
-                        <dxl:Column ColId="0" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="1" Attno="2" ColName="j" TypeMdid="0.23.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="2" Attno="3" ColName="k" TypeMdid="0.23.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                        <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                      </dxl:Columns>
-                    </dxl:TableDescriptor>
-                  </dxl:DynamicTableScan>
-                </dxl:Sequence>
-              </dxl:Result>
-            </dxl:Split>
-          </dxl:RoutedDistributeMotion>
-        </dxl:PartitionSelector>
+                  <dxl:Filter/>
+                  <dxl:TableDescriptor Mdid="6.24803.1.0" TableName="pt2">
+                    <dxl:Columns>
+                      <dxl:Column ColId="0" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="1" Attno="2" ColName="j" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="2" Attno="3" ColName="k" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                      <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    </dxl:Columns>
+                  </dxl:TableDescriptor>
+                </dxl:DynamicTableScan>
+              </dxl:Sequence>
+            </dxl:Result>
+          </dxl:Split>
+        </dxl:RoutedDistributeMotion>
       </dxl:DMLUpdate>
     </dxl:Plan>
   </dxl:Thread>

--- a/src/backend/gporca/data/dxl/minidump/UpdatePartTable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdatePartTable.mdp
@@ -249,7 +249,7 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:DMLUpdate Columns="0,1" ActionCol="10" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.086136" Rows="1.000000" Width="1"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.086114" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:DirectDispatchInfo/>
         <dxl:ProjList>
@@ -273,9 +273,9 @@
             <dxl:Column ColId="19" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
           </dxl:Columns>
         </dxl:TableDescriptor>
-        <dxl:PartitionSelector RelationMdid="6.224805.1.1" PartitionLevels="1" ScanId="0">
+        <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.000198" Rows="2.000000" Width="22"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000176" Rows="2.000000" Width="22"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="b">
@@ -294,26 +294,16 @@
               <dxl:Ident ColId="10" ColName="ColRef_0010" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
-          <dxl:PartEqFilters>
-            <dxl:PartEqFilterElems>
-              <dxl:Ident ColId="1" ColName="c" TypeMdid="0.23.1.0"/>
-            </dxl:PartEqFilterElems>
-          </dxl:PartEqFilters>
-          <dxl:PartFilters>
-            <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-          </dxl:PartFilters>
-          <dxl:ResidualFilter>
-            <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-          </dxl:ResidualFilter>
-          <dxl:PropagationExpression>
-            <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
-          </dxl:PropagationExpression>
-          <dxl:PrintableFilter>
-            <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-          </dxl:PrintableFilter>
-          <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
+          <dxl:Filter/>
+          <dxl:SortingColumnList/>
+          <dxl:HashExprList>
+            <dxl:HashExpr>
+              <dxl:Ident ColId="0" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:HashExpr>
+          </dxl:HashExprList>
+          <dxl:Split DeleteColumns="0,1" InsertColumns="9,1" ActionCol="10" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000176" Rows="2.000000" Width="22"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000107" Rows="2.000000" Width="22"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="b">
@@ -329,19 +319,12 @@
                 <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
               <dxl:ProjElem ColId="10" Alias="ColRef_0010">
-                <dxl:Ident ColId="10" ColName="ColRef_0010" TypeMdid="0.23.1.0"/>
+                <dxl:DMLAction/>
               </dxl:ProjElem>
             </dxl:ProjList>
-            <dxl:Filter/>
-            <dxl:SortingColumnList/>
-            <dxl:HashExprList>
-              <dxl:HashExpr>
-                <dxl:Ident ColId="0" ColName="b" TypeMdid="0.23.1.0"/>
-              </dxl:HashExpr>
-            </dxl:HashExprList>
-            <dxl:Split DeleteColumns="0,1" InsertColumns="9,1" ActionCol="10" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
+            <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000107" Rows="2.000000" Width="22"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000085" Rows="1.000000" Width="22"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="b">
@@ -350,19 +333,21 @@
                 <dxl:ProjElem ColId="1" Alias="c">
                   <dxl:Ident ColId="1" ColName="c" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
+                <dxl:ProjElem ColId="9" Alias="b">
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="3"/>
+                </dxl:ProjElem>
                 <dxl:ProjElem ColId="2" Alias="ctid">
                   <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
                 </dxl:ProjElem>
                 <dxl:ProjElem ColId="8" Alias="gp_segment_id">
                   <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
-                <dxl:ProjElem ColId="10" Alias="ColRef_0010">
-                  <dxl:DMLAction/>
-                </dxl:ProjElem>
               </dxl:ProjList>
-              <dxl:Result>
+              <dxl:Filter/>
+              <dxl:OneTimeFilter/>
+              <dxl:Sequence>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000085" Rows="1.000000" Width="22"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000074" Rows="1.000000" Width="22"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="b">
@@ -371,9 +356,6 @@
                   <dxl:ProjElem ColId="1" Alias="c">
                     <dxl:Ident ColId="1" ColName="c" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
-                  <dxl:ProjElem ColId="9" Alias="b">
-                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="3"/>
-                  </dxl:ProjElem>
                   <dxl:ProjElem ColId="2" Alias="ctid">
                     <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
                   </dxl:ProjElem>
@@ -381,9 +363,28 @@
                     <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:OneTimeFilter/>
-                <dxl:Sequence>
+                <dxl:PartitionSelector RelationMdid="6.224805.1.1" PartitionLevels="1" ScanId="1">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="10" TotalCost="100" Rows="100" Width="4"/>
+                  </dxl:Properties>
+                  <dxl:ProjList/>
+                  <dxl:PartEqFilters>
+                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                  </dxl:PartEqFilters>
+                  <dxl:PartFilters>
+                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                  </dxl:PartFilters>
+                  <dxl:ResidualFilter>
+                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                  </dxl:ResidualFilter>
+                  <dxl:PropagationExpression>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                  </dxl:PropagationExpression>
+                  <dxl:PrintableFilter>
+                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                  </dxl:PrintableFilter>
+                </dxl:PartitionSelector>
+                <dxl:DynamicTableScan PartIndexId="1">
                   <dxl:Properties>
                     <dxl:Cost StartupCost="0" TotalCost="431.000074" Rows="1.000000" Width="22"/>
                   </dxl:Properties>
@@ -401,70 +402,30 @@
                       <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
-                  <dxl:PartitionSelector RelationMdid="6.224805.1.1" PartitionLevels="1" ScanId="1">
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="10" TotalCost="100" Rows="100" Width="4"/>
-                    </dxl:Properties>
-                    <dxl:ProjList/>
-                    <dxl:PartEqFilters>
-                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                    </dxl:PartEqFilters>
-                    <dxl:PartFilters>
-                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                    </dxl:PartFilters>
-                    <dxl:ResidualFilter>
-                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                    </dxl:ResidualFilter>
-                    <dxl:PropagationExpression>
+                  <dxl:Filter>
+                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                      <dxl:Ident ColId="0" ColName="b" TypeMdid="0.23.1.0"/>
                       <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                    </dxl:PropagationExpression>
-                    <dxl:PrintableFilter>
-                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                    </dxl:PrintableFilter>
-                  </dxl:PartitionSelector>
-                  <dxl:DynamicTableScan PartIndexId="1">
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000074" Rows="1.000000" Width="22"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="0" Alias="b">
-                        <dxl:Ident ColId="0" ColName="b" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="1" Alias="c">
-                        <dxl:Ident ColId="1" ColName="c" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="2" Alias="ctid">
-                        <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="8" Alias="gp_segment_id">
-                        <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:Filter>
-                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                        <dxl:Ident ColId="0" ColName="b" TypeMdid="0.23.1.0"/>
-                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                      </dxl:Comparison>
-                    </dxl:Filter>
-                    <dxl:TableDescriptor Mdid="6.224805.1.1" TableName="p">
-                      <dxl:Columns>
-                        <dxl:Column ColId="0" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
-                        <dxl:Column ColId="1" Attno="3" ColName="c" TypeMdid="0.23.1.0"/>
-                        <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                        <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                        <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                        <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                        <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                        <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                        <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                      </dxl:Columns>
-                    </dxl:TableDescriptor>
-                  </dxl:DynamicTableScan>
-                </dxl:Sequence>
-              </dxl:Result>
-            </dxl:Split>
-          </dxl:RedistributeMotion>
-        </dxl:PartitionSelector>
+                    </dxl:Comparison>
+                  </dxl:Filter>
+                  <dxl:TableDescriptor Mdid="6.224805.1.1" TableName="p">
+                    <dxl:Columns>
+                      <dxl:Column ColId="0" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+                      <dxl:Column ColId="1" Attno="3" ColName="c" TypeMdid="0.23.1.0"/>
+                      <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                      <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                      <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                      <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                      <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                      <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                      <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                    </dxl:Columns>
+                  </dxl:TableDescriptor>
+                </dxl:DynamicTableScan>
+              </dxl:Sequence>
+            </dxl:Result>
+          </dxl:Split>
+        </dxl:RedistributeMotion>
       </dxl:DMLUpdate>
     </dxl:Plan>
   </dxl:Thread>

--- a/src/backend/gporca/libgpopt/src/xforms/CXformUpdate2DML.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformUpdate2DML.cpp
@@ -141,14 +141,6 @@ CXformUpdate2DML::Transform(CXformContext *pxfctxt, CXformResult *pxfres,
 		pexprAssertConstraints = pexprSplit;
 	}
 
-	CExpression *pexprProject = pexprAssertConstraints;
-	if (ptabdesc->IsPartitioned())
-	{
-		// generate a partition selector
-		pexprProject = CXformUtils::PexprLogicalPartitionSelector(
-			mp, ptabdesc, pdrgpcrInsert, pexprAssertConstraints);
-	}
-
 	const ULONG num_cols = pdrgpcrInsert->Size();
 
 	CBitSet *pbsModified = GPOS_NEW(mp) CBitSet(mp, ptabdesc->ColumnCount());
@@ -172,7 +164,7 @@ CXformUpdate2DML::Transform(CXformContext *pxfctxt, CXformResult *pxfres,
 		GPOS_NEW(mp) CLogicalDML(mp, CLogicalDML::EdmlUpdate, ptabdesc,
 								 pdrgpcrDelete, pbsModified, pcrAction, pcrCtid,
 								 pcrSegmentId, pcrTupleOid),
-		pexprProject);
+		pexprAssertConstraints);
 
 	// TODO:  - Oct 30, 2012; detect and handle AFTER triggers on update
 

--- a/src/backend/gporca/libgpopt/src/xforms/CXformUtils.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformUtils.cpp
@@ -1331,36 +1331,12 @@ CXformUtils::PexprLogicalDMLOverProject(CMemoryPool *mp,
 		val = CScalarDMLAction::EdmlactionDelete;
 	}
 
-	// new expressions to project
+	// generate one project node with new column: action
 	IMDId *rel_mdid = ptabdesc->MDId();
-	CExpression *pexprProject = NULL;
-	CColRef *pcrAction = NULL;
-
-	if (ptabdesc->IsPartitioned())
-	{
-		// generate a PartitionSelector node which generates OIDs, then add a project
-		// on top of that to add the action column
-		CExpression *pexprSelector = PexprLogicalPartitionSelector(
-			mp, ptabdesc, colref_array, pexprChild);
-		pexprProject = CUtils::PexprAddProjection(
-			mp, pexprSelector, CUtils::PexprScalarConstInt4(mp, val));
-		CExpression *pexprPrL = (*pexprProject)[1];
-		pcrAction = CUtils::PcrFromProjElem((*pexprPrL)[0]);
-	}
-	else
-	{
-		CExpressionArray *pdrgpexprProjected =
-			GPOS_NEW(mp) CExpressionArray(mp);
-		// generate one project node with new column: action
-		pdrgpexprProjected->Append(CUtils::PexprScalarConstInt4(mp, val));
-
-		pexprProject =
-			CUtils::PexprAddProjection(mp, pexprChild, pdrgpexprProjected);
-		pdrgpexprProjected->Release();
-
-		CExpression *pexprPrL = (*pexprProject)[1];
-		pcrAction = CUtils::PcrFromProjElem((*pexprPrL)[0]);
-	}
+	CExpression *pexprProject = CUtils::PexprAddProjection(
+		mp, pexprChild, CUtils::PexprScalarConstInt4(mp, val));
+	CExpression *pexprPrL = (*pexprProject)[1];
+	CColRef *pcrAction = CUtils::PcrFromProjElem((*pexprPrL)[0]);
 
 	GPOS_ASSERT(NULL != pcrAction);
 

--- a/src/test/regress/expected/gp_unique_rowid_optimizer.out
+++ b/src/test/regress/expected/gp_unique_rowid_optimizer.out
@@ -67,28 +67,27 @@ explain (costs off ) update rank_12402 set rank = 1 where id in (select id from 
                                                      QUERY PLAN                                                     
 --------------------------------------------------------------------------------------------------------------------
  Update
-   ->  Partition Selector for rank_12402
-         ->  Split
-               ->  Result
+   ->  Split
+         ->  Result
+               ->  Hash Semi Join
+                     Hash Cond: (rank_12402.value = rank1_12402_1.value)
                      ->  Hash Semi Join
-                           Hash Cond: (rank_12402.value = rank1_12402_1.value)
-                           ->  Hash Semi Join
-                                 Hash Cond: (rank_12402.id = rank1_12402.id)
-                                 ->  Sequence
-                                       ->  Partition Selector for rank_12402 (dynamic scan id: 1)
-                                             Partitions selected: 2 (out of 2)
-                                       ->  Dynamic Seq Scan on rank_12402 (dynamic scan id: 1)
-                                 ->  Hash
-                                       ->  Sequence
-                                             ->  Partition Selector for rank1_12402 (dynamic scan id: 2)
-                                                   Partitions selected: 2 (out of 2)
-                                             ->  Dynamic Seq Scan on rank1_12402 (dynamic scan id: 2)
+                           Hash Cond: (rank_12402.id = rank1_12402.id)
+                           ->  Sequence
+                                 ->  Partition Selector for rank_12402 (dynamic scan id: 1)
+                                       Partitions selected: 2 (out of 2)
+                                 ->  Dynamic Seq Scan on rank_12402 (dynamic scan id: 1)
                            ->  Hash
-                                 ->  Broadcast Motion 3:3  (slice1; segments: 3)
-                                       ->  Sequence
-                                             ->  Partition Selector for rank1_12402 (dynamic scan id: 3)
-                                                   Partitions selected: 2 (out of 2)
-                                             ->  Dynamic Seq Scan on rank1_12402 rank1_12402_1 (dynamic scan id: 3)
+                                 ->  Sequence
+                                       ->  Partition Selector for rank1_12402 (dynamic scan id: 2)
+                                             Partitions selected: 2 (out of 2)
+                                       ->  Dynamic Seq Scan on rank1_12402 (dynamic scan id: 2)
+                     ->  Hash
+                           ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                                 ->  Sequence
+                                       ->  Partition Selector for rank1_12402 (dynamic scan id: 3)
+                                             Partitions selected: 2 (out of 2)
+                                       ->  Dynamic Seq Scan on rank1_12402 rank1_12402_1 (dynamic scan id: 3)
  Optimizer: Pivotal Optimizer (GPORCA)
 (24 rows)
 

--- a/src/test/regress/expected/partition_pruning_optimizer.out
+++ b/src/test/regress/expected/partition_pruning_optimizer.out
@@ -3087,26 +3087,25 @@ where  trg.key1 = src.key1
                                                        QUERY PLAN
 ------------------------------------------------------------------------------------------------------------------------
  Update
-   ->  Partition Selector for t_part1
-         ->  Split
-               ->  Hash Join
-                     Hash Cond: (t_part1.key1 = t_part1_1.key1)
-                     ->  Sequence
-                           ->  Partition Selector for t_part1 (dynamic scan id: 1)
-                                 Partitions selected: 1 (out of 399)
-                           ->  Dynamic Seq Scan on t_part1 (dynamic scan id: 1)
-                                 Filter: (key1 = 2)
-                     ->  Hash
-                           ->  Broadcast Motion 1:3  (slice2; segments: 1)
-                                 ->  Result
-                                       Filter: (t_part1_1.key1 = 2)
-                                       ->  WindowAgg
-                                             ->  Gather Motion 3:1  (slice1; segments: 3)
-                                                   ->  Sequence
-                                                         ->  Partition Selector for t_part1 (dynamic scan id: 2)
-                                                               Partitions selected: 1 (out of 399)
-                                                         ->  Dynamic Seq Scan on t_part1 t_part1_1 (dynamic scan id: 2)
-                                                               Filter: (key1 = 2)
+   ->  Split
+         ->  Hash Join
+               Hash Cond: (t_part1.key1 = t_part1_1.key1)
+               ->  Sequence
+                     ->  Partition Selector for t_part1 (dynamic scan id: 1)
+                           Partitions selected: 1 (out of 399)
+                     ->  Dynamic Seq Scan on t_part1 (dynamic scan id: 1)
+                           Filter: (key1 = 2)
+               ->  Hash
+                     ->  Broadcast Motion 1:3  (slice2; segments: 1)
+                           ->  Result
+                                 Filter: (t_part1_1.key1 = 2)
+                                 ->  WindowAgg
+                                       ->  Gather Motion 3:1  (slice1; segments: 3)
+                                             ->  Sequence
+                                                   ->  Partition Selector for t_part1 (dynamic scan id: 2)
+                                                         Partitions selected: 1 (out of 399)
+                                                   ->  Dynamic Seq Scan on t_part1 t_part1_1 (dynamic scan id: 2)
+                                                         Filter: (key1 = 2)
  Optimizer: Pivotal Optimizer (GPORCA)
 (22 rows)
 

--- a/src/test/regress/expected/update_gp_optimizer.out
+++ b/src/test/regress/expected/update_gp_optimizer.out
@@ -634,19 +634,17 @@ where into_table.a=from_table.a and into_table.b=from_table.b and into_table.c=f
  Update
    ->  Redistribute Motion 3:3  (slice2; segments: 3)
          Hash Key: into_table.a, into_table.b, into_table.c
-         ->  Result
-               ->  Partition Selector for into_table
-                     ->  Split
-                           ->  Hash Join
-                                 Hash Cond: ((into_table.a = from_table.a) AND (into_table.b = from_table.b) AND (into_table.c = from_table.c))
-                                 ->  Redistribute Motion 3:3  (slice1; segments: 3)
-                                       Hash Key: into_table.a
-                                       ->  Sequence
-                                             ->  Partition Selector for into_table (dynamic scan id: 1)
-                                                   Partitions selected: 4 (out of 4)
-                                             ->  Dynamic Seq Scan on into_table (dynamic scan id: 1)
-                                 ->  Hash
-                                       ->  Seq Scan on from_table
+         ->  Split
+               ->  Hash Join
+                     Hash Cond: ((into_table.a = from_table.a) AND (into_table.b = from_table.b) AND (into_table.c = from_table.c))
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                           Hash Key: into_table.a
+                           ->  Sequence
+                                 ->  Partition Selector for into_table (dynamic scan id: 1)
+                                       Partitions selected: 4 (out of 4)
+                                 ->  Dynamic Seq Scan on into_table (dynamic scan id: 1)
+                     ->  Hash
+                           ->  Seq Scan on from_table
  Optimizer: Pivotal Optimizer (GPORCA)
 (17 rows)
 


### PR DESCRIPTION
If we use Delete or Insert over a partitioned table, we will get a PartitionSelector right under these operators.
```

create table test (i int, j int)
distributed by (i)
partition by range (j) (start (0) end (2) every(1));
create table test1(i int);

explain (costs off)
delete from test
where not exists (
	select 1 from test1 where test1.i = test.i
);

                                   QUERY PLAN                                   

--------------------------------------------------------------------------------
 Delete
   ->  Result
         ->  Partition Selector for test
               ->  Hash Anti Join
                     Hash Cond: (test.i = test1.i)
                     ->  Sequence
                           ->  Partition Selector for test (dynamic scan id: 1)
                                 Partitions selected: 2 (out of 2)
                           ->  Dynamic Seq Scan on test (dynamic scan id: 1)
                     ->  Hash
                           ->  Result
                                 ->  Seq Scan on test1
 Optimizer: Pivotal Optimizer (GPORCA) 
```

`PartitionSelector` memorizes selected partitions based on up-n-coming rows in global executor state dynamicTableScanInfo but it doesn't have a consumer `DynamicScan` node. Hence its appearance looks redundant in plan tree.

PartitionSelector node is added under transformation from `CLogicalDelete [11]` node to

```
                             CLogicalDML
                                  |
                            CLogicalProject
                           /               \
             CScalarProjectList         CLogicalPartitionSelector [11]
                       /
        CScalarProjectElement (DMLAction)
                   /
      CScalarConst (0)
```

Generally, injection of projection makes sense as it adds constant code for `DMLAction` as additional column in passing rows. But `CLogicalPartitionSelector` just adds partition oid value under [subtle conditions](https://github.com/greenplum-db/gpdb/blob/c18e60f21082724ec02a38a6e0465c936efb1c79/src/backend/gporca/libgpopt/src/xforms/CXformUtils.cpp#L1369) - for GPDB it's impossible. This oid value allows to avoid partition pruning on further steps, in particular, inside Insert/Delete operator.

For GPDB we might fully remove `CLogicalPartitionSelector` generation and table oid injection, in general. But in this case we move away from classic gporca project specializing it within greenplum needs. Otherwise, we might leave `CLogicalPartitionSelector` just when partition oid value in projection is required. This also resolves our problem preserving initial logic of transformation from gporca project.

We choosed the option with `CLogicalPartitionSelector` removal, however, it's debatable, so we offer to discuss this decision. 