### PR TITLE
Support intermediate aggregate in planner

### DIFF
--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -5966,8 +5966,6 @@ mark_partial_aggref(Aggref *agg, AggSplit aggsplit)
 {
 	/* aggtranstype should be computed by this point */
 	Assert(OidIsValid(agg->aggtranstype));
-	/* ... but aggsplit should still be as the parser left it */
-	Assert(agg->aggsplit == AGGSPLIT_SIMPLE);
 
 	/* Mark the Aggref with the intended partial-aggregation mode */
 	agg->aggsplit = aggsplit;

--- a/src/backend/optimizer/plan/setrefs.c
+++ b/src/backend/optimizer/plan/setrefs.c
@@ -971,33 +971,36 @@ set_plan_refs(PlannerInfo *root, Plan *plan, int rtoffset)
 		case T_Agg:
 			{
 				Agg		   *agg = (Agg *) plan;
+				int 		aggref_split = (int)agg->aggsplit;
 
 				if (DO_AGGSPLIT_DEDUPLICATED(agg->aggsplit))
 				{
 					plan->targetlist = (List *)
 						convert_deduplicated_aggrefs((Node *) plan->targetlist,
-													 NULL);
+													NULL);
 					plan->qual = (List *)
 						convert_deduplicated_aggrefs((Node *) plan->qual,
-													 NULL);
+													NULL);
 
 					agg->aggsplit &= ~AGGSPLITOP_DEDUPLICATED;
 				}
 
 				/*
-				 * If this node is combining partial-aggregation results, we
-				 * must convert its Aggrefs to contain references to the
-				 * partial-aggregate subexpressions that will be available
-				 * from the child plan node.
-				 */
+				* If this node is combining partial/intermedaite aggregation results,
+				* we must convert its Aggrefs to contain references to the
+				* partial-aggregate subexpressions that will be available
+				* from the child plan node.
+				* In order to ref subexpressions, child-aggref is always partial
+				* aggregate and parent-aggref is the same as aggregate in Aggplan. 
+				*/
 				if (DO_AGGSPLIT_COMBINE(agg->aggsplit))
 				{
 					plan->targetlist = (List *)
 						convert_combining_aggrefs((Node *) plan->targetlist,
-												  NULL);
+												&aggref_split);
 					plan->qual = (List *)
 						convert_combining_aggrefs((Node *) plan->qual,
-												  NULL);
+												&aggref_split);
 				}
 
 				set_upper_references(root, plan, rtoffset);
@@ -2279,7 +2282,7 @@ set_param_references(PlannerInfo *root, Plan *plan)
  * the plan node above the Agg has resolved its subplan references.
  */
 static Node *
-convert_combining_aggrefs(Node *node, void *context)
+convert_combining_aggrefs(Node *node, void *split)
 {
 	if (node == NULL)
 		return NULL;
@@ -2288,6 +2291,33 @@ convert_combining_aggrefs(Node *node, void *context)
 		Aggref	   *orig_agg = (Aggref *) node;
 		Aggref	   *child_agg;
 		Aggref	   *parent_agg;
+		int			aggsplit = *(int *)split;
+
+		/*
+		 * For AGGSPLIT_DQAWITHAGG final agg plan node, we should skip
+		 * aggdistinct Aggref like Count(distinct ..) because we have
+		 * eliminated duplicates, and just refer Vars instead of partial
+		 * Aggref.
+		 */
+		if (DO_AGGSPLIT_DQAWITHAGG(aggsplit))
+		{
+			if (orig_agg->aggdistinct != NULL)
+			{
+				Aggref	   *parent_agg = NULL;
+
+				parent_agg = makeNode(Aggref);
+				memcpy(parent_agg, orig_agg, sizeof(Aggref));
+
+				parent_agg->aggdistinct = NIL;
+				parent_agg->aggsplit = AGGSPLIT_SIMPLE;
+
+				return (Node *) parent_agg;
+			}
+			else
+			{
+				aggsplit = AGGSPLIT_FINAL_DESERIAL;
+			}
+		}
 
 		/* Assert we've not chosen to partial-ize any unsupported cases */
 		Assert(orig_agg->aggorder == NIL);
@@ -2331,7 +2361,7 @@ convert_combining_aggrefs(Node *node, void *context)
 		 */
 		parent_agg->args = list_make1(makeTargetEntry((Expr *) child_agg,
 													  1, NULL, false));
-		mark_partial_aggref(parent_agg, AGGSPLIT_FINAL_DESERIAL);
+		mark_partial_aggref(parent_agg, aggsplit);
 
 		/*
 		 * In GPDB two-stage aggregates with DISTINCT, the first stage
@@ -2343,7 +2373,7 @@ convert_combining_aggrefs(Node *node, void *context)
 		return (Node *) parent_agg;
 	}
 	return expression_tree_mutator(node, convert_combining_aggrefs,
-								   (void *) context);
+								   (void *)split);
 }
 
 static Node *

--- a/src/include/nodes/nodes.h
+++ b/src/include/nodes/nodes.h
@@ -922,6 +922,7 @@ typedef enum AggStrategy
 #define AGGSPLITOP_DESERIALIZE	0x08	/* apply deserializefn to input */
 
 #define AGGSPLITOP_DEDUPLICATED	0x100
+#define AGGSPLITOP_DQAWITHAGG	0x200
 
 /* Supported operating modes (i.e., useful combinations of these options): */
 typedef enum AggSplit
@@ -940,7 +941,14 @@ typedef enum AggSplit
 	 */
 	AGGSPLIT_DEDUPLICATED = AGGSPLITOP_DEDUPLICATED,
 
-	AGGSPLIT_INTERMEDIATE = AGGSPLITOP_SKIPFINAL | AGGSPLITOP_SERIALIZE | AGGSPLITOP_COMBINE | AGGSPLITOP_DESERIALIZE,
+	/*
+	 * Dummy agg-split type for intermediate agg targetlist(combine + simple)
+	 * Only exist on top/final agg node of intermediate aggregation in planner
+	 * It is never set on Aggrefs.
+	 */
+	AGGSPLIT_DQAWITHAGG = AGGSPLITOP_DQAWITHAGG,
+
+    AGGSPLIT_INTERMEDIATE = AGGSPLITOP_SKIPFINAL | AGGSPLITOP_SERIALIZE | AGGSPLITOP_COMBINE | AGGSPLITOP_DESERIALIZE,
 } AggSplit;
 
 /* Test whether an AggSplit value selects each primitive option: */
@@ -950,6 +958,7 @@ typedef enum AggSplit
 #define DO_AGGSPLIT_DESERIALIZE(as) (((as) & AGGSPLITOP_DESERIALIZE) != 0)
 
 #define DO_AGGSPLIT_DEDUPLICATED(as) (((as) & AGGSPLITOP_DEDUPLICATED) != 0)
+#define DO_AGGSPLIT_DQAWITHAGG(as)  (((as) & AGGSPLITOP_DQAWITHAGG) != 0)
 
 /*
  * SetOpCmd and SetOpStrategy -

--- a/src/test/regress/expected/gp_dqa.out
+++ b/src/test/regress/expected/gp_dqa.out
@@ -2336,6 +2336,7 @@ explain (verbose, costs off) select count(distinct (b)::text) as b, count(distin
  Settings: enable_groupagg = 'off', gp_motion_cost_per_row = '1'
 (19 rows)
 
+drop table dqa_f3;
 -- fix dqa bug when optimizer_force_multistage_agg is on
 set optimizer_force_multistage_agg = on;
 create table multiagg1(a int, b bigint, c int);
@@ -2351,20 +2352,15 @@ analyze multiagg2;
 explain (verbose, costs off) select count(distinct b), sum(c) from multiagg1;
                                                QUERY PLAN                                               
 --------------------------------------------------------------------------------------------------------
- Finalize Aggregate
+ Aggregate
    Output: count(DISTINCT b), sum(c)
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         Output: (PARTIAL count(DISTINCT b)), (PARTIAL sum(c))
-         ->  Partial Aggregate
-               Output: PARTIAL count(DISTINCT b), PARTIAL sum(c)
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                     Output: b, c
-                     Hash Key: b
-                     ->  Seq Scan on public.multiagg1
-                           Output: b, c
+         Output: b, c
+         ->  Seq Scan on public.multiagg1
+               Output: b, c
  Optimizer: Postgres query optimizer
  Settings: enable_groupagg = 'off', gp_motion_cost_per_row = '1', optimizer_force_multistage_agg = 'on'
-(13 rows)
+(8 rows)
 
 select count(distinct b), sum(c) from multiagg1;
  count | sum 
@@ -2375,20 +2371,15 @@ select count(distinct b), sum(c) from multiagg1;
 explain (verbose, costs off) select count(distinct b), sum(c) from multiagg2;
                                                QUERY PLAN                                               
 --------------------------------------------------------------------------------------------------------
- Finalize Aggregate
+ Aggregate
    Output: count(DISTINCT b), sum(c)
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         Output: (PARTIAL count(DISTINCT b)), (PARTIAL sum(c))
-         ->  Partial Aggregate
-               Output: PARTIAL count(DISTINCT b), PARTIAL sum(c)
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                     Output: b, c
-                     Hash Key: b
-                     ->  Seq Scan on public.multiagg2
-                           Output: b, c
+         Output: b, c
+         ->  Seq Scan on public.multiagg2
+               Output: b, c
  Optimizer: Postgres query optimizer
  Settings: enable_groupagg = 'off', gp_motion_cost_per_row = '1', optimizer_force_multistage_agg = 'on'
-(13 rows)
+(8 rows)
 
 select count(distinct b), sum(c) from multiagg2;
  count |    sum    
@@ -2417,16 +2408,19 @@ insert into num_table values(1,1,1,1),(2,2,2,2),(3,3,3,3);
 -- The trans func building process errored out due to mismatch between
 -- the input type (int) and trans type (bigint), and caused missing plan
 explain select count(distinct a), sum(b) from num_table;
-                                                 QUERY PLAN                                                  
--------------------------------------------------------------------------------------------------------------
- Finalize Aggregate  (cost=14212.19..14212.20 rows=1 width=16)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=14210.17..14212.18 rows=3 width=16)
-         ->  Partial Aggregate  (cost=14210.17..14210.18 rows=1 width=16)
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..14140.33 rows=13967 width=12)
+                                                 QUERY PLAN                                                 
+------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate  (cost=3320.92..3320.93 rows=1 width=16)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=1295.92..3305.92 rows=3000 width=0)
+         ->  Partial HashAggregate  (cost=1295.92..1305.92 rows=1000 width=0)
+               Group Key: a
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=278.42..1288.42 rows=1000 width=0)
                      Hash Key: a
-                     ->  Seq Scan on num_table  (cost=0.00..173.67 rows=13967 width=12)
+                     ->  Streaming Partial HashAggregate  (cost=278.42..288.42 rows=1000 width=0)
+                           Group Key: a
+                           ->  Seq Scan on num_table  (cost=0.00..173.67 rows=13967 width=12)
  Optimizer: Postgres query optimizer
-(7 rows)
+(10 rows)
 
 select count(distinct a), sum(b) from num_table;
  count | sum 
@@ -2435,13 +2429,13 @@ select count(distinct a), sum(b) from num_table;
 (1 row)
 
 explain select count(distinct a), sum(b) from num_table group by id;
-                                             QUERY PLAN                                             
-----------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=10000001135.25..10000001944.92 rows=1000 width=20)
-   ->  GroupAggregate  (cost=10000001135.25..10000001278.25 rows=333 width=20)
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=385.39..2395.39 rows=3000 width=20)
+   ->  Finalize HashAggregate  (cost=385.39..395.39 rows=1000 width=20)
          Group Key: id
-         ->  Sort  (cost=1135.25..1170.17 rows=13967 width=16)
-               Sort Key: id
+         ->  Partial HashAggregate  (cost=313.33..354.51 rows=4117 width=0)
+               Group Key: id, a
                ->  Seq Scan on num_table  (cost=0.00..173.67 rows=13967 width=16)
  Optimizer: Postgres query optimizer
 (7 rows)
@@ -2463,16 +2457,19 @@ select count(distinct a), sum(b) from num_table group by id;
 -- The executor then evaluated the aggregation state without deserializing it first
 -- This led to the creation of garbage NaN count, and caused NaN output
 explain select count(distinct a), sum(c) from num_table;
-                                                 QUERY PLAN                                                  
--------------------------------------------------------------------------------------------------------------
- Finalize Aggregate  (cost=14212.20..14212.21 rows=1 width=40)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=14210.17..14212.18 rows=3 width=40)
-         ->  Partial Aggregate  (cost=14210.17..14210.18 rows=1 width=40)
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..14140.33 rows=13967 width=40)
+                                                 QUERY PLAN                                                 
+------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate  (cost=3333.42..3333.43 rows=1 width=40)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=1298.42..3310.92 rows=3000 width=0)
+         ->  Partial HashAggregate  (cost=1298.42..1310.92 rows=1000 width=0)
+               Group Key: a
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=278.42..1290.92 rows=1000 width=0)
                      Hash Key: a
-                     ->  Seq Scan on num_table  (cost=0.00..173.67 rows=13967 width=40)
+                     ->  Streaming Partial HashAggregate  (cost=278.42..290.92 rows=1000 width=0)
+                           Group Key: a
+                           ->  Seq Scan on num_table  (cost=0.00..173.67 rows=13967 width=40)
  Optimizer: Postgres query optimizer
-(7 rows)
+(10 rows)
 
 select count(distinct a), sum(c) from num_table;
  count | sum 
@@ -2481,13 +2478,13 @@ select count(distinct a), sum(c) from num_table;
 (1 row)
 
 explain select id, count(distinct a), avg(b), sum(c) from num_table group by grouping sets ((id,c));
-                                             QUERY PLAN                                              
------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=10000001135.25..10000004159.03 rows=4190 width=108)
-   ->  GroupAggregate  (cost=10000001135.25..10000001365.70 rows=1397 width=108)
+                                      QUERY PLAN                                       
+---------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=531.31..8974.16 rows=12570 width=108)
+   ->  Finalize HashAggregate  (cost=531.31..594.16 rows=4190 width=108)
          Group Key: id, c
-         ->  Sort  (cost=1135.25..1170.17 rows=13967 width=48)
-               Sort Key: id, c
+         ->  Partial HashAggregate  (cost=418.08..469.55 rows=4117 width=0)
+               Group Key: id, c, a, a
                ->  Seq Scan on num_table  (cost=0.00..173.67 rows=13967 width=48)
  Optimizer: Postgres query optimizer
 (7 rows)
@@ -2501,3 +2498,431 @@ select id, count(distinct a), avg(b), sum(c) from num_table group by grouping se
 (3 rows)
 
 reset optimizer_force_multistage_agg;
+-- DQA with Agg(Intermediate Agg)
+set enable_hashagg=on;
+set enable_groupagg=off;
+create table dqa_f3(a int, b int, c int, d int, e int ) distributed by (a);
+insert into dqa_f3 select i % 17, i % 5 , i % 3, i %10, i % 7 from generate_series(1,1000) i;
+analyze dqa_f3;
+/*
+ * Test distinct or group by column is distributed key
+ *
+ * 1. If the input's locus matches the DISTINCT, but not GROUP BY:
+ *
+ *  HashAggregate
+ *     -> Redistribute (according to GROUP BY)
+ *         -> HashAggregate (to eliminate duplicates)
+ *             -> input (hashed by GROUP BY + DISTINCT)
+ *
+ * 2. If the input's locus matches the GROUP BY(don't care DISTINCT any more):
+ *
+ *  HashAggregate (to aggregate)
+ *     -> HashAggregate (to eliminate duplicates)
+ *           -> input (hashed by GROUP BY)
+ *
+ */
+explain (verbose on, costs off)select sum(Distinct a), count(b), sum(c) from dqa_f3 group by e;
+                             QUERY PLAN                             
+--------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: (sum(a)), (count(b)), (sum(c)), e
+   ->  Finalize HashAggregate
+         Output: sum(a), count(b), sum(c), e
+         Group Key: dqa_f3.e
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Output: e, a, (PARTIAL count(b)), (PARTIAL sum(c))
+               Hash Key: e
+               ->  Partial HashAggregate
+                     Output: e, a, PARTIAL count(b), PARTIAL sum(c)
+                     Group Key: dqa_f3.e, dqa_f3.a
+                     ->  Seq Scan on public.dqa_f3
+                           Output: a, b, c, d, e
+ Optimizer: Postgres query optimizer
+ Settings: enable_groupagg = 'off', gp_motion_cost_per_row = '1'
+(15 rows)
+
+select sum(Distinct a), count(b), sum(c) from dqa_f3 group by e;
+ sum | count | sum 
+-----+-------+-----
+ 136 |   143 | 142
+ 136 |   143 | 143
+ 136 |   143 | 142
+ 136 |   143 | 143
+ 136 |   143 | 144
+ 136 |   142 | 142
+ 136 |   143 | 144
+(7 rows)
+
+explain (verbose on, costs off) select sum(Distinct e), count(b), sum(c) from dqa_f3 group by a;
+                           QUERY PLAN                            
+-----------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: (sum(e)), (count(b)), (sum(c)), a
+   ->  Finalize HashAggregate
+         Output: sum(e), count(b), sum(c), a
+         Group Key: dqa_f3.a
+         ->  Partial HashAggregate
+               Output: a, e, PARTIAL count(b), PARTIAL sum(c)
+               Group Key: dqa_f3.a, dqa_f3.e
+               ->  Seq Scan on public.dqa_f3
+                     Output: a, b, c, d, e
+ Optimizer: Postgres query optimizer
+ Settings: enable_groupagg = 'off', gp_motion_cost_per_row = '1'
+(12 rows)
+
+select sum(Distinct e), count(b), sum(c) from dqa_f3 group by a;
+ sum | count | sum 
+-----+-------+-----
+  21 |    58 |  59
+  21 |    59 |  58
+  21 |    58 |  57
+  21 |    59 |  59
+  21 |    59 |  58
+  21 |    59 |  59
+  21 |    59 |  58
+  21 |    59 |  60
+  21 |    58 |  58
+  21 |    59 |  60
+  21 |    59 |  60
+  21 |    59 |  58
+  21 |    59 |  58
+  21 |    59 |  59
+  21 |    59 |  60
+  21 |    59 |  59
+  21 |    59 |  60
+(17 rows)
+
+/*
+ *  Test both distinct and group by column are not distributed key 
+ *
+ *  HashAgg (to aggregate)
+ *     -> HashAgg (to eliminate duplicates)
+ *          -> Redistribute (according to GROUP BY)
+ *               -> Streaming HashAgg (to eliminate duplicates)
+ *                    -> input
+ *
+ */
+explain (verbose on, costs off) select sum(Distinct c), count(a), sum(d) from dqa_f3 group by b;
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: (sum(c)), (count(a)), (sum(d)), b
+   ->  Finalize HashAggregate
+         Output: sum(c), count(a), sum(d), b
+         Group Key: dqa_f3.b
+         ->  Partial HashAggregate
+               Output: b, c, PARTIAL count(a), PARTIAL sum(d)
+               Group Key: dqa_f3.b, dqa_f3.c
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Output: b, c, (PARTIAL count(a)), (PARTIAL sum(d))
+                     Hash Key: b
+                     ->  Streaming Partial HashAggregate
+                           Output: b, c, PARTIAL count(a), PARTIAL sum(d)
+                           Group Key: dqa_f3.b, dqa_f3.c
+                           ->  Seq Scan on public.dqa_f3
+                                 Output: a, b, c, d, e
+ Optimizer: Postgres query optimizer
+ Settings: enable_groupagg = 'off', gp_motion_cost_per_row = '1'
+(18 rows)
+
+select sum(Distinct c), count(a), sum(d) from dqa_f3 group by b;
+ sum | count | sum  
+-----+-------+------
+   3 |   200 | 1100
+   3 |   200 | 1300
+   3 |   200 |  900
+   3 |   200 |  500
+   3 |   200 |  700
+(5 rows)
+
+explain (verbose on, costs off) select sum(Distinct c), count(a), sum(d) from dqa_f3 group by b order by b;
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: (sum(c)), (count(a)), (sum(d)), b
+   Merge Key: b
+   ->  Sort
+         Output: (sum(c)), (count(a)), (sum(d)), b
+         Sort Key: dqa_f3.b
+         ->  Finalize HashAggregate
+               Output: sum(c), count(a), sum(d), b
+               Group Key: dqa_f3.b
+               ->  Partial HashAggregate
+                     Output: b, c, PARTIAL count(a), PARTIAL sum(d)
+                     Group Key: dqa_f3.b, dqa_f3.c
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Output: b, c, (PARTIAL count(a)), (PARTIAL sum(d))
+                           Hash Key: b
+                           ->  Streaming Partial HashAggregate
+                                 Output: b, c, PARTIAL count(a), PARTIAL sum(d)
+                                 Group Key: dqa_f3.b, dqa_f3.c
+                                 ->  Seq Scan on public.dqa_f3
+                                       Output: a, b, c, d, e
+ Optimizer: Postgres query optimizer
+ Settings: enable_groupagg = 'off', gp_motion_cost_per_row = '1'
+(22 rows)
+
+select sum(Distinct c), count(a), sum(d) from dqa_f3 group by b order by b;
+ sum | count | sum  
+-----+-------+------
+   3 |   200 |  500
+   3 |   200 |  700
+   3 |   200 |  900
+   3 |   200 | 1100
+   3 |   200 | 1300
+(5 rows)
+
+explain (verbose on, costs off) select distinct sum(Distinct c), count(a), sum(d) from dqa_f3 group by b;
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
+ HashAggregate
+   Output: (sum(c)), (count(a)), (sum(d)), b
+   Group Key: (sum(dqa_f3.c)), (count(dqa_f3.a)), (sum(dqa_f3.d))
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Output: (sum(c)), (count(a)), (sum(d)), b
+         ->  HashAggregate
+               Output: (sum(c)), (count(a)), (sum(d)), b
+               Group Key: sum(dqa_f3.c), count(dqa_f3.a), sum(dqa_f3.d)
+               ->  Finalize HashAggregate
+                     Output: sum(c), count(a), sum(d), b
+                     Group Key: dqa_f3.b
+                     ->  Partial HashAggregate
+                           Output: b, c, PARTIAL count(a), PARTIAL sum(d)
+                           Group Key: dqa_f3.b, dqa_f3.c
+                           ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                                 Output: b, c, (PARTIAL count(a)), (PARTIAL sum(d))
+                                 Hash Key: b
+                                 ->  Streaming Partial HashAggregate
+                                       Output: b, c, PARTIAL count(a), PARTIAL sum(d)
+                                       Group Key: dqa_f3.b, dqa_f3.c
+                                       ->  Seq Scan on public.dqa_f3
+                                             Output: a, b, c, d, e
+ Optimizer: Postgres query optimizer
+ Settings: enable_groupagg = 'off', gp_motion_cost_per_row = '1'
+(24 rows)
+
+select distinct sum(Distinct c), count(a), sum(d) from dqa_f3 group by b;
+ sum | count | sum  
+-----+-------+------
+   3 |   200 |  500
+   3 |   200 |  900
+   3 |   200 |  700
+   3 |   200 | 1100
+   3 |   200 | 1300
+(5 rows)
+
+explain (verbose on, costs off) select sum(Distinct c), count(a), sum(d) from dqa_f3 group by b having avg(e) > 3;
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: (sum(c)), (count(a)), (sum(d)), b
+   ->  Finalize HashAggregate
+         Output: sum(c), count(a), sum(d), b
+         Group Key: dqa_f3.b
+         Filter: (avg(dqa_f3.e) > '3'::numeric)
+         ->  Partial HashAggregate
+               Output: b, c, PARTIAL count(a), PARTIAL sum(d), PARTIAL avg(e)
+               Group Key: dqa_f3.b, dqa_f3.c
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Output: b, c, (PARTIAL count(a)), (PARTIAL sum(d)), (PARTIAL avg(e))
+                     Hash Key: b
+                     ->  Streaming Partial HashAggregate
+                           Output: b, c, PARTIAL count(a), PARTIAL sum(d), PARTIAL avg(e)
+                           Group Key: dqa_f3.b, dqa_f3.c
+                           ->  Seq Scan on public.dqa_f3
+                                 Output: a, b, c, d, e
+ Optimizer: Postgres query optimizer
+ Settings: enable_groupagg = 'off', gp_motion_cost_per_row = '1'
+(19 rows)
+
+select sum(Distinct c), count(a), sum(d) from dqa_f3 group by b having avg(e) > 3;
+ sum | count | sum  
+-----+-------+------
+   3 |   200 | 1100
+   3 |   200 |  500
+   3 |   200 |  700
+(3 rows)
+
+explain (verbose on, costs off)
+select sum(Distinct sub.c), count(a), sum(d)
+            from dqa_f3 left join(select x, coalesce(y, 5) as c from dqa_f2) as sub
+            on sub.x = dqa_f3.e group by b;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: (sum((COALESCE(dqa_f2.y, 5)))), (count(dqa_f3.a)), (sum(dqa_f3.d)), dqa_f3.b
+   ->  Finalize HashAggregate
+         Output: sum((COALESCE(dqa_f2.y, 5))), count(dqa_f3.a), sum(dqa_f3.d), dqa_f3.b
+         Group Key: dqa_f3.b
+         ->  Partial HashAggregate
+               Output: dqa_f3.b, (COALESCE(dqa_f2.y, 5)), PARTIAL count(dqa_f3.a), PARTIAL sum(dqa_f3.d)
+               Group Key: dqa_f3.b, (COALESCE(dqa_f2.y, 5))
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Output: dqa_f3.b, (COALESCE(dqa_f2.y, 5)), (PARTIAL count(dqa_f3.a)), (PARTIAL sum(dqa_f3.d))
+                     Hash Key: dqa_f3.b
+                     ->  Streaming Partial HashAggregate
+                           Output: dqa_f3.b, (COALESCE(dqa_f2.y, 5)), PARTIAL count(dqa_f3.a), PARTIAL sum(dqa_f3.d)
+                           Group Key: dqa_f3.b, (COALESCE(dqa_f2.y, 5))
+                           ->  Hash Right Join
+                                 Output: dqa_f3.b, (COALESCE(dqa_f2.y, 5)), dqa_f3.a, dqa_f3.d
+                                 Hash Cond: (dqa_f2.x = dqa_f3.e)
+                                 ->  Seq Scan on public.dqa_f2
+                                       Output: dqa_f2.x, COALESCE(dqa_f2.y, 5)
+                                 ->  Hash
+                                       Output: dqa_f3.a, dqa_f3.d, dqa_f3.b, dqa_f3.e
+                                       ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                                             Output: dqa_f3.a, dqa_f3.d, dqa_f3.b, dqa_f3.e
+                                             Hash Key: dqa_f3.e
+                                             ->  Seq Scan on public.dqa_f3
+                                                   Output: dqa_f3.a, dqa_f3.d, dqa_f3.b, dqa_f3.e
+ Optimizer: Postgres query optimizer
+ Settings: enable_groupagg = 'off', gp_motion_cost_per_row = '1'
+(28 rows)
+
+select sum(Distinct sub.c), count(a), sum(d)
+            from dqa_f3 left join(select x, coalesce(y, 5) as c from dqa_f2) as sub
+            on sub.x = dqa_f3.e group by b;
+ sum | count |  sum  
+-----+-------+-------
+  10 | 15372 | 84546
+  10 | 15371 | 99914
+  10 | 15371 | 69167
+  10 | 15372 | 38430
+  10 | 15372 | 53802
+(5 rows)
+
+-- Test gp_enable_agg_distinct_pruning is off on this branch
+set gp_enable_agg_distinct_pruning = off;
+explain (verbose on, costs off) select sum(Distinct c), count(a), sum(d) from dqa_f3 group by b;
+                                               QUERY PLAN                                                
+---------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: (sum(c)), (count(a)), (sum(d)), b
+   ->  Finalize HashAggregate
+         Output: sum(c), count(a), sum(d), b
+         Group Key: dqa_f3.b
+         ->  Partial HashAggregate
+               Output: b, c, PARTIAL count(a), PARTIAL sum(d)
+               Group Key: dqa_f3.b, dqa_f3.c
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Output: b, c, a, d
+                     Hash Key: b
+                     ->  Seq Scan on public.dqa_f3
+                           Output: b, c, a, d
+ Optimizer: Postgres query optimizer
+ Settings: enable_groupagg = 'off', gp_enable_agg_distinct_pruning = 'off', gp_motion_cost_per_row = '1'
+(15 rows)
+
+select sum(Distinct c), count(a), sum(d) from dqa_f3 group by b;
+ sum | count | sum  
+-----+-------+------
+   3 |   200 |  500
+   3 |   200 |  700
+   3 |   200 | 1100
+   3 |   200 | 1300
+   3 |   200 |  900
+(5 rows)
+
+reset gp_enable_agg_distinct_pruning;
+/*
+ * Test multistage through Gather Motion(grouplocus cannot hashed or not exist)
+ *
+ *  Finalize Aggregate
+ *     -> Gather Motion
+ *          -> Partial Aggregate
+ *              -> HashAggregate, to remove duplicates
+ *                  -> Redistribute Motion (according to DISTINCT arg)
+ *                      -> Streaming HashAgg (to eliminate duplicates)
+ *                          -> input
+ */
+explain (verbose on, costs off) select sum(Distinct b), count(c), sum(a) from dqa_f3;
+                              QUERY PLAN                               
+-----------------------------------------------------------------------
+ Finalize Aggregate
+   Output: sum(b), count(c), sum(a)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Output: b, (PARTIAL count(c)), (PARTIAL sum(a))
+         ->  Partial HashAggregate
+               Output: b, PARTIAL count(c), PARTIAL sum(a)
+               Group Key: dqa_f3.b
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Output: b, (PARTIAL count(c)), (PARTIAL sum(a))
+                     Hash Key: b
+                     ->  Streaming Partial HashAggregate
+                           Output: b, PARTIAL count(c), PARTIAL sum(a)
+                           Group Key: dqa_f3.b
+                           ->  Seq Scan on public.dqa_f3
+                                 Output: a, b, c, d, e
+ Optimizer: Postgres query optimizer
+ Settings: enable_groupagg = 'off', gp_motion_cost_per_row = '1'
+(17 rows)
+
+select sum(Distinct b), count(c), sum(a) from dqa_f3;
+ sum | count | sum  
+-----+-------+------
+  10 |  1000 | 7993
+(1 row)
+
+explain (verbose on, costs off) select distinct sum(Distinct b), count(c), sum(a) from dqa_f3;
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Unique
+   Output: (sum(b)), (count(c)), (sum(a))
+   Group Key: (sum(b)), (count(c)), (sum(a))
+   ->  Sort
+         Output: (sum(b)), (count(c)), (sum(a))
+         Sort Key: (sum(dqa_f3.b)), (count(dqa_f3.c)), (sum(dqa_f3.a))
+         ->  Finalize Aggregate
+               Output: sum(b), count(c), sum(a)
+               ->  Gather Motion 3:1  (slice1; segments: 3)
+                     Output: b, (PARTIAL count(c)), (PARTIAL sum(a))
+                     ->  Partial HashAggregate
+                           Output: b, PARTIAL count(c), PARTIAL sum(a)
+                           Group Key: dqa_f3.b
+                           ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                                 Output: b, (PARTIAL count(c)), (PARTIAL sum(a))
+                                 Hash Key: b
+                                 ->  Streaming Partial HashAggregate
+                                       Output: b, PARTIAL count(c), PARTIAL sum(a)
+                                       Group Key: dqa_f3.b
+                                       ->  Seq Scan on public.dqa_f3
+                                             Output: a, b, c, d, e
+ Optimizer: Postgres query optimizer
+ Settings: enable_groupagg = 'off', gp_motion_cost_per_row = '1'
+(23 rows)
+
+select distinct sum(Distinct b), count(c), sum(a) from dqa_f3;
+ sum | count | sum  
+-----+-------+------
+  10 |  1000 | 7993
+(1 row)
+
+explain (verbose on, costs off) select sum(Distinct b), count(c) filter(where c > 1), sum(a) from dqa_f3;
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Finalize Aggregate
+   Output: sum(b), count(c) FILTER (WHERE (c > 1)), sum(a)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Output: b, (PARTIAL count(c) FILTER (WHERE (c > 1))), (PARTIAL sum(a))
+         ->  Partial HashAggregate
+               Output: b, PARTIAL count(c) FILTER (WHERE (c > 1)), PARTIAL sum(a)
+               Group Key: dqa_f3.b
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Output: b, (PARTIAL count(c) FILTER (WHERE (c > 1))), (PARTIAL sum(a))
+                     Hash Key: b
+                     ->  Streaming Partial HashAggregate
+                           Output: b, PARTIAL count(c) FILTER (WHERE (c > 1)), PARTIAL sum(a)
+                           Group Key: dqa_f3.b
+                           ->  Seq Scan on public.dqa_f3
+                                 Output: a, b, c, d, e
+ Optimizer: Postgres query optimizer
+ Settings: enable_groupagg = 'off', gp_motion_cost_per_row = '1'
+(17 rows)
+
+select sum(Distinct b), count(c) filter(where c > 1), sum(a) from dqa_f3;
+ sum | count | sum  
+-----+-------+------
+  10 |   333 | 7993
+(1 row)
+
+drop table dqa_f3;

--- a/src/test/regress/expected/gp_dqa_optimizer.out
+++ b/src/test/regress/expected/gp_dqa_optimizer.out
@@ -2485,6 +2485,7 @@ DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disab
  Settings: enable_groupagg = 'off', gp_motion_cost_per_row = '1'
 (19 rows)
 
+drop table dqa_f3;
 -- fix dqa bug when optimizer_force_multistage_agg is on
 set optimizer_force_multistage_agg = on;
 create table multiagg1(a int, b bigint, c int);
@@ -2680,3 +2681,479 @@ select id, count(distinct a), avg(b), sum(c) from num_table group by grouping se
 (3 rows)
 
 reset optimizer_force_multistage_agg;
+-- DQA with Agg(Intermediate Agg)
+set enable_hashagg=on;
+set enable_groupagg=off;
+create table dqa_f3(a int, b int, c int, d int, e int ) distributed by (a);
+insert into dqa_f3 select i % 17, i % 5 , i % 3, i %10, i % 7 from generate_series(1,1000) i;
+analyze dqa_f3;
+/*
+ * Test distinct or group by column is distributed key
+ *
+ * 1. If the input's locus matches the DISTINCT, but not GROUP BY:
+ *
+ *  HashAggregate
+ *     -> Redistribute (according to GROUP BY)
+ *         -> HashAggregate (to eliminate duplicates)
+ *             -> input (hashed by GROUP BY + DISTINCT)
+ *
+ * 2. If the input's locus matches the GROUP BY(don't care DISTINCT any more):
+ *
+ *  HashAggregate (to aggregate)
+ *     -> HashAggregate (to eliminate duplicates)
+ *           -> input (hashed by GROUP BY)
+ *
+ */
+explain (verbose on, costs off)select sum(Distinct a), count(b), sum(c) from dqa_f3 group by e;
+                             QUERY PLAN                             
+--------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: (sum(a)), (count(b)), (sum(c))
+   ->  Finalize HashAggregate
+         Output: sum(a), count(b), sum(c)
+         Group Key: dqa_f3.e
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Output: a, e, (PARTIAL count(b)), (PARTIAL sum(c))
+               Hash Key: e
+               ->  Streaming Partial HashAggregate
+                     Output: a, e, PARTIAL count(b), PARTIAL sum(c)
+                     Group Key: dqa_f3.e, dqa_f3.a
+                     ->  Seq Scan on public.dqa_f3
+                           Output: a, b, c, e
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Settings: enable_groupagg = 'off', gp_motion_cost_per_row = '1'
+(15 rows)
+
+select sum(Distinct a), count(b), sum(c) from dqa_f3 group by e;
+ sum | count | sum 
+-----+-------+-----
+ 136 |   142 | 142
+ 136 |   143 | 144
+ 136 |   143 | 142
+ 136 |   143 | 143
+ 136 |   143 | 144
+ 136 |   143 | 142
+ 136 |   143 | 143
+(7 rows)
+
+explain (verbose on, costs off) select sum(Distinct e), count(b), sum(c) from dqa_f3 group by a;
+                           QUERY PLAN                            
+-----------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: (sum(e)), (count(b)), (sum(c))
+   ->  Finalize HashAggregate
+         Output: sum(e), count(b), sum(c)
+         Group Key: dqa_f3.a
+         ->  Streaming Partial HashAggregate
+               Output: PARTIAL count(b), PARTIAL sum(c), a, e
+               Group Key: dqa_f3.a, dqa_f3.e
+               ->  Seq Scan on public.dqa_f3
+                     Output: a, b, c, e
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Settings: enable_groupagg = 'off', gp_motion_cost_per_row = '1'
+(12 rows)
+
+select sum(Distinct e), count(b), sum(c) from dqa_f3 group by a;
+ sum | count | sum 
+-----+-------+-----
+  21 |    58 |  57
+  21 |    58 |  59
+  21 |    59 |  58
+  21 |    59 |  59
+  21 |    59 |  59
+  21 |    59 |  58
+  21 |    59 |  60
+  21 |    59 |  60
+  21 |    58 |  58
+  21 |    59 |  58
+  21 |    59 |  60
+  21 |    59 |  58
+  21 |    59 |  58
+  21 |    59 |  59
+  21 |    59 |  60
+  21 |    59 |  59
+  21 |    59 |  60
+(17 rows)
+
+/*
+ *  Test both distinct and group by column are not distributed key 
+ *
+ *  HashAgg (to aggregate)
+ *     -> HashAgg (to eliminate duplicates)
+ *          -> Redistribute (according to GROUP BY)
+ *               -> Streaming HashAgg (to eliminate duplicates)
+ *                    -> input
+ *
+ */
+explain (verbose on, costs off) select sum(Distinct c), count(a), sum(d) from dqa_f3 group by b;
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: (sum(c)), (count(a)), (sum(d))
+   ->  Finalize HashAggregate
+         Output: sum(c), count(a), sum(d)
+         Group Key: dqa_f3.b
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Output: b, c, (PARTIAL count(a)), (PARTIAL sum(d))
+               Hash Key: b
+               ->  Partial GroupAggregate
+                     Output: b, c, PARTIAL count(a), PARTIAL sum(d)
+                     Group Key: dqa_f3.b, dqa_f3.c
+                     ->  Sort
+                           Output: b, c, (PARTIAL count(a)), (PARTIAL sum(d))
+                           Sort Key: dqa_f3.b, dqa_f3.c
+                           ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                                 Output: b, c, (PARTIAL count(a)), (PARTIAL sum(d))
+                                 Hash Key: b, c
+                                 ->  Streaming Partial HashAggregate
+                                       Output: b, c, PARTIAL count(a), PARTIAL sum(d)
+                                       Group Key: dqa_f3.b, dqa_f3.c
+                                       ->  Seq Scan on public.dqa_f3
+                                             Output: a, b, c, d
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Settings: enable_groupagg = 'off', gp_motion_cost_per_row = '1'
+(24 rows)
+
+select sum(Distinct c), count(a), sum(d) from dqa_f3 group by b;
+ sum | count | sum  
+-----+-------+------
+   3 |   200 | 1100
+   3 |   200 |  900
+   3 |   200 | 1300
+   3 |   200 |  500
+   3 |   200 |  700
+(5 rows)
+
+explain (verbose on, costs off) select sum(Distinct c), count(a), sum(d) from dqa_f3 group by b order by b;
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Result
+   Output: (sum(c)), (count(a)), (sum(d))
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Output: (sum(c)), (count(a)), (sum(d)), b
+         Merge Key: b
+         ->  Sort
+               Output: (sum(c)), (count(a)), (sum(d)), b
+               Sort Key: dqa_f3.b
+               ->  Finalize HashAggregate
+                     Output: sum(c), count(a), sum(d), b
+                     Group Key: dqa_f3.b
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Output: b, c, (PARTIAL count(a)), (PARTIAL sum(d))
+                           Hash Key: b
+                           ->  Partial GroupAggregate
+                                 Output: b, c, PARTIAL count(a), PARTIAL sum(d)
+                                 Group Key: dqa_f3.b, dqa_f3.c
+                                 ->  Sort
+                                       Output: b, c, (PARTIAL count(a)), (PARTIAL sum(d))
+                                       Sort Key: dqa_f3.b, dqa_f3.c
+                                       ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                                             Output: b, c, (PARTIAL count(a)), (PARTIAL sum(d))
+                                             Hash Key: b, c
+                                             ->  Streaming Partial HashAggregate
+                                                   Output: b, c, PARTIAL count(a), PARTIAL sum(d)
+                                                   Group Key: dqa_f3.b, dqa_f3.c
+                                                   ->  Seq Scan on public.dqa_f3
+                                                         Output: a, b, c, d
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Settings: enable_groupagg = 'off', gp_motion_cost_per_row = '1'
+(30 rows)
+
+select sum(Distinct c), count(a), sum(d) from dqa_f3 group by b order by b;
+ sum | count | sum  
+-----+-------+------
+   3 |   200 |  500
+   3 |   200 |  700
+   3 |   200 |  900
+   3 |   200 | 1100
+   3 |   200 | 1300
+(5 rows)
+
+explain (verbose on, costs off) select distinct sum(Distinct c), count(a), sum(d) from dqa_f3 group by b;
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: (sum(c)), (count(a)), (sum(d))
+   ->  GroupAggregate
+         Output: (sum(c)), (count(a)), (sum(d))
+         Group Key: (sum(dqa_f3.c)), (count(dqa_f3.a)), (sum(dqa_f3.d))
+         ->  Sort
+               Output: (sum(c)), (count(a)), (sum(d))
+               Sort Key: (sum(dqa_f3.c)), (count(dqa_f3.a)), (sum(dqa_f3.d))
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Output: (sum(c)), (count(a)), (sum(d))
+                     Hash Key: (sum(c)), (count(a)), (sum(d))
+                     ->  Finalize HashAggregate
+                           Output: sum(c), count(a), sum(d)
+                           Group Key: dqa_f3.b
+                           ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                                 Output: b, c, (PARTIAL count(a)), (PARTIAL sum(d))
+                                 Hash Key: b
+                                 ->  Partial GroupAggregate
+                                       Output: b, c, PARTIAL count(a), PARTIAL sum(d)
+                                       Group Key: dqa_f3.b, dqa_f3.c
+                                       ->  Sort
+                                             Output: b, c, (PARTIAL count(a)), (PARTIAL sum(d))
+                                             Sort Key: dqa_f3.b, dqa_f3.c
+                                             ->  Redistribute Motion 3:3  (slice4; segments: 3)
+                                                   Output: b, c, (PARTIAL count(a)), (PARTIAL sum(d))
+                                                   Hash Key: b, c
+                                                   ->  Streaming Partial HashAggregate
+                                                         Output: b, c, PARTIAL count(a), PARTIAL sum(d)
+                                                         Group Key: dqa_f3.b, dqa_f3.c
+                                                         ->  Seq Scan on public.dqa_f3
+                                                               Output: a, b, c, d
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Settings: enable_groupagg = 'off', gp_motion_cost_per_row = '1'
+(33 rows)
+
+select distinct sum(Distinct c), count(a), sum(d) from dqa_f3 group by b;
+ sum | count | sum  
+-----+-------+------
+   3 |   200 |  700
+   3 |   200 |  900
+   3 |   200 |  500
+   3 |   200 | 1300
+   3 |   200 | 1100
+(5 rows)
+
+explain (verbose on, costs off) select sum(Distinct c), count(a), sum(d) from dqa_f3 group by b having avg(e) > 3;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: (sum(c)), (count(a)), (sum(d))
+   ->  Result
+         Output: (sum(c)), (count(a)), (sum(d))
+         Filter: ((avg(dqa_f3.e)) > '3'::numeric)
+         ->  Finalize HashAggregate
+               Output: sum(c), count(a), sum(d), avg(e), b
+               Group Key: dqa_f3.b
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Output: b, c, (PARTIAL count(a)), (PARTIAL sum(d)), (PARTIAL avg(e))
+                     Hash Key: b
+                     ->  Partial HashAggregate
+                           Output: b, c, PARTIAL count(a), PARTIAL sum(d), PARTIAL avg(e)
+                           Group Key: dqa_f3.b, dqa_f3.c
+                           ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                                 Output: b, c, (PARTIAL count(a)), (PARTIAL sum(d)), (PARTIAL avg(e))
+                                 Hash Key: b, c
+                                 ->  Streaming Partial HashAggregate
+                                       Output: b, c, PARTIAL count(a), PARTIAL sum(d), PARTIAL avg(e)
+                                       Group Key: dqa_f3.b, dqa_f3.c
+                                       ->  Seq Scan on public.dqa_f3
+                                             Output: a, b, c, d, e
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Settings: enable_groupagg = 'off', gp_motion_cost_per_row = '1'
+(24 rows)
+
+select sum(Distinct c), count(a), sum(d) from dqa_f3 group by b having avg(e) > 3;
+ sum | count | sum  
+-----+-------+------
+   3 |   200 |  500
+   3 |   200 |  700
+   3 |   200 | 1100
+(3 rows)
+
+explain (verbose on, costs off)
+select sum(Distinct sub.c), count(a), sum(d)
+            from dqa_f3 left join(select x, coalesce(y, 5) as c from dqa_f2) as sub
+            on sub.x = dqa_f3.e group by b;
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: (sum((COALESCE(dqa_f2.y, 5)))), (count(dqa_f3.a)), (sum(dqa_f3.d))
+   ->  Finalize HashAggregate
+         Output: sum((COALESCE(dqa_f2.y, 5))), count(dqa_f3.a), sum(dqa_f3.d)
+         Group Key: dqa_f3.b
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Output: dqa_f3.b, (COALESCE(dqa_f2.y, 5)), (PARTIAL count(dqa_f3.a)), (PARTIAL sum(dqa_f3.d))
+               Hash Key: dqa_f3.b
+               ->  Partial GroupAggregate
+                     Output: dqa_f3.b, (COALESCE(dqa_f2.y, 5)), PARTIAL count(dqa_f3.a), PARTIAL sum(dqa_f3.d)
+                     Group Key: dqa_f3.b, (COALESCE(dqa_f2.y, 5))
+                     ->  Sort
+                           Output: dqa_f3.b, (COALESCE(dqa_f2.y, 5)), (PARTIAL count(dqa_f3.a)), (PARTIAL sum(dqa_f3.d))
+                           Sort Key: dqa_f3.b, (COALESCE(dqa_f2.y, 5))
+                           ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                                 Output: dqa_f3.b, (COALESCE(dqa_f2.y, 5)), (PARTIAL count(dqa_f3.a)), (PARTIAL sum(dqa_f3.d))
+                                 Hash Key: dqa_f3.b, (COALESCE(dqa_f2.y, 5))
+                                 ->  Streaming Partial HashAggregate
+                                       Output: dqa_f3.b, (COALESCE(dqa_f2.y, 5)), PARTIAL count(dqa_f3.a), PARTIAL sum(dqa_f3.d)
+                                       Group Key: dqa_f3.b, (COALESCE(dqa_f2.y, 5))
+                                       ->  Hash Left Join
+                                             Output: dqa_f3.a, dqa_f3.b, dqa_f3.d, (COALESCE(dqa_f2.y, 5))
+                                             Hash Cond: (dqa_f3.e = dqa_f2.x)
+                                             ->  Seq Scan on public.dqa_f3
+                                                   Output: dqa_f3.a, dqa_f3.b, dqa_f3.d, dqa_f3.e
+                                             ->  Hash
+                                                   Output: (COALESCE(dqa_f2.y, 5)), dqa_f2.x
+                                                   ->  Result
+                                                         Output: COALESCE(dqa_f2.y, 5), dqa_f2.x
+                                                         ->  Broadcast Motion 3:3  (slice4; segments: 3)
+                                                               Output: dqa_f2.x, dqa_f2.y
+                                                               ->  Seq Scan on public.dqa_f2
+                                                                     Output: dqa_f2.x, dqa_f2.y
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Settings: enable_groupagg = 'off', gp_motion_cost_per_row = '1'
+(35 rows)
+
+select sum(Distinct sub.c), count(a), sum(d)
+            from dqa_f3 left join(select x, coalesce(y, 5) as c from dqa_f2) as sub
+            on sub.x = dqa_f3.e group by b;
+ sum | count |  sum  
+-----+-------+-------
+  10 | 15372 | 38430
+  10 | 15372 | 53802
+  10 | 15372 | 84546
+  10 | 15371 | 99914
+  10 | 15371 | 69167
+(5 rows)
+
+-- Test gp_enable_agg_distinct_pruning is off on this branch
+set gp_enable_agg_distinct_pruning = off;
+explain (verbose on, costs off) select sum(Distinct c), count(a), sum(d) from dqa_f3 group by b;
+                                               QUERY PLAN                                                
+---------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: (sum(c)), (count(a)), (sum(d))
+   ->  Finalize HashAggregate
+         Output: sum(c), count(a), sum(d)
+         Group Key: dqa_f3.b
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Output: b, c, (PARTIAL count(a)), (PARTIAL sum(d))
+               Hash Key: b
+               ->  Partial GroupAggregate
+                     Output: b, c, PARTIAL count(a), PARTIAL sum(d)
+                     Group Key: dqa_f3.b, dqa_f3.c
+                     ->  Sort
+                           Output: b, c, (PARTIAL count(a)), (PARTIAL sum(d))
+                           Sort Key: dqa_f3.b, dqa_f3.c
+                           ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                                 Output: b, c, (PARTIAL count(a)), (PARTIAL sum(d))
+                                 Hash Key: b, c
+                                 ->  Streaming Partial HashAggregate
+                                       Output: b, c, PARTIAL count(a), PARTIAL sum(d)
+                                       Group Key: dqa_f3.b, dqa_f3.c
+                                       ->  Seq Scan on public.dqa_f3
+                                             Output: a, b, c, d
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Settings: enable_groupagg = 'off', gp_enable_agg_distinct_pruning = 'off', gp_motion_cost_per_row = '1'
+(24 rows)
+
+select sum(Distinct c), count(a), sum(d) from dqa_f3 group by b;
+ sum | count | sum  
+-----+-------+------
+   3 |   200 | 1100
+   3 |   200 |  900
+   3 |   200 | 1300
+   3 |   200 |  500
+   3 |   200 |  700
+(5 rows)
+
+reset gp_enable_agg_distinct_pruning;
+/*
+ * Test multistage through Gather Motion(grouplocus cannot hashed or not exist)
+ *
+ *  Finalize Aggregate
+ *     -> Gather Motion
+ *          -> Partial Aggregate
+ *              -> HashAggregate, to remove duplicates
+ *                  -> Redistribute Motion (according to DISTINCT arg)
+ *                      -> Streaming HashAgg (to eliminate duplicates)
+ *                          -> input
+ */
+explain (verbose on, costs off) select sum(Distinct b), count(c), sum(a) from dqa_f3;
+                                 QUERY PLAN                                  
+-----------------------------------------------------------------------------
+ Finalize Aggregate
+   Output: sum(b), count(c), sum(a)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Output: b, (PARTIAL count(c)), (PARTIAL sum(a))
+         ->  Partial GroupAggregate
+               Output: b, PARTIAL count(c), PARTIAL sum(a)
+               Group Key: dqa_f3.b
+               ->  Sort
+                     Output: b, (PARTIAL count(c)), (PARTIAL sum(a))
+                     Sort Key: dqa_f3.b
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Output: b, (PARTIAL count(c)), (PARTIAL sum(a))
+                           Hash Key: b
+                           ->  Streaming Partial HashAggregate
+                                 Output: b, PARTIAL count(c), PARTIAL sum(a)
+                                 Group Key: dqa_f3.b
+                                 ->  Seq Scan on public.dqa_f3
+                                       Output: a, b, c
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Settings: enable_groupagg = 'off', gp_motion_cost_per_row = '1'
+(20 rows)
+
+select sum(Distinct b), count(c), sum(a) from dqa_f3;
+ sum | count | sum  
+-----+-------+------
+  10 |  1000 | 7993
+(1 row)
+
+explain (verbose on, costs off) select distinct sum(Distinct b), count(c), sum(a) from dqa_f3;
+                                 QUERY PLAN                                  
+-----------------------------------------------------------------------------
+ Finalize Aggregate
+   Output: sum(b), count(c), sum(a)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Output: b, (PARTIAL count(c)), (PARTIAL sum(a))
+         ->  Partial GroupAggregate
+               Output: b, PARTIAL count(c), PARTIAL sum(a)
+               Group Key: dqa_f3.b
+               ->  Sort
+                     Output: b, (PARTIAL count(c)), (PARTIAL sum(a))
+                     Sort Key: dqa_f3.b
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Output: b, (PARTIAL count(c)), (PARTIAL sum(a))
+                           Hash Key: b
+                           ->  Streaming Partial HashAggregate
+                                 Output: b, PARTIAL count(c), PARTIAL sum(a)
+                                 Group Key: dqa_f3.b
+                                 ->  Seq Scan on public.dqa_f3
+                                       Output: a, b, c
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Settings: enable_groupagg = 'off', gp_motion_cost_per_row = '1'
+(20 rows)
+
+select distinct sum(Distinct b), count(c), sum(a) from dqa_f3;
+ sum | count | sum  
+-----+-------+------
+  10 |  1000 | 7993
+(1 row)
+
+explain (verbose on, costs off) select sum(Distinct b), count(c) filter(where c > 1), sum(a) from dqa_f3;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Aggregate functions with FILTER
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Finalize Aggregate
+   Output: sum(b), count(c) FILTER (WHERE (c > 1)), sum(a)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Output: b, (PARTIAL count(c) FILTER (WHERE (c > 1))), (PARTIAL sum(a))
+         ->  Partial HashAggregate
+               Output: b, PARTIAL count(c) FILTER (WHERE (c > 1)), PARTIAL sum(a)
+               Group Key: dqa_f3.b
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Output: b, (PARTIAL count(c) FILTER (WHERE (c > 1))), (PARTIAL sum(a))
+                     Hash Key: b
+                     ->  Streaming Partial HashAggregate
+                           Output: b, PARTIAL count(c) FILTER (WHERE (c > 1)), PARTIAL sum(a)
+                           Group Key: dqa_f3.b
+                           ->  Seq Scan on public.dqa_f3
+                                 Output: a, b, c, d, e
+ Optimizer: Postgres query optimizer
+ Settings: enable_groupagg = 'off', gp_motion_cost_per_row = '1'
+(17 rows)
+
+select sum(Distinct b), count(c) filter(where c > 1), sum(a) from dqa_f3;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Aggregate functions with FILTER
+ sum | count | sum  
+-----+-------+------
+  10 |   333 | 7993
+(1 row)
+
+drop table dqa_f3;

--- a/src/test/regress/expected/partition_aggregate.out
+++ b/src/test/regress/expected/partition_aggregate.out
@@ -1109,48 +1109,36 @@ SET max_parallel_workers_per_gather TO 2;
 -- is not partial agg safe.
 EXPLAIN (COSTS OFF)
 SELECT a, sum(b), array_agg(distinct c), count(*) FROM pagg_tab_ml GROUP BY a HAVING avg(b) < 3 ORDER BY 1, 2, 3;
-                                             QUERY PLAN                                              
------------------------------------------------------------------------------------------------------
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   Merge Key: pagg_tab_ml_p1.a, (sum(pagg_tab_ml_p1.b)), (array_agg(DISTINCT pagg_tab_ml_p1.c))
+   Merge Key: pagg_tab_ml_p1.a, (sum(pagg_tab_ml_p1.b)), (array_agg(pagg_tab_ml_p1.c))
    ->  Sort
-         Sort Key: pagg_tab_ml_p1.a, (sum(pagg_tab_ml_p1.b)), (array_agg(DISTINCT pagg_tab_ml_p1.c))
-         ->  Append
-               ->  GroupAggregate
-                     Group Key: pagg_tab_ml_p1.a
-                     Filter: (avg(pagg_tab_ml_p1.b) < '3'::numeric)
-                     ->  Sort
-                           Sort Key: pagg_tab_ml_p1.a
+         Sort Key: pagg_tab_ml_p1.a, (sum(pagg_tab_ml_p1.b)), (array_agg(pagg_tab_ml_p1.c))
+         ->  Finalize HashAggregate
+               Group Key: pagg_tab_ml_p1.a
+               Filter: (avg(pagg_tab_ml_p1.b) < '3'::numeric)
+               ->  Partial HashAggregate
+                     Group Key: pagg_tab_ml_p1.a, pagg_tab_ml_p1.c
+                     ->  Append
                            ->  Seq Scan on pagg_tab_ml_p1
-               ->  GroupAggregate
-                     Group Key: pagg_tab_ml_p2_s1.a
-                     Filter: (avg(pagg_tab_ml_p2_s1.b) < '3'::numeric)
-                     ->  Sort
-                           Sort Key: pagg_tab_ml_p2_s1.a
-                           ->  Append
-                                 ->  Seq Scan on pagg_tab_ml_p2_s1
-                                 ->  Seq Scan on pagg_tab_ml_p2_s2
-               ->  GroupAggregate
-                     Group Key: pagg_tab_ml_p3_s1.a
-                     Filter: (avg(pagg_tab_ml_p3_s1.b) < '3'::numeric)
-                     ->  Sort
-                           Sort Key: pagg_tab_ml_p3_s1.a
-                           ->  Append
-                                 ->  Seq Scan on pagg_tab_ml_p3_s1
-                                 ->  Seq Scan on pagg_tab_ml_p3_s2
+                           ->  Seq Scan on pagg_tab_ml_p2_s1
+                           ->  Seq Scan on pagg_tab_ml_p2_s2
+                           ->  Seq Scan on pagg_tab_ml_p3_s1
+                           ->  Seq Scan on pagg_tab_ml_p3_s2
  Optimizer: Postgres query optimizer
-(28 rows)
+(16 rows)
 
 SELECT a, sum(b), array_agg(distinct c), count(*) FROM pagg_tab_ml GROUP BY a HAVING avg(b) < 3 ORDER BY 1, 2, 3;
  a  | sum  |  array_agg  | count 
 ----+------+-------------+-------
   0 |    0 | {0000,0002} |  1000
-  1 | 1000 | {0001,0003} |  1000
+  1 | 1000 | {0003,0001} |  1000
   2 | 2000 | {0000,0002} |  1000
- 10 |    0 | {0000,0002} |  1000
- 11 | 1000 | {0001,0003} |  1000
- 12 | 2000 | {0000,0002} |  1000
- 20 |    0 | {0000,0002} |  1000
+ 10 |    0 | {0002,0000} |  1000
+ 11 | 1000 | {0003,0001} |  1000
+ 12 | 2000 | {0002,0000} |  1000
+ 20 |    0 | {0002,0000} |  1000
  21 | 1000 | {0001,0003} |  1000
  22 | 2000 | {0000,0002} |  1000
 (9 rows)
@@ -1158,34 +1146,22 @@ SELECT a, sum(b), array_agg(distinct c), count(*) FROM pagg_tab_ml GROUP BY a HA
 -- Without ORDER BY clause, to test Gather at top-most path
 EXPLAIN (COSTS OFF)
 SELECT a, sum(b), array_agg(distinct c), count(*) FROM pagg_tab_ml GROUP BY a HAVING avg(b) < 3;
-                           QUERY PLAN                            
------------------------------------------------------------------
+                         QUERY PLAN                          
+-------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  Append
-         ->  GroupAggregate
-               Group Key: pagg_tab_ml_p1.a
-               Filter: (avg(pagg_tab_ml_p1.b) < '3'::numeric)
-               ->  Sort
-                     Sort Key: pagg_tab_ml_p1.a
+   ->  Finalize HashAggregate
+         Group Key: pagg_tab_ml_p1.a
+         Filter: (avg(pagg_tab_ml_p1.b) < '3'::numeric)
+         ->  Partial HashAggregate
+               Group Key: pagg_tab_ml_p1.a, pagg_tab_ml_p1.c
+               ->  Append
                      ->  Seq Scan on pagg_tab_ml_p1
-         ->  GroupAggregate
-               Group Key: pagg_tab_ml_p2_s1.a
-               Filter: (avg(pagg_tab_ml_p2_s1.b) < '3'::numeric)
-               ->  Sort
-                     Sort Key: pagg_tab_ml_p2_s1.a
-                     ->  Append
-                           ->  Seq Scan on pagg_tab_ml_p2_s1
-                           ->  Seq Scan on pagg_tab_ml_p2_s2
-         ->  GroupAggregate
-               Group Key: pagg_tab_ml_p3_s1.a
-               Filter: (avg(pagg_tab_ml_p3_s1.b) < '3'::numeric)
-               ->  Sort
-                     Sort Key: pagg_tab_ml_p3_s1.a
-                     ->  Append
-                           ->  Seq Scan on pagg_tab_ml_p3_s1
-                           ->  Seq Scan on pagg_tab_ml_p3_s2
+                     ->  Seq Scan on pagg_tab_ml_p2_s1
+                     ->  Seq Scan on pagg_tab_ml_p2_s2
+                     ->  Seq Scan on pagg_tab_ml_p3_s1
+                     ->  Seq Scan on pagg_tab_ml_p3_s2
  Optimizer: Postgres query optimizer
-(25 rows)
+(13 rows)
 
 -- Full aggregation at level 1 as GROUP BY clause matches with PARTITION KEY
 -- for level 1 only. For subpartitions, GROUP BY clause does not match with


### PR DESCRIPTION
Support intermediate aggregate in planner on GPDB7. 

### Background

**_What is DQA?_**

DQA(Distinct-Qualified Aggregates) is a complex optimization  in MPP planner, which used to stand for Count(Distinct xxx) in query. We cannot use hashagg for DQA in postgresql and Greenplum, which is a historic restriction from Executor. However, sortagg has a bad performance especially in MPP system because of too many duplicate tuple involved. So we need to implement double-hashagg strategy to solve this problem.   

SortAgg case
Duplication on t1 will result in base performance for whole plan.
```
postgres=# explain(costs off) select count(Distinct a) from t1 group by c;
                            QUERY PLAN                            
------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)
   ->  GroupAggregate
         Group Key: c
         ->  Sort
               Sort Key: c
               ->  Redistribute Motion 3:3  (slice2; segments: 3)
                     Hash Key: c
                     ->  Seq Scan on t1
 Optimizer: Postgres query optimizer
(9 rows)
```

Double-Hashagg case
We could use first hashagg to deduplicate tuple grouped by a and c, then another hashagg for final result
```
postgres=# explain(costs off) select count(Distinct a) from t1 group by c;
                         QUERY PLAN                         
------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)
   ->  HashAggregate
         Group Key: c
         ->  Redistribute Motion 3:3  (slice2; segments: 3)
               Hash Key: c
               ->  HashAggregate
                     Group Key: c, a
                     ->  Seq Scan on t1
 Optimizer: Postgres query optimizer
(9 rows)
```

**_What is DQA_WTIHAGG(Intermediate AGG) ?_**

DQA_WTIHAGG is a special case for DQA, and we always treat query that consist of DQA and Aggregate
as DQA_WTIHAGG. 
Ex:
```
postgres=# explain(costs off, verbose on) select sum(distinct b), count(c) from t1 group by d;
                            QUERY PLAN                            
------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)
   Output: (sum(b)), (count(c)), d
   ->  Finalize HashAggregate
         Output: sum(b), count(c), d
         Group Key: t1.d
         **->  Partial HashAggregate**
               Output: d, b, **PARTIAL count(c)**
               Group Key: t1.d, t1.b
               ->  Redistribute Motion 3:3  (slice2; segments: 3)
                     Output: d, b, (PARTIAL count(c))
                     Hash Key: d
                     ->  Streaming Partial HashAggregate
                           Output: d, b, PARTIAL count(c)
                           Group Key: t1.d, t1.b
                           ->  Seq Scan on public.t1
                                 Output: a, b, c, d, e
 Optimizer: Postgres query optimizer
```
As plan case above, we could call the middle HashAgg is an Intermedaite Agg Plan
node here, because output Aggref of this node has as the same combining type as input.


### Implementation

- Intermediate agg targetlist
First, we need to generate targetlist which consist by deduplicate hash key and plain agg, which is related to function fetch_single_dqa_target().

- HashAgg path
We need to create rule_base hashagg path based on group by key and distinct key Locus, which use heuristic algorithm. This part is same as creating DQA hashagg path. 

- Planrefence
Handle intermediate Aggref in set_plan_refs for some special mark like AGGSPLIT_DQAWITHAGG.
AGGSPLIT_DQAWITHAGG is  aggsplit of final agg plan node, and there are two Aggrefs, aggsplit_simple and aggsplit_combine, existing in targetlist at same time. So we need to refer aggsplit_simple Aggref to Vars in child plan node and refer aggsplit_combine Aggref to partial Aggref.

### WorkAround
gp_enable_agg_distinct
DQA double-hashagg will be abandon if turn off gp_enable_agg_distinct.

### Future work

- Correct DQA costs, not only in DQA but also in DQA_WITHAGG
- Support MULTI_DQAS_WITHAGG 

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
