### PR TITLE
refactor the resource queue scheduler code

### DIFF
--- a/src/include/utils/resscheduler.h
+++ b/src/include/utils/resscheduler.h
@@ -49,13 +49,15 @@ extern bool	ResourceCleanupIdleGangs;
 
 /* Resource Limits */
 #define INVALID_RES_LIMIT_THRESHOLD		(-1)
-#define NUM_RES_LIMIT_TYPES				3
 
 typedef enum ResLimitType
 {
 	RES_COUNT_LIMIT,					/* Limit total # */
 	RES_COST_LIMIT,						/* Limit total cost */
-	RES_MEMORY_LIMIT
+	RES_MEMORY_LIMIT,
+
+	NUM_RES_LIMIT_TYPES					/* Number of the above resource limits.
+										   NB: keep it the last value */
 } ResLimitType;
 
 


### PR DESCRIPTION
1. put NUM_RES_LIMIT_TYPES into `enum ResLimitType` make it easier
   to add more resource limit.
2. remove the useless `switch case` code to make the code neat.
3. remove some trailing whitespaces.

Signed-off-by: Junwang Zhao <zhjwpku@gmail.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
