### PR TITLE
Move stats related tests under disable_autovacuum for validity of index's reltuples.

### DIFF
--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -207,23 +207,13 @@ ignore: tpch500GB_orca
 
 # Tests for "compaction", i.e. VACUUM, of updatable append-only tables
 test: uao_compaction/full uao_compaction/outdated_partialindex uao_compaction/drop_column_update uao_compaction/eof_truncate uao_compaction/basic uao_compaction/outdatedindex uao_compaction/update_toast uao_compaction/outdatedindex_abort uao_compaction/delete_toast uao_compaction/alter_table_analyze uao_compaction/full_eof_truncate uao_compaction/full_threshold
-# TODO find why these tests fail in parallel, for now keeping them sequential
-test: uao_compaction/full_stats
-test: uao_compaction/stats
-test: uao_compaction/index_stats
-test: uao_compaction/index
-test: uao_compaction/drop_column
-test: uao_compaction/index2
 
+test: uao_compaction/index
+test: uao_compaction/index2
+test: uaocs_compaction/index
 
 # Tests for "compaction", i.e. VACUUM, of updatable append-only column oriented tables
 test: uaocs_compaction/alter_table_analyze uaocs_compaction/basic uaocs_compaction/drop_column_update uaocs_compaction/eof_truncate uaocs_compaction/full uaocs_compaction/full_eof_truncate uaocs_compaction/full_threshold uaocs_compaction/outdated_partialindex uaocs_compaction/outdatedindex uaocs_compaction/outdatedindex_abort
-# TODO find why these tests fail in parallel, for now keeping them sequential
-test: uaocs_compaction/full_stats
-test: uaocs_compaction/stats
-test: uaocs_compaction/index_stats
-test: uaocs_compaction/index
-test: uaocs_compaction/drop_column
 
 test: uao_ddl/cursor_row uao_ddl/cursor_column uao_ddl/alter_ao_table_statistics_row uao_ddl/alter_ao_table_statistics_column uao_ddl/alter_ao_table_setdefault_row uao_ddl/alter_ao_table_index_row uao_ddl/alter_ao_table_owner_column uao_ddl/spgist_over_ao_table_row
 test: uao_ddl/alter_ao_table_owner_row uao_ddl/alter_ao_table_setstorage_row uao_ddl/alter_ao_table_constraint_row uao_ddl/alter_ao_table_constraint_column uao_ddl/alter_ao_table_index_column uao_ddl/blocksize_row uao_ddl/compresstype_column uao_ddl/alter_ao_table_setdefault_column uao_ddl/blocksize_column uao_ddl/temp_on_commit_delete_rows_row uao_ddl/temp_on_commit_delete_rows_column uao_ddl/spgist_over_ao_table_column
@@ -240,6 +230,19 @@ test: uao_dml/uao_dml_cursor_row uao_dml/uao_dml_select_row uao_dml/uao_dml_curs
 
 # disable autovacuum for the test
 test: disable_autovacuum
+# These cases need to run without autovacuum, as it acquiring ShareUpdateExclusiveLock
+# on table which does matter concurrent VACUUM stats on reltuples calculation.
+# TODO find why these tests fail in parallel, for now keeping them sequential
+test: uao_compaction/full_stats
+test: uao_compaction/stats
+test: uao_compaction/index_stats
+test: uao_compaction/drop_column
+# TODO find why these tests fail in parallel, for now keeping them sequential
+test: uaocs_compaction/full_stats
+test: uaocs_compaction/stats
+test: uaocs_compaction/index_stats
+test: uaocs_compaction/drop_column
+
 # Run uao[cs]_catalog_tables separately. They run VACUUM FULL on
 # append-optimized tables and assume that no AWAITING_DROP segfiles exist at
 # the end of VACUUM FULL.


### PR DESCRIPTION
This is intended to fix flaky cases introduced by VACUUM index
enhancement on AO PR https://github.com/greenplum-db/gpdb/pull/13255.

As the new VACUUM strategy cleaning up index dead tuples isn't based on
visibility map checking any more, there might be more index->reltuples
to be counted in the case of concurrent AUTOVACUUM/AUTOANALYZE(for sampling
the stats of user tables) being reading the same table result in dead tuples
deletion skipped. So move impact tests under disable_autovacuum for validity
of stats on index->reltuples.

As we didn't enable AUTOVACUUM on 6X, so it is supposed to be no issue on 6X.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
