### PR TITLE
Fix compile-time warn in pg_basebackup code

### DIFF
--- a/src/bin/pg_basebackup/pg_basebackup.c
+++ b/src/bin/pg_basebackup/pg_basebackup.c
@@ -1994,7 +1994,7 @@ BaseBackup(const char *argv0)
 			char	   *path = (char *) get_tablespace_mapping(PQgetvalue(res, i, 1));
 			char path_with_subdir[MAXPGPATH];
 
-			sprintf(path_with_subdir, "%s/%d/%s", path, target_gp_dbid, GP_TABLESPACE_VERSION_DIRECTORY);
+			snprintf(path_with_subdir, MAXPGPATH, "%s/%d/%s", path, target_gp_dbid, GP_TABLESPACE_VERSION_DIRECTORY);
 
 			verify_dir_is_empty_or_create(path_with_subdir);
 		}


### PR DESCRIPTION

I have noticed such a warn, while compiling gp from 6X_STABLE branch.

pg_basebackup.c: In function ‘BaseBackup’:
pg_basebackup.c:1997:34: warning: ‘%d’ directive writing between 1 and 11 bytes into a region of size between 0 and 1023 [-Wformat-overflow=]
 1997 |    sprintf(path_with_subdir, "%s/%d/%s", path, target_gp_dbid, GP_TABLESPACE_VERSION_DIRECTORY);

So, we simply change sprintf function to snprintf, to check resulting buffer size overflow, similar to what is done in this file several lines [below](https://github.com/greenplum-db/gpdb/blob/master/src/bin/pg_basebackup/pg_basebackup.c#L2014)


## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [x] Document changes
- [x] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [x] Review a PR in return to support the community
