### PR TITLE
Convert targetRoute Assert()s in SendTupleChunkToAMS() into FATALs

### DIFF
--- a/src/backend/cdb/motion/ic_common.c
+++ b/src/backend/cdb/motion/ic_common.c
@@ -324,8 +324,9 @@ SendTupleChunkToAMS(MotionLayerState *mlStates,
 		else
 		{
 			/* handle pt-to-pt message. Primary */
-			Assert(targetRoute >= 0);
-			Assert(targetRoute < pEntry->numConns);
+			if (targetRoute < 0 || targetRoute >= pEntry->numConns)
+				elog(FATAL, "SendTupleChunkToAMS: targetRoute is %d, must be between 0 and %d .",
+							targetRoute, pEntry->numConns);
 			conn = pEntry->conns + targetRoute;
 			/* only send to interested connections */
 			if (conn->stillActive)


### PR DESCRIPTION
From time to time I observe coredumps with similar backtraces of SEGFAULTs:

```
#4  0x0000561899aa5f08 in memcpy (__len=44, __src=0x56189b5c4350, __dest=<optimized out>) at /usr/include/x86_64-linux-gnu/bits/string_fortified.h:34
#5  SendChunkUDPIFC (transportStates=<optimized out>, pEntry=0x56189b598078, conn=0x56189b5a91d8, tcItem=0x56189b5c4338, motionId=<optimized out>) at ic_udpifc.c:5433
#6  0x0000561899a99144 in SendTupleChunkToAMS (mlStates=mlStates@entry=0x56189b447d08, transportStates=transportStates@entry=0x56189b566818, motNodeID=motNodeID@entry=9, targetRoute=targetRoute@entry=33, 
    tcItem=<optimized out>) at ic_common.c:333
#7  0x0000561899a96da5 in SendTuple (mlStates=0x56189b447d08, transportStates=0x56189b566818, motNodeID=9, slot=slot@entry=0x56189b565880, targetRoute=targetRoute@entry=33) at cdbmotion.c:502
#8  0x00005618997d1aaa in doSendTuple (outerTupleSlot=<optimized out>, node=<optimized out>, motion=<optimized out>) at nodeMotion.c:1653
#9  execMotionSender (node=0x21) at nodeMotion.c:339
#10 ExecMotion (node=node@entry=0x56189b564b40) at nodeMotion.c:260
#11 0x000056189979b418 in ExecProcNode (node=node@entry=0x56189b564b40) at execProcnode.c:1121
#12 0x00005618997936d1 in ExecutePlan (estate=estate@entry=0x56189b564788, planstate=0x56189b564b40, operation=operation@entry=CMD_SELECT, sendTuples=sendTuples@entry=0 '\000', 
    numberTuples=numberTuples@entry=0, direction=direction@entry=ForwardScanDirection, dest=0x7f06e819eb88) at execMain.c:2977
#13 0x0000561899794254 in ExecutePlan (dest=0x7f06e819eb88, direction=ForwardScanDirection, numberTuples=0, sendTuples=0 '\000', operation=CMD_SELECT, planstate=<optimized out>, estate=0x56189b564788)
    at execMain.c:2943
#14 standard_ExecutorRun (queryDesc=0x56189b407788, direction=ForwardScanDirection, count=0) at execMain.c:987
#15 0x000056189991d637 in PortalRunSelect (portal=portal@entry=0x56189b562778, forward=forward@entry=1 '\001', count=0, count@entry=9223372036854775807, dest=dest@entry=0x7f06e819eb88) at pquery.c:1151
#16 0x000056189991f248 in PortalRun (portal=portal@entry=0x56189b562778, count=count@entry=9223372036854775807, isTopLevel=isTopLevel@entry=1 '\001', dest=dest@entry=0x7f06e819eb88, 
    altdest=altdest@entry=0x7f06e819eb88, completionTag=completionTag@entry=0x7ffd40ebcbc0 "") at pquery.c:992
#17 0x000056189991948b in exec_mpp_query
```

and

```
#3  memcpy (__len=64, __src=0x561d50488090, __dest=0x50290000001) at /usr/include/x86_64-linux-gnu/bits/string_fortified.h:34
#4  prepareXmit (conn=0x561d50487ff8) at ic_udpifc.c:4534
#5  SendChunkUDPIFC (transportStates=0x561d504737b8, pEntry=0x561d504c19d8, conn=0x561d50487ff8, tcItem=0x561d506dbd08, motionId=3) at ic_udpifc.c:5447
#6  0x0000561d4eb22144 in SendTupleChunkToAMS (mlStates=mlStates@entry=0x561d503726b8, transportStates=transportStates@entry=0x561d504737b8, motNodeID=motNodeID@entry=3, targetRoute=targetRoute@entry=28, tcItem=<optimized out>) at ic_common.c:333
#7  0x0000561d4eb1fda5 in SendTuple (mlStates=0x561d503726b8, transportStates=0x561d504737b8, motNodeID=3, slot=slot@entry=0x561d50370ac0, targetRoute=targetRoute@entry=28) at cdbmotion.c:502
#8  0x0000561d4e85aaaa in doSendTuple (outerTupleSlot=<optimized out>, node=<optimized out>, motion=<optimized out>) at nodeMotion.c:1653
#9  execMotionSender (node=0x1c) at nodeMotion.c:339
#10 ExecMotion (node=node@entry=0x561d504d1dd8) at nodeMotion.c:260
#11 0x0000561d4e824418 in ExecProcNode (node=node@entry=0x561d504d1dd8) at execProcnode.c:1121
#12 0x0000561d4e81c6d1 in ExecutePlan (estate=estate@entry=0x561d503706a8, planstate=0x561d504d1dd8, operation=operation@entry=CMD_SELECT, sendTuples=sendTuples@entry=0 '\000', numberTuples=numberTuples@entry=0, 
    direction=direction@entry=ForwardScanDirection, dest=0x561d504b1140) at execMain.c:2977
#13 0x0000561d4e81d254 in ExecutePlan (dest=0x561d504b1140, direction=ForwardScanDirection, numberTuples=0, sendTuples=0 '\000', operation=CMD_SELECT, planstate=<optimized out>, estate=0x561d503706a8) at execMain.c:2943
#14 standard_ExecutorRun (queryDesc=0x561d503106a8, direction=ForwardScanDirection, count=0) at execMain.c:987
#15 0x0000561d4e9a6d39 in ProcessQuery (portal=portal@entry=0x561d5036e698, stmt=stmt@entry=0x561d5030c7b8, params=<optimized out>, dest=dest@entry=0x561d504b1140, completionTag=completionTag@entry=0x7fff36ee7800 "", sourceText=<optimized out>)
    at pquery.c:288
#16 0x0000561d4e9a71c3 in PortalRunMulti (portal=portal@entry=0x561d5036e698, isTopLevel=isTopLevel@entry=1 '\001', dest=dest@entry=0x561d504b1140, altdest=altdest@entry=0x561d504b1140, completionTag=completionTag@entry=0x7fff36ee7800 "")
    at pquery.c:1473
#17 0x0000561d4e9a810b in PortalRun (portal=portal@entry=0x561d5036e698, count=count@entry=9223372036854775807, isTopLevel=isTopLevel@entry=1 '\001', dest=dest@entry=0x561d504b1140, altdest=altdest@entry=0x561d504b1140, 
    completionTag=completionTag@entry=0x7fff36ee7800 "") at pquery.c:1018
#18 0x0000561d4e9a248b in exec_mpp_query (
```

This happens because ChunkTransportStateEntry pEntry (in SendTupleChunkToAMS()) have only one connection, while we are trying to use connection targetRoute == 28. I do not know exact reason why targetRoute is out of bounds, it seems we sent slightly less than 1Gb on conn[0]. Maybe it's related to #12150.

Currently out-of-bounds targetRoute leads to SEGFAULT and crashes the segment anyway. After this commit the problem will result only in one failed query. Though root cause of invalid targetRoute is still unknown bug.