### PR TITLE
Resolve a GPDB_12_MERGE_FIXME in regress/dsp.

### DIFF
--- a/src/test/regress/expected/dsp.out
+++ b/src/test/regress/expected/dsp.out
@@ -1197,23 +1197,13 @@ select c.relname, am.amname, c.relkind, c.reloptions
  dsp_partition1_1_prt_split_p2 | ao_row    | r       | 
 (6 rows)
 
--- GPDB_12_MERGE_FIXME: gpcheckcat fails for dsp_partition1_1_prt_1
--- with checksum mismatch between master and segments. The reason
--- being RESET gp_default_storage_options above somehow seems not
--- working properly. So, we should fix RESET to work. Plus, also we
--- should enhance code to not use `gp_default_storage_options` guc on
--- segments. Instead master should use it and make all the decisions
--- and pass the decision to segments. This should avoid any
--- mis-matches and eliminates the need for the guc to be in-sync
--- between master and segment.
-drop table dsp_partition1;
 RESET gp_default_storage_options;
 -- cleanup
 \c postgres
 -- Test that gp_default_storage_options option must be the same on all nodes
--- GPDB_12_MERGE_FIXME: Is this really strictly necessary? There's code in
--- gpconfig to verify this specifically for gp_default_storage_options. Can
--- we remove it?
+-- NOTE: although gpconfig might have unittest to verity this, the GUC
+-- gp_default_storage_options is so important that adding tests for it here
+-- do no harm.
 -- start_matchsubs
 -- m/.*\[ERROR\]*/
 -- s/.*\[ERROR\]/[ERROR]/gm

--- a/src/test/regress/sql/dsp.sql
+++ b/src/test/regress/sql/dsp.sql
@@ -477,26 +477,15 @@ select c.relname, am.amname, c.relkind, c.reloptions
 	from pg_class c left join pg_am am on (c.relam = am.oid)
     where c.relname like 'dsp_partition1%' order by relname;
 
--- GPDB_12_MERGE_FIXME: gpcheckcat fails for dsp_partition1_1_prt_1
--- with checksum mismatch between master and segments. The reason
--- being RESET gp_default_storage_options above somehow seems not
--- working properly. So, we should fix RESET to work. Plus, also we
--- should enhance code to not use `gp_default_storage_options` guc on
--- segments. Instead master should use it and make all the decisions
--- and pass the decision to segments. This should avoid any
--- mis-matches and eliminates the need for the guc to be in-sync
--- between master and segment.
-drop table dsp_partition1;
 RESET gp_default_storage_options;
 
 -- cleanup
 \c postgres
 
 -- Test that gp_default_storage_options option must be the same on all nodes
-
--- GPDB_12_MERGE_FIXME: Is this really strictly necessary? There's code in
--- gpconfig to verify this specifically for gp_default_storage_options. Can
--- we remove it?
+-- NOTE: although gpconfig might have unittest to verity this, the GUC
+-- gp_default_storage_options is so important that adding tests for it here
+-- do no harm.
 
 -- start_matchsubs
 -- m/.*\[ERROR\]*/


### PR DESCRIPTION
The first FIXME is introduced by the commit from
merge branch 002f61d8. Remove it and run the full
pipelines it passes the tests.

The second FIXME is asking if it is necassary to
test GUC gp_default_storage_options should keep
consistent among master and segments. Although
gpconfig's unittest might cover this, it does no
harm to also test here for this important GUC.
