### PR TITLE
Resolve tablecmd fixme for AT_SetDistributedBy external partition check

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -4860,9 +4860,6 @@ ATPrepCmd(List **wqueue, Relation rel, AlterTableCmd *cmd,
 				DistributedBy *ldistro;
 				GpPolicy   *policy;
 
-				// GPDB_12_MERGE_FIXME: is this still needed?
-				//ATExternalPartitionCheck(cmd->subtype, rel, recursing);
-
 				Assert(IsA(cmd->def, List));
 				/* The distributeby clause is the second element of cmd->def */
 				ldistro = (DistributedBy *) lsecond((List *)cmd->def);

--- a/src/test/regress/input/external_table.source
+++ b/src/test/regress/input/external_table.source
@@ -3603,3 +3603,21 @@ CREATE EXTERNAL WEB TABLE test_part_integrity_p2 (LIKE test_part_integrity_p1) E
 ALTER TABLE test_part_integrity ATTACH PARTITION test_part_integrity_p1 FOR VALUES IN (1);
 ALTER TABLE test_part_integrity ATTACH PARTITION test_part_integrity_p2 FOR VALUES IN (2);
 SELECT * FROM test_part_integrity;
+
+DROP TABLE test_part_integrity;
+
+-- Test external partition error out on changing root distribution policy
+CREATE TABLE part_root(a int) PARTITION BY RANGE(a);
+CREATE TABLE part_child (LIKE part_root);
+CREATE WRITABLE EXTERNAL WEB TABLE part_ext_w(a int) EXECUTE 'cat > @abs_srcdir@/data/part_ext.tbl' FORMAT 'TEXT' (DELIMITER AS '|' NULL AS 'null' ESCAPE AS ' ');;
+ALTER TABLE part_root ATTACH PARTITION part_child FOR VALUES FROM (0) TO (10);
+ALTER TABLE part_root ATTACH PARTITION part_ext_w FOR VALUES FROM (10) TO (20);
+
+-- Adding column should work fine
+ALTER TABLE part_root ADD COLUMN b int;
+INSERT INTO part_root SELECT i,i FROM generate_series(1,19)i;
+
+-- altering distribution policy should fail
+ALTER TABLE part_root SET DISTRIBUTED BY (b);
+
+DROP TABLE part_root;

--- a/src/test/regress/output/external_table.source
+++ b/src/test/regress/output/external_table.source
@@ -4912,3 +4912,17 @@ SELECT * FROM test_part_integrity;
  2 | 3
 (4 rows)
 
+DROP TABLE test_part_integrity;
+-- Test external partition error out on changing root distribution policy
+CREATE TABLE part_root(a int) PARTITION BY RANGE(a);
+CREATE TABLE part_child (LIKE part_root);
+CREATE WRITABLE EXTERNAL WEB TABLE part_ext_w(a int) EXECUTE 'cat > @abs_srcdir@/data/part_ext.tbl' FORMAT 'TEXT' (DELIMITER AS '|' NULL AS 'null' ESCAPE AS ' ');;
+ALTER TABLE part_root ATTACH PARTITION part_child FOR VALUES FROM (0) TO (10);
+ALTER TABLE part_root ATTACH PARTITION part_ext_w FOR VALUES FROM (10) TO (20);
+-- Adding column should work fine
+ALTER TABLE part_root ADD COLUMN b int;
+INSERT INTO part_root SELECT i,i FROM generate_series(1,19)i;
+-- altering distribution policy should fail
+ALTER TABLE part_root SET DISTRIBUTED BY (b);
+ERROR:  "part_ext_w" is not a table
+DROP TABLE part_root;


### PR DESCRIPTION
We have these checks as part of ATPrepCmd for individual AT commands,
These checks allow AT on external partitions iff ATT_FOREIGN_TABLE
is permitted
For AT_SetDistributedBy, we only allow ATT_TABLE, so external partitions
should always error out

Added test for this behavior
