### PR TITLE
Fix compile-time warn in pg_basebackup code

### DIFF
--- a/src/bin/pg_basebackup/pg_basebackup.c
+++ b/src/bin/pg_basebackup/pg_basebackup.c
@@ -1986,7 +1986,7 @@ BaseBackup(void)
 			char	   *path = unconstify(char *, get_tablespace_mapping(PQgetvalue(res, i, 1)));
 			char path_with_subdir[MAXPGPATH];
 
-			sprintf(path_with_subdir, "%s/%d/%s", path, target_gp_dbid, GP_TABLESPACE_VERSION_DIRECTORY);
+			snprintf(path_with_subdir, MAXPGPATH, "%s/%d/%s", path, target_gp_dbid, GP_TABLESPACE_VERSION_DIRECTORY);
 
 			verify_dir_is_empty_or_create(path_with_subdir, &made_tablespace_dirs, &found_tablespace_dirs);
 		}


### PR DESCRIPTION
Change sprintf function to snprintf, to check resulting buffer size overflow.

This is the same pr as #13963 applied to master branch.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [x] Document changes
- [x] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [x] Review a PR in return to support the community
