### PR TITLE
Skip validation for custom GUC setting in gpconfig

### DIFF
--- a/gpMgmt/bin/gpconfig
+++ b/gpMgmt/bin/gpconfig
@@ -411,6 +411,9 @@ def validate_change_options(options, conn, guc):
         LOGGER.fatal(msg)
         raise Exception(msg)
 
+    if '.' in options.entry:
+        return
+
     if not guc:
         # Hidden gucs: a guc is considered hidden if both:
         #     1. It is not present with normal gucs in pg_settings

--- a/gpMgmt/test/behave/mgmt_utils/gpconfig.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpconfig.feature
@@ -240,6 +240,22 @@ Feature: gpconfig integration tests
         And verify that the file "postgresql.conf" in the coordinator data directory has "some" line starting with "gp_resqueue_priority_cpucores_per_segment"
         And verify that the file "postgresql.conf" in each segment data directory has "some" line starting with "gp_resqueue_priority_cpucores_per_segment"
 
+    @concourse_cluster
+    @demo_cluster
+    Scenario: gpconfig custom guc validation works
+      Given the user runs "gpstop -u"
+        And gpstop should return a return code of 0
+        And the gpconfig context is setup
+
+        When the user runs "gpconfig -c custom.option -v 'value'"
+        Then gpconfig should return a return code of 0
+        And verify that the file "postgresql.conf" in the coordinator data directory has "some" line starting with "custom.option"
+        And verify that the file "postgresql.conf" in each segment data directory has "some" line starting with "custom.option"
+
+        When the user runs "gpconfig -c custom.option.invalid -v 'value'"
+        Then gpconfig should return a return code of 1
+
+       
     @demo_cluster
     Scenario: gpconfig checks liveness of correct number of hosts
       Given the database is running


### PR DESCRIPTION
PostgreSQL supports custom GUC (Grand Unified Configuration)
feature, allowing user to set up their own variables

Like this:
```
postgres=# set a.b to '1';
SET
postgres=# show a.b;
 a.b
-----
 1
(1 row)
```
Also, one can define theirs custom GUC in PostgreSQL
configuration file in form:

a.b = '1'

This feature is very helpfull for PostgreSQL extension developers.
gpconfig is utility that can be used for defining GUC variables
on each GP segment node. But it performs GUC validation, irrelevant
for custom GUCs. gpconfig executes ```SHOW guc_name``` to check if
GUC really exists and supported in running version of GP cluster.
But this is unneeded for custom GUC. Also, this check will always fail
when try to add new GUC to each segment.
```
postgres=# show a.b.c
;
ERROR:  unrecognized configuration parameter "a.b.c"
postgres=# set a.b.c to '1';
SET
postgres=# show a.b.c
;
 a.b.c
-------
 1
(1 row)
```


gpconfig will fail like this
```
reshke@reshke:~/gpdb$ PGPORT=7000 /usr/local/gpdb/bin/gpconfig -c yezzey.S3_getter -v 'wal-g st get %f %s --config $1'
20220822:09:41:25:2134757 gpconfig:reshke:reshke-[CRITICAL]:-not a valid GUC: yezzey.S3_getter
not a valid GUC: yezzey.S3_getter
```

Proposed approach is not to do this king of validation for custom GUC.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [x] Document changes
- [x] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [x] Review a PR in return to support the community
