### PR TITLE
Fixes for tests introduced in fixme PR for ATTACH partition

### DIFF
--- a/src/test/regress/expected/alter_table_aocs2.out
+++ b/src/test/regress/expected/alter_table_aocs2.out
@@ -972,17 +972,17 @@ SELECT * FROM subpartition_aoco_leaf;
 -- Check if add column doesn't rewrite the table
 CREATE TABLE addcol(i int) WITH (appendonly=true, orientation=column);
 INSERT INTO addcol SELECT generate_series(1, 5);
-CREATE TEMP TABLE relfilebefore AS
+CREATE TEMP TABLE relfilebeforeaddcol AS
     SELECT -1 segid, relname, relfilenode FROM pg_class WHERE relname LIKE 'addcol%'
     UNION SELECT gp_segment_id segid, relname, relfilenode FROM gp_dist_random('pg_class')
     WHERE relname LIKE 'addcol%' ORDER BY segid;
 ALTER TABLE addcol ADD COLUMN j int DEFAULT 5;
-CREATE TEMP TABLE relfileafter AS
+CREATE TEMP TABLE relfileafteraddcol AS
     SELECT -1 segid, relname, relfilenode FROM pg_class WHERE relname LIKE 'addcol%'
     UNION SELECT gp_segment_id segid, relname, relfilenode FROM gp_dist_random('pg_class')
     WHERE relname LIKE 'addcol%' ORDER BY segid;
 -- table shouldn't be rewritten
-SELECT count(*) FROM (SELECT * FROM relfilebefore UNION SELECT * FROM relfileafter)a;
+SELECT count(*) FROM (SELECT * FROM relfilebeforeaddcol UNION SELECT * FROM relfileafteraddcol)a;
  count 
 -------
      4

--- a/src/test/regress/expected/partition.out
+++ b/src/test/regress/expected/partition.out
@@ -6010,3 +6010,9 @@ ERROR:  distribution policy for "expanded_attach" must be the same as that for "
 ALTER TABLE expanded_attach2 EXPAND TABLE;
 ALTER TABLE expanded_parent2 ATTACH PARTITION expanded_attach2 FOR VALUES FROM (6) TO (9);
 ALTER TABLE expanded_parent ATTACH PARTITION expanded_attach FOR VALUES FROM (6) TO (9);
+-- cleanup
+DROP TABLE expanded_parent;
+DROP TABLE expanded_parent2;
+DROP TABLE unexpanded_parent;
+DROP TABLE unexpanded_attach;
+DROP TABLE unexpanded_attach2;

--- a/src/test/regress/expected/partition_optimizer.out
+++ b/src/test/regress/expected/partition_optimizer.out
@@ -5949,3 +5949,60 @@ select count(*) from pg_class where relname like 'temp_parent_%';
      0
 (1 row)
 
+-- check ATTACH PARTITION on parent table with different distribution policy
+CREATE EXTENSION IF NOT EXISTS gp_debug_numsegments;
+SELECT gp_debug_set_create_table_default_numsegments(1);
+ gp_debug_set_create_table_default_numsegments 
+-----------------------------------------------
+ 1
+(1 row)
+
+CREATE TABLE expanded_parent(a int, b int) PARTITION BY RANGE(b) (START (0) END (6) EVERY (3));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE expanded_parent2(a int, b int) PARTITION BY RANGE(b) (START (0) END (6) EVERY (3));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE unexpanded_parent(a int, b int) PARTITION BY RANGE(b) (START (0) END (6) EVERY (3));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE unexpanded_attach(a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE unexpanded_attach2(a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE expanded_attach(a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE expanded_attach2(a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+SELECT gp_debug_reset_create_table_default_numsegments();
+ gp_debug_reset_create_table_default_numsegments 
+-------------------------------------------------
+ 
+(1 row)
+
+-- attaching unexpanded partition to expanded table should fail
+ALTER TABLE expanded_parent EXPAND TABLE;
+ALTER TABLE expanded_parent ATTACH PARTITION unexpanded_attach FOR VALUES FROM (6) TO (9);
+ERROR:  distribution policy for "unexpanded_attach" must be the same as that for "expanded_parent"
+-- attaching unexpanded partition to expanded table with partition prepare should fail
+ALTER TABLE expanded_parent2 EXPAND PARTITION PREPARE;
+ALTER TABLE expanded_parent2 ATTACH PARTITION unexpanded_attach2 FOR VALUES FROM (6) TO (9);
+ERROR:  distribution policy for "unexpanded_attach2" must be the same as that for "expanded_parent2"
+-- attaching expanded partition to unexpanded table should fail
+ALTER TABLE expanded_attach EXPAND TABLE;
+ALTER TABLE unexpanded_parent ATTACH PARTITION expanded_attach FOR VALUES FROM (6) TO (9);
+ERROR:  distribution policy for "expanded_attach" must be the same as that for "unexpanded_parent"
+-- attaching expanded partition to expanded table should succeed
+ALTER TABLE expanded_attach2 EXPAND TABLE;
+ALTER TABLE expanded_parent2 ATTACH PARTITION expanded_attach2 FOR VALUES FROM (6) TO (9);
+ALTER TABLE expanded_parent ATTACH PARTITION expanded_attach FOR VALUES FROM (6) TO (9);
+-- cleanup
+DROP TABLE expanded_parent;
+DROP TABLE expanded_parent2;
+DROP TABLE unexpanded_parent;
+DROP TABLE unexpanded_attach;
+DROP TABLE unexpanded_attach2;

--- a/src/test/regress/sql/alter_table_aocs2.sql
+++ b/src/test/regress/sql/alter_table_aocs2.sql
@@ -616,20 +616,20 @@ SELECT * FROM subpartition_aoco_leaf;
 CREATE TABLE addcol(i int) WITH (appendonly=true, orientation=column);
 INSERT INTO addcol SELECT generate_series(1, 5);
 
-CREATE TEMP TABLE relfilebefore AS
+CREATE TEMP TABLE relfilebeforeaddcol AS
     SELECT -1 segid, relname, relfilenode FROM pg_class WHERE relname LIKE 'addcol%'
     UNION SELECT gp_segment_id segid, relname, relfilenode FROM gp_dist_random('pg_class')
     WHERE relname LIKE 'addcol%' ORDER BY segid;
 
 ALTER TABLE addcol ADD COLUMN j int DEFAULT 5;
 
-CREATE TEMP TABLE relfileafter AS
+CREATE TEMP TABLE relfileafteraddcol AS
     SELECT -1 segid, relname, relfilenode FROM pg_class WHERE relname LIKE 'addcol%'
     UNION SELECT gp_segment_id segid, relname, relfilenode FROM gp_dist_random('pg_class')
     WHERE relname LIKE 'addcol%' ORDER BY segid;
 
 -- table shouldn't be rewritten
-SELECT count(*) FROM (SELECT * FROM relfilebefore UNION SELECT * FROM relfileafter)a;
+SELECT count(*) FROM (SELECT * FROM relfilebeforeaddcol UNION SELECT * FROM relfileafteraddcol)a;
 
 -- data is intact
 SELECT * FROM addcol;

--- a/src/test/regress/sql/partition.sql
+++ b/src/test/regress/sql/partition.sql
@@ -3846,3 +3846,10 @@ ALTER TABLE unexpanded_parent ATTACH PARTITION expanded_attach FOR VALUES FROM (
 ALTER TABLE expanded_attach2 EXPAND TABLE;
 ALTER TABLE expanded_parent2 ATTACH PARTITION expanded_attach2 FOR VALUES FROM (6) TO (9);
 ALTER TABLE expanded_parent ATTACH PARTITION expanded_attach FOR VALUES FROM (6) TO (9);
+
+-- cleanup
+DROP TABLE expanded_parent;
+DROP TABLE expanded_parent2;
+DROP TABLE unexpanded_parent;
+DROP TABLE unexpanded_attach;
+DROP TABLE unexpanded_attach2;


### PR DESCRIPTION
Commit 60758eecea4 introduced a test which didn't work with gpcheckcat
for having different distribution policies on same table. 
This change fixes the test by dropping the tables in the end as cleanup.

Add output for partition_optimizer test

Change temp table name in alter_table_aocs2 to avoid collision with
other tests using same table name
