### PR TITLE
Not grab distributed snapshot if it's direct dispatch

### DIFF
--- a/src/backend/cdb/cdbtm.c
+++ b/src/backend/cdb/cdbtm.c
@@ -58,6 +58,8 @@
 #include "utils/snapmgr.h"
 #include "utils/memutils.h"
 
+#include "nodes/plannodes.h"
+
 typedef struct TmControlBlock
 {
 	bool						DtmStarted;
@@ -85,6 +87,7 @@ uint32 *shmNextSnapshotId;
 slock_t *shmGxidGenLock;
 
 int	max_tm_gxacts = 100;
+bool needDistributedSnapshot = true;
 
 int gp_gxid_prefetch_num;
 #define GXID_PRETCH_THRESHOLD (gp_gxid_prefetch_num>>1)

--- a/src/backend/storage/ipc/procarray.c
+++ b/src/backend/storage/ipc/procarray.c
@@ -2422,8 +2422,9 @@ GetSnapshotData(Snapshot snapshot, DtxContext distributedTransactionContext)
 		MyPgXact->xmin = TransactionXmin = xmin;
 	}
 
-	/* GP: QD takes a distributed snapshot */
-	if (distributedTransactionContext == DTX_CONTEXT_QD_DISTRIBUTED_CAPABLE && !Debug_disable_distributed_snapshot)
+	/* GP: QD takes a distributed snapshot iff QD not in retry phase and the query needs distributed snapshot */
+	if (distributedTransactionContext == DTX_CONTEXT_QD_DISTRIBUTED_CAPABLE && !Debug_disable_distributed_snapshot 
+			&& needDistributedSnapshot)
 	{
 		CreateDistributedSnapshot(ds);
 		snapshot->haveDistribSnapshot = true;

--- a/src/backend/tcop/pquery.c
+++ b/src/backend/tcop/pquery.c
@@ -612,7 +612,7 @@ PortalStart(Portal portal, ParamListInfo params,
 				 *
 				 * This could improve some efficiency on OLTP.
 				 */
-				if (!IsInTransactionBlock(true) && !snapshot)
+				if (Gp_role == GP_ROLE_DISPATCH && !IsInTransactionBlock(true) && !snapshot)
 				{
 					/* check whether we need to create distributed snapshot */
 					int 		determinedSliceIndex = 1;

--- a/src/include/cdb/cdbtm.h
+++ b/src/include/cdb/cdbtm.h
@@ -19,6 +19,7 @@
 #include "nodes/plannodes.h"
 
 struct Gang;
+struct PlanSlice;
 
 /**
  * DTX states, used to track the state of the distributed transaction
@@ -264,6 +265,10 @@ typedef enum
 
 extern int max_tm_gxacts;
 extern int gp_gxid_prefetch_num;
+
+/* whether we need a distributed snapshot or not, updated before each
+ * query been dispatched. */
+extern bool needDistributedSnapshot;
 
 extern DtxContext DistributedTransactionContext;
 

--- a/src/include/cdb/cdbtm.h
+++ b/src/include/cdb/cdbtm.h
@@ -19,7 +19,6 @@
 #include "nodes/plannodes.h"
 
 struct Gang;
-struct PlanSlice;
 
 /**
  * DTX states, used to track the state of the distributed transaction

--- a/src/test/isolation2/input/distributed_snapshot.source
+++ b/src/test/isolation2/input/distributed_snapshot.source
@@ -353,12 +353,12 @@ select pg_ctl(datadir, 'restart') from gp_segment_configuration where role = 'p'
 
 
 -- test the distributed snapshot in the situation of direct dispatch
-create or replace language plpython3u;
+0: create or replace language plpython3u;
 
-create table direct_dispatch_snapshot_alpha(a int, b int);
-insert into direct_dispatch_snapshot_alpha select i, i from generate_series(1, 10) i;
+0: create table direct_dispatch_snapshot_alpha(a int, b int);
+0: insert into direct_dispatch_snapshot_alpha select i, i from generate_series(1, 10) i;
 
-create function distributed_snapshot_test(is_direct_dispatch boolean) returns boolean as $$
+0: create function distributed_snapshot_test(is_direct_dispatch boolean) returns boolean as $$
 import re
 from pg import DB
 from copy import deepcopy
@@ -389,6 +389,6 @@ return False
 
 $$ language plpython3u;
 
-select distributed_snapshot_test(true);
-select distributed_snapshot_test(false);
+0: select distributed_snapshot_test(true);
+0: select distributed_snapshot_test(false);
 

--- a/src/test/isolation2/input/distributed_snapshot.source
+++ b/src/test/isolation2/input/distributed_snapshot.source
@@ -316,7 +316,7 @@ create table distributed_snapshot_fix1(a int);
 -- Details about how we consume it:
 -- 1. Using test_consume_xids to consume what's needed - 2;
 -- 2. The current transaction consumes 1 xid;
--- 3. Use another transaction to consume 1 more. This is to mark the last 
+-- 3. Use another transaction to consume 1 more. This is to mark the last
 --      one completed so that after restart we can start from that.
 1U: begin;
 1U: select test_consume_xids((131070 - (cur % 131072))::int) from txid_current() cur;
@@ -331,22 +331,64 @@ create table distributed_snapshot_fix1(a int);
 -- would successfully truncate the current working segment.
 select pg_ctl(datadir, 'restart') from gp_segment_configuration where role = 'p' and content = 1;
 
--- Do a SELECT. This assigns distributed snapshot but it won't assign new xid. 
--- Since we'll advance to the next future xid which is the first xid of the next segment, 
--- this will get all DLOG segments truncated. 
+-- Do a SELECT. This assigns distributed snapshot but it won't assign new xid.
+-- Since we'll advance to the next future xid which is the first xid of the next segment,
+-- this will get all DLOG segments truncated.
 1: select * from distributed_snapshot_fix1;
 
--- Checking the DLOG segments we have right now, which is none. 
+-- Checking the DLOG segments we have right now, which is none.
 1U: select count(*) from gp_distributed_log;
 
 1Uq:
 1q:
 
--- Restart server again. Previously DistributedLogShared->oldestXmin is initialized to 
+-- Restart server again. Previously DistributedLogShared->oldestXmin is initialized to
 -- latestCompletedXid.
 select pg_ctl(datadir, 'restart') from gp_segment_configuration where role = 'p' and content = 1;
 
--- Do a SELECT. Previously this would complain about missing segment file because we've 
+-- Do a SELECT. Previously this would complain about missing segment file because we've
 -- truncated the segment that latestCompletedXid is on. Now we don't, because we will
 -- be advancing from latestCompletedXid + 1.
 1: select * from distributed_snapshot_fix1;
+
+
+-- test the distributed snapshot in the situation of direct dispatch
+create or replace language plpython3u;
+
+create table direct_dispatch_snapshot_alpha(a int, b int);
+insert into direct_dispatch_snapshot_alpha select i, i from generate_series(1, 10) i;
+
+create function distributed_snapshot_test(is_direct_dispatch boolean) returns boolean as $$
+import re
+from pg import DB
+from copy import deepcopy
+
+dbname = plpy.execute("select current_database() db")[0]["db"]
+db = DB(dbname=dbname)
+
+info_results = []
+db.set_notice_receiver(lambda n: info_results.append(deepcopy(n.message)))
+
+db.query("set Debug_print_full_dtm = on")
+db.query("set client_min_messages = log")
+
+if is_direct_dispatch:
+	# should not create distributed snapshot
+	db.query("select * from direct_dispatch_snapshot_alpha where a = 6")
+else:
+	# should create distributed snapshot
+	db.query("select * from direct_dispatch_snapshot_alpha where b = 6")
+
+info_string = ", ".join(info_results)
+res = re.findall(r"Got distributed snapshot from CreateDistributedSnapshot", info_string)
+
+if (is_direct_dispatch and len(res) == 1) or (not is_direct_dispatch and len(res) == 2):
+	return True
+
+return False
+
+$$ language plpython3u;
+
+select distributed_snapshot_test(true);
+select distributed_snapshot_test(false);
+

--- a/src/test/isolation2/output/distributed_snapshot.source
+++ b/src/test/isolation2/output/distributed_snapshot.source
@@ -554,9 +554,9 @@ CREATE
 1U: begin;
 BEGIN
 1U: select test_consume_xids((131070 - (cur % 131072))::int) from txid_current() cur;
- test_consume_xids 
+ test_consume_xids
 -------------------
-                   
+
 (1 row)
 1U: end;
 END
@@ -570,25 +570,25 @@ INSERT 1
 -- when we do DistributedLog_AdvanceOldestXmin() again in the next query, we
 -- would successfully truncate the current working segment.
 select pg_ctl(datadir, 'restart') from gp_segment_configuration where role = 'p' and content = 1;
- pg_ctl 
+ pg_ctl
 --------
- OK     
+ OK
 (1 row)
 
 -- Do a SELECT. This assigns distributed snapshot but it won't assign new xid.
 -- Since we'll advance to the next future xid which is the first xid of the next segment,
 -- this will get all DLOG segments truncated.
 1: select * from distributed_snapshot_fix1;
- a 
+ a
 ---
- 1 
+ 1
 (1 row)
 
 -- Checking the DLOG segments we have right now, which is none.
 1U: select count(*) from gp_distributed_log;
- count 
+ count
 -------
- 0     
+ 0
 (1 row)
 
 1Uq: ... <quitting>
@@ -597,16 +597,49 @@ select pg_ctl(datadir, 'restart') from gp_segment_configuration where role = 'p'
 -- Restart server again. Previously DistributedLogShared->oldestXmin is initialized to
 -- latestCompletedXid.
 select pg_ctl(datadir, 'restart') from gp_segment_configuration where role = 'p' and content = 1;
- pg_ctl 
+ pg_ctl
 --------
- OK     
+ OK
 (1 row)
 
 -- Do a SELECT. Previously this would complain about missing segment file because we've
 -- truncated the segment that latestCompletedXid is on. Now we don't, because we will
 -- be advancing from latestCompletedXid + 1.
 1: select * from distributed_snapshot_fix1;
- a 
+ a
 ---
- 1 
+ 1
 (1 row)
+
+
+-- test the distributed snapshot in the situation of direct dispatch
+create or replace language plpython3u;
+CREATE
+
+create table direct_dispatch_snapshot_alpha(a int, b int);
+CREATE
+insert into direct_dispatch_snapshot_alpha select i, i from generate_series(1, 10) i;
+INSERT 10
+
+create function distributed_snapshot_test(is_direct_dispatch boolean) returns boolean as $$ import re from pg import DB from copy import deepcopy
+dbname = plpy.execute("select current_database() db")[0]["db"] db = DB(dbname=dbname)
+info_results = [] db.set_notice_receiver(lambda n: info_results.append(deepcopy(n.message)))
+db.query("set Debug_print_full_dtm = on") db.query("set client_min_messages = log")
+if is_direct_dispatch: # should not create distributed snapshot db.query("select * from direct_dispatch_snapshot_alpha where a = 6") else: # should create distributed snapshot db.query("select * from direct_dispatch_snapshot_alpha where b = 6")
+info_string = ", ".join(info_results) res = re.findall(r"Got distributed snapshot from CreateDistributedSnapshot", info_string)
+if (is_direct_dispatch and len(res) == 1) or (not is_direct_dispatch and len(res) == 2): return True
+return False
+$$ language plpython3u;
+CREATE
+
+select distributed_snapshot_test(true);
+ distributed_snapshot_test
+---------------------------
+ t
+(1 row)
+select distributed_snapshot_test(false);
+ distributed_snapshot_test
+---------------------------
+ t
+(1 row)
+

--- a/src/test/isolation2/output/distributed_snapshot.source
+++ b/src/test/isolation2/output/distributed_snapshot.source
@@ -554,9 +554,9 @@ CREATE
 1U: begin;
 BEGIN
 1U: select test_consume_xids((131070 - (cur % 131072))::int) from txid_current() cur;
- test_consume_xids
+ test_consume_xids 
 -------------------
-
+                   
 (1 row)
 1U: end;
 END
@@ -570,25 +570,25 @@ INSERT 1
 -- when we do DistributedLog_AdvanceOldestXmin() again in the next query, we
 -- would successfully truncate the current working segment.
 select pg_ctl(datadir, 'restart') from gp_segment_configuration where role = 'p' and content = 1;
- pg_ctl
+ pg_ctl 
 --------
- OK
+ OK     
 (1 row)
 
 -- Do a SELECT. This assigns distributed snapshot but it won't assign new xid.
 -- Since we'll advance to the next future xid which is the first xid of the next segment,
 -- this will get all DLOG segments truncated.
 1: select * from distributed_snapshot_fix1;
- a
+ a 
 ---
- 1
+ 1 
 (1 row)
 
 -- Checking the DLOG segments we have right now, which is none.
 1U: select count(*) from gp_distributed_log;
- count
+ count 
 -------
- 0
+ 0     
 (1 row)
 
 1Uq: ... <quitting>
@@ -597,49 +597,49 @@ select pg_ctl(datadir, 'restart') from gp_segment_configuration where role = 'p'
 -- Restart server again. Previously DistributedLogShared->oldestXmin is initialized to
 -- latestCompletedXid.
 select pg_ctl(datadir, 'restart') from gp_segment_configuration where role = 'p' and content = 1;
- pg_ctl
+ pg_ctl 
 --------
- OK
+ OK     
 (1 row)
 
 -- Do a SELECT. Previously this would complain about missing segment file because we've
 -- truncated the segment that latestCompletedXid is on. Now we don't, because we will
 -- be advancing from latestCompletedXid + 1.
 1: select * from distributed_snapshot_fix1;
- a
+ a 
 ---
- 1
+ 1 
 (1 row)
 
 
 -- test the distributed snapshot in the situation of direct dispatch
-create or replace language plpython3u;
+0: create or replace language plpython3u;
 CREATE
 
-create table direct_dispatch_snapshot_alpha(a int, b int);
+0: create table direct_dispatch_snapshot_alpha(a int, b int);
 CREATE
-insert into direct_dispatch_snapshot_alpha select i, i from generate_series(1, 10) i;
+0: insert into direct_dispatch_snapshot_alpha select i, i from generate_series(1, 10) i;
 INSERT 10
 
-create function distributed_snapshot_test(is_direct_dispatch boolean) returns boolean as $$ import re from pg import DB from copy import deepcopy
-dbname = plpy.execute("select current_database() db")[0]["db"] db = DB(dbname=dbname)
-info_results = [] db.set_notice_receiver(lambda n: info_results.append(deepcopy(n.message)))
-db.query("set Debug_print_full_dtm = on") db.query("set client_min_messages = log")
-if is_direct_dispatch: # should not create distributed snapshot db.query("select * from direct_dispatch_snapshot_alpha where a = 6") else: # should create distributed snapshot db.query("select * from direct_dispatch_snapshot_alpha where b = 6")
-info_string = ", ".join(info_results) res = re.findall(r"Got distributed snapshot from CreateDistributedSnapshot", info_string)
-if (is_direct_dispatch and len(res) == 1) or (not is_direct_dispatch and len(res) == 2): return True
-return False
+0: create function distributed_snapshot_test(is_direct_dispatch boolean) returns boolean as $$ import re from pg import DB from copy import deepcopy 
+dbname = plpy.execute("select current_database() db")[0]["db"] db = DB(dbname=dbname) 
+info_results = [] db.set_notice_receiver(lambda n: info_results.append(deepcopy(n.message))) 
+db.query("set Debug_print_full_dtm = on") db.query("set client_min_messages = log") 
+if is_direct_dispatch: # should not create distributed snapshot db.query("select * from direct_dispatch_snapshot_alpha where a = 6") else: # should create distributed snapshot db.query("select * from direct_dispatch_snapshot_alpha where b = 6") 
+info_string = ", ".join(info_results) res = re.findall(r"Got distributed snapshot from CreateDistributedSnapshot", info_string) 
+if (is_direct_dispatch and len(res) == 1) or (not is_direct_dispatch and len(res) == 2): return True 
+return False 
 $$ language plpython3u;
 CREATE
 
-select distributed_snapshot_test(true);
- distributed_snapshot_test
+0: select distributed_snapshot_test(true);
+ distributed_snapshot_test 
 ---------------------------
- t
+ t                         
 (1 row)
-select distributed_snapshot_test(false);
- distributed_snapshot_test
+0: select distributed_snapshot_test(false);
+ distributed_snapshot_test 
 ---------------------------
- t
+ t                         
 (1 row)
 


### PR DESCRIPTION
Currently, we will create a distributed snapshot in the function `GetSnapshotData()` if 
we are QD, and we will iterate `procArray` again to get the global xmin/xmax/xip.

But if the current query could be dispatched to a single segment directly, which means 
it's a direct dispatch, there is no need to create a distributed snapshot, the local snapshot 
is enough. 