### PR TITLE
Early free underlying Scan structures

### DIFF
--- a/src/backend/access/aocs/aocsam.c
+++ b/src/backend/access/aocs/aocsam.c
@@ -562,12 +562,28 @@ aocs_beginscan_internal(Relation relation,
 	return scan;
 }
 
+/* ----------------
+ *		aocs_afterscan	- perform after scan actions
+ *
+ * Release some structures, which is safe to free after initial scan, but
+ * before rescan.
+ * ----------------
+ */
+void
+aocs_afterscan(AOCSScanDesc scan)
+{
+	if (scan->columnScanInfo.ds)
+	{
+		close_ds_read(scan->columnScanInfo.ds, scan->columnScanInfo.relationTupleDesc->natts);
+		scan->columnScanInfo.ds = NULL;
+	}
+}
+
 void
 aocs_rescan(AOCSScanDesc scan)
 {
 	close_cur_scan_seg(scan);
-	if (scan->columnScanInfo.ds)
-		close_ds_read(scan->columnScanInfo.ds, scan->columnScanInfo.relationTupleDesc->natts);
+	aocs_afterscan(scan);
 	initscan_with_colinfo(scan);
 }
 

--- a/src/backend/access/aocs/aocsam_handler.c
+++ b/src/backend/access/aocs/aocsam_handler.c
@@ -577,6 +577,8 @@ aoco_getnextslot(TableScanDesc scan, ScanDirection direction, TupleTableSlot *sl
 
 		return true;
 	}
+	else
+		aocs_afterscan(aoscan);
 
 	return false;
 }

--- a/src/include/cdb/cdbaocsam.h
+++ b/src/include/cdb/cdbaocsam.h
@@ -298,6 +298,7 @@ extern AOCSScanDesc aocs_beginrangescan(Relation relation, Snapshot snapshot,
 										Snapshot appendOnlyMetaDataSnapshot,
 										int *segfile_no_arr, int segfile_count);
 
+extern void aocs_afterscan(AOCSScanDesc scan);
 extern void aocs_rescan(AOCSScanDesc scan);
 extern void aocs_endscan(AOCSScanDesc scan);
 

--- a/src/test/regress/expected/bfv_partition_plans.out
+++ b/src/test/regress/expected/bfv_partition_plans.out
@@ -36,6 +36,20 @@ for i in range(len(rv)):
 return result
 $$
 language plpython3u;
+create or replace function get_executor_mem(query text) returns int as
+$$
+import re
+rv = plpy.execute('EXPLAIN ANALYZE '+ query)
+comp_regex = re.compile("Executor memory: (\d+)K")
+mem = 0
+for i in range(len(rv)):
+    cur_line = rv[i]['QUERY PLAN']
+    m = comp_regex.search(cur_line)
+    if m is not None:
+        mem = mem + int(m.group(1))
+return mem
+$$
+language plpython3u;
 -- Test UPDATE that moves row from one partition to another. The partitioning
 -- key is also the distribution key in this case.
 create table mpp3061 (i int) partition by range(i) (start(1) end(5) every(1));
@@ -1153,6 +1167,46 @@ select count_operator('delete from mpp6247_foo using mpp6247_bar where mpp6247_f
 
 drop table mpp6247_bar;
 drop table mpp6247_foo;
+-- Test executor memory consumption for high partitioned column oriented tables
+drop table if exists aocs_part1;
+drop table if exists aocs_part2;
+create table aocs_part1 (i0 int, i1 int, i2 int, i3 int, i4 int, i5 int, i6 int, i7 int, i8 int, i9 int)
+with (appendonly=true, orientation=column) distributed by (i0)
+partition by range (i0) (start (0) end(1) every (1));
+create table aocs_part2 (i0 int, i1 int, i2 int, i3 int, i4 int, i5 int, i6 int, i7 int, i8 int, i9 int)
+with (appendonly=true, orientation=column) distributed by (i0)
+partition by range (i0) (start (0) end(50) every (1));
+-- For ORCA, this queries use Dynamic Seq Scan over the different number
+-- of partitions (1 and 50). Before, second query executor consumed high amount
+-- of memory (51126K). From now, it should consume far less memory (3035K),
+-- even less than 5x memory consumption of first query (1339K).
+-- As it's true for ORCA only, we analyze only ORCA's result.
+with vals as(
+  select
+  get_executor_mem('select i0, i1, i2, i3, i4, i5, i6, i7, i8, i9 
+  from (
+    select *,
+    row_number() over (partition by i0 order by i1) as seq
+    from aocs_part1
+  ) as p
+  where seq=1') as v1,
+  get_executor_mem('select i0, i1, i2, i3, i4, i5, i6, i7, i8, i9 
+  from (
+    select *,
+    row_number() over (partition by i0 order by i1) as seq
+    from aocs_part2
+  ) as p
+  where seq=1') as v2
+)
+select case when (select setting='off' from pg_settings where name = 'optimizer') then true
+    else (v2 < v1 * 5)
+    end as should_true
+from vals;
+ should_true 
+-------------
+ t
+(1 row)
+
 -- CLEANUP
 -- start_ignore
 drop schema if exists bfv_partition_plans cascade;

--- a/src/test/regress/expected/bfv_partition_plans_optimizer.out
+++ b/src/test/regress/expected/bfv_partition_plans_optimizer.out
@@ -36,6 +36,20 @@ for i in range(len(rv)):
 return result
 $$
 language plpython3u;
+create or replace function get_executor_mem(query text) returns int as
+$$
+import re
+rv = plpy.execute('EXPLAIN ANALYZE '+ query)
+comp_regex = re.compile("Executor memory: (\d+)K")
+mem = 0
+for i in range(len(rv)):
+    cur_line = rv[i]['QUERY PLAN']
+    m = comp_regex.search(cur_line)
+    if m is not None:
+        mem = mem + int(m.group(1))
+return mem
+$$
+language plpython3u;
 -- Test UPDATE that moves row from one partition to another. The partitioning
 -- key is also the distribution key in this case.
 create table mpp3061 (i int) partition by range(i) (start(1) end(5) every(1));
@@ -1151,6 +1165,46 @@ select count_operator('delete from mpp6247_foo using mpp6247_bar where mpp6247_f
 
 drop table mpp6247_bar;
 drop table mpp6247_foo;
+-- Test executor memory consumption for high partitioned column oriented tables
+drop table if exists aocs_part1;
+drop table if exists aocs_part2;
+create table aocs_part1 (i0 int, i1 int, i2 int, i3 int, i4 int, i5 int, i6 int, i7 int, i8 int, i9 int)
+with (appendonly=true, orientation=column) distributed by (i0)
+partition by range (i0) (start (0) end(1) every (1));
+create table aocs_part2 (i0 int, i1 int, i2 int, i3 int, i4 int, i5 int, i6 int, i7 int, i8 int, i9 int)
+with (appendonly=true, orientation=column) distributed by (i0)
+partition by range (i0) (start (0) end(50) every (1));
+-- For ORCA, this queries use Dynamic Seq Scan over the different number
+-- of partitions (1 and 50). Before, second query executor consumed high amount
+-- of memory (51126K). From now, it should consume far less memory (3035K),
+-- even less than 5x memory consumption of first query (1339K).
+-- As it's true for ORCA only, we analyze only ORCA's result.
+with vals as(
+  select
+  get_executor_mem('select i0, i1, i2, i3, i4, i5, i6, i7, i8, i9 
+  from (
+    select *,
+    row_number() over (partition by i0 order by i1) as seq
+    from aocs_part1
+  ) as p
+  where seq=1') as v1,
+  get_executor_mem('select i0, i1, i2, i3, i4, i5, i6, i7, i8, i9 
+  from (
+    select *,
+    row_number() over (partition by i0 order by i1) as seq
+    from aocs_part2
+  ) as p
+  where seq=1') as v2
+)
+select case when (select setting='off' from pg_settings where name = 'optimizer') then true
+    else (v2 < v1 * 5)
+    end as should_true
+from vals;
+ should_true 
+-------------
+ t
+(1 row)
+
 -- CLEANUP
 -- start_ignore
 drop schema if exists bfv_partition_plans cascade;

--- a/src/test/regress/sql/bfv_partition_plans.sql
+++ b/src/test/regress/sql/bfv_partition_plans.sql
@@ -40,6 +40,20 @@ return result
 $$
 language plpython3u;
 
+create or replace function get_executor_mem(query text) returns int as
+$$
+import re
+rv = plpy.execute('EXPLAIN ANALYZE '+ query)
+comp_regex = re.compile("Executor memory: (\d+)K")
+mem = 0
+for i in range(len(rv)):
+    cur_line = rv[i]['QUERY PLAN']
+    m = comp_regex.search(cur_line)
+    if m is not None:
+        mem = mem + int(m.group(1))
+return mem
+$$
+language plpython3u;
 
 -- Test UPDATE that moves row from one partition to another. The partitioning
 -- key is also the distribution key in this case.
@@ -582,6 +596,42 @@ select count_operator('delete from mpp6247_foo using mpp6247_bar where mpp6247_f
 
 drop table mpp6247_bar;
 drop table mpp6247_foo;
+
+-- Test executor memory consumption for high partitioned column oriented tables
+drop table if exists aocs_part1;
+drop table if exists aocs_part2;
+create table aocs_part1 (i0 int, i1 int, i2 int, i3 int, i4 int, i5 int, i6 int, i7 int, i8 int, i9 int)
+with (appendonly=true, orientation=column) distributed by (i0)
+partition by range (i0) (start (0) end(1) every (1));
+create table aocs_part2 (i0 int, i1 int, i2 int, i3 int, i4 int, i5 int, i6 int, i7 int, i8 int, i9 int)
+with (appendonly=true, orientation=column) distributed by (i0)
+partition by range (i0) (start (0) end(50) every (1));
+-- For ORCA, this queries use Dynamic Seq Scan over the different number
+-- of partitions (1 and 50). Before, second query executor consumed high amount
+-- of memory (51126K). From now, it should consume far less memory (3035K),
+-- even less than 5x memory consumption of first query (1339K).
+-- As it's true for ORCA only, we analyze only ORCA's result.
+with vals as(
+  select
+  get_executor_mem('select i0, i1, i2, i3, i4, i5, i6, i7, i8, i9 
+  from (
+    select *,
+    row_number() over (partition by i0 order by i1) as seq
+    from aocs_part1
+  ) as p
+  where seq=1') as v1,
+  get_executor_mem('select i0, i1, i2, i3, i4, i5, i6, i7, i8, i9 
+  from (
+    select *,
+    row_number() over (partition by i0 order by i1) as seq
+    from aocs_part2
+  ) as p
+  where seq=1') as v2
+)
+select case when (select setting='off' from pg_settings where name = 'optimizer') then true
+    else (v2 < v1 * 5)
+    end as should_true
+from vals;
 
 -- CLEANUP
 -- start_ignore


### PR DESCRIPTION
The tables with high count of partitions can drain high amount of executor
memory for processing. This can be especially critical for column-oriented
tables, because we allocating a buffer (which is triple of block size) for each
column. Following the standard flow we free such buffers at executor end. But it
seems, we can safely free some structures, including this buffers, after
processing all slots in `*getnextslot()` access method.

Related to https://github.com/greenplum-db/gpdb/issues/13725