### PR TITLE
Support setting reloptions for partition tables

### DIFF
--- a/src/backend/access/common/reloptions.c
+++ b/src/backend/access/common/reloptions.c
@@ -1527,12 +1527,11 @@ heap_reloptions(char relkind, Datum reloptions, bool validate)
 										  RELOPT_KIND_HEAP);
 		case RELKIND_PARTITIONED_TABLE:
 			/*
-			 * GPDB_12_AFTER_MERGE_FIXME: should we accept AO-related options for
-			 * partitioned tables? A partitioned table has no data, but the options
-			 * might be inherited by partitions.
+			 * GPDB: we maintain reloptions for partition roots to support reloption
+			 * inheritance and hierarchy wide ALTER TABLE SET().
 			 */
 			return default_reloptions(reloptions, validate,
-									  RELOPT_KIND_PARTITIONED);
+									  RELOPT_KIND_HEAP);
 		default:
 			/* other relkinds are not supported */
 			return NULL;

--- a/src/test/regress/expected/alter_table_set.out
+++ b/src/test/regress/expected/alter_table_set.out
@@ -52,3 +52,238 @@ select count(*) > 0 as has_different_distribution from
  t
 (1 row)
 
+-- ALTER TABLE ... SET for partition tables
+CREATE TABLE part_relopt(a int, b int) WITH (fillfactor=90) PARTITION BY RANGE(a);
+CREATE TABLE part_relopt_1 partition OF part_relopt FOR VALUES FROM (1) to (100);
+CREATE TABLE part_relopt_2 partition OF part_relopt FOR VALUES FROM (100) to (200) PARTITION BY RANGE(a);
+CREATE TABLE part_relopt_2_1 partition OF part_relopt_2 FOR VALUES FROM (100) to (150);
+CREATE TABLE part_relopt_2_2 partition OF part_relopt_2 FOR VALUES FROM (150) to (200);
+INSERT INTO part_relopt SELECT i,i FROM generate_series(1,199) i;
+-- All tables inherit the same reloptions as the root.
+SELECT c.relname, c.reloptions FROM pg_class c WHERE c.relname LIKE 'part_relopt%';
+     relname     |   reloptions    
+-----------------+-----------------
+ part_relopt     | {fillfactor=90}
+ part_relopt_1   | {fillfactor=90}
+ part_relopt_2   | {fillfactor=90}
+ part_relopt_2_1 | {fillfactor=90}
+ part_relopt_2_2 | {fillfactor=90}
+(5 rows)
+
+-- Set reloptions of the root, all child including subpartitions should inherit them too.
+ALTER TABLE part_relopt SET (fillfactor=80);
+SELECT c.relname, c.reloptions FROM pg_class c WHERE c.relname LIKE 'part_relopt%';
+     relname     |   reloptions    
+-----------------+-----------------
+ part_relopt     | {fillfactor=80}
+ part_relopt_1   | {fillfactor=80}
+ part_relopt_2   | {fillfactor=80}
+ part_relopt_2_1 | {fillfactor=80}
+ part_relopt_2_2 | {fillfactor=80}
+(5 rows)
+
+-- Altering it again with the same reloptions. Nothing should change.
+ALTER TABLE part_relopt SET (fillfactor=80);
+SELECT c.relname, c.reloptions FROM pg_class c WHERE c.relname LIKE 'part_relopt%';
+     relname     |   reloptions    
+-----------------+-----------------
+ part_relopt     | {fillfactor=80}
+ part_relopt_1   | {fillfactor=80}
+ part_relopt_2   | {fillfactor=80}
+ part_relopt_2_1 | {fillfactor=80}
+ part_relopt_2_2 | {fillfactor=80}
+(5 rows)
+
+-- Altering a subpartition root, should apply and only apply to the subpartition root/child.
+ALTER TABLE part_relopt_2 SET (fillfactor=70);
+SELECT c.relname, c.reloptions FROM pg_class c WHERE c.relname LIKE 'part_relopt%';
+     relname     |   reloptions    
+-----------------+-----------------
+ part_relopt     | {fillfactor=80}
+ part_relopt_1   | {fillfactor=80}
+ part_relopt_2   | {fillfactor=70}
+ part_relopt_2_1 | {fillfactor=70}
+ part_relopt_2_2 | {fillfactor=70}
+(5 rows)
+
+-- Altering the partition root but with ONLY keyword. Should affect future child but not affect existing child.
+ALTER TABLE ONLY part_relopt SET (fillfactor=60);
+CREATE TABLE part_relopt_3 partition OF part_relopt FOR VALUES FROM (200) to (300);
+SELECT c.relname, c.reloptions FROM pg_class c WHERE c.relname LIKE 'part_relopt%';
+     relname     |   reloptions    
+-----------------+-----------------
+ part_relopt     | {fillfactor=60}
+ part_relopt_1   | {fillfactor=80}
+ part_relopt_2   | {fillfactor=70}
+ part_relopt_2_1 | {fillfactor=70}
+ part_relopt_2_2 | {fillfactor=70}
+ part_relopt_3   | {fillfactor=60}
+(6 rows)
+
+-- Altering one child partition, should only affect that child.
+ALTER TABLE part_relopt_1 SET (fillfactor=50);
+SELECT c.relname, c.reloptions FROM pg_class c WHERE c.relname LIKE 'part_relopt%';
+     relname     |   reloptions    
+-----------------+-----------------
+ part_relopt     | {fillfactor=60}
+ part_relopt_1   | {fillfactor=50}
+ part_relopt_2   | {fillfactor=70}
+ part_relopt_2_1 | {fillfactor=70}
+ part_relopt_2_2 | {fillfactor=70}
+ part_relopt_3   | {fillfactor=60}
+(6 rows)
+
+-- RESET one subpartition, then the entire hierarchy
+ALTER TABLE part_relopt_2 RESET(fillfactor);
+SELECT c.relname, c.reloptions FROM pg_class c WHERE c.relname LIKE 'part_relopt%';
+     relname     |   reloptions    
+-----------------+-----------------
+ part_relopt     | {fillfactor=60}
+ part_relopt_1   | {fillfactor=50}
+ part_relopt_2   | 
+ part_relopt_2_1 | 
+ part_relopt_2_2 | 
+ part_relopt_3   | {fillfactor=60}
+(6 rows)
+
+ALTER TABLE part_relopt RESET(fillfactor);
+SELECT c.relname, c.reloptions FROM pg_class c WHERE c.relname LIKE 'part_relopt%';
+     relname     | reloptions 
+-----------------+------------
+ part_relopt     | 
+ part_relopt_1   | 
+ part_relopt_2   | 
+ part_relopt_2_1 | 
+ part_relopt_2_2 | 
+ part_relopt_3   | 
+(6 rows)
+
+-- Check setting reloptions for AO and AOCO tables too.
+-- Also, for these tables we check pg_appendonly and pg_attribute_encoding too.
+-- AO table:
+ALTER TABLE part_relopt SET ACCESS METHOD ao_row WITH (compresstype=zlib, compresslevel=5);
+SELECT c.relname, c.reloptions, a.blocksize, a.compresslevel FROM pg_class c LEFT JOIN pg_appendonly a ON a.relid = c.oid WHERE c.relname LIKE 'part_relopt%';
+     relname     |             reloptions              | blocksize | compresslevel 
+-----------------+-------------------------------------+-----------+---------------
+ part_relopt     | {compresstype=zlib,compresslevel=5} |           |              
+ part_relopt_1   | {compresstype=zlib,compresslevel=5} |     32768 |             5
+ part_relopt_2   | {compresstype=zlib,compresslevel=5} |           |              
+ part_relopt_2_1 | {compresstype=zlib,compresslevel=5} |     32768 |             5
+ part_relopt_2_2 | {compresstype=zlib,compresslevel=5} |     32768 |             5
+ part_relopt_3   | {compresstype=zlib,compresslevel=5} |     32768 |             5
+(6 rows)
+
+ALTER TABLE part_relopt SET (compresslevel=7);
+SELECT c.relname, c.reloptions, a.blocksize, a.compresslevel FROM pg_class c LEFT JOIN pg_appendonly a ON a.relid = c.oid WHERE c.relname LIKE 'part_relopt%';
+     relname     |             reloptions              | blocksize | compresslevel 
+-----------------+-------------------------------------+-----------+---------------
+ part_relopt     | {compresstype=zlib,compresslevel=7} |           |              
+ part_relopt_1   | {compresstype=zlib,compresslevel=7} |     32768 |             7
+ part_relopt_2   | {compresstype=zlib,compresslevel=7} |           |              
+ part_relopt_2_1 | {compresstype=zlib,compresslevel=7} |     32768 |             7
+ part_relopt_2_2 | {compresstype=zlib,compresslevel=7} |     32768 |             7
+ part_relopt_3   | {compresstype=zlib,compresslevel=7} |     32768 |             7
+(6 rows)
+
+--AOCO table:
+ALTER TABLE part_relopt SET ACCESS METHOD ao_column WITH (compresstype=rle_type, compresslevel=1);
+SELECT c.relname, c.reloptions, a.blocksize, a.compresslevel FROM pg_class c LEFT JOIN pg_appendonly a ON a.relid = c.oid WHERE c.relname LIKE 'part_relopt%';
+     relname     |               reloptions                | blocksize | compresslevel 
+-----------------+-----------------------------------------+-----------+---------------
+ part_relopt     | {compresstype=rle_type,compresslevel=1} |           |              
+ part_relopt_1   | {compresstype=rle_type,compresslevel=1} |     32768 |             1
+ part_relopt_2   | {compresstype=rle_type,compresslevel=1} |           |              
+ part_relopt_2_1 | {compresstype=rle_type,compresslevel=1} |     32768 |             1
+ part_relopt_2_2 | {compresstype=rle_type,compresslevel=1} |     32768 |             1
+ part_relopt_3   | {compresstype=rle_type,compresslevel=1} |     32768 |             1
+(6 rows)
+
+SELECT c.relname, a.attnum, a.attoptions FROM pg_attribute_encoding a, pg_class c WHERE a.attrelid = c.oid AND c.relname LIKE 'part_relopt%';
+     relname     | attnum |                       attoptions                        
+-----------------+--------+---------------------------------------------------------
+ part_relopt_1   |      1 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ part_relopt_1   |      2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ part_relopt_2_1 |      1 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ part_relopt_2_1 |      2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ part_relopt_2_2 |      1 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ part_relopt_2_2 |      2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ part_relopt_3   |      1 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ part_relopt_3   |      2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+(8 rows)
+
+ALTER TABLE part_relopt SET (compresslevel=3);
+SELECT c.relname, c.reloptions, a.blocksize, a.compresslevel FROM pg_class c LEFT JOIN pg_appendonly a ON a.relid = c.oid WHERE c.relname LIKE 'part_relopt%';
+     relname     |               reloptions                | blocksize | compresslevel 
+-----------------+-----------------------------------------+-----------+---------------
+ part_relopt     | {compresstype=rle_type,compresslevel=3} |           |              
+ part_relopt_1   | {compresstype=rle_type,compresslevel=3} |     32768 |             3
+ part_relopt_2   | {compresstype=rle_type,compresslevel=3} |           |              
+ part_relopt_2_1 | {compresstype=rle_type,compresslevel=3} |     32768 |             3
+ part_relopt_2_2 | {compresstype=rle_type,compresslevel=3} |     32768 |             3
+ part_relopt_3   | {compresstype=rle_type,compresslevel=3} |     32768 |             3
+(6 rows)
+
+SELECT c.relname, a.attnum, a.attoptions FROM pg_attribute_encoding a, pg_class c WHERE a.attrelid = c.oid AND c.relname LIKE 'part_relopt%';
+     relname     | attnum |                       attoptions                        
+-----------------+--------+---------------------------------------------------------
+ part_relopt_1   |      1 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ part_relopt_1   |      2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ part_relopt_2_1 |      1 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ part_relopt_2_1 |      2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ part_relopt_2_2 |      1 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ part_relopt_2_2 |      2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ part_relopt_3   |      1 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ part_relopt_3   |      2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+(8 rows)
+
+-- Check mixed AMs in the partition hierarchy. Currently we error out.
+CREATE TABLE part_relopt2(a int, b int) PARTITION BY RANGE(a);
+CREATE TABLE part_1 partition OF part_relopt2 FOR VALUES FROM (100) to (200);
+CREATE TABLE part_2 partition OF part_relopt2 FOR VALUES FROM (200) to (300) PARTITION BY RANGE (a);
+CREATE TABLE part_2_1 partition OF part_2 FOR VALUES FROM (200) to (250);
+-- error out because of the first child
+ALTER TABLE part_1 SET ACCESS METHOD ao_row;
+ALTER TABLE part_relopt2 SET (fillfactor=70);
+ERROR:  cannot alter reloptions for "part_relopt2" because one of the child tables "part_1" has different access method
+HINT:  Alter tables individually or change the child's AM to be same as parent.
+-- check subpartition too: error out because of the subpartition child
+ALTER TABLE part_1 SET ACCESS METHOD heap;
+ALTER TABLE part_2_1 SET ACCESS METHOD ao_row;
+ALTER TABLE part_relopt2 SET (fillfactor=70);
+ERROR:  cannot alter reloptions for "part_relopt2" because one of the child tables "part_2_1" has different access method
+HINT:  Alter tables individually or change the child's AM to be same as parent.
+-- SET individual child, and check if RESET works. 
+ALTER TABLE part_1 SET (fillfactor=70);
+ALTER TABLE part_2_1 SET (blocksize=65536);
+SELECT c.relname, c.reloptions FROM pg_class c WHERE c.relname = 'part_1' OR c.relname = 'part_2_1';
+ relname  |    reloptions     
+----------+-------------------
+ part_1   | {fillfactor=70}
+ part_2_1 | {blocksize=65536}
+(2 rows)
+
+ALTER TABLE part_relopt2 RESET(fillfactor);
+SELECT c.relname, c.reloptions FROM pg_class c WHERE c.relname = 'part_1' OR c.relname = 'part_2_1';
+ relname  |    reloptions     
+----------+-------------------
+ part_1   | 
+ part_2_1 | {blocksize=65536}
+(2 rows)
+
+ALTER TABLE part_relopt2 RESET(blocksize);
+SELECT c.relname, c.reloptions FROM pg_class c WHERE c.relname = 'part_1' OR c.relname = 'part_2_1';
+ relname  | reloptions 
+----------+------------
+ part_1   | 
+ part_2_1 | 
+(2 rows)
+
+-- Data is intact
+SELECT count(*) FROM part_relopt;
+ count 
+-------
+   199
+(1 row)
+
+DROP TABLE part_relopt;
+DROP TABLE part_relopt2;

--- a/src/test/regress/expected/alter_table_set_am.out
+++ b/src/test/regress/expected/alter_table_set_am.out
@@ -1394,9 +1394,9 @@ SELECT c.relname, a.amname, c.reloptions FROM pg_class c JOIN pg_am a ON c.relam
  atsetam_part_1   | heap   | 
  atsetam_part_2   | heap   | 
  atsetam_part_2_1 | heap   | 
- atsetam_part_3   | ao_row | {blocksize=65536,compresslevel=5}
- atsetam_part_4   | ao_row | {blocksize=65536,compresslevel=5}
- atsetam_part_4_1 | ao_row | {blocksize=65536,compresslevel=5}
+ atsetam_part_3   | ao_row | {blocksize=65536,compresslevel=7}
+ atsetam_part_4   | ao_row | {blocksize=65536,compresslevel=7}
+ atsetam_part_4_1 | ao_row | {blocksize=65536,compresslevel=7}
 (7 rows)
 
 DROP TABLE atsetam_part;

--- a/src/test/regress/expected/partition_locking.out
+++ b/src/test/regress/expected/partition_locking.out
@@ -78,6 +78,7 @@ select * from locktest_master where coalesce not like 'gp_%' and coalesce not li
      coalesce      |        mode         | locktype |  node  
 -------------------+---------------------+----------+--------
  partlockt         | AccessExclusiveLock | relation | master
+ partlockt         | AccessShareLock     | relation | master
  partlockt_1_prt_1 | AccessExclusiveLock | relation | master
  partlockt_1_prt_2 | AccessExclusiveLock | relation | master
  partlockt_1_prt_3 | AccessExclusiveLock | relation | master
@@ -105,12 +106,13 @@ select * from locktest_master where coalesce not like 'gp_%' and coalesce not li
  toast table       | ShareLock           | relation | master
  toast table       | ShareLock           | relation | master
  toast table       | ShareLock           | relation | master
-(28 rows)
+(29 rows)
 
 select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
      coalesce      |        mode         | locktype |    node    
 -------------------+---------------------+----------+------------
  partlockt         | AccessExclusiveLock | relation | n segments
+ partlockt         | AccessShareLock     | relation | n segments
  partlockt_1_prt_1 | AccessExclusiveLock | relation | n segments
  partlockt_1_prt_2 | AccessExclusiveLock | relation | n segments
  partlockt_1_prt_3 | AccessExclusiveLock | relation | n segments
@@ -138,7 +140,7 @@ select * from locktest_segments where coalesce not like 'gp_%' and coalesce not 
  toast index       | AccessExclusiveLock | relation | n segments
  toast table       | ShareLock           | relation | n segments
  toast index       | AccessExclusiveLock | relation | n segments
-(28 rows)
+(29 rows)
 
 commit;
 -- drop
@@ -224,6 +226,7 @@ select * from locktest_master where coalesce not like 'gp_%' and coalesce not li
      coalesce      |        mode         | locktype |  node  
 -------------------+---------------------+----------+--------
  partlockt         | AccessExclusiveLock | relation | master
+ partlockt         | AccessShareLock     | relation | master
  partlockt_1_prt_1 | AccessExclusiveLock | relation | master
  partlockt_1_prt_2 | AccessExclusiveLock | relation | master
  partlockt_1_prt_3 | AccessExclusiveLock | relation | master
@@ -233,12 +236,13 @@ select * from locktest_master where coalesce not like 'gp_%' and coalesce not li
  toast table       | ShareLock           | relation | master
  toast table       | ShareLock           | relation | master
  toast table       | ShareLock           | relation | master
-(10 rows)
+(11 rows)
 
 select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
      coalesce      |        mode         | locktype |    node    
 -------------------+---------------------+----------+------------
  partlockt         | AccessExclusiveLock | relation | n segments
+ partlockt         | AccessShareLock     | relation | n segments
  partlockt_1_prt_1 | AccessExclusiveLock | relation | n segments
  partlockt_1_prt_2 | AccessExclusiveLock | relation | n segments
  partlockt_1_prt_3 | AccessExclusiveLock | relation | n segments
@@ -248,7 +252,7 @@ select * from locktest_segments where coalesce not like 'gp_%' and coalesce not 
  toast index       | AccessExclusiveLock | relation | n segments
  toast table       | ShareLock           | relation | n segments
  toast index       | AccessExclusiveLock | relation | n segments
-(10 rows)
+(11 rows)
 
 commit;
 begin;

--- a/src/test/regress/expected/partition_locking_optimizer.out
+++ b/src/test/regress/expected/partition_locking_optimizer.out
@@ -78,6 +78,7 @@ select * from locktest_master where coalesce not like 'gp_%' and coalesce not li
      coalesce      |        mode         | locktype |  node  
 -------------------+---------------------+----------+--------
  partlockt         | AccessExclusiveLock | relation | master
+ partlockt         | AccessShareLock     | relation | master
  partlockt_1_prt_1 | AccessExclusiveLock | relation | master
  partlockt_1_prt_2 | AccessExclusiveLock | relation | master
  partlockt_1_prt_3 | AccessExclusiveLock | relation | master
@@ -105,12 +106,13 @@ select * from locktest_master where coalesce not like 'gp_%' and coalesce not li
  toast table       | ShareLock           | relation | master
  toast table       | ShareLock           | relation | master
  toast table       | ShareLock           | relation | master
-(28 rows)
+(29 rows)
 
 select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
      coalesce      |        mode         | locktype |    node    
 -------------------+---------------------+----------+------------
  partlockt         | AccessExclusiveLock | relation | n segments
+ partlockt         | AccessShareLock     | relation | n segments
  partlockt_1_prt_1 | AccessExclusiveLock | relation | n segments
  partlockt_1_prt_2 | AccessExclusiveLock | relation | n segments
  partlockt_1_prt_3 | AccessExclusiveLock | relation | n segments
@@ -138,7 +140,7 @@ select * from locktest_segments where coalesce not like 'gp_%' and coalesce not 
  toast index       | AccessExclusiveLock | relation | n segments
  toast table       | ShareLock           | relation | n segments
  toast index       | AccessExclusiveLock | relation | n segments
-(28 rows)
+(29 rows)
 
 commit;
 -- drop
@@ -224,6 +226,7 @@ select * from locktest_master where coalesce not like 'gp_%' and coalesce not li
      coalesce      |        mode         | locktype |  node  
 -------------------+---------------------+----------+--------
  partlockt         | AccessExclusiveLock | relation | master
+ partlockt         | AccessShareLock     | relation | master
  partlockt_1_prt_1 | AccessExclusiveLock | relation | master
  partlockt_1_prt_2 | AccessExclusiveLock | relation | master
  partlockt_1_prt_3 | AccessExclusiveLock | relation | master
@@ -233,12 +236,13 @@ select * from locktest_master where coalesce not like 'gp_%' and coalesce not li
  toast table       | ShareLock           | relation | master
  toast table       | ShareLock           | relation | master
  toast table       | ShareLock           | relation | master
-(10 rows)
+(11 rows)
 
 select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
      coalesce      |        mode         | locktype |    node    
 -------------------+---------------------+----------+------------
  partlockt         | AccessExclusiveLock | relation | n segments
+ partlockt         | AccessShareLock     | relation | n segments
  partlockt_1_prt_1 | AccessExclusiveLock | relation | n segments
  partlockt_1_prt_2 | AccessExclusiveLock | relation | n segments
  partlockt_1_prt_3 | AccessExclusiveLock | relation | n segments
@@ -248,7 +252,7 @@ select * from locktest_segments where coalesce not like 'gp_%' and coalesce not 
  toast index       | AccessExclusiveLock | relation | n segments
  toast table       | ShareLock           | relation | n segments
  toast index       | AccessExclusiveLock | relation | n segments
-(10 rows)
+(11 rows)
 
 commit;
 begin;

--- a/src/test/regress/sql/alter_table_set.sql
+++ b/src/test/regress/sql/alter_table_set.sql
@@ -37,3 +37,83 @@ select count(*) > 0 as has_different_distribution from
 select count(*) > 0 as has_different_distribution from
 (select gp_segment_id, * from ats_dist_by_d except
 	select gp_segment_id, * from ats_expected_by_d) t;
+
+-- ALTER TABLE ... SET for partition tables
+CREATE TABLE part_relopt(a int, b int) WITH (fillfactor=90) PARTITION BY RANGE(a);
+CREATE TABLE part_relopt_1 partition OF part_relopt FOR VALUES FROM (1) to (100);
+CREATE TABLE part_relopt_2 partition OF part_relopt FOR VALUES FROM (100) to (200) PARTITION BY RANGE(a);
+CREATE TABLE part_relopt_2_1 partition OF part_relopt_2 FOR VALUES FROM (100) to (150);
+CREATE TABLE part_relopt_2_2 partition OF part_relopt_2 FOR VALUES FROM (150) to (200);
+INSERT INTO part_relopt SELECT i,i FROM generate_series(1,199) i;
+
+-- All tables inherit the same reloptions as the root.
+SELECT c.relname, c.reloptions FROM pg_class c WHERE c.relname LIKE 'part_relopt%';
+
+-- Set reloptions of the root, all child including subpartitions should inherit them too.
+ALTER TABLE part_relopt SET (fillfactor=80);
+SELECT c.relname, c.reloptions FROM pg_class c WHERE c.relname LIKE 'part_relopt%';
+
+-- Altering it again with the same reloptions. Nothing should change.
+ALTER TABLE part_relopt SET (fillfactor=80);
+SELECT c.relname, c.reloptions FROM pg_class c WHERE c.relname LIKE 'part_relopt%';
+
+-- Altering a subpartition root, should apply and only apply to the subpartition root/child.
+ALTER TABLE part_relopt_2 SET (fillfactor=70);
+SELECT c.relname, c.reloptions FROM pg_class c WHERE c.relname LIKE 'part_relopt%';
+
+-- Altering the partition root but with ONLY keyword. Should affect future child but not affect existing child.
+ALTER TABLE ONLY part_relopt SET (fillfactor=60);
+CREATE TABLE part_relopt_3 partition OF part_relopt FOR VALUES FROM (200) to (300);
+SELECT c.relname, c.reloptions FROM pg_class c WHERE c.relname LIKE 'part_relopt%';
+
+-- Altering one child partition, should only affect that child.
+ALTER TABLE part_relopt_1 SET (fillfactor=50);
+SELECT c.relname, c.reloptions FROM pg_class c WHERE c.relname LIKE 'part_relopt%';
+
+-- RESET one subpartition, then the entire hierarchy
+ALTER TABLE part_relopt_2 RESET(fillfactor);
+SELECT c.relname, c.reloptions FROM pg_class c WHERE c.relname LIKE 'part_relopt%';
+ALTER TABLE part_relopt RESET(fillfactor);
+SELECT c.relname, c.reloptions FROM pg_class c WHERE c.relname LIKE 'part_relopt%';
+
+-- Check setting reloptions for AO and AOCO tables too.
+-- Also, for these tables we check pg_appendonly and pg_attribute_encoding too.
+-- AO table:
+ALTER TABLE part_relopt SET ACCESS METHOD ao_row WITH (compresstype=zlib, compresslevel=5);
+SELECT c.relname, c.reloptions, a.blocksize, a.compresslevel FROM pg_class c LEFT JOIN pg_appendonly a ON a.relid = c.oid WHERE c.relname LIKE 'part_relopt%';
+ALTER TABLE part_relopt SET (compresslevel=7);
+SELECT c.relname, c.reloptions, a.blocksize, a.compresslevel FROM pg_class c LEFT JOIN pg_appendonly a ON a.relid = c.oid WHERE c.relname LIKE 'part_relopt%';
+--AOCO table:
+ALTER TABLE part_relopt SET ACCESS METHOD ao_column WITH (compresstype=rle_type, compresslevel=1);
+SELECT c.relname, c.reloptions, a.blocksize, a.compresslevel FROM pg_class c LEFT JOIN pg_appendonly a ON a.relid = c.oid WHERE c.relname LIKE 'part_relopt%';
+SELECT c.relname, a.attnum, a.attoptions FROM pg_attribute_encoding a, pg_class c WHERE a.attrelid = c.oid AND c.relname LIKE 'part_relopt%';
+ALTER TABLE part_relopt SET (compresslevel=3);
+SELECT c.relname, c.reloptions, a.blocksize, a.compresslevel FROM pg_class c LEFT JOIN pg_appendonly a ON a.relid = c.oid WHERE c.relname LIKE 'part_relopt%';
+SELECT c.relname, a.attnum, a.attoptions FROM pg_attribute_encoding a, pg_class c WHERE a.attrelid = c.oid AND c.relname LIKE 'part_relopt%';
+
+-- Check mixed AMs in the partition hierarchy. Currently we error out.
+CREATE TABLE part_relopt2(a int, b int) PARTITION BY RANGE(a);
+CREATE TABLE part_1 partition OF part_relopt2 FOR VALUES FROM (100) to (200);
+CREATE TABLE part_2 partition OF part_relopt2 FOR VALUES FROM (200) to (300) PARTITION BY RANGE (a);
+CREATE TABLE part_2_1 partition OF part_2 FOR VALUES FROM (200) to (250);
+-- error out because of the first child
+ALTER TABLE part_1 SET ACCESS METHOD ao_row;
+ALTER TABLE part_relopt2 SET (fillfactor=70);
+-- check subpartition too: error out because of the subpartition child
+ALTER TABLE part_1 SET ACCESS METHOD heap;
+ALTER TABLE part_2_1 SET ACCESS METHOD ao_row;
+ALTER TABLE part_relopt2 SET (fillfactor=70);
+-- SET individual child, and check if RESET works. 
+ALTER TABLE part_1 SET (fillfactor=70);
+ALTER TABLE part_2_1 SET (blocksize=65536);
+SELECT c.relname, c.reloptions FROM pg_class c WHERE c.relname = 'part_1' OR c.relname = 'part_2_1';
+ALTER TABLE part_relopt2 RESET(fillfactor);
+SELECT c.relname, c.reloptions FROM pg_class c WHERE c.relname = 'part_1' OR c.relname = 'part_2_1';
+ALTER TABLE part_relopt2 RESET(blocksize);
+SELECT c.relname, c.reloptions FROM pg_class c WHERE c.relname = 'part_1' OR c.relname = 'part_2_1';
+
+-- Data is intact
+SELECT count(*) FROM part_relopt;
+
+DROP TABLE part_relopt;
+DROP TABLE part_relopt2;


### PR DESCRIPTION
Code ready to review. ~But the test cases that involved changing AM won't pass until https://github.com/greenplum-db/gpdb/pull/13897 is merged.~ (merged now)

-----------------------

Users can now use ALTER TABLE ... SET to set reloptions for root partition tables. E.g.:

```
ALTER TABLE part SET (fillfactor=70);
```

Similar to SET ACCESS METHOD, the reloptions being set for the root partition will be inherited by their existing child partitions and recursed into their children as well.

Also similarly, if user uses the "ONLY" keyword, e.g.:

```
ALTER TABLE ONLY part SET (fillfactor=70);
```

Then the reloptions will only apply to the root and its future child tables.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
