### PR TITLE
[6X] DatumStream teardown: NULL out after pfree

### DIFF
--- a/src/backend/access/aocs/aocsam.c
+++ b/src/backend/access/aocs/aocsam.c
@@ -2028,6 +2028,7 @@ aocs_addcol_finish(AOCSAddColumnDesc desc)
 	for (i = 0; i < desc->num_newcols; ++i)
 		destroy_datumstreamwrite(desc->dsw[i]);
 	pfree(desc->dsw);
+	desc->dsw = NULL;
 
 	pfree(desc);
 }

--- a/src/backend/access/aocs/aocsam.c
+++ b/src/backend/access/aocs/aocsam.c
@@ -528,7 +528,9 @@ aocs_endscan(AOCSScanDesc scan)
 	close_ds_read(scan->ds, scan->relationTupleDesc->natts);
 
 	pfree(scan->proj_atts);
+	scan->proj_atts = NULL;
 	pfree(scan->ds);
+	scan->ds = NULL;
 
 	for (i = 0; i < scan->total_seg; ++i)
 	{
@@ -539,7 +541,10 @@ aocs_endscan(AOCSScanDesc scan)
 		}
 	}
 	if (scan->seginfo)
+	{
 		pfree(scan->seginfo);
+		scan->seginfo = NULL;
+	}
 
 	AppendOnlyVisimap_Finish(&scan->visibilityMap, AccessShareLock);
 
@@ -1530,7 +1535,9 @@ aocs_fetch_finish(AOCSFetchDesc aocsFetchDesc)
 			Assert(datumStreamFetchDesc->datumStream != NULL);
 			datumstreamread_close_file(datumStreamFetchDesc->datumStream);
 			destroy_datumstreamread(datumStreamFetchDesc->datumStream);
+			datumStreamFetchDesc->datumStream = NULL;
 			pfree(datumStreamFetchDesc);
+			aocsFetchDesc->datumStreamFetchDesc[colno] = NULL;
 		}
 	}
 	pfree(aocsFetchDesc->datumStreamFetchDesc);

--- a/src/backend/catalog/pg_compression.c
+++ b/src/backend/catalog/pg_compression.c
@@ -265,6 +265,7 @@ zlib_destructor(PG_FUNCTION_ARGS)
 	if (cs != NULL && cs->opaque != NULL)
  	{
 		pfree(cs->opaque);
+		cs->opaque = NULL;
 	}
 
 	PG_RETURN_VOID();

--- a/src/backend/cdb/cdbappendonlystoragewrite.c
+++ b/src/backend/cdb/cdbappendonlystoragewrite.c
@@ -226,11 +226,13 @@ AppendOnlyStorageWrite_FinishSession(AppendOnlyStorageWrite *storageWrite)
 		if (storageWrite->compressionState != NULL)
 		{
 			pfree(storageWrite->compressionState);
+			storageWrite->compressionState = NULL;
 		}
 
 		if (storageWrite->verifyWriteCompressionState != NULL)
 		{
 			callCompressionDestructor(storageWrite->compression_functions[COMPRESSION_DESTRUCTOR], storageWrite->verifyWriteCompressionState);
+			storageWrite->verifyWriteCompressionState = NULL;
 		}
 	}
 

--- a/src/backend/utils/datumstream/datumstream.c
+++ b/src/backend/utils/datumstream/datumstream.c
@@ -764,6 +764,7 @@ destroy_datumstreamwrite(DatumStreamWrite * ds)
 	if (ds->title)
 	{
 		pfree(ds->title);
+		ds->title = NULL;
 	}
 	pfree(ds);
 }

--- a/src/backend/utils/datumstream/datumstream.c
+++ b/src/backend/utils/datumstream/datumstream.c
@@ -775,9 +775,15 @@ destroy_datumstreamread(DatumStreamRead * ds)
 	DatumStreamBlockRead_Finish(&ds->blockRead);
 
 	if (ds->large_object_buffer)
+	{
 		pfree(ds->large_object_buffer);
+		ds->large_object_buffer = NULL;
+	}
 	if (ds->datum_upgrade_buffer)
+	{
 		pfree(ds->datum_upgrade_buffer);
+		ds->datum_upgrade_buffer = NULL;
+	}
 
 	AppendOnlyStorageRead_FinishSession(&ds->ao_read);
 

--- a/src/backend/utils/datumstream/datumstreamblock.c
+++ b/src/backend/utils/datumstream/datumstreamblock.c
@@ -4440,25 +4440,45 @@ DatumStreamBlockWrite_Finish(
 
 	oldCtxt = MemoryContextSwitchTo(dsw->memctxt);
 	if (dsw->null_bitmap_buffer != NULL)
+	{
 		pfree(dsw->null_bitmap_buffer);
+		dsw->null_bitmap_buffer = NULL;
+	}
 
-	if (dsw->datum_buffer != NULL)
+	if (dsw->datum_buffer != NULL) {
 		pfree(dsw->datum_buffer);
+		dsw->datum_buffer = NULL;
+	}
 
 	if (dsw->rle_compress_bitmap_buffer != NULL)
+	{
 		pfree(dsw->rle_compress_bitmap_buffer);
+		dsw->rle_compress_bitmap_buffer = NULL;
+	}
 
 	if (dsw->rle_repeatcounts != NULL)
+	{
 		pfree(dsw->rle_repeatcounts);
+		dsw->rle_repeatcounts = NULL;
+	}
 
 	if (dsw->delta_bitmap_buffer != NULL)
+	{
 		pfree(dsw->delta_bitmap_buffer);
+		dsw->delta_bitmap_buffer = NULL;
+	}
 
 	if (dsw->deltas != NULL)
+	{
 		pfree(dsw->deltas);
+		dsw->deltas = NULL;
+	}
 
 	if (dsw->delta_sign != NULL)
+	{
 		pfree(dsw->delta_sign);
+		dsw->delta_sign = NULL;
+	}
 
 	MemoryContextSwitchTo(oldCtxt);
 }

--- a/src/backend/utils/datumstream/datumstreamblock.c
+++ b/src/backend/utils/datumstream/datumstreamblock.c
@@ -4445,7 +4445,8 @@ DatumStreamBlockWrite_Finish(
 		dsw->null_bitmap_buffer = NULL;
 	}
 
-	if (dsw->datum_buffer != NULL) {
+	if (dsw->datum_buffer != NULL)
+	{
 		pfree(dsw->datum_buffer);
 		dsw->datum_buffer = NULL;
 	}


### PR DESCRIPTION
Backport of #13988. Please see individual commits for details.