### PR TITLE
(6x backport) Eliminate alien nodes before execution for entry db

### DIFF
--- a/src/backend/cdb/dispatcher/cdbdisp_query.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_query.c
@@ -1542,5 +1542,15 @@ formIdleSegmentIdList(void)
 		}
 	}
 
+	if (cdbs->entry_db_info != NULL)
+	{
+		for (i = 0; i < cdbs->total_entry_dbs; i++)
+		{
+			CdbComponentDatabaseInfo *cdi = &cdbs->entry_db_info[i];
+			for (j = 0; j < cdi->numIdleQEs; j++)
+				segments = lappend_int(segments, cdi->config->segindex);
+		}
+	}
+
 	return segments;
 }

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -609,7 +609,7 @@ standard_ExecutorStart(QueryDesc *queryDesc, int eflags)
 	 *
 	 * TODO: eliminate aliens even on master, if not EXPLAIN ANALYZE
 	 */
-	estate->eliminateAliens = execute_pruned_plan && queryDesc->plannedstmt->nMotionNodes > 0 && !IS_QUERY_DISPATCHER();
+	estate->eliminateAliens = execute_pruned_plan && queryDesc->plannedstmt->nMotionNodes > 0 && (Gp_role == GP_ROLE_EXECUTE);
 
 	/*
 	 * Assign a Motion Node to every Plan Node. This makes it

--- a/src/backend/executor/execProcnode.c
+++ b/src/backend/executor/execProcnode.c
@@ -293,7 +293,7 @@ ExecInitNode(Plan *node, EState *estate, int eflags)
 	 * gathering stats from all slices.
 	 */
 	bool isAlienPlanNode = !((localMotionId == parentMotionId) || (parentMotionId == UNSET_SLICE_ID) ||
-							 (nodeTag(node) == T_Motion && ((Motion*)node)->motionID == localMotionId) || IS_QUERY_DISPATCHER());
+							 (nodeTag(node) == T_Motion && ((Motion*)node)->motionID == localMotionId)) && (Gp_role == GP_ROLE_EXECUTE);
 
 	/* We cannot have alien nodes if we are eliminating aliens */
 	AssertImply(estate->eliminateAliens, !isAlienPlanNode);

--- a/src/test/regress/expected/memconsumption.out
+++ b/src/test/regress/expected/memconsumption.out
@@ -6,41 +6,97 @@ set search_path to memconsumption;
 create table test (i int, j int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table t1 (a int, b int, c int) distributed by (a);
 set explain_memory_verbosity=detail;
 set execute_pruned_plan=on;
 insert into test select i, i % 100 from generate_series(1,1000) as i;
 -- start_ignore
 create language plpythonu;
 -- end_ignore
-create or replace function sum_owner_consumption(query text, owner text) returns int as
+create or replace function sum_owner_consumption(query text, owner text)
+returns table (slice text, mem_consumption int, is_entry_db boolean) as
 $$
 import re
 rv = plpy.execute('EXPLAIN ANALYZE '+ query)
 search_text = owner
 total_consumption = 0
-count = 0
+memory_consumption_per_slice = {}
 comp_regex = re.compile("[^0-9]+(\d+)\/(\d+).+")
+slice_regex = re.compile(".+\((slice\d+)")
+entry_db_regex = re.compile("\s+\((slice\d+)\).+\(entry db\)")
+entry_db_slices = set()
+after_planning_time = False
 for i in range(len(rv)):
     cur_line = rv[i]['QUERY PLAN']
+    if "Planning time" in cur_line:
+        # Summary begins here, look for entry db slice
+        after_planning_time = True
+    if after_planning_time:
+        m = entry_db_regex.match(cur_line)
+        if m is not None:
+            entry_db_slices.add(m.group(1))
+    else:
+        m = slice_regex.match(cur_line)
+        if m is not None:
+            current_slice = m.group(1)
+            slice_consumption = 0
+            memory_consumption_per_slice[current_slice] = 0
     if search_text.lower() in cur_line.lower():
         print search_text
         m = comp_regex.match(cur_line)
         if m is not None:
-            count = count + 1
+            memory_consumption_per_slice[current_slice] = memory_consumption_per_slice[current_slice] + int(m.group(2))
             total_consumption = total_consumption + int(m.group(2))
-return total_consumption
+
+return [
+        {
+            'slice': slice,
+            'mem_consumption': memory_consumption,
+            'is_entry_db': (slice in entry_db_slices)
+        } for slice, memory_consumption in  memory_consumption_per_slice.items()
+       ]
 $$
 language plpythonu;
-select sum_owner_consumption('SELECT t1.i, t2.j FROM test as t1 join test as t2 on t1.i = t2.j', 'X_Alien') = 0;
+select sum(mem_consumption) = 0 from sum_owner_consumption('SELECT t1.i, t2.j FROM test as t1 join test as t2 on t1.i = t2.j', 'X_Alien');
  ?column? 
 ----------
  t
 (1 row)
 
+-- Special handling for entry db: there is no entry db for legacy optimizer, so just return true.
+select
+case
+	when settings.is_orca
+	then query_result.check
+	else 'true'
+end result
+from
+(select sum(mem_consumption) = 0 as check from sum_owner_consumption('SELECT * FROM t1, (SELECT * FROM t1 LIMIT 1) a WHERE a.a = t1.a', 'X_Alien') where is_entry_db) query_result,
+(select setting='on' as is_orca from pg_settings where name = 'optimizer') settings;
+ result 
+--------
+ t
+(1 row)
+
 set execute_pruned_plan=off;
-select sum_owner_consumption('SELECT t1.i, t2.j FROM test as t1 join test as t2 on t1.i = t2.j', 'X_Alien') > 0;
+select sum(mem_consumption) > 0 from sum_owner_consumption('SELECT t1.i, t2.j FROM test as t1 join test as t2 on t1.i = t2.j', 'X_Alien');
  ?column? 
 ----------
+ t
+(1 row)
+
+-- Special handling for entry db: there is no entry db for legacy optimizer, so just return true.
+select
+case
+	when settings.is_orca
+	then query_result.check
+	else 'true'
+end result
+from
+(select sum(mem_consumption) > 0 as check from sum_owner_consumption('SELECT * FROM t1, (SELECT * FROM t1 LIMIT 1) a WHERE a.a = t1.a', 'X_Alien') where is_entry_db) query_result,
+(select setting='on' as is_orca from pg_settings where name = 'optimizer') settings;
+ result 
+--------
  t
 (1 row)
 
@@ -253,7 +309,7 @@ insert into bar_part select 1, 1 from generate_series(1,100000)i;
 insert into foo select 1, 1 from generate_series(1,80000)i;
 analyze foo;
 analyze bar_part;
-select sum_owner_consumption('select * from bar_part where exists (select 1 from foo where foo.b = bar_part.b and bar_part.b > 0);', 'X_PartitionSelector') between 1 and 1000000;
+select sum(mem_consumption) between 1 and 1000000 from sum_owner_consumption('select * from bar_part where exists (select 1 from foo where foo.b = bar_part.b and bar_part.b > 0);', 'X_PartitionSelector');
  ?column? 
 ----------
  t
@@ -272,14 +328,14 @@ select has_account_type('select simple_sql_function(i) from all_tuples_on_seg0',
 -- should be independent of the tuples. However, before the fix, it increased with
 -- more rows. Check the memory for X_PartitionSelector owner does not go above 1 MB.
 insert into foo select 1, 1 from generate_series(1,80000)i;
-select sum_owner_consumption('select * from bar_part where exists (select 1 from foo where foo.b = bar_part.b and bar_part.b > 0);', 'X_PartitionSelector') between 1 and 1000000;
+select sum(mem_consumption) between 1 and 1000000 from sum_owner_consumption('select * from bar_part where exists (select 1 from foo where foo.b = bar_part.b and bar_part.b > 0);', 'X_PartitionSelector');
  ?column? 
 ----------
  t
 (1 row)
 
 insert into foo select 1, 1 from generate_series(1,80000)i;
-select sum_owner_consumption('select * from bar_part where exists (select 1 from foo where foo.b = bar_part.b and bar_part.b > 0);', 'X_PartitionSelector') between 1 and 1000000;
+select sum(mem_consumption) between 1 and 1000000 from sum_owner_consumption('select * from bar_part where exists (select 1 from foo where foo.b = bar_part.b and bar_part.b > 0);', 'X_PartitionSelector');
  ?column? 
 ----------
  t


### PR DESCRIPTION
This is a https://github.com/greenplum-db/gpdb/pull/13857 backport from **master** branch that solves the following.

https://github.com/greenplum-db/gpdb/pull/2588  (commit 9b8f5c0) that eliminates alien nodes, but it lacks elimination
of alien nodes for entry db. This commit resolves this issue. Tests for alien nodes
elimination (added with https://github.com/greenplum-db/gpdb/pull/2663 commit b831ed6) are extended to support entry db too.
Also, this patch fixes dispatching of set command to already existing entry db gang in `formIdleSegmentIdList` function to propagate GUC change to **entry db** (e.g. `execute_pruned_plan` that was used in test).

The simple test to check alien nodes elimination:

```
create table t1 (a int, b int, c int) distributed by (a);
\pset pager off
set explain_memory_verbosity=detail;
set execute_pruned_plan to on;
explain analyze select * from t1, (select * from t1 limit 1) a where a.a = t1.a;
set execute_pruned_plan to off;
explain analyze select * from t1, (select * from t1 limit 1) a where a.a = t1.a;
```
With `execute_pruned_plan` GUC switched to `on` memory consumption for **X_Alien** nodes is 0, with `execute_pruned_plan` GUC switched to `off` memory consumption for **X_Alien** nodes exceeds 0.


## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
