### PR TITLE
Free underlying Dynamic Seq Scan structures after processing of each partition

### DIFF
--- a/src/backend/access/aocs/aocsam.c
+++ b/src/backend/access/aocs/aocsam.c
@@ -519,7 +519,18 @@ aocs_beginscan_internal(Relation relation,
 void
 aocs_afterscan(AOCSScanDesc scan)
 {
-	close_cur_scan_seg(scan);
+	int			nvp = scan->relationTupleDesc->natts;
+	int			i;
+
+	if (scan->cur_seg >= 0)
+	{
+		for (i = 0; i < nvp; ++i)
+		{
+			if (scan->ds[i])
+				datumstreamread_close_file(scan->ds[i]);
+		}
+	}
+
 	close_ds_read(scan->ds, scan->relationTupleDesc->natts);
 }
 

--- a/src/backend/access/aocs/aocsam.c
+++ b/src/backend/access/aocs/aocsam.c
@@ -509,11 +509,24 @@ aocs_beginscan_internal(Relation relation,
 	return scan;
 }
 
+/* ----------------
+ *		aocs_afterscan	- perform after scan actions
+ *
+ * Release some structures, which is safe to free after initial scan, but
+ * before rescan.
+ * ----------------
+ */
 void
-aocs_rescan(AOCSScanDesc scan)
+aocs_afterscan(AOCSScanDesc scan)
 {
 	close_cur_scan_seg(scan);
 	close_ds_read(scan->ds, scan->relationTupleDesc->natts);
+}
+
+void
+aocs_rescan(AOCSScanDesc scan)
+{
+	aocs_afterscan(scan);
 	aocs_initscan(scan);
 }
 

--- a/src/backend/executor/nodeDynamicSeqscan.c
+++ b/src/backend/executor/nodeDynamicSeqscan.c
@@ -313,9 +313,9 @@ CleanupOnePartition(DynamicSeqScanState *scanState)
 	{
 		if (sstate->ss_currentScanDesc_heap)
 			heap_afterscan(sstate->ss_currentScanDesc_heap);
-		if (sstate->ss_currentScanDesc_ao)
+		else if (sstate->ss_currentScanDesc_ao)
 			appendonly_afterscan(sstate->ss_currentScanDesc_ao);
-		if (sstate->ss_currentScanDesc_aocs)
+		else if (sstate->ss_currentScanDesc_aocs)
 			aocs_afterscan(sstate->ss_currentScanDesc_aocs);
 
 		/*

--- a/src/backend/executor/nodeDynamicSeqscan.c
+++ b/src/backend/executor/nodeDynamicSeqscan.c
@@ -32,6 +32,8 @@
 #include "cdb/cdbpartition.h"
 #include "cdb/cdbvars.h"
 #include "cdb/partitionselection.h"
+#include "cdb/cdbappendonlyam.h"
+#include "cdb/cdbaocsam.h"
 
 static void CleanupOnePartition(DynamicSeqScanState *node);
 
@@ -305,9 +307,17 @@ static void
 CleanupOnePartition(DynamicSeqScanState *scanState)
 {
 	Assert(NULL != scanState);
+	SeqScanState *sstate = scanState->seqScanState;
 
-	if (scanState->seqScanState)
+	if (sstate)
 	{
+		if (sstate->ss_currentScanDesc_heap)
+			heap_afterscan(sstate->ss_currentScanDesc_heap);
+		if (sstate->ss_currentScanDesc_ao)
+			appendonly_afterscan(sstate->ss_currentScanDesc_ao);
+		if (sstate->ss_currentScanDesc_aocs)
+			aocs_afterscan(sstate->ss_currentScanDesc_aocs);
+
 		/*
 		 * Since we use the cache hack, we cannot end the subscan
 		 * just set it to NULL and this will lead to the logic

--- a/src/include/access/heapam.h
+++ b/src/include/access/heapam.h
@@ -130,6 +130,7 @@ extern HeapScanDesc heap_beginscan_strat(Relation relation, Snapshot snapshot,
 					 bool allow_strat, bool allow_sync);
 extern HeapScanDesc heap_beginscan_bm(Relation relation, Snapshot snapshot,
 				  int nkeys, ScanKey key);
+extern void heap_afterscan(HeapScanDesc scan);
 extern void heap_rescan(HeapScanDesc scan, ScanKey key);
 extern void heap_endscan(HeapScanDesc scan);
 extern HeapTuple heap_getnext(HeapScanDesc scan, ScanDirection direction);

--- a/src/include/cdb/cdbaocsam.h
+++ b/src/include/cdb/cdbaocsam.h
@@ -208,6 +208,7 @@ extern AOCSScanDesc aocs_beginrangescan(Relation relation, Snapshot snapshot,
 		int *segfile_no_arr, int segfile_count,
 	TupleDesc relationTupleDesc, bool *proj);
 
+extern void aocs_afterscan(AOCSScanDesc scan);
 extern void aocs_rescan(AOCSScanDesc scan);
 extern void aocs_endscan(AOCSScanDesc scan);
 

--- a/src/include/cdb/cdbappendonlyam.h
+++ b/src/include/cdb/cdbappendonlyam.h
@@ -335,6 +335,7 @@ extern AppendOnlyScanDesc appendonly_beginrangescan(Relation relation,
 		Snapshot appendOnlyMetaDataSnapshot, 
 		int *segfile_no_arr, int segfile_count,
 		int nkeys, ScanKey keys);
+extern void appendonly_afterscan(AppendOnlyScanDesc scan);
 extern void appendonly_rescan(AppendOnlyScanDesc scan, ScanKey key);
 extern void appendonly_endscan(AppendOnlyScanDesc scan);
 extern bool appendonly_getnext(AppendOnlyScanDesc scan,

--- a/src/test/regress/expected/bfv_partition_plans.out
+++ b/src/test/regress/expected/bfv_partition_plans.out
@@ -32,6 +32,20 @@ for i in range(len(rv)):
 return result
 $$
 language plpythonu;
+create or replace function get_executor_mem(query text) returns int as
+$$
+import re
+rv = plpy.execute('EXPLAIN ANALYZE '+ query)
+comp_regex = re.compile("Executor memory: (\d+)K")
+mem = 0
+for i in range(len(rv)):
+    cur_line = rv[i]['QUERY PLAN']
+    m = comp_regex.search(cur_line)
+    if m is not None:
+        mem = mem + int(m.group(1))
+return mem
+$$
+language plpythonu;
 -- Test UPDATE that moves row from one partition to another. The partitioning
 -- key is also the distribution key in this case.
 create table mpp3061 (i int) partition by range(i) (start(1) end(5) every(1));
@@ -1548,6 +1562,45 @@ select count_operator('delete from mpp6247_foo using mpp6247_bar where mpp6247_f
 
 drop table mpp6247_bar;
 drop table mpp6247_foo;
+-- Test executor memory consumption for high partitioned column oriented tables
+drop table if exists aocs_part1;
+drop table if exists aocs_part2;
+create table aocs_part1 (i0 int, i1 int, i2 int, i3 int, i4 int, i5 int, i6 int, i7 int, i8 int, i9 int)
+with (appendonly=true, orientation=column) distributed by (i0)
+partition by range (i0) (start (0) end(1) every (1));
+create table aocs_part2 (i0 int, i1 int, i2 int, i3 int, i4 int, i5 int, i6 int, i7 int, i8 int, i9 int)
+with (appendonly=true, orientation=column) distributed by (i0)
+partition by range (i0) (start (0) end(50) every (1));
+-- For ORCA, this queries use Dynamic Seq Scan over the different number
+-- of partitions (1 and 50). Before, second query executor consumed high amount
+-- of memory (51126K). From now, it should consume far less memory (3035K),
+-- even less than 5x memory consumption of first query (1339K).
+-- As it's true for ORCA only, we use xor(#) to get final result.
+with vals as(
+  select
+  get_executor_mem('select i0, i1, i2, i3, i4, i5, i6, i7, i8, i9 
+  from (
+    select *,
+    row_number() over (partition by i0 order by i1) as seq
+    from aocs_part1
+  ) as p
+  where seq=1') as v1,
+  get_executor_mem('select i0, i1, i2, i3, i4, i5, i6, i7, i8, i9 
+  from (
+    select *,
+    row_number() over (partition by i0 order by i1) as seq
+    from aocs_part2
+  ) as p
+  where seq=1') as v2
+)
+select (select setting='off' from pg_settings where name = 'optimizer')::int::bit #
+    (v2 < v1 * 5)::int::bit as should_true
+from vals;
+ should_true 
+-------------
+ 1
+(1 row)
+
 -- CLEANUP
 -- start_ignore
 drop schema if exists bfv_partition_plans cascade;

--- a/src/test/regress/expected/bfv_partition_plans_optimizer.out
+++ b/src/test/regress/expected/bfv_partition_plans_optimizer.out
@@ -32,6 +32,20 @@ for i in range(len(rv)):
 return result
 $$
 language plpythonu;
+create or replace function get_executor_mem(query text) returns int as
+$$
+import re
+rv = plpy.execute('EXPLAIN ANALYZE '+ query)
+comp_regex = re.compile("Executor memory: (\d+)K")
+mem = 0
+for i in range(len(rv)):
+    cur_line = rv[i]['QUERY PLAN']
+    m = comp_regex.search(cur_line)
+    if m is not None:
+        mem = mem + int(m.group(1))
+return mem
+$$
+language plpythonu;
 -- Test UPDATE that moves row from one partition to another. The partitioning
 -- key is also the distribution key in this case.
 create table mpp3061 (i int) partition by range(i) (start(1) end(5) every(1));
@@ -1585,6 +1599,45 @@ select count_operator('delete from mpp6247_foo using mpp6247_bar where mpp6247_f
 
 drop table mpp6247_bar;
 drop table mpp6247_foo;
+-- Test executor memory consumption for high partitioned column oriented tables
+drop table if exists aocs_part1;
+drop table if exists aocs_part2;
+create table aocs_part1 (i0 int, i1 int, i2 int, i3 int, i4 int, i5 int, i6 int, i7 int, i8 int, i9 int)
+with (appendonly=true, orientation=column) distributed by (i0)
+partition by range (i0) (start (0) end(1) every (1));
+create table aocs_part2 (i0 int, i1 int, i2 int, i3 int, i4 int, i5 int, i6 int, i7 int, i8 int, i9 int)
+with (appendonly=true, orientation=column) distributed by (i0)
+partition by range (i0) (start (0) end(50) every (1));
+-- For ORCA, this queries use Dynamic Seq Scan over the different number
+-- of partitions (1 and 50). Before, second query executor consumed high amount
+-- of memory (51126K). From now, it should consume far less memory (3035K),
+-- even less than 5x memory consumption of first query (1339K).
+-- As it's true for ORCA only, we use xor(#) to get final result.
+with vals as(
+  select
+  get_executor_mem('select i0, i1, i2, i3, i4, i5, i6, i7, i8, i9 
+  from (
+    select *,
+    row_number() over (partition by i0 order by i1) as seq
+    from aocs_part1
+  ) as p
+  where seq=1') as v1,
+  get_executor_mem('select i0, i1, i2, i3, i4, i5, i6, i7, i8, i9 
+  from (
+    select *,
+    row_number() over (partition by i0 order by i1) as seq
+    from aocs_part2
+  ) as p
+  where seq=1') as v2
+)
+select (select setting='off' from pg_settings where name = 'optimizer')::int::bit #
+    (v2 < v1 * 5)::int::bit as should_true
+from vals;
+ should_true 
+-------------
+ 1
+(1 row)
+
 -- CLEANUP
 -- start_ignore
 drop schema if exists bfv_partition_plans cascade;


### PR DESCRIPTION
The tables with high count of partitions can drain high amount of executor
memory for processing. This can be especially critical for column-oriented
tables, because we allocating a buffer (which is triple of block size) for each
column. Following the standard flow we free such buffers at executor end. But it
seems, we can safely free some structures, including this buffers, after
processing of each partition. To do this in the uniform way, new *_afterscan()
access methods introduced by this patch.

Related to #13725