### PR TITLE
[6X]: backport of 7x gpcloud commit. gpcloud: use memcpy to avoid -Wstringop-truncation

### DIFF
--- a/gpcontrib/gpcloud/src/s3key_reader.cpp
+++ b/gpcontrib/gpcloud/src/s3key_reader.cpp
@@ -219,7 +219,7 @@ uint64_t S3KeyReader::read(char* buf, uint64_t count) {
         if (this->transferredKeyLen >= fileLen) {
             if (!this->hasEol && !this->eolAppended) {
                 uint64_t eolLen = strlen(eolString);
-                strncpy(buf, eolString, eolLen);
+                memcpy(buf, eolString, eolLen);
 
                 this->eolAppended = true;
 


### PR DESCRIPTION
I have notices such a warn while compiling gpcloud for 6X_STABLE. Lets fix this the similar way it is done in master 2 years ago

Original commit msg:
```
Latest version of GCC detects string truncation and gives warnings.
However here is by design, use memcpy instead to avoid the warning.
```

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
