### PR TITLE
Update gp_switch_wal() to include pg_walfile_name() output

### DIFF
--- a/src/include/catalog/catversion.h
+++ b/src/include/catalog/catversion.h
@@ -56,6 +56,6 @@
  */
 
 /*							3yyymmddN */
-#define CATALOG_VERSION_NO	302205121
+#define CATALOG_VERSION_NO	302208241
 
 #endif

--- a/src/test/gpdb_pitr/expected/gpdb_pitr_setup.out
+++ b/src/test/gpdb_pitr/expected/gpdb_pitr_setup.out
@@ -146,8 +146,16 @@ SELECT * FROM gpdb_two_phase_commit_after_restore_point ORDER BY num;
  10  
 (10 rows)
 
-CREATE TEMP TABLE gp_current_wal_lsn AS SELECT -1 AS content_id, pg_current_wal_lsn() AS current_lsn UNION SELECT gp_segment_id AS content_id, pg_current_wal_lsn() FROM gp_dist_random('gp_id');
+-- Get the current WAL segment filenames from each segment. The
+-- pg_walfile_name() for content -1 runs on a primary segment due to a
+-- redistribute motion so fix the timeline id for it as a workaround for
+-- now as its been consistently observed that it can run on content 1
+-- which has a different timeline id. We can do this workaround because
+-- of the test requirement of a fresh gpdemo cluster.
+CREATE TEMP TABLE gp_current_walfile_name AS SELECT -1 AS content_id, pg_walfile_name(pg_current_wal_lsn()) AS walfilename UNION SELECT gp_segment_id AS content_id, pg_walfile_name(pg_current_wal_lsn()) AS walfilename FROM gp_dist_random('gp_id');
 CREATE 4
+UPDATE gp_current_walfile_name SET walfilename = replace(walfilename, '00000003', '00000001') WHERE content_id = -1;
+UPDATE 1
 
 -- Run gp_switch_wal() so that the WAL segment files with the restore
 -- points are eligible for archival to the WAL Archive directories.
@@ -163,7 +171,7 @@ SELECT true FROM gp_switch_wal();
 -- Ensure that the last WAL segment file for each GP segment was archived.
 -- This function loops until the archival is complete. It times out after
 -- approximately 10mins.
-CREATE OR REPLACE FUNCTION check_archival() RETURNS BOOLEAN AS $$ DECLARE archived BOOLEAN; /*in func*/ DECLARE archived_count INTEGER; /*in func*/ BEGIN /*in func*/ FOR i in 1..3000 LOOP SELECT bool_and(seg_archived), count(*) FROM (SELECT last_archived_wal = pg_walfile_name(current_lsn) AS seg_archived FROM gp_current_wal_lsn l INNER JOIN gp_stat_archiver a ON l.content_id = a.gp_segment_id) s INTO archived, archived_count; /*in func*/ IF archived AND archived_count = 4 THEN RETURN archived; /*in func*/ END IF; /*in func*/ PERFORM pg_sleep(0.2); /*in func*/ END LOOP; /*in func*/ END $$ LANGUAGE plpgsql;
+CREATE OR REPLACE FUNCTION check_archival() RETURNS BOOLEAN AS $$ DECLARE archived BOOLEAN; /*in func*/ DECLARE archived_count INTEGER; /*in func*/ BEGIN /*in func*/ FOR i in 1..3000 LOOP SELECT bool_and(seg_archived), count(*) FROM (SELECT last_archived_wal = l.walfilename AS seg_archived FROM gp_current_walfile_name l INNER JOIN gp_stat_archiver a ON l.content_id = a.gp_segment_id) s INTO archived, archived_count; /*in func*/ IF archived AND archived_count = 4 THEN RETURN archived; /*in func*/ END IF; /*in func*/ PERFORM pg_sleep(0.2); /*in func*/ END LOOP; /*in func*/ END $$ LANGUAGE plpgsql;
 CREATE
 
 SELECT check_archival();

--- a/src/test/gpdb_pitr/expected/test_gp_switch_wal.out
+++ b/src/test/gpdb_pitr/expected/test_gp_switch_wal.out
@@ -1,0 +1,61 @@
+-- Test that gp_switch_wal() returns back WAL segment filenames
+-- constructed on the individual segments so that their timeline ids are
+-- used instead of each result having the same timeline id.
+
+-- timeline ids prior to failover/failback should all be 1 due to the
+-- test requirement of having a fresh gpdemo cluster with mirrors
+SELECT gp_segment_id, substring(pg_walfile_name, 1, 8) FROM gp_switch_wal() ORDER BY gp_segment_id;
+ gp_segment_id | substring 
+---------------+-----------
+ -1            | 00000001  
+ 0             | 00000001  
+ 1             | 00000001  
+ 2             | 00000001  
+(4 rows)
+
+-- stop a primary in order to trigger a mirror promotion
+SELECT pg_ctl((SELECT datadir FROM gp_segment_configuration WHERE role = 'p' AND content = 1), 'stop');
+ pg_ctl 
+--------
+ OK     
+(1 row)
+
+-- trigger failover
+select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+
+-- wait for content 1 (earlier mirror, now primary) to finish the promotion
+0U: SELECT 1;
+ ?column? 
+----------
+ 1        
+(1 row)
+
+-- recover the failed primary as new mirror
+!\retcode gprecoverseg -a --no-progress;
+(exited with code 0)
+
+-- loop while segments come in sync
+SELECT wait_until_all_segments_synchronized();
+ wait_until_all_segments_synchronized 
+--------------------------------------
+ OK                                   
+(1 row)
+
+-- rebalance back
+!\retcode gprecoverseg -ar --no-progress;
+(exited with code 0)
+
+-- test that the pg_walfile_name output of gp_switch_wal() does not
+-- use the same timeline id for content 1
+SELECT gp_segment_id, substring(pg_walfile_name, 1, 8) FROM gp_switch_wal() ORDER BY gp_segment_id;
+ gp_segment_id | substring 
+---------------+-----------
+ -1            | 00000001  
+ 0             | 00000001  
+ 1             | 00000003  
+ 2             | 00000001  
+(4 rows)

--- a/src/test/gpdb_pitr/sql/test_gp_switch_wal.sql
+++ b/src/test/gpdb_pitr/sql/test_gp_switch_wal.sql
@@ -1,0 +1,29 @@
+-- Test that gp_switch_wal() returns back WAL segment filenames
+-- constructed on the individual segments so that their timeline ids are
+-- used instead of each result having the same timeline id.
+
+-- timeline ids prior to failover/failback should all be 1 due to the
+-- test requirement of having a fresh gpdemo cluster with mirrors
+SELECT gp_segment_id, substring(pg_walfile_name, 1, 8) FROM gp_switch_wal() ORDER BY gp_segment_id;
+
+-- stop a primary in order to trigger a mirror promotion
+SELECT pg_ctl((SELECT datadir FROM gp_segment_configuration WHERE role = 'p' AND content = 1), 'stop');
+
+-- trigger failover
+select gp_request_fts_probe_scan();
+
+-- wait for content 1 (earlier mirror, now primary) to finish the promotion
+0U: SELECT 1;
+
+-- recover the failed primary as new mirror
+!\retcode gprecoverseg -a --no-progress;
+
+-- loop while segments come in sync
+SELECT wait_until_all_segments_synchronized();
+
+-- rebalance back
+!\retcode gprecoverseg -ar --no-progress;
+
+-- test that the pg_walfile_name output of gp_switch_wal() does not
+-- use the same timeline id for content 1
+SELECT gp_segment_id, substring(pg_walfile_name, 1, 8) FROM gp_switch_wal() ORDER BY gp_segment_id;

--- a/src/test/gpdb_pitr/test_gpdb_pitr.sh
+++ b/src/test/gpdb_pitr/test_gpdb_pitr.sh
@@ -68,6 +68,12 @@ run_test_isolation2()
 # Remove temporary test directory if it already exists.
 [ -d $TEMP_DIR ] && rm -rf $TEMP_DIR
 
+# Create our test database.
+createdb gpdb_pitr_database
+
+# Test output of gp_switch_wal()
+run_test_isolation2 test_gp_switch_wal
+
 # Set up WAL Archiving by updating the postgresql.conf files of the
 # master and primary segments. Afterwards, restart the cluster to load
 # the new settings.
@@ -90,9 +96,6 @@ for segment_role in MASTER PRIMARY1 PRIMARY2 PRIMARY3; do
   REPLICA_DBID_VAR=REPLICA_${segment_role}_DBID
   pg_basebackup -h localhost -p ${!PORT_VAR} -X stream -D ${!REPLICA_VAR} --target-gp-dbid ${!REPLICA_DBID_VAR}
 done
-
-# Create our test database.
-createdb gpdb_pitr_database
 
 # Run setup test. This will create the tables, create the restore
 # points, and demonstrate the commit blocking.


### PR DESCRIPTION
The LSN output from pg_switch_wal() is commonly used with
pg_walfile_name(). However, the LSN set outputted from gp_switch_wal()
cannot be used by pg_walfile_name() because of the very likely
timeline differences of the coordinator segment and all the
segments. To make sure users/developers that want the WAL segment
filename and 100% guarantee that it is correct, we should bake it into
gp_switch_wal(). Having a separate catalog function would create a
window where HA failover would make the timeline ids incorrect and we
would have the same problem all over again.

Issue example:
```
postgres=# SELECT gp_segment_id, last_archived_wal FROM gp_stat_archiver ORDER BY gp_segment_id;
 gp_segment_id |    last_archived_wal
---------------+--------------------------
            -1 | 000000070000000300000033
             0 | 000000060000000200000039
             1 | 00000006000000020000003B
             2 | 00000006000000020000003D
(4 rows)

postgres=# create table testtable(a int);
CREATE TABLE

-- the walfilenames all have the coordinator's timeline id in them
postgres=# SELECT gp_segment_id, pg_switch_wal, pg_walfile_name(pg_switch_wal) AS walfilename FROM gp_switch_wal() ORDER BY gp_segment_id;
 gp_segment_id | pg_switch_wal |       walfilename
---------------+---------------+--------------------------
            -1 | 3/D0042DB0    | 000000070000000300000034
             0 | 2/E8042230    | 00000007000000020000003A
             1 | 2/F0042230    | 00000007000000020000003C
             2 | 2/F8042230    | 00000007000000020000003E
(4 rows)

-- these are the expected WAL segment filenames with correct timeline id
postgres=# SELECT gp_segment_id, last_archived_wal FROM gp_stat_archiver ORDER BY gp_segment_id;
 gp_segment_id |    last_archived_wal
---------------+--------------------------
            -1 | 000000070000000300000034
             0 | 00000006000000020000003A
             1 | 00000006000000020000003C
             2 | 00000006000000020000003E
(4 rows)
```

This fix is also intended to be backported to the 6X_STABLE gp_pitr extension... preferably before 6.22.0 is tagged so that we wouldn't need to bump the extension version again and create another extension upgrade script.