### PR TITLE
Fix compilation warning in gram.y

### DIFF
--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -3323,7 +3323,7 @@ alter_table_cmd:
 					if (witham) 
 					{
 						if (strlen(witham) != strlen(n->name) || 
-							strncmp(n->name, witham, strlen(n->name) != 0))
+							strncmp(n->name, witham, strlen(n->name)) != 0)
 							ereport(ERROR,
 									(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 									 errmsg("ACCESS METHOD is specified as \"%s\" but "


### PR DESCRIPTION
gram.y compilation warning:
```
gram.y:3326:49: warning: size argument in 'strncmp' call is a comparison [-Wmemsize-comparison]
                                                        strncmp(n->name, witham, strlen(n->name) != 0))
                                                                                 ~~~~~~~~~~~~~~~~^~~~
gram.y:3326:8: note: did you mean to compare the result of 'strncmp' instead?
                                                        strncmp(n->name, witham, strlen(n->name) != 0))
                                                        ^                                            ~
                                                                                                )
gram.y:3326:33: note: explicitly cast the argument to size_t to silence this warning
                                                        strncmp(n->name, witham, strlen(n->name) != 0))
                                                                                 ^
                                                                                 (size_t)(           )
1 warning generated.
```

As suggested by the compiler, we simply needed to move the ending
parenthesis to compare the strncmp result as most likely intended. The
main reason why this didn't cause any issues is because the strlen
comparisons were good enough since the only comparable values
currently are ao_row, ao_column, and heap which all have different
string lengths.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
