### PR TITLE
Fix a test failure in test_unit_foreign_key_check

### DIFF
--- a/gpMgmt/bin/gppylib/test/unit/test_unit_foreign_key_check.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_foreign_key_check.py
@@ -175,7 +175,7 @@ class GpCheckCatTestCase(GpTestCase):
     ####################### PRIVATE METHODS #######################
     def _get_filter(self, table_name):
         query_filters = {}
-        query_filters['pg_appendonly'] = "(select amname from pg_am am where am.oid = relam) IN ('ao_row', 'ao_column')"
+        query_filters['pg_appendonly'] = "((select amname from pg_am am where am.oid = relam) IN ('ao_row', 'ao_column')) AND relkind != 'p'"
         query_filters['pg_attribute'] = "(relnatts > 0 or relnatts is NULL)"
         query_filters['pg_constraint'] = "((relchecks>0 or relhaspkey='t') and relkind = 'r')"
         query_filters['gp_distribution_policy'] = """(relnamespace not in(select oid from pg_namespace where nspname ~ 'pg_')


### PR DESCRIPTION
In commit afde39b3f973c429aa4175e5d70575566bb905bd we changed a query filter in the foreign_key_check test in gpcheckcat. That breaks the gppylib's unit test 'test_unit_foreign_key_check' where it checks if the gpcheckcat tests have desired calls. Adjusted it now.

Side note: we might be able to import the gpcheckcat filters into the gppylib unit test so we don't have to adjust it every time we modified them. But since these changes should be very rare (only one change since [the test was introduced 6 years ago](https://github.com/greenplum-db/gpdb/commit/92cc01872c81)), we can consider that in a later day.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
