### PR TITLE
vendor libzstd.so to clients

### DIFF
--- a/concourse/scripts/compile_gpdb.bash
+++ b/concourse/scripts/compile_gpdb.bash
@@ -145,6 +145,9 @@ function export_gpdb_clients() {
 	mkdir -p bin/ext/gppylib
 	cp ${GREENPLUM_INSTALL_DIR}/lib/python/gppylib/__init__.py ./bin/ext/gppylib
 	cp ${GREENPLUM_INSTALL_DIR}/lib/python/gppylib/gpversion.py ./bin/ext/gppylib
+	if ls ${GREENPLUM_INSTALL_DIR}/lib/libzstd* 1> /dev/null 2>&1; then
+	  cp ${GREENPLUM_INSTALL_DIR}/lib/libzstd* ./lib/
+	fi
 	# GPHOME_LOADERS and greenplum_loaders_path.sh are still requried by some users
 	# So link greenplum_loaders_path.sh to greenplum_clients_path.sh for compatible
 	ln -sf greenplum_clients_path.sh greenplum_loaders_path.sh


### PR DESCRIPTION
https://github.com/greenplum-db/gpdb/commit/80907fb1c3fbe7257befb4fa60a8757cec6d12eb has add introduced the
zstd for gpdb6 client's gpfdist.so So need to ship libzstd.so to customer

Authored-by: Shaoqi Bai <bshaoqi@vmware.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
