### PR TITLE
[ORCA] Enable DELETE on partitioned tables

### DIFF
--- a/src/backend/executor/nodeModifyTable.c
+++ b/src/backend/executor/nodeModifyTable.c
@@ -2544,7 +2544,7 @@ ExecModifyTable(PlanState *pstate)
 				break;
 			case CMD_DELETE:
 				if (proute)
-					slot = ExecPrepareTupleRouting(node, estate, proute,
+					planSlot = ExecPrepareTupleRouting(node, estate, proute,
 												   resultRelInfo, slot);
 				slot = ExecDelete(node, tupleid, segid, oldtuple, planSlot,
 								  &node->mt_epqstate, estate,

--- a/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
@@ -1176,13 +1176,6 @@ CTranslatorQueryToDXL::TranslateDeleteQueryToDXL()
 		&m_context->m_has_distributed_tables);
 	const IMDRelation *md_rel = m_md_accessor->RetrieveRel(table_descr->MDId());
 
-	if (md_rel->IsPartitioned())
-	{
-		// GPDB_12_MERGE_FIXME: Support DML operations on partitioned tables
-		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature,
-				   GPOS_WSZ_LIT("DML on partitioned tables"));
-	}
-
 	// make note of the operator classes used in the distribution key
 	NoteDistributionPolicyOpclasses(rte);
 

--- a/src/backend/gporca/libgpopt/src/xforms/CXformUtils.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformUtils.cpp
@@ -1342,47 +1342,26 @@ CXformUtils::PexprLogicalDMLOverProject(CMemoryPool *mp,
 	CColRef *pcrAction = nullptr;
 	CColRef *pcrOid = nullptr;
 
-	if (ptabdesc->IsPartitioned() && CLogicalDML::EdmlDelete == edmlop)
+	CExpressionArray *pdrgpexprProjected = GPOS_NEW(mp) CExpressionArray(mp);
+	// generate one project node with two new columns: action, oid (based on the traceflag)
+	pdrgpexprProjected->Append(CUtils::PexprScalarConstInt4(mp, val));
+
+	BOOL fGeneratePartOid = CUtils::FGeneratePartOid(ptabdesc->MDId());
+	if (fGeneratePartOid)
 	{
-		// generate a PartitionSelector node which generates OIDs, then add a project
-		// on top of that to add the action column
-		CExpression *pexprSelector = PexprLogicalPartitionSelector(
-			mp, ptabdesc, colref_array, pexprChild);
-		if (CUtils::FGeneratePartOid(ptabdesc->MDId()))
-		{
-			pcrOid = CLogicalPartitionSelector::PopConvert(pexprSelector->Pop())
-						 ->PcrOid();
-		}
-		pexprProject = CUtils::PexprAddProjection(
-			mp, pexprSelector, CUtils::PexprScalarConstInt4(mp, val));
-		CExpression *pexprPrL = (*pexprProject)[1];
-		pcrAction = CUtils::PcrFromProjElem((*pexprPrL)[0]);
+		OID oidTable = CMDIdGPDB::CastMdid(rel_mdid)->Oid();
+		pdrgpexprProjected->Append(CUtils::PexprScalarConstOid(mp, oidTable));
 	}
-	else
+
+	pexprProject =
+		CUtils::PexprAddProjection(mp, pexprChild, pdrgpexprProjected);
+	pdrgpexprProjected->Release();
+
+	CExpression *pexprPrL = (*pexprProject)[1];
+	pcrAction = CUtils::PcrFromProjElem((*pexprPrL)[0]);
+	if (fGeneratePartOid)
 	{
-		CExpressionArray *pdrgpexprProjected =
-			GPOS_NEW(mp) CExpressionArray(mp);
-		// generate one project node with two new columns: action, oid (based on the traceflag)
-		pdrgpexprProjected->Append(CUtils::PexprScalarConstInt4(mp, val));
-
-		BOOL fGeneratePartOid = CUtils::FGeneratePartOid(ptabdesc->MDId());
-		if (fGeneratePartOid)
-		{
-			OID oidTable = CMDIdGPDB::CastMdid(rel_mdid)->Oid();
-			pdrgpexprProjected->Append(
-				CUtils::PexprScalarConstOid(mp, oidTable));
-		}
-
-		pexprProject =
-			CUtils::PexprAddProjection(mp, pexprChild, pdrgpexprProjected);
-		pdrgpexprProjected->Release();
-
-		CExpression *pexprPrL = (*pexprProject)[1];
-		pcrAction = CUtils::PcrFromProjElem((*pexprPrL)[0]);
-		if (fGeneratePartOid)
-		{
-			pcrOid = CUtils::PcrFromProjElem((*pexprPrL)[1]);
-		}
+		pcrOid = CUtils::PcrFromProjElem((*pexprPrL)[1]);
 	}
 
 	GPOS_ASSERT(nullptr != pcrAction);

--- a/src/test/isolation2/expected/lockmodes_optimizer.out
+++ b/src/test/isolation2/expected/lockmodes_optimizer.out
@@ -1042,8 +1042,8 @@ DELETE 10
 1: select * from show_locks_lockmodes;
  locktype | mode            | granted | relation                        
 ----------+-----------------+---------+---------------------------------
- relation | ExclusiveLock   | t       | t_lockmods_part_tbl_dml_1_prt_1 
- relation | ExclusiveLock   | t       | t_lockmods_part_tbl_dml_1_prt_2 
+ relation | AccessShareLock | t       | t_lockmods_part_tbl_dml_1_prt_2 
+ relation | AccessShareLock | t       | t_lockmods_part_tbl_dml_1_prt_1 
  relation | AccessShareLock | t       | t_lockmods_part_tbl_dml         
  relation | ExclusiveLock   | t       | t_lockmods_part_tbl_dml         
 (4 rows)
@@ -2147,8 +2147,8 @@ DELETE 10
 1: select * from show_locks_lockmodes;
  locktype | mode             | granted | relation                        
 ----------+------------------+---------+---------------------------------
- relation | RowExclusiveLock | t       | t_lockmods_part_tbl_dml_1_prt_2 
- relation | RowExclusiveLock | t       | t_lockmods_part_tbl_dml_1_prt_1 
+ relation | AccessShareLock  | t       | t_lockmods_part_tbl_dml_1_prt_2 
+ relation | AccessShareLock  | t       | t_lockmods_part_tbl_dml_1_prt_1 
  relation | AccessShareLock  | t       | t_lockmods_part_tbl_dml         
  relation | RowExclusiveLock | t       | t_lockmods_part_tbl_dml         
 (4 rows)

--- a/src/test/regress/expected/DML_over_joins.out
+++ b/src/test/regress/expected/DML_over_joins.out
@@ -1635,11 +1635,178 @@ explain (costs off) delete from tab1 using tab2, tab3 where tab1.a = tab2.a and 
 (15 rows)
 
 -- ----------------------------------------------------------------------
+-- Test delete on partition table from join on another partition table
+-- ----------------------------------------------------------------------
+drop table if exists part_eq_dis_1;
+NOTICE:  table "part_eq_dis_1" does not exist, skipping
+drop table if exists part_eq_dis_2;
+NOTICE:  table "part_eq_dis_2" does not exist, skipping
+create table part_eq_dis_1 (a int4, b int4) partition by range (a) (start(1) end(20) every(1), default partition extra);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table part_eq_dis_2 (c int4, d int4) partition by range (c) (start(1) end(20) every(1), default partition extra);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into part_eq_dis_1 select generate_series(1,40), generate_series(1,40);
+insert into part_eq_dis_2 select generate_series(1,40), generate_series(1,40);
+drop table if exists part_neq_dis_1;
+NOTICE:  table "part_neq_dis_1" does not exist, skipping
+drop table if exists part_neq_dis_2;
+NOTICE:  table "part_neq_dis_2" does not exist, skipping
+create table part_neq_dis_1 (a int4, b int4) partition by range (b) (start(1) end(20) every(1), default partition extra);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table part_neq_dis_2 (c int4, d int4) partition by range (d) (start(1) end(20) every(1), default partition extra);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into part_neq_dis_1 select generate_series(1,40), generate_series(1,40);
+insert into part_neq_dis_2 select generate_series(1,40), generate_series(1,40);
+set optimizer_trace_fallback=on;
+-- T1 - distribution partitioned column, T2 - distributed partitioned column
+-- a) non-default partition
+delete from part_eq_dis_1 where a = (select c from part_eq_dis_2 where c=1);
+-- b) default partition
+delete from part_eq_dis_1 where a = (select c from part_eq_dis_2 where c=21);
+-- T1 - distribution partitioned column, T2 - non-distributed non-partitioned column
+-- a) non-default partition
+delete from part_eq_dis_1 where a = (select d from part_eq_dis_2 where c=2);
+-- b) default partition
+delete from part_eq_dis_1 where a = (select d from part_eq_dis_2 where c=22);
+-- T1 - distribution partitioned column, T2 - distributed non-partitioned column
+-- a) non-default partition
+delete from part_eq_dis_1 where a = (select c from part_neq_dis_2 where c=3);
+-- b) default partition
+delete from part_eq_dis_1 where a = (select c from part_neq_dis_2 where c=23);
+-- T1 - distribution partitioned column, T2 - non-distributed partitioned column
+-- a) non-default partition
+delete from part_eq_dis_1 where a = (select d from part_neq_dis_2 where c=4);
+-- b) default partition
+delete from part_eq_dis_1 where a = (select d from part_neq_dis_2 where c=24);
+-- T1 - non-distribution non-partitioned column, T2 - distributed partitioned column
+-- a) non-default partition
+delete from part_eq_dis_1 where b = (select c from part_eq_dis_2 where c=5);
+-- b) default partition
+delete from part_eq_dis_1 where b = (select c from part_eq_dis_2 where c=25);
+-- T1 - non-distribution non-partitioned column, T2 - non-distributed non-partitioned column
+-- a) non-default partition
+delete from part_eq_dis_1 where b = (select d from part_eq_dis_2 where c=6);
+-- b) default partition
+delete from part_eq_dis_1 where b = (select d from part_eq_dis_2 where c=26);
+-- T1 - non-distribution non-partitioned column, T2 - distributed non-partitioned column
+-- a) non-default partition
+delete from part_eq_dis_1 where b = (select c from part_neq_dis_2 where c=7);
+-- b) default partition
+delete from part_eq_dis_1 where b = (select c from part_neq_dis_2 where c=27);
+-- T1 - non-distribution non-partitioned column, T2 - non-distributed partitioned column
+-- a) non-default partition
+delete from part_eq_dis_1 where b = (select d from part_neq_dis_2 where c=8);
+-- b) default partition
+delete from part_eq_dis_1 where b = (select d from part_neq_dis_2 where c=28);
+-- T1 - distribution non-partitioned column, T2 - distributed partitioned column
+-- a) non-default partition
+delete from part_neq_dis_1 where a = (select c from part_eq_dis_2 where c=9);
+-- b) default partition
+delete from part_neq_dis_1 where a = (select c from part_eq_dis_2 where c=29);
+-- T1 - distribution non-partitioned column, T2 - non-distributed non-partitioned column
+-- a) non-default partition
+delete from part_neq_dis_1 where a = (select d from part_eq_dis_2 where c=10);
+-- b) default partition
+delete from part_neq_dis_1 where a = (select d from part_eq_dis_2 where c=30);
+-- T1 - distribution non-partitioned column, T2 - non-distributed partitioned column
+-- a) non-default partition
+delete from part_neq_dis_1 where a = (select d from part_neq_dis_2 where c=11);
+-- b) default partition
+delete from part_neq_dis_1 where a = (select d from part_neq_dis_2 where c=31);
+-- T1 - distribution non-partitioned column, T2 - distributed non-partitioned column
+-- a) non-default partition
+delete from part_neq_dis_1 where a = (select c from part_neq_dis_2 where c=12);
+-- b) default partition
+delete from part_neq_dis_1 where a = (select c from part_neq_dis_2 where c=32);
+-- T1 - non-distribution partitioned column, T2 - distributed partitioned column
+-- a) non-default partition
+delete from part_neq_dis_1 where b = (select c from part_eq_dis_2 where c=13);
+-- b) default partition
+delete from part_neq_dis_1 where b = (select c from part_eq_dis_2 where c=33);
+-- T1 - non-distribution partitioned column, T2 - non-distributed non-partitioned column
+-- a) non-default partition
+delete from part_neq_dis_1 where b = (select d from part_eq_dis_2 where c=14);
+-- b) default partition
+delete from part_neq_dis_1 where b = (select d from part_eq_dis_2 where c=34);
+-- T1 - non-distribution partitioned column, T2 - distributed non-partitioned column
+-- a) non-default partition
+delete from part_neq_dis_1 where b = (select d from part_neq_dis_2 where c=15);
+-- b) default partition
+delete from part_neq_dis_1 where b = (select d from part_neq_dis_2 where c=35);
+-- T1 - non-distribution partitioned column, T2 - non-distributed partitioned column
+-- a) non-default partition
+delete from part_neq_dis_1 where b = (select c from part_neq_dis_2 where c=16);
+-- b) default partition
+delete from part_neq_dis_1 where b = (select c from part_neq_dis_2 where c=36);
+select * from part_eq_dis_1;
+ a  | b  
+----+----
+ 16 | 16
+ 18 | 18
+ 19 | 19
+ 29 | 29
+ 34 | 34
+ 37 | 37
+ 39 | 39
+ 12 | 12
+ 15 | 15
+ 20 | 20
+ 30 | 30
+ 31 | 31
+ 35 | 35
+ 36 | 36
+ 38 | 38
+ 40 | 40
+  9 |  9
+ 10 | 10
+ 11 | 11
+ 13 | 13
+ 14 | 14
+ 17 | 17
+ 32 | 32
+ 33 | 33
+(24 rows)
+
+select * from part_neq_dis_1;
+ a  | b  
+----+----
+  2 |  2
+  3 |  3
+  4 |  4
+  7 |  7
+  8 |  8
+ 18 | 18
+ 19 | 19
+ 22 | 22
+ 24 | 24
+ 27 | 27
+ 37 | 37
+ 39 | 39
+  1 |  1
+ 20 | 20
+ 23 | 23
+ 26 | 26
+ 38 | 38
+ 40 | 40
+  5 |  5
+  6 |  6
+ 17 | 17
+ 21 | 21
+ 25 | 25
+ 28 | 28
+(24 rows)
+
+reset optimizer_trace_fallback;
+-- ----------------------------------------------------------------------
 -- Test: teardown.sql
 -- ----------------------------------------------------------------------
 -- start_ignore
 drop schema DML_over_joins cascade;
-NOTICE:  drop cascades to 15 other objects
+NOTICE:  drop cascades to 22 other objects
 DETAIL:  drop cascades to table update_test
 drop cascades to table t1
 drop cascades to table t2
@@ -1655,4 +1822,11 @@ drop cascades to table sales_par_co
 drop cascades to function insertintosales(character varying,integer,character varying)
 drop cascades to function insertmanyintosales(integer,character varying)
 drop cascades to table s_ao
+drop cascades to table tab1
+drop cascades to table tab2
+drop cascades to table tab3
+drop cascades to table part_eq_dis_1
+drop cascades to table part_eq_dis_2
+drop cascades to table part_neq_dis_1
+drop cascades to table part_neq_dis_2
 -- end_ignore

--- a/src/test/regress/expected/DML_over_joins_optimizer.out
+++ b/src/test/regress/expected/DML_over_joins_optimizer.out
@@ -1627,11 +1627,178 @@ HINT:  For non-partitioned tables, run analyze <table_name>(<column_list>). For 
 (16 rows)
 
 -- ----------------------------------------------------------------------
+-- Test delete on partition table from join on another partition table
+-- ----------------------------------------------------------------------
+drop table if exists part_eq_dis_1;
+NOTICE:  table "part_eq_dis_1" does not exist, skipping
+drop table if exists part_eq_dis_2;
+NOTICE:  table "part_eq_dis_2" does not exist, skipping
+create table part_eq_dis_1 (a int4, b int4) partition by range (a) (start(1) end(20) every(1), default partition extra);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table part_eq_dis_2 (c int4, d int4) partition by range (c) (start(1) end(20) every(1), default partition extra);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into part_eq_dis_1 select generate_series(1,40), generate_series(1,40);
+insert into part_eq_dis_2 select generate_series(1,40), generate_series(1,40);
+drop table if exists part_neq_dis_1;
+NOTICE:  table "part_neq_dis_1" does not exist, skipping
+drop table if exists part_neq_dis_2;
+NOTICE:  table "part_neq_dis_2" does not exist, skipping
+create table part_neq_dis_1 (a int4, b int4) partition by range (b) (start(1) end(20) every(1), default partition extra);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table part_neq_dis_2 (c int4, d int4) partition by range (d) (start(1) end(20) every(1), default partition extra);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into part_neq_dis_1 select generate_series(1,40), generate_series(1,40);
+insert into part_neq_dis_2 select generate_series(1,40), generate_series(1,40);
+set optimizer_trace_fallback=on;
+-- T1 - distribution partitioned column, T2 - distributed partitioned column
+-- a) non-default partition
+delete from part_eq_dis_1 where a = (select c from part_eq_dis_2 where c=1);
+-- b) default partition
+delete from part_eq_dis_1 where a = (select c from part_eq_dis_2 where c=21);
+-- T1 - distribution partitioned column, T2 - non-distributed non-partitioned column
+-- a) non-default partition
+delete from part_eq_dis_1 where a = (select d from part_eq_dis_2 where c=2);
+-- b) default partition
+delete from part_eq_dis_1 where a = (select d from part_eq_dis_2 where c=22);
+-- T1 - distribution partitioned column, T2 - distributed non-partitioned column
+-- a) non-default partition
+delete from part_eq_dis_1 where a = (select c from part_neq_dis_2 where c=3);
+-- b) default partition
+delete from part_eq_dis_1 where a = (select c from part_neq_dis_2 where c=23);
+-- T1 - distribution partitioned column, T2 - non-distributed partitioned column
+-- a) non-default partition
+delete from part_eq_dis_1 where a = (select d from part_neq_dis_2 where c=4);
+-- b) default partition
+delete from part_eq_dis_1 where a = (select d from part_neq_dis_2 where c=24);
+-- T1 - non-distribution non-partitioned column, T2 - distributed partitioned column
+-- a) non-default partition
+delete from part_eq_dis_1 where b = (select c from part_eq_dis_2 where c=5);
+-- b) default partition
+delete from part_eq_dis_1 where b = (select c from part_eq_dis_2 where c=25);
+-- T1 - non-distribution non-partitioned column, T2 - non-distributed non-partitioned column
+-- a) non-default partition
+delete from part_eq_dis_1 where b = (select d from part_eq_dis_2 where c=6);
+-- b) default partition
+delete from part_eq_dis_1 where b = (select d from part_eq_dis_2 where c=26);
+-- T1 - non-distribution non-partitioned column, T2 - distributed non-partitioned column
+-- a) non-default partition
+delete from part_eq_dis_1 where b = (select c from part_neq_dis_2 where c=7);
+-- b) default partition
+delete from part_eq_dis_1 where b = (select c from part_neq_dis_2 where c=27);
+-- T1 - non-distribution non-partitioned column, T2 - non-distributed partitioned column
+-- a) non-default partition
+delete from part_eq_dis_1 where b = (select d from part_neq_dis_2 where c=8);
+-- b) default partition
+delete from part_eq_dis_1 where b = (select d from part_neq_dis_2 where c=28);
+-- T1 - distribution non-partitioned column, T2 - distributed partitioned column
+-- a) non-default partition
+delete from part_neq_dis_1 where a = (select c from part_eq_dis_2 where c=9);
+-- b) default partition
+delete from part_neq_dis_1 where a = (select c from part_eq_dis_2 where c=29);
+-- T1 - distribution non-partitioned column, T2 - non-distributed non-partitioned column
+-- a) non-default partition
+delete from part_neq_dis_1 where a = (select d from part_eq_dis_2 where c=10);
+-- b) default partition
+delete from part_neq_dis_1 where a = (select d from part_eq_dis_2 where c=30);
+-- T1 - distribution non-partitioned column, T2 - non-distributed partitioned column
+-- a) non-default partition
+delete from part_neq_dis_1 where a = (select d from part_neq_dis_2 where c=11);
+-- b) default partition
+delete from part_neq_dis_1 where a = (select d from part_neq_dis_2 where c=31);
+-- T1 - distribution non-partitioned column, T2 - distributed non-partitioned column
+-- a) non-default partition
+delete from part_neq_dis_1 where a = (select c from part_neq_dis_2 where c=12);
+-- b) default partition
+delete from part_neq_dis_1 where a = (select c from part_neq_dis_2 where c=32);
+-- T1 - non-distribution partitioned column, T2 - distributed partitioned column
+-- a) non-default partition
+delete from part_neq_dis_1 where b = (select c from part_eq_dis_2 where c=13);
+-- b) default partition
+delete from part_neq_dis_1 where b = (select c from part_eq_dis_2 where c=33);
+-- T1 - non-distribution partitioned column, T2 - non-distributed non-partitioned column
+-- a) non-default partition
+delete from part_neq_dis_1 where b = (select d from part_eq_dis_2 where c=14);
+-- b) default partition
+delete from part_neq_dis_1 where b = (select d from part_eq_dis_2 where c=34);
+-- T1 - non-distribution partitioned column, T2 - distributed non-partitioned column
+-- a) non-default partition
+delete from part_neq_dis_1 where b = (select d from part_neq_dis_2 where c=15);
+-- b) default partition
+delete from part_neq_dis_1 where b = (select d from part_neq_dis_2 where c=35);
+-- T1 - non-distribution partitioned column, T2 - non-distributed partitioned column
+-- a) non-default partition
+delete from part_neq_dis_1 where b = (select c from part_neq_dis_2 where c=16);
+-- b) default partition
+delete from part_neq_dis_1 where b = (select c from part_neq_dis_2 where c=36);
+select * from part_eq_dis_1;
+ a  | b  
+----+----
+ 12 | 12
+ 15 | 15
+ 20 | 20
+ 30 | 30
+ 31 | 31
+ 35 | 35
+ 36 | 36
+ 38 | 38
+ 40 | 40
+ 16 | 16
+ 18 | 18
+ 19 | 19
+ 29 | 29
+ 34 | 34
+ 37 | 37
+ 39 | 39
+  9 |  9
+ 10 | 10
+ 11 | 11
+ 13 | 13
+ 14 | 14
+ 17 | 17
+ 32 | 32
+ 33 | 33
+(24 rows)
+
+select * from part_neq_dis_1;
+ a  | b  
+----+----
+  1 |  1
+ 20 | 20
+ 23 | 23
+ 26 | 26
+ 38 | 38
+ 40 | 40
+  2 |  2
+  3 |  3
+  4 |  4
+  7 |  7
+  8 |  8
+ 18 | 18
+ 19 | 19
+ 22 | 22
+ 24 | 24
+ 27 | 27
+ 37 | 37
+ 39 | 39
+  5 |  5
+  6 |  6
+ 17 | 17
+ 21 | 21
+ 25 | 25
+ 28 | 28
+(24 rows)
+
+reset optimizer_trace_fallback;
+-- ----------------------------------------------------------------------
 -- Test: teardown.sql
 -- ----------------------------------------------------------------------
 -- start_ignore
 drop schema DML_over_joins cascade;
-NOTICE:  drop cascades to 15 other objects
+NOTICE:  drop cascades to 22 other objects
 DETAIL:  drop cascades to table update_test
 drop cascades to table t1
 drop cascades to table t2
@@ -1647,4 +1814,11 @@ drop cascades to table sales_par_co
 drop cascades to function insertintosales(character varying,integer,character varying)
 drop cascades to function insertmanyintosales(integer,character varying)
 drop cascades to table s_ao
+drop cascades to table tab1
+drop cascades to table tab2
+drop cascades to table tab3
+drop cascades to table part_eq_dis_1
+drop cascades to table part_eq_dis_2
+drop cascades to table part_neq_dis_1
+drop cascades to table part_neq_dis_2
 -- end_ignore

--- a/src/test/regress/expected/bfv_partition_plans.out
+++ b/src/test/regress/expected/bfv_partition_plans.out
@@ -1,6 +1,16 @@
 -- start_matchsubs
 -- m/((Mon|Tue|Wed|Thu|Fri|Sat|Sun) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (0[1-9]|[12][0-9]|3[01]) ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](.[0-9]+)? (?!0000)[0-9]{4}.*)+(['"])/
 -- s/((Mon|Tue|Wed|Thu|Fri|Sat|Sun) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (0[1-9]|[12][0-9]|3[01]) ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](.[0-9]+)? (?!0000)[0-9]{4}.*)+(['"])/xxx xx xx xx:xx:xx xxxx"/
+-- m/Memory Usage: \d+\w?B/
+-- s/Memory Usage: \d+\w?B/Memory Usage: ###B/
+-- m/Memory: \d+kB/
+-- s/Memory: \d+kB/Memory: ###kB/
+-- m/Buckets: \d+/
+-- s/Buckets: \d+/Buckets: ###/
+-- m/Batches: \d+/
+-- s/Batches: \d+/Batches: ###/
+-- m/using \d+ of \d+ buckets/
+-- s/using \d+ of \d+ buckets/using ## of ### buckets/
 -- end_matchsubs
 create schema bfv_partition_plans;
 set search_path=bfv_partition_plans;
@@ -1182,6 +1192,109 @@ SELECT * FROM delete_from_indexed_pt;
   4 | 4
   6 | 0
   5 | 5
+  9 | 3
+ 10 | 4
+(8 rows)
+
+-- Validate that basic DELETE on partition table using DPE functions properly
+CREATE TABLE delete_from_pt (a int, b int) PARTITION BY RANGE(b) (START (0) END (7) EVERY (3));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE t(a int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO delete_from_pt SELECT i, i%6 FROM generate_series(1, 10)i;
+INSERT INTO t VALUES (1);
+ANALYZE delete_from_pt, t;
+EXPLAIN (COSTS OFF, TIMING OFF, SUMMARY OFF, ANALYZE) DELETE FROM delete_from_pt WHERE b IN (SELECT b FROM delete_from_pt, t WHERE t.a=delete_from_pt.b);
+                                                          QUERY PLAN                                                           
+-------------------------------------------------------------------------------------------------------------------------------
+ Delete on delete_from_pt (never executed)
+   Delete on delete_from_pt_1_prt_1
+   Delete on delete_from_pt_1_prt_2
+   Delete on delete_from_pt_1_prt_3
+   ->  Explicit Redistribute Motion 3:3  (slice1; segments: 3) (actual rows=1 loops=1)
+         ->  Hash Semi Join (actual rows=2 loops=1)
+               Hash Cond: (delete_from_pt_1_prt_1.b = t.a)
+               Extra Text: (seg1)   Hash chain length 2.0 avg, 2 max, using 1 of 65536 buckets.
+               ->  Redistribute Motion 3:3  (slice2; segments: 3) (actual rows=3 loops=1)
+                     Hash Key: delete_from_pt_1_prt_1.b
+                     ->  Seq Scan on delete_from_pt_1_prt_1 (actual rows=3 loops=1)
+               ->  Hash (actual rows=2 loops=1)
+                     Buckets: 65536  Batches: 1  Memory Usage: 513kB
+                     ->  Redistribute Motion 3:3  (slice3; segments: 3) (actual rows=2 loops=1)
+                           Hash Key: t.a
+                           ->  Hash Join (actual rows=1 loops=1)
+                                 Hash Cond: (delete_from_pt_1_prt_1_1.b = t.a)
+                                 Extra Text: (seg0)   Hash chain length 1.0 avg, 1 max, using 1 of 65536 buckets.
+                                 ->  Append (actual rows=3 loops=1)
+                                       Partition Selectors: $1
+                                       ->  Seq Scan on delete_from_pt_1_prt_1 delete_from_pt_1_prt_1_1 (actual rows=3 loops=1)
+                                       ->  Seq Scan on delete_from_pt_1_prt_2 delete_from_pt_1_prt_2_1 (never executed)
+                                       ->  Seq Scan on delete_from_pt_1_prt_3 delete_from_pt_1_prt_3_1 (never executed)
+                                 ->  Hash (actual rows=1 loops=1)
+                                       Buckets: 65536  Batches: 1  Memory Usage: 513kB
+                                       ->  Partition Selector (selector id: $1) (actual rows=1 loops=1)
+                                             ->  Broadcast Motion 3:3  (slice4; segments: 3) (actual rows=1 loops=1)
+                                                   ->  Seq Scan on t (actual rows=1 loops=1)
+   ->  Explicit Redistribute Motion 3:3  (slice5; segments: 3) (never executed)
+         ->  Hash Semi Join (never executed)
+               Hash Cond: (delete_from_pt_1_prt_2.b = t.a)
+               ->  Redistribute Motion 3:3  (slice6; segments: 3) (never executed)
+                     Hash Key: delete_from_pt_1_prt_2.b
+                     ->  Seq Scan on delete_from_pt_1_prt_2 (actual rows=3 loops=1)
+               ->  Hash (actual rows=2 loops=1)
+                     Buckets: 65536  Batches: 1  Memory Usage: 513kB
+                     ->  Redistribute Motion 3:3  (slice7; segments: 3) (actual rows=2 loops=1)
+                           Hash Key: t.a
+                           ->  Hash Join (actual rows=1 loops=1)
+                                 Hash Cond: (delete_from_pt_1_prt_1_1.b = t.a)
+                                 Extra Text: (seg0)   Hash chain length 1.0 avg, 1 max, using 1 of 65536 buckets.
+                                 ->  Append (actual rows=3 loops=1)
+                                       Partition Selectors: $2
+                                       ->  Seq Scan on delete_from_pt_1_prt_1 delete_from_pt_1_prt_1_1 (actual rows=3 loops=1)
+                                       ->  Seq Scan on delete_from_pt_1_prt_2 delete_from_pt_1_prt_2_1 (never executed)
+                                       ->  Seq Scan on delete_from_pt_1_prt_3 delete_from_pt_1_prt_3_1 (never executed)
+                                 ->  Hash (actual rows=1 loops=1)
+                                       Buckets: 65536  Batches: 1  Memory Usage: 513kB
+                                       ->  Partition Selector (selector id: $2) (actual rows=1 loops=1)
+                                             ->  Broadcast Motion 3:3  (slice8; segments: 3) (actual rows=1 loops=1)
+                                                   ->  Seq Scan on t (actual rows=1 loops=1)
+   ->  Explicit Redistribute Motion 3:3  (slice9; segments: 3) (never executed)
+         ->  Hash Semi Join (never executed)
+               Hash Cond: (delete_from_pt_1_prt_3.b = t.a)
+               ->  Redistribute Motion 3:3  (slice10; segments: 3) (never executed)
+                     Hash Key: delete_from_pt_1_prt_3.b
+                     ->  Seq Scan on delete_from_pt_1_prt_3 (never executed)
+               ->  Hash (actual rows=2 loops=1)
+                     Buckets: 65536  Batches: 1  Memory Usage: 513kB
+                     ->  Redistribute Motion 3:3  (slice11; segments: 3) (actual rows=2 loops=1)
+                           Hash Key: t.a
+                           ->  Hash Join (actual rows=1 loops=1)
+                                 Hash Cond: (delete_from_pt_1_prt_1_1.b = t.a)
+                                 Extra Text: (seg0)   Hash chain length 1.0 avg, 1 max, using 1 of 65536 buckets.
+                                 ->  Append (actual rows=3 loops=1)
+                                       Partition Selectors: $3
+                                       ->  Seq Scan on delete_from_pt_1_prt_1 delete_from_pt_1_prt_1_1 (actual rows=3 loops=1)
+                                       ->  Seq Scan on delete_from_pt_1_prt_2 delete_from_pt_1_prt_2_1 (never executed)
+                                       ->  Seq Scan on delete_from_pt_1_prt_3 delete_from_pt_1_prt_3_1 (never executed)
+                                 ->  Hash (actual rows=1 loops=1)
+                                       Buckets: 65536  Batches: 1  Memory Usage: 513kB
+                                       ->  Partition Selector (selector id: $3) (actual rows=1 loops=1)
+                                             ->  Broadcast Motion 3:3  (slice12; segments: 3) (actual rows=1 loops=1)
+                                                   ->  Seq Scan on t (actual rows=1 loops=1)
+ Optimizer: Postgres query optimizer
+(75 rows)
+
+SELECT * FROM delete_from_pt order by a;
+ a  | b 
+----+---
+  2 | 2
+  3 | 3
+  4 | 4
+  5 | 5
+  6 | 0
+  8 | 2
   9 | 3
  10 | 4
 (8 rows)

--- a/src/test/regress/expected/bfv_partition_plans.out
+++ b/src/test/regress/expected/bfv_partition_plans.out
@@ -1153,6 +1153,40 @@ select count_operator('delete from mpp6247_foo using mpp6247_bar where mpp6247_f
 
 drop table mpp6247_bar;
 drop table mpp6247_foo;
+-- Validate that basic DELETE on partition table with index functions properly
+SET optimizer_trace_fallback=on;
+CREATE TABLE delete_from_indexed_pt (a int, b int) PARTITION BY RANGE(b) (START (0) END (7) EVERY (3));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE INDEX index_delete_from_indexed_pt ON delete_from_indexed_pt USING bitmap(b);
+INSERT INTO delete_from_indexed_pt SELECT i, i%6 FROM generate_series(1, 10)i;
+EXPLAIN (COSTS OFF) DELETE FROM delete_from_indexed_pt WHERE b=1;
+                              QUERY PLAN                               
+-----------------------------------------------------------------------
+ Delete on delete_from_indexed_pt
+   Delete on delete_from_indexed_pt_1_prt_1
+   ->  Bitmap Heap Scan on delete_from_indexed_pt_1_prt_1
+         Recheck Cond: (b = 1)
+         ->  Bitmap Index Scan on delete_from_indexed_pt_1_prt_1_b_idx
+               Index Cond: (b = 1)
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+DELETE FROM delete_from_indexed_pt WHERE b=1;
+SELECT * FROM delete_from_indexed_pt;
+ a  | b 
+----+---
+  2 | 2
+  8 | 2
+  3 | 3
+  4 | 4
+  6 | 0
+  5 | 5
+  9 | 3
+ 10 | 4
+(8 rows)
+
+RESET optimizer_trace_fallback;
 -- CLEANUP
 -- start_ignore
 drop schema if exists bfv_partition_plans cascade;

--- a/src/test/regress/expected/bfv_partition_plans_optimizer.out
+++ b/src/test/regress/expected/bfv_partition_plans_optimizer.out
@@ -1151,6 +1151,38 @@ select count_operator('delete from mpp6247_foo using mpp6247_bar where mpp6247_f
 
 drop table mpp6247_bar;
 drop table mpp6247_foo;
+-- Validate that basic DELETE on partition table with index functions properly
+SET optimizer_trace_fallback=on;
+CREATE TABLE delete_from_indexed_pt (a int, b int) PARTITION BY RANGE(b) (START (0) END (7) EVERY (3));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE INDEX index_delete_from_indexed_pt ON delete_from_indexed_pt USING bitmap(b);
+INSERT INTO delete_from_indexed_pt SELECT i, i%6 FROM generate_series(1, 10)i;
+EXPLAIN (COSTS OFF) DELETE FROM delete_from_indexed_pt WHERE b=1;
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
+ Delete on delete_from_indexed_pt
+   ->  Dynamic Seq Scan on delete_from_indexed_pt delete_from_indexed_pt_1
+         Number of partitions to scan: 1 
+         Filter: (b = 1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(5 rows)
+
+DELETE FROM delete_from_indexed_pt WHERE b=1;
+SELECT * FROM delete_from_indexed_pt;
+ a  | b 
+----+---
+  6 | 0
+  5 | 5
+  9 | 3
+ 10 | 4
+  2 | 2
+  8 | 2
+  3 | 3
+  4 | 4
+(8 rows)
+
+RESET optimizer_trace_fallback;
 -- CLEANUP
 -- start_ignore
 drop schema if exists bfv_partition_plans cascade;

--- a/src/test/regress/expected/bfv_partition_plans_optimizer.out
+++ b/src/test/regress/expected/bfv_partition_plans_optimizer.out
@@ -1,6 +1,16 @@
 -- start_matchsubs
 -- m/((Mon|Tue|Wed|Thu|Fri|Sat|Sun) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (0[1-9]|[12][0-9]|3[01]) ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](.[0-9]+)? (?!0000)[0-9]{4}.*)+(['"])/
 -- s/((Mon|Tue|Wed|Thu|Fri|Sat|Sun) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (0[1-9]|[12][0-9]|3[01]) ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](.[0-9]+)? (?!0000)[0-9]{4}.*)+(['"])/xxx xx xx xx:xx:xx xxxx"/
+-- m/Memory Usage: \d+\w?B/
+-- s/Memory Usage: \d+\w?B/Memory Usage: ###B/
+-- m/Memory: \d+kB/
+-- s/Memory: \d+kB/Memory: ###kB/
+-- m/Buckets: \d+/
+-- s/Buckets: \d+/Buckets: ###/
+-- m/Batches: \d+/
+-- s/Batches: \d+/Batches: ###/
+-- m/using \d+ of \d+ buckets/
+-- s/using \d+ of \d+ buckets/using ## of ### buckets/
 -- end_matchsubs
 create schema bfv_partition_plans;
 set search_path=bfv_partition_plans;
@@ -1180,6 +1190,71 @@ SELECT * FROM delete_from_indexed_pt;
   8 | 2
   3 | 3
   4 | 4
+(8 rows)
+
+-- Validate that basic DELETE on partition table using DPE functions properly
+CREATE TABLE delete_from_pt (a int, b int) PARTITION BY RANGE(b) (START (0) END (7) EVERY (3));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE t(a int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO delete_from_pt SELECT i, i%6 FROM generate_series(1, 10)i;
+INSERT INTO t VALUES (1);
+ANALYZE delete_from_pt, t;
+EXPLAIN (COSTS OFF, TIMING OFF, SUMMARY OFF, ANALYZE) DELETE FROM delete_from_pt WHERE b IN (SELECT b FROM delete_from_pt, t WHERE t.a=delete_from_pt.b);
+                                                                    QUERY PLAN                                                                     
+---------------------------------------------------------------------------------------------------------------------------------------------------
+ Delete on delete_from_pt (never executed)
+   ->  Hash Join (actual rows=1 loops=1)
+         Hash Cond: (delete_from_pt_1.b = delete_from_pt_2.b)
+         Extra Text: (seg0)   Hash chain length 1.0 avg, 1 max, using 1 of 262144 buckets.
+         ->  Dynamic Seq Scan on delete_from_pt delete_from_pt_1 (actual rows=3 loops=1)
+               Number of partitions to scan: 3 
+               Partitions scanned:  Avg 1.0 x 3 workers.  Max 1 parts (seg0).
+         ->  Hash (actual rows=1 loops=1)
+               Buckets: 262144  Batches: 1  Memory Usage: 2049kB
+               ->  Partition Selector (selector id: $0) (actual rows=1 loops=1)
+                     ->  Broadcast Motion 3:3  (slice1; segments: 3) (actual rows=1 loops=1)
+                           ->  GroupAggregate (actual rows=1 loops=1)
+                                 Group Key: delete_from_pt_2.b
+                                 ->  Sort (actual rows=2 loops=1)
+                                       Sort Key: delete_from_pt_2.b
+                                       Sort Method:  quicksort  Memory: 75kB
+                                       Executor Memory: 178kB  Segments: 3  Max: 60kB (segment 0)
+                                       ->  Redistribute Motion 3:3  (slice2; segments: 3) (actual rows=2 loops=1)
+                                             Hash Key: delete_from_pt_2.b
+                                             ->  GroupAggregate (actual rows=1 loops=1)
+                                                   Group Key: delete_from_pt_2.b
+                                                   ->  Sort (actual rows=1 loops=1)
+                                                         Sort Key: delete_from_pt_2.b
+                                                         Sort Method:  quicksort  Memory: 75kB
+                                                         Executor Memory: 178kB  Segments: 3  Max: 60kB (segment 0)
+                                                         ->  Hash Join (actual rows=1 loops=1)
+                                                               Hash Cond: (delete_from_pt_2.b = t.a)
+                                                               Extra Text: (seg0)   Hash chain length 1.0 avg, 1 max, using 1 of 262144 buckets.
+                                                               ->  Dynamic Seq Scan on delete_from_pt delete_from_pt_2 (actual rows=3 loops=1)
+                                                                     Number of partitions to scan: 3 
+                                                                     Partitions scanned:  Avg 1.0 x 3 workers.  Max 1 parts (seg0).
+                                                               ->  Hash (actual rows=1 loops=1)
+                                                                     Buckets: 262144  Batches: 1  Memory Usage: 2049kB
+                                                                     ->  Partition Selector (selector id: $1) (actual rows=1 loops=1)
+                                                                           ->  Broadcast Motion 3:3  (slice3; segments: 3) (actual rows=1 loops=1)
+                                                                                 ->  Seq Scan on t (actual rows=1 loops=1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(37 rows)
+
+SELECT * FROM delete_from_pt order by a;
+ a  | b 
+----+---
+  2 | 2
+  3 | 3
+  4 | 4
+  5 | 5
+  6 | 0
+  8 | 2
+  9 | 3
+ 10 | 4
 (8 rows)
 
 RESET optimizer_trace_fallback;

--- a/src/test/regress/expected/direct_dispatch_optimizer.out
+++ b/src/test/regress/expected/direct_dispatch_optimizer.out
@@ -877,13 +877,13 @@ begin;
 -- orca does not handle direct dispatch for DELETE or UPDATE now
 -- also orca does not handle DELETE/UPDATE for partitioned tables now.
 explain (costs off) delete from t_hash_partition where r_regionkey=1;
-                    QUERY PLAN                    
---------------------------------------------------
+                          QUERY PLAN                           
+---------------------------------------------------------------
  Delete on t_hash_partition
-   Delete on t_hash_partition_1_prt_region1
-   ->  Seq Scan on t_hash_partition_1_prt_region1
+   ->  Dynamic Seq Scan on t_hash_partition t_hash_partition_1
+         Number of partitions to scan: 1 
          Filter: (r_regionkey = 1)
- Optimizer: Postgres query optimizer
+ Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
 
 delete from t_hash_partition where r_regionkey=1;
@@ -954,6 +954,7 @@ INFO:  Distributed transaction command 'Distributed Abort (No Prepared)' to ALL 
 begin;
 -- root & leaf policy mismatch, will not direct dispatch
 delete from t_hash_partition where r_regionkey=1;
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
 abort;
 INFO:  Distributed transaction command 'Distributed Abort (No Prepared)' to ALL contents: 0 1 2

--- a/src/test/regress/expected/partition_prune_optimizer.out
+++ b/src/test/regress/expected/partition_prune_optimizer.out
@@ -3424,13 +3424,13 @@ explain (costs off) update pp_arrpart set a = a where a = '{1}';
 (5 rows)
 
 explain (costs off) delete from pp_arrpart where a = '{1}';
-               QUERY PLAN               
-----------------------------------------
+                    QUERY PLAN                     
+---------------------------------------------------
  Delete on pp_arrpart
-   Delete on pp_arrpart1
-   ->  Seq Scan on pp_arrpart1
+   ->  Dynamic Seq Scan on pp_arrpart pp_arrpart_1
+         Number of partitions to scan: 1 
          Filter: (a = '{1}'::integer[])
- Optimizer: Postgres query optimizer
+ Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
 
 drop table pp_arrpart;
@@ -3597,13 +3597,13 @@ explain (costs off) update pp_lp set value = 10 where a = 1;
 (5 rows)
 
 explain (costs off) delete from pp_lp where a = 1;
-             QUERY PLAN              
--------------------------------------
+                QUERY PLAN                
+------------------------------------------
  Delete on pp_lp
-   Delete on pp_lp1
-   ->  Seq Scan on pp_lp1
+   ->  Dynamic Seq Scan on pp_lp pp_lp_1
+         Number of partitions to scan: 1 
          Filter: (a = 1)
- Optimizer: Postgres query optimizer
+ Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
 
 set enable_partition_pruning = off;
@@ -3632,17 +3632,14 @@ explain (costs off) update pp_lp set value = 10 where a = 1;
 (8 rows)
 
 explain (costs off) delete from pp_lp where a = 1;
-             QUERY PLAN              
--------------------------------------
+                QUERY PLAN                
+------------------------------------------
  Delete on pp_lp
-   Delete on pp_lp1
-   Delete on pp_lp2
-   ->  Seq Scan on pp_lp1
+   ->  Dynamic Seq Scan on pp_lp pp_lp_1
+         Number of partitions to scan: 1 
          Filter: (a = 1)
-   ->  Seq Scan on pp_lp2
-         Filter: (a = 1)
- Optimizer: Postgres query optimizer
-(8 rows)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(5 rows)
 
 set constraint_exclusion = 'off'; -- this should not affect the result.
 explain (costs off) select * from pp_lp where a = 1;
@@ -3669,17 +3666,14 @@ explain (costs off) update pp_lp set value = 10 where a = 1;
 (8 rows)
 
 explain (costs off) delete from pp_lp where a = 1;
-             QUERY PLAN              
--------------------------------------
+                QUERY PLAN                
+------------------------------------------
  Delete on pp_lp
-   Delete on pp_lp1
-   Delete on pp_lp2
-   ->  Seq Scan on pp_lp1
+   ->  Dynamic Seq Scan on pp_lp pp_lp_1
+         Number of partitions to scan: 1 
          Filter: (a = 1)
-   ->  Seq Scan on pp_lp2
-         Filter: (a = 1)
- Optimizer: Postgres query optimizer
-(8 rows)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(5 rows)
 
 drop table pp_lp;
 -- Ensure enable_partition_prune does not affect non-partitioned tables.

--- a/src/test/regress/expected/qp_dml_joins_optimizer.out
+++ b/src/test/regress/expected/qp_dml_joins_optimizer.out
@@ -2617,7 +2617,8 @@ SELECT COUNT(*) FROM dml_heap_pt_s;
 (1 row)
 
 DELETE FROM dml_heap_pt_s WHERE a = (SELECT dml_heap_pt_r.a FROM dml_heap_pt_r,dml_heap_pt_s WHERE dml_heap_pt_r.a = dml_heap_pt_s.a);
-ERROR:  more than one row returned by a subquery used as an expression
+ERROR:  one or more assertions failed  (seg1 10.138.0.30:7003 pid=706789)
+DETAIL:  Expected no more than one row to be returned by expression
 SELECT COUNT(*) FROM dml_heap_pt_s;
  count 
 -------

--- a/src/test/regress/sql/DML_over_joins.sql
+++ b/src/test/regress/sql/DML_over_joins.sql
@@ -1285,6 +1285,126 @@ update pg_class set reltuples = 100000 where oid='tab3'::regclass;
 explain (costs off) delete from tab1 using tab2, tab3 where tab1.a = tab2.a and tab1.b = tab3.b;
 
 -- ----------------------------------------------------------------------
+-- Test delete on partition table from join on another partition table
+-- ----------------------------------------------------------------------
+drop table if exists part_eq_dis_1;
+drop table if exists part_eq_dis_2;
+create table part_eq_dis_1 (a int4, b int4) partition by range (a) (start(1) end(20) every(1), default partition extra);
+create table part_eq_dis_2 (c int4, d int4) partition by range (c) (start(1) end(20) every(1), default partition extra);
+insert into part_eq_dis_1 select generate_series(1,40), generate_series(1,40);
+insert into part_eq_dis_2 select generate_series(1,40), generate_series(1,40);
+
+drop table if exists part_neq_dis_1;
+drop table if exists part_neq_dis_2;
+create table part_neq_dis_1 (a int4, b int4) partition by range (b) (start(1) end(20) every(1), default partition extra);
+create table part_neq_dis_2 (c int4, d int4) partition by range (d) (start(1) end(20) every(1), default partition extra);
+insert into part_neq_dis_1 select generate_series(1,40), generate_series(1,40);
+insert into part_neq_dis_2 select generate_series(1,40), generate_series(1,40);
+
+set optimizer_trace_fallback=on;
+
+-- T1 - distribution partitioned column, T2 - distributed partitioned column
+-- a) non-default partition
+delete from part_eq_dis_1 where a = (select c from part_eq_dis_2 where c=1);
+-- b) default partition
+delete from part_eq_dis_1 where a = (select c from part_eq_dis_2 where c=21);
+
+-- T1 - distribution partitioned column, T2 - non-distributed non-partitioned column
+-- a) non-default partition
+delete from part_eq_dis_1 where a = (select d from part_eq_dis_2 where c=2);
+-- b) default partition
+delete from part_eq_dis_1 where a = (select d from part_eq_dis_2 where c=22);
+
+-- T1 - distribution partitioned column, T2 - distributed non-partitioned column
+-- a) non-default partition
+delete from part_eq_dis_1 where a = (select c from part_neq_dis_2 where c=3);
+-- b) default partition
+delete from part_eq_dis_1 where a = (select c from part_neq_dis_2 where c=23);
+
+-- T1 - distribution partitioned column, T2 - non-distributed partitioned column
+-- a) non-default partition
+delete from part_eq_dis_1 where a = (select d from part_neq_dis_2 where c=4);
+-- b) default partition
+delete from part_eq_dis_1 where a = (select d from part_neq_dis_2 where c=24);
+
+-- T1 - non-distribution non-partitioned column, T2 - distributed partitioned column
+-- a) non-default partition
+delete from part_eq_dis_1 where b = (select c from part_eq_dis_2 where c=5);
+-- b) default partition
+delete from part_eq_dis_1 where b = (select c from part_eq_dis_2 where c=25);
+
+-- T1 - non-distribution non-partitioned column, T2 - non-distributed non-partitioned column
+-- a) non-default partition
+delete from part_eq_dis_1 where b = (select d from part_eq_dis_2 where c=6);
+-- b) default partition
+delete from part_eq_dis_1 where b = (select d from part_eq_dis_2 where c=26);
+
+-- T1 - non-distribution non-partitioned column, T2 - distributed non-partitioned column
+-- a) non-default partition
+delete from part_eq_dis_1 where b = (select c from part_neq_dis_2 where c=7);
+-- b) default partition
+delete from part_eq_dis_1 where b = (select c from part_neq_dis_2 where c=27);
+
+-- T1 - non-distribution non-partitioned column, T2 - non-distributed partitioned column
+-- a) non-default partition
+delete from part_eq_dis_1 where b = (select d from part_neq_dis_2 where c=8);
+-- b) default partition
+delete from part_eq_dis_1 where b = (select d from part_neq_dis_2 where c=28);
+
+-- T1 - distribution non-partitioned column, T2 - distributed partitioned column
+-- a) non-default partition
+delete from part_neq_dis_1 where a = (select c from part_eq_dis_2 where c=9);
+-- b) default partition
+delete from part_neq_dis_1 where a = (select c from part_eq_dis_2 where c=29);
+
+-- T1 - distribution non-partitioned column, T2 - non-distributed non-partitioned column
+-- a) non-default partition
+delete from part_neq_dis_1 where a = (select d from part_eq_dis_2 where c=10);
+-- b) default partition
+delete from part_neq_dis_1 where a = (select d from part_eq_dis_2 where c=30);
+
+-- T1 - distribution non-partitioned column, T2 - non-distributed partitioned column
+-- a) non-default partition
+delete from part_neq_dis_1 where a = (select d from part_neq_dis_2 where c=11);
+-- b) default partition
+delete from part_neq_dis_1 where a = (select d from part_neq_dis_2 where c=31);
+
+-- T1 - distribution non-partitioned column, T2 - distributed non-partitioned column
+-- a) non-default partition
+delete from part_neq_dis_1 where a = (select c from part_neq_dis_2 where c=12);
+-- b) default partition
+delete from part_neq_dis_1 where a = (select c from part_neq_dis_2 where c=32);
+
+-- T1 - non-distribution partitioned column, T2 - distributed partitioned column
+-- a) non-default partition
+delete from part_neq_dis_1 where b = (select c from part_eq_dis_2 where c=13);
+-- b) default partition
+delete from part_neq_dis_1 where b = (select c from part_eq_dis_2 where c=33);
+
+-- T1 - non-distribution partitioned column, T2 - non-distributed non-partitioned column
+-- a) non-default partition
+delete from part_neq_dis_1 where b = (select d from part_eq_dis_2 where c=14);
+-- b) default partition
+delete from part_neq_dis_1 where b = (select d from part_eq_dis_2 where c=34);
+
+-- T1 - non-distribution partitioned column, T2 - distributed non-partitioned column
+-- a) non-default partition
+delete from part_neq_dis_1 where b = (select d from part_neq_dis_2 where c=15);
+-- b) default partition
+delete from part_neq_dis_1 where b = (select d from part_neq_dis_2 where c=35);
+
+-- T1 - non-distribution partitioned column, T2 - non-distributed partitioned column
+-- a) non-default partition
+delete from part_neq_dis_1 where b = (select c from part_neq_dis_2 where c=16);
+-- b) default partition
+delete from part_neq_dis_1 where b = (select c from part_neq_dis_2 where c=36);
+
+select * from part_eq_dis_1;
+select * from part_neq_dis_1;
+
+reset optimizer_trace_fallback;
+
+-- ----------------------------------------------------------------------
 -- Test: teardown.sql
 -- ----------------------------------------------------------------------
 -- start_ignore

--- a/src/test/regress/sql/bfv_partition_plans.sql
+++ b/src/test/regress/sql/bfv_partition_plans.sql
@@ -1,6 +1,16 @@
 -- start_matchsubs
 -- m/((Mon|Tue|Wed|Thu|Fri|Sat|Sun) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (0[1-9]|[12][0-9]|3[01]) ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](.[0-9]+)? (?!0000)[0-9]{4}.*)+(['"])/
 -- s/((Mon|Tue|Wed|Thu|Fri|Sat|Sun) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (0[1-9]|[12][0-9]|3[01]) ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](.[0-9]+)? (?!0000)[0-9]{4}.*)+(['"])/xxx xx xx xx:xx:xx xxxx"/
+-- m/Memory Usage: \d+\w?B/
+-- s/Memory Usage: \d+\w?B/Memory Usage: ###B/
+-- m/Memory: \d+kB/
+-- s/Memory: \d+kB/Memory: ###kB/
+-- m/Buckets: \d+/
+-- s/Buckets: \d+/Buckets: ###/
+-- m/Batches: \d+/
+-- s/Batches: \d+/Batches: ###/
+-- m/using \d+ of \d+ buckets/
+-- s/using \d+ of \d+ buckets/using ## of ### buckets/
 -- end_matchsubs
 
 create schema bfv_partition_plans;
@@ -595,6 +605,18 @@ EXPLAIN (COSTS OFF) DELETE FROM delete_from_indexed_pt WHERE b=1;
 DELETE FROM delete_from_indexed_pt WHERE b=1;
 
 SELECT * FROM delete_from_indexed_pt;
+
+-- Validate that basic DELETE on partition table using DPE functions properly
+CREATE TABLE delete_from_pt (a int, b int) PARTITION BY RANGE(b) (START (0) END (7) EVERY (3));
+CREATE TABLE t(a int);
+
+INSERT INTO delete_from_pt SELECT i, i%6 FROM generate_series(1, 10)i;
+INSERT INTO t VALUES (1);
+
+ANALYZE delete_from_pt, t;
+EXPLAIN (COSTS OFF, TIMING OFF, SUMMARY OFF, ANALYZE) DELETE FROM delete_from_pt WHERE b IN (SELECT b FROM delete_from_pt, t WHERE t.a=delete_from_pt.b);
+
+SELECT * FROM delete_from_pt order by a;
 
 RESET optimizer_trace_fallback;
 

--- a/src/test/regress/sql/bfv_partition_plans.sql
+++ b/src/test/regress/sql/bfv_partition_plans.sql
@@ -583,6 +583,21 @@ select count_operator('delete from mpp6247_foo using mpp6247_bar where mpp6247_f
 drop table mpp6247_bar;
 drop table mpp6247_foo;
 
+-- Validate that basic DELETE on partition table with index functions properly
+SET optimizer_trace_fallback=on;
+
+CREATE TABLE delete_from_indexed_pt (a int, b int) PARTITION BY RANGE(b) (START (0) END (7) EVERY (3));
+CREATE INDEX index_delete_from_indexed_pt ON delete_from_indexed_pt USING bitmap(b);
+
+INSERT INTO delete_from_indexed_pt SELECT i, i%6 FROM generate_series(1, 10)i;
+
+EXPLAIN (COSTS OFF) DELETE FROM delete_from_indexed_pt WHERE b=1;
+DELETE FROM delete_from_indexed_pt WHERE b=1;
+
+SELECT * FROM delete_from_indexed_pt;
+
+RESET optimizer_trace_fallback;
+
 -- CLEANUP
 -- start_ignore
 drop schema if exists bfv_partition_plans cascade;


### PR DESCRIPTION
During Postgres 12 merge, DELETE on partitioned tables was disabled due
to changes in the partition selection framework. There is no longer a
need for CPhysicalPartitionSelectorDML (commit https://github.com/greenplum-db/gpdb/commit/6b9b9a94e47699703cc35b8cafd3aba6e2cf0ef2 removed it).
Now the required partition information is found in the plan node itself
during execution.

After this commit, ORCA is able to handle DELETE on partition table:

  ```sql
  CREATE TABLE pt (a int, b int) PARTITION BY RANGE(b) (START (0) END (7) EVERY (3));
  INSERT INTO pt SELECT i, i%6 FROM generate_series(1, 100)i;

  DELETE FROM pt WHERE b=1;
  ```

GP6 plan:
  ```
                                 QUERY PLAN
  ------------------------------------------------------------------------
   Delete
     ->  Result
           ->  Partition Selector for pt
                 ->  Sequence
                       ->  Partition Selector for pt (dynamic scan id: 1)
                             Partitions selected: 1 (out of 3)
                       ->  Dynamic Seq Scan on pt (dynamic scan id: 1)
                             Filter: (b = 1)
   Optimizer: Pivotal Optimizer (GPORCA)
  ```

GP7 plan:
  ```
                  QUERY PLAN
  ------------------------------------------
   Delete on pt
     ->  Dynamic Seq Scan on pt pt_1
           Number of partitions to scan: 1
           Filter: (b = 1)
   Optimizer: Pivotal Optimizer (GPORCA)
  ```

And the GP7 plan node looks something like:
  ```
  {PLANNEDSTMT
  :commandType 4
  :planGen 1
  ...
  :planTree
     {MODIFYTABLE
     ...
     :plans (
        {DYNAMICSEQSCAN
        :scanrelid 2
        :partOids (o 286823)
        ...
        }
     )
     ...
     }
  }
  ```
