### PR TITLE
[6X] gpinitsystem is not working with debug option (#13942)

### DIFF
--- a/gpMgmt/bin/lib/gp_bash_functions.sh
+++ b/gpMgmt/bin/lib/gp_bash_functions.sh
@@ -250,6 +250,9 @@ LOG_MSG () {
 # Limitation: If the token used for separating command output from banner appears in the begining
 # of the line in command output/banner output, in that case only partial command output will be returned
 REMOTE_EXECUTE_AND_GET_OUTPUT () {
+  INITIAL_DEBUG_LEVEL=$DEBUG_LEVEL
+  DEBUG_LEVEL=0
+
   LOG_MSG "[INFO]:-Start Function $FUNCNAME"
   HOST="$1"
   CMD="echo 'GP_DELIMITER_FOR_IGNORING_BASH_BANNER';$2"
@@ -262,6 +265,8 @@ REMOTE_EXECUTE_AND_GET_OUTPUT () {
      LOG_MSG "[INFO]:-Completed $TRUSTED_SHELL $HOST $CMD"
   fi
   LOG_MSG "[INFO]:-End Function $FUNCNAME"
+
+  DEBUG_LEVEL=$INITIAL_DEBUG_LEVEL
   #Return output
   echo "$OUTPUT"
 }

--- a/gpMgmt/test/behave/mgmt_utils/gpinitsystem.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpinitsystem.feature
@@ -326,3 +326,10 @@ Feature: gpinitsystem tests
         And gpinitsystem should return a return code of 0
         Then gpstate should return a return code of 0
         And check segment conf: postgresql.conf
+
+    Scenario: gpinitsystem creates a cluster successfully when run with -D option
+        Given create demo cluster config
+        When the user runs command "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile -D"
+        Then gpinitsystem should return a return code of 0
+        And gpinitsystem should not print "Start Function REMOTE_EXECUTE_AND_GET_OUTPUT" to stdout
+        And gpinitsystem should not print "End Function REMOTE_EXECUTE_AND_GET_OUTPUT" to stdout


### PR DESCRIPTION
Issue:
gpinitsystem is not working with debug option -D and throwing errors as below:
20220715:11:44:09:048391 gpinitsystem:-[INFO]:-End Function PING_HOST
/usr/local/gpdb6/bin/lib/gp_bash_functions.sh: line 1051: [: 2>/dev/null: integer expression expected
/usr/local/gpdb6/bin/lib/gp_bash_functions.sh: line 1051: [: REMOTE_EXECUTE_AND_GET_OUTPUT: integer expression expected
/usr/local/gpdb6/bin/lib/gp_bash_functions.sh: line 1055: [: too many arguments
/usr/local/gpdb6/bin/lib/gp_bash_functions.sh: line 1060: [: too many arguments
/usr/local/gpdb6/bin/lib/gp_bash_functions.sh: line 1066: [: too many arguments
/usr/local/gpdb6/bin/lib/gp_bash_functions.sh: line 1079: [: too many arguments
20220715:11:44:09:048391 gpinitsystem:-[INFO]:-End Function GET_PG_PID_ACTIVE

Cause:
When we run gpinitsystem with debug option, all the "LOG_MSG" statements are logging(echoing) messages to both STDOUT(console) and log file (As per LOG_MSG function definition present in gpdb/bin/lib/gp_bash_functions.sh). Causing "REMOTE_EXECUTE_AND_GET_OUTPUT" function to echo(print) mutliple messages but only one string is expected to be returned from this function, so the error
When we run gpinitsystem without debug option, there is no issue because in that case "LOG_MSG" will log messages to log file only.

Fix:
Save the initial DEBUG_LEVEL and turn off the debugging at start of this function and then reset DEBUG_LEVEL to INITIAL_DEBUG_LEVEL at end of this function, which will cause all the LOG_MSG statements to log messages only in log file, not echo on STDOUT.

Added behave scenario for the above changes

cherry picked from commit 5fcb249717a24fd6aca1c71ffa2148807464e390

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
