### PR TITLE
Resolve GPDB_12_MERGE_FIXME in describe.c about legacy partitioning.

### DIFF
--- a/src/bin/psql/describe.c
+++ b/src/bin/psql/describe.c
@@ -39,6 +39,7 @@ static bool describeOneTableDetails(const char *schemaname,
 									bool verbose);
 static void add_external_table_footer(printTableContent *const cont, const char *oid);
 static void add_distributed_by_footer(printTableContent *const cont, const char *oid);
+static void add_partition_by_footer(printTableContent *const cont, const char *oid);
 static void add_tablespace_footer(printTableContent *const cont, char relkind,
 								  Oid tablespace, const bool newline);
 static void add_role_attribute(PQExpBuffer buf, const char *const str);
@@ -3650,12 +3651,9 @@ describeOneTableDetails(const char *schemaname,
 		/* mpp addition start: dump distributed by clause */
 		add_distributed_by_footer(&cont, oid);
 
-		/* GPDB_12_MERGE_FIXME: legacy partitioning. Still needed for old server versions? */
-#if 0
-		/* print 'partition by' clause */
-		if (tuples > 0)
+		/* Still needed by legacy partitioning to print old version server's 'partition by' clause */
+		if (!isGPDB7000OrLater() && tuples > 0)
 			add_partition_by_footer(&cont, oid);
-#endif
 
 		/* Tablespace info */
 		add_tablespace_footer(&cont, tableinfo.relkind, tableinfo.tablespace,
@@ -4141,8 +4139,6 @@ add_distributed_by_footer(printTableContent *const cont, const char *oid)
 /*
  * Add a 'partition by' description to the footer.
  */
-/* GPDB_12_MERGE_FIXME: legacy partitioning. Still needed for old server versions? */
-#if 0
 static void
 add_partition_by_footer(printTableContent *const cont, const char *oid)
 {
@@ -4221,7 +4217,6 @@ add_partition_by_footer(printTableContent *const cont, const char *oid)
 	termPQExpBuffer(&buf);
 	return;		/* success */
 }
-#endif
 
 /*
  * Add a tablespace description to a footer.  If 'newline' is true, it is added


### PR DESCRIPTION
add_partition_by_footer is still needed by legacy partitioning to print
old version server's 'partition by' clause.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
