### PR TITLE
[7X] Add a GUC to control the output of suboverflow transaction sql statement

### DIFF
--- a/src/backend/access/transam/varsup.c
+++ b/src/backend/access/transam/varsup.c
@@ -30,7 +30,7 @@
 
 #include "access/distributedlog.h"
 #include "cdb/cdbvars.h"
-
+#include "tcop/tcopprot.h"
 
 /* Number of OIDs to prefetch (preallocate) per XLOG write */
 #define VAR_OID_PREFETCH		8192
@@ -279,7 +279,11 @@ GetNewTransactionId(bool isSubXact)
 			MyPgXact->nxids = nxids + 1;
 		}
 		else
+		{
 			MyPgXact->overflowed = true;
+			ereportif (gp_log_suboverflow_statement, LOG,
+						(errmsg("Statement caused suboverflow: %s", debug_query_string)));
+		}
 	}
 
 	LWLockRelease(XidGenLock);

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -156,6 +156,8 @@ bool		gp_create_table_random_default_distribution = true;
 bool		gp_allow_non_uniform_partitioning_ddl = true;
 int			dtx_phase2_retry_second = 0;
 
+bool gp_log_suboverflow_statement = false;
+
 bool		log_dispatch_stats = false;
 
 int			explain_memory_verbosity = 0;
@@ -2922,6 +2924,15 @@ struct config_bool ConfigureNamesBool_gp[] =
 		 NULL, NULL, NULL
 	},
 
+	{
+		{"gp_log_suboverflow_statement", PGC_SUSET, LOGGING_WHAT,
+		 gettext_noop("Enable logging of statements that cause subtransaction overflow."),
+		 NULL,
+		 },
+		 &gp_log_suboverflow_statement,
+		 false,
+		 NULL, NULL, NULL
+	},
 
 	/* End-of-list marker */
 	{

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -313,7 +313,7 @@ extern bool Debug_resource_group;
 extern bool gp_create_table_random_default_distribution;
 extern bool gp_allow_non_uniform_partitioning_ddl;
 extern int  dtx_phase2_retry_second;
-
+extern bool gp_log_suboverflow_statement;
 /* WAL replication debug gucs */
 extern bool debug_walrepl_snd;
 extern bool debug_walrepl_syncrep;

--- a/src/include/utils/sync_guc_name.h
+++ b/src/include/utils/sync_guc_name.h
@@ -48,6 +48,7 @@
 		"gp_log_resgroup_memory",
 		"gp_log_resqueue_memory",
 		"gp_log_stack_trace_lines",
+		"gp_log_suboverflow_statement",
 		"gp_max_packet_size",
 		"gp_max_slices",
 		"gp_motion_slice_noop",

--- a/src/test/regress/expected/subtrx_overflow.out
+++ b/src/test/regress/expected/subtrx_overflow.out
@@ -60,6 +60,7 @@ BEGIN
 END;
 $$
 LANGUAGE plpgsql;
+set gp_log_suboverflow_statement = on;
 BEGIN;
 SELECT transaction_test0();
  transaction_test0 
@@ -76,6 +77,16 @@ ORDER BY segid;
      0 |                 1
      1 |                 1
      2 |                 1
+(3 rows)
+
+SELECT DISTINCT logsegment, logmessage FROM gp_toolkit.gp_log_system
+	WHERE logdebug = 'INSERT INTO t_1352_1 VALUES(i)'
+	ORDER BY logsegment, logmessage;
+ logsegment |                          logmessage                          
+------------+--------------------------------------------------------------
+ seg0       | Statement caused suboverflow: INSERT INTO t_1352_1 VALUES(i)
+ seg1       | Statement caused suboverflow: INSERT INTO t_1352_1 VALUES(i)
+ seg2       | Statement caused suboverflow: INSERT INTO t_1352_1 VALUES(i)
 (3 rows)
 
 COMMIT;
@@ -97,6 +108,16 @@ ORDER BY segid;
      2 |                 1
 (3 rows)
 
+SELECT DISTINCT logsegment, logmessage FROM gp_toolkit.gp_log_system
+	WHERE logdebug = 'INSERT INTO t_1352_2 VALUES(i)'
+	ORDER BY logsegment, logmessage;
+ logsegment |                          logmessage                          
+------------+--------------------------------------------------------------
+ seg0       | Statement caused suboverflow: INSERT INTO t_1352_2 VALUES(i)
+ seg1       | Statement caused suboverflow: INSERT INTO t_1352_2 VALUES(i)
+ seg2       | Statement caused suboverflow: INSERT INTO t_1352_2 VALUES(i)
+(3 rows)
+
 COMMIT;
 BEGIN;
 SELECT transaction_test2();
@@ -115,6 +136,17 @@ ORDER BY segid;
      0 |                 1
      1 |                 1
      2 |                 1
+(4 rows)
+
+SELECT DISTINCT logsegment, logmessage FROM gp_toolkit.gp_log_system
+	WHERE logmessage = 'Statement caused suboverflow: SELECT transaction_test2();'
+	ORDER BY logsegment;
+ logsegment |                        logmessage                         
+------------+-----------------------------------------------------------
+ seg-1      | Statement caused suboverflow: SELECT transaction_test2();
+ seg0       | Statement caused suboverflow: SELECT transaction_test2();
+ seg1       | Statement caused suboverflow: SELECT transaction_test2();
+ seg2       | Statement caused suboverflow: SELECT transaction_test2();
 (4 rows)
 
 COMMIT;
@@ -139,3 +171,4 @@ ORDER BY segid;
 (3 rows)
 
 COMMIT;
+set gp_log_suboverflow_statement = off;

--- a/src/test/regress/sql/subtrx_overflow.sql
+++ b/src/test/regress/sql/subtrx_overflow.sql
@@ -61,12 +61,17 @@ END;
 $$
 LANGUAGE plpgsql;
 
+set gp_log_suboverflow_statement = on;
+
 BEGIN;
 SELECT transaction_test0();
 SELECT segid, count(*) AS num_suboverflowed FROM gp_suboverflowed_backend
 WHERE array_length(pids, 1) > 0
 GROUP BY segid
 ORDER BY segid;
+SELECT DISTINCT logsegment, logmessage FROM gp_toolkit.gp_log_system
+	WHERE logdebug = 'INSERT INTO t_1352_1 VALUES(i)'
+	ORDER BY logsegment, logmessage;
 COMMIT;
 
 BEGIN;
@@ -75,6 +80,9 @@ SELECT segid, count(*) AS num_suboverflowed FROM gp_suboverflowed_backend
 WHERE array_length(pids, 1) > 0
 GROUP BY segid
 ORDER BY segid;
+SELECT DISTINCT logsegment, logmessage FROM gp_toolkit.gp_log_system
+	WHERE logdebug = 'INSERT INTO t_1352_2 VALUES(i)'
+	ORDER BY logsegment, logmessage;
 COMMIT;
 
 BEGIN;
@@ -83,6 +91,9 @@ SELECT segid, count(*) AS num_suboverflowed FROM gp_suboverflowed_backend
 WHERE array_length(pids, 1) > 0
 GROUP BY segid
 ORDER BY segid;
+SELECT DISTINCT logsegment, logmessage FROM gp_toolkit.gp_log_system
+	WHERE logmessage = 'Statement caused suboverflow: SELECT transaction_test2();'
+	ORDER BY logsegment;
 COMMIT;
 
 BEGIN;
@@ -94,3 +105,5 @@ SELECT segid, count(*) AS num_suboverflowed FROM
 GROUP BY segid
 ORDER BY segid;
 COMMIT;
+
+set gp_log_suboverflow_statement = off;


### PR DESCRIPTION
We might want to also consider adding a log message to print the query string
that caused the overflow. This is important as only 1 statement out of thousands
executed in a backend may trigger the overflow, or the backend can come out of
the overflow state before it is inspected with our view/UDF. Logging the
statement will ensure that customers can pinpoint the offending statements.