### PR TITLE
ADBDEV-2982: SIGPIPE during ending not exhausted external table scan

### DIFF
--- a/src/backend/executor/execUtils.c
+++ b/src/backend/executor/execUtils.c
@@ -1647,7 +1647,8 @@ void mppExecutorFinishup(QueryDesc *queryDesc)
 	 * the dispatch results in order to tell we no longer
 	 * need any more tuples.
 	 */
-	if (Gp_role == GP_ROLE_DISPATCH && !estate->es_got_eos)
+	if (Gp_role == GP_ROLE_DISPATCH && !estate->es_got_eos &&
+		!(estate->es_top_eflags & EXEC_FLAG_EXPLAIN_ONLY))
 	{
 		ExecSquelchNode(queryDesc->planstate);
 	}

--- a/src/backend/executor/execUtils.c
+++ b/src/backend/executor/execUtils.c
@@ -1642,6 +1642,17 @@ void mppExecutorFinishup(QueryDesc *queryDesc)
 	}
 
 	/*
+	 * If we are finishing a query before all the tuples of the query
+	 * plan were fetched we must call ExecSquelchNode before checking
+	 * the dispatch results in order to tell we no longer
+	 * need any more tuples.
+	 */
+	if (Gp_role == GP_ROLE_DISPATCH && !estate->es_got_eos)
+	{
+		ExecSquelchNode(queryDesc->planstate);
+	}
+
+	/*
 	 * If QD, wait for QEs to finish and check their results.
 	 */
 	if (estate->dispatcherState && estate->dispatcherState->primaryResults)
@@ -1650,17 +1661,6 @@ void mppExecutorFinishup(QueryDesc *queryDesc)
 		CdbDispatcherState *ds = estate->dispatcherState;
 		DispatchWaitMode waitMode = DISPATCH_WAIT_NONE;
 		ErrorData *qeError = NULL;
-
-		/*
-		 * If we are finishing a query before all the tuples of the query
-		 * plan were fetched we must call ExecSquelchNode before checking
-		 * the dispatch results in order to tell the nodes below we no longer
-		 * need any more tuples.
-		 */
-		if (!estate->es_got_eos)
-		{
-			ExecSquelchNode(queryDesc->planstate);
-		}
 
 		/*
 		 * Wait for completion of all QEs.  We send a "graceful" query

--- a/src/test/regress/input/external_table.source
+++ b/src/test/regress/input/external_table.source
@@ -86,6 +86,7 @@ DROP EXTERNAL TABLE IF EXISTS exttab_udfs_1;
 DROP EXTERNAL TABLE IF EXISTS exttab_udfs_2;
 DROP EXTERNAL TABLE IF EXISTS exttab_views_3;
 DROP EXTERNAL WEB TABLE IF EXISTS table_env;
+DROP EXTERNAL WEB TABLE IF EXISTS table_master;
 DROP EXTERNAL WEB TABLE IF EXISTS table_qry;
 
 DROP VIEW IF EXISTS exttab_views_3;
@@ -116,6 +117,16 @@ CREATE EXTERNAL WEB TABLE table_env (val TEXT)
   FORMAT 'TEXT' (ESCAPE 'OFF');
 SELECT * FROM table_env WHERE val LIKE 'GP_QUERY%' ORDER BY val ASC;
 SELECT * FROM table_env WHERE val LIKE 'GP_QUERY%\%' ESCAPE '&' ORDER BY val ASC;
+
+-- ensure squelching on master
+CREATE EXTERNAL WEB TABLE table_master (val TEXT)
+  EXECUTE E'cat @abs_srcdir@/data/lineitem.csv' ON MASTER
+  FORMAT 'TEXT' (ESCAPE 'OFF');
+BEGIN;
+DECLARE _psql_cursor NO SCROLL CURSOR FOR SELECT 1 FROM table_master;
+FETCH FORWARD 1 FROM _psql_cursor;
+CLOSE _psql_cursor;
+COMMIT;
 
 -- echo will behave differently on different platforms, force to use bash with -E option
 CREATE EXTERNAL WEB TABLE table_qry (val TEXT)

--- a/src/test/regress/output/external_table.source
+++ b/src/test/regress/output/external_table.source
@@ -143,6 +143,20 @@ SELECT * FROM table_env WHERE val LIKE 'GP_QUERY%\%' ESCAPE '&' ORDER BY val ASC
  GP_QUERY_STRING=SELECT * FROM table_env WHERE val LIKE 'GP_QUERY%\%' ESCAPE '&' ORDER BY val ASC;
 (1 row)
 
+-- ensure squelching on master
+CREATE EXTERNAL WEB TABLE table_master (val TEXT)
+  EXECUTE E'cat @abs_srcdir@/data/lineitem.csv' ON MASTER
+  FORMAT 'TEXT' (ESCAPE 'OFF');
+BEGIN;
+DECLARE _psql_cursor NO SCROLL CURSOR FOR SELECT 1 FROM table_master;
+FETCH FORWARD 1 FROM _psql_cursor;
+ ?column? 
+----------
+        1
+(1 row)
+
+CLOSE _psql_cursor;
+COMMIT;
 -- echo will behave differently on different platforms, force to use bash with -E option
 CREATE EXTERNAL WEB TABLE table_qry (val TEXT)
   EXECUTE E'/usr/bin/env bash -c ''echo -E "$GP_QUERY_STRING"''' ON SEGMENT 0


### PR DESCRIPTION
Executing a query that doesn't fetch all tuples from external scan that execute
program on coordinator leads to the next error:

ERROR:  external table table_master command ended with SHELL TERMINATED by
signal SIGPIPE (13)
DETAIL:  Command: execute:(echo foo; sleep 1; echo bar)

There are several cases when gpdb ends unfinished plan: extended protocol,
cursors. Greenplum communicate with shell command by pipe, it closes pipe while
shell command steel sends results. And SIGPIPE happens here. In such cases
if external web table is executed on segments, then it uses squelching
mechanics, that provides a separate way to handle unfinished yet plan nodes and
simply ignore SIGPIPE for externalScan. But the squelching doesn't execute
for master-only plans on coordinator. So the solution is allowing squelching
on master for such plans.