### PR TITLE
Added data type links to Greenplum 6X pages

### DIFF
--- a/gpdb-doc/markdown/admin_guide/ddl/ddl-table.html.md
+++ b/gpdb-doc/markdown/admin_guide/ddl/ddl-table.html.md
@@ -4,11 +4,11 @@ title: Creating and Managing Tables
 
 Greenplum Database tables are similar to tables in any relational database, except that table rows are distributed across the different segments in the system. When you create a table, you specify the table's distribution policy.
 
-## <a id="topic26"></a>Creating a Table 
+## <a id="topic26"></a>Creating a Table
 
 The `CREATE TABLE` command creates a table and defines its structure. When you create a table, you define:
 
--   The columns of the table and their associated data types. See [Choosing Column Data Types](#topic27).
+-   The columns of the table and their associated [data types](https://docs.vmware.com/en/VMware-Tanzu-Greenplum/6/greenplum-database/GUID-ref_guide-data_types.html?hWord=N4IghgNiBcIHZgC4EsBuBTABAEyWTiAngA7oDOIAvkA). See [Choosing Column Data Types](#topic27).
 -   Any table or column constraints to limit the data that a column or table can contain. See [Setting Table and Column Constraints](#topic28).
 -   The distribution policy of the table, which determines how Greenplum Database divides data across the segments. See [Choosing the Table Distribution Policy](#topic34).
 -   The way the table is stored on disk. See [Choosing the Table Storage Model](ddl-storage.html).

--- a/gpdb-doc/markdown/admin_guide/query/topics/json-data.html.md
+++ b/gpdb-doc/markdown/admin_guide/query/topics/json-data.html.md
@@ -2,7 +2,7 @@
 title: Working with JSON Data 
 ---
 
-Greenplum Database supports the `json` and `jsonb` data types that store JSON \(JavaScript Object Notation\) data.
+Greenplum Database supports the `json` and `jsonb` [data types](https://docs.vmware.com/en/VMware-Tanzu-Greenplum/6/greenplum-database/GUID-ref_guide-data_types.html?hWord=N4IghgNiBcIHZgC4EsBuBTABAEyWTiAngA7oDOIAvkA) that store JSON \(JavaScript Object Notation\) data.
 
 Greenplum Database supports JSON as specified in the [RFC 7159](https://tools.ietf.org/html/rfc7159) document and enforces data validity according to the JSON rules. There are also JSON-specific functions and operators available for the `json` and `jsonb` data types. See [JSON Functions and Operators](#topic_gn4_x3w_mq).
 

--- a/gpdb-doc/markdown/analytics/overview.html.md
+++ b/gpdb-doc/markdown/analytics/overview.html.md
@@ -41,7 +41,7 @@ Greenplum Database advanced analytics can be used to address a wide variety of p
 
 The Greenplum analytics capabilities allow you to:
 
--   Analyze a multitude of data types – structured, text, geospatial, and graph – in a single environment, which can scale to petabytes and run algorithms designed for parallelism.
+-   Analyze a multitude of [data types](https://docs.vmware.com/en/VMware-Tanzu-Greenplum/6/greenplum-database/GUID-ref_guide-data_types.html?hWord=N4IghgNiBcIHZgC4EsBuBTABAEyWTiAngA7oDOIAvkA) – structured, text, geospatial, and graph – in a single environment, which can scale to petabytes and run algorithms designed for parallelism.
 -   Leverage existing SQL knowledge: Tanzu Greenplum can run dozens of statistical, machine learning, and graph methods, via SQL.
 -   Train more models in less time by taking advantage of the parallelism in the MPP architecture and in-database analytics.
 -   Access the data where it lives, therefore integrate data and analytics in one place. Tanzu Greenplum is infrastructure-agnostic and runs on bare metal, private cloud, and public cloud deployments.

--- a/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_TYPE.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_TYPE.html.md
@@ -2,7 +2,7 @@
 title: CREATE TYPE 
 ---
 
-Defines a new data type.
+Defines a new [data type](https://docs.vmware.com/en/VMware-Tanzu-Greenplum/6/greenplum-database/GUID-ref_guide-data_types.html?hWord=N4IghgNiBcIHZgC4EsBuBTABAEyWTiAngA7oDOIAvkA).
 
 ## <a id="section2"></a>Synopsis 
 


### PR DESCRIPTION
Added links to "data type" mentions in four Greenplum 6X topics. 
Links are to the Greenplum Reference Guide "Data Types" page (ref_guide-data_types.html)

- "Creating and Managing Tables" (admin_guide-ddl-ddl-table.html)
- "Overview of Greenplum Database Integrated Analytics" (analytics-overview.html)
- "Working with JSON Data" (admin_guide-query-topics-json-data.html)
- "Create Type" (ref_guide-sql_commands-CREATE_TYPE.html)