### PR TITLE
docs - new optimizer_enable_replicated_table guc

### DIFF
--- a/gpdb-doc/markdown/ref_guide/config_params/guc-list.html.md
+++ b/gpdb-doc/markdown/ref_guide/config_params/guc-list.html.md
@@ -2140,7 +2140,7 @@ For information about GPORCA, see [About GPORCA](../../admin_guide/query/topics/
 
 When GPORCA is enabled \(the default\), this parameter controls GPORCA's behavior when it encounters DML operations on a replicated table.
 
-The default value is `on`, GPORCA attempts to plan and execute operations on a replicated tables. When `off`, GPORCA immediately falls back to the Postgres Planner when it detects replicated table operations.
+The default value is `on`, GPORCA attempts to plan and execute operations on replicated tables. When `off`, GPORCA immediately falls back to the Postgres Planner when it detects replicated table operations.
 
 The parameter can be set for a database system, an individual database, or a session or query.
 

--- a/gpdb-doc/markdown/ref_guide/config_params/guc-list.html.md
+++ b/gpdb-doc/markdown/ref_guide/config_params/guc-list.html.md
@@ -2136,6 +2136,20 @@ For information about GPORCA, see [About GPORCA](../../admin_guide/query/topics/
 |-----------|-------|-------------------|
 |Boolean|off|master, session, reload|
 
+## <a id="optimizer_enable_replicated_table"></a>optimizer\_enable\_replicated\_table 
+
+When GPORCA is enabled \(the default\), this parameter controls GPORCA's behavior when it encounters DML operations on a distributed replicated table.
+
+The default value is `on`, GPORCA attempts to plan and execute operations on a distributed replicated table. When `off`, GPORCA immediately falls back to the Postgres Planner when it detects distributed replicated table operations.
+
+The parameter can be set for a database system, an individual database, or a session or query.
+
+For information about GPORCA, see [About GPORCA](../../admin_guide/query/topics/query-piv-optimizer.html) in the *Greenplum Database Administrator Guide*.
+
+|Value Range|Default|Set Classifications|
+|-----------|-------|-------------------|
+|Boolean|on|master, session, reload|
+
 ## <a id="optimizer_force_agg_skew_avoidance"></a>optimizer\_force\_agg\_skew\_avoidance 
 
 When GPORCA is enabled \(the default\), this parameter affects the query plan alternatives that GPORCA considers when 3 stage aggregate plans are generated. When the value is `true`, the default, GPORCA considers only 3 stage aggregate plans where the intermediate aggregation uses the `GROUP BY` and `DISTINCT` columns for distribution to reduce the effects of processing skew.

--- a/gpdb-doc/markdown/ref_guide/config_params/guc-list.html.md
+++ b/gpdb-doc/markdown/ref_guide/config_params/guc-list.html.md
@@ -2138,9 +2138,9 @@ For information about GPORCA, see [About GPORCA](../../admin_guide/query/topics/
 
 ## <a id="optimizer_enable_replicated_table"></a>optimizer\_enable\_replicated\_table 
 
-When GPORCA is enabled \(the default\), this parameter controls GPORCA's behavior when it encounters DML operations on a distributed replicated table.
+When GPORCA is enabled \(the default\), this parameter controls GPORCA's behavior when it encounters DML operations on a replicated table.
 
-The default value is `on`, GPORCA attempts to plan and execute operations on a distributed replicated table. When `off`, GPORCA immediately falls back to the Postgres Planner when it detects distributed replicated table operations.
+The default value is `on`, GPORCA attempts to plan and execute operations on a replicated tables. When `off`, GPORCA immediately falls back to the Postgres Planner when it detects replicated table operations.
 
 The parameter can be set for a database system, an individual database, or a session or query.
 

--- a/gpdb-doc/markdown/ref_guide/config_params/guc_category-list.html.md
+++ b/gpdb-doc/markdown/ref_guide/config_params/guc_category-list.html.md
@@ -112,6 +112,7 @@ These parameters control the usage of GPORCA by Greenplum Database. For informat
 - [optimizer_enable_indexonlyscan](guc-list.html#optimizer_enable_indexonlyscan)
 - [optimizer_enable_master_only_queries](guc-list.html#optimizer_enable_master_only_queries)
 - [optimizer_enable_multiple_distinct_aggs](guc-list.html#optimizer_enable_multiple_distinct_aggs)
+- [optimizer_enable_replicated_table](guc-list.html#optimizer_enable_replicated_table)
 - [optimizer_force_agg_skew_avoidance](guc-list.html#optimizer_force_agg_skew_avoidance)
 - [optimizer_force_comprehensive_join_implementation](guc-list.html#optimizer_force_comprehensive_join_implementation)
 - [optimizer_force_multistage_agg](guc-list.html#optimizer_force_multistage_agg)


### PR DESCRIPTION
docs for https://github.com/greenplum-db/gpdb/pull/13763 and https://github.com/greenplum-db/gpdb/pull/13764.  will be backported to 6X_STABLE.
