### PR TITLE
[6X backport] Update gp_switch_wal() to include pg_walfile_name() output

### DIFF
--- a/gpcontrib/gp_pitr/gp_pitr--1.0--1.1.sql
+++ b/gpcontrib/gp_pitr/gp_pitr--1.0--1.1.sql
@@ -4,33 +4,15 @@
 \echo Use "ALTER EXTENSION gp_pitr UPDATE TO '1.1'" to load this file. \quit
 
 -- pg_switch_xlog wrapper functions to switch WAL segment files on Greenplum cluster-wide
-CREATE FUNCTION gp_switch_wal_on_all_segments (OUT gp_segment_id int, OUT pg_switch_wal pg_lsn)
-    RETURNS SETOF RECORD AS
-$$
-DECLARE
-seg_id int;
-BEGIN
-EXECUTE 'SELECT pg_catalog.gp_execution_segment()' INTO seg_id;
--- check if execute in entrydb QE to prevent giving wrong results
-IF seg_id = -1 THEN
-    RAISE EXCEPTION 'Cannot execute in entrydb, this query is not currently supported by GPDB.';
-END IF;
-RETURN QUERY SELECT pg_catalog.gp_execution_segment() AS gp_segment_id, * FROM pg_catalog.pg_switch_xlog();
-END;
-$$ LANGUAGE plpgsql EXECUTE ON ALL SEGMENTS;
+CREATE FUNCTION gp_switch_wal(
+    OUT gp_segment_id smallint, OUT pg_switch_wal pg_lsn, OUT pg_walfile_name text
+)
+    RETURNS SETOF record
+AS '$libdir/gp_pitr', 'gp_switch_wal'
+LANGUAGE C VOLATILE EXECUTE ON MASTER;
 
-CREATE FUNCTION gp_switch_wal (OUT gp_segment_id int, OUT pg_switch_wal pg_lsn)
-    RETURNS SETOF RECORD
-AS
-  'SELECT * FROM @extschema@.gp_switch_wal_on_all_segments()
-   UNION ALL
-   SELECT pg_catalog.gp_execution_segment() AS gp_segment_id, * FROM pg_catalog.pg_switch_xlog()'
-LANGUAGE SQL EXECUTE ON MASTER;
-
-COMMENT ON FUNCTION gp_switch_wal_on_all_segments() IS 'Switch WAL segment files on all primary segments';
 COMMENT ON FUNCTION gp_switch_wal() IS 'Switch WAL segment files on all segments';
 
-REVOKE EXECUTE ON FUNCTION gp_switch_wal_on_all_segments() FROM public;
 REVOKE EXECUTE ON FUNCTION gp_switch_wal() FROM public;
 
 CREATE OR REPLACE VIEW gp_stat_archiver AS

--- a/gpcontrib/gp_pitr/gp_pitr--1.1.sql
+++ b/gpcontrib/gp_pitr/gp_pitr--1.1.sql
@@ -11,33 +11,15 @@ AS '$libdir/gp_pitr', 'gp_create_restore_point'
 LANGUAGE C IMMUTABLE STRICT;
 
 -- pg_switch_xlog wrapper functions to switch WAL segment files on Greenplum cluster-wide
-CREATE FUNCTION gp_switch_wal_on_all_segments (OUT gp_segment_id int, OUT pg_switch_wal pg_lsn)
-    RETURNS SETOF RECORD AS
-$$
-DECLARE
-seg_id int;
-BEGIN
-EXECUTE 'SELECT pg_catalog.gp_execution_segment()' INTO seg_id;
--- check if execute in entrydb QE to prevent giving wrong results
-IF seg_id = -1 THEN
-    RAISE EXCEPTION 'Cannot execute in entrydb, this query is not currently supported by GPDB.';
-END IF;
-RETURN QUERY SELECT pg_catalog.gp_execution_segment() AS gp_segment_id, * FROM pg_catalog.pg_switch_xlog();
-END;
-$$ LANGUAGE plpgsql EXECUTE ON ALL SEGMENTS;
+CREATE FUNCTION gp_switch_wal(
+    OUT gp_segment_id smallint, OUT pg_switch_wal pg_lsn, OUT pg_walfile_name text
+)
+    RETURNS SETOF record
+AS '$libdir/gp_pitr', 'gp_switch_wal'
+LANGUAGE C VOLATILE EXECUTE ON MASTER;
 
-CREATE FUNCTION gp_switch_wal (OUT gp_segment_id int, OUT pg_switch_wal pg_lsn)
-    RETURNS SETOF RECORD
-AS
-  'SELECT * FROM @extschema@.gp_switch_wal_on_all_segments()
-   UNION ALL
-   SELECT pg_catalog.gp_execution_segment() AS gp_segment_id, * FROM pg_catalog.pg_switch_xlog()'
-LANGUAGE SQL EXECUTE ON MASTER;
-
-COMMENT ON FUNCTION gp_switch_wal_on_all_segments() IS 'Switch WAL segment files on all primary segments';
 COMMENT ON FUNCTION gp_switch_wal() IS 'Switch WAL segment files on all segments';
 
-REVOKE EXECUTE ON FUNCTION gp_switch_wal_on_all_segments() FROM public;
 REVOKE EXECUTE ON FUNCTION gp_switch_wal() FROM public;
 
 CREATE OR REPLACE VIEW gp_stat_archiver AS

--- a/gpcontrib/gp_pitr/gp_pitr.c
+++ b/gpcontrib/gp_pitr/gp_pitr.c
@@ -14,9 +14,16 @@
 PG_MODULE_MAGIC;
 
 PG_FUNCTION_INFO_V1(gp_create_restore_point);
+PG_FUNCTION_INFO_V1(gp_switch_wal);
 
 Datum
 gp_create_restore_point(PG_FUNCTION_ARGS)
 {
 	return gp_create_restore_point_internal(fcinfo);
+}
+
+Datum
+gp_switch_wal(PG_FUNCTION_ARGS)
+{
+	return gp_switch_wal_internal(fcinfo);
 }

--- a/src/backend/access/transam/xlogfuncs_gp.c
+++ b/src/backend/access/transam/xlogfuncs_gp.c
@@ -164,3 +164,132 @@ gp_create_restore_point_internal(PG_FUNCTION_ARGS)
 
 	SRF_RETURN_DONE(funcctx);
 }
+
+/*
+ * gp_switch_wal_internal: switch WAL on all segments and return meaningful info
+ */
+Datum
+gp_switch_wal_internal(PG_FUNCTION_ARGS)
+{
+	typedef struct Context
+	{
+		CdbPgResults cdb_pgresults;
+		Datum qd_switch_lsn;
+		Datum qd_switch_walfilename;
+		int index;
+	} Context;
+
+	FuncCallContext *funcctx;
+	Context    *context;
+
+	if (SRF_IS_FIRSTCALL())
+	{
+		MemoryContext	oldcontext;
+		TupleDesc		tupdesc;
+		char			*switch_command;
+
+		/* create a function context for cross-call persistence */
+		funcctx = SRF_FIRSTCALL_INIT();
+
+		/* switch to memory context for appropriate multiple function call */
+		oldcontext = MemoryContextSwitchTo(funcctx->multi_call_memory_ctx);
+
+		/* create tupdesc for result */
+		tupdesc = CreateTemplateTupleDesc(3, false);
+		TupleDescInitEntry(tupdesc, (AttrNumber) 1, "segment_id",
+						   INT2OID, -1, 0);
+		TupleDescInitEntry(tupdesc, (AttrNumber) 2, "switch_lsn",
+						   LSNOID, -1, 0);
+		TupleDescInitEntry(tupdesc, (AttrNumber) 3, "switch_walfilename",
+						   TEXTOID, -1, 0);
+
+		funcctx->tuple_desc = BlessTupleDesc(tupdesc);
+
+		context = (Context *) palloc(sizeof(Context));
+		context->cdb_pgresults.pg_results = NULL;
+		context->cdb_pgresults.numResults = 0;
+		context->index = 0;
+		funcctx->user_fctx = (void *) context;
+
+		if (!IS_QUERY_DISPATCHER() || Gp_role != GP_ROLE_DISPATCH)
+			elog(ERROR,
+				 "cannot use gp_switch_wal() when not in QD mode");
+
+		switch_command = psprintf("SELECT switch_lsn, pg_xlogfile_name(switch_lsn) FROM pg_catalog.pg_switch_xlog() switch_lsn");
+		CdbDispatchCommand(switch_command,
+						   DF_NEED_TWO_PHASE | DF_CANCEL_ON_ERROR,
+						   &context->cdb_pgresults);
+		context->qd_switch_lsn = DatumGetLSN(DirectFunctionCall1(pg_switch_xlog, PointerGetDatum(NULL)));
+		context->qd_switch_walfilename = DirectFunctionCall1(pg_xlogfile_name, context->qd_switch_lsn);
+
+		pfree(switch_command);
+
+		funcctx->user_fctx = (void *) context;
+		MemoryContextSwitchTo(oldcontext);
+	}
+
+	/*
+	 * Using SRF to return all the segment LSN information of the form
+	 * {segment_id, switch_lsn, switch_walfilename}
+	 */
+	funcctx = SRF_PERCALL_SETUP();
+	context = (Context *) funcctx->user_fctx;
+
+	while (context->index <= context->cdb_pgresults.numResults)
+	{
+		Datum		values[3];
+		bool		nulls[3];
+		HeapTuple	tuple;
+		Datum		result;
+		Datum		switch_lsn;
+		Datum		switch_walfilename;
+		int			seg_index;
+
+		if (context->index == 0)
+		{
+			/* Setting fields representing QD's switch WAL */
+			seg_index = GpIdentity.segindex;
+			switch_lsn = context->qd_switch_lsn;
+			switch_walfilename = context->qd_switch_walfilename;
+		}
+		else
+		{
+			struct pg_result	*pgresult;
+			ExecStatusType		resultStatus;
+			uint32				hi, lo;
+
+			/* Setting fields representing QE's switch WAL */
+			seg_index = context->index - 1;
+			pgresult = context->cdb_pgresults.pg_results[seg_index];
+			resultStatus = PQresultStatus(pgresult);
+
+			if (resultStatus != PGRES_COMMAND_OK && resultStatus != PGRES_TUPLES_OK)
+				ereport(ERROR,
+						(errcode(ERRCODE_GP_INTERCONNECTION_ERROR),
+						 (errmsg("could not switch wal from segment"),
+						  errdetail("%s", PQresultErrorMessage(pgresult)))));
+			Assert(PQntuples(pgresult) == 1);
+
+			sscanf(PQgetvalue(pgresult, 0, 0), "%X/%X", &hi, &lo);
+			switch_lsn = LSNGetDatum(((uint64) hi) << 32 | lo);
+			switch_walfilename = CStringGetTextDatum(PQgetvalue(pgresult, 0, 1));
+		}
+
+		/*
+		 * Form tuple with appropriate data.
+		 */
+		MemSet(values, 0, sizeof(values));
+		MemSet(nulls, false, sizeof(nulls));
+
+		values[0] = Int16GetDatum(seg_index);
+		values[1] = switch_lsn;
+		values[2] = switch_walfilename;
+		tuple = heap_form_tuple(funcctx->tuple_desc, values, nulls);
+		result = HeapTupleGetDatum(tuple);
+
+		context->index++;
+		SRF_RETURN_NEXT(funcctx, result);
+	}
+
+	SRF_RETURN_DONE(funcctx);
+}

--- a/src/include/access/xlog_fn.h
+++ b/src/include/access/xlog_fn.h
@@ -34,5 +34,6 @@ extern Datum pg_backup_start_time(PG_FUNCTION_ARGS);
 
 /* GPDB-specific functions */
 extern Datum gp_create_restore_point_internal(PG_FUNCTION_ARGS);
+extern Datum gp_switch_wal_internal(PG_FUNCTION_ARGS);
 
 #endif   /* XLOG_FN_H */

--- a/src/test/gpdb_pitr/.gitignore
+++ b/src/test/gpdb_pitr/.gitignore
@@ -3,6 +3,7 @@ regression.out
 
 # Local symbolic links
 sql_isolation_testcase.py
+helpers
 
 # Generated subdirectories
 /results/

--- a/src/test/gpdb_pitr/Makefile
+++ b/src/test/gpdb_pitr/Makefile
@@ -8,7 +8,10 @@ include $(top_builddir)/src/Makefile.global
 sql_isolation_testcase.py:
 	rm -f $@ && $(LN_S) $(top_builddir)/src/test/isolation2/sql_isolation_testcase.py
 
-install: sql_isolation_testcase.py
+helpers:
+	rm -f $@ && $(LN_S) $(top_builddir)/src/test/isolation2/helpers
+
+install: sql_isolation_testcase.py helpers
 	$(MAKE) -C $(top_builddir)/src/test/isolation2 install
 	$(MAKE) -C $(top_builddir)/src/test/regress install
 

--- a/src/test/gpdb_pitr/expected/gpdb_pitr_setup.out
+++ b/src/test/gpdb_pitr/expected/gpdb_pitr_setup.out
@@ -150,24 +150,25 @@ SELECT * FROM gpdb_two_phase_commit_after_restore_point ORDER BY num;
  10  
 (10 rows)
 
-CREATE TEMP TABLE gp_current_wal_lsn AS SELECT -1 AS content_id, pg_current_xlog_location() AS current_lsn UNION SELECT gp_segment_id AS content_id, pg_current_xlog_location() FROM gp_dist_random('gp_id');
-CREATE 4
-
 -- Run gp_switch_wal() so that the WAL segment files with the restore
--- points are eligible for archival to the WAL Archive directories.
-SELECT true FROM gp_switch_wal();
- bool 
-------
- t    
- t    
- t    
- t    
-(4 rows)
+-- points are eligible for archival to the WAL Archive directories. While
+-- we're at it, store the WAL segment filenames that were just archived
+-- so that we can check that WAL archival was successful or not later. We
+-- must do this in a plpgsql cursor because of a known limitation with
+-- CTAS on an EXECUTE ON COORDINATOR function.
+CREATE TEMP TABLE switch_walfile_names(content_id smallint, walfilename text);
+CREATE
+CREATE OR REPLACE FUNCTION populate_switch_walfile_names() RETURNS void AS $$ DECLARE curs CURSOR FOR SELECT * FROM gp_switch_wal(); /*in func*/ DECLARE rec record; /*in func*/ BEGIN /*in func*/ OPEN curs; /*in func*/ LOOP FETCH curs INTO rec; /*in func*/ EXIT WHEN NOT FOUND; /*in func*/ 
+INSERT INTO switch_walfile_names VALUES (rec.gp_segment_id, rec.pg_walfile_name); /*in func*/ END LOOP; /*in func*/ END $$ LANGUAGE plpgsql; /*in func*/ SELECT populate_switch_walfile_names();
+ populate_switch_walfile_names 
+-------------------------------
+                               
+(1 row)
 
 -- Ensure that the last WAL segment file for each GP segment was archived.
 -- This function loops until the archival is complete. It times out after
 -- approximately 10mins.
-CREATE OR REPLACE FUNCTION check_archival() RETURNS BOOLEAN AS $$ DECLARE archived BOOLEAN; /*in func*/ DECLARE archived_count INTEGER; /*in func*/ BEGIN /*in func*/ FOR i in 1..3000 LOOP SELECT bool_and(seg_archived), count(*) FROM (SELECT last_archived_wal = pg_xlogfile_name(current_lsn) AS seg_archived FROM gp_current_wal_lsn l INNER JOIN gp_stat_archiver a ON l.content_id = a.gp_segment_id) s INTO archived, archived_count; /*in func*/ IF archived AND archived_count = 4 THEN RETURN archived; /*in func*/ END IF; /*in func*/ PERFORM pg_sleep(0.2); /*in func*/ END LOOP; /*in func*/ END $$ LANGUAGE plpgsql;
+CREATE OR REPLACE FUNCTION check_archival() RETURNS BOOLEAN AS $$ DECLARE archived BOOLEAN; /*in func*/ DECLARE archived_count INTEGER; /*in func*/ BEGIN /*in func*/ FOR i in 1..3000 LOOP SELECT bool_and(seg_archived), count(*) FROM (SELECT last_archived_wal = l.walfilename AS seg_archived FROM switch_walfile_names l INNER JOIN gp_stat_archiver a ON l.content_id = a.gp_segment_id) s INTO archived, archived_count; /*in func*/ IF archived AND archived_count = 4 THEN RETURN archived; /*in func*/ END IF; /*in func*/ PERFORM pg_sleep(0.2); /*in func*/ END LOOP; /*in func*/ END $$ LANGUAGE plpgsql;
 CREATE
 
 SELECT check_archival();

--- a/src/test/gpdb_pitr/expected/test_gp_switch_wal.out
+++ b/src/test/gpdb_pitr/expected/test_gp_switch_wal.out
@@ -1,0 +1,88 @@
+-- Test that gp_switch_wal() returns back WAL segment filenames
+-- constructed on the individual segments so that their timeline ids are
+-- used instead of each result having the same timeline id.
+
+-- start_matchsubs
+--
+-- # remove line number and entrydb in error message
+-- m/\(xlogfuncs_gp\.c\:\d+.*/
+-- s/\(xlogfuncs_gp\.c:\d+.*/\(xlogfuncs_gp\.c:LINE_NUM\)/
+--
+-- end_matchsubs
+
+include: helpers/server_helpers.sql;
+CREATE
+
+-- Prepare PITR extension
+CREATE EXTENSION IF NOT EXISTS gp_pitr;
+CREATE
+
+-- timeline ids prior to failover/failback should all be 1 due to the
+-- test requirement of having a fresh gpdemo cluster with mirrors
+SELECT gp_segment_id, substring(pg_walfile_name, 1, 8) FROM gp_switch_wal() ORDER BY gp_segment_id;
+ gp_segment_id | substring 
+---------------+-----------
+ -1            | 00000001  
+ 0             | 00000001  
+ 1             | 00000001  
+ 2             | 00000001  
+(4 rows)
+
+-- stop a primary in order to trigger a mirror promotion
+SELECT pg_ctl((SELECT datadir FROM gp_segment_configuration WHERE role = 'p' AND content = 1), 'stop');
+ pg_ctl 
+--------
+ OK     
+(1 row)
+
+-- trigger failover
+select gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+
+-- wait for content 1 (earlier mirror, now primary) to finish the promotion
+0U: SELECT 1;
+ ?column? 
+----------
+ 1        
+(1 row)
+
+-- recover the failed primary as new mirror
+!\retcode gprecoverseg -a --no-progress;
+(exited with code 0)
+
+-- loop while segments come in sync
+SELECT wait_until_all_segments_synchronized();
+ wait_until_all_segments_synchronized 
+--------------------------------------
+ OK                                   
+(1 row)
+
+-- rebalance back
+!\retcode gprecoverseg -ar --no-progress;
+(exited with code 0)
+
+-- loop while segments come in sync
+SELECT wait_until_all_segments_synchronized();
+ wait_until_all_segments_synchronized 
+--------------------------------------
+ OK                                   
+(1 row)
+
+-- test that gp_switch_wal() uses the segment-specific timeline id to construct each WAL filename
+SELECT gp_segment_id, substring(pg_walfile_name, 1, 8) FROM gp_switch_wal() ORDER BY gp_segment_id;
+ gp_segment_id | substring 
+---------------+-----------
+ -1            | 00000001  
+ 0             | 00000001  
+ 1             | 00000003  
+ 2             | 00000001  
+(4 rows)
+
+-- test simple gp_switch_wal() error scenarios
+SELECT gp_switch_wal() FROM gp_dist_random('gp_id');
+ERROR:  function with EXECUTE ON restrictions cannot be used in the SELECT list of a query with FROM
+CREATE TABLE this_ctas_should_fail AS SELECT gp_segment_id AS contentid, pg_switch_wal, pg_walfile_name FROM gp_switch_wal();
+ERROR:  cannot use gp_switch_wal() when not in QD mode (xlogfuncs_gp.c:LINE_NUM)

--- a/src/test/gpdb_pitr/sql/gpdb_pitr_setup.sql
+++ b/src/test/gpdb_pitr/sql/gpdb_pitr_setup.sql
@@ -63,14 +63,27 @@ SELECT * FROM gpdb_two_phase_commit_after_acquire_share_lock;
 SELECT * FROM gpdb_one_phase_commit;
 SELECT * FROM gpdb_two_phase_commit_after_restore_point ORDER BY num;
 
-CREATE TEMP TABLE gp_current_wal_lsn AS
-SELECT -1 AS content_id, pg_current_xlog_location() AS current_lsn
-UNION
-SELECT gp_segment_id AS content_id, pg_current_xlog_location() FROM gp_dist_random('gp_id');
-
 -- Run gp_switch_wal() so that the WAL segment files with the restore
--- points are eligible for archival to the WAL Archive directories.
-SELECT true FROM gp_switch_wal();
+-- points are eligible for archival to the WAL Archive directories. While
+-- we're at it, store the WAL segment filenames that were just archived
+-- so that we can check that WAL archival was successful or not later. We
+-- must do this in a plpgsql cursor because of a known limitation with
+-- CTAS on an EXECUTE ON COORDINATOR function.
+CREATE TEMP TABLE switch_walfile_names(content_id smallint, walfilename text);
+CREATE OR REPLACE FUNCTION populate_switch_walfile_names() RETURNS void AS $$
+DECLARE curs CURSOR FOR SELECT * FROM gp_switch_wal(); /*in func*/
+DECLARE rec record; /*in func*/
+BEGIN /*in func*/
+    OPEN curs; /*in func*/
+    LOOP
+        FETCH curs INTO rec; /*in func*/
+        EXIT WHEN NOT FOUND; /*in func*/
+
+        INSERT INTO switch_walfile_names VALUES (rec.gp_segment_id, rec.pg_walfile_name); /*in func*/
+    END LOOP; /*in func*/
+END $$
+LANGUAGE plpgsql; /*in func*/
+SELECT populate_switch_walfile_names();
 
 -- Ensure that the last WAL segment file for each GP segment was archived.
 -- This function loops until the archival is complete. It times out after
@@ -79,16 +92,16 @@ CREATE OR REPLACE FUNCTION check_archival() RETURNS BOOLEAN AS $$
 DECLARE archived BOOLEAN; /*in func*/
 DECLARE archived_count INTEGER; /*in func*/
 BEGIN /*in func*/
-FOR i in 1..3000 LOOP
-SELECT bool_and(seg_archived), count(*)
-FROM
-    (SELECT last_archived_wal =
-            pg_xlogfile_name(current_lsn) AS seg_archived
-     FROM gp_current_wal_lsn l
-              INNER JOIN gp_stat_archiver a
-                         ON l.content_id = a.gp_segment_id) s
-    INTO archived, archived_count; /*in func*/
-IF archived AND archived_count = 4 THEN
+    FOR i in 1..3000 LOOP
+        SELECT bool_and(seg_archived), count(*)
+        FROM
+            (SELECT last_archived_wal =
+            l.walfilename AS seg_archived
+            FROM switch_walfile_names l
+            INNER JOIN gp_stat_archiver a
+            ON l.content_id = a.gp_segment_id) s
+        INTO archived, archived_count; /*in func*/
+        IF archived AND archived_count = 4 THEN
             RETURN archived; /*in func*/
 END IF; /*in func*/
         PERFORM pg_sleep(0.2); /*in func*/

--- a/src/test/gpdb_pitr/sql/test_gp_switch_wal.sql
+++ b/src/test/gpdb_pitr/sql/test_gp_switch_wal.sql
@@ -1,0 +1,48 @@
+-- Test that gp_switch_wal() returns back WAL segment filenames
+-- constructed on the individual segments so that their timeline ids are
+-- used instead of each result having the same timeline id.
+
+-- start_matchsubs
+--
+-- # remove line number and entrydb in error message
+-- m/\(xlogfuncs_gp\.c\:\d+.*/
+-- s/\(xlogfuncs_gp\.c:\d+.*/\(xlogfuncs_gp\.c:LINE_NUM\)/
+--
+-- end_matchsubs
+
+include: helpers/server_helpers.sql;
+
+-- Prepare PITR extension
+CREATE EXTENSION IF NOT EXISTS gp_pitr;
+
+-- timeline ids prior to failover/failback should all be 1 due to the
+-- test requirement of having a fresh gpdemo cluster with mirrors
+SELECT gp_segment_id, substring(pg_walfile_name, 1, 8) FROM gp_switch_wal() ORDER BY gp_segment_id;
+
+-- stop a primary in order to trigger a mirror promotion
+SELECT pg_ctl((SELECT datadir FROM gp_segment_configuration WHERE role = 'p' AND content = 1), 'stop');
+
+-- trigger failover
+select gp_request_fts_probe_scan();
+
+-- wait for content 1 (earlier mirror, now primary) to finish the promotion
+0U: SELECT 1;
+
+-- recover the failed primary as new mirror
+!\retcode gprecoverseg -a --no-progress;
+
+-- loop while segments come in sync
+SELECT wait_until_all_segments_synchronized();
+
+-- rebalance back
+!\retcode gprecoverseg -ar --no-progress;
+
+-- loop while segments come in sync
+SELECT wait_until_all_segments_synchronized();
+
+-- test that gp_switch_wal() uses the segment-specific timeline id to construct each WAL filename
+SELECT gp_segment_id, substring(pg_walfile_name, 1, 8) FROM gp_switch_wal() ORDER BY gp_segment_id;
+
+-- test simple gp_switch_wal() error scenarios
+SELECT gp_switch_wal() FROM gp_dist_random('gp_id');
+CREATE TABLE this_ctas_should_fail AS SELECT gp_segment_id AS contentid, pg_switch_wal, pg_walfile_name FROM gp_switch_wal();

--- a/src/test/gpdb_pitr/test_gpdb_pitr.sh
+++ b/src/test/gpdb_pitr/test_gpdb_pitr.sh
@@ -68,6 +68,12 @@ run_test_isolation2()
 # Remove temporary test directory if it already exists.
 [ -d $TEMP_DIR ] && rm -rf $TEMP_DIR
 
+# Create our test database.
+createdb gpdb_pitr_database
+
+# Test output of gp_switch_wal()
+run_test_isolation2 test_gp_switch_wal
+
 # Set up WAL Archiving by updating the postgresql.conf files of the
 # master and primary segments. Afterwards, restart the cluster to load
 # the new settings.
@@ -90,9 +96,6 @@ for segment_role in MASTER PRIMARY1 PRIMARY2 PRIMARY3; do
   REPLICA_DBID_VAR=REPLICA_${segment_role}_DBID
   pg_basebackup -h localhost -p ${!PORT_VAR} -D ${!REPLICA_VAR} --target-gp-dbid ${!REPLICA_DBID_VAR}
 done
-
-# Create our test database.
-createdb gpdb_pitr_database
 
 # Run setup test. This will create the tables, create the restore
 # points, and demonstrate the commit blocking.


### PR DESCRIPTION
The LSN output from pg_switch_wal() is commonly used with
pg_walfile_name(). However, the LSN set outputted from gp_switch_wal()
cannot be used by pg_walfile_name() because of the very likely
timeline differences of the coordinator segment and all the
segments. To make sure users/developers that want the WAL segment
filename and 100% guarantee that it is correct, we should bake it into
gp_switch_wal(). Having a separate catalog function would create a
window where HA failover would make the timeline ids incorrect and we
would have the same problem all over again.

We also convert the function into a C function to guarantee that all
the function calls in gp_switch_wal() are called on the correct
segments. Using the EXECUTE ON SEGMENT/COORDINATOR combo with a UNION
was observed to have known issues when dealing with segment-specific
values (specifically the coordinator) and redistribute motion plans.

Issue example:
```
postgres=# SELECT gp_segment_id, last_archived_wal FROM gp_stat_archiver ORDER BY gp_segment_id;
 gp_segment_id |    last_archived_wal
---------------+--------------------------
            -1 | 000000070000000300000033
             0 | 000000060000000200000039
             1 | 00000006000000020000003B
             2 | 00000006000000020000003D
(4 rows)

postgres=# create table testtable(a int);
CREATE TABLE

-- the walfilenames all have the coordinator's timeline id in them
postgres=# SELECT gp_segment_id, pg_switch_wal, pg_walfile_name(pg_switch_wal) AS walfilename FROM gp_switch_wal() ORDER BY gp_segment_id;
 gp_segment_id | pg_switch_wal |       walfilename
---------------+---------------+--------------------------
            -1 | 3/D0042DB0    | 000000070000000300000034
             0 | 2/E8042230    | 00000007000000020000003A
             1 | 2/F0042230    | 00000007000000020000003C
             2 | 2/F8042230    | 00000007000000020000003E
(4 rows)

-- these are the expected WAL segment filenames with correct timeline id
postgres=# SELECT gp_segment_id, last_archived_wal FROM gp_stat_archiver ORDER BY gp_segment_id;
 gp_segment_id |    last_archived_wal
---------------+--------------------------
            -1 | 000000070000000300000034
             0 | 00000006000000020000003A
             1 | 00000006000000020000003C
             2 | 00000006000000020000003E
(4 rows)
```

Backported from GPDB master (7X):
https://github.com/greenplum-db/gpdb/commit/d3163467b018082b1b36d70f94fe95e59898b6e0

6X backport conflicts:
* Ported 7X catalog function changes to 6X-exclusive gp_pitr extension