### PR TITLE
Fix db_size_functions regress test

### DIFF
--- a/src/test/regress/expected/db_size_functions.out
+++ b/src/test/regress/expected/db_size_functions.out
@@ -6,6 +6,13 @@
 -- to collect the totals across segments, and to support AO / AOCS tables.
 -- Hence, we better have extra tests for those things.
 --
+-- start_matchsubs
+--
+-- # remove line number and entrydb in error message
+-- m/\(xlogfuncs_gp\.c\:\d+.*/
+-- s/\(xlogfuncs_gp\.c:\d+.*/\(xlogfuncs_gp\.c:LINE_NUM\)/
+--
+-- end_matchsubs
 -- The total depends on the number of segments, and will also change whenever
 -- the built-in objects change, so be lenient.
 -- As of this writing, the total size of template0 database, across three segments,
@@ -118,9 +125,7 @@ ERROR:  Cannot execute in entrydb, this query is not currently supported by GPDB
 CONTEXT:  PL/pgSQL function gp_tablespace_segment_location(oid) line 8 at RAISE
 SQL function "gp_tablespace_location" statement 1
 create temp table t1 as select gp_segment_id as seg_id from gp_switch_wal();
-ERROR:  Cannot execute in entrydb, this query is not currently supported by GPDB.
-CONTEXT:  PL/pgSQL function gp_switch_wal_on_all_segments() line 8 at RAISE
-SQL function "gp_switch_wal" statement 1
+ERROR:  cannot use gp_switch_wal() when not in QD mode (xlogfuncs_gp.c:LINE_NUM)
 --
 -- Tests on the table and index size variants.
 --

--- a/src/test/regress/sql/db_size_functions.sql
+++ b/src/test/regress/sql/db_size_functions.sql
@@ -7,6 +7,13 @@
 -- Hence, we better have extra tests for those things.
 --
 
+-- start_matchsubs
+--
+-- # remove line number and entrydb in error message
+-- m/\(xlogfuncs_gp\.c\:\d+.*/
+-- s/\(xlogfuncs_gp\.c:\d+.*/\(xlogfuncs_gp\.c:LINE_NUM\)/
+--
+-- end_matchsubs
 
 -- The total depends on the number of segments, and will also change whenever
 -- the built-in objects change, so be lenient.


### PR DESCRIPTION
The test started failing after a change to `gp_switch_wal()` was
made. The db_size_functions regress test was not updated
accordingly. Fix the test by simply updating the expected output
(matchsub in the test added as well).

GPDB commit reference:
https://github.com/greenplum-db/gpdb/commit/d3163467b018082b1b36d70f94fe95e59898b6e0

This PR fixes the ICW test job failures on the GPDB Concourse pipeline.