### PR TITLE
Revert "Turn on optimizer_force_multistage_agg by default for ORCA"

### DIFF
--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -2309,7 +2309,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 			GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_force_multistage_agg,
-		true,
+		false,
 		NULL, NULL, NULL
 	},
 

--- a/src/test/regress/expected/aggregates_optimizer.out
+++ b/src/test/regress/expected/aggregates_optimizer.out
@@ -1165,13 +1165,9 @@ explain (costs off) select a,c from t1 group by a,c,d;
                Sort Key: a, c, d
                ->  Redistribute Motion 3:3  (slice2; segments: 3)
                      Hash Key: a, c, d
-                     ->  GroupAggregate
-                           Group Key: a, c, d
-                           ->  Sort
-                                 Sort Key: a, c, d
-                                 ->  Seq Scan on t1
- Optimizer: Pivotal Optimizer (GPORCA)
-(13 rows)
+                     ->  Seq Scan on t1
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(9 rows)
 
 -- Test removal across multiple relations
 explain (costs off) select *
@@ -2989,15 +2985,13 @@ explain (costs off)
 select g%100000 as c1, sum(g::numeric) as c2, count(*) as c3
   from generate_series(0, 199999) g
   group by g%100000;
-                  QUERY PLAN                   
------------------------------------------------
- Finalize HashAggregate
-   Group Key: ((generate_series % 100000))
-   ->  Streaming Partial HashAggregate
-         Group Key: (generate_series % 100000)
-         ->  Function Scan on generate_series
+               QUERY PLAN                
+-----------------------------------------
+ HashAggregate
+   Group Key: (generate_series % 100000)
+   ->  Function Scan on generate_series
  Optimizer: Pivotal Optimizer (GPORCA)
-(6 rows)
+(4 rows)
 
 create table agg_group_1 as
 select g%100000 as c1, sum(g::numeric) as c2, count(*) as c3
@@ -3035,15 +3029,13 @@ explain (costs off)
 select g%100000 as c1, sum(g::numeric) as c2, count(*) as c3
   from generate_series(0, 199999) g
   group by g%100000;
-                  QUERY PLAN                   
------------------------------------------------
- Finalize HashAggregate
-   Group Key: ((generate_series % 100000))
-   ->  Streaming Partial HashAggregate
-         Group Key: (generate_series % 100000)
-         ->  Function Scan on generate_series
+               QUERY PLAN                
+-----------------------------------------
+ HashAggregate
+   Group Key: (generate_series % 100000)
+   ->  Function Scan on generate_series
  Optimizer: Pivotal Optimizer (GPORCA)
-(6 rows)
+(4 rows)
 
 create table agg_hash_1 as
 select g%100000 as c1, sum(g::numeric) as c2, count(*) as c3

--- a/src/test/regress/expected/bfv_aggregate.out
+++ b/src/test/regress/expected/bfv_aggregate.out
@@ -363,7 +363,6 @@ insert into mtup1 values
 -- from exceeding the limit in GPDB7 with that plan(a MinimalTuple has a limit of 1600
 -- columns). So set the parameter to off to prevent error happens.
 set gp_enable_multiphase_agg=off;
-set optimizer_force_multistage_agg=off;
 select c0, c1, array_length(ARRAY[
  SUM(c4 % 2), SUM(c4 % 3), SUM(c4 % 4),
  SUM(c4 % 5), SUM(c4 % 6), SUM(c4 % 7), SUM(c4 % 8), SUM(c4 % 9),
@@ -1507,7 +1506,6 @@ from mtup1 where c0 = 'foo' group by c0, c1 limit 10;
 (1 row)
 
 reset gp_enable_multiphase_agg;
-reset optimizer_force_multistage_agg;
 -- MPP-29042 Multistage aggregation plans should have consistent targetlists in
 -- case of same column aliases and grouping on them.
 DROP TABLE IF EXISTS t1;

--- a/src/test/regress/expected/bfv_aggregate_optimizer.out
+++ b/src/test/regress/expected/bfv_aggregate_optimizer.out
@@ -362,7 +362,6 @@ insert into mtup1 values
 -- from exceeding the limit in GPDB7 with that plan(a MinimalTuple has a limit of 1600
 -- columns). So set the parameter to off to prevent error happens.
 set gp_enable_multiphase_agg=off;
-set optimizer_force_multistage_agg=off;
 select c0, c1, array_length(ARRAY[
  SUM(c4 % 2), SUM(c4 % 3), SUM(c4 % 4),
  SUM(c4 % 5), SUM(c4 % 6), SUM(c4 % 7), SUM(c4 % 8), SUM(c4 % 9),
@@ -1506,7 +1505,6 @@ from mtup1 where c0 = 'foo' group by c0, c1 limit 10;
 (1 row)
 
 reset gp_enable_multiphase_agg;
-reset optimizer_force_multistage_agg;
 -- MPP-29042 Multistage aggregation plans should have consistent targetlists in
 -- case of same column aliases and grouping on them.
 DROP TABLE IF EXISTS t1;
@@ -1729,24 +1727,22 @@ SELECT a.x, b.y, count(*) FROM pagg_tab1 a FULL JOIN pagg_tab2 b ON a.x = b.y GR
                                   QUERY PLAN                                  
 ------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  Finalize HashAggregate
+   ->  HashAggregate
          Group Key: pagg_tab1.x, pagg_tab2.y
          ->  Redistribute Motion 3:3  (slice2; segments: 3)
                Hash Key: pagg_tab1.x, pagg_tab2.y
-               ->  Streaming Partial HashAggregate
-                     Group Key: pagg_tab1.x, pagg_tab2.y
-                     ->  Merge Full Join
-                           Merge Cond: (pagg_tab1.x = pagg_tab2.y)
-                           ->  Sort
-                                 Sort Key: pagg_tab1.x
-                                 ->  Seq Scan on pagg_tab1
-                           ->  Sort
-                                 Sort Key: pagg_tab2.y
-                                 ->  Redistribute Motion 3:3  (slice3; segments: 3)
-                                       Hash Key: pagg_tab2.y
-                                       ->  Seq Scan on pagg_tab2
+               ->  Merge Full Join
+                     Merge Cond: (pagg_tab1.x = pagg_tab2.y)
+                     ->  Sort
+                           Sort Key: pagg_tab1.x
+                           ->  Seq Scan on pagg_tab1
+                     ->  Sort
+                           Sort Key: pagg_tab2.y
+                           ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                                 Hash Key: pagg_tab2.y
+                                 ->  Seq Scan on pagg_tab2
  Optimizer: Pivotal Optimizer (GPORCA)
-(18 rows)
+(16 rows)
 
 SELECT a.x, b.y, count(*) FROM pagg_tab1 a FULL JOIN pagg_tab2 b ON a.x = b.y GROUP BY a.x, b.y;
  x  | y  | count 

--- a/src/test/regress/expected/bfv_index_optimizer.out
+++ b/src/test/regress/expected/bfv_index_optimizer.out
@@ -131,55 +131,53 @@ explain SELECT count(*)
 FROM bfv_tab2_facttable1 ft, bfv_tab2_dimdate dt, bfv_tab2_dimtabl1 dt1
 WHERE ft.wk_id = dt.wk_id
 AND ft.id = dt1.id;
-                                                               QUERY PLAN                                                               
-----------------------------------------------------------------------------------------------------------------------------------------
- Finalize Aggregate  (cost=0.00..1250.34 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1250.34 rows=1 width=8)
-         ->  Partial Aggregate  (cost=0.00..1250.34 rows=1 width=8)
-               ->  Hash Join  (cost=0.00..1250.34 rows=3 width=1)
-                     Hash Cond: (bfv_tab2_dimdate.wk_id = bfv_tab2_facttable1.wk_id)
-                     ->  Seq Scan on bfv_tab2_dimdate  (cost=0.00..431.00 rows=4 width=2)
-                     ->  Hash  (cost=819.34..819.34 rows=3 width=2)
-                           ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..819.34 rows=3 width=2)
-                                 Hash Key: bfv_tab2_facttable1.wk_id
-                                 ->  Nested Loop  (cost=0.00..819.34 rows=3 width=2)
-                                       Join Filter: true
-                                       ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=7 width=4)
-                                             ->  Seq Scan on bfv_tab2_dimtabl1  (cost=0.00..431.00 rows=3 width=4)
-                                       ->  Dynamic Bitmap Heap Scan on bfv_tab2_facttable1  (cost=0.00..388.34 rows=1 width=2)
-                                             Number of partitions to scan: 21 
-                                             Recheck Cond: (id = bfv_tab2_dimtabl1.id)
-                                             Filter: (id = bfv_tab2_dimtabl1.id)
-                                             ->  Dynamic Bitmap Index Scan on idx_bfv_tab2_facttable1  (cost=0.00..0.00 rows=0 width=0)
-                                                   Index Cond: (id = bfv_tab2_dimtabl1.id)
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..1250.34 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1250.34 rows=7 width=1)
+         ->  Hash Join  (cost=0.00..1250.34 rows=3 width=1)
+               Hash Cond: (bfv_tab2_dimdate.wk_id = bfv_tab2_facttable1.wk_id)
+               ->  Seq Scan on bfv_tab2_dimdate  (cost=0.00..431.00 rows=4 width=2)
+               ->  Hash  (cost=819.34..819.34 rows=3 width=2)
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..819.34 rows=3 width=2)
+                           Hash Key: bfv_tab2_facttable1.wk_id
+                           ->  Nested Loop  (cost=0.00..819.34 rows=3 width=2)
+                                 Join Filter: true
+                                 ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=7 width=4)
+                                       ->  Seq Scan on bfv_tab2_dimtabl1  (cost=0.00..431.00 rows=3 width=4)
+                                 ->  Dynamic Bitmap Heap Scan on bfv_tab2_facttable1  (cost=0.00..388.34 rows=1 width=2)
+                                       Number of partitions to scan: 21 
+                                       Recheck Cond: (id = bfv_tab2_dimtabl1.id)
+                                       Filter: (id = bfv_tab2_dimtabl1.id)
+                                       ->  Dynamic Bitmap Index Scan on idx_bfv_tab2_facttable1  (cost=0.00..0.00 rows=0 width=0)
+                                             Index Cond: (id = bfv_tab2_dimtabl1.id)
  Optimizer: Pivotal Optimizer (GPORCA)
-(20 rows)
+(19 rows)
 
 explain SELECT count(*)
 FROM bfv_tab2_facttable1 ft, bfv_tab2_dimdate dt, bfv_tab2_dimtabl1 dt1
 WHERE ft.wk_id = dt.wk_id
 AND ft.id = dt1.id;
-                                                               QUERY PLAN                                                               
-----------------------------------------------------------------------------------------------------------------------------------------
- Finalize Aggregate  (cost=0.00..1250.34 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1250.34 rows=1 width=8)
-         ->  Partial Aggregate  (cost=0.00..1250.34 rows=1 width=8)
-               ->  Hash Join  (cost=0.00..1250.34 rows=3 width=1)
-                     Hash Cond: (bfv_tab2_dimdate.wk_id = bfv_tab2_facttable1.wk_id)
-                     ->  Seq Scan on bfv_tab2_dimdate  (cost=0.00..431.00 rows=4 width=2)
-                     ->  Hash  (cost=819.34..819.34 rows=3 width=2)
-                           ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..819.34 rows=3 width=2)
-                                 Hash Key: bfv_tab2_facttable1.wk_id
-                                 ->  Nested Loop  (cost=0.00..819.34 rows=3 width=2)
-                                       Join Filter: true
-                                       ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=7 width=4)
-                                             ->  Seq Scan on bfv_tab2_dimtabl1  (cost=0.00..431.00 rows=3 width=4)
-                                       ->  Dynamic Bitmap Heap Scan on bfv_tab2_facttable1  (cost=0.00..388.34 rows=1 width=2)
-                                             Number of partitions to scan: 21 
-                                             Recheck Cond: (id = bfv_tab2_dimtabl1.id)
-                                             Filter: (id = bfv_tab2_dimtabl1.id)
-                                             ->  Dynamic Bitmap Index Scan on idx_bfv_tab2_facttable1  (cost=0.00..0.00 rows=0 width=0)
-                                                   Index Cond: (id = bfv_tab2_dimtabl1.id)
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..1250.34 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1250.34 rows=7 width=1)
+         ->  Hash Join  (cost=0.00..1250.34 rows=3 width=1)
+               Hash Cond: (bfv_tab2_dimdate.wk_id = bfv_tab2_facttable1.wk_id)
+               ->  Seq Scan on bfv_tab2_dimdate  (cost=0.00..431.00 rows=4 width=2)
+               ->  Hash  (cost=819.34..819.34 rows=3 width=2)
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..819.34 rows=3 width=2)
+                           Hash Key: bfv_tab2_facttable1.wk_id
+                           ->  Nested Loop  (cost=0.00..819.34 rows=3 width=2)
+                                 Join Filter: true
+                                 ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=7 width=4)
+                                       ->  Seq Scan on bfv_tab2_dimtabl1  (cost=0.00..431.00 rows=3 width=4)
+                                 ->  Dynamic Bitmap Heap Scan on bfv_tab2_facttable1  (cost=0.00..388.34 rows=1 width=2)
+                                       Number of partitions to scan: 21 
+                                       Recheck Cond: (id = bfv_tab2_dimtabl1.id)
+                                       Filter: (id = bfv_tab2_dimtabl1.id)
+                                       ->  Dynamic Bitmap Index Scan on idx_bfv_tab2_facttable1  (cost=0.00..0.00 rows=0 width=0)
+                                             Index Cond: (id = bfv_tab2_dimtabl1.id)
  Optimizer: Pivotal Optimizer (GPORCA)
 (19 rows)
 

--- a/src/test/regress/expected/bfv_joins_optimizer.out
+++ b/src/test/regress/expected/bfv_joins_optimizer.out
@@ -655,17 +655,16 @@ SELECT * FROM t1 LEFT OUTER JOIN t2 ON t1.a = t2.a WHERE t1.b IS NOT DISTINCT FR
 explain select 1 as mrs_t1 where 1 <= ALL (select x from z);
                                                                                                                                                        QUERY PLAN                                                                                                                                                        
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Nested Loop  (cost=0.00..882688.14 rows=1 width=1)
+ Nested Loop  (cost=0.00..882688.11 rows=1 width=1)
    Join Filter: true
    ->  Result  (cost=0.00..431.00 rows=1 width=1)
          Filter: ((CASE WHEN (sum((CASE WHEN (1 > x) THEN 1 ELSE 0 END)) IS NULL) THEN true WHEN (sum((CASE WHEN (x IS NULL) THEN 1 ELSE 0 END)) > '0'::bigint) THEN NULL::boolean WHEN (1 IS NULL) THEN NULL::boolean WHEN (sum((CASE WHEN (1 > x) THEN 1 ELSE 0 END)) = '0'::bigint) THEN true ELSE false END) = true)
-         ->  Finalize Aggregate  (cost=0.00..431.00 rows=1 width=16)
-               ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=16)
-                     ->  Partial Aggregate  (cost=0.00..431.00 rows=1 width=16)
-                           ->  Seq Scan on z  (cost=0.00..431.00 rows=1 width=4)
+         ->  Aggregate  (cost=0.00..431.00 rows=1 width=16)
+               ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                     ->  Seq Scan on z  (cost=0.00..431.00 rows=1 width=4)
    ->  Result  (cost=0.00..0.00 rows=1 width=1)
  Optimizer: Pivotal Optimizer (GPORCA)
-(10 rows)
+(9 rows)
 
 --
 -- Test for wrong results in window functions under joins #1

--- a/src/test/regress/expected/bfv_olap_optimizer.out
+++ b/src/test/regress/expected/bfv_olap_optimizer.out
@@ -618,20 +618,16 @@ from t2_github_issue_10143 a
 group by a.code;
                                                 QUERY PLAN                                                
 ------------------------------------------------------------------------------------------------------------------------
- WindowAgg  (cost=0.00..1324055.42 rows=2 width=16)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1324055.42 rows=2 width=16)
-         ->  Finalize GroupAggregate  (cost=0.00..431.00 rows=1 width=14)
+ WindowAgg  (cost=0.00..1324055.31 rows=1 width=16)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1324055.31 rows=1 width=16)
+         ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=14)
                Group Key: t2_github_issue_10143.code
-               ->  Sort  (cost=0.00..431.00 rows=1 width=14)
+               ->  Sort  (cost=0.00..431.00 rows=1 width=11)
                      Sort Key: t2_github_issue_10143.code
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=14)
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=11)
                            Hash Key: t2_github_issue_10143.code
-                           ->  Partial GroupAggregate  (cost=0.00..431.00 rows=1 width=14)
-                                 Group Key: t2_github_issue_10143.code
-                                 ->  Sort  (cost=0.00..431.00 rows=1 width=11)
-                                       Sort Key: t2_github_issue_10143.code
-                                       ->  Seq Scan on t2_github_issue_10143  (cost=0.00..431.00 rows=1 width=11)
-               SubPlan 1
+                           ->  Seq Scan on t2_github_issue_10143  (cost=0.00..431.00 rows=1 width=11)
+   SubPlan 1
                  ->  Limit  (cost=0.00..431.00 rows=1 width=6)
                        ->  Result  (cost=0.00..431.00 rows=1 width=6)
                              Filter: ((t1_github_issue_10143.code)::text = (t2_github_issue_10143.code)::text)

--- a/src/test/regress/expected/bfv_partition_plans.out
+++ b/src/test/regress/expected/bfv_partition_plans.out
@@ -54,7 +54,6 @@ drop table mpp3061;
 -- Tests if it produces SIGSEGV from "select from partition_table group by rollup or cube function"
 --
 -- SETUP
-set optimizer_force_multistage_agg=off;
 create table mpp7980
 (
  month_id date,
@@ -92,7 +91,6 @@ select cust_type, subscription_status,count(distinct subscription_id),sum(voice_
 
 -- CLEANUP
 drop table mpp7980;
-reset optimizer_force_multistage_agg;
 -- ************ORCA ENABLED**********
 --
 -- MPP-23195

--- a/src/test/regress/expected/bfv_partition_plans_optimizer.out
+++ b/src/test/regress/expected/bfv_partition_plans_optimizer.out
@@ -54,7 +54,6 @@ drop table mpp3061;
 -- Tests if it produces SIGSEGV from "select from partition_table group by rollup or cube function"
 --
 -- SETUP
-set optimizer_force_multistage_agg=off;
 create table mpp7980
 (
  month_id date,
@@ -92,7 +91,6 @@ select cust_type, subscription_status,count(distinct subscription_id),sum(voice_
 
 -- CLEANUP
 drop table mpp7980;
-reset optimizer_force_multistage_agg;
 -- ************ORCA ENABLED**********
 --
 -- MPP-23195
@@ -837,7 +835,7 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 explain analyze select a.* from mpp8031 a, mpp8031 b where a.oid = b.oid;
                                                        QUERY PLAN                                                        
 -------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=16) (actual time=5.028..5.028 rows=0 loops=1)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=16) (actual time=2.533..2.533 rows=0 loops=1)
    ->  Hash Join  (cost=0.00..862.00 rows=1 width=16) (never executed)
          Hash Cond: (mpp8031.oid = mpp8031_1.oid)
          ->  Dynamic Seq Scan on mpp8031  (cost=0.00..431.00 rows=1 width=16) (never executed)
@@ -846,13 +844,13 @@ explain analyze select a.* from mpp8031 a, mpp8031 b where a.oid = b.oid;
                Buckets: 524288  Batches: 1  Memory Usage: 4096kB
                ->  Dynamic Seq Scan on mpp8031 mpp8031_1  (cost=0.00..431.00 rows=1 width=4) (never executed)
                      Number of partitions to scan: 4 
-                     Partitions scanned:  Avg 4.0 x 3 workers.  Max 4 parts (seg0).
- Optimizer: Pivotal Optimizer (GPORCA)
- Planning Time: 23.538 ms
-   (slice0)    Executor memory: 38K bytes.
+                     Partitions scanned:  Avg 4.0 (out of 4) x 3 workers.  Max 4 parts (seg0).
+ Planning Time: 4.433 ms
+   (slice0)    Executor memory: 31K bytes.
    (slice1)    Executor memory: 4156K bytes avg x 3 workers, 4156K bytes max (seg0).  Work_mem: 4096K bytes max.
  Memory used:  128000kB
- Execution Time: 5.999 ms
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Execution Time: 3.231 ms
 (16 rows)
 
 drop table mpp8031;

--- a/src/test/regress/expected/bfv_planner_optimizer.out
+++ b/src/test/regress/expected/bfv_planner_optimizer.out
@@ -514,18 +514,15 @@ explain (costs off) select * from t_hashdist cross join (select a, sum(random())
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Nested Loop
          Join Filter: true
-         ->  Finalize HashAggregate
-               Group Key: generate_series.generate_series
-               ->  Redistribute Motion 1:3  (slice3)
-                     Hash Key: generate_series.generate_series
-                     ->  Streaming Partial HashAggregate
+         ->  Broadcast Motion 3:3  (slice3; segments: 3)
+               ->  Seq Scan on t_hashdist
+         ->  Materialize
+               ->  Redistribute Motion 1:3  (slice2)
+                     ->  HashAggregate
                            Group Key: generate_series.generate_series
                            ->  Function Scan on generate_series
-         ->  Materialize
-               ->  Broadcast Motion 3:3  (slice2; segments: 3)
-                     ->  Seq Scan on t_hashdist
  Optimizer: Pivotal Optimizer (GPORCA)
-(14 rows)
+(11 rows)
 
 explain (costs off) select * from t_hashdist cross join (select random() as k, sum(a) from generate_series(1, 10) a group by k) x;
                           QUERY PLAN                           
@@ -533,19 +530,16 @@ explain (costs off) select * from t_hashdist cross join (select random() as k, s
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Nested Loop
          Join Filter: true
-         ->  Finalize HashAggregate
+         ->  HashAggregate
                Group Key: (random())
-               ->  Redistribute Motion 3:3  (slice3; segments: 3)
+               ->  Redistribute Motion 1:3  (slice3)
                      Hash Key: (random())
-                     ->  Streaming Partial HashAggregate
-                           Group Key: (random())
-                           ->  Redistribute Motion 1:3  (slice4)
-                                 ->  Function Scan on generate_series
+                     ->  Function Scan on generate_series
          ->  Materialize
                ->  Broadcast Motion 3:3  (slice2; segments: 3)
                      ->  Seq Scan on t_hashdist
  Optimizer: Pivotal Optimizer (GPORCA)
-(15 rows)
+(12 rows)
 
 explain (costs off) select * from t_hashdist cross join (select a, count(1) as s from generate_series(1, 10) a group by a having count(1) > random() order by a) x ;
                             QUERY PLAN                             
@@ -612,15 +606,10 @@ explain (costs off) create table t_rep as select i from generate_series(5, 15) a
                Filter: (generate_series < nextval('test_seq'::regclass))
                ->  HashAggregate
                      Group Key: generate_series
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                           Hash Key: generate_series
-                           ->  Streaming HashAggregate
-                                 Group Key: generate_series
-                                 ->  Result
-                                       One-Time Filter: (gp_execution_segment() = 2)
-                                       ->  Function Scan on generate_series
+                     ->  Result
+                           ->  Function Scan on generate_series
  Optimizer: Pivotal Optimizer (GPORCA)
-(14 rows)
+(9 rows)
 
 create table t_rep2 as select i from generate_series(5, 15) as i group by i having i < nextval('test_seq') distributed replicated;
 select count(*) from gp_dist_random('t_rep2');
@@ -641,19 +630,16 @@ explain (costs off) create table t_rep as select i > nextval('test_seq') from ge
                                        QUERY PLAN                                        
 -----------------------------------------------------------------------------------------
  Result
-   ->  Broadcast Motion 1:3  (slice1)
+   ->  Broadcast Motion 3:3  (slice1; segments: 3)
          ->  GroupAggregate
                Group Key: ((generate_series > nextval('test_seq'::regclass)))
-               ->  Gather Motion 3:1  (slice2; segments: 3)
-                     Merge Key: ((generate_series > nextval('test_seq'::regclass)))
-                     ->  GroupAggregate
-                           Group Key: ((generate_series > nextval('test_seq'::regclass)))
-                           ->  Sort
-                                 Sort Key: ((generate_series > nextval('test_seq'::regclass)))
-                                 ->  Redistribute Motion 1:3  (slice3)
-                                       ->  Function Scan on generate_series
+               ->  Sort
+                     Sort Key: ((generate_series > nextval('test_seq'::regclass)))
+                     ->  Redistribute Motion 1:3  (slice2)
+                           Hash Key: ((generate_series > nextval('test_seq'::regclass)))
+                           ->  Function Scan on generate_series
  Optimizer: Pivotal Optimizer (GPORCA)
-(13 rows)
+(10 rows)
 
 create table t_rep3 as select i > nextval('test_seq') as a from generate_series(5, 15) as i group by i > nextval('test_seq') distributed replicated;
 select count(*) from gp_dist_random('t_rep3');

--- a/src/test/regress/expected/bitmap_index_optimizer.out
+++ b/src/test/regress/expected/bitmap_index_optimizer.out
@@ -984,20 +984,19 @@ select gp_inject_fault('simulate_bitmap_and', 'skip', dbid) from gp_segment_conf
 (1 row)
 
 explain (costs off) select count(*) from bmunion where a = 53 and b < 3;
-                           QUERY PLAN                           
---------------------------------------------------------------------
- Finalize Aggregate
+                          QUERY PLAN                          
+--------------------------------------------------------------
+ Aggregate
    ->  Gather Motion 1:1  (slice1; segments: 1)
-         ->  Partial Aggregate
-               ->  Bitmap Heap Scan on bmunion
-                     Recheck Cond: ((a = 53) AND (b < 3))
-                     ->  BitmapAnd
-                           ->  Bitmap Index Scan on bmu_i_bmtest2_a
-                                 Index Cond: (a = 53)
-                           ->  Bitmap Index Scan on bmu_i_bmtest2_b
-                                 Index Cond: (b < 3)
+         ->  Bitmap Heap Scan on bmunion
+               Recheck Cond: ((a = 53) AND (b < 3))
+               ->  BitmapAnd
+                     ->  Bitmap Index Scan on bmu_i_bmtest2_a
+                           Index Cond: (a = 53)
+                     ->  Bitmap Index Scan on bmu_i_bmtest2_b
+                           Index Cond: (b < 3)
  Optimizer: Pivotal Optimizer (GPORCA)
-(11 rows)
+(10 rows)
 
 select gp_inject_fault('simulate_bitmap_and', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = -1;
  gp_inject_fault 

--- a/src/test/regress/expected/bitmapops_optimizer.out
+++ b/src/test/regress/expected/bitmapops_optimizer.out
@@ -54,16 +54,15 @@ CREATE INDEX i_bmtest2_b ON bmscantest2 USING BITMAP(b);
 CREATE INDEX i_bmtest2_c ON bmscantest2(c);
 CREATE INDEX i_bmtest2_d ON bmscantest2(d);
 EXPLAIN SELECT count(*) FROM bmscantest2 WHERE a = 1 AND b = 1 AND c = 1;
-                                           QUERY PLAN                                            
--------------------------------------------------------------------------------------------------
- Finalize Aggregate  (cost=0.00..6.35 rows=1 width=8)
-   ->  Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..6.35 rows=1 width=8)
-         ->  Partial Aggregate  (cost=0.00..6.35 rows=1 width=8)
-               ->  Index Scan using i_bmtest2_c on bmscantest2  (cost=0.00..6.35 rows=1 width=1)
-                     Index Cond: (c = 1)
-                     Filter: ((a = 1) AND (b = 1))
- Optimizer: Pivotal Optimizer (GPORCA)
-(7 rows)
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..6.35 rows=1 width=8)
+   ->  Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..6.35 rows=2 width=1)
+         ->  Index Scan using i_bmtest2_c on bmscantest2  (cost=0.00..6.35 rows=2 width=1)
+               Index Cond: (c = 1)
+               Filter: ((a = 1) AND (b = 1))
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.95.0
+(6 rows)
 
 SELECT count(*) FROM bmscantest2 WHERE a = 1 AND b = 1 AND c = 1;
  count 
@@ -121,23 +120,22 @@ CREATE INDEX i_bmtest_ao_b ON bmscantest_ao USING BITMAP(b);
 CREATE INDEX i_bmtest_ao_c ON bmscantest_ao(c);
 CREATE INDEX i_bmtest_ao_d ON bmscantest_ao(d);
 EXPLAIN SELECT count(*) FROM bmscantest_ao WHERE a = 1 AND b = 1 AND c = 1;
-                                                QUERY PLAN                                                
-----------------------------------------------------------------------------------------------------------
- Finalize Aggregate  (cost=0.00..431.06 rows=1 width=8)
-   ->  Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..431.06 rows=1 width=8)
-         ->  Partial Aggregate  (cost=0.00..431.06 rows=1 width=8)
-               ->  Bitmap Heap Scan on bmscantest_ao  (cost=0.00..431.06 rows=1 width=1)
-                     Recheck Cond: ((b = 1) AND (a = 1) AND (c = 1))
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..431.06 rows=1 width=8)
+   ->  Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..431.06 rows=2 width=1)
+         ->  Bitmap Heap Scan on bmscantest_ao  (cost=0.00..431.06 rows=1 width=1)
+               Recheck Cond: ((b = 1) AND (a = 1) AND (c = 1))
+               ->  BitmapAnd  (cost=0.00..0.00 rows=0 width=0)
                      ->  BitmapAnd  (cost=0.00..0.00 rows=0 width=0)
-                           ->  BitmapAnd  (cost=0.00..0.00 rows=0 width=0)
-                                 ->  Bitmap Index Scan on i_bmtest_ao_b  (cost=0.00..0.00 rows=0 width=0)
-                                       Index Cond: (b = 1)
-                                 ->  Bitmap Index Scan on i_bmtest_ao_a  (cost=0.00..0.00 rows=0 width=0)
-                                       Index Cond: (a = 1)
-                           ->  Bitmap Index Scan on i_bmtest_ao_c  (cost=0.00..0.00 rows=0 width=0)
-                                 Index Cond: (c = 1)
- Optimizer: Pivotal Optimizer (GPORCA)
-(14 rows)
+                           ->  Bitmap Index Scan on i_bmtest_ao_b  (cost=0.00..0.00 rows=0 width=0)
+                                 Index Cond: (b = 1)
+                           ->  Bitmap Index Scan on i_bmtest_ao_a  (cost=0.00..0.00 rows=0 width=0)
+                                 Index Cond: (a = 1)
+                     ->  Bitmap Index Scan on i_bmtest_ao_c  (cost=0.00..0.00 rows=0 width=0)
+                           Index Cond: (c = 1)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.72.0
+(13 rows)
 
 SELECT count(*) FROM bmscantest_ao WHERE a = 1 AND b = 1 AND c = 1;
  count 
@@ -146,26 +144,25 @@ SELECT count(*) FROM bmscantest_ao WHERE a = 1 AND b = 1 AND c = 1;
 (1 row)
 
 EXPLAIN SELECT count(*) FROM bmscantest_ao WHERE a = 1 AND (b = 1 OR c = 1) AND d = 1;
-                                                QUERY PLAN                                                
-----------------------------------------------------------------------------------------------------------
- Finalize Aggregate  (cost=0.00..431.06 rows=1 width=8)
-   ->  Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..431.06 rows=1 width=8)
-         ->  Partial Aggregate  (cost=0.00..431.06 rows=1 width=8)
-               ->  Bitmap Heap Scan on bmscantest_ao  (cost=0.00..431.06 rows=1 width=1)
-                     Recheck Cond: (((b = 1) OR (c = 1)) AND ((d = 1) AND (a = 1)))
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..431.06 rows=1 width=8)
+   ->  Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..431.06 rows=3 width=1)
+         ->  Bitmap Heap Scan on bmscantest_ao  (cost=0.00..431.06 rows=1 width=1)
+               Recheck Cond: (((b = 1) OR (c = 1)) AND ((d = 1) AND (a = 1)))
+               ->  BitmapAnd  (cost=0.00..0.00 rows=0 width=0)
+                     ->  BitmapOr  (cost=0.00..0.00 rows=0 width=0)
+                           ->  Bitmap Index Scan on i_bmtest_ao_b  (cost=0.00..0.00 rows=0 width=0)
+                                 Index Cond: (b = 1)
+                           ->  Bitmap Index Scan on i_bmtest_ao_c  (cost=0.00..0.00 rows=0 width=0)
+                                 Index Cond: (c = 1)
                      ->  BitmapAnd  (cost=0.00..0.00 rows=0 width=0)
-                           ->  BitmapOr  (cost=0.00..0.00 rows=0 width=0)
-                                 ->  Bitmap Index Scan on i_bmtest_ao_b  (cost=0.00..0.00 rows=0 width=0)
-                                       Index Cond: (b = 1)
-                                 ->  Bitmap Index Scan on i_bmtest_ao_c  (cost=0.00..0.00 rows=0 width=0)
-                                       Index Cond: (c = 1)
-                           ->  BitmapAnd  (cost=0.00..0.00 rows=0 width=0)
-                                 ->  Bitmap Index Scan on i_bmtest_ao_d  (cost=0.00..0.00 rows=0 width=0)
-                                       Index Cond: (d = 1)
-                                 ->  Bitmap Index Scan on i_bmtest_ao_a  (cost=0.00..0.00 rows=0 width=0)
-                                       Index Cond: (a = 1)
- Optimizer: Pivotal Optimizer (GPORCA)
-(17 rows)
+                           ->  Bitmap Index Scan on i_bmtest_ao_d  (cost=0.00..0.00 rows=0 width=0)
+                                 Index Cond: (d = 1)
+                           ->  Bitmap Index Scan on i_bmtest_ao_a  (cost=0.00..0.00 rows=0 width=0)
+                                 Index Cond: (a = 1)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.72.0
+(16 rows)
 
 SELECT count(*) FROM bmscantest_ao WHERE a = 1 AND (b = 1 OR c = 1) AND d = 1;
  count 
@@ -239,23 +236,22 @@ CREATE INDEX i_bmtest_aocs_b ON bmscantest_aocs USING BITMAP(b);
 CREATE INDEX i_bmtest_aocs_c ON bmscantest_aocs(c);
 CREATE INDEX i_bmtest_aocs_d ON bmscantest_aocs(d);
 EXPLAIN SELECT count(*) FROM bmscantest_aocs WHERE a = 1 AND b = 1 AND c = 1;
-                                                 QUERY PLAN                                                 
-------------------------------------------------------------------------------------------------------------
- Finalize Aggregate  (cost=0.00..431.06 rows=1 width=8)
-   ->  Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..431.06 rows=1 width=8)
-         ->  Partial Aggregate  (cost=0.00..431.06 rows=1 width=8)
-               ->  Bitmap Heap Scan on bmscantest_aocs  (cost=0.00..431.06 rows=1 width=1)
-                     Recheck Cond: ((b = 1) AND (a = 1) AND (c = 1))
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..431.06 rows=1 width=8)
+   ->  Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..431.06 rows=2 width=1)
+         ->  Bitmap Heap Scan on bmscantest_aocs  (cost=0.00..431.06 rows=1 width=1)
+               Recheck Cond: ((b = 1) AND (a = 1) AND (c = 1))
+               ->  BitmapAnd  (cost=0.00..0.00 rows=0 width=0)
                      ->  BitmapAnd  (cost=0.00..0.00 rows=0 width=0)
-                           ->  BitmapAnd  (cost=0.00..0.00 rows=0 width=0)
-                                 ->  Bitmap Index Scan on i_bmtest_aocs_b  (cost=0.00..0.00 rows=0 width=0)
-                                       Index Cond: (b = 1)
-                                 ->  Bitmap Index Scan on i_bmtest_aocs_a  (cost=0.00..0.00 rows=0 width=0)
-                                       Index Cond: (a = 1)
-                           ->  Bitmap Index Scan on i_bmtest_aocs_c  (cost=0.00..0.00 rows=0 width=0)
-                                 Index Cond: (c = 1)
+                           ->  Bitmap Index Scan on i_bmtest_aocs_b  (cost=0.00..0.00 rows=0 width=0)
+                                 Index Cond: (b = 1)
+                           ->  Bitmap Index Scan on i_bmtest_aocs_a  (cost=0.00..0.00 rows=0 width=0)
+                                 Index Cond: (a = 1)
+                     ->  Bitmap Index Scan on i_bmtest_aocs_c  (cost=0.00..0.00 rows=0 width=0)
+                           Index Cond: (c = 1)
  Optimizer: Pivotal Optimizer (GPORCA)
-(14 rows)
+(13 rows)
 
 SELECT count(*) FROM bmscantest_aocs WHERE a = 1 AND b = 1 AND c = 1;
  count 
@@ -264,26 +260,25 @@ SELECT count(*) FROM bmscantest_aocs WHERE a = 1 AND b = 1 AND c = 1;
 (1 row)
 
 EXPLAIN SELECT count(*) FROM bmscantest_aocs WHERE a = 1 AND (b = 1 OR c = 1) AND d = 1;
-                                                 QUERY PLAN                                                 
-------------------------------------------------------------------------------------------------------------
- Finalize Aggregate  (cost=0.00..431.06 rows=1 width=8)
-   ->  Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..431.06 rows=1 width=8)
-         ->  Partial Aggregate  (cost=0.00..431.06 rows=1 width=8)
-               ->  Bitmap Heap Scan on bmscantest_aocs  (cost=0.00..431.06 rows=1 width=1)
-                     Recheck Cond: (((b = 1) OR (c = 1)) AND ((d = 1) AND (a = 1)))
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..431.06 rows=1 width=8)
+   ->  Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..431.06 rows=3 width=1)
+         ->  Bitmap Heap Scan on bmscantest_aocs  (cost=0.00..431.06 rows=1 width=1)
+               Recheck Cond: (((b = 1) OR (c = 1)) AND ((d = 1) AND (a = 1)))
+               ->  BitmapAnd  (cost=0.00..0.00 rows=0 width=0)
+                     ->  BitmapOr  (cost=0.00..0.00 rows=0 width=0)
+                           ->  Bitmap Index Scan on i_bmtest_aocs_b  (cost=0.00..0.00 rows=0 width=0)
+                                 Index Cond: (b = 1)
+                           ->  Bitmap Index Scan on i_bmtest_aocs_c  (cost=0.00..0.00 rows=0 width=0)
+                                 Index Cond: (c = 1)
                      ->  BitmapAnd  (cost=0.00..0.00 rows=0 width=0)
-                           ->  BitmapOr  (cost=0.00..0.00 rows=0 width=0)
-                                 ->  Bitmap Index Scan on i_bmtest_aocs_b  (cost=0.00..0.00 rows=0 width=0)
-                                       Index Cond: (b = 1)
-                                 ->  Bitmap Index Scan on i_bmtest_aocs_c  (cost=0.00..0.00 rows=0 width=0)
-                                       Index Cond: (c = 1)
-                           ->  BitmapAnd  (cost=0.00..0.00 rows=0 width=0)
-                                 ->  Bitmap Index Scan on i_bmtest_aocs_d  (cost=0.00..0.00 rows=0 width=0)
-                                       Index Cond: (d = 1)
-                                 ->  Bitmap Index Scan on i_bmtest_aocs_a  (cost=0.00..0.00 rows=0 width=0)
-                                       Index Cond: (a = 1)
+                           ->  Bitmap Index Scan on i_bmtest_aocs_d  (cost=0.00..0.00 rows=0 width=0)
+                                 Index Cond: (d = 1)
+                           ->  Bitmap Index Scan on i_bmtest_aocs_a  (cost=0.00..0.00 rows=0 width=0)
+                                 Index Cond: (a = 1)
  Optimizer: Pivotal Optimizer (GPORCA)
-(17 rows)
+(16 rows)
 
 SELECT count(*) FROM bmscantest_aocs WHERE a = 1 AND (b = 1 OR c = 1) AND d = 1;
  count 

--- a/src/test/regress/expected/create_index_optimizer.out
+++ b/src/test/regress/expected/create_index_optimizer.out
@@ -408,16 +408,15 @@ SELECT count(*) FROM gcircle_tbl WHERE f1 && '<(500,500),500>'::circle;
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM point_tbl WHERE f1 <@ box '(0,0,100,100)';
-                           QUERY PLAN                           
-----------------------------------------------------------------
- Finalize Aggregate
+                        QUERY PLAN                        
+----------------------------------------------------------
+ Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial Aggregate
-               ->  Index Scan using gpointind on point_tbl
-                     Index Cond: (f1 <@ '(100,100),(0,0)'::box)
-                     Filter: (f1 <@ '(100,100),(0,0)'::box)
- Optimizer: Pivotal Optimizer (GPORCA)
-(7 rows)
+         ->  Index Scan using gpointind on point_tbl
+               Index Cond: (f1 <@ '(100,100),(0,0)'::box)
+               Filter: (f1 <@ '(100,100),(0,0)'::box)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(6 rows)
 
 SELECT count(*) FROM point_tbl WHERE f1 <@ box '(0,0,100,100)';
  count 
@@ -427,16 +426,15 @@ SELECT count(*) FROM point_tbl WHERE f1 <@ box '(0,0,100,100)';
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM point_tbl WHERE box '(0,0,100,100)' @> f1;
-                           QUERY PLAN                           
-----------------------------------------------------------------
- Finalize Aggregate
+                        QUERY PLAN                        
+----------------------------------------------------------
+ Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial Aggregate
-               ->  Index Scan using gpointind on point_tbl
-                     Index Cond: (f1 <@ '(100,100),(0,0)'::box)
-                     Filter: (f1 <@ '(100,100),(0,0)'::box)
- Optimizer: Pivotal Optimizer (GPORCA)
-(7 rows)
+         ->  Index Scan using gpointind on point_tbl
+               Index Cond: (f1 <@ '(100,100),(0,0)'::box)
+               Filter: (f1 <@ '(100,100),(0,0)'::box)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(6 rows)
 
 SELECT count(*) FROM point_tbl WHERE box '(0,0,100,100)' @> f1;
  count 
@@ -446,16 +444,15 @@ SELECT count(*) FROM point_tbl WHERE box '(0,0,100,100)' @> f1;
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM point_tbl WHERE f1 <@ polygon '(0,0),(0,100),(100,100),(50,50),(100,0),(0,0)';
-                                             QUERY PLAN                                             
-----------------------------------------------------------------------------------------------------
- Finalize Aggregate
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial Aggregate
-               ->  Index Scan using gpointind on point_tbl
-                     Index Cond: (f1 <@ '((0,0),(0,100),(100,100),(50,50),(100,0),(0,0))'::polygon)
-                     Filter: (f1 <@ '((0,0),(0,100),(100,100),(50,50),(100,0),(0,0))'::polygon)
- Optimizer: Pivotal Optimizer (GPORCA)
-(7 rows)
+         ->  Index Scan using gpointind on point_tbl
+               Index Cond: (f1 <@ '((0,0),(0,100),(100,100),(50,50),(100,0),(0,0))'::polygon)
+               Filter: (f1 <@ '((0,0),(0,100),(100,100),(50,50),(100,0),(0,0))'::polygon)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(6 rows)
 
 SELECT count(*) FROM point_tbl WHERE f1 <@ polygon '(0,0),(0,100),(100,100),(50,50),(100,0),(0,0)';
  count 
@@ -465,16 +462,15 @@ SELECT count(*) FROM point_tbl WHERE f1 <@ polygon '(0,0),(0,100),(100,100),(50,
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM point_tbl WHERE f1 <@ circle '<(50,50),50>';
-                           QUERY PLAN                           
-----------------------------------------------------------------
- Finalize Aggregate
+                        QUERY PLAN                        
+----------------------------------------------------------
+ Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial Aggregate
-               ->  Index Scan using gpointind on point_tbl
-                     Index Cond: (f1 <@ '<(50,50),50>'::circle)
-                     Filter: (f1 <@ '<(50,50),50>'::circle)
- Optimizer: Pivotal Optimizer (GPORCA)
-(7 rows)
+         ->  Index Scan using gpointind on point_tbl
+               Index Cond: (f1 <@ '<(50,50),50>'::circle)
+               Filter: (f1 <@ '<(50,50),50>'::circle)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(6 rows)
 
 SELECT count(*) FROM point_tbl WHERE f1 <@ circle '<(50,50),50>';
  count 
@@ -484,16 +480,15 @@ SELECT count(*) FROM point_tbl WHERE f1 <@ circle '<(50,50),50>';
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM point_tbl p WHERE p.f1 << '(0.0, 0.0)';
-                        QUERY PLAN                         
------------------------------------------------------------
- Finalize Aggregate
+                     QUERY PLAN                      
+-----------------------------------------------------
+ Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial Aggregate
-               ->  Index Scan using gpointind on point_tbl
-                     Index Cond: (f1 << '(0,0)'::point)
-                     Filter: (f1 << '(0,0)'::point)
- Optimizer: Pivotal Optimizer (GPORCA)
-(7 rows)
+         ->  Index Scan using gpointind on point_tbl
+               Index Cond: (f1 << '(0,0)'::point)
+               Filter: (f1 << '(0,0)'::point)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(6 rows)
 
 SELECT count(*) FROM point_tbl p WHERE p.f1 << '(0.0, 0.0)';
  count 
@@ -503,16 +498,15 @@ SELECT count(*) FROM point_tbl p WHERE p.f1 << '(0.0, 0.0)';
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM point_tbl p WHERE p.f1 >> '(0.0, 0.0)';
-                        QUERY PLAN                         
------------------------------------------------------------
- Finalize Aggregate
+                     QUERY PLAN                      
+-----------------------------------------------------
+ Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial Aggregate
-               ->  Index Scan using gpointind on point_tbl
-                     Index Cond: (f1 >> '(0,0)'::point)
-                     Filter: (f1 >> '(0,0)'::point)
- Optimizer: Pivotal Optimizer (GPORCA)
-(7 rows)
+         ->  Index Scan using gpointind on point_tbl
+               Index Cond: (f1 >> '(0,0)'::point)
+               Filter: (f1 >> '(0,0)'::point)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(6 rows)
 
 SELECT count(*) FROM point_tbl p WHERE p.f1 >> '(0.0, 0.0)';
  count 
@@ -522,16 +516,15 @@ SELECT count(*) FROM point_tbl p WHERE p.f1 >> '(0.0, 0.0)';
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM point_tbl p WHERE p.f1 <^ '(0.0, 0.0)';
-                        QUERY PLAN                         
------------------------------------------------------------
- Finalize Aggregate
+                     QUERY PLAN                      
+-----------------------------------------------------
+ Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial Aggregate
-               ->  Index Scan using gpointind on point_tbl
-                     Index Cond: (f1 <^ '(0,0)'::point)
-                     Filter: (f1 <^ '(0,0)'::point)
- Optimizer: Pivotal Optimizer (GPORCA)
-(7 rows)
+         ->  Index Scan using gpointind on point_tbl
+               Index Cond: (f1 <^ '(0,0)'::point)
+               Filter: (f1 <^ '(0,0)'::point)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(6 rows)
 
 SELECT count(*) FROM point_tbl p WHERE p.f1 <^ '(0.0, 0.0)';
  count 
@@ -541,16 +534,15 @@ SELECT count(*) FROM point_tbl p WHERE p.f1 <^ '(0.0, 0.0)';
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM point_tbl p WHERE p.f1 >^ '(0.0, 0.0)';
-                        QUERY PLAN                         
------------------------------------------------------------
- Finalize Aggregate
+                     QUERY PLAN                      
+-----------------------------------------------------
+ Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial Aggregate
-               ->  Index Scan using gpointind on point_tbl
-                     Index Cond: (f1 >^ '(0,0)'::point)
-                     Filter: (f1 >^ '(0,0)'::point)
- Optimizer: Pivotal Optimizer (GPORCA)
-(7 rows)
+         ->  Index Scan using gpointind on point_tbl
+               Index Cond: (f1 >^ '(0,0)'::point)
+               Filter: (f1 >^ '(0,0)'::point)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(6 rows)
 
 SELECT count(*) FROM point_tbl p WHERE p.f1 >^ '(0.0, 0.0)';
  count 
@@ -560,16 +552,15 @@ SELECT count(*) FROM point_tbl p WHERE p.f1 >^ '(0.0, 0.0)';
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM point_tbl p WHERE p.f1 ~= '(-5, -12)';
-                        QUERY PLAN                         
------------------------------------------------------------
- Finalize Aggregate
+                     QUERY PLAN                      
+-----------------------------------------------------
+ Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial Aggregate
-               ->  Index Scan using gpointind on point_tbl
-                     Index Cond: (f1 ~= '(-5,-12)'::point)
-                     Filter: (f1 ~= '(-5,-12)'::point)
- Optimizer: Pivotal Optimizer (GPORCA)
-(7 rows)
+         ->  Index Scan using gpointind on point_tbl
+               Index Cond: (f1 ~= '(-5,-12)'::point)
+               Filter: (f1 ~= '(-5,-12)'::point)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(6 rows)
 
 SELECT count(*) FROM point_tbl p WHERE p.f1 ~= '(-5, -12)';
  count 
@@ -1863,16 +1854,15 @@ SELECT * FROM tenk1
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM tenk1
   WHERE hundred = 42 AND (thousand = 42 OR thousand = 99);
-                            QUERY PLAN                            
-------------------------------------------------------------------
- Finalize Aggregate
+                         QUERY PLAN                         
+------------------------------------------------------------
+ Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial Aggregate
-               ->  Index Scan using tenk1_hundred on tenk1
-                     Index Cond: (hundred = 42)
-                     Filter: ((thousand = 42) OR (thousand = 99))
+         ->  Index Scan using tenk1_hundred on tenk1
+               Index Cond: (hundred = 42)
+               Filter: ((thousand = 42) OR (thousand = 99))
  Optimizer: Pivotal Optimizer (GPORCA)
-(7 rows)
+(6 rows)
 
 SELECT count(*) FROM tenk1
   WHERE hundred = 42 AND (thousand = 42 OR thousand = 99);

--- a/src/test/regress/expected/dpe_optimizer.out
+++ b/src/test/regress/expected/dpe_optimizer.out
@@ -244,16 +244,10 @@ explain (costs off, timing off, summary off, analyze) select * from pt where pti
                                        Executor Memory: 178kB  Segments: 3  Max: 60kB (segment 0)
                                        ->  Redistribute Motion 3:3  (slice3; segments: 3) (actual rows=2 loops=1)
                                              Hash Key: t.tid
-                                             ->  GroupAggregate (actual rows=2 loops=1)
-                                                   Group Key: t.tid
-                                                   ->  Sort (actual rows=2 loops=1)
-                                                         Sort Key: t.tid
-                                                         Sort Method:  quicksort  Memory: 75kB
-                                                         Executor Memory: 178kB  Segments: 3  Max: 60kB (segment 0)
-                                                         ->  Seq Scan on t (actual rows=2 loops=1)
-                                                               Filter: (t1 = ('hello'::text || (tid)::text))
+                                             ->  Seq Scan on t (actual rows=2 loops=1)
+                                                   Filter: (t1 = ('hello'::text || (tid)::text))
  Optimizer: Pivotal Optimizer (GPORCA)
-(28 rows)
+(20 rows)
 
 select * from pt where ptid in (select tid from t where t1 = 'hello' || tid);
  dist |   pt1   |  pt2  |    pt3    | ptid 
@@ -303,16 +297,10 @@ explain (costs off, timing off, summary off, analyze) select * from pt where exi
                                        Executor Memory: 76kB  Segments: 3  Max: 26kB (segment 1)
                                        ->  Redistribute Motion 3:3  (slice3; segments: 3) (actual rows=2 loops=1)
                                              Hash Key: t.tid
-                                             ->  GroupAggregate (actual rows=2 loops=1)
-                                                   Group Key: t.tid
-                                                   ->  Sort (actual rows=2 loops=1)
-                                                         Sort Key: t.tid
-                                                         Sort Method:  quicksort  Memory: 75kB
-                                                         Executor Memory: 76kB  Segments: 3  Max: 26kB (segment 1)
-                                                         ->  Seq Scan on t (actual rows=2 loops=1)
-                                                               Filter: (t1 = ('hello'::text || (tid)::text))
+                                             ->  Seq Scan on t (actual rows=2 loops=1)
+                                                   Filter: (t1 = ('hello'::text || (tid)::text))
  Optimizer: Pivotal Optimizer (GPORCA)
-(28 rows)
+(20 rows)
 
 select * from pt where exists (select 1 from t where tid = ptid and t1 = 'hello' || tid);
  dist |   pt1   |  pt2  |    pt3    | ptid 

--- a/src/test/regress/expected/eagerfree_optimizer.out
+++ b/src/test/regress/expected/eagerfree_optimizer.out
@@ -41,29 +41,26 @@ select d, count(*) from smallt group by d;
 (20 rows)
 
 explain analyze select d, count(*) from smallt group by d;
-                                                                QUERY PLAN                                                                 
--------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.01 rows=20 width=12) (actual time=1.771..1.794 rows=20 loops=1)
-   ->  Finalize HashAggregate  (cost=0.00..431.01 rows=7 width=12) (actual time=1.533..1.535 rows=7 loops=1)
+                                                                    QUERY PLAN                                                                    
+--------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.01 rows=20 width=12) (actual time=1.785..1.787 rows=20 loops=1)
+   ->  GroupAggregate  (cost=0.00..431.01 rows=7 width=12) (actual time=1.513..1.522 rows=7 loops=1)
          Group Key: d
-         Peak Memory Usage: 0 kB
-         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.01 rows=7 width=12) (actual time=0.577..1.519 rows=7 loops=1)
-               Hash Key: d
-               ->  Partial GroupAggregate  (cost=0.00..431.01 rows=7 width=12) (actual time=0.132..0.167 rows=10 loops=1)
-                     Group Key: d
-                     ->  Sort  (cost=0.00..431.00 rows=34 width=4) (actual time=0.124..0.145 rows=50 loops=1)
-                           Sort Key: d
-                           Sort Method:  quicksort  Memory: 79kB
-                           Executor Memory: 79kB  Segments: 3  Max: 27kB (segment 0)
-                           ->  Seq Scan on smallt  (cost=0.00..431.00 rows=34 width=4) (actual time=0.089..0.101 rows=50 loops=1)
- Optimizer: Pivotal Optimizer (GPORCA)
- Planning Time: 7.563 ms
-   (slice0)    Executor memory: 44K bytes.
-   (slice1)    Executor memory: 19K bytes avg x 3 workers, 19K bytes max (seg1).  Work_mem: 24K bytes max.
-   (slice2)    Executor memory: 39K bytes avg x 3 workers, 39K bytes max (seg0).  Work_mem: 27K bytes max.
+         ->  Sort  (cost=0.00..431.01 rows=34 width=4) (actual time=1.510..1.513 rows=35 loops=1)
+               Sort Key: d
+               Sort Method:  quicksort  Memory: 99kB
+               Executor Memory: 79kB  Segments: 3  Max: 27kB (segment 1)
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=34 width=4) (actual time=0.342..1.481 rows=35 loops=1)
+                     Hash Key: d
+                     ->  Seq Scan on smallt  (cost=0.00..431.00 rows=34 width=4) (actual time=0.002..0.004 rows=50 loops=1)
+ Planning time: 17.216 ms
+   (slice0)    Executor memory: 63K bytes.
+   (slice1)    Executor memory: 42K bytes avg x 3 workers, 42K bytes max (seg0).
+   (slice2)    Executor memory: 64K bytes avg x 3 workers, 64K bytes max (seg0).  Work_mem: 33K bytes max.
  Memory used:  128000kB
- Execution Time: 2.468 ms
-(20 rows)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
+ Execution time: 2.061 ms
+(17 rows)
 
 select * from
   test_util.extract_plan_stats($$
@@ -88,20 +85,20 @@ select count(*) from (select i, t, d, count(*) from bigt group by i, t, d) tmp;
 explain analyze select count(*) from (select i, t, d, count(*) from bigt group by i, t, d) tmp;
                                                              QUERY PLAN                                                              
 -------------------------------------------------------------------------------------------------------------------------------------
- Finalize Aggregate  (cost=0.00..571.26 rows=1 width=8) (actual time=811.293..811.294 rows=1 loops=1)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..571.26 rows=1 width=8) (actual time=807.939..811.283 rows=3 loops=1)
-         ->  Partial Aggregate  (cost=0.00..571.26 rows=1 width=8) (actual time=810.862..810.862 rows=1 loops=1)
-               ->  HashAggregate  (cost=0.00..571.26 rows=333334 width=1) (actual time=419.883..804.251 rows=44538 loops=1)
+ Finalize Aggregate  (cost=0.00..571.36 rows=1 width=8) (actual time=362.957..362.957 rows=1 loops=1)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..571.36 rows=1 width=8) (actual time=265.826..362.941 rows=3 loops=1)
+         ->  Partial Aggregate  (cost=0.00..571.36 rows=1 width=8) (actual time=265.338..265.338 rows=1 loops=1)
+               ->  HashAggregate  (cost=0.00..571.36 rows=333580 width=1) (actual time=338.390..356.986 rows=44572 loops=1)
                      Group Key: i, t, d
-                     Planned Partitions: 16
-                     Peak Memory Usage: 0 kB
-                     ->  Seq Scan on bigt  (cost=0.00..439.80 rows=333334 width=18) (actual time=0.179..221.262 rows=334620 loops=1)
- Optimizer: Pivotal Optimizer (GPORCA)
- Planning Time: 7.650 ms
-   (slice0)    Executor memory: 426K bytes.
-   (slice1)    Executor memory: 1705K bytes avg x 3 workers, 1705K bytes max (seg1).  Work_mem: 2961K bytes max.
+                     (seg0)   44435 groups total in 32 batches; 1 overflows; 44435 spill groups.
+                     (seg0)   Hash chain length 2.8 avg, 10 max, using 30315 of 32768 buckets; total 9 expansions.
+                     ->  Seq Scan on bigt  (cost=0.00..439.81 rows=333580 width=18) (actual time=0.026..49.692 rows=333530 loops=1)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)  * Executor memory: 3180K bytes avg x 3 workers, 3180K bytes max (seg0).  Work_mem: 2461K bytes max, 4866K bytes wanted.
  Memory used:  2560kB
- Execution Time: 817.319 ms
+ Memory wanted:  5265kB
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.67.0
+ Total runtime: 363.922 ms
 (14 rows)
 
 set statement_mem=128000;
@@ -115,33 +112,22 @@ select count(distinct d) from smallt;
 (1 row)
 
 explain analyze select count(distinct d) from smallt;
-                                                                      QUERY PLAN                                                                      
-------------------------------------------------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=0.00..431.01 rows=1 width=8) (actual time=2.028..2.029 rows=1 loops=1)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.01 rows=20 width=4) (actual time=1.985..2.017 rows=20 loops=1)
-         ->  GroupAggregate  (cost=0.00..431.01 rows=7 width=4) (actual time=1.693..1.699 rows=7 loops=1)
-               Group Key: d
-               ->  Sort  (cost=0.00..431.01 rows=7 width=4) (actual time=1.686..1.688 rows=7 loops=1)
-                     Sort Key: d
-                     Sort Method:  quicksort  Memory: 75kB
-                     Executor Memory: 76kB  Segments: 3  Max: 26kB (segment 1)
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.01 rows=7 width=4) (actual time=1.631..1.678 rows=7 loops=1)
-                           Hash Key: d
-                           ->  GroupAggregate  (cost=0.00..431.01 rows=7 width=4) (actual time=0.182..0.221 rows=10 loops=1)
-                                 Group Key: d
-                                 ->  Sort  (cost=0.00..431.00 rows=34 width=4) (actual time=0.176..0.202 rows=50 loops=1)
-                                       Sort Key: d
-                                       Sort Method:  quicksort  Memory: 79kB
-                                       Executor Memory: 79kB  Segments: 3  Max: 27kB (segment 0)
-                                       ->  Seq Scan on smallt  (cost=0.00..431.00 rows=34 width=4) (actual time=0.143..0.155 rows=50 loops=1)
- Optimizer: Pivotal Optimizer (GPORCA)
- Planning Time: 7.912 ms
-   (slice0)    Executor memory: 50K bytes.
-   (slice1)    Executor memory: 43K bytes avg x 3 workers, 43K bytes max (seg1).  Work_mem: 26K bytes max.
-   (slice2)    Executor memory: 39K bytes avg x 3 workers, 39K bytes max (seg0).  Work_mem: 27K bytes max.
+                                                                    QUERY PLAN                                                                    
+--------------------------------------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate  (cost=0.00..431.00 rows=1 width=8) (actual time=1.637..1.637 rows=1 loops=1)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=8) (actual time=1.631..1.633 rows=3 loops=1)
+         ->  Partial Aggregate  (cost=0.00..431.00 rows=1 width=8) (actual time=1.408..1.408 rows=1 loops=1)
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=34 width=4) (actual time=1.396..1.402 rows=35 loops=1)
+                     Hash Key: d
+                     ->  Seq Scan on smallt  (cost=0.00..431.00 rows=34 width=4) (actual time=0.002..0.006 rows=50 loops=1)
+ Planning time: 19.307 ms
+   (slice0)    Executor memory: 59K bytes.
+   (slice1)    Executor memory: 42K bytes avg x 3 workers, 42K bytes max (seg0).
+   (slice2)    Executor memory: 64K bytes avg x 3 workers, 64K bytes max (seg0).  Work_mem: 33K bytes max.
  Memory used:  128000kB
- Execution Time: 2.652 ms
-(24 rows)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
+ Execution time: 1.904 ms
+(13 rows)
 
 set statement_mem=2560;
 select count(distinct d) from bigt;
@@ -153,25 +139,21 @@ select count(distinct d) from bigt;
 explain analyze select count(distinct d) from bigt;
                                                                          QUERY PLAN                                                                         
 ------------------------------------------------------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=0.00..485.81 rows=1 width=8) (actual time=943.870..943.870 rows=1 loops=1)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..485.79 rows=49431 width=4) (actual time=918.782..936.036 rows=50000 loops=1)
-         ->  HashAggregate  (cost=0.00..485.05 rows=16477 width=4) (actual time=918.032..929.811 rows=16746 loops=1)
-               Group Key: d
-               Peak Memory Usage: 0 kB
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..483.03 rows=16477 width=4) (actual time=368.473..904.774 rows=27966 loops=1)
+ Finalize Aggregate  (cost=0.00..446.60 rows=1 width=8) (actual time=394.139..394.139 rows=1 loops=1)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..446.60 rows=1 width=8) (actual time=388.126..394.130 rows=3 loops=1)
+         ->  Partial Aggregate  (cost=0.00..446.60 rows=1 width=8) (actual time=393.902..393.903 rows=1 loops=1)
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..446.45 rows=333334 width=4) (actual time=0.670..118.334 rows=334920 loops=1)
                      Hash Key: d
-                     ->  Streaming HashAggregate  (cost=0.00..482.82 rows=16477 width=4) (actual time=365.944..903.928 rows=27915 loops=1)
-                           Group Key: d
-                           Peak Memory Usage: 0 kB
-                           ->  Seq Scan on bigt  (cost=0.00..439.80 rows=333334 width=4) (actual time=0.144..234.229 rows=334620 loops=1)
- Optimizer: Pivotal Optimizer (GPORCA)
- Planning Time: 8.839 ms
-   (slice0)    Executor memory: 835K bytes.
-   (slice1)    Executor memory: 876K bytes avg x 3 workers, 876K bytes max (seg0).  Work_mem: 1553K bytes max.
-   (slice2)    Executor memory: 886K bytes avg x 3 workers, 918K bytes max (seg0).  Work_mem: 1553K bytes max.
+                     ->  Seq Scan on bigt  (cost=0.00..439.80 rows=333334 width=4) (actual time=0.013..46.779 rows=334620 loops=1)
+ Planning time: 27.350 ms
+   (slice0)    Executor memory: 59K bytes.
+   (slice1)    Executor memory: 68K bytes avg x 3 workers, 68K bytes max (seg0).
+ * (slice2)    Executor memory: 2768K bytes avg x 3 workers, 2768K bytes max (seg0).  Work_mem: 2617K bytes max, 7876K bytes wanted.
  Memory used:  2560kB
- Execution Time: 944.791 ms
-(18 rows)
+ Memory wanted:  8275kB
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
+ Execution time: 394.389 ms
+(14 rows)
 
 set statement_mem=128000;
 set gp_enable_agg_distinct=on;
@@ -212,44 +194,39 @@ where t1.d = t2.d;
 explain analyze select t1.*, t2.* from
 (select d, count(*) from smallt group by d) as t1, (select d, sum(i) from smallt group by d) as t2
 where t1.d = t2.d;
-                                                                      QUERY PLAN                                                                       
--------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.02 rows=20 width=24) (actual time=4.404..4.423 rows=20 loops=1)
-   ->  Hash Join  (cost=0.00..862.02 rows=7 width=24) (actual time=3.753..4.145 rows=7 loops=1)
+                                                                              QUERY PLAN                                                                               
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..862.02 rows=20 width=24) (actual time=1.873..1.922 rows=20 loops=1)
+   ->  Hash Join  (cost=0.00..862.02 rows=7 width=24) (actual time=1.498..1.631 rows=7 loops=1)
          Hash Cond: (smallt.d = smallt_1.d)
-         Extra Text: (seg1)   Hash chain length 1.0 avg, 1 max, using 7 of 131072 buckets.
-         ->  Finalize HashAggregate  (cost=0.00..431.01 rows=7 width=12) (actual time=0.166..0.169 rows=7 loops=1)
+         Extra Text: (seg1)   Hash chain length 1.0 avg, 1 max, using 7 of 131072 buckets.Hash chain length 1.2 avg, 2 max, using 6 of 32 buckets; total 0 expansions.
+ 
+         ->  GroupAggregate  (cost=0.00..431.01 rows=7 width=12) (actual time=0.032..0.038 rows=7 loops=1)
                Group Key: smallt.d
-               Peak Memory Usage: 0 kB
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.01 rows=7 width=12) (actual time=0.048..0.148 rows=7 loops=1)
-                     Hash Key: smallt.d
-                     ->  Partial GroupAggregate  (cost=0.00..431.01 rows=7 width=12) (actual time=0.858..0.889 rows=10 loops=1)
-                           Group Key: smallt.d
-                           ->  Sort  (cost=0.00..431.00 rows=34 width=4) (actual time=0.850..0.864 rows=50 loops=1)
-                                 Sort Key: smallt.d
-                                 Sort Method:  quicksort  Memory: 79kB
-                                 Executor Memory: 79kB  Segments: 3  Max: 27kB (segment 0)
-                                 ->  Seq Scan on smallt  (cost=0.00..431.00 rows=34 width=4) (actual time=0.799..0.814 rows=50 loops=1)
-         ->  Hash  (cost=431.01..431.01 rows=7 width=12) (actual time=3.117..3.117 rows=7 loops=1)
-               Buckets: 131072  Batches: 1  Memory Usage: 1025kB
-               ->  Finalize HashAggregate  (cost=0.00..431.01 rows=7 width=12) (actual time=3.105..3.108 rows=7 loops=1)
+               ->  Sort  (cost=0.00..431.01 rows=34 width=4) (actual time=0.029..0.032 rows=35 loops=1)
+                     Sort Key: smallt.d
+                     Sort Method:  quicksort  Memory: 99kB
+                     Executor Memory: 79kB  Segments: 3  Max: 27kB (segment 1)
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=34 width=4) (actual time=0.004..0.011 rows=35 loops=1)
+                           Hash Key: smallt.d
+                           ->  Seq Scan on smallt  (cost=0.00..431.00 rows=34 width=4) (actual time=0.003..0.018 rows=50 loops=1)
+         ->  Hash  (cost=431.01..431.01 rows=7 width=12) (actual time=1.402..1.402 rows=7 loops=1)
+               ->  HashAggregate  (cost=0.00..431.01 rows=7 width=12) (actual time=1.388..1.398 rows=7 loops=1)
                      Group Key: smallt_1.d
-                     Peak Memory Usage: 0 kB
-                     ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.01 rows=7 width=12) (actual time=2.520..3.089 rows=7 loops=1)
+                     Extra Text: (seg1)   Hash chain length 1.2 avg, 2 max, using 6 of 32 buckets; total 0 expansions.
+ 
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=34 width=8) (actual time=0.245..1.337 rows=35 loops=1)
                            Hash Key: smallt_1.d
-                           ->  Streaming Partial HashAggregate  (cost=0.00..431.01 rows=7 width=12) (actual time=1.471..1.474 rows=10 loops=1)
-                                 Group Key: smallt_1.d
-                                 Peak Memory Usage: 0 kB
-                                 ->  Seq Scan on smallt smallt_1  (cost=0.00..431.00 rows=34 width=8) (actual time=1.428..1.440 rows=50 loops=1)
- Optimizer: Pivotal Optimizer (GPORCA)
- Planning Time: 16.039 ms
-   (slice0)    Executor memory: 86K bytes.
-   (slice1)    Executor memory: 1097K bytes avg x 3 workers, 1098K bytes max (seg1).  Work_mem: 1025K bytes max.
-   (slice2)    Executor memory: 40K bytes avg x 3 workers, 40K bytes max (seg0).  Work_mem: 27K bytes max.
-   (slice3)    Executor memory: 38K bytes avg x 3 workers, 38K bytes max (seg0).  Work_mem: 24K bytes max.
+                           ->  Seq Scan on smallt smallt_1  (cost=0.00..431.00 rows=34 width=8) (actual time=0.003..0.018 rows=50 loops=1)
+ Planning time: 64.498 ms
+   (slice0)    Executor memory: 127K bytes.
+   (slice1)    Executor memory: 44K bytes avg x 3 workers, 44K bytes max (seg0).
+   (slice2)    Executor memory: 44K bytes avg x 3 workers, 44K bytes max (seg0).
+   (slice3)    Executor memory: 1192K bytes avg x 3 workers, 1192K bytes max (seg0).  Work_mem: 33K bytes max.
  Memory used:  128000kB
- Execution Time: 5.256 ms
-(35 rows)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
+ Execution time: 2.226 ms
+(29 rows)
 
 select * from
   test_util.extract_plan_stats($$
@@ -296,32 +273,30 @@ explain analyze select t1.*, t2.* from
 where t1.i = t2.i;
                                                                 QUERY PLAN                                                                 
 -------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.01 rows=10 width=24) (actual time=0.988..1.374 rows=10 loops=1)
-   ->  Hash Join  (cost=0.00..862.01 rows=4 width=24) (actual time=0.702..1.024 rows=5 loops=1)
-         Hash Cond: (smallt.i = smallt_1.i)
-         Extra Text: (seg0)   Hash chain length 1.0 avg, 1 max, using 5 of 131072 buckets.
-         ->  GroupAggregate  (cost=0.00..431.01 rows=4 width=12) (actual time=0.039..0.058 rows=5 loops=1)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.01 rows=10 width=24) (actual time=0.501..0.740 rows=5 loops=2)
+   ->  Hash Join  (cost=0.00..862.01 rows=4 width=24) (actual time=0.166..0.460 rows=2 loops=2)
+         Hash Cond: smallt.i = smallt_1.i
+         Extra Text: (seg0)   Hash chain length 1.0 avg, 1 max, using 4 of 131072 buckets.
+         ->  GroupAggregate  (cost=0.00..431.01 rows=4 width=12) (actual time=0.041..0.055 rows=2 loops=2)
                Group Key: smallt.i
-               ->  Sort  (cost=0.00..431.00 rows=34 width=4) (actual time=0.032..0.042 rows=50 loops=1)
+               ->  Sort  (cost=0.00..431.00 rows=34 width=4) (actual time=0.036..0.042 rows=20 loops=2)
                      Sort Key: smallt.i
-                     Sort Method:  quicksort  Memory: 79kB
+                     Sort Method:  quicksort  Memory: 99kB
                      Executor Memory: 79kB  Segments: 3  Max: 27kB (segment 0)
-                     ->  Seq Scan on smallt  (cost=0.00..431.00 rows=34 width=4) (actual time=0.005..0.015 rows=50 loops=1)
-         ->  Hash  (cost=431.01..431.01 rows=4 width=12) (actual time=0.226..0.227 rows=5 loops=1)
-               Buckets: 131072  Batches: 1  Memory Usage: 1025kB
-               ->  GroupAggregate  (cost=0.00..431.01 rows=4 width=12) (actual time=0.201..0.221 rows=5 loops=1)
+                     ->  Seq Scan on smallt  (cost=0.00..431.00 rows=34 width=4) (actual time=0.004..0.013 rows=20 loops=2)
+         ->  Hash  (cost=431.01..431.01 rows=4 width=12) (actual time=0.072..0.072 rows=2 loops=2)
+               ->  GroupAggregate  (cost=0.00..431.01 rows=4 width=12) (actual time=0.053..0.069 rows=2 loops=2)
                      Group Key: smallt_1.i
-                     ->  Sort  (cost=0.00..431.00 rows=34 width=4) (actual time=0.191..0.202 rows=50 loops=1)
+                     ->  Sort  (cost=0.00..431.00 rows=34 width=4) (actual time=0.048..0.053 rows=20 loops=2)
                            Sort Key: smallt_1.i
-                           Sort Method:  quicksort  Memory: 79kB
+                           Sort Method:  quicksort  Memory: 99kB
                            Executor Memory: 79kB  Segments: 3  Max: 27kB (segment 0)
-                           ->  Seq Scan on smallt smallt_1  (cost=0.00..431.00 rows=34 width=4) (actual time=0.159..0.169 rows=50 loops=1)
- Optimizer: Pivotal Optimizer (GPORCA)
- Planning Time: 14.621 ms
-   (slice0)    Executor memory: 57K bytes.
-   (slice1)    Executor memory: 1106K bytes avg x 3 workers, 1106K bytes max (seg0).  Work_mem: 1025K bytes max.
+                           ->  Seq Scan on smallt smallt_1  (cost=0.00..431.00 rows=34 width=4) (actual time=0.012..0.022 rows=20 loops=2)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 1238K bytes avg x 3 workers, 1238K bytes max (seg0).  Work_mem: 33K bytes max.
  Memory used:  128000kB
- Execution Time: 1.984 ms
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
+ Total runtime: 2.471 ms
 (26 rows)
 
 select * from
@@ -353,31 +328,28 @@ select d, count(*) from smallt group by d limit 5; --ignore
 (5 rows)
 
 explain analyze select d, count(*) from smallt group by d limit 5;
-                                                                      QUERY PLAN                                                                       
--------------------------------------------------------------------------------------------------------------------------------------------------------
- Limit  (cost=0.00..431.01 rows=5 width=12) (actual time=2.049..2.053 rows=5 loops=1)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.01 rows=5 width=12) (actual time=2.048..2.049 rows=5 loops=1)
-         ->  Limit  (cost=0.00..431.01 rows=2 width=12) (actual time=1.830..1.834 rows=5 loops=1)
-               ->  Finalize HashAggregate  (cost=0.00..431.01 rows=7 width=12) (actual time=1.829..1.831 rows=5 loops=1)
+                                                                          QUERY PLAN                                                                          
+--------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit  (cost=0.00..431.01 rows=2 width=12) (actual time=1.700..1.702 rows=5 loops=1)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.01 rows=5 width=12) (actual time=1.698..1.700 rows=5 loops=1)
+         ->  Limit  (cost=0.00..431.01 rows=2 width=12) (actual time=1.456..1.464 rows=5 loops=1)
+               ->  GroupAggregate  (cost=0.00..431.01 rows=7 width=12) (actual time=1.455..1.460 rows=5 loops=1)
                      Group Key: d
-                     Peak Memory Usage: 0 kB
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.01 rows=7 width=12) (actual time=1.781..1.817 rows=7 loops=1)
-                           Hash Key: d
-                           ->  Partial GroupAggregate  (cost=0.00..431.01 rows=7 width=12) (actual time=0.127..0.172 rows=10 loops=1)
-                                 Group Key: d
-                                 ->  Sort  (cost=0.00..431.00 rows=34 width=4) (actual time=0.120..0.132 rows=50 loops=1)
-                                       Sort Key: d
-                                       Sort Method:  quicksort  Memory: 79kB
-                                       Executor Memory: 79kB  Segments: 3  Max: 27kB (segment 0)
-                                       ->  Seq Scan on smallt  (cost=0.00..431.00 rows=34 width=4) (actual time=0.087..0.099 rows=50 loops=1)
- Optimizer: Pivotal Optimizer (GPORCA)
- Planning Time: 6.951 ms
-   (slice0)    Executor memory: 52K bytes.
-   (slice1)    Executor memory: 22K bytes avg x 3 workers, 22K bytes max (seg1).  Work_mem: 24K bytes max.
-   (slice2)    Executor memory: 39K bytes avg x 3 workers, 39K bytes max (seg0).  Work_mem: 27K bytes max.
+                     ->  Sort  (cost=0.00..431.01 rows=34 width=4) (actual time=1.449..1.453 rows=26 loops=1)
+                           Sort Key: d
+                           Sort Method:  quicksort  Memory: 99kB
+                           Executor Memory: 79kB  Segments: 3  Max: 27kB (segment 1)
+                           ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=34 width=4) (actual time=0.413..1.428 rows=35 loops=1)
+                                 Hash Key: d
+                                 ->  Seq Scan on smallt  (cost=0.00..431.00 rows=34 width=4) (actual time=0.003..0.006 rows=50 loops=1)
+ Planning time: 16.802 ms
+   (slice0)    Executor memory: 59K bytes.
+   (slice1)    Executor memory: 42K bytes avg x 3 workers, 42K bytes max (seg0).
+   (slice2)    Executor memory: 64K bytes avg x 3 workers, 64K bytes max (seg0).  Work_mem: 33K bytes max.
  Memory used:  128000kB
- Execution Time: 2.695 ms
-(22 rows)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
+ Execution time: 2.024 ms
+(19 rows)
 
 select * from
   test_util.extract_plan_stats($$
@@ -1401,21 +1373,20 @@ select t1.* from smallt as t1, smallt as t2 where t1.i = t2.i order by 1,2,3;
 explain analyze select t1.* from smallt as t1, smallt as t2 where t1.i = t2.i;
                                                           QUERY PLAN                                                           
 -------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.09 rows=1000 width=15) (actual time=2.571..4.414 rows=1000 loops=1)
-   ->  Hash Join  (cost=0.00..862.03 rows=334 width=15) (actual time=2.026..3.903 rows=500 loops=1)
-         Hash Cond: (smallt.i = smallt_1.i)
-         Extra Text: (seg0)   Hash chain length 10.0 avg, 10 max, using 5 of 524288 buckets.
-         ->  Seq Scan on smallt  (cost=0.00..431.00 rows=34 width=15) (actual time=0.004..0.014 rows=50 loops=1)
-         ->  Hash  (cost=431.00..431.00 rows=34 width=4) (actual time=0.172..0.172 rows=50 loops=1)
-               Buckets: 524288  Batches: 1  Memory Usage: 4098kB
-               ->  Seq Scan on smallt smallt_1  (cost=0.00..431.00 rows=34 width=4) (actual time=0.140..0.151 rows=50 loops=1)
- Optimizer: Pivotal Optimizer (GPORCA)
- Planning Time: 7.905 ms
-   (slice0)    Executor memory: 43K bytes.
-   (slice1)    Executor memory: 4160K bytes avg x 3 workers, 4163K bytes max (seg0).  Work_mem: 4098K bytes max.
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.09 rows=1000 width=15) (actual time=0.788..1.687 rows=500 loops=2)
+   ->  Hash Join  (cost=0.00..862.03 rows=334 width=15) (actual time=0.402..1.244 rows=200 loops=2)
+         Hash Cond: smallt.i = smallt_1.i
+         Extra Text: (seg0)   Hash chain length 10.0 avg, 10 max, using 4 of 524288 buckets.
+ 
+         ->  Seq Scan on smallt  (cost=0.00..431.00 rows=34 width=15) (actual time=0.002..0.008 rows=20 loops=2)
+         ->  Hash  (cost=431.00..431.00 rows=34 width=4) (actual time=0.034..0.034 rows=20 loops=2)
+               ->  Seq Scan on smallt smallt_1  (cost=0.00..431.00 rows=34 width=4) (actual time=0.019..0.023 rows=20 loops=2)
+   (slice0)    Executor memory: 322K bytes.
+   (slice1)    Executor memory: 4198K bytes avg x 3 workers, 4206K bytes max (seg0).  Work_mem: 1K bytes max.
  Memory used:  128000kB
- Execution Time: 5.087 ms
-(14 rows)
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
+ Total runtime: 4.129 ms
+(13 rows)
 
 -- Rescan on HashJoin
 --select t1.* from (select t11.* from smallt as t11, smallt as t22 where t11.i = t22.i and t11.i < 2) as t1,
@@ -1836,28 +1807,27 @@ select t1.* from smallt as t1, smallt as t2 where t1.d = t2.d and t1.i < 2;
 explain analyze select t1.* from smallt as t1, smallt as t2 where t1.d = t2.d and t1.i < 2;
                                                                     QUERY PLAN                                                                    
 --------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.02 rows=100 width=15) (actual time=4.312..4.343 rows=100 loops=1)
-   ->  Hash Join  (cost=0.00..862.01 rows=34 width=15) (actual time=1.885..3.954 rows=75 loops=1)
-         Hash Cond: (smallt.d = smallt_1.d)
-         Extra Text: (seg1)   Hash chain length 5.0 avg, 5 max, using 7 of 524288 buckets.
-         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=7 width=15) (actual time=0.005..0.008 rows=15 loops=1)
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..862.02 rows=100 width=15) (actual time=1.917..2.300 rows=50 loops=2)
+   ->  Hash Join  (cost=0.00..862.01 rows=34 width=15) (actual time=0.611..2.052 rows=25 loops=2)
+         Hash Cond: smallt.d = smallt_1.d
+         Extra Text: (seg1)   Hash chain length 5.0 avg, 5 max, using 11 of 524288 buckets.
+ 
+         ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=7 width=15) (actual time=0.004..0.199 rows=5 loops=2)
                Hash Key: smallt.d
-               ->  Seq Scan on smallt  (cost=0.00..431.00 rows=7 width=15) (actual time=0.102..0.110 rows=20 loops=1)
-                     Filter: (i < 2)
-         ->  Hash  (cost=431.00..431.00 rows=34 width=4) (actual time=0.032..0.032 rows=35 loops=1)
-               Buckets: 524288  Batches: 1  Memory Usage: 4098kB
-               ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=34 width=4) (actual time=0.010..0.020 rows=35 loops=1)
+               ->  Seq Scan on smallt  (cost=0.00..431.00 rows=7 width=15) (actual time=0.021..0.034 rows=5 loops=2)
+                     Filter: i < 2
+         ->  Hash  (cost=431.00..431.00 rows=34 width=4) (actual time=0.169..0.169 rows=28 loops=2)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=34 width=4) (actual time=0.032..0.153 rows=28 loops=2)
                      Hash Key: smallt_1.d
-                     ->  Seq Scan on smallt smallt_1  (cost=0.00..431.00 rows=34 width=4) (actual time=0.110..0.124 rows=50 loops=1)
- Optimizer: Pivotal Optimizer (GPORCA)
- Planning Time: 8.950 ms
-   (slice0)    Executor memory: 43K bytes.
-   (slice1)    Executor memory: 4149K bytes avg x 3 workers, 4149K bytes max (seg1).  Work_mem: 4098K bytes max.
-   (slice2)    Executor memory: 37K bytes avg x 3 workers, 37K bytes max (seg0).
-   (slice3)    Executor memory: 37K bytes avg x 3 workers, 37K bytes max (seg0).
+                     ->  Seq Scan on smallt smallt_1  (cost=0.00..431.00 rows=34 width=4) (actual time=0.022..0.036 rows=20 loops=2)
+   (slice0)    Executor memory: 386K bytes.
+   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice2)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
+   (slice3)    Executor memory: 4186K bytes avg x 3 workers, 4186K bytes max (seg0).  Work_mem: 2K bytes max.
  Memory used:  128000kB
- Execution Time: 5.275 ms
-(21 rows)
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
+ Total runtime: 5.688 ms
+(20 rows)
 
 --end_ignore
 set enable_hashjoin=on;
@@ -1909,23 +1879,21 @@ explain analyze select smallt.* from smallt, smallt2 where smallt.i = smallt2.i 
 and smallt.d = '2011-01-04'::date;
                                                                QUERY PLAN                                                                
 -----------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..12.00 rows=4 width=15) (actual time=2.419..3.600 rows=20 loops=1)
-   ->  Hash Join  (cost=0.00..12.00 rows=2 width=15) (actual time=0.577..2.072 rows=20 loops=1)
-         Hash Cond: (smallt.i = smallt2.i)
-         Extra Text: (seg0)   Hash chain length 4.0 avg, 4 max, using 1 of 524288 buckets.
-         ->  Index Scan using smallt_d_idx on smallt  (cost=0.00..6.00 rows=2 width=15) (actual time=0.007..0.010 rows=5 loops=1)
-               Index Cond: (d = '01-04-2011'::date)
-         ->  Hash  (cost=6.00..6.00 rows=2 width=4) (actual time=0.023..0.023 rows=4 loops=1)
-               Buckets: 524288  Batches: 1  Memory Usage: 4097kB
-               ->  Index Scan using smallt2_d_idx on smallt2  (cost=0.00..6.00 rows=2 width=4) (actual time=0.014..0.017 rows=4 loops=1)
-                     Index Cond: (d = '01-04-2011'::date)
- Optimizer: Pivotal Optimizer (GPORCA)
- Planning Time: 10.581 ms
-   (slice0)    Executor memory: 46K bytes.
-   (slice1)    Executor memory: 4172K bytes avg x 3 workers, 4216K bytes max (seg0).  Work_mem: 4097K bytes max.
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..17.99 rows=2 width=15) (actual time=2.338..2.341 rows=20 loops=1)
+   ->  Hash Join  (cost=0.00..17.99 rows=1 width=15) (actual time=0.464..1.817 rows=20 loops=1)
+         Hash Cond: smallt.i = smallt2.i
+         (seg2)   Hash chain length 4.0 avg, 4 max, using 1 of 524288 buckets.
+         ->  Index Scan using smallt_d_idx on smallt  (cost=0.00..9.99 rows=2 width=15) (actual time=0.005..0.007 rows=5 loops=1)
+               Index Cond: d = '01-04-2011'::date
+         ->  Hash  (cost=8.00..8.00 rows=2 width=4) (actual time=0.034..0.034 rows=4 loops=1)
+               ->  Index Scan using smallt2_d_idx on smallt2  (cost=0.00..8.00 rows=2 width=4) (actual time=0.023..0.027 rows=4 loops=1)
+                     Index Cond: d = '01-04-2011'::date
+   (slice0)    Executor memory: 450K bytes.
+   (slice1)    Executor memory: 4234K bytes avg x 3 workers, 4234K bytes max (seg0).  Work_mem: 1K bytes max.
  Memory used:  128000kB
- Execution Time: 4.741 ms
-(16 rows)
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.67.0
+ Total runtime: 3.325 ms
+(14 rows)
 
 -- IndexOnlyScan
 explain analyze select *, exists(select 1 from pg_class where oid = c.oid) as dummy from pg_class c;
@@ -1982,23 +1950,21 @@ explain analyze select smallt.* from smallt, smallt2 where smallt.i = smallt2.i 
 and smallt.d = '2011-01-04'::date;
                                                                QUERY PLAN                                                                
 -----------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..12.00 rows=4 width=15) (actual time=2.555..3.831 rows=20 loops=1)
-   ->  Hash Join  (cost=0.00..12.00 rows=2 width=15) (actual time=0.506..2.156 rows=20 loops=1)
-         Hash Cond: (smallt.i = smallt2.i)
-         Extra Text: (seg0)   Hash chain length 4.0 avg, 4 max, using 1 of 524288 buckets.
-         ->  Index Scan using smallt_d_idx on smallt  (cost=0.00..6.00 rows=2 width=15) (actual time=0.007..0.010 rows=5 loops=1)
-               Index Cond: (d = '01-04-2011'::date)
-         ->  Hash  (cost=6.00..6.00 rows=2 width=4) (actual time=0.024..0.024 rows=4 loops=1)
-               Buckets: 524288  Batches: 1  Memory Usage: 4097kB
-               ->  Index Scan using smallt2_d_idx on smallt2  (cost=0.00..6.00 rows=2 width=4) (actual time=0.015..0.018 rows=4 loops=1)
-                     Index Cond: (d = '01-04-2011'::date)
- Optimizer: Pivotal Optimizer (GPORCA)
- Planning Time: 11.888 ms
-   (slice0)    Executor memory: 46K bytes.
-   (slice1)    Executor memory: 4172K bytes avg x 3 workers, 4216K bytes max (seg0).  Work_mem: 4097K bytes max.
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..17.99 rows=2 width=15) (actual time=3.960..3.964 rows=20 loops=1)
+   ->  Hash Join  (cost=0.00..17.99 rows=1 width=15) (actual time=0.267..1.566 rows=20 loops=1)
+         Hash Cond: smallt.i = smallt2.i
+         (seg2)   Hash chain length 4.0 avg, 4 max, using 1 of 524288 buckets.
+         ->  Index Scan using smallt_d_idx on smallt  (cost=0.00..9.99 rows=2 width=15) (actual time=0.005..0.007 rows=5 loops=1)
+               Index Cond: d = '01-04-2011'::date
+         ->  Hash  (cost=8.00..8.00 rows=2 width=4) (actual time=0.031..0.031 rows=4 loops=1)
+               ->  Index Scan using smallt2_d_idx on smallt2  (cost=0.00..8.00 rows=2 width=4) (actual time=0.020..0.024 rows=4 loops=1)
+                     Index Cond: d = '01-04-2011'::date
+   (slice0)    Executor memory: 450K bytes.
+   (slice1)    Executor memory: 4234K bytes avg x 3 workers, 4234K bytes max (seg0).  Work_mem: 1K bytes max.
  Memory used:  128000kB
- Execution Time: 4.508 ms
-(16 rows)
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.67.0
+ Total runtime: 5.131 ms
+(14 rows)
 
 set enable_hashjoin=on;
 set enable_nestloop=off;
@@ -2040,35 +2006,34 @@ where 0 < all (select total from my_group_sum, smallt2 as tmp where my_group_sum
 explain with my_group_sum(d, total) as (select d, sum(i) from smallt group by d)
         select count(*) from smallt2
         where 0 < all (select total from my_group_sum, smallt2 as tmp where my_group_sum.d = smallt2.d);
-                                                                                                                                                                                         QUERY PLAN                                                                                                                                                                                          
+
+              QUERY PLAN
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Finalize Aggregate  (cost=0.00..1324486.44 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1324486.44 rows=1 width=8)
-         ->  Partial Aggregate  (cost=0.00..1324486.44 rows=1 width=8)
-               ->  Hash Join  (cost=0.00..1324486.44 rows=6 width=1)
+ Finalize Aggregate  (cost=0.00..1324486.07 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1324486.07 rows=1 width=8)
+         ->  Partial Aggregate  (cost=0.00..1324486.07 rows=1 width=8)
+               ->  Hash Join  (cost=0.00..1324486.07 rows=6 width=1)
                      Hash Cond: (smallt2.d = smallt.d)
                      ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=17 width=4)
                            Hash Key: smallt2.d
                            ->  Seq Scan on smallt2  (cost=0.00..431.00 rows=17 width=4)
-                     ->  Hash  (cost=1324055.44..1324055.44 rows=3 width=4)
-                           ->  Result  (cost=0.00..1324055.44 rows=3 width=4)
+                     ->  Hash  (cost=1324055.07..1324055.07 rows=3 width=4)
+                           ->  Result  (cost=0.00..1324055.07 rows=3 width=4)
                                  Filter: ((CASE WHEN (sum((CASE WHEN (0 >= (sum(smallt.i))) THEN 1 ELSE 0 END)) IS NULL) THEN true WHEN (sum((CASE WHEN ((sum(smallt.i)) IS NULL) THEN 1 ELSE 0 END)) > '0'::bigint) THEN NULL::boolean WHEN (0 IS NULL) THEN NULL::boolean WHEN (sum((CASE WHEN (0 >= (sum(smallt.i))) THEN 1 ELSE 0 END)) = '0'::bigint) THEN true ELSE false END) = true)
-                                 ->  HashAggregate  (cost=0.00..1324055.44 rows=7 width=20)
+                                 ->  HashAggregate  (cost=0.00..1324055.07 rows=7 width=20)
                                        Group Key: smallt.d
-                                       ->  Nested Loop  (cost=0.00..1324055.39 rows=334 width=12)
+                                       ->  Nested Loop  (cost=0.00..1324055.03 rows=334 width=12)
                                              Join Filter: true
-                                             ->  Finalize HashAggregate  (cost=0.00..431.01 rows=7 width=12)
+                                             ->  HashAggregate  (cost=0.00..431.01 rows=7 width=12)
                                                    Group Key: smallt.d
-                                                   ->  Redistribute Motion 3:3  (slice4; segments: 3)  (cost=0.00..431.01 rows=7 width=12)
+                                                   ->  Redistribute Motion 3:3  (slice4; segments: 3)  (cost=0.00..431.00 rows=34 width=8)
                                                          Hash Key: smallt.d
-                                                         ->  Streaming Partial HashAggregate  (cost=0.00..431.01 rows=7 width=12)
-                                                               Group Key: smallt.d
-                                                               ->  Seq Scan on smallt  (cost=0.00..431.00 rows=34 width=8)
+                                                         ->  Seq Scan on smallt  (cost=0.00..431.00 rows=34 width=8)
                                              ->  Materialize  (cost=0.00..431.00 rows=50 width=1)
                                                    ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=50 width=1)
                                                          ->  Seq Scan on smallt2 smallt2_1  (cost=0.00..431.00 rows=17 width=1)
  Optimizer: Pivotal Optimizer (GPORCA)
-(26 rows)
+(24 rows)
 
 --end_ignore
 -- Nested Subplan

--- a/src/test/regress/expected/gp_aggregates_costs_optimizer.out
+++ b/src/test/regress/expected/gp_aggregates_costs_optimizer.out
@@ -37,18 +37,14 @@ explain select avg(b) from cost_agg_t1 group by c;
 explain select avg(b) from cost_agg_t2 group by c;
                                              QUERY PLAN                                              
 -----------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..510.02 rows=290794 width=8)
-   ->  Finalize HashAggregate  (cost=0.00..501.35 rows=96932 width=8)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..501.88 rows=305691 width=8)
+   ->  HashAggregate  (cost=0.00..492.76 rows=101897 width=8)
          Group Key: c
-         Planned Partitions: 8
-         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..489.20 rows=96932 width=12)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..452.01 rows=333334 width=8)
                Hash Key: c
-               ->  Streaming Partial HashAggregate  (cost=0.00..485.56 rows=96932 width=12)
-                     Group Key: c
-                     Planned Partitions: 8
-                     ->  Seq Scan on cost_agg_t2  (cost=0.00..438.70 rows=333334 width=8)
+               ->  Seq Scan on cost_agg_t2  (cost=0.00..438.70 rows=333334 width=8)
  Optimizer: Pivotal Optimizer (GPORCA)
-(11 rows)
+(7 rows)
 
 -- But if there are a lot more duplicate values, the two-stage plan becomes
 -- cheaper again, even though it doesn't git in memory and has to spill.
@@ -57,18 +53,16 @@ analyze cost_agg_t2;
 explain select avg(b) from cost_agg_t2 group by c;
                                              QUERY PLAN                                              
 -----------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..504.94 rows=104001 width=8)
-   ->  Finalize HashAggregate  (cost=0.00..501.84 rows=34667 width=8)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..504.85 rows=102902 width=8)
+   ->  Finalize HashAggregate  (cost=0.00..501.78 rows=34301 width=8)
          Group Key: c
-         Planned Partitions: 8
-         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..497.49 rows=34667 width=12)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..497.48 rows=34301 width=12)
                Hash Key: c
-               ->  Streaming Partial HashAggregate  (cost=0.00..496.19 rows=34667 width=12)
+               ->  Streaming Partial HashAggregate  (cost=0.00..496.19 rows=34301 width=12)
                      Group Key: c
-                     Planned Partitions: 8
                      ->  Seq Scan on cost_agg_t2  (cost=0.00..440.24 rows=400000 width=8)
  Optimizer: Pivotal Optimizer (GPORCA)
-(11 rows)
+(9 rows)
 
 drop table cost_agg_t1;
 drop table cost_agg_t2;
@@ -89,19 +83,15 @@ explain (costs off) select b, sum(a) from t_planner_force_multi_stage group by b
                             QUERY PLAN                            
 ------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  Finalize GroupAggregate
+   ->  GroupAggregate
          Group Key: b
          ->  Sort
                Sort Key: b
                ->  Redistribute Motion 3:3  (slice2; segments: 3)
                      Hash Key: b
-                     ->  Partial GroupAggregate
-                           Group Key: b
-                           ->  Sort
-                                 Sort Key: b
-                                 ->  Seq Scan on t_planner_force_multi_stage
+                     ->  Seq Scan on t_planner_force_multi_stage
  Optimizer: Pivotal Optimizer (GPORCA)
-(13 rows)
+(9 rows)
 
 set gp_eager_two_phase_agg = on;
 -- when forcing two stage, it should generate two stage agg plan.
@@ -109,19 +99,15 @@ explain (costs off) select b, sum(a) from t_planner_force_multi_stage group by b
                             QUERY PLAN                            
 ------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  Finalize GroupAggregate
+   ->  GroupAggregate
          Group Key: b
          ->  Sort
                Sort Key: b
                ->  Redistribute Motion 3:3  (slice2; segments: 3)
                      Hash Key: b
-                     ->  Partial GroupAggregate
-                           Group Key: b
-                           ->  Sort
-                                 Sort Key: b
-                                 ->  Seq Scan on t_planner_force_multi_stage
+                     ->  Seq Scan on t_planner_force_multi_stage
  Optimizer: Pivotal Optimizer (GPORCA)
-(13 rows)
+(9 rows)
 
 reset gp_eager_two_phase_agg;
 drop table t_planner_force_multi_stage;

--- a/src/test/regress/expected/gp_dqa_optimizer.out
+++ b/src/test/regress/expected/gp_dqa_optimizer.out
@@ -342,21 +342,19 @@ explain (costs off) select count(distinct dqa_t1.d) from dqa_t1, dqa_t2 where dq
                             QUERY PLAN                            
 ------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  Finalize HashAggregate
+   ->  GroupAggregate
          Group Key: dqa_t2.dt
-         ->  Redistribute Motion 3:3  (slice2; segments: 3)
-               Hash Key: dqa_t2.dt
-               ->  Partial GroupAggregate
-                     Group Key: dqa_t2.dt
-                     ->  Sort
-                           Sort Key: dqa_t2.dt
-                           ->  Hash Join
-                                 Hash Cond: (dqa_t2.d = dqa_t1.d)
-                                 ->  Seq Scan on dqa_t2
-                                 ->  Hash
-                                       ->  Seq Scan on dqa_t1
- Optimizer: Pivotal Optimizer (GPORCA)
-(15 rows)
+         ->  Sort
+               Sort Key: dqa_t2.dt
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: dqa_t2.dt
+                     ->  Hash Join
+                           Hash Cond: (dqa_t2.d = dqa_t1.d)
+                           ->  Seq Scan on dqa_t2
+                           ->  Hash
+                                 ->  Seq Scan on dqa_t1
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(13 rows)
 
 -- Distinct keys are not distribution keys
 select count(distinct c) from dqa_t1;
@@ -366,23 +364,16 @@ select count(distinct c) from dqa_t1;
 (1 row)
 
 explain (costs off) select count(distinct c) from dqa_t1;
-                               QUERY PLAN                               
-------------------------------------------------------------------------
- Aggregate
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Finalize Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  GroupAggregate
-               Group Key: c
-               ->  Sort
-                     Sort Key: c
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                           Hash Key: c
-                           ->  GroupAggregate
-                                 Group Key: c
-                                 ->  Sort
-                                       Sort Key: c
-                                       ->  Seq Scan on dqa_t1
- Optimizer: Pivotal Optimizer (GPORCA)
-(14 rows)
+         ->  Partial Aggregate
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: c
+                     ->  Seq Scan on dqa_t1
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
+(7 rows)
 
 select count(distinct c) from dqa_t1 group by dt;
  count 
@@ -427,19 +418,15 @@ explain (costs off) select count(distinct c) from dqa_t1 group by dt;
                             QUERY PLAN                            
 ------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  Finalize HashAggregate
+   ->  GroupAggregate
          Group Key: dt
-         ->  Redistribute Motion 3:3  (slice2; segments: 3)
-               Hash Key: dt
-               ->  Partial GroupAggregate
-                     Group Key: dt
-                     ->  Sort
-                           Sort Key: dt, c
-                           ->  Redistribute Motion 3:3  (slice3; segments: 3)
-                                 Hash Key: c
-                                 ->  Seq Scan on dqa_t1
- Optimizer: Pivotal Optimizer (GPORCA)
-(13 rows)
+         ->  Sort
+               Sort Key: dt
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: dt
+                     ->  Seq Scan on dqa_t1
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(9 rows)
 
 select count(distinct c) from dqa_t1 group by d;
  count 
@@ -475,13 +462,11 @@ explain (costs off) select count(distinct c) from dqa_t1 group by d;
  Gather Motion 3:1  (slice1; segments: 3)
    ->  GroupAggregate
          Group Key: d
-         ->  GroupAggregate
-               Group Key: d, c
-               ->  Sort
-                     Sort Key: d, c
-                     ->  Seq Scan on dqa_t1
- Optimizer: Pivotal Optimizer (GPORCA)
-(9 rows)
+         ->  Sort
+               Sort Key: d
+               ->  Seq Scan on dqa_t1
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(7 rows)
 
 select count(distinct i), sum(distinct i) from dqa_t1 group by c;
  count | sum 
@@ -502,19 +487,15 @@ explain (costs off) select count(distinct i), sum(distinct i) from dqa_t1 group 
                             QUERY PLAN                            
 ------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  Finalize HashAggregate
+   ->  GroupAggregate
          Group Key: c
-         ->  Redistribute Motion 3:3  (slice2; segments: 3)
-               Hash Key: c
-               ->  Partial GroupAggregate
-                     Group Key: c
-                     ->  Sort
-                           Sort Key: c, i
-                           ->  Redistribute Motion 3:3  (slice3; segments: 3)
-                                 Hash Key: i
-                                 ->  Seq Scan on dqa_t1
- Optimizer: Pivotal Optimizer (GPORCA)
-(13 rows)
+         ->  Sort
+               Sort Key: c
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: c
+                     ->  Seq Scan on dqa_t1
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(9 rows)
 
 select count(distinct c), count(distinct dt) from dqa_t1;
 INFO:  GPORCA failed to produce a plan, falling back to planner
@@ -644,29 +625,24 @@ select count(distinct dqa_t1.dt) from dqa_t1, dqa_t2 where dqa_t1.c = dqa_t2.c;
 (1 row)
 
 explain (costs off) select count(distinct dqa_t1.dt) from dqa_t1, dqa_t2 where dqa_t1.c = dqa_t2.c;
-                                           QUERY PLAN                                           
-------------------------------------------------------------------------------------------------
- Aggregate
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Finalize Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  GroupAggregate
-               Group Key: dqa_t1.dt
-               ->  Sort
-                     Sort Key: dqa_t1.dt
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                           Hash Key: dqa_t1.dt
-                           ->  Streaming HashAggregate
-                                 Group Key: dqa_t1.dt
-                                 ->  Hash Join
-                                       Hash Cond: (dqa_t1.c = dqa_t2.c)
-                                       ->  Redistribute Motion 3:3  (slice3; segments: 3)
-                                             Hash Key: dqa_t1.c
-                                             ->  Seq Scan on dqa_t1
-                                       ->  Hash
-                                             ->  Redistribute Motion 3:3  (slice4; segments: 3)
-                                                   Hash Key: dqa_t2.c
-                                                   ->  Seq Scan on dqa_t2
- Optimizer: Pivotal Optimizer (GPORCA)
-(20 rows)
+         ->  Partial Aggregate
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: dqa_t1.dt
+                     ->  Hash Join
+                           Hash Cond: (dqa_t1.c = dqa_t2.c)
+                           ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                                 Hash Key: dqa_t1.c
+                                 ->  Seq Scan on dqa_t1
+                           ->  Hash
+                                 ->  Redistribute Motion 3:3  (slice4; segments: 3)
+                                       Hash Key: dqa_t2.c
+                                       ->  Seq Scan on dqa_t2
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
+(15 rows)
 
 select count(distinct dqa_t1.dt) from dqa_t1, dqa_t2 where dqa_t1.c = dqa_t2.c group by dqa_t2.dt;
  count 
@@ -733,25 +709,23 @@ explain (costs off) select count(distinct dqa_t1.dt) from dqa_t1, dqa_t2 where d
                                      QUERY PLAN                                     
 ------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  HashAggregate
+   ->  GroupAggregate
          Group Key: dqa_t2.dt
-         ->  Redistribute Motion 3:3  (slice2; segments: 3)
-               Hash Key: dqa_t2.dt
-               ->  Streaming HashAggregate
-                     Group Key: dqa_t2.dt, dqa_t1.dt
-                     ->  Redistribute Motion 3:3  (slice3; segments: 3)
-                           Hash Key: dqa_t2.dt, dqa_t1.dt, dqa_t1.dt
-                           ->  Hash Join
-                                 Hash Cond: (dqa_t1.c = dqa_t2.c)
+         ->  Sort
+               Sort Key: dqa_t2.dt
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: dqa_t2.dt
+                     ->  Hash Join
+                           Hash Cond: (dqa_t1.c = dqa_t2.c)
+                           ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                                 Hash Key: dqa_t1.c
+                                 ->  Seq Scan on dqa_t1
+                           ->  Hash
                                  ->  Redistribute Motion 3:3  (slice4; segments: 3)
-                                       Hash Key: dqa_t1.c
-                                       ->  Seq Scan on dqa_t1
-                                 ->  Hash
-                                       ->  Redistribute Motion 3:3  (slice5; segments: 3)
-                                             Hash Key: dqa_t2.c
-                                             ->  Seq Scan on dqa_t2
- Optimizer: Pivotal Optimizer (GPORCA)
-(19 rows)
+                                       Hash Key: dqa_t2.c
+                                       ->  Seq Scan on dqa_t2
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(17 rows)
 
 -- multidqa with groupby and order by
 select sum(distinct d), count(distinct i), count(distinct c),i,c from dqa_t1 group by i,c order by i,c;

--- a/src/test/regress/expected/gpdiffcheck_optimizer.out
+++ b/src/test/regress/expected/gpdiffcheck_optimizer.out
@@ -141,31 +141,30 @@ set optimizer_nestloop_factor = 1.0;
 explain analyze select a.* from gpd1 as a, gpd1 as b where b.c1 in (select max(c1) from gpd1);
                                                                     QUERY PLAN                                                                     
 ---------------------------------------------------------------------------------------------------------------------------------------------------
- Hash Join  (cost=0.00..1724.00 rows=1 width=12) (actual time=4.789..5.603 rows=16 loops=1)
+ Hash Join  (cost=0.00..1724.00 rows=1 width=12) (actual time=1.743..2.097 rows=16 loops=1)
    Hash Cond: (gpd1.c1 = (max(gpd1_2.c1)))
    Extra Text: Hash chain length 1.0 avg, 1 max, using 1 of 262144 buckets.
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1293.00 rows=1 width=14) (actual time=0.005..0.026 rows=64 loops=1)
-         ->  Nested Loop  (cost=0.00..1293.00 rows=1 width=14) (actual time=3.839..3.895 rows=32 loops=1)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1293.00 rows=1 width=14) (actual time=0.282..0.291 rows=64 loops=1)
+         ->  Nested Loop  (cost=0.00..1293.00 rows=1 width=14) (actual time=0.949..1.287 rows=32 loops=1)
                Join Filter: true
-               ->  Seq Scan on gpd1 gpd1_1  (cost=0.00..431.00 rows=1 width=12) (actual time=0.525..0.528 rows=4 loops=1)
-               ->  Materialize  (cost=0.00..431.00 rows=2 width=2) (actual time=0.660..0.663 rows=7 loops=5)
-                     ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=2 width=2) (actual time=3.391..3.397 rows=8 loops=1)
-                           ->  Seq Scan on gpd1  (cost=0.00..431.00 rows=1 width=2) (actual time=1.658..1.660 rows=4 loops=1)
-   ->  Hash  (cost=431.00..431.00 rows=1 width=8) (actual time=3.804..3.804 rows=1 loops=1)
-         Buckets: 262144  Batches: 1  Memory Usage: 2049kB
-         ->  Finalize Aggregate  (cost=0.00..431.00 rows=1 width=8) (actual time=3.794..3.794 rows=1 loops=1)
-               ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=8) (actual time=2.470..3.771 rows=3 loops=1)
-                     ->  Partial Aggregate  (cost=0.00..431.00 rows=1 width=8) (actual time=1.429..1.429 rows=1 loops=1)
-                           ->  Seq Scan on gpd1 gpd1_2  (cost=0.00..431.00 rows=1 width=2) (actual time=0.540..0.544 rows=4 loops=1)
- Optimizer: Pivotal Optimizer (GPORCA)
- Planning Time: 20.003 ms
-   (slice0)    Executor memory: 2145K bytes.  Work_mem: 2049K bytes max.
-   (slice1)    Executor memory: 41K bytes avg x 3 workers, 41K bytes max (seg0).  Work_mem: 17K bytes max.
-   (slice2)    Executor memory: 38K bytes avg x 3 workers, 38K bytes max (seg0).
-   (slice3)    Executor memory: 45K bytes avg x 3 workers, 45K bytes max (seg0).
+               ->  Seq Scan on gpd1 gpd1_1  (cost=0.00..431.00 rows=1 width=12) (actual time=0.005..0.006 rows=4 loops=1)
+               ->  Materialize  (cost=0.00..431.00 rows=2 width=2) (actual time=0.187..0.253 rows=7 loops=5)
+                     ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=2 width=2) (actual time=0.897..1.264 rows=8 loops=1)
+                           ->  Seq Scan on gpd1  (cost=0.00..431.00 rows=1 width=2) (actual time=0.012..0.134 rows=4 loops=1)
+   ->  Hash  (cost=431.00..431.00 rows=1 width=8) (actual time=0.137..0.137 rows=1 loops=1)
+         Buckets: 262144  Batches: 1  Memory Usage: 1kB
+         ->  Aggregate  (cost=0.00..431.00 rows=1 width=8) (actual time=0.133..0.133 rows=1 loops=1)
+               ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=2) (actual time=0.004..0.097 rows=8 loops=1)
+                     ->  Seq Scan on gpd1 gpd1_2  (cost=0.00..431.00 rows=1 width=2) (actual time=0.008..0.009 rows=4 loops=1)
+ Planning time: 109.024 ms
+   (slice0)    Executor memory: 2216K bytes.  Work_mem: 1K bytes max.
+   (slice1)    Executor memory: 96K bytes avg x 3 workers, 96K bytes max (seg0).
+   (slice2)    Executor memory: 60K bytes avg x 3 workers, 60K bytes max (seg0).
+   (slice3)    Executor memory: 60K bytes avg x 3 workers, 60K bytes max (seg0).
  Memory used:  128000kB
- Execution Time: 59.081 ms
-(24 rows)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
+ Execution time: 17.954 ms
+(23 rows)
 
 explain select a.* from gpd1 as a, gpd1 as b where b.c1 in (select max(c1) from gpd1);
                                                QUERY PLAN                                                
@@ -180,12 +179,11 @@ explain select a.* from gpd1 as a, gpd1 as b where b.c1 in (select max(c1) from 
                      ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=2 width=2)
                            ->  Seq Scan on gpd1  (cost=0.00..431.00 rows=1 width=2)
    ->  Hash  (cost=431.00..431.00 rows=1 width=8)
-         ->  Finalize Aggregate  (cost=0.00..431.00 rows=1 width=8)
-               ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
-                     ->  Partial Aggregate  (cost=0.00..431.00 rows=1 width=8)
-                           ->  Seq Scan on gpd1 gpd1_2  (cost=0.00..431.00 rows=1 width=2)
- Optimizer: Pivotal Optimizer (GPORCA)
-(15 rows)
+         ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+               ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=2)
+                     ->  Seq Scan on gpd1 gpd1_2  (cost=0.00..431.00 rows=1 width=2)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
+(14 rows)
 
 select a.* from gpd1 as a, gpd1 as b where b.c1 in (select max(c1) from gpd1);
  c1 | c2 | c3 
@@ -256,33 +254,32 @@ select a.* from gpd1 as a, gpd1 as b where b.c1 in (select max(c1) from gpd1);
 explain analyze select a.* from gpd1 as a, gpd1 as b where b.c1 in (select max(c1) from gpd1);
                                                                      QUERY PLAN                                                                      
 -----------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1724.00 rows=1 width=12) (actual time=7.070..7.073 rows=16 loops=1)
-   ->  Hash Join  (cost=0.00..1724.00 rows=1 width=12) (actual time=4.901..6.734 rows=16 loops=1)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1724.00 rows=1 width=12) (actual time=11.226..13.705 rows=16 loops=1)
+   ->  Hash Join  (cost=0.00..1724.00 rows=1 width=12) (actual time=5.349..10.009 rows=16 loops=1)
          Hash Cond: ((max(gpd1.c1)) = gpd1_1.c1)
          Extra Text: (seg0)   Hash chain length 16.0 avg, 16 max, using 1 of 524288 buckets.
-         ->  Redistribute Motion 1:3  (slice2)  (cost=0.00..431.00 rows=1 width=8) (actual time=0.558..0.559 rows=1 loops=1)
+         ->  Redistribute Motion 1:3  (slice2)  (cost=0.00..431.00 rows=1 width=8) (actual time=0.007..0.007 rows=1 loops=1)
                Hash Key: (max(gpd1.c1))
-               ->  Finalize Aggregate  (cost=0.00..431.00 rows=1 width=8) (actual time=4.739..4.739 rows=1 loops=1)
-                     ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=8) (actual time=3.954..4.726 rows=3 loops=1)
-                           ->  Partial Aggregate  (cost=0.00..431.00 rows=1 width=8) (actual time=1.551..1.551 rows=1 loops=1)
-                                 ->  Seq Scan on gpd1  (cost=0.00..431.00 rows=1 width=2) (actual time=0.673..0.675 rows=4 loops=1)
-         ->  Hash  (cost=1293.00..1293.00 rows=1 width=14) (actual time=2.475..2.475 rows=32 loops=1)
-               Buckets: 524288  Batches: 1  Memory Usage: 4098kB
-               ->  Nested Loop  (cost=0.00..1293.00 rows=1 width=14) (actual time=2.091..2.452 rows=32 loops=1)
+               ->  Finalize Aggregate  (cost=0.00..431.00 rows=1 width=8) (actual time=1.384..1.384 rows=1 loops=1)
+                     ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=8) (actual time=0.216..1.339 rows=3 loops=1)
+                           ->  Partial Aggregate  (cost=0.00..431.00 rows=1 width=8) (actual time=0.056..0.056 rows=1 loops=1)
+                                 ->  Seq Scan on gpd1  (cost=0.00..431.00 rows=1 width=2) (actual time=0.038..0.045 rows=4 loops=1)
+         ->  Hash  (cost=1293.00..1293.00 rows=1 width=14) (actual time=0.287..0.287 rows=32 loops=1)
+               ->  Nested Loop  (cost=0.00..1293.00 rows=1 width=14) (actual time=0.089..0.223 rows=32 loops=1)
                      Join Filter: true
-                     ->  Broadcast Motion 3:3  (slice4; segments: 3)  (cost=0.00..431.00 rows=14 width=12) (actual time=0.005..0.586 rows=8 loops=1)
-                           ->  Seq Scan on gpd1 gpd1_2  (cost=0.00..431.00 rows=1 width=12) (actual time=1.942..1.944 rows=4 loops=1)
-                     ->  Seq Scan on gpd1 gpd1_1  (cost=0.00..431.00 rows=1 width=2) (actual time=0.231..0.233 rows=4 loops=9)
- Optimizer: Pivotal Optimizer (GPORCA)
- Planning Time: 21.015 ms
-   (slice0)    Executor memory: 66K bytes.
-   (slice1)    Executor memory: 4159K bytes avg x 3 workers, 4159K bytes max (seg0).  Work_mem: 4098K bytes max.
-   (slice2)    Executor memory: 50K bytes (entry db).
-   (slice3)    Executor memory: 38K bytes avg x 3 workers, 38K bytes max (seg0).
-   (slice4)    Executor memory: 37K bytes avg x 3 workers, 37K bytes max (seg0).
+                     ->  Broadcast Motion 3:3  (slice4; segments: 3)  (cost=0.00..431.00 rows=14 width=12) (actual time=0.019..0.043 rows=8 loops=1)
+                           ->  Seq Scan on gpd1 gpd1_2  (cost=0.00..431.00 rows=1 width=12) (actual time=0.042..0.047 rows=4 loops=1)
+                     ->  Seq Scan on gpd1 gpd1_1  (cost=0.00..431.00 rows=1 width=2) (actual time=0.006..0.014 rows=4 loops=9)
+ Planning time: 63.479 ms
+   (slice0)    Executor memory: 127K bytes.
+   (slice1)    Executor memory: 4208K bytes avg x 3 workers, 4208K bytes max (seg0).  Work_mem: 4098K bytes max.
+   (slice2)    Executor memory: 79K bytes (seg0).
+   (slice3)    Executor memory: 75K bytes avg x 3 workers, 75K bytes max (seg0).
+   (slice4)    Executor memory: 60K bytes avg x 3 workers, 60K bytes max (seg0).
  Memory used:  128000kB
- Execution Time: 7.934 ms
-(26 rows)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+ Execution time: 16.006 ms
+(25 rows)
 
 --
 -- Clean up

--- a/src/test/regress/expected/gpdist_legacy_opclasses_optimizer.out
+++ b/src/test/regress/expected/gpdist_legacy_opclasses_optimizer.out
@@ -424,13 +424,10 @@ explain (costs off) select distinct test_array from try_distinct_array;
 ------------------------------------------------------
  GroupAggregate
    Group Key: test_array
-   ->  Gather Motion 3:1  (slice1; segments: 3)
-         Merge Key: test_array
-         ->  GroupAggregate
-               Group Key: test_array
-               ->  Sort
-                     Sort Key: test_array
-                     ->  Seq Scan on try_distinct_array
+   ->  Sort
+         Sort Key: test_array
+         ->  Gather Motion 3:1  (slice1; segments: 3)
+               ->  Seq Scan on try_distinct_array
  Optimizer: Pivotal Optimizer (GPORCA)
 (7 rows)
 

--- a/src/test/regress/expected/gpdist_optimizer.out
+++ b/src/test/regress/expected/gpdist_optimizer.out
@@ -659,17 +659,13 @@ explain (costs off) select even.i from even right outer join odd on (even.i = od
                Sort Key: even.i
                ->  Redistribute Motion 3:3  (slice2; segments: 3)
                      Hash Key: even.i
-                     ->  GroupAggregate
-                           Group Key: even.i
-                           ->  Sort
-                                 Sort Key: even.i
-                                 ->  Hash Left Join
-                                       Hash Cond: (odd.i = even.i)
-                                       ->  Seq Scan on odd
-                                       ->  Hash
-                                             ->  Seq Scan on even
+                     ->  Hash Left Join
+                           Hash Cond: (odd.i = even.i)
+                           ->  Seq Scan on odd
+                           ->  Hash
+                                 ->  Seq Scan on even
  Optimizer: Pivotal Optimizer (GPORCA)
-(17 rows)
+(13 rows)
 
 -- Check that we can track the distribution through multiple FULL OUTER JOINs.
 -- This query should not need Redistribute Motion.

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -11027,21 +11027,20 @@ FROM   (SELECT *
         SELECT region,
                code
         FROM   tab_3)a;
-                                                     QUERY PLAN                                                      
----------------------------------------------------------------------------------------------------------------------
- Finalize Aggregate  (cost=0.00..1293.00 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1293.00 rows=1 width=8)
-         ->  Partial Aggregate  (cost=0.00..1293.00 rows=1 width=8)
-               ->  Append  (cost=0.00..1293.00 rows=2 width=1)
-                     ->  Hash Left Join  (cost=0.00..862.00 rows=1 width=3)
-                           Hash Cond: ((tab_1.id)::text = (tab_2.id)::text)
-                           ->  Seq Scan on tab_1  (cost=0.00..431.00 rows=1 width=5)
-                           ->  Hash  (cost=431.00..431.00 rows=1 width=7)
-                                 ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=7)
-                                       ->  Seq Scan on tab_2  (cost=0.00..431.00 rows=1 width=7)
-                     ->  Seq Scan on tab_3  (cost=0.00..431.00 rows=1 width=8)
- Optimizer: Pivotal Optimizer (GPORCA)
-(12 rows)
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..1293.00 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1293.00 rows=4 width=1)
+         ->  Append  (cost=0.00..1293.00 rows=2 width=1)
+               ->  Hash Left Join  (cost=0.00..862.00 rows=1 width=3)
+                     Hash Cond: ((tab_1.id)::text = (tab_2.id)::text)
+                     ->  Seq Scan on tab_1  (cost=0.00..431.00 rows=1 width=5)
+                     ->  Hash  (cost=431.00..431.00 rows=1 width=7)
+                           ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=7)
+                                 ->  Seq Scan on tab_2  (cost=0.00..431.00 rows=1 width=7)
+               ->  Seq Scan on tab_3  (cost=0.00..431.00 rows=1 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(11 rows)
 
 SELECT Count(*)
 FROM   (SELECT *
@@ -11592,17 +11591,17 @@ SELECT * FROM varchar_sc_array_cmp t1, varchar_sc_array_cmp t2 where t1.a = t2.a
 
 SET optimizer_array_constraints=on;
 EXPLAIN SELECT * FROM varchar_sc_array_cmp t1, varchar_sc_array_cmp t2 where t1.a = t2.a and (t1.a in ('b', 'c') OR t1.a = 'a');
-                                                               QUERY PLAN                                                                
------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=16)
-   ->  Hash Join  (cost=0.00..862.00 rows=1 width=16)
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=4 width=4)
+   ->  Hash Join  (cost=0.00..862.00 rows=2 width=4)
          Hash Cond: ((varchar_sc_array_cmp.a)::text = (varchar_sc_array_cmp_1.a)::text)
-         ->  Seq Scan on varchar_sc_array_cmp  (cost=0.00..431.00 rows=1 width=8)
-               Filter: ((((a)::text = ANY ('{b,c}'::text[])) OR ((a)::text = 'a'::text)) AND (a = ANY ('{a,b,c}'::character varying[])))
-         ->  Hash  (cost=431.00..431.00 rows=1 width=8)
-               ->  Seq Scan on varchar_sc_array_cmp varchar_sc_array_cmp_1  (cost=0.00..431.00 rows=1 width=8)
+         ->  Seq Scan on varchar_sc_array_cmp  (cost=0.00..431.00 rows=1 width=2)
+               Filter: (a = ANY ('{a,b,c}'::character varying[]))
+         ->  Hash  (cost=431.00..431.00 rows=1 width=2)
+               ->  Seq Scan on varchar_sc_array_cmp varchar_sc_array_cmp_1  (cost=0.00..431.00 rows=1 width=2)
                      Filter: (a = ANY ('{a,b,c}'::character varying[]))
- Optimizer: Pivotal Optimizer (GPORCA)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.65.2
 (9 rows)
 
 SELECT * FROM varchar_sc_array_cmp t1, varchar_sc_array_cmp t2 where t1.a = t2.a and (t1.a in ('b', 'c') OR t1.a = 'a');
@@ -13236,15 +13235,13 @@ select * from foo join (select b, count(*) as cnt from tbtree group by b) grby o
          ->  Broadcast Motion 3:3  (slice3; segments: 3)
                ->  Seq Scan on foo
          ->  Materialize
-               ->  Finalize HashAggregate
+               ->  HashAggregate
                      Group Key: tbtree.b
                      ->  Redistribute Motion 3:3  (slice2; segments: 3)
                            Hash Key: tbtree.b
-                           ->  Streaming Partial HashAggregate
-                                 Group Key: tbtree.b
-                                 ->  Seq Scan on tbtree
+                           ->  Seq Scan on tbtree
  Optimizer: Pivotal Optimizer (GPORCA)
-(14 rows)
+(12 rows)
 
 -- 17 group by columns don't intersect - no index scan
 explain (costs off)
@@ -13262,15 +13259,13 @@ select * from foo join (select min_a, count(*) as cnt from (select min(a) as min
                            Hash Key: (min(tbitmap.a))
                            ->  Streaming Partial HashAggregate
                                  Group Key: min(tbitmap.a)
-                                 ->  Finalize HashAggregate
+                                 ->  HashAggregate
                                        Group Key: tbitmap.b
                                        ->  Redistribute Motion 3:3  (slice3; segments: 3)
                                              Hash Key: tbitmap.b
-                                             ->  Streaming Partial HashAggregate
-                                                   Group Key: tbitmap.b
-                                                   ->  Seq Scan on tbitmap
+                                             ->  Seq Scan on tbitmap
  Optimizer: Pivotal Optimizer (GPORCA)
-(19 rows)
+(17 rows)
 
 reset optimizer_join_order;
 reset optimizer_enable_hashjoin;
@@ -13545,21 +13540,20 @@ default partition def);
 create INDEX y_idx on y (j);
 set optimizer_enable_indexjoin=on;
 explain (costs off) select count(*) from x, y where (x.i > y.j AND x.j <= y.i);
-                             QUERY PLAN                              
----------------------------------------------------------------------
- Finalize Aggregate
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial Aggregate
-               ->  Nested Loop
-                     Join Filter: true
-                     ->  Broadcast Motion 3:3  (slice2; segments: 3)
-                           ->  Seq Scan on x
-                     ->  Dynamic Index Scan on y_idx on y
-                           Index Cond: (j < x.i)
-                           Filter: ((j < x.i) AND (x.j <= i))
-                           Number of partitions to scan: 5 
+         ->  Nested Loop
+               Join Filter: true
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                     ->  Seq Scan on x
+               ->  Dynamic Index Scan on y_idx on y
+                     Index Cond: (j < x.i)
+                     Filter: ((j < x.i) AND (x.j <= i))
+                     Number of partitions to scan: 5 
  Optimizer: Pivotal Optimizer (GPORCA)
-(12 rows)
+(11 rows)
 
 reset optimizer_enable_indexjoin;
 -- InferPredicatesBCC-vcpart-txt.mdp
@@ -13793,21 +13787,23 @@ ORDER BY to_char(order_datetime,'YYYY-Q')
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Merge Key: (to_char(order_datetime, 'YYYY-Q'::text)), item_shipment_status_code
-   ->  Finalize GroupAggregate
-         Group Key: (to_char(order_datetime, 'YYYY-Q'::text)), item_shipment_status_code
-         ->  Sort
-               Sort Key: (to_char(order_datetime, 'YYYY-Q'::text)), item_shipment_status_code
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                     Hash Key: (to_char(order_datetime, 'YYYY-Q'::text)), item_shipment_status_code
-                     ->  Partial GroupAggregate
-                           Group Key: (to_char(order_datetime, 'YYYY-Q'::text)), item_shipment_status_code
-                           ->  Sort
-                                 Sort Key: (to_char(order_datetime, 'YYYY-Q'::text)), item_shipment_status_code, order_id
-                                 ->  Dynamic Seq Scan on order_lineitems
-                                       Number of partitions to scan: 3 
-                                       Filter: ((order_datetime >= 'Thu Apr 01 00:00:00 2010'::timestamp without time zone) AND (order_datetime <= '06-30-2010'::date))
+   ->  Sort
+         Sort Key: (to_char(order_datetime, 'YYYY-Q'::text)), item_shipment_status_code
+         ->  Finalize GroupAggregate
+               Group Key: (to_char(order_datetime, 'YYYY-Q'::text)), item_shipment_status_code
+               ->  Sort
+                     Sort Key: (to_char(order_datetime, 'YYYY-Q'::text)), item_shipment_status_code
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: (to_char(order_datetime, 'YYYY-Q'::text)), item_shipment_status_code
+                           ->  Partial GroupAggregate
+                                 Group Key: (to_char(order_datetime, 'YYYY-Q'::text)), item_shipment_status_code
+                                 ->  Sort
+                                       Sort Key: (to_char(order_datetime, 'YYYY-Q'::text)), item_shipment_status_code, order_id
+                                       ->  Dynamic Seq Scan on order_lineitems
+                                             Number of partitions to scan: 3 
+                                             Filter: ((order_datetime >= 'Thu Apr 01 00:00:00 2010'::timestamp without time zone) AND (order_datetime <= '06-30-2010'::date))
  Optimizer: Pivotal Optimizer (GPORCA)
-(16 rows)
+(18 rows)
 
 -- test partioned table with no partitions
 create table no_part (a int, b int) partition by list (a) distributed by (b);
@@ -14453,17 +14449,16 @@ EXPLAIN (COSTS OFF) SELECT (
    Join Filter: true
    ->  Result
    ->  Materialize
-         ->  Finalize Aggregate
+         ->  Aggregate
                ->  Gather Motion 3:1  (slice1; segments: 3)
-                     ->  Partial Aggregate
-                           ->  Hash Join
-                                 Hash Cond: (join_null_rej1.i = join_null_rej2.i)
-                                 ->  Seq Scan on join_null_rej1
-                                 ->  Hash
-                                       ->  Seq Scan on join_null_rej2
-                                             Filter: (i < join_null_rej_func())
+                     ->  Hash Join
+                           Hash Cond: (join_null_rej1.i = join_null_rej2.i)
+                           ->  Seq Scan on join_null_rej1
+                           ->  Hash
+                                 ->  Seq Scan on join_null_rej2
+                                       Filter: (i < join_null_rej_func())
  Optimizer: Pivotal Optimizer (GPORCA)
-(14 rows)
+(13 rows)
 
 -- Optional, but let's check we get same result for both, folded and
 -- not folded join_null_rej_func() function.

--- a/src/test/regress/expected/groupingsets_optimizer.out
+++ b/src/test/regress/expected/groupingsets_optimizer.out
@@ -768,20 +768,16 @@ select * from gstest1 group by grouping sets((a,b,v),(v)) order by v,b,a;
          ->  Append
                ->  GroupAggregate
                      Group Key: share0_ref2.column3
-                     ->  GroupAggregate
-                           Group Key: share0_ref2.column3
-                           ->  Sort
-                                 Sort Key: share0_ref2.column3
-                                 ->  Shared Scan (share slice:id 0:0)
+                     ->  Sort
+                           Sort Key: share0_ref2.column3
+                           ->  Shared Scan (share slice:id 0:0)
                ->  GroupAggregate
                      Group Key: share0_ref3.column3, share0_ref3.column2, share0_ref3.column1
-                     ->  GroupAggregate
-                           Group Key: share0_ref3.column3, share0_ref3.column2, share0_ref3.column1
-                           ->  Sort
-                                 Sort Key: share0_ref3.column3, share0_ref3.column2, share0_ref3.column1
-                                 ->  Shared Scan (share slice:id 0:0)
+                     ->  Sort
+                           Sort Key: share0_ref3.column3, share0_ref3.column2, share0_ref3.column1
+                           ->  Shared Scan (share slice:id 0:0)
  Optimizer: Pivotal Optimizer (GPORCA)
-(21 rows)
+(17 rows)
 
 -- Agg level check. This query should error out.
 select (select grouping(a,b) from gstest2) from gstest2 group by a,b;
@@ -1820,18 +1816,17 @@ explain (costs off)
                            ->  Streaming Partial HashAggregate
                                  Group Key: share0_ref6.thousand
                                  ->  Shared Scan (share slice:id 6:0)
-               ->  Finalize HashAggregate
+               ->  HashAggregate
                      Group Key: share0_ref7.twothousand
                      ->  Redistribute Motion 3:3  (slice7; segments: 3)
                            Hash Key: share0_ref7.twothousand
-                           ->  Streaming Partial HashAggregate
-                                 Group Key: share0_ref7.twothousand
+                           ->  Result
                                  ->  Shared Scan (share slice:id 7:0)
                ->  HashAggregate
                      Group Key: share0_ref8.unique1
                      ->  Shared Scan (share slice:id 1:0)
  Optimizer: Pivotal Optimizer (GPORCA)
-(53 rows)
+(52 rows)
 
 explain (costs off)
   select unique1,
@@ -1934,18 +1929,17 @@ explain (costs off)
                            ->  Streaming Partial HashAggregate
                                  Group Key: share0_ref6.thousand
                                  ->  Shared Scan (share slice:id 6:0)
-               ->  Finalize HashAggregate
+               ->  HashAggregate
                      Group Key: share0_ref7.twothousand
                      ->  Redistribute Motion 3:3  (slice7; segments: 3)
                            Hash Key: share0_ref7.twothousand
-                           ->  Streaming Partial HashAggregate
-                                 Group Key: share0_ref7.twothousand
+                           ->  Result
                                  ->  Shared Scan (share slice:id 7:0)
                ->  HashAggregate
                      Group Key: share0_ref8.unique1
                      ->  Shared Scan (share slice:id 1:0)
  Optimizer: Pivotal Optimizer (GPORCA)
-(53 rows)
+(52 rows)
 
 -- check collation-sensitive matching between grouping expressions
 -- (similar to a check for aggregates, but there are additional code

--- a/src/test/regress/expected/limit_gp_optimizer.out
+++ b/src/test/regress/expected/limit_gp_optimizer.out
@@ -126,45 +126,37 @@ explain select distinct(a), sum(b) from t_volatile_limit_1 group by a order by a
                                                     QUERY PLAN                                                    
 ------------------------------------------------------------------------------------------------------------------
  Limit  (cost=0.00..431.00 rows=1 width=12)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
          Merge Key: a, (sum(b))
          ->  Sort  (cost=0.00..431.00 rows=1 width=12)
                Sort Key: a, (sum(b))
-               ->  Finalize GroupAggregate  (cost=0.00..431.00 rows=1 width=12)
+               ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=12)
                      Group Key: a
-                     ->  Sort  (cost=0.00..431.00 rows=1 width=12)
+                     ->  Sort  (cost=0.00..431.00 rows=1 width=8)
                            Sort Key: a
-                           ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
+                           ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
                                  Hash Key: a
-                                 ->  Partial GroupAggregate  (cost=0.00..431.00 rows=1 width=12)
-                                       Group Key: a
-                                       ->  Sort  (cost=0.00..431.00 rows=1 width=8)
-                                             Sort Key: a
-                                             ->  Seq Scan on t_volatile_limit_1  (cost=0.00..431.00 rows=1 width=8)
- Optimizer: Pivotal Optimizer (GPORCA)
-(17 rows)
+                                 ->  Seq Scan on t_volatile_limit_1  (cost=0.00..431.00 rows=1 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.80.0
+(13 rows)
 
 explain select distinct(a), sum(b) from t_volatile_limit_1 group by a order by a, sum(b) limit 2 offset (random()*2);
                                                     QUERY PLAN                                                    
 ------------------------------------------------------------------------------------------------------------------
  Limit  (cost=0.00..431.00 rows=1 width=12)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
          Merge Key: a, (sum(b))
          ->  Sort  (cost=0.00..431.00 rows=1 width=12)
                Sort Key: a, (sum(b))
-               ->  Finalize GroupAggregate  (cost=0.00..431.00 rows=1 width=12)
+               ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=12)
                      Group Key: a
-                     ->  Sort  (cost=0.00..431.00 rows=1 width=12)
+                     ->  Sort  (cost=0.00..431.00 rows=1 width=8)
                            Sort Key: a
-                           ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
+                           ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
                                  Hash Key: a
-                                 ->  Partial GroupAggregate  (cost=0.00..431.00 rows=1 width=12)
-                                       Group Key: a
-                                       ->  Sort  (cost=0.00..431.00 rows=1 width=8)
-                                             Sort Key: a
-                                             ->  Seq Scan on t_volatile_limit_1  (cost=0.00..431.00 rows=1 width=8)
- Optimizer: Pivotal Optimizer (GPORCA)
-(17 rows)
+                                 ->  Seq Scan on t_volatile_limit_1  (cost=0.00..431.00 rows=1 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.80.0
+(13 rows)
 
 drop table t_volatile_limit;
 drop table t_volatile_limit_1;

--- a/src/test/regress/expected/matview_optimizer.out
+++ b/src/test/regress/expected/matview_optimizer.out
@@ -22,19 +22,15 @@ EXPLAIN (costs off)
   CREATE MATERIALIZED VIEW mvtest_tm AS SELECT type, sum(amt) AS totamt FROM mvtest_t GROUP BY type WITH NO DATA distributed by(type);
                          QUERY PLAN                         
 ------------------------------------------------------------
- Finalize GroupAggregate
+ GroupAggregate
    Group Key: type
    ->  Sort
          Sort Key: type
          ->  Redistribute Motion 3:3  (slice1; segments: 3)
                Hash Key: type
-               ->  Partial GroupAggregate
-                     Group Key: type
-                     ->  Sort
-                           Sort Key: type
-                           ->  Seq Scan on mvtest_t
- Optimizer: Pivotal Optimizer (GPORCA)
-(12 rows)
+               ->  Seq Scan on mvtest_t
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(8 rows)
 
 CREATE MATERIALIZED VIEW mvtest_tm AS SELECT type, sum(amt) AS totamt FROM mvtest_t GROUP BY type WITH NO DATA distributed by(type);
 SELECT relispopulated FROM pg_class WHERE oid = 'mvtest_tm'::regclass;
@@ -72,19 +68,15 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entr
    ->  Sort
          Sort Key: type
          ->  Redistribute Motion 3:3  (slice1; segments: 3)
-               ->  Finalize GroupAggregate
+               ->  GroupAggregate
                      Group Key: type
                      ->  Sort
                            Sort Key: type
                            ->  Redistribute Motion 3:3  (slice2; segments: 3)
                                  Hash Key: type
-                                 ->  Partial GroupAggregate
-                                       Group Key: type
-                                       ->  Sort
-                                             Sort Key: type
-                                             ->  Seq Scan on mvtest_t
- Optimizer: Pivotal Optimizer (GPORCA)
-(16 rows)
+                                 ->  Seq Scan on mvtest_t
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(12 rows)
 
 CREATE MATERIALIZED VIEW mvtest_tvm AS SELECT * FROM mvtest_tv ORDER BY type;
 SELECT * FROM mvtest_tvm;
@@ -111,19 +103,15 @@ EXPLAIN (costs off)
          ->  Finalize Aggregate
                ->  Gather Motion 3:1  (slice2; segments: 3)
                      ->  Partial Aggregate
-                           ->  Finalize GroupAggregate
+                           ->  GroupAggregate
                                  Group Key: type
                                  ->  Sort
                                        Sort Key: type
                                        ->  Redistribute Motion 3:3  (slice3; segments: 3)
                                              Hash Key: type
-                                             ->  Partial GroupAggregate
-                                                   Group Key: type
-                                                   ->  Sort
-                                                         Sort Key: type
-                                                         ->  Seq Scan on mvtest_t
- Optimizer: Pivotal Optimizer (GPORCA)
-(17 rows)
+                                             ->  Seq Scan on mvtest_t
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(13 rows)
 
 CREATE MATERIALIZED VIEW mvtest_tvvm AS SELECT * FROM mvtest_tvv;
 CREATE VIEW mvtest_tvvmv AS SELECT * FROM mvtest_tvvm;

--- a/src/test/regress/expected/notin_optimizer.out
+++ b/src/test/regress/expected/notin_optimizer.out
@@ -1200,23 +1200,17 @@ explain select c1 from t1 where c1::absint not in
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1324035.89 rows=10 width=4)
    ->  Result  (cost=0.00..1324035.89 rows=4 width=4)
          Filter: (NOT CASE WHEN ((count((true))) > '0'::bigint) THEN CASE WHEN ((sum((CASE WHEN (((t1.c1)::absint = ((t1n.c1n)::absint)) IS NULL) THEN 1 ELSE 0 END))) = (count((true)))) THEN NULL::boolean ELSE true END ELSE false END)
-         ->  Finalize GroupAggregate  (cost=0.00..1324035.89 rows=4 width=20)
+         ->  HashAggregate  (cost=0.00..1324035.89 rows=4 width=20)
                Group Key: t1.c1, t1.ctid, t1.gp_segment_id
-               ->  Sort  (cost=0.00..1324035.89 rows=4 width=30)
-                     Sort Key: t1.ctid, t1.gp_segment_id
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..1324035.89 rows=4 width=30)
-                           Hash Key: t1.ctid, t1.gp_segment_id
-                           ->  Streaming Partial HashAggregate  (cost=0.00..1324035.89 rows=4 width=30)
-                                 Group Key: t1.c1, t1.ctid, t1.gp_segment_id
-                                 ->  Nested Loop Left Join  (cost=0.00..1324035.88 rows=11 width=19)
-                                       Join Filter: (((t1.c1)::absint = ((t1n.c1n)::absint)) IS NOT FALSE)
-                                       ->  Seq Scan on t1  (cost=0.00..431.00 rows=4 width=14)
-                                       ->  Result  (cost=0.00..431.00 rows=7 width=5)
-                                             ->  Materialize  (cost=0.00..431.00 rows=7 width=4)
-                                                   ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=7 width=4)
-                                                         ->  Seq Scan on t1n  (cost=0.00..431.00 rows=3 width=4)
- Optimizer: Pivotal Optimizer (GPORCA)
-(19 rows)
+               ->  Nested Loop Left Join  (cost=0.00..1324035.88 rows=11 width=19)
+                     Join Filter: (((t1.c1)::absint = ((t1n.c1n)::absint)) IS NOT FALSE)
+                     ->  Seq Scan on t1  (cost=0.00..431.00 rows=4 width=14)
+                     ->  Result  (cost=0.00..431.00 rows=7 width=5)
+                           ->  Materialize  (cost=0.00..431.00 rows=7 width=4)
+                                 ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=7 width=4)
+                                       ->  Seq Scan on t1n  (cost=0.00..431.00 rows=3 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(13 rows)
 
 select c1 from t1 where c1::absint not in
 	(select c1n::absint from t1n);

--- a/src/test/regress/expected/olap_plans_optimizer.out
+++ b/src/test/regress/expected/olap_plans_optimizer.out
@@ -142,21 +142,16 @@ select sum(distinct a) from olap_test_single;
 
 -- Otherwise, need a more complicated plans
 explain select sum(distinct b) from olap_test_single;
-                                                 QUERY PLAN
-------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=0.00..431.51 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.51 rows=11 width=4)
-         ->  GroupAggregate  (cost=0.00..431.51 rows=4 width=4)
-               Group Key: b
-               ->  Sort  (cost=0.00..431.51 rows=4 width=4)
-                     Sort Key: b
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.51 rows=4 width=4)
-                           Hash Key: b
-                           ->  Streaming HashAggregate  (cost=0.00..431.51 rows=4 width=4)
-                                 Group Key: b
-                                 ->  Seq Scan on olap_test_single  (cost=0.00..431.08 rows=3334 width=4)
- Optimizer: Pivotal Optimizer (GPORCA)
-(12 rows)
+                                               QUERY PLAN                                                
+---------------------------------------------------------------------------------------------------------
+ Finalize Aggregate  (cost=0.00..431.15 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.15 rows=1 width=8)
+         ->  Partial Aggregate  (cost=0.00..431.15 rows=1 width=8)
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.15 rows=3334 width=4)
+                     Hash Key: b
+                     ->  Seq Scan on olap_test_single  (cost=0.00..431.08 rows=3334 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.79.1
+(7 rows)
 
 select sum(distinct b) from olap_test_single;
  sum 
@@ -170,17 +165,14 @@ select sum(distinct b) from olap_test_single;
 explain select sum(distinct d) from olap_test_single;
                                                QUERY PLAN                                                
 ---------------------------------------------------------------------------------------------------------
- Aggregate  (cost=0.00..432.12 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..432.12 rows=10000 width=4)
-         ->  HashAggregate  (cost=0.00..431.97 rows=3334 width=4)
-               Group Key: d
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.56 rows=3334 width=4)
+ Finalize Aggregate  (cost=0.00..431.15 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.15 rows=1 width=8)
+         ->  Partial Aggregate  (cost=0.00..431.15 rows=1 width=8)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.15 rows=3334 width=4)
                      Hash Key: d
-                     ->  Streaming HashAggregate  (cost=0.00..431.52 rows=3334 width=4)
-                           Group Key: d
-                           ->  Seq Scan on olap_test_single  (cost=0.00..431.08 rows=3334 width=4)
- Optimizer: Pivotal Optimizer (GPORCA)
-(10 rows)
+                     ->  Seq Scan on olap_test_single  (cost=0.00..431.08 rows=3334 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.88.0
+(7 rows)
 
 select sum(distinct d) from olap_test_single;
    sum    
@@ -269,17 +261,16 @@ select a, b, c, sum(d) from olap_test group by grouping sets((a, b), (a), (b, c)
 explain select a, b, d, sum(d) from olap_test group by grouping sets((a, b), (a), (b, d));
                                                     QUERY PLAN                                                     
 -------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1728.41 rows=10022 width=20)
-   ->  Sequence  (cost=0.00..1727.67 rows=3341 width=20)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1727.49 rows=10022 width=20)
+   ->  Sequence  (cost=0.00..1726.74 rows=3341 width=20)
          ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.16 rows=3334 width=1)
                ->  Seq Scan on olap_test  (cost=0.00..431.08 rows=3334 width=12)
-         ->  Append  (cost=0.00..1296.44 rows=3341 width=20)
-               ->  Finalize HashAggregate  (cost=0.00..432.91 rows=3334 width=16)
+         ->  Append  (cost=0.00..1295.51 rows=3341 width=20)
+               ->  HashAggregate  (cost=0.00..431.99 rows=3334 width=16)
                      Group Key: share0_ref2.b, share0_ref2.d
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..432.07 rows=3334 width=16)
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.15 rows=3334 width=8)
                            Hash Key: share0_ref2.b, share0_ref2.d
-                           ->  Streaming Partial HashAggregate  (cost=0.00..431.91 rows=3334 width=16)
-                                 Group Key: share0_ref2.b, share0_ref2.d
+                           ->  Result  (cost=0.00..431.06 rows=3334 width=8)
                                  ->  Shared Scan (share slice:id 2:0)  (cost=0.00..431.06 rows=3334 width=8)
                ->  Finalize GroupAggregate  (cost=0.00..431.48 rows=1 width=12)
                      Group Key: share0_ref3.a

--- a/src/test/regress/expected/olap_window_seq_optimizer.out
+++ b/src/test/regress/expected/olap_window_seq_optimizer.out
@@ -7671,18 +7671,16 @@ order by 1,2,3;
 -- Once upon a time, there was a bug in deparsing a WindowAgg node with EXPLAIN
 -- that this query triggered (MPP-4840)
 explain select n from ( select row_number() over () from (values (0)) as t(x) ) as r(n) group by n;
-                            QUERY PLAN                            
-------------------------------------------------------------------
+                         QUERY PLAN                         
+------------------------------------------------------------
  GroupAggregate  (cost=0.00..0.00 rows=1 width=8)
    Group Key: (row_number() OVER (?))
-   ->  GroupAggregate  (cost=0.00..0.00 rows=1 width=8)
-         Group Key: (row_number() OVER (?))
-         ->  Sort  (cost=0.00..0.00 rows=1 width=8)
-               Sort Key: (row_number() OVER (?))
-               ->  WindowAgg  (cost=0.00..0.00 rows=1 width=8)
-                     ->  Result  (cost=0.00..0.00 rows=1 width=1)
+   ->  Sort  (cost=0.00..0.00 rows=1 width=8)
+         Sort Key: (row_number() OVER (?))
+         ->  WindowAgg  (cost=0.00..0.00 rows=1 width=8)
+               ->  Result  (cost=0.00..0.00 rows=1 width=1)
  Optimizer: Pivotal Optimizer (GPORCA)
-(9 rows)
+(7 rows)
 
 -- Test for MPP-11645
 create table olap_window_r (a int, b int, x int,  y int,  z int ) distributed by (b);

--- a/src/test/regress/expected/pg_lsn_optimizer.out
+++ b/src/test/regress/expected/pg_lsn_optimizer.out
@@ -72,27 +72,25 @@ SELECT DISTINCT (i || '/' || j)::pg_lsn f
        generate_series(1, 5) k
   WHERE i <= 10 AND j > 0 AND j <= 10
   ORDER BY f;
-                                                                 QUERY PLAN                                                                 
---------------------------------------------------------------------------------------------------------------------------------------------
- GroupAggregate
-   Group Key: (((((generate_series_2.generate_series)::text || '/'::text) || (generate_series_1.generate_series)::text))::pg_lsn)
-   ->  Sort
-         Sort Key: (((((generate_series_2.generate_series)::text || '/'::text) || (generate_series_1.generate_series)::text))::pg_lsn)
-         ->  Streaming HashAggregate
-               Group Key: ((((generate_series_2.generate_series)::text || '/'::text) || (generate_series_1.generate_series)::text))::pg_lsn
+                                                              QUERY PLAN                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: (((((generate_series_2.generate_series)::text || '/'::text) || (generate_series_1.generate_series)::text))::pg_lsn)
+   ->  HashAggregate
+         Group Key: ((((generate_series_2.generate_series)::text || '/'::text) || (generate_series_1.generate_series)::text))::pg_lsn
+         ->  Nested Loop
+               Join Filter: true
                ->  Nested Loop
                      Join Filter: true
-                     ->  Nested Loop
-                           Join Filter: true
-                           ->  Result
-                                 Filter: (generate_series_2.generate_series <= 10)
-                                 ->  Function Scan on generate_series generate_series_2
-                           ->  Result
-                                 Filter: ((generate_series_1.generate_series > 0) AND (generate_series_1.generate_series <= 10))
-                                 ->  Function Scan on generate_series generate_series_1
-                     ->  Function Scan on generate_series
- Optimizer: Pivotal Optimizer (GPORCA)
-(18 rows)
+                     ->  Result
+                           Filter: (generate_series_2.generate_series <= 10)
+                           ->  Function Scan on generate_series generate_series_2
+                     ->  Result
+                           Filter: ((generate_series_1.generate_series > 0) AND (generate_series_1.generate_series <= 10))
+                           ->  Function Scan on generate_series generate_series_1
+               ->  Function Scan on generate_series
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(16 rows)
 
 SELECT DISTINCT (i || '/' || j)::pg_lsn f
   FROM generate_series(1, 10) i,

--- a/src/test/regress/expected/plancache_optimizer.out
+++ b/src/test/regress/expected/plancache_optimizer.out
@@ -294,15 +294,14 @@ analyze test_mode;
 prepare test_mode_pp (int) as select count(*) from test_mode where a = $1;
 -- up to 5 executions, custom plan is used
 explain (costs off) execute test_mode_pp(2);
-                           QUERY PLAN                            
------------------------------------------------------------------
- Finalize Aggregate
+                        QUERY PLAN                        
+----------------------------------------------------------
+ Aggregate
    ->  Gather Motion 1:1  (slice1; segments: 1)
-         ->  Partial Aggregate
-               ->  Index Scan using test_mode_a_idx on test_mode
-                     Index Cond: (a = 2)
- Optimizer: Pivotal Optimizer (GPORCA)
-(6 rows)
+         ->  Index Scan using test_mode_a_idx on test_mode
+               Index Cond: (a = 2)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.93.0
+(5 rows)
 
 -- force generic plan
 set plan_cache_mode to force_generic_plan;
@@ -351,28 +350,26 @@ execute test_mode_pp(1); -- 5x
 
 -- we should now get a really bad plan
 explain (costs off) execute test_mode_pp(2);
-                           QUERY PLAN                            
------------------------------------------------------------------
- Finalize Aggregate
+         QUERY PLAN          
+-----------------------------
+ Aggregate
    ->  Gather Motion 1:1  (slice1; segments: 1)
-         ->  Partial Aggregate
-               ->  Index Scan using test_mode_a_idx on test_mode
-                     Index Cond: (a = 2)
- Optimizer: Pivotal Optimizer (GPORCA)
-(6 rows)
+         ->  Index Scan using test_mode_a_idx on test_mode
+               Index Cond: (a = 2)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.93.0
+(5 rows)
 
 -- but we can force a custom plan
 set plan_cache_mode to force_custom_plan;
 explain (costs off) execute test_mode_pp(2);
-                           QUERY PLAN                            
------------------------------------------------------------------
- Finalize Aggregate
+                        QUERY PLAN                        
+----------------------------------------------------------
+ Aggregate
    ->  Gather Motion 1:1  (slice1; segments: 1)
-         ->  Partial Aggregate
-               ->  Index Scan using test_mode_a_idx on test_mode
-                     Index Cond: (a = 2)
- Optimizer: Pivotal Optimizer (GPORCA)
-(6 rows)
+         ->  Index Scan using test_mode_a_idx on test_mode
+               Index Cond: (a = 2)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.93.0
+(5 rows)
 
 drop table test_mode;
 --

--- a/src/test/regress/expected/qp_correlated_query_optimizer.out
+++ b/src/test/regress/expected/qp_correlated_query_optimizer.out
@@ -667,14 +667,14 @@ select A.i, B.i, C.j from A, B, C where A.j = (select C.j from C where C.j = A.j
 explain select A.i, B.i, C.j from A, B, C where A.j = any ( select C.j from C where not exists(select C.i from C,A where C.i = A.i and C.i =10)) order by A.i, B.i, C.j limit 10;
                                                               QUERY PLAN                                                               
 ---------------------------------------------------------------------------------------------------------------------------------------
- Limit  (cost=0.00..1358457987.38 rows=10 width=12)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1358457987.38 rows=10 width=12)
+ Limit  (cost=0.00..1358457987.42 rows=4 width=12)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1358457987.42 rows=10 width=12)
          Merge Key: a.i, b.i, c.j
-         ->  Limit  (cost=0.00..1358457987.38 rows=4 width=12)
-               ->  Sort  (cost=0.00..1358457987.38 rows=90 width=12)
+         ->  Limit  (cost=0.00..1358457987.42 rows=4 width=12)
+               ->  Sort  (cost=0.00..1358457987.42 rows=90 width=12)
                      Sort Key: a.i, b.i, c.j
-                     ->  Hash Semi Join  (cost=0.00..1358457987.34 rows=90 width=12)
-                           Hash Cond: (a.j = c_2.j)
+                     ->  Hash Semi Join  (cost=0.00..1358457987.38 rows=90 width=12)
+                           Hash Cond: a.j = c_2.j
                            ->  Nested Loop  (cost=0.00..1356692610.50 rows=90 width=16)
                                  Join Filter: true
                                  ->  Nested Loop  (cost=0.00..1324033.12 rows=10 width=12)
@@ -686,21 +686,21 @@ explain select A.i, B.i, C.j from A, B, C where A.j = any ( select C.j from C wh
                                  ->  Materialize  (cost=0.00..431.00 rows=9 width=4)
                                        ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=9 width=4)
                                              ->  Seq Scan on c  (cost=0.00..431.00 rows=3 width=4)
-                           ->  Hash  (cost=1765376.81..1765376.81 rows=9 width=4)
-                                 ->  Broadcast Motion 3:3  (slice4; segments: 3)  (cost=0.00..1765376.81 rows=9 width=4)
-                                       ->  Nested Loop Anti Join  (cost=0.00..1765376.81 rows=3 width=4)
+                           ->  Hash  (cost=1765376.85..1765376.85 rows=9 width=4)
+                                 ->  Broadcast Motion 3:3  (slice4; segments: 3)  (cost=0.00..1765376.85 rows=9 width=4)
+                                       ->  Nested Loop Anti Join  (cost=0.00..1765376.85 rows=3 width=4)
                                              Join Filter: true
                                              ->  Seq Scan on c c_2  (cost=0.00..431.00 rows=3 width=4)
-                                             ->  Materialize  (cost=0.00..862.00 rows=1 width=1)
-                                                   ->  Broadcast Motion 3:3  (slice5; segments: 3)  (cost=0.00..862.00 rows=1 width=1)
+                                             ->  Materialize  (cost=0.00..862.00 rows=2 width=1)
+                                                   ->  Broadcast Motion 3:3  (slice5; segments: 3)  (cost=0.00..862.00 rows=2 width=1)
                                                          ->  Hash Join  (cost=0.00..862.00 rows=1 width=1)
-                                                               Hash Cond: (c_1.i = a_1.i)
+                                                               Hash Cond: c_1.i = a_1.i
                                                                ->  Seq Scan on c c_1  (cost=0.00..431.00 rows=1 width=4)
-                                                                     Filter: ((i = 10) AND (i = 10))
+                                                                     Filter: i = 10 AND i = 10
                                                                ->  Hash  (cost=431.00..431.00 rows=1 width=4)
                                                                      ->  Seq Scan on a a_1  (cost=0.00..431.00 rows=1 width=4)
-                                                                           Filter: ((i = 10) AND (i = 10))
- Optimizer: Pivotal Optimizer (GPORCA)
+                                                                           Filter: i = 10 AND i = 10
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (34 rows)
 
 select A.i, B.i, C.j from A, B, C where A.j = any ( select C.j from C where not exists(select C.i from C,A where C.i = A.i and C.i =10)) order by A.i, B.i, C.j limit 10;
@@ -721,7 +721,7 @@ select A.i, B.i, C.j from A, B, C where A.j = any ( select C.j from C where not 
 explain select A.i, B.i, C.j from A, B, C where A.j = any (select C.j from C where C.j = A.j and not exists (select sum(B.i) from B where C.i = B.i and C.i !=10)) order by A.i, B.i, C.j limit 10;
                                                                 QUERY PLAN                                                                
 ------------------------------------------------------------------------------------------------------------------------------------------
- Limit  (cost=0.00..1356692465.22 rows=10 width=12)
+ Limit  (cost=0.00..1356692465.22 rows=4 width=12)
    ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1356692465.22 rows=10 width=12)
          Merge Key: a.i, b.i, c.j
          ->  Limit  (cost=0.00..1356692465.22 rows=4 width=12)
@@ -733,10 +733,10 @@ explain select A.i, B.i, C.j from A, B, C where A.j = any (select C.j from C whe
                                  Join Filter: true
                                  ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
                                        ->  Hash Join  (cost=0.00..431.00 rows=1 width=4)
-                                             Hash Cond: ((NULL::integer) = a.j)
+                                             Hash Cond: "outer".j = a.j
                                              ->  Result  (cost=0.00..0.00 rows=0 width=4)
                                                    ->  HashAggregate  (cost=0.00..0.00 rows=0 width=4)
-                                                         Group Key: NULL::integer
+                                                         Group By: NULL::integer
                                                          ->  Result  (cost=0.00..0.00 rows=0 width=4)
                                                                One-Time Filter: false
                                              ->  Hash  (cost=431.00..431.00 rows=2 width=8)
@@ -747,8 +747,9 @@ explain select A.i, B.i, C.j from A, B, C where A.j = any (select C.j from C whe
                            ->  Materialize  (cost=0.00..431.00 rows=9 width=4)
                                  ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=9 width=4)
                                        ->  Seq Scan on c  (cost=0.00..431.00 rows=3 width=4)
- Optimizer: Pivotal Optimizer (GPORCA)
-(27 rows)
+ Settings:  optimizer=on
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.34.0
+(28 rows)
 
 select A.i, B.i, C.j from A, B, C where A.j = any (select C.j from C where C.j = A.j and not exists (select sum(B.i) from B where C.i = B.i and C.i !=10)) order by A.i, B.i, C.j limit 10;
  i | i | j 
@@ -812,15 +813,15 @@ select * from A,B where exists (select * from C where C.j = A.j and B.i = all (s
 (4 rows)
 
 explain select A.i, B.i, C.j from A, B, C where A.j = (select sum(C.j) from C where C.j = A.j and C.i = all (select B.i from B where C.i = B.i and B.i !=10)) order by A.i, B.i, C.j limit 10;
-                                                                                                                                                                                                      QUERY PLAN                                                                                                                                                                                                       
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Limit  (cost=0.00..2712506248.57 rows=10 width=12)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..2712506248.56 rows=10 width=12)
+                                                                                                                                                                                                QUERY PLAN                                                                                                                                                                                                 
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit  (cost=0.00..2712506248.09 rows=10 width=12)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..2712506248.09 rows=10 width=12)
          Merge Key: a.i, b_1.i, c_1.j
-         ->  Limit  (cost=0.00..2712506248.56 rows=4 width=12)
-               ->  Sort  (cost=0.00..2712506248.56 rows=90 width=12)
+         ->  Limit  (cost=0.00..2712506248.09 rows=4 width=12)
+               ->  Sort  (cost=0.00..2712506248.09 rows=90 width=12)
                      Sort Key: a.i, b_1.i, c_1.j
-                     ->  Nested Loop  (cost=0.00..2712506248.52 rows=90 width=12)
+                     ->  Nested Loop  (cost=0.00..2712506248.05 rows=90 width=12)
                            Join Filter: true
                            ->  Nested Loop  (cost=0.00..1324033.29 rows=18 width=8)
                                  Join Filter: true
@@ -831,34 +832,30 @@ explain select A.i, B.i, C.j from A, B, C where A.j = (select sum(C.j) from C wh
                                  ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1324467.58 rows=5 width=4)
                                        ->  Hash Join  (cost=0.00..1324467.58 rows=2 width=4)
                                              Hash Cond: (((sum(c.j)) = (a.j)::bigint) AND (c.j = a.j))
-                                             ->  Finalize GroupAggregate  (cost=0.00..1324036.58 rows=3 width=12)
+                                             ->  GroupAggregate  (cost=0.00..1324036.58 rows=3 width=12)
                                                    Group Key: c.j
-                                                   ->  Sort  (cost=0.00..1324036.58 rows=3 width=12)
+                                                   ->  Sort  (cost=0.00..1324036.58 rows=3 width=4)
                                                          Sort Key: c.j
-                                                         ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..1324036.58 rows=3 width=12)
+                                                         ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..1324036.58 rows=3 width=4)
                                                                Hash Key: c.j
-                                                               ->  Partial GroupAggregate  (cost=0.00..1324036.58 rows=3 width=12)
-                                                                     Group Key: c.j
-                                                                     ->  Sort  (cost=0.00..1324036.58 rows=3 width=4)
-                                                                           Sort Key: c.j
-                                                                           ->  Seq Scan on c  (cost=0.00..1324036.58 rows=3 width=4)
-                                                                                 Filter: (SubPlan 1)
-                                                                                 SubPlan 1
-                                                                                   ->  Result  (cost=0.00..431.00 rows=1 width=1)
-                                                                                         Filter: ((CASE WHEN (sum((CASE WHEN (c.i <> b.i) THEN 1 ELSE 0 END)) IS NULL) THEN true WHEN (sum((CASE WHEN (b.i IS NULL) THEN 1 ELSE 0 END)) > '0'::bigint) THEN NULL::boolean WHEN (c.i IS NULL) THEN NULL::boolean WHEN (sum((CASE WHEN (c.i <> b.i) THEN 1 ELSE 0 END)) = '0'::bigint) THEN true ELSE false END) = true)
-                                                                                         ->  Aggregate  (cost=0.00..431.00 rows=1 width=16)
-                                                                                               ->  Result  (cost=0.00..431.00 rows=1 width=4)
-                                                                                                     Filter: (c.i = b.i)
-                                                                                                     ->  Materialize  (cost=0.00..431.00 rows=6 width=4)
-                                                                                                           ->  Broadcast Motion 3:3  (slice4; segments: 3)  (cost=0.00..431.00 rows=6 width=4)
-                                                                                                                 ->  Seq Scan on b  (cost=0.00..431.00 rows=2 width=4)
-                                                                                                                       Filter: (i <> 10)
+                                                               ->  Seq Scan on c  (cost=0.00..1324036.58 rows=3 width=4)
+                                                                     Filter: (SubPlan 1)
+                                                                     SubPlan 1
+                                                                       ->  Result  (cost=0.00..431.00 rows=1 width=1)
+                                                                             Filter: ((CASE WHEN (sum((CASE WHEN (c.i <> b.i) THEN 1 ELSE 0 END)) IS NULL) THEN true WHEN (sum((CASE WHEN (b.i IS NULL) THEN 1 ELSE 0 END)) > '0'::bigint) THEN NULL::boolean WHEN (c.i IS NULL) THEN NULL::boolean WHEN (sum((CASE WHEN (c.i <> b.i) THEN 1 ELSE 0 END)) = '0'::bigint) THEN true ELSE false END) = true)
+                                                                             ->  Aggregate  (cost=0.00..431.00 rows=1 width=16)
+                                                                                   ->  Result  (cost=0.00..431.00 rows=1 width=4)
+                                                                                         Filter: (c.i = b.i)
+                                                                                         ->  Materialize  (cost=0.00..431.00 rows=6 width=4)
+                                                                                               ->  Broadcast Motion 3:3  (slice4; segments: 3)  (cost=0.00..431.00 rows=6 width=4)
+                                                                                                     ->  Seq Scan on b  (cost=0.00..431.00 rows=2 width=4)
+                                                                                                           Filter: (i <> 10)
                                              ->  Hash  (cost=431.00..431.00 rows=2 width=8)
                                                    ->  Redistribute Motion 3:3  (slice5; segments: 3)  (cost=0.00..431.00 rows=2 width=8)
                                                          Hash Key: a.j
                                                          ->  Seq Scan on a  (cost=0.00..431.00 rows=2 width=8)
  Optimizer: Pivotal Optimizer (GPORCA)
-(44 rows)
+(40 rows)
 
 select A.i, B.i, C.j from A, B, C where A.j = (select sum(C.j) from C where C.j = A.j and C.i = all (select B.i from B where C.i = B.i and B.i !=10)) order by A.i, B.i, C.j limit 10;
  i | i  | j  
@@ -878,14 +875,14 @@ select A.i, B.i, C.j from A, B, C where A.j = (select sum(C.j) from C where C.j 
 explain select A.i, B.i, C.j from A, B, C where A.j < all ( select C.j from C where not exists(select C.i from C,A where C.i = A.i and C.i =10)) order by A.i, B.i, C.j limit 10;
                                                               QUERY PLAN                                                               
 ---------------------------------------------------------------------------------------------------------------------------------------
- Limit  (cost=0.00..1391061420433.70 rows=10 width=12)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1391061420433.70 rows=10 width=12)
+ Limit  (cost=0.00..1391061420469.59 rows=4 width=12)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1391061420469.59 rows=10 width=12)
          Merge Key: a_1.i, b.i, c_2.j
-         ->  Limit  (cost=0.00..1391061420433.70 rows=4 width=12)
-               ->  Sort  (cost=0.00..1391061420433.70 rows=36 width=12)
+         ->  Limit  (cost=0.00..1391061420469.59 rows=4 width=12)
+               ->  Sort  (cost=0.00..1391061420469.59 rows=36 width=12)
                      Sort Key: a_1.i, b.i, c_2.j
-                     ->  Nested Loop Left Anti Semi (Not-In) Join  (cost=0.00..1391061420433.69 rows=36 width=12)
-                           Join Filter: (a_1.j >= c_1.j)
+                     ->  Nested Loop Left Anti Semi (Not-In) Join  (cost=0.00..1391061420469.58 rows=36 width=12)
+                           Join Filter: a_1.j >= c_1.j
                            ->  Nested Loop  (cost=0.00..1356692610.50 rows=90 width=16)
                                  Join Filter: true
                                  ->  Nested Loop  (cost=0.00..1324033.12 rows=10 width=12)
@@ -897,21 +894,21 @@ explain select A.i, B.i, C.j from A, B, C where A.j < all ( select C.j from C wh
                                  ->  Materialize  (cost=0.00..431.00 rows=9 width=4)
                                        ->  Broadcast Motion 3:3  (slice4; segments: 3)  (cost=0.00..431.00 rows=9 width=4)
                                              ->  Seq Scan on c c_2  (cost=0.00..431.00 rows=3 width=4)
-                           ->  Materialize  (cost=0.00..1765376.81 rows=9 width=4)
-                                 ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1765376.81 rows=9 width=4)
-                                       ->  Nested Loop Anti Join  (cost=0.00..1765376.81 rows=3 width=4)
+                           ->  Materialize  (cost=0.00..1765376.85 rows=9 width=4)
+                                 ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1765376.85 rows=9 width=4)
+                                       ->  Nested Loop Anti Join  (cost=0.00..1765376.85 rows=3 width=4)
                                              Join Filter: true
                                              ->  Seq Scan on c c_1  (cost=0.00..431.00 rows=3 width=4)
-                                             ->  Materialize  (cost=0.00..862.00 rows=1 width=1)
-                                                   ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..862.00 rows=1 width=1)
+                                             ->  Materialize  (cost=0.00..862.00 rows=2 width=1)
+                                                   ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..862.00 rows=2 width=1)
                                                          ->  Hash Join  (cost=0.00..862.00 rows=1 width=1)
-                                                               Hash Cond: (c.i = a.i)
+                                                               Hash Cond: c.i = a.i
                                                                ->  Seq Scan on c  (cost=0.00..431.00 rows=1 width=4)
-                                                                     Filter: ((i = 10) AND (i = 10))
+                                                                     Filter: i = 10 AND i = 10
                                                                ->  Hash  (cost=431.00..431.00 rows=1 width=4)
                                                                      ->  Seq Scan on a  (cost=0.00..431.00 rows=1 width=4)
-                                                                           Filter: ((i = 10) AND (i = 10))
- Optimizer: Pivotal Optimizer (GPORCA)
+                                                                           Filter: i = 10 AND i = 10
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (34 rows)
 
 select A.i, B.i, C.j from A, B, C where A.j < all ( select C.j from C where not exists(select C.i from C,A where C.i = A.i and C.i =10)) order by A.i, B.i, C.j limit 10;
@@ -1296,20 +1293,21 @@ select * from A where not exists (select sum(C.i) from C where C.i = A.i limit 0
 explain select * from A where not exists (select sum(C.i) from C where C.i = A.i limit 5 offset 3);
                                                   QUERY PLAN                                                  
 --------------------------------------------------------------------------------------------------------------
- Result  (cost=0.00..1324035.78 rows=5 width=8)
-   Filter: (SubPlan 1)
+ Result  (cost=0.00..1324035.78 rows=2 width=8)
+   Filter: (subplan)
    ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=5 width=8)
          ->  Seq Scan on a  (cost=0.00..431.00 rows=2 width=8)
    SubPlan 1
      ->  Limit  (cost=0.00..431.00 rows=1 width=8)
            ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
                  ->  Result  (cost=0.00..431.00 rows=1 width=4)
-                       Filter: (c.i = a.i)
-                       ->  Materialize  (cost=0.00..431.00 rows=9 width=4)
+                       Filter: c.i = $0
+                       ->  Materialize  (cost=0.00..431.00 rows=3 width=4)
                              ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=9 width=4)
                                    ->  Seq Scan on c  (cost=0.00..431.00 rows=3 width=4)
- Optimizer: Pivotal Optimizer (GPORCA)
-(13 rows)
+ Settings:  optimizer=on
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.42.0
+(14 rows)
 
 select * from A where not exists (select sum(C.i) from C where C.i = A.i limit 5 offset 3);
  i  | j  
@@ -1324,20 +1322,21 @@ select * from A where not exists (select sum(C.i) from C where C.i = A.i limit 5
 explain select * from A where not exists (select sum(C.i) from C where C.i = A.i limit 1 offset 0);
                                                   QUERY PLAN                                                  
 --------------------------------------------------------------------------------------------------------------
- Result  (cost=0.00..1324035.78 rows=5 width=8)
-   Filter: (SubPlan 1)
+ Result  (cost=0.00..1324035.78 rows=2 width=8)
+   Filter: (subplan)
    ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=5 width=8)
          ->  Seq Scan on a  (cost=0.00..431.00 rows=2 width=8)
    SubPlan 1
      ->  Limit  (cost=0.00..431.00 rows=1 width=8)
            ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
                  ->  Result  (cost=0.00..431.00 rows=1 width=4)
-                       Filter: (c.i = a.i)
-                       ->  Materialize  (cost=0.00..431.00 rows=9 width=4)
+                       Filter: c.i = $0
+                       ->  Materialize  (cost=0.00..431.00 rows=3 width=4)
                              ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=9 width=4)
                                    ->  Seq Scan on c  (cost=0.00..431.00 rows=3 width=4)
-(13 rows)
- Optimizer: Pivotal Optimizer (GPORCA)
+ Settings:  optimizer=on
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.42.0
+(14 rows)
 
 select * from A where not exists (select sum(C.i) from C where C.i = A.i limit 1 offset 0);
  i | j 
@@ -1352,18 +1351,19 @@ explain select C.j from C where not exists (select max(B.i) from B  where C.i = 
    ->  Sort  (cost=0.00..862.00 rows=2 width=4)
          Sort Key: c.j
          ->  Hash Anti Join  (cost=0.00..862.00 rows=2 width=4)
-               Hash Cond: (c.i = b.i)
+               Hash Cond: c.i = b.i
                ->  Seq Scan on c  (cost=0.00..431.00 rows=3 width=8)
                ->  Hash  (cost=431.00..431.00 rows=1 width=4)
                      ->  Result  (cost=0.00..431.00 rows=1 width=4)
-                           Filter: (NOT ((max(b.i)) IS NULL))
+                           Filter: NOT (max(b.i)) IS NULL
                            ->  GroupAggregate  (cost=0.00..431.00 rows=2 width=8)
-                                 Group Key: b.i
+                                 Group By: b.i
                                  ->  Sort  (cost=0.00..431.00 rows=2 width=4)
                                        Sort Key: b.i
                                        ->  Seq Scan on b  (cost=0.00..431.00 rows=2 width=4)
- Optimizer: Pivotal Optimizer (GPORCA)
-(16 rows)
+ Settings:  optimizer=on
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.34.0
+(17 rows)
 
 select C.j from C where not exists (select max(B.i) from B  where C.i = B.i having max(B.i) is not null) order by C.j;
  j  
@@ -1383,17 +1383,18 @@ explain select C.j from C where not exists (select max(B.i) from B  where C.i = 
          ->  Sort  (cost=0.00..1324036.36 rows=3 width=4)
                Sort Key: c.j
                ->  Seq Scan on c  (cost=0.00..1324036.36 rows=3 width=4)
-                     Filter: (SubPlan 1)
+                     Filter: (subplan)
                      SubPlan 1
                        ->  Limit  (cost=0.00..431.00 rows=1 width=4)
                              ->  Aggregate  (cost=0.00..431.00 rows=1 width=4)
                                    ->  Result  (cost=0.00..431.00 rows=1 width=4)
-                                         Filter: (c.i = b.i)
+                                         Filter: $0 = b.i
                                          ->  Materialize  (cost=0.00..431.00 rows=6 width=4)
                                                ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=6 width=4)
                                                      ->  Seq Scan on b  (cost=0.00..431.00 rows=2 width=4)
- Optimizer: Pivotal Optimizer (GPORCA)
-(16 rows)
+ Settings:  optimizer=on
+ Optimizer status: Pivotal Optimizer (GPORCA) version 2.34.0
+(17 rows)
 
 select C.j from C where not exists (select max(B.i) from B  where C.i = B.i offset 1000) order by C.j;
   j  
@@ -1446,11 +1447,11 @@ explain select * from A where not exists (select sum(C.i) from C where C.i = A.i
 ------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=2 width=8)
    ->  Hash Anti Join  (cost=0.00..862.00 rows=1 width=8)
-         Hash Cond: (a.i = c.i)
+         Hash Cond: a.i = c.i
          ->  Seq Scan on a  (cost=0.00..431.00 rows=2 width=8)
          ->  Hash  (cost=431.00..431.00 rows=3 width=4)
                ->  GroupAggregate  (cost=0.00..431.00 rows=3 width=4)
-                     Group Key: c.i
+                     Group By: c.i
                      ->  Sort  (cost=0.00..431.00 rows=3 width=4)
                            Sort Key: c.i
                            ->  Seq Scan on c  (cost=0.00..431.00 rows=3 width=4)
@@ -1468,11 +1469,11 @@ explain select A.i from A where not exists (select B.i from B where B.i in (sele
 ---------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1293.00 rows=2 width=4)
    ->  Hash Anti Join  (cost=0.00..1293.00 rows=1 width=4)
-         Hash Cond: (a.i = b.i)
+         Hash Cond: a.i = b.i
          ->  Seq Scan on a  (cost=0.00..431.00 rows=2 width=4)
          ->  Hash  (cost=862.00..862.00 rows=2 width=4)
                ->  Hash Semi Join  (cost=0.00..862.00 rows=2 width=4)
-                     Hash Cond: (b.i = c.i)
+                     Hash Cond: b.i = c.i
                      ->  Seq Scan on b  (cost=0.00..431.00 rows=2 width=4)
                      ->  Hash  (cost=431.00..431.00 rows=3 width=4)
                            ->  Seq Scan on c  (cost=0.00..431.00 rows=3 width=4)
@@ -1493,13 +1494,13 @@ explain select * from B where not exists (select * from C,A where C.i in (select
 ---------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1324895.10 rows=1 width=8)
    ->  Hash Anti Join  (cost=0.00..1324895.10 rows=1 width=8)
-         Hash Cond: (b.i = c.i)
+         Hash Cond: b.i = c.i
          ->  Seq Scan on b  (cost=0.00..431.00 rows=2 width=8)
-         ->  Hash  (cost=1324464.10..1324464.10 rows=3 width=4)
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..1324464.10 rows=3 width=4)
+         ->  Hash  (cost=1324464.10..1324464.10 rows=13 width=4)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..1324464.10 rows=13 width=4)
                      Hash Key: c.i
-                     ->  Hash Semi Join  (cost=0.00..1324464.10 rows=3 width=4)
-                           Hash Cond: ((a.i = c_1.i) AND (c.i = c_1.i))
+                     ->  Hash Semi Join  (cost=0.00..1324464.10 rows=13 width=4)
+                           Hash Cond: a.i = c_1.i AND c.i = c_1.i
                            ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..1324033.09 rows=15 width=8)
                                  Hash Key: a.i
                                  ->  Nested Loop  (cost=0.00..1324033.09 rows=15 width=8)
@@ -1509,8 +1510,8 @@ explain select * from B where not exists (select * from C,A where C.i in (select
                                        ->  Seq Scan on c  (cost=0.00..431.00 rows=3 width=4)
                            ->  Hash  (cost=431.00..431.00 rows=3 width=4)
                                  ->  Seq Scan on c c_1  (cost=0.00..431.00 rows=3 width=4)
-                                       Filter: (i <> 10)
- Optimizer: Pivotal Optimizer (GPORCA)
+                                       Filter: i <> 10
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (20 rows)
 
 select * from B where not exists (select * from C,A where C.i in (select C.i from C where C.i = A.i and C.i != 10) AND B.i = C.i);
@@ -1527,7 +1528,7 @@ explain select * from A where A.i in (select C.j from C,B where B.i in (select i
 ---------------------------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1324895.30 rows=5 width=8)
    ->  Hash Join  (cost=0.00..1324895.30 rows=2 width=8)
-         Hash Cond: (a.i = c.j)
+         Hash Cond: a.i = c.j
          ->  Seq Scan on a  (cost=0.00..431.00 rows=2 width=8)
          ->  Hash  (cost=1324464.30..1324464.30 rows=3 width=4)
                ->  GroupAggregate  (cost=0.00..1324464.30 rows=3 width=4)
@@ -1541,7 +1542,7 @@ explain select * from A where A.i in (select C.j from C,B where B.i in (select i
                                        ->  Sort  (cost=0.00..1324464.30 rows=18 width=4)
                                              Sort Key: c.j
                                              ->  Hash Semi Join  (cost=0.00..1324464.30 rows=18 width=4)
-                                                   Hash Cond: (b.i = c_1.i)
+                                                   Hash Cond: b.i = c_1.i
                                                    ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..1324033.29 rows=18 width=8)
                                                          Hash Key: b.i
                                                          ->  Nested Loop  (cost=0.00..1324033.29 rows=18 width=8)
@@ -1566,7 +1567,7 @@ explain select * from A where not exists (select sum(c.i) from C where C.i = A.i
 ---------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=2 width=8)
    ->  Hash Anti Join  (cost=0.00..862.00 rows=1 width=8)
-         Hash Cond: (a.i = c.i)
+         Hash Cond: a.i = c.i
          ->  Seq Scan on a  (cost=0.00..431.00 rows=2 width=8)
          ->  Hash  (cost=431.00..431.00 rows=2 width=4)
                ->  GroupAggregate  (cost=0.00..431.00 rows=2 width=4)
@@ -1574,8 +1575,8 @@ explain select * from A where not exists (select sum(c.i) from C where C.i = A.i
                      ->  Sort  (cost=0.00..431.00 rows=2 width=4)
                            Sort Key: c.i
                            ->  Seq Scan on c  (cost=0.00..431.00 rows=2 width=4)
-                                 Filter: (i > 3)
- Optimizer: Pivotal Optimizer (GPORCA)
+                                 Filter: i > 3
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.55.13
 (12 rows)
 
 select * from A where not exists (select sum(c.i) from C where C.i = A.i group by C.i having c.i > 3);
@@ -3770,13 +3771,13 @@ EXPLAIN SELECT * FROM qp_non_eq_a, qp_non_eq_b WHERE qp_non_eq_a.f = qp_non_eq_b
 ----------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=2 width=24)
    ->  Hash Join  (cost=0.00..862.00 rows=1 width=24)
-         Hash Cond: (qp_non_eq_b.f = qp_non_eq_a.f)
+         Hash Cond: qp_non_eq_b.f = qp_non_eq_a.f
          ->  Seq Scan on qp_non_eq_b  (cost=0.00..431.00 rows=1 width=12)
          ->  Hash  (cost=431.00..431.00 rows=1 width=12)
                ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
                      ->  Seq Scan on qp_non_eq_a  (cost=0.00..431.00 rows=1 width=12)
-                           Filter: ((f)::text <> '-0'::text)
- Optimizer: Pivotal Optimizer (GPORCA)
+                           Filter: f::text <> '-0'::text
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.72.0
 (9 rows)
 
 SELECT * FROM qp_non_eq_a, qp_non_eq_b WHERE qp_non_eq_a.f = qp_non_eq_b.f AND qp_non_eq_a.f::text <> '-0';
@@ -3791,13 +3792,13 @@ EXPLAIN SELECT * FROM qp_non_eq_a INNER JOIN qp_non_eq_b ON qp_non_eq_a.f = qp_n
 -------------------------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=2 width=24)
    ->  Hash Join  (cost=0.00..862.00 rows=1 width=24)
-         Hash Cond: (qp_non_eq_a.f = qp_non_eq_b.f)
+         Hash Cond: qp_non_eq_a.f = qp_non_eq_b.f
          ->  Seq Scan on qp_non_eq_a  (cost=0.00..431.00 rows=1 width=12)
          ->  Hash  (cost=431.00..431.00 rows=1 width=12)
                ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
                      ->  Seq Scan on qp_non_eq_b  (cost=0.00..431.00 rows=1 width=12)
-                           Filter: (CASE WHEN ((f)::text = '-0'::text) THEN '1'::double precision ELSE '-1'::double precision END < '0'::double precision)
- Optimizer: Pivotal Optimizer (GPORCA)
+                           Filter: CASE WHEN f::text = '-0'::text THEN 1::double precision ELSE (-1)::double precision END < 0::double precision
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.72.0
 (9 rows)
 
 SELECT * FROM qp_non_eq_a INNER JOIN qp_non_eq_b ON qp_non_eq_a.f = qp_non_eq_b.f AND CASE WHEN qp_non_eq_b.f::text = '-0' THEN 1 ELSE -1::float8 END < '0';
@@ -3812,13 +3813,13 @@ EXPLAIN SELECT * FROM qp_non_eq_a, qp_non_eq_b WHERE qp_non_eq_a.i = qp_non_eq_b
 --------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=2 width=24)
    ->  Hash Join  (cost=0.00..862.00 rows=1 width=24)
-         Hash Cond: (qp_non_eq_a.i = qp_non_eq_b.i)
+         Hash Cond: qp_non_eq_a.i = qp_non_eq_b.i
          ->  Seq Scan on qp_non_eq_a  (cost=0.00..431.00 rows=1 width=12)
-               Filter: ((i = ANY ('{1,2,3}'::integer[])) AND (i = ANY ('{1,2,3}'::integer[])))
+               Filter: (i = ANY ('{1,2,3}'::integer[])) AND (i = 1 OR i = 2 OR i = 3)
          ->  Hash  (cost=431.00..431.00 rows=1 width=12)
                ->  Seq Scan on qp_non_eq_b  (cost=0.00..431.00 rows=1 width=12)
-                     Filter: (i = ANY ('{1,2,3}'::integer[]))
- Optimizer: Pivotal Optimizer (GPORCA)
+                     Filter: i = 1 OR i = 2 OR i = 3
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.72.0
 (9 rows)
 
 SELECT * FROM qp_non_eq_a, qp_non_eq_b WHERE qp_non_eq_a.i = qp_non_eq_b.i AND qp_non_eq_a.i = ANY('{1,2,3}'::integer[]);
@@ -3832,12 +3833,12 @@ EXPLAIN SELECT * FROM qp_non_eq_a, qp_non_eq_b WHERE qp_non_eq_a.i = qp_non_eq_b
 --------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=24)
    ->  Hash Join  (cost=0.00..862.00 rows=1 width=24)
-         Hash Cond: (qp_non_eq_a.i = qp_non_eq_b.i)
+         Hash Cond: qp_non_eq_a.i = qp_non_eq_b.i
          ->  Seq Scan on qp_non_eq_a  (cost=0.00..431.00 rows=1 width=12)
-               Filter: ((i)::numeric = ANY ('{1,2,3}'::numeric[]))
+               Filter: i::numeric = ANY ('{1,2,3}'::numeric[])
          ->  Hash  (cost=431.00..431.00 rows=1 width=12)
                ->  Seq Scan on qp_non_eq_b  (cost=0.00..431.00 rows=1 width=12)
- Optimizer: Pivotal Optimizer (GPORCA)
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.72.0
 (8 rows)
 
 SELECT * FROM qp_non_eq_a, qp_non_eq_b WHERE qp_non_eq_a.i = qp_non_eq_b.i AND qp_non_eq_a.i = ANY('{1,2,3}'::numeric[]);

--- a/src/test/regress/expected/qp_misc_jiras_optimizer.out
+++ b/src/test/regress/expected/qp_misc_jiras_optimizer.out
@@ -4225,89 +4225,81 @@ reset gp_enable_agg_distinct;
 reset gp_enable_agg_distinct_pruning;
 -- both queries should use hashagg
 explain select count(distinct j) from (select t1.* from qp_misc_jiras.tbl5994_test t1, qp_misc_jiras.tbl5994_test t2 where t1.j = t2.j) tmp group by j;
-                                                         QUERY PLAN                                                          
------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
-   ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=8)
-         Group Key: tbl5994_test.j
-         ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=4)
-               Group Key: tbl5994_test.j
-               ->  Sort  (cost=0.00..862.00 rows=1 width=4)
-                     Sort Key: tbl5994_test.j
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
-                           Hash Key: tbl5994_test.j
-                           ->  Hash Join  (cost=0.00..862.00 rows=1 width=4)
-                                 Hash Cond: (tbl5994_test.j = tbl5994_test_1.j)
-                                 ->  Seq Scan on tbl5994_test  (cost=0.00..431.00 rows=1 width=4)
-                                 ->  Hash  (cost=431.00..431.00 rows=1 width=4)
-                                       ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
-                                             ->  Seq Scan on tbl5994_test tbl5994_test_1  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: Pivotal Optimizer (GPORCA)
-(16 rows)
-
-explain select count(distinct j) from (select t1.* from qp_misc_jiras.tbl5994_test t1, qp_misc_jiras.tbl5994_test t2 where t1.i = t2.i) tmp group by j;
                                                       QUERY PLAN                                                       
 -----------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
    ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=8)
          Group Key: tbl5994_test.j
-         ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=4)
-               Group Key: tbl5994_test.j
-               ->  Sort  (cost=0.00..862.00 rows=1 width=4)
-                     Sort Key: tbl5994_test.j
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
-                           Hash Key: tbl5994_test.j
-                           ->  Hash Join  (cost=0.00..862.00 rows=1 width=4)
-                                 Hash Cond: (tbl5994_test.i = tbl5994_test_1.i)
-                                 ->  Seq Scan on tbl5994_test  (cost=0.00..431.00 rows=1 width=8)
-                                 ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+         ->  Sort  (cost=0.00..862.00 rows=1 width=4)
+               Sort Key: tbl5994_test.j
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
+                     Hash Key: tbl5994_test.j
+                     ->  Hash Join  (cost=0.00..862.00 rows=1 width=4)
+                           Hash Cond: (tbl5994_test.j = tbl5994_test_1.j)
+                           ->  Seq Scan on tbl5994_test  (cost=0.00..431.00 rows=1 width=4)
+                           ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+                                 ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
                                        ->  Seq Scan on tbl5994_test tbl5994_test_1  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: Pivotal Optimizer (GPORCA)
-(15 rows)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(14 rows)
+
+explain select count(distinct j) from (select t1.* from qp_misc_jiras.tbl5994_test t1, qp_misc_jiras.tbl5994_test t2 where t1.i = t2.i) tmp group by j;
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
+   ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=8)
+         Group Key: tbl5994_test.j
+         ->  Sort  (cost=0.00..862.00 rows=1 width=4)
+               Sort Key: tbl5994_test.j
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
+                     Hash Key: tbl5994_test.j
+                     ->  Hash Join  (cost=0.00..862.00 rows=1 width=4)
+                           Hash Cond: (tbl5994_test.i = tbl5994_test_1.i)
+                           ->  Seq Scan on tbl5994_test  (cost=0.00..431.00 rows=1 width=8)
+                           ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+                                 ->  Seq Scan on tbl5994_test tbl5994_test_1  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(13 rows)
 
 -- Try same two queries, with group agg.
 set enable_groupagg=on;
 set enable_hashagg=off;
 explain select count(distinct j) from (select t1.* from qp_misc_jiras.tbl5994_test t1, qp_misc_jiras.tbl5994_test t2 where t1.j = t2.j) tmp group by j;
-                                                         QUERY PLAN                                                          
------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
-   ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=8)
-         Group Key: tbl5994_test.j
-         ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=4)
-               Group Key: tbl5994_test.j
-               ->  Sort  (cost=0.00..862.00 rows=1 width=4)
-                     Sort Key: tbl5994_test.j
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
-                           Hash Key: tbl5994_test.j
-                           ->  Hash Join  (cost=0.00..862.00 rows=1 width=4)
-                                 Hash Cond: (tbl5994_test.j = tbl5994_test_1.j)
-                                 ->  Seq Scan on tbl5994_test  (cost=0.00..431.00 rows=1 width=4)
-                                 ->  Hash  (cost=431.00..431.00 rows=1 width=4)
-                                       ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
-                                             ->  Seq Scan on tbl5994_test tbl5994_test_1  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: Pivotal Optimizer (GPORCA)
-(16 rows)
-
-explain select count(distinct j) from (select t1.* from qp_misc_jiras.tbl5994_test t1, qp_misc_jiras.tbl5994_test t2 where t1.i = t2.i) tmp group by j;
                                                       QUERY PLAN                                                       
 -----------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
    ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=8)
          Group Key: tbl5994_test.j
-         ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=4)
-               Group Key: tbl5994_test.j
-               ->  Sort  (cost=0.00..862.00 rows=1 width=4)
-                     Sort Key: tbl5994_test.j
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
-                           Hash Key: tbl5994_test.j
-                           ->  Hash Join  (cost=0.00..862.00 rows=1 width=4)
-                                 Hash Cond: (tbl5994_test.i = tbl5994_test_1.i)
-                                 ->  Seq Scan on tbl5994_test  (cost=0.00..431.00 rows=1 width=8)
-                                 ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+         ->  Sort  (cost=0.00..862.00 rows=1 width=4)
+               Sort Key: tbl5994_test.j
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
+                     Hash Key: tbl5994_test.j
+                     ->  Hash Join  (cost=0.00..862.00 rows=1 width=4)
+                           Hash Cond: (tbl5994_test.j = tbl5994_test_1.j)
+                           ->  Seq Scan on tbl5994_test  (cost=0.00..431.00 rows=1 width=4)
+                           ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+                                 ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
                                        ->  Seq Scan on tbl5994_test tbl5994_test_1  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: Pivotal Optimizer (GPORCA)
-(15 rows)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(14 rows)
+
+explain select count(distinct j) from (select t1.* from qp_misc_jiras.tbl5994_test t1, qp_misc_jiras.tbl5994_test t2 where t1.i = t2.i) tmp group by j;
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
+   ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=8)
+         Group Key: tbl5994_test.j
+         ->  Sort  (cost=0.00..862.00 rows=1 width=4)
+               Sort Key: tbl5994_test.j
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
+                     Hash Key: tbl5994_test.j
+                     ->  Hash Join  (cost=0.00..862.00 rows=1 width=4)
+                           Hash Cond: (tbl5994_test.i = tbl5994_test_1.i)
+                           ->  Seq Scan on tbl5994_test  (cost=0.00..431.00 rows=1 width=8)
+                           ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+                                 ->  Seq Scan on tbl5994_test tbl5994_test_1  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(13 rows)
 
 reset enable_groupagg;
 reset enable_hashagg;
@@ -4717,15 +4709,11 @@ else 'Unidentify' end
          Group Key: (CASE WHEN (ir_call_supplementary_svc_code = ANY ('{S20,S21}'::bpchar[])) THEN 'MO'::text ELSE 'foo'::text END), (CASE WHEN ((ir_call_type_group_code)::text = ANY ('{H,VH,PCB}'::text[])) THEN 'Thailland'::text ELSE 'Unidentify'::text END)
          ->  Sort  (cost=0.00..431.00 rows=1 width=16)
                Sort Key: (CASE WHEN (ir_call_supplementary_svc_code = ANY ('{S20,S21}'::bpchar[])) THEN 'MO'::text ELSE 'foo'::text END), (CASE WHEN ((ir_call_type_group_code)::text = ANY ('{H,VH,PCB}'::text[])) THEN 'Thailland'::text ELSE 'Unidentify'::text END)
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=16)
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=16)
                      Hash Key: (CASE WHEN (ir_call_supplementary_svc_code = ANY ('{S20,S21}'::bpchar[])) THEN 'MO'::text ELSE 'foo'::text END), (CASE WHEN ((ir_call_type_group_code)::text = ANY ('{H,VH,PCB}'::text[])) THEN 'Thailland'::text ELSE 'Unidentify'::text END)
-                     ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=16)
-                           Group Key: (CASE WHEN (ir_call_supplementary_svc_code = ANY ('{S20,S21}'::bpchar[])) THEN 'MO'::text ELSE 'foo'::text END), (CASE WHEN ((ir_call_type_group_code)::text = ANY ('{H,VH,PCB}'::text[])) THEN 'Thailland'::text ELSE 'Unidentify'::text END)
-                           ->  Sort  (cost=0.00..431.00 rows=1 width=16)
-                                 Sort Key: (CASE WHEN (ir_call_supplementary_svc_code = ANY ('{S20,S21}'::bpchar[])) THEN 'MO'::text ELSE 'foo'::text END), (CASE WHEN ((ir_call_type_group_code)::text = ANY ('{H,VH,PCB}'::text[])) THEN 'Thailland'::text ELSE 'Unidentify'::text END)
-                                 ->  Seq Scan on ir_voice_sms_and_data  (cost=0.00..431.00 rows=1 width=16)
- Optimizer: Pivotal Optimizer (GPORCA)
-(13 rows)
+                     ->  Seq Scan on ir_voice_sms_and_data  (cost=0.00..431.00 rows=1 width=16)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(9 rows)
 
 DROP TABLE qp_misc_jiras.ir_voice_sms_and_data;
 reset gp_motion_cost_per_row;
@@ -4961,18 +4949,15 @@ select  * from qp_misc_jiras.test_co where ctid='(33554432,2)' and gp_segment_id
 set gp_enable_explain_allstat=on;
 insert into qp_misc_jiras.test_heap select i, i from generate_series(0, 99999) i;
 explain analyze select count(*) from qp_misc_jiras.test_heap;
-                                                                      QUERY PLAN                                                                       
--------------------------------------------------------------------------------------------------------------------------------------------------------
- Finalize Aggregate  (cost=0.00..431.00 rows=1 width=8) (actual time=12.631..12.631 rows=1 loops=1)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8) (actual time=11.165..12.618 rows=3 loops=1)
-         ->  Partial Aggregate  (cost=0.00..431.00 rows=1 width=8) (actual time=11.309..11.309 rows=1 loops=1)
-               allstat: seg_firststart_total_ntuples/seg0_0.616 ms_11 ms_1/seg1_0.566 ms_12 ms_1/seg2_0.573 ms_11 ms_1//end
-               ->  Seq Scan on test_heap  (cost=0.00..431.00 rows=1 width=1) (actual time=0.177..7.124 rows=33462 loops=1)
-                     allstat: seg_firststart_total_ntuples/seg0_0.616 ms_7.124 ms_33462/seg1_0.566 ms_7.874 ms_33329/seg2_0.573 ms_6.812 ms_33210//end
- Optimizer: Pivotal Optimizer (GPORCA)
- Planning Time: 4.655 ms
-   (slice0)    Executor memory: 39K bytes.
-   (slice1)    Executor memory: 37K bytes avg x 3 workers, 37K bytes max (seg0).
+                                                                   QUERY PLAN                                                                    
+-------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..431.00 rows=1 width=8) (actual time=55.789..55.790 rows=1 loops=1)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=1) (actual time=2.020..42.516 rows=100001 loops=1)
+         ->  Seq Scan on test_heap  (cost=0.00..431.00 rows=1 width=1) (actual time=0.075..9.629 rows=33462 loops=1)
+               allstat: seg_firststart_total_ntuples/seg0_0.564 ms_9.629 ms_33462/seg1_0.542 ms_8.289 ms_33329/seg2_0.544 ms_9.122 ms_33210//end
+ Planning Time: 16.477 ms
+   (slice0)    Executor memory: 111K bytes.
+   (slice1)    Executor memory: 36K bytes avg x 3 workers, 36K bytes max (seg0).
  Memory used:  128000kB
  Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
  Execution time: 16.835 ms
@@ -5014,31 +4999,32 @@ explain select * from qp_misc_jiras.r;
 (4 rows)
 
 explain analyze select * from qp_misc_jiras.r,qp_misc_jiras.s where r.a=s.b;
-                                                                      QUERY PLAN                                                                      
-------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.26 rows=1000 width=16) (actual time=30.021..31.766 rows=1000 loops=1)
-   ->  Hash Join  (cost=0.00..862.20 rows=334 width=16) (actual time=29.310..31.236 rows=340 loops=1)
+                                                                     QUERY PLAN                                                                     
+----------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.26 rows=1000 width=16) (actual time=2.877..3.466 rows=1000 loops=1)
+   ->  Hash Join  (cost=0.00..862.20 rows=334 width=16) (actual time=1.944..2.717 rows=340 loops=1)
          Hash Cond: (r.a = s.b)
-         Extra Text: (seg2)   Hash chain length 1.0 avg, 1 max, using 340 of 524288 buckets.
-         allstat: seg_firststart_total_ntuples/seg0_24 ms_31 ms_338/seg1_24 ms_31 ms_322/seg2_24 ms_31 ms_340//end
-         ->  Seq Scan on r  (cost=0.00..431.01 rows=334 width=8) (actual time=4.611..4.661 rows=340 loops=1)
-               allstat: seg_firststart_total_ntuples/seg0_49 ms_4.869 ms_338/seg1_49 ms_4.874 ms_322/seg2_49 ms_4.661 ms_340//end
-         ->  Hash  (cost=431.02..431.02 rows=334 width=8) (actual time=24.278..24.278 rows=340 loops=1)
+         allstat: seg_firststart_total_ntuples/seg0_10 ms_2.565 ms_338/seg1_10 ms_2.644 ms_322/seg2_10 ms_2.717 ms_340//end
+         ->  Seq Scan on r  (cost=0.00..431.01 rows=334 width=8) (actual time=0.047..0.129 rows=340 loops=1)
+               allstat: seg_firststart_total_ntuples/seg0_12 ms_0.124 ms_338/seg1_12 ms_0.133 ms_322/seg2_12 ms_0.129 ms_340//end
+         ->  Hash  (cost=431.02..431.02 rows=334 width=8) (actual time=1.527..1.528 rows=340 loops=1)
                Buckets: 524288  Batches: 1  Memory Usage: 4110kB
-               allstat: seg_firststart_total_ntuples/seg0_26 ms_23 ms_338/seg1_26 ms_23 ms_322/seg2_25 ms_24 ms_340//end
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.02 rows=334 width=8) (actual time=24.130..24.183 rows=340 loops=1)
+               allstat: seg_firststart_total_ntuples/seg0_11 ms_1.561 ms_338/seg1_11 ms_1.614 ms_322/seg2_11 ms_1.528 ms_340//end
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.02 rows=334 width=8) (actual time=1.300..1.387 rows=340 loops=1)
                      Hash Key: s.b
-                     allstat: seg_firststart_total_ntuples/seg0_26 ms_23 ms_338/seg1_26 ms_23 ms_322/seg2_25 ms_24 ms_340//end
-                     ->  Seq Scan on s  (cost=0.00..431.01 rows=334 width=8) (actual time=13.746..13.791 rows=340 loops=1)
-                           allstat: seg_firststart_total_ntuples/seg0_28 ms_6.694 ms_338/seg1_28 ms_6.607 ms_322/seg2_35 ms_14 ms_340//end
- Optimizer: Pivotal Optimizer (GPORCA)
- Planning Time: 107.557 ms
-   (slice0)    Executor memory: 46K bytes.
-   (slice1)    Executor memory: 4164K bytes avg x 3 workers, 4164K bytes max (seg2).  Work_mem: 4110K bytes max.
-   (slice2)    Executor memory: 37K bytes avg x 3 workers, 37K bytes max (seg0).
- Memory used:  128000kB
- Execution Time: 56.696 ms
-(22 rows)
+                     allstat: seg_firststart_total_ntuples/seg0_61 ms_0.076 ms_321/seg1_60 ms_0.081 ms_342/seg2_61 ms_0.117 ms_337//end
+                     ->  Seq Scan on s  (cost=0.00..431.01 rows=334 width=8)
+                           allstat: seg_firststart_total_ntuples/seg0_2.222 ms_2.232 ms_321/seg1_2.265 ms_2.069 ms_342/seg2_2.286 ms_1.974 ms_337//end
+ Slice statistics:
+   (slice0)    Executor memory: 267K bytes.
+   (slice1)    Executor memory: 193K bytes avg x 3 workers, 193K bytes max (seg0).
+   (slice2)    Executor memory: 131378K bytes avg x 3 workers, 131399K bytes max (seg1).  Work_mem: 11K bytes max.
+ Statement statistics:
+   Memory used: 1945600K bytes
+ Settings:  enable_bitmapscan=off; enable_groupagg=on; enable_indexscan=on; enable_seqscan=off; optimizer=on; optimizer_segments=3
+ Optimizer status: Pivotal Optimizer (GPORCA) version 1.624
+ Total runtime: 87.064 ms
+(31 rows)
 
 drop table qp_misc_jiras.r;
 drop table qp_misc_jiras.s;
@@ -5571,17 +5557,16 @@ insert into tbl_z select i from generate_series(1,100) i;
 explain select 1 as t1 where 1 <= ALL (select x from tbl_z);
                                                                                                                                                        QUERY PLAN                                                                                                                                                        
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Nested Loop  (cost=0.00..882688.14 rows=1 width=1)
+ Nested Loop  (cost=0.00..882688.11 rows=1 width=1)
    Join Filter: true
    ->  Result  (cost=0.00..431.00 rows=1 width=1)
          Filter: ((CASE WHEN (sum((CASE WHEN (1 > x) THEN 1 ELSE 0 END)) IS NULL) THEN true WHEN (sum((CASE WHEN (x IS NULL) THEN 1 ELSE 0 END)) > '0'::bigint) THEN NULL::boolean WHEN (1 IS NULL) THEN NULL::boolean WHEN (sum((CASE WHEN (1 > x) THEN 1 ELSE 0 END)) = '0'::bigint) THEN true ELSE false END) = true)
-         ->  Finalize Aggregate  (cost=0.00..431.00 rows=1 width=16)
-               ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=16)
-                     ->  Partial Aggregate  (cost=0.00..431.00 rows=1 width=16)
-                           ->  Seq Scan on tbl_z  (cost=0.00..431.00 rows=1 width=4)
+         ->  Aggregate  (cost=0.00..431.00 rows=1 width=16)
+               ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                     ->  Seq Scan on tbl_z  (cost=0.00..431.00 rows=1 width=4)
    ->  Result  (cost=0.00..0.00 rows=1 width=1)
  Optimizer: Pivotal Optimizer (GPORCA)
-(10 rows)
+(9 rows)
 
 set gp_enable_relsize_collection = on;
 -- plan with relsize collection

--- a/src/test/regress/expected/qp_targeted_dispatch_optimizer.out
+++ b/src/test/regress/expected/qp_targeted_dispatch_optimizer.out
@@ -498,14 +498,13 @@ INFO:  (slice 1) Dispatch command to SINGLE content
 explain select count(*) from mpp7638 where a =1;
                                      QUERY PLAN                                     
 ------------------------------------------------------------------------------------
- Finalize Aggregate  (cost=0.00..431.00 rows=1 width=8)
-   ->  Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..431.00 rows=1 width=8)
-         ->  Partial Aggregate  (cost=0.00..431.00 rows=1 width=8)
-               ->  Dynamic Seq Scan on mpp7638  (cost=0.00..431.00 rows=1 width=4)
-                     Number of partitions to scan: 9 
-                     Filter: (a = 1)
+ Aggregate  (cost=0.00..431.00 rows=1 width=8)
+   ->  Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..431.00 rows=1 width=1)
+         ->  Dynamic Seq Scan on mpp7638  (cost=0.00..431.00 rows=1 width=4)
+               Number of partitions to scan: 9 
+               Filter: (a = 1)
  Optimizer: Pivotal Optimizer (GPORCA)
-(7 rows)
+(6 rows)
 
 alter table mpp7638 set distributed by (a, b, c);
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
@@ -666,11 +665,12 @@ INFO:  (slice 1) Dispatch command to SINGLE content
 explain select * from (select * from mpp7620 where key=200) ss where key =200; 
                                   QUERY PLAN                                   
 -------------------------------------------------------------------------------
- Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..431.00 rows=1 width=54)
-   ->  Seq Scan on mpp7620  (cost=0.00..431.00 rows=1 width=54)
-         Filter: (key = 200)
- Optimizer: Pivotal Optimizer (GPORCA)
-(4 rows)
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..431.00 rows=1 width=10)
+   ->  Seq Scan on mpp7620  (cost=0.00..431.00 rows=1 width=10)
+         Filter: key = 200
+ Settings:  optimizer=on
+ Optimizer status: Pivotal Optimizer (GPORCA) version 1.624
+(5 rows)
 
 explain insert into zoompp7620(key) select key from mpp7620 where mpp7620.key=200;
                                            QUERY PLAN                                           
@@ -688,9 +688,10 @@ explain select key from mpp7620 where mpp7620.key=200;
 ------------------------------------------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..431.00 rows=1 width=4)
    ->  Seq Scan on mpp7620  (cost=0.00..431.00 rows=1 width=4)
-         Filter: (key = 200)
- Optimizer: Pivotal Optimizer (GPORCA)
-(4 rows)
+         Filter: key = 200
+ Settings:  optimizer=on
+ Optimizer status: Pivotal Optimizer (GPORCA) version 1.624
+(5 rows)
 
 reset test_print_direct_dispatch_info;
 -- ----------------------------------------------------------------------
@@ -726,26 +727,26 @@ explain select * from table_a where a0=3;
 -------------------------------------------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..431.00 rows=1 width=16)
    ->  Seq Scan on table_a  (cost=0.00..431.00 rows=1 width=16)
-         Filter: (a0 = 3)
- Optimizer: Pivotal Optimizer (GPORCA)
-(4 rows)
+         Filter: a0 = 3
+ Settings:  optimizer=on
+ Optimizer status: Pivotal Optimizer (GPORCA) version 1.624
+(5 rows)
 
 explain select a0 from table_a where a0 in (select max(a1) from table_a);
                                               QUERY PLAN                                              
 ------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
    ->  Hash Join  (cost=0.00..862.00 rows=1 width=4)
          Hash Cond: ((max(table_a.a1)) = table_a_1.a0)
          ->  Redistribute Motion 1:3  (slice2)  (cost=0.00..431.00 rows=1 width=4)
                Hash Key: (max(table_a.a1))
-               ->  Finalize Aggregate  (cost=0.00..431.00 rows=1 width=4)
-                     ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
-                           ->  Partial Aggregate  (cost=0.00..431.00 rows=1 width=4)
-                                 ->  Seq Scan on table_a  (cost=0.00..431.00 rows=1 width=4)
+               ->  Aggregate  (cost=0.00..431.00 rows=1 width=4)
+                     ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                           ->  Seq Scan on table_a  (cost=0.00..431.00 rows=1 width=4)
          ->  Hash  (cost=431.00..431.00 rows=1 width=4)
                ->  Seq Scan on table_a table_a_1  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: Pivotal Optimizer (GPORCA)
-(12 rows)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
+(11 rows)
 
 select a0 from table_a where a0 in (select max(a1) from table_a);
 INFO:  (slice 3) Dispatch command to ALL contents: 0 1 2
@@ -772,20 +773,19 @@ INFO:  (slice 1) Dispatch command to SINGLE content
 explain select a0 from table_a where a0 in (select max(a1) from table_a where a0=1);
                                               QUERY PLAN                                              
 ------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
    ->  Hash Join  (cost=0.00..862.00 rows=1 width=4)
          Hash Cond: ((max(table_a.a1)) = table_a_1.a0)
          ->  Redistribute Motion 1:3  (slice2)  (cost=0.00..431.00 rows=1 width=4)
                Hash Key: (max(table_a.a1))
-               ->  Finalize Aggregate  (cost=0.00..431.00 rows=1 width=4)
-                     ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
-                           ->  Partial Aggregate  (cost=0.00..431.00 rows=1 width=4)
-                                 ->  Seq Scan on table_a  (cost=0.00..431.00 rows=1 width=4)
-                                       Filter: (a0 = 1)
+               ->  Aggregate  (cost=0.00..431.00 rows=1 width=4)
+                     ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                           ->  Seq Scan on table_a  (cost=0.00..431.00 rows=1 width=4)
+                                 Filter: (a0 = 1)
          ->  Hash  (cost=431.00..431.00 rows=1 width=4)
                ->  Seq Scan on table_a table_a_1  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: Pivotal Optimizer (GPORCA)
-(13 rows)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
+(12 rows)
 
 reset test_print_direct_dispatch_info;
 -- the filter is over a window, do not direct dispatch

--- a/src/test/regress/expected/rpt_optimizer.out
+++ b/src/test/regress/expected/rpt_optimizer.out
@@ -933,19 +933,15 @@ explain (costs off) select * from t_hashdist cross join (select random() as k, s
          Join Filter: true
          ->  Broadcast Motion 3:3  (slice3; segments: 3)
                ->  Seq Scan on t_hashdist
-         ->  Finalize GroupAggregate
+         ->  GroupAggregate
                Group Key: (random())
                ->  Sort
                      Sort Key: (random())
                      ->  Redistribute Motion 1:3  (slice2; segments: 1)
                            Hash Key: (random())
-                           ->  Partial GroupAggregate
-                                 Group Key: (random())
-                                 ->  Sort
-                                       Sort Key: (random())
-                                       ->  Seq Scan on t_replicate_volatile
+                           ->  Seq Scan on t_replicate_volatile
  Optimizer: Pivotal Optimizer (GPORCA)
-(17 rows)
+(13 rows)
 
 explain (costs off) select * from t_hashdist cross join (select a, sum(b) as s from t_replicate_volatile group by a having sum(b) > random() order by a) x ;
                                       QUERY PLAN                                      
@@ -953,23 +949,16 @@ explain (costs off) select * from t_hashdist cross join (select a, sum(b) as s f
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Nested Loop
          Join Filter: true
-         ->  Broadcast Motion 3:3  (slice3; segments: 3)
-               ->  Seq Scan on t_hashdist
+         ->  Seq Scan on t_hashdist
          ->  Result
                Filter: (((sum(t_replicate_volatile.b)))::double precision > random())
-               ->  Finalize GroupAggregate
+               ->  GroupAggregate
                      Group Key: t_replicate_volatile.a
                      ->  Sort
                            Sort Key: t_replicate_volatile.a
-                           ->  Redistribute Motion 1:3  (slice2; segments: 1)
-                                 Hash Key: t_replicate_volatile.a
-                                 ->  Partial GroupAggregate
-                                       Group Key: t_replicate_volatile.a
-                                       ->  Sort
-                                             Sort Key: t_replicate_volatile.a
-                                             ->  Seq Scan on t_replicate_volatile
+                           ->  Seq Scan on t_replicate_volatile
  Optimizer: Pivotal Optimizer (GPORCA)
-(19 rows)
+(12 rows)
 
 -- insert
 explain (costs off) insert into t_replicate_volatile select random() from t_replicate_volatile;
@@ -1016,32 +1005,25 @@ explain (costs off) select a from t_replicate_volatile union all select * from n
 
 -- CTAS
 explain (costs off) create table rpt_ctas as select random() from generate_series(1, 10) distributed replicated;
-                  QUERY PLAN                  
-----------------------------------------------
+QUERY PLAN
+___________
  Result
    ->  Broadcast Motion 1:3  (slice1)
          ->  Function Scan on generate_series
- Optimizer: Pivotal Optimizer (GPORCA)
-(4 rows)
+GP_IGNORE:(4 rows)
 
 explain (costs off) create table rpt_ctas as select a from generate_series(1, 10) a group by a having sum(a) > random() distributed replicated;
-                                     QUERY PLAN                                      
--------------------------------------------------------------------------------------
+QUERY PLAN
+___________
  Result
    ->  Broadcast Motion 3:3  (slice1; segments: 3)
          ->  Result
                Filter: (((sum(generate_series)))::double precision > random())
-               ->  Finalize HashAggregate
+               ->  HashAggregate
                      Group Key: generate_series
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                           Hash Key: generate_series
-                           ->  Streaming Partial HashAggregate
-                                 Group Key: generate_series
-                                 ->  Result
-                                       One-Time Filter: (gp_execution_segment() = 0)
-                                       ->  Function Scan on generate_series
- Optimizer: Pivotal Optimizer (GPORCA)
-(14 rows)
+                     ->  Result
+                           ->  Function Scan on generate_series
+GP_IGNORE:(9 rows)
 
 -- update & delete
 explain (costs off) update t_replicate_volatile set a = 1 where b > random();
@@ -1138,23 +1120,20 @@ explain select c from rep_tab where c in (select distinct c from rep_tab);
                                               QUERY PLAN                                               
 -------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=2 width=4)
-   ->  Hash Join  (cost=0.00..862.00 rows=1 width=4)
+   ->  Hash Semi Join  (cost=0.00..862.00 rows=1 width=4)
          Hash Cond: (rep_tab.c = rep_tab_1.c)
-         ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=4)
-               Group Key: rep_tab.c
-               ->  Sort  (cost=0.00..431.00 rows=1 width=4)
-                     Sort Key: rep_tab.c
-                     ->  Redistribute Motion 1:3  (slice2; segments: 1)  (cost=0.00..431.00 rows=1 width=4)
-                           Hash Key: rep_tab.c
-                           ->  GroupAggregate  (cost=0.00..431.00 rows=6 width=4)
-                                 Group Key: rep_tab.c
-                                 ->  Sort  (cost=0.00..431.00 rows=6 width=4)
-                                       Sort Key: rep_tab.c
-                                       ->  Seq Scan on rep_tab  (cost=0.00..431.00 rows=6 width=4)
-         ->  Hash  (cost=431.00..431.00 rows=2 width=4)
-               ->  Seq Scan on rep_tab rep_tab_1  (cost=0.00..431.00 rows=2 width=4)
+         ->  Result  (cost=0.00..431.00 rows=1 width=4)
+               ->  Seq Scan on rep_tab  (cost=0.00..431.00 rows=2 width=4)
+         ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+               ->  Redistribute Motion 1:3  (slice2; segments: 1)  (cost=0.00..431.00 rows=1 width=4)
+                     Hash Key: rep_tab_1.c
+                     ->  GroupAggregate  (cost=0.00..431.00 rows=6 width=4)
+                           Group Key: rep_tab_1.c
+                           ->  Sort  (cost=0.00..431.00 rows=6 width=4)
+                                 Sort Key: rep_tab_1.c
+                                 ->  Seq Scan on rep_tab rep_tab_1  (cost=0.00..431.00 rows=6 width=4)
  Optimizer: Pivotal Optimizer (GPORCA)
-(17 rows)
+(14 rows)
 
 select c from rep_tab where c in (select distinct c from rep_tab);
  c 
@@ -1175,18 +1154,8 @@ explain select a from dist_tab where a in (select distinct c from rep_tab);
    ->  Hash Semi Join  (cost=0.00..862.00 rows=2 width=4)
          Hash Cond: (dist_tab.a = rep_tab.c)
          ->  Seq Scan on dist_tab  (cost=0.00..431.00 rows=2 width=4)
-         ->  Hash  (cost=431.00..431.00 rows=1 width=4)
-               ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=4)
-                     Group Key: rep_tab.c
-                     ->  Sort  (cost=0.00..431.00 rows=1 width=4)
-                           Sort Key: rep_tab.c
-                           ->  Redistribute Motion 1:3  (slice2; segments: 1)  (cost=0.00..431.00 rows=1 width=4)
-                                 Hash Key: rep_tab.c
-                                 ->  GroupAggregate  (cost=0.00..431.00 rows=6 width=4)
-                                       Group Key: rep_tab.c
-                                       ->  Sort  (cost=0.00..431.00 rows=6 width=4)
-                                             Sort Key: rep_tab.c
-                                             ->  Seq Scan on rep_tab  (cost=0.00..431.00 rows=6 width=4)
+         ->  Hash  (cost=431.00..431.00 rows=2 width=4)
+               ->  Seq Scan on rep_tab  (cost=0.00..431.00 rows=2 width=4)
  Optimizer: Pivotal Optimizer (GPORCA)
 (7 rows)
 
@@ -1236,20 +1205,13 @@ explain select c from rep_tab where c in (select distinct a from dist_tab);
          Hash Cond: (dist_tab.a = rep_tab.c)
          ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=4)
                Group Key: dist_tab.a
-               ->  Sort  (cost=0.00..431.00 rows=1 width=4)
+               ->  Sort  (cost=0.00..431.00 rows=2 width=4)
                      Sort Key: dist_tab.a
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
-                           Hash Key: dist_tab.a
-                           ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=4)
-                                 Group Key: dist_tab.a
-                                 ->  Sort  (cost=0.00..431.00 rows=2 width=4)
-                                       Sort Key: dist_tab.a
-                                       ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=2 width=4)
-                                             ->  Seq Scan on dist_tab  (cost=0.00..431.00 rows=2 width=4)
+                     ->  Seq Scan on dist_tab  (cost=0.00..431.00 rows=2 width=4)
          ->  Hash  (cost=431.00..431.00 rows=2 width=4)
                ->  Seq Scan on rep_tab  (cost=0.00..431.00 rows=2 width=4)
  Optimizer: Pivotal Optimizer (GPORCA)
-(18 rows)
+(11 rows)
 
 select c from rep_tab where c in (select distinct a from dist_tab);
  c 
@@ -1275,15 +1237,11 @@ explain select c from rep_tab where c in (select distinct d from rand_tab);
                      Sort Key: rand_tab.d
                      ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
                            Hash Key: rand_tab.d
-                           ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=4)
-                                 Group Key: rand_tab.d
-                                 ->  Sort  (cost=0.00..431.00 rows=1 width=4)
-                                       Sort Key: rand_tab.d
-                                       ->  Seq Scan on rand_tab  (cost=0.00..431.00 rows=1 width=4)
+                           ->  Seq Scan on rand_tab  (cost=0.00..431.00 rows=1 width=4)
          ->  Hash  (cost=431.00..431.00 rows=2 width=4)
                ->  Seq Scan on rep_tab  (cost=0.00..431.00 rows=2 width=4)
  Optimizer: Pivotal Optimizer (GPORCA)
-(17 rows)
+(13 rows)
 
 select c from rep_tab where c in (select distinct d from rand_tab);
  c 

--- a/src/test/regress/expected/select_distinct_optimizer.out
+++ b/src/test/regress/expected/select_distinct_optimizer.out
@@ -130,30 +130,27 @@ SELECT DISTINCT p.age FROM person* p ORDER BY age using >;
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT count(*) FROM
   (SELECT DISTINCT two, four, two FROM tenk1) ss;
-                                    QUERY PLAN                                     
------------------------------------------------------------------------------------
- Finalize Aggregate
+                                 QUERY PLAN                                  
+-----------------------------------------------------------------------------
+ Aggregate
    Output: count()
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         Output: (PARTIAL count())
-         ->  Partial Aggregate
-               Output: PARTIAL count()
-               ->  GroupAggregate
+         ->  GroupAggregate
+               Group Key: tenk1.two, tenk1.four, tenk1.two
+               ->  Sort
                      Output: two, four
-                     Group Key: tenk1.two, tenk1.four, tenk1.two
-                     ->  Sort
+                     Sort Key: tenk1.two, tenk1.four, tenk1.two
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
                            Output: two, four
-                           Sort Key: tenk1.two, tenk1.four, tenk1.two
-                           ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: two, four, two
+                           ->  Streaming HashAggregate
                                  Output: two, four
-                                 Hash Key: two, four, two
-                                 ->  Streaming HashAggregate
+                                 Group Key: tenk1.two, tenk1.four, tenk1.two
+                                 ->  Seq Scan on public.tenk1
                                        Output: two, four
-                                       Group Key: tenk1.two, tenk1.four, tenk1.two
-                                       ->  Seq Scan on public.tenk1
-                                             Output: two, four
- Optimizer: Pivotal Optimizer (GPORCA)
-(21 rows)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+ Settings: optimizer=on
+(18 rows)
 
 SELECT count(*) FROM
   (SELECT DISTINCT two, four, two FROM tenk1) ss;
@@ -174,17 +171,15 @@ SET optimizer_enable_hashagg=FALSE;
 SET jit_above_cost=0;
 EXPLAIN (costs off)
 SELECT DISTINCT g%1000 FROM generate_series(0,9999) g;
-                     QUERY PLAN                     
-----------------------------------------------------
+                  QUERY PLAN                  
+----------------------------------------------
  GroupAggregate
    Group Key: ((generate_series % 1000))
-   ->  GroupAggregate
-         Group Key: ((generate_series % 1000))
-         ->  Sort
-               Sort Key: ((generate_series % 1000))
-               ->  Function Scan on generate_series
+   ->  Sort
+         Sort Key: ((generate_series % 1000))
+         ->  Function Scan on generate_series
  Optimizer: Pivotal Optimizer (GPORCA)
-(8 rows)
+(6 rows)
 
 CREATE TABLE distinct_group_1 AS
 SELECT DISTINCT g%1000 FROM generate_series(0,9999) g;
@@ -200,17 +195,13 @@ SET enable_sort=FALSE;
 SET jit_above_cost=0;
 EXPLAIN (costs off)
 SELECT DISTINCT g%1000 FROM generate_series(0,9999) g;
-                     QUERY PLAN                     
-----------------------------------------------------
- GroupAggregate
-   Group Key: ((generate_series % 1000))
-   ->  GroupAggregate
-         Group Key: ((generate_series % 1000))
-         ->  Sort
-               Sort Key: ((generate_series % 1000))
-               ->  Function Scan on generate_series
+               QUERY PLAN               
+----------------------------------------
+ HashAggregate
+   Group Key: (generate_series % 1000)
+   ->  Function Scan on generate_series
  Optimizer: Pivotal Optimizer (GPORCA)
-(8 rows)
+(4 rows)
 
 CREATE TABLE distinct_hash_1 AS
 SELECT DISTINCT g%1000 FROM generate_series(0,9999) g;

--- a/src/test/regress/expected/select_parallel_optimizer.out
+++ b/src/test/regress/expected/select_parallel_optimizer.out
@@ -306,15 +306,13 @@ explain (costs off)
                          QUERY PLAN                         
 ------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  Finalize HashAggregate
+   ->  HashAggregate
          Group Key: (sp_parallel_restricted(unique1))
          ->  Redistribute Motion 3:3  (slice2; segments: 3)
                Hash Key: (sp_parallel_restricted(unique1))
-               ->  Streaming Partial HashAggregate
-                     Group Key: sp_parallel_restricted(unique1)
-                     ->  Seq Scan on tenk1
- Optimizer: Pivotal Optimizer (GPORCA)
-(9 rows)
+               ->  Seq Scan on tenk1
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(7 rows)
 
 -- test prepared statement
 prepare tenk1_count(integer) As select  count((unique1)) from tenk1 where hundred > $1;

--- a/src/test/regress/expected/subselect_gp_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_optimizer.out
@@ -186,23 +186,19 @@ explain select * from mrs_t1 where x in (select x-95 from mrs_t1) or x < 5;
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1293.02 rows=20 width=4)
    ->  Result  (cost=0.00..1293.02 rows=7 width=4)
          Filter: (CASE WHEN ((count((true))) > '0'::bigint) THEN CASE WHEN ((sum((CASE WHEN ((mrs_t1_1.x = ((mrs_t1.x - 95))) IS NULL) THEN 1 ELSE 0 END))) = (count((true)))) THEN NULL::boolean ELSE true END ELSE false END OR (mrs_t1_1.x < 5))
-         ->  Finalize HashAggregate  (cost=0.00..1293.02 rows=7 width=20)
+         ->  GroupAggregate  (cost=0.00..1293.02 rows=7 width=20)
                Group Key: mrs_t1_1.x, mrs_t1_1.ctid, mrs_t1_1.gp_segment_id
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..1293.02 rows=7 width=30)
-                     Hash Key: mrs_t1_1.ctid, mrs_t1_1.gp_segment_id
-                     ->  Partial GroupAggregate  (cost=0.00..1293.02 rows=7 width=30)
-                           Group Key: mrs_t1_1.x, mrs_t1_1.ctid, mrs_t1_1.gp_segment_id
-                           ->  Nested Loop Left Join  (cost=0.00..1293.02 rows=56 width=19)
-                                 Join Filter: ((mrs_t1_1.x = ((mrs_t1.x - 95))) IS NOT FALSE)
-                                 ->  Sort  (cost=0.00..431.00 rows=7 width=14)
-                                       Sort Key: mrs_t1_1.ctid, mrs_t1_1.gp_segment_id
-                                       ->  Seq Scan on mrs_t1 mrs_t1_1  (cost=0.00..431.00 rows=7 width=14)
-                                 ->  Result  (cost=0.00..431.00 rows=20 width=5)
-                                       ->  Materialize  (cost=0.00..431.00 rows=20 width=4)
-                                             ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=20 width=4)
-                                                   ->  Seq Scan on mrs_t1  (cost=0.00..431.00 rows=7 width=4)
- Optimizer: Pivotal Optimizer (GPORCA)
-(19 rows)
+               ->  Nested Loop Left Join  (cost=0.00..1293.02 rows=56 width=19)
+                     Join Filter: ((mrs_t1_1.x = ((mrs_t1.x - 95))) IS NOT FALSE)
+                     ->  Sort  (cost=0.00..431.00 rows=7 width=14)
+                           Sort Key: mrs_t1_1.x, mrs_t1_1.ctid, mrs_t1_1.gp_segment_id
+                           ->  Seq Scan on mrs_t1 mrs_t1_1  (cost=0.00..431.00 rows=7 width=14)
+                     ->  Result  (cost=0.00..431.00 rows=20 width=5)
+                           ->  Materialize  (cost=0.00..431.00 rows=20 width=4)
+                                 ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=20 width=4)
+                                       ->  Seq Scan on mrs_t1  (cost=0.00..431.00 rows=7 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(15 rows)
 
 select * from mrs_t1 where x in (select x-95 from mrs_t1) or x < 5 order by 1;
  x 
@@ -259,11 +255,12 @@ analyze csq_d1;
 explain select array(select x from csq_m1); -- no initplan
                           QUERY PLAN                          
 --------------------------------------------------------------
- Result  (cost=1.01..1.02 rows=1 width=32)
+ Result  (cost=1.01..1.02 rows=1 width=0)
    InitPlan 1 (returns $0)
      ->  Seq Scan on csq_m1  (cost=0.00..1.01 rows=1 width=4)
- Optimizer: Postgres query optimizer
-(4 rows)
+ Settings:  optimizer_segments=3
+ Optimizer status: Postgres query optimizer
+(5 rows)
 
 select array(select x from csq_m1); -- {1}
  array 
@@ -402,25 +399,19 @@ explain select * from csq_d1 where x not in (select x from csq_m1) or x < -100; 
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1293.00 rows=2 width=4)
    ->  Result  (cost=0.00..1293.00 rows=1 width=4)
          Filter: (CASE WHEN ((count((true))) > '0'::bigint) THEN CASE WHEN ((sum((CASE WHEN ((csq_d1.x = csq_m1.x) IS NULL) THEN 1 ELSE 0 END))) = (count((true)))) THEN NULL::boolean ELSE false END ELSE true END OR (csq_d1.x < '-100'::integer))
-         ->  Finalize GroupAggregate  (cost=0.00..1293.00 rows=1 width=20)
+         ->  GroupAggregate  (cost=0.00..1293.00 rows=1 width=20)
                Group Key: csq_d1.x, csq_d1.ctid, csq_d1.gp_segment_id
-               ->  Sort  (cost=0.00..1293.00 rows=1 width=30)
-                     Sort Key: csq_d1.ctid, csq_d1.gp_segment_id
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..1293.00 rows=1 width=30)
-                           Hash Key: csq_d1.ctid, csq_d1.gp_segment_id
-                           ->  Partial GroupAggregate  (cost=0.00..1293.00 rows=1 width=30)
-                                 Group Key: csq_d1.x, csq_d1.ctid, csq_d1.gp_segment_id
-                                 ->  Nested Loop Left Join  (cost=0.00..1293.00 rows=2 width=19)
-                                       Join Filter: ((csq_d1.x = csq_m1.x) IS NOT FALSE)
-                                       ->  Sort  (cost=0.00..431.00 rows=1 width=14)
-                                             Sort Key: csq_d1.ctid, csq_d1.gp_segment_id
-                                             ->  Seq Scan on csq_d1  (cost=0.00..431.00 rows=1 width=14)
-                                       ->  Result  (cost=0.00..431.00 rows=3 width=5)
-                                             ->  Materialize  (cost=0.00..431.00 rows=3 width=4)
-                                                   ->  Broadcast Motion 1:3  (slice3)  (cost=0.00..431.00 rows=3 width=4)
-                                                         ->  Seq Scan on csq_m1  (cost=0.00..431.00 rows=3 width=4)
- Optimizer: Pivotal Optimizer (GPORCA)
-(21 rows)
+               ->  Nested Loop Left Join  (cost=0.00..1293.00 rows=2 width=19)
+                     Join Filter: ((csq_d1.x = csq_m1.x) IS NOT FALSE)
+                     ->  Sort  (cost=0.00..431.00 rows=1 width=14)
+                           Sort Key: csq_d1.x, csq_d1.ctid, csq_d1.gp_segment_id
+                           ->  Seq Scan on csq_d1  (cost=0.00..431.00 rows=1 width=14)
+                     ->  Result  (cost=0.00..431.00 rows=3 width=5)
+                           ->  Materialize  (cost=0.00..431.00 rows=3 width=4)
+                                 ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..431.00 rows=9 width=4)
+                                       ->  Seq Scan on csq_m1  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(15 rows)
 
 select * from csq_d1 where x not in (select x from csq_m1) or x < -100; -- (4)
  x 
@@ -663,19 +654,15 @@ explain select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1
                Hash Cond: (csq_pullup.t = (csq_pullup_1.v)::text)
                ->  Seq Scan on csq_pullup  (cost=0.00..431.00 rows=1 width=17)
                ->  Hash  (cost=431.00..431.00 rows=1 width=12)
-                     ->  Finalize GroupAggregate  (cost=0.00..431.00 rows=1 width=12)
+                     ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=12)
                            Group Key: csq_pullup_1.v
-                           ->  Sort  (cost=0.00..431.00 rows=1 width=12)
+                           ->  Sort  (cost=0.00..431.00 rows=1 width=4)
                                  Sort Key: csq_pullup_1.v
-                                 ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
+                                 ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
                                        Hash Key: csq_pullup_1.v
-                                       ->  Partial GroupAggregate  (cost=0.00..431.00 rows=1 width=12)
-                                             Group Key: csq_pullup_1.v
-                                             ->  Sort  (cost=0.00..431.00 rows=1 width=4)
-                                                   Sort Key: csq_pullup_1.v
-                                                   ->  Seq Scan on csq_pullup csq_pullup_1  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: Pivotal Optimizer (GPORCA)
-(19 rows)
+                                       ->  Seq Scan on csq_pullup csq_pullup_1  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(15 rows)
 
 select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.t=t1.v);
   t  | n | i |  v  
@@ -693,25 +680,21 @@ explain select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1
 ------------------------------------------------------------------------------------------------------------------------
  Result  (cost=0.00..862.00 rows=1 width=17)
    Filter: (1 = COALESCE((count()), '0'::bigint))
-   ->  Hash Left Join  (cost=0.00..862.00 rows=2 width=25)
+   ->  Hash Left Join  (cost=0.00..862.00 rows=1 width=25)
          Hash Cond: (csq_pullup.n = csq_pullup_1.n)
          ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=17)
                ->  Seq Scan on csq_pullup  (cost=0.00..431.00 rows=1 width=17)
          ->  Hash  (cost=431.00..431.00 rows=1 width=13)
                ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=13)
-                     ->  Finalize GroupAggregate  (cost=0.00..431.00 rows=1 width=13)
+                     ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=13)
                            Group Key: csq_pullup_1.n
-                           ->  Sort  (cost=0.00..431.00 rows=1 width=13)
+                           ->  Sort  (cost=0.00..431.00 rows=1 width=5)
                                  Sort Key: csq_pullup_1.n
-                                 ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=13)
+                                 ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=5)
                                        Hash Key: csq_pullup_1.n
-                                       ->  Partial GroupAggregate  (cost=0.00..431.00 rows=1 width=13)
-                                             Group Key: csq_pullup_1.n
-                                             ->  Sort  (cost=0.00..431.00 rows=1 width=5)
-                                                   Sort Key: csq_pullup_1.n
-                                                   ->  Seq Scan on csq_pullup csq_pullup_1  (cost=0.00..431.00 rows=1 width=5)
- Optimizer: Pivotal Optimizer (GPORCA)
-(20 rows)
+                                       ->  Seq Scan on csq_pullup csq_pullup_1  (cost=0.00..431.00 rows=1 width=5)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(16 rows)
 
 select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.n=t1.n);
   t  | n | i |  v  
@@ -729,12 +712,12 @@ explain select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1
 -----------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..5172.20 rows=1 width=17)
    ->  Result  (cost=0.00..5172.20 rows=1 width=17)
-         Filter: (1 = (SubPlan 1))
+         Filter: 1 = ((SubPlan 1))
          ->  Seq Scan on csq_pullup  (cost=0.00..5172.19 rows=334 width=36)
          SubPlan 1
            ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
                  ->  Result  (cost=0.00..431.00 rows=1 width=1)
-                       Filter: ((csq_pullup.n + '1'::numeric) = (csq_pullup_1.n + '1'::numeric))
+                       Filter: (csq_pullup.n + 1::numeric) = (csq_pullup_1.n + 1::numeric)
                        ->  Materialize  (cost=0.00..431.00 rows=1 width=5)
                              ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=5)
                                    ->  Seq Scan on csq_pullup csq_pullup_1  (cost=0.00..431.00 rows=1 width=5)
@@ -757,12 +740,12 @@ explain select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1
 -----------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..5172.20 rows=1 width=17)
    ->  Result  (cost=0.00..5172.20 rows=1 width=17)
-         Filter: (1 = (SubPlan 1))
+         Filter: 1 = ((SubPlan 1))
          ->  Seq Scan on csq_pullup  (cost=0.00..5172.19 rows=334 width=36)
          SubPlan 1
            ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
                  ->  Result  (cost=0.00..431.00 rows=1 width=1)
-                       Filter: ((csq_pullup.n + '1'::numeric) = ((csq_pullup_1.i + 1))::numeric)
+                       Filter: (csq_pullup.n + 1::numeric) = (csq_pullup_1.i + 1)::numeric
                        ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
                              ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
                                    ->  Seq Scan on csq_pullup csq_pullup_1  (cost=0.00..431.00 rows=1 width=4)
@@ -925,7 +908,7 @@ explain select * from subselect_t1 where x in (select y from subselect_t2);
 --------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=2 width=4)
    ->  Hash Semi Join  (cost=0.00..862.00 rows=1 width=4)
-         Hash Cond: (subselect_t1.x = subselect_t2.y)
+         Hash Cond: subselect_t1.x = subselect_t2.y
          ->  Seq Scan on subselect_t1  (cost=0.00..431.00 rows=1 width=4)
          ->  Hash  (cost=431.00..431.00 rows=1 width=4)
                ->  Seq Scan on subselect_t2  (cost=0.00..431.00 rows=1 width=4)
@@ -968,18 +951,17 @@ select * from subselect_t1 where x in (select y from subselect_t2 union all sele
 (2 rows)
 
 explain select count(*) from subselect_t1 where x in (select y from subselect_t2);
-                                         QUERY PLAN                                         
---------------------------------------------------------------------------------------------
- Finalize Aggregate  (cost=0.00..862.00 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
-         ->  Partial Aggregate  (cost=0.00..862.00 rows=1 width=8)
-               ->  Hash Semi Join  (cost=0.00..862.00 rows=1 width=1)
-                     Hash Cond: (subselect_t1.x = subselect_t2.y)
-                     ->  Seq Scan on subselect_t1  (cost=0.00..431.00 rows=1 width=4)
-                     ->  Hash  (cost=431.00..431.00 rows=1 width=4)
-                           ->  Seq Scan on subselect_t2  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: Pivotal Optimizer (GPORCA)
-(9 rows)
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..862.00 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=2 width=1)
+         ->  Hash Semi Join  (cost=0.00..862.00 rows=1 width=1)
+               Hash Cond: (subselect_t1.x = subselect_t2.y)
+               ->  Seq Scan on subselect_t1  (cost=0.00..431.00 rows=1 width=4)
+               ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+                     ->  Seq Scan on subselect_t2  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
+(8 rows)
 
 select count(*) from subselect_t1 where x in (select y from subselect_t2);
  count 
@@ -991,24 +973,23 @@ select count(*) from subselect_t1 where x in (select y from subselect_t2);
 -- Known_opt_diff: MPP-21351
 -- end_ignore
 explain select count(*) from subselect_t1 where x in (select y from subselect_t2 union all select y from subselect_t2);
-                                                         QUERY PLAN                                                          
------------------------------------------------------------------------------------------------------------------------------
- Finalize Aggregate  (cost=0.00..1293.00 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1293.00 rows=1 width=8)
-         ->  Partial Aggregate  (cost=0.00..1293.00 rows=1 width=8)
-               ->  Hash Join  (cost=0.00..1293.00 rows=1 width=1)
-                     Hash Cond: (subselect_t1.x = subselect_t2.y)
-                     ->  Seq Scan on subselect_t1  (cost=0.00..431.00 rows=1 width=4)
-                     ->  Hash  (cost=862.00..862.00 rows=1 width=4)
-                           ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=4)
-                                 Group Key: subselect_t2.y
-                                 ->  Sort  (cost=0.00..862.00 rows=2 width=4)
-                                       Sort Key: subselect_t2.y
-                                       ->  Append  (cost=0.00..862.00 rows=2 width=4)
-                                             ->  Seq Scan on subselect_t2  (cost=0.00..431.00 rows=1 width=4)
-                                             ->  Seq Scan on subselect_t2 subselect_t2_1  (cost=0.00..431.00 rows=1 width=4)
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..1293.00 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1293.00 rows=2 width=1)
+         ->  Hash Join  (cost=0.00..1293.00 rows=1 width=1)
+               Hash Cond: (subselect_t1.x = subselect_t2.y)
+               ->  Seq Scan on subselect_t1  (cost=0.00..431.00 rows=1 width=4)
+               ->  Hash  (cost=862.00..862.00 rows=1 width=4)
+                     ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=4)
+                           Group Key: subselect_t2.y
+                           ->  Sort  (cost=0.00..862.00 rows=2 width=4)
+                                 Sort Key: subselect_t2.y
+                                 ->  Append  (cost=0.00..862.00 rows=2 width=4)
+                                       ->  Seq Scan on subselect_t2  (cost=0.00..431.00 rows=1 width=4)
+                                       ->  Seq Scan on subselect_t2 subselect_t2_1  (cost=0.00..431.00 rows=1 width=4)
  Optimizer: Pivotal Optimizer (GPORCA)
-(15 rows)
+(14 rows)
 
 select count(*) from subselect_t1 where x in (select y from subselect_t2 union all select y from subselect_t2);
  count 
@@ -1289,20 +1270,16 @@ explain SELECT  cc, sum(nn) over() FROM v1_mpp_20470;
                      ->  Dynamic Seq Scan on t_mpp_20470  (cost=0.00..431.00 rows=1 width=8)
                            Number of partitions to scan: 2 
                ->  Hash  (cost=431.00..431.00 rows=1 width=16)
-                     ->  Finalize GroupAggregate  (cost=0.00..431.00 rows=1 width=16)
+                     ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=16)
                            Group Key: t_mpp_20470_1.col_name
-                           ->  Sort  (cost=0.00..431.00 rows=1 width=16)
+                           ->  Sort  (cost=0.00..431.00 rows=1 width=12)
                                  Sort Key: t_mpp_20470_1.col_name
-                                 ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=16)
+                                 ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
                                        Hash Key: t_mpp_20470_1.col_name
-                                       ->  Partial GroupAggregate  (cost=0.00..431.00 rows=1 width=16)
-                                             Group Key: t_mpp_20470_1.col_name
-                                             ->  Sort  (cost=0.00..431.00 rows=1 width=12)
-                                                   Sort Key: t_mpp_20470_1.col_name
-                                                   ->  Dynamic Seq Scan on t_mpp_20470 t_mpp_20470_1  (cost=0.00..431.00 rows=1 width=12)
-                                                         Number of partitions to scan: 2 
+                                       ->  Dynamic Seq Scan on t_mpp_20470 t_mpp_20470_1  (cost=0.00..431.00 rows=1 width=12)
+                                             Number of partitions to scan: 2 
  Optimizer: Pivotal Optimizer (GPORCA)
-(22 rows)
+(18 rows)
 
 drop view v1_mpp_20470;
 drop table t_mpp_20470;
@@ -1495,13 +1472,13 @@ EXPLAIN SELECT '' AS six, f1 AS "Uncorrelated Field" FROM SUBSELECT_TBL
   WHERE f1 IN (SELECT f2 FROM SUBSELECT_TBL) ORDER BY 2;
                                                     QUERY PLAN                                                     
 -------------------------------------------------------------------------------------------------------------------
- Result  (cost=0.00..862.00 rows=7 width=12)
+ Result  (cost=0.00..862.00 rows=3 width=12)
    ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=7 width=4)
          Merge Key: subselect_tbl.f1
          ->  Sort  (cost=0.00..862.00 rows=3 width=4)
                Sort Key: subselect_tbl.f1
                ->  Hash Semi Join  (cost=0.00..862.00 rows=3 width=4)
-                     Hash Cond: (subselect_tbl.f1 = subselect_tbl_1.f2)
+                     Hash Cond: subselect_tbl.f1 = subselect_tbl_1.f2
                      ->  Seq Scan on subselect_tbl  (cost=0.00..431.00 rows=3 width=4)
                      ->  Hash  (cost=431.00..431.00 rows=3 width=4)
                            ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=3 width=4)
@@ -1515,13 +1492,13 @@ EXPLAIN SELECT '' AS six, f1 AS "Uncorrelated Field" FROM SUBSELECT_TBL
     f2 IN (SELECT f1 FROM SUBSELECT_TBL)) ORDER BY 2;
                                                              QUERY PLAN                                                              
 -------------------------------------------------------------------------------------------------------------------------------------
- Result  (cost=0.00..1293.00 rows=4 width=12)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1293.00 rows=4 width=4)
+ Result  (cost=0.00..1293.00 rows=2 width=12)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1293.00 rows=5 width=4)
          Merge Key: subselect_tbl.f1
          ->  Sort  (cost=0.00..1293.00 rows=2 width=4)
                Sort Key: subselect_tbl.f1
                ->  Hash Join  (cost=0.00..1293.00 rows=2 width=4)
-                     Hash Cond: (subselect_tbl.f1 = subselect_tbl_1.f2)
+                     Hash Cond: subselect_tbl.f1 = subselect_tbl_1.f2
                      ->  Seq Scan on subselect_tbl  (cost=0.00..431.00 rows=3 width=4)
                      ->  Hash  (cost=862.00..862.00 rows=2 width=4)
                            ->  GroupAggregate  (cost=0.00..862.00 rows=2 width=4)
@@ -1529,7 +1506,7 @@ EXPLAIN SELECT '' AS six, f1 AS "Uncorrelated Field" FROM SUBSELECT_TBL
                                  ->  Sort  (cost=0.00..862.00 rows=3 width=4)
                                        Sort Key: subselect_tbl_1.f2
                                        ->  Hash Semi Join  (cost=0.00..862.00 rows=3 width=4)
-                                             Hash Cond: (subselect_tbl_1.f2 = subselect_tbl_2.f1)
+                                             Hash Cond: subselect_tbl_1.f2 = subselect_tbl_2.f1
                                              ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=3 width=4)
                                                    Hash Key: subselect_tbl_1.f2
                                                    ->  Seq Scan on subselect_tbl subselect_tbl_1  (cost=0.00..431.00 rows=3 width=4)
@@ -1586,15 +1563,15 @@ WHERE (a.unique1,b.unique2) IN (SELECT unique1,unique2 FROM tenk1 c);
 EXPLAIN SELECT '' AS six, f1 AS "Correlated Field", f2 AS "Second Field"
   FROM SUBSELECT_TBL upper
   WHERE f1 IN (SELECT f2 FROM SUBSELECT_TBL WHERE f1 = upper.f1) ORDER BY 2,3;
-                                                      QUERY PLAN                                                      
-----------------------------------------------------------------------------------------------------------------------
- Result  (cost=0.00..862.00 rows=8 width=16)
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Result  (cost=0.00..862.00 rows=3 width=16)
    ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=8 width=8)
          Merge Key: subselect_tbl.f1, subselect_tbl.f2
          ->  Sort  (cost=0.00..862.00 rows=3 width=8)
                Sort Key: subselect_tbl.f1, subselect_tbl.f2
                ->  Hash Semi Join  (cost=0.00..862.00 rows=3 width=8)
-                     Hash Cond: ((subselect_tbl.f1 = subselect_tbl_1.f1) AND (subselect_tbl.f1 = subselect_tbl_1.f2))
+                     Hash Cond: subselect_tbl.f1 = subselect_tbl_1.f1 AND subselect_tbl.f1 = subselect_tbl_1.f2
                      ->  Seq Scan on subselect_tbl  (cost=0.00..431.00 rows=3 width=8)
                      ->  Hash  (cost=431.00..431.00 rows=3 width=8)
                            ->  Seq Scan on subselect_tbl subselect_tbl_1  (cost=0.00..431.00 rows=3 width=8)
@@ -1605,15 +1582,15 @@ EXPLAIN SELECT '' AS six, f1 AS "Correlated Field", f3 AS "Second Field"
   FROM SUBSELECT_TBL upper
   WHERE f1 IN
     (SELECT f2 FROM SUBSELECT_TBL WHERE CAST(upper.f2 AS float) = f3) ORDER BY 2,3;
-                                                                QUERY PLAN                                                                
-------------------------------------------------------------------------------------------------------------------------------------------
- Result  (cost=0.00..862.00 rows=8 width=20)
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Result  (cost=0.00..862.00 rows=3 width=20)
    ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=8 width=12)
          Merge Key: subselect_tbl.f1, subselect_tbl.f3
          ->  Sort  (cost=0.00..862.00 rows=3 width=12)
                Sort Key: subselect_tbl.f1, subselect_tbl.f3
                ->  Hash Semi Join  (cost=0.00..862.00 rows=3 width=12)
-                     Hash Cond: (((subselect_tbl.f2)::double precision = subselect_tbl_1.f3) AND (subselect_tbl.f1 = subselect_tbl_1.f2))
+                     Hash Cond: subselect_tbl.f2::double precision = subselect_tbl_1.f3 AND subselect_tbl.f1 = subselect_tbl_1.f2
                      ->  Seq Scan on subselect_tbl  (cost=0.00..431.00 rows=3 width=16)
                      ->  Hash  (cost=431.00..431.00 rows=3 width=12)
                            ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=3 width=12)
@@ -1628,7 +1605,7 @@ EXPLAIN SELECT '' AS six, f1 AS "Correlated Field", f3 AS "Second Field"
                WHERE f2 = CAST(f3 AS integer)) ORDER BY 2,3;
                                                         QUERY PLAN                                                         
 ---------------------------------------------------------------------------------------------------------------------------
- Result  (cost=0.00..1324033.89 rows=8 width=20)
+ Result  (cost=0.00..1324033.89 rows=3 width=20)
    ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1324033.89 rows=8 width=12)
          Merge Key: subselect_tbl.f1, subselect_tbl.f3
          ->  Sort  (cost=0.00..1324033.89 rows=3 width=12)
@@ -1640,8 +1617,8 @@ EXPLAIN SELECT '' AS six, f1 AS "Correlated Field", f3 AS "Second Field"
                              ->  Materialize  (cost=0.00..431.00 rows=4 width=4)
                                    ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=4 width=4)
                                          ->  Seq Scan on subselect_tbl subselect_tbl_1  (cost=0.00..431.00 rows=2 width=4)
-                                               Filter: (f2 = int4(f3))
- Optimizer: Pivotal Optimizer (GPORCA)
+                                               Filter: f2 = f3::integer
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
 (14 rows)
 
 EXPLAIN SELECT '' AS five, f1 AS "Correlated Field"
@@ -1674,114 +1651,100 @@ EXPLAIN select count(*) from
    where unique1 IN (select hundred from tenk1 b)) ss;
                                                           QUERY PLAN                                                           
 -------------------------------------------------------------------------------------------------------------------------------
- Finalize Aggregate  (cost=0.00..864.06 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..864.06 rows=1 width=8)
-         ->  Partial Aggregate  (cost=0.00..864.06 rows=1 width=8)
-               ->  Hash Join  (cost=0.00..864.06 rows=34 width=1)
-                     Hash Cond: (tenk1.unique1 = tenk1_1.hundred)
-                     ->  Seq Scan on tenk1  (cost=0.00..431.50 rows=3334 width=4)
+ Finalize Aggregate  (cost=0.00..864.07 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..864.07 rows=1 width=8)
+         ->  Partial Aggregate  (cost=0.00..864.07 rows=1 width=8)
+               ->  Hash Join  (cost=0.00..864.07 rows=34 width=1)
+                     Hash Cond: tenk1.unique1 = tenk1_1.hundred
+                     ->  Seq Scan on tenk1  (cost=0.00..431.51 rows=3334 width=4)
                      ->  Hash  (cost=431.94..431.94 rows=34 width=4)
                            ->  GroupAggregate  (cost=0.00..431.94 rows=34 width=4)
                                  Group Key: tenk1_1.hundred
                                  ->  Sort  (cost=0.00..431.94 rows=34 width=4)
                                        Sort Key: tenk1_1.hundred
-                                       ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.93 rows=34 width=4)
+                                       ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.94 rows=34 width=4)
                                              Hash Key: tenk1_1.hundred
-                                             ->  Streaming HashAggregate  (cost=0.00..431.93 rows=34 width=4)
+                                             ->  Streaming HashAggregate  (cost=0.00..431.94 rows=34 width=4)
                                                    Group Key: tenk1_1.hundred
-                                                   ->  Seq Scan on tenk1 tenk1_1  (cost=0.00..431.50 rows=3334 width=4)
- Optimizer: Pivotal Optimizer (GPORCA)
+                                                   ->  Seq Scan on tenk1 tenk1_1  (cost=0.00..431.51 rows=3334 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.75.0
 (17 rows)
 
 EXPLAIN select count(distinct ss.ten) from
   (select ten from tenk1 a
    where unique1 IN (select hundred from tenk1 b)) ss;
-                                                                      QUERY PLAN                                                                       
--------------------------------------------------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=0.00..864.10 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..864.10 rows=10 width=4)
-         ->  GroupAggregate  (cost=0.00..864.10 rows=4 width=4)
-               Group Key: tenk1.ten
-               ->  Sort  (cost=0.00..864.10 rows=4 width=4)
-                     Sort Key: tenk1.ten
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..864.10 rows=4 width=4)
-                           Hash Key: tenk1.ten
-                           ->  GroupAggregate  (cost=0.00..864.10 rows=4 width=4)
-                                 Group Key: tenk1.ten
-                                 ->  Sort  (cost=0.00..864.10 rows=34 width=4)
-                                       Sort Key: tenk1.ten
-                                       ->  Hash Join  (cost=0.00..864.09 rows=34 width=4)
-                                             Hash Cond: (tenk1.unique1 = tenk1_1.hundred)
-                                             ->  Seq Scan on tenk1  (cost=0.00..431.50 rows=3334 width=8)
-                                             ->  Hash  (cost=431.94..431.94 rows=34 width=4)
-                                                   ->  GroupAggregate  (cost=0.00..431.94 rows=34 width=4)
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate  (cost=0.00..864.11 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..864.11 rows=1 width=8)
+         ->  Partial Aggregate  (cost=0.00..864.11 rows=1 width=8)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..864.11 rows=34 width=4)
+                     Hash Key: tenk1.ten
+                     ->  Hash Join  (cost=0.00..864.11 rows=34 width=4)
+                           Hash Cond: (tenk1.unique1 = tenk1_1.hundred)
+                           ->  Seq Scan on tenk1  (cost=0.00..431.51 rows=3334 width=8)
+                           ->  Hash  (cost=431.94..431.94 rows=34 width=4)
+                                 ->  GroupAggregate  (cost=0.00..431.94 rows=34 width=4)
+                                       Group Key: tenk1_1.hundred
+                                       ->  Sort  (cost=0.00..431.94 rows=34 width=4)
+                                             Sort Key: tenk1_1.hundred
+                                             ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.94 rows=34 width=4)
+                                                   Hash Key: tenk1_1.hundred
+                                                   ->  Streaming HashAggregate  (cost=0.00..431.94 rows=34 width=4)
                                                          Group Key: tenk1_1.hundred
-                                                         ->  Sort  (cost=0.00..431.94 rows=34 width=4)
-                                                               Sort Key: tenk1_1.hundred
-                                                               ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.93 rows=34 width=4)
-                                                                     Hash Key: tenk1_1.hundred
-                                                                     ->  Streaming HashAggregate  (cost=0.00..431.93 rows=34 width=4)
-                                                                           Group Key: tenk1_1.hundred
-                                                                           ->  Seq Scan on tenk1 tenk1_1  (cost=0.00..431.50 rows=3334 width=4)
- Optimizer: Pivotal Optimizer (GPORCA)
-(26 rows)
+                                                         ->  Seq Scan on tenk1 tenk1_1  (cost=0.00..431.51 rows=3334 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
+(19 rows)
 
 EXPLAIN select count(*) from
   (select 1 from tenk1 a
    where unique1 IN (select distinct hundred from tenk1 b)) ss;
                                                           QUERY PLAN                                                           
 -------------------------------------------------------------------------------------------------------------------------------
- Finalize Aggregate  (cost=0.00..864.06 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..864.06 rows=1 width=8)
-         ->  Partial Aggregate  (cost=0.00..864.06 rows=1 width=8)
-               ->  Hash Semi Join  (cost=0.00..864.06 rows=34 width=1)
-                     Hash Cond: (tenk1.unique1 = tenk1_1.hundred)
-                     ->  Seq Scan on tenk1  (cost=0.00..431.50 rows=3334 width=4)
+ Finalize Aggregate  (cost=0.00..864.07 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..864.07 rows=1 width=8)
+         ->  Partial Aggregate  (cost=0.00..864.07 rows=1 width=8)
+               ->  Hash Semi Join  (cost=0.00..864.07 rows=34 width=1)
+                     Hash Cond: tenk1.unique1 = tenk1_1.hundred
+                     ->  Seq Scan on tenk1  (cost=0.00..431.51 rows=3334 width=4)
                      ->  Hash  (cost=431.94..431.94 rows=34 width=4)
                            ->  GroupAggregate  (cost=0.00..431.94 rows=34 width=4)
                                  Group Key: tenk1_1.hundred
                                  ->  Sort  (cost=0.00..431.94 rows=34 width=4)
                                        Sort Key: tenk1_1.hundred
-                                       ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.93 rows=34 width=4)
+                                       ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.94 rows=34 width=4)
                                              Hash Key: tenk1_1.hundred
-                                             ->  Streaming HashAggregate  (cost=0.00..431.93 rows=34 width=4)
+                                             ->  Streaming HashAggregate  (cost=0.00..431.94 rows=34 width=4)
                                                    Group Key: tenk1_1.hundred
-                                                   ->  Seq Scan on tenk1 tenk1_1  (cost=0.00..431.50 rows=3334 width=4)
- Optimizer: Pivotal Optimizer (GPORCA)
+                                                   ->  Seq Scan on tenk1 tenk1_1  (cost=0.00..431.51 rows=3334 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 2.75.0
 (17 rows)
 
 EXPLAIN select count(distinct ss.ten) from
   (select ten from tenk1 a
    where unique1 IN (select distinct hundred from tenk1 b)) ss;
-                                                                      QUERY PLAN                                                                       
--------------------------------------------------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=0.00..864.10 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..864.10 rows=10 width=4)
-         ->  GroupAggregate  (cost=0.00..864.10 rows=4 width=4)
-               Group Key: tenk1.ten
-               ->  Sort  (cost=0.00..864.10 rows=4 width=4)
-                     Sort Key: tenk1.ten
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..864.10 rows=4 width=4)
-                           Hash Key: tenk1.ten
-                           ->  GroupAggregate  (cost=0.00..864.10 rows=4 width=4)
-                                 Group Key: tenk1.ten
-                                 ->  Sort  (cost=0.00..864.10 rows=34 width=4)
-                                       Sort Key: tenk1.ten
-                                       ->  Hash Semi Join  (cost=0.00..864.09 rows=34 width=4)
-                                             Hash Cond: (tenk1.unique1 = tenk1_1.hundred)
-                                             ->  Seq Scan on tenk1  (cost=0.00..431.50 rows=3334 width=8)
-                                             ->  Hash  (cost=431.94..431.94 rows=34 width=4)
-                                                   ->  GroupAggregate  (cost=0.00..431.94 rows=34 width=4)
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate  (cost=0.00..864.11 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..864.11 rows=1 width=8)
+         ->  Partial Aggregate  (cost=0.00..864.11 rows=1 width=8)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..864.11 rows=34 width=4)
+                     Hash Key: tenk1.ten
+                     ->  Hash Semi Join  (cost=0.00..864.11 rows=34 width=4)
+                           Hash Cond: (tenk1.unique1 = tenk1_1.hundred)
+                           ->  Seq Scan on tenk1  (cost=0.00..431.51 rows=3334 width=8)
+                           ->  Hash  (cost=431.94..431.94 rows=34 width=4)
+                                 ->  GroupAggregate  (cost=0.00..431.94 rows=34 width=4)
+                                       Group Key: tenk1_1.hundred
+                                       ->  Sort  (cost=0.00..431.94 rows=34 width=4)
+                                             Sort Key: tenk1_1.hundred
+                                             ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.94 rows=34 width=4)
+                                                   Hash Key: tenk1_1.hundred
+                                                   ->  Streaming HashAggregate  (cost=0.00..431.94 rows=34 width=4)
                                                          Group Key: tenk1_1.hundred
-                                                         ->  Sort  (cost=0.00..431.94 rows=34 width=4)
-                                                               Sort Key: tenk1_1.hundred
-                                                               ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.93 rows=34 width=4)
-                                                                     Hash Key: tenk1_1.hundred
-                                                                     ->  Streaming HashAggregate  (cost=0.00..431.93 rows=34 width=4)
-                                                                           Group Key: tenk1_1.hundred
-                                                                           ->  Seq Scan on tenk1 tenk1_1  (cost=0.00..431.50 rows=3334 width=4)
- Optimizer: Pivotal Optimizer (GPORCA)
-(26 rows)
+                                                         ->  Seq Scan on tenk1 tenk1_1  (cost=0.00..431.51 rows=3334 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
+(19 rows)
 
 --
 -- In case of simple exists query, planner can generate alternative
@@ -1803,7 +1766,7 @@ EXPLAIN SELECT EXISTS(SELECT * FROM tenk1 WHERE tenk1.unique1 = tenk2.unique1) F
                                  Group Key: tenk1.unique1
                                  ->  Seq Scan on tenk1  (cost=0.00..431.50 rows=3334 width=4)
  Optimizer: Pivotal Optimizer (GPORCA)
-(11 rows)
+(19 rows)
 
 SELECT EXISTS(SELECT * FROM tenk1 WHERE tenk1.unique1 = tenk2.unique1) FROM tenk2 LIMIT 1;
  exists 
@@ -1935,15 +1898,11 @@ select * from dedup_reptab r where r.a in (select t.a/10 from dedup_tab t);
                      Sort Key: ((dedup_tab.a / 10))
                      ->  Redistribute Motion 3:3  (slice2; segments: 3)
                            Hash Key: ((dedup_tab.a / 10))
-                           ->  GroupAggregate
-                                 Group Key: ((dedup_tab.a / 10))
-                                 ->  Sort
-                                       Sort Key: ((dedup_tab.a / 10))
-                                       ->  Seq Scan on dedup_tab
+                           ->  Seq Scan on dedup_tab
          ->  Hash
                ->  Seq Scan on dedup_reptab
- Optimizer: Pivotal Optimizer (GPORCA)
-(17 rows)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.94.0
+(13 rows)
 
 select * from dedup_reptab r where r.a in (select t.a/10 from dedup_tab t);
  a 

--- a/src/test/regress/expected/union_optimizer.out
+++ b/src/test/regress/expected/union_optimizer.out
@@ -365,11 +365,9 @@ select count(*) from
                                  Group Key: tenk1_1.fivethous
                                  ->  Redistribute Motion 3:3  (slice2; segments: 3)
                                        Hash Key: tenk1_1.fivethous
-                                       ->  Streaming HashAggregate
-                                             Group Key: tenk1_1.fivethous
-                                             ->  Seq Scan on tenk1 tenk1_1
+                                       ->  Seq Scan on tenk1 tenk1_1
  Optimizer: Pivotal Optimizer (GPORCA)
-(17 rows)
+(15 rows)
 
 select count(*) from
   ( select unique1 from tenk1 intersect select fivethous from tenk1 ) ss;
@@ -421,11 +419,9 @@ select count(*) from
                                  Group Key: tenk1_1.fivethous
                                  ->  Redistribute Motion 3:3  (slice2; segments: 3)
                                        Hash Key: tenk1_1.fivethous
-                                       ->  Streaming HashAggregate
-                                             Group Key: tenk1_1.fivethous
-                                             ->  Seq Scan on tenk1 tenk1_1
+                                       ->  Seq Scan on tenk1 tenk1_1
  Optimizer: Pivotal Optimizer (GPORCA)
-(17 rows)
+(15 rows)
 
 select count(*) from
   ( select unique1 from tenk1 intersect select fivethous from tenk1 ) ss;
@@ -758,20 +754,16 @@ explain (costs off)
          Group Key: ((t1.a || t1.b))
          ->  Sort
                Sort Key: ((t1.a || t1.b))
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                     Hash Key: ((t1.a || t1.b))
-                     ->  GroupAggregate
-                           Group Key: ((t1.a || t1.b))
-                           ->  Sort
-                                 Sort Key: ((t1.a || t1.b))
-                                 ->  Append
-                                       ->  Result
-                                             Filter: (((t1.a || t1.b)) = 'ab'::text)
-                                             ->  Seq Scan on t1
-                                       ->  Index Scan using t2_pkey on t2
-                                             Index Cond: (ab = 'ab'::text)
- Optimizer: Pivotal Optimizer (GPORCA)
-(18 rows)
+               ->  Append
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: ((t1.a || t1.b))
+                           ->  Result
+                                 Filter: (((t1.a || t1.b)) = 'ab'::text)
+                                 ->  Seq Scan on t1
+                     ->  Index Scan using t2_pkey on t2
+                           Index Cond: (ab = 'ab'::text)
+ Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+(14 rows)
 
 --
 -- Test that ORDER BY for UNION ALL can be pushed down to inheritance
@@ -913,12 +905,12 @@ WHERE x < 4
 ORDER BY x;
                             QUERY PLAN                            
 ------------------------------------------------------------------
- GroupAggregate
-   Group Key: (1), (generate_series(1, 10))
+ Sort
+   Sort Key: (generate_series(1, 10))
    ->  GroupAggregate
          Group Key: (1), (generate_series(1, 10))
          ->  Sort
-               Sort Key: (generate_series(1, 10)), (1)
+               Sort Key: (1), (generate_series(1, 10))
                ->  Append
                      ->  Result
                            Filter: ((generate_series(1, 10)) < 4)
@@ -991,26 +983,19 @@ where q2 = q2;
          Group Key: int8_tbl.q1
          ->  Sort
                Sort Key: int8_tbl.q1
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                     Hash Key: int8_tbl.q1
+               ->  Append
                      ->  GroupAggregate
                            Group Key: int8_tbl.q1
                            ->  Sort
                                  Sort Key: int8_tbl.q1
-                                 ->  Redistribute Motion 3:3  (slice3; segments: 3)
-                                       ->  Append
-                                             ->  GroupAggregate
-                                                   Group Key: int8_tbl.q1
-                                                   ->  Sort
-                                                         Sort Key: int8_tbl.q1
-                                                         ->  Seq Scan on int8_tbl
-                                                               Filter: (q2 = q2)
-                                             ->  GroupAggregate
-                                                   Group Key: int8_tbl_1.q1
-                                                   ->  Sort
-                                                         Sort Key: int8_tbl_1.q1
-                                                         ->  Seq Scan on int8_tbl int8_tbl_1
-                                                               Filter: (q2 = q2)
+                                 ->  Seq Scan on int8_tbl
+                                       Filter: (q2 = q2)
+                     ->  GroupAggregate
+                           Group Key: int8_tbl_1.q1
+                           ->  Sort
+                                 Sort Key: int8_tbl_1.q1
+                                 ->  Seq Scan on int8_tbl int8_tbl_1
+                                       Filter: (q2 = q2)
  Optimizer: Pivotal Optimizer (GPORCA)
 (26 rows)
 
@@ -1038,26 +1023,19 @@ where -q1 = q2;
          Group Key: int8_tbl.q1
          ->  Sort
                Sort Key: int8_tbl.q1
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                     Hash Key: int8_tbl.q1
+               ->  Append
                      ->  GroupAggregate
                            Group Key: int8_tbl.q1
                            ->  Sort
                                  Sort Key: int8_tbl.q1
-                                 ->  Redistribute Motion 3:3  (slice3; segments: 3)
-                                       ->  Append
-                                             ->  GroupAggregate
-                                                   Group Key: int8_tbl.q1
-                                                   ->  Sort
-                                                         Sort Key: int8_tbl.q1
-                                                         ->  Seq Scan on int8_tbl
-                                                               Filter: ((- q1) = q2)
-                                             ->  GroupAggregate
-                                                   Group Key: int8_tbl_1.q1
-                                                   ->  Sort
-                                                         Sort Key: int8_tbl_1.q1
-                                                         ->  Seq Scan on int8_tbl int8_tbl_1
-                                                               Filter: ((- q1) = q2)
+                                 ->  Seq Scan on int8_tbl
+                                       Filter: ((- q1) = q2)
+                     ->  GroupAggregate
+                           Group Key: int8_tbl_1.q1
+                           ->  Sort
+                                 Sort Key: int8_tbl_1.q1
+                                 ->  Seq Scan on int8_tbl int8_tbl_1
+                                       Filter: ((- q1) = q2)
  Optimizer: Pivotal Optimizer (GPORCA)
 (26 rows)
 

--- a/src/test/regress/expected/update_gp_optimizer.out
+++ b/src/test/regress/expected/update_gp_optimizer.out
@@ -144,10 +144,9 @@ WHERE t1.user_vie_project_code_pk = keo1.user_vie_project_code_pk;
                                                                            ->  Hash Join
                                                                                  Hash Cond: ((min((keo4.keo_para_budget_date)::text)) = (keo4_1.keo_para_budget_date)::text)
                                                                                  ->  Redistribute Motion 1:3  (slice5; segments: 1)
-                                                                                       ->  Finalize Aggregate
+                                                                                       ->  Aggregate
                                                                                              ->  Gather Motion 3:1  (slice6; segments: 3)
-                                                                                                   ->  Partial Aggregate
-                                                                                                         ->  Seq Scan on keo4
+                                                                                                   ->  Seq Scan on keo4
                                                                                  ->  Hash
                                                                                        ->  Broadcast Motion 3:3  (slice7; segments: 3)
                                                                                              ->  Seq Scan on keo4 keo4_1
@@ -158,7 +157,7 @@ WHERE t1.user_vie_project_code_pk = keo1.user_vie_project_code_pk;
                                  ->  Broadcast Motion 3:3  (slice9; segments: 3)
                                        ->  Seq Scan on keo2
  Optimizer: Pivotal Optimizer (GPORCA)
-(38 rows)
+(37 rows)
 
 UPDATE keo1 SET user_vie_act_cntr_marg_cum = 234.682 FROM
     ( SELECT a.user_vie_project_code_pk FROM keo1 a INNER JOIN keo2 b

--- a/src/test/regress/expected/with_clause_optimizer.out
+++ b/src/test/regress/expected/with_clause_optimizer.out
@@ -2286,16 +2286,15 @@ SELECT count(a1.i)
                            ->  Hash
                                  ->  Shared Scan (share slice:id 1:1)
                      ->  Redistribute Motion 1:3  (slice2)
-                           ->  Finalize Aggregate
+                           ->  Aggregate
                                  ->  Gather Motion 3:1  (slice3; segments: 3)
-                                       ->  Partial Aggregate
-                                             ->  Hash Join
-                                                   Hash Cond: (share0_ref3.i = share1_ref3.i)
-                                                   ->  Shared Scan (share slice:id 3:0)
-                                                   ->  Hash
-                                                         ->  Shared Scan (share slice:id 3:1)
+                                       ->  Hash Join
+                                             Hash Cond: (share0_ref3.i = share1_ref3.i)
+                                             ->  Shared Scan (share slice:id 3:0)
+                                             ->  Hash
+                                                   ->  Shared Scan (share slice:id 3:1)
  Optimizer: Pivotal Optimizer (GPORCA)
-(23 rows)
+(22 rows)
 
 -- Another cross-slice ShareInputScan test. There is one producing slice,
 -- and two consumers in second slice. Make sure the Share Input Scan
@@ -2333,26 +2332,22 @@ UNION ALL
                            Sort Key: ('a'::text), share0_ref2.j
                            ->  Redistribute Motion 3:3  (slice2; segments: 3)
                                  Hash Key: ('a'::text), share0_ref2.j
-                                 ->  GroupAggregate
-                                       Group Key: ('a'::text), share0_ref2.j
-                                       ->  Sort
-                                             Sort Key: ('a'::text), share0_ref2.j
-                                             ->  Result
-                                                   ->  Shared Scan (share slice:id 2:0)
+                                 ->  Result
+                                       ->  Shared Scan (share slice:id 2:0)
                ->  Hash Join
                      Hash Cond: (share0_ref4.i = share0_ref3.i)
                      ->  Shared Scan (share slice:id 1:0)
                      ->  Hash
                            ->  Shared Scan (share slice:id 1:0)
                ->  Result
-                     One-Time Filter: (gp_execution_segment() = 1)
+                     One-Time Filter: (gp_execution_segment() = 0)
                      ->  Result
                            Filter: (NOT (pg_sleep('1'::double precision) IS NULL))
                            ->  Result
                ->  Result
                      ->  Shared Scan (share slice:id 1:0)
  Optimizer: Pivotal Optimizer (GPORCA)
-(30 rows)
+(26 rows)
 
 WITH cte AS (SELECT * FROM foo)
   (SELECT DISTINCT 'a' as branch, j FROM cte)

--- a/src/test/regress/sql/bfv_aggregate.sql
+++ b/src/test/regress/sql/bfv_aggregate.sql
@@ -227,7 +227,7 @@ insert into mtup1 values
 -- from exceeding the limit in GPDB7 with that plan(a MinimalTuple has a limit of 1600
 -- columns). So set the parameter to off to prevent error happens.
 set gp_enable_multiphase_agg=off;
-set optimizer_force_multistage_agg=off;
+
 
 select c0, c1, array_length(ARRAY[
  SUM(c4 % 2), SUM(c4 % 3), SUM(c4 % 4),
@@ -1366,8 +1366,8 @@ select c0, c1, array_length(ARRAY[
  SUM(c4 % 5665), SUM(c4 % 5666), SUM(c4 % 5667), SUM(c4 % 5668), SUM(c4 % 5669),
  SUM(c4 % 5670), SUM(c4 % 5671)], 1)
 from mtup1 where c0 = 'foo' group by c0, c1 limit 10;
+
 reset gp_enable_multiphase_agg;
-reset optimizer_force_multistage_agg;
 
 -- MPP-29042 Multistage aggregation plans should have consistent targetlists in
 -- case of same column aliases and grouping on them.

--- a/src/test/regress/sql/bfv_partition_plans.sql
+++ b/src/test/regress/sql/bfv_partition_plans.sql
@@ -54,7 +54,6 @@ drop table mpp3061;
 --
 
 -- SETUP
-set optimizer_force_multistage_agg=off;
 create table mpp7980
 (
  month_id date,
@@ -81,7 +80,7 @@ select cust_type, subscription_status,count(distinct subscription_id),sum(voice_
 
 -- CLEANUP
 drop table mpp7980;
-reset optimizer_force_multistage_agg;
+
 
 -- ************ORCA ENABLED**********
 


### PR DESCRIPTION
This reverts commit 86d7da285c3fdd95d458d6a77b929c7d42220253.
Since enabling optimizer_force_multistage_aggs causing regression failures, hence reverting the changes. 

exp:
create table foo(id int, a bigint, b integer, c numeric);
insert into foo values(1,1,1,1),(2,2,2,2),(3,3,3,3);
explain select count(distinct a), sum(b) from foo; -- no plan
ERROR:  aggregate 2108 needs to have compatible input type and transition type

postgres=# select count(distinct a), sum(c) from foo; -- wrong result
 count | sum
-------+-----
     3 | NaN
(1 row)
postgres=# set optimizer=off;
SET
postgres=# select count(distinct a), sum(c) from foo;
 count | sum
-------+-----
     3 |   6
(1 row)

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
