### PR TITLE
Allow definition of lock mode for custom reloptions

### DIFF
--- a/contrib/bloom/blutils.c
+++ b/contrib/bloom/blutils.c
@@ -60,7 +60,8 @@ _PG_init(void)
 	/* Option for length of signature */
 	add_int_reloption(bl_relopt_kind, "length",
 					  "Length of signature in bits",
-					  DEFAULT_BLOOM_LENGTH, 1, MAX_BLOOM_LENGTH);
+					  DEFAULT_BLOOM_LENGTH, 1, MAX_BLOOM_LENGTH,
+					  AccessExclusiveLock);
 	bl_relopt_tab[0].optname = "length";
 	bl_relopt_tab[0].opttype = RELOPT_TYPE_INT;
 	bl_relopt_tab[0].offset = offsetof(BloomOptions, bloomLength);
@@ -71,7 +72,8 @@ _PG_init(void)
 		snprintf(buf, sizeof(buf), "col%d", i + 1);
 		add_int_reloption(bl_relopt_kind, buf,
 						  "Number of bits generated for each index column",
-						  DEFAULT_BLOOM_BITS, 1, MAX_BLOOM_BITS);
+						  DEFAULT_BLOOM_BITS, 1, MAX_BLOOM_BITS,
+						  AccessExclusiveLock);
 		bl_relopt_tab[i + 1].optname = MemoryContextStrdup(TopMemoryContext,
 														   buf);
 		bl_relopt_tab[i + 1].opttype = RELOPT_TYPE_INT;

--- a/src/backend/access/common/reloptions.c
+++ b/src/backend/access/common/reloptions.c
@@ -630,7 +630,8 @@ add_reloption(relopt_gen *newoption)
  *		(for types other than string)
  */
 static relopt_gen *
-allocate_reloption(bits32 kinds, int type, const char *name, const char *desc)
+allocate_reloption(bits32 kinds, int type, const char *name, const char *desc,
+				   LOCKMODE lockmode)
 {
 	MemoryContext oldcxt;
 	size_t		size;
@@ -667,6 +668,7 @@ allocate_reloption(bits32 kinds, int type, const char *name, const char *desc)
 	newoption->kinds = kinds;
 	newoption->namelen = strlen(name);
 	newoption->type = type;
+	newoption->lockmode = lockmode;
 
 	MemoryContextSwitchTo(oldcxt);
 
@@ -674,35 +676,17 @@ allocate_reloption(bits32 kinds, int type, const char *name, const char *desc)
 }
 
 /*
- * GPDB: the add_*_reloption() functions don't take 'lockmode' argument,but
- * we need to set it correctly for the GPDB-specific options. So use this
- * to set it after calling add_*_reloption() function.
- */
-void
-set_reloption_lockmode(const char *name, LOCKMODE lockmode)
-{
-	for (int i = num_custom_options - 1; i >= 0; i--)
-	{
-		if (strcmp(custom_options[i]->name, name) == 0)
-		{
-			custom_options[i]->lockmode = lockmode;
-			return;
-		}
-	}
-	elog(ERROR, "could not find reloption \"%s\"", name);
-}
-
-/*
  * add_bool_reloption
  *		Add a new boolean reloption
  */
 void
-add_bool_reloption(bits32 kinds, const char *name, const char *desc, bool default_val)
+add_bool_reloption(bits32 kinds, const char *name, const char *desc,
+				   bool default_val, LOCKMODE lockmode)
 {
 	relopt_bool *newoption;
 
 	newoption = (relopt_bool *) allocate_reloption(kinds, RELOPT_TYPE_BOOL,
-												   name, desc);
+												   name, desc, lockmode);
 	newoption->default_val = default_val;
 
 	add_reloption((relopt_gen *) newoption);
@@ -714,12 +698,12 @@ add_bool_reloption(bits32 kinds, const char *name, const char *desc, bool defaul
  */
 void
 add_int_reloption(bits32 kinds, const char *name, const char *desc, int default_val,
-				  int min_val, int max_val)
+				  int min_val, int max_val, LOCKMODE lockmode)
 {
 	relopt_int *newoption;
 
 	newoption = (relopt_int *) allocate_reloption(kinds, RELOPT_TYPE_INT,
-												  name, desc);
+												  name, desc, lockmode);
 	newoption->default_val = default_val;
 	newoption->min = min_val;
 	newoption->max = max_val;
@@ -732,13 +716,14 @@ add_int_reloption(bits32 kinds, const char *name, const char *desc, int default_
  *		Add a new float reloption
  */
 void
-add_real_reloption(bits32 kinds, const char *name, const char *desc, double default_val,
-				   double min_val, double max_val)
+add_real_reloption(bits32 kinds, const char *name, const char *desc,
+				   double default_val, double min_val, double max_val,
+				   LOCKMODE lockmode)
 {
 	relopt_real *newoption;
 
 	newoption = (relopt_real *) allocate_reloption(kinds, RELOPT_TYPE_REAL,
-												   name, desc);
+												   name, desc, lockmode);
 	newoption->default_val = default_val;
 	newoption->min = min_val;
 	newoption->max = max_val;
@@ -756,8 +741,9 @@ add_real_reloption(bits32 kinds, const char *name, const char *desc, double defa
  * the validation.
  */
 void
-add_string_reloption(bits32 kinds, const char *name, const char *desc, const char *default_val,
-					 validate_string_relopt validator)
+add_string_reloption(bits32 kinds, const char *name, const char *desc,
+					 const char *default_val, validate_string_relopt validator,
+					 LOCKMODE lockmode)
 {
 	relopt_string *newoption;
 
@@ -766,7 +752,7 @@ add_string_reloption(bits32 kinds, const char *name, const char *desc, const cha
 		(validator) (default_val);
 
 	newoption = (relopt_string *) allocate_reloption(kinds, RELOPT_TYPE_STRING,
-													 name, desc);
+													 name, desc, lockmode);
 	newoption->validate_cb = validator;
 	if (default_val)
 	{

--- a/src/backend/access/common/reloptions_gp.c
+++ b/src/backend/access/common/reloptions_gp.c
@@ -141,8 +141,8 @@ initialize_reloptions_gp(void)
 		add_bool_reloption(boolRelOpts_gp[i].gen.kinds,
 						   (char *) boolRelOpts_gp[i].gen.name,
 						   (char *) boolRelOpts_gp[i].gen.desc,
-						   boolRelOpts_gp[i].default_val);
-		set_reloption_lockmode(boolRelOpts_gp[i].gen.name, boolRelOpts_gp[i].gen.lockmode);
+						   boolRelOpts_gp[i].default_val,
+						   boolRelOpts_gp[i].gen.lockmode);
 	}
 
 	for (i = 0; intRelOpts_gp[i].gen.name; i++)
@@ -152,8 +152,8 @@ initialize_reloptions_gp(void)
 						  (char *) intRelOpts_gp[i].gen.desc,
 						  intRelOpts_gp[i].default_val,
 						  intRelOpts_gp[i].min,
-						  intRelOpts_gp[i].max);
-		set_reloption_lockmode(intRelOpts_gp[i].gen.name, intRelOpts_gp[i].gen.lockmode);
+						  intRelOpts_gp[i].max,
+						  intRelOpts_gp[i].gen.lockmode);
 	}
 
 	for (i = 0; realRelOpts_gp[i].gen.name; i++)
@@ -162,8 +162,8 @@ initialize_reloptions_gp(void)
 						   (char *) realRelOpts_gp[i].gen.name,
 						   (char *) realRelOpts_gp[i].gen.desc,
 						   realRelOpts_gp[i].default_val,
-						   realRelOpts_gp[i].min, realRelOpts_gp[i].max);
-		set_reloption_lockmode(realRelOpts_gp[i].gen.name, realRelOpts_gp[i].gen.lockmode);
+						   realRelOpts_gp[i].min, realRelOpts_gp[i].max,
+						   realRelOpts_gp[i].gen.lockmode);
 	}
 
 	for (i = 0; stringRelOpts_gp[i].gen.name; i++)
@@ -172,8 +172,8 @@ initialize_reloptions_gp(void)
 							 (char *) stringRelOpts_gp[i].gen.name,
 							 (char *) stringRelOpts_gp[i].gen.desc,
 							 NULL,
-							 stringRelOpts_gp[i].validate_cb);
-		set_reloption_lockmode(stringRelOpts_gp[i].gen.name, stringRelOpts_gp[i].gen.lockmode);
+							 stringRelOpts_gp[i].validate_cb,
+							 stringRelOpts_gp[i].gen.lockmode);
 	}
 }
 

--- a/src/include/access/reloptions.h
+++ b/src/include/access/reloptions.h
@@ -270,15 +270,16 @@ typedef struct
 
 extern relopt_kind add_reloption_kind(void);
 extern void add_bool_reloption(bits32 kinds, const char *name, const char *desc,
-							   bool default_val);
+							   bool default_val, LOCKMODE lockmode);
 extern void add_int_reloption(bits32 kinds, const char *name, const char *desc,
-							  int default_val, int min_val, int max_val);
+							  int default_val, int min_val, int max_val,
+							  LOCKMODE lockmode);
 extern void add_real_reloption(bits32 kinds, const char *name, const char *desc,
-							   double default_val, double min_val, double max_val);
+							   double default_val, double min_val,double max_val,
+							   LOCKMODE lockmode);
 extern void add_string_reloption(bits32 kinds, const char *name, const char *desc,
-								 const char *default_val, validate_string_relopt validator);
-
-extern void set_reloption_lockmode(const char *name, LOCKMODE lockmode);
+								 const char *default_val, validate_string_relopt validator,
+								 LOCKMODE lockmode);
 
 extern Datum transformRelOptions(Datum oldOptions, List *defList,
 								 const char *namspace, char *validnsps[],


### PR DESCRIPTION
This patch is derived from the postgres upstream [0],
the main idea is for each add_<type>_reloption and
allocate_reloption, add a LOCKMODE as a parameter,
so that we can initialize the option's lock mode
when allocating the struct.

we can get ride of *set_reloption_lockmode* then.

[0]: https://github.com/postgres/postgres/commit/69f94108079d70093b59096a3ae0ad82c842b4c0

Signed-off-by: Junwang Zhao <zhjwpku@gmail.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
