### PR TITLE
Check GUC variables if match the built-in default accurately

### DIFF
--- a/contrib/auto_explain/expected/auto_explain.out
+++ b/contrib/auto_explain/expected/auto_explain.out
@@ -101,6 +101,7 @@ Finalize Aggregate  (cost=35148.64..35148.65 rows=1 width=8) (actual rows=1 loop
                           ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..53.05 rows=1001 width=0) (actual rows=1001 loops=1)
                                 ->  Seq Scan on auto_explain_test.t2  (cost=0.00..13.01 rows=334 width=0) (actual rows=340 loops=1)
 Optimizer: Postgres query optimizer
+Settings: enable_nestloop = 'on', optimizer = 'off'
   (slice0)    Executor memory: 131K bytes.
   (slice1)    Executor memory: 152K bytes avg x 3 workers, 152K bytes max (seg0).
   (slice2)    Executor memory: 42K bytes avg x 3 workers, 42K bytes max (seg0).

--- a/contrib/auto_explain/expected/auto_explain_optimizer.out
+++ b/contrib/auto_explain/expected/auto_explain_optimizer.out
@@ -101,6 +101,7 @@ Finalize Aggregate  (cost=0.00..1326086.34 rows=1 width=8) (actual rows=1 loops=
                           ->  Seq Scan on auto_explain_test.t1  (cost=0.00..431.01 rows=334 width=1) (actual rows=340 loops=1)
                     ->  Seq Scan on auto_explain_test.t2  (cost=0.00..431.01 rows=334 width=1) (actual rows=340 loops=1002)
 Optimizer: Pivotal Optimizer (GPORCA)
+Settings: enable_nestloop = 'on'
   (slice0)    Executor memory: 67K bytes.
   (slice1)    Executor memory: 119K bytes avg x 3 workers, 119K bytes max (seg0).
   (slice2)    Executor memory: 42K bytes avg x 3 workers, 42K bytes max (seg0).

--- a/src/backend/commands/explain.c
+++ b/src/backend/commands/explain.c
@@ -774,8 +774,8 @@ ExplainPrintSettings(ExplainState *es)
 				continue;
 
 			/* Note the non-default GP GUCs */
-			if (gconf->source > PGC_S_DEFAULT)
-				lappend(gp_gucs, cell);
+			if (is_guc_modified(gconf))
+				gp_gucs = lappend(gp_gucs, lfirst(cell));
 		}
 
 		if (list_length(gp_gucs) > 0)

--- a/src/include/utils/guc_tables.h
+++ b/src/include/utils/guc_tables.h
@@ -313,6 +313,7 @@ extern void build_guc_variables(void);
 extern const char *config_enum_lookup_by_value(struct config_enum *record, int val);
 extern bool config_enum_lookup_by_name(struct config_enum *record,
 									   const char *value, int *retval);
+extern bool is_guc_modified(struct config_generic *conf);
 extern struct config_generic **get_explain_guc_options(int *num);
 
 extern bool parse_int(const char *value, int *result, int flags, const char **hintmsg);

--- a/src/test/regress/expected/explain_format.out
+++ b/src/test/regress/expected/explain_format.out
@@ -261,6 +261,48 @@ QUERY PLAN
 (1 row)
 SET random_page_cost = 1;
 SET cpu_index_tuple_cost = 0.1;
+EXPLAIN (FORMAT YAML, VERBOSE) SELECT * from boxes;
+QUERY PLAN
+- Plan: 
+    Node Type: "Gather Motion"
+    Senders: 3
+    Receivers: 1
+    Slice: 1
+    Segments: 3
+    Gang Type: "primary reader"
+    Parallel Aware: false
+    Startup Cost: 0.00
+    Total Cost: 1332.33
+    Plan Rows: 77900
+    Plan Width: 12
+    Output: 
+      - "id"
+      - "apple_id"
+      - "location_id"
+    Plans: 
+      - Node Type: "Seq Scan"
+        Parent Relationship: "Outer"
+        Slice: 1
+        Segments: 3
+        Gang Type: "primary reader"
+        Parallel Aware: false
+        Relation Name: "boxes"
+        Schema: "public"
+        Alias: "boxes"
+        Startup Cost: 0.00
+        Total Cost: 293.67
+        Plan Rows: 25967
+        Plan Width: 12
+        Output: 
+          - "id"
+          - "apple_id"
+          - "location_id"
+  Optimizer: "Postgres query optimizer"
+  Settings: 
+    cpu_index_tuple_cost: "0.1"
+    optimizer: "off"
+    random_page_cost: "1"
+(1 row)
 EXPLAIN (FORMAT YAML, VERBOSE, SETTINGS ON) SELECT * from boxes;
 QUERY PLAN
 - Plan: 
@@ -301,9 +343,8 @@ QUERY PLAN
   Settings: 
     cpu_index_tuple_cost: "0.1"
     random_page_cost: "1"
+    optimizer: "off"
 (1 row)
-RESET random_page_cost;
-RESET cpu_index_tuple_cost;
 --- Check Explain Analyze YAML output that include the slices information
 -- explain_processing_off
 EXPLAIN (ANALYZE, FORMAT YAML) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;
@@ -531,12 +572,15 @@ Gather Motion 3:1  (slice1; segments: 3)  (cost=2197.59..3301.17 rows=77900 widt
         ->  Seq Scan on public.boxes  (cost=0.00..293.67 rows=25967 width=12) (never executed)
               Output: id, apple_id, location_id
 Optimizer: Postgres query optimizer
+Settings: cpu_index_tuple_cost = '0.1', optimizer = 'off', random_page_cost = '1'
 Planning Time: 0.397 ms
   (slice0)    Executor memory: 40K bytes.
   (slice1)    Executor memory: 59K bytes avg x 3 workers, 59K bytes max (seg0).  Work_mem: 59K bytes max.
 Memory used:  128000kB
 Execution Time: 0.782 ms
-(17 rows)
+(18 rows)
+RESET random_page_cost;
+RESET cpu_index_tuple_cost;
 -- explain_processing_on
 --
 -- Test a simple case with JSON and XML output, too.

--- a/src/test/regress/expected/explain_format_optimizer.out
+++ b/src/test/regress/expected/explain_format_optimizer.out
@@ -243,6 +243,47 @@ QUERY PLAN
 (1 row)
 SET random_page_cost = 1;
 SET cpu_index_tuple_cost = 0.1;
+EXPLAIN (FORMAT YAML, VERBOSE) SELECT * from boxes;
+QUERY PLAN
+- Plan: 
+    Node Type: "Gather Motion"
+    Senders: 3
+    Receivers: 1
+    Slice: 1
+    Segments: 3
+    Gang Type: "primary reader"
+    Parallel Aware: false
+    Startup Cost: 0.00
+    Total Cost: 431.00
+    Plan Rows: 1
+    Plan Width: 12
+    Output: 
+      - "id"
+      - "apple_id"
+      - "location_id"
+    Plans: 
+      - Node Type: "Seq Scan"
+        Parent Relationship: "Outer"
+        Slice: 1
+        Segments: 3
+        Gang Type: "primary reader"
+        Parallel Aware: false
+        Relation Name: "boxes"
+        Schema: "public"
+        Alias: "boxes"
+        Startup Cost: 0.00
+        Total Cost: 431.00
+        Plan Rows: 1
+        Plan Width: 12
+        Output: 
+          - "id"
+          - "apple_id"
+          - "location_id"
+  Optimizer: "Pivotal Optimizer (GPORCA)"
+  Settings: 
+    cpu_index_tuple_cost: "0.1"
+    random_page_cost: "1"
+(1 row)
 EXPLAIN (FORMAT YAML, VERBOSE, SETTINGS ON) SELECT * from boxes;
 QUERY PLAN
 - Plan: 
@@ -284,8 +325,6 @@ QUERY PLAN
     cpu_index_tuple_cost: "0.1"
     random_page_cost: "1"
 (1 row)
-RESET random_page_cost;
-RESET cpu_index_tuple_cost;
 --- Check Explain Analyze YAML output that include the slices information
 -- explain_processing_off
 EXPLAIN (ANALYZE, FORMAT YAML) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;
@@ -481,12 +520,15 @@ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=12) (a
         ->  Seq Scan on public.boxes  (cost=0.00..431.00 rows=1 width=12) (never executed)
               Output: id, apple_id, location_id
 Optimizer: Pivotal Optimizer (GPORCA)
+Settings: cpu_index_tuple_cost = '0.1', random_page_cost = '1'
 Planning Time: 4.622 ms
   (slice0)    Executor memory: 40K bytes.
   (slice1)    Executor memory: 59K bytes avg x 3 workers, 59K bytes max (seg0).  Work_mem: 59K bytes max.
 Memory used:  128000kB
 Execution Time: 0.846 ms
-(17 rows)
+(18 rows)
+RESET random_page_cost;
+RESET cpu_index_tuple_cost;
 -- explain_processing_on
 --
 -- Test a simple case with JSON and XML output, too.

--- a/src/test/regress/expected/fast_default.out
+++ b/src/test/regress/expected/fast_default.out
@@ -306,8 +306,9 @@ SELECT c_bigint, c_text FROM T WHERE c_bigint = -1 LIMIT 1;
                ->  Seq Scan on fast_default.t
                      Output: c_bigint, c_text
                      Filter: (t.c_bigint = '-1'::integer)
- Optimizer: Pivotal Optimizer (GPORCA)
-(10 rows)
+ Optimizer: Postgres query optimizer
+ Settings: optimizer = 'off', seq_page_cost = '1'
+(11 rows)
 
 SELECT c_bigint, c_text FROM T WHERE c_text = 'hello' LIMIT 1;
  c_bigint | c_text 
@@ -327,8 +328,9 @@ EXPLAIN (VERBOSE TRUE, COSTS FALSE) SELECT c_bigint, c_text FROM T WHERE c_text 
                ->  Seq Scan on fast_default.t
                      Output: c_bigint, c_text
                      Filter: (t.c_text = 'hello'::text)
- Optimizer: Pivotal Optimizer (GPORCA)
-(10 rows)
+ Optimizer: Postgres query optimizer
+ Settings: optimizer = 'off', seq_page_cost = '1'
+(11 rows)
 
 -- COALESCE
 SELECT COALESCE(c_bigint, pk), COALESCE(c_text, pk::text)
@@ -387,8 +389,9 @@ SELECT * FROM T ORDER BY c_bigint, c_text, pk LIMIT 10;
                      Sort Key: t.c_bigint, t.c_text, t.pk
                      ->  Seq Scan on fast_default.t
                            Output: pk, c_bigint, c_text
- Optimizer: Pivotal Optimizer (GPORCA)
-(13 rows)
+ Optimizer: Postgres query optimizer
+ Settings: optimizer = 'off', seq_page_cost = '1'
+(14 rows)
 
 -- LIMIT
 SELECT * FROM T WHERE c_bigint > -1 ORDER BY c_bigint, c_text, pk LIMIT 10;
@@ -423,8 +426,9 @@ SELECT * FROM T WHERE c_bigint > -1 ORDER BY c_bigint, c_text, pk LIMIT 10;
                      ->  Seq Scan on fast_default.t
                            Output: pk, c_bigint, c_text
                            Filter: (t.c_bigint > '-1'::integer)
- Optimizer: Pivotal Optimizer (GPORCA)
-(14 rows)
+ Optimizer: Postgres query optimizer
+ Settings: optimizer = 'off', seq_page_cost = '1'
+(15 rows)
 
 --  DELETE with RETURNING
 DELETE FROM T WHERE pk BETWEEN 10 AND 20 RETURNING *;
@@ -455,7 +459,8 @@ DELETE FROM T WHERE pk BETWEEN 10 AND 20 RETURNING *;
                Output: ctid, gp_segment_id
                Filter: ((t.pk >= 10) AND (t.pk <= 20))
  Optimizer: Postgres query optimizer
-(8 rows)
+ Settings: optimizer = 'off', seq_page_cost = '1'
+(9 rows)
 
 -- UPDATE
 UPDATE T SET c_text = '"' || c_text || '"'  WHERE pk < 10;

--- a/src/test/regress/sql/explain_format.sql
+++ b/src/test/regress/sql/explain_format.sql
@@ -86,9 +86,8 @@ EXPLAIN (ANALYZE) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.appl
 EXPLAIN (FORMAT YAML) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;
 SET random_page_cost = 1;
 SET cpu_index_tuple_cost = 0.1;
+EXPLAIN (FORMAT YAML, VERBOSE) SELECT * from boxes;
 EXPLAIN (FORMAT YAML, VERBOSE, SETTINGS ON) SELECT * from boxes;
-RESET random_page_cost;
-RESET cpu_index_tuple_cost;
 
 --- Check Explain Analyze YAML output that include the slices information
 -- explain_processing_off
@@ -100,6 +99,8 @@ EXPLAIN (ANALYZE, FORMAT YAML) SELECT * from boxes LEFT JOIN apples ON apples.id
 -- end_matchsubs
 --- Check explain analyze sort infomation in verbose mode
 EXPLAIN (ANALYZE, VERBOSE) SELECT * from boxes ORDER BY apple_id;
+RESET random_page_cost;
+RESET cpu_index_tuple_cost;
 -- explain_processing_on
 
 --

--- a/src/test/regress/sql/fast_default.sql
+++ b/src/test/regress/sql/fast_default.sql
@@ -2,6 +2,18 @@
 -- ALTER TABLE ADD COLUMN DEFAULT test
 --
 
+-- start_ignore
+
+-- GPDB currently prints a "Settings: " line in the EXPLAIN output, if
+-- there any GUCs are set. gpdiff masks them out, but it does not mask
+-- out the differences in "(xx rows)" lines that happens if there is
+-- no Settings line at all. The expected output does include some Settings.
+-- To make those "(xx rows)" lines stable, set a GUC. Doesn't matter which
+-- one, as long as it's printed in the Settings lines.
+set seq_page_cost=1.001;
+
+-- end_ignore
+
 SET search_path = fast_default;
 CREATE SCHEMA fast_default;
 CREATE TABLE m(id OID);


### PR DESCRIPTION
EXPLAIN prints non-default GUCs on verbose mode, before this commit it actually
checked the source of the setting but not the value.

This commit borrows the upstream implementation and tests on the YAML and
unaligned mode. (gpdiff masks the settings out on normal mode)

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [x] Pass `make installcheck`