### PR TITLE
Change optimizer_array_expansion_threshold default value to 20

### DIFF
--- a/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
+++ b/gpdb-doc/dita/ref_guide/config_params/guc-list.xml
@@ -7084,9 +7084,9 @@
         in the query predicate contains more than the number elements specified by parameter, GPORCA
         disables the transformation of the predicate into its disjunctive normal form during query
         optimization. </p>
-      <p>The default value is 100. </p>
+      <p>The default value is 20. </p>
       <p>For example, when GPORCA is running a query that contains an <codeph>IN</codeph> clause
-        with more than 100 elements, GPORCA does not transform the predicate into its disjunctive
+        with more than 20 elements, GPORCA does not transform the predicate into its disjunctive
         normal form during query optimization to reduce optimization time consume less memory. The
         difference in query processing can be seen in the filter condition for the
           <codeph>IN</codeph> clause of the query <codeph>EXPLAIN</codeph> plan.</p>
@@ -7110,7 +7110,7 @@
           <tbody>
             <row>
               <entry colname="col1">Integer > 0</entry>
-              <entry colname="col2">25</entry>
+              <entry colname="col2">20</entry>
               <entry colname="col3">master<p>session</p><p>reload</p></entry>
             </row>
           </tbody>

--- a/gpdb-doc/markdown/ref_guide/config_params/guc-list.html.md
+++ b/gpdb-doc/markdown/ref_guide/config_params/guc-list.html.md
@@ -2014,9 +2014,9 @@ For information about the Postgres Planner and GPORCA, see [Querying Data](../..
 
 When GPORCA is enabled \(the default\) and is processing a query that contains a predicate with a constant array, the `optimizer_array_expansion_threshold` parameter limits the optimization process based on the number of constants in the array. If the array in the query predicate contains more than the number elements specified by parameter, GPORCA disables the transformation of the predicate into its disjunctive normal form during query optimization.
 
-The default value is 100.
+The default value is 20.
 
-For example, when GPORCA is running a query that contains an `IN` clause with more than 100 elements, GPORCA does not transform the predicate into its disjunctive normal form during query optimization to reduce optimization time consume less memory. The difference in query processing can be seen in the filter condition for the `IN` clause of the query `EXPLAIN` plan.
+For example, when GPORCA is running a query that contains an `IN` clause with more than 20 elements, GPORCA does not transform the predicate into its disjunctive normal form during query optimization to reduce optimization time consume less memory. The difference in query processing can be seen in the filter condition for the `IN` clause of the query `EXPLAIN` plan.
 
 Changing the value of this parameter changes the trade-off between a shorter optimization time and lower memory consumption, and the potential benefits from constraint derivation during query optimization, for example conflict detection and partition elimination.
 
@@ -2024,7 +2024,7 @@ The parameter can be set for a database system, an individual database, or a ses
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Integer \> 0|25|master, session, reload|
+|Integer \> 0|20|master, session, reload|
 
 ## <a id="optimizer_control"></a>optimizer\_control 
 

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -3950,7 +3950,7 @@ struct config_int ConfigureNamesInt_gp[] =
 			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_array_expansion_threshold,
-		100, 0, INT_MAX,
+		20, 0, INT_MAX,
 		NULL, NULL, NULL
 	},
 


### PR DESCRIPTION
It is expensive to derive constraints and stats if we expand the large array
into CNF/DNF form. 100 is still a large default value, so lower it down to 20
to get better performance for most queries.
Ref: GPQP-31
