### PR TITLE
Fix a panic case in the greenplum_fdw test.

### DIFF
--- a/src/backend/optimizer/util/pathnode.c
+++ b/src/backend/optimizer/util/pathnode.c
@@ -1578,6 +1578,7 @@ create_merge_append_path(PlannerInfo *root,
  * Set the locus of an Append or MergeAppend path.
  *
  * This modifies the 'subpaths', costs fields, and locus of 'pathnode'.
+ * It will return false if fails to create motion for parameterized path.
  */
 static bool
 set_append_path_locus(PlannerInfo *root, Path *pathnode, RelOptInfo *rel,
@@ -1910,7 +1911,6 @@ set_append_path_locus(PlannerInfo *root, Path *pathnode, RelOptInfo *rel,
 			if (subpath == NULL)
 				return false;
 		}
-
 
 		pathnode->sameslice_relids = bms_union(pathnode->sameslice_relids, subpath->sameslice_relids);
 

--- a/src/backend/optimizer/util/pathnode.c
+++ b/src/backend/optimizer/util/pathnode.c
@@ -71,7 +71,7 @@ static List *reparameterize_pathlist_by_child(PlannerInfo *root,
 											  List *pathlist,
 											  RelOptInfo *child_rel);
 
-static void set_append_path_locus(PlannerInfo *root, Path *pathnode, RelOptInfo *rel,
+static bool set_append_path_locus(PlannerInfo *root, Path *pathnode, RelOptInfo *rel,
 					  List *pathkeys);
 static CdbPathLocus
 adjust_modifytable_subpaths(PlannerInfo *root, CmdType operation,
@@ -1382,7 +1382,8 @@ create_append_path(PlannerInfo *root,
 	else
 		pathnode->limit_tuples = -1.0;
 
-    set_append_path_locus(root, (Path *) pathnode, rel, NIL);
+	if (!set_append_path_locus(root, (Path *) pathnode, rel, NIL))
+		return NULL;
 
 	foreach(l, pathnode->subpaths)
 	{
@@ -1508,7 +1509,8 @@ create_merge_append_path(PlannerInfo *root,
 	 * Add Motions to the child nodes as needed, and determine the locus
 	 * of the MergeAppend itself.
 	 */
-	set_append_path_locus(root, (Path *) pathnode, rel, pathkeys);
+	if (!set_append_path_locus(root, (Path *) pathnode, rel, pathkeys))
+		return NULL;
 
 	/*
 	 * Add up the sizes and costs of the input paths.
@@ -1577,7 +1579,7 @@ create_merge_append_path(PlannerInfo *root,
  *
  * This modifies the 'subpaths', costs fields, and locus of 'pathnode'.
  */
-static void
+static bool
 set_append_path_locus(PlannerInfo *root, Path *pathnode, RelOptInfo *rel,
 					  List *pathkeys)
 {
@@ -1609,7 +1611,7 @@ set_append_path_locus(PlannerInfo *root, Path *pathnode, RelOptInfo *rel,
 	if (!subpaths)
 	{
 		CdbPathLocus_MakeGeneral(&pathnode->locus);
-		return;
+		return true;
 	}
 
 	/*
@@ -1904,7 +1906,11 @@ set_append_path_locus(PlannerInfo *root, Path *pathnode, RelOptInfo *rel,
 				subpath = cdbpath_create_motion_path(root, subpath, pathkeys, false, targetlocus);
 			else
 				subpath = cdbpath_create_motion_path(root, subpath, NIL, false, targetlocus);
+
+			if (subpath == NULL)
+				return false;
 		}
+
 
 		pathnode->sameslice_relids = bms_union(pathnode->sameslice_relids, subpath->sameslice_relids);
 
@@ -1919,6 +1925,8 @@ set_append_path_locus(PlannerInfo *root, Path *pathnode, RelOptInfo *rel,
 	pathnode->locus = targetlocus;
 
 	*subpaths_out = new_subpaths;
+
+	return true;
 }
 
 /*


### PR DESCRIPTION
It happens in the below query:
 explain (verbose, costs off)
     select foo.f1, loct1.f1 from foo join loct1 on (foo.f1 = loct1.f1) order by foo.f2 offset 10 limit 10;
select foo.f1, loct1.f1 from foo join loct1 on (foo.f1 = loct1.f1) order by foo.f2 offset 10 limit 10;

The reason is that set_append_path_locus()->cdbpath_create_motion_path()
returns NULL (i.e. can not create a motion to reach the target locus
requirement) but set_append_path_locus() does not handle this bad case and
panic due to this (i.e. when accessing subpath->sameslice_relids while subpath
is NULL). This happens because in the above query, foo has a child with foreign
table (and a local heap table child additionally) and the append node tries to
create a parameterized path (one is an index scan path and another is the
foreign scan path; the target locus is Entry).  This happens when
use_remote_estimate is set on the foreign table. Per postgresGetForeignPaths()
code only when this option is set, parameterized path for foreign scan is
considered.

Fixing this by returning NULL path for the case that set_append_path_locus()
returns false.  Callers of them should take care of the NULL returning cases.

The test case will be covered by greenplum_fdw extension's test.

Co-authored-by: Huiliang.liu <lhuiliang@vmware.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
