### PR TITLE
FIXME: Support for explicit COLLATE type C for TEXTARRAYOID

### DIFF
--- a/src/backend/optimizer/util/walkers.c
+++ b/src/backend/optimizer/util/walkers.c
@@ -895,8 +895,12 @@ check_collation_walker(Node *node, check_collation_context *context)
 			{
 				if (collation != C_COLLATION_OID)
 					context->foundNonDefaultCollation = 1;
-			}
-			else if (InvalidOid != collation && DEFAULT_COLLATION_OID != collation)
+			} else if (type == TEXTARRAYOID) {
+                          if (collation != DEFAULT_COLLATION_OID &&
+                              collation != C_COLLATION_OID) {
+                            context->foundNonDefaultCollation = 1;
+                          }
+                        } else if (InvalidOid != collation && DEFAULT_COLLATION_OID != collation)
 			{
 				context->foundNonDefaultCollation = 1;
 			}

--- a/src/test/regress/sql/arrays.sql
+++ b/src/test/regress/sql/arrays.sql
@@ -785,11 +785,7 @@ GROUP BY l.id
 ORDER BY l.id;
 
 -- Array types are GPDB hashable
--- start_ignore
--- GPDB_12_MERGE_FIXME: Add an explicit COLLATE clause to cause ORCA to 
--- fallback instead of adding an optimizer.out file. Re-visit and fix 
--- when the collation work for ORCA is picked up again.
--- end_ignore
+
 CREATE TEMP TABLE text_array_table (t text[]) DISTRIBUTED BY ( t );
 INSERT INTO text_array_table VALUES ('{foo}' COLLATE "C");
 


### PR DESCRIPTION

The default collationID for type TEXTARRAYOID that orca assigns is DEFAULT_COLLATION_OID. 
Queries used to fallback when there is explicit collation "C" on TEXTARRAYOID .

This PR is trying to allow  allow explicite collate "C" type for TEXTARRAYOID.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
