### PR TITLE
Update gp_create_restore_point() catalog function

### DIFF
--- a/src/backend/access/transam/xlogfuncs_gp.c
+++ b/src/backend/access/transam/xlogfuncs_gp.c
@@ -61,7 +61,7 @@ gp_create_restore_point(PG_FUNCTION_ARGS)
 
 		/* create tupdesc for result */
 		tupdesc = CreateTemplateTupleDesc(2);
-		TupleDescInitEntry(tupdesc, (AttrNumber) 1, "segment_id",
+		TupleDescInitEntry(tupdesc, (AttrNumber) 1, "gp_segment_id",
 						   INT2OID, -1, 0);
 		TupleDescInitEntry(tupdesc, (AttrNumber) 2, "restore_lsn",
 						   LSNOID, -1, 0);
@@ -74,7 +74,7 @@ gp_create_restore_point(PG_FUNCTION_ARGS)
 		context->index = 0;
 		funcctx->user_fctx = (void *) context;
 
-		if (!IS_QUERY_DISPATCHER())
+		if (!IS_QUERY_DISPATCHER() || Gp_role != GP_ROLE_DISPATCH)
 			elog(ERROR,
 				 "cannot use gp_create_restore_point() when not in QD mode");
 
@@ -107,7 +107,7 @@ gp_create_restore_point(PG_FUNCTION_ARGS)
 
 	/*
 	 * Using SRF to return all the segment LSN information of the form
-	 * {segment_id, restore_lsn}
+	 * {gp_segment_id, restore_lsn}
 	 */
 	funcctx = SRF_PERCALL_SETUP();
 	context = (Context *) funcctx->user_fctx;

--- a/src/include/catalog/catversion.h
+++ b/src/include/catalog/catversion.h
@@ -56,6 +56,6 @@
  */
 
 /*							3yyymmddN */
-#define CATALOG_VERSION_NO	302208291
+#define CATALOG_VERSION_NO	302208301
 
 #endif

--- a/src/include/catalog/pg_proc.dat
+++ b/src/include/catalog/pg_proc.dat
@@ -11530,7 +11530,8 @@
    proname => 'cdblegacyhash_anyenum', prorettype => 'int4', proargtypes => 'anyenum', prosrc => 'cdblegacyhash_anyenum' },
 
 { oid => 6998, descr => 'Create a named restore point on all segments',
-   proname => 'gp_create_restore_point', prorows => '1000', proretset => 't', proparallel => 'u', provolatile => 'v', prorettype => 'record', proargtypes => 'text', prosrc => 'gp_create_restore_point' },
+   proname => 'gp_create_restore_point', prorows => '1000', proretset => 't', proparallel => 'u', provolatile => 'v', prorettype => 'record', proargtypes => 'text', proexeclocation => 'c',
+   proallargtypes => '{text,int2,pg_lsn}', proargmodes => '{i,o,o}', proargnames => '{restore_point_name,gp_segment_id,restore_lsn}', prosrc => 'gp_create_restore_point' },
 
 { oid => 7001, descr => 'Switch WAL segment files on all segments',
    proname => 'gp_switch_wal', prorows => '1000', proretset => 't', proparallel => 'u', provolatile => 'v', prorettype => 'record', proargtypes => '', proexeclocation => 'c',

--- a/src/test/gpdb_pitr/expected/gpdb_pitr_setup.out
+++ b/src/test/gpdb_pitr/expected/gpdb_pitr_setup.out
@@ -51,7 +51,7 @@ DELETE 10
 BEGIN
 4: INSERT INTO gpdb_two_phase_commit_after_restore_point SELECT generate_series(1, 10);
 INSERT 10
-4&: SELECT segment_id, count(*) FROM gp_create_restore_point('test_restore_point') AS r(segment_id smallint, restore_lsn pg_lsn) GROUP BY segment_id ORDER BY segment_id;  <waiting ...>
+4&: SELECT gp_segment_id, count(*) FROM gp_create_restore_point('test_restore_point') GROUP BY gp_segment_id ORDER BY gp_segment_id;  <waiting ...>
 1: SELECT gp_wait_until_triggered_fault('gp_create_restore_point_acquired_lock', 1, 1);
  gp_wait_until_triggered_fault 
 -------------------------------
@@ -97,12 +97,12 @@ INSERT 1
  Success:        
 (1 row)
 4<:  <... completed>
- segment_id | count 
-------------+-------
- -1         | 1     
- 0          | 1     
- 1          | 1     
- 2          | 1     
+ gp_segment_id | count 
+---------------+-------
+ -1            | 1     
+ 0             | 1     
+ 1             | 1     
+ 2             | 1     
 (4 rows)
 4: COMMIT;
 COMMIT

--- a/src/test/gpdb_pitr/expected/test_gp_create_restore_point.out
+++ b/src/test/gpdb_pitr/expected/test_gp_create_restore_point.out
@@ -1,0 +1,77 @@
+-- Test that gp_create_restore_point() creates a restore point WAL record
+-- on the coordinator and active primary segments.
+-- start_matchignore
+--
+-- # ignore NOTICE outputs from the test plpython function
+-- m/NOTICE\:.*pg_waldump.*/
+--
+-- end_matchignore
+-- Create plpython function that will run pg_waldump on given WAL segment
+-- file and check that the given restore point record exists or not.
+CREATE EXTENSION IF NOT EXISTS plpython3u;
+CREATE OR REPLACE FUNCTION check_restore_point_record_generated(current_walfile_path text, restore_point_name text)
+RETURNS bool AS $$
+    import os
+
+    cmd = 'pg_waldump -r xlog %s 2> /dev/null | grep %s' % (current_walfile_path, restore_point_name)
+    plpy.notice('Running: %s' % cmd) # useful debug info that is match ignored
+    rc = os.system(cmd)
+
+    return (rc == 0)
+$$ LANGUAGE plpython3u VOLATILE;
+-- Verify that there is currently no restore point record named
+-- test_gp_create_restore_point in the coordinator's and active primary
+-- segments' current WAL segment file. Running pg_walfile_name here() is
+-- okay due to the requirement of a fresh gpdemo cluster so timeline ids
+-- should all be 1.
+SELECT w.gp_segment_id,
+       check_restore_point_record_generated(c.datadir || '/pg_wal/' || w.pg_walfile_name, 'test_gp_create_restore_point') AS record_found
+FROM gp_segment_configuration c,
+     (SELECT -1 AS gp_segment_id, pg_walfile_name(pg_current_wal_lsn())
+     UNION ALL
+     SELECT gp_segment_id, pg_walfile_name(pg_current_wal_lsn())
+     FROM gp_dist_random('gp_id')) w
+WHERE c.content = w.gp_segment_id AND c.role = 'p'
+ORDER BY w.gp_segment_id;
+ gp_segment_id | record_found 
+---------------+--------------
+            -1 | f
+             0 | f
+             1 | f
+             2 | f
+(4 rows)
+
+-- Create the restore point records
+SELECT true FROM gp_create_restore_point('test_gp_create_restore_point');
+ bool 
+------
+ t
+ t
+ t
+ t
+(4 rows)
+
+-- Verify that the restore point records have been created on the
+-- coordinator and active primary segments.
+SELECT w.gp_segment_id,
+       check_restore_point_record_generated(c.datadir || '/pg_wal/' || w.pg_walfile_name, 'test_gp_create_restore_point') AS record_found
+FROM gp_segment_configuration c,
+     (SELECT -1 AS gp_segment_id, pg_walfile_name(pg_current_wal_lsn())
+     UNION ALL
+     SELECT gp_segment_id, pg_walfile_name(pg_current_wal_lsn())
+     FROM gp_dist_random('gp_id')) w
+WHERE c.content = w.gp_segment_id AND c.role = 'p'
+ORDER BY w.gp_segment_id;
+ gp_segment_id | record_found 
+---------------+--------------
+            -1 | t
+             0 | t
+             1 | t
+             2 | t
+(4 rows)
+
+-- test simple gp_create_restore_point() error scenarios
+SELECT gp_create_restore_point('this_should_fail') FROM gp_dist_random('gp_id');
+ERROR:  function with EXECUTE ON restrictions cannot be used in the SELECT list of a query with FROM
+CREATE TABLE this_ctas_should_fail AS SELECT gp_segment_id AS contentid, restore_lsn FROM gp_create_restore_point('this_should_fail');
+ERROR:  cannot use gp_create_restore_point() when not in QD mode (xlogfuncs_gp.c:LINE_NUM)

--- a/src/test/gpdb_pitr/expected/test_gp_switch_wal.out
+++ b/src/test/gpdb_pitr/expected/test_gp_switch_wal.out
@@ -2,14 +2,6 @@
 -- constructed on the individual segments so that their timeline ids are
 -- used instead of each result having the same timeline id.
 
--- start_matchsubs
---
--- # remove line number and entrydb in error message
--- m/\(xlogfuncs_gp\.c\:\d+.*/
--- s/\(xlogfuncs_gp\.c:\d+.*/\(xlogfuncs_gp\.c:LINE_NUM\)/
---
--- end_matchsubs
-
 -- timeline ids prior to failover/failback should all be 1 due to the
 -- test requirement of having a fresh gpdemo cluster with mirrors
 SELECT gp_segment_id, substring(pg_walfile_name, 1, 8) FROM gp_switch_wal() ORDER BY gp_segment_id;

--- a/src/test/gpdb_pitr/init_file_gpdb_pitr
+++ b/src/test/gpdb_pitr/init_file_gpdb_pitr
@@ -1,0 +1,7 @@
+-- start_matchsubs
+
+# remove line number and entrydb in error message
+m/\(xlogfuncs_gp\.c\:\d+.*/
+s/\(xlogfuncs_gp\.c:\d+.*/\(xlogfuncs_gp\.c:LINE_NUM\)/
+
+-- end_matchsubs

--- a/src/test/gpdb_pitr/sql/gpdb_pitr_setup.sql
+++ b/src/test/gpdb_pitr/sql/gpdb_pitr_setup.sql
@@ -29,7 +29,7 @@ INSERT INTO gpdb_one_phase_commit VALUES (1);
 -- so it will not show up later during PITR.
 4: BEGIN;
 4: INSERT INTO gpdb_two_phase_commit_after_restore_point SELECT generate_series(1, 10);
-4&: SELECT segment_id, count(*) FROM gp_create_restore_point('test_restore_point') AS r(segment_id smallint, restore_lsn pg_lsn) GROUP BY segment_id ORDER BY segment_id;
+4&: SELECT gp_segment_id, count(*) FROM gp_create_restore_point('test_restore_point') GROUP BY gp_segment_id ORDER BY gp_segment_id;
 1: SELECT gp_wait_until_triggered_fault('gp_create_restore_point_acquired_lock', 1, 1);
 
 -- Distributed commit record will not be written; commit blocked by

--- a/src/test/gpdb_pitr/sql/test_gp_create_restore_point.sql
+++ b/src/test/gpdb_pitr/sql/test_gp_create_restore_point.sql
@@ -1,0 +1,57 @@
+-- Test that gp_create_restore_point() creates a restore point WAL record
+-- on the coordinator and active primary segments.
+
+-- start_matchignore
+--
+-- # ignore NOTICE outputs from the test plpython function
+-- m/NOTICE\:.*pg_waldump.*/
+--
+-- end_matchignore
+
+-- Create plpython function that will run pg_waldump on given WAL segment
+-- file and check that the given restore point record exists or not.
+CREATE EXTENSION IF NOT EXISTS plpython3u;
+CREATE OR REPLACE FUNCTION check_restore_point_record_generated(current_walfile_path text, restore_point_name text)
+RETURNS bool AS $$
+    import os
+
+    cmd = 'pg_waldump -r xlog %s 2> /dev/null | grep %s' % (current_walfile_path, restore_point_name)
+    plpy.notice('Running: %s' % cmd) # useful debug info that is match ignored
+    rc = os.system(cmd)
+
+    return (rc == 0)
+$$ LANGUAGE plpython3u VOLATILE;
+
+-- Verify that there is currently no restore point record named
+-- test_gp_create_restore_point in the coordinator's and active primary
+-- segments' current WAL segment file. Running pg_walfile_name here() is
+-- okay due to the requirement of a fresh gpdemo cluster so timeline ids
+-- should all be 1.
+SELECT w.gp_segment_id,
+       check_restore_point_record_generated(c.datadir || '/pg_wal/' || w.pg_walfile_name, 'test_gp_create_restore_point') AS record_found
+FROM gp_segment_configuration c,
+     (SELECT -1 AS gp_segment_id, pg_walfile_name(pg_current_wal_lsn())
+     UNION ALL
+     SELECT gp_segment_id, pg_walfile_name(pg_current_wal_lsn())
+     FROM gp_dist_random('gp_id')) w
+WHERE c.content = w.gp_segment_id AND c.role = 'p'
+ORDER BY w.gp_segment_id;
+
+-- Create the restore point records
+SELECT true FROM gp_create_restore_point('test_gp_create_restore_point');
+
+-- Verify that the restore point records have been created on the
+-- coordinator and active primary segments.
+SELECT w.gp_segment_id,
+       check_restore_point_record_generated(c.datadir || '/pg_wal/' || w.pg_walfile_name, 'test_gp_create_restore_point') AS record_found
+FROM gp_segment_configuration c,
+     (SELECT -1 AS gp_segment_id, pg_walfile_name(pg_current_wal_lsn())
+     UNION ALL
+     SELECT gp_segment_id, pg_walfile_name(pg_current_wal_lsn())
+     FROM gp_dist_random('gp_id')) w
+WHERE c.content = w.gp_segment_id AND c.role = 'p'
+ORDER BY w.gp_segment_id;
+
+-- test simple gp_create_restore_point() error scenarios
+SELECT gp_create_restore_point('this_should_fail') FROM gp_dist_random('gp_id');
+CREATE TABLE this_ctas_should_fail AS SELECT gp_segment_id AS contentid, restore_lsn FROM gp_create_restore_point('this_should_fail');

--- a/src/test/gpdb_pitr/sql/test_gp_switch_wal.sql
+++ b/src/test/gpdb_pitr/sql/test_gp_switch_wal.sql
@@ -2,14 +2,6 @@
 -- constructed on the individual segments so that their timeline ids are
 -- used instead of each result having the same timeline id.
 
--- start_matchsubs
---
--- # remove line number and entrydb in error message
--- m/\(xlogfuncs_gp\.c\:\d+.*/
--- s/\(xlogfuncs_gp\.c:\d+.*/\(xlogfuncs_gp\.c:LINE_NUM\)/
---
--- end_matchsubs
-
 -- timeline ids prior to failover/failback should all be 1 due to the
 -- test requirement of having a fresh gpdemo cluster with mirrors
 SELECT gp_segment_id, substring(pg_walfile_name, 1, 8) FROM gp_switch_wal() ORDER BY gp_segment_id;

--- a/src/test/gpdb_pitr/test_gpdb_pitr.sh
+++ b/src/test/gpdb_pitr/test_gpdb_pitr.sh
@@ -42,7 +42,7 @@ REPLICA_PRIMARY2_DBID=12
 REPLICA_PRIMARY3_DBID=13
 
 # The options for pg_regress and pg_isolation2_regress.
-REGRESS_OPTS="--dbname=gpdb_pitr_database --use-existing --init-file=../regress/init_file --load-extension=gp_inject_fault"
+REGRESS_OPTS="--dbname=gpdb_pitr_database --use-existing --init-file=../regress/init_file --init-file=./init_file_gpdb_pitr --load-extension=gp_inject_fault"
 ISOLATION2_REGRESS_OPTS="${REGRESS_OPTS} --init-file=../isolation2/init_file_isolation2"
 
 # Run test via pg_regress with given test name.
@@ -70,6 +70,9 @@ run_test_isolation2()
 
 # Create our test database.
 createdb gpdb_pitr_database
+
+# Test gp_create_restore_point()
+run_test test_gp_create_restore_point
 
 # Test output of gp_switch_wal()
 run_test_isolation2 test_gp_switch_wal


### PR DESCRIPTION
The gp_create_restore_point() catalog function was not properly marked
as EXECUTE ON COORDINATOR and required a column definition list to get
nice looking output from a `SELECT *`. Fix the issues by marking the
proexeclocation as 'c' (previously using default 'a') and explicitly
setting the proarg details. A dedicated test has been added to the
gpdb_pitr test suite to add some needed test coverage.

This will be backported to the 6X-exclusive gp_pitr extension as well.