### PR TITLE
Fix Bitmap index null-array condition failed

### DIFF
--- a/src/backend/access/bitmap/bitmap.c
+++ b/src/backend/access/bitmap/bitmap.c
@@ -1063,3 +1063,23 @@ GetBitmapIndexAuxOids(Relation index, Oid *heapId, Oid *indexId)
 
 	_bitmap_relbuf(metabuf);
 }
+
+/*
+ * GetInitBitmapIndex() -- return an empty bitmap.
+ * */
+void
+GetInitBitmapIndex(Node **bmNodeP)
+{
+    IndexStream  *is;
+
+    is = (IndexStream *)palloc0(sizeof(IndexStream));
+    is->type = BMS_INDEX;
+    is->begin_iterate = stream_begin_iterate;
+    is->free = indexstream_free;
+
+    StreamBitmap *sb = makeNode(StreamBitmap);
+    sb->streamNode = is;
+    *bmNodeP = (Node *) sb;
+
+    return;
+}

--- a/src/backend/executor/nodeBitmapIndexscan.c
+++ b/src/backend/executor/nodeBitmapIndexscan.c
@@ -83,6 +83,10 @@ MultiExecBitmapIndexScan(BitmapIndexScanState *node)
 	{
 		ExecReScan((PlanState *) node);
 		doscan = node->biss_RuntimeKeysReady;
+
+        /* Return an empty bitmap if biss_RuntimeKeysReady still false.*/
+        if (!doscan)
+            index_initbitmap(scandesc, &bitmap);
 	}
 	else
 		doscan = true;

--- a/src/include/access/bitmap.h
+++ b/src/include/access/bitmap.h
@@ -749,6 +749,7 @@ extern Datum bmvacuumcleanup(PG_FUNCTION_ARGS);
 extern Datum bmoptions(PG_FUNCTION_ARGS);
 
 extern void GetBitmapIndexAuxOids(Relation index, Oid *heapId, Oid *indexId);
+extern void GetInitBitmapIndex(Node **bmNodeP);
 
 /* bitmappages.c */
 extern Buffer _bitmap_getbuf(Relation rel, BlockNumber blkno, int access);

--- a/src/include/access/genam.h
+++ b/src/include/access/genam.h
@@ -156,7 +156,7 @@ extern ItemPointer index_getnext_tid(IndexScanDesc scan,
 extern HeapTuple index_fetch_heap(IndexScanDesc scan);
 extern HeapTuple index_getnext(IndexScanDesc scan, ScanDirection direction);
 extern int64 index_getbitmap(IndexScanDesc scan, Node **bitmapP);
-
+extern void index_initbitmap(IndexScanDesc scan, Node **bitmapP);
 extern IndexBulkDeleteResult *index_bulk_delete(IndexVacuumInfo *info,
 				  IndexBulkDeleteResult *stats,
 				  IndexBulkDeleteCallback callback,

--- a/src/test/regress/expected/bitmap_index.out
+++ b/src/test/regress/expected/bitmap_index.out
@@ -885,5 +885,42 @@ select count(*) from foo_13446 where b = 1;
 (1 row)
 
 drop table foo_13446;
+-- test bitmap index scan when using NULL array-condition as index key
+create table foo(a int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create index foo_i on foo using bitmap(a);
+explain (verbose on, costs off) select * from foo where a = any(null::int[]);
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: a
+   ->  Bitmap Heap Scan on public.foo
+         Output: a
+         Recheck Cond: (foo.a = ANY (NULL::integer[]))
+         ->  Bitmap Index Scan on foo_i
+               Index Cond: (foo.a = ANY (NULL::integer[]))
+ Optimizer: Postgres query optimizer
+ Settings: enable_bitmapscan=off, enable_indexscan=on, enable_seqscan=off
+(9 rows)
+
+select * from foo where a = any(null::int[]);
+ a 
+---
+(0 rows)
+
+insert into foo values(1);
+select * from foo where a = 1 and a = any(null::int[]);
+ a 
+---
+(0 rows)
+
+select * from foo where a = 1 or a = any(null::int[]);
+ a 
+---
+ 1
+(1 row)
+
+drop table foo;
 SET enable_seqscan = ON;
 SET enable_bitmapscan = ON;

--- a/src/test/regress/expected/bitmap_index_optimizer.out
+++ b/src/test/regress/expected/bitmap_index_optimizer.out
@@ -890,5 +890,42 @@ select count(*) from foo_13446 where b = 1;
 (1 row)
 
 drop table foo_13446;
+-- test bitmap index scan when using NULL array-condition as index key
+create table foo(a int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create index foo_i on foo using bitmap(a);
+explain (verbose on, costs off) select * from foo where a = any(null::int[]);
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: a
+   ->  Bitmap Heap Scan on public.foo
+         Output: a
+         Recheck Cond: (foo.a = ANY (NULL::integer[]))
+         ->  Bitmap Index Scan on foo_i
+               Index Cond: (foo.a = ANY (NULL::integer[]))
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Settings: enable_bitmapscan=off, enable_indexscan=on, enable_seqscan=off
+(9 rows)
+
+select * from foo where a = any(null::int[]);
+ a 
+---
+(0 rows)
+
+insert into foo values(1);
+select * from foo where a = 1 and a = any(null::int[]);
+ a 
+---
+(0 rows)
+
+select * from foo where a = 1 or a = any(null::int[]);
+ a 
+---
+ 1
+(1 row)
+
+drop table foo;
 SET enable_seqscan = ON;
 SET enable_bitmapscan = ON;

--- a/src/test/regress/sql/bitmap_index.sql
+++ b/src/test/regress/sql/bitmap_index.sql
@@ -376,6 +376,18 @@ select count(*) from foo_13446 where b = 1;
 
 drop table foo_13446;
 
+-- test bitmap index scan when using NULL array-condition as index key
+create table foo(a int);
+create index foo_i on foo using bitmap(a);
+explain (verbose on, costs off) select * from foo where a = any(null::int[]);
+select * from foo where a = any(null::int[]);
+
+insert into foo values(1);
+select * from foo where a = 1 and a = any(null::int[]);
+select * from foo where a = 1 or a = any(null::int[]);
+
+drop table foo;
+
 SET enable_seqscan = ON;
 SET enable_bitmapscan = ON;
 


### PR DESCRIPTION
when we create bitmap-index on column and using bitmap index scan with NULL array condition on this column, then failed. Like this:
> create temp table foo (a int); 
> create index foo_i on foo using bitmap(a); 

> select * from foo where a = any(null::int[]); 
> Conversant: ERROR "unrecognized result from subplan (nodeBitmapHeapscan.c:293)"

The reason is when we using bitmap-index scan on NULL Array key condition, MultiExecbitmapscan treate it as runtime key then it will return NULL to parent node. But for parent node like BitmapHeapNext cannot handle NULL return, then error happened. So we should return an empty bitmap instead of nothing to upper node(BitmapHeapNext), and force BitmapHeapNext scan this empty bitmap.


## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
