### PR TITLE
[6X] support ldapsearchfilter option for LDAP authentication 

### DIFF
--- a/src/backend/libpq/auth.c
+++ b/src/backend/libpq/auth.c
@@ -2651,6 +2651,34 @@ InitializeLDAPConnection(Port *port, LDAP **ldap)
 	return STATUS_OK;
 }
 
+/* Placeholders recognized by FormatSearchFilter.  For now just one. */
+#define LPH_USERNAME "$username"
+#define LPH_USERNAME_LEN (sizeof(LPH_USERNAME) - 1)
+
+/*
+ * Return a newly allocated C string copied from "pattern" with all
+ * occurrences of the placeholder "$username" replaced with "user_name".
+ */
+static char *
+FormatSearchFilter(const char *pattern, const char *user_name)
+{
+	StringInfoData output;
+
+	initStringInfo(&output);
+	while (*pattern != '\0')
+	{
+		if (strncmp(pattern, LPH_USERNAME, LPH_USERNAME_LEN) == 0)
+		{
+			appendStringInfoString(&output, user_name);
+			pattern += LPH_USERNAME_LEN;
+		}
+		else
+			appendStringInfoChar(&output, *pattern++);
+	}
+
+	return output.data;
+}
+
 /*
  * Perform LDAP authentication
  */
@@ -2741,9 +2769,10 @@ CheckLDAPAuth(Port *port)
 		attributes[0] = port->hba->ldapsearchattribute ? port->hba->ldapsearchattribute : "uid";
 		attributes[1] = NULL;
 
-		filter = psprintf("(%s=%s)",
-						  attributes[0],
-						  port->user_name);
+		if (port->hba->ldapsearchfilter)
+			filter = FormatSearchFilter(port->hba->ldapsearchfilter, port->user_name);
+		else
+			filter = psprintf("(%s=%s)", attributes[0], port->user_name);
 
 		r = ldap_search_s(ldap,
 						  port->hba->ldapbasedn,

--- a/src/include/libpq/hba.h
+++ b/src/include/libpq/hba.h
@@ -71,6 +71,7 @@ typedef struct HbaLine
 	char	   *ldapbinddn;
 	char	   *ldapbindpasswd;
 	char	   *ldapsearchattribute;
+	char       *ldapsearchfilter;
 	char	   *ldapbasedn;
 	int			ldapscope;
 	char	   *ldapprefix;


### PR DESCRIPTION
Version 6X_STABLE don't support ldapsearchfilter option for LDAP authentication.
We use the value of ldapsearchattribute option as ldap search filters. 
For example, when the entry in pg_hba.conf is `host all user1 0.0.0.0/0 ldap ldapserver=xxx ldapbasedn="xxx" ldapbinddn="xxx" ldapbindpasswd="xxx" ldapsearchattribute="sAMAccountName"`, we use "(sAMAccountName=$username)" as ldap search filters.
We can't specify more complex ldap search filters by ourselves.

To allow for more flexible search filters, we backport ldapsearchfilter option from master branch.
With this pr, we can specify ldap search filters in pg_hba.conf by ldapsearchfilter option, like `host all user1 0.0.0.0/0 ldap ldapserver=xxx ldapbasedn="xxx" ldapbinddn="xxx" ldapbindpasswd="xxx" ldapsearchfilter="(&(objectClass=user)(sAMAccountName=$username))"`

GP6 lacks of LDAP related tests which is a long time known issue. We will make it work on GP7. 
We have manually tested with this backport and other LDAP feature a lot.