### PR TITLE
Fix checkpoint record corrupt with gp_before_filespace_setup

### DIFF
--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -9088,9 +9088,7 @@ CreateCheckPoint(int flags)
 	 * aggregate state (ptas) will be skipped when gp_before_filespace_setup
 	 * is ON. See comments inside UnpackCheckPointRecord(). For the case,
 	 * mmxlog_append_checkpoint_data() will return earlier.
-	 */
-
-	/*
+	 *
 	 * Note that we need to collect ptas data even when we don't need to write
 	 * it to check point xlog record.
 	 * When gp_before_filespace_setup is ON, we will not link mmxlog and ptas

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -9158,6 +9158,8 @@ CreateCheckPoint(int flags)
 	XLogRecPtr *ptrd_oldest_ptr = NULL;
 	XLogRecPtr ptrd_oldest;
 
+	memset(&ptrd_oldest, 0, sizeof(ptrd_oldest));
+
 	if (p != NULL)
 	{
 		ptrd_oldest_ptr = getTwoPhaseOldestPreparedTransactionXLogRecPtr(p);
@@ -9171,10 +9173,7 @@ CreateCheckPoint(int flags)
 
 
 	if (ptrd_oldest_ptr != NULL)
-	{
-		memset(&ptrd_oldest, 0, sizeof(ptrd_oldest));
 		memcpy(&ptrd_oldest, ptrd_oldest_ptr, sizeof(ptrd_oldest));
-	}
 
 	recptr = XLogInsert(RM_XLOG_ID,
 			            shutdown ? XLOG_CHECKPOINT_SHUTDOWN : XLOG_CHECKPOINT_ONLINE,

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -9100,9 +9100,11 @@ CreateCheckPoint(int flags)
 	if (pnext != &rdata[1].next)
 	{
 		/*
-		 * If pnext has advanced, gp_before_filespace_setup must be false.
+		 * If pnext has advanced, gp_before_filespace_setup must be false,
+		 * and pnext must point to rdata[4].next.
 		 */
 		Assert(!gp_before_filespace_setup);
+		Assert(pnext == &rdata[4].next);
 
 		*pnext = &rdata[5];
 		rdata[5].data = (char*)p;

--- a/src/test/regress/expected/checkpoint_xlog.out
+++ b/src/test/regress/expected/checkpoint_xlog.out
@@ -1,0 +1,20 @@
+-- start_matchsubs
+-- m/PostgreSQL stand-alone backend .*/ 
+-- s/PostgreSQL stand-alone backend .*/PostgreSQL stand-alone backend ###/ 
+-- end_matchsubs
+\!gpstop -M fast -aq;
+\! echo "select 1" | postgres  --single --gp_num_contents_in_cluster=1 -O -c gp_session_role=utility -c gp_debug_linger=0 -c gp_before_filespace_setup=true -D $MASTER_DATA_DIRECTORY template1;
+
+PostgreSQL stand-alone backend ###
+backend> 	 1: ?column?	(typeid = 23, len = 4, typmod = -1, byval = t)
+	----
+	 1: ?column? = "1"	(typeid = 23, len = 4, typmod = -1, byval = t)
+	----
+backend> \! echo "select 1" | postgres  --single --gp_num_contents_in_cluster=1 -O -c gp_session_role=utility -c gp_debug_linger=0 -D $MASTER_DATA_DIRECTORY template1;
+
+PostgreSQL stand-alone backend ###
+backend> 	 1: ?column?	(typeid = 23, len = 4, typmod = -1, byval = t)
+	----
+	 1: ?column? = "1"	(typeid = 23, len = 4, typmod = -1, byval = t)
+	----
+backend> \!gpstart -aq;

--- a/src/test/regress/expected/checkpoint_xlog.out
+++ b/src/test/regress/expected/checkpoint_xlog.out
@@ -1,6 +1,6 @@
 -- start_matchsubs
--- m/PostgreSQL stand-alone backend .*/ 
--- s/PostgreSQL stand-alone backend .*/PostgreSQL stand-alone backend ###/ 
+-- m/PostgreSQL stand-alone backend .*/
+-- s/PostgreSQL stand-alone backend .*/PostgreSQL stand-alone backend ###/
 -- end_matchsubs
 \!gpstop -M fast -aq;
 \! echo "select 1" | postgres  --single --gp_num_contents_in_cluster=1 -O -c gp_session_role=utility -c gp_debug_linger=0 -c gp_before_filespace_setup=true -D $MASTER_DATA_DIRECTORY template1;

--- a/src/test/regress/expected/checkpoint_xlog.out
+++ b/src/test/regress/expected/checkpoint_xlog.out
@@ -3,6 +3,7 @@
 -- s/PostgreSQL stand-alone backend .*/PostgreSQL stand-alone backend ###/
 -- end_matchsubs
 \!gpstop -M fast -aq;
+-- Generate shutdown checkpoint xlog record
 \! echo "select 1" | postgres  --single --gp_num_contents_in_cluster=1 -O -c gp_session_role=utility -c gp_debug_linger=0 -c gp_before_filespace_setup=true -D $MASTER_DATA_DIRECTORY template1;
 
 PostgreSQL stand-alone backend ###
@@ -10,7 +11,8 @@ backend> 	 1: ?column?	(typeid = 23, len = 4, typmod = -1, byval = t)
 	----
 	 1: ?column? = "1"	(typeid = 23, len = 4, typmod = -1, byval = t)
 	----
-backend> \! echo "select 1" | postgres  --single --gp_num_contents_in_cluster=1 -O -c gp_session_role=utility -c gp_debug_linger=0 -D $MASTER_DATA_DIRECTORY template1;
+backend> -- We will hit error when the checkpoint xlog record is corrupt
+\! echo "select 1" | postgres  --single --gp_num_contents_in_cluster=1 -O -c gp_session_role=utility -c gp_debug_linger=0 -D $MASTER_DATA_DIRECTORY template1;
 
 PostgreSQL stand-alone backend ###
 backend> 	 1: ?column?	(typeid = 23, len = 4, typmod = -1, byval = t)

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -226,4 +226,6 @@ test: autovacuum-template0
 
 test: freegang_initplan
 
+test: checkpoint_xlog
+
 # end of tests

--- a/src/test/regress/sql/checkpoint_xlog.sql
+++ b/src/test/regress/sql/checkpoint_xlog.sql
@@ -1,0 +1,9 @@
+-- start_matchsubs
+-- m/PostgreSQL stand-alone backend .*/
+-- s/PostgreSQL stand-alone backend .*/PostgreSQL stand-alone backend ###/ 
+-- end_matchsubs
+
+\!gpstop -M fast -aq;
+\! echo "select 1" | postgres  --single --gp_num_contents_in_cluster=1 -O -c gp_session_role=utility -c gp_debug_linger=0 -c gp_before_filespace_setup=true -D $MASTER_DATA_DIRECTORY template1;
+\! echo "select 1" | postgres  --single --gp_num_contents_in_cluster=1 -O -c gp_session_role=utility -c gp_debug_linger=0 -D $MASTER_DATA_DIRECTORY template1;
+\!gpstart -aq;

--- a/src/test/regress/sql/checkpoint_xlog.sql
+++ b/src/test/regress/sql/checkpoint_xlog.sql
@@ -4,6 +4,11 @@
 -- end_matchsubs
 
 \!gpstop -M fast -aq;
+
+-- Generate shutdown checkpoint xlog record
 \! echo "select 1" | postgres  --single --gp_num_contents_in_cluster=1 -O -c gp_session_role=utility -c gp_debug_linger=0 -c gp_before_filespace_setup=true -D $MASTER_DATA_DIRECTORY template1;
+
+-- We will hit error when the checkpoint xlog record is corrupt
 \! echo "select 1" | postgres  --single --gp_num_contents_in_cluster=1 -O -c gp_session_role=utility -c gp_debug_linger=0 -D $MASTER_DATA_DIRECTORY template1;
+
 \!gpstart -aq;

--- a/src/test/regress/sql/checkpoint_xlog.sql
+++ b/src/test/regress/sql/checkpoint_xlog.sql
@@ -1,6 +1,6 @@
 -- start_matchsubs
 -- m/PostgreSQL stand-alone backend .*/
--- s/PostgreSQL stand-alone backend .*/PostgreSQL stand-alone backend ###/ 
+-- s/PostgreSQL stand-alone backend .*/PostgreSQL stand-alone backend ###/
 -- end_matchsubs
 
 \!gpstop -M fast -aq;


### PR DESCRIPTION
### Issue

When we turned on the GUC `gp_before_filespace_setup` and restarted GPDB, we hit an assertion in `UnpackCheckPointRecord()`:

```
8393         Assert(remainderLen > ckptExtended->masterMirroringCheckpointLen);
```
Relevant stack:
```
#0  0x00007f47d42406b3 in __select_nocancel () at ../sysdeps/unix/syscall-template.S:84
#1  0x0000000000c03b8d in pg_usleep (microsec=30000000) at pgsleep.c:43
#2  0x0000000000a727dd in elog_debug_linger (edata=0x11f4940 <errordata>) at elog.c:4342
#3  0x0000000000a69d31 in errfinish (dummy=0) at elog.c:616
#4  0x0000000000a6847c in ExceptionalCondition (conditionName=0xc1f0d0 "!(remainderLen > ckptExtended->masterMirroringCheckpointLen)", errorType=0xc1a9ea "FailedAssertion", fileName=0xc1aa32 "xlog.c", lineNumber=8393) at assert.c:49
#5  0x000000000051a6ce in UnpackCheckPointRecord (record=0x7f47d5a72010, ckptExtended=0x7ffc642fc710) at xlog.c:8393
#6  0x0000000000516dd9 in StartupXLOG () at xlog.c:6685
#7  0x00000000005202fa in StartupProcessMain (passNum=1) at xlog.c:11270
#8  0x000000000059e8bc in AuxiliaryProcessMain (argc=2, argv=0x7ffc642fc840) at bootstrap.c:462
#9  0x00000000008b6601 in StartChildProcess (type=StartupProcess) at postmaster.c:7804
#10 0x00000000008ac388 in StartMasterOrPrimaryPostmasterProcesses () at postmaster.c:1562
#11 0x00000000008b929b in stepDoDatabaseStartup (nextState=TSDone, stateInOut=0x7ffc642fc94c) at primary_mirror_mode.c:1738
#12 0x00000000008b975b in applyStepForTransitionToMasterOrMirrorlessMode (args=0x7ffc642fc960, stateInOut=0x7ffc642fc94c, extraResultInfoOut=0x7ffc642fcb20 "") at primary_mirror_mode.c:1907
#13 0x00000000008b8e71 in doRequestedPrimaryMirrorModeTransitions (isInShutdown=0 '\000') at primary_mirror_mode.c:1643
#14 0x00000000008ad738 in ServerLoop () at postmaster.c:2268
#15 0x00000000008ac323 in PostmasterMain (argc=14, argv=0x2e35a30) at postmaster.c:1528
#16 0x00000000007ba4f3 in main (argc=14, argv=0x2e35a30) at main.c:206
```
In a production env with assertion disabled, we even hit segment fault when reading checkpoint record.

### Analysis

In a brief, the root cause is, with `gp_before_filespace_setup`=on, `CreateCheckPoint()` created a corrupt checkpoint xlog record which didn't contain mmxlog but did contain `ptas` (prepared transaction aggregate state),  and `UnpackCheckPointRecord()` cannot handle it.

The wrong version was introduced by https://github.com/greenplum-db/gpdb/pull/9730. 

Something interesting is, the description of `gp_before_filespace_setup` is "Indicates that the gp_persistent_filespace_node table is not setup and should not be used for lookups." So a reasonable understanding is that "with gp_before_filespace_setup mmxlog will be skipped but ptas will not". I was believing it, and I suppose the author of PR #9730 also believed it. However, `UnpackCheckPointRecord()` always expect no `ptas` with `gp_before_filespace_setup`:
```
 8378     /*
 8379      * The master mirror checkpoint (mmxlog) and prepared transaction aggregate state (ptas) will be skipped
 8380      * when gp_before_filespace_setup is ON.
 8381      */
```

See the different rdata chain generated by wrong (after PR #9730) and correct code (before PR #9730) with `gp_before_filespace_setup`=on:

Wrong version:
```
(gdb) p rdata[0]
$1 = {data = 0x7fff8b2d8840 "", len = 48, buffer = 0, buffer_std = -64 '\300', next = 0x7fff8b2d88c0}
(gdb) p rdata[1]
$2 = {data = 0x562d9295d890 "", len = 4, buffer = 0, buffer_std = 4 '\004', next = 0x7fff8b2d8940}
...
(gdb) p &rdata[5]
$12 = (XLogRecData *) 0x7fff8b2d8940
```
Correct version:
```
(gdb) p rdata[0]
$2 = {data = 0x7ffebc62c510 "", len = 48, buffer = 0, buffer_std = 96 '`', next = 0x7ffebc62c560}
(gdb) p rdata[1]
$3 = {data = 0x55ce673feb70 "", len = 4, buffer = 0, buffer_std = 4 '\004', next = 0x0}
```
For correct version, `rdata[1].next` is null and the chain stopped here. For wrong version, `rdata[1].next` is 0x7fff8b2d8940, which is actually the address of `rdata[5]`.

Relevant code in `CreateCheckPoint()`:
```
 9071     rdata[1].buffer = InvalidBuffer;
 9072     rdata[1].next = NULL;
 9073     pnext = &rdata[1].next;
 ...
 9081     /* mmxlog_append_checkpoint_data() may use rdata[2,3,4] */
 9082     pnext = mmxlog_append_checkpoint_data(&rdata[2], pnext);
...
 9088     *pnext = &rdata[5];
 9089     rdata[5].data = (char*)p;
 9090     rdata[5].buffer = InvalidBuffer;
 9091     rdata[5].len = PREPARED_TRANSACTION_CHECKPOINT_BYTES(p->count);
 9092     rdata[4].next = &(rdata[5]);
 9093     rdata[5].next = NULL;
```
Before the calling of `mmxlog_append_checkpoint_data()` (line 9082), `pnext` pointed to `&rdata[1].next`.  

With `gp_before_filespace_setup`=off, `pnext` changed to `&rdata[4].next` inside `mmxlog_append_checkpoint_data()` and then was set to `&rdata[5]`, which generated a valid chain. 

With `gp_before_filespace_setup`=on,  `mmxlog_append_checkpoint_data()` returned earlier and `pnext` still pointed to `&rdata[1].next` after the calling, then pointed to `&rdata[5] `and generated an invalid chain. 

### Fix
The fix is straightforward: 

The pointer `pnext` is supposed to advance after getting mmxlog data inside `mmxlog_append_checkpoint_data()`. We check whether `pnext` has advanced after the calling: if not, it means mmxlog was not collected due to returning earlier, and the `rdata` chain stops here. If not, go ahead and link to `ptas` data.

A further thought is, can we avoid all the codes of collection `ptas` data when `gp_before_filespace_setup`=on? Or an reverse approach also makes sense (maybe better): updating `UnpackCheckPointRecord()` and other parsing codes to handle checkpoint xlog record without mmxlog but with `ptas` . I took a basic look and it seems relevant code is complex. Since GPDB5 is a deprecated version, I don't want to impose more change with potential risk. Let's restrict to the fix itself for now.