### PR TITLE
Make headerfile  extaccess.h accessible to pxf extension

### DIFF
--- a/gpcontrib/gp_exttable_fdw/Makefile
+++ b/gpcontrib/gp_exttable_fdw/Makefile
@@ -10,6 +10,8 @@ DATA = gp_exttable_fdw--1.0.sql
 
 REGRESS =
 
+HEADERS = extaccess.h
+
 ifdef USE_PGXS
 PG_CONFIG = pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)


### PR DESCRIPTION
PXF external-table is dependent on `fileam.h`. In GP7, this file is renamed to `extaccess.h` and when we install the gpdb, the header file is not copied to `$GPHOME/include/postgresql/server/extension/gp_exttable_fdw`. 

By adding this `HEADERS` flag in the Makefile, the header file will get copied to the `gp_exttable_fdw` extension and can be referenced in the PXF code.   
