### PR TITLE
Invalidate CatCache in AbortTransaction to clear reader gang's cache.

### DIFF
--- a/src/test/regress/expected/catcache.out
+++ b/src/test/regress/expected/catcache.out
@@ -1,0 +1,62 @@
+-- Test abort transaction should invalidate reader gang's cat cache
+-- Discussion: https://groups.google.com/a/greenplum.org/g/gpdb-dev/c/u3-D7isdvmM
+set optimizer_force_multistage_agg = 1;
+create table dml_14027_union_s (a int not null, b numeric default 10.00) distributed by (a) partition by range(b);
+create table dml_14027_union_s_1_prt_2 partition of dml_14027_union_s for values from (1) to (1001);
+NOTICE:  table has parent, setting distribution columns to match parent table
+create table dml_14027_union_s_1_prt_def partition of dml_14027_union_s default;
+NOTICE:  table has parent, setting distribution columns to match parent table
+insert into dml_14027_union_s select generate_series(1,1), generate_series(1,1);
+begin;
+drop table dml_14027_union_s_1_prt_def;
+explain select count(distinct(b)) from dml_14027_union_s;
+                                                     QUERY PLAN                                                     
+--------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate  (cost=321.22..321.23 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=321.17..321.22 rows=3 width=8)
+         ->  Partial Aggregate  (cost=321.17..321.18 rows=1 width=8)
+               ->  HashAggregate  (cost=317.00..320.33 rows=333 width=32)
+                     Group Key: dml_14027_union_s_1_prt_2.b
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=282.00..312.00 rows=1000 width=32)
+                           Hash Key: dml_14027_union_s_1_prt_2.b
+                           ->  Streaming HashAggregate  (cost=282.00..292.00 rows=1000 width=32)
+                                 Group Key: dml_14027_union_s_1_prt_2.b
+                                 ->  Seq Scan on dml_14027_union_s_1_prt_2  (cost=0.00..199.33 rows=16533 width=32)
+ Optimizer: Postgres query optimizer
+(11 rows)
+
+select count(distinct(b)) from dml_14027_union_s;
+ count 
+-------
+     1
+(1 row)
+
+rollback;
+explain update dml_14027_union_s set a = (select null union select null)::numeric;
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Update on dml_14027_union_s  (cost=0.07..1969.41 rows=66133 width=46)
+   Update on dml_14027_union_s_1_prt_2
+   Update on dml_14027_union_s_1_prt_def
+   InitPlan 1 (returns $0)  (slice1)
+     ->  HashAggregate  (cost=0.06..0.07 rows=2 width=32)
+           Group Key: (NULL::text)
+           ->  Append  (cost=0.00..0.05 rows=2 width=32)
+                 ->  Result  (cost=0.00..0.01 rows=1 width=32)
+                 ->  Result  (cost=0.00..0.01 rows=1 width=32)
+   ->  Explicit Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..984.67 rows=33067 width=46)
+         ->  Split  (cost=0.00..323.33 rows=33067 width=46)
+               ->  Seq Scan on dml_14027_union_s_1_prt_2  (cost=0.00..323.33 rows=16533 width=46)
+   ->  Explicit Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..984.67 rows=33067 width=46)
+         ->  Split  (cost=0.00..323.33 rows=33067 width=46)
+               ->  Seq Scan on dml_14027_union_s_1_prt_def  (cost=0.00..323.33 rows=16533 width=46)
+ Optimizer: Postgres query optimizer
+(16 rows)
+
+-- Should not raise error due to stale catcache in reader gang.
+-- eg: ERROR: expected partdefid 134733, but got 0
+update dml_14027_union_s set a = (select null union select null)::numeric;
+ERROR:  null value in column "a" violates not-null constraint  (seg0 127.0.1.1:7002 pid=27795)
+DETAIL:  Failing row contains (null, 1).
+drop table dml_14027_union_s;
+reset optimizer_force_multistage_agg;

--- a/src/test/regress/expected/catcache_optimizer.out
+++ b/src/test/regress/expected/catcache_optimizer.out
@@ -1,0 +1,81 @@
+-- Test abort transaction should invalidate reader gang's cat cache
+-- Discussion: https://groups.google.com/a/greenplum.org/g/gpdb-dev/c/u3-D7isdvmM
+set optimizer_force_multistage_agg = 1;
+create table dml_14027_union_s (a int not null, b numeric default 10.00) distributed by (a) partition by range(b);
+create table dml_14027_union_s_1_prt_2 partition of dml_14027_union_s for values from (1) to (1001);
+NOTICE:  table has parent, setting distribution columns to match parent table
+create table dml_14027_union_s_1_prt_def partition of dml_14027_union_s default;
+NOTICE:  table has parent, setting distribution columns to match parent table
+insert into dml_14027_union_s select generate_series(1,1), generate_series(1,1);
+begin;
+drop table dml_14027_union_s_1_prt_def;
+explain select count(distinct(b)) from dml_14027_union_s;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..431.00 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+         ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=8)
+               Group Key: b
+               ->  Sort  (cost=0.00..431.00 rows=1 width=8)
+                     Sort Key: b
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                           Hash Key: b
+                           ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=8)
+                                 Group Key: b
+                                 ->  Sort  (cost=0.00..431.00 rows=1 width=8)
+                                       Sort Key: b
+                                       ->  Dynamic Seq Scan on dml_14027_union_s  (cost=0.00..431.00 rows=1 width=8)
+                                             Number of partitions to scan: 1 (out of 1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(15 rows)
+
+select count(distinct(b)) from dml_14027_union_s;
+ count 
+-------
+     1
+(1 row)
+
+rollback;
+explain update dml_14027_union_s set a = (select null union select null)::numeric;
+                                                                        QUERY PLAN                                                                        
+----------------------------------------------------------------------------------------------------------------------------------------------------------
+ Update on dml_14027_union_s  (cost=0.00..882689.29 rows=1 width=1)
+   ->  Result  (cost=0.00..882689.22 rows=2 width=30)
+         ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..882689.22 rows=2 width=26)
+               Hash Key: dml_14027_union_s_1.a
+               ->  Split  (cost=0.00..882689.22 rows=1 width=26)
+                     ->  Nested Loop Left Join  (cost=0.00..882689.22 rows=1 width=30)
+                           Join Filter: true
+                           ->  Dynamic Seq Scan on dml_14027_union_s dml_14027_union_s_1  (cost=0.00..431.00 rows=1 width=22)
+                                 Number of partitions to scan: 2 (out of 2)
+                           ->  Assert  (cost=0.00..0.00 rows=1 width=8)
+                                 Assert Cond: ((row_number() OVER (?)) = 1)
+                                 ->  Materialize  (cost=0.00..0.00 rows=1 width=16)
+                                       ->  Broadcast Motion 1:3  (slice2; segments: 1)  (cost=0.00..0.00 rows=1 width=16)
+                                             ->  WindowAgg  (cost=0.00..0.00 rows=1 width=16)
+                                                   ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..0.00 rows=1 width=8)
+                                                         ->  GroupAggregate  (cost=0.00..0.00 rows=1 width=8)
+                                                               Group Key: (NULL::text)
+                                                               ->  Sort  (cost=0.00..0.00 rows=1 width=8)
+                                                                     Sort Key: (NULL::text)
+                                                                     ->  Redistribute Motion 3:3  (slice4; segments: 3)  (cost=0.00..0.00 rows=1 width=8)
+                                                                           Hash Key: (NULL::text)
+                                                                           ->  GroupAggregate  (cost=0.00..0.00 rows=1 width=8)
+                                                                                 Group Key: (NULL::text)
+                                                                                 ->  Sort  (cost=0.00..0.00 rows=1 width=8)
+                                                                                       Sort Key: (NULL::text)
+                                                                                       ->  Result  (cost=0.00..0.00 rows=1 width=8)
+                                                                                             One-Time Filter: (gp_execution_segment() = 1)
+                                                                                             ->  Append  (cost=0.00..0.00 rows=1 width=8)
+                                                                                                   ->  Result  (cost=0.00..0.00 rows=1 width=1)
+                                                                                                   ->  Result  (cost=0.00..0.00 rows=1 width=1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(31 rows)
+
+-- Should not raise error due to stale catcache in reader gang.
+-- eg: ERROR: expected partdefid 134733, but got 0
+update dml_14027_union_s set a = (select null union select null)::numeric;
+ERROR:  null value in column "a" violates not-null constraint  (seg0 127.0.1.1:7002 pid=27466)
+DETAIL:  Failing row contains (null, 1).
+drop table dml_14027_union_s;
+reset optimizer_force_multistage_agg;

--- a/src/test/regress/expected/qp_union_intersect.out
+++ b/src/test/regress/expected/qp_union_intersect.out
@@ -1687,8 +1687,6 @@ rollback;
 -- @description union_update_test28: Negative Tests Update the partition key to an out of dml_union_range value with no default partition
 begin;
 DROP TABLE dml_union_s_1_prt_def;
--- GPDB_12_MERGE_FIXME: This test case is flaky, ERROR:  expected partdefid 134733, but got 0 (partdesc.c:194)
-set optimizer=off;
 SELECT COUNT(DISTINCT(d)) FROM dml_union_s;
  count 
 -------
@@ -1701,7 +1699,6 @@ DETAIL:  Partition key of the failing row contains (d) = (null).
 --SELECT DISTINCT(d) FROM dml_union_s;
 --SELECT COUNT(DISTINCT(d)) FROM dml_union_s;
 rollback;
-reset optimizer;
 -- @description union_update_test29: Negative Tests  UPDATE violates the CHECK constraint on the column
 SELECT COUNT(DISTINCT(b)) FROM dml_union_s;
  count 

--- a/src/test/regress/expected/qp_union_intersect_optimizer.out
+++ b/src/test/regress/expected/qp_union_intersect_optimizer.out
@@ -1688,8 +1688,6 @@ rollback;
 -- @description union_update_test28: Negative Tests Update the partition key to an out of dml_union_range value with no default partition
 begin;
 DROP TABLE dml_union_s_1_prt_def;
--- GPDB_12_MERGE_FIXME: This test case is flaky, ERROR:  expected partdefid 134733, but got 0 (partdesc.c:194)
-set optimizer=off;
 SELECT COUNT(DISTINCT(d)) FROM dml_union_s;
  count 
 -------
@@ -1702,7 +1700,6 @@ DETAIL:  Partition key of the failing row contains (d) = (null).
 --SELECT DISTINCT(d) FROM dml_union_s;
 --SELECT COUNT(DISTINCT(d)) FROM dml_union_s;
 rollback;
-reset optimizer;
 -- @description union_update_test29: Negative Tests  UPDATE violates the CHECK constraint on the column
 SELECT COUNT(DISTINCT(b)) FROM dml_union_s;
  count 

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -170,7 +170,7 @@ test: gp_toolkit_ao_funcs trig auth_constraint role portals_updatable plpgsql_ca
 # direct dispatch tests
 test: direct_dispatch bfv_dd bfv_dd_multicolumn bfv_dd_types
 
-test: bfv_catalog bfv_index bfv_olap bfv_aggregate bfv_partition_plans DML_over_joins bfv_statistic nested_case_null sort bb_mpph aggregate_with_groupingsets gporca gpsd
+test: bfv_catalog bfv_index bfv_olap bfv_aggregate bfv_partition_plans DML_over_joins bfv_statistic nested_case_null sort bb_mpph aggregate_with_groupingsets gporca gpsd catcache
 # Run minirepro separately to avoid concurrent deletes erroring out the internal pg_dump call
 test: minirepro
 

--- a/src/test/regress/sql/catcache.sql
+++ b/src/test/regress/sql/catcache.sql
@@ -1,0 +1,25 @@
+-- Test abort transaction should invalidate reader gang's cat cache
+-- Discussion: https://groups.google.com/a/greenplum.org/g/gpdb-dev/c/u3-D7isdvmM
+
+set optimizer_force_multistage_agg = 1;
+
+create table dml_14027_union_s (a int not null, b numeric default 10.00) distributed by (a) partition by range(b);
+create table dml_14027_union_s_1_prt_2 partition of dml_14027_union_s for values from (1) to (1001);
+create table dml_14027_union_s_1_prt_def partition of dml_14027_union_s default;
+
+insert into dml_14027_union_s select generate_series(1,1), generate_series(1,1);
+
+begin;
+drop table dml_14027_union_s_1_prt_def;
+explain select count(distinct(b)) from dml_14027_union_s;
+select count(distinct(b)) from dml_14027_union_s;
+rollback;
+
+explain update dml_14027_union_s set a = (select null union select null)::numeric;
+-- Should not raise error due to stale catcache in reader gang.
+-- eg: ERROR: expected partdefid 134733, but got 0
+update dml_14027_union_s set a = (select null union select null)::numeric;
+
+drop table dml_14027_union_s;
+
+reset optimizer_force_multistage_agg;

--- a/src/test/regress/sql/qp_union_intersect.sql
+++ b/src/test/regress/sql/qp_union_intersect.sql
@@ -619,14 +619,11 @@ rollback;
 -- @description union_update_test28: Negative Tests Update the partition key to an out of dml_union_range value with no default partition
 begin;
 DROP TABLE dml_union_s_1_prt_def;
--- GPDB_12_MERGE_FIXME: This test case is flaky, ERROR:  expected partdefid 134733, but got 0 (partdesc.c:194)
-set optimizer=off;
 SELECT COUNT(DISTINCT(d)) FROM dml_union_s;
 UPDATE dml_union_s SET d = (SELECT NULL EXCEPT SELECT NULL)::numeric; 
 --SELECT DISTINCT(d) FROM dml_union_s;
 --SELECT COUNT(DISTINCT(d)) FROM dml_union_s;
 rollback;
-reset optimizer;
 
 -- @description union_update_test29: Negative Tests  UPDATE violates the CHECK constraint on the column
 SELECT COUNT(DISTINCT(b)) FROM dml_union_s;


### PR DESCRIPTION
In AbortTransaction, Postgres does not need to tell other backend to
invalidate catcache because the change is invisible. However,
Greenplum's MPP architecture has writer gang, reader gangs and gangs
can be reused in the same session. Only writer gang can modify
catalogs, thus in Greenplum we have to tell other backends (reader
gangs) when abort transaction.

Discussion: https://groups.google.com/a/greenplum.org/g/gpdb-dev/c/u3-D7isdvmM

Authored-by: David Kimura <dkimura@vmware.com>
