### PR TITLE
change verify checksum FIXME to FEATURE NOT SUPPORTED

### DIFF
--- a/gpMgmt/bin/gppylib/commands/pg.py
+++ b/gpMgmt/bin/gppylib/commands/pg.py
@@ -222,7 +222,7 @@ class PgBaseBackup(Command):
 
         cmd_tokens.extend(self._xlog_arguments(replication_slot_name))
 
-        # GPDB_12_MERGE_FIXME: avoid checking checksum for heap tables
+        # GPDB_12_MERGE_FEATURE_NOT_SUPPORTED: avoid checking checksum for heap tables
         # till we code logic to skip/verify checksum for
         # appendoptimized tables. Enabling this results in basebackup
         # failures with appendoptimized tables.


### PR DESCRIPTION
--no-verify-checksum option shouldn't be needed but it was added to avoid basebackup failures with appendoptimized tables. To fix this improvement issue is created https://github.com/greenplum-db/gpdb/issues/12536

So change the GPDB_12_MERGE_FIXME to GPDB_12_MERGE_FEATURE_NOT_SUPPORTED.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
