### PR TITLE
Update gp_create_restore_point() catalog function

### DIFF
--- a/gpcontrib/gp_pitr/gp_pitr--1.0--1.1.sql
+++ b/gpcontrib/gp_pitr/gp_pitr--1.0--1.1.sql
@@ -3,6 +3,19 @@
 -- complain if script is sourced in psql, rather than via ALTER EXTENSION
 \echo Use "ALTER EXTENSION gp_pitr UPDATE TO '1.1'" to load this file. \quit
 
+DROP FUNCTION gp_create_restore_point(text);
+CREATE FUNCTION gp_create_restore_point(
+    IN restore_point_name text,
+    OUT gp_segment_id smallint, OUT restore_lsn pg_lsn
+)
+    RETURNS SETOF record
+AS '$libdir/gp_pitr', 'gp_create_restore_point'
+LANGUAGE C VOLATILE STRICT EXECUTE ON MASTER;
+
+COMMENT ON FUNCTION gp_create_restore_point(text) IS 'Create a named restore point on all segments';
+
+REVOKE EXECUTE ON FUNCTION gp_create_restore_point(text) FROM public;
+
 -- pg_switch_xlog wrapper functions to switch WAL segment files on Greenplum cluster-wide
 CREATE FUNCTION gp_switch_wal(
     OUT gp_segment_id smallint, OUT pg_switch_wal pg_lsn, OUT pg_walfile_name text

--- a/gpcontrib/gp_pitr/gp_pitr--1.1.sql
+++ b/gpcontrib/gp_pitr/gp_pitr--1.1.sql
@@ -3,12 +3,17 @@
 -- complain if script is sourced in psql, rather than via CREATE EXTENSION
 \echo Use "CREATE EXTENSION gp_pitr" to load this file. \quit
 
-CREATE FUNCTION gp_create_restore_point(restore_point_name text
-    --,OUT segment_id smallint, OUT restore_lsn pg_lsn -- columns left unnamed for compatibility
+CREATE FUNCTION gp_create_restore_point(
+    IN restore_point_name text,
+    OUT gp_segment_id smallint, OUT restore_lsn pg_lsn
 )
     RETURNS SETOF record
 AS '$libdir/gp_pitr', 'gp_create_restore_point'
-LANGUAGE C IMMUTABLE STRICT;
+LANGUAGE C VOLATILE STRICT EXECUTE ON MASTER;
+
+COMMENT ON FUNCTION gp_create_restore_point(text) IS 'Create a named restore point on all segments';
+
+REVOKE EXECUTE ON FUNCTION gp_create_restore_point(text) FROM public;
 
 -- pg_switch_xlog wrapper functions to switch WAL segment files on Greenplum cluster-wide
 CREATE FUNCTION gp_switch_wal(

--- a/src/backend/access/transam/xlogfuncs_gp.c
+++ b/src/backend/access/transam/xlogfuncs_gp.c
@@ -62,7 +62,7 @@ gp_create_restore_point_internal(PG_FUNCTION_ARGS)
 
 		/* create tupdesc for result */
 		tupdesc = CreateTemplateTupleDesc(2, false);
-		TupleDescInitEntry(tupdesc, (AttrNumber) 1, "segment_id",
+		TupleDescInitEntry(tupdesc, (AttrNumber) 1, "gp_segment_id",
 						   INT2OID, -1, 0);
 		TupleDescInitEntry(tupdesc, (AttrNumber) 2, "restore_lsn",
 						   LSNOID, -1, 0);
@@ -75,7 +75,7 @@ gp_create_restore_point_internal(PG_FUNCTION_ARGS)
 		context->index = 0;
 		funcctx->user_fctx = (void *) context;
 
-		if (!IS_QUERY_DISPATCHER())
+		if (!IS_QUERY_DISPATCHER() || Gp_role != GP_ROLE_DISPATCH)
 			elog(ERROR,
 				 "cannot use gp_create_restore_point() when not in QD mode");
 
@@ -108,7 +108,7 @@ gp_create_restore_point_internal(PG_FUNCTION_ARGS)
 
 	/*
 	 * Using SRF to return all the segment LSN information of the form
-	 * {segment_id, restore_lsn}
+	 * {gp_segment_id, restore_lsn}
 	 */
 	funcctx = SRF_PERCALL_SETUP();
 	context = (Context *) funcctx->user_fctx;

--- a/src/test/gpdb_pitr/expected/gpdb_pitr_setup.out
+++ b/src/test/gpdb_pitr/expected/gpdb_pitr_setup.out
@@ -55,7 +55,7 @@ DELETE 10
 BEGIN
 4: INSERT INTO gpdb_two_phase_commit_after_restore_point SELECT generate_series(1, 10);
 INSERT 10
-4&: SELECT segment_id, count(*) FROM gp_create_restore_point('test_restore_point') AS r(segment_id smallint, restore_lsn pg_lsn) GROUP BY segment_id ORDER BY segment_id;  <waiting ...>
+4&: SELECT gp_segment_id, count(*) FROM gp_create_restore_point('test_restore_point') GROUP BY gp_segment_id ORDER BY gp_segment_id;  <waiting ...>
 1: SELECT gp_wait_until_triggered_fault('gp_create_restore_point_acquired_lock', 1, 1);
  gp_wait_until_triggered_fault 
 -------------------------------
@@ -101,12 +101,12 @@ INSERT 1
  Success:        
 (1 row)
 4<:  <... completed>
- segment_id | count 
-------------+-------
- -1         | 1     
- 0          | 1     
- 1          | 1     
- 2          | 1     
+ gp_segment_id | count 
+---------------+-------
+ -1            | 1     
+ 0             | 1     
+ 1             | 1     
+ 2             | 1     
 (4 rows)
 4: COMMIT;
 COMMIT

--- a/src/test/gpdb_pitr/expected/test_gp_create_restore_point.out
+++ b/src/test/gpdb_pitr/expected/test_gp_create_restore_point.out
@@ -1,0 +1,80 @@
+-- Test that gp_create_restore_point() creates a restore point WAL record
+-- on the coordinator and active primary segments.
+-- start_matchignore
+--
+-- # ignore NOTICE outputs from the test plpython function
+-- m/NOTICE\:.*pg_xlogdump.*/
+--
+-- end_matchignore
+-- Prepare PITR extension
+CREATE EXTENSION IF NOT EXISTS gp_pitr;
+-- Create plpython function that will run pg_xlogdump on given WAL segment
+-- file and check that the given restore point record exists or not.
+CREATE EXTENSION IF NOT EXISTS plpython2u;
+CREATE OR REPLACE FUNCTION check_restore_point_record_generated(current_xlogfile_path text, restore_point_name text)
+RETURNS bool AS $$
+    import os
+
+    cmd = 'pg_xlogdump -r xlog %s 2> /dev/null | grep %s' % (current_xlogfile_path, restore_point_name)
+    plpy.notice('Running: %s' % cmd) # useful debug info that is match ignored
+    rc = os.system(cmd)
+
+    return (rc == 0)
+$$ LANGUAGE plpython2u VOLATILE;
+-- Verify that there is currently no restore point record named
+-- test_gp_create_restore_point in the coordinator's and active primary
+-- segments' current WAL segment file. Running pg_xlogfile_name here() is
+-- okay due to the requirement of a fresh gpdemo cluster so timeline ids
+-- should all be 1.
+SELECT w.gp_segment_id,
+       check_restore_point_record_generated(c.datadir || '/pg_xlog/' || w.pg_xlogfile_name, 'test_gp_create_restore_point') AS record_found
+FROM gp_segment_configuration c,
+     (SELECT -1 AS gp_segment_id, pg_xlogfile_name(pg_current_xlog_location())
+     UNION ALL
+     SELECT gp_segment_id, pg_xlogfile_name(pg_current_xlog_location())
+     FROM gp_dist_random('gp_id')) w
+WHERE c.content = w.gp_segment_id AND c.role = 'p'
+ORDER BY w.gp_segment_id;
+ gp_segment_id | record_found 
+---------------+--------------
+            -1 | f
+             0 | f
+             1 | f
+             2 | f
+(4 rows)
+
+-- Create the restore point records
+SELECT true FROM gp_create_restore_point('test_gp_create_restore_point');
+ bool 
+------
+ t
+ t
+ t
+ t
+(4 rows)
+
+CHECKPOINT;
+-- Verify that the restore point records have been created on the
+-- coordinator and active primary segments.
+SELECT w.gp_segment_id,
+       check_restore_point_record_generated(c.datadir || '/pg_xlog/' || w.pg_xlogfile_name, 'test_gp_create_restore_point') AS record_found
+FROM gp_segment_configuration c,
+     (SELECT -1 AS gp_segment_id, pg_xlogfile_name(pg_current_xlog_location())
+     UNION ALL
+     SELECT gp_segment_id, pg_xlogfile_name(pg_current_xlog_location())
+     FROM gp_dist_random('gp_id')) w
+WHERE c.content = w.gp_segment_id AND c.role = 'p'
+ORDER BY w.gp_segment_id;
+ gp_segment_id | record_found 
+---------------+--------------
+            -1 | t
+             0 | t
+             1 | t
+             2 | t
+(4 rows)
+
+-- test simple gp_create_restore_point() error scenarios
+SELECT gp_create_restore_point('this_should_fail') FROM gp_dist_random('gp_id');
+ERROR:  function with EXECUTE ON restrictions cannot be used in the SELECT list of a query with FROM
+CREATE TABLE this_ctas_should_fail AS SELECT gp_segment_id AS contentid, restore_lsn FROM gp_create_restore_point('this_should_fail');
+ERROR:  cannot use gp_create_restore_point() when not in QD mode (xlogfuncs_gp.c:LINE_NUM)

--- a/src/test/gpdb_pitr/expected/test_gp_switch_wal.out
+++ b/src/test/gpdb_pitr/expected/test_gp_switch_wal.out
@@ -2,14 +2,6 @@
 -- constructed on the individual segments so that their timeline ids are
 -- used instead of each result having the same timeline id.
 
--- start_matchsubs
---
--- # remove line number and entrydb in error message
--- m/\(xlogfuncs_gp\.c\:\d+.*/
--- s/\(xlogfuncs_gp\.c:\d+.*/\(xlogfuncs_gp\.c:LINE_NUM\)/
---
--- end_matchsubs
-
 include: helpers/server_helpers.sql;
 CREATE
 

--- a/src/test/gpdb_pitr/init_file_gpdb_pitr
+++ b/src/test/gpdb_pitr/init_file_gpdb_pitr
@@ -1,0 +1,7 @@
+-- start_matchsubs
+
+# remove line number and entrydb in error message
+m/\(xlogfuncs_gp\.c\:\d+.*/
+s/\(xlogfuncs_gp\.c:\d+.*/\(xlogfuncs_gp\.c:LINE_NUM\)/
+
+-- end_matchsubs

--- a/src/test/gpdb_pitr/sql/gpdb_pitr_setup.sql
+++ b/src/test/gpdb_pitr/sql/gpdb_pitr_setup.sql
@@ -32,7 +32,7 @@ INSERT INTO gpdb_one_phase_commit VALUES (1);
 -- so it will not show up later during PITR.
 4: BEGIN;
 4: INSERT INTO gpdb_two_phase_commit_after_restore_point SELECT generate_series(1, 10);
-4&: SELECT segment_id, count(*) FROM gp_create_restore_point('test_restore_point') AS r(segment_id smallint, restore_lsn pg_lsn) GROUP BY segment_id ORDER BY segment_id;
+4&: SELECT gp_segment_id, count(*) FROM gp_create_restore_point('test_restore_point') GROUP BY gp_segment_id ORDER BY gp_segment_id;
 1: SELECT gp_wait_until_triggered_fault('gp_create_restore_point_acquired_lock', 1, 1);
 
 -- Distributed commit record will not be written; commit blocked by

--- a/src/test/gpdb_pitr/sql/test_gp_create_restore_point.sql
+++ b/src/test/gpdb_pitr/sql/test_gp_create_restore_point.sql
@@ -1,0 +1,61 @@
+-- Test that gp_create_restore_point() creates a restore point WAL record
+-- on the coordinator and active primary segments.
+
+-- start_matchignore
+--
+-- # ignore NOTICE outputs from the test plpython function
+-- m/NOTICE\:.*pg_xlogdump.*/
+--
+-- end_matchignore
+
+-- Prepare PITR extension
+CREATE EXTENSION IF NOT EXISTS gp_pitr;
+
+-- Create plpython function that will run pg_xlogdump on given WAL segment
+-- file and check that the given restore point record exists or not.
+CREATE EXTENSION IF NOT EXISTS plpython2u;
+CREATE OR REPLACE FUNCTION check_restore_point_record_generated(current_xlogfile_path text, restore_point_name text)
+RETURNS bool AS $$
+    import os
+
+    cmd = 'pg_xlogdump -r xlog %s 2> /dev/null | grep %s' % (current_xlogfile_path, restore_point_name)
+    plpy.notice('Running: %s' % cmd) # useful debug info that is match ignored
+    rc = os.system(cmd)
+
+    return (rc == 0)
+$$ LANGUAGE plpython2u VOLATILE;
+
+-- Verify that there is currently no restore point record named
+-- test_gp_create_restore_point in the coordinator's and active primary
+-- segments' current WAL segment file. Running pg_xlogfile_name here() is
+-- okay due to the requirement of a fresh gpdemo cluster so timeline ids
+-- should all be 1.
+SELECT w.gp_segment_id,
+       check_restore_point_record_generated(c.datadir || '/pg_xlog/' || w.pg_xlogfile_name, 'test_gp_create_restore_point') AS record_found
+FROM gp_segment_configuration c,
+     (SELECT -1 AS gp_segment_id, pg_xlogfile_name(pg_current_xlog_location())
+     UNION ALL
+     SELECT gp_segment_id, pg_xlogfile_name(pg_current_xlog_location())
+     FROM gp_dist_random('gp_id')) w
+WHERE c.content = w.gp_segment_id AND c.role = 'p'
+ORDER BY w.gp_segment_id;
+
+-- Create the restore point records
+SELECT true FROM gp_create_restore_point('test_gp_create_restore_point');
+CHECKPOINT;
+
+-- Verify that the restore point records have been created on the
+-- coordinator and active primary segments.
+SELECT w.gp_segment_id,
+       check_restore_point_record_generated(c.datadir || '/pg_xlog/' || w.pg_xlogfile_name, 'test_gp_create_restore_point') AS record_found
+FROM gp_segment_configuration c,
+     (SELECT -1 AS gp_segment_id, pg_xlogfile_name(pg_current_xlog_location())
+     UNION ALL
+     SELECT gp_segment_id, pg_xlogfile_name(pg_current_xlog_location())
+     FROM gp_dist_random('gp_id')) w
+WHERE c.content = w.gp_segment_id AND c.role = 'p'
+ORDER BY w.gp_segment_id;
+
+-- test simple gp_create_restore_point() error scenarios
+SELECT gp_create_restore_point('this_should_fail') FROM gp_dist_random('gp_id');
+CREATE TABLE this_ctas_should_fail AS SELECT gp_segment_id AS contentid, restore_lsn FROM gp_create_restore_point('this_should_fail');

--- a/src/test/gpdb_pitr/sql/test_gp_switch_wal.sql
+++ b/src/test/gpdb_pitr/sql/test_gp_switch_wal.sql
@@ -2,14 +2,6 @@
 -- constructed on the individual segments so that their timeline ids are
 -- used instead of each result having the same timeline id.
 
--- start_matchsubs
---
--- # remove line number and entrydb in error message
--- m/\(xlogfuncs_gp\.c\:\d+.*/
--- s/\(xlogfuncs_gp\.c:\d+.*/\(xlogfuncs_gp\.c:LINE_NUM\)/
---
--- end_matchsubs
-
 include: helpers/server_helpers.sql;
 
 -- Prepare PITR extension

--- a/src/test/gpdb_pitr/test_gpdb_pitr.sh
+++ b/src/test/gpdb_pitr/test_gpdb_pitr.sh
@@ -42,7 +42,7 @@ REPLICA_PRIMARY2_DBID=12
 REPLICA_PRIMARY3_DBID=13
 
 # The options for pg_regress and pg_isolation2_regress.
-REGRESS_OPTS="--dbname=gpdb_pitr_database --use-existing --init-file=../regress/init_file --init-file=init_file --load-extension=gp_inject_fault"
+REGRESS_OPTS="--dbname=gpdb_pitr_database --use-existing --init-file=../regress/init_file --init-file=./init_file_gpdb_pitr --load-extension=gp_inject_fault"
 ISOLATION2_REGRESS_OPTS="${REGRESS_OPTS} --init-file=../isolation2/init_file_isolation2"
 
 # Run test via pg_regress with given test name.
@@ -70,6 +70,9 @@ run_test_isolation2()
 
 # Create our test database.
 createdb gpdb_pitr_database
+
+# Test gp_create_restore_point()
+run_test test_gp_create_restore_point
 
 # Test output of gp_switch_wal()
 run_test_isolation2 test_gp_switch_wal


### PR DESCRIPTION
The gp_create_restore_point() catalog function was not properly marked
as EXECUTE ON COORDINATOR and required a column definition list to get
nice looking output from a `SELECT *`. Fix the issues by marking the
proexeclocation as 'c' (previously using default 'a') and explicitly
setting the proarg details. A dedicated test has been added to the
gpdb_pitr test suite to add some needed test coverage.

Backported from GPDB master commit:
https://github.com/greenplum-db/gpdb/commit/8aaa0474610ee608eae2aa13d7096bff261819a0

6X backport merge conflicts:
* The gp_create_restore_point() catalog function is an extension
  function in 6X_STABLE so relative changes had to be made to the
  extension accordingly instead.
* On 6X, it's EXECUTE ON MASTER instead of EXECUTE ON COORDINATOR.
* Needed to mark the function as VOLATILE instead of IMMUTABLE as it's
  properly marked as VOLATILE in GPDB master (7X).

With this PR, the 6X gp_pitr extension function `gp_create_restore_point()` should match up with the 7X+ catalog function `gp_create_restore_point()`.