### PR TITLE
Update gp_stat_archiver view definition in gp_pitr extension

### DIFF
--- a/gpcontrib/gp_pitr/gp_pitr--1.0--1.1.sql
+++ b/gpcontrib/gp_pitr/gp_pitr--1.0--1.1.sql
@@ -15,7 +15,7 @@ COMMENT ON FUNCTION gp_switch_wal() IS 'Switch WAL segment files on all segments
 
 REVOKE EXECUTE ON FUNCTION gp_switch_wal() FROM public;
 
-CREATE OR REPLACE VIEW gp_stat_archiver AS
+CREATE VIEW gp_stat_archiver AS
 SELECT -1 AS gp_segment_id, * FROM pg_stat_archiver
 UNION
 SELECT gp_execution_segment() AS gp_segment_id, * FROM gp_dist_random('pg_stat_archiver');

--- a/gpcontrib/gp_pitr/gp_pitr--1.1.sql
+++ b/gpcontrib/gp_pitr/gp_pitr--1.1.sql
@@ -22,7 +22,7 @@ COMMENT ON FUNCTION gp_switch_wal() IS 'Switch WAL segment files on all segments
 
 REVOKE EXECUTE ON FUNCTION gp_switch_wal() FROM public;
 
-CREATE OR REPLACE VIEW gp_stat_archiver AS
+CREATE VIEW gp_stat_archiver AS
 SELECT -1 AS gp_segment_id, * FROM pg_stat_archiver
 UNION
 SELECT gp_execution_segment() AS gp_segment_id, * FROM gp_dist_random('pg_stat_archiver');


### PR DESCRIPTION
The newly introduced gp_stat_archiver view was added into the
extension script as CREATE OR REPLACE VIEW. While this is technically
okay, it doesn't look right and at the time of merging the commit into
GPDB 6X had a potential security issue (see reference commit). Update
it to simply use CREATE VIEW to prevent any possible future issues.

GPDB 6X commit reference:
https://github.com/greenplum-db/gpdb/commit/ecc2f0b2b7a11ab137078db3383d7245771df21a