### PR TITLE
[psql] Add support for describing auxiliary tables for ao table.

### DIFF
--- a/src/bin/psql/describe.c
+++ b/src/bin/psql/describe.c
@@ -2293,6 +2293,18 @@ describeOneTableDetails(const char *schemaname,
 				printfPQExpBuffer(&title, _("Partitioned table \"%s.%s\""),
 								  schemaname, relationname);
 			break;
+		case RELKIND_AOSEGMENTS:
+			printfPQExpBuffer(&title, _("Appendonly segment entry table: \"%s.%s\""),
+							  schemaname, relationname);
+			break;
+		case RELKIND_AOVISIMAP:
+			printfPQExpBuffer(&title, _("Appendonly visibility map table: \"%s.%s\""),
+							  schemaname, relationname);
+			break;
+		case RELKIND_AOBLOCKDIR:
+			printfPQExpBuffer(&title, _("Appendonly block directory table: \"%s.%s\""),
+							  schemaname, relationname);
+			break;
 		default:
 			/* untranslated unknown relkind */
 			printfPQExpBuffer(&title, "?%c? \"%s.%s\"",
@@ -2637,7 +2649,10 @@ describeOneTableDetails(const char *schemaname,
 	else if (tableinfo.relkind == RELKIND_RELATION ||
 			 tableinfo.relkind == RELKIND_MATVIEW ||
 			 tableinfo.relkind == RELKIND_FOREIGN_TABLE ||
-			 tableinfo.relkind == RELKIND_PARTITIONED_TABLE)
+			 tableinfo.relkind == RELKIND_PARTITIONED_TABLE ||
+			 tableinfo.relkind == RELKIND_AOSEGMENTS ||
+			 tableinfo.relkind == RELKIND_AOBLOCKDIR ||
+			 tableinfo.relkind == RELKIND_AOVISIMAP)
 	{
 		/* Footer information about a table */
 		PGresult   *result = NULL;


### PR DESCRIPTION
Fixes issue: #13997 for master branch.

This patch adds support for describing auxiliary tables. e.g.,

```
postgres=# create table foo(i int) with (appendonly=true);

postgres=# create index on foo(i);
CREATE INDEX

postgres=# select blkdirrelid::regclass from pg_appendonly where relid = 'foo'::regclass;
        blkdirrelid
----------------------------
 pg_aoseg.pg_aoblkdir_16411
(1 row)

postgres=# \d+ pg_aoseg.pg_aoblkdir_16411
Appendonly block directory table: "pg_aoseg.pg_aoblkdir_16411"
     Column     |  Type   | Storage
----------------+---------+---------
 segno          | integer | plain
 columngroup_no | integer | plain
 first_row_no   | bigint  | plain
 minipage       | bytea   | plain
Indexes:
    "pg_aoblkdir_16411_index" PRIMARY KEY, btree (segno, columngroup_no, first_row_no)

postgres=# \d+ pg_aoseg.pg_aovisimap_16411
Appendonly visibility map : "pg_aoseg.pg_aovisimap_16411"
    Column    |  Type   | Storage
--------------+---------+---------
 segno        | integer | plain
 first_row_no | bigint  | plain
 visimap      | bytea   | plain
Indexes:
    "pg_aovisimap_16411_index" PRIMARY KEY, btree (segno, first_row_no)

postgres=# \d+ pg_aoseg.pg_aoseg_16411
Appendonly segment entry table: "pg_aoseg.pg_aoseg_16411"
     Column      |   Type   | Storage
-----------------+----------+---------
 segno           | integer  | plain
 eof             | bigint   | plain
 tupcount        | bigint   | plain
 varblockcount   | bigint   | plain
 eofuncompressed | bigint   | plain
 modcount        | bigint   | plain
 formatversion   | smallint | plain
 state           | smallint | plain
```

I didn't add a test since the `oid` of appendonly tables are changing over time and this change is straight forward.