### PR TITLE
NEW SYNTAX of resource group cpuset

### DIFF
--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -615,6 +615,7 @@ InitResGroups(void)
 		Oid			groupId = ((Form_pg_resgroup) GETSTRUCT(tuple))->oid;
 		ResGroupData	*group;
 		int cpuRateLimit;
+		Bitmapset *bmsCurrent;
 
 		GetResGroupCapabilities(relResGroupCapability, groupId, &caps);
 		cpuRateLimit = caps.cpuRateLimit;
@@ -631,8 +632,12 @@ InitResGroups(void)
 		}
 		else
 		{
-			Bitmapset *bmsCurrent = CpusetToBitset(caps.cpuset,
-												   MaxCpuSetLength);
+			char **cpusetArray = getSpiltCpuSet(caps.cpuset);
+			if (Gp_role == GP_ROLE_EXECUTE && cpusetArray[1] != NULL)
+				bmsCurrent = CpusetToBitset(cpusetArray[1], MaxCpuSetLength);
+			else
+				bmsCurrent = CpusetToBitset(cpusetArray[0], MaxCpuSetLength);
+
 			Bitmapset *bmsCommon = bms_intersect(bmsCurrent, bmsUnused);
 			Bitmapset *bmsMissing = bms_difference(bmsCurrent, bmsCommon);
 
@@ -657,7 +662,11 @@ InitResGroups(void)
 				 * write cpus to corresponding file
 				 * if all the cores are available
 				 */
-				ResGroupOps_SetCpuSet(groupId, caps.cpuset);
+				char **cpusetArray = getSpiltCpuSet(caps.cpuset);
+				if (Gp_role == GP_ROLE_EXECUTE && cpusetArray[1] != NULL)
+					ResGroupOps_SetCpuSet(groupId, cpusetArray[1]);
+				else
+					ResGroupOps_SetCpuSet(groupId, cpusetArray[0]);
 				bmsUnused = bms_del_members(bmsUnused, bmsCurrent);
 			}
 			else
@@ -909,8 +918,13 @@ ResGroupAlterOnCommit(const ResourceGroupCallbackContext *callbackCtx)
 		else if (callbackCtx->limittype == RESGROUP_LIMIT_TYPE_CPUSET)
 		{
 			if (gp_resource_group_enable_cgroup_cpuset)
-				ResGroupOps_SetCpuSet(callbackCtx->groupid,
-									  callbackCtx->caps.cpuset);
+			{
+				char **cpusetArray = getSpiltCpuSet(callbackCtx->caps.cpuset);
+				if (Gp_role == GP_ROLE_EXECUTE && cpusetArray[1] != NULL)
+					ResGroupOps_SetCpuSet(callbackCtx->groupid, cpusetArray[1]);
+				else
+					ResGroupOps_SetCpuSet(callbackCtx->groupid, cpusetArray[0]);
+			}
 		}
 		else if (callbackCtx->limittype != RESGROUP_LIMIT_TYPE_MEMORY_SPILL_RATIO)
 		{
@@ -935,12 +949,32 @@ ResGroupAlterOnCommit(const ResourceGroupCallbackContext *callbackCtx)
 								  MaxCpuSetLength);
 			/* Add old value to default group
 			 * sub new value from default group */
-			CpusetUnion(defaultCpusetGroup,
-							callbackCtx->oldCaps.cpuset,
+			char **cpusetArray = getSpiltCpuSet(callbackCtx->caps.cpuset);
+			char **oldcpusetArray = getSpiltCpuSet(callbackCtx->oldCaps.cpuset);
+
+			if (Gp_role == GP_ROLE_EXECUTE)
+			{
+				char *oldcpuset = (oldcpusetArray[1] == NULL) ?
+								oldcpusetArray[0] : oldcpusetArray[1];
+				char *cpuset = (cpusetArray[1] == NULL) ?
+								cpusetArray[0] : cpusetArray[1];
+
+				CpusetUnion(defaultCpusetGroup,
+							oldcpuset,
 							MaxCpuSetLength);
-			CpusetDifference(defaultCpusetGroup,
-							callbackCtx->caps.cpuset,
+				CpusetDifference(defaultCpusetGroup,
+							cpuset,
 							MaxCpuSetLength);
+			} else
+			{
+				CpusetUnion(defaultCpusetGroup,
+							oldcpusetArray[0],
+							MaxCpuSetLength);
+				CpusetDifference(defaultCpusetGroup,
+							cpusetArray[0],
+							MaxCpuSetLength);
+			}
+
 			ResGroupOps_SetCpuSet(DEFAULT_CPUSET_GROUP_ID, defaultCpusetGroup);
 		}
 	}

--- a/src/include/utils/resgroup.h
+++ b/src/include/utils/resgroup.h
@@ -31,6 +31,11 @@
 #define MaxCpuSetLength 1024
 
 /*
+ * The max length of cpuset array
+ */
+#define CpuSetArrayLength 2
+
+/*
  * Default value of cpuset
  */
 #define DefaultCpuset "-1"
@@ -84,8 +89,9 @@ typedef struct ResGroupCaps
 } ResGroupCaps;
 
 /* Set 'cpuset' to an empty string, and reset all other fields to zero */
-#define ClearResGroupCaps(caps) \
-	MemSet((caps), 0, offsetof(ResGroupCaps, cpuset) + 1)
+#define ClearResGroupCaps(caps) do { \
+	MemSet((caps), 0, offsetof(ResGroupCaps, cpuset) + 1); \
+} while(0)
 
 
 /*
@@ -227,6 +233,7 @@ extern void ResGroupMoveQuery(int sessionId, Oid groupId, const char *groupName)
 extern int32 ResGroupGetSessionMemUsage(int sessionId);
 extern int32 ResGroupGetGroupAvailableMem(Oid groupId);
 extern Oid ResGroupGetGroupIdBySessionId(int sessionId);
+extern char **getSpiltCpuSet(const char *cpuset);
 
 #define LOG_RESGROUP_DEBUG(...) \
 	do {if (Debug_resource_group) elog(__VA_ARGS__); } while(false);

--- a/src/test/isolation2/expected/resgroup/resgroup_syntax.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_syntax.out
@@ -152,6 +152,17 @@ CREATE RESOURCE GROUP rg_test_group WITH (cpuset='3-1', memory_limit=5);
 ERROR:  cpuset invalid
 CREATE RESOURCE GROUP rg_test_group WITH (cpuset=' 0 ', memory_limit=5);
 ERROR:  cpuset invalid
+CREATE RESOURCE GROUP rg_test_group WITH (cpuset='0;3-1', memory_limit=5);
+ERROR:  cpuset invalid
+CREATE RESOURCE GROUP rg_test_group WITH (cpuset='4;a', memory_limit=5);
+ERROR:  cpuset invalid
+CREATE RESOURCE GROUP rg_test_group WITH (cpuset='-;4', memory_limit=5);
+ERROR:  cpuset invalid
+CREATE RESOURCE GROUP rg_test_group WITH (cpuset=';5', memory_limit=5);
+ERROR:  cpuset invalid
+CREATE RESOURCE GROUP rg_test_group WITH (cpuset='5;', memory_limit=5);
+ERROR:  cpuset invalid
+
 ---- suppose the core numbered 1024 is not exist
 CREATE RESOURCE GROUP rg_test_group WITH (cpuset='1024', memory_limit=5);
 ERROR:  cpu cores 1024 are unavailable on the system
@@ -177,6 +188,16 @@ ERROR:  cpuset invalid
 ALTER RESOURCE GROUP rg_test_group set CPUSET '3-1';
 ERROR:  cpuset invalid
 ALTER RESOURCE GROUP rg_test_group set CPUSET ' 0 ';
+ERROR:  cpuset invalid
+ALTER RESOURCE GROUP rg_test_group set CPUSET '5;3-1';
+ERROR:  cpuset invalid
+ALTER RESOURCE GROUP rg_test_group set CPUSET '4;a';
+ERROR:  cpuset invalid
+ALTER RESOURCE GROUP rg_test_group set CPUSET '-;4';
+ERROR:  cpuset invalid
+ALTER RESOURCE GROUP rg_test_group set CPUSET ';5';
+ERROR:  cpuset invalid
+ALTER RESOURCE GROUP rg_test_group set CPUSET '5;';
 ERROR:  cpuset invalid
 ---- suppose the core numbered 1024 is not exist
 ALTER RESOURCE GROUP rg_test_group set CPUSET '1024';
@@ -233,7 +254,15 @@ SELECT groupname,concurrency,cpu_rate_limit,memory_limit,memory_shared_quota,mem
 (1 row)
 DROP RESOURCE GROUP rg_test_group;
 DROP
-
+CREATE RESOURCE GROUP rg_test_group WITH (cpuset='1;4-5');
+CREATE
+SELECT groupname,concurrency,cpu_rate_limit,memory_limit,memory_shared_quota,memory_spill_ratio FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_test_group';
+ groupname     | concurrency | cpu_rate_limit | memory_limit | memory_shared_quota | memory_spill_ratio 
+---------------+-------------+----------------+--------------+---------------------+--------------------
+ rg_test_group | 20          | -1             | 0            | 80                  | 0                  
+(1 row)
+DROP RESOURCE GROUP rg_test_group;
+DROP
 -- ----------------------------------------------------------------------
 -- Test: boundary check in create resource group syntax
 -- ----------------------------------------------------------------------
@@ -610,5 +639,15 @@ CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, me
 CREATE
 ALTER RESOURCE GROUP rg_test_group SET memory_limit 0;
 ERROR:  when memory_limit is unlimited memory_spill_ratio must be set to 0
+DROP RESOURCE GROUP rg_test_group;
+DROP
+
+-- positive: test master/segment cpuset
+CREATE RESOURCE GROUP rg_test_group WITH (cpuset='1;4-5');
+CREATE
+ALTER RESOURCE GROUP rg_test_group SET CPUSET '2;4-5';
+ALTER
+ALTER RESOURCE GROUP rg_test_group SET CPUSET '3;4-5';
+ALTER
 DROP RESOURCE GROUP rg_test_group;
 DROP

--- a/src/test/isolation2/input/resgroup/resgroup_cpuset.source
+++ b/src/test/isolation2/input/resgroup/resgroup_cpuset.source
@@ -292,6 +292,25 @@ SELECT gp_inject_fault('create_resource_group_fail', 'reset', 1);
 DROP RESOURCE GROUP rg1_test_group;
 -- end_ignore
 
+-- test segment/master cpuset
+CREATE RESOURCE GROUP rg_multi_cpuset1 WITH (concurrency=2, cpuset='0;1-2');
+
+CREATE RESOURCE GROUP rg_multi_cpuset WITH (concurrency=2, cpuset='0;1-2');
+CREATE RESOURCE GROUP rg_multi_cpuset WITH (concurrency=2, cpuset='0');
+
+CREATE RESOURCE GROUP rg_multi_cpuset2 WITH (concurrency=2, cpuset='3;4-5');
+
+ALTER RESOURCE GROUP rg_multi_cpuset2 set CPUSET '0;1-3';
+ALTER RESOURCE GROUP rg_multi_cpuset2 set CPUSET '6';
+ALTER RESOURCE GROUP rg_multi_cpuset1 set CPUSET '3;4-5';
+ALTER RESOURCE GROUP rg_multi_cpuset2 set CPUSET '0;1-2';
+
+select groupname,cpuset from gp_toolkit.gp_resgroup_config where groupname='rg_multi_cpuset1';
+select groupname,cpuset from gp_toolkit.gp_resgroup_config where groupname='rg_multi_cpuset2';
+
+DROP RESOURCE GROUP rg_multi_cpuset1;
+DROP RESOURCE GROUP rg_multi_cpuset2;
+
 REVOKE ALL ON busy FROM role1_cpuset_test;
 DROP ROLE role1_cpuset_test;
 DROP RESOURCE GROUP rg1_cpuset_test;

--- a/src/test/isolation2/output/resgroup/resgroup_cpuset.source
+++ b/src/test/isolation2/output/resgroup/resgroup_cpuset.source
@@ -287,6 +287,43 @@ SELECT gp_inject_fault('create_resource_group_fail', 'reset', 1);
  Success:        
 (1 row)
 
+-- test segment/master cpuset
+CREATE RESOURCE GROUP rg_multi_cpuset1 WITH (concurrency=2, cpuset='0;1-2');
+CREATE
+
+CREATE RESOURCE GROUP rg_multi_cpuset WITH (concurrency=2, cpuset='0;1-2');
+ERROR:  cpu cores 0 are used by resource group rg_multi_cpuset1
+CREATE RESOURCE GROUP rg_multi_cpuset WITH (concurrency=2, cpuset='0');
+ERROR:  cpu cores 0 are used by resource group rg_multi_cpuset1
+
+CREATE RESOURCE GROUP rg_multi_cpuset2 WITH (concurrency=2, cpuset='3;4-5');
+CREATE
+
+ALTER RESOURCE GROUP rg_multi_cpuset2 set CPUSET '0;1-3';
+ERROR:  cpu cores 0 are used by resource group rg_multi_cpuset1
+ALTER RESOURCE GROUP rg_multi_cpuset2 set CPUSET '6';
+ALTER
+ALTER RESOURCE GROUP rg_multi_cpuset1 set CPUSET '3;4-5';
+ALTER
+ALTER RESOURCE GROUP rg_multi_cpuset2 set CPUSET '0;1-2';
+ALTER
+
+select groupname,cpuset from gp_toolkit.gp_resgroup_config where groupname='rg_multi_cpuset1';
+ groupname        | cpuset 
+------------------+--------
+ rg_multi_cpuset1 | 3;4-5  
+(1 row)
+select groupname,cpuset from gp_toolkit.gp_resgroup_config where groupname='rg_multi_cpuset2';
+ groupname        | cpuset 
+------------------+--------
+ rg_multi_cpuset2 | 0;1-2  
+(1 row)
+
+DROP RESOURCE GROUP rg_multi_cpuset1;
+DROP
+DROP RESOURCE GROUP rg_multi_cpuset2;
+DROP
+
 REVOKE ALL ON busy FROM role1_cpuset_test;
 REVOKE
 DROP ROLE role1_cpuset_test;

--- a/src/test/isolation2/sql/resgroup/resgroup_syntax.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_syntax.sql
@@ -77,6 +77,12 @@ CREATE RESOURCE GROUP rg_test_group WITH (cpuset='0-,', memory_limit=5);
 CREATE RESOURCE GROUP rg_test_group WITH (cpuset='-1', memory_limit=5);
 CREATE RESOURCE GROUP rg_test_group WITH (cpuset='3-1', memory_limit=5);
 CREATE RESOURCE GROUP rg_test_group WITH (cpuset=' 0 ', memory_limit=5);
+CREATE RESOURCE GROUP rg_test_group WITH (cpuset='0;3-1', memory_limit=5);
+CREATE RESOURCE GROUP rg_test_group WITH (cpuset='4;a', memory_limit=5);
+CREATE RESOURCE GROUP rg_test_group WITH (cpuset='-;4', memory_limit=5);
+CREATE RESOURCE GROUP rg_test_group WITH (cpuset=';5', memory_limit=5);
+CREATE RESOURCE GROUP rg_test_group WITH (cpuset='5;', memory_limit=5);
+
 ---- suppose the core numbered 1024 is not exist
 CREATE RESOURCE GROUP rg_test_group WITH (cpuset='1024', memory_limit=5);
 CREATE RESOURCE GROUP rg_test_group WITH (cpuset='0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,', memory_limit=5);
@@ -91,6 +97,11 @@ ALTER RESOURCE GROUP rg_test_group set CPUSET '0-';
 ALTER RESOURCE GROUP rg_test_group set CPUSET '-1';
 ALTER RESOURCE GROUP rg_test_group set CPUSET '3-1';
 ALTER RESOURCE GROUP rg_test_group set CPUSET ' 0 ';
+ALTER RESOURCE GROUP rg_test_group set CPUSET '5;3-1';
+ALTER RESOURCE GROUP rg_test_group set CPUSET '4;a';
+ALTER RESOURCE GROUP rg_test_group set CPUSET '-;4';
+ALTER RESOURCE GROUP rg_test_group set CPUSET ';5';
+ALTER RESOURCE GROUP rg_test_group set CPUSET '5;';
 ---- suppose the core numbered 1024 is not exist
 ALTER RESOURCE GROUP rg_test_group set CPUSET '1024';
 ALTER RESOURCE GROUP rg_test_group set CPUSET '0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,';
@@ -115,7 +126,10 @@ DROP RESOURCE GROUP rg_test_group;
 CREATE RESOURCE GROUP rg_test_group WITH (cpuset='0');
 SELECT groupname,concurrency,cpu_rate_limit,memory_limit,memory_shared_quota,memory_spill_ratio FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_test_group';
 DROP RESOURCE GROUP rg_test_group;
-
+CREATE RESOURCE GROUP rg_test_group WITH (cpuset='1;4-5');
+SELECT groupname,concurrency,cpu_rate_limit,memory_limit,memory_shared_quota,memory_spill_ratio
+FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_test_group';
+DROP RESOURCE GROUP rg_test_group;
 -- ----------------------------------------------------------------------
 -- Test: boundary check in create resource group syntax
 -- ----------------------------------------------------------------------
@@ -318,4 +332,10 @@ DROP RESOURCE GROUP rg_test_group;
 -- negative: memory_limit must be limited if memory_spill_ratio > 0
 CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio=10);
 ALTER RESOURCE GROUP rg_test_group SET memory_limit 0;
+DROP RESOURCE GROUP rg_test_group;
+
+-- positive: test master/segment cpuset
+CREATE RESOURCE GROUP rg_test_group WITH (cpuset='1;4-5');
+ALTER RESOURCE GROUP rg_test_group SET CPUSET '2;4-5';
+ALTER RESOURCE GROUP rg_test_group SET CPUSET '3;4-5';
 DROP RESOURCE GROUP rg_test_group;


### PR DESCRIPTION
New SYNTAX of resource group cpuset for different master and segment
Using syntax like cpuset="1;3-4" could different cpuset of master and segment by semicolon.  For example,
if we define cpuset="1;3-4", then master will use the first  cpu core, segments will use third  and fourth core.

CREATE and ALTER resource group support this new syntax.
```
postgres=# CREATE RESOURCE GROUP rg1 WITH (cpuset='1;2-3');
CREATE RESOURCE GROUP
postgres=# select groupname, cpuset from gp_toolkit.gp_resgroup_config where groupname = 'rg1';
 groupname | cpuset 
-----------+--------
 rg1       | 1;2-3
(1 row)

postgres=# ALTER resource group rg1 SET cpuset '4;5-6';
ALTER RESOURCE GROUP
postgres=# select groupname, cpuset from gp_toolkit.gp_resgroup_config where groupname = 'rg1';
 groupname | cpuset 
-----------+--------
 rg1       | 4;5-6
(1 row)
```

we didn't make too much motification on Resource group. For differentiate on mater and segment, seperating cpuset by semicolon, then apply the first half of it to master and second half to segment.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
