### PR TITLE
Resolve one GPDB_12_MERGE_FIXME in describe.c

### DIFF
--- a/src/bin/psql/describe.c
+++ b/src/bin/psql/describe.c
@@ -4646,12 +4646,8 @@ listTables(const char *tabtypes, const char *pattern, bool verbose, bool showSys
 	{
 		if (isGPDB7000OrLater())
 		{
-			appendPQExpBuffer(&buf, ", CASE c.relam");
-			appendPQExpBuffer(&buf, " WHEN %d THEN '%s'", HEAP_TABLE_AM_OID, gettext_noop("heap"));
-			appendPQExpBuffer(&buf, " WHEN %d THEN '%s'", AO_ROW_TABLE_AM_OID, gettext_noop("append only"));
-			appendPQExpBuffer(&buf, " WHEN %d THEN '%s'", AO_COLUMN_TABLE_AM_OID, gettext_noop("append only columnar"));
-			/* GPDB_12_MERGE_FIXME fill other storage types */
-			appendPQExpBuffer(&buf, " END as \"%s\"\n", gettext_noop("Storage"));
+			/* In GPDB7, we can have user defined access method, display the access method name directly */
+			appendPQExpBuffer(&buf, ", a.amname as \"%s\"\n", gettext_noop("Storage"));
 		}
 		else
 		{
@@ -4695,6 +4691,9 @@ listTables(const char *tabtypes, const char *pattern, bool verbose, bool showSys
 	appendPQExpBufferStr(&buf,
 						 "\nFROM pg_catalog.pg_class c"
 						 "\n     LEFT JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace");
+	if (showTables && isGPDB7000OrLater())
+		appendPQExpBufferStr(&buf,
+							"\n     LEFT JOIN pg_catalog.pg_am a ON a.oid = c.relam");
 	if (showIndexes)
 		appendPQExpBufferStr(&buf,
 							 "\n     LEFT JOIN pg_catalog.pg_index i ON i.indexrelid = c.oid"

--- a/src/test/regress/expected/psql_gp_commands.out
+++ b/src/test/regress/expected/psql_gp_commands.out
@@ -148,30 +148,38 @@ ALTER FOREIGN TABLE "dE_foreign_table" OWNER TO test_psql_de_role;
 CREATE EXTERNAL TABLE "dE_external_table"  (c1 integer)
   LOCATION ('file://localhost/dummy') FORMAT 'text';
 ALTER EXTERNAL TABLE "dE_external_table" OWNER TO test_psql_de_role;
+-- create table using user defined access method
+CREATE ACCESS METHOD bogus TYPE TABLE HANDLER heap_tableam_handler;
+CREATE TABLE d_bogus_heap(a int) USING bogus;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+ALTER TABLE "d_bogus_heap" OWNER TO test_psql_de_role;
 -- There's a GPDB-specific Storage column.
 \d
-                                        List of relations
-      Schema      |       Name        |     Type      |       Owner       |       Storage        
-------------------+-------------------+---------------+-------------------+----------------------
+                                  List of relations
+      Schema      |       Name        |     Type      |       Owner       |  Storage  
+------------------+-------------------+---------------+-------------------+-----------
  test_psql_schema | dE_external_table | foreign table | test_psql_de_role | 
  test_psql_schema | dE_foreign_table  | foreign table | test_psql_de_role | 
- test_psql_schema | d_ao              | table         | test_psql_de_role | append only
- test_psql_schema | d_aocs            | table         | test_psql_de_role | append only columnar
+ test_psql_schema | d_ao              | table         | test_psql_de_role | ao_row
+ test_psql_schema | d_aocs            | table         | test_psql_de_role | ao_column
+ test_psql_schema | d_bogus_heap      | table         | test_psql_de_role | bogus
  test_psql_schema | d_heap            | table         | test_psql_de_role | heap
  test_psql_schema | d_view            | view          | test_psql_de_role | 
-(6 rows)
+(7 rows)
 
 \d+
-                                                    List of relations
-      Schema      |       Name        |     Type      |       Owner       |       Storage        |  Size   | Description 
-------------------+-------------------+---------------+-------------------+----------------------+---------+-------------
- test_psql_schema | dE_external_table | foreign table | test_psql_de_role |                      | 0 bytes | 
- test_psql_schema | dE_foreign_table  | foreign table | test_psql_de_role |                      | 0 bytes | 
- test_psql_schema | d_ao              | table         | test_psql_de_role | append only          | 128 kB  | 
- test_psql_schema | d_aocs            | table         | test_psql_de_role | append only columnar | 128 kB  | 
- test_psql_schema | d_heap            | table         | test_psql_de_role | heap                 | 0 bytes | 
- test_psql_schema | d_view            | view          | test_psql_de_role |                      | 0 bytes | 
-(6 rows)
+                                              List of relations
+      Schema      |       Name        |     Type      |       Owner       |  Storage  |  Size   | Description 
+------------------+-------------------+---------------+-------------------+-----------+---------+-------------
+ test_psql_schema | dE_external_table | foreign table | test_psql_de_role |           | 0 bytes | 
+ test_psql_schema | dE_foreign_table  | foreign table | test_psql_de_role |           | 0 bytes | 
+ test_psql_schema | d_ao              | table         | test_psql_de_role | ao_row    | 128 kB  | 
+ test_psql_schema | d_aocs            | table         | test_psql_de_role | ao_column | 128 kB  | 
+ test_psql_schema | d_bogus_heap      | table         | test_psql_de_role | bogus     | 0 bytes | 
+ test_psql_schema | d_heap            | table         | test_psql_de_role | heap      | 0 bytes | 
+ test_psql_schema | d_view            | view          | test_psql_de_role |           | 0 bytes | 
+(7 rows)
 
 -- The Storage column is not interesting for indexes, so it's omitted with
 -- \di
@@ -191,14 +199,15 @@ ALTER EXTERNAL TABLE "dE_external_table" OWNER TO test_psql_de_role;
 
 -- But if tables are shown, too, then it's interesting again.
 \dti
-                                   List of relations
-      Schema      |  Name   | Type  |       Owner       |       Storage        | Table  
-------------------+---------+-------+-------------------+----------------------+--------
- test_psql_schema | d_ao    | table | test_psql_de_role | append only          | 
- test_psql_schema | d_aocs  | table | test_psql_de_role | append only columnar | 
- test_psql_schema | d_heap  | table | test_psql_de_role | heap                 | 
- test_psql_schema | d_index | index | test_psql_de_role |                      | d_heap
-(4 rows)
+                                List of relations
+      Schema      |     Name     | Type  |       Owner       |  Storage  | Table  
+------------------+--------------+-------+-------------------+-----------+--------
+ test_psql_schema | d_ao         | table | test_psql_de_role | ao_row    | 
+ test_psql_schema | d_aocs       | table | test_psql_de_role | ao_column | 
+ test_psql_schema | d_bogus_heap | table | test_psql_de_role | bogus     | 
+ test_psql_schema | d_heap       | table | test_psql_de_role | heap      | 
+ test_psql_schema | d_index      | index | test_psql_de_role | btree     | d_heap
+(5 rows)
 
 -- \dE should display both external and foreign tables
 \dE "dE"*

--- a/src/test/regress/sql/psql_gp_commands.sql
+++ b/src/test/regress/sql/psql_gp_commands.sql
@@ -96,6 +96,10 @@ CREATE EXTERNAL TABLE "dE_external_table"  (c1 integer)
   LOCATION ('file://localhost/dummy') FORMAT 'text';
 ALTER EXTERNAL TABLE "dE_external_table" OWNER TO test_psql_de_role;
 
+-- create table using user defined access method
+CREATE ACCESS METHOD bogus TYPE TABLE HANDLER heap_tableam_handler;
+CREATE TABLE d_bogus_heap(a int) USING bogus;
+ALTER TABLE "d_bogus_heap" OWNER TO test_psql_de_role;
 -- There's a GPDB-specific Storage column.
 \d
 \d+


### PR DESCRIPTION
IN GPDB7, we fill the storage type according to the access method
oid of the pg_am system catalog. Except the heap table and append
only table, we can't create correspond access method in pg_am for
other storage types. Just remove the fixme.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
