### PR TITLE
Change default permissions on gp_create_restore_point and gp_switch_wal

### DIFF
--- a/src/backend/catalog/system_views.sql
+++ b/src/backend/catalog/system_views.sql
@@ -1724,6 +1724,13 @@ REVOKE EXECUTE ON FUNCTION pg_ls_dir(text) FROM public;
 REVOKE EXECUTE ON FUNCTION pg_ls_dir(text,boolean,boolean) FROM public;
 
 --
+-- GPDB: These GPDB-specific catalog functions need to have their
+-- default permissions changed as well.
+--
+REVOKE EXECUTE ON FUNCTION gp_create_restore_point(text) FROM public;
+REVOKE EXECUTE ON FUNCTION gp_switch_wal() FROM public;
+
+--
 -- We also set up some things as accessible to standard roles.
 --
 GRANT EXECUTE ON FUNCTION pg_ls_logdir() TO pg_monitor;

--- a/src/include/catalog/catversion.h
+++ b/src/include/catalog/catversion.h
@@ -56,6 +56,6 @@
  */
 
 /*							3yyymmddN */
-#define CATALOG_VERSION_NO	302208301
+#define CATALOG_VERSION_NO	302209061
 
 #endif

--- a/src/test/gpdb_pitr/expected/test_gp_create_restore_point.out
+++ b/src/test/gpdb_pitr/expected/test_gp_create_restore_point.out
@@ -75,3 +75,9 @@ SELECT gp_create_restore_point('this_should_fail') FROM gp_dist_random('gp_id');
 ERROR:  function with EXECUTE ON restrictions cannot be used in the SELECT list of a query with FROM
 CREATE TABLE this_ctas_should_fail AS SELECT gp_segment_id AS contentid, restore_lsn FROM gp_create_restore_point('this_should_fail');
 ERROR:  cannot use gp_create_restore_point() when not in QD mode (xlogfuncs_gp.c:LINE_NUM)
+CREATE ROLE create_rp_error_role;
+SET ROLE TO create_rp_error_role;
+SELECT * FROM gp_create_restore_point('this_should_fail_too');
+ERROR:  permission denied for function gp_create_restore_point
+RESET ROLE;
+DROP ROLE create_rp_error_role;

--- a/src/test/gpdb_pitr/expected/test_gp_switch_wal.out
+++ b/src/test/gpdb_pitr/expected/test_gp_switch_wal.out
@@ -69,5 +69,17 @@ SELECT gp_segment_id, substring(pg_walfile_name, 1, 8) FROM gp_switch_wal() ORDE
 -- test simple gp_switch_wal() error scenarios
 SELECT gp_switch_wal() FROM gp_dist_random('gp_id');
 ERROR:  function with EXECUTE ON restrictions cannot be used in the SELECT list of a query with FROM
+
 CREATE TABLE this_ctas_should_fail AS SELECT gp_segment_id AS contentid, pg_switch_wal, pg_walfile_name FROM gp_switch_wal();
 ERROR:  cannot use gp_switch_wal() when not in QD mode (xlogfuncs_gp.c:LINE_NUM)
+
+CREATE ROLE switch_wal_error_role;
+CREATE
+SET ROLE TO switch_wal_error_role;
+SET
+SELECT * FROM gp_switch_wal();
+ERROR:  permission denied for function gp_switch_wal
+RESET ROLE;
+RESET
+DROP ROLE switch_wal_error_role;
+DROP

--- a/src/test/gpdb_pitr/sql/test_gp_create_restore_point.sql
+++ b/src/test/gpdb_pitr/sql/test_gp_create_restore_point.sql
@@ -54,4 +54,11 @@ ORDER BY w.gp_segment_id;
 
 -- test simple gp_create_restore_point() error scenarios
 SELECT gp_create_restore_point('this_should_fail') FROM gp_dist_random('gp_id');
+
 CREATE TABLE this_ctas_should_fail AS SELECT gp_segment_id AS contentid, restore_lsn FROM gp_create_restore_point('this_should_fail');
+
+CREATE ROLE create_rp_error_role;
+SET ROLE TO create_rp_error_role;
+SELECT * FROM gp_create_restore_point('this_should_fail_too');
+RESET ROLE;
+DROP ROLE create_rp_error_role;

--- a/src/test/gpdb_pitr/sql/test_gp_switch_wal.sql
+++ b/src/test/gpdb_pitr/sql/test_gp_switch_wal.sql
@@ -32,4 +32,11 @@ SELECT gp_segment_id, substring(pg_walfile_name, 1, 8) FROM gp_switch_wal() ORDE
 
 -- test simple gp_switch_wal() error scenarios
 SELECT gp_switch_wal() FROM gp_dist_random('gp_id');
+
 CREATE TABLE this_ctas_should_fail AS SELECT gp_segment_id AS contentid, pg_switch_wal, pg_walfile_name FROM gp_switch_wal();
+
+CREATE ROLE switch_wal_error_role;
+SET ROLE TO switch_wal_error_role;
+SELECT * FROM gp_switch_wal();
+RESET ROLE;
+DROP ROLE switch_wal_error_role;


### PR DESCRIPTION
The gp_create_restore_point (GPDB wrapper of pg_create_restore_point) and gp_switch_wal (GPDB wrapper of pg_switch_wal) catalog functions can be called by any user but would eventually error out if the user didn't have permissions on the wrapped catalog functions after the function dispatch (e.g. permission denied for function pg_switch_wal on segment 3). Instead of relying on the permissions error on the wrapped catalog functions when they're dispatched, revoke the EXEC permissions from the GPDB wrapper catalog functions to explicitly and immediately error out before the functions are even executed.
