### PR TITLE
(6x backport) auto_explain: fix failure when executor hooks are run in QEs

### DIFF
--- a/contrib/auto_explain/Makefile
+++ b/contrib/auto_explain/Makefile
@@ -3,7 +3,7 @@
 MODULE_big = auto_explain
 OBJS = auto_explain.o
 
-REGRESS = auto_explain
+REGRESS = auto_explain bfv_preload_auto_explain
 REGRESS_OPTS = --init-file=init_file
 
 ifdef USE_PGXS

--- a/contrib/auto_explain/expected/bfv_preload_auto_explain.out
+++ b/contrib/auto_explain/expected/bfv_preload_auto_explain.out
@@ -1,0 +1,64 @@
+-- start_ignore
+\! gpconfig -c shared_preload_libraries -v 'auto_explain';
+20220725:08:37:39:077123 gpconfig:evgeniy-pc:evgeniy-[INFO]:-completed successfully with parameters '-c shared_preload_libraries -v auto_explain'
+\! gpconfig -c auto_explain.log_min_duration -v 0 --skipvalidation;
+20220725:08:37:39:077208 gpconfig:evgeniy-pc:evgeniy-[INFO]:-completed successfully with parameters '-c auto_explain.log_min_duration -v 0 --skipvalidation'
+\! gpconfig -c auto_explain.log_analize -v true --skipvalidation;
+20220725:08:37:39:077292 gpconfig:evgeniy-pc:evgeniy-[INFO]:-completed successfully with parameters '-c auto_explain.log_analize -v true --skipvalidation'
+\! gpstop -raiq;
+\c
+-- end_ignore
+SET CLIENT_MIN_MESSAGES = LOG;
+-- check that auto_explain doesn't work on coordinator with Gp_role is not a GP_ROLE_DISPATCH
+-- Query 'SELECT count(1) from (select i from t1 limit 10) t join t2 using (i)' generate executor's slice on coordinator:
+--             ->  Redistribute Motion 1:3  (slice2)
+--                   Output: t1.i
+--                   Hash Key: t1.i
+--                   ->  Limit
+--                         Output: t1.i
+--                         ->  Gather Motion 3:1  (slice1; segments: 3)
+-- IMPORTANT: ./configure with --enable-orca
+CREATE TABLE t1(i int);
+LOG:  statement: CREATE TABLE t1(i int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE t2(i int);
+LOG:  statement: CREATE TABLE t2(i int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+SELECT count(1) from (select i from t1 limit 10) t join t2 using (i);
+LOG:  statement: SELECT count(1) from (select i from t1 limit 10) t join t2 using (i);
+LOG:  duration: 3.033 ms  plan:
+Query Text: SELECT count(1) from (select i from t1 limit 10) t join t2 using (i);
+Aggregate  (cost=1436.96..1436.97 rows=1 width=8) (actual time=6.224..6.224 rows=1 loops=1)
+  ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=1436.90..1436.95 rows=1 width=8) (actual time=5.807..6.211 rows=3 loops=1)
+        ->  Aggregate  (cost=1436.90..1436.91 rows=1 width=8) (actual time=5.068..5.068 rows=1 loops=1)
+              ->  Hash Join  (cost=0.74..1434.49 rows=321 width=0) (never executed)
+                    Hash Cond: (t2.i = t1.i)
+                    ->  Seq Scan on t2  (cost=0.00..1063.00 rows=32100 width=4) (never executed)
+                    ->  Hash  (cost=0.61..0.61 rows=4 width=4) (never executed)
+                          ->  Redistribute Motion 1:3  (slice2; segments: 1)  (cost=0.00..0.61 rows=10 width=4) (never executed)
+                                Hash Key: t1.i
+                                ->  Limit  (cost=0.00..0.31 rows=10 width=4) (never executed)
+                                      ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..0.31 rows=10 width=4) (never executed)
+                                            ->  Limit  (cost=0.00..0.11 rows=4 width=4) (never executed)
+                                                  ->  Seq Scan on t1  (cost=0.00..1063.00 rows=32100 width=4) (never executed)
+  (slice0)    Executor memory: 135K bytes.
+  (slice1)    Executor memory: 60K bytes avg x 3 workers, 60K bytes max (seg0).
+  (slice2)    Executor memory: 44K bytes (seg1).
+  (slice3)    Executor memory: 4172K bytes avg x 3 workers, 4172K bytes max (seg0).
+Memory used:  128000kB
+ count 
+-------
+     0
+(1 row)
+
+DROP TABLE t1;
+LOG:  statement: DROP TABLE t1;
+DROP TABLE t2;
+LOG:  statement: DROP TABLE t2;
+-- start_ignore
+\! gpconfig -r shared_preload_libraries;
+20220725:08:37:44:077741 gpconfig:evgeniy-pc:evgeniy-[INFO]:-completed successfully with parameters '-r shared_preload_libraries'
+\! gpstop -raiq;
+-- end_ignore

--- a/contrib/auto_explain/expected/bfv_preload_auto_explain_optimizer.out
+++ b/contrib/auto_explain/expected/bfv_preload_auto_explain_optimizer.out
@@ -1,0 +1,63 @@
+-- start_ignore
+\! gpconfig -c shared_preload_libraries -v 'auto_explain';
+20220725:08:28:26:008391 gpconfig:evgeniy-pc:evgeniy-[INFO]:-completed successfully with parameters '-c shared_preload_libraries -v auto_explain'
+\! gpconfig -c auto_explain.log_min_duration -v 0 --skipvalidation;
+20220725:08:28:27:008476 gpconfig:evgeniy-pc:evgeniy-[INFO]:-completed successfully with parameters '-c auto_explain.log_min_duration -v 0 --skipvalidation'
+\! gpconfig -c auto_explain.log_analize -v true --skipvalidation;
+20220725:08:28:27:008560 gpconfig:evgeniy-pc:evgeniy-[INFO]:-completed successfully with parameters '-c auto_explain.log_analize -v true --skipvalidation'
+\! gpstop -raiq;
+\c
+-- end_ignore
+SET CLIENT_MIN_MESSAGES = LOG;
+-- check that auto_explain doesn't work on coordinator with Gp_role is not a GP_ROLE_DISPATCH
+-- Query 'SELECT count(1) from (select i from t1 limit 10) t join t2 using (i)' generate executor's slice on coordinator:
+--             ->  Redistribute Motion 1:3  (slice2)
+--                   Output: t1.i
+--                   Hash Key: t1.i
+--                   ->  Limit
+--                         Output: t1.i
+--                         ->  Gather Motion 3:1  (slice1; segments: 3)
+-- IMPORTANT: ./configure with --enable-orca
+CREATE TABLE t1(i int);
+LOG:  statement: CREATE TABLE t1(i int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE t2(i int);
+LOG:  statement: CREATE TABLE t2(i int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+SELECT count(1) from (select i from t1 limit 10) t join t2 using (i);
+LOG:  statement: SELECT count(1) from (select i from t1 limit 10) t join t2 using (i);
+LOG:  statement: SELECT count(1) from (select i from t1 limit 10) t join t2 using (i);  (entry db 127.0.1.1:7000 pid=9001)
+LOG:  duration: 2.940 ms  plan:
+Query Text: SELECT count(1) from (select i from t1 limit 10) t join t2 using (i);
+Aggregate  (cost=0.00..862.00 rows=1 width=8) (actual time=5.106..5.106 rows=1 loops=1)
+  ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..862.00 rows=1 width=1) (actual time=5.099..5.099 rows=0 loops=1)
+        ->  Hash Join  (cost=0.00..862.00 rows=1 width=1) (never executed)
+              Hash Cond: (t1.i = t2.i)
+              ->  Redistribute Motion 1:3  (slice2)  (cost=0.00..431.00 rows=1 width=4) (never executed)
+                    Hash Key: t1.i
+                    ->  Limit  (cost=0.00..431.00 rows=1 width=4) (never executed)
+                          ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4) (never executed)
+                                ->  Seq Scan on t1  (cost=0.00..431.00 rows=1 width=4) (never executed)
+              ->  Hash  (cost=431.00..431.00 rows=1 width=4) (never executed)
+                    ->  Seq Scan on t2  (cost=0.00..431.00 rows=1 width=4) (never executed)
+  (slice0)    Executor memory: 135K bytes.
+  (slice1)    Executor memory: 60K bytes avg x 3 workers, 60K bytes max (seg0).
+  (slice2)    Executor memory: 96K bytes (entry db).
+  (slice3)    Executor memory: 4172K bytes avg x 3 workers, 4172K bytes max (seg0).
+Memory used:  128000kB
+ count 
+-------
+     0
+(1 row)
+
+DROP TABLE t1;
+LOG:  statement: DROP TABLE t1;
+DROP TABLE t2;
+LOG:  statement: DROP TABLE t2;
+-- start_ignore
+\! gpconfig -r shared_preload_libraries;
+20220725:08:28:31:009010 gpconfig:evgeniy-pc:evgeniy-[INFO]:-completed successfully with parameters '-r shared_preload_libraries'
+\! gpstop -raiq;
+-- end_ignore

--- a/contrib/auto_explain/init_file
+++ b/contrib/auto_explain/init_file
@@ -14,4 +14,13 @@ s/Rows Removed by Filter: .*/Rows Removed by Filter: /
 m/Memory used:\s+[0-9]+kB.*/
 s/Memory used:\s+[0-9]+kB.*/Memory used:/
 
+m/work_mem: \d+kB  Segments: \d+  Max: \d+kB \(segment \d+\)/
+s/work_mem: \d+kB  Segments: \d+  Max: \d+kB \(segment \d+\)/work_mem: 99kB  Segments: 9  Max: 99kB/
+
+m/LOG:  statement: SELECT count\(1\) from \(select i from t1 limit 10\) t join t2 using \(i\);  \(entry db .*/
+s/LOG:  statement: SELECT count\(1\) from \(select i from t1 limit 10\) t join t2 using \(i\);  \(entry db .*/LOG:  statement: SELECT count(1) from (select i from t1 limit 10) t join t2 using (i);  (entry db)/
+
+m/Buckets: \d+  Batches: 1  Memory Usage: \d+kB/
+s/Buckets: \d+  Batches: 1  Memory Usage: \d+kB/Buckets: 1048576  Batches: 1  Memory Usage: 8192kB/
+
 -- end_matchsubs

--- a/contrib/auto_explain/sql/bfv_preload_auto_explain.sql
+++ b/contrib/auto_explain/sql/bfv_preload_auto_explain.sql
@@ -1,0 +1,32 @@
+-- start_ignore
+\! gpconfig -c shared_preload_libraries -v 'auto_explain';
+\! gpconfig -c auto_explain.log_min_duration -v 0 --skipvalidation;
+\! gpconfig -c auto_explain.log_analyze -v true --skipvalidation;
+\! gpstop -raiq;
+\c
+-- end_ignore
+
+SET CLIENT_MIN_MESSAGES = LOG;
+
+-- check that auto_explain doesn't work on coordinator with Gp_role is not a GP_ROLE_DISPATCH
+-- Query 'SELECT count(1) from (select i from t1 limit 10) t join t2 using (i)' generate executor's slice on coordinator:
+--             ->  Redistribute Motion 1:3  (slice2)
+--                   Output: t1.i
+--                   Hash Key: t1.i
+--                   ->  Limit
+--                         Output: t1.i
+--                         ->  Gather Motion 3:1  (slice1; segments: 3)
+-- IMPORTANT: ./configure with --enable-orca
+
+CREATE TABLE t1(i int);
+CREATE TABLE t2(i int);
+SELECT count(1) from (select i from t1 limit 10) t join t2 using (i);
+DROP TABLE t1;
+DROP TABLE t2;
+
+-- start_ignore
+\! gpconfig -r auto_explain.log_min_duration;
+\! gpconfig -r auto_explain.log_analyze;
+\! gpconfig -r shared_preload_libraries;
+\! gpstop -raiq;
+-- end_ignore


### PR DESCRIPTION
The reason of failure is that auto_explain hooks are fully executed on QEs. The global variable Gp_role is initialized after auto_explain is loaded as shared preload library. In Greenplum 6X, each postmaster (not matter master, or segment) will have Gp_role == GP_ROLE_DISPATCH, and when create gang, new QEs will set Gp_role when the receive dispatch from QD. Since gpdb7, this is passed as cmd args to the binary postgres.

The QE has valid planstate objects just for nodes in query plan corresponded to the slice of current QE. As result, for "intermediate" slices we have NULL pointer to subtree state for "child" (within slice borders) Motion nodes (subtree itself is valid and points to real node but state for this subtree is not). ExplainNode() routine called within ExplainPrintPlan() function fails trying to dereference that pointer.

To fix the failure I've changed the guard check Gp_role != GP_ROLE_DISPATCH in _PG_init() of auto_explain to macro IS_QUERY_DISPATCHER() that relies on GpIdentity.segindex value to define the kind of node on which code is executed. As a consequence, hooks of auto_explain are activated just on master node. To exclude execution of hooks on master on entrydb kind of worker (having gp_role=executor) I've added additional check Gp_role != GP_ROLE_DISPATCH into macro auto_explain_enabled(). This check disables auto_explain when some work (as executor) is doing at master.

-----------

This is a 6x backport version of master branch PR https://github.com/greenplum-db/gpdb/pull/13846
