### PR TITLE
6X pgcrypto: allow enable FIPS in FIPS not enabled OS

### DIFF
--- a/contrib/pgcrypto/expected/fips_2.out
+++ b/contrib/pgcrypto/expected/fips_2.out
@@ -17,7 +17,7 @@ SELECT 'Test digest md5: EXPECTED ERROR FAIL FIPS' as comment;
 (1 row)
 
 SELECT digest('santa claus', 'md5');
-ERROR:  Cannot use "md5": No such hash algorithm
+ERROR:  Cannot use "md5": 
 SELECT 'Test digest sha256: EXPECTED PASS' as comment;
               comment              
 -----------------------------------
@@ -37,7 +37,7 @@ SELECT 'Test hmac md5: EXPECTED ERROR FAIL FIPS' as comment;
 (1 row)
 
 SELECT hmac('santa claus', 'aaa', 'md5');
-ERROR:  Cannot use "md5": No such hash algorithm
+ERROR:  Cannot use "md5": 
 SELECT 'Test hmac sha256: EXPECTED PASS' as comment;
              comment             
 ---------------------------------
@@ -57,7 +57,7 @@ SELECT 'Test gen_salt : EXPECTED FAIL FIPS' as comment;
 (1 row)
 
 UPDATE fipstest SET salt = gen_salt('md5');
-ERROR:  requested functionality not allowed in FIPS mode (pgcrypto.c:201)
+ERROR:  requested functionality not allowed in FIPS mode (pgcrypto.c:213)  (seg2 127.0.0.1:6004 pid=4140) (pgcrypto.c:213)
 SELECT 'Test crypt : EXPECTED FAIL FIPS' as comment;
              comment             
 ---------------------------------
@@ -65,9 +65,9 @@ SELECT 'Test crypt : EXPECTED FAIL FIPS' as comment;
 (1 row)
 
 UPDATE fipstest SET res = crypt(data, salt);
-ERROR:  requested functionality not allowed in FIPS mode (pgcrypto.c:254)
+ERROR:  requested functionality not allowed in FIPS mode (pgcrypto.c:266)  (seg2 127.0.0.1:6004 pid=4140) (pgcrypto.c:266)
 SELECT res = crypt(data, res) AS "worked" FROM fipstest;
-ERROR:  requested functionality not allowed in FIPS mode (pgcrypto.c:254)
+ERROR:  requested functionality not allowed in FIPS mode (pgcrypto.c:266)  (seg2 slice1 127.0.0.1:6004 pid=4140) (pgcrypto.c:266)
 SELECT 'Test pgp : EXPECTED PASS' as comment;
          comment          
 --------------------------
@@ -75,7 +75,7 @@ SELECT 'Test pgp : EXPECTED PASS' as comment;
 (1 row)
 
 select pgp_sym_decrypt(pgp_sym_encrypt('santa clause', 'mypass', 'cipher-algo=aes256'), 'mypass');
-ERROR:  requested functionality not allowed in FIPS mode (openssl.c:1055)
+ERROR:  requested functionality not allowed in FIPS mode (openssl.c:1057)
 SELECT 'Test pgp : EXPECTED FAIL FIPS' as comment;
             comment            
 -------------------------------
@@ -91,7 +91,7 @@ SELECT 'Test raw encrypt : EXPECTED PASS' as comment;
 (1 row)
 
 SELECT encrypt('santa claus', 'mypass', 'aes') as raw_aes;
-ERROR:  requested functionality not allowed in FIPS mode (openssl.c:1055)
+ERROR:  requested functionality not allowed in FIPS mode (openssl.c:1057)
 SELECT 'Test raw encrypt : EXPECTED FAIL FIPS' as comment;
                 comment                
 ---------------------------------------
@@ -99,5 +99,5 @@ SELECT 'Test raw encrypt : EXPECTED FAIL FIPS' as comment;
 (1 row)
 
 SELECT encrypt('santa claus', 'mypass', 'bf') as raw_blowfish;
-ERROR:  requested functionality not allowed in FIPS mode (openssl.c:1055)
+ERROR:  requested functionality not allowed in FIPS mode (openssl.c:1057)
 DROP TABLE fipstest;

--- a/contrib/pgcrypto/openssl.c
+++ b/contrib/pgcrypto/openssl.c
@@ -1164,7 +1164,7 @@ px_check_fipsmode(void)
 #else
 
 	/* Make sure that we are linked against a FIPS enabled OpenSSL */
-	if (!FIPS_mode_set || FIPS_mode() == 0)
+	if (!FIPS_mode_set)
 	{
 		ereport(ERROR,
 				(errmsg("FIPS enabled OpenSSL is required for strict FIPS mode"),

--- a/src/test/regress/init_file
+++ b/src/test/regress/init_file
@@ -120,8 +120,8 @@ s/ERROR:  FIPS enabled OpenSSL is required for strict FIPS mode .*/ERROR:  FIPS 
 # Mask out OpenSSL behavior change in different version
 m/ERROR:  Cannot use "md5": No such hash algorithm/
 s/ERROR:  Cannot use "md5": No such hash algorithm/ERROR:  Cannot use "md5": /
-m/ERROR: Cannot use "md5": Some PX error \(not specified\)/
-s/ERROR: Cannot use "md5": Some PX error \(not specified\)/ERROR:  Cannot use "md5": /
+m/ERROR:  Cannot use "md5": Some PX error \(not specified\)/
+s/ERROR:  Cannot use "md5": Some PX error \(not specified\)/ERROR:  Cannot use "md5": /
 
 # Mask out gp_execution_segment()
 m/One-Time Filter: \(gp_execution_segment\(\) = \d+/

--- a/src/test/regress/init_file
+++ b/src/test/regress/init_file
@@ -117,6 +117,12 @@ s/ERROR:  invalid partition constraint on "[^"]+".*/ERROR:  invalid partition co
 m/ERROR:  FIPS enabled OpenSSL is required for strict FIPS mode .*/
 s/ERROR:  FIPS enabled OpenSSL is required for strict FIPS mode .*/ERROR:  FIPS enabled OpenSSL is required for strict FIPS mode (openssl.c:XXX)/
 
+# Mask out OpenSSL behavior change in different version
+m/ERROR:  Cannot use "md5": No such hash algorithm/
+s/ERROR:  Cannot use "md5": No such hash algorithm/ERROR:  Cannot use "md5": /
+m/ERROR: Cannot use "md5": Some PX error \(not specified\)/
+s/ERROR: Cannot use "md5": Some PX error \(not specified\)/ERROR:  Cannot use "md5": /
+
 # Mask out gp_execution_segment()
 m/One-Time Filter: \(gp_execution_segment\(\) = \d+/
 s/One-Time Filter: \(gp_execution_segment\(\) = \d+/One-Time Filter: \(gp_execution_segment\(\) = ###/


### PR DESCRIPTION
old pgcrypto use FIPS_mode() == 0 to check if can enable FIPS or not. but FIPS_mode() return none zero means FIPS already initialized by the OS or env OPENSSL_FIPS=1

this PR removes the check, allow to enable FIPS on a none FIPS OS

7X: #13905


ci test case:

for 7X we have
- rhel8 with OpenSSL 1.1.1k  FIPS 25 Mar 2021:   FIPS_mode() support at application level, not certified
- centos7 with OpenSSL 1.0.2k-fips  26 Jan 2017: FIPS_mode() support at application level, not certified
- ubuntu 18.04 with OpenSSL 1.1.1  11 Sep 2018:  FIPS_mode not enabled

for 6X we have
- sles12 with OpenSSL 1.0.2p-fips  14 Aug 2018:   FIPS_mode() support at application level, not certified
- photon3 with OpenSSL 1.0.2zc-fips  22 Feb 2022: FIPS_mode() support at application level, not certified
- rhel8 with OpenSSL 1.1.1k  FIPS 25 Mar 2021:    FIPS_mode() support at application level, not certified
- centos6 with OpenSSL 1.0.1e-fips 11 Feb 2013:   FIPS_mode() support at application level, not certified
- centos7 with OpenSSL 1.0.2k-fips  26 Jan 2017:  FIPS_mode() support at application level, not certified
- ubuntu 18.04 with OpenSSL 1.1.1  11 Sep 2018:   FIPS_mode not enabled

---

no user behavior change, no need to modify document