### PR TITLE
docs - gpfdist and file protocols support zstd compression

### DIFF
--- a/gpdb-doc/markdown/admin_guide/external/g-file-protocol.html.md
+++ b/gpdb-doc/markdown/admin_guide/external/g-file-protocol.html.md
@@ -2,9 +2,11 @@
 title: file:// Protocol 
 ---
 
-The `file://` protocol is used in a URI that specifies the location of an operating system file.
+You can use the `file://` protocol with a Greenplum Database external table to read from one or more files located on each Greenplum Database segment host. The `file://` protocol does not support writing to files.
 
-The URI includes the host name, port, and path to the file. Each file must reside on a segment host in a location accessible by the Greenplum Database superuser \(`gpadmin`\). The host name used in the URI must match a segment host name registered in the `gp_segment_configuration` system catalog table.
+When reading, the `file://` protocol uncompresses `gzip` \(`.gz`\), `bzip2` \(.`bz2`\), and `zstd` \(`.zst`\) files automatically.
+
+You must provide a URI that specifies the location of an operating system file(s). The URI includes the host name, port, and path to the file. Each file must reside on a segment host in a location accessible by the Greenplum Database superuser \(`gpadmin`\). The host name used in the URI must match a segment host name registered in the `gp_segment_configuration` system catalog table.
 
 The `LOCATION` clause can have multiple URIs, as shown in this example:
 
@@ -19,7 +21,7 @@ FORMAT 'CSV' (HEADER);
 
 The number of URIs you specify in the `LOCATION` clause is the number of segment instances that will work in parallel to access the external table. For each URI, Greenplum assigns a primary segment on the specified host to the file. For maximum parallelism when loading data, divide the data into as many equally sized files as you have primary segments. This ensures that all segments participate in the load. The number of external files per segment host cannot exceed the number of primary segment instances on that host. For example, if your array has four primary segment instances per segment host, you can place four external files on each segment host. Tables based on the `file://` protocol can only be readable tables.
 
-The system view `pg_max_external_files` shows how many external table files are permitted per external table. This view lists the available file slots per segment host when using the `file:// protocol`. The view is only applicable for the `file:// protocol`. For example:
+The system view `pg_max_external_files` shows how many external table files are permitted per external table. This view lists the available file slots per segment host when using the `file://` protocol. The view is only applicable for the `file:// protocol`. For example:
 
 ```
 SELECT * FROM pg_max_external_files;

--- a/gpdb-doc/markdown/admin_guide/external/g-gpfdist-protocol.html.md
+++ b/gpdb-doc/markdown/admin_guide/external/g-gpfdist-protocol.html.md
@@ -8,7 +8,7 @@ The [gpfdist](../../utility_guide/ref/gpfdist.html) utility serves external data
 
 `gpfdist` is located in the `$GPHOME/bin` directory on your Greenplum Database master host and on each segment host.
 
-Run `gpfdist` on the host where the external data files reside. For readable external tables, `gpfdist` uncompresses `gzip` \(`.gz`\) and `bzip2` \(.`bz2`\) files automatically. For writable external tables, data is compressed using `gzip` if the target file has a `.gz` extension. You can use the wildcard character \(\*\) or other C-style pattern matching to denote multiple files to read. The files specified are assumed to be relative to the directory that you specified when you started the `gpfdist` instance.
+Run `gpfdist` on the host where the external data files reside. For readable external tables, `gpfdist` uncompresses `gzip` \(`.gz`\), `bzip2` \(.`bz2`\), and `zstd` \(`.zst`\) files automatically. For writable external tables, data is compressed using `gzip` if the target file has a `.gz` extension, `bzip` if the target file has a `.bz2` extension, or `zstd` if the target file has a `.zst` extension. You can use the wildcard character \(\*\) or other C-style pattern matching to denote multiple files to read. The files specified are assumed to be relative to the directory that you specified when you started the `gpfdist` instance.
 
 **Note:** Compression is not supported for readable and writeable external tables when the `gpfdist` utility runs on Windows platforms.
 

--- a/gpdb-doc/markdown/admin_guide/external/g-using-the-greenplum-parallel-file-server--gpfdist-.html.md
+++ b/gpdb-doc/markdown/admin_guide/external/g-using-the-greenplum-parallel-file-server--gpfdist-.html.md
@@ -27,7 +27,8 @@ The `CREATE EXTERNAL TABLE` command `LOCATION` clause connects an external table
 
 External data files can contain rows in CSV format or any delimited text format supported by the `FORMAT` clause of the `CREATE EXTERNAL TABLE` command. In addition, `gpfdist` can be configured with a YAML-formatted file to transform external data files between a supported text format and another format, for example XML or JSON. See <ref\> for an example that shows how to use `gpfdist` to read external XML files into a Greenplum Database readable external table.
 
-For readable external tables, `gpfdist` uncompresses `gzip` \(`.gz`\) and `bzip2` \(.`bz2`\) files automatically. You can use the wildcard character \(\*\) or other C-style pattern matching to denote multiple files to read. External files are assumed to be relative to the directory specified when you started the `gpfdist` instance.
+For readable external tables, `gpfdist` uncompresses `gzip` \(`.gz`\), `bzip2` \(.`bz2`\), and `zstd` \(`.zst`\)  files automatically. You can use the wildcard character \(\*\) or other C-style pattern matching to denote multiple files to read. External files are assumed to be relative to the directory specified when you started the `gpfdist` instance.
+
 
 ## <a id="topic14"></a>About gpfdist Setup and Performance 
 

--- a/gpdb-doc/markdown/utility_guide/ref/gpfdist.html.md
+++ b/gpdb-doc/markdown/utility_guide/ref/gpfdist.html.md
@@ -31,7 +31,7 @@ For readable external tables, `gpfdist` parses and serves data files evenly to a
 
 **Note:** When `gpfdist` reads data and encounters a data formatting error, the error message includes a row number indicating the location of the formatting error. `gpfdist` attempts to capture the row that contains the error. However, `gpfdist` might not capture the exact row for some formatting errors.
 
-For readable external tables, if load files are compressed using `gzip` or `bzip2` \(have a `.gz` or `.bz2` file extension\), `gpfdist` uncompresses the data while loading the data \(on the fly\). For writable external tables, `gpfdist` compresses the data using `gzip` if the target file has a `.gz` extension.
+For readable external tables, if load files are compressed using `gzip`, `bzip2`, or `zstd` \(have a `.gz`, `.bz2`, or `.zst` file extension\), `gpfdist` uncompresses the data while loading the data \(on the fly\). For writable external tables, `gpfdist` compresses the data using `gzip` if the target file has a `.gz` extension, `bzip` if the target file has a `.bz2` extension, or `zstd` if the target file has a `.zst` extension.
 
 **Note:** Compression is not supported for readable and writeable external tables when the `gpfdist` utility runs on Windows platforms.
 


### PR DESCRIPTION
docs for https://github.com/greenplum-db/gpdb/pull/13933, adds zstd compression on read/write to gpfdist.  by extension, also adds zstd compression on read for the file protocol; docs didn't reference any compression support for file protocol, so add that info.
