### PR TITLE
docs - pgbouncer includes native ldap support for client auth

### DIFF
--- a/gpdb-doc/markdown/utility_guide/ref/pgbouncer-ini.html.md
+++ b/gpdb-doc/markdown/utility_guide/ref/pgbouncer-ini.html.md
@@ -167,7 +167,7 @@ auth\_file
     Default: not set
 
 auth\_hba\_file
-:   HBA configuration file to use when `auth_type` is `hba`. Refer to the [Configuring HBA-based Authentication for PgBouncer](../../admin_guide/access_db/topics/pgbouncer.html#pgb_hba) for more information.
+:   HBA configuration file to use when `auth_type` is `hba`. Refer to the [Configuring HBA-based Authentication for PgBouncer](../../admin_guide/access_db/topics/pgbouncer.html#pgb_hba) and [Configuring LDAP-based Authentication for PgBouncer](../../admin_guide/access_db/topics/pgbouncer.html#pgb_ldap) for more information.
 
     Default: not set
 


### PR DESCRIPTION
docs for https://github.com/greenplum-db/pgbouncer/pull/15 and https://github.com/greenplum-db/pgbouncer/pull/16.  i updated the pgbouncer topic as follows:
- in migrating section, replaced the PAM statement with a mention of the new ldap support and xref off to a new topic
- add new topic "Configuring LDAP-based Authentication for PgBouncer"
- update the pgbouncer ref page to xref to the new topic when auth_type is hba

doc review site link (behind vpn) to new topic:  https://docs-staging.vmware.com/en/VMware-Tanzu-Greenplum/lisa-review/greenplum-database/GUID-admin_guide-access_db-topics-pgbouncer.html#pgb_ldap
