### PR TITLE
[6X] Prevent REINDEX TABLE partitioned table statement in function

### DIFF
--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -960,7 +960,7 @@ standard_ProcessUtility(Node *parsetree,
 						break;
 					case OBJECT_TABLE:
 					case OBJECT_MATVIEW:
-						ReindexTable(stmt);
+						ReindexTable(stmt, isTopLevel);
 						break;
 					case OBJECT_DATABASE:
 

--- a/src/include/access/xact.h
+++ b/src/include/access/xact.h
@@ -289,6 +289,7 @@ extern bool ExecutorSaysTransactionDoesWrites(void);
 extern char TransactionBlockStatusCode(void);
 extern void AbortOutOfAnyTransaction(void);
 extern void PreventTransactionChain(bool isTopLevel, const char *stmtType);
+extern void PreventInFunction(bool isTopLevel, const char *stmtType);
 extern void RequireTransactionChain(bool isTopLevel, const char *stmtType);
 extern void WarnNoTransactionChain(bool isTopLevel, const char *stmtType);
 extern bool IsInTransactionChain(bool isTopLevel);

--- a/src/include/commands/defrem.h
+++ b/src/include/commands/defrem.h
@@ -31,7 +31,7 @@ extern Oid DefineIndex(Oid relationId,
 			bool skip_build,
 			bool quiet);
 extern Oid	ReindexIndex(ReindexStmt *stmt);
-extern Oid	ReindexTable(ReindexStmt *stmt);
+extern Oid	ReindexTable(ReindexStmt *stmt, bool isTopLevel);
 extern Oid	ReindexDatabase(ReindexStmt *stmt);
 extern char *makeObjectName(const char *name1, const char *name2,
 			   const char *label);

--- a/src/test/regress/expected/partition_indexing.out
+++ b/src/test/regress/expected/partition_indexing.out
@@ -1242,3 +1242,49 @@ select relhassubclass from pg_class where relname = 'idxpart_idx';
 (1 row)
 
 drop index idxpart_idx;
+-- GPDB: Prevent REINDEX TABLE on partitioned table run in function call.
+-- Since we expand partitioned table when do the reindex, and try to reindex
+-- each table in its own transaction.
+create table reindex_part(id int, r int) partition by range (r)
+    ( start (1) end (21) every (10) );
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "reindex_part_1_prt_1" for table "reindex_part"
+NOTICE:  CREATE TABLE will create partition "reindex_part_1_prt_2" for table "reindex_part"
+create index reidx_idx on reindex_part (id);
+-- This should success
+begin;
+reindex table reindex_part;
+end;
+-- This should success
+begin;
+reindex table reindex_part_1_prt_1;
+end;
+-- This should raise error
+CREATE FUNCTION reindex_in_func() RETURNS void
+AS $$
+begin
+reindex table reindex_part;
+end
+$$
+LANGUAGE plpgsql;
+select reindex_in_func();
+ERROR:  REINDEX TABLE <partitioned_table> cannot be executed from a function or multi-command string
+CONTEXT:  SQL statement "reindex table reindex_part"
+PL/pgSQL function reindex_in_func() line 3 at SQL statement
+-- This should success
+CREATE OR REPLACE FUNCTION reindex_in_func() RETURNS void
+AS $$
+begin
+reindex table reindex_part_1_prt_1;
+end
+$$
+LANGUAGE plpgsql;
+select reindex_in_func();
+ reindex_in_func 
+-----------------
+ 
+(1 row)
+
+drop table reindex_part;
+drop function reindex_in_func();


### PR DESCRIPTION
This is intended to adjust https://github.com/greenplum-db/gpdb/pull/11994 to prevent executing reindex partitioned table in function only, keep allowing reindex partitioned table in transaction block in STABLE release.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
