### PR TITLE
ci: fix ci failure #13905

### DIFF
--- a/src/test/regress/init_file
+++ b/src/test/regress/init_file
@@ -121,8 +121,8 @@ s/ERROR:  FIPS enabled OpenSSL is required for strict FIPS mode .*/ERROR:  FIPS 
 # Mask out OpenSSL behavior change in different version
 m/ERROR:  Cannot use "md5": No such hash algorithm/
 s/ERROR:  Cannot use "md5": No such hash algorithm/ERROR:  Cannot use "md5": /
-m/ERROR: Cannot use "md5": Some PX error \(not specified\)/
-s/ERROR: Cannot use "md5": Some PX error \(not specified\)/ERROR:  Cannot use "md5": /
+m/ERROR:  Cannot use "md5": Some PX error \(not specified\)/
+s/ERROR:  Cannot use "md5": Some PX error \(not specified\)/ERROR:  Cannot use "md5": /
 
 # Mask out gp_execution_segment()
 m/One-Time Filter: \(gp_execution_segment\(\) = \d+/


### PR DESCRIPTION
some blank character mistake.


```diff
diff -I HINT: -I CONTEXT: -I GP_IGNORE: -U3 /tmp/build/e18b2f02/gpdb_src/contrib/pgcrypto/expected/fips_2.out /tmp/build/e18b2f02/gpdb_src/contrib/pgcrypto/results/fips.out
--- /tmp/build/e18b2f02/gpdb_src/contrib/pgcrypto/expected/fips_2.out	2022-09-07 06:59:53.878157887 +0000
+++ /tmp/build/e18b2f02/gpdb_src/contrib/pgcrypto/results/fips.out	2022-09-07 06:59:53.882158271 +0000
@@ -16,7 +16,7 @@
 (1 row)
 
 SELECT digest('santa claus', 'md5');
-ERROR:  Cannot use "md5": 
+ERROR:  Cannot use "md5": Some PX error (not specified)
 SELECT 'Test digest sha256: EXPECTED PASS' as comment;
               comment              
 -----------------------------------
@@ -36,7 +36,7 @@
 (1 row)
 
 SELECT hmac('santa claus', 'aaa', 'md5');
-ERROR:  Cannot use "md5": 
+ERROR:  Cannot use "md5": Some PX error (not specified)
 SELECT 'Test hmac sha256: EXPECTED PASS' as comment;
              comment             
 ---------------------------------
```