### PR TITLE
[typo] compatable => compatible

### DIFF
--- a/gpMgmt/bin/gppylib/gparray.py
+++ b/gpMgmt/bin/gppylib/gparray.py
@@ -189,7 +189,7 @@ class Segment:
         """
         Factory method, initializes a Segment object from string representation.
           - Used when importing from file format.
-          - TODO: Should be compatable with repr() formatting.
+          - Should be compatible with repr() formatting.
         """
         tup = s.strip().split('|')
 

--- a/src/pl/plpython/expected/plpython_returns.out
+++ b/src/pl/plpython/expected/plpython_returns.out
@@ -1616,7 +1616,7 @@ FROM gp_single_row;
 --------------------------
 (0 rows)
 
--- From Python List of compatable values
+-- From Python List of compatible values
 SELECT test_return_setof_circle('[None, ((3,1),4), "((5,3),1)"]');
  test_return_setof_circle 
 --------------------------

--- a/src/pl/plpython/sql/plpython_returns.sql
+++ b/src/pl/plpython/sql/plpython_returns.sql
@@ -777,7 +777,7 @@ SELECT * FROM test_return_setof_circle('[]');
 SELECT test_return_setof_circle('[]') 
 FROM gp_single_row;
 
--- From Python List of compatable values
+-- From Python List of compatible values
 SELECT test_return_setof_circle('[None, ((3,1),4), "((5,3),1)"]');
 SELECT * FROM test_return_setof_circle('[None, ((3,1),4), "((5,3),1)"]');
 SELECT test_return_setof_circle('[None, ((3,1),4), "((5,3),1)"]')


### PR DESCRIPTION
%s/compatable/compatible/g in file gparray.py

Since initFromString is already compatible with repr() formatting, remove the TODO mark.

Search `compatable` globally and change them all to `compatible`.

Signed-off-by: Junwang Zhao <zhjwpku@gmail.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
