### PR TITLE
Increased the standby promotion wait time in gpactivatestandby

### DIFF
--- a/gpMgmt/bin/gpactivatestandby
+++ b/gpMgmt/bin/gpactivatestandby
@@ -321,7 +321,7 @@ def promote_standby(master_data_dir):
     cmd.run(validateAfter=True)
 
     logger.debug('Waiting for connection...')
-    for i in xrange(50):
+    for i in xrange(600):
         try:
             dburl = dbconn.DbURL()
             with dbconn.connect(dburl, utility=True, logConn=False) as conn:


### PR DESCRIPTION
Increased the loop count to 600 in promote_standby(), to align the standby promotion timeout with MIRROR_PROMOTION_TIMEOUT. Fixes https://github.com/greenplum-db/gpdb/issues/11105

Backport of 7X PR https://github.com/greenplum-db/gpdb/pull/13504/

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
