### PR TITLE
Fix type_array oid assignment for pre-GPDB7 to GPDB7 upgrade

### DIFF
--- a/src/bin/pg_upgrade/greenplum/reporting.c
+++ b/src/bin/pg_upgrade/greenplum/reporting.c
@@ -94,13 +94,15 @@ report_progress(ClusterInfo *cluster, progress_type op, char *fmt,...)
 	}
 
 	/*
-	 * GPDB_12_MERGE_FIXME: The CLUSTER_NAME macro was removed, so we've
-	 * changed to printing the major version of the cluster instead. This may
-	 * well be good enough (or even better), but some more thought should go
-	 * into this before calling it done.
+	 * In the case where cluster is NULL, omit the cluster version in
+	 * the progress file.
 	 */
-	fprintf(progress_file, "%lu;%s;%s;%s;\n",
-			epoch_us(), cluster->major_version_str, opname(op), message);
+	if (cluster && *cluster->major_version_str != '\0')
+		fprintf(progress_file, "%lu;%s;%s;%s;\n",
+				epoch_us(), cluster->major_version_str, opname(op), message);
+	else
+		fprintf(progress_file, "%lu;%s;%s;\n", epoch_us(), opname(op), message);
+
 	progress_counter++;
 
 	/*

--- a/src/bin/pg_upgrade/test_gpdb.sh
+++ b/src/bin/pg_upgrade/test_gpdb.sh
@@ -172,7 +172,7 @@ upgrade_qd()
 
 	# Run pg_upgrade
 	pushd $1
-	time ${NEW_BINDIR}/pg_upgrade --mode=dispatcher --old-bindir=${OLD_BINDIR} --old-datadir=$2 --new-bindir=${NEW_BINDIR} --new-datadir=$3 ${PGUPGRADE_OPTS}
+	time ${NEW_BINDIR}/pg_upgrade --mode=dispatcher --progress --old-bindir=${OLD_BINDIR} --old-datadir=$2 --new-bindir=${NEW_BINDIR} --new-datadir=$3 ${PGUPGRADE_OPTS}
 	if (( $? )) ; then
 		echo "ERROR: Failure encountered in upgrading qd node"
 		exit 1


### PR DESCRIPTION
For DOMAINS, GPDB5/6 does not assign an array type, but GPDB7 does. To handle this, we find an unused type Oid to assign.

be8bb094d2ae8ec24c03a399611507a5f1a8f0d9 did not correctly dump the type array namespace and type array name when following this code path. As a result, during a pg_restore to GPDB7 we hit an Assertion failure

	/*
	 * We should never be asked to generate a new pg_type OID during
	 * pg_upgrade; doing so would risk collisions with the OIDs it wants to
	 * assign.  Hitting this assert means there's some path where we failed to
	 * ensure that a type OID is determined by commands in the dump script. */ Assert(!IsBinaryUpgrade || RelationGetRelid(relation) != TypeRelationId);

This commit will now use the namespace of the type and prepend an '_' for the type array name to properly assign the Oid.

Before:
```
-- For binary upgrade, must preserve pg_type oid
SELECT pg_catalog.binary_upgrade_set_next_pg_type_oid('58187'::pg_catalog.oid, '57868'::pg_catalog.oid, $$intdom$$::text);


-- For binary upgrade, must preserve pg_type array oid
SELECT pg_catalog.binary_upgrade_set_next_array_pg_type_oid('16385'::pg_catalog.oid, '0'::pg_catalog.oid, $$$$::text);

CREATE DOMAIN "gpdist_legacy_opclasses"."intdom" AS integer;
```

After:
```
-- For binary upgrade, must preserve pg_type oid
SELECT pg_catalog.binary_upgrade_set_next_pg_type_oid('58187'::pg_catalog.oid, '57868'::pg_catalog.oid, $$intdom$$::text);


-- For binary upgrade, must preserve pg_type array oid
SELECT pg_catalog.binary_upgrade_set_next_array_pg_type_oid('16385'::pg_catalog.oid, '57868'::pg_catalog.oid, $$_intdom$$::text);

CREATE DOMAIN "gpdist_legacy_opclasses"."intdom" AS integer;
```

