### PR TITLE
pg_upgrade: Fix core dump in report_progress()

### DIFF
--- a/src/bin/pg_upgrade/greenplum/reporting.c
+++ b/src/bin/pg_upgrade/greenplum/reporting.c
@@ -94,13 +94,15 @@ report_progress(ClusterInfo *cluster, progress_type op, char *fmt,...)
 	}
 
 	/*
-	 * GPDB_12_MERGE_FIXME: The CLUSTER_NAME macro was removed, so we've
-	 * changed to printing the major version of the cluster instead. This may
-	 * well be good enough (or even better), but some more thought should go
-	 * into this before calling it done.
+	 * In the case where cluster is NULL, omit the cluster version in
+	 * the progress file.
 	 */
-	fprintf(progress_file, "%lu;%s;%s;%s;\n",
-			epoch_us(), cluster->major_version_str, opname(op), message);
+	if (cluster && *cluster->major_version_str != '\0')
+		fprintf(progress_file, "%lu;%s;%s;%s;\n",
+				epoch_us(), cluster->major_version_str, opname(op), message);
+	else
+		fprintf(progress_file, "%lu;%s;%s;\n", epoch_us(), opname(op), message);
+
 	progress_counter++;
 
 	/*

--- a/src/bin/pg_upgrade/test_gpdb.sh
+++ b/src/bin/pg_upgrade/test_gpdb.sh
@@ -172,7 +172,7 @@ upgrade_qd()
 
 	# Run pg_upgrade
 	pushd $1
-	time ${NEW_BINDIR}/pg_upgrade --mode=dispatcher --old-bindir=${OLD_BINDIR} --old-datadir=$2 --new-bindir=${NEW_BINDIR} --new-datadir=$3 ${PGUPGRADE_OPTS}
+	time ${NEW_BINDIR}/pg_upgrade --mode=dispatcher --progress --old-bindir=${OLD_BINDIR} --old-datadir=$2 --new-bindir=${NEW_BINDIR} --new-datadir=$3 ${PGUPGRADE_OPTS}
 	if (( $? )) ; then
 		echo "ERROR: Failure encountered in upgrading qd node"
 		exit 1


### PR DESCRIPTION
The report_progress function called when using the pg_upgrade `--progress` flag may take a NULL argument for `cluster`, but was not checking for NULL before trying to print `cluster->major_version_str`, resulting in a core dump.

Add a check before fprintf call, which also resolves a FIXME.

Also use --progress flag in pg_upgrade regression test.