### PR TITLE
[5X Backport] Prevent REINDEX TABLE partitioned table statement in function.

### DIFF
--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -4010,6 +4010,34 @@ PreventTransactionChain(bool isTopLevel, const char *stmtType)
 }
 
 /*
+ *	PreventInFunction
+ *
+ *	This routine is to be called by statements that must not run inside
+ *	a user defined function (UDF). This is intended to prevent reindexing
+ *  a partitioned table in a function call. This is used in STABLE release
+ *  only for less impact of current transaction behavior. It will be replaced
+ *  with above PreventTransactionChain() in the next major release to fully
+ *  address preventing multi-transaction statement running in a transaction block.
+ *
+ *	isTopLevel: passed down from ProcessUtility to determine whether we are
+ *	inside a function or multi-query querystring.
+ *	stmtType: statement type name, for error messages.
+ */
+void
+PreventInFunction(bool isTopLevel, const char *stmtType)
+{
+	/*
+	 * inside a function call?
+	 */
+	if (!isTopLevel)
+		ereport(ERROR,
+				(errcode(ERRCODE_ACTIVE_SQL_TRANSACTION),
+		/* translator: %s represents an SQL statement name */
+				 errmsg("%s cannot be executed from a function or multi-command string",
+						stmtType)));
+}
+
+/*
  *	RequireTransactionChain
  *
  *	This routine is to be called by statements that must run inside

--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -1752,7 +1752,7 @@ ProcessUtility(Node *parsetree,
 						ReindexIndex(stmt);
 						break;
 					case OBJECT_TABLE:
-						ReindexTable(stmt);
+						ReindexTable(stmt, isTopLevel);
 						break;
 					case OBJECT_DATABASE:
 

--- a/src/include/access/xact.h
+++ b/src/include/access/xact.h
@@ -224,6 +224,7 @@ extern bool ExecutorSaysTransactionDoesWrites(void);
 extern char TransactionBlockStatusCode(void);
 extern void AbortOutOfAnyTransaction(void);
 extern void PreventTransactionChain(bool isTopLevel, const char *stmtType);
+extern void PreventInFunction(bool isTopLevel, const char *stmtType);
 extern void RequireTransactionChain(bool isTopLevel, const char *stmtType);
 extern bool IsInTransactionChain(bool isTopLevel);
 extern void RegisterXactCallback(XactCallback callback, void *arg);

--- a/src/include/commands/defrem.h
+++ b/src/include/commands/defrem.h
@@ -38,7 +38,7 @@ extern void DefineIndex(RangeVar *heapRelation,
 			IndexStmt *stmt /* MPP */);
 extern void RemoveIndex(RangeVar *relation, DropBehavior behavior);
 extern void ReindexIndex(ReindexStmt *stmt);
-extern void ReindexTable(ReindexStmt *stmt);
+extern void ReindexTable(ReindexStmt *stmt, bool isTopLevel);
 extern void ReindexDatabase(ReindexStmt *stmt);
 extern char *makeObjectName(const char *name1, const char *name2,
 			   const char *label);

--- a/src/test/regress/expected/partition_indexing.out
+++ b/src/test/regress/expected/partition_indexing.out
@@ -1707,3 +1707,49 @@ select count(*) from mpp3033b;
   1000
 (1 row)
 
+-- GPDB: Prevent REINDEX TABLE on partitioned table run in function call.
+-- Since we expand partitioned table when do the reindex, and try to reindex
+-- each table in its own transaction.
+create table reindex_part(id int, r int) partition by range (r)
+    ( start (1) end (21) every (10) );
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "reindex_part_1_prt_1" for table "reindex_part"
+NOTICE:  CREATE TABLE will create partition "reindex_part_1_prt_2" for table "reindex_part"
+create index reidx_idx on reindex_part (id);
+-- This should success
+begin;
+reindex table reindex_part;
+end;
+-- This should success
+begin;
+reindex table reindex_part_1_prt_1;
+end;
+-- This should raise error
+CREATE FUNCTION reindex_in_func() RETURNS void
+AS $$
+begin
+reindex table reindex_part;
+end
+$$
+LANGUAGE plpgsql;
+select reindex_in_func();
+ERROR:  REINDEX TABLE <partitioned_table> cannot be executed from a function or multi-command string
+CONTEXT:  SQL statement "reindex table reindex_part"
+PL/pgSQL function "reindex_in_func" line 2 at SQL statement
+-- This should success
+CREATE OR REPLACE FUNCTION reindex_in_func() RETURNS void
+AS $$
+begin
+reindex table reindex_part_1_prt_1;
+end
+$$
+LANGUAGE plpgsql;
+select reindex_in_func();
+ reindex_in_func 
+-----------------
+
+(1 row)
+
+drop table reindex_part;
+drop function reindex_in_func();

--- a/src/test/regress/sql/partition_indexing.sql
+++ b/src/test/regress/sql/partition_indexing.sql
@@ -609,3 +609,43 @@ reindex index mpp3033b_stringu1;
 
 select count(*) from mpp3033a;
 select count(*) from mpp3033b;
+
+-- GPDB: Prevent REINDEX TABLE on partitioned table run in function call.
+-- Since we expand partitioned table when do the reindex, and try to reindex
+-- each table in its own transaction.
+create table reindex_part(id int, r int) partition by range (r)
+    ( start (1) end (21) every (10) );
+create index reidx_idx on reindex_part (id);
+
+-- This should success
+begin;
+reindex table reindex_part;
+end;
+
+-- This should success
+begin;
+reindex table reindex_part_1_prt_1;
+end;
+
+-- This should raise error
+CREATE FUNCTION reindex_in_func() RETURNS void
+AS $$
+begin
+reindex table reindex_part;
+end
+$$
+LANGUAGE plpgsql;
+select reindex_in_func();
+
+-- This should success
+CREATE OR REPLACE FUNCTION reindex_in_func() RETURNS void
+AS $$
+begin
+reindex table reindex_part_1_prt_1;
+end
+$$
+LANGUAGE plpgsql;
+select reindex_in_func();
+
+drop table reindex_part;
+drop function reindex_in_func();


### PR DESCRIPTION
This is a backport of https://github.com/greenplum-db/gpdb/pull/14081.

As different from upstream, we support REINDEX TABLE on partitioned table which will expand the partitioned table and start new transaction to do the reindex for each table. This has side effects that cannot be rolled back if it gets called in PL language and may crash, so we need to make sure it must not run inside a function.
This fix is related to issue greenplum-db#11948.

This is applied to STABLE release only for less impact of current transaction behavior. It will be changed in the next major release to fully address preventing multi-transaction statement running in a transaction block.

Co-authored-by: Haolin Wang <whaolin@vmware.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
