### PR TITLE
FIXME(WIP): Allow SPE plans to show "Partitions selected: 1 (out of 5)"

### DIFF
--- a/src/backend/commands/explain.c
+++ b/src/backend/commands/explain.c
@@ -2213,19 +2213,16 @@ ExplainNode(PlanState *planstate, List *ancestors,
 		case T_NamedTuplestoreScan:
 		case T_WorkTableScan:
 		case T_SubqueryScan:
-			/*
-			 * GPDB_12_MERGE_FIXME: we used to show something along the lines of
-			 * "Partitions selected: 1 (out of 5)" under the partition selector.
-			 * By eleminating the (static) partition selector during translation,
-			 * we only get the survivor count, and lose the size of the universe
-			 * temporarily. However, if we manage to shift the static pruning
-			 * information sufficiently adjacent to (or better, into) a DXL Dynamic
-			 * Table Scan, we should be able to get that information back.
-			 */
-			if (IsA(plan, DynamicSeqScan))
+			if (IsA(plan, DynamicSeqScan)) {
+				char *buf = "";
+				if (0 != ((DynamicSeqScan *)plan)->total_partitions) {
+					buf = psprintf("(out of %u)",
+						((DynamicSeqScan *)plan)->total_partitions);
+				}
 				ExplainPropertyInteger(
-					"Number of partitions to scan", "",
-					list_length(((DynamicSeqScan *) plan)->partOids), es);
+					"Number of partitions to scan", buf,
+					list_length(((DynamicSeqScan *)plan)->partOids),es);
+			}
 			show_scan_qual(plan->qual, "Filter", planstate, ancestors, es);
 			if (plan->qual)
 				show_instrumentation_count("Rows Removed by Filter", 1,

--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -3978,7 +3978,8 @@ CTranslatorDXLToPlStmt::TranslateDXLDynTblScan(
 	}
 
 	dyn_seq_scan->partOids = oids_list;
-
+	dyn_seq_scan->total_partitions =
+		dyn_tbl_scan_dxlop->GetTotalPartitions();
 	dyn_seq_scan->join_prune_paramids = NIL;
 
 	OID oid_type =

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalDynamicGet.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalDynamicGet.h
@@ -50,7 +50,8 @@ public:
 					   CColRefArray *pdrgpcrOutput,
 					   CColRef2dArray *pdrgpdrgpcrPart,
 					   IMdIdArray *partition_mdids,
-					   CConstraint *partition_cnstrs_disj, BOOL static_pruned);
+					   CConstraint *partition_cnstrs_disj, BOOL static_pruned,
+					   ULONG total_partitions = 0);
 
 	CLogicalDynamicGet(CMemoryPool *mp, const CName *pnameAlias,
 					   CTableDescriptor *ptabdesc, ULONG ulPartIndex,

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalDynamicGetBase.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalDynamicGetBase.h
@@ -61,6 +61,10 @@ protected:
 
 	// Child partitions
 	IMdIdArray *m_partition_mdids = nullptr;
+
+	// total paritions
+	ULONG m_total_partitions;
+
 	// Map of Root colref -> col index in child tabledesc
 	// per child partition in m_partition_mdid
 	ColRefToUlongMapArray *m_root_col_mapping_per_part = nullptr;
@@ -78,7 +82,8 @@ public:
 						   CTableDescriptor *ptabdesc, ULONG scan_id,
 						   CColRefArray *pdrgpcrOutput,
 						   CColRef2dArray *pdrgpdrgpcrPart,
-						   IMdIdArray *partition_mdids);
+						   IMdIdArray *partition_mdids,
+						   ULONG total_partitions = 0);
 
 	CLogicalDynamicGetBase(CMemoryPool *mp, const CName *pnameAlias,
 						   CTableDescriptor *ptabdesc, ULONG scan_id,
@@ -120,6 +125,13 @@ public:
 	ScanId() const
 	{
 		return m_scan_id;
+	}
+
+	// return total partitions
+	virtual ULONG
+	Total_partitions() const
+	{
+		return m_total_partitions;
 	}
 
 	// return the partition columns

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalDynamicScan.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalDynamicScan.h
@@ -52,6 +52,9 @@ private:
 	// child partitions
 	IMdIdArray *m_partition_mdids;
 
+	// total partitions
+	ULONG m_total_partitions;
+
 	// Map of Root colref -> col index in child tabledesc
 	// per child partition in m_partition_mdid
 	ColRefToUlongMapArray *m_root_col_mapping_per_part = nullptr;
@@ -65,7 +68,8 @@ public:
 						 ULONG scan_id, CColRefArray *pdrgpcrOutput,
 						 CColRef2dArray *pdrgpdrgpcrParts,
 						 IMdIdArray *partition_mdids,
-						 ColRefToUlongMapArray *root_col_mapping_per_part);
+						 ColRefToUlongMapArray *root_col_mapping_per_part,
+						 ULONG total_partitions = 0);
 
 	// dtor
 	~CPhysicalDynamicScan() override;
@@ -82,6 +86,12 @@ public:
 	ScanId() const
 	{
 		return m_scan_id;
+	}
+
+	ULONG
+	GetTotalPartitions() const
+	{
+		return m_total_partitions;
 	}
 
 	// partition keys

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalDynamicTableScan.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalDynamicTableScan.h
@@ -37,7 +37,8 @@ public:
 							  ULONG scan_id, CColRefArray *pdrgpcrOutput,
 							  CColRef2dArray *pdrgpdrgpcrParts,
 							  IMdIdArray *partition_mdids,
-							  ColRefToUlongMapArray *root_col_mapping_per_part);
+							  ColRefToUlongMapArray *root_col_mapping_per_part,
+							  ULONG total_partitions = 0);
 
 	// ident accessors
 	EOperatorId

--- a/src/backend/gporca/libgpopt/src/operators/CExpressionPreprocessor.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CExpressionPreprocessor.cpp
@@ -2563,7 +2563,8 @@ CExpressionPreprocessor::PrunePartitions(CMemoryPool *mp, CExpression *expr)
 			GPOS_NEW(mp) CConstraintArray(mp);
 
 		IMdIdArray *all_partition_mdids = dyn_get->GetPartitionMdids();
-		for (ULONG ul = 0; ul < all_partition_mdids->Size(); ++ul)
+		ULONG total_partitions = all_partition_mdids->Size();
+		for (ULONG ul = 0; ul < total_partitions; ++ul)
 		{
 			IMDId *part_mdid = (*all_partition_mdids)[ul];
 			const IMDRelation *partrel = mda->RetrieveRel(part_mdid);
@@ -2630,7 +2631,8 @@ CExpressionPreprocessor::PrunePartitions(CMemoryPool *mp, CExpression *expr)
 		CLogicalDynamicGet *new_dyn_get = GPOS_NEW(mp) CLogicalDynamicGet(
 			mp, new_alias, dyn_get->Ptabdesc(), dyn_get->ScanId(),
 			dyn_get->PdrgpcrOutput(), dyn_get->PdrgpdrgpcrPart(),
-			selected_partition_mdids, selected_part_cnstr_disj, true);
+			selected_partition_mdids, selected_part_cnstr_disj, true,
+			total_partitions);
 
 		CExpressionArray *select_children = GPOS_NEW(mp) CExpressionArray(mp);
 		select_children->Append(GPOS_NEW(mp) CExpression(mp, new_dyn_get));

--- a/src/backend/gporca/libgpopt/src/operators/CLogicalDynamicGet.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CLogicalDynamicGet.cpp
@@ -56,15 +56,16 @@ CLogicalDynamicGet::CLogicalDynamicGet(
 	CMemoryPool *mp, const CName *pnameAlias, CTableDescriptor *ptabdesc,
 	ULONG ulPartIndex, CColRefArray *pdrgpcrOutput,
 	CColRef2dArray *pdrgpdrgpcrPart, IMdIdArray *partition_mdids,
-	CConstraint *partition_cnstrs_disj, BOOL static_pruned)
+	CConstraint *partition_cnstrs_disj, BOOL static_pruned,
+	ULONG total_partitions)
 	: CLogicalDynamicGetBase(mp, pnameAlias, ptabdesc, ulPartIndex,
-							 pdrgpcrOutput, pdrgpdrgpcrPart, partition_mdids),
+							 pdrgpcrOutput, pdrgpdrgpcrPart, partition_mdids,
+							 total_partitions),
 	  m_partition_cnstrs_disj(partition_cnstrs_disj),
 	  m_static_pruned(static_pruned)
 {
 	GPOS_ASSERT(static_pruned || (nullptr == partition_cnstrs_disj));
 }
-
 
 //---------------------------------------------------------------------------
 //	@function:

--- a/src/backend/gporca/libgpopt/src/operators/CLogicalDynamicGetBase.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CLogicalDynamicGetBase.cpp
@@ -64,7 +64,7 @@ CLogicalDynamicGetBase::CLogicalDynamicGetBase(CMemoryPool *mp)
 CLogicalDynamicGetBase::CLogicalDynamicGetBase(
 	CMemoryPool *mp, const CName *pnameAlias, CTableDescriptor *ptabdesc,
 	ULONG scan_id, CColRefArray *pdrgpcrOutput, CColRef2dArray *pdrgpdrgpcrPart,
-	IMdIdArray *partition_mdids)
+	IMdIdArray *partition_mdids, ULONG total_partitions)
 	: CLogical(mp),
 	  m_pnameAlias(pnameAlias),
 	  m_ptabdesc(ptabdesc),
@@ -72,8 +72,8 @@ CLogicalDynamicGetBase::CLogicalDynamicGetBase(
 	  m_pdrgpcrOutput(pdrgpcrOutput),
 	  m_pdrgpdrgpcrPart(pdrgpdrgpcrPart),
 	  m_pcrsDist(nullptr),
-	  m_partition_mdids(partition_mdids)
-
+	  m_partition_mdids(partition_mdids),
+	  m_total_partitions(total_partitions)
 {
 	GPOS_ASSERT(nullptr != ptabdesc);
 	GPOS_ASSERT(nullptr != pnameAlias);
@@ -84,7 +84,6 @@ CLogicalDynamicGetBase::CLogicalDynamicGetBase(
 	m_root_col_mapping_per_part =
 		ConstructRootColMappingPerPart(mp, m_pdrgpcrOutput, m_partition_mdids);
 }
-
 
 //---------------------------------------------------------------------------
 //	@function:

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalDynamicScan.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalDynamicScan.cpp
@@ -39,14 +39,14 @@ CPhysicalDynamicScan::CPhysicalDynamicScan(
 	CMemoryPool *mp, CTableDescriptor *ptabdesc, ULONG ulOriginOpId,
 	const CName *pnameAlias, ULONG scan_id, CColRefArray *pdrgpcrOutput,
 	CColRef2dArray *pdrgpdrgpcrParts, IMdIdArray *partition_mdids,
-	ColRefToUlongMapArray *root_col_mapping_per_part)
+	ColRefToUlongMapArray *root_col_mapping_per_part, ULONG total_partitions)
 	: CPhysicalScan(mp, pnameAlias, ptabdesc, pdrgpcrOutput),
 	  m_ulOriginOpId(ulOriginOpId),
 	  m_scan_id(scan_id),
 	  m_pdrgpdrgpcrPart(pdrgpdrgpcrParts),
 	  m_partition_mdids(partition_mdids),
+	  m_total_partitions(total_partitions),
 	  m_root_col_mapping_per_part(root_col_mapping_per_part)
-
 {
 	GPOS_ASSERT(nullptr != pdrgpdrgpcrParts);
 	GPOS_ASSERT(0 < pdrgpdrgpcrParts->Size());

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalDynamicTableScan.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalDynamicTableScan.cpp
@@ -37,10 +37,10 @@ CPhysicalDynamicTableScan::CPhysicalDynamicTableScan(
 	CMemoryPool *mp, const CName *pnameAlias, CTableDescriptor *ptabdesc,
 	ULONG ulOriginOpId, ULONG scan_id, CColRefArray *pdrgpcrOutput,
 	CColRef2dArray *pdrgpdrgpcrParts, IMdIdArray *partition_mdids,
-	ColRefToUlongMapArray *root_col_mapping_per_part)
+	ColRefToUlongMapArray *root_col_mapping_per_part, ULONG total_partitions)
 	: CPhysicalDynamicScan(mp, ptabdesc, ulOriginOpId, pnameAlias, scan_id,
 						   pdrgpcrOutput, pdrgpdrgpcrParts, partition_mdids,
-						   root_col_mapping_per_part)
+						   root_col_mapping_per_part, total_partitions)
 {
 }
 

--- a/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
+++ b/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
@@ -1359,7 +1359,7 @@ CTranslatorExprToDXL::PdxlnDynamicTableScan(
 	// construct dynamic table scan operator
 	IMdIdArray *part_mdids = popDTS->GetPartitionMdids();
 	part_mdids->AddRef();
-
+	ULONG total_partitions = popDTS->GetTotalPartitions();
 	ULongPtrArray *selector_ids = GPOS_NEW(m_mp) ULongPtrArray(m_mp);
 	CPartitionPropagationSpec *pps_reqd =
 		pexprDTS->Prpp()->Pepp()->PppsRequired();
@@ -1375,8 +1375,8 @@ CTranslatorExprToDXL::PdxlnDynamicTableScan(
 
 
 	CDXLPhysicalDynamicTableScan *pdxlopDTS =
-		GPOS_NEW(m_mp) CDXLPhysicalDynamicTableScan(m_mp, table_descr,
-													part_mdids, selector_ids);
+		GPOS_NEW(m_mp) CDXLPhysicalDynamicTableScan(
+			m_mp, table_descr, part_mdids, selector_ids, total_partitions);
 
 	CDXLNode *pdxlnDTS = GPOS_NEW(m_mp) CDXLNode(m_mp, pdxlopDTS);
 	pdxlnDTS->SetProperties(pdxlpropDTS);

--- a/src/backend/gporca/libgpopt/src/xforms/CXformDynamicGet2DynamicTableScan.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformDynamicGet2DynamicTableScan.cpp
@@ -77,10 +77,11 @@ CXformDynamicGet2DynamicTableScan::Transform(CXformContext *pxfctxt,
 
 	// create alternative expression
 	CExpression *pexprAlt = GPOS_NEW(mp) CExpression(
-		mp, GPOS_NEW(mp) CPhysicalDynamicTableScan(
-				mp, pname, ptabdesc, popGet->UlOpId(), popGet->ScanId(),
-				pdrgpcrOutput, pdrgpdrgpcrPart, popGet->GetPartitionMdids(),
-				popGet->GetRootColMappingPerPart()));
+		mp,
+		GPOS_NEW(mp) CPhysicalDynamicTableScan(
+			mp, pname, ptabdesc, popGet->UlOpId(), popGet->ScanId(),
+			pdrgpcrOutput, pdrgpdrgpcrPart, popGet->GetPartitionMdids(),
+			popGet->GetRootColMappingPerPart(), popGet->Total_partitions()));
 	// add alternative to transformation result
 	pxfres->Add(pexprAlt);
 }

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLPhysicalDynamicTableScan.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLPhysicalDynamicTableScan.h
@@ -47,6 +47,7 @@ private:
 	IMdIdArray *m_part_mdids;
 
 	ULongPtrArray *m_selector_ids = nullptr;
+	ULONG m_total_partitions;
 
 public:
 	CDXLPhysicalDynamicTableScan(CDXLPhysicalDynamicTableScan &) = delete;
@@ -54,7 +55,8 @@ public:
 	// ctor
 	CDXLPhysicalDynamicTableScan(CMemoryPool *mp, CDXLTableDescr *table_descr,
 								 IMdIdArray *part_mdids,
-								 ULongPtrArray *selector_ids);
+								 ULongPtrArray *selector_ids,
+								 ULONG total_partitions = 0);
 
 	// dtor
 	~CDXLPhysicalDynamicTableScan() override;
@@ -75,6 +77,13 @@ public:
 	{
 		return m_selector_ids;
 	}
+
+	ULONG
+	GetTotalPartitions() const
+	{
+		return m_total_partitions;
+	}
+
 	// serialize operator in DXL format
 	void SerializeToDXL(CXMLSerializer *xml_serializer,
 						const CDXLNode *node) const override;

--- a/src/backend/gporca/libnaucrates/src/operators/CDXLPhysicalDynamicTableScan.cpp
+++ b/src/backend/gporca/libnaucrates/src/operators/CDXLPhysicalDynamicTableScan.cpp
@@ -31,16 +31,16 @@ using namespace gpdxl;
 //---------------------------------------------------------------------------
 CDXLPhysicalDynamicTableScan::CDXLPhysicalDynamicTableScan(
 	CMemoryPool *mp, CDXLTableDescr *table_descr, IMdIdArray *part_mdids,
-	ULongPtrArray *selector_ids)
+	ULongPtrArray *selector_ids, ULONG total_partitions)
 	: CDXLPhysical(mp),
 	  m_dxl_table_descr(table_descr),
 	  m_part_mdids(part_mdids),
-	  m_selector_ids(selector_ids)
+	  m_selector_ids(selector_ids),
+	  m_total_partitions(total_partitions)
 
 {
 	GPOS_ASSERT(nullptr != table_descr);
 }
-
 
 //---------------------------------------------------------------------------
 //	@function:

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -599,6 +599,7 @@ _copyDynamicSeqScan(const DynamicSeqScan *from)
 	COPY_NODE_FIELD(partOids);
 	COPY_NODE_FIELD(part_prune_info);
 	COPY_NODE_FIELD(join_prune_paramids);
+	COPY_SCALAR_FIELD(total_partitions);
 
 	return newnode;
 }

--- a/src/include/nodes/plannodes.h
+++ b/src/include/nodes/plannodes.h
@@ -765,6 +765,7 @@ typedef struct DynamicSeqScan
 	 * partitions.
 	 */
 	List	   *join_prune_paramids;
+	unsigned int total_partitions;
 
 } DynamicSeqScan;
 


### PR DESCRIPTION
""GPDB_12_MERGE_FIXME: we used to show something along the lines of
"Partitions selected: 1 (out of 5)" under the partition selector.
By eleminating the (static) partition selector during translation,
we only get the survivor count, and lose the size of the universe
temporarily. However, if we manage to shift the static pruning
information sufficiently adjacent to (or better, into) a DXL Dynamic
Table Scan, we should be able to get that information back.""

Through this PR I am trying to pass the total partition information
through ORCA and into the plan node used in explain.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
