### PR TITLE
Explain plan shows the number of leaf partitions for dynamic scans

### DIFF
--- a/src/test/regress/expected/dpe_optimizer.out
+++ b/src/test/regress/expected/dpe_optimizer.out
@@ -91,7 +91,7 @@ explain (costs off, timing off, summary off, analyze) select * from t, pt where 
                ->  Seq Scan on t (actual rows=2 loops=1)
          ->  Dynamic Index Scan on ptid_idx on pt (actual rows=4 loops=2)
                Index Cond: (ptid = t.tid)
-               Number of partitions to scan: 6 
+               Number of partitions to scan: 6 (out of 6)
                Partitions scanned:  Avg 6.0 x 3 workers of 2 scans.  Max 6 parts (seg0).
  Optimizer: Pivotal Optimizer (GPORCA)
 (10 rows)
@@ -129,7 +129,7 @@ explain (costs off, timing off, summary off, analyze) select * from t, pt where 
                ->  Seq Scan on t (actual rows=2 loops=1)
          ->  Dynamic Index Scan on ptid_idx on pt (actual rows=4 loops=2)
                Index Cond: (ptid = (t.tid + 1))
-               Number of partitions to scan: 6 
+               Number of partitions to scan: 6 (out of 6)
                Partitions scanned:  Avg 6.0 x 3 workers of 2 scans.  Max 6 parts (seg0).
  Optimizer: Pivotal Optimizer (GPORCA)
 (10 rows)
@@ -168,7 +168,7 @@ explain (costs off, timing off, summary off, analyze) select * from t, pt where 
                      Filter: (t1 = ('hello'::text || (tid)::text))
          ->  Dynamic Index Scan on ptid_idx on pt (actual rows=4 loops=2)
                Index Cond: (ptid = t.tid)
-               Number of partitions to scan: 6 
+               Number of partitions to scan: 6 (out of 6)
                Partitions scanned:  Avg 6.0 x 3 workers of 2 scans.  Max 6 parts (seg0).
  Optimizer: Pivotal Optimizer (GPORCA)
 (11 rows)
@@ -207,7 +207,7 @@ explain (costs off, timing off, summary off, analyze) select * from t, pt where 
          ->  Dynamic Index Scan on pt1_idx on pt (actual rows=1 loops=2)
                Index Cond: (pt1 = t.t1)
                Filter: ((pt1 = t.t1) AND (ptid = t.tid))
-               Number of partitions to scan: 6 
+               Number of partitions to scan: 6 (out of 6)
                Partitions scanned:  Avg 6.0 x 3 workers of 2 scans.  Max 6 parts (seg0).
  Optimizer: Pivotal Optimizer (GPORCA)
 (11 rows)
@@ -230,7 +230,7 @@ explain (costs off, timing off, summary off, analyze) select * from pt where pti
          Hash Cond: (pt.ptid = t.tid)
          Extra Text: (seg1)   Hash chain length 1.0 avg, 1 max, using 2 of 262144 buckets.
          ->  Dynamic Seq Scan on pt (actual rows=8 loops=1)
-               Number of partitions to scan: 6 
+               Number of partitions to scan: 6 (out of 6)
                Partitions scanned:  Avg 2.0 x 3 workers.  Max 2 parts (seg0).
          ->  Hash (actual rows=2 loops=1)
                Buckets: 262144  Batches: 1  Memory Usage: 2049kB
@@ -283,7 +283,7 @@ explain (costs off, timing off, summary off, analyze) select * from pt where exi
          Hash Cond: (pt.ptid = t.tid)
          Extra Text: (seg1)   Hash chain length 1.0 avg, 1 max, using 2 of 262144 buckets.
          ->  Dynamic Seq Scan on pt (actual rows=8 loops=1)
-               Number of partitions to scan: 6 
+               Number of partitions to scan: 6 (out of 6)
                Partitions scanned:  Avg 2.0 x 3 workers.  Max 2 parts (seg0).
          ->  Hash (actual rows=2 loops=1)
                Buckets: 262144  Batches: 1  Memory Usage: 2049kB
@@ -340,7 +340,7 @@ explain (costs off, timing off, summary off, analyze) select count(*) from t, pt
                            ->  Seq Scan on t (actual rows=2 loops=1)
                      ->  Dynamic Index Scan on ptid_idx on pt (actual rows=4 loops=2)
                            Index Cond: (ptid = t.tid)
-                           Number of partitions to scan: 6 
+                           Number of partitions to scan: 6 (out of 6)
                            Partitions scanned:  Avg 6.0 x 3 workers of 2 scans.  Max 6 parts (seg0).
  Optimizer: Pivotal Optimizer (GPORCA)
 (12 rows)
@@ -371,7 +371,7 @@ explain (costs off, timing off, summary off, analyze) select *, rank() over (ord
                            ->  Seq Scan on t (actual rows=2 loops=1)
                      ->  Dynamic Index Scan on ptid_idx on pt (actual rows=4 loops=2)
                            Index Cond: (ptid = t.tid)
-                           Number of partitions to scan: 6 
+                           Number of partitions to scan: 6 (out of 6)
                            Partitions scanned:  Avg 6.0 x 3 workers of 2 scans.  Max 6 parts (seg0).
  Optimizer: Pivotal Optimizer (GPORCA)
 (16 rows)
@@ -415,7 +415,7 @@ explain (costs off, timing off, summary off, analyze) select * from t, pt where 
                      ->  Seq Scan on t (actual rows=2 loops=1)
                ->  Dynamic Index Scan on ptid_idx on pt (actual rows=4 loops=2)
                      Index Cond: (ptid = t.tid)
-                     Number of partitions to scan: 6 
+                     Number of partitions to scan: 6 (out of 6)
                      Partitions scanned:  Avg 6.0 x 3 workers of 2 scans.  Max 6 parts (seg0).
          ->  Nested Loop (actual rows=7 loops=1)
                Join Filter: true
@@ -423,7 +423,7 @@ explain (costs off, timing off, summary off, analyze) select * from t, pt where 
                      ->  Seq Scan on t t_1 (actual rows=2 loops=1)
                ->  Dynamic Index Scan on ptid_idx on pt pt_1 (actual rows=4 loops=2)
                      Index Cond: (ptid = (t_1.tid + 2))
-                     Number of partitions to scan: 6 
+                     Number of partitions to scan: 6 (out of 6)
                      Partitions scanned:  Avg 6.0 x 3 workers of 2 scans.  Max 6 parts (seg0).
  Optimizer: Pivotal Optimizer (GPORCA)
 (19 rows)
@@ -491,7 +491,7 @@ explain (costs off, timing off, summary off, analyze) select count(*) from
                                  ->  Seq Scan on t (actual rows=2 loops=1)
                            ->  Dynamic Index Scan on ptid_idx on pt (actual rows=4 loops=2)
                                  Index Cond: (ptid = t.tid)
-                                 Number of partitions to scan: 6 
+                                 Number of partitions to scan: 6 (out of 6)
                                  Partitions scanned:  Avg 6.0 x 3 workers of 2 scans.  Max 6 parts (seg0).
                      ->  Nested Loop (actual rows=7 loops=1)
                            Join Filter: true
@@ -499,7 +499,7 @@ explain (costs off, timing off, summary off, analyze) select count(*) from
                                  ->  Seq Scan on t t_1 (actual rows=2 loops=1)
                            ->  Dynamic Index Scan on ptid_idx on pt pt_1 (actual rows=4 loops=2)
                                  Index Cond: (ptid = (t_1.tid + 2))
-                                 Number of partitions to scan: 6 
+                                 Number of partitions to scan: 6 (out of 6)
                                  Partitions scanned:  Avg 6.0 x 3 workers of 2 scans.  Max 6 parts (seg0).
  Optimizer: Pivotal Optimizer (GPORCA)
 (21 rows)
@@ -530,7 +530,7 @@ explain (costs off, timing off, summary off, analyze) select * from t, pt where 
                ->  Seq Scan on t (actual rows=2 loops=1)
          ->  Dynamic Index Scan on ptid_idx on pt (actual rows=4 loops=2)
                Index Cond: (ptid = t.tid)
-               Number of partitions to scan: 6 
+               Number of partitions to scan: 6 (out of 6)
                Partitions scanned:  Avg 6.0 x 3 workers of 2 scans.  Max 6 parts (seg0).
  Optimizer: Pivotal Optimizer (GPORCA)
 (10 rows)
@@ -582,7 +582,7 @@ explain (costs off, timing off, summary off, analyze) select * from t, pt where 
          ->  Gather Motion 3:1  (slice2; segments: 3) (actual rows=1 loops=1)
                ->  Dynamic Index Scan on pt1_idx on pt (actual rows=1 loops=1)
                      Index Cond: (pt1 = 'hello0'::text)
-                     Number of partitions to scan: 6 
+                     Number of partitions to scan: 6 (out of 6)
                      Partitions scanned:  Avg 6.0 x 3 workers.  Max 6 parts (seg0).
  Optimizer: Pivotal Optimizer (GPORCA)
 (12 rows)
@@ -610,7 +610,7 @@ explain (costs off, timing off, summary off, analyze) select * from t, pt where 
                ->  Seq Scan on t (actual rows=2 loops=1)
          ->  Dynamic Index Scan on ptid_idx on pt (actual rows=4 loops=2)
                Index Cond: (ptid = t.tid)
-               Number of partitions to scan: 6 
+               Number of partitions to scan: 6 (out of 6)
                Partitions scanned:  Avg 6.0 x 3 workers of 2 scans.  Max 6 parts (seg0).
  Optimizer: Pivotal Optimizer (GPORCA)
 (10 rows)
@@ -655,7 +655,7 @@ explain (costs off, timing off, summary off, analyze) select * from t, pt where 
                ->  Seq Scan on t (actual rows=2 loops=1)
          ->  Dynamic Index Scan on pt1_idx on pt (actual rows=1 loops=2)
                Index Cond: (pt1 = t.t1)
-               Number of partitions to scan: 6 
+               Number of partitions to scan: 6 (out of 6)
                Partitions scanned:  Avg 6.0 x 3 workers of 2 scans.  Max 6 parts (seg0).
  Optimizer: Pivotal Optimizer (GPORCA)
 (10 rows)
@@ -677,7 +677,7 @@ explain (costs off, timing off, summary off, analyze) select * from t, pt where 
                ->  Seq Scan on t (actual rows=2 loops=1)
          ->  Dynamic Index Scan on ptid_idx on pt (actual rows=16 loops=2)
                Index Cond: (ptid > t.tid)
-               Number of partitions to scan: 6 
+               Number of partitions to scan: 6 (out of 6)
                Partitions scanned:  Avg 6.0 x 3 workers of 2 scans.  Max 6 parts (seg0).
  Optimizer: Pivotal Optimizer (GPORCA)
 (10 rows)
@@ -789,7 +789,7 @@ explain (costs off, timing off, summary off, analyze) select * from t, t1, pt wh
                      ->  Seq Scan on t1 (actual rows=1 loops=1)
                ->  Dynamic Index Scan on ptid_idx on pt (actual rows=4 loops=2)
                      Index Cond: (ptid = t1.tid)
-                     Number of partitions to scan: 6 
+                     Number of partitions to scan: 6 (out of 6)
                      Partitions scanned:  Avg 6.0 x 3 workers of 2 scans.  Max 6 parts (seg0).
    ->  Hash (actual rows=2 loops=1)
          Buckets: 262144  Batches: 1  Memory Usage: 2049kB
@@ -867,7 +867,7 @@ explain (costs off, timing off, summary off, analyze) select * from t, t1, pt wh
                                  ->  Seq Scan on t1 (actual rows=6 loops=1)
                            ->  Dynamic Index Scan on ptid_idx on pt (actual rows=1 loops=12)
                                  Index Cond: (ptid = t1.tid)
-                                 Number of partitions to scan: 6 
+                                 Number of partitions to scan: 6 (out of 6)
                                  Partitions scanned:  Avg 6.0 x 3 workers of 12 scans.  Max 6 parts (seg0).
  Optimizer: Pivotal Optimizer (GPORCA)
 (19 rows)
@@ -906,12 +906,12 @@ explain (costs off, timing off, summary off, analyze) select * from t1 inner joi
                ->  Dynamic Index Scan on ptid_idx on pt (actual rows=1 loops=1)
                      Index Cond: (ptid = t1.tid)
                      Filter: ((ptid = t1.tid) AND (t1.dist = dist))
-                     Number of partitions to scan: 6 
+                     Number of partitions to scan: 6 (out of 6)
                      Partitions scanned:  Avg 6.0 x 2 workers.  Max 6 parts (seg0).
          ->  Dynamic Index Scan on ptid_idx on pt pt_1 (actual rows=1 loops=1)
                Index Cond: ((ptid <= pt.ptid) AND (ptid = pt.ptid))
                Filter: ((ptid <= pt.ptid) AND (ptid = pt.ptid) AND (dist = pt.dist))
-               Number of partitions to scan: 6 
+               Number of partitions to scan: 6 (out of 6)
                Partitions scanned:  Avg 6.0 x 2 workers.  Max 6 parts (seg0).
  Optimizer: Pivotal Optimizer (GPORCA)
 (17 rows)
@@ -934,7 +934,7 @@ explain (costs off, timing off, summary off, analyze) select * from pt, pt1 wher
                Hash Cond: (pt1.ptid = pt.ptid)
                Extra Text: (seg1)   Hash chain length 1.0 avg, 1 max, using 1 of 131072 buckets.
                ->  Dynamic Seq Scan on pt1 (actual rows=5 loops=1)
-                     Number of partitions to scan: 6 
+                     Number of partitions to scan: 6 (out of 6)
                      Partitions scanned:  Avg 1.0 x 3 workers.  Max 1 parts (seg0).
                ->  Hash (actual rows=1 loops=1)
                      Buckets: 131072  Batches: 1  Memory Usage: 1025kB
@@ -942,7 +942,7 @@ explain (costs off, timing off, summary off, analyze) select * from pt, pt1 wher
                            ->  Broadcast Motion 3:3  (slice2; segments: 3) (actual rows=1 loops=1)
                                  ->  Dynamic Index Scan on pt1_idx on pt (actual rows=1 loops=1)
                                        Index Cond: (pt1 = 'hello0'::text)
-                                       Number of partitions to scan: 6 
+                                       Number of partitions to scan: 6 (out of 6)
                                        Partitions scanned:  Avg 6.0 x 3 workers.  Max 6 parts (seg0).
  Optimizer: Pivotal Optimizer (GPORCA)
 (19 rows)
@@ -971,7 +971,7 @@ explain (costs off, timing off, summary off, analyze) select count(*) from pt, p
                      Hash Cond: (pt1.ptid = pt.ptid)
                      Extra Text: (seg1)   Hash chain length 1.0 avg, 1 max, using 1 of 524288 buckets.
                      ->  Dynamic Seq Scan on pt1 (actual rows=5 loops=1)
-                           Number of partitions to scan: 6 
+                           Number of partitions to scan: 6 (out of 6)
                            Partitions scanned:  Avg 1.0 x 3 workers.  Max 1 parts (seg0).
                      ->  Hash (actual rows=1 loops=1)
                            Buckets: 524288  Batches: 1  Memory Usage: 4097kB
@@ -979,7 +979,7 @@ explain (costs off, timing off, summary off, analyze) select count(*) from pt, p
                                  ->  Broadcast Motion 3:3  (slice2; segments: 3) (actual rows=1 loops=1)
                                        ->  Dynamic Index Scan on pt1_idx on pt (actual rows=1 loops=1)
                                              Index Cond: (pt1 = 'hello0'::text)
-                                             Number of partitions to scan: 6 
+                                             Number of partitions to scan: 6 (out of 6)
                                              Partitions scanned:  Avg 6.0 x 3 workers.  Max 6 parts (seg0).
  Optimizer: Pivotal Optimizer (GPORCA)
 (17 rows)
@@ -1022,7 +1022,7 @@ explain (costs off, timing off, summary off, analyze) select * from t, pt where 
                ->  Redistribute Motion 3:3  (slice3; segments: 3) (actual rows=3 loops=1)
                      Hash Key: pt.b
                      ->  Dynamic Seq Scan on pt (actual rows=3 loops=1)
-                           Number of partitions to scan: 5 
+                           Number of partitions to scan: 5 (out of 5)
                            Partitions scanned:  Avg 5.0 x 3 workers.  Max 5 parts (seg0).
  Optimizer: Pivotal Optimizer (GPORCA)
 (14 rows)
@@ -1069,7 +1069,7 @@ explain (costs off, timing off, summary off, analyze) select * from t, pt where 
    ->  Hash Join (actual rows=0 loops=1)
          Hash Cond: (pt.b = t.a)
          ->  Dynamic Seq Scan on pt (actual rows=0 loops=1)
-               Number of partitions to scan: 5 
+               Number of partitions to scan: 5 (out of 5)
          ->  Hash (actual rows=4 loops=1)
                Buckets: 524288  Batches: 1  Memory Usage: 4097kB
                ->  Partition Selector (selector id: $0) (actual rows=4 loops=1)
@@ -2432,7 +2432,7 @@ explain (costs off, timing off, summary off, analyze) select * from apart as a, 
                Hash Cond: (apart.t = b.t)
                Extra Text: (seg0)   Hash chain length 1.0 avg, 1 max, using 5 of 262144 buckets.
                ->  Dynamic Seq Scan on apart (actual rows=70 loops=1)
-                     Number of partitions to scan: 5 
+                     Number of partitions to scan: 5 (out of 5)
                      Partitions scanned:  Avg 1.0 x 3 workers.  Max 1 parts (seg0).
                ->  Hash (actual rows=5 loops=1)
                      Buckets: 262144  Batches: 1  Memory Usage: 2049kB
@@ -2467,7 +2467,7 @@ explain (costs off, timing off, summary off, analyze) select * from apart as a, 
                Hash Cond: (apart.t = b.t)
                Extra Text: (seg0)   Hash chain length 1.0 avg, 1 max, using 5 of 262144 buckets.
                ->  Dynamic Seq Scan on apart (actual rows=70 loops=1)
-                     Number of partitions to scan: 5 
+                     Number of partitions to scan: 5 (out of 5)
                      Partitions scanned:  Avg 1.0 x 3 workers.  Max 1 parts (seg0).
                ->  Hash (actual rows=5 loops=1)
                      Buckets: 262144  Batches: 1  Memory Usage: 2049kB
@@ -2530,7 +2530,7 @@ explain (costs off, timing off, summary off, analyze) select * from (select coun
          Buckets: 131072  Batches: 1  Memory Usage: 1025kB
          ->  Gather Motion 3:1  (slice2; segments: 3) (actual rows=10 loops=1)
                ->  Dynamic Seq Scan on pat (actual rows=5 loops=1)
-                     Number of partitions to scan: 5 
+                     Number of partitions to scan: 5 (out of 5)
                      Partitions scanned:  Avg 5.0 x 3 workers.  Max 5 parts (seg0).
  Optimizer: Pivotal Optimizer (GPORCA)
 (17 rows)
@@ -2703,7 +2703,7 @@ select * from pt, t where t.dist = pt.dist and t.tid < pt.ptid;
          Rows Removed by Join Filter: 3
          Extra Text: (seg1)   Hash chain length 2.0 avg, 2 max, using 1 of 524288 buckets.
          ->  Dynamic Seq Scan on pt (actual rows=7 loops=1)
-               Number of partitions to scan: 6 
+               Number of partitions to scan: 6 (out of 6)
                Partitions scanned:  4  (seg1).
          ->  Hash (actual rows=2 loops=1)
                Buckets: 524288  Batches: 1  Memory Usage: 4097kB
@@ -2756,7 +2756,7 @@ select * from pt, t where t.dist = pt.dist and t.tid = pt.ptid order by t.tid, t
                Hash Cond: ((pt.dist = t.dist) AND (pt.ptid = t.tid))
                Extra Text: (seg0)   Hash chain length 1.0 avg, 1 max, using 36 of 262144 buckets.
                ->  Dynamic Seq Scan on pt  (cost=0.00..431.00 rows=33 width=12) (actual rows=36 loops=1)
-                     Number of partitions to scan: 6 
+                     Number of partitions to scan: 6 (out of 6)
                      Partitions scanned:  Avg 2.0 x 3 workers.  Max 2 parts (seg0).
                ->  Hash  (cost=431.00..431.00 rows=33 width=12) (actual rows=37 loops=1)
                      Buckets: 262144  Batches: 1  Memory Usage: 2050kB

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -8294,7 +8294,7 @@ explain select * from orca.t order by 1,2;
    ->  Sort  (cost=0.00..431.00 rows=1 width=24)
          Sort Key: timest, user_id
          ->  Dynamic Seq Scan on t  (cost=0.00..431.00 rows=1 width=24)
-               Number of partitions to scan: 6 
+               Number of partitions to scan: 6 (out of 6)
  Optimizer: Pivotal Optimizer (GPORCA)
 (7 rows)
 
@@ -8368,7 +8368,7 @@ explain select * from orca.t_date where user_id=9;
 -------------------------------------------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..431.00 rows=2 width=20)
    ->  Dynamic Seq Scan on t_date  (cost=0.00..431.00 rows=1 width=20)
-         Number of partitions to scan: 6 
+         Number of partitions to scan: 6 (out of 6)
          Filter: (user_id = '9'::numeric)
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
@@ -8411,7 +8411,7 @@ explain select * from orca.t_text where user_id=9;
 -------------------------------------------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..431.00 rows=2 width=20)
    ->  Dynamic Seq Scan on t_text  (cost=0.00..431.00 rows=1 width=20)
-         Number of partitions to scan: 3 
+         Number of partitions to scan: 3 (out of 3)
          Filter: (user_id = '9'::numeric)
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
@@ -8446,7 +8446,7 @@ explain select * from orca.t_ceeval_ints where user_id=4;
 -------------------------------------------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..431.00 rows=1 width=21)
    ->  Dynamic Seq Scan on t_ceeval_ints  (cost=0.00..431.00 rows=1 width=21)
-         Number of partitions to scan: 3 
+         Number of partitions to scan: 3 (out of 3)
          Filter: (user_id = '4'::numeric)
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
@@ -9978,7 +9978,7 @@ explain select * from orca.bm_dyn_test where i=2 and t='2';
 --------------------------------------------------------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..398.03 rows=2 width=10)
    ->  Dynamic Bitmap Heap Scan on bm_dyn_test  (cost=0.00..398.03 rows=1 width=10)
-         Number of partitions to scan: 6 
+         Number of partitions to scan: 6 (out of 6)
          Recheck Cond: (i = 2)
          Filter: ((i = 2) AND (t = '2'::text))
          ->  Dynamic Bitmap Index Scan on bm_dyn_test_idx  (cost=0.00..0.00 rows=0 width=0)
@@ -11525,7 +11525,7 @@ explain SELECT * FROM ds_part, non_part2 WHERE ds_part.c = non_part2.e AND non_p
    ->  Hash Join  (cost=0.00..1324481.18 rows=1 width=20)
          Hash Cond: (ds_part.c = non_part2.e)
          ->  Dynamic Seq Scan on ds_part  (cost=0.00..1324050.11 rows=334 width=12)
-               Number of partitions to scan: 6 
+               Number of partitions to scan: 6 (out of 6)
                Filter: ((a = (b + 1)) AND (SubPlan 1))
                SubPlan 1
                  ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
@@ -11952,12 +11952,12 @@ explain select * from part1, part2 where part1.b = part2.b limit 5;
                ->  Hash Join  (cost=0.00..862.13 rows=334 width=16)
                      Hash Cond: (part1.b = part2.b)
                      ->  Dynamic Seq Scan on part1  (cost=0.00..431.01 rows=334 width=8)
-                           Number of partitions to scan: 4 
+                           Number of partitions to scan: 4 (out of 4)
                      ->  Hash  (cost=431.02..431.02 rows=100 width=8)
                            ->  Partition Selector (selector id: $0)  (cost=0.00..431.02 rows=100 width=8)
                                  ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.02 rows=100 width=8)
                                        ->  Dynamic Seq Scan on part2  (cost=0.00..431.00 rows=34 width=8)
-                                             Number of partitions to scan: 4 
+                                             Number of partitions to scan: 4 (out of 4)
  Optimizer: Pivotal Optimizer (GPORCA)
 (13 rows)
 
@@ -12290,7 +12290,7 @@ explain select * from lossycastrangepart where b::int = 10;
 -----------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=16)
    ->  Dynamic Seq Scan on lossycastrangepart  (cost=0.00..431.00 rows=1 width=16)
-         Number of partitions to scan: 4 
+         Number of partitions to scan: 4 (out of 4)
          Filter: (int4(b) = 10)
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
@@ -12307,7 +12307,7 @@ explain select * from lossycastrangepart where b::int = 11;
 -----------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=16)
    ->  Dynamic Seq Scan on lossycastrangepart  (cost=0.00..431.00 rows=1 width=16)
-         Number of partitions to scan: 4 
+         Number of partitions to scan: 4 (out of 4)
          Filter: (int4(b) = 11)
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
@@ -12324,7 +12324,7 @@ explain select * from lossycastrangepart where b::int < 10;
 -----------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=16)
    ->  Dynamic Seq Scan on lossycastrangepart  (cost=0.00..431.00 rows=1 width=16)
-         Number of partitions to scan: 4 
+         Number of partitions to scan: 4 (out of 4)
          Filter: (int4(b) < 10)
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
@@ -12341,7 +12341,7 @@ explain select * from lossycastrangepart where b::int < 11;
 -----------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=16)
    ->  Dynamic Seq Scan on lossycastrangepart  (cost=0.00..431.00 rows=1 width=16)
-         Number of partitions to scan: 4 
+         Number of partitions to scan: 4 (out of 4)
          Filter: (int4(b) < 11)
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
@@ -12367,7 +12367,7 @@ explain select * from lossycastlistpart where b::int < 2;
 ----------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
    ->  Dynamic Seq Scan on lossycastlistpart  (cost=0.00..431.00 rows=1 width=12)
-         Number of partitions to scan: 3 
+         Number of partitions to scan: 3 (out of 3)
          Filter: (int4(b) < 2)
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
@@ -12383,7 +12383,7 @@ explain select * from lossycastlistpart where b::int = 2;
 ----------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
    ->  Dynamic Seq Scan on lossycastlistpart  (cost=0.00..431.00 rows=1 width=12)
-         Number of partitions to scan: 3 
+         Number of partitions to scan: 3 (out of 3)
          Filter: (int4(b) = 2)
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
@@ -13361,7 +13361,7 @@ explain (costs off) select * from tpart_dim d join tpart_ao_btree f on d.a=f.a w
          ->  Seq Scan on tpart_dim
                Filter: (b = 1)
          ->  Dynamic Bitmap Heap Scan on tpart_ao_btree
-               Number of partitions to scan: 2 
+               Number of partitions to scan: 2 (out of 2)
                Recheck Cond: (a = tpart_dim.a)
                Filter: (a = tpart_dim.a)
                ->  Dynamic Bitmap Index Scan on tpart_ao_btree_ix
@@ -13413,7 +13413,7 @@ explain (costs off) select * from tpart_ao_btree where a = 3 and b = 3;
 ------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)
    ->  Dynamic Seq Scan on tpart_ao_btree
-         Number of partitions to scan: 1 
+         Number of partitions to scan: 1 (out of 2)
          Filter: ((a = 3) AND (b = 3))
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
@@ -13511,7 +13511,7 @@ group by asset_records.uid, asset_records.hostname, asset_records.asset_type, as
                      ->  Hash Join
                            Hash Cond: ((upper((asset_records.hostname)::text) = upper((coverage.hostname)::text)) AND (asset_records.create_ts = coverage.date))
                            ->  Dynamic Seq Scan on asset_records
-                                 Number of partitions to scan: 5 
+                                 Number of partitions to scan: 5 (out of 5)
                                  Filter: ((upper((COALESCE(vendor, 'none'::character varying))::text) <> 'some_vendor'::text) AND (((asset_type)::text = 'xx'::text) OR ((asset_type)::text = 'yy'::text)) AND active)
                            ->  Hash
                                  ->  Partition Selector (selector id: $0)
@@ -13545,7 +13545,7 @@ explain (costs off) select count(*) from x, y where (x.i > y.j AND x.j <= y.i);
                ->  Dynamic Index Scan on y_idx on y
                      Index Cond: (j < x.i)
                      Filter: ((j < x.i) AND (x.j <= i))
-                     Number of partitions to scan: 5 
+                     Number of partitions to scan: 5 (out of 5)
  Optimizer: Pivotal Optimizer (GPORCA)
 (11 rows)
 
@@ -13572,7 +13572,7 @@ explain (costs off) select * from infer_part_vc inner join infer_txt on (infer_p
    ->  Hash Join
          Hash Cond: ((infer_part_vc.gender)::text = infer_txt.a)
          ->  Dynamic Seq Scan on infer_part_vc
-               Number of partitions to scan: 1 
+               Number of partitions to scan: 1 (out of 3)
                Filter: ((gender)::text = 'M'::text)
          ->  Hash
                ->  Partition Selector (selector id: $0)
@@ -13641,7 +13641,7 @@ explain (costs off) select * from pt where gender in ( 'F', 'FM');
 -----------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Dynamic Seq Scan on pt
-         Number of partitions to scan: 2 
+         Number of partitions to scan: 2 (out of 3)
          Filter: ((gender)::text = ANY ('{F,FM}'::text[]))
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
@@ -13659,16 +13659,16 @@ select * from pt where gender is null;
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Append
          ->  Dynamic Seq Scan on pt
-               Number of partitions to scan: 1 
+               Number of partitions to scan: 1 (out of 3)
                Filter: ((gender)::text = 'F'::text)
          ->  Dynamic Seq Scan on pt pt_1
-               Number of partitions to scan: 3 
+               Number of partitions to scan: 3 (out of 3)
                Filter: ((gender)::text <= 'M'::text)
          ->  Dynamic Seq Scan on pt pt_2
-               Number of partitions to scan: 2 
+               Number of partitions to scan: 2 (out of 3)
                Filter: ((gender)::text = ANY ('{F,FM}'::text[]))
          ->  Dynamic Seq Scan on pt pt_3
-               Number of partitions to scan: 1 
+               Number of partitions to scan: 1 (out of 3)
                Filter: (gender IS NULL)
  Optimizer: Pivotal Optimizer (GPORCA)
 (15 rows)
@@ -13712,7 +13712,7 @@ where d.msisdn=f.subscriberaddress and
          ->  Hash
                ->  Broadcast Motion 3:3  (slice2; segments: 3)
                      ->  Dynamic Seq Scan on stg_xdr_crce_cdr
-                           Number of partitions to scan: 2 
+                           Number of partitions to scan: 2 (out of 2)
  Optimizer: Pivotal Optimizer (GPORCA)
 (11 rows)
 
@@ -13733,7 +13733,7 @@ where month_id::text = 'Apr';
 --------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Dynamic Seq Scan on ds_4
-         Number of partitions to scan: 1 
+         Number of partitions to scan: 1 (out of 2)
          Filter: ((month_id)::text = 'Apr'::text)
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
@@ -13750,7 +13750,7 @@ where month_id::text >= 'Feb' and month_id::text < 'Mar';
 ------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Dynamic Seq Scan on ds_4
-         Number of partitions to scan: 2 
+         Number of partitions to scan: 2 (out of 2)
          Filter: (((month_id)::text >= 'Feb'::text) AND ((month_id)::text < 'Mar'::text))
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
@@ -13794,7 +13794,7 @@ ORDER BY to_char(order_datetime,'YYYY-Q')
                                  ->  Sort
                                        Sort Key: (to_char(order_datetime, 'YYYY-Q'::text)), item_shipment_status_code, order_id
                                        ->  Dynamic Seq Scan on order_lineitems
-                                             Number of partitions to scan: 3 
+                                             Number of partitions to scan: 3 (out of 12)
                                              Filter: ((order_datetime >= 'Thu Apr 01 00:00:00 2010'::timestamp without time zone) AND (order_datetime <= '06-30-2010'::date))
  Optimizer: Pivotal Optimizer (GPORCA)
 (18 rows)

--- a/src/test/regress/expected/inherit_optimizer.out
+++ b/src/test/regress/expected/inherit_optimizer.out
@@ -1881,7 +1881,7 @@ explain (costs off) select * from list_parted;
 ------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Dynamic Seq Scan on list_parted
-         Number of partitions to scan: 3 
+         Number of partitions to scan: 3 (out of 3)
  Optimizer: Pivotal Optimizer (GPORCA)
 (4 rows)
 
@@ -1890,7 +1890,7 @@ explain (costs off) select * from list_parted where a is null;
 ------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)
    ->  Dynamic Seq Scan on list_parted
-         Number of partitions to scan: 1 
+         Number of partitions to scan: 1 (out of 3)
          Filter: (a IS NULL)
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
@@ -1900,7 +1900,7 @@ explain (costs off) select * from list_parted where a is not null;
 ------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Dynamic Seq Scan on list_parted
-         Number of partitions to scan: 3 
+         Number of partitions to scan: 3 (out of 3)
          Filter: (NOT (a IS NULL))
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
@@ -1910,7 +1910,7 @@ explain (costs off) select * from list_parted where a in ('ab', 'cd', 'ef');
 ----------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Dynamic Seq Scan on list_parted
-         Number of partitions to scan: 2 
+         Number of partitions to scan: 2 (out of 3)
          Filter: ((a)::text = ANY ('{ab,cd,ef}'::text[]))
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
@@ -1920,7 +1920,7 @@ explain (costs off) select * from list_parted where a = 'ab' or a in (null, 'cd'
 ---------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Dynamic Seq Scan on list_parted
-         Number of partitions to scan: 1 
+         Number of partitions to scan: 1 (out of 3)
          Filter: (((a)::text = 'ab'::text) OR ((a)::text = ANY ('{NULL,cd}'::text[])))
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
@@ -1930,7 +1930,7 @@ explain (costs off) select * from list_parted where a = 'ab';
 ------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Dynamic Seq Scan on list_parted
-         Number of partitions to scan: 1 
+         Number of partitions to scan: 1 (out of 3)
          Filter: ((a)::text = 'ab'::text)
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
@@ -2201,7 +2201,7 @@ explain (costs off) select min(a), max(a) from parted_minmax where b = '12345';
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Partial Aggregate
                ->  Dynamic Seq Scan on parted_minmax
-                     Number of partitions to scan: 1 
+                     Number of partitions to scan: 1 (out of 1)
                      Filter: ((b)::text = '12345'::text)
  Optimizer: Pivotal Optimizer (GPORCA)
 (7 rows)
@@ -2343,7 +2343,7 @@ explain (costs off) select * from mclparted order by a;
    ->  Sort
          Sort Key: a
          ->  Dynamic Seq Scan on mclparted
-               Number of partitions to scan: 2 
+               Number of partitions to scan: 2 (out of 2)
  Optimizer: Pivotal Optimizer (GPORCA)
 (7 rows)
 
@@ -2359,7 +2359,7 @@ explain (costs off) select * from mclparted order by a;
    ->  Sort
          Sort Key: a
          ->  Dynamic Seq Scan on mclparted
-               Number of partitions to scan: 4 
+               Number of partitions to scan: 4 (out of 4)
  Optimizer: Pivotal Optimizer (GPORCA)
 (7 rows)
 
@@ -2423,7 +2423,7 @@ explain (costs off) select * from bool_lp order by b;
    ->  Sort
          Sort Key: b
          ->  Dynamic Seq Scan on bool_lp
-               Number of partitions to scan: 2 
+               Number of partitions to scan: 2 (out of 2)
  Optimizer: Pivotal Optimizer (GPORCA)
 (7 rows)
 

--- a/src/test/regress/expected/orca_static_pruning_optimizer.out
+++ b/src/test/regress/expected/orca_static_pruning_optimizer.out
@@ -22,7 +22,7 @@ EXPLAIN (COSTS OFF, VERBOSE)
    Output: a, b, c
    ->  Dynamic Seq Scan on orca_static_pruning.rp
          Output: a, b, c
-         Number of partitions to scan: 1 
+         Number of partitions to scan: 1 (out of 3)
          Filter: (rp.b > 4200)
  Optimizer: Pivotal Optimizer (GPORCA)
  Settings: optimizer=on
@@ -47,7 +47,7 @@ EXPLAIN (COSTS OFF, VERBOSE)
    Output: a, b, c
    ->  Dynamic Seq Scan on orca_static_pruning.rp
          Output: a, b, c
-         Number of partitions to scan: 1 
+         Number of partitions to scan: 1 (out of 3)
          Filter: (rp.b = 4201)
  Optimizer: Pivotal Optimizer (GPORCA)
  Settings: optimizer=on
@@ -72,7 +72,7 @@ EXPLAIN (COSTS OFF, VERBOSE)
    Output: a, b, c
    ->  Dynamic Seq Scan on orca_static_pruning.rp
          Output: a, b, c
-         Number of partitions to scan: 1 
+         Number of partitions to scan: 1 (out of 3)
          Filter: (rp.b = ANY ('{4201,4200}'::integer[]))
  Optimizer: Pivotal Optimizer (GPORCA)
  Settings: optimizer=on
@@ -107,7 +107,7 @@ EXPLAIN (COSTS OFF, VERBOSE)
    Output: a, b
    ->  Dynamic Seq Scan on orca_static_pruning.lp
          Output: a, b
-         Number of partitions to scan: 1 
+         Number of partitions to scan: 1 (out of 3)
          Filter: (lp.b > 42)
  Optimizer: Pivotal Optimizer (GPORCA)
  Settings: optimizer=on
@@ -131,7 +131,7 @@ EXPLAIN (COSTS OFF, VERBOSE)
    Output: a, b
    ->  Dynamic Seq Scan on orca_static_pruning.lp
          Output: a, b
-         Number of partitions to scan: 1 
+         Number of partitions to scan: 1 (out of 3)
          Filter: (lp.b = 42)
  Optimizer: Pivotal Optimizer (GPORCA)
  Settings: optimizer=on
@@ -205,7 +205,7 @@ EXPLAIN (COSTS OFF, VERBOSE) SELECT * FROM rp_multi_inds WHERE b = 11 AND (c = 1
    Output: a, b, c
    ->  Dynamic Bitmap Heap Scan on orca_static_pruning.rp_multi_inds
          Output: a, b, c
-         Number of partitions to scan: 1 
+         Number of partitions to scan: 1 (out of 3)
          Recheck Cond: (((rp_multi_inds.c = 11) OR (rp_multi_inds.c = 4201)) AND (rp_multi_inds.b = 11))
          Filter: (((rp_multi_inds.c = 11) OR (rp_multi_inds.c = 4201)) AND (rp_multi_inds.b = 11))
          ->  BitmapAnd
@@ -259,7 +259,7 @@ EXPLAIN (COSTS OFF, VERBOSE) SELECT * FROM foo JOIN bar on foo.a = bar.a AND foo
                Output: foo.a, foo.b
                Index Cond: (foo.a = bar.a)
                Filter: ((foo.a = bar.a) AND (foo.b = 11))
-               Number of partitions to scan: 1 
+               Number of partitions to scan: 1 (out of 3)
  Optimizer: Pivotal Optimizer (GPORCA)
  Settings: enable_hashjoin=off, enable_mergejoin=off, enable_nestloop=on, optimizer=on
 (14 rows)
@@ -302,7 +302,7 @@ EXPLAIN (COSTS OFF, VERBOSE) INSERT INTO rp_insert SELECT * FROM rp_insert;
  Insert on orca_static_pruning.rp_insert
    ->  Dynamic Seq Scan on orca_static_pruning.rp_insert rp_insert_1
          Output: rp_insert_1.a, rp_insert_1.b
-         Number of partitions to scan: 2 
+         Number of partitions to scan: 2 (out of 2)
  Optimizer: Pivotal Optimizer (GPORCA)
  Settings: optimizer=on
 (6 rows)

--- a/src/test/regress/expected/partition_prune_optimizer.out
+++ b/src/test/regress/expected/partition_prune_optimizer.out
@@ -46,7 +46,7 @@ explain (costs off) select * from lp;
 ------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Dynamic Seq Scan on lp
-         Number of partitions to scan: 6 
+         Number of partitions to scan: 6 (out of 6)
  Optimizer: Pivotal Optimizer (GPORCA)
 (4 rows)
 
@@ -55,7 +55,7 @@ explain (costs off) select * from lp where a > 'a' and a < 'd';
 -----------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Dynamic Seq Scan on lp
-         Number of partitions to scan: 2 
+         Number of partitions to scan: 2 (out of 6)
          Filter: ((a > 'a'::bpchar) AND (a < 'd'::bpchar))
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
@@ -65,7 +65,7 @@ explain (costs off) select * from lp where a > 'a' and a <= 'd';
 ------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Dynamic Seq Scan on lp
-         Number of partitions to scan: 3 
+         Number of partitions to scan: 3 (out of 6)
          Filter: ((a > 'a'::bpchar) AND (a <= 'd'::bpchar))
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
@@ -75,7 +75,7 @@ explain (costs off) select * from lp where a = 'a';
 ------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)
    ->  Dynamic Seq Scan on lp
-         Number of partitions to scan: 1 
+         Number of partitions to scan: 1 (out of 6)
          Filter: (a = 'a'::bpchar)
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
@@ -85,7 +85,7 @@ explain (costs off) select * from lp where 'a' = a;	/* commuted */
 ------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)
    ->  Dynamic Seq Scan on lp
-         Number of partitions to scan: 1 
+         Number of partitions to scan: 1 (out of 6)
          Filter: (a = 'a'::bpchar)
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
@@ -95,7 +95,7 @@ explain (costs off) select * from lp where a is not null;
 ------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Dynamic Seq Scan on lp
-         Number of partitions to scan: 5 
+         Number of partitions to scan: 5 (out of 6)
          Filter: (NOT (a IS NULL))
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
@@ -105,7 +105,7 @@ explain (costs off) select * from lp where a is null;
 ------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)
    ->  Dynamic Seq Scan on lp
-         Number of partitions to scan: 1 
+         Number of partitions to scan: 1 (out of 6)
          Filter: (a IS NULL)
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
@@ -115,7 +115,7 @@ explain (costs off) select * from lp where a = 'a' or a = 'c';
 ----------------------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)
    ->  Dynamic Seq Scan on lp
-         Number of partitions to scan: 2 
+         Number of partitions to scan: 2 (out of 6)
          Filter: ((a = 'a'::bpchar) OR (a = 'c'::bpchar))
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
@@ -125,7 +125,7 @@ explain (costs off) select * from lp where a is not null and (a = 'a' or a = 'c'
 ----------------------------------------------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)
    ->  Dynamic Seq Scan on lp
-         Number of partitions to scan: 2 
+         Number of partitions to scan: 2 (out of 6)
          Filter: ((NOT (a IS NULL)) AND ((a = 'a'::bpchar) OR (a = 'c'::bpchar)))
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
@@ -135,7 +135,7 @@ explain (costs off) select * from lp where a <> 'g';
 ------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Dynamic Seq Scan on lp
-         Number of partitions to scan: 4 
+         Number of partitions to scan: 4 (out of 6)
          Filter: (a <> 'g'::bpchar)
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
@@ -145,7 +145,7 @@ explain (costs off) select * from lp where a <> 'a' and a <> 'd';
 -------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Dynamic Seq Scan on lp
-         Number of partitions to scan: 4 
+         Number of partitions to scan: 4 (out of 6)
          Filter: ((a <> 'a'::bpchar) AND (a <> 'd'::bpchar))
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
@@ -155,7 +155,7 @@ explain (costs off) select * from lp where a not in ('a', 'd');
 ------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Dynamic Seq Scan on lp
-         Number of partitions to scan: 4 
+         Number of partitions to scan: 4 (out of 6)
          Filter: (a <> ALL ('{a,d}'::bpchar[]))
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
@@ -1161,7 +1161,7 @@ explain (costs off) select * from boolpart where a in (true, false);
 ------------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)
    ->  Dynamic Seq Scan on boolpart
-         Number of partitions to scan: 2 
+         Number of partitions to scan: 2 (out of 3)
          Filter: (a = ANY ('{t,f}'::boolean[]))
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
@@ -1171,7 +1171,7 @@ explain (costs off) select * from boolpart where a = false;
 ------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Dynamic Seq Scan on boolpart
-         Number of partitions to scan: 3 
+         Number of partitions to scan: 3 (out of 3)
          Filter: (NOT a)
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
@@ -1181,7 +1181,7 @@ explain (costs off) select * from boolpart where not a = false;
 ------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Dynamic Seq Scan on boolpart
-         Number of partitions to scan: 3 
+         Number of partitions to scan: 3 (out of 3)
          Filter: a
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
@@ -1191,7 +1191,7 @@ explain (costs off) select * from boolpart where a is true or a is not true;
 --------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Dynamic Seq Scan on boolpart
-         Number of partitions to scan: 3 
+         Number of partitions to scan: 3 (out of 3)
          Filter: ((a IS TRUE) OR (a IS NOT TRUE))
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
@@ -1201,7 +1201,7 @@ explain (costs off) select * from boolpart where a is not true;
 ------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Dynamic Seq Scan on boolpart
-         Number of partitions to scan: 3 
+         Number of partitions to scan: 3 (out of 3)
          Filter: (a IS NOT TRUE)
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
@@ -1211,7 +1211,7 @@ explain (costs off) select * from boolpart where a is not true and a is not fals
 --------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Dynamic Seq Scan on boolpart
-         Number of partitions to scan: 3 
+         Number of partitions to scan: 3 (out of 3)
          Filter: ((a IS NOT TRUE) AND (a IS NOT FALSE))
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
@@ -1221,7 +1221,7 @@ explain (costs off) select * from boolpart where a is unknown;
 ------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Dynamic Seq Scan on boolpart
-         Number of partitions to scan: 3 
+         Number of partitions to scan: 3 (out of 3)
          Filter: (a IS UNKNOWN)
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
@@ -1231,7 +1231,7 @@ explain (costs off) select * from boolpart where a is not unknown;
 ------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Dynamic Seq Scan on boolpart
-         Number of partitions to scan: 3 
+         Number of partitions to scan: 3 (out of 3)
          Filter: (a IS NOT UNKNOWN)
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
@@ -1246,7 +1246,7 @@ explain (costs off) select * from coercepart where a in ('ab', to_char(125, '999
 -----------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Dynamic Seq Scan on coercepart
-         Number of partitions to scan: 1 
+         Number of partitions to scan: 1 (out of 3)
          Filter: ((a)::text = ANY ('{ab," 125"}'::text[]))
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
@@ -1256,7 +1256,7 @@ explain (costs off) select * from coercepart where a ~ any ('{ab}');
 ----------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Dynamic Seq Scan on coercepart
-         Number of partitions to scan: 3 
+         Number of partitions to scan: 3 (out of 3)
          Filter: ((a)::text ~ ANY ('{ab}'::text[]))
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
@@ -1266,7 +1266,7 @@ explain (costs off) select * from coercepart where a !~ all ('{ab}');
 -----------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Dynamic Seq Scan on coercepart
-         Number of partitions to scan: 3 
+         Number of partitions to scan: 3 (out of 3)
          Filter: ((a)::text !~ ALL ('{ab}'::text[]))
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
@@ -1276,7 +1276,7 @@ explain (costs off) select * from coercepart where a ~ any ('{ab,bc}');
 -------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Dynamic Seq Scan on coercepart
-         Number of partitions to scan: 3 
+         Number of partitions to scan: 3 (out of 3)
          Filter: ((a)::text ~ ANY ('{ab,bc}'::text[]))
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
@@ -1286,7 +1286,7 @@ explain (costs off) select * from coercepart where a !~ all ('{ab,bc}');
 --------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Dynamic Seq Scan on coercepart
-         Number of partitions to scan: 3 
+         Number of partitions to scan: 3 (out of 3)
          Filter: ((a)::text !~ ALL ('{ab,bc}'::text[]))
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
@@ -1421,7 +1421,7 @@ explain (costs off) select * from rp where a <> 1;
 ------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Dynamic Seq Scan on rp
-         Number of partitions to scan: 3 
+         Number of partitions to scan: 3 (out of 3)
          Filter: (a <> 1)
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
@@ -1431,7 +1431,7 @@ explain (costs off) select * from rp where a <> 1 and a <> 2;
 ------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Dynamic Seq Scan on rp
-         Number of partitions to scan: 3 
+         Number of partitions to scan: 3 (out of 3)
          Filter: ((a <> 1) AND (a <> 2))
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
@@ -1442,7 +1442,7 @@ explain (costs off) select * from lp where a <> 'a';
 ------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Dynamic Seq Scan on lp
-         Number of partitions to scan: 5 
+         Number of partitions to scan: 5 (out of 6)
          Filter: (a <> 'a'::bpchar)
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
@@ -1461,7 +1461,7 @@ explain (costs off) select * from lp where (a <> 'a' and a <> 'd') or a is null;
 ------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Dynamic Seq Scan on lp
-         Number of partitions to scan: 5 
+         Number of partitions to scan: 5 (out of 6)
          Filter: (((a <> 'a'::bpchar) AND (a <> 'd'::bpchar)) OR (a IS NULL))
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
@@ -1537,7 +1537,7 @@ explain (costs off) select * from like_op_noprune where a like '%BC';
 -------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Dynamic Seq Scan on like_op_noprune
-         Number of partitions to scan: 2 
+         Number of partitions to scan: 2 (out of 2)
          Filter: (a ~~ '%BC'::text)
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
@@ -1575,7 +1575,7 @@ explain (costs off) select * from rparted_by_int2 where a > 100000000000000;
 -------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Dynamic Seq Scan on rparted_by_int2
-         Number of partitions to scan: 1 
+         Number of partitions to scan: 1 (out of 3)
          Filter: (a > '100000000000000'::bigint)
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
@@ -1953,7 +1953,7 @@ explain (analyze, costs off, summary off, timing off) select * from list_part wh
 ------------------------------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1) (actual rows=1 loops=1)
    ->  Dynamic Seq Scan on list_part (actual rows=1 loops=1)
-         Number of partitions to scan: 1 
+         Number of partitions to scan: 1 (out of 4)
          Filter: (a = 1)
          Partitions scanned:  1 .
  Optimizer: Pivotal Optimizer (GPORCA)
@@ -1965,7 +1965,7 @@ explain (analyze, costs off, summary off, timing off) select * from list_part wh
 ------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=4 loops=1)
    ->  Dynamic Seq Scan on list_part (actual rows=3 loops=1)
-         Number of partitions to scan: 4 
+         Number of partitions to scan: 4 (out of 4)
          Filter: (a = list_part_fn(a))
          Partitions scanned:  Avg 4.0 x 3 workers.  Max 4 parts (seg0).
  Optimizer: Pivotal Optimizer (GPORCA)
@@ -1977,7 +1977,7 @@ explain (analyze, costs off, summary off, timing off) select * from list_part wh
 ------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
    ->  Dynamic Seq Scan on list_part (actual rows=0 loops=1)
-         Number of partitions to scan: 4 
+         Number of partitions to scan: 4 (out of 4)
          Filter: (a = (1 + a))
          Partitions scanned:  Avg 4.0 x 3 workers.  Max 4 parts (seg0).
  Optimizer: Pivotal Optimizer (GPORCA)
@@ -2722,7 +2722,7 @@ select * from tbl1 join tprt on tbl1.col1 > tprt.col1;
          Rows Removed by Join Filter: 3
          ->  Broadcast Motion 3:3  (slice2; segments: 3) (actual rows=7 loops=1)
                ->  Dynamic Seq Scan on tprt (actual rows=3 loops=1)
-                     Number of partitions to scan: 6 
+                     Number of partitions to scan: 6 (out of 6)
                      Partitions scanned:  Avg 6.0 x 3 workers.  Max 6 parts (seg0).
          ->  Seq Scan on tbl1 (actual rows=1 loops=8)
  Optimizer: Pivotal Optimizer (GPORCA)
@@ -2740,7 +2740,7 @@ select * from tbl1 join tprt on tbl1.col1 = tprt.col1;
          ->  Hash (actual rows=3 loops=1)
                Buckets: 524288  Batches: 1  Memory Usage: 4097kB
                ->  Dynamic Seq Scan on tprt (actual rows=3 loops=1)
-                     Number of partitions to scan: 6 
+                     Number of partitions to scan: 6 (out of 6)
                      Partitions scanned:  Avg 6.0 x 3 workers.  Max 6 parts (seg0).
  Optimizer: Pivotal Optimizer (GPORCA)
 (10 rows)
@@ -2779,7 +2779,7 @@ select * from tbl1 inner join tprt on tbl1.col1 > tprt.col1;
          Rows Removed by Join Filter: 6
          ->  Broadcast Motion 3:3  (slice2; segments: 3) (actual rows=7 loops=1)
                ->  Dynamic Seq Scan on tprt (actual rows=3 loops=1)
-                     Number of partitions to scan: 6 
+                     Number of partitions to scan: 6 (out of 6)
                      Partitions scanned:  Avg 6.0 x 3 workers.  Max 6 parts (seg0).
          ->  Seq Scan on tbl1 (actual rows=3 loops=8)
  Optimizer: Pivotal Optimizer (GPORCA)
@@ -2797,7 +2797,7 @@ select * from tbl1 inner join tprt on tbl1.col1 = tprt.col1;
          ->  Hash (actual rows=3 loops=1)
                Buckets: 524288  Batches: 1  Memory Usage: 4097kB
                ->  Dynamic Seq Scan on tprt (actual rows=3 loops=1)
-                     Number of partitions to scan: 6 
+                     Number of partitions to scan: 6 (out of 6)
                      Partitions scanned:  Avg 6.0 x 3 workers.  Max 6 parts (seg0).
  Optimizer: Pivotal Optimizer (GPORCA)
 (10 rows)
@@ -2855,7 +2855,7 @@ select * from tbl1 join tprt on tbl1.col1 < tprt.col1;
          Rows Removed by Join Filter: 6
          ->  Broadcast Motion 3:3  (slice2; segments: 3) (actual rows=7 loops=1)
                ->  Dynamic Seq Scan on tprt (actual rows=3 loops=1)
-                     Number of partitions to scan: 6 
+                     Number of partitions to scan: 6 (out of 6)
                      Partitions scanned:  Avg 6.0 x 3 workers.  Max 6 parts (seg0).
          ->  Seq Scan on tbl1 (actual rows=1 loops=8)
  Optimizer: Pivotal Optimizer (GPORCA)
@@ -2884,7 +2884,7 @@ select * from tbl1 join tprt on tbl1.col1 = tprt.col1;
          ->  Hash (actual rows=3 loops=1)
                Buckets: 524288  Batches: 1  Memory Usage: 4097kB
                ->  Dynamic Seq Scan on tprt (actual rows=3 loops=1)
-                     Number of partitions to scan: 6 
+                     Number of partitions to scan: 6 (out of 6)
                      Partitions scanned:  Avg 6.0 x 3 workers.  Max 6 parts (seg0).
  Optimizer: Pivotal Optimizer (GPORCA)
 (10 rows)
@@ -3055,8 +3055,8 @@ select * from stable_qual_pruning where a < localtimestamp;
 -------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
    ->  Dynamic Seq Scan on stable_qual_pruning (actual rows=0 loops=1)
-         Number of partitions to scan: 2 
-         Filter: (a < 'Thu May 19 15:14:26.02528 2022'::timestamp without time zone)
+         Number of partitions to scan: 2 (out of 3)
+         Filter: (a < 'Tue Sep 13 01:07:32.868324 2022'::timestamp without time zone)
          Partitions scanned:  Avg 2.0 x 3 workers.  Max 2 parts (seg0).
  Optimizer: Pivotal Optimizer (GPORCA)
 (6 rows)
@@ -3068,7 +3068,7 @@ select * from stable_qual_pruning where a < '2000-02-01'::timestamptz;
 --------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
    ->  Dynamic Seq Scan on stable_qual_pruning (actual rows=0 loops=1)
-         Number of partitions to scan: 1 
+         Number of partitions to scan: 1 (out of 3)
          Filter: (a < 'Tue Feb 01 00:00:00 2000 PST'::timestamp with time zone)
          Partitions scanned:  Avg 1.0 x 3 workers.  Max 1 parts (seg0).
  Optimizer: Pivotal Optimizer (GPORCA)
@@ -3092,7 +3092,7 @@ select * from stable_qual_pruning
 ----------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
    ->  Dynamic Seq Scan on stable_qual_pruning (actual rows=0 loops=1)
-         Number of partitions to scan: 1 
+         Number of partitions to scan: 1 (out of 3)
          Filter: (a = ANY ('{"Tue Feb 01 00:00:00 2000","Fri Jan 01 00:00:00 2010"}'::timestamp without time zone[]))
          Partitions scanned:  Avg 1.0 x 3 workers.  Max 1 parts (seg0).
  Optimizer: Pivotal Optimizer (GPORCA)
@@ -3105,8 +3105,8 @@ select * from stable_qual_pruning
 -----------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
    ->  Dynamic Seq Scan on stable_qual_pruning (actual rows=0 loops=1)
-         Number of partitions to scan: 1 
-         Filter: (a = ANY ('{"Tue Feb 01 00:00:00 2000","Thu May 19 15:14:26.037645 2022"}'::timestamp without time zone[]))
+         Number of partitions to scan: 1 (out of 3)
+         Filter: (a = ANY ('{"Tue Feb 01 00:00:00 2000","Tue Sep 13 01:07:32.90543 2022"}'::timestamp without time zone[]))
          Partitions scanned:  Avg 1.0 x 3 workers.  Max 1 parts (seg0).
  Optimizer: Pivotal Optimizer (GPORCA)
 (6 rows)
@@ -3128,7 +3128,7 @@ select * from stable_qual_pruning
 ---------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=0 loops=1)
    ->  Dynamic Seq Scan on stable_qual_pruning (actual rows=0 loops=1)
-         Number of partitions to scan: 1 
+         Number of partitions to scan: 1 (out of 3)
          Filter: (a = ANY ('{"Tue Feb 01 00:00:00 2000 PST","Fri Jan 01 00:00:00 2010 PST"}'::timestamp with time zone[]))
          Partitions scanned:  Avg 1.0 x 3 workers.  Max 1 parts (seg0).
  Optimizer: Pivotal Optimizer (GPORCA)
@@ -3241,7 +3241,7 @@ select * from boolp where a = (select value from boolvalues where value);
                Buckets: 262144  Batches: 1  Memory Usage: 2048kB
                ->  Broadcast Motion 3:3  (slice4; segments: 3) (actual rows=0 loops=1)
                      ->  Dynamic Seq Scan on boolp (actual rows=0 loops=1)
-                           Number of partitions to scan: 2 
+                           Number of partitions to scan: 2 (out of 2)
                            Partitions scanned:  Avg 2.0 x 3 workers.  Max 2 parts (seg0).
  Optimizer: Pivotal Optimizer (GPORCA)
 (18 rows)
@@ -3265,7 +3265,7 @@ select * from boolp where a = (select value from boolvalues where not value);
                Buckets: 262144  Batches: 1  Memory Usage: 2048kB
                ->  Broadcast Motion 3:3  (slice4; segments: 3) (actual rows=0 loops=1)
                      ->  Dynamic Seq Scan on boolp (actual rows=0 loops=1)
-                           Number of partitions to scan: 2 
+                           Number of partitions to scan: 2 (out of 2)
                            Partitions scanned:  Avg 2.0 x 3 workers.  Max 2 parts (seg0).
  Optimizer: Pivotal Optimizer (GPORCA)
 (18 rows)
@@ -3372,7 +3372,7 @@ explain (analyze, costs off, summary off, timing off) select * from ma_test wher
                                  ->  Partial Aggregate (actual rows=1 loops=1)
                                        ->  Seq Scan on ma_test_p2 (actual rows=5 loops=1)
                ->  Dynamic Seq Scan on ma_test (actual rows=6 loops=2)
-                     Number of partitions to scan: 3 
+                     Number of partitions to scan: 3 (out of 3)
                      Partitions scanned:  Avg 2.0 x 3 workers of 2 scans.  Max 2 parts (seg0).
  Optimizer: Pivotal Optimizer (GPORCA)
 (17 rows)
@@ -3398,7 +3398,7 @@ explain (costs off) select * from pp_arrpart where a = '{1}';
 ------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)
    ->  Dynamic Seq Scan on pp_arrpart
-         Number of partitions to scan: 1 
+         Number of partitions to scan: 1 (out of 2)
          Filter: (a = '{1}'::integer[])
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
@@ -3416,7 +3416,7 @@ explain (costs off) select * from pp_arrpart where a in ('{4, 5}', '{1}');
 ----------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Dynamic Seq Scan on pp_arrpart
-         Number of partitions to scan: 2 
+         Number of partitions to scan: 2 (out of 2)
          Filter: ((a = '{4,5}'::integer[]) OR (a = '{1}'::integer[]))
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
@@ -3504,7 +3504,7 @@ explain (costs off) select * from pp_enumpart where a = 'blue';
 ------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)
    ->  Dynamic Seq Scan on pp_enumpart
-         Number of partitions to scan: 1 
+         Number of partitions to scan: 1 (out of 2)
          Filter: (a = 'blue'::pp_colors)
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
@@ -3532,7 +3532,7 @@ explain (costs off) select * from pp_recpart where a = '(1,1)'::pp_rectype;
 -------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Dynamic Seq Scan on pp_recpart
-         Number of partitions to scan: 1 
+         Number of partitions to scan: 1 (out of 2)
          Filter: (a = '(1,1)'::pp_rectype)
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
@@ -3560,7 +3560,7 @@ explain (costs off) select * from pp_intrangepart where a = '[1,2]'::int4range;
 -------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)
    ->  Dynamic Seq Scan on pp_intrangepart
-         Number of partitions to scan: 1 
+         Number of partitions to scan: 1 (out of 2)
          Filter: (a = '[1,3)'::int4range)
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
@@ -3589,7 +3589,7 @@ explain (costs off) select * from pp_lp where a = 1;
 ------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)
    ->  Dynamic Seq Scan on pp_lp
-         Number of partitions to scan: 1 
+         Number of partitions to scan: 1 (out of 2)
          Filter: (a = 1)
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
@@ -3621,7 +3621,7 @@ explain (costs off) select * from pp_lp where a = 1;
 ------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)
    ->  Dynamic Seq Scan on pp_lp
-         Number of partitions to scan: 1 
+         Number of partitions to scan: 1 (out of 2)
          Filter: (a = 1)
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
@@ -3658,7 +3658,7 @@ explain (costs off) select * from pp_lp where a = 1;
 ------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)
    ->  Dynamic Seq Scan on pp_lp
-         Number of partitions to scan: 1 
+         Number of partitions to scan: 1 (out of 2)
          Filter: (a = 1)
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
@@ -3774,7 +3774,7 @@ explain (costs off) select * from pp_temp_parent where true;
 ------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Dynamic Seq Scan on pp_temp_parent
-         Number of partitions to scan: 2 
+         Number of partitions to scan: 2 (out of 2)
  Optimizer: Pivotal Optimizer (GPORCA)
 (4 rows)
 
@@ -3783,7 +3783,7 @@ explain (costs off) select * from pp_temp_parent where a = 2;
 ------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)
    ->  Dynamic Seq Scan on pp_temp_parent
-         Number of partitions to scan: 1 
+         Number of partitions to scan: 1 (out of 2)
          Filter: (a = 2)
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)


### PR DESCRIPTION
""GPDB_12_MERGE_FIXME: we used to show something along the lines of "Partitions selected: 1 (out of 5)" under the partition selector. By eleminating the (static) partition selector during translation, we only get the survivor count, and lose the size of the universe temporarily. However, if we manage to shift the static pruning information sufficiently adjacent to (or better, into) a DXL Dynamic Table Scan, we should be able to get that information back.""

Through this PR I am trying to pass the total partition information through ORCA and into the plan node used in explain.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
