### PR TITLE
Fixes for dumping from GPDB5/6 using GPDB7 pg_dump

### DIFF
--- a/src/bin/pg_dump/pg_backup_db.c
+++ b/src/bin/pg_dump/pg_backup_db.c
@@ -335,7 +335,7 @@ ConnectDatabase(Archive *AHX,
 	if (binary_upgrade)
 	{
 		keywords[6] = "options";
-		values[6] = AH->public.remoteVersion < 12000 ?
+		values[6] = AH->public.remoteVersion < 120000 ?
 								"-c gp_session_role=utility" : "-c gp_role=utility";
 		keywords[7] = NULL;
 		values[7] = NULL;

--- a/src/bin/pg_dump/pg_dump.h
+++ b/src/bin/pg_dump/pg_dump.h
@@ -386,7 +386,7 @@ typedef struct _tableInfo
 	 */
 	int			numParents;		/* number of (immediate) parent tables */
 	struct _tableInfo **parents;	/* TableInfos of immediate parents */
-	Oid			parrelid;			/* external partition's parent oid */
+	Oid			parrelid;			/* partition's parent oid */
 	bool		parparent;		/* true if the table is partition parent */
 	int			numIndexes;		/* number of indexes */
 	struct _indxInfo *indexes;	/* indexes */

--- a/src/bin/pg_dump/pg_dump.h
+++ b/src/bin/pg_dump/pg_dump.h
@@ -399,6 +399,8 @@ typedef struct _tableInfo
 	Oid		toast_type;					/* OID of toast table's composite type */
 	struct _aotableInfo	*aotbl; /* AO auxilliary table metadata */
 	char	*distclause; /* distributed by clause */
+	char	*partclause;	/* partition definition, if table is partition parent */
+	char	*parttemplate;	/* subpartition template */
 } TableInfo;
 
 /* AO auxilliary table metadata */

--- a/src/bin/pg_dump/pg_dumpall.c
+++ b/src/bin/pg_dump/pg_dumpall.c
@@ -1348,10 +1348,13 @@ dumpRoles(PGconn *conn)
 		else
 			appendPQExpBufferStr(buf, " NOREPLICATION");
 
-		if (strcmp(PQgetvalue(res, i, i_rolbypassrls), "t") == 0)
-			appendPQExpBufferStr(buf, " BYPASSRLS");
-		else
-			appendPQExpBufferStr(buf, " NOBYPASSRLS");
+		if (server_version >= 90600)
+		{
+			if (strcmp(PQgetvalue(res, i, i_rolbypassrls), "t") == 0)
+				appendPQExpBufferStr(buf, " BYPASSRLS");
+			else
+				appendPQExpBufferStr(buf, " NOBYPASSRLS");
+		}
 
 		if (strcmp(PQgetvalue(res, i, i_rolconnlimit), "-1") != 0)
 			appendPQExpBuffer(buf, " CONNECTION LIMIT %s",


### PR DESCRIPTION
This PR updates child partition metadata handling when dumping from GPDB{5,6}

To gather binary upgrade information for GPDB{5,6} partition children, they need to exist in the tblinfo array for findTableByOid.
This requires the getTable query to also collect all GPDB partition children, then filter them out of the dump so we only dump the partition root DDL. Previously, partition children were being excluded from the getTables query and gathered separately in
dumpTableSchema. This allows dumpTableSchema to perform lookups of the partition children to dump their OIDs for binary upgrade. [1]

Move pg_get_partition_def and pg_get_partition_template_def queries from dumpTableSchema to getTables. The functions
are only run for parent tables. This change reduces the number repetitive queries and simplifies dumpTableSchema.

Omit BYPASSRLS clause for pre GPDB7 server. GPDB5/6 do not support RLS. Without the version gate a dump and restore on these server versions will fail.

Fix type_array oid assignment for pre-GPDB7 to GPDB7 upgrade.

[1] https://github.com/greenplum-db/gpdb/pull/13978#discussion_r952893857
