### PR TITLE
Fix gpinitsystem Behave tests that use environment variables

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/gpinitsystem.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpinitsystem.feature
@@ -24,6 +24,7 @@ Feature: gpinitsystem tests
         Then gpinitsystem should return a return code of 0
         Given the user runs "gpstate"
         Then gpstate should return a return code of 0
+        And "LC_ALL" environment variable should be restored
 
     Scenario: gpinitsystem creates a cluster when the user set -n or --locale parameter
         Given create demo cluster config
@@ -39,6 +40,7 @@ Feature: gpinitsystem tests
         Then gpinitsystem should return a return code of 0
         Given the user runs "gpstate"
         Then gpstate should return a return code of 0
+        And "LC_MONETARY" environment variable should be restored
 
     Scenario: gpinitsystem exits with status 0 when the user set locale parameters
         Given create demo cluster config
@@ -213,6 +215,7 @@ Feature: gpinitsystem tests
         And the database timezone matches "HST"
         And the startup timezone is saved
         And the startup timezone matches "HST"
+        And "TZ" environment variable should be restored
 
     Scenario: gpinitsystem should print FQDN in pg_hba.conf when HBA_HOSTNAMES=1
         Given the cluster config is generated with HBA_HOSTNAMES "1"
@@ -284,6 +287,8 @@ Feature: gpinitsystem tests
         And the database locales "lc_collate" match the locale "C"
         And the database locales "lc_ctype" match the installed UTF locale
         And the database locales "lc_messages,lc_monetary,lc_numeric,lc_time" match the system locale
+        And "LC_COLLATE" environment variable should be restored
+        And "LC_CTYPE" environment variable should be restored
 
     @backup_restore_bashrc
     Scenario: gpinitsystem succeeds if there is banner on host

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -341,7 +341,7 @@ def impl(context, dbname):
     drop_database(context, dbname)
 
 
-@given('{env_var} environment variable is not set')
+@given('"{env_var}" environment variable is not set')
 def impl(context, env_var):
     if not hasattr(context, 'orig_env'):
         context.orig_env = dict()
@@ -350,7 +350,15 @@ def impl(context, env_var):
     if env_var in os.environ:
         del os.environ[env_var]
 
-@then('{env_var} environment variable should be restored')
+@given('the environment variable "{env_var}" is set to "{val}"')
+def impl(context, env_var, val):
+    if not hasattr(context, 'orig_env'):
+        context.orig_env = dict()
+
+    context.orig_env[env_var] = os.environ.get(env_var)
+    os.environ[env_var] = val
+
+@then('"{env_var}" environment variable should be restored')
 def impl(context, env_var):
     if not hasattr(context, 'orig_env'):
         raise Exception('%s can not be reset' % env_var)
@@ -358,7 +366,10 @@ def impl(context, env_var):
     if env_var not in context.orig_env:
         raise Exception('%s can not be reset.' % env_var)
 
-    os.environ[env_var] = context.orig_env[env_var]
+    if context.orig_env[env_var] is None:
+        del os.environ[env_var]
+    else:
+        os.environ[env_var] = context.orig_env[env_var]
 
     del context.orig_env[env_var]
 
@@ -1426,13 +1437,6 @@ def stop_segments_immediate(context, where_clause):
 @then('user can start transactions')
 def impl(context):
     wait_for_unblocked_transactions(context)
-
-
-@given('the environment variable "{var}" is set to "{val}"')
-def impl(context, var, val):
-    context.env_var = os.environ.get(var)
-    os.environ[var] = val
-
 
 @given('below sql is executed in "{dbname}" db')
 @when('below sql is executed in "{dbname}" db')


### PR DESCRIPTION
Currently, the gpinitsystem Behave tests fail because of environment variables being set in the tests not being unset/reset. Subsequent tests after an environment variable is set are affected and could fail if related (e.g. the locale tests). It didn't help that our Behave steps relating to environment variables were not working cohesively as well. The step to set the environment variable was not storing the original into the context for the other two steps to use. The step to unset the environment variable was not being used properly in our Behave tests because the step format did not have double quotes whereas all step references were double-quoting the environment variable. The previously unused step to restore the environment variable did not properly check for None values and would have also been confused with the double quotes if used. Fix the gpinitsystem Behave tests by fixing the mgmt_utils steps relating to environment variables and make sure to unset environment variables at the end of relevant Behave tests.

The gpinitsystem Behave tests on GPDB master branch are green with this patch (tested on dev pipeline).