### PR TITLE
FIXME remove gp_enable_sort_distinct and noduplicates optimizing

### DIFF
--- a/src/backend/commands/explain.c
+++ b/src/backend/commands/explain.c
@@ -2845,10 +2845,7 @@ show_sort_keys(SortState *sortstate, List *ancestors, ExplainState *es)
 	Sort	   *plan = (Sort *) sortstate->ss.ps.plan;
 	const char *SortKeystr;
 
-	if (sortstate->noduplicates)
-		SortKeystr = "Sort Key (Distinct)";
-	else
-		SortKeystr = "Sort Key";
+	SortKeystr = "Sort Key";
 
 	show_sort_group_keys((PlanState *) sortstate, SortKeystr,
 						 plan->numCols, plan->sortColIdx,

--- a/src/backend/executor/nodeSort.c
+++ b/src/backend/executor/nodeSort.c
@@ -260,11 +260,6 @@ ExecInitSort(Sort *node, EState *estate, int eflags)
 	 */
 	ExecAssignExprContext(estate, &sortstate->ss.ps);
 
-	/* CDB */ /* evaluate a limit as part of the sort */
-	{
-		sortstate->noduplicates = node->noduplicates;
-	}
-
 	/*
 	 * Miscellaneous initialization
 	 *

--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -3003,8 +3003,6 @@ CTranslatorDXLToPlStmt::TranslateDXLSort(
 	Plan *plan = &(sort->plan);
 	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
 
-	CDXLPhysicalSort *sort_dxlop =
-		CDXLPhysicalSort::Cast(sort_dxlnode->GetOperator());
 
 	// translate operator costs
 	TranslatePlanCosts(sort_dxlnode, plan);
@@ -3031,9 +3029,6 @@ CTranslatorDXLToPlStmt::TranslateDXLSort(
 							   output_context);
 
 	plan->lefttree = child_plan;
-
-	// set sorting info
-	sort->noduplicates = sort_dxlop->FDiscardDuplicates();
 
 	// translate sorting columns
 

--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -2997,12 +2997,16 @@ CTranslatorDXLToPlStmt::TranslateDXLSort(
 	const CDXLNode *sort_dxlnode, CDXLTranslateContext *output_context,
 	CDXLTranslationContextArray *ctxt_translation_prev_siblings)
 {
+	// Ensure operator of sort_dxlnode exists and is EdxlopPhysicalSort
+	CDXLOperator *sort_dxlop = sort_dxlnode->GetOperator();
+	GPOS_ASSERT(nullptr != sort_dxlop);
+	GPOS_ASSERT(EdxlopPhysicalSort == sort_dxlop->GetDXLOperator());
+
 	// create sort plan node
 	Sort *sort = MakeNode(Sort);
 
 	Plan *plan = &(sort->plan);
 	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
-
 
 	// translate operator costs
 	TranslatePlanCosts(sort_dxlnode, plan);

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -1220,9 +1220,6 @@ _copySort(const Sort *from)
 	COPY_POINTER_FIELD(collations, from->numCols * sizeof(Oid));
 	COPY_POINTER_FIELD(nullsFirst, from->numCols * sizeof(bool));
 
-    /* CDB */
-	COPY_SCALAR_FIELD(noduplicates);
-
 	return newnode;
 }
 

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -1145,9 +1145,6 @@ _outSort(StringInfo str, const Sort *node)
     WRITE_OID_ARRAY(sortOperators, node->numCols);
     WRITE_OID_ARRAY(collations, node->numCols);
     WRITE_BOOL_ARRAY(nullsFirst, node->numCols);
-
-	/* CDB */
-    WRITE_BOOL_FIELD(noduplicates);
 }
 
 static void

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -3186,9 +3186,6 @@ _readSort(void)
 	READ_OID_ARRAY(collations, local_node->numCols);
 	READ_BOOL_ARRAY(nullsFirst, local_node->numCols);
 
-    /* CDB */
-	READ_BOOL_FIELD(noduplicates);
-
 	READ_DONE();
 }
 

--- a/src/backend/optimizer/path/allpaths.c
+++ b/src/backend/optimizer/path/allpaths.c
@@ -60,7 +60,6 @@
 
 // TODO: these planner gucs need to be refactored into PlannerConfig.
 bool		gp_enable_sort_limit = false;
-bool		gp_enable_sort_distinct = false;
 
 /* results of subquery_is_pushdown_safe */
 typedef struct pushdown_safety_info

--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -6756,8 +6756,6 @@ make_sort(Plan *lefttree, int numCols,
 
 	Assert(sortColIdx[0] != 0);
 
-	node->noduplicates = false; /* CDB */
-
 	return node;
 }
 
@@ -7514,14 +7512,6 @@ make_unique_from_sortclauses(Plan *lefttree, List *distinctList)
 	node->uniqColIdx = uniqColIdx;
 	node->uniqOperators = uniqOperators;
 	node->uniqCollations = uniqCollations;
-
-	/* CDB */	/* pass DISTINCT to sort */
-	if (IsA(lefttree, Sort) && gp_enable_sort_distinct)
-	{
-		Sort	   *pSort = (Sort *) lefttree;
-
-		pSort->noduplicates = true;
-	}
 
 	return node;
 }

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -749,16 +749,6 @@ struct config_bool ConfigureNamesBool_gp[] =
 	},
 
 	{
-		{"gp_enable_sort_distinct", PGC_USERSET, QUERY_TUNING_METHOD,
-			gettext_noop("Enable duplicate removal to be performed while sorting."),
-			gettext_noop("Reduces data handling when plan calls for removing duplicates from sorted rows.")
-		},
-		&gp_enable_sort_distinct,
-		true,
-		NULL, NULL, NULL
-	},
-
-	{
 		{"gp_enable_motion_deadlock_sanity", PGC_USERSET, DEVELOPER_OPTIONS,
 			gettext_noop("Enable verbose check at planning time."),
 			NULL,

--- a/src/backend/utils/misc/postgresql.conf.sample
+++ b/src/backend/utils/misc/postgresql.conf.sample
@@ -374,7 +374,6 @@ max_prepared_transactions = 250		# can be 0 or more
 #gp_selectivity_damping_for_joins = off
 
 #gp_enable_sort_limit = on
-#gp_enable_sort_distinct = on
 
 # - Planner Cost Constants -
 

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -617,16 +617,6 @@ extern int explain_memory_verbosity;
  */
 extern bool gp_enable_sort_limit;
 
-/* May Greenplum discard duplicate rows in sort if it is is wrapped by a
- * DISTINCT clause (unique aggregation operator)?
- *
- * The code does not currently use planner estimates for this.  If enabled,
- * the tactic is used whenever possible.
- *
- * GPDB_12_MERGE_FIXME: Resurrect this
- */
-extern bool gp_enable_sort_distinct;
-
 extern bool trace_sort;
 
 /**

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -2352,8 +2352,6 @@ typedef struct SortState
 	bool		am_worker;		/* are we a worker? */
 	SharedSortInfo *shared_info;	/* one entry per worker */
 
-	bool		noduplicates;	/* true if discard duplicate rows */
-
 	bool		delayEagerFree;		/* is it safe to free memory used by this node,
 									 * when this node has outputted its last row? */
 	TuplesortInstrumentation sortstats; /* holds stats, if the Sort is eagerly free'd */

--- a/src/include/nodes/plannodes.h
+++ b/src/include/nodes/plannodes.h
@@ -1154,8 +1154,6 @@ typedef struct Sort
 	Oid		   *sortOperators;	/* OIDs of operators to sort them by */
 	Oid		   *collations;		/* OIDs of collations */
 	bool	   *nullsFirst;		/* NULLS FIRST/LAST directions */
-    /* CDB */
-	bool		noduplicates;   /* TRUE if sort should discard duplicates */
 } Sort;
 
 /* ---------------

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -195,7 +195,6 @@
 		"gp_enable_query_metrics",
 		"gp_enable_relsize_collection",
 		"gp_enable_slow_writer_testmode",
-		"gp_enable_sort_distinct",
 		"gp_enable_sort_limit",
 		"gp_encoding_check_locale_compatibility",
 		"gp_external_enable_exec",

--- a/src/test/regress/expected/join_gp.out
+++ b/src/test/regress/expected/join_gp.out
@@ -1504,7 +1504,7 @@ select * from foo where exists (select 1 from bar where foo.a = bar.b);
          ->  Unique
                Group Key: (RowIdExpr)
                ->  Sort
-                     Sort Key (Distinct): (RowIdExpr)
+                     Sort Key: (RowIdExpr)
                      ->  Redistribute Motion 3:3  (slice2; segments: 3)
                            Hash Key: (RowIdExpr)
                            ->  Hash Join

--- a/src/test/regress/expected/subselect_gp.out
+++ b/src/test/regress/expected/subselect_gp.out
@@ -1855,7 +1855,7 @@ select * from dedup_reptab r where r.a in (select t.a/10 from dedup_tab t);
          ->  Unique
                Group Key: (RowIdExpr)
                ->  Sort
-                     Sort Key (Distinct): (RowIdExpr)
+                     Sort Key: (RowIdExpr)
                      ->  Redistribute Motion 3:3  (slice2; segments: 3)
                            Hash Key: (RowIdExpr)
                            ->  Hash Join
@@ -1907,7 +1907,7 @@ select * from dedup_srf() r(a) where r.a in (select t.a/10 from dedup_tab t);
          ->  Unique
                Group Key: (RowIdExpr)
                ->  Sort
-                     Sort Key (Distinct): (RowIdExpr)
+                     Sort Key: (RowIdExpr)
                      ->  Redistribute Motion 3:3  (slice2; segments: 3)
                            Hash Key: (RowIdExpr)
                            ->  Hash Join
@@ -1936,7 +1936,7 @@ select * from dedup_srf_stable() r(a) where r.a in (select t.a/10 from dedup_tab
          ->  Unique
                Group Key: (RowIdExpr)
                ->  Sort
-                     Sort Key (Distinct): (RowIdExpr)
+                     Sort Key: (RowIdExpr)
                      ->  Redistribute Motion 3:3  (slice2; segments: 3)
                            Hash Key: (RowIdExpr)
                            ->  Hash Join
@@ -1965,7 +1965,7 @@ select * from dedup_srf_volatile() r(a) where r.a in (select t.a/10 from dedup_t
          ->  Unique
                Group Key: (RowIdExpr)
                ->  Sort
-                     Sort Key (Distinct): (RowIdExpr)
+                     Sort Key: (RowIdExpr)
                      ->  Redistribute Motion 3:3  (slice2; segments: 3)
                            Hash Key: (RowIdExpr)
                            ->  Hash Join
@@ -2007,7 +2007,7 @@ select * from dedup_func() r(a) where r.a in (select t.a/10 from dedup_tab t);
          ->  Unique
                Group Key: (RowIdExpr)
                ->  Sort
-                     Sort Key (Distinct): (RowIdExpr)
+                     Sort Key: (RowIdExpr)
                      ->  Redistribute Motion 3:3  (slice2; segments: 3)
                            Hash Key: (RowIdExpr)
                            ->  Hash Join
@@ -2034,7 +2034,7 @@ select * from dedup_func_stable() r(a) where r.a in (select t.a/10 from dedup_ta
          ->  Unique
                Group Key: (RowIdExpr)
                ->  Sort
-                     Sort Key (Distinct): (RowIdExpr)
+                     Sort Key: (RowIdExpr)
                      ->  Redistribute Motion 3:3  (slice2; segments: 3)
                            Hash Key: (RowIdExpr)
                            ->  Hash Join
@@ -2061,7 +2061,7 @@ select * from dedup_func_volatile() r(a) where r.a in (select t.a/10 from dedup_
          ->  Unique
                Group Key: (RowIdExpr)
                ->  Sort
-                     Sort Key (Distinct): (RowIdExpr)
+                     Sort Key: (RowIdExpr)
                      ->  Redistribute Motion 3:3  (slice2; segments: 3)
                            Hash Key: (RowIdExpr)
                            ->  Hash Join

--- a/src/test/regress/expected/tpch500GB.out
+++ b/src/test/regress/expected/tpch500GB.out
@@ -2005,7 +2005,7 @@ order by
                                  ->  Unique  (cost=78801360.21..78983928.42 rows=18256821 width=22)
                                        Group By: orders.ctid
                                        ->  Sort  (cost=78801360.21..78892644.32 rows=18256821 width=22)
-                                             Sort Key (Distinct): orders.ctid
+                                             Sort Key: orders.ctid
                                              ->  Hash Join  (cost=14835362.82..71460313.52 rows=18256821 width=22)
                                                    Hash Cond: lineitem.l_orderkey = orders.o_orderkey
                                                    ->  Seq Scan on lineitem  (cost=0.00..51767512.60 rows=489638315 width=8)


### PR DESCRIPTION
On GPDB6, the GUC `gp_enable_sort_distinct` is used to optimize sort by indicating "noduplicate" to remove duplicated rows and reduce data handling. It effects on replacement selection sort only. However, on GPDB7, replacement selection sort has been removed completely. So we need to remove `gp_enable_sort_distinct` and other codes related to "noduplicate" sort.

In GPDB6, `Tuplesortstate` has a member `noduplicates`:
```
 326     bool        noduplicates;   /* discard duplicate rows if true *//* CDB */
```
The usages of `noduplicates` is to indicate `tuplesort_sorted_insert()` to discard duplicated tuples:
```
3990     if (state->noduplicates && (0 == comparestat))
3991     {
3992         freetup = tuple;
3993         goto L_freetup;
3994     }
```
And they are ONLY usages of noduplicates, which has been removed on GPDB7.

Besides those, there are other codes, including `Sort.noduplicates` and `SortState.noduplicates`, which are just related to save and pass the flag. All of they need to be removed on GPDB7.