### PR TITLE
Fixme: gp_partition_template for segments

### DIFF
--- a/gpMgmt/bin/gppylib/gpcatalog.py
+++ b/gpMgmt/bin/gppylib/gpcatalog.py
@@ -33,7 +33,7 @@ COORDINATOR_ONLY_TABLES = [
     'pg_statistic',
     'pg_statistic_ext',
     'pg_statistic_ext_data',
-    'gp_partition_template', # GPDB_12_MERGE_FIXME: is gp_partition_template intentionally missing from segments?
+    'gp_partition_template',
     ]
 
 # Hard coded tables that have different values on every segment


### PR DESCRIPTION
The setting of partition template only happens on QD and is not dispatched to QEs https://github.com/greenplum-db/gpdb/blob/master/src/backend/commands/tablecmds_gp.c#L1375 This is intentional since only QD needs to read the partition template when creating new subpartitions, and it then dispatches custom CreateStmts to the QEs. So QE doesn’t need the catalog.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
