### PR TITLE
Resolve a FIXME in merge_leaf_stats()

### DIFF
--- a/src/backend/commands/analyze.c
+++ b/src/backend/commands/analyze.c
@@ -3830,11 +3830,17 @@ merge_leaf_stats(VacAttrStatsP stats,
 			(errmsg("Merging leaf partition stats to calculate root partition stats : column %s",
 					get_attname(stats->attr->attrelid, stats->attr->attnum, false))));
 
-	/* GPDB_12_MERGE_FIXME: what's the appropriate lock level? AccessShareLock
-	 * is enough to scan the table, but are we updating them, too? If not,
-	 * NoLock might be enough?
+	/* 
+	 * Since we have acquired ShareUpdateExclusiveLock on the parent table when
+	 * ANALYZE'ing it, we don't need extra lock to guard against concurrent DROP
+	 * of either the parent or the child (which requries AccessExclusiveLock on
+	 * the parent).
+	 * Concurrent UPDATE is possible but because we are not updating the table
+	 * ourselves, NoLock is sufficient here.
 	 */
-	all_children_list = find_all_inheritors(stats->attr->attrelid, AccessShareLock, NULL);
+	all_children_list = find_all_inheritors(stats->attr->attrelid, NoLock, NULL);
+	SIMPLE_FAULT_INJECTOR("merge_leaf_stats_after_find_children");
+
 	oid_list = NIL;
 	foreach (lc, all_children_list)
 	{

--- a/src/test/isolation2/expected/lockmodes.out
+++ b/src/test/isolation2/expected/lockmodes.out
@@ -2355,3 +2355,63 @@ COMMIT
 DROP
 1q: ... <quitting>
 2q: ... <quitting>
+
+-- Check that concurrent DROP on leaf partition won't impact analyze on the
+-- parent since analyze will hold a ShareUpdateExclusiveLock and DROP will
+-- require an AccessExclusiveLock.
+-- Case 1. The analyze result is expected when there's concurrent drop on child.
+1:create table analyzedrop(a int) partition by range(a);
+CREATE
+1:create table analyzedrop_1 partition of analyzedrop for values from (0) to (10);
+CREATE
+1:create table analyzedrop_2 partition of analyzedrop for values from (10) to (20);
+CREATE
+1:insert into analyzedrop select * from generate_series(0,19);
+INSERT 20
+1:select gp_inject_fault_infinite('merge_leaf_stats_after_find_children', 'suspend', dbid) from gp_segment_configuration where content = -1 and role = 'p';
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+1&: analyze analyzedrop;  <waiting ...>
+2&: drop table analyzedrop_1;  <waiting ...>
+3:select gp_inject_fault_infinite('merge_leaf_stats_after_find_children', 'reset', dbid) from gp_segment_configuration where content = -1 and role = 'p';
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+1<:  <... completed>
+ANALYZE
+2<:  <... completed>
+DROP
+3:select * from pg_stats where tablename like 'analyzedrop%';
+ schemaname | tablename     | attname | inherited | null_frac | avg_width | n_distinct | most_common_vals | most_common_freqs | histogram_bounds                                 | correlation | most_common_elems | most_common_elem_freqs | elem_count_histogram 
+------------+---------------+---------+-----------+-----------+-----------+------------+------------------+-------------------+--------------------------------------------------+-------------+-------------------+------------------------+----------------------
+ public     | analyzedrop   | a       | t         | 0         | 4         | -1         |                  |                   | {0,1,2,3,4,5,6,7,8,9,11,12,13,14,15,16,17,18,19} |             |                   |                        |                      
+ public     | analyzedrop_2 | a       | f         | 0         | 4         | -1         |                  |                   | {10,11,12,13,14,15,16,17,18,19}                  | -0.345455   |                   |                        |                      
+(2 rows)
+-- Case 2. No failure should happen when there's concurrent drop on parent as well.
+1:select gp_inject_fault_infinite('merge_leaf_stats_after_find_children', 'suspend', dbid) from gp_segment_configuration where content = -1 and role = 'p';
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+1&: analyze analyzedrop;  <waiting ...>
+2&: drop table analyzedrop_2;  <waiting ...>
+3&: drop table analyzedrop;  <waiting ...>
+4:select gp_inject_fault_infinite('merge_leaf_stats_after_find_children', 'reset', dbid) from gp_segment_configuration where content = -1 and role = 'p';
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+1<:  <... completed>
+ANALYZE
+2<:  <... completed>
+DROP
+3<:  <... completed>
+DROP
+--empty as table is dropped
+4:select * from pg_stats where tablename like 'analyzedrop%';
+ schemaname | tablename | attname | inherited | null_frac | avg_width | n_distinct | most_common_vals | most_common_freqs | histogram_bounds | correlation | most_common_elems | most_common_elem_freqs | elem_count_histogram 
+------------+-----------+---------+-----------+-----------+-----------+------------+------------------+-------------------+------------------+-------------+-------------------+------------------------+----------------------
+(0 rows)

--- a/src/test/isolation2/expected/lockmodes_optimizer.out
+++ b/src/test/isolation2/expected/lockmodes_optimizer.out
@@ -2356,3 +2356,63 @@ COMMIT
 DROP
 1q: ... <quitting>
 2q: ... <quitting>
+
+-- Check that concurrent DROP on leaf partition won't impact analyze on the
+-- parent since analyze will hold a ShareUpdateExclusiveLock and DROP will
+-- require an AccessExclusiveLock.
+-- Case 1. The analyze result is expected when there's concurrent drop on child.
+1:create table analyzedrop(a int) partition by range(a);
+CREATE
+1:create table analyzedrop_1 partition of analyzedrop for values from (0) to (10);
+CREATE
+1:create table analyzedrop_2 partition of analyzedrop for values from (10) to (20);
+CREATE
+1:insert into analyzedrop select * from generate_series(0,19);
+INSERT 20
+1:select gp_inject_fault_infinite('merge_leaf_stats_after_find_children', 'suspend', dbid) from gp_segment_configuration where content = -1 and role = 'p';
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+1&: analyze analyzedrop;  <waiting ...>
+2&: drop table analyzedrop_1;  <waiting ...>
+3:select gp_inject_fault_infinite('merge_leaf_stats_after_find_children', 'reset', dbid) from gp_segment_configuration where content = -1 and role = 'p';
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+1<:  <... completed>
+ANALYZE
+2<:  <... completed>
+DROP
+3:select * from pg_stats where tablename like 'analyzedrop%';
+ schemaname | tablename     | attname | inherited | null_frac | avg_width | n_distinct | most_common_vals | most_common_freqs | histogram_bounds                                 | correlation | most_common_elems | most_common_elem_freqs | elem_count_histogram 
+------------+---------------+---------+-----------+-----------+-----------+------------+------------------+-------------------+--------------------------------------------------+-------------+-------------------+------------------------+----------------------
+ public     | analyzedrop   | a       | t         | 0         | 4         | -1         |                  |                   | {0,1,2,3,4,5,6,7,8,9,11,12,13,14,15,16,17,18,19} |             |                   |                        |                      
+ public     | analyzedrop_2 | a       | f         | 0         | 4         | -1         |                  |                   | {10,11,12,13,14,15,16,17,18,19}                  | -0.345455   |                   |                        |                      
+(2 rows)
+-- Case 2. No failure should happen when there's concurrent drop on parent as well.
+1:select gp_inject_fault_infinite('merge_leaf_stats_after_find_children', 'suspend', dbid) from gp_segment_configuration where content = -1 and role = 'p';
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+1&: analyze analyzedrop;  <waiting ...>
+2&: drop table analyzedrop_2;  <waiting ...>
+3&: drop table analyzedrop;  <waiting ...>
+4:select gp_inject_fault_infinite('merge_leaf_stats_after_find_children', 'reset', dbid) from gp_segment_configuration where content = -1 and role = 'p';
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+1<:  <... completed>
+ANALYZE
+2<:  <... completed>
+DROP
+3<:  <... completed>
+DROP
+--empty as table is dropped
+4:select * from pg_stats where tablename like 'analyzedrop%';
+ schemaname | tablename | attname | inherited | null_frac | avg_width | n_distinct | most_common_vals | most_common_freqs | histogram_bounds | correlation | most_common_elems | most_common_elem_freqs | elem_count_histogram 
+------------+-----------+---------+-----------+-----------+-----------+------------+------------------+-------------------+------------------+-------------+-------------------+------------------------+----------------------
+(0 rows)


### PR DESCRIPTION
A FIXME was left noting whether to use AccessShareLock or NoLock when opening child tables to merge their stats. Since we are not updating or even opening the child tables, NoLock should be enough.

Dev pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/fixme-analyze-lock

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
