### PR TITLE
docs - clarify use of gp_resource_group_enable_recalculate_query_mem guc

### DIFF
--- a/gpdb-doc/markdown/admin_guide/workload_mgmt_resgroups.html.md
+++ b/gpdb-doc/markdown/admin_guide/workload_mgmt_resgroups.html.md
@@ -235,9 +235,12 @@ query_mem = (rg_perseg_mem * memory_limit) * memory_spill_ratio / concurrency
 
 Where `memory_limit`, `memory_spill_ratio`, and `concurrency` are specified by the resource group under which the transaction runs.
 
-By default, Greenplum Database calculates the maximum amount of segment host memory allocated to a transaction based on the `rg_perseg_mem` and the number of primary segments on the *master host*.
+By default, Greenplum Database calculates the maximum amount of segment host memory allocated to a transaction based on the `rg_perseg_mem` and the number of primary segments configured on the *master host*.
 
-If the memory configuration on your Greenplum Database master and segment hosts differ, you may prefer that the maximum per-transaction memory calculation be based on the segment host configuration. To instruct Greenplum Database to recalculate the maximum memory allocation per-transaction based on the `rg_perseg_mem` and the number of primary segments *on the segment host*, set the [gp_resource_group_enable_recalculate_query_mem](../ref_guide/config_params/guc-list.html#gp_resource_group_enable_recalculate_query_mem) server configuration parameter to `true`.
+**Note:** If the memory configuration on your Greenplum Database master and segment hosts differ, you may encounter out-of-memory conditions or underutilization of resources with the default configuration.
+
+If the hardware configuration of your master and segment hosts differ, set the [gp_resource_group_enable_recalculate_query_mem](../ref_guide/config_params/guc-list.html#gp_resource_group_enable_recalculate_query_mem) server configuration parameter to `true`; this prompts Greenplum Database to recalculate the maximum per-query memory allotment on each segment host based on the `rg_perseg_mem` and the number of primary segments configured on *that segment host*.
+
 
 ##### <a id="topic833low"></a>memory\_spill\_ratio and Low Memory Queries 
 

--- a/gpdb-doc/markdown/best_practices/resgroups.html.md
+++ b/gpdb-doc/markdown/best_practices/resgroups.html.md
@@ -30,6 +30,14 @@ The following operating system and Greenplum Database memory settings are signif
 
     The percentage of system memory to allocate to Greenplum Database. The default value is .7 \(70%\).
 
+-   **gp_resource_group_enable_recalculate_query_mem**
+
+    By default, Greenplum Database calculates the maximum per-query memory allotment for all hosts using the memory configuration of, and the number of primary segments configured on, the master host.
+
+    **Note:** The default behavior may lead to out of memory issues and underutilization of resources when the hardware configuration of the master and segment hosts differ.
+
+    If the hardware configuration of your master and segment hosts differ, set the `gp_resource_group_enable_recalculate_query_mem` server configuration parameter to `true`; this prompts Greenplum Database to recalculate the maximum per-query memory allotment on each segment host based on the memory and the number of primary segments configured on that segment host.
+
 -   **gp_workfile_limit_files_per_query**
 
     Set `gp_workfile_limit_files_per_query` to limit the maximum number of temporary spill files \(workfiles\) allowed per query. Spill files are created when a query requires more memory than it is allocated. When the limit is exceeded the query is terminated. The default is zero, which allows an unlimited number of spill files and may fill up the file system.

--- a/gpdb-doc/markdown/ref_guide/config_params/guc-list.html.md
+++ b/gpdb-doc/markdown/ref_guide/config_params/guc-list.html.md
@@ -1308,7 +1308,7 @@ Identifies the maximum percentage of system CPU resources to allocate to resourc
 
 **Note:** The `gp_resource_group_enable_recalculate_query_mem` server configuration parameter is enforced only when resource group-based resource management is active.
 
-Specifies whether or not Greenplum Database recalculates the maximum amount of memory to allocate per query running in a resource group. The default value is `false`, Greenplum database calculates the maximum per-query memory based on the memory configuration and the number of primary segments on the master host. When set to `true`, Greenplum Database recalculates the maximum per-query memory based on the memory configuration and the number of primary segments on the segment host.
+Specifies whether or not Greenplum Database recalculates the maximum amount of memory to allocate on a segment host per query running in a resource group. The default value is `false`, Greenplum database calculates the maximum per-query memory on a segment host based on the memory configuration and the number of primary segments on the master host. When set to `true`, Greenplum Database recalculates the maximum per-query memory on a segment host based on the memory and the number of primary segments configured for that segment host.
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|


### PR DESCRIPTION
6X_STABLE docs:  clarify description the of gp_resource_group_enable_recalculate_query_mem guc.  add the guc to resource group best practices topic.
