### PR TITLE
FixMe: removed transforming of hasharray to hashstring

### DIFF
--- a/gpMgmt/bin/gpcheckcat
+++ b/gpMgmt/bin/gpcheckcat
@@ -1481,26 +1481,6 @@ def missingEntryQuery(max_content, catname, pkey, castedPkey):
     return qry
 
 
-def transformTextArrayCols(catname, columns, colnames, coltypes):
-    # Distributing by hash(text[]) is potentially dangerous,
-    # so if the table has text[] column, then we need array_to_string
-    #
-    # We should fix the text[] hash expression issue, but
-    # for this script, this seems like a reasonable workaround.
-    #
-    # GPDB_12_MERGE_FIXME: was this fixed by the hashing changes
-    # in GPDB 6?
-
-    transformed = []
-    for i in range(len(columns)):
-        if coltypes[colnames[i]] == '_text':
-            transformed.append("array_to_string(" + columns[i] + ", ',') AS " + columns[i])
-        else:
-            transformed.append(columns[i])
-
-    return transformed
-
-
 # -------------------------------------------------------------------------------
 def checkInconsistentEntry():
     logger.info('-----------------------------------')
@@ -1545,9 +1525,6 @@ def checkTableInconsistentEntry(cat):
     castedPkey = cat.getPrimaryKey()
     castedPkey = [c + autoCast.get(coltypes[c], '') for c in castedPkey]
     castcols = [c + autoCast.get(coltypes[c], '') for c in columns]
-
-    # transform text[] cols for sure. See comments on transformTextArrayCols
-    castcols = transformTextArrayCols(catname, castcols, columns, cat.getTableColtypes())
 
     # pg_attribute.attmissingval has pseudo-type 'any', which doesn't allow
     # much operations on it. Cast it to text, by replacing it with


### PR DESCRIPTION
As the hashing of text array is fixed in PR https://github.com/greenplum-db/gpdb/pull/4940
removing dependency to transform hash array to hash string 
which is currently being done in function transformTextArrayCols()

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
