### PR TITLE
docs - default sequence cache size is 20

### DIFF
--- a/gpdb-doc/markdown/ref_guide/sql_commands/ALTER_SEQUENCE.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/ALTER_SEQUENCE.html.md
@@ -58,6 +58,7 @@ new\_owner
 
 cache
 :   The clause `CACHE cache` enables sequence numbers to be preallocated and stored in memory for faster access. The minimum value is 1 \(only one value can be generated at a time, i.e., no cache\). If unspecified, the old cache value will be maintained.
+:   **Note:** When operating with a cache of sequence numbers (`cache > 1`), Greenplum Database may discard some cached sequence values. If you require consecutive values, you must explicitly set `CACHE 1` when you create or alter the sequence.
 
 CYCLE
 :   The optional `CYCLE` key word may be used to enable the sequence to wrap around when the maxvalue or minvalue has been reached by an ascending or descending sequence. If the limit is reached, the next number generated will be the respective minvalue or maxvalue.

--- a/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_SEQUENCE.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_SEQUENCE.html.md
@@ -79,7 +79,7 @@ start
 
 cache
 :   Specifies how many sequence numbers are to be preallocated and stored in memory for faster access. The default value is 20. The minimum value is 1 \(no cache\).
-:   **Note:** When operating with a cache of sequence numbers (`cache > 1`), Greenplum Database may discard some cached sequence values. If you require consecutive values, you must explicitly set `CACHE 1` when you create the sequence.
+:   **Note:** When operating with a cache of sequence numbers (`cache > 1`), Greenplum Database may discard some cached sequence values. If you require consecutive values, you must explicitly set `CACHE 1` when you create or alter the sequence.
 
 CYCLE
 NO CYCLE

--- a/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_SEQUENCE.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_SEQUENCE.html.md
@@ -78,7 +78,8 @@ start
 :   Allows the sequence to begin anywhere. The default starting value is minvalue for ascending sequences and maxvalue for descending ones.
 
 cache
-:   Specifies how many sequence numbers are to be preallocated and stored in memory for faster access. The minimum \(and default\) value is 1 \(no cache\).
+:   Specifies how many sequence numbers are to be preallocated and stored in memory for faster access. The default value is 20. The minimum value is 1 \(no cache\).
+:   **Note:** When operating with a cache of sequence numbers (`cache > 1`), Greenplum Database may discard some cached sequence values. If you require consecutive values, you must explicitly set `CACHE 1` when you create the sequence.
 
 CYCLE
 NO CYCLE


### PR DESCRIPTION
docs for https://github.com/greenplum-db/gpdb/pull/10612.

update the default value and add a note about consecutive values.
