### PR TITLE
Add GUC to enable HLL collection during analyze

### DIFF
--- a/src/backend/commands/analyze.c
+++ b/src/backend/commands/analyze.c
@@ -801,9 +801,10 @@ do_analyze_rel(Relation onerel, VacuumParams *params,
 									 totalrows);
 				/*
 				 * Store HLL/HLL fullscan information for leaf partitions in
-				 * the stats object
+				 * the stats object. If optimizer_analyze_always_collect_hll is enabled, also collect
+				 * HLL stats for non-leaf tables
 				 */
-				if (onerel->rd_rel->relkind == RELKIND_RELATION && onerel->rd_rel->relispartition)
+				if (onerel->rd_rel->relkind == RELKIND_RELATION && (onerel->rd_rel->relispartition || optimizer_analyze_always_collect_hll))
 				{
 					MemoryContext old_context;
 					Datum *hll_values;

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -390,6 +390,7 @@ bool		optimizer_enable_range_predicate_dpe;
 /* Analyze related GUCs for Optimizer */
 bool		optimizer_analyze_root_partition;
 bool		optimizer_analyze_midlevel_partition;
+bool		optimizer_analyze_always_collect_hll;
 
 /* GUCs for replicated table */
 bool		optimizer_replicated_table_insert;
@@ -2488,6 +2489,17 @@ struct config_bool ConfigureNamesBool_gp[] =
 			GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_analyze_midlevel_partition,
+		false,
+		NULL, NULL, NULL
+	},
+
+	{
+		{"optimizer_analyze_always_collect_hll", PGC_USERSET, STATS_ANALYZE,
+			gettext_noop("Enable HLL statistics collection on both partition leaves and ordinary tables during ANALYZE"),
+			NULL,
+			GUC_NOT_IN_SAMPLE
+		},
+		&optimizer_analyze_always_collect_hll,
 		false,
 		NULL, NULL, NULL
 	},

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -563,6 +563,7 @@ extern bool optimizer_enable_range_predicate_dpe;
 /* Analyze related GUCs for Optimizer */
 extern bool optimizer_analyze_root_partition;
 extern bool optimizer_analyze_midlevel_partition;
+extern bool optimizer_analyze_always_collect_hll;
 
 extern bool optimizer_use_gpdb_allocators;
 

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -348,6 +348,7 @@
 		"old_snapshot_threshold",
 		"operator_precedence_warning",
 		"optimizer",
+		"optimizer_analyze_always_collect_hll",
 		"optimizer_analyze_midlevel_partition",
 		"optimizer_analyze_root_partition",
 		"optimizer_apply_left_outer_to_union_all_disregarding_stats",

--- a/src/test/regress/expected/incremental_analyze.out
+++ b/src/test/regress/expected/incremental_analyze.out
@@ -2043,3 +2043,37 @@ INFO:  analyzing "public.foo_1_prt_20210201"
 INFO:  Executing SQL: select pg_catalog.gp_acquire_sample_rows(65903, 400, 'f');
 INFO:  analyzing "public.foo" inheritance tree
 rollback;
+create table hll_part (i int, j int) distributed by (i)
+partition by range(j)
+(start(1) end(10) every(1));
+insert into hll_part select i, i%9+1 from generate_series(1,10)i;
+analyze hll_part;
+create table hll_regular (i int, j int) distributed by (i);
+insert into hll_regular values (777777,6);
+analyze hll_regular;
+-- hll stats should not be collected in non-partition table by default
+select 1 from pg_statistic where starelid='hll_regular'::regclass and stavalues5 is not null;
+ ?column? 
+----------
+(0 rows)
+
+set optimizer_analyze_always_collect_hll to on;
+analyze hll_regular;
+reset optimizer_analyze_always_collect_hll;
+-- hll stats should be collected when guc is set
+select 1 from pg_statistic where starelid='hll_regular'::regclass and stavalues5 is not null;
+ ?column? 
+----------
+        1
+        1
+(2 rows)
+
+alter table hll_part exchange partition for (6)  with table hll_regular;
+-- hll stats should be present after partition exchange
+select 1 from pg_statistic where starelid='hll_part_1_prt_6'::regclass and stavalues5 is not null;
+ ?column? 
+----------
+        1
+        1
+(2 rows)
+

--- a/src/test/regress/expected/incremental_analyze_optimizer.out
+++ b/src/test/regress/expected/incremental_analyze_optimizer.out
@@ -2052,3 +2052,37 @@ INFO:  analyzing "public.foo_1_prt_20210201"
 INFO:  Executing SQL: select pg_catalog.gp_acquire_sample_rows(74833, 400, 'f');
 INFO:  analyzing "public.foo" inheritance tree
 rollback;
+create table hll_part (i int, j int) distributed by (i)
+partition by range(j)
+(start(1) end(10) every(1));
+insert into hll_part select i, i%9+1 from generate_series(1,10)i;
+analyze hll_part;
+create table hll_regular (i int, j int) distributed by (i);
+insert into hll_regular values (777777,6);
+analyze hll_regular;
+-- hll stats should not be collected in non-partition table by default
+select 1 from pg_statistic where starelid='hll_regular'::regclass and stavalues5 is not null;
+ ?column? 
+----------
+(0 rows)
+
+set optimizer_analyze_always_collect_hll to on;
+analyze hll_regular;
+reset optimizer_analyze_always_collect_hll;
+-- hll stats should be collected when guc is set
+select 1 from pg_statistic where starelid='hll_regular'::regclass and stavalues5 is not null;
+ ?column? 
+----------
+        1
+        1
+(2 rows)
+
+alter table hll_part exchange partition for (6)  with table hll_regular;
+-- hll stats should be present after partition exchange
+select 1 from pg_statistic where starelid='hll_part_1_prt_6'::regclass and stavalues5 is not null;
+ ?column? 
+----------
+        1
+        1
+(2 rows)
+


### PR DESCRIPTION
Currently, analyze will only collect HLL specific stats if it is a leaf partition. This presents an issue if an ordinary table is analyzed, then exchanged or added to a partition table. The leaf partition in this case won't have HLL stats, and this information won't be merged into the root partition, which can cause poor Orca plans.

This commit adds a GUC, `optimizer_analyze_always_collect_hll`, that when enabled will also collect HLL stats for ordinary tables during analyze.

A couple other approaches were considered here.

1) Always collect HLL stats. This can cause catalog bloat, as the HLL value is quite wide and wouldn't be used in ordinary tables until it's part of a partitioned table.

2) Analyze/collect stats during exchange, with the assumption that the overhead from analyzing would be much less than the constraint checks that partitions already undergo when exchanged/added. However, in the use case we're looking at, the user disables this validation, so the overhead would be noticeable.

3) An additional syntax option in analyze. This wouldn't be able to be backported to 6X, but I believe this is also a valid option for the master branch.