### PR TITLE
Fix incorrect hash-key of Redistribute-Motion when creating path for multi-DQA expr.

### DIFF
--- a/src/test/regress/expected/gp_dqa.out
+++ b/src/test/regress/expected/gp_dqa.out
@@ -2188,3 +2188,151 @@ select count(distinct a), sum(b), sum(c) from dqa_f1;
     17 | 2000 | 1000
 (1 row)
 
+-- multi DQA with type conversions
+create table dqa_f3(a character varying, b bigint) distributed by (a);
+insert into dqa_f3 values ('123', 2), ('213', 0), ('231', 2), ('312', 0), ('321', 2), ('132', 1), ('4', 0);
+-- Case 1: When converting the type of column 'a' from 'VARCHAR' to 'TEXT' in DQA expression, instead of generating a new column '(a)::text'
+-- by TupleSplit, we can reference the column 'a' as part of hash-key in Redistribute-Motion directly, since the conversion is binary-compatible.
+-- ->  Redistribute Motion 3:3  (slice2; segments: 3)
+--       Output: b, a, ((b)::text), (AggExprId)
+--       Hash Key: ((b)::text), a, (AggExprId)
+--     ...
+--     ->  TupleSplit
+--           Output: b, a, ((b)::text), AggExprId
+--           Split by Col: (((dqa_f3.b)::text)), (dqa_f3.a)
+--           ->  Seq Scan on public.dqa_f3
+--                 Output: b, a, (b)::text
+select count(distinct (b)::text) as b, count(distinct (a)::text) as a from dqa_f3;
+ b | a 
+---+---
+ 3 | 7
+(1 row)
+
+explain (verbose, costs off) select count(distinct (b)::text) as b, count(distinct (a)::text) as a from dqa_f3;
+                                          QUERY PLAN
+----------------------------------------------------------------------------------------------
+ Finalize Aggregate
+   Output: count(DISTINCT ((b)::text)), count(DISTINCT (a)::text)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Output: (PARTIAL count(DISTINCT ((b)::text))), (PARTIAL count(DISTINCT (a)::text))
+         ->  Partial Aggregate
+               Output: PARTIAL count(DISTINCT ((b)::text)), PARTIAL count(DISTINCT (a)::text)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Output: b, a, ((b)::text), (AggExprId)
+                     Hash Key: ((b)::text), a, (AggExprId)
+                     ->  Streaming HashAggregate
+                           Output: b, a, ((b)::text), (AggExprId)
+                           Group Key: AggExprId, ((dqa_f3.b)::text), dqa_f3.a
+                           ->  TupleSplit
+                                 Output: b, a, ((b)::text), AggExprId
+                                 Split by Col: (((dqa_f3.b)::text)), (dqa_f3.a)
+                                 ->  Seq Scan on public.dqa_f3
+                                       Output: b, a, (b)::text
+ Optimizer: Postgres query optimizer
+ Settings: enable_groupagg = 'off', gp_motion_cost_per_row = '1'
+(19 rows)
+
+-- Case 2: Same as the above one, but convert the type of column 'a' to 'varchar' via binary-compatible types.
+select count(distinct (b)::text) as b, count(distinct (a)::text::varchar) as a from dqa_f3;
+ b | a 
+---+---
+ 3 | 7
+(1 row)
+
+explain (verbose, costs off) select count(distinct (b)::text) as b, count(distinct (a)::text::varchar) as a from dqa_f3;
+                                                QUERY PLAN
+-----------------------------------------------------------------------------------------------------------
+ Finalize Aggregate
+   Output: count(DISTINCT ((b)::text)), count(DISTINCT (a)::character varying)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Output: (PARTIAL count(DISTINCT ((b)::text))), (PARTIAL count(DISTINCT (a)::character varying))
+         ->  Partial Aggregate
+               Output: PARTIAL count(DISTINCT ((b)::text)), PARTIAL count(DISTINCT (a)::character varying)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Output: b, a, ((b)::text), (AggExprId)
+                     Hash Key: ((b)::text), a, (AggExprId)
+                     ->  Streaming HashAggregate
+                           Output: b, a, ((b)::text), (AggExprId)
+                           Group Key: AggExprId, ((dqa_f3.b)::text), dqa_f3.a
+                           ->  TupleSplit
+                                 Output: b, a, ((b)::text), AggExprId
+                                 Split by Col: (((dqa_f3.b)::text)), (dqa_f3.a)
+                                 ->  Seq Scan on public.dqa_f3
+                                       Output: b, a, (b)::text
+ Optimizer: Postgres query optimizer
+ Settings: enable_groupagg = 'off', gp_motion_cost_per_row = '1'
+(19 rows)
+
+-- Case 3: When converting the type of column 'a' from 'varchar' to 'int' in DQA expression, TupleSplit should generate an additional
+-- column '(a)::integer' as part of hash-key in Redistribute-Motion, since the conversion is not binary-compatible.
+-- ->  Redistribute Motion 3:3  (slice2; segments: 3)
+--       Output: b, a, ((b)::text), ((a)::integer), (AggExprId)
+--       Hash Key: ((b)::text), ((a)::integer), (AggExprId)
+--     ...
+--     ->  TupleSplit
+--           Output: b, a, ((b)::text), ((a)::integer), AggExprId
+--           Split by Col: (((dqa_f3.b)::text)), (((dqa_f3.a)::integer))
+--           ->  Seq Scan on public.dqa_f3
+--                 Output: b, a, (b)::text, (a)::integer
+select count(distinct (b)::text) as b, count(distinct (a)::int) as a from dqa_f3;
+ b | a 
+---+---
+ 3 | 7
+(1 row)
+
+explain (verbose, costs off) select count(distinct (b)::text) as b, count(distinct (a)::int) as a from dqa_f3;
+                                            QUERY PLAN
+---------------------------------------------------------------------------------------------------
+ Finalize Aggregate
+   Output: count(DISTINCT ((b)::text)), count(DISTINCT ((a)::integer))
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Output: (PARTIAL count(DISTINCT ((b)::text))), (PARTIAL count(DISTINCT ((a)::integer)))
+         ->  Partial Aggregate
+               Output: PARTIAL count(DISTINCT ((b)::text)), PARTIAL count(DISTINCT ((a)::integer))
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Output: b, a, ((b)::text), ((a)::integer), (AggExprId)
+                     Hash Key: ((b)::text), ((a)::integer), (AggExprId)
+                     ->  Streaming HashAggregate
+                           Output: b, a, ((b)::text), ((a)::integer), (AggExprId)
+                           Group Key: AggExprId, ((dqa_f3.b)::text), ((dqa_f3.a)::integer)
+                           ->  TupleSplit
+                                 Output: b, a, ((b)::text), ((a)::integer), AggExprId
+                                 Split by Col: (((dqa_f3.b)::text)), (((dqa_f3.a)::integer))
+                                 ->  Seq Scan on public.dqa_f3
+                                       Output: b, a, (b)::text, (a)::integer
+ Optimizer: Postgres query optimizer
+ Settings: enable_groupagg = 'off', gp_motion_cost_per_row = '1'
+(19 rows)
+
+-- Case 4: When converting the type of column 'a' from 'varchar' to 'int' to 'varchar', TupleSplit should generate an additional
+-- column '(a)::integer::varchar' as part of hash-key in Redistribute-Motion.
+select count(distinct (b)::text) as b, count(distinct (a)::int::varchar) as a from dqa_f3;
+ b | a 
+---+---
+ 3 | 7
+(1 row)
+
+explain (verbose, costs off) select count(distinct (b)::text) as b, count(distinct (a)::int::varchar) as a from dqa_f3;
+                                                       QUERY PLAN
+------------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate
+   Output: count(DISTINCT ((b)::text)), count(DISTINCT (((a)::integer)::character varying))
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Output: (PARTIAL count(DISTINCT ((b)::text))), (PARTIAL count(DISTINCT (((a)::integer)::character varying)))
+         ->  Partial Aggregate
+               Output: PARTIAL count(DISTINCT ((b)::text)), PARTIAL count(DISTINCT (((a)::integer)::character varying))
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Output: b, a, ((b)::text), (((a)::integer)::character varying), (AggExprId)
+                     Hash Key: ((b)::text), (((a)::integer)::character varying), (AggExprId)
+                     ->  Streaming HashAggregate
+                           Output: b, a, ((b)::text), (((a)::integer)::character varying), (AggExprId)
+                           Group Key: AggExprId, ((dqa_f3.b)::text), (((dqa_f3.a)::integer)::character varying)
+                           ->  TupleSplit
+                                 Output: b, a, ((b)::text), (((a)::integer)::character varying), AggExprId
+                                 Split by Col: (((dqa_f3.b)::text)), ((((dqa_f3.a)::integer)::character varying))
+                                 ->  Seq Scan on public.dqa_f3
+                                       Output: b, a, (b)::text, ((a)::integer)::character varying
+ Optimizer: Postgres query optimizer
+ Settings: enable_groupagg = 'off', gp_motion_cost_per_row = '1'
+(19 rows)
+

--- a/src/test/regress/expected/gp_dqa_optimizer.out
+++ b/src/test/regress/expected/gp_dqa_optimizer.out
@@ -2321,3 +2321,167 @@ select count(distinct a), sum(b), sum(c) from dqa_f1;
     17 | 2000 | 1000
 (1 row)
 
+-- multi DQA with type conversions
+create table dqa_f3(a character varying, b bigint) distributed by (a);
+insert into dqa_f3 values ('123', 2), ('213', 0), ('231', 2), ('312', 0), ('321', 2), ('132', 1), ('4', 0);
+-- Case 1: When converting the type of column 'a' from 'VARCHAR' to 'TEXT' in DQA expression, instead of generating a new column '(a)::text'
+-- by TupleSplit, we can reference the column 'a' as part of hash-key in Redistribute-Motion directly, since the conversion is binary-compatible.
+-- ->  Redistribute Motion 3:3  (slice2; segments: 3)
+--       Output: b, a, ((b)::text), (AggExprId)
+--       Hash Key: ((b)::text), a, (AggExprId)
+--     ...
+--     ->  TupleSplit
+--           Output: b, a, ((b)::text), AggExprId
+--           Split by Col: (((dqa_f3.b)::text)), (dqa_f3.a)
+--           ->  Seq Scan on public.dqa_f3
+--                 Output: b, a, (b)::text
+select count(distinct (b)::text) as b, count(distinct (a)::text) as a from dqa_f3;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+ b | a 
+---+---
+ 3 | 7
+(1 row)
+
+explain (verbose, costs off) select count(distinct (b)::text) as b, count(distinct (a)::text) as a from dqa_f3;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+                                           QUERY PLAN
+------------------------------------------------------------------------------------------------
+ Finalize Aggregate
+   Output: count(DISTINCT ((b)::text)), count(DISTINCT (a)::text)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Output: (PARTIAL count(DISTINCT ((b)::text))), (PARTIAL count(DISTINCT (a)::text))
+         ->  Partial Aggregate
+               Output: PARTIAL count(DISTINCT ((b)::text)), PARTIAL count(DISTINCT (a)::text)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Output: b, a, ((b)::text), (AggExprId)
+                     Hash Key: ((b)::text), a, (AggExprId)
+                     ->  Streaming HashAggregate
+                           Output: b, a, ((b)::text), (AggExprId)
+                           Group Key: AggExprId, ((dqa_f3.b)::text), dqa_f3.a
+                           ->  TupleSplit
+                                 Output: b, a, ((b)::text), AggExprId
+                                 Split by Col: (((dqa_f3.b)::text)), (dqa_f3.a)
+                                 ->  Seq Scan on public.dqa_f3
+                                       Output: b, a, (b)::text
+ Optimizer: Postgres query optimizer
+ Settings: enable_groupagg = 'off', gp_motion_cost_per_row = '1'
+(19 rows)
+
+-- Case 2: Same as the above one, but convert the type of column 'a' to 'varchar' via binary-compatible types.
+select count(distinct (b)::text) as b, count(distinct (a)::text::varchar) as a from dqa_f3;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+ b | a 
+---+---
+ 3 | 7
+(1 row)
+
+explain (verbose, costs off) select count(distinct (b)::text) as b, count(distinct (a)::text::varchar) as a from dqa_f3;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+                                                 QUERY PLAN
+-------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate
+   Output: count(DISTINCT ((b)::text)), count(DISTINCT (a)::character varying)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Output: (PARTIAL count(DISTINCT ((b)::text))), (PARTIAL count(DISTINCT (a)::character varying))
+         ->  Partial Aggregate
+               Output: PARTIAL count(DISTINCT ((b)::text)), PARTIAL count(DISTINCT (a)::character varying)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Output: b, a, ((b)::text), (AggExprId)
+                     Hash Key: ((b)::text), a, (AggExprId)
+                     ->  Streaming HashAggregate
+                           Output: b, a, ((b)::text), (AggExprId)
+                           Group Key: AggExprId, ((dqa_f3.b)::text), dqa_f3.a
+                           ->  TupleSplit
+                                 Output: b, a, ((b)::text), AggExprId
+                                 Split by Col: (((dqa_f3.b)::text)), (dqa_f3.a)
+                                 ->  Seq Scan on public.dqa_f3
+                                       Output: b, a, (b)::text
+ Optimizer: Postgres query optimizer
+ Settings: enable_groupagg = 'off', gp_motion_cost_per_row = '1'
+(19 rows)
+
+-- Case 3: When converting the type of column 'a' from 'varchar' to 'int' in DQA expression, TupleSplit should generate an additional
+-- column '(a)::integer' as part of hash-key in Redistribute-Motion, since the conversion is not binary-compatible.
+-- ->  Redistribute Motion 3:3  (slice2; segments: 3)
+--       Output: b, a, ((b)::text), ((a)::integer), (AggExprId)
+--       Hash Key: ((b)::text), ((a)::integer), (AggExprId)
+--     ...
+--     ->  TupleSplit
+--           Output: b, a, ((b)::text), ((a)::integer), AggExprId
+--           Split by Col: (((dqa_f3.b)::text)), (((dqa_f3.a)::integer))
+--           ->  Seq Scan on public.dqa_f3
+--                 Output: b, a, (b)::text, (a)::integer
+select count(distinct (b)::text) as b, count(distinct (a)::int) as a from dqa_f3;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+ b | a 
+---+---
+ 3 | 7
+(1 row)
+
+explain (verbose, costs off) select count(distinct (b)::text) as b, count(distinct (a)::int) as a from dqa_f3;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+                                            QUERY PLAN
+---------------------------------------------------------------------------------------------------
+ Finalize Aggregate
+   Output: count(DISTINCT ((b)::text)), count(DISTINCT ((a)::integer))
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Output: (PARTIAL count(DISTINCT ((b)::text))), (PARTIAL count(DISTINCT ((a)::integer)))
+         ->  Partial Aggregate
+               Output: PARTIAL count(DISTINCT ((b)::text)), PARTIAL count(DISTINCT ((a)::integer))
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Output: b, a, ((b)::text), ((a)::integer), (AggExprId)
+                     Hash Key: ((b)::text), ((a)::integer), (AggExprId)
+                     ->  Streaming HashAggregate
+                           Output: b, a, ((b)::text), ((a)::integer), (AggExprId)
+                           Group Key: AggExprId, ((dqa_f3.b)::text), ((dqa_f3.a)::integer)
+                           ->  TupleSplit
+                                 Output: b, a, ((b)::text), ((a)::integer), AggExprId
+                                 Split by Col: (((dqa_f3.b)::text)), (((dqa_f3.a)::integer))
+                                 ->  Seq Scan on public.dqa_f3
+                                       Output: b, a, (b)::text, (a)::integer
+ Optimizer: Postgres query optimizer
+ Settings: enable_groupagg = 'off', gp_motion_cost_per_row = '1'
+(19 rows)
+
+-- Case 4: When converting the type of column 'a' from 'varchar' to 'int' to 'varchar', TupleSplit should generate an additional
+-- column '(a)::integer::varchar' as part of hash-key in Redistribute-Motion.
+select count(distinct (b)::text) as b, count(distinct (a)::int::varchar) as a from dqa_f3;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+ b | a 
+---+---
+ 3 | 7
+(1 row)
+
+explain (verbose, costs off) select count(distinct (b)::text) as b, count(distinct (a)::int::varchar) as a from dqa_f3;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+                                                       QUERY PLAN
+------------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate
+   Output: count(DISTINCT ((b)::text)), count(DISTINCT (((a)::integer)::character varying))
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Output: (PARTIAL count(DISTINCT ((b)::text))), (PARTIAL count(DISTINCT (((a)::integer)::character varying)))
+         ->  Partial Aggregate
+               Output: PARTIAL count(DISTINCT ((b)::text)), PARTIAL count(DISTINCT (((a)::integer)::character varying))
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Output: b, a, ((b)::text), (((a)::integer)::character varying), (AggExprId)
+                     Hash Key: ((b)::text), (((a)::integer)::character varying), (AggExprId)
+                     ->  Streaming HashAggregate
+                           Output: b, a, ((b)::text), (((a)::integer)::character varying), (AggExprId)
+                           Group Key: AggExprId, ((dqa_f3.b)::text), (((dqa_f3.a)::integer)::character varying)
+                           ->  TupleSplit
+                                 Output: b, a, ((b)::text), (((a)::integer)::character varying), AggExprId
+                                 Split by Col: (((dqa_f3.b)::text)), ((((dqa_f3.a)::integer)::character varying))
+                                 ->  Seq Scan on public.dqa_f3
+                                       Output: b, a, (b)::text, ((a)::integer)::character varying
+ Optimizer: Postgres query optimizer
+ Settings: enable_groupagg = 'off', gp_motion_cost_per_row = '1'
+(19 rows)
+

--- a/src/test/regress/sql/gp_dqa.sql
+++ b/src/test/regress/sql/gp_dqa.sql
@@ -354,3 +354,44 @@ explain select count(distinct a) filter (where a > 3),count( distinct b) filter 
 -- the following SQL should use two stage agg
 explain select count(distinct a), sum(b), sum(c) from dqa_f1;
 select count(distinct a), sum(b), sum(c) from dqa_f1;
+
+-- multi DQA with type conversions
+create table dqa_f3(a character varying, b bigint) distributed by (a);
+insert into dqa_f3 values ('123', 2), ('213', 0), ('231', 2), ('312', 0), ('321', 2), ('132', 1), ('4', 0);
+
+-- Case 1: When converting the type of column 'a' from 'VARCHAR' to 'TEXT' in DQA expression, instead of generating a new column '(a)::text'
+-- by TupleSplit, we can reference the column 'a' as part of hash-key in Redistribute-Motion directly, since the conversion is binary-compatible.
+-- ->  Redistribute Motion 3:3  (slice2; segments: 3)
+--       Output: b, a, ((b)::text), (AggExprId)
+--       Hash Key: ((b)::text), a, (AggExprId)
+--     ...
+--     ->  TupleSplit
+--           Output: b, a, ((b)::text), AggExprId
+--           Split by Col: (((dqa_f3.b)::text)), (dqa_f3.a)
+--           ->  Seq Scan on public.dqa_f3
+--                 Output: b, a, (b)::text
+select count(distinct (b)::text) as b, count(distinct (a)::text) as a from dqa_f3;
+explain (verbose, costs off) select count(distinct (b)::text) as b, count(distinct (a)::text) as a from dqa_f3;
+
+-- Case 2: Same as the above one, but convert the type of column 'a' to 'varchar' via binary-compatible types.
+select count(distinct (b)::text) as b, count(distinct (a)::text::varchar) as a from dqa_f3;
+explain (verbose, costs off) select count(distinct (b)::text) as b, count(distinct (a)::text::varchar) as a from dqa_f3;
+
+-- Case 3: When converting the type of column 'a' from 'varchar' to 'int' in DQA expression, TupleSplit should generate an additional
+-- column '(a)::integer' as part of hash-key in Redistribute-Motion, since the conversion is not binary-compatible.
+-- ->  Redistribute Motion 3:3  (slice2; segments: 3)
+--       Output: b, a, ((b)::text), ((a)::integer), (AggExprId)
+--       Hash Key: ((b)::text), ((a)::integer), (AggExprId)
+--     ...
+--     ->  TupleSplit
+--           Output: b, a, ((b)::text), ((a)::integer), AggExprId
+--           Split by Col: (((dqa_f3.b)::text)), (((dqa_f3.a)::integer))
+--           ->  Seq Scan on public.dqa_f3
+--                 Output: b, a, (b)::text, (a)::integer
+select count(distinct (b)::text) as b, count(distinct (a)::int) as a from dqa_f3;
+explain (verbose, costs off) select count(distinct (b)::text) as b, count(distinct (a)::int) as a from dqa_f3;
+
+-- Case 4: When converting the type of column 'a' from 'varchar' to 'int' to 'varchar', TupleSplit should generate an additional
+-- column '(a)::integer::varchar' as part of hash-key in Redistribute-Motion.
+select count(distinct (b)::text) as b, count(distinct (a)::int::varchar) as a from dqa_f3;
+explain (verbose, costs off) select count(distinct (b)::text) as b, count(distinct (a)::int::varchar) as a from dqa_f3;


### PR DESCRIPTION
This patch is to fix #14096.

How does multi-DQA work:

When creating path for multi-DQA (multiple distinct qualified aggregate), the planner generates the plan as follows:

```
Finalize Aggregate
  -> Gather Motion
       -> Partial Aggregate
            -> HashAggregate, to remove duplicates
                 -> Redistribute Motion
                      -> TupleSplit (according to DISTINCT expr)
                           -> input
```

The plan is generated via the following steps:

1. The planner compares the expr in DQA with the input tuples, if the DQA expr is not in PathTarget, the TupleSplit node will append the corresponding column the the PathTarget together with a special column 'AggExprId' to the output tuple. E.g., if the input of TupleSplit is '(a: 1, b: 2, c: 3)' and the DQA expressions are 'DQA(a)', 'DQA(b)', the output of TupleSplit are '(a: 1, b: null, c: 3, AggExprId: 1)', '(a: null, b: 2, c: 3, AggExprId: 2)'. Only one of the DQA expr's column is set to non-null per tuple and the AggExprId is used to indicate which DQA expr's column is non-null in that tuple.

2. The output tuples of TupleSplit are hashed and sent to different segments via Redistribute-Motion. Because in the previous stage, only one of the DQA expr's column is set to non-null per tuple, DQA expr with same value is gathered on the same segment and we can apply HashAggregate on these tuples to remove duplicate values.

3. We apply Partial Aggregate function on tuples across segments.

4. We gather tuples to QD and apply the Finalize Aggregate function on tuples.

The RCA is given below:

1. When there're type conversions in DQA exprs, the planner will wrap the expr with type conversion node. E.g., for binary-compatible datatypes, like 'VARCHAR' and 'TEXT' the expr will be wrapped with 'ReplabelType' node.

2. When there are queries like 'SELECT DQA(a::TEXT) FROM foo(a VARCHAR)', the planner compares the DQA expr with exprs in PathTarget directly without removing the 'RelabelType' node. So, the TupleSplit looks like:

   ```
   TupleSplit:
     Input: a
     Output: a, a::TEXT
   ```

3. When the planner generating the Redistribute-Motion operator, it tries to find the expr of equivalent class with the expr in targetlist as the hashkey (src/backend/cdb/cdbpullup.c:cdbpullup_findEclassInTargetList). However, in this stage, the planner will ignore the 'RelabelType' when comparing two exprs. Finally, the planner may choose incorrect column as the hash key.

This patch helps resolve the issue by teaching 'TupleSplit' node to ignore 'RelabelType' node when comparing DQA expr and the one in PathTarget. So the TupleSplit node looks like:

```
TupleSplit:
  Input: a
  Output: a
```

when planning queries like: 'SELECT DQA(a::TEXT) FROM foo(a VARCHAR)'.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [x] Pass `make installcheck`
