### PR TITLE
docs - remove refs to gp_enable_sort_distinct guc

### DIFF
--- a/gpdb-doc/markdown/ref_guide/config_params/guc-list.html.md
+++ b/gpdb-doc/markdown/ref_guide/config_params/guc-list.html.md
@@ -787,14 +787,6 @@ The parameter can be set for a database system or a session. The parameter canno
 |-----------|-------|-------------------|
 |Boolean|true|master, session, reload|
 
-## <a id="gp_enable_sort_distinct"></a>gp\_enable\_sort\_distinct 
-
-Enable duplicates to be removed while sorting.
-
-|Value Range|Default|Set Classifications|
-|-----------|-------|-------------------|
-|Boolean|on|master, session, reload|
-
 ## <a id="gp_enable_sort_limit"></a>gp\_enable\_sort\_limit 
 
 Enable `LIMIT` operation to be performed while sorting. Sorts more efficiently when the plan requires the first *limit\_number* of rows at most.

--- a/gpdb-doc/markdown/ref_guide/config_params/guc_category-list.html.md
+++ b/gpdb-doc/markdown/ref_guide/config_params/guc_category-list.html.md
@@ -158,7 +158,6 @@ The following parameters control the types of plan operations the Postgres Plann
 - [gp_enable_predicate_propagation](guc-list.html#gp_enable_predicate_propagation)
 - [gp_enable_preunique](guc-list.html#gp_enable_preunique)
 - [gp_enable_relsize_collection](guc-list.html#gp_enable_relsize_collection)
-- [gp_enable_sort_distinct](guc-list.html#gp_enable_sort_distinct)
 - [gp_enable_sort_limit](guc-list.html#gp_enable_sort_limit)
 
 ### <a id="topic23"></a>Postgres Planner Costing Parameters 
@@ -183,7 +182,6 @@ These parameters adjust the amount of data sampled by an `ANALYZE` operation. Ad
 
 ### <a id="topic25"></a>Sort Operator Configuration Parameters 
 
-- [gp_enable_sort_distinct](guc-list.html#gp_enable_sort_distinct)
 - [gp_enable_sort_limit](guc-list.html#gp_enable_sort_limit)
 
 ### <a id="topic26"></a>Aggregate Operator Configuration Parameters 


### PR DESCRIPTION
https://github.com/greenplum-db/gpdb/pull/14105 removed the gp_enable_sort_distinct guc from the code.  remove doc refs to this guc.
