### PR TITLE
docs - add guc ref for gp_eager_two_phase_agg

### DIFF
--- a/gpdb-doc/markdown/ref_guide/config_params/guc-list.html.md
+++ b/gpdb-doc/markdown/ref_guide/config_params/guc-list.html.md
@@ -655,6 +655,16 @@ Enables plans that can dynamically eliminate the scanning of partitions.
 |-----------|-------|-------------------|
 |Boolean|on|master, session, reload|
 
+## <a id="gp_eager_two_phase_agg"></a>gp\_eager\_two\_phase\_agg
+
+Activates or deactivates two-phase aggregation for the Postgres Planner.
+
+The default value is `off`; the Planner chooses the best aggregate path for a query based on the cost. When set to `on`, the Planner adds a disable cost to each of the first stage aggregate paths, which in turn forces the Planner to generate and choose a multi-stage aggregate path.
+
+|Value Range|Default|Set Classifications|
+|-----------|-------|-------------------|
+|Boolean|off|master, session, reload|
+
 ## <a id="gp_enable_agg_distinct"></a>gp\_enable\_agg\_distinct 
 
  Activates or deactivates  two-phase aggregation to compute a single distinct-qualified aggregate. This applies only to subqueries that include a single distinct-qualified aggregate function.

--- a/gpdb-doc/markdown/ref_guide/config_params/guc_category-list.html.md
+++ b/gpdb-doc/markdown/ref_guide/config_params/guc_category-list.html.md
@@ -148,6 +148,7 @@ The following parameters control the types of plan operations the Postgres Plann
 - [enable_seqscan](guc-list.html#enable_seqscan)
 - [enable_sort](guc-list.html#enable_sort)
 - [enable_tidscan](guc-list.html#enable_tidscan)
+- [gp_eager_two_phase_agg](guc-list.html#gp_eager_two_phase_agg)
 - [gp_enable_agg_distinct](guc-list.html#gp_enable_agg_distinct)
 - [gp_enable_agg_distinct_pruning](guc-list.html#gp_enable_agg_distinct_pruning)
 - [gp_enable_direct_dispatch](guc-list.html#gp_enable_direct_dispatch)


### PR DESCRIPTION
docs for https://github.com/greenplum-db/gpdb/pull/11443.  add ref docs for the gp_eager_two_phase_agg guc.

the guc is in 6X_STABLE with the same default value, so will backport to that branch.
