### PR TITLE
Introduce timeout to tcp ic teardown select loop

### DIFF
--- a/src/backend/cdb/motion/ic_tcp.c
+++ b/src/backend/cdb/motion/ic_tcp.c
@@ -2307,8 +2307,8 @@ flushInterconnectListenerBacklog(void)
 
 /*
  * Wait for our peer to close the socket (at which point our select(2)
- * will tell us that the socket is ready to read, and the socket-read
- * will only return 0.
+ * will tell us that the socket is ready to read, and the socket recv
+ * will return 0 or a 'stop' message.
  *
  * This works without the select, but burns tons of CPU doing nothing
  * useful.
@@ -2330,19 +2330,23 @@ flushInterconnectListenerBacklog(void)
  * can tell, the only interrupt-driven state change we care
  * about). This should give us notification of ProcDiePending and
  * QueryCancelPending
+ *
+ * XXX: Consider using something like WaitLatchOrSocket() instead of select().
  */
 static void
 waitOnOutbound(ChunkTransportStateEntry *pEntry)
 {
 	MotionConn *conn;
 
-	struct timeval timeout;
 	mpp_fd_set	waitset,
 				curset;
 	int			maxfd = -1;
 	int			i,
 				n,
 				conn_count = 0;
+	struct timeval endtime;
+
+	SIMPLE_FAULT_INJECTOR("waitOnOutbound");
 
 	MPP_FD_ZERO(&waitset);
 
@@ -2359,9 +2363,15 @@ waitOnOutbound(ChunkTransportStateEntry *pEntry)
 		}
 	}
 
+	gettimeofday(&endtime, NULL);
+	endtime.tv_sec += Gp_interconnect_transmit_timeout;
+
 	for (;;)
 	{
 		int			saved_err;
+		struct timeval timeout;
+		struct timeval now;
+		int64		timeoutval;
 
 		if (conn_count == 0)
 			return;
@@ -2374,28 +2384,59 @@ waitOnOutbound(ChunkTransportStateEntry *pEntry)
 			return;
 		}
 
-		timeout.tv_sec = 0;
-		timeout.tv_usec = 500000;
+		gettimeofday(&now, NULL);
+		timeoutval = (endtime.tv_sec * 1000000 + endtime.tv_usec) - (now.tv_sec * 1000000 + now.tv_usec);
+		if (timeoutval <= 0)
+		{
+			/*
+			 * We timed out trying to receive a final response from the motion
+			 * receiver (either a 'stop' message or 0). Since this response
+			 * confirms that the receiver has received the EOS from this sender
+			 * (and all preceding data), receipt of this response is vital.
+			 * Hence, we error out.
+			 */
+			ereport(ERROR,
+					errcode(ERRCODE_GP_INTERCONNECTION_ERROR),
+					errmsg("timed out waiting for response from motion receiver during TCP interconnect teardown"),
+					errdetail("%d connection(s) with pending response after %d seconds",
+							  conn_count,
+							  Gp_interconnect_transmit_timeout));
+		}
+		timeout.tv_sec = timeoutval / 1000000;
+		timeout.tv_usec = timeoutval % 1000000;
 
 		memcpy(&curset, &waitset, sizeof(mpp_fd_set));
 
 		n = select(maxfd + 1, (fd_set *) &curset, NULL, NULL, &timeout);
-		if (n == 0 || (n < 0 && errno == EINTR))
+		if (n < 0)
 		{
-			continue;
-		}
-		else if (n < 0)
-		{
+			if (errno == EINTR)
+				continue;
+
 			saved_err = errno;
 
 			if (CancelRequested() || QueryFinishPending)
 				return;
 
-			/*
-			 * Something unexpected, but probably not horrible warn and return
-			 */
+			/* Something unexpected, but probably not horrible warn and return */
 			elog(LOG, "TeardownTCPInterconnect: waitOnOutbound select errno=%d", saved_err);
 			break;
+		}
+		if (n == 0)
+		{
+			/*
+			 * We timed out trying to receive a final response from the motion
+			 * receiver (either a 'stop' message or 0). Since this response
+			 * confirms that the receiver has received the EOS from this sender
+			 * (and all preceding data), receipt of this response is vital.
+			 * Hence, we error out.
+			 */
+			ereport(ERROR,
+					errcode(ERRCODE_GP_INTERCONNECTION_ERROR),
+					errmsg("timed out waiting for response from motion receiver during TCP interconnect teardown"),
+					errdetail("%d connection(s) with pending response after %d seconds",
+							  conn_count,
+							  Gp_interconnect_transmit_timeout));
 		}
 
 		for (i = 0; i < pEntry->numConns; i++)
@@ -2447,6 +2488,8 @@ doSendStopMessageTCP(ChunkTransportState *transportStates, int16 motNodeID)
 	int			i;
 	char		m = 'S';
 	ssize_t		written;
+
+	SIMPLE_FAULT_INJECTOR("doSendStopMessageTCP");
 
 	getChunkTransportState(transportStates, motNodeID, &pEntry);
 	Assert(pEntry);

--- a/src/test/isolation2/expected/tcp_ic_teardown.out
+++ b/src/test/isolation2/expected/tcp_ic_teardown.out
@@ -1,0 +1,92 @@
+-- Test ensuring that we perform a timed wait inside the TCP interconnect
+-- teardown on the motion sender side, for the final response from the motion
+-- receiver(s).
+
+CREATE FUNCTION set_gp_ic_type(ic_type text) RETURNS VOID as $$ import os cmd = 'gpconfig -c gp_interconnect_type -v %s' % ic_type if os.system(cmd) is not 0: plpy.error('Setting gp_interconnect_type to %s failed' % ic_type) $$ LANGUAGE plpython3u;
+CREATE
+
+CREATE TABLE tcp_ic_teardown(i int);
+CREATE
+INSERT INTO tcp_ic_teardown SELECT generate_series(1, 5);
+INSERT 5
+
+-- Save current IC type before we set it to 'tcp', so we can revert it at the
+-- end of the test.
+-1U: CREATE TABLE saved_ic_type AS SELECT current_setting('gp_interconnect_type') AS ic_type;
+CREATE 1
+-1U: SELECT set_gp_ic_type('tcp');
+ set_gp_ic_type 
+----------------
+                
+(1 row)
+!\retcode gpstop -au;
+-- start_ignore
+-- end_ignore
+(exited with code 0)
+
+SELECT gp_inject_fault('waitOnOutbound', 'suspend', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+SELECT gp_inject_fault('doSendStopMessageTCP', 'suspend', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+1: SET gp_interconnect_transmit_timeout TO '3s';
+SET
+-- Use a LIMIT to squelch the motion node in order to send a 'stop' message.
+1&: SELECT * FROM tcp_ic_teardown LIMIT 1;  <waiting ...>
+
+-- Ensure that we have suspended the QD's gather motion receiver at the point
+-- before it sends out the 'stop' message and have reached the point just prior
+-- to starting the timed wait during TCP teardown on one of the motion senders.
+SELECT gp_wait_until_triggered_fault('waitOnOutbound', 1, dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+SELECT gp_wait_until_triggered_fault('doSendStopMessageTCP', 1, dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
+-- Let the timed wait proceed on the sender side.
+SELECT gp_inject_fault('waitOnOutbound', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+!\retcode sleep 6;
+-- start_ignore
+
+-- end_ignore
+(exited with code 0)
+
+SELECT gp_inject_fault('doSendStopMessageTCP', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+-- After 6s have elapsed (enough to have covered the timed wait of 3s, we should
+-- have consequently ERRORed out on the motion sender side)
+1<:  <... completed>
+ERROR:  timed out waiting for response from motion receiver during TCP interconnect teardown  (seg1 slice1 192.168.0.148:7003 pid=654372)
+DETAIL:  1 connection(s) with pending response after 3 seconds
+
+-- Revert IC type
+-1U: SELECT set_gp_ic_type(ic_type) FROM saved_ic_type;
+ set_gp_ic_type 
+----------------
+                
+(1 row)
+!\retcode gpstop -au;
+-- start_ignore
+-- end_ignore
+(exited with code 0)
+-1U: DROP TABLE saved_ic_type;
+DROP

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -302,3 +302,6 @@ test: sync_guc
 
 # test pg_export_snapshot with distributed snapshot functionality
 test: export_distributed_snapshot
+
+# test TCP interconnect teardown bounded wait
+test: tcp_ic_teardown

--- a/src/test/isolation2/sql/tcp_ic_teardown.sql
+++ b/src/test/isolation2/sql/tcp_ic_teardown.sql
@@ -1,0 +1,54 @@
+-- Test ensuring that we perform a timed wait inside the TCP interconnect
+-- teardown on the motion sender side, for the final response from the motion
+-- receiver(s).
+
+CREATE FUNCTION set_gp_ic_type(ic_type text)
+    RETURNS VOID as $$
+import os
+cmd = 'gpconfig -c gp_interconnect_type -v %s' % ic_type
+if os.system(cmd) is not 0:
+    plpy.error('Setting gp_interconnect_type to %s failed' % ic_type)
+$$ LANGUAGE plpython3u;
+
+CREATE TABLE tcp_ic_teardown(i int);
+INSERT INTO tcp_ic_teardown SELECT generate_series(1, 5);
+
+-- Save current IC type before we set it to 'tcp', so we can revert it at the
+-- end of the test.
+-1U: CREATE TABLE saved_ic_type AS SELECT current_setting('gp_interconnect_type') AS ic_type;
+-1U: SELECT set_gp_ic_type('tcp');
+!\retcode gpstop -au;
+
+SELECT gp_inject_fault('waitOnOutbound', 'suspend', dbid)
+    FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
+SELECT gp_inject_fault('doSendStopMessageTCP', 'suspend', dbid)
+    FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+
+1: SET gp_interconnect_transmit_timeout TO '3s';
+-- Use a LIMIT to squelch the motion node in order to send a 'stop' message.
+1&: SELECT * FROM tcp_ic_teardown LIMIT 1;
+
+-- Ensure that we have suspended the QD's gather motion receiver at the point
+-- before it sends out the 'stop' message and have reached the point just prior
+-- to starting the timed wait during TCP teardown on one of the motion senders.
+SELECT gp_wait_until_triggered_fault('waitOnOutbound', 1, dbid)
+    FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
+SELECT gp_wait_until_triggered_fault('doSendStopMessageTCP', 1, dbid)
+    FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+
+-- Let the timed wait proceed on the sender side.
+SELECT gp_inject_fault('waitOnOutbound', 'reset', dbid)
+    FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
+
+!\retcode sleep 6;
+
+SELECT gp_inject_fault('doSendStopMessageTCP', 'reset', dbid)
+    FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+-- After 6s have elapsed (enough to have covered the timed wait of 3s, we should
+-- have consequently ERRORed out on the motion sender side)
+1<:
+
+-- Revert IC type
+-1U: SELECT set_gp_ic_type(ic_type) FROM saved_ic_type;
+!\retcode gpstop -au;
+-1U: DROP TABLE saved_ic_type;


### PR DESCRIPTION
Introduce timeout to tcp ic teardown select loop

Background:

1c1f16448ba introduced the waitOnOutbound() call for non-error cases as
well during TCP IC teardown, after "Interconnect error: connection
closed prematurely." ERRORs were seen in Azure environments. This is
essential because performing a close() does not necessitate that the
peer has received any unflushed data in the kernel send buffers. Neither
does it flag cases where the peer may have crashed after the sender
performed the close(). Thus it is essential we have an app-defined
protocol to ensure delivery - this is where the EOS message comes in.
Motion senders send an EOS to the motion receiver. Then the receiver
closes the socket (and sent an optional 'stop' message), which is
detected by the sender in waitOnOutbound() by recv()ing 0 or the stop
message. ONLY after this detection step can the sender can safely
close() its socket.

Implementation:

We currently poll for a stop message in a motion sender teardown.
However, we were performing infinite retries (as we weren't handling the
return value of 0 from select()), which can cause hung queries. So, use
a timeout equal to gp_interconnect_transmit_timeout, which is used
throughout the interconnect to enforce an upper bound on the time it
takes to transmit a packet (in this case the EOS). Once this timeout
elapses, an ERROR will result.

PS: The implementation is inspired by PerformRadiusTransaction().
