### PR TITLE
Integrate python3.9 to GPDB6

### DIFF
--- a/concourse/scripts/compile_gpdb.bash
+++ b/concourse/scripts/compile_gpdb.bash
@@ -42,10 +42,12 @@ function generate_build_number() {
 
 function link_python() {
 	echo "Installing python"
-	export PYTHONHOME=$(find /opt -maxdepth 1 -type d -name "python*")
+	export PYTHONHOME=$(find /opt -maxdepth 1 -type d -name "python-2*")
 	export PATH="${PYTHONHOME}/bin:${PATH}"
 	echo "${PYTHONHOME}/lib" >>/etc/ld.so.conf.d/gpdb.conf
 	ldconfig
+	export PYTHONHOME39=$(find /opt -maxdepth 1 -type d -name "python-3.9.*")
+	export PATH="${PYTHONHOME39}/bin:${PATH}"
 }
 
 function build_gpdb() {

--- a/gpAux/Makefile
+++ b/gpAux/Makefile
@@ -597,6 +597,15 @@ copylibs :
 	else \
 	    echo "INFO: Python not found on this platform, $(BLD_ARCH), not copying it into the GPDB package."; \
 	fi
+	# Create the python3.9 directory to flag to build scripts that python has been handled
+	mkdir -p $(INSTLOC)/ext/python3.9
+	@if [ ! -z "$(PYTHONHOME39)" ]; then \
+	    echo "Copying python3.9, ., from $(PYTHONHOME39) into $(INSTLOC)/ext/python3.9..."; \
+	    (cd $(PYTHONHOME39) && tar cf - .) | (cd $(INSTLOC)/ext/python3.9/ && tar xpf -); \
+		echo "...DONE"; \
+	else \
+	    echo "INFO: Python3.9 not found on this platform, $(BLD_ARCH), not copying it into the GPDB package."; \
+	fi
 	mkdir -p $(INSTLOC)/etc
 	mkdir -p $(INSTLOC)/include
 

--- a/gpMgmt/bin/generate-greenplum-path.sh
+++ b/gpMgmt/bin/generate-greenplum-path.sh
@@ -23,8 +23,8 @@ fi
 
 cat <<"EOF"
 PYTHONPATH="${GPHOME}/lib/python"
-PATH="${GPHOME}/bin:${PATH}"
-LD_LIBRARY_PATH="${GPHOME}/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+PATH="${GPHOME}/bin:${GPHOME}/ext/python3.9/bin:${PATH}"
+LD_LIBRARY_PATH="${GPHOME}/lib:${GPHOME}/ext/python3.9/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
 
 if [ -e "${GPHOME}/etc/openssl.cnf" ]; then
 	OPENSSL_CONF="${GPHOME}/etc/openssl.cnf"


### PR DESCRIPTION
Python3.9 is the dependency of the plpython3 extension, which is not integrated into gpdb6. This commit integrates python3.9 into GPDB6 and does not set PYTHONPATH and PYTHONHOME for python3.9 to guarantee it does not influence python2.

Co-authored-by: Ning Wu <ningw@vmware.com>
