### PR TITLE
(6x only) CUBE is limited to at most have 12 elements.

### DIFF
--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -12425,6 +12425,7 @@ group_elem:
 					GroupingClause *n = makeNode(GroupingClause);
 					n->groupType = GROUPINGTYPE_ROLLUP;
 					n->groupsets = $3;
+					n->location = @1;
 					$$ = list_make1 ((Node*)n);
 				}
             | CUBE '(' expr_list ')'
@@ -12432,6 +12433,7 @@ group_elem:
 					GroupingClause *n = makeNode(GroupingClause);
 					n->groupType = GROUPINGTYPE_CUBE;
 					n->groupsets = $3;
+					n->location = @1;
 					$$ = list_make1 ((Node*)n);
 				}
             | GROUPING SETS '(' group_elem_list ')'
@@ -12439,6 +12441,7 @@ group_elem:
 					GroupingClause *n = makeNode(GroupingClause);
 					n->groupType = GROUPINGTYPE_GROUPING_SETS;
 					n->groupsets = $4;
+					n->location = @1;
 					$$ = list_make1 ((Node*)n);
 				}
             | '(' ')'

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -1026,6 +1026,7 @@ typedef struct GroupingClause
 	NodeTag      type;
 	GroupingType groupType;
 	List         *groupsets;
+	int			 location;
 } GroupingClause;
 
 /*

--- a/src/test/regress/expected/olap_group.out
+++ b/src/test/regress/expected/olap_group.out
@@ -6253,3 +6253,15 @@ order by 1, 2;
 (20 rows)
 
 drop table foo_gset;
+-- test CUBE cannot have more than 12 elements
+create table t_cube_12_limit(c1 int, c2 int, c3 int, c4 int, c5 int, c6 int, c7 int,
+                             c8 int, c9 int, c10 int, c11 int, c12 int, c13 int, c14 int,
+			     c15 int, c16 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+select c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15, sum(c16) from t_cube_12_limit
+group by cube(c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13), c14, c15;
+ERROR:  CUBE is limited to 12 elements
+LINE 2: group by cube(c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, ...
+                 ^
+drop table t_cube_12_limit;

--- a/src/test/regress/sql/olap_group.sql
+++ b/src/test/regress/sql/olap_group.sql
@@ -705,3 +705,11 @@ group by c2, rollup((c1))
 order by 1, 2;
 
 drop table foo_gset;
+
+-- test CUBE cannot have more than 12 elements
+create table t_cube_12_limit(c1 int, c2 int, c3 int, c4 int, c5 int, c6 int, c7 int,
+                             c8 int, c9 int, c10 int, c11 int, c12 int, c13 int, c14 int,
+			     c15 int, c16 int);
+select c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15, sum(c16) from t_cube_12_limit
+group by cube(c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13), c14, c15;
+drop table t_cube_12_limit;


### PR DESCRIPTION
Arbitrarily cap the size of CUBE, which has exponential grow is not a computationable SQL. 
Disallow elements more than 12 to keep align with upstream.

----------

* Master branch already have this kind of code when merging PG9.6. So this PR is only for 6X.
* I add a field in the parse tree's struct, append the filed at the end of the struct, so it should not break ABI
* In my local VM (very small machine), it runs 36 sec to generate a plan for the following SQL with 12 elements (NOTE the main part of explain cannot be interrupted still).

```
gpadmin@zlyu:~/workspace/gpdb$ psql
psql (9.4.26)
Type "help" for help.

gpadmin=# \timing
Timing is on.
gpadmin=# set statement_mem = '2GB';
SET
Time: 28.256 ms
gpadmin=# explain select c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c25, c26, c27, sum(c26) from t group by cube(c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11), c25, c26, c27;

 Gather Motion 3:1  (slice925; segments: 3)  (cost=4394.86..3463873.05 rows=8149366 width=80)
   ->  Append  (cost=4394.86..3463873.05 rows=2716456 width=80)
         ->  HashAggregate  (cost=4394.86..4611.33 rows=7216 width=80)
               Group Key: "rollup".c25, "rollup".c26, "rollup".c27, "rollup".c11, "rollup".c10, "rollup".c9, "rollup".c8, "rollup".c7, "rollup".c6, "rollup".c5, "rollup".c4, "rollup".c3, "rollup".c2, "rollup".c1, "rollup".c0, "rollup"."grouping", "rollup"."group_id"
               ->  Subquery Scan on "rollup"  (cost=2146.67..4364.44 rows=226 width=80)
                     ............
Time: 38780.634 ms
```