### PR TITLE
docs - update sql ref pages for ABORT/BEGIN/END/COMMIT/ROLLBACK/...

### DIFF
--- a/gpdb-doc/markdown/admin_guide/dml.html.md
+++ b/gpdb-doc/markdown/admin_guide/dml.html.md
@@ -144,7 +144,7 @@ Transactions allow you to bundle multiple SQL statements in one all-or-nothing o
 
 The following are the Greenplum Database SQL transaction commands:
 
--   `BEGIN` or `START TRANSACTION`starts a transaction block.
+-   `BEGIN` or `START TRANSACTION` starts a transaction block.
 -   `END` or `COMMIT` commits the results of a transaction.
 -   `ROLLBACK` abandons a transaction without making any changes.
 -   `SAVEPOINT` marks a place in a transaction and enables partial rollback. You can roll back commands run after a savepoint while maintaining commands run before the savepoint.

--- a/gpdb-doc/markdown/ref_guide/feature_summary.html.md
+++ b/gpdb-doc/markdown/ref_guide/feature_summary.html.md
@@ -868,7 +868,6 @@ Greenplum Database is based on PostgreSQL 9.4. To support the distributed nature
 <td class="entry nocellnorowborder" style="vertical-align:top;" headers="d119146e605 ">YES</td>
 <td class="entry cell-norowborder" style="vertical-align:top;" headers="d119146e608 "><strong class="ph b">Limitations:</strong><p class="p"><code class="ph codeph">DEFERRABLE</code> clause has no
                   effect.</p>
-<p class="p"><code class="ph codeph">SET TRANSACTION SNAPSHOT</code>YES</p>
 </td>
 </tr>
 <tr class="row">

--- a/gpdb-doc/markdown/ref_guide/feature_summary.html.md
+++ b/gpdb-doc/markdown/ref_guide/feature_summary.html.md
@@ -868,8 +868,7 @@ Greenplum Database is based on PostgreSQL 9.4. To support the distributed nature
 <td class="entry nocellnorowborder" style="vertical-align:top;" headers="d119146e605 ">YES</td>
 <td class="entry cell-norowborder" style="vertical-align:top;" headers="d119146e608 "><strong class="ph b">Limitations:</strong><p class="p"><code class="ph codeph">DEFERRABLE</code> clause has no
                   effect.</p>
-<p class="p"><code class="ph codeph">SET TRANSACTION SNAPSHOT</code> command is not
-                  supported.</p>
+<p class="p"><code class="ph codeph">SET TRANSACTION SNAPSHOT</code>YES</p>
 </td>
 </tr>
 <tr class="row">

--- a/gpdb-doc/markdown/ref_guide/sql_commands/ABORT.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/ABORT.html.md
@@ -5,7 +5,7 @@ Terminates the current transaction.
 ## <a id="section2"></a>Synopsis 
 
 ``` {#sql_command_synopsis}
-ABORT [WORK | TRANSACTION]
+ABORT [WORK | TRANSACTION] [AND [NO] CHAIN]
 ```
 
 ## <a id="section3"></a>Description 
@@ -18,11 +18,22 @@ WORK
 TRANSACTION
 :   Optional key words. They have no effect.
 
+AND CHAIN
+:   If `AND CHAIN` is specified, a new transaction is immediately started with the same transaction characteristics \(see [SET TRANSACTION](SET_TRANSACTION.html)\) as the just finished one. Otherwise, no new transaction is started.
+
 ## <a id="section5"></a>Notes 
 
-Use `COMMIT` to successfully terminate a transaction.
+Use [COMMIT](COMMIT.html) to successfully terminate a transaction.
 
-Issuing `ABORT` when not inside a transaction does no harm, but it will provoke a warning message.
+Issuing `ABORT` outside of a transaction block emits a warning and otherwise has no effect.
+
+## <a id="section5a"></a>Examples 
+
+To terminate all changes:
+
+```
+ABORT;
+```
 
 ## <a id="section6"></a>Compatibility 
 

--- a/gpdb-doc/markdown/ref_guide/sql_commands/BEGIN.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/BEGIN.html.md
@@ -6,19 +6,17 @@ Starts a transaction block.
 
 ``` {#sql_command_synopsis}
 BEGIN [WORK | TRANSACTION] [<transaction_mode>]
-```
 
-where transaction\_mode is:
+where <transaction_mode> is:
 
-```
    ISOLATION LEVEL {READ UNCOMMITTED | READ COMMITTED | REPEATABLE READ | SERIALIZABLE}
    READ WRITE | READ ONLY
-   [ NOT ] DEFERRABLE
+   [NOT] DEFERRABLE
 ```
 
 ## <a id="section3"></a>Description 
 
-`BEGIN` initiates a transaction block, that is, all statements after a `BEGIN` command will be run in a single transaction until an explicit `COMMIT` or `ROLLBACK` is given. By default \(without `BEGIN`\), Greenplum Database runs transactions in autocommit mode, that is, each statement is run in its own transaction and a commit is implicitly performed at the end of the statement \(if execution was successful, otherwise a rollback is done\).
+`BEGIN` initiates a transaction block, that is, all statements after a `BEGIN` command will be run in a single transaction until an explicit [COMMIT](COMMIT.html) or [ROLLBACK](ROLLBACK.html) is given. By default \(without `BEGIN`\), Greenplum Database runs transactions in "autocommit" mode, that is, each statement is run in its own transaction and a commit is implicitly performed at the end of the statement \(if execution was successful, otherwise a rollback is done\).
 
 Statements are run more quickly in a transaction block, because transaction start/commit requires significant CPU and disk activity. Execution of multiple statements inside a transaction is also useful to ensure consistency when making several related changes: other sessions will be unable to see the intermediate states wherein not all the related updates have been done.
 
@@ -30,20 +28,7 @@ WORK
 TRANSACTION
 :   Optional key words. They have no effect.
 
-SERIALIZABLE
-READ COMMITTED
-READ UNCOMMITTED
-:   The SQL standard defines four transaction isolation levels: `READ UNCOMMITTED`, `READ COMMITTED`, `REPEATABLE READ`, and `SERIALIZABLE`.
-
-:   `READ UNCOMMITTED` allows transactions to see changes made by uncomitted concurrent transactions. This is not possible in Greenplum Database, so `READ UNCOMMITTED` is treated the same as `READ COMMITTED`.
-
-:   `READ COMMITTED`, the default isolation level in Greenplum Database, guarantees that a statement can only see rows committed before it began. The same statement run twice in a transaction can produce different results if another concurrent transaction commits after the statement is run the first time.
-
-:   The `REPEATABLE READ` isolation level guarantees that a transaction can only see rows committed before it began. `REPEATABLE READ` is the strictest transaction isolation level Greenplum Database supports. Applications that use the `REPEATABLE READ` isolation level must be prepared to retry transactions due to serialization failures.
-
-:   The `SERIALIZABLE` transaction isolation level guarantees that running multiple concurrent transactions produces the same effects as running the same transactions one at a time. If you specify `SERIALIZABLE`, Greenplum Database falls back to `REPEATABLE READ`.
-
-:   Specifying `DEFERRABLE` has no effect in Greenplum Database, but the syntax is supported for compatibility with PostgreSQL. A transaction can only be deferred if it is `READ ONLY` and `SERIALIZABLE`, and Greenplum Database does not support `SERIALIAZABLE` transactions.
+Refer to [SET TRANSACTION](SET_TRANSACTION.html) for information on the meaning of the other parameters to this statement.
 
 ## <a id="section5"></a>Notes 
 
@@ -51,7 +36,9 @@ READ UNCOMMITTED
 
 Use [COMMIT](COMMIT.html) or [ROLLBACK](ROLLBACK.html) to terminate a transaction block.
 
-Issuing `BEGIN` when already inside a transaction block will provoke a warning message. The state of the transaction is not affected. To nest transactions within a transaction block, use savepoints \(see `SAVEPOINT`\).
+Issuing `BEGIN` when already inside a transaction block will provoke a warning message. The state of the transaction is not affected. To nest transactions within a transaction block, use savepoints \(see [SAVEPOINT](SAVEPOINT.html)\).
+
+For reasons of backwards compatibility, the commas between successive transaction\_modes can be omitted.
 
 ## <a id="section6"></a>Examples 
 
@@ -61,23 +48,17 @@ To begin a transaction block:
 BEGIN;
 ```
 
-To begin a transaction block with the repeatable read isolation level:
-
-```
-BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
-```
-
 ## <a id="section7"></a>Compatibility 
 
-`BEGIN` is a Greenplum Database language extension. It is equivalent to the SQL-standard command [START TRANSACTION](START_TRANSACTION.html).
+`BEGIN` is a Greenplum Database language extension. It is equivalent to the SQL-standard command [START TRANSACTION](START_TRANSACTION.html), whose reference page contains additional compatibility information.
 
-`DEFERRABLE` transaction\_mode is a Greenplum Database language extension.
+The `DEFERRABLE` transaction\_mode is a Greenplum Database language extension.
 
 Incidentally, the `BEGIN` key word is used for a different purpose in embedded SQL. You are advised to be careful about the transaction semantics when porting database applications.
 
 ## <a id="section8"></a>See Also 
 
-[COMMIT](COMMIT.html), [ROLLBACK](ROLLBACK.html), [START TRANSACTION](START_TRANSACTION.html), [SAVEPOINT](SAVEPOINT.html)
+[COMMIT](COMMIT.html), [ROLLBACK](ROLLBACK.html), [SAVEPOINT](SAVEPOINT.html), [START TRANSACTION](START_TRANSACTION.html)
 
 **Parent topic:** [SQL Commands](../sql_commands/sql_ref.html)
 

--- a/gpdb-doc/markdown/ref_guide/sql_commands/COMMIT.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/COMMIT.html.md
@@ -5,7 +5,7 @@ Commits the current transaction.
 ## <a id="section2"></a>Synopsis 
 
 ``` {#sql_command_synopsis}
-COMMIT [WORK | TRANSACTION]
+COMMIT [WORK | TRANSACTION] [AND [NO] CHAIN]
 ```
 
 ## <a id="section3"></a>Description 
@@ -18,11 +18,14 @@ WORK
 TRANSACTION
 :   Optional key words. They have no effect.
 
+AND CHAIN
+:   If `AND CHAIN` is specified, a new transaction is immediately started with the same transaction characteristics \(see [SET TRANSACTION](SET_TRANSACTION.html)\) as the just finished one. Otherwise, no new transaction is started.
+
 ## <a id="section5"></a>Notes 
 
 Use [ROLLBACK](ROLLBACK.html) to prematurely end a transaction.
 
-Issuing `COMMIT` when not inside a transaction does no harm, but it will provoke a warning message.
+Issuing `COMMIT` when not inside a transaction does no harm, but it will provoke a warning message. `COMMIT AND CHAIN` when not inside a transaction is an error.
 
 ## <a id="section6"></a>Examples 
 
@@ -34,11 +37,11 @@ COMMIT;
 
 ## <a id="section7"></a>Compatibility 
 
-The SQL standard only specifies the two forms `COMMIT` and `COMMIT WORK`. Otherwise, this command is fully conforming.
+The command `COMMIT` conforms to the SQL standard. The form `COMMIT TRANSACTION` is a Greenplum Database extension.
 
 ## <a id="section8"></a>See Also 
 
-[BEGIN](BEGIN.html), [END](END.html), [START TRANSACTION](START_TRANSACTION.html), [ROLLBACK](ROLLBACK.html)
+[BEGIN](BEGIN.html), [END](END.html), [ROLLBACK](ROLLBACK.html), [START TRANSACTION](START_TRANSACTION.html)
 
 **Parent topic:** [SQL Commands](../sql_commands/sql_ref.html)
 

--- a/gpdb-doc/markdown/ref_guide/sql_commands/END.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/END.html.md
@@ -5,7 +5,7 @@ Commits the current transaction.
 ## <a id="section2"></a>Synopsis 
 
 ``` {#sql_command_synopsis}
-END [WORK | TRANSACTION]
+END [WORK | TRANSACTION] [AND [NO] CHAIN]
 ```
 
 ## <a id="section3"></a>Description 
@@ -18,9 +18,18 @@ WORK
 TRANSACTION
 :   Optional keywords. They have no effect.
 
+AND CHAIN
+:   If `AND CHAIN` is specified, a new transaction is immediately started with the same transaction characteristics \(see [SET TRANSACTION](SET_TRANSACTION.html)\) as the just finished one. Otherwise, no new transaction is started.
+
+## <a id="section4a"></a>Notes
+
+Use [ROLLBACK](ROLLBACK.html) to terminate a transaction.
+
+Issuing `END` when not inside a transaction does no harm, but it will provoke a warning message.
+
 ## <a id="section5"></a>Examples 
 
-Commit the current transaction:
+To commit the current transaction and make all changes permanent:
 
 ```
 END;
@@ -32,7 +41,7 @@ END;
 
 ## <a id="section7"></a>See Also 
 
-[BEGIN](BEGIN.html), [ROLLBACK](ROLLBACK.html), [COMMIT](COMMIT.html)
+[BEGIN](BEGIN.html), [COMMIT](COMMIT.html), [ROLLBACK](ROLLBACK.html)
 
 **Parent topic:** [SQL Commands](../sql_commands/sql_ref.html)
 

--- a/gpdb-doc/markdown/ref_guide/sql_commands/ROLLBACK.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/ROLLBACK.html.md
@@ -5,7 +5,7 @@ Stops the current transaction.
 ## <a id="section2"></a>Synopsis 
 
 ``` {#sql_command_synopsis}
-ROLLBACK [WORK | TRANSACTION]
+ROLLBACK [WORK | TRANSACTION] [AND [NO] CHAIN]
 ```
 
 ## <a id="section3"></a>Description 
@@ -18,11 +18,14 @@ WORK
 TRANSACTION
 :   Optional key words. They have no effect.
 
+AND CHAIN
+:   If `AND CHAIN` is specified, a new transaction is immediately started with the same transaction characteristics \(see [SET TRANSACTION](SET_TRANSACTION.html)\) as the just finished one. Otherwise, no new transaction is started.
+
 ## <a id="section5"></a>Notes 
 
-Use `COMMIT` to successfully end the current transaction.
+Use [COMMIT](COMMIT.html) to successfully end the current transaction.
 
-Issuing `ROLLBACK` when not inside a transaction does no harm, but it will provoke a warning message.
+Issuing `ROLLBACK` when not inside a transaction block emits a warning and otherwise has no effect. `ROLLBACK AND CHAIN` outside of a transaction block is an error.
 
 ## <a id="section6"></a>Examples 
 
@@ -34,11 +37,11 @@ ROLLBACK;
 
 ## <a id="section7"></a>Compatibility 
 
-The SQL standard only specifies the two forms `ROLLBACK` and `ROLLBACK WORK`. Otherwise, this command is fully conforming.
+The command `ROLLBACK` conforms to the SQL standard. The form `ROLLBACK TRANSACTION` is a Greenplum Database extension.
 
 ## <a id="section8"></a>See Also 
 
-[BEGIN](BEGIN.html), [COMMIT](COMMIT.html), [SAVEPOINT](SAVEPOINT.html), [ROLLBACK TO SAVEPOINT](ROLLBACK_TO_SAVEPOINT.html)
+[BEGIN](BEGIN.html), [COMMIT](COMMIT.html), [ROLLBACK TO SAVEPOINT](ROLLBACK_TO_SAVEPOINT.html), [SAVEPOINT](SAVEPOINT.html)
 
 **Parent topic:** [SQL Commands](../sql_commands/sql_ref.html)
 

--- a/gpdb-doc/markdown/ref_guide/sql_commands/SET_TRANSACTION.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/SET_TRANSACTION.html.md
@@ -5,28 +5,26 @@ Sets the characteristics of the current transaction.
 ## <a id="section2"></a>Synopsis 
 
 ``` {#sql_command_synopsis}
-SET TRANSACTION [<transaction_mode>] [READ ONLY | READ WRITE]
-
+SET TRANSACTION <transaction_mode> [, ...]
 SET TRANSACTION SNAPSHOT <snapshot_id>
-
-SET SESSION CHARACTERISTICS AS TRANSACTION <transaction_mode> 
+SET SESSION CHARACTERISTICS AS TRANSACTION <transaction_mode> [, ...] 
      [READ ONLY | READ WRITE]
      [NOT] DEFERRABLE
-```
 
-where transaction\_mode is one of:
+where <transaction_mode> is one of:
 
-```
-   ISOLATION LEVEL {SERIALIZABLE | REPEATABLE READ | READ COMMITTED | READ UNCOMMITTED}
-```
+    ISOLATION LEVEL {SERIALIZABLE | REPEATABLE READ | READ COMMITTED | READ UNCOMMITTED}
+    READ WRITE | READ ONLY
+    [NOT] DEFERRABLE
 
-and snapshot_id is the id of the existing transaction whose snapshot you want this transaction to run with.
+and <snapshot_id> is the id of the existing transaction whose snapshot you want this transaction to run with.
+```
 
 ## <a id="section3"></a>Description 
 
-The `SET TRANSACTION` command sets the characteristics of the current transaction. It has no effect on any subsequent transactions.
+The `SET TRANSACTION` command sets the characteristics of the current transaction. It has no effect on any subsequent transactions. `SET SESSION CHARACTERISTICS` sets the default transaction characteristics for subsequent transactions of a session. These defaults can be overridden by `SET TRANSACTION` for an individual transaction.
 
-The available transaction characteristics are the transaction isolation level, the transaction access mode \(read/write or read-only\), and the deferrable mode.
+The available transaction characteristics are the transaction isolation level, the transaction access mode \(read/write or read-only\), and the deferrable mode. In addition, a snapshot can be selected, though only for the current transaction, not as a session default.
 
 **Note:** Deferrable transactions require the transaction to be serializable. Greenplum Database does not support serializable transactions, so including the `DEFERRABLE` clause has no effect.
 
@@ -35,75 +33,59 @@ The isolation level of a transaction determines what data the transaction can se
 -   **READ COMMITTED** — A statement can only see rows committed before it began. This is the default.
 -   **REPEATABLE READ** — All statements in the current transaction can only see rows committed before the first query or data-modification statement run in the transaction.
 
-The SQL standard defines two additional levels, `READ UNCOMMITTED` and `SERIALIZABLE`. In Greenplum Database `READ UNCOMMITTED` is treated as `READ COMMITTED`. If you specify `SERIALIZABLE`, Greenplum Database falls back to `REPEATABLE READ`.
+The SQL standard defines two additional levels, `READ UNCOMMITTED` and `SERIALIZABLE`. In Greenplum Database, `READ UNCOMMITTED` is treated as `READ COMMITTED`. If you specify `SERIALIZABLE`, Greenplum Database falls back to `REPEATABLE READ`.
 
 The transaction isolation level cannot be changed after the first query or data-modification statement \(`SELECT`, `INSERT`, `DELETE`, `UPDATE`, `FETCH`, or `COPY`\) of a transaction has been run.
 
-The transaction access mode determines whether the transaction is read/write or read-only. Read/write is the default. When a transaction is read-only, the following SQL commands are disallowed: `INSERT`, `UPDATE`, `DELETE`, and `COPY FROM` if the table they would write to is not a temporary table; all `CREATE`, `ALTER`, and `DROP` commands; `GRANT`, `REVOKE`, `TRUNCATE`; and `EXPLAIN ANALYZE` and `EXECUTE` if the command they would run is among those listed. This is a high-level notion of read-only that does not prevent all writes to disk.
+The transaction access mode determines whether the transaction is read/write or read-only. Read/write is the default. When a transaction is read-only, the following SQL commands are disallowed: `INSERT`, `UPDATE`, `DELETE`, and `COPY FROM` if the table they would write to is not a temporary table; all `CREATE`, `ALTER`, and `DROP` commands; `COMMENT`, `GRANT`, `REVOKE`, `TRUNCATE`; and `EXPLAIN ANALYZE` and `EXECUTE` if the command they would run is among those listed. This is a high-level notion of read-only that does not prevent all writes to disk.
 
-The `DEFERRABLE` transaction property has no effect unless the transaction is also `SERIALIZABLE` and `READ ONLY`. When all of these properties are set on a transaction, the transaction may block when first acquiring its snapshot, after which it is able to run without the normal overhead of a `SERIALIZABLE` transaction and without any risk of contributing to or being cancelled by a serialization failure. Because Greenplum Database does not support serializable transactions, the `DEFERRABLE` transaction property has no effect in Greenplum Database.
+The `DEFERRABLE` transaction property has no effect unless the transaction is also `SERIALIZABLE` and `READ ONLY`. When all of these properties are set on a transaction, the transaction may block when first acquiring its snapshot, after which it is able to run without the normal overhead of a `SERIALIZABLE` transaction and without any risk of contributing to or being cancelled by a serialization failure. This mode is well suited for long-running reports or backups. *Because Greenplum Database does not support serializable transactions, the `DEFERRABLE` transaction property has no effect in Greenplum Database.*
 
-## <a id="section4"></a>Parameters 
-
-SNAPSHOT
-:   Allows a new transaction to run with the same snapshot as an existing transaction. You pass the id of the existing transaction to the `SET TRANSACTION SNAPSHOT` command. You must first call the `pg_export_snapshot` function to obtain the existing transaction's id.  
-
-SESSION CHARACTERISTICS
-:   Sets the default transaction characteristics for subsequent transactions of a session.
-
-READ UNCOMMITTED
-READ COMMITTED
-REPEATABLE READ
-SERIALIZABLE
-:   The SQL standard defines four transaction isolation levels: `READ UNCOMMITTED`, `READ COMMITTED`, `REPEATABLE READ`, and `SERIALIZABLE`.
-
-:   `READ UNCOMMITTED` allows transactions to see changes made by uncomitted concurrent transactions. This is not possible in Greenplum Database, so `READ UNCOMMITTED` is treated the same as `READ COMMITTED`.
-
-:   `READ COMMITTED`, the default isolation level in Greenplum Database, guarantees that a statement can only see rows committed before it began. The same statement run twice in a transaction can produce different results if another concurrent transaction commits after the statement is run the first time.
-
-:   The `REPEATABLE READ` isolation level guarantees that a transaction can only see rows committed before it began. `REPEATABLE READ` is the strictest transaction isolation level Greenplum Database supports. Applications that use the `REPEATABLE READ` isolation level must be prepared to retry transactions due to serialization failures.
-
-:   The `SERIALIZABLE` transaction isolation level guarantees that all statements of the current transaction can only see rows committed before the first query or data-modification statement was run in this transaction. If a pattern of reads and writes among concurrent serializable transactions would create a situation which could not have occurred for any serial \(one-at-a-time\) execution of those transactions, one of the transactions will be rolled back with a `serialization_failure` error. Greenplum Database does not fully support `SERIALIZABLE` as defined by the standard, so if you specify `SERIALIZABLE`, Greenplum Database falls back to `REPEATABLE READ`. See [Compatibility](#section7) for more information about transaction serializability in Greenplum Database.
-
-READ WRITE
-READ ONLY
-:   Determines whether the transaction is read/write or read-only. Read/write is the default. When a transaction is read-only, the following SQL commands are disallowed: `INSERT`, `UPDATE`, `DELETE`, and `COPY FROM` if the table they would write to is not a temporary table; all `CREATE`, `ALTER`, and `DROP` commands; `GRANT`, `REVOKE`, `TRUNCATE`; and `EXPLAIN ANALYZE` and `EXECUTE` if the command they would run is among those listed.
-
-\[NOT\] DEFERRABLE
-:   The `DEFERRABLE` transaction property has no effect in Greenplum Database because `SERIALIZABLE` transactions are not supported. If `DEFERRABLE` is specified and the transaction is also `SERIALIZABLE` and `READ ONLY`, the transaction may block when first acquiring its snapshot, after which it is able to run without the normal overhead of a `SERIALIZABLE` transaction and without any risk of contributing to or being cancelled by a serialization failure. This mode is well suited for long-running reports or backups.
+The `SET TRANSACTION SNAPSHOT` command allows a new transaction to run with the same snapshot as an existing transaction. The pre-existing transaction must have exported its snapshot with the `pg_export_snapshot()` function. That function returns a snapshot identifier, which must be given to `SET TRANSACTION SNAPSHOT` to specify which snapshot is to be imported. The identifier must be written as a string literal in this command, for example `'000003A1-1'`. `SET TRANSACTION SNAPSHOT` can only be executed at the start of a transaction, before the first query or data-modification statement \(`SELECT`, `INSERT`, `DELETE`, `UPDATE`, `FETCH`, or `COPY`\) of the transaction. Furthermore, the transaction must already be set to `SERIALIZABLE` or `REPEATABLE READ` isolation level \(otherwise, the snapshot would be discarded immediately, since `READ COMMITTED` mode takes a new snapshot for each command\). If the importing transaction uses `SERIALIZABLE` isolation level, then the transaction that exported the snapshot must also use that isolation level. Also, a non-read-only serializable transaction cannot import a snapshot from a read-only transaction.
 
 ## <a id="section5"></a>Notes 
 
-If `SET TRANSACTION` is run without a prior `START TRANSACTION` or `BEGIN`, a warning is issued and the command has no effect.
+If `SET TRANSACTION` is run without a prior [START TRANSACTION](START_TRANSACTION.html) or [BEGIN](BEGIN.html), it emits a warning and otherwise has no effect.
 
-It is possible to dispense with `SET TRANSACTION` by instead specifying the desired transaction modes in `BEGIN` or `START TRANSACTION`.
+It is possible to dispense with `SET TRANSACTION` by instead specifying the desired transaction\_modes in `BEGIN` or `START TRANSACTION`. But that option is not available for `SET TRANSACTION SNAPSHOT`.
 
-The session default transaction modes can also be set by setting the configuration parameters [default\_transaction\_isolation](../config_params/guc-list.html), [default\_transaction\_read\_only](../config_params/guc-list.html), and [default\_transaction\_deferrable](../config_params/guc-list.html).
+The session default transaction modes can also be set or examined via the configuration parameters [default\_transaction\_isolation](../config_params/guc-list.html#default_transaction_isolation), [default\_transaction\_read\_only](../config_params/guc-list.html#default_transaction_read_only), and [default\_transaction\_deferrable](../config_params/guc-list.html#default_transaction_deferrable). \(In fact `SET SESSION CHARACTERISTICS` is just a verbose equivalent for setting these variables with `SET`.\) This means the defaults can be set in the configuration file, via `ALTER DATABASE`, etc.
+
+The current transaction's modes can similarly be set or examined via the configuration parameters [transaction\_isolation](../config_params/guc-list.html#transaction_isolation), [transaction\_read\_only](../config_params/guc-list.html#transaction_read_only), and [transaction\_deferrable](../config_params/guc-list.html#transaction_deferrable). Setting one of these parameters acts the same as the corresponding `SET TRANSACTION` option, with the same restrictions on when it can be done. However, these parameters cannot be set in the configuration file, or from any source other than live SQL.
 
 ## <a id="section6"></a>Examples 
 
-Set the transaction isolation level for the current transaction:
+To begin a new transaction with the same snapshot as an already existing transaction, first export the snapshot from the existing transaction. That will return the snapshot identifier, for example:
 
 ```
-BEGIN;
-SET TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+SELECT pg_export_snapshot();
+ pg_export_snapshot
+---------------------
+ 00000003-0000001B-1
+(1 row)
+```
+
+Then give the snapshot identifier in a `SET TRANSACTION SNAPSHOT` command at the beginning of the newly opened transaction:
+
+```
+BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+SET TRANSACTION SNAPSHOT '00000003-0000001B-1';
 ```
 
 ## <a id="section7"></a>Compatibility 
 
-Both commands are defined in the SQL standard. `SERIALIZABLE` is the default transaction isolation level in the standard. In Greenplum Database the default is `READ COMMITTED`. Due to lack of predicate locking, Greenplum Database does not fully support the `SERIALIZABLE` level, so it falls back to the `REPEATABLE READ` level when `SERIAL` is specified. Essentially, a predicate-locking system prevents phantom reads by restricting what is written, whereas a multi-version concurrency control model \(MVCC\) as used in Greenplum Database prevents them by restricting what is read.
+These commands are defined in the SQL standard, except for the `DEFERRABLE` transaction mode and the `SET TRANSACTION SNAPSHOT` form, which are Greenplum Database extensions.
 
-PostgreSQL provides a true serializable isolation level, called serializable snapshot isolation \(SSI\), which monitors concurrent transactions and rolls back transactions that could introduce serialization anomalies. Greenplum Database does not implement this isolation mode.
+`SERIALIZABLE` is the default transaction isolation level in the standard. In Greenplum Database, the default is `READ COMMITTED`. Due to lack of predicate locking, Greenplum Database does not fully support the `SERIALIZABLE` level, so it falls back to the `REPEATABLE READ` level when `SERIALIZABLE` is specified. Essentially, a predicate-locking system prevents phantom reads by restricting what is written, whereas a multi-version concurrency control model \(MVCC\) as used in Greenplum Database prevents them by restricting what is read.
 
 In the SQL standard, there is one other transaction characteristic that can be set with these commands: the size of the diagnostics area. This concept is specific to embedded SQL, and therefore is not implemented in the Greenplum Database server.
-
-The `DEFERRABLE` transaction mode is a Greenplum Database language extension.
 
 The SQL standard requires commas between successive transaction\_modes, but for historical reasons Greenplum Database allows the commas to be omitted.
 
 ## <a id="section8"></a>See Also 
 
-[BEGIN](BEGIN.html), [LOCK](LOCK.html)
+[BEGIN](BEGIN.html)
 
 **Parent topic:** [SQL Commands](../sql_commands/sql_ref.html)
 

--- a/gpdb-doc/markdown/ref_guide/sql_commands/START_TRANSACTION.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/START_TRANSACTION.html.md
@@ -5,50 +5,29 @@ Starts a transaction block.
 ## <a id="section2"></a>Synopsis 
 
 ``` {#sql_command_synopsis}
-START TRANSACTION [<transaction_mode>] [READ WRITE | READ ONLY]
-```
+START TRANSACTION [<transaction_mode>] [, ...]
 
-where transaction\_mode is:
+where <transaction_mode> is one of:
 
-```
-   ISOLATION LEVEL {SERIALIZABLE | READ COMMITTED | READ UNCOMMITTED}
+   ISOLATION LEVEL {SERIALIZABLE | REPEATABLE READ | READ COMMITTED | READ UNCOMMITTED}
+   READ WRITE | READ ONLY
+   [NOT] DEFERRABLE
 ```
 
 ## <a id="section3"></a>Description 
 
-`START TRANSACTION` begins a new transaction block. If the isolation level or read/write mode is specified, the new transaction has those characteristics, as if [SET TRANSACTION](SET_TRANSACTION.html) was run. This is the same as the `BEGIN` command.
+`START TRANSACTION` begins a new transaction block. If the isolation level, read/write mode, or deferrable mode is specified, the new transaction has those characteristics, as if [SET TRANSACTION](SET_TRANSACTION.html) was run. This is the same as the [BEGIN](BEGIN.html) command.
 
 ## <a id="section4"></a>Parameters 
 
-READ UNCOMMITTED
-READ COMMITTED
-REPEATABLE READ
-SERIALIZABLE
-:   The SQL standard defines four transaction isolation levels: `READ UNCOMMITTED`, `READ COMMITTED`, `REPEATABLE READ`, and `SERIALIZABLE`.
+Refer to [SET TRANSACTION](SET_TRANSACTION.html) for information on the meaning of the parameters to this statement.
 
-:   `READ UNCOMMITTED` allows transactions to see changes made by uncomitted concurrent transactions. This is not possible in Greenplum Database, so `READ UNCOMMITTED` is treated the same as `READ COMMITTED`.
-
-:   `READ COMMITTED`, the default isolation level in Greenplum Database, guarantees that a statement can only see rows committed before it began. The same statement run twice in a transaction can produce different results if another concurrent transaction commits after the statement is run the first time.
-
-:   The `REPEATABLE READ` isolation level guarantees that a transaction can only see rows committed before it began. `REPEATABLE READ` is the strictest transaction isolation level Greenplum Database supports. Applications that use the `REPEATABLE READ` isolation level must be prepared to retry transactions due to serialization failures.
-
-:   The `SERIALIZABLE` transaction isolation level guarantees that running multiple concurrent transactions produces the same effects as running the same transactions one at a time. If you specify `SERIALIZABLE`, Greenplum Database falls back to `REPEATABLE READ`.
-
-READ WRITE
-READ ONLY
-:   Determines whether the transaction is read/write or read-only. Read/write is the default. When a transaction is read-only, the following SQL commands are disallowed: `INSERT`, `UPDATE`, `DELETE`, and `COPY FROM` if the table they would write to is not a temporary table; all `CREATE`, `ALTER`, and `DROP` commands; `GRANT`, `REVOKE`, `TRUNCATE`; and `EXPLAIN ANALYZE` and `EXECUTE` if the command they would run is among those listed.
-
-## <a id="section5"></a>Examples 
-
-To begin a transaction block:
-
-```
-START TRANSACTION;
-```
 
 ## <a id="section6"></a>Compatibility 
 
-In the standard, it is not necessary to issue `START TRANSACTION` to start a transaction block: any SQL command implicitly begins a block. Greenplum Database behavior can be seen as implicitly issuing a `COMMIT` after each command that does not follow `START TRANSACTION` \(or `BEGIN`\), and it is therefore often called 'autocommit'. Other relational database systems may offer an autocommit feature as a convenience.
+In the standard, it is not necessary to issue `START TRANSACTION` to start a transaction block: any SQL command implicitly begins a block. Greenplum Database's behavior can be seen as implicitly issuing a `COMMIT` after each command that does not follow `START TRANSACTION` \(or `BEGIN`\), and it is therefore often called 'autocommit'. Other relational database systems may offer an autocommit feature as a convenience.
+
+The `DEFERRABLE` transaction\_mode is a Greenplum Database language extension.
 
 The SQL standard requires commas between successive transaction\_modes, but for historical reasons Greenplum Database allows the commas to be omitted.
 
@@ -56,7 +35,7 @@ See also the compatibility section of [SET TRANSACTION](SET_TRANSACTION.html).
 
 ## <a id="section7"></a>See Also 
 
-[BEGIN](BEGIN.html),
+[BEGIN](BEGIN.html), [COMMIT](COMMIT.html), [ROLLBACK](ROLLBACK.html), [SAVEPOINT](SAVEPOINT.html), [SET TRANSACTION](SET_TRANSACTION.html)
 
 **Parent topic:** [SQL Commands](../sql_commands/sql_ref.html)
 


### PR DESCRIPTION
  SET TRANSACTION and START TRANSACTION commands

this PR updates the listed sql command reference pages to the postgres v12 content.  in some cases i changed a parameter option name to align with pg.  in cases where there was greenplum-specific info in the original reference page, (like greenplum doesn't support SERIALIZABLE transaction isolation level), i retained the info.

tbd if greenplum supports AND CHAIN.

doc review site link for ABORT (behind vpn), can navigate to others from there:  https://docs-staging.vmware.com/en/draft/VMware-Tanzu-Greenplum/lisa-sqlref-abort/greenplum-database/GUID-ref_guide-sql_commands-ABORT.html
