### PR TITLE
[ORCA] Allow empty target list

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
@@ -2708,7 +2708,6 @@ CTranslatorQueryToDXL::CreateDXLSetOpFromColumns(
 	CDXLNodeArray *children_dxlnodes, BOOL is_cast_across_input,
 	BOOL keep_res_junked) const
 {
-	GPOS_ASSERT(nullptr != output_target_list);
 	GPOS_ASSERT(nullptr != output_colids);
 	GPOS_ASSERT(nullptr != input_colids);
 	GPOS_ASSERT(nullptr != children_dxlnodes);
@@ -2826,7 +2825,6 @@ CTranslatorQueryToDXL::SetOpNeedsCast(List *target_list,
 									  IMdIdArray *input_col_mdids)
 {
 	GPOS_ASSERT(nullptr != input_col_mdids);
-	GPOS_ASSERT(nullptr != target_list);
 	GPOS_ASSERT(
 		input_col_mdids->Size() <=
 		gpdb::ListLength(target_list));	 // there may be resjunked columns
@@ -2867,39 +2865,6 @@ CTranslatorQueryToDXL::TranslateSetOpChild(Node *child_node,
 {
 	GPOS_ASSERT(nullptr != colids);
 	GPOS_ASSERT(nullptr != input_col_mdids);
-
-	// GPDB_12_MERGE_FIXME: We have to fallback here because otherwise we trip
-	// the following assert in ORCA:
-	//
-	// INFO:  GPORCA failed to produce a plan, falling back to planner
-	// DETAIL:  CKeyCollection.cpp:84: Failed assertion: __null != colref_array && 0 < colref_array->Size()
-	// Stack trace:
-	// 1    0x000055c239243b8a gpos::CException::Raise + 278
-	// 2    0x000055c2393ab075 gpopt::CKeyCollection::CKeyCollection + 221
-	// 3    0x000055c239449ab6 gpopt::CLogicalSetOp::DeriveKeyCollection + 98
-	// 4    0x000055c2393a5a67 gpopt::CDrvdPropRelational::DeriveKeyCollection + 135
-	// 5    0x000055c2393a4937 gpopt::CDrvdPropRelational::Derive + 197
-	// 6    0x000055c239405d9f gpopt::CExpression::PdpDerive + 703
-	// 7    0x000055c2394d1e14 gpopt::CMemo::PgroupInsert + 512
-	// 8    0x000055c2393dd734 gpopt::CEngine::PgroupInsert + 632
-	// 9    0x000055c2393dcd73 gpopt::CEngine::InitLogicalExpression + 225
-	// 10   0x000055c2393dd106 gpopt::CEngine::Init + 884
-	// 11   0x000055c23949da9f gpopt::COptimizer::PexprOptimize + 103
-	// 12   0x000055c23949d3d8 gpopt::COptimizer::PdxlnOptimize + 1414
-	// 13   0x000055c23960e55e COptTasks::OptimizeTask + 1530
-	// 14   0x000055c2392572b6 gpos::CTask::Execute + 196
-	// 15   0x000055c239259dbf gpos::CWorker::Execute + 191
-	// 16   0x000055c2392556b5 gpos::CAutoTaskProxy::Execute + 221
-	// 17   0x000055c23925c0c0 gpos_exec + 876
-	//
-	// Currently there are a lot of asserts on NULL != target_list in the
-	// translator, but most of them are unnecessary. We should instead fix ORCA
-	// to handle empty target list.
-	if (NIL == target_list)
-	{
-		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature,
-				   GPOS_WSZ_LIT("Empty target list"));
-	}
 
 	if (IsA(child_node, RangeTblRef))
 	{

--- a/src/backend/gpopt/translate/CTranslatorUtils.cpp
+++ b/src/backend/gpopt/translate/CTranslatorUtils.cpp
@@ -1146,7 +1146,6 @@ CTranslatorUtils::GenerateColIds(
 		is_outer_ref,  // array of flags indicating if input columns are outer references
 	CIdGenerator *colid_generator)
 {
-	GPOS_ASSERT(nullptr != target_list);
 	GPOS_ASSERT(nullptr != input_mdid_arr);
 	GPOS_ASSERT(nullptr != input_colids);
 	GPOS_ASSERT(nullptr != is_outer_ref);
@@ -1206,7 +1205,10 @@ CTranslatorUtils::FixUnknownTypeConstant(Query *old_query,
 										 List *output_target_list)
 {
 	GPOS_ASSERT(nullptr != old_query);
-	GPOS_ASSERT(nullptr != output_target_list);
+	if (nullptr == output_target_list)
+	{
+		return old_query;
+	}
 
 	Query *new_query = nullptr;
 
@@ -1346,8 +1348,6 @@ ULongPtrArray *
 CTranslatorUtils::GetPosInTargetList(CMemoryPool *mp, List *target_list,
 									 BOOL keep_res_junked)
 {
-	GPOS_ASSERT(nullptr != target_list);
-
 	ListCell *target_entry_cell = nullptr;
 	ULongPtrArray *positions = GPOS_NEW(mp) ULongPtrArray(mp);
 	ULONG ul = 0;

--- a/src/backend/gporca/libgpopt/src/base/CDistributionSpecHashed.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CDistributionSpecHashed.cpp
@@ -48,6 +48,7 @@ CDistributionSpecHashed::CDistributionSpecHashed(CExpressionArray *pdrgpexpr,
 	  m_equiv_hash_exprs(nullptr)
 {
 	GPOS_ASSERT(nullptr != pdrgpexpr);
+	GPOS_ASSERT(0 < pdrgpexpr->Size());
 	if (GPOS_FTRACE(EopttraceConsiderOpfamiliesForDistribution) &&
 		nullptr == opfamilies)
 	{

--- a/src/backend/gporca/libgpopt/src/base/CDistributionSpecHashed.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CDistributionSpecHashed.cpp
@@ -48,7 +48,6 @@ CDistributionSpecHashed::CDistributionSpecHashed(CExpressionArray *pdrgpexpr,
 	  m_equiv_hash_exprs(nullptr)
 {
 	GPOS_ASSERT(nullptr != pdrgpexpr);
-	GPOS_ASSERT(0 < pdrgpexpr->Size());
 	if (GPOS_FTRACE(EopttraceConsiderOpfamiliesForDistribution) &&
 		nullptr == opfamilies)
 	{

--- a/src/backend/gporca/libgpopt/src/base/CKeyCollection.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CKeyCollection.cpp
@@ -67,7 +67,7 @@ CKeyCollection::CKeyCollection(CMemoryPool *mp, CColRefArray *colref_array)
 	: m_pdrgpcrs(nullptr)
 {
 	GPOS_ASSERT(nullptr != mp);
-	GPOS_ASSERT(nullptr != colref_array && 0 < colref_array->Size());
+	GPOS_ASSERT(nullptr != colref_array);
 
 	m_pdrgpcrs = GPOS_NEW(mp) CColRefSetArray(mp);
 

--- a/src/backend/gporca/libgpopt/src/base/CUtils.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CUtils.cpp
@@ -3708,7 +3708,6 @@ CUtils::PexprConjINDFCond(CMemoryPool *mp, CColRef2dArray *pdrgpdrgpcrInput)
 	// assemble the new scalar condition
 	CExpression *pexprScCond = nullptr;
 	const ULONG length = (*pdrgpdrgpcrInput)[0]->Size();
-	GPOS_ASSERT(0 != length);
 	GPOS_ASSERT(length == (*pdrgpdrgpcrInput)[1]->Size());
 
 	CExpressionArray *pdrgpexprInput =

--- a/src/backend/gporca/libgpopt/src/xforms/CXformDifference2LeftAntiSemiJoin.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformDifference2LeftAntiSemiJoin.cpp
@@ -83,18 +83,26 @@ CXformDifference2LeftAntiSemiJoin::Transform(CXformContext *pxfctxt,
 		GPOS_NEW(mp) CExpression(mp, GPOS_NEW(mp) CLogicalLeftAntiSemiJoin(mp),
 								 pexprLeftChild, pexprRightChild, pexprScCond);
 
-	// assemble the aggregate operator
-	pdrgpcrOutput->AddRef();
+	if (pdrgpcrOutput->Size() > 0)
+	{
+		// assemble the aggregate operator
+		pdrgpcrOutput->AddRef();
 
-	CExpression *pexprProjList =
-		GPOS_NEW(mp) CExpression(mp, GPOS_NEW(mp) CScalarProjectList(mp),
-								 GPOS_NEW(mp) CExpressionArray(mp));
+		CExpression *pexprProjList =
+			GPOS_NEW(mp) CExpression(mp, GPOS_NEW(mp) CScalarProjectList(mp),
+									 GPOS_NEW(mp) CExpressionArray(mp));
 
-	CExpression *pexprAgg = CUtils::PexprLogicalGbAggGlobal(
-		mp, pdrgpcrOutput, pexprLASJ, pexprProjList);
+		CExpression *pexprAgg = CUtils::PexprLogicalGbAggGlobal(
+			mp, pdrgpcrOutput, pexprLASJ, pexprProjList);
 
-	// add alternative to results
-	pxfres->Add(pexprAgg);
+		// add alternative to results
+		pxfres->Add(pexprAgg);
+	}
+	else
+	{
+		// skip the aggregate operator if output columns is empty
+		pxfres->Add(pexprLASJ);
+	}
 }
 
 // EOF

--- a/src/backend/gporca/libgpopt/src/xforms/CXformUtils.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformUtils.cpp
@@ -2217,7 +2217,7 @@ CXformUtils::PexprWindowWithRowNumber(CMemoryPool *mp,
 {
 	// partitioning information
 	CDistributionSpec *pds = nullptr;
-	if (nullptr != pdrgpcrInput)
+	if (nullptr != pdrgpcrInput && 0 < pdrgpcrInput->Size())
 	{
 		CExpressionArray *pdrgpexprInput =
 			CUtils::PdrgpexprScalarIdents(mp, pdrgpcrInput);

--- a/src/test/regress/expected/union.out
+++ b/src/test/regress/expected/union.out
@@ -1,3 +1,4 @@
+set optimizer_trace_fallback = on;
 --
 -- UNION (also INTERSECT, EXCEPT)
 --
@@ -1121,3 +1122,4 @@ where (x = 0) or (q1 >= q2 and q1 <= q2);
  4567890123456789 |  4567890123456789 | 1
 (6 rows)
 
+reset optimizer_trace_fallback;

--- a/src/test/regress/expected/union_optimizer.out
+++ b/src/test/regress/expected/union_optimizer.out
@@ -1,3 +1,4 @@
+set optimizer_trace_fallback = on;
 --
 -- UNION (also INTERSECT, EXCEPT)
 --
@@ -785,6 +786,8 @@ explain (costs off)
    UNION ALL
    SELECT ab FROM t2) t
   ORDER BY 1 LIMIT 8;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Inherited tables
                          QUERY PLAN                         
 ------------------------------------------------------------
  Limit
@@ -805,6 +808,8 @@ explain (costs off)
    UNION ALL
    SELECT ab FROM t2) t
   ORDER BY 1 LIMIT 8;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Inherited tables
  ab 
 ----
  ab
@@ -833,6 +838,8 @@ select event_id
        union all
        select event_id from other_events) ss
  order by event_id;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Inherited tables
                            QUERY PLAN                           
 ----------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
@@ -857,6 +864,8 @@ explain (costs off)
    UNION ALL
    SELECT 2 AS t, * FROM tenk1 b) c
  WHERE t = 2;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Non-default collation
                 QUERY PLAN                
 ------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
@@ -941,6 +950,8 @@ SELECT * FROM
    SELECT 2 AS t, 4 AS x) ss
 WHERE x > 3
 ORDER BY x;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: SIRV functions
                                QUERY PLAN                                
 -------------------------------------------------------------------------
  Sort
@@ -963,6 +974,8 @@ SELECT * FROM
    SELECT 2 AS t, 4 AS x) ss
 WHERE x > 3
 ORDER BY x;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: SIRV functions
  t | x 
 ---+---
  2 | 4
@@ -1121,3 +1134,4 @@ where (x = 0) or (q1 >= q2 and q1 <= q2);
  4567890123456789 |  4567890123456789 | 1
 (6 rows)
 
+reset optimizer_trace_fallback;

--- a/src/test/regress/expected/union_optimizer.out
+++ b/src/test/regress/expected/union_optimizer.out
@@ -593,25 +593,29 @@ set enable_hashagg = true;
 set enable_sort = false;
 explain (costs off)
 select from generate_series(1,5) union select from generate_series(1,3);
-                           QUERY PLAN                           
-----------------------------------------------------------------
- HashAggregate
+                              QUERY PLAN                              
+----------------------------------------------------------------------
+ Aggregate
    ->  Append
-         ->  Function Scan on generate_series
-         ->  Function Scan on generate_series generate_series_1
-(4 rows)
+         ->  Aggregate
+               ->  Function Scan on generate_series
+         ->  Aggregate
+               ->  Function Scan on generate_series generate_series_1
+ Optimizer: Pivotal Optimizer (GPORCA)
+(7 rows)
 
 explain (costs off)
 select from generate_series(1,5) intersect select from generate_series(1,3);
-                              QUERY PLAN                              
-----------------------------------------------------------------------
- HashSetOp Intersect
-   ->  Append
-         ->  Subquery Scan on "*SELECT* 1"
-               ->  Function Scan on generate_series
-         ->  Subquery Scan on "*SELECT* 2"
-               ->  Function Scan on generate_series generate_series_1
-(6 rows)
+                           QUERY PLAN                           
+----------------------------------------------------------------
+ Nested Loop
+   Join Filter: true
+   ->  Aggregate
+         ->  Function Scan on generate_series generate_series_1
+   ->  Aggregate
+         ->  Function Scan on generate_series
+ Optimizer: Pivotal Optimizer (GPORCA)
+(7 rows)
 
 select from generate_series(1,5) union select from generate_series(1,3);
 --
@@ -642,25 +646,29 @@ set enable_hashagg = false;
 set enable_sort = true;
 explain (costs off)
 select from generate_series(1,5) union select from generate_series(1,3);
-                           QUERY PLAN                           
-----------------------------------------------------------------
- Unique
+                              QUERY PLAN                              
+----------------------------------------------------------------------
+ Aggregate
    ->  Append
-         ->  Function Scan on generate_series
-         ->  Function Scan on generate_series generate_series_1
-(4 rows)
+         ->  Aggregate
+               ->  Function Scan on generate_series
+         ->  Aggregate
+               ->  Function Scan on generate_series generate_series_1
+ Optimizer: Pivotal Optimizer (GPORCA)
+(7 rows)
 
 explain (costs off)
 select from generate_series(1,5) intersect select from generate_series(1,3);
-                              QUERY PLAN                              
-----------------------------------------------------------------------
- SetOp Intersect
-   ->  Append
-         ->  Subquery Scan on "*SELECT* 1"
-               ->  Function Scan on generate_series
-         ->  Subquery Scan on "*SELECT* 2"
-               ->  Function Scan on generate_series generate_series_1
-(6 rows)
+                           QUERY PLAN                           
+----------------------------------------------------------------
+ Nested Loop
+   Join Filter: true
+   ->  Aggregate
+         ->  Function Scan on generate_series generate_series_1
+   ->  Aggregate
+         ->  Function Scan on generate_series
+ Optimizer: Pivotal Optimizer (GPORCA)
+(7 rows)
 
 select from generate_series(1,5) union select from generate_series(1,3);
 --

--- a/src/test/regress/sql/union.sql
+++ b/src/test/regress/sql/union.sql
@@ -1,3 +1,4 @@
+set optimizer_trace_fallback = on;
 --
 -- UNION (also INTERSECT, EXCEPT)
 --
@@ -450,3 +451,5 @@ select * from
    union all
    select *, 1 as x from int8_tbl b) ss
 where (x = 0) or (q1 >= q2 and q1 <= q2);
+
+reset optimizer_trace_fallback;


### PR DESCRIPTION
There were a lot of asserts on NULL != target_list in the translator,
but most of them were unnecessary. Fix ORCA to handle empty target list.

Following SQL works:
```sql
EXPLAIN (COSTS OFF) SELECT UNION SELECT;
```