### PR TITLE
Add assert to the length of shared hash table name

### DIFF
--- a/src/backend/storage/ipc/shmem.c
+++ b/src/backend/storage/ipc/shmem.c
@@ -444,6 +444,7 @@ ShmemInitStruct(const char *name, Size size, bool *foundPtr)
 		return structPtr;
 	}
 
+	Assert(strlen(name) < SHMEM_INDEX_KEYSIZE);
 	/* look it up in the shmem index */
 	result = (ShmemIndexEnt *)
 		hash_search(ShmemIndex, name, HASH_ENTER_NULL, foundPtr);


### PR DESCRIPTION
The max size for shared memory hash table name is SHMEM_INDEX_KEYSIZE - 1 (shared hash table name is stored and indexed by ShmemIndex hash table, the key size of it is SHMEM_INDEX_KEYSIZE), but when caller using a longer hash table name, it doesn't report any error, instead it just uses the first SHMEM_INDEX_KEYSIZE chars as the hash table name.

When some hash tables' names have a same prefix which is longer than (SHMEM_INDEX_KEYSIZE - 1), issues will come: those hash tables actually are created as a same hash table whose name is the prefix. So add the assert to prevent it.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
