### PR TITLE
[6X_STABLE]Fix several memory leaks

### DIFF
--- a/src/backend/access/aocs/aocsam.c
+++ b/src/backend/access/aocs/aocsam.c
@@ -170,6 +170,10 @@ open_ds_write(Relation rel, DatumStreamWrite **ds, TupleDesc relationTupleDesc,
 										XLogIsNeeded() && RelationNeedsWAL(rel));
 
 	}
+
+	for (int i = 0; i < RelationGetNumberOfAttributes(rel); i++)
+			pfree(opts[i]);
+	pfree(opts);
 }
 
 /*
@@ -230,6 +234,10 @@ open_ds_read(Relation rel, DatumStreamRead **ds, TupleDesc relationTupleDesc,
 										   RelationGetRelationName(rel),
 										    /* title */ titleBuf.data);
 	}
+
+	for (i = 0; i < RelationGetNumberOfAttributes(rel); i++)
+			pfree(opts[i]);
+	pfree(opts);
 }
 
 static void
@@ -1765,6 +1773,11 @@ aocs_begin_headerscan(Relation rel, int colno)
 							   "ALTER TABLE ADD COLUMN scan",
 							   &ao_attr);
 	hdesc->colno = colno;
+
+	for (int i = 0; i < RelationGetNumberOfAttributes(rel); i++)
+		pfree(opts[i]);
+	pfree(opts);
+
 	return hdesc;
 }
 
@@ -1852,6 +1865,11 @@ aocs_addcol_init(Relation rel,
 											   titleBuf.data,
 											   XLogIsNeeded() && RelationNeedsWAL(rel));
 	}
+
+	for (i = 0; i < RelationGetNumberOfAttributes(rel); i++)
+			pfree(opts[i]);
+	pfree(opts);
+
 	return desc;
 }
 

--- a/src/backend/access/common/reloptions.c
+++ b/src/backend/access/common/reloptions.c
@@ -1239,7 +1239,7 @@ default_reloptions(Datum reloptions, bool validate, relopt_kind kind)
 
 	validate_and_refill_options(rdopts, options, numoptions, kind, validate);
 
-	pfree(options);
+	free_options_deep(options, numoptions);
 
 	return (bytea *) rdopts;
 }
@@ -1271,7 +1271,7 @@ view_reloptions(Datum reloptions, bool validate)
 	fillRelOptions((void *) vopts, sizeof(ViewOptions), options, numoptions,
 				   validate, tab, lengthof(tab));
 
-	pfree(options);
+	free_options_deep(options, numoptions);
 
 	return (bytea *) vopts;
 }
@@ -1371,8 +1371,7 @@ attribute_reloptions(Datum reloptions, bool validate)
 	fillRelOptions((void *) aopts, sizeof(AttributeOpts), options, numoptions,
 				   validate, tab, lengthof(tab));
 
-	pfree(options);
-
+	free_options_deep(options, numoptions);
 	return (bytea *) aopts;
 }
 
@@ -1402,7 +1401,7 @@ tablespace_reloptions(Datum reloptions, bool validate)
 	fillRelOptions((void *) tsopts, sizeof(TableSpaceOpts), options, numoptions,
 				   validate, tab, lengthof(tab));
 
-	pfree(options);
+	free_options_deep(options, numoptions);
 
 	return (bytea *) tsopts;
 }

--- a/src/backend/access/common/reloptions_gp.c
+++ b/src/backend/access/common/reloptions_gp.c
@@ -131,7 +131,6 @@ static relopt_string stringRelOpts_gp[] =
 	{{NULL}}
 };
 
-static void free_options_deep(relopt_value *options, int num_options);
 static relopt_value *get_option_set(relopt_value *options, int num_options, const char *opt_name);
 
 /*

--- a/src/backend/access/gin/ginutil.c
+++ b/src/backend/access/gin/ginutil.c
@@ -534,7 +534,7 @@ ginoptions(PG_FUNCTION_ARGS)
 	fillRelOptions((void *) rdopts, sizeof(GinOptions), options, numoptions,
 				   validate, tab, lengthof(tab));
 
-	pfree(options);
+	free_options_deep(options, numoptions);
 
 	PG_RETURN_BYTEA_P(rdopts);
 }

--- a/src/backend/access/gist/gistutil.c
+++ b/src/backend/access/gist/gistutil.c
@@ -791,7 +791,7 @@ gistoptions(PG_FUNCTION_ARGS)
 	fillRelOptions((void *) rdopts, sizeof(GiSTOptions), options, numoptions,
 				   validate, tab, lengthof(tab));
 
-	pfree(options);
+	free_options_deep(options, numoptions);
 
 	PG_RETURN_BYTEA_P(rdopts);
 

--- a/src/backend/executor/nodeBitmapHeapscan.c
+++ b/src/backend/executor/nodeBitmapHeapscan.c
@@ -165,6 +165,9 @@ initFetchDesc(BitmapHeapScanState *scanstate)
 
 			scanstate->bhs_currentAOCSLossyFetchDesc =
 				aocs_fetch_init(currentRelation, estate->es_snapshot, appendOnlyMetaDataSnapshot, projLossy);
+
+			pfree(proj);
+			pfree(projLossy);
 		}
 	}
 	else

--- a/src/include/access/reloptions.h
+++ b/src/include/access/reloptions.h
@@ -318,5 +318,5 @@ extern void validate_and_adjust_options(StdRdOptions *result, relopt_value *opti
 										int num_options, relopt_kind kind, bool validate);
 extern bool reloptions_has_opt(List *opts, const char *name);
 extern List *build_ao_rel_storage_opts(List *opts, Relation rel);
-
+extern void free_options_deep(relopt_value *options, int num_options);
 #endif   /* RELOPTIONS_H */


### PR DESCRIPTION
- Cherry-pick https://github.com/greenplum-db/gpdb/commit/d09c39cfcd45934ef796bf75566eb726d63b9874 from master branch. 
> Prevent memory leaks in parseRelOptions().
parseRelOptions() tended to leak memory in the caller's context.  Most
of the time this doesn't really matter since the caller's context is
at most query-lifespan, and the function won't be invoked very many times.
However, when testing with CLOBBER_CACHE_RECURSIVELY, the same relcache
entry can get rebuilt a *lot* of times in one query, leading to significant
intraquery memory bloat if it has any reloptions.  Noted while
investigating a related report from Tomas Vondra.

> In passing, get rid of some Asserts that are redundant with the one
done by deconstruct_array().

> As with other patches to avoid leaks in CLOBBER_CACHE testing, it doesn't
really seem worth back-patching this.

- Fix several memory leaks.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
