### PR TITLE
[6X][psql] Add support for describing auxiliary tables for ao table.

### DIFF
--- a/src/bin/psql/describe.c
+++ b/src/bin/psql/describe.c
@@ -1703,6 +1703,18 @@ describeOneTableDetails(const char *schemaname,
 			printfPQExpBuffer(&title, _("Foreign table \"%s.%s\""),
 							  schemaname, relationname);
 			break;
+		case 'o':
+			printfPQExpBuffer(&title, _("Appendonly segment entry table: \"%s.%s\""),
+							  schemaname, relationname);
+			break;
+		case 'b':
+			printfPQExpBuffer(&title, _("Appendonly block directory table: \"%s.%s\""),
+							  schemaname, relationname);
+			break;
+		case 'M':
+			printfPQExpBuffer(&title, _("Appendonly visibility map table: \"%s.%s\""),
+							  schemaname, relationname);
+			break;
 		default:
 			/* untranslated unknown relkind */
 			printfPQExpBuffer(&title, "?%c? \"%s.%s\"",
@@ -2333,7 +2345,8 @@ describeOneTableDetails(const char *schemaname,
 		PQclear(result);
 	}
 	else if (tableinfo.relkind == 'r' || tableinfo.relkind == 'm' ||
-			 tableinfo.relkind == 'f')
+			 tableinfo.relkind == 'f' || tableinfo.relkind == 'o' ||
+			 tableinfo.relkind == 'b' || tableinfo.relkind == 'M')
 	{
 		/* Footer information about a table */
 		PGresult   *result = NULL;


### PR DESCRIPTION
Fixes #13997 for 6X_STABLE branch.
Commit for master branch: e0f7833d10776610cffc5bae524161840924afb3

This patch adds support for describing auxiliary tables. e.g.,

```
postgres=# create table foo(i int) with (appendonly=true);
NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
CREATE TABLE
postgres=# create index on foo(i);
CREATE INDEX
postgres=# select blkdirrelid::regclass from pg_appendonly where relid = 'foo'::regclass;
        blkdirrelid
----------------------------
 pg_aoseg.pg_aoblkdir_16384
(1 row)

postgres=# \d+ pg_aoseg.pg_aoblkdir_16384
Appendonly block directory table: "pg_aoseg.pg_aoblkdir_16384"
     Column     |  Type   | Storage
----------------+---------+---------
 segno          | integer | plain
 columngroup_no | integer | plain
 first_row_no   | bigint  | plain
 minipage       | bytea   | plain
Indexes:
    "pg_aoblkdir_16384_index" PRIMARY KEY, btree (segno, columngroup_no, first_row_no)

postgres=# \d+ pg_aoseg.pg_aovisimap_16384
Appendonly visibility map table: "pg_aoseg.pg_aovisimap_16384"
    Column    |  Type   | Storage
--------------+---------+---------
 segno        | integer | plain
 first_row_no | bigint  | plain
 visimap      | bytea   | plain
Indexes:
    "pg_aovisimap_16384_index" PRIMARY KEY, btree (segno, first_row_no)

postgres=# \d+ pg_aoseg.pg_aoseg_16384
Appendonly segment entry table: "pg_aoseg.pg_aoseg_16384"
     Column      |   Type   | Storage
-----------------+----------+---------
 segno           | integer  | plain
 eof             | bigint   | plain
 tupcount        | bigint   | plain
 varblockcount   | bigint   | plain
 eofuncompressed | bigint   | plain
 modcount        | bigint   | plain
 formatversion   | smallint | plain
 state           | smallint | plain
```

