### PR TITLE
Resolving few FIXMEs from gp_replica_check

### DIFF
--- a/gpcontrib/gp_replica_check/Makefile
+++ b/gpcontrib/gp_replica_check/Makefile
@@ -14,7 +14,8 @@ include $(top_builddir)/src/Makefile.global
 include $(top_srcdir)/contrib/contrib-global.mk
 endif
 
-# GPDB_94_MERGE_FIXME: Enable btree, gin and gist when physical and logical
-# order is equivalent.
+# GPDB_FEATURE_NOT_SUPPORTED: Enable btree, gin and gist as physical
+# and logical order is equivalent now. Also, enable brin, spgist,
+# bitmap. Basically, "all" option should be functional for this tool.
 installcheck: install
-	gp_replica_check.py -r="heap, sequence, ao"
+	gp_replica_check.py -r="heap, ao_row, ao_column"

--- a/gpcontrib/gp_replica_check/gp_replica_check.py
+++ b/gpcontrib/gp_replica_check/gp_replica_check.py
@@ -71,9 +71,9 @@ class ReplicaCheck(threading.Thread):
         self.lock = threading.Lock()
 
     def __str__(self):
-        return '(%s) Host: %s, Port: %s, Database: %s\n\
-Primary Data Directory Location: %s\n\
-Mirror Data Directory Location: %s' % (self.getName(), self.host, self.port, self.datname,
+        return '\n(%s) ---------\nHost: %s, Port: %s, Database: %s\n\
+Primary Location: %s\n\
+Mirror  Location: %s' % (self.getName(), self.host, self.port, self.datname,
                                           self.ploc, self.mloc)
 
     def run(self):
@@ -86,9 +86,11 @@ Mirror Data Directory Location: %s' % (self.getName(), self.host, self.port, sel
                 self.result = True if res and res[0] and res[0][0] else False
                 with self.lock:
                     print(self)
-                    print (res)
-                    if not self.result:
-                        print("replica check failed")
+                    if self.result:
+                        print("(%s) ** passed **" % (self.getName()))
+                    else:
+                        print("(%s) --> failed <--" % (self.getName()))
+                        print (res)
             except:
                 with self.lock:
                     print(self)


### PR DESCRIPTION
```
    gp_replica_check: resolve FIXMEs
    
    FIXMEs were related to adding support for checking dynamic access
    methods. Given we are far away from supporting all built-in access
    methods, dynamic support is not on the radar at all. Plus, having a new
    access method is not a common act at all. So, we can cross the bridge of
    converting RelationTypeData to a dynamic array instead of the static
    array when we get there. Hence, for now, resolving the FIXME by
    manually updating the static array to reflect all the current access
    methods.
    
    Note: with this change now "ao" gets split into ao_row and
    ao_column. This is nice as can run more granular checking if desired.
    
    Also, converted GPDB_94_MERGE_FIXME to GPDB_FEATURE_NOT_SUPPORTED in
    Makefile. As we are yet to test/validate/enable this tool for various
    index access methods - which we should do separately.
```

```
    gp_replica_check: cosmetic changes to output
    
    Added code to print thread id for passed or failed status to easily
    correlate the message result with the data directory. Some minor
    formatting along the way.
```

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
