### PR TITLE
Fix an out-dated comment for dispatching SET command. NFC.

### DIFF
--- a/src/backend/cdb/dispatcher/cdbdisp_query.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_query.c
@@ -347,12 +347,12 @@ CdbDispatchSetCommand(const char *strCommand, bool cancelOnError)
 
 		cdbdisp_dispatchToGang(ds, rg, -1);
 	}
-	addToGxactDtxSegments(primaryGang);
-
 	/*
-	 * No need for two-phase commit, so no need to call
-	 * addToGxactDtxSegments.
+	 * 2-phase commit isn't involved in dispatching SET command. We call
+	 * addTogxactdtxsegments() here is to update the writer gang when the SET
+	 * command is the first command in an explicit transaction.
 	 */
+	addToGxactDtxSegments(primaryGang);
 
 	cdbdisp_waitDispatchFinish(ds);
 


### PR DESCRIPTION
This patch fixes an out-dated comment for dispatching SET command.

Original discussion can be found here:

https://github.com/greenplum-db/gpdb/pull/7529/files#r285830213

