### PR TITLE
Fix pipeline failure caused by psql_gp_commands test

### DIFF
--- a/src/test/regress/expected/psql_gp_commands.out
+++ b/src/test/regress/expected/psql_gp_commands.out
@@ -270,3 +270,4 @@ ALTER FUNCTION foofunc_exec_on_initplan() OWNER TO test_psql_de_role;
 -- Clean up
 DROP OWNED BY test_psql_de_role;
 DROP ROLE test_psql_de_role;
+DROP ACCESS METHOD bogus;

--- a/src/test/regress/sql/psql_gp_commands.sql
+++ b/src/test/regress/sql/psql_gp_commands.sql
@@ -140,3 +140,4 @@ ALTER FUNCTION foofunc_exec_on_initplan() OWNER TO test_psql_de_role;
 -- Clean up
 DROP OWNED BY test_psql_de_role;
 DROP ROLE test_psql_de_role;
+DROP ACCESS METHOD bogus;


### PR DESCRIPTION
pipeline failed with the log 'Table pg_am has a dependency issue on oid 152563 at content ...'.

The newly created access method in psql_gp_commands regress test is not cleaned up at the end. Then the gpcheckcat checked that the newly created object in pg_am catalog doesn't have a reference in pg_depend under objid or refobjid column, it will show a dependency issue.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
