### PR TITLE
Remove references to conan from dependency installation scripts.

### DIFF
--- a/README.CentOS.bash
+++ b/README.CentOS.bash
@@ -30,7 +30,6 @@ sudo yum install -y \
     postgresql \
     postgresql-devel
 
-sudo pip3 install conan
 sudo pip3 install -r python-dependencies.txt
 
 sudo tee -a /etc/sysctl.conf << EOF

--- a/README.Ubuntu.bash
+++ b/README.Ubuntu.bash
@@ -40,8 +40,6 @@ sudo apt-get install -y \
 	python3-yaml \
 	zlib1g-dev
 
-pip3 install conan
-
 sudo tee -a /etc/sysctl.conf << EOF
 kernel.shmmax = 5000000000000
 kernel.shmmni = 32768

--- a/README.macOS.bash
+++ b/README.macOS.bash
@@ -12,7 +12,6 @@ else
 fi
 
 brew install bash-completion
-brew install conan
 brew install cmake # gporca
 brew install xerces-c #gporca
 brew install libyaml # enables `--enable-mapreduce`


### PR DESCRIPTION
The conan package has been removed in commit
274c5411b8044147b3970338cf1b708a40e2ada9.

This patch helps remove that from README.[platform].bash scripts.

