### PR TITLE
Fix external protocol dump from gp6 using gp7 pg_dump.

### DIFF
--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -5999,7 +5999,7 @@ getExtProtocols(Archive *fout, int *numExtProtocols)
 	int			i_ptcvalidid;
 
 	/* find all user-defined external protocol */
-	if (fout->remoteVersion >= 90200)
+	if (fout->remoteVersion >= 90600)
 	{
 		appendPQExpBuffer(query, "SELECT tableoid, "
 								 "oid, "


### PR DESCRIPTION
As in gp6 there is no 'objtype' abbreviation E in 'acldefault' fuction.