### PR TITLE
Fix error out when partitioned children has different am with parent. 

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -798,12 +798,15 @@ DefineRelation(CreateStmt *stmt, char relkind, Oid ownerId,
 
 		/*
 		 * For partitioned children, when no reloptions is specified, we
-		 * default to the parent table's reloptions.
+		 * default to the parent table's reloptions. If partitioned
+		 * children has different access method with parent. Do not do it.
 		 */
 		Assert(list_length(inheritOids) == 1);
 		relid = linitial_oid(inheritOids);
 		rel = table_open(relid, AccessShareLock);
 
+		if (rel->rd_rel->relam == accessMethodId)
+			oldoptions = get_rel_opts(rel);
 		oldoptions = get_rel_opts(rel);
 
 		table_close(rel, AccessExclusiveLock);

--- a/src/test/regress/expected/partition_storage.out
+++ b/src/test/regress/expected/partition_storage.out
@@ -785,3 +785,22 @@ Distributed by: (a)
  alter table pt_co_tab_rng add default partition dft;
 -- Split default partition
  alter table pt_co_tab_rng split default partition start(45) end(60) into (partition dft, partition two);
+-- Add partition with different table am
+ SET gp_default_storage_options = 'blocksize=32768,compresstype=zstd,compresslevel=9';
+ SET default_table_access_method TO ao_column;
+ CREATE TABLE pt_co_to_heap
+ (
+    col1 int,
+    col2 decimal,
+    col3 text,
+    col4 bool
+ )
+ distributed by (col1)
+ partition by list(col2)
+ (
+    partition part1 values(1,2,3)
+ );
+ ALTER TABLE pt_co_to_heap ADD PARTITION p4 values(4) WITH (appendonly=false);
+ DROP TABLE pt_co_to_heap;
+ SET gp_default_storage_options TO DEFAULT;
+ SET default_table_access_method TO DEFAULT;

--- a/src/test/regress/sql/partition_storage.sql
+++ b/src/test/regress/sql/partition_storage.sql
@@ -472,3 +472,23 @@ drop table if exists co_can cascade;
 
 -- Split default partition
  alter table pt_co_tab_rng split default partition start(45) end(60) into (partition dft, partition two);
+
+-- Add partition with different table am
+ SET gp_default_storage_options = 'blocksize=32768,compresstype=zstd,compresslevel=9';
+ SET default_table_access_method TO ao_column;
+ CREATE TABLE pt_co_to_heap
+ (
+    col1 int,
+    col2 decimal,
+    col3 text,
+    col4 bool
+ )
+ distributed by (col1)
+ partition by list(col2)
+ (
+    partition part1 values(1,2,3)
+ );
+ ALTER TABLE pt_co_to_heap ADD PARTITION p4 values(4) WITH (appendonly=false);
+ DROP TABLE pt_co_to_heap;
+ SET gp_default_storage_options TO DEFAULT;
+ SET default_table_access_method TO DEFAULT;


### PR DESCRIPTION
Fix error out when partitioned children has different access method with parent. 
Just like what we do during 'ALTER ACCESS METHOD'. Do not inherit reloptions from the parent in this condition.
