### PR TITLE
Remove python3 ENV from `PATH` and `LD_LIBRARY_PATH`

### DIFF
--- a/gpMgmt/bin/generate-greenplum-path.sh
+++ b/gpMgmt/bin/generate-greenplum-path.sh
@@ -23,8 +23,8 @@ fi
 
 cat <<"EOF"
 PYTHONPATH="${GPHOME}/lib/python"
-PATH="${GPHOME}/bin:${GPHOME}/ext/python3.9/bin:${PATH}"
-LD_LIBRARY_PATH="${GPHOME}/lib:${GPHOME}/ext/python3.9/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+PATH="${GPHOME}/bin:${PATH}"
+LD_LIBRARY_PATH="${GPHOME}/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
 
 if [ -e "${GPHOME}/etc/openssl.cnf" ]; then
 	OPENSSL_CONF="${GPHOME}/etc/openssl.cnf"


### PR DESCRIPTION
Python3.9 is the dependency of the plpython3 extension, it is better to set the python3 ENV in the plpython3 script.

[GPR-1035]

Authored-by: Ning Wu <ningw@vmware.com>