### PR TITLE
[6X only] Fix NPE in ATPExecPartSplit.

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -18474,7 +18474,7 @@ ATPExecPartSplit(Relation *rel,
 
 			mypc->partid = (Node *)mypid;
 
-			if (intopid)
+			if (intopid && intopid->partiddef)
 				parname = strVal(intopid->partiddef);
 
 			if (prule->topRule->parisdefault && i == into_exists)


### PR DESCRIPTION

The issue is reported as https://github.com/greenplum-db/gpdb/issues/14186 .

Analysis:

A NULL ptr is passed to strVal  which caused the segment fault:

https://github.com/greenplum-db/gpdb/blob/da7ebfb5bfcf76653b9dcbd8de503b1deab2c015/src/backend/commands/tablecmds.c#L18478

The gdb context is:

```
(gdb) p	*intopid
$13 = {type = T_AlterPartitionId, idtype = AT_AP_IDDefault, partiddef = 0x0, location = 0}
(gdb) p	*intopid1
$14 = {type = T_AlterPartitionId, idtype = AT_AP_IDName, partiddef = 0x1643018, location = 0}
(gdb) p	*intopid2
$15 = {type = T_AlterPartitionId, idtype = AT_AP_IDDefault, partiddef = 0x0, location = 0}
```

Obviously this intopid is copied from intopid2:

https://github.com/greenplum-db/gpdb/blob/da7ebfb5bfcf76653b9dcbd8de503b1deab2c015/src/backend/commands/tablecmds.c#L18463

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
