### PR TITLE
[6X only] Error out with wrong syntax into cause in AlterPartitionCmd.

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -521,7 +521,7 @@ static void inherit_parent(Relation parent_rel, Relation child_rel,
 						   bool is_partition, List *inhAttrNameList);
 static inline void SetConstraints(TupleDesc tupleDesc, char *relName, List **constraints, AttrNumber *attnos);
 static inline void SetSchema(TupleDesc tuple_desc, List **schema, AttrNumber **attnos);
-
+static inline void ErrorOnInvalidDefaultPartition(Relation *rel, AlterPartitionId *id);
 
 
 /* ----------------------------------------------------------------
@@ -17977,6 +17977,19 @@ make_orientation_options(Relation rel)
 	return l;
 }
 
+static inline void 
+ErrorOnInvalidDefaultPartition(Relation *rel, AlterPartitionId *id)
+{
+	if (id->idtype == AT_AP_IDDefault)
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_UNDEFINED_OBJECT),
+				errmsg("relation \"%s\" does not have a "
+						"default partition",
+						RelationGetRelationName(*rel))));
+	}
+}
+
 static void
 ATPExecPartSplit(Relation *rel,
                  AlterPartitionCmd *pc)
@@ -18085,12 +18098,7 @@ ATPExecPartSplit(Relation *rel,
 					ListCell *rc;
 					AlterPartitionId *id = (AlterPartitionId *)pc2->partid;
 
-					if (id->idtype == AT_AP_IDDefault)
-						ereport(ERROR,
-								(errcode(ERRCODE_UNDEFINED_OBJECT),
-								 errmsg("relation \"%s\" does not have a "
-										"default partition",
-										RelationGetRelationName(*rel))));
+					ErrorOnInvalidDefaultPartition(rel, id);
 
 					foreach(rc, prule->pNode->rules)
 					{
@@ -18170,12 +18178,7 @@ ATPExecPartSplit(Relation *rel,
 					ListCell *rc;
 					AlterPartitionId *id = (AlterPartitionId *)pc2->arg1;
 
-					if (id->idtype == AT_AP_IDDefault)
-						ereport(ERROR,
-								(errcode(ERRCODE_UNDEFINED_OBJECT),
-								 errmsg("relation \"%s\" does not have a "
-										"default partition",
-										RelationGetRelationName(*rel))));
+					ErrorOnInvalidDefaultPartition(rel, id);
 
 					foreach(rc, prule->pNode->rules)
 					{
@@ -18474,8 +18477,10 @@ ATPExecPartSplit(Relation *rel,
 
 			mypc->partid = (Node *)mypid;
 
-			if (intopid)
+			if (intopid && intopid->partiddef)
 				parname = strVal(intopid->partiddef);
+			else if (intopid)
+				ErrorOnInvalidDefaultPartition(rel, intopid);
 
 			if (prule->topRule->parisdefault && i == into_exists)
 			{

--- a/src/test/regress/expected/partition.out
+++ b/src/test/regress/expected/partition.out
@@ -2730,6 +2730,25 @@ alter table k split default partition start(10) end(20);
 ERROR:  cannot SPLIT DEFAULT PARTITION with LIST
 HINT:  Use SPLIT with the AT clause instead.
 drop table k;
+-- Test default partiton check inside split into cause
+-- See: https://github.com/greenplum-db/gpdb/issues/14186
+DROP TABLE IF EXISTS issue_14186;
+NOTICE:  table "issue_14186" does not exist, skipping
+CREATE TABLE issue_14186 (id int, date date, name_ text)
+WITH (appendonly=true, compresstype=zlib, compresslevel=5)
+DISTRIBUTED BY (id)
+PARTITION BY RANGE (date)
+( START (date '2021-03-01') INCLUSIVE
+   END (date '2021-04-01') EXCLUSIVE
+   EVERY (INTERVAL '7 day') );
+NOTICE:  CREATE TABLE will create partition "issue_14186_1_prt_1" for table "issue_14186"
+NOTICE:  CREATE TABLE will create partition "issue_14186_1_prt_2" for table "issue_14186"
+NOTICE:  CREATE TABLE will create partition "issue_14186_1_prt_3" for table "issue_14186"
+NOTICE:  CREATE TABLE will create partition "issue_14186_1_prt_4" for table "issue_14186"
+NOTICE:  CREATE TABLE will create partition "issue_14186_1_prt_5" for table "issue_14186"
+ALTER TABLE issue_14186 SPLIT PARTITION FOR ('2021-03-01') AT ('2021-03-02') INTO (PARTITION prt_20210301, DEFAULT PARTITION);
+NOTICE:  CREATE TABLE will create partition "issue_14186_1_prt_prt_20210301" for table "issue_14186"
+ERROR:  relation "issue_14186" does not have a default partition
 -- Check that we support int2
 CREATE TABLE myINT2_TBL(q1 int2)
  partition by range (q1)

--- a/src/test/regress/expected/partition_optimizer.out
+++ b/src/test/regress/expected/partition_optimizer.out
@@ -2734,6 +2734,25 @@ alter table k split default partition start(10) end(20);
 ERROR:  cannot SPLIT DEFAULT PARTITION with LIST
 HINT:  Use SPLIT with the AT clause instead.
 drop table k;
+-- Test default partiton check inside split into cause
+-- See: https://github.com/greenplum-db/gpdb/issues/14186
+DROP TABLE IF EXISTS issue_14186;
+NOTICE:  table "issue_14186" does not exist, skipping
+CREATE TABLE issue_14186 (id int, date date, name_ text)
+WITH (appendonly=true, compresstype=zlib, compresslevel=5)
+DISTRIBUTED BY (id)
+PARTITION BY RANGE (date)
+( START (date '2021-03-01') INCLUSIVE
+   END (date '2021-04-01') EXCLUSIVE
+   EVERY (INTERVAL '7 day') );
+NOTICE:  CREATE TABLE will create partition "issue_14186_1_prt_1" for table "issue_14186"
+NOTICE:  CREATE TABLE will create partition "issue_14186_1_prt_2" for table "issue_14186"
+NOTICE:  CREATE TABLE will create partition "issue_14186_1_prt_3" for table "issue_14186"
+NOTICE:  CREATE TABLE will create partition "issue_14186_1_prt_4" for table "issue_14186"
+NOTICE:  CREATE TABLE will create partition "issue_14186_1_prt_5" for table "issue_14186"
+ALTER TABLE issue_14186 SPLIT PARTITION FOR ('2021-03-01') AT ('2021-03-02') INTO (PARTITION prt_20210301, DEFAULT PARTITION);
+NOTICE:  CREATE TABLE will create partition "issue_14186_1_prt_prt_20210301" for table "issue_14186"
+ERROR:  relation "issue_14186" does not have a default partition
 -- Check that we support int2
 CREATE TABLE myINT2_TBL(q1 int2)
  partition by range (q1)

--- a/src/test/regress/sql/partition.sql
+++ b/src/test/regress/sql/partition.sql
@@ -1397,6 +1397,18 @@ default partition mydef);
 alter table k split default partition start(10) end(20);
 drop table k;
 
+-- Test default partiton check inside split into cause
+-- See: https://github.com/greenplum-db/gpdb/issues/14186
+DROP TABLE IF EXISTS issue_14186;
+CREATE TABLE issue_14186 (id int, date date, name_ text)
+WITH (appendonly=true, compresstype=zlib, compresslevel=5)
+DISTRIBUTED BY (id)
+PARTITION BY RANGE (date)
+( START (date '2021-03-01') INCLUSIVE
+   END (date '2021-04-01') EXCLUSIVE
+   EVERY (INTERVAL '7 day') );
+ALTER TABLE issue_14186 SPLIT PARTITION FOR ('2021-03-01') AT ('2021-03-02') INTO (PARTITION prt_20210301, DEFAULT PARTITION);
+
 -- Check that we support int2
 CREATE TABLE myINT2_TBL(q1 int2)
  partition by range (q1)


### PR DESCRIPTION
The issue is reported as https://github.com/greenplum-db/gpdb/issues/14186 .

This PR is a more proper way to fix this issue compared to https://github.com/greenplum-db/gpdb/pull/14187.

We should error out with wrong syntax into cause in AlterPartitionCmd, then the behavior could align with 7X branch.

```

postgres=# ALTER TABLE ao_test_spilt SPLIT PARTITION FOR ('2021-03-01') AT ('2021-03-02') INTO (PARTITION prt_20210301, default partition);
ERROR:  INTO can only have second partition by name
LINE 1: ...IT PARTITION FOR ('2021-03-01') AT ('2021-03-02') INTO (PART...
                                                             ^
```
The current test cases have already covered this scenario, so I only updated the test answer files.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [x] Review a PR in return to support the community
