### PR TITLE
[6X_STABLE] Ignore XLOG archive check when creating restart point on mirror segment

### DIFF
--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -3966,6 +3966,10 @@ RemoveOldXlogFiles(XLogSegNo segno, XLogRecPtr endptr)
 	}
 
 	FreeDir(xldir);
+
+#ifdef FAULT_INJECTOR
+	SIMPLE_FAULT_INJECTOR("finished_removing_old_xlog_files");
+#endif
 }
 
 /*

--- a/src/backend/access/transam/xlogarchive.c
+++ b/src/backend/access/transam/xlogarchive.c
@@ -636,6 +636,13 @@ XLogArchiveCheckDone(const char *xlog)
 	if (!XLogArchivingActive())
 		return true;
 
+	/*
+	 * GPDB: Always delete if this is a mirror segment and archive_mode is
+	 * "on". Continuous WAL archiving on mirrors is not supportable yet.
+	 */
+	if (XLogArchivingActive() && RecoveryInProgress())
+		return true;
+
 	/* First check for .done --- this means archiver is done with it */
 	StatusFilePath(archiveStatusPath, xlog, ".done");
 	if (stat(archiveStatusPath, &stat_buf) == 0)

--- a/src/test/gpdb_pitr/expected/test_mirror_wal_recycling.out
+++ b/src/test/gpdb_pitr/expected/test_mirror_wal_recycling.out
@@ -1,0 +1,48 @@
+-- Test that archive_mode=on does not affect WAL recycling on a GPDB
+-- High Availability mirror segment... mainly that it shouldn't be
+-- marking WAL segments as ready for archiving. This test assumes that
+-- archive_mode=on has already been enabled for the content 0 mirror.
+-- start_matchignore
+--
+-- # ignore NOTICE outputs from the test plpython function
+-- m/NOTICE\:.*archive_status.*/
+-- m/CONTEXT\:.*PL\/Python function.*/
+--
+-- end_matchignore
+-- Add fault injector skip to where deletion/recycling of WAL segments finishes
+SELECT gp_inject_fault_infinite('finished_removing_old_xlog_files', 'skip', dbid)
+	FROM gp_segment_configuration WHERE role = 'm' AND content = 0;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:
+(1 row)
+
+-- Force a restartpoint
+CHECKPOINT;
+-- Wait until restartpoint finishes recycling WAL segments
+SELECT gp_wait_until_triggered_fault('finished_removing_old_xlog_files', 1, dbid)
+	FROM gp_segment_configuration WHERE content=0 AND role='m';
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:
+(1 row)
+
+-- Check if a .ready file exists in the mirror's
+-- $datadir/pg_xlog/archive_status/ directory after recycling WAL
+-- segments. It should not.
+CREATE OR REPLACE FUNCTION ready_file_exists(datadir text)
+RETURNS bool AS $$
+    import os
+
+    cmd = 'find %s/pg_xlog/archive_status -name "*.ready" | grep .' % (datadir)
+    plpy.notice('Running: %s' % cmd) # useful debug info that is match ignored
+    rc = os.system(cmd)
+
+    return (rc == 0)
+$$ LANGUAGE plpython2u VOLATILE;
+SELECT ready_file_exists(datadir) FROM gp_segment_configuration WHERE content=0 AND role='m';
+ ready_file_exists 
+-------------------
+ f
+(1 row)
+

--- a/src/test/gpdb_pitr/sql/test_mirror_wal_recycling.sql
+++ b/src/test/gpdb_pitr/sql/test_mirror_wal_recycling.sql
@@ -1,0 +1,53 @@
+-- Test that archive_mode=on does not affect WAL recycling on a GPDB
+-- High Availability mirror segment... mainly that it shouldn't be
+-- marking WAL segments as ready for archiving. This test assumes that
+-- archive_mode=on has already been enabled for the content 0 mirror.
+
+-- start_matchignore
+--
+-- # ignore NOTICE outputs from the test plpython function
+-- m/NOTICE\:.*archive_status.*/
+-- m/CONTEXT\:.*PL\/Python function.*/
+--
+-- end_matchignore
+
+-- start_ignore
+-- Enable GUC to do faster restartpoints
+\! gpconfig -c create_restartpoint_on_ckpt_record_replay -v on --skipvalidation;
+\! gpstop -u;
+-- end_ignore
+
+-- Add fault injector skip to where deletion/recycling of WAL segments finishes
+SELECT gp_inject_fault_infinite('finished_removing_old_xlog_files', 'skip', dbid)
+	FROM gp_segment_configuration WHERE role = 'm' AND content = 0;
+
+-- Force a restartpoint
+CHECKPOINT;
+
+-- Wait until restartpoint finishes recycling WAL segments
+SELECT gp_wait_until_triggered_fault('finished_removing_old_xlog_files', 1, dbid)
+	FROM gp_segment_configuration WHERE content=0 AND role='m';
+
+-- Check if a .ready file exists in the mirror's
+-- $datadir/pg_xlog/archive_status/ directory after recycling WAL
+-- segments. It should not.
+-- start_ignore
+CREATE EXTENSION IF NOT EXISTS plpython2u;
+-- end_ignore
+CREATE OR REPLACE FUNCTION ready_file_exists(datadir text)
+RETURNS bool AS $$
+    import os
+
+    cmd = 'find %s/pg_xlog/archive_status -name "*.ready" | grep .' % (datadir)
+    plpy.notice('Running: %s' % cmd) # useful debug info that is match ignored
+    rc = os.system(cmd)
+
+    return (rc == 0)
+$$ LANGUAGE plpython2u VOLATILE;
+SELECT ready_file_exists(datadir) FROM gp_segment_configuration WHERE content=0 AND role='m';
+
+-- start_ignore
+-- Do clean up
+\! gpconfig -c create_restartpoint_on_ckpt_record_replay -v off --skipvalidation;
+\! gpstop -u;
+-- end_ignore

--- a/src/test/gpdb_pitr/test_gpdb_pitr.sh
+++ b/src/test/gpdb_pitr/test_gpdb_pitr.sh
@@ -21,6 +21,7 @@ MASTER=${DATADIR}/qddir/demoDataDir-1
 PRIMARY1=${DATADIR}/dbfast1/demoDataDir0
 PRIMARY2=${DATADIR}/dbfast2/demoDataDir1
 PRIMARY3=${DATADIR}/dbfast3/demoDataDir2
+MIRROR1=${DATADIR}/dbfast_mirror1/demoDataDir0
 MASTER_PORT=6000
 PRIMARY1_PORT=6002
 PRIMARY2_PORT=6003
@@ -81,7 +82,7 @@ run_test_isolation2 test_gp_switch_wal
 # master and primary segments. Afterwards, restart the cluster to load
 # the new settings.
 echo "Setting up WAL Archiving configurations..."
-for segment_role in MASTER PRIMARY1 PRIMARY2 PRIMARY3; do
+for segment_role in MASTER PRIMARY1 PRIMARY2 PRIMARY3 MIRROR1; do
   DATADIR_VAR=$segment_role
   echo "wal_level = hot_standby
 archive_mode = on
@@ -103,6 +104,9 @@ done
 # Run setup test. This will create the tables, create the restore
 # points, and demonstrate the commit blocking.
 run_test_isolation2 gpdb_pitr_setup
+
+# Test if mirrors properly recycle WAL when archive_mode=on
+run_test test_mirror_wal_recycling
 
 # Stop the gpdemo cluster. We'll be focusing on the PITR cluster from
 # now onwards.


### PR DESCRIPTION
When a mirror is running with archive_mode=on, it may incorrectly mark WAL segments as ready to be archived (".ready" file in the $datadir/pg_xlog/archive_status directory) when checking to see if any WAL segments can be recycled. This causes the marked WAL segment to never be recycled. It can also cause issues when the mirror is promoted and tries to start archiving WAL since the old stale WAL segment may already exist in the archive location.

To fix the issue, ignore the XLOG archive check when creating a restart point on a mirror segment. We really shouldn't be doing anything relating to WAL archiving on the mirror segment while it's in standby mode anyways since continuous WAL archiving for mirrors/standbys is not supported until its introduction in Postgres 9.5.

This patch was heavily inspired from upstream postgres commit:
https://github.com/postgres/postgres/commit/78ea8b5daab9237fd42d7a8a836c1c451765499f
```
Fix WAL recycling on standbys depending on archive_mode

A restart point or a checkpoint recycling WAL segments treats segments
marked with neither ".done" (archiving is done) or ".ready" (segment is
ready to be archived) in archive_status the same way for archive_mode
being "on" or "always".  While for a primary this is fine, a standby
running a restart point with archive_mode = on would try to mark such a
segment as ready for archiving, which is something that will never
happen except after the standby is promoted.

Note that this problem applies only to WAL segments coming from the
local pg_wal the first time archive recovery is run.  Segments part of a
self-contained base backup are the most common case where this could
happen, however even in this case normally the .done markers would be
most likely part of the backup.  Segments recovered from an archive are
marked as .ready or .done by the startup process, and segments finished
streaming are marked as such by the WAL receiver, so they are handled
already.

Reported-by: Haruka Takatsuka
Author: Michael Paquier
Discussion: https://postgr.es/m/15402-a453c90ed4cf88b2@postgresql.org
Backpatch-through: 9.5, where archive_mode = always has been added.
```

Upstream postgres commit reference for continuous WAL archiving support for standbys:
https://github.com/postgres/postgres/commit/ffd37740ee6fcd434416ec0c5461f7040e0a11de