### PR TITLE
Support high security SSL encryption algorithms in libpq of 5X_STABLE

### DIFF
--- a/src/backend/libpq/be-secure.c
+++ b/src/backend/libpq/be-secure.c
@@ -836,6 +836,7 @@ initialize_SSL(void)
 	/* set up ephemeral DH keys, and disallow SSL v2 while at it */
 	SSL_CTX_set_tmp_dh_callback(SSL_context, tmp_dh_cb);
 	SSL_CTX_set_options(SSL_context, SSL_OP_SINGLE_DH_USE | SSL_OP_NO_SSLv2);
+	SSL_CTX_set_ecdh_auto(SSL_context, 1);
 
 	/* setup the allowed cipher list */
 	if (SSL_CTX_set_cipher_list(SSL_context, SSLCipherSuites) != 1)


### PR DESCRIPTION
### Problem
Some users reported a problem about libpq ssl in gpdb 5X_STABLE.
Users want to apply high level ssl algorithm such as 'ECDHE-RSA-AES256-GCM-SHA384', but they can not set it and take effect.
The original result is reproduced as followed:
```
[gpadmin@localhost gpseg-1]$ gpconfig -c ssl_ciphers -v 'ECDHE-RSA-AES256-GCM-SHA384'
20220923:18:07:55:015540 gpconfig:localhost:gpadmin-[INFO]:-completed successfully with parameters '-c ssl_ciphers -v ECDHE-RSA-AES256-GCM-SHA384'
[gpadmin@localhost gpseg-1]$  gpstop -ar
... ... ...
20220923:18:07:56:023550 gpstop:localhost:gpadmin-[INFO]:-Restarting System...
[gpadmin@localhost gpseg-1]$ psql -h 127.0.0.1
psql (8.3.23)
SSL connection (cipher: DHE-RSA-AES256-GCM-SHA384, bits: 256) 
Type "help" for help.
 
gpadmin=#
```
Although we have set it as **ECDHE-RSA-AES256-GCM-SHA384**, the working algorithm is still **DHE-RSA-AES256-GCM-SHA384**.
This problem does not exist in 6X_STABLE and MASTER, only in 5X_STABLE.

### Solution
`SSL_set_ecdh_auto` can help us apply a high security algorithm during ssl handshake.
Please refer to https://www.openssl.org/docs/man3.0/man3/SSL_CTX_set_ecdh_auto.html
We have fixed this bug for gpdb 5X_STABLE. After this patch in gpdb 5X_STABLE, user demand can be met.

### Result
The test reuslt after this patch is shown as followed:
```
-bash-4.2$ gpconfig -c ssl_ciphers -v 'ECDHE-RSA-AES256-GCM-SHA384'
/home/gpadmin/.local/lib/python2.7/site-packages/paramiko/transport.py:33: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.hazmat.backends import default_backend
20220927:17:26:52:024320 gpconfig:localhost:gpadmin-[INFO]:-completed successfully with parameters '-c ssl_ciphers -v ECDHE-RSA-AES256-GCM-SHA384'
Segment value: DHE-RSA-AES256-GCM-SHA384
-bash-4.2$ gpstop -ar
... ... ...
20220927:17:27:17:024514 gpstop:localhost:gpadmin-[INFO]:-Restarting System...
-bash-4.2$ psql -h 127.0.0.1
psql (8.3.23)
SSL connection (cipher: ECDHE-RSA-AES256-GCM-SHA384, bits: 256)
Type "help" for help.

gpadmin=# \q
-bash-4.2$ gpconfig -s ssl_ciphers
/home/gpadmin/.local/lib/python2.7/site-packages/paramiko/transport.py:33: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
  from cryptography.hazmat.backends import default_backend
Values on all segments are consistent
GUC          : ssl_ciphers
Master  value: ECDHE-RSA-AES256-GCM-SHA384
Segment value: ECDHE-RSA-AES256-GCM-SHA384
```
Signed-off-by: Yongtao Huang <yongtaoh@vmware.com>