### PR TITLE
Penalize skewed hash join

### DIFF
--- a/src/backend/gpopt/utils/COptTasks.cpp
+++ b/src/backend/gpopt/utils/COptTasks.cpp
@@ -367,6 +367,7 @@ COptTasks::CreateOptimizerConfig(CMemoryPool *mp, ICostModel *cost_model)
 	ULONG push_group_by_below_setop_threshold =
 		(ULONG) optimizer_push_group_by_below_setop_threshold;
 	ULONG xform_bind_threshold = (ULONG) optimizer_xform_bind_threshold;
+	ULONG skew_factor = (ULONG) optimizer_skew_factor;
 
 	return GPOS_NEW(mp) COptimizerConfig(
 		GPOS_NEW(mp)
@@ -382,7 +383,8 @@ COptTasks::CreateOptimizerConfig(CMemoryPool *mp, ICostModel *cost_model)
 				  broadcast_threshold,
 				  false, /* don't create Assert nodes for constraints, we'll
 								      * enforce them ourselves in the executor */
-				  push_group_by_below_setop_threshold, xform_bind_threshold),
+				  push_group_by_below_setop_threshold, xform_bind_threshold,
+				  skew_factor),
 		GPOS_NEW(mp) CWindowOids(OID(F_WINDOW_ROW_NUMBER), OID(F_WINDOW_RANK)));
 }
 

--- a/src/backend/gporca/data/dxl/minidump/CTAS_OrderedAgg_multiple_cols.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTAS_OrderedAgg_multiple_cols.mdp
@@ -1803,7 +1803,7 @@ EXPLAIN CREATE TABLE test AS
       </dxl:LogicalCTAS>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="29379751833600">
-      <dxl:PhysicalCTAS Name="fake ctas rel" IsTemporary="true" HasOids="false" StorageType="Heap" DistributionPolicy="Random" InsertColumns="19,20,21" VarTypeModList="-1,-1,-1">
+      <dxl:PhysicalCTAS Name="fake ctas rel" IsTemporary="true" StorageType="Heap" DistributionPolicy="Random" InsertColumns="19,20,21" VarTypeModList="-1,-1,-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="2778516240645.427246" Rows="1.000000" Width="24"/>
         </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/HAWQ-TPCH-Stat-Derivation.mdp
+++ b/src/backend/gporca/data/dxl/minidump/HAWQ-TPCH-Stat-Derivation.mdp
@@ -885,6 +885,18 @@ ORDER BY s_name;
         <dxl:SumAgg Mdid="0.2108.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
+      <dxl:GPDBScalarOp Mdid="0.97.1.0" Name="&lt;" ComparisonType="LT" ReturnsNullOnNullInput="true">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.66.1.0"/>
+        <dxl:Commutator Mdid="0.521.1.0"/>
+        <dxl:InverseOp Mdid="0.525.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.3027.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
       <dxl:ColumnStatistics Mdid="1.11778166.1.1.18" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.11778166.1.1.11" Name="l_commitdate" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
         <dxl:StatsBucket Frequency="0.037692" DistinctValues="94.384615">

--- a/src/backend/gporca/libgpopt/include/gpopt/cost/ICostModel.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/cost/ICostModel.h
@@ -98,6 +98,13 @@ public:
 		{
 			return m_pstats->GetNDVs(colref);
 		}
+
+		// root stats getter
+		IStatistics *
+		Pstats()
+		{
+			return m_pstats;
+		}
 	};	// class CCostingStats
 
 	//---------------------------------------------------------------------------

--- a/src/backend/gporca/libgpopt/include/gpopt/engine/CHint.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/engine/CHint.h
@@ -19,6 +19,7 @@
 #define BROADCAST_THRESHOLD ULONG(10000000)
 #define PUSH_GROUP_BY_BELOW_SETOP_THRESHOLD ULONG(10)
 #define XFORM_BIND_THRESHOLD ULONG(0)
+#define SKEW_FACTOR ULONG(0)
 
 
 namespace gpopt
@@ -52,6 +53,8 @@ private:
 
 	ULONG m_ulXform_bind_threshold;
 
+	ULONG m_ulSkewFactor;
+
 public:
 	CHint(const CHint &) = delete;
 
@@ -60,7 +63,8 @@ public:
 		  ULONG join_arity_for_associativity_commutativity,
 		  ULONG array_expansion_threshold, ULONG ulJoinOrderDPLimit,
 		  ULONG broadcast_threshold, BOOL enforce_constraint_on_dml,
-		  ULONG push_group_by_below_setop_threshold, ULONG xform_bind_threshold)
+		  ULONG push_group_by_below_setop_threshold, ULONG xform_bind_threshold,
+		  ULONG skew_factor)
 		: m_ulMinNumOfPartsToRequireSortOnInsert(
 			  min_num_of_parts_to_require_sort_on_insert),
 		  m_ulJoinArityForAssociativityCommutativity(
@@ -71,7 +75,8 @@ public:
 		  m_fEnforceConstraintsOnDML(enforce_constraint_on_dml),
 		  m_ulPushGroupByBelowSetopThreshold(
 			  push_group_by_below_setop_threshold),
-		  m_ulXform_bind_threshold(xform_bind_threshold)
+		  m_ulXform_bind_threshold(xform_bind_threshold),
+		  m_ulSkewFactor(skew_factor)
 	{
 	}
 
@@ -144,6 +149,13 @@ public:
 		return m_ulXform_bind_threshold;
 	}
 
+	// User defined skew multiplier, multiplied to the skew ratio calculated from 1000 samples
+	ULONG
+	UlSkewFactor() const
+	{
+		return m_ulSkewFactor;
+	}
+
 	// generate default hint configurations, which disables sort during insert on
 	// append only row-oriented partitioned tables by default
 	static CHint *
@@ -157,7 +169,8 @@ public:
 			BROADCAST_THRESHOLD,				 /*broadcast_threshold*/
 			true,								 /* enforce_constraint_on_dml */
 			PUSH_GROUP_BY_BELOW_SETOP_THRESHOLD, /* push_group_by_below_setop_threshold */
-			XFORM_BIND_THRESHOLD				 /* xform_bind_threshold */
+			XFORM_BIND_THRESHOLD,				 /* xform_bind_threshold */
+			SKEW_FACTOR							 /* skew_factor */
 		);
 	}
 

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysical.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysical.h
@@ -265,10 +265,6 @@ protected:
 												  CDistributionSpec *pds,
 												  ULONG child_index);
 
-	// helper to compute skew estimate based on given stats and distribution spec
-	static CDouble GetSkew(IStatistics *stats, CDistributionSpec *pds);
-
-
 	// return true if the given column set includes any of the columns defined by
 	// the unary node, as given by the handle
 	static BOOL FUnaryUsesDefinedColumns(CColRefSet *pcrs,
@@ -299,6 +295,9 @@ public:
 		CRefCount::SafeRelease(m_phmrcr);
 		CRefCount::SafeRelease(m_pdrgpulpOptReqsExpanded);
 	}
+
+	// helper to compute skew estimate based on given stats and distribution spec
+	static CDouble GetSkew(IStatistics *stats, CDistributionSpec *pds);
 
 	// type of operator
 	BOOL

--- a/src/backend/gporca/libgpopt/src/optimizer/COptimizerConfig.cpp
+++ b/src/backend/gporca/libgpopt/src/optimizer/COptimizerConfig.cpp
@@ -210,6 +210,9 @@ COptimizerConfig::Serialize(CMemoryPool *mp, CXMLSerializer *xml_serializer,
 	xml_serializer->AddAttribute(
 		CDXLTokens::GetDXLTokenStr(EdxltokenXformBindThreshold),
 		m_hint->UlXformBindThreshold());
+	xml_serializer->AddAttribute(
+		CDXLTokens::GetDXLTokenStr(gpdxl::EdxltokenSkewFactor),
+		m_hint->UlSkewFactor());
 	xml_serializer->CloseElement(
 		CDXLTokens::GetDXLTokenStr(EdxltokenNamespacePrefix),
 		CDXLTokens::GetDXLTokenStr(EdxltokenHint));

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/xml/dxltokens.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/xml/dxltokens.h
@@ -66,6 +66,7 @@ enum Edxltoken
 	EdxltokenEnforceConstraintsOnDML,
 	EdxltokenPushGroupByBelowSetopThreshold,
 	EdxltokenXformBindThreshold,
+	EdxltokenSkewFactor,
 	EdxltokenMaxStatsBuckets,
 	EdxltokenWindowOids,
 	EdxltokenOidRowNumber,

--- a/src/backend/gporca/libnaucrates/include/naucrates/statistics/CBucket.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/statistics/CBucket.h
@@ -216,8 +216,8 @@ public:
 
 	BOOL Equals(const CBucket *bucket) const;
 
-	// generate a random data point within bucket boundaries
-	CDouble GetSample(ULONG *seed) const;
+	// generate a data point within bucket boundaries
+	CDouble GetSample(DOUBLE ratio) const;
 
 	// compare lower bucket boundaries
 	static INT CompareLowerBounds(const CBucket *bucket1,

--- a/src/backend/gporca/libnaucrates/include/naucrates/statistics/CHistogram.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/statistics/CHistogram.h
@@ -135,6 +135,10 @@ private:
 	// accessor for n-th bucket
 	CBucket *operator[](ULONG) const;
 
+	// Populate sample ratio within each bucket
+	void GetSampleRate(DOUBLE left, DOUBLE right, DOUBLE sample_rate[],
+					   ULONG index);
+
 	// compute skew estimate
 	void ComputeSkew();
 

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerHint.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerHint.cpp
@@ -114,12 +114,15 @@ CParseHandlerHint::StartElement(const XMLCh *const,	 //element_uri,
 			m_parse_handler_mgr->GetDXLMemoryManager(), attrs,
 			EdxltokenXformBindThreshold, EdxltokenHint, true,
 			XFORM_BIND_THRESHOLD);
+	ULONG skew_factor = CDXLOperatorFactory::ExtractConvertAttrValueToUlong(
+		m_parse_handler_mgr->GetDXLMemoryManager(), attrs, EdxltokenSkewFactor,
+		EdxltokenHint, true, SKEW_FACTOR);
 
 	m_hint = GPOS_NEW(m_mp) CHint(
 		min_num_of_parts_to_require_sort_on_insert,
 		join_arity_for_associativity_commutativity, array_expansion_threshold,
 		join_order_dp_threshold, broadcast_threshold, enforce_constraint_on_dml,
-		push_group_by_below_setop_threshold, xform_bind_threshold);
+		push_group_by_below_setop_threshold, xform_bind_threshold, skew_factor);
 }
 
 //---------------------------------------------------------------------------

--- a/src/backend/gporca/libnaucrates/src/statistics/CBucket.cpp
+++ b/src/backend/gporca/libnaucrates/src/statistics/CBucket.cpp
@@ -1363,11 +1363,11 @@ CBucket::SplitAndMergeBuckets(
 //		CBucket::GetSample
 //
 //	@doc:
-//		Generate a random data point within bucket boundaries
+//		Generate a data point within bucket boundaries
 //
 //---------------------------------------------------------------------------
 CDouble
-CBucket::GetSample(ULONG *seed) const
+CBucket::GetSample(DOUBLE ratio) const
 {
 	GPOS_ASSERT(CanSample());
 
@@ -1378,11 +1378,9 @@ CBucket::GetSample(ULONG *seed) const
 	}
 
 	DOUBLE upper_val = m_bucket_upper_bound->GetDatum()->GetValAsDouble().Get();
-	DOUBLE rand_val = ((DOUBLE) clib::Rand(seed)) / RAND_MAX;
 
-	return CDouble(lower_val + rand_val * (upper_val - lower_val));
+	return CDouble(lower_val + ratio * (upper_val - lower_val));
 }
-
 
 //---------------------------------------------------------------------------
 //	@function:

--- a/src/backend/gporca/libnaucrates/src/statistics/CHistogram.cpp
+++ b/src/backend/gporca/libnaucrates/src/statistics/CHistogram.cpp
@@ -2074,6 +2074,24 @@ CHistogram::GetRandomBucketIndex(ULONG *seed) const
 	return size - 1;
 }
 
+// Populate the sample ratio within bucket boundaries
+void
+CHistogram::GetSampleRate(DOUBLE left, DOUBLE right, DOUBLE *sample_rate,
+						  ULONG index)
+{
+	GPOS_CHECK_STACK_SIZE;
+
+	if (index >= GPOPT_SKEW_SAMPLE_SIZE)
+	{
+		return;
+	}
+
+	sample_rate[index + 1] = (left + right) / 2;
+
+	GetSampleRate(left, (left + right) / 2, sample_rate, index * 2);
+	GetSampleRate((left + right) / 2, right, sample_rate, index * 2 + 1);
+}
+
 // estimate data skew by sampling histogram buckets,
 // the estimate value is >= 1.0, where 1.0 indicates no skew
 //
@@ -2089,26 +2107,50 @@ CHistogram::ComputeSkew()
 {
 	m_skew_was_measured = true;
 
-	if (!IsNormalized() || 0 == m_histogram_buckets->Size() ||
+	if (0 == m_histogram_buckets->Size() ||
 		!(*m_histogram_buckets)[0]->CanSample())
 	{
 		return;
 	}
 
-	// generate randomization seed from system time
-	TIMEVAL tv;
-	syslib::GetTimeOfDay(&tv, nullptr /*timezone*/);
-	ULONG seed = CombineHashes((ULONG) tv.tv_sec, (ULONG) tv.tv_usec);
+	if (!IsNormalized())
+	{
+		this->NormalizeHistogram();
+	}
 
 	// generate a sample from histogram data, and compute sample mean
 	DOUBLE sample_mean = 0;
 	DOUBLE samples[GPOPT_SKEW_SAMPLE_SIZE];
+	DOUBLE sample_rate[GPOPT_SKEW_SAMPLE_SIZE];
+	sample_rate[0] = 0;
+	sample_rate[1] = 1;
+	ULONG index = 1;
+	GetSampleRate(sample_rate[0], sample_rate[1], sample_rate, index);
+
+	// start with the lowest frequency bucket
+	ULONG bucket_index = m_histogram_buckets->Size() - 1;
+	// start with bucket lower boundary
+	ULONG sample_index = 0;
+	CDouble accumulated_freq = 0;
 	for (ULONG ul = 0; ul < GPOPT_SKEW_SAMPLE_SIZE; ul++)
 	{
-		ULONG bucket_index = GetRandomBucketIndex(&seed);
 		CBucket *bucket = (*m_histogram_buckets)[bucket_index];
-		samples[ul] = bucket->GetSample(&seed).Get();
+		samples[ul] = bucket->GetSample(sample_rate[sample_index]).Get();
 		sample_mean = sample_mean + samples[ul];
+		// iterate sample rate series
+		sample_index++;
+		DOUBLE filling_rate = (DOUBLE) ul / GPOPT_SKEW_SAMPLE_SIZE;
+
+		// compare the sample filling rate to the current bucket's frequency
+		// if enough samples are collected from this bucket
+		// reset the sample index to the lower boundary for the next bucket
+		if (filling_rate >= accumulated_freq + bucket->GetFrequency() &&
+			bucket_index > 0)
+		{
+			accumulated_freq = accumulated_freq + bucket->GetFrequency();
+			bucket_index--;
+			sample_index = 0;
+		}
 	}
 	sample_mean = (DOUBLE) sample_mean / GPOPT_SKEW_SAMPLE_SIZE;
 
@@ -2120,11 +2162,19 @@ CHistogram::ComputeSkew()
 		num2 = num2 + pow((samples[ul] - sample_mean), 2.0);
 		num3 = num3 + pow((samples[ul] - sample_mean), 3.0);
 	}
+	// second moment: variance
 	DOUBLE moment2 = (DOUBLE)(num2 / GPOPT_SKEW_SAMPLE_SIZE);
+	// third moment: a/symmetry
 	DOUBLE moment3 = (DOUBLE)(num3 / GPOPT_SKEW_SAMPLE_SIZE);
 
-	// set skew measure
-	m_skew = CDouble(1.0 + fabs(moment3 / pow(moment2, 1.5)));
+	if (moment2 == 0)
+	{
+		m_skew = pow(GPOPT_SKEW_SAMPLE_SIZE, 0.5);
+	}
+	else
+	{
+		m_skew = CDouble(1.0 + fabs(moment3 / pow(moment2, 1.5)));
+	}
 }
 
 // create the default histogram for a given column reference

--- a/src/backend/gporca/libnaucrates/src/xml/dxltokens.cpp
+++ b/src/backend/gporca/libnaucrates/src/xml/dxltokens.cpp
@@ -88,6 +88,7 @@ CDXLTokens::Init(CMemoryPool *mp)
 		{EdxltokenPushGroupByBelowSetopThreshold,
 		 GPOS_WSZ_LIT("PushGroupByBelowSetopThreshold")},
 		{EdxltokenXformBindThreshold, GPOS_WSZ_LIT("XformBindThreshold")},
+		{EdxltokenSkewFactor, GPOS_WSZ_LIT("SkewFactor")},
 		{EdxltokenWindowOids, GPOS_WSZ_LIT("WindowOids")},
 		{EdxltokenOidRowNumber, GPOS_WSZ_LIT("RowNumber")},
 		{EdxltokenOidRank, GPOS_WSZ_LIT("Rank")},

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -368,6 +368,7 @@ int			optimizer_join_order;
 int			optimizer_cte_inlining_bound;
 int			optimizer_push_group_by_below_setop_threshold;
 int			optimizer_xform_bind_threshold;
+int			optimizer_skew_factor;
 bool		optimizer_force_multistage_agg;
 bool		optimizer_force_three_stage_scalar_dqa;
 bool		optimizer_force_expanded_distinct_aggs;
@@ -3975,6 +3976,17 @@ struct config_int ConfigureNamesInt_gp[] =
 		0, 0, INT_MAX,
 		NULL, NULL, NULL
 	},
+
+    {
+            {"optimizer_skew_factor", PGC_USERSET, DEVELOPER_OPTIONS,
+             gettext_noop("Coefficient of skew ratio computed from sample stastics. Default 0: skew computation from sample statistics turned off. [1,100]: skew ratio computed from sample statistics. The skewness used for costing is the product of the optimizer_skew_factor and the skew ratio."),
+             NULL,
+             GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+            },
+            &optimizer_skew_factor,
+            0, 0, 100,
+            NULL, NULL, NULL
+    },
 
 	{
 		{"optimizer_join_order_threshold", PGC_USERSET, QUERY_TUNING_METHOD,

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -540,6 +540,7 @@ extern int optimizer_join_arity_for_associativity_commutativity;
 extern int optimizer_cte_inlining_bound;
 extern int optimizer_push_group_by_below_setop_threshold;
 extern int optimizer_xform_bind_threshold;
+extern int optimizer_skew_factor;
 extern bool optimizer_force_multistage_agg;
 extern bool optimizer_force_three_stage_scalar_dqa;
 extern bool optimizer_force_expanded_distinct_aggs;

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -450,6 +450,7 @@
 		"optimizer_segments",
 		"optimizer_sort_factor",
 		"optimizer_trace_fallback",
+		"optimizer_skew_factor",
 		"optimizer_use_external_constant_expression_evaluation_for_ints",
 		"optimizer_use_gpdb_allocators",
 		"parallel_leader_participation",

--- a/src/test/regress/expected/qp_skew.out
+++ b/src/test/regress/expected/qp_skew.out
@@ -1,0 +1,274 @@
+create schema orca_skew;
+set optimizer_skew_factor = 1;
+-- Verify ORCA chooses broadcast over redistribution for skewed join 
+-- t1 skewed, randomly distributed
+-- t2 uniform, randomly distributed
+-- t1, t2 have ~25 rows
+-- start_ignore
+DROP TABLE t1;
+ERROR:  table "t1" does not exist
+DROP TABLE t2;
+ERROR:  table "t2" does not exist
+-- end_ignore
+CREATE TABLE t1 (
+    c11 integer,
+    c12 integer
+)
+ DISTRIBUTED RANDOMLY;
+CREATE TABLE t2 (
+    c21 integer,
+    c22 integer
+)
+ DISTRIBUTED RANDOMLY;
+-- t1: 6 distinct values
+-- (0,1) 20 rows (skewed)
+-- (1,2) 1 row
+-- (2,3) 1 row
+-- (3,4) 1 row
+-- (5,6) 1 row
+-- (6,7) 1 row
+insert into t1 select 0,1 from generate_series(1,20);
+insert into t1 select 1,2;
+insert into t1 select 2,3;
+insert into t1 select 3,4;
+insert into t1 select 5,6;
+insert into t1 select 6,7;
+-- t2: 9 distinct values
+-- (7,8) 3 rows
+-- (8,9) 3 rows
+-- (9,10) 3 rows
+-- (10,11) 3 rows
+-- (12,13) 3 rows
+-- (15,16) 3 rows
+-- (16,1) 3 rows (match)
+-- (17,2) 3 rows (match)
+-- (20,3) 3 rows (match)
+insert into t2 select 7,8 from generate_series(1,3);
+insert into t2 select 8,9 from generate_series(1,3);
+insert into t2 select 9,10 from generate_series(1,3);
+insert into t2 select 10,11 from generate_series(1,3);
+insert into t2 select 12,13 from generate_series(1,3);
+insert into t2 select 15,16 from generate_series(1,3);
+insert into t2 select 16,1 from generate_series(1,3);
+insert into t2 select 17,2 from generate_series(1,3);
+insert into t2 select 20,3 from generate_series(1,3);
+ANALYZE t1;
+ANALYZE t2;
+EXPLAIN SELECT
+  c12, c22
+  FROM
+  t1 INNER JOIN t2
+    ON c12 = c22;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=1.38..3.91 rows=75 width=8)
+   ->  Hash Join  (cost=1.38..2.91 rows=25 width=8)
+         Hash Cond: (t1.c12 = t2.c22)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..1.25 rows=8 width=4)
+               Hash Key: t1.c12
+               ->  Seq Scan on t1  (cost=0.00..1.08 rows=8 width=4)
+         ->  Hash  (cost=1.27..1.27 rows=9 width=4)
+               ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..1.27 rows=9 width=4)
+                     Hash Key: t2.c22
+                     ->  Seq Scan on t2  (cost=0.00..1.09 rows=9 width=4)
+ Optimizer: Postgres query optimizer
+(11 rows)
+
+-- Verify ORCA chooses broadcast over redistribution for skewed multiple joins 
+-- t1 has a skewed value (0,1) matching tuples (16,1) in t2
+-- the result of t1 ⋈ t2 also tends to skew
+-- start_ignore
+DROP TABLE t3;
+ERROR:  table "t3" does not exist
+-- end_ignore
+CREATE TABLE t3 (
+    c31 integer,
+    c32 integer
+)
+ DISTRIBUTED RANDOMLY;
+-- t3: 3 distinct values
+-- (0,1) 7 rows
+-- (1,2) 7 rows
+-- (2,3) 7 rows
+insert into t3 select 0,1 from generate_series(1,7);
+insert into t3 select 1,2 from generate_series(1,7);
+insert into t3 select 2,3 from generate_series(1,7);
+ANALYZE t3;
+-- Force ORCA to execute t1 ⋈ t2 first
+set optimizer_join_order = query;
+EXPLAIN SELECT
+  c12, c22, c32
+  FROM
+  t1 INNER JOIN t2
+    ON c12 = c22
+  INNER JOIN t3
+    ON c22 = c32;
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=2.65..12.09 rows=462 width=12)
+   ->  Hash Join  (cost=2.65..5.93 rows=154 width=12)
+         Hash Cond: (t2.c22 = t1.c12)
+         ->  Hash Join  (cost=1.30..2.81 rows=21 width=8)
+               Hash Cond: (t2.c22 = t3.c32)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..1.27 rows=9 width=4)
+                     Hash Key: t2.c22
+                     ->  Seq Scan on t2  (cost=0.00..1.09 rows=9 width=4)
+               ->  Hash  (cost=1.21..1.21 rows=7 width=4)
+                     ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..1.21 rows=7 width=4)
+                           Hash Key: t3.c32
+                           ->  Seq Scan on t3  (cost=0.00..1.07 rows=7 width=4)
+         ->  Hash  (cost=1.25..1.25 rows=8 width=4)
+               ->  Redistribute Motion 3:3  (slice4; segments: 3)  (cost=0.00..1.25 rows=8 width=4)
+                     Hash Key: t1.c12
+                     ->  Seq Scan on t1  (cost=0.00..1.08 rows=8 width=4)
+ Optimizer: Postgres query optimizer
+(17 rows)
+
+-- Reset join order
+set optimizer_join_order = exhaustive2;
+-- Verify ORCA chooses redistribution over broadcast
+-- when the data skew isn't pronuounced
+-- start_ignore
+DROP TABLE t4;
+ERROR:  table "t4" does not exist
+-- end_ignore
+CREATE TABLE t4 (
+    c41 integer,
+    c42 integer
+)
+ DISTRIBUTED RANDOMLY;
+-- t4: 3 distinct values
+-- (3,2) 8 rows
+-- (4,3) 6 rows
+-- (5,4) 4 rows
+insert into t4 select 3,2 from generate_series(1,8);
+insert into t4 select 4,3 from generate_series(1,6);
+insert into t4 select 5,4 from generate_series(1,4);
+ANALYZE t4;
+EXPLAIN SELECT
+  c32, c42
+  FROM
+  t3 INNER JOIN t4
+    ON c32 = c42;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=1.26..4.14 rows=98 width=8)
+   ->  Hash Join  (cost=1.26..2.83 rows=33 width=8)
+         Hash Cond: (t3.c32 = t4.c42)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..1.21 rows=7 width=4)
+               Hash Key: t3.c32
+               ->  Seq Scan on t3  (cost=0.00..1.07 rows=7 width=4)
+         ->  Hash  (cost=1.18..1.18 rows=6 width=4)
+               ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..1.18 rows=6 width=4)
+                     Hash Key: t4.c42
+                     ->  Seq Scan on t4  (cost=0.00..1.06 rows=6 width=4)
+ Optimizer: Postgres query optimizer
+(11 rows)
+
+-- user option to emphasize data skew by multiplying
+-- the skew ratio with a larger-than 1 skew factor
+set optimizer_skew_factor = 25;
+EXPLAIN SELECT
+  c32, c42
+  FROM
+  t3 INNER JOIN t4
+    ON c32 = c42;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=1.26..4.14 rows=98 width=8)
+   ->  Hash Join  (cost=1.26..2.83 rows=33 width=8)
+         Hash Cond: (t3.c32 = t4.c42)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..1.21 rows=7 width=4)
+               Hash Key: t3.c32
+               ->  Seq Scan on t3  (cost=0.00..1.07 rows=7 width=4)
+         ->  Hash  (cost=1.18..1.18 rows=6 width=4)
+               ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..1.18 rows=6 width=4)
+                     Hash Key: t4.c42
+                     ->  Seq Scan on t4  (cost=0.00..1.06 rows=6 width=4)
+ Optimizer: Postgres query optimizer
+(11 rows)
+
+-- reset skew factor
+set optimizer_skew_factor = 1;
+-- Currently ORCA doesn't introduce a shuffle motion
+-- before joining a table distributed by a skewed column
+-- To demonstrate that, we recreate t1 and t2 with the same
+-- data but distribute them by the c*1 column
+-- t1 skewed, distributed by c11
+-- t2 uniform, distributed by c21
+-- t1, t2 have ~25 rows
+-- start_ignore
+DROP TABLE t1;
+DROP TABLE t2;
+-- end_ignore
+CREATE TABLE t1 (
+    c11 integer,
+    c12 integer
+)
+ DISTRIBUTED BY (c11);
+CREATE TABLE t2 (
+    c21 integer,
+    c22 integer
+)
+ DISTRIBUTED BY (c21);
+-- t1: 6 distinct values
+-- segment 1:
+-- (0,1) 20 rows
+-- (1,2) 1 rows
+-- segment 2:
+-- (2,3) 1 rows
+-- (3,4) 1 rows
+-- segment 3:
+-- (5,6) 1 rows
+-- (6,7) 1 rows
+insert into t1 select 0,1 from generate_series(1,20);
+insert into t1 select 1,2;
+insert into t1 select 2,3;
+insert into t1 select 3,4;
+insert into t1 select 5,6;
+insert into t1 select 6,7;
+-- t2: 6 distinct values
+-- segment 1:
+-- (7,8) 3 rows
+-- (8,9) 3 rows
+-- (16,1) 3 rows
+-- segment 2:
+-- (9,10) 3 rows
+-- (10,11) 3 rows
+-- (17,2) 3 rows
+-- segment 3:
+-- (12,13) 3 rows
+-- (15,16) 3 rows
+-- (20,3) 3 rows
+insert into t2 select 7,8 from generate_series(1,3);
+insert into t2 select 8,9 from generate_series(1,3);
+insert into t2 select 9,10 from generate_series(1,3);
+insert into t2 select 10,11 from generate_series(1,3);
+insert into t2 select 12,13 from generate_series(1,3);
+insert into t2 select 15,16 from generate_series(1,3);
+insert into t2 select 16,1 from generate_series(1,3);
+insert into t2 select 17,2 from generate_series(1,3);
+insert into t2 select 20,3 from generate_series(1,3);
+ANALYZE t1;
+ANALYZE t2;
+EXPLAIN SELECT
+  c12, c22
+  FROM
+  t1 INNER JOIN t2
+    ON c12 = c22;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=1.38..3.91 rows=75 width=8)
+   ->  Hash Join  (cost=1.38..2.91 rows=25 width=8)
+         Hash Cond: (t1.c12 = t2.c22)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..1.25 rows=8 width=4)
+               Hash Key: t1.c12
+               ->  Seq Scan on t1  (cost=0.00..1.08 rows=8 width=4)
+         ->  Hash  (cost=1.27..1.27 rows=9 width=4)
+               ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..1.27 rows=9 width=4)
+                     Hash Key: t2.c22
+                     ->  Seq Scan on t2  (cost=0.00..1.09 rows=9 width=4)
+ Optimizer: Postgres query optimizer
+(11 rows)
+
+reset optimizer_skew_factor;

--- a/src/test/regress/expected/qp_skew_optimizer.out
+++ b/src/test/regress/expected/qp_skew_optimizer.out
@@ -1,0 +1,261 @@
+create schema orca_skew;
+set optimizer_skew_factor = 1;
+-- Verify ORCA chooses broadcast over redistribution for skewed join 
+-- t1 skewed, randomly distributed
+-- t2 uniform, randomly distributed
+-- t1, t2 have ~25 rows
+-- start_ignore
+DROP TABLE t1;
+ERROR:  table "t1" does not exist
+DROP TABLE t2;
+ERROR:  table "t2" does not exist
+-- end_ignore
+CREATE TABLE t1 (
+    c11 integer,
+    c12 integer
+)
+ DISTRIBUTED RANDOMLY;
+CREATE TABLE t2 (
+    c21 integer,
+    c22 integer
+)
+ DISTRIBUTED RANDOMLY;
+-- t1: 6 distinct values
+-- (0,1) 20 rows (skewed)
+-- (1,2) 1 row
+-- (2,3) 1 row
+-- (3,4) 1 row
+-- (5,6) 1 row
+-- (6,7) 1 row
+insert into t1 select 0,1 from generate_series(1,20);
+insert into t1 select 1,2;
+insert into t1 select 2,3;
+insert into t1 select 3,4;
+insert into t1 select 5,6;
+insert into t1 select 6,7;
+-- t2: 9 distinct values
+-- (7,8) 3 rows
+-- (8,9) 3 rows
+-- (9,10) 3 rows
+-- (10,11) 3 rows
+-- (12,13) 3 rows
+-- (15,16) 3 rows
+-- (16,1) 3 rows (match)
+-- (17,2) 3 rows (match)
+-- (20,3) 3 rows (match)
+insert into t2 select 7,8 from generate_series(1,3);
+insert into t2 select 8,9 from generate_series(1,3);
+insert into t2 select 9,10 from generate_series(1,3);
+insert into t2 select 10,11 from generate_series(1,3);
+insert into t2 select 12,13 from generate_series(1,3);
+insert into t2 select 15,16 from generate_series(1,3);
+insert into t2 select 16,1 from generate_series(1,3);
+insert into t2 select 17,2 from generate_series(1,3);
+insert into t2 select 20,3 from generate_series(1,3);
+ANALYZE t1;
+ANALYZE t2;
+EXPLAIN SELECT
+  c12, c22
+  FROM
+  t1 INNER JOIN t2
+    ON c12 = c22;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.01 rows=75 width=8)
+   ->  Hash Join  (cost=0.00..862.01 rows=25 width=8)
+         Hash Cond: (t2.c22 = t1.c12)
+         ->  Seq Scan on t2  (cost=0.00..431.00 rows=9 width=4)
+         ->  Hash  (cost=431.00..431.00 rows=25 width=4)
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=25 width=4)
+                     ->  Seq Scan on t1  (cost=0.00..431.00 rows=9 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(8 rows)
+
+-- Verify ORCA chooses broadcast over redistribution for skewed multiple joins 
+-- t1 has a skewed value (0,1) matching tuples (16,1) in t2
+-- the result of t1 ⋈ t2 also tends to skew
+-- start_ignore
+DROP TABLE t3;
+ERROR:  table "t3" does not exist
+-- end_ignore
+CREATE TABLE t3 (
+    c31 integer,
+    c32 integer
+)
+ DISTRIBUTED RANDOMLY;
+-- t3: 3 distinct values
+-- (0,1) 7 rows
+-- (1,2) 7 rows
+-- (2,3) 7 rows
+insert into t3 select 0,1 from generate_series(1,7);
+insert into t3 select 1,2 from generate_series(1,7);
+insert into t3 select 2,3 from generate_series(1,7);
+ANALYZE t3;
+-- Force ORCA to execute t1 ⋈ t2 first
+set optimizer_join_order = query;
+EXPLAIN SELECT
+  c12, c22, c32
+  FROM
+  t1 INNER JOIN t2
+    ON c12 = c22
+  INNER JOIN t3
+    ON c22 = c32;
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1293.05 rows=525 width=12)
+   ->  Hash Join  (cost=0.00..1293.03 rows=175 width=12)
+         Hash Cond: (t2.c22 = t3.c32)
+         ->  Hash Join  (cost=0.00..862.01 rows=25 width=8)
+               Hash Cond: (t1.c12 = t2.c22)
+               ->  Seq Scan on t1  (cost=0.00..431.00 rows=9 width=4)
+               ->  Hash  (cost=431.00..431.00 rows=27 width=4)
+                     ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=27 width=4)
+                           ->  Seq Scan on t2  (cost=0.00..431.00 rows=9 width=4)
+         ->  Hash  (cost=431.00..431.00 rows=21 width=4)
+               ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=21 width=4)
+                     ->  Seq Scan on t3  (cost=0.00..431.00 rows=7 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(13 rows)
+
+-- Reset join order
+set optimizer_join_order = exhaustive2;
+-- Verify ORCA chooses redistribution over broadcast
+-- when the data skew isn't pronuounced
+-- start_ignore
+DROP TABLE t4;
+ERROR:  table "t4" does not exist
+-- end_ignore
+CREATE TABLE t4 (
+    c41 integer,
+    c42 integer
+)
+ DISTRIBUTED RANDOMLY;
+-- t4: 3 distinct values
+-- (3,2) 8 rows
+-- (4,3) 6 rows
+-- (5,4) 4 rows
+insert into t4 select 3,2 from generate_series(1,8);
+insert into t4 select 4,3 from generate_series(1,6);
+insert into t4 select 5,4 from generate_series(1,4);
+ANALYZE t4;
+EXPLAIN SELECT
+  c32, c42
+  FROM
+  t3 INNER JOIN t4
+    ON c32 = c42;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.01 rows=126 width=8)
+   ->  Hash Join  (cost=0.00..862.01 rows=42 width=8)
+         Hash Cond: (t3.c32 = t4.c42)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=7 width=4)
+               Hash Key: t3.c32
+               ->  Seq Scan on t3  (cost=0.00..431.00 rows=7 width=4)
+         ->  Hash  (cost=431.00..431.00 rows=6 width=4)
+               ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=6 width=4)
+                     Hash Key: t4.c42
+                     ->  Seq Scan on t4  (cost=0.00..431.00 rows=6 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(11 rows)
+
+-- user option to emphasize data skew by multiplying
+-- the skew ratio with a larger-than 1 skew factor
+set optimizer_skew_factor = 25;
+EXPLAIN SELECT
+  c32, c42
+  FROM
+  t3 INNER JOIN t4
+    ON c32 = c42;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.01 rows=126 width=8)
+   ->  Hash Join  (cost=0.00..862.01 rows=42 width=8)
+         Hash Cond: (t3.c32 = t4.c42)
+         ->  Seq Scan on t3  (cost=0.00..431.00 rows=7 width=4)
+         ->  Hash  (cost=431.00..431.00 rows=18 width=4)
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=18 width=4)
+                     ->  Seq Scan on t4  (cost=0.00..431.00 rows=6 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(8 rows)
+
+-- reset skew factor
+set optimizer_skew_factor = 1;
+-- Currently ORCA doesn't introduce a shuffle motion
+-- before joining a table distributed by a skewed column
+-- To demonstrate that, we recreate t1 and t2 with the same
+-- data but distribute them by the c*1 column
+-- t1 skewed, distributed by c11
+-- t2 uniform, distributed by c21
+-- t1, t2 have ~25 rows
+-- start_ignore
+DROP TABLE t1;
+DROP TABLE t2;
+-- end_ignore
+CREATE TABLE t1 (
+    c11 integer,
+    c12 integer
+)
+ DISTRIBUTED BY (c11);
+CREATE TABLE t2 (
+    c21 integer,
+    c22 integer
+)
+ DISTRIBUTED BY (c21);
+-- t1: 6 distinct values
+-- segment 1:
+-- (0,1) 20 rows
+-- (1,2) 1 rows
+-- segment 2:
+-- (2,3) 1 rows
+-- (3,4) 1 rows
+-- segment 3:
+-- (5,6) 1 rows
+-- (6,7) 1 rows
+insert into t1 select 0,1 from generate_series(1,20);
+insert into t1 select 1,2;
+insert into t1 select 2,3;
+insert into t1 select 3,4;
+insert into t1 select 5,6;
+insert into t1 select 6,7;
+-- t2: 6 distinct values
+-- segment 1:
+-- (7,8) 3 rows
+-- (8,9) 3 rows
+-- (16,1) 3 rows
+-- segment 2:
+-- (9,10) 3 rows
+-- (10,11) 3 rows
+-- (17,2) 3 rows
+-- segment 3:
+-- (12,13) 3 rows
+-- (15,16) 3 rows
+-- (20,3) 3 rows
+insert into t2 select 7,8 from generate_series(1,3);
+insert into t2 select 8,9 from generate_series(1,3);
+insert into t2 select 9,10 from generate_series(1,3);
+insert into t2 select 10,11 from generate_series(1,3);
+insert into t2 select 12,13 from generate_series(1,3);
+insert into t2 select 15,16 from generate_series(1,3);
+insert into t2 select 16,1 from generate_series(1,3);
+insert into t2 select 17,2 from generate_series(1,3);
+insert into t2 select 20,3 from generate_series(1,3);
+ANALYZE t1;
+ANALYZE t2;
+EXPLAIN SELECT
+  c12, c22
+  FROM
+  t1 INNER JOIN t2
+    ON c12 = c22;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.01 rows=75 width=8)
+   ->  Hash Join  (cost=0.00..862.01 rows=25 width=8)
+         Hash Cond: (t2.c22 = t1.c12)
+         ->  Seq Scan on t2  (cost=0.00..431.00 rows=9 width=4)
+         ->  Hash  (cost=431.00..431.00 rows=25 width=4)
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=25 width=4)
+                     ->  Seq Scan on t1  (cost=0.00..431.00 rows=9 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(8 rows)
+
+reset optimizer_skew_factor;

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -190,7 +190,7 @@ test: rpt rpt_joins rpt_tpch rpt_returning
 # temp tables
 test: bfv_cte bfv_joins bfv_subquery bfv_planner bfv_legacy bfv_temp bfv_dml
 
-test: qp_olap_mdqa qp_misc gp_recursive_cte qp_dml_joins
+test: qp_olap_mdqa qp_misc gp_recursive_cte qp_dml_joins qp_skew
 
 test: qp_misc_jiras qp_with_clause qp_executor qp_olap_windowerr qp_olap_window qp_derived_table qp_bitmapscan qp_dropped_cols
 test: qp_with_functional_inlining qp_with_functional_noinlining

--- a/src/test/regress/sql/qp_skew.sql
+++ b/src/test/regress/sql/qp_skew.sql
@@ -1,0 +1,243 @@
+create schema orca_skew;
+-- start_ignore
+GRANT ALL ON SCHEMA orca_skew TO PUBLIC;
+SET search_path to orca_skew, public;
+-- end_ignore
+
+-- start_ignore
+SET optimizer_trace_fallback to on;
+-- end_ignore
+
+set optimizer_skew_factor = 1;
+
+-- Verify ORCA chooses broadcast over redistribution for skewed join 
+-- t1 skewed, randomly distributed
+-- t2 uniform, randomly distributed
+-- t1, t2 have ~25 rows
+
+-- start_ignore
+DROP TABLE t1;
+DROP TABLE t2;
+-- end_ignore
+
+CREATE TABLE t1 (
+    c11 integer,
+    c12 integer
+)
+ DISTRIBUTED RANDOMLY;
+
+CREATE TABLE t2 (
+    c21 integer,
+    c22 integer
+)
+ DISTRIBUTED RANDOMLY;
+
+-- t1: 6 distinct values
+-- (0,1) 20 rows (skewed)
+-- (1,2) 1 row
+-- (2,3) 1 row
+-- (3,4) 1 row
+-- (5,6) 1 row
+-- (6,7) 1 row
+
+insert into t1 select 0,1 from generate_series(1,20);
+insert into t1 select 1,2;
+insert into t1 select 2,3;
+insert into t1 select 3,4;
+insert into t1 select 5,6;
+insert into t1 select 6,7;
+
+-- t2: 9 distinct values
+-- (7,8) 3 rows
+-- (8,9) 3 rows
+-- (9,10) 3 rows
+-- (10,11) 3 rows
+-- (12,13) 3 rows
+-- (15,16) 3 rows
+-- (16,1) 3 rows (match)
+-- (17,2) 3 rows (match)
+-- (20,3) 3 rows (match)
+
+insert into t2 select 7,8 from generate_series(1,3);
+insert into t2 select 8,9 from generate_series(1,3);
+insert into t2 select 9,10 from generate_series(1,3);
+insert into t2 select 10,11 from generate_series(1,3);
+insert into t2 select 12,13 from generate_series(1,3);
+insert into t2 select 15,16 from generate_series(1,3);
+insert into t2 select 16,1 from generate_series(1,3);
+insert into t2 select 17,2 from generate_series(1,3);
+insert into t2 select 20,3 from generate_series(1,3);
+
+ANALYZE t1;
+ANALYZE t2;
+
+EXPLAIN SELECT
+  c12, c22
+  FROM
+  t1 INNER JOIN t2
+    ON c12 = c22;
+
+-- Verify ORCA chooses broadcast over redistribution for skewed multiple joins 
+-- t1 has a skewed value (0,1) matching tuples (16,1) in t2
+-- the result of t1 ⋈ t2 also tends to skew
+
+-- start_ignore
+DROP TABLE t3;
+-- end_ignore
+
+CREATE TABLE t3 (
+    c31 integer,
+    c32 integer
+)
+ DISTRIBUTED RANDOMLY;
+
+-- t3: 3 distinct values
+-- (0,1) 7 rows
+-- (1,2) 7 rows
+-- (2,3) 7 rows
+
+insert into t3 select 0,1 from generate_series(1,7);
+insert into t3 select 1,2 from generate_series(1,7);
+insert into t3 select 2,3 from generate_series(1,7);
+
+ANALYZE t3;
+
+-- Force ORCA to execute t1 ⋈ t2 first
+set optimizer_join_order = query;
+
+EXPLAIN SELECT
+  c12, c22, c32
+  FROM
+  t1 INNER JOIN t2
+    ON c12 = c22
+  INNER JOIN t3
+    ON c22 = c32;
+
+-- Reset join order
+set optimizer_join_order = exhaustive2;
+
+-- Verify ORCA chooses redistribution over broadcast
+-- when the data skew isn't pronuounced
+
+-- start_ignore
+DROP TABLE t4;
+-- end_ignore
+
+CREATE TABLE t4 (
+    c41 integer,
+    c42 integer
+)
+ DISTRIBUTED RANDOMLY;
+
+-- t4: 3 distinct values
+-- (3,2) 8 rows
+-- (4,3) 6 rows
+-- (5,4) 4 rows
+
+insert into t4 select 3,2 from generate_series(1,8);
+insert into t4 select 4,3 from generate_series(1,6);
+insert into t4 select 5,4 from generate_series(1,4);
+
+ANALYZE t4;
+
+EXPLAIN SELECT
+  c32, c42
+  FROM
+  t3 INNER JOIN t4
+    ON c32 = c42;
+
+-- user option to emphasize data skew by multiplying
+-- the skew ratio with a larger-than 1 skew factor
+set optimizer_skew_factor = 25;
+
+EXPLAIN SELECT
+  c32, c42
+  FROM
+  t3 INNER JOIN t4
+    ON c32 = c42;
+
+-- reset skew factor
+set optimizer_skew_factor = 1;
+
+-- Currently ORCA doesn't introduce a shuffle motion
+-- before joining a table distributed by a skewed column
+-- To demonstrate that, we recreate t1 and t2 with the same
+-- data but distribute them by the c*1 column
+-- t1 skewed, distributed by c11
+-- t2 uniform, distributed by c21
+-- t1, t2 have ~25 rows
+
+-- start_ignore
+DROP TABLE t1;
+DROP TABLE t2;
+-- end_ignore
+
+CREATE TABLE t1 (
+    c11 integer,
+    c12 integer
+)
+ DISTRIBUTED BY (c11);
+
+CREATE TABLE t2 (
+    c21 integer,
+    c22 integer
+)
+ DISTRIBUTED BY (c21);
+
+-- t1: 6 distinct values
+-- segment 1:
+-- (0,1) 20 rows
+-- (1,2) 1 rows
+-- segment 2:
+-- (2,3) 1 rows
+-- (3,4) 1 rows
+-- segment 3:
+-- (5,6) 1 rows
+-- (6,7) 1 rows
+
+insert into t1 select 0,1 from generate_series(1,20);
+insert into t1 select 1,2;
+insert into t1 select 2,3;
+insert into t1 select 3,4;
+insert into t1 select 5,6;
+insert into t1 select 6,7;
+
+-- t2: 6 distinct values
+-- segment 1:
+-- (7,8) 3 rows
+-- (8,9) 3 rows
+-- (16,1) 3 rows
+-- segment 2:
+-- (9,10) 3 rows
+-- (10,11) 3 rows
+-- (17,2) 3 rows
+-- segment 3:
+-- (12,13) 3 rows
+-- (15,16) 3 rows
+-- (20,3) 3 rows
+
+insert into t2 select 7,8 from generate_series(1,3);
+insert into t2 select 8,9 from generate_series(1,3);
+insert into t2 select 9,10 from generate_series(1,3);
+insert into t2 select 10,11 from generate_series(1,3);
+insert into t2 select 12,13 from generate_series(1,3);
+insert into t2 select 15,16 from generate_series(1,3);
+insert into t2 select 16,1 from generate_series(1,3);
+insert into t2 select 17,2 from generate_series(1,3);
+insert into t2 select 20,3 from generate_series(1,3);
+
+
+ANALYZE t1;
+ANALYZE t2;
+
+EXPLAIN SELECT
+  c12, c22
+  FROM
+  t1 INNER JOIN t2
+    ON c12 = c22;
+
+reset optimizer_skew_factor;
+
+-- start_ignore
+DROP SCHEMA orca_skew CASCADE;
+-- end_ignore


### PR DESCRIPTION
**Penalize hash join in case of skew**

**Issue:**
ORCA generates plan with hash redistribution when data is highly skewed,
making one segment the bottleneck in execution

**Root cause:**
Currently skew is only taken into account when the number of
distinct value is less than the segment count. This over simplifies the scenario
where skew may arise.

**Solution:**
We compute skew ratio using sampled statistics. The sampling rate of each bucket
is proportional to the bucket frequency, i.e, the higher the bucket frequency,
the more datum we sample from that bucket.

We employ deterministic sampling algorithm by always starting with the lower
bound, then the high bound, medium, quarter, three quarters, one eighth, three
eighths, etc. In normalized terms, 0, 1, 0.5, 0,25, 0.75, 0.125, 0.375, etc. The
sampling series ensures discrete sampling.

The skew computation is controlled by GUC optimizer_skew_factor. Its default
value is 0, i.e, skew computation is turned off. Users can turn it on by setting
the GUC to a larger than 0 value. The GUC is called skew factor, because the
final skewness used for costing is the product of the skew factor (coefficient)
and the skew ratio (variable). This GUC gives user additional control over plan
motions (broadcast/gather vs. redistribution) if they choose to emphasize the
data skew.

**Implementation:**
[CCostModelGPDB] -- Enable Histogram ComputeSkew to calculate the skew factor of
relations to be joined. Implement superlinear skew multiplier, to allow fine
tuning when the skew factor is small, and coarse tuning when the skew factor is
big.
[ICostModel] -- Add root stats getter
[CPhysical] -- Make helper function GetSkew public
[CHistogram] -- Replace RAND function with deterministic algorithm in computing
data skew. Collect sample from low frequency buckets first to ensure sampling of
low frequency buckets. Normalize the bucket frequency in case they aren't
normalized. Set skew multiplier to sqrt(SAMPLE_SIZE) in case of zero variance.
[CBucket] -- Remove unused GetRandomSample
[COptTasks, CHint, COptimizerConfig, dxltokens, CParseHandlerHint, dxltokens,
guc_gp, guc, unsync_guc_name] -- Add optimizer_skew_factor GUC. Default case:
optimizer_skew_factor = 0. Calculate skew from # of segments over # distinct
values. General case: optimizer_skew_factor ∈ [1, 100]. First, calculate skew
from 1000 samples. Then, multiply that by the multiplier. Keep the maximum
between this value and the one calculated using the default algorithm.
[regress] -- Add skew test
[HAWQ-TPCH-Stat-Derivation.mdp] -- Manually add object info to avoid cache
lookup failure