### PR TITLE
Add reloption to force table to collect HLL stats

### DIFF
--- a/src/backend/access/common/reloptions.c
+++ b/src/backend/access/common/reloptions.c
@@ -1435,7 +1435,7 @@ default_reloptions(Datum reloptions, bool validate, relopt_kind kind)
 		{"vacuum_truncate", RELOPT_TYPE_BOOL,
 		offsetof(StdRdOptions, vacuum_truncate)},
 		{SOPT_ANALYZEHLL, RELOPT_TYPE_BOOL,
-		offsetof(StdRdOptions, analyze_hll)}
+		offsetof(StdRdOptions, analyze_hll_non_part_table)}
 
 	};
 

--- a/src/backend/access/common/reloptions.c
+++ b/src/backend/access/common/reloptions.c
@@ -1434,7 +1434,7 @@ default_reloptions(Datum reloptions, bool validate, relopt_kind kind)
 		offsetof(StdRdOptions, vacuum_index_cleanup)},
 		{"vacuum_truncate", RELOPT_TYPE_BOOL,
 		offsetof(StdRdOptions, vacuum_truncate)},
-		{"analyze_hll", RELOPT_TYPE_BOOL,
+		{SOPT_ANALYZEHLL, RELOPT_TYPE_BOOL,
 		offsetof(StdRdOptions, analyze_hll)}
 
 	};

--- a/src/backend/access/common/reloptions.c
+++ b/src/backend/access/common/reloptions.c
@@ -1433,7 +1433,10 @@ default_reloptions(Datum reloptions, bool validate, relopt_kind kind)
 		{"vacuum_index_cleanup", RELOPT_TYPE_BOOL,
 		offsetof(StdRdOptions, vacuum_index_cleanup)},
 		{"vacuum_truncate", RELOPT_TYPE_BOOL,
-		offsetof(StdRdOptions, vacuum_truncate)}
+		offsetof(StdRdOptions, vacuum_truncate)},
+		{"analyze_hll", RELOPT_TYPE_BOOL,
+		offsetof(StdRdOptions, analyze_hll)}
+
 	};
 
 	options = parseRelOptions(reloptions, validate, kind, &numoptions);

--- a/src/backend/access/common/reloptions_gp.c
+++ b/src/backend/access/common/reloptions_gp.c
@@ -56,7 +56,7 @@ static relopt_bool boolRelOpts_gp[] =
 	},
 	{
 		{
-			"analyze_hll",
+			SOPT_ANALYZEHLL,
 			"Enable HLL stats collection during analyze",
 			RELOPT_KIND_HEAP | RELOPT_KIND_TOAST | RELOPT_KIND_APPENDOPTIMIZED,
 			ShareUpdateExclusiveLock
@@ -626,13 +626,13 @@ transformAOStdRdOptions(StdRdOptions *opts, Datum withOpts)
 				astate = accumArrayResult(astate, d, false, TEXTOID,
 										  CurrentMemoryContext);
 			}
-			soptLen = strlen("analyze_hll");
+			soptLen = strlen(SOPT_ANALYZEHLL);
 			if (withLen > soptLen &&
-				pg_strncasecmp(strval, "analyze_hll", soptLen) == 0)
+				pg_strncasecmp(strval, SOPT_ANALYZEHLL, soptLen) == 0)
 			{
 				foundAnalyzeHLL = true;
 				d = CStringGetTextDatum(psprintf("%s=%s",
-												 "analyze_hll",
+												 SOPT_ANALYZEHLL,
 												 (opts->analyze_hll ? "true" : "false")));
 				astate = accumArrayResult(astate, d, false, TEXTOID,
 										  CurrentMemoryContext);
@@ -692,7 +692,7 @@ transformAOStdRdOptions(StdRdOptions *opts, Datum withOpts)
 	if ((opts->analyze_hll != ANALYZE_DEFAULT_HLL) && !foundAnalyzeHLL)
 	{
 		d = CStringGetTextDatum(psprintf("%s=%s",
-										 "analyze_hll",
+										 SOPT_ANALYZEHLL,
 										 (opts->analyze_hll ? "true" : "false")));
 		astate = accumArrayResult(astate, d, false, TEXTOID,
 								  CurrentMemoryContext);
@@ -739,11 +739,11 @@ reloption_is_default(const char *optstr, int optlen)
 										 SOPT_CHECKSUM,
 										 AO_DEFAULT_CHECKSUM ? "true" : "false");
 	}
-	else if (optlen > strlen("analyze_hll") &&
-		pg_strncasecmp(optstr, "analyze_hll", strlen("analyze_hll")) == 0)
+	else if (optlen > strlen(SOPT_ANALYZEHLL) &&
+		pg_strncasecmp(optstr, SOPT_ANALYZEHLL, strlen("analyze_hll")) == 0)
 	{
 		defaultopt = psprintf("%s=%s",
-							  "analyze_hll",
+							  SOPT_ANALYZEHLL,
 										 ANALYZE_DEFAULT_HLL ? "true" : "false");
 	}
 	if (defaultopt != NULL)

--- a/src/backend/access/common/reloptions_gp.c
+++ b/src/backend/access/common/reloptions_gp.c
@@ -54,6 +54,15 @@ static relopt_bool boolRelOpts_gp[] =
 		},
 		AO_DEFAULT_CHECKSUM
 	},
+	{
+		{
+			"analyze_hll",
+			"Enable HLL stats collection during analyze",
+			RELOPT_KIND_HEAP | RELOPT_KIND_TOAST | RELOPT_KIND_APPENDOPTIMIZED,
+			ShareUpdateExclusiveLock
+		},
+		ANALYZE_DEFAULT_HLL
+	},
 	/* list terminator */
 	{{NULL}}
 };
@@ -533,7 +542,8 @@ transformAOStdRdOptions(StdRdOptions *opts, Datum withOpts)
 	bool		foundBlksz = false,
 				foundComptype = false,
 				foundComplevel = false,
-				foundChecksum = false;
+				foundChecksum = false,
+				foundAnalyzeHLL = false;
 
 	/*
 	 * withOpts must be parsed to see if an option was spcified in WITH()
@@ -616,6 +626,17 @@ transformAOStdRdOptions(StdRdOptions *opts, Datum withOpts)
 				astate = accumArrayResult(astate, d, false, TEXTOID,
 										  CurrentMemoryContext);
 			}
+			soptLen = strlen("analyze_hll");
+			if (withLen > soptLen &&
+				pg_strncasecmp(strval, "analyze_hll", soptLen) == 0)
+			{
+				foundAnalyzeHLL = true;
+				d = CStringGetTextDatum(psprintf("%s=%s",
+												 "analyze_hll",
+												 (opts->analyze_hll ? "true" : "false")));
+				astate = accumArrayResult(astate, d, false, TEXTOID,
+										  CurrentMemoryContext);
+			}
 		}
 	}
 
@@ -668,6 +689,14 @@ transformAOStdRdOptions(StdRdOptions *opts, Datum withOpts)
 		astate = accumArrayResult(astate, d, false, TEXTOID,
 								  CurrentMemoryContext);
 	}
+	if ((opts->analyze_hll != ANALYZE_DEFAULT_HLL) && !foundAnalyzeHLL)
+	{
+		d = CStringGetTextDatum(psprintf("%s=%s",
+										 "analyze_hll",
+										 (opts->analyze_hll ? "true" : "false")));
+		astate = accumArrayResult(astate, d, false, TEXTOID,
+								  CurrentMemoryContext);
+	}
 	return astate ?
 		makeArrayResult(astate, CurrentMemoryContext) :
 		PointerGetDatum(NULL);
@@ -710,7 +739,13 @@ reloption_is_default(const char *optstr, int optlen)
 										 SOPT_CHECKSUM,
 										 AO_DEFAULT_CHECKSUM ? "true" : "false");
 	}
-
+	else if (optlen > strlen("analyze_hll") &&
+		pg_strncasecmp(optstr, "analyze_hll", strlen("analyze_hll")) == 0)
+	{
+		defaultopt = psprintf("%s=%s",
+							  "analyze_hll",
+										 ANALYZE_DEFAULT_HLL ? "true" : "false");
+	}
 	if (defaultopt != NULL)
 		res = strlen(defaultopt) == optlen && 
 				pg_strncasecmp(optstr, defaultopt, optlen) == 0;

--- a/src/backend/access/common/reloptions_gp.c
+++ b/src/backend/access/common/reloptions_gp.c
@@ -633,7 +633,7 @@ transformAOStdRdOptions(StdRdOptions *opts, Datum withOpts)
 				foundAnalyzeHLL = true;
 				d = CStringGetTextDatum(psprintf("%s=%s",
 												 SOPT_ANALYZEHLL,
-												 (opts->analyze_hll ? "true" : "false")));
+												 (opts->analyze_hll_non_part_table ? "true" : "false")));
 				astate = accumArrayResult(astate, d, false, TEXTOID,
 										  CurrentMemoryContext);
 			}
@@ -689,11 +689,11 @@ transformAOStdRdOptions(StdRdOptions *opts, Datum withOpts)
 		astate = accumArrayResult(astate, d, false, TEXTOID,
 								  CurrentMemoryContext);
 	}
-	if ((opts->analyze_hll != ANALYZE_DEFAULT_HLL) && !foundAnalyzeHLL)
+	if ((opts->analyze_hll_non_part_table != ANALYZE_DEFAULT_HLL) && !foundAnalyzeHLL)
 	{
 		d = CStringGetTextDatum(psprintf("%s=%s",
 										 SOPT_ANALYZEHLL,
-										 (opts->analyze_hll ? "true" : "false")));
+										 (opts->analyze_hll_non_part_table ? "true" : "false")));
 		astate = accumArrayResult(astate, d, false, TEXTOID,
 								  CurrentMemoryContext);
 	}
@@ -740,7 +740,7 @@ reloption_is_default(const char *optstr, int optlen)
 										 AO_DEFAULT_CHECKSUM ? "true" : "false");
 	}
 	else if (optlen > strlen(SOPT_ANALYZEHLL) &&
-		pg_strncasecmp(optstr, SOPT_ANALYZEHLL, strlen("analyze_hll")) == 0)
+		pg_strncasecmp(optstr, SOPT_ANALYZEHLL, strlen("analyze_hll_non_part_table")) == 0)
 	{
 		defaultopt = psprintf("%s=%s",
 							  SOPT_ANALYZEHLL,

--- a/src/backend/commands/analyze.c
+++ b/src/backend/commands/analyze.c
@@ -807,7 +807,9 @@ do_analyze_rel(Relation onerel, VacuumParams *params,
 				bool analyze_hll = false;
 				if (onerel->rd_options != NULL &&
 							((StdRdOptions *) onerel->rd_options)->analyze_hll)
+				{
 					analyze_hll = true;
+				}
 				if (onerel->rd_rel->relkind == RELKIND_RELATION && (onerel->rd_rel->relispartition || analyze_hll))
 				{
 					MemoryContext old_context;

--- a/src/backend/commands/analyze.c
+++ b/src/backend/commands/analyze.c
@@ -801,16 +801,16 @@ do_analyze_rel(Relation onerel, VacuumParams *params,
 									 totalrows);
 				/*
 				 * Store HLL/HLL fullscan information for leaf partitions in
-				 * the stats object. If table was created with "analyze_hll" option, also collect
+				 * the stats object. If table was created with "analyze_hll_non_part_table" option, also collect
 				 * HLL stats for non-leaf tables
 				 */
-				bool analyze_hll = false;
+				bool analyze_hll_non_part_table = false;
 				if (onerel->rd_options != NULL &&
-							((StdRdOptions *) onerel->rd_options)->analyze_hll)
+							((StdRdOptions *) onerel->rd_options)->analyze_hll_non_part_table)
 				{
-					analyze_hll = true;
+					analyze_hll_non_part_table = true;
 				}
-				if (onerel->rd_rel->relkind == RELKIND_RELATION && (onerel->rd_rel->relispartition || analyze_hll))
+				if (onerel->rd_rel->relkind == RELKIND_RELATION && (onerel->rd_rel->relispartition || analyze_hll_non_part_table))
 				{
 					MemoryContext old_context;
 					Datum *hll_values;

--- a/src/backend/commands/analyze.c
+++ b/src/backend/commands/analyze.c
@@ -801,9 +801,14 @@ do_analyze_rel(Relation onerel, VacuumParams *params,
 									 totalrows);
 				/*
 				 * Store HLL/HLL fullscan information for leaf partitions in
-				 * the stats object
+				 * the stats object. If table was created with "analyze_hll" option, also collect
+				 * HLL stats for non-leaf tables
 				 */
-				if (onerel->rd_rel->relkind == RELKIND_RELATION && onerel->rd_rel->relispartition)
+				bool analyze_hll = false;
+				if (onerel->rd_options != NULL &&
+							((StdRdOptions *) onerel->rd_options)->analyze_hll)
+					analyze_hll = true;
+				if (onerel->rd_rel->relkind == RELKIND_RELATION && (onerel->rd_rel->relispartition || analyze_hll))
 				{
 					MemoryContext old_context;
 					Datum *hll_values;

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -1084,7 +1084,6 @@ static const char *const table_storage_parameters[] = {
 	"user_catalog_table",
 	"vacuum_index_cleanup",
 	"vacuum_truncate",
-	"analyze_hll",
 	NULL
 };
 

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -1049,7 +1049,7 @@ static const pgsql_thing_t words_after_create[] = {
 
 /* Storage parameters for CREATE TABLE and ALTER TABLE */
 static const char *const table_storage_parameters[] = {
-	"analyze_hll",
+	"analyze_hll_non_part_table",
 	"autovacuum_analyze_scale_factor",
 	"autovacuum_analyze_threshold",
 	"autovacuum_enabled",

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -1049,6 +1049,7 @@ static const pgsql_thing_t words_after_create[] = {
 
 /* Storage parameters for CREATE TABLE and ALTER TABLE */
 static const char *const table_storage_parameters[] = {
+	"analyze_hll",
 	"autovacuum_analyze_scale_factor",
 	"autovacuum_analyze_threshold",
 	"autovacuum_enabled",
@@ -1083,6 +1084,7 @@ static const char *const table_storage_parameters[] = {
 	"user_catalog_table",
 	"vacuum_index_cleanup",
 	"vacuum_truncate",
+	"analyze_hll",
 	NULL
 };
 

--- a/src/include/access/reloptions.h
+++ b/src/include/access/reloptions.h
@@ -43,6 +43,7 @@
 #define AO_DEFAULT_COMPRESSTYPE   "none"
 #endif
 #define AO_DEFAULT_CHECKSUM       true
+#define ANALYZE_DEFAULT_HLL       false
 
 /* types supported by reloptions */
 typedef enum relopt_type

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -618,6 +618,7 @@ extern IndexCheckType gp_indexcheck_insert;
 #define SOPT_COMPTYPE      "compresstype"
 #define SOPT_COMPLEVEL     "compresslevel"
 #define SOPT_CHECKSUM      "checksum"
+#define SOPT_ANALYZEHLL    "analyze_hll"
 
 /*
  * Functions exported by guc.c

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -618,7 +618,7 @@ extern IndexCheckType gp_indexcheck_insert;
 #define SOPT_COMPTYPE      "compresstype"
 #define SOPT_COMPLEVEL     "compresslevel"
 #define SOPT_CHECKSUM      "checksum"
-#define SOPT_ANALYZEHLL    "analyze_hll"
+#define SOPT_ANALYZEHLL    "analyze_hll_non_part_table"
 
 /*
  * Functions exported by guc.c

--- a/src/include/utils/rel.h
+++ b/src/include/utils/rel.h
@@ -277,6 +277,7 @@ typedef struct StdRdOptions
 	int			parallel_workers;	/* max number of parallel workers */
 	bool		vacuum_index_cleanup;	/* enables index vacuuming and cleanup */
 	bool		vacuum_truncate;	/* enables vacuum to truncate a relation */
+	bool		analyze_hll; 		/* force hll statistics collection on relation */
 
 	int			blocksize;		/* max varblock size (AO rels only) */
 	int			compresslevel;  /* compression level (AO rels only) */

--- a/src/include/utils/rel.h
+++ b/src/include/utils/rel.h
@@ -277,7 +277,7 @@ typedef struct StdRdOptions
 	int			parallel_workers;	/* max number of parallel workers */
 	bool		vacuum_index_cleanup;	/* enables index vacuuming and cleanup */
 	bool		vacuum_truncate;	/* enables vacuum to truncate a relation */
-	bool		analyze_hll; 		/* force hll statistics collection on relation */
+	bool		analyze_hll_non_part_table; 		/* force hll statistics collection on relation */
 
 	int			blocksize;		/* max varblock size (AO rels only) */
 	int			compresslevel;  /* compression level (AO rels only) */

--- a/src/test/regress/expected/incremental_analyze.out
+++ b/src/test/regress/expected/incremental_analyze.out
@@ -2043,3 +2043,67 @@ INFO:  analyzing "public.foo_1_prt_20210201"
 INFO:  Executing SQL: select pg_catalog.gp_acquire_sample_rows(65903, 400, 'f');
 INFO:  analyzing "public.foo" inheritance tree
 rollback;
+-- test behavior of "analyze_hll" create table option
+create table hll_part (i int, j int) distributed by (i)
+partition by range(j)
+(start(1) end(10) every(1));
+insert into hll_part select i, i%9+1 from generate_series(1,100)i;
+analyze hll_part;
+create table hll_default_heap (i int, j int) distributed by (i);
+insert into hll_default_heap values (777,6);
+analyze hll_default_heap;
+-- hll stats should not be collected in non-partition heap table by default
+select 1 from pg_statistic where starelid='hll_default_heap'::regclass and stavalues5 is not null;
+ ?column? 
+----------
+(0 rows)
+
+create table hll_default_ao (i int, j int) with (appendonly=true) distributed by (i);
+insert into hll_default_ao values (777,6);
+analyze hll_default_ao;
+-- hll stats should not be collected in non-partition ao table by default
+select 1 from pg_statistic where starelid='hll_default_ao'::regclass and stavalues5 is not null;
+ ?column? 
+----------
+(0 rows)
+
+create table hll_off (i int, j int) with (analyze_hll=false) distributed by (i);
+insert into hll_off values (777,6);
+analyze hll_off;
+-- hll stats should not be collected in non-partition table when disabled
+select 1 from pg_statistic where starelid='hll_off'::regclass and stavalues5 is not null;
+ ?column? 
+----------
+(0 rows)
+
+create table hll_on_ao (i int, j int) with (analyze_hll=true) distributed by (i);
+insert into hll_on_ao values (777,6);
+analyze hll_on_ao;
+-- hll stats should be collected in non-partition AO table when enabled
+select 1 from pg_statistic where starelid='hll_on_ao'::regclass and stavalues5 is not null;
+ ?column? 
+----------
+        1
+        1
+(2 rows)
+
+create table hll_on_heap (i int, j int) with (analyze_hll=true) distributed by (i);
+insert into hll_on_heap values (777,6);
+analyze hll_on_heap;
+-- hll stats should be collected in non-partition heap table when enabled
+select 1 from pg_statistic where starelid='hll_on_heap'::regclass and stavalues5 is not null;
+ ?column? 
+----------
+        1
+        1
+(2 rows)
+
+alter table hll_part exchange partition for (6)  with table hll_on_heap;
+-- hll stats should be present after partition exchange of table with "analyze_hll" enabled
+select 1 from pg_statistic where starelid='hll_part_1_prt_6'::regclass and stavalues5 is not null;
+ ?column? 
+----------
+        1
+        1
+(2 rows)
+

--- a/src/test/regress/expected/incremental_analyze.out
+++ b/src/test/regress/expected/incremental_analyze.out
@@ -2076,6 +2076,24 @@ select 1 from pg_statistic where starelid='hll_off'::regclass and stavalues5 is 
 ----------
 (0 rows)
 
+-- alter table, set analyze_hll on, ensure hll stats collected
+alter table hll_off set (analyze_hll=true);
+analyze hll_off;
+select 1 from pg_statistic where starelid='hll_off'::regclass and stavalues5 is not null;
+ ?column? 
+----------
+        1
+        1
+(2 rows)
+
+-- alter table, set analyze_hll ooff, ensure hll stats not collected
+alter table hll_off set (analyze_hll=false);
+analyze hll_off;
+select 1 from pg_statistic where starelid='hll_off'::regclass and stavalues5 is not null;
+ ?column? 
+----------
+(0 rows)
+
 create table hll_on_ao (i int, j int) with (analyze_hll=true) distributed by (i);
 insert into hll_on_ao values (777,6);
 analyze hll_on_ao;

--- a/src/test/regress/expected/incremental_analyze.out
+++ b/src/test/regress/expected/incremental_analyze.out
@@ -2043,7 +2043,7 @@ INFO:  analyzing "public.foo_1_prt_20210201"
 INFO:  Executing SQL: select pg_catalog.gp_acquire_sample_rows(65903, 400, 'f');
 INFO:  analyzing "public.foo" inheritance tree
 rollback;
--- test behavior of "analyze_hll" create table option
+-- test behavior of "analyze_hll_non_part_table" create table option
 create table hll_part (i int, j int) distributed by (i)
 partition by range(j)
 (start(1) end(10) every(1));
@@ -2078,11 +2078,11 @@ select 1 from pg_statistic where starelid='hll_default_ao'::regclass and stavalu
 ----------
 (0 rows)
 
-create table hll_off (i int, j int) with (analyze_hll=false) distributed by (i);
+create table hll_off (i int, j int) with (analyze_hll_non_part_table=false) distributed by (i);
 select reloptions from pg_class where relname='hll_off';
-     reloptions      
----------------------
- {analyze_hll=false}
+             reloptions             
+------------------------------------
+ {analyze_hll_non_part_table=false}
 (1 row)
 
 insert into hll_off values (777,6);
@@ -2093,12 +2093,12 @@ select 1 from pg_statistic where starelid='hll_off'::regclass and stavalues5 is 
 ----------
 (0 rows)
 
--- alter table, set analyze_hll on, ensure hll stats collected
-alter table hll_off set (analyze_hll=true);
+-- alter table, set analyze_hll_non_part_table on, ensure hll stats collected
+alter table hll_off set (analyze_hll_non_part_table=true);
 select reloptions from pg_class where relname='hll_off';
-     reloptions     
---------------------
- {analyze_hll=true}
+            reloptions             
+-----------------------------------
+ {analyze_hll_non_part_table=true}
 (1 row)
 
 analyze hll_off;
@@ -2109,12 +2109,12 @@ select 1 from pg_statistic where starelid='hll_off'::regclass and stavalues5 is 
         1
 (2 rows)
 
--- alter table, set analyze_hll off, ensure hll stats not collected
-alter table hll_off set (analyze_hll=false);
+-- alter table, set analyze_hll_non_part_table off, ensure hll stats not collected
+alter table hll_off set (analyze_hll_non_part_table=false);
 select reloptions from pg_class where relname='hll_off';
-     reloptions      
----------------------
- {analyze_hll=false}
+             reloptions             
+------------------------------------
+ {analyze_hll_non_part_table=false}
 (1 row)
 
 analyze hll_off;
@@ -2123,11 +2123,11 @@ select 1 from pg_statistic where starelid='hll_off'::regclass and stavalues5 is 
 ----------
 (0 rows)
 
-create table hll_on_ao (i int, j int) with (analyze_hll=true) distributed by (i);
+create table hll_on_ao (i int, j int) with (analyze_hll_non_part_table=true) distributed by (i);
 select reloptions from pg_class where relname='hll_on_ao';
-     reloptions     
---------------------
- {analyze_hll=true}
+            reloptions             
+-----------------------------------
+ {analyze_hll_non_part_table=true}
 (1 row)
 
 insert into hll_on_ao values (777,6);
@@ -2140,11 +2140,11 @@ select 1 from pg_statistic where starelid='hll_on_ao'::regclass and stavalues5 i
         1
 (2 rows)
 
-create table hll_on_heap (i int, j int) with (analyze_hll=true) distributed by (i);
+create table hll_on_heap (i int, j int) with (analyze_hll_non_part_table=true) distributed by (i);
 select reloptions from pg_class where relname='hll_on_heap';
-     reloptions     
---------------------
- {analyze_hll=true}
+            reloptions             
+-----------------------------------
+ {analyze_hll_non_part_table=true}
 (1 row)
 
 insert into hll_on_heap values (777,6);
@@ -2159,12 +2159,12 @@ select 1 from pg_statistic where starelid='hll_on_heap'::regclass and stavalues5
 
 alter table hll_part exchange partition for (6)  with table hll_on_heap;
 select reloptions from pg_class where relname='hll_part_1_prt_6';
-     reloptions     
---------------------
- {analyze_hll=true}
+            reloptions             
+-----------------------------------
+ {analyze_hll_non_part_table=true}
 (1 row)
 
--- hll stats should be present after partition exchange of table with "analyze_hll" enabled
+-- hll stats should be present after partition exchange of table with "analyze_hll_non_part_table" enabled
 select 1 from pg_statistic where starelid='hll_part_1_prt_6'::regclass and stavalues5 is not null;
  ?column? 
 ----------
@@ -2173,49 +2173,49 @@ select 1 from pg_statistic where starelid='hll_part_1_prt_6'::regclass and stava
 (2 rows)
 
 -- verify that reloption is correctly set for partitioned table
-create table hll_part_def (i int, j int) with (analyze_hll=false) distributed by (i)
+create table hll_part_def (i int, j int) with (analyze_hll_non_part_table=false) distributed by (i)
 partition by range(j)
 (start(1) end(3) every(1));
 select reloptions from pg_class where relname='hll_part_def';
-     reloptions      
----------------------
- {analyze_hll=false}
+             reloptions             
+------------------------------------
+ {analyze_hll_non_part_table=false}
 (1 row)
 
 select reloptions from pg_class where relname='hll_part_def_1_prt_2';
-     reloptions      
----------------------
- {analyze_hll=false}
+             reloptions             
+------------------------------------
+ {analyze_hll_non_part_table=false}
 (1 row)
 
 -- see if altering the reloption at the partition root with the ONLY keyword
 -- only modifies the reloption for the root and future children (should NOT
 -- touch existing children)
-alter table only hll_part_def set (analyze_hll=true);
+alter table only hll_part_def set (analyze_hll_non_part_table=true);
 select reloptions from pg_class where relname='hll_part_def';
-     reloptions     
---------------------
- {analyze_hll=true}
+            reloptions             
+-----------------------------------
+ {analyze_hll_non_part_table=true}
 (1 row)
 
 select reloptions from pg_class where relname='hll_part_def_1_prt_2';
-     reloptions      
----------------------
- {analyze_hll=false}
+             reloptions             
+------------------------------------
+ {analyze_hll_non_part_table=false}
 (1 row)
 
 -- see if altering the reloption at the partition root without the ONLY keyword
 -- modifies the reloption for all existing children AND all future children
-alter table hll_part_def set (analyze_hll=true);
+alter table hll_part_def set (analyze_hll_non_part_table=true);
 select reloptions from pg_class where relname='hll_part_def';
-     reloptions     
---------------------
- {analyze_hll=true}
+            reloptions             
+-----------------------------------
+ {analyze_hll_non_part_table=true}
 (1 row)
 
 select reloptions from pg_class where relname='hll_part_def_1_prt_2';
-     reloptions     
---------------------
- {analyze_hll=true}
+            reloptions             
+-----------------------------------
+ {analyze_hll_non_part_table=true}
 (1 row)
 

--- a/src/test/regress/expected/incremental_analyze.out
+++ b/src/test/regress/expected/incremental_analyze.out
@@ -2050,15 +2050,26 @@ partition by range(j)
 insert into hll_part select i, i%9+1 from generate_series(1,100)i;
 analyze hll_part;
 create table hll_default_heap (i int, j int) distributed by (i);
+select reloptions from pg_class where relname='hll_default_heap';
+ reloptions 
+------------
+ 
+(1 row)
+
 insert into hll_default_heap values (777,6);
-analyze hll_default_heap;
--- hll stats should not be collected in non-partition heap table by default
+analyze hll_default_heap; -- hll stats should not be collected in non-partition heap table by default
 select 1 from pg_statistic where starelid='hll_default_heap'::regclass and stavalues5 is not null;
  ?column? 
 ----------
 (0 rows)
 
 create table hll_default_ao (i int, j int) with (appendonly=true) distributed by (i);
+select reloptions from pg_class where relname='hll_default_ao';
+ reloptions 
+------------
+ 
+(1 row)
+
 insert into hll_default_ao values (777,6);
 analyze hll_default_ao;
 -- hll stats should not be collected in non-partition ao table by default
@@ -2068,6 +2079,12 @@ select 1 from pg_statistic where starelid='hll_default_ao'::regclass and stavalu
 (0 rows)
 
 create table hll_off (i int, j int) with (analyze_hll=false) distributed by (i);
+select reloptions from pg_class where relname='hll_off';
+     reloptions      
+---------------------
+ {analyze_hll=false}
+(1 row)
+
 insert into hll_off values (777,6);
 analyze hll_off;
 -- hll stats should not be collected in non-partition table when disabled
@@ -2078,6 +2095,12 @@ select 1 from pg_statistic where starelid='hll_off'::regclass and stavalues5 is 
 
 -- alter table, set analyze_hll on, ensure hll stats collected
 alter table hll_off set (analyze_hll=true);
+select reloptions from pg_class where relname='hll_off';
+     reloptions     
+--------------------
+ {analyze_hll=true}
+(1 row)
+
 analyze hll_off;
 select 1 from pg_statistic where starelid='hll_off'::regclass and stavalues5 is not null;
  ?column? 
@@ -2086,8 +2109,14 @@ select 1 from pg_statistic where starelid='hll_off'::regclass and stavalues5 is 
         1
 (2 rows)
 
--- alter table, set analyze_hll ooff, ensure hll stats not collected
+-- alter table, set analyze_hll off, ensure hll stats not collected
 alter table hll_off set (analyze_hll=false);
+select reloptions from pg_class where relname='hll_off';
+     reloptions      
+---------------------
+ {analyze_hll=false}
+(1 row)
+
 analyze hll_off;
 select 1 from pg_statistic where starelid='hll_off'::regclass and stavalues5 is not null;
  ?column? 
@@ -2095,6 +2124,12 @@ select 1 from pg_statistic where starelid='hll_off'::regclass and stavalues5 is 
 (0 rows)
 
 create table hll_on_ao (i int, j int) with (analyze_hll=true) distributed by (i);
+select reloptions from pg_class where relname='hll_on_ao';
+     reloptions     
+--------------------
+ {analyze_hll=true}
+(1 row)
+
 insert into hll_on_ao values (777,6);
 analyze hll_on_ao;
 -- hll stats should be collected in non-partition AO table when enabled
@@ -2106,6 +2141,12 @@ select 1 from pg_statistic where starelid='hll_on_ao'::regclass and stavalues5 i
 (2 rows)
 
 create table hll_on_heap (i int, j int) with (analyze_hll=true) distributed by (i);
+select reloptions from pg_class where relname='hll_on_heap';
+     reloptions     
+--------------------
+ {analyze_hll=true}
+(1 row)
+
 insert into hll_on_heap values (777,6);
 analyze hll_on_heap;
 -- hll stats should be collected in non-partition heap table when enabled
@@ -2117,6 +2158,12 @@ select 1 from pg_statistic where starelid='hll_on_heap'::regclass and stavalues5
 (2 rows)
 
 alter table hll_part exchange partition for (6)  with table hll_on_heap;
+select reloptions from pg_class where relname='hll_part_1_prt_6';
+     reloptions     
+--------------------
+ {analyze_hll=true}
+(1 row)
+
 -- hll stats should be present after partition exchange of table with "analyze_hll" enabled
 select 1 from pg_statistic where starelid='hll_part_1_prt_6'::regclass and stavalues5 is not null;
  ?column? 
@@ -2124,4 +2171,51 @@ select 1 from pg_statistic where starelid='hll_part_1_prt_6'::regclass and stava
         1
         1
 (2 rows)
+
+-- verify that reloption is correctly set for partitioned table
+create table hll_part_def (i int, j int) with (analyze_hll=false) distributed by (i)
+partition by range(j)
+(start(1) end(3) every(1));
+select reloptions from pg_class where relname='hll_part_def';
+     reloptions      
+---------------------
+ {analyze_hll=false}
+(1 row)
+
+select reloptions from pg_class where relname='hll_part_def_1_prt_2';
+     reloptions      
+---------------------
+ {analyze_hll=false}
+(1 row)
+
+-- see if altering the reloption at the partition root with the ONLY keyword
+-- only modifies the reloption for the root and future children (should NOT
+-- touch existing children)
+alter table only hll_part_def set (analyze_hll=true);
+select reloptions from pg_class where relname='hll_part_def';
+     reloptions     
+--------------------
+ {analyze_hll=true}
+(1 row)
+
+select reloptions from pg_class where relname='hll_part_def_1_prt_2';
+     reloptions      
+---------------------
+ {analyze_hll=false}
+(1 row)
+
+-- see if altering the reloption at the partition root without the ONLY keyword
+-- modifies the reloption for all existing children AND all future children
+alter table hll_part_def set (analyze_hll=true);
+select reloptions from pg_class where relname='hll_part_def';
+     reloptions     
+--------------------
+ {analyze_hll=true}
+(1 row)
+
+select reloptions from pg_class where relname='hll_part_def_1_prt_2';
+     reloptions     
+--------------------
+ {analyze_hll=true}
+(1 row)
 

--- a/src/test/regress/expected/incremental_analyze_optimizer.out
+++ b/src/test/regress/expected/incremental_analyze_optimizer.out
@@ -2085,6 +2085,24 @@ select 1 from pg_statistic where starelid='hll_off'::regclass and stavalues5 is 
 ----------
 (0 rows)
 
+-- alter table, set analyze_hll on, ensure hll stats collected
+alter table hll_off set (analyze_hll=true);
+analyze hll_off;
+select 1 from pg_statistic where starelid='hll_off'::regclass and stavalues5 is not null;
+ ?column? 
+----------
+        1
+        1
+(2 rows)
+
+-- alter table, set analyze_hll ooff, ensure hll stats not collected
+alter table hll_off set (analyze_hll=false);
+analyze hll_off;
+select 1 from pg_statistic where starelid='hll_off'::regclass and stavalues5 is not null;
+ ?column? 
+----------
+(0 rows)
+
 create table hll_on_ao (i int, j int) with (analyze_hll=true) distributed by (i);
 insert into hll_on_ao values (777,6);
 analyze hll_on_ao;

--- a/src/test/regress/expected/incremental_analyze_optimizer.out
+++ b/src/test/regress/expected/incremental_analyze_optimizer.out
@@ -2052,3 +2052,67 @@ INFO:  analyzing "public.foo_1_prt_20210201"
 INFO:  Executing SQL: select pg_catalog.gp_acquire_sample_rows(74833, 400, 'f');
 INFO:  analyzing "public.foo" inheritance tree
 rollback;
+-- test behavior of "analyze_hll" create table option
+create table hll_part (i int, j int) distributed by (i)
+partition by range(j)
+(start(1) end(10) every(1));
+insert into hll_part select i, i%9+1 from generate_series(1,100)i;
+analyze hll_part;
+create table hll_default_heap (i int, j int) distributed by (i);
+insert into hll_default_heap values (777,6);
+analyze hll_default_heap;
+-- hll stats should not be collected in non-partition heap table by default
+select 1 from pg_statistic where starelid='hll_default_heap'::regclass and stavalues5 is not null;
+ ?column? 
+----------
+(0 rows)
+
+create table hll_default_ao (i int, j int) with (appendonly=true) distributed by (i);
+insert into hll_default_ao values (777,6);
+analyze hll_default_ao;
+-- hll stats should not be collected in non-partition ao table by default
+select 1 from pg_statistic where starelid='hll_default_ao'::regclass and stavalues5 is not null;
+ ?column? 
+----------
+(0 rows)
+
+create table hll_off (i int, j int) with (analyze_hll=false) distributed by (i);
+insert into hll_off values (777,6);
+analyze hll_off;
+-- hll stats should not be collected in non-partition table when disabled
+select 1 from pg_statistic where starelid='hll_off'::regclass and stavalues5 is not null;
+ ?column? 
+----------
+(0 rows)
+
+create table hll_on_ao (i int, j int) with (analyze_hll=true) distributed by (i);
+insert into hll_on_ao values (777,6);
+analyze hll_on_ao;
+-- hll stats should be collected in non-partition AO table when enabled
+select 1 from pg_statistic where starelid='hll_on_ao'::regclass and stavalues5 is not null;
+ ?column? 
+----------
+        1
+        1
+(2 rows)
+
+create table hll_on_heap (i int, j int) with (analyze_hll=true) distributed by (i);
+insert into hll_on_heap values (777,6);
+analyze hll_on_heap;
+-- hll stats should be collected in non-partition heap table when enabled
+select 1 from pg_statistic where starelid='hll_on_heap'::regclass and stavalues5 is not null;
+ ?column? 
+----------
+        1
+        1
+(2 rows)
+
+alter table hll_part exchange partition for (6)  with table hll_on_heap;
+-- hll stats should be present after partition exchange of table with "analyze_hll" enabled
+select 1 from pg_statistic where starelid='hll_part_1_prt_6'::regclass and stavalues5 is not null;
+ ?column? 
+----------
+        1
+        1
+(2 rows)
+

--- a/src/test/regress/expected/incremental_analyze_optimizer.out
+++ b/src/test/regress/expected/incremental_analyze_optimizer.out
@@ -2059,15 +2059,26 @@ partition by range(j)
 insert into hll_part select i, i%9+1 from generate_series(1,100)i;
 analyze hll_part;
 create table hll_default_heap (i int, j int) distributed by (i);
+select reloptions from pg_class where relname='hll_default_heap';
+ reloptions 
+------------
+ 
+(1 row)
+
 insert into hll_default_heap values (777,6);
-analyze hll_default_heap;
--- hll stats should not be collected in non-partition heap table by default
+analyze hll_default_heap; -- hll stats should not be collected in non-partition heap table by default
 select 1 from pg_statistic where starelid='hll_default_heap'::regclass and stavalues5 is not null;
  ?column? 
 ----------
 (0 rows)
 
 create table hll_default_ao (i int, j int) with (appendonly=true) distributed by (i);
+select reloptions from pg_class where relname='hll_default_ao';
+ reloptions 
+------------
+ 
+(1 row)
+
 insert into hll_default_ao values (777,6);
 analyze hll_default_ao;
 -- hll stats should not be collected in non-partition ao table by default
@@ -2077,6 +2088,12 @@ select 1 from pg_statistic where starelid='hll_default_ao'::regclass and stavalu
 (0 rows)
 
 create table hll_off (i int, j int) with (analyze_hll=false) distributed by (i);
+select reloptions from pg_class where relname='hll_off';
+     reloptions      
+---------------------
+ {analyze_hll=false}
+(1 row)
+
 insert into hll_off values (777,6);
 analyze hll_off;
 -- hll stats should not be collected in non-partition table when disabled
@@ -2087,6 +2104,12 @@ select 1 from pg_statistic where starelid='hll_off'::regclass and stavalues5 is 
 
 -- alter table, set analyze_hll on, ensure hll stats collected
 alter table hll_off set (analyze_hll=true);
+select reloptions from pg_class where relname='hll_off';
+     reloptions     
+--------------------
+ {analyze_hll=true}
+(1 row)
+
 analyze hll_off;
 select 1 from pg_statistic where starelid='hll_off'::regclass and stavalues5 is not null;
  ?column? 
@@ -2095,8 +2118,14 @@ select 1 from pg_statistic where starelid='hll_off'::regclass and stavalues5 is 
         1
 (2 rows)
 
--- alter table, set analyze_hll ooff, ensure hll stats not collected
+-- alter table, set analyze_hll off, ensure hll stats not collected
 alter table hll_off set (analyze_hll=false);
+select reloptions from pg_class where relname='hll_off';
+     reloptions      
+---------------------
+ {analyze_hll=false}
+(1 row)
+
 analyze hll_off;
 select 1 from pg_statistic where starelid='hll_off'::regclass and stavalues5 is not null;
  ?column? 
@@ -2104,6 +2133,12 @@ select 1 from pg_statistic where starelid='hll_off'::regclass and stavalues5 is 
 (0 rows)
 
 create table hll_on_ao (i int, j int) with (analyze_hll=true) distributed by (i);
+select reloptions from pg_class where relname='hll_on_ao';
+     reloptions     
+--------------------
+ {analyze_hll=true}
+(1 row)
+
 insert into hll_on_ao values (777,6);
 analyze hll_on_ao;
 -- hll stats should be collected in non-partition AO table when enabled
@@ -2115,6 +2150,12 @@ select 1 from pg_statistic where starelid='hll_on_ao'::regclass and stavalues5 i
 (2 rows)
 
 create table hll_on_heap (i int, j int) with (analyze_hll=true) distributed by (i);
+select reloptions from pg_class where relname='hll_on_heap';
+     reloptions     
+--------------------
+ {analyze_hll=true}
+(1 row)
+
 insert into hll_on_heap values (777,6);
 analyze hll_on_heap;
 -- hll stats should be collected in non-partition heap table when enabled
@@ -2126,6 +2167,12 @@ select 1 from pg_statistic where starelid='hll_on_heap'::regclass and stavalues5
 (2 rows)
 
 alter table hll_part exchange partition for (6)  with table hll_on_heap;
+select reloptions from pg_class where relname='hll_part_1_prt_6';
+     reloptions     
+--------------------
+ {analyze_hll=true}
+(1 row)
+
 -- hll stats should be present after partition exchange of table with "analyze_hll" enabled
 select 1 from pg_statistic where starelid='hll_part_1_prt_6'::regclass and stavalues5 is not null;
  ?column? 
@@ -2133,4 +2180,51 @@ select 1 from pg_statistic where starelid='hll_part_1_prt_6'::regclass and stava
         1
         1
 (2 rows)
+
+-- verify that reloption is correctly set for partitioned table
+create table hll_part_def (i int, j int) with (analyze_hll=false) distributed by (i)
+partition by range(j)
+(start(1) end(3) every(1));
+select reloptions from pg_class where relname='hll_part_def';
+     reloptions      
+---------------------
+ {analyze_hll=false}
+(1 row)
+
+select reloptions from pg_class where relname='hll_part_def_1_prt_2';
+     reloptions      
+---------------------
+ {analyze_hll=false}
+(1 row)
+
+-- see if altering the reloption at the partition root with the ONLY keyword
+-- only modifies the reloption for the root and future children (should NOT
+-- touch existing children)
+alter table only hll_part_def set (analyze_hll=true);
+select reloptions from pg_class where relname='hll_part_def';
+     reloptions     
+--------------------
+ {analyze_hll=true}
+(1 row)
+
+select reloptions from pg_class where relname='hll_part_def_1_prt_2';
+     reloptions      
+---------------------
+ {analyze_hll=false}
+(1 row)
+
+-- see if altering the reloption at the partition root without the ONLY keyword
+-- modifies the reloption for all existing children AND all future children
+alter table hll_part_def set (analyze_hll=true);
+select reloptions from pg_class where relname='hll_part_def';
+     reloptions     
+--------------------
+ {analyze_hll=true}
+(1 row)
+
+select reloptions from pg_class where relname='hll_part_def_1_prt_2';
+     reloptions     
+--------------------
+ {analyze_hll=true}
+(1 row)
 

--- a/src/test/regress/expected/incremental_analyze_optimizer.out
+++ b/src/test/regress/expected/incremental_analyze_optimizer.out
@@ -2052,7 +2052,7 @@ INFO:  analyzing "public.foo_1_prt_20210201"
 INFO:  Executing SQL: select pg_catalog.gp_acquire_sample_rows(74833, 400, 'f');
 INFO:  analyzing "public.foo" inheritance tree
 rollback;
--- test behavior of "analyze_hll" create table option
+-- test behavior of "analyze_hll_non_part_table" create table option
 create table hll_part (i int, j int) distributed by (i)
 partition by range(j)
 (start(1) end(10) every(1));
@@ -2087,11 +2087,11 @@ select 1 from pg_statistic where starelid='hll_default_ao'::regclass and stavalu
 ----------
 (0 rows)
 
-create table hll_off (i int, j int) with (analyze_hll=false) distributed by (i);
+create table hll_off (i int, j int) with (analyze_hll_non_part_table=false) distributed by (i);
 select reloptions from pg_class where relname='hll_off';
-     reloptions      
----------------------
- {analyze_hll=false}
+             reloptions             
+------------------------------------
+ {analyze_hll_non_part_table=false}
 (1 row)
 
 insert into hll_off values (777,6);
@@ -2102,12 +2102,12 @@ select 1 from pg_statistic where starelid='hll_off'::regclass and stavalues5 is 
 ----------
 (0 rows)
 
--- alter table, set analyze_hll on, ensure hll stats collected
-alter table hll_off set (analyze_hll=true);
+-- alter table, set analyze_hll_non_part_table on, ensure hll stats collected
+alter table hll_off set (analyze_hll_non_part_table=true);
 select reloptions from pg_class where relname='hll_off';
-     reloptions     
---------------------
- {analyze_hll=true}
+            reloptions             
+-----------------------------------
+ {analyze_hll_non_part_table=true}
 (1 row)
 
 analyze hll_off;
@@ -2118,12 +2118,12 @@ select 1 from pg_statistic where starelid='hll_off'::regclass and stavalues5 is 
         1
 (2 rows)
 
--- alter table, set analyze_hll off, ensure hll stats not collected
-alter table hll_off set (analyze_hll=false);
+-- alter table, set analyze_hll_non_part_table off, ensure hll stats not collected
+alter table hll_off set (analyze_hll_non_part_table=false);
 select reloptions from pg_class where relname='hll_off';
-     reloptions      
----------------------
- {analyze_hll=false}
+             reloptions             
+------------------------------------
+ {analyze_hll_non_part_table=false}
 (1 row)
 
 analyze hll_off;
@@ -2132,11 +2132,11 @@ select 1 from pg_statistic where starelid='hll_off'::regclass and stavalues5 is 
 ----------
 (0 rows)
 
-create table hll_on_ao (i int, j int) with (analyze_hll=true) distributed by (i);
+create table hll_on_ao (i int, j int) with (analyze_hll_non_part_table=true) distributed by (i);
 select reloptions from pg_class where relname='hll_on_ao';
-     reloptions     
---------------------
- {analyze_hll=true}
+            reloptions             
+-----------------------------------
+ {analyze_hll_non_part_table=true}
 (1 row)
 
 insert into hll_on_ao values (777,6);
@@ -2149,11 +2149,11 @@ select 1 from pg_statistic where starelid='hll_on_ao'::regclass and stavalues5 i
         1
 (2 rows)
 
-create table hll_on_heap (i int, j int) with (analyze_hll=true) distributed by (i);
+create table hll_on_heap (i int, j int) with (analyze_hll_non_part_table=true) distributed by (i);
 select reloptions from pg_class where relname='hll_on_heap';
-     reloptions     
---------------------
- {analyze_hll=true}
+            reloptions             
+-----------------------------------
+ {analyze_hll_non_part_table=true}
 (1 row)
 
 insert into hll_on_heap values (777,6);
@@ -2168,12 +2168,12 @@ select 1 from pg_statistic where starelid='hll_on_heap'::regclass and stavalues5
 
 alter table hll_part exchange partition for (6)  with table hll_on_heap;
 select reloptions from pg_class where relname='hll_part_1_prt_6';
-     reloptions     
---------------------
- {analyze_hll=true}
+            reloptions             
+-----------------------------------
+ {analyze_hll_non_part_table=true}
 (1 row)
 
--- hll stats should be present after partition exchange of table with "analyze_hll" enabled
+-- hll stats should be present after partition exchange of table with "analyze_hll_non_part_table" enabled
 select 1 from pg_statistic where starelid='hll_part_1_prt_6'::regclass and stavalues5 is not null;
  ?column? 
 ----------
@@ -2182,49 +2182,49 @@ select 1 from pg_statistic where starelid='hll_part_1_prt_6'::regclass and stava
 (2 rows)
 
 -- verify that reloption is correctly set for partitioned table
-create table hll_part_def (i int, j int) with (analyze_hll=false) distributed by (i)
+create table hll_part_def (i int, j int) with (analyze_hll_non_part_table=false) distributed by (i)
 partition by range(j)
 (start(1) end(3) every(1));
 select reloptions from pg_class where relname='hll_part_def';
-     reloptions      
----------------------
- {analyze_hll=false}
+             reloptions             
+------------------------------------
+ {analyze_hll_non_part_table=false}
 (1 row)
 
 select reloptions from pg_class where relname='hll_part_def_1_prt_2';
-     reloptions      
----------------------
- {analyze_hll=false}
+             reloptions             
+------------------------------------
+ {analyze_hll_non_part_table=false}
 (1 row)
 
 -- see if altering the reloption at the partition root with the ONLY keyword
 -- only modifies the reloption for the root and future children (should NOT
 -- touch existing children)
-alter table only hll_part_def set (analyze_hll=true);
+alter table only hll_part_def set (analyze_hll_non_part_table=true);
 select reloptions from pg_class where relname='hll_part_def';
-     reloptions     
---------------------
- {analyze_hll=true}
+            reloptions             
+-----------------------------------
+ {analyze_hll_non_part_table=true}
 (1 row)
 
 select reloptions from pg_class where relname='hll_part_def_1_prt_2';
-     reloptions      
----------------------
- {analyze_hll=false}
+             reloptions             
+------------------------------------
+ {analyze_hll_non_part_table=false}
 (1 row)
 
 -- see if altering the reloption at the partition root without the ONLY keyword
 -- modifies the reloption for all existing children AND all future children
-alter table hll_part_def set (analyze_hll=true);
+alter table hll_part_def set (analyze_hll_non_part_table=true);
 select reloptions from pg_class where relname='hll_part_def';
-     reloptions     
---------------------
- {analyze_hll=true}
+            reloptions             
+-----------------------------------
+ {analyze_hll_non_part_table=true}
 (1 row)
 
 select reloptions from pg_class where relname='hll_part_def_1_prt_2';
-     reloptions     
---------------------
- {analyze_hll=true}
+            reloptions             
+-----------------------------------
+ {analyze_hll_non_part_table=true}
 (1 row)
 

--- a/src/test/regress/sql/incremental_analyze.sql
+++ b/src/test/regress/sql/incremental_analyze.sql
@@ -881,7 +881,7 @@ insert into foo select a, '20210101'::date+a from (select generate_series(31,40)
 analyze verbose foo_1_prt_20210201;
 rollback;
 
--- test behavior of "analyze_hll" create table option
+-- test behavior of "analyze_hll_non_part_table" create table option
 create table hll_part (i int, j int) distributed by (i)
 partition by range(j)
 (start(1) end(10) every(1));
@@ -901,33 +901,33 @@ analyze hll_default_ao;
 -- hll stats should not be collected in non-partition ao table by default
 select 1 from pg_statistic where starelid='hll_default_ao'::regclass and stavalues5 is not null;
 
-create table hll_off (i int, j int) with (analyze_hll=false) distributed by (i);
+create table hll_off (i int, j int) with (analyze_hll_non_part_table=false) distributed by (i);
 select reloptions from pg_class where relname='hll_off';
 insert into hll_off values (777,6);
 analyze hll_off;
 -- hll stats should not be collected in non-partition table when disabled
 select 1 from pg_statistic where starelid='hll_off'::regclass and stavalues5 is not null;
 
--- alter table, set analyze_hll on, ensure hll stats collected
-alter table hll_off set (analyze_hll=true);
+-- alter table, set analyze_hll_non_part_table on, ensure hll stats collected
+alter table hll_off set (analyze_hll_non_part_table=true);
 select reloptions from pg_class where relname='hll_off';
 analyze hll_off;
 select 1 from pg_statistic where starelid='hll_off'::regclass and stavalues5 is not null;
 
--- alter table, set analyze_hll off, ensure hll stats not collected
-alter table hll_off set (analyze_hll=false);
+-- alter table, set analyze_hll_non_part_table off, ensure hll stats not collected
+alter table hll_off set (analyze_hll_non_part_table=false);
 select reloptions from pg_class where relname='hll_off';
 analyze hll_off;
 select 1 from pg_statistic where starelid='hll_off'::regclass and stavalues5 is not null;
 
-create table hll_on_ao (i int, j int) with (analyze_hll=true) distributed by (i);
+create table hll_on_ao (i int, j int) with (analyze_hll_non_part_table=true) distributed by (i);
 select reloptions from pg_class where relname='hll_on_ao';
 insert into hll_on_ao values (777,6);
 analyze hll_on_ao;
 -- hll stats should be collected in non-partition AO table when enabled
 select 1 from pg_statistic where starelid='hll_on_ao'::regclass and stavalues5 is not null;
 
-create table hll_on_heap (i int, j int) with (analyze_hll=true) distributed by (i);
+create table hll_on_heap (i int, j int) with (analyze_hll_non_part_table=true) distributed by (i);
 select reloptions from pg_class where relname='hll_on_heap';
 insert into hll_on_heap values (777,6);
 analyze hll_on_heap;
@@ -937,11 +937,11 @@ select 1 from pg_statistic where starelid='hll_on_heap'::regclass and stavalues5
 alter table hll_part exchange partition for (6)  with table hll_on_heap;
 select reloptions from pg_class where relname='hll_part_1_prt_6';
 
--- hll stats should be present after partition exchange of table with "analyze_hll" enabled
+-- hll stats should be present after partition exchange of table with "analyze_hll_non_part_table" enabled
 select 1 from pg_statistic where starelid='hll_part_1_prt_6'::regclass and stavalues5 is not null;
 
 -- verify that reloption is correctly set for partitioned table
-create table hll_part_def (i int, j int) with (analyze_hll=false) distributed by (i)
+create table hll_part_def (i int, j int) with (analyze_hll_non_part_table=false) distributed by (i)
 partition by range(j)
 (start(1) end(3) every(1));
 
@@ -951,13 +951,13 @@ select reloptions from pg_class where relname='hll_part_def_1_prt_2';
 -- see if altering the reloption at the partition root with the ONLY keyword
 -- only modifies the reloption for the root and future children (should NOT
 -- touch existing children)
-alter table only hll_part_def set (analyze_hll=true);
+alter table only hll_part_def set (analyze_hll_non_part_table=true);
 select reloptions from pg_class where relname='hll_part_def';
 select reloptions from pg_class where relname='hll_part_def_1_prt_2';
 
 -- see if altering the reloption at the partition root without the ONLY keyword
 -- modifies the reloption for all existing children AND all future children
-alter table hll_part_def set (analyze_hll=true);
+alter table hll_part_def set (analyze_hll_non_part_table=true);
 select reloptions from pg_class where relname='hll_part_def';
 select reloptions from pg_class where relname='hll_part_def_1_prt_2';
 

--- a/src/test/regress/sql/incremental_analyze.sql
+++ b/src/test/regress/sql/incremental_analyze.sql
@@ -889,18 +889,20 @@ insert into hll_part select i, i%9+1 from generate_series(1,100)i;
 analyze hll_part;
 
 create table hll_default_heap (i int, j int) distributed by (i);
+select reloptions from pg_class where relname='hll_default_heap';
 insert into hll_default_heap values (777,6);
-analyze hll_default_heap;
--- hll stats should not be collected in non-partition heap table by default
+analyze hll_default_heap; -- hll stats should not be collected in non-partition heap table by default
 select 1 from pg_statistic where starelid='hll_default_heap'::regclass and stavalues5 is not null;
 
 create table hll_default_ao (i int, j int) with (appendonly=true) distributed by (i);
+select reloptions from pg_class where relname='hll_default_ao';
 insert into hll_default_ao values (777,6);
 analyze hll_default_ao;
 -- hll stats should not be collected in non-partition ao table by default
 select 1 from pg_statistic where starelid='hll_default_ao'::regclass and stavalues5 is not null;
 
 create table hll_off (i int, j int) with (analyze_hll=false) distributed by (i);
+select reloptions from pg_class where relname='hll_off';
 insert into hll_off values (777,6);
 analyze hll_off;
 -- hll stats should not be collected in non-partition table when disabled
@@ -908,27 +910,54 @@ select 1 from pg_statistic where starelid='hll_off'::regclass and stavalues5 is 
 
 -- alter table, set analyze_hll on, ensure hll stats collected
 alter table hll_off set (analyze_hll=true);
+select reloptions from pg_class where relname='hll_off';
 analyze hll_off;
 select 1 from pg_statistic where starelid='hll_off'::regclass and stavalues5 is not null;
 
--- alter table, set analyze_hll ooff, ensure hll stats not collected
+-- alter table, set analyze_hll off, ensure hll stats not collected
 alter table hll_off set (analyze_hll=false);
+select reloptions from pg_class where relname='hll_off';
 analyze hll_off;
 select 1 from pg_statistic where starelid='hll_off'::regclass and stavalues5 is not null;
 
 create table hll_on_ao (i int, j int) with (analyze_hll=true) distributed by (i);
+select reloptions from pg_class where relname='hll_on_ao';
 insert into hll_on_ao values (777,6);
 analyze hll_on_ao;
 -- hll stats should be collected in non-partition AO table when enabled
 select 1 from pg_statistic where starelid='hll_on_ao'::regclass and stavalues5 is not null;
 
 create table hll_on_heap (i int, j int) with (analyze_hll=true) distributed by (i);
+select reloptions from pg_class where relname='hll_on_heap';
 insert into hll_on_heap values (777,6);
 analyze hll_on_heap;
 -- hll stats should be collected in non-partition heap table when enabled
 select 1 from pg_statistic where starelid='hll_on_heap'::regclass and stavalues5 is not null;
 
 alter table hll_part exchange partition for (6)  with table hll_on_heap;
+select reloptions from pg_class where relname='hll_part_1_prt_6';
 
 -- hll stats should be present after partition exchange of table with "analyze_hll" enabled
 select 1 from pg_statistic where starelid='hll_part_1_prt_6'::regclass and stavalues5 is not null;
+
+-- verify that reloption is correctly set for partitioned table
+create table hll_part_def (i int, j int) with (analyze_hll=false) distributed by (i)
+partition by range(j)
+(start(1) end(3) every(1));
+
+select reloptions from pg_class where relname='hll_part_def';
+select reloptions from pg_class where relname='hll_part_def_1_prt_2';
+
+-- see if altering the reloption at the partition root with the ONLY keyword
+-- only modifies the reloption for the root and future children (should NOT
+-- touch existing children)
+alter table only hll_part_def set (analyze_hll=true);
+select reloptions from pg_class where relname='hll_part_def';
+select reloptions from pg_class where relname='hll_part_def_1_prt_2';
+
+-- see if altering the reloption at the partition root without the ONLY keyword
+-- modifies the reloption for all existing children AND all future children
+alter table hll_part_def set (analyze_hll=true);
+select reloptions from pg_class where relname='hll_part_def';
+select reloptions from pg_class where relname='hll_part_def_1_prt_2';
+

--- a/src/test/regress/sql/incremental_analyze.sql
+++ b/src/test/regress/sql/incremental_analyze.sql
@@ -906,6 +906,16 @@ analyze hll_off;
 -- hll stats should not be collected in non-partition table when disabled
 select 1 from pg_statistic where starelid='hll_off'::regclass and stavalues5 is not null;
 
+-- alter table, set analyze_hll on, ensure hll stats collected
+alter table hll_off set (analyze_hll=true);
+analyze hll_off;
+select 1 from pg_statistic where starelid='hll_off'::regclass and stavalues5 is not null;
+
+-- alter table, set analyze_hll ooff, ensure hll stats not collected
+alter table hll_off set (analyze_hll=false);
+analyze hll_off;
+select 1 from pg_statistic where starelid='hll_off'::regclass and stavalues5 is not null;
+
 create table hll_on_ao (i int, j int) with (analyze_hll=true) distributed by (i);
 insert into hll_on_ao values (777,6);
 analyze hll_on_ao;

--- a/src/test/regress/sql/incremental_analyze.sql
+++ b/src/test/regress/sql/incremental_analyze.sql
@@ -880,3 +880,45 @@ truncate foo_1_prt_20210201;
 insert into foo select a, '20210101'::date+a from (select generate_series(31,40) a) t1;
 analyze verbose foo_1_prt_20210201;
 rollback;
+
+-- test behavior of "analyze_hll" create table option
+create table hll_part (i int, j int) distributed by (i)
+partition by range(j)
+(start(1) end(10) every(1));
+insert into hll_part select i, i%9+1 from generate_series(1,100)i;
+analyze hll_part;
+
+create table hll_default_heap (i int, j int) distributed by (i);
+insert into hll_default_heap values (777,6);
+analyze hll_default_heap;
+-- hll stats should not be collected in non-partition heap table by default
+select 1 from pg_statistic where starelid='hll_default_heap'::regclass and stavalues5 is not null;
+
+create table hll_default_ao (i int, j int) with (appendonly=true) distributed by (i);
+insert into hll_default_ao values (777,6);
+analyze hll_default_ao;
+-- hll stats should not be collected in non-partition ao table by default
+select 1 from pg_statistic where starelid='hll_default_ao'::regclass and stavalues5 is not null;
+
+create table hll_off (i int, j int) with (analyze_hll=false) distributed by (i);
+insert into hll_off values (777,6);
+analyze hll_off;
+-- hll stats should not be collected in non-partition table when disabled
+select 1 from pg_statistic where starelid='hll_off'::regclass and stavalues5 is not null;
+
+create table hll_on_ao (i int, j int) with (analyze_hll=true) distributed by (i);
+insert into hll_on_ao values (777,6);
+analyze hll_on_ao;
+-- hll stats should be collected in non-partition AO table when enabled
+select 1 from pg_statistic where starelid='hll_on_ao'::regclass and stavalues5 is not null;
+
+create table hll_on_heap (i int, j int) with (analyze_hll=true) distributed by (i);
+insert into hll_on_heap values (777,6);
+analyze hll_on_heap;
+-- hll stats should be collected in non-partition heap table when enabled
+select 1 from pg_statistic where starelid='hll_on_heap'::regclass and stavalues5 is not null;
+
+alter table hll_part exchange partition for (6)  with table hll_on_heap;
+
+-- hll stats should be present after partition exchange of table with "analyze_hll" enabled
+select 1 from pg_statistic where starelid='hll_part_1_prt_6'::regclass and stavalues5 is not null;


### PR DESCRIPTION
Currently, tables do not collect HLL statistics by default unless the table is part of a partitioned table. This however means that a regular table that is exchanged or added to a partition table will also not have HLL statistics unless it is re-analyzed, and the root table will also therefore not have statistics for the exchanged/added partition.

This commit adds a reloption, "analyze_hll", that will force collection of HLL stats even if the table isn't part of a partitioned table. HLL stats will still always be collected if the table is created as part of a partitioned table.

AO tables go through a different path for parsing reloptions, so additional logic/tests were added for this. Also, pg_dump/gpbackup will automatically dump this without any changes since this is stored as a string in the reloption in pg_class.

New syntax:
`CREATE TABLE foo (a int) with (analyze_hll=true);`