### PR TITLE
[6X backport] Unify ic-proxy log level under GUC gp_log_interconnect's control, and remove macro IC_PROXY_LOG_LEVEL.

### DIFF
--- a/src/backend/cdb/motion/ic_proxy.h
+++ b/src/backend/cdb/motion/ic_proxy.h
@@ -30,17 +30,16 @@
 #define IC_PROXY_ACK_INTERVAL 10
 
 
-#ifndef IC_PROXY_LOG_LEVEL
-#define IC_PROXY_LOG_LEVEL WARNING
-#endif
 
 #define ic_proxy_alloc(size) palloc(size)
 #define ic_proxy_free(ptr) pfree(ptr)
 #define ic_proxy_new(type) ((type *) ic_proxy_alloc(sizeof(type)))
 
 #define ic_proxy_log(elevel, msg...) do { \
-	if (elevel >= IC_PROXY_LOG_LEVEL) \
+	if ((elevel) >= WARNING || gp_log_interconnect >= GPVARS_VERBOSITY_TERSE) \
 	{ \
+		if ((elevel) <= DEBUG1 && gp_log_interconnect < GPVARS_VERBOSITY_DEBUG) \
+			break;	\
 		elog(elevel, msg); \
 	} \
 } while (0)

--- a/src/backend/cdb/motion/ic_proxy_addr.c
+++ b/src/backend/cdb/motion/ic_proxy_addr.c
@@ -73,7 +73,7 @@ ic_proxy_addr_on_getaddrinfo(uv_getaddrinfo_t *req,
 			if (iter->ai_family == AF_UNIX)
 				continue;
 
-#if IC_PROXY_LOG_LEVEL <= LOG
+			if (gp_log_interconnect >= GPVARS_VERBOSITY_TERSE)
 			{
 				char		name[HOST_NAME_MAX] = "unknown";
 				int			port = 0;
@@ -96,7 +96,6 @@ ic_proxy_addr_on_getaddrinfo(uv_getaddrinfo_t *req,
 								 name, port, family,
 								 uv_strerror(ret));
 			}
-#endif /* IC_PROXY_LOG_LEVEL <= LOG */
 
 			memcpy(&addr->addr, iter->ai_addr, iter->ai_addrlen);
 			ic_proxy_addrs = lappend(ic_proxy_addrs, addr);

--- a/src/backend/cdb/motion/ic_proxy_client.c
+++ b/src/backend/cdb/motion/ic_proxy_client.c
@@ -467,7 +467,7 @@ ic_proxy_client_on_c2p_data_pkt(void *opaque, const void *data, uint16 size)
 {
 	ICProxyClient *client = opaque;
 
-	ic_proxy_log(LOG, "%s: received B2C PKT [%d bytes] from the backend",
+	ic_proxy_log(DEBUG5, "%s: received B2C PKT [%d bytes] from the backend",
 				 ic_proxy_client_get_name(client), size);
 
 	/* increase the number of unack packets */

--- a/src/backend/cdb/motion/ic_proxy_main.c
+++ b/src/backend/cdb/motion/ic_proxy_main.c
@@ -149,7 +149,7 @@ ic_proxy_server_peer_listener_init(uv_loop_t *loop)
 		/* Cannot get my addr, maybe the setting is invalid */
 		return;
 
-#if IC_PROXY_LOG_LEVEL <= LOG
+	if (gp_log_interconnect >= GPVARS_VERBOSITY_TERSE)
 	{
 		char		name[HOST_NAME_MAX] = "unknown";
 		int			port = 0;
@@ -168,7 +168,6 @@ ic_proxy_server_peer_listener_init(uv_loop_t *loop)
 						 addr->hostname, addr->service, name, port, family,
 						 uv_strerror(ret));
 	}
-#endif /* IC_PROXY_LOG_LEVEL <= LOG */
 
 	/*
 	 * It is important to set TCP_NODELAY, otherwise we will suffer from

--- a/src/backend/cdb/motion/ic_proxy_pkt_cache.c
+++ b/src/backend/cdb/motion/ic_proxy_pkt_cache.c
@@ -26,7 +26,6 @@
  *-------------------------------------------------------------------------
  */
 
-#define IC_PROXY_LOG_LEVEL WARNING
 #include "ic_proxy.h"
 #include "ic_proxy_pkt_cache.h"
 


### PR DESCRIPTION
This PR is a 6X backport of #14153 .

Commit 24140214f21df4276f239b061754eefe610c1d8a was cherry-picked from master branch smoothly here, and no conflicts to resolve.

Currently ic_proxy_log(LOG would never log anything as IC_PROXY_LOG_LEVEL is hard-coded to WARNING. This should be under a GUC's control. This commit unified ic-proxy log level under GUC gp_log_interconnect's control, and remove macro IC_PROXY_LOG_LEVEL.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [x] Review a PR in return to support the community
