### PR TITLE
Clean up objects after test finish to prevent gpcheckcat failed.

### DIFF
--- a/src/test/regress/expected/psql_gp_commands.out
+++ b/src/test/regress/expected/psql_gp_commands.out
@@ -270,3 +270,4 @@ ALTER FUNCTION foofunc_exec_on_initplan() OWNER TO test_psql_de_role;
 -- Clean up
 DROP OWNED BY test_psql_de_role;
 DROP ROLE test_psql_de_role;
+DROP ACCESS METHOD bogus;

--- a/src/test/regress/sql/psql_gp_commands.sql
+++ b/src/test/regress/sql/psql_gp_commands.sql
@@ -140,3 +140,4 @@ ALTER FUNCTION foofunc_exec_on_initplan() OWNER TO test_psql_de_role;
 -- Clean up
 DROP OWNED BY test_psql_de_role;
 DROP ROLE test_psql_de_role;
+DROP ACCESS METHOD bogus;


### PR DESCRIPTION
Custom access method in test case remain in pg_am may lead to gpcheckcat failed. Clean it.
![image](https://user-images.githubusercontent.com/13748374/193011958-1338eeff-aa52-4e94-ba64-da6594b795cd.png)
![image](https://user-images.githubusercontent.com/13748374/193011988-c7153fed-0c4c-4991-a0b9-11099556a0e6.png)
