### PR TITLE
pg_upgrade: Remove flags to add/remove data checksums

### DIFF
--- a/src/bin/pg_upgrade/controldata.c
+++ b/src/bin/pg_upgrade/controldata.c
@@ -755,27 +755,18 @@ check_control_data(ControlData *oldctrl,
 	 */
 
 	/*
-	 * Check for allowed combinations of data checksums. PostgreSQL only allow
-	 * upgrades where the checksum settings match, in Greenplum we can however
-	 * set or remove checksums during the upgrade.
+	 * We might eventually allow upgrades from checksum to no-checksum
+	 * clusters.
 	 */
 	if (oldctrl->data_checksum_version == 0 &&
-		newctrl->data_checksum_version != 0 &&
-		!is_checksum_mode(CHECKSUM_ADD))
-		pg_fatal("old cluster does not use data checksums but the new one does\n");
+		newctrl->data_checksum_version != 0)
+		pg_fatal("old cluster does not use data checksums but the new one does");
 	else if (oldctrl->data_checksum_version != 0 &&
-			 newctrl->data_checksum_version == 0 &&
-			 !is_checksum_mode(CHECKSUM_REMOVE))
-		pg_fatal("old cluster uses data checksums but the new one does not\n");
-	else if (oldctrl->data_checksum_version == newctrl->data_checksum_version &&
-			 !is_checksum_mode(CHECKSUM_NONE))
-		pg_fatal("old and new cluster data checksum configuration match, cannot %s data checksums\n",
-				 (is_checksum_mode(CHECKSUM_ADD) ? "add" : "remove"));
-	else if (oldctrl->data_checksum_version != 0 && is_checksum_mode(CHECKSUM_ADD))
-		pg_fatal("--add-checksum option not supported for old cluster which uses data checksums\n");
-	else if (oldctrl->data_checksum_version != newctrl->data_checksum_version
-			 && is_checksum_mode(CHECKSUM_NONE))
-		pg_fatal("old and new cluster pg_controldata checksum versions do not match\n");
+			 newctrl->data_checksum_version == 0)
+		pg_fatal("old cluster uses data checksums but the new one does not");
+	else if (oldctrl->data_checksum_version != newctrl->data_checksum_version)
+		pg_fatal("old and new cluster pg_controldata checksum versions do not match");
+
 }
 
 

--- a/src/bin/pg_upgrade/greenplum/option_gp.c
+++ b/src/bin/pg_upgrade/greenplum/option_gp.c
@@ -9,7 +9,6 @@ typedef enum
 typedef struct {
 	bool progress;
 	segmentMode segment_mode;
-	checksumMode checksum_mode;
 	bool continue_check_on_fatal;
 	bool skip_target_check;
 } GreenplumUserOpts;
@@ -44,14 +43,6 @@ process_greenplum_option(greenplumOption option)
 
 		case GREENPLUM_PROGRESS_OPTION:        /* --progress */
 			greenplum_user_opts.progress = true;
-			break;
-
-		case GREENPLUM_ADD_CHECKSUM_OPTION:        /* --add-checksum */
-			greenplum_user_opts.checksum_mode = CHECKSUM_ADD;
-			break;
-
-		case GREENPLUM_REMOVE_CHECKSUM_OPTION:        /* --remove-checksum */
-			greenplum_user_opts.checksum_mode = CHECKSUM_REMOVE;
 			break;
 
 		case GREENPLUM_CONTINUE_CHECK_ON_FATAL:
@@ -90,12 +81,6 @@ bool
 is_greenplum_dispatcher_mode()
 {
 	return greenplum_user_opts.segment_mode == DISPATCHER;
-}
-
-bool
-is_checksum_mode(checksumMode mode)
-{
-	return mode == greenplum_user_opts.checksum_mode;
 }
 
 bool

--- a/src/bin/pg_upgrade/greenplum/pg_upgrade_greenplum.h
+++ b/src/bin/pg_upgrade/greenplum/pg_upgrade_greenplum.h
@@ -31,35 +31,22 @@ typedef enum
 	DONE
 } progress_type;
 
-typedef enum
-{
-	CHECKSUM_NONE = 0,
-	CHECKSUM_ADD,
-	CHECKSUM_REMOVE
-} checksumMode;
-
 typedef enum {
 	GREENPLUM_MODE_OPTION = 10,
 	GREENPLUM_PROGRESS_OPTION = 11,
-	GREENPLUM_ADD_CHECKSUM_OPTION = 12,
-	GREENPLUM_REMOVE_CHECKSUM_OPTION = 13,
-	GREENPLUM_CONTINUE_CHECK_ON_FATAL = 14,
-	GREENPLUM_SKIP_TARGET_CHECK = 15
+	GREENPLUM_CONTINUE_CHECK_ON_FATAL = 12,
+	GREENPLUM_SKIP_TARGET_CHECK = 13
 } greenplumOption;
 
 #define GREENPLUM_OPTIONS \
 	{"mode", required_argument, NULL, GREENPLUM_MODE_OPTION}, \
 	{"progress", no_argument, NULL, GREENPLUM_PROGRESS_OPTION}, \
-	{"add-checksum", no_argument, NULL, GREENPLUM_ADD_CHECKSUM_OPTION}, \
-	{"remove-checksum", no_argument, NULL, GREENPLUM_REMOVE_CHECKSUM_OPTION}, \
 	{"continue-check-on-fatal", no_argument, NULL, GREENPLUM_CONTINUE_CHECK_ON_FATAL}, \
 	{"skip-target-check", no_argument, NULL, GREENPLUM_SKIP_TARGET_CHECK},
 
 #define GREENPLUM_USAGE "\
       --mode=TYPE               designate node type to upgrade, \"segment\" or \"dispatcher\" (default \"segment\")\n\
       --progress                enable progress reporting\n\
-      --remove-checksum         remove data checksums when creating new cluster\n\
-      --add-checksum            add data checksumming to the new cluster\n\
       --continue-check-on-fatal continue to run through all pg_upgrade checks without upgrade. Stops on major issues\n\
       --skip-target-check       skip all checks on new/target cluster\n\
 "
@@ -68,7 +55,6 @@ typedef enum {
 void initialize_greenplum_user_options(void);
 bool process_greenplum_option(greenplumOption option);
 bool is_greenplum_dispatcher_mode(void);
-bool is_checksum_mode(checksumMode mode);
 bool is_show_progress_mode(void);
 bool is_continue_check_on_fatal(void);
 void set_check_fatal_occured(void);

--- a/src/bin/pg_upgrade/option.c
+++ b/src/bin/pg_upgrade/option.c
@@ -278,11 +278,6 @@ parseCommandLine(int argc, char *argv[])
 	check_required_directory(&user_opts.socketdir, "PGSOCKETDIR", true,
 							 "-s", _("sockets will be created"));
 
-	/* Ensure we are only adding checksums in copy mode */
-	if (user_opts.transfer_mode != TRANSFER_MODE_COPY &&
-		!is_checksum_mode(CHECKSUM_NONE))
-		pg_fatal("Adding and removing checksums only supported in copy mode.\n");
-
 #ifdef WIN32
 	/*
 	 * On Windows, initdb --sync-only will fail with a "Permission denied"

--- a/src/bin/pg_upgrade/test_gpdb.sh
+++ b/src/bin/pg_upgrade/test_gpdb.sh
@@ -216,8 +216,6 @@ usage()
 	echo " -B <dir>     old cluster executable directory (defaults to new binaries)"
 	echo " -s           Run smoketest only"
 	echo " -C           Skip gpcheckcat test"
-	echo " -k           Add checksums to new cluster"
-	echo " -K           Remove checksums during upgrade"
 	echo " -m           Upgrade mirrors"
 	echo " -r           Retain temporary installation after test, even on success"
 	echo " -p           pg_upgrade performance checking only"
@@ -332,15 +330,6 @@ main() {
 			C )
 				gpcheckcat=0
 				;;
-			k )
-				add_checksums=1
-				PGUPGRADE_OPTS+=' --add-checksum '
-				;;
-			K )
-				remove_checksums=1
-				DEMOCLUSTER_OPTS=' -K '
-				PGUPGRADE_OPTS+=' --remove-checksum '
-				;;
 			m )
 				mirrors=1
 				;;
@@ -364,14 +353,6 @@ main() {
 	
 	if [ -z "${OLD_DATADIR}" ] || [ -z "${NEW_BINDIR}" ]; then
 		usage
-	fi
-	
-	# This should be rejected by pg_upgrade as well, but this test is not concerned
-	# with testing handling incorrect option handling in pg_upgrade so we'll error
-	# out early instead.
-	if [ ! -z "${add_checksums}"] && [ ! -z "${remove_checksums}" ]; then
-		echo "ERROR: adding and removing checksums are mutually exclusive"
-		exit 1
 	fi
 	
 	rm -rf "$temp_root"


### PR DESCRIPTION
These flags are unused by gpupgrade and are safe to remove.