### PR TITLE
[6X-Only] fix up the lack of timestamp when we import snapshot

### DIFF
--- a/src/backend/utils/time/snapmgr.c
+++ b/src/backend/utils/time/snapmgr.c
@@ -1142,6 +1142,7 @@ ExportSnapshot(Snapshot snapshot)
 	if (snapshot->haveDistribSnapshot)
 	{
 		distributed_snapshot = &snapshot->distribSnapshotWithLocalMapping.ds;
+		appendStringInfo(&buf, "dstimestamp:%u\n", distributed_snapshot->distribTransactionTimeStamp);
 		appendStringInfo(&buf, "dsxminall:%u\n", distributed_snapshot->xminAllDistributedSnapshots);
 		appendStringInfo(&buf, "dsid:%d\n", distributed_snapshot->distribSnapshotId);
 		appendStringInfo(&buf, "dsxmin:%u\n", distributed_snapshot->xmin);
@@ -1408,6 +1409,7 @@ ImportSnapshot(const char *idstr)
 				errhint("export the snapshot in utility mode")));
 		}
 		distributed_snapshot = &snapshot.distribSnapshotWithLocalMapping.ds;
+		distributed_snapshot->distribTransactionTimeStamp = parseXidFromText("dstimestamp:", &filebuf, path);
 		distributed_snapshot->xminAllDistributedSnapshots = parseXidFromText("dsxminall:", &filebuf, path);
 		distributed_snapshot->distribSnapshotId = parseIntFromText("dsid:", &filebuf, path);
 		distributed_snapshot->xmin = parseXidFromText("dsxmin:", &filebuf, path);

--- a/src/test/isolation2/expected/export_distributed_snapshot.out
+++ b/src/test/isolation2/expected/export_distributed_snapshot.out
@@ -342,3 +342,55 @@ BEGIN
 SET
 
 -1Uq: ... <quitting>
+
+
+-- test set transaction snapshot in 6X-STABLE, more details can be found in
+-- https://github.com/greenplum-db/gpdb/issues/14177
+
+drop table if exists fix_set_transaction_snapshot;
+DROP
+create table fix_set_transaction_snapshot(a int);
+CREATE
+
+1: begin;
+BEGIN
+1: set transaction isolation level repeatable read;
+SET
+1: @post_run ' TOKEN=`echo "${RAW_STR}" | awk \'NR==3\' | awk \'{print $1}\'` && echo "${RAW_STR}"': SELECT pg_export_snapshot();
+ pg_export_snapshot
+--------------------
+ 00000D6E-1
+(1 row)
+1: select * from fix_set_transaction_snapshot;
+ a 
+---
+(0 rows)
+
+2: insert into fix_set_transaction_snapshot values (1), (2), (3);
+INSERT 3
+
+1: select * from fix_set_transaction_snapshot;
+ a 
+---
+(0 rows)
+
+3: begin;
+BEGIN
+3: set transaction isolation level repeatable read;
+SET
+3: @pre_run 'echo "${RAW_STR}" | sed "s#@TOKEN#${TOKEN}#"': SET TRANSACTION SNAPSHOT '@TOKEN';
+SET
+-- should return 0 row
+3: select * from fix_set_transaction_snapshot;
+ a 
+---
+(0 rows)
+3: commit;
+COMMIT
+
+1: commit;
+COMMIT
+
+drop table fix_set_transaction_snapshot;
+DROP
+


### PR DESCRIPTION
This PR is trying to fix the issue #14177. Because 6X-STABLE is still using the 
`DistributedTransactionTimeStamp` to check the visibility, which 7.0-Alpha has 
removed this filed from `DistributedSnapshot` in PR #10910. 

In 6X-STABLE, we will not write the distributed snapshot's timestamp into snapshot 
files, it just like:

```
smart@stable: qddir/demoDataDir-1/pg_snapshots$ cat 000002DF-1
xid:735
dbid:12812
iso:2
ro:1
xmin:735
xmax:735
xcnt:0
sof:0
sxcnt:0
rec:0
dsxminall:5
dsid:12
dsxmin:5
dsxmax:5
dsxcnt:0
``` 

So in the function `ImportSnapshot()` we could not get the value of timestamp in QD, 
then there is no way to serialize this value and pass it to QE, so this value will be 0 in 
QE, and will lead to the wrong judgment of visibility.

This PR adds the value of `distribTransactionTimeStamp` to the snapshot files, though
SET TRANSACTION SNAPSHOT  can work normally in 6X-STABLE.



