### PR TITLE
FIX crash of GET_AO_COMPRESSION_RATIO on heap table 

### DIFF
--- a/src/backend/access/appendonly/aosegfiles.c
+++ b/src/backend/access/appendonly/aosegfiles.c
@@ -1610,12 +1610,10 @@ aorow_compression_ratio_internal(Relation parentrel)
 
 			if (NULL == attr1 || NULL == attr2)
 			{
-				SPI_finish();
-				return 1;
+				compress_ratio = 1;
 			}
-
-			if (scanint8(attr1, true, &eof) &&
-				scanint8(attr2, true, &eof_uncomp))
+			else if (scanint8(attr1, true, &eof) &&
+					 scanint8(attr2, true, &eof_uncomp))
 			{
 				/* guard against division by zero */
 				if (eof > 0)
@@ -1626,6 +1624,12 @@ aorow_compression_ratio_internal(Relation parentrel)
 					/* format to 2 digit decimal precision */
 					compress_ratio = round(compress_ratio * 100.0) / 100.0;
 				}
+			}
+			else
+			{
+				ereport(ERROR,
+						(errcode(ERRCODE_INTERNAL_ERROR),
+						errmsg("unable to parse aorow compress_ratio string to int8.")));
 			}
 		}
 

--- a/src/test/regress/expected/AORO_Compression.out
+++ b/src/test/regress/expected/AORO_Compression.out
@@ -25,3 +25,15 @@ CREATE TABLE a_aoro_table_with_rle_type_compression(col int) WITH (APPENDONLY=tr
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'col' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 ERROR:  rle_type cannot be used with Append Only relations row orientation
+-- Test get_ao_compression_ratio
+CREATE TABLE test_table (date date)
+PARTITION BY RANGE(date)
+(
+PARTITION test_cmp_02 START ('2022-02-01'::date) END ('2022-03-01'::date) EVERY ('1 mon'::interval) WITH (tablename='test_table_1_prt_cmp_202202', appendonly='true', orientation='row', compresstype=zlib),
+START ('2022-03-01'::date) END ('2022-04-01'::date) EVERY ('1 mon'::interval) WITH (tablename='test_table_1_prt_123', appendonly='false')
+);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'date' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+select get_ao_compression_ratio(t.relid) from (select relid from pg_partition_tree('test_table') where isleaf != false) as t;
+ERROR:  'test_table_1_prt_123' is not an append-only relation
+drop table test_table;

--- a/src/test/regress/sql/AORO_Compression.sql
+++ b/src/test/regress/sql/AORO_Compression.sql
@@ -11,3 +11,15 @@ SELECT pg_size_pretty(pg_relation_size('a_aoro_table_with_zlib_compression')),
 
 -- Test basic create table for AO/RO table fails for rle compression. rle is only supported for columnar tables.
 CREATE TABLE a_aoro_table_with_rle_type_compression(col int) WITH (APPENDONLY=true, COMPRESSTYPE=rle_type, COMPRESSLEVEL=1, ORIENTATION=row);
+
+-- Test get_ao_compression_ratio
+CREATE TABLE test_table (date date)
+PARTITION BY RANGE(date)
+(
+PARTITION test_cmp_02 START ('2022-02-01'::date) END ('2022-03-01'::date) EVERY ('1 mon'::interval) WITH (tablename='test_table_1_prt_cmp_202202', appendonly='true', orientation='row', compresstype=zlib),
+START ('2022-03-01'::date) END ('2022-04-01'::date) EVERY ('1 mon'::interval) WITH (tablename='test_table_1_prt_123', appendonly='false')
+);
+
+select get_ao_compression_ratio(t.relid) from (select relid from pg_partition_tree('test_table') where isleaf != false) as t;
+
+drop table test_table;


### PR DESCRIPTION
Crash happened on Master when we call GET_AO_COMPRESSION_RATIO functions on partition table. 
```
postgres=# \d+;
                                          List of relations
 Schema |            Name             |       Type        |  Owner  | Storage |  Size   | Description 
--------+-----------------------------+-------------------+---------+---------+---------+-------------
 public | test_table                  | partitioned table | gpadmin | heap    | 0 bytes | 
 public | test_table_1_prt_123        | table             | gpadmin | heap    | 0 bytes | 
 public | test_table_1_prt_cmp_202202 | table             | gpadmin | ao_row  | 128 kB  | 
(3 rows)

postgres=# select get_ao_compression_ratio(t.relid) from (select relid from pg_partition_tree('test_table') where isleaf != false) as t;
server closed the connection unexpectedly
	This probably means the server terminated abnormally
	before or while processing the request.
The connection to the server was lost. Attempting reset: Failed.
!> 
```

TRY-CATCH exist in get_ao_compression_ratio, and the case as above trigger RETURN branch in TRY. Some 
setjump/longjump context has been mess so that we cannot longjump to right address once ereport(ERROR) 
exists later. In a word, we should not return anything in TRY-CATCH block.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community