### PR TITLE
cdb: fix SEGFAULT for gpdb builded with cassert

### DIFF
--- a/src/backend/cdb/cdbpartition.c
+++ b/src/backend/cdb/cdbpartition.c
@@ -7872,7 +7872,6 @@ is_exchangeable(Relation rel, Relation oldrel, Relation newrel, bool throw)
 			for (i = 0; i < adjpol->nattrs; i++)
 			{
 				adjpol->attrs[i] = attrMap(map_new, parpol->attrs[i]);
-				Assert(newpol->attrs[i] > 0);	/* check new part */
 			}
 		}
 		else

--- a/src/test/regress/expected/partition.out
+++ b/src/test/regress/expected/partition.out
@@ -8707,3 +8707,13 @@ reset optimizer_enable_hashjoin;
 reset optimizer_enable_materialize;
 drop table t1_12533;
 drop table t2_12533;
+-- test echange partition without distribution (with deleted column won't produce SEGFAULT for gpdb builded with --enable-cassert)
+CREATE TABLE tbl_default_distribution( a int, b int, c int) partition by range(c)( start(1) end (10) every (2), default partition deflt);
+create table tbl_default_distribution_dropped_field(a1 int, a int, b int, c int);
+alter table tbl_default_distribution_dropped_field drop column a1;
+alter table tbl_default_distribution exchange partition for (rank(2)) with table tbl_default_distribution_dropped_field;
+ERROR:  distribution policy for "tbl_default_distribution_dropped_field" must be the same as that for "tbl_default_distribution"
+create table rnd_distribution(a1 int, a int, b int, c int) distributed randomly;
+alter table rnd_distribution drop column a1;
+alter table tbl_default_distribution exchange partition for (rank(2)) with table rnd_distribution;
+ERROR:  distribution policy for "rnd_distribution" must be the same as that for "tbl_default_distribution"

--- a/src/test/regress/expected/partition_optimizer.out
+++ b/src/test/regress/expected/partition_optimizer.out
@@ -8636,3 +8636,13 @@ reset optimizer_enable_hashjoin;
 reset optimizer_enable_materialize;
 drop table t1_12533;
 drop table t2_12533;
+-- test echange partition without distribution (with deleted column won't produce SEGFAULT for gpdb builded with --enable-cassert)
+CREATE TABLE tbl_default_distribution( a int, b int, c int) partition by range(c)( start(1) end (10) every (2), default partition deflt);
+create table tbl_default_distribution_dropped_field(a1 int, a int, b int, c int);
+alter table tbl_default_distribution_dropped_field drop column a1;
+alter table tbl_default_distribution exchange partition for (rank(2)) with table tbl_default_distribution_dropped_field;
+ERROR:  distribution policy for "tbl_default_distribution_dropped_field" must be the same as that for "tbl_default_distribution"
+create table rnd_distribution(a1 int, a int, b int, c int) distributed randomly;
+alter table rnd_distribution drop column a1;
+alter table tbl_default_distribution exchange partition for (rank(2)) with table rnd_distribution;
+ERROR:  distribution policy for "rnd_distribution" must be the same as that for "tbl_default_distribution"

--- a/src/test/regress/sql/partition.sql
+++ b/src/test/regress/sql/partition.sql
@@ -4163,3 +4163,13 @@ reset optimizer_enable_materialize;
 
 drop table t1_12533;
 drop table t2_12533;
+
+-- test echange partition without distribution (with deleted column won't produce SEGFAULT for gpdb builded with --enable-cassert)
+CREATE TABLE tbl_default_distribution( a int, b int, c int) partition by range(c)( start(1) end (10) every (2), default partition deflt);
+create table tbl_default_distribution_dropped_field(a1 int, a int, b int, c int);
+alter table tbl_default_distribution_dropped_field drop column a1;
+alter table tbl_default_distribution exchange partition for (rank(2)) with table tbl_default_distribution_dropped_field;
+
+create table rnd_distribution(a1 int, a int, b int, c int) distributed randomly;
+alter table rnd_distribution drop column a1;
+alter table tbl_default_distribution exchange partition for (rank(2)) with table rnd_distribution;


### PR DESCRIPTION
# Problem description.
Partition exchanging with different distribution policy may produce `SEGFAULT` at gpdb builded with `--enable-cassert`.

For ex., the next query, will produce SEGFAULT:
```
postgres=# CREATE TABLE ds_part ( a INT, b INT, c INT) PARTITION BY RANGE(c)( START(1) END (10) EVERY (2), DEFAULT PARTITION deflt);
NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
NOTICE:  CREATE TABLE will create partition "ds_part_1_prt_deflt" for table "ds_part"
NOTICE:  CREATE TABLE will create partition "ds_part_1_prt_2" for table "ds_part"
NOTICE:  CREATE TABLE will create partition "ds_part_1_prt_3" for table "ds_part"
NOTICE:  CREATE TABLE will create partition "ds_part_1_prt_4" for table "ds_part"
NOTICE:  CREATE TABLE will create partition "ds_part_1_prt_5" for table "ds_part"
NOTICE:  CREATE TABLE will create partition "ds_part_1_prt_6" for table "ds_part"
CREATE TABLE
postgres=# create table ds2 (a1 INT, a INT, b INT, c INT);
NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a1' as the Greenplum Database data distribution key for this table.
HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
CREATE TABLE
postgres=# alter table ds2 drop column a1;
NOTICE:  dropping a column that is part of the distribution policy forces a NULL distribution policy
ALTER TABLE
postgres=# alter table ds_part exchange partition for (RANK(2)) with table ds2;
server closed the connection unexpectedly
        This probably means the server terminated abnormally
        before or while processing the request.
The connection to the server was lost. Attempting reset: Failed.
!>
```

If table, that are exhanging, has deleted column and has difference in distribution policy with parent table (ex. parent was created with default policy and new table created with `GpPolicy` `distributed randomly`, or distribution column was dropped at new table) then operation:
`alter table parent_tbl exhange partition for ... with exchange_tbl` may produce `SEGFAULT` at function `is_exchangeble`. In case described above, `Assert(newpol->attrs[i] > 0)`, checks that new `GpPolicy` (of new table) has distribution keys, but it doesn't have them (`attrs` is `NULL` and `nattrs`=0), so a NULL pointer dereference occurs.
This assertion, seems, should be deleted, because next access to `attrs` is at function `GpPolicyEqual(adjpol, newpol)` (in the code below), but before accessing to `attrs` function validates equality of the GpPolicie's `nattrs`, if them not equal this function returns false and `attrs` won't be accessed.

Next [issue](https://github.com/greenplum-db/gpdb/pull/11206) is related to current patch (issue was closed, but problem was not solved). Also master doesn't produce SEGFAULT, there is no file `cdbpartition.c` seems code was moved (splitted) to different functions, so this patch is only for `6.x`.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
