### PR TITLE
Revert "Unify ic-proxy log level under GUC gp_log_interconnect's cont…

### DIFF
--- a/src/backend/cdb/motion/ic_proxy.h
+++ b/src/backend/cdb/motion/ic_proxy.h
@@ -30,16 +30,17 @@
 #define IC_PROXY_ACK_INTERVAL 10
 
 
+#ifndef IC_PROXY_LOG_LEVEL
+#define IC_PROXY_LOG_LEVEL WARNING
+#endif
 
 #define ic_proxy_alloc(size) palloc(size)
 #define ic_proxy_free(ptr) pfree(ptr)
 #define ic_proxy_new(type) ((type *) ic_proxy_alloc(sizeof(type)))
 
 #define ic_proxy_log(elevel, msg...) do { \
-	if ((elevel) >= WARNING || gp_log_interconnect >= GPVARS_VERBOSITY_TERSE) \
+	if (elevel >= IC_PROXY_LOG_LEVEL) \
 	{ \
-		if ((elevel) <= DEBUG1 && gp_log_interconnect < GPVARS_VERBOSITY_DEBUG) \
-			break;	\
 		elog(elevel, msg); \
 	} \
 } while (0)

--- a/src/backend/cdb/motion/ic_proxy_addr.c
+++ b/src/backend/cdb/motion/ic_proxy_addr.c
@@ -186,7 +186,7 @@ ic_proxy_addr_on_getaddrinfo(uv_getaddrinfo_t *req,
 			if (iter->ai_family == AF_UNIX)
 				continue;
 
-			if (gp_log_interconnect >= GPVARS_VERBOSITY_TERSE)
+#if IC_PROXY_LOG_LEVEL <= LOG
 			{
 				char		name[HOST_NAME_MAX] = "unknown";
 				int			port = 0;
@@ -209,6 +209,7 @@ ic_proxy_addr_on_getaddrinfo(uv_getaddrinfo_t *req,
 								 name, port, family,
 								 uv_strerror(ret));
 			}
+#endif /* IC_PROXY_LOG_LEVEL <= LOG */
 
 			memcpy(&addr->sockaddr, iter->ai_addr, iter->ai_addrlen);
 			ic_proxy_addrs = lappend(ic_proxy_addrs, addr);

--- a/src/backend/cdb/motion/ic_proxy_client.c
+++ b/src/backend/cdb/motion/ic_proxy_client.c
@@ -468,7 +468,7 @@ ic_proxy_client_on_c2p_data_pkt(void *opaque, const void *data, uint16 size)
 {
 	ICProxyClient *client = opaque;
 
-	ic_proxy_log(DEBUG5, "%s: received B2C PKT [%d bytes] from the backend",
+	ic_proxy_log(LOG, "%s: received B2C PKT [%d bytes] from the backend",
 				 ic_proxy_client_get_name(client), size);
 
 	/* increase the number of unack packets */

--- a/src/backend/cdb/motion/ic_proxy_main.c
+++ b/src/backend/cdb/motion/ic_proxy_main.c
@@ -159,7 +159,7 @@ ic_proxy_server_peer_listener_init(uv_loop_t *loop)
 		/* Cannot get my addr, maybe the setting is invalid */
 		return;
 
-	if (gp_log_interconnect >= GPVARS_VERBOSITY_TERSE)
+#if IC_PROXY_LOG_LEVEL <= LOG
 	{
 		char		name[HOST_NAME_MAX] = "unknown";
 		int			port = 0;
@@ -178,6 +178,7 @@ ic_proxy_server_peer_listener_init(uv_loop_t *loop)
 						 addr->hostname, addr->service, name, port, family,
 						 uv_strerror(ret));
 	}
+#endif /* IC_PROXY_LOG_LEVEL <= LOG */
 
 	/*
 	 * It is important to set TCP_NODELAY, otherwise we will suffer from

--- a/src/backend/cdb/motion/ic_proxy_pkt_cache.c
+++ b/src/backend/cdb/motion/ic_proxy_pkt_cache.c
@@ -26,6 +26,7 @@
  *-------------------------------------------------------------------------
  */
 
+#define IC_PROXY_LOG_LEVEL WARNING
 #include "ic_proxy.h"
 #include "ic_proxy_pkt_cache.h"
 


### PR DESCRIPTION
…rol, and remove macro IC_PROXY_LOG_LEVEL"

This reverts commit 24140214f21df4276f239b061754eefe610c1d8a.

This change caused ICW proxy pipelines to go red [1][2][3][4][5][6] due to extra logging.  Reverting so that pipelines go back to green again.

[1] https://prod.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb_master/jobs/icw_gporca_icproxy_rhel8/builds/568 [2] https://prod.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb_master/jobs/icw_planner_icproxy_rhel8/builds/571 [3] https://prod.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb_master/jobs/icw_gporca_icproxy_ubuntu18.04/builds/1324 [4] https://prod.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb_master/jobs/icw_planner_icproxy_ubuntu18.04/builds/1322 [5] https://prod.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb_master/jobs/icw_gporca_icproxy_centos7/builds/1342 [6] https://prod.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb_master/jobs/icw_planner_icproxy_centos7/builds/1344