### PR TITLE
Revamp ic-proxy logging

### DIFF
--- a/src/backend/cdb/motion/ic_proxy.h
+++ b/src/backend/cdb/motion/ic_proxy.h
@@ -29,21 +29,9 @@
 /* send a ack message after a batch of packets*/
 #define IC_PROXY_ACK_INTERVAL 10
 
-
-#ifndef IC_PROXY_LOG_LEVEL
-#define IC_PROXY_LOG_LEVEL WARNING
-#endif
-
 #define ic_proxy_alloc(size) palloc(size)
 #define ic_proxy_free(ptr) pfree(ptr)
 #define ic_proxy_new(type) ((type *) ic_proxy_alloc(sizeof(type)))
-
-#define ic_proxy_log(elevel, msg...) do { \
-	if (elevel >= IC_PROXY_LOG_LEVEL) \
-	{ \
-		elog(elevel, msg); \
-	} \
-} while (0)
 
 /*
  * Build the domain socket path.

--- a/src/backend/cdb/motion/ic_proxy_iobuf.c
+++ b/src/backend/cdb/motion/ic_proxy_iobuf.c
@@ -77,7 +77,7 @@ void
 ic_proxy_ibuf_clear(ICProxyIBuf *ibuf)
 {
 	if (ibuf->len > 0)
-		ic_proxy_log(WARNING, "ic-proxy-ibuf: dropped %d bytes", ibuf->len);
+		elog(WARNING, "ic-proxy: dropped %d bytes", ibuf->len);
 
 	ibuf->len = 0;
 }
@@ -322,8 +322,8 @@ ic_proxy_obuf_push(ICProxyOBuf *obuf,
 				   void *opaque)
 {
 	if (unlikely(obuf->buf == NULL))
-		ic_proxy_log(ERROR,
-					 "ic-proxy-obuf: the caller must init the header before pushing data");
+		elog(ERROR,
+					 "ic-proxy: the caller must init the header before pushing data");
 
 	/*
 	 * Need a flush when:
@@ -333,8 +333,8 @@ ic_proxy_obuf_push(ICProxyOBuf *obuf,
 	if (unlikely(size == 0 || size + obuf->len > IC_PROXY_MAX_PKT_SIZE))
 	{
 		if (obuf->header_size + size > IC_PROXY_MAX_PKT_SIZE)
-			ic_proxy_log(ERROR,
-						 "ic-proxy-obuf: no enough buffer to store the data:"
+			elog(ERROR,
+						 "ic-proxy: not enough buffer to store the data:"
 						 " the data size is %d bytes,"
 						 " but the buffer size is only %zd bytes,"
 						 " including a %d bytes header",
@@ -342,7 +342,10 @@ ic_proxy_obuf_push(ICProxyOBuf *obuf,
 
 		/* TODO: should we flush if no data in the packet? */
 		if (obuf->len == obuf->header_size)
-			ic_proxy_log(LOG, "ic-proxy-obuf: no data to flush");
+		{
+			elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG1,
+				   "ic-proxy: no data to flush");
+		}
 		else
 		{
 			obuf->set_packet_size(obuf->buf, obuf->len);

--- a/src/backend/cdb/motion/ic_proxy_pkt_cache.c
+++ b/src/backend/cdb/motion/ic_proxy_pkt_cache.c
@@ -26,7 +26,6 @@
  *-------------------------------------------------------------------------
  */
 
-#define IC_PROXY_LOG_LEVEL WARNING
 #include "ic_proxy.h"
 #include "ic_proxy_pkt_cache.h"
 
@@ -113,7 +112,8 @@ ic_proxy_pkt_cache_alloc(size_t *pkt_size)
 	memset(cpkt, 0, ic_proxy_pkt_cache.pkt_size);
 #endif
 
-	ic_proxy_log(LOG, "pkt-cache: allocated, %d free, %d total",
+	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG5,
+		   "ic-proxy: pkt-cache: allocated, %d free, %d total",
 				 ic_proxy_pkt_cache.n_free, ic_proxy_pkt_cache.n_total);
 	return cpkt;
 }
@@ -159,7 +159,8 @@ ic_proxy_pkt_cache_free(void *pkt)
 		ic_proxy_pkt_cache.freelist = cpkt;
 		ic_proxy_pkt_cache.n_free++;
 
-		ic_proxy_log(LOG, "pkt-cache: recycled, %d free, %d total",
+		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG5,
+			   "ic-proxy: pkt-cache: recycled, %d free, %d total",
 					 ic_proxy_pkt_cache.n_free, ic_proxy_pkt_cache.n_total);
 	}
 }

--- a/src/backend/cdb/motion/ic_proxy_router.c
+++ b/src/backend/cdb/motion/ic_proxy_router.c
@@ -104,7 +104,8 @@ ic_proxy_router_loopback_on_check(uv_check_t *handle)
 		ic_proxy_key_from_p2c_pkt(&key, delay->pkt);
 		client = ic_proxy_client_blessed_lookup(handle->loop, &key);
 
-		ic_proxy_log(LOG, "ic-proxy-router: looped back %s to %s",
+		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG5,
+			   "ic-proxy: router: looped back %s to %s",
 					 ic_proxy_pkt_to_str(delay->pkt),
 					 ic_proxy_client_get_name(client));
 
@@ -131,7 +132,8 @@ ic_proxy_router_loopback_push(ICProxyPkt *pkt,
 {
 	ICProxyDelay *delay;
 
-	ic_proxy_log(LOG, "ic-proxy-router: looping back %s",
+	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG5,
+		   "ic-proxy: router: looping back %s",
 				 ic_proxy_pkt_to_str(pkt));
 
 	/*
@@ -221,7 +223,8 @@ ic_proxy_router_route(uv_loop_t *loop, ICProxyPkt *pkt,
 		ic_proxy_key_from_p2c_pkt(&key, pkt);
 		client = ic_proxy_client_blessed_lookup(loop, &key);
 
-		ic_proxy_log(LOG, "ic-proxy-router: routing %s to %s",
+		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG5,
+			   "ic-proxy: router: routing %s to %s",
 					 ic_proxy_pkt_to_str(pkt),
 					 ic_proxy_client_get_name(client));
 
@@ -234,7 +237,8 @@ ic_proxy_router_route(uv_loop_t *loop, ICProxyPkt *pkt,
 		peer = ic_proxy_peer_blessed_lookup(loop,
 											pkt->dstContentId, pkt->dstDbid);
 
-		ic_proxy_log(LOG, "ic-proxy-router: routing %s to %s",
+		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG5,
+			   "ic-proxy: router: routing %s to %s",
 					 ic_proxy_pkt_to_str(pkt), peer->name);
 
 		ic_proxy_peer_route_data(peer, pkt, callback, opaque);
@@ -251,11 +255,17 @@ ic_proxy_router_on_write(uv_write_t *req, int status)
 	ICProxyPkt *pkt = req->data;
 
 	if (status < 0)
-		ic_proxy_log(LOG, "ic-proxy-router: fail to send %s: %s",
+	{
+		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG5,
+			   "ic-proxy: router: fail to send %s: %s",
 					 ic_proxy_pkt_to_str(pkt), uv_strerror(status));
+	}
 	else
-		ic_proxy_log(LOG, "ic-proxy-router: sent %s",
+	{
+		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG5,
+			   "ic-proxy: router: sent %s",
 					 ic_proxy_pkt_to_str(pkt));
+	}
 
 	if (wreq->callback)
 		wreq->callback(wreq->opaque, pkt, status);
@@ -289,7 +299,8 @@ ic_proxy_router_write(uv_stream_t *stream, ICProxyPkt *pkt, int32 offset,
 	ICProxyWriteReq *wreq;
 	uv_buf_t	wbuf;
 
-	ic_proxy_log(LOG, "ic-proxy-router: sending %s", ic_proxy_pkt_to_str(pkt));
+	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG5,
+		   "ic-proxy: router: sending %s", ic_proxy_pkt_to_str(pkt));
 
 	wreq = ic_proxy_new(ICProxyWriteReq);
 


### PR DESCRIPTION
This is a follow-up to 24140214f21, which was reverted for being too verbose by default, causing CI failures. This reintroduces the gp_log_interconnect GUC to ic-proxy logging and follows the specifications outlined in cdbvars.c. The ic_proxy_log macro is replaced with elog and elogif for WARNINGs/ERRORs and other events respectively.

The scheme used:
TERSE[LOG]:     Server main loop events, signals
VERBOSE[LOG]:   Startup, (un)register, close/shutdown, EOF receipt etc.
DEBUG[DEBUG1]:  Special packet (BYE/HELLO) transfer, pause/resume events
DEBUG[DEBUG3]:  Less interesting packet transfers, caching
DEBUG[DEBUG5]:  Very low-level tracing info

Dev-pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/fix_proxy_logging