### PR TITLE
[6X] Fix memory leak in DynamicBitmapScans

### DIFF
--- a/src/backend/executor/nodeBitmapIndexscan.c
+++ b/src/backend/executor/nodeBitmapIndexscan.c
@@ -212,9 +212,12 @@ ExecEndBitmapIndexScan(BitmapIndexScanState *node)
 	indexScanDesc = node->biss_ScanDesc;
 
 	/*
-	 * Free the exprcontext ... now dead code, see ExecFreeExprContext
+	 * Free the exprcontext(s) ... now dead code, see ExecFreeExprContext
+	 *
+	 * GPDB: This is not dead code in GPDB, because we don't want to leak
+	 * exprcontexts in a dynamic bitmap index scan.
 	 */
-#ifdef NOT_USED
+#if 1
 	if (node->biss_RuntimeContext)
 		FreeExprContext(node->biss_RuntimeContext, true);
 #endif


### PR DESCRIPTION
If a DynamicBitmapScan was under a NLJ, memory would increase very quickly and the system would soon terminate due to OOM. Additionally, performance was slower than an equivalent plan using regular Bitmap Scans. This only affected Orca as only Orca uses Dynamic Scans.

This change had been done for regular index scans, but was not done for bitmap scans.

(cherry picked from commit fe5f92b165bd135ebf5614630990df5cc4333f45)