### PR TITLE
support lz4 compression for ao tables.

### DIFF
--- a/README.CentOS.bash
+++ b/README.CentOS.bash
@@ -17,6 +17,7 @@ sudo yum install -y \
     libyaml-devel \
     libxml2-devel \
     libzstd-devel \
+    liblz4-devel \
     openssl-devel \
     perl-ExtUtils-Embed \
     python3-devel \

--- a/README.Ubuntu.bash
+++ b/README.Ubuntu.bash
@@ -26,6 +26,7 @@ sudo apt-get install -y \
 	libxml2-dev \
 	libyaml-dev \
 	libzstd-dev \
+	liblz4-dev \
 	locales \
 	net-tools \
 	ninja-build \

--- a/README.macOS.bash
+++ b/README.macOS.bash
@@ -20,6 +20,7 @@ brew install libevent # gpfdist
 brew install apr # gpfdist
 brew install apr-util # gpfdist
 brew install zstd
+brew install lz4
 brew install pkg-config
 brew install perl
 brew link --force apr

--- a/configure
+++ b/configure
@@ -719,6 +719,7 @@ with_apr_config
 with_libcurl
 with_rt
 with_quicklz
+with_lz4
 ZSTD_LIBS
 ZSTD_CFLAGS
 with_zstd
@@ -908,6 +909,7 @@ with_system_tzdata
 with_zlib
 with_libbz2
 with_zstd
+with_lz4
 with_quicklz
 with_rt
 with_libcurl
@@ -1629,6 +1631,7 @@ Optional Packages:
   --without-zlib          do not use Zlib
   --without-libbz2        do not use bzip2
   --without-zstd          do not build with Zstandard
+  --without-lz4           do not build with LZ4
   --with-quicklz          build with QuickLZ support (requires quicklz
                           library)
   --without-rt            do not use Realtime Library
@@ -9479,6 +9482,43 @@ $as_echo "yes" >&6; }
 
 fi
 fi
+
+#
+# lz4
+#
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether to build with LZ4 support" >&5
+$as_echo_n "checking whether to build with LZ4 support... " >&6; }
+
+
+
+# Check whether --with-lz4 was given.
+if test "${with_lz4+set}" = set; then :
+  withval=$with_lz4;
+  case $withval in
+    yes)
+
+$as_echo "#define USE_LZ4 1" >>confdefs.h
+
+      ;;
+    no)
+      :
+      ;;
+    *)
+      as_fn_error $? "no argument expected for --with-lz4 option" "$LINENO" 5
+      ;;
+  esac
+
+else
+  with_lz4=yes
+
+$as_echo "#define USE_LZ4 1" >>confdefs.h
+
+fi
+
+
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $with_lz4" >&5
+$as_echo "$with_lz4" >&6; }
+
 
 #
 # quicklz

--- a/configure.in
+++ b/configure.in
@@ -1127,6 +1127,15 @@ if test "$with_zstd" = yes; then
 fi
 
 #
+# lz4
+#
+AC_MSG_CHECKING([whether to build with LZ4 support])
+PGAC_ARG_BOOL(with, lz4, yes, [do not build with LZ4],
+              [AC_DEFINE([USE_LZ4], 1, [Define to build with lz4 support. (--with-lz4)])])
+AC_MSG_RESULT($[with_lz4])
+AC_SUBST(with_lz4)
+
+#
 # quicklz
 #
 PGAC_ARG_BOOL(with, quicklz, no,

--- a/gpcontrib/Makefile
+++ b/gpcontrib/Makefile
@@ -35,6 +35,9 @@ endif
 ifeq "$(with_quicklz)" "yes"
 	recurse_targets += quicklz
 endif
+ifeq "$(with_lz4)" "yes"
+	recurse_targets += lz4
+endif
 $(call recurse,all install clean distclean, $(recurse_targets))
 
 all: gpcloud pxf mapreduce orafce
@@ -97,4 +100,5 @@ installcheck:
 	if [ "$(enable_pxf)" = "yes" ]; then $(MAKE) -C pxf_fdw installcheck; fi
 	if [ "$(with_zstd)" = "yes" ]; then $(MAKE) -C zstd installcheck; fi
 	if [ "$(with_quicklz)" = "yes" ]; then $(MAKE) -C quicklz installcheck; fi
+	if [ "$(with_lz4)" = "yes" ]; then $(MAKE) -C lz4 installcheck; fi
 	$(MAKE) -C gp_sparse_vector installcheck

--- a/gpcontrib/lz4/.gitignore
+++ b/gpcontrib/lz4/.gitignore
@@ -1,0 +1,5 @@
+# Generated subdirectories
+/results/
+
+regression.diffs
+regression.out

--- a/gpcontrib/lz4/Makefile
+++ b/gpcontrib/lz4/Makefile
@@ -1,0 +1,32 @@
+PG_CONFIG = pg_config
+
+MODULE_big = gp_lz4_compression
+OBJS = lz4_compression.o
+CFLAGS_SL += -llz4
+LDFLAGS_SL += -llz4
+
+REGRESS = lz4_column_compression compression_lz4 AOCO_lz4 AORO_lz4
+
+ifdef USE_PGXS
+  PGXS := $(shell $(PG_CONFIG) --pgxs)
+  include $(PGXS)
+else
+  top_builddir = ../..
+  include $(top_builddir)/src/Makefile.global
+  include $(top_srcdir)/contrib/contrib-global.mk
+endif
+
+# Install into cdb_init.d, so that the catalog changes performed by initdb,
+# and the compressor is available in all databases.
+.PHONY: install-data
+install-data:
+	$(INSTALL_DATA) lz4_compression.sql '$(DESTDIR)$(datadir)/cdb_init.d/lz4_compression.sql'
+
+install: install-data
+
+.PHONY: uninstall-data
+
+uninstall-data:
+	rm -f '$(DESTDIR)$(datadir)/cdb_init.d/lz4_compression.sql'
+
+uninstall: uninstall-data

--- a/gpcontrib/lz4/expected/AOCO_lz4.out
+++ b/gpcontrib/lz4/expected/AOCO_lz4.out
@@ -1,0 +1,26 @@
+-- Given that we built with and have lz4 compression available
+-- Test basic create table for AO/CO table succeeds for lz4 compression
+-- Given a column-oriented table with compresstype lz4
+DROP TABLE IF EXISTS a_aoco_table_with_lz4_compression;
+NOTICE:  table "a_aoco_table_with_lz4_compression" does not exist, skipping
+CREATE TABLE a_aoco_table_with_lz4_compression(col text) WITH (APPENDONLY=true, COMPRESSTYPE=lz4, compresslevel=1, ORIENTATION=column);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'col' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- Before I insert data, the size is 0 and compression ratio is unavailable (-1)
+SELECT pg_size_pretty(pg_relation_size('a_aoco_table_with_lz4_compression')),
+       get_ao_compression_ratio('a_aoco_table_with_lz4_compression');
+ pg_size_pretty | get_ao_compression_ratio 
+----------------+--------------------------
+ 0 bytes        |                       -1
+(1 row)
+
+-- After I insert data
+INSERT INTO a_aoco_table_with_lz4_compression values('ksjdhfksdhfksdhfksjhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhh');
+-- Then the data will be compressed according to a consistent compression ratio
+select pg_size_pretty(pg_relation_size('a_aoco_table_with_lz4_compression')),
+       get_ao_compression_ratio('a_aoco_table_with_lz4_compression');
+ pg_size_pretty | get_ao_compression_ratio 
+----------------+--------------------------
+ 64 bytes       |                      1.5
+(1 row)
+

--- a/gpcontrib/lz4/expected/AORO_lz4.out
+++ b/gpcontrib/lz4/expected/AORO_lz4.out
@@ -1,0 +1,24 @@
+-- Given that we built with and have lz4 compression available
+-- Test basic create table for AO/RO table succeeds for lz4 compression
+-- Given a row-oriented table with compresstype lz4
+create table a_aoro_table_with_lz4_compression(col text) WITH (APPENDONLY=true, ORIENTATION=row, COMPRESSTYPE=lz4, compresslevel=1);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'col' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- Before inserting data, the size is 0 and ratio is 1 (for a row-oriented table, ends up being 1)
+select pg_size_pretty(pg_relation_size('a_aoro_table_with_lz4_compression')),
+       get_ao_compression_ratio('a_aoro_table_with_lz4_compression');
+ pg_size_pretty | get_ao_compression_ratio 
+----------------+--------------------------
+ 0 bytes        |                        1
+(1 row)
+
+-- After I insert data
+insert into a_aoro_table_with_lz4_compression values('ksjdhfksdhfksdhfksjhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhh');
+-- Then the data will be compressed according to a consistent compression ratio
+select pg_size_pretty(pg_relation_size('a_aoro_table_with_lz4_compression')),
+       get_ao_compression_ratio('a_aoro_table_with_lz4_compression');
+ pg_size_pretty | get_ao_compression_ratio 
+----------------+--------------------------
+ 56 bytes       |                     1.57
+(1 row)
+

--- a/gpcontrib/lz4/expected/compression_lz4.out
+++ b/gpcontrib/lz4/expected/compression_lz4.out
@@ -1,0 +1,121 @@
+-- Tests for lz4 compression.
+-- Check that callbacks are registered
+SELECT * FROM pg_compression WHERE compname = 'lz4';
+ compname |  compconstructor   |  compdestructor   | compcompressor  | compdecompressor  |  compvalidator   | compowner 
+----------+--------------------+-------------------+-----------------+-------------------+------------------+-----------
+ lz4      | gp_lz4_constructor | gp_lz4_destructor | gp_lz4_compress | gp_lz4_decompress | gp_lz4_validator |        10
+(1 row)
+
+CREATE TABLE lz4test (id int4, t text) WITH (appendonly=true, compresstype=lz4, orientation=column);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- Check that the reloptions on the table shows compression type
+SELECT reloptions FROM pg_class WHERE relname = 'lz4test';
+     reloptions     
+--------------------
+ {compresstype=lz4}
+(1 row)
+
+INSERT INTO lz4test SELECT g, 'foo' || g FROM generate_series(1, 100000) g;
+INSERT INTO lz4test SELECT g, 'bar' || g FROM generate_series(1, 100000) g;
+-- Check that we actually compressed data. With liblz4-1.9.4, the ratio is 1.59.
+SELECT get_ao_compression_ratio('lz4test') IN (1.59);
+ ?column? 
+----------
+ t
+(1 row)
+
+-- Check contents, at the beginning of the table and at the end.
+SELECT * FROM lz4test ORDER BY (id, t) LIMIT 5;
+ id |  t   
+----+------
+  1 | bar1
+  1 | foo1
+  2 | bar2
+  2 | foo2
+  3 | bar3
+(5 rows)
+
+SELECT * FROM lz4test ORDER BY (id, t) DESC LIMIT 5;
+   id   |     t     
+--------+-----------
+ 100000 | foo100000
+ 100000 | bar100000
+  99999 | foo99999
+  99999 | bar99999
+  99998 | foo99998
+(5 rows)
+
+-- Test different compression levels:
+CREATE TABLE lz4test_1 (id int4, t text) WITH (appendonly=true, compresstype=lz4, compresslevel=1);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE lz4test_9 (id int4, t text) WITH (appendonly=true, compresstype=lz4, compresslevel=9);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE lz4test_12 (id int4, t text) WITH (appendonly=true, compresstype=lz4, compresslevel=12);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO lz4test_1 SELECT g, 'foo' || g FROM generate_series(1, 10000) g;
+INSERT INTO lz4test_1 SELECT g, 'bar' || g FROM generate_series(1, 10000) g;
+SELECT * FROM lz4test_1 ORDER BY (id, t) LIMIT 5;
+ id |  t   
+----+------
+  1 | bar1
+  1 | foo1
+  2 | bar2
+  2 | foo2
+  3 | bar3
+(5 rows)
+
+SELECT * FROM lz4test_1 ORDER BY (id, t) DESC LIMIT 5;
+  id   |    t     
+-------+----------
+ 10000 | foo10000
+ 10000 | bar10000
+  9999 | foo9999
+  9999 | bar9999
+  9998 | foo9998
+(5 rows)
+
+INSERT INTO lz4test_9 SELECT g, 'foo' || g FROM generate_series(1, 10000) g;
+INSERT INTO lz4test_9 SELECT g, 'bar' || g FROM generate_series(1, 10000) g;
+SELECT * FROM lz4test_9 ORDER BY (id, t) LIMIT 5;
+ id |  t   
+----+------
+  1 | bar1
+  1 | foo1
+  2 | bar2
+  2 | foo2
+  3 | bar3
+(5 rows)
+
+SELECT * FROM lz4test_9 ORDER BY (id, t) DESC LIMIT 5;
+  id   |    t     
+-------+----------
+ 10000 | foo10000
+ 10000 | bar10000
+  9999 | foo9999
+  9999 | bar9999
+  9998 | foo9998
+(5 rows)
+
+-- Test the bounds of compresslevel. None of these are allowed.
+CREATE TABLE lz4test_invalid (id int4) WITH (appendonly=true, compresstype=lz4, compresslevel=-1);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+ERROR:  value -1 out of bounds for option "compresslevel"
+DETAIL:  Valid values are between "0" and "19".
+CREATE TABLE lz4test_invalid (id int4) WITH (appendonly=true, compresstype=lz4, compresslevel=0);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+ERROR:  compresstype "lz4" can't be used with compresslevel 0
+CREATE TABLE lz4test_invalid (id int4) WITH (appendonly=true, compresstype=lz4, compresslevel=13);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+ERROR:  compresslevel=13 is out of range for lz4 (should be in the range 1 to 12)
+-- CREATE TABLE for heap table with compresstype=lz4 should fail
+CREATE TABLE lz4test_heap (id int4, t text) WITH (compresstype=lz4);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+ERROR:  unrecognized parameter "compresstype"

--- a/gpcontrib/lz4/expected/lz4_column_compression.out
+++ b/gpcontrib/lz4/expected/lz4_column_compression.out
@@ -1,0 +1,107 @@
+DROP DATABASE IF EXISTS lz4_column_compression;
+NOTICE:  database "lz4_column_compression" does not exist, skipping
+CREATE DATABASE lz4_column_compression;
+\c lz4_column_compression
+PREPARE attribute_encoding_check AS
+SELECT attrelid::regclass AS relname,
+attnum, attoptions FROM pg_class c, pg_attribute_encoding e
+WHERE c.relname = $1 AND c.oid=e.attrelid
+ORDER BY relname, attnum;
+drop type if exists int42 cascade;
+NOTICE:  type "int42" does not exist, skipping
+create type int42;
+CREATE FUNCTION int42_in(cstring)
+RETURNS int42
+AS 'int4in'
+LANGUAGE internal IMMUTABLE STRICT;
+NOTICE:  return type int42 is only a shell
+CREATE FUNCTION int42_out(int42)
+RETURNS cstring
+AS 'int4out'
+LANGUAGE internal IMMUTABLE STRICT;
+NOTICE:  argument type int42 is only a shell
+CREATE TYPE int42 (
+internallength = 4,
+input = int42_in,
+output = int42_out,
+alignment = int4,
+default = 42,
+passedbyvalue,
+compresstype="zlib",
+blocksize=65536,
+compresslevel=1
+);
+-- Ensure type has been created with compresstype zlib
+select typoptions from pg_type_encoding where typid='public.int42'::regtype;
+                     typoptions                      
+-----------------------------------------------------
+ {compresstype=zlib,blocksize=65536,compresslevel=1}
+(1 row)
+
+alter type int42 set default encoding (compresstype=lz4);
+-- Ensure compresstype for type has been modified to be lz4
+select typoptions from pg_type_encoding where typid='public.int42'::regtype;
+                     typoptions                     
+----------------------------------------------------
+ {compresstype=lz4,compresslevel=1,blocksize=32768}
+(1 row)
+
+-- Given an AO/CO table using the int42 type with lz4 compresstype
+CREATE TABLE IF NOT EXISTS aoco_table_compressed_type (i int42) with(appendonly = true, orientation=column);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+-- Attribute should show as compressed
+EXECUTE attribute_encoding_check ('aoco_table_compressed_type');
+          relname           | attnum |                     attoptions                     
+----------------------------+--------+----------------------------------------------------
+ aoco_table_compressed_type |      1 | {compresstype=lz4,compresslevel=1,blocksize=32768}
+(1 row)
+
+-- When I insert data
+insert into aoco_table_compressed_type select '123456'::int42 from generate_series(1, 1000)i;
+-- Then the data should be compressed and return a consistent compression ratio
+-- Because the ratio varies depending on the version, use > here instead of checking the exact ratio.
+select get_ao_compression_ratio('aoco_table_compressed_type') > 21 as lz4_compress_ratio;
+ lz4_compress_ratio 
+--------------------
+ t
+(1 row)
+
+-- Given an AO/RO table using the int42 type with lz4 compresstype
+CREATE TABLE IF NOT EXISTS aoro_table_compressed_type (i int42) WITH (appendonly=true, orientation=row);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+-- No results are returned from the attribute encoding check, as compression with lz4 is not supported for row-oriented tables
+EXECUTE attribute_encoding_check ('aoro_table_compressed_type');
+ relname | attnum | attoptions 
+---------+--------+------------
+(0 rows)
+
+-- Given a heap table using the int42 type with lz4 compresstype
+CREATE TABLE IF NOT EXISTS heap_table_compressed_type (i int42);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+-- No results are returned from the attribute encoding check, as compression with lz4 is not supported for heap tables
+EXECUTE attribute_encoding_check ('heap_table_compressed_type');
+ relname | attnum | attoptions 
+---------+--------+------------
+(0 rows)
+
+-- Given an AO/CO table with a regular int column and a default column encoding of compresstype lz4
+CREATE TABLE IF NOT EXISTS aoco_table_default_encoding (i int, default column encoding (compresstype=lz4, compresslevel=1)) with(appendonly = true, orientation=column);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- Attribute should show as compressed
+EXECUTE attribute_encoding_check ('aoco_table_default_encoding');
+           relname           | attnum |                     attoptions                     
+-----------------------------+--------+----------------------------------------------------
+ aoco_table_default_encoding |      1 | {compresstype=lz4,compresslevel=1,blocksize=32768}
+(1 row)
+
+-- When I insert data
+INSERT into aoco_table_default_encoding select 1 from generate_series(1, 100);
+-- Then the data should be compressed and return a consistent compression ratio
+-- Because the ratio varies depending on the version, use > here instead of checking the exact ratio.
+SELECT get_ao_compression_ratio('aoco_table_default_encoding') > 7 as lz4_compress_ratio;
+ lz4_compress_ratio 
+--------------------
+ t
+(1 row)
+

--- a/gpcontrib/lz4/lz4_compression.c
+++ b/gpcontrib/lz4/lz4_compression.c
@@ -1,0 +1,154 @@
+/*---------------------------------------------------------------------
+ *
+ * lz4_compression.c
+ *
+ * IDENTIFICATION
+ *	    gpcontrib/lz4/lz4_compression.c
+ *
+ *---------------------------------------------------------------------
+ */
+
+#include "postgres.h"
+
+#include "access/genam.h"
+#include "catalog/pg_compression.h"
+#include "fmgr.h"
+#include "storage/gp_compress.h"
+#include "utils/builtins.h"
+
+#include <lz4.h>
+#include <lz4hc.h>
+
+Datum		lz4_constructor(PG_FUNCTION_ARGS);
+Datum		lz4_destructor(PG_FUNCTION_ARGS);
+Datum		lz4_compress(PG_FUNCTION_ARGS);
+Datum		lz4_decompress(PG_FUNCTION_ARGS);
+Datum		lz4_validator(PG_FUNCTION_ARGS);
+
+PG_FUNCTION_INFO_V1(lz4_constructor);
+PG_FUNCTION_INFO_V1(lz4_destructor);
+PG_FUNCTION_INFO_V1(lz4_compress);
+PG_FUNCTION_INFO_V1(lz4_decompress);
+PG_FUNCTION_INFO_V1(lz4_validator);
+
+#ifndef UNIT_TESTING
+PG_MODULE_MAGIC;
+#endif
+
+/* Internal state for lz4 */
+typedef struct lz4_state
+{
+	int			level;			/* Compression level */
+	bool		compress;		/* Compress if true, decompress otherwise */
+} lz4_state;
+
+Datum
+lz4_constructor(PG_FUNCTION_ARGS)
+{
+	/* PG_GETARG_POINTER(0) is TupleDesc that is currently unused. */
+	StorageAttributes	   *sa = (StorageAttributes *) PG_GETARG_POINTER(1);
+	CompressionState	   *cs = palloc0(sizeof(CompressionState));
+	lz4_state			   *state = palloc0(sizeof(lz4_state));
+	bool					compress = PG_GETARG_BOOL(2);
+
+	if (!PointerIsValid(sa->comptype))
+		elog(ERROR, "lz4_constructor called with no compression type");
+
+	cs->opaque = (void *) state;
+	cs->desired_sz = NULL;
+
+	if (sa->complevel == 0)
+		sa->complevel = 1;
+
+	state->level = sa->complevel;
+	state->compress = compress;
+
+	PG_RETURN_POINTER(cs);
+}
+
+Datum
+lz4_destructor(PG_FUNCTION_ARGS)
+{
+	CompressionState	   *cs = (CompressionState *) PG_GETARG_POINTER(0);
+
+	if (cs != NULL && cs->opaque != NULL)
+	{
+		lz4_state *state = (lz4_state *) cs->opaque;
+		pfree(state);
+	}
+
+	PG_RETURN_VOID();
+}
+
+/*
+ * lz4 compression implementation
+ *
+ * Note that when compression fails due to algorithm inefficiency,
+ * dst_used is set to src_sz, but the output buffer contents are left undefined,
+ * upper layer callers should `memcpy` the uncompressed data to the output
+ * buffer.
+ */
+Datum
+lz4_compress(PG_FUNCTION_ARGS)
+{
+	const void		   *src = PG_GETARG_POINTER(0);
+	int32				src_sz = PG_GETARG_INT32(1);
+	void			   *dst = PG_GETARG_POINTER(2);
+	int32				dst_sz = PG_GETARG_INT32(3);
+	int32			   *dst_used = (int32 *) PG_GETARG_POINTER(4);
+	CompressionState   *cs = (CompressionState *) PG_GETARG_POINTER(5);
+	lz4_state		   *state = (lz4_state *) cs->opaque;
+
+	int dst_length_used;
+
+	/* lz4hc treats level 0/1/2 the same
+	 * see https://github.com/lz4/lz4/blob/v1.9.4/lib/lz4hc.c#L817
+	 * we steal level 1 from High Compression mode as the fast mode
+	 */
+	if (state->level == 1)
+	{
+		dst_length_used = LZ4_compress_fast(src, dst, src_sz, dst_sz, state->level);
+	}
+	else
+	{
+		dst_length_used = LZ4_compress_HC(src, dst, src_sz, dst_sz, state->level);
+	}
+
+	if (dst_length_used == 0)
+		*dst_used = src_sz;
+	else
+		*dst_used = dst_length_used;
+
+	PG_RETURN_VOID();
+}
+
+Datum
+lz4_decompress(PG_FUNCTION_ARGS)
+{
+	const void		   *src = PG_GETARG_POINTER(0);
+	int32				src_sz = PG_GETARG_INT32(1);
+	void			   *dst = PG_GETARG_POINTER(2);
+	int32				dst_sz = PG_GETARG_INT32(3);
+	int32			   *dst_used = (int32 *) PG_GETARG_POINTER(4);
+
+	int result;
+
+	if (src_sz <= 0)
+		elog(ERROR, "invalid source buffer size %d", src_sz);
+	if (dst_sz <= 0)
+		elog(ERROR, "invalid destination buffer size %d", dst_sz);
+
+	result = LZ4_decompress_safe(src, dst, src_sz, dst_sz);
+	if (result < 0)
+		elog(ERROR, "decompress failed with error code: %d", result);
+
+	*dst_used = result;
+
+	PG_RETURN_VOID();
+}
+
+Datum
+lz4_validator(PG_FUNCTION_ARGS)
+{
+	PG_RETURN_VOID();
+}

--- a/gpcontrib/lz4/lz4_compression.sql
+++ b/gpcontrib/lz4/lz4_compression.sql
@@ -1,0 +1,22 @@
+CREATE FUNCTION gp_lz4_constructor(internal, internal, bool) RETURNS internal
+LANGUAGE C VOLATILE AS '$libdir/gp_lz4_compression.so', 'lz4_constructor';
+COMMENT ON FUNCTION gp_lz4_constructor(internal, internal, bool) IS 'lz4 compressor and decompressor constructor';
+
+CREATE FUNCTION gp_lz4_destructor(internal) RETURNS void
+LANGUAGE C VOLATILE AS '$libdir/gp_lz4_compression.so', 'lz4_destructor';
+COMMENT ON FUNCTION gp_lz4_destructor(internal) IS 'lz4 compressor and decompressor destructor';
+
+CREATE FUNCTION gp_lz4_compress(internal, int4, internal, int4, internal, internal) RETURNS void
+LANGUAGE C VOLATILE AS '$libdir/gp_lz4_compression.so', 'lz4_compress';
+COMMENT ON FUNCTION gp_lz4_compress(internal, int4, internal, int4, internal, internal) IS 'lz4 compressor';
+
+CREATE FUNCTION gp_lz4_decompress(internal, int4, internal, int4, internal, internal) RETURNS void
+LANGUAGE C VOLATILE AS '$libdir/gp_lz4_compression.so', 'lz4_decompress';
+COMMENT ON FUNCTION gp_lz4_decompress(internal, int4, internal, int4, internal, internal) IS 'lz4 decompressor';
+
+CREATE FUNCTION gp_lz4_validator(internal) RETURNS void
+LANGUAGE C VOLATILE AS '$libdir/gp_lz4_compression.so', 'lz4_validator';
+COMMENT ON FUNCTION gp_lz4_validator(internal) IS 'lz4 compression validator';
+
+INSERT INTO pg_catalog.pg_compression (compname, compconstructor, compdestructor, compcompressor, compdecompressor, compvalidator, compowner)
+VALUES ('lz4', 'gp_lz4_constructor', 'gp_lz4_destructor', 'gp_lz4_compress', 'gp_lz4_decompress', 'gp_lz4_validator', 10 /* BOOTSTRAP_SUPERUSERID */);

--- a/gpcontrib/lz4/sql/AOCO_lz4.sql
+++ b/gpcontrib/lz4/sql/AOCO_lz4.sql
@@ -1,0 +1,14 @@
+-- Given that we built with and have lz4 compression available
+-- Test basic create table for AO/CO table succeeds for lz4 compression
+
+-- Given a column-oriented table with compresstype lz4
+DROP TABLE IF EXISTS a_aoco_table_with_lz4_compression;
+CREATE TABLE a_aoco_table_with_lz4_compression(col text) WITH (APPENDONLY=true, COMPRESSTYPE=lz4, compresslevel=1, ORIENTATION=column);
+-- Before I insert data, the size is 0 and compression ratio is unavailable (-1)
+SELECT pg_size_pretty(pg_relation_size('a_aoco_table_with_lz4_compression')),
+       get_ao_compression_ratio('a_aoco_table_with_lz4_compression');
+-- After I insert data
+INSERT INTO a_aoco_table_with_lz4_compression values('ksjdhfksdhfksdhfksjhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhh');
+-- Then the data will be compressed according to a consistent compression ratio
+select pg_size_pretty(pg_relation_size('a_aoco_table_with_lz4_compression')),
+       get_ao_compression_ratio('a_aoco_table_with_lz4_compression');

--- a/gpcontrib/lz4/sql/AORO_lz4.sql
+++ b/gpcontrib/lz4/sql/AORO_lz4.sql
@@ -1,0 +1,13 @@
+-- Given that we built with and have lz4 compression available
+-- Test basic create table for AO/RO table succeeds for lz4 compression
+
+-- Given a row-oriented table with compresstype lz4
+create table a_aoro_table_with_lz4_compression(col text) WITH (APPENDONLY=true, ORIENTATION=row, COMPRESSTYPE=lz4, compresslevel=1);
+-- Before inserting data, the size is 0 and ratio is 1 (for a row-oriented table, ends up being 1)
+select pg_size_pretty(pg_relation_size('a_aoro_table_with_lz4_compression')),
+       get_ao_compression_ratio('a_aoro_table_with_lz4_compression');
+-- After I insert data
+insert into a_aoro_table_with_lz4_compression values('ksjdhfksdhfksdhfksjhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhh');
+-- Then the data will be compressed according to a consistent compression ratio
+select pg_size_pretty(pg_relation_size('a_aoro_table_with_lz4_compression')),
+       get_ao_compression_ratio('a_aoro_table_with_lz4_compression');

--- a/gpcontrib/lz4/sql/compression_lz4.sql
+++ b/gpcontrib/lz4/sql/compression_lz4.sql
@@ -1,0 +1,44 @@
+-- Tests for lz4 compression.
+
+-- Check that callbacks are registered
+SELECT * FROM pg_compression WHERE compname = 'lz4';
+
+CREATE TABLE lz4test (id int4, t text) WITH (appendonly=true, compresstype=lz4, orientation=column);
+
+-- Check that the reloptions on the table shows compression type
+SELECT reloptions FROM pg_class WHERE relname = 'lz4test';
+
+INSERT INTO lz4test SELECT g, 'foo' || g FROM generate_series(1, 100000) g;
+INSERT INTO lz4test SELECT g, 'bar' || g FROM generate_series(1, 100000) g;
+
+-- Check that we actually compressed data. With liblz4-1.9.4, the ratio is 1.59.
+SELECT get_ao_compression_ratio('lz4test') IN (1.59);
+
+-- Check contents, at the beginning of the table and at the end.
+SELECT * FROM lz4test ORDER BY (id, t) LIMIT 5;
+SELECT * FROM lz4test ORDER BY (id, t) DESC LIMIT 5;
+
+
+-- Test different compression levels:
+CREATE TABLE lz4test_1 (id int4, t text) WITH (appendonly=true, compresstype=lz4, compresslevel=1);
+CREATE TABLE lz4test_9 (id int4, t text) WITH (appendonly=true, compresstype=lz4, compresslevel=9);
+CREATE TABLE lz4test_12 (id int4, t text) WITH (appendonly=true, compresstype=lz4, compresslevel=12);
+
+INSERT INTO lz4test_1 SELECT g, 'foo' || g FROM generate_series(1, 10000) g;
+INSERT INTO lz4test_1 SELECT g, 'bar' || g FROM generate_series(1, 10000) g;
+SELECT * FROM lz4test_1 ORDER BY (id, t) LIMIT 5;
+SELECT * FROM lz4test_1 ORDER BY (id, t) DESC LIMIT 5;
+
+INSERT INTO lz4test_9 SELECT g, 'foo' || g FROM generate_series(1, 10000) g;
+INSERT INTO lz4test_9 SELECT g, 'bar' || g FROM generate_series(1, 10000) g;
+SELECT * FROM lz4test_9 ORDER BY (id, t) LIMIT 5;
+SELECT * FROM lz4test_9 ORDER BY (id, t) DESC LIMIT 5;
+
+
+-- Test the bounds of compresslevel. None of these are allowed.
+CREATE TABLE lz4test_invalid (id int4) WITH (appendonly=true, compresstype=lz4, compresslevel=-1);
+CREATE TABLE lz4test_invalid (id int4) WITH (appendonly=true, compresstype=lz4, compresslevel=0);
+CREATE TABLE lz4test_invalid (id int4) WITH (appendonly=true, compresstype=lz4, compresslevel=13);
+
+-- CREATE TABLE for heap table with compresstype=lz4 should fail
+CREATE TABLE lz4test_heap (id int4, t text) WITH (compresstype=lz4);

--- a/gpcontrib/lz4/sql/lz4_column_compression.sql
+++ b/gpcontrib/lz4/sql/lz4_column_compression.sql
@@ -1,0 +1,70 @@
+DROP DATABASE IF EXISTS lz4_column_compression;
+CREATE DATABASE lz4_column_compression;
+\c lz4_column_compression
+
+PREPARE attribute_encoding_check AS
+SELECT attrelid::regclass AS relname,
+attnum, attoptions FROM pg_class c, pg_attribute_encoding e
+WHERE c.relname = $1 AND c.oid=e.attrelid
+ORDER BY relname, attnum;
+
+drop type if exists int42 cascade;
+create type int42;
+CREATE FUNCTION int42_in(cstring)
+RETURNS int42
+AS 'int4in'
+LANGUAGE internal IMMUTABLE STRICT;
+
+CREATE FUNCTION int42_out(int42)
+RETURNS cstring
+AS 'int4out'
+LANGUAGE internal IMMUTABLE STRICT;
+
+CREATE TYPE int42 (
+internallength = 4,
+input = int42_in,
+output = int42_out,
+alignment = int4,
+default = 42,
+passedbyvalue,
+compresstype="zlib",
+blocksize=65536,
+compresslevel=1
+);
+
+-- Ensure type has been created with compresstype zlib
+select typoptions from pg_type_encoding where typid='public.int42'::regtype;
+
+alter type int42 set default encoding (compresstype=lz4);
+-- Ensure compresstype for type has been modified to be lz4
+select typoptions from pg_type_encoding where typid='public.int42'::regtype;
+
+-- Given an AO/CO table using the int42 type with lz4 compresstype
+CREATE TABLE IF NOT EXISTS aoco_table_compressed_type (i int42) with(appendonly = true, orientation=column);
+-- Attribute should show as compressed
+EXECUTE attribute_encoding_check ('aoco_table_compressed_type');
+-- When I insert data
+insert into aoco_table_compressed_type select '123456'::int42 from generate_series(1, 1000)i;
+-- Then the data should be compressed and return a consistent compression ratio
+-- Because the ratio varies depending on the version, use > here instead of checking the exact ratio.
+select get_ao_compression_ratio('aoco_table_compressed_type') > 21 as lz4_compress_ratio;
+
+-- Given an AO/RO table using the int42 type with lz4 compresstype
+CREATE TABLE IF NOT EXISTS aoro_table_compressed_type (i int42) WITH (appendonly=true, orientation=row);
+-- No results are returned from the attribute encoding check, as compression with lz4 is not supported for row-oriented tables
+EXECUTE attribute_encoding_check ('aoro_table_compressed_type');
+
+-- Given a heap table using the int42 type with lz4 compresstype
+CREATE TABLE IF NOT EXISTS heap_table_compressed_type (i int42);
+-- No results are returned from the attribute encoding check, as compression with lz4 is not supported for heap tables
+EXECUTE attribute_encoding_check ('heap_table_compressed_type');
+
+-- Given an AO/CO table with a regular int column and a default column encoding of compresstype lz4
+CREATE TABLE IF NOT EXISTS aoco_table_default_encoding (i int, default column encoding (compresstype=lz4, compresslevel=1)) with(appendonly = true, orientation=column);
+-- Attribute should show as compressed
+EXECUTE attribute_encoding_check ('aoco_table_default_encoding');
+-- When I insert data
+INSERT into aoco_table_default_encoding select 1 from generate_series(1, 100);
+-- Then the data should be compressed and return a consistent compression ratio
+-- Because the ratio varies depending on the version, use > here instead of checking the exact ratio.
+SELECT get_ao_compression_ratio('aoco_table_default_encoding') > 7 as lz4_compress_ratio;

--- a/src/Makefile.global.in
+++ b/src/Makefile.global.in
@@ -267,6 +267,7 @@ with_zstd 		= @with_zstd@
 ZSTD_CFLAGS		= @ZSTD_CFLAGS@
 ZSTD_LIBS		= @ZSTD_LIBS@
 with_quicklz		= @with_quicklz@
+with_lz4		= @with_lz4@
 EVENT_LIBS		= @EVENT_LIBS@
 
 ##########################################################################

--- a/src/backend/catalog/pg_compression.c
+++ b/src/backend/catalog/pg_compression.c
@@ -517,6 +517,9 @@ compresstype_is_valid(char *comptype)
 #ifdef USE_ZSTD
 			"zstd",
 #endif
+#ifdef USE_LZ4
+			"lz4",
+#endif
 			"rle_type", "none"};
 
 	for (int i = 0; i < ARRAY_SIZE(valid_comptypes); ++i)

--- a/src/include/pg_config.h.in
+++ b/src/include/pg_config.h.in
@@ -1062,6 +1062,9 @@
 /* Define to build with zstd support. (--with-zstd) */
 #undef USE_ZSTD
 
+/* Define to build with lz4 support. (--with-lz4) */
+#undef USE_LZ4
+
 /* Define to 1 if `wcstombs_l' requires <xlocale.h>. */
 #undef WCSTOMBS_L_IN_XLOCALE
 

--- a/src/include/pg_config.h.win32
+++ b/src/include/pg_config.h.win32
@@ -811,6 +811,9 @@
 /* Define to build with zstd support. (--with-zstd) */
 #undef USE_ZSTD
 
+/* Define to build with lz4 support. (--with-lz4) */
+#undef USE_LZ4
+
 /* Define to 1 if `wcstombs_l' requires <xlocale.h>. */
 /* #undef WCSTOMBS_L_IN_XLOCALE */
 


### PR DESCRIPTION
implementation of lz4 compression, when compresslevel = 1, lz4_compress performs fast mode compression with acceleration = 1, otherwise performs high compression mode with given compress level.

Signed-off-by: Junwang Zhao <zhjwpku@gmail.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
