### PR TITLE
Removed unnecessary variable assignment

### DIFF
--- a/src/backend/access/aocs/aocs_compaction.c
+++ b/src/backend/access/aocs/aocs_compaction.c
@@ -107,7 +107,6 @@ AOCSSegmentFileTruncateToEOF(Relation aorel,
 	Assert(RelationIsAoCols(aorel));
 
 	segno = fsinfo->segno;
-	relname = RelationGetRelationName(aorel);
 
 	for (j = 0; j < fsinfo->vpinfo.nEntry; ++j)
 	{


### PR DESCRIPTION
The same value is assigned to the variable at the moment of declaration (some lines before) 