### PR TITLE
Resolve FIXME in typecmds.c

### DIFF
--- a/src/backend/commands/typecmds.c
+++ b/src/backend/commands/typecmds.c
@@ -2193,7 +2193,6 @@ findRangeSubtypeDiffFunction(List *procname, Oid subtype)
 Oid
 AssignTypeArrayOid(char *arrayTypeName, Oid typeNamespace)
 {
-	/* GPDB_12_MERGE_FIXME: do we need some special code for IsBinaryUpgrade here? */
 	Oid			type_array_oid;
 	Relation	pg_type;
 


### PR DESCRIPTION
Whenever a new OID is needed for an object in PostgreSQL, the GetNewOidWithIndex() is used. In GPDB, all the upstream calls to GetNewOidWithIndex() function have been replaced with calls to the GetNewOidFor* functions.  

All the GetNewOidFor*() functions are actually just wrappers for the GetNewOrPreassignedOid() function, and only differ in the key arguments for each object type. GetNewOrPreassignedOid() does the heavy lifting. 

In GPDB Binary Upgrade, pg_upgrade records the OIDs from the old cluster and inserts them into a preassigned_oids list to restore them, which is then used to assign specific OIDs.

The AssignTypeArrayOid call is a wrapper for GetNewOidForType, which handles the OID preassignment, so no special code is needed.

See the comment at the top of src/backend/catalog/oid_dispatch.c for more context.
