### PR TITLE
Fix dependency bug with minirepro and materialized views

### DIFF
--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -1988,7 +1988,7 @@ BeginCopy(ParseState *pstate,
 		 */
 		rewritten = pg_analyze_and_rewrite(copyObject(raw_query),
 										   pstate->p_sourcetext, NULL, 0,
-										   NULL);
+										   NULL, false);
 
 		/* check that we got back something we can work with */
 		if (rewritten == NIL)

--- a/src/backend/commands/extension.c
+++ b/src/backend/commands/extension.c
@@ -733,7 +733,8 @@ execute_sql_string(const char *sql)
 										   sql,
 										   NULL,
 										   0,
-										   NULL);
+										   NULL,
+										   false);
 		stmt_list = pg_plan_queries(stmt_list, CURSOR_OPT_PARALLEL_OK, NULL);
 
 		foreach(lc2, stmt_list)

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -16063,7 +16063,7 @@ build_ctas_with_dist(Relation rel, DistributedBy *dist_clause,
 		rawstmt->stmt_location = -1;
 		rawstmt->stmt_len = 0;
 
-		q_list = pg_analyze_and_rewrite(rawstmt, synthetic_sql, NULL, 0, NULL);
+		q_list = pg_analyze_and_rewrite(rawstmt, synthetic_sql, NULL, 0, NULL, false);
 		p_list = pg_plan_queries(q_list, 0, NULL);
 		pstmt = linitial_node(PlannedStmt, p_list);
 		ctas = castNode(CreateTableAsStmt, pstmt->utilityStmt);

--- a/src/backend/executor/spi.c
+++ b/src/backend/executor/spi.c
@@ -2066,7 +2066,8 @@ _SPI_prepare_plan(const char *src, SPIPlanPtr plan)
 											   src,
 											   plan->argtypes,
 											   plan->nargs,
-											   _SPI_current->queryEnv);
+											   _SPI_current->queryEnv,
+											   false);
 		}
 
 		/* Check that all the queries are safe to execute on QE. */
@@ -2280,7 +2281,8 @@ _SPI_execute_plan(SPIPlanPtr plan, ParamListInfo paramLI,
 												   src,
 												   plan->argtypes,
 												   plan->nargs,
-												   _SPI_current->queryEnv);
+												   _SPI_current->queryEnv,
+												   false);
 			}
 
 			/* Check that all the queries are safe to execute on QE. */

--- a/src/backend/rewrite/rewriteHandler.c
+++ b/src/backend/rewrite/rewriteHandler.c
@@ -2011,7 +2011,7 @@ fireRIRrules(Query *parsetree, List *activeRIRs)
 		 * In that case this test would need to be postponed till after we've
 		 * opened the rel, so that we could check its state.
 		 */
-		if (rte->relkind == RELKIND_MATVIEW)
+		if (rte->relkind == RELKIND_MATVIEW && !parsetree->expandMatViews)
 			continue;
 
 		/*

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -818,7 +818,7 @@ pg_parse_query(const char *query_string)
 List *
 pg_analyze_and_rewrite(RawStmt *parsetree, const char *query_string,
 					   Oid *paramTypes, int numParams,
-					   QueryEnvironment *queryEnv)
+					   QueryEnvironment *queryEnv, bool expandMatViews)
 {
 	Query	   *query;
 	List	   *querytree_list;
@@ -833,6 +833,7 @@ pg_analyze_and_rewrite(RawStmt *parsetree, const char *query_string,
 
 	query = parse_analyze(parsetree, query_string, paramTypes, numParams,
 						  queryEnv);
+	query->expandMatViews = expandMatViews;
 
 	if (log_parser_stats)
 		ShowUsage("PARSE ANALYSIS STATISTICS");
@@ -1844,7 +1845,7 @@ exec_simple_query(const char *query_string)
 		oldcontext = MemoryContextSwitchTo(MessageContext);
 
 		querytree_list = pg_analyze_and_rewrite(parsetree, query_string,
-												NULL, 0, NULL);
+												NULL, 0, NULL, false);
 
 		plantree_list = pg_plan_queries(querytree_list,
 										CURSOR_OPT_PARALLEL_OK, NULL);

--- a/src/backend/utils/adt/gp_dump_oids.c
+++ b/src/backend/utils/adt/gp_dump_oids.c
@@ -123,7 +123,8 @@ gp_dump_query_oids(PG_FUNCTION_ARGS)
 												   sqlText,
 												   NULL,
 												   0,
-												   NULL);
+												   NULL,
+												   true);
 		flat_query_list = list_concat(flat_query_list,
 									  list_copy(queryTree_sublist));
 	}

--- a/src/backend/utils/cache/plancache.c
+++ b/src/backend/utils/cache/plancache.c
@@ -703,7 +703,7 @@ RevalidateCachedQuery(CachedPlanSource *plansource,
 									   plansource->query_string,
 									   plansource->param_types,
 									   plansource->num_params,
-									   queryEnv);
+									   queryEnv, false);
 
 	/* GPDB: For CTAS query, set its isCTAS to be true */
 	if (intoClause)

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -226,6 +226,8 @@ typedef struct Query
 	 */
 	int			stmt_location;	/* start location, or -1 if unknown */
 	int			stmt_len;		/* length in bytes; 0 means "rest of string" */
+
+	bool		expandMatViews; /* force expansion of materialized views during rewrite to treat as views */
 } Query;
 
 /****************************************************************************
@@ -2346,6 +2348,7 @@ typedef struct CreateStmt
 	/* names chosen for partition indexes */
 	List	   *part_idx_oids;
 	List	   *part_idx_names;
+
 } CreateStmt;
 
 /* ----------------------

--- a/src/include/tcop/tcopprot.h
+++ b/src/include/tcop/tcopprot.h
@@ -47,7 +47,8 @@ extern List *pg_parse_query(const char *query_string);
 extern List *pg_analyze_and_rewrite(RawStmt *parsetree,
 									const char *query_string,
 									Oid *paramTypes, int numParams,
-									QueryEnvironment *queryEnv);
+									QueryEnvironment *queryEnv,
+									bool expandMatViews);
 extern List *pg_analyze_and_rewrite_params(RawStmt *parsetree,
 										   const char *query_string,
 										   ParserSetupHook parserSetup,

--- a/src/test/modules/test_planner/src/planner_test_helpers.c
+++ b/src/test/modules/test_planner/src/planner_test_helpers.c
@@ -14,7 +14,7 @@ get_parsetree_for(const char *query_string)
 static Query *
 get_query_for_parsetree(Node *parsetree, const char *query_string)
 {
-	List *querytree_list = pg_analyze_and_rewrite(parsetree, query_string, NULL, 0, NULL);
+	List *querytree_list = pg_analyze_and_rewrite(parsetree, query_string, NULL, 0, NULL, false);
 	ListCell *querytree = list_head(querytree_list);
 	return (Query *)lfirst(querytree);
 }

--- a/src/test/regress/expected/gp_dump_query_oids.out
+++ b/src/test/regress/expected/gp_dump_query_oids.out
@@ -1,17 +1,28 @@
 -- gp_dump_query_oids() doesn't list built-in functions, so we need a UDF to test with.
 CREATE FUNCTION dumptestfunc(t text) RETURNS integer AS $$ SELECT 123 $$ LANGUAGE SQL;
 CREATE FUNCTION dumptestfunc2(t text) RETURNS integer AS $$ SELECT 123 $$ LANGUAGE SQL;
+create table base(a int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create materialized view base_mv as select a from base;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 -- The function returns OIDs. We need to replace them with something reproducable.
 CREATE FUNCTION sanitize_output(t text) RETURNS text AS $$
 declare
   dumptestfunc_oid oid;
   dumptestfunc2_oid oid;
+  base_oid oid;
+  base_mv_oid oid;
 begin
     dumptestfunc_oid = 'dumptestfunc'::regproc::oid;
     dumptestfunc2_oid = 'dumptestfunc2'::regproc::oid;
+    base_oid = 'base'::regclass::oid;
+    base_mv_oid = 'base_mv'::regclass::oid;
 
     t := replace(t, dumptestfunc_oid::text, '<dumptestfunc>');
     t := replace(t, dumptestfunc2_oid::text, '<dumptestfunc2>');
+    t := replace(t, base_oid::text, '<base_table>');
+    t := replace(t, base_mv_oid::text, '<base_mv>');
 
     RETURN t;
 end;
@@ -125,6 +136,12 @@ SELECT array['pg_class'::regclass::oid::text] <@  (string_to_array((SELECT info-
  ?column? 
 ----------
  t
+(1 row)
+
+SELECT sanitize_output(gp_dump_query_oids('SELECT * FROM base_mv'));
+                   sanitize_output                   
+-----------------------------------------------------
+ {"relids": "<base_mv>,<base_table>", "funcids": ""}
 (1 row)
 
 DROP TABLE foo;


### PR DESCRIPTION
Previously, when using minirepro on a query that accessed materialized views, the objects that the materialized view used/accessed were not dumped with the minirepro. This is because queries treat materialized views as tables, not views. However, when enumerating the dependent objects for dumping the relevant DDL, we need to treat materialized views as regular views in order to get their dependent objects and create a valid dump.

This commit adds a flag when dumping from gp_dump_query_oids so that materialized views are treated as views and the logic goes through pg_rewrite to retrieve necessary dependencies.