### PR TITLE
Fix errors when trying to DELETE FROM AO/CO auxiliary tables

### DIFF
--- a/src/backend/executor/nodeModifyTable.c
+++ b/src/backend/executor/nodeModifyTable.c
@@ -59,6 +59,7 @@
 #include "utils/rel.h"
 
 #include "access/transam.h"
+#include "catalog/aocatalog.h"
 #include "cdb/cdbaocsam.h"
 #include "cdb/cdbappendonlyam.h"
 #include "cdb/cdbvars.h"
@@ -2422,7 +2423,8 @@ ExecModifyTable(PlanState *pstate)
 
 				relkind = resultRelInfo->ri_RelationDesc->rd_rel->relkind;
 				if (relkind == RELKIND_RELATION || relkind == RELKIND_MATVIEW ||
-					relkind == RELKIND_PARTITIONED_TABLE)
+					relkind == RELKIND_PARTITIONED_TABLE ||
+					IsAppendonlyMetadataRelkind(relkind))
 				{
 					datum = ExecGetJunkAttribute(slot,
 												 junkfilter->jf_junkAttNo,
@@ -3085,7 +3087,8 @@ ExecInitModifyTable(ModifyTable *node, EState *estate, int eflags)
 					relkind = resultRelInfo->ri_RelationDesc->rd_rel->relkind;
 					if (relkind == RELKIND_RELATION ||
 						relkind == RELKIND_MATVIEW ||
-						relkind == RELKIND_PARTITIONED_TABLE)
+						relkind == RELKIND_PARTITIONED_TABLE ||
+						IsAppendonlyMetadataRelkind(relkind))
 					{
 						j->jf_junkAttNo = ExecFindJunkAttribute(j, "ctid");
 						if (!AttributeNumberIsValid(j->jf_junkAttNo))

--- a/src/backend/rewrite/rewriteHandler.c
+++ b/src/backend/rewrite/rewriteHandler.c
@@ -43,6 +43,8 @@
 #include "utils/lsyscache.h"
 #include "utils/rel.h"
 
+#include "catalog/aocatalog.h"
+
 
 /* We use a list of these to detect recursion in RewriteQuery */
 typedef struct rewrite_event
@@ -1504,7 +1506,8 @@ rewriteTargetListUD(Query *parsetree, RangeTblEntry *target_rte,
 
 	if (target_relation->rd_rel->relkind == RELKIND_RELATION ||
 		target_relation->rd_rel->relkind == RELKIND_MATVIEW ||
-		target_relation->rd_rel->relkind == RELKIND_PARTITIONED_TABLE)
+		target_relation->rd_rel->relkind == RELKIND_PARTITIONED_TABLE ||
+		IsAppendonlyMetadataRelkind(target_relation->rd_rel->relkind))
 	{
 		/*
 		 * Emit CTID so that executor can find the row to update or delete.

--- a/src/test/regress/expected/uao_catalog_tables.out
+++ b/src/test/regress/expected/uao_catalog_tables.out
@@ -1,3 +1,7 @@
+-- start_matchsubs
+-- m/ERROR:  permission denied: "pg_ao(seg|visimap|blkdir)_\d+" is a system catalog/
+-- s/pg_ao(seg|visimap|blkdir)_\d+/pg_ao_aux_table_xxxxx/
+-- end_matchsubs
 -- create functions to query uao auxiliary tables through gp_dist_random instead of going through utility mode
 CREATE OR REPLACE FUNCTION gp_aovisimap_dist_random(
   IN relation_name text) RETURNS setof record AS $$
@@ -338,3 +342,118 @@ select * from gp_toolkit.__gp_aovisimap_hidden_info('uao_table_check_hidden_tup_
      2 |               0 |              1
 (6 rows)
 
+-- Verify that we can delete from the AO auxiliary tables when allow_system_table_mods is enabled
+CREATE OR REPLACE FUNCTION insert_dummy_ao_aux_entry(fqname text)
+RETURNS void AS
+$$
+BEGIN
+    EXECUTE 'INSERT INTO ' || fqname || ' VALUES(null)';
+END
+$$ LANGUAGE plpgsql;
+CREATE OR REPLACE FUNCTION delete_dummy_ao_aux_entry(fqname text)
+RETURNS void AS
+$$
+BEGIN
+    EXECUTE 'DELETE FROM ' || fqname;
+END
+$$ LANGUAGE plpgsql;
+CREATE TABLE uao_catalog_delete_from (a int) USING ao_row DISTRIBUTED BY (a);
+CREATE INDEX uao_catalog_delete_from_idx ON uao_catalog_delete_from USING btree(a);
+SELECT delete_dummy_ao_aux_entry(s.interior_fqname)
+FROM (
+     SELECT segrelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uao_catalog_delete_from'::regclass::oid
+) s;
+ERROR:  permission denied: "pg_ao_aux_table_xxxxx" is a system catalog
+CONTEXT:  SQL statement "DELETE FROM pg_aoseg.pg_aoseg_xxxxx"
+PL/pgSQL function delete_dummy_ao_aux_entry(text) line 3 at EXECUTE
+SELECT delete_dummy_ao_aux_entry(s.interior_fqname)
+FROM (
+     SELECT blkdirrelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uao_catalog_delete_from'::regclass::oid
+) s;
+ERROR:  permission denied: "pg_ao_aux_table_xxxxx" is a system catalog
+CONTEXT:  SQL statement "DELETE FROM pg_aoseg.pg_aoblkdir_xxxxx"
+PL/pgSQL function delete_dummy_ao_aux_entry(text) line 3 at EXECUTE
+SELECT delete_dummy_ao_aux_entry(s.interior_fqname)
+FROM (
+     SELECT visimaprelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uao_catalog_delete_from'::regclass::oid
+) s;
+ERROR:  permission denied: "pg_ao_aux_table_xxxxx" is a system catalog
+CONTEXT:  SQL statement "DELETE FROM pg_aoseg.pg_aovisimap_xxxxx"
+PL/pgSQL function delete_dummy_ao_aux_entry(text) line 3 at EXECUTE
+SET allow_system_table_mods = on;
+SELECT insert_dummy_ao_aux_entry(s.interior_fqname)
+FROM (
+     SELECT segrelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uao_catalog_delete_from'::regclass::oid
+) s;
+ insert_dummy_ao_aux_entry 
+---------------------------
+ 
+(1 row)
+
+SELECT insert_dummy_ao_aux_entry(s.interior_fqname)
+FROM (
+     SELECT blkdirrelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uao_catalog_delete_from'::regclass::oid
+) s;
+ insert_dummy_ao_aux_entry 
+---------------------------
+ 
+(1 row)
+
+SELECT insert_dummy_ao_aux_entry(s.interior_fqname)
+FROM (
+     SELECT visimaprelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uao_catalog_delete_from'::regclass::oid
+) s;
+ insert_dummy_ao_aux_entry 
+---------------------------
+ 
+(1 row)
+
+SELECT delete_dummy_ao_aux_entry(s.interior_fqname)
+FROM (
+     SELECT segrelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uao_catalog_delete_from'::regclass::oid
+) s;
+ delete_dummy_ao_aux_entry 
+---------------------------
+ 
+(1 row)
+
+SELECT delete_dummy_ao_aux_entry(s.interior_fqname)
+FROM (
+     SELECT blkdirrelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uao_catalog_delete_from'::regclass::oid
+) s;
+ delete_dummy_ao_aux_entry 
+---------------------------
+ 
+(1 row)
+
+SELECT delete_dummy_ao_aux_entry(s.interior_fqname)
+FROM (
+     SELECT visimaprelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uao_catalog_delete_from'::regclass::oid
+) s;
+ delete_dummy_ao_aux_entry 
+---------------------------
+ 
+(1 row)
+
+SELECT count(*) FROM gp_toolkit.__gp_aoseg('uao_catalog_delete_from');
+ count 
+-------
+     0
+(1 row)
+
+SELECT count(*) FROM gp_toolkit.__gp_aoblkdir('uao_catalog_delete_from');
+ count 
+-------
+     0
+(1 row)
+
+SELECT count(*) FROM gp_toolkit.__gp_aovisimap('uao_catalog_delete_from');
+ count 
+-------
+     0
+(1 row)
+
+SET allow_system_table_mods = off;
+DROP FUNCTION insert_dummy_ao_aux_entry(fqname text);
+DROP FUNCTION delete_dummy_ao_aux_entry(fqname text);
+DROP TABLE uao_catalog_delete_from;

--- a/src/test/regress/expected/uaocs_catalog_tables.out
+++ b/src/test/regress/expected/uaocs_catalog_tables.out
@@ -1,3 +1,7 @@
+-- start_matchsubs
+-- m/ERROR:  permission denied: "pg_ao(csseg|visimap|blkdir)_\d+" is a system catalog/
+-- s/pg_ao(csseg|visimap|blkdir)_\d+/pg_aocs_aux_table_xxxxx/
+-- end_matchsubs
 -- create functions to query uaocs auxiliary tables through gp_dist_random instead of going through utility mode
 CREATE OR REPLACE FUNCTION gp_aocsseg_dist_random(
   IN relation_name text) RETURNS setof record AS $$
@@ -86,3 +90,118 @@ select * from gp_toolkit.__gp_aovisimap_hidden_info('uaocs_table_check_hidden_tu
      2 |               0 |              1
 (6 rows)
 
+-- Verify that we can delete from the AOCO auxiliary tables when allow_system_table_mods is enabled
+CREATE OR REPLACE FUNCTION insert_dummy_aoco_aux_entry(fqname text)
+RETURNS void AS
+$$
+BEGIN
+    EXECUTE 'INSERT INTO ' || fqname || ' VALUES(null)';
+END
+$$ LANGUAGE plpgsql;
+CREATE OR REPLACE FUNCTION delete_dummy_aoco_aux_entry(fqname text)
+RETURNS void AS
+$$
+BEGIN
+    EXECUTE 'DELETE FROM ' || fqname;
+END
+$$ LANGUAGE plpgsql;
+CREATE TABLE uaocs_catalog_delete_from (a int) USING ao_column DISTRIBUTED BY (a);
+CREATE INDEX uaocs_catalog_delete_from_idx ON uaocs_catalog_delete_from USING btree(a);
+SELECT delete_dummy_aoco_aux_entry(s.interior_fqname)
+FROM (
+     SELECT segrelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uaocs_catalog_delete_from'::regclass::oid
+) s;
+ERROR:  permission denied: "pg_aocs_aux_table_xxxxx" is a system catalog
+CONTEXT:  SQL statement "DELETE FROM pg_aoseg.pg_aocsseg_xxxxx"
+PL/pgSQL function delete_dummy_aoco_aux_entry(text) line 3 at EXECUTE
+SELECT delete_dummy_aoco_aux_entry(s.interior_fqname)
+FROM (
+     SELECT blkdirrelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uaocs_catalog_delete_from'::regclass::oid
+) s;
+ERROR:  permission denied: "pg_aocs_aux_table_xxxxx" is a system catalog
+CONTEXT:  SQL statement "DELETE FROM pg_aoseg.pg_aoblkdir_xxxxx"
+PL/pgSQL function delete_dummy_aoco_aux_entry(text) line 3 at EXECUTE
+SELECT delete_dummy_aoco_aux_entry(s.interior_fqname)
+FROM (
+     SELECT visimaprelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uaocs_catalog_delete_from'::regclass::oid
+) s;
+ERROR:  permission denied: "pg_aocs_aux_table_xxxxx" is a system catalog
+CONTEXT:  SQL statement "DELETE FROM pg_aoseg.pg_aovisimap_xxxxx"
+PL/pgSQL function delete_dummy_aoco_aux_entry(text) line 3 at EXECUTE
+SET allow_system_table_mods = on;
+SELECT insert_dummy_aoco_aux_entry(s.interior_fqname)
+FROM (
+     SELECT segrelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uaocs_catalog_delete_from'::regclass::oid
+) s;
+ insert_dummy_aoco_aux_entry 
+-----------------------------
+ 
+(1 row)
+
+SELECT insert_dummy_aoco_aux_entry(s.interior_fqname)
+FROM (
+     SELECT blkdirrelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uaocs_catalog_delete_from'::regclass::oid
+) s;
+ insert_dummy_aoco_aux_entry 
+-----------------------------
+ 
+(1 row)
+
+SELECT insert_dummy_aoco_aux_entry(s.interior_fqname)
+FROM (
+     SELECT visimaprelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uaocs_catalog_delete_from'::regclass::oid
+) s;
+ insert_dummy_aoco_aux_entry 
+-----------------------------
+ 
+(1 row)
+
+SELECT delete_dummy_aoco_aux_entry(s.interior_fqname)
+FROM (
+     SELECT segrelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uaocs_catalog_delete_from'::regclass::oid
+) s;
+ delete_dummy_aoco_aux_entry 
+-----------------------------
+ 
+(1 row)
+
+SELECT delete_dummy_aoco_aux_entry(s.interior_fqname)
+FROM (
+     SELECT blkdirrelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uaocs_catalog_delete_from'::regclass::oid
+) s;
+ delete_dummy_aoco_aux_entry 
+-----------------------------
+ 
+(1 row)
+
+SELECT delete_dummy_aoco_aux_entry(s.interior_fqname)
+FROM (
+     SELECT visimaprelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uaocs_catalog_delete_from'::regclass::oid
+) s;
+ delete_dummy_aoco_aux_entry 
+-----------------------------
+ 
+(1 row)
+
+SELECT count(*) FROM gp_toolkit.__gp_aocsseg('uaocs_catalog_delete_from');
+ count 
+-------
+     0
+(1 row)
+
+SELECT count(*) FROM gp_toolkit.__gp_aoblkdir('uaocs_catalog_delete_from');
+ count 
+-------
+     0
+(1 row)
+
+SELECT count(*) FROM gp_toolkit.__gp_aovisimap('uaocs_catalog_delete_from');
+ count 
+-------
+     0
+(1 row)
+
+SET allow_system_table_mods = off;
+DROP FUNCTION insert_dummy_aoco_aux_entry(fqname text);
+DROP FUNCTION delete_dummy_aoco_aux_entry(fqname text);
+DROP TABLE uaocs_catalog_delete_from;

--- a/src/test/regress/sql/uao_catalog_tables.sql
+++ b/src/test/regress/sql/uao_catalog_tables.sql
@@ -1,3 +1,8 @@
+-- start_matchsubs
+-- m/ERROR:  permission denied: "pg_ao(seg|visimap|blkdir)_\d+" is a system catalog/
+-- s/pg_ao(seg|visimap|blkdir)_\d+/pg_ao_aux_table_xxxxx/
+-- end_matchsubs
+
 -- create functions to query uao auxiliary tables through gp_dist_random instead of going through utility mode
 CREATE OR REPLACE FUNCTION gp_aovisimap_dist_random(
   IN relation_name text) RETURNS setof record AS $$
@@ -127,3 +132,71 @@ update uao_table_check_hidden_tup_count_after_update set j = 'test21';
 select * from gp_toolkit.__gp_aovisimap_hidden_info('uao_table_check_hidden_tup_count_after_update'::regclass);
 vacuum full uao_table_check_hidden_tup_count_after_update;
 select * from gp_toolkit.__gp_aovisimap_hidden_info('uao_table_check_hidden_tup_count_after_update'::regclass);
+
+-- Verify that we can delete from the AO auxiliary tables when allow_system_table_mods is enabled
+CREATE OR REPLACE FUNCTION insert_dummy_ao_aux_entry(fqname text)
+RETURNS void AS
+$$
+BEGIN
+    EXECUTE 'INSERT INTO ' || fqname || ' VALUES(null)';
+END
+$$ LANGUAGE plpgsql;
+CREATE OR REPLACE FUNCTION delete_dummy_ao_aux_entry(fqname text)
+RETURNS void AS
+$$
+BEGIN
+    EXECUTE 'DELETE FROM ' || fqname;
+END
+$$ LANGUAGE plpgsql;
+
+CREATE TABLE uao_catalog_delete_from (a int) USING ao_row DISTRIBUTED BY (a);
+CREATE INDEX uao_catalog_delete_from_idx ON uao_catalog_delete_from USING btree(a);
+
+SELECT delete_dummy_ao_aux_entry(s.interior_fqname)
+FROM (
+     SELECT segrelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uao_catalog_delete_from'::regclass::oid
+) s;
+SELECT delete_dummy_ao_aux_entry(s.interior_fqname)
+FROM (
+     SELECT blkdirrelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uao_catalog_delete_from'::regclass::oid
+) s;
+SELECT delete_dummy_ao_aux_entry(s.interior_fqname)
+FROM (
+     SELECT visimaprelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uao_catalog_delete_from'::regclass::oid
+) s;
+
+SET allow_system_table_mods = on;
+SELECT insert_dummy_ao_aux_entry(s.interior_fqname)
+FROM (
+     SELECT segrelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uao_catalog_delete_from'::regclass::oid
+) s;
+SELECT insert_dummy_ao_aux_entry(s.interior_fqname)
+FROM (
+     SELECT blkdirrelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uao_catalog_delete_from'::regclass::oid
+) s;
+SELECT insert_dummy_ao_aux_entry(s.interior_fqname)
+FROM (
+     SELECT visimaprelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uao_catalog_delete_from'::regclass::oid
+) s;
+
+SELECT delete_dummy_ao_aux_entry(s.interior_fqname)
+FROM (
+     SELECT segrelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uao_catalog_delete_from'::regclass::oid
+) s;
+SELECT delete_dummy_ao_aux_entry(s.interior_fqname)
+FROM (
+     SELECT blkdirrelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uao_catalog_delete_from'::regclass::oid
+) s;
+SELECT delete_dummy_ao_aux_entry(s.interior_fqname)
+FROM (
+     SELECT visimaprelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uao_catalog_delete_from'::regclass::oid
+) s;
+
+SELECT count(*) FROM gp_toolkit.__gp_aoseg('uao_catalog_delete_from');
+SELECT count(*) FROM gp_toolkit.__gp_aoblkdir('uao_catalog_delete_from');
+SELECT count(*) FROM gp_toolkit.__gp_aovisimap('uao_catalog_delete_from');
+
+SET allow_system_table_mods = off;
+DROP FUNCTION insert_dummy_ao_aux_entry(fqname text);
+DROP FUNCTION delete_dummy_ao_aux_entry(fqname text);
+DROP TABLE uao_catalog_delete_from;

--- a/src/test/regress/sql/uaocs_catalog_tables.sql
+++ b/src/test/regress/sql/uaocs_catalog_tables.sql
@@ -1,3 +1,8 @@
+-- start_matchsubs
+-- m/ERROR:  permission denied: "pg_ao(csseg|visimap|blkdir)_\d+" is a system catalog/
+-- s/pg_ao(csseg|visimap|blkdir)_\d+/pg_aocs_aux_table_xxxxx/
+-- end_matchsubs
+
 -- create functions to query uaocs auxiliary tables through gp_dist_random instead of going through utility mode
 CREATE OR REPLACE FUNCTION gp_aocsseg_dist_random(
   IN relation_name text) RETURNS setof record AS $$
@@ -38,3 +43,71 @@ update uaocs_table_check_hidden_tup_count_after_update set j = 'test_update';
 select * from gp_toolkit.__gp_aovisimap_hidden_info('uaocs_table_check_hidden_tup_count_after_update'::regclass);
 vacuum full uaocs_table_check_hidden_tup_count_after_update;
 select * from gp_toolkit.__gp_aovisimap_hidden_info('uaocs_table_check_hidden_tup_count_after_update'::regclass);
+
+-- Verify that we can delete from the AOCO auxiliary tables when allow_system_table_mods is enabled
+CREATE OR REPLACE FUNCTION insert_dummy_aoco_aux_entry(fqname text)
+RETURNS void AS
+$$
+BEGIN
+    EXECUTE 'INSERT INTO ' || fqname || ' VALUES(null)';
+END
+$$ LANGUAGE plpgsql;
+CREATE OR REPLACE FUNCTION delete_dummy_aoco_aux_entry(fqname text)
+RETURNS void AS
+$$
+BEGIN
+    EXECUTE 'DELETE FROM ' || fqname;
+END
+$$ LANGUAGE plpgsql;
+
+CREATE TABLE uaocs_catalog_delete_from (a int) USING ao_column DISTRIBUTED BY (a);
+CREATE INDEX uaocs_catalog_delete_from_idx ON uaocs_catalog_delete_from USING btree(a);
+
+SELECT delete_dummy_aoco_aux_entry(s.interior_fqname)
+FROM (
+     SELECT segrelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uaocs_catalog_delete_from'::regclass::oid
+) s;
+SELECT delete_dummy_aoco_aux_entry(s.interior_fqname)
+FROM (
+     SELECT blkdirrelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uaocs_catalog_delete_from'::regclass::oid
+) s;
+SELECT delete_dummy_aoco_aux_entry(s.interior_fqname)
+FROM (
+     SELECT visimaprelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uaocs_catalog_delete_from'::regclass::oid
+) s;
+
+SET allow_system_table_mods = on;
+SELECT insert_dummy_aoco_aux_entry(s.interior_fqname)
+FROM (
+     SELECT segrelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uaocs_catalog_delete_from'::regclass::oid
+) s;
+SELECT insert_dummy_aoco_aux_entry(s.interior_fqname)
+FROM (
+     SELECT blkdirrelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uaocs_catalog_delete_from'::regclass::oid
+) s;
+SELECT insert_dummy_aoco_aux_entry(s.interior_fqname)
+FROM (
+     SELECT visimaprelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uaocs_catalog_delete_from'::regclass::oid
+) s;
+
+SELECT delete_dummy_aoco_aux_entry(s.interior_fqname)
+FROM (
+     SELECT segrelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uaocs_catalog_delete_from'::regclass::oid
+) s;
+SELECT delete_dummy_aoco_aux_entry(s.interior_fqname)
+FROM (
+     SELECT blkdirrelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uaocs_catalog_delete_from'::regclass::oid
+) s;
+SELECT delete_dummy_aoco_aux_entry(s.interior_fqname)
+FROM (
+     SELECT visimaprelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uaocs_catalog_delete_from'::regclass::oid
+) s;
+
+SELECT count(*) FROM gp_toolkit.__gp_aocsseg('uaocs_catalog_delete_from');
+SELECT count(*) FROM gp_toolkit.__gp_aoblkdir('uaocs_catalog_delete_from');
+SELECT count(*) FROM gp_toolkit.__gp_aovisimap('uaocs_catalog_delete_from');
+
+SET allow_system_table_mods = off;
+DROP FUNCTION insert_dummy_aoco_aux_entry(fqname text);
+DROP FUNCTION delete_dummy_aoco_aux_entry(fqname text);
+DROP TABLE uaocs_catalog_delete_from;


### PR DESCRIPTION
When the AO/CO auxiliary tables have data and a DELETE is called on them after setting allow_system_table_mods to on, the DELETE would fail due to assertion failure. The issue was that the rewrite handler and the executor did not know about AO/CO auxiliary tables so the junk filters were not being set up correctly like they would be if the AO/CO auxiliary tables were regular heap tables. To fix the issue, simply add logic to check for the AO/CO auxiliary table relkinds.

Issue was reported from gpupgrade team where this DELETE operation is done in the data migration scripts.