### PR TITLE
Dump number of segments during minirepro

### DIFF
--- a/gpMgmt/bin/gpsd
+++ b/gpMgmt/bin/gpsd
@@ -35,10 +35,19 @@ def ResultIter(cursor, arraysize=1000):
 def getVersion(envOpts):
     cmd = subprocess.Popen('psql --pset footer -Atqc "select version()" template1', shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=envOpts)
     if cmd.wait() != 0:
-        sys.stderr.write('\nError while trying to find HAWQ/GPDB version.\n\n' + cmd.communicate()[1].decode('ascii') + '\n\n')
+        sys.stderr.write('\nError while trying to find GPDB version.\n\n' + cmd.communicate()[1].decode('ascii') + '\n\n')
         sys.exit(1)
     return cmd.communicate()[0].decode('ascii')
 
+def get_num_segments(cursor):
+    query = "select count(*) from gp_segment_configuration where role='p' and content >=0;"
+    try:
+        cursor.execute(query)
+        vals = cursor.fetchone()
+        return vals[0]
+    except pgdb.DatabaseError as e:
+        sys.stderr.write('\nError while trying to retrieve number of segments.\n\n' + str(e) + '\n\n')
+        sys.exit(1)
 
 def dumpSchema(connectionInfo, envOpts):
     dump_cmd = 'pg_dump -h {host} -p {port} -U {user} -s -x -O {database}'.format(**connectionInfo)
@@ -133,6 +142,7 @@ def main():
 
     version = getVersion(envOpts)
 
+
     timestamp = datetime.datetime.today()
 
     connectionInfo = {
@@ -142,9 +152,14 @@ def main():
     'database': db,
     'options': pgoptions
     }
+    num_segments = 0
+    with closing(pgdb.connect(**connectionInfo)) as connection:
+        with closing(connection.cursor()) as cursor:
+            num_segments = get_num_segments(cursor)
     sys.stdout.writelines(['\n-- Greenplum database Statistics Dump',
                            '\n-- Copyright (C) 2007 - 2014 Pivotal'
                            '\n-- Database: ' + db,
+                           '\n-- Num Segments: ' + str(num_segments),
                            '\n-- Date:     ' + timestamp.date().isoformat(),
                            '\n-- Time:     ' + timestamp.time().isoformat(),
                            '\n-- CmdLine:  ' + ' '.join(sys.argv),
@@ -168,6 +183,7 @@ def main():
                            '\n-- Allow system table modifications',
                            '\n-- ',
                            '\nset allow_system_table_mods=true;\n\n'])
+    sys.stdout.writelines('set optimizer to off;\n\n')
     sys.stdout.flush()
 
     try:

--- a/gpMgmt/bin/gpsd
+++ b/gpMgmt/bin/gpsd
@@ -43,11 +43,11 @@ def get_num_segments(cursor):
     query = "select count(*) from gp_segment_configuration where role='p' and content >=0;"
     try:
         cursor.execute(query)
-        vals = cursor.fetchone()
-        return vals[0]
     except pgdb.DatabaseError as e:
         sys.stderr.write('\nError while trying to retrieve number of segments.\n\n' + str(e) + '\n\n')
         sys.exit(1)
+    vals = cursor.fetchone()
+    return vals[0]
 
 def dumpSchema(connectionInfo, envOpts):
     dump_cmd = 'pg_dump -h {host} -p {port} -U {user} -s -x -O {database}'.format(**connectionInfo)
@@ -183,6 +183,7 @@ def main():
                            '\n-- Allow system table modifications',
                            '\n-- ',
                            '\nset allow_system_table_mods=true;\n\n'])
+    # turn off optimizer when loading stats. Orca adds a bit of overhead, but it's significant when small insrt queries take 1 vs .1ms
     sys.stdout.writelines('set optimizer to off;\n\n')
     sys.stdout.flush()
 

--- a/gpMgmt/bin/minirepro
+++ b/gpMgmt/bin/minirepro
@@ -100,7 +100,17 @@ def get_server_version(cursor):
         vals = cursor.fetchone()
         return vals[0]
     except pgdb.DatabaseError as e:
-        sys.stderr.write('\nError while trying to find HAWQ/GPDB version.\n\n' + str(e) + '\n\n')
+        sys.stderr.write('\nError while trying to find GPDB version.\n\n' + str(e) + '\n\n')
+        sys.exit(1)
+
+def get_num_segments(cursor):
+    query = "select count(*) from gp_segment_configuration where role='p' and content >=0;"
+    try:
+        cursor.execute(query)
+        vals = cursor.fetchone()
+        return vals[0]
+    except pgdb.DatabaseError as e:
+        sys.stderr.write('\nError while trying to retrieve number of segments.\n\n' + str(e) + '\n\n')
         sys.exit(1)
 
 def parse_cmd_line():
@@ -295,6 +305,8 @@ def main():
     # get server version, which is dumped to minirepro output file
     server_ver = get_server_version(cursor)
 
+    num_segments = get_num_segments(cursor)
+
     """
     invoke gp_toolkit UDF, dump object oids as json text
     input: query file name
@@ -330,6 +342,8 @@ def main():
     # make sure we connect with the right database
     f_out.writelines('\\connect ' + db + '\n\n')
 
+    f_out.writelines('set optimizer to off;\n\n')
+
     # first create schema DDLs
     print("Writing schema DDLs ...")
     table_schemas = ["CREATE SCHEMA %s;\n" % Escape(schema) for schema in mr_query.schemas if schema != 'public']
@@ -362,7 +376,8 @@ def main():
     f_out.writelines(['\n-- ',
                        '\n-- Query text',
                        '\n-- \n\n'])
-
+    line = 'set optimizer_segments = ' + str(num_segments) + ';'
+    f_out.writelines('\n-- ' + line + '\n')
     with open(query_file, 'r') as query_f:
         for line in query_f:
             f_out.writelines('-- ' + line)

--- a/gpMgmt/bin/minirepro
+++ b/gpMgmt/bin/minirepro
@@ -97,21 +97,21 @@ def get_server_version(cursor):
     query = "select version()"
     try:
         cursor.execute(query)
-        vals = cursor.fetchone()
-        return vals[0]
     except pgdb.DatabaseError as e:
         sys.stderr.write('\nError while trying to find GPDB version.\n\n' + str(e) + '\n\n')
         sys.exit(1)
+    vals = cursor.fetchone()
+    return vals[0]
 
 def get_num_segments(cursor):
     query = "select count(*) from gp_segment_configuration where role='p' and content >=0;"
     try:
         cursor.execute(query)
-        vals = cursor.fetchone()
-        return vals[0]
     except pgdb.DatabaseError as e:
         sys.stderr.write('\nError while trying to retrieve number of segments.\n\n' + str(e) + '\n\n')
         sys.exit(1)
+    vals = cursor.fetchone()
+    return vals[0]
 
 def parse_cmd_line():
     p = OptionParser(usage='Usage: %prog <database> [options]', version='%prog '+version, conflict_handler="resolve", epilog="WARNING: This tool collects statistics about your data, including most common values, which requires some data elements to be included in the output file. Please review output file to ensure it is within corporate policy to transport the output file.")
@@ -341,7 +341,7 @@ def main():
 
     # make sure we connect with the right database
     f_out.writelines('\\connect ' + db + '\n\n')
-
+    # turn off optimizer when loading stats. Orca adds a bit of overhead, but it's significant when small insrt queries take 1 vs .1ms
     f_out.writelines('set optimizer to off;\n\n')
 
     # first create schema DDLs

--- a/src/test/regress/expected/minirepro.out
+++ b/src/test/regress/expected/minirepro.out
@@ -65,6 +65,7 @@ SET
 SET
 SET
 SET
+SET
  set_config 
 ------------
  
@@ -141,6 +142,7 @@ analyze minirepro_foo;
 drop table minirepro_foo; -- this will also delete the pg_statistic tuples for minirepro_foo and minirepro_foo_1
 \! psql -f data/minirepro.sql regression
 You are now connected to database "regression" as user "pivotal".
+SET
 SET
 SET
 SET
@@ -231,6 +233,7 @@ SET
 SET
 SET
 SET
+SET
  set_config 
 ------------
  
@@ -266,6 +269,7 @@ drop table minirepro_foo;
 -- corrupted stats for pg_tablespace. But, that shouldn't matter too much?
 \! psql -f data/minirepro.sql regression
 You are now connected to database "regression" as user "pivotal".
+SET
 SET
 SET
 SET

--- a/src/test/regress/expected/minirepro.out
+++ b/src/test/regress/expected/minirepro.out
@@ -287,10 +287,10 @@ SET
 SET
 SET
 SET
-psql:data/minirepro.sql:44: ERROR:  only shared relations can be placed in pg_global tablespace
-psql:data/minirepro.sql:46: ERROR:  permission denied: "pg_tablespace" is a system catalog
-psql:data/minirepro.sql:53: ERROR:  permission denied: "pg_tablespace" is a system catalog
-psql:data/minirepro.sql:60: ERROR:  permission denied: "pg_tablespace" is a system catalog
+psql:data/minirepro.sql:46: ERROR:  only shared relations can be placed in pg_global tablespace
+psql:data/minirepro.sql:48: ERROR:  permission denied: "pg_tablespace" is a system catalog
+psql:data/minirepro.sql:55: ERROR:  permission denied: "pg_tablespace" is a system catalog
+psql:data/minirepro.sql:62: ERROR:  permission denied: "pg_tablespace" is a system catalog
 SET
 UPDATE 1
 DELETE 1


### PR DESCRIPTION
This commit includes a couple improvements when dumping minirepros:
1. Dump the number of segments. This is needed to replicate the plan, and often we have to ask users/customers this separately. Instead just retrieve it during the minirepro
2. Output a `set optimizer=off` for when the minirepro is being restored. The short insert statements into pg_statistic/pg_class are much faster (~10X) using planner than Orca, especially if done in a debug buiild. Output this by default so I don't have to modify this manually.
