### PR TITLE
docs - update sql ref pages for ALTER/CREATE/DROP DOMAIN

### DIFF
--- a/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_DOMAIN.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_DOMAIN.html.md
@@ -5,20 +5,24 @@ Defines a new domain.
 ## <a id="section2"></a>Synopsis 
 
 ``` {#sql_command_synopsis}
-CREATE DOMAIN <name> [AS] <data_type> [DEFAULT <expression>]
+CREATE DOMAIN <name> [AS] <data_type>
        [ COLLATE <collation> ] 
-       [ CONSTRAINT <constraint_name>
-       | NOT NULL | NULL 
-       | CHECK (<expression>) [...]]
+       [ DEFAULT <expression> ]
+       [ <constraint> [ ... ] ]
+
+where <constraint> is:
+
+[ CONSTRAINT <constraint_name>
+{ NOT NULL | NULL | CHECK (<expression>)  }
 ```
 
 ## <a id="section3"></a>Description 
 
-`CREATE DOMAIN` creates a new domain. A domain is essentially a data type with optional constraints \(restrictions on the allowed set of values\). The user who defines a domain becomes its owner. The domain name must be unique among the data types and domains existing in its schema.
+`CREATE DOMAIN` creates a new domain. A domain is essentially a data type with optional constraints \(restrictions on the allowed set of values\). The user who defines a domain becomes its owner.
 
-If a schema name is given \(for example, `CREATE DOMAIN myschema.mydomain ...`\) then the domain is created in the specified schema. Otherwise it is created in the current schema.
+If a schema name is given \(for example, `CREATE DOMAIN myschema.mydomain ...`\) then the domain is created in the specified schema. Otherwise it is created in the current schema. The domain name must be unique among the data types and domains existing in its schema.
 
-Domains are useful for abstracting common constraints on fields into a single location for maintenance. For example, several tables might contain email address columns, all requiring the same `CHECK` constraint to verify the address syntax. It is easier to define a domain rather than setting up a column constraint for each table that has an email column.
+Domains are useful for abstracting common constraints on fields into a single location for maintenance. For example, several tables might contain email address columns, all requiring the same `CHECK` constraint to verify the address syntax. Define a domain rather than setting up each table's constraint individually.
 
 To be able to create a domain, you must have `USAGE` privilege on the underlying type.
 
@@ -30,31 +34,63 @@ name
 data\_type
 :   The underlying data type of the domain. This may include array specifiers.
 
-DEFAULT expression
-:   Specifies a default value for columns of the domain data type. The value is any variable-free expression \(but subqueries are not allowed\). The data type of the default expression must match the data type of the domain. If no default value is specified, then the default value is the null value. The default expression will be used in any insert operation that does not specify a value for the column. If a default value is defined for a particular column, it overrides any default associated with the domain. In turn, the domain default overrides any default value associated with the underlying data type.
+collation
+:   An optional collation for the domain. If no collation is specified, the domain has the same collation behavior as its underlying data type. The underlying type must be collatable if `COLLATE` is specified.
 
-COLLATE collation
-:   An optional collation for the domain. If no collation is specified, the underlying data type's default collation is used. The underlying type must be collatable if `COLLATE` is specified.
+DEFAULT expression
+:   Specifies a default value for columns of the domain data type. The value is any variable-free expression \(but subqueries are not allowed\). The data type of the default expression must match the data type of the domain. If no default value is specified, then the default value is the null value.
+:   The default expression will be used in any insert operation that does not specify a value for the column. If a default value is defined for a particular column, it overrides any default associated with the domain. In turn, the domain default overrides any default value associated with the underlying data type.
 
 CONSTRAINT constraint\_name
 :   An optional name for a constraint. If not specified, the system generates a name.
 
 NOT NULL
-:   Values of this domain are normally prevented from being null. However, it is still possible for a domain with this constraint to take a null value if it is assigned a matching domain type that has become null, e.g. via a left outer join, or a command such as `INSERT INTO tab (domcol) VALUES ((SELECT domcol FROM tab WHERE false))`.
+:   Values of this domain are normally prevented from being null. This is the default.
 
 NULL
-:   Values of this domain are allowed to be null. This is the default. This clause is only intended for compatibility with nonstandard SQL databases. Its use is discouraged in new applications.
+:   Values of this domain are allowed to be null. This is the default.
+:   This clause is only intended for compatibility with nonstandard SQL databases. Its use is discouraged in new applications.
 
 CHECK \(expression\)
-:   `CHECK` clauses specify integrity constraints or tests which values of the domain must satisfy. Each constraint must be an expression producing a Boolean result. It should use the key word `VALUE` to refer to the value being tested. Currently, `CHECK` expressions cannot contain subqueries nor refer to variables other than `VALUE`.
+:   `CHECK` clauses specify integrity constraints or tests which values of the domain must satisfy. Each constraint must be an expression producing a Boolean result. It should use the key word `VALUE` to refer to the value being tested. Expressions evaluating to TRUE or UNKNOWN succeed. If the expression produces a FALSE result, an error is reported and the value is not allowed to be converted to the domain type.
+:   Currently, `CHECK` expressions cannot contain subqueries nor refer to variables other than `VALUE`.
+:   When a domain has multiple `CHECK` constraints, they will be tested in alphabetical order by name. \(Greenplum Database versions before 7.0 did not honor any particular firing order for `CHECK` constraints.\)
+
+## <a id="section4a"></a>Notes
+
+Domain constraints, particularly `NOT NULL`, are checked when converting a value to the domain type. It is possible for a column that is nominally of the domain type to read as null despite there being such a constraint. For example, this can happen in an outer-join query, if the domain column is on the nullable side of the outer join. A more subtle example is:
+
+```
+INSERT INTO tab (domcol) VALUES ((SELECT domcol FROM tab WHERE false));
+```
+
+The empty scalar sub-SELECT will produce a null value that is considered to be of the domain type, so no further constraint checking is applied to it, and the insertion will succeed.
+
+It is very difficult to avoid such problems, because of SQL's general assumption that a null value is a valid value of every data type. Best practice therefore is to design a domain's constraints so that a null value is allowed, and then to apply column `NOT NULL` constraints to columns of the domain type as needed, rather than directly to the domain type.
+
+Greeplum Database assumes that `CHECK` constraints' conditions are immutable, that is, they will always give the same result for the same input value. This assumption is what justifies examining `CHECK` constraints only when a value is first converted to be of a domain type, and not at other times. \(This is essentially the same as the treatment of table `CHECK` constraints.\)
+
+An example of a common way to break this assumption is to reference a user-defined function in a `CHECK` expression, and then change the behavior of that function. Greenplum Database does not disallow that, but it will not notice if there are stored values of the domain type that now violate the `CHECK` constraint. That would cause a subsequent database dump and restore to fail. The recommended way to handle such a change is to drop the constraint \(using `ALTER DOMAIN`\), adjust the function definition, and re-add the constraint, thereby rechecking it against stored data.
 
 ## <a id="section5"></a>Examples 
 
-Create the `us_zip_code` data type. A regular expression test is used to verify that the value looks like a valid US zip code.
+This example creates the `us_postal_code` data type and then uses the type in a table defintion. A regular expression test is used to verify that the value looks like a valid US postal code.
 
 ```
-CREATE DOMAIN us_zip_code AS TEXT CHECK 
-       ( VALUE ~ '^\d{5}$' OR VALUE ~ '^\d{5}-\d{4}$' );
+CREATE DOMAIN us_postal_code AS TEXT
+CHECK(
+   VALUE ~ '^\d{5}$'
+OR VALUE ~ '^\d{5}-\d{4}$'
+);
+
+CREATE TABLE us_snail_addy (
+  address_id SERIAL PRIMARY KEY,
+  street1 TEXT NOT NULL,
+  street2 TEXT,
+  street3 TEXT,
+  city TEXT NOT NULL,
+  postal us_postal_code NOT NULL
+);
 ```
 
 ## <a id="section6"></a>Compatibility 

--- a/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_DOMAIN.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_DOMAIN.html.md
@@ -74,7 +74,7 @@ An example of a common way to break this assumption is to reference a user-defin
 
 ## <a id="section5"></a>Examples 
 
-This example creates the `us_postal_code` data type and then uses the type in a table defintion. A regular expression test is used to verify that the value looks like a valid US postal code.
+This example creates the `us_postal_code` data type and then uses the type in a table definition. A regular expression test is used to verify that the value looks like a valid US postal code.
 
 ```
 CREATE DOMAIN us_postal_code AS TEXT

--- a/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_DOMAIN.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_DOMAIN.html.md
@@ -12,7 +12,7 @@ CREATE DOMAIN <name> [AS] <data_type>
 
 where <constraint> is:
 
-[ CONSTRAINT <constraint_name>
+[ CONSTRAINT <constraint_name> ]
 { NOT NULL | NULL | CHECK (<expression>)  }
 ```
 
@@ -45,7 +45,7 @@ CONSTRAINT constraint\_name
 :   An optional name for a constraint. If not specified, the system generates a name.
 
 NOT NULL
-:   Values of this domain are normally prevented from being null. This is the default.
+:   Values of this domain are prevented from being null (but see the Notes below).
 
 NULL
 :   Values of this domain are allowed to be null. This is the default.

--- a/gpdb-doc/markdown/ref_guide/sql_commands/DROP_DOMAIN.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/DROP_DOMAIN.html.md
@@ -10,7 +10,7 @@ DROP DOMAIN [IF EXISTS] <name> [, ...]  [CASCADE | RESTRICT]
 
 ## <a id="section3"></a>Description 
 
-`DROP DOMAIN` removes a previously defined domain. You must be the owner of a domain to drop it.
+`DROP DOMAIN` removes a previously defined domain. Only the owner of a domain can remove it.
 
 ## <a id="section4"></a>Parameters 
 
@@ -21,17 +21,17 @@ name
 :   The name \(optionally schema-qualified\) of an existing domain.
 
 CASCADE
-:   Automatically drop objects that depend on the domain \(such as table columns\).
+:   Automatically drop objects that depend on the domain \(such as table columns\), and in turn all objects that depend on those objects.
 
 RESTRICT
 :   Refuse to drop the domain if any objects depend on it. This is the default.
 
 ## <a id="section5"></a>Examples 
 
-Drop the domain named `zipcode`:
+Remove the domain named `box`:
 
 ```
-DROP DOMAIN zipcode;
+DROP DOMAIN box;
 ```
 
 ## <a id="section6"></a>Compatibility 

--- a/gpdb-doc/markdown/ref_guide/sql_commands/DROP_DOMAIN.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/DROP_DOMAIN.html.md
@@ -28,10 +28,10 @@ RESTRICT
 
 ## <a id="section5"></a>Examples 
 
-Remove the domain named `box`:
+Remove the domain named `us_postal_code`:
 
 ```
-DROP DOMAIN box;
+DROP DOMAIN us_postal_code;
 ```
 
 ## <a id="section6"></a>Compatibility 


### PR DESCRIPTION
this PR updates the listed sql command reference pages to align with the postgres v12 ref page content.  i don't believe there was any greenplum-specific content in the original (v6) pages.  postgres ref page added Notes.

doc review site link for ALTER DOMAIN (behind vpn), can navigate to others from there:  https://docs-staging.vmware.com/en/draft/VMware-Tanzu-Greenplum/sqlref-domain/greenplum-database/GUID-ref_guide-sql_commands-ALTER_DOMAIN.html
