### PR TITLE
docs - update sql ref pages for ALTER/CREATE/DROP DATABASE

### DIFF
--- a/gpdb-doc/markdown/ref_guide/sql_commands/ALTER_DATABASE.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/ALTER_DATABASE.html.md
@@ -5,17 +5,23 @@ Changes the attributes of a database.
 ## <a id="section2"></a>Synopsis 
 
 ``` {#sql_command_synopsis}
-ALTER DATABASE <name> [ WITH CONNECTION LIMIT <connlimit> ]
+ALTER DATABASE <name> [ [WITH] <option> [ ... ]  ]
 
-ALTER DATABASE <name> RENAME TO <newname>
+where <option> can be:
 
-ALTER DATABASE <name> OWNER TO <new_owner>
+    ALLOW_CONNECTIONS <allowconn>
+    CONNECTION LIMIT <connlimit>
+    IS_TEMPLATE <istemplate>
+
+ALTER DATABASE <name> RENAME TO <new_name>
+
+ALTER DATABASE <name> OWNER TO { <new_owner> | CURRENT_USER | SESSION_USER }
 
 ALTER DATABASE <name> SET TABLESPACE <new_tablespace>
 
-ALTER DATABASE <name> SET <parameter> { TO | = } { <value> | DEFAULT }
-ALTER DATABASE <name> SET <parameter> FROM CURRENT
-ALTER DATABASE <name> RESET <parameter>
+ALTER DATABASE <name> SET <configuration_parameter> { TO | = } { <value> | DEFAULT }
+ALTER DATABASE <name> SET <configuration_parameter> FROM CURRENT
+ALTER DATABASE <name> RESET <configuration_parameter>
 ALTER DATABASE <name> RESET ALL
 
 ```
@@ -24,13 +30,13 @@ ALTER DATABASE <name> RESET ALL
 
 `ALTER DATABASE` changes the attributes of a database.
 
-The first form changes the allowed connection limit for a database. Only the database owner or a superuser can change this setting.
+The first form changes the per-database settings. \(See below for details.\)  Only the database owner or a superuser can change these settings.
 
 The second form changes the name of the database. Only the database owner or a superuser can rename a database; non-superuser owners must also have the `CREATEDB` privilege. You cannot rename the current database. Connect to a different database first.
 
 The third form changes the owner of the database. To alter the owner, you must own the database and also be a direct or indirect member of the new owning role, and you must have the `CREATEDB` privilege. \(Note that superusers have all these privileges automatically.\)
 
-The fourth form changes the default tablespace of the database. Only the database owner or a superuser can do this; you must also have create privilege for the new tablespace. This command physically moves any tables or indexes in the database's old default tablespace to the new tablespace. Note that tables and indexes in non-default tablespaces are not affected.
+The fourth form changes the default tablespace of the database. Only the database owner or a superuser can do this; you must also have create privilege for the new tablespace. This command physically moves any tables or indexes in the database's old default tablespace to the new tablespace. The new default tablespace must be empty for this database, and no one can be connected to the database. Note that tables and indexes in non-default tablespaces are not affected.
 
 The remaining forms change the session default for a configuration parameter for a Greenplum database. Whenever a new session is subsequently started in that database, the specified value becomes the session default value. The database-specific default overrides whatever setting is present in the server configuration file \(`postgresql.conf`\). Only the database owner or a superuser can change the session defaults for a database. Certain parameters cannot be set this way, or can only be set by a superuser.
 
@@ -39,13 +45,16 @@ The remaining forms change the session default for a configuration parameter for
 name
 :   The name of the database whose attributes are to be altered.
 
+allowconn
+:   If `false`, then no one can connect to this database.
+
 connlimit
-:   The maximum number of concurrent connections possible. The default of -1 means there is no limitation.
+:   The maximum number of concurrent connections allowed to this database. The default is `-1`, no limit.
 
-parameter value
-:   Set this database's session default for the specified configuration parameter to the given value. If value is `DEFAULT` or, equivalently, `RESET` is used, the database-specific setting is removed, so the system-wide default setting will be inherited in new sessions. Use `RESET ALL` to clear all database-specific settings. See [Server Configuration Parameters](../config_params/guc_config.html) for information about all user-settable configuration parameters.
+istemplate
+:   If `true`, then this database can be cloned by any user with `CREATEDB` privileges; if `false`, then only superusers or the owner of the database can clone it.
 
-newname
+new_name
 :   The new name of the database.
 
 new\_owner
@@ -53,18 +62,28 @@ new\_owner
 
 new\_tablespace
 :   The new default tablespace of the database.
+:   This form of the command cannot be executed inside a transaction block.
+
+configuration\_parameter value
+:   Set this database's session default for the specified configuration parameter to the given value. If value is `DEFAULT` or, equivalently, `RESET` is used, the database-specific setting is removed, so the system-wide default setting will be inherited in new sessions. Use `RESET ALL` to clear all database-specific settings. `SET FROM CURRENT` saves the session's current value of the parameter as the database-specific value.
+:   See [SET](SET.html) and [Server Configuration Parameters](../config_params/guc_config.html) for more information about allowed parameter names and values.
 
 ## <a id="section5"></a>Notes 
 
-It is also possible to set a configuration parameter session default for a specific role \(user\) rather than to a database. Role-specific settings override database-specific ones if there is a conflict. See `ALTER ROLE`.
+It is also possible to tie a session default to a specific role rather than to a database; see [ALTER ROLE](ALTER_ROLE.html). Role-specific settings override database-specific ones if there is a conflict.
 
 ## <a id="section6"></a>Examples 
+
+To disable index scans by default in the `test` database:
+
+```
+ALTER DATABASE test SET enable_indexscan TO off;
+```
 
 To set the default schema search path for the `mydatabase` database:
 
 ```
-ALTER DATABASE mydatabase SET search_path TO myschema, 
-public, pg_catalog;
+ALTER DATABASE mydatabase SET search_path TO myschema, public, pg_catalog;
 ```
 
 ## <a id="section7"></a>Compatibility 

--- a/gpdb-doc/markdown/ref_guide/sql_commands/ALTER_DATABASE.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/ALTER_DATABASE.html.md
@@ -49,10 +49,10 @@ allowconn
 :   If `false`, then no one can connect to this database.
 
 connlimit
-:   The maximum number of concurrent connections allowed to this database. The default is `-1`, no limit.
+:   The maximum number of concurrent connections allowed to this database. The default is `-1`, no limit. Greenplum Database superusers are exempt from this limit.
 
 istemplate
-:   If `true`, then this database can be cloned by any user with `CREATEDB` privileges; if `false`, then only superusers or the owner of the database can clone it.
+:   If `true`, then this database can be cloned by any user with `CREATEDB` privileges; if `false`, then only superusers or the owner of the database can clone it. Note that template databases cannot be dropped.
 
 new_name
 :   The new name of the database.

--- a/gpdb-doc/markdown/ref_guide/sql_commands/ALTER_DATABASE.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/ALTER_DATABASE.html.md
@@ -49,7 +49,7 @@ allowconn
 :   If `false`, then no one can connect to this database.
 
 connlimit
-:   The maximum number of concurrent connections allowed to this database. The default is `-1`, no limit. Greenplum Database superusers are exempt from this limit.
+:   The maximum number of concurrent connections allowed to this database on the coordinator. The default is `-1`, no limit. Greenplum Database superusers are exempt from this limit.
 
 istemplate
 :   If `true`, then this database can be cloned by any user with `CREATEDB` privileges; if `false`, then only superusers or the owner of the database can clone it. Note that template databases cannot be dropped.

--- a/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_DATABASE.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_DATABASE.html.md
@@ -54,10 +54,10 @@ allowconn
 :   If `false`, then no one can connect to this database. The default is `true`, allowing connections \(except as restricted by other mechanisms, such as `GRANT/REVOKE CONNECT`\).
 
 connlimit
-:   The maximum number of concurrent connections allowed to this database. The default is `-1`, no limit.
+:   The maximum number of concurrent connections allowed to this database. The default is `-1`, no limit. Greenplum Database superusers are exempt from this limit.
 
 istemplate
-:   If `true`, then this database can be cloned by any user with `CREATEDB` privileges; if `false` \(the default\), then only superusers or the owner of the database can clone it.
+:   If `true`, then this database can be cloned by any user with `CREATEDB` privileges; if `false` \(the default\), then only superusers or the owner of the database can clone it. Note that template databases cannot be dropped.
 
 Optional parameters can be written in any order, not only the order illustrated above.
 

--- a/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_DATABASE.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_DATABASE.html.md
@@ -5,18 +5,23 @@ Creates a new database.
 ## <a id="section2"></a>Synopsis 
 
 ``` {#sql_command_synopsis}
-CREATE DATABASE name [ [WITH] [OWNER [=] <user_name>]
-                     [TEMPLATE [=] <template>]
-                     [ENCODING [=] <encoding>]
-                     [LC_COLLATE [=] <lc_collate>]
-                     [LC_CTYPE [=] <lc_ctype>]
-                     [TABLESPACE [=] <tablespace>]
-                     [CONNECTION LIMIT [=] connlimit ] ]
+CREATE DATABASE name
+    [ [WITH] [OWNER [=] <user_name>]
+          [TEMPLATE [=] <template>]
+          [ENCODING [=] <encoding>]
+          [LC_COLLATE [=] <lc_collate>]
+          [LC_CTYPE [=] <lc_ctype>]
+          [TABLESPACE [=] <tablespace_name>]
+          [ALLOW_CONNECTIONS [=] <allowconn>]
+          [CONNECTION LIMIT [=] <connlimit> ]
+          [IS_TEMPLATE [=] <istemplate> ] ]
 ```
 
 ## <a id="section3"></a>Description 
 
-`CREATE DATABASE` creates a new database. To create a database, you must be a superuser or have the special `CREATEDB` privilege.
+`CREATE DATABASE` creates a new database.
+
+To create a database, you must be a superuser or have the special `CREATEDB` privilege. See [CREATE ROLE](CREATE_ROLE.html).
 
 The creator becomes the owner of the new database by default. Superusers can create databases owned by other users by using the `OWNER` clause. They can even create databases owned by users with no special privileges. Non-superusers with `CREATEDB` privilege can only create databases owned by themselves.
 
@@ -28,37 +33,54 @@ name
 :   The name of a database to create.
 
 user\_name
-:   The name of the database user who will own the new database, or `DEFAULT` to use the default owner \(the user running the command\).
+:   The name of the database user who will own the new database, or `DEFAULT` to use the default owner \(the user running the command\). To create a database owned by another role, you must be a direct or indirect member of that role, or be a superuser.
 
 template
 :   The name of the template from which to create the new database, or `DEFAULT` to use the default template \(template1\).
 
 encoding
-:   Character set encoding to use in the new database. Specify a string constant \(such as `'SQL_ASCII'`\), an integer encoding number, or `DEFAULT` to use the default encoding. For more information, see [Character Set Support](../character_sets.html).
+:   Character set encoding to use in the new database. Specify a string constant \(such as `'SQL_ASCII'`\), an integer encoding number, or `DEFAULT` to use the default encoding  \(namely, the encoding of the template database\). For more information, see [Character Set Support](../character_sets.html). Refer to the [Notes](#section5) for additional restrictions.
 
 lc\_collate
-:   The collation order \(`LC_COLLATE`\) to use in the new database. This affects the sort order applied to strings, e.g. in queries with `ORDER BY`, as well as the order used in indexes on text columns. The default is to use the collation order of the template database. See the Notes section for additional restrictions.
+:   The collation order \(`LC_COLLATE`\) to use in the new database. This affects the sort order applied to strings, e.g. in queries with `ORDER BY`, as well as the order used in indexes on text columns. The default is to use the collation order of the template database. See the [Notes](#section5) for additional restrictions.
 
 lc\_ctype
-:   The character classification \(`LC_CTYPE`\) to use in the new database. This affects the categorization of characters, e.g. lower, upper and digit. The default is to use the character classification of the template database. See below for additional restrictions.
+:   The character classification \(`LC_CTYPE`\) to use in the new database. This affects the categorization of characters, e.g. lower, upper, and digit. The default is to use the character classification of the template database. See the [Notes](#section5) for additional restrictions.
 
-tablespace
-:   The name of the tablespace that will be associated with the new database, or `DEFAULT` to use the template database's tablespace. This tablespace will be the default tablespace used for objects created in this database.
+tablespace\_name
+:   The name of the tablespace that will be associated with the new database, or `DEFAULT` to use the template database's tablespace. This tablespace will be the default tablespace used for objects created in this database. See [CREATE TABLESPACE](CREATE_TABLESPACE.html) for more information.
+
+allowconn
+:   If `false`, then no one can connect to this database. The default is `true`, allowing connections \(except as restricted by other mechanisms, such as `GRANT/REVOKE CONNECT`\).
 
 connlimit
-:   The maximum number of concurrent connections possible. The default of -1 means there is no limitation.
+:   The maximum number of concurrent connections allowed to this database. The default is `-1`, no limit.
+
+istemplate
+:   If `true`, then this database can be cloned by any user with `CREATEDB` privileges; if `false` \(the default\), then only superusers or the owner of the database can clone it.
+
+Optional parameters can be written in any order, not only the order illustrated above.
 
 ## <a id="section5"></a>Notes 
 
 `CREATE DATABASE` cannot be run inside a transaction block.
 
-When you copy a database by specifying its name as the template, no other sessions can be connected to the template database while it is being copied. New connections to the template database are locked out until `CREATE DATABASE` completes.
+Errors along the line of “could not initialize database directory” are most likely related to insufficient permissions on the data directory, a full disk, or other file system problems.
 
-The `CONNECTION LIMIT` is not enforced against superusers.
+Use [DROP DATABASE](DROP_DATABASE.HTML) to remove a database.
+
+The program [createdb](../../utility_guide/ref/createdb.html) is a wrapper program around this command, provided for convenience.
+
+Database-level configuration parameters \(set via [ALTER DATABASE](\)ALTER_DATABASE.html) and database-level permissions \(set via [GRANT](GRANT.html)\) are not copied from the template database.
+
+Although it is possible to copy a database other than `template1` by specifying its name as the template, this is not \(yet\) intended as a general-purpose `“COPY DATABASE”` facility. The principal limitation is that no other sessions can be connected to the template database while it is being copied. `CREATE DATABASE` will fail if any other connection exists when it starts; otherwise, new connections to the template database are locked out until `CREATE DATABASE` completes.
 
 The character set encoding specified for the new database must be compatible with the chosen locale settings \(`LC_COLLATE` and `LC_CTYPE`\). If the locale is `C` \(or equivalently `POSIX`\), then all encodings are allowed, but for other locale settings there is only one encoding that will work properly. `CREATE DATABASE` will allow superusers to specify `SQL_ASCII` encoding regardless of the locale settings, but this choice is deprecated and may result in misbehavior of character-string functions if data that is not encoding-compatible with the locale is stored in the database.
 
-The encoding and locale settings must match those of the template database, except when `template0` is used as template. This is because `COLLATE` and `CTYPE` affect the ordering in indexes, so that any indexes copied from the template database would be invalid in the new database with different settings. `template0`, however, is known to not contain any data or indexes that would be affected.
+The encoding and locale settings must match those of the template database, except when `template0` is used as template. This is because other databases might contain data that does not match the specified encoding, or might contain indexes whose ordering is affected by `LC_COLLATE` and `LC_CTYPE`. Copying such data would result in a database that is corrupt according to the new settings. `template0`, however, is known to not contain any data or indexes that would be affected.
+
+The `CONNECTION LIMIT` option is enforced approximately; if two new sessions start at about the same time when just one connection “slot” remains for the database, it is possible that both will fail. Also, the limit is not enforced against superusers or background worker processes.
+
 
 ## <a id="section6"></a>Examples 
 
@@ -74,13 +96,28 @@ To create a database `sales` owned by user `salesapp` with a default tablespace 
 CREATE DATABASE sales OWNER salesapp TABLESPACE salesspace;
 ```
 
-To create a database `music` which supports the ISO-8859-1 character set:
+To create a database `music` with a different locale:
 
 ```
-CREATE DATABASE music ENCODING 'LATIN1' TEMPLATE template0;
+CREATE DATABASE music
+    LC_COLLATE 'sv_SE.utf8' LC_CTYPE 'sv_SE.utf8'
+    TEMPLATE template0;
 ```
 
-In this example, the `TEMPLATE template0` clause would only be required if `template1`'s encoding is not ISO-8859-1. Note that changing encoding might require selecting new `LC_COLLATE` and `LC_CTYPE` settings as well.
+In this example, the `TEMPLATE template0` clause is required if the specialized locale is different from the one in `template1`. \(If it is not, then specifying the locale explicitly is redundant.\)
+
+To create a database `music2` with a different locale and a different character set encoding:
+
+```
+CREATE DATABASE music2
+    LC_COLLATE 'sv_SE.iso885915' LC_CTYPE 'sv_SE.iso885915'
+    ENCODING LATIN9
+    TEMPLATE template0;
+```
+
+The specified locale and encoding settings must match, or an error will be reported.
+
+Note that locale names are specific to the operating system, so that the above commands might not work in the same way everywhere.
 
 ## <a id="section7"></a>Compatibility 
 

--- a/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_DATABASE.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_DATABASE.html.md
@@ -54,7 +54,7 @@ allowconn
 :   If `false`, then no one can connect to this database. The default is `true`, allowing connections \(except as restricted by other mechanisms, such as `GRANT/REVOKE CONNECT`\).
 
 connlimit
-:   The maximum number of concurrent connections allowed to this database. The default is `-1`, no limit. Greenplum Database superusers are exempt from this limit.
+:   The maximum number of concurrent connections allowed to this database on the coordinator. The default is `-1`, no limit. Greenplum Database superusers are exempt from this limit.
 
 istemplate
 :   If `true`, then this database can be cloned by any user with `CREATEDB` privileges; if `false` \(the default\), then only superusers or the owner of the database can clone it. Note that template databases cannot be dropped.

--- a/gpdb-doc/markdown/ref_guide/sql_commands/DROP_DATABASE.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/DROP_DATABASE.html.md
@@ -26,7 +26,7 @@ name
 
 `DROP DATABASE` cannot be run inside a transaction block.
 
-This command cannot be run while connected to the target database. Thus, it might be more convenient to use the program `dropdb` instead, which is a wrapper around this command.
+This command cannot be run while connected to the target database. Thus, it might be more convenient to use the program [dropdb](../../utility_guide/ref/dropdb.html) instead, which is a wrapper around this command.
 
 ## <a id="section6"></a>Examples 
 


### PR DESCRIPTION
this PR updates the listed sql command reference pages to align with the postgres v12 ref page content. i don't believe there was any greenplum-specific content in the original (v6) pages.

doc review site link for ALTER DATABASE (behind vpn), can navigate to others from there:  https://docs-staging.vmware.com/en/draft/VMware-Tanzu-Greenplum/sqlref-db/greenplum-database/GUID-ref_guide-sql_commands-ALTER_DATABASE.html
