### PR TITLE
docs - update sql ref pages for ALTER DEFAULT PRIVS, GRANT, REVOKE

### DIFF
--- a/gpdb-doc/markdown/ref_guide/sql_commands/ALTER_DEFAULT_PRIVILEGES.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/ALTER_DEFAULT_PRIVILEGES.html.md
@@ -24,11 +24,15 @@ GRANT { { USAGE | SELECT | UPDATE }
     TO { [ GROUP ] <role_name> | PUBLIC } [, ...] [ WITH GRANT OPTION ]
 
 GRANT { EXECUTE | ALL [ PRIVILEGES ] }
-    ON FUNCTIONS
+    ON { FUNCTIONS | ROUTINES }
     TO { [ GROUP ] <role_name> | PUBLIC } [, ...] [ WITH GRANT OPTION ]
 
 GRANT { USAGE | ALL [ PRIVILEGES ] }
     ON TYPES
+    TO { [ GROUP ] <role_name> | PUBLIC } [, ...] [ WITH GRANT OPTION ]
+
+GRANT { USAGE | CREATE | ALL [ PRIVILEGES ] }
+    ON SCHEMAS
     TO { [ GROUP ] <role_name> | PUBLIC } [, ...] [ WITH GRANT OPTION ]
 
 REVOKE [ GRANT OPTION FOR ]
@@ -47,7 +51,7 @@ REVOKE [ GRANT OPTION FOR ]
 
 REVOKE [ GRANT OPTION FOR ]
     { EXECUTE | ALL [ PRIVILEGES ] }
-    ON FUNCTIONS
+    ON { FUNCTIONS | ROUTINES }
     FROM { [ GROUP ] <role_name> | PUBLIC } [, ...]
     [ CASCADE | RESTRICT ]
 
@@ -57,15 +61,23 @@ REVOKE [ GRANT OPTION FOR ]
     FROM { [ GROUP ] <role_name> | PUBLIC } [, ...]
     [ CASCADE | RESTRICT ]
 
+REVOKE [ GRANT OPTION FOR ]
+    { USAGE | CREATE | ALL [ PRIVILEGES ] }
+    ON SCHEMAS
+    FROM { [ GROUP ] <role_name> | PUBLIC } [, ...]
+    [ CASCADE | RESTRICT ]
+
 ```
 
 ## <a id="section3"></a>Description 
 
-`ALTER DEFAULT PRIVILEGES` allows you to set the privileges that will be applied to objects created in the future. \(It does not affect privileges assigned to already-existing objects.\) Currently, only the privileges for tables \(including views and foreign tables\), sequences, functions, and types \(including domains\) can be altered.
+`ALTER DEFAULT PRIVILEGES` allows you to set the privileges that will be applied to objects created in the future. \(It does not affect privileges assigned to already-existing objects.\) Currently, only the privileges for schemas, tables \(including views and foreign tables\), sequences, functions, and types \(including domains\) can be altered. For this command, functions include aggregates and procedures. The words `FUNCTIONS` and `ROUTINES` are equivalent in this command. \(`ROUTINES` is preferred going forward as the standard term for functions and procedures taken together. In earlier Greenplum Database releases, only the word `FUNCTIONS` was allowed. It is not possible to set default privileges for functions and procedures separately.\)
 
-You can change default privileges only for objects that will be created by yourself or by roles that you are a member of. The privileges can be set globally \(i.e., for all objects created in the current database\), or just for objects created in specified schemas. Default privileges that are specified per-schema are added to whatever the global default privileges are for the particular object type.
+You can change default privileges only for objects that will be created by yourself or by roles that you are a member of. The privileges can be set globally \(i.e., for all objects created in the current database\), or just for objects created in specified schemas.
 
 As explained under [GRANT](GRANT.html), the default privileges for any object type normally grant all grantable permissions to the object owner, and may grant some privileges to `PUBLIC` as well. However, this behavior can be changed by altering the global default privileges with `ALTER DEFAULT PRIVILEGES`.
+
+Default privileges that are specified per-schema are added to whatever the global default privileges are for the particular object type. This means you cannot revoke privileges per-schema if they are granted globally \(either by default, or according to a previous `ALTER DEFAULT PRIVILEGES` command that did not specify a schema\). Per-schema `REVOKE` is only useful to reverse the effects of a previous per-schema `GRANT`.
 
 ## <a id="parms"></a>Parameters 
 
@@ -73,7 +85,7 @@ target\_role
 :   The name of an existing role of which the current role is a member. If `FOR ROLE` is omitted, the current role is assumed.
 
 schema\_name
-:   The name of an existing schema. If specified, the default privileges are altered for objects later created in that schema. If `IN SCHEMA` is omitted, the global default privileges are altered.
+:   The name of an existing schema. If specified, the default privileges are altered for objects later created in that schema. If `IN SCHEMA` is omitted, the global default privileges are altered. `IN SCHEMA` is not allowed when setting privileges for schemas, since schemas can't be nested.
 
 role\_name
 :   The name of an existing role to grant or revoke privileges for. This parameter, and all the other parameters in abbreviated\_grant\_or\_revoke, act as described under [GRANT](GRANT.html) or [REVOKE](REVOKE.html), except that one is setting permissions for a whole class of objects rather than specific named objects.
@@ -89,28 +101,30 @@ If you wish to drop a role for which the default privileges have been altered, i
 Grant SELECT privilege to everyone for all tables \(and views\) you subsequently create in schema `myschema`, and allow role `webuser` to INSERT into them too:
 
 ```
-
 ALTER DEFAULT PRIVILEGES IN SCHEMA myschema GRANT SELECT ON TABLES TO PUBLIC;
 ALTER DEFAULT PRIVILEGES IN SCHEMA myschema GRANT INSERT ON TABLES TO webuser;
-
 ```
 
 Undo the above, so that subsequently-created tables won't have any more permissions than normal:
 
 ```
-
 ALTER DEFAULT PRIVILEGES IN SCHEMA myschema REVOKE SELECT ON TABLES FROM PUBLIC;
 ALTER DEFAULT PRIVILEGES IN SCHEMA myschema REVOKE INSERT ON TABLES FROM webuser;
-
 ```
 
 Remove the public EXECUTE permission that is normally granted on functions, for all functions subsequently created by role `admin`:
 
 ```
-
 ALTER DEFAULT PRIVILEGES FOR ROLE admin REVOKE EXECUTE ON FUNCTIONS FROM PUBLIC;
+```
+
+Note however that you *cannot* accomplish that effect with a command limited to a single schema. The following command has no effect, unless it is undoing a matching `GRANT`:
 
 ```
+ALTER DEFAULT PRIVILEGES IN SCHEMA public REVOKE EXECUTE ON FUNCTIONS FROM PUBLIC;
+```
+
+That's because per-schema default privileges can only add privileges to the global setting, not remove privileges granted by it.
 
 ## <a id="compat"></a>Compatibility 
 

--- a/gpdb-doc/markdown/ref_guide/sql_commands/GRANT.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/GRANT.html.md
@@ -104,6 +104,7 @@ The possible privileges are:
 - `CONNECT`
 - `TEMPORARY`, `TEMP`
 - `EXECUTE`
+- `USAGE`
 - `ALL PRIVILEGES`
 
 The `FUNCTION` syntax works for plain functions, aggregate functions, and window functions, but not for procedures; use `PROCEDURE` for those. Alternatively, use `ROUTINE` to refer to a function, aggregate function, window function, or procedure regardless of its precise type.

--- a/gpdb-doc/markdown/ref_guide/sql_commands/GRANT.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/GRANT.html.md
@@ -9,76 +9,79 @@ GRANT { {SELECT | INSERT | UPDATE | DELETE | REFERENCES |
 TRIGGER | TRUNCATE } [, ...] | ALL [PRIVILEGES] }
     ON { [TABLE] <table_name> [, ...]
          | ALL TABLES IN SCHEMA <schema_name> [, ...] }
-    TO { [ GROUP ] <role_name> | PUBLIC} [, ...] [ WITH GRANT OPTION ] 
+    TO <role_specification> [, ...] [ WITH GRANT OPTION ]
 
 GRANT { { SELECT | INSERT | UPDATE | REFERENCES } ( <column_name> [, ...] )
     [, ...] | ALL [ PRIVILEGES ] ( <column_name> [, ...] ) }
     ON [ TABLE ] <table_name> [, ...]
-    TO { <role_name> | PUBLIC } [, ...] [ WITH GRANT OPTION ]
+    TO <role_specification> [, ...] [ WITH GRANT OPTION ]
 
 GRANT { {USAGE | SELECT | UPDATE} [, ...] | ALL [PRIVILEGES] }
     ON { SEQUENCE <sequence_name> [, ...]
          | ALL SEQUENCES IN SCHEMA <schema_name> [, ...] }
-    TO { [ GROUP ] <role_name> | PUBLIC } [, ...] [ WITH GRANT OPTION ] 
+    TO <role_specification> [, ...] [ WITH GRANT OPTION ]
 
 GRANT { {CREATE | CONNECT | TEMPORARY | TEMP} [, ...] | ALL 
 [PRIVILEGES] }
     ON DATABASE <database_name> [, ...]
-    TO { [ GROUP ] <role_name> | PUBLIC } [, ...] [ WITH GRANT OPTION ]
+    TO <role_specification> [, ...] [ WITH GRANT OPTION ]
 
 GRANT { USAGE | ALL [ PRIVILEGES ] }
     ON DOMAIN <domain_name> [, ...]
-    TO { [ GROUP ] <role_name> | PUBLIC } [, ...] [ WITH GRANT OPTION ]
+    TO <role_specification> [, ...] [ WITH GRANT OPTION ]
 
 GRANT { USAGE | ALL [ PRIVILEGES ] }
     ON FOREIGN DATA WRAPPER <fdw_name> [, ...]
-    TO { [ GROUP ] <role_name> | PUBLIC } [, ...] [ WITH GRANT OPTION ]
+    TO <role_specification> [, ...] [ WITH GRANT OPTION ]
 
 GRANT { USAGE | ALL [ PRIVILEGES ] }
     ON FOREIGN SERVER <server_name> [, ...]
-    TO { [ GROUP ] <role_name> | PUBLIC } [, ...] [ WITH GRANT OPTION ]
+    TO <role_specification> [, ...] [ WITH GRANT OPTION ]
 
 GRANT { EXECUTE | ALL [PRIVILEGES] }
-    ON { FUNCTION <function_name> ( [ [ <argmode> ] [ <argname> ] <argtype> [, ...] 
-] ) [, ...]
-        | ALL FUNCTIONS IN SCHEMA <schema_name> [, ...] }
-    TO { [ GROUP ] <role_name> | PUBLIC } [, ...] [ WITH GRANT OPTION ]
+    ON { { FUNCTION | PROCEDURE | ROUTINE } <routine_name> [ ( [ [ <argmode> ] [ <argname> ] <argtype> [, ...] ] ) ] [, ...]
+        | ALL { FUNCTIONS | PROCEDURES | ROUTINES }  IN SCHEMA <schema_name> [, ...] }
+    TO <role_specification> [, ...] [ WITH GRANT OPTION ]
 
 GRANT { USAGE | ALL [PRIVILEGES] }
     ON LANGUAGE <lang_name> [, ...]
-    TO { [ GROUP ] <role_name> | PUBLIC } [, ...] [ WITH GRANT OPTION ]
+    TO <role_specification> [, ...] [ WITH GRANT OPTION ]
 
 GRANT { { CREATE | USAGE } [, ...] | ALL [PRIVILEGES] }
     ON SCHEMA <schema_name> [, ...]
-    TO { [ GROUP ] <role_name> | PUBLIC}  [, ...] [ WITH GRANT OPTION ]
+    TO <role_specification> [, ...] [ WITH GRANT OPTION ]
 
 GRANT { CREATE | ALL [PRIVILEGES] }
     ON TABLESPACE <tablespace_name> [, ...]
-    TO { [ GROUP ] <role_name> | PUBLIC } [, ...] [ WITH GRANT OPTION ]
+    TO <role_specification> [ WITH GRANT OPTION ]
 
 GRANT { USAGE | ALL [ PRIVILEGES ] }
     ON TYPE <type_name> [, ...]
-    TO { [ GROUP ] <role_name> | PUBLIC } [, ...] [ WITH GRANT OPTION ]
+    TO <role_specification> [, ...] [ WITH GRANT OPTION ]
 
-GRANT <parent_role> [, ...] 
-    TO <member_role> [, ...] [WITH ADMIN OPTION]
+GRANT <role_name> [, ...] TO <role_specification> [, ...]
+    [ WITH ADMIN OPTION ]
+    [ GRANTED BY <role_specification> ]
 
 GRANT { SELECT | INSERT | ALL [PRIVILEGES] } 
     ON PROTOCOL <protocolname>
     TO <username>
+
+where <role_specification> can be:
+
+    [ GROUP ] <role_name>
+  | PUBLIC
+  | CURRENT_USER
+  | SESSION_USER
 ```
 
 ## <a id="section3"></a>Description 
 
-Greenplum Database unifies the concepts of users and groups into a single kind of entity called a role. It is therefore not necessary to use the keyword `GROUP` to identify whether a grantee is a user or a group. `GROUP` is still allowed in the command, but it is a noise word.
-
-The `GRANT` command has two basic variants: one that grants privileges on a database object \(table, column, view, foreign table, sequence, database, foreign-data wrapper, foreign server, function, procedural language, schema, or tablespace\), and one that grants membership in a role.
+The `GRANT` command has two basic variants: one that grants privileges on a database object \(table, column, view, foreign table, sequence, database, foreign-data wrapper, foreign server, function, procedural language, schema, or tablespace\), and one that grants membership in a role. These variants are similar in many ways, but they are different enough to be described separately.
 
 **GRANT on Database Objects**
 
 This variant of the `GRANT` command gives specific privileges on a database object to one or more roles. These privileges are added to those already granted, if any.
-
-There is also an option to grant privileges on all objects of the same type within one or more schemas. This functionality is currently supported only for tables, sequences, and functions \(but note that `ALL TABLES` is considered to include views and foreign tables\).
 
 The keyword `PUBLIC` indicates that the privileges are to be granted to all roles, including those that may be created later. `PUBLIC` may be thought of as an implicitly defined group-level role that always includes all roles. Any particular role will have the sum of privileges granted directly to it, privileges granted to any role it is presently a member of, and privileges granted to `PUBLIC`.
 
@@ -88,13 +91,24 @@ There is no need to grant privileges to the owner of an object \(usually the rol
 
 The right to drop an object, or to alter its definition in any way is not treated as a grantable privilege; it is inherent in the owner, and cannot be granted or revoked. \(However, a similar effect can be obtained by granting or revoking membership in the role that owns the object; see below.\) The owner implicitly has all grant options for the object, too.
 
-Greenplum Database grants default privileges on some types of objects to `PUBLIC`. No privileges are granted to `PUBLIC` by default on tables, table columns, sequences, foreign-data wrappers, foreign servers, large objects, schemas, or tablespaces. For other types of objects, the default privileges granted to `PUBLIC` are as follows:
+The possible privileges are:
 
--   `CONNECT` and `TEMPORARY` \(create temporary tables\) privileges for databases,
--   `EXECUTE` privilege for functions, and
--   `USAGE` privilege for languages and data types \(including domains\).
+- `SELECT`
+- `INSERT`
+- `UPDATE`
+- `DELETE`
+- `TRUNCATE`
+- `REFERENCES`
+- `TRIGGER`
+- `CREATE`
+- `CONNECT`
+- `TEMPORARY`, `TEMP`
+- `EXECUTE`
+- `ALL PRIVILEGES`
 
-The object owner can, of course, `REVOKE` both default and expressly granted privileges. \(For maximum security, issue the `REVOKE` in the same transaction that creates the object; then there is no window in which another user can use the object.\)
+The `FUNCTION` syntax works for plain functions, aggregate functions, and window functions, but not for procedures; use `PROCEDURE` for those. Alternatively, use `ROUTINE` to refer to a function, aggregate function, window function, or procedure regardless of its precise type.
+
+There is also an option to grant privileges on all objects of the same type within one or more schemas. This functionality is currently supported only for tables, sequences, functions, and procedures. `ALL TABLES` also affects views and foreign tables, just like the specific-object `GRANT` command. `ALL FUNCTIONS` also affects aggregate and window functions, but not procedures, again just like the specific-object `GRANT` command. Use `ALL ROUTINES` to include procedures.
 
 **GRANT on Roles**
 
@@ -102,7 +116,9 @@ This variant of the `GRANT` command grants membership in a role to one or more o
 
 If `WITH ADMIN OPTION` is specified, the member may in turn grant membership in the role to others, and revoke membership in the role as well. Without the admin option, ordinary users cannot do that. A role is not considered to hold `WITH ADMIN OPTION` on itself, but it may grant or revoke membership in itself from a database session where the session user matches the role. Database superusers can grant or revoke membership in any role to anyone. Roles having `CREATEROLE` privilege can grant or revoke membership in any role that is not a superuser.
 
-Unlike the case with privileges, membership in a role cannot be granted to `PUBLIC`.
+If `GRANTED BY` is specified, the grant is recorded as having been done by the specified role. Only database superusers may use this option, except when it names the same role executing the command.
+
+Unlike the case with privileges, membership in a role cannot be granted to `PUBLIC`. Note also that this form of the command does not allow the noise word `GROUP` in role\_specification.
 
 **GRANT on Protocols**
 
@@ -198,13 +214,21 @@ WITH ADMIN OPTION
 
 ## <a id="section8"></a>Notes 
 
+The [REVOKE](REVOKE.html) command is used to revoke access privileges.
+
+Greenplum Database unifies the concepts of users and groups into a single kind of entity called a role. It is therefore not necessary to use the keyword `GROUP` to identify whether a grantee is a user or a group. `GROUP` is still allowed in the command, but it is a noise word.
+
 A user may perform `SELECT`, `INSERT`, and so forth, on a column if they hold that privilege for either the specific column or the whole table. Granting the privilege at the table level and then revoking it for one column does not do what you might wish: the table-level grant is unaffected by a column-level operation.
 
-Database superusers can access all objects regardless of object privilege settings. One exception to this rule is view objects. Access to tables referenced in the view is determined by permissions of the view owner not the current user \(even if the current user is a superuser\).
+When a non-owner of an object attempts to `GRANT` privileges on the object, the command will fail outright if the user has no privileges whatsoever on the object. As long as some privilege is available, the command will proceed, but it will grant only those privileges for which the user has grant options. The `GRANT ALL PRIVILEGES` forms will issue a warning message if no grant options are held, while the other forms will issue a warning if grant options for any of the privileges specifically named in the command are not held. \(In principle these statements apply to the object owner as well, but since the owner is always treated as holding all grant options, the cases can never occur.\)
 
-If a superuser chooses to issue a `GRANT` or `REVOKE` command, the command is performed as though it were issued by the owner of the affected object. In particular, privileges granted via such a command will appear to have been granted by the object owner. For role membership, the membership appears to have been granted by the containing role itself.
+Database superusers can access all objects regardless of object privilege settings. This is comparable to the rights of `root` in a Unix system. As with `root`, it's unwise to operate as a superuser except when absolutely necessary. One exception to this rule is view objects. Access to tables referenced in the view is determined by permissions of the view owner not the current user \(even if the current user is a superuser\).
 
-`GRANT` and `REVOKE` can also be done by a role that is not the owner of the affected object, but is a member of the role that owns the object, or is a member of a role that holds privileges `WITH GRANT OPTION` on the object. In this case the privileges will be recorded as having been granted by the role that actually owns the object or holds the privileges `WITH GRANT OPTION`.
+If a superuser chooses to issue a `GRANT` or `REVOKE` command, the command is performed as though it were issued by the owner of the affected object. In particular, privileges granted via such a command will appear to have been granted by the object owner. \(For role membership, the membership appears to have been granted by the containing role itself.\)
+
+`GRANT` and `REVOKE` can also be done by a role that is not the owner of the affected object, but is a member of the role that owns the object, or is a member of a role that holds privileges `WITH GRANT OPTION` on the object. In this case the privileges will be recorded as having been granted by the role that actually owns the object or holds the privileges `WITH GRANT OPTION`. For example, if table `t1` is owned by role `g1`, of which role `u1` is a member, then `u1` can grant privileges on `t1` to `u2`, but those privileges will appear to have been granted directly by `g1`. Any other member of role `g1` could revoke them later.
+
+If the role executing `GRANT` holds the required privileges indirectly via more than one role membership path, it is unspecified which containing role will be recorded as having done the grant. In such cases it is best practice to use `SET ROLE` to become the specific role you want to do the `GRANT` as.
 
 Granting permission on a table does not automatically extend permissions to any sequences used by the table, including sequences tied to `SERIAL` columns. Permissions on a sequence must be set separately.
 
@@ -220,11 +244,13 @@ Grant insert privilege to all roles on table `mytable`:
 GRANT INSERT ON mytable TO PUBLIC;
 ```
 
-Grant all available privileges to role `sally` on the view `topten`. Note that while the above will indeed grant all privileges if run by a superuser or the owner of `topten`, when run by someone else it will only grant those permissions for which the granting role has grant options.
+Grant all available privileges to user `manuel` on view `kinds`:
 
 ```
-GRANT ALL PRIVILEGES ON topten TO sally;
+GRANT ALL PRIVILEGES ON kinds TO manuel;
 ```
+
+Note that while the above will indeed grant all privileges if run by a superuser or the owner of `kinds`, when run by someone else it will only grant those permissions for which the granting role has grant options.
 
 Grant membership in role `admins` to user `joe`:
 
@@ -234,19 +260,21 @@ GRANT admins TO joe;
 
 ## <a id="section10"></a>Compatibility 
 
-The `PRIVILEGES` key word is required in the SQL standard, but optional in Greenplum Database. The SQL standard does not support setting the privileges on more than one object per command.
+According to the SQL standard, the `PRIVILEGES` key word in `ALL PRIVILEGES` is required, but it is optional in Greenplum Database. The SQL standard does not support setting the privileges on more than one object per command.
 
-Greenplum Database allows an object owner to revoke their own ordinary privileges: for example, a table owner can make the table read-only to theirself by revoking their own `INSERT`, `UPDATE`, `DELETE`, and `TRUNCATE` privileges. This is not possible according to the SQL standard. Greenplum Database treats the owner's privileges as having been granted by the owner to the owner; therefore they can revoke them too. In the SQL standard, the owner's privileges are granted by an assumed *system* entity.
+Greenplum Database allows an object owner to revoke their own ordinary privileges: for example, a table owner can make the table read-only to theirself by revoking their own `INSERT`, `UPDATE`, `DELETE`, and `TRUNCATE` privileges. This is not possible according to the SQL standard. Greenplum Database treats the owner's privileges as having been granted by the owner to the owner; therefore they can revoke them too. In the SQL standard, the owner's privileges are granted by an assumed *system* entity. Not being *system*, the owner cannot revoke these rights.
+
+The SQL standard allows the `GRANTED BY` option to be used in all forms of `GRANT`. Greenplum Database only supports it when granting role membership, and even then only superusers may use it in nontrivial ways.
 
 The SQL standard provides for a `USAGE` privilege on other kinds of objects: character sets, collations, translations.
 
-In the SQL standard, sequences only have a `USAGE` privilege, which controls the use of the `NEXT VALUE FOR` expression, which is equivalent to the function `nextval` in Greenplum Database. The sequence privileges `SELECT` and `UPDATE` are Greenplum Database extensions. The application of the sequence `USAGE` privilege to the `currval` function is also a Greenplum Database extension \(as is the function itself\).
+In the SQL standard, sequences only have a `USAGE` privilege, which controls the use of the `NEXT VALUE FOR` expression, which is equivalent to the function `nextval()` in Greenplum Database. The sequence privileges `SELECT` and `UPDATE` are Greenplum Database extensions. The application of the sequence `USAGE` privilege to the `currval()` function is also a Greenplum Database extension \(as is the function itself\).
 
 Privileges on databases, tablespaces, schemas, and languages are Greenplum Database extensions.
 
 ## <a id="section11"></a>See Also 
 
-[REVOKE](REVOKE.html), [CREATE ROLE](CREATE_ROLE.html), [ALTER ROLE](ALTER_ROLE.html)
+[ALTER DEFAULT PRIVILEGES](ALTER_DEFAULT_PRIVILEGES.html), [REVOKE](REVOKE.html)
 
 **Parent topic:** [SQL Commands](../sql_commands/sql_ref.html)
 

--- a/gpdb-doc/markdown/ref_guide/sql_commands/REVOKE.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/REVOKE.html.md
@@ -5,85 +5,90 @@ Removes access privileges.
 ## <a id="section2"></a>Synopsis 
 
 ``` {#sql_command_synopsis}
-REVOKE [GRANT OPTION FOR] { {SELECT | INSERT | UPDATE | DELETE 
-       | REFERENCES | TRIGGER | TRUNCATE } [, ...] | ALL [PRIVILEGES] }
-
-       ON { [TABLE] <table_name> [, ...]
-            | ALL TABLES IN SCHEMA schema_name [, ...] }
-       FROM { [ GROUP ] <role_name> | PUBLIC} [, ...]
+REVOKE [GRANT OPTION FOR]
+       { {SELECT | INSERT | UPDATE | DELETE | REFERENCES | TRIGGER | TRUNCATE }
+       [, ...] | ALL [PRIVILEGES] }
+       ON { [TABLE] <table_name> [, ...]
+          | ALL TABLES IN SCHEMA schema_name [, ...] }
+       FROM <role_specification> [, ...]
        [CASCADE | RESTRICT]
 
-REVOKE [ GRANT OPTION FOR ] { { SELECT | INSERT | UPDATE 
-       | REFERENCES } ( <column_name> [, ...] )
+REVOKE [ GRANT OPTION FOR ]
+       { { SELECT | INSERT | UPDATE | REFERENCES } ( <column_name> [, ...] )
        [, ...] | ALL [ PRIVILEGES ] ( <column_name> [, ...] ) }
        ON [ TABLE ] <table_name> [, ...]
-       FROM { [ GROUP ]  <role_name> | PUBLIC } [, ...]
+       FROM <role_specification> [, ...]
        [ CASCADE | RESTRICT ]
 
 REVOKE [GRANT OPTION FOR] { {USAGE | SELECT | UPDATE} [,...] 
        | ALL [PRIVILEGES] }
        ON { SEQUENCE <sequence_name> [, ...]
             | ALL SEQUENCES IN SCHEMA schema_name [, ...] }
-       FROM { [ GROUP ] <role_name> | PUBLIC } [, ...]
+       FROM <role_specification> [, ...]
        [CASCADE | RESTRICT]
 
-REVOKE [GRANT OPTION FOR] { {CREATE | CONNECT 
-       | TEMPORARY | TEMP} [, ...] | ALL [PRIVILEGES] }
+REVOKE [GRANT OPTION FOR]
+       { {CREATE | CONNECT | TEMPORARY | TEMP} [, ...] | ALL [PRIVILEGES] }
        ON DATABASE <database_name> [, ...]
-       FROM { [ GROUP ] <role_name> | PUBLIC} [, ...]
+       FROM <role_specification> [, ...]
        [CASCADE | RESTRICT]
 
 REVOKE [ GRANT OPTION FOR ]
        { USAGE | ALL [ PRIVILEGES ] }
        ON DOMAIN <domain_name> [, ...]
-       FROM { [ GROUP ] <role_name> | PUBLIC } [, ...]
+       FROM <role_specification> [, ...]
        [ CASCADE | RESTRICT ]
-
 
 REVOKE [ GRANT OPTION FOR ]
        { USAGE | ALL [ PRIVILEGES ] }
        ON FOREIGN DATA WRAPPER <fdw_name> [, ...]
-       FROM { [ GROUP ] <role_name> | PUBLIC } [, ...]
+       FROM <role_specification> [, ...]
        [ CASCADE | RESTRICT ]
 
 REVOKE [ GRANT OPTION FOR ]
        { USAGE | ALL [ PRIVILEGES ] }
        ON FOREIGN SERVER <server_name> [, ...]
-       FROM { [ GROUP ] <role_name> | PUBLIC } [, ...]
+       FROM <role_specification> [, ...]
        [ CASCADE | RESTRICT ]
 
 REVOKE [GRANT OPTION FOR] {EXECUTE | ALL [PRIVILEGES]}
-       ON { FUNCTION <funcname> ( [[<argmode>] [<argname>] <argtype>
-                              [, ...]] ) [, ...]
-            | ALL FUNCTIONS IN SCHEMA schema_name [, ...] }
-       FROM { [ GROUP ] <role_name> | PUBLIC} [, ...]
+       ON { { FUNCTION | PROCEDURE | ROUTINE }  <funcname> [( [[<argmode>] [<argname>] <argtype> [, ...]] )] [, ...]
+            | ALL { FUNCTIONS | PROCEDURES | ROUTINES } IN SCHEMA schema_name [, ...] }
+       FROM <role_specification> [, ...]
        [CASCADE | RESTRICT]
 
 REVOKE [GRANT OPTION FOR] {USAGE | ALL [PRIVILEGES]}
-       ON LANGUAGE <langname> [, ...]
-       FROM { [ GROUP ]  <role_name> | PUBLIC} [, ...]
+       ON LANGUAGE <lang_name> [, ...]
+       FROM <role_specification> [, ...]
        [ CASCADE | RESTRICT ]
 
-REVOKE [GRANT OPTION FOR] { {CREATE | USAGE} [, ...] 
-       | ALL [PRIVILEGES] }
+REVOKE [GRANT OPTION FOR] { {CREATE | USAGE} [, ...] | ALL [PRIVILEGES] }
        ON SCHEMA <schema_name> [, ...]
-       FROM { [ GROUP ] <role_name> | PUBLIC} [, ...]
+       FROM <role_specification> [, ...]
        [CASCADE | RESTRICT]
 
 REVOKE [GRANT OPTION FOR] { CREATE | ALL [PRIVILEGES] }
-       ON TABLESPACE <tablespacename> [, ...]
-       FROM { [ GROUP ] <role_name> | PUBLIC } [, ...]
+       ON TABLESPACE <tablespace_name> [, ...]
+       FROM <role_specification> [, ...]
        [CASCADE | RESTRICT]
 
 REVOKE [ GRANT OPTION FOR ]
        { USAGE | ALL [ PRIVILEGES ] }
        ON TYPE <type_name> [, ...]
-       FROM { [ GROUP ] <role_name> | PUBLIC } [, ...]
+       FROM <role_specification> [, ...]
        [ CASCADE | RESTRICT ] 
 
-REVOKE [ADMIN OPTION FOR] <parent_role> [, ...] 
-       FROM [ GROUP ] <member_role> [, ...]
+REVOKE [ADMIN OPTION FOR] <role_name> [, ...]
+       FROM [ GROUP ] <role_specification> [, ...]
+       [GRANTED BY <role_specification> ]
        [CASCADE | RESTRICT]
+
+where <role_specification> can be:
+
+    [ GROUP ] <role_name>
+  | PUBLIC
+  | CURRENT_USER
+  | SESSION_USER
 ```
 
 ## <a id="section3"></a>Description 
@@ -100,7 +105,7 @@ If a role holds a privilege with grant option and has granted it to other roles 
 
 When you revoke privileges on a table, Greenplum Database revokes the corresponding column privileges \(if any\) on each column of the table, as well. On the other hand, if a role has been granted privileges on a table, then revoking the same privileges from individual columns will have no effect.
 
-When revoking membership in a role, `GRANT OPTION` is instead called `ADMIN OPTION`, but the behavior is similar.
+When revoking membership in a role, `GRANT OPTION` is instead called `ADMIN OPTION`, but the behavior is similar. This form of the command also allows a `GRANTED BY` option, but that option is currently ignored \(except for checking the existence of the named role\). Note also that this form of the command does not allow the noise word `GROUP` in role\_specification.
 
 ## <a id="section4a"></a>Parameters 
 
@@ -128,10 +133,10 @@ Revoke insert privilege for the public on table `films`:
 REVOKE INSERT ON films FROM PUBLIC;
 ```
 
-Revoke all privileges from role `sally` on view `topten`. Note that this actually means revoke all privileges that the current role granted \(if not a superuser\).
+Revoke all privileges from user `manuel` on view `kinds`. Note that this actually means revoke all privileges that the current role granted \(if not a superuser\).
 
 ```
-REVOKE ALL PRIVILEGES ON topten FROM sally;
+REVOKE ALL PRIVILEGES ON kinds FROM manuel;
 ```
 
 Revoke membership in role `admins` from user `joe`:
@@ -148,7 +153,7 @@ Either `RESTRICT` or `CASCADE` is required according to the standard, but Greenp
 
 ## <a id="section7"></a>See Also 
 
-[GRANT](GRANT.html)
+[ALTER DEFAULT PRIVILEGES](ALTER_DEFAULT_PRIVILEGES.html), [GRANT](GRANT.html)
 
 **Parent topic:** [SQL Commands](../sql_commands/sql_ref.html)
 


### PR DESCRIPTION
this PR updates the listed sql command reference pages to align with the postgres v12 ref page content. i don't believe there was any greenplum-specific content in the original (v6) pages.

doc review site link for ALTER DEFAULT PRIVILEGES (behind vpn), can navigate to others from there:  https://docs-staging.vmware.com/en/draft/VMware-Tanzu-Greenplum/sqlref-privs/greenplum-database/GUID-ref_guide-sql_commands-ALTER_DEFAULT_PRIVILEGES.html