### PR TITLE
[6X] Dump number of segments during minirepro and gpsd (#14225)

### DIFF
--- a/gpMgmt/bin/gpsd
+++ b/gpMgmt/bin/gpsd
@@ -34,10 +34,19 @@ def ResultIter(cursor, arraysize=1000):
 def getVersion(envOpts):
     cmd = subprocess.Popen('psql --pset footer -Atqc "select version()" template1', shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=envOpts)
     if cmd.wait() is not 0:
-        sys.stderr.write('\nError while trying to find HAWQ/GPDB version.\n\n' + cmd.communicate()[1] + '\n\n')
+        sys.stderr.write('\nError while trying to find GPDB version.\n\n' + cmd.communicate()[1] + '\n\n')
         sys.exit(1)
     return cmd.communicate()[0]
 
+def get_num_segments(cursor):
+    query = "select count(*) from gp_segment_configuration where role='p' and content >=0;"
+    try:
+        cursor.execute(query)
+    except pgdb.DatabaseError as e:
+        sys.stderr.write('\nError while trying to retrieve number of segments.\n\n' + str(e) + '\n\n')
+        sys.exit(1)
+    vals = cursor.fetchone()
+    return vals[0]
 
 def dumpSchema(connectionInfo, envOpts):
     dmp_cmd = 'pg_dump -h %s -p %s -U %s -s -x --gp-syntax -O %s' % connectionInfo
@@ -223,9 +232,15 @@ def main():
     connectionInfo = (host, port, user, db)
     connectionString = ':'.join([host, port, db, user, '', pgoptions, ''])
 
+    num_segments = 0
+    with closing(pgdb.connect(connectionString)) as connection:
+        with closing(connection.cursor()) as cursor:
+            num_segments = get_num_segments(cursor)
+
     sys.stdout.writelines(['\n-- Greenplum database Statistics Dump',
                            '\n-- Copyright (C) 2007 - 2014 Pivotal'
                            '\n-- Database: ' + db,
+                           '\n-- Num Segments: ' + str(num_segments),
                            '\n-- Date:     ' + timestamp.date().isoformat(),
                            '\n-- Time:     ' + timestamp.time().isoformat(),
                            '\n-- CmdLine:  ' + ' '.join(sys.argv),
@@ -249,6 +264,8 @@ def main():
                            '\n-- Allow system table modifications',
                            '\n-- ',
                            '\nset allow_system_table_mods=true;\n\n'])
+    # turn off optimizer when loading stats. Orca adds a bit of overhead, but it's significant when small insrt queries take 1 vs .1ms
+    sys.stdout.writelines('set optimizer to off;\n\n')
     sys.stdout.flush()
 
     try:

--- a/gpMgmt/bin/minirepro
+++ b/gpMgmt/bin/minirepro
@@ -97,11 +97,21 @@ def get_server_version(cursor):
     query = "select version()"
     try:
         cursor.execute(query)
-        vals = cursor.fetchone()
-        return vals[0]
     except pgdb.DatabaseError as e:
-        sys.stderr.write('\nError while trying to find HAWQ/GPDB version.\n\n' + str(e) + '\n\n')
+        sys.stderr.write('\nError while trying to find GPDB version.\n\n' + str(e) + '\n\n')
         sys.exit(1)
+    vals = cursor.fetchone()
+    return vals[0]
+
+def get_num_segments(cursor):
+    query = "select count(*) from gp_segment_configuration where role='p' and content >=0;"
+    try:
+        cursor.execute(query)
+    except pgdb.DatabaseError as e:
+        sys.stderr.write('\nError while trying to retrieve number of segments.\n\n' + str(e) + '\n\n')
+        sys.exit(1)
+    vals = cursor.fetchone()
+    return vals[0]
 
 def parse_cmd_line():
     p = OptionParser(usage='Usage: %prog <database> [options]', version='%prog '+version, conflict_handler="resolve", epilog="WARNING: This tool collects statistics about your data, including most common values, which requires some data elements to be included in the output file. Please review output file to ensure it is within corporate policy to transport the output file.")
@@ -358,6 +368,8 @@ def main():
     # get server version, which is dumped to minirepro output file
     server_ver = get_server_version(cursor)
 
+    num_segments = get_num_segments(cursor)
+
     """
     invoke gp_toolkit UDF, dump object oids as json text
     input: query file name
@@ -392,6 +404,8 @@ def main():
 
     # make sure we connect with the right database
     f_out.writelines('\\connect ' + db + '\n\n')
+    # turn off optimizer when loading stats. Orca adds a bit of overhead, but it's significant when small insrt queries take 1 vs .1ms
+    f_out.writelines('set optimizer to off;\n\n')
 
     # first create schema DDLs
     print "Writing schema DDLs ..."
@@ -425,7 +439,8 @@ def main():
     f_out.writelines(['\n-- ',
                        '\n-- Query text',
                        '\n-- \n\n'])
-
+    line = 'set optimizer_segments = ' + str(num_segments) + ';'
+    f_out.writelines('\n-- ' + line + '\n')
     with open(query_file, 'r') as query_f:
         for line in query_f:
             f_out.writelines('-- ' + line)

--- a/src/test/regress/expected/minirepro.out
+++ b/src/test/regress/expected/minirepro.out
@@ -33,6 +33,7 @@ SET
 SET
 SET
 SET
+SET
  set_config 
 ------------
  


### PR DESCRIPTION
This commit includes a couple improvements when dumping minirepros and gpsd:

1. Dump the number of segments. This is needed to replicate the plan, and often we have to ask users/customers this separately. Instead just retrieve it during the minirepro
2. Output a `set optimizer=off` for when the minirepro is being restored. The short insert statements are much faster (~10X) using planner than Orca, especially if done in debug buiild. Output this by default so I don't have to modify this manually.

(cherry picked from commit 40b2d540928f1f5ad12b588eb74dafde13eea86e)

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
