### PR TITLE
Alter column encoding for AOCO tables

### DIFF
--- a/src/backend/catalog/pg_attribute_encoding.c
+++ b/src/backend/catalog/pg_attribute_encoding.c
@@ -255,10 +255,6 @@ AddRelationAttributeEncodings(Relation rel, List *attr_encodings)
 	Oid relid = RelationGetRelid(rel);
 	ListCell *lc;
 
-	/* No pg_attribute_encoding entries for partition root. */
-	if (rel->rd_rel->relkind == RELKIND_PARTITIONED_TABLE)
-		return;
-
 	foreach(lc, attr_encodings)
 	{
 		Datum attoptions;

--- a/src/backend/commands/matview.c
+++ b/src/backend/commands/matview.c
@@ -334,7 +334,7 @@ ExecRefreshMatView(RefreshMatViewStmt *stmt, const char *queryString,
 	 * it against access by any other process until commit (by which time it
 	 * will be gone).
 	 */
-	OIDNewHeap = make_new_heap(matviewOid, tableSpace, matviewRel->rd_rel->relam, relpersistence,
+	OIDNewHeap = make_new_heap(matviewOid, tableSpace, matviewRel->rd_rel->relam, NULL, relpersistence,
 							   ExclusiveLock, false, true);
 	LockRelationOid(OIDNewHeap, AccessExclusiveLock);
 	dest = CreateTransientRelDestReceiver(OIDNewHeap, matviewOid, concurrent, relpersistence,
@@ -576,7 +576,7 @@ transientrel_init(QueryDesc *queryDesc)
 	 * will be gone).
 	 */
 	OIDNewHeap = make_new_heap(matviewOid, tableSpace, matviewRel->rd_rel->relam,
-							   relpersistence,
+							   NULL, relpersistence,
 							   ExclusiveLock, false, false);
 	LockRelationOid(OIDNewHeap, AccessExclusiveLock);
 

--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -2912,6 +2912,18 @@ alter_table_cmd:
 					n->def = (Node *) makeInteger($6);
 					$$ = (Node *)n;
 				}
+			/* ALTER TABLE <name> ALTER COLUMN <column> SET ENCODING <coldef> */
+			| ALTER opt_column ColId SET ENCODING definition
+				{
+					ColumnReferenceStorageDirective *c =
+						makeNode(ColumnReferenceStorageDirective);
+					c->column = $3;
+					c->encoding = $6;
+					AlterTableCmd *n = makeNode(AlterTableCmd);
+					n->subtype = AT_SetColumnEncoding;
+					n->def = (Node *)c;
+					$$ = (Node *)n;
+				}
 			/* ALTER TABLE <name> ALTER [COLUMN] <colname> SET ( column_parameter = value [, ... ] ) */
 			| ALTER opt_column ColId SET reloptions
 				{

--- a/src/bin/psql/describe.c
+++ b/src/bin/psql/describe.c
@@ -2190,8 +2190,7 @@ describeOneTableDetails(const char *schemaname,
 			attstattarget_col = cols++;
 		}
 
-		if (greenplum_is_ao_column(tableinfo.relstorage, tableinfo.relam) &&
-				tableinfo.relkind != RELKIND_PARTITIONED_TABLE)
+		if (greenplum_is_ao_column(tableinfo.relstorage, tableinfo.relam))
 		{
 			if (isGE42 == true)
 			{
@@ -2334,8 +2333,7 @@ describeOneTableDetails(const char *schemaname,
 	if (attstattarget_col >= 0)
 		headers[cols++] = gettext_noop("Stats target");
 
-	if (verbose && greenplum_is_ao_column(tableinfo.relstorage, tableinfo.relam) && 
-			tableinfo.relkind != RELKIND_PARTITIONED_TABLE)
+	if (verbose && greenplum_is_ao_column(tableinfo.relstorage, tableinfo.relam))
 	{
 		headers[cols++] = gettext_noop("Compression Type");
 		headers[cols++] = gettext_noop("Compression Level");
@@ -2422,7 +2420,7 @@ describeOneTableDetails(const char *schemaname,
 							  false, false);
 
 		if (greenplum_is_ao_column(tableinfo.relstorage, tableinfo.relam)
-				&& attoptions_col >= 0 && tableinfo.relkind != RELKIND_PARTITIONED_TABLE)
+				&& attoptions_col >= 0)
 		{
 			/* The compression type, compression level, and block size are all in the next column.
 			 * attributeOptions is a text array of key=value pairs retrieved as a string from the catalog.

--- a/src/include/access/reloptions.h
+++ b/src/include/access/reloptions.h
@@ -336,8 +336,8 @@ extern List *build_ao_rel_storage_opts(List *opts, Relation rel);
 
 /* attribute enconding specific functions */
 extern List *transformColumnEncoding(Relation rel, List *colDefs,
-										List *stenc, List *withOptions,
-										bool rootpartition, bool allowEncodingClause);
+										List *stenc, List *withOptions, List *parentenc,
+										bool forChildPartitions, bool allowEncodingClause);
 extern List *transformStorageEncodingClause(List *options, bool validate);
 extern List *form_default_storage_directive(List *enc);
 extern bool is_storage_encoding_directive(char *name);

--- a/src/include/access/reloptions.h
+++ b/src/include/access/reloptions.h
@@ -337,8 +337,10 @@ extern List *build_ao_rel_storage_opts(List *opts, Relation rel);
 /* attribute enconding specific functions */
 extern List *transformColumnEncoding(Relation rel, List *colDefs,
 										List *stenc, List *withOptions, List *parentenc,
-										bool forChildPartitions, bool allowEncodingClause);
+										bool explicitOnly, bool allowEncodingClause);
 extern List *transformStorageEncodingClause(List *options, bool validate);
+extern bool updateEncodingList(List *current_encodings,
+								  ColumnReferenceStorageDirective *new_crsd);
 extern List *form_default_storage_directive(List *enc);
 extern bool is_storage_encoding_directive(char *name);
 extern void free_options_deep(relopt_value *options, int num_options);

--- a/src/include/catalog/pg_attribute_encoding.h
+++ b/src/include/catalog/pg_attribute_encoding.h
@@ -51,9 +51,10 @@ extern PGFunction *get_funcs_for_compression(char *compresstype);
 extern StdRdOptions **RelationGetAttributeOptions(Relation rel);
 extern List **RelationGetUntransformedAttributeOptions(Relation rel);
 
-extern void AddRelationAttributeEncodings(Relation rel, List *attr_encodings);
+extern void AddRelationAttributeEncodings(Oid relid, List *attr_encodings);
 extern void RemoveAttributeEncodingsByRelid(Oid relid);
-extern void cloneAttributeEncoding(Oid oldrelid, Oid newrelid, AttrNumber max_attno);
+extern void CloneAttributeEncodings(Oid oldrelid, Oid newrelid, AttrNumber max_attno);
+extern void UpdateAttributeEncodings(Oid relid, List *new_attr_encodings);
 extern Datum *get_rel_attoptions(Oid relid, AttrNumber max_attno);
 extern List * rel_get_column_encodings(Relation rel);
 

--- a/src/include/commands/cluster.h
+++ b/src/include/commands/cluster.h
@@ -26,6 +26,7 @@ extern void check_index_is_clusterable(Relation OldHeap, Oid indexOid,
 extern void mark_index_clustered(Relation rel, Oid indexOid, bool is_internal);
 
 extern Oid make_new_heap(Oid OIDOldHeap, Oid NewTableSpace, Oid NewAccessMethod,
+						 List *NewEncodings,
 						 char relpersistence,
 						 LOCKMODE lockmode,
 						 bool createAoBlockDirectory,

--- a/src/include/nodes/altertablenodes.h
+++ b/src/include/nodes/altertablenodes.h
@@ -80,6 +80,7 @@ typedef struct AlteredTableInfo
 	List	   *changedConstraintDefs;	/* string definitions of same */
 	List	   *changedIndexOids;	/* OIDs of indexes to rebuild */
 	List	   *changedIndexDefs;	/* string definitions of same */
+	List       *new_crsds; /* new column reference storage directives */
 } AlteredTableInfo;
 
 /* Struct describing one new constraint to check in Phase 3 scan */

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -1963,6 +1963,7 @@ typedef enum AlterTableType
 	AT_DropOids,				/* SET WITHOUT OIDS */
 	AT_SetAccessMethod,			/* SET ACCESS METHOD */
 	AT_SetTableSpace,			/* SET TABLESPACE */
+	AT_SetColumnEncoding,        /* SET ENCODING (...)*/
 	AT_SetRelOptions,			/* SET (...) -- AM specific parameters */
 	AT_ResetRelOptions,			/* RESET (...) -- AM specific parameters */
 	AT_ReplaceRelOptions,		/* replace reloption list in its entirety */

--- a/src/test/regress/expected/alter_table_aocs.out
+++ b/src/test/regress/expected/alter_table_aocs.out
@@ -573,11 +573,11 @@ alter table alter_aocs_part_table split default partition start(6) inclusive end
 ERROR:  partition "alter_aocs_part_table_1_prt_11" would overlap partition "alter_aocs_part_table_1_prt_1"
 alter table alter_aocs_part_table split default partition start(7) inclusive end(8) exclusive;
 \d+ alter_aocs_part_table
-                  Partitioned table "aocs_addcol.alter_aocs_part_table"
- Column |  Type   | Collation | Nullable | Default | Storage | Stats target | Description 
---------+---------+-----------+----------+---------+---------+--------------+-------------
- a      | integer |           |          |         | plain   |              | 
- b      | integer |           |          |         | plain   |              | 
+                                            Partitioned table "aocs_addcol.alter_aocs_part_table"
+ Column |  Type   | Collation | Nullable | Default | Storage | Stats target | Compression Type | Compression Level | Block Size | Description 
+--------+---------+-----------+----------+---------+---------+--------------+------------------+-------------------+------------+-------------
+ a      | integer |           |          |         | plain   |              | none             | 0                 | 32768      | 
+ b      | integer |           |          |         | plain   |              | none             | 0                 | 32768      | 
 Partition key: RANGE (b)
 Partitions: alter_aocs_part_table_1_prt_1 FOR VALUES FROM (6) TO (7),
             alter_aocs_part_table_1_prt_11 FOR VALUES FROM (7) TO (8),

--- a/src/test/regress/expected/alter_table_set.out
+++ b/src/test/regress/expected/alter_table_set.out
@@ -201,15 +201,19 @@ SELECT c.relname, c.reloptions, a.blocksize, a.compresslevel FROM pg_class c LEF
 SELECT c.relname, a.attnum, a.attoptions FROM pg_attribute_encoding a, pg_class c WHERE a.attrelid = c.oid AND c.relname LIKE 'part_relopt%';
      relname     | attnum |                       attoptions                        
 -----------------+--------+---------------------------------------------------------
- part_relopt_1   |      1 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ part_relopt     |      2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ part_relopt     |      1 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
  part_relopt_1   |      2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- part_relopt_2_1 |      1 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ part_relopt_1   |      1 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ part_relopt_2   |      2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ part_relopt_2   |      1 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
  part_relopt_2_1 |      2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- part_relopt_2_2 |      1 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ part_relopt_2_1 |      1 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
  part_relopt_2_2 |      2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- part_relopt_3   |      1 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ part_relopt_2_2 |      1 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
  part_relopt_3   |      2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
-(8 rows)
+ part_relopt_3   |      1 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+(12 rows)
 
 ALTER TABLE part_relopt SET (compresslevel=3);
 SELECT c.relname, c.reloptions, a.blocksize, a.compresslevel FROM pg_class c LEFT JOIN pg_appendonly a ON a.relid = c.oid WHERE c.relname LIKE 'part_relopt%';
@@ -226,15 +230,19 @@ SELECT c.relname, c.reloptions, a.blocksize, a.compresslevel FROM pg_class c LEF
 SELECT c.relname, a.attnum, a.attoptions FROM pg_attribute_encoding a, pg_class c WHERE a.attrelid = c.oid AND c.relname LIKE 'part_relopt%';
      relname     | attnum |                       attoptions                        
 -----------------+--------+---------------------------------------------------------
- part_relopt_1   |      1 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ part_relopt     |      2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ part_relopt     |      1 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
  part_relopt_1   |      2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- part_relopt_2_1 |      1 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ part_relopt_1   |      1 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ part_relopt_2   |      2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ part_relopt_2   |      1 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
  part_relopt_2_1 |      2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- part_relopt_2_2 |      1 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ part_relopt_2_1 |      1 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
  part_relopt_2_2 |      2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- part_relopt_3   |      1 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ part_relopt_2_2 |      1 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
  part_relopt_3   |      2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
-(8 rows)
+ part_relopt_3   |      1 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+(12 rows)
 
 -- Check mixed AMs in the partition hierarchy. Currently we error out.
 CREATE TABLE part_relopt2(a int, b int) PARTITION BY RANGE(a);
@@ -258,24 +266,24 @@ ALTER TABLE part_2_1 SET (blocksize=65536);
 SELECT c.relname, c.reloptions FROM pg_class c WHERE c.relname = 'part_1' OR c.relname = 'part_2_1';
  relname  |    reloptions     
 ----------+-------------------
- part_1   | {fillfactor=70}
  part_2_1 | {blocksize=65536}
+ part_1   | {fillfactor=70}
 (2 rows)
 
 ALTER TABLE part_relopt2 RESET(fillfactor);
 SELECT c.relname, c.reloptions FROM pg_class c WHERE c.relname = 'part_1' OR c.relname = 'part_2_1';
  relname  |    reloptions     
 ----------+-------------------
- part_1   | 
  part_2_1 | {blocksize=65536}
+ part_1   | 
 (2 rows)
 
 ALTER TABLE part_relopt2 RESET(blocksize);
 SELECT c.relname, c.reloptions FROM pg_class c WHERE c.relname = 'part_1' OR c.relname = 'part_2_1';
  relname  | reloptions 
 ----------+------------
- part_1   | 
  part_2_1 | 
+ part_1   | 
 (2 rows)
 
 -- Data is intact

--- a/src/test/regress/expected/alter_table_set.out
+++ b/src/test/regress/expected/alter_table_set.out
@@ -185,8 +185,8 @@ SELECT c.relname, c.reloptions, a.blocksize, a.compresslevel FROM pg_class c LEF
  part_relopt_3   | {compresstype=zlib,compresslevel=7} |     32768 |             7
 (6 rows)
 
---AOCO table:
-ALTER TABLE part_relopt SET ACCESS METHOD ao_column WITH (compresstype=rle_type, compresslevel=1);
+--AOCO table: Also check setting column encoding
+ALTER TABLE part_relopt SET ACCESS METHOD ao_column WITH (compresstype=rle_type, compresslevel=1), ALTER COLUMN a SET ENCODING (compresstype=rle_type, compresslevel=2), ALTER COLUMN b SET ENCODING (compresstype=zlib, compresslevel=3);
 SELECT c.relname, c.reloptions, a.blocksize, a.compresslevel FROM pg_class c LEFT JOIN pg_appendonly a ON a.relid = c.oid WHERE c.relname LIKE 'part_relopt%';
      relname     |               reloptions                | blocksize | compresslevel 
 -----------------+-----------------------------------------+-----------+---------------
@@ -198,21 +198,22 @@ SELECT c.relname, c.reloptions, a.blocksize, a.compresslevel FROM pg_class c LEF
  part_relopt_3   | {compresstype=rle_type,compresslevel=1} |     32768 |             1
 (6 rows)
 
-SELECT c.relname, a.attnum, a.attoptions FROM pg_attribute_encoding a, pg_class c WHERE a.attrelid = c.oid AND c.relname LIKE 'part_relopt%';
-     relname     | attnum |                       attoptions                        
------------------+--------+---------------------------------------------------------
- part_relopt     |      2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- part_relopt     |      1 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- part_relopt_1   |      2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- part_relopt_1   |      1 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- part_relopt_2   |      2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- part_relopt_2   |      1 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- part_relopt_2_1 |      2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- part_relopt_2_1 |      1 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- part_relopt_2_2 |      2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- part_relopt_2_2 |      1 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- part_relopt_3   |      2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- part_relopt_3   |      1 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+SELECT c.relname, a.attname, e.attoptions FROM pg_attribute_encoding e, pg_class c, pg_attribute a
+WHERE e.attrelid = c.oid AND e.attnum = a.attnum and e.attrelid = a.attrelid AND c.relname LIKE 'part_relopt%';
+     relname     | attname |                       attoptions                        
+-----------------+---------+---------------------------------------------------------
+ part_relopt     | a       | {compresstype=rle_type,compresslevel=2,blocksize=32768}
+ part_relopt     | b       | {compresstype=zlib,compresslevel=3,blocksize=32768}
+ part_relopt_1   | a       | {compresstype=rle_type,compresslevel=2,blocksize=32768}
+ part_relopt_1   | b       | {compresstype=zlib,compresslevel=3,blocksize=32768}
+ part_relopt_2   | a       | {compresstype=rle_type,compresslevel=2,blocksize=32768}
+ part_relopt_2   | b       | {compresstype=zlib,compresslevel=3,blocksize=32768}
+ part_relopt_2_1 | a       | {compresstype=rle_type,compresslevel=2,blocksize=32768}
+ part_relopt_2_1 | b       | {compresstype=zlib,compresslevel=3,blocksize=32768}
+ part_relopt_2_2 | a       | {compresstype=rle_type,compresslevel=2,blocksize=32768}
+ part_relopt_2_2 | b       | {compresstype=zlib,compresslevel=3,blocksize=32768}
+ part_relopt_3   | a       | {compresstype=rle_type,compresslevel=2,blocksize=32768}
+ part_relopt_3   | b       | {compresstype=zlib,compresslevel=3,blocksize=32768}
 (12 rows)
 
 ALTER TABLE part_relopt SET (compresslevel=3);
@@ -227,71 +228,448 @@ SELECT c.relname, c.reloptions, a.blocksize, a.compresslevel FROM pg_class c LEF
  part_relopt_3   | {compresstype=rle_type,compresslevel=3} |     32768 |             3
 (6 rows)
 
-SELECT c.relname, a.attnum, a.attoptions FROM pg_attribute_encoding a, pg_class c WHERE a.attrelid = c.oid AND c.relname LIKE 'part_relopt%';
-     relname     | attnum |                       attoptions                        
------------------+--------+---------------------------------------------------------
- part_relopt     |      2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- part_relopt     |      1 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- part_relopt_1   |      2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- part_relopt_1   |      1 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- part_relopt_2   |      2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- part_relopt_2   |      1 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- part_relopt_2_1 |      2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- part_relopt_2_1 |      1 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- part_relopt_2_2 |      2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- part_relopt_2_2 |      1 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- part_relopt_3   |      2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- part_relopt_3   |      1 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+SELECT c.relname, a.attname, e.attoptions FROM pg_attribute_encoding e, pg_class c, pg_attribute a
+WHERE e.attrelid = c.oid AND e.attnum = a.attnum and e.attrelid = a.attrelid AND c.relname LIKE 'part_relopt%';
+     relname     | attname |                       attoptions                        
+-----------------+---------+---------------------------------------------------------
+ part_relopt     | a       | {compresstype=rle_type,compresslevel=2,blocksize=32768}
+ part_relopt     | b       | {compresstype=zlib,compresslevel=3,blocksize=32768}
+ part_relopt_1   | a       | {compresstype=rle_type,compresslevel=2,blocksize=32768}
+ part_relopt_1   | b       | {compresstype=zlib,compresslevel=3,blocksize=32768}
+ part_relopt_2   | a       | {compresstype=rle_type,compresslevel=2,blocksize=32768}
+ part_relopt_2   | b       | {compresstype=zlib,compresslevel=3,blocksize=32768}
+ part_relopt_2_1 | a       | {compresstype=rle_type,compresslevel=2,blocksize=32768}
+ part_relopt_2_1 | b       | {compresstype=zlib,compresslevel=3,blocksize=32768}
+ part_relopt_2_2 | a       | {compresstype=rle_type,compresslevel=2,blocksize=32768}
+ part_relopt_2_2 | b       | {compresstype=zlib,compresslevel=3,blocksize=32768}
+ part_relopt_3   | a       | {compresstype=rle_type,compresslevel=2,blocksize=32768}
+ part_relopt_3   | b       | {compresstype=zlib,compresslevel=3,blocksize=32768}
 (12 rows)
 
--- Check mixed AMs in the partition hierarchy. Currently we error out.
-CREATE TABLE part_relopt2(a int, b int) PARTITION BY RANGE(a);
-CREATE TABLE part_1 partition OF part_relopt2 FOR VALUES FROM (100) to (200);
-CREATE TABLE part_2 partition OF part_relopt2 FOR VALUES FROM (200) to (300) PARTITION BY RANGE (a);
-CREATE TABLE part_2_1 partition OF part_2 FOR VALUES FROM (200) to (250);
--- error out because of the first child
-ALTER TABLE part_1 SET ACCESS METHOD ao_row;
-ALTER TABLE part_relopt2 SET (fillfactor=70);
-ERROR:  cannot alter reloptions for "part_relopt2" because one of the child tables "part_1" has different access method
-HINT:  Alter tables individually or change the child's AM to be same as parent.
--- check subpartition too: error out because of the subpartition child
-ALTER TABLE part_1 SET ACCESS METHOD heap;
-ALTER TABLE part_2_1 SET ACCESS METHOD ao_row;
-ALTER TABLE part_relopt2 SET (fillfactor=70);
-ERROR:  cannot alter reloptions for "part_relopt2" because one of the child tables "part_2_1" has different access method
-HINT:  Alter tables individually or change the child's AM to be same as parent.
--- SET individual child, and check if RESET works. 
-ALTER TABLE part_1 SET (fillfactor=70);
-ALTER TABLE part_2_1 SET (blocksize=65536);
-SELECT c.relname, c.reloptions FROM pg_class c WHERE c.relname = 'part_1' OR c.relname = 'part_2_1';
- relname  |    reloptions     
-----------+-------------------
- part_2_1 | {blocksize=65536}
- part_1   | {fillfactor=70}
-(2 rows)
+ALTER TABLE part_relopt ALTER COLUMN a SET ENCODING (compresstype=rle_type, compresslevel=4), ALTER COLUMN b SET ENCODING (compresstype=zlib, compresslevel=5);
+SELECT c.relname, a.attname, e.attoptions FROM pg_attribute_encoding e, pg_class c, pg_attribute a
+WHERE e.attrelid = c.oid AND e.attnum = a.attnum and e.attrelid = a.attrelid AND c.relname LIKE 'part_relopt%';
+     relname     | attname |                       attoptions                        
+-----------------+---------+---------------------------------------------------------
+ part_relopt     | a       | {compresstype=rle_type,compresslevel=4,blocksize=32768}
+ part_relopt     | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_1   | a       | {compresstype=rle_type,compresslevel=4,blocksize=32768}
+ part_relopt_1   | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_2   | a       | {compresstype=rle_type,compresslevel=4,blocksize=32768}
+ part_relopt_2   | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_2_1 | a       | {compresstype=rle_type,compresslevel=4,blocksize=32768}
+ part_relopt_2_1 | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_2_2 | a       | {compresstype=rle_type,compresslevel=4,blocksize=32768}
+ part_relopt_2_2 | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_3   | a       | {compresstype=rle_type,compresslevel=4,blocksize=32768}
+ part_relopt_3   | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+(12 rows)
 
-ALTER TABLE part_relopt2 RESET(fillfactor);
-SELECT c.relname, c.reloptions FROM pg_class c WHERE c.relname = 'part_1' OR c.relname = 'part_2_1';
- relname  |    reloptions     
-----------+-------------------
- part_2_1 | {blocksize=65536}
- part_1   | 
-(2 rows)
+-- Check double edit on same column
+ALTER TABLE part_relopt ALTER COLUMN a SET ENCODING (compresstype=rle_type, compresslevel=4), ALTER COLUMN a SET ENCODING (compresstype=zlib, compresslevel=5);
+SELECT c.relname, a.attname, e.attoptions FROM pg_attribute_encoding e, pg_class c, pg_attribute a
+WHERE e.attrelid = c.oid AND e.attnum = a.attnum and e.attrelid = a.attrelid AND c.relname LIKE 'part_relopt%';
+     relname     | attname |                     attoptions                      
+-----------------+---------+-----------------------------------------------------
+ part_relopt     | a       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt     | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_1   | a       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_1   | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_2   | a       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_2   | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_2_1 | a       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_2_1 | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_2_2 | a       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_2_2 | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_3   | a       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_3   | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+(12 rows)
 
-ALTER TABLE part_relopt2 RESET(blocksize);
-SELECT c.relname, c.reloptions FROM pg_class c WHERE c.relname = 'part_1' OR c.relname = 'part_2_1';
- relname  | reloptions 
-----------+------------
- part_2_1 | 
- part_1   | 
-(2 rows)
+-- Check double edit of same option
+ALTER TABLE part_relopt ALTER COLUMN a SET ENCODING (compresslevel=3, compresslevel=4);
+ERROR:  parameter "compresslevel" specified more than once
+SELECT c.relname, a.attname, e.attoptions FROM pg_attribute_encoding e, pg_class c, pg_attribute a
+WHERE e.attrelid = c.oid AND e.attnum = a.attnum and e.attrelid = a.attrelid AND c.relname LIKE 'part_relopt%';
+     relname     | attname |                     attoptions                      
+-----------------+---------+-----------------------------------------------------
+ part_relopt     | a       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt     | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_1   | a       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_1   | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_2   | a       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_2   | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_2_1 | a       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_2_1 | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_2_2 | a       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_2_2 | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_3   | a       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_3   | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+(12 rows)
+
+-- Check double edit of same column different options
+ALTER TABLE part_relopt ALTER COLUMN a SET ENCODING (compresstype=zlib), ALTER COLUMN a SET ENCODING (compresslevel=7);
+SELECT c.relname, a.attname, e.attoptions FROM pg_attribute_encoding e, pg_class c, pg_attribute a
+WHERE e.attrelid = c.oid AND e.attnum = a.attnum and e.attrelid = a.attrelid AND c.relname LIKE 'part_relopt%';
+     relname     | attname |                     attoptions                      
+-----------------+---------+-----------------------------------------------------
+ part_relopt     | a       | {compresstype=zlib,compresslevel=7,blocksize=32768}
+ part_relopt     | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_1   | a       | {compresstype=zlib,compresslevel=7,blocksize=32768}
+ part_relopt_1   | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_2   | a       | {compresstype=zlib,compresslevel=7,blocksize=32768}
+ part_relopt_2   | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_2_1 | a       | {compresstype=zlib,compresslevel=7,blocksize=32768}
+ part_relopt_2_1 | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_2_2 | a       | {compresstype=zlib,compresslevel=7,blocksize=32768}
+ part_relopt_2_2 | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_3   | a       | {compresstype=zlib,compresslevel=7,blocksize=32768}
+ part_relopt_3   | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+(12 rows)
+
+ALTER TABLE part_relopt ALTER COLUMN a SET ENCODING (compresstype=zlib, compresslevel=5);
+SELECT c.relname, a.attname, e.attoptions FROM pg_attribute_encoding e, pg_class c, pg_attribute a
+WHERE e.attrelid = c.oid AND e.attnum = a.attnum and e.attrelid = a.attrelid AND c.relname LIKE 'part_relopt%';
+     relname     | attname |                     attoptions                      
+-----------------+---------+-----------------------------------------------------
+ part_relopt     | a       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt     | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_1   | a       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_1   | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_2   | a       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_2   | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_2_1 | a       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_2_1 | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_2_2 | a       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_2_2 | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_3   | a       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_3   | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+(12 rows)
 
 -- Data is intact
+SELECT * from part_relopt order by a limit 10;
+ a  | b  
+----+----
+  1 |  1
+  2 |  2
+  3 |  3
+  4 |  4
+  5 |  5
+  6 |  6
+  7 |  7
+  8 |  8
+  9 |  9
+ 10 | 10
+(10 rows)
+
 SELECT count(*) FROM part_relopt;
  count 
 -------
    199
 (1 row)
 
-DROP TABLE part_relopt;
+-- with empty segfiles
+CREATE TABLE aoco_relopt(a int, b int) WITH (appendoptimized = true, orientation = column);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+ALTER TABLE aoco_relopt ALTER COLUMN a SET ENCODING (compresstype=rle_type, compresslevel=4), ALTER COLUMN b SET ENCODING (compresstype=zlib, compresslevel=5);
+SELECT c.relname, a.attname, e.attoptions FROM pg_attribute_encoding e, pg_class c, pg_attribute a
+WHERE e.attrelid = c.oid AND e.attnum = a.attnum and e.attrelid = a.attrelid AND c.relname LIKE 'aoco_relopt%';
+   relname   | attname |                       attoptions                        
+-------------+---------+---------------------------------------------------------
+ aoco_relopt | a       | {compresstype=rle_type,blocksize=32768,compresslevel=4}
+ aoco_relopt | b       | {compresstype=zlib,blocksize=32768,compresslevel=5}
+(2 rows)
+
+DROP TABLE aoco_relopt;
+-- Check mixed AMs in the partition hierarchy. Currently we error out.
+CREATE TABLE part_relopt2(a int, b int) PARTITION BY RANGE(a);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE part_relopt2_1 partition OF part_relopt2 FOR VALUES FROM (100) to (200);
+NOTICE:  table has parent, setting distribution columns to match parent table
+CREATE TABLE part_relopt2_2 partition OF part_relopt2 FOR VALUES FROM (200) to (300) PARTITION BY RANGE (a);
+NOTICE:  table has parent, setting distribution columns to match parent table
+CREATE TABLE part_relopt2_2_1 partition OF part_relopt2_2 FOR VALUES FROM (200) to (250);
+NOTICE:  table has parent, setting distribution columns to match parent table
+-- error out because of the first child
+ALTER TABLE part_relopt2_1 SET ACCESS METHOD ao_row;
+ALTER TABLE part_relopt2 SET (fillfactor=70);
+ERROR:  cannot alter reloptions for "part_relopt2" because one of the child tables "part_relopt2_1" has different access method
+HINT:  Alter tables individually or change the child's AM to be same as parent.
+-- check subpartition too: error out because of the subpartition child
+ALTER TABLE part_relopt2_1 SET ACCESS METHOD heap;
+ALTER TABLE part_relopt2_2_1 SET ACCESS METHOD ao_row;
+ALTER TABLE part_relopt2 SET (fillfactor=70);
+ERROR:  cannot alter reloptions for "part_relopt2" because one of the child tables "part_relopt2_2_1" has different access method
+HINT:  Alter tables individually or change the child's AM to be same as parent.
+-- SET individual child, and check if RESET works.
+ALTER TABLE part_relopt2_1 SET (fillfactor=70);
+ALTER TABLE part_relopt2_2_1 SET (blocksize=65536);
+SELECT c.relname, c.reloptions FROM pg_class c WHERE c.relname = 'part_relopt2_1' OR c.relname = 'part_relopt2_2_1';
+     relname      |    reloptions     
+------------------+-------------------
+ part_relopt2_1   | {fillfactor=70}
+ part_relopt2_2_1 | {blocksize=65536}
+(2 rows)
+
+ALTER TABLE part_relopt2 RESET(fillfactor);
+SELECT c.relname, c.reloptions FROM pg_class c WHERE c.relname = 'part_relopt2_1' OR c.relname = 'part_relopt2_2_1';
+     relname      |    reloptions     
+------------------+-------------------
+ part_relopt2_1   | 
+ part_relopt2_2_1 | {blocksize=65536}
+(2 rows)
+
+ALTER TABLE part_relopt2 RESET(blocksize);
+SELECT c.relname, c.reloptions FROM pg_class c WHERE c.relname = 'part_relopt2_1' OR c.relname = 'part_relopt2_2_1';
+     relname      | reloptions 
+------------------+------------
+ part_relopt2_1   | 
+ part_relopt2_2_1 | 
+(2 rows)
+
 DROP TABLE part_relopt2;
+-- Check mixed AM aoco column encoding
+CREATE TABLE part_relopt3(a int, b int) WITH (appendoptimized = true, orientation = column, compresstype=zlib, compresslevel=5) PARTITION BY RANGE(a);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE part_relopt3_1 partition OF part_relopt3 FOR VALUES FROM (100) to (200);
+NOTICE:  table has parent, setting distribution columns to match parent table
+CREATE TABLE part_relopt3_2 partition OF part_relopt3 FOR VALUES FROM (200) to (300) PARTITION BY RANGE (a);
+NOTICE:  table has parent, setting distribution columns to match parent table
+CREATE TABLE part_relopt3_2_1 partition OF part_relopt3_2 FOR VALUES FROM (200) to (250);
+NOTICE:  table has parent, setting distribution columns to match parent table
+INSERT INTO part_relopt3 SELECT i,i FROM generate_series(101,249) i;
+SELECT c.relname, a.attname, e.attoptions FROM pg_attribute_encoding e, pg_class c, pg_attribute a
+WHERE e.attrelid = c.oid AND e.attnum = a.attnum and e.attrelid = a.attrelid AND c.relname LIKE 'part_relopt3%';
+     relname      | attname |                     attoptions                      
+------------------+---------+-----------------------------------------------------
+ part_relopt3     | a       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt3     | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt3_1   | a       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt3_1   | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt3_2   | a       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt3_2   | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt3_2_1 | a       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt3_2_1 | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+(8 rows)
+
+-- error out because of the first child
+ALTER TABLE part_relopt3_1 SET ACCESS METHOD heap;
+ALTER TABLE part_relopt3 ALTER COLUMN a SET ENCODING (compresslevel=3, compresstype=zlib);
+ERROR:  ALTER COLUMN SET ENCODING operation is only applicable to AOCO tables
+DETAIL:  "part_relopt3_1" is not an AOCO table
+-- check subpartition too: error out because of the subpartition child
+ALTER TABLE part_relopt3_1 SET ACCESS METHOD ao_column;
+ALTER TABLE part_relopt3_2_1 SET ACCESS METHOD heap;
+ALTER TABLE part_relopt3 ALTER COLUMN a SET ENCODING (compresslevel=3, compresstype=zlib);
+ERROR:  ALTER COLUMN SET ENCODING operation is only applicable to AOCO tables
+DETAIL:  "part_relopt3_2_1" is not an AOCO table
+SELECT c.relname, a.attname, e.attoptions FROM pg_attribute_encoding e, pg_class c, pg_attribute a
+WHERE e.attrelid = c.oid AND e.attnum = a.attnum and e.attrelid = a.attrelid AND c.relname LIKE 'part_relopt3%';
+    relname     | attname |                     attoptions                      
+----------------+---------+-----------------------------------------------------
+ part_relopt3   | a       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt3   | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt3_1 | a       | {compresstype=none,blocksize=32768,compresslevel=0}
+ part_relopt3_1 | b       | {compresstype=none,blocksize=32768,compresslevel=0}
+ part_relopt3_2 | a       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt3_2 | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+(6 rows)
+
+ALTER TABLE part_relopt3_1 ALTER COLUMN a SET ENCODING (compresslevel=3, compresstype=zlib);
+SELECT c.relname, a.attname, e.attoptions FROM pg_attribute_encoding e, pg_class c, pg_attribute a
+WHERE e.attrelid = c.oid AND e.attnum = a.attnum and e.attrelid = a.attrelid AND c.relname LIKE 'part_relopt3%';
+    relname     | attname |                     attoptions                      
+----------------+---------+-----------------------------------------------------
+ part_relopt3   | a       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt3   | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt3_1 | a       | {compresstype=zlib,blocksize=32768,compresslevel=3}
+ part_relopt3_1 | b       | {compresstype=none,blocksize=32768,compresslevel=0}
+ part_relopt3_2 | a       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt3_2 | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+(6 rows)
+
+ALTER TABLE part_relopt3_2_1 SET ACCESS METHOD ao_column, ALTER COLUMN a SET ENCODING (compresslevel=4, compresstype=zlib);
+SELECT c.relname, a.attname, e.attoptions FROM pg_attribute_encoding e, pg_class c, pg_attribute a
+WHERE e.attrelid = c.oid AND e.attnum = a.attnum and e.attrelid = a.attrelid AND c.relname LIKE 'part_relopt3%';
+     relname      | attname |                     attoptions                      
+------------------+---------+-----------------------------------------------------
+ part_relopt3     | a       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt3     | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt3_1   | a       | {compresstype=zlib,blocksize=32768,compresslevel=3}
+ part_relopt3_1   | b       | {compresstype=none,blocksize=32768,compresslevel=0}
+ part_relopt3_2   | a       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt3_2   | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt3_2_1 | a       | {compresstype=zlib,blocksize=32768,compresslevel=4}
+ part_relopt3_2_1 | b       | {compresstype=none,blocksize=32768,compresslevel=0}
+(8 rows)
+
+ALTER TABLE part_relopt3_2 ALTER COLUMN a SET ENCODING (compresslevel=1, compresstype=rle_type);
+SELECT c.relname, a.attname, e.attoptions FROM pg_attribute_encoding e, pg_class c, pg_attribute a
+WHERE e.attrelid = c.oid AND e.attnum = a.attnum and e.attrelid = a.attrelid AND c.relname LIKE 'part_relopt3%';
+     relname      | attname |                       attoptions                        
+------------------+---------+---------------------------------------------------------
+ part_relopt3     | a       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt3     | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt3_1   | a       | {compresstype=zlib,blocksize=32768,compresslevel=3}
+ part_relopt3_1   | b       | {compresstype=none,blocksize=32768,compresslevel=0}
+ part_relopt3_2   | a       | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ part_relopt3_2   | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt3_2_1 | a       | {compresstype=rle_type,blocksize=32768,compresslevel=1}
+ part_relopt3_2_1 | b       | {compresstype=none,blocksize=32768,compresslevel=0}
+(8 rows)
+
+ALTER TABLE part_relopt3 ALTER COLUMN a SET ENCODING (compresslevel=4, compresstype=rle_type);
+SELECT c.relname, a.attname, e.attoptions FROM pg_attribute_encoding e, pg_class c, pg_attribute a
+WHERE e.attrelid = c.oid AND e.attnum = a.attnum and e.attrelid = a.attrelid AND c.relname LIKE 'part_relopt3%';
+     relname      | attname |                       attoptions                        
+------------------+---------+---------------------------------------------------------
+ part_relopt3     | a       | {compresstype=rle_type,compresslevel=4,blocksize=32768}
+ part_relopt3     | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt3_1   | a       | {compresstype=rle_type,blocksize=32768,compresslevel=4}
+ part_relopt3_1   | b       | {compresstype=none,blocksize=32768,compresslevel=0}
+ part_relopt3_2   | a       | {compresstype=rle_type,compresslevel=4,blocksize=32768}
+ part_relopt3_2   | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt3_2_1 | a       | {compresstype=rle_type,blocksize=32768,compresslevel=4}
+ part_relopt3_2_1 | b       | {compresstype=none,blocksize=32768,compresslevel=0}
+(8 rows)
+
+-- Check if table is rewritten if encoding doesn't change
+CREATE TEMP TABLE relfilebeforeredo AS
+SELECT -1 segid, relname, relfilenode FROM pg_class WHERE relname LIKE 'part_relopt3%'
+UNION SELECT gp_segment_id segid, relname, relfilenode FROM gp_dist_random('pg_class')
+WHERE relname LIKE 'part_relopt3%' ORDER BY segid;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'segid' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+ALTER TABLE part_relopt3 ALTER COLUMN a SET ENCODING (compresslevel=4, compresstype=rle_type);
+SELECT c.relname, a.attname, e.attoptions FROM pg_attribute_encoding e, pg_class c, pg_attribute a
+WHERE e.attrelid = c.oid AND e.attnum = a.attnum and e.attrelid = a.attrelid AND c.relname LIKE 'part_relopt3%';
+     relname      | attname |                       attoptions                        
+------------------+---------+---------------------------------------------------------
+ part_relopt3     | a       | {compresstype=rle_type,compresslevel=4,blocksize=32768}
+ part_relopt3     | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt3_1   | a       | {compresstype=rle_type,blocksize=32768,compresslevel=4}
+ part_relopt3_1   | b       | {compresstype=none,blocksize=32768,compresslevel=0}
+ part_relopt3_2   | a       | {compresstype=rle_type,compresslevel=4,blocksize=32768}
+ part_relopt3_2   | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt3_2_1 | a       | {compresstype=rle_type,blocksize=32768,compresslevel=4}
+ part_relopt3_2_1 | b       | {compresstype=none,blocksize=32768,compresslevel=0}
+(8 rows)
+
+CREATE TEMP TABLE relfileafterredo AS
+SELECT -1 segid, relname, relfilenode FROM pg_class WHERE relname LIKE 'part_relopt3%'
+UNION SELECT gp_segment_id segid, relname, relfilenode FROM gp_dist_random('pg_class')
+WHERE relname LIKE 'part_relopt3%' ORDER BY segid;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'segid' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- Alter table shouldn't have rewritten the table since the options aren't changing
+SELECT * FROM relfilebeforeredo EXCEPT SELECT * FROM relfileafterredo;
+ segid | relname | relfilenode 
+-------+---------+-------------
+(0 rows)
+
+-- Check alter column set encoding for root partition ONLY
+ALTER TABLE ONLY part_relopt3 ALTER COLUMN a SET ENCODING (compresslevel=2, compresstype=zlib);
+SELECT c.relname, a.attname, e.attoptions FROM pg_attribute_encoding e, pg_class c, pg_attribute a
+WHERE e.attrelid = c.oid AND e.attnum = a.attnum and e.attrelid = a.attrelid AND c.relname LIKE 'part_relopt3%';
+     relname      | attname |                       attoptions                        
+------------------+---------+---------------------------------------------------------
+ part_relopt3     | a       | {compresstype=zlib,compresslevel=2,blocksize=32768}
+ part_relopt3     | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt3_1   | a       | {compresstype=rle_type,blocksize=32768,compresslevel=4}
+ part_relopt3_1   | b       | {compresstype=none,blocksize=32768,compresslevel=0}
+ part_relopt3_2   | a       | {compresstype=rle_type,compresslevel=4,blocksize=32768}
+ part_relopt3_2   | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt3_2_1 | a       | {compresstype=rle_type,blocksize=32768,compresslevel=4}
+ part_relopt3_2_1 | b       | {compresstype=none,blocksize=32768,compresslevel=0}
+(8 rows)
+
+-- Check alter column set encoding for mid level root partition ONLY
+ALTER TABLE ONLY part_relopt3_2 ALTER COLUMN a SET ENCODING (compresslevel=3, compresstype=zlib);
+SELECT c.relname, a.attname, e.attoptions FROM pg_attribute_encoding e, pg_class c, pg_attribute a
+WHERE e.attrelid = c.oid AND e.attnum = a.attnum and e.attrelid = a.attrelid AND c.relname LIKE 'part_relopt3%';
+     relname      | attname |                       attoptions                        
+------------------+---------+---------------------------------------------------------
+ part_relopt3     | a       | {compresstype=zlib,compresslevel=2,blocksize=32768}
+ part_relopt3     | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt3_1   | a       | {compresstype=rle_type,blocksize=32768,compresslevel=4}
+ part_relopt3_1   | b       | {compresstype=none,blocksize=32768,compresslevel=0}
+ part_relopt3_2   | a       | {compresstype=zlib,compresslevel=3,blocksize=32768}
+ part_relopt3_2   | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt3_2_1 | a       | {compresstype=rle_type,blocksize=32768,compresslevel=4}
+ part_relopt3_2_1 | b       | {compresstype=none,blocksize=32768,compresslevel=0}
+(8 rows)
+
+-- altering when changing am to heap should error out for root partition
+ALTER TABLE part_relopt3 SET ACCESS METHOD heap, ALTER COLUMN a SET ENCODING (compresslevel=4, compresstype=rle_type);
+ERROR:  ALTER COLUMN SET ENCODING operation is only applicable to AOCO tables
+DETAIL:  New access method for "part_relopt3" is not AOCO
+SELECT c.relname, a.attname, e.attoptions FROM pg_attribute_encoding e, pg_class c, pg_attribute a
+WHERE e.attrelid = c.oid AND e.attnum = a.attnum and e.attrelid = a.attrelid AND c.relname LIKE 'part_relopt3%';
+     relname      | attname |                       attoptions                        
+------------------+---------+---------------------------------------------------------
+ part_relopt3     | a       | {compresstype=zlib,compresslevel=2,blocksize=32768}
+ part_relopt3     | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt3_1   | a       | {compresstype=rle_type,blocksize=32768,compresslevel=4}
+ part_relopt3_1   | b       | {compresstype=none,blocksize=32768,compresslevel=0}
+ part_relopt3_2   | a       | {compresstype=zlib,compresslevel=3,blocksize=32768}
+ part_relopt3_2   | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt3_2_1 | a       | {compresstype=rle_type,blocksize=32768,compresslevel=4}
+ part_relopt3_2_1 | b       | {compresstype=none,blocksize=32768,compresslevel=0}
+(8 rows)
+
+-- altering when changing am to heap should error out for child partition
+ALTER TABLE part_relopt3_2_1 SET ACCESS METHOD heap, ALTER COLUMN a SET ENCODING (compresslevel=4, compresstype=rle_type);
+ERROR:  ALTER COLUMN SET ENCODING operation is only applicable to AOCO tables
+DETAIL:  New access method for "part_relopt3_2_1" is not AOCO
+SELECT c.relname, a.attname, e.attoptions FROM pg_attribute_encoding e, pg_class c, pg_attribute a
+WHERE e.attrelid = c.oid AND e.attnum = a.attnum and e.attrelid = a.attrelid AND c.relname LIKE 'part_relopt3%';
+     relname      | attname |                       attoptions                        
+------------------+---------+---------------------------------------------------------
+ part_relopt3     | a       | {compresstype=zlib,compresslevel=2,blocksize=32768}
+ part_relopt3     | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt3_1   | a       | {compresstype=rle_type,blocksize=32768,compresslevel=4}
+ part_relopt3_1   | b       | {compresstype=none,blocksize=32768,compresslevel=0}
+ part_relopt3_2   | a       | {compresstype=zlib,compresslevel=3,blocksize=32768}
+ part_relopt3_2   | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt3_2_1 | a       | {compresstype=rle_type,blocksize=32768,compresslevel=4}
+ part_relopt3_2_1 | b       | {compresstype=none,blocksize=32768,compresslevel=0}
+(8 rows)
+
+-- set access method and then alter column set encoding should generate same encoding values as
+-- set access method + alter column set encoding
+ALTER TABLE part_relopt3 SET ACCESS METHOD heap;
+ALTER TABLE part_relopt3 SET ACCESS METHOD ao_column, ALTER COLUMN a SET ENCODING (compresslevel=4);
+SELECT c.relname, a.attname, e.attoptions FROM pg_attribute_encoding e, pg_class c, pg_attribute a
+WHERE e.attrelid = c.oid AND e.attnum = a.attnum and e.attrelid = a.attrelid AND c.relname LIKE 'part_relopt3%';
+     relname      | attname |                     attoptions                      
+------------------+---------+-----------------------------------------------------
+ part_relopt3     | a       | {compresstype=none,blocksize=32768,compresslevel=4}
+ part_relopt3     | b       | {compresstype=none,blocksize=32768,compresslevel=0}
+ part_relopt3_1   | a       | {compresstype=none,blocksize=32768,compresslevel=4}
+ part_relopt3_1   | b       | {compresstype=none,blocksize=32768,compresslevel=0}
+ part_relopt3_2   | a       | {compresstype=none,blocksize=32768,compresslevel=4}
+ part_relopt3_2   | b       | {compresstype=none,blocksize=32768,compresslevel=0}
+ part_relopt3_2_1 | a       | {compresstype=none,blocksize=32768,compresslevel=4}
+ part_relopt3_2_1 | b       | {compresstype=none,blocksize=32768,compresslevel=0}
+(8 rows)
+
+ALTER TABLE part_relopt3 SET ACCESS METHOD heap;
+ALTER TABLE part_relopt3 SET ACCESS METHOD ao_column;
+ALTER TABLE part_relopt3 ALTER COLUMN a SET ENCODING (compresslevel=4);
+SELECT c.relname, a.attname, e.attoptions FROM pg_attribute_encoding e, pg_class c, pg_attribute a
+WHERE e.attrelid = c.oid AND e.attnum = a.attnum and e.attrelid = a.attrelid AND c.relname LIKE 'part_relopt3%';
+     relname      | attname |                     attoptions                      
+------------------+---------+-----------------------------------------------------
+ part_relopt3     | a       | {compresstype=none,blocksize=32768,compresslevel=4}
+ part_relopt3     | b       | {compresstype=none,blocksize=32768,compresslevel=0}
+ part_relopt3_1   | a       | {compresstype=none,blocksize=32768,compresslevel=4}
+ part_relopt3_1   | b       | {compresstype=none,blocksize=32768,compresslevel=0}
+ part_relopt3_2   | a       | {compresstype=none,blocksize=32768,compresslevel=4}
+ part_relopt3_2   | b       | {compresstype=none,blocksize=32768,compresslevel=0}
+ part_relopt3_2_1 | a       | {compresstype=none,blocksize=32768,compresslevel=4}
+ part_relopt3_2_1 | b       | {compresstype=none,blocksize=32768,compresslevel=0}
+(8 rows)
+
+DROP TABLE part_relopt3;

--- a/src/test/regress/expected/column_compression.out
+++ b/src/test/regress/expected/column_compression.out
@@ -7,10 +7,10 @@
 create database column_compression;
 \c column_compression
 prepare ccddlcheck as
-select attrelid::regclass as relname,
-attnum, attoptions from pg_class c, pg_attribute_encoding e
-where c.relname like 'ccddl%' and c.oid=e.attrelid
-order by relname, attnum;
+select e.attrelid::regclass as relname,
+a.attname, e.attoptions from pg_class c, pg_attribute_encoding e, pg_attribute a
+where c.relname like 'ccddl%' and c.oid=e.attrelid and e.attrelid=a.attrelid and e.attnum = a.attnum
+order by relname, e.attnum;
 -- default encoding clause
 create table ccddl (
 	i int,
@@ -20,10 +20,10 @@ create table ccddl (
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 execute ccddlcheck;
- relname | attnum |                     attoptions                      
----------+--------+-----------------------------------------------------
- ccddl   |      1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl   |      2 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ relname | attname |                     attoptions                      
+---------+---------+-----------------------------------------------------
+ ccddl   | i       | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl   | j       | {compresstype=zlib,compresslevel=1,blocksize=32768}
 (2 rows)
 
 -- This is enough to force compression, specially since we'll hash
@@ -144,10 +144,10 @@ create table ccddl (
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 execute ccddlcheck;
- relname | attnum |                     attoptions                      
----------+--------+-----------------------------------------------------
- ccddl   |      1 | {compresstype=zlib,compresslevel=5,blocksize=32768}
- ccddl   |      2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ relname | attname |                     attoptions                      
+---------+---------+-----------------------------------------------------
+ ccddl   | i       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ ccddl   | j       | {compresstype=zlib,compresslevel=5,blocksize=32768}
 (2 rows)
 
 drop table ccddl;
@@ -159,10 +159,10 @@ create table ccddl (
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 execute ccddlcheck;
- relname | attnum |                     attoptions                      
----------+--------+-----------------------------------------------------
- ccddl   |      1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl   |      2 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ relname | attname |                     attoptions                      
+---------+---------+-----------------------------------------------------
+ ccddl   | i       | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl   | j       | {compresstype=zlib,compresslevel=1,blocksize=32768}
 (2 rows)
 
 -- This is enough to force compression, specially since we'll hash
@@ -291,10 +291,10 @@ create table ccddl (
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 execute ccddlcheck;
- relname | attnum |                       attoptions                        
----------+--------+---------------------------------------------------------
- ccddl   |      1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl   |      2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ relname | attname |                       attoptions                        
+---------+---------+---------------------------------------------------------
+ ccddl   | i       | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl   | j       | {compresstype=rle_type,compresslevel=1,blocksize=32768}
 (2 rows)
 
 drop table ccddl;
@@ -308,10 +308,10 @@ create table ccddl (
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 execute ccddlcheck;
- relname | attnum |                       attoptions                        
----------+--------+---------------------------------------------------------
- ccddl   |      1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl   |      2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ relname | attname |                       attoptions                        
+---------+---------+---------------------------------------------------------
+ ccddl   | i       | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl   | j       | {compresstype=rle_type,compresslevel=1,blocksize=32768}
 (2 rows)
 
 drop table ccddl;
@@ -324,33 +324,33 @@ create table ccddl (
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 execute ccddlcheck;
- relname | attnum |                     attoptions                      
----------+--------+-----------------------------------------------------
- ccddl   |      1 | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl   |      2 | {compresstype=zlib,blocksize=65536,compresslevel=1}
+ relname | attname |                     attoptions                      
+---------+---------+-----------------------------------------------------
+ ccddl   | i       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl   | j       | {compresstype=zlib,blocksize=65536,compresslevel=1}
 (2 rows)
 
 -- Should see the encoding information for the new column
 alter table ccddl add column k timestamp default now()
 	encoding (compresstype=zlib);
 execute ccddlcheck;
- relname | attnum |                     attoptions                      
----------+--------+-----------------------------------------------------
- ccddl   |      1 | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl   |      2 | {compresstype=zlib,blocksize=65536,compresslevel=1}
- ccddl   |      3 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ relname | attname |                     attoptions                      
+---------+---------+-----------------------------------------------------
+ ccddl   | i       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl   | j       | {compresstype=zlib,blocksize=65536,compresslevel=1}
+ ccddl   | k       | {compresstype=zlib,compresslevel=1,blocksize=32768}
 (3 rows)
 
 -- no encoding information for this one though
 alter table ccddl add column l numeric
 	default 3.141;
 execute ccddlcheck;
- relname | attnum |                     attoptions                      
----------+--------+-----------------------------------------------------
- ccddl   |      1 | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl   |      2 | {compresstype=zlib,blocksize=65536,compresslevel=1}
- ccddl   |      3 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl   |      4 | {compresstype=none,blocksize=32768,compresslevel=0}
+ relname | attname |                     attoptions                      
+---------+---------+-----------------------------------------------------
+ ccddl   | i       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl   | j       | {compresstype=zlib,blocksize=65536,compresslevel=1}
+ ccddl   | k       | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl   | l       | {compresstype=none,blocksize=32768,compresslevel=0}
 (4 rows)
 
 drop table ccddl;
@@ -361,10 +361,10 @@ create table ccddl (i int, j int encoding(compresstype=zlib), column i encoding
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 execute ccddlcheck;
- relname | attnum |                     attoptions                      
----------+--------+-----------------------------------------------------
- ccddl   |      1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl   |      2 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ relname | attname |                     attoptions                      
+---------+---------+-----------------------------------------------------
+ ccddl   | i       | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl   | j       | {compresstype=zlib,compresslevel=1,blocksize=32768}
 (2 rows)
 
 drop table ccddl;
@@ -374,10 +374,10 @@ compresstype=zlib);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 execute ccddlcheck;
- relname | attnum |                     attoptions                      
----------+--------+-----------------------------------------------------
- ccddl   |      1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl   |      2 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ relname | attname |                     attoptions                      
+---------+---------+-----------------------------------------------------
+ ccddl   | i       | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl   | j       | {compresstype=zlib,compresslevel=1,blocksize=32768}
 (2 rows)
 
 drop table ccddl;
@@ -387,10 +387,10 @@ create table ccddl (i int, j int encoding (COMPRESSTYPE="ZlIb"))
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 execute ccddlcheck;
- relname | attnum |                     attoptions                      
----------+--------+-----------------------------------------------------
- ccddl   |      1 | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl   |      2 | {compresstype=ZlIb,compresslevel=1,blocksize=32768}
+ relname | attname |                     attoptions                      
+---------+---------+-----------------------------------------------------
+ ccddl   | i       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl   | j       | {compresstype=ZlIb,compresslevel=1,blocksize=32768}
 (2 rows)
 
 drop table ccddl;
@@ -402,9 +402,9 @@ create table ccddl_co(LIKE ccddl)
   with (appendonly = true, orientation=column);
 NOTICE:  table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 execute ccddlcheck;
- relname  | attnum |                     attoptions                      
-----------+--------+-----------------------------------------------------
- ccddl_co |      1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ relname  | attname |                     attoptions                      
+----------+---------+-----------------------------------------------------
+ ccddl_co | i       | {compresstype=none,blocksize=32768,compresslevel=0}
 (1 row)
 
 drop table ccddl_co;
@@ -412,9 +412,9 @@ create table ccddl_co(LIKE ccddl)
   with (appendonly = true, orientation=column, compresstype=zlib);
 NOTICE:  table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 execute ccddlcheck;
- relname  | attnum |                     attoptions                      
-----------+--------+-----------------------------------------------------
- ccddl_co |      1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ relname  | attname |                     attoptions                      
+----------+---------+-----------------------------------------------------
+ ccddl_co | i       | {compresstype=zlib,compresslevel=1,blocksize=32768}
 (1 row)
 
 drop table ccddl_co, ccddl;
@@ -462,9 +462,9 @@ appendonly=true, orientation=column);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 execute ccddlcheck;
- relname | attnum |                       attoptions                        
----------+--------+---------------------------------------------------------
- ccddl   |      1 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ relname | attname |                       attoptions                        
+---------+---------+---------------------------------------------------------
+ ccddl   | i       | {compresstype=rle_type,compresslevel=1,blocksize=32768}
 (1 row)
 
 drop table ccddl;
@@ -506,13 +506,13 @@ NOTICE:  table has parent, setting distribution columns to match parent table
 NOTICE:  moving and merging column "parentcol" with inherited definition
 DETAIL:  User-specified column moved to the position of the inherited column.
 execute ccddlcheck;
-   relname   | attnum |                     attoptions                      
--------------+--------+-----------------------------------------------------
- ccddlparent |      1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddlchild  |      1 | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddlchild  |      2 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddlchild2 |      1 | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddlchild2 |      2 | {compresstype=none,blocksize=32768,compresslevel=0}
+   relname   |  attname  |                     attoptions                      
+-------------+-----------+-----------------------------------------------------
+ ccddlparent | parentcol | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddlchild  | parentcol | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddlchild  | childcol  | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddlchild2 | parentcol | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddlchild2 | childcol  | {compresstype=none,blocksize=32768,compresslevel=0}
 (5 rows)
 
 drop table ccddlparent cascade;
@@ -538,15 +538,15 @@ NOTICE:  table has parent, setting distribution columns to match parent table
 NOTICE:  merging multiple inherited definitions of column "parentcol1"
 NOTICE:  merging multiple inherited definitions of column "parentcol2"
 execute ccddlcheck;
-   relname    | attnum |                     attoptions                      
---------------+--------+-----------------------------------------------------
- ccddlparent1 |      1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddlparent1 |      2 | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddlparent2 |      1 | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddlparent2 |      2 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddlchild   |      1 | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddlchild   |      2 | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddlchild   |      3 | {compresstype=none,blocksize=32768,compresslevel=0}
+   relname    |  attname   |                     attoptions                      
+--------------+------------+-----------------------------------------------------
+ ccddlparent1 | parentcol1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddlparent1 | parentcol2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddlparent2 | parentcol1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddlparent2 | parentcol2 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddlchild   | parentcol1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddlchild   | parentcol2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddlchild   | childcol   | {compresstype=none,blocksize=32768,compresslevel=0}
 (7 rows)
 
 drop table ccddlparent1 cascade;
@@ -568,10 +568,10 @@ select 1, 1;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 execute ccddlcheck;
- relname | attnum |                     attoptions                      
----------+--------+-----------------------------------------------------
- ccddl   |      1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl   |      2 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ relname | attname |                     attoptions                      
+---------+---------+-----------------------------------------------------
+ ccddl   | a       | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl   | b       | {compresstype=zlib,compresslevel=1,blocksize=32768}
 (2 rows)
 
 drop table ccddl;
@@ -584,10 +584,10 @@ create table ccddl_co (like ccddl, column i encoding(compresstype=RLE_TYPE))
 with (appendonly=true, orientation=column, compresstype=zlib);
 NOTICE:  table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 execute ccddlcheck;
- relname  | attnum |                       attoptions                        
-----------+--------+---------------------------------------------------------
- ccddl_co |      1 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- ccddl_co |      2 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ relname  | attname |                       attoptions                        
+----------+---------+---------------------------------------------------------
+ ccddl_co | i       | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ ccddl_co | j       | {compresstype=zlib,compresslevel=1,blocksize=32768}
 (2 rows)
 
 drop table ccddl;
@@ -608,13 +608,15 @@ partition by range(j)
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 execute ccddlcheck;
-    relname     | attnum |                       attoptions                        
-----------------+--------+---------------------------------------------------------
- ccddl_1_prt_p1 |      1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p1 |      2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p2 |      1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p2 |      2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
-(4 rows)
+    relname     | attname |                       attoptions                        
+----------------+---------+---------------------------------------------------------
+ ccddl          | i       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl          | j       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p1 | i       | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p1 | j       | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p2 | i       | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p2 | j       | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+(6 rows)
 
 insert into ccddl select 1,2 from generate_series(1, 100);
 select * from ccddl;
@@ -741,17 +743,29 @@ partition by range(j)
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 execute ccddlcheck;
-         relname          | attnum |                       attoptions                        
---------------------------+--------+---------------------------------------------------------
- ccddl_1_prt_p1_2_prt_sp1 |      1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p1_2_prt_sp1 |      2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p1_2_prt_sp1 |      3 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p1_2_prt_sp1 |      4 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p2_2_prt_sp1 |      1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p2_2_prt_sp1 |      2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p2_2_prt_sp1 |      3 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p2_2_prt_sp1 |      4 | {compresstype=zlib,compresslevel=1,blocksize=32768}
-(8 rows)
+         relname          | attname |                       attoptions                        
+--------------------------+---------+---------------------------------------------------------
+ ccddl                    | i       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl                    | j       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl                    | k       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl                    | l       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p1           | i       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p1           | j       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p1           | k       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p1           | l       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p2           | i       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p2           | j       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p2           | k       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p2           | l       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p1_2_prt_sp1 | i       | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p1_2_prt_sp1 | j       | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p1_2_prt_sp1 | k       | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p1_2_prt_sp1 | l       | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p2_2_prt_sp1 | i       | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p2_2_prt_sp1 | j       | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p2_2_prt_sp1 | k       | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p2_2_prt_sp1 | l       | {compresstype=zlib,compresslevel=1,blocksize=32768}
+(20 rows)
 
 SELECT level, pg_get_expr(template, relid) from gp_partition_template t WHERE t.relid = 'ccddl'::regclass;
  level |                                                                                                          pg_get_expr                                                                                                           
@@ -1092,35 +1106,63 @@ partition p2 start(10) end(20)
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 execute ccddlcheck;
-         relname          | attnum |                       attoptions                        
---------------------------+--------+---------------------------------------------------------
- ccddl_1_prt_p1_2_prt_sp1 |      1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p1_2_prt_sp1 |      2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p1_2_prt_sp1 |      3 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p1_2_prt_sp1 |      4 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p2_2_prt_sp1 |      1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p2_2_prt_sp1 |      2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p2_2_prt_sp1 |      3 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p2_2_prt_sp1 |      4 | {compresstype=zlib,compresslevel=1,blocksize=32768}
-(8 rows)
+         relname          | attname |                       attoptions                        
+--------------------------+---------+---------------------------------------------------------
+ ccddl                    | i       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl                    | j       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl                    | k       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl                    | l       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p1           | i       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p1           | j       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p1           | k       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p1           | l       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p2           | i       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p2           | j       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p2           | k       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p2           | l       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p1_2_prt_sp1 | i       | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p1_2_prt_sp1 | j       | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p1_2_prt_sp1 | k       | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p1_2_prt_sp1 | l       | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p2_2_prt_sp1 | i       | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p2_2_prt_sp1 | j       | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p2_2_prt_sp1 | k       | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p2_2_prt_sp1 | l       | {compresstype=zlib,compresslevel=1,blocksize=32768}
+(20 rows)
 
 alter table ccddl add partition p3 start(20) end(30);
 execute ccddlcheck;
-         relname          | attnum |                       attoptions                        
---------------------------+--------+---------------------------------------------------------
- ccddl_1_prt_p1_2_prt_sp1 |      1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p1_2_prt_sp1 |      2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p1_2_prt_sp1 |      3 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p1_2_prt_sp1 |      4 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p2_2_prt_sp1 |      1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p2_2_prt_sp1 |      2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p2_2_prt_sp1 |      3 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p2_2_prt_sp1 |      4 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p3_2_prt_sp1 |      1 | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_p3_2_prt_sp1 |      2 | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_p3_2_prt_sp1 |      3 | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_p3_2_prt_sp1 |      4 | {compresstype=none,blocksize=32768,compresslevel=0}
-(12 rows)
+         relname          | attname |                       attoptions                        
+--------------------------+---------+---------------------------------------------------------
+ ccddl                    | i       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl                    | j       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl                    | k       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl                    | l       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p1           | i       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p1           | j       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p1           | k       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p1           | l       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p2           | i       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p2           | j       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p2           | k       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p2           | l       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p1_2_prt_sp1 | i       | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p1_2_prt_sp1 | j       | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p1_2_prt_sp1 | k       | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p1_2_prt_sp1 | l       | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p2_2_prt_sp1 | i       | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p2_2_prt_sp1 | j       | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p2_2_prt_sp1 | k       | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p2_2_prt_sp1 | l       | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p3           | i       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p3           | j       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p3           | k       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p3           | l       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p3_2_prt_sp1 | i       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p3_2_prt_sp1 | j       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p3_2_prt_sp1 | k       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p3_2_prt_sp1 | l       | {compresstype=none,blocksize=32768,compresslevel=0}
+(28 rows)
 
 drop table ccddl;
 -- Make sure the AO/CO case didn't screw up the non CO case
@@ -1137,14 +1179,14 @@ partition p2 start(10) end(20)
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 execute ccddlcheck;
- relname | attnum | attoptions 
----------+--------+------------
+ relname | attname | attoptions 
+---------+---------+------------
 (0 rows)
 
 alter table ccddl add partition p3 start(20) end(30);
 execute ccddlcheck;
- relname | attnum | attoptions 
----------+--------+------------
+ relname | attname | attoptions 
+---------+---------+------------
 (0 rows)
 
 drop table ccddl;
@@ -1156,18 +1198,20 @@ partition by range(i)
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 execute ccddlcheck;
-    relname     | attnum |                     attoptions                      
-----------------+--------+-----------------------------------------------------
- ccddl_1_prt_p1 |      1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
-(1 row)
+    relname     | attname |                     attoptions                      
+----------------+---------+-----------------------------------------------------
+ ccddl          | i       | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p1 | i       | {compresstype=zlib,compresslevel=1,blocksize=32768}
+(2 rows)
 
 alter table ccddl split partition p1 at (5) into (partition p2, partition p3);
 execute ccddlcheck;
-    relname     | attnum |                     attoptions                      
-----------------+--------+-----------------------------------------------------
- ccddl_1_prt_p2 |      1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p3 |      1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
-(2 rows)
+    relname     | attname |                     attoptions                      
+----------------+---------+-----------------------------------------------------
+ ccddl          | i       | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p2 | i       | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p3 | i       | {compresstype=zlib,compresslevel=1,blocksize=32768}
+(3 rows)
 
 drop table ccddl;
 -- With subpartitioning
@@ -1181,11 +1225,15 @@ subpartition template (subpartition sp1 start(1) end(20),
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 execute ccddlcheck;
-         relname          | attnum |                       attoptions                        
---------------------------+--------+---------------------------------------------------------
- ccddl_1_prt_p1_2_prt_sp1 |      1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p1_2_prt_sp1 |      2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
-(2 rows)
+         relname          | attname |                       attoptions                        
+--------------------------+---------+---------------------------------------------------------
+ ccddl                    | i       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl                    | j       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p1           | i       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p1           | j       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p1_2_prt_sp1 | i       | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p1_2_prt_sp1 | j       | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+(6 rows)
 
 SELECT level, pg_get_expr(template, relid) from gp_partition_template t WHERE t.relid = 'ccddl'::regclass;
  level |                                                                          pg_get_expr                                                                           
@@ -1195,25 +1243,33 @@ SELECT level, pg_get_expr(template, relid) from gp_partition_template t WHERE t.
 
 alter table ccddl alter partition p1 split partition sp1 at (10) into (partition sp2, partition sp3);
 execute ccddlcheck;
-         relname          | attnum |                       attoptions                        
---------------------------+--------+---------------------------------------------------------
- ccddl_1_prt_p1_2_prt_sp2 |      1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p1_2_prt_sp2 |      2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p1_2_prt_sp3 |      1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p1_2_prt_sp3 |      2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
-(4 rows)
+         relname          | attname |                       attoptions                        
+--------------------------+---------+---------------------------------------------------------
+ ccddl                    | i       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl                    | j       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p1           | i       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p1           | j       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p1_2_prt_sp2 | i       | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p1_2_prt_sp2 | j       | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p1_2_prt_sp3 | i       | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p1_2_prt_sp3 | j       | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+(8 rows)
 
 alter table ccddl alter partition p1 split partition sp2 at (5) into (partition sp2, partition sp2_5);
 execute ccddlcheck;
-          relname           | attnum |                       attoptions                        
-----------------------------+--------+---------------------------------------------------------
- ccddl_1_prt_p1_2_prt_sp3   |      1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p1_2_prt_sp3   |      2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p1_2_prt_sp2   |      1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p1_2_prt_sp2   |      2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p1_2_prt_sp2_5 |      1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p1_2_prt_sp2_5 |      2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
-(6 rows)
+          relname           | attname |                       attoptions                        
+----------------------------+---------+---------------------------------------------------------
+ ccddl                      | i       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl                      | j       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p1             | i       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p1             | j       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p1_2_prt_sp3   | i       | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p1_2_prt_sp3   | j       | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p1_2_prt_sp2   | i       | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p1_2_prt_sp2   | j       | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p1_2_prt_sp2_5 | i       | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p1_2_prt_sp2_5 | j       | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+(10 rows)
 
 drop table ccddl;
 -- MPP-14407
@@ -1238,14 +1294,29 @@ CREATE TABLE ccddl (id int, year int, month int, day int, region text)
 		)
 	( START (2008) END (2010) );
 execute ccddlcheck;
-             relname             | attnum |                       attoptions                        
----------------------------------+--------+---------------------------------------------------------
- ccddl_1_prt_1_2_prt_1_3_prt_usa |      1 | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_1_2_prt_1_3_prt_usa |      2 | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_1_2_prt_1_3_prt_usa |      3 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- ccddl_1_prt_1_2_prt_1_3_prt_usa |      4 | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_1_2_prt_1_3_prt_usa |      5 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
-(5 rows)
+             relname             | attname |                       attoptions                        
+---------------------------------+---------+---------------------------------------------------------
+ ccddl                           | id      | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl                           | year    | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl                           | month   | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl                           | day     | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl                           | region  | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_1                   | id      | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_1                   | year    | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_1                   | month   | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_1                   | day     | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_1                   | region  | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_1_2_prt_1           | id      | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_1_2_prt_1           | year    | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_1_2_prt_1           | month   | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_1_2_prt_1           | day     | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_1_2_prt_1           | region  | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_1_2_prt_1_3_prt_usa | id      | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_1_2_prt_1_3_prt_usa | year    | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_1_2_prt_1_3_prt_usa | month   | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_1_2_prt_1_3_prt_usa | day     | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_1_2_prt_1_3_prt_usa | region  | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+(20 rows)
 
 SELECT level, pg_get_expr(template, relid) from gp_partition_template t WHERE t.relid = 'ccddl'::regclass;
  level |                                                 pg_get_expr                                                 
@@ -1385,21 +1456,25 @@ create table ccddl (
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 execute ccddlcheck;
-    relname     | attnum |                       attoptions                        
-----------------+--------+---------------------------------------------------------
- ccddl_1_prt_p1 |      1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p1 |      2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p1 |      3 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p1 |      4 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p2 |      1 | {blocksize=65536,compresstype=none,compresslevel=0}
- ccddl_1_prt_p2 |      2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p2 |      3 | {blocksize=8192,compresstype=none,compresslevel=0}
- ccddl_1_prt_p2 |      4 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p3 |      1 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p3 |      2 | {blocksize=8192,compresstype=none,compresslevel=0}
- ccddl_1_prt_p3 |      3 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p3 |      4 | {compresstype=zlib,compresslevel=1,blocksize=32768}
-(12 rows)
+    relname     | attname |                       attoptions                        
+----------------+---------+---------------------------------------------------------
+ ccddl          | i       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl          | j       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl          | k       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl          | l       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p1 | i       | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p1 | j       | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p1 | k       | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p1 | l       | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p2 | i       | {blocksize=65536,compresstype=none,compresslevel=0}
+ ccddl_1_prt_p2 | j       | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p2 | k       | {blocksize=8192,compresstype=none,compresslevel=0}
+ ccddl_1_prt_p2 | l       | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p3 | i       | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p3 | j       | {blocksize=8192,compresstype=none,compresslevel=0}
+ ccddl_1_prt_p3 | k       | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p3 | l       | {compresstype=zlib,compresslevel=1,blocksize=32768}
+(16 rows)
 
 drop table ccddl;
 create table ccddl (i int, j int, k int, l int )
@@ -1422,17 +1497,90 @@ partition by range(i) subpartition by range(j)
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 execute ccddlcheck;
-         relname          | attnum |                       attoptions                        
---------------------------+--------+---------------------------------------------------------
- ccddl_1_prt_p1_2_prt_sp1 |      1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p1_2_prt_sp1 |      2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p1_2_prt_sp1 |      3 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p1_2_prt_sp1 |      4 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p2_2_prt_sp1 |      1 | {blocksize=65536,compresstype=none,compresslevel=0}
- ccddl_1_prt_p2_2_prt_sp1 |      2 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p2_2_prt_sp1 |      3 | {blocksize=8192,compresstype=none,compresslevel=0}
- ccddl_1_prt_p2_2_prt_sp1 |      4 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
-(8 rows)
+         relname          | attname |                       attoptions                        
+--------------------------+---------+---------------------------------------------------------
+ ccddl                    | i       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl                    | j       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl                    | k       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl                    | l       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p1           | i       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p1           | j       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p1           | k       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p1           | l       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p2           | i       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p2           | j       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p2           | k       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p2           | l       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p1_2_prt_sp1 | i       | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p1_2_prt_sp1 | j       | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p1_2_prt_sp1 | k       | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p1_2_prt_sp1 | l       | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p2_2_prt_sp1 | i       | {blocksize=65536,compresstype=none,compresslevel=0}
+ ccddl_1_prt_p2_2_prt_sp1 | j       | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p2_2_prt_sp1 | k       | {blocksize=8192,compresstype=none,compresslevel=0}
+ ccddl_1_prt_p2_2_prt_sp1 | l       | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+(20 rows)
+
+drop table ccddl;
+-- multi level partitioning with column encoding inheritance
+create table ccddl (a int ENCODING (compresslevel=1),
+                    b int ENCODING (compresslevel=1),
+                    c int ENCODING (compresslevel=1),
+                    d int ENCODING (compresslevel=1),
+                    e int, f int, g int, h int)
+    with (appendonly = true, orientation=column, compresslevel=5)
+    partition by range(a) subpartition by range(b)
+        (partition p1 start(1) end(10)
+            (subpartition sp1 start(1) end(5)
+             column a encoding(compresslevel=3),
+             column d encoding(compresslevel=3),
+             column f encoding(compresslevel=3),
+             column g encoding(compresslevel=3)),
+       column a encoding(compresslevel=2),
+       column b encoding(compresslevel=2),
+       column e encoding(compresslevel=2),
+       column g encoding(compresslevel=2));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+execute ccddlcheck;
+         relname          | attname |                     attoptions                      
+--------------------------+---------+-----------------------------------------------------
+ ccddl                    | a       | {compresslevel=1,compresstype=zlib,blocksize=32768}
+ ccddl                    | b       | {compresslevel=1,compresstype=zlib,blocksize=32768}
+ ccddl                    | c       | {compresslevel=1,compresstype=zlib,blocksize=32768}
+ ccddl                    | d       | {compresslevel=1,compresstype=zlib,blocksize=32768}
+ ccddl                    | e       | {compresslevel=5,compresstype=zlib,blocksize=32768}
+ ccddl                    | f       | {compresslevel=5,compresstype=zlib,blocksize=32768}
+ ccddl                    | g       | {compresslevel=5,compresstype=zlib,blocksize=32768}
+ ccddl                    | h       | {compresslevel=5,compresstype=zlib,blocksize=32768}
+ ccddl_1_prt_p1           | a       | {compresslevel=2,compresstype=zlib,blocksize=32768}
+ ccddl_1_prt_p1           | b       | {compresslevel=2,compresstype=zlib,blocksize=32768}
+ ccddl_1_prt_p1           | c       | {compresslevel=1,compresstype=zlib,blocksize=32768}
+ ccddl_1_prt_p1           | d       | {compresslevel=1,compresstype=zlib,blocksize=32768}
+ ccddl_1_prt_p1           | e       | {compresslevel=2,compresstype=zlib,blocksize=32768}
+ ccddl_1_prt_p1           | f       | {compresslevel=5,compresstype=zlib,blocksize=32768}
+ ccddl_1_prt_p1           | g       | {compresslevel=2,compresstype=zlib,blocksize=32768}
+ ccddl_1_prt_p1           | h       | {compresslevel=5,compresstype=zlib,blocksize=32768}
+ ccddl_1_prt_p1_2_prt_sp1 | a       | {compresslevel=3,compresstype=zlib,blocksize=32768}
+ ccddl_1_prt_p1_2_prt_sp1 | b       | {compresslevel=2,compresstype=zlib,blocksize=32768}
+ ccddl_1_prt_p1_2_prt_sp1 | c       | {compresslevel=1,compresstype=zlib,blocksize=32768}
+ ccddl_1_prt_p1_2_prt_sp1 | d       | {compresslevel=3,compresstype=zlib,blocksize=32768}
+ ccddl_1_prt_p1_2_prt_sp1 | e       | {compresslevel=2,compresstype=zlib,blocksize=32768}
+ ccddl_1_prt_p1_2_prt_sp1 | f       | {compresslevel=3,compresstype=zlib,blocksize=32768}
+ ccddl_1_prt_p1_2_prt_sp1 | g       | {compresslevel=3,compresstype=zlib,blocksize=32768}
+ ccddl_1_prt_p1_2_prt_sp1 | h       | {compresslevel=5,compresstype=zlib,blocksize=32768}
+(24 rows)
+
+insert into ccddl select 2,3 from generate_series(1, 100);
+select * from ccddl limit 5;
+ a | b | c | d | e | f | g | h 
+---+---+---+---+---+---+---+---
+ 2 | 3 |   |   |   |   |   |  
+ 2 | 3 |   |   |   |   |   |  
+ 2 | 3 |   |   |   |   |   |  
+ 2 | 3 |   |   |   |   |   |  
+ 2 | 3 |   |   |   |   |   |  
+(5 rows)
 
 drop table ccddl;
 -- Precedence test: c3 in the partition child must be zlib, not RLE_TYPE
@@ -1449,12 +1597,15 @@ WITH (appendonly=true, orientation=column)
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 execute ccddlcheck;
-    relname    | attnum |                       attoptions                        
----------------+--------+---------------------------------------------------------
- ccddl_1_prt_1 |      1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_1 |      2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- ccddl_1_prt_1 |      3 | {compresstype=zlib,compresslevel=1,blocksize=32768}
-(3 rows)
+    relname    | attname |                       attoptions                        
+---------------+---------+---------------------------------------------------------
+ ccddl         | c1      | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl         | c2      | {compresstype=rle_type,blocksize=65536,compresslevel=1}
+ ccddl         | c3      | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_1 | c1      | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_1 | c2      | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_1 | c3      | {compresstype=zlib,compresslevel=1,blocksize=32768}
+(6 rows)
 
 drop table ccddl;
 -- Should be able to turn have a partition ignore a column encoding clause
@@ -1472,11 +1623,13 @@ create table ccddl
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 execute ccddlcheck;
-    relname     | attnum |                       attoptions                        
-----------------+--------+---------------------------------------------------------
- ccddl_1_prt_p2 |      1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p2 |      2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
-(2 rows)
+    relname     | attname |                       attoptions                        
+----------------+---------+---------------------------------------------------------
+ ccddl          | i       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl          | j       | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p2 | i       | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p2 | j       | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+(4 rows)
 
 drop table ccddl;
 -- MPP-16875: ensure that WITH () is honoured
@@ -1493,13 +1646,15 @@ alter table ccddl add partition "s_xyz" values ('xyz')
 	WITH (appendonly=true, orientation=column,
 		  compresstype=zlib, compresslevel=1);
 execute ccddlcheck;
-      relname      | attnum |                     attoptions                      
--------------------+--------+-----------------------------------------------------
- ccddl_1_prt_s_abc |      1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_s_abc |      2 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_s_xyz |      1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_s_xyz |      2 | {compresstype=zlib,compresslevel=1,blocksize=32768}
-(4 rows)
+      relname      | attname |                     attoptions                      
+-------------------+---------+-----------------------------------------------------
+ ccddl             | a       | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl             | b       | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_s_abc | a       | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_s_abc | b       | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_s_xyz | a       | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_s_xyz | b       | {compresstype=zlib,compresslevel=1,blocksize=32768}
+(6 rows)
 
 drop table ccddl;
 -- Ensure that WITH () and subpartition template column encoding rules
@@ -1516,24 +1671,42 @@ alter table ccddl add partition newp
 	start('2010-01-06') end('2010-01-07')
 	with (appendonly=true, orientation=column);
 execute ccddlcheck;
-          relname           | attnum |                     attoptions                      
-----------------------------+--------+-----------------------------------------------------
- ccddl_1_prt_1_2_prt_sp1    |      1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_1_2_prt_sp1    |      2 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_1_2_prt_sp1    |      3 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_2_2_prt_sp1    |      1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_2_2_prt_sp1    |      2 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_2_2_prt_sp1    |      3 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_3_2_prt_sp1    |      1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_3_2_prt_sp1    |      2 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_3_2_prt_sp1    |      3 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_4_2_prt_sp1    |      1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_4_2_prt_sp1    |      2 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_4_2_prt_sp1    |      3 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_newp_2_prt_sp1 |      1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_newp_2_prt_sp1 |      2 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_newp_2_prt_sp1 |      3 | {compresstype=zlib,compresslevel=1,blocksize=32768}
-(15 rows)
+          relname           | attname |                     attoptions                      
+----------------------------+---------+-----------------------------------------------------
+ ccddl                      | i       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl                      | d       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl                      | j       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_1              | i       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_1              | d       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_1              | j       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_2              | i       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_2              | d       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_2              | j       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_3              | i       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_3              | d       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_3              | j       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_4              | i       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_4              | d       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_4              | j       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_1_2_prt_sp1    | i       | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_1_2_prt_sp1    | d       | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_1_2_prt_sp1    | j       | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_2_2_prt_sp1    | i       | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_2_2_prt_sp1    | d       | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_2_2_prt_sp1    | j       | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_3_2_prt_sp1    | i       | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_3_2_prt_sp1    | d       | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_3_2_prt_sp1    | j       | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_4_2_prt_sp1    | i       | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_4_2_prt_sp1    | d       | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_4_2_prt_sp1    | j       | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_newp           | i       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_newp           | d       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_newp           | j       | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_newp_2_prt_sp1 | i       | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_newp_2_prt_sp1 | d       | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_newp_2_prt_sp1 | j       | {compresstype=zlib,compresslevel=1,blocksize=32768}
+(33 rows)
 
 SELECT level, pg_get_expr(template, relid) from gp_partition_template t WHERE t.relid = 'ccddl'::regclass;
  level |                                           pg_get_expr                                           
@@ -1584,8 +1757,8 @@ partition by range(a1)
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a1' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 execute ccddlcheck;
- relname | attnum | attoptions 
----------+--------+------------
+ relname | attname | attoptions 
+---------+---------+------------
 (0 rows)
 
 drop table ccddl;
@@ -1627,27 +1800,27 @@ select typoptions from pg_type_encoding where typid='public.int42'::regtype;
 create table ccddl (i int42) with(appendonly = true, orientation=column);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
 execute ccddlcheck;
- relname | attnum |                     attoptions                      
----------+--------+-----------------------------------------------------
- ccddl   |      1 | {compresstype=zlib,blocksize=65536,compresslevel=1}
+ relname | attname |                     attoptions                      
+---------+---------+-----------------------------------------------------
+ ccddl   | i       | {compresstype=zlib,blocksize=65536,compresslevel=1}
 (1 row)
 
 alter type int42 set default encoding (compresstype=zlib);
 alter table ccddl add column j int42 default '1'::int42;
 execute ccddlcheck;
- relname | attnum |                     attoptions                      
----------+--------+-----------------------------------------------------
- ccddl   |      1 | {compresstype=zlib,blocksize=65536,compresslevel=1}
- ccddl   |      2 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ relname | attname |                     attoptions                      
+---------+---------+-----------------------------------------------------
+ ccddl   | i       | {compresstype=zlib,blocksize=65536,compresslevel=1}
+ ccddl   | j       | {compresstype=zlib,compresslevel=1,blocksize=32768}
 (2 rows)
 
 drop table ccddl;
 create table ccddl (i int42) with(appendonly = true, orientation=column);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
 execute ccddlcheck;
- relname | attnum |                     attoptions                      
----------+--------+-----------------------------------------------------
- ccddl   |      1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ relname | attname |                     attoptions                      
+---------+---------+-----------------------------------------------------
+ ccddl   | i       | {compresstype=zlib,compresslevel=1,blocksize=32768}
 (1 row)
 
 drop table ccddl;
@@ -1655,16 +1828,16 @@ drop table ccddl;
 create table ccddl (i int42);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
 execute ccddlcheck;
- relname | attnum | attoptions 
----------+--------+------------
+ relname | attname | attoptions 
+---------+---------+------------
 (0 rows)
 
 drop table ccddl;
 create table ccddl (i int42) with (appendonly = true);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
 execute ccddlcheck;
- relname | attnum | attoptions 
----------+--------+------------
+ relname | attname | attoptions 
+---------+---------+------------
 (0 rows)
 
 drop table ccddl;
@@ -1674,10 +1847,10 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suita
 alter type int42 set default encoding (compresstype=RLE_TYPE);
 alter table ccddl add column j int42 default '1'::int42;
 execute ccddlcheck;
- relname | attnum |                       attoptions                        
----------+--------+---------------------------------------------------------
- ccddl   |      1 | {compresstype=none,compresslevel=0,blocksize=32768}
- ccddl   |      2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ relname | attname |                       attoptions                        
+---------+---------+---------------------------------------------------------
+ ccddl   | i       | {compresstype=none,compresslevel=0,blocksize=32768}
+ ccddl   | j       | {compresstype=rle_type,compresslevel=1,blocksize=32768}
 (2 rows)
 
 drop table ccddl;
@@ -1687,8 +1860,8 @@ alter type int42 set default encoding (compresstype=RLE_TYPE);
 alter table ccddl add column j int42 default '1'::int42;
 -- No results are returned from the attribute encoding check, as compression with rle is not supported for row tables
 execute ccddlcheck;
- relname | attnum | attoptions 
----------+--------+------------
+ relname | attname | attoptions 
+---------+---------+------------
 (0 rows)
 
 drop table ccddl;
@@ -1698,8 +1871,8 @@ alter type int42 set default encoding (compresstype=RLE_TYPE);
 alter table ccddl add column j int42 default '1'::int42;
 -- No results are returned from the attribute encoding check, as compression with rle is not supported for heap tables
 execute ccddlcheck;
- relname | attnum | attoptions 
----------+--------+------------
+ relname | attname | attoptions 
+---------+---------+------------
 (0 rows)
 
 drop table ccddl;

--- a/src/test/regress/expected/gp_partition_template.out
+++ b/src/test/regress/expected/gp_partition_template.out
@@ -566,6 +566,18 @@ SELECT t.*, pg_get_expr(relpartbound, oid) FROM pg_partition_tree('subpart_templ
 EXECUTE encoding_check;
                    relname                   | attnum |                       attoptions                        
 ---------------------------------------------+--------+---------------------------------------------------------
+ subpart_templ_encoding                      |      1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding                      |      2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding                      |      3 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding                      |      4 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p1             |      1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p1             |      2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p1             |      3 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p1             |      4 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p2             |      1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p2             |      2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p2             |      3 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p2             |      4 | {compresstype=none,blocksize=32768,compresslevel=0}
  subpart_templ_encoding_1_prt_p1_2_prt_sp1_1 |      1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
  subpart_templ_encoding_1_prt_p1_2_prt_sp1_1 |      2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
  subpart_templ_encoding_1_prt_p1_2_prt_sp1_1 |      3 | {compresstype=zlib,compresslevel=1,blocksize=32768}
@@ -582,13 +594,25 @@ EXECUTE encoding_check;
  subpart_templ_encoding_1_prt_p2_2_prt_sp1_2 |      2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
  subpart_templ_encoding_1_prt_p2_2_prt_sp1_2 |      3 | {compresstype=zlib,compresslevel=1,blocksize=32768}
  subpart_templ_encoding_1_prt_p2_2_prt_sp1_2 |      4 | {compresstype=zlib,compresslevel=1,blocksize=32768}
-(16 rows)
+(28 rows)
 
 -- FIXME: the new partitions should have the encodings specified in the template
 ALTER TABLE subpart_templ_encoding ADD PARTITION p3 START (30) END (40);
 EXECUTE encoding_check;
                    relname                   | attnum |                       attoptions                        
 ---------------------------------------------+--------+---------------------------------------------------------
+ subpart_templ_encoding                      |      1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding                      |      2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding                      |      3 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding                      |      4 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p1             |      1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p1             |      2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p1             |      3 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p1             |      4 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p2             |      1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p2             |      2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p2             |      3 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p2             |      4 | {compresstype=none,blocksize=32768,compresslevel=0}
  subpart_templ_encoding_1_prt_p1_2_prt_sp1_1 |      1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
  subpart_templ_encoding_1_prt_p1_2_prt_sp1_1 |      2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
  subpart_templ_encoding_1_prt_p1_2_prt_sp1_1 |      3 | {compresstype=zlib,compresslevel=1,blocksize=32768}
@@ -605,6 +629,10 @@ EXECUTE encoding_check;
  subpart_templ_encoding_1_prt_p2_2_prt_sp1_2 |      2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
  subpart_templ_encoding_1_prt_p2_2_prt_sp1_2 |      3 | {compresstype=zlib,compresslevel=1,blocksize=32768}
  subpart_templ_encoding_1_prt_p2_2_prt_sp1_2 |      4 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ subpart_templ_encoding_1_prt_p3             |      1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p3             |      2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p3             |      3 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p3             |      4 | {compresstype=none,blocksize=32768,compresslevel=0}
  subpart_templ_encoding_1_prt_p3_2_prt_sp1_1 |      1 | {compresstype=none,blocksize=32768,compresslevel=0}
  subpart_templ_encoding_1_prt_p3_2_prt_sp1_1 |      2 | {compresstype=none,blocksize=32768,compresslevel=0}
  subpart_templ_encoding_1_prt_p3_2_prt_sp1_1 |      3 | {compresstype=none,blocksize=32768,compresslevel=0}
@@ -613,7 +641,7 @@ EXECUTE encoding_check;
  subpart_templ_encoding_1_prt_p3_2_prt_sp1_2 |      2 | {compresstype=none,blocksize=32768,compresslevel=0}
  subpart_templ_encoding_1_prt_p3_2_prt_sp1_2 |      3 | {compresstype=none,blocksize=32768,compresslevel=0}
  subpart_templ_encoding_1_prt_p3_2_prt_sp1_2 |      4 | {compresstype=none,blocksize=32768,compresslevel=0}
-(24 rows)
+(40 rows)
 
 -- List partition with enclause
 DROP TABLE IF EXISTS subpart_templ_encoding;
@@ -652,6 +680,18 @@ SELECT t.*, pg_get_expr(relpartbound, oid) FROM pg_partition_tree('subpart_templ
 EXECUTE encoding_check;
                   relname                  | attnum |                       attoptions                        
 -------------------------------------------+--------+---------------------------------------------------------
+ subpart_templ_encoding                    |      1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding                    |      2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding                    |      3 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding                    |      4 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p1           |      1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p1           |      2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p1           |      3 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p1           |      4 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p2           |      1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p2           |      2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p2           |      3 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p2           |      4 | {compresstype=none,blocksize=32768,compresslevel=0}
  subpart_templ_encoding_1_prt_p1_2_prt_sp1 |      1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
  subpart_templ_encoding_1_prt_p1_2_prt_sp1 |      2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
  subpart_templ_encoding_1_prt_p1_2_prt_sp1 |      3 | {compresstype=zlib,compresslevel=1,blocksize=32768}
@@ -660,13 +700,25 @@ EXECUTE encoding_check;
  subpart_templ_encoding_1_prt_p2_2_prt_sp1 |      2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
  subpart_templ_encoding_1_prt_p2_2_prt_sp1 |      3 | {compresstype=zlib,compresslevel=1,blocksize=32768}
  subpart_templ_encoding_1_prt_p2_2_prt_sp1 |      4 | {compresstype=zlib,compresslevel=1,blocksize=32768}
-(8 rows)
+(20 rows)
 
 -- FIXME: the new partitions should have the encodings specified in the template
 ALTER TABLE subpart_templ_encoding ADD PARTITION p3 START (30) END (40);
 EXECUTE encoding_check;
                   relname                  | attnum |                       attoptions                        
 -------------------------------------------+--------+---------------------------------------------------------
+ subpart_templ_encoding                    |      1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding                    |      2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding                    |      3 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding                    |      4 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p1           |      1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p1           |      2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p1           |      3 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p1           |      4 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p2           |      1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p2           |      2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p2           |      3 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p2           |      4 | {compresstype=none,blocksize=32768,compresslevel=0}
  subpart_templ_encoding_1_prt_p1_2_prt_sp1 |      1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
  subpart_templ_encoding_1_prt_p1_2_prt_sp1 |      2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
  subpart_templ_encoding_1_prt_p1_2_prt_sp1 |      3 | {compresstype=zlib,compresslevel=1,blocksize=32768}
@@ -675,11 +727,15 @@ EXECUTE encoding_check;
  subpart_templ_encoding_1_prt_p2_2_prt_sp1 |      2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
  subpart_templ_encoding_1_prt_p2_2_prt_sp1 |      3 | {compresstype=zlib,compresslevel=1,blocksize=32768}
  subpart_templ_encoding_1_prt_p2_2_prt_sp1 |      4 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ subpart_templ_encoding_1_prt_p3           |      1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p3           |      2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p3           |      3 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p3           |      4 | {compresstype=none,blocksize=32768,compresslevel=0}
  subpart_templ_encoding_1_prt_p3_2_prt_sp1 |      1 | {compresstype=none,blocksize=32768,compresslevel=0}
  subpart_templ_encoding_1_prt_p3_2_prt_sp1 |      2 | {compresstype=none,blocksize=32768,compresslevel=0}
  subpart_templ_encoding_1_prt_p3_2_prt_sp1 |      3 | {compresstype=none,blocksize=32768,compresslevel=0}
  subpart_templ_encoding_1_prt_p3_2_prt_sp1 |      4 | {compresstype=none,blocksize=32768,compresslevel=0}
-(12 rows)
+(28 rows)
 
 -- Partition specific ENCODING clause is not supported in SUBPARTITION TEMPLATE
 create table template_partelem_enc (i int, j int, k int, l int)

--- a/src/test/regress/expected/partition_storage.out
+++ b/src/test/regress/expected/partition_storage.out
@@ -67,6 +67,32 @@ NOTICE:  table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution 
  alter table pt_heap_tab exchange partition for ('def') with table co_can; -- AO exchanged with CO
  alter table pt_heap_tab exchange partition for ('pqr') with table heap_can; -- CO exchanged with Heap
 --Check for the storage properties and indexes of the two tables involved in the exchange
+ \d+ pt_heap_tab
+                           Partitioned table "public.pt_heap_tab"
+ Column  |  Type   | Collation | Nullable | Default | Storage  | Stats target | Description 
+---------+---------+-----------+----------+---------+----------+--------------+-------------
+ a       | integer |           |          |         | plain    |              | 
+ b       | text    |           |          |         | extended |              | 
+ c       | integer |           |          |         | plain    |              | 
+ d       | integer |           |          |         | plain    |              | 
+ e       | numeric |           |          |         | main     |              | 
+ success | boolean |           |          |         | plain    |              | 
+Partition key: LIST (b)
+Indexes:
+    "heap_idx1" btree (a) WHERE c > 10
+    "heap_idx2" btree (upper(b))
+Partitions: pt_heap_tab_1_prt_abc1 FOR VALUES IN ('abc', 'abc2'),
+            pt_heap_tab_1_prt_abc2 FOR VALUES IN ('abc1'),
+            pt_heap_tab_1_prt_def FOR VALUES IN ('def', 'def1', 'def3'),
+            pt_heap_tab_1_prt_ghi1 FOR VALUES IN ('ghi', 'ghi2'),
+            pt_heap_tab_1_prt_ghi2 FOR VALUES IN ('ghi1'),
+            pt_heap_tab_1_prt_jkl FOR VALUES IN ('jkl', 'jkl1', 'jkl2'),
+            pt_heap_tab_1_prt_mno FOR VALUES IN ('mno', 'mno1', 'mno2'),
+            pt_heap_tab_1_prt_pqr FOR VALUES IN ('pqr', 'pqr1', 'pqr2'),
+            pt_heap_tab_1_prt_xyz1 FOR VALUES IN ('xyz', 'xyz2'),
+            pt_heap_tab_1_prt_xyz2 FOR VALUES IN ('xyz1')
+Distributed by: (a)
+
  \d+ heap_can
                                                             Table "public.heap_can"
  Column  |  Type   | Collation | Nullable | Default | Storage  | Stats target | Compression Type | Compression Level | Block Size | Description 
@@ -204,6 +230,33 @@ NOTICE:  table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution 
  alter table pt_ao_tab exchange partition for ('def') with table co_can; --AO tab exchanged with CO
  alter table pt_ao_tab exchange partition for ('pqr') with table heap_can; --CO tab exchanged with Heap
 --Check for the storage properties and indexes of the two tables involved in the exchange
+ \d+ pt_ao_tab
+                            Partitioned table "public.pt_ao_tab"
+ Column  |  Type   | Collation | Nullable | Default | Storage  | Stats target | Description 
+---------+---------+-----------+----------+---------+----------+--------------+-------------
+ a       | integer |           |          |         | plain    |              | 
+ b       | text    |           |          |         | extended |              | 
+ c       | integer |           |          |         | plain    |              | 
+ d       | integer |           |          |         | plain    |              | 
+ e       | numeric |           |          |         | main     |              | 
+ success | boolean |           |          |         | plain    |              | 
+Partition key: LIST (b)
+Indexes:
+    "ao_idx1" btree (a) WHERE c > 10
+    "ao_idx2" btree (upper(b))
+Partitions: pt_ao_tab_1_prt_abc1 FOR VALUES IN ('abc', 'abc2'),
+            pt_ao_tab_1_prt_abc2 FOR VALUES IN ('abc1'),
+            pt_ao_tab_1_prt_def FOR VALUES IN ('def', 'def1', 'def3'),
+            pt_ao_tab_1_prt_ghi1 FOR VALUES IN ('ghi', 'ghi2'),
+            pt_ao_tab_1_prt_ghi2 FOR VALUES IN ('ghi1'),
+            pt_ao_tab_1_prt_jkl FOR VALUES IN ('jkl', 'jkl1', 'jkl2'),
+            pt_ao_tab_1_prt_mno FOR VALUES IN ('mno', 'mno1', 'mno2'),
+            pt_ao_tab_1_prt_pqr FOR VALUES IN ('pqr', 'pqr1', 'pqr2'),
+            pt_ao_tab_1_prt_stu FOR VALUES IN ('stu', 'stu1', 'stu2'),
+            pt_ao_tab_1_prt_xyz1 FOR VALUES IN ('xyz', 'xyz2'),
+            pt_ao_tab_1_prt_xyz2 FOR VALUES IN ('xyz1')
+Distributed by: (a)
+
  \d+ heap_can
                                                             Table "public.heap_can"
  Column  |  Type   | Collation | Nullable | Default | Storage  | Stats target | Compression Type | Compression Level | Block Size | Description 
@@ -351,6 +404,33 @@ NOTICE:  table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution 
  alter table pt_co_tab exchange partition for ('pqr') with table co_can; -- AO exchanged with CO
  alter table pt_co_tab exchange partition for ('xyz1') with table heap_can; -- CO exchanged with Heap
 --Check for the storage properties and indexes of the two tables involved in the exchange
+ \d+ pt_co_tab
+                                                      Partitioned table "public.pt_co_tab"
+ Column  |  Type   | Collation | Nullable | Default | Storage  | Stats target | Compression Type | Compression Level | Block Size | Description 
+---------+---------+-----------+----------+---------+----------+--------------+------------------+-------------------+------------+-------------
+ a       | integer |           |          |         | plain    |              | none             | 0                 | 32768      | 
+ b       | text    |           |          |         | extended |              | none             | 0                 | 32768      | 
+ c       | integer |           |          |         | plain    |              | none             | 0                 | 32768      | 
+ d       | integer |           |          |         | plain    |              | none             | 0                 | 32768      | 
+ e       | numeric |           |          |         | main     |              | none             | 0                 | 32768      | 
+ success | boolean |           |          |         | plain    |              | none             | 0                 | 32768      | 
+Partition key: LIST (b)
+Indexes:
+    "co_idx1" btree (a) WHERE c > 10
+    "co_idx2" btree (upper(b))
+Partitions: pt_co_tab_1_prt_abc1 FOR VALUES IN ('abc', 'abc2'),
+            pt_co_tab_1_prt_abc2 FOR VALUES IN ('abc1'),
+            pt_co_tab_1_prt_def FOR VALUES IN ('def', 'def1', 'def3'),
+            pt_co_tab_1_prt_ghi1 FOR VALUES IN ('ghi', 'ghi2'),
+            pt_co_tab_1_prt_ghi2 FOR VALUES IN ('ghi1'),
+            pt_co_tab_1_prt_jkl FOR VALUES IN ('jkl', 'jkl1', 'jkl2'),
+            pt_co_tab_1_prt_mno FOR VALUES IN ('mno', 'mno1', 'mno2'),
+            pt_co_tab_1_prt_pqr FOR VALUES IN ('pqr', 'pqr1', 'pqr2'),
+            pt_co_tab_1_prt_stu FOR VALUES IN ('stu', 'stu1', 'stu2'),
+            pt_co_tab_1_prt_xyz1 FOR VALUES IN ('xyz', 'xyz2'),
+            pt_co_tab_1_prt_xyz2 FOR VALUES IN ('xyz1')
+Distributed by: (a)
+
  \d+ heap_can
                                                             Table "public.heap_can"
  Column  |  Type   | Collation | Nullable | Default | Storage  | Stats target | Compression Type | Compression Level | Block Size | Description 
@@ -480,6 +560,34 @@ NOTICE:  table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution 
  alter table pt_heap_tab_rng exchange partition heap1 with table ao_can; -- HEAP <=> AO
  alter table pt_heap_tab_rng exchange partition newao with table co_can; -- AO <=> CO
  alter table pt_heap_tab_rng exchange partition newco with table heap_can; -- CO <=> HEAP
+ \d+ pt_heap_tab_rng
+                         Partitioned table "public.pt_heap_tab_rng"
+ Column  |  Type   | Collation | Nullable | Default | Storage  | Stats target | Description 
+---------+---------+-----------+----------+---------+----------+--------------+-------------
+ a       | integer |           |          |         | plain    |              | 
+ b       | text    |           |          |         | extended |              | 
+ c       | integer |           |          |         | plain    |              | 
+ d       | integer |           |          |         | plain    |              | 
+ e       | numeric |           |          |         | main     |              | 
+ success | boolean |           |          |         | plain    |              | 
+Partition key: RANGE (a)
+Indexes:
+    "heap_rng_idx1" btree (a) WHERE c > 10
+    "heap_rng_idx2" btree (upper(b))
+Partitions: pt_heap_tab_rng_1_prt_2 FOR VALUES FROM (1) TO (6),
+            pt_heap_tab_rng_1_prt_3 FOR VALUES FROM (6) TO (11),
+            pt_heap_tab_rng_1_prt_4 FOR VALUES FROM (11) TO (16),
+            pt_heap_tab_rng_1_prt_5 FOR VALUES FROM (16) TO (20),
+            pt_heap_tab_rng_1_prt_ao1 FOR VALUES FROM (25) TO (27),
+            pt_heap_tab_rng_1_prt_ao2 FOR VALUES FROM (27) TO (30),
+            pt_heap_tab_rng_1_prt_co1 FOR VALUES FROM (31) TO (33),
+            pt_heap_tab_rng_1_prt_co2 FOR VALUES FROM (33) TO (35),
+            pt_heap_tab_rng_1_prt_heap1 FOR VALUES FROM (21) TO (23),
+            pt_heap_tab_rng_1_prt_heap2 FOR VALUES FROM (23) TO (25),
+            pt_heap_tab_rng_1_prt_newao FOR VALUES FROM (40) TO (45),
+            pt_heap_tab_rng_1_prt_newco FOR VALUES FROM (36) TO (40)
+Distributed by: (a)
+
  \d+ ao_can 
                                    Table "public.ao_can"
  Column  |  Type   | Collation | Nullable | Default | Storage  | Stats target | Description 
@@ -604,6 +712,35 @@ NOTICE:  table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution 
  alter table pt_ao_tab_rng exchange partition newheap with table ao_can; -- HEAP <=> AO
  alter table pt_ao_tab_rng exchange partition ao1 with table co_can;-- AO <=> CO
  alter table pt_ao_tab_rng exchange partition newco with table heap_can; --CO <=> HEAP
+ \d+ pt_ao_tab_rng
+                          Partitioned table "public.pt_ao_tab_rng"
+ Column  |  Type   | Collation | Nullable | Default | Storage  | Stats target | Description 
+---------+---------+-----------+----------+---------+----------+--------------+-------------
+ a       | integer |           |          |         | plain    |              | 
+ b       | text    |           |          |         | extended |              | 
+ c       | integer |           |          |         | plain    |              | 
+ d       | integer |           |          |         | plain    |              | 
+ e       | numeric |           |          |         | main     |              | 
+ success | boolean |           |          |         | plain    |              | 
+Partition key: RANGE (a)
+Indexes:
+    "ao_rng_idx1" btree (a) WHERE c > 10
+    "ao_rng_idx2" btree (upper(b))
+Partitions: pt_ao_tab_rng_1_prt_2 FOR VALUES FROM (1) TO (6),
+            pt_ao_tab_rng_1_prt_3 FOR VALUES FROM (6) TO (11),
+            pt_ao_tab_rng_1_prt_4 FOR VALUES FROM (11) TO (16),
+            pt_ao_tab_rng_1_prt_5 FOR VALUES FROM (16) TO (20),
+            pt_ao_tab_rng_1_prt_ao1 FOR VALUES FROM (25) TO (27),
+            pt_ao_tab_rng_1_prt_ao2 FOR VALUES FROM (27) TO (30),
+            pt_ao_tab_rng_1_prt_co1 FOR VALUES FROM (31) TO (33),
+            pt_ao_tab_rng_1_prt_co2 FOR VALUES FROM (33) TO (35),
+            pt_ao_tab_rng_1_prt_heap1 FOR VALUES FROM (21) TO (23),
+            pt_ao_tab_rng_1_prt_heap2 FOR VALUES FROM (23) TO (25),
+            pt_ao_tab_rng_1_prt_newco FOR VALUES FROM (36) TO (40),
+            pt_ao_tab_rng_1_prt_newheap FOR VALUES FROM (40) TO (45)
+Distributed by: (a)
+Options: compresstype=zlib, compresslevel=1
+
  \d+ ao_can 
                                    Table "public.ao_can"
  Column  |  Type   | Collation | Nullable | Default | Storage  | Stats target | Description 
@@ -729,6 +866,35 @@ NOTICE:  table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution 
  alter table pt_co_tab_rng exchange partition newheap with table ao_can;-- HEAP <=> AO
  alter table pt_co_tab_rng exchange partition newao with table co_can; -- AO <=> CO
  alter table pt_co_tab_rng exchange partition co1 with table heap_can; -- CO <=> HEAP
+ \d+ pt_co_tab_rng
+                                                    Partitioned table "public.pt_co_tab_rng"
+ Column  |  Type   | Collation | Nullable | Default | Storage  | Stats target | Compression Type | Compression Level | Block Size | Description 
+---------+---------+-----------+----------+---------+----------+--------------+------------------+-------------------+------------+-------------
+ a       | integer |           |          |         | plain    |              | zlib             | 1                 | 32768      | 
+ b       | text    |           |          |         | extended |              | zlib             | 1                 | 32768      | 
+ c       | integer |           |          |         | plain    |              | zlib             | 1                 | 32768      | 
+ d       | integer |           |          |         | plain    |              | zlib             | 1                 | 32768      | 
+ e       | numeric |           |          |         | main     |              | zlib             | 1                 | 32768      | 
+ success | boolean |           |          |         | plain    |              | zlib             | 1                 | 32768      | 
+Partition key: RANGE (a)
+Indexes:
+    "co_rng_idx1" btree (a) WHERE c > 10
+    "co_rng_idx2" btree (upper(b))
+Partitions: pt_co_tab_rng_1_prt_2 FOR VALUES FROM (1) TO (6),
+            pt_co_tab_rng_1_prt_3 FOR VALUES FROM (6) TO (11),
+            pt_co_tab_rng_1_prt_4 FOR VALUES FROM (11) TO (16),
+            pt_co_tab_rng_1_prt_5 FOR VALUES FROM (16) TO (20),
+            pt_co_tab_rng_1_prt_ao1 FOR VALUES FROM (25) TO (27),
+            pt_co_tab_rng_1_prt_ao2 FOR VALUES FROM (27) TO (30),
+            pt_co_tab_rng_1_prt_co1 FOR VALUES FROM (31) TO (33),
+            pt_co_tab_rng_1_prt_co2 FOR VALUES FROM (33) TO (35),
+            pt_co_tab_rng_1_prt_heap1 FOR VALUES FROM (21) TO (23),
+            pt_co_tab_rng_1_prt_heap2 FOR VALUES FROM (23) TO (25),
+            pt_co_tab_rng_1_prt_newao FOR VALUES FROM (36) TO (40),
+            pt_co_tab_rng_1_prt_newheap FOR VALUES FROM (40) TO (45)
+Distributed by: (a)
+Options: compresstype=zlib, compresslevel=1
+
  \d+ ao_can 
                                    Table "public.ao_can"
  Column  |  Type   | Collation | Nullable | Default | Storage  | Stats target | Description 
@@ -767,12 +933,12 @@ Distributed by: (a)
                                                             Table "public.heap_can"
  Column  |  Type   | Collation | Nullable | Default | Storage  | Stats target | Compression Type | Compression Level | Block Size | Description 
 ---------+---------+-----------+----------+---------+----------+--------------+------------------+-------------------+------------+-------------
- a       | integer |           |          |         | plain    |              | none             | 0                 | 32768      | 
- b       | text    |           |          |         | extended |              | none             | 0                 | 32768      | 
- c       | integer |           |          |         | plain    |              | none             | 0                 | 32768      | 
- d       | integer |           |          |         | plain    |              | none             | 0                 | 32768      | 
- e       | numeric |           |          |         | main     |              | none             | 0                 | 32768      | 
- success | boolean |           |          |         | plain    |              | none             | 0                 | 32768      | 
+ a       | integer |           |          |         | plain    |              | zlib             | 1                 | 32768      | 
+ b       | text    |           |          |         | extended |              | zlib             | 1                 | 32768      | 
+ c       | integer |           |          |         | plain    |              | zlib             | 1                 | 32768      | 
+ d       | integer |           |          |         | plain    |              | zlib             | 1                 | 32768      | 
+ e       | numeric |           |          |         | main     |              | zlib             | 1                 | 32768      | 
+ success | boolean |           |          |         | plain    |              | zlib             | 1                 | 32768      | 
 Checksum: t
 Indexes:
     "pt_co_tab_rng_1_prt_co1_a_idx" btree (a) WHERE c > 10

--- a/src/test/regress/sql/partition_storage.sql
+++ b/src/test/regress/sql/partition_storage.sql
@@ -60,6 +60,7 @@
  alter table pt_heap_tab exchange partition for ('pqr') with table heap_can; -- CO exchanged with Heap
 
 --Check for the storage properties and indexes of the two tables involved in the exchange
+ \d+ pt_heap_tab
  \d+ heap_can
  \d+ co_can
  \d+ ao_can
@@ -146,6 +147,7 @@ drop table if exists co_can cascade;
  alter table pt_ao_tab exchange partition for ('pqr') with table heap_can; --CO tab exchanged with Heap
 
 --Check for the storage properties and indexes of the two tables involved in the exchange
+ \d+ pt_ao_tab
  \d+ heap_can
  \d+ co_can
  \d+ ao_can
@@ -239,6 +241,7 @@ drop table if exists co_can cascade;
  alter table pt_co_tab exchange partition for ('xyz1') with table heap_can; -- CO exchanged with Heap
 
 --Check for the storage properties and indexes of the two tables involved in the exchange
+ \d+ pt_co_tab
  \d+ heap_can
  \d+ co_can
  \d+ ao_can
@@ -315,6 +318,7 @@ drop table if exists co_can cascade;
  alter table pt_heap_tab_rng exchange partition newao with table co_can; -- AO <=> CO
  alter table pt_heap_tab_rng exchange partition newco with table heap_can; -- CO <=> HEAP
 
+ \d+ pt_heap_tab_rng
  \d+ ao_can 
  \d+ co_can
  \d+ heap_can
@@ -386,6 +390,7 @@ drop table if exists co_can cascade;
  alter table pt_ao_tab_rng exchange partition ao1 with table co_can;-- AO <=> CO
  alter table pt_ao_tab_rng exchange partition newco with table heap_can; --CO <=> HEAP
 
+ \d+ pt_ao_tab_rng
  \d+ ao_can 
  \d+ co_can
  \d+ heap_can
@@ -458,6 +463,7 @@ drop table if exists co_can cascade;
  alter table pt_co_tab_rng exchange partition newao with table co_can; -- AO <=> CO
  alter table pt_co_tab_rng exchange partition co1 with table heap_can; -- CO <=> HEAP
 
+ \d+ pt_co_tab_rng
  \d+ ao_can 
  \d+ co_can
  \d+ heap_can


### PR DESCRIPTION
This PR includes two commits:

1. Add pg_attribute_encoding entries for partition roots.
During create statement, we add attribute encoding entries to catalog
If the table has a parent partition, and no options or encodings are
specified, we copy the parent partition's encoding entries
Also add encoding info to d+ description of root partitions
The storage encoding clause for a column is picked as follows:
 * 1. An explicit encoding clause in the ColumnDef of self/parent
 * 2. A column reference storage directive for this column
 * 3. A default column encoding in the statement
 * 4. Parent partition's column encoding values
 * 5. A default for the type.

2. Alter column encoding for AOCO tables
This commit introduces a new command to alter a column's encoding for an AOCO table.

ALTER TABLE aoco ALTER COLUMN a SET ENCODING (compresslevel=5);

This command rewrites the aoco table with the new encoding entries for specified columns. These are set to recuse to child partitions by default.
