### PR TITLE
Change how enums are hashed

### DIFF
--- a/src/include/utils/typcache.h
+++ b/src/include/utils/typcache.h
@@ -122,6 +122,7 @@ extern TupleDesc lookup_rowtype_tupdesc_copy(Oid type_id, int32 typmod);
 extern void assign_record_type_typmod(TupleDesc tupDesc);
 
 extern int	compare_values_of_enum(TypeCacheEntry *tcache, Oid arg1, Oid arg2);
+extern float4 extract_enum_sort_order(uint32 enum_oid);
 
 extern List *build_tuple_node_list(int start);
 


### PR DESCRIPTION
Instead of using oid when hashing an enum value, instead look up the enumsortorder and pass that into the hash function. This is necessary because enum OIDs will be rewritten when restored to a new database, and this will result in non-deterministic hashing.  The hash value is used to distribute rows to various segments and so restoring data will fail for any tables distributed by an enum column if hashed by OID.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
