### PR TITLE
[6X] Fix dependency bug with minirepro and materialized views (#14223)

### DIFF
--- a/src/backend/rewrite/rewriteHandler.c
+++ b/src/backend/rewrite/rewriteHandler.c
@@ -1840,8 +1840,12 @@ fireRIRrules(Query *parsetree, List *activeRIRs, bool forUpdatePushedDown)
 		 * expanded as if they were regular views, if they are not scannable.
 		 * In that case this test would need to be postponed till after we've
 		 * opened the rel, so that we could check its state.
+		 *
+		 * In the minirepro utility in GPDB, we use the expandMatViews flag
+		 * to treat materialized views as regular views when dumping the
+		 * DDL in order to dump dependent objects
 		 */
-		if (rte->relkind == RELKIND_MATVIEW)
+		if (rte->relkind == RELKIND_MATVIEW && !parsetree->expandMatViews)
 			continue;
 
 		/*

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -241,7 +241,6 @@ static int	interactive_getc(void);
 static int	SocketBackend(StringInfo inBuf);
 static int	ReadCommand(StringInfo inBuf);
 static void forbidden_in_wal_sender(int firstchar);
-static List *pg_rewrite_query(Query *query);
 static bool check_log_statement(List *stmt_list);
 static int	errdetail_execute(List *raw_parsetree_list);
 static int	errdetail_params(ParamListInfo params);
@@ -901,7 +900,7 @@ pg_analyze_and_rewrite_params(Node *parsetree,
  * Note: query must just have come from the parser, because we do not do
  * AcquireRewriteLocks() on it.
  */
-static List *
+List *
 pg_rewrite_query(Query *query)
 {
 	List	   *querytree_list;

--- a/src/backend/utils/adt/gp_dump_oids.c
+++ b/src/backend/utils/adt/gp_dump_oids.c
@@ -16,6 +16,7 @@
 #include "catalog/pg_proc.h"
 #include "tcop/tcopprot.h"
 #include "optimizer/planmain.h"
+#include "parser/analyze.h"
 #include "utils/builtins.h"
 #include "utils/fmgroids.h"
 #include "utils/syscache.h"
@@ -118,10 +119,10 @@ gp_dump_query_oids(PG_FUNCTION_ARGS)
 		Node	   *parsetree = (Node *) lfirst(lc);
 		List	   *queryTree_sublist;
 
-		queryTree_sublist = pg_analyze_and_rewrite(parsetree,
-												   sqlText,
-												   NULL,
-												   0);
+		Query	*query = parse_analyze(parsetree, sqlText, NULL, 0);
+		query->expandMatViews = true;
+		queryTree_sublist = pg_rewrite_query(query);
+
 		flat_query_list = list_concat(flat_query_list,
 									  list_copy(queryTree_sublist));
 	}

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -214,6 +214,7 @@ typedef struct Query
 	 * would always be dispatched in parallel.
 	 */
 	ParentStmtType	parentStmtType;
+	bool		expandMatViews; /* force expansion of materialized views during rewrite to treat as views */
 } Query;
 
 /****************************************************************************

--- a/src/include/tcop/tcopprot.h
+++ b/src/include/tcop/tcopprot.h
@@ -48,6 +48,7 @@ typedef enum
 extern PGDLLIMPORT int log_statement;
 
 extern List *pg_parse_query(const char *query_string);
+extern List *pg_rewrite_query(Query *query);
 extern List *pg_analyze_and_rewrite(Node *parsetree, const char *query_string,
 					   Oid *paramTypes, int numParams);
 extern List *pg_analyze_and_rewrite_params(Node *parsetree,

--- a/src/test/regress/expected/gp_dump_query_oids.out
+++ b/src/test/regress/expected/gp_dump_query_oids.out
@@ -1,17 +1,28 @@
 -- gp_dump_query_oids() doesn't list built-in functions, so we need a UDF to test with.
 CREATE FUNCTION dumptestfunc(t text) RETURNS integer AS $$ SELECT 123 $$ LANGUAGE SQL;
 CREATE FUNCTION dumptestfunc2(t text) RETURNS integer AS $$ SELECT 123 $$ LANGUAGE SQL;
+create table base(a int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create materialized view base_mv as select a from base;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
 -- The function returns OIDs. We need to replace them with something reproducable.
 CREATE FUNCTION sanitize_output(t text) RETURNS text AS $$
 declare
   dumptestfunc_oid oid;
   dumptestfunc2_oid oid;
+  base_oid oid;
+  base_mv_oid oid;
 begin
     dumptestfunc_oid = 'dumptestfunc'::regproc::oid;
     dumptestfunc2_oid = 'dumptestfunc2'::regproc::oid;
+    base_oid = 'base'::regclass::oid;
+    base_mv_oid = 'base_mv'::regclass::oid;
 
     t := replace(t, dumptestfunc_oid::text, '<dumptestfunc>');
     t := replace(t, dumptestfunc2_oid::text, '<dumptestfunc2>');
+    t := replace(t, base_oid::text, '<base_table>');
+    t := replace(t, base_mv_oid::text, '<base_mv>');
 
     RETURN t;
 end;
@@ -149,6 +160,12 @@ SELECT count(*) from (SELECT pg_catalog.gp_dump_query_oids('select * from unknow
  count 
 -------
      1
+(1 row)
+
+SELECT sanitize_output(gp_dump_query_oids('SELECT * FROM base_mv'));
+                   sanitize_output                   
+-----------------------------------------------------
+ {"relids": "<base_mv>,<base_table>", "funcids": ""}
 (1 row)
 
 DROP TABLE foo;


### PR DESCRIPTION
Previously, when using minirepro on a query that accessed materialized views, the object that the materialized view used/accessed were not dumped with the minirepro. This is because queries themselves treat materialized views as tables, not views. However, when enumerating the dependent objects for dumping the relevant DDL, we need to treat materialized views as regular views.

This commit sets a flag when dumping from gp_dump_query_oids so that materialized views are treated as regular views when parsing the query.

(cherry-picked from eedd5ff94edc137abe75ebe16b094bd977345435)