### PR TITLE
[6X backport] Fix errors when trying to DELETE FROM AO/CO auxiliary tables

### DIFF
--- a/src/backend/executor/nodeModifyTable.c
+++ b/src/backend/executor/nodeModifyTable.c
@@ -53,6 +53,7 @@
 
 #include "access/fileam.h"
 #include "access/transam.h"
+#include "catalog/aocatalog.h"
 #include "catalog/pg_statistic.h"
 #include "cdb/cdbaocsam.h"
 #include "cdb/cdbappendonlyam.h"
@@ -1852,7 +1853,8 @@ ExecModifyTable(ModifyTableState *node)
 				bool		isNull;
 
 				relkind = resultRelInfo->ri_RelationDesc->rd_rel->relkind;
-				if (relkind == RELKIND_RELATION || relkind == RELKIND_MATVIEW)
+				if (relkind == RELKIND_RELATION || relkind == RELKIND_MATVIEW ||
+					IsAppendonlyMetadataRelkind(relkind))
 				{
 					datum = ExecGetJunkAttribute(slot,
 												 junkfilter->jf_junkAttNo,
@@ -2347,7 +2349,8 @@ ExecInitModifyTable(ModifyTable *node, EState *estate, int eflags)
 
 					relkind = resultRelInfo->ri_RelationDesc->rd_rel->relkind;
 					if (relkind == RELKIND_RELATION ||
-						relkind == RELKIND_MATVIEW)
+						relkind == RELKIND_MATVIEW ||
+						IsAppendonlyMetadataRelkind(relkind))
 					{
 						j->jf_junkAttNo = ExecFindJunkAttribute(j, "ctid");
 						if (!AttributeNumberIsValid(j->jf_junkAttNo))

--- a/src/backend/rewrite/rewriteHandler.c
+++ b/src/backend/rewrite/rewriteHandler.c
@@ -32,8 +32,8 @@
 #include "utils/lsyscache.h"
 #include "utils/rel.h"
 
+#include "catalog/aocatalog.h"
 #include "catalog/pg_exttable.h"
-
 
 /* We use a list of these to detect recursion in RewriteQuery */
 typedef struct rewrite_event
@@ -1379,7 +1379,8 @@ rewriteTargetListUD(Query *parsetree, RangeTblEntry *target_rte,
 	Var 		*varSegid = NULL;
 
 	if (target_relation->rd_rel->relkind == RELKIND_RELATION ||
-		target_relation->rd_rel->relkind == RELKIND_MATVIEW)
+		target_relation->rd_rel->relkind == RELKIND_MATVIEW ||
+		IsAppendonlyMetadataRelkind(target_relation->rd_rel->relkind))
 	{
 		/*
 		 * Emit CTID so that executor can find the row to update or delete.

--- a/src/test/regress/expected/uao_catalog_tables.out
+++ b/src/test/regress/expected/uao_catalog_tables.out
@@ -1,3 +1,7 @@
+-- start_matchsubs
+-- m/ERROR:  permission denied: "pg_ao(seg|visimap|blkdir)_\d+" is a system catalog/
+-- s/pg_ao(seg|visimap|blkdir)_\d+/pg_ao_aux_table_xxxxx/
+-- end_matchsubs
 -- create functions to query uao auxiliary tables through gp_dist_random instead of going through utility mode
 CREATE OR REPLACE FUNCTION gp_aovisimap_dist_random(
   IN relation_name text) RETURNS setof record AS $$
@@ -336,3 +340,131 @@ select gp_toolkit.__gp_aovisimap_hidden_info('uao_table_check_hidden_tup_count_a
  (2,0,1)
 (6 rows)
 
+-- Verify that we can delete from the AO auxiliary tables when allow_system_table_mods is enabled
+CREATE OR REPLACE FUNCTION insert_dummy_ao_aux_entry(fqname text)
+RETURNS void AS
+$$
+BEGIN
+    EXECUTE 'INSERT INTO ' || fqname || ' VALUES(null)';
+END
+$$ LANGUAGE plpgsql;
+CREATE OR REPLACE FUNCTION delete_dummy_ao_aux_entry(fqname text)
+RETURNS void AS
+$$
+BEGIN
+    EXECUTE 'DELETE FROM ' || fqname;
+END
+$$ LANGUAGE plpgsql;
+CREATE OR REPLACE FUNCTION select_dummy_ao_aux_entry(fqname text)
+RETURNS int AS
+$$
+DECLARE result int;
+BEGIN
+    EXECUTE 'SELECT count(*) FROM ' || fqname INTO result;
+    RETURN result;
+END
+$$ LANGUAGE plpgsql;
+CREATE TABLE uao_catalog_delete_from (a int) WITH (appendonly=true) DISTRIBUTED BY (a);
+CREATE INDEX uao_catalog_delete_from_idx ON uao_catalog_delete_from USING btree(a);
+SELECT delete_dummy_ao_aux_entry(s.interior_fqname)
+FROM (
+     SELECT segrelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uao_catalog_delete_from'::regclass::oid
+) s;
+ERROR:  permission denied: "pg_ao_aux_table_xxxxx" is a system catalog
+CONTEXT:  SQL statement "DELETE FROM pg_aoseg.pg_aoseg_xxxxx"
+PL/pgSQL function delete_dummy_ao_aux_entry(text) line 3 at EXECUTE statement
+SELECT delete_dummy_ao_aux_entry(s.interior_fqname)
+FROM (
+     SELECT blkdirrelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uao_catalog_delete_from'::regclass::oid
+) s;
+ERROR:  permission denied: "pg_ao_aux_table_xxxxx" is a system catalog
+CONTEXT:  SQL statement "DELETE FROM pg_aoseg.pg_aoblkdir_xxxxx"
+PL/pgSQL function delete_dummy_ao_aux_entry(text) line 3 at EXECUTE statement
+SELECT delete_dummy_ao_aux_entry(s.interior_fqname)
+FROM (
+     SELECT visimaprelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uao_catalog_delete_from'::regclass::oid
+) s;
+ERROR:  permission denied: "pg_ao_aux_table_xxxxx" is a system catalog
+CONTEXT:  SQL statement "DELETE FROM pg_aoseg.pg_aovisimap_xxxxx"
+PL/pgSQL function delete_dummy_ao_aux_entry(text) line 3 at EXECUTE statement
+SET allow_system_table_mods = on;
+SELECT insert_dummy_ao_aux_entry(s.interior_fqname)
+FROM (
+     SELECT segrelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uao_catalog_delete_from'::regclass::oid
+) s;
+ insert_dummy_ao_aux_entry 
+---------------------------
+ 
+(1 row)
+
+SELECT insert_dummy_ao_aux_entry(s.interior_fqname)
+FROM (
+     SELECT blkdirrelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uao_catalog_delete_from'::regclass::oid
+) s;
+ insert_dummy_ao_aux_entry 
+---------------------------
+ 
+(1 row)
+
+SELECT insert_dummy_ao_aux_entry(s.interior_fqname)
+FROM (
+     SELECT visimaprelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uao_catalog_delete_from'::regclass::oid
+) s;
+ insert_dummy_ao_aux_entry 
+---------------------------
+ 
+(1 row)
+
+SELECT delete_dummy_ao_aux_entry(s.interior_fqname)
+FROM (
+     SELECT segrelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uao_catalog_delete_from'::regclass::oid
+) s;
+ delete_dummy_ao_aux_entry 
+---------------------------
+ 
+(1 row)
+
+SELECT delete_dummy_ao_aux_entry(s.interior_fqname)
+FROM (
+     SELECT blkdirrelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uao_catalog_delete_from'::regclass::oid
+) s;
+ delete_dummy_ao_aux_entry 
+---------------------------
+ 
+(1 row)
+
+SELECT delete_dummy_ao_aux_entry(s.interior_fqname)
+FROM (
+     SELECT visimaprelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uao_catalog_delete_from'::regclass::oid
+) s;
+ delete_dummy_ao_aux_entry 
+---------------------------
+ 
+(1 row)
+
+SELECT count(*) FROM gp_toolkit.__gp_aoseg('uao_catalog_delete_from');
+ count 
+-------
+     0
+(1 row)
+
+SELECT count(*) FROM gp_toolkit.__gp_aovisimap('uao_catalog_delete_from');
+ count 
+-------
+     0
+(1 row)
+
+SELECT select_dummy_ao_aux_entry(s.interior_fqname)
+FROM (
+     SELECT blkdirrelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uao_catalog_delete_from'::regclass::oid
+) s;
+ select_dummy_ao_aux_entry 
+---------------------------
+                         0
+(1 row)
+
+SET allow_system_table_mods = off;
+DROP FUNCTION insert_dummy_ao_aux_entry(fqname text);
+DROP FUNCTION delete_dummy_ao_aux_entry(fqname text);
+DROP FUNCTION select_dummy_ao_aux_entry(fqname text);
+DROP TABLE uao_catalog_delete_from;

--- a/src/test/regress/expected/uaocs_catalog_tables.out
+++ b/src/test/regress/expected/uaocs_catalog_tables.out
@@ -1,3 +1,7 @@
+-- start_matchsubs
+-- m/ERROR:  permission denied: "pg_ao(csseg|visimap|blkdir)_\d+" is a system catalog/
+-- s/pg_ao(csseg|visimap|blkdir)_\d+/pg_aocs_aux_table_xxxxx/
+-- end_matchsubs
 -- create functions to query uaocs auxiliary tables through gp_dist_random instead of going through utility mode
 CREATE OR REPLACE FUNCTION gp_aocsseg_dist_random(
   IN relation_name text) RETURNS setof record AS $$
@@ -88,3 +92,131 @@ select gp_toolkit.__gp_aovisimap_hidden_info('uaocs_table_check_hidden_tup_count
  (2,0,1)
 (6 rows)
 
+-- Verify that we can delete from the AOCO auxiliary tables when allow_system_table_mods is enabled
+CREATE OR REPLACE FUNCTION insert_dummy_aoco_aux_entry(fqname text)
+RETURNS void AS
+$$
+BEGIN
+    EXECUTE 'INSERT INTO ' || fqname || ' VALUES(null)';
+END
+$$ LANGUAGE plpgsql;
+CREATE OR REPLACE FUNCTION delete_dummy_aoco_aux_entry(fqname text)
+RETURNS void AS
+$$
+BEGIN
+    EXECUTE 'DELETE FROM ' || fqname;
+END
+$$ LANGUAGE plpgsql;
+CREATE OR REPLACE FUNCTION select_dummy_aoco_aux_entry(fqname text)
+RETURNS int AS
+$$
+DECLARE result int;
+BEGIN
+    EXECUTE 'SELECT count(*) FROM ' || fqname INTO result;
+    RETURN result;
+END
+$$ LANGUAGE plpgsql;
+CREATE TABLE uaocs_catalog_delete_from (a int) WITH (appendonly=true, orientation=column) DISTRIBUTED BY (a);
+CREATE INDEX uaocs_catalog_delete_from_idx ON uaocs_catalog_delete_from USING btree(a);
+SELECT delete_dummy_aoco_aux_entry(s.interior_fqname)
+FROM (
+     SELECT segrelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uaocs_catalog_delete_from'::regclass::oid
+) s;
+ERROR:  permission denied: "pg_aocs_aux_table_xxxxx" is a system catalog
+CONTEXT:  SQL statement "DELETE FROM pg_aoseg.pg_aocsseg_xxxxx"
+PL/pgSQL function delete_dummy_aoco_aux_entry(text) line 3 at EXECUTE statement
+SELECT delete_dummy_aoco_aux_entry(s.interior_fqname)
+FROM (
+     SELECT blkdirrelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uaocs_catalog_delete_from'::regclass::oid
+) s;
+ERROR:  permission denied: "pg_aocs_aux_table_xxxxx" is a system catalog
+CONTEXT:  SQL statement "DELETE FROM pg_aoseg.pg_aoblkdir_xxxxx"
+PL/pgSQL function delete_dummy_aoco_aux_entry(text) line 3 at EXECUTE statement
+SELECT delete_dummy_aoco_aux_entry(s.interior_fqname)
+FROM (
+     SELECT visimaprelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uaocs_catalog_delete_from'::regclass::oid
+) s;
+ERROR:  permission denied: "pg_aocs_aux_table_xxxxx" is a system catalog
+CONTEXT:  SQL statement "DELETE FROM pg_aoseg.pg_aovisimap_xxxxx"
+PL/pgSQL function delete_dummy_aoco_aux_entry(text) line 3 at EXECUTE statement
+SET allow_system_table_mods = on;
+SELECT insert_dummy_aoco_aux_entry(s.interior_fqname)
+FROM (
+     SELECT segrelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uaocs_catalog_delete_from'::regclass::oid
+) s;
+ insert_dummy_aoco_aux_entry 
+-----------------------------
+ 
+(1 row)
+
+SELECT insert_dummy_aoco_aux_entry(s.interior_fqname)
+FROM (
+     SELECT blkdirrelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uaocs_catalog_delete_from'::regclass::oid
+) s;
+ insert_dummy_aoco_aux_entry 
+-----------------------------
+ 
+(1 row)
+
+SELECT insert_dummy_aoco_aux_entry(s.interior_fqname)
+FROM (
+     SELECT visimaprelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uaocs_catalog_delete_from'::regclass::oid
+) s;
+ insert_dummy_aoco_aux_entry 
+-----------------------------
+ 
+(1 row)
+
+SELECT delete_dummy_aoco_aux_entry(s.interior_fqname)
+FROM (
+     SELECT segrelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uaocs_catalog_delete_from'::regclass::oid
+) s;
+ delete_dummy_aoco_aux_entry 
+-----------------------------
+ 
+(1 row)
+
+SELECT delete_dummy_aoco_aux_entry(s.interior_fqname)
+FROM (
+     SELECT blkdirrelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uaocs_catalog_delete_from'::regclass::oid
+) s;
+ delete_dummy_aoco_aux_entry 
+-----------------------------
+ 
+(1 row)
+
+SELECT delete_dummy_aoco_aux_entry(s.interior_fqname)
+FROM (
+     SELECT visimaprelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uaocs_catalog_delete_from'::regclass::oid
+) s;
+ delete_dummy_aoco_aux_entry 
+-----------------------------
+ 
+(1 row)
+
+SELECT count(*) FROM gp_toolkit.__gp_aocsseg('uaocs_catalog_delete_from');
+ count 
+-------
+     0
+(1 row)
+
+SELECT count(*) FROM gp_toolkit.__gp_aovisimap('uaocs_catalog_delete_from');
+ count 
+-------
+     0
+(1 row)
+
+SELECT select_dummy_aoco_aux_entry(s.interior_fqname)
+FROM (
+     SELECT blkdirrelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uaocs_catalog_delete_from'::regclass::oid
+) s;
+ select_dummy_aoco_aux_entry 
+-----------------------------
+                           0
+(1 row)
+
+SET allow_system_table_mods = off;
+DROP FUNCTION insert_dummy_aoco_aux_entry(fqname text);
+DROP FUNCTION delete_dummy_aoco_aux_entry(fqname text);
+DROP FUNCTION select_dummy_aoco_aux_entry(fqname text);
+DROP TABLE uaocs_catalog_delete_from;

--- a/src/test/regress/sql/uao_catalog_tables.sql
+++ b/src/test/regress/sql/uao_catalog_tables.sql
@@ -1,3 +1,8 @@
+-- start_matchsubs
+-- m/ERROR:  permission denied: "pg_ao(seg|visimap|blkdir)_\d+" is a system catalog/
+-- s/pg_ao(seg|visimap|blkdir)_\d+/pg_ao_aux_table_xxxxx/
+-- end_matchsubs
+
 -- create functions to query uao auxiliary tables through gp_dist_random instead of going through utility mode
 CREATE OR REPLACE FUNCTION gp_aovisimap_dist_random(
   IN relation_name text) RETURNS setof record AS $$
@@ -125,3 +130,84 @@ update uao_table_check_hidden_tup_count_after_update set j = 'test21';
 select gp_toolkit.__gp_aovisimap_hidden_info('uao_table_check_hidden_tup_count_after_update'::regclass) from gp_dist_random('gp_id');
 vacuum full uao_table_check_hidden_tup_count_after_update;
 select gp_toolkit.__gp_aovisimap_hidden_info('uao_table_check_hidden_tup_count_after_update'::regclass) from gp_dist_random('gp_id');
+
+-- Verify that we can delete from the AO auxiliary tables when allow_system_table_mods is enabled
+CREATE OR REPLACE FUNCTION insert_dummy_ao_aux_entry(fqname text)
+RETURNS void AS
+$$
+BEGIN
+    EXECUTE 'INSERT INTO ' || fqname || ' VALUES(null)';
+END
+$$ LANGUAGE plpgsql;
+CREATE OR REPLACE FUNCTION delete_dummy_ao_aux_entry(fqname text)
+RETURNS void AS
+$$
+BEGIN
+    EXECUTE 'DELETE FROM ' || fqname;
+END
+$$ LANGUAGE plpgsql;
+CREATE OR REPLACE FUNCTION select_dummy_ao_aux_entry(fqname text)
+RETURNS int AS
+$$
+DECLARE result int;
+BEGIN
+    EXECUTE 'SELECT count(*) FROM ' || fqname INTO result;
+    RETURN result;
+END
+$$ LANGUAGE plpgsql;
+
+CREATE TABLE uao_catalog_delete_from (a int) WITH (appendonly=true) DISTRIBUTED BY (a);
+CREATE INDEX uao_catalog_delete_from_idx ON uao_catalog_delete_from USING btree(a);
+
+SELECT delete_dummy_ao_aux_entry(s.interior_fqname)
+FROM (
+     SELECT segrelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uao_catalog_delete_from'::regclass::oid
+) s;
+SELECT delete_dummy_ao_aux_entry(s.interior_fqname)
+FROM (
+     SELECT blkdirrelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uao_catalog_delete_from'::regclass::oid
+) s;
+SELECT delete_dummy_ao_aux_entry(s.interior_fqname)
+FROM (
+     SELECT visimaprelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uao_catalog_delete_from'::regclass::oid
+) s;
+
+SET allow_system_table_mods = on;
+SELECT insert_dummy_ao_aux_entry(s.interior_fqname)
+FROM (
+     SELECT segrelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uao_catalog_delete_from'::regclass::oid
+) s;
+SELECT insert_dummy_ao_aux_entry(s.interior_fqname)
+FROM (
+     SELECT blkdirrelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uao_catalog_delete_from'::regclass::oid
+) s;
+SELECT insert_dummy_ao_aux_entry(s.interior_fqname)
+FROM (
+     SELECT visimaprelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uao_catalog_delete_from'::regclass::oid
+) s;
+
+SELECT delete_dummy_ao_aux_entry(s.interior_fqname)
+FROM (
+     SELECT segrelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uao_catalog_delete_from'::regclass::oid
+) s;
+SELECT delete_dummy_ao_aux_entry(s.interior_fqname)
+FROM (
+     SELECT blkdirrelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uao_catalog_delete_from'::regclass::oid
+) s;
+SELECT delete_dummy_ao_aux_entry(s.interior_fqname)
+FROM (
+     SELECT visimaprelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uao_catalog_delete_from'::regclass::oid
+) s;
+
+SELECT count(*) FROM gp_toolkit.__gp_aoseg('uao_catalog_delete_from');
+SELECT count(*) FROM gp_toolkit.__gp_aovisimap('uao_catalog_delete_from');
+SELECT select_dummy_ao_aux_entry(s.interior_fqname)
+FROM (
+     SELECT blkdirrelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uao_catalog_delete_from'::regclass::oid
+) s;
+
+SET allow_system_table_mods = off;
+DROP FUNCTION insert_dummy_ao_aux_entry(fqname text);
+DROP FUNCTION delete_dummy_ao_aux_entry(fqname text);
+DROP FUNCTION select_dummy_ao_aux_entry(fqname text);
+DROP TABLE uao_catalog_delete_from;

--- a/src/test/regress/sql/uaocs_catalog_tables.sql
+++ b/src/test/regress/sql/uaocs_catalog_tables.sql
@@ -1,3 +1,8 @@
+-- start_matchsubs
+-- m/ERROR:  permission denied: "pg_ao(csseg|visimap|blkdir)_\d+" is a system catalog/
+-- s/pg_ao(csseg|visimap|blkdir)_\d+/pg_aocs_aux_table_xxxxx/
+-- end_matchsubs
+
 -- create functions to query uaocs auxiliary tables through gp_dist_random instead of going through utility mode
 CREATE OR REPLACE FUNCTION gp_aocsseg_dist_random(
   IN relation_name text) RETURNS setof record AS $$
@@ -38,3 +43,84 @@ update uaocs_table_check_hidden_tup_count_after_update set j = 'test_update';
 select gp_toolkit.__gp_aovisimap_hidden_info('uaocs_table_check_hidden_tup_count_after_update'::regclass) from gp_dist_random('gp_id');
 vacuum full uaocs_table_check_hidden_tup_count_after_update;
 select gp_toolkit.__gp_aovisimap_hidden_info('uaocs_table_check_hidden_tup_count_after_update'::regclass) from gp_dist_random('gp_id');
+
+-- Verify that we can delete from the AOCO auxiliary tables when allow_system_table_mods is enabled
+CREATE OR REPLACE FUNCTION insert_dummy_aoco_aux_entry(fqname text)
+RETURNS void AS
+$$
+BEGIN
+    EXECUTE 'INSERT INTO ' || fqname || ' VALUES(null)';
+END
+$$ LANGUAGE plpgsql;
+CREATE OR REPLACE FUNCTION delete_dummy_aoco_aux_entry(fqname text)
+RETURNS void AS
+$$
+BEGIN
+    EXECUTE 'DELETE FROM ' || fqname;
+END
+$$ LANGUAGE plpgsql;
+CREATE OR REPLACE FUNCTION select_dummy_aoco_aux_entry(fqname text)
+RETURNS int AS
+$$
+DECLARE result int;
+BEGIN
+    EXECUTE 'SELECT count(*) FROM ' || fqname INTO result;
+    RETURN result;
+END
+$$ LANGUAGE plpgsql;
+
+CREATE TABLE uaocs_catalog_delete_from (a int) WITH (appendonly=true, orientation=column) DISTRIBUTED BY (a);
+CREATE INDEX uaocs_catalog_delete_from_idx ON uaocs_catalog_delete_from USING btree(a);
+
+SELECT delete_dummy_aoco_aux_entry(s.interior_fqname)
+FROM (
+     SELECT segrelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uaocs_catalog_delete_from'::regclass::oid
+) s;
+SELECT delete_dummy_aoco_aux_entry(s.interior_fqname)
+FROM (
+     SELECT blkdirrelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uaocs_catalog_delete_from'::regclass::oid
+) s;
+SELECT delete_dummy_aoco_aux_entry(s.interior_fqname)
+FROM (
+     SELECT visimaprelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uaocs_catalog_delete_from'::regclass::oid
+) s;
+
+SET allow_system_table_mods = on;
+SELECT insert_dummy_aoco_aux_entry(s.interior_fqname)
+FROM (
+     SELECT segrelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uaocs_catalog_delete_from'::regclass::oid
+) s;
+SELECT insert_dummy_aoco_aux_entry(s.interior_fqname)
+FROM (
+     SELECT blkdirrelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uaocs_catalog_delete_from'::regclass::oid
+) s;
+SELECT insert_dummy_aoco_aux_entry(s.interior_fqname)
+FROM (
+     SELECT visimaprelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uaocs_catalog_delete_from'::regclass::oid
+) s;
+
+SELECT delete_dummy_aoco_aux_entry(s.interior_fqname)
+FROM (
+     SELECT segrelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uaocs_catalog_delete_from'::regclass::oid
+) s;
+SELECT delete_dummy_aoco_aux_entry(s.interior_fqname)
+FROM (
+     SELECT blkdirrelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uaocs_catalog_delete_from'::regclass::oid
+) s;
+SELECT delete_dummy_aoco_aux_entry(s.interior_fqname)
+FROM (
+     SELECT visimaprelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uaocs_catalog_delete_from'::regclass::oid
+) s;
+
+SELECT count(*) FROM gp_toolkit.__gp_aocsseg('uaocs_catalog_delete_from');
+SELECT count(*) FROM gp_toolkit.__gp_aovisimap('uaocs_catalog_delete_from');
+SELECT select_dummy_aoco_aux_entry(s.interior_fqname)
+FROM (
+     SELECT blkdirrelid::regclass::text AS interior_fqname FROM pg_appendonly WHERE relid = 'uaocs_catalog_delete_from'::regclass::oid
+) s;
+
+SET allow_system_table_mods = off;
+DROP FUNCTION insert_dummy_aoco_aux_entry(fqname text);
+DROP FUNCTION delete_dummy_aoco_aux_entry(fqname text);
+DROP FUNCTION select_dummy_aoco_aux_entry(fqname text);
+DROP TABLE uaocs_catalog_delete_from;


### PR DESCRIPTION
When the AO/CO auxiliary tables have data and a DELETE is called on them after setting allow_system_table_mods to on, the DELETE would fail due to assertion failure. The issue was that the rewrite handler and the executor did not know about AO/CO auxiliary tables so the junk filters were not being set up correctly like they would be if the AO/CO auxiliary tables were regular heap tables. To fix the issue, simply add logic to check for the AO/CO auxiliary table relkinds.

Issue was reported from gpupgrade team where this DELETE operation is done in the data migration scripts.

Merge conflicts:
* USING ao_row/ao_column doesn't exist in 6X so replaced with the old WITH (appendonly=true) and WITH (appendonly=true, orientation=column).
* gp_toolkit.__gp_aoblkdir() does not exist so replaced with simple plpgsql function similar to the INSERT and DELETE ones already added by the test.

Backported from GPDB master branch:
https://github.com/greenplum-db/gpdb/commit/232d1565c3c915a663f0621beb1f9691f1e8cc3f