### PR TITLE
[6X] Fix incorrect sortOp and eqOp generated by IsCorrelatedEqualityOpExpr.

### DIFF
--- a/src/backend/cdb/cdbsubselect.c
+++ b/src/backend/cdb/cdbsubselect.c
@@ -155,13 +155,13 @@ IsCorrelatedOpExpr(OpExpr *opexp, Expr **innerExpr)
  *	returns true if correlated equality condition
  *	*innerExpr - points to the inner expr i.e. bar(innervar) in the condition
  *	*eqOp and *sortOp - equality and < operators, to implement the condition as a mergejoin.
+ *  The *eqOp and *sortOp should be determined according to innervar's type.
  */
 static bool
 IsCorrelatedEqualityOpExpr(OpExpr *opexp, Expr **innerExpr, Oid *eqOp, Oid *sortOp, bool *hashable)
 {
 	Oid			opfamily;
-	Oid			ltype;
-	Oid			rtype;
+	Oid			innerExprType;
 	List	   *l;
 
 	Assert(opexp);
@@ -170,11 +170,17 @@ IsCorrelatedEqualityOpExpr(OpExpr *opexp, Expr **innerExpr, Oid *eqOp, Oid *sort
 	Assert(eqOp);
 	Assert(sortOp);
 
+	if (!IsCorrelatedOpExpr(opexp, innerExpr))
+		return false;
+
+	Assert(*innerExpr);
+	innerExprType = exprType((Node *)*innerExpr);
+
 	/*
 	 * If this is an expression of the form a = b, then we want to know about
 	 * the vars involved.
 	 */
-	if (!op_mergejoinable(opexp->opno, exprType(linitial(opexp->args))))
+	if (!op_mergejoinable(opexp->opno, innerExprType))
 		return false;
 
 	/*
@@ -189,24 +195,19 @@ IsCorrelatedEqualityOpExpr(OpExpr *opexp, Expr **innerExpr, Oid *eqOp, Oid *sort
 	list_free(l);
 
 	/*
-	 * Look up the correct sort operator from the chosen opfamily.
+	 * Look up the correct equility/sort operators from the chosen opfamily.
 	 */
-	ltype = exprType(linitial(opexp->args));
-	rtype = exprType(lsecond(opexp->args));
-	*eqOp = get_opfamily_member(opfamily, ltype, rtype, BTEqualStrategyNumber);
+	*eqOp = get_opfamily_member(opfamily, innerExprType, innerExprType, BTEqualStrategyNumber);
 	if (!OidIsValid(*eqOp))	/* should not happen */
 		elog(ERROR, "could not find member %d(%u,%u) of opfamily %u",
-			 BTEqualStrategyNumber, ltype, rtype, opfamily);
+			 BTEqualStrategyNumber, innerExprType, innerExprType, opfamily);
 
-	*sortOp = get_opfamily_member(opfamily, ltype, rtype, BTLessStrategyNumber);
+	*sortOp = get_opfamily_member(opfamily, innerExprType, innerExprType, BTLessStrategyNumber);
 	if (!OidIsValid(*sortOp))	/* should not happen */
 		elog(ERROR, "could not find member %d(%u,%u) of opfamily %u",
-			 BTLessStrategyNumber, ltype, rtype, opfamily);
+			 BTLessStrategyNumber, innerExprType, innerExprType, opfamily);
 
-	*hashable = op_hashjoinable(*eqOp, ltype);
-
-	if (!IsCorrelatedOpExpr(opexp, innerExpr))
-		return false;
+	*hashable = op_hashjoinable(*eqOp, innerExprType);
 
 	return true;
 }

--- a/src/test/regress/expected/subselect_gp.out
+++ b/src/test/regress/expected/subselect_gp.out
@@ -2787,3 +2787,77 @@ reset enable_hashjoin;
 reset enable_nestloop;
 reset enable_indexscan;
 reset enable_bitmapscan;
+create table sublink_outer_table(a int, b int) distributed by(b);
+create table sublink_inner_table(x int, y bigint) distributed by(y);
+set optimizer to off;
+explain select t.* from sublink_outer_table t join (select y ,10*avg(x) s from sublink_inner_table group by y) RR on RR.y = t.b and t.a > rr.s;
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=436.00..1310.77 rows=28700 width=8)
+   ->  Hash Join  (cost=436.00..928.11 rows=9567 width=8)
+         Hash Cond: (t.b = sublink_inner_table.y)
+         Join Filter: ((t.a)::numeric > (('10'::numeric * avg(sublink_inner_table.x))))
+         ->  Seq Scan on sublink_outer_table t  (cost=0.00..321.00 rows=28700 width=8)
+         ->  Hash  (cost=431.83..431.83 rows=333 width=40)
+               ->  HashAggregate  (cost=423.50..428.50 rows=333 width=40)
+                     Group Key: sublink_inner_table.y
+                     ->  Seq Scan on sublink_inner_table  (cost=0.00..293.67 rows=25967 width=12)
+ Optimizer: Postgres query optimizer
+(10 rows)
+
+explain select * from sublink_outer_table T where a > (select 10*avg(x) from sublink_inner_table R where T.b=R.y);
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=436.00..1310.77 rows=28700 width=8)
+   ->  Hash Join  (cost=436.00..928.11 rows=9567 width=8)
+         Hash Cond: (t.b = "Expr_SUBQUERY".csq_c0)
+         Join Filter: ((t.a)::numeric > "Expr_SUBQUERY".csq_c1)
+         ->  Seq Scan on sublink_outer_table t  (cost=0.00..321.00 rows=28700 width=8)
+         ->  Hash  (cost=431.83..431.83 rows=333 width=40)
+               ->  Subquery Scan on "Expr_SUBQUERY"  (cost=423.50..431.83 rows=333 width=40)
+                     ->  HashAggregate  (cost=423.50..428.50 rows=333 width=40)
+                           Group Key: r.y
+                           ->  Seq Scan on sublink_inner_table r  (cost=0.00..293.67 rows=25967 width=12)
+ Optimizer: Postgres query optimizer
+(11 rows)
+
+set enable_hashagg to off;
+explain select t.* from sublink_outer_table t join (select y ,10*avg(x) s from sublink_inner_table group by y) RR on RR.y = t.b and t.a > rr.s;
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=2404.84..3279.62 rows=28700 width=8)
+   ->  Hash Join  (cost=2404.84..2896.95 rows=9567 width=8)
+         Hash Cond: (t.b = sublink_inner_table.y)
+         Join Filter: ((t.a)::numeric > (('10'::numeric * avg(sublink_inner_table.x))))
+         ->  Seq Scan on sublink_outer_table t  (cost=0.00..321.00 rows=28700 width=8)
+         ->  Hash  (cost=2400.67..2400.67 rows=333 width=40)
+               ->  GroupAggregate  (cost=2197.59..2397.34 rows=333 width=40)
+                     Group Key: sublink_inner_table.y
+                     ->  Sort  (cost=2197.59..2262.51 rows=25967 width=12)
+                           Sort Key: sublink_inner_table.y
+                           ->  Seq Scan on sublink_inner_table  (cost=0.00..293.67 rows=25967 width=12)
+ Optimizer: Postgres query optimizer
+(12 rows)
+
+explain select * from sublink_outer_table T where a > (select 10*avg(x) from sublink_inner_table R where T.b=R.y);
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=2404.84..3279.62 rows=28700 width=8)
+   ->  Hash Join  (cost=2404.84..2896.95 rows=9567 width=8)
+         Hash Cond: (t.b = "Expr_SUBQUERY".csq_c0)
+         Join Filter: ((t.a)::numeric > "Expr_SUBQUERY".csq_c1)
+         ->  Seq Scan on sublink_outer_table t  (cost=0.00..321.00 rows=28700 width=8)
+         ->  Hash  (cost=2400.67..2400.67 rows=333 width=40)
+               ->  Subquery Scan on "Expr_SUBQUERY"  (cost=2197.59..2400.67 rows=333 width=40)
+                     ->  GroupAggregate  (cost=2197.59..2397.34 rows=333 width=40)
+                           Group Key: r.y
+                           ->  Sort  (cost=2197.59..2262.51 rows=25967 width=12)
+                                 Sort Key: r.y
+                                 ->  Seq Scan on sublink_inner_table r  (cost=0.00..293.67 rows=25967 width=12)
+ Optimizer: Postgres query optimizer
+(13 rows)
+
+drop table sublink_outer_table;
+drop table sublink_inner_table;
+reset optimizer;
+reset enable_hashagg;

--- a/src/test/regress/expected/subselect_gp_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_optimizer.out
@@ -2936,3 +2936,77 @@ reset enable_hashjoin;
 reset enable_nestloop;
 reset enable_indexscan;
 reset enable_bitmapscan;
+create table sublink_outer_table(a int, b int) distributed by(b);
+create table sublink_inner_table(x int, y bigint) distributed by(y);
+set optimizer to off;
+explain select t.* from sublink_outer_table t join (select y ,10*avg(x) s from sublink_inner_table group by y) RR on RR.y = t.b and t.a > rr.s;
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=436.00..1310.77 rows=28700 width=8)
+   ->  Hash Join  (cost=436.00..928.11 rows=9567 width=8)
+         Hash Cond: (t.b = sublink_inner_table.y)
+         Join Filter: ((t.a)::numeric > (('10'::numeric * avg(sublink_inner_table.x))))
+         ->  Seq Scan on sublink_outer_table t  (cost=0.00..321.00 rows=28700 width=8)
+         ->  Hash  (cost=431.83..431.83 rows=333 width=40)
+               ->  HashAggregate  (cost=423.50..428.50 rows=333 width=40)
+                     Group Key: sublink_inner_table.y
+                     ->  Seq Scan on sublink_inner_table  (cost=0.00..293.67 rows=25967 width=12)
+ Optimizer: Postgres query optimizer
+(10 rows)
+
+explain select * from sublink_outer_table T where a > (select 10*avg(x) from sublink_inner_table R where T.b=R.y);
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=436.00..1310.77 rows=28700 width=8)
+   ->  Hash Join  (cost=436.00..928.11 rows=9567 width=8)
+         Hash Cond: (t.b = "Expr_SUBQUERY".csq_c0)
+         Join Filter: ((t.a)::numeric > "Expr_SUBQUERY".csq_c1)
+         ->  Seq Scan on sublink_outer_table t  (cost=0.00..321.00 rows=28700 width=8)
+         ->  Hash  (cost=431.83..431.83 rows=333 width=40)
+               ->  Subquery Scan on "Expr_SUBQUERY"  (cost=423.50..431.83 rows=333 width=40)
+                     ->  HashAggregate  (cost=423.50..428.50 rows=333 width=40)
+                           Group Key: r.y
+                           ->  Seq Scan on sublink_inner_table r  (cost=0.00..293.67 rows=25967 width=12)
+ Optimizer: Postgres query optimizer
+(11 rows)
+
+set enable_hashagg to off;
+explain select t.* from sublink_outer_table t join (select y ,10*avg(x) s from sublink_inner_table group by y) RR on RR.y = t.b and t.a > rr.s;
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=2404.84..3279.62 rows=28700 width=8)
+   ->  Hash Join  (cost=2404.84..2896.95 rows=9567 width=8)
+         Hash Cond: (t.b = sublink_inner_table.y)
+         Join Filter: ((t.a)::numeric > (('10'::numeric * avg(sublink_inner_table.x))))
+         ->  Seq Scan on sublink_outer_table t  (cost=0.00..321.00 rows=28700 width=8)
+         ->  Hash  (cost=2400.67..2400.67 rows=333 width=40)
+               ->  GroupAggregate  (cost=2197.59..2397.34 rows=333 width=40)
+                     Group Key: sublink_inner_table.y
+                     ->  Sort  (cost=2197.59..2262.51 rows=25967 width=12)
+                           Sort Key: sublink_inner_table.y
+                           ->  Seq Scan on sublink_inner_table  (cost=0.00..293.67 rows=25967 width=12)
+ Optimizer: Postgres query optimizer
+(12 rows)
+
+explain select * from sublink_outer_table T where a > (select 10*avg(x) from sublink_inner_table R where T.b=R.y);
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=2404.84..3279.62 rows=28700 width=8)
+   ->  Hash Join  (cost=2404.84..2896.95 rows=9567 width=8)
+         Hash Cond: (t.b = "Expr_SUBQUERY".csq_c0)
+         Join Filter: ((t.a)::numeric > "Expr_SUBQUERY".csq_c1)
+         ->  Seq Scan on sublink_outer_table t  (cost=0.00..321.00 rows=28700 width=8)
+         ->  Hash  (cost=2400.67..2400.67 rows=333 width=40)
+               ->  Subquery Scan on "Expr_SUBQUERY"  (cost=2197.59..2400.67 rows=333 width=40)
+                     ->  GroupAggregate  (cost=2197.59..2397.34 rows=333 width=40)
+                           Group Key: r.y
+                           ->  Sort  (cost=2197.59..2262.51 rows=25967 width=12)
+                                 Sort Key: r.y
+                                 ->  Seq Scan on sublink_inner_table r  (cost=0.00..293.67 rows=25967 width=12)
+ Optimizer: Postgres query optimizer
+(13 rows)
+
+drop table sublink_outer_table;
+drop table sublink_inner_table;
+reset optimizer;
+reset enable_hashagg;

--- a/src/test/regress/sql/subselect_gp.sql
+++ b/src/test/regress/sql/subselect_gp.sql
@@ -1158,3 +1158,17 @@ reset enable_hashjoin;
 reset enable_nestloop;
 reset enable_indexscan;
 reset enable_bitmapscan;
+create table sublink_outer_table(a int, b int) distributed by(b);
+create table sublink_inner_table(x int, y bigint) distributed by(y);
+
+set optimizer to off;
+explain select t.* from sublink_outer_table t join (select y ,10*avg(x) s from sublink_inner_table group by y) RR on RR.y = t.b and t.a > rr.s;
+explain select * from sublink_outer_table T where a > (select 10*avg(x) from sublink_inner_table R where T.b=R.y);
+
+set enable_hashagg to off;
+explain select t.* from sublink_outer_table t join (select y ,10*avg(x) s from sublink_inner_table group by y) RR on RR.y = t.b and t.a > rr.s;
+explain select * from sublink_outer_table T where a > (select 10*avg(x) from sublink_inner_table R where T.b=R.y);
+drop table sublink_outer_table;
+drop table sublink_inner_table;
+reset optimizer;
+reset enable_hashagg;


### PR DESCRIPTION
This PR backports commit 6473bbf87786c697347293c08499378311eec8c5 from 7X.

Original commit message:

In GPDB, expression subquery is promoted to join, e.g. select * from T where a > (select 10*avg(x) from R where T.b=R.y); in postgres, the plan is:

```
                          QUERY PLAN
-----------------------------------------------------------------
 Seq Scan on t  (cost=0.00..80364.30 rows=753 width=8)
   Filter: ((a)::numeric > (SubPlan 1))
   SubPlan 1
     ->  Aggregate  (cost=35.53..35.54 rows=1 width=32)
           ->  Seq Scan on r  (cost=0.00..35.50 rows=10 width=4)
                 Filter: (t.b = y)
```

while in GPDB, the subquery is promoted to join:

```

                                         QUERY PLAN
---------------------------------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)
   ->  Hash Join  (cost=477.00..969.11 rows=9567 width=8)
         Hash Cond: (t.b = "Expr_SUBQUERY".csq_c0)
         Join Filter: ((t.a)::numeric > "Expr_SUBQUERY".csq_c1)
         ->  Seq Scan on t  (cost=0.00..321.00 rows=28700 width=8)
         ->  Hash  (cost=472.83..472.83 rows=333 width=36)
               ->  Subquery Scan on "Expr_SUBQUERY"
                     ->  HashAggregate
                           Group Key: r.y
                           ->  Seq Scan on r
 Optimizer: Postgres query optimizer
```

But if the T.b and R.y are different type, it will report error like: ERROR:  operator 37 is not a valid ordering operator (pathkeys.c:579)

The root cause is that IsCorrelatedEqualityOpExpr may generate incorrect sort operator and equal operator for SortGroupClause when the types of left and right operands of OpExpr are different.

Since get_ordering_op_properties() requires the type of the left and right operands being consistent and SortGroupClause->tleSortGroupRef is referencing the target entry created from innerExpr, we teach IsCorrelatedEqualityOpExpr() construct appropriate eqOp and sortOp according to the type of innerExpr.

