### PR TITLE
Remove relcache for tablespaces located in non-default directory

### DIFF
--- a/src/backend/utils/cache/relcache.c
+++ b/src/backend/utils/cache/relcache.c
@@ -5006,6 +5006,16 @@ RelationCacheInitFileRemoveInDir(const char *tblspcpath)
 	FreeDir(dir);
 }
 
+void
+RelationCacheInitFileRemoveInDb(const char *dbpath)
+{
+	char		initfilename[MAXPGPATH];
+
+	snprintf(initfilename, sizeof(initfilename), "%s/%s",
+					 dbpath, RELCACHE_INIT_FILENAME);
+	unlink_initfile(initfilename);
+}
+
 static void
 unlink_initfile(const char *initfilename)
 {

--- a/src/backend/utils/init/flatfiles.c
+++ b/src/backend/utils/init/flatfiles.c
@@ -296,6 +296,13 @@ write_database_file(Relation drel, bool startup)
 		 */
 		if (gp_before_filespace_setup && !IsBuiltinTablespace(dattablespace))
 			continue;
+
+		if (startup) {
+			char	   *dbpath = GetDatabasePath(datoid, dattablespace);
+
+			RelationCacheInitFileRemoveInDb(dbpath);
+			pfree(dbpath);
+		}
 	}
 	heap_endscan(scan);
 

--- a/src/include/utils/relcache.h
+++ b/src/include/utils/relcache.h
@@ -96,6 +96,7 @@ extern bool RelationIdIsInInitFile(Oid relationId);
 extern void RelationCacheInitFilePreInvalidate(void);
 extern void RelationCacheInitFilePostInvalidate(void);
 extern void RelationCacheInitFileRemove(void);
+extern void RelationCacheInitFileRemoveInDb(const char *dbpath);
 
 extern void IndexSupportInitialize(oidvector *indclass,
 					   Oid *indexOperator,


### PR DESCRIPTION
### Description

The problem occurs if you have a database created in a tablespace in non-defalut data directory. To reproduce the error, you need to create a filespace, and then create the _whole_ database in that filesapce. Then you have to stop any primary segment and make the relcache to readjust, for example, with `REINDEX DATABASE` or `VACUUM`. After segment rebalancing is done, if you use DML on any table of a database, you get an error:
```
DETAIL:  FATAL:  could not open relation 16714/16955/2701: No such file or directory
 (seg0 10.92.5.6:10000)
```
The reason for this error is that gpdb doesn't properly update relcache in external filespaces, the only data path which is handled correclty is `base` directory in `PG_DATA`, so when the whole cluster is reindexed, the recovered segments has an outdated cache.

gpdb has a machanism of relcache removal that differs from vanilla postgres. postgres loads critical tables and then loads database paths directly from system tables. In postgres cache removal is a side effect of `write_relcache_init_file`, which traverses through table list and calls `RelationCacheInitFileRemove(dbpath)`. Cache update happens on backend startup. When postgres creates a tablespace, it creates a symlink in pg_tblspc, so the path to the relcache is `pg_tblspc/databaseId/pg_internal.init`.

gpdb tries to distinguish cache removal and creation routines. Unlike postgres, `RelationCacheInitFileRemove(void)` handles only `base` directory and it's called on database startup. Relcache is getting updated only when there's no `pg_internal.init` file in a data directory, so if there's a tablespace outside base directory, its cache won't be updated. **There's no easy way to separate cache construction and removal in gpdb, because `RelationCacheInitFileRemove` is called when no system tables are loaded, so we can't construct db's paths. Also, gpdb doesn't create symlinks in pg_tblspc, therefore we don't have an easy way to get db's path. We can force symlink creation on tablespace initialization, but this will make users create symlinks manually. The only way to fix the problem is to use postgre's aproach when the cache is removed in `write_relcache_init_file`**

### Repro steps
```
// create filespace tmpfs

// create a new db in it
[kds@kds ~]$ psql postgres -p 15432
postgres=# CREATE TABLESPACE tmptb FILESPACE tmpfs;
CREATE TABLESPACE
postgres=# CREATE DATABASE tmpdb WITH tablespace = "tmptb";
CREATE DATABASE

// add some data to the new db
postgres=# \c tmpdb
tmpdb=# CREATE TABLE test(i int);
tmpdb=# insert into test(i) select a from generate_series(1, 10) r(a);

// kill one primary segment and rebuild relcache for the rest
[kds@kds ~]$ kill -9 1965
[kds@kds ~]$ psql tmpdb -p 15432
tmpdb=# REINDEX SYSTEM tmpdb;
tmpdb=# REINDEX DATABASE tmpdb;
tmpdb=# insert into test(i) select a from generate_series(1, 10) r(a);
tmpdb=# REINDEX DATABASE tmpdb;
tmpdb=# REINDEX SYSTEM tmpdb;

// recover and rebalance 
[kds@kds ~]$ PGPORT=15432 gprecoverseg -a
[kds@kds ~]$ PGPORT=15432 gprecoverseg -ra

// try to select some data
[kds@kds ~]$ psql tmpdb -p 15432
tmpdb=# select * from test;
ERROR:  failed to acquire resources on one or more segments
DETAIL:  FATAL:  could not open relation 16385/16386/2701: No such file or directory

tmpdb=# select version();
                                                                                                            version                                                          
                                                   
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
---------------------------------------------------
 PostgreSQL 8.3.23 (Greenplum Database 5.29.8+dev.10.g27763c22bb build dev) on x86_64-pc-linux-gnu, compiled by GCC gcc (GCC) 4.8.5 20150623 (Red Hat 4.8.5-44), 64-bit compi
led on Oct 23 2022 16:37:09 (with assert checking)
```
