### PR TITLE
Removed unnecessary variable assignment

### DIFF
--- a/src/backend/access/aocs/aocs_compaction.c
+++ b/src/backend/access/aocs/aocs_compaction.c
@@ -107,8 +107,6 @@ AOCSSegmentFileTruncateToEOF(Relation aorel, int segno, AOCSVPInfo *vpinfo)
 
 	Assert(RelationIsAoCols(aorel));
 
-	relname = RelationGetRelationName(aorel);
-
 	for (j = 0; j < vpinfo->nEntry; ++j)
 	{
 		int64		segeof;


### PR DESCRIPTION
The same value is assigned to the variable at the moment of declaration (some lines before)
