### PR TITLE
[6X][Doc] pg_partition.paratts's type should be int2vector.

### DIFF
--- a/gpdb-doc/dita/ref_guide/system_catalogs/pg_partition.xml
+++ b/gpdb-doc/dita/ref_guide/system_catalogs/pg_partition.xml
@@ -61,7 +61,7 @@
           </row>
           <row>
             <entry colname="col1"><codeph>paratts</codeph></entry>
-            <entry colname="col2">smallint()</entry>
+            <entry colname="col2">int2vector</entry>
             <entry colname="col3"/>
             <entry colname="col4">An array of the attribute numbers (as in
                 <codeph>pg_attribute.attnum</codeph>) of the attributes that participate in defining

--- a/gpdb-doc/markdown/ref_guide/system_catalogs/pg_partition.html.md
+++ b/gpdb-doc/markdown/ref_guide/system_catalogs/pg_partition.html.md
@@ -11,7 +11,7 @@ The `pg_partition` system catalog table is used to track partitioned tables and 
 |`parlevel`|smallint| |The partition level of this row: 0 for the top-level parent table, 1 for the first level under the parent table, 2 for the second level, and so on.|
 |`paristemplate`|boolean| |Whether or not this row represents a subpartition template definition \(true\) or an actual partitioning level \(false\).|
 |`parnatts`|smallint| |The number of attributes that define this level.|
-|`paratts`|smallint\(\)| |An array of the attribute numbers \(as in `pg_attribute.attnum`\) of the attributes that participate in defining this level.|
+|`paratts`|int2vector| |An array of the attribute numbers \(as in `pg_attribute.attnum`\) of the attributes that participate in defining this level.|
 |`parclass`|oidvector|pg\_opclass.oid|The operator class identifier\(s\) of the partition columns.|
 
 **Parent topic:** [System Catalogs Definitions](../system_catalogs/catalog_ref-html.html)


### PR DESCRIPTION
The type of pg_partition.paratts should be int2 vector. This patch helps correct the documentation.

See:

```
postgres=# \d+ pg_partition;
                        Table "pg_catalog.pg_partition"
    Column     |    Type    | Modifiers | Storage | Stats target | Description
---------------+------------+-----------+---------+--------------+-------------
 parrelid      | oid        | not null  | plain   |              |
 parkind       | "char"     | not null  | plain   |              |
 parlevel      | smallint   | not null  | plain   |              |
 paristemplate | boolean    | not null  | plain   |              |
 parnatts      | smallint   | not null  | plain   |              |
 paratts       | int2vector | not null  | plain   |              |  <---------- Here
 parclass      | oidvector  | not null  | plain   |              |
Indexes:
    "pg_partition_oid_index" UNIQUE, btree (oid)
    "pg_partition_parrelid_index" btree (parrelid)
    "pg_partition_parrelid_parlevel_istemplate_index" btree (parrelid, parlevel, paristemplate)
Has OIDs: yes
```