### PR TITLE
[6X backport] Simplify IN subquery for sublink pullup.

### DIFF
--- a/src/backend/cdb/cdbsubselect.c
+++ b/src/backend/cdb/cdbsubselect.c
@@ -410,7 +410,42 @@ SubqueryToJoinWalker(Node *node, ConvertSubqueryToJoinContext *context)
 	return;
 }
 
+/*
+ * cdbsubselect_drop_distinct
+ */
+void
+cdbsubselect_drop_distinct(Query *subselect)
+{
+	if (subselect->limitCount == NULL &&
+		subselect->limitOffset == NULL)
+	{
+		/* Delete DISTINCT. */
+		if (!subselect->hasDistinctOn ||
+			list_length(subselect->distinctClause) == list_length(subselect->targetList))
+			subselect->distinctClause = NIL;
 
+		/* Delete GROUP BY if subquery has no aggregates and no HAVING. */
+		if (!subselect->hasAggs &&
+			subselect->havingQual == NULL)
+			subselect->groupClause = NIL;
+	}
+}	/* cdbsubselect_drop_distinct */
+
+/*
+ * cdbsubselect_drop_orderby
+ */
+void
+cdbsubselect_drop_orderby(Query *subselect)
+{
+	if (subselect->limitCount == NULL &&
+		subselect->limitOffset == NULL)
+	{
+		/* Delete ORDER BY. */
+		if (!subselect->hasDistinctOn ||
+			list_length(subselect->distinctClause) == list_length(subselect->targetList))
+			subselect->sortClause = NIL;
+	}
+}	/* cdbsubselect_drop_orderby */
 
 /**
  * Safe to convert expr sublink to a join
@@ -1424,6 +1459,20 @@ convert_IN_to_antijoin(PlannerInfo *root, SubLink *sublink,
 	if (safe_to_convert_NOTIN(sublink, available_rels))
 	{
 		Assert(list_length(parse->jointree->fromlist) == 1);
+
+		/* Delete ORDER BY and DISTINCT.
+		 *
+		 * There is no need to do the group-by or order-by inside the
+		 * subquery, if we have decided to pull up the sublink. For the
+		 * group-by case, after the sublink pull-up, there will be a semi-join
+		 * plan node generated in top level, which will weed out duplicate
+		 * tuples naturally. For the order-by case, after the sublink pull-up,
+		 * the subquery will become a jointree, inside which the tuples' order
+		 * doesn't matter. In a summary, it's safe to elimate the group-by or
+		 * order-by causes here.
+		 */
+		cdbsubselect_drop_orderby(subselect);
+		cdbsubselect_drop_distinct(subselect);
 
 		int			subq_indx      = add_notin_subquery_rte(parse, subselect);
 		List       *inner_exprs    = NIL;

--- a/src/backend/optimizer/plan/subselect.c
+++ b/src/backend/optimizer/plan/subselect.c
@@ -1405,6 +1405,20 @@ convert_ANY_sublink_to_join(PlannerInfo *root, SubLink *sublink,
 	Assert(sublink->subLinkType == ANY_SUBLINK);
 	Assert(IsA(subselect, Query));
 
+	/* Delete ORDER BY and DISTINCT.
+	 *
+	 * There is no need to do the group-by or order-by inside the
+	 * subquery, if we have decided to pull up the sublink. For the
+	 * group-by case, after the sublink pull-up, there will be a semi-join
+	 * plan node generated in top level, which will weed out duplicate
+	 * tuples naturally. For the order-by case, after the sublink pull-up,
+	 * the subquery will become a jointree, inside which the tuples' order
+	 * doesn't matter. In a summary, it's safe to elimate the group-by or
+	 * order-by causes here.
+	*/
+	cdbsubselect_drop_orderby(subselect);
+	cdbsubselect_drop_distinct(subselect);
+
 	/*
 	 * If deeply correlated, then don't pull it up
 	 */

--- a/src/include/cdb/cdbsubselect.h
+++ b/src/include/cdb/cdbsubselect.h
@@ -24,4 +24,7 @@ extern bool is_simple_subquery(PlannerInfo *root, Query *subquery, RangeTblEntry
 				   JoinExpr *lowest_outer_join);
 extern JoinExpr *convert_IN_to_antijoin(PlannerInfo *root, SubLink *sublink, Relids available_rels);
 
+extern void cdbsubselect_drop_orderby(Query *subselect);
+extern void cdbsubselect_drop_distinct(Query *subselect);
+
 #endif   /* CDBSUBSELECT_H */

--- a/src/test/regress/expected/join_gp.out
+++ b/src/test/regress/expected/join_gp.out
@@ -1441,15 +1441,11 @@ where x.a + 1 in (select distinct b from t2_dedupsemi_indexonly);
                ->  Seq Scan on t1_dedupsemi_indexonly
                      Filter: (a < 3)
          ->  Hash
-               ->  HashAggregate
-                     Group Key: t2_dedupsemi_indexonly.b
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                           Hash Key: t2_dedupsemi_indexonly.b
-                           ->  HashAggregate
-                                 Group Key: t2_dedupsemi_indexonly.b
-                                 ->  Seq Scan on t2_dedupsemi_indexonly
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: t2_dedupsemi_indexonly.b
+                     ->  Seq Scan on t2_dedupsemi_indexonly
  Optimizer: Postgres query optimizer
-(16 rows)
+(12 rows)
 
 select * from
 (

--- a/src/test/regress/expected/notin.out
+++ b/src/test/regress/expected/notin.out
@@ -393,38 +393,28 @@ select a,b from g1 where (a,b) not in
 --
 explain select x,y from l1 where (x,y) not in
 	(select distinct y, sum(x) from l1 group by y having y < 4 order by y) order by 1,2;
-                                                         QUERY PLAN
+                                                         QUERY PLAN                                                          
 -----------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice3; segments: 3)  (cost=10000000008.02..10000000008.03 rows=4 width=8)
    Merge Key: l1.x, l1.y
    ->  Sort  (cost=10000000008.02..10000000008.03 rows=2 width=8)
          Sort Key: l1.x, l1.y
-         ->  Nested Loop Left Anti Semi (Not-In) Join  (cost=10000000001.07..10000000002.34 rows=1 width=8)
+         ->  Nested Loop Left Anti Semi (Not-In) Join  (cost=10000000003.25..10000000007.99 rows=2 width=8)
                Join Filter: ((l1.x = "NotIn_SUBQUERY".y) AND (l1.y = "NotIn_SUBQUERY".sum))
                ->  Seq Scan on l1  (cost=0.00..3.10 rows=4 width=8)
-               ->  Materialize  (cost=3.35..3.56 rows=3 width=12)
-                     ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=3.35..3.51 rows=3 width=12)
-                           ->  Subquery Scan on "NotIn_SUBQUERY"  (cost=3.35..3.39 rows=1 width=12)
-                                 ->  Unique  (cost=3.35..3.36 rows=1 width=16)
-                                       Group Key: l1_1.y, (pg_catalog.sum((sum(l1_1.x))))
-                                       ->  Sort  (cost=3.35..3.36 rows=1 width=16)
-                                             Sort Key (Distinct): l1_1.y, (pg_catalog.sum((sum(l1_1.x))))
-                                             ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=3.30..3.34 rows=1 width=16)
-                                                   Hash Key: l1_1.y, (pg_catalog.sum((sum(l1_1.x))))
-                                                   ->  Unique  (cost=3.30..3.32 rows=1 width=16)
-                                                         Group Key: l1_1.y, (pg_catalog.sum((sum(l1_1.x))))
-                                                         ->  Sort  (cost=3.30..3.31 rows=1 width=16)
-                                                               Sort Key (Distinct): l1_1.y
-                                                               ->  HashAggregate  (cost=3.25..3.28 rows=1 width=16)
-                                                                     Group Key: l1_1.y
-                                                                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=3.14..3.20 rows=1 width=12)
-                                                                           Hash Key: l1_1.y
-                                                                           ->  HashAggregate  (cost=3.14..3.14 rows=1 width=12)
-                                                                                 Group Key: l1_1.y
-                                                                                 ->  Seq Scan on l1 l1_1  (cost=0.00..3.12 rows=2 width=8)
-                                                                                       Filter: (y < 4)
+               ->  Materialize  (cost=3.25..3.47 rows=3 width=12)
+                     ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=3.25..3.43 rows=3 width=12)
+                           ->  Subquery Scan on "NotIn_SUBQUERY"  (cost=3.25..3.31 rows=1 width=12)
+                                 ->  HashAggregate  (cost=3.25..3.28 rows=1 width=16)
+                                       Group Key: l1_1.y
+                                       ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=3.14..3.20 rows=1 width=12)
+                                             Hash Key: l1_1.y
+                                             ->  HashAggregate  (cost=3.14..3.14 rows=1 width=12)
+                                                   Group Key: l1_1.y
+                                                   ->  Seq Scan on l1 l1_1  (cost=0.00..3.12 rows=2 width=8)
+                                                         Filter: (y < 4)
  Optimizer: Postgres query optimizer
-(29 rows)
+(19 rows)
 
 select x,y from l1 where (x,y) not in
 	(select distinct y, sum(x) from l1 group by y having y < 4 order by y) order by 1,2;

--- a/src/test/regress/expected/notin_optimizer.out
+++ b/src/test/regress/expected/notin_optimizer.out
@@ -399,38 +399,28 @@ select a,b from g1 where (a,b) not in
 --
 explain select x,y from l1 where (x,y) not in
 	(select distinct y, sum(x) from l1 group by y having y < 4 order by y) order by 1,2;
-                                                         QUERY PLAN
+                                                         QUERY PLAN                                                          
 -----------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice3; segments: 3)  (cost=10000000008.02..10000000008.03 rows=4 width=8)
    Merge Key: l1.x, l1.y
    ->  Sort  (cost=10000000008.02..10000000008.03 rows=2 width=8)
          Sort Key: l1.x, l1.y
-         ->  Nested Loop Left Anti Semi (Not-In) Join  (cost=10000000001.07..10000000002.34 rows=1 width=8)
+         ->  Nested Loop Left Anti Semi (Not-In) Join  (cost=10000000003.25..10000000007.99 rows=2 width=8)
                Join Filter: ((l1.x = "NotIn_SUBQUERY".y) AND (l1.y = "NotIn_SUBQUERY".sum))
                ->  Seq Scan on l1  (cost=0.00..3.10 rows=4 width=8)
-               ->  Materialize  (cost=3.35..3.56 rows=3 width=12)
-                     ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=3.35..3.51 rows=3 width=12)
-                           ->  Subquery Scan on "NotIn_SUBQUERY"  (cost=3.35..3.39 rows=1 width=12)
-                                 ->  Unique  (cost=3.35..3.36 rows=1 width=16)
-                                       Group Key: l1_1.y, (pg_catalog.sum((sum(l1_1.x))))
-                                       ->  Sort  (cost=3.35..3.36 rows=1 width=16)
-                                             Sort Key (Distinct): l1_1.y, (pg_catalog.sum((sum(l1_1.x))))
-                                             ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=3.30..3.34 rows=1 width=16)
-                                                   Hash Key: l1_1.y, (pg_catalog.sum((sum(l1_1.x))))
-                                                   ->  Unique  (cost=3.30..3.32 rows=1 width=16)
-                                                         Group Key: l1_1.y, (pg_catalog.sum((sum(l1_1.x))))
-                                                         ->  Sort  (cost=3.30..3.31 rows=1 width=16)
-                                                               Sort Key (Distinct): l1_1.y
-                                                               ->  HashAggregate  (cost=3.25..3.28 rows=1 width=16)
-                                                                     Group Key: l1_1.y
-                                                                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=3.14..3.20 rows=1 width=12)
-                                                                           Hash Key: l1_1.y
-                                                                           ->  HashAggregate  (cost=3.14..3.14 rows=1 width=12)
-                                                                                 Group Key: l1_1.y
-                                                                                 ->  Seq Scan on l1 l1_1  (cost=0.00..3.12 rows=2 width=8)
-                                                                                       Filter: (y < 4)
+               ->  Materialize  (cost=3.25..3.47 rows=3 width=12)
+                     ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=3.25..3.43 rows=3 width=12)
+                           ->  Subquery Scan on "NotIn_SUBQUERY"  (cost=3.25..3.31 rows=1 width=12)
+                                 ->  HashAggregate  (cost=3.25..3.28 rows=1 width=16)
+                                       Group Key: l1_1.y
+                                       ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=3.14..3.20 rows=1 width=12)
+                                             Hash Key: l1_1.y
+                                             ->  HashAggregate  (cost=3.14..3.14 rows=1 width=12)
+                                                   Group Key: l1_1.y
+                                                   ->  Seq Scan on l1 l1_1  (cost=0.00..3.12 rows=2 width=8)
+                                                         Filter: (y < 4)
  Optimizer: Postgres query optimizer
-(29 rows)
+(19 rows)
 
 select x,y from l1 where (x,y) not in
 	(select distinct y, sum(x) from l1 group by y having y < 4 order by y) order by 1,2;

--- a/src/test/regress/expected/rpt.out
+++ b/src/test/regress/expected/rpt.out
@@ -1178,12 +1178,12 @@ set enable_nestloop=on;
 explain select b from dist_tab where b in (select distinct c from rep_tab);
                                             QUERY PLAN                                             
 ---------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000001.16..10000000601.46 rows=4 width=4)
-   ->  Nested Loop  (cost=10000000001.16..10000000601.46 rows=2 width=4)
-         ->  GroupAggregate  (cost=10000000001.03..10000000001.06 rows=2 width=4)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000001.16..10000000601.42 rows=4 width=4)
+   ->  Nested Loop  (cost=10000000001.16..10000000601.42 rows=2 width=4)
+         ->  Unique  (cost=10000000001.03..10000000001.04 rows=1 width=4)
                Group Key: rep_tab.c
-               ->  Sort  (cost=10000000001.03..10000000001.03 rows=2 width=4)
-                     Sort Key: rep_tab.c
+               ->  Sort  (cost=10000000001.03..10000000001.03 rows=1 width=4)
+                     Sort Key (Distinct): rep_tab.c
                      ->  Seq Scan on rep_tab  (cost=10000000000.00..10000000001.02 rows=2 width=4)
          ->  Index Only Scan using idx on dist_tab  (cost=0.13..300.17 rows=1 width=4)
                Index Cond: (b = rep_tab.c)
@@ -1211,20 +1211,16 @@ analyze rand_tab;
 --
 -- join derives EdtHashed
 explain select c from rep_tab where c in (select distinct c from rep_tab);
-                                                    QUERY PLAN                                                     
--------------------------------------------------------------------------------------------------------------------
- Gather Motion 1:1  (slice1; segments: 1)  (cost=20000000001.11..20000000002.17 rows=4 width=4)
-   ->  Hash Semi Join  (cost=20000000001.11..20000000002.17 rows=4 width=4)
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=20000000001.05..20000000002.11 rows=4 width=4)
+   ->  Hash Semi Join  (cost=20000000001.05..20000000002.11 rows=4 width=4)
          Hash Cond: (rep_tab.c = rep_tab_1.c)
          ->  Seq Scan on rep_tab  (cost=10000000000.00..10000000001.02 rows=2 width=4)
-         ->  Hash  (cost=10000000001.08..10000000001.08 rows=1 width=4)
-               ->  GroupAggregate  (cost=10000000001.03..10000000001.06 rows=2 width=4)
-                     Group Key: rep_tab_1.c
-                     ->  Sort  (cost=10000000001.03..10000000001.03 rows=2 width=4)
-                           Sort Key: rep_tab_1.c
-                           ->  Seq Scan on rep_tab rep_tab_1  (cost=10000000000.00..10000000001.02 rows=2 width=4)
+         ->  Hash  (cost=10000000001.02..10000000001.02 rows=1 width=4)
+               ->  Seq Scan on rep_tab rep_tab_1  (cost=10000000000.00..10000000001.02 rows=2 width=4)
  Optimizer: Postgres query optimizer
-(11 rows)
+(7 rows)
 
 select c from rep_tab where c in (select distinct c from rep_tab);
  c 
@@ -1239,20 +1235,16 @@ select c from rep_tab where c in (select distinct c from rep_tab);
 --
 -- join derives EdtHashed
 explain select a from dist_tab where a in (select distinct c from rep_tab);
-                                               QUERY PLAN                                                
----------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=20000000001.11..20000000003.20 rows=4 width=4)
-   ->  Hash Semi Join  (cost=20000000001.11..20000000003.20 rows=2 width=4)
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=20000000001.05..20000000003.14 rows=4 width=4)
+   ->  Hash Semi Join  (cost=20000000001.05..20000000003.14 rows=2 width=4)
          Hash Cond: (dist_tab.a = rep_tab.c)
          ->  Seq Scan on dist_tab  (cost=10000000000.00..10000000002.04 rows=2 width=4)
-         ->  Hash  (cost=10000000001.08..10000000001.08 rows=1 width=4)
-               ->  GroupAggregate  (cost=10000000001.03..10000000001.06 rows=2 width=4)
-                     Group Key: rep_tab.c
-                     ->  Sort  (cost=10000000001.03..10000000001.03 rows=2 width=4)
-                           Sort Key: rep_tab.c
-                           ->  Seq Scan on rep_tab  (cost=10000000000.00..10000000001.02 rows=2 width=4)
+         ->  Hash  (cost=10000000001.02..10000000001.02 rows=1 width=4)
+               ->  Seq Scan on rep_tab  (cost=10000000000.00..10000000001.02 rows=2 width=4)
  Optimizer: Postgres query optimizer
-(11 rows)
+(7 rows)
 
 select a from dist_tab where a in (select distinct c from rep_tab);
  a 
@@ -1269,20 +1261,16 @@ select a from dist_tab where a in (select distinct c from rep_tab);
 --
 -- join derives EdtRandom
 explain select d from rand_tab where d in (select distinct c from rep_tab);
-                                               QUERY PLAN                                                
----------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=20000000001.11..20000000003.17 rows=4 width=4)
-   ->  Hash Semi Join  (cost=20000000001.11..20000000003.17 rows=2 width=4)
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=20000000001.05..20000000002.11 rows=4 width=4)
+   ->  Hash Semi Join  (cost=20000000001.05..20000000002.11 rows=2 width=4)
          Hash Cond: (rand_tab.d = rep_tab.c)
-         ->  Seq Scan on rand_tab  (cost=10000000000.00..10000000002.02 rows=1 width=4)
-         ->  Hash  (cost=10000000001.08..10000000001.08 rows=1 width=4)
-               ->  GroupAggregate  (cost=10000000001.03..10000000001.06 rows=2 width=4)
-                     Group Key: rep_tab.c
-                     ->  Sort  (cost=10000000001.03..10000000001.03 rows=2 width=4)
-                           Sort Key: rep_tab.c
-                           ->  Seq Scan on rep_tab  (cost=10000000000.00..10000000001.02 rows=2 width=4)
+         ->  Seq Scan on rand_tab  (cost=10000000000.00..10000000001.02 rows=1 width=4)
+         ->  Hash  (cost=10000000001.02..10000000001.02 rows=1 width=4)
+               ->  Seq Scan on rep_tab  (cost=10000000000.00..10000000001.02 rows=2 width=4)
  Optimizer: Postgres query optimizer
-(11 rows)
+(7 rows)
 
 select d from rand_tab where d in (select distinct c from rep_tab);
  d 
@@ -1299,17 +1287,15 @@ select d from rand_tab where d in (select distinct c from rep_tab);
 explain select c from rep_tab where c in (select distinct a from dist_tab);
                                                  QUERY PLAN                                                 
 ------------------------------------------------------------------------------------------------------------
- Hash Semi Join  (cost=20000000003.18..20000000003.22 rows=4 width=4)
+ Hash Semi Join  (cost=20000000003.19..20000000003.23 rows=4 width=4)
    Hash Cond: (rep_tab.c = dist_tab.a)
    ->  Gather Motion 1:1  (slice1; segments: 1)  (cost=10000000001.02..10000000001.02 rows=2 width=4)
          ->  Seq Scan on rep_tab  (cost=10000000000.00..10000000001.02 rows=2 width=4)
-   ->  Hash  (cost=10000000002.13..10000000002.13 rows=1 width=4)
-         ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=10000000002.05..10000000002.13 rows=2 width=4)
-               ->  HashAggregate  (cost=10000000002.05..10000000002.07 rows=1 width=4)
-                     Group Key: dist_tab.a
-                     ->  Seq Scan on dist_tab  (cost=10000000000.00..10000000002.04 rows=2 width=4)
+   ->  Hash  (cost=10000000002.12..10000000002.12 rows=2 width=4)
+         ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=10000000000.00..10000000002.12 rows=4 width=4)
+               ->  Seq Scan on dist_tab  (cost=10000000000.00..10000000002.04 rows=2 width=4)
  Optimizer: Postgres query optimizer
-(10 rows)
+(8 rows)
 
 select c from rep_tab where c in (select distinct a from dist_tab);
  c 
@@ -1324,27 +1310,17 @@ select c from rep_tab where c in (select distinct a from dist_tab);
 --
 -- join derives EdtHashed
 explain select c from rep_tab where c in (select distinct d from rand_tab);
-                                                             QUERY PLAN                                                             
-------------------------------------------------------------------------------------------------------------------------------------
- Hash Semi Join  (cost=20000000003.27..20000000003.31 rows=4 width=4)
+                                                 QUERY PLAN                                                 
+------------------------------------------------------------------------------------------------------------
+ Hash Semi Join  (cost=20000000003.11..20000000003.15 rows=4 width=4)
    Hash Cond: (rep_tab.c = rand_tab.d)
    ->  Gather Motion 1:1  (slice1; segments: 1)  (cost=10000000001.02..10000000001.02 rows=2 width=4)
          ->  Seq Scan on rep_tab  (cost=10000000000.00..10000000001.02 rows=2 width=4)
-   ->  Hash  (cost=10000000002.22..10000000002.22 rows=1 width=4)
-         ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=10000000002.11..10000000002.22 rows=2 width=4)
-               ->  GroupAggregate  (cost=10000000002.11..10000000002.16 rows=1 width=4)
-                     Group Key: rand_tab.d
-                     ->  Sort  (cost=10000000002.11..10000000002.11 rows=1 width=4)
-                           Sort Key: rand_tab.d
-                           ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=10000000002.03..10000000002.10 rows=1 width=4)
-                                 Hash Key: rand_tab.d
-                                 ->  GroupAggregate  (cost=10000000002.03..10000000002.06 rows=1 width=4)
-                                       Group Key: rand_tab.d
-                                       ->  Sort  (cost=10000000002.03..10000000002.03 rows=1 width=4)
-                                             Sort Key: rand_tab.d
-                                             ->  Seq Scan on rand_tab  (cost=10000000000.00..10000000002.02 rows=1 width=4)
+   ->  Hash  (cost=10000000002.06..10000000002.06 rows=1 width=4)
+         ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=10000000000.00..10000000002.06 rows=2 width=4)
+               ->  Seq Scan on rand_tab  (cost=10000000000.00..10000000002.02 rows=1 width=4)
  Optimizer: Postgres query optimizer
-(18 rows)
+(8 rows)
 
 select c from rep_tab where c in (select distinct d from rand_tab);
  c 

--- a/src/test/regress/expected/subselect.out
+++ b/src/test/regress/expected/subselect.out
@@ -820,7 +820,7 @@ explain (verbose, costs off)
 select * from int4_tbl where
   (case when f1 in (select unique1 from tenk1 a) then f1 else null end) in
   (select ten from tenk1 b);
-                                                  QUERY PLAN
+                                                  QUERY PLAN                                                   
 ---------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice4; segments: 3)
    Output: int4_tbl.f1
@@ -880,13 +880,12 @@ select * from int4_tbl o where (f1, f1) in
                ->  Subquery Scan on "ANY_subquery"
                      Output: "ANY_subquery".f1, "ANY_subquery".g
                      Filter: ("ANY_subquery".f1 = "ANY_subquery".g)
-                     ->  HashAggregate
+                     ->  Result
                            Output: i.f1, (generate_series(1, 2) / 10)
-                           Group Key: i.f1
                            ->  Seq Scan on public.int4_tbl i
                                  Output: i.f1
  Optimizer: Postgres query optimizer
-(18 rows)
+(17 rows)
 
 select * from int4_tbl o where (f1, f1) in
   (select f1, generate_series(1,2) / 10 g from int4_tbl i group by f1);

--- a/src/test/regress/expected/subselect_gp.out
+++ b/src/test/regress/expected/subselect_gp.out
@@ -1672,6 +1672,81 @@ EXPLAIN SELECT '' AS five, f1 AS "Correlated Field"
  Optimizer: Postgres query optimizer
 (13 rows)
 
+-- Test simplify group-by/order-by inside subquery if sublink pull-up is possible
+EXPLAIN SELECT '' AS six, f1 AS "Correlated Field", f2 AS "Second Field"
+  FROM SUBSELECT_TBL upper
+  WHERE f1 IN (SELECT f2 FROM SUBSELECT_TBL WHERE f1 = upper.f1 GROUP BY f2);
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=3.11..6.30 rows=8 width=8)
+   ->  Hash Semi Join  (cost=3.11..6.30 rows=3 width=8)
+         Hash Cond: (upper.f1 = subselect_tbl.f1)
+         ->  Seq Scan on subselect_tbl upper  (cost=0.00..3.08 rows=3 width=8)
+         ->  Hash  (cost=3.10..3.10 rows=1 width=8)
+               ->  Seq Scan on subselect_tbl  (cost=0.00..3.10 rows=1 width=8)
+                     Filter: (f1 = f2)
+ Optimizer: Postgres query optimizer
+(8 rows)
+
+EXPLAIN SELECT '' AS six, f1 AS "Correlated Field", f2 AS "Second Field"
+  FROM SUBSELECT_TBL upper
+  WHERE f1 IN (SELECT f2 FROM SUBSELECT_TBL WHERE f1 = upper.f1  GROUP BY f2 LIMIT 3);
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..28.15 rows=4 width=8)
+   ->  Seq Scan on subselect_tbl upper  (cost=0.00..28.15 rows=2 width=8)
+         Filter: (SubPlan 1)
+         SubPlan 1  (slice2; segments: 3)
+           ->  Limit  (cost=3.11..3.15 rows=1 width=4)
+                 ->  Limit  (cost=3.11..3.13 rows=1 width=4)
+                       ->  GroupAggregate  (cost=3.11..3.13 rows=1 width=4)
+                             Group Key: subselect_tbl.f2
+                             ->  Sort  (cost=3.11..3.11 rows=1 width=4)
+                                   Sort Key: subselect_tbl.f2
+                                   ->  Result  (cost=0.00..3.11 rows=1 width=4)
+                                         Filter: (subselect_tbl.f1 = upper.f1)
+                                         ->  Materialize  (cost=0.00..3.11 rows=1 width=4)
+                                               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.10 rows=1 width=4)
+                                                     ->  Seq Scan on subselect_tbl  (cost=0.00..3.10 rows=1 width=4)
+ Optimizer: Postgres query optimizer
+(16 rows)
+
+EXPLAIN SELECT '' AS six, f1 AS "Correlated Field", f2 AS "Second Field"
+  FROM SUBSELECT_TBL upper
+  WHERE f1 IN (SELECT f2 FROM SUBSELECT_TBL WHERE f1 = upper.f1 ORDER BY f2);
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=3.11..6.30 rows=8 width=8)
+   ->  Hash Semi Join  (cost=3.11..6.30 rows=3 width=8)
+         Hash Cond: (upper.f1 = subselect_tbl.f1)
+         ->  Seq Scan on subselect_tbl upper  (cost=0.00..3.08 rows=3 width=8)
+         ->  Hash  (cost=3.10..3.10 rows=1 width=8)
+               ->  Seq Scan on subselect_tbl  (cost=0.00..3.10 rows=1 width=8)
+                     Filter: (f1 = f2)
+ Optimizer: Postgres query optimizer
+(8 rows)
+
+EXPLAIN SELECT '' AS six, f1 AS "Correlated Field", f2 AS "Second Field"
+  FROM SUBSELECT_TBL upper
+  WHERE f1 IN (SELECT f2 FROM SUBSELECT_TBL WHERE f1 = upper.f1  ORDER BY f2 LIMIT 3);
+                                                        QUERY PLAN                                                         
+---------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..28.14 rows=4 width=8)
+   ->  Seq Scan on subselect_tbl upper  (cost=0.00..28.14 rows=2 width=8)
+         Filter: (SubPlan 1)
+         SubPlan 1  (slice2; segments: 3)
+           ->  Limit  (cost=3.11..3.15 rows=1 width=4)
+                 ->  Limit  (cost=3.11..3.11 rows=1 width=4)
+                       ->  Sort  (cost=3.11..3.11 rows=1 width=4)
+                             Sort Key: subselect_tbl.f2
+                             ->  Result  (cost=0.00..3.11 rows=1 width=4)
+                                   Filter: (subselect_tbl.f1 = upper.f1)
+                                   ->  Materialize  (cost=0.00..3.11 rows=1 width=4)
+                                         ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..3.10 rows=1 width=4)
+                                               ->  Seq Scan on subselect_tbl  (cost=0.00..3.10 rows=1 width=4)
+ Optimizer: Postgres query optimizer
+(14 rows)
+
 --
 -- Test cases to catch unpleasant interactions between IN-join processing
 -- and subquery pullup.
@@ -1723,10 +1798,10 @@ EXPLAIN select count(*) from
    where unique1 IN (select distinct hundred from tenk1 b)) ss;
                                                         QUERY PLAN                                                         
 ---------------------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=437.18..437.19 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=437.11..437.16 rows=1 width=8)
-         ->  Aggregate  (cost=437.11..437.12 rows=1 width=8)
-               ->  Hash Semi Join  (cost=220.50..436.86 rows=34 width=0)
+ Aggregate  (cost=644.06..644.07 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=644.00..644.05 rows=1 width=8)
+         ->  Aggregate  (cost=644.00..644.01 rows=1 width=8)
+               ->  Hash Join  (cost=416.25..643.75 rows=34 width=0)
                      Hash Cond: (a.unique1 = b.hundred)
                      ->  Seq Scan on tenk1 a  (cost=0.00..189.00 rows=3334 width=4)
                      ->  Hash  (cost=219.25..219.25 rows=34 width=4)
@@ -1734,9 +1809,7 @@ EXPLAIN select count(*) from
                                  Group Key: b.hundred
                                  ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..387.00 rows=3334 width=4)
                                        Hash Key: b.hundred
-                                       ->  HashAggregate  (cost=70.67..71.67 rows=100 width=4)
-                                             Group Key: b.hundred
-                                             ->  Seq Scan on tenk1 b  (cost=0.00..62.33 rows=3333 width=4)
+                                       ->  Seq Scan on tenk1 b  (cost=0.00..189.00 rows=3334 width=4)
  Optimizer: Postgres query optimizer
 (15 rows)
 
@@ -1750,7 +1823,7 @@ EXPLAIN select count(distinct ss.ten) from
          ->  Aggregate  (cost=439.11..439.12 rows=1 width=8)
                ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=220.50..438.86 rows=34 width=4)
                      Hash Key: a.ten
-                     ->  Hash Semi Join  (cost=220.50..436.86 rows=34 width=4)
+                     ->  Hash Join  (cost=416.25..643.75 rows=34 width=4)
                            Hash Cond: (a.unique1 = b.hundred)
                            ->  Seq Scan on tenk1 a  (cost=0.00..189.00 rows=3334 width=8)
                            ->  Hash  (cost=219.25..219.25 rows=34 width=4)
@@ -1758,9 +1831,7 @@ EXPLAIN select count(distinct ss.ten) from
                                        Group Key: b.hundred
                                        ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=214.00..216.00 rows=34 width=4)
                                              Hash Key: b.hundred
-                                             ->  HashAggregate  (cost=214.00..214.00 rows=34 width=4)
-                                                   Group Key: b.hundred
-                                                   ->  Seq Scan on tenk1 b  (cost=0.00..189.00 rows=3334 width=4)
+                                             ->  Seq Scan on tenk1 b  (cost=0.00..189.00 rows=3334 width=4)
  Optimizer: Postgres query optimizer
 (15 rows)
 
@@ -2668,6 +2739,34 @@ select * from issue_12656 where (i, j) in (select distinct on (i) i, j from issu
  i |   j   
 ---+-------
  1 | 10002
+(1 row)
+
+-- case 3, check correlated DISTINCT ON
+explain select * from issue_12656 a where (i, j) in
+(select distinct on (i) i, j from issue_12656 b where a.i=b.i order by i, j asc);
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..3.11 rows=1 width=8)
+   ->  Seq Scan on issue_12656 a  (cost=0.00..3.11 rows=1 width=8)
+         Filter: (SubPlan 1)
+         SubPlan 1  (slice2; segments: 3)
+           ->  Unique  (cost=1.03..1.04 rows=1 width=8)
+                 Group Key: b.i
+                 ->  Sort  (cost=1.03..1.04 rows=1 width=8)
+                       Sort Key (Distinct): b.j
+                       ->  Result  (cost=0.00..1.03 rows=1 width=8)
+                             Filter: (a.i = b.i)
+                             ->  Materialize  (cost=0.00..1.03 rows=1 width=8)
+                                   ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.02 rows=1 width=8)
+                                         ->  Seq Scan on issue_12656 b  (cost=0.00..1.02 rows=1 width=8)
+ Optimizer: Postgres query optimizer
+(14 rows)
+
+select * from issue_12656 a where (i, j) in
+(select distinct on (i) i, j from issue_12656 b where a.i=b.i order by i, j asc);
+ i |   j   
+---+-------
+ 1 | 10001
 (1 row)
 
 -- A guard test case for gpexpand's populate SQL

--- a/src/test/regress/expected/subselect_gp_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_optimizer.out
@@ -1654,6 +1654,81 @@ EXPLAIN SELECT '' AS five, f1 AS "Correlated Field"
  Optimizer: Postgres query optimizer
 (13 rows)
 
+-- Test simplify group-by/order-by inside subquery if sublink pull-up is possible
+EXPLAIN SELECT '' AS six, f1 AS "Correlated Field", f2 AS "Second Field"
+  FROM SUBSELECT_TBL upper
+  WHERE f1 IN (SELECT f2 FROM SUBSELECT_TBL WHERE f1 = upper.f1 GROUP BY f2);
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Result  (cost=0.00..862.00 rows=3 width=16)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=8 width=8)
+         ->  Hash Semi Join  (cost=0.00..862.00 rows=3 width=8)
+               Hash Cond: ((subselect_tbl.f1 = subselect_tbl_1.f1) AND (subselect_tbl.f1 = subselect_tbl_1.f2))
+               ->  Seq Scan on subselect_tbl  (cost=0.00..431.00 rows=3 width=8)
+               ->  Hash  (cost=431.00..431.00 rows=3 width=8)
+                     ->  Seq Scan on subselect_tbl subselect_tbl_1  (cost=0.00..431.00 rows=3 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(8 rows)
+
+EXPLAIN SELECT '' AS six, f1 AS "Correlated Field", f2 AS "Second Field"
+  FROM SUBSELECT_TBL upper
+  WHERE f1 IN (SELECT f2 FROM SUBSELECT_TBL WHERE f1 = upper.f1  GROUP BY f2 LIMIT 3);
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Result  (cost=0.00..1324038.55 rows=3 width=16)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1324038.55 rows=8 width=8)
+         ->  Seq Scan on subselect_tbl  (cost=0.00..1324038.55 rows=3 width=8)
+               Filter: (SubPlan 1)
+               SubPlan 1  (slice2; segments: 3)
+                 ->  Limit  (cost=0.00..431.01 rows=1 width=4)
+                       ->  GroupAggregate  (cost=0.00..431.01 rows=1 width=4)
+                             Group Key: subselect_tbl_1.f2
+                             ->  Sort  (cost=0.00..431.01 rows=1 width=4)
+                                   Sort Key: subselect_tbl_1.f2
+                                   ->  Result  (cost=0.00..431.01 rows=1 width=4)
+                                         Filter: (subselect_tbl_1.f1 = subselect_tbl.f1)
+                                         ->  Materialize  (cost=0.00..431.00 rows=8 width=8)
+                                               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=8 width=8)
+                                                     ->  Seq Scan on subselect_tbl subselect_tbl_1  (cost=0.00..431.00 rows=3 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(16 rows)
+
+EXPLAIN SELECT '' AS six, f1 AS "Correlated Field", f2 AS "Second Field"
+  FROM SUBSELECT_TBL upper
+  WHERE f1 IN (SELECT f2 FROM SUBSELECT_TBL WHERE f1 = upper.f1 ORDER BY f2);
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Result  (cost=0.00..862.00 rows=3 width=16)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=8 width=8)
+         ->  Hash Semi Join  (cost=0.00..862.00 rows=3 width=8)
+               Hash Cond: ((subselect_tbl.f1 = subselect_tbl_1.f1) AND (subselect_tbl.f1 = subselect_tbl_1.f2))
+               ->  Seq Scan on subselect_tbl  (cost=0.00..431.00 rows=3 width=8)
+               ->  Hash  (cost=431.00..431.00 rows=3 width=8)
+                     ->  Seq Scan on subselect_tbl subselect_tbl_1  (cost=0.00..431.00 rows=3 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(8 rows)
+
+EXPLAIN SELECT '' AS six, f1 AS "Correlated Field", f2 AS "Second Field"
+  FROM SUBSELECT_TBL upper
+  WHERE f1 IN (SELECT f2 FROM SUBSELECT_TBL WHERE f1 = upper.f1  ORDER BY f2 LIMIT 3);
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Result  (cost=0.00..1324038.57 rows=3 width=16)
+   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1324038.57 rows=8 width=8)
+         ->  Seq Scan on subselect_tbl  (cost=0.00..1324038.57 rows=3 width=8)
+               Filter: (SubPlan 1)
+               SubPlan 1  (slice2; segments: 3)
+                 ->  Limit  (cost=0.00..431.01 rows=1 width=4)
+                       ->  Sort  (cost=0.00..431.01 rows=1 width=4)
+                             Sort Key: subselect_tbl_1.f2
+                             ->  Result  (cost=0.00..431.01 rows=1 width=4)
+                                   Filter: (subselect_tbl_1.f1 = subselect_tbl.f1)
+                                   ->  Materialize  (cost=0.00..431.00 rows=8 width=8)
+                                         ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=8 width=8)
+                                               ->  Seq Scan on subselect_tbl subselect_tbl_1  (cost=0.00..431.00 rows=3 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(14 rows)
+
 --
 -- Test cases to catch unpleasant interactions between IN-join processing
 -- and subquery pullup.
@@ -2817,6 +2892,34 @@ select * from issue_12656 where (i, j) in (select distinct on (i) i, j from issu
  i |   j   
 ---+-------
  1 | 10002
+(1 row)
+
+-- case 3, check correlated DISTINCT ON
+explain select * from issue_12656 a where (i, j) in
+(select distinct on (i) i, j from issue_12656 b where a.i=b.i order by i, j asc);
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..3.11 rows=1 width=8)
+   ->  Seq Scan on issue_12656 a  (cost=0.00..3.11 rows=1 width=8)
+         Filter: (SubPlan 1)
+         SubPlan 1  (slice2; segments: 3)
+           ->  Unique  (cost=1.03..1.04 rows=1 width=8)
+                 Group Key: b.i
+                 ->  Sort  (cost=1.03..1.04 rows=1 width=8)
+                       Sort Key (Distinct): b.j
+                       ->  Result  (cost=0.00..1.03 rows=1 width=8)
+                             Filter: (a.i = b.i)
+                             ->  Materialize  (cost=0.00..1.03 rows=1 width=8)
+                                   ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.02 rows=1 width=8)
+                                         ->  Seq Scan on issue_12656 b  (cost=0.00..1.02 rows=1 width=8)
+ Optimizer: Postgres query optimizer
+(14 rows)
+
+select * from issue_12656 a where (i, j) in
+(select distinct on (i) i, j from issue_12656 b where a.i=b.i order by i, j asc);
+ i |   j   
+---+-------
+ 1 | 10001
 (1 row)
 
 -- A guard test case for gpexpand's populate SQL

--- a/src/test/regress/expected/subselect_optimizer.out
+++ b/src/test/regress/expected/subselect_optimizer.out
@@ -928,9 +928,8 @@ select * from int4_tbl o where (f1, f1) in
                ->  Subquery Scan on "ANY_subquery"
                      Output: "ANY_subquery".f1, "ANY_subquery".g
                      Filter: ("ANY_subquery".f1 = "ANY_subquery".g)
-                     ->  HashAggregate
+                     ->  Result
                            Output: i.f1, (generate_series(1, 2) / 10)
-                           Group Key: i.f1
                            ->  Seq Scan on public.int4_tbl i
                                  Output: i.f1
  Optimizer: Postgres query optimizer


### PR DESCRIPTION
This is a backport of master PR #14258 & #14322.

In GP6's convert_ANY_sublink_to_join(), there is no simplification of origin subquery, as a result sometimes the sublink cannot be pulled up, which produced a bad query plan. In GP5, there is a subquery simplify step which helped sublink pull-up:
```
/* Delete ORDER BY and DISTINCT. */
		cdbsubselect_drop_orderby(subselect);
		cdbsubselect_drop_distinct(subselect);
```
As only simple sub-query is allowed to be pulled up:
```
                 /*
		 * Under certain conditions, we cannot pull up the subquery as a join.
		 */
		if (!is_simple_subquery(root, subselect, NULL, NULL))
			return NULL;
```
Take a look at the following query case:
```
EXPLAIN SELECT rmv_1.cover_no,
            rmv_1.period_no,
            rmv_1.risk_no,
            rmv_1.risk_period_no,
            rmv_1.location_ext_no,
            rmv_1.source_system
           FROM ctx.gis_risk_mv rmv_1
          WHERE ((rmv_1.cover_no, rmv_1.period_no, rmv_1.risk_no, rmv_1.risk_period_no, (rmv_1.source_system)::text) IN ( SELECT rp1.cover_no,
                    rp1.period_no,
                    rp1.risk_no,
                    rp1.risk_period_no,
                    rmv_1.source_system
                   FROM ( SELECT rp.cover_no,
                            rp.period_no,
                            rp.risk_no,
                            rp.risk_period_no,
                            row_number() OVER (PARTITION BY rp.cover_no, rp.period_no, rp.risk_no ORDER BY rp.risk_period_no DESC) AS risk_period_rank
                           FROM ctx.gis_risk_period rp) rp1
                  WHERE (rp1.risk_period_rank = 1)
                  GROUP BY rp1.cover_no, rp1.period_no, rp1.risk_no, rp1.risk_period_no, rmv_1.source_system));
```

But we lose this simplification since version 6X until master, which caused the sublink pull-up doesn't work:

```
Gather Motion 3:1  (slice5; segments: 3)  (cost=0.00..1334551428791.85 rows=77599 width=48)
   ->  Subquery Scan on rmv_1  (cost=0.00..1334551428791.85 rows=25867 width=48)
         Filter: (SubPlan 1)
         ->  Append  (cost=0.00..3478.96 rows=51733 width=210)
               ->  Seq Scan on sor_cm_risk_mv rskmv  (cost=0.00..236.89 rows=3097 width=208)
               ->  Seq Scan on sor_cm_risk_mv rskmv_1  (cost=0.00..225.56 rows=2719 width=208)
               ->  Seq Scan on sor_cm_risk_mv rskmv_2  (cost=0.00..1.00 rows=1 width=824)
               ->  Seq Scan on sor_cm_risk_mv rskmv_3  (cost=0.00..3015.51 rows=45917 width=210)
         SubPlan 1  (slice5; segments: 3)
           ->  HashAggregate  (cost=8599060.81..8599091.54 rows=1025 width=46)
                 Group Key: rp1.cover_no, rp1.period_no, rp1.risk_no, rp1.risk_period_no, rmv_1.source_system
                 ->  Subquery Scan on rp1  (cost=7446600.66..8598676.79 rows=10241 width=14)
                       Filter: (rp1.risk_period_rank = 1)
                       ->  WindowAgg  (cost=7446600.66..8214651.41 rows=10240677 width=14)
                             Partition By: rp.cover_no, rp.period_no, rp.risk_no
                             Order By: rp.risk_period_no
                             ->  Sort  (cost=7446600.66..7523405.74 rows=10240677 width=14)
                                   Sort Key: rp.cover_no, rp.period_no, rp.risk_no, rp.risk_period_no
                                   ->  Subquery Scan on rp  (cost=0.00..1080045.60 rows=10240677 width=14)
                                         ->  Append  (cost=0.00..772825.30 rows=10240677 width=319)
                                               ->  Result  (cost=0.00..170393.60 rows=1433280 width=319)
                                                     ->  Materialize  (cost=0.00..170393.60 rows=1433280 width=319)
                                                           ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..103754.40 rows=1433280 width=319)
                                                                 ->  Seq Scan on sor_cm_risk_period rskp  (cost=0.00..103754.40 rows=1433280 width=319)
                                               ->  Result  (cost=0.00..118234.50 rows=993900 width=319)
                                                     ->  Materialize  (cost=0.00..118234.50 rows=993900 width=319)
                                                           ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..72023.00 rows=993900 width=319)
                                                                 ->  Seq Scan on sor_cm_risk_period rskp_1  (cost=0.00..72023.00 rows=993900 width=319)
                                               ->  Result  (cost=0.00..94955.35 rows=777497 width=319)
                                                     ->  Materialize  (cost=0.00..94955.35 rows=777497 width=319)
                                                           ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..58805.90 rows=777497 width=319)
                                                                 ->  Seq Scan on sor_cm_risk_period rskp_2  (cost=0.00..58805.90 rows=777497 width=319)
                                               ->  Result  (cost=0.00..865375.00 rows=7036000 width=319)
                                                     ->  Materialize  (cost=0.00..865375.00 rows=7036000 width=319)
                                                           ->  Broadcast Motion 3:3  (slice4; segments: 3)  (cost=0.00..538242.00 rows=7036000 width=319)
                                                                 ->  Seq Scan on sor_cm_risk_period rskp_3  (cost=0.00..538242.00 rows=7036000 width=319)
 Optimizer: Postgres query optimizer
(37 rows)
```
After we brought back `cdbsubselect_drop_distinct` and `cdbsubselect_drop_orderby`, we can got simplified subquery again and do the sublink pull-up optimization, which produced a better plan:
```
Gather Motion 3:1  (slice3; segments: 3)  (cost=8599137.66..8845829.72 rows=9700 width=48)
   ->  Hash Join  (cost=8599137.66..8845829.72 rows=3234 width=48)
         Hash Cond: ((rmv_1.cover_no = rp1.cover_no) AND (rmv_1.period_no = rp1.period_no) AND (rmv_1.risk_no = rp1.risk_no) AND (rmv_1.risk_period_no = rp1.risk_period_no))
         ->  Subquery Scan on rmv_1  (cost=0.00..6582.90 rows=51733 width=48)
               ->  Append  (cost=0.00..5030.93 rows=51733 width=210)
                     ->  Seq Scan on sor_cm_risk_mv rskmv  (cost=0.00..236.89 rows=3097 width=176)
                     ->  Seq Scan on sor_cm_risk_mv rskmv_1  (cost=0.00..225.56 rows=2719 width=176)
                     ->  Seq Scan on sor_cm_risk_mv rskmv_2  (cost=0.00..1.00 rows=1 width=792)
                     ->  Seq Scan on sor_cm_risk_mv rskmv_3  (cost=0.00..3015.51 rows=45917 width=178)
         ->  Hash  (cost=8599076.20..8599076.20 rows=1025 width=14)
               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=8598984.01..8599076.20 rows=1025 width=14)
                     Hash Key: rp1.cover_no, rp1.period_no, rp1.risk_no, rp1.risk_period_no
                     ->  HashAggregate  (cost=8598984.01..8599014.74 rows=1025 width=14)
                           Group Key: rp1.cover_no, rp1.period_no, rp1.risk_no, rp1.risk_period_no
                           ->  Subquery Scan on rp1  (cost=7446600.66..8598676.79 rows=10241 width=14)
                                 Filter: (rp1.risk_period_rank = 1)
                                 ->  WindowAgg  (cost=7446600.66..8214651.41 rows=10240677 width=14)
                                       Partition By: rp.cover_no, rp.period_no, rp.risk_no
                                       Order By: rp.risk_period_no
                                       ->  Sort  (cost=7446600.66..7523405.74 rows=10240677 width=14)
                                             Sort Key: rp.cover_no, rp.period_no, rp.risk_no, rp.risk_period_no
                                             ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..1694486.20 rows=10240677 width=14)
                                                   Hash Key: rp.cover_no, rp.period_no, rp.risk_no
                                                   ->  Subquery Scan on rp  (cost=0.00..1080045.60 rows=10240677 width=14)
                                                         ->  Append  (cost=0.00..772825.30 rows=10240677 width=319)
                                                               ->  Seq Scan on sor_cm_risk_period rskp  (cost=0.00..103754.40 rows=1433280 width=319)
                                                               ->  Seq Scan on sor_cm_risk_period rskp_1  (cost=0.00..72023.00 rows=993900 width=319)
                                                               ->  Seq Scan on sor_cm_risk_period rskp_2  (cost=0.00..58805.90 rows=777497 width=319)
                                                               ->  Seq Scan on sor_cm_risk_period rskp_3  (cost=0.00..538242.00 rows=7036000 width=319)
 Optimizer: Postgres query optimizer
(30 rows)
```

Notice this PR doesn't break the test cases in #12724 which fixed issue #12656, because we only do the simplification in the correlated case:
```
        if (correlated)
	{
		/* Delete ORDER BY and DISTINCT. */
		cdbsubselect_drop_orderby(subselect);
		cdbsubselect_drop_distinct(subselect);
```
Issue #12656 meets an explicitly distinct case, which will not go into this branch, so there would be no test case broken.


## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
