### PR TITLE
Simplify IN subquery for sublink pullup. 

### DIFF
--- a/src/backend/cdb/cdbsubselect.c
+++ b/src/backend/cdb/cdbsubselect.c
@@ -464,7 +464,38 @@ SubqueryToJoinWalker(Node *node, ConvertSubqueryToJoinContext *context)
 	return;
 }
 
+/*
+ * cdbsubselect_drop_distinct
+ */
+void
+cdbsubselect_drop_distinct(Query *subselect)
+{
+	if (subselect->limitCount == NULL &&
+		subselect->limitOffset == NULL)
+	{
+		/* Delete DISTINCT. */
+		subselect->distinctClause = NIL;
 
+		/* Delete GROUP BY if subquery has no aggregates and no HAVING. */
+		if (!subselect->hasAggs &&
+			subselect->havingQual == NULL)
+			subselect->groupClause = NIL;
+	}
+}	/* cdbsubselect_drop_distinct */
+
+/*
+ * cdbsubselect_drop_orderby
+ */
+void
+cdbsubselect_drop_orderby(Query *subselect)
+{
+	if (subselect->limitCount == NULL &&
+		subselect->limitOffset == NULL)
+	{
+		/* Delete ORDER BY. */
+		subselect->sortClause = NIL;
+	}
+}	/* cdbsubselect_drop_orderby */
 
 /**
  * Safe to convert expr sublink to a join

--- a/src/backend/optimizer/plan/subselect.c
+++ b/src/backend/optimizer/plan/subselect.c
@@ -1454,6 +1454,20 @@ convert_ANY_sublink_to_join(PlannerInfo *root, SubLink *sublink,
 
 	if (correlated)
 	{
+		/* Delete ORDER BY and DISTINCT. 
+		 *
+		 * There is no need to do the group-by or order-by inside the
+		 * subquery, if we have decided to pull up the sublink (when the
+		 * subquery is correlated). For the group-by case, after the sublink
+		 * pull-up, there will be a semi-join plan node generated in top
+		 * level, which will weed out duplicate tuples naturally. For the
+		 * order-by case, after the sublink pull-up, the subquery will become
+		 * a jointree, inside which the tuples' order doesn't matter. In a
+		 * summary, it's safe to elimate the group-by or order-by causes here.
+		*/
+		cdbsubselect_drop_orderby(subselect);
+		cdbsubselect_drop_distinct(subselect);
+
 		/*
 		 * Under certain conditions, we cannot pull up the subquery as a join.
 		 */

--- a/src/include/cdb/cdbsubselect.h
+++ b/src/include/cdb/cdbsubselect.h
@@ -24,4 +24,7 @@ extern bool is_simple_subquery(PlannerInfo *root, Query *subquery, RangeTblEntry
 							   JoinExpr *lowest_outer_join);
 extern JoinExpr *convert_IN_to_antijoin(PlannerInfo *root, SubLink *sublink, Relids available_rels);
 
+extern void cdbsubselect_drop_orderby(Query *subselect);
+extern void cdbsubselect_drop_distinct(Query *subselect);
+
 #endif   /* CDBSUBSELECT_H */

--- a/src/test/regress/expected/subselect_gp.out
+++ b/src/test/regress/expected/subselect_gp.out
@@ -1626,6 +1626,77 @@ EXPLAIN SELECT '' AS five, f1 AS "Correlated Field"
  Optimizer: Postgres query optimizer
 (13 rows)
 
+-- Test simplify group-by/order-by inside subquery if sublink pull-up is possible
+EXPLAIN SELECT '' AS six, f1 AS "Correlated Field", f2 AS "Second Field"
+  FROM SUBSELECT_TBL upper
+  WHERE f1 IN (SELECT f2 FROM SUBSELECT_TBL WHERE f1 = upper.f1 GROUP BY f2);
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=1.05..2.13 rows=3 width=40)
+   ->  Hash Semi Join  (cost=1.05..2.09 rows=1 width=40)
+         Hash Cond: (upper.f1 = subselect_tbl.f1)
+         ->  Seq Scan on subselect_tbl upper  (cost=0.00..1.03 rows=3 width=8)
+         ->  Hash  (cost=1.03..1.03 rows=1 width=8)
+               ->  Seq Scan on subselect_tbl  (cost=0.00..1.03 rows=1 width=8)
+                     Filter: (f1 = f2)
+ Optimizer: Postgres query optimizer
+(8 rows)
+
+EXPLAIN SELECT '' AS six, f1 AS "Correlated Field", f2 AS "Second Field"
+  FROM SUBSELECT_TBL upper
+  WHERE f1 IN (SELECT f2 FROM SUBSELECT_TBL WHERE f1 = upper.f1  GROUP BY f2 LIMIT 3);
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1.08 rows=4 width=40)
+   ->  Seq Scan on subselect_tbl upper  (cost=0.00..1.03 rows=1 width=40)
+         Filter: (SubPlan 1)
+         SubPlan 1
+           ->  Limit  (cost=1.27..1.30 rows=3 width=4)
+                 ->  HashAggregate  (cost=1.27..1.33 rows=6 width=4)
+                       Group Key: subselect_tbl.f2
+                       ->  Result  (cost=0.00..1.25 rows=8 width=4)
+                             Filter: (subselect_tbl.f1 = upper.f1)
+                             ->  Materialize  (cost=0.00..1.17 rows=8 width=8)
+                                   ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1.13 rows=8 width=8)
+                                         ->  Seq Scan on subselect_tbl  (cost=0.00..1.03 rows=3 width=8)
+ Optimizer: Postgres query optimizer
+(13 rows)
+
+EXPLAIN SELECT '' AS six, f1 AS "Correlated Field", f2 AS "Second Field"
+  FROM SUBSELECT_TBL upper
+  WHERE f1 IN (SELECT f2 FROM SUBSELECT_TBL WHERE f1 = upper.f1 ORDER BY f2);
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=1.05..2.13 rows=3 width=40)
+   ->  Hash Semi Join  (cost=1.05..2.09 rows=1 width=40)
+         Hash Cond: (upper.f1 = subselect_tbl.f1)
+         ->  Seq Scan on subselect_tbl upper  (cost=0.00..1.03 rows=3 width=8)
+         ->  Hash  (cost=1.03..1.03 rows=1 width=8)
+               ->  Seq Scan on subselect_tbl  (cost=0.00..1.03 rows=1 width=8)
+                     Filter: (f1 = f2)
+ Optimizer: Postgres query optimizer
+(8 rows)
+
+EXPLAIN SELECT '' AS six, f1 AS "Correlated Field", f2 AS "Second Field"
+  FROM SUBSELECT_TBL upper
+  WHERE f1 IN (SELECT f2 FROM SUBSELECT_TBL WHERE f1 = upper.f1  ORDER BY f2 LIMIT 3);
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1.08 rows=4 width=40)
+   ->  Seq Scan on subselect_tbl upper  (cost=0.00..1.03 rows=1 width=40)
+         Filter: (SubPlan 1)
+         SubPlan 1
+           ->  Limit  (cost=1.36..1.36 rows=3 width=4)
+                 ->  Sort  (cost=1.36..1.38 rows=8 width=4)
+                       Sort Key: subselect_tbl.f2
+                       ->  Result  (cost=0.00..1.25 rows=8 width=4)
+                             Filter: (subselect_tbl.f1 = upper.f1)
+                             ->  Materialize  (cost=0.00..1.17 rows=8 width=8)
+                                   ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1.13 rows=8 width=8)
+                                         ->  Seq Scan on subselect_tbl  (cost=0.00..1.03 rows=3 width=8)
+ Optimizer: Postgres query optimizer
+(13 rows)
+
 --
 -- Test cases to catch unpleasant interactions between IN-join processing
 -- and subquery pullup.

--- a/src/test/regress/expected/subselect_gp_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_optimizer.out
@@ -1642,6 +1642,81 @@ EXPLAIN SELECT '' AS five, f1 AS "Correlated Field"
  Optimizer: Postgres query optimizer
 (13 rows)
 
+-- Test simplify group-by/order-by inside subquery if sublink pull-up is possible
+EXPLAIN SELECT '' AS six, f1 AS "Correlated Field", f2 AS "Second Field"
+  FROM SUBSELECT_TBL upper
+  WHERE f1 IN (SELECT f2 FROM SUBSELECT_TBL WHERE f1 = upper.f1 GROUP BY f2);
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Result  (cost=0.00..862.00 rows=8 width=16)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=8 width=8)
+         ->  Hash Semi Join  (cost=0.00..862.00 rows=3 width=8)
+               Hash Cond: ((subselect_tbl.f1 = subselect_tbl_1.f1) AND (subselect_tbl.f1 = subselect_tbl_1.f2))
+               ->  Seq Scan on subselect_tbl  (cost=0.00..431.00 rows=3 width=8)
+               ->  Hash  (cost=431.00..431.00 rows=3 width=8)
+                     ->  Seq Scan on subselect_tbl subselect_tbl_1  (cost=0.00..431.00 rows=3 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(8 rows)
+
+EXPLAIN SELECT '' AS six, f1 AS "Correlated Field", f2 AS "Second Field"
+  FROM SUBSELECT_TBL upper
+  WHERE f1 IN (SELECT f2 FROM SUBSELECT_TBL WHERE f1 = upper.f1  GROUP BY f2 LIMIT 3);
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Result  (cost=0.00..1324038.55 rows=8 width=16)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1324038.55 rows=8 width=8)
+         ->  Seq Scan on subselect_tbl  (cost=0.00..1324038.55 rows=3 width=8)
+               Filter: (SubPlan 1)
+               SubPlan 1
+                 ->  Limit  (cost=0.00..431.01 rows=1 width=4)
+                       ->  GroupAggregate  (cost=0.00..431.01 rows=1 width=4)
+                             Group Key: subselect_tbl_1.f2
+                             ->  Sort  (cost=0.00..431.01 rows=1 width=4)
+                                   Sort Key: subselect_tbl_1.f2
+                                   ->  Result  (cost=0.00..431.01 rows=1 width=4)
+                                         Filter: (subselect_tbl_1.f1 = subselect_tbl.f1)
+                                         ->  Materialize  (cost=0.00..431.00 rows=8 width=8)
+                                               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=8 width=8)
+                                                     ->  Seq Scan on subselect_tbl subselect_tbl_1  (cost=0.00..431.00 rows=3 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(16 rows)
+
+EXPLAIN SELECT '' AS six, f1 AS "Correlated Field", f2 AS "Second Field"
+  FROM SUBSELECT_TBL upper
+  WHERE f1 IN (SELECT f2 FROM SUBSELECT_TBL WHERE f1 = upper.f1 ORDER BY f2);
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Result  (cost=0.00..862.00 rows=8 width=16)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=8 width=8)
+         ->  Hash Semi Join  (cost=0.00..862.00 rows=3 width=8)
+               Hash Cond: ((subselect_tbl.f1 = subselect_tbl_1.f1) AND (subselect_tbl.f1 = subselect_tbl_1.f2))
+               ->  Seq Scan on subselect_tbl  (cost=0.00..431.00 rows=3 width=8)
+               ->  Hash  (cost=431.00..431.00 rows=3 width=8)
+                     ->  Seq Scan on subselect_tbl subselect_tbl_1  (cost=0.00..431.00 rows=3 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(8 rows)
+
+EXPLAIN SELECT '' AS six, f1 AS "Correlated Field", f2 AS "Second Field"
+  FROM SUBSELECT_TBL upper
+  WHERE f1 IN (SELECT f2 FROM SUBSELECT_TBL WHERE f1 = upper.f1  ORDER BY f2 LIMIT 3);
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Result  (cost=0.00..1324038.57 rows=8 width=16)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1324038.57 rows=8 width=8)
+         ->  Seq Scan on subselect_tbl  (cost=0.00..1324038.57 rows=3 width=8)
+               Filter: (SubPlan 1)
+               SubPlan 1
+                 ->  Limit  (cost=0.00..431.01 rows=1 width=4)
+                       ->  Sort  (cost=0.00..431.01 rows=1 width=4)
+                             Sort Key: subselect_tbl_1.f2
+                             ->  Result  (cost=0.00..431.01 rows=1 width=4)
+                                   Filter: (subselect_tbl_1.f1 = subselect_tbl.f1)
+                                   ->  Materialize  (cost=0.00..431.00 rows=8 width=8)
+                                         ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=8 width=8)
+                                               ->  Seq Scan on subselect_tbl subselect_tbl_1  (cost=0.00..431.00 rows=3 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(14 rows)
+
 --
 -- Test cases to catch unpleasant interactions between IN-join processing
 -- and subquery pullup.

--- a/src/test/regress/sql/subselect_gp.sql
+++ b/src/test/regress/sql/subselect_gp.sql
@@ -745,6 +745,24 @@ EXPLAIN SELECT '' AS five, f1 AS "Correlated Field"
   WHERE (f1, f2) IN (SELECT f2, CAST(f3 AS int4) FROM SUBSELECT_TBL
                      WHERE f3 IS NOT NULL) ORDER BY 2;
 
+-- Test simplify group-by/order-by inside subquery if sublink pull-up is possible
+EXPLAIN SELECT '' AS six, f1 AS "Correlated Field", f2 AS "Second Field"
+  FROM SUBSELECT_TBL upper
+  WHERE f1 IN (SELECT f2 FROM SUBSELECT_TBL WHERE f1 = upper.f1 GROUP BY f2);
+
+EXPLAIN SELECT '' AS six, f1 AS "Correlated Field", f2 AS "Second Field"
+  FROM SUBSELECT_TBL upper
+  WHERE f1 IN (SELECT f2 FROM SUBSELECT_TBL WHERE f1 = upper.f1  GROUP BY f2 LIMIT 3);
+
+EXPLAIN SELECT '' AS six, f1 AS "Correlated Field", f2 AS "Second Field"
+  FROM SUBSELECT_TBL upper
+  WHERE f1 IN (SELECT f2 FROM SUBSELECT_TBL WHERE f1 = upper.f1 ORDER BY f2);
+
+EXPLAIN SELECT '' AS six, f1 AS "Correlated Field", f2 AS "Second Field"
+  FROM SUBSELECT_TBL upper
+  WHERE f1 IN (SELECT f2 FROM SUBSELECT_TBL WHERE f1 = upper.f1  ORDER BY f2 LIMIT 3);
+
+
 --
 -- Test cases to catch unpleasant interactions between IN-join processing
 -- and subquery pullup.


### PR DESCRIPTION
In GP7's convert_ANY_sublink_to_join(), there is no simplification of origin subquery, as a result sometimes the sublink cannot be pulled up, which produced a bad query plan. In GP5, there is a subquery simplify step which helped sublink pull-up:
```
/* Delete ORDER BY and DISTINCT. */
		cdbsubselect_drop_orderby(subselect);
		cdbsubselect_drop_distinct(subselect);
```
As only simple sub-query is allowed to be pulled up:
```
                 /*
		 * Under certain conditions, we cannot pull up the subquery as a join.
		 */
		if (!is_simple_subquery(root, subselect, NULL, NULL))
			return NULL;
```

Take a look at the following query case:
```
EXPLAIN SELECT rmv_1.cover_no,
            rmv_1.period_no,
            rmv_1.risk_no,
            rmv_1.risk_period_no,
            rmv_1.location_ext_no,
            rmv_1.source_system
           FROM ctx.gis_risk_mv rmv_1
          WHERE ((rmv_1.cover_no, rmv_1.period_no, rmv_1.risk_no, rmv_1.risk_period_no, (rmv_1.source_system)::text) IN ( SELECT rp1.cover_no,
                    rp1.period_no,
                    rp1.risk_no,
                    rp1.risk_period_no,
                    rmv_1.source_system
                   FROM ( SELECT rp.cover_no,
                            rp.period_no,
                            rp.risk_no,
                            rp.risk_period_no,
                            row_number() OVER (PARTITION BY rp.cover_no, rp.period_no, rp.risk_no ORDER BY rp.risk_period_no DESC) AS risk_period_rank
                           FROM ctx.gis_risk_period rp) rp1
                  WHERE (rp1.risk_period_rank = 1)
                  GROUP BY rp1.cover_no, rp1.period_no, rp1.risk_no, rp1.risk_period_no, rmv_1.source_system));
```

But we lose this simplification since version 6X until master, which caused the sublink pull-up doesn't work:

```
Gather Motion 3:1  (slice5; segments: 3)  (cost=0.00..1334551428791.85 rows=77599 width=48)
   ->  Subquery Scan on rmv_1  (cost=0.00..1334551428791.85 rows=25867 width=48)
         Filter: (SubPlan 1)
         ->  Append  (cost=0.00..3478.96 rows=51733 width=210)
               ->  Seq Scan on sor_cm_risk_mv rskmv  (cost=0.00..236.89 rows=3097 width=208)
               ->  Seq Scan on sor_cm_risk_mv rskmv_1  (cost=0.00..225.56 rows=2719 width=208)
               ->  Seq Scan on sor_cm_risk_mv rskmv_2  (cost=0.00..1.00 rows=1 width=824)
               ->  Seq Scan on sor_cm_risk_mv rskmv_3  (cost=0.00..3015.51 rows=45917 width=210)
         SubPlan 1  (slice5; segments: 3)
           ->  HashAggregate  (cost=8599060.81..8599091.54 rows=1025 width=46)
                 Group Key: rp1.cover_no, rp1.period_no, rp1.risk_no, rp1.risk_period_no, rmv_1.source_system
                 ->  Subquery Scan on rp1  (cost=7446600.66..8598676.79 rows=10241 width=14)
                       Filter: (rp1.risk_period_rank = 1)
                       ->  WindowAgg  (cost=7446600.66..8214651.41 rows=10240677 width=14)
                             Partition By: rp.cover_no, rp.period_no, rp.risk_no
                             Order By: rp.risk_period_no
                             ->  Sort  (cost=7446600.66..7523405.74 rows=10240677 width=14)
                                   Sort Key: rp.cover_no, rp.period_no, rp.risk_no, rp.risk_period_no
                                   ->  Subquery Scan on rp  (cost=0.00..1080045.60 rows=10240677 width=14)
                                         ->  Append  (cost=0.00..772825.30 rows=10240677 width=319)
                                               ->  Result  (cost=0.00..170393.60 rows=1433280 width=319)
                                                     ->  Materialize  (cost=0.00..170393.60 rows=1433280 width=319)
                                                           ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..103754.40 rows=1433280 width=319)
                                                                 ->  Seq Scan on sor_cm_risk_period rskp  (cost=0.00..103754.40 rows=1433280 width=319)
                                               ->  Result  (cost=0.00..118234.50 rows=993900 width=319)
                                                     ->  Materialize  (cost=0.00..118234.50 rows=993900 width=319)
                                                           ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..72023.00 rows=993900 width=319)
                                                                 ->  Seq Scan on sor_cm_risk_period rskp_1  (cost=0.00..72023.00 rows=993900 width=319)
                                               ->  Result  (cost=0.00..94955.35 rows=777497 width=319)
                                                     ->  Materialize  (cost=0.00..94955.35 rows=777497 width=319)
                                                           ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..58805.90 rows=777497 width=319)
                                                                 ->  Seq Scan on sor_cm_risk_period rskp_2  (cost=0.00..58805.90 rows=777497 width=319)
                                               ->  Result  (cost=0.00..865375.00 rows=7036000 width=319)
                                                     ->  Materialize  (cost=0.00..865375.00 rows=7036000 width=319)
                                                           ->  Broadcast Motion 3:3  (slice4; segments: 3)  (cost=0.00..538242.00 rows=7036000 width=319)
                                                                 ->  Seq Scan on sor_cm_risk_period rskp_3  (cost=0.00..538242.00 rows=7036000 width=319)
 Optimizer: Postgres query optimizer
(37 rows)
```
After we brought back `cdbsubselect_drop_distinct` and `cdbsubselect_drop_orderby`, we can got simplified subquery again and do the sublink pull-up optimization, which produced a better plan:
```
Gather Motion 3:1  (slice3; segments: 3)  (cost=8599137.66..8845829.72 rows=9700 width=48)
   ->  Hash Join  (cost=8599137.66..8845829.72 rows=3234 width=48)
         Hash Cond: ((rmv_1.cover_no = rp1.cover_no) AND (rmv_1.period_no = rp1.period_no) AND (rmv_1.risk_no = rp1.risk_no) AND (rmv_1.risk_period_no = rp1.risk_period_no))
         ->  Subquery Scan on rmv_1  (cost=0.00..6582.90 rows=51733 width=48)
               ->  Append  (cost=0.00..5030.93 rows=51733 width=210)
                     ->  Seq Scan on sor_cm_risk_mv rskmv  (cost=0.00..236.89 rows=3097 width=176)
                     ->  Seq Scan on sor_cm_risk_mv rskmv_1  (cost=0.00..225.56 rows=2719 width=176)
                     ->  Seq Scan on sor_cm_risk_mv rskmv_2  (cost=0.00..1.00 rows=1 width=792)
                     ->  Seq Scan on sor_cm_risk_mv rskmv_3  (cost=0.00..3015.51 rows=45917 width=178)
         ->  Hash  (cost=8599076.20..8599076.20 rows=1025 width=14)
               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=8598984.01..8599076.20 rows=1025 width=14)
                     Hash Key: rp1.cover_no, rp1.period_no, rp1.risk_no, rp1.risk_period_no
                     ->  HashAggregate  (cost=8598984.01..8599014.74 rows=1025 width=14)
                           Group Key: rp1.cover_no, rp1.period_no, rp1.risk_no, rp1.risk_period_no
                           ->  Subquery Scan on rp1  (cost=7446600.66..8598676.79 rows=10241 width=14)
                                 Filter: (rp1.risk_period_rank = 1)
                                 ->  WindowAgg  (cost=7446600.66..8214651.41 rows=10240677 width=14)
                                       Partition By: rp.cover_no, rp.period_no, rp.risk_no
                                       Order By: rp.risk_period_no
                                       ->  Sort  (cost=7446600.66..7523405.74 rows=10240677 width=14)
                                             Sort Key: rp.cover_no, rp.period_no, rp.risk_no, rp.risk_period_no
                                             ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..1694486.20 rows=10240677 width=14)
                                                   Hash Key: rp.cover_no, rp.period_no, rp.risk_no
                                                   ->  Subquery Scan on rp  (cost=0.00..1080045.60 rows=10240677 width=14)
                                                         ->  Append  (cost=0.00..772825.30 rows=10240677 width=319)
                                                               ->  Seq Scan on sor_cm_risk_period rskp  (cost=0.00..103754.40 rows=1433280 width=319)
                                                               ->  Seq Scan on sor_cm_risk_period rskp_1  (cost=0.00..72023.00 rows=993900 width=319)
                                                               ->  Seq Scan on sor_cm_risk_period rskp_2  (cost=0.00..58805.90 rows=777497 width=319)
                                                               ->  Seq Scan on sor_cm_risk_period rskp_3  (cost=0.00..538242.00 rows=7036000 width=319)
 Optimizer: Postgres query optimizer
(30 rows)
```

Notice this PR doesn't break the test cases in #12724 which fixed issue #12656, because we only do the simplification in the correlated case:
```
        if (correlated)
	{
		/* Delete ORDER BY and DISTINCT. */
		cdbsubselect_drop_orderby(subselect);
		cdbsubselect_drop_distinct(subselect);
```
Issue #12656 meets an explicitly distinct case, which will not go into this branch, so there would be no test case broken.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [x] Review a PR in return to support the community
