### PR TITLE
fix unpredictable behavior during AO index vacuum

### DIFF
--- a/src/backend/commands/vacuum.c
+++ b/src/backend/commands/vacuum.c
@@ -125,7 +125,7 @@ static void vac_truncate_clog(TransactionId frozenXID,
 							  MultiXactId lastSaneMinMulti);
 static bool vacuum_rel(Relation onerel, Oid relid, VacuumStmt *vacstmt, LOCKMODE lmode,
 		   bool for_wraparound);
-static void scan_index(Relation indrel, bool check_stats, int elevel);
+static void scan_index(Relation indrel, double num_tuples, bool check_stats, int elevel);
 static bool appendonly_tid_reaped(ItemPointer itemptr, void *state);
 static void dispatchVacuum(VacuumStmt *vacstmt, VacuumStatsContext *ctx);
 static void vacuumStatement_Relation(VacuumStmt *vacstmt, Oid relid,
@@ -2645,7 +2645,10 @@ vacuum_appendonly_indexes(Relation aoRelation, VacuumStmt *vacstmt, Bitmapset *d
 		{
 			for (i = 0; i < nindexes; i++)
 			{
-				scan_index(Irel[i], true, elevel);
+				scan_index(Irel[i],
+						   aoRelation->rd_rel->reltuples,
+						   true,
+						   elevel);
 			}
 		}
 		else
@@ -2653,7 +2656,7 @@ vacuum_appendonly_indexes(Relation aoRelation, VacuumStmt *vacstmt, Bitmapset *d
 			for (i = 0; i < nindexes; i++)
 			{
 				vacuum_appendonly_index(Irel[i],
-										Irel[i]->rd_rel->reltuples,
+										aoRelation->rd_rel->reltuples,
 										dead_segs,
 										elevel);
 			}
@@ -2692,13 +2695,13 @@ vac_is_partial_index(Relation indrel)
  * We use this when we have no deletions to do.
  * 
  * We used to pass an argument num_tuples with value of table->reltuples to
- * ivinfo.num_heap_tuples, now with the new VACUUM strategy, we removed it
- * since we cannot get table->reltuples in the calling context.
- * Therefore, ivinfo.num_heap_tuples is not an accurate value, so we need
- * to set estimated_count to true.
+ * ivinfo.num_heap_tuples, now with the new VACUUM strategy,  we cannot get
+ * exact table->reltuples in the calling context. We able to use existing
+ * value from pg_class for table. Therefore, ivinfo.num_heap_tuples is not an
+ * accurate value, so we need to set estimated_count to true.
  */
 static void
-scan_index(Relation indrel, bool check_stats, int elevel)
+scan_index(Relation indrel, double num_tuples, bool check_stats, int elevel)
 {
 	IndexBulkDeleteResult *stats;
 	IndexVacuumInfo ivinfo;
@@ -2710,7 +2713,7 @@ scan_index(Relation indrel, bool check_stats, int elevel)
 	ivinfo.analyze_only = false;
 	ivinfo.estimated_count = true;
 	ivinfo.message_level = elevel;
-	ivinfo.num_heap_tuples = indrel->rd_rel->reltuples; /* inaccurate */
+	ivinfo.num_heap_tuples = num_tuples;
 	ivinfo.strategy = vac_strategy;
 
 	stats = index_vacuum_cleanup(&ivinfo, NULL);
@@ -2771,6 +2774,12 @@ scan_index(Relation indrel, bool check_stats, int elevel)
  * This is called after an append-only segment file compaction to move
  * all tuples from the compacted segment files.
  * The segmentFileList is an
+ *
+ * We used to pass an argument rel_tuple_count with value of table->reltuples to
+ * ivinfo.num_heap_tuples, now with the new VACUUM strategy,  we cannot get
+ * exact table->reltuples in the calling context. We able to use existing
+ * value from pg_class for table. Therefore, ivinfo.num_heap_tuples is not an
+ * accurate value, so we need to set estimated_count to true.
  */
 static void
 vacuum_appendonly_index(Relation indexRelation,
@@ -2779,7 +2788,7 @@ vacuum_appendonly_index(Relation indexRelation,
 						int elevel)
 {
 	IndexBulkDeleteResult *stats;
-	IndexVacuumInfo ivinfo;
+	IndexVacuumInfo ivinfo = {0};
 	PGRUsage	ru0;
 
 	Assert(RelationIsValid(indexRelation));
@@ -2787,6 +2796,8 @@ vacuum_appendonly_index(Relation indexRelation,
 	pg_rusage_init(&ru0);
 
 	ivinfo.index = indexRelation;
+	ivinfo.analyze_only = false;
+	ivinfo.estimated_count = true;
 	ivinfo.message_level = elevel;
 	ivinfo.num_heap_tuples = rel_tuple_count;
 	ivinfo.strategy = vac_strategy;

--- a/src/test/regress/expected/uao_compaction/index_stats.out
+++ b/src/test/regress/expected/uao_compaction/index_stats.out
@@ -35,3 +35,23 @@ SELECT relname, reltuples FROM pg_class WHERE relname = 'mytab_int_idx1';
  mytab_int_idx1 |         2
 (1 row)
 
+-- A test of index stat for access methods that rely on table tuple count (bitmap, gin)
+truncate mytab;
+create index mytab_int_idx2 on mytab using bitmap(col_int);
+insert into mytab values(1,'aa',1001,101),(2,'bb',1002,102);
+SELECT relname, reltuples FROM pg_class WHERE relname = 'mytab_int_idx2';
+    relname     | reltuples 
+----------------+-----------
+ mytab_int_idx2 |         2
+(1 row)
+
+-- first vacuum collect table stat on segments
+vacuum mytab;
+-- second vacuum update index stat with table stat
+vacuum mytab;
+SELECT relname, reltuples FROM pg_class WHERE relname = 'mytab_int_idx2';
+    relname     | reltuples 
+----------------+-----------
+ mytab_int_idx2 |         2
+(1 row)
+

--- a/src/test/regress/expected/uaocs_compaction/index_stats.out
+++ b/src/test/regress/expected/uaocs_compaction/index_stats.out
@@ -40,3 +40,23 @@ SELECT relname, reltuples FROM pg_class WHERE relname = 'uaocs_index_stats_int_i
  uaocs_index_stats_int_idx1 |         2
 (1 row)
 
+-- A test of index stat for access methods that rely on table tuple count (bitmap, gin)
+truncate uaocs_index_stats;
+create index uaocs_index_stats_int_idx2 on uaocs_index_stats using bitmap(col_int);
+insert into uaocs_index_stats values(1,'aa',1001,101),(2,'bb',1002,102);
+SELECT relname, reltuples FROM pg_class WHERE relname = 'uaocs_index_stats_int_idx2';
+          relname           | reltuples 
+----------------------------+-----------
+ uaocs_index_stats_int_idx2 |         2
+(1 row)
+
+-- first vacuum collect table stat on segments
+vacuum uaocs_index_stats;
+-- second vacuum update index stat with table stat
+vacuum uaocs_index_stats;
+SELECT relname, reltuples FROM pg_class WHERE relname = 'uaocs_index_stats_int_idx2';
+          relname           | reltuples 
+----------------------------+-----------
+ uaocs_index_stats_int_idx2 |         2
+(1 row)
+

--- a/src/test/regress/sql/uao_compaction/index_stats.sql
+++ b/src/test/regress/sql/uao_compaction/index_stats.sql
@@ -17,3 +17,18 @@ select * from mytab;
 vacuum mytab;
 SELECT relname, reltuples FROM pg_class WHERE relname = 'mytab';
 SELECT relname, reltuples FROM pg_class WHERE relname = 'mytab_int_idx1';
+
+-- A test of index stat for access methods that rely on table tuple count (bitmap, gin)
+truncate mytab;
+create index mytab_int_idx2 on mytab using bitmap(col_int);
+
+insert into mytab values(1,'aa',1001,101),(2,'bb',1002,102);
+
+SELECT relname, reltuples FROM pg_class WHERE relname = 'mytab_int_idx2';
+
+-- first vacuum collect table stat on segments
+vacuum mytab;
+-- second vacuum update index stat with table stat
+vacuum mytab;
+
+SELECT relname, reltuples FROM pg_class WHERE relname = 'mytab_int_idx2';

--- a/src/test/regress/sql/uaocs_compaction/index_stats.sql
+++ b/src/test/regress/sql/uaocs_compaction/index_stats.sql
@@ -17,3 +17,18 @@ select * from uaocs_index_stats;
 vacuum uaocs_index_stats;
 SELECT relname, reltuples FROM pg_class WHERE relname = 'uaocs_index_stats';
 SELECT relname, reltuples FROM pg_class WHERE relname = 'uaocs_index_stats_int_idx1';
+
+-- A test of index stat for access methods that rely on table tuple count (bitmap, gin)
+truncate uaocs_index_stats;
+create index uaocs_index_stats_int_idx2 on uaocs_index_stats using bitmap(col_int);
+
+insert into uaocs_index_stats values(1,'aa',1001,101),(2,'bb',1002,102);
+
+SELECT relname, reltuples FROM pg_class WHERE relname = 'uaocs_index_stats_int_idx2';
+
+-- first vacuum collect table stat on segments
+vacuum uaocs_index_stats;
+-- second vacuum update index stat with table stat
+vacuum uaocs_index_stats;
+
+SELECT relname, reltuples FROM pg_class WHERE relname = 'uaocs_index_stats_int_idx2';


### PR DESCRIPTION
Before this patch, IndexVacuumInfo structure didn't have initial value in the `vacuum_appendonly_index` and as result its unfilled members contained memory garbage. E.g. estimated_count and analyzed_only. This problem could affect `index_vacuum_cleanup` (e.g. btvacuumcleanup for btree indexes). This function refuses to do something (including index fsm cleanup) in case of analyzed_only contained non-zero value.

The problem manifested itself after c7d99d911fd2f813ca1661155aa973a3366ac165, that rework vacuum for AO indexes. As a part of this patch, it was decided to not recalculate alive tuple counts during each vacuum compaction-drop iteration to improve performance. (The final recalculation to update pg_class statistic entries is proceeded during the vacuum cleanup phase after removing dead segments). As a result, it was suggested as a workaround to use an old index reltuples value as num_heap_tuples. It was quite strange decision, because this value is used as is as an index tuple count for several kinds of indexes (bitmap, gin). So, these indexes always will have initial reltuples count on segments (see provided test case). So, I suggest changing this estimation to **relation** tuples count extracted from pg_class before vacuum (really?). But this value is updated only by VACUUM on segments. Analyze updates pg_class statistic only on the coordinator, index building - only on segments.

Moreover, the new AO index vacuum strategy uses similar approach with an old index/relation tuples count not only for scan_index but for vacuum_appendonly_index too. gpdb allows notifying index access method functions about provided table tuple count is not exact by an estimated_count flag in the IndexVacuumInfo structure. Index access methods won't try to limit index tuple count calculated during index scan by using such table value (see *indexcleanup functions for btree, spgist).

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
