### PR TITLE
(6x) Fix unittest aocsam_test.

### DIFF
--- a/src/backend/access/aocs/test/aocsam_test.c
+++ b/src/backend/access/aocs/test/aocsam_test.c
@@ -25,9 +25,15 @@ test__aocs_begin_headerscan(void **state)
 	pgappendonly.checksum = true;
 	reldata.rd_appendonly = &pgappendonly;
 	FormData_pg_class pgclass;
+	int nattr = 1;
 
 	reldata.rd_rel = &pgclass;
-	int nattr = 1;
+	reldata.rd_rel->relnatts = nattr;
+	reldata.rd_att = (TupleDesc) palloc(sizeof(struct tupleDesc));
+	reldata.rd_att->attrs =
+		(Form_pg_attribute *) palloc(sizeof(Form_pg_attribute *) * nattr);
+	memset(reldata.rd_att->attrs, 0, sizeof(Form_pg_attribute *) * nattr);
+	reldata.rd_att->natts = nattr;
 
 	/* opts and opt will be freed by aocs_begin_headerscan */
 	StdRdOptions **opts =
@@ -106,12 +112,14 @@ test__aocs_addcol_init(void **state)
 	FormData_pg_class rel;
 	rel.relpersistence = RELPERSISTENCE_PERMANENT;
 	reldata.rd_rel = &rel;
+	reldata.rd_rel->relnatts = 5;
 	reldata.rd_appendonly = &pgappendonly;
 	reldata.rd_att = (TupleDesc) palloc(sizeof(struct tupleDesc));
 	reldata.rd_att->attrs =
 		(Form_pg_attribute *) palloc(sizeof(Form_pg_attribute *) * nattr);
 	memset(reldata.rd_att->attrs, 0, sizeof(Form_pg_attribute *) * nattr);
 	reldata.rd_att->natts = 5;
+
 	/* 3 existing columns, 2 new columns */
 	desc = aocs_addcol_init(&reldata, 2);
 	assert_int_equal(desc->num_newcols, 2);


### PR DESCRIPTION
We see unittest failure in pipeline:

FATAL:  (XX000) Unexpected internal error
          DETAIL:  FailedAssertion("!(pointer != ((void *)0))", File: "mcxt.c", Line: 1291)

Unittest code forget to mock Relation->rd_rel->relnatts which is needed by core code (like aocs_addcol_init). Mock them to fix the unittest.

Co-author-by: Qing Ma <maqi@vmware.com>

-------

pipeline failure: https://prod.ci.gpdb.pivotal.io/teams/main/pipelines/6X_STABLE/jobs/compile_gpdb_sles12/builds/715

master branch does not have the code yet. 

-----

**Interesting that this only constantly fail on SLES, I have run a GCP of SLES 12 and run the unitest with the fix commit many times, all passed.**
