### PR TITLE
[7X] Allow executing non-srf on coordinator.

### DIFF
--- a/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_FUNCTION.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_FUNCTION.html.md
@@ -264,7 +264,7 @@ Most functions that run queries to access tables can only run on the master. How
 
 These are limitations for functions defined with the `EXECUTE ON MASTER` or `EXECUTE ON ALL SEGMENTS` attribute:
 
--   The function must be a set-returning function.
+-   The function must be a set-returning function (This restriction only applies on the functions defined with `EXECUTE ON ALL SEGMENTS` attribute).
 -   The function cannot be in the `FROM` clause of a query.
 -   The function cannot be in the `SELECT` list of a query with a `FROM` clause.
 -   A query that includes the function falls back from GPORCA to the Postgres Planner.

--- a/src/backend/commands/functioncmds.c
+++ b/src/backend/commands/functioncmds.c
@@ -745,20 +745,14 @@ static void
 validate_sql_exec_location(char exec_location, bool proretset)
 {
 	/*
-	 * ON COORDINATOR and ON ALL SEGMENTS are only supported for set-returning
+	 * ON ALL SEGMENTS is only supported for set-returning
 	 * functions.
 	 */
 	switch (exec_location)
 	{
 		case PROEXECLOCATION_ANY:
-			/* ok */
-			break;
-
 		case PROEXECLOCATION_COORDINATOR:
-			if (!proretset)
-				ereport(ERROR,
-						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-						 errmsg("EXECUTE ON COORDINATOR is only supported for set-returning functions")));
+			/* ok */
 			break;
 
 		case PROEXECLOCATION_INITPLAN:

--- a/src/test/regress/expected/function_extensions.out
+++ b/src/test/regress/expected/function_extensions.out
@@ -435,6 +435,26 @@ alter function test_srf() EXECUTE ON ANY;
 
 DROP FUNCTION test_srf();
 DROP ROLE srftestuser;
+-- Test that we allow non-srf qualified by 'EXECUTE ON COORDINATOR'.
+CREATE FUNCTION test_non_srf_exec_on_coordinator () RETURNS TEXT AS $$
+BEGIN
+  RETURN 'test_non_srf_exec_on_coordinator()';
+END;
+$$ LANGUAGE plpgsql EXECUTE ON COORDINATOR IMMUTABLE;
+SELECT test_non_srf_exec_on_coordinator();
+  test_non_srf_exec_on_coordinator  
+------------------------------------
+ test_non_srf_exec_on_coordinator()
+(1 row)
+
+DROP FUNCTION test_non_srf_exec_on_coordinator;
+-- Test that we don't allow non-srf qualified by 'EXECUTE ON ALL SEGMENTS'.
+CREATE FUNCTION test_non_srf_exec_on_segments () RETURNS TEXT AS $$
+BEGIN
+  RETURN 'test_non_srf_exec_on_segments()';
+END;
+$$ LANGUAGE plpgsql EXECUTE ON ALL SEGMENTS IMMUTABLE;
+ERROR:  EXECUTE ON ALL SEGMENTS is only supported for set-returning functions
 -- Test error propagation from segments
 CREATE TABLE uniq_test(id int primary key);
 CREATE OR REPLACE FUNCTION trigger_unique() RETURNS void AS $$

--- a/src/test/regress/expected/function_extensions_optimizer.out
+++ b/src/test/regress/expected/function_extensions_optimizer.out
@@ -439,6 +439,26 @@ alter function test_srf() EXECUTE ON ANY;
 
 DROP FUNCTION test_srf();
 DROP ROLE srftestuser;
+-- Test that we allow non-srf qualified by 'EXECUTE ON COORDINATOR'.
+CREATE FUNCTION test_non_srf_exec_on_coordinator () RETURNS TEXT AS $$
+BEGIN
+  RETURN 'test_non_srf_exec_on_coordinator()';
+END;
+$$ LANGUAGE plpgsql EXECUTE ON COORDINATOR IMMUTABLE;
+SELECT test_non_srf_exec_on_coordinator();
+  test_non_srf_exec_on_coordinator  
+------------------------------------
+ test_non_srf_exec_on_coordinator()
+(1 row)
+
+DROP FUNCTION test_non_srf_exec_on_coordinator;
+-- Test that we don't allow non-srf qualified by 'EXECUTE ON ALL SEGMENTS'.
+CREATE FUNCTION test_non_srf_exec_on_segments () RETURNS TEXT AS $$
+BEGIN
+  RETURN 'test_non_srf_exec_on_segments()';
+END;
+$$ LANGUAGE plpgsql EXECUTE ON ALL SEGMENTS IMMUTABLE;
+ERROR:  EXECUTE ON ALL SEGMENTS is only supported for set-returning functions
 -- Test error propagation from segments
 CREATE TABLE uniq_test(id int primary key);
 CREATE OR REPLACE FUNCTION trigger_unique() RETURNS void AS $$

--- a/src/test/regress/sql/function_extensions.sql
+++ b/src/test/regress/sql/function_extensions.sql
@@ -247,6 +247,24 @@ alter function test_srf() EXECUTE ON ANY;
 DROP FUNCTION test_srf();
 DROP ROLE srftestuser;
 
+-- Test that we allow non-srf qualified by 'EXECUTE ON COORDINATOR'.
+CREATE FUNCTION test_non_srf_exec_on_coordinator () RETURNS TEXT AS $$
+BEGIN
+  RETURN 'test_non_srf_exec_on_coordinator()';
+END;
+$$ LANGUAGE plpgsql EXECUTE ON COORDINATOR IMMUTABLE;
+
+SELECT test_non_srf_exec_on_coordinator();
+
+DROP FUNCTION test_non_srf_exec_on_coordinator;
+
+-- Test that we don't allow non-srf qualified by 'EXECUTE ON ALL SEGMENTS'.
+CREATE FUNCTION test_non_srf_exec_on_segments () RETURNS TEXT AS $$
+BEGIN
+  RETURN 'test_non_srf_exec_on_segments()';
+END;
+$$ LANGUAGE plpgsql EXECUTE ON ALL SEGMENTS IMMUTABLE;
+
 -- Test error propagation from segments
 CREATE TABLE uniq_test(id int primary key);
 CREATE OR REPLACE FUNCTION trigger_unique() RETURNS void AS $$


### PR DESCRIPTION
Currently, Greenplum doesn't allow executing non-srf (non-set-returning function) on segments or on coordinator. However, executing an non-srf on coordinator is possible, e.g.,

```
CREATE FUNCTION test_non_srf_exec_on_coordinator () RETURNS TEXT AS $$
BEGIN
  RETURN 'test_non_srf_exec_on_coordinator()';
END;
$$ LANGUAGE plpgsql EXECUTE ON COORDINATOR IMMUTABLE;
```

Without this pactch, Greenplum will emit an error message when creating the function:

```
ERROR:  0A000: EXECUTE ON COORDINATOR is only supported for set-returning functions
LOCATION:  validate_sql_exec_location, functioncmds.c:761
Time: 3.617 ms
```

With this patch, we can create the non-SRF and evaluate it.

```
=# SELECT test_non_srf_exec_on_coordinator();
  test_non_srf_exec_on_coordinator
------------------------------------
 test_non_srf_exec_on_coordinator()
(1 row)

```

After playing with it, I think there's no potential risk to remove the restriction so I raise this PR for discussing. I didn't install documentation toolchian on my laptop so I didn't generate the documentation, if this PR is correct, I will try to update the documentation.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [x] Document changes
- [x] Pass `make installcheck`
