### PR TITLE
Comment out assertion in CBucket::SplitAndMergeBuckets

### DIFF
--- a/src/backend/gporca/libgpos/src/string/CWStringDynamic.cpp
+++ b/src/backend/gporca/libgpos/src/string/CWStringDynamic.cpp
@@ -116,8 +116,6 @@ CWStringDynamic::AppendBuffer(const WCHAR *w_str)
 
 	clib::WcStrNCpy(m_w_str_buffer + m_length, w_str, length + 1);
 	m_length = new_length;
-
-	GPOS_ASSERT(IsValid());
 }
 
 

--- a/src/backend/gporca/libnaucrates/src/statistics/CBucket.cpp
+++ b/src/backend/gporca/libnaucrates/src/statistics/CBucket.cpp
@@ -1345,10 +1345,13 @@ CBucket::SplitAndMergeBuckets(
 	{
 		// there is only one bucket
 		GPOS_ASSERT(nullptr == upper_third);
+
+		/* FIXME: this assert currently triggers for some queries, see GPQP-74
 		GPOS_ASSERT_IMP(
 			is_union_all,
 			middle_third->GetFrequency() * total_rows <=
 				this_bucket_rows + bucket_other_rows + CStatistics::Epsilon);
+		*/
 	}
 
 	*result_rows = total_rows;


### PR DESCRIPTION
We may hit this assertion error in some cases, see GPQP-74. Also removed assertion in CWStringDynamic::AppendBuffer, the assertion is useless, and extremely time-consuming, remove it to get faster optimizer in debug mode.
