### PR TITLE
Fix bug that Orca may crash on null pointer in case of DPE with dynamic partial scan

### DIFF
--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalJoin.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalJoin.cpp
@@ -1250,7 +1250,10 @@ CPhysicalJoin::PppsRequiredCompute(CMemoryPool *mp, CExpressionHandle &exprhdl,
 				// outer side of the nested loop join
 				CPartKeysArray *pdrgppartkeys =
 					ppartinfo->PdrgppartkeysByScanId(part_idx_id);
-				GPOS_ASSERT(NULL != pdrgppartkeys);
+				if (NULL == pdrgppartkeys)
+				{
+					continue;
+				}
 				pdrgppartkeys->AddRef();
 
 				ppimResult->AddRequiredPartPropagation(
@@ -1286,7 +1289,10 @@ CPhysicalJoin::PppsRequiredCompute(CMemoryPool *mp, CExpressionHandle &exprhdl,
 				CPartKeysArray *pdrgppartkeys =
 					exprhdl.DerivePartitionInfo(1)->PdrgppartkeysByScanId(
 						part_idx_id);
-				GPOS_ASSERT(NULL != pdrgppartkeys);
+				if (NULL == pdrgppartkeys)
+				{
+					continue;
+				}
 				pdrgppartkeys->AddRef();
 
 				ppimResult->AddRequiredPartPropagation(

--- a/src/backend/gporca/libgpos/src/string/CWStringDynamic.cpp
+++ b/src/backend/gporca/libgpos/src/string/CWStringDynamic.cpp
@@ -116,8 +116,6 @@ CWStringDynamic::AppendBuffer(const WCHAR *w_str)
 
 	clib::WcStrNCpy(m_w_str_buffer + m_length, w_str, length + 1);
 	m_length = new_length;
-
-	GPOS_ASSERT(IsValid());
 }
 
 

--- a/src/backend/gporca/libnaucrates/src/statistics/CBucket.cpp
+++ b/src/backend/gporca/libnaucrates/src/statistics/CBucket.cpp
@@ -1342,10 +1342,13 @@ CBucket::SplitAndMergeBuckets(
 	{
 		// there is only one bucket
 		GPOS_ASSERT(NULL == upper_third);
+
+		/* FIXME: this assert currently triggers for some queries, see GPQP-74
 		GPOS_ASSERT_IMP(
 			is_union_all,
 			middle_third->GetFrequency() * total_rows <=
 				this_bucket_rows + bucket_other_rows + CStatistics::Epsilon);
+		*/
 	}
 
 	*result_rows = total_rows;


### PR DESCRIPTION
For the following case:
```go
T join PT1 on func(T.a) = PT1.a join PT2 on func(T.a) = PT2.a

HashJoin1
  +-- Dynamic Scan on PT1
  +-- Hash
       +-- HashJoin2
            +-- Seq Scan on T
            +-- Hash
                 +-- Dynamic Scan on PT2
```
When HashJoin2 computes the required partition propagation spec for inner child dynamic scan on PT2, it may not be able to find the partition keys for dynamic scan id 1 (pdrgppartkeys is NULL), the server crashes with null pointer error. This patch fixes that issue by adding a NULL check.

Comment out assertion in CBucket::SplitAndMergeBuckets, because we may hit this assertion error in some cases. Also removed assertion in CWStringDynamic::AppendBuffer, the assertion is useless, and extremely time-consuming, remove it to get faster optimizer in debug mode.

Ref: GPQP-80

I can't reproduce the issue using minidump and ICW, because it is so hard to generate the exact schema and stats, so I have to open this patch without test cases. :(


