### PR TITLE
fix candidates lookup complexity

### DIFF
--- a/gpMgmt/bin/analyzedb
+++ b/gpMgmt/bin/analyzedb
@@ -658,7 +658,7 @@ class AnalyzeDb(Operation):
                     valid_tables.append(tup)
             return valid_tables
 
-        return ret
+        return set(ret)
 
     def _get_dirty_data_tables(self, heap_tables_set, curr_ao_state, curr_last_op, prev_ao_state, prev_last_op):
         """
@@ -872,7 +872,7 @@ class AnalyzeDb(Operation):
         2. The leaf partitions (if range partitioned, especially by date) will be ordered in descending
            order of the partition key, so that newer partitions can be analyzed first.
         """
-        candidate_regclass_str = get_oid_str(candidates + root_partition_col_dict.keys())
+        candidate_regclass_str = get_oid_str(list(candidates) + root_partition_col_dict.keys())
         qresult = run_sql(self.conn, ORDER_CANDIDATES_BY_OID_SQL % candidate_regclass_str)
         ordered_candidates = []
         for schema_tbl in qresult:

--- a/gpMgmt/bin/analyzedb
+++ b/gpMgmt/bin/analyzedb
@@ -635,7 +635,7 @@ class AnalyzeDb(Operation):
             tup = (schema_tbl[0], schema_tbl[1])
             mid_level_partitions.append(tup)
 
-        ret = []
+        ret = set()
         for can in candidates:
             schema = can[0]
             table = can[1]
@@ -646,19 +646,19 @@ class AnalyzeDb(Operation):
             if can in mid_level_partitions:
                 logger.warning("Skipping mid-level partition %s.%s" % (schema, table))
             else:
-                ret.append(can)
+                ret.add(can)
 
         if self.config_file is not None or self.single_table is not None:
-            valid_tables = []
+            valid_tables = set()
             if len(ret) > 0:
                 oid_str = get_oid_str(ret)
                 qresult = run_sql(self.conn, GET_VALID_DATA_TABLES_SQL % oid_str)
                 for schema_tbl in qresult:
                     tup = (schema_tbl[0], schema_tbl[1])
-                    valid_tables.append(tup)
+                    valid_tables.add(tup)
             return valid_tables
 
-        return set(ret)
+        return ret
 
     def _get_dirty_data_tables(self, heap_tables_set, curr_ao_state, curr_last_op, prev_ao_state, prev_last_op):
         """


### PR DESCRIPTION
analyzedb keeps list of tables (partitions) to analyze as python list.
List lookups are slow, analyzedb may spend hours if `candidates` list has ~ 1M items.

Lookups in `set` are much faster.