### PR TITLE
[6X]Consider oversized rows for stawidth computation

### DIFF
--- a/src/backend/commands/analyzefuncs.c
+++ b/src/backend/commands/analyzefuncs.c
@@ -66,11 +66,11 @@ typedef struct
  * the actual sample rows.
  *
  * To make things even more complicated, each sample row contains one extra
- * column too: oversized_cols_bitmap. It's a bitmap indicating which attributes
- * on the sample row were omitted, because they were "too large". The omitted
- * attributes are returned as NULLs, and the bitmap can be used to distinguish
- * real NULLs from values that were too large to be included in the sample. The
- * bitmap is represented as a text column, with '0' or '1' for every column.
+ * column too: oversized_cols_length. It's an array indicating which attributes
+ * on the sample row were omitted and stores these omitted attributes' length,
+ * because they were "too large". The omitted attributes are returned as NULLs,
+ * and the array can be used to distinguish real NULLs from values that were
+ * too large to be included in the sample.
  *
  * So overall, this returns a result set like this:
  *
@@ -78,16 +78,16 @@ typedef struct
  *     -- special columns
  *     totalrows pg_catalog.float8,
  *     totaldeadrows pg_catalog.float8,
- *     oversized_cols_bitmap pg_catalog.text,
+ *     oversized_cols_length pg_catalog._float8,
  *     -- columns matching the table
  *     id int4,
  *     t text
  *  );
- *  totalrows | totaldeadrows | oversized_cols_bitmap | id  |    t    
+ *  totalrows | totaldeadrows | oversized_cols_length | id  |    t
  * -----------+---------------+-----------------------+-----+---------
  *            |               |                       |   1 | foo
  *            |               |                       |   2 | bar
- *            |               | 01                    |  50 | 
+ *            |               | {0,3004}              |  50 |
  *            |               |                       | 100 | foo 100
  *          2 |             0 |                       |     | 
  *          1 |             0 |                       |     | 
@@ -95,7 +95,7 @@ typedef struct
  * (7 rows)
  *
  * The first four rows form the actual sample. One of the columns contained
- * an oversized text datum. The function is marked as EXECUTE ON SEGMENTS in
+ * an oversized array datum. The function is marked as EXECUTE ON SEGMENTS in
  * the catalog so you get one summary row *for each segment*.
  */
 Datum
@@ -171,8 +171,8 @@ gp_acquire_sample_rows(PG_FUNCTION_ARGS)
 		/* extra column to indicate oversize cols */
 		TupleDescInitEntry(outDesc,
 						   3,
-						   "oversized_cols_bitmap",
-						   TEXTOID,
+						   "oversized_cols_length",
+						   FLOAT8ARRAYOID,
 						   -1,
 						   0);
 
@@ -253,17 +253,17 @@ gp_acquire_sample_rows(PG_FUNCTION_ARGS)
 		HeapTuple	relTuple = ctx->sample_rows[ctx->index];
 		int			attno;
 		int			outattno;
-		Bitmapset  *toolarge = NULL;
+		bool		has_toolarge = false;
 		Datum	   *relvalues = (Datum *) palloc(relDesc->natts * sizeof(Datum));
 		bool	   *relnulls = (bool *) palloc(relDesc->natts * sizeof(bool));
+		Datum      *oversized_cols_length = (Datum *) palloc0(relDesc->natts * sizeof(Datum));
 
 		heap_deform_tuple(relTuple, relDesc, relvalues, relnulls);
 
 		outattno = NUM_SAMPLE_FIXED_COLS + 1;
 		for (attno = 1; attno <= relDesc->natts; attno++)
 		{
-			Form_pg_attribute relatt = (Form_pg_attribute) relDesc->attrs[attno - 1];
-			bool		is_toolarge = false;
+			Form_pg_attribute relatt = TupleDescAttr(relDesc, attno - 1);
 			Datum		relvalue;
 			bool		relnull;
 
@@ -279,8 +279,8 @@ gp_acquire_sample_rows(PG_FUNCTION_ARGS)
 
 				if (toasted_size > WIDTH_THRESHOLD)
 				{
-					toolarge = bms_add_member(toolarge, outattno - NUM_SAMPLE_FIXED_COLS);
-					is_toolarge = true;
+					oversized_cols_length[attno - 1] = Float8GetDatum((double)toasted_size);
+					has_toolarge = true;
 					relvalue = (Datum) 0;
 					relnull = true;
 				}
@@ -294,18 +294,10 @@ gp_acquire_sample_rows(PG_FUNCTION_ARGS)
 		 * If any of the attributes were oversized, construct the text datum
 		 * to represent the bitmap.
 		 */
-		if (toolarge)
+		if (has_toolarge)
 		{
-			char	   *toolarge_str;
-			int			i;
-			int			live_natts = outDesc->natts - NUM_SAMPLE_FIXED_COLS;
-
-			toolarge_str = palloc((live_natts + 1) * sizeof(char));
-			for (i = 0; i < live_natts; i++)
-				toolarge_str[i] = bms_is_member(i + 1, toolarge) ? '1' : '0';
-			toolarge_str[i] = '\0';
-
-			outvalues[2] = CStringGetTextDatum(toolarge_str);
+			outvalues[2] = PointerGetDatum(construct_array(oversized_cols_length, relDesc->natts,
+														FLOAT8OID, 8, true, 'd'));
 			outnulls[2] = false;
 		}
 		else

--- a/src/backend/tsearch/ts_typanalyze.c
+++ b/src/backend/tsearch/ts_typanalyze.c
@@ -302,7 +302,7 @@ compute_tsvector_stats(VacAttrStats *stats,
 		stats->stats_valid = true;
 		/* Do the simple null-frac and average width stats */
 		stats->stanullfrac = (double) null_cnt / (double) samplerows;
-		stats->stawidth = total_width / (double) nonnull_cnt;
+		stats->stawidth = (total_width + stats->totalwidelength) / (double) (nonnull_cnt + stats->widerow_num);
 
 		/* Assume it's a unique column (see notes above) */
 		stats->stadistinct = -1.0 * (1.0 - stats->stanullfrac);

--- a/src/backend/utils/adt/rangetypes_typanalyze.c
+++ b/src/backend/utils/adt/rangetypes_typanalyze.c
@@ -202,7 +202,7 @@ compute_range_stats(VacAttrStats *stats, AnalyzeAttrFetchFunc fetchfunc,
 		stats->stats_valid = true;
 		/* Do the simple null-frac and width stats */
 		stats->stanullfrac = (double) null_cnt / (double) samplerows;
-		stats->stawidth = total_width / (double) non_null_cnt;
+		stats->stawidth = (total_width + stats->totalwidelength) / (double) (non_null_cnt + stats->widerow_num);
 
 		/* Estimate that non-null values are unique */
 		stats->stadistinct = -1.0 * (1.0 - stats->stanullfrac);

--- a/src/include/commands/vacuum.h
+++ b/src/include/commands/vacuum.h
@@ -94,6 +94,10 @@ typedef struct VacAttrStats
 	int			minrows;		/* Minimum # of rows wanted for stats */
 	void	   *extra_data;		/* for extra type-specific data */
 
+	/* These fields are used to compute stawidth during the compute_stats routine. */
+	double                  totalwidelength;/* total length of toowide row */
+	int                     widerow_num;    /* # of toowide row */
+
 	/*
 	 * These fields are to be filled in by the compute_stats routine. (They
 	 * are initialized to zero when the struct is created.)

--- a/src/test/regress/expected/analyze.out
+++ b/src/test/regress/expected/analyze.out
@@ -817,7 +817,7 @@ ANALYZE foo_stats;
 SELECT schemaname, tablename, attname, null_frac, avg_width, n_distinct, most_common_vals, most_common_freqs, histogram_bounds FROM pg_stats WHERE tablename='foo_stats' ORDER BY attname;
  schemaname | tablename | attname | null_frac | avg_width | n_distinct |          most_common_vals           | most_common_freqs | histogram_bounds 
 ------------+-----------+---------+-----------+-----------+------------+-------------------------------------+-------------------+------------------
- public     | foo_stats | a       |         0 |         4 |      -0.25 | {aaa}                               | {1}               | 
+ public     | foo_stats | a       |         0 |      1504 |      -0.25 | {aaa}                               | {1}               | 
  public     | foo_stats | b       |         0 |         6 |       -0.5 | {"\\x6262626262","\\x626262626232"} | {0.5,0.5}         | 
  public     | foo_stats | c       |         0 |         5 |       -0.5 | {cccc,cccc2}                        | {0.5,0.5}         | 
  public     | foo_stats | d       |         0 |         4 |       -0.5 | {2,3}                               | {0.5,0.5}         | 
@@ -840,7 +840,7 @@ ANALYZE foo_stats;
 SELECT schemaname, tablename, attname, null_frac, avg_width, n_distinct, most_common_vals, most_common_freqs, histogram_bounds FROM pg_stats WHERE tablename='foo_stats' ORDER BY attname;
  schemaname | tablename | attname | null_frac | avg_width | n_distinct |  most_common_vals   | most_common_freqs | histogram_bounds 
 ------------+-----------+---------+-----------+-----------+------------+---------------------+-------------------+------------------
- public     | foo_stats | a       |         0 |      1024 |          0 |                     |                   | 
+ public     | foo_stats | a       |         0 |      1156 |          0 |                     |                   | 
  public     | foo_stats | b       |         0 |         7 |       -0.5 | {"\\x626262626232"} | {1}               | 
  public     | foo_stats | c       |         0 |         6 |       -0.5 | {cccc2}             | {1}               | 
  public     | foo_stats | d       |         0 |         4 |       -0.5 | {3}                 | {1}               | 
@@ -938,7 +938,7 @@ select attname, null_frac, avg_width, n_distinct from pg_stats where tablename =
  attname | null_frac | avg_width | n_distinct 
 ---------+-----------+-----------+------------
  a       |         0 |         2 |         -1
- c       |         0 |      1024 |          0
+ c       |         0 |      5004 |          0
  d       |         0 |         5 |         -1
 (3 rows)
 

--- a/src/test/regress/expected/incremental_analyze.out
+++ b/src/test/regress/expected/incremental_analyze.out
@@ -1532,9 +1532,9 @@ ANALYZE foo;
 SELECT * FROM pg_stats WHERE tablename like 'foo%' and attname = 'c' ORDER BY attname,tablename;
  schemaname |  tablename  | attname | inherited | null_frac | avg_width | n_distinct | most_common_vals | most_common_freqs | histogram_bounds | correlation | most_common_elems | most_common_elem_freqs | elem_count_histogram 
 ------------+-------------+---------+-----------+-----------+-----------+------------+------------------+-------------------+------------------+-------------+-------------------+------------------------+----------------------
- public     | foo         | c       | t         |         0 |      1024 |          0 |                  |                   |                  |             |                   |                        | 
- public     | foo_1_prt_1 | c       | f         |         0 |      1024 |          0 |                  |                   |                  |             |                   |                        | 
- public     | foo_1_prt_2 | c       | f         |         0 |      1024 |          0 |                  |                   |                  |             |                   |                        | 
+ public     | foo         | c       | t         |         0 |      4591 |          0 |                  |                   |                  |             |                   |                        | 
+ public     | foo_1_prt_1 | c       | f         |         0 |      4591 |          0 |                  |                   |                  |             |                   |                        | 
+ public     | foo_1_prt_2 | c       | f         |         0 |      4591 |          0 |                  |                   |                  |             |                   |                        | 
 (3 rows)
 
 -- Test ANALYZE full scan HLL


### PR DESCRIPTION
gp_bloat_diag use the given statistics(including stawidth) in pg_statistic to compute the expected number of pages for the given table.

To avoid consuming too much memory during analysis and/or too much space in the resulting pg_statistic rows, ANALYZE ignores varlena datums that are wider than WIDTH_THRESHOLD. So the average width of column values is far smaller than the real average width, especially for varlena datums which are larger than WIDTH_THRESHOLD but stored uncompressed.

The wrong stawidth value causes gp_bloat_diag view shows tables have bloat and require a "VACUUM" or "VACUUM FULL", although these tables don't have bloat in fact.

Include the total length and number of oversized rows when computing the stawidth.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
