### PR TITLE
Fix incorrect index->reltuples after VACUUM

### DIFF
--- a/src/backend/access/nbtree/nbtree.c
+++ b/src/backend/access/nbtree/nbtree.c
@@ -890,6 +890,10 @@ _bt_vacuum_needs_cleanup(IndexVacuumInfo *info)
 	BTMetaPageData *metad;
 	bool		result = false;
 
+	/* Return true directly on QE for stats collection from QD. */
+	if (gp_vacuum_needs_update_stats())
+		return true;
+
 	metabuf = _bt_getbuf(info->index, BTREE_METAPAGE, BT_READ);
 	metapg = BufferGetPage(metabuf);
 	metad = BTPageGetMeta(metapg);

--- a/src/backend/cdb/dispatcher/cdbdispatchresult.c
+++ b/src/backend/cdb/dispatcher/cdbdispatchresult.c
@@ -821,6 +821,8 @@ cdbdisp_returnResults(CdbDispatchResults *primaryResults, CdbPgResults *cdb_pgre
 
 	/* tell the caller how many sets we're returning. */
 	cdb_pgresults->numResults = nresults;
+	/* set the number of dispatched QE */
+	cdb_pgresults->numDispatches = primaryResults->resultCount;
 }
 
 /*

--- a/src/backend/commands/vacuum.c
+++ b/src/backend/commands/vacuum.c
@@ -74,7 +74,8 @@
 
 typedef struct VacuumStatsContext
 {
-	List	   *updated_stats;
+	List		*updated_stats;
+	int			nsegs;
 } VacuumStatsContext;
 
 /*
@@ -107,7 +108,7 @@ static void dispatchVacuum(VacuumParams *params, Oid relid,
 static List *vacuum_params_to_options_list(VacuumParams *params);
 static void vacuum_combine_stats(VacuumStatsContext *stats_context,
 								 CdbPgResults *cdb_pgresults);
-static void vac_update_relstats_from_list(List *updated_stats);
+static void vac_update_relstats_from_list(VacuumStatsContext *stats_context);
 
 /*
  * Primary entry point for manual VACUUM and ANALYZE commands
@@ -2446,7 +2447,7 @@ vacuum_rel(Oid relid, RangeVar *relation, VacuumParams *params,
 
 		stats_context.updated_stats = NIL;
 		dispatchVacuum(params, relid, &stats_context);
-		vac_update_relstats_from_list(stats_context.updated_stats);
+		vac_update_relstats_from_list(&stats_context);
 
 		/* Also update pg_stat_last_operation */
 		if (IsAutoVacuumWorkerProcess())
@@ -2763,6 +2764,8 @@ vacuum_combine_stats(VacuumStatsContext *stats_context, CdbPgResults *cdb_pgresu
 	if (cdb_pgresults == NULL || cdb_pgresults->numResults <= 0)
 		return;
 
+	stats_context->nsegs = cdb_pgresults->numDispatches;
+
 	/*
 	 * Process the dispatch results from the primary. Note that the QE
 	 * processes also send back the new stats info, such as stats on
@@ -2775,9 +2778,7 @@ vacuum_combine_stats(VacuumStatsContext *stats_context, CdbPgResults *cdb_pgresu
 	 *
 	 */
 	for(result_no = 0; result_no < cdb_pgresults->numResults; result_no++)
-	{
-		VPgClassStats *pgclass_stats = NULL;
-		ListCell *lc = NULL;
+	{		
 		struct pg_result *pgresult = cdb_pgresults->pg_results[result_no];
 
 		if (pgresult->extras == NULL || pgresult->extraType != PGExtraTypeVacuumStats)
@@ -2789,30 +2790,38 @@ vacuum_combine_stats(VacuumStatsContext *stats_context, CdbPgResults *cdb_pgresu
 		 * Process the stats for pg_class. We simply compute the maximum
 		 * number of rel_tuples and rel_pages.
 		 */
-		pgclass_stats = (VPgClassStats *) pgresult->extras;
+		VPgClassStatsCombo *pgclass_stats_combo = (VPgClassStatsCombo *) pgresult->extras;
+		ListCell *lc = NULL;
+
 		foreach (lc, stats_context->updated_stats)
 		{
-			VPgClassStats *tmp_stats = (VPgClassStats *) lfirst(lc);
+			VPgClassStatsCombo *tmp_stats_combo = (VPgClassStatsCombo *) lfirst(lc);
 
-			if (tmp_stats->relid == pgclass_stats->relid)
+			if (tmp_stats_combo->relid == pgclass_stats_combo->relid)
 			{
-				tmp_stats->rel_pages += pgclass_stats->rel_pages;
-				tmp_stats->rel_tuples += pgclass_stats->rel_tuples;
-				tmp_stats->relallvisible += pgclass_stats->relallvisible;
+				tmp_stats_combo->rel_pages += pgclass_stats_combo->rel_pages;
+				tmp_stats_combo->rel_tuples += pgclass_stats_combo->rel_tuples;
+				tmp_stats_combo->relallvisible += pgclass_stats_combo->relallvisible;
+				/* 
+				 * Accumulate the number of QEs, assuming sending only once
+				 * per QE for each relid in the VACUUM scenario.
+				 */
+				tmp_stats_combo->count++;
 				break;
 			}
 		}
 
-		if (lc == NULL)
+		if (lc == NULL) /* get the first stats result of the current relid */
 		{
 			Assert(pgresult->extraslen == sizeof(VPgClassStats));
 
 			old_context = MemoryContextSwitchTo(vac_context);
-			pgclass_stats = palloc(sizeof(VPgClassStats));
-			memcpy(pgclass_stats, pgresult->extras, pgresult->extraslen);
+			pgclass_stats_combo = palloc(sizeof(VPgClassStatsCombo));
+			memcpy(pgclass_stats_combo, pgresult->extras, pgresult->extraslen);
+			pgclass_stats_combo->count = 1;
 
 			stats_context->updated_stats =
-				lappend(stats_context->updated_stats, pgclass_stats);
+				lappend(stats_context->updated_stats, pgclass_stats_combo);
 			MemoryContextSwitchTo(old_context);
 		}
 	}
@@ -2822,8 +2831,9 @@ vacuum_combine_stats(VacuumStatsContext *stats_context, CdbPgResults *cdb_pgresu
  * Update relpages/reltuples of all the relations in the list.
  */
 static void
-vac_update_relstats_from_list(List *updated_stats)
+vac_update_relstats_from_list(VacuumStatsContext *stats_context)
 {
+	List *updated_stats = stats_context->updated_stats;
 	ListCell *lc;
 
 	/*
@@ -2834,30 +2844,70 @@ vac_update_relstats_from_list(List *updated_stats)
 
 	foreach (lc, updated_stats)
 	{
-		VPgClassStats *stats = (VPgClassStats *) lfirst(lc);
+		VPgClassStatsCombo *stats = (VPgClassStatsCombo *) lfirst(lc);
 		Relation	rel;
 
 		rel = relation_open(stats->relid, AccessShareLock);
 
 		if (GpPolicyIsReplicated(rel->rd_cdbpolicy))
 		{
+			Assert(stats->count == rel->rd_cdbpolicy->numsegments);
+
 			stats->rel_pages = stats->rel_pages / rel->rd_cdbpolicy->numsegments;
 			stats->rel_tuples = stats->rel_tuples / rel->rd_cdbpolicy->numsegments;
 			stats->relallvisible = stats->relallvisible / rel->rd_cdbpolicy->numsegments;
 		}
 
 		/*
-		 * Pass 'false' for isvacuum, so that the stats are
-		 * actually updated.
+		 * Update QD stats only when receiving all dispatched QEs' stats, to
+		 * avoid being overwritten by a partial accumulated value (i.e., index->reltuples)
+		 * in case when not receiving all QEs' stats.
 		 */
-		vac_update_relstats(rel,
-							stats->rel_pages, stats->rel_tuples,
-							stats->relallvisible,
-							rel->rd_rel->relhasindex,
-							InvalidTransactionId,
-							InvalidMultiXactId,
-							false,
-							false /* isvacuum */);
+		if (stats_context->nsegs > 0 && stats->count == stats_context->nsegs)
+		{
+			/*
+			 * Pass 'false' for isvacuum, so that the stats are
+			 * actually updated.
+			 */
+			vac_update_relstats(rel,
+								stats->rel_pages, stats->rel_tuples,
+								stats->relallvisible,
+								rel->rd_rel->relhasindex,
+								InvalidTransactionId,
+								InvalidMultiXactId,
+								false,
+								false /* isvacuum */);
+		}
+		else
+		{
+			/*
+			 * We do have chance to enter this branch in the case when in compact phase.
+			 * For example, in compact phase, some QEs may need to drop dead segfiles,
+			 * while others may not. Only the QEs which dropping dead segfiles could go to
+			 * vacuum indexes path then update and send the statistics to QD, QD just
+			 * collected part of QEs' stats hence should not be as the final result to
+			 * overwrite QD's stats. 
+			 * 
+			 * One may think why not having the stats update only happens in the final
+			 * phase (POST_CLEANUP_PHASE), yes that's an alternative to get a final stats
+			 * accurately for QD. 
+			 * 
+			 * Given the AO/CO VACUUM is a multi-phases process which may have an interval
+			 * between each phase. In real circumstance, concurrent VACUUM is mostly a heavy
+			 * job and this interval could get longer than normal cases, hence it seems
+			 * better to collect and update QD's stats timely. So current strategy is, QD always 
+			 * collect QE's stats across phases, once we collected the expected number (means
+			 * same as dispatched QE number) of QE's stats, we update QD's stats subsequently,
+			 * instead of updating at the final phase.
+			 * 
+			 * Set the logging level to LOG as skipping sending stats here is not considered as
+			 * a real issue, displaying it in log may be helpful to hint.
+			 */
+			elog(LOG, "Vacuum update stats oid=%u pages=%d tuples=%f was skipped because "
+				 "collected segment number %d didn't match the expected %d.", stats->relid,
+				 stats->rel_pages, stats->rel_tuples, stats->count, stats_context->nsegs);
+		}
+
 		relation_close(rel, AccessShareLock);
 	}
 }
@@ -2922,4 +2972,19 @@ vacuumStatement_IsTemporary(Relation onerel)
 	if (!bTemp)
 		bTemp = isAnyTempNamespace(RelationGetNamespace(onerel));
 	return bTemp;
+}
+
+/*
+ * GPDB: Check whether needs to update or send stats from QE to QD.
+ * This is GPDB specific check in vacuum-index scenario for collecting
+ * QEs' stats (such as index->relpages and index->reltuples) on QD.
+ * GPDB needs accumulating all QEs' stats for updating corresponding 
+ * statistics into QD's pg_class correctly. So if current instance is
+ * acting as QE, it should scan and send its current stats to QD instead
+ * of skipping them for cost saving.
+ */
+bool
+gp_vacuum_needs_update_stats(void)
+{
+	return (Gp_role == GP_ROLE_EXECUTE);
 }

--- a/src/include/cdb/cdbdispatchresult.h
+++ b/src/include/cdb/cdbdispatchresult.h
@@ -29,6 +29,7 @@ typedef struct CdbPgResults
 {
 	struct pg_result **pg_results;
 	int numResults;
+	int numDispatches; /* the number of dispatched QE, from CdbDispatchResults.resultCount */
 }CdbPgResults;
 
 /*

--- a/src/include/commands/vacuum.h
+++ b/src/include/commands/vacuum.h
@@ -206,6 +206,16 @@ typedef struct VPgClassStats
 	BlockNumber relallvisible;
 } VPgClassStats;
 
+typedef struct VPgClassStatsCombo
+{
+	Oid			relid;
+	BlockNumber rel_pages;
+	double		rel_tuples;
+	BlockNumber relallvisible;
+
+	int			count; /* expect to equal to the number of dispatched segments */
+} VPgClassStatsCombo;
+
 /*
  * Parameters customizing behavior of VACUUM and ANALYZE.
  *
@@ -318,7 +328,7 @@ extern void analyze_rel(Oid relid, RangeVar *relation,
 /* in commands/vacuumlazy.c */
 extern void lazy_vacuum_rel_heap(Relation onerel,
 							VacuumParams *params, BufferAccessStrategy bstrategy);
-extern void scan_index(Relation indrel, double num_tuples, int elevel, BufferAccessStrategy bstrategy);
+extern void scan_index(Relation indrel, Relation aorel, int elevel, BufferAccessStrategy bstrategy);
 
 /* in commands/vacuum_ao.c */
 extern void ao_vacuum_rel(Relation rel, VacuumParams *params, BufferAccessStrategy bstrategy);
@@ -340,5 +350,7 @@ extern int acquire_inherited_sample_rows(Relation onerel, int elevel,
 /* in commands/analyzefuncs.c */
 extern Datum gp_acquire_sample_rows(PG_FUNCTION_ARGS);
 extern Oid gp_acquire_sample_rows_col_type(Oid typid);
+
+extern bool gp_vacuum_needs_update_stats(void);
 
 #endif							/* VACUUM_H */

--- a/src/include/commands/vacuum.h
+++ b/src/include/commands/vacuum.h
@@ -318,7 +318,7 @@ extern void analyze_rel(Oid relid, RangeVar *relation,
 /* in commands/vacuumlazy.c */
 extern void lazy_vacuum_rel_heap(Relation onerel,
 							VacuumParams *params, BufferAccessStrategy bstrategy);
-extern void scan_index(Relation indrel, int elevel, BufferAccessStrategy bstrategy);
+extern void scan_index(Relation indrel, double num_tuples, int elevel, BufferAccessStrategy bstrategy);
 
 /* in commands/vacuum_ao.c */
 extern void ao_vacuum_rel(Relation rel, VacuumParams *params, BufferAccessStrategy bstrategy);

--- a/src/test/regress/expected/btree_index.out
+++ b/src/test/regress/expected/btree_index.out
@@ -267,3 +267,112 @@ VACUUM delete_test_table;
 -- The vacuum above should've turned the leaf page into a fast root. We just
 -- need to insert some rows to cause the fast root page to split.
 INSERT INTO delete_test_table SELECT i, 1, 2, 3 FROM generate_series(1,1000) i;
+--
+-- GPDB: Test correctness of B-tree stats in consecutively VACUUM.
+--
+CREATE TABLE btree_stats_tbl(col_int int, col_text text, col_numeric numeric, col_unq int) DISTRIBUTED BY (col_int);
+CREATE INDEX btree_stats_idx ON btree_stats_tbl(col_int);
+INSERT INTO btree_stats_tbl VALUES (1, 'aa', 1001, 101), (2, 'bb', 1002, 102);
+SELECT reltuples FROM pg_class WHERE relname='btree_stats_tbl';
+ reltuples 
+-----------
+         0
+(1 row)
+
+-- inspect the state of the stats on segments
+SELECT gp_segment_id, relname, reltuples FROM gp_dist_random('pg_class') WHERE relname = 'btree_stats_idx';
+ gp_segment_id |     relname     | reltuples 
+---------------+-----------------+-----------
+             0 | btree_stats_idx |         0
+             1 | btree_stats_idx |         0
+             2 | btree_stats_idx |         0
+(3 rows)
+
+SELECT reltuples FROM pg_class WHERE relname='btree_stats_idx';
+ reltuples 
+-----------
+         0
+(1 row)
+
+-- 1st VACUUM, expect reltuples = 2
+vacuum btree_stats_tbl;
+SELECT reltuples FROM pg_class WHERE relname='btree_stats_tbl';
+ reltuples 
+-----------
+         2
+(1 row)
+
+-- inspect the state of the stats on segments
+SELECT gp_segment_id, relname, reltuples FROM gp_dist_random('pg_class') WHERE relname = 'btree_stats_idx';
+ gp_segment_id |     relname     | reltuples 
+---------------+-----------------+-----------
+             0 | btree_stats_idx |         1
+             1 | btree_stats_idx |         1
+             2 | btree_stats_idx |         0
+(3 rows)
+
+SELECT reltuples FROM pg_class WHERE relname='btree_stats_idx';
+ reltuples 
+-----------
+         2
+(1 row)
+
+-- 2nd VACUUM, expect reltuples = 2
+vacuum btree_stats_tbl;
+SELECT reltuples FROM pg_class WHERE relname='btree_stats_tbl';
+ reltuples 
+-----------
+         2
+(1 row)
+
+-- inspect the state of the stats on segments
+SELECT gp_segment_id, relname, reltuples FROM gp_dist_random('pg_class') WHERE relname = 'btree_stats_idx';
+ gp_segment_id |     relname     | reltuples 
+---------------+-----------------+-----------
+             0 | btree_stats_idx |         1
+             1 | btree_stats_idx |         1
+             2 | btree_stats_idx |         0
+(3 rows)
+
+SELECT reltuples FROM pg_class WHERE relname='btree_stats_idx';
+ reltuples 
+-----------
+         2
+(1 row)
+
+-- Prior to this fix, the case would be failed here. Given the
+-- scenario of updating stats during VACUUM:
+-- 1) coordinator vacuums and updates stats of its own;
+-- 2) then coordinator dispatches vacuum to segments;
+-- 3) coordinator combines stats received from segments to overwrite the stats of its own.
+-- Because upstream introduced a feature which could skip full index scan uring cleanup
+-- of B-tree indexes when possible (refer to:
+-- https://github.com/postgres/postgres/commit/857f9c36cda520030381bd8c2af20adf0ce0e1d4),
+-- there was a case in QD-QEs distributed deployment that some QEs could skip full index scan and
+-- stop updating statistics, result in QD being unable to collect all QEs' stats thus overwrote
+-- a paritial accumulated value to index->reltuples. More interesting, it usually happened starting
+-- from the 3rd time of consecutively VACUUM after fresh inserts due to above skipping index scan
+-- criteria.
+-- 3rd VACUUM, expect reltuples = 2
+vacuum btree_stats_tbl;
+SELECT reltuples FROM pg_class WHERE relname='btree_stats_tbl';
+ reltuples 
+-----------
+         2
+(1 row)
+
+-- inspect the state of the stats on segments
+SELECT gp_segment_id, relname, reltuples FROM gp_dist_random('pg_class') WHERE relname = 'btree_stats_idx';
+ gp_segment_id |     relname     | reltuples 
+---------------+-----------------+-----------
+             0 | btree_stats_idx |         1
+             1 | btree_stats_idx |         1
+             2 | btree_stats_idx |         0
+(3 rows)
+
+SELECT reltuples FROM pg_class WHERE relname='btree_stats_idx';
+ reltuples 
+-----------
+         2
+(1 row)
+

--- a/src/test/regress/expected/uao_compaction/index_stats.out
+++ b/src/test/regress/expected/uao_compaction/index_stats.out
@@ -35,3 +35,22 @@ SELECT relname, reltuples FROM pg_class WHERE relname = 'mytab_int_idx1';
  mytab_int_idx1 |         2
 (1 row)
 
+-- A test of index stat for access methods that rely on table tuple count (bitmap, gin)
+truncate mytab;
+create index mytab_int_idx2 on mytab using bitmap(col_int);
+insert into mytab values(1,'aa',1001,101),(2,'bb',1002,102);
+SELECT relname, reltuples FROM pg_class WHERE relname = 'mytab_int_idx2';
+    relname     | reltuples 
+----------------+-----------
+ mytab_int_idx2 |         2
+(1 row)
+
+-- first vacuum collect table stat on segments
+vacuum mytab;
+-- second vacuum update index stat with table stat
+vacuum mytab;
+SELECT relname, reltuples FROM pg_class WHERE relname = 'mytab_int_idx2';
+    relname     | reltuples 
+----------------+-----------
+ mytab_int_idx2 |         2
+(1 row)

--- a/src/test/regress/expected/uao_compaction/index_stats.out
+++ b/src/test/regress/expected/uao_compaction/index_stats.out
@@ -35,22 +35,164 @@ SELECT relname, reltuples FROM pg_class WHERE relname = 'mytab_int_idx1';
  mytab_int_idx1 |         2
 (1 row)
 
--- A test of index stat for access methods that rely on table tuple count (bitmap, gin)
-truncate mytab;
-create index mytab_int_idx2 on mytab using bitmap(col_int);
-insert into mytab values(1,'aa',1001,101),(2,'bb',1002,102);
-SELECT relname, reltuples FROM pg_class WHERE relname = 'mytab_int_idx2';
-    relname     | reltuples 
-----------------+-----------
- mytab_int_idx2 |         2
+-- Test to ensure that reltuples is updated for an index after lazy vacuum.
+-- This is vital as most index AMs that depend on this tuple count (eg btree, bitmap etc)
+-- which is passed up from the table AM during lazy vacuum.
+-- create a fresh table for the test
+CREATE TABLE mytab2(
+          col_int int,
+          col_text text,
+          col_numeric numeric,
+          col_unq int
+          ) with(appendonly=true) DISTRIBUTED BY (col_int);
+create index mytab2_int_idx1 on mytab2 using bitmap(col_int);
+insert into mytab2 values(1,'aa',1001,101),(2,'bb',1002,102);
+SELECT relname, reltuples FROM pg_class WHERE relname = 'mytab2_int_idx1';
+     relname     | reltuples 
+-----------------+-----------
+ mytab2_int_idx1 |         0
 (1 row)
 
 -- first vacuum collect table stat on segments
-vacuum mytab;
+vacuum mytab2;
+-- inspect the state of the stats on segments
+SELECT gp_segment_id, relname, reltuples FROM gp_dist_random('pg_class') WHERE relname = 'mytab2_int_idx1';
+ gp_segment_id |     relname     | reltuples 
+---------------+-----------------+-----------
+             0 | mytab2_int_idx1 |         0
+             1 | mytab2_int_idx1 |         0
+             2 | mytab2_int_idx1 |         0
+(3 rows)
+
 -- second vacuum update index stat with table stat
-vacuum mytab;
-SELECT relname, reltuples FROM pg_class WHERE relname = 'mytab_int_idx2';
-    relname     | reltuples 
-----------------+-----------
- mytab_int_idx2 |         2
+vacuum mytab2;
+-- inspect the state of the stats on segments
+SELECT gp_segment_id, relname, reltuples FROM gp_dist_random('pg_class') WHERE relname = 'mytab2_int_idx1';
+ gp_segment_id |     relname     | reltuples 
+---------------+-----------------+-----------
+             0 | mytab2_int_idx1 |         1
+             1 | mytab2_int_idx1 |         1
+             2 | mytab2_int_idx1 |         0
+(3 rows)
+
+SELECT relname, reltuples FROM pg_class WHERE relname = 'mytab2_int_idx1';
+     relname     | reltuples 
+-----------------+-----------
+ mytab2_int_idx1 |         2
 (1 row)
+
+-- Test correctness of index->reltuples in consecutively VACUUM.
+CREATE TABLE mytab3(
+          col_int int,
+          col_text text,
+          col_numeric numeric,
+          col_unq int
+          ) with(appendonly=true) DISTRIBUTED BY (col_int);
+create index mytab3_int_idx1 on mytab3(col_int);
+insert into mytab3 values(1,'aa',1001,101),(2,'bb',1002,102);
+select reltuples from pg_class where relname='mytab3';
+ reltuples 
+-----------
+         0
+(1 row)
+
+-- inspect the state of the stats on segments
+select gp_segment_id, relname, reltuples from gp_dist_random('pg_class') where relname = 'mytab3_int_idx1';
+ gp_segment_id |     relname     | reltuples 
+---------------+-----------------+-----------
+             0 | mytab3_int_idx1 |         0
+             1 | mytab3_int_idx1 |         0
+             2 | mytab3_int_idx1 |         0
+(3 rows)
+
+select reltuples from pg_class where relname='mytab3_int_idx1';
+ reltuples 
+-----------
+         0
+(1 row)
+
+-- 1st VACUUM, expect reltuples = 2
+vacuum mytab3;
+select reltuples from pg_class where relname='mytab3';
+ reltuples 
+-----------
+         2
+(1 row)
+
+-- inspect the state of the stats on segments
+select gp_segment_id, relname, reltuples from gp_dist_random('pg_class') where relname = 'mytab3_int_idx1';
+ gp_segment_id |     relname     | reltuples 
+---------------+-----------------+-----------
+             0 | mytab3_int_idx1 |         1
+             1 | mytab3_int_idx1 |         1
+             2 | mytab3_int_idx1 |         0
+(3 rows)
+
+select reltuples from pg_class where relname='mytab3_int_idx1';
+ reltuples 
+-----------
+         2
+(1 row)
+
+-- 2nd VACUUM, expect reltuples = 2
+vacuum mytab3;
+select reltuples from pg_class where relname='mytab3';
+ reltuples 
+-----------
+         2
+(1 row)
+
+-- inspect the state of the stats on segments
+select gp_segment_id, relname, reltuples from gp_dist_random('pg_class') where relname = 'mytab3_int_idx1';
+ gp_segment_id |     relname     | reltuples 
+---------------+-----------------+-----------
+             0 | mytab3_int_idx1 |         1
+             1 | mytab3_int_idx1 |         1
+             2 | mytab3_int_idx1 |         0
+(3 rows)
+
+select reltuples from pg_class where relname='mytab3_int_idx1';
+ reltuples 
+-----------
+         2
+(1 row)
+
+-- Prior to this fix, the case would be failed here. Given the
+-- scenario of updating stats during VACUUM:
+-- 1) coordinator vacuums and updates stats of its own;
+-- 2) then coordinator dispatches vacuum to segments;
+-- 3) coordinator combines stats received from segments to overwrite the stats of its own.
+-- Because upstream introduced a feature which could skip full index scan uring cleanup
+-- of B-tree indexes when possible (refer to:
+-- https://github.com/postgres/postgres/commit/857f9c36cda520030381bd8c2af20adf0ce0e1d4),
+-- there was a case in QD-QEs distributed deployment that some QEs could skip full index scan and
+-- stop updating statistics, result in QD being unable to collect all QEs' stats thus overwrote
+-- a paritial accumulated value to index->reltuples. More interesting, it usually happened starting
+-- from the 3rd time of consecutively VACUUM after fresh inserts due to above skipping index scan
+-- criteria.
+-- 3rd VACUUM, expect reltuples = 2
+vacuum mytab3;
+select reltuples from pg_class where relname='mytab3';
+ reltuples 
+-----------
+         2
+(1 row)
+
+-- inspect the state of the stats on segments
+select gp_segment_id, relname, reltuples from gp_dist_random('pg_class') where relname = 'mytab3_int_idx1';
+ gp_segment_id |     relname     | reltuples 
+---------------+-----------------+-----------
+             0 | mytab3_int_idx1 |         1
+             1 | mytab3_int_idx1 |         1
+             2 | mytab3_int_idx1 |         0
+(3 rows)
+
+select reltuples from pg_class where relname='mytab3_int_idx1';
+ reltuples 
+-----------
+         2
+(1 row)
+
+drop table mytab;
+drop table mytab2;
+drop table mytab3;

--- a/src/test/regress/expected/uaocs_compaction/index_stats.out
+++ b/src/test/regress/expected/uaocs_compaction/index_stats.out
@@ -40,3 +40,22 @@ SELECT relname, reltuples FROM pg_class WHERE relname = 'uaocs_index_stats_int_i
  uaocs_index_stats_int_idx1 |         2
 (1 row)
 
+-- A test of index stat for access methods that rely on table tuple count (bitmap, gin)
+truncate uaocs_index_stats;
+create index uaocs_index_stats_int_idx2 on uaocs_index_stats using bitmap(col_int);
+insert into uaocs_index_stats values(1,'aa',1001,101),(2,'bb',1002,102);
+SELECT relname, reltuples FROM pg_class WHERE relname = 'uaocs_index_stats_int_idx2';
+          relname           | reltuples 
+----------------------------+-----------
+ uaocs_index_stats_int_idx2 |         2
+(1 row)
+
+-- first vacuum collect table stat on segments
+vacuum uaocs_index_stats;
+-- second vacuum update index stat with table stat
+vacuum uaocs_index_stats;
+SELECT relname, reltuples FROM pg_class WHERE relname = 'uaocs_index_stats_int_idx2';
+          relname           | reltuples 
+----------------------------+-----------
+ uaocs_index_stats_int_idx2 |         2
+(1 row)

--- a/src/test/regress/expected/uaocs_compaction/index_stats.out
+++ b/src/test/regress/expected/uaocs_compaction/index_stats.out
@@ -40,22 +40,164 @@ SELECT relname, reltuples FROM pg_class WHERE relname = 'uaocs_index_stats_int_i
  uaocs_index_stats_int_idx1 |         2
 (1 row)
 
--- A test of index stat for access methods that rely on table tuple count (bitmap, gin)
-truncate uaocs_index_stats;
-create index uaocs_index_stats_int_idx2 on uaocs_index_stats using bitmap(col_int);
-insert into uaocs_index_stats values(1,'aa',1001,101),(2,'bb',1002,102);
-SELECT relname, reltuples FROM pg_class WHERE relname = 'uaocs_index_stats_int_idx2';
-          relname           | reltuples 
-----------------------------+-----------
- uaocs_index_stats_int_idx2 |         2
+-- Test to ensure that reltuples is updated for an index after lazy vacuum.
+-- This is vital as most index AMs that depend on this tuple count (eg btree, bitmap etc)
+-- which is passed up from the table AM during lazy vacuum.
+-- create a fresh table for the test
+CREATE TABLE uaocs_index_stats2(
+          col_int int,
+          col_text text,
+          col_numeric numeric,
+          col_unq int
+          ) with(appendonly=true, orientation=column) DISTRIBUTED BY (col_int);
+create index uaocs_index_stats2_int_idx1 on uaocs_index_stats2 using bitmap(col_int);
+insert into uaocs_index_stats2 values(1,'aa',1001,101),(2,'bb',1002,102);
+SELECT relname, reltuples FROM pg_class WHERE relname = 'uaocs_index_stats2_int_idx1';
+           relname           | reltuples 
+-----------------------------+-----------
+ uaocs_index_stats2_int_idx1 |         0
 (1 row)
 
 -- first vacuum collect table stat on segments
-vacuum uaocs_index_stats;
+vacuum uaocs_index_stats2;
+-- inspect the state of the stats on segments
+SELECT gp_segment_id, relname, reltuples FROM gp_dist_random('pg_class') WHERE relname = 'uaocs_index_stats2_int_idx1';
+ gp_segment_id |           relname           | reltuples 
+---------------+-----------------------------+-----------
+             0 | uaocs_index_stats2_int_idx1 |         0
+             1 | uaocs_index_stats2_int_idx1 |         0
+             2 | uaocs_index_stats2_int_idx1 |         0
+(3 rows)
+
 -- second vacuum update index stat with table stat
-vacuum uaocs_index_stats;
-SELECT relname, reltuples FROM pg_class WHERE relname = 'uaocs_index_stats_int_idx2';
-          relname           | reltuples 
-----------------------------+-----------
- uaocs_index_stats_int_idx2 |         2
+vacuum uaocs_index_stats2;
+-- inspect the state of the stats on segments
+SELECT gp_segment_id, relname, reltuples FROM gp_dist_random('pg_class') WHERE relname = 'uaocs_index_stats2_int_idx1';
+ gp_segment_id |           relname           | reltuples 
+---------------+-----------------------------+-----------
+             0 | uaocs_index_stats2_int_idx1 |         1
+             1 | uaocs_index_stats2_int_idx1 |         1
+             2 | uaocs_index_stats2_int_idx1 |         0
+(3 rows)
+
+SELECT relname, reltuples FROM pg_class WHERE relname = 'uaocs_index_stats2_int_idx1';
+           relname           | reltuples 
+-----------------------------+-----------
+ uaocs_index_stats2_int_idx1 |         2
 (1 row)
+
+-- Test correctness of index->reltuples in consecutively VACUUM.
+CREATE TABLE uaocs_index_stats3(
+          col_int int,
+          col_text text,
+          col_numeric numeric,
+          col_unq int
+          ) with(appendonly=true, orientation=column) DISTRIBUTED BY (col_int);
+create index uaocs_index_stats3_int_idx1 on uaocs_index_stats3(col_int);
+insert into uaocs_index_stats3 values(1,'aa',1001,101),(2,'bb',1002,102);
+select reltuples from pg_class where relname='uaocs_index_stats3';
+ reltuples 
+-----------
+         0
+(1 row)
+
+-- inspect the state of the stats on segments
+select gp_segment_id, relname, reltuples from gp_dist_random('pg_class') where relname = 'uaocs_index_stats3_int_idx1';
+ gp_segment_id |           relname           | reltuples 
+---------------+-----------------------------+-----------
+             0 | uaocs_index_stats3_int_idx1 |         0
+             1 | uaocs_index_stats3_int_idx1 |         0
+             2 | uaocs_index_stats3_int_idx1 |         0
+(3 rows)
+
+select reltuples from pg_class where relname='uaocs_index_stats3_int_idx1';
+ reltuples 
+-----------
+         0
+(1 row)
+
+-- 1st VACUUM, expect reltuples = 2
+vacuum uaocs_index_stats3;
+select reltuples from pg_class where relname='uaocs_index_stats';
+ reltuples 
+-----------
+         2
+(1 row)
+
+-- inspect the state of the stats on segments
+select gp_segment_id, relname, reltuples from gp_dist_random('pg_class') where relname = 'uaocs_index_stats3_int_idx1';
+ gp_segment_id |           relname           | reltuples 
+---------------+-----------------------------+-----------
+             0 | uaocs_index_stats3_int_idx1 |         1
+             1 | uaocs_index_stats3_int_idx1 |         1
+             2 | uaocs_index_stats3_int_idx1 |         0
+(3 rows)
+
+select reltuples from pg_class where relname='uaocs_index_stats3_int_idx1';
+ reltuples 
+-----------
+         2
+(1 row)
+
+-- 2nd VACUUM, expect reltuples = 2
+vacuum uaocs_index_stats3;
+select reltuples from pg_class where relname='uaocs_index_stats3';
+ reltuples 
+-----------
+         2
+(1 row)
+
+-- inspect the state of the stats on segments
+select gp_segment_id, relname, reltuples from gp_dist_random('pg_class') where relname = 'uaocs_index_stats3_int_idx1';
+ gp_segment_id |           relname           | reltuples 
+---------------+-----------------------------+-----------
+             0 | uaocs_index_stats3_int_idx1 |         1
+             1 | uaocs_index_stats3_int_idx1 |         1
+             2 | uaocs_index_stats3_int_idx1 |         0
+(3 rows)
+
+select reltuples from pg_class where relname='uaocs_index_stats3_int_idx1';
+ reltuples 
+-----------
+         2
+(1 row)
+
+-- Prior to this fix, the case would be failed here. Given the
+-- scenario of updating stats during VACUUM:
+-- 1) coordinator vacuums and updates stats of its own;
+-- 2) then coordinator dispatches vacuum to segments;
+-- 3) coordinator combines stats received from segments to overwrite the stats of its own.
+-- Because upstream introduced a feature which could skip full index scan uring cleanup
+-- of B-tree indexes when possible (refer to:
+-- https://github.com/postgres/postgres/commit/857f9c36cda520030381bd8c2af20adf0ce0e1d4),
+-- there was a case in QD-QEs distributed deployment that some QEs could skip full index scan and
+-- stop updating statistics, result in QD being unable to collect all QEs' stats thus overwrote
+-- a paritial accumulated value to index->reltuples. More interesting, it usually happened starting
+-- from the 3rd time of consecutively VACUUM after fresh inserts due to above skipping index scan
+-- criteria.
+-- 3rd VACUUM, expect reltuples = 2
+vacuum uaocs_index_stats3;
+select reltuples from pg_class where relname='uaocs_index_stats3';
+ reltuples 
+-----------
+         2
+(1 row)
+
+-- inspect the state of the stats on segments
+select gp_segment_id, relname, reltuples from gp_dist_random('pg_class') where relname = 'uaocs_index_stats3_int_idx1';
+ gp_segment_id |           relname           | reltuples 
+---------------+-----------------------------+-----------
+             0 | uaocs_index_stats3_int_idx1 |         1
+             1 | uaocs_index_stats3_int_idx1 |         1
+             2 | uaocs_index_stats3_int_idx1 |         0
+(3 rows)
+
+select reltuples from pg_class where relname='uaocs_index_stats3_int_idx1';
+ reltuples 
+-----------
+         2
+(1 row)
+
+drop table uaocs_index_stats;
+drop table uaocs_index_stats2;
+drop table uaocs_index_stats3;

--- a/src/test/regress/sql/btree_index.sql
+++ b/src/test/regress/sql/btree_index.sql
@@ -145,3 +145,46 @@ VACUUM delete_test_table;
 -- The vacuum above should've turned the leaf page into a fast root. We just
 -- need to insert some rows to cause the fast root page to split.
 INSERT INTO delete_test_table SELECT i, 1, 2, 3 FROM generate_series(1,1000) i;
+
+--
+-- GPDB: Test correctness of B-tree stats in consecutively VACUUM.
+--
+CREATE TABLE btree_stats_tbl(col_int int, col_text text, col_numeric numeric, col_unq int) DISTRIBUTED BY (col_int);
+CREATE INDEX btree_stats_idx ON btree_stats_tbl(col_int);
+INSERT INTO btree_stats_tbl VALUES (1, 'aa', 1001, 101), (2, 'bb', 1002, 102);
+SELECT reltuples FROM pg_class WHERE relname='btree_stats_tbl';
+-- inspect the state of the stats on segments
+SELECT gp_segment_id, relname, reltuples FROM gp_dist_random('pg_class') WHERE relname = 'btree_stats_idx';
+SELECT reltuples FROM pg_class WHERE relname='btree_stats_idx';
+-- 1st VACUUM, expect reltuples = 2
+vacuum btree_stats_tbl;
+SELECT reltuples FROM pg_class WHERE relname='btree_stats_tbl';
+-- inspect the state of the stats on segments
+SELECT gp_segment_id, relname, reltuples FROM gp_dist_random('pg_class') WHERE relname = 'btree_stats_idx';
+SELECT reltuples FROM pg_class WHERE relname='btree_stats_idx';
+-- 2nd VACUUM, expect reltuples = 2
+vacuum btree_stats_tbl;
+SELECT reltuples FROM pg_class WHERE relname='btree_stats_tbl';
+-- inspect the state of the stats on segments
+SELECT gp_segment_id, relname, reltuples FROM gp_dist_random('pg_class') WHERE relname = 'btree_stats_idx';
+SELECT reltuples FROM pg_class WHERE relname='btree_stats_idx';
+
+-- Prior to this fix, the case would be failed here. Given the
+-- scenario of updating stats during VACUUM:
+-- 1) coordinator vacuums and updates stats of its own;
+-- 2) then coordinator dispatches vacuum to segments;
+-- 3) coordinator combines stats received from segments to overwrite the stats of its own.
+-- Because upstream introduced a feature which could skip full index scan uring cleanup
+-- of B-tree indexes when possible (refer to:
+-- https://github.com/postgres/postgres/commit/857f9c36cda520030381bd8c2af20adf0ce0e1d4),
+-- there was a case in QD-QEs distributed deployment that some QEs could skip full index scan and
+-- stop updating statistics, result in QD being unable to collect all QEs' stats thus overwrote
+-- a paritial accumulated value to index->reltuples. More interesting, it usually happened starting
+-- from the 3rd time of consecutively VACUUM after fresh inserts due to above skipping index scan
+-- criteria.
+-- 3rd VACUUM, expect reltuples = 2
+vacuum btree_stats_tbl;
+SELECT reltuples FROM pg_class WHERE relname='btree_stats_tbl';
+-- inspect the state of the stats on segments
+SELECT gp_segment_id, relname, reltuples FROM gp_dist_random('pg_class') WHERE relname = 'btree_stats_idx';
+SELECT reltuples FROM pg_class WHERE relname='btree_stats_idx';

--- a/src/test/regress/sql/uao_compaction/index_stats.sql
+++ b/src/test/regress/sql/uao_compaction/index_stats.sql
@@ -17,3 +17,18 @@ select * from mytab;
 vacuum mytab;
 SELECT relname, reltuples FROM pg_class WHERE relname = 'mytab';
 SELECT relname, reltuples FROM pg_class WHERE relname = 'mytab_int_idx1';
+
+-- A test of index stat for access methods that rely on table tuple count (bitmap, gin)
+truncate mytab;
+create index mytab_int_idx2 on mytab using bitmap(col_int);
+
+insert into mytab values(1,'aa',1001,101),(2,'bb',1002,102);
+
+SELECT relname, reltuples FROM pg_class WHERE relname = 'mytab_int_idx2';
+
+-- first vacuum collect table stat on segments
+vacuum mytab;
+-- second vacuum update index stat with table stat
+vacuum mytab;
+
+SELECT relname, reltuples FROM pg_class WHERE relname = 'mytab_int_idx2';

--- a/src/test/regress/sql/uao_compaction/index_stats.sql
+++ b/src/test/regress/sql/uao_compaction/index_stats.sql
@@ -18,17 +18,82 @@ vacuum mytab;
 SELECT relname, reltuples FROM pg_class WHERE relname = 'mytab';
 SELECT relname, reltuples FROM pg_class WHERE relname = 'mytab_int_idx1';
 
--- A test of index stat for access methods that rely on table tuple count (bitmap, gin)
-truncate mytab;
-create index mytab_int_idx2 on mytab using bitmap(col_int);
+-- Test to ensure that reltuples is updated for an index after lazy vacuum.
+-- This is vital as most index AMs that depend on this tuple count (eg btree, bitmap etc)
+-- which is passed up from the table AM during lazy vacuum.
+-- create a fresh table for the test
+CREATE TABLE mytab2(
+          col_int int,
+          col_text text,
+          col_numeric numeric,
+          col_unq int
+          ) with(appendonly=true) DISTRIBUTED BY (col_int);
 
-insert into mytab values(1,'aa',1001,101),(2,'bb',1002,102);
+create index mytab2_int_idx1 on mytab2 using bitmap(col_int);
 
-SELECT relname, reltuples FROM pg_class WHERE relname = 'mytab_int_idx2';
+insert into mytab2 values(1,'aa',1001,101),(2,'bb',1002,102);
+
+SELECT relname, reltuples FROM pg_class WHERE relname = 'mytab2_int_idx1';
 
 -- first vacuum collect table stat on segments
-vacuum mytab;
+vacuum mytab2;
+-- inspect the state of the stats on segments
+SELECT gp_segment_id, relname, reltuples FROM gp_dist_random('pg_class') WHERE relname = 'mytab2_int_idx1';
 -- second vacuum update index stat with table stat
-vacuum mytab;
+vacuum mytab2;
+-- inspect the state of the stats on segments
+SELECT gp_segment_id, relname, reltuples FROM gp_dist_random('pg_class') WHERE relname = 'mytab2_int_idx1';
+SELECT relname, reltuples FROM pg_class WHERE relname = 'mytab2_int_idx1';
 
-SELECT relname, reltuples FROM pg_class WHERE relname = 'mytab_int_idx2';
+-- Test correctness of index->reltuples in consecutively VACUUM.
+CREATE TABLE mytab3(
+          col_int int,
+          col_text text,
+          col_numeric numeric,
+          col_unq int
+          ) with(appendonly=true) DISTRIBUTED BY (col_int);
+
+create index mytab3_int_idx1 on mytab3(col_int);
+
+insert into mytab3 values(1,'aa',1001,101),(2,'bb',1002,102);
+
+select reltuples from pg_class where relname='mytab3';
+-- inspect the state of the stats on segments
+select gp_segment_id, relname, reltuples from gp_dist_random('pg_class') where relname = 'mytab3_int_idx1';
+select reltuples from pg_class where relname='mytab3_int_idx1';
+-- 1st VACUUM, expect reltuples = 2
+vacuum mytab3;
+select reltuples from pg_class where relname='mytab3';
+-- inspect the state of the stats on segments
+select gp_segment_id, relname, reltuples from gp_dist_random('pg_class') where relname = 'mytab3_int_idx1';
+select reltuples from pg_class where relname='mytab3_int_idx1';
+-- 2nd VACUUM, expect reltuples = 2
+vacuum mytab3;
+select reltuples from pg_class where relname='mytab3';
+-- inspect the state of the stats on segments
+select gp_segment_id, relname, reltuples from gp_dist_random('pg_class') where relname = 'mytab3_int_idx1';
+select reltuples from pg_class where relname='mytab3_int_idx1';
+
+-- Prior to this fix, the case would be failed here. Given the
+-- scenario of updating stats during VACUUM:
+-- 1) coordinator vacuums and updates stats of its own;
+-- 2) then coordinator dispatches vacuum to segments;
+-- 3) coordinator combines stats received from segments to overwrite the stats of its own.
+-- Because upstream introduced a feature which could skip full index scan uring cleanup
+-- of B-tree indexes when possible (refer to:
+-- https://github.com/postgres/postgres/commit/857f9c36cda520030381bd8c2af20adf0ce0e1d4),
+-- there was a case in QD-QEs distributed deployment that some QEs could skip full index scan and
+-- stop updating statistics, result in QD being unable to collect all QEs' stats thus overwrote
+-- a paritial accumulated value to index->reltuples. More interesting, it usually happened starting
+-- from the 3rd time of consecutively VACUUM after fresh inserts due to above skipping index scan
+-- criteria.
+-- 3rd VACUUM, expect reltuples = 2
+vacuum mytab3;
+select reltuples from pg_class where relname='mytab3';
+-- inspect the state of the stats on segments
+select gp_segment_id, relname, reltuples from gp_dist_random('pg_class') where relname = 'mytab3_int_idx1';
+select reltuples from pg_class where relname='mytab3_int_idx1';
+
+drop table mytab;
+drop table mytab2;
+drop table mytab3;

--- a/src/test/regress/sql/uaocs_compaction/index_stats.sql
+++ b/src/test/regress/sql/uaocs_compaction/index_stats.sql
@@ -17,3 +17,18 @@ select * from uaocs_index_stats;
 vacuum uaocs_index_stats;
 SELECT relname, reltuples FROM pg_class WHERE relname = 'uaocs_index_stats';
 SELECT relname, reltuples FROM pg_class WHERE relname = 'uaocs_index_stats_int_idx1';
+
+-- A test of index stat for access methods that rely on table tuple count (bitmap, gin)
+truncate uaocs_index_stats;
+create index uaocs_index_stats_int_idx2 on uaocs_index_stats using bitmap(col_int);
+
+insert into uaocs_index_stats values(1,'aa',1001,101),(2,'bb',1002,102);
+
+SELECT relname, reltuples FROM pg_class WHERE relname = 'uaocs_index_stats_int_idx2';
+
+-- first vacuum collect table stat on segments
+vacuum uaocs_index_stats;
+-- second vacuum update index stat with table stat
+vacuum uaocs_index_stats;
+
+SELECT relname, reltuples FROM pg_class WHERE relname = 'uaocs_index_stats_int_idx2';

--- a/src/test/regress/sql/uaocs_compaction/index_stats.sql
+++ b/src/test/regress/sql/uaocs_compaction/index_stats.sql
@@ -18,17 +18,82 @@ vacuum uaocs_index_stats;
 SELECT relname, reltuples FROM pg_class WHERE relname = 'uaocs_index_stats';
 SELECT relname, reltuples FROM pg_class WHERE relname = 'uaocs_index_stats_int_idx1';
 
--- A test of index stat for access methods that rely on table tuple count (bitmap, gin)
-truncate uaocs_index_stats;
-create index uaocs_index_stats_int_idx2 on uaocs_index_stats using bitmap(col_int);
+-- Test to ensure that reltuples is updated for an index after lazy vacuum.
+-- This is vital as most index AMs that depend on this tuple count (eg btree, bitmap etc)
+-- which is passed up from the table AM during lazy vacuum.
+-- create a fresh table for the test
+CREATE TABLE uaocs_index_stats2(
+          col_int int,
+          col_text text,
+          col_numeric numeric,
+          col_unq int
+          ) with(appendonly=true, orientation=column) DISTRIBUTED BY (col_int);
 
-insert into uaocs_index_stats values(1,'aa',1001,101),(2,'bb',1002,102);
+create index uaocs_index_stats2_int_idx1 on uaocs_index_stats2 using bitmap(col_int);
 
-SELECT relname, reltuples FROM pg_class WHERE relname = 'uaocs_index_stats_int_idx2';
+insert into uaocs_index_stats2 values(1,'aa',1001,101),(2,'bb',1002,102);
+
+SELECT relname, reltuples FROM pg_class WHERE relname = 'uaocs_index_stats2_int_idx1';
 
 -- first vacuum collect table stat on segments
-vacuum uaocs_index_stats;
+vacuum uaocs_index_stats2;
+-- inspect the state of the stats on segments
+SELECT gp_segment_id, relname, reltuples FROM gp_dist_random('pg_class') WHERE relname = 'uaocs_index_stats2_int_idx1';
 -- second vacuum update index stat with table stat
-vacuum uaocs_index_stats;
+vacuum uaocs_index_stats2;
+-- inspect the state of the stats on segments
+SELECT gp_segment_id, relname, reltuples FROM gp_dist_random('pg_class') WHERE relname = 'uaocs_index_stats2_int_idx1';
+SELECT relname, reltuples FROM pg_class WHERE relname = 'uaocs_index_stats2_int_idx1';
 
-SELECT relname, reltuples FROM pg_class WHERE relname = 'uaocs_index_stats_int_idx2';
+-- Test correctness of index->reltuples in consecutively VACUUM.
+CREATE TABLE uaocs_index_stats3(
+          col_int int,
+          col_text text,
+          col_numeric numeric,
+          col_unq int
+          ) with(appendonly=true, orientation=column) DISTRIBUTED BY (col_int);
+
+create index uaocs_index_stats3_int_idx1 on uaocs_index_stats3(col_int);
+
+insert into uaocs_index_stats3 values(1,'aa',1001,101),(2,'bb',1002,102);
+
+select reltuples from pg_class where relname='uaocs_index_stats3';
+-- inspect the state of the stats on segments
+select gp_segment_id, relname, reltuples from gp_dist_random('pg_class') where relname = 'uaocs_index_stats3_int_idx1';
+select reltuples from pg_class where relname='uaocs_index_stats3_int_idx1';
+-- 1st VACUUM, expect reltuples = 2
+vacuum uaocs_index_stats3;
+select reltuples from pg_class where relname='uaocs_index_stats';
+-- inspect the state of the stats on segments
+select gp_segment_id, relname, reltuples from gp_dist_random('pg_class') where relname = 'uaocs_index_stats3_int_idx1';
+select reltuples from pg_class where relname='uaocs_index_stats3_int_idx1';
+-- 2nd VACUUM, expect reltuples = 2
+vacuum uaocs_index_stats3;
+select reltuples from pg_class where relname='uaocs_index_stats3';
+-- inspect the state of the stats on segments
+select gp_segment_id, relname, reltuples from gp_dist_random('pg_class') where relname = 'uaocs_index_stats3_int_idx1';
+select reltuples from pg_class where relname='uaocs_index_stats3_int_idx1';
+
+-- Prior to this fix, the case would be failed here. Given the
+-- scenario of updating stats during VACUUM:
+-- 1) coordinator vacuums and updates stats of its own;
+-- 2) then coordinator dispatches vacuum to segments;
+-- 3) coordinator combines stats received from segments to overwrite the stats of its own.
+-- Because upstream introduced a feature which could skip full index scan uring cleanup
+-- of B-tree indexes when possible (refer to:
+-- https://github.com/postgres/postgres/commit/857f9c36cda520030381bd8c2af20adf0ce0e1d4),
+-- there was a case in QD-QEs distributed deployment that some QEs could skip full index scan and
+-- stop updating statistics, result in QD being unable to collect all QEs' stats thus overwrote
+-- a paritial accumulated value to index->reltuples. More interesting, it usually happened starting
+-- from the 3rd time of consecutively VACUUM after fresh inserts due to above skipping index scan
+-- criteria.
+-- 3rd VACUUM, expect reltuples = 2
+vacuum uaocs_index_stats3;
+select reltuples from pg_class where relname='uaocs_index_stats3';
+-- inspect the state of the stats on segments
+select gp_segment_id, relname, reltuples from gp_dist_random('pg_class') where relname = 'uaocs_index_stats3_int_idx1';
+select reltuples from pg_class where relname='uaocs_index_stats3_int_idx1';
+
+drop table uaocs_index_stats;
+drop table uaocs_index_stats2;
+drop table uaocs_index_stats3;


### PR DESCRIPTION
Commit 1: fix unpredictable behavior during AO index vacuum
This is a backport of 6X https://github.com/greenplum-db/gpdb/pull/14260

Commit 2: Fix incorrect index->reltuples after VACUUM
Given the scenario of updating stats during VACUUM:

1) coordinator vacuums and updates stats of its own;
2) then coordinator dispatches vacuum to segments;
3) coordinator combines stats received from segments
   to overwrite the stats of its own.

Because upstream introduced a feature which could skip
full index scan uring cleanup of B-tree indexes when
possible (refer to: https://github.com/postgres/postgres/commit/857f9c36cda520030381bd8c2af20adf0ce0e1d4),
there was a case in QD-QEs distributed deployment that
some QEs could skip full index scan and stop updating
statistics, resulting in QD being unable to collect all
QEs' stats thus overwrote a paritial accumulated value
to index->reltuples. More interesting, it usually happened
starting from the 3rd time of consecutively VACUUM after
fresh inserts due to above skipping index scan criteria.

This patch is intended to prevent from above issue by two aspects:
on QE, do not skip full index scan, report current statistics
to QD as requested;
on QD, restrict updating statistics only when collecting all QEs'
data completely, if the reporting QE number doesn't match
the total number of dispatched QEs, no stats update happens.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
