### PR TITLE
fix compiler warning in appendonlyblockdirectory.c

### DIFF
--- a/src/backend/access/appendonly/appendonlyblockdirectory.c
+++ b/src/backend/access/appendonly/appendonlyblockdirectory.c
@@ -1445,8 +1445,6 @@ void
 AppendOnlyBlockDirectory_End_forSearch(
 									   AppendOnlyBlockDirectory *blockDirectory)
 {
-	int			groupNo;
-
 	if (blockDirectory->blkdirRel == NULL)
 		return;
 


### PR DESCRIPTION
remove unused variable `groupNo` In function `AppendOnlyBlockDirectory_End_forSearch`.
```
appendonlyblockdirectory.c: In function 'AppendOnlyBlockDirectory_End_forSearch':
appendonlyblockdirectory.c:1448:8: warning: unused variable 'groupNo' [-Wunused-variable]
  int   groupNo;
        ^
```

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
