### PR TITLE
Rename UpdateSerializableCommandId() to UpdateCommandIdInSnapshot()

### DIFF
--- a/src/backend/storage/ipc/procarray.c
+++ b/src/backend/storage/ipc/procarray.c
@@ -3132,10 +3132,9 @@ HaveVirtualXIDsDelayingChkpt(VirtualTransactionId *vxids, int nvxids)
 
 /*
  * MPP: Special code to update the command id in the SharedLocalSnapshot
- * when we are in SERIALIZABLE isolation mode.
  */
 void
-UpdateSerializableCommandId(CommandId curcid)
+UpdateCommandIdInSnapshot(CommandId curcid)
 {
 	if ((DistributedTransactionContext == DTX_CONTEXT_QE_TWO_PHASE_EXPLICIT_WRITER ||
 		 DistributedTransactionContext == DTX_CONTEXT_QE_TWO_PHASE_IMPLICIT_WRITER) &&

--- a/src/backend/utils/time/snapmgr.c
+++ b/src/backend/utils/time/snapmgr.c
@@ -375,11 +375,7 @@ GetTransactionSnapshot(void)
 			 getDistributedTransactionId(),
 			 DtxContextToString(DistributedTransactionContext));
 
-		// GPDB_91_MERGE_FIXME: the name of UpdateSerializableCommandId is a bit
-		// wrong, now that SERIALIZABLE and REPEATABLE READ are not the same.
-		// From comparison, the if-check above was changed from checking
-		// IsXactIsoLevelSerializable to IsolationUsesXactSnapshot()
-		UpdateSerializableCommandId(CurrentSnapshot->curcid);
+		UpdateCommandIdInSnapshot(CurrentSnapshot->curcid);
 
 		return CurrentSnapshot;
 	}

--- a/src/include/storage/procarray.h
+++ b/src/include/storage/procarray.h
@@ -125,7 +125,7 @@ extern void XidCacheRemoveRunningXids(TransactionId xid,
 									  TransactionId latestXid);
 						  
 extern PGPROC *FindProcByGpSessionId(long gp_session_id);
-extern void UpdateSerializableCommandId(CommandId curcid);
+extern void UpdateCommandIdInSnapshot(CommandId curcid);
 
 extern void updateSharedLocalSnapshot(struct DtxContextInfo *dtxContextInfo,
 									  DtxContext distributedTransactionContext,


### PR DESCRIPTION
The name of UpdateSerializableCommandId is a bit wrong, now that SERIALIZABLE and REPEATABLE READ are not the same. From comparison, the if-check above was changed from checking IsXactIsoLevelSerializable to IsolationUsesXactSnapshot().

This commit renames it and resolves that GPDB_91_MERGE_FIXME.

	commit 5eb15c9942a9bd6aaf712f2ab6175005e035168a
	Author: Joe Conway <mail@joeconway.com>
	Date:   Sat Sep 11 18:38:58 2010 +0000

	    SERIALIZABLE transactions are actually implemented beneath the covers with
	    transaction snapshots, i.e. a snapshot registered at the beginning of
	    a transaction. Change variable naming and comments to reflect this reality
	    in preparation for a future, truly serializable mode, e.g.
	    Serializable Snapshot Isolation (SSI).

	    For the moment transaction snapshots are still used to implement
	    SERIALIZABLE, but hopefully not for too much longer. Patch by Kevin
	    Grittner and Dan Ports with review and some minor wording changes by me.