### PR TITLE
Patch handling of composite type returning TVF that evaluates to cons…

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
@@ -3695,6 +3695,16 @@ CTranslatorQueryToDXL::TranslateTVFToDXL(const RangeTblEntry *rte,
 	// funcexpr evaluates to const and returns composite type
 	if (IsA(rtfunc->funcexpr, Const))
 	{
+		// If the const is NULL, the const value cannot be populated
+		// Raise exception
+		// This happens to PostGIS functions, which aren't supported
+		const Const *constant = (Const *) rtfunc->funcexpr;
+		if (constant->constisnull)
+		{
+			GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature,
+					   GPOS_WSZ_LIT("Row-type variable"));
+		}
+
 		CDXLNode *constValue = m_scalar_translator->TranslateScalarToDXL(
 			(Expr *) (rtfunc->funcexpr), m_var_to_colid_map);
 		tvf_dxlnode->AddChild(constValue);


### PR DESCRIPTION
…t (#14283)

Issue:
Regression in GPDB compatibility with PostGIS. Exception hit by NULL Datum pointer.

Root cause:
While implementing support for composite type returning TVF, we didn't factor in unsupported PostGIS functions.

Solution:
Patch 323cb73a60. While translating query to DXL, check if the const value of TVF is NULL. If so, fall back on planner.

Implementation:
[CTranslatorQueryToDXL] -- Raise exception if the const value of TVF cannot be populated

(cherry picked from commit 8397162f2bcedad43af2e59d42ba343ef8dadf56)

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
