### PR TITLE
Support ONLY keyword for GRANT/REVOKE and add test coverage for ALTER TABLE SET TABLESPACE

### DIFF
--- a/src/backend/catalog/aclchk.c
+++ b/src/backend/catalog/aclchk.c
@@ -732,9 +732,11 @@ objectNamesToOids(ObjectType objtype, List *objnames)
 				 * GPDB: If we the object is a partitioned relation, also
 				 * recurse to the child partitions. It is different from
 				 * PostgreSQL, but it is how GRANT has historically worked on
-				 * GPDB.
+				 * GPDB. Unless it is indicated that we should not recurse
+				 * (e.g. by specifying the 'ONLY' keyword), in which case
+				 * don't bother finding the inheritors.
 				 */
-				if (objtype == OBJECT_TABLE)
+				if (objtype == OBJECT_TABLE && relvar->inh)
 				{
 					HeapTuple	tp;
 

--- a/src/test/regress/expected/partition.out
+++ b/src/test/regress/expected/partition.out
@@ -283,9 +283,98 @@ select has_table_privilege('part_role', 'bar_p'::regclass, 'select');
  t
 (1 row)
 
+-- the ONLY keyword will affect just the partition root for both grant/revoke
+create role part_role2;
+grant select on only foo_p to part_role2;
+select has_table_privilege('part_role2', 'foo_p'::regclass, 'select');
+ has_table_privilege 
+---------------------
+ t
+(1 row)
+
+select has_table_privilege('part_role2', 'foo_p_1_prt_6'::regclass, 'select');
+ has_table_privilege 
+---------------------
+ f
+(1 row)
+
+grant select on foo_p to part_role2;
+revoke select on only foo_p from part_role2;
+select has_table_privilege('part_role2', 'foo_p'::regclass, 'select');
+ has_table_privilege 
+---------------------
+ f
+(1 row)
+
+select has_table_privilege('part_role2', 'foo_p_1_prt_6'::regclass, 'select');
+ has_table_privilege 
+---------------------
+ t
+(1 row)
+
+revoke select on foo_p from part_role2;
+select has_table_privilege('part_role2', 'foo_p_1_prt_6'::regclass, 'select');
+ has_table_privilege 
+---------------------
+ f
+(1 row)
+
+create table foo_p2 (a int, b int) partition by range(a) (start(1) end(10) every(1));
+grant select on foo_p, only foo_p2 to part_role2; -- multiple tables in same statement
+select has_table_privilege('part_role2', 'foo_p'::regclass, 'select');
+ has_table_privilege 
+---------------------
+ t
+(1 row)
+
+select has_table_privilege('part_role2', 'foo_p_1_prt_6'::regclass, 'select');
+ has_table_privilege 
+---------------------
+ t
+(1 row)
+
+select has_table_privilege('part_role2', 'foo_p2'::regclass, 'select');
+ has_table_privilege 
+---------------------
+ t
+(1 row)
+
+select has_table_privilege('part_role2', 'foo_p2_1_prt_6'::regclass, 'select');
+ has_table_privilege 
+---------------------
+ f
+(1 row)
+
+-- more cases
+revoke all on foo_p from part_role2;
+revoke all on foo_p2 from part_role2;
+grant select on only public.foo_p to part_role2; -- with schema
+select has_table_privilege('part_role2', 'foo_p'::regclass, 'select');
+ has_table_privilege 
+---------------------
+ t
+(1 row)
+
+select has_table_privilege('part_role2', 'foo_p_1_prt_6'::regclass, 'select');
+ has_table_privilege 
+---------------------
+ f
+(1 row)
+
+grant update(b) on only foo_p2 to part_role2; -- column level priviledge
+select relname, has_column_privilege('part_role2', oid, 'b', 'update') from pg_class
+where relname = 'foo_p2' or relname = 'foo_p2_1_prt_6';
+    relname     | has_column_privilege 
+----------------+----------------------
+ foo_p2         | t
+ foo_p2_1_prt_6 | f
+(2 rows)
+
 drop table foo_p;
+drop table foo_p2;
 drop table bar_p;
 drop role part_role;
+drop role part_role2;
 -- validation
 create table foo_p (i int) partition by range(i)
 (start(1) end(10) every(1));

--- a/src/test/regress/expected/partition_optimizer.out
+++ b/src/test/regress/expected/partition_optimizer.out
@@ -283,9 +283,98 @@ select has_table_privilege('part_role', 'bar_p'::regclass, 'select');
  t
 (1 row)
 
+-- the ONLY keyword will affect just the partition root for both grant/revoke
+create role part_role2;
+grant select on only foo_p to part_role2;
+select has_table_privilege('part_role2', 'foo_p'::regclass, 'select');
+ has_table_privilege 
+---------------------
+ t
+(1 row)
+
+select has_table_privilege('part_role2', 'foo_p_1_prt_6'::regclass, 'select');
+ has_table_privilege 
+---------------------
+ f
+(1 row)
+
+grant select on foo_p to part_role2;
+revoke select on only foo_p from part_role2;
+select has_table_privilege('part_role2', 'foo_p'::regclass, 'select');
+ has_table_privilege 
+---------------------
+ f
+(1 row)
+
+select has_table_privilege('part_role2', 'foo_p_1_prt_6'::regclass, 'select');
+ has_table_privilege 
+---------------------
+ t
+(1 row)
+
+revoke select on foo_p from part_role2;
+select has_table_privilege('part_role2', 'foo_p_1_prt_6'::regclass, 'select');
+ has_table_privilege 
+---------------------
+ f
+(1 row)
+
+create table foo_p2 (a int, b int) partition by range(a) (start(1) end(10) every(1));
+grant select on foo_p, only foo_p2 to part_role2; -- multiple tables in same statement
+select has_table_privilege('part_role2', 'foo_p'::regclass, 'select');
+ has_table_privilege 
+---------------------
+ t
+(1 row)
+
+select has_table_privilege('part_role2', 'foo_p_1_prt_6'::regclass, 'select');
+ has_table_privilege 
+---------------------
+ t
+(1 row)
+
+select has_table_privilege('part_role2', 'foo_p2'::regclass, 'select');
+ has_table_privilege 
+---------------------
+ t
+(1 row)
+
+select has_table_privilege('part_role2', 'foo_p2_1_prt_6'::regclass, 'select');
+ has_table_privilege 
+---------------------
+ f
+(1 row)
+
+-- more cases
+revoke all on foo_p from part_role2;
+revoke all on foo_p2 from part_role2;
+grant select on only public.foo_p to part_role2; -- with schema
+select has_table_privilege('part_role2', 'foo_p'::regclass, 'select');
+ has_table_privilege 
+---------------------
+ t
+(1 row)
+
+select has_table_privilege('part_role2', 'foo_p_1_prt_6'::regclass, 'select');
+ has_table_privilege 
+---------------------
+ f
+(1 row)
+
+grant update(b) on only foo_p2 to part_role2; -- column level priviledge
+select relname, has_column_privilege('part_role2', oid, 'b', 'update') from pg_class
+where relname = 'foo_p2' or relname = 'foo_p2_1_prt_6';
+    relname     | has_column_privilege 
+----------------+----------------------
+ foo_p2         | t
+ foo_p2_1_prt_6 | f
+(2 rows)
+
 drop table foo_p;
+drop table foo_p2;
 drop table bar_p;
 drop role part_role;
+drop role part_role2;
 -- validation
 create table foo_p (i int) partition by range(i)
 (start(1) end(10) every(1));

--- a/src/test/regress/input/tablespace.source
+++ b/src/test/regress/input/tablespace.source
@@ -311,3 +311,22 @@ DROP SCHEMA testschema CASCADE;
 
 DROP ROLE regress_tablespace_user1;
 DROP ROLE regress_tablespace_user2;
+
+-- Test that altering tablespace of a partition table should recurse into its child tables unless ONLY is specified.
+CREATE TABLE tablespace_part(a int, b int) PARTITION BY RANGE(a) (partition t1 START (1) END (100));
+CREATE TABLESPACE myts LOCATION '@testtablespace@';
+ALTER TABLE tablespace_part SET TABLESPACE myts;
+
+-- Both parent and child tables use the new tablespace
+SELECT c.relname, t.spcname FROM pg_class c LEFT JOIN pg_tablespace t ON c.reltablespace = t.oid WHERE relname LIKE 'tablespace_part%';
+
+DROP TABLE tablespace_part;
+
+CREATE TABLE tablespace_part(a int, b int) PARTITION BY RANGE(a) (partition t1 START (1) END (100));
+ALTER TABLE ONLY tablespace_part SET TABLESPACE myts;
+
+-- Only the parent table uses the new tablespace
+SELECT c.relname, t.spcname FROM pg_class c LEFT JOIN pg_tablespace t ON c.reltablespace = t.oid WHERE relname LIKE 'tablespace_part%';
+
+DROP TABLE tablespace_part;
+DROP TABLESPACE myts;

--- a/src/test/regress/output/tablespace.source
+++ b/src/test/regress/output/tablespace.source
@@ -707,3 +707,28 @@ drop cascades to table testschema.atable
 drop cascades to table testschema.tablespace_acl
 DROP ROLE regress_tablespace_user1;
 DROP ROLE regress_tablespace_user2;
+-- Test that altering tablespace of a partition table should recurse into its child tables unless ONLY is specified.
+CREATE TABLE tablespace_part(a int, b int) PARTITION BY RANGE(a) (partition t1 START (1) END (100));
+CREATE TABLESPACE myts LOCATION '@testtablespace@';
+ALTER TABLE tablespace_part SET TABLESPACE myts;
+-- Both parent and child tables use the new tablespace
+SELECT c.relname, t.spcname FROM pg_class c LEFT JOIN pg_tablespace t ON c.reltablespace = t.oid WHERE relname LIKE 'tablespace_part%';
+         relname          | spcname 
+--------------------------+---------
+ tablespace_part          | myts
+ tablespace_part_1_prt_t1 | myts
+(2 rows)
+
+DROP TABLE tablespace_part;
+CREATE TABLE tablespace_part(a int, b int) PARTITION BY RANGE(a) (partition t1 START (1) END (100));
+ALTER TABLE ONLY tablespace_part SET TABLESPACE myts;
+-- Only the parent table uses the new tablespace
+SELECT c.relname, t.spcname FROM pg_class c LEFT JOIN pg_tablespace t ON c.reltablespace = t.oid WHERE relname LIKE 'tablespace_part%';
+         relname          | spcname 
+--------------------------+---------
+ tablespace_part          | myts
+ tablespace_part_1_prt_t1 | 
+(2 rows)
+
+DROP TABLE tablespace_part;
+DROP TABLESPACE myts;


### PR DESCRIPTION
Historically in GPDB6, when executing GRANT/REVOKE on a partition root, we will recurse into its child tables. We have decided to keep this behavior for 7X, but to also support the ONLY keyword so that users can choose to grant/revoke just the partition root, without recursion. The syntax is e.g.:

```
GRANT SELECT ON ONLY foo_par TO role;
```

Similarly, for other commands like ALTER TABLE SET TABLESPACE we will do the same. However, since the ONLY keyword has been implicitly supported for ALTER TABLE, we just need to add test coverage.

Discussion: https://groups.google.com/a/greenplum.org/g/gpdb-dev/c/ImJrvQEECwA

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
