### PR TITLE
Resolve GPDB_12_MERGE_FIXME create index on AO/CO allows read-onl…

### DIFF
--- a/src/backend/catalog/aoblkdir.c
+++ b/src/backend/catalog/aoblkdir.c
@@ -51,17 +51,18 @@ AlterTableCreateAoBlkdirTable(Oid relOid)
 		return;
 
 	/*
-	 * GPDB_12_MERGE_FIXME: Block directory creation must block any
-	 * transactions that may create or update indexes such as insert, vacuum
-	 * and create-index.  Concurrent sequential scans (select) transactions
-	 * need not be blocked.  Index scans cannot happen because the fact that
-	 * we are creating block directory implies no index is yet defined on this
-	 * appendoptimized table.  ShareRowExclusiveLock seems appropriate for
-	 * this purpose.  See if using that instead of the sledgehammer of
-	 * AccessExclusiveLock.  New tests will be needed to validate concurrent
-	 * select with index creation.
+	 * Block directory creation must block any transactions that may create
+	 * or update indexes such as insert, vacuum and create-index. Concurrent
+	 * sequential scans (select) transactions need not be blocked. Index scans
+	 * cannot happen because the fact that we are creating block directory
+	 * implies no index is yet defined on this appendoptimized table.
+	 * Using ShareRowExclusiveLock for this purpose as we allow read-only transactions
+	 * being running concurrently. 
+	 * 
+	 * P.S. GPDB has specific behavior on select statement with locking clause,
+	 * refer to comments around checkCanOptSelectLockingClause() for detail. 
 	 */
-	rel = table_open(relOid, AccessExclusiveLock);
+	rel = table_open(relOid, ShareRowExclusiveLock);
 
 	/* Create a tuple descriptor */
 	tupdesc = CreateTemplateTupleDesc(4);

--- a/src/test/isolation2/expected/lockmodes.out
+++ b/src/test/isolation2/expected/lockmodes.out
@@ -2216,21 +2216,142 @@ INSERT 10
 ROLLBACK
 1q: ... <quitting>
 
+-- 2.8 Verify behaviors of select with locking clause (i.e. select for update)
+-- when running concurrently with index creation, for Heap tables.
+-- For AO/CO tables, refer to create_index_allows_readonly.source.
+
+1: CREATE TABLE create_index_select_for_update_tbl(a int, b int);
+CREATE
+1: INSERT INTO create_index_select_for_update_tbl SELECT i,i FROM generate_series(1,10)i;
+INSERT 10
+1: set optimizer = off;
+SET
+
+-- 2.8.1 with GDD enabled, expect no blocking
+1: show gp_enable_global_deadlock_detector;
+ gp_enable_global_deadlock_detector 
+------------------------------------
+ on                                 
+(1 row)
+
+1: BEGIN;
+BEGIN
+1: SELECT * FROM create_index_select_for_update_tbl WHERE a = 2 FOR UPDATE;
+ a | b 
+---+---
+ 2 | 2 
+(1 row)
+
+2: set optimizer = off;
+SET
+
+2: BEGIN;
+BEGIN
+-- expect no blocking
+2: CREATE INDEX create_index_select_for_update_idx ON create_index_select_for_update_tbl(a);
+CREATE
+2: COMMIT;
+COMMIT
+
+1: COMMIT;
+COMMIT
+
+2: DROP INDEX create_index_select_for_update_idx;
+DROP
+
+2: BEGIN;
+BEGIN
+2: CREATE INDEX create_index_select_for_update_idx ON create_index_select_for_update_tbl(a);
+CREATE
+
+1: BEGIN;
+BEGIN
+-- expect no blocking
+1: SELECT * FROM create_index_select_for_update_tbl WHERE a = 2 FOR UPDATE;
+ a | b 
+---+---
+ 2 | 2 
+(1 row)
+1: COMMIT;
+COMMIT
+-- close session to avoid renew session failure after restart
+1q: ... <quitting>
+
+2: COMMIT;
+COMMIT
+
+2: DROP INDEX create_index_select_for_update_idx;
+DROP
+
+-- 2.8.2 with GDD disabled, expect blocking
 -- reset gdd
 2: ALTER SYSTEM RESET gp_enable_global_deadlock_detector;
 ALTER
+-- close session to avoid renew session failure after restart
+2q: ... <quitting>
 1U:SELECT pg_ctl(dir, 'restart') from lockmodes_datadir;
  pg_ctl 
 --------
  OK     
 (1 row)
 
+1: set optimizer = off;
+SET
 1: show gp_enable_global_deadlock_detector;
  gp_enable_global_deadlock_detector 
 ------------------------------------
  off                                
 (1 row)
 
+1: BEGIN;
+BEGIN
+1: SELECT * FROM create_index_select_for_update_tbl WHERE a = 2 FOR UPDATE;
+ a | b 
+---+---
+ 2 | 2 
+(1 row)
+
+2: set optimizer = off;
+SET
+
+2: BEGIN;
+BEGIN
+-- expect blocking
+2&: CREATE INDEX create_index_select_for_update_idx ON create_index_select_for_update_tbl(a);  <waiting ...>
+
+1: COMMIT;
+COMMIT
+
+2<:  <... completed>
+CREATE
+2: COMMIT;
+COMMIT
+
+2: DROP INDEX create_index_select_for_update_idx;
+DROP
+
+2: BEGIN;
+BEGIN
+2: CREATE INDEX create_index_select_for_update_idx ON create_index_select_for_update_tbl(a);
+CREATE
+
+1: BEGIN;
+BEGIN
+-- expect blocking
+1&: SELECT * FROM create_index_select_for_update_tbl WHERE a = 2 FOR UPDATE;  <waiting ...>
+
+2: COMMIT;
+COMMIT
+
+1<:  <... completed>
+ a | b 
+---+---
+ 2 | 2 
+(1 row)
+1: COMMIT;
+COMMIT
+
 1: drop table lockmodes_datadir;
 DROP
 1q: ... <quitting>
+2q: ... <quitting>

--- a/src/test/isolation2/expected/lockmodes_optimizer.out
+++ b/src/test/isolation2/expected/lockmodes_optimizer.out
@@ -2217,21 +2217,142 @@ INSERT 10
 ROLLBACK
 1q: ... <quitting>
 
+-- 2.8 Verify behaviors of select with locking clause (i.e. select for update)
+-- when running concurrently with index creation, for Heap tables.
+-- For AO/CO tables, refer to create_index_allows_readonly.source.
+
+1: CREATE TABLE create_index_select_for_update_tbl(a int, b int);
+CREATE
+1: INSERT INTO create_index_select_for_update_tbl SELECT i,i FROM generate_series(1,10)i;
+INSERT 10
+1: set optimizer = off;
+SET
+
+-- 2.8.1 with GDD enabled, expect no blocking
+1: show gp_enable_global_deadlock_detector;
+ gp_enable_global_deadlock_detector 
+------------------------------------
+ on                                 
+(1 row)
+
+1: BEGIN;
+BEGIN
+1: SELECT * FROM create_index_select_for_update_tbl WHERE a = 2 FOR UPDATE;
+ a | b 
+---+---
+ 2 | 2 
+(1 row)
+
+2: set optimizer = off;
+SET
+
+2: BEGIN;
+BEGIN
+-- expect no blocking
+2: CREATE INDEX create_index_select_for_update_idx ON create_index_select_for_update_tbl(a);
+CREATE
+2: COMMIT;
+COMMIT
+
+1: COMMIT;
+COMMIT
+
+2: DROP INDEX create_index_select_for_update_idx;
+DROP
+
+2: BEGIN;
+BEGIN
+2: CREATE INDEX create_index_select_for_update_idx ON create_index_select_for_update_tbl(a);
+CREATE
+
+1: BEGIN;
+BEGIN
+-- expect no blocking
+1: SELECT * FROM create_index_select_for_update_tbl WHERE a = 2 FOR UPDATE;
+ a | b 
+---+---
+ 2 | 2 
+(1 row)
+1: COMMIT;
+COMMIT
+-- close session to avoid renew session failure after restart
+1q: ... <quitting>
+
+2: COMMIT;
+COMMIT
+
+2: DROP INDEX create_index_select_for_update_idx;
+DROP
+
+-- 2.8.2 with GDD disabled, expect blocking
 -- reset gdd
 2: ALTER SYSTEM RESET gp_enable_global_deadlock_detector;
 ALTER
+-- close session to avoid renew session failure after restart
+2q: ... <quitting>
 1U:SELECT pg_ctl(dir, 'restart') from lockmodes_datadir;
  pg_ctl 
 --------
  OK     
 (1 row)
 
+1: set optimizer = off;
+SET
 1: show gp_enable_global_deadlock_detector;
  gp_enable_global_deadlock_detector 
 ------------------------------------
  off                                
 (1 row)
 
+1: BEGIN;
+BEGIN
+1: SELECT * FROM create_index_select_for_update_tbl WHERE a = 2 FOR UPDATE;
+ a | b 
+---+---
+ 2 | 2 
+(1 row)
+
+2: set optimizer = off;
+SET
+
+2: BEGIN;
+BEGIN
+-- expect blocking
+2&: CREATE INDEX create_index_select_for_update_idx ON create_index_select_for_update_tbl(a);  <waiting ...>
+
+1: COMMIT;
+COMMIT
+
+2<:  <... completed>
+CREATE
+2: COMMIT;
+COMMIT
+
+2: DROP INDEX create_index_select_for_update_idx;
+DROP
+
+2: BEGIN;
+BEGIN
+2: CREATE INDEX create_index_select_for_update_idx ON create_index_select_for_update_tbl(a);
+CREATE
+
+1: BEGIN;
+BEGIN
+-- expect blocking
+1&: SELECT * FROM create_index_select_for_update_tbl WHERE a = 2 FOR UPDATE;  <waiting ...>
+
+2: COMMIT;
+COMMIT
+
+1<:  <... completed>
+ a | b 
+---+---
+ 2 | 2 
+(1 row)
+1: COMMIT;
+COMMIT
+
 1: drop table lockmodes_datadir;
 DROP
 1q: ... <quitting>
+2q: ... <quitting>

--- a/src/test/isolation2/input/uao/create_index_allows_readonly.source
+++ b/src/test/isolation2/input/uao/create_index_allows_readonly.source
@@ -1,0 +1,56 @@
+-- This is intended to verify read-only transactions is able to run
+-- concurently with index creation.
+
+set default_table_access_method=@amname@;
+
+create table @amname@_create_index_with_select_tbl(a int, b int);
+insert into @amname@_create_index_with_select_tbl select a,a from generate_series(1,10) a;
+
+-- Verify readonly transaction is able to run concurrently with index creation.
+
+1: begin;
+1: select * from @amname@_create_index_with_select_tbl where a = 2;
+
+2: begin;
+-- expect no hang
+2: create index @amname@_create_index_with_select_idx on @amname@_create_index_with_select_tbl(a);
+-- expect no hang
+3: select * from @amname@_create_index_with_select_tbl where a = 2;
+
+1: end;
+2: end;
+
+-- Verify behaviors of select with locking clause (i.e. select for update)
+-- when running concurrently with index creation, expect blocking with each other.
+-- This is only for AO/CO tables, for Heap tables, refer to lockmodes.sql.
+
+drop index @amname@_create_index_with_select_idx;
+
+1: begin;
+1: select * from @amname@_create_index_with_select_tbl where a = 2 for update;
+
+2: begin;
+-- expect blocking
+2&: create index @amname@_create_index_with_select_idx on @amname@_create_index_with_select_tbl(a);
+
+1: commit;
+
+2<:
+2: commit;
+
+drop index @amname@_create_index_with_select_idx;
+
+2: begin;
+2: create index @amname@_create_index_with_select_idx on @amname@_create_index_with_select_tbl(a);
+
+1: begin;
+-- expect blocking
+1&: select * from @amname@_create_index_with_select_tbl where a = 2 for update;
+
+2: commit;
+
+1<:
+1: commit;
+
+drop table @amname@_create_index_with_select_tbl;
+reset default_table_access_method;

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -157,6 +157,7 @@ test: uao/vacuum_cleanup_row
 test: uao/vacuum_index_stats_row
 test: uao/bitmapindex_rescan_row
 test: uao/limit_indexscan_inits_row
+test: uao/create_index_allows_readonly_row
 test: reorganize_after_ao_vacuum_skip_drop truncate_after_ao_vacuum_skip_drop mark_all_aoseg_await_drop
 # below test(s) inject faults so each of them need to be in a separate group
 test: segwalrep/master_wal_switch
@@ -210,6 +211,7 @@ test: uao/vacuum_cleanup_column
 test: uao/vacuum_index_stats_column
 test: uao/bitmapindex_rescan_column
 test: uao/limit_indexscan_inits_column
+test: uao/create_index_allows_readonly_column
 
 # this case contains fault injection, must be put in a separate test group
 test: terminate_in_gang_creation

--- a/src/test/isolation2/output/uao/create_index_allows_readonly.source
+++ b/src/test/isolation2/output/uao/create_index_allows_readonly.source
@@ -1,0 +1,94 @@
+-- This is intended to verify read-only transactions is able to run
+-- concurently with index creation.
+
+set default_table_access_method=@amname@;
+SET
+
+create table @amname@_create_index_with_select_tbl(a int, b int);
+CREATE
+insert into @amname@_create_index_with_select_tbl select a,a from generate_series(1,10) a;
+INSERT 10
+
+-- Verify readonly transaction is able to run concurrently with index creation.
+
+1: begin;
+BEGIN
+1: select * from @amname@_create_index_with_select_tbl where a = 2;
+ a | b 
+---+---
+ 2 | 2 
+(1 row)
+
+2: begin;
+BEGIN
+-- expect no hang
+2: create index @amname@_create_index_with_select_idx on @amname@_create_index_with_select_tbl(a);
+CREATE
+-- expect no hang
+3: select * from @amname@_create_index_with_select_tbl where a = 2;
+ a | b 
+---+---
+ 2 | 2 
+(1 row)
+
+1: end;
+END
+2: end;
+END
+
+-- Verify behaviors of select with locking clause (i.e. select for update)
+-- when running concurrently with index creation, expect blocking with each other.
+-- This is only for AO/CO tables, for Heap tables, refer to lockmodes.sql.
+
+drop index @amname@_create_index_with_select_idx;
+DROP
+
+1: begin;
+BEGIN
+1: select * from @amname@_create_index_with_select_tbl where a = 2 for update;
+ a | b 
+---+---
+ 2 | 2 
+(1 row)
+
+2: begin;
+BEGIN
+-- expect blocking
+2&: create index @amname@_create_index_with_select_idx on @amname@_create_index_with_select_tbl(a);  <waiting ...>
+
+1: commit;
+COMMIT
+
+2<:  <... completed>
+CREATE
+2: commit;
+COMMIT
+
+drop index @amname@_create_index_with_select_idx;
+DROP
+
+2: begin;
+BEGIN
+2: create index @amname@_create_index_with_select_idx on @amname@_create_index_with_select_tbl(a);
+CREATE
+
+1: begin;
+BEGIN
+-- expect blocking
+1&: select * from @amname@_create_index_with_select_tbl where a = 2 for update;  <waiting ...>
+
+2: commit;
+COMMIT
+
+1<:  <... completed>
+ a | b 
+---+---
+ 2 | 2 
+(1 row)
+1: commit;
+COMMIT
+
+drop table @amname@_create_index_with_select_tbl;
+DROP
+reset default_table_access_method;
+RESET


### PR DESCRIPTION
…y transactions

Previously, CREATE INDEX could hang if there was a pre-existing read-only transaction accessing to the same AO/CO table. This is because index creation on AO/CO table requires acquiring AccessExclusiveLock which could be blocked by existing readers holding the shared lock.

This patch is to allow index creation on AO/CO working concurrently with read-only transactions, replace AccessExclusiveLock with ShareRowExclusiveLock to avoid blocking each other.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
