### PR TITLE
Fix gpload regress case failure when OS user is not gpadmin

### DIFF
--- a/gpMgmt/bin/gpload_test/gpload2/TEST_local_config.py
+++ b/gpMgmt/bin/gpload_test/gpload2/TEST_local_config.py
@@ -38,7 +38,7 @@ def test_49_gpload_config_wrong_d():
     copy_data('external_file_01.txt', 'data_file.txt')
     write_config_file(database="", format='text',file='data_file.txt',table='texttable')
 
-@prepare_before_test(num=50, cmd="-U gpadmin")
+@prepare_before_test(num=50, cmd="-U "+str(PGUSER))
 def test_50_gpload_config_U():
     "50 gpload command config test -U username"
     copy_data('external_file_01.txt', 'data_file.txt')


### PR DESCRIPTION
If OS user that installed gpdb cluster is not gpadmin, gpload regression case#50 would be fail since it specified a hard code user gpadmin. To fix it, we need to use PGUSER instead.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
