### PR TITLE
Fix EPQ for DML operations

### DIFF
--- a/src/backend/gpopt/translate/CContextDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CContextDXLToPlStmt.cpp
@@ -64,6 +64,7 @@ CContextDXLToPlStmt::CContextDXLToPlStmt(
 	m_cte_consumer_info = GPOS_NEW(m_mp) HMUlCTEConsumerInfo(m_mp);
 	m_num_partition_selectors_array = GPOS_NEW(m_mp) ULongPtrArray(m_mp);
 	m_part_selector_to_param_map = GPOS_NEW(m_mp) UlongToUlongMap(m_mp);
+	m_used_rte_indexes = GPOS_NEW(m_mp) HMUlIndex(m_mp);
 }
 
 //---------------------------------------------------------------------------
@@ -79,6 +80,7 @@ CContextDXLToPlStmt::~CContextDXLToPlStmt()
 	m_cte_consumer_info->Release();
 	m_num_partition_selectors_array->Release();
 	m_part_selector_to_param_map->Release();
+	m_used_rte_indexes->Release();
 }
 
 //---------------------------------------------------------------------------

--- a/src/backend/gpopt/translate/CContextDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CContextDXLToPlStmt.cpp
@@ -625,7 +625,7 @@ CContextDXLToPlStmt::GetRTEIndexByTableDescr(const CDXLTableDescr *table_descr,
 	Index *usedIndex =
 		m_used_rte_indexes->Find(&assigned_query_id_for_target_rel);
 
-	//	`usedIndex` is a non zero value in next case: table descriptor with
+	//	`usedIndex` is a non NULL value in next case: table descriptor with
 	//	the same `assigned_query_id_for_target_rel` was processed previously
 	//	(so no need to create a new index for result relation like the relation
 	//	itself)

--- a/src/backend/gpopt/translate/CContextDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CContextDXLToPlStmt.cpp
@@ -588,28 +588,58 @@ CContextDXLToPlStmt::GetRTEByIndex(Index index)
 //		rte was processed.
 //		In case of DML operations there is more than one table descr pointing
 //		to the result relation and to detect position of already processed rte
-//		assigned_queiry_id of table descriptor is used.
+//		`assigned_query_id_for_target_rel` of table descriptor is used.
 //---------------------------------------------------------------------------
 Index
 CContextDXLToPlStmt::GetRTEIndexByTableDescr(const CDXLTableDescr *table_descr,
 											 BOOL *is_rte_exists)
 {
 	*is_rte_exists = false;
-	ULONG assigned_query_id = table_descr->GetAssignedQueryId();
-	if (assigned_query_id == UNASSIGNED_QUERYID)
+
+	//	`assigned_query_id_for_target_rel` is a "tag" of table descriptors, it
+	//	shows id of query structure which contains result relation. If table
+	//	descriptors have the same `assigned_query_id_for_target_rel` - these
+	//	table descriptors point to the same result relation in `ModifyTable`
+	//	operation. It's not zero (0) value (which equal to `UNASSIGNED_QUERYID`
+	//	define) if: user query is a INSERT/UPDATE/DELETE (`ModifyTable`
+	//	operation) and this table descriptor points to the result relation of
+	//	operation, for ex.:
+	//	```sql
+	//	create table b (i int, j int);
+	//	create table c (i int);
+	//	insert into b(i,j) values (1,2), (2,3), (3,4);
+	//	insert into c(i) values (1), (2);
+	//	delete from b where i in (select i from c);
+	//	```
+	//	where `b` is a result relation (table descriptors pointing to it
+	//	will have the same `assigned_query_id_for_target_rel` > 0), and
+	//	`c` is not (all table descriptors which points to `c` will have
+	//	`assigned_query_id_for_target_rel`=0 (equal to `UNASSIGNED_QUERYID`)
+	ULONG assigned_query_id_for_target_rel =
+		table_descr->GetAssignedQueryIdForTargetRel();
+	if (assigned_query_id_for_target_rel == UNASSIGNED_QUERYID)
 	{
 		return gpdb::ListLength(m_rtable_entries_list) + 1;
 	}
 
-	Index *usedIndex = m_used_rte_indexes->Find(&assigned_query_id);
+	Index *usedIndex =
+		m_used_rte_indexes->Find(&assigned_query_id_for_target_rel);
+
+	//	`usedIndex` is a non zero value in next case: table descriptor with
+	//	the same `assigned_query_id_for_target_rel` was processed previously
+	//	(so no need to create a new index for result relation like the relation
+	//	itself)
 	if (usedIndex)
 	{
 		*is_rte_exists = true;
 		return *usedIndex;
 	}
 
+	//	`assigned_query_id_for_target_rel` of table descriptor which points to
+	//	result relation wasn't previously processed - create a new index.
 	Index new_index = gpdb::ListLength(m_rtable_entries_list) + 1;
-	m_used_rte_indexes->Insert(GPOS_NEW(m_mp) ULONG(assigned_query_id),
+	m_used_rte_indexes->Insert(GPOS_NEW(m_mp)
+								   ULONG(assigned_query_id_for_target_rel),
 							   GPOS_NEW(m_mp) Index(new_index));
 
 	return new_index;

--- a/src/backend/gpopt/translate/CContextQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CContextQueryToDXL.cpp
@@ -29,11 +29,19 @@ CContextQueryToDXL::CContextQueryToDXL(CMemoryPool *mp)
 {
 	// map that stores gpdb att to optimizer col mapping
 	m_colid_counter = GPOS_NEW(mp) CIdGenerator(GPDXL_COL_ID_START);
+	m_queryid_counter = GPOS_NEW(mp) CIdGenerator(GPDXL_QUERY_ID_START);
 	m_cte_id_counter = GPOS_NEW(mp) CIdGenerator(GPDXL_CTE_ID_START);
 }
 
 CContextQueryToDXL::~CContextQueryToDXL()
 {
+	GPOS_DELETE(m_queryid_counter);
 	GPOS_DELETE(m_colid_counter);
 	GPOS_DELETE(m_cte_id_counter);
+}
+
+ULONG
+CContextQueryToDXL::GetNextQueryId()
+{
+	return m_queryid_counter->next_id();
 }

--- a/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
@@ -3344,20 +3344,20 @@ CTranslatorQueryToDXL::TranslateRTEToDXLLogicalGet(const RangeTblEntry *rte,
 				   GPOS_WSZ_LIT("ONLY in the FROM clause"));
 	}
 
-	// table_desc_query_id is used to tag table descriptors assigned to target
+	// query_id_for_target_rel is used to tag table descriptors assigned to target
 	// (result) relations one. In case of possible nested DML subqueries it's
 	// field points to target relation of corresponding Query structure of subquery.
-	BOOL table_desc_query_id = UNASSIGNED_QUERYID;
+	ULONG query_id_for_target_rel = UNASSIGNED_QUERYID;
 	if (m_query->resultRelation > 0 &&
 		ULONG(m_query->resultRelation) == rt_index)
 	{
-		table_desc_query_id = m_query_id;
+		query_id_for_target_rel = m_query_id;
 	}
 
 	// construct table descriptor for the scan node from the range table entry
 	CDXLTableDescr *dxl_table_descr = CTranslatorUtils::GetTableDescr(
 		m_mp, m_md_accessor, m_context->m_colid_counter, rte,
-		table_desc_query_id, &m_context->m_has_distributed_tables);
+		query_id_for_target_rel, &m_context->m_has_distributed_tables);
 
 	CDXLLogicalGet *dxl_op = nullptr;
 	const IMDRelation *md_rel =

--- a/src/backend/gpopt/translate/CTranslatorUtils.cpp
+++ b/src/backend/gpopt/translate/CTranslatorUtils.cpp
@@ -113,13 +113,12 @@ CTranslatorUtils::GetIndexDescr(CMemoryPool *mp, CMDAccessor *md_accessor,
 CDXLTableDescr *
 CTranslatorUtils::GetTableDescr(CMemoryPool *mp, CMDAccessor *md_accessor,
 								CIdGenerator *id_generator,
-								const RangeTblEntry *rte,
+								const RangeTblEntry *rte, BOOL is_result_rel,
 								BOOL *is_distributed_table,	 // output
-								ULONG assigned_query_id)
+								ULONG query_id)
 {
 	// generate an MDId for the table desc.
 	OID rel_oid = rte->relid;
-
 #if 0
 	if (gpdb::HasExternalPartition(rel_oid))
 	{
@@ -137,6 +136,10 @@ CTranslatorUtils::GetTableDescr(CMemoryPool *mp, CMDAccessor *md_accessor,
 	const CWStringConst *tablename = rel->Mdname().GetMDName();
 	CMDName *table_mdname = GPOS_NEW(mp) CMDName(mp, tablename);
 
+	// assigned_query_id field is used to tag relations assigned to target one.
+	// In case of possible nested DML subqueries this field points to target
+	// relation of corresponding Query structure of subquery.
+	ULONG assigned_query_id = is_result_rel ? query_id : UNASSIGNED_QUERYID;
 	CDXLTableDescr *table_descr =
 		GPOS_NEW(mp) CDXLTableDescr(mp, mdid, table_mdname, rte->checkAsUser,
 									rte->rellockmode, assigned_query_id);

--- a/src/backend/gpopt/translate/CTranslatorUtils.cpp
+++ b/src/backend/gpopt/translate/CTranslatorUtils.cpp
@@ -114,8 +114,8 @@ CDXLTableDescr *
 CTranslatorUtils::GetTableDescr(CMemoryPool *mp, CMDAccessor *md_accessor,
 								CIdGenerator *id_generator,
 								const RangeTblEntry *rte,
-								BOOL *is_distributed_table	// output
-)
+								BOOL *is_distributed_table,	 // output
+								ULONG assigned_query_id)
 {
 	// generate an MDId for the table desc.
 	OID rel_oid = rte->relid;
@@ -137,8 +137,9 @@ CTranslatorUtils::GetTableDescr(CMemoryPool *mp, CMDAccessor *md_accessor,
 	const CWStringConst *tablename = rel->Mdname().GetMDName();
 	CMDName *table_mdname = GPOS_NEW(mp) CMDName(mp, tablename);
 
-	CDXLTableDescr *table_descr = GPOS_NEW(mp) CDXLTableDescr(
-		mp, mdid, table_mdname, rte->checkAsUser, rte->rellockmode);
+	CDXLTableDescr *table_descr =
+		GPOS_NEW(mp) CDXLTableDescr(mp, mdid, table_mdname, rte->checkAsUser,
+									rte->rellockmode, assigned_query_id);
 
 	const ULONG len = rel->ColumnCount();
 

--- a/src/backend/gpopt/translate/CTranslatorUtils.cpp
+++ b/src/backend/gpopt/translate/CTranslatorUtils.cpp
@@ -114,12 +114,13 @@ CDXLTableDescr *
 CTranslatorUtils::GetTableDescr(CMemoryPool *mp, CMDAccessor *md_accessor,
 								CIdGenerator *id_generator,
 								const RangeTblEntry *rte,
-								ULONG assigned_query_id,
+								ULONG assigned_query_id_for_target_rel,
 								BOOL *is_distributed_table	// output
 )
 {
 	// generate an MDId for the table desc.
 	OID rel_oid = rte->relid;
+
 #if 0
 	if (gpdb::HasExternalPartition(rel_oid))
 	{
@@ -137,9 +138,9 @@ CTranslatorUtils::GetTableDescr(CMemoryPool *mp, CMDAccessor *md_accessor,
 	const CWStringConst *tablename = rel->Mdname().GetMDName();
 	CMDName *table_mdname = GPOS_NEW(mp) CMDName(mp, tablename);
 
-	CDXLTableDescr *table_descr =
-		GPOS_NEW(mp) CDXLTableDescr(mp, mdid, table_mdname, rte->checkAsUser,
-									rte->rellockmode, assigned_query_id);
+	CDXLTableDescr *table_descr = GPOS_NEW(mp)
+		CDXLTableDescr(mp, mdid, table_mdname, rte->checkAsUser,
+					   rte->rellockmode, assigned_query_id_for_target_rel);
 
 	const ULONG len = rel->ColumnCount();
 

--- a/src/backend/gpopt/translate/CTranslatorUtils.cpp
+++ b/src/backend/gpopt/translate/CTranslatorUtils.cpp
@@ -113,9 +113,10 @@ CTranslatorUtils::GetIndexDescr(CMemoryPool *mp, CMDAccessor *md_accessor,
 CDXLTableDescr *
 CTranslatorUtils::GetTableDescr(CMemoryPool *mp, CMDAccessor *md_accessor,
 								CIdGenerator *id_generator,
-								const RangeTblEntry *rte, BOOL is_result_rel,
-								BOOL *is_distributed_table,	 // output
-								ULONG query_id)
+								const RangeTblEntry *rte,
+								ULONG assigned_query_id,
+								BOOL *is_distributed_table	// output
+)
 {
 	// generate an MDId for the table desc.
 	OID rel_oid = rte->relid;
@@ -136,10 +137,6 @@ CTranslatorUtils::GetTableDescr(CMemoryPool *mp, CMDAccessor *md_accessor,
 	const CWStringConst *tablename = rel->Mdname().GetMDName();
 	CMDName *table_mdname = GPOS_NEW(mp) CMDName(mp, tablename);
 
-	// assigned_query_id field is used to tag relations assigned to target one.
-	// In case of possible nested DML subqueries this field points to target
-	// relation of corresponding Query structure of subquery.
-	ULONG assigned_query_id = is_result_rel ? query_id : UNASSIGNED_QUERYID;
 	CDXLTableDescr *table_descr =
 		GPOS_NEW(mp) CDXLTableDescr(mp, mdid, table_mdname, rte->checkAsUser,
 									rte->rellockmode, assigned_query_id);

--- a/src/backend/gporca/data/dxl/minidump/Delete-Check-AssignedQueryIdForTargetRel.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Delete-Check-AssignedQueryIdForTargetRel.mdp
@@ -1,0 +1,458 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Comment><![CDATA[
+    Test case: Simple delete from table. Expect AssignedQueryIdForTargetRel exists at
+               table descriptor, which points to result (target) relation
+
+  create table test as select 0 as i distributed randomly;
+  delete from test where i in (select i from test where i > 10);
+
+ 	Physical plan:
+
+   	                                         QUERY PLAN                                             
+	---------------------------------------------------------------------------------------------------
+	 Delete on test  (cost=0.00..862.02 rows=1 width=1)
+	   ->  Hash Semi Join  (cost=0.00..862.00 rows=1 width=14)
+	         Hash Cond: (test.i = test_1.i)
+	         ->  Seq Scan on test  (cost=0.00..431.00 rows=1 width=14)
+	         ->  Hash  (cost=431.00..431.00 rows=3 width=4)
+	               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=3 width=4)
+	                     ->  Seq Scan on test test_1  (cost=0.00..431.00 rows=1 width=4)
+	                           Filter: (i > 10)
+	 Optimizer: Pivotal Optimizer (GPORCA)
+	(9 rows)
+  ]]>
+  </dxl:Comment>
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="20" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0" SkewFactor="0"/>
+      <dxl:TraceFlags Value="101013,102001,102002,102003,102043,102074,102120,102144,103001,103014,103022,103026,103027,103029,103033,103038,103040,104002,104003,104004,104005,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:GPDBScalarOp Mdid="0.521.1.0" Name="&gt;" ComparisonType="GT" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.147.1.0"/>
+        <dxl:Commutator Mdid="0.97.1.0"/>
+        <dxl:InverseOp Mdid="0.523.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.20.1.0" Name="Int8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.410.1.0"/>
+        <dxl:InequalityOp Mdid="0.411.1.0"/>
+        <dxl:LessThanOp Mdid="0.412.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.414.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.413.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.415.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1016.1.0"/>
+        <dxl:MinAgg Mdid="0.2131.1.0"/>
+        <dxl:MaxAgg Mdid="0.2115.1.0"/>
+        <dxl:AvgAgg Mdid="0.2100.1.0"/>
+        <dxl:SumAgg Mdid="0.2107.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.16384.1.0.0" Name="i" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:GPDBScalarOp Mdid="0.410.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.20.1.0"/>
+        <dxl:RightType Mdid="0.20.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.467.1.0"/>
+        <dxl:Commutator Mdid="0.410.1.0"/>
+        <dxl:InverseOp Mdid="0.411.1.0"/>
+        <dxl:HashOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7100.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.1977.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.7100.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2134.1.0"/>
+        <dxl:MaxAgg Mdid="0.2118.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.2227.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:GPDBScalarOp Mdid="0.413.1.0" Name="&gt;" ComparisonType="GT" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.20.1.0"/>
+        <dxl:RightType Mdid="0.20.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.470.1.0"/>
+        <dxl:Commutator Mdid="0.412.1.0"/>
+        <dxl:InverseOp Mdid="0.414.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.3315.1.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:RelationStatistics Mdid="2.16384.1.0" Name="test" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
+      <dxl:Relation Mdid="6.16384.1.0" Name="test" IsTemporary="false" StorageType="Heap" DistributionPolicy="Random" Keys="7,1" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="i" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:CheckConstraints/>
+      </dxl:Relation>
+      <dxl:GPDBAgg Mdid="0.2108.1.0" Name="sum" IsSplittable="true" HashAggCapable="true">
+        <dxl:ResultType Mdid="0.20.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.20.1.0"/>
+      </dxl:GPDBAgg>
+      <dxl:RelationExtendedStatistics Mdid="10.16384.1.0" Name="test"/>
+      <dxl:MDCast Mdid="3.23.1.0;23.1.0" Name="int4" BinaryCoercible="true" SourceTypeId="0.23.1.0" DestinationTypeId="0.23.1.0" CastFuncId="0.0.0.0" CoercePathType="0"/>
+      <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.65.1.0"/>
+        <dxl:Commutator Mdid="0.96.1.0"/>
+        <dxl:InverseOp Mdid="0.518.1.0"/>
+        <dxl:HashOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7100.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.1977.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.7100.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:GPDBAgg Mdid="0.2803.1.0" Name="count" IsSplittable="true" HashAggCapable="true">
+        <dxl:ResultType Mdid="0.20.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.20.1.0"/>
+      </dxl:GPDBAgg>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns/>
+      <dxl:CTEList/>
+      <dxl:LogicalDelete DeleteColumns="1" CtidCol="2" SegmentIdCol="8">
+        <dxl:TableDescriptor Mdid="6.16384.1.0" TableName="test" LockMode="7" AssignedQueryIdForTargetRel="1">
+          <dxl:Columns>
+            <dxl:Column ColId="17" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="18" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+            <dxl:Column ColId="19" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="20" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="21" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="22" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="23" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+            <dxl:Column ColId="24" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+          </dxl:Columns>
+        </dxl:TableDescriptor>
+        <dxl:LogicalSelect>
+          <dxl:SubqueryAny OperatorName="=" OperatorMdid="0.96.1.0" ColId="9">
+            <dxl:Ident ColId="1" ColName="i" TypeMdid="0.23.1.0"/>
+            <dxl:LogicalSelect>
+              <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
+                <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
+              </dxl:Comparison>
+              <dxl:LogicalGet>
+                <dxl:TableDescriptor Mdid="6.16384.1.0" TableName="test" LockMode="1">
+                  <dxl:Columns>
+                    <dxl:Column ColId="9" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="10" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                    <dxl:Column ColId="11" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="12" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="13" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="14" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="15" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="16" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:LogicalGet>
+            </dxl:LogicalSelect>
+          </dxl:SubqueryAny>
+          <dxl:LogicalGet>
+            <dxl:TableDescriptor Mdid="6.16384.1.0" TableName="test" LockMode="7" AssignedQueryIdForTargetRel="1">
+              <dxl:Columns>
+                <dxl:Column ColId="1" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="3" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="4" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="5" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="6" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="7" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="8" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:LogicalGet>
+        </dxl:LogicalSelect>
+      </dxl:LogicalDelete>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="150">
+      <dxl:DMLDelete Columns="0" ActionCol="20" CtidCol="1" SegmentIdCol="7">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="862.023818" Rows="1.000000" Width="1"/>
+        </dxl:Properties>
+        <dxl:DirectDispatchInfo/>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="0" Alias="i">
+            <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:TableDescriptor Mdid="6.16384.1.0" TableName="test" LockMode="7" AssignedQueryIdForTargetRel="1">
+          <dxl:Columns>
+            <dxl:Column ColId="21" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="22" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+            <dxl:Column ColId="23" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="24" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="25" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="26" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="27" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+            <dxl:Column ColId="28" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+          </dxl:Columns>
+        </dxl:TableDescriptor>
+        <dxl:Result>
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="862.000380" Rows="1.000000" Width="18"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="0" Alias="i">
+              <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="1" Alias="ctid">
+              <dxl:Ident ColId="1" ColName="ctid" TypeMdid="0.27.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="7" Alias="gp_segment_id">
+              <dxl:Ident ColId="7" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="20" Alias="ColRef_0020">
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:OneTimeFilter/>
+          <dxl:HashJoin JoinType="In">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="862.000374" Rows="1.000000" Width="14"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="0" Alias="i">
+                <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="1" Alias="ctid">
+                <dxl:Ident ColId="1" ColName="ctid" TypeMdid="0.27.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="7" Alias="gp_segment_id">
+                <dxl:Ident ColId="7" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:JoinFilter/>
+            <dxl:HashCondList>
+              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+                <dxl:Ident ColId="8" ColName="i" TypeMdid="0.23.1.0"/>
+              </dxl:Comparison>
+            </dxl:HashCondList>
+            <dxl:TableScan>
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.000006" Rows="1.000000" Width="14"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="0" Alias="i">
+                  <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="1" Alias="ctid">
+                  <dxl:Ident ColId="1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="7" Alias="gp_segment_id">
+                  <dxl:Ident ColId="7" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:TableDescriptor Mdid="6.16384.1.0" TableName="test" LockMode="7" AssignedQueryIdForTargetRel="1">
+                <dxl:Columns>
+                  <dxl:Column ColId="0" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="1" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                  <dxl:Column ColId="2" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="3" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="4" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="5" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="6" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="7" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:TableScan>
+            <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.000091" Rows="3.000000" Width="4"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="8" Alias="i">
+                  <dxl:Ident ColId="8" ColName="i" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:SortingColumnList/>
+              <dxl:TableScan>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000020" Rows="1.000000" Width="4"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="8" Alias="i">
+                    <dxl:Ident ColId="8" ColName="i" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter>
+                  <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
+                    <dxl:Ident ColId="8" ColName="i" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
+                  </dxl:Comparison>
+                </dxl:Filter>
+                <dxl:TableDescriptor Mdid="6.16384.1.0" TableName="test" LockMode="1">
+                  <dxl:Columns>
+                    <dxl:Column ColId="8" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="9" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                    <dxl:Column ColId="10" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="11" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="12" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="13" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="14" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="15" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:TableScan>
+            </dxl:BroadcastMotion>
+          </dxl:HashJoin>
+        </dxl:Result>
+      </dxl:DMLDelete>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/libgpopt/include/gpopt/metadata/CTableDescriptor.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/metadata/CTableDescriptor.h
@@ -90,8 +90,9 @@ private:
 
 	// identifier of query to which current table belongs.
 	// This field is used for assigning current table entry with
-	// target one within DML operation
-	ULONG m_assigned_query_id;
+	// target one within DML operation. If descriptor doesn't point
+	// to the target (result) relation it has value UNASSIGNED_QUERYID
+	ULONG m_assigned_query_id_for_target_rel;
 
 public:
 	CTableDescriptor(const CTableDescriptor &) = delete;
@@ -102,7 +103,7 @@ public:
 					 IMDRelation::Ereldistrpolicy rel_distr_policy,
 					 IMDRelation::Erelstoragetype erelstoragetype,
 					 ULONG ulExecuteAsUser, INT lockmode,
-					 ULONG assigned_query_id);
+					 ULONG assigned_query_id_for_target_rel);
 
 	// dtor
 	~CTableDescriptor() override;
@@ -238,9 +239,9 @@ public:
 	}
 
 	ULONG
-	GetAssignedQueryId() const
+	GetAssignedQueryIdForTargetRel() const
 	{
-		return m_assigned_query_id;
+		return m_assigned_query_id_for_target_rel;
 	}
 
 };	// class CTableDescriptor

--- a/src/backend/gporca/libgpopt/include/gpopt/metadata/CTableDescriptor.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/metadata/CTableDescriptor.h
@@ -88,6 +88,11 @@ private:
 	// lockmode from the parser
 	INT m_lockmode;
 
+	// identifier of query to which current table belongs.
+	// This field is used for assigning current table entry with
+	// target one within DML operation
+	ULONG m_assigned_query_id;
+
 public:
 	CTableDescriptor(const CTableDescriptor &) = delete;
 
@@ -96,7 +101,8 @@ public:
 					 BOOL convert_hash_to_random,
 					 IMDRelation::Ereldistrpolicy rel_distr_policy,
 					 IMDRelation::Erelstoragetype erelstoragetype,
-					 ULONG ulExecuteAsUser, INT lockmode);
+					 ULONG ulExecuteAsUser, INT lockmode,
+					 ULONG assigned_query_id);
 
 	// dtor
 	~CTableDescriptor() override;
@@ -229,6 +235,12 @@ public:
 	{
 		return m_erelstoragetype == IMDRelation::ErelstorageAppendOnlyCols ||
 			   m_erelstoragetype == IMDRelation::ErelstorageAppendOnlyRows;
+	}
+
+	ULONG
+	GetAssignedQueryId() const
+	{
+		return m_assigned_query_id;
 	}
 
 };	// class CTableDescriptor

--- a/src/backend/gporca/libgpopt/src/metadata/CTableDescriptor.cpp
+++ b/src/backend/gporca/libgpopt/src/metadata/CTableDescriptor.cpp
@@ -38,7 +38,7 @@ CTableDescriptor::CTableDescriptor(
 	CMemoryPool *mp, IMDId *mdid, const CName &name,
 	BOOL convert_hash_to_random, IMDRelation::Ereldistrpolicy rel_distr_policy,
 	IMDRelation::Erelstoragetype erelstoragetype, ULONG ulExecuteAsUser,
-	INT lockmode, ULONG assigned_query_id)
+	INT lockmode, ULONG assigned_query_id_for_target_rel)
 	: m_mp(mp),
 	  m_mdid(mdid),
 	  m_name(mp, name),
@@ -52,7 +52,7 @@ CTableDescriptor::CTableDescriptor(
 	  m_pdrgpbsKeys(nullptr),
 	  m_execute_as_user_id(ulExecuteAsUser),
 	  m_lockmode(lockmode),
-	  m_assigned_query_id(assigned_query_id)
+	  m_assigned_query_id_for_target_rel(assigned_query_id_for_target_rel)
 {
 	GPOS_ASSERT(nullptr != mp);
 	GPOS_ASSERT(mdid->IsValid());

--- a/src/backend/gporca/libgpopt/src/metadata/CTableDescriptor.cpp
+++ b/src/backend/gporca/libgpopt/src/metadata/CTableDescriptor.cpp
@@ -38,7 +38,7 @@ CTableDescriptor::CTableDescriptor(
 	CMemoryPool *mp, IMDId *mdid, const CName &name,
 	BOOL convert_hash_to_random, IMDRelation::Ereldistrpolicy rel_distr_policy,
 	IMDRelation::Erelstoragetype erelstoragetype, ULONG ulExecuteAsUser,
-	INT lockmode)
+	INT lockmode, ULONG assigned_query_id)
 	: m_mp(mp),
 	  m_mdid(mdid),
 	  m_name(mp, name),
@@ -51,7 +51,8 @@ CTableDescriptor::CTableDescriptor(
 	  m_pdrgpulPart(nullptr),
 	  m_pdrgpbsKeys(nullptr),
 	  m_execute_as_user_id(ulExecuteAsUser),
-	  m_lockmode(lockmode)
+	  m_lockmode(lockmode),
+	  m_assigned_query_id(assigned_query_id)
 {
 	GPOS_ASSERT(nullptr != mp);
 	GPOS_ASSERT(mdid->IsValid());

--- a/src/backend/gporca/libgpopt/src/translate/CTranslatorDXLToExpr.cpp
+++ b/src/backend/gporca/libgpopt/src/translate/CTranslatorDXLToExpr.cpp
@@ -2120,7 +2120,7 @@ CTranslatorDXLToExpr::Ptabdesc(CDXLTableDescr *table_descr)
 	CTableDescriptor *ptabdesc = GPOS_NEW(m_mp) CTableDescriptor(
 		m_mp, mdid, CName(m_mp, &strName), pmdrel->ConvertHashToRandom(),
 		rel_distr_policy, rel_storage_type, table_descr->GetExecuteAsUserId(),
-		table_descr->LockMode());
+		table_descr->LockMode(), table_descr->GetAssignedQueryId());
 
 	const ULONG ulColumns = table_descr->Arity();
 	for (ULONG ul = 0; ul < ulColumns; ul++)
@@ -2318,9 +2318,9 @@ CTranslatorDXLToExpr::PtabdescFromCTAS(CDXLLogicalCTAS *pdxlopCTAS)
 	CTableDescriptor *ptabdesc = GPOS_NEW(m_mp) CTableDescriptor(
 		m_mp, mdid, CName(m_mp, &strName), pmdrel->ConvertHashToRandom(),
 		rel_distr_policy, rel_storage_type,
-		0,	// TODO:  - Mar 5, 2014; ulExecuteAsUser
-		-1	// GPDB_12_MERGE_FIXME: Extract the lockmode from CTE
-	);
+		0,	 // TODO:  - Mar 5, 2014; ulExecuteAsUser
+		-1,	 // GPDB_12_MERGE_FIXME: Extract the lockmode from CTE
+		UNASSIGNED_QUERYID);
 
 	// populate column information from the dxl table descriptor
 	CDXLColDescrArray *dxl_col_descr_array =

--- a/src/backend/gporca/libgpopt/src/translate/CTranslatorDXLToExpr.cpp
+++ b/src/backend/gporca/libgpopt/src/translate/CTranslatorDXLToExpr.cpp
@@ -2120,7 +2120,7 @@ CTranslatorDXLToExpr::Ptabdesc(CDXLTableDescr *table_descr)
 	CTableDescriptor *ptabdesc = GPOS_NEW(m_mp) CTableDescriptor(
 		m_mp, mdid, CName(m_mp, &strName), pmdrel->ConvertHashToRandom(),
 		rel_distr_policy, rel_storage_type, table_descr->GetExecuteAsUserId(),
-		table_descr->LockMode(), table_descr->GetAssignedQueryId());
+		table_descr->LockMode(), table_descr->GetAssignedQueryIdForTargetRel());
 
 	const ULONG ulColumns = table_descr->Arity();
 	for (ULONG ul = 0; ul < ulColumns; ul++)

--- a/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
+++ b/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
@@ -1250,7 +1250,8 @@ CTranslatorExprToDXL::MakeTableDescForPart(const IMDRelation *part,
 		m_mp, part_mdid, part->Mdname().GetMDName(),
 		part->ConvertHashToRandom(), part->GetRelDistribution(),
 		part->RetrieveRelStorageType(), root_table_desc->GetExecuteAsUserId(),
-		root_table_desc->LockMode(), root_table_desc->GetAssignedQueryId());
+		root_table_desc->LockMode(),
+		root_table_desc->GetAssignedQueryIdForTargetRel());
 
 	for (ULONG ul = 0; ul < part->ColumnCount(); ++ul)
 	{
@@ -6580,9 +6581,9 @@ CTranslatorExprToDXL::MakeDXLTableDescr(
 	CMDIdGPDB *mdid = CMDIdGPDB::CastMdid(ptabdesc->MDId());
 	mdid->AddRef();
 
-	CDXLTableDescr *table_descr = GPOS_NEW(m_mp)
-		CDXLTableDescr(m_mp, mdid, pmdnameTbl, ptabdesc->GetExecuteAsUserId(),
-					   ptabdesc->LockMode(), ptabdesc->GetAssignedQueryId());
+	CDXLTableDescr *table_descr = GPOS_NEW(m_mp) CDXLTableDescr(
+		m_mp, mdid, pmdnameTbl, ptabdesc->GetExecuteAsUserId(),
+		ptabdesc->LockMode(), ptabdesc->GetAssignedQueryIdForTargetRel());
 
 	const ULONG ulColumns = ptabdesc->ColumnCount();
 	// translate col descriptors

--- a/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
+++ b/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
@@ -1250,7 +1250,7 @@ CTranslatorExprToDXL::MakeTableDescForPart(const IMDRelation *part,
 		m_mp, part_mdid, part->Mdname().GetMDName(),
 		part->ConvertHashToRandom(), part->GetRelDistribution(),
 		part->RetrieveRelStorageType(), root_table_desc->GetExecuteAsUserId(),
-		root_table_desc->LockMode());
+		root_table_desc->LockMode(), root_table_desc->GetAssignedQueryId());
 
 	for (ULONG ul = 0; ul < part->ColumnCount(); ++ul)
 	{
@@ -6582,7 +6582,7 @@ CTranslatorExprToDXL::MakeDXLTableDescr(
 
 	CDXLTableDescr *table_descr = GPOS_NEW(m_mp)
 		CDXLTableDescr(m_mp, mdid, pmdnameTbl, ptabdesc->GetExecuteAsUserId(),
-					   ptabdesc->LockMode());
+					   ptabdesc->LockMode(), ptabdesc->GetAssignedQueryId());
 
 	const ULONG ulColumns = ptabdesc->ColumnCount();
 	// translate col descriptors

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLTableDescr.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLTableDescr.h
@@ -20,7 +20,7 @@
 #include "naucrates/md/CMDName.h"
 #include "naucrates/md/IMDId.h"
 
-// default value for m_assigned_query_id - no assigned query for table descriptor
+// default value for m_assigned_query_id_for_target_rel - no assigned query for table descriptor
 #define UNASSIGNED_QUERYID 0
 
 namespace gpdxl
@@ -55,8 +55,9 @@ private:
 
 	// identifier of query to which current table belongs.
 	// This field is used for assigning current table entry with
-	// target one within DML operation
-	ULONG m_assigned_query_id;
+	// target one within DML operation. If descriptor doesn't point
+	// to the target (result) relation it has value UNASSIGNED_QUERYID
+	ULONG m_assigned_query_id_for_target_rel;
 
 	void SerializeMDId(CXMLSerializer *xml_serializer) const;
 
@@ -66,7 +67,7 @@ public:
 	// ctor/dtor
 	CDXLTableDescr(CMemoryPool *mp, IMDId *mdid, CMDName *mdname,
 				   ULONG ulExecuteAsUser, int lockmode,
-				   ULONG assigned_query_id = UNASSIGNED_QUERYID);
+				   ULONG assigned_query_id_for_target_rel = UNASSIGNED_QUERYID);
 
 	~CDXLTableDescr() override;
 
@@ -96,8 +97,8 @@ public:
 	// serialize to dxl format
 	void SerializeToDXL(CXMLSerializer *xml_serializer) const;
 
-	// assigned query id
-	ULONG GetAssignedQueryId() const;
+	// get assigned query id for target relation
+	ULONG GetAssignedQueryIdForTargetRel() const;
 };
 }  // namespace gpdxl
 

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLTableDescr.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLTableDescr.h
@@ -20,6 +20,9 @@
 #include "naucrates/md/CMDName.h"
 #include "naucrates/md/IMDId.h"
 
+// default value for m_assigned_query_id - no assigned query for table descriptor
+#define UNASSIGNED_QUERYID 0
+
 namespace gpdxl
 {
 using namespace gpmd;
@@ -50,6 +53,11 @@ private:
 	// lock mode from the parser
 	INT m_lockmode;
 
+	// identifier of query to which current table belongs.
+	// This field is used for assigning current table entry with
+	// target one within DML operation
+	ULONG m_assigned_query_id;
+
 	void SerializeMDId(CXMLSerializer *xml_serializer) const;
 
 public:
@@ -57,7 +65,8 @@ public:
 
 	// ctor/dtor
 	CDXLTableDescr(CMemoryPool *mp, IMDId *mdid, CMDName *mdname,
-				   ULONG ulExecuteAsUser, int lockmode);
+				   ULONG ulExecuteAsUser, int lockmode,
+				   ULONG assigned_query_id = UNASSIGNED_QUERYID);
 
 	~CDXLTableDescr() override;
 
@@ -86,6 +95,9 @@ public:
 
 	// serialize to dxl format
 	void SerializeToDXL(CXMLSerializer *xml_serializer) const;
+
+	// assigned query id
+	ULONG GetAssignedQueryId() const;
 };
 }  // namespace gpdxl
 

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/xml/dxltokens.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/xml/dxltokens.h
@@ -473,7 +473,7 @@ enum Edxltoken
 	EdxltokenIsNull,
 	EdxltokenLintValue,
 	EdxltokenDoubleValue,
-	EdxltokenAssignedQueryId,
+	EdxltokenAssignedQueryIdForTargetRel,
 
 	EdxltokenRelTemporary,
 

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/xml/dxltokens.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/xml/dxltokens.h
@@ -473,6 +473,7 @@ enum Edxltoken
 	EdxltokenIsNull,
 	EdxltokenLintValue,
 	EdxltokenDoubleValue,
+	EdxltokenAssignedQueryId,
 
 	EdxltokenRelTemporary,
 

--- a/src/backend/gporca/libnaucrates/src/operators/CDXLOperatorFactory.cpp
+++ b/src/backend/gporca/libnaucrates/src/operators/CDXLOperatorFactory.cpp
@@ -1535,7 +1535,12 @@ CDXLOperatorFactory::MakeDXLTableDescr(CDXLMemoryManager *dxl_memory_manager,
 			EdxltokenTableDescr);
 	}
 
-	return GPOS_NEW(mp) CDXLTableDescr(mp, mdid, mdname, user_id, lockmode);
+	ULONG assigned_query_id = ExtractConvertAttrValueToUlong(
+		dxl_memory_manager, attrs, EdxltokenAssignedQueryId,
+		EdxltokenTableDescr, true /* is_optional */, UNASSIGNED_QUERYID);
+
+	return GPOS_NEW(mp)
+		CDXLTableDescr(mp, mdid, mdname, user_id, lockmode, assigned_query_id);
 }
 
 //---------------------------------------------------------------------------

--- a/src/backend/gporca/libnaucrates/src/operators/CDXLOperatorFactory.cpp
+++ b/src/backend/gporca/libnaucrates/src/operators/CDXLOperatorFactory.cpp
@@ -1535,12 +1535,12 @@ CDXLOperatorFactory::MakeDXLTableDescr(CDXLMemoryManager *dxl_memory_manager,
 			EdxltokenTableDescr);
 	}
 
-	ULONG assigned_query_id = ExtractConvertAttrValueToUlong(
-		dxl_memory_manager, attrs, EdxltokenAssignedQueryId,
+	ULONG assigned_query_id_for_target_rel = ExtractConvertAttrValueToUlong(
+		dxl_memory_manager, attrs, EdxltokenAssignedQueryIdForTargetRel,
 		EdxltokenTableDescr, true /* is_optional */, UNASSIGNED_QUERYID);
 
-	return GPOS_NEW(mp)
-		CDXLTableDescr(mp, mdid, mdname, user_id, lockmode, assigned_query_id);
+	return GPOS_NEW(mp) CDXLTableDescr(mp, mdid, mdname, user_id, lockmode,
+									   assigned_query_id_for_target_rel);
 }
 
 //---------------------------------------------------------------------------

--- a/src/backend/gporca/libnaucrates/src/operators/CDXLTableDescr.cpp
+++ b/src/backend/gporca/libnaucrates/src/operators/CDXLTableDescr.cpp
@@ -32,13 +32,13 @@ using namespace gpdxl;
 //---------------------------------------------------------------------------
 CDXLTableDescr::CDXLTableDescr(CMemoryPool *mp, IMDId *mdid, CMDName *mdname,
 							   ULONG ulExecuteAsUser, int lockmode,
-							   ULONG assigned_query_id)
+							   ULONG assigned_query_id_for_target_rel)
 	: m_mdid(mdid),
 	  m_mdname(mdname),
 	  m_dxl_column_descr_array(nullptr),
 	  m_execute_as_user_id(ulExecuteAsUser),
 	  m_lockmode(lockmode),
-	  m_assigned_query_id(assigned_query_id)
+	  m_assigned_query_id_for_target_rel(assigned_query_id_for_target_rel)
 {
 	GPOS_ASSERT(nullptr != m_mdname);
 	m_dxl_column_descr_array = GPOS_NEW(mp) CDXLColDescrArray(mp);
@@ -220,11 +220,11 @@ CDXLTableDescr::SerializeToDXL(CXMLSerializer *xml_serializer) const
 			CDXLTokens::GetDXLTokenStr(EdxltokenLockMode), LockMode());
 	}
 
-	if (UNASSIGNED_QUERYID != m_assigned_query_id)
+	if (UNASSIGNED_QUERYID != m_assigned_query_id_for_target_rel)
 	{
 		xml_serializer->AddAttribute(
-			CDXLTokens::GetDXLTokenStr(EdxltokenAssignedQueryId),
-			m_assigned_query_id);
+			CDXLTokens::GetDXLTokenStr(EdxltokenAssignedQueryIdForTargetRel),
+			m_assigned_query_id_for_target_rel);
 	}
 
 	// serialize columns
@@ -252,17 +252,18 @@ CDXLTableDescr::SerializeToDXL(CXMLSerializer *xml_serializer) const
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CDXLTableDescr::GetAssignedQueryId
+//		CDXLTableDescr::GetAssignedQueryIdForTargetRel
 //
 //	@doc:
 //		Return id of query, to which TableDescr belongs to
-//		(if it's a target entry)
+//		(if this descriptor points to a result (target) entry,
+//		else UNASSIGNED_QUERYID returned)
 //
 //---------------------------------------------------------------------------
 ULONG
-CDXLTableDescr::GetAssignedQueryId() const
+CDXLTableDescr::GetAssignedQueryIdForTargetRel() const
 {
-	return m_assigned_query_id;
+	return m_assigned_query_id_for_target_rel;
 }
 
 // EOF

--- a/src/backend/gporca/libnaucrates/src/operators/CDXLTableDescr.cpp
+++ b/src/backend/gporca/libnaucrates/src/operators/CDXLTableDescr.cpp
@@ -31,12 +31,14 @@ using namespace gpdxl;
 //
 //---------------------------------------------------------------------------
 CDXLTableDescr::CDXLTableDescr(CMemoryPool *mp, IMDId *mdid, CMDName *mdname,
-							   ULONG ulExecuteAsUser, int lockmode)
+							   ULONG ulExecuteAsUser, int lockmode,
+							   ULONG assigned_query_id)
 	: m_mdid(mdid),
 	  m_mdname(mdname),
 	  m_dxl_column_descr_array(nullptr),
 	  m_execute_as_user_id(ulExecuteAsUser),
-	  m_lockmode(lockmode)
+	  m_lockmode(lockmode),
+	  m_assigned_query_id(assigned_query_id)
 {
 	GPOS_ASSERT(nullptr != m_mdname);
 	m_dxl_column_descr_array = GPOS_NEW(mp) CDXLColDescrArray(mp);
@@ -218,6 +220,13 @@ CDXLTableDescr::SerializeToDXL(CXMLSerializer *xml_serializer) const
 			CDXLTokens::GetDXLTokenStr(EdxltokenLockMode), LockMode());
 	}
 
+	if (UNASSIGNED_QUERYID != m_assigned_query_id)
+	{
+		xml_serializer->AddAttribute(
+			CDXLTokens::GetDXLTokenStr(EdxltokenAssignedQueryId),
+			m_assigned_query_id);
+	}
+
 	// serialize columns
 	xml_serializer->OpenElement(
 		CDXLTokens::GetDXLTokenStr(EdxltokenNamespacePrefix),
@@ -238,6 +247,22 @@ CDXLTableDescr::SerializeToDXL(CXMLSerializer *xml_serializer) const
 	xml_serializer->CloseElement(
 		CDXLTokens::GetDXLTokenStr(EdxltokenNamespacePrefix),
 		CDXLTokens::GetDXLTokenStr(EdxltokenTableDescr));
+}
+
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CDXLTableDescr::GetAssignedQueryId
+//
+//	@doc:
+//		Return id of query, to which TableDescr belongs to
+//		(if it's a target entry)
+//
+//---------------------------------------------------------------------------
+ULONG
+CDXLTableDescr::GetAssignedQueryId() const
+{
+	return m_assigned_query_id;
 }
 
 // EOF

--- a/src/backend/gporca/libnaucrates/src/xml/dxltokens.cpp
+++ b/src/backend/gporca/libnaucrates/src/xml/dxltokens.cpp
@@ -520,6 +520,7 @@ CDXLTokens::Init(CMemoryPool *mp)
 		{EdxltokenIsNull, GPOS_WSZ_LIT("IsNull")},
 		{EdxltokenLintValue, GPOS_WSZ_LIT("LintValue")},
 		{EdxltokenDoubleValue, GPOS_WSZ_LIT("DoubleValue")},
+		{EdxltokenAssignedQueryId, GPOS_WSZ_LIT("AssignedQueryId")},
 
 		{EdxltokenRelTemporary, GPOS_WSZ_LIT("IsTemporary")},
 

--- a/src/backend/gporca/libnaucrates/src/xml/dxltokens.cpp
+++ b/src/backend/gporca/libnaucrates/src/xml/dxltokens.cpp
@@ -520,7 +520,7 @@ CDXLTokens::Init(CMemoryPool *mp)
 		{EdxltokenIsNull, GPOS_WSZ_LIT("IsNull")},
 		{EdxltokenLintValue, GPOS_WSZ_LIT("LintValue")},
 		{EdxltokenDoubleValue, GPOS_WSZ_LIT("DoubleValue")},
-		{EdxltokenAssignedQueryId, GPOS_WSZ_LIT("AssignedQueryId")},
+		{EdxltokenAssignedQueryIdForTargetRel, GPOS_WSZ_LIT("AssignedQueryId")},
 
 		{EdxltokenRelTemporary, GPOS_WSZ_LIT("IsTemporary")},
 

--- a/src/backend/gporca/libnaucrates/src/xml/dxltokens.cpp
+++ b/src/backend/gporca/libnaucrates/src/xml/dxltokens.cpp
@@ -520,7 +520,8 @@ CDXLTokens::Init(CMemoryPool *mp)
 		{EdxltokenIsNull, GPOS_WSZ_LIT("IsNull")},
 		{EdxltokenLintValue, GPOS_WSZ_LIT("LintValue")},
 		{EdxltokenDoubleValue, GPOS_WSZ_LIT("DoubleValue")},
-		{EdxltokenAssignedQueryIdForTargetRel, GPOS_WSZ_LIT("AssignedQueryId")},
+		{EdxltokenAssignedQueryIdForTargetRel,
+		 GPOS_WSZ_LIT("AssignedQueryIdForTargetRel")},
 
 		{EdxltokenRelTemporary, GPOS_WSZ_LIT("IsTemporary")},
 

--- a/src/backend/gporca/server/src/unittest/CTestUtils.cpp
+++ b/src/backend/gporca/server/src/unittest/CTestUtils.cpp
@@ -221,8 +221,9 @@ CTestUtils::PtabdescPlainWithColNameFormat(
 		mp, mdid, nameTable,
 		false,	// convert_hash_to_random
 		IMDRelation::EreldistrRandom, IMDRelation::ErelstorageHeap,
-		0,	// ulExecuteAsUser
-		-1	// lockmode
+		0,	 // ulExecuteAsUser
+		-1,	 // lockmode
+		0	 // UNASSIGNED_QUERYID
 	);
 
 	for (ULONG i = 0; i < num_cols; i++)

--- a/src/backend/gporca/server/src/unittest/dxl/statistics/CStatisticsTest.cpp
+++ b/src/backend/gporca/server/src/unittest/dxl/statistics/CStatisticsTest.cpp
@@ -317,8 +317,9 @@ CStatisticsTest::PtabdescTwoColumnSource(CMemoryPool *mp,
 		nameTable,
 		false,	// convert_hash_to_random
 		IMDRelation::EreldistrRandom, IMDRelation::ErelstorageHeap,
-		0,	// ulExecuteAsUser
-		-1	// lockmode
+		0,	 // ulExecuteAsUser
+		-1,	 // lockmode
+		0	 // UNASSIGNED_QUERYID
 	);
 
 	for (ULONG i = 0; i < 2; i++)

--- a/src/backend/gporca/server/src/unittest/gpopt/minidump/CDMLTest.cpp
+++ b/src/backend/gporca/server/src/unittest/gpopt/minidump/CDMLTest.cpp
@@ -47,6 +47,7 @@ const CHAR *rgszDMLFileNames[] = {
 	"../data/dxl/minidump/InsertSortDistributed2MasterOnly.mdp",
 	"../data/dxl/minidump/InsertProjectSort.mdp",
 	"../data/dxl/minidump/InsertAssertSort.mdp",
+	"../data/dxl/minidump/Delete-Check-AssignedQueryIdForTargetRel.mdp",
 	"../data/dxl/minidump/UpdateRandomDistr.mdp",
 	"../data/dxl/minidump/DeleteRandomDistr.mdp",
 	"../data/dxl/minidump/DeleteRandomlyDistributedTableJoin.mdp",

--- a/src/backend/gporca/server/src/unittest/gpopt/translate/CTranslatorDXLToExprTest.cpp
+++ b/src/backend/gporca/server/src/unittest/gpopt/translate/CTranslatorDXLToExprTest.cpp
@@ -253,7 +253,8 @@ public:
 			mp, mdid, CName(&strTableName), convert_hash_to_random,
 			CMDRelationGPDB::EreldistrMasterOnly,
 			CMDRelationGPDB::ErelstorageHeap, ulExecuteAsUser,
-			-1 /* lockmode */);
+			-1, /* lockmode */
+			0 /* UNASSIGNED_QUERYID */);
 	}
 
 	void

--- a/src/include/gpopt/translate/CContextDXLToPlStmt.h
+++ b/src/include/gpopt/translate/CContextDXLToPlStmt.h
@@ -87,9 +87,9 @@ private:
 				 gpos::Equals<ULONG>, CleanupDelete<ULONG>,
 				 CleanupDelete<SCTEConsumerInfo>>;
 
-	typedef CHashMap<ULONG, Index, gpos::HashValue<ULONG>, gpos::Equals<ULONG>,
-					 CleanupDelete<ULONG>, CleanupDelete<Index>>
-		HMUlIndex;
+	using HMUlIndex =
+		CHashMap<ULONG, Index, gpos::HashValue<ULONG>, gpos::Equals<ULONG>,
+				 CleanupDelete<ULONG>, CleanupDelete<Index>>;
 
 	CMemoryPool *m_mp;
 

--- a/src/include/gpopt/translate/CContextDXLToPlStmt.h
+++ b/src/include/gpopt/translate/CContextDXLToPlStmt.h
@@ -268,11 +268,11 @@ public:
 	// used by internal GPDB functions to build the RelOptInfo when creating foreign scans
 	Query *m_orig_query;
 
-	HMUlIndex *
-	GetUsedRelationIndexesMap() const
-	{
-		return m_used_rte_indexes;
-	}
+	// get rte from m_rtable_entries_list by given index
+	RangeTblEntry *GetRTEByIndex(Index index);
+
+	Index GetRTEIndexByTableDescr(const CDXLTableDescr *table_descr,
+								  BOOL *is_rte_exists);
 };
 
 }  // namespace gpdxl

--- a/src/include/gpopt/translate/CContextDXLToPlStmt.h
+++ b/src/include/gpopt/translate/CContextDXLToPlStmt.h
@@ -87,6 +87,10 @@ private:
 				 gpos::Equals<ULONG>, CleanupDelete<ULONG>,
 				 CleanupDelete<SCTEConsumerInfo>>;
 
+	typedef CHashMap<ULONG, Index, gpos::HashValue<ULONG>, gpos::Equals<ULONG>,
+					 CleanupDelete<ULONG>, CleanupDelete<Index>>
+		HMUlIndex;
+
 	CMemoryPool *m_mp;
 
 	// counter for generating plan ids
@@ -137,6 +141,8 @@ private:
 
 	UlongToUlongMap *m_part_selector_to_param_map;
 
+	// hash map of the queryid (of DML query) and the target relation index
+	HMUlIndex *m_used_rte_indexes;
 
 public:
 	// ctor/dtor
@@ -261,6 +267,12 @@ public:
 
 	// used by internal GPDB functions to build the RelOptInfo when creating foreign scans
 	Query *m_orig_query;
+
+	HMUlIndex *
+	GetUsedRelationIndexesMap() const
+	{
+		return m_used_rte_indexes;
+	}
 };
 
 }  // namespace gpdxl

--- a/src/include/gpopt/translate/CContextQueryToDXL.h
+++ b/src/include/gpopt/translate/CContextQueryToDXL.h
@@ -22,6 +22,7 @@
 
 #define GPDXL_CTE_ID_START 1
 #define GPDXL_COL_ID_START 1
+#define GPDXL_QUERY_ID_START 1
 
 namespace gpdxl
 {
@@ -53,6 +54,9 @@ private:
 	// counter for generating unique CTE ids
 	CIdGenerator *m_cte_id_counter;
 
+	// counter for upper-level query and its subqueries
+	CIdGenerator *m_queryid_counter;
+
 	// does the query have any distributed tables?
 	BOOL m_has_distributed_tables;
 
@@ -65,6 +69,8 @@ public:
 
 	// dtor
 	~CContextQueryToDXL();
+
+	ULONG GetNextQueryId();
 };
 }  // namespace gpdxl
 #endif	// GPDXL_CContextQueryToDXL_H

--- a/src/include/gpopt/translate/CTranslatorDXLToPlStmt.h
+++ b/src/include/gpopt/translate/CTranslatorDXLToPlStmt.h
@@ -426,10 +426,9 @@ private:
 		CDXLTranslateContextBaseTable *base_table_context);
 
 	// create range table entry from a table descriptor
-	RangeTblEntry *TranslateDXLTblDescrToRangeTblEntry(
-		const CDXLTableDescr *table_descr, Index index,
-		CDXLTranslateContextBaseTable *base_table_context,
-		BOOL rte_was_translated, AclMode acl_mode);
+	Index ProcessDXLTblDescr(const CDXLTableDescr *table_descr,
+							 CDXLTranslateContextBaseTable *base_table_context,
+							 AclMode acl_mode);
 
 	// translate DXL projection list into a target list
 	List *TranslateDXLProjList(

--- a/src/include/gpopt/translate/CTranslatorDXLToPlStmt.h
+++ b/src/include/gpopt/translate/CTranslatorDXLToPlStmt.h
@@ -167,6 +167,11 @@ private:
 	// Set the bitmapset of a plan to the list of param_ids defined by the plan
 	static void SetParamIds(Plan *);
 
+	Index ProcessTableDescr(
+		const gpdxl::CDXLTableDescr *dxl_table_descr, RangeTblEntry **rte,
+		gpdxl::CDXLTranslateContextBaseTable *base_table_context,
+		AclMode acl_mode = ACL_SELECT);
+
 	// translate DXL table scan node into a SeqScan node
 	Plan *TranslateDXLTblScan(
 		const CDXLNode *tbl_scan_dxlnode, CDXLTranslateContext *output_context,

--- a/src/include/gpopt/translate/CTranslatorDXLToPlStmt.h
+++ b/src/include/gpopt/translate/CTranslatorDXLToPlStmt.h
@@ -167,11 +167,6 @@ private:
 	// Set the bitmapset of a plan to the list of param_ids defined by the plan
 	static void SetParamIds(Plan *);
 
-	Index ProcessTableDescr(
-		const gpdxl::CDXLTableDescr *dxl_table_descr, RangeTblEntry **rte,
-		gpdxl::CDXLTranslateContextBaseTable *base_table_context,
-		AclMode acl_mode = ACL_SELECT);
-
 	// translate DXL table scan node into a SeqScan node
 	Plan *TranslateDXLTblScan(
 		const CDXLNode *tbl_scan_dxlnode, CDXLTranslateContext *output_context,
@@ -433,7 +428,8 @@ private:
 	// create range table entry from a table descriptor
 	RangeTblEntry *TranslateDXLTblDescrToRangeTblEntry(
 		const CDXLTableDescr *table_descr, Index index,
-		CDXLTranslateContextBaseTable *base_table_context);
+		CDXLTranslateContextBaseTable *base_table_context,
+		BOOL rte_was_translated, AclMode acl_mode);
 
 	// translate DXL projection list into a target list
 	List *TranslateDXLProjList(

--- a/src/include/gpopt/translate/CTranslatorQueryToDXL.h
+++ b/src/include/gpopt/translate/CTranslatorQueryToDXL.h
@@ -129,6 +129,10 @@ private:
 	// CTE producer IDs defined at the current query level
 	UlongBoolHashMap *m_cteid_at_current_query_level_map;
 
+	// id of current query (and for nested queries), it's used for correct assigning
+	// of relation links to target relation of DML query
+	ULONG m_query_id;
+
 	//ctor
 	// private constructor, called from the public factory function QueryToDXLInstance
 	CTranslatorQueryToDXL(
@@ -416,6 +420,8 @@ private:
 
 	// true iff this query or one of its ancestors is a DML query
 	BOOL IsDMLQuery();
+
+	CDXLTableDescr *GetTableDescr(const RangeTblEntry *rte, ULONG rt_index);
 
 public:
 	CTranslatorQueryToDXL(const CTranslatorQueryToDXL &) = delete;

--- a/src/include/gpopt/translate/CTranslatorQueryToDXL.h
+++ b/src/include/gpopt/translate/CTranslatorQueryToDXL.h
@@ -421,8 +421,6 @@ private:
 	// true iff this query or one of its ancestors is a DML query
 	BOOL IsDMLQuery();
 
-	CDXLTableDescr *GetTableDescr(const RangeTblEntry *rte, ULONG rt_index);
-
 public:
 	CTranslatorQueryToDXL(const CTranslatorQueryToDXL &) = delete;
 

--- a/src/include/gpopt/translate/CTranslatorUtils.h
+++ b/src/include/gpopt/translate/CTranslatorUtils.h
@@ -156,11 +156,12 @@ public:
 										 CMDAccessor *md_accessor, IMDId *mdid);
 
 	// translate a RangeTableEntry into a CDXLTableDescr
-	static CDXLTableDescr *GetTableDescr(
-		CMemoryPool *mp, CMDAccessor *md_accessor, CIdGenerator *id_generator,
-		const RangeTblEntry *rte, BOOL is_result_rel,
-		BOOL *is_distributed_table = nullptr,
-		ULONG assigned_query_id = UNASSIGNED_QUERYID);
+	static CDXLTableDescr *GetTableDescr(CMemoryPool *mp,
+										 CMDAccessor *md_accessor,
+										 CIdGenerator *id_generator,
+										 const RangeTblEntry *rte,
+										 ULONG assigned_query_id,
+										 BOOL *is_distributed_table = nullptr);
 
 	// translate a RangeTableEntry into a CDXLLogicalTVF
 	static CDXLLogicalTVF *ConvertToCDXLLogicalTVF(CMemoryPool *mp,

--- a/src/include/gpopt/translate/CTranslatorUtils.h
+++ b/src/include/gpopt/translate/CTranslatorUtils.h
@@ -156,11 +156,10 @@ public:
 										 CMDAccessor *md_accessor, IMDId *mdid);
 
 	// translate a RangeTableEntry into a CDXLTableDescr
-	static CDXLTableDescr *GetTableDescr(CMemoryPool *mp,
-										 CMDAccessor *md_accessor,
-										 CIdGenerator *id_generator,
-										 const RangeTblEntry *rte,
-										 BOOL *is_distributed_table = nullptr);
+	static CDXLTableDescr *GetTableDescr(
+		CMemoryPool *mp, CMDAccessor *md_accessor, CIdGenerator *id_generator,
+		const RangeTblEntry *rte, BOOL *is_distributed_table = nullptr,
+		ULONG assigned_query_id = UNASSIGNED_QUERYID);
 
 	// translate a RangeTableEntry into a CDXLLogicalTVF
 	static CDXLLogicalTVF *ConvertToCDXLLogicalTVF(CMemoryPool *mp,

--- a/src/include/gpopt/translate/CTranslatorUtils.h
+++ b/src/include/gpopt/translate/CTranslatorUtils.h
@@ -158,7 +158,8 @@ public:
 	// translate a RangeTableEntry into a CDXLTableDescr
 	static CDXLTableDescr *GetTableDescr(
 		CMemoryPool *mp, CMDAccessor *md_accessor, CIdGenerator *id_generator,
-		const RangeTblEntry *rte, BOOL *is_distributed_table = nullptr,
+		const RangeTblEntry *rte, BOOL is_result_rel,
+		BOOL *is_distributed_table = nullptr,
 		ULONG assigned_query_id = UNASSIGNED_QUERYID);
 
 	// translate a RangeTableEntry into a CDXLLogicalTVF

--- a/src/include/gpopt/translate/CTranslatorUtils.h
+++ b/src/include/gpopt/translate/CTranslatorUtils.h
@@ -160,7 +160,7 @@ public:
 										 CMDAccessor *md_accessor,
 										 CIdGenerator *id_generator,
 										 const RangeTblEntry *rte,
-										 ULONG assigned_query_id,
+										 ULONG assigned_query_id_for_target_rel,
 										 BOOL *is_distributed_table = nullptr);
 
 	// translate a RangeTableEntry into a CDXLLogicalTVF

--- a/src/test/isolation2/expected/gdd/concurrent_update_optimizer.out
+++ b/src/test/isolation2/expected/gdd/concurrent_update_optimizer.out
@@ -171,7 +171,7 @@ UPDATE 1
 1: end;
 END
 2<:  <... completed>
-ERROR:  EvalPlanQual can not handle subPlan with Motion node  (seg1 127.0.1.1:7003 pid=34629)
+ERROR:  EvalPlanQual can not handle subPlan with Motion node
 2: end;
 END
 0: select * from tab_update_hashcol;
@@ -225,7 +225,7 @@ UPDATE 1
 1: end;
 END
 2<:  <... completed>
-ERROR:  EvalPlanQual can not handle subPlan with Motion node  (seg0 127.0.1.1:7002 pid=108407)
+ERROR:  EvalPlanQual can not handle subPlan with Motion node  (seg1 127.0.1.1:6003 pid=76275)
 2: end;
 END
 
@@ -306,7 +306,7 @@ BEGIN
 1: end;
 END
 2<:  <... completed>
-ERROR:  tuple to be locked was already moved to another partition or segment due to concurrent update  (seg1 127.0.1.1:7003 pid=34629)
+ERROR:  tuple to be locked was already moved to another partition or segment due to concurrent update  (seg1 127.0.1.1:6003 pid=76275)
 
 2: abort;
 ABORT
@@ -326,7 +326,7 @@ BEGIN
 1: end;
 END
 2<:  <... completed>
-ERROR:  tuple to be locked was already moved to another partition or segment due to concurrent update  (seg0 127.0.1.1:7002 pid=43842)
+ERROR:  tuple to be locked was already moved to another partition or segment due to concurrent update  (seg0 127.0.1.1:6002 pid=76337)
 
 2: abort;
 ABORT

--- a/src/test/isolation2/expected/modify_table_data_corrupt_optimizer.out
+++ b/src/test/isolation2/expected/modify_table_data_corrupt_optimizer.out
@@ -72,17 +72,17 @@ explain (costs off) delete from tab1 using tab2, tab3 where tab1.a = tab2.a and 
  Delete on tab1                                                            
    ->  Result                                                              
          ->  Redistribute Motion 3:3  (slice1; segments: 3)                
-               Hash Key: tab1_1.b                                          
+               Hash Key: tab1.b                                            
                ->  Hash Join                                               
-                     Hash Cond: (tab2.a = tab1_1.a)                        
+                     Hash Cond: (tab2.a = tab1.a)                          
                      ->  Seq Scan on tab2                                  
                      ->  Hash                                              
                            ->  Broadcast Motion 3:3  (slice2; segments: 3) 
                                  ->  Hash Join                             
-                                       Hash Cond: (tab3.b = tab1_1.b)      
+                                       Hash Cond: (tab3.b = tab1.b)        
                                        ->  Seq Scan on tab3                
                                        ->  Hash                            
-                                             ->  Seq Scan on tab1 tab1_1   
+                                             ->  Seq Scan on tab1          
  Optimizer: Pivotal Optimizer (GPORCA) version 3.86.0                      
 (15 rows)
 begin;
@@ -99,17 +99,17 @@ explain (costs off) update tab1 set a = 999 from tab2, tab3 where tab1.a = tab2.
  Update on tab1                                                            
    ->  Result                                                              
          ->  Redistribute Motion 3:3  (slice1; segments: 3)                
-               Hash Key: tab1_1.b                                          
+               Hash Key: tab1.b                                            
                ->  Hash Join                                               
-                     Hash Cond: (tab2.a = tab1_1.a)                        
+                     Hash Cond: (tab2.a = tab1.a)                          
                      ->  Seq Scan on tab2                                  
                      ->  Hash                                              
                            ->  Broadcast Motion 3:3  (slice2; segments: 3) 
                                  ->  Hash Join                             
-                                       Hash Cond: (tab3.b = tab1_1.b)      
+                                       Hash Cond: (tab3.b = tab1.b)        
                                        ->  Seq Scan on tab3                
                                        ->  Hash                            
-                                             ->  Seq Scan on tab1 tab1_1   
+                                             ->  Seq Scan on tab1          
  Optimizer: Pivotal Optimizer (GPORCA)                                     
 (15 rows)
 begin;
@@ -126,18 +126,18 @@ explain (costs off) delete from tab1 using tab2, tab3 where tab1.a = tab2.a and 
  Delete on tab1                                                                              
    ->  Result                                                                                
          ->  Redistribute Motion 3:3  (slice1; segments: 3)                                  
-               Hash Key: tab1_1.b                                                            
+               Hash Key: tab1.b                                                              
                ->  Hash Join                                                                 
-                     Hash Cond: (tab3.a = tab1_1.b)                                          
+                     Hash Cond: (tab3.a = tab1.b)                                            
                      ->  Seq Scan on tab3                                                    
                      ->  Hash                                                                
                            ->  Broadcast Motion 3:3  (slice2; segments: 3)                   
                                  ->  Hash Join                                               
-                                       Hash Cond: (tab2.a = tab1_1.a)                        
+                                       Hash Cond: (tab2.a = tab1.a)                          
                                        ->  Seq Scan on tab2                                  
                                        ->  Hash                                              
                                              ->  Broadcast Motion 3:3  (slice3; segments: 3) 
-                                                   ->  Seq Scan on tab1 tab1_1               
+                                                   ->  Seq Scan on tab1                      
  Optimizer: Pivotal Optimizer (GPORCA) version 3.86.0                                        
 (16 rows)
 begin;
@@ -154,18 +154,18 @@ explain (costs off) update tab1 set a = 999 from tab2, tab3 where tab1.a = tab2.
  Update on tab1                                                                              
    ->  Result                                                                                
          ->  Redistribute Motion 3:3  (slice1; segments: 3)                                  
-               Hash Key: tab1_1.b                                                            
+               Hash Key: tab1.b                                                              
                ->  Hash Join                                                                 
-                     Hash Cond: (tab3.a = tab1_1.b)                                          
+                     Hash Cond: (tab3.a = tab1.b)                                            
                      ->  Seq Scan on tab3                                                    
                      ->  Hash                                                                
                            ->  Broadcast Motion 3:3  (slice2; segments: 3)                   
                                  ->  Hash Join                                               
-                                       Hash Cond: (tab2.a = tab1_1.a)                        
+                                       Hash Cond: (tab2.a = tab1.a)                          
                                        ->  Seq Scan on tab2                                  
                                        ->  Hash                                              
                                              ->  Broadcast Motion 3:3  (slice3; segments: 3) 
-                                                   ->  Seq Scan on tab1 tab1_1               
+                                                   ->  Seq Scan on tab1                      
  Optimizer: Pivotal Optimizer (GPORCA)                                                       
 (16 rows)
 begin;
@@ -187,9 +187,9 @@ explain (costs off) update tab1 set b = b + 1;
  Update on tab1                                             
    ->  Result                                               
          ->  Redistribute Motion 3:3  (slice1; segments: 3) 
-               Hash Key: tab1_1.b                           
+               Hash Key: b                                  
                ->  Split                                    
-                     ->  Seq Scan on tab1 tab1_1            
+                     ->  Seq Scan on tab1                   
  Optimizer: Pivotal Optimizer (GPORCA) version 3.86.0       
 (7 rows)
 begin;

--- a/src/test/regress/expected/DML_over_joins_optimizer.out
+++ b/src/test/regress/expected/DML_over_joins_optimizer.out
@@ -81,7 +81,7 @@ explain update s set b = b + 1 where exists (select 1 from r where s.a = r.b);
  Update on s  (cost=0.00..865.66 rows=34 width=1)
    ->  Hash Semi Join  (cost=0.00..862.80 rows=100 width=18)
          Hash Cond: (s_1.a = r.b)
-         ->  Seq Scan on s s_1  (cost=0.00..431.00 rows=100 width=18)
+         ->  Seq Scan on s  (cost=0.00..431.00 rows=100 width=18)
          ->  Hash  (cost=431.15..431.15 rows=10000 width=4)
                ->  Result  (cost=0.00..431.15 rows=10000 width=4)
                      ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.14 rows=10000 width=4)
@@ -97,7 +97,7 @@ explain delete from s where exists (select 1 from r where s.a = r.b);
  Delete on s  (cost=0.00..865.66 rows=34 width=1)
    ->  Hash Semi Join  (cost=0.00..862.80 rows=34 width=18)
          Hash Cond: (s_1.a = r.b)
-         ->  Seq Scan on s s_1  (cost=0.00..431.00 rows=34 width=18)
+         ->  Seq Scan on s  (cost=0.00..431.00 rows=34 width=18)
          ->  Hash  (cost=431.15..431.15 rows=3334 width=4)
                ->  Result  (cost=0.00..431.15 rows=3334 width=4)
                      ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.14 rows=3334 width=4)
@@ -1802,8 +1802,8 @@ explain (costs off) delete from tab1 using tab2 where tab1.a = tab2.a;
 ------------------------------------------------------
  Delete on tab1
    ->  Hash Join
-         Hash Cond: (tab1_1.a = tab2.a)
-         ->  Seq Scan on tab1 tab1_1
+         Hash Cond: (tab1.a = tab2.a)
+         ->  Seq Scan on tab1
          ->  Hash
                ->  Seq Scan on tab2
  Optimizer: Pivotal Optimizer (GPORCA) version 3.86.0
@@ -1816,8 +1816,8 @@ explain (costs off) delete from tab1 using tab2 where tab1.a = tab2.b;
 ------------------------------------------------------------------
  Delete on tab1
    ->  Hash Join
-         Hash Cond: (tab1_1.a = tab2.b)
-         ->  Seq Scan on tab1 tab1_1
+         Hash Cond: (tab1.a = tab2.b)
+         ->  Seq Scan on tab1
          ->  Hash
                ->  Redistribute Motion 3:3  (slice1; segments: 3)
                      Hash Key: tab2.b
@@ -1831,8 +1831,8 @@ explain (costs off) delete from tab1 using tab2 where tab1.b = tab2.b;
 ---------------------------------------------------------------
  Delete on tab1
    ->  Hash Join
-         Hash Cond: (tab1_1.b = tab2.b)
-         ->  Seq Scan on tab1 tab1_1
+         Hash Cond: (tab1.b = tab2.b)
+         ->  Seq Scan on tab1
          ->  Hash
                ->  Broadcast Motion 3:3  (slice1; segments: 3)
                      ->  Seq Scan on tab2
@@ -1872,18 +1872,18 @@ HINT:  For non-partitioned tables, run analyze <table_name>(<column_list>). For 
  Delete on tab1
    ->  Result
          ->  Redistribute Motion 3:3  (slice1; segments: 3)
-               Hash Key: tab1_1.b
+               Hash Key: tab1.b
                ->  Hash Join
-                     Hash Cond: (tab2.a = tab1_1.a)
+                     Hash Cond: (tab2.a = tab1.a)
                      ->  Seq Scan on tab2
                      ->  Hash
                            ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                                 Hash Key: tab1_1.a
+                                 Hash Key: tab1.a
                                  ->  Hash Join
-                                       Hash Cond: (tab3.b = tab1_1.b)
+                                       Hash Cond: (tab3.b = tab1.b)
                                        ->  Seq Scan on tab3
                                        ->  Hash
-                                             ->  Seq Scan on tab1 tab1_1
+                                             ->  Seq Scan on tab1
  Optimizer: Pivotal Optimizer (GPORCA) version 3.86.0
 (16 rows)
 

--- a/src/test/regress/expected/bfv_dml_optimizer.out
+++ b/src/test/regress/expected/bfv_dml_optimizer.out
@@ -186,7 +186,7 @@ explain update update_pk_test set b = 5;
                                        QUERY PLAN                                       
 ----------------------------------------------------------------------------------------
  Update on update_pk_test  (cost=0.00..431.03 rows=1 width=1)
-   ->  Seq Scan on update_pk_test update_pk_test_1  (cost=0.00..431.00 rows=1 width=14)
+   ->  Seq Scan on update_pk_test  (cost=0.00..431.00 rows=1 width=14)
  Optimizer: Pivotal Optimizer (GPORCA)
 (3 rows)
 
@@ -207,7 +207,7 @@ explain update update_pk_test set a = 5;
                ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=22)
                      Hash Key: update_pk_test_1.a
                      ->  Split  (cost=0.00..431.00 rows=1 width=22)
-                           ->  Seq Scan on update_pk_test update_pk_test_1  (cost=0.00..431.00 rows=1 width=18)
+                           ->  Seq Scan on update_pk_test  (cost=0.00..431.00 rows=1 width=18)
  Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
 (9 rows)
 
@@ -329,8 +329,8 @@ explain delete from foo using bar where foo.a=bar.a;
                ->  Hash Join  (cost=0.00..862.00 rows=1 width=18)
                      Hash Cond: (foo_1.a = bar.a)
                      ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=18)
-                           Hash Key: foo_1.a
-                           ->  Seq Scan on foo foo_1  (cost=0.00..431.00 rows=1 width=18)
+                           Hash Key: foo.a
+                           ->  Seq Scan on foo  (cost=0.00..431.00 rows=1 width=18)
                      ->  Hash  (cost=431.00..431.00 rows=1 width=4)
                            ->  Seq Scan on bar  (cost=0.00..431.00 rows=1 width=4)
  Optimizer: Pivotal Optimizer (GPORCA)
@@ -400,7 +400,7 @@ explain delete from foo where foo.a=1;
                             QUERY PLAN                            
 ------------------------------------------------------------------
  Delete on foo  (cost=0.00..431.03 rows=1 width=1)
-   ->  Seq Scan on foo foo_1  (cost=0.00..431.00 rows=1 width=18)
+   ->  Seq Scan on foo  (cost=0.00..431.00 rows=1 width=18)
          Filter: (a = 1)
  Optimizer: Pivotal Optimizer (GPORCA)
 (4 rows)
@@ -421,8 +421,8 @@ explain delete from foo using bar where foo.a=bar.b;
 ---------------------------------------------------------------------------------------------------
  Delete on foo  (cost=0.00..862.03 rows=1 width=1)
    ->  Hash Join  (cost=0.00..862.00 rows=1 width=18)
-         Hash Cond: (foo_1.a = bar.b)
-         ->  Seq Scan on foo foo_1  (cost=0.00..431.00 rows=1 width=18)
+         Hash Cond: (foo.a = bar.b)
+         ->  Seq Scan on foo  (cost=0.00..431.00 rows=1 width=18)
          ->  Hash  (cost=431.00..431.00 rows=3 width=4)
                ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=3 width=4)
                      ->  Seq Scan on bar  (cost=0.00..431.00 rows=1 width=4)
@@ -446,11 +446,11 @@ explain delete from foo using foo foo_1 where foo_1.a=foo.a;
 ----------------------------------------------------------------------------------------------------
  Delete on foo  (cost=0.00..862.29 rows=4 width=1)
    ->  Hash Join  (cost=0.00..862.00 rows=10 width=18)
-         Hash Cond: (foo_1.a = foo_2.a)
-         ->  Seq Scan on foo foo_1  (cost=0.00..431.00 rows=10 width=18)
+         Hash Cond: (foo.a = foo_1.a)
+         ->  Seq Scan on foo  (cost=0.00..431.00 rows=10 width=18)
          ->  Hash  (cost=431.00..431.00 rows=30 width=4)
                ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=30 width=4)
-                     ->  Seq Scan on foo foo_2  (cost=0.00..431.00 rows=4 width=4)
+                     ->  Seq Scan on foo foo_1  (cost=0.00..431.00 rows=4 width=4)
  Optimizer: Pivotal Optimizer (GPORCA)
 (8 rows)
 
@@ -466,7 +466,7 @@ explain delete from foo;
                             QUERY PLAN                            
 ------------------------------------------------------------------
  Delete on foo  (cost=0.00..431.03 rows=1 width=1)
-   ->  Seq Scan on foo foo_1  (cost=0.00..431.00 rows=1 width=18)
+   ->  Seq Scan on foo  (cost=0.00..431.00 rows=1 width=18)
  Optimizer: Pivotal Optimizer (GPORCA)
 (3 rows)
 
@@ -488,7 +488,7 @@ explain delete from foo using bar;
  Delete on foo  (cost=0.00..1324032.10 rows=1 width=1)
    ->  Nested Loop  (cost=0.00..1324032.07 rows=1 width=18)
          Join Filter: true
-         ->  Seq Scan on foo foo_1  (cost=0.00..431.00 rows=1 width=18)
+         ->  Seq Scan on foo  (cost=0.00..431.00 rows=1 width=18)
          ->  Materialize  (cost=0.00..431.00 rows=3 width=1)
                ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=3 width=1)
                      ->  Seq Scan on bar  (cost=0.00..431.00 rows=1 width=1)
@@ -514,8 +514,8 @@ explain delete from foo using bar where foo.b=bar.b;
 ------------------------------------------------------------------------------------------------------
  Delete on foo  (cost=0.00..862.56 rows=4 width=1)
    ->  Hash Join  (cost=0.00..862.27 rows=10 width=18)
-         Hash Cond: (foo_1.b = bar.b)
-         ->  Seq Scan on foo foo_1  (cost=0.00..431.00 rows=10 width=18)
+         Hash Cond: (foo.b = bar.b)
+         ->  Seq Scan on foo  (cost=0.00..431.00 rows=10 width=18)
          ->  Hash  (cost=431.08..431.08 rows=3000 width=4)
                ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.08 rows=3000 width=4)
                      ->  Seq Scan on bar  (cost=0.00..431.01 rows=334 width=4)
@@ -557,8 +557,8 @@ explain update foo set a=4 from bar where foo.a=bar.a;
 ---------------------------------------------------------------------------------------------------
  Update on foo  (cost=0.00..862.03 rows=1 width=1)
    ->  Hash Join  (cost=0.00..862.00 rows=1 width=14)
-         Hash Cond: (foo_1.a = bar.a)
-         ->  Seq Scan on foo foo_1  (cost=0.00..431.00 rows=1 width=18)
+         Hash Cond: (foo.a = bar.a)
+         ->  Seq Scan on foo  (cost=0.00..431.00 rows=1 width=18)
          ->  Hash  (cost=431.00..431.00 rows=3 width=4)
                ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=3 width=4)
                      ->  Seq Scan on bar  (cost=0.00..431.00 rows=1 width=4)
@@ -622,7 +622,7 @@ explain delete from foo using (select a from foo union all select b from bar) v;
  Delete on foo  (cost=0.00..1765376.09 rows=1 width=1)
    ->  Nested Loop  (cost=0.00..1765376.07 rows=1 width=14)
          Join Filter: true
-         ->  Seq Scan on foo foo_2  (cost=0.00..431.00 rows=1 width=14)
+         ->  Seq Scan on foo  (cost=0.00..431.00 rows=1 width=14)
          ->  Materialize  (cost=0.00..862.00 rows=3 width=1)
                ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..862.00 rows=3 width=1)
                      ->  Append  (cost=0.00..862.00 rows=1 width=1)

--- a/src/test/regress/expected/bfv_partition_plans_optimizer.out
+++ b/src/test/regress/expected/bfv_partition_plans_optimizer.out
@@ -1238,7 +1238,7 @@ EXPLAIN (COSTS OFF) DELETE FROM delete_from_indexed_pt WHERE b=1;
                                 QUERY PLAN                                 
 ---------------------------------------------------------------------------
  Delete on delete_from_indexed_pt
-   ->  Dynamic Seq Scan on delete_from_indexed_pt delete_from_indexed_pt_1
+   ->  Dynamic Seq Scan on delete_from_indexed_pt
          Number of partitions to scan: 1 (out of 3)
          Filter: (b = 1)
  Optimizer: Pivotal Optimizer (GPORCA)
@@ -1273,9 +1273,9 @@ EXPLAIN (COSTS OFF, TIMING OFF, SUMMARY OFF, ANALYZE) DELETE FROM delete_from_pt
 ---------------------------------------------------------------------------------------------------------------------------------------------------
  Delete on delete_from_pt (actual rows=0 loops=1)
    ->  Hash Join (actual rows=1 loops=1)
-         Hash Cond: (delete_from_pt_1.b = delete_from_pt_2.b)
+         Hash Cond: (delete_from_pt.b = delete_from_pt_1.b)
          Extra Text: (seg0)   Hash chain length 1.0 avg, 1 max, using 1 of 262144 buckets.
-         ->  Dynamic Seq Scan on delete_from_pt delete_from_pt_1 (actual rows=3 loops=1)
+         ->  Dynamic Seq Scan on delete_from_pt (actual rows=3 loops=1)
                Number of partitions to scan: 3 (out of 3)
                Partitions scanned:  Avg 1.0 x 3 workers.  Max 1 parts (seg0).
          ->  Hash (actual rows=1 loops=1)
@@ -1283,23 +1283,23 @@ EXPLAIN (COSTS OFF, TIMING OFF, SUMMARY OFF, ANALYZE) DELETE FROM delete_from_pt
                ->  Partition Selector (selector id: $0) (actual rows=1 loops=1)
                      ->  Broadcast Motion 3:3  (slice1; segments: 3) (actual rows=1 loops=1)
                            ->  GroupAggregate (actual rows=1 loops=1)
-                                 Group Key: delete_from_pt_2.b
+                                 Group Key: delete_from_pt_1.b
                                  ->  Sort (actual rows=2 loops=1)
-                                       Sort Key: delete_from_pt_2.b
+                                       Sort Key: delete_from_pt_1.b
                                        Sort Method:  quicksort  Memory: 75kB
                                        Executor Memory: 178kB  Segments: 3  Max: 60kB (segment 0)
                                        ->  Redistribute Motion 3:3  (slice2; segments: 3) (actual rows=2 loops=1)
-                                             Hash Key: delete_from_pt_2.b
+                                             Hash Key: delete_from_pt_1.b
                                              ->  GroupAggregate (actual rows=1 loops=1)
-                                                   Group Key: delete_from_pt_2.b
+                                                   Group Key: delete_from_pt_1.b
                                                    ->  Sort (actual rows=1 loops=1)
-                                                         Sort Key: delete_from_pt_2.b
+                                                         Sort Key: delete_from_pt_1.b
                                                          Sort Method:  quicksort  Memory: 75kB
                                                          Executor Memory: 178kB  Segments: 3  Max: 60kB (segment 0)
                                                          ->  Hash Join (actual rows=1 loops=1)
-                                                               Hash Cond: (delete_from_pt_2.b = t.a)
+                                                               Hash Cond: (delete_from_pt_1.b = t.a)
                                                                Extra Text: (seg0)   Hash chain length 1.0 avg, 1 max, using 1 of 262144 buckets.
-                                                               ->  Dynamic Seq Scan on delete_from_pt delete_from_pt_2 (actual rows=3 loops=1)
+                                                               ->  Dynamic Seq Scan on delete_from_pt delete_from_pt_1 (actual rows=3 loops=1)
                                                                      Number of partitions to scan: 3 (out of 3)
                                                                      Partitions scanned:  Avg 1.0 x 3 workers.  Max 1 parts (seg0).
                                                                ->  Hash (actual rows=1 loops=1)

--- a/src/test/regress/expected/catcache_optimizer.out
+++ b/src/test/regress/expected/catcache_optimizer.out
@@ -46,7 +46,7 @@ explain update dml_14027_union_s set a = (select null union select null)::numeri
                ->  Split  (cost=0.00..882689.22 rows=1 width=26)
                      ->  Nested Loop Left Join  (cost=0.00..882689.22 rows=1 width=30)
                            Join Filter: true
-                           ->  Dynamic Seq Scan on dml_14027_union_s dml_14027_union_s_1  (cost=0.00..431.00 rows=1 width=22)
+                           ->  Dynamic Seq Scan on dml_14027_union_s  (cost=0.00..431.00 rows=1 width=22)
                                  Number of partitions to scan: 2 (out of 2)
                            ->  Assert  (cost=0.00..0.00 rows=1 width=8)
                                  Assert Cond: ((row_number() OVER (?)) = 1)

--- a/src/test/regress/expected/direct_dispatch_optimizer.out
+++ b/src/test/regress/expected/direct_dispatch_optimizer.out
@@ -1225,7 +1225,7 @@ explain (costs off) delete from srt_dd where name='ABA'::text;
                   QUERY PLAN                  
 ----------------------------------------------
  Delete on srt_dd
-   ->  Seq Scan on srt_dd srt_dd_1
+   ->  Seq Scan on srt_dd
          Filter: ((name)::text = 'ABA'::text)
  Optimizer: Pivotal Optimizer (GPORCA)
 (4 rows)

--- a/src/test/regress/expected/direct_dispatch_optimizer.out
+++ b/src/test/regress/expected/direct_dispatch_optimizer.out
@@ -1346,7 +1346,7 @@ explain (costs off) delete from t_hash_partition where r_regionkey=1;
                           QUERY PLAN                           
 ---------------------------------------------------------------
  Delete on t_hash_partition
-   ->  Dynamic Seq Scan on t_hash_partition t_hash_partition_1
+   ->  Dynamic Seq Scan on t_hash_partition
          Number of partitions to scan: 1 (out of 3)
          Filter: (r_regionkey = 1)
  Optimizer: Pivotal Optimizer (GPORCA)
@@ -1370,7 +1370,7 @@ explain (costs off) update t_hash_partition set r_name = 'CHINA' where r_regionk
                           QUERY PLAN                           
 ---------------------------------------------------------------
  Update on t_hash_partition
-   ->  Dynamic Seq Scan on t_hash_partition t_hash_partition_1
+   ->  Dynamic Seq Scan on t_hash_partition
          Number of partitions to scan: 1 (out of 3)
          Filter: (r_regionkey = 1)
  Optimizer: Pivotal Optimizer (GPORCA)

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -14489,17 +14489,17 @@ where t.j = tt.j;
    ->  Result  (cost=0.00..0.00 rows=0 width=0)
          ->  Explicit Redistribute Motion 1:3  (slice1; segments: 1)  (cost=0.00..862.00 rows=1 width=18)
                ->  Hash Join  (cost=0.00..862.00 rows=1 width=18)
-                     Hash Cond: (window_agg_test_1.j = window_agg_test_2.j)
+                     Hash Cond: (window_agg_test.j = window_agg_test_1.j)
                      ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=14)
-                           ->  Seq Scan on window_agg_test window_agg_test_1  (cost=0.00..431.00 rows=1 width=14)
+                           ->  Seq Scan on window_agg_test  (cost=0.00..431.00 rows=1 width=14)
                      ->  Hash  (cost=431.00..431.00 rows=1 width=8)
                            ->  WindowAgg  (cost=0.00..431.00 rows=1 width=8)
-                                 Order By: window_agg_test_2.j
+                                 Order By: window_agg_test_1.j
                                  ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
-                                       Merge Key: window_agg_test_2.j
+                                       Merge Key: window_agg_test_1.j
                                        ->  Sort  (cost=0.00..431.00 rows=1 width=8)
-                                             Sort Key: window_agg_test_2.j
-                                             ->  Seq Scan on window_agg_test window_agg_test_2  (cost=0.00..431.00 rows=1 width=8)
+                                             Sort Key: window_agg_test_1.j
+                                             ->  Seq Scan on window_agg_test window_agg_test_1  (cost=0.00..431.00 rows=1 width=8)
  Optimizer: Pivotal Optimizer (GPORCA)
 (16 rows)
 

--- a/src/test/regress/expected/partition_prune_optimizer.out
+++ b/src/test/regress/expected/partition_prune_optimizer.out
@@ -2633,7 +2633,7 @@ update ab_a1 set b = 3 from ab_a2 where ab_a2.b = (select 1);
          ->  Split (actual rows=6 loops=1)
                ->  Nested Loop (actual rows=3 loops=1)
                      Join Filter: true
-                     ->  Dynamic Seq Scan on ab_a1 ab_a1_1 (actual rows=3 loops=1)
+                     ->  Dynamic Seq Scan on ab_a1 (actual rows=3 loops=1)
                            Number of partitions to scan: 3 (out of 3)
                            Partitions scanned:  Avg 3.0 x 3 workers.  Max 3 parts (seg0).
                      ->  Materialize (actual rows=1 loops=4)
@@ -3408,7 +3408,7 @@ explain (costs off) update pp_arrpart set a = a where a = '{1}';
                     QUERY PLAN                     
 ---------------------------------------------------
  Update on pp_arrpart
-   ->  Dynamic Seq Scan on pp_arrpart pp_arrpart_1
+   ->  Dynamic Seq Scan on pp_arrpart
          Number of partitions to scan: 1 (out of 2)
          Filter: (a = '{1}'::integer[])
  Optimizer: Pivotal Optimizer (GPORCA)
@@ -3418,7 +3418,7 @@ explain (costs off) delete from pp_arrpart where a = '{1}';
                     QUERY PLAN                     
 ---------------------------------------------------
  Delete on pp_arrpart
-   ->  Dynamic Seq Scan on pp_arrpart pp_arrpart_1
+   ->  Dynamic Seq Scan on pp_arrpart
          Number of partitions to scan: 1 (out of 2)
          Filter: (a = '{1}'::integer[])
  Optimizer: Pivotal Optimizer (GPORCA)
@@ -3581,7 +3581,7 @@ explain (costs off) update pp_lp set value = 10 where a = 1;
                 QUERY PLAN                
 ------------------------------------------
  Update on pp_lp
-   ->  Dynamic Seq Scan on pp_lp pp_lp_1
+   ->  Dynamic Seq Scan on pp_lp
          Number of partitions to scan: 1 (out of 2)
          Filter: (a = 1)
  Optimizer: Pivotal Optimizer (GPORCA)
@@ -3591,7 +3591,7 @@ explain (costs off) delete from pp_lp where a = 1;
                 QUERY PLAN                
 ------------------------------------------
  Delete on pp_lp
-   ->  Dynamic Seq Scan on pp_lp pp_lp_1
+   ->  Dynamic Seq Scan on pp_lp
          Number of partitions to scan: 1 (out of 2)
          Filter: (a = 1)
  Optimizer: Pivotal Optimizer (GPORCA)
@@ -3613,7 +3613,7 @@ explain (costs off) update pp_lp set value = 10 where a = 1;
                 QUERY PLAN                
 ------------------------------------------
  Update on pp_lp
-   ->  Dynamic Seq Scan on pp_lp pp_lp_1
+   ->  Dynamic Seq Scan on pp_lp
          Number of partitions to scan: 1 (out of 2)
          Filter: (a = 1)
  Optimizer: Pivotal Optimizer (GPORCA)
@@ -3623,7 +3623,7 @@ explain (costs off) delete from pp_lp where a = 1;
                 QUERY PLAN                
 ------------------------------------------
  Delete on pp_lp
-   ->  Dynamic Seq Scan on pp_lp pp_lp_1
+   ->  Dynamic Seq Scan on pp_lp
          Number of partitions to scan: 1 (out of 2)
          Filter: (a = 1)
  Optimizer: Pivotal Optimizer (GPORCA)
@@ -3644,7 +3644,7 @@ explain (costs off) update pp_lp set value = 10 where a = 1;
                 QUERY PLAN                
 ------------------------------------------
  Update on pp_lp
-   ->  Dynamic Seq Scan on pp_lp pp_lp_1
+   ->  Dynamic Seq Scan on pp_lp
          Number of partitions to scan: 1 (out of 2)
          Filter: (a = 1)
  Optimizer: Pivotal Optimizer (GPORCA)
@@ -3654,7 +3654,7 @@ explain (costs off) delete from pp_lp where a = 1;
                 QUERY PLAN                
 ------------------------------------------
  Delete on pp_lp
-   ->  Dynamic Seq Scan on pp_lp pp_lp_1
+   ->  Dynamic Seq Scan on pp_lp
          Number of partitions to scan: 1 (out of 2)
          Filter: (a = 1)
  Optimizer: Pivotal Optimizer (GPORCA)
@@ -3912,9 +3912,9 @@ explain (costs off) update listp1 set a = 1 where a = 2;
  Update on listp1
    ->  Result
          ->  Redistribute Motion 3:3  (slice1; segments: 3)
-               Hash Key: listp1_1.a
+               Hash Key: a
                ->  Split
-                     ->  Seq Scan on listp1 listp1_1
+                     ->  Seq Scan on listp1
                            Filter: (a = 2)
  Optimizer: Pivotal Optimizer (GPORCA)
 (8 rows)
@@ -3936,9 +3936,9 @@ explain (costs off) update listp1 set a = 1 where a = 2;
  Update on listp1
    ->  Result
          ->  Redistribute Motion 3:3  (slice1; segments: 3)
-               Hash Key: listp1_1.a
+               Hash Key: a
                ->  Split
-                     ->  Seq Scan on listp1 listp1_1
+                     ->  Seq Scan on listp1
                            Filter: (a = 2)
  Optimizer: Pivotal Optimizer (GPORCA)
 (8 rows)

--- a/src/test/regress/expected/qp_orca_fallback_optimizer.out
+++ b/src/test/regress/expected/qp_orca_fallback_optimizer.out
@@ -56,7 +56,7 @@ explain update constr_tab set b = 10;
                                    QUERY PLAN                                   
 --------------------------------------------------------------------------------
  Update on constr_tab  (cost=0.00..431.04 rows=1 width=1)
-   ->  Seq Scan on constr_tab constr_tab_1  (cost=0.00..431.00 rows=1 width=22)
+   ->  Seq Scan on constr_tab  (cost=0.00..431.00 rows=1 width=22)
  Optimizer: Pivotal Optimizer (GPORCA)
 (3 rows)
 
@@ -109,9 +109,9 @@ explain update constr_tab set a = 10;
  Update on constr_tab  (cost=0.00..431.09 rows=1 width=1)
    ->  Result  (cost=0.00..431.00 rows=1 width=34)
          ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=30)
-               Hash Key: constr_tab_1.a
+               Hash Key: a
                ->  Split  (cost=0.00..431.00 rows=1 width=30)
-                     ->  Seq Scan on constr_tab constr_tab_1  (cost=0.00..431.00 rows=1 width=26)
+                     ->  Seq Scan on constr_tab  (cost=0.00..431.00 rows=1 width=26)
  Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
 (7 rows)
 

--- a/src/test/regress/expected/qp_subquery_optimizer.out
+++ b/src/test/regress/expected/qp_subquery_optimizer.out
@@ -1448,8 +1448,8 @@ explain delete from TabDel1 where TabDel1.a not in (select a from TabDel3); -- d
 ---------------------------------------------------------------------------------------------------
  Delete on tabdel1  (cost=0.00..862.04 rows=1 width=1)
    ->  Hash Left Anti Semi (Not-In) Join  (cost=0.00..862.00 rows=1 width=18)
-         Hash Cond: (tabdel1_1.a = tabdel3.a)
-         ->  Seq Scan on tabdel1 tabdel1_1  (cost=0.00..431.00 rows=1 width=18)
+         Hash Cond: (tabdel1.a = tabdel3.a)
+         ->  Seq Scan on tabdel1  (cost=0.00..431.00 rows=1 width=18)
          ->  Hash  (cost=431.00..431.00 rows=1 width=4)
                ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
                      ->  Seq Scan on tabdel3  (cost=0.00..431.00 rows=1 width=4)
@@ -1461,8 +1461,8 @@ explain delete from TabDel2 where TabDel2.a not in (select a from TabDel4); -- s
 ---------------------------------------------------------------------------------------------------
  Delete on tabdel2  (cost=0.00..862.03 rows=1 width=1)
    ->  Hash Left Anti Semi (Not-In) Join  (cost=0.00..862.00 rows=1 width=18)
-         Hash Cond: (tabdel2_1.a = tabdel4.a)
-         ->  Seq Scan on tabdel2 tabdel2_1  (cost=0.00..431.00 rows=1 width=18)
+         Hash Cond: (tabdel2.a = tabdel4.a)
+         ->  Seq Scan on tabdel2  (cost=0.00..431.00 rows=1 width=18)
          ->  Hash  (cost=431.00..431.00 rows=3 width=4)
                ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=3 width=4)
                      ->  Seq Scan on tabdel4  (cost=0.00..431.00 rows=1 width=4)

--- a/src/test/regress/expected/updatable_views_optimizer.out
+++ b/src/test/regress/expected/updatable_views_optimizer.out
@@ -409,9 +409,9 @@ EXPLAIN (costs off) UPDATE rw_view1 SET a=6 WHERE a=5;
          ->  Sort
                Sort Key: (DMLAction)
                ->  Redistribute Motion 3:3  (slice1; segments: 3)
-                     Hash Key: base_tbl_1.a
+                     Hash Key: a
                      ->  Split
-                           ->  Index Scan using base_tbl_pkey on base_tbl base_tbl_1
+                           ->  Index Scan using base_tbl_pkey on base_tbl
                                  Index Cond: ((a = 5) AND (a > 0))
  Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
 (10 rows)
@@ -420,7 +420,7 @@ EXPLAIN (costs off) DELETE FROM rw_view1 WHERE a=5;
                          QUERY PLAN                          
 -------------------------------------------------------------
  Delete on base_tbl
-   ->  Index Scan using base_tbl_pkey on base_tbl base_tbl_1
+   ->  Index Scan using base_tbl_pkey on base_tbl
          Index Cond: ((a = 5) AND (a > 0))
  Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
 (4 rows)
@@ -488,9 +488,9 @@ EXPLAIN (costs off) UPDATE rw_view2 SET aaa=5 WHERE aaa=4;
          ->  Sort
                Sort Key: (DMLAction)
                ->  Redistribute Motion 3:3  (slice1; segments: 3)
-                     Hash Key: base_tbl_1.a
+                     Hash Key: a
                      ->  Split
-                           ->  Index Scan using base_tbl_pkey on base_tbl base_tbl_1
+                           ->  Index Scan using base_tbl_pkey on base_tbl
                                  Index Cond: ((a = 4) AND (a < 10) AND (a > 0))
  Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
 (10 rows)
@@ -499,7 +499,7 @@ EXPLAIN (costs off) DELETE FROM rw_view2 WHERE aaa=4;
                          QUERY PLAN                          
 -------------------------------------------------------------
  Delete on base_tbl
-   ->  Index Scan using base_tbl_pkey on base_tbl base_tbl_1
+   ->  Index Scan using base_tbl_pkey on base_tbl
          Index Cond: ((a = 4) AND (a < 10) AND (a > 0))
  Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
 (4 rows)
@@ -686,13 +686,13 @@ EXPLAIN (costs off) UPDATE rw_view2 SET a=3 WHERE a=2;
 -------------------------------------------------------------------------------
  Update on base_tbl
    ->  Hash Join
-         Hash Cond: (base_tbl_1.a = base_tbl_2.a)
-         ->  Index Scan using base_tbl_pkey on base_tbl base_tbl_1
+         Hash Cond: (base_tbl.a = base_tbl_1.a)
+         ->  Index Scan using base_tbl_pkey on base_tbl
                Index Cond: (a = 2)
          ->  Hash
                ->  Result
-                     Filter: ((base_tbl_2.a = 2) AND (base_tbl_2.a < 10))
-                     ->  Index Scan using base_tbl_pkey on base_tbl base_tbl_2
+                     Filter: ((base_tbl_1.a = 2) AND (base_tbl_1.a < 10))
+                     ->  Index Scan using base_tbl_pkey on base_tbl base_tbl_1
                            Index Cond: (a > 0)
  Optimizer: Pivotal Optimizer (GPORCA)
 (11 rows)
@@ -702,13 +702,13 @@ EXPLAIN (costs off) DELETE FROM rw_view2 WHERE a=2;
 -------------------------------------------------------------------------------
  Delete on base_tbl
    ->  Hash Join
-         Hash Cond: (base_tbl_1.a = base_tbl_2.a)
-         ->  Index Scan using base_tbl_pkey on base_tbl base_tbl_1
+         Hash Cond: (base_tbl.a = base_tbl_1.a)
+         ->  Index Scan using base_tbl_pkey on base_tbl
                Index Cond: (a = 2)
          ->  Hash
                ->  Result
-                     Filter: ((base_tbl_2.a = 2) AND (base_tbl_2.a < 10))
-                     ->  Index Scan using base_tbl_pkey on base_tbl base_tbl_2
+                     Filter: ((base_tbl_1.a = 2) AND (base_tbl_1.a < 10))
+                     ->  Index Scan using base_tbl_pkey on base_tbl base_tbl_1
                            Index Cond: (a > 0)
  Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
 (11 rows)
@@ -2289,7 +2289,7 @@ EXPLAIN (costs off) INSERT INTO rw_view1 VALUES (2, 'New row 2');
  Update on base_tbl
    ->  Nested Loop Semi Join
          Join Filter: true
-         ->  Index Scan using base_tbl_pkey on base_tbl base_tbl_2
+         ->  Index Scan using base_tbl_pkey on base_tbl
                Index Cond: (id = 2)
          ->  Materialize
                ->  Broadcast Motion 1:3  (slice1; segments: 1)

--- a/src/test/regress/expected/update_gp_optimizer.out
+++ b/src/test/regress/expected/update_gp_optimizer.out
@@ -122,14 +122,14 @@ WHERE t1.user_vie_project_code_pk = keo1.user_vie_project_code_pk;
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Update on keo1
    ->  Hash Join
-         Hash Cond: ((keo1_1.user_vie_project_code_pk)::text = (keo1_2.user_vie_project_code_pk)::text)
-         ->  Seq Scan on keo1 keo1_1
+         Hash Cond: ((keo1.user_vie_project_code_pk)::text = (keo1_1.user_vie_project_code_pk)::text)
+         ->  Seq Scan on keo1
          ->  Hash
                ->  Broadcast Motion 3:3  (slice1; segments: 3)
                      ->  Hash Join
-                           Hash Cond: ((keo1_2.user_vie_project_code_pk)::text = (keo2.projects_pk)::text)
+                           Hash Cond: ((keo1_1.user_vie_project_code_pk)::text = (keo2.projects_pk)::text)
                            ->  Hash Join
-                                 Hash Cond: ((max((keo3.sky_per)::text)) = (keo1_2.user_vie_fiscal_year_period_sk)::text)
+                                 Hash Cond: ((max((keo3.sky_per)::text)) = (keo1_1.user_vie_fiscal_year_period_sk)::text)
                                  ->  Redistribute Motion 1:3  (slice2; segments: 1)
                                        ->  Aggregate
                                              ->  Hash Join
@@ -152,7 +152,7 @@ WHERE t1.user_vie_project_code_pk = keo1.user_vie_project_code_pk;
                                                                                              ->  Seq Scan on keo4 keo4_1
                                  ->  Hash
                                        ->  Broadcast Motion 3:3  (slice8; segments: 3)
-                                             ->  Seq Scan on keo1 keo1_2
+                                             ->  Seq Scan on keo1 keo1_1
                            ->  Hash
                                  ->  Broadcast Motion 3:3  (slice9; segments: 3)
                                        ->  Seq Scan on keo2
@@ -182,17 +182,17 @@ EXPLAIN (COSTS OFF) DELETE FROM keo5 WHERE x IN (SELECT x FROM keo5 WHERE EXISTS
 ------------------------------------------------------------------------------------
  Delete on keo5
    ->  Hash Semi Join
-         Hash Cond: (keo5_1.x = keo5_3.x)
-         ->  Seq Scan on keo5 keo5_1
+         Hash Cond: (keo5.x = keo5_2.x)
+         ->  Seq Scan on keo5
          ->  Hash
                ->  Nested Loop Semi Join
                      Join Filter: true
-                     ->  Seq Scan on keo5 keo5_3
+                     ->  Seq Scan on keo5 keo5_2
                      ->  Materialize
                            ->  Broadcast Motion 1:3  (slice1; segments: 1)
                                  ->  Limit
                                        ->  Gather Motion 3:1  (slice2; segments: 3)
-                                             ->  Seq Scan on keo5 keo5_2
+                                             ->  Seq Scan on keo5 keo5_1
                                                    Filter: (x < 2)
  Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
 (15 rows)
@@ -438,9 +438,9 @@ EXPLAIN (COSTS OFF ) UPDATE tab3 SET C1 = C1 + 1, C5 = C5+1;
  Update on tab3
    ->  Result
          ->  Redistribute Motion 3:3  (slice1; segments: 3)
-               Hash Key: tab3_1.c1, tab3_1.c2, tab3_1.c3
+               Hash Key: c1, c2, c3
                ->  Split
-                     ->  Seq Scan on tab3 tab3_1
+                     ->  Seq Scan on tab3
  Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
 (7 rows)
 

--- a/src/test/regress/expected/update_gp_optimizer.out
+++ b/src/test/regress/expected/update_gp_optimizer.out
@@ -879,13 +879,13 @@ where into_table.a=from_table.a and into_table.b=from_table.b and into_table.c=f
  Update on into_table
    ->  Result
          ->  Redistribute Motion 3:3  (slice1; segments: 3)
-               Hash Key: into_table_1.a, into_table_1.b, into_table_1.c
+               Hash Key: into_table.a, into_table.b, into_table.c
                ->  Split
                      ->  Hash Join
-                           Hash Cond: ((into_table_1.a = from_table.a) AND (into_table_1.b = from_table.b) AND (into_table_1.c = from_table.c))
+                           Hash Cond: ((into_table.a = from_table.a) AND (into_table.b = from_table.b) AND (into_table.c = from_table.c))
                            ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                                 Hash Key: into_table_1.a
-                                 ->  Dynamic Seq Scan on into_table into_table_1
+                                 Hash Key: into_table.a
+                                 ->  Dynamic Seq Scan on into_table
                                        Number of partitions to scan: 4 (out of 4)
                            ->  Hash
                                  ->  Seq Scan on from_table


### PR DESCRIPTION
## Problem description

Currently `EPQ` mechanism doesnt't work correctly at `ORCA` planner. Here is example of query which proves that:

```sql
-- gp_enable_global_deadlock_detector is on 
create table test as select 0 as i distributed randomly;

-- Start update transaction
1: begin;
1: update test set i = i + 1;

-- Second session tries to delete modified row and
-- it waits for result of update
2&: delete from test where i = 0;
1: end;
-- as a result updated row was deleted - this is
-- not vaild behaviour (there must be no deletion)
DELETE 1
```

Unlike postgres plan, `SEQSCAN` node (corresponding to `ModifyTable` node) doesn't points to the target(result) relation of the plan. `scanrelid` of `SEQSCAN` node points to the `RTE` `2`, but `resultRelation` has index `1`. Here is a plan:

```
{PLANNEDSTMT 
    ...
   :planTree 
      {MODIFYTABLE
      ... 
      :resultRelations (i 1)
      ...
      :plans (
         {SEQSCAN 
         ...
         :plan_node_id 1
         ... 
         :scanrelid 2
         ...
         }
      )
      ...
      }
   :rtable (
      {RTE 
      :alias <> 
      :eref 
         {ALIAS 
         :aliasname test 
         :colnames (""i"")
         }
      :relid 16548 
      :requiredPerms 8 
      ...
      }
      {RTE 
      :alias <> 
      :eref 
         {ALIAS 
         :aliasname test 
         :colnames (""i"")
         }
      :relid 16548 
      :requiredPerms 2 
      ...
      }
   )
   :resultRelations (i 1)
   :relationOids (o 16548 16548 16548)
   ...
   }
```

EPQ mechanism through function call chain calls `ExecScanFetch`.
Due to incorrect `scanrelid` at `SEQSCAN` node next branch under  `if (estate->es_epqTupleSet[scanrelid - 1])` won't be executed. Thus instead of working with slot from `es_epqTuple` cache - slot with an old row is returned from access method routine - `(*accessMtd) (node)` (which uses snapshot for delete operation). As a result `EvalPlanQual` returns not null slot with an old version of row to `ExecDelete`, but [tupleid points to the updated version and deletion is performed](https://github.com/greenplum-db/gpdb/blob/84a251adfdd87ad8d39af4d123083a7869a21742/src/backend/executor/nodeModifyTable.c#L943-L957)

```c
static inline TupleTableSlot *
ExecScanFetch(ScanState *node,
			  ExecScanAccessMtd accessMtd,
			  ExecScanRecheckMtd recheckMtd)
{
	EState	   *estate = node->ps.state;
    //...
	if (estate->es_epqTupleSlot != NULL)
	{
        // ...
		Index		scanrelid = ((Scan *) node->ps.plan)->scanrelid;

        // ...
		else if (estate->es_epqTupleSlot[scanrelid - 1] != NULL)
		{
			TupleTableSlot *slot = node->ss_ScanTupleSlot;

			/* Return empty slot if we already returned a tuple */
			if (estate->es_epqScanDone[scanrelid - 1])
				return ExecClearTuple(slot);
			/* Else mark to remember that we shouldn't return more */
			estate->es_epqScanDone[scanrelid - 1] = true

			slot = estate->es_epqTupleSlot[scanrelid - 1];
			//...
			return slot;
		}
	}

	/*
	 * Run the node-type-specific access method function to get the next tuple
	 */
	return (*accessMtd) (node);
}
```

At the initial Query structure (parsed and analyzed query) we have right links to `RTE`'s, so to fix the problem with `scanrelid` - we want to transfer this information to the initial algebrized plan tree of orca. So we assign the `queryid` to each query structure (for subqueruies `queryid` assigned too) and, also, we assign `queryid` to table descriptors `CDXLTableDescr` which explicitly refers to target relation of DML (`ModifyTable`). After orca planning transformations this value exposes to which target relation of DML (`ModifyTable`) operation is referred the current table descriptor. And this allows to correctly assign `RTE` indexes in result plan under transformation from `DXL` representation.

## Forced changes

After solving problem with `scanrelid` for `*SCAN` (`SEQSCAN`, `INDEXSCAN` and others) nodes of DML (`ModifyTable`) node
(`scanrelid` of `*SCAN` node corresponding to `ModifyTable` node points to the result/target relation of operation) output of `EXPLAIN` has changed. Thus `regress` tests and `modify_table_data_corrupt` test from `isolation2` was changed.
These changes could be divided into two groups:

### Tests that contains one table at DML (`ModifyTable`) operation

Here is exapmle of some test cases (links from master):

* [updatable_views_optimizer - prefixes at coulumn names and table alias are not needed](https://github.com/greenplum-db/gpdb/blob/84a251adfdd87ad8d39af4d123083a7869a21742/src/test/regress/expected/updatable_views_optimizer.out#L404-L416)

* [update_gp_optimizer - prefixes at coulumn names and table alias are not needed](https://github.com/greenplum-db/gpdb/blob/84a251adfdd87ad8d39af4d123083a7869a21742/src/test/regress/expected/update_gp_optimizer.out#L435-L443)

* [bfv_dml_optimizer - alias for table name is not needed](https://github.com/greenplum-db/gpdb/blob/84a251adfdd87ad8d39af4d123083a7869a21742/src/test/regress/expected/bfv_dml_optimizer.out#L185-L189)

At these tests DML (`ModifyTable`) operation is performed on the one table. Due to fixes of this patch, `ModifyTable` operations at these tests has only one (single) RTE - target relation, unlike it was before (scanrelid of `*SCAN` plan node (correspoinmg to `ModifyTalbe`) didn't point to the result (target) relation and plan contained two rtables, but there should be only one). Thus prefixes to column names at queries, that uses one table is not shown, like it is in postgres. Here is some links to code, related to showing prefix ([setting flag to show prefix](https://github.com/greenplum-db/gpdb/blob/84a251adfdd87ad8d39af4d123083a7869a21742/src/backend/commands/explain_gp.c#L2109) and and function `get_variable`, where prefix [may be appended](https://github.com/greenplum-db/gpdb/blob/84a251adfdd87ad8d39af4d123083a7869a21742/src/backend/utils/adt/ruleutils.c#L6852)).
Also at some tests `explain` aliases was [deleted, because them are equal to the original relation name](https://github.com/greenplum-db/gpdb/blob/84a251adfdd87ad8d39af4d123083a7869a21742/src/backend/commands/explain.c#L4033-L4035)

### Tests with explain (used more than one relation)

Here is an example of some test case (links from master):

* [qp_subquery_optimizer - aliases for table name in explain shouldn't have "_1" suffix](https://github.com/greenplum-db/gpdb/blob/84a251adfdd87ad8d39af4d123083a7869a21742/src/test/regress/expected/qp_subquery_optimizer.out#L1446-L1453)

This test group was changed due to fixes of `scanrelid` too. `scanrelid` for `*SCAN` node of corresponoding `ModifyTable` node now points to the target(result) relation (and rtable list doesn't contain duplicate of `ModifyTable` target relation). Thus `ExplainPrintPlan` calculates list of `relation` names for explain a bit different (in comparsion to what was before) (calcultion is [based on "rels_used" bitmap](https://github.com/greenplum-db/gpdb/blob/84a251adfdd87ad8d39af4d123083a7869a21742/src/backend/commands/explain.c#L895-L897), which now [calculates correctly](https://github.com/greenplum-db/gpdb/blob/84a251adfdd87ad8d39af4d123083a7869a21742/src/backend/commands/explain.c#L1338-L1383) - `ModifyTable` node doesn't insert at bitmap by the fact unused rti, like it was before, so there is no phantom relation name in `rtable_names`). So position of table names (`explain` aliases) with suffixes changed due to fixes of `scanrelid`'. Like at previous test group at some tests `explain` aliases was [deleted, because them are equal to the original relation name](https://github.com/greenplum-db/gpdb/blob/84a251adfdd87ad8d39af4d123083a7869a21742/src/backend/commands/explain.c#L4033-L4035)

### Tests for the patch

The `gdd/concurrent_update.sql` (`expected/gdd/concurrent_update_optimizer.out`) was partially [ported from the 6X_STABLE](https://github.com/greenplum-db/gpdb/blob/f1bf39d23057f24aac1189577262340e4b72054b/src/test/isolation2/sql/gdd/concurrent_update.sql) branch and extended with test case from the description.