### PR TITLE
docs - update sql ref pages for GROUP/ROLE/USER commands

### DIFF
--- a/gpdb-doc/markdown/ref_guide/sql_commands/ALTER_GROUP.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/ALTER_GROUP.html.md
@@ -5,29 +5,37 @@ Changes a role name or membership.
 ## <a id="section2"></a>Synopsis 
 
 ``` {#sql_command_synopsis}
-ALTER GROUP <groupname> ADD USER <username> [, ... ]
+ALTER GROUP <role_specification> ADD USER <user_name> [, ... ]
 
-ALTER GROUP <groupname> DROP USER <username> [, ... ]
+ALTER GROUP <role_specification> DROP USER <user_name> [, ... ]
 
-ALTER GROUP <groupname> RENAME TO <newname>
+where <role_specification> can be:
+
+    <role_name>
+  | CURRENT_USER
+  | SESSION_USER
+
+ALTER GROUP <group_name> RENAME TO <new_name>
 ```
 
 ## <a id="section3"></a>Description 
 
-`ALTER GROUP` changes the attributes of a user group. This is an obsolete command, though still accepted for backwards compatibility, because users and groups are superseded by the more general concept of roles. See [ALTER ROLE](ALTER_ROLE.html) for more information.
+`ALTER GROUP` changes the attributes of a user group. This is an obsolete command, though still accepted for backwards compatibility, because users and groups are superseded by the more general concept of roles.
 
-The first two variants add users to a group or remove them from a group. Any role can play the part of groupname or username. The preferred method for accomplishing these tasks is to use [GRANT](GRANT.html) and [REVOKE](REVOKE.html).
+The first two variants add users to a group or remove them from a group. \(Any role can play the part of either a "user" or "group" for this purpose. These variants are effectively equivalent to granting or revoking membership in the role named as the "group"; so, the preferred way to do this is to use [GRANT](GRANT.html) or [REVOKE](REVOKE.html).
+
+The third variant changes the name of the group. This is exactly equivalent to renaming the role with [ALTER ROLE](ALTER_ROLE.html).
 
 ## <a id="section4"></a>Parameters 
 
-groupname
+group\_name
 :   The name of the group \(role\) to modify.
 
-username
-:   Users \(roles\) that are to be added to or removed from the group. The users \(roles\) must already exist.
+user\_name
+:   Users \(roles\) that are to be added to or removed from the group. The users \(roles\) must already exist; `ALTER GROUP` does not create or drop users.
 
-newname
-:   The new name of the group \(role\).
+new\_name
+:   The new name of the group.
 
 ## <a id="section5"></a>Examples 
 

--- a/gpdb-doc/markdown/ref_guide/sql_commands/ALTER_ROLE.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/ALTER_ROLE.html.md
@@ -23,6 +23,9 @@ where <option> can be:
   | CONNECTION LIMIT <connlimit>
   | [ ENCRYPTED ] PASSWORD '<password>' | PASSWORD NULL
   | VALID UNTIL '<timestamp>'
+  | [ DENY <deny_point> ]
+  | [ DENY BETWEEN <deny_point> AND <deny_point>]
+  | [ DROP DENY FOR <deny_point> ]
 
 ALTER ROLE <name> RENAME TO <new_name>
 

--- a/gpdb-doc/markdown/ref_guide/sql_commands/ALTER_ROLE.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/ALTER_ROLE.html.md
@@ -34,8 +34,8 @@ ALTER ROLE { <role_specification> | ALL } [ IN DATABASE <database_name> ] SET <c
 ALTER ROLE { <role_specification> | ALL } [ IN DATABASE <database_name> ] RESET <configuration_parameter>
 ALTER ROLE { <role_specification> | ALL } [ IN DATABASE <database_name> ] RESET ALL
 
-ALTER ROLE <role_name> RESOURCE QUEUE {<queue_name> | NONE}
-ALTER ROLE <role_name> RESOURCE GROUP {<group_name> | NONE}
+ALTER ROLE <role_specification> RESOURCE QUEUE {<queue_name> | NONE}
+ALTER ROLE <role_specification> RESOURCE GROUP {<group_name> | NONE}
 
 where <role_specification> can be:
 

--- a/gpdb-doc/markdown/ref_guide/sql_commands/ALTER_ROLE.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/ALTER_ROLE.html.md
@@ -5,7 +5,7 @@ Changes a database role \(user or group\).
 ## <a id="section2"></a>Synopsis 
 
 ``` {#sql_command_synopsis}
-ALTER ROLE <name> [ [ WITH ] <option> [ ... ] ]
+ALTER ROLE <role_specification> [ WITH ] <option> [ ... ]
 
 where <option> can be:
 
@@ -19,19 +19,26 @@ where <option> can be:
   | INHERIT | NOINHERIT
   | LOGIN | NOLOGIN
   | REPLICATION | NOREPLICATION
+  | BYPASSRLS | NOBYPASSRLS
   | CONNECTION LIMIT <connlimit>
-  | [ ENCRYPTED | UNENCRYPTED ] PASSWORD '<password>'
+  | [ ENCRYPTED ] PASSWORD '<password>' | PASSWORD NULL
   | VALID UNTIL '<timestamp>'
 
 ALTER ROLE <name> RENAME TO <new_name>
 
-ALTER ROLE { <name> | ALL } [ IN DATABASE <database_name> ] SET <configuration_parameter> { TO | = } { <value> | DEFAULT }
-ALTER ROLE { <name> | ALL } [ IN DATABASE <database_name> ] SET <configuration_parameter> FROM CURRENT
-ALTER ROLE { <name> | ALL } [ IN DATABASE <database_name> ] RESET <configuration_parameter>
-ALTER ROLE { <name> | ALL } [ IN DATABASE <database_name> ] RESET ALL
-ALTER ROLE <name> RESOURCE QUEUE {<queue_name> | NONE}
-ALTER ROLE <name> RESOURCE GROUP {<group_name> | NONE}
+ALTER ROLE { <role_specification> | ALL } [ IN DATABASE <database_name> ] SET <configuration_parameter> { TO | = } { <value> | DEFAULT }
+ALTER ROLE { <role_specification> | ALL } [ IN DATABASE <database_name> ] SET <configuration_parameter> FROM CURRENT
+ALTER ROLE { <role_specification> | ALL } [ IN DATABASE <database_name> ] RESET <configuration_parameter>
+ALTER ROLE { <role_specification> | ALL } [ IN DATABASE <database_name> ] RESET ALL
 
+ALTER ROLE <role_name> RESOURCE QUEUE {<queue_name> | NONE}
+ALTER ROLE <role_name> RESOURCE GROUP {<group_name> | NONE}
+
+where <role_specification> can be:
+
+    <role_name>
+  | CURRENT_USER
+  | SESSION_USER
 ```
 
 ## <a id="section3"></a>Description 
@@ -39,22 +46,20 @@ ALTER ROLE <name> RESOURCE GROUP {<group_name> | NONE}
 `ALTER ROLE` changes the attributes of a Greenplum Database role. There are several variants of this command.
 
 **WITH option**
-:   Changes many of the role attributes that can be specified in [CREATE ROLE](CREATE_ROLE.html). \(All of the possible attributes are covered, execept that there are no options for adding or removing memberships; use [GRANT](GRANT.html) and [REVOKE](REVOKE.html) for that.\) Attributes not mentioned in the command retain their previous settings. Database superusers can change any of these settings for any role. Roles having `CREATEROLE` privilege can change any of these settings, but only for non-superuser and non-replication roles. Ordinary roles can only change their own password.
+:   Changes many of the role attributes that can be specified in [CREATE ROLE](CREATE_ROLE.html). \(All of the possible attributes are covered, execept that there are no options for adding or removing memberships; use [GRANT](GRANT.html) and [REVOKE](REVOKE.html) for that.\) Attributes not mentioned in the command retain their previous settings. Database superusers can change any of these settings for any role. Roles having `CREATEROLE` privilege can change any of these settings except `SUPERUSER`, `REPLICATION`, and `BYPASSRLS`, but only for non-superuser and non-replication roles. Ordinary roles can only change their own password.
 
 **RENAME**
 :   Changes the name of the role. Database superusers can rename any role. Roles having `CREATEROLE` privilege can rename non-superuser roles. The current session user cannot be renamed \(connect as a different user to rename a role\). Because MD5-encrypted passwords use the role name as cryptographic salt, renaming a role clears its password if the password is MD5-encrypted.
 
 **SET \| RESET**
-:   Changes a role's session default for a specified configuration parameter, either for all databases or, when the `IN DATABASE` clause is specified, only for sessions in the named database. If `ALL` is specified instead of a role name, this changes the setting for all roles. Using `ALL` with `IN DATABASE` is effectively the same as using the command `ALTER DATABASE...SET...`.
+:   Changes a role's session default for a specified configuration parameter, either for all databases or, when the `IN DATABASE` clause is specified, only for sessions in the named database. If `ALL` is specified instead of a role name, this changes the setting for all roles. Using `ALL` with `IN DATABASE` is effectively the same as using the command `ALTER DATABASE ... SET ...`.
 
-    Whenever the role subsequently starts a new session, the specified value becomes the session default, overriding whatever setting is present in the server configuration file \(`postgresql.conf`\) or has been received from the `postgres` command line. This only happens at login time; running [SET ROLE](SET_ROLE.html) or [SET SESSION AUTHORIZATION](SET_SESSION_AUTHORIZATION.html) does not cause new configuration values to be set.
+    Whenever the role subsequently starts a new session, the specified value becomes the session default, overriding whatever setting is present in the server configuration file \(`postgresql.conf`\) or has been received from the `postgres` command line. This only happens at login time; running [SET ROLE](SET_ROLE.html) or [SET SESSION AUTHORIZATION](SET_SESSION_AUTHORIZATION.html) does not cause new configuration values to be set. Settings set for all databases are overridden by database-specific settings attached to a role. Settings for specific databases or specific roles override settings for all roles.
 
-    Database-specific settings attached to a role override settings for all databases. Settings for specific databases or specific roles override settings for all roles.
-
-    For a role without `LOGIN` privilege, session defaults have no effect. Ordinary roles can change their own session defaults. Superusers can change anyone's session defaults. Roles having `CREATEROLE` privilege can change defaults for non-superuser roles. Ordinary roles can only set defaults for themselves. Certain configuration variables cannot be set this way, or can only be set if a superuser issues the command. See the *Greenplum Database Reference Guide* for information about all user-settable configuration parameters. Only superusers can change a setting for all roles in all databases.
+    Superusers can change anyone's session defaults. Roles having `CREATEROLE` privilege can change defaults for non-superuser roles. Ordinary roles can only set defaults for themselves. Certain configuration variables cannot be set this way, or can only be set if a superuser issues the command. Only superusers can change a setting for all roles in all databases.
 
 **RESOURCE QUEUE**
-:   Assigns the role to a resource queue. The role would then be subject to the limits assigned to the resource queue when issuing queries. Specify `NONE` to assign the role to the default resource queue. A role can only belong to one resource queue. For a role without `LOGIN` privilege, resource queues have no effect. See [CREATE RESOURCE QUEUE](CREATE_RESOURCE_QUEUE.html) for more information.
+:   Assigns the role to a resource queue. The role would then be subject to the limits assigned to the resource queue when issuing queries. Specify `NONE` to assign the role to the default resource queue. A role can belong to only one resource queue. For a role without `LOGIN` privilege, resource queues have no effect. See [CREATE RESOURCE QUEUE](CREATE_RESOURCE_QUEUE.html) for more information.
 
 **RESOURCE GROUP**
 :   Assigns a resource group to the role. The role would then be subject to the concurrent transaction, memory, and CPU limits configured for the resource group. You can assign a single resource group to one or more roles. You cannot assign a resource group that you create for an external component to a role. See [CREATE RESOURCE GROUP](CREATE_RESOURCE_GROUP.html) for additional information.
@@ -64,18 +69,45 @@ ALTER ROLE <name> RESOURCE GROUP {<group_name> | NONE}
 name
 :   The name of the role whose attributes are to be altered.
 
+CURRENT_USER
+:   Alter the current user instead of an explicitly identified role.
+
+SESSION_USER
+:   Alter the current session user instead of an explicitly identified role.
+
+SUPERUSER
+NOSUPERUSER
+CREATEDB
+NOCREATEDB
+CREATEROLE
+NOCREATEROLE
+INHERIT
+NOINHERIT
+LOGIN
+NOLOGIN
+REPLICATION
+NOREPLICATION
+BYPASSRLS
+NOBYPASSRLS
+CONNECTION LIMIT connlimit
+[ ENCRYPTED ] PASSWORD 'password'
+PASSWORD NULL
+VALID UNTIL 'timestamp'
+:   These clauses alter attributes originally set by `CREATE ROLE`. For more information, see the [CREATE ROLE](CREATE_ROLE.html) reference page.
+
 new\_name
 :   The new name of the role.
 
 database\_name
 :   The name of the database in which to set the configuration parameter.
 
-config\_parameter=value
-:   Set this role's session default for the specified configuration parameter to the given value. If value is `DEFAULT` or if `RESET` is used, the role-specific parameter setting is removed, so the role will inherit the system-wide default setting in new sessions. Use `RESET ALL` to clear all role-specific settings. `SET FROM CURRENT` saves the session's current value of the parameter as the role-specific value. If `IN DATABASE` is specified, the configuration parameter is set or removed for the given role and database only. Whenever the role subsequently starts a new session, the specified value becomes the session default, overriding whatever setting is present in `postgresql.conf` or has been received from the `postgres` command line.
+configuration\_parameter
+value
+:   Set this role's session default for the specified configuration parameter to the given value. If value is `DEFAULT` or, equivalently, `RESET` is used, the role-specific parameter setting is removed, so the role will inherit the system-wide default setting in new sessions. Use `RESET ALL` to clear all role-specific settings. `SET FROM CURRENT` saves the session's current value of the parameter as the role-specific value. If `IN DATABASE` is specified, the configuration parameter is set or removed for the given role and database only.
 
-:   Role-specific variable settings take effect only at login; `SET ROLE` and [SET SESSION AUTHORIZATION](SET_SESSION_AUTHORIZATION.html) do not process role-specific variable settings.
+:   Role-specific variable settings take effect only at login; [SET ROLE](SET_ROLE.html) and [SET SESSION AUTHORIZATION](SET_SESSION_AUTHORIZATION.html) do not process role-specific variable settings.
 
-:   See [Server Configuration Parameters](../config_params/guc_config.html) for information about user-settable configuration parameters.
+:   See [SET](SET.html) and [Server Configuration Parameters](../config_params/guc_config.html) for more information about allowed parameter names and values.
 
 group\_name
 :   The name of the resource group to assign to this role. Specifying the group\_name `NONE` removes the role's current resource group assignment and assigns a default resource group based on the role's capability. `SUPERUSER` roles are assigned the `admin_group` resource group, while the `default_group` resource group is assigned to non-admin roles.
@@ -83,76 +115,15 @@ group\_name
 :   You cannot assign a resource group that you create for an external component to a role.
 
 queue\_name
-:   The name of the resource queue to which the user-level role is to be assigned. Only roles with `LOGIN` privilege can be assigned to a resource queue. To unassign a role from a resource queue and put it in the default resource queue, specify `NONE`. A role can only belong to one resource queue.
-
-SUPERUSER \| NOSUPERUSER
-CREATEDB \| NOCREATEDB
-CREATEROLE \| NOCREATEROLE
-CREATEUSER \| NOCREATEUSER
-:   `CREATEUSER` and `NOCREATEUSER` are obsolete, but still accepted, spellings of `SUPERUSER` and `NOSUPERUSER`. Note that they are not equivalent to the `CREATEROLE and` `NOCREATEROLE` clauses.
-
-CREATEEXTTABLE \| NOCREATEEXTTABLE \[\(attribute='value'\)\]
-:   If `CREATEEXTTABLE` is specified, the role being defined is allowed to create external tables. The default `type` is `readable` and the default `protocol` is `gpfdist` if not specified. `NOCREATEEXTTABLE` \(the default\) denies the role the ability to create external tables. Note that external tables that use the `file` or `execute` protocols can only be created by superusers.
-
-INHERIT \| NOINHERIT
-LOGIN \| NOLOGIN
-REPLICATION
-NOREPLICATION
-CONNECTION LIMIT connlimit
-PASSWORD password
-ENCRYPTED \| UNENCRYPTED
-VALID UNTIL 'timestamp'
-:   These clauses alter role attributes originally set by `[CREATE ROLE](CREATE_ROLE.html)`.
-
-DENY deny\_point
-DENY BETWEEN deny\_point AND deny\_point
-:   The `DENY` and `DENY BETWEEN` keywords set time-based constraints that are enforced at login. `DENY` sets a day or a day and time to deny access. `DENY BETWEEN` sets an interval during which access is denied. Both use the parameter deny\_point that has following format:
-
-    ```
-    DAY day [ TIME 'time' ]
-    ```
-
-:   The two parts of the `deny_point` parameter use the following formats:
-
-    For day:
-
-    ```
-    {'Sunday' | 'Monday' | 'Tuesday' |'Wednesday' | 'Thursday' | 'Friday' | 
-    'Saturday' | 0-6 }
-    ```
-
-    For `time:`
-
-    ```
-    { 00-23 : 00-59 | 01-12 : 00-59 { AM | PM }}
-    ```
-
-    The `DENY BETWEEN` clause uses two deny\_point parameters which must indicate day and time.
-
-    ```
-    DENY BETWEEN <deny_point> AND <deny_point>
-    ```
-
-    For example:
-
-    ```
-    ALTER USER user1 DENY BETWEEN day 'Sunday' time '00:00' AND day 'Monday' time '00:00'; 
-    ```
-
-    For more information about time-based constraints and examples, see "Managing Roles and Privileges" in the *Greenplum Database Administrator Guide*.
-
-DROP DENY FOR deny\_point
-:   The `DROP DENY FOR` clause removes a time-based constraint from the role. It uses the deny\_point parameter described above.
-
-:   For more information about time-based constraints and examples, see "Managing Roles and Privileges" in the *Greenplum Database Administrator Guide*.
+:   The name of the resource queue to which the user-level role is to be assigned. Only roles with `LOGIN` privilege can be assigned to a resource queue. To unassign a role from a resource queue and put it in the default resource queue, specify `NONE`. A role can belong only to one resource queue.
 
 ## <a id="section5"></a>Notes 
 
-Use [CREATE ROLE](CREATE_ROLE.html) to add new roles, and [DROP ROLE](DROP_ROLE.html) to remove a role.
+Use [CREATE ROLE](CREATE_ROLE.html) to add a new role, and [DROP ROLE](DROP_ROLE.html) to remove a role.
 
-Use [GRANT](GRANT.html) and [REVOKE](REVOKE.html) for adding and removing role memberships.
+`ALTER ROLE` cannot change a role's memberships; use [GRANT](GRANT.html) and [REVOKE](REVOKE.html) to do that.
 
-Caution must be exercised when specifying an unencrypted password with this command. The password will be transmitted to the server in clear text, and it might also be logged in the client's command history or the server log. The `psql` command-line client contains a meta-command `\password` that can be used to change a role's password without exposing the clear text password.
+You must exercise caution when specifying an unencrypted password with this command. The password will be transmitted to the server in clear text, and it might also be logged in the client's command history or the server log. The [psql](../../utility_guide/ref/psql.html) command-line client contains a meta-command `\password` that can be used to change a role's password without exposing the clear text password.
 
 It is also possible to tie a session default to a specific database rather than to a role; see [ALTER DATABASE](ALTER_DATABASE.html). If there is a conflict, database-role-specific settings override role-specific ones, which in turn override database-specific ones.
 
@@ -170,10 +141,10 @@ Remove a role's password:
 ALTER ROLE daria WITH PASSWORD NULL;
 ```
 
-Change a password expiration date:
+Change a password expiration date, specifying that the password should expire at midday on 4th May 2022 using the time zone which is one hour ahead of UTC:
 
 ```
-ALTER ROLE scott VALID UNTIL 'May 4 12:00:00 2015 +1';
+ALTER ROLE scott VALID UNTIL 'May 4 12:00:00 2022 +1';
 ```
 
 Make a password valid forever:

--- a/gpdb-doc/markdown/ref_guide/sql_commands/ALTER_USER.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/ALTER_USER.html.md
@@ -1,6 +1,6 @@
 # ALTER USER 
 
-Changes the defintion of a database role.
+Changes the definition of a database role.
 
 ## <a id="section2"></a>Synopsis 
 

--- a/gpdb-doc/markdown/ref_guide/sql_commands/ALTER_USER.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/ALTER_USER.html.md
@@ -24,6 +24,9 @@ where option can be:
     | CONNECTION LIMIT <connlimit>
     | [ENCRYPTED ] PASSWORD '<password>' | PASSWORD NULL
     | VALID UNTIL '<timestamp>'
+    | [ DENY <deny_point> ]
+    | [ DENY BETWEEN <deny_point> AND <deny_point>]
+    | [ DROP DENY FOR <deny_point> ]
 
 ALTER USER <name> RENAME TO <new_name>
 

--- a/gpdb-doc/markdown/ref_guide/sql_commands/ALTER_USER.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/ALTER_USER.html.md
@@ -1,30 +1,17 @@
 # ALTER USER 
 
-Changes the definition of a database role \(user\).
+Changes the defintion of a database role.
 
 ## <a id="section2"></a>Synopsis 
 
 ``` {#sql_command_synopsis}
-ALTER USER <name> RENAME TO <newname>
-
-ALTER USER <name> SET <config_parameter> {TO | =} {<value> | DEFAULT}
-
-ALTER USER <name> RESET <config_parameter>
-
-ALTER USER <name> RESOURCE QUEUE {<queue_name> | NONE}
-
-ALTER USER <name> RESOURCE GROUP {<group_name> | NONE}
-
-ALTER USER <name> [ [WITH] <option> [ ... ] ]
-```
+ALTER USER <role_specification> [WITH] <option> [ ... ]
 
 where option can be:
 
-```
       SUPERUSER | NOSUPERUSER
     | CREATEDB | NOCREATEDB
     | CREATEROLE | NOCREATEROLE
-    | CREATEUSER | NOCREATEUSER
     | CREATEEXTTABLE | NOCREATEEXTTABLE 
       [ ( <attribute>='<value>'[, ...] ) ]
            where <attributes> and <value> are:
@@ -33,17 +20,32 @@ where option can be:
     | INHERIT | NOINHERIT
     | LOGIN | NOLOGIN
     | REPLICATION | NOREPLICATION
+    | BYPASSRLS | NOBYPASSRLS
     | CONNECTION LIMIT <connlimit>
-    | [ENCRYPTED | UNENCRYPTED] PASSWORD '<password>'
+    | [ENCRYPTED ] PASSWORD '<password>' | PASSWORD NULL
     | VALID UNTIL '<timestamp>'
-    | [ DENY <deny_point> ]
-    | [ DENY BETWEEN <deny_point> AND <deny_point>]
-    | [ DROP DENY FOR <deny_point> ]
+
+ALTER USER <name> RENAME TO <new_name>
+
+ALTER USER <name> RESOURCE QUEUE {<queue_name> | NONE}
+
+ALTER USER <name> RESOURCE GROUP {<group_name> | NONE}
+
+ALTER USER { <role_specification> | ALL } [ IN DATABASE <database_name> ] SET <configuration_parameter> {TO | =} {<value> | DEFAULT}
+ALTER USER { <role_specification> | ALL } [ IN DATABASE <database_name> ] SET <configuration_parameter> FROM CURRENT
+ALTER USER { <role_specification> | ALL } [ IN DATABASE <database_name> ] RESET <configuration_parameter>
+ALTER USER { <role_specification> | ALL } [ IN DATABASE <database_name> ] RESET ALL
+
+where <role_specification> can be:
+
+    role_name
+  | CURRENT_USER
+  | SESSION_USER
 ```
 
 ## <a id="section3"></a>Description 
 
-`ALTER USER` is an alias for `ALTER ROLE`. See [ALTER ROLE](ALTER_ROLE.html) for more information.
+`ALTER USER` is an alias for [ALTER ROLE](ALTER_ROLE.html).
 
 ## <a id="section4"></a>Compatibility 
 
@@ -51,7 +53,7 @@ The `ALTER USER` statement is a Greenplum Database extension. The SQL standard l
 
 ## <a id="section5"></a>See Also 
 
-[ALTER ROLE](ALTER_ROLE.html), [CREATE USER](CREATE_USER.html), [DROP USER](DROP_USER.html)
+[ALTER ROLE](ALTER_ROLE.html)
 
 **Parent topic:** [SQL Commands](../sql_commands/sql_ref.html)
 

--- a/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_GROUP.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_GROUP.html.md
@@ -14,7 +14,6 @@ where option can be:
       SUPERUSER | NOSUPERUSER
     | CREATEDB | NOCREATEDB
     | CREATEROLE | NOCREATEROLE
-    | CREATEUSER | NOCREATEUSER
     | CREATEEXTTABLE | NOCREATEEXTTABLE 
       [ ( <attribute>='<value>'[, ...] ) ]
            where <attributes> and <value> are:
@@ -22,16 +21,19 @@ where option can be:
            protocol='gpfdist'|'http'
     | INHERIT | NOINHERIT
     | LOGIN | NOLOGIN
+    | REPLICATION | NOREPLICATION
+    | BYPASSRLS | NOBYPASSRLS
     | CONNECTION LIMIT <connlimit>
-    | [ ENCRYPTED | UNENCRYPTED ] PASSWORD '<password>'
+    | [ ENCRYPTED | UNENCRYPTED ] PASSWORD '<password>' | PASSWORD NULL
     | VALID UNTIL '<timestamp>' 
-    | IN ROLE <rolename> [, ...]
-    | ROLE <rolename> [, ...]
-    | ADMIN <rolename> [, ...]
+    | IN ROLE <role_name> [, ...]
+    | IN GROUP <role_name> [, ...]
+    | ROLE <role_name> [, ...]
+    | ADMIN <role_name> [, ...]
+    | USER <role_name> [, ...]
+    | SYSID <uid> [, ...]
     | RESOURCE QUEUE <queue_name>
     | RESOURCE GROUP <group_name>
-    | [ DENY <deny_point> ]
-    | [ DENY BETWEEN <deny_point> AND <deny_point>]
 ```
 
 ## <a id="section3"></a>Description 

--- a/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_GROUP.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_GROUP.html.md
@@ -34,6 +34,8 @@ where option can be:
     | SYSID <uid> [, ...]
     | RESOURCE QUEUE <queue_name>
     | RESOURCE GROUP <group_name>
+    | [ DENY <deny_point> ]
+    | [ DENY BETWEEN <deny_point> AND <deny_point>]
 ```
 
 ## <a id="section3"></a>Description 

--- a/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_ROLE.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_ROLE.html.md
@@ -14,7 +14,6 @@ where option can be:
       SUPERUSER | NOSUPERUSER
     | CREATEDB | NOCREATEDB
     | CREATEROLE | NOCREATEROLE
-    | CREATEUSER | NOCREATEUSER
     | CREATEEXTTABLE | NOCREATEEXTTABLE 
       [ ( <attribute>='<value>'[, ...] ) ]
            where <attributes> and <value> are:
@@ -23,18 +22,18 @@ where option can be:
     | INHERIT | NOINHERIT
     | LOGIN | NOLOGIN
     | REPLICATION | NOREPLICATION
+    | BYPASSRLS | NOBYPASSRLS
     | CONNECTION LIMIT <connlimit>
-    | [ ENCRYPTED | UNENCRYPTED ] PASSWORD '<password>'
+    | [ ENCRYPTED ] PASSWORD '<password>' | PASSWORD NULL
     | VALID UNTIL '<timestamp>' 
-    | IN ROLE <rolename> [, ...]
-    | ROLE <rolename> [, ...]
-    | ADMIN <rolename> [, ...]
-    | USER <rolename> [, ...]
+    | IN ROLE <role_name> [, ...]
+    | IN GROUP <role_name> [, ...]
+    | ROLE <role_name> [, ...]
+    | ADMIN <role_name> [, ...]
+    | USER <role_name> [, ...]
     | SYSID <uid> [, ...]
     | RESOURCE QUEUE <queue_name>
     | RESOURCE GROUP <group_name>
-    | [ DENY <deny_point> ]
-    | [ DENY BETWEEN <deny_point> AND <deny_point>]
 ```
 
 ## <a id="section3"></a>Description 
@@ -50,19 +49,15 @@ name
 
 SUPERUSER
 NOSUPERUSER
-:   If `SUPERUSER` is specified, the role being defined will be a superuser, who can override all access restrictions within the database. Superuser status is dangerous and should be used only when really needed. You must yourself be a superuser to create a new superuser. `NOSUPERUSER` is the default.
+:   These clauses determine whether the new role is a "superuser". If `SUPERUSER` is specified, the role being defined will be a superuser, who can override all access restrictions within the database. Superuser status is dangerous and should be used only when really needed. You must yourself be a superuser to create a new superuser. `NOSUPERUSER` is the default.
 
 CREATEDB
 NOCREATEDB
-:   If `CREATEDB` is specified, the role being defined will be allowed to create new databases. `NOCREATEDB` \(the default\) will deny a role the ability to create databases.
+:   These clauses define a role's ability to create databases. If `CREATEDB` is specified, the role being defined will be allowed to create new databases. Specifying `NOCREATEDB` \(the default\) will deny a role the ability to create databases.
 
 CREATEROLE
 NOCREATEROLE
-:   If `CREATEROLE` is specified, the role being defined will be allowed to create new roles, alter other roles, and drop other roles. `NOCREATEROLE` \(the default\) will deny a role the ability to create roles or modify roles other than their own.
-
-CREATEUSER
-NOCREATEUSER
-:   These clauses are obsolete, but still accepted, spellings of `SUPERUSER` and `NOSUPERUSER`. Note that they are not equivalent to the `CREATEROLE` and `NOCREATEROLE` clauses.
+:   These clauses determine whether a role will be permitted to create new roles (that is, execute `CREATE ROLE`). If `CREATEROLE` is specified, the role being defined will be allowed to create new roles, alter other roles, and drop other roles. `NOCREATEROLE` \(the default\) will deny a role the ability to create roles or modify roles other than their own.
 
 CREATEEXTTABLE
 NOCREATEEXTTABLE
@@ -72,37 +67,51 @@ NOCREATEEXTTABLE
 
 INHERIT
 NOINHERIT
-:   If specified, `INHERIT` \(the default\) allows the role to use whatever database privileges have been granted to all roles it is directly or indirectly a member of. With `NOINHERIT`, membership in another role only grants the ability to `SET ROLE` to that other role.
+:   These clauses determine whether a role "inherits" the privileges of roles it is a member of. If specified, `INHERIT` \(the default\) allows the role to use whatever database privileges have been granted to all roles it is directly or indirectly a member of. With `NOINHERIT`, membership in another role only grants the ability to `SET ROLE` to that other role; the privileges of the other role are only available after having done so.
 
 LOGIN
 NOLOGIN
-:   If specified, `LOGIN` allows a role to log in to a database. A role having the `LOGIN` attribute can be thought of as a user. Roles with `NOLOGIN` are useful for managing database privileges, and can be thought of as groups. If not specified, `NOLOGIN` is the default, except when `CREATE ROLE` is invoked through its alternative spelling [CREATE USER](CREATE_USER.html).
+:   These clauses determine whether a role is allowed to log in; that is, whether the role can be given as the initial session authorization name during client connection. If specified, `LOGIN` allows a role to log in to a database. A role having the `LOGIN` attribute can be thought of as a user. Roles with `NOLOGIN` are useful for managing database privileges, but are not users in the usual sense of the word. If not specified, `NOLOGIN` is the default, except when `CREATE ROLE` is invoked through its alternative spelling [CREATE USER](CREATE_USER.html).
 
 REPLICATION
 NOREPLICATION
-:   These clauses determine whether a role is allowed to initiate streaming replication or put the system in and out of backup mode. A role having the `REPLICATION` attribute is a very highly privileged role, and should only be used on roles actually used for replication. If not specified, `NOREPLICATION` is the default .
+:   These clauses determine whether a role is a replication role. A role must have this attribute \(or be a superuser\) in order to be able to connect to the server in replication mode \(physical or logical replication\) and in order to be able to create or drop replication slots. A role having the `REPLICATION` attribute is a very highly privileged role, and should only be used on roles actually used for replication. If not specified, `NOREPLICATION` is the default. You must be a superuser to create a new role having the `REPLICATION` attribute.
+
+BYPASSRLS
+NOBYPASSRLS
+:   These clauses determine whether a role bypasses every row-level security \(RLS\) policy. `NOBYPASSRLS` is the default. You must be a superuser to create a new role having the `BYPASSRLS` attribute.
+
+:   Note that `pg_dump` will set row_security to `OFF` by default, to ensure all contents of a table are dumped out. If the user running `pg_dump` does not have appropriate permissions, an error will be returned. However, superusers and the owner of the table being dumped always bypass RLS.
 
 CONNECTION LIMIT connlimit
-:   The number maximum of concurrent connections this role can make. The default of -1 means there is no limitation.
+:   If role can log in, this specifies how many concurrent connections the role can make. The default of `-1` means there is no limit. Note that only normal connections are counted towards this limit. Neither prepared transactions nor background worker connections are counted towards this limit.
 
-PASSWORD password
-:   Sets the user password for roles with the `LOGIN` attribute. If you do not plan to use password authentication you can omit this option. If no password is specified, the password will be set to null and password authentication will always fail for that user. A null password can optionally be written explicitly as `PASSWORD NULL`.
-
-ENCRYPTED
-UNENCRYPTED
-:   These key words control whether the password is stored encrypted in the system catalogs. \(If neither is specified, the default behavior is determined by the configuration parameter password\_encryption.\) If the presented password string is already in MD5-encrypted format, then it is stored encrypted as-is, regardless of whether `ENCRYPTED` or `UNENCRYPTED` is specified \(since the system cannot decrypt the specified encrypted password string\). This allows reloading of encrypted passwords during dump/restore.
+[ ENCRYPTED ] PASSWORD 'password'
+PASSWORD NULL
+:   Sets the role's password. \(A password is only of use for roles having the `LOGIN` attribute, but you can nonetheless define one for roles without it.\) If you do not plan to use password authentication you can omit this option. If no password is specified, the password will be set to null and password authentication will always fail for that user. A null password can optionally be written explicitly as `PASSWORD NULL`.
+    <div class="note><b>Note:</b>  Specifying an empty string will also set the password to null, but that was not the case before Greenplum Database version 7. In earlier versions, an empty string could be used, or not, depending on the authentication method and the exact version, and `libpq` would refuse to use it in any case. To avoid the ambiguity, specifying an empty string should be avoided.</div>
+:   The password is always stored encrypted in the system catalogs. The `ENCRYPTED` keyword has no effect, but is accepted for backwards compatibility. The method of encryption is determined by the configuration parameter `password_encryption`. If the presented password string is already in MD5-encrypted or SCRAM-encrypted format, then it is stored as-is regardless of `password_encryption` \(since the system cannot decrypt the specified encrypted password string, to encrypt it in a different format\). This allows reloading of encrypted passwords during dump/restore.
 
 VALID UNTIL 'timestamp'
 :   The VALID UNTIL clause sets a date and time after which the role's password is no longer valid. If this clause is omitted the password will never expire.
 
-IN ROLE rolename
-:   Adds the new role as a member of the named roles. Note that there is no option to add the new role as an administrator; use a separate `GRANT` command to do that.
+IN ROLE role\_name
+:   Adds the new role as a member of the named roles. \(Note that there is no option to add the new role as an administrator; use a separate `GRANT` command to do that.\)
 
-ROLE rolename
-:   Adds the named roles as members of this role, making this new role a group.
+IN GROUP role\_name
+:   `IN GROUP` is an obsolete spelling of `IN ROLE`.
+
+ROLE role\_name
+:   Adds the named roles as members of this role. \(This in effect makes the new role a "group".\)
 
 ADMIN rolename
 :   The `ADMIN` clause is like `ROLE`, but the named roles are added to the new role `WITH ADMIN OPTION`, giving them the right to grant membership in this role to others.
+
+USER role\_name
+:   The `USER` clause is an obsolete spelling of the `ROLE` clause.
+
+SYSID uid
+:   The `SYSID` clause is ignored, but is accepted for backwards compatibility.
 
 RESOURCE GROUP group\_name
 :   The name of the resource group to assign to the new role. The role will be subject to the concurrent transaction, memory, and CPU limits configured for the resource group. You can assign a single resource group to one or more roles.
@@ -120,52 +129,25 @@ RESOURCE QUEUE queue\_name
 
 :   Roles with the `SUPERUSER` attribute are exempt from resource queue limits. For a superuser role, queries always run immediately regardless of limits imposed by an assigned resource queue.
 
-DENY deny\_point
-DENY BETWEEN deny\_point AND deny\_point
-:   The `DENY` and `DENY BETWEEN` keywords set time-based constraints that are enforced at login. `DENY` sets a day or a day and time to deny access. `DENY BETWEEN` sets an interval during which access is denied. Both use the parameter deny\_point that has the following format:
-
-```
-DAY day [ TIME 'time' ]
-```
-
-The two parts of the `deny_point` parameter use the following formats:
-
-For `day`:
-
-```
-{'Sunday' | 'Monday' | 'Tuesday' |'Wednesday' | 'Thursday' | 'Friday' | 
-'Saturday' | 0-6 }
-```
-
-For `time`:
-
-```
-{ 00-23 : 00-59 | 01-12 : 00-59 { AM | PM }}
-```
-
-The `DENY BETWEEN` clause uses two deny\_point parameters:
-
-```
-DENY BETWEEN <deny_point> AND <deny_point>
-```
-
-For more information and examples about time-based constraints, see "Managing Roles and Privileges" in the *Greenplum Database Administrator Guide*.
-
 ## <a id="section5"></a>Notes 
 
-The preferred way to add and remove role members \(manage groups\) is to use [GRANT](GRANT.html) and [REVOKE](REVOKE.html).
+Use [ALTER ROLE](ALTER_ROLE.html) to change the attributes of a role, and [DROP ROLE](DROP_ROLE.html) to remove a role. All the attributes specified by `CREATE ROLE` can be modified by later `ALTER ROLE` commands.
 
-The `VALID UNTIL` clause defines an expiration time for a password only, not for the role. The expiration time is not enforced when logging in using a non-password-based authentication method.
+The preferred way to add and remove role members of roles is to use [GRANT](GRANT.html) and [REVOKE](REVOKE.html).
 
-The `INHERIT` attribute governs inheritance of grantable privileges \(access privileges for database objects and role memberships\). It does not apply to the special role attributes set by `CREATE ROLE` and `ALTER ROLE`. For example, being a member of a role with `CREATEDB` privilege does not immediately grant the ability to create databases, even if `INHERIT` is set. These privileges/attributes are never inherited: `SUPERUSER`, `CREATEDB`, `CREATEROLE`, `CREATEEXTTABLE`, `LOGIN`, `RESOURCE GROUP`, and `RESOURCE QUEUE`. The attributes must be set on each user-level role.
+The `VALID UNTIL` clause defines an expiration time for a password only, not for the role *per se*. The expiration time is not enforced when logging in using a non-password-based authentication method.
+
+The `INHERIT` attribute governs inheritance of grantable privileges \(access privileges for database objects and role memberships\). It does not apply to the special role attributes set by `CREATE ROLE` and `ALTER ROLE`. For example, being a member of a role with `CREATEDB` privilege does not immediately grant the ability to create databases, even if `INHERIT` is set; it would be necessary to become that role via [SET ROLE](SET_ROLE.html) before creating a database.
 
 The `INHERIT` attribute is the default for reasons of backwards compatibility. In prior releases of Greenplum Database, users always had access to all privileges of groups they were members of. However, `NOINHERIT` provides a closer match to the semantics specified in the SQL standard.
 
 Be careful with the `CREATEROLE` privilege. There is no concept of inheritance for the privileges of a `CREATEROLE`-role. That means that even if a role does not have a certain privilege but is allowed to create other roles, it can easily create another role with different privileges than its own \(except for creating roles with superuser privileges\). For example, if a role has the `CREATEROLE` privilege but not the `CREATEDB` privilege, it can create a new role with the `CREATEDB` privilege. Therefore, regard roles that have the `CREATEROLE` privilege as almost-superuser-roles.
 
-The `CONNECTION LIMIT` option is never enforced for superusers.
+Greenplum Database includes a program [createuser](../../utility_guide/ref/createuser.html) that has the same functionality as `CREATE ROLE` \(in fact, it calls this command\) but can be run from the command shell.
 
-Caution must be exercised when specifying an unencrypted password with this command. The password will be transmitted to the server in clear-text, and it might also be logged in the client's command history or the server log. The client program `createuser`, however, transmits the password encrypted. Also, psql contains a command `\password` that can be used to safely change the password later.
+The `CONNECTION LIMIT` option is only enforced approximately; if two new sessions start at about the same time when just one connection "slot" remains for the role, it is possible that both will fail. Also, the limit is never enforced for superusers.
+
+You must exercise caution when specifying an unencrypted password with this command. The password will be transmitted to the server in clear-text, and it might also be logged in the client's command history or the server log. The client program [createuser](../../utility_guide/ref/createuser.html), however, transmits the password encrypted. Also, [psql](../../utility_guide/ref/psql.html) contains a command `\password` that can be used to safely change the password later.
 
 ## <a id="section6"></a>Examples 
 
@@ -175,28 +157,24 @@ Create a role that can log in, but don't give it a password:
 CREATE ROLE jonathan LOGIN;
 ```
 
-Create a role that belongs to a resource queue:
+Create a role with a password:
 
 ```
-CREATE ROLE jonathan LOGIN RESOURCE QUEUE poweruser;
+CREATE USER davide WITH PASSWORD 'jw8s0F4';
 ```
 
-Create a role with a password that is valid until the end of 2016 \(`CREATE USER` is the same as `CREATE ROLE` except that it implies `LOGIN`\):
+\(`CREATE USER` is the same as `CREATE ROLE` except that it implies `LOGIN`.\)
+
+Create a role with a password that is valid until the end of 2022:
 
 ```
-CREATE USER joelle WITH PASSWORD 'jw8s0F4' VALID UNTIL '2017-01-01';
+CREATE USER joelle WITH LOGIN PASSWORD 'jw8s0F4' VALID UNTIL '2023-01-01';
 ```
 
 Create a role that can create databases and manage other roles:
 
 ```
 CREATE ROLE admin WITH CREATEDB CREATEROLE;
-```
-
-Create a role that does not allow login access on Sundays:
-
-```
-CREATE ROLE user3 DENY DAY 'Sunday';
 ```
 
 Create a role that can create readable and writable external tables of type 'gpfdist':
@@ -212,9 +190,13 @@ Create a role, assigning a resource group:
 CREATE ROLE bill RESOURCE GROUP rg_light;
 ```
 
-## <a id="section7"></a>Compatibility 
+Create a role that belongs to a resource queue:
 
-The SQL standard defines the concepts of users and roles, but it regards them as distinct concepts and leaves all commands defining users to be specified by the database implementation. In Greenplum Database users and roles are unified into a single type of object. Roles therefore have many more optional attributes than they do in the standard.
+```
+CREATE ROLE jonathan LOGIN RESOURCE QUEUE poweruser;
+```
+
+## <a id="section7"></a>Compatibility 
 
 `CREATE ROLE` is in the SQL standard, but the standard only requires the syntax:
 
@@ -224,11 +206,13 @@ CREATE ROLE <name> [WITH ADMIN <rolename>]
 
 Allowing multiple initial administrators, and all the other options of `CREATE ROLE`, are Greenplum Database extensions.
 
+The SQL standard defines the concepts of users and roles, but it regards them as distinct concepts and leaves all commands defining users to be specified by the database implementation. In Greenplum Database users and roles are unified into a single type of object. Roles therefore have many more optional attributes than they do in the standard.
+
 The behavior specified by the SQL standard is most closely approximated by giving users the `NOINHERIT` attribute, while roles are given the `INHERIT` attribute.
 
 ## <a id="section8"></a>See Also 
 
-[SET ROLE](SET_ROLE.html), [ALTER ROLE](ALTER_ROLE.html), [DROP ROLE](DROP_ROLE.html), [GRANT](GRANT.html), [REVOKE](REVOKE.html), [CREATE RESOURCE QUEUE](CREATE_RESOURCE_QUEUE.html) [CREATE RESOURCE GROUP](CREATE_RESOURCE_GROUP.html)
+[SET ROLE](SET_ROLE.html), [ALTER ROLE](ALTER_ROLE.html), [DROP ROLE](DROP_ROLE.html), [GRANT](GRANT.html), [REVOKE](REVOKE.html), [CREATE RESOURCE QUEUE](CREATE_RESOURCE_QUEUE.html) [CREATE RESOURCE GROUP](CREATE_RESOURCE_GROUP.html), [createuser](../../utility_guide/ref/createuser.html)
 
 **Parent topic:** [SQL Commands](../sql_commands/sql_ref.html)
 

--- a/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_ROLE.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_ROLE.html.md
@@ -34,6 +34,8 @@ where option can be:
     | SYSID <uid> [, ...]
     | RESOURCE QUEUE <queue_name>
     | RESOURCE GROUP <group_name>
+    | [ DENY <deny_point> ]
+    | [ DENY BETWEEN <deny_point> AND <deny_point>]
 ```
 
 ## <a id="section3"></a>Description 
@@ -129,6 +131,35 @@ RESOURCE QUEUE queue\_name
 
 :   Roles with the `SUPERUSER` attribute are exempt from resource queue limits. For a superuser role, queries always run immediately regardless of limits imposed by an assigned resource queue.
 
+DENY deny\_point
+DENY BETWEEN deny\_point AND deny\_point
+:   The `DENY` and `DENY BETWEEN` keywords set time-based constraints that are enforced at login. `DENY` sets a day or a day and time to deny access. `DENY BETWEEN` sets an interval during which access is denied. Both use the parameter deny\_point that has the following format:
+
+```
+DAY day [ TIME 'time' ]
+```
+
+The two parts of the `deny_point` parameter use the following formats:
+
+For `day`:
+
+```
+{'Sunday' | 'Monday' | 'Tuesday' |'Wednesday' | 'Thursday' | 'Friday' | 
+'Saturday' | 0-6 }
+```
+
+For `time`:
+
+```
+{ 00-23 : 00-59 | 01-12 : 00-59 { AM | PM }}
+```
+
+The `DENY BETWEEN` clause uses two deny\_point parameters:
+
+```
+DENY BETWEEN <deny_point> AND <deny_point>
+```
+
 ## <a id="section5"></a>Notes 
 
 Use [ALTER ROLE](ALTER_ROLE.html) to change the attributes of a role, and [DROP ROLE](DROP_ROLE.html) to remove a role. All the attributes specified by `CREATE ROLE` can be modified by later `ALTER ROLE` commands.
@@ -175,6 +206,12 @@ Create a role that can create databases and manage other roles:
 
 ```
 CREATE ROLE admin WITH CREATEDB CREATEROLE;
+```
+
+Create a role that does not allow login access on Sundays:
+
+```
+CREATE ROLE user3 DENY DAY 'Sunday';
 ```
 
 Create a role that can create readable and writable external tables of type 'gpfdist':

--- a/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_USER.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_USER.html.md
@@ -31,6 +31,8 @@ where option can be:
     | SYSID <uid>
     | RESOURCE QUEUE <queue_name>
     | RESOURCE GROUP <group_name>
+    | [ DENY <deny_point> ]
+    | [ DENY BETWEEN <deny_point> AND <deny_point>]
 ```
 
 ## <a id="section3"></a>Description 

--- a/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_USER.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_USER.html.md
@@ -1,20 +1,16 @@
 # CREATE USER 
 
-Defines a new database role with the `LOGIN` privilege by default.
+Defines a new database role.
 
 ## <a id="section2"></a>Synopsis 
 
 ``` {#sql_command_synopsis}
 CREATE USER <name> [[WITH] <option> [ ... ]]
-```
 
 where option can be:
-
-```
       SUPERUSER | NOSUPERUSER
     | CREATEDB | NOCREATEDB
     | CREATEROLE | NOCREATEROLE
-    | CREATEUSER | NOCREATEUSER
     | CREATEEXTTABLE | NOCREATEEXTTABLE 
       [ ( <attribute>='<value>'[, ...] ) ]
            where <attributes> and <value> are:
@@ -23,8 +19,9 @@ where option can be:
     | INHERIT | NOINHERIT
     | LOGIN | NOLOGIN
     | REPLICATION | NOREPLICATION
+    | BYPASSRLS | NOBYPASSRLS
     | CONNECTION LIMIT <connlimit>
-    | [ ENCRYPTED | UNENCRYPTED ] PASSWORD '<password>'
+    | [ ENCRYPTED ] PASSWORD '<password>' | PASSWORD NULL
     | VALID UNTIL '<timestamp>'
     | IN ROLE <role_name> [, ...]
     | IN GROUP <role_name>
@@ -34,19 +31,15 @@ where option can be:
     | SYSID <uid>
     | RESOURCE QUEUE <queue_name>
     | RESOURCE GROUP <group_name>
-    | [ DENY <deny_point> ]
-    | [ DENY BETWEEN <deny_point> AND <deny_point>]
 ```
 
 ## <a id="section3"></a>Description 
 
-`CREATE USER` is an alias for [CREATE ROLE](CREATE_ROLE.html).
-
-The only difference between `CREATE ROLE` and `CREATE USER` is that `LOGIN` is assumed by default with `CREATE USER`, whereas `NOLOGIN` is assumed by default with `CREATE ROLE`.
+`CREATE USER` is an alias for [CREATE ROLE](CREATE_ROLE.html). The only difference is that when the command `CREATE USER` is invoked, `LOGIN` is assumed by default, whereas `NOLOGIN` is assumed when the command invoked is `CREATE ROLE`.
 
 ## <a id="section4"></a>Compatibility 
 
-There is no `CREATE USER` statement in the SQL standard.
+The `CREATE USER` statement is a Greenplum Database extension. The SQL standard leaves the definition of users to the implementation.
 
 ## <a id="section5"></a>See Also 
 

--- a/gpdb-doc/markdown/ref_guide/sql_commands/DROP_GROUP.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/DROP_GROUP.html.md
@@ -10,7 +10,7 @@ DROP GROUP [IF EXISTS] <name> [, ...]
 
 ## <a id="section3"></a>Description 
 
-`DROP GROUP` is an alias for `DROP ROLE`. See [DROP ROLE](DROP_ROLE.html) for more information.
+`DROP GROUP` is an alias for [DROP ROLE](DROP_ROLE.html).
 
 ## <a id="section5"></a>Compatibility 
 

--- a/gpdb-doc/markdown/ref_guide/sql_commands/DROP_USER.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/DROP_USER.html.md
@@ -10,15 +10,15 @@ DROP USER [IF EXISTS] <name> [, ...]
 
 ## <a id="section3"></a>Description 
 
-`DROP USER` is an alias for [DROP ROLE](DROP_ROLE.html). See [DROP ROLE](DROP_ROLE.html) for more information.
+`DROP USER` is an alias for [DROP ROLE](DROP_ROLE.html).
 
 ## <a id="section5"></a>Compatibility 
 
-There is no `DROP USER` statement in the SQL standard. The SQL standard leaves the definition of users to the implementation.
+The `DROP USER` statement is a Greenplum Database extension. The SQL standard leaves the definition of users to the implementation.
 
 ## <a id="section6"></a>See Also 
 
-[DROP ROLE](DROP_ROLE.html), [CREATE USER](CREATE_USER.html)
+[DROP ROLE](DROP_ROLE.html)
 
 **Parent topic:** [SQL Commands](../sql_commands/sql_ref.html)
 


### PR DESCRIPTION
this PR updates the listed sql command reference pages to align with the postgres v12 ref page content.  existing greenplum-specific content on the CREATE/ALTER role pages includes RESOURCE QUEUE and RESOURCE GROUP clauses and examples

questions:  
1.  do  the `ALTER ROLE <role_name> RESOURCE QUEUE {<queue_name> | NONE}`, and `ALTER ROLE <role_name> RESOURCE GROUP {<group_name> | NONE}` commands allow `<role_name>` to be `CURRENT_USER` or  `SESSION_USER`?  (i'll try to bring up a greenplum 7 cluster and test this out.)
2. postgres 12 ref pages did not include `DENY`-related clauses.  are these greenplum additions that i should add back in?

doc review site link for ALTER GROUP (behind vpn), can navigate to others from there:  https://docs-staging.vmware.com/en/draft/VMware-Tanzu-Greenplum/sqlref-gru/greenplum-database/GUID-ref_guide-sql_commands-ALTER_GROUP.html
doc review site link for ALTER ROLE (behind vpn), can navigate to others from there:  https://docs-staging.vmware.com/en/draft/VMware-Tanzu-Greenplum/sqlref-gru/greenplum-database/GUID-ref_guide-sql_commands-ALTER_ROLE.html
doc review site link for ALTER USER (behind vpn), can navigate to others from there:  https://docs-staging.vmware.com/en/draft/VMware-Tanzu-Greenplum/sqlref-gru/greenplum-database/GUID-ref_guide-sql_commands-ALTER_USER.html
