### PR TITLE
Remove already fixed non-default collate orca fallback in test.

### DIFF
--- a/src/test/regress/expected/arrays.out
+++ b/src/test/regress/expected/arrays.out
@@ -2373,13 +2373,8 @@ ORDER BY l.id;
 (12 rows)
 
 -- Array types are GPDB hashable
--- start_ignore
--- GPDB_12_MERGE_FIXME: Add an explicit COLLATE clause to cause ORCA to 
--- fallback instead of adding an optimizer.out file. Re-visit and fix 
--- when the collation work for ORCA is picked up again.
--- end_ignore
 CREATE TEMP TABLE text_array_table (t text[]) DISTRIBUTED BY ( t );
-INSERT INTO text_array_table VALUES ('{foo}' COLLATE "C");
+INSERT INTO text_array_table VALUES ('{foo}');
 CREATE TEMP TABLE int2_array_table (f1 int2[]) DISTRIBUTED BY (f1);
 INSERT INTO int2_array_table VALUES ('{1,2,3}');
 CREATE TEMP TABLE int4_array_table (f1 int4[]) DISTRIBUTED BY (f1);

--- a/src/test/regress/expected/bfv_index.out
+++ b/src/test/regress/expected/bfv_index.out
@@ -20,7 +20,6 @@ CREATE TABLE bfv_tab1 (
 	string4		name
 ) distributed by (unique1);
 create index bfv_tab1_idx1 on bfv_tab1 using btree(unique1);
--- GPDB_12_MERGE_FIXME: Non default collation
 explain select * from bfv_tab1, (values(147, 'RFAAAA'), (931, 'VJAAAA')) as v (i, j)
     WHERE bfv_tab1.unique1 = v.i and bfv_tab1.stringu1 = v.j;
                                                 QUERY PLAN                                                 
@@ -35,7 +34,6 @@ explain select * from bfv_tab1, (values(147, 'RFAAAA'), (931, 'VJAAAA')) as v (i
 (7 rows)
 
 set gp_enable_relsize_collection=on;
--- GPDB_12_MERGE_FIXME: Non default collation
 explain select * from bfv_tab1, (values(147, 'RFAAAA'), (931, 'VJAAAA')) as v (i, j)
     WHERE bfv_tab1.unique1 = v.i and bfv_tab1.stringu1 = v.j;
                                                 QUERY PLAN                                                 

--- a/src/test/regress/expected/bfv_index_optimizer.out
+++ b/src/test/regress/expected/bfv_index_optimizer.out
@@ -20,7 +20,6 @@ CREATE TABLE bfv_tab1 (
 	string4		name
 ) distributed by (unique1);
 create index bfv_tab1_idx1 on bfv_tab1 using btree(unique1);
--- GPDB_12_MERGE_FIXME: Non default collation
 explain select * from bfv_tab1, (values(147, 'RFAAAA'), (931, 'VJAAAA')) as v (i, j)
     WHERE bfv_tab1.unique1 = v.i and bfv_tab1.stringu1 = v.j;
                                          QUERY PLAN                                          
@@ -37,7 +36,6 @@ explain select * from bfv_tab1, (values(147, 'RFAAAA'), (931, 'VJAAAA')) as v (i
 (9 rows)
 
 set gp_enable_relsize_collection=on;
--- GPDB_12_MERGE_FIXME: Non default collation
 explain select * from bfv_tab1, (values(147, 'RFAAAA'), (931, 'VJAAAA')) as v (i, j)
     WHERE bfv_tab1.unique1 = v.i and bfv_tab1.stringu1 = v.j;
                                          QUERY PLAN                                          

--- a/src/test/regress/sql/arrays.sql
+++ b/src/test/regress/sql/arrays.sql
@@ -785,13 +785,8 @@ GROUP BY l.id
 ORDER BY l.id;
 
 -- Array types are GPDB hashable
--- start_ignore
--- GPDB_12_MERGE_FIXME: Add an explicit COLLATE clause to cause ORCA to 
--- fallback instead of adding an optimizer.out file. Re-visit and fix 
--- when the collation work for ORCA is picked up again.
--- end_ignore
 CREATE TEMP TABLE text_array_table (t text[]) DISTRIBUTED BY ( t );
-INSERT INTO text_array_table VALUES ('{foo}' COLLATE "C");
+INSERT INTO text_array_table VALUES ('{foo}');
 
 CREATE TEMP TABLE int2_array_table (f1 int2[]) DISTRIBUTED BY (f1);
 INSERT INTO int2_array_table VALUES ('{1,2,3}');

--- a/src/test/regress/sql/bfv_index.sql
+++ b/src/test/regress/sql/bfv_index.sql
@@ -21,12 +21,10 @@ CREATE TABLE bfv_tab1 (
 ) distributed by (unique1);
 
 create index bfv_tab1_idx1 on bfv_tab1 using btree(unique1);
--- GPDB_12_MERGE_FIXME: Non default collation
 explain select * from bfv_tab1, (values(147, 'RFAAAA'), (931, 'VJAAAA')) as v (i, j)
     WHERE bfv_tab1.unique1 = v.i and bfv_tab1.stringu1 = v.j;
 
 set gp_enable_relsize_collection=on;
--- GPDB_12_MERGE_FIXME: Non default collation
 explain select * from bfv_tab1, (values(147, 'RFAAAA'), (931, 'VJAAAA')) as v (i, j)
     WHERE bfv_tab1.unique1 = v.i and bfv_tab1.stringu1 = v.j;
 


### PR DESCRIPTION
Commit 5f168fa5f already fix non-default collation fallbacks of
ORCA then we can remove some related FIXMEs.

NOTE: the one in select_parallel still fallback to planner due to
non default collate, we should take a look at it later.