### PR TITLE
[6X] Backport GPDB_12_MERGE_FIXME create index on AO/CO allows read-only tr…

### DIFF
--- a/src/test/isolation2/expected/lockmodes.out
+++ b/src/test/isolation2/expected/lockmodes.out
@@ -401,20 +401,149 @@ ABORT
 1q: ... <quitting>
 2q: ... <quitting>
 
-11: ALTER SYSTEM RESET gp_enable_global_deadlock_detector;
+-- 2.8 Verify behaviors of select with locking clause (i.e. select for update)
+-- when running concurrently with index creation, for Heap tables.
+-- For AO/CO tables, refer to create_index_allows_readonly.source.
+
+1: CREATE TABLE create_index_select_for_update_tbl(a int, b int);
+CREATE
+1: INSERT INTO create_index_select_for_update_tbl SELECT i,i FROM generate_series(1,10)i;
+INSERT 10
+1: set optimizer = off;
+SET
+
+-- 2.8.1 with GDD enabled, expect blocking as is.
+-- This behavior will be changed to no-blocking on GPDB7 and later.
+1: show gp_enable_global_deadlock_detector;
+ gp_enable_global_deadlock_detector 
+------------------------------------
+ on                                 
+(1 row)
+
+1: BEGIN;
+BEGIN
+1: SELECT * FROM create_index_select_for_update_tbl WHERE a = 2 FOR UPDATE;
+ a | b 
+---+---
+ 2 | 2 
+(1 row)
+
+2: set optimizer = off;
+SET
+
+2: BEGIN;
+BEGIN
+-- expect blocking as is
+-- This behavior will be changed to no-blocking on GPDB7 and later.
+2&: CREATE INDEX create_index_select_for_update_idx ON create_index_select_for_update_tbl(a);  <waiting ...>
+
+1: COMMIT;
+COMMIT
+
+2<:  <... completed>
+CREATE
+2: COMMIT;
+COMMIT
+
+2: DROP INDEX create_index_select_for_update_idx;
+DROP
+
+2: BEGIN;
+BEGIN
+2: CREATE INDEX create_index_select_for_update_idx ON create_index_select_for_update_tbl(a);
+CREATE
+
+1: BEGIN;
+BEGIN
+-- expect blocking as is
+-- This behavior will be changed to no-blocking on GPDB7 and later.
+1&: SELECT * FROM create_index_select_for_update_tbl WHERE a = 2 FOR UPDATE;  <waiting ...>
+
+2: COMMIT;
+COMMIT
+
+1<:  <... completed>
+ a | b 
+---+---
+ 2 | 2 
+(1 row)
+1: COMMIT;
+COMMIT
+-- close session to avoid renew session failure after restart
+1q: ... <quitting>
+
+2: DROP INDEX create_index_select_for_update_idx;
+DROP
+
+-- 2.8.2 with GDD disabled, expect blocking
+-- reset gdd
+2: ALTER SYSTEM RESET gp_enable_global_deadlock_detector;
 ALTER
+-- close session to avoid renew session failure after restart
+2q: ... <quitting>
 1U:SELECT pg_ctl(dir, 'restart') from lockmodes_datadir;
  pg_ctl 
 --------
  OK     
 (1 row)
 
+1: set optimizer = off;
+SET
 1: show gp_enable_global_deadlock_detector;
  gp_enable_global_deadlock_detector 
 ------------------------------------
  off                                
 (1 row)
 
+1: BEGIN;
+BEGIN
+1: SELECT * FROM create_index_select_for_update_tbl WHERE a = 2 FOR UPDATE;
+ a | b 
+---+---
+ 2 | 2 
+(1 row)
+
+2: set optimizer = off;
+SET
+
+2: BEGIN;
+BEGIN
+-- expect blocking
+2&: CREATE INDEX create_index_select_for_update_idx ON create_index_select_for_update_tbl(a);  <waiting ...>
+
+1: COMMIT;
+COMMIT
+
+2<:  <... completed>
+CREATE
+2: COMMIT;
+COMMIT
+
+2: DROP INDEX create_index_select_for_update_idx;
+DROP
+
+2: BEGIN;
+BEGIN
+2: CREATE INDEX create_index_select_for_update_idx ON create_index_select_for_update_tbl(a);
+CREATE
+
+1: BEGIN;
+BEGIN
+-- expect blocking
+1&: SELECT * FROM create_index_select_for_update_tbl WHERE a = 2 FOR UPDATE;  <waiting ...>
+
+2: COMMIT;
+COMMIT
+
+1<:  <... completed>
+ a | b 
+---+---
+ 2 | 2 
+(1 row)
+1: COMMIT;
+COMMIT
+
 1: drop table lockmodes_datadir;
 DROP
 1q: ... <quitting>
+2q: ... <quitting>

--- a/src/test/isolation2/input/uao/create_index_allows_readonly.source
+++ b/src/test/isolation2/input/uao/create_index_allows_readonly.source
@@ -1,0 +1,53 @@
+-- This is intended to verify read-only transactions is able to run
+-- concurently with index creation.
+
+create table ao_@orientation@_create_index_with_select_tbl(a int, b int) with (appendonly = true, orientation = @orientation@);
+insert into ao_@orientation@_create_index_with_select_tbl select a,a from generate_series(1,10) a;
+
+-- Verify readonly transaction is able to run concurrently with index creation.
+
+1: begin;
+1: select * from ao_@orientation@_create_index_with_select_tbl where a = 2;
+
+2: begin;
+-- expect no hang
+2: create index ao_@orientation@_create_index_with_select_idx on ao_@orientation@_create_index_with_select_tbl(a);
+-- expect no hang
+3: select * from ao_@orientation@_create_index_with_select_tbl where a = 2;
+
+1: end;
+2: end;
+
+-- Verify behaviors of select with locking clause (i.e. select for update)
+-- when running concurrently with index creation, expect blocking with each other.
+-- This is only for AO/CO tables, for Heap tables, refer to lockmodes.sql.
+
+drop index ao_@orientation@_create_index_with_select_idx;
+
+1: begin;
+1: select * from ao_@orientation@_create_index_with_select_tbl where a = 2 for update;
+
+2: begin;
+-- expect blocking
+2&: create index ao_@orientation@_create_index_with_select_idx on ao_@orientation@_create_index_with_select_tbl(a);
+
+1: commit;
+
+2<:
+2: commit;
+
+drop index ao_@orientation@_create_index_with_select_idx;
+
+2: begin;
+2: create index ao_@orientation@_create_index_with_select_idx on ao_@orientation@_create_index_with_select_tbl(a);
+
+1: begin;
+-- expect blocking
+1&: select * from ao_@orientation@_create_index_with_select_tbl where a = 2 for update;
+
+2: commit;
+
+1<:
+1: commit;
+
+drop table ao_@orientation@_create_index_with_select_tbl;

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -159,6 +159,7 @@ test: uao/vacuum_cleanup_row
 test: uao/vacuum_index_stats_row
 test: uao/insert_should_not_use_awaiting_drop_row
 test: uao/bitmapindex_rescan_row
+test: uao/create_index_allows_readonly_row
 test: reorganize_after_ao_vacuum_skip_drop truncate_after_ao_vacuum_skip_drop mark_all_aoseg_await_drop
 # below test(s) inject faults so each of them need to be in a separate group
 test: segwalrep/master_xlog_switch
@@ -213,6 +214,7 @@ test: uao/vacuum_cleanup_column
 test: uao/vacuum_index_stats_column
 test: uao/insert_should_not_use_awaiting_drop_column
 test: uao/bitmapindex_rescan_column
+test: uao/create_index_allows_readonly_column
 test: add_column_after_vacuum_skip_drop_column
 test: vacuum_after_vacuum_skip_drop_column
 

--- a/src/test/isolation2/output/uao/create_index_allows_readonly.source
+++ b/src/test/isolation2/output/uao/create_index_allows_readonly.source
@@ -1,0 +1,89 @@
+-- This is intended to verify read-only transactions is able to run
+-- concurently with index creation.
+
+create table ao_@orientation@_create_index_with_select_tbl(a int, b int) with (appendonly = true, orientation = @orientation@);
+CREATE
+insert into ao_@orientation@_create_index_with_select_tbl select a,a from generate_series(1,10) a;
+INSERT 10
+
+-- Verify readonly transaction is able to run concurrently with index creation.
+
+1: begin;
+BEGIN
+1: select * from ao_@orientation@_create_index_with_select_tbl where a = 2;
+ a | b 
+---+---
+ 2 | 2 
+(1 row)
+
+2: begin;
+BEGIN
+-- expect no hang
+2: create index ao_@orientation@_create_index_with_select_idx on ao_@orientation@_create_index_with_select_tbl(a);
+CREATE
+-- expect no hang
+3: select * from ao_@orientation@_create_index_with_select_tbl where a = 2;
+ a | b 
+---+---
+ 2 | 2 
+(1 row)
+
+1: end;
+END
+2: end;
+END
+
+-- Verify behaviors of select with locking clause (i.e. select for update)
+-- when running concurrently with index creation, expect blocking with each other.
+-- This is only for AO/CO tables, for Heap tables, refer to lockmodes.sql.
+
+drop index ao_@orientation@_create_index_with_select_idx;
+DROP
+
+1: begin;
+BEGIN
+1: select * from ao_@orientation@_create_index_with_select_tbl where a = 2 for update;
+ a | b 
+---+---
+ 2 | 2 
+(1 row)
+
+2: begin;
+BEGIN
+-- expect blocking
+2&: create index ao_@orientation@_create_index_with_select_idx on ao_@orientation@_create_index_with_select_tbl(a);  <waiting ...>
+
+1: commit;
+COMMIT
+
+2<:  <... completed>
+CREATE
+2: commit;
+COMMIT
+
+drop index ao_@orientation@_create_index_with_select_idx;
+DROP
+
+2: begin;
+BEGIN
+2: create index ao_@orientation@_create_index_with_select_idx on ao_@orientation@_create_index_with_select_tbl(a);
+CREATE
+
+1: begin;
+BEGIN
+-- expect blocking
+1&: select * from ao_@orientation@_create_index_with_select_tbl where a = 2 for update;  <waiting ...>
+
+2: commit;
+COMMIT
+
+1<:  <... completed>
+ a | b 
+---+---
+ 2 | 2 
+(1 row)
+1: commit;
+COMMIT
+
+drop table ao_@orientation@_create_index_with_select_tbl;
+DROP

--- a/src/test/isolation2/sql/lockmodes.sql
+++ b/src/test/isolation2/sql/lockmodes.sql
@@ -201,10 +201,90 @@ create table t_lockmods_ao1 (c int) with (appendonly=true) distributed randomly;
 1q:
 2q:
 
-11: ALTER SYSTEM RESET gp_enable_global_deadlock_detector;
+-- 2.8 Verify behaviors of select with locking clause (i.e. select for update)
+-- when running concurrently with index creation, for Heap tables.
+-- For AO/CO tables, refer to create_index_allows_readonly.source.
+
+1: CREATE TABLE create_index_select_for_update_tbl(a int, b int);
+1: INSERT INTO create_index_select_for_update_tbl SELECT i,i FROM generate_series(1,10)i;
+1: set optimizer = off;
+
+-- 2.8.1 with GDD enabled, expect blocking as is.
+-- This behavior will be changed to no-blocking on GPDB7 and later.
+1: show gp_enable_global_deadlock_detector;
+
+1: BEGIN;
+1: SELECT * FROM create_index_select_for_update_tbl WHERE a = 2 FOR UPDATE;
+
+2: set optimizer = off;
+
+2: BEGIN;
+-- expect blocking as is
+-- This behavior will be changed to no-blocking on GPDB7 and later.
+2&: CREATE INDEX create_index_select_for_update_idx ON create_index_select_for_update_tbl(a);
+
+1: COMMIT;
+
+2<:
+2: COMMIT;
+
+2: DROP INDEX create_index_select_for_update_idx;
+
+2: BEGIN;
+2: CREATE INDEX create_index_select_for_update_idx ON create_index_select_for_update_tbl(a);
+
+1: BEGIN;
+-- expect blocking as is
+-- This behavior will be changed to no-blocking on GPDB7 and later.
+1&: SELECT * FROM create_index_select_for_update_tbl WHERE a = 2 FOR UPDATE;
+
+2: COMMIT;
+
+1<:
+1: COMMIT;
+-- close session to avoid renew session failure after restart
+1q:
+
+2: DROP INDEX create_index_select_for_update_idx;
+
+-- 2.8.2 with GDD disabled, expect blocking
+-- reset gdd
+2: ALTER SYSTEM RESET gp_enable_global_deadlock_detector;
+-- close session to avoid renew session failure after restart
+2q:
 1U:SELECT pg_ctl(dir, 'restart') from lockmodes_datadir;
 
+1: set optimizer = off;
 1: show gp_enable_global_deadlock_detector;
+
+1: BEGIN;
+1: SELECT * FROM create_index_select_for_update_tbl WHERE a = 2 FOR UPDATE;
+
+2: set optimizer = off;
+
+2: BEGIN;
+-- expect blocking
+2&: CREATE INDEX create_index_select_for_update_idx ON create_index_select_for_update_tbl(a);
+
+1: COMMIT;
+
+2<:
+2: COMMIT;
+
+2: DROP INDEX create_index_select_for_update_idx;
+
+2: BEGIN;
+2: CREATE INDEX create_index_select_for_update_idx ON create_index_select_for_update_tbl(a);
+
+1: BEGIN;
+-- expect blocking
+1&: SELECT * FROM create_index_select_for_update_tbl WHERE a = 2 FOR UPDATE;
+
+2: COMMIT;
+
+1<:
+1: COMMIT;
 
 1: drop table lockmodes_datadir;
 1q:
+2q:


### PR DESCRIPTION
…ansactions

This is a backport of https://github.com/greenplum-db/gpdb/pull/14300

Previously, CREATE INDEX could hang if there was a pre-existing read-only transaction accessing to the same AO/CO table. This is because index creation on AO/CO table requires acquiring AccessExclusiveLock which could be blocked by existing readers holding the shared lock.

This patch is to allow index creation on AO/CO working concurrently with read-only transactions, replace AccessExclusiveLock with ShareRowExclusiveLock to avoid blocking each other.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
