### PR TITLE
Fix crash of not-in pullup sublink with Params

### DIFF
--- a/src/backend/cdb/cdbsubselect.c
+++ b/src/backend/cdb/cdbsubselect.c
@@ -1352,7 +1352,18 @@ is_exprs_nullable_internal(Node *exprs, List *nonnullable_vars, List *rtable)
 
 	if (IsA(exprs, Var))
 	{
+		Var *tmpvar = (Var *)exprs;
+
+		/* params treat as nullable exprs */
+		if (tmpvar->varlevelsup != 0)
+			return true;
+
 		Var		   *var = cdb_map_to_base_var((Var *) exprs, rtable);
+
+		/* once not found RTE of var, return as nullable expr */
+		if (var == NULL)
+			return true;
+
 		return !list_member(nonnullable_vars, var);
 	}
 	else if (IsA(exprs, List))
@@ -1494,7 +1505,10 @@ cdb_find_all_vars_walker(Node *node, FindAllVarsContext *context)
 
 	if (IsA(node, Var))
 	{
-		Var     *var;
+		Var *var = (Var *)node;
+
+		if (var->varlevelsup != 0)
+			return false;
 
 		/*
 		 * The vars fetched from targetList/testexpr.. can be from virtual range table (RTE_JOIN),
@@ -1502,7 +1516,10 @@ cdb_find_all_vars_walker(Node *node, FindAllVarsContext *context)
 		 * them to base vars is needed before check nullable.
 		 */
 		var = cdb_map_to_base_var((Var *) node, context->rtable);
-		context->vars = list_append_unique(context->vars, var);
+
+		if (var != NULL)
+			context->vars = list_append_unique(context->vars, var);
+
 		return false;
 	}
 
@@ -1514,11 +1531,15 @@ cdb_map_to_base_var(Var *var, List *rtable)
 {
 	RangeTblEntry *rte    = rt_fetch(var->varno, rtable);
 
-	while(rte->rtekind == RTE_JOIN && rte->joinaliasvars)
+	while(rte != NULL && rte->rtekind == RTE_JOIN && rte->joinaliasvars)
 	{
 		var = (Var *) list_nth(rte->joinaliasvars, var->varattno-1);
 		rte = rt_fetch(var->varno, rtable);
 	}
+
+	/* not found RTE in current level rtable */
+	if (rte == NULL)
+		return NULL;
 
 	return var;
 }

--- a/src/test/regress/expected/notin.out
+++ b/src/test/regress/expected/notin.out
@@ -1633,6 +1633,81 @@ select 1 from t1_13212 where (NULL, b) not in (select a, b from t2_13212);
         1
 (1 row)
 
+-- test for params of not-in sublink
+create table t1p(a int, b int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table t2p(b int, a int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'b' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+explain (costs off)
+update
+  t1p
+set
+  a = age.aging
+from
+  (
+    select
+      c,
+      (
+        select
+            diff
+        from
+            generate_series(1, 10) diff
+        where
+            (diff, t1p.b) not in (select a, b from t2p)
+      ) as aging
+    from
+      t1p
+  ) age
+where a = age.c;
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Update on t1p
+   ->  Redistribute Motion 3:3  (slice3; segments: 3)
+         Hash Key: ((SubPlan 1))
+         ->  Split
+               ->  Hash Join
+                     Hash Cond: (t1p_1.c = t1p.a)
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: t1p_1.c
+                           ->  Seq Scan on t1p t1p_1
+                     ->  Hash
+                           ->  Seq Scan on t1p
+                     SubPlan 1  (slice3; segments: 1)
+                       ->  Nested Loop Left Anti Semi (Not-In) Join
+                             Join Filter: ((diff.diff = t2p.a) AND (t1p_1.b = t2p.b))
+                             ->  Function Scan on generate_series diff
+                             ->  Materialize
+                                   ->  Result
+                                         ->  Materialize
+                                               ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                                                     ->  Seq Scan on t2p
+ Optimizer: Postgres query optimizer
+(21 rows)
+
+update
+  t1p
+set
+  a = age.aging
+from
+  (
+    select
+      c,
+      (
+        select
+            diff
+        from
+            generate_series(1, 10) diff
+        where
+            (diff, t1p.b) not in (select a, b from t2p)
+      ) as aging
+    from
+      t1p
+  ) age
+where a = age.c;
+drop table t1p;
+drop table t2p;
 reset search_path;
 drop schema notin cascade;
 NOTICE:  drop cascades to 24 other objects

--- a/src/test/regress/expected/notin_optimizer.out
+++ b/src/test/regress/expected/notin_optimizer.out
@@ -1712,6 +1712,81 @@ select 1 from t1_13212 where (NULL, b) not in (select a, b from t2_13212);
         1
 (1 row)
 
+-- test for params of not-in sublink
+create table t1p(a int, b int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table t2p(b int, a int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'b' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+explain (costs off)
+update
+  t1p
+set
+  a = age.aging
+from
+  (
+    select
+      c,
+      (
+        select
+            diff
+        from
+            generate_series(1, 10) diff
+        where
+            (diff, t1p.b) not in (select a, b from t2p)
+      ) as aging
+    from
+      t1p
+  ) age
+where a = age.c;
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Update on t1p
+   ->  Redistribute Motion 3:3  (slice3; segments: 3)
+         Hash Key: ((SubPlan 1))
+         ->  Split
+               ->  Hash Join
+                     Hash Cond: (t1p_1.c = t1p.a)
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: t1p_1.c
+                           ->  Seq Scan on t1p t1p_1
+                     ->  Hash
+                           ->  Seq Scan on t1p
+                     SubPlan 1  (slice3; segments: 1)
+                       ->  Nested Loop Left Anti Semi (Not-In) Join
+                             Join Filter: ((diff.diff = t2p.a) AND (t1p_1.b = t2p.b))
+                             ->  Function Scan on generate_series diff
+                             ->  Materialize
+                                   ->  Result
+                                         ->  Materialize
+                                               ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                                                     ->  Seq Scan on t2p
+ Optimizer: Postgres query optimizer
+(21 rows)
+
+update
+  t1p
+set
+  a = age.aging
+from
+  (
+    select
+      c,
+      (
+        select
+            diff
+        from
+            generate_series(1, 10) diff
+        where
+            (diff, t1p.b) not in (select a, b from t2p)
+      ) as aging
+    from
+      t1p
+  ) age
+where a = age.c;
+drop table t1p;
+drop table t2p;
 reset search_path;
 drop schema notin cascade;
 NOTICE:  drop cascades to 24 other objects

--- a/src/test/regress/sql/notin.sql
+++ b/src/test/regress/sql/notin.sql
@@ -532,5 +532,54 @@ select 1 from t1_13212 where (NULL, b) not in (select a, b from t2_13212);
 update t2_13212 set b = 2;
 select 1 from t1_13212 where (NULL, b) not in (select a, b from t2_13212);
 
+-- test for params of not-in sublink
+create table t1p(a int, b int, c int);
+create table t2p(b int, a int);
+explain (costs off)
+update
+  t1p
+set
+  a = age.aging
+from
+  (
+    select
+      c,
+      (
+        select
+            diff
+        from
+            generate_series(1, 10) diff
+        where
+            (diff, t1p.b) not in (select a, b from t2p)
+      ) as aging
+    from
+      t1p
+  ) age
+where a = age.c;
+
+update
+  t1p
+set
+  a = age.aging
+from
+  (
+    select
+      c,
+      (
+        select
+            diff
+        from
+            generate_series(1, 10) diff
+        where
+            (diff, t1p.b) not in (select a, b from t2p)
+      ) as aging
+    from
+      t1p
+  ) age
+where a = age.c;
+
+drop table t1p;
+drop table t2p;
+
 reset search_path;
 drop schema notin cascade;


### PR DESCRIPTION
The crash happened in not-in pullup sublink optimization, Param has been ignored when check non-nullable of not-in exprs. Like example below:
```
update
  t1p
set
  a = age.aging
from
  (
    select
      c,
      (
        select
            diff
        from
            generate_series(1, 10) diff
        where
            (diff, **t1p.b**) not in (select a, b from t2p)
      ) as aging
    from
      t1p
  ) age
where a = age.c;
```
aging is target-sublink in age subquery which is from UPDATE from clause, and _t1p.b_ is from table t1p in age subquery, so we could call _t1p.b_ as  correlated column. Steps optimization of this sql as below

- age subquery will be pull up, and table t1p in age subquery will be pulled up in UPDATE level.
- handle sublink aging, optimize not-in

As optimizing not-in sublink in step two, we still handle t1p.b in aging level. But it's param from upper level which also has been pullup in step one. So as we check varno of t1p.b which is from upper level instead of current one, crash happened.

Check nullable attribute of Param is the best way to fix. But checking param is hard in pullup sublink stage. There are only
two places could approach param.

- Transform stage, could get upper level details by parent pstate.
- SubPlan stage, making subplans for sublink, get upper level details parent plannerinfo.

But pullup sublink happens before SubPlan stage and after Transform stage. So for now we DO NOT check param nullable attribute and just treat it as nullable expr. 


## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
