### PR TITLE
[6X] Backport recovery_target_action from PostgreSQL 9.5

### DIFF
--- a/doc/src/sgml/recovery-config.sgml
+++ b/doc/src/sgml/recovery-config.sgml
@@ -282,21 +282,28 @@ restore_command = 'copy "C:\\server\\archivedir\\%f" "%p"'  # Windows
       </listitem>
      </varlistentry>
 
-     <varlistentry id="pause-at-recovery-target"
-                   xreflabel="pause_at_recovery_target">
-      <term><varname>pause_at_recovery_target</varname> (<type>boolean</type>)
+     <varlistentry id="recovery-target-action"
+                   xreflabel="recovery_target_action">
+      <term><varname>recovery_target_action</varname> (<type>enum</type>)
       <indexterm>
-        <primary><varname>pause_at_recovery_target</> recovery parameter</primary>
+        <primary><varname>recovery_target_action</> recovery parameter</primary>
       </indexterm>
       </term>
       <listitem>
        <para>
-        Specifies whether recovery should pause when the recovery target
-        is reached. The default is true.
-        This is intended to allow queries to be executed against the
-        database to check if this recovery target is the most desirable
-        point for recovery. The paused state can be resumed by using
-        <function>pg_xlog_replay_resume()</> (see
+        Specifies what action the server should take once the recovery target is
+        reached. The default is <literal>pause</>, which means recovery will
+        be paused. <literal>promote</> means the recovery process will finish
+        and the server will start to accept connections.
+        Finally <literal>shutdown</> will stop the server after reaching the
+        recovery target.
+       </para>
+       <para>
+        The intended use of the <literal>pause</> setting is to allow queries
+        to be executed against the database to check if this recovery target
+        is the most desirable point for recovery.
+        The paused state can be resumed by
+        using <function>pg_xlog_replay_resume()</> (see
         <xref linkend="functions-recovery-control-table">), which then
         causes recovery to end. If this recovery target is not the
         desired stopping point, then shut down the server, change the
@@ -304,8 +311,22 @@ restore_command = 'copy "C:\\server\\archivedir\\%f" "%p"'  # Windows
         continue recovery.
        </para>
        <para>
-        This setting has no effect if <xref linkend="guc-hot-standby"> is not
-        enabled, or if no recovery target is set.
+        The <literal>shutdown</> setting is useful to have the instance ready
+        at the exact replay point desired.  The instance will still be able to
+        replay more WAL records (and in fact will have to replay WAL records
+        since the last checkpoint next time it is started).
+       </para>
+       <para>
+        Note that because <filename>recovery.conf</> will not be renamed when
+        <varname>recovery_target_action</> is set to <literal>shutdown</>,
+        any subsequent start will end with immediate shutdown unless the
+        configuration is changed or the <filename>recovery.conf</> file is
+        removed manually.
+       </para>
+       <para>
+        This setting has no effect if no recovery target is set.
+        If <xref linkend="guc-hot-standby"> is not enabled, a setting of
+        <literal>pause</> will act the same as <literal>shutdown</>.
        </para>
       </listitem>
      </varlistentry>

--- a/src/backend/access/transam/recovery.conf.sample
+++ b/src/backend/access/transam/recovery.conf.sample
@@ -94,12 +94,14 @@
 #recovery_target_timeline = 'latest'
 #
 #
-# If pause_at_recovery_target is enabled, recovery will pause when
-# the recovery target is reached. The pause state will continue until
+# If recovery_target_action = 'pause', recovery will pause when the
+# recovery target is reached. The pause state will continue until
 # pg_xlog_replay_resume() is called. This setting has no effect if
-# hot standby is not enabled, or if no recovery target is set.
+# no recovery target is set. If hot_standby is not enabled then the
+# server will shutdown instead, though you may request this in
+# any case by specifying 'shutdown'.
 #
-#pause_at_recovery_target = true
+#recovery_target_action = 'pause'
 #
 #---------------------------------------------------------------------------
 # STANDBY SERVER PARAMETERS

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -259,7 +259,7 @@ static char *recoveryEndCommand = NULL;
 static char *archiveCleanupCommand = NULL;
 static RecoveryTargetType recoveryTarget = RECOVERY_TARGET_UNSET;
 static bool recoveryTargetInclusive = true;
-static bool recoveryPauseAtTarget = true;
+static RecoveryTargetAction recoveryTargetAction = RECOVERY_TARGET_ACTION_PAUSE;
 static TransactionId recoveryTargetXid;
 static TimestampTz recoveryTargetTime;
 static char *recoveryTargetName;
@@ -5285,6 +5285,8 @@ readRecoveryCommandFile(void)
 	ConfigVariable *item,
 			   *head = NULL,
 			   *tail = NULL;
+	bool		recoveryTargetActionSet = false;
+
 
 	fd = AllocateFile(RECOVERY_COMMAND_FILE, "r");
 	if (fd == NULL)
@@ -5328,15 +5330,26 @@ readRecoveryCommandFile(void)
 					(errmsg_internal("archive_cleanup_command = '%s'",
 									 archiveCleanupCommand)));
 		}
-		else if (strcmp(item->name, "pause_at_recovery_target") == 0)
+		else if (strcmp(item->name, "recovery_target_action") == 0)
 		{
-			if (!parse_bool(item->value, &recoveryPauseAtTarget))
+			if (strcmp(item->value, "pause") == 0)
+				recoveryTargetAction = RECOVERY_TARGET_ACTION_PAUSE;
+			else if (strcmp(item->value, "promote") == 0)
+				recoveryTargetAction = RECOVERY_TARGET_ACTION_PROMOTE;
+			else if (strcmp(item->value, "shutdown") == 0)
+				recoveryTargetAction = RECOVERY_TARGET_ACTION_SHUTDOWN;
+			else
 				ereport(ERROR,
 						(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-						 errmsg("parameter \"%s\" requires a Boolean value", "pause_at_recovery_target")));
+						 errmsg("invalid value for recovery parameter \"%s\"",
+								"recovery_target_action"),
+						 errhint("The allowed values are \"pause\", \"promote\" and \"shutdown\".")));
+
 			ereport(DEBUG2,
-					(errmsg_internal("pause_at_recovery_target = '%s'",
+					(errmsg_internal("recovery_target_action = '%s'",
 									 item->value)));
+
+			recoveryTargetActionSet = true;
 		}
 		else if (strcmp(item->name, "recovery_target_timeline") == 0)
 		{
@@ -5513,6 +5526,16 @@ readRecoveryCommandFile(void)
 		ereport(FATAL,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 			errmsg("standby mode is not supported by single-user servers")));
+
+	/*
+	 * Override any inconsistent requests. Not that this is a change
+	 * of behaviour in 9.5; prior to this we simply ignored a request
+	 * to pause if hot_standby = off, which was surprising behaviour.
+	 */
+	if (recoveryTargetAction == RECOVERY_TARGET_ACTION_PAUSE &&
+		recoveryTargetActionSet &&
+		!EnableHotStandby)
+		recoveryTargetAction = RECOVERY_TARGET_ACTION_SHUTDOWN;
 
 	/* Enable fetching from archive recovery area */
 	ArchiveRecoveryRequested = true;
@@ -7439,10 +7462,37 @@ StartupXLOG(void)
 			 * end of main redo apply loop
 			 */
 
-			if (recoveryPauseAtTarget && reachedStopPoint)
+			if (reachedStopPoint)
 			{
-				SetRecoveryPause(true);
-				recoveryPausesHere();
+				if (!reachedConsistency)
+					ereport(FATAL,
+						(errmsg("requested recovery stop point is before consistent recovery point")));
+
+				/*
+				 * This is the last point where we can restart recovery with a
+				 * new recovery target, if we shutdown and begin again. After
+				 * this, Resource Managers may choose to do permanent corrective
+				 * actions at end of recovery.
+				 */
+				switch (recoveryTargetAction)
+				{
+					case RECOVERY_TARGET_ACTION_SHUTDOWN:
+							/*
+							 * exit with special return code to request shutdown
+							 * of postmaster.  Log messages issued from
+							 * postmaster.
+							 */
+							proc_exit(3);
+
+					case RECOVERY_TARGET_ACTION_PAUSE:
+							SetRecoveryPause(true);
+							recoveryPausesHere();
+
+							/* drop into promote */
+
+					case RECOVERY_TARGET_ACTION_PROMOTE:
+							break;
+				}
 			}
 
 			/* Allow resource managers to do any required cleanup. */
@@ -7460,6 +7510,7 @@ StartupXLOG(void)
 				ereport(LOG,
 					 (errmsg("last completed transaction was at log time %s",
 							 timestamptz_to_str(xtime))));
+
 			InRedo = false;
 		}
 		else
@@ -7546,13 +7597,6 @@ StartupXLOG(void)
 		(EndOfLog < minRecoveryPoint ||
 		 !XLogRecPtrIsInvalid(ControlFile->backupStartPoint)))
 	{
-		if (reachedStopPoint)
-		{
-			/* stopped because of stop request */
-			ereport(FATAL,
-					(errmsg("requested recovery stop point is before consistent recovery point")));
-		}
-
 		/*
 		 * Ran off end of WAL before reaching end-of-backup WAL record, or
 		 * minRecoveryPoint. That's usually a bad sign, indicating that you

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -5330,6 +5330,13 @@ readRecoveryCommandFile(void)
 					(errmsg_internal("archive_cleanup_command = '%s'",
 									 archiveCleanupCommand)));
 		}
+		else if (strcmp(item->name, "pause_at_recovery_target") == 0)
+		{
+			ereport(WARNING,
+					(errcode(ERRCODE_WARNING_DEPRECATED_FEATURE),
+					 errmsg("pause_at_recovery_target is deprecated and no longer has function"),
+					 errhint("Use recovery parameter \"recovery_target_action\" instead.")));
+		}
 		else if (strcmp(item->name, "recovery_target_action") == 0)
 		{
 			if (strcmp(item->value, "pause") == 0)

--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -629,6 +629,7 @@ static void ShmemBackendArrayRemove(Backend *bn);
 /* Macros to check exit status of a child process */
 #define EXIT_STATUS_0(st)  ((st) == 0)
 #define EXIT_STATUS_1(st)  (WIFEXITED(st) && WEXITSTATUS(st) == 1)
+#define EXIT_STATUS_3(st)  (WIFEXITED(st) && WEXITSTATUS(st) == 3)
 
 /* if we are a QD postmaster or not */
 bool Gp_entry_postmaster = false;
@@ -3228,6 +3229,17 @@ reaper(SIGNAL_ARGS)
 				(EXIT_STATUS_0(exitstatus) || EXIT_STATUS_1(exitstatus)))
 			{
 				StartupStatus = STARTUP_NOT_RUNNING;
+				pmState = PM_WAIT_BACKENDS;
+				/* PostmasterStateMachine logic does the rest */
+				continue;
+			}
+
+			if (EXIT_STATUS_3(exitstatus))
+			{
+				ereport(LOG,
+					(errmsg("shutdown at recovery target")));
+				Shutdown = SmartShutdown;
+				TerminateChildren(SIGTERM);
 				pmState = PM_WAIT_BACKENDS;
 				/* PostmasterStateMachine logic does the rest */
 				continue;

--- a/src/include/access/xlog_internal.h
+++ b/src/include/access/xlog_internal.h
@@ -250,6 +250,16 @@ typedef struct CheckpointExtendedRecord
 struct XLogRecord;
 
 /*
+ * Recovery target action.
+ */
+typedef enum
+{
+	RECOVERY_TARGET_ACTION_PAUSE,
+	RECOVERY_TARGET_ACTION_PROMOTE,
+	RECOVERY_TARGET_ACTION_SHUTDOWN,
+} RecoveryTargetAction;
+
+/*
  * Method table for resource managers.
  *
  * This struct must be kept in sync with the PG_RMGR definition in

--- a/src/test/recovery/t/104_recovery_target_action.pl
+++ b/src/test/recovery/t/104_recovery_target_action.pl
@@ -1,0 +1,70 @@
+# Check that backported recovery_target_action feature works
+use strict;
+use warnings;
+
+use PostgresNode;
+use TestLib;
+use Test::More tests => 7;
+
+# Initialize node to backup
+my $node_to_backup = get_new_node('to_backup');
+$node_to_backup->init(
+	has_archiving    => 1);
+$node_to_backup->start;
+
+# Take backup
+my $backup_name = 'my_backup';
+$node_to_backup->backup_fs_hot($backup_name);
+
+# Create first restore point with some data
+$node_to_backup->safe_psql('postgres', "CREATE TABLE table1 AS SELECT generate_series(1, 10) AS a1;");
+$node_to_backup->safe_psql('postgres', "CHECKPOINT;");
+$node_to_backup->safe_psql('postgres', "SELECT pg_create_restore_point('first_restore_point');");
+$node_to_backup->safe_psql('postgres', "SELECT pg_switch_xlog();");
+
+# Create second restore point with some data
+$node_to_backup->safe_psql('postgres', "CREATE TABLE table2 AS SELECT generate_series(1, 20) AS a2;");
+$node_to_backup->safe_psql('postgres', "CHECKPOINT;");
+$node_to_backup->safe_psql('postgres', "SELECT pg_create_restore_point('second_restore_point');");
+$node_to_backup->safe_psql('postgres', "SELECT pg_switch_xlog();");
+
+# Create new node from from backup
+my $node_restored = get_new_node('restored');
+my $delay         = 5;
+$node_restored->init_from_backup($node_to_backup, $backup_name,
+	has_restoring => 1);
+
+## Test 1: recovery_target_action=shutdown works
+$node_restored->append_conf(
+	'recovery.conf', qq(
+recovery_target_name = 'first_restore_point'
+recovery_target_action = 'shutdown'
+pause_at_recovery_target = false # deprecated but should not FATAL if provided
+));
+$node_restored->start(fail_ok => 1); # non-zero return code since pg_ctl -w expects db to be up
+
+# We should see that recovery stopped at the first restore point and
+# that the database is no longer up.
+command_ok(["grep", 'recovery stopping at restore point "first_restore_point"', $node_restored->logfile],
+	"recovered up to first_restore_point");
+ok(!-f $node_restored->data_dir . "/postmaster.pid", "recovery_target_action=shutdown was successful");
+
+## Test 2: recovery_target_action=promote works
+command_ok(["echo", "''", ">", $node_restored->data_dir . "/recovery.conf"],
+	"truncate recovery.conf to reset for next test");
+$node_restored->append_conf(
+	'recovery.conf', qq(
+recovery_target_name = 'second_restore_point'
+recovery_target_action = 'promote'
+));
+$node_restored->start;
+
+# We should see that recovery stopped at the second restore point and
+# that the database has been promoted and is now queryable.
+command_ok(["grep", 'recovery stopping at restore point "second_restore_point"', $node_restored->logfile],
+	"recovered up to second_restore_point");
+ok(-f $node_restored->data_dir . "/postmaster.pid", "recovery_target_action=promote was successful");
+my $result1 = $node_restored->safe_psql('postgres', "SELECT count(*) FROM table1;");
+is($result1, qq(10), 'check table table1 after promote');
+my $result2 = $node_restored->safe_psql('postgres', "SELECT count(*) FROM table2;");
+is($result2, qq(20), 'check table table2 after promote');


### PR DESCRIPTION
Currently, the `pause_at_recovery_target` recovery config option is effectively useless in GP 6X since it works only when `hot_standby` mode is enabled and GP 6X does not support it.

I propose to backport the following patches from Postgres 9.5 to replace the `pause_at_recovery_target` with the `recovery_target_action` recovery config setting for better control over the recovery process:

- https://github.com/postgres/postgres/commit/aedccb1f6fef988af1d1a25b78151f3773954b4c
- https://github.com/postgres/postgres/commit/b8e33a85d4e86a8391118c3d5cdb249b560dec4f
- https://github.com/postgres/postgres/commit/da71632fcfc4e642e9bafb2c0074cad109e59486
- https://github.com/postgres/postgres/commit/51c11a7025ecc10c2b922d60a056ad7c6cf147a5
- https://github.com/postgres/postgres/commit/85d0e661aae656d3ec710dab24f883c4b4ef90da


This is a follow-up for https://github.com/greenplum-db/gpdb/pull/12424. Basically, it allows pausing the restore on the specified restore point with the ability to continue it by changing the recovery target to the next restore point.