### PR TITLE
Loading environment variable from etc/environment.d

### DIFF
--- a/gpMgmt/bin/generate-greenplum-path.sh
+++ b/gpMgmt/bin/generate-greenplum-path.sh
@@ -45,7 +45,7 @@ export OPENSSL_CONF
 if [ -d "${GPHOME}/etc/environment.d" ]; then
 	LOGGER=$(which logger 2> /dev/null || which true)
 	set -o allexport
-	for env in $(find "${GPHOME}/etc/environment.d" -name '*.conf' -type f | sort -n); do
+	for env in $(find "${GPHOME}/etc/environment.d" -regextype sed -regex '.*/[0-9][0-9]-*.\.conf$' -type f | sort -n); do
 		$LOGGER -t "greenplum-path.sh" "loading environment from ${env}"
 		source "${env}"
 	done

--- a/gpMgmt/bin/generate-greenplum-path.sh
+++ b/gpMgmt/bin/generate-greenplum-path.sh
@@ -40,4 +40,13 @@ export PATH
 export PYTHONPATH
 export LD_LIBRARY_PATH
 export OPENSSL_CONF
+
+# Load the external environment variable files
+if [ -d "${GPHOME}/etc/environment.d" ]; then
+	set -o allexport
+	for env in $(find "${GPHOME}/etc/environment.d" -name '*.conf' -type f | sort -n); do
+		source "${env}"
+	done
+	set +o allexport
+fi
 EOF

--- a/gpMgmt/bin/generate-greenplum-path.sh
+++ b/gpMgmt/bin/generate-greenplum-path.sh
@@ -43,8 +43,10 @@ export OPENSSL_CONF
 
 # Load the external environment variable files
 if [ -d "${GPHOME}/etc/environment.d" ]; then
+	LOGGER=$(which logger 2> /dev/null || which true)
 	set -o allexport
 	for env in $(find "${GPHOME}/etc/environment.d" -name '*.conf' -type f | sort -n); do
+		$LOGGER -t "greenplum-path.sh" "loading environment from ${env}"
 		source "${env}"
 	done
 	set +o allexport


### PR DESCRIPTION
Load an external environment variable from '$GPHOME/etc/environment.d/'. The name of the configuration must be '\d\d-\w*\.conf'. Adding two numeric prefixes in front of the file name simplifies the ordering.

For example:

```
etc/environment.d/
   - 00-overload-openssl.conf
   - 10-add-python-path-gpdb.conf
   - 90-add-rlib.conf
   - 90-load-pfx-path.conf
   - some_bad_file
```

The order of loading will be an ascending numerical order, in this case it will be 00, 10 and then 90, the order between two 90's is undefined. files without .conf suffix will not be loaded.

The format and file path are from systemd, which is already widely used in most Linux systems.
https://www.freedesktop.org/software/systemd/man/environment.d.html

Use case:

Some extensions need an additional environment variable to boot up, with environment.d, the extension can add the environment variable without modifying greenplum_path.sh.
example: https://github.com/greenplum-db/pljava/blob/9a14421cfad80be06d8245a64a5766481e89c6df/gpdb/packaging/gppkg_spec.yml.in#L11-L19

Load pxf environment file automatically. pxf and gptext need an additional PATH directory to store the executable files. with this environment file, the component can add them self to greenplum_path.sh without modifying this file.
