### PR TITLE
[ORCA] Enable CUBE result grouping set 

### DIFF
--- a/src/include/gpopt/translate/CTranslatorUtils.h
+++ b/src/include/gpopt/translate/CTranslatorUtils.h
@@ -109,6 +109,11 @@ private:
 		CMemoryPool *mp, const GroupingSet *grouping_set, ULONG num_cols,
 		CBitSet *group_cols, UlongToUlongMap *group_col_pos);
 
+	// create a set of grouping sets for a cube
+	static CBitSetArray *CreateGroupingSetsForCube(
+		CMemoryPool *mp, const GroupingSet *grouping_set, ULONG num_cols,
+		CBitSet *group_cols, UlongToUlongMap *group_col_pos);
+
 	// create a set of grouping sets for a grouping sets subclause
 	static CBitSetArray *CreateGroupingSetsForSets(
 		CMemoryPool *mp, const GroupingSet *grouping_set_node, ULONG num_cols,

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -10771,25 +10771,32 @@ set log_statement='none';
 set log_min_duration_statement=-1;
 set client_min_messages='log';
 explain select count(*) from foo group by cube(a,b);
-LOG:  2020-10-19 17:17:37:192241 PDT,THD000,NOTICE,"Feature not supported: Cube",
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Cube
-                                              QUERY PLAN                                              
-------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=1319.44..1496.29 rows=10611 width=16)
-   ->  Finalize HashAggregate  (cost=1319.44..1354.81 rows=3537 width=16)
-         Group Key: a, b, (GROUPINGSET_ID())
-         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..1213.33 rows=10611 width=16)
-               Hash Key: a, b, (GROUPINGSET_ID())
-               ->  Partial MixedAggregate  (cost=0.00..1001.11 rows=10611 width=16)
-                     Hash Key: a, b
-                     Hash Key: a
-                     Hash Key: b
-                     Group Key: ()
-                     Planned Partitions: 4
-                     ->  Seq Scan on foo  (cost=0.00..321.00 rows=28700 width=8)
- Optimizer: Postgres query optimizer
-(15 rows)
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Sequence  (cost=0.00..2155.00 rows=1 width=8)
+   ->  Shared Scan (share slice:id 0:0)  (cost=0.00..431.00 rows=1 width=1)
+         ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+               ->  Seq Scan on foo  (cost=0.00..431.00 rows=1 width=8)
+   ->  Append  (cost=0.00..1724.00 rows=1 width=8)
+         ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=8)
+               Group Key: share0_ref2.a, share0_ref2.b
+               ->  Sort  (cost=0.00..431.00 rows=1 width=8)
+                     Sort Key: share0_ref2.a, share0_ref2.b
+                     ->  Shared Scan (share slice:id 0:0)  (cost=0.00..431.00 rows=1 width=8)
+         ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=8)
+               Group Key: share0_ref3.b
+               ->  Sort  (cost=0.00..431.00 rows=1 width=4)
+                     Sort Key: share0_ref3.b
+                     ->  Shared Scan (share slice:id 0:0)  (cost=0.00..431.00 rows=1 width=4)
+         ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=8)
+               Group Key: share0_ref4.a
+               ->  Sort  (cost=0.00..431.00 rows=1 width=4)
+                     Sort Key: share0_ref4.a
+                     ->  Shared Scan (share slice:id 0:0)  (cost=0.00..431.00 rows=1 width=4)
+         ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
+               ->  Shared Scan (share slice:id 0:0)  (cost=0.00..431.00 rows=1 width=1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(23 rows)
 
 reset client_min_messages;
 reset log_statement;

--- a/src/test/regress/expected/groupingsets_optimizer.out
+++ b/src/test/regress/expected/groupingsets_optimizer.out
@@ -701,7 +701,7 @@ DETAIL:  Feature not supported: Grouping function with multiple arguments
 
 select(select (select grouping(a,b) from (values (1)) v2(c)) from (values (1,2)) v1(a,b) group by (a,b)) from (values(6,7)) v3(e,f) GROUP BY CUBE((e+1),(f+1)) ORDER BY (e+1),(f+1);
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Cube
+DETAIL:  Feature not supported: Grouping function with multiple arguments
  grouping 
 ----------
         0
@@ -712,8 +712,6 @@ DETAIL:  Feature not supported: Cube
 
 select a, b, sum(c), sum(sum(c)) over (order by a,b) as rsum
   from gstest2 group by cube (a,b) order by rsum, a, b;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Cube
  a | b | sum | rsum 
 ---+---+-----+------
  1 | 1 |   8 |    8
@@ -747,7 +745,7 @@ select a, b, sum(v.x)
   from (values (1),(2)) v(x), gstest_data(v.x)
  group by cube (a,b) order by a,b;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Cube
+DETAIL:  Feature not supported: LATERAL
  a | b | sum 
 ---+---+-----
  1 | 1 |   1
@@ -960,8 +958,6 @@ order by 2,1;
 select ten, grouping(ten) from onek
 group by cube(ten) having grouping(ten) > 0
 order by 2,1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Cube
  ten | grouping 
 -----+----------
      |        1
@@ -1169,7 +1165,7 @@ DETAIL:  Feature not supported: Grouping function with multiple arguments
 select a, b, grouping(a,b), sum(v), count(*), max(v)
   from gstest1 group by cube(a,b) order by 3,1,2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Cube
+DETAIL:  Feature not supported: Grouping function with multiple arguments
  a | b | grouping | sum | count | max 
 ---+---+----------+-----+-------+-----
  1 | 1 |        0 |  21 |     2 |  11
@@ -1193,7 +1189,7 @@ DETAIL:  Feature not supported: Cube
 explain (costs off) select a, b, grouping(a,b), sum(v), count(*), max(v)
   from gstest1 group by cube(a,b) order by 3,1,2;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Cube
+DETAIL:  Feature not supported: Grouping function with multiple arguments
                                                QUERY PLAN                                               
 --------------------------------------------------------------------------------------------------------
  Sort
@@ -1212,7 +1208,7 @@ explain (costs off)
   select a, b, grouping(a,b), array_agg(v order by v)
     from gstest1 group by cube(a,b);
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Cube
+DETAIL:  Feature not supported: Grouping function with multiple arguments
                         QUERY PLAN                        
 ----------------------------------------------------------
  GroupAggregate
@@ -1633,8 +1629,6 @@ DETAIL:  Feature not supported: Grouping function with multiple arguments
 
 select a, b, sum(c), sum(sum(c)) over (order by a,b) as rsum
   from gstest2 group by cube (a,b) order by rsum, a, b;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Cube
  a | b | sum | rsum 
 ---+---+-----+------
  1 | 1 |   8 |    8
@@ -1650,36 +1644,55 @@ DETAIL:  Feature not supported: Cube
 explain (costs off)
   select a, b, sum(c), sum(sum(c)) over (order by a,b) as rsum
     from gstest2 group by cube (a,b) order by rsum, a, b;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Cube
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
  Sort
-   Sort Key: (sum((sum(c))) OVER (?)), a, b
+   Sort Key: (sum((sum(share0_ref2.c))) OVER (?)), share0_ref2.a, share0_ref2.b
    ->  WindowAgg
-         Order By: a, b
+         Order By: share0_ref2.a, share0_ref2.b
          ->  Gather Motion 3:1  (slice1; segments: 3)
-               Merge Key: a, b
+               Merge Key: share0_ref2.a, share0_ref2.b
                ->  Sort
-                     Sort Key: a, b
-                     ->  Finalize HashAggregate
-                           Group Key: a, b, (GROUPINGSET_ID())
-                           ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                                 Hash Key: a, b, (GROUPINGSET_ID())
-                                 ->  Partial MixedAggregate
-                                       Hash Key: a, b
-                                       Hash Key: a
-                                       Hash Key: b
-                                       Group Key: ()
-                                       ->  Seq Scan on gstest2
- Optimizer: Postgres query optimizer
-(19 rows)
+                     Sort Key: share0_ref2.a, share0_ref2.b
+                     ->  Sequence
+                           ->  Shared Scan (share slice:id 1:0)
+                                 ->  Seq Scan on gstest2
+                           ->  Append
+                                 ->  GroupAggregate
+                                       Group Key: share0_ref2.a, share0_ref2.b
+                                       ->  Sort
+                                             Sort Key: share0_ref2.a, share0_ref2.b
+                                             ->  Shared Scan (share slice:id 1:0)
+                                 ->  Finalize GroupAggregate
+                                       Group Key: share0_ref3.b
+                                       ->  Sort
+                                             Sort Key: share0_ref3.b
+                                             ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                                                   Hash Key: share0_ref3.b
+                                                   ->  Partial GroupAggregate
+                                                         Group Key: share0_ref3.b
+                                                         ->  Sort
+                                                               Sort Key: share0_ref3.b
+                                                               ->  Shared Scan (share slice:id 2:0)
+                                 ->  GroupAggregate
+                                       Group Key: share0_ref4.a
+                                       ->  Sort
+                                             Sort Key: share0_ref4.a
+                                             ->  Shared Scan (share slice:id 1:0)
+                                 ->  Result
+                                       ->  Redistribute Motion 1:3  (slice3)
+                                             ->  Finalize Aggregate
+                                                   ->  Gather Motion 3:1  (slice4; segments: 3)
+                                                         ->  Partial Aggregate
+                                                               ->  Shared Scan (share slice:id 4:0)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(40 rows)
 
 select a, b, sum(v.x)
   from (values (1),(2)) v(x), gstest_data(v.x)
  group by cube (a,b) order by a,b;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Cube
+DETAIL:  Feature not supported: LATERAL
  a | b | sum 
 ---+---+-----
  1 | 1 |   1
@@ -1701,7 +1714,7 @@ explain (costs off)
     from (values (1),(2)) v(x), gstest_data(v.x)
    group by cube (a,b) order by a,b;
 INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Cube
+DETAIL:  Feature not supported: LATERAL
                    QUERY PLAN                   
 ------------------------------------------------
  Sort
@@ -2077,34 +2090,43 @@ select g1000, g100, g10, sum(g::numeric), count(*), max(g::text) from
   (select g%1000 as g1000, g%100 as g100, g%10 as g10, g
    from generate_series(0,199999) g) s
 group by cube (g1000,g100,g10);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Cube
-                          QUERY PLAN                           
----------------------------------------------------------------
- GroupAggregate
-   Group Key: ((g.g % 1000)), ((g.g % 100)), ((g.g % 10))
-   Group Key: ((g.g % 1000)), ((g.g % 100))
-   Group Key: ((g.g % 1000))
-   Group Key: ()
-   Sort Key: ((g.g % 100)), ((g.g % 10))
-     Group Key: ((g.g % 100)), ((g.g % 10))
-     Group Key: ((g.g % 100))
-   Sort Key: ((g.g % 10)), ((g.g % 1000))
-     Group Key: ((g.g % 10)), ((g.g % 1000))
-     Group Key: ((g.g % 10))
-   ->  Sort
-         Sort Key: ((g.g % 1000)), ((g.g % 100)), ((g.g % 10))
-         ->  Function Scan on generate_series g
- Optimizer: Postgres query optimizer
-(15 rows)
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Sequence
+   ->  Shared Scan (share slice:id 0:0)
+         ->  Function Scan on generate_series
+   ->  Append
+         ->  HashAggregate
+               Group Key: share0_ref2.g1000, share0_ref2.g100, share0_ref2.g10
+               ->  Shared Scan (share slice:id 0:0)
+         ->  HashAggregate
+               Group Key: share0_ref3.g100, share0_ref3.g10
+               ->  Shared Scan (share slice:id 0:0)
+         ->  HashAggregate
+               Group Key: share0_ref4.g1000, share0_ref4.g10
+               ->  Shared Scan (share slice:id 0:0)
+         ->  HashAggregate
+               Group Key: share0_ref5.g10
+               ->  Shared Scan (share slice:id 0:0)
+         ->  HashAggregate
+               Group Key: share0_ref6.g1000, share0_ref6.g100
+               ->  Shared Scan (share slice:id 0:0)
+         ->  HashAggregate
+               Group Key: share0_ref7.g100
+               ->  Shared Scan (share slice:id 0:0)
+         ->  HashAggregate
+               Group Key: share0_ref8.g1000
+               ->  Shared Scan (share slice:id 0:0)
+         ->  Aggregate
+               ->  Shared Scan (share slice:id 0:0)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(28 rows)
 
 create table gs_group_1 as
 select g1000, g100, g10, sum(g::numeric), count(*), max(g::text) from
   (select g%1000 as g1000, g%100 as g100, g%10 as g10, g
    from generate_series(0,199999) g) s
 group by cube (g1000,g100,g10);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Cube
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'g1000' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 set jit_above_cost to default;
@@ -2113,8 +2135,6 @@ select g1000, g100, g10, sum(g::numeric), count(*), max(g::text) from
   (select g/20 as g1000, g/200 as g100, g/2000 as g10, g
    from generate_series(0,19999) g) s
 group by cube (g1000,g100,g10);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Cube
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'g1000' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 create table gs_group_3 as
@@ -2134,30 +2154,43 @@ select g1000, g100, g10, sum(g::numeric), count(*), max(g::text) from
   (select g%1000 as g1000, g%100 as g100, g%10 as g10, g
    from generate_series(0,199999) g) s
 group by cube (g1000,g100,g10);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Cube
-                    QUERY PLAN                     
----------------------------------------------------
- MixedAggregate
-   Hash Key: (g.g % 1000), (g.g % 100), (g.g % 10)
-   Hash Key: (g.g % 1000), (g.g % 100)
-   Hash Key: (g.g % 1000)
-   Hash Key: (g.g % 100), (g.g % 10)
-   Hash Key: (g.g % 100)
-   Hash Key: (g.g % 10), (g.g % 1000)
-   Hash Key: (g.g % 10)
-   Group Key: ()
-   ->  Function Scan on generate_series g
- Optimizer: Postgres query optimizer
-(11 rows)
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Sequence
+   ->  Shared Scan (share slice:id 0:0)
+         ->  Function Scan on generate_series
+   ->  Append
+         ->  HashAggregate
+               Group Key: share0_ref2.g1000, share0_ref2.g100, share0_ref2.g10
+               ->  Shared Scan (share slice:id 0:0)
+         ->  HashAggregate
+               Group Key: share0_ref3.g100, share0_ref3.g10
+               ->  Shared Scan (share slice:id 0:0)
+         ->  HashAggregate
+               Group Key: share0_ref4.g1000, share0_ref4.g10
+               ->  Shared Scan (share slice:id 0:0)
+         ->  HashAggregate
+               Group Key: share0_ref5.g10
+               ->  Shared Scan (share slice:id 0:0)
+         ->  HashAggregate
+               Group Key: share0_ref6.g1000, share0_ref6.g100
+               ->  Shared Scan (share slice:id 0:0)
+         ->  HashAggregate
+               Group Key: share0_ref7.g100
+               ->  Shared Scan (share slice:id 0:0)
+         ->  HashAggregate
+               Group Key: share0_ref8.g1000
+               ->  Shared Scan (share slice:id 0:0)
+         ->  Aggregate
+               ->  Shared Scan (share slice:id 0:0)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(28 rows)
 
 create table gs_hash_1 as
 select g1000, g100, g10, sum(g::numeric), count(*), max(g::text) from
   (select g%1000 as g1000, g%100 as g100, g%10 as g10, g
    from generate_series(0,199999) g) s
 group by cube (g1000,g100,g10);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Cube
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'g1000' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 set jit_above_cost to default;
@@ -2166,8 +2199,6 @@ select g1000, g100, g10, sum(g::numeric), count(*), max(g::text) from
   (select g/20 as g1000, g/200 as g100, g/2000 as g10, g
    from generate_series(0,19999) g) s
 group by cube (g1000,g100,g10);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Cube
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'g1000' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 create table gs_hash_3 as

--- a/src/test/regress/expected/orca_groupingsets_fallbacks_optimizer.out
+++ b/src/test/regress/expected/orca_groupingsets_fallbacks_optimizer.out
@@ -13,8 +13,6 @@ insert into gstest1 values (2, 5, 30, 21, 300);
 insert into gstest1 values (2, 42, 40, 53, 400);
 -- Orca falls back due to Cube
 select a, b, c, sum(v) from gstest1 group by cube(a, b, c);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Cube
  a | b  | c  | sum  
 ---+----+----+------
  1 |  5 | 10 |  100

--- a/src/test/regress/expected/tsrf.out
+++ b/src/test/regress/expected/tsrf.out
@@ -325,7 +325,7 @@ SELECT dataa, datab b, generate_series(1,2) g, count(*) FROM few GROUP BY CUBE(d
        | foo | 2 |     1
 (16 rows)
 
-SELECT dataa, datab b, generate_series(1,2) g, count(*) FROM few GROUP BY CUBE(dataa, datab) ORDER BY dataa;
+SELECT dataa, datab b, generate_series(1,2) g, count(*) FROM few GROUP BY CUBE(dataa, datab) ORDER BY dataa, b, g;
  dataa |  b  | g | count 
 -------+-----+---+-------
  a     | bar | 1 |     1
@@ -346,7 +346,7 @@ SELECT dataa, datab b, generate_series(1,2) g, count(*) FROM few GROUP BY CUBE(d
        |     | 2 |     3
 (16 rows)
 
-SELECT dataa, datab b, generate_series(1,2) g, count(*) FROM few GROUP BY CUBE(dataa, datab) ORDER BY g;
+SELECT dataa, datab b, generate_series(1,2) g, count(*) FROM few GROUP BY CUBE(dataa, datab) ORDER BY g, dataa, b;
  dataa |  b  | g | count 
 -------+-----+---+-------
  a     | bar | 1 |     1
@@ -354,17 +354,17 @@ SELECT dataa, datab b, generate_series(1,2) g, count(*) FROM few GROUP BY CUBE(d
  a     |     | 1 |     2
  b     | bar | 1 |     1
  b     |     | 1 |     1
-       |     | 1 |     3
        | bar | 1 |     2
        | foo | 1 |     1
-       | foo | 2 |     1
+       |     | 1 |     3
  a     | bar | 2 |     1
- b     |     | 2 |     1
  a     | foo | 2 |     1
-       | bar | 2 |     2
  a     |     | 2 |     2
-       |     | 2 |     3
  b     | bar | 2 |     1
+ b     |     | 2 |     1
+       | bar | 2 |     2
+       | foo | 2 |     1
+       |     | 2 |     3
 (16 rows)
 
 SELECT dataa, datab b, generate_series(1,2) g, count(*) FROM few GROUP BY CUBE(dataa, datab, g);
@@ -396,7 +396,7 @@ SELECT dataa, datab b, generate_series(1,2) g, count(*) FROM few GROUP BY CUBE(d
        |     | 2 |     3
 (24 rows)
 
-SELECT dataa, datab b, generate_series(1,2) g, count(*) FROM few GROUP BY CUBE(dataa, datab, g) ORDER BY dataa;
+SELECT dataa, datab b, generate_series(1,2) g, count(*) FROM few GROUP BY CUBE(dataa, datab, g) ORDER BY dataa, b, g;
  dataa |  b  | g | count 
 -------+-----+---+-------
  a     | bar | 1 |     1
@@ -425,33 +425,33 @@ SELECT dataa, datab b, generate_series(1,2) g, count(*) FROM few GROUP BY CUBE(d
        |     |   |     6
 (24 rows)
 
-SELECT dataa, datab b, generate_series(1,2) g, count(*) FROM few GROUP BY CUBE(dataa, datab, g) ORDER BY g;
+SELECT dataa, datab b, generate_series(1,2) g, count(*) FROM few GROUP BY CUBE(dataa, datab, g) ORDER BY g, dataa, b;
  dataa |  b  | g | count 
 -------+-----+---+-------
  a     | bar | 1 |     1
  a     | foo | 1 |     1
+ a     |     | 1 |     2
  b     | bar | 1 |     1
+ b     |     | 1 |     1
        | bar | 1 |     2
        | foo | 1 |     1
- a     |     | 1 |     2
- b     |     | 1 |     1
        |     | 1 |     3
- a     |     | 2 |     2
- b     |     | 2 |     1
-       | bar | 2 |     2
-       |     | 2 |     3
-       | foo | 2 |     1
  a     | bar | 2 |     1
  a     | foo | 2 |     1
+ a     |     | 2 |     2
  b     | bar | 2 |     1
+ b     |     | 2 |     1
+       | bar | 2 |     2
+       | foo | 2 |     1
+       |     | 2 |     3
+ a     | bar |   |     2
+ a     | foo |   |     2
  a     |     |   |     4
  b     | bar |   |     2
  b     |     |   |     2
-       |     |   |     6
- a     | foo |   |     2
- a     | bar |   |     2
        | bar |   |     4
        | foo |   |     2
+       |     |   |     6
 (24 rows)
 
 reset enable_hashagg;

--- a/src/test/regress/expected/tsrf_optimizer.out
+++ b/src/test/regress/expected/tsrf_optimizer.out
@@ -339,7 +339,7 @@ SELECT dataa, datab b, generate_series(1,2) g, count(*) FROM few GROUP BY CUBE(d
        | foo | 2 |     1
 (16 rows)
 
-SELECT dataa, datab b, generate_series(1,2) g, count(*) FROM few GROUP BY CUBE(dataa, datab) ORDER BY dataa;
+SELECT dataa, datab b, generate_series(1,2) g, count(*) FROM few GROUP BY CUBE(dataa, datab) ORDER BY dataa, b, g;
  dataa |  b  | g | count 
 -------+-----+---+-------
  a     | bar | 1 |     1
@@ -360,7 +360,7 @@ SELECT dataa, datab b, generate_series(1,2) g, count(*) FROM few GROUP BY CUBE(d
        |     | 2 |     3
 (16 rows)
 
-SELECT dataa, datab b, generate_series(1,2) g, count(*) FROM few GROUP BY CUBE(dataa, datab) ORDER BY g;
+SELECT dataa, datab b, generate_series(1,2) g, count(*) FROM few GROUP BY CUBE(dataa, datab) ORDER BY g, dataa, b;
  dataa |  b  | g | count 
 -------+-----+---+-------
  a     | bar | 1 |     1
@@ -368,17 +368,17 @@ SELECT dataa, datab b, generate_series(1,2) g, count(*) FROM few GROUP BY CUBE(d
  a     |     | 1 |     2
  b     | bar | 1 |     1
  b     |     | 1 |     1
-       |     | 1 |     3
        | bar | 1 |     2
        | foo | 1 |     1
-       | foo | 2 |     1
+       |     | 1 |     3
  a     | bar | 2 |     1
- b     |     | 2 |     1
  a     | foo | 2 |     1
-       | bar | 2 |     2
  a     |     | 2 |     2
-       |     | 2 |     3
  b     | bar | 2 |     1
+ b     |     | 2 |     1
+       | bar | 2 |     2
+       | foo | 2 |     1
+       |     | 2 |     3
 (16 rows)
 
 SELECT dataa, datab b, generate_series(1,2) g, count(*) FROM few GROUP BY CUBE(dataa, datab, g);
@@ -410,7 +410,7 @@ SELECT dataa, datab b, generate_series(1,2) g, count(*) FROM few GROUP BY CUBE(d
        |     | 2 |     3
 (24 rows)
 
-SELECT dataa, datab b, generate_series(1,2) g, count(*) FROM few GROUP BY CUBE(dataa, datab, g) ORDER BY dataa;
+SELECT dataa, datab b, generate_series(1,2) g, count(*) FROM few GROUP BY CUBE(dataa, datab, g) ORDER BY dataa, b, g;
  dataa |  b  | g | count 
 -------+-----+---+-------
  a     | bar | 1 |     1
@@ -439,33 +439,33 @@ SELECT dataa, datab b, generate_series(1,2) g, count(*) FROM few GROUP BY CUBE(d
        |     |   |     6
 (24 rows)
 
-SELECT dataa, datab b, generate_series(1,2) g, count(*) FROM few GROUP BY CUBE(dataa, datab, g) ORDER BY g;
+SELECT dataa, datab b, generate_series(1,2) g, count(*) FROM few GROUP BY CUBE(dataa, datab, g) ORDER BY g, dataa, b;
  dataa |  b  | g | count 
 -------+-----+---+-------
  a     | bar | 1 |     1
  a     | foo | 1 |     1
+ a     |     | 1 |     2
  b     | bar | 1 |     1
+ b     |     | 1 |     1
        | bar | 1 |     2
        | foo | 1 |     1
- a     |     | 1 |     2
- b     |     | 1 |     1
        |     | 1 |     3
- a     |     | 2 |     2
- b     |     | 2 |     1
-       | bar | 2 |     2
-       |     | 2 |     3
-       | foo | 2 |     1
  a     | bar | 2 |     1
  a     | foo | 2 |     1
+ a     |     | 2 |     2
  b     | bar | 2 |     1
+ b     |     | 2 |     1
+       | bar | 2 |     2
+       | foo | 2 |     1
+       |     | 2 |     3
+ a     | bar |   |     2
+ a     | foo |   |     2
  a     |     |   |     4
  b     | bar |   |     2
  b     |     |   |     2
-       |     |   |     6
- a     | foo |   |     2
- a     | bar |   |     2
        | bar |   |     4
        | foo |   |     2
+       |     |   |     6
 (24 rows)
 
 reset enable_hashagg;

--- a/src/test/regress/sql/tsrf.sql
+++ b/src/test/regress/sql/tsrf.sql
@@ -94,11 +94,11 @@ SELECT few.dataa, count(*), min(id), max(id), generate_series(1,3) FROM few GROU
 -- grouping sets are a bit special, they produce NULLs in columns not actually NULL
 set enable_hashagg = false;
 SELECT dataa, datab b, generate_series(1,2) g, count(*) FROM few GROUP BY CUBE(dataa, datab);
-SELECT dataa, datab b, generate_series(1,2) g, count(*) FROM few GROUP BY CUBE(dataa, datab) ORDER BY dataa;
-SELECT dataa, datab b, generate_series(1,2) g, count(*) FROM few GROUP BY CUBE(dataa, datab) ORDER BY g;
+SELECT dataa, datab b, generate_series(1,2) g, count(*) FROM few GROUP BY CUBE(dataa, datab) ORDER BY dataa, b, g;
+SELECT dataa, datab b, generate_series(1,2) g, count(*) FROM few GROUP BY CUBE(dataa, datab) ORDER BY g, dataa, b;
 SELECT dataa, datab b, generate_series(1,2) g, count(*) FROM few GROUP BY CUBE(dataa, datab, g);
-SELECT dataa, datab b, generate_series(1,2) g, count(*) FROM few GROUP BY CUBE(dataa, datab, g) ORDER BY dataa;
-SELECT dataa, datab b, generate_series(1,2) g, count(*) FROM few GROUP BY CUBE(dataa, datab, g) ORDER BY g;
+SELECT dataa, datab b, generate_series(1,2) g, count(*) FROM few GROUP BY CUBE(dataa, datab, g) ORDER BY dataa, b, g;
+SELECT dataa, datab b, generate_series(1,2) g, count(*) FROM few GROUP BY CUBE(dataa, datab, g) ORDER BY g, dataa, b;
 reset enable_hashagg;
 
 -- case with degenerate ORDER BY


### PR DESCRIPTION
This builds on the work of commit https://github.com/greenplum-db/gpdb/commit/df3ce784285f7d9ceccfa761fd790ece65b65cde to implement CUBE.
Following now works in ORCA:

```sql
  EXPLAIN (COSTS OFF) SELECT i FROM generate_series(1, 3) i GROUP BY CUBE(i, i);
```

Note: Current optimization time for CUBE is slow. Seems ORCA is
generating many alternatives. Look into if this can be reduced.