### PR TITLE
NEW SYNTAX for resource group cpuset

### DIFF
--- a/src/backend/commands/resgroupcmds.c
+++ b/src/backend/commands/resgroupcmds.c
@@ -95,7 +95,7 @@ static void createResgroupCallback(XactEvent event, void *arg);
 static void dropResgroupCallback(XactEvent event, void *arg);
 static void alterResgroupCallback(XactEvent event, void *arg);
 static int getResGroupMemAuditor(char *name);
-static bool checkCpusetSyntax(const char *cpuset);
+static void checkCpusetSyntax(const char *cpuset);
 
 /*
  * CREATE RESOURCE GROUP
@@ -248,13 +248,14 @@ CreateResourceGroup(CreateResourceGroupStmt *stmt)
 		{
 			EnsureCpusetIsAvailable(ERROR);
 
-			cgroupOpsRoutine->setcpuset(groupid, caps.cpuset);
+			char *cpuset = getCpuSetByRole(caps.cpuset);
+			cgroupOpsRoutine->setcpuset(groupid, cpuset);
 			/* reset default group, subtract new group cpu cores */
 			char defaultGroupCpuset[MaxCpuSetLength];
 			cgroupOpsRoutine->getcpuset(DEFAULT_CPUSET_GROUP_ID,
 								  defaultGroupCpuset,
 								  MaxCpuSetLength);
-			CpusetDifference(defaultGroupCpuset, caps.cpuset, MaxCpuSetLength);
+			CpusetDifference(defaultGroupCpuset, cpuset, MaxCpuSetLength);
 			cgroupOpsRoutine->setcpuset(DEFAULT_CPUSET_GROUP_ID, defaultGroupCpuset);
 		}
 		SIMPLE_FAULT_INJECTOR("create_resource_group_fail");
@@ -400,9 +401,8 @@ AlterResourceGroup(AlterResourceGroupStmt *stmt)
 	else if (limitType == RESGROUP_LIMIT_TYPE_CPUSET)
 	{
 		EnsureCpusetIsAvailable(ERROR);
-
 		cpuset = defGetString(defel);
-		checkCpusetSyntax(cpuset);
+		checkCpuSetByRole(cpuset);
 	}
 	else
 	{
@@ -1011,8 +1011,8 @@ parseStmtOptions(CreateResourceGroupStmt *stmt, ResGroupCaps *caps)
 		if (type == RESGROUP_LIMIT_TYPE_CPUSET) 
 		{
 			const char *cpuset = defGetString(defel);
-			checkCpusetSyntax(cpuset);
 			StrNCpy(caps->cpuset, cpuset, sizeof(caps->cpuset));
+			checkCpuSetByRole(cpuset);
 			caps->cpuRateLimit = CPU_RATE_LIMIT_DISABLED;
 		}
 		else 
@@ -1292,18 +1292,20 @@ validateCapabilities(Relation rel,
 		gp_resource_group_enable_cgroup_cpuset)
 	{
 		Bitmapset *bmsAll = NULL;
+		Bitmapset *bmsMissing = NULL;
 
 		/* Get all available cores */
 		cgroupOpsRoutine->getcpuset(CGROUP_ROOT_ID,
 							  cpusetAll,
 							  MaxCpuSetLength);
 		bmsAll = CpusetToBitset(cpusetAll, MaxCpuSetLength);
+
 		/* Check whether the cores in this group are available */
 		if (!CpusetIsEmpty(caps->cpuset))
 		{
-			Bitmapset *bmsMissing = NULL;
+			char *cpuset = getCpuSetByRole(caps->cpuset);
+			bmsCurrent = CpusetToBitset(cpuset, MaxCpuSetLength);
 
-			bmsCurrent = CpusetToBitset(caps->cpuset, MaxCpuSetLength);
 			bmsCommon = bms_intersect(bmsCurrent, bmsAll);
 			bmsMissing = bms_difference(bmsCurrent, bmsCommon);
 
@@ -1313,8 +1315,8 @@ validateCapabilities(Relation rel,
 
 				ereport(ERROR,
 						(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-						 errmsg("cpu cores %s are unavailable on the system",
-								cpusetMissing)));
+						errmsg("cpu cores %s are unavailable on the system",
+						cpusetMissing)));
 			}
 		}
 	}
@@ -1396,7 +1398,8 @@ validateCapabilities(Relation rel,
 
 					Assert(!bms_is_empty(bmsCurrent));
 
-					bmsOther = CpusetToBitset(valueStr, MaxCpuSetLength);
+					char *cpuset = getCpuSetByRole(valueStr);
+					bmsOther = CpusetToBitset(cpuset, MaxCpuSetLength);
 					bmsCommon = bms_intersect(bmsCurrent, bmsOther);
 
 					if (!bms_is_empty(bmsCommon))
@@ -1547,16 +1550,22 @@ getResGroupMemAuditor(char *name)
 /*
  * check whether the cpuset value is syntactically right
  */
-static bool
+static void
 checkCpusetSyntax(const char *cpuset)
 {
+	if (cpuset == NULL)
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_SYNTAX_ERROR),
+				 errmsg("cpuset invalid")));
+	}
+
 	if (strlen(cpuset) >= MaxCpuSetLength)
 	{
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 				 errmsg("the length of cpuset reached the upper limit %d",
 						MaxCpuSetLength)));
-		return false;
 	}
 	if (!CpusetToBitset(cpuset,
 						 strlen(cpuset)))
@@ -1564,7 +1573,81 @@ checkCpusetSyntax(const char *cpuset)
 		ereport(ERROR,
 				(errcode(ERRCODE_SYNTAX_ERROR),
 				 errmsg("cpuset invalid")));
-		return false;
 	}
-	return true;
+
+	return;
+}
+
+/*
+ * Check Cpuset by coordinator and segment
+ */
+extern void
+checkCpuSetByRole(const char *cpuset)
+{
+	char **arraycpuset = (char **)palloc0(sizeof(char *) * CpuSetArrayLength);
+	char *copycpuset = (char *)palloc0(sizeof(char) * MaxCpuSetLength);
+	strcpy(copycpuset, cpuset);
+
+	int cnt = 0;
+	for (int i = 0; i < sizeof(cpuset); i++)
+	{
+		if (cpuset[i] == ';')
+			cnt++;
+	}
+
+	if (cnt == 0)
+	{
+		checkCpusetSyntax(copycpuset);
+		arraycpuset[0] = copycpuset;
+	}
+	else if (cnt == 1)
+	{
+		int iter = 0;
+		char *nextcpuset = strtok(copycpuset, ";");
+		while (nextcpuset != NULL)
+		{
+			arraycpuset[iter++] = nextcpuset;
+			nextcpuset = strtok(NULL, ";");
+		}
+		checkCpusetSyntax(arraycpuset[0]);
+		checkCpusetSyntax(arraycpuset[1]);
+	}
+	else
+		ereport(ERROR,
+				(errcode(ERRCODE_SYNTAX_ERROR),
+				errmsg("cpuset invalid")));
+
+	pfree(copycpuset);
+	pfree(arraycpuset);
+	return;
+}
+
+/*
+ * Seperate cpuset by coordinator and segment
+ * Return as splitcpuset
+ */
+extern char *
+getCpuSetByRole(const char *cpuset)
+{
+	int iter = 0;
+	char *splitcpuset = NULL;
+
+	char **arraycpuset = (char **)palloc0(sizeof(char *) * CpuSetArrayLength);
+	char *copycpuset = (char *)palloc0(sizeof(char) * MaxCpuSetLength);
+	strcpy(copycpuset, cpuset);
+
+	char *nextcpuset = strtok(copycpuset, ";");
+	while (nextcpuset != NULL)
+	{
+		arraycpuset[iter++] = nextcpuset;
+		nextcpuset = strtok(NULL, ";");
+	}
+
+	/* Get result cpuset by gprole, on master or segment */
+	if (Gp_role == GP_ROLE_EXECUTE && arraycpuset[1] != NULL)
+		splitcpuset = arraycpuset[1];
+	else
+		splitcpuset = arraycpuset[0];
+
+	return splitcpuset;
 }

--- a/src/include/utils/resgroup.h
+++ b/src/include/utils/resgroup.h
@@ -32,6 +32,11 @@
 #define MaxCpuSetLength 1024
 
 /*
+ * The max length of cpuset array
+ */
+#define CpuSetArrayLength 2
+
+/*
  * Default value of cpuset
  */
 #define DefaultCpuset "-1"
@@ -85,8 +90,9 @@ typedef struct ResGroupCaps
 } ResGroupCaps;
 
 /* Set 'cpuset' to an empty string, and reset all other fields to zero */
-#define ClearResGroupCaps(caps) \
-	MemSet((caps), 0, offsetof(ResGroupCaps, cpuset) + 1)
+#define ClearResGroupCaps(caps) do { \
+	MemSet((caps), 0, offsetof(ResGroupCaps, cpuset) + 1); \
+} while(0)
 
 
 /*
@@ -229,6 +235,8 @@ extern void ResGroupMoveQuery(int sessionId, Oid groupId, const char *groupName)
 extern int32 ResGroupGetSessionMemUsage(int sessionId);
 extern int32 ResGroupGetGroupAvailableMem(Oid groupId);
 extern Oid ResGroupGetGroupIdBySessionId(int sessionId);
+extern char *getCpuSetByRole(const char *cpuset);
+extern void checkCpuSetByRole(const char *cpuset);
 
 #define LOG_RESGROUP_DEBUG(...) \
 	do {if (Debug_resource_group) elog(__VA_ARGS__); } while(false);

--- a/src/test/isolation2/expected/resgroup/resgroup_syntax.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_syntax.out
@@ -153,6 +153,17 @@ CREATE RESOURCE GROUP rg_test_group WITH (cpuset='3-1', memory_limit=5);
 ERROR:  cpuset invalid
 CREATE RESOURCE GROUP rg_test_group WITH (cpuset=' 0 ', memory_limit=5);
 ERROR:  cpuset invalid
+CREATE RESOURCE GROUP rg_test_group WITH (cpuset='0;3-1', memory_limit=5);
+ERROR:  cpuset invalid
+CREATE RESOURCE GROUP rg_test_group WITH (cpuset='4;a', memory_limit=5);
+ERROR:  cpuset invalid
+CREATE RESOURCE GROUP rg_test_group WITH (cpuset='-;4', memory_limit=5);
+ERROR:  cpuset invalid
+CREATE RESOURCE GROUP rg_test_group WITH (cpuset=';5', memory_limit=5);
+ERROR:  cpuset invalid
+CREATE RESOURCE GROUP rg_test_group WITH (cpuset='5;', memory_limit=5);
+ERROR:  cpuset invalid
+
 ---- suppose the core numbered 1024 is not exist
 CREATE RESOURCE GROUP rg_test_group WITH (cpuset='1024', memory_limit=5);
 ERROR:  cpu cores 1024 are unavailable on the system
@@ -178,6 +189,22 @@ ERROR:  cpuset invalid
 ALTER RESOURCE GROUP rg_test_group set CPUSET '3-1';
 ERROR:  cpuset invalid
 ALTER RESOURCE GROUP rg_test_group set CPUSET ' 0 ';
+ERROR:  cpuset invalid
+ALTER RESOURCE GROUP rg_test_group set CPUSET '5;3-1';
+ERROR:  cpuset invalid
+ALTER RESOURCE GROUP rg_test_group set CPUSET '4;a';
+ERROR:  cpuset invalid
+ALTER RESOURCE GROUP rg_test_group set CPUSET '-;4';
+ERROR:  cpuset invalid
+ALTER RESOURCE GROUP rg_test_group set CPUSET ';5';
+ERROR:  cpuset invalid
+ALTER RESOURCE GROUP rg_test_group set CPUSET '5;';
+ERROR:  cpuset invalid
+ALTER RESOURCE GROUP rg_test_group set CPUSET ';';
+ERROR:  cpuset invalid
+ALTER RESOURCE GROUP rg_test_group set CPUSET '1;2;';
+ERROR:  cpuset invalid
+ALTER RESOURCE GROUP rg_test_group set CPUSET '1;2;3';
 ERROR:  cpuset invalid
 ---- suppose the core numbered 1024 is not exist
 ALTER RESOURCE GROUP rg_test_group set CPUSET '1024';
@@ -234,7 +261,15 @@ SELECT groupname,concurrency,cpu_rate_limit,memory_limit,memory_shared_quota,mem
 (1 row)
 DROP RESOURCE GROUP rg_test_group;
 DROP
-
+CREATE RESOURCE GROUP rg_test_group WITH (cpuset='1;4-5');
+CREATE
+SELECT groupname,concurrency,cpu_rate_limit,memory_limit,memory_shared_quota,memory_spill_ratio FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_test_group';
+ groupname     | concurrency | cpu_rate_limit | memory_limit | memory_shared_quota | memory_spill_ratio 
+---------------+-------------+----------------+--------------+---------------------+--------------------
+ rg_test_group | 20          | -1             | 0            | 80                  | 0                  
+(1 row)
+DROP RESOURCE GROUP rg_test_group;
+DROP
 -- ----------------------------------------------------------------------
 -- Test: boundary check in create resource group syntax
 -- ----------------------------------------------------------------------
@@ -611,5 +646,15 @@ CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, me
 CREATE
 ALTER RESOURCE GROUP rg_test_group SET memory_limit 0;
 ERROR:  when memory_limit is unlimited memory_spill_ratio must be set to 0
+DROP RESOURCE GROUP rg_test_group;
+DROP
+
+-- positive: test master/segment cpuset
+CREATE RESOURCE GROUP rg_test_group WITH (cpuset='1;4-5');
+CREATE
+ALTER RESOURCE GROUP rg_test_group SET CPUSET '2;4-5';
+ALTER
+ALTER RESOURCE GROUP rg_test_group SET CPUSET '3;4-5';
+ALTER
 DROP RESOURCE GROUP rg_test_group;
 DROP

--- a/src/test/isolation2/input/resgroup/resgroup_cpuset.source
+++ b/src/test/isolation2/input/resgroup/resgroup_cpuset.source
@@ -292,6 +292,25 @@ SELECT gp_inject_fault('create_resource_group_fail', 'reset', 1);
 DROP RESOURCE GROUP rg1_test_group;
 -- end_ignore
 
+-- test segment/master cpuset
+CREATE RESOURCE GROUP rg_multi_cpuset1 WITH (concurrency=2, cpuset='0;1-2');
+
+CREATE RESOURCE GROUP rg_multi_cpuset WITH (concurrency=2, cpuset='0;1-2');
+CREATE RESOURCE GROUP rg_multi_cpuset WITH (concurrency=2, cpuset='0');
+
+CREATE RESOURCE GROUP rg_multi_cpuset2 WITH (concurrency=2, cpuset='3;4-5');
+
+ALTER RESOURCE GROUP rg_multi_cpuset2 set CPUSET '0;1-3';
+ALTER RESOURCE GROUP rg_multi_cpuset2 set CPUSET '6';
+ALTER RESOURCE GROUP rg_multi_cpuset1 set CPUSET '3;4-5';
+ALTER RESOURCE GROUP rg_multi_cpuset2 set CPUSET '0;1-2';
+
+select groupname,cpuset from gp_toolkit.gp_resgroup_config where groupname='rg_multi_cpuset1';
+select groupname,cpuset from gp_toolkit.gp_resgroup_config where groupname='rg_multi_cpuset2';
+
+DROP RESOURCE GROUP rg_multi_cpuset1;
+DROP RESOURCE GROUP rg_multi_cpuset2;
+
 REVOKE ALL ON busy FROM role1_cpuset_test;
 DROP ROLE role1_cpuset_test;
 DROP RESOURCE GROUP rg1_cpuset_test;

--- a/src/test/isolation2/output/resgroup/resgroup_cpuset.source
+++ b/src/test/isolation2/output/resgroup/resgroup_cpuset.source
@@ -287,6 +287,43 @@ SELECT gp_inject_fault('create_resource_group_fail', 'reset', 1);
  Success:        
 (1 row)
 
+-- test segment/master cpuset
+CREATE RESOURCE GROUP rg_multi_cpuset1 WITH (concurrency=2, cpuset='0;1-2');
+CREATE
+
+CREATE RESOURCE GROUP rg_multi_cpuset WITH (concurrency=2, cpuset='0;1-2');
+ERROR:  cpu cores 0 are used by resource group rg_multi_cpuset1
+CREATE RESOURCE GROUP rg_multi_cpuset WITH (concurrency=2, cpuset='0');
+ERROR:  cpu cores 0 are used by resource group rg_multi_cpuset1
+
+CREATE RESOURCE GROUP rg_multi_cpuset2 WITH (concurrency=2, cpuset='3;4-5');
+CREATE
+
+ALTER RESOURCE GROUP rg_multi_cpuset2 set CPUSET '0;1-3';
+ERROR:  cpu cores 0 are used by resource group rg_multi_cpuset1
+ALTER RESOURCE GROUP rg_multi_cpuset2 set CPUSET '6';
+ALTER
+ALTER RESOURCE GROUP rg_multi_cpuset1 set CPUSET '3;4-5';
+ALTER
+ALTER RESOURCE GROUP rg_multi_cpuset2 set CPUSET '0;1-2';
+ALTER
+
+select groupname,cpuset from gp_toolkit.gp_resgroup_config where groupname='rg_multi_cpuset1';
+ groupname        | cpuset 
+------------------+--------
+ rg_multi_cpuset1 | 3;4-5  
+(1 row)
+select groupname,cpuset from gp_toolkit.gp_resgroup_config where groupname='rg_multi_cpuset2';
+ groupname        | cpuset 
+------------------+--------
+ rg_multi_cpuset2 | 0;1-2  
+(1 row)
+
+DROP RESOURCE GROUP rg_multi_cpuset1;
+DROP
+DROP RESOURCE GROUP rg_multi_cpuset2;
+DROP
+
 REVOKE ALL ON busy FROM role1_cpuset_test;
 REVOKE
 DROP ROLE role1_cpuset_test;

--- a/src/test/isolation2/sql/resgroup/resgroup_syntax.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_syntax.sql
@@ -77,6 +77,12 @@ CREATE RESOURCE GROUP rg_test_group WITH (cpuset='0-,', memory_limit=5);
 CREATE RESOURCE GROUP rg_test_group WITH (cpuset='-1', memory_limit=5);
 CREATE RESOURCE GROUP rg_test_group WITH (cpuset='3-1', memory_limit=5);
 CREATE RESOURCE GROUP rg_test_group WITH (cpuset=' 0 ', memory_limit=5);
+CREATE RESOURCE GROUP rg_test_group WITH (cpuset='0;3-1', memory_limit=5);
+CREATE RESOURCE GROUP rg_test_group WITH (cpuset='4;a', memory_limit=5);
+CREATE RESOURCE GROUP rg_test_group WITH (cpuset='-;4', memory_limit=5);
+CREATE RESOURCE GROUP rg_test_group WITH (cpuset=';5', memory_limit=5);
+CREATE RESOURCE GROUP rg_test_group WITH (cpuset='5;', memory_limit=5);
+
 ---- suppose the core numbered 1024 is not exist
 CREATE RESOURCE GROUP rg_test_group WITH (cpuset='1024', memory_limit=5);
 CREATE RESOURCE GROUP rg_test_group WITH (cpuset='0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,', memory_limit=5);
@@ -91,6 +97,14 @@ ALTER RESOURCE GROUP rg_test_group set CPUSET '0-';
 ALTER RESOURCE GROUP rg_test_group set CPUSET '-1';
 ALTER RESOURCE GROUP rg_test_group set CPUSET '3-1';
 ALTER RESOURCE GROUP rg_test_group set CPUSET ' 0 ';
+ALTER RESOURCE GROUP rg_test_group set CPUSET '5;3-1';
+ALTER RESOURCE GROUP rg_test_group set CPUSET '4;a';
+ALTER RESOURCE GROUP rg_test_group set CPUSET '-;4';
+ALTER RESOURCE GROUP rg_test_group set CPUSET ';5';
+ALTER RESOURCE GROUP rg_test_group set CPUSET '5;';
+ALTER RESOURCE GROUP rg_test_group set CPUSET ';';
+ALTER RESOURCE GROUP rg_test_group set CPUSET '1;2;';
+ALTER RESOURCE GROUP rg_test_group set CPUSET '1;2;3';
 ---- suppose the core numbered 1024 is not exist
 ALTER RESOURCE GROUP rg_test_group set CPUSET '1024';
 ALTER RESOURCE GROUP rg_test_group set CPUSET '0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,';
@@ -115,7 +129,10 @@ DROP RESOURCE GROUP rg_test_group;
 CREATE RESOURCE GROUP rg_test_group WITH (cpuset='0');
 SELECT groupname,concurrency,cpu_rate_limit,memory_limit,memory_shared_quota,memory_spill_ratio FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_test_group';
 DROP RESOURCE GROUP rg_test_group;
-
+CREATE RESOURCE GROUP rg_test_group WITH (cpuset='1;4-5');
+SELECT groupname,concurrency,cpu_rate_limit,memory_limit,memory_shared_quota,memory_spill_ratio
+FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_test_group';
+DROP RESOURCE GROUP rg_test_group;
 -- ----------------------------------------------------------------------
 -- Test: boundary check in create resource group syntax
 -- ----------------------------------------------------------------------
@@ -318,4 +335,10 @@ DROP RESOURCE GROUP rg_test_group;
 -- negative: memory_limit must be limited if memory_spill_ratio > 0
 CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio=10);
 ALTER RESOURCE GROUP rg_test_group SET memory_limit 0;
+DROP RESOURCE GROUP rg_test_group;
+
+-- positive: test master/segment cpuset
+CREATE RESOURCE GROUP rg_test_group WITH (cpuset='1;4-5');
+ALTER RESOURCE GROUP rg_test_group SET CPUSET '2;4-5';
+ALTER RESOURCE GROUP rg_test_group SET CPUSET '3;4-5';
 DROP RESOURCE GROUP rg_test_group;


### PR DESCRIPTION
New SYNTAX of resource group cpuset for different master and segment
Using syntax like cpuset="1;3-4" could different cpuset of master and segment by semicolon.  For example,
if we define cpuset="1;3-4", then master will use the first  cpu core, segments will use third  and fourth core.

CREATE and ALTER resource group support this new syntax.
```
postgres=# CREATE RESOURCE GROUP rg1 WITH (cpuset='1;2-3');
CREATE RESOURCE GROUP
postgres=# select groupname, cpuset from gp_toolkit.gp_resgroup_config where groupname = 'rg1';
 groupname | cpuset 
-----------+--------
 rg1       | 1;2-3
(1 row)

postgres=# ALTER resource group rg1 SET cpuset '4;5-6';
ALTER RESOURCE GROUP
postgres=# select groupname, cpuset from gp_toolkit.gp_resgroup_config where groupname = 'rg1';
 groupname | cpuset 
-----------+--------
 rg1       | 4;5-6
(1 row)
```

we didn't make too much motification on Resource group. For differentiate on mater and segment, seperating cpuset by semicolon, then apply the first half of it to master and second half to segment.


## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
