### PR TITLE
[5X] Clear retry flags properly in replacement OpenSSL sock_write function.

### DIFF
--- a/src/backend/libpq/be-secure.c
+++ b/src/backend/libpq/be-secure.c
@@ -484,6 +484,7 @@ my_sock_write(BIO *h, const char *buf, int size)
 	prepare_for_client_write();
 
 	res = send(h->num, buf, size, 0);
+	BIO_clear_retry_flags(h);
 	if (res <= 0)
 	{
 		if (errno == EINTR)


### PR DESCRIPTION
Current OpenSSL code includes a BIO_clear_retry_flags() step in the sock_write() function.  Either we failed to copy the code correctly, or they added this since we copied it.  In any case, lack of the clear step appears to be the cause of the server lockup after connection loss reported in bug 8647 from Valentine Gogichashvili.  Assume that this is correct coding for all OpenSSL versions, and hence back-patch to all supported branches.

Diagnosis and patch by Alexander Kukushkin.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [x] Review a PR in return to support the community
