### PR TITLE
Fixme: basebackup slot creation

### DIFF
--- a/gpMgmt/bin/gppylib/commands/test/unit/test_unit_pg_base_backup.py
+++ b/gpMgmt/bin/gppylib/commands/test/unit/test_unit_pg_base_backup.py
@@ -1,5 +1,90 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) Greenplum Inc 2012. All Rights Reserved.
+#
+
 import unittest
+from mock import call, Mock, patch
 from gppylib.commands import pg
+from test.unit.gp_unittest import GpTestCase, run_tests
+from pgdb import DatabaseError
+
+class TestUnitPgReplicationSlot(GpTestCase):
+    def setUp(self):
+        mock_logger = Mock(spec=['log', 'warn', 'info', 'debug', 'error', 'warning', 'fatal'])
+        self.replication_slot_name = "internal_wal_replication_slot"
+        self.source_host = "bar"
+        self.source_port = 1234
+
+        self.pg_replication_slot = pg.PgReplicationSlot(
+            self.source_host,
+            self.source_port,
+            self.replication_slot_name,
+        )
+        self.apply_patches([
+            patch('gppylib.commands.pg.logger', return_value=mock_logger),
+            patch('gppylib.db.dbconn.DbURL', return_value=Mock())
+        ])
+
+        self.mock_logger = self.get_mock_from_apply_patch('logger')
+
+    @patch('gppylib.db.dbconn.connect', side_effect=Exception())
+    def test_slot_exist_conn_exception(self, mock1):
+
+        with self.assertRaises(Exception) as ex:
+            self.pg_replication_slot.slot_exists()
+
+        self.assertEqual(1, self.mock_logger.debug.call_count)
+        self.assertEqual([call('Checking if slot internal_wal_replication_slot exists for host:bar, port:1234')],
+                         self.mock_logger.debug.call_args_list)
+        self.assertTrue('Failed to query pg_replication_slots for' in str(ex.exception))
+
+    @patch('gppylib.db.dbconn.connect', autospec=True)
+    @patch('gppylib.db.dbconn.querySingleton', return_value=1)
+    def test_slot_exist_query_true(self, mock1, mock2):
+        self.assertTrue(self.pg_replication_slot.slot_exists())
+        self.assertEqual(1, self.mock_logger.debug.call_count)
+        self.assertEqual([call('Checking if slot internal_wal_replication_slot exists for host:bar, port:1234')],
+                         self.mock_logger.debug.call_args_list)
+
+    @patch('gppylib.db.dbconn.connect', autospec=True)
+    @patch('gppylib.db.dbconn.querySingleton', return_value=0)
+    def test_slot_exist_query_false(self, mock1, mock2):
+        self.assertFalse(self.pg_replication_slot.slot_exists())
+        self.assertEqual(2, self.mock_logger.debug.call_count)
+        self.assertEqual([call('Checking if slot internal_wal_replication_slot exists for host:bar, port:1234'),
+                          call('Slot internal_wal_replication_slot does not exist for host:bar, port:1234')],
+                         self.mock_logger.debug.call_args_list)
+
+    @patch('gppylib.db.dbconn.connect', side_effect=Exception())
+    def test_drop_slot_conn_exception(self, mock1):
+        with self.assertRaises(Exception) as ex:
+            self.pg_replication_slot.drop_slot()
+
+        self.assertEqual(1, self.mock_logger.debug.call_count)
+        self.assertEqual([call('Dropping slot internal_wal_replication_slot for host:bar, port:1234')],
+                         self.mock_logger.debug.call_args_list)
+        self.assertTrue('Failed to drop replication slot for host:bar, port:1234' in str(ex.exception))
+
+    @patch('gppylib.db.dbconn.connect', autospec=True)
+    @patch('gppylib.db.dbconn.query', side_effect=DatabaseError("DatabaseError Exception"))
+    def test_drop_slot_db_error_exception(self, mock1, mock2):
+        self.pg_replication_slot.drop_slot()
+        self.assertEqual(1, self.mock_logger.debug.call_count)
+        self.assertEqual(1, self.mock_logger.exception.call_count)
+        self.assertEqual([call('Dropping slot internal_wal_replication_slot for host:bar, port:1234')],
+                         self.mock_logger.debug.call_args_list)
+        self.assertEqual([call('Failed to query pg_drop_replication_slot for host:bar, port:1234: DatabaseError Exception')],
+                         self.mock_logger.exception.call_args_list)
+
+    @patch('gppylib.db.dbconn.connect', autospec=True)
+    @patch('gppylib.db.dbconn.query', autospec=True)
+    def test_drop_slot_success(self, mock1, mock2):
+        self.assertTrue(self.pg_replication_slot.drop_slot())
+        self.assertEqual(2, self.mock_logger.debug.call_count)
+        self.assertEqual([call('Dropping slot internal_wal_replication_slot for host:bar, port:1234'),
+                          call('Successfully dropped replication slot internal_wal_replication_slot for host:bar, port:1234')],
+                         self.mock_logger.debug.call_args_list)
 
 
 class TestUnitPgBaseBackup(unittest.TestCase):
@@ -19,7 +104,9 @@ class TestUnitPgBaseBackup(unittest.TestCase):
         self.assertIn("fetch", tokens)
         self.assertNotIn("stream", tokens)
 
-    def test_base_backup_passes_parameters_necessary_to_create_replication_slot_when_given_slotname(self):
+    @patch('gppylib.commands.pg.PgReplicationSlot.slot_exists', return_value=True)
+    @patch('gppylib.commands.pg.PgReplicationSlot.drop_slot', return_value=True)
+    def test_base_backup_passes_parameters_necessary_to_create_replication_slot_when_given_slotname(self, mock1, mock2):
         base_backup = pg.PgBaseBackup(
             create_slot=True,
             replication_slot_name='some-replication-slot-name',
@@ -32,8 +119,28 @@ class TestUnitPgBaseBackup(unittest.TestCase):
         self.assertIn("some-replication-slot-name", base_backup.command_tokens)
         self.assertIn("--wal-method", base_backup.command_tokens)
         self.assertIn("stream", base_backup.command_tokens)
+        self.assertIn("--create-slot", base_backup.command_tokens)
 
-    def test_base_backup_does_not_pass_conflicting_xlog_method_argument_when_given_replication_slot(self):
+    @patch('gppylib.commands.pg.PgReplicationSlot.slot_exists', return_value=True)
+    @patch('gppylib.commands.pg.PgReplicationSlot.drop_slot', return_value=False)
+    def test_base_backup_passes_parameters_necessary_when_drop_replication_slot_ret_false(self, mock1, mock2):
+        base_backup = pg.PgBaseBackup(
+            create_slot=True,
+            replication_slot_name='some-replication-slot-name',
+            target_datadir="foo",
+            source_host="bar",
+            source_port="baz",
+            )
+
+        self.assertIn("--slot", base_backup.command_tokens)
+        self.assertIn("some-replication-slot-name", base_backup.command_tokens)
+        self.assertIn("--wal-method", base_backup.command_tokens)
+        self.assertIn("stream", base_backup.command_tokens)
+        self.assertNotIn("--create-slot", base_backup.command_tokens)
+
+    @patch('gppylib.commands.pg.PgReplicationSlot.slot_exists', return_value=True)
+    @patch('gppylib.commands.pg.PgReplicationSlot.drop_slot', return_value=True)
+    def test_base_backup_does_not_pass_conflicting_xlog_method_argument_when_given_replication_slot(self, mock1, mock2):
         base_backup = pg.PgBaseBackup(
             create_slot=True,
             replication_slot_name='some-replication-slot-name',
@@ -46,4 +153,4 @@ class TestUnitPgBaseBackup(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()
+    run_tests()

--- a/gpMgmt/bin/lib/gpconfigurenewsegment
+++ b/gpMgmt/bin/lib/gpconfigurenewsegment
@@ -138,7 +138,7 @@ class ConfExpSegCmd(Command):
                     cmd = PgBaseBackup(target_datadir=self.datadir,
                                        source_host=self.syncWithSegmentHostname,
                                        source_port=str(self.syncWithSegmentPort),
-                                       create_slot = False,
+                                       create_slot=True,
                                        replication_slot_name=self.replicationSlotName,
                                        forceoverwrite=self.forceoverwrite,
                                        target_gp_dbid=self.dbid,
@@ -149,30 +149,9 @@ class ConfExpSegCmd(Command):
                         self.set_results(CommandResult(0, b'', b'', True, False))
                         if shouldDeleteProgressFile:
                             os.remove(self.progressFile)
-
                     except Exception as e:
-                        #  If the cluster never has mirrors, cmd will fail
-                        #  quickly because the internal slot doesn't exist.
-                        #  Re-run with `create_slot`.
-                        #  GPDB_12_MERGE_FIXME could we check it before? or let
-                        #  pg_basebackup create slot if not exists.
-                        cmd = PgBaseBackup(target_datadir=self.datadir,
-                                           source_host=self.syncWithSegmentHostname,
-                                           source_port=str(self.syncWithSegmentPort),
-                                           create_slot = True,
-                                           replication_slot_name=self.replicationSlotName,
-                                           forceoverwrite=True,
-                                           target_gp_dbid=self.dbid,
-                                           logfile=self.progressFile)
-                        try:
-                            logger.info("Re-running pg_basebackup, creating the slot this time")
-                            cmd.run(validateAfter=True)
-                            self.set_results(CommandResult(0, b'', b'', True, False))
-                            if shouldDeleteProgressFile:
-                                os.remove(self.progressFile)
-                        except Exception as e:
-                            self.set_results(CommandResult(1, b'', str(e).encode(), True, False))
-                            raise
+                        self.set_results(CommandResult(1, b'', str(e).encode(), True, False))
+                        raise
 
                     logger.info("Successfully ran pg_basebackup: %s" % cmd.cmdStr)
                     return

--- a/gpMgmt/sbin/gpsegrecovery.py
+++ b/gpMgmt/sbin/gpsegrecovery.py
@@ -30,33 +30,13 @@ class FullRecovery(Command):
         cmd = PgBaseBackup(self.recovery_info.target_datadir,
                            self.recovery_info.source_hostname,
                            str(self.recovery_info.source_port),
-                           create_slot=False,
+                           create_slot=True,
                            replication_slot_name=self.replicationSlotName,
                            forceoverwrite=self.forceoverwrite,
                            target_gp_dbid=self.recovery_info.target_segment_dbid,
                            progress_file=self.recovery_info.progress_file)
         self.logger.info("Running pg_basebackup with progress output temporarily in %s" % self.recovery_info.progress_file)
-        try:
-            cmd.run(validateAfter=True)
-        except Exception as e: #TODO should this be ExecutionError?
-            self.logger.info("Running pg_basebackup failed: {}".format(str(e)))
-
-            #  If the cluster never has mirrors, cmd will fail
-            #  quickly because the internal slot doesn't exist.
-            #  Re-run with `create_slot`.
-            #  GPDB_12_MERGE_FIXME could we check it before? or let
-            #  pg_basebackup create slot if not exists.
-            cmd = PgBaseBackup(self.recovery_info.target_datadir,
-                               self.recovery_info.source_hostname,
-                               str(self.recovery_info.source_port),
-                               create_slot=True,
-                               replication_slot_name=self.replicationSlotName,
-                               forceoverwrite=True,
-                               target_gp_dbid=self.recovery_info.target_segment_dbid,
-                               progress_file=self.recovery_info.progress_file)
-            self.logger.info("Re-running pg_basebackup, creating the slot this time")
-            cmd.run(validateAfter=True)
-
+        cmd.run(validateAfter=True)
         self.error_type = RecoveryErrorType.DEFAULT_ERROR
         self.logger.info("Successfully ran pg_basebackup for dbid: {}".format(
             self.recovery_info.target_segment_dbid))

--- a/gpMgmt/test/behave/mgmt_utils/gpaddmirrors.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpaddmirrors.feature
@@ -5,6 +5,8 @@ Feature: Tests for gpaddmirrors
           And a tablespace is created with data
          When gpaddmirrors adds 3 mirrors
           And an FTS probe is triggered
+          #gpaddmirrors triggers full recovery where old replication slot is dropped and new one is created
+          And verify replication slot internal_wal_replication_slot is available on all the segments
           And the segments are synchronized
          Then verify the database has mirrors
           And the tablespace is valid
@@ -24,6 +26,8 @@ Feature: Tests for gpaddmirrors
         And an FTS probe is triggered
         And the segments are synchronized
         And verify the database has mirrors
+        #gpaddmirrors triggers full recovery where old replication slot is dropped and new one is created
+        And verify replication slot internal_wal_replication_slot is available on all the segments
         And the tablespace is valid
         And user stops all primary processes
         And user can start transactions

--- a/gpMgmt/test/behave/mgmt_utils/gpmovemirrors.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpmovemirrors.feature
@@ -26,9 +26,12 @@ Feature: Tests for gpmovemirrors
         Given a standard local demo cluster is created
         And a gpmovemirrors directory under '/tmp/gpmovemirrors' with mode '0700' is created
         And a 'good' gpmovemirrors file is created
+        And verify replication slot internal_wal_replication_slot is available on all the segments
         When the user runs gpmovemirrors
         Then gpmovemirrors should return a return code of 0
         And verify the database has mirrors
+        #gpmovemirrors triggers full recovery where old replication slot is dropped and new one is created
+        And verify replication slot internal_wal_replication_slot is available on all the segments
         And all the segments are running
         And the segments are synchronized
         And check segment conf: postgresql.conf
@@ -38,9 +41,12 @@ Feature: Tests for gpmovemirrors
         Given a standard local demo cluster is created
         And a gpmovemirrors directory under '/tmp/gpmovemirrors' with mode '0700' is created
         And a 'samedir' gpmovemirrors file is created
+        And verify replication slot internal_wal_replication_slot is available on all the segments
         When the user runs gpmovemirrors
         Then gpmovemirrors should return a return code of 0
         And verify the database has mirrors
+        #gpmovemirrors triggers full recovery where old replication slot is dropped and new one is created
+        And verify replication slot internal_wal_replication_slot is available on all the segments
         And all the segments are running
         And the segments are synchronized
         And verify that mirrors are recognized after a restart

--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -1228,7 +1228,7 @@ Feature: gprecoverseg tests
     And the gp_configuration_history table should contain a backout entry for the primary segment for contents 0,1
 
     And the mode of all the created data directories is changed to 0700
-    When the user runs "gprecoverseg -a"
+    When the user runs "gprecoverseg -aF"
     Then gprecoverseg should return a return code of 0
     And user can start transactions
     And all the segments are running

--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -255,6 +255,48 @@ Feature: gprecoverseg tests
         And the segments are synchronized
         And the cluster is rebalanced
 
+    Scenario: gprecoverseg should drop existing slot on full recovery
+        Given the database is running
+        And all the segments are running
+        And the segments are synchronized
+        And verify replication slot internal_wal_replication_slot is available on all the segments
+        And user stops all mirror processes
+        And user can start transactions
+        And the user waits until mirror on content 0,1,2 is down
+        When the user runs "gprecoverseg -a -F -v"
+        Then gprecoverseg should return a return code of 0
+        And gprecoverseg should print "Checking if slot internal_wal_replication_slot exists" to stdout
+        And gprecoverseg should print "Successfully dropped replication slot internal_wal_replication_slot" to stdout
+        And gprecoverseg should print "pg_basebackup: base backup completed" to stdout
+        And gprecoverseg should print "Segments successfully recovered" to stdout
+        And the user waits until mirror on content 0,1,2 is up
+        And verify replication slot internal_wal_replication_slot is available on all the segments
+        And all the segments are running
+        And the segments are synchronized
+        And the cluster is rebalanced
+
+    Scenario: gprecoverseg should not try to drop slot if slot does not exist
+        Given the database is running
+        And all the segments are running
+        And the segments are synchronized
+        And verify replication slot internal_wal_replication_slot is available on all the segments
+        And the mirror on content 0 is stopped
+        And user can start transactions
+        And the status of the mirror on content 0 should be "d"
+        And the user runs sql "select pg_drop_replication_slot('internal_wal_replication_slot');" in "postgres" on first primary segment
+        When the user runs "gprecoverseg -a -F -v"
+        Then gprecoverseg should return a return code of 0
+        And gprecoverseg should print "Checking if slot internal_wal_replication_slot exists" to stdout
+        And gprecoverseg should print "Slot internal_wal_replication_slot does not exist" to stdout
+        And gprecoverseg should not print "Successfully dropped replication slot internal_wal_replication_slot" to stdout
+        And gprecoverseg should print "pg_basebackup: base backup completed" to stdout
+        And gprecoverseg should print "Segments successfully recovered" to stdout
+        And the user waits until mirror on content 0 is up
+        And verify replication slot internal_wal_replication_slot is available on all the segments
+        And all the segments are running
+        And the segments are synchronized
+        And the cluster is rebalanced
+
     @backup_restore_bashrc
     Scenario: gprecoverseg should not return error when banner configured on host
         Given the database is running


### PR DESCRIPTION
**Issue**: If the cluster never has mirrors, PgBasebackUp call will fail with create-slot option False.
To add the mirror as part of fall back we were making the PgBasebackUp call with create-slot option True.
Fixme was added to fix this code structure.

**Fix**: We did few spike to check if the slot is present and create-slot is true can it reuse the existing slot.
but there is no support for that. As a optimal solution we are now
droping the available existing slot and creating new if the create-slot
option is provided as True. Which will also help to clean up the orphaned slot.

**Implementation details:**

- Added class PgReplicationSlot which has utility functions to check if the slot exists and dropping the slot.
- Added unit test cases for the class PgReplicationSlot covering all required code path.
- Added test case to TestUnitPgBaseBackup class for the check of PgBaseBackup command
- Added step to verify if the segment has replication slot and included in behave test of gpmovemirror, gpaddmirror and gprecoverseg
- Added scenario to verify the drop slot behaviour.
- Updated old unit test cases for pgBaseBackup call count assert and mock. 

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
