### PR TITLE
Fix gpcheckcat partition distribution policy check

### DIFF
--- a/gpMgmt/bin/gpcheckcat
+++ b/gpMgmt/bin/gpcheckcat
@@ -563,6 +563,69 @@ def checkPartitionIntegrity():
     err = []
     db = connect()
 
+    # Check for the numsegments value of parent and child partition from the gp_distribution_policy table
+    qry = '''
+    select inhparent::regclass, inhrelid::regclass, parent.numsegments as numsegments_parent, child.numsegments as numsegments_child
+    from pg_inherits inner join pg_partitioned_table on (pg_inherits.inhparent = pg_partitioned_table.partrelid)
+                     inner join gp_distribution_policy parent on (parent.localoid = inhparent)
+                     inner join gp_distribution_policy child on (child.localoid = inhrelid)
+    where parent.numsegments is distinct from child.numsegments
+          and not (inhrelid in (select ftrelid from pg_catalog.pg_foreign_table) and child.numsegments = NULL);
+    '''
+    try:
+        curs = db.query(qry)
+        cols = ('inhparent', 'inhrelid', 'numsegments_parent', 'numsegments_child')
+        col_names = {
+            'inhparent': 'table',
+            'inhrelid': 'affected child',
+            'numsegments_parent': 'parent numsegments value',
+            'numsegments_child': 'child numsegments value',
+        }
+
+        err = []
+        for row in curs.dictresult():
+            err.append([GV.cfg[GV.coordinator_dbid], cols, row])
+
+        if not err:
+            logger.info('[OK] partition numsegments check')
+        else:
+            err_count = len(err)
+            GV.checkStatus = False
+            setError(ERROR_REMOVE)
+            logger.info('[FAIL] partition numsegments check')
+            logger.error('partition numsegments check found %d issue(s)' % err_count)
+            if err_count > 100:
+                logger.error(qry)
+
+            myprint(
+                '[ERROR]: child partition(s) have different numsegments value '
+                'from the root partition. Check the gpcheckcat log for details.'
+            )
+            logger.error('The following tables have different numsegments value (showing at most 100 rows):')
+
+            # report at most 100 rows, for brevity
+            err = err[:100]
+
+            for index, e in enumerate(err):
+                cfg = e[0]
+                col = e[1]
+                row = e[2]
+
+                if index == 0:
+                    logger.error("--------")
+                    logger.error("  " + " | ".join(map(col_names.get, col)))
+                    logger.error("  " + "-+-".join(['-' * len(col_names[x]) for x in col]))
+
+                logger.error("  " + " | ".join([str(row[x]) for x in col]))
+
+            if err_count > 100:
+                logger.error(" ...")
+
+    except Exception as e:
+        setError(ERROR_NOREPAIR)
+        myprint('[ERROR] executing test: checkPartitionIntegrity')
+        myprint('  Execution error: ' + str(e))
+
     # Check for the distribution policy of parent and child partitions based on the following conditions:
     #   1. If a root is randomly distributed, then all middle, leaf level partitions must also be randomly distributed
     #   2. If a root is hash distributed, then middle level should be same as root and

--- a/gpMgmt/bin/gpcheckcat
+++ b/gpMgmt/bin/gpcheckcat
@@ -563,8 +563,10 @@ def checkPartitionIntegrity():
     err = []
     db = connect()
 
-    # MPP-11120: check for child partitions with different
-    # distribution policies.
+    # Check for the distribution policy of parent and child partitions based on the following conditions:
+    #   1. If a root is randomly distributed, then all middle, leaf level partitions must also be randomly distributed
+    #   2. If a root is hash distributed, then middle level should be same as root and
+    #      leaf level partition can be hash on same key or randomly distributed
     qry = '''
     select inhparent::regclass, inhrelid::regclass,
            pg_get_table_distributedby(inhparent) as dby_parent,
@@ -572,7 +574,9 @@ def checkPartitionIntegrity():
     from pg_inherits inner join pg_partitioned_table on (pg_inherits.inhparent = pg_partitioned_table.partrelid)
     where pg_get_table_distributedby(inhrelid) is distinct from pg_get_table_distributedby(inhparent)
           and not (pg_get_table_distributedby(inhparent) = 'DISTRIBUTED RANDOMLY' and pg_get_table_distributedby(inhrelid) = '')
-          and not (inhrelid in (select ftrelid from pg_catalog.pg_foreign_table) and pg_get_table_distributedby(inhrelid) = '');
+          and not (inhrelid in (select ftrelid from pg_catalog.pg_foreign_table) and pg_get_table_distributedby(inhrelid) = '')
+          and not (pg_get_table_distributedby(inhparent) like 'DISTRIBUTED BY%' and pg_get_table_distributedby(inhrelid) = 'DISTRIBUTED RANDOMLY'
+                   and (select isleaf from pg_partition_tree(inhparent) where relid = inhrelid));
     '''
     try:
         curs = db.query(qry)

--- a/gpMgmt/test/behave/mgmt_utils/steps/data/gpcheckcat/create_multilevel_partition.sql
+++ b/gpMgmt/test/behave/mgmt_utils/steps/data/gpcheckcat/create_multilevel_partition.sql
@@ -1,0 +1,14 @@
+CREATE TABLE sales (trans_id int, date date, amount
+decimal(9,2), region text)
+DISTRIBUTED BY (trans_id)
+PARTITION BY RANGE (date)
+SUBPARTITION BY LIST (region)
+SUBPARTITION TEMPLATE
+( SUBPARTITION usa VALUES ('usa'),
+  SUBPARTITION asia VALUES ('asia'),
+  SUBPARTITION europe VALUES ('europe'),
+  DEFAULT SUBPARTITION other_regions)
+  (START (date '2011-01-01') INCLUSIVE
+   END (date '2012-01-01') EXCLUSIVE
+   EVERY (INTERVAL '1 month'),
+   DEFAULT PARTITION outlying_dates );


### PR DESCRIPTION
Earlier gpcheckcat used to error out when root partition has different distribution policy than child partition. But commit a45be43489294386c23c5fa068ce071ec068d0d8 introduces a new statement `ALTER TABLE EXPAND PARTITION PREPARE` which modifies the distribution policy of the leaf partitions to be randomly distributed. Based on this a policy is good if the following conditions are satisfied:

- numsegments value is equal for all root, middle and leaf level partitions
- if a root is randomly distributed, then all middle, leaf level partitions must also be randomly distributed
- if a root is hash distributed, then middle level should be same as root and leaf level partition can be hash on same key or randomly distributed

This commit modifies the existing SQL query such that whenever a parent is hash distributed, the child can be randomly distributed if and only if it is a leaf level partition.

And also based on the first condition, for a partitioned table to have a correct distribution policy, the numsegments value for all root, middle and leaf level partitions must be equal. This check is also added for gpcheckcat. Readable external partitions are excluded from this check.

Sample log output for numsegments check failure:
```
20221103:11:36:30:098659 gpcheckcat:jnihal-a01:jnihal-[INFO]:-[FAIL] partition numsegments check
20221103:11:36:30:098659 gpcheckcat:jnihal-a01:jnihal-[ERROR]:-partition numsegments check found 1 issue(s)
[ERROR]: child partition(s) have different numsegments value from the root partition. Check the gpcheckcat log for details.
20221103:11:36:30:098659 gpcheckcat:jnihal-a01:jnihal-[ERROR]:-The following tables have different numsegments value (showing at most 100 rows):
20221103:11:36:30:098659 gpcheckcat:jnihal-a01:jnihal-[ERROR]:---------
20221103:11:36:30:098659 gpcheckcat:jnihal-a01:jnihal-[ERROR]:-  table | affected child | parent numsegments value | child numsegments value
20221103:11:36:30:098659 gpcheckcat:jnihal-a01:jnihal-[ERROR]:-  ------+----------------+--------------------------+------------------------
20221103:11:36:30:098659 gpcheckcat:jnihal-a01:jnihal-[ERROR]:-  public.sales_1_prt_10 | public.sales_1_prt_10_2_prt_asia | 3 | 1
```


Added behave test cases for the same.