### PR TITLE
Dump more info of releasing resource queue lock info

### DIFF
--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -3517,7 +3517,13 @@ StatementCancelHandler(SIGNAL_ARGS)
 		 * interrupt, service the interrupt immediately
 		 */
 		if (ImmediateInterruptOK)
+		{
+			/* Print out stack for immediate interruption */
+			ereport(LOG,
+					(errmsg("immediate interruption"),
+					errprintstack(true)));
 			ProcessInterrupts(__FILE__, __LINE__);
+		}
 	}
 
 	/* If we're still here, waken anything waiting on the process latch */

--- a/src/test/isolation2/expected/resource_queue_multi_portal.out
+++ b/src/test/isolation2/expected/resource_queue_multi_portal.out
@@ -149,6 +149,8 @@ DECLARE
 
 -- There should now only be one active statement, following the abort of session
 -- 1's transaction. The active statement is contributed by session 2.
+1<:  <... completed>
+ERROR:  canceling statement due to user request
 0:SELECT rsqcountlimit, rsqcountvalue FROM pg_resqueue_status WHERE rsqname = 'rq_multi_portal';
  rsqcountlimit | rsqcountvalue 
 ---------------+---------------
@@ -161,8 +163,6 @@ DECLARE
 (1 row)
 
 -- After ending the transactions, there should be 0 active statements.
-1<:  <... completed>
-ERROR:  canceling statement due to user request
 1:END;
 END
 2:END;

--- a/src/test/isolation2/sql/resource_queue_multi_portal.sql
+++ b/src/test/isolation2/sql/resource_queue_multi_portal.sql
@@ -88,12 +88,12 @@
 
 -- There should now only be one active statement, following the abort of session
 -- 1's transaction. The active statement is contributed by session 2.
+1<:
 0:SELECT rsqcountlimit, rsqcountvalue FROM pg_resqueue_status WHERE rsqname = 'rq_multi_portal';
 0:SELECT query, state from pg_stat_activity
   WHERE query = 'DECLARE c2 CURSOR FOR SELECT 1;';
 
 -- After ending the transactions, there should be 0 active statements.
-1<:
 1:END;
 2:END;
 0:SELECT rsqcountlimit, rsqcountvalue FROM pg_resqueue_status WHERE rsqname = 'rq_multi_portal';


### PR DESCRIPTION
A reported issue shows that queries belonging to a specific resource queue were blocked because the limit counter of the RQ was full. Actually, no query of the RQ were running. So we hit kind of limit counter "leak".

Investigation shows that `ResLockAcquire()` or `ResLockRelease()` was interrupted previously. Then, in `ResLockRelease()`, it found one or more locks (locallock, proclock and lock) were missing and returned early. It most likely missed updating resource queue limit counter and pg_locks info resulting that future queries were blocked due to the incorrect limit counter. However, we cannot determine the interruption point and lack more details. We need to dump more info for the case.

The PR includes three parts:

1. Use two static vars `ResLockAcquireStatus` and `ResLockReleaseStatus` to trace the progress of `ResLockAcquire()/ResLockRelease()`. Once they are interrupted, the next call will check the vars and dump it to log. `ResLockAcquireStatus` and `ResLockReleaseStatus` are to enumerate all possible status.
2. In `ResLockRelease()`, when it finds one or more locks (locallock, proclock and lock) are missing, it will dump all existing locks info, plus relevant resource queue limit counter.
3. In `StatementCancelHandler()`, print out stack to log for immediate interruption.

### Supplements

1. It's pretty mess if I dumped the complex structure of locks in one line, so I used a kind of formatting. The result is like this:
```
    Dumping locallock: 
    tag.lock.locktag_field1:                 6055
    tag.lock.locktag_field2:                 0   
    tag.lock.locktag_field3:                 0   
    tag.lock.locktag_field4:                 0   
    tag.mode:                                7   
    lock:                                    (nil)
    proclock:                                (nil)
    nLocks:                                  0   
    numLockOwners:                           0   
    maxLockOwners:                           8   
    lockOwners.nLocks:                       9187201950435737471
    holdsStrongLockCount:                    false
    lockCleared:                             false
    istemptable:                             false
```
2. In GPDB a process can be interrupted immediately only when it is waiting for input or a lock (see comments of `StatementCancelHandler()`). But it's difficult to recognize all possible interruption points due to the complex sub callings. So I just simply added traces to all steps.

### Test

It's difficult to add test case to emulate the scenario of interrupting `ResLockAcquire()/ResLockRelease()`. Since it's just about dumping info but not a new feature, I suppose manual test is enough.

It's the manual test I did:

Session 1: create table t1 (c1 int);
GDB: attach to session 1; handle SIGINT nostop print pass; set breakpoint to `ResLockAcquire()`, line 225 which is after getting LOCALLOCK and before other locks; and `StatementCancelHandler()`
Session 1: select count(*) from t1; -- suspended on the breakpoint
Session 2: select pg_cancel_backend(1686245); -- cancel the query on session 1
GDB: continue, hit `StatementCancelHandler()`.
GDB: set ImmediateInterruptOK=1 and continue to emulate force interruption
Session 1: continue and print relevant info in `ResLockRelease()`.

I tried different interruption points in `ResLockAcquire()/ResLockRelease()` and the code works as design.