### PR TITLE
pg_dump: fix upgrading external tables with dropped cols

### DIFF
--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -16182,7 +16182,20 @@ dumpExternal(Archive *fout, const TableInfo *tbinfo, PQExpBuffer q, PQExpBuffer 
 				appendPQExpBuffer(q, "%s ", fmtId(tbinfo->attnames[j]));
 
 				/* Attribute type */
-				appendPQExpBufferStr(q, tbinfo->atttypnames[j]);
+				if (tbinfo->attisdropped[j])
+				{
+					/*
+					 * ALTER TABLE DROP COLUMN clears
+					 * pg_attribute.atttypid, so we will not have gotten a
+					 * valid type name; insert INTEGER as a stopgap. We'll
+					 * clean things up later.
+					*/
+					appendPQExpBufferStr(q, " INTEGER /* dummy */");
+				}
+				else
+				{
+					appendPQExpBufferStr(q, tbinfo->atttypnames[j]);
+				}
 
 				actual_atts++;
 			}

--- a/src/test/regress/expected/pg_dump_binary_upgrade.out
+++ b/src/test/regress/expected/pg_dump_binary_upgrade.out
@@ -1,0 +1,18 @@
+-- Ensure that pg_dump --binary-upgrade correctly outputs
+-- ALTER TABLE DROP COLUMN DDL for external tables.
+CREATE SCHEMA dump_this_schema;
+-- External tables with dropped columns is dumped correctly.
+CREATE EXTERNAL TABLE dump_this_schema.external_table_with_dropped_columns (
+    a int,
+    b int,
+    c int
+) LOCATION ('gpfdist://1.1.1.1:8082/xxxx.csv') FORMAT 'csv';
+ALTER EXTERNAL TABLE dump_this_schema.external_table_with_dropped_columns DROP COLUMN a;
+ALTER EXTERNAL TABLE dump_this_schema.external_table_with_dropped_columns DROP COLUMN b;
+-- Run pg_dump and expect to see an ALTER TABLE DROP COLUMN output
+-- for the tables with dropped column references.
+\! pg_dump --binary-upgrade --schema dump_this_schema regression | grep " DROP COLUMN "
+ALTER FOREIGN TABLE ONLY dump_this_schema.external_table_with_dropped_columns DROP COLUMN "........pg.dropped.1........";
+ALTER FOREIGN TABLE ONLY dump_this_schema.external_table_with_dropped_columns DROP COLUMN "........pg.dropped.2........";
+DROP SCHEMA dump_this_schema CASCADE;
+NOTICE:  drop cascades to foreign table dump_this_schema.external_table_with_dropped_columns

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -18,6 +18,8 @@
 # required setup steps
 test: test_setup
 
+test: pg_dump_binary_upgrade
+
 test: gp_dispatch_keepalives
 
 # copy command

--- a/src/test/regress/sql/pg_dump_binary_upgrade.sql
+++ b/src/test/regress/sql/pg_dump_binary_upgrade.sql
@@ -1,0 +1,20 @@
+-- Ensure that pg_dump --binary-upgrade correctly outputs
+-- ALTER TABLE DROP COLUMN DDL for external tables.
+
+CREATE SCHEMA dump_this_schema;
+
+-- External tables with dropped columns is dumped correctly.
+CREATE EXTERNAL TABLE dump_this_schema.external_table_with_dropped_columns (
+    a int,
+    b int,
+    c int
+) LOCATION ('gpfdist://1.1.1.1:8082/xxxx.csv') FORMAT 'csv';
+
+ALTER EXTERNAL TABLE dump_this_schema.external_table_with_dropped_columns DROP COLUMN a;
+ALTER EXTERNAL TABLE dump_this_schema.external_table_with_dropped_columns DROP COLUMN b;
+
+-- Run pg_dump and expect to see an ALTER TABLE DROP COLUMN output
+-- for the tables with dropped column references.
+\! pg_dump --binary-upgrade --schema dump_this_schema regression | grep " DROP COLUMN "
+
+DROP SCHEMA dump_this_schema CASCADE;


### PR DESCRIPTION
External tables with dropped columns failed to upgrade with:
```
pg_restore: creating EXTERNAL TABLE ext_upgrade_failure_test
pg_restore: [archiver (db)] Error while PROCESSING TOC:
pg_restore: [archiver (db)] Error from TOC entry 237; 1259 18142 EXTERNAL TABLE ext_upgrade_failure_test gpadmin
pg_restore: [archiver (db)] could not execute query: ERROR:  syntax error at or near ","
LINE 14:     "........pg.dropped.1........" ,
                                            ^
```

Fix pg_dump to output the ALTER TABLE DROP COLUMN DDL for external tables with dropped columns.

Pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/pgDumpExternalTables_7X_dev