### PR TITLE
[6X backport] pg_dump: fix upgrading external tables with dropped cols

### DIFF
--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -13914,7 +13914,20 @@ dumpExternal(Archive *fout, TableInfo *tbinfo, PQExpBuffer q, PQExpBuffer delq)
 				appendPQExpBuffer(q, "%s ", fmtId(tbinfo->attnames[j]));
 
 				/* Attribute type */
-				appendPQExpBufferStr(q, tbinfo->atttypnames[j]);
+				if (tbinfo->attisdropped[j])
+				{
+					/*
+					 * ALTER TABLE DROP COLUMN clears
+					 * pg_attribute.atttypid, so we will not have gotten a
+					 * valid type name; insert INTEGER as a stopgap. We'll
+					 * clean things up later.
+					 */
+					appendPQExpBufferStr(q, " INTEGER /* dummy */");
+				}
+				else
+				{
+					appendPQExpBufferStr(q, tbinfo->atttypnames[j]);
+				}
 
 				actual_atts++;
 			}

--- a/src/test/regress/expected/pg_dump_binary_upgrade.out
+++ b/src/test/regress/expected/pg_dump_binary_upgrade.out
@@ -1,4 +1,6 @@
--- Ensure that pg_dump --binary-upgrade correctly suppresses the ALTER
+-- 1) Ensure that pg_dump --binary-upgrade correctly outputs
+-- ALTER TABLE DROP COLUMN DDL for external tables.
+-- 2) Ensure that pg_dump --binary-upgrade correctly suppresses the ALTER
 -- TABLE DROP COLUMN DDL ouptut when a GPDB partition table with a
 -- dropped column reference on the root partition exists whereas the
 -- same dropped column reference does not exist on all of its child
@@ -8,7 +10,15 @@
 -- pg_upgrade's check_gp.c for more details on homogeneous and
 -- heterogeneous partitions.
 CREATE SCHEMA dump_this_schema;
--- Scenario 1: Create homogeneous partition table where the root
+-- 1) External tables with dropped columns is dumped correctly.
+CREATE EXTERNAL TABLE dump_this_schema.external_table_with_dropped_columns (
+    a int,
+    b int,
+    c int
+) LOCATION ('gpfdist://1.1.1.1:8082/xxxx.csv') FORMAT 'csv';
+ALTER EXTERNAL TABLE dump_this_schema.external_table_with_dropped_columns DROP COLUMN a;
+ALTER EXTERNAL TABLE dump_this_schema.external_table_with_dropped_columns DROP COLUMN b;
+-- 2) Scenario 1: Create homogeneous partition table where the root
 -- partition and ALL of its child partitions have the dropped column
 -- reference.
 CREATE TABLE dump_this_schema.dropped_column_homogeneous_partition_table (
@@ -41,7 +51,7 @@ WHERE a.attisdropped = true AND relname LIKE 'dropped_column_homogeneous_partiti
  dropped_column_homogeneous_partition_table          | ........pg.dropped.3........
 (3 rows)
 
--- Scenario 2: Create homogeneous partition table where only the root
+-- 2) Scenario 2: Create homogeneous partition table where only the root
 -- partition has the dropped column reference (as defined by
 -- pg_upgrade heterogeneous partition check function).
 CREATE TABLE dump_this_schema.dropped_column_special_homogeneous_partition_table (
@@ -75,7 +85,7 @@ WHERE a.attisdropped = true AND relname LIKE 'dropped_column_special_homogeneous
  dropped_column_special_homogeneous_partition_table | ........pg.dropped.3........
 (1 row)
 
--- Scenario 3: Create homogeneous partition table where only the root
+-- 2) Scenario 3: Create homogeneous partition table where only the root
 -- and subroot partition has the dropped column reference (as defined
 -- by pg_upgrade heterogeneous partition check function).
 CREATE TABLE dump_this_schema.dropped_column_special_homogeneous_partition_with_subpart (
@@ -121,7 +131,8 @@ WHERE a.attisdropped = true AND relname LIKE 'dropped_column_special_homogeneous
 \! pg_dump --binary-upgrade --schema dump_this_schema regression | grep " DROP COLUMN "
 ALTER TABLE dump_this_schema.dropped_column_homogeneous_partition_table DROP COLUMN "........pg.dropped.3........";
 DROP SCHEMA dump_this_schema CASCADE;
-NOTICE:  drop cascades to 3 other objects
-DETAIL:  drop cascades to table dump_this_schema.dropped_column_homogeneous_partition_table
+NOTICE:  drop cascades to 4 other objects
+DETAIL:  drop cascades to external table dump_this_schema.external_table_with_dropped_columns
+drop cascades to table dump_this_schema.dropped_column_homogeneous_partition_table
 drop cascades to table dump_this_schema.dropped_column_special_homogeneous_partition_table
 drop cascades to table dump_this_schema.dropped_column_special_homogeneous_partition_with_subpart


### PR DESCRIPTION
External tables with dropped columns failed to upgrade with:
```
pg_restore: creating EXTERNAL TABLE ext_upgrade_failure_test
pg_restore: [archiver (db)] Error while PROCESSING TOC:
pg_restore: [archiver (db)] Error from TOC entry 237; 1259 18142 EXTERNAL TABLE ext_upgrade_failure_test gpadmin
pg_restore: [archiver (db)] could not execute query: ERROR:  syntax error at or near ","
LINE 14:     "........pg.dropped.1........" ,
                                            ^
```

Fix pg_dump to output the ALTER TABLE DROP COLUMN DDL for external tables with dropped columns.

7X PR: https://github.com/greenplum-db/gpdb/pull/14355
Pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/pgDumpExternalTables_6X_dev