### PR TITLE
aoco: Refactor DML state machinery

### DIFF
--- a/src/backend/access/aocs/aocsam_handler.c
+++ b/src/backend/access/aocs/aocsam_handler.c
@@ -80,6 +80,9 @@ typedef struct AOCSBitmapScanData
 	int	rs_cindex;	/* current tuple's index tbmres->offset or -1 */
 } *AOCSBitmapScan;
 
+/*
+ * Per-relation backend-local DML state for DML or DML-like operations.
+ */
 typedef struct AOCODMLState
 {
 	Oid relationOid;
@@ -89,17 +92,10 @@ typedef struct AOCODMLState
 } AOCODMLState;
 
 static void reset_state_cb(void *arg);
+
 /*
- * GPDB_12_MERGE_FIXME: This is a temporary state of things. A locally stored
- * state is needed currently because there is no viable place to store this
- * information outside of the table access method. Ideally the caller should be
- * responsible for initializing a state and passing it over using the table
- * access method api.
- *
- * Until this is in place, the local state is not to be accessed directly but
- * only via the *_dml_state functions.
- * It contains:
- *		a quick look up member for the common case
+ * A repository for per-relation backend-local DML states. Contains:
+ *		a quick look up member for the common case (only 1 relation)
  *		a hash table which keeps per relation information
  *		a memory context that should be long lived enough and is
  *			responsible for reseting the state via its reset cb

--- a/src/backend/access/aocs/aocsam_handler.c
+++ b/src/backend/access/aocs/aocsam_handler.c
@@ -246,7 +246,8 @@ remove_dml_state(const Oid relationOid)
 }
 
 /*
- * This function should be called exactly once per relation.
+ * Provides an opportunity to create backend-local state to be consulted during
+ * the course of the current DML or DML-like command, for the given relation.
  */
 void
 aoco_dml_init(Relation relation)
@@ -256,7 +257,8 @@ aoco_dml_init(Relation relation)
 }
 
 /*
- * This function should be called exactly once per relation.
+ * Provides an opportunity to clean up backend-local state set up for the
+ * current DML or DML-like command, for the given relation.
  */
 void
 aoco_dml_finish(Relation relation)
@@ -2063,6 +2065,9 @@ static const TableAmRoutine ao_column_methods = {
 	.index_fetch_end = aoco_index_fetch_end,
 	.index_fetch_tuple = aoco_index_fetch_tuple,
 	.index_fetch_tuple_exists = aoco_index_fetch_tuple_exists,
+
+	.dml_init = aoco_dml_init,
+	.dml_finish = aoco_dml_finish,
 
 	.tuple_insert = aoco_tuple_insert,
 	.tuple_insert_speculative = aoco_tuple_insert_speculative,

--- a/src/backend/access/aocs/aocsam_handler.c
+++ b/src/backend/access/aocs/aocsam_handler.c
@@ -247,13 +247,10 @@ remove_dml_state(const Oid relationOid)
 }
 
 /*
- * Although the operation param is superfluous at the momment, the signature of
- * the function is such for balance between the init and finish.
- *
  * This function should be called exactly once per relation.
  */
 void
-aoco_dml_init(Relation relation, CmdType operation)
+aoco_dml_init(Relation relation)
 {
 	init_dml_local_state();
 	(void) enter_dml_state(RelationGetRelid(relation));
@@ -263,7 +260,7 @@ aoco_dml_init(Relation relation, CmdType operation)
  * This function should be called exactly once per relation.
  */
 void
-aoco_dml_finish(Relation relation, CmdType operation)
+aoco_dml_finish(Relation relation)
 {
 	AOCODMLState *state;
 
@@ -981,7 +978,7 @@ aoco_tuple_lock(Relation relation, ItemPointer tid, Snapshot snapshot,
 static void
 aoco_finish_bulk_insert(Relation relation, int options)
 {
-	aoco_dml_finish(relation, CMD_INSERT);
+	aoco_dml_finish(relation);
 }
 
 

--- a/src/backend/access/appendonly/appendonlyam_handler.c
+++ b/src/backend/access/appendonly/appendonlyam_handler.c
@@ -48,6 +48,9 @@ static void reset_state_cb(void *arg);
 
 static const TableAmRoutine ao_row_methods;
 
+/*
+ * Per-relation backend-local DML state for DML or DML-like operations.
+ */
 typedef struct AppendOnlyDMLState
 {
 	Oid relationOid;
@@ -58,16 +61,8 @@ typedef struct AppendOnlyDMLState
 
 
 /*
- * GPDB_12_MERGE_FIXME: This is a temporary state of things. A locally stored
- * state is needed currently because there is no viable place to store this
- * information outside of the table access method. Ideally the caller should be
- * responsible for initializing a state and passing it over using the table
- * access method api.
- *
- * Until this is in place, the local state is not to be accessed directly but
- * only via the *_dml_state functions.
- * It contains:
- *		a quick look up member for the common case
+ * A repository for per-relation backend-local DML states. Contains:
+ *		a quick look up member for the common case (only 1 relation)
  *		a hash table which keeps per relation information
  *		a memory context that should be long lived enough and is
  *			responsible for reseting the state via its reset cb

--- a/src/backend/access/appendonly/appendonlyam_handler.c
+++ b/src/backend/access/appendonly/appendonlyam_handler.c
@@ -203,17 +203,24 @@ remove_dml_state(const Oid relationOid)
 }
 
 /*
- * This function should be called exactly once per relation.
+ * Provides an opportunity to create backend-local state to be consulted during
+ * the course of the current DML or DML-like command, for the given relation.
  */
 void
 appendonly_dml_init(Relation relation)
 {
+	/*
+	 * Initialize the repository of per-relation states, if not done already for
+	 * the current DML or DML-like command.
+	 */
 	init_appendonly_dml_states();
+	/* initialize the per-relation state */
 	init_dml_state(RelationGetRelid(relation));
 }
 
 /*
- * This function should be called exactly once per relation.
+ * Provides an opportunity to clean up backend-local state set up for the
+ * current DML or DML-like command, for the given relation.
  */
 void
 appendonly_dml_finish(Relation relation)
@@ -2067,6 +2074,9 @@ static const TableAmRoutine ao_row_methods = {
 	.index_fetch_end = appendonly_index_fetch_end,
 	.index_fetch_tuple = appendonly_index_fetch_tuple,
 	.index_fetch_tuple_exists = appendonly_index_fetch_tuple_exists,
+
+	.dml_init = appendonly_dml_init,
+	.dml_finish = appendonly_dml_finish,
 
 	.tuple_insert = appendonly_tuple_insert,
 	.tuple_insert_speculative = appendonly_tuple_insert_speculative,

--- a/src/backend/access/appendonly/appendonlyam_handler.c
+++ b/src/backend/access/appendonly/appendonlyam_handler.c
@@ -215,13 +215,10 @@ remove_dml_state(const Oid relationOid)
 }
 
 /*
- * Although the operation param is superfluous at the momment, the signature of
- * the function is such for balance between the init and finish.
- *
  * This function should be called exactly once per relation.
  */
 void
-appendonly_dml_init(Relation relation, CmdType operation)
+appendonly_dml_init(Relation relation)
 {
 	init_dml_local_state();
 	(void) enter_dml_state(RelationGetRelid(relation));
@@ -231,7 +228,7 @@ appendonly_dml_init(Relation relation, CmdType operation)
  * This function should be called exactly once per relation.
  */
 void
-appendonly_dml_finish(Relation relation, CmdType operation)
+appendonly_dml_finish(Relation relation)
 {
 	AppendOnlyDMLState *state;
 
@@ -854,7 +851,7 @@ appendonly_tuple_lock(Relation relation, ItemPointer tid, Snapshot snapshot,
 static void
 appendonly_finish_bulk_insert(Relation relation, int options)
 {
-	appendonly_dml_finish(relation, CMD_INSERT);
+	appendonly_dml_finish(relation);
 }
 
 

--- a/src/backend/access/heap/heapam_handler.c
+++ b/src/backend/access/heap/heapam_handler.c
@@ -237,6 +237,21 @@ heapam_tuple_satisfies_snapshot(Relation rel, TupleTableSlot *slot,
 	return res;
 }
 
+/*
+ * ------------------------------------------------------------------------
+ * GPDB: DML state manipulation functions (not implemented by heap AM)
+ * ------------------------------------------------------------------------
+ */
+
+static inline void
+heap_dml_init(Relation relation)
+{
+}
+
+static inline void
+heap_dml_finish(Relation relation)
+{
+}
 
 /* ----------------------------------------------------------------------------
  *  Functions for manipulations of physical tuples for heap AM.
@@ -2631,6 +2646,9 @@ static const TableAmRoutine heapam_methods = {
 	.parallelscan_estimate = table_block_parallelscan_estimate,
 	.parallelscan_initialize = table_block_parallelscan_initialize,
 	.parallelscan_reinitialize = table_block_parallelscan_reinitialize,
+
+	.dml_init = heap_dml_init,
+	.dml_finish = heap_dml_finish,
 
 	.index_fetch_begin = heapam_index_fetch_begin,
 	.index_fetch_reset = heapam_index_fetch_reset,

--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -4220,9 +4220,9 @@ CopyFrom(CopyState cstate)
 	 * provide a good enough interface for this yet.
 	 */
 	if (RelationIsAoRows(resultRelInfo->ri_RelationDesc))
-		appendonly_dml_init(resultRelInfo->ri_RelationDesc, CMD_INSERT);
+		appendonly_dml_init(resultRelInfo->ri_RelationDesc);
 	else if (RelationIsAoCols(resultRelInfo->ri_RelationDesc))
-		aoco_dml_init(resultRelInfo->ri_RelationDesc, CMD_INSERT);
+		aoco_dml_init(resultRelInfo->ri_RelationDesc);
 
 	for (;;)
 	{

--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -4213,16 +4213,8 @@ CopyFrom(CopyState cstate)
 
 	CopyInitDataParser(cstate);
 
-	/*
-	 * GPDB_12_MERGE_FIXME: We still have to perform the initialization
-	 * here for AO relations. It is preferreable by all means to perform the
-	 * initialization via the table AP API, however it simply does not
-	 * provide a good enough interface for this yet.
-	 */
-	if (RelationIsAoRows(resultRelInfo->ri_RelationDesc))
-		appendonly_dml_init(resultRelInfo->ri_RelationDesc);
-	else if (RelationIsAoCols(resultRelInfo->ri_RelationDesc))
-		aoco_dml_init(resultRelInfo->ri_RelationDesc);
+	if (resultRelInfo->ri_RelationDesc->rd_tableam)
+		table_dml_init(resultRelInfo->ri_RelationDesc);
 
 	for (;;)
 	{

--- a/src/backend/commands/createas.c
+++ b/src/backend/commands/createas.c
@@ -558,9 +558,9 @@ intorel_startup_dummy(DestReceiver *self, int operation, TupleDesc typeinfo)
 	/* See intorel_initplan() for explanation */
 
 	if (RelationIsAoRows(((DR_intorel *)self)->rel))
-		appendonly_dml_init(((DR_intorel *)self)->rel, CMD_INSERT);
+		appendonly_dml_init(((DR_intorel *)self)->rel);
 	else if (RelationIsAoCols(((DR_intorel *)self)->rel))
-		aoco_dml_init(((DR_intorel *)self)->rel, CMD_INSERT);
+		aoco_dml_init(((DR_intorel *)self)->rel);
 }
 
 /*

--- a/src/backend/commands/createas.c
+++ b/src/backend/commands/createas.c
@@ -548,19 +548,10 @@ CreateIntoRelDestReceiver(IntoClause *intoClause)
 static void
 intorel_startup_dummy(DestReceiver *self, int operation, TupleDesc typeinfo)
 {
-	/*
-	 * In PostgreSQL, this is a no-op, but in GPDB, AO relations do need some
-	 * initialization of state, because the tableam API does not provide a
-	 * good enough interface for handling with this later, we need to
-	 * specifically all the init at start up.
-	 */
-
+	Relation rel = ((DR_intorel *)self)->rel;
 	/* See intorel_initplan() for explanation */
-
-	if (RelationIsAoRows(((DR_intorel *)self)->rel))
-		appendonly_dml_init(((DR_intorel *)self)->rel);
-	else if (RelationIsAoCols(((DR_intorel *)self)->rel))
-		aoco_dml_init(((DR_intorel *)self)->rel);
+	if (rel->rd_tableam)
+		table_dml_init(rel);
 }
 
 /*

--- a/src/backend/commands/matview.c
+++ b/src/backend/commands/matview.c
@@ -613,10 +613,8 @@ transientrel_startup(DestReceiver *self, int operation, TupleDesc typeinfo)
 	myState->bistate = GetBulkInsertState();
 	myState->processed = 0;
 
-	if (RelationIsAoRows(myState->transientrel))
-		appendonly_dml_init(myState->transientrel);
-	else if (RelationIsAoCols(myState->transientrel))
-		aoco_dml_init(myState->transientrel);
+	if (myState->transientrel->rd_tableam)
+		table_dml_init(myState->transientrel);
 
 	/* Not using WAL requires smgr_targblock be initially invalid */
 	Assert(RelationGetTargetBlock(transientrel) == InvalidBlockNumber);

--- a/src/backend/commands/matview.c
+++ b/src/backend/commands/matview.c
@@ -614,9 +614,9 @@ transientrel_startup(DestReceiver *self, int operation, TupleDesc typeinfo)
 	myState->processed = 0;
 
 	if (RelationIsAoRows(myState->transientrel))
-		appendonly_dml_init(myState->transientrel, CMD_INSERT);
+		appendonly_dml_init(myState->transientrel);
 	else if (RelationIsAoCols(myState->transientrel))
-		aoco_dml_init(myState->transientrel, CMD_INSERT);
+		aoco_dml_init(myState->transientrel);
 
 	/* Not using WAL requires smgr_targblock be initially invalid */
 	Assert(RelationGetTargetBlock(transientrel) == InvalidBlockNumber);

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -6445,10 +6445,8 @@ ATRewriteTable(AlteredTableInfo *tab, Oid OIDNewHeap, LOCKMODE lockmode)
 		snapshot = RegisterSnapshot(GetLatestSnapshot());
 		scan = table_beginscan(oldrel, snapshot, 0, NULL);
 
-		if (newrel && RelationIsAoRows(newrel))
-			appendonly_dml_init(newrel);
-		else if (newrel && RelationIsAoCols(newrel))
-			aoco_dml_init(newrel);
+		if (newrel && newrel->rd_tableam)
+			table_dml_init(newrel);
 
 		/*
 		 * Switch to per-tuple memory context and reset it for each tuple

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -6446,9 +6446,9 @@ ATRewriteTable(AlteredTableInfo *tab, Oid OIDNewHeap, LOCKMODE lockmode)
 		scan = table_beginscan(oldrel, snapshot, 0, NULL);
 
 		if (newrel && RelationIsAoRows(newrel))
-			appendonly_dml_init(newrel, CMD_INSERT);
+			appendonly_dml_init(newrel);
 		else if (newrel && RelationIsAoCols(newrel))
-			aoco_dml_init(newrel, CMD_INSERT);
+			aoco_dml_init(newrel);
 
 		/*
 		 * Switch to per-tuple memory context and reset it for each tuple

--- a/src/backend/executor/execPartition.c
+++ b/src/backend/executor/execPartition.c
@@ -879,9 +879,9 @@ ExecInitPartitionInfo(ModifyTableState *mtstate, EState *estate,
 				leaf_part_rri);
 
 	if (RelationIsAoRows(leaf_part_rri->ri_RelationDesc))
-		appendonly_dml_init(leaf_part_rri->ri_RelationDesc, mtstate->operation);
+		appendonly_dml_init(leaf_part_rri->ri_RelationDesc);
 	else if (RelationIsAoCols(leaf_part_rri->ri_RelationDesc))
-		aoco_dml_init(leaf_part_rri->ri_RelationDesc, mtstate->operation);
+		aoco_dml_init(leaf_part_rri->ri_RelationDesc);
 
 	MemoryContextSwitchTo(oldcxt);
 
@@ -1170,9 +1170,9 @@ ExecCleanupTupleRouting(ModifyTableState *mtstate,
 		 * appendoptimized table, ensure the DML operation is finished.
 		 */
 		if (RelationIsAoRows(resultRelInfo->ri_RelationDesc))
-			appendonly_dml_finish(resultRelInfo->ri_RelationDesc, mtstate->operation);
+			appendonly_dml_finish(resultRelInfo->ri_RelationDesc);
 		if (RelationIsAoCols(resultRelInfo->ri_RelationDesc))
-			aoco_dml_finish(resultRelInfo->ri_RelationDesc, mtstate->operation);
+			aoco_dml_finish(resultRelInfo->ri_RelationDesc);
 
 		ExecCloseIndices(resultRelInfo);
 		table_close(resultRelInfo->ri_RelationDesc, NoLock);

--- a/src/backend/executor/execPartition.c
+++ b/src/backend/executor/execPartition.c
@@ -878,10 +878,8 @@ ExecInitPartitionInfo(ModifyTableState *mtstate, EState *estate,
 		lappend(estate->es_tuple_routing_result_relations,
 				leaf_part_rri);
 
-	if (RelationIsAoRows(leaf_part_rri->ri_RelationDesc))
-		appendonly_dml_init(leaf_part_rri->ri_RelationDesc);
-	else if (RelationIsAoCols(leaf_part_rri->ri_RelationDesc))
-		aoco_dml_init(leaf_part_rri->ri_RelationDesc);
+	if (leaf_part_rri->ri_RelationDesc->rd_tableam)
+		table_dml_init(leaf_part_rri->ri_RelationDesc);
 
 	MemoryContextSwitchTo(oldcxt);
 
@@ -1165,14 +1163,8 @@ ExecCleanupTupleRouting(ModifyTableState *mtstate,
 				continue;
 		}
 
-		/*
-		 * Only leaf node can have a valid access method.  If we find an
-		 * appendoptimized table, ensure the DML operation is finished.
-		 */
-		if (RelationIsAoRows(resultRelInfo->ri_RelationDesc))
-			appendonly_dml_finish(resultRelInfo->ri_RelationDesc);
-		if (RelationIsAoCols(resultRelInfo->ri_RelationDesc))
-			aoco_dml_finish(resultRelInfo->ri_RelationDesc);
+		if (resultRelInfo->ri_RelationDesc->rd_tableam)
+			table_dml_finish(resultRelInfo->ri_RelationDesc);
 
 		ExecCloseIndices(resultRelInfo);
 		table_close(resultRelInfo->ri_RelationDesc, NoLock);

--- a/src/backend/executor/nodeModifyTable.c
+++ b/src/backend/executor/nodeModifyTable.c
@@ -2750,9 +2750,9 @@ ExecInitModifyTable(ModifyTable *node, EState *estate, int eflags)
 								   table_slot_callbacks(resultRelInfo->ri_RelationDesc));
 
 		if (RelationIsAoRows(resultRelInfo->ri_RelationDesc))
-			appendonly_dml_init(resultRelInfo->ri_RelationDesc, operation);
+			appendonly_dml_init(resultRelInfo->ri_RelationDesc);
 		else if (RelationIsAoCols(resultRelInfo->ri_RelationDesc))
-			aoco_dml_init(resultRelInfo->ri_RelationDesc, operation);
+			aoco_dml_init(resultRelInfo->ri_RelationDesc);
 
 		/* Also let FDWs init themselves for foreign-table result rels */
 		if (!resultRelInfo->ri_usesFdwDirectModify &&
@@ -3203,10 +3203,9 @@ ExecEndModifyTable(ModifyTableState *node)
 			resultRelInfo->ri_FdwRoutine->EndForeignModify(node->ps.state,
 														   resultRelInfo);
 		if (RelationIsAoRows(resultRelInfo->ri_RelationDesc))
-			appendonly_dml_finish(resultRelInfo->ri_RelationDesc,
-								  node->operation);
+			appendonly_dml_finish(resultRelInfo->ri_RelationDesc);
 		else if(RelationIsAoCols(resultRelInfo->ri_RelationDesc))
-			aoco_dml_finish(resultRelInfo->ri_RelationDesc, node->operation);
+			aoco_dml_finish(resultRelInfo->ri_RelationDesc);
 	}
 
 	/*

--- a/src/backend/executor/nodeModifyTable.c
+++ b/src/backend/executor/nodeModifyTable.c
@@ -2749,10 +2749,8 @@ ExecInitModifyTable(ModifyTable *node, EState *estate, int eflags)
 			ExecInitExtraTupleSlot(mtstate->ps.state, ExecGetResultType(mtstate->mt_plans[i]),
 								   table_slot_callbacks(resultRelInfo->ri_RelationDesc));
 
-		if (RelationIsAoRows(resultRelInfo->ri_RelationDesc))
-			appendonly_dml_init(resultRelInfo->ri_RelationDesc);
-		else if (RelationIsAoCols(resultRelInfo->ri_RelationDesc))
-			aoco_dml_init(resultRelInfo->ri_RelationDesc);
+		if (resultRelInfo->ri_RelationDesc->rd_tableam)
+			table_dml_init(resultRelInfo->ri_RelationDesc);
 
 		/* Also let FDWs init themselves for foreign-table result rels */
 		if (!resultRelInfo->ri_usesFdwDirectModify &&
@@ -3202,10 +3200,8 @@ ExecEndModifyTable(ModifyTableState *node)
 			resultRelInfo->ri_FdwRoutine->EndForeignModify != NULL)
 			resultRelInfo->ri_FdwRoutine->EndForeignModify(node->ps.state,
 														   resultRelInfo);
-		if (RelationIsAoRows(resultRelInfo->ri_RelationDesc))
-			appendonly_dml_finish(resultRelInfo->ri_RelationDesc);
-		else if(RelationIsAoCols(resultRelInfo->ri_RelationDesc))
-			aoco_dml_finish(resultRelInfo->ri_RelationDesc);
+		if (resultRelInfo->ri_RelationDesc->rd_tableam)
+			table_dml_finish(resultRelInfo->ri_RelationDesc);
 	}
 
 	/*

--- a/src/include/access/tableam.h
+++ b/src/include/access/tableam.h
@@ -372,6 +372,15 @@ typedef struct TableAmRoutine
 													 int nitems);
 
 
+	/*
+	 * ------------------------------------------------------------------------
+	 * GPDB: DML state manipulation functions
+	 * ------------------------------------------------------------------------
+	 */
+	void		(*dml_init) (Relation rel);
+
+	void		(*dml_finish) (Relation rel);
+
 	/* ------------------------------------------------------------------------
 	 * Manipulations of physical tuples.
 	 * ------------------------------------------------------------------------
@@ -1163,6 +1172,36 @@ table_compute_xid_horizon_for_tuples(Relation rel,
 	return rel->rd_tableam->compute_xid_horizon_for_tuples(rel, items, nitems);
 }
 
+/*
+ * ------------------------------------------------------------------------
+ * GPDB: DML state manipulation functions
+ * ------------------------------------------------------------------------
+ */
+
+/*
+ * Gives an opportunity to the table AM to create some state to be used across
+ * the lifecycle of a DML or DML-like command. It is called once for every
+ * relation involved in the command (there can be multiple relations when there
+ * are partitioned tables are involved). It is called at the beginning of the
+ * command's execution.
+ */
+static inline void
+table_dml_init(Relation rel)
+{
+	rel->rd_tableam->dml_init(rel);
+}
+
+/*
+ * Gives an opportunity to the table AM to clean up any state allocated by
+ * table_dml_init(). It is called once for every relation involved in a DML
+ * or DML-like command (there can be multiple relations when there are partitioned
+ * tables are involved). It is called at the end of the command's execution.
+ */
+static inline void
+table_dml_finish(Relation rel)
+{
+	rel->rd_tableam->dml_finish(rel);
+}
 
 /* ----------------------------------------------------------------------------
  *  Functions for manipulations of physical tuples.

--- a/src/include/cdb/cdbaocsam.h
+++ b/src/include/cdb/cdbaocsam.h
@@ -351,7 +351,7 @@ extern void aocs_addcol_emptyvpe(
 extern void aocs_addcol_setfirstrownum(AOCSAddColumnDesc desc,
 		int64 firstRowNum);
 
-extern void aoco_dml_init(Relation relation, CmdType operation);
-extern void aoco_dml_finish(Relation relation, CmdType operation);
+extern void aoco_dml_init(Relation relation);
+extern void aoco_dml_finish(Relation relation);
 
 #endif   /* AOCSAM_H */

--- a/src/include/cdb/cdbappendonlyam.h
+++ b/src/include/cdb/cdbappendonlyam.h
@@ -395,7 +395,7 @@ extern bool appendonly_fetch(
 	AOTupleId *aoTid,
 	TupleTableSlot *slot);
 extern void appendonly_fetch_finish(AppendOnlyFetchDesc aoFetchDesc);
-extern void appendonly_dml_init(Relation relation, CmdType operation);
+extern void appendonly_dml_init(Relation relation);
 extern AppendOnlyInsertDesc appendonly_insert_init(Relation rel,
 												   int segno,
 												   int64 num_rows);
@@ -404,7 +404,7 @@ extern void appendonly_insert(
 		MemTuple instup, 
 		AOTupleId *aoTupleId);
 extern void appendonly_insert_finish(AppendOnlyInsertDesc aoInsertDesc);
-extern void appendonly_dml_finish(Relation relation, CmdType operation);
+extern void appendonly_dml_finish(Relation relation);
 
 extern AppendOnlyDeleteDesc appendonly_delete_init(Relation rel);
 extern TM_Result appendonly_delete(


### PR DESCRIPTION
This PR does minor refactors to the DML state machinery, and lifts core FIXMEs surrounding this area, in addition to formally adding tableAM support for DML state initialization/teardown.

Please review commits individually.