### PR TITLE
[6X] Commits to fix some bgworker issues on gpdb6

### DIFF
--- a/src/backend/postmaster/bgworker.c
+++ b/src/backend/postmaster/bgworker.c
@@ -344,7 +344,7 @@ BackgroundWorkerStateChange(void)
 		rw->rw_terminate = false;
 
 		/* Log it! */
-		ereport(LOG,
+		ereport(DEBUG1,
 				(errmsg("registering background worker \"%s\"",
 						rw->rw_worker.bgw_name)));
 
@@ -373,7 +373,7 @@ ForgetBackgroundWorker(slist_mutable_iter *cur)
 	slot = &BackgroundWorkerData->slot[rw->rw_shmem_slot];
 	slot->in_use = false;
 
-	ereport(LOG,
+	ereport(DEBUG1,
 			(errmsg("unregistering background worker \"%s\"",
 					rw->rw_worker.bgw_name)));
 
@@ -770,7 +770,7 @@ RegisterBackgroundWorker(BackgroundWorker *worker)
 	static int	numworkers = 0;
 
 	if (!IsUnderPostmaster)
-		ereport(LOG,
+		ereport(DEBUG1,
 		 (errmsg("registering background worker \"%s\"", worker->bgw_name)));
 
 	auxworker = isAuxiliaryBgWorker(worker);

--- a/src/backend/postmaster/bgworker.c
+++ b/src/backend/postmaster/bgworker.c
@@ -410,12 +410,14 @@ ReportBackgroundWorkerExit(slist_mutable_iter *cur)
 {
 	RegisteredBgWorker *rw;
 	BackgroundWorkerSlot *slot;
+	int		notify_pid;
 
 	rw = slist_container(RegisteredBgWorker, rw_lnode, cur->cur);
 
 	Assert(rw->rw_shmem_slot < max_worker_processes);
 	slot = &BackgroundWorkerData->slot[rw->rw_shmem_slot];
 	slot->pid = rw->rw_pid;
+	notify_pid = rw->rw_worker.bgw_notify_pid;
 
 	/*
 	 * If this worker is slated for deregistration, do that before notifying
@@ -428,8 +430,8 @@ ReportBackgroundWorkerExit(slist_mutable_iter *cur)
 		rw->rw_worker.bgw_restart_time == BGW_NEVER_RESTART)
 		ForgetBackgroundWorker(cur);
 
-	if (rw->rw_worker.bgw_notify_pid != 0)
-		kill(rw->rw_worker.bgw_notify_pid, SIGUSR1);
+	if (notify_pid != 0)
+		kill(notify_pid, SIGUSR1);
 }
 
 /*

--- a/src/backend/postmaster/bgworker.c
+++ b/src/backend/postmaster/bgworker.c
@@ -400,6 +400,39 @@ ReportBackgroundWorkerPID(RegisteredBgWorker *rw)
 }
 
 /*
+ * Report that the PID of a background worker is now zero because a
+ * previously-running background worker has exited.
+ *
+ * This function should only be called from the postmaster.
+ */
+void
+ReportBackgroundWorkerExit(slist_mutable_iter *cur)
+{
+	RegisteredBgWorker *rw;
+	BackgroundWorkerSlot *slot;
+
+	rw = slist_container(RegisteredBgWorker, rw_lnode, cur->cur);
+
+	Assert(rw->rw_shmem_slot < max_worker_processes);
+	slot = &BackgroundWorkerData->slot[rw->rw_shmem_slot];
+	slot->pid = rw->rw_pid;
+
+	/*
+	 * If this worker is slated for deregistration, do that before notifying
+	 * the process which started it.  Otherwise, if that process tries to
+	 * reuse the slot immediately, it might not be available yet.  In theory
+	 * that could happen anyway if the process checks slot->pid at just the
+	 * wrong moment, but this makes the window narrower.
+	 */
+	if (rw->rw_terminate ||
+		rw->rw_worker.bgw_restart_time == BGW_NEVER_RESTART)
+		ForgetBackgroundWorker(cur);
+
+	if (rw->rw_worker.bgw_notify_pid != 0)
+		kill(rw->rw_worker.bgw_notify_pid, SIGUSR1);
+}
+
+/*
  * Cancel SIGUSR1 notifications for a PID belonging to an exiting backend.
  *
  * This function should only be called from the postmaster.

--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -3606,7 +3606,8 @@ CleanupBackgroundWorker(int pid,
 		rw->rw_child_slot = 0;
 		ReportBackgroundWorkerPID(rw);	/* report child death */
 
-		LogChildExit(LOG, namebuf, pid, exitstatus);
+		LogChildExit(EXIT_STATUS_0(exitstatus) ? DEBUG1 : LOG,
+							    namebuf, pid, exitstatus);
 
 		return true;
 	}
@@ -6144,7 +6145,7 @@ do_start_bgworker(RegisteredBgWorker *rw)
 	else
 		rw->rw_child_slot = MyPMChildSlot = AssignPostmasterChildSlot();
 
-	ereport(LOG,
+	ereport(DEBUG1,
 			(errmsg("starting background worker process \"%s\"",
 					rw->rw_worker.bgw_name)));
 

--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -3524,9 +3524,9 @@ CleanupBackgroundWorker(int pid,
 						int exitstatus) /* child's exit status */
 {
 	char		namebuf[MAXPGPATH];
-	slist_iter	iter;
+	slist_mutable_iter	iter;
 
-	slist_foreach(iter, &BackgroundWorkerList)
+	slist_foreach_modify(iter, &BackgroundWorkerList)
 	{
 		RegisteredBgWorker *rw;
 
@@ -3604,7 +3604,7 @@ CleanupBackgroundWorker(int pid,
 		}
 		rw->rw_pid = 0;
 		rw->rw_child_slot = 0;
-		ReportBackgroundWorkerPID(rw);	/* report child death */
+		ReportBackgroundWorkerExit(&iter);	/* report child death */
 
 		LogChildExit(EXIT_STATUS_0(exitstatus) ? DEBUG1 : LOG,
 							    namebuf, pid, exitstatus);

--- a/src/include/postmaster/bgworker_internals.h
+++ b/src/include/postmaster/bgworker_internals.h
@@ -42,6 +42,7 @@ extern void BackgroundWorkerShmemInit(void);
 extern void BackgroundWorkerStateChange(void);
 extern void ForgetBackgroundWorker(slist_mutable_iter *cur);
 extern void ReportBackgroundWorkerPID(RegisteredBgWorker *);
+extern void ReportBackgroundWorkerExit(slist_mutable_iter *cur);
 extern void BackgroundWorkerStopNotifications(pid_t pid);
 extern void ResetBackgroundWorkerCrashTimes(void);
 


### PR DESCRIPTION
Hi，
As diskquota uses dynamic bgworkers to monitor databases in the latest version (2.1), we have encountered some problems with it and found that those are all resolved on gpdb7, so we want to cherry-pick them into gpdb6.

There are total 3 commits in this pr: 
91118f1a59f2038f072552fdbb98e01363e30b59  this commit reduces log level for background worker events from LOG to DEBUG1,  as LOG is just too chatty for something that will happen as routinely as this.

aea5d298362e881b13d95a48c5ae116879237389 and 7f6fa29f18aa84743185ee7ada97f277459228a7, those 2 commits, fix failures of trying to launch new bgworkers before the worker slots used by the previous ones were freed. More details are in the commit message.


