### PR TITLE
[6X] vacuum_appendonly_index: Fix IndexVacuumInfo initialization

### DIFF
--- a/src/test/regress/expected/uao_compaction/index_stats.out
+++ b/src/test/regress/expected/uao_compaction/index_stats.out
@@ -35,3 +35,23 @@ SELECT relname, reltuples FROM pg_class WHERE relname = 'mytab_int_idx1';
  mytab_int_idx1 |         2
 (1 row)
 
+-- A test of index stat for access methods that rely on table tuple count (bitmap, gin)
+truncate mytab;
+create index mytab_int_idx2 on mytab using bitmap(col_int);
+insert into mytab values(1,'aa',1001,101),(2,'bb',1002,102);
+SELECT relname, reltuples FROM pg_class WHERE relname = 'mytab_int_idx2';
+    relname     | reltuples 
+----------------+-----------
+ mytab_int_idx2 |         2
+(1 row)
+
+-- first vacuum collect table stat on segments
+vacuum mytab;
+-- second vacuum update index stat with table stat
+vacuum mytab;
+SELECT relname, reltuples FROM pg_class WHERE relname = 'mytab_int_idx2';
+    relname     | reltuples 
+----------------+-----------
+ mytab_int_idx2 |         2
+(1 row)
+

--- a/src/test/regress/expected/uaocs_compaction/index_stats.out
+++ b/src/test/regress/expected/uaocs_compaction/index_stats.out
@@ -40,3 +40,23 @@ SELECT relname, reltuples FROM pg_class WHERE relname = 'uaocs_index_stats_int_i
  uaocs_index_stats_int_idx1 |         2
 (1 row)
 
+-- A test of index stat for access methods that rely on table tuple count (bitmap, gin)
+truncate uaocs_index_stats;
+create index uaocs_index_stats_int_idx2 on uaocs_index_stats using bitmap(col_int);
+insert into uaocs_index_stats values(1,'aa',1001,101),(2,'bb',1002,102);
+SELECT relname, reltuples FROM pg_class WHERE relname = 'uaocs_index_stats_int_idx2';
+          relname           | reltuples 
+----------------------------+-----------
+ uaocs_index_stats_int_idx2 |         2
+(1 row)
+
+-- first vacuum collect table stat on segments
+vacuum uaocs_index_stats;
+-- second vacuum update index stat with table stat
+vacuum uaocs_index_stats;
+SELECT relname, reltuples FROM pg_class WHERE relname = 'uaocs_index_stats_int_idx2';
+          relname           | reltuples 
+----------------------------+-----------
+ uaocs_index_stats_int_idx2 |         2
+(1 row)
+

--- a/src/test/regress/sql/uao_compaction/index_stats.sql
+++ b/src/test/regress/sql/uao_compaction/index_stats.sql
@@ -17,3 +17,18 @@ select * from mytab;
 vacuum mytab;
 SELECT relname, reltuples FROM pg_class WHERE relname = 'mytab';
 SELECT relname, reltuples FROM pg_class WHERE relname = 'mytab_int_idx1';
+
+-- A test of index stat for access methods that rely on table tuple count (bitmap, gin)
+truncate mytab;
+create index mytab_int_idx2 on mytab using bitmap(col_int);
+
+insert into mytab values(1,'aa',1001,101),(2,'bb',1002,102);
+
+SELECT relname, reltuples FROM pg_class WHERE relname = 'mytab_int_idx2';
+
+-- first vacuum collect table stat on segments
+vacuum mytab;
+-- second vacuum update index stat with table stat
+vacuum mytab;
+
+SELECT relname, reltuples FROM pg_class WHERE relname = 'mytab_int_idx2';

--- a/src/test/regress/sql/uaocs_compaction/index_stats.sql
+++ b/src/test/regress/sql/uaocs_compaction/index_stats.sql
@@ -17,3 +17,18 @@ select * from uaocs_index_stats;
 vacuum uaocs_index_stats;
 SELECT relname, reltuples FROM pg_class WHERE relname = 'uaocs_index_stats';
 SELECT relname, reltuples FROM pg_class WHERE relname = 'uaocs_index_stats_int_idx1';
+
+-- A test of index stat for access methods that rely on table tuple count (bitmap, gin)
+truncate uaocs_index_stats;
+create index uaocs_index_stats_int_idx2 on uaocs_index_stats using bitmap(col_int);
+
+insert into uaocs_index_stats values(1,'aa',1001,101),(2,'bb',1002,102);
+
+SELECT relname, reltuples FROM pg_class WHERE relname = 'uaocs_index_stats_int_idx2';
+
+-- first vacuum collect table stat on segments
+vacuum uaocs_index_stats;
+-- second vacuum update index stat with table stat
+vacuum uaocs_index_stats;
+
+SELECT relname, reltuples FROM pg_class WHERE relname = 'uaocs_index_stats_int_idx2';


### PR DESCRIPTION
This is backporting (https://github.com/greenplum-db/gpdb/pull/14260).
 
* IndexVacuumInfo.analyze_only was not initialized, leading to possible no-ops in index_vacuum_cleanup(), if the garbage value for it was non-zero.

* IndexVacuumInfo.num_heap_tuples should be set to the AO table's old reltuples value (value prior to kicking off vacuum). Please see IndexVacuumInfo and lazy_vacuum_index() for details. As explained in the code comments, num_heap_tuples will always be an estimate during ambulkdelete(). Since dedd407, we have been using the index rel's reltuples instead. This is wrong (eg in scenarios where the index has been created post data manipulation). So, correctly use the table's reltuples value to provide the estimate.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
