### PR TITLE
Support running GPDB dev pipelines in GP alternate CI environments.

### DIFF
--- a/concourse/pipelines/gen_pipeline.py
+++ b/concourse/pipelines/gen_pipeline.py
@@ -156,10 +156,7 @@ def create_pipeline(args, git_remote, git_branch):
     else:
         test_trigger = "false"
 
-    if args.pipeline_target == 'prod':
-        variables_type = "prod"
-    else:
-        variables_type = "dev"
+    variables_type = args.pipeline_target
 
     context = {
         'template_filename': args.template_filename,
@@ -262,9 +259,9 @@ def print_fly_commands(args, git_remote, git_branch):
                            "https://github.com/greenplum-db/gpdb.git", BASE_BRANCH))
         return
 
-    print('NOTE: You can set the developer pipeline with the following:\n')
-    print(gen_pipeline(args, pipeline_name, ["common_prod.yml", "common_dev.yml"], git_remote, git_branch))
-
+    else:
+        print('NOTE: You can set the developer pipeline with the following:\n')
+        print(gen_pipeline(args, pipeline_name, ["common_prod.yml", "common_" + args.pipeline_target + ".yml"], git_remote, git_branch))
 
 def main():
     """main: parse args and create pipeline"""

--- a/concourse/vars/common_cm.yml
+++ b/concourse/vars/common_cm.yml
@@ -1,5 +1,4 @@
 ---
-# usage: fly set-pipeline -p 6X_STABLE-dev -l common_dev.yml
 aws-bucket: gpdb5-assert-concourse-builds-dev
 google-project-id: data-gpdb-cm
 gcs-bucket: pivotal-gpdb-concourse-resources-dev

--- a/concourse/vars/common_cm.yml
+++ b/concourse/vars/common_cm.yml
@@ -1,0 +1,7 @@
+---
+# usage: fly set-pipeline -p 6X_STABLE-dev -l common_dev.yml
+aws-bucket: gpdb5-assert-concourse-builds-dev
+google-project-id: data-gpdb-cm
+gcs-bucket: pivotal-gpdb-concourse-resources-dev
+gcs-bucket-intermediates: pivotal-gpdb-concourse-resources-intermediates-dev
+gcs-bucket-coverage: pivotal-gpdb-cli-coverage-dev


### PR DESCRIPTION
Based on the pipeline target specified to gen_pipeline.py script:
* Enhance pipeline generation script to use CCP vault entries.
* Use GCP project-dependent CI vars file.
* The fly command output from gen_pipeline.py will be able to run unchanged. The exception is the need to specify the developer-specific GitHub repo and possibly the branch.

I have flown dev branches in dev and cm instances to validate the fix.