### PR TITLE
Fix plans for queries to replicated table with volatile function

### DIFF
--- a/src/backend/cdb/cdbllize.c
+++ b/src/backend/cdb/cdbllize.c
@@ -573,6 +573,14 @@ ParallelizeCorrelatedSubPlanMutator(Node *node, ParallelizeCorrelatedPlanWalkerC
 		if (ctx->movement == MOVEMENT_BROADCAST)
 		{
 			Assert (NULL != ctx->currentPlanFlow);
+
+			if (scanPlan->flow->locustype == CdbLocusType_SegmentGeneral &&
+				contain_volatile_functions((Node *) scanPlan->qual))
+			{
+				scanPlan->flow->locustype = CdbLocusType_SingleQE;
+				scanPlan->flow->flotype = FLOW_SINGLETON;
+			}
+
 			broadcastPlan(scanPlan, false /* stable */ , false /* rescannable */,
 						  ctx->currentPlanFlow->numsegments /* numsegments */);
 		}

--- a/src/backend/cdb/cdbllize.c
+++ b/src/backend/cdb/cdbllize.c
@@ -1131,13 +1131,11 @@ broadcastPlan(Plan *plan, bool stable, bool rescannable, int numsegments)
 
 	/*
 	 * Already focused and flow is CdbLocusType_SegmentGeneral and data
-	 * is replicated on every segment of target and no volatile functions in
-	 * target list, do nothing.
+	 * is replicated on every segment of target, do nothing.
 	 */
 	if (plan->flow->flotype == FLOW_SINGLETON &&
 		plan->flow->locustype == CdbLocusType_SegmentGeneral &&
-		plan->flow->numsegments >= numsegments &&
-		!contain_volatile_functions((Node *)plan->targetlist))
+		plan->flow->numsegments >= numsegments)
 		return true;
 
 	return adjustPlanFlow(plan, stable, rescannable, MOVEMENT_BROADCAST, NIL, NIL,

--- a/src/backend/cdb/cdbmutate.c
+++ b/src/backend/cdb/cdbmutate.c
@@ -845,7 +845,13 @@ apply_motion_mutator(Node *node, ApplyMotionState *context)
 	if (IsA(newnode, Motion) &&flow->req_move != MOVEMENT_NONE)
 	{
 		plan = ((Motion *) newnode)->plan.lefttree;
-		flow = plan->flow;
+
+		/* We'll recreate this motion later below. But we should save motion
+		 * request to create appropriate motion above the child node.
+		 * Original flow for the child node will be restored
+		 * after motion creation. */
+		flow->flow_before_req_move = plan->flow;
+		plan->flow = flow;
 		newnode = (Node *) plan;
 	}
 

--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -6684,12 +6684,15 @@ adjust_modifytable_flow(PlannerInfo *root, ModifyTable *node, List *is_split_upd
 				 * Obviously, tmp_tab in new segments can't get data if we don't
 				 * add a broadcast here. 
 				 */
-				if (optimizer_replicated_table_insert &&
-					subplan->flow->flotype == FLOW_SINGLETON &&
-					subplan->flow->locustype == CdbLocusType_SegmentGeneral &&
-					!contain_volatile_functions((Node *)subplan->targetlist))
+				if (subplan->flow->flotype == FLOW_SINGLETON &&
+					subplan->flow->locustype == CdbLocusType_SegmentGeneral)
 				{
-					if (subplan->flow->numsegments >= targetPolicy->numsegments)
+					if (contain_volatile_functions((Node *)subplan->targetlist))
+					{
+						subplan->flow->locustype = CdbLocusType_SingleQE;
+					}
+					else if (optimizer_replicated_table_insert &&
+							 subplan->flow->numsegments >= targetPolicy->numsegments)
 					{
 						/*
 						 * A query to reach here:

--- a/src/backend/optimizer/plan/subselect.c
+++ b/src/backend/optimizer/plan/subselect.c
@@ -41,8 +41,10 @@
 #include "utils/syscache.h"
 
 #include "cdb/cdbmutate.h"
+#include "cdb/cdbsetop.h"
 #include "cdb/cdbsubselect.h"
 #include "cdb/cdbvars.h"
+
 
 typedef struct convert_testexpr_context
 {
@@ -638,13 +640,19 @@ make_subplan(PlannerInfo *root, Query *orig_subquery, SubLinkType subLinkType,
 							&subroot,
 							config);
 
-	if ((plan->flow->locustype == CdbLocusType_SegmentGeneral ||
-		 plan->flow->locustype == CdbLocusType_General) &&
+	if (plan->flow->locustype == CdbLocusType_General &&
 		(contain_volatile_functions((Node *) plan->targetlist) ||
 		 contain_volatile_functions(subquery->havingQual)))
 	{
 		plan->flow->locustype = CdbLocusType_SingleQE;
 		plan->flow->flotype = FLOW_SINGLETON;
+	}
+
+	if (plan->flow->locustype == CdbLocusType_SegmentGeneral &&
+		(contain_volatile_functions((Node *) plan->targetlist) ||
+		 contain_volatile_functions(subquery->havingQual)))
+	{
+		plan = (Plan *) make_motion_gather(subroot, plan, NIL, CdbLocusType_SingleQE);
 	}
 
 	/* Isolate the params needed by this specific subplan */

--- a/src/test/regress/expected/rpt.out
+++ b/src/test/regress/expected/rpt.out
@@ -985,6 +985,51 @@ explain (costs off) select a from t_replicate_volatile union all select * from n
  Optimizer: Postgres query optimizer
 (6 rows)
 
+-- insert into table with serial column
+create table t_replicate_dst(id serial, i integer) distributed replicated;
+create table t_replicate_src(i integer) distributed replicated;
+insert into t_replicate_src select i from generate_series(1, 5) i;
+explain (costs off, verbose) insert into t_replicate_dst (i) select i from t_replicate_src;
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Insert on rpt.t_replicate_dst
+   ->  Broadcast Motion 1:3  (slice1; segments: 1)
+         Output: ((nextval('t_replicate_dst_id_seq'::regclass))::integer), t_replicate_src.i
+         ->  Seq Scan on rpt.t_replicate_src
+               Output: nextval('t_replicate_dst_id_seq'::regclass), t_replicate_src.i
+ Optimizer: Postgres query optimizer
+ Settings: enable_bitmapscan=off, enable_seqscan=off, optimizer=off
+(7 rows)
+
+explain (costs off, verbose) with s as (select i from t_replicate_src group by i having random() > 0) insert into t_replicate_dst (i) select i from s;
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Insert on rpt.t_replicate_dst
+   ->  Broadcast Motion 1:3  (slice1; segments: 1)
+         Output: ((nextval('t_replicate_dst_id_seq'::regclass))::integer), "*SELECT*".i
+         ->  Subquery Scan on "*SELECT*"
+               Output: nextval('t_replicate_dst_id_seq'::regclass), "*SELECT*".i
+               ->  HashAggregate
+                     Output: t_replicate_src.i
+                     Group Key: t_replicate_src.i
+                     Filter: (random() > '0'::double precision)
+                     ->  Seq Scan on rpt.t_replicate_src
+                           Output: t_replicate_src.i
+ Optimizer: Postgres query optimizer
+ Settings: enable_bitmapscan=off, enable_seqscan=off, optimizer=off
+(13 rows)
+
+insert into t_replicate_dst (i) select i from t_replicate_src;
+select distinct id from gp_dist_random('t_replicate_dst') order by id;
+ id 
+----
+  1
+  2
+  3
+  4
+  5
+(5 rows)
+
 -- update & delete
 explain (costs off) update t_replicate_volatile set a = 1 where b > random();
 ERROR:  could not devise a plan (cdbpath.c:2074)
@@ -1326,6 +1371,176 @@ explain (costs off) select * from rep_tab;
 
 reset optimizer_trace_fallback;
 reset optimizer_enable_replicated_table;
+--
+-- Check sub-selects with distributed replicated tables and volatile functions
+--
+create table t (i int) distributed replicated;
+create table t1 (a int) distributed by (a);
+create table t2 (a int, b float) distributed replicated;
+create or replace function f(i int) returns int language sql security definer as $$ select i; $$;
+-- ensure we make gather motion when volatile functions in subplan
+explain (costs off, verbose) select (select f(i) from t);
+                     QUERY PLAN                      
+-----------------------------------------------------
+ Result
+   Output: $0
+   InitPlan 1 (returns $0)  (slice2)
+     ->  Gather Motion 1:1  (slice1; segments: 1)
+           Output: (f(i))
+           ->  Seq Scan on rpt.t
+                 Output: f(i)
+ Optimizer: Postgres query optimizer
+ Settings: enable_bitmapscan=off, enable_seqscan=off
+(9 rows)
+
+explain (costs off, verbose) select (select f(i) from t group by f(i));
+                     QUERY PLAN                      
+-----------------------------------------------------
+ Result
+   Output: $0
+   InitPlan 1 (returns $0)  (slice2)
+     ->  Gather Motion 1:1  (slice1; segments: 1)
+           Output: (f(i))
+           ->  HashAggregate
+                 Output: (f(i))
+                 Group Key: f(t.i)
+                 ->  Seq Scan on rpt.t
+                       Output: i, f(i)
+ Optimizer: Postgres query optimizer
+ Settings: enable_bitmapscan=off, enable_seqscan=off
+(12 rows)
+
+explain (costs off, verbose) select (select i from t group by i having f(i) > 0);
+                     QUERY PLAN                      
+-----------------------------------------------------
+ Result
+   Output: $0
+   InitPlan 1 (returns $0)  (slice2)
+     ->  Gather Motion 1:1  (slice1; segments: 1)
+           Output: i
+           ->  HashAggregate
+                 Output: i
+                 Group Key: t.i
+                 Filter: (f(t.i) > 0)
+                 ->  Seq Scan on rpt.t
+                       Output: i
+ Optimizer: Postgres query optimizer
+ Settings: enable_bitmapscan=off, enable_seqscan=off
+(13 rows)
+
+-- ensure we do not make broadcast motion
+explain (costs off, verbose) select * from t1 where a in (select random() from t where i=a group by i);
+                     QUERY PLAN                      
+-----------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: t1.a
+   ->  Seq Scan on rpt.t1
+         Output: t1.a
+         Filter: (SubPlan 1)
+         SubPlan 1  (slice1; segments: 1)
+           ->  GroupAggregate
+                 Output: random(), t.i
+                 Group Key: t.i
+                 ->  Result
+                       Output: t.i
+                       Filter: (t.i = t1.a)
+                       ->  Materialize
+                             Output: t.i, t.i
+                             ->  Seq Scan on rpt.t
+                                   Output: t.i, t.i
+ Optimizer: Postgres query optimizer
+ Settings: enable_bitmapscan=off, enable_seqscan=off
+(18 rows)
+
+explain (costs off, verbose) select * from t1 where a in (select random() from t where i=a);
+                     QUERY PLAN                      
+-----------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: t1.a
+   ->  Seq Scan on rpt.t1
+         Output: t1.a
+         Filter: (SubPlan 1)
+         SubPlan 1  (slice1; segments: 1)
+           ->  Result
+                 Output: random()
+                 Filter: (t.i = t1.a)
+                 ->  Materialize
+                       Output: t.i
+                       ->  Seq Scan on rpt.t
+                             Output: t.i
+ Optimizer: Postgres query optimizer
+ Settings: enable_bitmapscan=off, enable_seqscan=off
+(15 rows)
+
+-- ensure we make broadcast motion when volatile function in deleting motion flow
+explain (costs off, verbose) insert into t2 (a, b) select i, random() from t;
+                     QUERY PLAN                      
+-----------------------------------------------------
+ Insert on rpt.t2
+   ->  Broadcast Motion 1:3  (slice1; segments: 1)
+         Output: t.i, (random())
+         ->  Seq Scan on rpt.t
+               Output: t.i, random()
+ Optimizer: Postgres query optimizer
+ Settings: enable_bitmapscan=off, enable_seqscan=off
+(7 rows)
+
+-- ensure we make broadcast motion when volatile function in correlated subplan qual
+explain (costs off, verbose) select * from t1 where a in (select f(i) from t where i=a and f(i) > 0);
+                                 QUERY PLAN                                  
+-----------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)
+   Output: t1.a
+   ->  Seq Scan on rpt.t1
+         Output: t1.a
+         Filter: (SubPlan 1)
+         SubPlan 1  (slice2; segments: 3)
+           ->  Result
+                 Output: f(t.i)
+                 ->  Result
+                       Output: t.i
+                       Filter: (t.i = t1.a)
+                       ->  Materialize
+                             Output: t.i, t.i
+                             ->  Broadcast Motion 1:3  (slice1; segments: 1)
+                                   Output: t.i, t.i
+                                   ->  Seq Scan on rpt.t
+                                         Output: t.i, t.i
+                                         Filter: (f(t.i) > 0)
+ Optimizer: Postgres query optimizer
+ Settings: enable_bitmapscan=off, enable_seqscan=off
+(20 rows)
+
+-- ensure we do not break broadcast motion
+explain (costs off, verbose) select * from t1 where 1 <= ALL (select i from t group by i having random() > 0);
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)
+   Output: t1.a
+   ->  Result
+         Output: t1.a
+         One-Time Filter: (SubPlan 1)
+         ->  Seq Scan on rpt.t1
+               Output: t1.a
+         SubPlan 1  (slice2; segments: 3)
+           ->  Materialize
+                 Output: t.i
+                 ->  Broadcast Motion 1:3  (slice1; segments: 1)
+                       Output: t.i
+                       ->  HashAggregate
+                             Output: t.i
+                             Group Key: t.i
+                             Filter: (random() > '0'::double precision)
+                             ->  Seq Scan on rpt.t
+                                   Output: t.i
+ Optimizer: Postgres query optimizer
+ Settings: enable_bitmapscan=off, enable_seqscan=off
+(20 rows)
+
+drop table if exists t;
+drop table if exists t1;
+drop table if exists t2;
+drop function if exists f(i int);
 -- start_ignore
 drop schema rpt cascade;
 NOTICE:  drop cascades to 13 other objects

--- a/src/test/regress/expected/rpt.out
+++ b/src/test/regress/expected/rpt.out
@@ -985,30 +985,6 @@ explain (costs off) select a from t_replicate_volatile union all select * from n
  Optimizer: Postgres query optimizer
 (6 rows)
 
--- insert into table with serial column
-create table t_replicate_dst(id serial, i integer) distributed replicated;
-create table t_replicate_src(i integer) distributed replicated;
-insert into t_replicate_src select i from generate_series(1, 5) i;
-explain (costs off) insert into t_replicate_dst (i) select i from t_replicate_src;
-                    QUERY PLAN                     
----------------------------------------------------
- Insert on t_replicate_dst
-   ->  Broadcast Motion 1:3  (slice1; segments: 1)
-         ->  Seq Scan on t_replicate_src
- Optimizer: Postgres query optimizer
-(4 rows)
-
-insert into t_replicate_dst (i) select i from t_replicate_src;
-select distinct id from gp_dist_random('t_replicate_dst') order by id;
- id 
-----
-  1
-  2
-  3
-  4
-  5
-(5 rows)
-
 -- update & delete
 explain (costs off) update t_replicate_volatile set a = 1 where b > random();
 ERROR:  could not devise a plan (cdbpath.c:2074)
@@ -1363,8 +1339,6 @@ drop cascades to table minmaxtest
 drop cascades to table t_hashdist
 drop cascades to table t_replicate_volatile
 drop cascades to sequence seq_for_insert_replicated_table
-drop cascades to table t_replicate_dst
-drop cascades to table t_replicate_src
 drop cascades to table rtbl
 drop cascades to table t1_13532
 drop cascades to table t2_13532

--- a/src/test/regress/expected/rpt.out
+++ b/src/test/regress/expected/rpt.out
@@ -875,13 +875,13 @@ explain (costs off, verbose) select * from t_hashdist left join t_replicate_vola
                      Output: t_replicate_volatile.a, t_replicate_volatile.b, t_replicate_volatile.c
          SubPlan 1  (slice2; segments: 3)
            ->  Materialize
-                 Output: random()
+                 Output: (random())
                  ->  Broadcast Motion 1:3  (slice1; segments: 1)
                        Output: (random())
                        ->  Seq Scan on rpt.t_replicate_volatile t_replicate_volatile_1
                              Output: random()
  Optimizer: Postgres query optimizer
- Settings: enable_seqscan=off, optimizer=off
+ Settings: enable_bitmapscan=off, enable_seqscan=off, optimizer=off
 (20 rows)
 
 -- targetlist
@@ -1012,7 +1012,7 @@ explain (costs off, verbose) with s as (select i from t_replicate_src group by i
                ->  HashAggregate
                      Output: t_replicate_src.i
                      Group Key: t_replicate_src.i
-                     Filter: (random() > '0'::double precision)
+                     Filter: (random() > 0::double precision)
                      ->  Seq Scan on rpt.t_replicate_src
                            Output: t_replicate_src.i
  Optimizer: Postgres query optimizer
@@ -1380,8 +1380,8 @@ create table t2 (a int, b float) distributed replicated;
 create or replace function f(i int) returns int language sql security definer as $$ select i; $$;
 -- ensure we make gather motion when volatile functions in subplan
 explain (costs off, verbose) select (select f(i) from t);
-                     QUERY PLAN                      
------------------------------------------------------
+                             QUERY PLAN                             
+--------------------------------------------------------------------
  Result
    Output: $0
    InitPlan 1 (returns $0)  (slice2)
@@ -1390,12 +1390,12 @@ explain (costs off, verbose) select (select f(i) from t);
            ->  Seq Scan on rpt.t
                  Output: f(i)
  Optimizer: Postgres query optimizer
- Settings: enable_bitmapscan=off, enable_seqscan=off
+ Settings: enable_bitmapscan=off, enable_seqscan=off, optimizer=off
 (9 rows)
 
 explain (costs off, verbose) select (select f(i) from t group by f(i));
-                     QUERY PLAN                      
------------------------------------------------------
+                             QUERY PLAN                             
+--------------------------------------------------------------------
  Result
    Output: $0
    InitPlan 1 (returns $0)  (slice2)
@@ -1407,12 +1407,12 @@ explain (costs off, verbose) select (select f(i) from t group by f(i));
                  ->  Seq Scan on rpt.t
                        Output: i, f(i)
  Optimizer: Postgres query optimizer
- Settings: enable_bitmapscan=off, enable_seqscan=off
+ Settings: enable_bitmapscan=off, enable_seqscan=off, optimizer=off
 (12 rows)
 
 explain (costs off, verbose) select (select i from t group by i having f(i) > 0);
-                     QUERY PLAN                      
------------------------------------------------------
+                             QUERY PLAN                             
+--------------------------------------------------------------------
  Result
    Output: $0
    InitPlan 1 (returns $0)  (slice2)
@@ -1425,36 +1425,33 @@ explain (costs off, verbose) select (select i from t group by i having f(i) > 0)
                  ->  Seq Scan on rpt.t
                        Output: i
  Optimizer: Postgres query optimizer
- Settings: enable_bitmapscan=off, enable_seqscan=off
+ Settings: enable_bitmapscan=off, enable_seqscan=off, optimizer=off
 (13 rows)
 
 -- ensure we do not make broadcast motion
 explain (costs off, verbose) select * from t1 where a in (select random() from t where i=a group by i);
-                     QUERY PLAN                      
------------------------------------------------------
+                             QUERY PLAN                             
+--------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Output: t1.a
    ->  Seq Scan on rpt.t1
          Output: t1.a
          Filter: (SubPlan 1)
          SubPlan 1  (slice1; segments: 1)
-           ->  GroupAggregate
+           ->  Result
                  Output: random(), t.i
-                 Group Key: t.i
-                 ->  Result
-                       Output: t.i
-                       Filter: (t.i = t1.a)
-                       ->  Materialize
+                 Filter: (t.i = t1.a)
+                 ->  Materialize
+                       Output: t.i, t.i
+                       ->  Seq Scan on rpt.t
                              Output: t.i, t.i
-                             ->  Seq Scan on rpt.t
-                                   Output: t.i, t.i
  Optimizer: Postgres query optimizer
- Settings: enable_bitmapscan=off, enable_seqscan=off
-(18 rows)
+ Settings: enable_bitmapscan=off, enable_seqscan=off, optimizer=off
+(15 rows)
 
 explain (costs off, verbose) select * from t1 where a in (select random() from t where i=a);
-                     QUERY PLAN                      
------------------------------------------------------
+                             QUERY PLAN                             
+--------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Output: t1.a
    ->  Seq Scan on rpt.t1
@@ -1469,20 +1466,20 @@ explain (costs off, verbose) select * from t1 where a in (select random() from t
                        ->  Seq Scan on rpt.t
                              Output: t.i
  Optimizer: Postgres query optimizer
- Settings: enable_bitmapscan=off, enable_seqscan=off
+ Settings: enable_bitmapscan=off, enable_seqscan=off, optimizer=off
 (15 rows)
 
 -- ensure we make broadcast motion when volatile function in deleting motion flow
 explain (costs off, verbose) insert into t2 (a, b) select i, random() from t;
-                     QUERY PLAN                      
------------------------------------------------------
+                             QUERY PLAN                             
+--------------------------------------------------------------------
  Insert on rpt.t2
    ->  Broadcast Motion 1:3  (slice1; segments: 1)
          Output: t.i, (random())
          ->  Seq Scan on rpt.t
                Output: t.i, random()
  Optimizer: Postgres query optimizer
- Settings: enable_bitmapscan=off, enable_seqscan=off
+ Settings: enable_bitmapscan=off, enable_seqscan=off, optimizer=off
 (7 rows)
 
 -- ensure we make broadcast motion when volatile function in correlated subplan qual
@@ -1508,13 +1505,13 @@ explain (costs off, verbose) select * from t1 where a in (select f(i) from t whe
                                          Output: t.i, t.i
                                          Filter: (f(t.i) > 0)
  Optimizer: Postgres query optimizer
- Settings: enable_bitmapscan=off, enable_seqscan=off
+ Settings: enable_bitmapscan=off, enable_seqscan=off, optimizer=off
 (20 rows)
 
 -- ensure we do not break broadcast motion
 explain (costs off, verbose) select * from t1 where 1 <= ALL (select i from t group by i having random() > 0);
-                               QUERY PLAN                               
-------------------------------------------------------------------------
+                              QUERY PLAN                              
+----------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)
    Output: t1.a
    ->  Result
@@ -1530,11 +1527,11 @@ explain (costs off, verbose) select * from t1 where 1 <= ALL (select i from t gr
                        ->  HashAggregate
                              Output: t.i
                              Group Key: t.i
-                             Filter: (random() > '0'::double precision)
+                             Filter: (random() > 0::double precision)
                              ->  Seq Scan on rpt.t
                                    Output: t.i
  Optimizer: Postgres query optimizer
- Settings: enable_bitmapscan=off, enable_seqscan=off
+ Settings: enable_bitmapscan=off, enable_seqscan=off, optimizer=off
 (20 rows)
 
 drop table if exists t;

--- a/src/test/regress/expected/rpt_optimizer.out
+++ b/src/test/regress/expected/rpt_optimizer.out
@@ -976,30 +976,6 @@ explain (costs off) select a from t_replicate_volatile union all select * from n
  Optimizer: Postgres query optimizer
 (6 rows)
 
--- insert into table with serial column
-create table t_replicate_dst(id serial, i integer) distributed replicated;
-create table t_replicate_src(i integer) distributed replicated;
-insert into t_replicate_src select i from generate_series(1, 5) i;
-explain (costs off) insert into t_replicate_dst (i) select i from t_replicate_src;
-                    QUERY PLAN                     
----------------------------------------------------
- Insert on t_replicate_dst
-   ->  Broadcast Motion 1:3  (slice1; segments: 1)
-         ->  Seq Scan on t_replicate_src
- Optimizer: Postgres query optimizer
-(4 rows)
-
-insert into t_replicate_dst (i) select i from t_replicate_src;
-select distinct id from gp_dist_random('t_replicate_dst') order by id;
- id 
-----
-  1
-  2
-  3
-  4
-  5
-(5 rows)
-
 -- update & delete
 explain (costs off) update t_replicate_volatile set a = 1 where b > random();
 ERROR:  could not devise a plan (cdbpath.c:2089)
@@ -1361,8 +1337,6 @@ drop cascades to table minmaxtest
 drop cascades to table t_hashdist
 drop cascades to table t_replicate_volatile
 drop cascades to sequence seq_for_insert_replicated_table
-drop cascades to table t_replicate_dst
-drop cascades to table t_replicate_src
 drop cascades to table rtbl
 drop cascades to table t1_13532
 drop cascades to table t2_13532

--- a/src/test/regress/expected/rpt_optimizer.out
+++ b/src/test/regress/expected/rpt_optimizer.out
@@ -976,6 +976,51 @@ explain (costs off) select a from t_replicate_volatile union all select * from n
  Optimizer: Postgres query optimizer
 (6 rows)
 
+-- insert into table with serial column
+create table t_replicate_dst(id serial, i integer) distributed replicated;
+create table t_replicate_src(i integer) distributed replicated;
+insert into t_replicate_src select i from generate_series(1, 5) i;
+explain (costs off, verbose) insert into t_replicate_dst (i) select i from t_replicate_src;
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Insert on rpt.t_replicate_dst
+   ->  Broadcast Motion 1:3  (slice1; segments: 1)
+         Output: ((nextval('t_replicate_dst_id_seq'::regclass))::integer), t_replicate_src.i
+         ->  Seq Scan on rpt.t_replicate_src
+               Output: nextval('t_replicate_dst_id_seq'::regclass), t_replicate_src.i
+ Optimizer: Postgres query optimizer
+ Settings: enable_bitmapscan=off, enable_seqscan=off, optimizer=off
+(7 rows)
+
+explain (costs off, verbose) with s as (select i from t_replicate_src group by i having random() > 0) insert into t_replicate_dst (i) select i from s;
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Insert on rpt.t_replicate_dst
+   ->  Broadcast Motion 1:3  (slice1; segments: 1)
+         Output: ((nextval('t_replicate_dst_id_seq'::regclass))::integer), "*SELECT*".i
+         ->  Subquery Scan on "*SELECT*"
+               Output: nextval('t_replicate_dst_id_seq'::regclass), "*SELECT*".i
+               ->  HashAggregate
+                     Output: t_replicate_src.i
+                     Group Key: t_replicate_src.i
+                     Filter: (random() > '0'::double precision)
+                     ->  Seq Scan on rpt.t_replicate_src
+                           Output: t_replicate_src.i
+ Optimizer: Postgres query optimizer
+ Settings: enable_bitmapscan=off, enable_seqscan=off, optimizer=off
+(13 rows)
+
+insert into t_replicate_dst (i) select i from t_replicate_src;
+select distinct id from gp_dist_random('t_replicate_dst') order by id;
+ id 
+----
+  1
+  2
+  3
+  4
+  5
+(5 rows)
+
 -- update & delete
 explain (costs off) update t_replicate_volatile set a = 1 where b > random();
 ERROR:  could not devise a plan (cdbpath.c:2089)
@@ -1324,6 +1369,176 @@ WARNING:  relcache reference leak: relation "rep_tab" not closed
 
 reset optimizer_trace_fallback;
 reset optimizer_enable_replicated_table;
+--
+-- Check sub-selects with distributed replicated tables and volatile functions
+--
+create table t (i int) distributed replicated;
+create table t1 (a int) distributed by (a);
+create table t2 (a int, b float) distributed replicated;
+create or replace function f(i int) returns int language sql security definer as $$ select i; $$;
+-- ensure we make gather motion when volatile functions in subplan
+explain (costs off, verbose) select (select f(i) from t);
+                     QUERY PLAN                      
+-----------------------------------------------------
+ Result
+   Output: $0
+   InitPlan 1 (returns $0)  (slice2)
+     ->  Gather Motion 1:1  (slice1; segments: 1)
+           Output: (f(i))
+           ->  Seq Scan on rpt.t
+                 Output: f(i)
+ Optimizer: Postgres query optimizer
+ Settings: enable_bitmapscan=off, enable_seqscan=off
+(9 rows)
+
+explain (costs off, verbose) select (select f(i) from t group by f(i));
+                     QUERY PLAN                      
+-----------------------------------------------------
+ Result
+   Output: $0
+   InitPlan 1 (returns $0)  (slice2)
+     ->  Gather Motion 1:1  (slice1; segments: 1)
+           Output: (f(i))
+           ->  HashAggregate
+                 Output: (f(i))
+                 Group Key: f(t.i)
+                 ->  Seq Scan on rpt.t
+                       Output: i, f(i)
+ Optimizer: Postgres query optimizer
+ Settings: enable_bitmapscan=off, enable_seqscan=off
+(12 rows)
+
+explain (costs off, verbose) select (select i from t group by i having f(i) > 0);
+                     QUERY PLAN                      
+-----------------------------------------------------
+ Result
+   Output: $0
+   InitPlan 1 (returns $0)  (slice2)
+     ->  Gather Motion 1:1  (slice1; segments: 1)
+           Output: i
+           ->  HashAggregate
+                 Output: i
+                 Group Key: t.i
+                 Filter: (f(t.i) > 0)
+                 ->  Seq Scan on rpt.t
+                       Output: i
+ Optimizer: Postgres query optimizer
+ Settings: enable_bitmapscan=off, enable_seqscan=off
+(13 rows)
+
+-- ensure we do not make broadcast motion
+explain (costs off, verbose) select * from t1 where a in (select random() from t where i=a group by i);
+                     QUERY PLAN                      
+-----------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: t1.a
+   ->  Seq Scan on rpt.t1
+         Output: t1.a
+         Filter: (SubPlan 1)
+         SubPlan 1  (slice1; segments: 1)
+           ->  GroupAggregate
+                 Output: random(), t.i
+                 Group Key: t.i
+                 ->  Result
+                       Output: t.i
+                       Filter: (t.i = t1.a)
+                       ->  Materialize
+                             Output: t.i, t.i
+                             ->  Seq Scan on rpt.t
+                                   Output: t.i, t.i
+ Optimizer: Postgres query optimizer
+ Settings: enable_bitmapscan=off, enable_seqscan=off
+(18 rows)
+
+explain (costs off, verbose) select * from t1 where a in (select random() from t where i=a);
+                     QUERY PLAN                      
+-----------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: t1.a
+   ->  Seq Scan on rpt.t1
+         Output: t1.a
+         Filter: (SubPlan 1)
+         SubPlan 1  (slice1; segments: 1)
+           ->  Result
+                 Output: random()
+                 Filter: (t.i = t1.a)
+                 ->  Materialize
+                       Output: t.i
+                       ->  Seq Scan on rpt.t
+                             Output: t.i
+ Optimizer: Postgres query optimizer
+ Settings: enable_bitmapscan=off, enable_seqscan=off
+(15 rows)
+
+-- ensure we make broadcast motion when volatile function in deleting motion flow
+explain (costs off, verbose) insert into t2 (a, b) select i, random() from t;
+                     QUERY PLAN                      
+-----------------------------------------------------
+ Insert on rpt.t2
+   ->  Broadcast Motion 1:3  (slice1; segments: 1)
+         Output: t.i, (random())
+         ->  Seq Scan on rpt.t
+               Output: t.i, random()
+ Optimizer: Postgres query optimizer
+ Settings: enable_bitmapscan=off, enable_seqscan=off
+(7 rows)
+
+-- ensure we make broadcast motion when volatile function in correlated subplan qual
+explain (costs off, verbose) select * from t1 where a in (select f(i) from t where i=a and f(i) > 0);
+                                 QUERY PLAN                                  
+-----------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)
+   Output: t1.a
+   ->  Seq Scan on rpt.t1
+         Output: t1.a
+         Filter: (SubPlan 1)
+         SubPlan 1  (slice2; segments: 3)
+           ->  Result
+                 Output: f(t.i)
+                 ->  Result
+                       Output: t.i
+                       Filter: (t.i = t1.a)
+                       ->  Materialize
+                             Output: t.i, t.i
+                             ->  Broadcast Motion 1:3  (slice1; segments: 1)
+                                   Output: t.i, t.i
+                                   ->  Seq Scan on rpt.t
+                                         Output: t.i, t.i
+                                         Filter: (f(t.i) > 0)
+ Optimizer: Postgres query optimizer
+ Settings: enable_bitmapscan=off, enable_seqscan=off
+(20 rows)
+
+-- ensure we do not break broadcast motion
+explain (costs off, verbose) select * from t1 where 1 <= ALL (select i from t group by i having random() > 0);
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)
+   Output: t1.a
+   ->  Result
+         Output: t1.a
+         One-Time Filter: (SubPlan 1)
+         ->  Seq Scan on rpt.t1
+               Output: t1.a
+         SubPlan 1  (slice2; segments: 3)
+           ->  Materialize
+                 Output: t.i
+                 ->  Broadcast Motion 1:3  (slice1; segments: 1)
+                       Output: t.i
+                       ->  HashAggregate
+                             Output: t.i
+                             Group Key: t.i
+                             Filter: (random() > '0'::double precision)
+                             ->  Seq Scan on rpt.t
+                                   Output: t.i
+ Optimizer: Postgres query optimizer
+ Settings: enable_bitmapscan=off, enable_seqscan=off
+(20 rows)
+
+drop table if exists t;
+drop table if exists t1;
+drop table if exists t2;
+drop function if exists f(i int);
 -- start_ignore
 drop schema rpt cascade;
 NOTICE:  drop cascades to 13 other objects

--- a/src/test/regress/expected/rpt_optimizer.out
+++ b/src/test/regress/expected/rpt_optimizer.out
@@ -866,7 +866,7 @@ explain (costs off, verbose) select * from t_hashdist left join t_replicate_vola
                      Output: t_replicate_volatile.a, t_replicate_volatile.b, t_replicate_volatile.c
          SubPlan 1  (slice2; segments: 3)
            ->  Materialize
-                 Output: random()
+                 Output: (random())
                  ->  Broadcast Motion 1:3  (slice1; segments: 1)
                        Output: (random())
                        ->  Seq Scan on rpt.t_replicate_volatile t_replicate_volatile_1
@@ -1003,7 +1003,7 @@ explain (costs off, verbose) with s as (select i from t_replicate_src group by i
                ->  HashAggregate
                      Output: t_replicate_src.i
                      Group Key: t_replicate_src.i
-                     Filter: (random() > '0'::double precision)
+                     Filter: (random() > 0::double precision)
                      ->  Seq Scan on rpt.t_replicate_src
                            Output: t_replicate_src.i
  Optimizer: Postgres query optimizer
@@ -1378,8 +1378,8 @@ create table t2 (a int, b float) distributed replicated;
 create or replace function f(i int) returns int language sql security definer as $$ select i; $$;
 -- ensure we make gather motion when volatile functions in subplan
 explain (costs off, verbose) select (select f(i) from t);
-                     QUERY PLAN                      
------------------------------------------------------
+                            QUERY PLAN                             
+-------------------------------------------------------------------
  Result
    Output: $0
    InitPlan 1 (returns $0)  (slice2)
@@ -1388,12 +1388,12 @@ explain (costs off, verbose) select (select f(i) from t);
            ->  Seq Scan on rpt.t
                  Output: f(i)
  Optimizer: Postgres query optimizer
- Settings: enable_bitmapscan=off, enable_seqscan=off
+ Settings: enable_bitmapscan=off, enable_seqscan=off, optimizer=on
 (9 rows)
 
 explain (costs off, verbose) select (select f(i) from t group by f(i));
-                     QUERY PLAN                      
------------------------------------------------------
+                            QUERY PLAN                             
+-------------------------------------------------------------------
  Result
    Output: $0
    InitPlan 1 (returns $0)  (slice2)
@@ -1405,12 +1405,12 @@ explain (costs off, verbose) select (select f(i) from t group by f(i));
                  ->  Seq Scan on rpt.t
                        Output: i, f(i)
  Optimizer: Postgres query optimizer
- Settings: enable_bitmapscan=off, enable_seqscan=off
+ Settings: enable_bitmapscan=off, enable_seqscan=off, optimizer=on
 (12 rows)
 
 explain (costs off, verbose) select (select i from t group by i having f(i) > 0);
-                     QUERY PLAN                      
------------------------------------------------------
+                            QUERY PLAN                             
+-------------------------------------------------------------------
  Result
    Output: $0
    InitPlan 1 (returns $0)  (slice2)
@@ -1423,117 +1423,141 @@ explain (costs off, verbose) select (select i from t group by i having f(i) > 0)
                  ->  Seq Scan on rpt.t
                        Output: i
  Optimizer: Postgres query optimizer
- Settings: enable_bitmapscan=off, enable_seqscan=off
+ Settings: enable_bitmapscan=off, enable_seqscan=off, optimizer=on
 (13 rows)
 
 -- ensure we do not make broadcast motion
 explain (costs off, verbose) select * from t1 where a in (select random() from t where i=a group by i);
-                     QUERY PLAN                      
------------------------------------------------------
+                            QUERY PLAN                             
+-------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Output: t1.a
-   ->  Seq Scan on rpt.t1
+   ->  Hash Semi Join
          Output: t1.a
-         Filter: (SubPlan 1)
-         SubPlan 1  (slice1; segments: 1)
-           ->  GroupAggregate
-                 Output: random(), t.i
-                 Group Key: t.i
-                 ->  Result
-                       Output: t.i
-                       Filter: (t.i = t1.a)
-                       ->  Materialize
-                             Output: t.i, t.i
-                             ->  Seq Scan on rpt.t
-                                   Output: t.i, t.i
- Optimizer: Postgres query optimizer
- Settings: enable_bitmapscan=off, enable_seqscan=off
-(18 rows)
+         Hash Cond: (t1.a = t.i)
+         ->  Seq Scan on rpt.t1
+               Output: t1.a
+               Filter: ((t1.a)::double precision = random())
+         ->  Hash
+               Output: t.i
+               ->  GroupAggregate
+                     Output: t.i
+                     Group Key: t.i
+                     ->  Sort
+                           Output: t.i
+                           Sort Key: t.i
+                           ->  Seq Scan on rpt.t
+                                 Output: t.i
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Settings: enable_bitmapscan=off, enable_seqscan=off, optimizer=on
+(20 rows)
 
 explain (costs off, verbose) select * from t1 where a in (select random() from t where i=a);
-                     QUERY PLAN                      
------------------------------------------------------
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Output: t1.a
-   ->  Seq Scan on rpt.t1
+   ->  Hash Semi Join
          Output: t1.a
-         Filter: (SubPlan 1)
-         SubPlan 1  (slice1; segments: 1)
-           ->  Result
-                 Output: random()
-                 Filter: (t.i = t1.a)
-                 ->  Materialize
-                       Output: t.i
-                       ->  Seq Scan on rpt.t
-                             Output: t.i
- Optimizer: Postgres query optimizer
- Settings: enable_bitmapscan=off, enable_seqscan=off
-(15 rows)
+         Hash Cond: (t1.a = t.i)
+         ->  Seq Scan on rpt.t1
+               Output: t1.a
+               Filter: ((NOT (t1.a IS NULL)) AND ((t1.a)::double precision = random()))
+         ->  Hash
+               Output: t.i
+               ->  Seq Scan on rpt.t
+                     Output: t.i
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Settings: enable_bitmapscan=off, enable_seqscan=off, optimizer=on
+(14 rows)
 
 -- ensure we make broadcast motion when volatile function in deleting motion flow
 explain (costs off, verbose) insert into t2 (a, b) select i, random() from t;
-                     QUERY PLAN                      
------------------------------------------------------
- Insert on rpt.t2
-   ->  Broadcast Motion 1:3  (slice1; segments: 1)
-         Output: t.i, (random())
-         ->  Seq Scan on rpt.t
-               Output: t.i, random()
- Optimizer: Postgres query optimizer
- Settings: enable_bitmapscan=off, enable_seqscan=off
-(7 rows)
+                            QUERY PLAN                             
+-------------------------------------------------------------------
+ Insert
+   Output: t.i, (random()), "outer".ColRef_0009, t.i
+   ->  Result
+         Output: t.i, (random()), 1
+         ->  Broadcast Motion 1:3  (slice1; segments: 1)
+               Output: t.i, (random())
+               ->  Result
+                     Output: t.i, (random())
+                     ->  Result
+                           Output: random(), t.i
+                           ->  Seq Scan on rpt.t
+                                 Output: t.i
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Settings: enable_bitmapscan=off, enable_seqscan=off, optimizer=on
+(14 rows)
 
 -- ensure we make broadcast motion when volatile function in correlated subplan qual
 explain (costs off, verbose) select * from t1 where a in (select f(i) from t where i=a and f(i) > 0);
-                                 QUERY PLAN                                  
------------------------------------------------------------------------------
- Gather Motion 3:1  (slice2; segments: 3)
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice4; segments: 3)
+   Output: t1.a
+   ->  Hash Join
+         Output: t1.a
+         Hash Cond: ((t.i = t1.a) AND ((f(t.i)) = t1.a))
+         ->  Redistribute Motion 3:3  (slice3; segments: 3)
+               Output: t.i, (f(t.i))
+               Hash Key: t.i
+               ->  GroupAggregate
+                     Output: t.i, (f(t.i))
+                     Group Key: t.i, (f(t.i))
+                     ->  Sort
+                           Output: t.i, (f(t.i))
+                           Sort Key: t.i, (f(t.i))
+                           ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                                 Output: t.i, (f(t.i))
+                                 Hash Key: t.i, (f(t.i))
+                                 ->  GroupAggregate
+                                       Output: t.i, (f(t.i))
+                                       Group Key: t.i, (f(t.i))
+                                       ->  Sort
+                                             Output: (f(t.i)), t.i
+                                             Sort Key: t.i, (f(t.i))
+                                             ->  Result
+                                                   Output: f(t.i), t.i
+                                                   ->  Redistribute Motion 1:3  (slice1; segments: 1)
+                                                         Output: t.i
+                                                         ->  Seq Scan on rpt.t
+                                                               Output: t.i
+                                                               Filter: (f(t.i) > 0)
+         ->  Hash
+               Output: t1.a
+               ->  Seq Scan on rpt.t1
+                     Output: t1.a
+                     Filter: (NOT (t1.a IS NULL))
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Settings: enable_bitmapscan=off, enable_seqscan=off, optimizer=on
+(37 rows)
+
+-- ensure we do not break broadcast motion
+explain (costs off, verbose) select * from t1 where 1 <= ALL (select i from t group by i having random() > 0);
+                            QUERY PLAN                             
+-------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
    Output: t1.a
    ->  Seq Scan on rpt.t1
          Output: t1.a
          Filter: (SubPlan 1)
-         SubPlan 1  (slice2; segments: 3)
+         SubPlan 1  (slice1; segments: 3)
            ->  Result
-                 Output: f(t.i)
-                 ->  Result
-                       Output: t.i
-                       Filter: (t.i = t1.a)
-                       ->  Materialize
-                             Output: t.i, t.i
-                             ->  Broadcast Motion 1:3  (slice1; segments: 1)
-                                   Output: t.i, t.i
-                                   ->  Seq Scan on rpt.t
-                                         Output: t.i, t.i
-                                         Filter: (f(t.i) > 0)
- Optimizer: Postgres query optimizer
- Settings: enable_bitmapscan=off, enable_seqscan=off
-(20 rows)
-
--- ensure we do not break broadcast motion
-explain (costs off, verbose) select * from t1 where 1 <= ALL (select i from t group by i having random() > 0);
-                               QUERY PLAN                               
-------------------------------------------------------------------------
- Gather Motion 3:1  (slice2; segments: 3)
-   Output: t1.a
-   ->  Result
-         Output: t1.a
-         One-Time Filter: (SubPlan 1)
-         ->  Seq Scan on rpt.t1
-               Output: t1.a
-         SubPlan 1  (slice2; segments: 3)
-           ->  Materialize
                  Output: t.i
-                 ->  Broadcast Motion 1:3  (slice1; segments: 1)
+                 Filter: (random() > 0::double precision)
+                 ->  GroupAggregate
                        Output: t.i
-                       ->  HashAggregate
+                       Group Key: t.i
+                       ->  Sort
                              Output: t.i
-                             Group Key: t.i
-                             Filter: (random() > '0'::double precision)
+                             Sort Key: t.i
                              ->  Seq Scan on rpt.t
                                    Output: t.i
- Optimizer: Postgres query optimizer
- Settings: enable_bitmapscan=off, enable_seqscan=off
-(20 rows)
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Settings: enable_bitmapscan=off, enable_seqscan=off, optimizer=on
+(19 rows)
 
 drop table if exists t;
 drop table if exists t1;

--- a/src/test/regress/sql/rpt.sql
+++ b/src/test/regress/sql/rpt.sql
@@ -424,15 +424,6 @@ explain (costs off) insert into t_replicate_volatile select random(), a, a from 
 create sequence seq_for_insert_replicated_table;
 explain (costs off) insert into t_replicate_volatile select nextval('seq_for_insert_replicated_table');
 explain (costs off) select a from t_replicate_volatile union all select * from nextval('seq_for_insert_replicated_table');
-
--- insert into table with serial column
-create table t_replicate_dst(id serial, i integer) distributed replicated;
-create table t_replicate_src(i integer) distributed replicated;
-insert into t_replicate_src select i from generate_series(1, 5) i;
-explain (costs off) insert into t_replicate_dst (i) select i from t_replicate_src;
-insert into t_replicate_dst (i) select i from t_replicate_src;
-select distinct id from gp_dist_random('t_replicate_dst') order by id;
-
 -- update & delete
 explain (costs off) update t_replicate_volatile set a = 1 where b > random();
 explain (costs off) update t_replicate_volatile set a = 1 from t_replicate_volatile x where x.a + random() = t_replicate_volatile.b;

--- a/src/test/regress/sql/rpt.sql
+++ b/src/test/regress/sql/rpt.sql
@@ -424,6 +424,16 @@ explain (costs off) insert into t_replicate_volatile select random(), a, a from 
 create sequence seq_for_insert_replicated_table;
 explain (costs off) insert into t_replicate_volatile select nextval('seq_for_insert_replicated_table');
 explain (costs off) select a from t_replicate_volatile union all select * from nextval('seq_for_insert_replicated_table');
+
+-- insert into table with serial column
+create table t_replicate_dst(id serial, i integer) distributed replicated;
+create table t_replicate_src(i integer) distributed replicated;
+insert into t_replicate_src select i from generate_series(1, 5) i;
+explain (costs off, verbose) insert into t_replicate_dst (i) select i from t_replicate_src;
+explain (costs off, verbose) with s as (select i from t_replicate_src group by i having random() > 0) insert into t_replicate_dst (i) select i from s;
+insert into t_replicate_dst (i) select i from t_replicate_src;
+select distinct id from gp_dist_random('t_replicate_dst') order by id;
+
 -- update & delete
 explain (costs off) update t_replicate_volatile set a = 1 where b > random();
 explain (costs off) update t_replicate_volatile set a = 1 from t_replicate_volatile x where x.a + random() = t_replicate_volatile.b;
@@ -539,6 +549,31 @@ set optimizer_trace_fallback=on;
 explain (costs off) select * from rep_tab;
 reset optimizer_trace_fallback;
 reset optimizer_enable_replicated_table;
+
+--
+-- Check sub-selects with distributed replicated tables and volatile functions
+--
+create table t (i int) distributed replicated;
+create table t1 (a int) distributed by (a);
+create table t2 (a int, b float) distributed replicated;
+create or replace function f(i int) returns int language sql security definer as $$ select i; $$;
+-- ensure we make gather motion when volatile functions in subplan
+explain (costs off, verbose) select (select f(i) from t);
+explain (costs off, verbose) select (select f(i) from t group by f(i));
+explain (costs off, verbose) select (select i from t group by i having f(i) > 0);
+-- ensure we do not make broadcast motion
+explain (costs off, verbose) select * from t1 where a in (select random() from t where i=a group by i);
+explain (costs off, verbose) select * from t1 where a in (select random() from t where i=a);
+-- ensure we make broadcast motion when volatile function in deleting motion flow
+explain (costs off, verbose) insert into t2 (a, b) select i, random() from t;
+-- ensure we make broadcast motion when volatile function in correlated subplan qual
+explain (costs off, verbose) select * from t1 where a in (select f(i) from t where i=a and f(i) > 0);
+-- ensure we do not break broadcast motion
+explain (costs off, verbose) select * from t1 where 1 <= ALL (select i from t group by i having random() > 0);
+drop table if exists t;
+drop table if exists t1;
+drop table if exists t2;
+drop function if exists f(i int);
 
 -- start_ignore
 drop schema rpt cascade;


### PR DESCRIPTION
There are several cases in which planner produces bogus plan
for queries to replicated tables with volatile functions,
that may lead to wrong results or even segfault.

1. Volatile function in subplan

Query with subplan containing volatile functions on distributed
replicated tables may not make gather motion. Currently, gpdb
replaces locuses for subplans subtrees to SingleQE in case of they
have SegmentGeneral (i.e. replicated table scan, data is only on segments)
locus and contains volatile functions. But it's incorrect because
SingleQE locus assume that data is available on any segment instance
including coordinator. As a result, there is no reason to add gather motion
above such subtree and the resulting plan will be invalid.

Solution is to make explicit gather motion in such case.

2. Volatile function in modify subplan targret list

Query on distributed replicated tables may not make broadcast motion.
Usually, insert query uses subquery. Volatile functions in such subqueries
are caught in set_subqueryscan_pathlist which adds gather motion for that.
But some subqueries are simplified on early planning stages and subquery
subtree is substituted into main plan (see is_simple_subquery). In such case
we should explicit catch volatile functions before adding ModifyTable node.
To ensure rows are explicitly forwarded to all segments we should replace
subplan locus (with volatile functions) with SingleQE before request motion
append. It is necessary because planner considers pointless to send rows
from replicated tables.

Solution is set CdbLocusType_SingleQE in such cases, that later make
broadcast motion.

3. Volatile function in deleting motion flow

Query containing volatile functions on distributed replicated tables may
not make broadcast motion. This produces wrong plan. This happens, because
apply_motion_mutator delete pre-existing broadcast motion to recreate it later.
But we should save motion request to create appropriate motion above the
child node. Original flow for the child node will be restored after motion creation.

Solution is to save such flow, that later make broadcast motion.

4. Volatile function in correlated subplan quals

Query on distributed replicated tables may not make broadcast motion.
This produces wrong plan. This happens, because broadcast motion does not
made, when volatile function exists. Planner considers pointless to send
rows from replicated tables. But if volatile function exist in quals we
need broadcast motion.

Solution is set CdbLocusType_SingleQE in such cases, that later make
broadcast motion.
