### PR TITLE
docs - update the sql ref pages for ALTER/CREATE/DROP SCHEMA

### DIFF
--- a/gpdb-doc/markdown/ref_guide/sql_commands/ALTER_SCHEMA.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/ALTER_SCHEMA.html.md
@@ -5,9 +5,9 @@ Changes the definition of a schema.
 ## <a id="section2"></a>Synopsis 
 
 ``` {#sql_command_synopsis}
-ALTER SCHEMA <name> RENAME TO <newname>
+ALTER SCHEMA <name> RENAME TO <new_name>
 
-ALTER SCHEMA <name> OWNER TO <newowner>
+ALTER SCHEMA <name> OWNER TO { <new_owner> | CURRENT_USER | SESSION_USER }
 ```
 
 ## <a id="section3"></a>Description 
@@ -21,10 +21,10 @@ You must own the schema to use `ALTER SCHEMA`. To rename a schema you must also 
 name
 :   The name of an existing schema.
 
-newname
+new\_name
 :   The new name of the schema. The new name cannot begin with `pg_`, as such names are reserved for system schemas.
 
-newowner
+new\_owner
 :   The new owner of the schema.
 
 ## <a id="section5"></a>Compatibility 

--- a/gpdb-doc/markdown/ref_guide/sql_commands/DROP_SCHEMA.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/DROP_SCHEMA.html.md
@@ -10,7 +10,9 @@ DROP SCHEMA [IF EXISTS] <name> [, ...] [CASCADE | RESTRICT]
 
 ## <a id="section3"></a>Description 
 
-`DROP SCHEMA` removes schemas from the database. A schema can only be dropped by its owner or a superuser. Note that the owner can drop the schema \(and thereby all contained objects\) even if they do not own some of the objects within the schema.
+`DROP SCHEMA` removes schemas from the database.
+
+A schema can be dropped only by its owner or a superuser. Note that the owner can drop the schema \(and thereby all contained objects\) even if they do not own some of the objects within the schema.
 
 ## <a id="section4"></a>Parameters 
 
@@ -21,10 +23,14 @@ name
 :   The name of the schema to remove.
 
 CASCADE
-:   Automatically drops any objects contained in the schema \(tables, functions, etc.\).
+:   Automatically drop objects \(tables, functions, etc.\) that are contained in the schema, and in turn all objects that depend on those objects
 
 RESTRICT
 :   Refuse to drop the schema if it contains any objects. This is the default.
+
+## <a id="section4a"></a>Notes
+
+Using the `CASCADE` option may result in the command removing objects in other schemas besides the one\(s\) named.
 
 ## <a id="section5"></a>Examples 
 

--- a/gpdb-doc/markdown/ref_guide/sql_commands/DROP_SCHEMA.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/DROP_SCHEMA.html.md
@@ -23,7 +23,7 @@ name
 :   The name of the schema to remove.
 
 CASCADE
-:   Automatically drop objects \(tables, functions, etc.\) that are contained in the schema, and in turn all objects that depend on those objects
+:   Automatically drop objects \(tables, functions, etc.\) that are contained in the schema, and in turn all objects that depend on those objects.
 
 RESTRICT
 :   Refuse to drop the schema if it contains any objects. This is the default.


### PR DESCRIPTION
this PR updates the listed sql command reference pages to align with the postgres v12 ref page content.  there didn't appear to be any greenplum-specific info in the gp6 pages.

doc review site  link for ALTER SCHEMA (behind vpn), can navigate to others from there:  https://docs-staging.vmware.com/en/draft/VMware-Tanzu-Greenplum/sqlref-schema/greenplum-database/GUID-ref_guide-sql_commands-ALTER_SCHEMA.html
