### PR TITLE
Fix a wrong unlock mode in DefineRelation

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -810,7 +810,7 @@ DefineRelation(CreateStmt *stmt, char relkind, Oid ownerId,
 		if (parentrel->rd_rel->relam == accessMethodId)
 			oldoptions = get_rel_opts(parentrel);
 
-		table_close(parentrel, AccessExclusiveLock);
+		table_close(parentrel, AccessShareLock);
 	}
 
 	/*

--- a/src/test/regress/expected/partition_locking.out
+++ b/src/test/regress/expected/partition_locking.out
@@ -78,7 +78,6 @@ select * from locktest_master where coalesce not like 'gp_%' and coalesce not li
      coalesce      |        mode         | locktype |  node  
 -------------------+---------------------+----------+--------
  partlockt         | AccessExclusiveLock | relation | master
- partlockt         | AccessShareLock     | relation | master
  partlockt_1_prt_1 | AccessExclusiveLock | relation | master
  partlockt_1_prt_2 | AccessExclusiveLock | relation | master
  partlockt_1_prt_3 | AccessExclusiveLock | relation | master
@@ -106,13 +105,12 @@ select * from locktest_master where coalesce not like 'gp_%' and coalesce not li
  toast table       | ShareLock           | relation | master
  toast table       | ShareLock           | relation | master
  toast table       | ShareLock           | relation | master
-(29 rows)
+(28 rows)
 
 select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
      coalesce      |        mode         | locktype |    node    
 -------------------+---------------------+----------+------------
  partlockt         | AccessExclusiveLock | relation | n segments
- partlockt         | AccessShareLock     | relation | n segments
  partlockt_1_prt_1 | AccessExclusiveLock | relation | n segments
  partlockt_1_prt_2 | AccessExclusiveLock | relation | n segments
  partlockt_1_prt_3 | AccessExclusiveLock | relation | n segments
@@ -140,7 +138,7 @@ select * from locktest_segments where coalesce not like 'gp_%' and coalesce not 
  toast index       | AccessExclusiveLock | relation | n segments
  toast table       | ShareLock           | relation | n segments
  toast index       | AccessExclusiveLock | relation | n segments
-(29 rows)
+(28 rows)
 
 commit;
 -- drop
@@ -226,7 +224,6 @@ select * from locktest_master where coalesce not like 'gp_%' and coalesce not li
      coalesce      |        mode         | locktype |  node  
 -------------------+---------------------+----------+--------
  partlockt         | AccessExclusiveLock | relation | master
- partlockt         | AccessShareLock     | relation | master
  partlockt_1_prt_1 | AccessExclusiveLock | relation | master
  partlockt_1_prt_2 | AccessExclusiveLock | relation | master
  partlockt_1_prt_3 | AccessExclusiveLock | relation | master
@@ -236,13 +233,12 @@ select * from locktest_master where coalesce not like 'gp_%' and coalesce not li
  toast table       | ShareLock           | relation | master
  toast table       | ShareLock           | relation | master
  toast table       | ShareLock           | relation | master
-(11 rows)
+(10 rows)
 
 select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
      coalesce      |        mode         | locktype |    node    
 -------------------+---------------------+----------+------------
  partlockt         | AccessExclusiveLock | relation | n segments
- partlockt         | AccessShareLock     | relation | n segments
  partlockt_1_prt_1 | AccessExclusiveLock | relation | n segments
  partlockt_1_prt_2 | AccessExclusiveLock | relation | n segments
  partlockt_1_prt_3 | AccessExclusiveLock | relation | n segments
@@ -252,7 +248,7 @@ select * from locktest_segments where coalesce not like 'gp_%' and coalesce not 
  toast index       | AccessExclusiveLock | relation | n segments
  toast table       | ShareLock           | relation | n segments
  toast index       | AccessExclusiveLock | relation | n segments
-(11 rows)
+(10 rows)
 
 commit;
 begin;

--- a/src/test/regress/expected/partition_locking_optimizer.out
+++ b/src/test/regress/expected/partition_locking_optimizer.out
@@ -78,7 +78,6 @@ select * from locktest_master where coalesce not like 'gp_%' and coalesce not li
      coalesce      |        mode         | locktype |  node  
 -------------------+---------------------+----------+--------
  partlockt         | AccessExclusiveLock | relation | master
- partlockt         | AccessShareLock     | relation | master
  partlockt_1_prt_1 | AccessExclusiveLock | relation | master
  partlockt_1_prt_2 | AccessExclusiveLock | relation | master
  partlockt_1_prt_3 | AccessExclusiveLock | relation | master
@@ -106,13 +105,12 @@ select * from locktest_master where coalesce not like 'gp_%' and coalesce not li
  toast table       | ShareLock           | relation | master
  toast table       | ShareLock           | relation | master
  toast table       | ShareLock           | relation | master
-(29 rows)
+(28 rows)
 
 select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
      coalesce      |        mode         | locktype |    node    
 -------------------+---------------------+----------+------------
  partlockt         | AccessExclusiveLock | relation | n segments
- partlockt         | AccessShareLock     | relation | n segments
  partlockt_1_prt_1 | AccessExclusiveLock | relation | n segments
  partlockt_1_prt_2 | AccessExclusiveLock | relation | n segments
  partlockt_1_prt_3 | AccessExclusiveLock | relation | n segments
@@ -140,7 +138,7 @@ select * from locktest_segments where coalesce not like 'gp_%' and coalesce not 
  toast index       | AccessExclusiveLock | relation | n segments
  toast table       | ShareLock           | relation | n segments
  toast index       | AccessExclusiveLock | relation | n segments
-(29 rows)
+(28 rows)
 
 commit;
 -- drop
@@ -226,7 +224,6 @@ select * from locktest_master where coalesce not like 'gp_%' and coalesce not li
      coalesce      |        mode         | locktype |  node  
 -------------------+---------------------+----------+--------
  partlockt         | AccessExclusiveLock | relation | master
- partlockt         | AccessShareLock     | relation | master
  partlockt_1_prt_1 | AccessExclusiveLock | relation | master
  partlockt_1_prt_2 | AccessExclusiveLock | relation | master
  partlockt_1_prt_3 | AccessExclusiveLock | relation | master
@@ -236,13 +233,12 @@ select * from locktest_master where coalesce not like 'gp_%' and coalesce not li
  toast table       | ShareLock           | relation | master
  toast table       | ShareLock           | relation | master
  toast table       | ShareLock           | relation | master
-(11 rows)
+(10 rows)
 
 select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
      coalesce      |        mode         | locktype |    node    
 -------------------+---------------------+----------+------------
  partlockt         | AccessExclusiveLock | relation | n segments
- partlockt         | AccessShareLock     | relation | n segments
  partlockt_1_prt_1 | AccessExclusiveLock | relation | n segments
  partlockt_1_prt_2 | AccessExclusiveLock | relation | n segments
  partlockt_1_prt_3 | AccessExclusiveLock | relation | n segments
@@ -252,7 +248,7 @@ select * from locktest_segments where coalesce not like 'gp_%' and coalesce not 
  toast index       | AccessExclusiveLock | relation | n segments
  toast table       | ShareLock           | relation | n segments
  toast index       | AccessExclusiveLock | relation | n segments
-(11 rows)
+(10 rows)
 
 commit;
 begin;


### PR DESCRIPTION
In commit 0ae9dce7b54f313b88c8306d0640cb45fbebb34c we open table in DefineRelation with AccessShareLock to read its reloptions. But we close it with AccessExclusiveLock which would inadvertently release the AccessExclusiveLock we already held. Fix it now.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
