### PR TITLE
docs - update sql ref pages for ALTER/CREATE/DROP/REFRESH MATERIALIZE…

### DIFF
--- a/gpdb-doc/markdown/ref_guide/sql_commands/ALTER_MATERIALIZED_VIEW.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/ALTER_MATERIALIZED_VIEW.html.md
@@ -6,6 +6,8 @@ Changes the definition of a materialized view.
 
 ``` {#sql_command_synopsis}
 ALTER MATERIALIZED VIEW [ IF EXISTS ] <name> <action> [, ... ]
+ALTER MATERIALIZED VIEW <name>
+    DEPENDS ON EXTENSION <extension_name>
 ALTER MATERIALIZED VIEW [ IF EXISTS ] <name>
     RENAME [ COLUMN ] <column_name> TO <new_column_name>
 ALTER MATERIALIZED VIEW [ IF EXISTS ] <name>
@@ -23,9 +25,10 @@ where <action> is one of:
     ALTER [ COLUMN ] <column_name> SET STORAGE { PLAIN | EXTERNAL | EXTENDED | MAIN }
     CLUSTER ON <index_name>
     SET WITHOUT CLUSTER
+    SET TABLESPACE <new_tablespace>
     SET ( <storage_paramete>r = <value> [, ... ] )
     RESET ( <storage_parameter> [, ... ] )
-    OWNER TO <new_owner>
+    OWNER TO { <new_owner> | CURRENT_USER | SESSION_USER }
 ```
 
 ## <a id="section3"></a>Description 
@@ -33,6 +36,8 @@ where <action> is one of:
 `ALTER MATERIALIZED VIEW` changes various auxiliary properties of an existing materialized view.
 
 You must own the materialized view to use `ALTER MATERIALIZED VIEW`. To change a materialized view's schema, you must also have `CREATE` privilege on the new schema. To alter the owner, you must also be a direct or indirect member of the new owning role, and that role must have `CREATE` privilege on the materialized view's schema. \(These restrictions enforce that altering the owner doesn't do anything you couldn't do by dropping and recreating the materialized view. However, a superuser can alter ownership of any view anyway.\)
+
+The `DEPENDS ON EXTENSION` form marks the materialized view as dependent on an extension, such that the materialized view will automatically be dropped if the extension is dropped.
 
 The statement subforms and actions available for `ALTER MATERIALIZED VIEW` are a subset of those available for `ALTER TABLE`, and have the same meaning when used for materialized views. See the descriptions for [ALTER TABLE](ALTER_TABLE.html) for details.
 
@@ -43,6 +48,9 @@ name
 
 column\_name
 :   Name of a new or existing column.
+
+extension\_name
+:   The name of the extension that the materialized view is to depend on.
 
 new\_column\_name
 :   New name for an existing column.
@@ -58,7 +66,7 @@ new\_schema
 
 ## <a id="section6"></a>Examples 
 
-To rename the materialized view foo to bar:
+To rename the materialized view `foo` to `bar`:
 
 ```
 ALTER MATERIALIZED VIEW foo RENAME TO bar;

--- a/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_MATERIALIZED_VIEW.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_MATERIALIZED_VIEW.html.md
@@ -5,8 +5,9 @@ Defines a new materialized view.
 ## <a id="section1"></a>Synopsis 
 
 ``` {#sql_command_synopsis}
-CREATE MATERIALIZED VIEW <table_name>
+CREATE MATERIALIZED VIEW [ IF  NOT EXISTS ] <table_name>
     [ (<column_name> [, ...] ) ]
+    [ USING <method> ]
     [ WITH ( <storage_parameter> [= <value>] [, ... ] ) ]
     [ TABLESPACE <tablespace_name> ]
     AS <query>
@@ -16,29 +17,35 @@ CREATE MATERIALIZED VIEW <table_name>
 
 ## <a id="section3"></a>Description 
 
-`CREATE MATERIALIZED VIEW` defines a materialized view of a query. The query is run and used to populate the view at the time the command is issued \(unless `WITH NO DATA` is used\) and can be refreshed using `REFRESH MATERIALIZED VIEW`.
+`CREATE MATERIALIZED VIEW` defines a materialized view of a query. The query is run and used to populate the view at the time the command is issued \(unless `WITH NO DATA` is used\) and can be refreshed later using [REFRESH MATERIALIZED VIEW](REFRESH_MATERIALIZED_VIEW.html).
 
-`CREATE MATERIALIZED VIEW` is similar to `CREATE TABLE AS`, except that it also remembers the query used to initialize the view, so that it can be refreshed later upon demand. To refresh materialized view data, use the `REFRESH MATERIALIZED VIEW` command. A materialized view has many of the same properties as a table, but there is no support for temporary materialized views or automatic generation of OIDs.
+`CREATE MATERIALIZED VIEW` is similar to `CREATE TABLE AS`, except that it also remembers the query used to initialize the view, so that it can be refreshed later upon demand. To refresh materialized view data, use the `REFRESH MATERIALIZED VIEW` command. A materialized view has many of the same properties as a table, but there is no support for temporary materialized views.
 
 ## <a id="section4"></a>Parameters 
+
+IF NOT EXISTS
+:   Do not throw an error if a materialized view with the same name already exists. A notice is issued in this case. Note that there is no guarantee that the existing materialized view is anything like the one that would have been created.
 
 table\_name
 :   The name \(optionally schema-qualified\) of the materialized view to be created.
 
 column\_name
-:   The name of a column in the materialized view. The column names are assigned based on position. The first column name is assigned to the first column of the query result, and so on. If a column name is not provided, it is taken from the output column names of the query.
+:   The name of a column in the new materialized view. The column names are assigned based on position. The first column name is assigned to the first column of the query result, and so on. If a column name is not provided, it is taken from the output column names of the query.
+
+USING method
+:   This optional clause specifies the table access method to use to store the contents for the new materialized view; the method needs be an access method of type `TABLE`. If this option is not specified, the default table access method is chosen for the new materialized view. See [default_table_access_method](../config_params/guc-list.html) for more information.
 
 WITH \( storage\_parameter \[= value\] \[, ... \] \)
-:   This clause specifies optional storage parameters for the materialized view. All parameters supported for `CREATE TABLE` are also supported for `CREATE MATERIALIZED VIEW` with the exception of OIDS. See [CREATE TABLE](CREATE_TABLE.html) for more information.
+:   This clause specifies optional storage parameters for the materialized view. All parameters supported for `CREATE TABLE` are also supported for `CREATE MATERIALIZED VIEW`. See [CREATE TABLE](CREATE_TABLE.html) for more information.
 
 TABLESPACE tablespace\_name
 :   The tablespace\_name is the name of the tablespace in which the new materialized view is to be created. If not specified, server configuration parameter [default\_tablespace](../config_params/guc-list.html) is consulted.
 
 query
-:   A [SELECT](SELECT.html) or [VALUES](VALUES.html) command. This query will run within a security-restricted operation; in particular, calls to functions that themselves create temporary tables will fail.
+:   A [SELECT](SELECT.html), [TABLE](https://www.postgresql.org/docs/12/sql-select.html#SQL-TABLE), or [VALUES](VALUES.html) command. This query will run within a security-restricted operation; in particular, calls to functions that themselves create temporary tables will fail.
 
 WITH \[ NO \] DATA
-:   This clause specifies whether or not the materialized view should be populated with data at creation time. `WITH DATA` is the default, populate the materialized view. For `WITH NO DATA`, the materialized view is not populated with data, is flagged as unscannable, and cannot be queried until `REFRESH MATERIALIZED VIEW` is used to populate the materialized view. An error is returned if a query attempts to access an unscannable materialized view.
+:   This clause specifies whether or not the materialized view should be populated with data at creation time. `WITH DATA` is the default, populate the materialized view. For `WITH NO DATA`, the materialized view is not populated with data, is flagged as unscannable, and cannot be queried until `REFRESH MATERIALIZED VIEW` is used to populate the materialized view.
 
 DISTRIBUTED BY \(column \[opclass\], \[ ... \] \)
 DISTRIBUTED RANDOMLY

--- a/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_MATERIALIZED_VIEW.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_MATERIALIZED_VIEW.html.md
@@ -42,7 +42,7 @@ TABLESPACE tablespace\_name
 :   The tablespace\_name is the name of the tablespace in which the new materialized view is to be created. If not specified, server configuration parameter [default\_tablespace](../config_params/guc-list.html) is consulted.
 
 query
-:   A [SELECT](SELECT.html), [TABLE](https://www.postgresql.org/docs/12/sql-select.html#SQL-TABLE), or [VALUES](VALUES.html) command. This query will run within a security-restricted operation; in particular, calls to functions that themselves create temporary tables will fail.
+:   A [SELECT](SELECT.html), [TABLE](SELECT.html#table-command), or [VALUES](VALUES.html) command. This query will run within a security-restricted operation; in particular, calls to functions that themselves create temporary tables will fail.
 
 WITH \[ NO \] DATA
 :   This clause specifies whether or not the materialized view should be populated with data at creation time. `WITH DATA` is the default, populate the materialized view. For `WITH NO DATA`, the materialized view is not populated with data, is flagged as unscannable, and cannot be queried until `REFRESH MATERIALIZED VIEW` is used to populate the materialized view.

--- a/gpdb-doc/markdown/ref_guide/sql_commands/DROP_MATERIALIZED_VIEW.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/DROP_MATERIALIZED_VIEW.html.md
@@ -21,7 +21,7 @@ name
 :   The name \(optionally schema-qualified\) of a materialized view to be dropped.
 
 CASCADE
-:   Automatically drop objects that depend on the materialized view \(such as other materialized views, or regular views\).
+:   Automatically drop objects that depend on the materialized view \(such as other materialized views, or regular views\), and in turn all objects that depend on those objects.
 
 RESTRICT
 :   Refuse to drop the materialized view if any objects depend on it. This is the default.

--- a/gpdb-doc/markdown/ref_guide/sql_commands/REFRESH_MATERIALIZED_VIEW.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/REFRESH_MATERIALIZED_VIEW.html.md
@@ -11,30 +11,28 @@ REFRESH MATERIALIZED VIEW [ CONCURRENTLY ] <name>
 
 ## <a id="section3"></a>Description 
 
-`REFRESH MATERIALIZED VIEW` completely replaces the contents of a materialized view. The old contents are discarded. To run this command you must be the owner of the materialized view. With the default, `WITH DATA`, the materialized view query is run to provide the new data, and the materialized view is left in a scannable state. If `WITH NO DATA` is specified, no new data is generated and the materialized view is left in an unscannable state. A query returns an error if the query attempts to access the materialized view.
+`REFRESH MATERIALIZED VIEW` completely replaces the contents of a materialized view. The old contents are discarded. To run this command you must be the owner of the materialized view. If `WITH DATA` is specified \(or defaults\), the backing query is executed to provide the new data, and the materialized view is left in a scannable state. If `WITH NO DATA` is specified, no new data is generated, and the materialized view is left in an unscannable state.
+
+You may not specify `CONCURRENTLY` and `WITH NO DATA` together.
 
 ## <a id="section4"></a>Parameters 
 
 CONCURRENTLY
 :   Refresh the materialized view without locking out concurrent selects on the materialized view. Without this option, a refresh that affects a lot of rows tends to use fewer resources and completes more quickly, but could block other connections which are trying to read from the materialized view. This option might be faster in cases where a small number of rows are affected.
-
-    This option is only allowed if there is at least one `UNIQUE` index on the materialized view which uses only column names and includes all rows; that is, it must not index on any expressions nor include a `WHERE` clause.
-
-    This option cannot be used when the materialized view is not already populated, and it cannot be used with the `WITH NO DATA` clause.
-
-    Even with this option, only one `REFRESH` at a time may run against any one materialized view.
+:   This option is only allowed if there is at least one `UNIQUE` index on the materialized view which uses only column names and includes all rows; that is, it must not index on any expressions nor include a `WHERE` clause.
+:   You can not use this option when the materialized view is not already populated.
+:   Even with this option, only one `REFRESH` at a time may run against any one materialized view.
 
 name
 :   The name \(optionally schema-qualified\) of the materialized view to refresh.
 
 WITH \[ NO \] DATA
-:   `WITH DATA` is the default and specifies that the materialized view query is run to provide new data, and the materialized view is left in a scannable state. If `WITH NO DATA` is specified, no new data is generated and the materialized view is left in an unscannable state. An error is returned if a query attempts to access an unscannable materialized view.
-
-:   `WITH NO DATA` cannot be used with `CONCURRENTLY`.
+:   `WITH DATA` is the default and specifies that the materialized view query is run to provide new data, and the materialized view is left in a scannable state. If `WITH NO DATA` is specified, no new data is generated and the materialized view is left in an unscannable state.
 
 ## <a id="section5"></a>Notes 
 
-While the default index for future [CLUSTER](CLUSTER.html) operations is retained, `REFRESH MATERIALIZED VIEW` does not order the generated rows based on this property. If you want the data to be ordered upon generation, you must use an `ORDER BY` clause in the materialized view query. However, if a materialized view query contains an `ORDER BY` or `SORT` clause, the data is not guaranteed to be ordered or sorted if `SELECT` is performed on the materialized view.
+If there is an `ORDER BY` clause in the materialized view's defining query, the original contents of the materialized view will be ordered that way; but `REFRESH MATERIALIZED VIEW` does not guarantee to preserve that ordering.
+
 
 ## <a id="section6"></a>Examples 
 


### PR DESCRIPTION
…D VIEW

this PR updates the listed sql command reference pages to align with the postgres v12 ref page content. i didn't notice any greenplum-specific info on the v6 pages.

notes/questions:
1.  the CREATE page xrefs to the default_table_access_method guc. the guc ref is in PR now, i will update the link after it is merged.
2.  the CREATE page xrefs to postgres docs for TABLE command (https://www.postgresql.org/docs/12/sql-select.html#SQL-TABLE).  should i bring this content into the greenplum docs?
3.  the Notes section on the CREATE page is not present in the postgres v12 docs, and the content doesn't seem greenplum-specific.
4.  is greenplum 7 support for materialized views equivalent to postgres?  if not, are there any greenplum limitations?

doc review site link for ALTER MATERIALIZED VIEW (behind vpn), can navigate to others from there: https://docs-staging.vmware.com/en/draft/VMware-Tanzu-Greenplum/sqlref-matview/greenplum-database/GUID-ref_guide-sql_commands-ALTER_MATERIALIZED_VIEW.html
