### PR TITLE
Fix CBitSet Intersection logic in Orca

### DIFF
--- a/src/backend/gporca/data/dxl/minidump/NestedInSubqWithPrjListOuterRefNoInnerRef.mdp
+++ b/src/backend/gporca/data/dxl/minidump/NestedInSubqWithPrjListOuterRefNoInnerRef.mdp
@@ -699,7 +699,7 @@ EXPLAIN SELECT * FROM foo WHERE foo.a IN (SELECT foo.b + 1 FROM (SELECT * FROM b
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="6496">
+    <dxl:Plan Id="0" SpaceSize="6340">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="2155.006784" Rows="40.000000" Width="8"/>

--- a/src/backend/gporca/libgpos/server/src/unittest/gpos/common/CBitSetTest.cpp
+++ b/src/backend/gporca/libgpos/server/src/unittest/gpos/common/CBitSetTest.cpp
@@ -204,6 +204,19 @@ CBitSetTest::EresUnittest_SetOps()
 
 	pbs->Release();
 
+	// Test that intersection properly deletes links
+	CBitSet *pbs4 = GPOS_NEW(mp) CBitSet(mp, vector_size);
+	CBitSet *pbs5 = GPOS_NEW(mp) CBitSet(mp, vector_size);
+	pbs4->ExchangeSet(1);
+	pbs5->ExchangeSet(10);
+	pbs5->ExchangeSet(50);
+	pbs4->Intersection(pbs5);
+	pbs5->ExchangeClear(10);
+	pbs5->ExchangeClear(50);
+	GPOS_ASSERT(pbs4->Equals(pbs5));
+
+	pbs4->Release();
+	pbs5->Release();
 	return GPOS_OK;
 }
 

--- a/src/backend/gporca/libgpos/src/common/CBitSet.cpp
+++ b/src/backend/gporca/libgpos/src/common/CBitSet.cpp
@@ -436,7 +436,17 @@ CBitSet::Intersection(const CBitSet *pbsOther)
 		if (nullptr != bsl_other && bsl_other->GetOffset() == bsl->GetOffset())
 		{
 			bsl->GetVec()->And(bsl_other->GetVec());
+			CBitSetLink *bsl_prev = bsl;
+
 			bsl = m_bsllist.Next(bsl);
+			// If vector is empty after "ANDing", remove the vector, otherwise
+			// we can get into a situation where an empty vector exists
+			// and causes wrong results for equals/contains operations later
+			if (bsl_prev->GetVec()->IsEmpty())
+			{
+				m_bsllist.Remove(bsl_prev);
+				GPOS_DELETE(bsl_prev);
+			}
 		}
 		else
 		{


### PR DESCRIPTION
There was a corner case where intersecting a bitset A with bitset B, where A had elements in a vector that did not exist in B, would cause bitset A to have a size of 0, but still have a bitvector. This was an undefined and unexpected state. We assume that bitvectors in a bitset are non-empty, and breaking this assumption causes operations such as Equals() and Contains() to produce wrong results. In this case, it led to Orca failing to produce a plan since required columns did not satisfy the Contains() method.

This is a VERY hot codepath, bitset operations are heavily used in Orca and isEmpty requires iterating through the bitvector. I ran this through some performance tests and didn't see any decrease in performance.