### PR TITLE
Properly set memory limit for Share Input Scan

### DIFF
--- a/src/backend/executor/nodeShareInputScan.c
+++ b/src/backend/executor/nodeShareInputScan.c
@@ -235,7 +235,7 @@ init_tuplestore_state(ShareInputScanState *node)
 
 				ts = tuplestore_begin_heap(true, /* randomAccess */
 										   false, /* interXact */
-										   10); /* maxKBytes FIXME */
+										   PlanStateOperatorMemKB((PlanState *) node)); /* maxKBytes */
 
 				shareinput_create_bufname_prefix(rwfile_prefix, sizeof(rwfile_prefix), sisc->share_id);
 				tuplestore_make_shared(ts,


### PR DESCRIPTION
When creating a tuplestore for Share Input Scan, we should cap the tuplestore's memory limit using either the global work_mem or the operator's memory limit.

This addresses a FIXME introduced by PG12 merge.

Reported-by: Xin Zhang <xinzweb@users.noreply.github.com>
