### PR TITLE
(WIP)Add multi-thread compression and transmission from gpfdist to gpdb7

### DIFF
--- a/src/backend/access/external/url_curl.c
+++ b/src/backend/access/external/url_curl.c
@@ -1965,13 +1965,14 @@ gp_proto0_write(URL_CURL_FILE *file, CopyState pstate)
 {	
 	char*		buf;
 	int		nbytes;
-	if(file->zstd){
 #ifdef USE_ZSTD
+	if(file->zstd){
 		nbytes = compress_zstd_data(file);
 		buf = file->out.cptr;
-#endif
 	}
-	else{
+	else
+#endif
+	{
 		buf = file->out.ptr;
 	 	nbytes = file->out.top;
 	}
@@ -2075,11 +2076,14 @@ curl_fwrite(char *buf, int nbytes, URL_CURL_FILE *file, CopyState pstate)
 			if (!newbuf)
 				elog(ERROR, "out of memory (curl_fwrite)");
 			file->out.ptr = newbuf;
-
-			newbuf = repalloc(file->out.cptr, n);
-			if (!newbuf)
-				elog(ERROR, "out of compress memory (curl_fwrite)");
-			file->out.cptr = newbuf;
+			
+			if (file->zstd) 
+			{
+				newbuf = repalloc(file->out.cptr, n);
+				if (!newbuf)
+					elog(ERROR, "out of compress memory (curl_fwrite)");
+				file->out.cptr = newbuf;
+			}
 
 			file->out.max = n;
 

--- a/src/backend/access/external/url_curl.c
+++ b/src/backend/access/external/url_curl.c
@@ -1491,6 +1491,10 @@ url_curl_fclose(URL_FILE *fileg, bool failOnError, const char *relname)
 	memset(&file->block, 0, sizeof(file->block));
 
 	pfree(file->common.url);
+#ifdef USE_ZSTD
+	if (file->zstd)
+		ZSTD_freeDCtx(file->zstd_dctx);
+#endif
 
 	pfree(file);
 }

--- a/src/backend/access/external/url_curl.c
+++ b/src/backend/access/external/url_curl.c
@@ -1274,6 +1274,9 @@ url_curl_fopen(char *url, bool forwrite, extvar_t *ev, CopyState pstate)
 	set_httpheader(file, "X-GP-SEGMENT-COUNT", ev->GP_SEGMENT_COUNT);
 	set_httpheader(file, "X-GP-LINE-DELIM-STR", ev->GP_LINE_DELIM_STR);
 	set_httpheader(file, "X-GP-LINE-DELIM-LENGTH", ev->GP_LINE_DELIM_LENGTH);
+#ifdef USE_ZSTD
+		set_httpheader(file, "X-GP-ZSTD", "1");
+#endif
 
 	if (forwrite)
 	{
@@ -1289,13 +1292,11 @@ url_curl_fopen(char *url, bool forwrite, extvar_t *ev, CopyState pstate)
 		set_httpheader(file, "X-GP-PROTO", "0");
 		set_httpheader(file, "X-GP-SEQ", "1");
 		set_httpheader(file, "Content-Type", "text/xml");
-		set_httpheader(file, "X-GP-ZSTD", "1");
 	}
 	else
 	{
 		/* read specific - (TODO: unclear why some of these are needed) */
 		set_httpheader(file, "X-GP-PROTO", "1");
-		set_httpheader(file, "X-GP-ZSTD", "1");
 		set_httpheader(file, "X-GP-MASTER_HOST", ev->GP_MASTER_HOST);
 		set_httpheader(file, "X-GP-MASTER_PORT", ev->GP_MASTER_PORT);
 		set_httpheader(file, "X-GP-CSVOPT", ev->GP_CSVOPT);
@@ -1870,7 +1871,6 @@ gp_proto0_write(URL_CURL_FILE *file, CopyState pstate)
 		buf = file->out.ptr;
 	 	nbytes = file->out.top;
 	}
-	
 
 	if (nbytes == 0)
 		return;

--- a/src/bin/gpfdist/gpfdist.c
+++ b/src/bin/gpfdist/gpfdist.c
@@ -3224,6 +3224,10 @@ static void handle_post_request(request_t *r, int header_end)
 				return;
 			}
 		}
+		if (r->zstd) 
+		{
+			r->in.cflag = data_bytes_in_req;
+		}
 	}
 
 	/*

--- a/src/bin/gpfdist/gpfdist.c
+++ b/src/bin/gpfdist/gpfdist.c
@@ -3207,13 +3207,13 @@ static void handle_post_request(request_t *r, int header_end)
 			want = r->in.davailable;
 
 		/* read from socket into data buf */
-		if (r->zstd && !r->in.cflag)
-		{
-			n = gpfdist_receive(r, r->in.cbuf + r->in.cbuftop, want);
-		}
-		else
+		if (!r->zstd) 
 		{
 			n = gpfdist_receive(r, r->in.dbuf + r->in.dbuftop, want);
+		} 
+		else if (!r->in.cflag)
+		{
+			n = gpfdist_receive(r, r->in.cbuf + r->in.cbuftop, want);
 		}
 
 		if (n < 0)

--- a/src/bin/gpfdist/regress/input/gpfdist2_compress.source
+++ b/src/bin/gpfdist/regress/input/gpfdist2_compress.source
@@ -55,7 +55,69 @@ FORMAT 'text'
         DELIMITER AS '|'
 )
 ;
+CREATE TABLE lineitem (like ext_lineitem);
 SELECT count(*) FROM ext_lineitem;
+INSERT INTO lineitem SELECT * FROM ext_lineitem;
+DROP EXTERNAL TABLE ext_lineitem;
+--test 1.1 test writable table using compression
+CREATE WRITABLE EXTERNAL TABLE ext_lineitem_w (
+                L_ORDERKEY INT8,
+                L_PARTKEY INTEGER,
+                L_SUPPKEY INTEGER,
+                L_LINENUMBER integer,
+                L_QUANTITY decimal,
+                L_EXTENDEDPRICE decimal,
+                L_DISCOUNT decimal,
+                L_TAX decimal,
+                L_RETURNFLAG CHAR(1),
+                L_LINESTATUS CHAR(1),
+                L_SHIPDATE date,
+                L_COMMITDATE date,
+                L_RECEIPTDATE date,
+                L_SHIPINSTRUCT CHAR(25),
+                L_SHIPMODE CHAR(10),
+                L_COMMENT VARCHAR(44)
+                )
+LOCATION
+(
+      'gpfdist://@hostname@:7070/gpfdist2/lineitem.tbl.w'
+)
+FORMAT 'text'
+(
+        DELIMITER AS '|'
+)
+;
+CREATE EXTERNAL TABLE ext_lineitem (
+                L_ORDERKEY INT8,
+                L_PARTKEY INTEGER,
+                L_SUPPKEY INTEGER,
+                L_LINENUMBER integer,
+                L_QUANTITY decimal,
+                L_EXTENDEDPRICE decimal,
+                L_DISCOUNT decimal,
+                L_TAX decimal,
+                L_RETURNFLAG CHAR(1),
+                L_LINESTATUS CHAR(1),
+                L_SHIPDATE date,
+                L_COMMITDATE date,
+                L_RECEIPTDATE date,
+                L_SHIPINSTRUCT CHAR(25),
+                L_SHIPMODE CHAR(10),
+                L_COMMENT VARCHAR(44)
+                )
+LOCATION
+(
+      'gpfdist://@hostname@:7070/gpfdist2/lineitem.tbl.w'
+)
+FORMAT 'text'
+(
+        DELIMITER AS '|'
+)
+;
+INSERT INTO ext_lineitem_w SELECT * FROM lineitem;
+DROP TABLE lineitem;
+SELECT count(*) FROM ext_lineitem;
+DROP EXTERNAL TABLE ext_lineitem_w;
 DROP EXTERNAL TABLE ext_lineitem;
 
 -- test 2 use a bigger file.
@@ -193,7 +255,6 @@ FORMAT 'text'
 ;
 SELECT count(*) FROM ext_lineitem;
 DROP EXTERNAL TABLE ext_lineitem;
-
 -- test 2 use a bigger file.
 
 CREATE EXTERNAL TABLE ext_lineitem (

--- a/src/bin/gpfdist/regress/input/gpfdist2_compress.source
+++ b/src/bin/gpfdist/regress/input/gpfdist2_compress.source
@@ -269,6 +269,60 @@ FORMAT 'text'
 ;
 SELECT count(*) FROM ext_lineitem;
 DROP EXTERNAL TABLE ext_lineitem;
+-- test 2 use a bigger file.
+
+CREATE EXTERNAL TABLE ext_lineitem (
+                L_ORDERKEY INT8,
+                L_PARTKEY INTEGER,
+                L_SUPPKEY INTEGER,
+                L_LINENUMBER integer,
+                L_QUANTITY decimal,
+                L_EXTENDEDPRICE decimal,
+                L_DISCOUNT decimal,
+                L_TAX decimal,
+                L_RETURNFLAG CHAR(1),
+                L_LINESTATUS CHAR(1),
+                L_SHIPDATE date,
+                L_COMMITDATE date,
+                L_RECEIPTDATE date,
+                L_SHIPINSTRUCT CHAR(25),
+                L_SHIPMODE CHAR(10),
+                L_COMMENT VARCHAR(44)
+                )
+LOCATION
+(
+        'gpfdist://@hostname@:7070/gpfdist2/lineitem.tbl.long'
+)
+FORMAT 'text'
+(
+        DELIMITER AS '|'
+)
+;
+SELECT count(*) FROM ext_lineitem;
+DROP EXTERNAL TABLE ext_lineitem;
+
+-- test 3 line too long with defaults
+
+CREATE EXTERNAL TABLE ext_test (
+                id text,
+                stuff text
+                )
+LOCATION
+(
+      'gpfdist://@hostname@:7070/gpfdist2/longline.txt'
+)
+FORMAT 'text'
+(
+        DELIMITER AS ','
+) LOG ERRORS SEGMENT REJECT LIMIT 2
+;
+SELECT count(*) FROM ext_test;
+DROP EXTERNAL TABLE ext_test;
+
+--test 4 using csv data
+CREATE EXTERNAL TABLE ext_crlf_with_lf_column(c1 int, c2 text) LOCATION ('gpfdist://@hostname@:7070/gpfdist2/crlf_with_lf_column.csv') FORMAT 'csv' (NEWLINE 'CRLF');
+SELECT count(*) FROM ext_crlf_with_lf_column;
+DROP EXTERNAL TABLE ext_crlf_with_lf_column;
 
 -- start_ignore
 select * from gpfdist2_stop;
@@ -372,3 +426,134 @@ DROP EXTERNAL TABLE ext_test;
 CREATE EXTERNAL TABLE ext_crlf_with_lf_column(c1 int, c2 text) LOCATION ('gpfdist://@hostname@:7070/gpfdist2/crlf_with_lf_column.csv') FORMAT 'csv' (NEWLINE 'CRLF');
 SELECT count(*) FROM ext_crlf_with_lf_column;
 DROP EXTERNAL TABLE ext_crlf_with_lf_column;
+
+-- start_ignore
+select * from gpfdist2_stop;
+-- end_ignore
+
+--test multi-thread transmission start
+DROP EXTERNAL WEB TABLE IF EXISTS gpfdist2_start;
+
+CREATE EXTERNAL WEB TABLE gpfdist2_start (x text)
+execute E'((@bindir@/gpfdist -p 7070 -d @abs_srcdir@/data --mthread </dev/null >/dev/null 2>&1 &); for i in `seq 1 30`; do curl 127.0.0.1:7070 >/dev/null 2>&1 && break; sleep 1; done; echo "starting...") '
+on SEGMENT 0
+FORMAT 'text' (delimiter '|');
+
+-- start_ignore
+select * from gpfdist2_start;
+-- end_ignore
+
+-- test 2 use a bigger file.
+
+CREATE EXTERNAL TABLE ext_lineitem (
+                L_ORDERKEY INT8,
+                L_PARTKEY INTEGER,
+                L_SUPPKEY INTEGER,
+                L_LINENUMBER integer,
+                L_QUANTITY decimal,
+                L_EXTENDEDPRICE decimal,
+                L_DISCOUNT decimal,
+                L_TAX decimal,
+                L_RETURNFLAG CHAR(1),
+                L_LINESTATUS CHAR(1),
+                L_SHIPDATE date,
+                L_COMMITDATE date,
+                L_RECEIPTDATE date,
+                L_SHIPINSTRUCT CHAR(25),
+                L_SHIPMODE CHAR(10),
+                L_COMMENT VARCHAR(44)
+                )
+LOCATION
+(
+        'gpfdist://@hostname@:7070/gpfdist2/lineitem.tbl.long'
+)
+FORMAT 'text'
+(
+        DELIMITER AS '|'
+)
+;
+SELECT count(*) FROM ext_lineitem;
+DROP EXTERNAL TABLE ext_lineitem;
+
+-- start_ignore
+select * from gpfdist2_stop;
+-- end_ignore
+
+--test multi-thread compression and transmission with bigger buffer start
+DROP EXTERNAL WEB TABLE IF EXISTS gpfdist2_start;
+
+CREATE EXTERNAL WEB TABLE gpfdist2_start (x text)
+execute E'((@bindir@/gpfdist -p 7070 -d @abs_srcdir@/data --compress -m 1200000 --mthread </dev/null >/dev/null 2>&1 &); for i in `seq 1 30`; do curl 127.0.0.1:7070 >/dev/null 2>&1 && break; sleep 1; done; echo "starting...") '
+on SEGMENT 0
+FORMAT 'text' (delimiter '|');
+
+-- start_ignore
+select * from gpfdist2_start;
+-- end_ignore
+
+-- test 1 using a little file
+
+CREATE EXTERNAL TABLE ext_lineitem (
+                L_ORDERKEY INT8,
+                L_PARTKEY INTEGER,
+                L_SUPPKEY INTEGER,
+                L_LINENUMBER integer,
+                L_QUANTITY decimal,
+                L_EXTENDEDPRICE decimal,
+                L_DISCOUNT decimal,
+                L_TAX decimal,
+                L_RETURNFLAG CHAR(1),
+                L_LINESTATUS CHAR(1),
+                L_SHIPDATE date,
+                L_COMMITDATE date,
+                L_RECEIPTDATE date,
+                L_SHIPINSTRUCT CHAR(25),
+                L_SHIPMODE CHAR(10),
+                L_COMMENT VARCHAR(44)
+                )
+LOCATION
+(
+      'gpfdist://@hostname@:7070/gpfdist2/lineitem.tbl'
+)
+FORMAT 'text'
+(
+        DELIMITER AS '|'
+)
+;
+SELECT count(*) FROM ext_lineitem;
+DROP EXTERNAL TABLE ext_lineitem;
+-- test 2 use a bigger file.
+
+CREATE EXTERNAL TABLE ext_lineitem (
+                L_ORDERKEY INT8,
+                L_PARTKEY INTEGER,
+                L_SUPPKEY INTEGER,
+                L_LINENUMBER integer,
+                L_QUANTITY decimal,
+                L_EXTENDEDPRICE decimal,
+                L_DISCOUNT decimal,
+                L_TAX decimal,
+                L_RETURNFLAG CHAR(1),
+                L_LINESTATUS CHAR(1),
+                L_SHIPDATE date,
+                L_COMMITDATE date,
+                L_RECEIPTDATE date,
+                L_SHIPINSTRUCT CHAR(25),
+                L_SHIPMODE CHAR(10),
+                L_COMMENT VARCHAR(44)
+                )
+LOCATION
+(
+        'gpfdist://@hostname@:7070/gpfdist2/lineitem.tbl.long'
+)
+FORMAT 'text'
+(
+        DELIMITER AS '|'
+)
+;
+SELECT count(*) FROM ext_lineitem;
+DROP EXTERNAL TABLE ext_lineitem;
+
+-- start_ignore
+select * from gpfdist2_stop;
+-- end_ignore

--- a/src/bin/gpfdist/regress/input/gpfdist2_compress.source
+++ b/src/bin/gpfdist/regress/input/gpfdist2_compress.source
@@ -149,7 +149,70 @@ FORMAT 'text'
         DELIMITER AS '|'
 )
 ;
+CREATE TABLE lineitem (like ext_lineitem);
 SELECT count(*) FROM ext_lineitem;
+INSERT INTO lineitem SELECT * FROM ext_lineitem;
+DROP EXTERNAL TABLE ext_lineitem;
+
+--test 2.1 test writable table using compression with big data
+CREATE WRITABLE EXTERNAL TABLE ext_lineitem_w (
+                L_ORDERKEY INT8,
+                L_PARTKEY INTEGER,
+                L_SUPPKEY INTEGER,
+                L_LINENUMBER integer,
+                L_QUANTITY decimal,
+                L_EXTENDEDPRICE decimal,
+                L_DISCOUNT decimal,
+                L_TAX decimal,
+                L_RETURNFLAG CHAR(1),
+                L_LINESTATUS CHAR(1),
+                L_SHIPDATE date,
+                L_COMMITDATE date,
+                L_RECEIPTDATE date,
+                L_SHIPINSTRUCT CHAR(25),
+                L_SHIPMODE CHAR(10),
+                L_COMMENT VARCHAR(44)
+                )
+LOCATION
+(
+      'gpfdist://@hostname@:7070/gpfdist2/lineitem.tbl.w'
+)
+FORMAT 'text'
+(
+        DELIMITER AS '|'
+)
+;
+CREATE EXTERNAL TABLE ext_lineitem (
+                L_ORDERKEY INT8,
+                L_PARTKEY INTEGER,
+                L_SUPPKEY INTEGER,
+                L_LINENUMBER integer,
+                L_QUANTITY decimal,
+                L_EXTENDEDPRICE decimal,
+                L_DISCOUNT decimal,
+                L_TAX decimal,
+                L_RETURNFLAG CHAR(1),
+                L_LINESTATUS CHAR(1),
+                L_SHIPDATE date,
+                L_COMMITDATE date,
+                L_RECEIPTDATE date,
+                L_SHIPINSTRUCT CHAR(25),
+                L_SHIPMODE CHAR(10),
+                L_COMMENT VARCHAR(44)
+                )
+LOCATION
+(
+      'gpfdist://@hostname@:7070/gpfdist2/lineitem.tbl.w'
+)
+FORMAT 'text'
+(
+        DELIMITER AS '|'
+)
+;
+INSERT INTO ext_lineitem_w SELECT * FROM lineitem;
+DROP TABLE lineitem;
+SELECT count(*) FROM ext_lineitem;
+DROP EXTERNAL TABLE ext_lineitem_w;
 DROP EXTERNAL TABLE ext_lineitem;
 
 -- test 3 line too long with defaults

--- a/src/bin/gpfdist/regress/output/gpfdist2_compress.source
+++ b/src/bin/gpfdist/regress/output/gpfdist2_compress.source
@@ -61,12 +61,80 @@ FORMAT 'text'
         DELIMITER AS '|'
 )
 ;
+CREATE TABLE lineitem (like ext_lineitem);
+NOTICE:  table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 SELECT count(*) FROM ext_lineitem;
  count 
 -------
    256
 (1 row)
 
+INSERT INTO lineitem SELECT * FROM ext_lineitem;
+DROP EXTERNAL TABLE ext_lineitem;
+--test 1.1 test writable table using compression
+CREATE WRITABLE EXTERNAL TABLE ext_lineitem_w (
+                L_ORDERKEY INT8,
+                L_PARTKEY INTEGER,
+                L_SUPPKEY INTEGER,
+                L_LINENUMBER integer,
+                L_QUANTITY decimal,
+                L_EXTENDEDPRICE decimal,
+                L_DISCOUNT decimal,
+                L_TAX decimal,
+                L_RETURNFLAG CHAR(1),
+                L_LINESTATUS CHAR(1),
+                L_SHIPDATE date,
+                L_COMMITDATE date,
+                L_RECEIPTDATE date,
+                L_SHIPINSTRUCT CHAR(25),
+                L_SHIPMODE CHAR(10),
+                L_COMMENT VARCHAR(44)
+                )
+LOCATION
+(
+      'gpfdist://@hostname@:7070/gpfdist2/lineitem.tbl.w'
+)
+FORMAT 'text'
+(
+        DELIMITER AS '|'
+)
+;
+CREATE EXTERNAL TABLE ext_lineitem (
+                L_ORDERKEY INT8,
+                L_PARTKEY INTEGER,
+                L_SUPPKEY INTEGER,
+                L_LINENUMBER integer,
+                L_QUANTITY decimal,
+                L_EXTENDEDPRICE decimal,
+                L_DISCOUNT decimal,
+                L_TAX decimal,
+                L_RETURNFLAG CHAR(1),
+                L_LINESTATUS CHAR(1),
+                L_SHIPDATE date,
+                L_COMMITDATE date,
+                L_RECEIPTDATE date,
+                L_SHIPINSTRUCT CHAR(25),
+                L_SHIPMODE CHAR(10),
+                L_COMMENT VARCHAR(44)
+                )
+LOCATION
+(
+      'gpfdist://@hostname@:7070/gpfdist2/lineitem.tbl.w'
+)
+FORMAT 'text'
+(
+        DELIMITER AS '|'
+)
+;
+INSERT INTO ext_lineitem_w SELECT * FROM lineitem;
+DROP TABLE lineitem;
+SELECT count(*) FROM ext_lineitem;
+ count 
+-------
+   256
+(1 row)
+
+DROP EXTERNAL TABLE ext_lineitem_w;
 DROP EXTERNAL TABLE ext_lineitem;
 -- test 2 use a bigger file.
 CREATE EXTERNAL TABLE ext_lineitem (

--- a/src/bin/gpfdist/regress/output/gpfdist2_compress.source
+++ b/src/bin/gpfdist/regress/output/gpfdist2_compress.source
@@ -423,3 +423,160 @@ SELECT count(*) FROM ext_crlf_with_lf_column;
 (1 row)
 
 DROP EXTERNAL TABLE ext_crlf_with_lf_column;
+-- start_ignore
+select * from gpfdist2_stop;
+      x      
+-------------
+ stopping...
+(1 row)
+
+-- end_ignore
+--test multi-thread transmission start
+DROP EXTERNAL WEB TABLE IF EXISTS gpfdist2_start;
+CREATE EXTERNAL WEB TABLE gpfdist2_start (x text)
+execute E'((@bindir@/gpfdist -p 7070 -d @abs_srcdir@/data --mthread </dev/null >/dev/null 2>&1 &); for i in `seq 1 30`; do curl 127.0.0.1:7070 >/dev/null 2>&1 && break; sleep 1; done; echo "starting...") '
+on SEGMENT 0
+FORMAT 'text' (delimiter '|');
+-- start_ignore
+select * from gpfdist2_start;
+      x      
+-------------
+ starting...
+(1 row)
+
+-- end_ignore
+-- test 2 use a bigger file.
+CREATE EXTERNAL TABLE ext_lineitem (
+                L_ORDERKEY INT8,
+                L_PARTKEY INTEGER,
+                L_SUPPKEY INTEGER,
+                L_LINENUMBER integer,
+                L_QUANTITY decimal,
+                L_EXTENDEDPRICE decimal,
+                L_DISCOUNT decimal,
+                L_TAX decimal,
+                L_RETURNFLAG CHAR(1),
+                L_LINESTATUS CHAR(1),
+                L_SHIPDATE date,
+                L_COMMITDATE date,
+                L_RECEIPTDATE date,
+                L_SHIPINSTRUCT CHAR(25),
+                L_SHIPMODE CHAR(10),
+                L_COMMENT VARCHAR(44)
+                )
+LOCATION
+(
+        'gpfdist://@hostname@:7070/gpfdist2/lineitem.tbl.long'
+)
+FORMAT 'text'
+(
+        DELIMITER AS '|'
+)
+;
+SELECT count(*) FROM ext_lineitem;
+ count  
+--------
+ 100000
+(1 row)
+
+DROP EXTERNAL TABLE ext_lineitem;
+-- start_ignore
+select * from gpfdist2_stop;
+      x      
+-------------
+ stopping...
+(1 row)
+
+-- end_ignore
+--test multi-thread compression and transmission with bigger buffer start
+DROP EXTERNAL WEB TABLE IF EXISTS gpfdist2_start;
+CREATE EXTERNAL WEB TABLE gpfdist2_start (x text)
+execute E'((@bindir@/gpfdist -p 7070 -d @abs_srcdir@/data --compress -m 1200000 --mthread </dev/null >/dev/null 2>&1 &); for i in `seq 1 30`; do curl 127.0.0.1:7070 >/dev/null 2>&1 && break; sleep 1; done; echo "starting...") '
+on SEGMENT 0
+FORMAT 'text' (delimiter '|');
+-- start_ignore
+select * from gpfdist2_start;
+      x      
+-------------
+ starting...
+(1 row)
+
+-- end_ignore
+-- test 1 using a little file
+CREATE EXTERNAL TABLE ext_lineitem (
+                L_ORDERKEY INT8,
+                L_PARTKEY INTEGER,
+                L_SUPPKEY INTEGER,
+                L_LINENUMBER integer,
+                L_QUANTITY decimal,
+                L_EXTENDEDPRICE decimal,
+                L_DISCOUNT decimal,
+                L_TAX decimal,
+                L_RETURNFLAG CHAR(1),
+                L_LINESTATUS CHAR(1),
+                L_SHIPDATE date,
+                L_COMMITDATE date,
+                L_RECEIPTDATE date,
+                L_SHIPINSTRUCT CHAR(25),
+                L_SHIPMODE CHAR(10),
+                L_COMMENT VARCHAR(44)
+                )
+LOCATION
+(
+      'gpfdist://@hostname@:7070/gpfdist2/lineitem.tbl'
+)
+FORMAT 'text'
+(
+        DELIMITER AS '|'
+)
+;
+SELECT count(*) FROM ext_lineitem;
+ count 
+-------
+   256
+(1 row)
+
+DROP EXTERNAL TABLE ext_lineitem;
+-- test 2 use a bigger file.
+CREATE EXTERNAL TABLE ext_lineitem (
+                L_ORDERKEY INT8,
+                L_PARTKEY INTEGER,
+                L_SUPPKEY INTEGER,
+                L_LINENUMBER integer,
+                L_QUANTITY decimal,
+                L_EXTENDEDPRICE decimal,
+                L_DISCOUNT decimal,
+                L_TAX decimal,
+                L_RETURNFLAG CHAR(1),
+                L_LINESTATUS CHAR(1),
+                L_SHIPDATE date,
+                L_COMMITDATE date,
+                L_RECEIPTDATE date,
+                L_SHIPINSTRUCT CHAR(25),
+                L_SHIPMODE CHAR(10),
+                L_COMMENT VARCHAR(44)
+                )
+LOCATION
+(
+        'gpfdist://@hostname@:7070/gpfdist2/lineitem.tbl.long'
+)
+FORMAT 'text'
+(
+        DELIMITER AS '|'
+)
+;
+SELECT count(*) FROM ext_lineitem;
+ count  
+--------
+ 100000
+(1 row)
+
+DROP EXTERNAL TABLE ext_lineitem;
+-- start_ignore
+select * from gpfdist2_stop;
+      x      
+-------------
+ stopping...
+(1 row)
+
+-- end_ignore

--- a/src/bin/gpfdist/regress/output/gpfdist2_compress.source
+++ b/src/bin/gpfdist/regress/output/gpfdist2_compress.source
@@ -164,12 +164,79 @@ FORMAT 'text'
         DELIMITER AS '|'
 )
 ;
+CREATE TABLE lineitem (like ext_lineitem);
 SELECT count(*) FROM ext_lineitem;
  count  
 --------
  100000
 (1 row)
 
+INSERT INTO lineitem SELECT * FROM ext_lineitem;
+DROP EXTERNAL TABLE ext_lineitem;
+--test 2.1 test writable table using compression with big data
+CREATE WRITABLE EXTERNAL TABLE ext_lineitem_w (
+                L_ORDERKEY INT8,
+                L_PARTKEY INTEGER,
+                L_SUPPKEY INTEGER,
+                L_LINENUMBER integer,
+                L_QUANTITY decimal,
+                L_EXTENDEDPRICE decimal,
+                L_DISCOUNT decimal,
+                L_TAX decimal,
+                L_RETURNFLAG CHAR(1),
+                L_LINESTATUS CHAR(1),
+                L_SHIPDATE date,
+                L_COMMITDATE date,
+                L_RECEIPTDATE date,
+                L_SHIPINSTRUCT CHAR(25),
+                L_SHIPMODE CHAR(10),
+                L_COMMENT VARCHAR(44)
+                )
+LOCATION
+(
+      'gpfdist://@hostname@:7070/gpfdist2/lineitem.tbl.w'
+)
+FORMAT 'text'
+(
+        DELIMITER AS '|'
+)
+;
+CREATE EXTERNAL TABLE ext_lineitem (
+                L_ORDERKEY INT8,
+                L_PARTKEY INTEGER,
+                L_SUPPKEY INTEGER,
+                L_LINENUMBER integer,
+                L_QUANTITY decimal,
+                L_EXTENDEDPRICE decimal,
+                L_DISCOUNT decimal,
+                L_TAX decimal,
+                L_RETURNFLAG CHAR(1),
+                L_LINESTATUS CHAR(1),
+                L_SHIPDATE date,
+                L_COMMITDATE date,
+                L_RECEIPTDATE date,
+                L_SHIPINSTRUCT CHAR(25),
+                L_SHIPMODE CHAR(10),
+                L_COMMENT VARCHAR(44)
+                )
+LOCATION
+(
+      'gpfdist://@hostname@:7070/gpfdist2/lineitem.tbl.w'
+)
+FORMAT 'text'
+(
+        DELIMITER AS '|'
+)
+;
+INSERT INTO ext_lineitem_w SELECT * FROM lineitem;
+DROP TABLE lineitem;
+SELECT count(*) FROM ext_lineitem;
+ count  
+--------
+ 100256
+(1 row)
+
+DROP EXTERNAL TABLE ext_lineitem_w;
 DROP EXTERNAL TABLE ext_lineitem;
 -- test 3 line too long with defaults
 CREATE EXTERNAL TABLE ext_test (


### PR DESCRIPTION
Compression is very useful for data transmission with low bandwidth and high efficiency. But compression is a computationally intensive task and may increase the cost of time in the compression stage. To improve the efficiency of data transmission with compression, multi-thread data compression and transmission are introduced in this PR. 

The feature makes each segment served by a single thread. In the main thread, requests are read and further parsed into specific data structures. And when all the data is ready, the main thread creates a sub-thread, which compresses data and sends the compressed data.

To start multi-thread transmission, the flag '--mthread' is required. If you want multi-thread transmission with compression, the flag '--compress' is required as well.