### PR TITLE
docs - update sql ref pages for ALTER/CREATE/DROP SERVER

### DIFF
--- a/gpdb-doc/markdown/ref_guide/sql_commands/ALTER_SERVER.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/ALTER_SERVER.html.md
@@ -5,12 +5,12 @@ Changes the definition of a foreign server.
 ## <a id="section2"></a>Synopsis 
 
 ``` {#sql_command_synopsis}
-ALTER SERVER <server_name> [ VERSION '<new_version>' ]
+ALTER SERVER <name> [ VERSION '<new_version>' ]
     [ OPTIONS ( [ ADD | SET | DROP ] <option> ['<value>'] [, ... ] ) ]
 
-ALTER SERVER <server_name> OWNER TO <new_owner>
+ALTER SERVER <name> OWNER TO { <new_owner> | CURRENT_USER | SESSION_USER }
                 
-ALTER SERVER <server_name> RENAME TO <new_name>
+ALTER SERVER <name> RENAME TO <new_name>
 ```
 
 ## <a id="section3"></a>Description 
@@ -27,7 +27,7 @@ Superusers automatically satisfy all of these criteria.
 
 ## <a id="section4"></a>Parameters 
 
-server\_name
+name
 :   The name of an existing server.
 
 new\_version
@@ -36,10 +36,10 @@ new\_version
 OPTIONS \( \[ ADD \| SET \| DROP \] option \['value'\] \[, ... \] \)
 :   Change the server's options. `ADD`, `SET`, and `DROP` specify the action to perform. If no operation is explicitly specified, the default operation is `ADD`. Option names must be unique. Greenplum Database validates names and values using the server's foreign-data wrapper library.
 
-OWNER TO new\_owner
+new\_owner
 :   Specifies the new owner of the foreign server.
 
-RENAME TO new\_name
+new\_name
 :   Specifies the new name of the foreign server.
 
 ## <a id="section6"></a>Examples 

--- a/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_SERVER.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_SERVER.html.md
@@ -5,7 +5,7 @@ Defines a new foreign server.
 ## <a id="section2"></a>Synopsis 
 
 ``` {#sql_command_synopsis}
-CREATE SERVER <server_name> [ TYPE '<server_type>' ] [ VERSION '<server_version>' ]
+CREATE SERVER [ IF NOT EXISTS ] <server_name> [ TYPE '<server_type>' ] [ VERSION '<server_version>' ]
     FOREIGN DATA WRAPPER <fdw_name>
     [ OPTIONS ( [ mpp_execute { 'master' | 'any' | 'all segments' } [, ] ]
                 [ num_segments '<num>' [, ] ]
@@ -21,6 +21,10 @@ A foreign server typically encapsulates connection information that a foreign-da
 Creating a server requires the `USAGE` privilege on the foreign-data wrapper specified.
 
 ## <a id="section4"></a>Parameters 
+
+IF NOT EXISTS
+
+:   Do not throw an error if a server with the same name already exists. Greenplum Database issues a notice in this case. Note that there is no guarantee that the existing server is anything like the one that would have been created.
 
 server\_name
 :   The name of the foreign server to create. The server name must be unique within the database.
@@ -61,10 +65,10 @@ When using the dblink module \(see [dblink](../modules/dblink.html)\), you can u
 
 ## <a id="section6"></a>Examples 
 
-Create a foreign server named `myserver` that uses the foreign-data wrapper named `pgsql` and includes connection options:
+Create a foreign server named `myserver` that uses a foreign-data wrapper named `gpfdw1` and includes connection options:
 
 ```
-CREATE SERVER myserver FOREIGN DATA WRAPPER pgsql 
+CREATE SERVER myserver FOREIGN DATA WRAPPER gpfdw1 
     OPTIONS (host 'foo', dbname 'foodb', port '5432');
 ```
 
@@ -74,7 +78,7 @@ CREATE SERVER myserver FOREIGN DATA WRAPPER pgsql
 
 ## <a id="section8"></a>See Also 
 
-[ALTER SERVER](ALTER_SERVER.html), [DROP SERVER](DROP_SERVER.html), [CREATE FOREIGN DATA WRAPPER](CREATE_FOREIGN_DATA_WRAPPER.html), [CREATE USER MAPPING](CREATE_USER_MAPPING.html)
+[ALTER SERVER](ALTER_SERVER.html), [DROP SERVER](DROP_SERVER.html), [CREATE FOREIGN DATA WRAPPER](CREATE_FOREIGN_DATA_WRAPPER.html), [CREATE FOREIGN TABLE](CREATE_FOREIGN_TABLE.html), [CREATE USER MAPPING](CREATE_USER_MAPPING.html)
 
 **Parent topic:** [SQL Commands](../sql_commands/sql_ref.html)
 

--- a/gpdb-doc/markdown/ref_guide/sql_commands/DROP_SERVER.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/DROP_SERVER.html.md
@@ -5,7 +5,7 @@ Removes a foreign server descriptor.
 ## <a id="section2"></a>Synopsis 
 
 ``` {#sql_command_synopsis}
-DROP SERVER [ IF EXISTS ] <servername> [ CASCADE | RESTRICT ]
+DROP SERVER [ IF EXISTS ] <name> [, ...] [ CASCADE | RESTRICT ]
 ```
 
 ## <a id="section3"></a>Description 
@@ -17,11 +17,11 @@ DROP SERVER [ IF EXISTS ] <servername> [ CASCADE | RESTRICT ]
 IF EXISTS
 :   Do not throw an error if the server does not exist. Greenplum Database issues a notice in this case.
 
-servername
+name
 :   The name of an existing server.
 
 CASCADE
-:   Automatically drop objects that depend on the server \(such as user mappings\).
+:   Automatically drop objects that depend on the server \(such as user mappings\), and in turn all objects that depend on those objects.
 
 RESTRICT
 :   Refuse to drop the server if any object depends on it. This is the default.


### PR DESCRIPTION
this PR updates the listed sql command reference pages to align with the postgres v12 ref page content.  the CREATE page includes content describing the greenplum-specific mpp_execute and num_segments options, i've retained this info.

(no review site, changes are pretty self-explanatory.)
