### PR TITLE
docs - update sql ref pages for ALTER/CREATE/DROP USER MAPPING

### DIFF
--- a/gpdb-doc/markdown/ref_guide/sql_commands/ALTER_USER_MAPPING.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/ALTER_USER_MAPPING.html.md
@@ -5,8 +5,8 @@ Changes the definition of a user mapping for a foreign server.
 ## <a id="section2"></a>Synopsis 
 
 ``` {#sql_command_synopsis}
-ALTER USER MAPPING FOR { <username> | USER | CURRENT_USER | PUBLIC }
-    SERVER <servername>
+ALTER USER MAPPING FOR { <user_name> | USER | CURRENT_USER | SESSION_USER | PUBLIC }
+    SERVER <server_name>
     OPTIONS ( [ ADD | SET | DROP ] <option> ['<value>'] [, ... ] )
 ```
 
@@ -18,10 +18,10 @@ The owner of a foreign server can alter user mappings for that server for any us
 
 ## <a id="section4"></a>Parameters 
 
-username
+user\_name
 :   User name of the mapping. `CURRENT_USER` and `USER` match the name of the current user. `PUBLIC` is used to match all present and future user names in the system.
 
-servername
+server\_name
 :   Server name of the user mapping.
 
 OPTIONS \( \[ ADD \| SET \| DROP \] option \['value'\] \[, ... \] \)

--- a/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_USER_MAPPING.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_USER_MAPPING.html.md
@@ -5,21 +5,26 @@ Defines a new mapping of a user to a foreign server.
 ## <a id="section2"></a>Synopsis 
 
 ``` {#sql_command_synopsis}
-CREATE USER MAPPING FOR { <username> | USER | CURRENT_USER | PUBLIC }
-    SERVER <servername>
+CREATE USER MAPPING [ IF NOT EXISTS ] FOR { <user_name> | USER | CURRENT_USER | PUBLIC }
+    SERVER <server_name>
     [ OPTIONS ( <option> '<value>' [, ... ] ) ]
 ```
 
 ## <a id="section3"></a>Description 
 
-`CREATE USER MAPPING` defines a mapping of a user to a foreign server. You must be the owner of the server to define user mappings for it.
+`CREATE USER MAPPING` defines a mapping of a user to a foreign server. A user mapping typically encapsulates connection information that a foreign-data wrapper uses together with the information encapsulated by a foreign server to access an external data resource.
+
+The owner of a foreign server can create user mappings for that server for any user. Also, a user can create a user mapping for their own user name if they have been granted `USAGE` privilege on the server.
 
 ## <a id="section4"></a>Parameters 
 
-username
-:   The name of an existing user that is mapped to the foreign server. `CURRENT_USER` and `USER` match the name of the current user. `PUBLIC` is used to match all present and future user names in the system.
+IF NOT EXISTS
+:   Do not throw an error if a mapping of the given user to the given foreign server already exists. Greenplum Database issues a notice in this case. Note that there is no guarantee that the existing user mapping is anything like the one that would have been created.
 
-servername
+user\_name
+:   The name of an existing user that is mapped to the foreign server. `CURRENT_USER` and `USER` match the name of the current user. When `PUBLIC` is specified, Greenplum Database creates a so-called public mapping that is used when no user-specific mapping is applicable.
+
+server\_name
 :   The name of an existing server for which Greenplum Database is to create the user mapping.
 
 OPTIONS \( option 'value' \[, ... \] \)
@@ -39,7 +44,7 @@ CREATE USER MAPPING FOR bob SERVER foo OPTIONS (user 'bob', password 'secret');
 
 ## <a id="section8"></a>See Also 
 
-[ALTER USER MAPPING](ALTER_USER_MAPPING.html), [DROP USER MAPPING](DROP_USER_MAPPING.html), [DROP USER MAPPING](DROP_USER_MAPPING.html), [CREATE FOREIGN DATA WRAPPER](CREATE_FOREIGN_DATA_WRAPPER.html), [CREATE SERVER](CREATE_SERVER.html)
+[ALTER USER MAPPING](ALTER_USER_MAPPING.html), [DROP USER MAPPING](DROP_USER_MAPPING.html), [CREATE FOREIGN DATA WRAPPER](CREATE_FOREIGN_DATA_WRAPPER.html), [CREATE SERVER](CREATE_SERVER.html)
 
 **Parent topic:** [SQL Commands](../sql_commands/sql_ref.html)
 

--- a/gpdb-doc/markdown/ref_guide/sql_commands/DROP_USER_MAPPING.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/DROP_USER_MAPPING.html.md
@@ -5,23 +5,25 @@ Removes a user mapping for a foreign server.
 ## <a id="section2"></a>Synopsis 
 
 ``` {#sql_command_synopsis}
-DROP USER MAPPING [ IF EXISTS ] { <username> | USER | CURRENT_USER | PUBLIC } 
-    SERVER <servername>
+DROP USER MAPPING [ IF EXISTS ] { <user_name> | USER | CURRENT_USER | PUBLIC } 
+    SERVER <server_name>
 ```
 
 ## <a id="section3"></a>Description 
 
-`DROP USER MAPPING` removes an existing user mapping from a foreign server. To run this command, the current user must be the owner of the server containing the mapping.
+`DROP USER MAPPING` removes an existing user mapping from a foreign server.
+
+The owner of a foreign server can drop user mappings for that server for any user. Also, a user can drop a user mapping for their own user name if they have been granted the `USAGE` privilege on the server.
 
 ## <a id="section4"></a>Parameters 
 
 IF EXISTS
 :   Do not throw an error if the user mapping does not exist. Greenplum Database issues a notice in this case.
 
-username
+user\_name
 :   User name of the mapping. `CURRENT_USER` and `USER` match the name of the current user. `PUBLIC` is used to match all present and future user names in the system.
 
-servername
+server\_name
 :   Server name of the user mapping.
 
 ## <a id="section6"></a>Examples 


### PR DESCRIPTION
this PR updates the listed sql command reference pages to align with the postgres v12 ref page content. i didn't notice any greenplum-specific content on the pages.

in this PR:   mostly editing changes and some narrative additions.

question:  the postgres ref pages do not identify SESSION_USER as a `user_name` option for the ALTER and DROP cl. a ds, i am wondering if this is a mistake?  i noticed that we have some (positive) tests for this in src/test/modules/unsafe_tests/expected/rolenames.out - do we run these?

(no review site, changes are pretty self-explanatory.)
