### PR TITLE
Renamed gpscp_help to gpsync_help

### DIFF
--- a/gpMgmt/doc/gpsync_help
+++ b/gpMgmt/doc/gpsync_help
@@ -1,4 +1,4 @@
-COMMAND NAME: gpscp
+COMMAND NAME: gpsync
 
 Copies files between multiple hosts at once.
 
@@ -6,26 +6,26 @@ Copies files between multiple hosts at once.
 SYNOPSIS
 *****************************************************
 
-gpscp { -f <hostfile_gpssh> | -h <hostname> [-h <hostname> ...] } 
-[-J <character>] [-v] [[<user>@]<hostname>:]<file_to_copy> [...] 
+gpsync { -f <hostfile_gpssh> | -h <hostname> [-h <hostname> ...] } 
+[-a] [-J <character>] [-v] [[<user>@]<hostname>:]<file_to_copy> [...]
 [[<user>@]<hostname>:]<copy_to_path>
 
-gpscp -? 
+gpsync -? 
 
-gpscp --version
+gpsync --version
 
 *****************************************************
 DESCRIPTION
 *****************************************************
 
 
-The gpscp utility allows you to copy one or more files from the 
+The gpsync utility allows you to copy one or more files from the 
 specified hosts to other specified hosts in one command using 
-SCP (secure copy). For example, you can copy a file from the 
-Greenplum Database coordinator host to all of the segment hosts at 
-the same time.
+remote synchronization. For example, you can copy a file
+from the Greenplum Database coordinator host to all of the segment
+hosts at the same time.
 
-To specify the hosts involved in the SCP session, use the -f 
+To specify the hosts involved in the remote sync session, use the -f
 option to specify a file containing a list of host names, or use 
 the -h option to name single host names on the command-line. At 
 least one host name (-h) or a host file (-f) is required. The 
@@ -36,18 +36,18 @@ an equal sign (=). For example, the following command will
 copy .bashrc from the local host to /home/gpadmin on all hosts 
 named in hostfile_gpssh:
 
-    gpscp -f hostfile_gpssh .bashrc =:/home/gpadmin 
+    gpsync -f hostfile_gpssh .bashrc =:/home/gpadmin 
 
 If a user name is not specified in the host list or with 
-user@ in the file path, gpscp will copy files as the currently 
+user@ in the file path, gpsync will copy files as the currently 
 logged in user. To determine the currently logged in user, do a 
-whoami command. By default, gpscp goes to $HOME of the session 
+whoami command. By default, gpsync goes to $HOME of the session 
 user on the remote hosts after login. To ensure the file is 
 copied to the correct location on the remote hosts, it is 
 recommended that you use absolute paths.
 
-Before using gpscp, you must have a trusted host setup between 
-the hosts involved in the SCP session. You can use the utility 
+Before using gpsync, you must have a trusted host setup between 
+the hosts involved in the remote sync session. You can use the utility
 gpssh-exkeys to update the known host files and exchange public 
 keys between hosts if you have not done so already.
 
@@ -60,7 +60,7 @@ OPTIONS
 -f <hostfile_gpssh>
 
 Specifies the name of a file that contains a list of hosts 
-that will participate in this SCP session. The syntax of the 
+that will participate in this remote sync session. The syntax of the
 host file is one host per line as follows:
 
 <hostname>
@@ -68,9 +68,12 @@ host file is one host per line as follows:
 -h <hostname>
 
 Specifies a single host name that will participate in this 
-SCP session. You can use the -h option multiple times to 
+remote sync session. You can use the -h option multiple times to
 specify multiple host names.
 
+-a (archive mode)
+
+Sync source and target directories in archive mode.
 
 -J <character>
 
@@ -81,8 +84,7 @@ character is an equal sign (=).
 
 -v (verbose mode)
 
-Optional. Reports additional messages in addition to the 
-SCP command output.
+Optional. Reports additional messages.
 
 <file_to_copy>
 
@@ -117,12 +119,12 @@ EXAMPLES
 Copy the file named installer.tar to / on all the hosts in the 
 file host_file.
 
-gpscp -f host_file installer.tar =:/
+gpsync -f host_file installer.tar =:/
 
 Copy the file named myfuncs.so to the specified location on 
 the hosts named sdw1 and sdw2:
 
-gpscp -h sdw1 -h sdw2 myfuncs.so \
+gpsync -h sdw1 -h sdw2 myfuncs.so \
 =:/usr/local/greenplum-db/lib
 
 


### PR DESCRIPTION
Replaced scp with rsync and all gpscp references with gpsync in gpscp_help doc file and renamed it to gpsync_help as the next step of PR https://github.com/greenplum-db/gpdb/pull/14145

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
