### PR TITLE
Fix missing wal files for pg_rewind

### DIFF
--- a/src/backend/access/transam/test/xlog_test.c
+++ b/src/backend/access/transam/test/xlog_test.c
@@ -8,7 +8,7 @@
 static void
 KeepLogSeg_wrapper(XLogRecPtr recptr, XLogSegNo *logSegNo)
 {
-	KeepLogSeg(recptr, logSegNo, InvalidXLogRecPtr);
+	KeepLogSeg(recptr, logSegNo, InvalidXLogRecPtr, false);
 }
 
 static void

--- a/src/backend/replication/slot.c
+++ b/src/backend/replication/slot.c
@@ -1251,6 +1251,10 @@ SaveSlotToPath(ReplicationSlot *slot, const char *dir, int elevel)
 	ReplicationSlotOnDisk cp;
 	bool		was_dirty;
 
+	ereport(DEBUG2,
+			(errmsg("saving replication slot to path. slot's restart_lsn is %X/%X",
+					(uint32) (slot->data.restart_lsn >> 32), (uint32) slot->data.restart_lsn)));
+
 	/* first check whether there's something to write out */
 	SpinLockAcquire(&slot->mutex);
 	was_dirty = slot->dirty;

--- a/src/test/isolation2/expected/pg_rewind_fail_missing_xlog.out
+++ b/src/test/isolation2/expected/pg_rewind_fail_missing_xlog.out
@@ -1,22 +1,28 @@
--- Test the bug that if checkpoint.redo before the oldest replication slot LSN
--- is removed/recylced in checkpointer, gprecoverseg (based on pg_rewind) would
--- would fail.
+-- Ensure that the wal files up until the one which has the last CHECKPOINT wal
+-- record BEFORE the oldest replication slot restart_lsn are not recycled even
+-- if more than one CHECKPOINTs are performed after that restart_lsn. Otherwise
+-- gprecoverseg (based on pg_rewind) would fail due to missing wal file
 
 CREATE TABLE tst_missing_tbl (a int);
 CREATE
 INSERT INTO tst_missing_tbl values(2),(1),(5);
 INSERT 3
 
--- make the test faster.
-!\retcode gpconfig -c wal_keep_segments -v 2;
+-- Make the test faster by not preserving any extra wal segment files
+!\retcode gpconfig -c wal_keep_segments -v 0;
+-- start_ignore
+
+-- end_ignore
 (exited with code 0)
 !\retcode gpstop -ari;
 (exited with code 0)
 
--- Test 1: primary was marked down by the master but acetually it keeps running
--- and previously, checkpoints could recycle/remove the checkpoint.redo wal
--- file before the oldest replication slot LSN and thus make pg_rewind fail due
--- to missing xlog file.
+-- Test 1: Ensure that pg_rewind doesn't fail due to checkpoints inadvertently
+-- recycling WAL when a former primary is marked down in configuration, while it
+-- actually continues to run. The subsequent CHECKPOINT which is performed after the
+-- failover on the segment being marked down should not recycle the wal file
+-- which has the last common checkpoint of the target and source segment of
+-- pg_rewind.
 
 -- Run a checkpoint so that the below sqls won't cause a checkpoint
 -- until an explicit checkpoint command is issued by the test.
@@ -25,20 +31,6 @@ INSERT 3
 1: CHECKPOINT;
 CHECKPOINT
 
-0U: SELECT pg_switch_wal is not null FROM pg_switch_wal();
- ?column? 
-----------
- t        
-(1 row)
-1: INSERT INTO tst_missing_tbl values(2),(1),(5);
-INSERT 3
-0U: SELECT pg_switch_wal is not null FROM pg_switch_wal();
- ?column? 
-----------
- t        
-(1 row)
-1: INSERT INTO tst_missing_tbl values(2),(1),(5);
-INSERT 3
 0U: SELECT pg_switch_wal is not null FROM pg_switch_wal();
  ?column? 
 ----------
@@ -55,6 +47,7 @@ INSERT 3
 (1 row)
 1: INSERT INTO tst_missing_tbl values(2),(1),(5);
 INSERT 3
+0Uq: ... <quitting>
 
 -- Make sure primary/mirror pair is in sync, otherwise FTS can't promote mirror
 1: SELECT wait_until_all_segments_synchronized();
@@ -86,8 +79,15 @@ INSERT 3
 -- file before the oldest replication slot LSN is recycled/removed.
 0M: CHECKPOINT;
 CHECKPOINT
+0M: BEGIN;
+BEGIN
+0M: DROP TABLE tst_missing_tbl;
+DROP
+0M: ABORT;
+ABORT
 0M: CHECKPOINT;
 CHECKPOINT
+0Mq: ... <quitting>
 
 -- Write something (promote adds a 'End Of Recovery' xlog that causes the
 -- divergence between primary and mirror, but I add a write here so that we
@@ -98,9 +98,9 @@ INSERT 3
 2: SELECT gp_segment_id, count(*) from tst_missing_tbl group by gp_segment_id;
  gp_segment_id | count 
 ---------------+-------
- 0             | 6     
- 1             | 6     
- 2             | 6     
+ 0             | 4     
+ 1             | 4     
+ 2             | 4     
 (3 rows)
 
 -- Ensure that pg_rewind succeeds. Previously it could fail since the divergence
@@ -124,9 +124,13 @@ INSERT 3
  OK                                   
 (1 row)
 
--- Test 2
--- primary is abnormally shutdown, but pg_rewind would call single mode
--- postgres to ensure it clean shutdown and that causes two checkpoints.
+-- Test 2: Ensure that pg_rewind doesn't fail due to checkpoints inadvertently
+-- recycling WAL when a former primary was abnormally shutdown. In the case the
+-- target segment was abnormally shutdown, pg_rewind starts and then stops
+-- the target segment as single-user mode postgres to ensure clean shutdown which
+-- causes two checkpoints. The two newer checkpoints introduced by pg_rewind
+-- should not recycle the wal file that has the last common checkpoint of the
+-- target and source segment of pg_rewind.
 
 -- See previous comment for why.
 3: CHECKPOINT;
@@ -215,9 +219,9 @@ INSERT 3
 4: SELECT gp_segment_id, count(*) from tst_missing_tbl group by gp_segment_id;
  gp_segment_id | count 
 ---------------+-------
- 1             | 11    
- 0             | 11    
- 2             | 11    
+ 2             | 9     
+ 0             | 9     
+ 1             | 9     
 (3 rows)
 
 -- CHECKPOINT should fail now.
@@ -228,15 +232,284 @@ server closed the connection unexpectedly
 1Uq: ... <quitting>
 
 -- Ensure that pg_rewind succeeds. For unclean shutdown, there are two
--- checkpoints are introduced in pg_rewind when running single-mode postgres
+-- checkpoints are introduced in pg_rewind when running single-user mode postgres
 -- (one is the checkpoint after crash recovery and another is the shutdown
 -- checkpoint) and previously the checkpoints clean up the wal files that
 -- include the previous checkpoint (before divergence LSN) for pg_rewind and
 -- thus makes gprecoverseg (pg_rewind) fail.
 !\retcode gprecoverseg -av;
+-- start_ignore
+-- end_ignore
 (exited with code 0)
 -- In case it fails it should not affect subsequent testing.
 !\retcode gprecoverseg -aF;
+-- start_ignore
+-- end_ignore
+(exited with code 0)
+4: SELECT wait_until_all_segments_synchronized();
+ wait_until_all_segments_synchronized 
+--------------------------------------
+ OK                                   
+(1 row)
+
+-- Test 3: Ensure that pg_rewind doesn't fail due to checkpoints inadvertently
+-- recycling WAL when a former primary is marked down in configuration, while it
+-- actually continued running for a while before it was cleanly shutdown. The wal
+-- file on the target segment which has the last common checkpoint of the target
+-- and source segment of pg_rewind should survive the subsequent CHECKPOINTs
+-- performed on the target segment even if the segment was cleanly shutdown
+-- and started again after the failover.
+
+-- Run a checkpoint so that the below sqls won't cause a checkpoint
+-- until an explicit checkpoint command is issued by the test.
+-- checkpoint_timeout is by default 300 but the below test should be able to
+-- finish in 300 seconds.
+1: CHECKPOINT;
+CHECKPOINT
+
+0U: SELECT pg_switch_wal is not null FROM pg_switch_wal();
+ ?column? 
+----------
+ t        
+(1 row)
+1: INSERT INTO tst_missing_tbl values(2),(1),(5);
+INSERT 3
+-- Should be not needed mostly but let's 100% ensure since pg_switch_wal()
+-- won't switch if it has been on the boundary (seldom though).
+0U: SELECT pg_switch_wal is not null FROM pg_switch_wal();
+ ?column? 
+----------
+ t        
+(1 row)
+1: INSERT INTO tst_missing_tbl values(2),(1),(5);
+INSERT 3
+0Uq: ... <quitting>
+
+-- Make sure primary/mirror pair is in sync, otherwise FTS can't promote mirror
+1: SELECT wait_until_all_segments_synchronized();
+ wait_until_all_segments_synchronized 
+--------------------------------------
+ OK                                   
+(1 row)
+-- Mark down the primary with content 0 via fts fault injection.
+1: SELECT gp_inject_fault_infinite('fts_handle_message', 'error', dbid) FROM gp_segment_configuration WHERE content = 0 AND role = 'p';
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+
+-- Trigger failover and double check.
+1: SELECT gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+1: SELECT role, preferred_role from gp_segment_configuration where content = 0;
+ role | preferred_role 
+------+----------------
+ m    | m              
+ p    | p              
+(2 rows)
+
+-- Run two more checkpoints. Previously this causes the checkpoint.redo wal
+-- file before the oldest replication slot LSN is recycled/removed.
+0M: BEGIN;
+BEGIN
+0M: DROP TABLE tst_missing_tbl;
+DROP
+0M: ABORT;
+ABORT
+0M: CHECKPOINT;
+CHECKPOINT
+0M: BEGIN;
+BEGIN
+0M: DROP TABLE tst_missing_tbl;
+DROP
+0M: ABORT;
+ABORT
+0M: CHECKPOINT;
+CHECKPOINT
+
+-- Clean shutdown. Clean shutdown performs CHECKPOINT
+2: SELECT pg_ctl(datadir, 'stop', 'fast') from gp_segment_configuration where role = 'm' and content = 0;
+ pg_ctl 
+--------
+ OK     
+(1 row)
+0Mq: ... <quitting>
+
+-- Start again. Start from a clean shutdown does not perform CHECKPOINT
+2: SELECT pg_ctl_start(datadir, port) from gp_segment_configuration where role = 'm' and content = 0;
+ pg_ctl_start                                     
+--------------------------------------------------
+ waiting for server to start done
+server started
+ 
+(1 row)
+
+-- Perform CHECKPOINT. Previously this causes the checkpoint.redo wal
+-- file before the oldest replication slot LSN is recycled/removed.
+0M: CHECKPOINT;
+CHECKPOINT
+
+-- Write something (promote adds a 'End Of Recovery' xlog that causes the
+-- divergence between primary and mirror, but I add a write here so that we
+-- know that a wal divergence is explicitly triggered and 100% completed.  Also
+-- sanity check the tuple distribution (assumption of the test).
+2: INSERT INTO tst_missing_tbl values(2),(1),(5);
+INSERT 3
+2: SELECT gp_segment_id, count(*) from tst_missing_tbl group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+ 1             | 12    
+ 2             | 12    
+ 0             | 12    
+(3 rows)
+
+-- Ensure that pg_rewind succeeds. Previously it could fail since the divergence
+-- LSN wal file is missing.
+!\retcode gprecoverseg -av;
+-- start_ignore
+-- end_ignore
+(exited with code 0)
+-- In case it fails it should not affect subsequent testing.
+!\retcode gprecoverseg -aF;
+-- start_ignore
+
+
+
+-- end_ignore
+(exited with code 0)
+2: SELECT wait_until_all_segments_synchronized();
+ wait_until_all_segments_synchronized 
+--------------------------------------
+ OK                                   
+(1 row)
+
+-- Test 4: Ensure that pg_rewind doesn't fail due to checkpoints inadvertently
+-- recycling WAL when a former primary was abnormally shutdown and it wrote
+-- a CHECKPOINT record locally but the record did not make to the wal receiver.
+-- In the case the target segment was abnormally shutdown, pg_rewind starts and
+-- then stops the target segment as single-user mode postgres to ensure clean shutdown
+-- which causes two checkpoints. The two newer checkpoints introduced by pg_rewind
+-- plus the checkpoint during the unclean shutdown should not recycle the wal
+-- file that has the last common checkpoint of the target and source segment of
+-- pg_rewind.
+
+-- See previous comment for why.
+3: CHECKPOINT;
+CHECKPOINT
+1U: SELECT pg_switch_wal is not null FROM pg_switch_wal();
+ ?column? 
+----------
+ t        
+(1 row)
+3: INSERT INTO tst_missing_tbl values(2),(1),(5);
+INSERT 3
+-- Should be not needed mostly but let's 100% ensure since pg_switch_wal()
+-- won't switch if it is on the boundary already (seldom though).
+1U: SELECT pg_switch_wal is not null FROM pg_switch_wal();
+ ?column? 
+----------
+ t        
+(1 row)
+3: INSERT INTO tst_missing_tbl values(2),(1),(5);
+INSERT 3
+
+-- Have primary/mirror pair in sync before suspending the wal sender.
+3: SELECT wait_until_all_segments_synchronized();
+ wait_until_all_segments_synchronized 
+--------------------------------------
+ OK                                   
+(1 row)
+
+-- Hang the wal sender before writing checkpoint wal record.
+3: SELECT gp_inject_fault('wal_sender_loop', 'suspend', dbid) FROM gp_segment_configuration WHERE role='p' AND content = 1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+3: SELECT gp_wait_until_triggered_fault('wal_sender_loop', 1, dbid) FROM gp_segment_configuration WHERE role='p' AND content = 1;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
+-- Checkpoint and make sure the CHECKPOINT record is written on disk
+3: SELECT gp_inject_fault('checkpoint_control_file_updated', 'suspend', dbid) FROM gp_segment_configuration WHERE role='p' AND content = 1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+1U&: CHECKPOINT;  <waiting ...>
+3: SELECT gp_wait_until_triggered_fault('checkpoint_control_file_updated', 1, dbid) FROM gp_segment_configuration WHERE role='p' AND content = 1;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
+-- Stop the primary immediately and promote the mirror.
+3: SELECT pg_ctl(datadir, 'stop', 'immediate') FROM gp_segment_configuration WHERE role='p' AND content = 1;
+ pg_ctl 
+--------
+ OK     
+(1 row)
+3: SELECT gp_request_fts_probe_scan();
+ gp_request_fts_probe_scan 
+---------------------------
+ t                         
+(1 row)
+
+-- Reset faults and confirm FTS configuration
+3: SELECT gp_inject_fault('wal_sender_loop', 'reset', dbid) FROM gp_segment_configuration WHERE role='p' AND content = 1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+3: SELECT gp_inject_fault('checkpoint_control_file_updated', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = 1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+3: SELECT role, preferred_role from gp_segment_configuration where content = 1;
+ role | preferred_role 
+------+----------------
+ m    | m              
+ p    | p              
+(2 rows)
+
+-- Write something on the current primary
+4: INSERT INTO tst_missing_tbl values(2),(1),(5);
+INSERT 3
+4: SELECT gp_segment_id, count(*) from tst_missing_tbl group by gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+ 0             | 15    
+ 2             | 15    
+ 1             | 15    
+(3 rows)
+
+-- CHECKPOINT should fail now.
+1U<:  <... completed>
+server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+1Uq: ... <quitting>
+
+-- Ensure that pg_rewind succeeds. For unclean shutdown, there are two
+-- checkpoints are introduced in pg_rewind when running single-user mode postgres
+-- (one is the checkpoint after crash recovery and another is the shutdown
+-- checkpoint) and previously the checkpoints clean up the wal files that
+-- include the previous checkpoint (before divergence LSN) for pg_rewind and
+-- thus makes gprecoverseg (pg_rewind) fail.
+!\retcode gprecoverseg -av;
+-- start_ignore
+-- end_ignore
+(exited with code 0)
+-- In case it fails it should not affect subsequent testing.
+!\retcode gprecoverseg -aF;
+-- start_ignore
+-- end_ignore
 (exited with code 0)
 4: SELECT wait_until_all_segments_synchronized();
  wait_until_all_segments_synchronized 

--- a/src/test/isolation2/sql/pg_rewind_fail_missing_xlog.sql
+++ b/src/test/isolation2/sql/pg_rewind_fail_missing_xlog.sql
@@ -1,18 +1,21 @@
--- Test the bug that if checkpoint.redo before the oldest replication slot LSN
--- is removed/recylced in checkpointer, gprecoverseg (based on pg_rewind) would
--- would fail.
+-- Ensure that the wal files up until the one which has the last CHECKPOINT wal
+-- record BEFORE the oldest replication slot restart_lsn are not recycled even
+-- if more than one CHECKPOINTs are performed after that restart_lsn. Otherwise
+-- gprecoverseg (based on pg_rewind) would fail due to missing wal file
 
 CREATE TABLE tst_missing_tbl (a int);
 INSERT INTO tst_missing_tbl values(2),(1),(5);
 
--- make the test faster.
-!\retcode gpconfig -c wal_keep_segments -v 2;
+-- Make the test faster by not preserving any extra wal segment files
+!\retcode gpconfig -c wal_keep_segments -v 0;
 !\retcode gpstop -ari;
 
--- Test 1: primary was marked down by the master but acetually it keeps running
--- and previously, checkpoints could recycle/remove the checkpoint.redo wal
--- file before the oldest replication slot LSN and thus make pg_rewind fail due
--- to missing xlog file.
+-- Test 1: Ensure that pg_rewind doesn't fail due to checkpoints inadvertently
+-- recycling WAL when a former primary is marked down in configuration, while it
+-- actually continues to run. The subsequent CHECKPOINT which is performed after the
+-- failover on the segment being marked down should not recycle the wal file
+-- which has the last common checkpoint of the target and source segment of
+-- pg_rewind.
 
 -- Run a checkpoint so that the below sqls won't cause a checkpoint
 -- until an explicit checkpoint command is issued by the test.
@@ -22,14 +25,11 @@ INSERT INTO tst_missing_tbl values(2),(1),(5);
 
 0U: SELECT pg_switch_wal is not null FROM pg_switch_wal();
 1: INSERT INTO tst_missing_tbl values(2),(1),(5);
-0U: SELECT pg_switch_wal is not null FROM pg_switch_wal();
-1: INSERT INTO tst_missing_tbl values(2),(1),(5);
-0U: SELECT pg_switch_wal is not null FROM pg_switch_wal();
-1: INSERT INTO tst_missing_tbl values(2),(1),(5);
 -- Should be not needed mostly but let's 100% ensure since pg_switch_wal()
 -- won't switch if it has been on the boundary (seldom though).
 0U: SELECT pg_switch_wal is not null FROM pg_switch_wal();
 1: INSERT INTO tst_missing_tbl values(2),(1),(5);
+0Uq:
 
 -- Make sure primary/mirror pair is in sync, otherwise FTS can't promote mirror
 1: SELECT wait_until_all_segments_synchronized();
@@ -43,7 +43,11 @@ INSERT INTO tst_missing_tbl values(2),(1),(5);
 -- Run two more checkpoints. Previously this causes the checkpoint.redo wal
 -- file before the oldest replication slot LSN is recycled/removed.
 0M: CHECKPOINT;
+0M: BEGIN;
+0M: DROP TABLE tst_missing_tbl;
+0M: ABORT;
 0M: CHECKPOINT;
+0Mq:
 
 -- Write something (promote adds a 'End Of Recovery' xlog that causes the
 -- divergence between primary and mirror, but I add a write here so that we
@@ -59,9 +63,13 @@ INSERT INTO tst_missing_tbl values(2),(1),(5);
 !\retcode gprecoverseg -aF;
 2: SELECT wait_until_all_segments_synchronized();
 
--- Test 2
--- primary is abnormally shutdown, but pg_rewind would call single mode
--- postgres to ensure it clean shutdown and that causes two checkpoints.
+-- Test 2: Ensure that pg_rewind doesn't fail due to checkpoints inadvertently
+-- recycling WAL when a former primary was abnormally shutdown. In the case the
+-- target segment was abnormally shutdown, pg_rewind starts and then stops
+-- the target segment as single-user mode postgres to ensure clean shutdown which
+-- causes two checkpoints. The two newer checkpoints introduced by pg_rewind
+-- should not recycle the wal file that has the last common checkpoint of the
+-- target and source segment of pg_rewind.
 
 -- See previous comment for why.
 3: CHECKPOINT;
@@ -99,7 +107,133 @@ INSERT INTO tst_missing_tbl values(2),(1),(5);
 1Uq:
 
 -- Ensure that pg_rewind succeeds. For unclean shutdown, there are two
--- checkpoints are introduced in pg_rewind when running single-mode postgres
+-- checkpoints are introduced in pg_rewind when running single-user mode postgres
+-- (one is the checkpoint after crash recovery and another is the shutdown
+-- checkpoint) and previously the checkpoints clean up the wal files that
+-- include the previous checkpoint (before divergence LSN) for pg_rewind and
+-- thus makes gprecoverseg (pg_rewind) fail.
+!\retcode gprecoverseg -av;
+-- In case it fails it should not affect subsequent testing.
+!\retcode gprecoverseg -aF;
+4: SELECT wait_until_all_segments_synchronized();
+
+-- Test 3: Ensure that pg_rewind doesn't fail due to checkpoints inadvertently
+-- recycling WAL when a former primary is marked down in configuration, while it
+-- actually continued running for a while before it was cleanly shutdown. The wal
+-- file on the target segment which has the last common checkpoint of the target
+-- and source segment of pg_rewind should survive the subsequent CHECKPOINTs
+-- performed on the target segment even if the segment was cleanly shutdown
+-- and started again after the failover.
+
+-- Run a checkpoint so that the below sqls won't cause a checkpoint
+-- until an explicit checkpoint command is issued by the test.
+-- checkpoint_timeout is by default 300 but the below test should be able to
+-- finish in 300 seconds.
+1: CHECKPOINT;
+
+0U: SELECT pg_switch_wal is not null FROM pg_switch_wal();
+1: INSERT INTO tst_missing_tbl values(2),(1),(5);
+-- Should be not needed mostly but let's 100% ensure since pg_switch_wal()
+-- won't switch if it has been on the boundary (seldom though).
+0U: SELECT pg_switch_wal is not null FROM pg_switch_wal();
+1: INSERT INTO tst_missing_tbl values(2),(1),(5);
+0Uq:
+
+-- Make sure primary/mirror pair is in sync, otherwise FTS can't promote mirror
+1: SELECT wait_until_all_segments_synchronized();
+-- Mark down the primary with content 0 via fts fault injection.
+1: SELECT gp_inject_fault_infinite('fts_handle_message', 'error', dbid) FROM gp_segment_configuration WHERE content = 0 AND role = 'p';
+
+-- Trigger failover and double check.
+1: SELECT gp_request_fts_probe_scan();
+1: SELECT role, preferred_role from gp_segment_configuration where content = 0;
+
+-- Run two more checkpoints. Previously this causes the checkpoint.redo wal
+-- file before the oldest replication slot LSN is recycled/removed.
+0M: BEGIN;
+0M: DROP TABLE tst_missing_tbl;
+0M: ABORT;
+0M: CHECKPOINT;
+0M: BEGIN;
+0M: DROP TABLE tst_missing_tbl;
+0M: ABORT;
+0M: CHECKPOINT;
+
+-- Clean shutdown. Clean shutdown performs CHECKPOINT
+2: SELECT pg_ctl(datadir, 'stop', 'fast') from gp_segment_configuration where role = 'm' and content = 0;
+0Mq:
+
+-- Start again. Start from a clean shutdown does not perform CHECKPOINT
+2: SELECT pg_ctl_start(datadir, port) from gp_segment_configuration where role = 'm' and content = 0;
+
+-- Perform CHECKPOINT. Previously this causes the checkpoint.redo wal
+-- file before the oldest replication slot LSN is recycled/removed.
+0M: CHECKPOINT;
+
+-- Write something (promote adds a 'End Of Recovery' xlog that causes the
+-- divergence between primary and mirror, but I add a write here so that we
+-- know that a wal divergence is explicitly triggered and 100% completed.  Also
+-- sanity check the tuple distribution (assumption of the test).
+2: INSERT INTO tst_missing_tbl values(2),(1),(5);
+2: SELECT gp_segment_id, count(*) from tst_missing_tbl group by gp_segment_id;
+
+-- Ensure that pg_rewind succeeds. Previously it could fail since the divergence
+-- LSN wal file is missing.
+!\retcode gprecoverseg -av;
+-- In case it fails it should not affect subsequent testing.
+!\retcode gprecoverseg -aF;
+2: SELECT wait_until_all_segments_synchronized();
+
+-- Test 4: Ensure that pg_rewind doesn't fail due to checkpoints inadvertently
+-- recycling WAL when a former primary was abnormally shutdown and it wrote
+-- a CHECKPOINT record locally but the record did not make to the wal receiver.
+-- In the case the target segment was abnormally shutdown, pg_rewind starts and
+-- then stops the target segment as single-user mode postgres to ensure clean shutdown
+-- which causes two checkpoints. The two newer checkpoints introduced by pg_rewind
+-- plus the checkpoint during the unclean shutdown should not recycle the wal
+-- file that has the last common checkpoint of the target and source segment of
+-- pg_rewind.
+
+-- See previous comment for why.
+3: CHECKPOINT;
+1U: SELECT pg_switch_wal is not null FROM pg_switch_wal();
+3: INSERT INTO tst_missing_tbl values(2),(1),(5);
+-- Should be not needed mostly but let's 100% ensure since pg_switch_wal()
+-- won't switch if it is on the boundary already (seldom though).
+1U: SELECT pg_switch_wal is not null FROM pg_switch_wal();
+3: INSERT INTO tst_missing_tbl values(2),(1),(5);
+
+-- Have primary/mirror pair in sync before suspending the wal sender.
+3: SELECT wait_until_all_segments_synchronized();
+
+-- Hang the wal sender before writing checkpoint wal record.
+3: SELECT gp_inject_fault('wal_sender_loop', 'suspend', dbid) FROM gp_segment_configuration WHERE role='p' AND content = 1;
+3: SELECT gp_wait_until_triggered_fault('wal_sender_loop', 1, dbid) FROM gp_segment_configuration WHERE role='p' AND content = 1;
+
+-- Checkpoint and make sure the CHECKPOINT record is written on disk
+3: SELECT gp_inject_fault('checkpoint_control_file_updated', 'suspend', dbid) FROM gp_segment_configuration WHERE role='p' AND content = 1;
+1U&: CHECKPOINT;
+3: SELECT gp_wait_until_triggered_fault('checkpoint_control_file_updated', 1, dbid) FROM gp_segment_configuration WHERE role='p' AND content = 1;
+
+-- Stop the primary immediately and promote the mirror.
+3: SELECT pg_ctl(datadir, 'stop', 'immediate') FROM gp_segment_configuration WHERE role='p' AND content = 1;
+3: SELECT gp_request_fts_probe_scan();
+
+-- Reset faults and confirm FTS configuration
+3: SELECT gp_inject_fault('wal_sender_loop', 'reset', dbid) FROM gp_segment_configuration WHERE role='p' AND content = 1;
+3: SELECT gp_inject_fault('checkpoint_control_file_updated', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = 1;
+3: SELECT role, preferred_role from gp_segment_configuration where content = 1;
+
+-- Write something on the current primary
+4: INSERT INTO tst_missing_tbl values(2),(1),(5);
+4: SELECT gp_segment_id, count(*) from tst_missing_tbl group by gp_segment_id;
+
+-- CHECKPOINT should fail now.
+1U<:
+1Uq:
+
+-- Ensure that pg_rewind succeeds. For unclean shutdown, there are two
+-- checkpoints are introduced in pg_rewind when running single-user mode postgres
 -- (one is the checkpoint after crash recovery and another is the shutdown
 -- checkpoint) and previously the checkpoints clean up the wal files that
 -- include the previous checkpoint (before divergence LSN) for pg_rewind and

--- a/src/test/isolation2/sql_isolation_testcase.py
+++ b/src/test/isolation2/sql_isolation_testcase.py
@@ -787,6 +787,10 @@ class SQLIsolationExecutor(object):
                     pass
         elif flag == "M":
             self.get_process(output_file, process_name, con_mode, dbname=dbname).query(sql.strip(), post_run_cmd, global_sh_executor)
+        elif flag == "Mq":
+            if len(sql) > 0:
+                raise Exception("No query should be given on quit Mq")
+            self.quit_process(output_file, process_name, con_mode, dbname=dbname)
         else:
             raise Exception("Invalid isolation flag")
 
@@ -813,7 +817,7 @@ class SQLIsolationExecutor(object):
                 if command_part == "" or command_part == "\n":
                     print(file=output_file)
                     newline = True
-                elif re.match(r".*;\s*$", command_part) or re.match(r"^\d+[q\\<]:\s*$", line) or re.match(r"^\*Rq:$", line) or re.match(r"^-?\d+[SUR][q\\<]:\s*$", line):
+                elif re.match(r".*;\s*$", command_part) or re.match(r"^\d+[q\\<]:\s*$", line) or re.match(r"^\*Rq:$", line) or re.match(r"^-?\d+[SUMR][q\\<]:\s*$", line):
                     command += command_part
                     try:
                         self.process_command(command, output_file, shell_executor)


### PR DESCRIPTION
Previously, commit https://github.com/greenplum-db/gpdb/commit/185c7d796f9cfd431cea69c05dc06932faa0300b as part of PR 11989 added extra protection
for wal files for the following scenario:

- The common CHECKPOINT record of the source and the target segment
  locates in an older wal file than the one that contains the
  divergence record. AND
- More than one CHECKPOINT happened on the failed primary which
  proceed the divergence LSN.

The previous fix was to have an in-memory variable that keeps track of
the last CHECKPOINT prior to the smallest replication slot's
restart_lsn. However, this fix only works if the segment has not gone
through shutdown and restart.

This commit prevents CHECKPOINT from removing wal files if the last
CHECKPOINT record pointer prior to the replication slot minimum lsn is
not available. This usually happens when the previously failed segment
is just restarted and the in-memory variable is not yet populated.

Also added more debug loggings for our future selves.
