### PR TITLE
docs - update sql ref pages for TEXT SEARCH-related commands

### DIFF
--- a/gpdb-doc/markdown/ref_guide/sql_commands/ALTER_TEXT_SEARCH_CONFIGURATION.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/ALTER_TEXT_SEARCH_CONFIGURATION.html.md
@@ -6,6 +6,8 @@ Changes the definition of a text search configuration.
 
 ``` {#sql_command_synopsis}
 ALTER TEXT SEARCH CONFIGURATION <name>
+    ADD MAPPING FOR <token_type> [, ... ] WITH <dictionary_name> [, ... ]
+ALTER TEXT SEARCH CONFIGURATION <name>
     ALTER MAPPING FOR <token_type> [, ... ] WITH <dictionary_name> [, ... ]
 ALTER TEXT SEARCH CONFIGURATION <name>
     ALTER MAPPING REPLACE <old_dictionary> WITH <new_dictionary>
@@ -14,7 +16,7 @@ ALTER TEXT SEARCH CONFIGURATION <name>
 ALTER TEXT SEARCH CONFIGURATION <name>
     DROP MAPPING [ IF EXISTS ] FOR <token_type> [, ... ]
 ALTER TEXT SEARCH CONFIGURATION <name> RENAME TO <new_name>
-ALTER TEXT SEARCH CONFIGURATION <name> OWNER TO <new_owner>
+ALTER TEXT SEARCH CONFIGURATION <name> OWNER TO { <new_owner> | CURRENT_USER | SESSION_USER }
 ALTER TEXT SEARCH CONFIGURATION <name> SET SCHEMA <new_schema>
 ```
 
@@ -26,28 +28,28 @@ You must be the owner of the configuration to use `ALTER TEXT SEARCH CONFIGURATI
 
 ## <a id="section4"></a>Parameters 
 
-`name`
+name
 :   The name \(optionally schema-qualified\) of an existing text search configuration.
 
-`token\_type`
+token\_type
 :   The name of a token type that is emitted by the configuration's parser.
 
-`dictionary\_name`
+dictionary\_name
 :   The name of a text search dictionary to be consulted for the specified token type\(s\). If multiple dictionaries are listed, they are consulted in the specified order.
 
-`old\_dictionary`
+old\_dictionary
 :   The name of a text search dictionary to be replaced in the mapping.
 
-`new\_dictionary`
+new\_dictionary
 :   The name of a text search dictionary to be substituted for old\_dictionary.
 
-`new\_name`
+new\_name
 :   The new name of the text search configuration.
 
 new\_owner
 :   The new owner of the text search configuration.
 
-`new\_schema`
+new\_schema
 :   The new schema for the text search configuration.
 
 The `ADD MAPPING FOR` form installs a list of dictionaries to be consulted for the specified token type\(s\); it is an error if there is already a mapping for any of the token types. The `ALTER MAPPING FOR` form does the same, but first removing any existing mapping for those token types. The `ALTER MAPPING REPLACE` forms substitute new\_dictionary for old\_dictionary anywhere the latter appears. This is done for only the specified token types when `FOR` appears, or for all mappings of the configuration when it doesn't. The `DROP MAPPING` form removes all dictionaries for the specified token type\(s\), causing tokens of those types to be ignored by the text search configuration. It is an error if there is no mapping for the token types, unless `IF EXISTS` appears.

--- a/gpdb-doc/markdown/ref_guide/sql_commands/ALTER_TEXT_SEARCH_DICTIONARY.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/ALTER_TEXT_SEARCH_DICTIONARY.html.md
@@ -9,7 +9,7 @@ ALTER TEXT SEARCH DICTIONARY <name> (
     <option> [ = <value> ] [, ... ]
 )
 ALTER TEXT SEARCH DICTIONARY <name> RENAME TO <new_name>
-ALTER TEXT SEARCH DICTIONARY <name> OWNER TO <new_owner>
+ALTER TEXT SEARCH DICTIONARY <name> OWNER TO { <new_owner> | CURRENT_USER | SESSION_USER }
 ALTER TEXT SEARCH DICTIONARY <name> SET SCHEMA <new_schema>
 ```
 
@@ -21,47 +21,47 @@ You must be the owner of the dictionary to use `ALTER TEXT SEARCH DICTIONARY`.
 
 ## <a id="section4"></a>Parameters 
 
-`name`
+name
 :   The name \(optionally schema-qualified\) of an existing text search dictionary.
 
-`option`
+option
 :   The name of a template-specific option to be set for this dictionary.
 
-`value`
+value
 :   The new value to use for a template-specific option. If the equal sign and value are omitted, then any previous setting for the option is removed from the dictionary, allowing the default to be used.
 
-`new\_name`
+new\_name
 :   The new name of the text search dictionary.
 
-`new\_owner`
+new\_owner
 :   The new owner of the text search dictionary.
 
-`new\_schema`
+new\_schema
 :   The new schema for the text search dictionary.
 
 Template-specific options can appear in any order.
 
 ## <a id="section5"></a>Examples 
 
-The following example command changes the stopword list for a Snowball-based dictionary. Other parameters remain unchanged.
+The following example command changes the stop word list for a Snowball-based dictionary. Other parameters remain unchanged.
 
 ```
 ALTER TEXT SEARCH DICTIONARY my_dict ( StopWords = newrussian );
 ```
 
-The following example command changes the language option to `dutch`, and removes the stopword option entirely.
+The following example command changes the language option to `dutch`, and removes the stop word option entirely:
 
 ```
 ALTER TEXT SEARCH DICTIONARY my_dict ( language = dutch, StopWords );
 ```
 
-The following example command "updates" the dictionary's definition without actually changing anything.
+The following example command "updates" the dictionary's definition without actually changing anything:
 
 ```
 ALTER TEXT SEARCH DICTIONARY my_dict ( dummy );
 ```
 
-\(The reason this works is that the option removal code doesn't complain if there is no such option.\) This trick is useful when changing configuration files for the dictionary: the ALTER will force existing database sessions to re-read the configuration files, which otherwise they would never do if they had read them earlier.
+\(The reason this works is that the option removal code doesn't complain if there is no such option.\) This trick is useful when changing configuration files for the dictionary: the `ALTER` will force existing database sessions to re-read the configuration files, which they would otherwise never do if they had read them earlier.
 
 ## <a id="section6"></a>Compatibility 
 

--- a/gpdb-doc/markdown/ref_guide/sql_commands/ALTER_TEXT_SEARCH_TEMPLATE.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/ALTER_TEXT_SEARCH_TEMPLATE.html.md
@@ -13,7 +13,7 @@ ALTER TEXT SEARCH TEMPLATE <name> SET SCHEMA <new_schema>
 
 ## <a id="section3"></a>Description 
 
-`ALTER TEXT SEARCH TEMPLATE` changes the definition of a text search parser. Currently, the only supported functionality is to change the parser's name.
+`ALTER TEXT SEARCH TEMPLATE` changes the definition of a text search parser. Currently, the only supported functionality is to change the template's name.
 
 You must be a superuser to use `ALTER TEXT SEARCH TEMPLATE`.
 

--- a/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_TEXT_SEARCH_CONFIGURATION.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_TEXT_SEARCH_CONFIGURATION.html.md
@@ -15,9 +15,9 @@ CREATE TEXT SEARCH CONFIGURATION <name> (
 
 `CREATE TEXT SEARCH CONFIGURATION` creates a new text search configuration. A text search configuration specifies a text search parser that can divide a string into tokens, plus dictionaries that can be used to determine which tokens are of interest for searching.
 
-If only the parser is specified, then the new text search configuration initially has no mappings from token types to dictionaries, and therefore will ignore all words. Subsequent `ALTER TEXT SEARCH CONFIGURATION` commands must be used to create mappings to make the configuration useful. Alternatively, an existing text search configuration can be copied.
+If only the parser is specified, then the new text search configuration initially has no mappings from token types to dictionaries, and therefore will ignore all words. Subsequent [ALTER TEXT SEARCH CONFIGURATION](ALTER_TEXT_SEARCH_CONFIGURATION.html) commands must be used to create mappings to make the configuration useful. Alternatively, an existing text search configuration can be copied.
 
-If a schema name is given then the text search configuration is created in the specified schema. Otherwise it is created in the current schema.
+If a schema name is provided then the text search configuration is created in the specified schema. Otherwise it is created in the current schema.
 
 The user who defines a text search configuration becomes its owner.
 

--- a/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_TEXT_SEARCH_DICTIONARY.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_TEXT_SEARCH_DICTIONARY.html.md
@@ -23,16 +23,16 @@ Refer to [Using Full Text Search](../../admin_guide/textsearch/full-text-search.
 
 ## <a id="section4"></a>Parameters 
 
-`name`
+name
 :   The name of the text search dictionary to be created. The name can be schema-qualified.
 
-`template`
+template
 :   The name of the text search template that will define the basic behavior of this dictionary.
 
-`option`
+option
 :   The name of a template-specific option to be set for this dictionary.
 
-`value`
+value
 :   The value to use for a template-specific option. If the value is not a simple identifier or number, it must be quoted \(but you can always quote it, if you wish\).
 
 The options can appear in any order.

--- a/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_TEXT_SEARCH_PARSER.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_TEXT_SEARCH_PARSER.html.md
@@ -7,12 +7,12 @@ Defines a new text search parser.
 ## <a id="Synopsis"></a>Synopsis 
 
 ``` {#sql_command_synopsis}
-CREATE TEXT SEARCH PARSER name (
-    START = start_function ,
-    GETTOKEN = gettoken_function ,
-    END = end_function ,
-    LEXTYPES = lextypes_function
-    [, HEADLINE = headline_function ]
+CREATE TEXT SEARCH PARSER <name> (
+    START = <start_function> ,
+    GETTOKEN = <gettoken_function> ,
+    END = <end_function> ,
+    LEXTYPES = <lextypes_function>
+    [, HEADLINE = <headline_function> ]
 )
 ```
 
@@ -28,22 +28,22 @@ Refer to [Using Full Text Search](../../admin_guide/textsearch/full-text-search.
 
 ## <a id="section4"></a>Parameters 
 
-`name`
+name
 :   The name of the text search parser to be created. The name can be schema-qualified.
 
-`start\_function`
+start\_function
 :   The name of the start function for the parser.
 
-`gettoken\_function`
+gettoken\_function
 :   The name of the get-next-token function for the parser.
 
-`end\_function`
+end\_function
 :   The name of the end function for the parser.
 
-`lextypes\_function`
+lextypes\_function
 :   The name of the lextypes function for the parser \(a function that returns information about the set of token types it produces\).
 
-`headline\_function`
+headline\_function
 :   The name of the headline function for the parser \(a function that summarizes a set of tokens\).
 
 The function names can be schema-qualified if necessary. Argument types are not given, since the argument list for each type of function is predetermined. All except the headline function are required.

--- a/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_TEXT_SEARCH_TEMPLATE.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_TEXT_SEARCH_TEMPLATE.html.md
@@ -25,13 +25,13 @@ Refer to [Using Full Text Search](../../admin_guide/textsearch/full-text-search.
 
 ## <a id="section4"></a>Parameters 
 
-`name`
+name
 :   The name of the text search template to be created. The name can be schema-qualified.
 
-`init\_function`
+init\_function
 :   The name of the init function for the template.
 
-`lexize\_function`
+lexize\_function
 :   The name of the lexize function for the template.
 
 The function names can be schema-qualified if necessary. Argument types are not given, since the argument list for each type of function is predetermined. The lexize function is required, but the init function is optional.

--- a/gpdb-doc/markdown/ref_guide/sql_commands/DROP_TEXT_SEARCH_CONFIGURATION.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/DROP_TEXT_SEARCH_CONFIGURATION.html.md
@@ -10,25 +10,25 @@ DROP TEXT SEARCH CONFIGURATION [ IF EXISTS ] <name> [ CASCADE | RESTRICT ]
 
 ## <a id="section3"></a>Description 
 
-`DROP TEXT SEARCH CONFIGURATION` drops an existing text search configuration. To run this command you must be the owner of the configuration.
+`DROP TEXT SEARCH CONFIGURATION` drops an existing text search configuration. You must be the owner of the configuration to run this command.
 
 ## <a id="section4"></a>Parameters 
 
-`IF EXISTS`
-:   Do not throw an error if the text search configuration does not exist. A notice is issued in this case.
+IF EXISTS
+:   Do not throw an error if the text search configuration does not exist. Greenplum Database issues a notice in this case.
 
-`name`
+name
 :   The name \(optionally schema-qualified\) of an existing text search configuration.
 
-`CASCADE`
-:   Automatically drop objects that depend on the text search configuration.
+CASCADE
+:   Automatically drop objects that depend on the text search configuration, and in turn all objects that depend on those objects.
 
-`RESTRICT`
+RESTRICT
 :   Refuse to drop the text search configuration if any objects depend on it. This is the default.
 
 ## <a id="section5"></a>Examples 
 
-Remove the text search configuration my\_english:
+Remove the text search configuration `my_english`:
 
 ```
 DROP TEXT SEARCH CONFIGURATION my_english;

--- a/gpdb-doc/markdown/ref_guide/sql_commands/DROP_TEXT_SEARCH_DICTIONARY.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/DROP_TEXT_SEARCH_DICTIONARY.html.md
@@ -10,20 +10,20 @@ DROP TEXT SEARCH DICTIONARY [ IF EXISTS ] <name> [ CASCADE | RESTRICT ]
 
 ## <a id="section3"></a>Description 
 
-`DROP TEXT SEARCH DICTIONARY` drops an existing text search dictionary. To run this command you must be the owner of the dictionary.
+`DROP TEXT SEARCH DICTIONARY` drops an existing text search dictionary. You must be the owner of the dictionary to run this command.
 
 ## <a id="section4"></a>Parameters 
 
-`IF EXISTS`
-:   Do not throw an error if the text search dictionary does not exist. A notice is issued in this case.
+IF EXISTS
+:   Do not throw an error if the text search dictionary does not exist. Greenplum Database issues a notice in this case.
 
-`name`
+name
 :   The name \(optionally schema-qualified\) of an existing text search dictionary.
 
-`CASCADE`
-:   Automatically drop objects that depend on the text search dictionary.
+CASCADE
+:   Automatically drop objects that depend on the text search dictionary, and in turn all objects that depend on those objects.
 
-`RESTRICT`
+RESTRICT
 :   Refuse to drop the text search dictionary if any objects depend on it. This is the default.
 
 ## <a id="section5"></a>Examples 

--- a/gpdb-doc/markdown/ref_guide/sql_commands/DROP_TEXT_SEARCH_PARSER.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/DROP_TEXT_SEARCH_PARSER.html.md
@@ -2,7 +2,7 @@
 
 ## <a id="Description"></a>Description 
 
-Remove a text search parser.
+Removes a text search parser.
 
 ## <a id="Synopsis"></a>Synopsis 
 
@@ -16,16 +16,16 @@ DROP TEXT SEARCH PARSER [ IF EXISTS ] <name> [ CASCADE | RESTRICT ]
 
 ## <a id="section4"></a>Parameters 
 
-`IF EXISTS`
-:   Do not throw an error if the text search parser does not exist. A notice is issued in this case.
+IF EXISTS
+:   Do not throw an error if the text search parser does not exist. Greenplum Database issues a notice in this case.
 
-`name`
+name
 :   The name \(optionally schema-qualified\) of an existing text search parser.
 
-`CASCADE`
-:   Automatically drop objects that depend on the text search parser.
+CASCADE
+:   Automatically drop objects that depend on the text search parser, and in turn all objects that depend on those objects.
 
-`RESTRICT`
+RESTRICT
 :   Refuse to drop the text search parser if any objects depend on it. This is the default.
 
 ## <a id="Examples"></a>Examples 

--- a/gpdb-doc/markdown/ref_guide/sql_commands/DROP_TEXT_SEARCH_TEMPLATE.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/DROP_TEXT_SEARCH_TEMPLATE.html.md
@@ -18,17 +18,27 @@ You must be a superuser to use `ALTER TEXT SEARCH TEMPLATE`.
 
 ## <a id="section4"></a>Parameters 
 
-`IF EXISTS`
-:   Do not throw an error if the text search template does not exist. A notice is issued in this case.
+IF EXISTS
+:   Do not throw an error if the text search template does not exist. Greenplum Database issues a notice in this case.
 
-`name`
+name
 :   The name \(optionally schema-qualified\) of an existing text search template.
 
-`CASCADE`
-:   Automatically drop objects that depend on the text search template.
+CASCADE
+:   Automatically drop objects that depend on the text search template, and in turn all objects that depend on those objects.
 
-`RESTRICT`
+RESTRICT
 :   Refuse to drop the text search template if any objects depend on it. This is the default.
+
+## <a id="section6"></a>Examples
+
+Remove the text search template `thesaurus`:
+
+```
+DROP TEXT SEARCH TEMPLATE thesaurus;
+```
+
+This command will not succeed if there are any existing text search dictionaries that use the template. Add `CASCADE` to drop such dictionaries along with the template. 
 
 ## <a id="section7"></a>Compatibility 
 


### PR DESCRIPTION
this PR updates the following sql command reference pages to align with the postgres v12 ref page content:
- ALTER/CREATE/DROP TEXT SEARCH CONFIGURATION
- ALTER/CREATE/DROP TEXT SEARCH DICTIONARY
- ALTER/CREATE/DROP TEXT SEARCH PARSER
- ALTER/CREATE/DROP TEXT SEARCH TEMPLATE

i didn't notice any greenplum-specific content on the pages.  most of the changes are minor edits or formatting fixes.
