### PR TITLE
Fix disjunctive constraint colid remapping

### DIFF
--- a/src/backend/gporca/libgpopt/src/operators/CLogicalDynamicGet.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CLogicalDynamicGet.cpp
@@ -159,14 +159,19 @@ CLogicalDynamicGet::PopCopyWithRemappedColumns(CMemoryPool *mp,
 	CName *pnameAlias = GPOS_NEW(mp) CName(mp, *m_pnameAlias);
 	m_ptabdesc->AddRef();
 	m_partition_mdids->AddRef();
+
+	CConstraint *partition_cnstrs_disj = nullptr;
+
 	if (m_partition_cnstrs_disj)
 	{
-		m_partition_cnstrs_disj->AddRef();
+		partition_cnstrs_disj =
+			m_partition_cnstrs_disj->PcnstrCopyWithRemappedColumns(
+				mp, colref_mapping, must_exist);
 	}
 
 	return GPOS_NEW(mp) CLogicalDynamicGet(
 		mp, pnameAlias, m_ptabdesc, m_scan_id, pdrgpcrOutput, pdrgpdrgpcrPart,
-		m_partition_mdids, m_partition_cnstrs_disj, m_static_pruned);
+		m_partition_mdids, partition_cnstrs_disj, m_static_pruned);
 }
 
 //---------------------------------------------------------------------------

--- a/src/test/regress/expected/bfv_partition.out
+++ b/src/test/regress/expected/bfv_partition.out
@@ -3083,6 +3083,25 @@ SELECT grant_table_in_function();
  
 (1 row)
 
+-- Validate that ISSUE #14395 which manifested as a crash while deriving stats
+-- on partitioned tables over CTEs is resolved.
+CREATE TABLE a_partition_table_used_in_cte_test(c1 int)
+PARTITION BY LIST(c1)
+(
+	PARTITION a_part values(2,3),
+	DEFAULT partition other
+);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO a_partition_table_used_in_cte_test SELECT 2;
+ANALYZE a_partition_table_used_in_cte_test;
+WITH cte AS (
+  SELECT * FROM a_partition_table_used_in_cte_test WHERE c1 < 2
+) SELECT * FROM cte WHERE c1 = 1;
+ c1 
+----
+(0 rows)
+
 -- CLEANUP
 -- start_ignore
 drop schema if exists bfv_partition cascade;

--- a/src/test/regress/sql/bfv_partition.sql
+++ b/src/test/regress/sql/bfv_partition.sql
@@ -1667,6 +1667,21 @@ SELECT grant_table_in_function();
 -- GrantStmt
 SELECT grant_table_in_function();
 
+-- Validate that ISSUE #14395 which manifested as a crash while deriving stats
+-- on partitioned tables over CTEs is resolved.
+CREATE TABLE a_partition_table_used_in_cte_test(c1 int)
+PARTITION BY LIST(c1)
+(
+	PARTITION a_part values(2,3),
+	DEFAULT partition other
+);
+
+INSERT INTO a_partition_table_used_in_cte_test SELECT 2;
+ANALYZE a_partition_table_used_in_cte_test;
+WITH cte AS (
+  SELECT * FROM a_partition_table_used_in_cte_test WHERE c1 < 2
+) SELECT * FROM cte WHERE c1 = 1;
+
 -- CLEANUP
 -- start_ignore
 drop schema if exists bfv_partition cascade;


### PR DESCRIPTION
ORCA was not remapping the colids of the disjunctive constraint when copying CLogicalDynamicGet with remapped columns. This led to a case where ORCA crashed while trying to derive stats on an unexpected colid.

Following is an example that demonstrated the issue:

  ```sql
CREATE TABLE pt(c1 int) PARTITION BY LIST(c1) (
  PARTITION a_part values(2,3),
  DEFAULT partition other);

INSERT INTO pt SELECT 2;
ANALYZE pt;
WITH cte AS (SELECT * FROM pt WHERE c1 < 2) SELECT * FROM cte WHERE c1 = 1;
  ```

Fixes #14395