### PR TITLE
ic-proxy: Fix cache eviction on remote peer shutdown

### DIFF
--- a/src/backend/cdb/motion/ic_proxy_backend.c
+++ b/src/backend/cdb/motion/ic_proxy_backend.c
@@ -456,7 +456,9 @@ void
 ic_proxy_backend_init_context(ChunkTransportState *state)
 {
 	ICProxyBackendContext *context;
-	
+
+	SIMPLE_FAULT_INJECTOR("ic_proxy_backend_init_context");
+
 	/* initialize backend context */
 	state->proxyContext = palloc0(sizeof(ICProxyBackendContext));
 	state->proxyContext->transportState = state;

--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -417,7 +417,11 @@ static BackgroundWorker PMAuxProcList[MaxPMAuxProc] =
 
 #ifdef ENABLE_IC_PROXY
 	{"ic proxy process", "ic proxy process",
+#ifdef FAULT_INJECTOR
+	 BGWORKER_SHMEM_ACCESS,
+#else
 	 0,
+#endif
 	 BgWorkerStart_RecoveryFinished,
 	 0, /* restart immediately if ic proxy process exits with non-zero code */
 	 "postgres", "ICProxyMain", 0, {0}, 0,

--- a/src/test/isolation2/Makefile
+++ b/src/test/isolation2/Makefile
@@ -62,7 +62,7 @@ clean distclean:
 
 install: all gpdiff.pl gpstringsubs.pl
 
-installcheck: install installcheck-parallel-retrieve-cursor
+installcheck: install installcheck-parallel-retrieve-cursor installcheck-ic-tcp installcheck-ic-proxy
 	$(pg_isolation2_regress_installcheck) --init-file=$(top_builddir)/src/test/regress/init_file --init-file=./init_file_isolation2 --schedule=$(srcdir)/isolation2_schedule
 
 installcheck-resgroup: install
@@ -73,3 +73,13 @@ installcheck-parallel-retrieve-cursor: install
 
 installcheck-mirrorless: install
 	$(pg_isolation2_regress_installcheck) $(EXTRA_REGRESS_OPTS) --init-file=$(top_builddir)/src/test/regress/init_file --init-file=./init_file_isolation2 --schedule=$(srcdir)/mirrorless_schedule --dbname=isolation2-mirrorless
+
+installcheck-ic-tcp: install
+ifeq ($(findstring gp_interconnect_type=tcp,$(PGOPTIONS)),gp_interconnect_type=tcp)
+	$(pg_isolation2_regress_installcheck) $(EXTRA_REGRESS_OPTS) --init-file=$(top_builddir)/src/test/regress/init_file --init-file=./init_file_isolation2 --bindir='$(bindir)' --inputdir=$(srcdir) --schedule=$(srcdir)/isolation2_ic_tcp_schedule
+endif
+
+installcheck-ic-proxy: install
+ifeq ($(findstring gp_interconnect_type=proxy,$(PGOPTIONS)),gp_interconnect_type=proxy)
+	$(pg_isolation2_regress_installcheck) $(EXTRA_REGRESS_OPTS) --init-file=$(top_builddir)/src/test/regress/init_file --init-file=./init_file_isolation2 --bindir='$(bindir)' --inputdir=$(srcdir) --schedule=$(srcdir)/isolation2_ic_proxy_schedule
+endif

--- a/src/test/isolation2/expected/ic_proxy_peer_shutdown.out
+++ b/src/test/isolation2/expected/ic_proxy_peer_shutdown.out
@@ -1,0 +1,85 @@
+-- Test to ensure that peer shutdown doesn't lead to packet loss.
+CREATE TABLE ic_proxy_peer_shutdown(i int);
+CREATE
+INSERT INTO ic_proxy_peer_shutdown VALUES (1), (2), (3);
+INSERT 3
+-- Will ensure that all peer setup is done.
+SELECT * FROM ic_proxy_peer_shutdown;
+ i 
+---
+ 1 
+ 2 
+ 3 
+(3 rows)
+
+-- Suspend regular client registration to force placeholder client creation for
+-- seg0 <-> seg-1.
+SELECT gp_inject_fault('ic_proxy_backend_init_context', 'suspend', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+SELECT gp_inject_fault_infinite('ic_proxy_client_cached_p2c_pkt', 'skip', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+
+-- Query involving only seg-1 (receiver) and seg0 (sender) will block.
+1&: SELECT * FROM ic_proxy_peer_shutdown WHERE i = 2;  <waiting ...>
+
+-- Wait until we have created a placeholder client for seg0 <-> seg-1
+-- communication in seg-1's proxy, and that placeholder has cached a DATA packet
+-- and a BYE packet from seg0.
+SELECT gp_wait_until_triggered_fault('ic_proxy_client_cached_p2c_pkt', 2, dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
+SELECT gp_inject_fault('ic_proxy_client_table_shutdown_by_dbid_end', 'skip', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+-- Now kill any IC proxy process to trigger a peer shutdown event in seg-1's proxy.
+!\retcode ps -ef | grep $(psql postgres -Atc "select port from gp_segment_configuration where content=1 and role='p'") | grep "ic proxy" | awk '{print $2}' | xargs kill;
+-- start_ignore
+
+-- end_ignore
+(exited with code 0)
+
+-- Wait until any client cache eviction has finished, resultant from the peer
+-- proxy shutdown.
+SELECT gp_wait_until_triggered_fault('ic_proxy_client_table_shutdown_by_dbid_end', 1, dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
+-- We should have handled the peer shutdown event gracefully, not lost any
+-- client-cached packets and let the blocked query complete.
+-- So, once we resume client processing, the query should be able to complete
+-- gracefully.
+SELECT gp_inject_fault('ic_proxy_backend_init_context', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+1<:  <... completed>
+ i 
+---
+ 2 
+(1 row)
+
+SELECT gp_inject_fault('ic_proxy_client_cached_p2c_pkt', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+SELECT gp_inject_fault('ic_proxy_client_table_shutdown_by_dbid_end', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)

--- a/src/test/isolation2/expected/tcp_ic_teardown.out
+++ b/src/test/isolation2/expected/tcp_ic_teardown.out
@@ -1,28 +1,10 @@
 -- Test ensuring that we perform a timed wait inside the TCP interconnect
 -- teardown on the motion sender side, for the final response from the motion
 -- receiver(s).
-
-CREATE FUNCTION set_gp_ic_type(ic_type text) RETURNS VOID as $$ import os cmd = 'gpconfig -c gp_interconnect_type -v %s' % ic_type if os.system(cmd) is not 0: plpy.error('Setting gp_interconnect_type to %s failed' % ic_type) $$ LANGUAGE plpython3u;
-CREATE
-
 CREATE TABLE tcp_ic_teardown(i int);
 CREATE
 INSERT INTO tcp_ic_teardown SELECT generate_series(1, 5);
 INSERT 5
-
--- Save current IC type before we set it to 'tcp', so we can revert it at the
--- end of the test.
--1U: CREATE TABLE saved_ic_type AS SELECT current_setting('gp_interconnect_type') AS ic_type;
-CREATE 1
--1U: SELECT set_gp_ic_type('tcp');
- set_gp_ic_type 
-----------------
-                
-(1 row)
-!\retcode gpstop -au;
--- start_ignore
--- end_ignore
-(exited with code 0)
 
 SELECT gp_inject_fault('waitOnOutbound', 'suspend', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
  gp_inject_fault 
@@ -77,16 +59,3 @@ SELECT gp_inject_fault('doSendStopMessageTCP', 'reset', dbid) FROM gp_segment_co
 1<:  <... completed>
 ERROR:  timed out waiting for response from motion receiver during TCP interconnect teardown  (seg1 slice1 192.168.0.148:7003 pid=654372)
 DETAIL:  1 connection(s) with pending response after 3 seconds
-
--- Revert IC type
--1U: SELECT set_gp_ic_type(ic_type) FROM saved_ic_type;
- set_gp_ic_type 
-----------------
-                
-(1 row)
-!\retcode gpstop -au;
--- start_ignore
--- end_ignore
-(exited with code 0)
--1U: DROP TABLE saved_ic_type;
-DROP

--- a/src/test/isolation2/isolation2_ic_proxy_schedule
+++ b/src/test/isolation2/isolation2_ic_proxy_schedule
@@ -1,0 +1,6 @@
+# Schedule with targeted tests for proxy interconnect.
+# Assumes that gp_interconnect_type=proxy
+# Assumes that gp_interconnect_proxy_addresses has been set up
+
+# test TCP interconnect teardown bounded wait (Proxy IC reuses TCP setup/teardown)
+test: tcp_ic_teardown

--- a/src/test/isolation2/isolation2_ic_proxy_schedule
+++ b/src/test/isolation2/isolation2_ic_proxy_schedule
@@ -4,3 +4,6 @@
 
 # test TCP interconnect teardown bounded wait (Proxy IC reuses TCP setup/teardown)
 test: tcp_ic_teardown
+
+# test TCP proxy peer shutdown
+test: ic_proxy_peer_shutdown

--- a/src/test/isolation2/isolation2_ic_tcp_schedule
+++ b/src/test/isolation2/isolation2_ic_tcp_schedule
@@ -1,0 +1,5 @@
+# Schedule with targeted tests for TCP interconnect.
+# Assumes that gp_interconnect_type=tcp
+
+# test TCP interconnect teardown bounded wait
+test: tcp_ic_teardown

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -307,9 +307,6 @@ test: sync_guc
 # test pg_export_snapshot with distributed snapshot functionality
 test: export_distributed_snapshot
 
-# test TCP interconnect teardown bounded wait
-test: tcp_ic_teardown
-
 # Tests for unique indexes on AO/CO tables (uses fault injector)
 test: ao_unique_index
 test: aocs_unique_index

--- a/src/test/isolation2/sql/ic_proxy_peer_shutdown.sql
+++ b/src/test/isolation2/sql/ic_proxy_peer_shutdown.sql
@@ -1,0 +1,45 @@
+-- Test to ensure that peer shutdown doesn't lead to packet loss.
+CREATE TABLE ic_proxy_peer_shutdown(i int);
+INSERT INTO ic_proxy_peer_shutdown VALUES (1), (2), (3);
+-- Will ensure that all peer setup is done.
+SELECT * FROM ic_proxy_peer_shutdown;
+
+-- Suspend regular client registration to force placeholder client creation for
+-- seg0 <-> seg-1.
+SELECT gp_inject_fault('ic_proxy_backend_init_context', 'suspend', dbid)
+    FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+SELECT gp_inject_fault_infinite('ic_proxy_client_cached_p2c_pkt', 'skip', dbid)
+    FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+
+-- Query involving only seg-1 (receiver) and seg0 (sender) will block.
+1&: SELECT * FROM ic_proxy_peer_shutdown WHERE i = 2;
+
+-- Wait until we have created a placeholder client for seg0 <-> seg-1
+-- communication in seg-1's proxy, and that placeholder has cached a DATA packet
+-- and a BYE packet from seg0.
+SELECT gp_wait_until_triggered_fault('ic_proxy_client_cached_p2c_pkt', 2, dbid)
+    FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+
+SELECT gp_inject_fault('ic_proxy_client_table_shutdown_by_dbid_end', 'skip', dbid)
+    FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+
+-- Now kill any IC proxy process to trigger a peer shutdown event in seg-1's proxy.
+!\retcode ps -ef | grep $(psql postgres -Atc "select port from gp_segment_configuration where content=1 and role='p'") | grep "ic proxy" | awk '{print $2}' | xargs kill;
+
+-- Wait until any client cache eviction has finished, resultant from the peer
+-- proxy shutdown.
+SELECT gp_wait_until_triggered_fault('ic_proxy_client_table_shutdown_by_dbid_end', 1, dbid)
+    FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+
+-- We should have handled the peer shutdown event gracefully, not lost any
+-- client-cached packets and let the blocked query complete.
+-- So, once we resume client processing, the query should be able to complete
+-- gracefully.
+SELECT gp_inject_fault('ic_proxy_backend_init_context', 'reset', dbid)
+    FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+1<:
+
+SELECT gp_inject_fault('ic_proxy_client_cached_p2c_pkt', 'reset', dbid)
+    FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+SELECT gp_inject_fault('ic_proxy_client_table_shutdown_by_dbid_end', 'reset', dbid)
+    FROM gp_segment_configuration WHERE role = 'p' AND content = -1;

--- a/src/test/isolation2/sql/tcp_ic_teardown.sql
+++ b/src/test/isolation2/sql/tcp_ic_teardown.sql
@@ -1,23 +1,8 @@
 -- Test ensuring that we perform a timed wait inside the TCP interconnect
 -- teardown on the motion sender side, for the final response from the motion
 -- receiver(s).
-
-CREATE FUNCTION set_gp_ic_type(ic_type text)
-    RETURNS VOID as $$
-import os
-cmd = 'gpconfig -c gp_interconnect_type -v %s' % ic_type
-if os.system(cmd) is not 0:
-    plpy.error('Setting gp_interconnect_type to %s failed' % ic_type)
-$$ LANGUAGE plpython3u;
-
 CREATE TABLE tcp_ic_teardown(i int);
 INSERT INTO tcp_ic_teardown SELECT generate_series(1, 5);
-
--- Save current IC type before we set it to 'tcp', so we can revert it at the
--- end of the test.
--1U: CREATE TABLE saved_ic_type AS SELECT current_setting('gp_interconnect_type') AS ic_type;
--1U: SELECT set_gp_ic_type('tcp');
-!\retcode gpstop -au;
 
 SELECT gp_inject_fault('waitOnOutbound', 'suspend', dbid)
     FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
@@ -47,8 +32,3 @@ SELECT gp_inject_fault('doSendStopMessageTCP', 'reset', dbid)
 -- After 6s have elapsed (enough to have covered the timed wait of 3s, we should
 -- have consequently ERRORed out on the motion sender side)
 1<:
-
--- Revert IC type
--1U: SELECT set_gp_ic_type(ic_type) FROM saved_ic_type;
-!\retcode gpstop -au;
--1U: DROP TABLE saved_ic_type;


### PR DESCRIPTION
Upon remote peer shutdown, we need to drop all logical connections
involving the remote peer. A part of that is dropping packets that were
cached by placeholder clients.

Unfortunately, we were indiscriminately dropping these for clients
belonging to ALL logical connections (regardless of the dbid of the
remote peer) in ic_proxy_client_table_shutdown_by_dbid().

This can lead to DATA and BYE packets being dropped from the client-local
cache for unrelated connections, leading to messages like:

WARNING: ic-proxy: client.placeholder[...]: unhandled cached BYE [..], dropping it

Consequently, later when the placeholder clients are replaced by actual
clients, these packets aren't transferred and ultimately are never
processed, leading to messages like:
DEBUG3: ic-proxy: [...]: replace my placeholder client.placeholder[...]
DEBUG3: ic-proxy: [...]: no cached pkts in the placeholder client.placeholder[...]

If BYEs are dropped like this and left unhandled, it will lead to hangs
on the remote side in waitForOutbound(). The test added highlights this
case.

We fix this by dropping cached packets ONLY for clients whose remote dbid
matches the remote peer's dbid.