### PR TITLE
ao/co: Move unique index DML tests to new group

### DIFF
--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -229,7 +229,7 @@ test: uao_ddl/alter_drop_allcol_row uao_ddl/alter_drop_allcol_column uao_ddl/alt
 # These tests use gp_select_invisible and VACUUM, and will get confused if there are
 # concurrent transactions holding back the global xmin.
 
-test: uao_dml/uao_dml_cursor_row uao_dml/uao_dml_select_row uao_dml/uao_dml_cursor_column uao_dml/uao_dml_select_column uao_dml/uao_dml_unique_index_delete_row uao_dml/uao_dml_unique_index_delete_column uao_dml/uao_dml_unique_index_update_row uao_dml/uao_dml_unique_index_update_column
+test: uao_dml/uao_dml_cursor_row uao_dml/uao_dml_select_row uao_dml/uao_dml_cursor_column uao_dml/uao_dml_select_column
 
 
 # disable autovacuum for the test
@@ -312,5 +312,8 @@ test: motion_socket
 test: subtrx_overflow
 
 test: dboptions
+
+# DML tests for AO/CO unique indexes.
+test: uao_dml/uao_dml_unique_index_delete_row uao_dml/uao_dml_unique_index_delete_column uao_dml/uao_dml_unique_index_update_row uao_dml/uao_dml_unique_index_update_column
 
 # end of tests


### PR DESCRIPTION
Grouping them with the other uao_dml tests led to flakes. Move them to a new group.

Heed the words of wisdom:

"These tests use gp_select_invisible and VACUUM, and will get confused if there are concurrent transactions holding back the global xmin."