### PR TITLE
ao/co: Fix snapshot setup for unique index checks

### DIFF
--- a/src/backend/access/aocs/aocsam_handler.c
+++ b/src/backend/access/aocs/aocsam_handler.c
@@ -401,7 +401,7 @@ get_or_create_delete_descriptor(const Relation relation, bool forUpdate)
 }
 
 static AOCSUniqueCheckDesc
-get_or_create_unique_check_desc(Relation relation, Snapshot snapshot)
+get_or_create_unique_check_desc(Relation relation)
 {
 	AOCODMLState *state = find_dml_state(RelationGetRelid(relation));
 
@@ -417,8 +417,16 @@ get_or_create_unique_check_desc(Relation relation, Snapshot snapshot)
 
 		/* Initialize the block directory */
 		uniqueCheckDesc->blockDirectory = palloc0(sizeof(AppendOnlyBlockDirectory));
+		/*
+		 * Note: we defer setting up the appendOnlyMetaDataSnapshot for the
+		 * block directory to aoco_index_fetch_tuple_exists(). This is because
+		 * snapshots used for unique index lookups may be stack-allocated and a
+		 * new snapshot object may be passed to every unique index check. (for
+		 * SNAPSHOT_DIRTY)
+		 */
 		AppendOnlyBlockDirectory_Init_forSearch(uniqueCheckDesc->blockDirectory,
-												snapshot, NULL, -1, relation,
+												InvalidSnapshot, /* appendOnlyMetaDataSnapshot */
+												NULL, -1, relation,
 												relation->rd_att->natts, false, NULL);
 		/*
 		 * If this is part of an update, we need to reuse the visimap used by
@@ -434,14 +442,21 @@ get_or_create_unique_check_desc(Relation relation, Snapshot snapshot)
 			/* Initialize the visimap */
 			uniqueCheckDesc->visimap = palloc0(sizeof(AppendOnlyVisimap));
 			GetAppendOnlyEntryAuxOids(relation->rd_id,
-									  snapshot,
+									  InvalidSnapshot, /* catalog snap is fine for this */
 									  NULL, NULL, NULL,
 									  &visimaprelid, &visimapidxid);
+			/*
+			 * Note: we don't set up the appendOnlyMetadataSnapshot for the
+			 * visimap here. It is deferred to aoco_index_fetch_tuple_exists().
+			 * This is because snapshots used for unique index lookups may be
+			 * stack-allocated and a new snapshot object may be used for every
+			 * unique index check. (for SNAPSHOT_DIRTY)
+			 */
 			AppendOnlyVisimap_Init(uniqueCheckDesc->visimap,
 								   visimaprelid,
 								   visimapidxid,
 								   AccessShareLock,
-								   snapshot);
+								   InvalidSnapshot /* appendOnlyMetaDataSnapshot */);
 		}
 
 		state->uniqueCheckDesc = uniqueCheckDesc;
@@ -841,7 +856,11 @@ aoco_index_fetch_tuple_exists(Relation rel,
 {
 	AOCSUniqueCheckDesc 		uniqueCheckDesc;
 	AOTupleId 					*aoTupleId = (AOTupleId *) tid;
+	AppendOnlyBlockDirectory 	*blockDirectory;
+	AppendOnlyVisimap 			*visimap;
+	bool						blkdir_covers;
 	bool						visible;
+	Snapshot 					save_snapshot;
 
 #ifdef USE_ASSERT_CHECKING
 	int			segmentFileNum = AOTupleIdGet_segmentFileNum(aoTupleId);
@@ -880,14 +899,23 @@ aoco_index_fetch_tuple_exists(Relation rel,
 	if (snapshot->snapshot_type == SNAPSHOT_SELF)
 		return true;
 
-	uniqueCheckDesc = get_or_create_unique_check_desc(rel, snapshot);
+	uniqueCheckDesc = get_or_create_unique_check_desc(rel);
 
 	/*
 	 * Check to see if there is a block directory entry for the tuple. If no
 	 * such entry exists, the tuple doesn't exist physically in the segfile.
+	 *
+	 * Note: We need to use the passed in snapshot to perform the block
+	 * directory lookup. See get_or_create_unique_check_desc() for why we don't
+	 * set the snapshot up prior.
 	 */
-	if (!AppendOnlyBlockDirectory_CoversTuple(uniqueCheckDesc->blockDirectory,
-											  aoTupleId))
+	blockDirectory = uniqueCheckDesc->blockDirectory;
+	Assert(blockDirectory->appendOnlyMetaDataSnapshot == InvalidSnapshot);
+	blockDirectory->appendOnlyMetaDataSnapshot = snapshot;
+	blkdir_covers = AppendOnlyBlockDirectory_CoversTuple(blockDirectory,
+														 aoTupleId);
+	blockDirectory->appendOnlyMetaDataSnapshot = InvalidSnapshot;
+	if (!blkdir_covers)
 		return false;
 
 	/*
@@ -902,8 +930,19 @@ aoco_index_fetch_tuple_exists(Relation rel,
 	/*
 	 * Consult the visimap to check if the tuple was deleted by a *committed*
 	 * transaction.
+	 *
+	 * Note: we need to use the passed in snapshot to perform the visimap lookup.
+	 * See get_or_create_unique_check_desc() for why we don't set the snapshot
+	 * up prior there.
+	 * If this is part of an update, we are reusing the visimap from the delete
+	 * half of the update, so better restore its snapshot once we are done.
 	 */
-	visible = AppendOnlyVisimap_IsVisible(uniqueCheckDesc->visimap, aoTupleId);
+	visimap = uniqueCheckDesc->visimap;
+	save_snapshot = visimap->visimapStore.snapshot;
+	visimap->visimapStore.snapshot = snapshot;
+	visible = AppendOnlyVisimap_IsVisible(visimap, aoTupleId);
+	visimap->visimapStore.snapshot = save_snapshot;
+
 	/*
 	 * Since we disallow deletes and updates running in parallel with inserts,
 	 * there is no way that the dirty snapshot has it's xmin and xmax populated
@@ -915,6 +954,7 @@ aoco_index_fetch_tuple_exists(Relation rel,
 	 */
 	AssertImply(Gp_role != GP_ROLE_UTILITY,
 				(!TransactionIdIsValid(snapshot->xmin) && !TransactionIdIsValid(snapshot->xmax)));
+
 	return visible;
 }
 

--- a/src/backend/access/appendonly/appendonlyam_handler.c
+++ b/src/backend/access/appendonly/appendonlyam_handler.c
@@ -354,7 +354,7 @@ get_or_create_delete_descriptor(const Relation relation, bool forUpdate)
 }
 
 static AppendOnlyUniqueCheckDesc
-get_or_create_unique_check_desc(Relation relation, Snapshot snapshot)
+get_or_create_unique_check_desc(Relation relation)
 {
 	AppendOnlyDMLState *state = find_dml_state(RelationGetRelid(relation));
 
@@ -370,8 +370,16 @@ get_or_create_unique_check_desc(Relation relation, Snapshot snapshot)
 
 		/* Initialize the block directory */
 		uniqueCheckDesc->blockDirectory = palloc0(sizeof(AppendOnlyBlockDirectory));
+		/*
+		 * Note: we defer setting up the appendOnlyMetaDataSnapshot for the
+		 * block directory to appendonly_index_fetch_tuple_exists(). This is
+		 * because snapshots used for unique index lookups may be stack-allocated
+		 * and a new snapshot object may be passed to every unique index check.
+		 * (for SNAPSHOT_DIRTY)
+		 */
 		AppendOnlyBlockDirectory_Init_forSearch(uniqueCheckDesc->blockDirectory,
-												snapshot, NULL, -1, relation,
+												InvalidSnapshot, /* appendOnlyMetaDataSnapshot */
+												NULL, -1, relation,
 												1, false, NULL);
 
 		/*
@@ -388,14 +396,21 @@ get_or_create_unique_check_desc(Relation relation, Snapshot snapshot)
 			/* Initialize the visimap */
 			uniqueCheckDesc->visimap = palloc0(sizeof(AppendOnlyVisimap));
 			GetAppendOnlyEntryAuxOids(relation->rd_id,
-									  snapshot,
+									  InvalidSnapshot, /* catalog snap is fine for this */
 									  NULL, NULL, NULL,
 									  &visimaprelid, &visimapidxid);
+			/*
+			 * Note: we don't set up the appendOnlyMetadataSnapshot for the
+			 * visimap here. It is deferred to appendonly_index_fetch_tuple_exists().
+			 * This is because snapshots used for unique index lookups may be
+			 * stack-allocated and a new snapshot object may be used for every
+			 * unique index check. (for SNAPSHOT_DIRTY)
+			 */
 			AppendOnlyVisimap_Init(uniqueCheckDesc->visimap,
 								   visimaprelid,
 								   visimapidxid,
 								   AccessShareLock,
-								   snapshot);
+								   InvalidSnapshot /* appendOnlyMetaDataSnapshot */);
 		}
 
 		state->uniqueCheckDesc = uniqueCheckDesc;
@@ -608,7 +623,11 @@ appendonly_index_fetch_tuple_exists(Relation rel,
 {
 	AppendOnlyUniqueCheckDesc 	uniqueCheckDesc;
 	AOTupleId 					*aoTupleId = (AOTupleId *) tid;
+	AppendOnlyBlockDirectory 	*blockDirectory;
+	AppendOnlyVisimap 			*visimap;
+	bool						blkdir_covers;
 	bool						visible;
+	Snapshot 					save_snapshot;
 
 #ifdef USE_ASSERT_CHECKING
 	int			segmentFileNum = AOTupleIdGet_segmentFileNum(aoTupleId);
@@ -647,13 +666,23 @@ appendonly_index_fetch_tuple_exists(Relation rel,
 	if (snapshot->snapshot_type == SNAPSHOT_SELF)
 		return true;
 
-	uniqueCheckDesc = get_or_create_unique_check_desc(rel, snapshot);
+	uniqueCheckDesc = get_or_create_unique_check_desc(rel);
+
 	/*
 	 * Check to see if there is a block directory entry for the tuple. If no
 	 * such entry exists, the tuple doesn't exist physically in the segfile.
+	 *
+	 * Note: We need to use the passed in snapshot to perform the block
+	 * directory lookup. See get_or_create_unique_check_desc() for why we don't
+	 * set the snapshot up prior.
 	 */
-	if (!AppendOnlyBlockDirectory_CoversTuple(uniqueCheckDesc->blockDirectory,
-											  aoTupleId))
+	blockDirectory = uniqueCheckDesc->blockDirectory;
+	Assert(blockDirectory->appendOnlyMetaDataSnapshot == InvalidSnapshot);
+	blockDirectory->appendOnlyMetaDataSnapshot = snapshot;
+	blkdir_covers = AppendOnlyBlockDirectory_CoversTuple(blockDirectory,
+														 aoTupleId);
+	blockDirectory->appendOnlyMetaDataSnapshot = InvalidSnapshot;
+	if (!blkdir_covers)
 		return false;
 
 	/*
@@ -668,8 +697,19 @@ appendonly_index_fetch_tuple_exists(Relation rel,
 	/*
 	 * Consult the visimap to check if the tuple was deleted by a *committed*
 	 * transaction.
+	 *
+	 * Note: we need to use the passed in snapshot to perform the visimap lookup.
+	 * See get_or_create_unique_check_desc() for why we don't set the snapshot
+	 * up prior there.
+	 * If this is part of an update, we are reusing the visimap from the delete
+	 * half of the update, so better restore its snapshot once we are done.
 	 */
-	visible = AppendOnlyVisimap_IsVisible(uniqueCheckDesc->visimap, aoTupleId);
+	visimap = uniqueCheckDesc->visimap;
+	save_snapshot = visimap->visimapStore.snapshot;
+	visimap->visimapStore.snapshot = snapshot;
+	visible = AppendOnlyVisimap_IsVisible(visimap, aoTupleId);
+	visimap->visimapStore.snapshot = save_snapshot;
+
 	/*
 	 * Since we disallow deletes and updates running in parallel with inserts,
 	 * there is no way that the dirty snapshot has it's xmin and xmax populated
@@ -681,6 +721,7 @@ appendonly_index_fetch_tuple_exists(Relation rel,
 	 */
 	AssertImply(Gp_role != GP_ROLE_UTILITY,
 				(!TransactionIdIsValid(snapshot->xmin) && !TransactionIdIsValid(snapshot->xmax)));
+
 	return visible;
 }
 


### PR DESCRIPTION
Unique index checks use SNAPSHOT_DIRTY, which is stack allocated and a
new snapshot object is passed always to table_index_fetch_tuple_check().

While this is fine for heap, for AO/CO tables, we persist this stack
allocated object in the unique check descriptor's block directory and
visimap data structures, which are palloced. This leads to nasty memory
trespassing, resulting in segfaults.

Remedy this by deferring the metadata snapshot assignment to
index_fetch_tuple_exists(), just before the block directory and visimap
are scanned.

This should help fix the prod CI.

Dev pipeline for added coverage: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/aoco_uniq_snap_fix