### PR TITLE
Implement Fast Analyze on AO/CO Tables

### DIFF
--- a/src/backend/access/aocs/aocs_compaction.c
+++ b/src/backend/access/aocs/aocs_compaction.c
@@ -309,7 +309,7 @@ AOCSSegmentFileFullCompaction(Relation aorel,
 		/*
 		 * Report that we are now scanning and compacting segment files.
 		 */
-		curr_num_dead_tuples = scanDesc->cur_seg_row + 1 - moved_tupleCount;
+		curr_num_dead_tuples = scanDesc->segrowsprocessed + 1 - moved_tupleCount;
 		if (curr_num_dead_tuples > prev_num_dead_tuples)
 		{
 			pgstat_progress_update_param(PROGRESS_VACUUM_NUM_DEAD_TUPLES,
@@ -326,7 +326,7 @@ AOCSSegmentFileFullCompaction(Relation aorel,
 		}
 	}
 	/* Accumulate total number dead tuples */
-	vacrelstats->num_dead_tuples += scanDesc->cur_seg_row - moved_tupleCount;
+	vacrelstats->num_dead_tuples += scanDesc->segrowsprocessed - moved_tupleCount;
 
 	MarkAOCSFileSegInfoAwaitingDrop(aorel, compact_segno);
 

--- a/src/backend/access/aocs/aocsam.c
+++ b/src/backend/access/aocs/aocsam.c
@@ -112,6 +112,11 @@ open_all_datumstreamread_segfiles(AOCSScanDesc scan, AOCSFileSegInfo *segInfo)
 		AttrNumber	attno = proj_atts[i];
 
 		open_datumstreamread_segfile(basepath, rel, segInfo, ds[attno], attno);
+
+		/* skip reading block for ANALYZE */
+		if ((scan->rs_base.rs_flags & SO_TYPE_ANALYZE) != 0)
+			continue;
+
 		datumstreamread_block(ds[attno], blockDirectory, attno);
 
 		AOCSScanDesc_UpdateTotalBytesRead(scan, attno);
@@ -426,6 +431,46 @@ close_cur_scan_seg(AOCSScanDesc scan)
 		AppendOnlyBlockDirectory_End_forInsert(scan->blockDirectory);
 }
 
+static void
+aocs_blkdirscan_init(AOCSScanDesc scan)
+{
+	if (scan->aocsfetch == NULL)
+	{
+		int natts = RelationGetNumberOfAttributes(scan->rs_base.rs_rd);
+		scan->proj = palloc(natts * sizeof(*scan->proj));
+		MemSet(scan->proj, true, natts * sizeof(*scan->proj));
+
+		scan->aocsfetch = aocs_fetch_init(scan->rs_base.rs_rd,
+										  scan->rs_base.rs_snapshot,
+										  scan->appendOnlyMetaDataSnapshot,
+										  scan->proj);
+	}
+
+	scan->blkdirscan = palloc0(sizeof(AOBlkDirScanData));
+	AOBlkDirScan_Init(scan->blkdirscan, &scan->aocsfetch->blockDirectory);
+}
+
+static void
+aocs_blkdirscan_finish(AOCSScanDesc scan)
+{
+	AOBlkDirScan_Finish(scan->blkdirscan);
+	pfree(scan->blkdirscan);
+	scan->blkdirscan = NULL;
+
+	if (scan->aocsfetch != NULL)
+	{
+		aocs_fetch_finish(scan->aocsfetch);
+		pfree(scan->aocsfetch);
+		scan->aocsfetch = NULL;
+	}
+
+	if (scan->proj != NULL)
+	{
+		pfree(scan->proj);
+		scan->proj = NULL;
+	}
+}
+
 /*
  * aocs_beginrangescan
  *
@@ -508,6 +553,7 @@ aocs_beginscan_internal(Relation relation,
 	AOCSScanDesc	scan;
 	AttrNumber		natts;
 	Oid				visimaprelid;
+	Oid				blkdirrelid;
 
 	scan = (AOCSScanDesc) palloc0(sizeof(AOCSScanDescData));
 	scan->rs_base.rs_rd = relation;
@@ -547,6 +593,12 @@ aocs_beginscan_internal(Relation relation,
 
 	scan->columnScanInfo.ds = NULL;
 
+	if ((flags & SO_TYPE_ANALYZE) != 0)
+	{
+		scan->segfirstrow = 0;
+		scan->targrow = 0;
+	}
+
 	GetAppendOnlyEntryAttributes(RelationGetRelid(relation),
 								 NULL,
 								 NULL,
@@ -554,14 +606,23 @@ aocs_beginscan_internal(Relation relation,
 								 NULL);
 
 	GetAppendOnlyEntryAuxOids(relation,
-							  NULL, NULL,
+							  NULL,
+							  &blkdirrelid,
 							  &visimaprelid);
 
 	if (scan->total_seg != 0)
+	{
 		AppendOnlyVisimap_Init(&scan->visibilityMap,
 							   visimaprelid,
 							   AccessShareLock,
 							   appendOnlyMetaDataSnapshot);
+
+		if ((flags & SO_TYPE_ANALYZE) != 0)
+		{
+			if (OidIsValid(blkdirrelid))
+				aocs_blkdirscan_init(scan);
+		}
+	}
 
 	return scan;
 }
@@ -615,9 +676,403 @@ aocs_endscan(AOCSScanDesc scan)
 	if (scan->total_seg != 0)
 		AppendOnlyVisimap_Finish(&scan->visibilityMap, AccessShareLock);
 
+	if (scan->blkdirscan != NULL)
+		aocs_blkdirscan_finish(scan);
+
 	RelationDecrementReferenceCount(scan->rs_base.rs_rd);
 
 	pfree(scan);
+}
+
+static int
+aocs_locate_target_segment(AOCSScanDesc scan, int64 targrow)
+{
+	int64 rowcount;
+
+	for (int i = scan->cur_seg; i < scan->total_seg; i++)
+	{
+		if (i < 0)
+			continue;
+
+		rowcount = scan->seginfo[i]->total_tupcount;
+		if (rowcount <= 0)
+			continue;
+
+		if (scan->segfirstrow + rowcount - 1 >= targrow)
+		{
+			/* found the target segment */
+			return i;
+		}
+
+		/* continue next segment */
+		scan->segfirstrow += rowcount;
+		scan->segrowsprocessed = 0;
+	}
+
+	/* row is beyond the total number of rows in the relation */
+	return -1;
+}
+
+/*
+ * block directory based get_target_tuple()
+ */
+static bool
+aocs_blkdirscan_get_target_tuple(AOCSScanDesc scan, int64 targrow, TupleTableSlot *slot)
+{
+	int segno, segidx;
+	int64 rownum = -1;
+	int64 rowsprocessed;
+	AOTupleId aotid;
+	int ncols = scan->columnScanInfo.relationTupleDesc->natts;
+	AppendOnlyBlockDirectory *blkdir = &scan->aocsfetch->blockDirectory;
+
+	Assert(scan->blkdirscan != NULL);
+
+	/* locate the target segment */
+	segidx = aocs_locate_target_segment(scan, targrow);
+	if (segidx < 0)
+		return false;
+
+	/* next starting position in locating segfile */
+	scan->cur_seg = segidx;
+
+	segno = scan->seginfo[segidx]->segno;
+	Assert(segno > InvalidFileSegNumber && segno <= AOTupleId_MaxSegmentFileNum);
+
+	/*
+	 * Note: It is safe to assume that the scan's segfile array and the
+	 * blockdir's segfile array are identical. Otherwise, we should stop
+	 * processing and throw an exception to make the error visible.
+	 */
+	if (blkdir->segmentFileInfo[segidx]->segno != segno)
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_INTERNAL_ERROR),
+				 errmsg("segfile array contents in both scan descriptor "
+				 		"and block directory are not identical on "
+						"append-optimized relation '%s'",
+						RelationGetRelationName(blkdir->aoRel))));
+	}
+
+	/*
+	 * Unlike ao_row, we set currentSegmentFileNum for ao_column here
+	 * just for passing the assertion in extract_minipage() called by
+	 * AOBlkDirScan_GetRowNum().
+	 * Since we don't invoke AppendOnlyBlockDirectory_GetCachedEntry()
+	 * for ao_column, it shoule be restored back to the original value
+	 * for AppendOnlyBlockDirectory_GetEntry() working properly.
+	 */
+	int currentSegmentFileNum = blkdir->currentSegmentFileNum;
+	blkdir->currentSegmentFileNum = blkdir->segmentFileInfo[segidx]->segno;
+
+	/* locate the target row by seqscan block directory */
+	for (int col = 0; col < ncols; col++)
+	{
+		/*
+		 * "segfirstrow" should be always pointing to the first row of
+		 * a new segfile, only locate_target_segment could update
+		 * its value.
+		 * 
+		 * "segrowsprocessed" is used for tracking the position of
+		 * processed rows in the current segfile.
+		 */
+		rowsprocessed = scan->segfirstrow + scan->segrowsprocessed;
+
+		if ((scan->rs_base.rs_rd)->rd_att->attrs[col].attisdropped)
+			continue;
+
+		rownum = AOBlkDirScan_GetRowNum(scan->blkdirscan,
+										segno,
+										col,
+										targrow,
+										&rowsprocessed);
+
+		elog(DEBUG2, "AOBlkDirScan_GetRowNum(segno: %d, col: %d, targrow: %ld): "
+			 "[segfirstrow: %ld, segrowsprocessed: %ld, rownum: %ld, cached_mpentry_num: %d]",
+			 segno, col, targrow, scan->segfirstrow, scan->segrowsprocessed, rownum,
+			 blkdir->cached_mpentry_num);
+
+		if (rownum < 0)
+			continue;
+
+		scan->segrowsprocessed = rowsprocessed - scan->segfirstrow;
+
+		/*
+		 * Found a column represented in the block directory.
+		 * Here we just look for the 1st such column, no need
+		 * to read other columns within the same row.
+		 */
+		break;
+	}
+
+	/* restore to the original value as above mentioned */
+	blkdir->currentSegmentFileNum = currentSegmentFileNum;
+
+	if (rownum < 0)
+		return false;
+
+	/* form the target tuple TID */
+	AOTupleIdInit(&aotid, segno, rownum);
+
+	ExecClearTuple(slot);
+
+	/* fetch the target tuple */
+	if(!aocs_fetch(scan->aocsfetch, &aotid, slot))
+		return false;
+
+	/* OK to return this tuple */
+	ExecStoreVirtualTuple(slot);
+	pgstat_count_heap_fetch(scan->rs_base.rs_rd);
+
+	return true;
+}
+
+/*
+ * returns the segfile number in which `targrow` locates  
+ */
+static int
+aocs_getsegment(AOCSScanDesc scan, int64 targrow)
+{
+	int segno, segidx;
+
+	/* locate the target segment */
+	segidx = aocs_locate_target_segment(scan, targrow);
+	if (segidx < 0)
+	{
+		/* done reading all segments */
+		close_cur_scan_seg(scan);
+		scan->cur_seg = -1;
+		return -1;
+	}
+
+	segno = scan->seginfo[segidx]->segno;
+	Assert(segno > InvalidFileSegNumber && segno <= AOTupleId_MaxSegmentFileNum);
+
+	if (segidx > scan->cur_seg)
+	{
+		close_cur_scan_seg(scan);
+		/* adjust cur_seg to fit for open_next_scan_seg() */
+		scan->cur_seg = segidx - 1;
+		if (open_next_scan_seg(scan) >= 0)
+		{
+			/* new segment, make sure segrowsprocessed was reset */
+			Assert(scan->segrowsprocessed == 0);
+		}
+		else
+		{
+			ereport(ERROR,
+					(errcode(ERRCODE_INTERNAL_ERROR),
+					 errmsg("Unexpected behavior, failed to open segno %d during scanning AOCO table %s",
+							segno, RelationGetRelationName(scan->rs_base.rs_rd))));
+		}
+	}
+	
+	return segno;
+}
+
+static inline int
+aocs_block_remaining_rows(DatumStreamRead *ds)
+{
+	return (ds->blockRowCount - ds->blockRowsProcessed);
+}
+
+/*
+ * fetches a single column value corresponding to `endrow` (equals to `targrow`)
+ */
+static bool
+aocs_gettuple_column(AOCSScanDesc scan, AttrNumber attno, int64 startrow, int64 endrow, bool chkvisimap, TupleTableSlot *slot)
+{
+	bool isSnapshotAny = (scan->rs_base.rs_snapshot == SnapshotAny);
+	DatumStreamRead *ds = scan->columnScanInfo.ds[attno];
+	int segno = scan->seginfo[scan->cur_seg]->segno;
+	AOTupleId aotid;
+	bool ret = true;
+	int64 rowstoprocess, nrows, rownum;
+	Datum *values;
+	bool *nulls;
+
+	if (ds->blockFirstRowNum <= 0)
+		elog(ERROR, "AOCO varblock->blockFirstRowNum should be greater than zero.");
+
+	Assert(segno > InvalidFileSegNumber && segno <= AOTupleId_MaxSegmentFileNum);
+	Assert(startrow <= endrow);
+
+	rowstoprocess = endrow - startrow + 1;
+	nrows = ds->blockRowsProcessed + rowstoprocess;
+	rownum = ds->blockFirstRowNum + nrows - 1;
+
+	/* form the target tuple TID */
+	AOTupleIdInit(&aotid, segno, rownum);
+
+	if (chkvisimap && !isSnapshotAny && !AppendOnlyVisimap_IsVisible(&scan->visibilityMap, &aotid))
+	{
+		if (slot != NULL)
+			ExecClearTuple(slot);
+		
+		ret = false;
+		/* must update tracking vars before return */
+		goto out;
+	}
+
+	/* rowNumInBlock = rowNum - blockFirstRowNum */
+	datumstreamread_find(ds, rownum - ds->blockFirstRowNum);
+
+	values = slot->tts_values;
+	nulls = slot->tts_isnull;
+
+	datumstreamread_get(ds, &(values[attno]), &(nulls[attno]));
+
+out:
+	/* update rows processed */
+	ds->blockRowsProcessed += rowstoprocess;
+
+	return ret;
+}
+
+/*
+ * fetches all columns of the target tuple corresponding to `targrow`
+ */
+static bool
+aocs_gettuple(AOCSScanDesc scan, int64 targrow, TupleTableSlot *slot)
+{
+	bool ret = true;
+	int64 rowcount = -1;
+	int64 rowstoprocess;
+	bool chkvisimap = true;
+
+	Assert(scan->cur_seg >= 0);
+	Assert(slot != NULL);
+
+	ExecClearTuple(slot);
+
+	rowstoprocess = targrow - scan->segfirstrow + 1;
+
+	/* read from scan->cur_seg */
+	for (AttrNumber i = 0; i < scan->columnScanInfo.num_proj_atts; i++)
+	{
+		AttrNumber attno = scan->columnScanInfo.proj_atts[i];
+		DatumStreamRead *ds = scan->columnScanInfo.ds[attno];
+		int64 startrow = scan->segfirstrow + scan->segrowsprocessed;
+
+		if (ds->blockRowCount <= 0)
+			; /* haven't read block */
+		else
+		{
+			/* block was read */
+			rowcount = aocs_block_remaining_rows(ds);
+			Assert(rowcount >= 0);
+
+			if (startrow + rowcount - 1 >= targrow)
+			{
+				if (!aocs_gettuple_column(scan, attno, startrow, targrow, chkvisimap, slot))
+				{
+					ret = false;
+					/* must update tracking vars before return */
+					goto out;
+				}
+
+				chkvisimap = false;
+				/* haven't finished scanning on current block */
+				continue;
+			}
+			else
+				startrow += rowcount; /* skip scanning remaining rows */
+		}
+
+		/*
+		 * Keep reading block headers until we find the block containing
+		 * the target row.
+		 */
+		while (true)
+		{
+			elog(DEBUG2, "aocs_gettuple(): [targrow: %ld, currow: %ld, diff: %ld, "
+				 "startrow: %ld, rowcount: %ld, segfirstrow: %ld, segrowsprocessed: %ld, nth: %d, "
+				 "blockRowCount: %d, blockRowsProcessed: %d]", targrow, startrow + rowcount - 1,
+				 startrow + rowcount - 1 - targrow, startrow, rowcount, scan->segfirstrow,
+				 scan->segrowsprocessed, datumstreamread_nth(ds), ds->blockRowCount,
+				 ds->blockRowsProcessed);
+
+			if (datumstreamread_block_info(ds))
+			{
+				rowcount = ds->blockRowCount;
+				Assert(rowcount > 0);
+
+				/* new block, reset blockRowsProcessed */
+				ds->blockRowsProcessed = 0;
+
+				if (startrow + rowcount - 1 >= targrow)
+				{
+					/* read a new buffer to consume */
+					datumstreamread_block_content(ds);
+
+					if (!aocs_gettuple_column(scan, attno, startrow, targrow, chkvisimap, slot))
+					{
+						ret = false;
+						/* must update tracking vars before return */
+						goto out;
+					}
+
+					chkvisimap = false;
+					/* done this column */
+					break;
+				}
+
+				startrow += rowcount;
+				AppendOnlyStorageRead_SkipCurrentBlock(&ds->ao_read);
+				/* continue next block */
+			}
+			else
+				pg_unreachable(); /* unreachable code */
+		}
+	}
+
+out:
+	/* update rows processed */
+	scan->segrowsprocessed = rowstoprocess;
+
+	if (ret)
+	{
+		ExecStoreVirtualTuple(slot);
+		pgstat_count_heap_getnext(scan->rs_base.rs_rd);
+	}
+
+	return ret;
+}
+
+/*
+ * Given a specific target row number 'targrow' (in the space of all row numbers
+ * physically present in the table, i.e. across all segfiles), scan and return
+ * the corresponding tuple in 'slot'.
+ *
+ * If the tuple is visible, return true. Otherwise, return false.
+ */
+bool
+aocs_get_target_tuple(AOCSScanDesc aoscan, int64 targrow, TupleTableSlot *slot)
+{
+	if (aoscan->columnScanInfo.relationTupleDesc == NULL)
+	{
+		aoscan->columnScanInfo.relationTupleDesc = slot->tts_tupleDescriptor;
+		/* Pin it! ... and of course release it upon destruction / rescan */
+		PinTupleDesc(aoscan->columnScanInfo.relationTupleDesc);
+		initscan_with_colinfo(aoscan);
+	}
+
+	if (aoscan->blkdirscan != NULL)
+		return aocs_blkdirscan_get_target_tuple(aoscan, targrow, slot);
+
+	if (aocs_getsegment(aoscan, targrow) < 0)
+	{
+		/* all done */
+		ExecClearTuple(slot);
+		return false;
+	}
+
+	/*
+	 * Unlike AO_ROW, AO_COLUMN may have different varblocks
+	 * for different columns, so we get per-column tuple directly
+	 * on the way of walking per-column varblock.
+	 */
+	return aocs_gettuple(aoscan, targrow, slot);
 }
 
 bool
@@ -633,6 +1088,9 @@ aocs_getnext(AOCSScanDesc scan, ScanDirection direction, TupleTableSlot *slot)
 	AttrNumber	natts;
 
 	Assert(ScanDirectionIsForward(direction));
+
+	/* should not be in ANALYZE - we use a different API */
+	Assert((scan->rs_base.rs_flags & SO_TYPE_ANALYZE) == 0);
 
 	if (scan->columnScanInfo.relationTupleDesc == NULL)
 	{
@@ -721,13 +1179,7 @@ ReadNext:
 
 		if (!isSnapshotAny && !AppendOnlyVisimap_IsVisible(&scan->visibilityMap, &aoTupleId))
 		{
-			/*
-			 * The tuple is invisible.
-			 * In `analyze`, we can simply return false
-			 */
-			if ((scan->rs_base.rs_flags & SO_TYPE_ANALYZE) != 0)
-				return false;
-
+			/* The tuple is invisible */
 			rowNum = INT64CONST(-1);
 			goto ReadNext;
 		}

--- a/src/backend/access/aocs/aocsam.c
+++ b/src/backend/access/aocs/aocsam.c
@@ -326,7 +326,7 @@ initscan_with_colinfo(AOCSScanDesc scan)
 	MemoryContextSwitchTo(oldCtx);
 
 	scan->cur_seg = -1;
-	scan->cur_seg_row = 0;
+	scan->segrowsprocessed = 0;
 
 	ItemPointerSet(&scan->cdb_fake_ctid, 0, 0);
 
@@ -661,7 +661,7 @@ ReadNext:
 				scan->cur_seg = -1;
 				return false;
 			}
-			scan->cur_seg_row = 0;
+			scan->segrowsprocessed = 0;
 		}
 
 		Assert(scan->cur_seg >= 0);
@@ -709,10 +709,10 @@ ReadNext:
 			}
 		}
 
-		scan->cur_seg_row++;
+		scan->segrowsprocessed++;
 		if (rowNum == INT64CONST(-1))
 		{
-			AOTupleIdInit(&aoTupleId, curseginfo->segno, scan->cur_seg_row);
+			AOTupleIdInit(&aoTupleId, curseginfo->segno, scan->segrowsprocessed);
 		}
 		else
 		{

--- a/src/backend/access/appendonly/appendonlyam.c
+++ b/src/backend/access/appendonly/appendonlyam.c
@@ -738,7 +738,7 @@ AppendOnlyExecutorReadBlock_Finish(AppendOnlyExecutorReadBlock *executorReadBloc
 static void
 AppendOnlyExecutorReadBlock_ResetCounts(AppendOnlyExecutorReadBlock *executorReadBlock)
 {
-	executorReadBlock->totalRowsScannned = 0;
+	executorReadBlock->totalRowsScanned = 0;
 }
 
 static void
@@ -868,7 +868,7 @@ AppendOnlyExecutorReadBlock_ScanNextTuple(AppendOnlyExecutorReadBlock *executorR
 
 				executorReadBlock->currentItemCount++;
 
-				executorReadBlock->totalRowsScannned++;
+				executorReadBlock->totalRowsScanned++;
 
 				if (itemLen > 0)
 				{
@@ -921,7 +921,7 @@ AppendOnlyExecutorReadBlock_ScanNextTuple(AppendOnlyExecutorReadBlock *executorR
 				executorReadBlock->singleRow = NULL;
 				executorReadBlock->singleRowLen = 0;
 
-				executorReadBlock->totalRowsScannned++;
+				executorReadBlock->totalRowsScanned++;
 
 				if (AppendOnlyExecutorReadBlock_ProcessTuple(
 															 executorReadBlock,

--- a/src/backend/access/appendonly/appendonlyam.c
+++ b/src/backend/access/appendonly/appendonlyam.c
@@ -114,7 +114,7 @@ initscan(AppendOnlyScanDesc scan, ScanKey key)
 	scan->aos_segfiles_processed = 0;
 	scan->aos_need_new_segfile = true;	/* need to assign a file to be scanned */
 	scan->aos_done_all_segfiles = false;
-	scan->bufferDone = true;
+	scan->needNextBuffer = true;
 
 	if (scan->initedStorageRoutines)
 		AppendOnlyExecutorReadBlock_ResetCounts(
@@ -200,7 +200,7 @@ SetNextFileSegForRead(AppendOnlyScanDesc scan)
 										 &scan->storageRead,
 										 scan->usableBlockSize);
 
-		scan->bufferDone = true;	/* so we read a new buffer right away */
+		scan->needNextBuffer = true;	/* so we read a new buffer right away */
 
 		scan->initedStorageRoutines = true;
 	}
@@ -1104,7 +1104,7 @@ appendonlygettup(AppendOnlyScanDesc scan,
 	{
 		bool		found;
 
-		if (scan->bufferDone)
+		if (scan->needNextBuffer)
 		{
 			/*
 			 * Get the next block. We call this function until we successfully
@@ -1118,7 +1118,7 @@ appendonlygettup(AppendOnlyScanDesc scan,
 					return false;
 			}
 
-			scan->bufferDone = false;
+			scan->needNextBuffer = false;
 		}
 
 		found = AppendOnlyExecutorReadBlock_ScanNextTuple(&scan->executorReadBlock,
@@ -1151,7 +1151,7 @@ appendonlygettup(AppendOnlyScanDesc scan,
 		else
 		{
 			/* no more items in the varblock, get new buffer */
-			scan->bufferDone = true;
+			scan->needNextBuffer = true;
 		}
 	}
 }

--- a/src/backend/commands/analyze.c
+++ b/src/backend/commands/analyze.c
@@ -1665,18 +1665,6 @@ compare_rows(const void *a, const void *b)
 {
 	HeapTuple	ha = *(const HeapTuple *) a;
 	HeapTuple	hb = *(const HeapTuple *) b;
-
-	/*
-	 * For AO/AOCO tables, blocknumber does not have a meaning and is not set.
-	 * We leave this workaround here for legacy AO/CO analyze still working.
-	 * There should be no apparent and measurable perfomance hit from calling
-	 * this function.
-	 * 
-	 * The AO/CO Fast Analyze won't reach here anymore.
-	 */
-	if (!BlockNumberIsValid(ItemPointerGetBlockNumberNoCheck(&ha->t_self)))
-		return 0;
-
 	BlockNumber ba = ItemPointerGetBlockNumber(&ha->t_self);
 	OffsetNumber oa = ItemPointerGetOffsetNumber(&ha->t_self);
 	BlockNumber bb = ItemPointerGetBlockNumber(&hb->t_self);

--- a/src/backend/commands/analyze.c
+++ b/src/backend/commands/analyze.c
@@ -179,13 +179,22 @@ static void compute_index_stats(Relation onerel, double totalrows,
 								MemoryContext col_context);
 static VacAttrStats *examine_attribute(Relation onerel, int attnum,
 									   Node *index_expr, int elevel);
+static int acquire_sample_rows(Relation onerel, int elevel,
+							   HeapTuple *rows, int targrows,
+							   double *totalrows, double *totaldeadrows);
 static int acquire_sample_rows_dispatcher(Relation onerel, bool inh, int elevel,
 										  HeapTuple *rows, int targrows,
 										  double *totalrows, double *totaldeadrows);
+static int gp_acquire_sample_rows_func(Relation onerel, int elevel,
+									   HeapTuple *rows, int targrows,
+									   double *totalrows, double *totaldeadrows);
 static BlockNumber acquire_index_number_of_blocks(Relation indexrel, Relation tablerel);
 
 static void gp_acquire_correlations_dispatcher(Oid relOid, bool inh, float4 *correlations, bool *correlationsIsNull);
 static int	compare_rows(const void *a, const void *b);
+static int	acquire_inherited_sample_rows(Relation onerel, int elevel,
+										  HeapTuple *rows, int targrows,
+										  double *totalrows, double *totaldeadrows);
 static void update_attstats(Oid relid, bool inh,
 							int natts, VacAttrStats **vacattrstats);
 static Datum std_fetch_func(VacAttrStatsP stats, int rownum, bool *isNull);
@@ -343,7 +352,7 @@ analyze_rel_internal(Oid relid, RangeVar *relation,
 		onerel->rd_rel->relkind == RELKIND_MATVIEW)
 	{
 		/* Regular table, so we'll use the regular row acquisition function */
-		acquirefunc = acquire_sample_rows;
+		acquirefunc = gp_acquire_sample_rows_func;
 
 		/* Also get regular table's size */
 		relpages = AcquireNumberOfBlocks(onerel);
@@ -1429,6 +1438,32 @@ examine_attribute(Relation onerel, int attnum, Node *index_expr, int elevel)
 }
 
 /*
+ * GPDB: If we are the dispatcher, then issue analyze on the segments and
+ * collect the statistics from them.
+ */
+int
+gp_acquire_sample_rows_func(Relation onerel, int elevel,
+							   HeapTuple *rows, int targrows,
+							   double *totalrows, double *totaldeadrows)
+{
+	if (Gp_role == GP_ROLE_DISPATCH &&
+		onerel->rd_cdbpolicy && !GpPolicyIsEntry(onerel->rd_cdbpolicy))
+	{
+		/* Fetch sample from the segments. */
+		return acquire_sample_rows_dispatcher(onerel, false, elevel,
+											  rows, targrows,
+											  totalrows, totaldeadrows);
+	}
+
+    if (RelationIsAppendOptimized(onerel))
+        return table_relation_acquire_sample_rows(onerel, elevel, rows, 
+									  	 		  targrows, totalrows, totaldeadrows);
+    
+    return acquire_sample_rows(onerel, elevel, rows,
+							   targrows, totalrows, totaldeadrows);
+}
+
+/*
  * acquire_sample_rows -- acquire a random sample of rows from the table
  *
  * Selected rows are returned in the caller-allocated array rows[], which
@@ -1460,14 +1495,8 @@ examine_attribute(Relation onerel, int attnum, Node *index_expr, int elevel)
  * unbiased estimates of the average numbers of live and dead rows per
  * block.  The previous sampling method put too much credence in the row
  * density near the start of the table.
- *
- * The returned list of tuples is in order by physical position in the table.
- * (We will rely on this later to derive correlation estimates.)
- *
- * GPDB: If we are the dispatcher, then issue analyze on the segments and
- * collect the statistics from them.
  */
-int
+static int
 acquire_sample_rows(Relation onerel, int elevel,
 					HeapTuple *rows, int targrows,
 					double *totalrows, double *totaldeadrows)
@@ -1488,41 +1517,22 @@ acquire_sample_rows(Relation onerel, int elevel,
 
 	Assert(targrows > 0);
 
-	if (Gp_role == GP_ROLE_DISPATCH &&
-		onerel->rd_cdbpolicy && !GpPolicyIsEntry(onerel->rd_cdbpolicy))
-	{
-		/* Fetch sample from the segments. */
-		return acquire_sample_rows_dispatcher(onerel, false, elevel,
-											  rows, targrows,
-											  totalrows, totaldeadrows);
-	}
-
 	/*
-	 * GPDB: Analyze does make a lot of assumptions regarding the file layout of a
-	 * relation. These assumptions are heap specific and do not hold for AO/AOCO
-	 * relations. In the case of AO/AOCO, what is actually needed and used instead
-	 * of number of blocks, is number of tuples.
-	 *
-	 * GPDB_12_MERGE_FIXME: BlockNumber is uint32 and Number of tuples is uint64.
-	 * That means that after row number UINT_MAX we will never analyze the table.
+	 * GPDB: Legacy analyze does make a lot of assumptions regarding the file
+	 * layout of a relation. These assumptions are heap specific and do not hold
+	 * for AO/AOCO relations. In the case of AO/AOCO, what is actually needed and
+	 * used instead of number of blocks, is number of tuples. Moreover, BlockNumber
+	 * is uint32 and Number of tuples is uint64. That means that after row number
+	 * UINT_MAX we will never analyze the table.
+	 * 
+	 * We introduced a tuple based sampling approach for AO/CO tables to address
+	 * above problems, all corresponding logics were moved out of here and enclosed
+	 * in table_relation_acquire_sample_rows(). So leave here an assertion to ensure
+	 * the relation should not be an AO/CO table.
 	 */
-	if (RelationIsAppendOptimized(onerel))
-	{
-		BlockNumber pages;
-		double		tuples;
-		double		allvisfrac;
-		int32		attr_widths;
+	Assert(!RelationIsAppendOptimized(onerel));
 
-		table_relation_estimate_size(onerel,	&attr_widths, &pages,
-									&tuples, &allvisfrac);
-
-		if (tuples > UINT_MAX)
-			tuples = UINT_MAX;
-
-		totalblocks = (BlockNumber)tuples;
-	}
-	else
-		totalblocks = RelationGetNumberOfBlocks(onerel);
+	totalblocks = RelationGetNumberOfBlocks(onerel);
 
 	/* Need a cutoff xmin for HeapTupleSatisfiesVacuum */
 	OldestXmin = GetOldestXmin(onerel, PROCARRAY_FLAGS_VACUUM);
@@ -1636,13 +1646,13 @@ acquire_sample_rows(Relation onerel, int elevel,
 	 * Emit some interesting relation info
 	 */
 	ereport(elevel,
-		(errmsg("\"%s\": scanned %d of %u pages, "
-				"containing %.0f live rows and %.0f dead rows; "
-				"%d rows in sample, %.0f estimated total rows",
-				RelationGetRelationName(onerel),
-				bs.m, totalblocks,
-				liverows, deadrows,
-				numrows, *totalrows)));
+			(errmsg("\"%s\": scanned %d of %u pages, "
+					"containing %.0f live rows and %.0f dead rows; "
+					"%d rows in sample, %.0f estimated total rows",
+					RelationGetRelationName(onerel),
+					bs.m, totalblocks,
+					liverows, deadrows,
+					numrows, *totalrows)));
 
 	return numrows;
 }
@@ -1657,17 +1667,12 @@ compare_rows(const void *a, const void *b)
 	HeapTuple	hb = *(const HeapTuple *) b;
 
 	/*
-	 * GPDB_12_MERGE_FIXME: For AO/AOCO tables, blocknumber does not have a
-	 * meaning and is not set. The current implementation of analyze makes
-	 * assumptions about the file layout which do not hold for these two cases.
-	 * The compare function should maintain the row order as consrtucted, hence
-	 * return 0;
-	 *
+	 * For AO/AOCO tables, blocknumber does not have a meaning and is not set.
+	 * We leave this workaround here for legacy AO/CO analyze still working.
 	 * There should be no apparent and measurable perfomance hit from calling
 	 * this function.
-	 *
-	 * One possible proper fix is to refactor analyze to use the tableam api and
-	 * this sorting should move to the specific implementation.
+	 * 
+	 * The AO/CO Fast Analyze won't reach here anymore.
 	 */
 	if (!BlockNumberIsValid(ItemPointerGetBlockNumberNoCheck(&ha->t_self)))
 		return 0;
@@ -1790,7 +1795,7 @@ acquire_inherited_sample_rows(Relation onerel, int elevel,
 			childrel->rd_rel->relkind == RELKIND_MATVIEW)
 		{
 			/* Regular table, so use the regular row acquisition function */
-			acquirefunc = acquire_sample_rows;
+			acquirefunc = gp_acquire_sample_rows_func;
 			relpages = AcquireNumberOfBlocks(childrel);
 		}
 		else if (childrel->rd_rel->relkind == RELKIND_FOREIGN_TABLE)

--- a/src/backend/commands/analyzefuncs.c
+++ b/src/backend/commands/analyzefuncs.c
@@ -20,6 +20,7 @@
 #include "miscadmin.h"
 #include "funcapi.h"
 #include "utils/syscache.h"
+#include "utils/faultinjector.h"
 
 /**
  * Statistics related parameters.
@@ -295,6 +296,8 @@ gp_acquire_sample_rows(PG_FUNCTION_ARGS)
 		res = heap_form_tuple(outDesc, outvalues, outnulls);
 
 		ctx->index++;
+
+		SIMPLE_FAULT_INJECTOR("returned_sample_row");
 
 		SRF_RETURN_NEXT(funcctx, HeapTupleGetDatum(res));
 	}

--- a/src/backend/utils/datumstream/datumstream.c
+++ b/src/backend/utils/datumstream/datumstream.c
@@ -1078,7 +1078,7 @@ datumstreamwrite_lob(DatumStreamWrite *acc,
 	return varLen;
 }
 
-static bool
+bool
 datumstreamread_block_info(DatumStreamRead * acc)
 {
 	bool		readOK = false;

--- a/src/backend/utils/misc/sampling.c
+++ b/src/backend/utils/misc/sampling.c
@@ -116,6 +116,81 @@ BlockSampler_Next(BlockSampler bs)
 }
 
 /*
+ * This is a 64 bit version of BlockSampler.
+ *
+ * The code is same as BlockSampler except replacing
+ * int type of variables with int64, which is intended
+ * to support larger size of the data set (N).
+ * 
+ * Duplicate code for not willing to break the original
+ * design to conflict with upstream for some special case.
+ */
+void
+RowSampler_Init(RowSampler rs, int64 nobjects, int64 samplesize,
+				   long randseed)
+{
+	rs->N = nobjects;			/* measured table size */
+
+	/*
+	 * If we decide to reduce samplesize for tables that have less or not much
+	 * more than samplesize objects, here is the place to do it.
+	 */
+	rs->n = samplesize;
+	rs->t = 0;					/* objects scanned so far */
+	rs->m = 0;					/* objects selected so far */
+
+	sampler_random_init_state(randseed, rs->randstate);
+}
+
+bool
+RowSampler_HasMore(RowSampler rs)
+{
+	return (rs->t < rs->N) && (rs->m < rs->n);
+}
+
+int64
+RowSampler_Next(RowSampler rs)
+{
+	int64       K = rs->N - rs->t;	/* remaining objects */
+	int64		k = rs->n - rs->m;	/* objects still to sample */
+	double		p;				    /* probability to skip object */
+	double		V;				    /* random */
+
+	Assert(RowSampler_HasMore(rs));	/* hence K > 0 and k > 0 */
+
+	if (k >= K)
+	{
+		/* need all the rest */
+		rs->m++;
+		return rs->t++;
+	}
+
+    /* 
+     * It is not obvious that this code matches Knuth's Algorithm S.
+     * Refer to BlockSampler_Next() for detail.
+     */
+	V = sampler_random_fract(rs->randstate);
+    /*
+	 * Don't bother overflow of conversion from int64 K (N) as it was
+	 * already converted to "double" range value when initialized.
+	 */
+	p = 1.0 - (double) k / (double) K;
+	while (V < p)
+	{
+		/* skip */
+		rs->t++;
+		K--; /* keep K == N - t */
+
+		/* adjust p to be new cutoff point in reduced range */
+		p *= 1.0 - (double) k / (double) K;
+	}
+
+	/* select */
+	rs->m++;
+	return rs->t++;
+}
+
+/*
  * These two routines embody Algorithm Z from "Random sampling with a
  * reservoir" by Jeffrey S. Vitter, in ACM Trans. Math. Softw. 11, 1
  * (Mar. 1985), Pages 37-57.  Vitter describes his algorithm in terms

--- a/src/backend/utils/misc/sampling.c
+++ b/src/backend/utils/misc/sampling.c
@@ -116,7 +116,11 @@ BlockSampler_Next(BlockSampler bs)
 }
 
 /*
- * This is a 64 bit version of BlockSampler.
+ * This is used for sampling AO/CO row numbers, in the flattened
+ * row number space, across all segfile tuple counts. 64 bits is
+ * used for simplicity and is sufficient to hold a maximum tuple
+ * count of (AOTupleId_MaxSegmentFileNum * MAX_AOREL_CONCURRENCY),
+ * which can be represented with 48 bits.
  *
  * The code is same as BlockSampler except replacing
  * int type of variables with int64, which is intended
@@ -127,7 +131,7 @@ BlockSampler_Next(BlockSampler bs)
  */
 void
 RowSampler_Init(RowSampler rs, int64 nobjects, int64 samplesize,
-				   long randseed)
+				long randseed)
 {
 	rs->N = nobjects;			/* measured table size */
 

--- a/src/include/cdb/cdbaocsam.h
+++ b/src/include/cdb/cdbaocsam.h
@@ -109,7 +109,7 @@ typedef struct AOCSScanDescData
 	/* synthetic system attributes */
 	ItemPointerData cdb_fake_ctid;
 	int64 total_row;
-	int64 cur_seg_row;
+	int64 segrowsprocessed;
 
 	/*
 	 * Only used by `analyze`

--- a/src/include/cdb/cdbappendonlyam.h
+++ b/src/include/cdb/cdbappendonlyam.h
@@ -199,7 +199,7 @@ typedef struct AppendOnlyScanDescData
 	AppendOnlyExecutorReadBlock	executorReadBlock;
 
 	/* current scan state */
-	bool		bufferDone;
+	bool		needNextBuffer;
 
 	bool	initedStorageRoutines;
 

--- a/src/include/cdb/cdbappendonlyam.h
+++ b/src/include/cdb/cdbappendonlyam.h
@@ -134,6 +134,7 @@ typedef struct AppendOnlyExecutorReadBlock
 	int				segmentFileNum;
 
 	int64			totalRowsScanned;
+	int64			blockRowsProcessed;
 
 	int64			blockFirstRowNum;
 	int64			headerOffsetInFile;
@@ -229,10 +230,31 @@ typedef struct AppendOnlyScanDescData
 	AppendOnlyVisimap visibilityMap;
 
 	/*
-	 * Only used by `analyze`
+	 * used by `analyze`
 	 */
-	int64		nextTupleId;
-	int64		targetTupleId;
+
+	/*
+	 * targrow: the output of the Row-based sampler (Alogrithm S), denotes a
+	 * rownumber in the flattened row number space that is the target of a sample,
+	 * which starts from 0.
+	 * In other words, if we have seg0 rownums: [1, 100], seg1 rownums: [1, 200]
+	 * If targrow = 150, then we are referring to seg1's rownum=51.
+	 */
+	int64				targrow;
+
+	/*
+	 * segfirstrow: pointing to the next starting row which is used to check
+	 * the distance to `targrow`
+	 */
+	int64				segfirstrow;
+
+	/*
+	 * segrowsprocessed: track the rows processed under the current segfile.
+	 * Don't miss updating it accordingly when "segfirstrow" is updated.
+	 */
+	int64				segrowsprocessed;
+
+	AOBlkDirScan		blkdirscan;
 
 	/* For Bitmap scan */
 	int			rs_cindex;		/* current tuple's index in tbmres->offsets */
@@ -433,6 +455,9 @@ extern void appendonly_endscan(TableScanDesc scan);
 extern bool appendonly_getnextslot(TableScanDesc scan,
 								   ScanDirection direction,
 								   TupleTableSlot *slot);
+extern bool appendonly_get_target_tuple(AppendOnlyScanDesc aoscan,
+										int64 targrow,
+										TupleTableSlot *slot);
 extern AppendOnlyFetchDesc appendonly_fetch_init(
 	Relation 	relation,
 	Snapshot    snapshot,
@@ -479,6 +504,23 @@ AppendOnlyScanDesc_UpdateTotalBytesRead(AppendOnlyScanDesc scan)
 		scan->totalBytesRead += scan->storageRead.current.compressedLen;
 	else
 		scan->totalBytesRead += scan->storageRead.current.uncompressedLen;
+}
+
+static inline int64
+AppendOnlyScanDesc_TotalTupCount(AppendOnlyScanDesc scan)
+{
+	Assert(scan != NULL);
+
+	int64 totalrows = 0;
+	FileSegInfo **seginfo = scan->aos_segfile_arr;
+
+    for (int i = 0; i < scan->aos_total_segfiles; i++)
+    {
+	    if (seginfo[i]->state != AOSEG_STATE_AWAITING_DROP)
+		    totalrows += seginfo[i]->total_tupcount;
+    }
+
+    return totalrows;
 }
 
 #endif   /* CDBAPPENDONLYAM_H */

--- a/src/include/cdb/cdbappendonlyam.h
+++ b/src/include/cdb/cdbappendonlyam.h
@@ -133,7 +133,7 @@ typedef struct AppendOnlyExecutorReadBlock
 
 	int				segmentFileNum;
 
-	int64			totalRowsScannned;
+	int64			totalRowsScanned;
 
 	int64			blockFirstRowNum;
 	int64			headerOffsetInFile;

--- a/src/include/cdb/cdbappendonlyblockdirectory.h
+++ b/src/include/cdb/cdbappendonlyblockdirectory.h
@@ -95,6 +95,8 @@ typedef struct MinipagePerColumnGroup
 #define IsMinipageFull(minipagePerColumnGroup) \
 	((minipagePerColumnGroup)->numMinipageEntries == (uint32) gp_blockdirectory_minipage_size)
 
+#define InvalidEntryNum (-1)
+
 /*
  * Define a structure for the append-only relation block directory.
  */
@@ -135,6 +137,14 @@ typedef struct AppendOnlyBlockDirectory
 	ScanKey scanKeys;
 	StrategyNumber *strategyNumbers;
 
+	/*
+	 * Minipage entry number, for caching purpose.
+	 *
+	 * XXX: scenarios which call AppendOnlyBlockDirectory_GetEntry()
+	 * may need to consider using this cache.
+	 */
+	int cached_mpentry_num;
+
 }	AppendOnlyBlockDirectory;
 
 
@@ -174,10 +184,16 @@ typedef struct AOFetchSegmentFile
 	int64 logicalEof;
 } AOFetchSegmentFile;
 
-typedef struct AppendOnlyBlockDirectorySeqScan {
-	AppendOnlyBlockDirectory blkdir;
-	SysScanDesc sysScan;
-} AppendOnlyBlockDirectorySeqScan;
+/*
+ * Tracks block directory scan state for block-directory based ANALYZE.
+ */
+typedef struct AOBlkDirScanData
+{
+	AppendOnlyBlockDirectory	*blkdir;
+	SysScanDesc					sysscan;
+	int							segno;
+	int							colgroupno;
+} AOBlkDirScanData, *AOBlkDirScan;
 
 extern void AppendOnlyBlockDirectoryEntry_GetBeginRange(
 	AppendOnlyBlockDirectoryEntry	*directoryEntry,
@@ -195,6 +211,12 @@ extern bool AppendOnlyBlockDirectory_GetEntry(
 	AOTupleId 						*aoTupleId,
 	int                             columnGroupNo,
 	AppendOnlyBlockDirectoryEntry	*directoryEntry);
+extern int64 AOBlkDirScan_GetRowNum(
+	AOBlkDirScan					blkdirscan,
+	int								targsegno,
+	int								colgroupno,
+	int64							targrow,
+	int64							*startrow);
 extern bool AppendOnlyBlockDirectory_CoversTuple(
 	AppendOnlyBlockDirectory		*blockDirectory,
 	AOTupleId 						*aoTupleId);
@@ -253,6 +275,8 @@ extern void
 AppendOnlyBlockDirectory_DeleteSegmentFiles(Oid blkdirrelid,
 											Snapshot snapshot,
 											int segno);
+extern void AppendOnlyBlockDirectory_End_forSearch_InSequence(
+	AOBlkDirScan seqscan);
 extern void AppendOnlyBlockDirectory_End_forUniqueChecks(
 	AppendOnlyBlockDirectory *blockDirectory);
 extern void AppendOnlyBlockDirectory_End_forIndexOnlyScan(
@@ -334,6 +358,37 @@ copy_out_minipage(MinipagePerColumnGroup *minipageInfo,
 	Assert(minipageInfo->minipage->nEntry <= NUM_MINIPAGE_ENTRIES);
 
 	minipageInfo->numMinipageEntries = minipageInfo->minipage->nEntry;
+}
+
+static inline void
+AOBlkDirScan_Init(AOBlkDirScan blkdirscan,
+				  AppendOnlyBlockDirectory *blkdir)
+{
+	blkdirscan->blkdir = blkdir;
+	blkdirscan->sysscan = NULL;
+	blkdirscan->segno = -1;
+	blkdirscan->colgroupno = 0;
+}
+
+/* should be called before fetch_finish() */
+static inline void
+AOBlkDirScan_Finish(AOBlkDirScan blkdirscan)
+{
+	/*
+	 * Make sure blkdir hasn't been destroyed by fetch_finish(),
+	 * or systable_endscan_ordered() will be crashed for sysscan
+	 * is holding blkdir relation which is freed.
+	 */
+	Assert(blkdirscan->blkdir != NULL);
+
+	if (blkdirscan->sysscan != NULL)
+	{
+		systable_endscan_ordered(blkdirscan->sysscan);
+		blkdirscan->sysscan = NULL;
+	}
+	blkdirscan->segno = -1;
+	blkdirscan->colgroupno = 0;
+	blkdirscan->blkdir = NULL;
 }
 
 #endif

--- a/src/include/commands/vacuum.h
+++ b/src/include/commands/vacuum.h
@@ -365,13 +365,6 @@ extern double anl_random_fract(void);
 extern double anl_init_selection_state(int n);
 extern double anl_get_next_S(double t, int n, double *stateptr);
 
-extern int acquire_sample_rows(Relation onerel, int elevel,
-							   HeapTuple *rows, int targrows,
-							   double *totalrows, double *totaldeadrows);
-extern int acquire_inherited_sample_rows(Relation onerel, int elevel,
-							  HeapTuple *rows, int targrows,
-							  double *totalrows, double *totaldeadrows);
-
 /* in commands/analyzefuncs.c */
 extern Datum gp_acquire_sample_rows(PG_FUNCTION_ARGS);
 extern Datum gp_acquire_correlations(PG_FUNCTION_ARGS);

--- a/src/include/utils/datumstream.h
+++ b/src/include/utils/datumstream.h
@@ -93,6 +93,7 @@ typedef struct DatumStreamRead
 	int64		blockFirstRowNum;
 	int64		blockFileOffset;
 	int			blockRowCount;
+	int			blockRowsProcessed;
 
 	AppendOnlyStorageRead ao_read;
 
@@ -316,8 +317,9 @@ extern bool datumstreamread_find_block(DatumStreamRead * datumStream,
 extern void *datumstreamread_get_upgrade_space(DatumStreamRead *datumStream,
 											   size_t len);
 
+extern bool datumstreamread_block_info(DatumStreamRead * acc);
 /*
- * MPP-17061: make sure datumstream_read_block_info was called first for the CO block
+ * MPP-17061: make sure datumstreamread_block_info was called first for the CO block
  * before calling datumstreamread_block_content.
  */
 extern void datumstreamread_block_content(DatumStreamRead * acc);

--- a/src/include/utils/sampling.h
+++ b/src/include/utils/sampling.h
@@ -42,6 +42,23 @@ extern BlockNumber BlockSampler_Init(BlockSampler bs, BlockNumber nblocks,
 extern bool BlockSampler_HasMore(BlockSampler bs);
 extern BlockNumber BlockSampler_Next(BlockSampler bs);
 
+/* 64 bit version of BlockSampler */
+typedef struct
+{
+	int64           N;				/* number of objects, known in advance */
+	int64			n;				/* desired sample size */
+	int64           t;				/* current object number */
+	int64			m;				/* objects selected so far */
+	SamplerRandomState randstate;	/* random generator state */
+} RowSamplerData;
+
+typedef RowSamplerData *RowSampler;
+
+extern void RowSampler_Init(RowSampler rs, int64 nobjects,
+							   int64 samplesize, long randseed);
+extern bool RowSampler_HasMore(RowSampler rs);
+extern int64 RowSampler_Next(RowSampler rs);
+
 /* Reservoir sampling methods */
 
 typedef struct

--- a/src/include/utils/sampling.h
+++ b/src/include/utils/sampling.h
@@ -42,7 +42,7 @@ extern BlockNumber BlockSampler_Init(BlockSampler bs, BlockNumber nblocks,
 extern bool BlockSampler_HasMore(BlockSampler bs);
 extern BlockNumber BlockSampler_Next(BlockSampler bs);
 
-/* 64 bit version of BlockSampler */
+/* 64 bit version of BlockSampler (used for sampling AO/CO table rows) */
 typedef struct
 {
 	int64           N;				/* number of objects, known in advance */

--- a/src/test/isolation2/expected/ao_blkdir.out
+++ b/src/test/isolation2/expected/ao_blkdir.out
@@ -315,6 +315,155 @@ COMMIT
 DROP TABLE ao_blkdir_test;
 DROP
 
+-- Test `tupcount` in pg_aoseg == sum of number of `row_count` across all
+-- aoblkdir entries for each segno. Test with commits, aborts and deletes.
+
+-- Case1: without VACUUM ANALYZE
+CREATE TABLE ao_blkdir_test_rowcount(i int, j int) USING ao_row DISTRIBUTED BY (j);
+CREATE
+1: BEGIN;
+BEGIN
+2: BEGIN;
+BEGIN
+3: BEGIN;
+BEGIN
+4: BEGIN;
+BEGIN
+1: INSERT INTO ao_blkdir_test_rowcount SELECT i, 2 FROM generate_series(1, 10) i;
+INSERT 10
+2: INSERT INTO ao_blkdir_test_rowcount SELECT i, 3 FROM generate_series(1, 20) i;
+INSERT 20
+3: INSERT INTO ao_blkdir_test_rowcount SELECT i, 4 FROM generate_series(1, 30) i;
+INSERT 30
+3: ABORT;
+ABORT
+3: BEGIN;
+BEGIN
+3: INSERT INTO ao_blkdir_test_rowcount SELECT i, 4 FROM generate_series(1, 40) i;
+INSERT 40
+4: INSERT INTO ao_blkdir_test_rowcount SELECT i, 7 FROM generate_series(1, 50) i;
+INSERT 50
+1: COMMIT;
+COMMIT
+2: COMMIT;
+COMMIT
+3: COMMIT;
+COMMIT
+4: COMMIT;
+COMMIT
+DELETE FROM ao_blkdir_test_rowcount WHERE j = 7;
+DELETE 50
+
+CREATE INDEX ao_blkdir_test_rowcount_idx ON ao_blkdir_test_rowcount(i);
+CREATE
+
+SELECT segno, sum(row_count) AS totalrows FROM (SELECT (gp_toolkit.__gp_aoblkdir('ao_blkdir_test_rowcount')).* FROM gp_dist_random('gp_id') WHERE gp_segment_id = 0)s GROUP BY segno, columngroup_no ORDER BY segno;
+ segno | totalrows 
+-------+-----------
+ 1     | 10        
+ 2     | 20        
+ 3     | 40        
+ 4     | 50        
+(4 rows)
+SELECT segno, sum(tupcount) AS totalrows FROM gp_toolkit.__gp_aoseg('ao_blkdir_test_rowcount') WHERE segment_id = 0 GROUP BY segno;
+ segno | totalrows 
+-------+-----------
+ 1     | 10        
+ 2     | 20        
+ 3     | 40        
+ 4     | 50        
+(4 rows)
+
+-- Case2: with VACUUM ANALYZE
+DROP TABLE ao_blkdir_test_rowcount;
+DROP
+CREATE TABLE ao_blkdir_test_rowcount(i int, j int) USING ao_row DISTRIBUTED BY (j);
+CREATE
+CREATE INDEX ao_blkdir_test_rowcount_idx ON ao_blkdir_test_rowcount(i);
+CREATE
+1: BEGIN;
+BEGIN
+2: BEGIN;
+BEGIN
+3: BEGIN;
+BEGIN
+4: BEGIN;
+BEGIN
+1: INSERT INTO ao_blkdir_test_rowcount SELECT i, 2 FROM generate_series(1, 10) i;
+INSERT 10
+1: INSERT INTO ao_blkdir_test_rowcount SELECT i, 2 FROM ao_blkdir_test_rowcount;
+INSERT 10
+1: INSERT INTO ao_blkdir_test_rowcount SELECT i, 2 FROM ao_blkdir_test_rowcount;
+INSERT 20
+2: INSERT INTO ao_blkdir_test_rowcount SELECT i, 3 FROM generate_series(1, 20) i;
+INSERT 20
+2: INSERT INTO ao_blkdir_test_rowcount SELECT i, 3 FROM ao_blkdir_test_rowcount;
+INSERT 20
+2: INSERT INTO ao_blkdir_test_rowcount SELECT i, 3 FROM ao_blkdir_test_rowcount;
+INSERT 40
+3: INSERT INTO ao_blkdir_test_rowcount SELECT i, 4 FROM generate_series(1, 30) i;
+INSERT 30
+3: INSERT INTO ao_blkdir_test_rowcount SELECT i, 4 FROM ao_blkdir_test_rowcount;
+INSERT 30
+3: INSERT INTO ao_blkdir_test_rowcount SELECT i, 4 FROM ao_blkdir_test_rowcount;
+INSERT 60
+4: INSERT INTO ao_blkdir_test_rowcount SELECT i, 7 FROM generate_series(1, 50) i;
+INSERT 50
+4: INSERT INTO ao_blkdir_test_rowcount SELECT i, 7 FROM ao_blkdir_test_rowcount;
+INSERT 50
+4: INSERT INTO ao_blkdir_test_rowcount SELECT i, 7 FROM ao_blkdir_test_rowcount;
+INSERT 100
+1: COMMIT;
+COMMIT
+2: COMMIT;
+COMMIT
+3: ABORT;
+ABORT
+4: COMMIT;
+COMMIT
+
+DELETE FROM ao_blkdir_test_rowcount WHERE j = 7;
+DELETE 200
+VACUUM ANALYZE ao_blkdir_test_rowcount;
+VACUUM
+
+SELECT segno, sum(row_count) AS totalrows FROM (SELECT (gp_toolkit.__gp_aoblkdir('ao_blkdir_test_rowcount')).* FROM gp_dist_random('gp_id') WHERE gp_segment_id = 0)s GROUP BY segno, columngroup_no ORDER BY segno;
+ segno | totalrows 
+-------+-----------
+ 1     | 40        
+ 2     | 80        
+(2 rows)
+SELECT segno, sum(tupcount) AS totalrows FROM gp_toolkit.__gp_aoseg('ao_blkdir_test_rowcount') WHERE segment_id = 0 GROUP BY segno;
+ segno | totalrows 
+-------+-----------
+ 1     | 40        
+ 2     | 80        
+ 3     | 0         
+ 4     | 0         
+(4 rows)
+
+UPDATE ao_blkdir_test_rowcount SET i = i + 1;
+UPDATE 120
+VACUUM ANALYZE ao_blkdir_test_rowcount;
+VACUUM
+
+SELECT segno, sum(row_count) AS totalrows FROM (SELECT (gp_toolkit.__gp_aoblkdir('ao_blkdir_test_rowcount')).* FROM gp_dist_random('gp_id') WHERE gp_segment_id = 0)s GROUP BY segno, columngroup_no ORDER BY segno;
+ segno | totalrows 
+-------+-----------
+ 3     | 120       
+(1 row)
+SELECT segno, sum(tupcount) AS totalrows FROM gp_toolkit.__gp_aoseg('ao_blkdir_test_rowcount') WHERE segment_id = 0 GROUP BY segno;
+ segno | totalrows 
+-------+-----------
+ 1     | 0         
+ 2     | 0         
+ 3     | 120       
+ 4     | 0         
+(4 rows)
+
+DROP TABLE ao_blkdir_test_rowcount;
+DROP
+
 --------------------------------------------------------------------------------
 -- AOCO tables
 --------------------------------------------------------------------------------
@@ -816,4 +965,173 @@ ERROR:  duplicate key value violates unique constraint "aoco_blkdir_test_i_key" 
 DETAIL:  Key (i)=(2) already exists.
 
 DROP TABLE aoco_blkdir_test;
+DROP
+
+-- Test `tupcount` in pg_ao(cs)seg == sum of number of `row_count` across all
+-- aoblkdir entries for each <segno, columngroup_no>. Test with commits, aborts
+-- and deletes.
+
+-- Case1: without VACUUM ANALYZE
+CREATE TABLE aoco_blkdir_test_rowcount(i int, j int) USING ao_column DISTRIBUTED BY (j);
+CREATE
+1: BEGIN;
+BEGIN
+2: BEGIN;
+BEGIN
+3: BEGIN;
+BEGIN
+4: BEGIN;
+BEGIN
+1: INSERT INTO aoco_blkdir_test_rowcount SELECT i, 2 FROM generate_series(1, 10) i;
+INSERT 10
+2: INSERT INTO aoco_blkdir_test_rowcount SELECT i, 3 FROM generate_series(1, 20) i;
+INSERT 20
+3: INSERT INTO aoco_blkdir_test_rowcount SELECT i, 4 FROM generate_series(1, 30) i;
+INSERT 30
+3: ABORT;
+ABORT
+3: BEGIN;
+BEGIN
+3: INSERT INTO aoco_blkdir_test_rowcount SELECT i, 4 FROM generate_series(1, 40) i;
+INSERT 40
+4: INSERT INTO aoco_blkdir_test_rowcount SELECT i, 7 FROM generate_series(1, 50) i;
+INSERT 50
+1: COMMIT;
+COMMIT
+2: COMMIT;
+COMMIT
+3: COMMIT;
+COMMIT
+4: COMMIT;
+COMMIT
+DELETE FROM aoco_blkdir_test_rowcount WHERE j = 7;
+DELETE 50
+
+CREATE INDEX aoco_blkdir_test_rowcount_idx ON aoco_blkdir_test_rowcount(i);
+CREATE
+
+SELECT segno, columngroup_no, sum(row_count) AS totalrows FROM (SELECT (gp_toolkit.__gp_aoblkdir('aoco_blkdir_test_rowcount')).* FROM gp_dist_random('gp_id') WHERE gp_segment_id = 0)s GROUP BY segno, columngroup_no ORDER BY segno, columngroup_no;
+ segno | columngroup_no | totalrows 
+-------+----------------+-----------
+ 1     | 0              | 10        
+ 1     | 1              | 10        
+ 2     | 0              | 20        
+ 2     | 1              | 20        
+ 3     | 0              | 40        
+ 3     | 1              | 40        
+ 4     | 0              | 50        
+ 4     | 1              | 50        
+(8 rows)
+SELECT segno, column_num, sum(tupcount) AS totalrows FROM gp_toolkit.__gp_aocsseg('aoco_blkdir_test_rowcount') WHERE segment_id = 0 GROUP BY segno, column_num;
+ segno | column_num | totalrows 
+-------+------------+-----------
+ 1     | 0          | 10        
+ 1     | 1          | 10        
+ 2     | 0          | 20        
+ 2     | 1          | 20        
+ 3     | 0          | 40        
+ 3     | 1          | 40        
+ 4     | 0          | 50        
+ 4     | 1          | 50        
+(8 rows)
+
+-- Case2: with VACUUM ANALYZE
+DROP TABLE aoco_blkdir_test_rowcount;
+DROP
+CREATE TABLE aoco_blkdir_test_rowcount(i int, j int) USING ao_column DISTRIBUTED BY (j);
+CREATE
+CREATE INDEX aoco_blkdir_test_rowcount_idx ON aoco_blkdir_test_rowcount(i);
+CREATE
+1: BEGIN;
+BEGIN
+2: BEGIN;
+BEGIN
+3: BEGIN;
+BEGIN
+4: BEGIN;
+BEGIN
+1: INSERT INTO aoco_blkdir_test_rowcount SELECT i, 2 FROM generate_series(1, 10) i;
+INSERT 10
+1: INSERT INTO aoco_blkdir_test_rowcount SELECT i, 2 FROM aoco_blkdir_test_rowcount;
+INSERT 10
+1: INSERT INTO aoco_blkdir_test_rowcount SELECT i, 2 FROM aoco_blkdir_test_rowcount;
+INSERT 20
+2: INSERT INTO aoco_blkdir_test_rowcount SELECT i, 3 FROM generate_series(1, 20) i;
+INSERT 20
+2: INSERT INTO aoco_blkdir_test_rowcount SELECT i, 3 FROM aoco_blkdir_test_rowcount;
+INSERT 20
+2: INSERT INTO aoco_blkdir_test_rowcount SELECT i, 3 FROM aoco_blkdir_test_rowcount;
+INSERT 40
+3: INSERT INTO aoco_blkdir_test_rowcount SELECT i, 4 FROM generate_series(1, 30) i;
+INSERT 30
+3: INSERT INTO aoco_blkdir_test_rowcount SELECT i, 4 FROM aoco_blkdir_test_rowcount;
+INSERT 30
+3: INSERT INTO aoco_blkdir_test_rowcount SELECT i, 4 FROM aoco_blkdir_test_rowcount;
+INSERT 60
+4: INSERT INTO aoco_blkdir_test_rowcount SELECT i, 7 FROM generate_series(1, 50) i;
+INSERT 50
+4: INSERT INTO aoco_blkdir_test_rowcount SELECT i, 7 FROM aoco_blkdir_test_rowcount;
+INSERT 50
+4: INSERT INTO aoco_blkdir_test_rowcount SELECT i, 7 FROM aoco_blkdir_test_rowcount;
+INSERT 100
+1: COMMIT;
+COMMIT
+2: COMMIT;
+COMMIT
+3: ABORT;
+ABORT
+4: COMMIT;
+COMMIT
+
+DELETE FROM aoco_blkdir_test_rowcount WHERE j = 7;
+DELETE 200
+VACUUM ANALYZE aoco_blkdir_test_rowcount;
+VACUUM
+
+SELECT segno, columngroup_no, sum(row_count) AS totalrows FROM (SELECT (gp_toolkit.__gp_aoblkdir('aoco_blkdir_test_rowcount')).* FROM gp_dist_random('gp_id') WHERE gp_segment_id = 0)s GROUP BY segno, columngroup_no ORDER BY segno, columngroup_no;
+ segno | columngroup_no | totalrows 
+-------+----------------+-----------
+ 1     | 0              | 40        
+ 1     | 1              | 40        
+ 2     | 0              | 80        
+ 2     | 1              | 80        
+(4 rows)
+SELECT segno, column_num, sum(tupcount) AS totalrows FROM gp_toolkit.__gp_aocsseg('aoco_blkdir_test_rowcount') WHERE segment_id = 0 GROUP BY segno, column_num;
+ segno | column_num | totalrows 
+-------+------------+-----------
+ 1     | 0          | 40        
+ 1     | 1          | 40        
+ 2     | 0          | 80        
+ 2     | 1          | 80        
+ 3     | 0          | 0         
+ 3     | 1          | 0         
+ 4     | 0          | 0         
+ 4     | 1          | 0         
+(8 rows)
+
+UPDATE aoco_blkdir_test_rowcount SET i = i + 1;
+UPDATE 120
+VACUUM ANALYZE aoco_blkdir_test_rowcount;
+VACUUM
+
+SELECT segno, columngroup_no, sum(row_count) AS totalrows FROM (SELECT (gp_toolkit.__gp_aoblkdir('aoco_blkdir_test_rowcount')).* FROM gp_dist_random('gp_id') WHERE gp_segment_id = 0)s GROUP BY segno, columngroup_no ORDER BY segno, columngroup_no;
+ segno | columngroup_no | totalrows 
+-------+----------------+-----------
+ 3     | 0              | 120       
+ 3     | 1              | 120       
+(2 rows)
+SELECT segno, column_num, sum(tupcount) AS totalrows FROM gp_toolkit.__gp_aocsseg('aoco_blkdir_test_rowcount') WHERE segment_id = 0 GROUP BY segno, column_num;
+ segno | column_num | totalrows 
+-------+------------+-----------
+ 1     | 0          | 0         
+ 1     | 1          | 0         
+ 2     | 0          | 0         
+ 2     | 1          | 0         
+ 3     | 0          | 120       
+ 3     | 1          | 120       
+ 4     | 0          | 0         
+ 4     | 1          | 0         
+(8 rows)
+
+DROP TABLE aoco_blkdir_test_rowcount;
 DROP

--- a/src/test/isolation2/input/uao/fast_analyze.source
+++ b/src/test/isolation2/input/uao/fast_analyze.source
@@ -1,0 +1,349 @@
+--
+-- Test AO/CO sampling method.
+--
+-- These tests ensure that we achieve our ANALYZE targets for AO/CO tables.
+--
+CREATE TABLE fast_analyze_@amname@_1(i int, j int) USING @amname@ DISTRIBUTED BY (j);
+
+-- Stats target info shows that we will sample 300 * (100) rows.
+SHOW default_statistics_target;
+SELECT attstattarget FROM pg_attribute
+  WHERE attrelid = 'fast_analyze_@amname@_1'::regclass AND attname IN ('i', 'j');
+
+--------------------------------------------------------------------------------
+-- Scenario 1:
+-- We have MORE than 300 * default_statistics_target = 30k rows for a 2 int table,
+-- spread across 3 segments, with no aborted rows [2 subcases -> blkdir and
+-- non-blkdir].
+-- Expectation: We have collected 30k live rows.
+--------------------------------------------------------------------------------
+
+-- (a) Without blkdir subcase
+
+-- Insert 10.5k rows in each QE.
+1: BEGIN;
+2: BEGIN;
+3: BEGIN;
+1: INSERT INTO fast_analyze_@amname@_1 SELECT i, 2 FROM generate_series(1, 10500) i;
+2: INSERT INTO fast_analyze_@amname@_1 SELECT i, 1 FROM generate_series(1, 10500) i;
+3: INSERT INTO fast_analyze_@amname@_1 SELECT i, 5 FROM generate_series(1, 10500) i;
+1: COMMIT;
+2: COMMIT;
+3: COMMIT;
+
+SELECT gp_inject_fault_infinite('returned_sample_row', 'skip', dbid)
+  FROM gp_segment_configuration WHERE content != -1 AND role = 'p';
+
+ANALYZE fast_analyze_@amname@_1;
+
+-- We have sampled 10k live rows.
+SELECT gp_inject_fault('returned_sample_row', 'status', dbid)
+  FROM gp_segment_configuration WHERE content != -1 AND role = 'p';
+
+SELECT gp_inject_fault('returned_sample_row', 'reset', dbid)
+  FROM gp_segment_configuration WHERE content != -1 AND role = 'p';
+
+-- (b) With blkdir subcase
+
+CREATE INDEX ON fast_analyze_@amname@_1(i);
+
+SELECT gp_inject_fault_infinite('returned_sample_row', 'skip', dbid)
+  FROM gp_segment_configuration WHERE content != -1 AND role = 'p';
+
+ANALYZE fast_analyze_@amname@_1;
+
+-- We have sampled 10k live rows from each QE.
+SELECT gp_inject_fault('returned_sample_row', 'status', dbid)
+  FROM gp_segment_configuration WHERE content != -1 AND role = 'p';
+
+SELECT gp_inject_fault('returned_sample_row', 'reset', dbid)
+  FROM gp_segment_configuration WHERE content != -1 AND role = 'p';
+
+--------------------------------------------------------------------------------
+-- Scenario 2:
+-- We have LESS than 300 * default_statistics_target = 30k rows for a 2 int table,
+-- spread across 3 segments, with no aborted rows [2 subcases -> blkdir and
+-- non-blkdir].
+-- Expectation: We have collected number of live rows = total tupcount of table.
+--------------------------------------------------------------------------------
+
+CREATE TABLE fast_analyze_@amname@_2(i int, j int) USING @amname@ DISTRIBUTED BY (j);
+
+-- (a) Without blkdir subcase
+
+-- Insert 10 rows in each QE.
+1: BEGIN;
+2: BEGIN;
+3: BEGIN;
+1: INSERT INTO fast_analyze_@amname@_2 SELECT i, 2 FROM generate_series(1, 10) i;
+2: INSERT INTO fast_analyze_@amname@_2 SELECT i, 1 FROM generate_series(1, 10) i;
+3: INSERT INTO fast_analyze_@amname@_2 SELECT i, 5 FROM generate_series(1, 10) i;
+1: COMMIT;
+2: COMMIT;
+3: COMMIT;
+
+SELECT gp_inject_fault_infinite('returned_sample_row', 'skip', dbid)
+  FROM gp_segment_configuration WHERE content != -1 AND role = 'p';
+
+ANALYZE fast_analyze_@amname@_2;
+
+-- We have sampled 10 live rows from each QE.
+SELECT gp_inject_fault('returned_sample_row', 'status', dbid)
+  FROM gp_segment_configuration WHERE content != -1 AND role = 'p';
+
+SELECT gp_inject_fault('returned_sample_row', 'reset', dbid)
+  FROM gp_segment_configuration WHERE content != -1 AND role = 'p';
+
+-- (b) With blkdir subcase
+
+CREATE INDEX ON fast_analyze_@amname@_2(i);
+
+SELECT gp_inject_fault_infinite('returned_sample_row', 'skip', dbid)
+  FROM gp_segment_configuration WHERE content != -1 AND role = 'p';
+
+ANALYZE fast_analyze_@amname@_2;
+
+-- We have sampled 10 live rows from each QE.
+SELECT gp_inject_fault('returned_sample_row', 'status', dbid)
+  FROM gp_segment_configuration WHERE content != -1 AND role = 'p';
+
+SELECT gp_inject_fault('returned_sample_row', 'reset', dbid)
+  FROM gp_segment_configuration WHERE content != -1 AND role = 'p';
+
+--------------------------------------------------------------------------------
+-- Scenario 3:
+-- We have ALL aborted rows [2 subcases -> blkdir and non-blkdir].
+-- Expectation: We have not sampled any live rows.
+--------------------------------------------------------------------------------
+
+CREATE TABLE fast_analyze_@amname@_3(i int, j int) USING @amname@ DISTRIBUTED BY (j);
+
+-- (a) Without blkdir subcase
+
+-- Insert 10 rows in each QE.
+1: BEGIN;
+2: BEGIN;
+3: BEGIN;
+1: INSERT INTO fast_analyze_@amname@_3 SELECT i, 2 FROM generate_series(1, 10) i;
+2: INSERT INTO fast_analyze_@amname@_3 SELECT i, 1 FROM generate_series(1, 10) i;
+3: INSERT INTO fast_analyze_@amname@_3 SELECT i, 5 FROM generate_series(1, 10) i;
+1: ABORT;
+2: ABORT;
+3: ABORT;
+
+SELECT gp_inject_fault_infinite('returned_sample_row', 'skip', dbid)
+  FROM gp_segment_configuration WHERE content != -1 AND role = 'p';
+
+ANALYZE fast_analyze_@amname@_3;
+
+-- We have not sampled any live rows on any QE.
+SELECT gp_inject_fault('returned_sample_row', 'status', dbid)
+  FROM gp_segment_configuration WHERE content != -1 AND role = 'p';
+
+SELECT gp_inject_fault('returned_sample_row', 'reset', dbid)
+  FROM gp_segment_configuration WHERE content != -1 AND role = 'p';
+
+-- (b) With blkdir subcase
+
+CREATE INDEX ON fast_analyze_@amname@_3(i);
+
+SELECT gp_inject_fault_infinite('returned_sample_row', 'skip', dbid)
+  FROM gp_segment_configuration WHERE content != -1 AND role = 'p';
+
+ANALYZE fast_analyze_@amname@_3;
+
+-- We have not sampled any live rows on any QE.
+SELECT gp_inject_fault('returned_sample_row', 'status', dbid)
+  FROM gp_segment_configuration WHERE content != -1 AND role = 'p';
+
+SELECT gp_inject_fault('returned_sample_row', 'reset', dbid)
+  FROM gp_segment_configuration WHERE content != -1 AND role = 'p';
+
+--------------------------------------------------------------------------------
+-- Scenario 4:
+-- We have ALL deleted rows [2 subcases -> blkdir and non-blkdir].
+-- Expectation: We have not collected any live rows.
+--------------------------------------------------------------------------------
+
+CREATE TABLE fast_analyze_@amname@_4(i int, j int) USING @amname@ DISTRIBUTED BY (j);
+
+-- (a) Without blkdir subcase
+
+-- Insert 10 rows in each QE.
+1: BEGIN;
+2: BEGIN;
+3: BEGIN;
+1: INSERT INTO fast_analyze_@amname@_4 SELECT i, 2 FROM generate_series(1, 10) i;
+2: INSERT INTO fast_analyze_@amname@_4 SELECT i, 1 FROM generate_series(1, 10) i;
+3: INSERT INTO fast_analyze_@amname@_4 SELECT i, 5 FROM generate_series(1, 10) i;
+1: COMMIT;
+2: COMMIT;
+3: COMMIT;
+-- Delete all rows.
+DELETE FROM fast_analyze_@amname@_4;
+SELECT gp_inject_fault_infinite('returned_sample_row', 'skip', dbid)
+  FROM gp_segment_configuration WHERE content != -1 AND role = 'p';
+
+ANALYZE fast_analyze_@amname@_4;
+
+-- We have not sampled any live rows on any QE.
+SELECT gp_inject_fault('returned_sample_row', 'status', dbid)
+  FROM gp_segment_configuration WHERE content != -1 AND role = 'p';
+
+SELECT gp_inject_fault('returned_sample_row', 'reset', dbid)
+  FROM gp_segment_configuration WHERE content != -1 AND role = 'p';
+
+-- (b) With blkdir subcase
+
+CREATE INDEX ON fast_analyze_@amname@_4(i);
+
+SELECT gp_inject_fault_infinite('returned_sample_row', 'skip', dbid)
+  FROM gp_segment_configuration WHERE content != -1 AND role = 'p';
+
+ANALYZE fast_analyze_@amname@_4;
+
+-- We have not sampled any live rows on any QE.
+SELECT gp_inject_fault('returned_sample_row', 'status', dbid)
+  FROM gp_segment_configuration WHERE content != -1 AND role = 'p';
+
+SELECT gp_inject_fault('returned_sample_row', 'reset', dbid)
+  FROM gp_segment_configuration WHERE content != -1 AND role = 'p';
+
+DROP TABLE fast_analyze_@amname@_1;
+DROP TABLE fast_analyze_@amname@_2;
+DROP TABLE fast_analyze_@amname@_3;
+DROP TABLE fast_analyze_@amname@_4;
+
+--
+-- The following tests ensure fast analyze function to work
+-- with multi-segfiles tables under concurrent inserts.
+--
+
+create table analyze_@amname@ (id int, a int, b inet, c inet) using @amname@ with (compresstype=zlib, compresslevel=3);
+
+insert into analyze_@amname@ select 2, i, (select ((i%255)::text || '.' || (i%255)::text || '.' || (i%255)::text || '.' ||
+  (i%255)::text))::inet, (select ((i%255)::text || '.' || (i%255)::text || '.' || (i%255)::text || '.' ||
+  (i%255)::text))::inet from generate_series(1,30000)i;
+
+insert into analyze_@amname@ select * from analyze_@amname@ limit 1000;
+insert into analyze_@amname@ select * from analyze_@amname@ limit 1000;
+
+-- test ANALYZE after concurrent inserts commit
+
+1: begin;
+1: insert into analyze_@amname@ select * from analyze_@amname@ limit 1000;
+
+2: begin;
+2: insert into analyze_@amname@ select * from analyze_@amname@ limit 1000;
+
+3: begin;
+3: insert into analyze_@amname@ select * from analyze_@amname@ limit 1000;
+
+4: insert into analyze_@amname@ select * from analyze_@amname@ limit 1000;
+
+5: analyze analyze_@amname@;
+
+1: commit;
+2: commit;
+3: abort;
+
+1: analyze analyze_@amname@;
+
+-- test aoblkdir based ANALYZE
+
+create index on analyze_@amname@(id);
+
+1: begin;
+1: insert into analyze_@amname@ select * from analyze_@amname@ limit 1000;
+
+2: begin;
+2: insert into analyze_@amname@ select * from analyze_@amname@ limit 1000;
+
+3: begin;
+3: insert into analyze_@amname@ select * from analyze_@amname@ limit 1000;
+
+4: insert into analyze_@amname@ select * from analyze_@amname@ limit 1000;
+
+5: analyze analyze_@amname@;
+
+1: commit;
+2: commit;
+3: abort;
+
+1: analyze analyze_@amname@;
+
+drop table analyze_@amname@;
+
+-- test more data and stability, note, it could take a little long time
+
+create table analyze_@amname@_2 (id int, a int, b inet, c inet) using @amname@ with (compresstype=zlib, compresslevel=3);
+insert into analyze_@amname@_2 select 2, i, (select ((i%255)::text || '.' || (i%255)::text || '.' || (i%255)::text || '.' ||
+  (i%255)::text))::inet, (select ((i%255)::text || '.' || (i%255)::text || '.' || (i%255)::text || '.' ||
+  (i%255)::text))::inet from generate_series(1,1000)i;
+
+insert into analyze_@amname@_2 select * from analyze_@amname@_2;
+insert into analyze_@amname@_2 select * from analyze_@amname@_2;
+insert into analyze_@amname@_2 select * from analyze_@amname@_2;
+insert into analyze_@amname@_2 select * from analyze_@amname@_2;
+insert into analyze_@amname@_2 select * from analyze_@amname@_2;
+insert into analyze_@amname@_2 select * from analyze_@amname@_2;
+insert into analyze_@amname@_2 select * from analyze_@amname@_2;
+insert into analyze_@amname@_2 select * from analyze_@amname@_2;
+
+1: begin;
+1: insert into analyze_@amname@_2 select * from analyze_@amname@_2;
+
+2: insert into analyze_@amname@_2 select * from analyze_@amname@_2;
+
+1: commit;
+
+1: analyze analyze_@amname@_2;
+1: analyze analyze_@amname@_2;
+1: analyze analyze_@amname@_2;
+1: analyze analyze_@amname@_2;
+1: analyze analyze_@amname@_2;
+
+1: begin;
+1: insert into analyze_@amname@_2 select * from analyze_@amname@_2;
+
+2: insert into analyze_@amname@_2 select * from analyze_@amname@_2;
+
+1: abort;
+
+1: analyze analyze_@amname@_2;
+1: analyze analyze_@amname@_2;
+1: analyze analyze_@amname@_2;
+1: analyze analyze_@amname@_2;
+1: analyze analyze_@amname@_2;
+
+-- test with aoblkdir
+
+create index on analyze_@amname@_2(a);
+
+1: begin;
+1: insert into analyze_@amname@_2 select * from analyze_@amname@_2;
+
+2: insert into analyze_@amname@_2 select * from analyze_@amname@_2;
+
+1: commit;
+
+1: analyze analyze_@amname@_2;
+1: analyze analyze_@amname@_2;
+1: analyze analyze_@amname@_2;
+1: analyze analyze_@amname@_2;
+1: analyze analyze_@amname@_2;
+
+1: begin;
+1: insert into analyze_@amname@_2 select * from analyze_@amname@_2;
+
+2: insert into analyze_@amname@_2 select * from analyze_@amname@_2;
+
+1: abort;
+
+1: analyze analyze_@amname@_2;
+1: analyze analyze_@amname@_2;
+1: analyze analyze_@amname@_2;
+1: analyze analyze_@amname@_2;
+1: analyze analyze_@amname@_2;
+
+drop table analyze_@amname@_2;

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -161,6 +161,7 @@ test: uao/cluster_progress_row
 # test: uao/bad_buffer_on_temp_ao_row
 # check storage-dependent collected statistics views
 test: uao/collected_stats_views_row
+test: uao/fast_analyze_row
 
 test: reorganize_after_ao_vacuum_skip_drop truncate_after_ao_vacuum_skip_drop mark_all_aoseg_await_drop
 # below test(s) inject faults so each of them need to be in a separate group
@@ -226,6 +227,7 @@ test: uao/cluster_progress_column
 # test: uao/bad_buffer_on_temp_ao_column
 # check storage-dependent collected statistics views
 test: uao/collected_stats_views_column
+test: uao/fast_analyze_column
 
 # this case contains fault injection, must be put in a separate test group
 test: terminate_in_gang_creation

--- a/src/test/isolation2/output/uao/fast_analyze.source
+++ b/src/test/isolation2/output/uao/fast_analyze.source
@@ -1,0 +1,632 @@
+--
+-- Test AO/CO sampling method.
+--
+-- These tests ensure that we achieve our ANALYZE targets for AO/CO tables.
+--
+CREATE TABLE fast_analyze_@amname@_1(i int, j int) USING @amname@ DISTRIBUTED BY (j);
+CREATE
+
+-- Stats target info shows that we will sample 300 * (100) rows.
+SHOW default_statistics_target;
+ default_statistics_target 
+---------------------------
+ 100                       
+(1 row)
+SELECT attstattarget FROM pg_attribute WHERE attrelid = 'fast_analyze_@amname@_1'::regclass AND attname IN ('i', 'j');
+ attstattarget 
+---------------
+ -1            
+ -1            
+(2 rows)
+
+--------------------------------------------------------------------------------
+-- Scenario 1:
+-- We have MORE than 300 * default_statistics_target = 30k rows for a 2 int table,
+-- spread across 3 segments, with no aborted rows [2 subcases -> blkdir and
+-- non-blkdir].
+-- Expectation: We have collected 30k live rows.
+--------------------------------------------------------------------------------
+
+-- (a) Without blkdir subcase
+
+-- Insert 10.5k rows in each QE.
+1: BEGIN;
+BEGIN
+2: BEGIN;
+BEGIN
+3: BEGIN;
+BEGIN
+1: INSERT INTO fast_analyze_@amname@_1 SELECT i, 2 FROM generate_series(1, 10500) i;
+INSERT 10500
+2: INSERT INTO fast_analyze_@amname@_1 SELECT i, 1 FROM generate_series(1, 10500) i;
+INSERT 10500
+3: INSERT INTO fast_analyze_@amname@_1 SELECT i, 5 FROM generate_series(1, 10500) i;
+INSERT 10500
+1: COMMIT;
+COMMIT
+2: COMMIT;
+COMMIT
+3: COMMIT;
+COMMIT
+
+SELECT gp_inject_fault_infinite('returned_sample_row', 'skip', dbid) FROM gp_segment_configuration WHERE content != -1 AND role = 'p';
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+ Success:                 
+ Success:                 
+(3 rows)
+
+ANALYZE fast_analyze_@amname@_1;
+ANALYZE
+
+-- We have sampled 10k live rows.
+SELECT gp_inject_fault('returned_sample_row', 'status', dbid) FROM gp_segment_configuration WHERE content != -1 AND role = 'p';
+ gp_inject_fault                                                                                                                                                                                                               
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Success: fault name:'returned_sample_row' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'triggered'  num times hit:'10000' 
+ 
+ Success: fault name:'returned_sample_row' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'triggered'  num times hit:'10000' 
+ 
+ Success: fault name:'returned_sample_row' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'triggered'  num times hit:'10000' 
+ 
+(3 rows)
+
+SELECT gp_inject_fault('returned_sample_row', 'reset', dbid) FROM gp_segment_configuration WHERE content != -1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+(3 rows)
+
+-- (b) With blkdir subcase
+
+CREATE INDEX ON fast_analyze_@amname@_1(i);
+CREATE
+
+SELECT gp_inject_fault_infinite('returned_sample_row', 'skip', dbid) FROM gp_segment_configuration WHERE content != -1 AND role = 'p';
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+ Success:                 
+ Success:                 
+(3 rows)
+
+ANALYZE fast_analyze_@amname@_1;
+ANALYZE
+
+-- We have sampled 10k live rows from each QE.
+SELECT gp_inject_fault('returned_sample_row', 'status', dbid) FROM gp_segment_configuration WHERE content != -1 AND role = 'p';
+ gp_inject_fault                                                                                                                                                                                                               
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Success: fault name:'returned_sample_row' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'triggered'  num times hit:'10000' 
+ 
+ Success: fault name:'returned_sample_row' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'triggered'  num times hit:'10000' 
+ 
+ Success: fault name:'returned_sample_row' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'triggered'  num times hit:'10000' 
+ 
+(3 rows)
+
+SELECT gp_inject_fault('returned_sample_row', 'reset', dbid) FROM gp_segment_configuration WHERE content != -1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+(3 rows)
+
+--------------------------------------------------------------------------------
+-- Scenario 2:
+-- We have LESS than 300 * default_statistics_target = 30k rows for a 2 int table,
+-- spread across 3 segments, with no aborted rows [2 subcases -> blkdir and
+-- non-blkdir].
+-- Expectation: We have collected number of live rows = total tupcount of table.
+--------------------------------------------------------------------------------
+
+CREATE TABLE fast_analyze_@amname@_2(i int, j int) USING @amname@ DISTRIBUTED BY (j);
+CREATE
+
+-- (a) Without blkdir subcase
+
+-- Insert 10 rows in each QE.
+1: BEGIN;
+BEGIN
+2: BEGIN;
+BEGIN
+3: BEGIN;
+BEGIN
+1: INSERT INTO fast_analyze_@amname@_2 SELECT i, 2 FROM generate_series(1, 10) i;
+INSERT 10
+2: INSERT INTO fast_analyze_@amname@_2 SELECT i, 1 FROM generate_series(1, 10) i;
+INSERT 10
+3: INSERT INTO fast_analyze_@amname@_2 SELECT i, 5 FROM generate_series(1, 10) i;
+INSERT 10
+1: COMMIT;
+COMMIT
+2: COMMIT;
+COMMIT
+3: COMMIT;
+COMMIT
+
+SELECT gp_inject_fault_infinite('returned_sample_row', 'skip', dbid) FROM gp_segment_configuration WHERE content != -1 AND role = 'p';
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+ Success:                 
+ Success:                 
+(3 rows)
+
+ANALYZE fast_analyze_@amname@_2;
+ANALYZE
+
+-- We have sampled 10 live rows from each QE.
+SELECT gp_inject_fault('returned_sample_row', 'status', dbid) FROM gp_segment_configuration WHERE content != -1 AND role = 'p';
+ gp_inject_fault                                                                                                                                                                                                            
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Success: fault name:'returned_sample_row' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'triggered'  num times hit:'10' 
+ 
+ Success: fault name:'returned_sample_row' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'triggered'  num times hit:'10' 
+ 
+ Success: fault name:'returned_sample_row' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'triggered'  num times hit:'10' 
+ 
+(3 rows)
+
+SELECT gp_inject_fault('returned_sample_row', 'reset', dbid) FROM gp_segment_configuration WHERE content != -1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+(3 rows)
+
+-- (b) With blkdir subcase
+
+CREATE INDEX ON fast_analyze_@amname@_2(i);
+CREATE
+
+SELECT gp_inject_fault_infinite('returned_sample_row', 'skip', dbid) FROM gp_segment_configuration WHERE content != -1 AND role = 'p';
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+ Success:                 
+ Success:                 
+(3 rows)
+
+ANALYZE fast_analyze_@amname@_2;
+ANALYZE
+
+-- We have sampled 10 live rows from each QE.
+SELECT gp_inject_fault('returned_sample_row', 'status', dbid) FROM gp_segment_configuration WHERE content != -1 AND role = 'p';
+ gp_inject_fault                                                                                                                                                                                                            
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Success: fault name:'returned_sample_row' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'triggered'  num times hit:'10' 
+ 
+ Success: fault name:'returned_sample_row' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'triggered'  num times hit:'10' 
+ 
+ Success: fault name:'returned_sample_row' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'triggered'  num times hit:'10' 
+ 
+(3 rows)
+
+SELECT gp_inject_fault('returned_sample_row', 'reset', dbid) FROM gp_segment_configuration WHERE content != -1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+(3 rows)
+
+--------------------------------------------------------------------------------
+-- Scenario 3:
+-- We have ALL aborted rows [2 subcases -> blkdir and non-blkdir].
+-- Expectation: We have not sampled any live rows.
+--------------------------------------------------------------------------------
+
+CREATE TABLE fast_analyze_@amname@_3(i int, j int) USING @amname@ DISTRIBUTED BY (j);
+CREATE
+
+-- (a) Without blkdir subcase
+
+-- Insert 10 rows in each QE.
+1: BEGIN;
+BEGIN
+2: BEGIN;
+BEGIN
+3: BEGIN;
+BEGIN
+1: INSERT INTO fast_analyze_@amname@_3 SELECT i, 2 FROM generate_series(1, 10) i;
+INSERT 10
+2: INSERT INTO fast_analyze_@amname@_3 SELECT i, 1 FROM generate_series(1, 10) i;
+INSERT 10
+3: INSERT INTO fast_analyze_@amname@_3 SELECT i, 5 FROM generate_series(1, 10) i;
+INSERT 10
+1: ABORT;
+ABORT
+2: ABORT;
+ABORT
+3: ABORT;
+ABORT
+
+SELECT gp_inject_fault_infinite('returned_sample_row', 'skip', dbid) FROM gp_segment_configuration WHERE content != -1 AND role = 'p';
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+ Success:                 
+ Success:                 
+(3 rows)
+
+ANALYZE fast_analyze_@amname@_3;
+ANALYZE
+
+-- We have not sampled any live rows on any QE.
+SELECT gp_inject_fault('returned_sample_row', 'status', dbid) FROM gp_segment_configuration WHERE content != -1 AND role = 'p';
+ gp_inject_fault                                                                                                                                                                                                     
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Success: fault name:'returned_sample_row' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'set'  num times hit:'0' 
+ 
+ Success: fault name:'returned_sample_row' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'set'  num times hit:'0' 
+ 
+ Success: fault name:'returned_sample_row' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'set'  num times hit:'0' 
+ 
+(3 rows)
+
+SELECT gp_inject_fault('returned_sample_row', 'reset', dbid) FROM gp_segment_configuration WHERE content != -1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+(3 rows)
+
+-- (b) With blkdir subcase
+
+CREATE INDEX ON fast_analyze_@amname@_3(i);
+CREATE
+
+SELECT gp_inject_fault_infinite('returned_sample_row', 'skip', dbid) FROM gp_segment_configuration WHERE content != -1 AND role = 'p';
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+ Success:                 
+ Success:                 
+(3 rows)
+
+ANALYZE fast_analyze_@amname@_3;
+ANALYZE
+
+-- We have not sampled any live rows on any QE.
+SELECT gp_inject_fault('returned_sample_row', 'status', dbid) FROM gp_segment_configuration WHERE content != -1 AND role = 'p';
+ gp_inject_fault                                                                                                                                                                                                     
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Success: fault name:'returned_sample_row' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'set'  num times hit:'0' 
+ 
+ Success: fault name:'returned_sample_row' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'set'  num times hit:'0' 
+ 
+ Success: fault name:'returned_sample_row' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'set'  num times hit:'0' 
+ 
+(3 rows)
+
+SELECT gp_inject_fault('returned_sample_row', 'reset', dbid) FROM gp_segment_configuration WHERE content != -1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+(3 rows)
+
+--------------------------------------------------------------------------------
+-- Scenario 4:
+-- We have ALL deleted rows [2 subcases -> blkdir and non-blkdir].
+-- Expectation: We have not collected any live rows.
+--------------------------------------------------------------------------------
+
+CREATE TABLE fast_analyze_@amname@_4(i int, j int) USING @amname@ DISTRIBUTED BY (j);
+CREATE
+
+-- (a) Without blkdir subcase
+
+-- Insert 10 rows in each QE.
+1: BEGIN;
+BEGIN
+2: BEGIN;
+BEGIN
+3: BEGIN;
+BEGIN
+1: INSERT INTO fast_analyze_@amname@_4 SELECT i, 2 FROM generate_series(1, 10) i;
+INSERT 10
+2: INSERT INTO fast_analyze_@amname@_4 SELECT i, 1 FROM generate_series(1, 10) i;
+INSERT 10
+3: INSERT INTO fast_analyze_@amname@_4 SELECT i, 5 FROM generate_series(1, 10) i;
+INSERT 10
+1: COMMIT;
+COMMIT
+2: COMMIT;
+COMMIT
+3: COMMIT;
+COMMIT
+-- Delete all rows.
+DELETE FROM fast_analyze_@amname@_4;
+DELETE 30
+SELECT gp_inject_fault_infinite('returned_sample_row', 'skip', dbid) FROM gp_segment_configuration WHERE content != -1 AND role = 'p';
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+ Success:                 
+ Success:                 
+(3 rows)
+
+ANALYZE fast_analyze_@amname@_4;
+ANALYZE
+
+-- We have not sampled any live rows on any QE.
+SELECT gp_inject_fault('returned_sample_row', 'status', dbid) FROM gp_segment_configuration WHERE content != -1 AND role = 'p';
+ gp_inject_fault                                                                                                                                                                                                     
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Success: fault name:'returned_sample_row' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'set'  num times hit:'0' 
+ 
+ Success: fault name:'returned_sample_row' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'set'  num times hit:'0' 
+ 
+ Success: fault name:'returned_sample_row' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'set'  num times hit:'0' 
+ 
+(3 rows)
+
+SELECT gp_inject_fault('returned_sample_row', 'reset', dbid) FROM gp_segment_configuration WHERE content != -1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+(3 rows)
+
+-- (b) With blkdir subcase
+
+CREATE INDEX ON fast_analyze_@amname@_4(i);
+CREATE
+
+SELECT gp_inject_fault_infinite('returned_sample_row', 'skip', dbid) FROM gp_segment_configuration WHERE content != -1 AND role = 'p';
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+ Success:                 
+ Success:                 
+(3 rows)
+
+ANALYZE fast_analyze_@amname@_4;
+ANALYZE
+
+-- We have not sampled any live rows on any QE.
+SELECT gp_inject_fault('returned_sample_row', 'status', dbid) FROM gp_segment_configuration WHERE content != -1 AND role = 'p';
+ gp_inject_fault                                                                                                                                                                                                     
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Success: fault name:'returned_sample_row' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'set'  num times hit:'0' 
+ 
+ Success: fault name:'returned_sample_row' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'set'  num times hit:'0' 
+ 
+ Success: fault name:'returned_sample_row' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'set'  num times hit:'0' 
+ 
+(3 rows)
+
+SELECT gp_inject_fault('returned_sample_row', 'reset', dbid) FROM gp_segment_configuration WHERE content != -1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+(3 rows)
+
+DROP TABLE fast_analyze_@amname@_1;
+DROP
+DROP TABLE fast_analyze_@amname@_2;
+DROP
+DROP TABLE fast_analyze_@amname@_3;
+DROP
+DROP TABLE fast_analyze_@amname@_4;
+DROP
+
+--
+-- The following tests ensure fast analyze function to work
+-- with multi-segfiles tables under concurrent inserts.
+--
+
+create table analyze_@amname@ (id int, a int, b inet, c inet) using @amname@ with (compresstype=zlib, compresslevel=3);
+CREATE
+
+insert into analyze_@amname@ select 2, i, (select ((i%255)::text || '.' || (i%255)::text || '.' || (i%255)::text || '.' || (i%255)::text))::inet, (select ((i%255)::text || '.' || (i%255)::text || '.' || (i%255)::text || '.' || (i%255)::text))::inet from generate_series(1,30000)i;
+INSERT 30000
+
+insert into analyze_@amname@ select * from analyze_@amname@ limit 1000;
+INSERT 1000
+insert into analyze_@amname@ select * from analyze_@amname@ limit 1000;
+INSERT 1000
+
+-- test ANALYZE after concurrent inserts commit
+
+1: begin;
+BEGIN
+1: insert into analyze_@amname@ select * from analyze_@amname@ limit 1000;
+INSERT 1000
+
+2: begin;
+BEGIN
+2: insert into analyze_@amname@ select * from analyze_@amname@ limit 1000;
+INSERT 1000
+
+3: begin;
+BEGIN
+3: insert into analyze_@amname@ select * from analyze_@amname@ limit 1000;
+INSERT 1000
+
+4: insert into analyze_@amname@ select * from analyze_@amname@ limit 1000;
+INSERT 1000
+
+5: analyze analyze_@amname@;
+ANALYZE
+
+1: commit;
+COMMIT
+2: commit;
+COMMIT
+3: abort;
+ABORT
+
+1: analyze analyze_@amname@;
+ANALYZE
+
+-- test aoblkdir based ANALYZE
+
+create index on analyze_@amname@(id);
+CREATE
+
+1: begin;
+BEGIN
+1: insert into analyze_@amname@ select * from analyze_@amname@ limit 1000;
+INSERT 1000
+
+2: begin;
+BEGIN
+2: insert into analyze_@amname@ select * from analyze_@amname@ limit 1000;
+INSERT 1000
+
+3: begin;
+BEGIN
+3: insert into analyze_@amname@ select * from analyze_@amname@ limit 1000;
+INSERT 1000
+
+4: insert into analyze_@amname@ select * from analyze_@amname@ limit 1000;
+INSERT 1000
+
+5: analyze analyze_@amname@;
+ANALYZE
+
+1: commit;
+COMMIT
+2: commit;
+COMMIT
+3: abort;
+ABORT
+
+1: analyze analyze_@amname@;
+ANALYZE
+
+drop table analyze_@amname@;
+DROP
+
+-- test more data and stability, note, it could take a little long time
+
+create table analyze_@amname@_2 (id int, a int, b inet, c inet) using @amname@ with (compresstype=zlib, compresslevel=3);
+CREATE
+insert into analyze_@amname@_2 select 2, i, (select ((i%255)::text || '.' || (i%255)::text || '.' || (i%255)::text || '.' || (i%255)::text))::inet, (select ((i%255)::text || '.' || (i%255)::text || '.' || (i%255)::text || '.' || (i%255)::text))::inet from generate_series(1,1000)i;
+INSERT 1000
+
+insert into analyze_@amname@_2 select * from analyze_@amname@_2;
+INSERT 1000
+insert into analyze_@amname@_2 select * from analyze_@amname@_2;
+INSERT 2000
+insert into analyze_@amname@_2 select * from analyze_@amname@_2;
+INSERT 4000
+insert into analyze_@amname@_2 select * from analyze_@amname@_2;
+INSERT 8000
+insert into analyze_@amname@_2 select * from analyze_@amname@_2;
+INSERT 16000
+insert into analyze_@amname@_2 select * from analyze_@amname@_2;
+INSERT 32000
+insert into analyze_@amname@_2 select * from analyze_@amname@_2;
+INSERT 64000
+insert into analyze_@amname@_2 select * from analyze_@amname@_2;
+INSERT 128000
+
+1: begin;
+BEGIN
+1: insert into analyze_@amname@_2 select * from analyze_@amname@_2;
+INSERT 256000
+
+2: insert into analyze_@amname@_2 select * from analyze_@amname@_2;
+INSERT 256000
+
+1: commit;
+COMMIT
+
+1: analyze analyze_@amname@_2;
+ANALYZE
+1: analyze analyze_@amname@_2;
+ANALYZE
+1: analyze analyze_@amname@_2;
+ANALYZE
+1: analyze analyze_@amname@_2;
+ANALYZE
+1: analyze analyze_@amname@_2;
+ANALYZE
+
+1: begin;
+BEGIN
+1: insert into analyze_@amname@_2 select * from analyze_@amname@_2;
+INSERT 768000
+
+2: insert into analyze_@amname@_2 select * from analyze_@amname@_2;
+INSERT 768000
+
+1: abort;
+ABORT
+
+1: analyze analyze_@amname@_2;
+ANALYZE
+1: analyze analyze_@amname@_2;
+ANALYZE
+1: analyze analyze_@amname@_2;
+ANALYZE
+1: analyze analyze_@amname@_2;
+ANALYZE
+1: analyze analyze_@amname@_2;
+ANALYZE
+
+-- test with aoblkdir
+
+create index on analyze_@amname@_2(a);
+CREATE
+
+1: begin;
+BEGIN
+1: insert into analyze_@amname@_2 select * from analyze_@amname@_2;
+INSERT 1536000
+
+2: insert into analyze_@amname@_2 select * from analyze_@amname@_2;
+INSERT 1536000
+
+1: commit;
+COMMIT
+
+1: analyze analyze_@amname@_2;
+ANALYZE
+1: analyze analyze_@amname@_2;
+ANALYZE
+1: analyze analyze_@amname@_2;
+ANALYZE
+1: analyze analyze_@amname@_2;
+ANALYZE
+1: analyze analyze_@amname@_2;
+ANALYZE
+
+1: begin;
+BEGIN
+1: insert into analyze_@amname@_2 select * from analyze_@amname@_2;
+INSERT 4608000
+
+2: insert into analyze_@amname@_2 select * from analyze_@amname@_2;
+INSERT 4608000
+
+1: abort;
+ABORT
+
+1: analyze analyze_@amname@_2;
+ANALYZE
+1: analyze analyze_@amname@_2;
+ANALYZE
+1: analyze analyze_@amname@_2;
+ANALYZE
+1: analyze analyze_@amname@_2;
+ANALYZE
+1: analyze analyze_@amname@_2;
+ANALYZE
+
+drop table analyze_@amname@_2;
+DROP


### PR DESCRIPTION
Prior to this patch, GPDB ANALYZE on large AO/CO tables is a time-consuming process.
This is because PostgreSQL's two-stage sampling method didn't work well on AO/CO tables.
GPDB had to unpack all varblocks till to the target tuples, which could easily result in
almost full table scanning if sampling tuples fall around the end of the table.

Denis Smirnov <sd@picodata.io> 's PR greenplum-db#11190 introduced
a `logical` block concept containing fixed number of tuples to support PG's two-stage sampling
mechanism, also it sped up fetching target tuples by skipping uncompression of varblock content.
Thanks for Denis Smirnov's great contribution!

Also, thanks for Ashwin Agrawal <aashwin@vmware.com> 's advice on leveraging AO Block Directory
to locate the target sample row without scanning unnecessary varblocks, which brings another
significant performance improvement with caching warmed up.

In addition,
- GPDB has AO/CO specific feature that storing total tuple count in an auxiliary table
  which could be easily obtained without too much overhead.
- GPDB has `fetch` facilities support finding varblock based on AOTupleId without
  uncompressing unnecessary varblocks.

Based on above works and properties, we re-implemented AO/CO ANALYZE sampling by combining
Knuth's Algorithm S and varblock skipping in this patch, to address the time-consuming problem.

We didn't impelment two-stage sampling for AO/CO as the total size of data set (total tuple count)
could be known in advance hence Algorithm S is sufficient to satisfy the sampling requirement.

Special thanks Zhenghua Lyu (https://kainwen.com/) for detail analysis of Algorithm S:
[Analysis of Algorithm S](https://kainwen.com/2022/11/06/analysis-of-algorithm-s) and
follow up [discussion](https://stackoverflow.com/questions/74345921/performance-comparsion-algorithm-s-and-algorithm-z?noredirect=1#comment131292564_74345921)

Here is a simple example to show the optimization effect:

[AO with compression, with Fast Analyze enabled]
```SQL
create table ao (a int, b inet, c inet) with (appendonly=true, orientation=row, compresstype=zlib, compresslevel=3);
insert into ao select i, (select ((i%255)::text || '.' || (i%255)::text || '.' || (i%255)::text || '.' ||
(i%255)::text))::inet, (select ((i%255)::text || '.' || (i%255)::text || '.' || (i%255)::text || '.' ||
(i%255)::text))::inet from generate_series(1,10000000)i;

insert into ao select * from ao;
insert into ao select * from ao;
insert into ao select * from ao;
insert into ao select * from ao;
insert into ao select * from ao;
insert into ao select * from ao;
insert into ao select * from ao;

select count(*) from ao;
   count
------------
 1280000000
(1 row)

gpadmin=# analyze ao;
ANALYZE
Time: 2814.939 ms (00:02.815)
gpadmin=#
```
[with block directory and caching warmed]
```SQL
gpadmin=# analyze ao;
ANALYZE
Time: 1605.342 ms (00:01.605)
gpadmin=# 
```
[Legacy Analyze]
```SQL
gpadmin=# analyze ao;
ANALYZE
Time: 59711.905 ms (00:59.712)
gpadmin=#
```
[Heap without compression]
```SQL
create table heap (a int, b inet, c inet);
insert same data set

gpadmin=# analyze heap;
ANALYZE
Time: 2087.694 ms (00:02.088)
gpadmin=#
```