### PR TITLE
Fix Range Tables related relations opening's locking issue inside ExecInitModifyTable().

### DIFF
--- a/src/test/regress/expected/delete.out
+++ b/src/test/regress/expected/delete.out
@@ -30,4 +30,12 @@ SELECT id, a, char_length(b) FROM delete_test;
   1 | 10 |            
 (1 row)
 
+-- issue 14417: Range Tables related relations opening's locking issue
+CREATE EXTERNAL WEB TABLE dummy(x int) EXECUTE 'touch /tmp/dummy2.csv;cat /tmp/dummy2.csv' ON MASTER FORMAT 'csv';
+CREATE TABLE issue_14417(x int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'x' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+DELETE FROM issue_14417 WHERE x IN (SELECT x FROM dummy);
 DROP TABLE delete_test;
+DROP TABLE issue_14417;
+DROP EXTERNAL TABLE dummy;

--- a/src/test/regress/sql/delete.sql
+++ b/src/test/regress/sql/delete.sql
@@ -22,4 +22,11 @@ DELETE FROM delete_test WHERE a > 25;
 
 SELECT id, a, char_length(b) FROM delete_test;
 
+-- issue 14417: Range Tables related relations opening's locking issue
+CREATE EXTERNAL WEB TABLE dummy(x int) EXECUTE 'touch /tmp/dummy2.csv;cat /tmp/dummy2.csv' ON MASTER FORMAT 'csv';
+CREATE TABLE issue_14417(x int);
+DELETE FROM issue_14417 WHERE x IN (SELECT x FROM dummy);
+
 DROP TABLE delete_test;
+DROP TABLE issue_14417;
+DROP EXTERNAL TABLE dummy;


### PR DESCRIPTION
As #14417 reported, there will be assertion failures in some cases when executing ModifyTable.

This is because we opened all the range table relations in `NoLock` mode, but sometimes with no lock holding by us.

This also resolved a GPDB_91_MERGE FIXME left around range table locking code: https://github.com/greenplum-db/gpdb/blob/05b333dfdc03d0477fafe132b10c0cfa2a19d5ae/src/backend/executor/nodeModifyTable.c#L2991~L2993

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
