### PR TITLE
WIP: (6X only) Remove hash_destory in apply_motion.

### DIFF
--- a/src/backend/cdb/cdbmutate.c
+++ b/src/backend/cdb/cdbmutate.c
@@ -705,7 +705,6 @@ apply_motion(PlannerInfo *root, Plan *plan, Query *query)
 			subplan->qDispSliceId = sliceId;
 		}
 	}
-	hash_destroy(state.planid_subplans);
 
 	/*
 	 * Discard subtrees of Query node that aren't needed for execution. Note


### PR DESCRIPTION
Commit 9d45d2384 create a hash table in apply_motion under CurrentMemoryContext (MessageContext for normal SQL, portal->heap for explain SQL) and later it invokes hash_destroy to delete the hash table. This is a horrible bug because hash_destroy will invoke MemoryContextDelete on the memory context of the hash table.

This commit simply removes the hash_destroy function call since we do not need to worry about memory leak here, just let the hash table's life time the same as the CurrentMemoryContext.

---------

I think this is a horrible bug since 6.18.0. But I never heard anyone report it and I only catch it in a private pipeline.
The code change is just one line removal. Add WIP in the title since I am trying to write a test case.
