### PR TITLE
Remove gp_allow_rename_relation_without_lock

### DIFF
--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -233,7 +233,6 @@ bool		execute_pruned_plan = false;
 bool		gp_maintenance_mode;
 bool		gp_maintenance_conn;
 bool		allow_segment_DML;
-bool		gp_allow_rename_relation_without_lock = false;
 
 /* Time based authentication GUC */
 char	   *gp_auth_time_override_str = NULL;
@@ -592,16 +591,6 @@ struct config_bool ConfigureNamesBool_gp[] =
 			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&allow_segment_DML,
-		false,
-		NULL, NULL, NULL
-	},
-	{
-		{"gp_allow_rename_relation_without_lock", PGC_USERSET, CUSTOM_OPTIONS,
-			gettext_noop("Allow ALTER TABLE RENAME without AccessExclusiveLock"),
-			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
-		},
-		&gp_allow_rename_relation_without_lock,
 		false,
 		NULL, NULL, NULL
 	},

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -326,7 +326,6 @@ extern int rep_lag_avoidance_threshold;
 extern bool gp_maintenance_mode;
 extern bool gp_maintenance_conn;
 extern bool allow_segment_DML;
-extern bool gp_allow_rename_relation_without_lock;
 
 extern bool gp_ignore_error_table;
 

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -149,7 +149,6 @@
 		"geqo_threshold",
 		"gp_adjust_selectivity_for_outerjoins",
 		"gp_allow_non_uniform_partitioning_ddl",
-		"gp_allow_rename_relation_without_lock",
 		"gp_appendonly_compaction",
 		"gp_appendonly_compaction_threshold",
 		"gp_appendonly_verify_block_checksums",

--- a/src/test/regress/expected/alter_table_gp.out
+++ b/src/test/regress/expected/alter_table_gp.out
@@ -1,25 +1,3 @@
--- ALTER TABLE ... RENAME on corrupted relations
-SET allow_system_table_mods = true;
-SET gp_allow_rename_relation_without_lock = ON;
--- missing entry
-CREATE TABLE cor (a int, b float);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-INSERT INTO cor SELECT i, i+1 FROM generate_series(1,100)i;
-DELETE FROM pg_attribute WHERE attname='a' AND attrelid='cor'::regclass;
-ALTER TABLE cor RENAME TO oldcor;
-INSERT INTO pg_attribute SELECT distinct on(attrelid, attnum) * FROM gp_dist_random('pg_attribute') WHERE attname='a' AND attrelid='oldcor'::regclass;
-DROP TABLE oldcor;
--- typname is out of sync
-CREATE TABLE cor (a int, b float, c text);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-UPDATE pg_type SET typname='newcor' WHERE typrelid='cor'::regclass;
-ALTER TABLE cor RENAME TO newcor2;
-ALTER TABLE newcor2 RENAME TO cor;
-DROP TABLE cor;
-RESET allow_system_table_mods;
-RESET gp_allow_rename_relation_without_lock;
 -- MPP-20466 Dis-allow duplicate constraint names for same table
 create table dupconstr (
 						i int,

--- a/src/test/regress/sql/alter_table_gp.sql
+++ b/src/test/regress/sql/alter_table_gp.sql
@@ -1,25 +1,3 @@
--- ALTER TABLE ... RENAME on corrupted relations
-SET allow_system_table_mods = true;
-SET gp_allow_rename_relation_without_lock = ON;
--- missing entry
-CREATE TABLE cor (a int, b float);
-INSERT INTO cor SELECT i, i+1 FROM generate_series(1,100)i;
-DELETE FROM pg_attribute WHERE attname='a' AND attrelid='cor'::regclass;
-ALTER TABLE cor RENAME TO oldcor;
-INSERT INTO pg_attribute SELECT distinct on(attrelid, attnum) * FROM gp_dist_random('pg_attribute') WHERE attname='a' AND attrelid='oldcor'::regclass;
-DROP TABLE oldcor;
-
--- typname is out of sync
-CREATE TABLE cor (a int, b float, c text);
-UPDATE pg_type SET typname='newcor' WHERE typrelid='cor'::regclass;
-ALTER TABLE cor RENAME TO newcor2;
-ALTER TABLE newcor2 RENAME TO cor;
-DROP TABLE cor;
-
-RESET allow_system_table_mods;
-RESET gp_allow_rename_relation_without_lock;
-
-
 -- MPP-20466 Dis-allow duplicate constraint names for same table
 create table dupconstr (
 						i int,


### PR DESCRIPTION
This GUC was introduced in de4e95a6a914 in order to workaround a specific case where we couldn't rename a relation if its metadata is corrupted. When this GUC is ON, we don't really open the relation which would throw error with the aforementioned metadata corruption.

Now removing this GUC at least for 7X because its benefit is questionable: 
(1) It seems to be a one-time workaround trick, and has been obsolete for a long time. There's no Slack/JIRA/Github history that could show it has been actively used by support;
(2) There is better alternative to workaround the issue, which is to simply fix the metadata. Leaving a hole like this in the product does not feel safe. It creates needless divergence from the upstream too.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
