### PR TITLE
ao/co: Correct tuple visibility reporting for index builds

### DIFF
--- a/src/backend/access/appendonly/appendonlyam_handler.c
+++ b/src/backend/access/appendonly/appendonlyam_handler.c
@@ -1512,6 +1512,7 @@ appendonly_index_build_range_scan(Relation heapRelation,
 	while (appendonly_getnextslot(&aoscan->rs_base, ForwardScanDirection, slot))
 	{
 		bool		tupleIsAlive;
+		AOTupleId 	*aoTupleId;
 
 		CHECK_FOR_INTERRUPTS();
 
@@ -1540,14 +1541,20 @@ appendonly_index_build_range_scan(Relation heapRelation,
 		}
 #endif
 
+		aoTupleId = (AOTupleId *) &slot->tts_tid;
 		/*
-		 * appendonly_getnext did the time qual check
-		 *
-		 * GPDB_12_MERGE_FIXME: in heapam, we do visibility checks in SnapshotAny case
-		 * here. Is that not needed with AO tables?
+		 * We didn't perform the check to see if the tuple was deleted in
+		 * appendonlygettup(), since we passed it SnapshotAny. See
+		 * appendonlygettup() for details. We need to do this to avoid spurious
+		 * conflicts with deleted tuples for unique index builds.
 		 */
-		tupleIsAlive = true;
-		reltuples += 1;
+		if (AppendOnlyVisimap_IsVisible(&aoscan->visibilityMap, aoTupleId))
+		{
+			tupleIsAlive = true;
+			reltuples += 1;
+		}
+		else
+			tupleIsAlive = false; /* excluded from unique-checking */
 
 		MemoryContextReset(econtext->ecxt_per_tuple_memory);
 

--- a/src/backend/access/appendonly/appendonlyam_handler.c
+++ b/src/backend/access/appendonly/appendonlyam_handler.c
@@ -1369,8 +1369,6 @@ appendonly_index_build_range_scan(Relation heapRelation,
 	EState	   *estate;
 	ExprContext *econtext;
 	Snapshot	snapshot;
-	bool		need_unregister_snapshot = false;
-	TransactionId OldestXmin;
 
 	/*
 	 * sanity checks
@@ -1410,35 +1408,15 @@ appendonly_index_build_range_scan(Relation heapRelation,
 	/* Set up execution state for predicate, if any. */
 	predicate = ExecPrepareQual(indexInfo->ii_Predicate, estate);
 
-	/*
-	 * Prepare for scan of the base relation.  In a normal index build, we use
-	 * SnapshotAny because we must retrieve all tuples and do our own time
-	 * qual checks (because we have to index RECENTLY_DEAD tuples). In a
-	 * concurrent build, or during bootstrap, we take a regular MVCC snapshot
-	 * and index whatever's live according to that.
-	 */
-	OldestXmin = InvalidTransactionId;
-
-	/* okay to ignore lazy VACUUMs here */
-	if (!IsBootstrapProcessingMode() && !indexInfo->ii_Concurrent)
-		OldestXmin = GetOldestXmin(heapRelation, PROCARRAY_FLAGS_VACUUM);
-
 	if (!scan)
 	{
 		/*
 		 * Serial index build.
 		 *
-		 * Must begin our own heap scan in this case.  We may also need to
-		 * register a snapshot whose lifetime is under our direct control.
+		 * XXX: We always use SnapshotAny here. An MVCC snapshot and oldest xmin
+		 * calculation is necessary to support indexes built CONCURRENTLY.
 		 */
-		if (!TransactionIdIsValid(OldestXmin))
-		{
-			snapshot = RegisterSnapshot(GetTransactionSnapshot());
-			need_unregister_snapshot = true;
-		}
-		else
-			snapshot = SnapshotAny;
-
+		snapshot = SnapshotAny;
 		scan = table_beginscan_strat(heapRelation,	/* relation */
 									 snapshot,	/* snapshot */
 									 0, /* number of keys */
@@ -1514,17 +1492,6 @@ appendonly_index_build_range_scan(Relation heapRelation,
 									 nblocks);
 	}
 #endif
-
-	/*
-	 * Must call GetOldestXmin() with SnapshotAny.  Should never call
-	 * GetOldestXmin() with MVCC snapshot. (It's especially worth checking
-	 * this for parallel builds, since ambuild routines that support parallel
-	 * builds must work these details out for themselves.)
-	 */
-	Assert(snapshot == SnapshotAny || IsMVCCSnapshot(snapshot));
-	Assert(snapshot == SnapshotAny ? TransactionIdIsValid(OldestXmin) :
-		   !TransactionIdIsValid(OldestXmin));
-	Assert(snapshot == SnapshotAny || !anyvisible);
 
 	/* set our scan endpoints */
 	if (!allow_sync)
@@ -1645,10 +1612,6 @@ appendonly_index_build_range_scan(Relation heapRelation,
 #endif
 
 	table_endscan(scan);
-
-	/* we can now forget our snapshot, if set and registered by us */
-	if (need_unregister_snapshot)
-		UnregisterSnapshot(snapshot);
 
 	ExecDropSingleTupleTableSlot(slot);
 

--- a/src/test/isolation2/input/uao/index_build_reltuples.source
+++ b/src/test/isolation2/input/uao/index_build_reltuples.source
@@ -1,0 +1,101 @@
+-- Coverage to ensure that reltuples is updated correctly upon an index build
+-- (i.e. CREATE INDEX) on AO/CO tables.
+-- FIXME: Currently doesn't assert reltuples on QD (at the moment, we don't
+-- aggregate the reltuples counts on QD at end of command)
+
+SET default_table_access_method TO @amname@;
+
+-- Case 1: Verify that CREATE INDEX is able to update both the aorel's reltuples
+-- and the index's reltuples, to equal the actual segment tuple counts.
+
+CREATE TABLE index_build_reltuples_@amname@(a int);
+INSERT INTO index_build_reltuples_@amname@ SELECT generate_series(1, 10);
+
+CREATE INDEX ON index_build_reltuples_@amname@(a);
+
+SELECT gp_segment_id, count(*) FROM index_build_reltuples_@amname@
+	GROUP BY gp_segment_id ORDER BY gp_segment_id;
+SELECT gp_segment_id, reltuples FROM gp_dist_random('pg_class')
+	WHERE relname='index_build_reltuples_@amname@' ORDER BY gp_segment_id;
+SELECT gp_segment_id, reltuples FROM gp_dist_random('pg_class')
+	WHERE relname='index_build_reltuples_@amname@_a_idx' ORDER BY gp_segment_id;
+
+DROP TABLE index_build_reltuples_@amname@;
+
+-- Case 2: Verify that CREATE INDEX is able to update the aorel's reltuples
+-- to equal the actual segment tuple counts, when there are deleted tuples. For
+-- the index, since we don't have a notion of "recently dead" vs surely dead,
+-- we are conservative and form index entries even for deleted tuples. Thus, the
+-- reltuples count for the index would also account for deleted tuples.
+
+CREATE TABLE index_build_reltuples_@amname@(a int);
+INSERT INTO index_build_reltuples_@amname@ SELECT generate_series(1, 20);
+
+SELECT gp_segment_id, count(*) FROM index_build_reltuples_@amname@
+	GROUP BY gp_segment_id ORDER BY gp_segment_id;
+
+DELETE FROM index_build_reltuples_@amname@ WHERE a <= 10;
+
+CREATE INDEX ON index_build_reltuples_@amname@(a);
+
+SELECT gp_segment_id, count(*) FROM index_build_reltuples_@amname@
+	GROUP BY gp_segment_id ORDER BY gp_segment_id;
+SELECT gp_segment_id, reltuples FROM gp_dist_random('pg_class')
+	WHERE relname='index_build_reltuples_@amname@' ORDER BY gp_segment_id;
+SELECT gp_segment_id, reltuples FROM gp_dist_random('pg_class')
+	WHERE relname='index_build_reltuples_@amname@_a_idx' ORDER BY gp_segment_id;
+
+DROP TABLE index_build_reltuples_@amname@;
+
+-- Case 3: Verify that CREATE INDEX is able to update both the aorel's reltuples
+-- and the index's reltuples, to equal the actual segment tuple counts, when
+-- there are aborted tuples.
+
+CREATE TABLE index_build_reltuples_@amname@(a int);
+
+INSERT INTO index_build_reltuples_@amname@ SELECT generate_series(1, 10);
+
+SELECT gp_segment_id, count(*) FROM index_build_reltuples_@amname@
+	GROUP BY gp_segment_id ORDER BY gp_segment_id;
+
+BEGIN;
+INSERT INTO index_build_reltuples_@amname@ SELECT generate_series(11, 20);
+ABORT;
+
+CREATE INDEX ON index_build_reltuples_@amname@(a);
+
+SELECT gp_segment_id, count(*) FROM index_build_reltuples_@amname@
+	GROUP BY gp_segment_id ORDER BY gp_segment_id;
+SELECT gp_segment_id, reltuples FROM gp_dist_random('pg_class')
+	WHERE relname='index_build_reltuples_@amname@' ORDER BY gp_segment_id;
+SELECT gp_segment_id, reltuples FROM gp_dist_random('pg_class')
+	WHERE relname='index_build_reltuples_@amname@_a_idx' ORDER BY gp_segment_id;
+
+DROP TABLE index_build_reltuples_@amname@;
+
+-- Case 4: Verify that CREATE INDEX is able to update both the aorel's reltuples
+-- and the index's reltuples, to equal the latest segment tuple counts, even
+-- when it is executed in a transaction with a snapshot that precedes the INSERT
+-- (highlights the need for using SnapshotAny)
+
+CREATE TABLE index_build_reltuples_@amname@(a int);
+
+1: BEGIN ISOLATION LEVEL REPEATABLE READ;
+1: SELECT gp_segment_id, count(*) FROM index_build_reltuples_@amname@
+    GROUP BY gp_segment_id ORDER BY gp_segment_id;
+
+INSERT INTO index_build_reltuples_@amname@ SELECT generate_series(1, 10);
+
+1: CREATE INDEX ON index_build_reltuples_@amname@(a);
+1: COMMIT;
+
+SELECT gp_segment_id, count(*) FROM index_build_reltuples_@amname@
+    GROUP BY gp_segment_id ORDER BY gp_segment_id;
+SELECT gp_segment_id, reltuples FROM gp_dist_random('pg_class')
+    WHERE relname='index_build_reltuples_@amname@' ORDER BY gp_segment_id;
+SELECT gp_segment_id, reltuples FROM gp_dist_random('pg_class')
+    WHERE relname='index_build_reltuples_@amname@_a_idx' ORDER BY gp_segment_id;
+
+DROP TABLE index_build_reltuples_@amname@;
+
+RESET default_table_access_method;

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -119,6 +119,7 @@ test: uao/cursor_before_update_row
 test: uao/cursor_withhold_row
 test: uao/cursor_withhold2_row
 test: uao/delete_while_vacuum_row
+test: uao/index_build_reltuples_row
 test: uao/insert_policy_row
 test: uao/insert_while_vacuum_row
 test: uao/max_concurrency_row
@@ -173,6 +174,7 @@ test: uao/cursor_before_update_column
 test: uao/cursor_withhold_column
 test: uao/cursor_withhold2_column
 test: uao/delete_while_vacuum_column
+test: uao/index_build_reltuples_column
 test: uao/insert_policy_column
 test: uao/insert_while_vacuum_column
 test: uao/max_concurrency_column

--- a/src/test/isolation2/output/uao/index_build_reltuples.source
+++ b/src/test/isolation2/output/uao/index_build_reltuples.source
@@ -1,0 +1,197 @@
+-- Coverage to ensure that reltuples is updated correctly upon an index build
+-- (i.e. CREATE INDEX) on AO/CO tables.
+-- FIXME: Currently doesn't assert reltuples on QD (at the moment, we don't
+-- aggregate the reltuples counts on QD at end of command)
+
+SET default_table_access_method TO @amname@;
+SET
+
+-- Case 1: Verify that CREATE INDEX is able to update both the aorel's reltuples
+-- and the index's reltuples, to equal the actual segment tuple counts.
+
+CREATE TABLE index_build_reltuples_@amname@(a int);
+CREATE
+INSERT INTO index_build_reltuples_@amname@ SELECT generate_series(1, 10);
+INSERT 10
+
+CREATE INDEX ON index_build_reltuples_@amname@(a);
+CREATE
+
+SELECT gp_segment_id, count(*) FROM index_build_reltuples_@amname@ GROUP BY gp_segment_id ORDER BY gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+ 0             | 5     
+ 1             | 1     
+ 2             | 4     
+(3 rows)
+SELECT gp_segment_id, reltuples FROM gp_dist_random('pg_class') WHERE relname='index_build_reltuples_@amname@' ORDER BY gp_segment_id;
+ gp_segment_id | reltuples 
+---------------+-----------
+ 0             | 5         
+ 1             | 1         
+ 2             | 4         
+(3 rows)
+SELECT gp_segment_id, reltuples FROM gp_dist_random('pg_class') WHERE relname='index_build_reltuples_@amname@_a_idx' ORDER BY gp_segment_id;
+ gp_segment_id | reltuples 
+---------------+-----------
+ 0             | 5         
+ 1             | 1         
+ 2             | 4         
+(3 rows)
+
+DROP TABLE index_build_reltuples_@amname@;
+DROP
+
+-- Case 2: Verify that CREATE INDEX is able to update the aorel's reltuples
+-- to equal the actual segment tuple counts, when there are deleted tuples. For
+-- the index, since we don't have a notion of "recently dead" vs surely dead,
+-- we are conservative and form index entries even for deleted tuples. Thus, the
+-- reltuples count for the index would also account for deleted tuples.
+
+CREATE TABLE index_build_reltuples_@amname@(a int);
+CREATE
+INSERT INTO index_build_reltuples_@amname@ SELECT generate_series(1, 20);
+INSERT 20
+
+SELECT gp_segment_id, count(*) FROM index_build_reltuples_@amname@ GROUP BY gp_segment_id ORDER BY gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+ 0             | 8     
+ 1             | 4     
+ 2             | 8     
+(3 rows)
+
+DELETE FROM index_build_reltuples_@amname@ WHERE a <= 10;
+DELETE 10
+
+CREATE INDEX ON index_build_reltuples_@amname@(a);
+CREATE
+
+SELECT gp_segment_id, count(*) FROM index_build_reltuples_@amname@ GROUP BY gp_segment_id ORDER BY gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+ 0             | 3     
+ 1             | 3     
+ 2             | 4     
+(3 rows)
+SELECT gp_segment_id, reltuples FROM gp_dist_random('pg_class') WHERE relname='index_build_reltuples_@amname@' ORDER BY gp_segment_id;
+ gp_segment_id | reltuples 
+---------------+-----------
+ 0             | 3         
+ 1             | 3         
+ 2             | 4         
+(3 rows)
+SELECT gp_segment_id, reltuples FROM gp_dist_random('pg_class') WHERE relname='index_build_reltuples_@amname@_a_idx' ORDER BY gp_segment_id;
+ gp_segment_id | reltuples 
+---------------+-----------
+ 0             | 8         
+ 1             | 4         
+ 2             | 8         
+(3 rows)
+
+DROP TABLE index_build_reltuples_@amname@;
+DROP
+
+-- Case 3: Verify that CREATE INDEX is able to update both the aorel's reltuples
+-- and the index's reltuples, to equal the actual segment tuple counts, when
+-- there are aborted tuples.
+
+CREATE TABLE index_build_reltuples_@amname@(a int);
+CREATE
+
+INSERT INTO index_build_reltuples_@amname@ SELECT generate_series(1, 10);
+INSERT 10
+
+SELECT gp_segment_id, count(*) FROM index_build_reltuples_@amname@ GROUP BY gp_segment_id ORDER BY gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+ 0             | 5     
+ 1             | 1     
+ 2             | 4     
+(3 rows)
+
+BEGIN;
+BEGIN
+INSERT INTO index_build_reltuples_@amname@ SELECT generate_series(11, 20);
+INSERT 10
+ABORT;
+ABORT
+
+CREATE INDEX ON index_build_reltuples_@amname@(a);
+CREATE
+
+SELECT gp_segment_id, count(*) FROM index_build_reltuples_@amname@ GROUP BY gp_segment_id ORDER BY gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+ 0             | 5     
+ 1             | 1     
+ 2             | 4     
+(3 rows)
+SELECT gp_segment_id, reltuples FROM gp_dist_random('pg_class') WHERE relname='index_build_reltuples_@amname@' ORDER BY gp_segment_id;
+ gp_segment_id | reltuples 
+---------------+-----------
+ 0             | 5         
+ 1             | 1         
+ 2             | 4         
+(3 rows)
+SELECT gp_segment_id, reltuples FROM gp_dist_random('pg_class') WHERE relname='index_build_reltuples_@amname@_a_idx' ORDER BY gp_segment_id;
+ gp_segment_id | reltuples 
+---------------+-----------
+ 0             | 5         
+ 1             | 1         
+ 2             | 4         
+(3 rows)
+
+DROP TABLE index_build_reltuples_@amname@;
+DROP
+
+-- Case 4: Verify that CREATE INDEX is able to update both the aorel's reltuples
+-- and the index's reltuples, to equal the latest segment tuple counts, even
+-- when it is executed in a transaction with a snapshot that precedes the INSERT
+-- (highlights the need for using SnapshotAny)
+
+CREATE TABLE index_build_reltuples_@amname@(a int);
+CREATE
+
+1: BEGIN ISOLATION LEVEL REPEATABLE READ;
+BEGIN
+1: SELECT gp_segment_id, count(*) FROM index_build_reltuples_@amname@ GROUP BY gp_segment_id ORDER BY gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+(0 rows)
+
+INSERT INTO index_build_reltuples_@amname@ SELECT generate_series(1, 10);
+INSERT 10
+
+1: CREATE INDEX ON index_build_reltuples_@amname@(a);
+CREATE
+1: COMMIT;
+COMMIT
+
+SELECT gp_segment_id, count(*) FROM index_build_reltuples_@amname@ GROUP BY gp_segment_id ORDER BY gp_segment_id;
+ gp_segment_id | count 
+---------------+-------
+ 0             | 5     
+ 1             | 1     
+ 2             | 4     
+(3 rows)
+SELECT gp_segment_id, reltuples FROM gp_dist_random('pg_class') WHERE relname='index_build_reltuples_@amname@' ORDER BY gp_segment_id;
+ gp_segment_id | reltuples 
+---------------+-----------
+ 0             | 5         
+ 1             | 1         
+ 2             | 4         
+(3 rows)
+SELECT gp_segment_id, reltuples FROM gp_dist_random('pg_class') WHERE relname='index_build_reltuples_@amname@_a_idx' ORDER BY gp_segment_id;
+ gp_segment_id | reltuples 
+---------------+-----------
+ 0             | 5         
+ 1             | 1         
+ 2             | 4         
+(3 rows)
+
+DROP TABLE index_build_reltuples_@amname@;
+DROP
+
+RESET default_table_access_method;
+RESET

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -316,4 +316,7 @@ test: dboptions
 # DML tests for AO/CO unique indexes.
 test: uao_dml/uao_dml_unique_index_delete_row uao_dml/uao_dml_unique_index_delete_column uao_dml/uao_dml_unique_index_update_row uao_dml/uao_dml_unique_index_update_column
 
+# test CREATE UNIQUE INDEX on AO/CO tables.
+test: uao_dml/ao_unique_index_build_row uao_dml/ao_unique_index_build_column
+
 # end of tests

--- a/src/test/regress/input/uao_dml/ao_unique_index_build.source
+++ b/src/test/regress/input/uao_dml/ao_unique_index_build.source
@@ -1,0 +1,62 @@
+-- Test cases to cover CREATE UNIQUE INDEX on AO/CO tables.
+
+SET gp_appendonly_enable_unique_index TO ON;
+SET default_table_access_method TO @amname@;
+-- To force index scans for smoke tests
+SET enable_seqscan TO off;
+SET optimizer TO off;
+
+-- Case 1: Build with no conflicting rows.
+CREATE TABLE unique_index_build_@amname@(i int) DISTRIBUTED REPLICATED;
+INSERT INTO unique_index_build_@amname@ VALUES(1);
+-- should succeed
+CREATE UNIQUE INDEX on unique_index_build_@amname@(i);
+-- post-build smoke test
+EXPLAIN SELECT * FROM unique_index_build_@amname@ WHERE i = 1;
+SELECT * FROM unique_index_build_@amname@ WHERE i = 1;
+INSERT INTO unique_index_build_@amname@ VALUES(1);
+
+DROP TABLE unique_index_build_@amname@;
+
+-- Case 2: Build with conflicting row.
+CREATE TABLE unique_index_build_@amname@(i int) DISTRIBUTED REPLICATED;
+INSERT INTO unique_index_build_@amname@ VALUES(1);
+INSERT INTO unique_index_build_@amname@ VALUES(1);
+-- should ERROR out
+CREATE UNIQUE INDEX on unique_index_build_@amname@(i);
+
+DROP TABLE unique_index_build_@amname@;
+
+-- Case 3: Build with conflict on aborted row.
+CREATE TABLE unique_index_build_@amname@(i int) DISTRIBUTED REPLICATED;
+BEGIN;
+INSERT INTO unique_index_build_@amname@ VALUES(1);
+ABORT;
+INSERT INTO unique_index_build_@amname@ VALUES(1);
+-- should succeed
+CREATE UNIQUE INDEX on unique_index_build_@amname@(i);
+-- post-build smoke test
+EXPLAIN SELECT * FROM unique_index_build_@amname@ WHERE i = 1;
+SELECT * FROM unique_index_build_@amname@ WHERE i = 1;
+INSERT INTO unique_index_build_@amname@ VALUES(1);
+
+DROP TABLE unique_index_build_@amname@;
+
+-- Case 4: Build with conflict on deleted row.
+CREATE TABLE unique_index_build_@amname@(i int) DISTRIBUTED REPLICATED;
+INSERT INTO unique_index_build_@amname@ VALUES(1);
+DELETE FROM unique_index_build_@amname@;
+INSERT INTO unique_index_build_@amname@ VALUES(1);
+-- should succeed
+CREATE UNIQUE INDEX on unique_index_build_@amname@(i);
+-- post-build smoke test
+EXPLAIN SELECT * FROM unique_index_build_@amname@ WHERE i = 1;
+SELECT * FROM unique_index_build_@amname@ WHERE i = 1;
+INSERT INTO unique_index_build_@amname@ VALUES(1);
+
+DROP TABLE unique_index_build_@amname@;
+
+RESET gp_appendonly_enable_unique_index;
+RESET default_table_access_method;
+RESET enable_seqscan;
+RESET optimizer;

--- a/src/test/regress/output/uao_dml/ao_unique_index_build.source
+++ b/src/test/regress/output/uao_dml/ao_unique_index_build.source
@@ -1,0 +1,105 @@
+-- Test cases to cover CREATE UNIQUE INDEX on AO/CO tables.
+SET gp_appendonly_enable_unique_index TO ON;
+SET default_table_access_method TO @amname@;
+-- To force index scans for smoke tests
+SET enable_seqscan TO off;
+SET optimizer TO off;
+-- Case 1: Build with no conflicting rows.
+CREATE TABLE unique_index_build_@amname@(i int) DISTRIBUTED REPLICATED;
+INSERT INTO unique_index_build_@amname@ VALUES(1);
+-- should succeed
+CREATE UNIQUE INDEX on unique_index_build_@amname@(i);
+-- post-build smoke test
+EXPLAIN SELECT * FROM unique_index_build_@amname@ WHERE i = 1;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=8.19..8.19 rows=1 width=4)
+   ->  Bitmap Heap Scan on unique_index_build_@amname@  (cost=4.18..8.19 rows=1 width=4)
+         Recheck Cond: (i = 1)
+         ->  Bitmap Index Scan on unique_index_build_@amname@_i_idx  (cost=0.00..4.18 rows=1 width=0)
+               Index Cond: (i = 1)
+ Optimizer: Postgres query optimizer
+(6 rows)
+
+SELECT * FROM unique_index_build_@amname@ WHERE i = 1;
+ i 
+---
+ 1
+(1 row)
+
+INSERT INTO unique_index_build_@amname@ VALUES(1);
+ERROR:  duplicate key value violates unique constraint "unique_index_build_@amname@_i_idx"  (seg0 192.168.0.148:7002 pid=1421591)
+DETAIL:  Key (i)=(1) already exists.
+DROP TABLE unique_index_build_@amname@;
+-- Case 2: Build with conflicting row.
+CREATE TABLE unique_index_build_@amname@(i int) DISTRIBUTED REPLICATED;
+INSERT INTO unique_index_build_@amname@ VALUES(1);
+INSERT INTO unique_index_build_@amname@ VALUES(1);
+-- should ERROR out
+CREATE UNIQUE INDEX on unique_index_build_@amname@(i);
+ERROR:  could not create unique index "unique_index_build_@amname@_i_idx"  (seg0 192.168.0.148:7002 pid=1421591)
+DETAIL:  Key (i)=(1) is duplicated.
+DROP TABLE unique_index_build_@amname@;
+-- Case 3: Build with conflict on aborted row.
+CREATE TABLE unique_index_build_@amname@(i int) DISTRIBUTED REPLICATED;
+BEGIN;
+INSERT INTO unique_index_build_@amname@ VALUES(1);
+ABORT;
+INSERT INTO unique_index_build_@amname@ VALUES(1);
+-- should succeed
+CREATE UNIQUE INDEX on unique_index_build_@amname@(i);
+-- post-build smoke test
+EXPLAIN SELECT * FROM unique_index_build_@amname@ WHERE i = 1;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=8.19..8.19 rows=1 width=4)
+   ->  Bitmap Heap Scan on unique_index_build_@amname@  (cost=4.18..8.19 rows=1 width=4)
+         Recheck Cond: (i = 1)
+         ->  Bitmap Index Scan on unique_index_build_@amname@_i_idx  (cost=0.00..4.18 rows=1 width=0)
+               Index Cond: (i = 1)
+ Optimizer: Postgres query optimizer
+(6 rows)
+
+SELECT * FROM unique_index_build_@amname@ WHERE i = 1;
+ i 
+---
+ 1
+(1 row)
+
+INSERT INTO unique_index_build_@amname@ VALUES(1);
+ERROR:  duplicate key value violates unique constraint "unique_index_build_@amname@_i_idx"  (seg0 192.168.0.148:7002 pid=1421591)
+DETAIL:  Key (i)=(1) already exists.
+DROP TABLE unique_index_build_@amname@;
+-- Case 4: Build with conflict on deleted row.
+CREATE TABLE unique_index_build_@amname@(i int) DISTRIBUTED REPLICATED;
+INSERT INTO unique_index_build_@amname@ VALUES(1);
+DELETE FROM unique_index_build_@amname@;
+INSERT INTO unique_index_build_@amname@ VALUES(1);
+-- should succeed
+CREATE UNIQUE INDEX on unique_index_build_@amname@(i);
+-- post-build smoke test
+EXPLAIN SELECT * FROM unique_index_build_@amname@ WHERE i = 1;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=8.19..8.19 rows=1 width=4)
+   ->  Bitmap Heap Scan on unique_index_build_@amname@  (cost=4.18..8.19 rows=1 width=4)
+         Recheck Cond: (i = 1)
+         ->  Bitmap Index Scan on unique_index_build_@amname@_i_idx  (cost=0.00..4.18 rows=1 width=0)
+               Index Cond: (i = 1)
+ Optimizer: Postgres query optimizer
+(6 rows)
+
+SELECT * FROM unique_index_build_@amname@ WHERE i = 1;
+ i 
+---
+ 1
+(1 row)
+
+INSERT INTO unique_index_build_@amname@ VALUES(1);
+ERROR:  duplicate key value violates unique constraint "unique_index_build_@amname@_i_idx"  (seg0 192.168.0.148:7002 pid=1421591)
+DETAIL:  Key (i)=(1) already exists.
+DROP TABLE unique_index_build_@amname@;
+RESET gp_appendonly_enable_unique_index;
+RESET default_table_access_method;
+RESET enable_seqscan;
+RESET optimizer;


### PR DESCRIPTION
This is a follow-up to the discussion:
https://github.com/greenplum-db/gpdb/pull/13526#discussion_r1002037396

It consists of 2 commits:
1. Pre-factor commit to only use SnapshotAny (alternatives are dead code really)
2. Address the visibility check FIXME for AO/CO index build scans, which fixes buggy CREATE UNIQUE INDEX behavior.