### PR TITLE
ao/co: Refactor blkdir/visimap access for unique checks

### DIFF
--- a/src/backend/access/aocs/aocsam_handler.c
+++ b/src/backend/access/aocs/aocsam_handler.c
@@ -290,7 +290,7 @@ aoco_dml_finish(Relation relation)
 	if (state->uniqueCheckDesc)
 	{
 		/* clean up the block directory */
-		AppendOnlyBlockDirectory_End_forSearch(state->uniqueCheckDesc->blockDirectory);
+		AppendOnlyBlockDirectory_End_forUniqueChecks(state->uniqueCheckDesc->blockDirectory);
 		pfree(state->uniqueCheckDesc->blockDirectory);
 		state->uniqueCheckDesc->blockDirectory = NULL;
 
@@ -301,7 +301,7 @@ aoco_dml_finish(Relation relation)
 		 */
 		if (!had_delete_desc)
 		{
-			AppendOnlyVisimap_Finish(state->uniqueCheckDesc->visimap, AccessShareLock);
+			AppendOnlyVisimap_Finish_forUniquenessChecks(state->uniqueCheckDesc->visimap);
 			pfree(state->uniqueCheckDesc->visimap);
 		}
 		state->uniqueCheckDesc->visimap = NULL;
@@ -401,7 +401,7 @@ get_or_create_delete_descriptor(const Relation relation, bool forUpdate)
 }
 
 static AOCSUniqueCheckDesc
-get_or_create_unique_check_desc(Relation relation)
+get_or_create_unique_check_desc(Relation relation, Snapshot snapshot)
 {
 	AOCODMLState *state = find_dml_state(RelationGetRelid(relation));
 
@@ -409,25 +409,16 @@ get_or_create_unique_check_desc(Relation relation)
 	{
 		MemoryContext oldcxt;
 		AOCSUniqueCheckDesc uniqueCheckDesc;
-		Oid visimaprelid;
-		Oid visimapidxid;
 
 		oldcxt = MemoryContextSwitchTo(aocoDMLStates.stateCxt);
 		uniqueCheckDesc = palloc0(sizeof(AOCSUniqueCheckDescData));
 
 		/* Initialize the block directory */
 		uniqueCheckDesc->blockDirectory = palloc0(sizeof(AppendOnlyBlockDirectory));
-		/*
-		 * Note: we defer setting up the appendOnlyMetaDataSnapshot for the
-		 * block directory to aoco_index_fetch_tuple_exists(). This is because
-		 * snapshots used for unique index lookups may be stack-allocated and a
-		 * new snapshot object may be passed to every unique index check. (for
-		 * SNAPSHOT_DIRTY)
-		 */
-		AppendOnlyBlockDirectory_Init_forSearch(uniqueCheckDesc->blockDirectory,
-												InvalidSnapshot, /* appendOnlyMetaDataSnapshot */
-												NULL, -1, relation,
-												relation->rd_att->natts, false, NULL);
+		AppendOnlyBlockDirectory_Init_forUniqueChecks(uniqueCheckDesc->blockDirectory,
+													  relation,
+													  relation->rd_att->natts, /* numColGroups */
+													  snapshot);
 		/*
 		 * If this is part of an update, we need to reuse the visimap used by
 		 * the delete half of the update. This is to avoid spurious conflicts
@@ -441,22 +432,9 @@ get_or_create_unique_check_desc(Relation relation)
 		{
 			/* Initialize the visimap */
 			uniqueCheckDesc->visimap = palloc0(sizeof(AppendOnlyVisimap));
-			GetAppendOnlyEntryAuxOids(relation->rd_id,
-									  InvalidSnapshot, /* catalog snap is fine for this */
-									  NULL, NULL, NULL,
-									  &visimaprelid, &visimapidxid);
-			/*
-			 * Note: we don't set up the appendOnlyMetadataSnapshot for the
-			 * visimap here. It is deferred to aoco_index_fetch_tuple_exists().
-			 * This is because snapshots used for unique index lookups may be
-			 * stack-allocated and a new snapshot object may be used for every
-			 * unique index check. (for SNAPSHOT_DIRTY)
-			 */
-			AppendOnlyVisimap_Init(uniqueCheckDesc->visimap,
-								   visimaprelid,
-								   visimapidxid,
-								   AccessShareLock,
-								   InvalidSnapshot /* appendOnlyMetaDataSnapshot */);
+			AppendOnlyVisimap_Init_forUniqueCheck(uniqueCheckDesc->visimap,
+												  relation,
+												  snapshot);
 		}
 
 		state->uniqueCheckDesc = uniqueCheckDesc;
@@ -856,11 +834,7 @@ aoco_index_fetch_tuple_exists(Relation rel,
 {
 	AOCSUniqueCheckDesc 		uniqueCheckDesc;
 	AOTupleId 					*aoTupleId = (AOTupleId *) tid;
-	AppendOnlyBlockDirectory 	*blockDirectory;
-	AppendOnlyVisimap 			*visimap;
-	bool						blkdir_covers;
 	bool						visible;
-	Snapshot 					save_snapshot;
 
 #ifdef USE_ASSERT_CHECKING
 	int			segmentFileNum = AOTupleIdGet_segmentFileNum(aoTupleId);
@@ -899,23 +873,12 @@ aoco_index_fetch_tuple_exists(Relation rel,
 	if (snapshot->snapshot_type == SNAPSHOT_SELF)
 		return true;
 
-	uniqueCheckDesc = get_or_create_unique_check_desc(rel);
+	uniqueCheckDesc = get_or_create_unique_check_desc(rel, snapshot);
 
-	/*
-	 * Check to see if there is a block directory entry for the tuple. If no
-	 * such entry exists, the tuple doesn't exist physically in the segfile.
-	 *
-	 * Note: We need to use the passed in snapshot to perform the block
-	 * directory lookup. See get_or_create_unique_check_desc() for why we don't
-	 * set the snapshot up prior.
-	 */
-	blockDirectory = uniqueCheckDesc->blockDirectory;
-	Assert(blockDirectory->appendOnlyMetaDataSnapshot == InvalidSnapshot);
-	blockDirectory->appendOnlyMetaDataSnapshot = snapshot;
-	blkdir_covers = AppendOnlyBlockDirectory_CoversTuple(blockDirectory,
-														 aoTupleId);
-	blockDirectory->appendOnlyMetaDataSnapshot = InvalidSnapshot;
-	if (!blkdir_covers)
+	/* First, scan the block directory */
+	if (!AppendOnlyBlockDirectory_UniqueCheck(uniqueCheckDesc->blockDirectory,
+											  aoTupleId,
+											  snapshot))
 		return false;
 
 	/*
@@ -924,24 +887,14 @@ aoco_index_fetch_tuple_exists(Relation rel,
 	 * concurrent in-progress transaction inserting the tuple. So, return true
 	 * and have the xwait machinery kick in.
 	 */
+	Assert(snapshot->snapshot_type == SNAPSHOT_DIRTY);
 	if (TransactionIdIsValid(snapshot->xmin) || TransactionIdIsValid(snapshot->xmax))
 		return true;
 
-	/*
-	 * Consult the visimap to check if the tuple was deleted by a *committed*
-	 * transaction.
-	 *
-	 * Note: we need to use the passed in snapshot to perform the visimap lookup.
-	 * See get_or_create_unique_check_desc() for why we don't set the snapshot
-	 * up prior there.
-	 * If this is part of an update, we are reusing the visimap from the delete
-	 * half of the update, so better restore its snapshot once we are done.
-	 */
-	visimap = uniqueCheckDesc->visimap;
-	save_snapshot = visimap->visimapStore.snapshot;
-	visimap->visimapStore.snapshot = snapshot;
-	visible = AppendOnlyVisimap_IsVisible(visimap, aoTupleId);
-	visimap->visimapStore.snapshot = save_snapshot;
+	/* Now, consult the visimap */
+	visible = AppendOnlyVisimap_UniqueCheck(uniqueCheckDesc->visimap,
+											aoTupleId,
+											snapshot);
 
 	/*
 	 * Since we disallow deletes and updates running in parallel with inserts,

--- a/src/backend/access/appendonly/appendonly_visimap.c
+++ b/src/backend/access/appendonly/appendonly_visimap.c
@@ -875,3 +875,58 @@ AppendOnlyVisimapDelete_Finish(
 	hash_destroy(visiMapDelete->dirtyEntryCache);
 	BufFileClose(visiMapDelete->workfile);
 }
+
+/*
+ * AppendOnlyVisimap_Init_forUniqueCheck
+ *
+ * Initializes the visimap to determine if tuples were deleted as a part of
+ * uniqueness checks.
+ *
+ * Note: we defer setting up the appendOnlyMetaDataSnapshot for the visibility
+ * map to the index_fetch_tuple_exists() table AM call. This is because
+ * snapshots used for unique index lookups are special and don't follow the
+ * usual allocation or registration mechanism. They may be stack-allocated and a
+ * new snapshot object may be passed to every unique index check (this happens
+ * when SNAPSHOT_DIRTY is passed). While technically, we could set up the
+ * metadata snapshot in advance for SNAPSHOT_SELF, the alternative is fine.
+ */
+void AppendOnlyVisimap_Init_forUniqueCheck(
+	AppendOnlyVisimap *visiMap,
+	Relation aoRel,
+	Snapshot snapshot)
+{
+	Oid visimaprelid;
+	Oid visimapidxid;
+
+	Assert(snapshot->snapshot_type == SNAPSHOT_DIRTY ||
+			   snapshot->snapshot_type == SNAPSHOT_SELF);
+
+	GetAppendOnlyEntryAuxOids(aoRel->rd_id,
+							  InvalidSnapshot, /* catalog snapshot is enough */
+							  NULL, NULL, NULL, &visimaprelid, &visimapidxid);
+	if (!OidIsValid(visimaprelid) || !OidIsValid(visimapidxid))
+		elog(ERROR, "Could not find block directory for relation: %u", aoRel->rd_id);
+
+	AppendOnlyVisimap_Init(visiMap,
+						   visimaprelid,
+						   visimapidxid,
+						   AccessShareLock,
+						   InvalidSnapshot /* appendOnlyMetaDataSnapshot */);
+}
+
+void
+AppendOnlyVisimap_Finish_forUniquenessChecks(
+	AppendOnlyVisimap *visiMap)
+{
+	/*
+	 * The snapshot was either reset to NULL in between calls or already cleaned
+	 * up (if this was part of an update command)
+	 */
+	Assert(visiMap->visimapStore.snapshot == InvalidSnapshot);
+
+	AppendOnlyVisimapStore_Finish(&visiMap->visimapStore, AccessShareLock);
+	AppendOnlyVisimapEntry_Finish(&visiMap->visimapEntry);
+
+	MemoryContextDelete(visiMap->memoryContext);
+	visiMap->memoryContext = NULL;
+}

--- a/src/backend/access/appendonly/appendonlyam_handler.c
+++ b/src/backend/access/appendonly/appendonlyam_handler.c
@@ -251,7 +251,7 @@ appendonly_dml_finish(Relation relation)
 	if (state->uniqueCheckDesc)
 	{
 		/* clean up the block directory */
-		AppendOnlyBlockDirectory_End_forSearch(state->uniqueCheckDesc->blockDirectory);
+		AppendOnlyBlockDirectory_End_forUniqueChecks(state->uniqueCheckDesc->blockDirectory);
 		pfree(state->uniqueCheckDesc->blockDirectory);
 		state->uniqueCheckDesc->blockDirectory = NULL;
 
@@ -262,7 +262,7 @@ appendonly_dml_finish(Relation relation)
 		 */
 		if (!had_delete_desc)
 		{
-			AppendOnlyVisimap_Finish(state->uniqueCheckDesc->visimap, AccessShareLock);
+			AppendOnlyVisimap_Finish_forUniquenessChecks(state->uniqueCheckDesc->visimap);
 			pfree(state->uniqueCheckDesc->visimap);
 		}
 		state->uniqueCheckDesc->visimap = NULL;
@@ -354,7 +354,7 @@ get_or_create_delete_descriptor(const Relation relation, bool forUpdate)
 }
 
 static AppendOnlyUniqueCheckDesc
-get_or_create_unique_check_desc(Relation relation)
+get_or_create_unique_check_desc(Relation relation, Snapshot snapshot)
 {
 	AppendOnlyDMLState *state = find_dml_state(RelationGetRelid(relation));
 
@@ -362,25 +362,16 @@ get_or_create_unique_check_desc(Relation relation)
 	{
 		MemoryContext oldcxt;
 		AppendOnlyUniqueCheckDesc uniqueCheckDesc;
-		Oid visimaprelid;
-		Oid visimapidxid;
 
 		oldcxt = MemoryContextSwitchTo(appendOnlyDMLStates.stateCxt);
 		uniqueCheckDesc = palloc0(sizeof(AppendOnlyUniqueCheckDescData));
 
 		/* Initialize the block directory */
 		uniqueCheckDesc->blockDirectory = palloc0(sizeof(AppendOnlyBlockDirectory));
-		/*
-		 * Note: we defer setting up the appendOnlyMetaDataSnapshot for the
-		 * block directory to appendonly_index_fetch_tuple_exists(). This is
-		 * because snapshots used for unique index lookups may be stack-allocated
-		 * and a new snapshot object may be passed to every unique index check.
-		 * (for SNAPSHOT_DIRTY)
-		 */
-		AppendOnlyBlockDirectory_Init_forSearch(uniqueCheckDesc->blockDirectory,
-												InvalidSnapshot, /* appendOnlyMetaDataSnapshot */
-												NULL, -1, relation,
-												1, false, NULL);
+		AppendOnlyBlockDirectory_Init_forUniqueChecks(uniqueCheckDesc->blockDirectory,
+													  relation,
+													  1, /* numColGroups */
+													  snapshot);
 
 		/*
 		 * If this is part of an update, we need to reuse the visimap used by
@@ -395,22 +386,9 @@ get_or_create_unique_check_desc(Relation relation)
 		{
 			/* Initialize the visimap */
 			uniqueCheckDesc->visimap = palloc0(sizeof(AppendOnlyVisimap));
-			GetAppendOnlyEntryAuxOids(relation->rd_id,
-									  InvalidSnapshot, /* catalog snap is fine for this */
-									  NULL, NULL, NULL,
-									  &visimaprelid, &visimapidxid);
-			/*
-			 * Note: we don't set up the appendOnlyMetadataSnapshot for the
-			 * visimap here. It is deferred to appendonly_index_fetch_tuple_exists().
-			 * This is because snapshots used for unique index lookups may be
-			 * stack-allocated and a new snapshot object may be used for every
-			 * unique index check. (for SNAPSHOT_DIRTY)
-			 */
-			AppendOnlyVisimap_Init(uniqueCheckDesc->visimap,
-								   visimaprelid,
-								   visimapidxid,
-								   AccessShareLock,
-								   InvalidSnapshot /* appendOnlyMetaDataSnapshot */);
+			AppendOnlyVisimap_Init_forUniqueCheck(uniqueCheckDesc->visimap,
+												  relation,
+												  snapshot);
 		}
 
 		state->uniqueCheckDesc = uniqueCheckDesc;
@@ -623,11 +601,7 @@ appendonly_index_fetch_tuple_exists(Relation rel,
 {
 	AppendOnlyUniqueCheckDesc 	uniqueCheckDesc;
 	AOTupleId 					*aoTupleId = (AOTupleId *) tid;
-	AppendOnlyBlockDirectory 	*blockDirectory;
-	AppendOnlyVisimap 			*visimap;
-	bool						blkdir_covers;
 	bool						visible;
-	Snapshot 					save_snapshot;
 
 #ifdef USE_ASSERT_CHECKING
 	int			segmentFileNum = AOTupleIdGet_segmentFileNum(aoTupleId);
@@ -666,23 +640,12 @@ appendonly_index_fetch_tuple_exists(Relation rel,
 	if (snapshot->snapshot_type == SNAPSHOT_SELF)
 		return true;
 
-	uniqueCheckDesc = get_or_create_unique_check_desc(rel);
+	uniqueCheckDesc = get_or_create_unique_check_desc(rel, snapshot);
 
-	/*
-	 * Check to see if there is a block directory entry for the tuple. If no
-	 * such entry exists, the tuple doesn't exist physically in the segfile.
-	 *
-	 * Note: We need to use the passed in snapshot to perform the block
-	 * directory lookup. See get_or_create_unique_check_desc() for why we don't
-	 * set the snapshot up prior.
-	 */
-	blockDirectory = uniqueCheckDesc->blockDirectory;
-	Assert(blockDirectory->appendOnlyMetaDataSnapshot == InvalidSnapshot);
-	blockDirectory->appendOnlyMetaDataSnapshot = snapshot;
-	blkdir_covers = AppendOnlyBlockDirectory_CoversTuple(blockDirectory,
-														 aoTupleId);
-	blockDirectory->appendOnlyMetaDataSnapshot = InvalidSnapshot;
-	if (!blkdir_covers)
+	/* First, scan the block directory */
+	if (!AppendOnlyBlockDirectory_UniqueCheck(uniqueCheckDesc->blockDirectory,
+											  aoTupleId,
+											  snapshot))
 		return false;
 
 	/*
@@ -691,24 +654,14 @@ appendonly_index_fetch_tuple_exists(Relation rel,
 	 * concurrent in-progress transaction inserting the tuple. So, return true
 	 * and have the xwait machinery kick in.
 	 */
+	Assert(snapshot->snapshot_type == SNAPSHOT_DIRTY);
 	if (TransactionIdIsValid(snapshot->xmin) || TransactionIdIsValid(snapshot->xmax))
 		return true;
 
-	/*
-	 * Consult the visimap to check if the tuple was deleted by a *committed*
-	 * transaction.
-	 *
-	 * Note: we need to use the passed in snapshot to perform the visimap lookup.
-	 * See get_or_create_unique_check_desc() for why we don't set the snapshot
-	 * up prior there.
-	 * If this is part of an update, we are reusing the visimap from the delete
-	 * half of the update, so better restore its snapshot once we are done.
-	 */
-	visimap = uniqueCheckDesc->visimap;
-	save_snapshot = visimap->visimapStore.snapshot;
-	visimap->visimapStore.snapshot = snapshot;
-	visible = AppendOnlyVisimap_IsVisible(visimap, aoTupleId);
-	visimap->visimapStore.snapshot = save_snapshot;
+	/* Now, consult the visimap */
+	visible = AppendOnlyVisimap_UniqueCheck(uniqueCheckDesc->visimap,
+											aoTupleId,
+											snapshot);
 
 	/*
 	 * Since we disallow deletes and updates running in parallel with inserts,

--- a/src/backend/access/appendonly/appendonlyblockdirectory.c
+++ b/src/backend/access/appendonly/appendonlyblockdirectory.c
@@ -221,6 +221,64 @@ AppendOnlyBlockDirectory_Init_forSearch(
 }
 
 /*
+ * AppendOnlyBlockDirectory_Init_forUniqueChecks
+ *
+ * Initializes the block directory to handle lookups for uniqueness checks.
+ *
+ * Note: These lookups will be purely restricted to the block directory relation
+ * itself and will not involve the physical AO relation.
+ *
+ * Note: we defer setting up the appendOnlyMetaDataSnapshot for the block
+ * directory to the index_fetch_tuple_exists() table AM call. This is because
+ * snapshots used for unique index lookups are special and don't follow the
+ * usual allocation or registration mechanism. They may be stack-allocated and a
+ * new snapshot object may be passed to every unique index check (this happens
+ * when SNAPSHOT_DIRTY is passed). While technically, we could set up the
+ * metadata snapshot in advance for SNAPSHOT_SELF, the alternative is fine.
+ */
+void
+AppendOnlyBlockDirectory_Init_forUniqueChecks(
+											  AppendOnlyBlockDirectory *blockDirectory,
+											  Relation aoRel,
+											  int numColumnGroups,
+											  Snapshot snapshot)
+{
+	Oid blkdirrelid;
+	Oid blkdiridxid;
+
+	Assert(RelationIsValid(aoRel));
+
+	Assert(snapshot->snapshot_type == SNAPSHOT_DIRTY ||
+			snapshot->snapshot_type == SNAPSHOT_SELF);
+
+	GetAppendOnlyEntryAuxOids(aoRel->rd_id,
+							  InvalidSnapshot, /* catalog snapshot is enough */
+							  NULL, &blkdirrelid, &blkdiridxid, NULL, NULL);
+
+	if (!OidIsValid(blkdirrelid) || !OidIsValid(blkdiridxid))
+		elog(ERROR, "Could not find block directory for relation: %u", aoRel->rd_id);
+
+	blockDirectory->aoRel = aoRel;
+	blockDirectory->isAOCol = RelationIsAoCols(aoRel);
+
+	/* Segfile setup is not necessary as physical AO tuples will not be accessed */
+	blockDirectory->segmentFileInfo = NULL;
+	blockDirectory->totalSegfiles = -1;
+	blockDirectory->currentSegmentFileNum = -1;
+
+	/* Metadata snapshot assignment is deferred to lookup-time */
+	blockDirectory->appendOnlyMetaDataSnapshot = InvalidSnapshot;
+
+	blockDirectory->numColumnGroups = numColumnGroups;
+	blockDirectory->proj = NULL;
+
+	blockDirectory->blkdirRel = heap_open(blkdirrelid, AccessShareLock);
+	blockDirectory->blkdirIdx = index_open(blkdiridxid, AccessShareLock);
+
+	init_internal(blockDirectory);
+}
+
+/*
  * AppendOnlyBlockDirectory_Init_forInsert
  *
  * Initialize the block directory to handle the inserts.
@@ -1507,6 +1565,21 @@ AppendOnlyBlockDirectory_End_addCol(
 	index_close(blockDirectory->blkdirIdx, NoLock);
 	heap_close(blockDirectory->blkdirRel, NoLock);
 	CatalogCloseIndexes(blockDirectory->indinfo);
+
+	MemoryContextDelete(blockDirectory->memoryContext);
+}
+
+void
+AppendOnlyBlockDirectory_End_forUniqueChecks(AppendOnlyBlockDirectory *blockDirectory)
+{
+	Assert(RelationIsValid(blockDirectory->blkdirRel));
+
+	/* This must have been reset after each uniqueness check */
+	Assert(blockDirectory->appendOnlyMetaDataSnapshot == InvalidSnapshot);
+
+	if (blockDirectory->blkdirIdx)
+		index_close(blockDirectory->blkdirIdx, AccessShareLock);
+	heap_close(blockDirectory->blkdirRel, AccessShareLock);
 
 	MemoryContextDelete(blockDirectory->memoryContext);
 }

--- a/src/include/cdb/cdbappendonlyblockdirectory.h
+++ b/src/include/cdb/cdbappendonlyblockdirectory.h
@@ -216,6 +216,10 @@ extern void AppendOnlyBlockDirectory_Init_forSearch(
 	int numColumnGroups,
 	bool isAOCol,
 	bool *proj);
+extern void AppendOnlyBlockDirectory_Init_forUniqueChecks(AppendOnlyBlockDirectory *blockDirectory,
+														  Relation aoRel,
+														  int numColumnGroups,
+														  Snapshot snapshot);
 extern void AppendOnlyBlockDirectory_Init_addCol(
 	AppendOnlyBlockDirectory *blockDirectory,
 	Snapshot appendOnlyMetaDataSnapshot,
@@ -242,11 +246,51 @@ extern void AppendOnlyBlockDirectory_DeleteSegmentFile(
 		Snapshot snapshot,
 		int segno,
 		int columnGroupNo);
+extern void AppendOnlyBlockDirectory_End_forUniqueChecks(
+	AppendOnlyBlockDirectory *blockDirectory);
 
 extern void AppendOnlyBlockDirectory_InsertPlaceholder(AppendOnlyBlockDirectory *blockDirectory,
 												  int64 firstRowNum,
 												  int64 fileOffset,
 												  int columnGroupNo);
+
+/*
+ * AppendOnlyBlockDirectory_UniqueCheck
+ *
+ * Check to see if there is a block directory entry for the tuple. If no such
+ * entry exists, the tuple doesn't exist physically in the segfile.
+ *
+ * Note: We need to use the passed in per-tuple snapshot to perform the block
+ * directory lookup. See AppendOnlyBlockDirectory_Init_forUniqueCheck() for
+ * details on why we can't set up the metadata snapshot at init time.
+ */
+static inline bool AppendOnlyBlockDirectory_UniqueCheck(
+	AppendOnlyBlockDirectory		*blockDirectory,
+	AOTupleId 						*aoTupleId,
+	Snapshot						appendOnlyMetaDataSnapshot
+)
+{
+	bool covers;
+
+	Assert(appendOnlyMetaDataSnapshot->snapshot_type == SNAPSHOT_DIRTY ||
+			   appendOnlyMetaDataSnapshot->snapshot_type == SNAPSHOT_SELF);
+
+	Assert(blockDirectory->appendOnlyMetaDataSnapshot == InvalidSnapshot);
+
+	/* Set up the snapshot to use for the block directory scan */
+	blockDirectory->appendOnlyMetaDataSnapshot = appendOnlyMetaDataSnapshot;
+
+	covers = AppendOnlyBlockDirectory_CoversTuple(blockDirectory,
+												  aoTupleId);
+
+	/*
+	 * Reset the metadata snapshot to avoid leaking a stack reference. We have
+	 * to do this since SNAPSHOT_DIRTY is stack-allocated.
+	 */
+	blockDirectory->appendOnlyMetaDataSnapshot = InvalidSnapshot;
+
+	return covers;
+}
 
 static inline uint32
 minipage_size(uint32 nEntry)


### PR DESCRIPTION
This commit refactors block directory and visimap initialization, lookup
and teardown code to make the special non-MVCC snapshot manipulation
more apparent. Assumptions are also asserted copiously.