### PR TITLE
Disable autovacuum by default.

### DIFF
--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -1494,7 +1494,7 @@ static struct config_bool ConfigureNamesBool[] =
 			NULL
 		},
 		&autovacuum_start_daemon,
-		true,
+		false,
 		NULL, NULL, NULL
 	},
 


### PR DESCRIPTION
Set GUC `autovacuum = false` by default.

For now we will disable autovacuum which also disables auto-analyze. In a future commit we will provide a method to independently enable auto-analyze.
