### PR TITLE
Workaround flaky test "dispatch"

### DIFF
--- a/src/test/regress/expected/bfv_partition.out
+++ b/src/test/regress/expected/bfv_partition.out
@@ -3102,6 +3102,7 @@ WITH cte AS (
 ----
 (0 rows)
 
+DROP TABLE a_partition_table_used_in_cte_test;
 -- CLEANUP
 -- start_ignore
 drop schema if exists bfv_partition cascade;

--- a/src/test/regress/sql/bfv_partition.sql
+++ b/src/test/regress/sql/bfv_partition.sql
@@ -1681,6 +1681,7 @@ ANALYZE a_partition_table_used_in_cte_test;
 WITH cte AS (
   SELECT * FROM a_partition_table_used_in_cte_test WHERE c1 < 2
 ) SELECT * FROM cte WHERE c1 = 1;
+DROP TABLE a_partition_table_used_in_cte_test;
 
 -- CLEANUP
 -- start_ignore


### PR DESCRIPTION
Test case "dispatch started failing on PLANNER CI after commit a7ca9e27.
Using github Issue #14428 for tracking. It seems somehow triggered to
the test added in bfv_partition in aforementioned commit.