### PR TITLE
[6X] ic-proxy: Fix cache eviction on remote peer shutdown

### DIFF
--- a/src/backend/cdb/motion/ic_proxy_backend.c
+++ b/src/backend/cdb/motion/ic_proxy_backend.c
@@ -456,7 +456,9 @@ void
 ic_proxy_backend_init_context(ChunkTransportState *state)
 {
 	ICProxyBackendContext *context;
-	
+
+	SIMPLE_FAULT_INJECTOR("ic_proxy_backend_init_context");
+
 	/* initialize backend context */
 	state->proxyContext = palloc0(sizeof(ICProxyBackendContext));
 	state->proxyContext->transportState = state;

--- a/src/backend/cdb/motion/ic_proxy_client.c
+++ b/src/backend/cdb/motion/ic_proxy_client.c
@@ -63,6 +63,7 @@
 #include "ic_proxy_server.h"
 #include "ic_proxy_pkt_cache.h"
 #include "ic_proxy_router.h"
+#include "utils/faultinjector.h"
 
 #include <uv.h>
 
@@ -210,18 +211,20 @@ ic_proxy_client_table_shutdown_by_dbid(uint16 dbid)
 	{
 		ICProxyClient *client = entry->client;
 
-		/* cached pkts must also be dropped */
-		ic_proxy_client_drop_p2c_cache(client);
-
 		if (client->state & IC_PROXY_CLIENT_STATE_PLACEHOLDER)
 			continue;
 
 		if (client->key.remoteDbid != dbid)
 			continue;
 
+		/* cached pkts from/to the remote dbid must also be dropped */
+		ic_proxy_client_drop_p2c_cache(client);
+
 		ic_proxy_client_shutdown_c2p(client);
 		ic_proxy_client_shutdown_p2c(client);
 	}
+
+	SIMPLE_FAULT_INJECTOR("ic_proxy_client_table_shutdown_by_dbid_end");
 }
 
 /*
@@ -1261,6 +1264,8 @@ ic_proxy_client_cache_p2c_pkt(ICProxyClient *client, ICProxyPkt *pkt)
 		   "ic-proxy: %s: cached a %s for future use, %d in the list",
 				 ic_proxy_client_get_name(client), ic_proxy_pkt_to_str(pkt),
 				 list_length(client->pkts));
+
+	SIMPLE_FAULT_INJECTOR("ic_proxy_client_cached_p2c_pkt");
 }
 
 /*

--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -421,7 +421,11 @@ static BackgroundWorker PMAuxProcList[MaxPMAuxProc] =
 
 #ifdef ENABLE_IC_PROXY
 	{"ic proxy process",
+#ifdef FAULT_INJECTOR
+	 BGWORKER_SHMEM_ACCESS,
+#else
 	 0,
+#endif
 	 BgWorkerStart_RecoveryFinished,
 	 0, /* restart immediately if ic proxy process exits with non-zero code */
 	 ICProxyMain, {0}, {0}, 0, 0,

--- a/src/test/isolation2/Makefile
+++ b/src/test/isolation2/Makefile
@@ -69,7 +69,7 @@ clean distclean:
 
 install: all gpdiff.pl gpstringsubs.pl
 
-installcheck: install installcheck-parallel-retrieve-cursor
+installcheck: install installcheck-parallel-retrieve-cursor installcheck-ic-tcp installcheck-ic-proxy
 	./pg_isolation2_regress $(EXTRA_REGRESS_OPTS) --init-file=$(top_builddir)/src/test/regress/init_file --init-file=./init_file_isolation2 --psqldir='$(PSQLDIR)' --inputdir=$(srcdir) --schedule=$(srcdir)/isolation2_schedule
 
 installcheck-resgroup: install
@@ -81,3 +81,12 @@ installcheck-parallel-retrieve-cursor: install
 installcheck-mirrorless: install
 	./pg_isolation2_regress $(EXTRA_REGRESS_OPTS) --init-file=$(top_builddir)/src/test/regress/init_file --init-file=./init_file_isolation2 --schedule=$(srcdir)/mirrorless_schedule --dbname=isolation2-mirrorless --load-extension=gp_inject_fault
 
+installcheck-ic-tcp: install
+ifeq ($(findstring gp_interconnect_type=tcp,$(PGOPTIONS)),gp_interconnect_type=tcp)
+	./pg_isolation2_regress $(EXTRA_REGRESS_OPTS) --init-file=$(top_builddir)/src/test/regress/init_file --init-file=./init_file_isolation2 --psqldir='$(PSQLDIR)' --inputdir=$(srcdir) --load-extension=gp_inject_fault --schedule=$(srcdir)/isolation2_ic_tcp_schedule
+endif
+
+installcheck-ic-proxy: install
+ifeq ($(findstring gp_interconnect_type=proxy,$(PGOPTIONS)),gp_interconnect_type=proxy)
+	./pg_isolation2_regress $(EXTRA_REGRESS_OPTS) --init-file=$(top_builddir)/src/test/regress/init_file --init-file=./init_file_isolation2 --psqldir='$(PSQLDIR)' --inputdir=$(srcdir) --load-extension=gp_inject_fault --schedule=$(srcdir)/isolation2_ic_proxy_schedule
+endif

--- a/src/test/isolation2/expected/ic_proxy_peer_shutdown.out
+++ b/src/test/isolation2/expected/ic_proxy_peer_shutdown.out
@@ -1,0 +1,85 @@
+-- Test to ensure that peer shutdown doesn't lead to packet loss.
+CREATE TABLE ic_proxy_peer_shutdown(i int);
+CREATE
+INSERT INTO ic_proxy_peer_shutdown VALUES (1), (2), (3);
+INSERT 3
+-- Will ensure that all peer setup is done.
+SELECT * FROM ic_proxy_peer_shutdown;
+ i 
+---
+ 1 
+ 2 
+ 3 
+(3 rows)
+
+-- Suspend regular client registration to force placeholder client creation for
+-- seg0 <-> seg-1.
+SELECT gp_inject_fault('ic_proxy_backend_init_context', 'suspend', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+SELECT gp_inject_fault_infinite('ic_proxy_client_cached_p2c_pkt', 'skip', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+
+-- Query involving only seg-1 (receiver) and seg0 (sender) will block.
+1&: SELECT * FROM ic_proxy_peer_shutdown WHERE i = 2;  <waiting ...>
+
+-- Wait until we have created a placeholder client for seg0 <-> seg-1
+-- communication in seg-1's proxy, and that placeholder has cached a DATA packet
+-- and a BYE packet from seg0.
+SELECT gp_wait_until_triggered_fault('ic_proxy_client_cached_p2c_pkt', 2, dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
+SELECT gp_inject_fault('ic_proxy_client_table_shutdown_by_dbid_end', 'skip', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+-- Now kill any IC proxy process to trigger a peer shutdown event in seg-1's proxy.
+!\retcode ps -ef | grep $(psql postgres -Atc "select port from gp_segment_configuration where content=1 and role='p'") | grep "ic proxy" | awk '{print $2}' | xargs kill;
+-- start_ignore
+
+-- end_ignore
+(exited with code 0)
+
+-- Wait until any client cache eviction has finished, resultant from the peer
+-- proxy shutdown.
+SELECT gp_wait_until_triggered_fault('ic_proxy_client_table_shutdown_by_dbid_end', 1, dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
+-- We should have handled the peer shutdown event gracefully, not lost any
+-- client-cached packets and let the blocked query complete.
+-- So, once we resume client processing, the query should be able to complete
+-- gracefully.
+SELECT gp_inject_fault('ic_proxy_backend_init_context', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+1<:  <... completed>
+ i 
+---
+ 2 
+(1 row)
+
+SELECT gp_inject_fault('ic_proxy_client_cached_p2c_pkt', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+SELECT gp_inject_fault('ic_proxy_client_table_shutdown_by_dbid_end', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)

--- a/src/test/isolation2/expected/tcp_ic_teardown.out
+++ b/src/test/isolation2/expected/tcp_ic_teardown.out
@@ -2,27 +2,10 @@
 -- teardown on the motion sender side, for the final response from the motion
 -- receiver(s).
 
-CREATE FUNCTION set_gp_ic_type(ic_type text) RETURNS VOID as $$ import os cmd = 'gpconfig -c gp_interconnect_type -v %s' % ic_type if os.system(cmd) is not 0: plpy.error('Setting gp_interconnect_type to %s failed' % ic_type) $$ LANGUAGE plpythonu;
-CREATE
-
 CREATE TABLE tcp_ic_teardown(i int);
 CREATE
 INSERT INTO tcp_ic_teardown SELECT generate_series(1, 5);
 INSERT 5
-
--- Save current IC type before we set it to 'tcp', so we can revert it at the
--- end of the test.
--1U: CREATE TABLE saved_ic_type AS SELECT current_setting('gp_interconnect_type') AS ic_type;
-CREATE 1
--1U: SELECT set_gp_ic_type('tcp');
- set_gp_ic_type 
-----------------
-                
-(1 row)
-!\retcode gpstop -au;
--- start_ignore
--- end_ignore
-(exited with code 0)
 
 SELECT gp_inject_fault('waitOnOutbound', 'suspend', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
  gp_inject_fault 
@@ -77,16 +60,3 @@ SELECT gp_inject_fault('doSendStopMessageTCP', 'reset', dbid) FROM gp_segment_co
 1<:  <... completed>
 ERROR:  timed out waiting for response from motion receiver during TCP interconnect teardown  (seg1 slice1 192.168.0.148:7003 pid=654372)
 DETAIL:  1 connection(s) with pending response after 3 seconds
-
--- Revert IC type
--1U: SELECT set_gp_ic_type(ic_type) FROM saved_ic_type;
- set_gp_ic_type 
-----------------
-                
-(1 row)
-!\retcode gpstop -au;
--- start_ignore
--- end_ignore
-(exited with code 0)
--1U: DROP TABLE saved_ic_type;
-DROP

--- a/src/test/isolation2/isolation2_ic_proxy_schedule
+++ b/src/test/isolation2/isolation2_ic_proxy_schedule
@@ -1,0 +1,6 @@
+# Schedule with targeted tests for proxy interconnect.
+# Assumes that gp_interconnect_type=proxy
+# Assumes that gp_interconnect_proxy_addresses has been set up
+
+# test TCP interconnect teardown bounded wait (Proxy IC reuses TCP setup/teardown)
+test: tcp_ic_teardown

--- a/src/test/isolation2/isolation2_ic_proxy_schedule
+++ b/src/test/isolation2/isolation2_ic_proxy_schedule
@@ -4,3 +4,6 @@
 
 # test TCP interconnect teardown bounded wait (Proxy IC reuses TCP setup/teardown)
 test: tcp_ic_teardown
+
+# test TCP proxy peer shutdown
+test: ic_proxy_peer_shutdown

--- a/src/test/isolation2/isolation2_ic_tcp_schedule
+++ b/src/test/isolation2/isolation2_ic_tcp_schedule
@@ -1,0 +1,5 @@
+# Schedule with targeted tests for TCP interconnect.
+# Assumes that gp_interconnect_type=tcp
+
+# test TCP interconnect teardown bounded wait
+test: tcp_ic_teardown

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -317,6 +317,3 @@ test: alter_partition_table_owner
 
 # test copy/insert in utility mode on partition/inheritance hierarchies
 test: copy_insert_utility_mode_hierarchies
-
-# test TCP interconnect teardown bounded wait
-test: tcp_ic_teardown

--- a/src/test/isolation2/sql/ic_proxy_peer_shutdown.sql
+++ b/src/test/isolation2/sql/ic_proxy_peer_shutdown.sql
@@ -1,0 +1,45 @@
+-- Test to ensure that peer shutdown doesn't lead to packet loss.
+CREATE TABLE ic_proxy_peer_shutdown(i int);
+INSERT INTO ic_proxy_peer_shutdown VALUES (1), (2), (3);
+-- Will ensure that all peer setup is done.
+SELECT * FROM ic_proxy_peer_shutdown;
+
+-- Suspend regular client registration to force placeholder client creation for
+-- seg0 <-> seg-1.
+SELECT gp_inject_fault('ic_proxy_backend_init_context', 'suspend', dbid)
+    FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+SELECT gp_inject_fault_infinite('ic_proxy_client_cached_p2c_pkt', 'skip', dbid)
+    FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+
+-- Query involving only seg-1 (receiver) and seg0 (sender) will block.
+1&: SELECT * FROM ic_proxy_peer_shutdown WHERE i = 2;
+
+-- Wait until we have created a placeholder client for seg0 <-> seg-1
+-- communication in seg-1's proxy, and that placeholder has cached a DATA packet
+-- and a BYE packet from seg0.
+SELECT gp_wait_until_triggered_fault('ic_proxy_client_cached_p2c_pkt', 2, dbid)
+    FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+
+SELECT gp_inject_fault('ic_proxy_client_table_shutdown_by_dbid_end', 'skip', dbid)
+    FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+
+-- Now kill any IC proxy process to trigger a peer shutdown event in seg-1's proxy.
+!\retcode ps -ef | grep $(psql postgres -Atc "select port from gp_segment_configuration where content=1 and role='p'") | grep "ic proxy" | awk '{print $2}' | xargs kill;
+
+-- Wait until any client cache eviction has finished, resultant from the peer
+-- proxy shutdown.
+SELECT gp_wait_until_triggered_fault('ic_proxy_client_table_shutdown_by_dbid_end', 1, dbid)
+    FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+
+-- We should have handled the peer shutdown event gracefully, not lost any
+-- client-cached packets and let the blocked query complete.
+-- So, once we resume client processing, the query should be able to complete
+-- gracefully.
+SELECT gp_inject_fault('ic_proxy_backend_init_context', 'reset', dbid)
+    FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+1<:
+
+SELECT gp_inject_fault('ic_proxy_client_cached_p2c_pkt', 'reset', dbid)
+    FROM gp_segment_configuration WHERE role = 'p' AND content = -1;
+SELECT gp_inject_fault('ic_proxy_client_table_shutdown_by_dbid_end', 'reset', dbid)
+    FROM gp_segment_configuration WHERE role = 'p' AND content = -1;

--- a/src/test/isolation2/sql/tcp_ic_teardown.sql
+++ b/src/test/isolation2/sql/tcp_ic_teardown.sql
@@ -2,22 +2,8 @@
 -- teardown on the motion sender side, for the final response from the motion
 -- receiver(s).
 
-CREATE FUNCTION set_gp_ic_type(ic_type text)
-    RETURNS VOID as $$
-import os
-cmd = 'gpconfig -c gp_interconnect_type -v %s' % ic_type
-if os.system(cmd) is not 0:
-    plpy.error('Setting gp_interconnect_type to %s failed' % ic_type)
-$$ LANGUAGE plpythonu;
-
 CREATE TABLE tcp_ic_teardown(i int);
 INSERT INTO tcp_ic_teardown SELECT generate_series(1, 5);
-
--- Save current IC type before we set it to 'tcp', so we can revert it at the
--- end of the test.
--1U: CREATE TABLE saved_ic_type AS SELECT current_setting('gp_interconnect_type') AS ic_type;
--1U: SELECT set_gp_ic_type('tcp');
-!\retcode gpstop -au;
 
 SELECT gp_inject_fault('waitOnOutbound', 'suspend', dbid)
     FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
@@ -47,8 +33,3 @@ SELECT gp_inject_fault('doSendStopMessageTCP', 'reset', dbid)
 -- After 6s have elapsed (enough to have covered the timed wait of 3s, we should
 -- have consequently ERRORed out on the motion sender side)
 1<:
-
--- Revert IC type
--1U: SELECT set_gp_ic_type(ic_type) FROM saved_ic_type;
-!\retcode gpstop -au;
--1U: DROP TABLE saved_ic_type;


### PR DESCRIPTION
This is a backport of https://github.com/greenplum-db/gpdb/pull/14412

Dev pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/6X_proxy_shutdown_bug