### PR TITLE
docs - update sql ref pages for ALTER/CREATE/DROP TABLESPACE

### DIFF
--- a/gpdb-doc/markdown/ref_guide/sql_commands/ALTER_TABLESPACE.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/ALTER_TABLESPACE.html.md
@@ -7,13 +7,11 @@ Changes the definition of a tablespace.
 ``` {#sql_command_synopsis}
 ALTER TABLESPACE <name> RENAME TO <new_name>
 
-ALTER TABLESPACE <name> OWNER TO <new_owner>
+ALTER TABLESPACE <name> OWNER TO { <new_owner> | CURRENT_USER | SESSION_USER }
 
 ALTER TABLESPACE <name> SET ( <tablespace_option> = <value> [, ... ] )
 
 ALTER TABLESPACE <name> RESET ( <tablespace_option> [, ... ] )
-
-
 ```
 
 ## <a id="section3"></a>Description 
@@ -28,13 +26,13 @@ name
 :   The name of an existing tablespace.
 
 new\_name
-:   The new name of the tablespace. The new name cannot begin with pg\_ or gp\_ \(reserved for system tablespaces\).
+:   The new name of the tablespace. The new name cannot begin with `pg_` or `gp_ `\(reserved for system tablespaces\).
 
 new\_owner
 :   The new owner of the tablespace.
 
 tablespace\_parameter
-:   A tablespace parameter to be set or reset. Currently, the only available parameters are seq\_page\_cost and random\_page\_cost. Setting either value for a particular tablespace will override the planner's usual estimate of the cost of reading pages from tables in that tablespace, as established by the configuration parameters of the same name \(see [seq-page-cost](../config_params/guc-list.html), [random-page-cost](../config_params/guc-list.html)\). This may be useful if one tablespace is located on a disk which is faster or slower than the remainder of the I/O subsystem.
+:   A tablespace parameter to set or reset. Currently, the only available parameters are `seq_page_cost` and `random_page_cost`. Setting either value for a particular tablespace will override the planner's usual estimate of the cost of reading pages from tables in that tablespace, as established by the configuration parameters of the same name \(see [seq_page_cost](../config_params/guc-list.html#seq_page_cost), [random_page_cost](../config_params/guc-list.html#random_page_cost)\). This may be useful if one tablespace is located on a disk which is faster or slower than the remainder of the I/O subsystem.
 
 ## <a id="section5"></a>Examples 
 

--- a/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_TABLESPACE.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_TABLESPACE.html.md
@@ -30,7 +30,7 @@ owner\_name
 :   The name of the user who will own the tablespace. If omitted, defaults to the user running the command. Only superusers can create tablespaces, but they can assign ownership of tablespaces to non-superusers.
 
 LOCATION 'directory'
-:   The directory that will be used for the tablespace. The directory should be empty and must be owned by the Greenplum Database system user. You must specify the absolute path of the directory, XXX and the path name must not be greater than 100 characters in length. \(The location is used to create a symlink target in the pg\_tblspc directory, and symlink targets are truncated to 100 characters when sending to `tar` from utilities such as `pg_basebackup`.\) XXX
+:   The directory that will be used for the tablespace. The directory should be empty and must be owned by the Greenplum Database system user. You must specify the absolute path of the directory, and the path name must not be greater than 100 characters in length. \(The location is used to create a symlink target in the pg\_tblspc directory, and symlink targets are truncated to 100 characters when sending to `tar` from utilities such as `pg_basebackup`.\)
 
 :   You can specify a different tablespace directory for any Greenplum Database segment instance in the `WITH` clause.
 
@@ -50,9 +50,9 @@ Because `CREATE TABLESPACE` creates symbolic links from the `pg_tblspc` director
 
 You cannot run `CREATE TABLESPACE` inside a transaction block.
 
-XXX When creating tablespaces, ensure that file system locations have sufficient I/O speed and available disk space.
+When creating tablespaces, ensure that file system locations have sufficient I/O speed and available disk space.
 
-XXX **Note:** Greenplum Database does not support different tablespace locations for a primary-mirror pair with the same content ID. It is only possible to configure different locations for different content IDs. Do not modify symbolic links under the `pg_tblspc` directory so that primary-mirror pairs point to different file locations; this will lead to erroneous behavior.
+**Note:** Greenplum Database does not support different tablespace locations for a primary-mirror pair with the same content ID. It is only possible to configure different locations for different content IDs. Do not modify symbolic links under the `pg_tblspc` directory so that primary-mirror pairs point to different file locations; this will lead to erroneous behavior.
 
 ## <a id="section6"></a>Examples 
 

--- a/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_TABLESPACE.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_TABLESPACE.html.md
@@ -5,8 +5,10 @@ Defines a new tablespace.
 ## <a id="section2"></a>Synopsis 
 
 ``` {#sql_command_synopsis}
-CREATE TABLESPACE <tablespace_name> [OWNER <username>]  LOCATION '</path/to/dir>' 
-   [WITH (content<ID_1>='</path/to/dir1>'[, content<ID_2>='</path/to/dir2>' ... ])]
+CREATE TABLESPACE <tablespace_name>
+   [ OWNER { <owner_name> | CURRENT_USER | SESSION_USER } ]
+   LOCATION '<directory>' 
+   [ WITH (content<ID_1>='<directory>'[, content<ID_2>='<directory>' ... ] [, <tablespace_option = value [, ... ] ] ) ]
 ```
 
 ## <a id="section3"></a>Description 
@@ -15,53 +17,42 @@ CREATE TABLESPACE <tablespace_name> [OWNER <username>]  LOCATION '</path/to/dir>
 
 A tablespace allows superusers to define an alternative host file system location where the data files containing database objects \(such as tables and indexes\) reside.
 
-A user with appropriate privileges can pass a tablespace name to [CREATE DATABASE](CREATE_DATABASE.html), [CREATE TABLE](CREATE_TABLE.html), or [CREATE INDEX](CREATE_INDEX.html) to have the data files for these objects stored within the specified tablespace.
+A user with appropriate privileges can pass tablespace\_name to [CREATE DATABASE](CREATE_DATABASE.html), [CREATE TABLE](CREATE_TABLE.html), or [CREATE INDEX](CREATE_INDEX.html) to direct Greenplum Database to store the data files for these objects within the specified tablespace.
 
 In Greenplum Database, the file system location must exist on all hosts including the hosts running the master, standby mirror, each primary segment, and each mirror segment.
 
 ## <a id="section4"></a>Parameters 
 
-tablespacename
+tablespace\_name
 :   The name of a tablespace to be created. The name cannot begin with `pg_` or `gp_`, as such names are reserved for system tablespaces.
 
-OWNER username
+owner\_name
 :   The name of the user who will own the tablespace. If omitted, defaults to the user running the command. Only superusers can create tablespaces, but they can assign ownership of tablespaces to non-superusers.
 
-LOCATION '/path/to/dir'
-:   The absolute path to the directory \(host system file location\) that will be the root directory for the tablespace. When registering a tablepace, the directory should be empty and must be owned by the Greenplum Database system user. The directory must be specified by an absolute path name of no more than 100 characters. \(The location is used to create a symlink target in the pg\_tblspc directory, and symlink targets are truncated to 100 characters when sending to `tar` from utilities such as `pg_basebackup`.\)
+LOCATION 'directory'
+:   The directory that will be used for the tablespace. The directory should be empty and must be owned by the Greenplum Database system user. You must specify the absolute path of the directory, XXX and the path name must not be greater than 100 characters in length. \(The location is used to create a symlink target in the pg\_tblspc directory, and symlink targets are truncated to 100 characters when sending to `tar` from utilities such as `pg_basebackup`.\) XXX
 
-:   For each segment instance, you can specify a different directory for the tablespace in the `WITH` clause.
+:   You can specify a different tablespace directory for any Greenplum Database segment instance in the `WITH` clause.
 
-contentID\_i='/path/to/dir\_i'
-:   The value ID\_i is the content ID for the segment instance. /path/to/dir\_i is the absolute path to the host system file location that the segment instance uses as the root directory for the tablespace. You cannot specify the content ID of the master instance \(`-1`\). You can specify the same directory for multiple segments.
+contentID\_i='directory_i'
+:   The value ID\_i is the content ID for the segment instance. directory\_i is the absolute path to the host system file location that the segment instance uses as the root directory for the tablespace. You cannot specify the content ID of the master instance \(`-1`\). You can specify the same directory for multiple segments.
 
-:   If a segment instance is not listed in the `WITH` clause, Greenplum Database uses the directory specified in the `LOCATION` clause.
+:   If a segment instance is not listed in the `WITH` clause, Greenplum Database uses the tablespace directory specified in the `LOCATION` clause.
 
-:   When registering a tablepace, the directories should be empty and must be owned by the Greenplum Database system user. Each directory must be specified by an absolute path name of no more than 100 characters.
+:   The restrictions identified for the `LOCATION` directory also hold for directory\_i.
+
+tablespace\_option
+:   A tablespace parameter to set or reset. Currently, the only available parameters are `seq_page_cost` and `random_page_cost`. Setting either value for a particular tablespace will override the planner's usual estimate of the cost of reading pages from tables in that tablespace, as established by the configuration parameters of the same name (see [seq_page_cost](../config_params/guc-list.html#seq_page_cost), [random_page_cost](../config_params/guc-list.html#random_page_cost)). This may be useful if one tablespace is located on a disk which is faster or slower than the remainder of the I/O subsystem.
 
 ## <a id="section5"></a>Notes 
 
-Tablespaces are only supported on systems that support symbolic links.
+Because `CREATE TABLESPACE` creates symbolic links from the `pg_tblspc` directory in the master and segment instance data directory to the directories specified in the command, Greenplum Database supports tablespaces only on systems that support symbolic links.
 
-`CREATE TABLESPACE` cannot be run inside a transaction block.
+You cannot run `CREATE TABLESPACE` inside a transaction block.
 
-When creating tablespaces, ensure that file system locations have sufficient I/O speed and available disk space.
+XXX When creating tablespaces, ensure that file system locations have sufficient I/O speed and available disk space.
 
-`CREATE TABLESPACE` creates symbolic links from the `pg_tblspc` directory in the master and segment instance data directory to the directories specified in the command.
-
-The system catalog table `pg_tablespace` stores tablespace information. This command displays the tablespace OID values, names, and owner.
-
-```
-SELECT oid, spcname, spcowner FROM pg_tablespace;
-```
-
-The Greenplum Database built-in function `gp_tablespace_location(tablespace\_oid)` displays the tablespace host system file locations for all segment instances. This command lists the segment database IDs and host system file locations for the tablespace with OID `16385`.
-
-```
-SELECT * FROM gp_tablespace_location(16385) 
-```
-
-**Note:** Greenplum Database does not support different tablespace locations for a primary-mirror pair with the same content ID. It is only possible to configure different locations for different content IDs. Do not modify symbolic links under the `pg_tblspc` directory so that primary-mirror pairs point to different file locations; this will lead to erroneous behavior.
+XXX **Note:** Greenplum Database does not support different tablespace locations for a primary-mirror pair with the same content ID. It is only possible to configure different locations for different content IDs. Do not modify symbolic links under the `pg_tblspc` directory so that primary-mirror pairs point to different file locations; this will lead to erroneous behavior.
 
 ## <a id="section6"></a>Examples 
 
@@ -71,7 +62,13 @@ Create a new tablespace and specify the file system location for the master and 
 CREATE TABLESPACE mytblspace LOCATION '/gpdbtspc/mytestspace';
 ```
 
-Create a new tablespace and specify a location for segment instances with content ID 0 and 1. For the master and segment instances not listed in the `WITH` clause, the file system location for the tablespace is specified in the `LOCATION` clause.
+Create a tablespace `indexspace` at `/data/indexes` owned by user `genevieve`:
+
+```
+CREATE TABLESPACE indexspace OWNER genevieve LOCATION '/data/indexes';
+```
+
+Create a new tablespace and specify a location for segment instances with content ID 0 and 1. For the master and segment instances not listed in the `WITH` clause, the file system location for the tablespace is the directory specified in the `LOCATION` clause.
 
 ```
 CREATE TABLESPACE mytblspace LOCATION '/gpdbtspc/mytestspace' WITH (content0='/temp/mytest', content1='/temp/mytest');

--- a/gpdb-doc/markdown/ref_guide/sql_commands/DROP_TABLESPACE.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/DROP_TABLESPACE.html.md
@@ -5,7 +5,7 @@ Removes a tablespace.
 ## <a id="section2"></a>Synopsis 
 
 ``` {#sql_command_synopsis}
-DROP TABLESPACE [IF EXISTS] <tablespacename>
+DROP TABLESPACE [IF EXISTS] <name>
 ```
 
 ## <a id="section3"></a>Description 
@@ -17,13 +17,16 @@ A tablespace can only be dropped by its owner or a superuser. The tablespace mus
 ## <a id="section4"></a>Parameters 
 
 IF EXISTS
-:   Do not throw an error if the tablespace does not exist. A notice is issued in this case.
+:   Do not throw an error if the tablespace does not exist. Greenplum Database issues a notice in this case.
 
-tablespacename
+name
 :   The name of the tablespace to remove.
 
 ## <a id="Notes"></a>Notes 
 
+You cannot run `DROP TABLESPACE` inside a transaction block.
+
+XXX 
 Run `DROP TABLESPACE` during a period of low activity to avoid issues due to concurrent creation of tables and temporary objects. When a tablespace is dropped, there is a small window in which a table could be created in the tablespace that is currently being dropped. If this occurs, Greenplum Database returns a warning. This is an example of the `DROP TABLESPACE` warning.
 
 ```
@@ -35,6 +38,7 @@ DROP TABLESPACE
 ```
 
 The table data in the tablespace directory is not dropped. You can use the [ALTER TABLE](ALTER_TABLE.html) command to change the tablespace defined for the table and move the data to an existing tablespace.
+XXX 
 
 ## <a id="section5"></a>Examples 
 

--- a/gpdb-doc/markdown/ref_guide/sql_commands/DROP_TABLESPACE.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/DROP_TABLESPACE.html.md
@@ -26,7 +26,6 @@ name
 
 You cannot run `DROP TABLESPACE` inside a transaction block.
 
-XXX 
 Run `DROP TABLESPACE` during a period of low activity to avoid issues due to concurrent creation of tables and temporary objects. When a tablespace is dropped, there is a small window in which a table could be created in the tablespace that is currently being dropped. If this occurs, Greenplum Database returns a warning. This is an example of the `DROP TABLESPACE` warning.
 
 ```
@@ -38,7 +37,6 @@ DROP TABLESPACE
 ```
 
 The table data in the tablespace directory is not dropped. You can use the [ALTER TABLE](ALTER_TABLE.html) command to change the tablespace defined for the table and move the data to an existing tablespace.
-XXX 
 
 ## <a id="section5"></a>Examples 
 


### PR DESCRIPTION
this PR updates the listed sql command reference pages to align with the postgres v12 ref page content. there was some greenplum-specific content on the v6 pages, see notes/questions for more info.

notes/questions:
- CREATE page has some greenplum-specifics related to content<N>, i retained this info.
- CREATE page was missing the tablespace_option = value (where tablespace_option = seq_page_cost or random_page_cost).  i added this to the synopsis and included the postgres option/value discussion.  was that the right thing to do?
- CREATE page - includes some text about max char length of the LOCATION directory - search for XXX.  is this still true for greenplum 7?
- CREATE page - removed some info from the Notes that was duplicated in the "using tablespaces" topic (https://docs.vmware.com/en/VMware-Tanzu-Greenplum/6/greenplum-database/GUID-admin_guide-ddl-ddl-tablespace.html#viewing-existing-tablespaces)
- CREATE page - is the Note in the Notes section valid?  (it is also in the using topic.)
- DROP page - is the greenplum-specific text between the XXX tags it the Notes section correct/valid for greenplum 7?

doc review site link for ALTER TABLESPACE (behind vpn), can navigate to others from there:  https://docs-staging.vmware.com/en/draft/VMware-Tanzu-Greenplum/sqlref-tblsp/greenplum-database/GUID-ref_guide-sql_commands-ALTER_TABLESPACE.html
