### PR TITLE
[6X] Add reloption to force table to collect HLL stats

### DIFF
--- a/src/backend/access/common/reloptions.c
+++ b/src/backend/access/common/reloptions.c
@@ -1223,7 +1223,9 @@ default_reloptions(Datum reloptions, bool validate, relopt_kind kind)
 		{"autovacuum_analyze_scale_factor", RELOPT_TYPE_REAL,
 		offsetof(StdRdOptions, autovacuum) +offsetof(AutoVacOpts, analyze_scale_factor)},
 		{"user_catalog_table", RELOPT_TYPE_BOOL,
-		offsetof(StdRdOptions, user_catalog_table)}
+		offsetof(StdRdOptions, user_catalog_table)},
+		{SOPT_ANALYZEHLL, RELOPT_TYPE_BOOL,
+		offsetof(StdRdOptions, analyze_hll_non_part_table)}
 	};
 
 	options = parseRelOptions(reloptions, validate, kind, &numoptions);

--- a/src/backend/commands/analyze.c
+++ b/src/backend/commands/analyze.c
@@ -802,9 +802,17 @@ do_analyze_rel(Relation onerel, VacuumStmt *vacstmt,
 										 totalrows);
 				/*
 				 * Store HLL/HLL fullscan information for leaf partitions in
-				 * the stats object
+				 * the stats object. If table was created with "analyze_hll_non_part_table" option, also collect
+				 * HLL stats for non-leaf tables
 				 */
-				if (rel_part_status(stats->attr->attrelid) == PART_STATUS_LEAF)
+				bool analyze_hll_non_part_table = false;
+				if (onerel->rd_options != NULL &&
+							((StdRdOptions *) onerel->rd_options)->analyze_hll_non_part_table)
+				{
+					analyze_hll_non_part_table = true;
+				}
+				if (rel_part_status(stats->attr->attrelid) == PART_STATUS_LEAF || 
+						(onerel->rd_rel->relkind == RELKIND_RELATION && analyze_hll_non_part_table))
 				{
 					MemoryContext old_context;
 					Datum *hll_values;

--- a/src/include/access/reloptions.h
+++ b/src/include/access/reloptions.h
@@ -41,6 +41,7 @@
 #endif
 #define AO_DEFAULT_CHECKSUM       true
 #define AO_DEFAULT_COLUMNSTORE    false
+#define ANALYZE_DEFAULT_HLL       false
 
 /* types supported by reloptions */
 typedef enum relopt_type

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -613,6 +613,7 @@ extern IndexCheckType gp_indexcheck_vacuum;
 #define SOPT_ALIAS_APPENDOPTIMIZED "appendoptimized"
 /* Max number of chars needed to hold value of a storage option. */
 #define MAX_SOPT_VALUE_LEN 15
+#define SOPT_ANALYZEHLL    "analyze_hll_non_part_table"
 
 /*
  * Functions exported by guc.c

--- a/src/include/utils/rel.h
+++ b/src/include/utils/rel.h
@@ -228,6 +228,7 @@ typedef struct StdRdOptions
 	int			fillfactor;		/* page fill factor in percent (0..100) */
 	AutoVacOpts autovacuum;		/* autovacuum-related options */
 
+	bool		analyze_hll_non_part_table; 		/* force hll statistics collection on relation */
 	bool		appendonly;		/* is this an appendonly relation? */
 	int			blocksize;		/* max varblock size (AO rels only) */
 	int			compresslevel;  /* compression level (AO rels only) */

--- a/src/test/regress/expected/incremental_analyze.out
+++ b/src/test/regress/expected/incremental_analyze.out
@@ -2037,3 +2037,179 @@ INFO:  analyzing "public.foo_1_prt_20210201"
 INFO:  Executing SQL: select pg_catalog.gp_acquire_sample_rows(755246, 400, 'f');
 INFO:  analyzing "public.foo" inheritance tree
 rollback;
+-- test behavior of "analyze_hll_non_part_table" create table option
+create table hll_part (i int, j int) distributed by (i)
+partition by range(j)
+(start(1) end(10) every(1));
+insert into hll_part select i, i%9+1 from generate_series(1,100)i;
+analyze hll_part;
+create table hll_default_heap (i int, j int) distributed by (i);
+select reloptions from pg_class where relname='hll_default_heap';
+ reloptions 
+------------
+ 
+(1 row)
+
+insert into hll_default_heap values (777,6);
+analyze hll_default_heap; -- hll stats should not be collected in non-partition heap table by default
+select 1 from pg_statistic where starelid='hll_default_heap'::regclass and stavalues5 is not null;
+ ?column? 
+----------
+(0 rows)
+
+create table hll_default_ao (i int, j int) with (appendonly=true) distributed by (i);
+select reloptions from pg_class where relname='hll_default_ao';
+    reloptions     
+-------------------
+ {appendonly=true}
+(1 row)
+
+insert into hll_default_ao values (777,6);
+analyze hll_default_ao;
+-- hll stats should not be collected in non-partition ao table by default
+select 1 from pg_statistic where starelid='hll_default_ao'::regclass and stavalues5 is not null;
+ ?column? 
+----------
+(0 rows)
+
+create table hll_off (i int, j int) with (analyze_hll_non_part_table=false) distributed by (i);
+select reloptions from pg_class where relname='hll_off';
+             reloptions             
+------------------------------------
+ {analyze_hll_non_part_table=false}
+(1 row)
+
+insert into hll_off values (777,6);
+analyze hll_off;
+-- hll stats should not be collected in non-partition table when disabled
+select 1 from pg_statistic where starelid='hll_off'::regclass and stavalues5 is not null;
+ ?column? 
+----------
+(0 rows)
+
+-- alter table, set analyze_hll_non_part_table on, ensure hll stats collected
+alter table hll_off set (analyze_hll_non_part_table=true);
+select reloptions from pg_class where relname='hll_off';
+            reloptions             
+-----------------------------------
+ {analyze_hll_non_part_table=true}
+(1 row)
+
+analyze hll_off;
+select 1 from pg_statistic where starelid='hll_off'::regclass and stavalues5 is not null;
+ ?column? 
+----------
+        1
+        1
+(2 rows)
+
+-- alter table, set analyze_hll_non_part_table off, ensure hll stats not collected
+alter table hll_off set (analyze_hll_non_part_table=false);
+select reloptions from pg_class where relname='hll_off';
+             reloptions             
+------------------------------------
+ {analyze_hll_non_part_table=false}
+(1 row)
+
+analyze hll_off;
+select 1 from pg_statistic where starelid='hll_off'::regclass and stavalues5 is not null;
+ ?column? 
+----------
+(0 rows)
+
+create table hll_on_ao (i int, j int) with (analyze_hll_non_part_table=true) distributed by (i);
+select reloptions from pg_class where relname='hll_on_ao';
+            reloptions             
+-----------------------------------
+ {analyze_hll_non_part_table=true}
+(1 row)
+
+insert into hll_on_ao values (777,6);
+analyze hll_on_ao;
+-- hll stats should be collected in non-partition AO table when enabled
+select 1 from pg_statistic where starelid='hll_on_ao'::regclass and stavalues5 is not null;
+ ?column? 
+----------
+        1
+        1
+(2 rows)
+
+create table hll_on_heap (i int, j int) with (analyze_hll_non_part_table=true) distributed by (i);
+select reloptions from pg_class where relname='hll_on_heap';
+            reloptions             
+-----------------------------------
+ {analyze_hll_non_part_table=true}
+(1 row)
+
+insert into hll_on_heap values (777,6);
+analyze hll_on_heap;
+-- hll stats should be collected in non-partition heap table when enabled
+select 1 from pg_statistic where starelid='hll_on_heap'::regclass and stavalues5 is not null;
+ ?column? 
+----------
+        1
+        1
+(2 rows)
+
+alter table hll_part exchange partition for (6)  with table hll_on_heap;
+select reloptions from pg_class where relname='hll_part_1_prt_6';
+            reloptions             
+-----------------------------------
+ {analyze_hll_non_part_table=true}
+(1 row)
+
+-- hll stats should be present after partition exchange of table with "analyze_hll_non_part_table" enabled
+select 1 from pg_statistic where starelid='hll_part_1_prt_6'::regclass and stavalues5 is not null;
+ ?column? 
+----------
+        1
+        1
+(2 rows)
+
+-- verify that reloption is correctly set for partitioned table
+create table hll_part_def (i int, j int) with (analyze_hll_non_part_table=false) distributed by (i)
+partition by range(j)
+(start(1) end(3) every(1));
+select reloptions from pg_class where relname='hll_part_def';
+             reloptions             
+------------------------------------
+ {analyze_hll_non_part_table=false}
+(1 row)
+
+select reloptions from pg_class where relname='hll_part_def_1_prt_2';
+             reloptions             
+------------------------------------
+ {analyze_hll_non_part_table=false}
+(1 row)
+
+-- see if altering the reloption at the partition root with the ONLY keyword
+-- only modifies the reloption for the root and future children (should NOT
+-- touch existing children)
+alter table only hll_part_def set (analyze_hll_non_part_table=true);
+select reloptions from pg_class where relname='hll_part_def';
+            reloptions             
+-----------------------------------
+ {analyze_hll_non_part_table=true}
+(1 row)
+
+select reloptions from pg_class where relname='hll_part_def_1_prt_2';
+             reloptions             
+------------------------------------
+ {analyze_hll_non_part_table=false}
+(1 row)
+
+-- see if altering the reloption at the partition root without the ONLY keyword
+-- modifies the reloption for all existing children AND all future children
+alter table hll_part_def set (analyze_hll_non_part_table=true);
+select reloptions from pg_class where relname='hll_part_def';
+            reloptions             
+-----------------------------------
+ {analyze_hll_non_part_table=true}
+(1 row)
+
+select reloptions from pg_class where relname='hll_part_def_1_prt_2';
+             reloptions             
+------------------------------------
+ {analyze_hll_non_part_table=false}
+(1 row)
+

--- a/src/test/regress/sql/incremental_analyze.sql
+++ b/src/test/regress/sql/incremental_analyze.sql
@@ -845,3 +845,84 @@ truncate foo_1_prt_20210201;
 insert into foo select a, '20210101'::date+a from (select generate_series(31,40) a) t1;
 analyze verbose foo_1_prt_20210201;
 rollback;
+
+-- test behavior of "analyze_hll_non_part_table" create table option
+create table hll_part (i int, j int) distributed by (i)
+partition by range(j)
+(start(1) end(10) every(1));
+insert into hll_part select i, i%9+1 from generate_series(1,100)i;
+analyze hll_part;
+
+create table hll_default_heap (i int, j int) distributed by (i);
+select reloptions from pg_class where relname='hll_default_heap';
+insert into hll_default_heap values (777,6);
+analyze hll_default_heap; -- hll stats should not be collected in non-partition heap table by default
+select 1 from pg_statistic where starelid='hll_default_heap'::regclass and stavalues5 is not null;
+
+create table hll_default_ao (i int, j int) with (appendonly=true) distributed by (i);
+select reloptions from pg_class where relname='hll_default_ao';
+insert into hll_default_ao values (777,6);
+analyze hll_default_ao;
+-- hll stats should not be collected in non-partition ao table by default
+select 1 from pg_statistic where starelid='hll_default_ao'::regclass and stavalues5 is not null;
+
+create table hll_off (i int, j int) with (analyze_hll_non_part_table=false) distributed by (i);
+select reloptions from pg_class where relname='hll_off';
+insert into hll_off values (777,6);
+analyze hll_off;
+-- hll stats should not be collected in non-partition table when disabled
+select 1 from pg_statistic where starelid='hll_off'::regclass and stavalues5 is not null;
+
+-- alter table, set analyze_hll_non_part_table on, ensure hll stats collected
+alter table hll_off set (analyze_hll_non_part_table=true);
+select reloptions from pg_class where relname='hll_off';
+analyze hll_off;
+select 1 from pg_statistic where starelid='hll_off'::regclass and stavalues5 is not null;
+
+-- alter table, set analyze_hll_non_part_table off, ensure hll stats not collected
+alter table hll_off set (analyze_hll_non_part_table=false);
+select reloptions from pg_class where relname='hll_off';
+analyze hll_off;
+select 1 from pg_statistic where starelid='hll_off'::regclass and stavalues5 is not null;
+
+create table hll_on_ao (i int, j int) with (analyze_hll_non_part_table=true) distributed by (i);
+select reloptions from pg_class where relname='hll_on_ao';
+insert into hll_on_ao values (777,6);
+analyze hll_on_ao;
+-- hll stats should be collected in non-partition AO table when enabled
+select 1 from pg_statistic where starelid='hll_on_ao'::regclass and stavalues5 is not null;
+
+create table hll_on_heap (i int, j int) with (analyze_hll_non_part_table=true) distributed by (i);
+select reloptions from pg_class where relname='hll_on_heap';
+insert into hll_on_heap values (777,6);
+analyze hll_on_heap;
+-- hll stats should be collected in non-partition heap table when enabled
+select 1 from pg_statistic where starelid='hll_on_heap'::regclass and stavalues5 is not null;
+
+alter table hll_part exchange partition for (6)  with table hll_on_heap;
+select reloptions from pg_class where relname='hll_part_1_prt_6';
+
+-- hll stats should be present after partition exchange of table with "analyze_hll_non_part_table" enabled
+select 1 from pg_statistic where starelid='hll_part_1_prt_6'::regclass and stavalues5 is not null;
+
+-- verify that reloption is correctly set for partitioned table
+create table hll_part_def (i int, j int) with (analyze_hll_non_part_table=false) distributed by (i)
+partition by range(j)
+(start(1) end(3) every(1));
+
+select reloptions from pg_class where relname='hll_part_def';
+select reloptions from pg_class where relname='hll_part_def_1_prt_2';
+
+-- see if altering the reloption at the partition root with the ONLY keyword
+-- only modifies the reloption for the root and future children (should NOT
+-- touch existing children)
+alter table only hll_part_def set (analyze_hll_non_part_table=true);
+select reloptions from pg_class where relname='hll_part_def';
+select reloptions from pg_class where relname='hll_part_def_1_prt_2';
+
+-- see if altering the reloption at the partition root without the ONLY keyword
+-- modifies the reloption for all existing children AND all future children
+alter table hll_part_def set (analyze_hll_non_part_table=true);
+select reloptions from pg_class where relname='hll_part_def';
+select reloptions from pg_class where relname='hll_part_def_1_prt_2';
+


### PR DESCRIPTION
Currently, tables do not collect HLL statistics unless they are part of a partitioned table. However, this means that a regular table that is exchanged or added to a partition table will also not have HLL statistics unless it is reanalyzed, and the root table will also therefore not have statistics for the exchanged/added partition.

This commit adds a reloption, "analyze_hll_non_part_table", that will also collect HLL stats if the table is created with this reloption. HLL stats will still always be collected if the table is created as part of a partitioned table, so this option only has an effect when tables are not part of the partition hierarchy.

Note: pg_dump/upgrade/gpbackup will automatically dump this since this is stored as a string in the reloption in pg_class.

New syntax:
`CREATE TABLE foo (a int) with (analyze_hll_non_part_table=true);` `ALTER TABLE foo SET with (analyze_hll_non_part_table=true)`

(cherry-picked from commit 6606072bd75270755f066825dfc7a38f8419377d)

Note: This was not a clean cherry-pick, so please review a bit more closely.