### PR TITLE
Remove support for centos7 and ubuntu18.04

### DIFF
--- a/concourse/scripts/compile_gpdb.bash
+++ b/concourse/scripts/compile_gpdb.bash
@@ -88,16 +88,6 @@ function include_dependencies() {
 	pkgconfigs=(quicklz.pc)
 	vendored_libs=(libquicklz.so{,.1,.1.5.0} libxerces-c{,-3.1}.so)
 
-	# If not building for rhel8, vendor libzstd and libuv shared library, headers, and pkgconfig
-	if [[ "${BLD_ARCH}" != "rhel8_x86_64"* ]]; then
-		vendored_headers=(zstd*.h uv.h uv)
-		pkgconfigs+=(libzstd.pc libuv.pc)
-		vendored_libs+=(libzstd.so{,.1,.1.3.7} libuv.so{,.1,.1.0.0})
-
-		# Vendor headers - follow symlinks
-		for path in "${header_search_path[@]}"; do if [[ -d "${path}" ]]; then for header in "${vendored_headers[@]}"; do find -L $path -name $header -exec cp -avn '{}' ${GREENPLUM_INSTALL_DIR}/include \;; done; fi; done
-	fi
-
 	# Vendor shared libraries - follow symlinks
 	for path in "${library_search_path[@]}"; do if [[ -d "${path}" ]]; then for lib in "${vendored_libs[@]}"; do find -L $path -name $lib -exec cp -avn '{}' ${GREENPLUM_INSTALL_DIR}/lib \;; done; fi; done
 	# vendor pkgconfig files


### PR DESCRIPTION
Remove support for centos7 and ubuntu18.04, we vendor zstd, libuv header and shared library to customer, but in rhel8, we do not need to vendor, since they can be installed from the os official repo.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
