### PR TITLE
Remove all host all all entries in segment pg_hba.conf

### DIFF
--- a/gpMgmt/bin/lib/gpcreateseg.sh
+++ b/gpMgmt/bin/lib/gpcreateseg.sh
@@ -143,7 +143,7 @@ CREATE_QES_PRIMARY () {
         do
             # MPP-15889
             CIDR_COORDINATOR_IP=$(GET_CIDRADDR $COORDINATOR_IP)
-            $TRUSTED_SHELL ${GP_HOSTADDRESS} "$ECHO host	all	all	${CIDR_COORDINATOR_IP}	trust >> ${GP_DIR}/$PG_HBA"
+            $TRUSTED_SHELL ${GP_HOSTADDRESS} "$ECHO host	all	$USER_NAME	${CIDR_COORDINATOR_IP}	trust >> ${GP_DIR}/$PG_HBA"
             PARA_EXIT $? "Update $PG_HBA for coordinator IP address ${CIDR_COORDINATOR_IP}"
           done
         if [ x"" != x"$STANDBY_HOSTNAME" ];then
@@ -152,13 +152,13 @@ CREATE_QES_PRIMARY () {
           do
           # MPP-15889
               CIDR_STANDBY_IP=$(GET_CIDRADDR $STANDBY_IP)
-              $TRUSTED_SHELL ${GP_HOSTADDRESS} "$ECHO host	all	all	${CIDR_STANDBY_IP}	trust >> ${GP_DIR}/$PG_HBA"
+              $TRUSTED_SHELL ${GP_HOSTADDRESS} "$ECHO host	all	$USER_NAME	${CIDR_STANDBY_IP}	trust >> ${GP_DIR}/$PG_HBA"
               PARA_EXIT $? "Update $PG_HBA for coordinator standby address ${CIDR_STANDBY_IP}"
           done
         fi
     
         # Add all local IPV4 addresses
-        SEGMENT_IPV4_LOCAL_ADDRESS_ALL=( $( REMOTE_EXECUTE_AND_GET_OUTPUT $GP_HOSTADDRESS "$IPV4_ADDR_LIST_CMD | $GREP inet | $GREP -v \"127.0.0\" | $AWK '{print \$2}' | $CUT -d'/' -f1" ))
+        SEGMENT_IPV4_LOCAL_ADDRESS_ALL=( $( REMOTE_EXECUTE_AND_GET_OUTPUT $GP_HOSTADDRESS "$IPV4_ADDR_LIST_CMD | $GREP inet | $AWK '{print \$2}' | $CUT -d'/' -f1" ))
         ADD_PG_HBA_ENTRIES "${SEGMENT_IPV4_LOCAL_ADDRESS_ALL[@]}"
     
         if [ x"" != x"$MIRROR_HOSTADDRESS" ]; then
@@ -178,8 +178,8 @@ CREATE_QES_PRIMARY () {
         fi
     else # use hostnames in pg_hba.conf
         # add localhost
-        $TRUSTED_SHELL ${GP_HOSTADDRESS} "$ECHO host     all          all         localhost      trust >> ${GP_DIR}/$PG_HBA"
-        $TRUSTED_SHELL ${GP_HOSTADDRESS} "$ECHO host	all	all	${COORDINATOR_HOSTNAME}	trust >> ${GP_DIR}/$PG_HBA"
+        $TRUSTED_SHELL ${GP_HOSTADDRESS} "$ECHO host     all          $USER_NAME         localhost      trust >> ${GP_DIR}/$PG_HBA"
+        $TRUSTED_SHELL ${GP_HOSTADDRESS} "$ECHO host	all	$USER_NAME	${COORDINATOR_HOSTNAME}	trust >> ${GP_DIR}/$PG_HBA"
         if [ x"" != x"$MIRROR_HOSTADDRESS" ]; then
           $TRUSTED_SHELL ${GP_HOSTADDRESS} "$ECHO host     all          $USER_NAME         $MIRROR_HOSTADDRESS      trust >> ${GP_DIR}/$PG_HBA"
         fi

--- a/src/backend/libpq/pg_hba.conf.sample
+++ b/src/backend/libpq/pg_hba.conf.sample
@@ -77,11 +77,11 @@
 # TYPE  DATABASE        USER            ADDRESS                 METHOD
 
 @remove-line-for-nolocal@# "local" is for Unix domain socket connections only
-@remove-line-for-nolocal@#local   all             all                                     @authmethodlocal@
+@remove-line-for-nolocal@local   all             gpadmin                                     @authmethodlocal@
 # IPv4 local connections:
-#host    all             all             127.0.0.1/24            @authmethodhost@
+host    all             gpadmin             127.0.0.1/24            @authmethodhost@
 # IPv6 local connections:
-#host    all             all             ::1/128                 @authmethodhost@
+host    all             gpadmin             ::1/128                 @authmethodhost@
 # Allow replication connections from localhost, by a user with the
 # replication privilege.
 @remove-line-for-nolocal@local   replication     all                                     @authmethodlocal@

--- a/src/backend/libpq/pg_hba.conf.sample
+++ b/src/backend/libpq/pg_hba.conf.sample
@@ -77,11 +77,11 @@
 # TYPE  DATABASE        USER            ADDRESS                 METHOD
 
 @remove-line-for-nolocal@# "local" is for Unix domain socket connections only
-@remove-line-for-nolocal@local   all             all                                     @authmethodlocal@
+@remove-line-for-nolocal@#local   all             all                                     @authmethodlocal@
 # IPv4 local connections:
-host    all             all             127.0.0.1/24            @authmethodhost@
+#host    all             all             127.0.0.1/24            @authmethodhost@
 # IPv6 local connections:
-host    all             all             ::1/128                 @authmethodhost@
+#host    all             all             ::1/128                 @authmethodhost@
 # Allow replication connections from localhost, by a user with the
 # replication privilege.
 @remove-line-for-nolocal@local   replication     all                                     @authmethodlocal@

--- a/src/test/recovery/t/001_stream_rep.pl
+++ b/src/test/recovery/t/001_stream_rep.pl
@@ -11,7 +11,7 @@ my $node_master = get_new_node('master');
 # and it needs proper authentication configuration.
 $node_master->init(
 	allows_streaming => 1,
-	auth_extra       => [ '--create-role', 'repl_role' ]);
+	auth_extra       => [ '--create-role', 'gpadmin' ]);
 $node_master->start;
 my $backup_name = 'my_backup';
 

--- a/src/test/regress/expected/gp_connections.out
+++ b/src/test/regress/expected/gp_connections.out
@@ -45,7 +45,7 @@ SELECT port FROM gp_segment_configuration
 			WHERE content <> -1 AND role = 'p'
 			LIMIT 1
 \gset
-\connect - - - :port
+\connect - gpadmin - :port
 \connect: FATAL:  connections to primary segments are not allowed
 DETAIL:  This database instance is running as a primary segment in a Greenplum cluster and does not permit direct connections.
 HINT:  To force a connection anyway (dangerous!), use utility mode.

--- a/src/test/regress/sql/gp_connections.sql
+++ b/src/test/regress/sql/gp_connections.sql
@@ -40,7 +40,7 @@ SELECT port FROM gp_segment_configuration
 			WHERE content <> -1 AND role = 'p'
 			LIMIT 1
 \gset
-\connect - - - :port
+\connect - gpadmin - :port
 
 -- DON'T PUT ANYTHING BELOW THIS TEST! It'll be ignored since the above \connect
 -- fails and exits the script. Add them above, instead.


### PR DESCRIPTION
Vulnerabilities exist due to pg_hba.conf file in all segment servers containing "host all all" entries. The master node doesn't have this issue.

The segments can communicate with each other normally under the `gpadmin` user or any other configured user for greenplum database, so it's safe to remove the `all` user entries to harden the cluster.

Users never touched pg_hba.conf file except allowed default installation configuration. They were generated by the management scripts.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
