### PR TITLE
Consider oversized rows for stawidth computation

### DIFF
--- a/src/backend/commands/analyze.c
+++ b/src/backend/commands/analyze.c
@@ -163,6 +163,7 @@ static MemoryContext anl_context = NULL;
 static BufferAccessStrategy vac_strategy;
 
 Bitmapset	**acquire_func_colLargeRowIndexes;
+double		 *acquire_func_colLargeRowLength;
 
 
 static void do_analyze_rel(Relation onerel,
@@ -481,6 +482,7 @@ do_analyze_rel(Relation onerel, VacuumParams *params,
 	int			save_sec_context;
 	int			save_nestlevel;
 	Bitmapset **colLargeRowIndexes;
+	double     *colLargeRowLength;
 	bool		sample_needed;
 
 	if (inh)
@@ -669,6 +671,7 @@ do_analyze_rel(Relation onerel, VacuumParams *params,
 	 * Maintain information if the row of a column exceeds WIDTH_THRESHOLD
 	 */
 	colLargeRowIndexes = (Bitmapset **) palloc0(sizeof(Bitmapset *) * onerel->rd_att->natts);
+	colLargeRowLength = (double *)palloc0(sizeof(double) * onerel->rd_att->natts);
 
 	if ((params->options & VACOPT_FULLSCAN) != 0)
 	{
@@ -690,10 +693,18 @@ do_analyze_rel(Relation onerel, VacuumParams *params,
 		/*
 		 * Acquire the sample rows
 		 *
-		 * colLargeRowindexes is passed out-of-band, in a global variable,
+		 * colLargeRowIndexes is passed out-of-band, in a global variable,
 		 * to avoid changing the function signature from upstream's.
+		 *
+		 * The same as colLargeRowIndexes. colLargeRowLength stores total
+		 * length of too wide rows in the sample for every attribute of
+		 * the target relation. ANALYZE ignores too wide columns during
+		 * analysis(See comments of WIDTH_THRESHOLD), the stawidth can be
+		 * far smaller than the real average width for varlena datums which
+		 * are larger than WIDTH_THRESHOLD but stored uncompressed.
 		 */
 		acquire_func_colLargeRowIndexes = colLargeRowIndexes;
+		acquire_func_colLargeRowLength = colLargeRowLength;
 		if (inh)
 			numrows = acquire_inherited_sample_rows(onerel, elevel,
 													rows, targrows,
@@ -703,6 +714,7 @@ do_analyze_rel(Relation onerel, VacuumParams *params,
 									  rows, targrows,
 									  &totalrows, &totaldeadrows);
 		acquire_func_colLargeRowIndexes = NULL;
+		acquire_func_colLargeRowLength = NULL;
 		if (ctx)
 			MemoryContextSwitchTo(anl_context);
 	}
@@ -792,6 +804,12 @@ do_analyze_rel(Relation onerel, VacuumParams *params,
 			get_attribute_options(onerel->rd_id, stats->attr->attnum);
 
 			stats->tupDesc = onerel->rd_att;
+			/*
+			 * get total length and number of too wide rows in the sample,
+			 * in case get wrong stawidth.
+			 */
+			stats->totalwidelength = colLargeRowLength[stats->attr->attnum - 1];
+			stats->widerow_num = numrows - validRowsLength;
 
 			if (validRowsLength > 0)
 			{
@@ -851,7 +869,7 @@ do_analyze_rel(Relation onerel, VacuumParams *params,
 				// that every item was >= WIDTH_THRESHOLD in width.
 				stats->stats_valid = true;
 				stats->stanullfrac = 0.0;
-				stats->stawidth = WIDTH_THRESHOLD;
+				stats->stawidth = stats->totalwidelength/numrows;
 				stats->stadistinct = 0.0;		/* "unknown" */
 			}
 			stats->rows = rows; // Reset to original rows
@@ -2172,6 +2190,7 @@ acquire_sample_rows_dispatcher(Relation onerel, bool inh, int elevel,
 	 * global variable to avoid changing the AcquireSampleRowsFunc prototype.
 	 */
 	Bitmapset **colLargeRowIndexes = acquire_func_colLargeRowIndexes;
+	double     *colLargeRowLength = acquire_func_colLargeRowLength;
 	TupleDesc	relDesc = RelationGetDescr(onerel);
 	TupleDesc	funcTupleDesc;
 	TupleDesc	sampleTupleDesc;
@@ -2258,7 +2277,7 @@ acquire_sample_rows_dispatcher(Relation onerel, bool inh, int elevel,
 	funcTupleDesc = CreateTemplateTupleDesc(ncolumns);
 	TupleDescInitEntry(funcTupleDesc, (AttrNumber) 1, "", FLOAT8OID, -1, 0);
 	TupleDescInitEntry(funcTupleDesc, (AttrNumber) 2, "", FLOAT8OID, -1, 0);
-	TupleDescInitEntry(funcTupleDesc, (AttrNumber) 3, "", TEXTOID, -1, 0);
+	TupleDescInitEntry(funcTupleDesc, (AttrNumber) 3, "", FLOAT8ARRAYOID, -1, 0);
 	
 	for (i = 0; i < relDesc->natts; i++)
 	{
@@ -2357,12 +2376,17 @@ acquire_sample_rows_dispatcher(Relation onerel, bool inh, int elevel,
 				/* Read the 'toolarge' bitmap, if any */
 				if (colLargeRowIndexes && !funcRetNulls[2])
 				{
-					char	   *toolarge;
-					toolarge = funcRetValues[2];
-					if (strlen(toolarge) != numLiveColumns)
-						elog(ERROR, "'toolarge' bitmap has incorrect length");
+					ArrayType  *arrayVal;
+					Datum	   *largelength;
+					bool	   *nulls;
+					int	    numelems;
+					arrayVal = DatumGetArrayTypeP(OidFunctionCall3(F_ARRAY_IN,
+											CStringGetDatum(funcRetValues[2]),
+											FLOAT8OID,
+											-1));
+					deconstruct_array(arrayVal, FLOAT8OID, 8, true, 'd',
+								&largelength, &nulls, &numelems);
 
-					index = 0;
 					for (i = 0; i < relDesc->natts; i++)
 					{
 						Form_pg_attribute attr = TupleDescAttr(relDesc, i);
@@ -2370,9 +2394,11 @@ acquire_sample_rows_dispatcher(Relation onerel, bool inh, int elevel,
 						if (attr->attisdropped)
 							continue;
 
-						if (toolarge[index] == '1')
+						if (largelength[i] != (Datum) 0)
+						{
 							colLargeRowIndexes[i] = bms_add_member(colLargeRowIndexes[i], sampleTuples);
-						index++;
+							colLargeRowLength[i] += DatumGetFloat8(largelength[i]);
+						}
 					}
 				}
 
@@ -2385,10 +2411,10 @@ acquire_sample_rows_dispatcher(Relation onerel, bool inh, int elevel,
 					if (attr->attisdropped)
 						continue;
 
-					if (funcRetNulls[3 + index])
+					if (funcRetNulls[FIX_ATTR_NUM + index])
 						values[i] = NULL;
 					else
-						values[i] = funcRetValues[3 + index];
+						values[i] = funcRetValues[FIX_ATTR_NUM + index];
 					index++; /* Move index to the next result set attribute */
 				}
 
@@ -3021,7 +3047,7 @@ compute_distinct_stats(VacAttrStatsP stats,
 		/* Do the simple null-frac and width stats */
 		stats->stanullfrac = (double) null_cnt / (double) samplerows;
 		if (is_varwidth)
-			stats->stawidth = total_width / (double) nonnull_cnt;
+			stats->stawidth = (total_width + stats->totalwidelength) / (double) (nonnull_cnt + stats->widerow_num);
 		else
 			stats->stawidth = stats->attrtype->typlen;
 
@@ -3203,7 +3229,7 @@ compute_distinct_stats(VacAttrStatsP stats,
 			stats->stawidth = 0;	/* "unknown" */
 		else
 			stats->stawidth = stats->attrtype->typlen;
-		stats->stadistinct = 0.0;	/* "unknown" */
+		stats->stadistinct = 0.0;		/* "unknown" */
 	}
 
 	/* We don't need to bother cleaning up any of our temporary palloc's */
@@ -3414,7 +3440,7 @@ compute_scalar_stats(VacAttrStatsP stats,
 		/* Do the simple null-frac and width stats */
 		stats->stanullfrac = (double) null_cnt / (double) samplerows;
 		if (is_varwidth)
-			stats->stawidth = total_width / (double) nonnull_cnt;
+			stats->stawidth = (total_width + stats->totalwidelength) / (double) (nonnull_cnt + stats->widerow_num);
 		else
 			stats->stawidth = stats->attrtype->typlen;
 
@@ -3753,7 +3779,7 @@ compute_scalar_stats(VacAttrStatsP stats,
 		/* Do the simple null-frac and width stats */
 		stats->stanullfrac = (double) null_cnt / (double) samplerows;
 		if (is_varwidth)
-			stats->stawidth = total_width / (double) nonnull_cnt;
+			stats->stawidth = (total_width + stats->totalwidelength) / (double) (nonnull_cnt + stats->widerow_num);
 		else
 			stats->stawidth = stats->attrtype->typlen;
 		/* Assume all too-wide values are distinct, so it's a unique column */

--- a/src/backend/commands/analyzefuncs.c
+++ b/src/backend/commands/analyzefuncs.c
@@ -46,11 +46,11 @@ bool			gp_statistics_use_fkeys = false;
  * the actual sample rows.
  *
  * To make things even more complicated, each sample row contains one extra
- * column too: oversized_cols_bitmap. It's a bitmap indicating which attributes
- * on the sample row were omitted, because they were "too large". The omitted
- * attributes are returned as NULLs, and the bitmap can be used to distinguish
- * real NULLs from values that were too large to be included in the sample. The
- * bitmap is represented as a text column, with '0' or '1' for every column.
+ * column too: oversized_cols_length. It's an array indicating which attributes
+ * on the sample row were omitted and stores these omitted attributes' length,
+ * because they were "too large". The omitted attributes are returned as NULLs,
+ * and the array can be used to distinguish real NULLs from values that were
+ * too large to be included in the sample.
  *
  * So overall, this returns a result set like this:
  *
@@ -58,16 +58,16 @@ bool			gp_statistics_use_fkeys = false;
  *     -- special columns
  *     totalrows pg_catalog.float8,
  *     totaldeadrows pg_catalog.float8,
- *     oversized_cols_bitmap pg_catalog.text,
+ *     oversized_cols_length pg_catalog._float8,
  *     -- columns matching the table
  *     id int4,
  *     t text
  *  );
- *  totalrows | totaldeadrows | oversized_cols_bitmap | id  |    t    
+ *  totalrows | totaldeadrows | oversized_cols_length | id  |    t
  * -----------+---------------+-----------------------+-----+---------
  *            |               |                       |   1 | foo
  *            |               |                       |   2 | bar
- *            |               | 01                    |  50 | 
+ *            |               | {0,3004}              |  50 |
  *            |               |                       | 100 | foo 100
  *          2 |             0 |                       |     | 
  *          1 |             0 |                       |     | 
@@ -75,7 +75,7 @@ bool			gp_statistics_use_fkeys = false;
  * (7 rows)
  *
  * The first four rows form the actual sample. One of the columns contained
- * an oversized text datum. The function is marked as EXECUTE ON SEGMENTS in
+ * an oversized array datum. The function is marked as EXECUTE ON SEGMENTS in
  * the catalog so you get one summary row *for each segment*.
  */
 Datum
@@ -171,8 +171,8 @@ gp_acquire_sample_rows(PG_FUNCTION_ARGS)
 		/* extra column to indicate oversize cols */
 		TupleDescInitEntry(outDesc,
 						   3,
-						   "oversized_cols_bitmap",
-						   TEXTOID,
+						   "oversized_cols_length",
+						   FLOAT8ARRAYOID,
 						   -1,
 						   0);
 
@@ -225,9 +225,10 @@ gp_acquire_sample_rows(PG_FUNCTION_ARGS)
 		HeapTuple	relTuple = ctx->sample_rows[ctx->index];
 		int			attno;
 		int			outattno;
-		Bitmapset  *toolarge = NULL;
+		bool			has_toolarge = false;
 		Datum	   *relvalues = (Datum *) palloc(relDesc->natts * sizeof(Datum));
 		bool	   *relnulls = (bool *) palloc(relDesc->natts * sizeof(bool));
+		Datum      *oversized_cols_length = (Datum *) palloc0(relDesc->natts * sizeof(Datum));
 
 		heap_deform_tuple(relTuple, relDesc, relvalues, relnulls);
 
@@ -235,7 +236,6 @@ gp_acquire_sample_rows(PG_FUNCTION_ARGS)
 		for (attno = 1; attno <= relDesc->natts; attno++)
 		{
 			Form_pg_attribute relatt = TupleDescAttr(relDesc, attno - 1);
-			bool		is_toolarge = false;
 			Datum		relvalue;
 			bool		relnull;
 
@@ -251,8 +251,8 @@ gp_acquire_sample_rows(PG_FUNCTION_ARGS)
 
 				if (toasted_size > WIDTH_THRESHOLD)
 				{
-					toolarge = bms_add_member(toolarge, outattno - NUM_SAMPLE_FIXED_COLS);
-					is_toolarge = true;
+					oversized_cols_length[attno - 1] = Float8GetDatum((double)toasted_size);
+					has_toolarge = true;
 					relvalue = (Datum) 0;
 					relnull = true;
 				}
@@ -266,18 +266,10 @@ gp_acquire_sample_rows(PG_FUNCTION_ARGS)
 		 * If any of the attributes were oversized, construct the text datum
 		 * to represent the bitmap.
 		 */
-		if (toolarge)
+		if (has_toolarge)
 		{
-			char	   *toolarge_str;
-			int			i;
-			int			live_natts = outDesc->natts - NUM_SAMPLE_FIXED_COLS;
-
-			toolarge_str = palloc((live_natts + 1) * sizeof(char));
-			for (i = 0; i < live_natts; i++)
-				toolarge_str[i] = bms_is_member(i + 1, toolarge) ? '1' : '0';
-			toolarge_str[i] = '\0';
-
-			outvalues[2] = CStringGetTextDatum(toolarge_str);
+			outvalues[2] = PointerGetDatum(construct_array(oversized_cols_length, relDesc->natts,
+														FLOAT8OID, 8, true, 'd'));
 			outnulls[2] = false;
 		}
 		else

--- a/src/backend/tsearch/ts_typanalyze.c
+++ b/src/backend/tsearch/ts_typanalyze.c
@@ -303,7 +303,7 @@ compute_tsvector_stats(VacAttrStats *stats,
 		stats->stats_valid = true;
 		/* Do the simple null-frac and average width stats */
 		stats->stanullfrac = (double) null_cnt / (double) samplerows;
-		stats->stawidth = total_width / (double) nonnull_cnt;
+		stats->stawidth = (total_width + stats->totalwidelength) / (double) (nonnull_cnt + stats->widerow_num);
 
 		/* Assume it's a unique column (see notes above) */
 		stats->stadistinct = -1.0 * (1.0 - stats->stanullfrac);

--- a/src/backend/utils/adt/rangetypes_typanalyze.c
+++ b/src/backend/utils/adt/rangetypes_typanalyze.c
@@ -203,7 +203,7 @@ compute_range_stats(VacAttrStats *stats, AnalyzeAttrFetchFunc fetchfunc,
 		stats->stats_valid = true;
 		/* Do the simple null-frac and width stats */
 		stats->stanullfrac = (double) null_cnt / (double) samplerows;
-		stats->stawidth = total_width / (double) non_null_cnt;
+		stats->stawidth = (total_width + stats->totalwidelength) / (double) (non_null_cnt + stats->widerow_num);
 
 		/* Estimate that non-null values are unique */
 		stats->stadistinct = -1.0 * (1.0 - stats->stanullfrac);

--- a/src/include/commands/vacuum.h
+++ b/src/include/commands/vacuum.h
@@ -98,6 +98,10 @@ typedef struct VacAttrStats
 	int			minrows;		/* Minimum # of rows wanted for stats */
 	void	   *extra_data;		/* for extra type-specific data */
 
+	/* These fields are used to compute stawidth during the compute_stats routine. */
+	double                  totalwidelength;/* total length of toowide row */
+	int                     widerow_num;    /* # of toowide row */
+
 	/*
 	 * These fields are to be filled in by the compute_stats routine. (They
 	 * are initialized to zero when the struct is created.)

--- a/src/test/regress/expected/analyze.out
+++ b/src/test/regress/expected/analyze.out
@@ -817,7 +817,7 @@ ANALYZE foo_stats;
 SELECT schemaname, tablename, attname, null_frac, avg_width, n_distinct, most_common_vals, most_common_freqs, histogram_bounds FROM pg_stats WHERE tablename='foo_stats' ORDER BY attname;
  schemaname | tablename | attname | null_frac | avg_width | n_distinct |          most_common_vals           | most_common_freqs | histogram_bounds 
 ------------+-----------+---------+-----------+-----------+------------+-------------------------------------+-------------------+------------------
- public     | foo_stats | a       |         0 |         4 |      -0.25 |                                     |                   | 
+ public     | foo_stats | a       |         0 |      1504 |      -0.25 |                                     |                   | 
  public     | foo_stats | b       |         0 |         6 |       -0.5 | {"\\x6262626262","\\x626262626232"} | {0.5,0.5}         | 
  public     | foo_stats | c       |         0 |         5 |       -0.5 | {cccc,cccc2}                        | {0.5,0.5}         | 
  public     | foo_stats | d       |         0 |         4 |       -0.5 | {2,3}                               | {0.5,0.5}         | 
@@ -840,7 +840,7 @@ ANALYZE foo_stats;
 SELECT schemaname, tablename, attname, null_frac, avg_width, n_distinct, most_common_vals, most_common_freqs, histogram_bounds FROM pg_stats WHERE tablename='foo_stats' ORDER BY attname;
  schemaname | tablename | attname | null_frac | avg_width | n_distinct |  most_common_vals   | most_common_freqs | histogram_bounds 
 ------------+-----------+---------+-----------+-----------+------------+---------------------+-------------------+------------------
- public     | foo_stats | a       |         0 |      1024 |          0 |                     |                   | 
+ public     | foo_stats | a       |         0 |      1156 |          0 |                     |                   | 
  public     | foo_stats | b       |         0 |         7 |       -0.5 | {"\\x626262626232"} | {1}               | 
  public     | foo_stats | c       |         0 |         6 |       -0.5 | {cccc2}             | {1}               | 
  public     | foo_stats | d       |         0 |         4 |       -0.5 | {3}                 | {1}               | 
@@ -938,7 +938,7 @@ select attname, null_frac, avg_width, n_distinct from pg_stats where tablename =
  attname | null_frac | avg_width | n_distinct 
 ---------+-----------+-----------+------------
  a       |         0 |         2 |         -1
- c       |         0 |      1024 |          0
+ c       |         0 |      5004 |          0
  d       |         0 |         5 |         -1
 (3 rows)
 

--- a/src/test/regress/expected/incremental_analyze.out
+++ b/src/test/regress/expected/incremental_analyze.out
@@ -1534,9 +1534,9 @@ ANALYZE foo;
 SELECT * FROM pg_stats WHERE tablename like 'foo%' and attname = 'c' ORDER BY attname,tablename;
  schemaname |  tablename  | attname | inherited | null_frac | avg_width | n_distinct | most_common_vals | most_common_freqs | histogram_bounds | correlation | most_common_elems | most_common_elem_freqs | elem_count_histogram 
 ------------+-------------+---------+-----------+-----------+-----------+------------+------------------+-------------------+------------------+-------------+-------------------+------------------------+----------------------
- public     | foo         | c       | t         |         0 |      1024 |          0 |                  |                   |                  |             |                   |                        | 
- public     | foo_1_prt_1 | c       | f         |         0 |      1024 |          0 |                  |                   |                  |             |                   |                        | 
- public     | foo_1_prt_2 | c       | f         |         0 |      1024 |          0 |                  |                   |                  |             |                   |                        | 
+ public     | foo         | c       | t         |         0 |      4591 |          0 |                  |                   |                  |             |                   |                        | 
+ public     | foo_1_prt_1 | c       | f         |         0 |      4591 |          0 |                  |                   |                  |             |                   |                        | 
+ public     | foo_1_prt_2 | c       | f         |         0 |      4591 |          0 |                  |                   |                  |             |                   |                        | 
 (3 rows)
 
 -- Test ANALYZE full scan HLL

--- a/src/test/regress/expected/incremental_analyze_optimizer.out
+++ b/src/test/regress/expected/incremental_analyze_optimizer.out
@@ -1543,9 +1543,9 @@ ANALYZE foo;
 SELECT * FROM pg_stats WHERE tablename like 'foo%' and attname = 'c' ORDER BY attname,tablename;
  schemaname |  tablename  | attname | inherited | null_frac | avg_width | n_distinct | most_common_vals | most_common_freqs | histogram_bounds | correlation | most_common_elems | most_common_elem_freqs | elem_count_histogram 
 ------------+-------------+---------+-----------+-----------+-----------+------------+------------------+-------------------+------------------+-------------+-------------------+------------------------+----------------------
- public     | foo         | c       | t         |         0 |      1024 |          0 |                  |                   |                  |             |                   |                        | 
- public     | foo_1_prt_1 | c       | f         |         0 |      1024 |          0 |                  |                   |                  |             |                   |                        | 
- public     | foo_1_prt_2 | c       | f         |         0 |      1024 |          0 |                  |                   |                  |             |                   |                        | 
+ public     | foo         | c       | t         |         0 |      4591 |          0 |                  |                   |                  |             |                   |                        | 
+ public     | foo_1_prt_1 | c       | f         |         0 |      4591 |          0 |                  |                   |                  |             |                   |                        | 
+ public     | foo_1_prt_2 | c       | f         |         0 |      4591 |          0 |                  |                   |                  |             |                   |                        | 
 (3 rows)
 
 -- Test ANALYZE full scan HLL


### PR DESCRIPTION
gp_bloat_diag use the given statistics(including stawidth) in pg_statistic to compute the expected number of pages for the given table.

To avoid consuming too much memory during analysis and/or too much space in the resulting pg_statistic rows, ANALYZE ignores varlena datums that are wider than WIDTH_THRESHOLD. So the average width of column values is far smaller than the real average width, especially for varlena datums which are larger than WIDTH_THRESHOLD but stored uncompressed.

The wrong stawidth value causes gp_bloat_diag view shows tables have bloat and require a "VACUUM" or "VACUUM FULL", although these tables don't have bloat in fact.

Include the total length and number of oversized rows when computing the stawidth.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
