### PR TITLE
Add the switch for writable external table transfer retry.

### DIFF
--- a/src/backend/access/external/url_curl.c
+++ b/src/backend/access/external/url_curl.c
@@ -568,6 +568,17 @@ gp_perform_backoff_and_check_response(URL_CURL_FILE *file, perform_func perform)
 			return;
 		}
 		/*
+		 * If gpfdist_retry_timeout == 0, Retry is prohibited
+		 */
+		if (!gpfdist_retry_timeout)
+		{
+			elog(LOG, "abort writing data to gpfdist, and retry is prohibited");
+			ereport(ERROR,
+					(errcode(ERRCODE_CONNECTION_FAILURE),
+					 errmsg("error when connecting to gpfdist %s, quit without retry",
+							file->curl_url)));
+		}
+		/*
 		 * Retry until end_time is reached
 		 */
 		now = time(NULL);

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -2950,7 +2950,7 @@ struct config_int ConfigureNamesInt_gp[] =
 			GUC_UNIT_S | GUC_NOT_IN_SAMPLE
 		},
 		&gpfdist_retry_timeout,
-		300, 1, 7200,
+		300, 0, 7200,
 		NULL, NULL, NULL
 	},
 

--- a/src/bin/gpfdist/regress/input/exttab1.source
+++ b/src/bin/gpfdist/regress/input/exttab1.source
@@ -527,7 +527,9 @@ CREATE WRITABLE EXTERNAL TABLE wext_test_guc (a int, b text) LOCATION ('gpfdist:
 -- retry interval 1, 2, 4, 8, 16, then timeout. total 6 tries
 set gpfdist_retry_timeout = 20;
 INSERT INTO wext_test_guc SELECT * FROM test_guc;
-
+-- set gpfdist_retry_timeout to be 0, and the retry will be prohibited.
+set gpfdist_retry_timeout = 0;
+INSERT INTO wext_test_guc SELECT * FROM test_guc;
 DROP TABLE IF EXISTS test_guc;
 DROP EXTERNAL TABLE IF EXISTS wext_test_guc;
 

--- a/src/bin/gpfdist/regress/output/exttab1.source
+++ b/src/bin/gpfdist/regress/output/exttab1.source
@@ -719,6 +719,10 @@ CREATE WRITABLE EXTERNAL TABLE wext_test_guc (a int, b text) LOCATION ('gpfdist:
 set gpfdist_retry_timeout = 20;
 INSERT INTO wext_test_guc SELECT * FROM test_guc;
 ERROR:  error when connecting to gpfdist http://127.0.0.1:7070/test_guc.tbl, quit after 6 tries  (seg0 10.152.8.113:6005 pid=17374)
+-- set gpfdist_retry_timeout to be 0, and the retry will be prohibited.
+set gpfdist_retry_timeout = 0;
+INSERT INTO wext_test_guc SELECT * FROM test_guc;
+ERROR:  error when connecting to gpfdist http://127.0.0.1:7070/test_guc.tbl, quit without retry  (seg0 10.152.8.113:6005 pid=17374)
 DROP TABLE IF EXISTS test_guc;
 DROP EXTERNAL TABLE IF EXISTS wext_test_guc;
 --


### PR DESCRIPTION
The implementation of the writable external table of gpfdist is a process that gpdb posts data to gpfdist, and gpfdisit write the data into the corresponding file.

If the network condition is terrible, gpdb would not be able to get the response of gpfdist within a reasonable time interval leading to response timeout. Further, the gpdb will retry to send the same data, which will incur an error returned by gpfdsit. When gpdb receive the error, it will close all the connection to gpfdist and reset the HTTP requests.

If the network latency cannot be avoid, user need means to close the retry mechanism to avoid repeated restarting of writing job. 

Thus, we change the legal range of GUC gpfdist_retry_timeout to 0~2700. If users set gpfdist_retry_timeout to zero, gpdb turn off the retry for writing into writable external table(set gpfdist_retry_timeout = 0;). 
