### PR TITLE
Try to bypass query with only catalog tables

### DIFF
--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -3677,6 +3677,17 @@ groupWaitQueueFind(ResGroupData *group, const PGPROC *proc)
 }
 #endif/* USE_ASSERT_CHECKING */
 
+static bool checkBypassWalker(Node *node, void *context) {
+	if (node == NULL)
+		return false;
+
+	if (IsA(node, SelectStmt)){
+
+	}
+
+	return true;
+}
+
 /*
  * Parse the query and check if this query should
  * bypass the management of resource group.
@@ -3742,6 +3753,8 @@ shouldBypassQuery(const char *query_string)
 			bypass = false;
 			break;
 		}
+
+		raw_expression_tree_walker(parsetree, checkBypassWalker, NULL);
 	}
 
 	list_free_deep(parsetree_list);

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -3747,14 +3747,14 @@ shouldBypassQuery(const char *query_string)
 	{
 		parsetree = (Node *) lfirst(parsetree_item);
 
+		raw_expression_tree_walker(parsetree, checkBypassWalker, NULL);
+
 		if (nodeTag(parsetree) != T_VariableSetStmt &&
 			nodeTag(parsetree) != T_VariableShowStmt)
 		{
 			bypass = false;
 			break;
 		}
-
-		raw_expression_tree_walker(parsetree, checkBypassWalker, NULL);
 	}
 
 	list_free_deep(parsetree_list);

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -3685,7 +3685,7 @@ static bool checkBypassWalker(Node *node, void *context) {
 
 	}
 
-	return true;
+	return false;
 }
 
 /*

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -3689,7 +3689,7 @@ checkBypassWalker(Node *node, void *context)
 	if (IsA(node, RangeVar))
 	{
 		RangeVar *from = (RangeVar *)node;
-		if (from->schemaname != NULL &&
+		if (from->schemaname == NULL ||
 			strcmp(from->schemaname, "pg_catalog") != 0){
 			*bypass = false;
 			return true;

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -3689,7 +3689,8 @@ checkBypassWalker(Node *node, void *context)
 	if (IsA(node, RangeVar))
 	{
 		RangeVar *from = (RangeVar *)node;
-		if (strcmp(from->schemaname, "pg_catalog") != 0){
+		if (from->schemaname != NULL &&
+			strcmp(from->schemaname, "pg_catalog") != 0){
 			*bypass = false;
 			return true;
 		}

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -3692,7 +3692,7 @@ static bool checkBypassWalker(Node *node, void *context) {
 		}
 	}
 
-	return false;
+	return raw_expression_tree_walker(node, checkBypassWalker, context);
 }
 
 /*

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -3687,8 +3687,10 @@ static bool checkBypassWalker(Node *node, void *context) {
 	if (IsA(node, RangeVar)) {
 		foreach(cell, (List *)node) {
 			RangeVar *from = (RangeVar *)lfirst(cell);
-			if (strcmp(from->schemaname, "pg_catalog") != 0)
+			if (strcmp(from->schemaname, "pg_catalog") != 0){
 				*bypass = false;
+				return true;
+			}
 		}
 	}
 
@@ -3756,12 +3758,9 @@ shouldBypassQuery(const char *query_string)
 
 		if (IsA(parsetree, SelectStmt)){
 			raw_expression_tree_walker(parsetree, checkBypassWalker, &bypass);
-		}
-
-		if (bypass == false)
-			break;
-
-		if (nodeTag(parsetree) != T_VariableSetStmt &&
+			if (bypass == false)
+				break;
+		}else if (nodeTag(parsetree) != T_VariableSetStmt &&
 			nodeTag(parsetree) != T_VariableShowStmt)
 		{
 			bypass = false;


### PR DESCRIPTION
Try to bypass query with only catalog tables.

We need to bypass the query with only catalog tables in resource groups in some situations.

I just walk the parse tree and find `RangeVar` to compare it's `schemaname` with `pg_catalog`, it's just a few cases which be considered now.