### PR TITLE
[7x] test/regress: fix misleading error message

### DIFF
--- a/src/test/regress/pg_regress.c
+++ b/src/test/regress/pg_regress.c
@@ -2454,37 +2454,53 @@ run_single_test(const char *test, test_function tfunc)
 }
 
 /*
+ * Get error message pattern based on return code
+ */
+static const char *
+get_helper_err_pattern(int rc)
+{
+	if (rc == -2)
+	{
+		return "The program \"%s\" is needed by %s "
+			"has differece in build version (check \"GpTest.pm\" import) with "
+			"\"%s\".\nPlease rebuild tests or reconfigure the project.\n";
+	}
+	/* default error message pattern */
+	return "The program \"%s\" is needed by %s "
+		"but was not found in the same directory as \"%s\".\n"
+		"Please check that file exists (or is it a regular file).\n";
+}
+
+/*
  * Find the other binaries that we need. Currently, gpdiff.pl and
  * gpstringsubs.pl.
  */
 static void
 find_helper_programs(const char *argv0)
 {
-	if (find_other_exec(argv0, "gpdiff.pl", "gpdiff.pl " GP_VERSION"\n", gpdiffprog) != 0)
+	int 		rc;
+	char		full_path[MAXPGPATH];
+	const char 	*msg;
+
+	if ((rc = find_other_exec(argv0, "gpdiff.pl", "gpdiff.pl " GP_VERSION"\n", gpdiffprog)) != 0)
 	{
-		char		full_path[MAXPGPATH];
+		msg = get_helper_err_pattern(rc);
 
 		if (find_my_exec(argv0, full_path) < 0)
 			strlcpy(full_path, progname, sizeof(full_path));
 
-		fprintf(stderr,
-				_("The program \"gpdiff.pl\" is needed by %s "
-				  "but was not found in the same directory as \"%s\".\n"),
-				progname, full_path);
+		fprintf(stderr, _(msg), "gpdiff.pl", progname, full_path);
 		exit(1);
 	}
 
-	if (find_other_exec(argv0, "gpstringsubs.pl", "gpstringsubs.pl " GP_VERSION"\n", gpstringsubsprog) != 0)
+	if ((rc = find_other_exec(argv0, "gpstringsubs.pl", "gpstringsubs.pl " GP_VERSION"\n", gpstringsubsprog)) != 0)
 	{
-		char		full_path[MAXPGPATH];
+		msg = get_helper_err_pattern(rc);
 
 		if (find_my_exec(argv0, full_path) < 0)
 			strlcpy(full_path, progname, sizeof(full_path));
 
-		fprintf(stderr,
-				_("The program \"gpstringsubs.pl\" is needed by %s "
-				  "but was not found in the same directory as \"%s\".\n"),
-				progname, full_path);
+		fprintf(stderr, _(msg), "gpstringsubs.pl", progname, full_path);
 		exit(1);
 	}
 }


### PR DESCRIPTION
## Problem descritpion:

The next sequence of commands will lead to problem with running `pg_regress` tests (this sequence of commands is strange, and shouldn't be used). But as a result problem in a misleading error message exists:
```bash
 ./configure --enable-debug-extensions --disable-gpcloud --enable-debug --enable-cassert CFLAGS='-O0 -g3 -fno-omit-frame-pointer' CXXLAGS='-O0 -g3 -fno-omit-frame-pointer' --with-libxml --prefix=$HOME/builds/gpdb/master
make -j8
make install
cd src/test/regress
./pg_regress # ok - tests start
cd -
git commit --allow-empty -m "empty"
# regenerate GPTest.pm and version of gpdb
./configure --enable-debug-extensions --disable-gpcloud --enable-debug --enable-cassert CFLAGS='-O0 -g3 -fno-omit-frame-pointer' CXXLAGS='-O0 -g3 -fno-omit-frame-pointer' --with-libxml --prefix=$HOME/builds/gpdb/master\n
cd src/test/regress
./pg_regress
# This erroc occured:
The program "gpdiff.pl" is needed by pg_regress but was not found in the same directory as ".../greenplum/gpdb/src/test/regress/pg_regress".
```
Here is a problem: test binaries are builded at previous gpdb version (previous commit) and `./configure` script is called again, so `src/test/regress/GPTest.pm` (which stores version of gpdb at `$VERSION` constant) file is generated with newer version. Thus the real problem is next: `GP_VERSION` from binaries doesn't equal `$VERSION` from `GPTest.pm` script (here is some links to code: [passing the GP_VERSION to find_other_exec](https://github.com/greenplum-db/gpdb/blob/95f013ce0e6e9b409d606767cc6e0cde4b69cd2b/src/test/regress/pg_regress.c#L2463) and [version matching](https://github.com/greenplum-db/gpdb/blob/95f013ce0e6e9b409d606767cc6e0cde4b69cd2b/src/common/exec.c#L324-L351))

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
