### PR TITLE
Fix statistic counters for parent memory contexts when some child one…

### DIFF
--- a/src/backend/utils/mmgr/mcxt.c
+++ b/src/backend/utils/mmgr/mcxt.c
@@ -317,6 +317,8 @@ MemoryContextSetParent(MemoryContext context, MemoryContext new_parent)
 	{
 		MemoryContext parent = context->parent;
 
+		MemoryContextNoteFree(parent, context->allBytesAlloc - context->allBytesFreed);
+
 		if (context == parent->firstchild)
 			parent->firstchild = context->nextchild;
 		else
@@ -341,6 +343,7 @@ MemoryContextSetParent(MemoryContext context, MemoryContext new_parent)
 		context->parent = new_parent;
 		context->nextchild = new_parent->firstchild;
 		new_parent->firstchild = context;
+		MemoryContextNoteAlloc(new_parent, context->allBytesAlloc - context->allBytesFreed);
 	}
 	else
 	{


### PR DESCRIPTION
… attaches/detaches

Counters of memory contexts became incorrect when we deleted child memory context from it. At first, pointer to parent memory context was reset, at second, all allocated memory was freed and counters were updated. Because of reseted pointer to parent memory context, counters of parent memory context and their parents were not updated.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
