### PR TITLE
DOCS: Document new parameter to force collection of HLL stats for tables that are part of a partitioned table

### DIFF
--- a/gpdb-doc/markdown/ref_guide/sql_commands/ALTER_TABLE.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/ALTER_TABLE.html.md
@@ -161,7 +161,7 @@ where storage\_parameter when used with the `SET` command is:
 where storage\_parameter when used with the `SET WITH` command is:
 
 ```
-   appendoptimized={TRUE|FALSE}
+   appendoptimized={true | false }
    blocksize={8192-2097152}
    orientation={COLUMN|ROW}
    compresstype={ZLIB|ZSTD|QUICKLZ|RLE_TYPE|NONE}
@@ -169,6 +169,7 @@ where storage\_parameter when used with the `SET WITH` command is:
    fillfactor={10-100}
    checksum={true | false }
    reorganize={true | false }
+   analyze_hll_non_part_table={true | false }
 ```
 
   <p class="note">
@@ -316,8 +317,11 @@ DISTRIBUTED BY \(\{column\_name \[opclass\]\}\) \| DISTRIBUTED RANDOMLY \| DISTR
 
 :   Changing to or from a replicated distribution policy causes the table data to be redistributed.
 
+analyze_hll_non_part_table=true|false
+:   Use `analyze_hll_non_part_table=true` to force collection of HLL statistics even if the table is not part of a partitioned table. The default is `false`.
+
 reorganize=true\|false
-:   Use `reorganize=true` when the hash distribution policy has not changed or when you have changed from a hash to a random distribution, and you want to redistribute the data anyways.
+:   Use `reorganize=true` when the hash distribution policy has not changed or when you have changed from a hash to a random distribution, and you want to redistribute the data anyway.
 
 parent\_table
 :   A parent table to associate or de-associate with this table.

--- a/gpdb-doc/markdown/ref_guide/sql_commands/ALTER_TABLE.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/ALTER_TABLE.html.md
@@ -156,6 +156,8 @@ where storage\_parameter when used with the `SET` command is:
    compresslevel={0-9}
    fillfactor={10-100}
    checksum= {true | false }
+   analyze_hll_non_part_table={true | false }
+
 ```
 
 where storage\_parameter when used with the `SET WITH` command is:
@@ -169,7 +171,6 @@ where storage\_parameter when used with the `SET WITH` command is:
    fillfactor={10-100}
    checksum={true | false }
    reorganize={true | false }
-   analyze_hll_non_part_table={true | false }
 ```
 
   <p class="note">

--- a/gpdb-doc/markdown/ref_guide/sql_commands/ALTER_TABLE.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/ALTER_TABLE.html.md
@@ -157,7 +157,6 @@ where storage\_parameter when used with the `SET` command is:
    fillfactor={10-100}
    checksum= {true | false }
    analyze_hll_non_part_table={true | false }
-
 ```
 
 where storage\_parameter when used with the `SET WITH` command is:

--- a/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_TABLE.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_TABLE.html.md
@@ -206,6 +206,7 @@ where storage\_parameter for a partition is:
    compresstype={ZLIB|ZSTD|QUICKLZ|RLE_TYPE|NONE}
    compresslevel={1-19}
    fillfactor={10-100}
+   analyze_hll_non_part_table={TRUE|FALSE}
    [oids=FALSE]
 ```
 
@@ -390,6 +391,8 @@ WITH \( storage\_parameter=value \)
 :   The `compresslevel` option is valid only if `appendoptimized=TRUE`.
 
 :   **fillfactor** — The fillfactor for a table is a percentage between 10 and 100. 100 \(complete packing\) is the default. When a smaller fillfactor is specified, `INSERT` operations pack table pages only to the indicated percentage; the remaining space on each page is reserved for updating rows on that page. This gives `UPDATE` a chance to place the updated copy of a row on the same page as the original, which is more efficient than placing it on a different page. For a table whose entries are never updated, complete packing is the best choice, but in heavily updated tables smaller fillfactors are appropriate. This parameter cannot be set for TOAST tables.
+
+:   **analyze_hll_non_part_table** — Set this storage parameter to `true` to force collection of HLL statistics even if the table is not part of a partitioned table. The default is `false`.
 
 ON COMMIT
 :   The behavior of temporary tables at the end of a transaction block can be controlled using `ON COMMIT`. The three options are:

--- a/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_TABLE.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_TABLE.html.md
@@ -392,7 +392,7 @@ WITH \( storage\_parameter=value \)
 
 :   **fillfactor** — The fillfactor for a table is a percentage between 10 and 100. 100 \(complete packing\) is the default. When a smaller fillfactor is specified, `INSERT` operations pack table pages only to the indicated percentage; the remaining space on each page is reserved for updating rows on that page. This gives `UPDATE` a chance to place the updated copy of a row on the same page as the original, which is more efficient than placing it on a different page. For a table whose entries are never updated, complete packing is the best choice, but in heavily updated tables smaller fillfactors are appropriate. This parameter cannot be set for TOAST tables.
 
-:   **analyze_hll_non_part_table** — Set this storage parameter to `true` to force collection of HLL statistics even if the table is not part of a partitioned table. The default is `false`.
+:   **analyze_hll_non_part_table** — Set this storage parameter to `true` to force collection of HLL statistics even if the table is not part of a partitioned table. This is useful if the table will be exchanged or added to a partitioned table, so that the table does not need to be re-analyzed. The default is `false`.
 
 ON COMMIT
 :   The behavior of temporary tables at the end of a transaction block can be controlled using `ON COMMIT`. The three options are:


### PR DESCRIPTION
Staging here:

NOTE: No release note, as this is being introduced in 6X (v likely 6.24), not in 7X. 

https://docs-staging.vmware.com/en/Greenplum-Database-7/collect-HLL-stats/greenplum-database/GUID-ref_guide-sql_commands-CREATE_TABLE.html

https://docs-staging.vmware.com/en/Greenplum-Database-7/collect-HLL-stats/greenplum-database/GUID-ref_guide-sql_commands-ALTER_TABLE.html