### PR TITLE
6X:Add a GUC to display create gang time while executing statements

### DIFF
--- a/src/backend/cdb/dispatcher/cdbconn.c
+++ b/src/backend/cdb/dispatcher/cdbconn.c
@@ -90,6 +90,7 @@ cdbconn_createSegmentDescriptor(struct CdbComponentDatabaseInfo *cdbinfo, int id
 	segdbDesc->whoami = NULL;
 	segdbDesc->identifier = identifier;
 	segdbDesc->isWriter = isWriter;
+	segdbDesc->establishConnTime = 0;
 
 	MemoryContextSwitchTo(oldContext);
 	return segdbDesc;

--- a/src/backend/cdb/dispatcher/cdbdisp_query.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_query.c
@@ -53,6 +53,7 @@
 
 extern bool Test_print_direct_dispatch_info;
 
+extern bool gp_print_create_gang_time;
 /*
  * We need an array describing the relationship between a slice and
  * the number of "child" slices which depend on it.
@@ -299,6 +300,8 @@ CdbDispatchSetCommand(const char *strCommand, bool cancelOnError)
 	queryText = buildGpQueryString(pQueryParms, &queryTextLength);
 
 	primaryGang = AllocateGang(ds, GANGTYPE_PRIMARY_WRITER, cdbcomponent_getCdbComponentsList());
+	if (gp_print_create_gang_time)
+		printCreateGangTime(-1, primaryGang);
 
 	/* put all idle segment to a gang so QD can send SET command to them */
 	AllocateGang(ds, GANGTYPE_PRIMARY_READER, formIdleSegmentIdList());
@@ -454,6 +457,8 @@ cdbdisp_dispatchCommandInternal(DispatchCommandQueryParms *pQueryParms,
 	 */
 	primaryGang = AllocateGang(ds, GANGTYPE_PRIMARY_WRITER, segments);
 	Assert(primaryGang);
+	if (gp_print_create_gang_time)
+		printCreateGangTime(-1, primaryGang);
 
 	cdbdisp_makeDispatchResults(ds, 1, flags & DF_CANCEL_ON_ERROR);
 	cdbdisp_makeDispatchParams (ds, 1, queryText, queryTextLength);
@@ -1172,6 +1177,8 @@ cdbdisp_dispatchX(QueryDesc* queryDesc,
 		}
 
 		primaryGang = slice->primaryGang;
+		if (gp_print_create_gang_time)
+			printCreateGangTime(-1, primaryGang);
 		Assert(primaryGang != NULL);
 		AssertImply(queryDesc->extended_query,
 					primaryGang->type == GANGTYPE_PRIMARY_READER ||
@@ -1481,6 +1488,8 @@ CdbDispatchCopyStart(struct CdbCopy *cdbCopy, Node *stmt, int flags)
 	 */
 	primaryGang = AllocateGang(ds, GANGTYPE_PRIMARY_WRITER, cdbCopy->seglist);
 	Assert(primaryGang);
+	if (gp_print_create_gang_time)
+		printCreateGangTime(-1, primaryGang);
 
 	cdbdisp_makeDispatchResults(ds, 1, flags & DF_CANCEL_ON_ERROR);
 	cdbdisp_makeDispatchParams (ds, 1, queryText, queryTextLength);

--- a/src/backend/cdb/dispatcher/cdbgang.c
+++ b/src/backend/cdb/dispatcher/cdbgang.c
@@ -964,3 +964,64 @@ RecycleGang(Gang *gp, bool forceDestroy)
 	}
 	RESUME_INTERRUPTS();
 }
+
+/*
+ * Print the time of create a gang.
+ * if all segDescs of the gang are cached, we regard the gang as reused.
+ * else we print the shortest time and the longest time of estabishing connection to the segDesc.
+ */
+void
+printCreateGangTime(int sliceId, Gang *gang)
+{
+	double	shortestTime = -1, longestTime = -1;
+	int		shortestSegIndex = -1, longestSegIndex = -1;
+	int		size = gang->size;
+	SegmentDatabaseDescriptor *segdbDesc;
+	for (int i = 0; i < size; i++)
+	{
+		segdbDesc = gang->db_descriptors[i];
+		/* the connection of segdbDesc is not cached */
+		if (segdbDesc->establishConnTime != -1)
+		{
+			if (longestTime == -1 || segdbDesc->establishConnTime > longestTime)
+			{
+				longestTime = segdbDesc->establishConnTime;
+				longestSegIndex = segdbDesc->segindex;
+			}
+			if (shortestTime == -1 || segdbDesc->establishConnTime < shortestTime)
+			{
+				shortestTime = segdbDesc->establishConnTime;
+				shortestSegIndex = segdbDesc->segindex;
+			}
+		}
+	}
+
+	/* All the segDescs are cached, and we regard this gang as reused gang. */
+	if (longestTime == -1)
+	{
+		if (sliceId == -1)
+		{
+			elog(INFO, "(Gang) is reused");
+		}
+		else
+		{
+			elog(INFO, "(Slice%d) is reused", sliceId);
+		}
+
+	}
+	else
+	{
+		if (sliceId == -1)
+		{
+			elog(INFO, "The shortest establish conn time: %.2f ms, segindex: %d,\n"
+				"       The longest  establish conn time: %.2f ms, segindex: %d",
+				shortestTime, shortestSegIndex, longestTime, longestSegIndex);
+			}
+		else
+		{
+			elog(INFO, "(Slice%d) The shortest establish conn time: %.2f ms, segindex: %d,\n"
+				 "                The longest  establish conn time: %.2f ms, segindex: %d",
+				sliceId, shortestTime, shortestSegIndex, longestTime, longestSegIndex);
+		}
+	}
+}

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -154,6 +154,7 @@ bool		Debug_datumstream_read_print_varlena_info = false;
 bool		Debug_datumstream_write_use_small_initial_buffers = false;
 bool		gp_create_table_random_default_distribution = true;
 bool		gp_allow_non_uniform_partitioning_ddl = true;
+bool		gp_print_create_gang_time = false;
 bool		gp_enable_exchange_default_partition = false;
 int			dtx_phase2_retry_count = 0;
 bool		gp_log_suboverflow_statement = false;
@@ -2013,6 +2014,17 @@ struct config_bool ConfigureNamesBool_gp[] =
 		},
 		&gp_allow_non_uniform_partitioning_ddl,
 		true,
+		NULL, NULL, NULL
+	},
+
+	{
+		{"gp_print_create_gang_time", PGC_USERSET, CUSTOM_OPTIONS,
+			gettext_noop("Allow print information about create gang time."),
+			NULL,
+			GUC_NOT_IN_SAMPLE
+		},
+		&gp_print_create_gang_time,
+		false,
 		NULL, NULL, NULL
 	},
 

--- a/src/include/cdb/cdbconn.h
+++ b/src/include/cdb/cdbconn.h
@@ -53,6 +53,8 @@ typedef struct SegmentDatabaseDescriptor
     char                   *whoami;         /* QE identifier for msgs */
 	bool					isWriter;
 	int						identifier;		/* unique identifier in the cdbcomponent segment pool */
+	double					establishConnTime; /* the time of establish connection to the segment,
+												* -1 means this connection is cached */
 } SegmentDatabaseDescriptor;
 
 SegmentDatabaseDescriptor *

--- a/src/include/cdb/cdbgang.h
+++ b/src/include/cdb/cdbgang.h
@@ -129,5 +129,6 @@ typedef struct CdbProcess
 } CdbProcess;
 
 typedef Gang *(*CreateGangFunc)(List *segments, SegmentType segmentType);
+extern void printCreateGangTime(int sliceId, Gang *gang);
 
 #endif   /* _CDBGANG_H_ */

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -220,6 +220,7 @@
 		"gp_max_plan_size",
 		"gp_motion_cost_per_row",
 		"gp_perfmon_segment_interval",
+		"gp_print_create_gang_time",
 		"gp_qd_hostname",
 		"gp_qd_port",
 		"gp_recursive_cte",

--- a/src/test/regress/init_file
+++ b/src/test/regress/init_file
@@ -130,4 +130,10 @@ s/ERROR:  could not find hash function for hash operator.*/ERROR:  could not fin
 m/ERROR:  could not devise a plan.*/
 s/ERROR:  could not devise a plan.*/ERROR:  could not devise a plan/
 
+# ignore establish time and segindex num
+m/ The shortest establish conn time: \d+\.\d+ ms, segindex: \d+,/
+s/ The shortest establish conn time: \d+\.\d+ ms, segindex: \d+,/ The shortest establish conn time: xx\.xx ms, segindex: xx,/
+m/ The longest  establish conn time: \d+\.\d+ ms, segindex: \d+/
+s/ The longest  establish conn time: \d+\.\d+ ms, segindex: \d+/ The longest  establish conn time: xx\.xx ms, segindex: xx/
+
 -- end_matchsubs

--- a/src/test/regress/input/dispatch.source
+++ b/src/test/regress/input/dispatch.source
@@ -589,3 +589,34 @@ select * from gp_segment_configuration a, t13393 ,gp_segment_configuration b whe
 SELECT gp_inject_fault('cdbcomponent_recycle_idle_qe_error', 'reset', dbid, current_setting('gp_session_id')::int)
  from gp_segment_configuration where content=-1 and role='p';
 drop table t13393;
+
+-- test for print create time for gang.
+CREATE OR REPLACE FUNCTION cleanupAllGangs() RETURNS BOOL
+AS '@abs_builddir@/regress@DLSUFFIX@', 'cleanupAllGangs' LANGUAGE C;
+
+-- cleanupAllGangs();
+select cleanupAllGangs();
+
+show gp_print_create_gang_time;
+
+-- create a new n-gang
+set gp_print_create_gang_time=on;
+
+set optimizer=off;
+
+--gang reused
+create table t_create_gang_time(tc1 int,tc2 int);
+
+--1-gang reused
+select * from t_create_gang_time where tc1=1;
+explain analyze select * from t_create_gang_time where tc1=1;
+
+--n-gang reused and 1-gang is created.
+select * from t_create_gang_time t1, t_create_gang_time t2 where t1.tc1=2;
+
+explain analyze select * from t_create_gang_time t1, t_create_gang_time t2 where t1.tc1=2;
+
+reset gp_print_create_gang_time;
+reset optimizer;
+drop function cleanupAllGangs();
+drop table t_create_gang_time;

--- a/src/test/regress/output/dispatch.source
+++ b/src/test/regress/output/dispatch.source
@@ -968,3 +968,86 @@ SELECT gp_inject_fault('cdbcomponent_recycle_idle_qe_error', 'reset', dbid, curr
 (1 row)
 
 drop table t13393;
+-- test for print create time for gang.
+CREATE OR REPLACE FUNCTION cleanupAllGangs() RETURNS BOOL
+AS '@abs_builddir@/regress@DLSUFFIX@', 'cleanupAllGangs' LANGUAGE C;
+-- cleanupAllGangs();
+select cleanupAllGangs();
+ cleanupallgangs 
+-----------------
+ t
+(1 row)
+
+show gp_print_create_gang_time;
+ gp_print_create_gang_time 
+---------------------------
+ off
+(1 row)
+
+-- create a new n-gang
+set gp_print_create_gang_time=on;
+INFO:  The shortest establish conn time: 3.07 ms, segindex: 0,
+       The longest  establish conn time: 3.56 ms, segindex: 2
+set optimizer=off;
+INFO:  (Gang) is reused
+--gang reused
+create table t_create_gang_time(tc1 int,tc2 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'tc1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INFO:  (Gang) is reused
+--1-gang reused
+select * from t_create_gang_time where tc1=1;
+INFO:  (Gang) is reused
+ tc1 | tc2 
+-----+-----
+(0 rows)
+
+explain analyze select * from t_create_gang_time where tc1=1;
+INFO:  (Gang) is reused
+                                                        QUERY PLAN                                                        
+--------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..1176.25 rows=87 width=8) (actual time=0.329..0.329 rows=0 loops=1)
+   ->  Seq Scan on t_create_gang_time  (cost=0.00..1176.25 rows=29 width=8) (never executed)
+         Filter: (tc1 = 1)
+ Planning time: 0.289 ms
+   (slice0)    Executor memory: 59K bytes.
+   (slice1)    Executor memory: 42K bytes (seg1).
+ Memory used:  128000kB
+ Optimizer: Postgres query optimizer
+ Execution time: 0.718 ms
+(9 rows)
+
+--n-gang reused and 1-gang is created.
+select * from t_create_gang_time t1, t_create_gang_time t2 where t1.tc1=2;
+INFO:  (Gang) is reused
+INFO:  The shortest establish conn time: 3.54 ms, segindex: 0,
+       The longest  establish conn time: 3.54 ms, segindex: 0
+ tc1 | tc2 | tc1 | tc2 
+-----+-----+-----+-----
+(0 rows)
+
+explain analyze select * from t_create_gang_time t1, t_create_gang_time t2 where t1.tc1=2;
+INFO:  (Gang) is reused
+INFO:  (Gang) is reused
+                                                                   QUERY PLAN                                                                    
+-------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=10000000000.00..10000243071.10 rows=7413211 width=16) (actual time=0.328..0.328 rows=0 loops=1)
+   ->  Nested Loop  (cost=10000000000.00..10000243071.10 rows=2471071 width=16) (never executed)
+         ->  Seq Scan on t_create_gang_time t2  (cost=0.00..961.00 rows=28700 width=8) (never executed)
+         ->  Materialize  (cost=0.00..1180.99 rows=87 width=8) (never executed)
+               ->  Broadcast Motion 1:3  (slice1; segments: 1)  (cost=0.00..1179.69 rows=259 width=8) (never executed)
+                     ->  Seq Scan on t_create_gang_time t1  (cost=0.00..1176.25 rows=29 width=8) (never executed)
+                           Filter: (tc1 = 2)
+ Planning time: 0.485 ms
+   (slice0)    Executor memory: 63K bytes.
+   (slice1)    Executor memory: 42K bytes (seg0).
+   (slice2)    Executor memory: 63K bytes avg x 3 workers, 63K bytes max (seg0).
+ Memory used:  128000kB
+ Optimizer: Postgres query optimizer
+ Execution time: 0.927 ms
+(14 rows)
+
+reset gp_print_create_gang_time;
+reset optimizer;
+drop function cleanupAllGangs();
+drop table t_create_gang_time;


### PR DESCRIPTION
Add GUC gp_print_create_gang_time control whether to print information about creating gang time.
We print the create gang time for both DDL and DML.

If all the segDescs of a gang are from the cached pool, we regard the gang as reused.
We only display the shortest and longest establish conn time and their segindexs of a gang.

The info of the shortest establish conn time and the longest establish conn time is the same for 1-gang.

DDL:
```
create table t(tc1 int);
INFO: The shortest establish conn time: 4.48 ms, segindex: 2,
      The longest  establish  conn time: 8.13 ms, segindex: 1

set optimizer=off;
INFO: (Gang) is reused
```
DML:
we can use DML or explain analyze to get create gang time.
```
select * from t_create_gang_time t1, t_create_gang_time t2 where t1.tc1=2;
INFO: (Slice1) is reused
INFO: (Slice2) The shortest establish conn time: 4.80 ms, segindex: 0,
               The longest  establish conn time: 4.80 ms, segindex: 0
tc1 | tc2 | tc1 | tc2
-----+-----+-----+-----
(0 rows)

explain analyze select * from t_create_gang_time t1, t_create_gang_time t2 where t1.tc1=2;
INFO: (Slice1) is reused
INFO: (Slice2) is reused
QUERY PLAN
......
```
cherry-pick from master commit: 3ebc3c4bbe6b98c9d308ce0f6737368e780c5aa0