### PR TITLE
ORCA: Fix data corruption error for text related domain types

### DIFF
--- a/src/backend/gpopt/gpdbwrappers.cpp
+++ b/src/backend/gpopt/gpdbwrappers.cpp
@@ -2178,6 +2178,22 @@ gpdb::GetMergeJoinOpFamilies(Oid opno)
 }
 
 
+// get the OID of base elementtype for a given typid
+// eg.: CREATE DOMAIN text_domain as text;
+// SELECT oid, typbasetype from pg_type where typname = 'text_domain';
+// oid         | XXXXX  --> Oid for text_domain
+// typbasetype | 25     --> Oid for base element ie, TEXT
+Oid
+gpdb::GetBaseType(Oid typid)
+{
+	GP_WRAP_START;
+	{
+		return getBaseType(typid);
+	}
+	GP_WRAP_END;
+	return InvalidOid;
+}
+
 // Evaluates 'expr' and returns the result as an Expr.
 // Caller keeps ownership of 'expr' and takes ownership of the result
 Expr *

--- a/src/backend/gpopt/translate/CTranslatorScalarToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorScalarToDXL.cpp
@@ -2305,7 +2305,11 @@ CTranslatorScalarToDXL::TranslateGenericDatumToDXL(CMemoryPool *mp,
 	LINT lint_value = 0;
 	if (CMDTypeGenericGPDB::HasByte2IntMapping(md_type))
 	{
-		lint_value = ExtractLintValueFromDatum(md_type, is_null, bytes, length);
+		IMDId *base_mdid = GPOS_NEW(mp)
+			CMDIdGPDB(IMDId::EmdidGeneral, gpdb::GetBaseType(mdid->Oid()));
+		// base_mdid is used for text related domain types
+		lint_value = ExtractLintValueFromDatum(md_type, is_null, bytes, length,
+											   base_mdid);
 	}
 
 	return CMDTypeGenericGPDB::CreateDXLDatumVal(
@@ -2548,7 +2552,8 @@ CTranslatorScalarToDXL::ExtractByteArrayFromDatum(CMemoryPool *mp,
 LINT
 CTranslatorScalarToDXL::ExtractLintValueFromDatum(const IMDType *md_type,
 												  BOOL is_null, BYTE *bytes,
-												  ULONG length)
+												  ULONG length,
+												  IMDId *base_mdid)
 {
 	IMDId *mdid = md_type->MDId();
 	GPOS_ASSERT(CMDTypeGenericGPDB::HasByte2IntMapping(md_type));
@@ -2582,15 +2587,21 @@ CTranslatorScalarToDXL::ExtractLintValueFromDatum(const IMDType *md_type,
 			{
 				hash = gpdb::UUIDHash((Datum) bytes);
 			}
-			else if (mdid->Equals(&CMDIdGPDB::m_mdid_bpchar))
+			else if (mdid->Equals(&CMDIdGPDB::m_mdid_bpchar) ||
+					 (base_mdid->IsValid() &&
+					  base_mdid->Equals(&CMDIdGPDB::m_mdid_bpchar)))
 			{
 				hash = gpdb::HashBpChar((Datum) bytes);
 			}
-			else if (mdid->Equals(&CMDIdGPDB::m_mdid_char))
+			else if (mdid->Equals(&CMDIdGPDB::m_mdid_char) ||
+					 (base_mdid->IsValid() &&
+					  base_mdid->Equals(&CMDIdGPDB::m_mdid_char)))
 			{
 				hash = gpdb::HashChar((Datum) bytes);
 			}
-			else if (mdid->Equals(&CMDIdGPDB::m_mdid_name))
+			else if (mdid->Equals(&CMDIdGPDB::m_mdid_name) ||
+					 (base_mdid->IsValid() &&
+					  base_mdid->Equals(&CMDIdGPDB::m_mdid_name)))
 			{
 				hash = gpdb::HashName((Datum) bytes);
 			}

--- a/src/include/gpopt/gpdbwrappers.h
+++ b/src/include/gpopt/gpdbwrappers.h
@@ -609,6 +609,9 @@ List *GetIndexOpFamilies(Oid index_oid);
 // get oids of op classes for the merge join
 List *GetMergeJoinOpFamilies(Oid opno);
 
+// get the OID of base elementtype fora given typid
+Oid GetBaseType(Oid typid);
+
 // returns the result of evaluating 'expr' as an Expr. Caller keeps ownership of 'expr'
 // and takes ownership of the result
 Expr *EvaluateExpr(Expr *expr, Oid result_type, int32 typmod);

--- a/src/include/gpopt/translate/CTranslatorScalarToDXL.h
+++ b/src/include/gpopt/translate/CTranslatorScalarToDXL.h
@@ -314,7 +314,8 @@ public:
 
 	// extract the long int value of a datum
 	static LINT ExtractLintValueFromDatum(const IMDType *md_type, BOOL is_null,
-										  BYTE *bytes, ULONG len);
+										  BYTE *bytes, ULONG len,
+										  IMDId *base_mdid);
 
 	// datum to oid CDXLDatum
 	static CDXLDatum *TranslateOidDatumToDXL(CMemoryPool *mp,

--- a/src/test/regress/expected/domain.out
+++ b/src/test/regress/expected/domain.out
@@ -1145,3 +1145,66 @@ from
      1
 (1 row)
 
+--
+-- ORCA shouldn't fail for data corruption while translating query to DXL
+-- for a constant domain value of the following text related types:
+-- char, bpchar, name.
+-- github issue: https://github.com/greenplum-db/gpdb/issues/14155
+--
+create table test_table_14155(txtime timestamptz default now(), user_role text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'txtime' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create domain domainname as name;
+create function test_func_name(
+    i_msg text,
+    i_caller domainname = current_user
+) returns void language plpgsql as $$
+begin
+    insert into test_table_14155 (
+        txtime, user_role
+    )
+    select now(), i_caller;
+end
+$$;
+select * from test_func_name('test');
+ test_func_name 
+----------------
+ 
+(1 row)
+
+create domain domainchar as char;
+create function test_func_char(
+    i_msg text,
+    i_caller domainchar = 'a'
+) returns void language plpgsql as $$
+begin
+    insert into test_table_14155 (
+        txtime, user_role
+    )
+    select now(), i_caller;
+end
+$$;
+select * from test_func_char('test');
+ test_func_char 
+----------------
+ 
+(1 row)
+
+create domain domainbpchar as bpchar;
+create function test_func_bpchar(
+    i_msg text,
+    i_caller domainbpchar = 'test'
+) returns void language plpgsql as $$
+begin
+    insert into test_table_14155 (
+        txtime, user_role
+    )
+    select now(), i_caller;
+end
+$$;
+select * from test_func_bpchar('test');
+ test_func_bpchar 
+------------------
+ 
+(1 row)
+

--- a/src/test/regress/expected/domain_optimizer.out
+++ b/src/test/regress/expected/domain_optimizer.out
@@ -1146,3 +1146,66 @@ from
      1
 (1 row)
 
+--
+-- ORCA shouldn't fail for data corruption while translating query to DXL
+-- for a constant domain value of the following text related types:
+-- char, bpchar, name.
+-- github issue: https://github.com/greenplum-db/gpdb/issues/14155
+--
+create table test_table_14155(txtime timestamptz default now(), user_role text);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'txtime' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create domain domainname as name;
+create function test_func_name(
+    i_msg text,
+    i_caller domainname = current_user
+) returns void language plpgsql as $$
+begin
+    insert into test_table_14155 (
+        txtime, user_role
+    )
+    select now(), i_caller;
+end
+$$;
+select * from test_func_name('test');
+ test_func_name 
+----------------
+ 
+(1 row)
+
+create domain domainchar as char;
+create function test_func_char(
+    i_msg text,
+    i_caller domainchar = 'a'
+) returns void language plpgsql as $$
+begin
+    insert into test_table_14155 (
+        txtime, user_role
+    )
+    select now(), i_caller;
+end
+$$;
+select * from test_func_char('test');
+ test_func_char 
+----------------
+ 
+(1 row)
+
+create domain domainbpchar as bpchar;
+create function test_func_bpchar(
+    i_msg text,
+    i_caller domainbpchar = 'test'
+) returns void language plpgsql as $$
+begin
+    insert into test_table_14155 (
+        txtime, user_role
+    )
+    select now(), i_caller;
+end
+$$;
+select * from test_func_bpchar('test');
+ test_func_bpchar 
+------------------
+ 
+(1 row)
+


### PR DESCRIPTION
Prior to this PR, while translating constant values for text related
domains like char, bpchar and name ORCA was calling the incorrect
hashing function. This lead to `data corrupt` error while Query to DXL
translation in ORCA. This PR fixes that issue by checking for the
basetype of such domain types and calling the corresponding hashing
function.

Fixes issue: https://github.com/greenplum-db/gpdb/issues/14155
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
