### PR TITLE
Revert "Fix postgres_fdw's libpq issue (#10617)"

### DIFF
--- a/contrib/postgres_fdw/Makefile
+++ b/contrib/postgres_fdw/Makefile
@@ -5,7 +5,7 @@ OBJS = postgres_fdw.o option.o deparse.o connection.o shippable.o $(WIN32RES)
 PGFILEDESC = "postgres_fdw - foreign data wrapper for PostgreSQL"
 
 PG_CPPFLAGS = -I$(libpq_srcdir)
-SHLIB_LINK_INTERNAL = -Wl,--exclude-libs=libpq.a -Wl,-Bstatic $(libpq) -Wl,-Bdynamic
+SHLIB_LINK_INTERNAL = $(libpq)
 
 EXTENSION = postgres_fdw
 DATA = postgres_fdw--1.0.sql

--- a/contrib/postgres_fdw/postgres_fdw.h
+++ b/contrib/postgres_fdw/postgres_fdw.h
@@ -18,32 +18,7 @@
 #include "nodes/pathnodes.h"
 #include "utils/relcache.h"
 
-/* postgres_fdw is compiled as a backend, it needs the server's
- * header files such as executor/tuptable.h. It also needs libpq
- * to connect to a remote postgres database, so it's statically
- * linked to libpq.a which is compiled as a frontend using
- * -DFRONTEND.
- *
- * But the struct PQconninfoOption's length is different between
- * backend and frontend, there is no "connofs" field in frontend.
- * When postgres_fdw calls the function "PQconndefaults" implemented
- * in libpq.a and uses the returned PQconninfoOption variable, it crashs,
- * because the PQconninfoOption variable returned by libpq.a doesn't contain
- * the "connofs" value, but the postgres_fdw thinks it has, so it crashes.
- *
- * We define FRONTEND here to include frontend libpq header files.
- */
-#ifdef LIBPQ_FE_H
-#error "postgres_fdw.h" must be included before "libpq-fe.h"
-#endif /* LIBPQ_FE_H */
-
-#ifndef FRONTEND
-#define FRONTEND
 #include "libpq-fe.h"
-#undef FRONTEND
-#else
-#include "libpq-fe.h"
-#endif /* FRONTEND */
 
 /*
  * FDW-specific planner information kept in RelOptInfo.fdw_private for a


### PR DESCRIPTION
This reverts commit 667f0c37bc6d7bce7be8b758652ef95ddb823e19.

It would also work without it, in the opposite way, it has two issues:

1, it failed to build on macOS, with an error "ld: unknown option: --exclude-libs=libpq.a"
2, after the 12 merge, it triggers a PostgreSQL's error: "libpq is incorrectly linked to backend functions"

Fixes https://github.com/greenplum-db/gpdb/issues/11400 and https://github.com/greenplum-db/gpdb/issues/11523

BTW, checkout https://github.com/greenplum-db/gpdb/pull/9462 if you have frontend/backend concern.