### PR TITLE
ao/co: don't dereference dangling pointers

### DIFF
--- a/src/backend/access/aocs/aocsam_handler.c
+++ b/src/backend/access/aocs/aocsam_handler.c
@@ -262,7 +262,16 @@ aoco_dml_finish(Relation relation)
 	AOCODMLState *state;
 	bool		 had_delete_desc = false;
 
-	state = remove_dml_state(RelationGetRelid(relation));
+	Oid relationOid = RelationGetRelid(relation);
+
+	Assert(aocoDMLStates.state_table);
+
+	state = (AOCODMLState *) hash_search(aocoDMLStates.state_table,
+										 &relationOid,
+										 HASH_FIND,
+										 NULL);
+
+	Assert(state);
 
 	if (state->deleteDesc)
 	{
@@ -310,6 +319,7 @@ aoco_dml_finish(Relation relation)
 		state->uniqueCheckDesc = NULL;
 	}
 
+	remove_dml_state(relationOid);
 }
 
 /*

--- a/src/backend/access/aocs/aocsam_handler.c
+++ b/src/backend/access/aocs/aocsam_handler.c
@@ -221,7 +221,7 @@ find_dml_state(const Oid relationOid)
  *
  * Should be called exactly once per relation.
  */
-static inline AOCODMLState *
+static inline void
 remove_dml_state(const Oid relationOid)
 {
 	AOCODMLState *state;
@@ -238,7 +238,7 @@ remove_dml_state(const Oid relationOid)
 		aocoDMLStates.last_used_state->relationOid == relationOid)
 		aocoDMLStates.last_used_state = NULL;
 
-	return state;
+	return;
 }
 
 /*

--- a/src/backend/access/appendonly/appendonlyam_handler.c
+++ b/src/backend/access/appendonly/appendonlyam_handler.c
@@ -223,7 +223,16 @@ appendonly_dml_finish(Relation relation)
 	AppendOnlyDMLState *state;
 	bool				had_delete_desc = false;
 
-	state = remove_dml_state(RelationGetRelid(relation));
+	Oid relationOid = RelationGetRelid(relation);
+
+	Assert(appendOnlyDMLStates.state_table);
+
+	state = (AppendOnlyDMLState *)hash_search(appendOnlyDMLStates.state_table,
+											  &relationOid,
+											  HASH_FIND,
+											  NULL);
+
+	Assert(state);
 
 	if (state->deleteDesc)
 	{
@@ -270,6 +279,8 @@ appendonly_dml_finish(Relation relation)
 		pfree(state->uniqueCheckDesc);
 		state->uniqueCheckDesc = NULL;
 	}
+
+	remove_dml_state(relationOid);
 }
 
 /*

--- a/src/backend/access/appendonly/appendonlyam_handler.c
+++ b/src/backend/access/appendonly/appendonlyam_handler.c
@@ -177,7 +177,7 @@ find_dml_state(const Oid relationOid)
  *
  * Should be called exactly once per relation.
  */
-static inline AppendOnlyDMLState *
+static inline void
 remove_dml_state(const Oid relationOid)
 {
 	AppendOnlyDMLState *state;
@@ -194,7 +194,7 @@ remove_dml_state(const Oid relationOid)
 			appendOnlyDMLStates.last_used_state->relationOid == relationOid)
 		appendOnlyDMLStates.last_used_state = NULL;
 
-	return state;
+	return;
 }
 
 /*


### PR DESCRIPTION
hash_search(,,HASH_REMOVE,) returns a dangling pointer that shouldn't be dereferenced.