### PR TITLE
Replaced gpscp_help with gpsync_help

### DIFF
--- a/gpMgmt/doc/Makefile
+++ b/gpMgmt/doc/Makefile
@@ -11,7 +11,7 @@ DOCS= gpactivatestandby_help gpaddmirrors_help gpcheckperf_help \
 	gpconfig_help gpdeletesystem_help gpexpand_help gpfdist_help \
 	gpinitstandby_help gpinitsystem_help gpload_help gplogfilter_help \
 	gpmapreduce_help gppkg_help gprecoverseg_help \
-	gpreload_help gpscp_help gpssh-exkeys_help gpssh_help gpstart_help \
+	gpreload_help gpsync_help gpssh-exkeys_help gpssh_help gpstart_help \
 	gpstate_help gpstop_help
 
 installdirs:


### PR DESCRIPTION
As part of scp to rsync replacement task gpscp_help file was renamed to gpsync_help https://github.com/greenplum-db/gpdb/pull/14392, so did the code clean up and replaced all the references of gpscp_help with gpsync_help.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
