### PR TITLE
Remove FIXME in test index_constraint_naming_upgrade

### DIFF
--- a/src/test/regress/expected/index_constraint_naming_upgrade.out
+++ b/src/test/regress/expected/index_constraint_naming_upgrade.out
@@ -58,47 +58,52 @@ SELECT table_name,* FROM constraints_and_indices() WHERE table_name::text='table
 DROP TYPE table_collision_a_b_key;
 -- *************************************************************
 -- Exchange Partition Scenario
--- Create a partition table with a primary key constraint
+-- Create two partition tables with primary key constraints.
+-- One to drop in this test, and one to be testd druing upgrade.
 CREATE TABLE part_table_for_upgrade (a INT, b INT) DISTRIBUTED BY (a) PARTITION BY RANGE(b) (PARTITION alpha  END (3), PARTITION beta START (3));
+CREATE TABLE part_table_for_upgrade2 (a INT, b INT) DISTRIBUTED BY (a) PARTITION BY RANGE(b) (PARTITION alpha  END (3), PARTITION beta START (3));
 ALTER TABLE part_table_for_upgrade ADD PRIMARY KEY(a, b);
+ALTER TABLE part_table_for_upgrade2 ADD PRIMARY KEY(a, b);
 -- Create a table to be used as a partition exchange.
 CREATE TABLE like_table (like part_table_for_upgrade INCLUDING CONSTRAINTS INCLUDING INDEXES) DISTRIBUTED BY (a) ;
+CREATE TABLE like_table2 (like part_table_for_upgrade INCLUDING CONSTRAINTS INCLUDING INDEXES) DISTRIBUTED BY (a) ;
 -- show constraint and index names
-SELECT table_name,* FROM constraints_and_indices() WHERE table_name::text='part_table_for_upgrade';
-       table_name       |       table_name       |       constraint_name       |         index_name          | constraint_type 
-------------------------+------------------------+-----------------------------+-----------------------------+-----------------
- part_table_for_upgrade | part_table_for_upgrade | part_table_for_upgrade_pkey | part_table_for_upgrade_pkey | p
-(1 row)
+SELECT table_name,* FROM constraints_and_indices() WHERE table_name::text IN ('part_table_for_upgrade', 'part_table_for_upgrade2');
+       table_name        |       table_name        |       constraint_name        |          index_name          | constraint_type 
+-------------------------+-------------------------+------------------------------+------------------------------+-----------------
+ part_table_for_upgrade  | part_table_for_upgrade  | part_table_for_upgrade_pkey  | part_table_for_upgrade_pkey  | p
+ part_table_for_upgrade2 | part_table_for_upgrade2 | part_table_for_upgrade2_pkey | part_table_for_upgrade2_pkey | p
+(2 rows)
 
-SELECT table_name,* FROM constraints_and_indices() WHERE table_name::text='like_table';
- table_name | table_name | constraint_name |   index_name    | constraint_type 
-------------+------------+-----------------+-----------------+-----------------
- like_table | like_table | like_table_pkey | like_table_pkey | p
-(1 row)
+SELECT table_name,* FROM constraints_and_indices() WHERE table_name::text IN ('like_table', 'like_table2');
+ table_name  | table_name  | constraint_name  |    index_name    | constraint_type 
+-------------+-------------+------------------+------------------+-----------------
+ like_table  | like_table  | like_table_pkey  | like_table_pkey  | p
+ like_table2 | like_table2 | like_table2_pkey | like_table2_pkey | p
+(2 rows)
 
 -- Exchange the beta partition with like_table.
 -- Everything gets swapped, but the constraint index name of like_table does not match with part_table_for_upgrade_1_prt_beta.
 ALTER TABLE part_table_for_upgrade EXCHANGE PARTITION beta WITH TABLE like_table;
+ALTER TABLE part_table_for_upgrade2 EXCHANGE PARTITION beta WITH TABLE like_table2;
 -- show constraint and index names for each table
-SELECT table_name,* FROM constraints_and_indices() WHERE table_name::text='part_table_for_upgrade';
-       table_name       |       table_name       |       constraint_name       |         index_name          | constraint_type 
-------------------------+------------------------+-----------------------------+-----------------------------+-----------------
- part_table_for_upgrade | part_table_for_upgrade | part_table_for_upgrade_pkey | part_table_for_upgrade_pkey | p
-(1 row)
+SELECT table_name,* FROM constraints_and_indices() WHERE table_name::text IN ('part_table_for_upgrade', 'part_table_for_upgrade2');
+       table_name        |       table_name        |       constraint_name        |          index_name          | constraint_type 
+-------------------------+-------------------------+------------------------------+------------------------------+-----------------
+ part_table_for_upgrade  | part_table_for_upgrade  | part_table_for_upgrade_pkey  | part_table_for_upgrade_pkey  | p
+ part_table_for_upgrade2 | part_table_for_upgrade2 | part_table_for_upgrade2_pkey | part_table_for_upgrade2_pkey | p
+(2 rows)
 
--- GPDB_12_MERGE_FIXME: only tables are renamed in exchange partition,
--- constraints or indexes used to be renamed as well pre-GPDB7, not
--- any more. Does it surprise users (functionally it doesn't affect
--- anything)?
-SELECT table_name,* FROM constraints_and_indices() WHERE table_name::text='like_table';
- table_name | table_name |            constraint_name             |               index_name               | constraint_type 
-------------+------------+----------------------------------------+----------------------------------------+-----------------
- like_table | like_table | part_table_for_upgrade_1_prt_beta_pkey | part_table_for_upgrade_1_prt_beta_pkey | p
-(1 row)
+-- only tables are renamed in exchange partition
+SELECT table_name,* FROM constraints_and_indices() WHERE table_name::text IN ('like_table', 'like_table2');
+ table_name  | table_name  |             constraint_name             |               index_name                | constraint_type 
+-------------+-------------+-----------------------------------------+-----------------------------------------+-----------------
+ like_table  | like_table  | part_table_for_upgrade_1_prt_beta_pkey  | part_table_for_upgrade_1_prt_beta_pkey  | p
+ like_table2 | like_table2 | part_table_for_upgrade2_1_prt_beta_pkey | part_table_for_upgrade2_1_prt_beta_pkey | p
+(2 rows)
 
--- Drop part_table_for_upgrade before upgrade since that is not where the issue is.
+-- Drop the first partition table, the constraint in like_table should NOT be dropped
 DROP TABLE part_table_for_upgrade CASCADE;
--- Verify that the constraint in like_table was NOT dropped
 SELECT table_name,* FROM constraints_and_indices() WHERE table_name::text='like_table';
  table_name | table_name |            constraint_name             |               index_name               | constraint_type 
 ------------+------------+----------------------------------------+----------------------------------------+-----------------


### PR DESCRIPTION
We used to rename index-backed constraints in the EXCHANGE PARTITION command in 6X. Now we don't. We've decided to keep that behavior in 7X after looking into the opposing arguments:

Argument #1. It might cause problem during upgrade.
- Firstly, we won't be using legacy syntax in the dump scripts so we just need to worry about the existing tables produced by EXCHANGE PARTITION. I.e. whether or not they can be restored correctly.
- For upgrading from 6X->7X, since those tables already have matched constraint and index names with the table names, we should be OK.
- For upgrading 7X->onward, since we implement EXCHANGE PARTIITON simply as a combination of upstream-syntax commands (see AtExecGPExchangePartition()), pg_upgrade should be able to handle them. We've verified that manually and the automated test should cover that too. In fact, this gives another point that we shouldn't do our own hacky things as part of EXCHANGE PARTITION which might confuse pg_upgrade.

Argument #2. It might surprise the users and their existing workloads.
- The indexed constraint names are all implicitly generated and shouldn't be directly used in most cases.
- They are not the only thing that will appear changed. E.g. the normal indexes (e.g. B-tree ones) will be too. So the decision to change one should be made with changing all of them.

More details see: https://docs.google.com/document/d/1enJdKYxkk5WFRV1WoqIgLgRxCGxOqI2nglJVE_Wglec

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
