### PR TITLE
Refactor SaveOidAssignments and RestoreOidAssignments logic.

### DIFF
--- a/src/backend/commands/matview.c
+++ b/src/backend/commands/matview.c
@@ -444,7 +444,7 @@ refresh_matview_datafill(DestReceiver *dest, Query *query,
 	 *
 	 * See Github Issue for details: https://github.com/greenplum-db/gpdb/issues/11956
 	 */
-	List       *saved_dispatch_oids = GetAssignedOidsForDispatch();
+	List       *saved_dispatch_oids = SaveOidAssignments();
 
 	/* Lock and rewrite, using a copy to preserve the original query. */
 	copied_query = copyObject(query);

--- a/src/include/catalog/oid_dispatch.h
+++ b/src/include/catalog/oid_dispatch.h
@@ -116,6 +116,7 @@ extern void RememberPreassignedIndexNameForChildIndex(Oid parentIdxOid, Oid chil
 /* Functions used in master and QE nodes */
 extern void PreserveOidAssignmentsOnCommit(void);
 extern void ClearOidAssignmentsOnCommit(void);
+extern List * SaveOidAssignments(void);
 extern void RestoreOidAssignments(List *oid_assignments);
 
 /* Functions used in binary upgrade */

--- a/src/test/regress/expected/oid_consistency.out
+++ b/src/test/regress/expected/oid_consistency.out
@@ -797,3 +797,17 @@ select verify('trigger_oid');
       1
 (1 row)
 
+-- Case for Issue: https://github.com/greenplum-db/gpdb/issues/14465
+create function func_fail_14465(int) returns int
+        immutable language plpgsql as $$
+begin
+        perform unwanted_grant();
+        raise warning 'owned';
+        return 1;
+exception when others then
+        return 2;
+end$$;
+create materialized view mv_14465 as select 1 as c;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'c' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create index on mv_14465 (c) where func_fail_14465(1) > 0;


### PR DESCRIPTION
The two functions SaveOidAssignments and RestoreOidAssignments should come together, before some procedures that do not want to touch the global vars (dispatch_oids or preassigned_oids), we need to first save the oid assignments, and then do the job, finally restore oid assignments. A typical usage should be as below:
   List *l = SaveOidAssignments();
   do_the_job();
   RestoreOidAssignments(l);

The global var dispatch_oids is only used on QD, and the global var preassigned_oids is only used on QEs. They are both Lists, in a specific memorycontext, normally the memorycontext will be reset at the end of transaction. Greenplum's MPP architecture need to make some OIDs consistent among coordinator and segments (like table OIDs). The oid assignments are generated on QD and then dispatched to QEs. A single SQL might involve sever dispatch events, for example, there are some functions involving SQLs and these functions are evaluated during planning stage before we dispatch the final Utility plan. We do not want to the dispatches during plannign stage to touch oid assignments.

Another subtle case that the pair of functions are useful is that subtransaction abort will lead to reset  of the oid assignments memory context. Subtransaction abort might happen for UDF with exception handling and nothing to do with the main statement needed to dispatch. That is why we deep copy the content to CurrentMemoryContext and reset oid assignment context during SaveOidAssignments and bring everything back during RestoreOidAssignments.

This commit adds the two functions before eval_constant_expressions() to make sure the procedure does not touch oid assignments.

Fix issue: https://github.com/greenplum-db/gpdb/issues/14465.
