### PR TITLE
Skip recovery of failed segment if it already has running pg_rewind

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/environment.py
+++ b/gpMgmt/test/behave/mgmt_utils/environment.py
@@ -185,3 +185,6 @@ def after_scenario(context, scenario):
         execute_sql('postgres', create_fault_query)
         reset_fault_query = "SELECT gp_inject_fault_infinite('all', 'reset', dbid) FROM gp_segment_configuration WHERE status='u';"
         execute_sql('postgres', reset_fault_query)
+
+    if os.getenv('SUSPEND_PG_REWIND') is not None:
+        del os.environ['SUSPEND_PG_REWIND']

--- a/src/bin/pg_rewind/pg_rewind.c
+++ b/src/bin/pg_rewind/pg_rewind.c
@@ -310,6 +310,18 @@ main(int argc, char **argv)
 	sanityChecks();
 
 	/*
+	 * SUSPEND_PG_REWIND is used for testing purposes. If set to true, the pg_rewind process will be
+	 * suspended indefinitely, so that it's entry can be checked in the pg_stat_activity table. The goal
+	 * being that we can run another instance of gprecoverseg and assert that it ignores recovery for
+	 * segments that already have an active pg_rewind process.
+	 */
+	while(getenv("SUSPEND_PG_REWIND") != NULL && getenv("SUSPEND_PG_REWIND") == "true")
+	{
+		sleep(1);
+		pg_log_info("pg_rewind suspended");
+	}
+
+	/*
 	 * If both clusters are already on the same timeline, there's nothing to
 	 * do.
 	 */


### PR DESCRIPTION
gprecoverseg should give warning and skip the recovery if there is already a running instance of pg_rewind for the segment that needs to be recovered.

Implementation:
pg_stat_activity contains entries for active pg_rewind processes. So to check for active pg_rewind processes for a failed segment, pg_stat_activity can be queried on it's source server.  Reasons to check for pg_stat_activity entry: 

  - pg_rewind is invoked using --source-server connection string as it needs libpq connection with source server, which will be remote to the target server and --source-pgdata can not be used in that case. Thus pg_stat_activity will always contain entry for active pg_rewind.
  - pg_rewind keeps a connection open throughout it's lifecycle, so pg_stat_activity will contain entries for active pg_rewind process till the end of execution.
  - gpstate uses the above mentioned approach (pg_stat_activity entry check) to check for incremental recoveries in progress. Thus, using the same approach will make it consistent everywhere.

Introduced an environment variable SUSPEND_PG_REWIND to use for testing purposes. If set to true, the pg_rewind process will be suspended indefinitely, so that it's entry can be checked in the pg_stat_activity table. The goal being that we can run another instance of gprecoverseg and assert that it ignores recovery for segments that already have an active pg_rewind process.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
