### PR TITLE
Docs - add pl/container enable_network parameter reference

### DIFF
--- a/gpdb-doc/markdown/utility_guide/ref/plcontainer-configuration.html.md
+++ b/gpdb-doc/markdown/utility_guide/ref/plcontainer-configuration.html.md
@@ -141,7 +141,7 @@ settings
     :   Optional.  Activates or deactivates  Docker logging for the container. The attribute value `yes` enables logging. The attribute value `no` deactivates logging \(the default\).
 
     enable\_network="\{yes \| no\}"
-    :   Optional. Activates or deactivates network access for the UDF container. The attribute value `yes` enables UDFs to access the network. The attribute value `no` deactivates network access \(the default\).
+    :   Optional. Available starting with PL/Container version 2.2, this attribute activates or deactivates network access for the UDF container. The attribute value `yes` enables UDFs to access the network. The attribute value `no` deactivates network access \(the default\).
 
     The Greenplum Database server configuration parameter [log\_min\_messages](../../ref_guide/config_params/guc-list.html) controls the PL/Container log level. The default log level is `warning`. For information about PL/Container log information, see [Notes](../../analytics/pl_container_using.html).
 

--- a/gpdb-doc/markdown/utility_guide/ref/plcontainer-configuration.html.md
+++ b/gpdb-doc/markdown/utility_guide/ref/plcontainer-configuration.html.md
@@ -44,6 +44,7 @@ This is an example file. Note that all XML elements, names, and attributes are c
         <command>/clientdir/rclient.sh</command>
         <shared_directory access="ro" container="/clientdir" host="/usr/local/greenplum-db/bin/plcontainer_clients"/>
         <setting use_container_logging="yes"/>
+        <setting enable_netowrk="no"/>
         <setting roles="gpadmin,user1"/>
     </runtime>
     <runtime>
@@ -138,6 +139,9 @@ settings
 
     use\_container\_logging="\{yes \| no\}"
     :   Optional.  Activates or deactivates  Docker logging for the container. The attribute value `yes` enables logging. The attribute value `no` deactivates logging \(the default\).
+
+    enable\_network="\{yes \| no\}"
+    :   Optional. Activates or deactivates network access for the UDF container. The attribute value `yes` enables UDFs to access the network. The attribute value `no` deactivates network access \(the default\).
 
     The Greenplum Database server configuration parameter [log\_min\_messages](../../ref_guide/config_params/guc-list.html) controls the PL/Container log level. The default log level is `warning`. For information about PL/Container log information, see [Notes](../../analytics/pl_container_using.html).
 


### PR DESCRIPTION
Add `enable_network` reference docs for next pl/container release.
