### PR TITLE
ao/co: Unique indexes: release readiness

### DIFF
--- a/src/backend/access/appendonly/README.md
+++ b/src/backend/access/appendonly/README.md
@@ -252,3 +252,10 @@ conflicts will still be detected. Depending on whether the concurrent
 transaction committed or is still in progress, the repeatable read transaction
 will raise a conflict or enter into xwait respectively. This behavior is table
 AM agnostic.
+
+Partial unique indexes: We don't have to do anything special for partial indexes.
+Keys not satisfying the partial index predicate are never inserted into the
+index, and hence there are no uniqueness checks triggered (see
+ExecInsertIndexTuples()). Also during partial unique index builds, keys that
+don't satisfy the partial index predicate are never inserted into the index
+(see *_index_build_range_scan()).

--- a/src/backend/access/appendonly/README.md
+++ b/src/backend/access/appendonly/README.md
@@ -240,3 +240,15 @@ index entries will still point to the segment being compacted. This will be the
 case up until the index entries are bulk deleted, but by then the new index
 entries along with new block directory rows would already have been written and
 would be able to answer uniqueness checks.
+
+Transaction isolation: Since uniqueness checks utilize the special dirty
+snapshot, these checks can cross transaction isolation boundaries. For instance,
+let us consider what will happen if we are in a repeatable read transaction and
+we insert a key that was inserted by a concurrent transaction. Further let's say
+that the repeatable read transaction's snapshot was taken before the concurrent
+transaction started. This means that the repeatable read transaction won't be
+able to see the conflicting key (for eg. with a SELECT). In spite of that
+conflicts will still be detected. Depending on whether the concurrent
+transaction committed or is still in progress, the repeatable read transaction
+will raise a conflict or enter into xwait respectively. This behavior is table
+AM agnostic.

--- a/src/backend/access/appendonly/README.md
+++ b/src/backend/access/appendonly/README.md
@@ -185,8 +185,11 @@ to protect the scan over pg_aoseg.
 To answer uniqueness checks for AO/AOCO tables, we have a complication. Unlike
 heap, in AO/CO we don't store the xmin/xmax fields in the tuples. So, we have to
 rely on block directory rows that "cover" the data rows to satisfy index lookups.
-The xmin/xmax of the block directory row(s) help determine tuple visibility for
-uniqueness checks.
+Since the block directory is maintained as a heap table, visibility checks on it
+are identical to any other heap table: the xmin/xmax of the block directory
+row(s) will be leveraged. This means we don't have to write any special
+visibility checking code ourselves, nor do we need to worry about transactions
+vs subtransactions.
 
 Since block directory rows are written usually much after the data row has been
 inserted, there are windows in which there is no block  directory row on disk

--- a/src/backend/access/appendonly/appendonly_visimap.c
+++ b/src/backend/access/appendonly/appendonly_visimap.c
@@ -907,6 +907,11 @@ void AppendOnlyVisimap_Init_forUniqueCheck(
 	if (!OidIsValid(visimaprelid) || !OidIsValid(visimapidxid))
 		elog(ERROR, "Could not find block directory for relation: %u", aoRel->rd_id);
 
+	ereportif(Debug_appendonly_print_visimap, LOG,
+			  (errmsg("Append-only visimap init for unique checks"),
+				  errdetail("(aoRel = %u, visimaprel = %u, visimapidxrel = %u)",
+							aoRel->rd_id, visimaprelid, visimapidxid)));
+
 	AppendOnlyVisimap_Init(visiMap,
 						   visimaprelid,
 						   visimapidxid,
@@ -918,11 +923,18 @@ void
 AppendOnlyVisimap_Finish_forUniquenessChecks(
 	AppendOnlyVisimap *visiMap)
 {
+	AppendOnlyVisimapStore *visimapStore = &visiMap->visimapStore;
 	/*
 	 * The snapshot was either reset to NULL in between calls or already cleaned
 	 * up (if this was part of an update command)
 	 */
-	Assert(visiMap->visimapStore.snapshot == InvalidSnapshot);
+	Assert(visimapStore->snapshot == InvalidSnapshot);
+
+	ereportif(Debug_appendonly_print_visimap, LOG,
+			  (errmsg("Append-only visimap finish for unique checks"),
+				  errdetail("(visimaprel = %u, visimapidxrel = %u)",
+							visimapStore->visimapRelation->rd_id,
+							visimapStore->visimapRelation->rd_id)));
 
 	AppendOnlyVisimapStore_Finish(&visiMap->visimapStore, AccessShareLock);
 	AppendOnlyVisimapEntry_Finish(&visiMap->visimapEntry);

--- a/src/backend/access/appendonly/appendonlyblockdirectory.c
+++ b/src/backend/access/appendonly/appendonlyblockdirectory.c
@@ -1577,8 +1577,10 @@ AppendOnlyBlockDirectory_End_forUniqueChecks(AppendOnlyBlockDirectory *blockDire
 	/* This must have been reset after each uniqueness check */
 	Assert(blockDirectory->appendOnlyMetaDataSnapshot == InvalidSnapshot);
 
-	if (blockDirectory->blkdirIdx)
-		index_close(blockDirectory->blkdirIdx, AccessShareLock);
+	Assert(RelationIsValid(blockDirectory->blkdirIdx));
+	Assert(RelationIsValid(blockDirectory->blkdirRel));
+
+	index_close(blockDirectory->blkdirIdx, AccessShareLock);
 	heap_close(blockDirectory->blkdirRel, AccessShareLock);
 
 	MemoryContextDelete(blockDirectory->memoryContext);

--- a/src/backend/access/appendonly/appendonlyblockdirectory.c
+++ b/src/backend/access/appendonly/appendonlyblockdirectory.c
@@ -258,6 +258,11 @@ AppendOnlyBlockDirectory_Init_forUniqueChecks(
 	if (!OidIsValid(blkdirrelid) || !OidIsValid(blkdiridxid))
 		elog(ERROR, "Could not find block directory for relation: %u", aoRel->rd_id);
 
+	ereportif(Debug_appendonly_print_blockdirectory, LOG,
+			  (errmsg("Append-only block directory init for unique checks"),
+			   errdetail("(aoRel = %u, blkdirrel = %u, blkdiridxrel = %u, numColumnGroups = %d)",
+						 aoRel->rd_id, blkdirrelid, blkdiridxid, numColumnGroups)));
+
 	blockDirectory->aoRel = aoRel;
 	blockDirectory->isAOCol = RelationIsAoCols(aoRel);
 
@@ -1579,6 +1584,13 @@ AppendOnlyBlockDirectory_End_forUniqueChecks(AppendOnlyBlockDirectory *blockDire
 
 	Assert(RelationIsValid(blockDirectory->blkdirIdx));
 	Assert(RelationIsValid(blockDirectory->blkdirRel));
+
+	ereportif(Debug_appendonly_print_blockdirectory, LOG,
+			  (errmsg("Append-only block directory end for unique checks"),
+				  errdetail("(aoRel = %u, blkdirrel = %u, blkdiridxrel = %u)",
+							blockDirectory->aoRel->rd_id,
+							blockDirectory->blkdirRel->rd_id,
+							blockDirectory->blkdirIdx->rd_id)));
 
 	index_close(blockDirectory->blkdirIdx, AccessShareLock);
 	heap_close(blockDirectory->blkdirRel, AccessShareLock);

--- a/src/backend/commands/indexcmds.c
+++ b/src/backend/commands/indexcmds.c
@@ -948,12 +948,6 @@ DefineIndex(Oid relationId,
 
 	if (stmt->unique && RelationIsAppendOptimized(rel))
 	{
-		/* XXX: Remove when unique indexes are fully supported on AO/CO tables. */
-		if (!gp_appendonly_enable_unique_index)
-			ereport(ERROR,
-					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-						errmsg("append-only tables do not support unique indexes")));
-
 		if (stmt->concurrent)
 			ereport(ERROR,
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -14242,19 +14242,6 @@ ATPrepSetAccessMethod(AlteredTableInfo *tab, Relation rel, const char *amname)
 	if (rel->rd_rel->relam == amoid)
 		return;
 
-	/*
-	 * Since we don't support unique indexes for AO/AOCO tables, ban
-	 * heap->AO/AOCO in case the heap table has a unique index.
-	 */
-	if (rel->rd_rel->relam == HEAP_TABLE_AM_OID &&
-		(amoid == AO_ROW_TABLE_AM_OID || amoid == AO_COLUMN_TABLE_AM_OID))
-	{
-		if (relationHasUniqueIndex(rel))
-				ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-					errmsg("append-only tables do not support unique indexes"),
-					errdetail("heap table \"%s\" being altered contains unique index", RelationGetRelationName(rel))));
-	}
-
 	/* Save info for Phase 3 to do the real work */
 	tab->rewrite |= AT_REWRITE_ACCESS_METHOD;
 	tab->newAccessMethod = amoid;

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -137,7 +137,6 @@ bool        Test_print_prefetch_joinqual = false;
 bool		Test_copy_qd_qe_split = false;
 bool		gp_permit_relation_node_change = false;
 int			gp_max_local_distributed_cache = 1024;
-bool		gp_appendonly_enable_unique_index = false;
 bool		gp_appendonly_verify_block_checksums = true;
 bool		gp_appendonly_verify_write_block = false;
 bool		gp_appendonly_compaction = true;
@@ -834,17 +833,6 @@ struct config_bool ConfigureNamesBool_gp[] =
 			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&gp_debug_pgproc,
-		false,
-		NULL, NULL, NULL
-	},
-
-	{
-		{"gp_appendonly_enable_unique_index", PGC_USERSET, DEVELOPER_OPTIONS,
-		 gettext_noop("Enable unique indexes on AO/CO tables (experimental)."),
-		 NULL,
-		 GUC_NOT_IN_SAMPLE | GUC_NO_SHOW_ALL
-		},
-		&gp_appendonly_enable_unique_index,
 		false,
 		NULL, NULL, NULL
 	},

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -285,7 +285,6 @@ extern bool Debug_bitmap_print_insert;
 extern bool enable_checksum_on_tables;
 extern int  gp_max_local_distributed_cache;
 extern bool gp_local_distributed_cache_stats;
-extern bool gp_appendonly_enable_unique_index;
 extern bool gp_appendonly_verify_block_checksums;
 extern bool gp_appendonly_verify_write_block;
 extern bool gp_appendonly_compaction;

--- a/src/include/utils/sync_guc_name.h
+++ b/src/include/utils/sync_guc_name.h
@@ -13,7 +13,6 @@
 		"gin_fuzzy_search_limit",
 		"gin_pending_list_limit",
 		"gp_allow_date_field_width_5digits",
-		"gp_appendonly_enable_unique_index",
 		"gp_blockdirectory_entry_min_range",
 		"gp_blockdirectory_minipage_size",
 		"gp_debug_linger",

--- a/src/test/isolation2/expected/ao_blkdir.out
+++ b/src/test/isolation2/expected/ao_blkdir.out
@@ -233,8 +233,6 @@ SELECT (gp_toolkit.__gp_aoblkdir('ao_blkdir_test')).* FROM gp_dist_random('gp_id
 -- Unique index white box tests
 DROP TABLE ao_blkdir_test;
 DROP
-SET gp_appendonly_enable_unique_index TO ON;
-SET
 CREATE TABLE ao_blkdir_test(i int UNIQUE, j int) USING ao_row DISTRIBUTED BY (i);
 CREATE
 
@@ -316,8 +314,6 @@ COMMIT
 
 DROP TABLE ao_blkdir_test;
 DROP
-RESET gp_appendonly_enable_unique_index;
-RESET
 
 --------------------------------------------------------------------------------
 -- AOCO tables
@@ -721,8 +717,6 @@ SELECT (gp_toolkit.__gp_aoblkdir('aoco_blkdir_test')).* FROM gp_dist_random('gp_
 -- Unique index white box tests
 DROP TABLE aoco_blkdir_test;
 DROP
-SET gp_appendonly_enable_unique_index TO ON;
-SET
 CREATE TABLE aoco_blkdir_test(h int, i int UNIQUE, j int) USING ao_column DISTRIBUTED BY (i);
 CREATE
 
@@ -823,5 +817,3 @@ DETAIL:  Key (i)=(2) already exists.
 
 DROP TABLE aoco_blkdir_test;
 DROP
-RESET gp_appendonly_enable_unique_index;
-RESET

--- a/src/test/isolation2/expected/ao_unique_index.out
+++ b/src/test/isolation2/expected/ao_unique_index.out
@@ -405,8 +405,60 @@ CONTEXT:  COPY unique_index_ao_row, line 1
 -- now that tx 1 was aborted, tx 2 is successful.
 2<:  <... completed>
 COPY 3
+1: END;
+END
 
 DROP TABLE unique_index_ao_row;
 DROP
+
+--------------------------------------------------------------------------------
+-------------------- Smoke tests for subtransactions ---------------------------
+--------------------------------------------------------------------------------
+CREATE TABLE unique_index_ao_row (a INT unique) USING ao_row DISTRIBUTED REPLICATED;
+CREATE
+
+1: BEGIN;
+BEGIN
+1: SAVEPOINT a;
+SAVEPOINT
+1: INSERT INTO unique_index_ao_row VALUES(1);
+INSERT 1
+
+-- concurrent tx inserting conflicting row should block.
+2: BEGIN;
+BEGIN
+2&: INSERT INTO unique_index_ao_row VALUES(1);  <waiting ...>
+-- concurrent tx inserting non-conflicting row should be successful.
+3: INSERT INTO unique_index_ao_row VALUES(2);
+INSERT 1
+
+-- conflict should be detected within the same subtx.
+1: INSERT INTO unique_index_ao_row VALUES(1);
+ERROR:  duplicate key value violates unique constraint "unique_index_ao_row_a_key"  (seg2 192.168.0.148:7004 pid=3396954)
+DETAIL:  Key (a)=(1) already exists.
+-- the concurrent tx should now succeed.
+2<:  <... completed>
+INSERT 1
+2: ABORT;
+ABORT
+
+-- after rolling back to the savepoint, we should be able to re-insert the key
+1: ROLLBACK TO SAVEPOINT a;
+ROLLBACK
+1: INSERT INTO unique_index_ao_row VALUES(1);
+INSERT 1
+1: COMMIT;
+COMMIT
+
+SELECT * FROM unique_index_ao_row;
+ a 
+---
+ 1 
+ 2 
+(2 rows)
+
+DROP TABLE unique_index_ao_row;
+DROP
+
 RESET gp_appendonly_enable_unique_index;
 RESET

--- a/src/test/isolation2/expected/ao_unique_index.out
+++ b/src/test/isolation2/expected/ao_unique_index.out
@@ -460,5 +460,69 @@ SELECT * FROM unique_index_ao_row;
 DROP TABLE unique_index_ao_row;
 DROP
 
+--------------------------------------------------------------------------------
+-------------------- Smoke tests for repeatable read ---------------------------
+--------------------------------------------------------------------------------
+
+-- Test that shows that unique index checks transcend transaction isolation
+-- boundaries.
+
+CREATE TABLE unique_index_ao_row (a INT unique) USING ao_row DISTRIBUTED REPLICATED;
+CREATE
+
+-- Begin two txs with tx level snapshot taken early.
+1: BEGIN ISOLATION LEVEL REPEATABLE READ;
+BEGIN
+1: SELECT * FROM unique_index_ao_row;
+ a 
+---
+(0 rows)
+2: BEGIN ISOLATION LEVEL REPEATABLE READ;
+BEGIN
+2: SELECT * FROM unique_index_ao_row;
+ a 
+---
+(0 rows)
+
+-- Now begin a concurrent transaction which inserts a key.
+3: BEGIN;
+BEGIN
+3: INSERT INTO unique_index_ao_row VALUES(1);
+INSERT 1
+
+-- And another transaction inserts a key and commits.
+INSERT INTO unique_index_ao_row VALUES(2);
+INSERT 1
+
+-- Tx should block on insert of conflicting key, even though it can't "see" the
+-- conflicting key due to its isolation level.
+1: SELECT * FROM unique_index_ao_row;
+ a 
+---
+(0 rows)
+1&: INSERT INTO unique_index_ao_row VALUES(1);  <waiting ...>
+
+3: ABORT;
+ABORT
+1<:  <... completed>
+INSERT 1
+1: ABORT;
+ABORT
+
+-- Tx should raise a conflict, even though it can't "see" the conflicting key
+-- due to its isolation level.
+2: SELECT * FROM unique_index_ao_row;
+ a 
+---
+(0 rows)
+2: INSERT INTO unique_index_ao_row VALUES(2);
+ERROR:  duplicate key value violates unique constraint "unique_index_ao_row_a_key"  (seg1 192.168.0.148:7003 pid=3417060)
+DETAIL:  Key (a)=(2) already exists.
+2: ABORT;
+ABORT
+
+DROP TABLE unique_index_ao_row;
+DROP
+
 RESET gp_appendonly_enable_unique_index;
 RESET

--- a/src/test/isolation2/expected/ao_unique_index.out
+++ b/src/test/isolation2/expected/ao_unique_index.out
@@ -6,9 +6,6 @@
 -- us to predict block directory entries without having to worry about the
 -- table's distribution.
 
-SET gp_appendonly_enable_unique_index TO ON;
-SET
-
 -- Case 1: Conflict with committed transaction----------------------------------
 CREATE TABLE unique_index_ao_row (a INT unique) USING ao_row DISTRIBUTED REPLICATED;
 CREATE
@@ -523,6 +520,3 @@ ABORT
 
 DROP TABLE unique_index_ao_row;
 DROP
-
-RESET gp_appendonly_enable_unique_index;
-RESET

--- a/src/test/isolation2/expected/aocs_unique_index.out
+++ b/src/test/isolation2/expected/aocs_unique_index.out
@@ -460,5 +460,69 @@ SELECT * FROM unique_index_ao_column;
 DROP TABLE unique_index_ao_column;
 DROP
 
+--------------------------------------------------------------------------------
+-------------------- Smoke tests for repeatable read ---------------------------
+--------------------------------------------------------------------------------
+
+-- Test that shows that unique index checks transcend transaction isolation
+-- boundaries.
+
+CREATE TABLE unique_index_ao_column (a INT unique) USING ao_column DISTRIBUTED REPLICATED;
+CREATE
+
+-- Begin two txs with tx level snapshot taken early.
+1: BEGIN ISOLATION LEVEL REPEATABLE READ;
+BEGIN
+1: SELECT * FROM unique_index_ao_column;
+ a 
+---
+(0 rows)
+2: BEGIN ISOLATION LEVEL REPEATABLE READ;
+BEGIN
+2: SELECT * FROM unique_index_ao_column;
+ a 
+---
+(0 rows)
+
+-- Now begin a concurrent transaction which inserts a key.
+3: BEGIN;
+BEGIN
+3: INSERT INTO unique_index_ao_column VALUES(1);
+INSERT 1
+
+-- And another transaction inserts a key and commits.
+INSERT INTO unique_index_ao_column VALUES(2);
+INSERT 1
+
+-- Tx should block on insert of conflicting key, even though it can't "see" the
+-- conflicting key due to its isolation level.
+1: SELECT * FROM unique_index_ao_column;
+ a 
+---
+(0 rows)
+1&: INSERT INTO unique_index_ao_column VALUES(1);  <waiting ...>
+
+3: ABORT;
+ABORT
+1<:  <... completed>
+INSERT 1
+1: ABORT;
+ABORT
+
+-- Tx should raise a conflict, even though it can't "see" the conflicting key
+-- due to its isolation level.
+2: SELECT * FROM unique_index_ao_column;
+ a 
+---
+(0 rows)
+2: INSERT INTO unique_index_ao_column VALUES(2);
+ERROR:  duplicate key value violates unique constraint "unique_index_ao_column_a_key"  (seg0 192.168.0.148:7002 pid=3417500)
+DETAIL:  Key (a)=(2) already exists.
+2: ABORT;
+ABORT
+
+DROP TABLE unique_index_ao_column;
+DROP
+
 RESET gp_appendonly_enable_unique_index;
 RESET

--- a/src/test/isolation2/expected/aocs_unique_index.out
+++ b/src/test/isolation2/expected/aocs_unique_index.out
@@ -6,9 +6,6 @@
 -- us to predict block directory entries without having to worry about the
 -- table's distribution.
 
-SET gp_appendonly_enable_unique_index TO ON;
-SET
-
 -- Case 1: Conflict with committed transaction----------------------------------
 CREATE TABLE unique_index_ao_column (a bigint unique) USING ao_column DISTRIBUTED REPLICATED;
 CREATE
@@ -523,6 +520,3 @@ ABORT
 
 DROP TABLE unique_index_ao_column;
 DROP
-
-RESET gp_appendonly_enable_unique_index;
-RESET

--- a/src/test/isolation2/expected/aocs_unique_index.out
+++ b/src/test/isolation2/expected/aocs_unique_index.out
@@ -405,8 +405,60 @@ CONTEXT:  COPY unique_index_ao_column, line 1
 -- now that tx 1 was aborted, tx 2 is successful.
 2<:  <... completed>
 COPY 3
+1: END;
+END
 
 DROP TABLE unique_index_ao_column;
 DROP
+
+--------------------------------------------------------------------------------
+-------------------- Smoke tests for subtransactions ---------------------------
+--------------------------------------------------------------------------------
+CREATE TABLE unique_index_ao_column (a INT unique) USING ao_column DISTRIBUTED REPLICATED;
+CREATE
+
+1: BEGIN;
+BEGIN
+1: SAVEPOINT a;
+SAVEPOINT
+1: INSERT INTO unique_index_ao_column VALUES(1);
+INSERT 1
+
+-- concurrent tx inserting conflicting row should block.
+2: BEGIN;
+BEGIN
+2&: INSERT INTO unique_index_ao_column VALUES(1);  <waiting ...>
+-- concurrent tx inserting non-conflicting row should be successful.
+3: INSERT INTO unique_index_ao_column VALUES(2);
+INSERT 1
+
+-- conflict should be detected within the same subtx.
+1: INSERT INTO unique_index_ao_column VALUES(1);
+ERROR:  duplicate key value violates unique constraint "unique_index_ao_column_a_key"  (seg1 192.168.0.148:7003 pid=3397768)
+DETAIL:  Key (a)=(1) already exists.
+-- the concurrent tx should now succeed.
+2<:  <... completed>
+INSERT 1
+2: ABORT;
+ABORT
+
+-- after rolling back to the savepoint, we should be able to re-insert the key
+1: ROLLBACK TO SAVEPOINT a;
+ROLLBACK
+1: INSERT INTO unique_index_ao_column VALUES(1);
+INSERT 1
+1: COMMIT;
+COMMIT
+
+SELECT * FROM unique_index_ao_column;
+ a 
+---
+ 1 
+ 2 
+(2 rows)
+
+DROP TABLE unique_index_ao_column;
+DROP
+
 RESET gp_appendonly_enable_unique_index;
 RESET

--- a/src/test/isolation2/input/uao/ao_unique_index_vacuum.source
+++ b/src/test/isolation2/input/uao/ao_unique_index_vacuum.source
@@ -1,8 +1,6 @@
 -- Test cases to cover VACUUM and concurrent INSERT behavior on append-optimized
 -- tables with unique indexes.
 
-SET gp_appendonly_enable_unique_index TO ON;
-
 -- Case 1: Basic case with a few deleted tuples---------------------------------
 CREATE TABLE unique_index_vacuum_@amname@(i int UNIQUE) USING @amname@
     DISTRIBUTED REPLICATED;

--- a/src/test/isolation2/output/uao/ao_unique_index_vacuum.source
+++ b/src/test/isolation2/output/uao/ao_unique_index_vacuum.source
@@ -1,9 +1,6 @@
 -- Test cases to cover VACUUM and concurrent INSERT behavior on append-optimized
 -- tables with unique indexes.
 
-SET gp_appendonly_enable_unique_index TO ON;
-SET
-
 -- Case 1: Basic case with a few deleted tuples---------------------------------
 CREATE TABLE unique_index_vacuum_@amname@(i int UNIQUE) USING @amname@ DISTRIBUTED REPLICATED;
 CREATE

--- a/src/test/isolation2/sql/ao_blkdir.sql
+++ b/src/test/isolation2/sql/ao_blkdir.sql
@@ -43,7 +43,6 @@ WHERE gp_segment_id = 0 ORDER BY 1,2,3,4,5;
 
 -- Unique index white box tests
 DROP TABLE ao_blkdir_test;
-SET gp_appendonly_enable_unique_index TO ON;
 CREATE TABLE ao_blkdir_test(i int UNIQUE, j int) USING ao_row DISTRIBUTED BY (i);
 
 SELECT gp_inject_fault('appendonly_insert', 'suspend', '', '', 'ao_blkdir_test', 1, 1, 0, dbid)
@@ -94,7 +93,6 @@ WHERE gp_segment_id = 0 ORDER BY 1,2,3,4,5;
 WHERE gp_segment_id = 0 ORDER BY 1,2,3,4,5;
 
 DROP TABLE ao_blkdir_test;
-RESET gp_appendonly_enable_unique_index;
 
 --------------------------------------------------------------------------------
 -- AOCO tables
@@ -139,7 +137,6 @@ WHERE gp_segment_id = 0 ORDER BY 1,2,3,4,5;
 
 -- Unique index white box tests
 DROP TABLE aoco_blkdir_test;
-SET gp_appendonly_enable_unique_index TO ON;
 CREATE TABLE aoco_blkdir_test(h int, i int UNIQUE, j int) USING ao_column DISTRIBUTED BY (i);
 
 SELECT gp_inject_fault('appendonly_insert', 'suspend', '', '', 'aoco_blkdir_test', 1, 1, 0, dbid)
@@ -202,4 +199,3 @@ FROM gp_segment_configuration WHERE role = 'p' AND content = 0;
 4: INSERT INTO aoco_blkdir_test VALUES (2, 2);
 
 DROP TABLE aoco_blkdir_test;
-RESET gp_appendonly_enable_unique_index;

--- a/src/test/isolation2/sql/ao_unique_index.sql
+++ b/src/test/isolation2/sql/ao_unique_index.sql
@@ -305,4 +305,44 @@ SELECT * FROM unique_index_ao_row;
 
 DROP TABLE unique_index_ao_row;
 
+--------------------------------------------------------------------------------
+-------------------- Smoke tests for repeatable read ---------------------------
+--------------------------------------------------------------------------------
+
+-- Test that shows that unique index checks transcend transaction isolation
+-- boundaries.
+
+CREATE TABLE unique_index_ao_row (a INT unique) USING ao_row
+    DISTRIBUTED REPLICATED;
+
+-- Begin two txs with tx level snapshot taken early.
+1: BEGIN ISOLATION LEVEL REPEATABLE READ;
+1: SELECT * FROM unique_index_ao_row;
+2: BEGIN ISOLATION LEVEL REPEATABLE READ;
+2: SELECT * FROM unique_index_ao_row;
+
+-- Now begin a concurrent transaction which inserts a key.
+3: BEGIN;
+3: INSERT INTO unique_index_ao_row VALUES(1);
+
+-- And another transaction inserts a key and commits.
+INSERT INTO unique_index_ao_row VALUES(2);
+
+-- Tx should block on insert of conflicting key, even though it can't "see" the
+-- conflicting key due to its isolation level.
+1: SELECT * FROM unique_index_ao_row;
+1&: INSERT INTO unique_index_ao_row VALUES(1);
+
+3: ABORT;
+1<:
+1: ABORT;
+
+-- Tx should raise a conflict, even though it can't "see" the conflicting key
+-- due to its isolation level.
+2: SELECT * FROM unique_index_ao_row;
+2: INSERT INTO unique_index_ao_row VALUES(2);
+2: ABORT;
+
+DROP TABLE unique_index_ao_row;
+
 RESET gp_appendonly_enable_unique_index;

--- a/src/test/isolation2/sql/ao_unique_index.sql
+++ b/src/test/isolation2/sql/ao_unique_index.sql
@@ -6,8 +6,6 @@
 -- us to predict block directory entries without having to worry about the
 -- table's distribution.
 
-SET gp_appendonly_enable_unique_index TO ON;
-
 -- Case 1: Conflict with committed transaction----------------------------------
 CREATE TABLE unique_index_ao_row (a INT unique) USING ao_row
     DISTRIBUTED REPLICATED;
@@ -344,5 +342,3 @@ INSERT INTO unique_index_ao_row VALUES(2);
 2: ABORT;
 
 DROP TABLE unique_index_ao_row;
-
-RESET gp_appendonly_enable_unique_index;

--- a/src/test/isolation2/sql/aocs_unique_index.sql
+++ b/src/test/isolation2/sql/aocs_unique_index.sql
@@ -270,6 +270,39 @@ CREATE TABLE unique_index_ao_column (a INT unique) USING ao_column
 1: COPY unique_index_ao_column FROM PROGRAM 'seq 1 1';
 -- now that tx 1 was aborted, tx 2 is successful.
 2<:
+1: END;
 
 DROP TABLE unique_index_ao_column;
+
+--------------------------------------------------------------------------------
+-------------------- Smoke tests for subtransactions ---------------------------
+--------------------------------------------------------------------------------
+CREATE TABLE unique_index_ao_column (a INT unique) USING ao_column
+    DISTRIBUTED REPLICATED;
+
+1: BEGIN;
+1: SAVEPOINT a;
+1: INSERT INTO unique_index_ao_column VALUES(1);
+
+-- concurrent tx inserting conflicting row should block.
+2: BEGIN;
+2&: INSERT INTO unique_index_ao_column VALUES(1);
+-- concurrent tx inserting non-conflicting row should be successful.
+3: INSERT INTO unique_index_ao_column VALUES(2);
+
+-- conflict should be detected within the same subtx.
+1: INSERT INTO unique_index_ao_column VALUES(1);
+-- the concurrent tx should now succeed.
+2<:
+2: ABORT;
+
+-- after rolling back to the savepoint, we should be able to re-insert the key
+1: ROLLBACK TO SAVEPOINT a;
+1: INSERT INTO unique_index_ao_column VALUES(1);
+1: COMMIT;
+
+SELECT * FROM unique_index_ao_column;
+
+DROP TABLE unique_index_ao_column;
+
 RESET gp_appendonly_enable_unique_index;

--- a/src/test/isolation2/sql/aocs_unique_index.sql
+++ b/src/test/isolation2/sql/aocs_unique_index.sql
@@ -305,4 +305,44 @@ SELECT * FROM unique_index_ao_column;
 
 DROP TABLE unique_index_ao_column;
 
+--------------------------------------------------------------------------------
+-------------------- Smoke tests for repeatable read ---------------------------
+--------------------------------------------------------------------------------
+
+-- Test that shows that unique index checks transcend transaction isolation
+-- boundaries.
+
+CREATE TABLE unique_index_ao_column (a INT unique) USING ao_column
+    DISTRIBUTED REPLICATED;
+
+-- Begin two txs with tx level snapshot taken early.
+1: BEGIN ISOLATION LEVEL REPEATABLE READ;
+1: SELECT * FROM unique_index_ao_column;
+2: BEGIN ISOLATION LEVEL REPEATABLE READ;
+2: SELECT * FROM unique_index_ao_column;
+
+-- Now begin a concurrent transaction which inserts a key.
+3: BEGIN;
+3: INSERT INTO unique_index_ao_column VALUES(1);
+
+-- And another transaction inserts a key and commits.
+INSERT INTO unique_index_ao_column VALUES(2);
+
+-- Tx should block on insert of conflicting key, even though it can't "see" the
+-- conflicting key due to its isolation level.
+1: SELECT * FROM unique_index_ao_column;
+1&: INSERT INTO unique_index_ao_column VALUES(1);
+
+3: ABORT;
+1<:
+1: ABORT;
+
+-- Tx should raise a conflict, even though it can't "see" the conflicting key
+-- due to its isolation level.
+2: SELECT * FROM unique_index_ao_column;
+2: INSERT INTO unique_index_ao_column VALUES(2);
+2: ABORT;
+
+DROP TABLE unique_index_ao_column;
+
 RESET gp_appendonly_enable_unique_index;

--- a/src/test/isolation2/sql/aocs_unique_index.sql
+++ b/src/test/isolation2/sql/aocs_unique_index.sql
@@ -6,8 +6,6 @@
 -- us to predict block directory entries without having to worry about the
 -- table's distribution.
 
-SET gp_appendonly_enable_unique_index TO ON;
-
 -- Case 1: Conflict with committed transaction----------------------------------
 CREATE TABLE unique_index_ao_column (a bigint unique) USING ao_column
     DISTRIBUTED REPLICATED;
@@ -344,5 +342,3 @@ INSERT INTO unique_index_ao_column VALUES(2);
 2: ABORT;
 
 DROP TABLE unique_index_ao_column;
-
-RESET gp_appendonly_enable_unique_index;

--- a/src/test/regress/expected/alter_table_aocs.out
+++ b/src/test/regress/expected/alter_table_aocs.out
@@ -527,11 +527,6 @@ select attstattarget from pg_attribute where attrelid = 'aocs_addcol.addcol1'::r
 -- test alter distribution policy
 alter table addcol1 set distributed randomly;
 alter table addcol1 set distributed by (a);
--- test some constraints (unique indexes do not work for unique and pkey)
-alter table addcol1 add constraint tunique unique(a);
-ERROR:  append-only tables do not support unique indexes
-alter table addcol1 add constraint tpkey primary key(a);
-ERROR:  append-only tables do not support unique indexes
 alter table addcol1 add constraint tcheck check (a is not null);
 -- test changing the storage type of a column
 alter table addcol1 alter column f_renamed type varchar(7);

--- a/src/test/regress/expected/alter_table_set_am.out
+++ b/src/test/regress/expected/alter_table_set_am.out
@@ -1,4 +1,5 @@
 -- Check changing table access method
+\set HIDE_TABLEAM off
 -- Scenario 1: Changing to the same AM: it should have no effect but
 -- make sure it doesn't rewrite table or blow up existing reloptions:
 CREATE TABLE sameam_heap(a int, b int) WITH (fillfactor=70) DISTRIBUTED BY (a);
@@ -68,41 +69,46 @@ CREATE TEMP TABLE relfilebeforeao AS
     WHERE relname in ('heap2ao', 'heap2ao2', 'heapi') ORDER BY segid;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'segid' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
--- Altering a heap table with a unique index to AO should error out
--- as unique indexes aren't supported on AO tables
-ALTER TABLE heap2ao2 SET ACCESS METHOD ao_row;
-ERROR:  append-only tables do not support unique indexes
-DETAIL:  heap table "heap2ao2" being altered contains unique index
-ALTER TABLE heap2ao2 DROP CONSTRAINT unique_constraint;
 -- Set default storage options for the table to inherit from
 SET gp_default_storage_options = 'blocksize=65536, compresstype=zlib, compresslevel=5, checksum=true';
--- Alter table heap to AO should work
+-- Alter table heap to AO should work, even if heap table has unique indexes.
 ALTER TABLE heap2ao SET ACCESS METHOD ao_row;
 ALTER TABLE heap2ao2 SET WITH (appendoptimized=true);
 -- The altered tables should have AO AM
-SELECT c.relname, a.amname FROM pg_class c JOIN pg_am a ON c.relam = a.oid WHERE c.relname LIKE 'heap2ao%';
- relname  | amname 
-----------+--------
- heap2ao  | ao_row
- heap2ao2 | ao_row
-(2 rows)
-
 -- The altered tables should inherit storage options from gp_default_storage_options
--- And, the original heap reloptions are gone (in this case, 'fillfactor'). 
-SELECT blocksize,compresslevel,checksum,compresstype,columnstore
-FROM pg_appendonly WHERE relid in ('heap2ao'::regclass::oid, 'heap2ao2'::regclass::oid);
- blocksize | compresslevel | checksum | compresstype | columnstore 
------------+---------------+----------+--------------+-------------
-     65536 |             5 | t        | zlib         | f
-     65536 |             5 | t        | zlib         | f
-(2 rows)
+-- And, the original heap reloptions are gone (in this case, 'fillfactor').
+-- Also, equivalent indexes have been created
+\d+ heap2ao
+                                  Table "public.heap2ao"
+ Column |  Type   | Collation | Nullable | Default | Storage | Stats target | Description 
+--------+---------+-----------+----------+---------+---------+--------------+-------------
+ a      | integer |           |          |         | plain   |              | 
+ b      | integer |           |          |         | plain   |              | 
+Compression Type: zlib
+Compression Level: 5
+Block Size: 65536
+Checksum: t
+Indexes:
+    "heapi" btree (b)
+Distributed by: (a)
+Access method: ao_row
+Options: blocksize=65536, compresslevel=5
 
-SELECT reloptions from pg_class where relname in ('heap2ao', 'heap2ao2');
-            reloptions             
------------------------------------
- {blocksize=65536,compresslevel=5}
- {blocksize=65536,compresslevel=5}
-(2 rows)
+\d+ heap2ao2
+                                 Table "public.heap2ao2"
+ Column |  Type   | Collation | Nullable | Default | Storage | Stats target | Description 
+--------+---------+-----------+----------+---------+---------+--------------+-------------
+ a      | integer |           |          |         | plain   |              | 
+ b      | integer |           |          |         | plain   |              | 
+Compression Type: zlib
+Compression Level: 5
+Block Size: 65536
+Checksum: t
+Indexes:
+    "unique_constraint" UNIQUE CONSTRAINT, btree (a)
+Distributed by: (a)
+Access method: ao_row
+Options: blocksize=65536, compresslevel=5
 
 -- Check data is intact
 SELECT * FROM heap2ao;

--- a/src/test/regress/expected/qp_with_clause.out
+++ b/src/test/regress/expected/qp_with_clause.out
@@ -6393,15 +6393,6 @@ CREATE TABLE countrylanguage_ao (
     isofficial boolean NOT NULL,
     percentage real NOT NULL
 ) with (appendonly=true) distributed by (countrycode,language);
-ALTER TABLE ONLY city_ao
-    ADD CONSTRAINT city_ao_pkey PRIMARY KEY (id);
-ERROR:  append-only tables do not support unique indexes
-ALTER TABLE ONLY country_ao
-    ADD CONSTRAINT country_ao_pkey PRIMARY KEY (code);
-ERROR:  append-only tables do not support unique indexes
-ALTER TABLE ONLY countrylanguage_ao
-    ADD CONSTRAINT countrylanguage_ao_pkey PRIMARY KEY (countrycode, "language");
-ERROR:  append-only tables do not support unique indexes
 create index bitmap_city_ao_countrycode on city_ao using bitmap(countrycode);
 create index bitmap_country_ao_gf on country_ao using bitmap(governmentform);
 create index bitmap_country_ao_region on country_ao using bitmap(region);
@@ -7295,15 +7286,6 @@ CREATE TABLE countrylanguage_co (
     isofficial boolean NOT NULL,
     percentage real NOT NULL
 ) with (appendonly=true,orientation=column) distributed by (countrycode,language);
-ALTER TABLE ONLY city_co
-    ADD CONSTRAINT city_co_pkey PRIMARY KEY (id);
-ERROR:  append-only tables do not support unique indexes
-ALTER TABLE ONLY country_co
-    ADD CONSTRAINT country_co_pkey PRIMARY KEY (code);
-ERROR:  append-only tables do not support unique indexes
-ALTER TABLE ONLY countrylanguage_co
-    ADD CONSTRAINT countrylanguage_co_pkey PRIMARY KEY (countrycode, "language");
-ERROR:  append-only tables do not support unique indexes
 create index bitmap_city_co_countrycode on city_co using bitmap(countrycode);
 create index bitmap_country_co_gf on country_co using bitmap(governmentform);
 create index bitmap_country_co_region on country_co using bitmap(region);

--- a/src/test/regress/expected/qp_with_clause_optimizer.out
+++ b/src/test/regress/expected/qp_with_clause_optimizer.out
@@ -6415,15 +6415,6 @@ CREATE TABLE countrylanguage_ao (
     isofficial boolean NOT NULL,
     percentage real NOT NULL
 ) with (appendonly=true) distributed by (countrycode,language);
-ALTER TABLE ONLY city_ao
-    ADD CONSTRAINT city_ao_pkey PRIMARY KEY (id);
-ERROR:  append-only tables do not support unique indexes
-ALTER TABLE ONLY country_ao
-    ADD CONSTRAINT country_ao_pkey PRIMARY KEY (code);
-ERROR:  append-only tables do not support unique indexes
-ALTER TABLE ONLY countrylanguage_ao
-    ADD CONSTRAINT countrylanguage_ao_pkey PRIMARY KEY (countrycode, "language");
-ERROR:  append-only tables do not support unique indexes
 create index bitmap_city_ao_countrycode on city_ao using bitmap(countrycode);
 create index bitmap_country_ao_gf on country_ao using bitmap(governmentform);
 create index bitmap_country_ao_region on country_ao using bitmap(region);
@@ -7321,15 +7312,6 @@ CREATE TABLE countrylanguage_co (
     isofficial boolean NOT NULL,
     percentage real NOT NULL
 ) with (appendonly=true,orientation=column) distributed by (countrycode,language);
-ALTER TABLE ONLY city_co
-    ADD CONSTRAINT city_co_pkey PRIMARY KEY (id);
-ERROR:  append-only tables do not support unique indexes
-ALTER TABLE ONLY country_co
-    ADD CONSTRAINT country_co_pkey PRIMARY KEY (code);
-ERROR:  append-only tables do not support unique indexes
-ALTER TABLE ONLY countrylanguage_co
-    ADD CONSTRAINT countrylanguage_co_pkey PRIMARY KEY (countrycode, "language");
-ERROR:  append-only tables do not support unique indexes
 create index bitmap_city_co_countrycode on city_co using bitmap(countrycode);
 create index bitmap_country_co_gf on country_co using bitmap(governmentform);
 create index bitmap_country_co_region on country_co using bitmap(region);

--- a/src/test/regress/input/uao_ddl/alter_ao_table_index.source
+++ b/src/test/regress/input/uao_ddl/alter_ao_table_index.source
@@ -51,6 +51,3 @@ select relfrozenxid from pg_class c, pg_namespace n where
 select relfrozenxid from gp_dist_random('pg_class') c, pg_namespace n where
        c.relnamespace = n.oid and relname = 'sto_alt_uao3_idx'
        and n.nspname = 'alter_ao_table_index_@amname@';
-
--- Verify that unique index is not allowed
-CREATE UNIQUE INDEX uni_index ON sto_alt_uao3_idx (text_col);

--- a/src/test/regress/input/uao_dml/ao_unique_index_build.source
+++ b/src/test/regress/input/uao_dml/ao_unique_index_build.source
@@ -1,6 +1,5 @@
 -- Test cases to cover CREATE UNIQUE INDEX on AO/CO tables.
 
-SET gp_appendonly_enable_unique_index TO ON;
 SET default_table_access_method TO @amname@;
 -- To force index scans for smoke tests
 SET enable_seqscan TO off;
@@ -82,7 +81,6 @@ SELECT * FROM unique_index_build_@amname@ WHERE i = 6;
 
 DROP TABLE unique_index_build_@amname@;
 
-RESET gp_appendonly_enable_unique_index;
 RESET default_table_access_method;
 RESET enable_seqscan;
 RESET optimizer;

--- a/src/test/regress/input/uao_dml/ao_unique_index_build.source
+++ b/src/test/regress/input/uao_dml/ao_unique_index_build.source
@@ -56,6 +56,32 @@ INSERT INTO unique_index_build_@amname@ VALUES(1);
 
 DROP TABLE unique_index_build_@amname@;
 
+-- Case 5: Partial unique index build
+CREATE TABLE unique_index_build_@amname@(i int) DISTRIBUTED REPLICATED;
+INSERT INTO unique_index_build_@amname@ VALUES(1);
+INSERT INTO unique_index_build_@amname@ VALUES(1);
+INSERT INTO unique_index_build_@amname@ VALUES(2);
+INSERT INTO unique_index_build_@amname@ VALUES(6);
+INSERT INTO unique_index_build_@amname@ VALUES(6);
+-- should fail as conflict lies in indexed portion of data
+CREATE UNIQUE INDEX on unique_index_build_@amname@(i) WHERE i < 5;
+-- removing conflict should make index build succeed
+DELETE FROM unique_index_build_@amname@ WHERE i = 1;
+CREATE UNIQUE INDEX on unique_index_build_@amname@(i) WHERE i < 5;
+-- post build smoke tests:
+-- should succeed as it lies in non-indexed portion
+INSERT INTO unique_index_build_@amname@ VALUES(6);
+-- should fail as conflict lies in indexed portion of data
+INSERT INTO unique_index_build_@amname@ VALUES(2);
+-- should succeed as there is no conflicting key that exists
+INSERT INTO unique_index_build_@amname@ VALUES(3);
+SELECT * FROM unique_index_build_@amname@ WHERE i = 1;
+SELECT * FROM unique_index_build_@amname@ WHERE i = 2;
+SELECT * FROM unique_index_build_@amname@ WHERE i = 3;
+SELECT * FROM unique_index_build_@amname@ WHERE i = 6;
+
+DROP TABLE unique_index_build_@amname@;
+
 RESET gp_appendonly_enable_unique_index;
 RESET default_table_access_method;
 RESET enable_seqscan;

--- a/src/test/regress/input/uao_dml/uao_dml_unique_index_delete.source
+++ b/src/test/regress/input/uao_dml/uao_dml_unique_index_delete.source
@@ -71,3 +71,43 @@ DELETE FROM uao_unique_index_delete WHERE a = 2;
 SELECT * FROM uao_unique_index_delete;
 
 DROP TABLE uao_unique_index_delete;
+
+-- Case 7: Deleting tx deletes a key inserted in the same subtx-----------------
+CREATE TABLE uao_unique_index_delete (a INT unique);
+BEGIN;
+SAVEPOINT a;
+INSERT INTO uao_unique_index_delete VALUES (1);
+DELETE FROM uao_unique_index_delete WHERE a = 1;
+COMMIT;
+SELECT * FROM uao_unique_index_delete;
+
+DROP TABLE uao_unique_index_delete;
+
+-- Case 8: Deleting tx deletes a key deleted in the same subtx------------------
+CREATE TABLE uao_unique_index_delete (a INT unique);
+BEGIN;
+SAVEPOINT a;
+INSERT INTO uao_unique_index_delete VALUES (1);
+DELETE FROM uao_unique_index_delete WHERE a = 1;
+-- should be a no-op
+DELETE FROM uao_unique_index_delete WHERE a = 1;
+COMMIT;
+SELECT * FROM uao_unique_index_delete;
+
+DROP TABLE uao_unique_index_delete;
+
+-- Case 9: Deleting tx deletes a key whose earlier delete was rolled back-------
+CREATE TABLE uao_unique_index_delete (a INT unique);
+INSERT INTO uao_unique_index_delete VALUES (1);
+BEGIN;
+SAVEPOINT a;
+DELETE FROM uao_unique_index_delete WHERE a = 1;
+ROLLBACK TO SAVEPOINT a;
+-- should be able to delete it again.
+DELETE FROM uao_unique_index_delete WHERE a = 1;
+-- should be able to insert it now since it has been deleted
+INSERT INTO uao_unique_index_delete VALUES (1);
+COMMIT;
+SELECT * FROM uao_unique_index_delete;
+
+DROP TABLE uao_unique_index_delete;

--- a/src/test/regress/input/uao_dml/uao_dml_unique_index_delete.source
+++ b/src/test/regress/input/uao_dml/uao_dml_unique_index_delete.source
@@ -2,8 +2,6 @@ create schema uao_dml_unique_index_@amname@;
 set search_path=uao_dml_unique_index_@amname@;
 set default_table_access_method=@amname@;
 
-SET gp_appendonly_enable_unique_index TO ON;
-
 -- Case 1: Inserting tx inserting a deleted key---------------------------------
 CREATE TABLE uao_unique_index_delete (a INT unique);
 INSERT INTO uao_unique_index_delete VALUES (1);

--- a/src/test/regress/input/uao_dml/uao_dml_unique_index_update.source
+++ b/src/test/regress/input/uao_dml/uao_dml_unique_index_update.source
@@ -2,8 +2,6 @@ create schema uao_dml_unique_index_update_@amname@;
 set search_path=uao_dml_unique_index_update_@amname@;
 set default_table_access_method=@amname@;
 
-SET gp_appendonly_enable_unique_index TO ON;
-
 -- Case 1: Inserting tx inserting a key affected by an update--------------------
 CREATE TABLE uao_unique_index_update (a INT unique);
 INSERT INTO uao_unique_index_update VALUES (1);

--- a/src/test/regress/input/uao_dml/uao_dml_unique_index_update.source
+++ b/src/test/regress/input/uao_dml/uao_dml_unique_index_update.source
@@ -116,3 +116,59 @@ INSERT INTO uao_unique_index_update SELECT generate_series(1,5);
 UPDATE uao_unique_index_update SET a=6 WHERE a>2;
 
 DROP TABLE uao_unique_index_update;
+
+-- Case 11: Updating tx updates a key inserted in the same subtx----------------
+CREATE TABLE uao_unique_index_update (a INT unique);
+BEGIN;
+SAVEPOINT a;
+INSERT INTO uao_unique_index_update VALUES(1);
+UPDATE uao_unique_index_update SET a=2 WHERE a=1;
+COMMIT;
+SELECT * FROM uao_unique_index_update;
+
+DROP TABLE uao_unique_index_update;
+
+-- Case 12: Updating tx updates a key updated in the same subtx-----------------
+CREATE TABLE uao_unique_index_update (a INT unique);
+BEGIN;
+SAVEPOINT a;
+INSERT INTO uao_unique_index_update VALUES(1);
+UPDATE uao_unique_index_update SET a=2 WHERE a=1;
+-- should be a no-op
+UPDATE uao_unique_index_update SET a=2 WHERE a=1;
+-- should succeed
+UPDATE uao_unique_index_update SET a=3 WHERE a=2;
+COMMIT;
+SELECT * FROM uao_unique_index_update;
+
+DROP TABLE uao_unique_index_update;
+
+-- Case 13: Updating tx updates a key whose earlier update was rolled back------
+CREATE TABLE uao_unique_index_update (a INT unique);
+INSERT INTO uao_unique_index_update VALUES(1);
+BEGIN;
+SAVEPOINT a;
+UPDATE uao_unique_index_update SET a=2 WHERE a=1;
+ROLLBACK TO SAVEPOINT a;
+-- should be able to run the update again as we have rolled back.
+UPDATE uao_unique_index_update SET a=2 WHERE a=1;
+COMMIT;
+SELECT * FROM uao_unique_index_update;
+
+DROP TABLE uao_unique_index_update;
+
+-- Case 14: Updating tx updates a key to a key inserted in the same subtx-------
+CREATE TABLE uao_unique_index_update (a INT unique);
+INSERT INTO uao_unique_index_update VALUES (1);
+BEGIN;
+SAVEPOINT a;
+INSERT INTO uao_unique_index_update VALUES (2);
+-- should raise a conflict with the key inserted inside the same subtx.
+UPDATE uao_unique_index_update SET a = 2 WHERE a = 1;
+ROLLBACK TO SAVEPOINT a;
+-- should be able to run the update again as we have rolled back.
+UPDATE uao_unique_index_update SET a = 2 WHERE a = 1;
+COMMIT;
+SELECT * FROM uao_unique_index_update;
+
+DROP TABLE uao_unique_index_update;

--- a/src/test/regress/output/uao_ddl/alter_ao_table_index.source
+++ b/src/test/regress/output/uao_ddl/alter_ao_table_index.source
@@ -111,6 +111,3 @@ select relfrozenxid from gp_dist_random('pg_class') c, pg_namespace n where
             0
 (3 rows)
 
--- Verify that unique index is not allowed
-CREATE UNIQUE INDEX uni_index ON sto_alt_uao3_idx (text_col);
-ERROR:  append-only tables do not support unique indexes

--- a/src/test/regress/output/uao_dml/ao_unique_index_build.source
+++ b/src/test/regress/output/uao_dml/ao_unique_index_build.source
@@ -1,5 +1,4 @@
 -- Test cases to cover CREATE UNIQUE INDEX on AO/CO tables.
-SET gp_appendonly_enable_unique_index TO ON;
 SET default_table_access_method TO @amname@;
 -- To force index scans for smoke tests
 SET enable_seqscan TO off;
@@ -148,7 +147,6 @@ SELECT * FROM unique_index_build_@amname@ WHERE i = 6;
 (3 rows)
 
 DROP TABLE unique_index_build_@amname@;
-RESET gp_appendonly_enable_unique_index;
 RESET default_table_access_method;
 RESET enable_seqscan;
 RESET optimizer;

--- a/src/test/regress/output/uao_dml/ao_unique_index_build.source
+++ b/src/test/regress/output/uao_dml/ao_unique_index_build.source
@@ -99,6 +99,55 @@ INSERT INTO unique_index_build_@amname@ VALUES(1);
 ERROR:  duplicate key value violates unique constraint "unique_index_build_@amname@_i_idx"  (seg0 192.168.0.148:7002 pid=1421591)
 DETAIL:  Key (i)=(1) already exists.
 DROP TABLE unique_index_build_@amname@;
+-- Case 5: Partial unique index build
+CREATE TABLE unique_index_build_@amname@(i int) DISTRIBUTED REPLICATED;
+INSERT INTO unique_index_build_@amname@ VALUES(1);
+INSERT INTO unique_index_build_@amname@ VALUES(1);
+INSERT INTO unique_index_build_@amname@ VALUES(2);
+INSERT INTO unique_index_build_@amname@ VALUES(6);
+INSERT INTO unique_index_build_@amname@ VALUES(6);
+-- should fail as conflict lies in indexed portion of data
+CREATE UNIQUE INDEX on unique_index_build_@amname@(i) WHERE i < 5;
+ERROR:  could not create unique index "unique_index_build_@amname@_i_idx"  (seg0 192.168.0.148:7002 pid=3690142)
+DETAIL:  Key (i)=(1) is duplicated.
+-- removing conflict should make index build succeed
+DELETE FROM unique_index_build_@amname@ WHERE i = 1;
+CREATE UNIQUE INDEX on unique_index_build_@amname@(i) WHERE i < 5;
+-- post build smoke tests:
+-- should succeed as it lies in non-indexed portion
+INSERT INTO unique_index_build_@amname@ VALUES(6);
+-- should fail as conflict lies in indexed portion of data
+INSERT INTO unique_index_build_@amname@ VALUES(2);
+ERROR:  duplicate key value violates unique constraint "unique_index_build_@amname@_i_idx"  (seg1 192.168.0.148:7003 pid=3690143)
+DETAIL:  Key (i)=(2) already exists.
+-- should succeed as there is no conflicting key that exists
+INSERT INTO unique_index_build_@amname@ VALUES(3);
+SELECT * FROM unique_index_build_@amname@ WHERE i = 1;
+ i 
+---
+(0 rows)
+
+SELECT * FROM unique_index_build_@amname@ WHERE i = 2;
+ i 
+---
+ 2
+(1 row)
+
+SELECT * FROM unique_index_build_@amname@ WHERE i = 3;
+ i 
+---
+ 3
+(1 row)
+
+SELECT * FROM unique_index_build_@amname@ WHERE i = 6;
+ i 
+---
+ 6
+ 6
+ 6
+(3 rows)
+
+DROP TABLE unique_index_build_@amname@;
 RESET gp_appendonly_enable_unique_index;
 RESET default_table_access_method;
 RESET enable_seqscan;

--- a/src/test/regress/output/uao_dml/uao_dml_unique_index_delete.source
+++ b/src/test/regress/output/uao_dml/uao_dml_unique_index_delete.source
@@ -88,3 +88,50 @@ SELECT * FROM uao_unique_index_delete;
 (1 row)
 
 DROP TABLE uao_unique_index_delete;
+-- Case 7: Deleting tx deletes a key inserted in the same subtx-----------------
+CREATE TABLE uao_unique_index_delete (a INT unique);
+BEGIN;
+SAVEPOINT a;
+INSERT INTO uao_unique_index_delete VALUES (1);
+DELETE FROM uao_unique_index_delete WHERE a = 1;
+COMMIT;
+SELECT * FROM uao_unique_index_delete;
+ a 
+---
+(0 rows)
+
+DROP TABLE uao_unique_index_delete;
+-- Case 8: Deleting tx deletes a key deleted in the same subtx------------------
+CREATE TABLE uao_unique_index_delete (a INT unique);
+BEGIN;
+SAVEPOINT a;
+INSERT INTO uao_unique_index_delete VALUES (1);
+DELETE FROM uao_unique_index_delete WHERE a = 1;
+-- should be a no-op
+DELETE FROM uao_unique_index_delete WHERE a = 1;
+COMMIT;
+SELECT * FROM uao_unique_index_delete;
+ a 
+---
+(0 rows)
+
+DROP TABLE uao_unique_index_delete;
+-- Case 9: Deleting tx deletes a key whose earlier delete was rolled back-------
+CREATE TABLE uao_unique_index_delete (a INT unique);
+INSERT INTO uao_unique_index_delete VALUES (1);
+BEGIN;
+SAVEPOINT a;
+DELETE FROM uao_unique_index_delete WHERE a = 1;
+ROLLBACK TO SAVEPOINT a;
+-- should be able to delete it again.
+DELETE FROM uao_unique_index_delete WHERE a = 1;
+-- should be able to insert it now since it has been deleted
+INSERT INTO uao_unique_index_delete VALUES (1);
+COMMIT;
+SELECT * FROM uao_unique_index_delete;
+ a 
+---
+ 1
+(1 row)
+
+DROP TABLE uao_unique_index_delete;

--- a/src/test/regress/output/uao_dml/uao_dml_unique_index_delete.source
+++ b/src/test/regress/output/uao_dml/uao_dml_unique_index_delete.source
@@ -1,7 +1,6 @@
 create schema uao_dml_unique_index_@amname@;
 set search_path=uao_dml_unique_index_@amname@;
 set default_table_access_method=@amname@;
-SET gp_appendonly_enable_unique_index TO ON;
 -- Case 1: Inserting tx inserting a deleted key---------------------------------
 CREATE TABLE uao_unique_index_delete (a INT unique);
 INSERT INTO uao_unique_index_delete VALUES (1);

--- a/src/test/regress/output/uao_dml/uao_dml_unique_index_update.source
+++ b/src/test/regress/output/uao_dml/uao_dml_unique_index_update.source
@@ -1,7 +1,6 @@
 create schema uao_dml_unique_index_update_@amname@;
 set search_path=uao_dml_unique_index_update_@amname@;
 set default_table_access_method=@amname@;
-SET gp_appendonly_enable_unique_index TO ON;
 -- Case 1: Inserting tx inserting a key affected by an update--------------------
 CREATE TABLE uao_unique_index_update (a INT unique);
 INSERT INTO uao_unique_index_update VALUES (1);

--- a/src/test/regress/output/uao_dml/uao_dml_unique_index_update.source
+++ b/src/test/regress/output/uao_dml/uao_dml_unique_index_update.source
@@ -159,3 +159,73 @@ UPDATE uao_unique_index_update SET a=6 WHERE a>2;
 ERROR:  duplicate key value violates unique constraint "uao_unique_index_update_a_key"  (seg2 192.168.0.148:7004 pid=1669359)
 DETAIL:  Key (a)=(6) already exists.
 DROP TABLE uao_unique_index_update;
+-- Case 11: Updating tx updates a key inserted in the same subtx----------------
+CREATE TABLE uao_unique_index_update (a INT unique);
+BEGIN;
+SAVEPOINT a;
+INSERT INTO uao_unique_index_update VALUES(1);
+UPDATE uao_unique_index_update SET a=2 WHERE a=1;
+COMMIT;
+SELECT * FROM uao_unique_index_update;
+ a 
+---
+ 2
+(1 row)
+
+DROP TABLE uao_unique_index_update;
+-- Case 12: Updating tx updates a key updated in the same subtx-----------------
+CREATE TABLE uao_unique_index_update (a INT unique);
+BEGIN;
+SAVEPOINT a;
+INSERT INTO uao_unique_index_update VALUES(1);
+UPDATE uao_unique_index_update SET a=2 WHERE a=1;
+-- should be a no-op
+UPDATE uao_unique_index_update SET a=2 WHERE a=1;
+-- should succeed
+UPDATE uao_unique_index_update SET a=3 WHERE a=2;
+COMMIT;
+SELECT * FROM uao_unique_index_update;
+ a 
+---
+ 3
+(1 row)
+
+DROP TABLE uao_unique_index_update;
+-- Case 13: Updating tx updates a key whose earlier update was rolled back------
+CREATE TABLE uao_unique_index_update (a INT unique);
+INSERT INTO uao_unique_index_update VALUES(1);
+BEGIN;
+SAVEPOINT a;
+UPDATE uao_unique_index_update SET a=2 WHERE a=1;
+ROLLBACK TO SAVEPOINT a;
+-- should be able to run the update again as we have rolled back.
+UPDATE uao_unique_index_update SET a=2 WHERE a=1;
+COMMIT;
+SELECT * FROM uao_unique_index_update;
+ a 
+---
+ 2
+(1 row)
+
+DROP TABLE uao_unique_index_update;
+-- Case 14: Updating tx updates a key to a key inserted in the same subtx-------
+CREATE TABLE uao_unique_index_update (a INT unique);
+INSERT INTO uao_unique_index_update VALUES (1);
+BEGIN;
+SAVEPOINT a;
+INSERT INTO uao_unique_index_update VALUES (2);
+-- should raise a conflict with the key inserted inside the same subtx.
+UPDATE uao_unique_index_update SET a = 2 WHERE a = 1;
+ERROR:  duplicate key value violates unique constraint "uao_unique_index_update_a_key"  (seg0 192.168.0.148:7002 pid=3411438)
+DETAIL:  Key (a)=(2) already exists.
+ROLLBACK TO SAVEPOINT a;
+-- should be able to run the update again as we have rolled back.
+UPDATE uao_unique_index_update SET a = 2 WHERE a = 1;
+COMMIT;
+SELECT * FROM uao_unique_index_update;
+ a 
+---
+ 2
+(1 row)
+
+DROP TABLE uao_unique_index_update;

--- a/src/test/regress/sql/alter_table_aocs.sql
+++ b/src/test/regress/sql/alter_table_aocs.sql
@@ -308,9 +308,6 @@ select attstattarget from pg_attribute where attrelid = 'aocs_addcol.addcol1'::r
 alter table addcol1 set distributed randomly;
 alter table addcol1 set distributed by (a);
 
--- test some constraints (unique indexes do not work for unique and pkey)
-alter table addcol1 add constraint tunique unique(a);
-alter table addcol1 add constraint tpkey primary key(a);
 alter table addcol1 add constraint tcheck check (a is not null);
 
 -- test changing the storage type of a column

--- a/src/test/regress/sql/qp_with_clause.sql
+++ b/src/test/regress/sql/qp_with_clause.sql
@@ -8135,16 +8135,6 @@ CREATE TABLE countrylanguage_ao (
     percentage real NOT NULL
 ) with (appendonly=true) distributed by (countrycode,language);
 
-ALTER TABLE ONLY city_ao
-    ADD CONSTRAINT city_ao_pkey PRIMARY KEY (id);
-
-ALTER TABLE ONLY country_ao
-    ADD CONSTRAINT country_ao_pkey PRIMARY KEY (code);
-
-ALTER TABLE ONLY countrylanguage_ao
-    ADD CONSTRAINT countrylanguage_ao_pkey PRIMARY KEY (countrycode, "language");
-
-
 create index bitmap_city_ao_countrycode on city_ao using bitmap(countrycode);
 create index bitmap_country_ao_gf on country_ao using bitmap(governmentform);
 create index bitmap_country_ao_region on country_ao using bitmap(region);
@@ -8621,16 +8611,6 @@ CREATE TABLE countrylanguage_co (
     isofficial boolean NOT NULL,
     percentage real NOT NULL
 ) with (appendonly=true,orientation=column) distributed by (countrycode,language);
-
-ALTER TABLE ONLY city_co
-    ADD CONSTRAINT city_co_pkey PRIMARY KEY (id);
-
-ALTER TABLE ONLY country_co
-    ADD CONSTRAINT country_co_pkey PRIMARY KEY (code);
-
-ALTER TABLE ONLY countrylanguage_co
-    ADD CONSTRAINT countrylanguage_co_pkey PRIMARY KEY (countrycode, "language");
-
 
 create index bitmap_city_co_countrycode on city_co using bitmap(countrycode);
 create index bitmap_country_co_gf on country_co using bitmap(governmentform);


### PR DESCRIPTION
Constitutes a set of changes to make unique indexes for AO/CO tables release ready.
Please consult individual commits.