### PR TITLE
[6X] change the max allowed value of gp_resource_group_cpu_priority to 50

### DIFF
--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -3372,7 +3372,7 @@ struct config_int ConfigureNamesInt_gp[] =
 			NULL
 		},
 		&gp_resource_group_cpu_priority,
-		10, 1, 256,
+		10, 1, 50,
 		NULL, NULL, NULL
 	},
 

--- a/src/backend/utils/resgroup/resgroup-ops-linux.c
+++ b/src/backend/utils/resgroup/resgroup-ops-linux.c
@@ -1296,14 +1296,9 @@ initCpu(void)
 	/*
 	 * shares := parent.shares * gp_resource_group_cpu_priority
 	 *
-	 * We used to set a large shares (like 1024 * 256, the maximum possible
+	 * We used to set a large shares (like 1024 * 50, the maximum possible
 	 * value), it has very bad effect on overall system performance,
 	 * especially on 1-core or 2-core low-end systems.
-	 * Processes in a cold cgroup get launched and scheduled with large
-	 * latency (a simple `cat a.txt` may executes for more than 100s).
-	 * Here a cold cgroup is a cgroup that doesn't have active running
-	 * processes, this includes not only the toplevel system cgroup,
-	 * but also the inactive gpdb resgroups.
 	 */
 	shares = readInt64(RESGROUP_ROOT_ID, BASETYPE_PARENT, comp, "cpu.shares");
 	shares = shares * gp_resource_group_cpu_priority;


### PR DESCRIPTION
Currently, the max value of the GUC `gp_resource_group_cpu_priority` is 256,
it has a very bad effect on overall system performance, especially on 1-core or 
2-core low-end systems, since we will change the value of Cgroup `cpu.shares`
to 1024 * 256, but the other value is just 1024, which means the amount of CPU
between GPDB and other groups is 256:1.

So this PR changed the max allowed value of `gp_resource_group_cpu_priority`
to 50. 

No more test cases added, cause the `resgroup_cpu_rate_limit.source` has 
covered it.
