### PR TITLE
[6X] Warn if any segment has a running basebackup

### DIFF
--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -17,6 +17,7 @@ import signal
 import traceback
 from collections import defaultdict
 from time import strftime, sleep
+from gppylib.programs.clsRecoverSegment_triples import get_segments_with_running_basebackup
 
 try:
     from gppylib.commands.unix import *
@@ -1161,6 +1162,14 @@ class gpexpand:
         return dict(cursor.fetchall())
 
     def addNewSegments(self, inputFileEntryList):
+        segments_with_running_basebackup = get_segments_with_running_basebackup()
+        contentIds_with_running_basebackup = [seg.contentId for seg in inputFileEntryList if
+                                              seg.contentId in segments_with_running_basebackup]
+
+        if len(contentIds_with_running_basebackup) > 0:
+            raise Exception(
+                "Found pg_basebackup running for segments with contentIds %s" % contentIds_with_running_basebackup)
+        
         for seg in inputFileEntryList:
             self.gparray.addExpansionSeg(content=int(seg.contentId)
                                          , preferred_role=seg.role

--- a/gpMgmt/bin/gpmovemirrors
+++ b/gpMgmt/bin/gpmovemirrors
@@ -371,12 +371,12 @@ try:
                     PgHbaEntriesToUpdate.append((segment.getSegmentDataDirectory(), segment.getSegmentHostName(), newMirror.address))
 
     """ Prepare common execution steps for running commands on segments """
-    mirrorsToDelete = [mirror for mirror in newConfig.oldMirrorList if not mirror.inPlace]
-    totalDirsToDelete = len(mirrorsToDelete)
+    oldMirrorsToMove = [mirror for mirror in newConfig.oldMirrorList if not mirror.inPlace]
+    totalDirsToDelete = len(oldMirrorsToMove)
     numberOfWorkers = min(totalDirsToDelete, options.batch_size)
 
     """ Fetch tablespace locations before mirror move """
-    for mirror in mirrorsToDelete:
+    for mirror in oldMirrorsToMove:
         mirror_tablespace_locations[mirror.dataDirectory] = get_tablespace_locations(False, mirror.dataDirectory)
 
     """ Update pg_hba.conf on primary segments with new mirror information """
@@ -398,6 +398,13 @@ try:
     """ Reinitialize gparray after the new mirrors are in place. """
     gpArrayInstance = GpArray.initFromCatalog(dburl, utility=True)
     mirrorDirectories = set((seg.getSegmentHostName(),seg.getSegmentContentId()) for seg in gpArrayInstance.getDbList() if seg.isSegmentMirror())
+    newMirrorAddressDir = set(
+        (seg.getSegmentAddress(), seg.getSegmentDataDirectory()) for seg in gpArrayInstance.getDbList() if
+        seg.isSegmentMirror())
+
+    """If mirror has not moved to new location due to any reason, skip deletion of old mirror directory"""
+    mirrorsToDelete = [mirror for mirror in oldMirrorsToMove if
+                       (mirror.address, mirror.dataDirectory) not in newMirrorAddressDir]
 
     """ Delete old mirror directories. """
     if numberOfWorkers > 0:

--- a/gpMgmt/bin/gppylib/programs/clsRecoverSegment_triples.py
+++ b/gpMgmt/bin/gppylib/programs/clsRecoverSegment_triples.py
@@ -1,11 +1,36 @@
 import abc
 
+from contextlib import closing
+from gppylib.db import dbconn
+from gppylib import gplog
 from gppylib.mainUtils import ExceptionNoStackTraceNeeded
 from gppylib.operations.detect_unreachable_hosts import get_unreachable_segment_hosts
 from gppylib.parseutils import line_reader, check_values, canonicalize_address
 from gppylib.utils import checkNotNone, normalizeAndValidateInputPath
 from gppylib.gparray import GpArray, Segment
 
+logger = gplog.get_default_logger()
+
+def get_segments_with_running_basebackup():
+    """
+    Returns a list of contentIds of source segments of running pg_basebackup processes
+    At present gp_stat_replication table does not contain any info about datadir and dbid of the target of running pg_basebackup
+    """
+
+    sql = "select gp_segment_id from gp_stat_replication where application_name = 'pg_basebackup'"
+
+    try:
+        with closing(dbconn.connect(dbconn.DbURL())) as conn:
+            res = dbconn.execSQL(conn, sql)
+            rows = res.fetchall()
+    except Exception as e:
+        raise Exception("Failed to query gp_stat_replication: %s" %str(e))
+
+    segments_with_running_basebackup = {row[0] for row in rows}
+
+    if len(segments_with_running_basebackup) == 0:
+        logger.debug("No basebackup running")
+    return segments_with_running_basebackup
 
 class RecoveryTriplet:
     """
@@ -144,7 +169,15 @@ class RecoveryTriplets:
         triplets = []
 
         dbIdToPeerMap = self.gpArray.getDbIdToPeerMap()
+
+        failed_segments_with_running_basebackup = []
+        segments_with_running_basebackup = get_segments_with_running_basebackup()
+
         for req in requests:
+            if req.failed.getSegmentContentId() in segments_with_running_basebackup:
+                failed_segments_with_running_basebackup.append(req.failed.getSegmentContentId())
+                continue
+
             # TODO: These 2 cases have different behavior which might be confusing to the user.
             # "<failed_address>|<failed_port>|<failed_data_dir> <failed_address>|<failed_port>|<failed_data_dir>" does full recovery
             # "<failed_address>|<failed_port>|<failed_data_dir>" does incremental recovery
@@ -171,6 +204,11 @@ class RecoveryTriplets:
             peer = dbIdToPeerMap.get(req.failed.getSegmentDbId())
 
             triplets.append(RecoveryTriplet(req.failed, peer, failover))
+
+        if len(failed_segments_with_running_basebackup) > 0:
+            logger.warning(
+                "Found pg_basebackup running for segments with contentIds %s, skipping recovery of these segments" % (
+                    failed_segments_with_running_basebackup))
 
         return triplets
 

--- a/gpMgmt/bin/gppylib/programs/test/unit/test_cluster_clsrecoversegment_triples.py
+++ b/gpMgmt/bin/gppylib/programs/test/unit/test_cluster_clsrecoversegment_triples.py
@@ -2,29 +2,36 @@
 
 import copy
 import io
-from mock import Mock, patch, MagicMock
+from mock import Mock, patch, MagicMock, call
 import tempfile
 
 import gppylib
 from gppylib.gparray import GpArray, Segment
-from gppylib.programs.clsRecoverSegment_triples import RecoveryTripletsUserConfigFile, RecoveryTripletsFactory, RecoveryTriplet
-from test.unit.gp_unittest import GpTestCase, SubTest
+from gppylib.programs.clsRecoverSegment_triples import RecoveryTripletsUserConfigFile, RecoveryTripletsFactory, RecoveryTriplet, get_segments_with_running_basebackup
+from test.unit.gp_unittest import GpTestCase, SubTest, FakeCursor
 
 
 class RecoveryTripletsFactoryTestCase(GpTestCase):
     def setUp(self):
         # Set maxDiff to None to see the entire diff on the console in case of failure
         self.maxDiff = None
+        mock_logger = Mock(spec=['log', 'warn', 'info', 'debug', 'error', 'warning', 'fatal'])
+
+        self.apply_patches([
+            patch('gppylib.programs.clsRecoverSegment_triples.logger', return_value=mock_logger),
+        ])
+
+        self.mock_logger = self.get_mock_from_apply_patch('logger')
 
     def run_single_ConfigFile_test(self, test):
         with tempfile.NamedTemporaryFile() as f:
             f.write(test["config"].encode("utf-8"))
             f.flush()
-            return self._run_single_FromGpArray_test(test["gparray"], f.name, None, None, test.get("unreachable_existing_hosts"))
+            return self._run_single_FromGpArray_test(test["gparray"], f.name, None, None, test.get("segments_with_running_basebackup", set()), test.get("unreachable_existing_hosts"))
 
     def run_single_GpArray_test(self, test):
         return self._run_single_FromGpArray_test(test["gparray"], None, test["new_hosts"], test.get("unreachable_hosts"),
-                                     test.get("unreachable_existing_hosts"))
+                                     test.get("segments_with_running_basebackup", set()), test.get("unreachable_existing_hosts"))
 
     #TODO: do we want new hosts here?  We do not officially support new hosts with "-i"
     def test_RecoveryTripletsUserConfigFile_getMirrorTriples_should_pass(self):
@@ -100,7 +107,37 @@ class RecoveryTripletsFactoryTestCase(GpTestCase):
                 "config": "sdw2|21000|/mirror/gpseg0",
                 "unreachable_existing_hosts": ['sdw2'],
                 "expected": []
-            }
+            },
+            {
+                "name": "one_mirror_inconfig_has_running_basebackup",
+                "gparray": self.all_up_gparray_str,
+                "config": """sdw2|21000|/mirror/gpseg0 sdw2|21000|/mirror/gpseg0_new
+                                     sdw1|21000|/mirror/gpseg6 sdw1|21000|/mirror/gpseg6_new""",
+                "segments_with_running_basebackup": {0},
+                "expected": [self._triplet('16|6|m|m|s|u|sdw1|sdw1|21000|/mirror/gpseg6',
+                                           '8|6|p|p|s|u|sdw4|sdw4|20000|/primary/gpseg6',
+                                           '16|6|m|m|s|u|sdw1|sdw1|21000|/mirror/gpseg6_new')]
+            },
+            {
+                "name": "some_mirrors_inconfig_have_running_basebackup",
+                "gparray": self.all_up_gparray_str,
+                "config": """sdw2|21000|/mirror/gpseg0 sdw2|21000|/mirror/gpseg0_new
+                                     sdw2|21001|/mirror/gpseg1 sdw2|21000|/mirror/gpseg1_new
+                                     sdw1|21000|/mirror/gpseg6 sdw1|21000|/mirror/gpseg6_new""",
+                "segments_with_running_basebackup": {0, 1},
+                "expected": [self._triplet('16|6|m|m|s|u|sdw1|sdw1|21000|/mirror/gpseg6',
+                                           '8|6|p|p|s|u|sdw4|sdw4|20000|/primary/gpseg6',
+                                           '16|6|m|m|s|u|sdw1|sdw1|21000|/mirror/gpseg6_new')]
+            },
+            {
+                "name": "all_mirrors_inconfig_have_running_basebackup",
+                "gparray": self.all_up_gparray_str,
+                "config": """sdw2|21000|/mirror/gpseg0 sdw2|21000|/mirror/gpseg0_new
+                                     sdw2|21001|/mirror/gpseg1 sdw2|21000|/mirror/gpseg1_new
+                                     sdw1|21000|/mirror/gpseg6 sdw1|21000|/mirror/gpseg6_new""",
+                "segments_with_running_basebackup": {0, 1, 6},
+                "expected": []
+            },
         ]
         self.run_pass_tests(tests, self.run_single_ConfigFile_test)
 
@@ -269,6 +306,34 @@ class RecoveryTripletsFactoryTestCase(GpTestCase):
                                            '6|0|p|m|s|u|sdw2|sdw2|21000|/mirror/gpseg0',
                                            '2|0|m|p|s|d|new_1|new_1|20000|/primary/gpseg0', failed_unreachable=True)]
             },
+            {
+                "name": "one_failed_segments_has_running_basebackup",
+                "gparray": self.three_failedover_segs_gparray_str,
+                "new_hosts": [],
+                "segments_with_running_basebackup": {0},
+                "expected": [self._triplet('3|1|m|p|s|d|sdw1|sdw1|20001|/primary/gpseg1',
+                                           '7|1|p|m|s|u|sdw2|sdw2|21001|/mirror/gpseg1',
+                                           None),
+                             self._triplet('4|2|m|p|s|d|sdw2|sdw2|20000|/primary/gpseg2',
+                                           '8|2|p|m|s|u|sdw3|sdw3|21000|/mirror/gpseg2',
+                                           None)]
+            },
+            {
+                "name": "some_failed_segments_have_running_basebackup",
+                "gparray": self.three_failedover_segs_gparray_str,
+                "new_hosts": [],
+                "segments_with_running_basebackup": {0, 1},
+                "expected": [self._triplet('4|2|m|p|s|d|sdw2|sdw2|20000|/primary/gpseg2',
+                                           '8|2|p|m|s|u|sdw3|sdw3|21000|/mirror/gpseg2',
+                                           None)]
+            },
+            {
+                "name": "all_failed_segments_have_running_basebackup",
+                "gparray": self.three_failedover_segs_gparray_str,
+                "new_hosts": [],
+                "segments_with_running_basebackup": {0, 1, 2},
+                "expected": []
+            },
         ]
 
         self.run_pass_tests(tests, self.run_single_GpArray_test)
@@ -375,6 +440,35 @@ class RecoveryTripletsFactoryTestCase(GpTestCase):
                 with self.assertRaisesRegexp(Exception, test["expected"]):
                     fn_to_test(test)
 
+    @patch('gppylib.db.dbconn.connect', side_effect=Exception())
+    def test_get_segments_with_running_basebackup_conn_exception(self, mock1):
+        with self.assertRaises(Exception) as ex:
+            get_segments_with_running_basebackup()
+
+        self.assertTrue('Failed to query gp_stat_replication' in str(ex.exception))
+
+    @patch('gppylib.db.dbconn.connect', autospec=True)
+    @patch('gppylib.db.dbconn.execSQL', side_effect=Exception())
+    def test_get_segments_with_running_basebackup_query_exception(self, mock1, mock2):
+        with self.assertRaises(Exception) as ex:
+            get_segments_with_running_basebackup()
+
+        self.assertTrue('Failed to query gp_stat_replication:' in str(ex.exception))
+
+    @patch('gppylib.db.dbconn.connect', autospec=True)
+    @patch('gppylib.db.dbconn.execSQL', return_value=FakeCursor(my_list=[]))
+    def test_get_segments_with_running_basebackup_no_basebackup(self, mock1, mock2):
+        segments_with_running_basebackup = get_segments_with_running_basebackup()
+        self.assertEqual(list(segments_with_running_basebackup), [])
+        self.assertEqual([call("No basebackup running")], self.mock_logger.debug.call_args_list)
+
+    @patch('gppylib.db.dbconn.connect', autospec=True)
+    @patch('gppylib.db.dbconn.execSQL', return_value=FakeCursor(my_list=[[1]]))
+    def test_get_segments_with_running_basebackup_has_basebackup(self, mock1, mock2):
+        segments_with_running_basebackup = get_segments_with_running_basebackup()
+        self.assertEqual(list(segments_with_running_basebackup), [1])
+        self.assertEqual(0, self.mock_logger.debug.call_count)
+
     def __init__(self, arg):
         super(RecoveryTripletsFactoryTestCase, self).__init__(arg)
 
@@ -438,9 +532,11 @@ class RecoveryTripletsFactoryTestCase(GpTestCase):
                                   5|3|p|p|s|u|sdw2|sdw2|20001|/primary/gpseg3'''
 
     def _run_single_FromGpArray_test(self, gparray_str, config_file, new_hosts, unreachable_hosts,
-                                              unreachable_existing_hosts=None):
+                                              segments_with_running_basebackup, unreachable_existing_hosts=None):
         unreachable_hosts = unreachable_hosts if unreachable_hosts else []
         gppylib.programs.clsRecoverSegment_triples.get_unreachable_segment_hosts = Mock(return_value=unreachable_hosts)
+        gppylib.programs.clsRecoverSegment_triples.get_segments_with_running_basebackup = Mock(
+            return_value=segments_with_running_basebackup)
 
         initial_gparray = self.get_gp_array(gparray_str, unreachable_existing_hosts)
         mutated_gparray = self.get_gp_array(gparray_str, unreachable_existing_hosts)

--- a/gpMgmt/test/behave/mgmt_utils/environment.py
+++ b/gpMgmt/test/behave/mgmt_utils/environment.py
@@ -146,7 +146,7 @@ def after_scenario(context, scenario):
         return
 
     tags_to_cleanup = ['gpmovemirrors', 'gpssh-exkeys']
-    if set(context.feature.tags).intersection(tags_to_cleanup):
+    if set(context.feature.tags).intersection(tags_to_cleanup) and "skip_cleanup" not in scenario.effective_tags:
         if 'temp_base_dir' in context and os.path.exists(context.temp_base_dir):
             os.chmod(context.temp_base_dir, 0o700)
             shutil.rmtree(context.temp_base_dir)

--- a/gpMgmt/test/behave/mgmt_utils/gpaddmirrors.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpaddmirrors.feature
@@ -178,6 +178,19 @@ Feature: Tests for gpaddmirrors
         And check segment conf: postgresql.conf
         And all files in gpAdminLogs directory are deleted
 
+    Scenario: gpaddmirrors errors out if the directory for the mirror to be added is not empty
+        Given the cluster is generated with "3" primaries only
+        And all files in gpAdminLogs directory are deleted
+        And a gaddmirrors directory under '/tmp' with mode '0700' is created
+        And a gpaddmirrors input file is created
+        And edit the input file to add mirror with content 0,1,2 to a new non-empty directory with mode 0700
+        When the user runs gpaddmirrors with input file and additional args "-a"
+        Then gpaddmirrors should print "Segment directory '/tmp/.*' exists but is not empty!" to stdout
+        And all the segments are running
+        And check segment conf: postgresql.conf
+        And all files in gpAdminLogs directory are deleted
+
+
 
 #    Scenario: gpaddmirrors deletes progress file on SIGINT
 #        Given the cluster is generated with "3" primaries only

--- a/gpMgmt/test/behave/mgmt_utils/gpmovemirrors.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpmovemirrors.feature
@@ -229,6 +229,127 @@ Feature: Tests for gpmovemirrors
     And check if mirrors on content 0,1,2 are moved to new location on input file
     And user can start transactions
     And all files in gpAdminLogs directory are deleted on all hosts in the cluster
+    And the cluster is recovered in full and rebalanced
+
+  @demo_cluster
+  @concourse_cluster
+  @skip_cleanup
+  Scenario: gpmovemirrors gives warning if pg_basebackup is already running for one of the mirrors to be moved
+    Given the database is running
+    And all the segments are running
+    And the segments are synchronized
+    And all files in gpAdminLogs directory are deleted on all hosts in the cluster
+    And the information of contents 0,1,2 is saved
+    And user immediately stops all mirror processes for content 0,1,2
+    And user can start transactions
+    And the user suspend the walsender on the primary on content 0
+    And sql "DROP TABLE if exists test_recoverseg; CREATE TABLE test_recoverseg AS SELECT generate_series(1,100000000) AS i" is executed in "postgres" db
+    And the "test_recoverseg" table row count in "postgres" is saved
+    And the user asynchronously runs "gprecoverseg -aF" and the process is saved
+    And the user waits until recovery_progress.file is created in gpAdminLogs and verifies its format
+    And the user waits until mirror on content 1,2 is up
+    And verify that mirror on content 0 is down
+    And the gprecoverseg lock directory is removed
+    And user immediately stops all mirror processes for content 1,2
+    And the user waits until mirror on content 1,2 is down
+    And a gpmovemirrors directory under '/tmp' with mode '0700' is created
+    And a gpmovemirrors input file is created
+    And edit the input file to recover mirror with content 0,1,2 to a new directory with mode 0700
+    When the user runs gpmovemirrors with input file and additional args " "
+    Then gprecoverseg should return a return code of 0
+    And gpmovemirrors should return a return code of 0
+    And gprecoverseg should print "Found pg_basebackup running for segments with contentIds [0], skipping recovery of these segments" to logfile
+    And verify that mirror on content 1,2 is up
+    And verify that mirror on content 0 is down
+    And check if mirrors on content 1,2 are moved to new location on input file
+    And check if mirrors on content 0 are in their original configuration
+    And an FTS probe is triggered
+    And the user reset the walsender on the primary on content 0
+    And the user waits until saved async process is completed
+    And recovery_progress.file should not exist in gpAdminLogs
+    And verify that mirror on content 0 is up
+    And the cluster is recovered in full and rebalanced
+    And all files in gpAdminLogs directory are deleted on all hosts in the cluster
+
+  @demo_cluster
+  @concourse_cluster
+  @skip_cleanup
+  Scenario: gpmovemirrors gives warning if pg_basebackup is already running for some of the mirrors to be moved
+    Given the database is running
+    And all the segments are running
+    And the segments are synchronized
+    And all files in gpAdminLogs directory are deleted on all hosts in the cluster
+    And the information of contents 0,1,2 is saved
+    And user immediately stops all mirror processes for content 0,1,2
+    And user can start transactions
+    And the user suspend the walsender on the primary on content 0
+    And the user suspend the walsender on the primary on content 1
+    And sql "DROP TABLE if exists test_recoverseg; CREATE TABLE test_recoverseg AS SELECT generate_series(1,100000000) AS i" is executed in "postgres" db
+    And the "test_recoverseg" table row count in "postgres" is saved
+    And the user asynchronously runs "gprecoverseg -aF" and the process is saved
+    And the user waits until recovery_progress.file is created in gpAdminLogs and verifies its format
+    And the user waits until mirror on content 2 is up
+    And verify that mirror on content 0,1 is down
+    And the gprecoverseg lock directory is removed
+    And user immediately stops all mirror processes for content 2
+    And the user waits until mirror on content 2 is down
+    And a gpmovemirrors directory under '/tmp' with mode '0700' is created
+    And a gpmovemirrors input file is created
+    And edit the input file to recover mirror with content 0,1,2 to a new directory with mode 0700
+    When the user runs gpmovemirrors with input file and additional args " "
+    Then gprecoverseg should return a return code of 0
+    And gpmovemirrors should return a return code of 0
+    And gprecoverseg should print "Found pg_basebackup running for segments with contentIds [0, 1], skipping recovery of these segments" to logfile
+    And verify that mirror on content 2 is up
+    And verify that mirror on content 0,1 is down
+    And check if mirrors on content 2 are moved to new location on input file
+    And check if mirrors on content 0,1 are in their original configuration
+    And an FTS probe is triggered
+    And the user reset the walsender on the primary on content 0
+    And the user reset the walsender on the primary on content 1
+    And the user waits until saved async process is completed
+    And recovery_progress.file should not exist in gpAdminLogs
+    And verify that mirror on content 0,1 is up
+    And the cluster is recovered in full and rebalanced
+    And all files in gpAdminLogs directory are deleted on all hosts in the cluster
+
+  @demo_cluster
+  @concourse_cluster
+  @skip_cleanup
+  Scenario: gpmovemirrors gives warning if pg_basebackup is already running for all mirrors to be moved
+    Given the database is running
+    And all the segments are running
+    And the segments are synchronized
+    And all files in gpAdminLogs directory are deleted on all hosts in the cluster
+    And the information of contents 0,1,2 is saved
+    And user immediately stops all mirror processes for content 0,1,2
+    And user can start transactions
+    And the user suspend the walsender on the primary on content 0
+    And the user suspend the walsender on the primary on content 1
+    And the user suspend the walsender on the primary on content 2
+    And sql "DROP TABLE if exists test_recoverseg; CREATE TABLE test_recoverseg AS SELECT generate_series(1,100000000) AS i" is executed in "postgres" db
+    And the "test_recoverseg" table row count in "postgres" is saved
+    And the user asynchronously runs "gprecoverseg -aF" and the process is saved
+    And the user waits until recovery_progress.file is created in gpAdminLogs and verifies its format
+    And verify that mirror on content 0,1,2 is down
+    And the gprecoverseg lock directory is removed
+    Given a gpmovemirrors directory under '/tmp' with mode '0700' is created
+    And a gpmovemirrors input file is created
+    And edit the input file to recover mirror with content 0,1,2 to a new directory with mode 0700
+    When the user runs gpmovemirrors with input file and additional args "-v"
+    Then gprecoverseg should return a return code of 0
+    And gpmovemirrors should return a return code of 0
+    And gprecoverseg should print "Found pg_basebackup running for segments with contentIds [0, 1, 2], skipping recovery of these segments" to logfile
+    And check if mirrors on content 0,1,2 are in their original configuration
+    And an FTS probe is triggered
+    And the user reset the walsender on the primary on content 0
+    And the user reset the walsender on the primary on content 1
+    And the user reset the walsender on the primary on content 2
+    And the user waits until saved async process is completed
+    And recovery_progress.file should not exist in gpAdminLogs
+    And verify that mirror on content 0,1,2 is up
+    And the cluster is recovered in full and rebalanced
+    And all files in gpAdminLogs directory are deleted on all hosts in the cluster
 
 
 ########################### @concourse_cluster tests ###########################

--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -270,6 +270,182 @@ Feature: gprecoverseg tests
         And the segments are synchronized
         And the cluster is rebalanced
 
+  @demo_cluster
+  Scenario: gprecoverseg should not give warning if pg_basebackup is running for the up segments
+    Given the database is running
+    And all the segments are running
+    And the segments are synchronized
+    And all files in gpAdminLogs directory are deleted on all hosts in the cluster
+    And user immediately stops all primary processes for content 0,1
+    And user can start transactions
+    And an FTS probe is triggered
+    And the user suspend the walsender on the primary on content 2
+    And the user asynchronously runs pg_basebackup with primary of content 2 as source and the process is saved
+    And an FTS probe is triggered
+    And gp_stat_replication table has pg_basebackup entry for content 2
+    When the user runs "gprecoverseg -avF"
+    Then gprecoverseg should return a return code of 0
+    And gprecoverseg should not print "No basebackup running" to stdout
+    And verify that mirror on content 0,1 is up
+    And an FTS probe is triggered
+    And gp_stat_replication table has pg_basebackup entry for content 2
+    And the user reset the walsender on the primary on content 2
+    And the user waits until saved async process is completed
+    And the user waits until mirror on content 2 is up
+    And user can start transactions
+    And all files in gpAdminLogs directory are deleted on all hosts in the cluster
+    And the cluster is rebalanced
+
+  @demo_cluster
+  @concourse_cluster
+  Scenario: gprecoverseg gives warning if pg_basebackup already running for one of the failed segments
+    Given the database is running
+    And all the segments are running
+    And the segments are synchronized
+    And all files in gpAdminLogs directory are deleted on all hosts in the cluster
+    And user immediately stops all primary processes for content 0,1,2
+    And user can start transactions
+    And the user suspend the walsender on the primary on content 0
+    And sql "DROP TABLE if exists test_recoverseg; CREATE TABLE test_recoverseg AS SELECT generate_series(1,100000000) AS i" is executed in "postgres" db
+    And the "test_recoverseg" table row count in "postgres" is saved
+    And the user asynchronously runs "gprecoverseg -aF" and the process is saved
+    And the user waits until recovery_progress.file is created in gpAdminLogs and verifies its format
+    And the user waits until mirror on content 1,2 is up
+    And verify that mirror on content 0 is down
+    And the gprecoverseg lock directory is removed
+    And user immediately stops all primary processes for content 1,2
+    And the user waits until mirror on content 1,2 is down
+    When the user runs "gprecoverseg -avF"
+    Then gprecoverseg should return a return code of 0
+    And gprecoverseg should print "Found pg_basebackup running for segments with contentIds [0], skipping recovery of these segments" to logfile
+    And verify that mirror on content 1,2 is up
+    And verify that mirror on content 0 is down
+    And an FTS probe is triggered
+    And the user reset the walsender on the primary on content 0
+    And the user waits until saved async process is completed
+    And recovery_progress.file should not exist in gpAdminLogs
+    And verify that mirror on content 0 is up
+    And the user runs "gprecoverseg -avF"
+    Then gprecoverseg should print "No basebackup running" to stdout
+    And gprecoverseg should return a return code of 0
+    And the cluster is rebalanced
+    And the row count from table "test_recoverseg" in "postgres" is verified against the saved data
+
+  @demo_cluster
+  @concourse_cluster
+  Scenario: gprecoverseg gives warning if pg_basebackup already running for some of the failed segments
+    Given the database is running
+    And all the segments are running
+    And the segments are synchronized
+    And all files in gpAdminLogs directory are deleted on all hosts in the cluster
+    And user immediately stops all primary processes for content 0,1,2
+    And user can start transactions
+    And the user suspend the walsender on the primary on content 0
+    And the user suspend the walsender on the primary on content 1
+    And sql "DROP TABLE if exists test_recoverseg; CREATE TABLE test_recoverseg AS SELECT generate_series(1,100000000) AS i" is executed in "postgres" db
+    And the "test_recoverseg" table row count in "postgres" is saved
+    And the user asynchronously runs "gprecoverseg -aF" and the process is saved
+    And the user waits until recovery_progress.file is created in gpAdminLogs and verifies its format
+    And the user waits until mirror on content 2 is up
+    And verify that mirror on content 0,1 is down
+    And the gprecoverseg lock directory is removed
+    And user immediately stops all primary processes for content 2
+    And the user waits until mirror on content 2 is down
+    When the user runs "gprecoverseg -avF"
+    Then gprecoverseg should return a return code of 0
+    And gprecoverseg should print "Found pg_basebackup running for segments with contentIds [0, 1], skipping recovery of these segments" to logfile
+    And verify that mirror on content 2 is up
+    And verify that mirror on content 0,1 is down
+    And an FTS probe is triggered
+    And the user reset the walsender on the primary on content 0
+    And the user reset the walsender on the primary on content 1
+    And the user waits until saved async process is completed
+    And recovery_progress.file should not exist in gpAdminLogs
+    And verify that mirror on content 0,1 is up
+    And the user runs "gprecoverseg -avF"
+    Then gprecoverseg should print "No basebackup running" to stdout
+    And gprecoverseg should return a return code of 0
+    And the cluster is rebalanced
+    And the row count from table "test_recoverseg" in "postgres" is verified against the saved data
+
+  @demo_cluster
+  @concourse_cluster
+  Scenario: gprecoverseg -aF gives warning if pg_basebackup already running for all of the failed segments
+    Given the database is running
+    And all the segments are running
+    And the segments are synchronized
+    And all files in gpAdminLogs directory are deleted on all hosts in the cluster
+    And user immediately stops all primary processes for content 0,1,2
+    And user can start transactions
+    And the user suspend the walsender on the primary on content 0
+    And the user suspend the walsender on the primary on content 1
+    And the user suspend the walsender on the primary on content 2
+    And sql "DROP TABLE if exists test_recoverseg; CREATE TABLE test_recoverseg AS SELECT generate_series(1,100000000) AS i" is executed in "postgres" db
+    And the "test_recoverseg" table row count in "postgres" is saved
+    And the user asynchronously runs "gprecoverseg -aF" and the process is saved
+    And the user waits until recovery_progress.file is created in gpAdminLogs and verifies its format
+    And verify that mirror on content 0,1,2 is down
+    And the gprecoverseg lock directory is removed
+    When the user runs "gprecoverseg -aF"
+    Then gprecoverseg should return a return code of 0
+    And gprecoverseg should print "Found pg_basebackup running for segments with contentIds [0, 1, 2], skipping recovery of these segments" to logfile
+    And gprecoverseg should print "No segments to recover" to stdout
+    And verify that mirror on content 0,1,2 is down
+    And an FTS probe is triggered
+    And the user reset the walsender on the primary on content 0
+    And the user reset the walsender on the primary on content 1
+    And the user reset the walsender on the primary on content 2
+    And the user waits until saved async process is completed
+    And recovery_progress.file should not exist in gpAdminLogs
+    And verify that mirror on content 0,1,2 is up
+    And the user runs "gprecoverseg -avF"
+    Then gprecoverseg should print "No basebackup running" to stdout
+    And gprecoverseg should return a return code of 0
+    And verify that mirror on content 0,1,2 is up
+    And the cluster is rebalanced
+    And the row count from table "test_recoverseg" in "postgres" is verified against the saved data
+
+  @demo_cluster
+  @concourse_cluster
+  Scenario: gprecoverseg -i gives warning if pg_basebackup already running for all failed segments
+    Given the database is running
+    And all the segments are running
+    And the segments are synchronized
+    And all files in gpAdminLogs directory are deleted on all hosts in the cluster
+    And user immediately stops all primary processes for content 0,1,2
+    And user can start transactions
+    And the user suspend the walsender on the primary on content 0
+    And the user suspend the walsender on the primary on content 1
+    And the user suspend the walsender on the primary on content 2
+    And sql "DROP TABLE if exists test_recoverseg; CREATE TABLE test_recoverseg AS SELECT generate_series(1,100000000) AS i" is executed in "postgres" db
+    And the "test_recoverseg" table row count in "postgres" is saved
+    And a gprecoverseg directory under '/tmp' with mode '0700' is created
+    And a gprecoverseg input file is created
+    And edit the input file to recover mirror with content 0 full inplace
+    And edit the input file to recover mirror with content 1 full inplace
+    And edit the input file to recover mirror with content 2 full inplace
+    When the user asynchronously runs gprecoverseg with input file and additional args "-a" and the process is saved
+    Then the user waits until recovery_progress.file is created in gpAdminLogs and verifies its format
+    And verify that mirror on content 0,1,2 is down
+    And the gprecoverseg lock directory is removed
+    When the user runs gprecoverseg with input file and additional args "-a"
+    Then gprecoverseg should print "Found pg_basebackup running for segments with contentIds [0, 1, 2], skipping recovery of these segments" to logfile
+    And gprecoverseg should print "No segments to recover" to stdout
+    And gprecoverseg should return a return code of 0
+    And verify that mirror on content 0,1,2 is down
+    And an FTS probe is triggered
+    And the user reset the walsender on the primary on content 0
+    And the user reset the walsender on the primary on content 1
+    And the user reset the walsender on the primary on content 2
+    And the user waits until saved async process is completed
+    And recovery_progress.file should not exist in gpAdminLogs
+    And verify that mirror on content 0,1,2 is up
+    When the user runs gprecoverseg with input file and additional args "-av"
+    Then gprecoverseg should print "No basebackup running" to stdout
+    And gprecoverseg should return a return code of 0
+    Then the cluster is rebalanced
+    And the row count from table "test_recoverseg" in "postgres" is verified against the saved data
+
 
 ########################### @concourse_cluster tests ###########################
 # The @concourse_cluster tag denotes the scenario that requires a remote cluster

--- a/gpMgmt/test/behave/mgmt_utils/steps/mirrors_mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mirrors_mgmt_utils.py
@@ -382,13 +382,15 @@ def impl(context, content_ids, mode):
                 break
 
 
-@given("edit the input file to add mirror with content {content_ids} to a new directory with mode {mode}")
-def impl(context, content_ids, mode):
+@given("edit the input file to add mirror with content {content_ids} to a new {directory} with mode {mode}")
+def impl(context, content_ids, directory, mode):
     if content_ids == "None":
         return
     for content in [int(c) for c in content_ids.split(',')]:
         make_temp_dir(context, context.mirror_context.working_directory[0], mode)
         new_datadir = context.temp_base_dir
+        if directory == "non-empty directory":
+            make_temp_dir(context, new_datadir, mode)
         segments = GpArray.initFromCatalog(dbconn.DbURL()).getSegmentList()
 
         for seg in segments:
@@ -667,6 +669,8 @@ def impl(context, utility, extra_args=''):
 
 
 @when('the user asynchronously runs {utility} with input file and additional args "{extra_args}" and the process is saved')
+@given('the user asynchronously runs {utility} with input file and additional args "{extra_args}" and the process is saved')
+@then('the user asynchronously runs {utility} with input file and additional args "{extra_args}" and the process is saved')
 def impl(context, utility, extra_args=''):
     cmd = "%s -i %s %s" % (utility, context.mirror_context.input_file_path(), extra_args)
     run_gpcommand_async(context, cmd)

--- a/gpMgmt/test/behave/mgmt_utils/steps/recoverseg_mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/recoverseg_mgmt_utils.py
@@ -571,6 +571,8 @@ def impl(context):
     if len(dirs) > 0:
         raise Exception("One or more backout directories exist: %s" % dirs)
 
+@given('the gprecoverseg lock directory is removed')
+@when('the gprecoverseg lock directory is removed')
 @then('the gprecoverseg lock directory is removed')
 def impl(context):
     lock_dir = "%s/gprecoverseg.lock" % os.environ["MASTER_DATA_DIRECTORY"]


### PR DESCRIPTION
gprecoverseg, gpmovemirrors should show warning and gpexpand should raise an exception if there is already a running instance of pg_basebackup for the segment that needs to be recovered/moved.

Fix:
Create a list segments_with_running_basebackup of segment dbids for which pg_basebackup is running and while creating the recovery triplets, check if the segment to be recovered/moved/added(expansion segments) is already present in the segments_with_running_basebackup list. If that's the case give warning or raise exception and terminate the utility execution.

* Behaviour of gprecoverseg - Warning message is logged containing list of segment contentIds with running basebackup and for the rest of the segments gprecoverseg will proceed with recovery

* Behaviour of gpmovemirrors - Warning message is logged containing list of segment contentIds with running basebackup and for the rest of the mirrors gpmovemirrors will proceed with movement

* Behaviour of gpexpand - Exception is raised and execution is stopped immediately if segments to be added have running pg_basebackup

* Behaviour of gpaddmirrors - As gpaddmirrors does not use force-overwrite flag with pg_basebackup to sync newly added mirrors with primary, the check is not required here. Have added behave test case to ensure it fails when mirror directories are not empty

Limitation of above fix:
To get the list of segments with running pg_basebackup we are querying gp_stat_replication table. At present this table shows only content ID of the source segment for any running pg_basebackup process and no information about the target segment/DataDirectory

Backport of 7X PR: https://github.com/greenplum-db/gpdb/pull/13620

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
