### PR TITLE
Provide signal info to handlers

### DIFF
--- a/src/backend/access/external/url_execute.c
+++ b/src/backend/access/external/url_execute.c
@@ -272,7 +272,7 @@ url_execute_fopen(char *url, bool forwrite, extvar_t *ev, CopyState pstate)
 	 * allows "normal" SIGPIPE handling in the command pipeline.  Normal
 	 * for PG is to *ignore* SIGPIPE.
 	 */
-	save_SIGPIPE = pqsignal(SIGPIPE, SIG_DFL);
+	save_SIGPIPE = pqsignal(SIGPIPE, PQ_SIG_DFL);
 
 	/* execute the user command */
 	file->handle->pid = popen_with_stderr(file->handle->pipes,

--- a/src/backend/bootstrap/bootstrap.c
+++ b/src/backend/bootstrap/bootstrap.c
@@ -548,23 +548,23 @@ bootstrap_signals(void)
 		/*
 		 * Properly accept or ignore signals the postmaster might send us
 		 */
-		pqsignal(SIGHUP, SIG_IGN);
-		pqsignal(SIGINT, SIG_IGN);		/* ignore query-cancel */
+		pqsignal(SIGHUP, PQ_SIG_IGN);
+		pqsignal(SIGINT, PQ_SIG_IGN);		/* ignore query-cancel */
 		pqsignal(SIGTERM, die);
 		pqsignal(SIGQUIT, quickdie);
-		pqsignal(SIGALRM, SIG_IGN);
-		pqsignal(SIGPIPE, SIG_IGN);
-		pqsignal(SIGUSR1, SIG_IGN);
-		pqsignal(SIGUSR2, SIG_IGN);
+		pqsignal(SIGALRM, PQ_SIG_IGN);
+		pqsignal(SIGPIPE, PQ_SIG_IGN);
+		pqsignal(SIGUSR1, PQ_SIG_IGN);
+		pqsignal(SIGUSR2, PQ_SIG_IGN);
 
 		/*
 		 * Reset some signals that are accepted by postmaster but not here
 		 */
-		pqsignal(SIGCHLD, SIG_DFL);
-		pqsignal(SIGTTIN, SIG_DFL);
-		pqsignal(SIGTTOU, SIG_DFL);
-		pqsignal(SIGCONT, SIG_DFL);
-		pqsignal(SIGWINCH, SIG_DFL);
+		pqsignal(SIGCHLD, PQ_SIG_DFL);
+		pqsignal(SIGTTIN, PQ_SIG_DFL);
+		pqsignal(SIGTTOU, PQ_SIG_DFL);
+		pqsignal(SIGCONT, PQ_SIG_DFL);
+		pqsignal(SIGWINCH, PQ_SIG_DFL);
 
 		/*
 		 * Unblock signals (they were blocked when the postmaster forked us)

--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -7951,7 +7951,7 @@ open_program_pipes(char *command, bool forwrite)
 	 * allows "normal" SIGPIPE handling in the command pipeline.  Normal
 	 * for PG is to *ignore* SIGPIPE.
 	 */
-	save_SIGPIPE = pqsignal(SIGPIPE, SIG_DFL);
+	save_SIGPIPE = pqsignal(SIGPIPE, PQ_SIG_DFL);
 
 	program_pipes->pid = popen_with_stderr(program_pipes->pipes, program_pipes->shexec, forwrite);
 

--- a/src/backend/postmaster/autovacuum.c
+++ b/src/backend/postmaster/autovacuum.c
@@ -463,11 +463,11 @@ AutoVacLauncherMain(int argc, char *argv[])
 	pqsignal(SIGQUIT, quickdie);
 	InitializeTimeouts();		/* establishes SIGALRM handler */
 
-	pqsignal(SIGPIPE, SIG_IGN);
+	pqsignal(SIGPIPE, PQ_SIG_IGN);
 	pqsignal(SIGUSR1, procsignal_sigusr1_handler);
 	pqsignal(SIGUSR2, avl_sigusr2_handler);
 	pqsignal(SIGFPE, FloatExceptionHandler);
-	pqsignal(SIGCHLD, SIG_DFL);
+	pqsignal(SIGCHLD, PQ_SIG_DFL);
 
 	/* Early initialization */
 	BaseInit();
@@ -1571,7 +1571,7 @@ AutoVacWorkerMain(int argc, char *argv[])
 	 * Currently, we don't pay attention to postgresql.conf changes that
 	 * happen during a single daemon iteration, so we can ignore SIGHUP.
 	 */
-	pqsignal(SIGHUP, SIG_IGN);
+	pqsignal(SIGHUP, PQ_SIG_IGN);
 
 	/*
 	 * SIGINT is used to signal canceling the current table's vacuum; SIGTERM
@@ -1582,11 +1582,11 @@ AutoVacWorkerMain(int argc, char *argv[])
 	pqsignal(SIGQUIT, quickdie);
 	InitializeTimeouts();		/* establishes SIGALRM handler */
 
-	pqsignal(SIGPIPE, SIG_IGN);
+	pqsignal(SIGPIPE, PQ_SIG_IGN);
 	pqsignal(SIGUSR1, procsignal_sigusr1_handler);
-	pqsignal(SIGUSR2, SIG_IGN);
+	pqsignal(SIGUSR2, PQ_SIG_IGN);
 	pqsignal(SIGFPE, FloatExceptionHandler);
-	pqsignal(SIGCHLD, SIG_DFL);
+	pqsignal(SIGCHLD, PQ_SIG_DFL);
 
 	/* Early initialization */
 	BaseInit();

--- a/src/backend/postmaster/bgworker.c
+++ b/src/backend/postmaster/bgworker.c
@@ -656,19 +656,19 @@ StartBackgroundWorker(void)
 	}
 	else
 	{
-		pqsignal(SIGINT, SIG_IGN);
+		pqsignal(SIGINT, PQ_SIG_IGN);
 		pqsignal(SIGUSR1, bgworker_sigusr1_handler);
-		pqsignal(SIGFPE, SIG_IGN);
+		pqsignal(SIGFPE, PQ_SIG_IGN);
 	}
 	pqsignal(SIGTERM, bgworker_die);
-	pqsignal(SIGHUP, SIG_IGN);
+	pqsignal(SIGHUP, PQ_SIG_IGN);
 
 	pqsignal(SIGQUIT, bgworker_quickdie);
 	InitializeTimeouts();		/* establishes SIGALRM handler */
 
-	pqsignal(SIGPIPE, SIG_IGN);
-	pqsignal(SIGUSR2, SIG_IGN);
-	pqsignal(SIGCHLD, SIG_DFL);
+	pqsignal(SIGPIPE, PQ_SIG_IGN);
+	pqsignal(SIGUSR2, PQ_SIG_IGN);
+	pqsignal(SIGCHLD, PQ_SIG_DFL);
 
 	/*
 	 * If an exception is encountered, processing resumes here.

--- a/src/backend/postmaster/bgwriter.c
+++ b/src/backend/postmaster/bgwriter.c
@@ -132,22 +132,22 @@ BackgroundWriterMain(void)
 	 * handler is still needed for latch wakeups.
 	 */
 	pqsignal(SIGHUP, BgSigHupHandler);	/* set flag to read config file */
-	pqsignal(SIGINT, SIG_IGN);
+	pqsignal(SIGINT, PQ_SIG_IGN);
 	pqsignal(SIGTERM, ReqShutdownHandler);		/* shutdown */
 	pqsignal(SIGQUIT, bg_quickdie);		/* hard crash time */
-	pqsignal(SIGALRM, SIG_IGN);
-	pqsignal(SIGPIPE, SIG_IGN);
+	pqsignal(SIGALRM, PQ_SIG_IGN);
+	pqsignal(SIGPIPE, PQ_SIG_IGN);
 	pqsignal(SIGUSR1, bgwriter_sigusr1_handler);
-	pqsignal(SIGUSR2, SIG_IGN);
+	pqsignal(SIGUSR2, PQ_SIG_IGN);
 
 	/*
 	 * Reset some signals that are accepted by postmaster but not here
 	 */
-	pqsignal(SIGCHLD, SIG_DFL);
-	pqsignal(SIGTTIN, SIG_DFL);
-	pqsignal(SIGTTOU, SIG_DFL);
-	pqsignal(SIGCONT, SIG_DFL);
-	pqsignal(SIGWINCH, SIG_DFL);
+	pqsignal(SIGCHLD, PQ_SIG_DFL);
+	pqsignal(SIGTTIN, PQ_SIG_DFL);
+	pqsignal(SIGTTOU, PQ_SIG_DFL);
+	pqsignal(SIGCONT, PQ_SIG_DFL);
+	pqsignal(SIGWINCH, PQ_SIG_DFL);
 
 	/* We allow SIGQUIT (quickdie) at all times */
 	sigdelset(&BlockSig, SIGQUIT);

--- a/src/backend/postmaster/checkpointer.c
+++ b/src/backend/postmaster/checkpointer.c
@@ -232,21 +232,21 @@ CheckpointerMain(void)
 	pqsignal(SIGHUP, ChkptSigHupHandler);		/* set flag to read config
 												 * file */
 	pqsignal(SIGINT, ReqCheckpointHandler);		/* request checkpoint */
-	pqsignal(SIGTERM, SIG_IGN); /* ignore SIGTERM */
+	pqsignal(SIGTERM, PQ_SIG_IGN); /* ignore SIGTERM */
 	pqsignal(SIGQUIT, chkpt_quickdie);	/* hard crash time */
-	pqsignal(SIGALRM, SIG_IGN);
-	pqsignal(SIGPIPE, SIG_IGN);
+	pqsignal(SIGALRM, PQ_SIG_IGN);
+	pqsignal(SIGPIPE, PQ_SIG_IGN);
 	pqsignal(SIGUSR1, chkpt_sigusr1_handler);
 	pqsignal(SIGUSR2, ReqShutdownHandler);		/* request shutdown */
 
 	/*
 	 * Reset some signals that are accepted by postmaster but not here
 	 */
-	pqsignal(SIGCHLD, SIG_DFL);
-	pqsignal(SIGTTIN, SIG_DFL);
-	pqsignal(SIGTTOU, SIG_DFL);
-	pqsignal(SIGCONT, SIG_DFL);
-	pqsignal(SIGWINCH, SIG_DFL);
+	pqsignal(SIGCHLD, PQ_SIG_DFL);
+	pqsignal(SIGTTIN, PQ_SIG_DFL);
+	pqsignal(SIGTTOU, PQ_SIG_DFL);
+	pqsignal(SIGCONT, PQ_SIG_DFL);
+	pqsignal(SIGWINCH, PQ_SIG_DFL);
 
 	/* We allow SIGQUIT (quickdie) at all times */
 #ifdef HAVE_SIGPROCMASK

--- a/src/backend/postmaster/pgarch.c
+++ b/src/backend/postmaster/pgarch.c
@@ -250,18 +250,18 @@ PgArchiverMain(int argc, char *argv[])
 	 * except for SIGHUP, SIGTERM, SIGUSR1, SIGUSR2, and SIGQUIT.
 	 */
 	pqsignal(SIGHUP, ArchSigHupHandler);
-	pqsignal(SIGINT, SIG_IGN);
+	pqsignal(SIGINT, PQ_SIG_IGN);
 	pqsignal(SIGTERM, ArchSigTermHandler);
 	pqsignal(SIGQUIT, pgarch_exit);
-	pqsignal(SIGALRM, SIG_IGN);
-	pqsignal(SIGPIPE, SIG_IGN);
+	pqsignal(SIGALRM, PQ_SIG_IGN);
+	pqsignal(SIGPIPE, PQ_SIG_IGN);
 	pqsignal(SIGUSR1, pgarch_waken);
 	pqsignal(SIGUSR2, pgarch_waken_stop);
-	pqsignal(SIGCHLD, SIG_DFL);
-	pqsignal(SIGTTIN, SIG_DFL);
-	pqsignal(SIGTTOU, SIG_DFL);
-	pqsignal(SIGCONT, SIG_DFL);
-	pqsignal(SIGWINCH, SIG_DFL);
+	pqsignal(SIGCHLD, PQ_SIG_DFL);
+	pqsignal(SIGTTIN, PQ_SIG_DFL);
+	pqsignal(SIGTTOU, PQ_SIG_DFL);
+	pqsignal(SIGCONT, PQ_SIG_DFL);
+	pqsignal(SIGWINCH, PQ_SIG_DFL);
 	PG_SETMASK(&UnBlockSig);
 
 	/*

--- a/src/backend/postmaster/pgstat.c
+++ b/src/backend/postmaster/pgstat.c
@@ -3338,18 +3338,18 @@ PgstatCollectorMain(int argc, char *argv[])
 	 * support latch operations, because pgStatLatch is local not shared.
 	 */
 	pqsignal(SIGHUP, pgstat_sighup_handler);
-	pqsignal(SIGINT, SIG_IGN);
-	pqsignal(SIGTERM, SIG_IGN);
+	pqsignal(SIGINT, PQ_SIG_IGN);
+	pqsignal(SIGTERM, PQ_SIG_IGN);
 	pqsignal(SIGQUIT, pgstat_exit);
-	pqsignal(SIGALRM, SIG_IGN);
-	pqsignal(SIGPIPE, SIG_IGN);
-	pqsignal(SIGUSR1, SIG_IGN);
-	pqsignal(SIGUSR2, SIG_IGN);
-	pqsignal(SIGCHLD, SIG_DFL);
-	pqsignal(SIGTTIN, SIG_DFL);
-	pqsignal(SIGTTOU, SIG_DFL);
-	pqsignal(SIGCONT, SIG_DFL);
-	pqsignal(SIGWINCH, SIG_DFL);
+	pqsignal(SIGALRM, PQ_SIG_IGN);
+	pqsignal(SIGPIPE, PQ_SIG_IGN);
+	pqsignal(SIGUSR1, PQ_SIG_IGN);
+	pqsignal(SIGUSR2, PQ_SIG_IGN);
+	pqsignal(SIGCHLD, PQ_SIG_DFL);
+	pqsignal(SIGTTIN, PQ_SIG_DFL);
+	pqsignal(SIGTTOU, PQ_SIG_DFL);
+	pqsignal(SIGCONT, PQ_SIG_DFL);
+	pqsignal(SIGWINCH, PQ_SIG_DFL);
 	PG_SETMASK(&UnBlockSig);
 
 	/*

--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -713,16 +713,16 @@ PostmasterMain(int argc, char *argv[])
 	pqsignal(SIGINT, pmdie);	/* send SIGTERM and shut down */
 	pqsignal(SIGQUIT, pmdie);	/* send SIGQUIT and die */
 	pqsignal(SIGTERM, pmdie);	/* wait for children and shut down */
-	pqsignal(SIGALRM, SIG_IGN); /* ignored */
-	pqsignal(SIGPIPE, SIG_IGN); /* ignored */
+	pqsignal(SIGALRM, PQ_SIG_IGN); /* ignored */
+	pqsignal(SIGPIPE, PQ_SIG_IGN); /* ignored */
 	pqsignal(SIGUSR1, sigusr1_handler); /* message from child process */
 	pqsignal(SIGUSR2, dummy_handler);	/* unused, reserve for children */
 	pqsignal(SIGCHLD, reaper);	/* handle child termination */
-	pqsignal(SIGTTIN, SIG_IGN); /* ignored */
-	pqsignal(SIGTTOU, SIG_IGN); /* ignored */
+	pqsignal(SIGTTIN, PQ_SIG_IGN); /* ignored */
+	pqsignal(SIGTTOU, PQ_SIG_IGN); /* ignored */
 	/* ignore SIGXFSZ, so that ulimit violations work like disk full */
 #ifdef SIGXFSZ
-	pqsignal(SIGXFSZ, SIG_IGN); /* ignored */
+	pqsignal(SIGXFSZ, PQ_SIG_IGN); /* ignored */
 #endif
 
 	/*
@@ -1726,7 +1726,7 @@ checkPgDir(const char *dir)
 			elog(LOG, "System file or directory missing (%s), shutting down segment", dir);
 
 		/* quit all processes and exit */
-		pmdie(SIGQUIT);
+		pmdie(SIGQUIT, NULL, NULL);
 	}
 }
 

--- a/src/backend/postmaster/startup.c
+++ b/src/backend/postmaster/startup.c
@@ -198,11 +198,11 @@ StartupProcessMain(void)
 	 * Properly accept or ignore signals the postmaster might send us.
 	 */
 	pqsignal(SIGHUP, StartupProcSigHupHandler); /* reload config file */
-	pqsignal(SIGINT, SIG_IGN);	/* ignore query cancel */
+	pqsignal(SIGINT, PQ_SIG_IGN);	/* ignore query cancel */
 	pqsignal(SIGTERM, StartupProcShutdownHandler);		/* request shutdown */
 	pqsignal(SIGQUIT, startupproc_quickdie);	/* hard crash time */
 	InitializeTimeouts();		/* establishes SIGALRM handler */
-	pqsignal(SIGPIPE, SIG_IGN);
+	pqsignal(SIGPIPE, PQ_SIG_IGN);
 	pqsignal(SIGUSR1, StartupProcSigUsr1Handler);
 	pqsignal(SIGUSR2, StartupProcTriggerHandler);
 
@@ -219,11 +219,11 @@ StartupProcessMain(void)
 	/*
 	 * Reset some signals that are accepted by postmaster but not here
 	 */
-	pqsignal(SIGCHLD, SIG_DFL);
-	pqsignal(SIGTTIN, SIG_DFL);
-	pqsignal(SIGTTOU, SIG_DFL);
-	pqsignal(SIGCONT, SIG_DFL);
-	pqsignal(SIGWINCH, SIG_DFL);
+	pqsignal(SIGCHLD, PQ_SIG_DFL);
+	pqsignal(SIGTTIN, PQ_SIG_DFL);
+	pqsignal(SIGTTOU, PQ_SIG_DFL);
+	pqsignal(SIGCONT, PQ_SIG_DFL);
+	pqsignal(SIGWINCH, PQ_SIG_DFL);
 
 	/*
 	 * Register timeouts needed for standby mode

--- a/src/backend/postmaster/syslogger.c
+++ b/src/backend/postmaster/syslogger.c
@@ -373,22 +373,22 @@ SysLoggerMain(int argc, char *argv[])
 	 */
 
 	pqsignal(SIGHUP, sigHupHandler);	/* set flag to read config file */
-	pqsignal(SIGINT, SIG_IGN);
-	pqsignal(SIGTERM, SIG_IGN);
-	pqsignal(SIGQUIT, SIG_IGN);
-	pqsignal(SIGALRM, SIG_IGN);
-	pqsignal(SIGPIPE, SIG_IGN);
+	pqsignal(SIGINT, PQ_SIG_IGN);
+	pqsignal(SIGTERM, PQ_SIG_IGN);
+	pqsignal(SIGQUIT, PQ_SIG_IGN);
+	pqsignal(SIGALRM, PQ_SIG_IGN);
+	pqsignal(SIGPIPE, PQ_SIG_IGN);
 	pqsignal(SIGUSR1, sigUsr1Handler);	/* request log rotation */
-	pqsignal(SIGUSR2, SIG_IGN);
+	pqsignal(SIGUSR2, PQ_SIG_IGN);
 
 	/*
 	 * Reset some signals that are accepted by postmaster but not here
 	 */
-	pqsignal(SIGCHLD, SIG_DFL);
-	pqsignal(SIGTTIN, SIG_DFL);
-	pqsignal(SIGTTOU, SIG_DFL);
-	pqsignal(SIGCONT, SIG_DFL);
-	pqsignal(SIGWINCH, SIG_DFL);
+	pqsignal(SIGCHLD, PQ_SIG_DFL);
+	pqsignal(SIGTTIN, PQ_SIG_DFL);
+	pqsignal(SIGTTOU, PQ_SIG_DFL);
+	pqsignal(SIGCONT, PQ_SIG_DFL);
+	pqsignal(SIGWINCH, PQ_SIG_DFL);
 
 	PG_SETMASK(&UnBlockSig);
 

--- a/src/backend/postmaster/walwriter.c
+++ b/src/backend/postmaster/walwriter.c
@@ -122,19 +122,19 @@ WalWriterMain(void)
 	pqsignal(SIGINT, WalShutdownHandler);		/* request shutdown */
 	pqsignal(SIGTERM, WalShutdownHandler);		/* request shutdown */
 	pqsignal(SIGQUIT, wal_quickdie);	/* hard crash time */
-	pqsignal(SIGALRM, SIG_IGN);
-	pqsignal(SIGPIPE, SIG_IGN);
+	pqsignal(SIGALRM, PQ_SIG_IGN);
+	pqsignal(SIGPIPE, PQ_SIG_IGN);
 	pqsignal(SIGUSR1, walwriter_sigusr1_handler);
-	pqsignal(SIGUSR2, SIG_IGN); /* not used */
+	pqsignal(SIGUSR2, PQ_SIG_IGN); /* not used */
 
 	/*
 	 * Reset some signals that are accepted by postmaster but not here
 	 */
-	pqsignal(SIGCHLD, SIG_DFL);
-	pqsignal(SIGTTIN, SIG_DFL);
-	pqsignal(SIGTTOU, SIG_DFL);
-	pqsignal(SIGCONT, SIG_DFL);
-	pqsignal(SIGWINCH, SIG_DFL);
+	pqsignal(SIGCHLD, PQ_SIG_DFL);
+	pqsignal(SIGTTIN, PQ_SIG_DFL);
+	pqsignal(SIGTTOU, PQ_SIG_DFL);
+	pqsignal(SIGCONT, PQ_SIG_DFL);
+	pqsignal(SIGWINCH, PQ_SIG_DFL);
 
 	/* We allow SIGQUIT (quickdie) at all times */
 	sigdelset(&BlockSig, SIGQUIT);

--- a/src/backend/replication/walreceiver.c
+++ b/src/backend/replication/walreceiver.c
@@ -261,20 +261,20 @@ WalReceiverMain(void)
 	/* Properly accept or ignore signals the postmaster might send us */
 	pqsignal(SIGHUP, WalRcvSigHupHandler);		/* set flag to read config
 												 * file */
-	pqsignal(SIGINT, SIG_IGN);
+	pqsignal(SIGINT, PQ_SIG_IGN);
 	pqsignal(SIGTERM, WalRcvShutdownHandler);	/* request shutdown */
 	pqsignal(SIGQUIT, WalRcvQuickDieHandler);	/* hard crash time */
-	pqsignal(SIGALRM, SIG_IGN);
-	pqsignal(SIGPIPE, SIG_IGN);
+	pqsignal(SIGALRM, PQ_SIG_IGN);
+	pqsignal(SIGPIPE, PQ_SIG_IGN);
 	pqsignal(SIGUSR1, WalRcvSigUsr1Handler);
-	pqsignal(SIGUSR2, SIG_IGN);
+	pqsignal(SIGUSR2, PQ_SIG_IGN);
 
 	/* Reset some signals that are accepted by postmaster but not here */
-	pqsignal(SIGCHLD, SIG_DFL);
-	pqsignal(SIGTTIN, SIG_DFL);
-	pqsignal(SIGTTOU, SIG_DFL);
-	pqsignal(SIGCONT, SIG_DFL);
-	pqsignal(SIGWINCH, SIG_DFL);
+	pqsignal(SIGCHLD, PQ_SIG_DFL);
+	pqsignal(SIGTTIN, PQ_SIG_DFL);
+	pqsignal(SIGTTOU, PQ_SIG_DFL);
+	pqsignal(SIGCONT, PQ_SIG_DFL);
+	pqsignal(SIGWINCH, PQ_SIG_DFL);
 
 #ifdef SIGILL
 	pqsignal(SIGILL, WalRcvCrashHandler);

--- a/src/backend/replication/walsender.c
+++ b/src/backend/replication/walsender.c
@@ -2838,21 +2838,21 @@ WalSndSignals(void)
 	/* Set up signal handlers */
 	pqsignal(SIGHUP, PostgresSigHupHandler);	/* set flag to read config
 												 * file */
-	pqsignal(SIGINT, SIG_IGN);	/* not used */
+	pqsignal(SIGINT, PQ_SIG_IGN);	/* not used */
 	pqsignal(SIGTERM, die);		/* request shutdown */
 	pqsignal(SIGQUIT, quickdie);	/* hard crash time */
 	InitializeTimeouts();		/* establishes SIGALRM handler */
-	pqsignal(SIGPIPE, SIG_IGN);
+	pqsignal(SIGPIPE, PQ_SIG_IGN);
 	pqsignal(SIGUSR1, procsignal_sigusr1_handler);
 	pqsignal(SIGUSR2, WalSndLastCycleHandler);	/* request a last cycle and
 												 * shutdown */
 
 	/* Reset some signals that are accepted by postmaster but not here */
-	pqsignal(SIGCHLD, SIG_DFL);
-	pqsignal(SIGTTIN, SIG_DFL);
-	pqsignal(SIGTTOU, SIG_DFL);
-	pqsignal(SIGCONT, SIG_DFL);
-	pqsignal(SIGWINCH, SIG_DFL);
+	pqsignal(SIGCHLD, PQ_SIG_DFL);
+	pqsignal(SIGTTIN, PQ_SIG_DFL);
+	pqsignal(SIGTTOU, PQ_SIG_DFL);
+	pqsignal(SIGCONT, PQ_SIG_DFL);
+	pqsignal(SIGWINCH, PQ_SIG_DFL);
 
 #ifdef SIGILL
 	pqsignal(SIGILL, WalSndCrashHandler);

--- a/src/backend/storage/ipc/ipc.c
+++ b/src/backend/storage/ipc/ipc.c
@@ -98,7 +98,7 @@ static int	on_proc_exit_index,
 void
 proc_exit(int code)
 {
-	pqsignal(SIGALRM, SIG_IGN);
+	pqsignal(SIGALRM, PQ_SIG_IGN);
 
 	/* Clean up everything that must be cleaned up */
 	proc_exit_prepare(code);

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -3500,6 +3500,10 @@ StatementCancelHandler(SIGNAL_ARGS)
 {
 	int			save_errno = errno;
 
+#ifdef HAVE_POSIX_SIGNALS
+	dump_signal_info(postgres_signal_info);
+#endif
+
 	/*
 	 * Don't joggle the elbow of proc_exit
 	 */
@@ -4799,16 +4803,16 @@ PostgresMain(int argc, char *argv[],
 		 * returns to outer loop.  This seems safer than forcing exit in the
 		 * midst of output during who-knows-what operation...
 		 */
-		pqsignal(SIGPIPE, SIG_IGN);
+		pqsignal(SIGPIPE, PQ_SIG_IGN);
 		pqsignal(SIGUSR1, procsignal_sigusr1_handler);
-		pqsignal(SIGUSR2, SIG_IGN);
+		pqsignal(SIGUSR2, PQ_SIG_IGN);
 		pqsignal(SIGFPE, FloatExceptionHandler);
 
 		/*
 		 * Reset some signals that are accepted by postmaster but not by
 		 * backend
 		 */
-		pqsignal(SIGCHLD, SIG_DFL);		/* system() requires this on some
+		pqsignal(SIGCHLD, PQ_SIG_DFL);		/* system() requires this on some
 										 * platforms */
 #ifndef _WIN32
 #ifdef SIGILL

--- a/src/backend/utils/gpmon/gpmon.c
+++ b/src/backend/utils/gpmon/gpmon.c
@@ -41,9 +41,9 @@ struct  {
 
 int64 gpmon_tick = 0;
 
-void gpmon_sig_handler(int sig);
+void gpmon_sig_handler(SIGNAL_ARGS);
 
-void gpmon_sig_handler(int sig) 
+void gpmon_sig_handler(SIGNAL_ARGS)
 {
 	gpmon_tick++;
 }
@@ -62,7 +62,7 @@ void gpmon_init(void)
 		return;
 #ifndef WIN32
 	sfunc = pqsignal(SIGVTALRM, gpmon_sig_handler);
-	if (sfunc == SIG_ERR) {
+	if (sfunc == PQ_SIG_ERR) {
 		elog(WARNING, "gpmon: unable to set signal handler for SIGVTALRM (%m)");
 	}
 	else if (sfunc == gpmon_sig_handler) {

--- a/src/bin/initdb/initdb.c
+++ b/src/bin/initdb/initdb.c
@@ -286,7 +286,7 @@ static void vacuum_db(void);
 static void make_template0(void);
 static void make_postgres(void);
 static void fsync_pgdata(void);
-static void trapsig(int signum);
+static void trapsig(SIGNAL_ARGS);
 static void check_ok(void);
 static char *escape_quotes(const char *src);
 static int	locale_date_order(const char *locale);
@@ -2608,10 +2608,10 @@ fsync_pgdata(void)
  * So this will need some testing on Windows.
  */
 static void
-trapsig(int signum)
+trapsig(SIGNAL_ARGS)
 {
 	/* handle systems that reset the handler, like Windows (grr) */
-	pqsignal(signum, trapsig);
+	pqsignal(postgres_signal_arg, trapsig);
 	caught_signal = true;
 }
 
@@ -3472,12 +3472,12 @@ setup_signals(void)
 
 	/* Ignore SIGPIPE when writing to backend, so we can clean up */
 #ifdef SIGPIPE
-	pqsignal(SIGPIPE, SIG_IGN);
+	pqsignal(SIGPIPE, PQ_SIG_IGN);
 #endif
 
 	/* Prevent SIGSYS so we can probe for kernel calls that might not work */
 #ifdef SIGSYS
-	pqsignal(SIGSYS, SIG_IGN);
+	pqsignal(SIGSYS, PQ_SIG_IGN);
 #endif
 }
 

--- a/src/bin/pg_basebackup/pg_receivexlog.c
+++ b/src/bin/pg_basebackup/pg_receivexlog.c
@@ -317,7 +317,7 @@ StreamLog(void)
 #ifndef WIN32
 
 static void
-sigint_handler(int signum)
+sigint_handler(SIGNAL_ARGS)
 {
 	time_to_abort = true;
 }

--- a/src/bin/pg_basebackup/pg_recvlogical.c
+++ b/src/bin/pg_basebackup/pg_recvlogical.c
@@ -592,7 +592,7 @@ error:
  * moment.
  */
 static void
-sigint_handler(int signum)
+sigint_handler(SIGNAL_ARGS)
 {
 	time_to_abort = true;
 }
@@ -601,7 +601,7 @@ sigint_handler(int signum)
  * Trigger the output file to be reopened.
  */
 static void
-sighup_handler(int signum)
+sighup_handler(SIGNAL_ARGS)
 {
 	output_reopen = true;
 }

--- a/src/bin/pg_ctl/pg_ctl.c
+++ b/src/bin/pg_ctl/pg_ctl.c
@@ -870,7 +870,7 @@ read_post_opts(void)
  * waiting for the server to start up, the server launch is aborted.
  */
 static void
-trap_sigint_during_startup(int sig)
+trap_sigint_during_startup(SIGNAL_ARGS)
 {
 	if (postmasterPID != -1)
 	{
@@ -883,7 +883,7 @@ trap_sigint_during_startup(int sig)
 	 * Clear the signal handler, and send the signal again, to terminate the
 	 * process as normal.
 	 */
-	pqsignal(SIGINT, SIG_DFL);
+	pqsignal(SIGINT, PQ_SIG_DFL);
 	raise(SIGINT);
 }
 

--- a/src/bin/pg_dump/parallel.c
+++ b/src/bin/pg_dump/parallel.c
@@ -534,9 +534,9 @@ sigTermHandler(SIGNAL_ARGS)
 	 * signal handler.  That could muck up our attempt to send PQcancel, so
 	 * disable the signals that setup_cancel_handler enabled.
 	 */
-	pqsignal(SIGINT, SIG_IGN);
-	pqsignal(SIGTERM, SIG_IGN);
-	pqsignal(SIGQUIT, SIG_IGN);
+	pqsignal(SIGINT, PQ_SIG_IGN);
+	pqsignal(SIGTERM, PQ_SIG_IGN);
+	pqsignal(SIGQUIT, PQ_SIG_IGN);
 
 	/*
 	 * If we're in the master, forward signal to all workers.  (It seems best
@@ -1023,7 +1023,7 @@ ParallelBackupStart(ArchiveHandle *AH, RestoreOptions *ropt)
 	 * the workers to inherit this setting, though.
 	 */
 #ifndef WIN32
-	pqsignal(SIGPIPE, SIG_IGN);
+	pqsignal(SIGPIPE, PQ_SIG_IGN);
 #endif
 
 	/*

--- a/src/bin/psql/common.c
+++ b/src/bin/psql/common.c
@@ -80,7 +80,7 @@ setQFout(const char *fname)
 
 	/* Direct signals */
 #ifndef WIN32
-	pqsignal(SIGPIPE, pset.queryFoutPipe ? SIG_IGN : SIG_DFL);
+	pqsignal(SIGPIPE, pset.queryFoutPipe ? PQ_SIG_IGN : PQ_SIG_DFL);
 #endif
 
 	return status;

--- a/src/bin/psql/copy.c
+++ b/src/bin/psql/copy.c
@@ -366,7 +366,7 @@ do_copy(const char *args)
 				fflush(stderr);
 				errno = 0;
 #ifndef WIN32
-				pqsignal(SIGPIPE, SIG_IGN);
+				pqsignal(SIGPIPE, PQ_SIG_IGN);
 #endif
 				copystream = popen(options->file, PG_BINARY_W);
 			}
@@ -453,7 +453,7 @@ do_copy(const char *args)
 				success = false;
 			}
 #ifndef WIN32
-			pqsignal(SIGPIPE, SIG_DFL);
+			pqsignal(SIGPIPE, PQ_SIG_DFL);
 #endif
 		}
 		else

--- a/src/bin/psql/print.c
+++ b/src/bin/psql/print.c
@@ -2242,14 +2242,14 @@ PageOutput(int lines, unsigned short int pager)
 					return stdout;
 			}
 #ifndef WIN32
-			pqsignal(SIGPIPE, SIG_IGN);
+			pqsignal(SIGPIPE, PQ_SIG_IGN);
 #endif
 			pagerpipe = popen(pagerprog, "w");
 			if (pagerpipe)
 				return pagerpipe;
 			/* if popen fails, silently proceed without pager */
 #ifndef WIN32
-			pqsignal(SIGPIPE, SIG_DFL);
+			pqsignal(SIGPIPE, PQ_SIG_DFL);
 #endif
 #ifdef TIOCGWINSZ
 		}
@@ -2282,7 +2282,7 @@ ClosePager(FILE *pagerpipe)
 
 		pclose(pagerpipe);
 #ifndef WIN32
-		pqsignal(SIGPIPE, SIG_DFL);
+		pqsignal(SIGPIPE, PQ_SIG_DFL);
 #endif
 	}
 }

--- a/src/include/c.h
+++ b/src/include/c.h
@@ -115,6 +115,9 @@ extern "C" {
 #include "pg_config_os.h"
 #endif
 
+#ifdef HAVE_POSIX_SIGNALS
+#include <signal.h>
+#endif
 
 /* ----------------------------------------------------------------
  *				Section 1: compiler characteristics
@@ -1282,11 +1285,18 @@ extern unsigned long long strtoull(const char *str, char **endptr, int base);
  */
 
 #ifndef SIGNAL_ARGS
+#ifdef HAVE_POSIX_SIGNALS
+#define SIGNAL_ARGS  int postgres_signal_arg, \
+                     siginfo_t *postgres_signal_info, \
+                     void *postgres_signal_ucontext
+#else
 #define SIGNAL_ARGS  int postgres_signal_arg
+#endif
 #endif
 
 #ifndef PASS_SIGNAL_ARGS
 #define PASS_SIGNAL_ARGS postgres_signal_arg
+#define PASS_SIGNAL_ARGS_DEF int postgres_signal_arg
 #endif
 
 /*

--- a/src/include/port.h
+++ b/src/include/port.h
@@ -482,7 +482,20 @@ extern int	pg_check_dir(const char *dir);
 extern int	pg_mkdir_p(char *path, int omode);
 
 /* port/pqsignal.c */
+#include <signal.h>
+
+#ifdef HAVE_POSIX_SIGNALS
+typedef void (*pqsigfunc) (int signo, siginfo_t *siginfo, void *ucontext);
+#define PQ_SIG_ERR  ((pqsigfunc) -1)
+#define PQ_SIG_DFL  ((pqsigfunc)  0)
+#define PQ_SIG_IGN  ((pqsigfunc)  1)
+#else
 typedef void (*pqsigfunc) (int signo);
+#define PQ_SIG_DFL SIG_DFL
+#define PQ_SIG_IGN SIG_IGN
+#define PQ_SIG_ERR SIG_ERR
+#endif
+
 extern pqsigfunc pqsignal(int signo, pqsigfunc func);
 
 /* port/quotes.c */

--- a/src/include/utils/elog.h
+++ b/src/include/utils/elog.h
@@ -19,6 +19,7 @@
 #include "c.h"
 #include <sys/time.h>
 #include <setjmp.h>
+#include <signal.h>
 
 /* Error level codes */
 #define DEBUG5		10			/* Debugging messages, in categories of
@@ -641,6 +642,10 @@ extern char *stack_base_ptr;
 extern bool gp_log_stack_trace_lines;   /* session GUC, controls line info in stack traces */
 
 extern const char *SegvBusIllName(int signal);
-extern void StandardHandlerForSigillSigsegvSigbus_OnMainThread(char * processName, SIGNAL_ARGS);
+extern void StandardHandlerForSigillSigsegvSigbus_OnMainThread(char * processName, PASS_SIGNAL_ARGS_DEF);
+
+#ifdef HAVE_POSIX_SIGNALS
+extern void dump_signal_info(siginfo_t *postgres_signal_info);
+#endif
 
 #endif   /* ELOG_H */

--- a/src/interfaces/libpq/fe-print.c
+++ b/src/interfaces/libpq/fe-print.c
@@ -189,7 +189,7 @@ PQprint(FILE *fout, const PGresult *res, const PQprintOpt *po)
 					if (pq_block_sigpipe(&osigset, &sigpipe_pending) == 0)
 						sigpipe_masked = true;
 #else
-					oldsigpipehandler = pqsignal(SIGPIPE, SIG_IGN);
+					oldsigpipehandler = pqsignal(SIGPIPE, PQ_SIG_IGN);
 #endif   /* ENABLE_THREAD_SAFETY */
 #endif   /* WIN32 */
 				}

--- a/src/interfaces/libpq/fe-secure.c
+++ b/src/interfaces/libpq/fe-secure.c
@@ -165,7 +165,7 @@ struct sigpipe_info
 #define DISABLE_SIGPIPE(conn, spinfo, failaction) \
 	do { \
 		if (!SIGPIPE_MASKED(conn)) \
-			spinfo = pqsignal(SIGPIPE, SIG_IGN); \
+			spinfo = pqsignal(SIGPIPE, PQ_SIG_IGN); \
 	} while (0)
 
 #define REMEMBER_EPIPE(spinfo, cond)

--- a/src/test/regress/pg_regress.c
+++ b/src/test/regress/pg_regress.c
@@ -371,12 +371,12 @@ remove_temp(void)
  * Signal handler that calls remove_temp() and reraises the signal.
  */
 static void
-signal_remove_temp(int signum)
+signal_remove_temp(SIGNAL_ARGS)
 {
 	remove_temp();
 
-	pqsignal(signum, SIG_DFL);
-	raise(signum);
+	pqsignal(postgres_signal_arg, PQ_SIG_DFL);
+	raise(postgres_signal_arg);
 }
 
 /*


### PR DESCRIPTION
Hello guys.
This PR changes a signal handler signature to extended one so that we can find out who sends signal. This improves investigation of some problems that we have in our environment and probably it will be helpful to community. The problem is that on one of the segment hosts a query process (gang member) receives SIGINT. Looking at logs we can't say who sends it. It just write in segment logs that process receives a query cancel request (SIGINT). Than master writes out that he lost one of the gang and cancel the whole query. This patch adds logging of signal sender pid, uid and his command line so that we can have a clue for investigation.
Regression tests almost passes (97%). I'm struggling with them right now, because some of them depends on cluster configuration and installed extensions. But anyway it's worth to be reviewed and discussed here.