### PR TITLE
docs - add content for ltree module

### DIFF
--- a/gpdb-doc/markdown/install_guide/install_modules.html.md
+++ b/gpdb-doc/markdown/install_guide/install_modules.html.md
@@ -29,12 +29,13 @@ You can register the following modules in this manner:
 <li class="li"><a class="xref" href="../ref_guide/modules/diskquota.html">diskquota</a></li>
 <li class="li"><a class="xref" href="../ref_guide/modules/fuzzystrmatch.html">fuzzystrmatch</a></li>
 <li class="li"><a class="xref" href="../ref_guide/modules/gp_sparse_vector.html">gp_sparse_vector</a></li>
+<li class="li"><a class="xref" href="../ref_guide/modules/hstore.html">hstore</a></li>
+<li class="li"><a class="xref" href="../ref_guide/modules/ip4r.html">ip4r</a></li>
 </ul>
 </td>
 <td style="vertical-align:top;">
 <ul class="ul">
-<li class="li"><a class="xref" href="../ref_guide/modules/hstore.html">hstore</a></li>
-<li class="li"><a class="xref" href="../ref_guide/modules/ip4r.html">ip4r</a></li>
+<li class="li"><a class="xref" href="../ref_guide/modules/ltree.html">ltree</a></li>
 <li class="li"><a class="xref" href="../ref_guide/modules/orafce_ref.html">orafce</a> (Tanzu Greenplum only)</li>
 <li class="li"><a class="xref" href="../ref_guide/modules/pageinspect.html">pageinspect</a></li>
 <li class="li"><a class="xref" href="../ref_guide/modules/pg_trgm.html">pg_trgm</a></li>

--- a/gpdb-doc/markdown/ref_guide/modules/intro.html.md
+++ b/gpdb-doc/markdown/ref_guide/modules/intro.html.md
@@ -17,6 +17,7 @@ The following Greenplum Database and PostgreSQL `contrib` modules are installed;
 -   [gp\_sparse\_vector](gp_sparse_vector.html) - Implements a Greenplum Database data type that uses compressed storage of zeros to make vector computations on floating point numbers faster.
 -   [hstore](hstore.html) - Provides a data type for storing sets of key/value pairs within a single PostgreSQL value.
 -   [ip4r](ip4r.html) - Provides data types for operations on IPv4 and IPv6 IP addresses.
+-   [ltree](ltree.html) - Provides data types for representing labels of data stored in a hierarchical tree-like structure.
 -   [orafce](orafce_ref.html) - Provides Greenplum Database-specific Oracle SQL compatibility functions.
 -   [pageinspect](pageinspect.html) - Provides functions for low level inspection of the contents of database pages; available to superusers only.
 -   [pg\_trgm](pg_trgm.html) - Provides functions and operators for determining the similarity of alphanumeric text based on trigram matching. The module also provides index operator classes that support fast searching for similar strings.

--- a/gpdb-doc/markdown/ref_guide/modules/ltree.html.md
+++ b/gpdb-doc/markdown/ref_guide/modules/ltree.html.md
@@ -1,0 +1,20 @@
+# ltree
+
+The `ltree` module implements a data type named `ltree` that you can use to represent labels of data stored in a hierarchical tree-like structure. The module also provides extensive facilities for searching through label trees.
+
+The Greenplum Database `ltree` module is equivalent to the `ltree` module used with PostgreSQL. There are no Greenplum Database or MPP-specific considerations for the module.
+
+## <a id="topic_reg"></a>Installing and Registering the Module
+
+The `ltree` module is installed when you install Greenplum Database. Before you can use any of the data types, functions, or operators defined in the module, you must register the `ltree` extension in each database in which you want to use the objects:
+
+```
+CREATE EXTENSION ltree;
+```
+
+Refer to [Installing Additional Supplied Modules](../../install_guide/install_modules.html) for more information.
+
+## <a id="topic_info"></a>Module Documentation
+
+Refer to the [ltree](https://www.postgresql.org/docs/12/ltree.html) PostgreSQL documentation for detailed information about the data types, functions, and operators defined in this module.
+

--- a/gpdb-doc/markdown/ref_guide/modules/ltree.html.md
+++ b/gpdb-doc/markdown/ref_guide/modules/ltree.html.md
@@ -2,7 +2,7 @@
 
 The `ltree` module implements a data type named `ltree` that you can use to represent labels of data stored in a hierarchical tree-like structure. The module also provides extensive facilities for searching through label trees.
 
-The Greenplum Database `ltree` module is equivalent to the `ltree` module used with PostgreSQL. There are no Greenplum Database or MPP-specific considerations for the module.
+The Greenplum Database `ltree` module is equivalent to the `ltree` module used with PostgreSQL. The Greenplum version of the module differs as described in the [Greenplum Database Considerations](#topic_gp) topic.
 
 ## <a id="topic_reg"></a>Installing and Registering the Module
 
@@ -17,4 +17,8 @@ Refer to [Installing Additional Supplied Modules](../../install_guide/install_mo
 ## <a id="topic_info"></a>Module Documentation
 
 Refer to the [ltree](https://www.postgresql.org/docs/12/ltree.html) PostgreSQL documentation for detailed information about the data types, functions, and operators defined in this module.
+
+## <a id="topic_gp"></a>Greenplum Database Considerations
+
+Because this extension does not provide a hash operator class, columns defined with the data type `ltree` can not be used as the distribution key for a Greenplum Database table.
 

--- a/gpdb-doc/markdown/ref_guide/modules/ltree.html.md
+++ b/gpdb-doc/markdown/ref_guide/modules/ltree.html.md
@@ -2,7 +2,7 @@
 
 The `ltree` module implements a data type named `ltree` that you can use to represent labels of data stored in a hierarchical tree-like structure. The module also provides extensive facilities for searching through label trees.
 
-The Greenplum Database `ltree` module is equivalent to the `ltree` module used with PostgreSQL. The Greenplum version of the module differs as described in the [Greenplum Database Considerations](#topic_gp) topic.
+The Greenplum Database `ltree` module is based on the `ltree` module used with PostgreSQL. The Greenplum version of the module differs as described in the [Greenplum Database Considerations](#topic_gp) topic.
 
 ## <a id="topic_reg"></a>Installing and Registering the Module
 

--- a/gpdb-doc/markdown/ref_guide/toc.md
+++ b/gpdb-doc/markdown/ref_guide/toc.md
@@ -179,6 +179,7 @@ Doc Index
         - [gp\_sparse\_vector](./modules/gp_sparse_vector.md)
         - [hstore](./modules/hstore.md)
         - [ip4r](./modules/ip4r.md)
+        - [ltree](./modules/ltree.md)
         - [orafce](./modules/orafce_ref.md)
         - [pageinspect](./modules/pageinspect.md)
         - [pg\_trgm](./modules/pg_trgm.md)


### PR DESCRIPTION
add a topic for the ltree module that will now be included in the greenplum 7 and 6.23 distributions.
  
we are xref'ing out to the postgres docs for the bulk of the "using" content. this PR is for master, xrefs to the postgres v12 version of the docs.  i will create a new PR for 6X_STABLE that xrefs to the postgres v9.4 docs.

question:  are there any greenplum- or mpp-specific considerations to call out for this module?

doc review site link (behind vpn):  https://docs-staging.vmware.com/en/draft/VMware-Tanzu-Greenplum/ltree/greenplum-database/GUID-ref_guide-modules-ltree.html
