### PR TITLE
Declare gp_gettmid as an extern function

### DIFF
--- a/src/backend/executor/instrument.c
+++ b/src/backend/executor/instrument.c
@@ -39,7 +39,6 @@ static bool shouldPickInstrInShmem(NodeTag tag);
 static Instrumentation *pickInstrFromShmem(const Plan *plan, int instrument_options);
 static void instrShmemRecycleCallback(ResourceReleasePhase phase, bool isCommit,
 						  bool isTopLevel, void *arg);
-static void gp_gettmid(int32* tmid);
 
 InstrumentationHeader *InstrumentGlobal = NULL;
 static int  scanNodeCounter = 0;
@@ -518,7 +517,8 @@ static int32 gp_gettmid_helper()
 /*
  * Wrapper for gp_gettmid_helper()
  */
-static void gp_gettmid(int32* tmid)
+void
+gp_gettmid(int32* tmid)
 {
 	int32 time = gp_gettmid_helper();
 	if (time == -1)

--- a/src/include/executor/instrument.h
+++ b/src/include/executor/instrument.h
@@ -142,6 +142,9 @@ extern Size InstrShmemSize(void);
 extern void InstrShmemInit(void);
 extern Instrumentation *GpInstrAlloc(const Plan *node, int instrument_options);
 
+/* needed by metrics_collector*/
+extern void gp_gettmid(int32*);
+
 /*
  * For each free slot in shmem, fill it with specific pattern
  * Use this pattern to detect the slot has been recycled.


### PR DESCRIPTION
The extension metrics collector needs gp_gettmid to get the timestamp.