### PR TITLE
workfile_mgr: Fix thinko in entry array resize

### DIFF
--- a/src/backend/utils/workfile_manager/workfile_mgr.c
+++ b/src/backend/utils/workfile_manager/workfile_mgr.c
@@ -293,7 +293,7 @@ ensureLocalEntriesSize(File file)
 	if (file < oldsize)
 		return;
 
-	newsize = file * 2 + 5;
+	newsize = oldsize * 2 + 5;
 	if (oldsize == 0)
 	{
 		localCtl.entries = (WorkFileLocalEntry *)


### PR DESCRIPTION
We were mistakenly multiplying the file descriptor to arrive at the new size for the WorkFileLocalCtl->entries array.

Co-authored-by: Ashwin Agrawal <aashwin@vmware.com>
