### PR TITLE
[7X] Fix incorrect distkey when copy partitions on segment.

### DIFF
--- a/src/test/regress/input/gpcopy.source
+++ b/src/test/regress/input/gpcopy.source
@@ -1335,3 +1335,41 @@ COPY foo FROM PROGRAM 'cat /tmp/gpcopyenvtest' ESCAPE 'OFF';
 COPY foo FROM PROGRAM '/usr/bin/env bash -c ''echo -E database in COPY FROM: $GP_DATABASE''' ESCAPE 'OFF';
 
 select * from foo;
+
+--
+-- Test copy a partitioned table whose columns' orders are not consistent between the root table and partitions.
+--
+
+-- 1. Test copy a partitioned table with a single distribution key on segment.
+CREATE TABLE issue_14353       (a integer, b integer, c text) PARTITION BY RANGE (a) DISTRIBUTED BY (a);
+CREATE TABLE issue_14353_prt_1 (b integer, a integer, c text) DISTRIBUTED BY (a);
+CREATE TABLE issue_14353_def   (a integer, b integer, c text) DISTRIBUTED BY (a);
+
+ALTER TABLE ONLY issue_14353 ATTACH PARTITION issue_14353_prt_1 FOR VALUES FROM (1) TO (2);
+ALTER TABLE ONLY issue_14353 ATTACH PARTITION issue_14353_def DEFAULT;
+INSERT INTO issue_14353 SELECT x, x%3, 'a' FROM generate_series(1, 20)x;
+
+-- Test that the data are successfully copied out and copied in on segment.
+COPY issue_14353 TO   '/tmp/issue_14353_<SEGID>.csv' WITH CSV DELIMITER ',' ON SEGMENT;
+COPY issue_14353 FROM '/tmp/issue_14353_<SEGID>.csv' WITH CSV DELIMITER ',' ON SEGMENT;
+
+-- Test that gpdb emits an error message saying the data distribution is malformed.
+\! cp /tmp/issue_14353_1.csv /tmp/issue_14353_0.csv
+COPY issue_14353 FROM '/tmp/issue_14353_<SEGID>.csv' WITH CSV DELIMITER ',' ON SEGMENT;
+
+-- 2. Test copy a partitioned table with multiple distribution keys on segment.
+CREATE TABLE issue_14353_multi_dist       (a integer, b integer, c text) PARTITION BY RANGE (a) DISTRIBUTED BY (a, c);
+CREATE TABLE issue_14353_multi_dist_prt_1 (b integer, a integer, c text) DISTRIBUTED BY (a, c);
+CREATE TABLE issue_14353_multi_dist_def   (a integer, b integer, c text) DISTRIBUTED BY (a, c);
+
+ALTER TABLE ONLY issue_14353_multi_dist ATTACH PARTITION issue_14353__multi_dist_prt_1 FOR VALUES FROM (1) TO (2);
+ALTER TABLE ONLY issue_14353_multi_dist ATTACH PARTITION issue_14353_multi_dist_def DEFAULT;
+INSERT INTO issue_14353_multi_dist SELECT x, x%3, 'a' || (x%5)::text FROM generate_series(1, 20)x;
+
+-- Test that the data are successfully copied out and copied in on segment.
+COPY issue_14353_multi_dist TO   '/tmp/issue_14353_multi_dist_<SEGID>.csv' WITH CSV DELIMITER ',' ON SEGMENT;
+COPY issue_14353_multi_dist FROM '/tmp/issue_14353_multi_dist_<SEGID>.csv' WITH CSV DELIMITER ',' ON SEGMENT;
+
+-- Test that gpdb emits an error message saying the data distribution is malformed.
+\! cp /tmp/issue_14353_multi_dist_1.csv /tmp/issue_14353_multi_dist_0.csv
+COPY issue_14353_multi_dist FROM '/tmp/issue_14353_multi_dist_<SEGID>.csv' WITH CSV DELIMITER ',' ON SEGMENT;

--- a/src/test/regress/output/gpcopy.source
+++ b/src/test/regress/output/gpcopy.source
@@ -1658,3 +1658,37 @@ select * from foo;
  database in COPY TO: funny copy"db'with\\quotes
 (3 rows)
 
+--
+-- Test copy a partitioned table whose columns' orders are not consistent between the root table and partitions.
+--
+-- 1. Test copy a partitioned table with a single distribution key on segment.
+CREATE TABLE issue_14353       (a integer, b integer, c text) PARTITION BY RANGE (a) DISTRIBUTED BY (a);
+CREATE TABLE issue_14353_prt_1 (b integer, a integer, c text) DISTRIBUTED BY (a);
+CREATE TABLE issue_14353_def   (a integer, b integer, c text) DISTRIBUTED BY (a);
+ALTER TABLE ONLY issue_14353 ATTACH PARTITION issue_14353_prt_1 FOR VALUES FROM (1) TO (2);
+ALTER TABLE ONLY issue_14353 ATTACH PARTITION issue_14353_def DEFAULT;
+INSERT INTO issue_14353 SELECT x, x%3, 'a' FROM generate_series(1, 20)x;
+-- Test that the data are successfully copied out and copied in on segment.
+COPY issue_14353 TO   '/tmp/issue_14353_<SEGID>.csv' WITH CSV DELIMITER ',' ON SEGMENT;
+COPY issue_14353 FROM '/tmp/issue_14353_<SEGID>.csv' WITH CSV DELIMITER ',' ON SEGMENT;
+-- Test that gpdb emits an error message saying the data distribution is malformed.
+\! cp /tmp/issue_14353_1.csv /tmp/issue_14353_0.csv
+COPY issue_14353 FROM '/tmp/issue_14353_<SEGID>.csv' WITH CSV DELIMITER ',' ON SEGMENT;
+ERROR:  value of distribution key doesn't belong to segment with ID 0, it belongs to segment with ID 1  (seg0 127.0.0.1:7002 pid=16166)
+CONTEXT:  COPY issue_14353, line 17: "1,1,a"
+-- 2. Test copy a partitioned table with multiple distribution keys on segment.
+CREATE TABLE issue_14353_multi_dist       (a integer, b integer, c text) PARTITION BY RANGE (a) DISTRIBUTED BY (a, c);
+CREATE TABLE issue_14353_multi_dist_prt_1 (b integer, a integer, c text) DISTRIBUTED BY (a, c);
+CREATE TABLE issue_14353_multi_dist_def   (a integer, b integer, c text) DISTRIBUTED BY (a, c);
+ALTER TABLE ONLY issue_14353_multi_dist ATTACH PARTITION issue_14353__multi_dist_prt_1 FOR VALUES FROM (1) TO (2);
+ERROR:  relation "issue_14353__multi_dist_prt_1" does not exist
+ALTER TABLE ONLY issue_14353_multi_dist ATTACH PARTITION issue_14353_multi_dist_def DEFAULT;
+INSERT INTO issue_14353_multi_dist SELECT x, x%3, 'a' || (x%5)::text FROM generate_series(1, 20)x;
+-- Test that the data are successfully copied out and copied in on segment.
+COPY issue_14353_multi_dist TO   '/tmp/issue_14353_multi_dist_<SEGID>.csv' WITH CSV DELIMITER ',' ON SEGMENT;
+COPY issue_14353_multi_dist FROM '/tmp/issue_14353_multi_dist_<SEGID>.csv' WITH CSV DELIMITER ',' ON SEGMENT;
+-- Test that gpdb emits an error message saying the data distribution is malformed.
+\! cp /tmp/issue_14353_multi_dist_1.csv /tmp/issue_14353_multi_dist_0.csv
+COPY issue_14353_multi_dist FROM '/tmp/issue_14353_multi_dist_<SEGID>.csv' WITH CSV DELIMITER ',' ON SEGMENT;
+ERROR:  value of distribution key doesn't belong to segment with ID 0, it belongs to segment with ID 1  (seg0 127.0.0.1:7002 pid=21933)
+CONTEXT:  COPY issue_14353_multi_dist, line 11: "1,1,a"


### PR DESCRIPTION
When the column order isn't consistent between the root table and its partitions, the data distribution check may fail due to it referencing the root table's distribution policy.

We have 2 optional choices to fix this issue:

1. We should use partition's distribution policy for computing the tuple's target segment.

2. As what we do in this PR, we move the distribution check logic before the reordering of the tuple's columns. Because before the reordering of the tuple's columns, the tuple's columns order is the same as the root table's column order. The benefit is that, we don't need to introduce another variable to store partition's distribution policy.

Fix #14353.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [x] Pass `make installcheck`
