### PR TITLE
[6X] Skip invalid socks in checkDispatchResult()

### DIFF
--- a/src/backend/cdb/dispatcher/cdbdisp_async.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_async.c
@@ -534,7 +534,7 @@ checkDispatchResult(CdbDispatcherState *ds, int timeout_sec)
 
 #ifdef FAULT_INJECTOR
 			/* inject invalid sock to simulate an pqFlush() error */
-			static bool saved_sock = -1;
+			static int saved_sock = -1;
 			if (FaultInjector_InjectFaultIfSet("inject_invalid_sock_for_checkDispatchResult",
 						DDLNotSpecified,
 						"" /* databaseName */,

--- a/src/test/regress/input/dispatch.source
+++ b/src/test/regress/input/dispatch.source
@@ -12,6 +12,8 @@ CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
 -- s/^DETAIL:  Internal error: No motion listener port \(seg\d.*:.*\)/DETAIL:  Internal error: No motion listener port/
 -- m/WARNING:.*Any temporary tables for this session have been dropped because the gang was disconnected/
 -- s/session id \=\s*\d+/session id \= DUMMY/gm
+-- m/WARNING:  Connection \(seg\d.*:.*\) is broken/
+-- s/WARNING:  Connection \(seg\d.*:.*\) is broken/WARNING:  Connection seg0 slice1 is broken/
 -- end_matchsubs
 
 -- skip FTS probes always
@@ -19,11 +21,15 @@ select gp_inject_fault_infinite('fts_probe', 'skip', 1);
 select gp_request_fts_probe_scan();
 select gp_wait_until_triggered_fault('fts_probe', 1, 1);
 
--- Test cdbdisp_getDispatchResults() fail in CdbDispatchCopyStart()
-
 create table dispatch_tbl (a int) distributed by (a);
 insert into dispatch_tbl values (2),(1),(5);
 
+-- Test invalid sock in checkDispatchResult()
+select gp_inject_fault('inject_invalid_sock_for_checkDispatchResult', 'skip', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+select count(*) from dispatch_tbl;
+select gp_inject_fault('inject_invalid_sock_for_checkDispatchResult', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+
+-- Test cdbdisp_getDispatchResults() fail in CdbDispatchCopyStart()
 -- fault on seg1 to block insert command into the dispatch_tbl table
 select gp_inject_fault('DoCopyToFail', 'error', '', '', '',
    1, 1, 0, dbid) from gp_segment_configuration

--- a/src/test/regress/output/dispatch.source
+++ b/src/test/regress/output/dispatch.source
@@ -10,6 +10,8 @@ CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
 -- s/^DETAIL:  Internal error: No motion listener port \(seg\d.*:.*\)/DETAIL:  Internal error: No motion listener port/
 -- m/WARNING:.*Any temporary tables for this session have been dropped because the gang was disconnected/
 -- s/session id \=\s*\d+/session id \= DUMMY/gm
+-- m/WARNING:  Connection \(seg\d.*:.*\) is broken/
+-- s/WARNING:  Connection \(seg\d.*:.*\) is broken/WARNING:  Connection seg0 slice1 is broken/
 -- end_matchsubs
 -- skip FTS probes always
 select gp_inject_fault_infinite('fts_probe', 'skip', 1);
@@ -30,9 +32,29 @@ select gp_wait_until_triggered_fault('fts_probe', 1, 1);
  Success:
 (1 row)
 
--- Test cdbdisp_getDispatchResults() fail in CdbDispatchCopyStart()
 create table dispatch_tbl (a int) distributed by (a);
 insert into dispatch_tbl values (2),(1),(5);
+-- Test invalid sock in checkDispatchResult()
+select gp_inject_fault('inject_invalid_sock_for_checkDispatchResult', 'skip', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+select count(*) from dispatch_tbl;
+WARNING:  Connection (seg0 slice1 10.170.0.8:6000 pid=23469) is broken, PQerrorMessage:inject invalid sock
+ count 
+-------
+     3
+(1 row)
+
+select gp_inject_fault('inject_invalid_sock_for_checkDispatchResult', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = -1;
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+-- Test cdbdisp_getDispatchResults() fail in CdbDispatchCopyStart()
 -- fault on seg1 to block insert command into the dispatch_tbl table
 select gp_inject_fault('DoCopyToFail', 'error', '', '', '',
    1, 1, 0, dbid) from gp_segment_configuration


### PR DESCRIPTION
In `checkDispatchResult()`, we flush out the buffer when something are not fully dispatched to QEs:
https://github.com/greenplum-db/gpdb/blob/f90428b433203893fa12dca78334ed4fd6b473b5/src/backend/cdb/dispatcher/cdbdisp_async.c#L519-L533
The `pqFlush()` set `sock = -1` when the connection is broken. And no `Assert()` in product code, so this fd (sock==-1) will be added in the poll array:
https://github.com/greenplum-db/gpdb/blob/f90428b433203893fa12dca78334ed4fd6b473b5/src/backend/cdb/dispatcher/cdbdisp_async.c#L538-L542
Then `poll()` it (fd==-1) later, it causes an infinite hang, and we already have user cases of it.
 
Fix it is easy: skip to add these fds to poll array. This issue also exists in main branch, ported: https://github.com/greenplum-db/gpdb/pull/14521

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [x] Review a PR in return to support the community
