### PR TITLE
FIX multi-level correlated subquery bug 6X  backport

### DIFF
--- a/src/backend/cdb/cdbsubselect.c
+++ b/src/backend/cdb/cdbsubselect.c
@@ -474,12 +474,6 @@ safe_to_convert_EXPR(SubLink *sublink, ConvertSubqueryToJoinContext *ctx1)
 		return false;
 
 	/**
-	 * If deeply correlated, don't bother.
-	 */
-	if (IsSubqueryMultiLevelCorrelated(subselect))
-		return false;
-
-	/**
 	 * If there are correlations in a func expr in the from clause, then don't bother.
 	 */
 	if (has_correlation_in_funcexpr_rte(subselect->rtable))

--- a/src/backend/optimizer/plan/subselect.c
+++ b/src/backend/optimizer/plan/subselect.c
@@ -103,6 +103,9 @@ assign_param_for_var(PlannerInfo *root, Var *var)
 	PlannerParamItem *pitem;
 	Index		levelsup;
 
+	/* check multi-level correlated subquery in GPDB planner */
+	check_multi_subquery_correlated(root, var);
+
 	/* Find the query level the Var belongs to */
 	for (levelsup = var->varlevelsup; levelsup > 0; levelsup--)
 		root = root->parent_root;
@@ -504,18 +507,53 @@ IsSubqueryCorrelated(Query *sq)
 	return (ctx.maxLevelsUpVar > 0 || ctx.maxLevelsUpPlaceHolderVar > 0);
 }
 
-/**
- * Returns true if subquery contains references to more than its immediate outer query.
+/*
+ * Check multi-level correlated subquery in Postgres legacy planner
+ *
+ * We could support one-level correlated subquery by adding
+ * broadcast + result(param filter). For multi-level scenario
+ * we should prevent planner from adding another motion above
+ * result node which is from one-level correlated subquery.
+ *
+ * In this function, firstly we find the top root which refer
+ * to Param, then check table distribution below current root
+ * Not support if any distributed table exist.
  */
-bool
-IsSubqueryMultiLevelCorrelated(Query *sq)
+void
+check_multi_subquery_correlated(PlannerInfo *root, Var *var)
 {
-	Assert(sq);
-	CorrelatedVarWalkerContext ctx;
-	ctx.maxLevelsUpVar = 0;
-	ctx.maxLevelsUpPlaceHolderVar = 0;
-	CorrelatedVarWalker((Node *) sq, &ctx);
-	return (ctx.maxLevelsUpVar > 1 || ctx.maxLevelsUpPlaceHolderVar > 1);
+	int levelsup;
+
+	if (Gp_role != GP_ROLE_DISPATCH)
+		return;
+	if (var->varlevelsup <= 1)
+		return;
+
+	if (list_length(root->parse->rtable) == 0)
+		return;
+
+	for (levelsup = var->varlevelsup; levelsup > 0; levelsup--)
+	{
+		PlannerInfo *parent_root = root->parent_root;
+
+		if (parent_root == NULL)
+			elog(ERROR, "not found parent root when checking skip-level correlations");
+
+		/*
+		 * Only check sublink not include subquery
+		 */
+		if(parent_root->parse->hasSubLinks &&
+			QueryHasDistributedRelation(root->parse, parent_root->is_correlated_subplan))
+		{
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					errmsg("correlated subquery with skip-level correlations is not supported")));
+		}
+
+		root = root->parent_root;
+	}
+
+	return;
 }
 
 /*
@@ -592,15 +630,6 @@ make_subplan(PlannerInfo *root, Query *orig_subquery, SubLinkType subLinkType,
 	Assert(root->plan_params == NIL);
 
 	PlannerConfig *config = CopyPlannerConfig(root->config);
-
-	if ((Gp_role == GP_ROLE_DISPATCH)
-			&& IsSubqueryMultiLevelCorrelated(subquery)
-			&& QueryHasDistributedRelation(subquery, root->is_correlated_subplan))
-	{
-		ereport(ERROR,
-				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-				 errmsg("correlated subquery with skip-level correlations is not supported")));
-	}
 
 	if (Gp_role == GP_ROLE_DISPATCH)
 	{
@@ -1418,12 +1447,6 @@ convert_ANY_sublink_to_join(PlannerInfo *root, SubLink *sublink,
 	*/
 	cdbsubselect_drop_orderby(subselect);
 	cdbsubselect_drop_distinct(subselect);
-
-	/*
-	 * If deeply correlated, then don't pull it up
-	 */
-	if (IsSubqueryMultiLevelCorrelated(subselect))
-		return NULL;
 
 	/*
 	 * If there are CTEs, then the transformation does not work. Don't attempt

--- a/src/include/optimizer/subselect.h
+++ b/src/include/optimizer/subselect.h
@@ -45,7 +45,7 @@ extern int	SS_assign_special_param(PlannerInfo *root);
 
 
 extern bool IsSubqueryCorrelated(Query *sq);
-extern bool IsSubqueryMultiLevelCorrelated(Query *sq);
+extern void check_multi_subquery_correlated(PlannerInfo *root, Var *var);
 
 extern List *generate_subquery_vars(PlannerInfo *root, List *tlist,
 					   Index varno);

--- a/src/test/regress/expected/bfv_catalog.out
+++ b/src/test/regress/expected/bfv_catalog.out
@@ -121,7 +121,10 @@ CREATE TABLE t1 (a int, b int) DISTRIBUTED BY (a);
 CREATE TABLE t2 (a int, b int) DISTRIBUTED BY (a);
 CREATE TABLE x (a int) DISTRIBUTED BY (a);
 select * from x where a=  (select sum(t1.a)  from t1 inner join (select x.a as outer_ref, * from t2) as foo on (foo.a=t1.a+ outer_ref)  group by foo.a);
-ERROR:  correlated subquery with skip-level correlations is not supported
+ a 
+---
+(0 rows)
+
 SET statement_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = off;

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -8799,10 +8799,22 @@ select (select sum(foo.a + bar.d) + 1 from bar) from foo group by a, b;
 
 -- aggrefs with multiple agglevelsup
 select (select (select sum(foo.a + bar.d) from jazz) from bar) from foo group by a, b;
-ERROR:  correlated subquery with skip-level correlations is not supported
+ sum 
+-----
+   9
+  15
+  12
+(3 rows)
+
 -- aggrefs with multiple agglevelsup in an expression
 select (select (select sum(foo.a + bar.d) * 2 from jazz) from bar) from foo group by a, b;
-ERROR:  correlated subquery with skip-level correlations is not supported
+ ?column? 
+----------
+       30
+       24
+       18
+(3 rows)
+
 -- nested group by
 select (select max(f) from bar where d = 1 group by a, e) from foo group by a;
  max 
@@ -8901,7 +8913,13 @@ SELECT  foo.b+1, avg (( SELECT bar.f FROM bar WHERE bar.d = foo.b)) AS t FROM fo
 (3 rows)
 
 SELECT foo.b+1, sum( 1 + (SELECT bar.f FROM bar WHERE bar.d = ANY (SELECT jazz.g FROM jazz WHERE jazz.h = foo.b))) AS t FROM foo GROUP BY foo.b;
-ERROR:  correlated subquery with skip-level correlations is not supported
+ ?column? | t 
+----------+---
+        3 | 3
+        4 |  
+        2 |  
+(3 rows)
+
 select foo.b+1, sum((with cte as (select * from jazz) select 1 from cte where cte.h = foo.b)) as t FROM foo GROUP BY foo.b;
  ?column? | t 
 ----------+---
@@ -12568,7 +12586,28 @@ where out.b in (select coalesce(tcorr2_d.c, 99)
                                              from tcorr2
                                              where tcorr2.b = out.b
                                              group by a) tcorr2_d on tcorr1.a=tcorr2_d.a);
-ERROR:  correlated subquery with skip-level correlations is not supported
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
+ Nested Loop Semi Join  (cost=10000000001.07..10000000003.21 rows=4 width=8)
+   Join Filter: ("out".b = COALESCE((count(*)), 99::bigint))
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1.03 rows=1 width=8)
+         ->  Seq Scan on tcorr1 "out"  (cost=0.00..1.01 rows=1 width=8)
+   ->  Materialize  (cost=1.07..2.16 rows=2 width=8)
+         ->  Hash Left Join  (cost=1.07..2.14 rows=4 width=8)
+               Hash Cond: (tcorr1.a = tcorr2.a)
+               ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1.03 rows=1 width=4)
+                     ->  Seq Scan on tcorr1  (cost=0.00..1.01 rows=1 width=4)
+               ->  Hash  (cost=1.06..1.06 rows=1 width=12)
+                     ->  HashAggregate  (cost=1.04..1.05 rows=1 width=12)
+                           Group Key: tcorr2.a
+                           ->  Result  (cost=0.00..1.03 rows=1 width=8)
+                                 Filter: (tcorr2.b = "out".b)
+                                 ->  Materialize  (cost=0.00..1.03 rows=1 width=8)
+                                       ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1.03 rows=1 width=8)
+                                             ->  Seq Scan on tcorr2  (cost=0.00..1.01 rows=1 width=8)
+ Optimizer: Postgres query optimizer
+(18 rows)
+
 -- expect 1 row
 select *
 from tcorr1 out
@@ -12577,7 +12616,11 @@ where out.b in (select coalesce(tcorr2_d.c, 99)
                                              from tcorr2
                                              where tcorr2.b = out.b
                                              group by a) tcorr2_d on tcorr1.a=tcorr2_d.a);
-ERROR:  correlated subquery with skip-level correlations is not supported
+ a | b  
+---+----
+ 1 | 99
+(1 row)
+
 -- expect 1 row
 -- FIXME: A process terminates during execution, see https://github.com/greenplum-db/gpdb/issues/10791
 -- select *
@@ -12659,7 +12702,28 @@ where out.b in (select coalesce(tcorr2_d.c, 99)
                                              from tcorr2
                                              where tcorr2.b = out.b
                                              group by a) tcorr2_d on tcorr1.a=tcorr2_d.a);
-ERROR:  correlated subquery with skip-level correlations is not supported
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
+ Nested Loop Semi Join  (cost=10000000001.07..10000000003.21 rows=4 width=8)
+   Join Filter: ("out".b = COALESCE((count(*)), 99::bigint))
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1.03 rows=1 width=8)
+         ->  Seq Scan on tcorr1 "out"  (cost=0.00..1.01 rows=1 width=8)
+   ->  Materialize  (cost=1.07..2.16 rows=2 width=8)
+         ->  Hash Left Join  (cost=1.07..2.14 rows=4 width=8)
+               Hash Cond: (tcorr1.a = tcorr2.a)
+               ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1.03 rows=1 width=4)
+                     ->  Seq Scan on tcorr1  (cost=0.00..1.01 rows=1 width=4)
+               ->  Hash  (cost=1.06..1.06 rows=1 width=12)
+                     ->  HashAggregate  (cost=1.04..1.05 rows=1 width=12)
+                           Group Key: tcorr2.a
+                           ->  Result  (cost=0.00..1.03 rows=1 width=8)
+                                 Filter: (tcorr2.b = "out".b)
+                                 ->  Materialize  (cost=0.00..1.03 rows=1 width=8)
+                                       ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1.03 rows=1 width=8)
+                                             ->  Seq Scan on tcorr2  (cost=0.00..1.01 rows=1 width=8)
+ Optimizer: Postgres query optimizer
+(18 rows)
+
 -- expect 1 row
 select *
 from tcorr1 out
@@ -12668,7 +12732,11 @@ where out.b in (select coalesce(tcorr2_d.c, 99)
                                              from tcorr2
                                              where tcorr2.b = out.b
                                              group by a) tcorr2_d on tcorr1.a=tcorr2_d.a);
-ERROR:  correlated subquery with skip-level correlations is not supported
+ a | b  
+---+----
+ 1 | 99
+(1 row)
+
 -- expect 1 row
 -- FIXME: A process terminates during execution, see https://github.com/greenplum-db/gpdb/issues/10791
 -- select *
@@ -13134,7 +13202,23 @@ from foo l1 where b in (select ab
                                     on l2.a=tbtree_derived.a and l2.b=tbtree_derived.b
                         where l2.c = 1
                        );
-ERROR:  correlated subquery with skip-level correlations is not supported
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)
+   ->  Nested Loop Semi Join
+         Join Filter: ((l1.a + tbtree.b) = l1.b)
+         ->  Seq Scan on foo l1
+         ->  Materialize
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                     ->  Hash Join
+                           Hash Cond: ((tbtree.a = l2.a) AND (tbtree.b = l2.b))
+                           ->  Seq Scan on tbtree
+                           ->  Hash
+                                 ->  Seq Scan on foo l2
+                                       Filter: (c = 1)
+ Optimizer: Postgres query optimizer
+(13 rows)
+
 -- 16 group by columns are not a superset of the distribution columns - no index scan
 explain (costs off)
 select * from foo join (select b, count(*) as cnt from tbtree group by b) grby on foo.a=grby.cnt;

--- a/src/test/regress/expected/qp_subquery.out
+++ b/src/test/regress/expected/qp_subquery.out
@@ -1342,9 +1342,17 @@ select sum(case when b in (select b from temp_b where t.a>c) then 1 else 0 end),
 (1 row)
 
 select sum(case when b in (select b from temp_b where EXISTS (select sum(d) from temp_c where t.a > d)) then 1 else 0 end),sum(case when not( b in (select b from temp_b where t.a>c)) then 1 else 0 end) from temp_a t;
-ERROR:  correlated subquery with skip-level correlations is not supported
+ sum | sum 
+-----+-----
+   4 |   6
+(1 row)
+
 select sum(case when b in (select b from temp_b where EXISTS (select sum(d) from temp_c where t.a > d or t.a > temp_b.c)) then 1 else 0 end),sum(case when not( b in (select b from temp_b, temp_c where t.a>temp_b.c or t.a > temp_c.d)) then 1 else 0 end) from temp_a t;
-ERROR:  correlated subquery with skip-level correlations is not supported
+ sum | sum 
+-----+-----
+   4 |   6
+(1 row)
+
 -- Check that predicate with set-returning function is not pushed down
 create table table_with_array_column (an_array_column double precision[]);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'an_array_column' as the Greenplum Database data distribution key for this table.


### PR DESCRIPTION
Fix bug of multi-level correlated subplan with message in planner.

> ERROR:  correlated subquery with skip-level correlations is not supported

### Background
GPDB could support one-level correlated subquery by adding broadcast + result(param filter). 
like query below, add broadcast motion below param filter, and it's a easy way to support
correlated subplan in MPP-panner.
```
postgres=# explain(verbose on, costs off) select a, (select sum(b) from t2 where c = t1.c) from t1;
                                 QUERY PLAN                                  
-----------------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)
   Output: t1.a, ((SubPlan 1))
   ->  Seq Scan on public.t1
         Output: t1.a, (SubPlan 1)
         SubPlan 1
           ->  Aggregate
                 Output: sum(t2.b)
                 ->  Result
                       Output: t2.b, t2.c
                       Filter: (t2.c = t1.c)
                       ->  Materialize
                             Output: t2.b, t2.c
                             ->  Broadcast Motion 3:3  (slice2; segments: 3)
                                   Output: t2.b, t2.c
                                   ->  Seq Scan on public.t2
                                         Output: t2.b, t2.c
 Optimizer: Postgres query optimizer
(17 rows)
```
However, something became more complex when multi-level correlated subquery involved.
(t3.b = t1.b) is a param result filter from level3, we can add broadcast each level3 based table.
But how about level2? we cannot prevent level2 from adding motion node, if level2 add a motion
node on level3  subquery which has para filter, something wrong happen. As we know, Param
cannot pass through Motion.
```
select                            ---- level1
  a, 
  (
    select                       ----- level2
      (
        select                   ----- level3
          a 
        from 
          t3 
        where 
          t3.b = t1.b
      ) 
    from 
      t2
  ) 
from 
  t1;
```

### RCA
We have explained the reason why multi-level correlated subquery not supported.  Let's back to this problem
```
--- before pullup, cannot support
select                                 ---- level 1
  (
    select                             ---- level 2
      t3.a 
    from 
      (
        select                         -----level 3
          * 
        from 
          t2 
        where 
          t2.a = t1.a
      ) sub, 
      t3 on sub.b = t3.b
  ) 
from                          
  t1;

--- After pullup, can support
select                                 ---- level 1
  (
    select                             ---- level 2
      t3.a 
    from 
      t3 join t2 
      on t2.b = t3.b
    where
       t2.a = t1.a
  ) 
from                          
  t1;

```
Like sql above, we will check If multi-level subplan exist when make subplan for level2 subquery. If subquery could be pull up then var->varlevelup will also be increment. So we could support this sql because there is no multi-level subplan as subquery has been pulled up.
We could check whether multi-level correlated subquery exist or not after pull-up subquery.

### Implemention
In assign_param_for_vars, we do check multi-level subplan if var's levelup greater than two.  For forward compatibility, there are two things need to be care.

- Just copy previous code logic of checking multi-level subplan to current assign_param_for_vars.
- Only support correlated subplan except subquery, we did nothing check for correlated subquery as previous code.

### Future

- consider more about multi-level correlated subquery not just subplan
- find ways to support multi-level correlated case.



## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
