### PR TITLE
Try to bypass query with only catalog tables

### DIFF
--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -222,6 +222,8 @@ bool		gp_debug_resqueue_priority = false;
 int			gp_resource_group_cpu_priority;
 double		gp_resource_group_cpu_limit;
 bool		gp_resource_group_bypass;
+bool		gp_resource_group_enable_cgroup_version_two;
+bool		gp_resource_group_bypass_catalog_query;
 
 /* Metrics collector debug GUC */
 bool		vmem_process_interrupt = false;
@@ -2765,6 +2767,24 @@ struct config_bool ConfigureNamesBool_gp[] =
 		&gp_resource_group_bypass,
 		false,
 		check_gp_resource_group_bypass, NULL, NULL
+	},
+
+	{
+		{"gp_resource_group_enable_cgroup_version_two", PGC_POSTMASTER, RESOURCES,
+			gettext_noop("Enable linux cgroup version 2"),
+			NULL
+		},
+		&gp_resource_group_enable_cgroup_version_two,
+		false, NULL, NULL
+	},
+
+	{
+		{"gp_resource_group_bypass_catalog_query", PGC_USERSET, RESOURCES,
+			gettext_noop("Bypass all catalog only queries."),
+			NULL
+		},
+		&gp_resource_group_bypass_catalog_query,
+		true, NULL, NULL
 	},
 
 	{

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -222,7 +222,6 @@ bool		gp_debug_resqueue_priority = false;
 int			gp_resource_group_cpu_priority;
 double		gp_resource_group_cpu_limit;
 bool		gp_resource_group_bypass;
-bool		gp_resource_group_enable_cgroup_version_two;
 bool		gp_resource_group_bypass_catalog_query;
 
 /* Metrics collector debug GUC */
@@ -2767,15 +2766,6 @@ struct config_bool ConfigureNamesBool_gp[] =
 		&gp_resource_group_bypass,
 		false,
 		check_gp_resource_group_bypass, NULL, NULL
-	},
-
-	{
-		{"gp_resource_group_enable_cgroup_version_two", PGC_POSTMASTER, RESOURCES,
-			gettext_noop("Enable linux cgroup version 2"),
-			NULL
-		},
-		&gp_resource_group_enable_cgroup_version_two,
-		false, NULL, NULL
 	},
 
 	{

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -2557,11 +2557,12 @@ checkBypassWalker(Node *node, void *context)
 {
 	bool *bypass = context;
 
-	if (node == NULL) return false;
+	if (node == NULL)
+		return false;
 
 	if (IsA(node, RangeVar))
 	{
-		RangeVar *from = (RangeVar *)node;
+		RangeVar *from = (RangeVar *) node;
 		if (from->schemaname == NULL ||
 			strcmp(from->schemaname, "pg_catalog") != 0)
 		{
@@ -2585,7 +2586,7 @@ shouldBypassSelectQuery(Node *node)
 {
 	bool catalog_bypass = false;
 
-	if(gp_resource_group_bypass_catalog_query)
+	if (gp_resource_group_bypass_catalog_query)
 		raw_expression_tree_walker(node, checkBypassWalker, &catalog_bypass);
 
 	return catalog_bypass;

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -246,6 +246,8 @@ static void groupWaitQueuePush(ResGroupData *group, PGPROC *proc);
 static PGPROC *groupWaitQueuePop(ResGroupData *group);
 static void groupWaitQueueErase(ResGroupData *group, PGPROC *proc);
 static bool groupWaitQueueIsEmpty(const ResGroupData *group);
+static bool checkBypassWalker(Node *node, void *context);
+static bool shouldBypassSelectQuery(Node *node);
 static bool shouldBypassQuery(const char *query_string);
 static void lockResGroupForDrop(ResGroupData *group);
 static void unlockResGroupForDrop(ResGroupData *group);
@@ -2546,10 +2548,55 @@ groupWaitQueueFind(ResGroupData *group, const PGPROC *proc)
 #endif/* USE_ASSERT_CHECKING */
 
 /*
+ * Walk through the raw expression tree, if there is a RangeVar without
+ * `pg_catalog` prefix, terminate the process immediately to save the cpu
+ * resource.
+ */
+static bool
+checkBypassWalker(Node *node, void *context)
+{
+	bool *bypass = context;
+
+	if (node == NULL) return false;
+
+	if (IsA(node, RangeVar))
+	{
+		RangeVar *from = (RangeVar *)node;
+		if (from->schemaname == NULL ||
+			strcmp(from->schemaname, "pg_catalog") != 0)
+		{
+			*bypass = false;
+			return true;
+		}
+		else
+		{
+			/*
+			 * Make sure there is at least one RangeVar
+			 */
+			*bypass = true;
+		}
+	}
+
+	return raw_expression_tree_walker(node, checkBypassWalker, context);
+}
+
+static bool
+shouldBypassSelectQuery(Node *node)
+{
+	bool catalog_bypass = false;
+
+	if(gp_resource_group_bypass_catalog_query)
+		raw_expression_tree_walker(node, checkBypassWalker, &catalog_bypass);
+
+	return catalog_bypass;
+}
+
+/*
  * Parse the query and check if this query should
  * bypass the management of resource group.
  *
- * Currently, only SET/RESET/SHOW command can be bypassed
+ * Currently, only SET/RESET/SHOW command and SELECT with only catalog tables
+ * can be bypassed
  */
 static bool
 shouldBypassQuery(const char *query_string)
@@ -2598,7 +2645,8 @@ shouldBypassQuery(const char *query_string)
 	if (parsetree_list == NULL)
 		return false;
 
-	/* Only bypass SET/RESET/SHOW command for now */
+	/* Only bypass SET/RESET/SHOW command and SELECT with only catalog tables
+	 * for now */
 	bypass = true;
 	foreach(parsetree_item, parsetree_list)
 	{
@@ -2607,7 +2655,15 @@ shouldBypassQuery(const char *query_string)
 		if (nodeTag(parsetree) == T_RawStmt)
 			parsetree = ((RawStmt *)parsetree)->stmt;
 
-		if (nodeTag(parsetree) != T_VariableSetStmt &&
+		if (IsA(parsetree, SelectStmt))
+		{
+			if (!shouldBypassSelectQuery(parsetree))
+			{
+				bypass = false;
+				break;
+			}
+		}
+		else if (nodeTag(parsetree) != T_VariableSetStmt &&
 			nodeTag(parsetree) != T_VariableShowStmt)
 		{
 			bypass = false;

--- a/src/backend/utils/resgroup/test/resgroup_test.c
+++ b/src/backend/utils/resgroup/test/resgroup_test.c
@@ -344,6 +344,14 @@ test__shouldBypassQuery__message_context_is_null(void **state)
 	assert_false(shouldBypassQuery("select 1"));
 }
 
+static void
+test__shouldBypassQuery__with_only_catalog(void **state)
+{
+	MessageContext = NULL;
+
+	assert_true(shouldBypassQuery("select * from pg_catalog.pg_rules"));
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -367,6 +375,7 @@ main(int argc, char *argv[])
 			test_with_setup_and_teardown(test__shouldBypassQuery__cmd_mixed),
 			test_with_setup_and_teardown(test__shouldBypassQuery__forced_bypass_mode),
 			test_with_setup_and_teardown(test__shouldBypassQuery__message_context_is_null),
+			test_with_setup_and_teardown(test__shouldBypassQuery__with_only_catalog),
 	};
 
 	MemoryContextInit();

--- a/src/include/utils/resgroup.h
+++ b/src/include/utils/resgroup.h
@@ -93,6 +93,7 @@ extern int gp_resource_group_cpu_priority;
 extern double gp_resource_group_cpu_limit;
 extern bool gp_resource_group_bypass;
 extern int gp_resource_group_queuing_timeout;
+extern bool gp_resource_group_bypass_catalog_query;
 
 /*
  * Non-GUC global variables.

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -215,6 +215,8 @@
 		"gp_resource_group_bypass",
 		"gp_resource_group_cpu_limit",
 		"gp_resource_group_cpu_priority",
+		"gp_resource_group_enable_cgroup_version_two",
+		"gp_resource_group_bypass_catalog_query",
 		"gp_resource_group_queuing_timeout",
 		"gp_resource_manager",
 		"gp_resqueue_memory_policy",

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -215,7 +215,6 @@
 		"gp_resource_group_bypass",
 		"gp_resource_group_cpu_limit",
 		"gp_resource_group_cpu_priority",
-		"gp_resource_group_enable_cgroup_version_two",
 		"gp_resource_group_bypass_catalog_query",
 		"gp_resource_group_queuing_timeout",
 		"gp_resource_manager",

--- a/src/test/isolation2/expected/resgroup/resgroup_bypass_catalog.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_bypass_catalog.out
@@ -1,0 +1,76 @@
+CREATE RESOURCE GROUP rg_test_catalog WITH (CONCURRENCY=2, CPU_HARD_QUOTA_LIMIT=10);
+CREATE
+CREATE ROLE role_test_catalog RESOURCE GROUP rg_test_catalog;
+CREATE
+
+CREATE FUNCTION rg_test_udf() RETURNS integer AS $$ return 1 $$ LANGUAGE plpython3u;
+CREATE
+
+-- take 1 slot
+1: SET ROLE role_test_catalog;
+SET
+1: BEGIN;
+BEGIN
+
+-- take another slot
+2: SET ROLE role_test_catalog;
+SET
+2: BEGIN;
+BEGIN
+
+-- two slot have all been taken, so this query will be hung up.
+3: SET ROLE role_test_catalog;
+SET
+3&: BEGIN;  <waiting ...>
+
+-- It's a catalog only query, so it will be bypassed.
+4: SET ROLE role_test_catalog;
+SET
+4: SELECT 1 FROM pg_catalog.pg_rules;
+ ?column? 
+----------
+ 1        
+ 1        
+(2 rows)
+
+-- It's a udf only query, will be hung up.
+-- Because there is no RangeVar, it doesn't belong to catalog only query.
+5: SET ROLE role_test_catalog;
+SET
+5&: SELECT rg_test_udf();  <waiting ...>
+
+-- turn of bypass catalog query
+6: SET ROLE role_test_catalog;
+SET
+6: SET gp_resource_group_bypass_catalog_query = false;
+SET
+6&: SELECT 1 FROM pg_catalog.pg_rules;  <waiting ...>
+
+1: COMMIT;
+COMMIT
+2: COMMIT;
+COMMIT
+3<:  <... completed>
+BEGIN
+3: COMMIT;
+COMMIT
+5<:  <... completed>
+ rg_test_udf 
+-------------
+ 1           
+(1 row)
+5: COMMIT;
+COMMIT
+6<:  <... completed>
+ ?column? 
+----------
+ 1        
+ 1        
+(2 rows)
+
+-- cleanup
+-- start_ignore
+DROP ROLE role_test_catalog;
+DROP RESOURCE GROUP rg_test_catalog;
+DROP FUNCTION rg_test_udf;
+-- end_ignore

--- a/src/test/isolation2/isolation2_resgroup_v2_schedule
+++ b/src/test/isolation2/isolation2_resgroup_v2_schedule
@@ -4,6 +4,9 @@
 # enable resource group v2
 test: resgroup/resgroup_auxiliary_tools_v2
 
+# bypass catalog
+test: resgroup/resgroup_bypass_catalog
+
 # basic syntax
 test: resgroup/resgroup_views
 test: resgroup/resgroup_syntax

--- a/src/test/isolation2/sql/resgroup/resgroup_bypass_catalog.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_bypass_catalog.sql
@@ -1,0 +1,50 @@
+CREATE RESOURCE GROUP rg_test_catalog WITH (CONCURRENCY=2, CPU_HARD_QUOTA_LIMIT=10);
+CREATE ROLE role_test_catalog RESOURCE GROUP rg_test_catalog;
+
+CREATE FUNCTION rg_test_udf()
+RETURNS integer AS
+$$
+return 1
+$$
+LANGUAGE plpython3u;
+
+-- take 1 slot
+1: SET ROLE role_test_catalog;
+1: BEGIN;
+
+-- take another slot
+2: SET ROLE role_test_catalog;
+2: BEGIN;
+
+-- two slot have all been taken, so this query will be hung up.
+3: SET ROLE role_test_catalog;
+3&: BEGIN;
+
+-- It's a catalog only query, so it will be bypassed.
+4: SET ROLE role_test_catalog;
+4: SELECT 1 FROM pg_catalog.pg_rules;
+
+-- It's a udf only query, will be hung up.
+-- Because there is no RangeVar, it doesn't belong to catalog only query.
+5: SET ROLE role_test_catalog;
+5&: SELECT rg_test_udf();
+
+-- turn of bypass catalog query
+6: SET ROLE role_test_catalog;
+6: SET gp_resource_group_bypass_catalog_query = false;
+6&: SELECT 1 FROM pg_catalog.pg_rules;
+
+1: COMMIT;
+2: COMMIT;
+3<:
+3: COMMIT;
+5<:
+5: COMMIT;
+6<:
+
+-- cleanup
+-- start_ignore
+DROP ROLE role_test_catalog;
+DROP RESOURCE GROUP rg_test_catalog;
+DROP FUNCTION rg_test_udf;
+-- end_ignore


### PR DESCRIPTION
Try to bypass query with only catalog tables.

We need to bypass the query with only `catalog` tables in resource groups in some situations, like the Database GUI client(DBeaver), which will run some catalog queries to fetch metadata.

The code just walk the parse tree and find `RangeVar` to compare it's schemaname with `pg_catalog`, it's just a few cases which be considered now. Because every query will be walked after enabling resource group, so the effort should be as small as as possible.

Following catalog query will be bypassed:
```sql
SELECT n.oid,n.*,d.description FROM pg_catalog.pg_namespace n  
LEFT OUTER JOIN pg_catalog.pg_description d ON d.objoid=n.oid AND d.objsubid=0 AND d.classoid='pg_namespace'::regclass
WHERE nspname='public' ORDER BY nspname;
```
But query without any `RangeVar`s will be ignored, such as:
```sql
SELECT 1;
SELECT some_udf();
```
