### PR TITLE
Fix the test extension to execute SQL code inside of a Portal

### DIFF
--- a/src/test/fdw/extension/extended_protocol_commit_test_fdw.c
+++ b/src/test/fdw/extension/extended_protocol_commit_test_fdw.c
@@ -37,10 +37,11 @@ test_execute_spi_expression(const char *query)
 
 	ActivePortal = CreateNewPortal();
 
-	if (SPI_connect() != SPI_OK_CONNECT)
-		elog(ERROR, "Failed to connect to SPI");
 	PG_TRY();
 	{
+		if (SPI_connect() != SPI_OK_CONNECT)
+			elog(ERROR, "Failed to connect to SPI");
+
 		r = SPI_execute(query, false, 0);
 		if (r < 0)
 			elog(ERROR, "Failed to execute '%s' via SPI: %s [%d]", query, SPI_result_code_string(r), r);
@@ -55,6 +56,7 @@ test_execute_spi_expression(const char *query)
 		PG_RE_THROW();
 	}
 	PG_END_TRY();
+
 	SPI_finish();
 
 	/* Restore the global portal */


### PR DESCRIPTION
This extension fails with a later version of PostgreSQL, which we will merge.

	commit 41c6a5bec25e720d98bd60d77dd5c2939189ed3c
	Author: Tom Lane <tgl@sss.pgh.pa.us>
	Date:   Fri May 21 14:03:53 2021 -0400

	    Restore the portal-level snapshot after procedure COMMIT/ROLLBACK.

And quote the release note:

> Some extensions may attempt to execute SQL code outside of any Portal.
> They are responsible for ensuring that an outer snapshot exists before
> doing so. Previously, not providing a snapshot might work or it might
> not; now it will consistently fail with “cannot execute SQL without an
> outer snapshot or portal”.