### PR TITLE
Correct direct dispatch error in ORCA, if distribution column is of varchar type

### DIFF
--- a/src/backend/gporca/libgpopt/include/gpopt/translate/CTranslatorExprToDXLUtils.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/translate/CTranslatorExprToDXLUtils.h
@@ -93,7 +93,8 @@ private:
 
 	// check if the given constant value for a particular distribution column can be used
 	// to identify which segment to direct dispatch to.
-	static BOOL FDirectDispatchable(const CColRef *pcrDistrCol,
+	static BOOL FDirectDispatchable(CMDAccessor *md_accessor,
+									const CColRef *pcrDistrCol,
 									const CDXLDatum *dxl_datum);
 
 public:

--- a/src/include/gpopt/translate/CTranslatorDXLToPlStmt.h
+++ b/src/include/gpopt/translate/CTranslatorDXLToPlStmt.h
@@ -569,10 +569,12 @@ private:
 
 	// compute directed dispatch segment ids
 	List *TranslateDXLDirectDispatchInfo(
-		CDXLDirectDispatchInfo *dxl_direct_dispatch_info);
+		CDXLDirectDispatchInfo *dxl_direct_dispatch_info,
+		RangeTblEntry *pRTEHashFuncCal);
 
 	// hash a DXL datum with GPDB's hash function
-	ULONG GetDXLDatumGPDBHash(CDXLDatumArray *dxl_datum_array);
+	ULONG GetDXLDatumGPDBHash(CDXLDatumArray *dxl_datum_array,
+							  RangeTblEntry *pRTEHashFuncCal);
 
 	// translate nest loop colrefs to GPDB nestparams
 	static List *TranslateNestLoopParamList(

--- a/src/test/regress/expected/bfv_dd_types_optimizer.out
+++ b/src/test/regress/expected/bfv_dd_types_optimizer.out
@@ -170,7 +170,7 @@ INFO:  (slice 1) Dispatch command to SINGLE content
 
 -- TODO: this currently not directly dispatched (AGL-1246)
 select * from direct_test_type_cidr where x = '68.44.55.111';
-INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to SINGLE content
         x        
 -----------------
  68.44.55.111/32

--- a/src/test/regress/expected/direct_dispatch.out
+++ b/src/test/regress/expected/direct_dispatch.out
@@ -907,6 +907,328 @@ INFO:  (slice 1) Dispatch command to PARTIAL contents: 1 0
              1 | 1 | 1
 (2 rows)
 
+--test direct dispatch if distribution column is of varchar type
+drop table if exists t1_varchar;
+NOTICE:  table "t1_varchar" does not exist, skipping
+INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to ALL contents: 0 1 2
+create table t1_varchar(col1_varchar varchar, col2_int int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'col1_varchar' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
+insert into t1_varchar values ('a',1);
+INFO:  (slice 0) Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to SINGLE content
+insert into t1_varchar values ('b',2);
+INFO:  (slice 0) Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to SINGLE content
+insert into t1_varchar values ('c',3);
+INFO:  (slice 0) Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to SINGLE content
+insert into t1_varchar values ('d',4);
+INFO:  (slice 0) Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to SINGLE content
+insert into t1_varchar values ('e',5);
+INFO:  (slice 0) Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to SINGLE content
+insert into t1_varchar values ('97',6);
+INFO:  (slice 0) Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to SINGLE content
+explain (costs off) select gp_segment_id,  * from t1_varchar where col1_varchar = 'c';
+                     QUERY PLAN                     
+----------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
+   ->  Seq Scan on t1_varchar
+         Filter: ((col1_varchar)::text = 'c'::text)
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+select gp_segment_id,  * from t1_varchar where col1_varchar = 'c';
+INFO:  (slice 1) Dispatch command to SINGLE content
+ gp_segment_id | col1_varchar | col2_int 
+---------------+--------------+----------
+             2 | c            |        3
+(1 row)
+
+explain (costs off) select gp_segment_id,  * from t1_varchar where col1_varchar <>'c';
+                     QUERY PLAN                      
+-----------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on t1_varchar
+         Filter: ((col1_varchar)::text <> 'c'::text)
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+select gp_segment_id,  * from t1_varchar where col1_varchar <>'c';
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+ gp_segment_id | col1_varchar | col2_int 
+---------------+--------------+----------
+             1 | b            |        2
+             1 | e            |        5
+             0 | d            |        4
+             2 | a            |        1
+             2 | 97           |        6
+(5 rows)
+
+--test direct dispatch if distribution column is of varchar type and disjunction scenario
+explain (costs off) select gp_segment_id, * from t1_varchar where col1_varchar in ('a','b');
+                           QUERY PLAN                           
+----------------------------------------------------------------
+ Gather Motion 2:1  (slice1; segments: 2)
+   ->  Seq Scan on t1_varchar
+         Filter: ((col1_varchar)::text = ANY ('{a,b}'::text[]))
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+select gp_segment_id, * from t1_varchar where col1_varchar in ('a','b');
+INFO:  (slice 1) Dispatch command to PARTIAL contents: 1 2
+ gp_segment_id | col1_varchar | col2_int 
+---------------+--------------+----------
+             1 | b            |        2
+             2 | a            |        1
+(2 rows)
+
+explain (costs off) select gp_segment_id, * from t1_varchar where col1_varchar = 'a' or col1_varchar = 'b';
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Gather Motion 2:1  (slice1; segments: 2)
+   ->  Seq Scan on t1_varchar
+         Filter: (((col1_varchar)::text = 'a'::text) OR ((col1_varchar)::text = 'b'::text))
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+select gp_segment_id, * from t1_varchar where col1_varchar = 'a' or col1_varchar = 'b';
+INFO:  (slice 1) Dispatch command to PARTIAL contents: 1 2
+ gp_segment_id | col1_varchar | col2_int 
+---------------+--------------+----------
+             1 | b            |        2
+             2 | a            |        1
+(2 rows)
+
+--test direct dispatch if distribution column is of varchar type, having disjunction condition
+-- or an additional conjunction constraint using another table column or both
+explain (costs off) select gp_segment_id, * from t1_varchar where col1_varchar = 'c' and col2_int=3;
+                               QUERY PLAN                                
+-------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
+   ->  Seq Scan on t1_varchar
+         Filter: (((col1_varchar)::text = 'c'::text) AND (col2_int = 3))
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+select gp_segment_id, * from t1_varchar where col1_varchar = 'c' and col2_int=3;
+INFO:  (slice 1) Dispatch command to SINGLE content
+ gp_segment_id | col1_varchar | col2_int 
+---------------+--------------+----------
+             2 | c            |        3
+(1 row)
+
+explain (costs off) select gp_segment_id, * from t1_varchar where col1_varchar = 'a' and col2_int in (1,3);
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
+   ->  Seq Scan on t1_varchar
+         Filter: ((col2_int = ANY ('{1,3}'::integer[])) AND ((col1_varchar)::text = 'a'::text))
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+select gp_segment_id, * from t1_varchar where col1_varchar = 'a' and col2_int in (1,3);
+INFO:  (slice 1) Dispatch command to SINGLE content
+ gp_segment_id | col1_varchar | col2_int 
+---------------+--------------+----------
+             2 | a            |        1
+(1 row)
+
+explain (costs off) select gp_segment_id, * from t1_varchar where col1_varchar = 'a' and col2_int not in (2,3);
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
+   ->  Seq Scan on t1_varchar
+         Filter: ((col2_int <> ALL ('{2,3}'::integer[])) AND ((col1_varchar)::text = 'a'::text))
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+select gp_segment_id, * from t1_varchar where col1_varchar = 'a' and col2_int not in (2,3);
+INFO:  (slice 1) Dispatch command to SINGLE content
+ gp_segment_id | col1_varchar | col2_int 
+---------------+--------------+----------
+             2 | a            |        1
+(1 row)
+
+explain (costs off) select gp_segment_id, * from t1_varchar where col1_varchar in ('a', 'b') and col2_int=2;
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Gather Motion 2:1  (slice1; segments: 2)
+   ->  Seq Scan on t1_varchar
+         Filter: (((col1_varchar)::text = ANY ('{a,b}'::text[])) AND (col2_int = 2))
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+select gp_segment_id, * from t1_varchar where col1_varchar in ('a', 'b') and col2_int=2;
+INFO:  (slice 1) Dispatch command to PARTIAL contents: 1 2
+ gp_segment_id | col1_varchar | col2_int 
+---------------+--------------+----------
+             1 | b            |        2
+(1 row)
+
+explain (costs off) select gp_segment_id, * from t1_varchar where (col1_varchar = 'a' or col1_varchar = 'b') and col2_int=1;
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
+ Gather Motion 2:1  (slice1; segments: 2)
+   ->  Seq Scan on t1_varchar
+         Filter: ((col2_int = 1) AND (((col1_varchar)::text = 'a'::text) OR ((col1_varchar)::text = 'b'::text)))
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+select gp_segment_id, * from t1_varchar where (col1_varchar = 'a' or col1_varchar = 'b') and col2_int=1;
+INFO:  (slice 1) Dispatch command to PARTIAL contents: 1 2
+ gp_segment_id | col1_varchar | col2_int 
+---------------+--------------+----------
+             2 | a            |        1
+(1 row)
+
+--Test direct dispatch with explicit typecasting
+explain (costs off) select gp_segment_id, * from t1_varchar where col1_varchar = 97::VARCHAR;
+                     QUERY PLAN                      
+-----------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
+   ->  Seq Scan on t1_varchar
+         Filter: ((col1_varchar)::text = '97'::text)
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+select gp_segment_id, * from t1_varchar where col1_varchar = 97::VARCHAR;
+INFO:  (slice 1) Dispatch command to SINGLE content
+ gp_segment_id | col1_varchar | col2_int 
+---------------+--------------+----------
+             2 | 97           |        6
+(1 row)
+
+-- explicit cast using "char", generates a scenario of cast function from Dist Colm to datum in CTranslatorExprToDXLUtils::FDirectDispatchable(,,)
+explain (costs off) select gp_segment_id,  * from t1_varchar where col1_varchar = 'c'::char;
+                          QUERY PLAN                          
+--------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
+   ->  Seq Scan on t1_varchar
+         Filter: ((col1_varchar)::bpchar = 'c'::character(1))
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+select gp_segment_id,  * from t1_varchar where col1_varchar = 'c'::char;
+INFO:  (slice 1) Dispatch command to SINGLE content
+ gp_segment_id | col1_varchar | col2_int 
+---------------+--------------+----------
+             2 | c            |        3
+(1 row)
+
+explain (costs off) select gp_segment_id,  * from t1_varchar where col1_varchar = '2'::char;
+                          QUERY PLAN                          
+--------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
+   ->  Seq Scan on t1_varchar
+         Filter: ((col1_varchar)::bpchar = '2'::character(1))
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+select gp_segment_id,  * from t1_varchar where col1_varchar = '2'::char;
+INFO:  (slice 1) Dispatch command to SINGLE content
+ gp_segment_id | col1_varchar | col2_int 
+---------------+--------------+----------
+(0 rows)
+
+--No direct dispatch case, scenario: cast exists but not binary coercible
+drop table if exists t3;
+NOTICE:  table "t3" does not exist, skipping
+INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to ALL contents: 0 1 2
+create table t3 (c1 timestamp without time zone);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
+insert into t3 values ('2015-07-03 00:00:00'::timestamp without time zone);
+INFO:  (slice 0) Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to SINGLE content
+explain (costs off) select c1 from t3 where c1 = '2015-07-03'::date;
+                QUERY PLAN                 
+-------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on t3
+         Filter: (c1 = '07-03-2015'::date)
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+select c1 from t3 where c1 = '2015-07-03'::date;
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+            c1            
+--------------------------
+ Fri Jul 03 00:00:00 2015
+(1 row)
+
+drop table t3;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
+drop table t1_varchar;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
+--check direct dispatch working based on the distribution policy of relation
+drop extension if exists citext cascade;
+NOTICE:  extension "citext" does not exist, skipping
+INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to ALL contents: 0 1 2
+drop table if exists srt_dd;
+NOTICE:  table "srt_dd" does not exist, skipping
+INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to ALL contents: 0 1 2
+CREATE EXTENSION citext;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
+create table srt_dd (name CITEXT);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'name' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
+INSERT INTO srt_dd (name)
+VALUES ('abb'),
+       ('ABA'),
+       ('ABC'),
+       ('abd');
+INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
+explain (costs off) select LOWER(name) as aba FROM srt_dd WHERE name = 'ABA'::text;
+                  QUERY PLAN                  
+----------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
+   ->  Seq Scan on srt_dd
+         Filter: ((name)::text = 'ABA'::text)
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+select LOWER(name) as aba FROM srt_dd WHERE name = 'ABA'::text;
+INFO:  (slice 1) Dispatch command to SINGLE content
+ aba 
+-----
+ aba
+(1 row)
+
+explain (costs off) delete from srt_dd where name='ABA'::text;
+                  QUERY PLAN                  
+----------------------------------------------
+ Delete on srt_dd
+   ->  Seq Scan on srt_dd
+         Filter: ((name)::text = 'ABA'::text)
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+delete from srt_dd where name='ABA'::text;
+INFO:  (slice 0) Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to SINGLE content
+drop extension if exists citext cascade;
+NOTICE:  drop cascades to table srt_dd
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
+drop table if exists srt_dd;
+NOTICE:  table "srt_dd" does not exist, skipping
+INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to ALL contents: 0 1 2
 -- test direct dispatch via SQLValueFunction and FuncExpr for single row insertion.
 create table t_sql_value_function1 (a int, b date);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.

--- a/src/test/regress/expected/direct_dispatch_optimizer.out
+++ b/src/test/regress/expected/direct_dispatch_optimizer.out
@@ -919,6 +919,327 @@ INFO:  (slice 1) Dispatch command to PARTIAL contents: 0 1
              0 | 3 | 3
 (2 rows)
 
+--test direct dispatch if distribution column is of varchar type
+drop table if exists t1_varchar;
+NOTICE:  table "t1_varchar" does not exist, skipping
+INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to ALL contents: 0 1 2
+create table t1_varchar(col1_varchar varchar, col2_int int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'col1_varchar' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
+insert into t1_varchar values ('a',1);
+INFO:  (slice 0) Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to SINGLE content
+insert into t1_varchar values ('b',2);
+INFO:  (slice 0) Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to SINGLE content
+insert into t1_varchar values ('c',3);
+INFO:  (slice 0) Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to SINGLE content
+insert into t1_varchar values ('d',4);
+INFO:  (slice 0) Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to SINGLE content
+insert into t1_varchar values ('e',5);
+INFO:  (slice 0) Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to SINGLE content
+insert into t1_varchar values ('97',6);
+INFO:  (slice 0) Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to SINGLE content
+explain (costs off) select gp_segment_id,  * from t1_varchar where col1_varchar = 'c';
+                     QUERY PLAN                     
+----------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
+   ->  Seq Scan on t1_varchar
+         Filter: ((col1_varchar)::text = 'c'::text)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(4 rows)
+
+select gp_segment_id,  * from t1_varchar where col1_varchar = 'c';
+INFO:  (slice 1) Dispatch command to SINGLE content
+ gp_segment_id | col1_varchar | col2_int 
+---------------+--------------+----------
+             2 | c            |        3
+(1 row)
+
+explain (costs off) select gp_segment_id,  * from t1_varchar where col1_varchar <>'c';
+                     QUERY PLAN                      
+-----------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on t1_varchar
+         Filter: ((col1_varchar)::text <> 'c'::text)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(4 rows)
+
+select gp_segment_id,  * from t1_varchar where col1_varchar <>'c';
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+ gp_segment_id | col1_varchar | col2_int 
+---------------+--------------+----------
+             1 | b            |        2
+             1 | e            |        5
+             0 | d            |        4
+             2 | a            |        1
+             2 | 97           |        6
+(5 rows)
+
+--test direct dispatch if distribution column is of varchar type and disjunction scenario
+explain (costs off) select gp_segment_id, * from t1_varchar where col1_varchar in ('a','b');
+                           QUERY PLAN                           
+----------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on t1_varchar
+         Filter: ((col1_varchar)::text = ANY ('{a,b}'::text[]))
+ Optimizer: Pivotal Optimizer (GPORCA)
+(4 rows)
+
+select gp_segment_id, * from t1_varchar where col1_varchar in ('a','b');
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+ gp_segment_id | col1_varchar | col2_int 
+---------------+--------------+----------
+             1 | b            |        2
+             2 | a            |        1
+(2 rows)
+
+explain (costs off) select gp_segment_id, * from t1_varchar where col1_varchar = 'a' or col1_varchar = 'b';
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on t1_varchar
+         Filter: (((col1_varchar)::text = 'a'::text) OR ((col1_varchar)::text = 'b'::text))
+ Optimizer: Pivotal Optimizer (GPORCA)
+(4 rows)
+
+select gp_segment_id, * from t1_varchar where col1_varchar = 'a' or col1_varchar = 'b';
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+ gp_segment_id | col1_varchar | col2_int 
+---------------+--------------+----------
+             1 | b            |        2
+             2 | a            |        1
+(2 rows)
+
+--test direct dispatch if distribution column is of varchar type, having disjunction condition
+-- or an additional conjunction constraint using another table column or both
+explain (costs off) select gp_segment_id, * from t1_varchar where col1_varchar = 'c' and col2_int=3;
+                               QUERY PLAN                                
+-------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
+   ->  Seq Scan on t1_varchar
+         Filter: (((col1_varchar)::text = 'c'::text) AND (col2_int = 3))
+ Optimizer: Pivotal Optimizer (GPORCA)
+(4 rows)
+
+select gp_segment_id, * from t1_varchar where col1_varchar = 'c' and col2_int=3;
+INFO:  (slice 1) Dispatch command to SINGLE content
+ gp_segment_id | col1_varchar | col2_int 
+---------------+--------------+----------
+             2 | c            |        3
+(1 row)
+
+explain (costs off) select gp_segment_id, * from t1_varchar where col1_varchar = 'a' and col2_int in (1,3);
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
+   ->  Seq Scan on t1_varchar
+         Filter: (((col1_varchar)::text = 'a'::text) AND (col2_int = ANY ('{1,3}'::integer[])))
+ Optimizer: Pivotal Optimizer (GPORCA)
+(4 rows)
+
+select gp_segment_id, * from t1_varchar where col1_varchar = 'a' and col2_int in (1,3);
+INFO:  (slice 1) Dispatch command to SINGLE content
+ gp_segment_id | col1_varchar | col2_int 
+---------------+--------------+----------
+             2 | a            |        1
+(1 row)
+
+explain (costs off) select gp_segment_id, * from t1_varchar where col1_varchar = 'a' and col2_int not in (2,3);
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
+   ->  Seq Scan on t1_varchar
+         Filter: (((col1_varchar)::text = 'a'::text) AND (col2_int <> ALL ('{2,3}'::integer[])))
+ Optimizer: Pivotal Optimizer (GPORCA)
+(4 rows)
+
+select gp_segment_id, * from t1_varchar where col1_varchar = 'a' and col2_int not in (2,3);
+INFO:  (slice 1) Dispatch command to SINGLE content
+ gp_segment_id | col1_varchar | col2_int 
+---------------+--------------+----------
+             2 | a            |        1
+(1 row)
+
+explain (costs off) select gp_segment_id, * from t1_varchar where col1_varchar in ('a', 'b') and col2_int=2;
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on t1_varchar
+         Filter: (((col1_varchar)::text = ANY ('{a,b}'::text[])) AND (col2_int = 2))
+ Optimizer: Pivotal Optimizer (GPORCA)
+(4 rows)
+
+select gp_segment_id, * from t1_varchar where col1_varchar in ('a', 'b') and col2_int=2;
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+ gp_segment_id | col1_varchar | col2_int 
+---------------+--------------+----------
+             1 | b            |        2
+(1 row)
+
+explain (costs off) select gp_segment_id, * from t1_varchar where (col1_varchar = 'a' or col1_varchar = 'b') and col2_int=1;
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on t1_varchar
+         Filter: ((((col1_varchar)::text = 'a'::text) OR ((col1_varchar)::text = 'b'::text)) AND (col2_int = 1))
+ Optimizer: Pivotal Optimizer (GPORCA)
+(4 rows)
+
+select gp_segment_id, * from t1_varchar where (col1_varchar = 'a' or col1_varchar = 'b') and col2_int=1;
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+ gp_segment_id | col1_varchar | col2_int 
+---------------+--------------+----------
+             2 | a            |        1
+(1 row)
+
+--Test direct dispatch with explicit typecasting
+explain (costs off) select gp_segment_id, * from t1_varchar where col1_varchar = 97::VARCHAR;
+                     QUERY PLAN                      
+-----------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
+   ->  Seq Scan on t1_varchar
+         Filter: ((col1_varchar)::text = '97'::text)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(4 rows)
+
+select gp_segment_id, * from t1_varchar where col1_varchar = 97::VARCHAR;
+INFO:  (slice 1) Dispatch command to SINGLE content
+ gp_segment_id | col1_varchar | col2_int 
+---------------+--------------+----------
+             2 | 97           |        6
+(1 row)
+
+-- explicit cast using "char", generates a scenario of cast function from Dist Colm to datum in CTranslatorExprToDXLUtils::FDirectDispatchable(,,)
+explain (costs off) select gp_segment_id,  * from t1_varchar where col1_varchar = 'c'::char;
+                          QUERY PLAN                          
+--------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
+   ->  Seq Scan on t1_varchar
+         Filter: ((col1_varchar)::bpchar = 'c'::character(1))
+ Optimizer: Pivotal Optimizer (GPORCA)
+(4 rows)
+
+select gp_segment_id,  * from t1_varchar where col1_varchar = 'c'::char;
+INFO:  (slice 1) Dispatch command to SINGLE content
+ gp_segment_id | col1_varchar | col2_int 
+---------------+--------------+----------
+             2 | c            |        3
+(1 row)
+
+explain (costs off) select gp_segment_id,  * from t1_varchar where col1_varchar = '2'::char;
+                          QUERY PLAN                          
+--------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
+   ->  Seq Scan on t1_varchar
+         Filter: ((col1_varchar)::bpchar = '2'::character(1))
+ Optimizer: Pivotal Optimizer (GPORCA)
+(4 rows)
+
+select gp_segment_id,  * from t1_varchar where col1_varchar = '2'::char;
+INFO:  (slice 1) Dispatch command to SINGLE content
+ gp_segment_id | col1_varchar | col2_int 
+---------------+--------------+----------
+(0 rows)
+
+--No direct dispatch case, scenario: cast exists but not binary coercible
+drop table if exists t3;
+NOTICE:  table "t3" does not exist, skipping
+INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to ALL contents: 0 1 2
+create table t3 (c1 timestamp without time zone);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
+insert into t3 values ('2015-07-03 00:00:00'::timestamp without time zone);
+INFO:  (slice 0) Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to SINGLE content
+explain (costs off) select c1 from t3 where c1 = '2015-07-03'::date;
+                QUERY PLAN                 
+-------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on t3
+         Filter: (c1 = '07-03-2015'::date)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(4 rows)
+
+select c1 from t3 where c1 = '2015-07-03'::date;
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+            c1            
+--------------------------
+ Fri Jul 03 00:00:00 2015
+(1 row)
+
+drop table t3;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
+drop table t1_varchar;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
+--check direct dispatch working based on the distribution policy of relation
+drop extension if exists citext cascade;
+NOTICE:  extension "citext" does not exist, skipping
+INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to ALL contents: 0 1 2
+drop table if exists srt_dd;
+NOTICE:  table "srt_dd" does not exist, skipping
+INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to ALL contents: 0 1 2
+CREATE EXTENSION citext;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
+create table srt_dd (name CITEXT);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'name' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
+INSERT INTO srt_dd (name)
+VALUES ('abb'),
+       ('ABA'),
+       ('ABC'),
+       ('abd');
+INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
+explain (costs off) select LOWER(name) as aba FROM srt_dd WHERE name = 'ABA'::text;
+                  QUERY PLAN                  
+----------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
+   ->  Seq Scan on srt_dd
+         Filter: ((name)::text = 'ABA'::text)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(4 rows)
+
+select LOWER(name) as aba FROM srt_dd WHERE name = 'ABA'::text;
+INFO:  (slice 1) Dispatch command to SINGLE content
+ aba 
+-----
+ aba
+(1 row)
+
+explain (costs off) delete from srt_dd where name='ABA'::text;
+                  QUERY PLAN                  
+----------------------------------------------
+ Delete on srt_dd
+   ->  Seq Scan on srt_dd srt_dd_1
+         Filter: ((name)::text = 'ABA'::text)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(4 rows)
+
+delete from srt_dd where name='ABA'::text;
+INFO:  (slice 0) Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to SINGLE content
+drop extension if exists citext cascade;
+NOTICE:  drop cascades to table srt_dd
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
+drop table if exists srt_dd;
+NOTICE:  table "srt_dd" does not exist, skipping
+INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to ALL contents: 0 1 2
 -- test direct dispatch via SQLValueFunction and FuncExpr for single row insertion.
 create table t_sql_value_function1 (a int, b date);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.

--- a/src/test/regress/expected/inherit_optimizer.out
+++ b/src/test/regress/expected/inherit_optimizer.out
@@ -1930,9 +1930,9 @@ explain (costs off) select * from list_parted where a = 'ab' or a in (null, 'cd'
 (5 rows)
 
 explain (costs off) select * from list_parted where a = 'ab';
-                   QUERY PLAN                   
-------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
+                     QUERY PLAN                     
+----------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
    ->  Dynamic Seq Scan on list_parted
          Number of partitions to scan: 1 (out of 3)
          Filter: ((a)::text = 'ab'::text)

--- a/src/test/regress/expected/qp_targeted_dispatch_optimizer.out
+++ b/src/test/regress/expected/qp_targeted_dispatch_optimizer.out
@@ -323,7 +323,7 @@ INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
 INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
 select * from bytea where bytea1='d' and cidr1='0.0.0.1';
-INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to SINGLE content
  bytea1 |   cidr1    
 --------+------------
  \x64   | 0.0.0.1/32

--- a/src/test/regress/expected/window_optimizer.out
+++ b/src/test/regress/expected/window_optimizer.out
@@ -3058,7 +3058,7 @@ SELECT * FROM
 WHERE depname = 'sales';
                                    QUERY PLAN                                    
 ---------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
+ Gather Motion 1:1  (slice1; segments: 1)
    ->  WindowAgg
          Partition By: (((depname)::text || 'A'::text)), depname
          ->  Sort
@@ -3137,7 +3137,7 @@ SELECT * FROM
 WHERE depname = 'sales';
                                 QUERY PLAN                                 
 ---------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)
+ Gather Motion 1:1  (slice1; segments: 1)
    ->  WindowAgg
          Partition By: depname, empno
          Order By: enroll_date


### PR DESCRIPTION
ORCA did not perform direct dispatch when the distribution column was of type 'varchar'
With this update this error is fixed.

For direct dispatch, in the code, for datum and distribution column OIds are compared. 
Direct dispatch is performed, if they are equal. 

Consider the following query which failed for a table (create table t1_varchar(col1_varchar varchar, col2_int int)):

       explain select * from t1_varchar where col1_varchar = ‘c’;

In this case both the Old field in IMDid class, were different, thus direct dispatch was not performed. 
To fix this, it is checked if a cast exist between them and if that cast is binary coercible. Eg if datum oid id 25(Text) and DistCol oid is 1043(VarChar) then since a cast is possible and cast is binary coercible, we go ahead with direct dispatch.


**`21.12.2022`**

After the code was corrected for direct dispatch for varchar distribution column, another bug surfaced out in the code due the fix. During the pipeline run, it was found that following tests  in citext.sql were failed

SETUP

```
CREATE EXTENSION citext;
CREATE TEMP TABLE srt ( name CITEXT);
INSERT INTO srt (name) VALUES ('abb'), ('ABA'), ('ABC'), ('abd');
```

QUERIES

```
SELECT LOWER(name) as aba FROM srt WHERE name = 'ABA'::text;
SELECT LOWER(name) as aba FROM srt WHERE name = 'ABA'::varchar;
SELECT LOWER(name) as aba FROM srt WHERE name = 'ABA'::bpchar;
```

Before the fix for direct dispatch, these queries were running successfully as direct dispatch
was not performed for them, Planner on the other hand was performing direct dispatch for them.

With the update in direct dispatch concept, ORCA was trying to perform direct dispatch
in these queries also, but a wrong segment number was generated by the hashing function.

On debugging the code, it was found that, wrong segment number was selected due to selection of 
wrong hash function. On further analysis, it was found that for direct dispatch ORCA selected hash function based on the 
const typeoid. Planner on the other hand selected hash function based on the distribution policy of the relation.

To correct this bug, the hash function selection for direct dispatch was also made on the distribution policy of the relation.

Implementation Key points 

1. During the DXL to planned statement stage, we extract the information of available RTEs in FROM clause 

2. We perform direct dispatch based on the distribution policy, if there is only one unique RTE in from clause of query,
else we go back to the old logic. 
