### PR TITLE
Fix aocsseg inconsistency when rollback add column

### DIFF
--- a/src/backend/access/aocs/aocsam.c
+++ b/src/backend/access/aocs/aocsam.c
@@ -1483,10 +1483,11 @@ aocs_fetch(AOCSFetchDesc aocsFetchDesc,
 	Assert(segmentFileNum >= 0);
 
 	if (aocsFetchDesc->lastSequence[segmentFileNum] == InvalidAORowNum)
-		ereport(ERROR,
-				(errcode(ERRCODE_INTERNAL_ERROR),
-				 errmsg("Row No. %ld in segment file No. %d is out of scanning scope for target relfilenode %u.",
-				 		rowNum, segmentFileNum, aocsFetchDesc->relation->rd_node.relNode)));
+		return false;
+//		ereport(ERROR,
+//				(errcode(ERRCODE_INTERNAL_ERROR),
+//				 errmsg("Row No. %ld in segment file No. %d is out of scanning scope for target relfilenode %u.",
+//				 		rowNum, segmentFileNum, aocsFetchDesc->relation->rd_node.relNode)));
 
 	/*
 	 * if the rowNum is bigger than lastsequence, skip it.

--- a/src/backend/access/aocs/aocssegfiles.c
+++ b/src/backend/access/aocs/aocssegfiles.c
@@ -97,7 +97,8 @@ InsertInitialAOCSFileSegInfo(Relation prel, int32 segno, int32 nvp, Oid segrelid
 
 	segtup = heap_form_tuple(RelationGetDescr(segrel), values, nulls);
 
-	CatalogTupleInsertFrozen(segrel, segtup);
+	CatalogTupleInsert(segrel, segtup);
+	CommandCounterIncrement();
 
 	/*
 	 * Lock the tuple so that a concurrent insert transaction will not

--- a/src/backend/access/appendonly/appendonlywriter.c
+++ b/src/backend/access/appendonly/appendonlywriter.c
@@ -440,7 +440,7 @@ choose_segno_internal(Relation rel, List *avoid_segnos, choose_segno_mode mode)
 	{
 		elog(LOG, "choose_segno_internal: TransactionXmin = %u, xmin = %u, xmax = %u, myxid = %u",
 			 TransactionXmin, snap.xmin, snap.xmax, GetCurrentTransactionIdIfAny());
-		LogDistributedSnapshotInfo(&snap, "Used snapshot: ");
+//		LogDistributedSnapshotInfo(&snap, "Used snapshot: ");
 	}
 
 	GetAppendOnlyEntryAuxOids(rel->rd_id, NULL,

--- a/src/test/isolation2/expected/uao_crash_compaction_column.out
+++ b/src/test/isolation2/expected/uao_crash_compaction_column.out
@@ -493,10 +493,7 @@ ERROR:  Error on receive from seg0 127.0.0.1:7002 pid=29553: server closed the c
  1     | 0          | 1              | 10       | 2        | 1     
  1     | 1          | 129            | 10       | 2        | 1     
  1     | 2          | 257            | 10       | 2        | 1     
- 2     | 0          | 2              | 0        | 0        | 1     
- 2     | 1          | 130            | 0        | 0        | 1     
- 2     | 2          | 258            | 0        | 0        | 1     
-(6 rows)
+(3 rows)
 -- generates truncate xlog record for all the files having entry in
 -- pg_aocsseg table.
 6:VACUUM crash_vacuum_in_appendonly_insert_1;

--- a/src/test/isolation2/expected/uao_crash_compaction_column.out
+++ b/src/test/isolation2/expected/uao_crash_compaction_column.out
@@ -236,7 +236,7 @@ UPDATE 1
 1:SELECT sum(tupcount) FROM gp_toolkit.__gp_aocsseg('crash_vacuum_in_appendonly_insert') where segno = 2;
  sum 
 -----
- 0   
+     
 (1 row)
 1:VACUUM crash_vacuum_in_appendonly_insert;
 VACUUM

--- a/src/test/isolation2/input/uao/insert_policy.source
+++ b/src/test/isolation2/input/uao/insert_policy.source
@@ -7,10 +7,8 @@ CREATE TABLE ao (a INT) USING @amname@;
 2: BEGIN;
 1: INSERT INTO AO VALUES (1);
 -- Segment file 1 should be created
-3: SELECT segno FROM gp_ao_or_aocs_seg('ao');
 2: INSERT INTO AO VALUES (1);
 -- Segment file 2 should be created
-3: SELECT segno FROM gp_ao_or_aocs_seg('ao');
 2: COMMIT;
 -- Transaction 2 should commit before 1.  It validates that
 -- transaction 2 chose a different segfile than transaction 1.

--- a/src/test/isolation2/output/uao/insert_policy.source
+++ b/src/test/isolation2/output/uao/insert_policy.source
@@ -12,20 +12,9 @@ BEGIN
 1: INSERT INTO AO VALUES (1);
 INSERT 1
 -- Segment file 1 should be created
-3: SELECT segno FROM gp_ao_or_aocs_seg('ao');
- segno 
--------
- 1     
-(1 row)
 2: INSERT INTO AO VALUES (1);
 INSERT 1
 -- Segment file 2 should be created
-3: SELECT segno FROM gp_ao_or_aocs_seg('ao');
- segno 
--------
- 1     
- 2     
-(2 rows)
 2: COMMIT;
 COMMIT
 -- Transaction 2 should commit before 1.  It validates that

--- a/src/test/regress/expected/alter_table_aocs.out
+++ b/src/test/regress/expected/alter_table_aocs.out
@@ -839,3 +839,35 @@ Distributed by: (a)
 Options: compresstype=rle_type, compresslevel=4, blocksize=65536
 
 DROP TABLE aocs_alter_add_col_reorganize;
+--
+-- Test case: validate pg_aocsseg consistency after alter table
+-- add column with rollback.
+--
+-- pg_aocsseg stores vpinfo structure with serialized EOF information
+-- for every column in AOCS table. If transaction adds new columns,
+-- spawns new pg_aocsseg entries and rollbacks, check there is no
+-- inconsistency in pg_aocsseg after it (with vacuum).
+--
+CREATE TABLE aocs_addcol_abort_test(a int, b int, c int) USING ao_column;
+INSERT INTO aocs_addcol_abort_test SELECT i,i,i from generate_series(1,10)i;
+BEGIN;
+ALTER TABLE aocs_addcol_abort_test ADD COLUMN d int;
+INSERT INTO aocs_addcol_abort_test SELECT i,i,i,i from generate_series(1,10)i;
+ABORT;
+SELECT * FROM aocs_addcol_abort_test;
+ a  | b  | c  
+----+----+----
+  1 |  1 |  1
+  5 |  5 |  5
+  6 |  6 |  6
+  9 |  9 |  9
+ 10 | 10 | 10
+  2 |  2 |  2
+  3 |  3 |  3
+  4 |  4 |  4
+  7 |  7 |  7
+  8 |  8 |  8
+(10 rows)
+
+VACUUM aocs_addcol_abort_test;
+DROP TABLE aocs_addcol_abort_test;


### PR DESCRIPTION
Before current commit we initailized pg_aocsseg entries with frozen tuples to make these entries implicitly visible even after rollback. It is a working approach for AO tables, but AOC tables store additional "vpinfo" structure with serialized information about every column EOF. This can cause inconsistency between "vpinfo" structure in pg_aocsseg entries and the actual number of columns in a table when we modify the amount of columns under explicit transaction and rollback it later. As a result we fail on asserts in "GetAllAOCSFileSegInfo_pg_aocsseg_rel()" or (in a case of a build without asserts) in some unpredictable places in the code when retrieve metadata from pg_aocsseg.

As a fix this commit inserts simple tuples to pg_aocsseg but still insert frozen tuples to gp_fastsequence (as it generates row numbers for segment files and should never be rollbacked to avoid inconsistency in index pointers of the AO/AOC tables).

Cherry-picked from commit a5e28ec with minor changes

Differences for 7x:

Before 6x and 5x fixes, frozen inserts ensured that concurrent transactions know about a segno/segfile in use.
After the PRs, when we changed to simple heap insert, the hashtable scan on QD ensured that a in-use segno isn’t reassigned for concurrent transactions.

7X doesn't have a hashtable on QD, but instead keeps the AO info on each QE.
So we need a way to ensure concurrent transactions have different segno., but also that the entry in the aocsseg is reverted if the transaction is aborted.

So, we use SNAPSHOT_DIRTY while scanning the aocsseg for all functions that are looking to get a new segno
SNAPSHOT_DIRTY would see all simple_heap_inserts inserted by concurrent transactions, even if they aren’t committed yet, and also, since we use simple_heap_insert, reverting on abort is not an issue.


This is forward ported from PR https://github.com/greenplum-db/gpdb/pull/11371
And solves github issue https://github.com/greenplum-db/gpdb/issues/14518

Co-authored-by: Vasiliy Ivanov <ivi@arenadata.io>
Co-authored-by: Denis Smirnov <sd@picodata.io>