### PR TITLE
(WIP) Prevent pre-evaluate json_populate_XXX() functions in planner

### DIFF
--- a/src/test/regress/expected/json.out
+++ b/src/test/regress/expected/json.out
@@ -1752,6 +1752,13 @@ SELECT json_populate_record(row(1,2), '{"f1": 0, "f2": 1}');
  (0,1)
 (1 row)
 
+SELECT * FROM
+  json_populate_record(null::record, '{"x": 776}') AS (x int, y int);
+  x  | y 
+-----+---
+ 776 |  
+(1 row)
+
 -- composite domain
 SELECT json_populate_record(null::j_ordered_pair, '{"x": 0, "y": 1}');
  json_populate_record 
@@ -1853,6 +1860,13 @@ FROM (VALUES (1),(2)) v(i);
  2 | (2,43)
 (4 rows)
 
+SELECT * FROM
+  json_populate_recordset(null::record, '[{"x": 776}]') AS (x int, y int);
+  x  | y 
+-----+---
+ 776 |  
+(1 row)
+
 -- empty array is a corner case
 SELECT json_populate_recordset(null::record, '[]');
 ERROR:  could not determine row type for result of json_populate_recordset
@@ -1865,6 +1879,12 @@ SELECT json_populate_recordset(row(1,2), '[]');
 SELECT * FROM json_populate_recordset(NULL::jpop,'[]') q;
  a | b | c 
 ---+---+---
+(0 rows)
+
+SELECT * FROM
+  json_populate_recordset(null::record, '[]') AS (x int, y int);
+ x | y 
+---+---
 (0 rows)
 
 -- composite domain

--- a/src/test/regress/sql/json.sql
+++ b/src/test/regress/sql/json.sql
@@ -522,6 +522,8 @@ SELECT rec FROM json_populate_record(
 -- anonymous record type
 SELECT json_populate_record(null::record, '{"x": 0, "y": 1}');
 SELECT json_populate_record(row(1,2), '{"f1": 0, "f2": 1}');
+SELECT * FROM
+  json_populate_record(null::record, '{"x": 776}') AS (x int, y int);
 
 -- composite domain
 SELECT json_populate_record(null::j_ordered_pair, '{"x": 0, "y": 1}');
@@ -549,11 +551,15 @@ SELECT json_populate_recordset(null::record, '[{"x": 0, "y": 1}]');
 SELECT json_populate_recordset(row(1,2), '[{"f1": 0, "f2": 1}]');
 SELECT i, json_populate_recordset(row(i,50), '[{"f1":"42"},{"f2":"43"}]')
 FROM (VALUES (1),(2)) v(i);
+SELECT * FROM
+  json_populate_recordset(null::record, '[{"x": 776}]') AS (x int, y int);
 
 -- empty array is a corner case
 SELECT json_populate_recordset(null::record, '[]');
 SELECT json_populate_recordset(row(1,2), '[]');
 SELECT * FROM json_populate_recordset(NULL::jpop,'[]') q;
+SELECT * FROM
+  json_populate_recordset(null::record, '[]') AS (x int, y int);
 
 -- composite domain
 SELECT json_populate_recordset(null::j_ordered_pair, '[{"x": 0, "y": 1}]');


### PR DESCRIPTION
This PR fix https://github.com/greenplum-db/gpdb/issues/14499.

`json_populate_record()` is a STABLE function, so it will be pre-evaluated in planner: https://github.com/greenplum-db/gpdb/blob/c654c503faf67bf88c871c4e135b2219c5060c8f/src/backend/optimizer/util/clauses.c#L4677-L4687

But its retype=ANY (like RECORDOID), pre-evaluate it may cause ERROR later (please see the issue).
https://github.com/greenplum-db/gpdb/blob/c654c503faf67bf88c871c4e135b2219c5060c8f/src/backend/optimizer/util/clauses.c#L4627-L4630

Considering there are only 4 such functions: 
```
demo=# select oid, proname, provolatile from pg_proc where prorettype=2283 and provolatile = 's';
 oid  |         proname          | provolatile
------+--------------------------+-------------
 3209 | jsonb_populate_record    | s
 3475 | jsonb_populate_recordset | s
 3960 | json_populate_record     | s
 3961 | json_populate_recordset  | s
(4 rows)
```
So just simply check whether it's in the list to prevent pre-evaluate them.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
