### PR TITLE
Adbdev 3234

### DIFF
--- a/src/backend/commands/extension.c
+++ b/src/backend/commands/extension.c
@@ -811,37 +811,6 @@ is_begin_state(const Node *stmt)
 #endif
 
 /*
- * Set up the search path to contain the target schema, then the schemas
- * of any prerequisite extensions, and nothing else.  In particular this
- * makes the target schema be the default creation target namespace.
- *
- * Note: it might look tempting to use PushOverrideSearchPath for this,
- * but we cannot do that.  We have to actually set the search_path GUC in
- * case the extension script examines or changes it.  In any case, the
- * GUC_ACTION_SAVE method is just as convenient.
- */
-static void
-set_serach_path_for_extension(List *requiredSchemas, const char *schemaName)
-{
-	StringInfoData pathbuf;
-	ListCell *lc;
-	initStringInfo(&pathbuf);
-	appendStringInfoString(&pathbuf, quote_identifier(schemaName));
-	foreach(lc, requiredSchemas)
-	{
-		Oid			reqschema = lfirst_oid(lc);
-		char	   *reqname = get_namespace_name(reqschema);
-
-		if (reqname)
-			appendStringInfo(&pathbuf, ", %s", quote_identifier(reqname));
-	}
-
-	(void) set_config_option("search_path", pathbuf.data,
-							 PGC_USERSET, PGC_S_SESSION,
-							 GUC_ACTION_SAVE, true, 0, false);
-}
-
-/*
  * Execute the appropriate script file for installing or updating the extension
  *
  * If from_version isn't NULL, it's an update
@@ -854,10 +823,13 @@ execute_extension_script(Node *stmt,
 						 Oid extensionOid, ExtensionControlFile *control,
 						 const char *from_version,
 						 const char *version,
+						 List *requiredSchemas,
 						 const char *schemaName, Oid schemaOid)
 {
 	char	   *filename;
 	int			save_nestlevel;
+	StringInfoData pathbuf;
+	ListCell   *lc;
 
 	AssertState(Gp_role != GP_ROLE_EXECUTE);
 	AssertImply(Gp_role == GP_ROLE_DISPATCH, stmt != NULL &&
@@ -906,6 +878,31 @@ execute_extension_script(Node *stmt,
 		(void) set_config_option("log_min_messages", "warning",
 								 PGC_SUSET, PGC_S_SESSION,
 								 GUC_ACTION_SAVE, true, 0, false);
+
+	/*
+	 * Set up the search path to contain the target schema, then the schemas
+	 * of any prerequisite extensions, and nothing else.  In particular this
+	 * makes the target schema be the default creation target namespace.
+	 *
+	 * Note: it might look tempting to use PushOverrideSearchPath for this,
+	 * but we cannot do that.  We have to actually set the search_path GUC in
+	 * case the extension script examines or changes it.  In any case, the
+	 * GUC_ACTION_SAVE method is just as convenient.
+	 */
+	initStringInfo(&pathbuf);
+	appendStringInfoString(&pathbuf, quote_identifier(schemaName));
+	foreach(lc, requiredSchemas)
+	{
+		Oid			reqschema = lfirst_oid(lc);
+		char	   *reqname = get_namespace_name(reqschema);
+
+		if (reqname)
+			appendStringInfo(&pathbuf, ", %s", quote_identifier(reqname));
+	}
+
+	(void) set_config_option("search_path", pathbuf.data,
+							 PGC_USERSET, PGC_S_SESSION,
+							 GUC_ACTION_SAVE, true, 0, false);
 
 	/*
 	 * Set creating_extension and related variables so that
@@ -1644,12 +1641,11 @@ CreateExtensionInternal(char *extensionName,
 		stmt = NULL;
 	}
 
-	set_serach_path_for_extension(requiredSchemas, schemaName);
-
 	if (Gp_role != GP_ROLE_EXECUTE)
 	{
 		execute_extension_script((Node *) stmt, extensionOid, control,
 							 oldVersionName, versionName,
+							 requiredSchemas,
 							 schemaName, schemaOid);
 
 		/*
@@ -3324,8 +3320,6 @@ ApplyExtensionUpdates(Oid extensionOid,
 
 		InvokeObjectPostAlterHook(ExtensionRelationId, extensionOid, 0);
 
-		set_serach_path_for_extension(requiredSchemas, schemaName);
-
 		if (Gp_role != GP_ROLE_EXECUTE)
 		{
 			Node *stmt = NULL;
@@ -3351,6 +3345,7 @@ ApplyExtensionUpdates(Oid extensionOid,
 			 */
 			execute_extension_script(stmt, extensionOid, control,
 									 oldVersionName, versionName,
+									 requiredSchemas,
 									 schemaName, schemaOid);
 		}
 		else

--- a/src/backend/commands/extension.c
+++ b/src/backend/commands/extension.c
@@ -76,6 +76,9 @@
 bool		creating_extension = false;
 Oid			CurrentExtensionObject = InvalidOid;
 
+/* File visible "segment" variable for GUCs state */
+static int	segment_nestlevel = 0;
+
 /*
  * Internal data structure to hold the results of parsing a control file
  */
@@ -813,6 +816,9 @@ is_begin_state(const Node *stmt)
 /*
  * Execute the appropriate script file for installing or updating the extension
  *
+ * This function executes on QD and QE's. On QE's this function only sets up
+ * necessary GUC's and state variables, needed for further execution.
+ *
  * If from_version isn't NULL, it's an update
  *
  * If stmt isn't NULL, it means that there already has been a Gang of type GANGTYPE_PRIMARY_WRITER,
@@ -831,7 +837,6 @@ execute_extension_script(Node *stmt,
 	StringInfoData pathbuf;
 	ListCell   *lc;
 
-	AssertState(Gp_role != GP_ROLE_EXECUTE);
 	AssertImply(Gp_role == GP_ROLE_DISPATCH, stmt != NULL &&
 			(nodeTag(stmt) == T_CreateExtensionStmt || nodeTag(stmt) == T_AlterExtensionStmt) &&
 			is_begin_state(stmt));
@@ -911,6 +916,16 @@ execute_extension_script(Node *stmt,
 	 */
 	creating_extension = true;
 	CurrentExtensionObject = extensionOid;
+
+	/*
+	 * All necessary variables at segment is set up.
+	 */
+	if (Gp_role == GP_ROLE_EXECUTE)
+	{
+			segment_nestlevel = save_nestlevel;
+			return;
+	}
+
 	PG_TRY();
 	{
 		char	   *c_sql = read_extension_script_file(control, filename);
@@ -1345,7 +1360,7 @@ CreateExtensionInternal(char *extensionName,
 	Oid			extensionOid;
 	ObjectAddress address;
 	ListCell   *lc;
-	CreateExtensionStmt *stmt;
+	CreateExtensionStmt *stmt = NULL;
 
 	/*
 	 * Read the primary control file.  Note we assume that it does not contain
@@ -1635,19 +1650,20 @@ CreateExtensionInternal(char *extensionName,
 									GetAssignedOidsForDispatch(),
 									NULL);
 	}
-	else
-	{
-		CurrentExtensionObject = extensionOid;
-		stmt = NULL;
-	}
 
-	if (Gp_role != GP_ROLE_EXECUTE)
-	{
-		execute_extension_script((Node *) stmt, extensionOid, control,
+	execute_extension_script((Node *) stmt, extensionOid, control,
 							 oldVersionName, versionName,
 							 requiredSchemas,
 							 schemaName, schemaOid);
 
+	/*
+	 * On the QD and the QE's updateVersions list is calculated
+	 * and this lists are the same. Thus ApplyExtensionUpdates
+	 * call for must be forbidden at QE. (It would be dispatchered
+	 * from QD a bit later)
+	 */
+	if (Gp_role != GP_ROLE_EXECUTE)
+	{
 		/*
 		 * If additional update scripts have to be executed, apply the updates as
 		 * though a series of ALTER EXTENSION UPDATE commands were given
@@ -1784,12 +1800,12 @@ CreateExtension(ParseState *pstate, CreateExtensionStmt *stmt)
 				elog(ERROR, "invalid CREATE EXTENSION state");
 				break;
 
-			case CREATE_EXTENSION_BEGIN:	/* Mark creating_extension flag and add pg_extension catalog tuple */
-				creating_extension = true;
+			case CREATE_EXTENSION_BEGIN:
 				break;
 			case CREATE_EXTENSION_END:		/* Mark creating_extension flag = false */
-				creating_extension = false;
-				CurrentExtensionObject = InvalidOid;
+				Assert(segment_nestlevel > 0);
+				AtEOXact_GUC(true, segment_nestlevel);
+				ResetExtensionCreatingGlobalVarsOnQE();
 				ObjectAddressSet(address,
 								 ExtensionRelationId,
 								 get_extension_oid(stmt->extname, true));
@@ -1804,10 +1820,8 @@ CreateExtension(ParseState *pstate, CreateExtensionStmt *stmt)
 	/*
 	 * We use global variables to track the extension being created, so we can
 	 * create only one extension at the same time.
-	 * Except that QE do CREATE_EXTENSION_BEGIN.
 	 */
-	if (creating_extension && !(stmt->create_ext_state == CREATE_EXTENSION_BEGIN &&
-		Gp_role == GP_ROLE_EXECUTE))
+	if (creating_extension)
 		ereport(ERROR,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 					errmsg("nested CREATE EXTENSION is not supported")));
@@ -3037,8 +3051,9 @@ ExecAlterExtensionStmt(ParseState *pstate, AlterExtensionStmt *stmt)
 			case UPDATE_EXTENSION_BEGIN:
 				break;
 			case UPDATE_EXTENSION_END:		/* Mark creating_extension flag = false */
-				creating_extension = false;
-				CurrentExtensionObject = InvalidOid;
+				Assert(segment_nestlevel > 0);
+				AtEOXact_GUC(true, segment_nestlevel);
+				ResetExtensionCreatingGlobalVarsOnQE();
 				ObjectAddressSet(address,
 								 ExtensionRelationId,
 								 get_extension_oid(stmt->extname, true));
@@ -3320,42 +3335,31 @@ ApplyExtensionUpdates(Oid extensionOid,
 
 		InvokeObjectPostAlterHook(ExtensionRelationId, extensionOid, 0);
 
-		if (Gp_role != GP_ROLE_EXECUTE)
+		Node *stmt = NULL;
+		if (Gp_role == GP_ROLE_DISPATCH)
 		{
-			Node *stmt = NULL;
 
-			if (Gp_role == GP_ROLE_DISPATCH)
-			{
-				AlterExtensionStmt *update_stmt = makeNode(AlterExtensionStmt);
-				update_stmt->extname = pcontrol->name;
-				update_stmt->options = lappend(NIL,
-											   makeDefElem("new_version",
-														   (Node *) makeString(versionName),
-														   -1));
-				update_stmt->update_ext_state = UPDATE_EXTENSION_BEGIN;
-				stmt = (Node*)update_stmt;
-				CdbDispatchUtilityStatement(stmt,
-											DF_WITH_SNAPSHOT | DF_CANCEL_ON_ERROR | DF_NEED_TWO_PHASE,
-											NIL  /* We don't create any object in UPDATE EXTENSION, so NIL here. */,
-											NULL);
-			}
+			AlterExtensionStmt *update_stmt = makeNode(AlterExtensionStmt);
+			update_stmt->extname = pcontrol->name;
+			update_stmt->options = lappend(NIL,
+											makeDefElem("new_version",
+														(Node *) makeString(versionName),
+														-1));
+			update_stmt->update_ext_state = UPDATE_EXTENSION_BEGIN;
+			stmt = (Node*)update_stmt;
+			CdbDispatchUtilityStatement(stmt,
+										DF_WITH_SNAPSHOT | DF_CANCEL_ON_ERROR | DF_NEED_TWO_PHASE,
+										NIL  /* We don't create any object in UPDATE EXTENSION, so NIL here. */,
+										NULL);
+		}
 
-			/*
-			 * Finally, execute the update script file
-			 */
-			execute_extension_script(stmt, extensionOid, control,
-									 oldVersionName, versionName,
-									 requiredSchemas,
-									 schemaName, schemaOid);
-		}
-		else
-		{
-			/* GP_ROLE_EXECUTE */
-			/* Set these global states for the execute_extension_script() that is called next in QD. */
-			creating_extension = true;
-			CurrentExtensionObject = extensionOid;
-			/* break */
-		}
+		/*
+			* Finally, execute the update script file
+			*/
+		execute_extension_script(stmt, extensionOid, control,
+								 oldVersionName, versionName,
+								 requiredSchemas,
+								 schemaName, schemaOid);
 
 		/*
 		 * Update prior-version name and loop around.  Since
@@ -3588,4 +3592,5 @@ ResetExtensionCreatingGlobalVarsOnQE(void)
 {
 	creating_extension = false;
 	CurrentExtensionObject = InvalidOid;
+	segment_nestlevel = 0;
 }

--- a/src/test/modules/test_extensions/Makefile
+++ b/src/test/modules/test_extensions/Makefile
@@ -5,15 +5,17 @@ PGFILEDESC = "test_extensions - regression testing for EXTENSION support"
 
 EXTENSION = test_ext1 test_ext2 test_ext3 test_ext4 test_ext5 test_ext6 \
             test_ext7 test_ext8 test_ext_cine test_ext_cor \
-            test_ext_cyclic1 test_ext_cyclic2
+            test_ext_cyclic1 test_ext_cyclic2 test_ext_cau
 DATA = test_ext1--1.0.sql test_ext2--1.0.sql test_ext3--1.0.sql \
        test_ext4--1.0.sql test_ext5--1.0.sql test_ext6--1.0.sql \
        test_ext7--1.0.sql test_ext7--1.0--2.0.sql test_ext8--1.0.sql \
        test_ext_cine--1.0.sql test_ext_cine--1.0--1.1.sql \
        test_ext_cor--1.0.sql \
-       test_ext_cyclic1--1.0.sql test_ext_cyclic2--1.0.sql
+       test_ext_cyclic1--1.0.sql test_ext_cyclic2--1.0.sql \
+       test_ext_cau--1.0--1.1.sql test_ext_cau--1.0.sql \
+       test_ext_cau--1.1.sql test_ext_cau--unpackaged--1.0.sql
 
-REGRESS = test_extensions test_extdepend
+REGRESS = test_extensions #test_extdepend TODO: enable this test after https://github.com/greenplum-db/gpdb/issues/14532
 
 ifdef USE_PGXS
 PG_CONFIG = pg_config

--- a/src/test/modules/test_extensions/expected/test_extensions.out
+++ b/src/test/modules/test_extensions/expected/test_extensions.out
@@ -148,7 +148,10 @@ SELECT create_extension_with_temp_schema();
 (1 row)
 
 PREPARE TRANSACTION 'twophase_extension';
-ERROR:  cannot PREPARE a transaction that has operated on temporary objects
+ERROR:  PREPARE TRANSACTION is not yet supported in Greenplum Database
+-- rollback transaction, or further commands will fail with message (at gpdb):
+-- "ERROR:  current transaction is aborted, commands ignored until end of transaction block"
+ROLLBACK;
 -- Clean up
 DROP TABLE test_ext4_tab;
 DROP FUNCTION create_extension_with_temp_schema();
@@ -307,3 +310,162 @@ Objects in extension "test_ext_cine"
  table ext_cine_tab3
 (9 rows)
 
+--
+-- Test cases from Issue: https://github.com/greenplum-db/gpdb/issues/6716
+--
+drop extension if exists gp_inject_fault;
+NOTICE:  extension "gp_inject_fault" does not exist, skipping
+create schema issue6716;
+create extension gp_inject_fault with schema issue6716;
+select issue6716.gp_inject_fault('issue6716', 'skip', 1);
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+select issue6716.gp_inject_fault('issue6716', 'reset', 1);
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+drop extension gp_inject_fault;
+--
+-- Another test cases for problem https://github.com/greenplum-db/gpdb/issues/6716.
+-- Segments of gpdb builed with `--enable-cassert` stops with error like
+-- FailedAssertion(""!(stack->state == GUC_SAVE)" at next cases. At gpdb builed
+-- without `--enable-cassert` segments won't stop with errors, but there may be
+-- incorrect search_path.
+--
+--
+-- create extension in the same schema
+--
+begin;
+set search_path=pg_catalog;
+create extension btree_gin;
+show search_path;
+ search_path 
+-------------
+ pg_catalog
+(1 row)
+
+rollback;
+--
+-- create extension in the different schema
+--
+begin;
+set search_path=issue6716;
+show search_path;
+ search_path 
+-------------
+ issue6716
+(1 row)
+
+create extension btree_gin with schema pg_catalog;
+show search_path;
+ search_path 
+-------------
+ issue6716
+(1 row)
+
+end;
+-- check search_path after transaction commit
+show search_path;
+ search_path 
+-------------
+ issue6716
+(1 row)
+
+drop extension btree_gin;
+--
+-- Test case for create extension from unpackaged
+--
+-- Create extension functions at existing schema (issue6716). Code copied from from test_ext_cau--1.0.sql
+create function test_func1(a int, b int) returns int
+as $$
+begin
+	return a + b;
+end;
+$$
+LANGUAGE plpgsql;
+create function test_func2(a int, b int) returns int
+as $$
+begin
+	return a - b;
+end;
+$$
+LANGUAGE plpgsql;
+-- restore search path
+reset search_path;
+begin;
+-- change search_path
+set search_path=pg_catalog;
+show search_path;
+ search_path 
+-------------
+ pg_catalog
+(1 row)
+
+-- create extension in schema issue6716
+create extension test_ext_cau with schema issue6716 version '1.1' from unpackaged;
+-- check that search path doesn't changed after create extension
+show search_path;
+ search_path 
+-------------
+ pg_catalog
+(1 row)
+
+-- show that functions belong to schema issue6716 (check that create extension works correctly)
+set search_path=issue6716;
+\df
+                            List of functions
+  Schema   |    Name    | Result data type | Argument data types  | Type 
+-----------+------------+------------------+----------------------+------
+ issue6716 | test_func1 | integer          | a integer, b integer | func
+ issue6716 | test_func2 | integer          | a integer, b integer | func
+(2 rows)
+
+SELECT e.extname, ne.nspname AS extschema, p.proname, np.nspname AS proschema
+FROM pg_catalog.pg_extension AS e
+    INNER JOIN pg_catalog.pg_depend AS d ON (d.refobjid = e.oid)
+    INNER JOIN pg_catalog.pg_proc AS p ON (p.oid = d.objid)
+    INNER JOIN pg_catalog.pg_namespace AS ne ON (ne.oid = e.extnamespace)
+    INNER JOIN pg_catalog.pg_namespace AS np ON (np.oid = p.pronamespace)
+WHERE d.deptype = 'e' and e.extname = 'test_ext_cau'
+ORDER BY 1, 3;
+   extname    | extschema |  proname   | proschema 
+--------------+-----------+------------+-----------
+ test_ext_cau | issue6716 | test_func2 | issue6716
+(1 row)
+
+end;
+-- check search_path after transaction commit
+show search_path;
+ search_path 
+-------------
+ issue6716
+(1 row)
+
+reset search_path;
+drop function issue6716.test_func1(int,int);
+drop extension test_ext_cau;
+--
+-- check that alter extension (with search_path is set) won't fail (on gpdb builded with --enable-cassert)
+--
+create extension test_ext_cau with version '1.0' schema issue6716;
+begin;
+set search_path=issue6716;
+alter extension test_ext_cau update to '1.1';
+end;
+-- check search_path after transaction commit
+show search_path;
+ search_path 
+-------------
+ issue6716
+(1 row)
+
+reset search_path;
+drop schema issue6716 cascade;
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to function issue6716.test_func1(integer,integer)
+drop cascades to extension test_ext_cau

--- a/src/test/modules/test_extensions/test_ext_cau--1.0--1.1.sql
+++ b/src/test/modules/test_extensions/test_ext_cau--1.0--1.1.sql
@@ -1,0 +1,6 @@
+/* src/test/modules/test_extensions/test_ext_cau--1.0--1.1.sql */
+
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "ALTER EXTENSION test_ext_cau" to load this file. \quit
+
+ALTER EXTENSION test_ext_cau DROP function test_func1(int, int);

--- a/src/test/modules/test_extensions/test_ext_cau--1.0.sql
+++ b/src/test/modules/test_extensions/test_ext_cau--1.0.sql
@@ -1,0 +1,20 @@
+/* src/test/modules/test_extensions/test_ext_cau--1.0.sql */
+
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "CREATE EXTENSION test_ext_cau" to load this file. \quit
+
+create function test_func1(a int, b int) returns int
+as $$
+begin
+	return a + b;
+end;
+$$
+LANGUAGE plpgsql;
+
+create function test_func2(a int, b int) returns int
+as $$
+begin
+	return a - b;
+end;
+$$
+LANGUAGE plpgsql;

--- a/src/test/modules/test_extensions/test_ext_cau--1.1.sql
+++ b/src/test/modules/test_extensions/test_ext_cau--1.1.sql
@@ -1,0 +1,12 @@
+/* src/test/modules/test_extensions/test_ext_cau--1.1.sql */
+
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "CREATE EXTENSION test_ext_cau" to load this file. \quit
+
+create function test_func2(a int, b int) returns int
+as $$
+begin
+	return a - b;
+end;
+$$
+LANGUAGE plpgsql;

--- a/src/test/modules/test_extensions/test_ext_cau--unpackaged--1.0.sql
+++ b/src/test/modules/test_extensions/test_ext_cau--unpackaged--1.0.sql
@@ -1,0 +1,7 @@
+/* src/test/modules/test_extensions/test_ext_cau--unpackaged--1.0.sql */
+
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "CREATE EXTENSION test_ext_cau FROM unpackaged" to load this file. \quit
+
+ALTER EXTENSION test_ext_cau ADD function test_func1(int, int);
+ALTER EXTENSION test_ext_cau ADD function test_func2(int, int);

--- a/src/test/modules/test_extensions/test_ext_cau.control
+++ b/src/test/modules/test_extensions/test_ext_cau.control
@@ -1,0 +1,4 @@
+# test_ext_cau
+comment = 'Test extension using CREATE/ALTER extension (from unpackaged/update)'
+default_version = '1.1'
+relocatable = true

--- a/src/test/regress/expected/create_extension_fail.out
+++ b/src/test/regress/expected/create_extension_fail.out
@@ -59,11 +59,3 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 \c
 drop table t_12713;
 drop role user_12713;
---
--- Another Test from Issue: https://github.com/greenplum-db/gpdb/issues/6716
---
-drop extension if exists gp_inject_fault;
-create schema issue6716;
-create extension gp_inject_fault with schema issue6716;
-drop extension gp_inject_fault;
-drop schema issue6716;

--- a/src/test/regress/sql/create_extension_fail.sql
+++ b/src/test/regress/sql/create_extension_fail.sql
@@ -46,12 +46,3 @@ create table t_12713(a int);
 \c
 drop table t_12713;
 drop role user_12713;
-
---
--- Another Test from Issue: https://github.com/greenplum-db/gpdb/issues/6716
---
-drop extension if exists gp_inject_fault;
-create schema issue6716;
-create extension gp_inject_fault with schema issue6716;
-drop extension gp_inject_fault;
-drop schema issue6716;


### PR DESCRIPTION
## Problem description

The next sql commands don't work correctly:

```sql
create schema foo;
begin;
set search_path=foo;
show search_path;
create extension btree_gin with schema pg_catalog;
show search_path;
end;
```

Running this script at gpdb builded with `--enable-cassert` leads to stopping segment with error:

```sql
postgres=# create schema foo;
CREATE SCHEMA
postgres=# begin;
BEGIN
postgres=# set search_path=foo;
SET
postgres=# show search_path;
 search_path 
-------------
 foo
(1 row)

postgres=# create extension btree_gin with schema pg_catalog;
ERROR:  Unexpected internal error (assert.c:44)  (seg0 127.0.1.1:7002 pid=157584) (assert.c:44)
DETAIL:  FailedAssertion("!(stack->state == GUC_SAVE)", File: "guc.c", Line: 5895)
```

While at gpdb builded without `--enable-cassert` `search_path` after create extension will have an incorrect value:

```sql
postgres=# create schema foo;
CREATE SCHEMA
postgres=# begin;
BEGIN
postgres=# set search_path=foo;
SET
postgres=# show search_path;
 search_path 
-------------
 foo
(1 row)

postgres=# create extension btree_gin with schema pg_catalog;
CREATE EXTENSION
postgres=# show search_path;
 search_path 
-------------
 pg_catalog    #### There must be foo path
(1 row)

postgres=# end;
COMMIT
```

Here is a related [issue](https://github.com/greenplum-db/gpdb/issues/6716). Previous fix doesn't cover all cases (see scripts above).
The base problem is in ditributed work of create/alter extension: `CreateExtension/CreateExtensionInternal` executes on QD only once per `create extension` process, while this function executes on QE twice inside it's state machine (firstly [QD tells QE's that process is started from CreateExtensionInternal](https://github.com/greenplum-db/gpdb/blob/795278996fc6bb3e0ca920c28ccf50424600f2b1/src/backend/commands/extension.c#L1609-L1653) (all prepare work were done) and the scond time [QD informs QE about the of end process from execute_extension_script](https://github.com/greenplum-db/gpdb/blob/795278996fc6bb3e0ca920c28ccf50424600f2b1/src/backend/commands/extension.c#L1001) to cleanup all state variables/GUC's). QD all necessary GUC variables sets and updates `GUCNestlevel` (inside `execute_extension_script`) for further cleanup, while segment doesn't call `execute_extension_script` as a result doesn't updates `GUCNestlevel` (also QE doesn't sets `client_min_messages` `log_min_messages`), but `CreateExtensionInternal` [calls set_serach_path_for_extension on QD/QE](https://github.com/greenplum-db/gpdb/blob/795278996fc6bb3e0ca920c28ccf50424600f2b1/src/backend/commands/extension.c#L1647-L1651) without storing `GUCNestLevel` (for QE it's fatal - [set_serach_path_for_extension modifies GUC](https://github.com/greenplum-db/gpdb/blob/795278996fc6bb3e0ca920c28ccf50424600f2b1/src/backend/commands/extension.c#L823--L842), but doesn't saves metadata for restore (QD already has updated `GUCNestLevel`)) thus `search_path` can't be restored at QE after end of `create extension` process inside transaction (`alter extension set schema` has the same problem.

The patch fixes this problem by saving the state of `GUCNestlevel` at QE variable to enable correct state machine work (of `create/alter extension` process) executed on QE (it allows restoring of GUC's setted at this process). By the way `log_min_messages` and `client_min_messages` GUC's which are set at QD at `create/alter extension` process now sets at the QE.

### Tests
Also test cases was added (and one test case was moved from `src/test/regress/create_extension_fail`) to `src/test/modules/test_extensions`, but seems targets from `src/test/modules` are not run at CI due to [filtered-out `modules` target from installcheck-world target](https://github.com/greenplum-db/gpdb/blob/546d963879a690be6f655cfb5888f7d02ac47943/src/test/Makefile#L46-L50).
I've run tests locally with next commands:
```bash
make -C src/test/modules/test_extensions/ install
REGRESS_OPTS=--init-file=/PATH_TO_GPDB_REPO/src/test/regress/init_file make -C src/test/modules/test_extensions installcheck
```

But I've no idea, how to enable running tests from `src/test/modules/` at CI correctly.
Also next tests from `src/test/modules/` are failed locally at main branch:
- brin
- test_ddl_deparse
- test_extensions/test_extdepend - https://github.com/greenplum-db/gpdb/issues/14532
- test_pg_dump
- test_predtest

## Backport

These changes should be backported to 6X_STABLE branch

## Here are some reminders before you submit the pull request

* [ ] Add tests for the change

* [ ] Document changes

* [ ] Communicate in the mailing list if needed

* [ ] Pass `make installcheck`

* [ ] Review a PR in return to support the community
