### PR TITLE
【5X】Fix crash when group by key is subplan expression in multi-agg plan

### DIFF
--- a/src/backend/cdb/cdbgroup.c
+++ b/src/backend/cdb/cdbgroup.c
@@ -3178,6 +3178,32 @@ void generate_dqa_pruning_tlists(MppGroupContext *ctx,
 	}
 }
 
+/*
+ * Constructing the target list for the preliminary Agg node by
+ * placing targets for the grouping attributes on the grps_tlist
+ * temporary. Make sure ressortgroupref matches the original. Copying the
+ * expression may be overkill, but it is safe.
+ */
+static TargetEntry *
+construct_prelim_tle(TargetEntry *sub_tle, MppGroupContext *ctx)
+{
+	char *resname;
+	TargetEntry *prelim_tle;
+	if (sub_tle->resname)
+		resname = pstrdup(sub_tle->resname);
+	else
+		resname = psprintf("prelim_aggref_%d", sub_tle->ressortgroupref);
+
+	prelim_tle = makeTargetEntry(copyObject(sub_tle->expr),
+								 list_length(ctx->grps_tlist) + 1,
+								 resname,
+								 false);
+	prelim_tle->ressortgroupref = sub_tle->ressortgroupref;
+	prelim_tle->resjunk = false;
+	ctx->grps_tlist = lappend(ctx->grps_tlist, prelim_tle);
+	return prelim_tle;
+}
+
 /* Function: deconstruct_agg_info
  *
  * Top-level deconstruction of the target list and having qual of an
@@ -3202,26 +3228,12 @@ void deconstruct_agg_info(MppGroupContext *ctx)
 	ctx->fin_tlist = NIL;
 	ctx->fin_hqual = NIL;
 	
-	/*
-	 * Begin constructing the target list for the preliminary Agg node
-	 * by placing targets for the grouping attributes on the grps_tlist
-	 * temporary. Make sure ressortgroupref matches the original. Copying
-	 * the expression may be overkill, but it is safe.
-	 */
 	for ( i = 0; i < ctx->numGroupCols; i++ )
 	{
 		TargetEntry *sub_tle, *prelim_tle;
 		
 		sub_tle = get_tle_by_resno(ctx->sub_tlist, ctx->groupColIdx[i]);
-		prelim_tle = makeTargetEntry(copyObject(sub_tle->expr),
-									list_length(ctx->grps_tlist) + 1,
-									(sub_tle->resname == NULL) ?
-											NULL :
-											pstrdup(sub_tle->resname),
-									false);
-		prelim_tle->ressortgroupref = sub_tle->ressortgroupref;
-		prelim_tle->resjunk = false;
-		ctx->grps_tlist = lappend(ctx->grps_tlist, prelim_tle);
+		construct_prelim_tle(sub_tle, ctx);
 	}
 
 	/*
@@ -3521,6 +3533,24 @@ Node* deconstruct_expr_mutator(Node *node, MppGroupContext *ctx)
 										relabeltypeNode->relabelformat);
 		}
 		return (Node*) var;
+	}
+
+	if (IsA(node, Var))
+	{
+		TargetEntry *sub_tle;
+
+		sub_tle = tlist_member_ignore_relabel(node, ctx->sub_tlist);
+		if (sub_tle != NULL)
+		{
+			TargetEntry *prelim_tle;
+			Var *var;
+			prelim_tle = construct_prelim_tle(sub_tle, ctx);
+			var = makeVar(grp_varno, prelim_tle->resno,
+						  exprType((Node *) prelim_tle->expr),
+						  exprTypmod((Node *) prelim_tle->expr),
+						  0);
+			return (Node*) var;
+		}
 	}
 
 	return expression_tree_mutator(node, deconstruct_expr_mutator, (void*)ctx);

--- a/src/test/regress/expected/gp_hashagg.out
+++ b/src/test/regress/expected/gp_hashagg.out
@@ -132,3 +132,117 @@ select nohash_int from hashagg_test2 group by nohash_int;
  9
 (10 rows)
 
+-- Test multi-phase aggregate with an expression as the group key
+create table multiagg_expr_group_tbl (i int, j int) distributed by (i);
+insert into multiagg_expr_group_tbl values(-1, -2), (-1, -1), (0, 1), (1, 2);
+select j >= 0, not j >= 0 from multiagg_expr_group_tbl group by 1;
+ ?column? | ?column? 
+----------+----------
+ f        | t
+ t        | f
+(2 rows)
+
+explain select j >= 0, not j >= 0 from multiagg_expr_group_tbl group by 1;
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=1.15..1.17 rows=2 width=2)
+   ->  HashAggregate  (cost=1.15..1.17 rows=1 width=2)
+         Group By: (multiagg_expr_group_tbl.j >= 0)
+         ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=1.06..1.12 rows=1 width=1)
+               Hash Key: (multiagg_expr_group_tbl.j >= 0)
+               ->  HashAggregate  (cost=1.06..1.08 rows=1 width=1)
+                     Group By: multiagg_expr_group_tbl.j >= 0
+                     ->  Seq Scan on multiagg_expr_group_tbl  (cost=0.00..1.05 rows=2 width=4)
+ Settings:  enable_indexscan=off; enable_seqscan=on; enable_sort=off; gp_hashagg_streambottom=off
+ Optimizer status: legacy query optimizer
+(10 rows)
+
+select j >= 0,
+		case when not j >= 0 then
+			'not greater than 0'
+		end
+		from multiagg_expr_group_tbl group by 1;
+ ?column? |        case        
+----------+--------------------
+ f        | not greater than 0
+ t        | 
+(2 rows)
+
+drop table multiagg_expr_group_tbl;
+create table t1(a int, b int, c int, d int, e int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table t2(a int, b int, c int, d int, e int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into t1 values(1, 1, 1, 1, 1);
+insert into t1 values(2, 2, 2, 2, 2);
+insert into t2 values(1, 1, 1, 1, 1);
+insert into t2 values(2, 2, 2, 2, 2);
+explain SELECT
+	(case
+         when num1 >= 1 then
+          '是'
+         else
+          '否'
+       end) tn1,
+      COUNT(DISTINCT(a)) tn2
+from (
+  select a,
+         (select count(*)
+            from t2
+           where t2.e = t1.a and t2.d = t1.d) num1
+    from t1
+   ) tt
+group by tt.num1;
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice4; segments: 3)  (cost=3.20..4.29 rows=1 width=44)
+   ->  HashAggregate  (cost=3.20..4.29 rows=1 width=44)
+         Group By: ((subplan))
+         ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=2.09..3.19 rows=1 width=20)
+               Hash Key: ((subplan))
+               ->  HashAggregate  (cost=2.09..3.17 rows=1 width=20)
+                     Group By: (subplan), t1.a
+                     ->  Seq Scan on t1  (cost=0.00..2.08 rows=1 width=8)
+                           SubPlan 2
+                             ->  Aggregate  (cost=1.06..1.07 rows=1 width=8)
+                                   ->  Result  (cost=1.02..1.03 rows=1 width=0)
+                                         Filter: public.t2.e = $0 AND public.t2.d = $1
+                                         ->  Materialize  (cost=1.02..1.03 rows=1 width=0)
+                                               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1.01 rows=1 width=0)
+                                                     ->  Seq Scan on t2  (cost=0.00..1.01 rows=1 width=0)
+         SubPlan 1
+           ->  Aggregate  (cost=1.06..1.07 rows=1 width=8)
+                 ->  Result  (cost=1.02..1.03 rows=1 width=0)
+                       Filter: public.t2.e = $0 AND public.t2.d = $1
+                       ->  Materialize  (cost=1.02..1.03 rows=1 width=0)
+                             ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..1.01 rows=1 width=0)
+                                   ->  Seq Scan on t2  (cost=0.00..1.01 rows=1 width=0)
+ Settings:  enable_indexscan=off; enable_seqscan=on; enable_sort=off; gp_hashagg_streambottom=off
+ Optimizer status: legacy query optimizer
+(24 rows)
+
+SELECT
+	(case
+         when num1 >= 1 then
+          '是'
+         else
+          '否'
+       end) tn1,
+      COUNT(DISTINCT(a)) tn2
+from (
+  select a,
+         (select count(*)
+            from t2
+           where t2.e = t1.a and t2.d = t1.d) num1
+    from t1
+   ) tt
+group by tt.num1;
+ tn1 | tn2 
+-----+-----
+ 是  |   2
+(1 row)
+
+drop table t1;
+drop table t2;


### PR DESCRIPTION
when the group by key is an Subplan expression not simple column, planner may crash
in multi-agg plan. Group-by key was used to adding into targetlist in transform phase,
but for subplan expression, there are duplicated subplan when it is in group-by clause and 
some other targetlist, and it's not only the problem of GP but also in PG.
```
   SELECT
         (case
         when num1 >= 1 then
          '是'
         else
          '否'
       end) tn1,
      COUNT(DISTINCT(a)) tn2
 from (
  select a,
         (select count(*)
            from t2
           where t2.a = t1.a and t2.b = t1.b) num1
    from t1
   ) tt
 group by tt.num1;

                                    QUERY PLAN                                    
----------------------------------------------------------------------------------
 GroupAggregate  (cost=83009.16..99596.91 rows=204 width=48)
   Group Key: ((SubPlan 2))
   ->  Sort  (cost=83009.16..83014.26 rows=2040 width=16)
         Sort Key: ((SubPlan 2))
         ->  Seq Scan on t1  (cost=0.00..82879.90 rows=2040 width=16)
               SubPlan 2
                 ->  Aggregate  (cost=40.60..40.61 rows=1 width=8)
                       ->  Seq Scan on t2 t2_1  (cost=0.00..40.60 rows=1 width=0)
                             Filter: ((a = t1.a) AND (b = t1.b))
   SubPlan 1
     ->  Aggregate  (cost=40.60..40.61 rows=1 width=8)
           ->  Seq Scan on t2  (cost=0.00..40.60 rows=1 width=0)
                 Filter: ((a = t1.a) AND (b = t1.b))
(13 rows)
```
As sql above, tt.num1 exists in targetlist and group-by clause as suplan expression, but the final plan
generate two different subplan for tt.num1. The reason is when we pull-up tt subquery, we will replace
tt.num1 and num1 in CASE by CopyObject(subquery) which came from num1 in tt subquery.
After that, we cannot handle two different subplans which could be point to the same one as in multi-agg
plan. And subplan in CASE expression could not refer correct subplan or columns in sub targetist.
we could solve this problem by adding all the colums in subplan to grp_list of multi-agg context, and
final subplan in targetlist could refer theses columns by projecting these columns in multi-agg plan.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
