### PR TITLE
Improve refresh materialized view with "no data" option

### DIFF
--- a/src/test/regress/expected/matview.out
+++ b/src/test/regress/expected/matview.out
@@ -646,3 +646,32 @@ distributed randomly;
 refresh materialized view mat_view_github_issue_11956;
 drop materialized view mat_view_github_issue_11956;
 drop table t_github_issue_11956;
+-- test REFRESH MATERIALIZED VIEW with 'WITH NO DATA' option can be executed immediately.
+DROP TABLE IF EXISTS mvtest_twn;
+CREATE TABLE mvtest_twn(a int);
+CREATE MATERIALIZED VIEW mat_view_twn as SELECT a.a as p, b.a as q, c.a as x, d.a as y FROM mvtest_twn a, mvtest_twn b, mvtest_twn c, mvtest_twn d;
+INSERT INTO mvtest_twn SELECT i FROM generate_series(1,10000)i;
+-- t1 contains 10000 tuples, after cross join it four times, the output is much too huge
+-- refresh with 'no data' should not actually execute the sql
+set statement_timeout = 5000;
+REFRESH MATERIALIZED VIEW mat_view_twn WITH NO DATA;
+reset statement_timeout;
+SELECT relispopulated FROM pg_class WHERE oid = 'mat_view_twn'::regclass;
+ relispopulated 
+----------------
+ f
+(1 row)
+
+SELECT relispopulated FROM gp_dist_random('pg_class') WHERE oid = 'mat_view_twn'::regclass;
+ relispopulated 
+----------------
+ f
+ f
+ f
+(3 rows)
+
+SELECT * FROM mat_view_twn;
+ERROR:  materialized view "mat_view_twn" has not been populated
+HINT:  Use the REFRESH MATERIALIZED VIEW command.
+DROP MATERIALIZED VIEW mat_view_twn;
+DROP TABLE mvtest_twn;

--- a/src/test/regress/expected/matview_optimizer.out
+++ b/src/test/regress/expected/matview_optimizer.out
@@ -656,3 +656,32 @@ distributed randomly;
 refresh materialized view mat_view_github_issue_11956;
 drop materialized view mat_view_github_issue_11956;
 drop table t_github_issue_11956;
+-- test REFRESH MATERIALIZED VIEW with 'WITH NO DATA' option can be executed immediately.
+DROP TABLE IF EXISTS mvtest_twn;
+CREATE TABLE mvtest_twn(a int);
+CREATE MATERIALIZED VIEW mat_view_twn as SELECT a.a as p, b.a as q, c.a as x, d.a as y FROM mvtest_twn a, mvtest_twn b, mvtest_twn c, mvtest_twn d;
+INSERT INTO mvtest_twn SELECT i FROM generate_series(1,10000)i;
+-- t1 contains 10000 tuples, after cross join it four times, the output is much too huge
+-- refresh with 'no data' should not actually execute the sql
+set statement_timeout = 5000;
+REFRESH MATERIALIZED VIEW mat_view_twn WITH NO DATA;
+reset statement_timeout;
+SELECT relispopulated FROM pg_class WHERE oid = 'mat_view_twn'::regclass;
+ relispopulated 
+----------------
+ f
+(1 row)
+
+SELECT relispopulated FROM gp_dist_random('pg_class') WHERE oid = 'mat_view_twn'::regclass;
+ relispopulated 
+----------------
+ f
+ f
+ f
+(3 rows)
+
+SELECT * FROM mat_view_twn;
+ERROR:  materialized view "mat_view_twn" has not been populated
+HINT:  Use the REFRESH MATERIALIZED VIEW command.
+DROP MATERIALIZED VIEW mat_view_twn;
+DROP TABLE mvtest_twn;


### PR DESCRIPTION
In postgres, with option "WITH NO DATA", the materialized view will be truncated without run the query.

In GPDB, the refresh clause is dispatched to segments when execute the query plan. But for WITH NO DATA option, it should be like a TRUNCATE like in postgres, so it doesn't need to take long time to run the query.

By adding an constant-FALSE to the qual to generate a result plan with One-Time Filter. We have hold matview's distribution policy into the query->intoPolicy, planner will create a motion node on the top so that the refresh clause will still dispatch to segments with the query plan and the query can be execute quickly.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
