### PR TITLE
[6X] Improve refresh materialized view with "no data" option

### DIFF
--- a/src/backend/commands/matview.c
+++ b/src/backend/commands/matview.c
@@ -35,6 +35,7 @@
 #include "executor/executor.h"
 #include "executor/spi.h"
 #include "miscadmin.h"
+#include "nodes/makefuncs.h"
 #include "parser/parse_relation.h"
 #include "rewrite/rewriteHandler.h"
 #include "storage/lmgr.h"
@@ -421,6 +422,21 @@ refresh_matview_datafill(DestReceiver *dest, Query *query,
 	if (list_length(rewritten) != 1)
 		elog(ERROR, "unexpected rewrite result for REFRESH MATERIALIZED VIEW");
 	query = (Query *) linitial(rewritten);
+	/*
+	 * In GPDB, the refresh clause is dispatched to segments when execute the query plan.
+	 * But for WITH NO DATA option, it's effectively like a TRUNCATE, so it doesn't need
+	 * to take a long time to run the query.
+	 *
+	 * Add a constant-FALSE to the qual to simulate a plan like this, dispatch the refresh
+	 * clause without run the long query:
+	 * Motion
+	 * 	Result  (cost=0.00..0.01 rows=1 width=0)
+	 * 	  One-Time Filter: false
+	 * Planner create the motion node on the top according to the matview's distribution
+	 * policy in the query->intoPolicy.
+	 */
+	if (refreshClause->skipData)
+		query->jointree->quals = (Node *) makeBoolConst(false, false);
 
 	/* Check for user-requested abort. */
 	CHECK_FOR_INTERRUPTS();

--- a/src/test/regress/expected/matview.out
+++ b/src/test/regress/expected/matview.out
@@ -668,3 +668,32 @@ SELECT * FROM base_view where idn_ban = '10';
 
 DROP MATERIALIZED VIEW base_view;
 DROP TABLE base_table;
+-- test REFRESH MATERIALIZED VIEW with 'WITH NO DATA' option can be executed immediately.
+DROP TABLE IF EXISTS mvtest_twn;
+CREATE TABLE mvtest_twn(a int);
+CREATE MATERIALIZED VIEW mat_view_twn as SELECT a.a as p, b.a as q, c.a as x, d.a as y FROM mvtest_twn a, mvtest_twn b, mvtest_twn c, mvtest_twn d;
+INSERT INTO mvtest_twn SELECT i FROM generate_series(1,10000)i;
+-- t1 contains 10000 tuples, after cross join it four times, the output is much too huge
+-- refresh with 'no data' should not actually execute the sql
+set statement_timeout = 5000;
+REFRESH MATERIALIZED VIEW mat_view_twn WITH NO DATA;
+reset statement_timeout;
+SELECT relispopulated FROM pg_class WHERE oid = 'mat_view_twn'::regclass;
+ relispopulated 
+----------------
+ f
+(1 row)
+
+SELECT relispopulated FROM gp_dist_random('pg_class') WHERE oid = 'mat_view_twn'::regclass;
+ relispopulated 
+----------------
+ f
+ f
+ f
+(3 rows)
+
+SELECT * FROM mat_view_twn;
+ERROR:  materialized view "mat_view_twn" has not been populated
+HINT:  Use the REFRESH MATERIALIZED VIEW command.
+DROP MATERIALIZED VIEW mat_view_twn;
+DROP TABLE mvtest_twn;

--- a/src/test/regress/expected/matview_optimizer.out
+++ b/src/test/regress/expected/matview_optimizer.out
@@ -668,3 +668,32 @@ SELECT * FROM base_view where idn_ban = '10';
 
 DROP MATERIALIZED VIEW base_view;
 DROP TABLE base_table;
+-- test REFRESH MATERIALIZED VIEW with 'WITH NO DATA' option can be executed immediately.
+DROP TABLE IF EXISTS mvtest_twn;
+CREATE TABLE mvtest_twn(a int);
+CREATE MATERIALIZED VIEW mat_view_twn as SELECT a.a as p, b.a as q, c.a as x, d.a as y FROM mvtest_twn a, mvtest_twn b, mvtest_twn c, mvtest_twn d;
+INSERT INTO mvtest_twn SELECT i FROM generate_series(1,10000)i;
+-- t1 contains 10000 tuples, after cross join it four times, the output is much too huge
+-- refresh with 'no data' should not actually execute the sql
+set statement_timeout = 5000;
+REFRESH MATERIALIZED VIEW mat_view_twn WITH NO DATA;
+reset statement_timeout;
+SELECT relispopulated FROM pg_class WHERE oid = 'mat_view_twn'::regclass;
+ relispopulated 
+----------------
+ f
+(1 row)
+
+SELECT relispopulated FROM gp_dist_random('pg_class') WHERE oid = 'mat_view_twn'::regclass;
+ relispopulated 
+----------------
+ f
+ f
+ f
+(3 rows)
+
+SELECT * FROM mat_view_twn;
+ERROR:  materialized view "mat_view_twn" has not been populated
+HINT:  Use the REFRESH MATERIALIZED VIEW command.
+DROP MATERIALIZED VIEW mat_view_twn;
+DROP TABLE mvtest_twn;

--- a/src/test/regress/sql/matview.sql
+++ b/src/test/regress/sql/matview.sql
@@ -265,3 +265,20 @@ SELECT * FROM base_view where idn_ban = '10';
 
 DROP MATERIALIZED VIEW base_view;
 DROP TABLE base_table;
+
+-- test REFRESH MATERIALIZED VIEW with 'WITH NO DATA' option can be executed immediately.
+DROP TABLE IF EXISTS mvtest_twn;
+CREATE TABLE mvtest_twn(a int);
+CREATE MATERIALIZED VIEW mat_view_twn as SELECT a.a as p, b.a as q, c.a as x, d.a as y FROM mvtest_twn a, mvtest_twn b, mvtest_twn c, mvtest_twn d;
+INSERT INTO mvtest_twn SELECT i FROM generate_series(1,10000)i;
+-- t1 contains 10000 tuples, after cross join it four times, the output is much too huge
+-- refresh with 'no data' should not actually execute the sql
+set statement_timeout = 5000;
+REFRESH MATERIALIZED VIEW mat_view_twn WITH NO DATA;
+reset statement_timeout;
+SELECT relispopulated FROM pg_class WHERE oid = 'mat_view_twn'::regclass;
+SELECT relispopulated FROM gp_dist_random('pg_class') WHERE oid = 'mat_view_twn'::regclass;
+SELECT * FROM mat_view_twn;
+
+DROP MATERIALIZED VIEW mat_view_twn;
+DROP TABLE mvtest_twn;


### PR DESCRIPTION
In postgres, with option "WITH NO DATA", the materialized view will be truncated without run the query.

In GPDB, the refresh clause is dispatched to segments when execute the query plan. But for WITH NO DATA option, it should be like a TRUNCATE like in postgres, so it doesn't need to take long time to run the query.

By adding an constant-FALSE to the qual to generate a result plan with One-Time Filter. We have hold matview's distribution policy into the query->intoPolicy, planner will create a motion node on the top so that the refresh clause will still dispatch to segments with the query plan and the query can be execute quickly.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
