### PR TITLE
Ensure that an active outer snapshot exists prior to executing SPI

### DIFF
--- a/src/test/fdw/.gitignore
+++ b/src/test/fdw/.gitignore
@@ -1,0 +1,2 @@
+extended_protocol_commit_test
+results/

--- a/src/test/fdw/extension/extended_protocol_commit_test_fdw.c
+++ b/src/test/fdw/extension/extended_protocol_commit_test_fdw.c
@@ -14,7 +14,7 @@
 #include "optimizer/pathnode.h"
 #include "optimizer/planmain.h"
 #include "optimizer/restrictinfo.h"
-#include "tcop/pquery.h"
+#include "utils/snapmgr.h"
 
 #ifdef PG_MODULE_MAGIC
 PG_MODULE_MAGIC;
@@ -32,10 +32,7 @@ test_execute_spi_expression(const char *query)
 {
 	int			r;
 
-	/* Set up the global portal */
-	Portal saveActivePortal = ActivePortal;
-
-	ActivePortal = CreateNewPortal();
+	PushActiveSnapshot(GetTransactionSnapshot());
 
 	PG_TRY();
 	{
@@ -50,8 +47,7 @@ test_execute_spi_expression(const char *query)
 	{
 		SPI_finish();
 
-		/* Restore the global portal */
-		ActivePortal = saveActivePortal;
+		PopActiveSnapshot();
 
 		PG_RE_THROW();
 	}
@@ -59,8 +55,7 @@ test_execute_spi_expression(const char *query)
 
 	SPI_finish();
 
-	/* Restore the global portal */
-	ActivePortal = saveActivePortal;
+	PopActiveSnapshot();
 }
 
 static void


### PR DESCRIPTION
"795278996fc - Fix the test extension to execute SQL code inside of a Portal" (#14515) "fixed" it but also failed an assertion, this commit fixes it in another way as the pgsql-hackers suggests.

Ref: https://www.mail-archive.com/pgsql-hackers@lists.postgresql.org/msg95584.html

        commit 41c6a5bec25e720d98bd60d77dd5c2939189ed3c
        Author: Tom Lane <tgl@sss.pgh.pa.us>
        Date:   Fri May 21 14:03:53 2021 -0400

            Restore the portal-level snapshot after procedure COMMIT/ROLLBACK.

And quote the release note:

> Some extensions may attempt to execute SQL code outside of any Portal.
> They are responsible for ensuring that an outer snapshot exists before
> doing so. Previously, not providing a snapshot might work or it might
> not; now it will consistently fail with “cannot execute SQL without an
> outer snapshot or portal”.
