### PR TITLE
Ensure that WAL pages skipped by a forced WAL switch are zero-filled. 

### DIFF
--- a/src/bin/pg_basebackup/t/010_pg_basebackup.pl
+++ b/src/bin/pg_basebackup/t/010_pg_basebackup.pl
@@ -2,6 +2,7 @@ use strict;
 use warnings;
 use Cwd;
 use TestLib;
+use File::Path qw(rmtree);
 use Test::More tests => 42;
 
 program_help_ok('pg_basebackup');
@@ -224,7 +225,7 @@ ok(-f "$exclude_tempdir/exclude/keep", 'other files were created');
 # GPDB: Exclude gpbackup default directory
 my $gpbackup_test_dir = "$tempdir/gpbackup_test_dir";
 mkdir "$tempdir/pgdata/backups";
-append_to_file("$tempdir/pgdata/backups/random_backup_file", "some random backup data");
+TestLib::append_to_file("$tempdir/pgdata/backups/random_backup_file", "some random backup data");
 
 command_ok([ 'pg_basebackup', '-D', $gpbackup_test_dir, '--target-gp-dbid', '123' ],
 	'pg_basebackup does not copy over \'backups/\' directory created by gpbackup');


### PR DESCRIPTION
In GPDB 6X, WAL segment files that are force switched (e.g. pg_switch_wal) will mostly zero out the rest of the WAL segment file (with some headers interleaved) while pg_basebackup’s WAL receiver simply just writes the records it receives in a pre-allocated zero’d file and just stops when the replication connection is closed abruptly. This causes the switched files on the primary and mirror to be different(even though they contain the same records).

This was [accidentally fixed in PG11](https://github.com/greenplum-db/gpdb/commit/4a33bb59dfc33566f04e18ab5e1f90b8e7461052) by simply completely zeroing out the end of switched WAL segment files. Original postgres thread that inspired the code change: also https://www.postgresql.org/message-id/flat/579297F8.7020107%40anastigmatix.net

This PR backports the commit and also adds a pg_basebackup test.
```
Ensure that when pg_basebackup is run, the last WAL segment file
containing the XLOG_BACKUP_END and XLOG_SWITCH records match on both
the primary and mirror segment. We want to ensure that all pages after
the XLOG_SWITCH record are all zeroed out. Previously, the primary
segment's WAL segment file would have interleaved page headers instead
of all zeros. Although the WAL segment files from the primary and
mirror segments were logically the same, they were different physically
and would lead to checksum mismatches for external tools that checked
for that.

This test is inspired from the
[patch](https://www.postgresql.org/message-id/attachment/60027/0002-Add-test-for-ensuring-WAL-segment-is-zeroed-out.patch)
which was proposed in the [postgres
discussion](https://www.postgresql.org/message-id/flat/579297F8.7020107%40anastigmatix.net)
From: Chapman Flack <chap@anastigmatix.net> Date: Mon, 26 Mar 2018
23:09:04 -0400

Co-authored-by: Kate Dontsova <edontsova@pivotal.io>
```