### PR TITLE
docs - add content for uuid-ossp module (6x)

### DIFF
--- a/gpdb-doc/markdown/install_guide/install_modules.html.md
+++ b/gpdb-doc/markdown/install_guide/install_modules.html.md
@@ -46,6 +46,7 @@ You can register the following modules in this manner:
 <li class="li"><a class="xref" href="../ref_guide/modules/postgres_fdw.html">postgres_fdw</a></li>
 <li class="li"><a class="xref" href="../ref_guide/modules/postgresql-hll.html">postgresql-hll</a></li>
 <li class="li"><a class="xref" href="../ref_guide/modules/sslinfo.html">sslinfo</a></li>
+<li class="li"><a class="xref" href="../ref_guide/modules/uuid-ossp.html">uuid-ossp</a></li>
 </ul>
 </td>
 </tr>

--- a/gpdb-doc/markdown/ref_guide/modules/intro.html.md
+++ b/gpdb-doc/markdown/ref_guide/modules/intro.html.md
@@ -32,4 +32,5 @@ The following Greenplum Database and PostgreSQL `contrib` modules are installed;
 -   [postgres\_fdw](postgres_fdw.html) - Provides a foreign data wrapper \(FDW\) for accessing data stored in an external PostgreSQL or Greenplum database.
 -   [postgresql-hll](postgresql-hll.html) - Provides HyperLogLog data types for PostgreSQL and Greenplum Database.
 -   [sslinfo](sslinfo.html) - Provides information about the SSL certificate that the current client provided when connecting to Greenplum.
+-   [uuid-ossp](uuid-ossp.html) - Provides functions to generate universally unique identifiers (UUIDs).
 

--- a/gpdb-doc/markdown/ref_guide/modules/uuid-ossp.html.md
+++ b/gpdb-doc/markdown/ref_guide/modules/uuid-ossp.html.md
@@ -1,0 +1,20 @@
+# uuid-ossp
+
+The `uuid-ossp` module provides functions to generate universally unique identifiers (UUIDs) using one of several standard algorithms. The module also includes functions to produce certain special UUID constants.
+
+The Greenplum Database `uuid-ossp` module is equivalent to the PostgreSQL `uuid-ossp` module. There are no Greenplum Database or MPP-specific considerations for the module.
+
+## <a id="topic_reg"></a>Installing and Registering the Module
+
+The `uuid-ossp` module is installed when you install Greenplum Database. Before you can use any of the functions defined in the module, you must register the `uuid-ossp` extension in each database in which you want to use the functions:
+
+```
+CREATE EXTENSION uuid-ossp;
+```
+
+Refer to [Installing Additional Supplied Modules](../../install_guide/install_modules.html) for more information.
+
+## <a id="topic_info"></a>Module Documentation
+
+See the PostgreSQL [uuid-ossp](https://www.postgresql.org/docs/9.4/uuid-ossp.html) documentation for detailed information about this module.
+

--- a/gpdb-doc/markdown/ref_guide/toc.md
+++ b/gpdb-doc/markdown/ref_guide/toc.md
@@ -191,6 +191,7 @@ Doc Index
         - [postgres\_fdw](./modules/postgres_fdw.md)
         - [postgresql-hll](./modules/postgresql-hll.md)
         - [sslinfo](./modules/sslinfo.md)
+        - [uuid-ossp](./modules/uuid-ossp.md)
     - [Character Set Support](./character_sets.md)
     - [Server Configuration Parameters](./config_params/guc_config.md)
         - [Parameter Categories](./config_params/guc_category-list.md)


### PR DESCRIPTION
backport of https://github.com/greenplum-db/gpdb/pull/14495 for 6X_STABLE branch. the only difference is we xref to postgres v9.4 version of the docs.