### PR TITLE
docs - add content for new gp_max_parallel_cursors guc

### DIFF
--- a/gpdb-doc/markdown/admin_guide/parallel_retrieve_cursor.html.md
+++ b/gpdb-doc/markdown/admin_guide/parallel_retrieve_cursor.html.md
@@ -264,7 +264,7 @@ Refer to the [gp_segment_endpoints](../ref_guide/system_catalogs/gp_segment_endp
 
 ## <a id="topic_cfg"></a>Limiting the Number of Concurrently Open Cursors
 
-By default, Greenplum Database allows an unlimited number of parallel retrieve cursors to be active in the cluster. Should you wish to limit the number of open cursors, the Greenplum Database superuser can set the [gp\_max\_parallel\_cursors](../ref_guide/config_params/guc-list.html#gp_max_parallel_cursors) server configuration parameter to the desired maximum.
+By default, Greenplum Database allows an unlimited number of parallel retrieve cursors to be active in the cluster. The Greenplum Database superuser can set the [gp\_max\_parallel\_cursors](../ref_guide/config_params/guc-list.html#gp_max_parallel_cursors) server configuration parameter to limit the number of open cursors.
 
 
 ## <a id="topic_limits"></a>Known Issues and Limitations

--- a/gpdb-doc/markdown/admin_guide/parallel_retrieve_cursor.html.md
+++ b/gpdb-doc/markdown/admin_guide/parallel_retrieve_cursor.html.md
@@ -264,7 +264,7 @@ Refer to the [gp_segment_endpoints](../ref_guide/system_catalogs/gp_segment_endp
 
 ## <a id="topic_cfg"></a>Limiting the Number of Concurrently Open Cursors
 
-By default, Greenplum Database allows an unlimited number of parallel retrieve cursors to be active in the cluster. The Greenplum Database superuser can set the [gp\_max\_parallel\_cursors](../ref_guide/config_params/guc-list.html#gp_max_parallel_cursors) server configuration parameter to limit the number of open cursors.
+By default, Greenplum Database does not limit the number of parallel retrieve cursors that are active in the cluster \(up to the maximum value of 1024\). The Greenplum Database superuser can set the [gp\_max\_parallel\_cursors](../ref_guide/config_params/guc-list.html#gp_max_parallel_cursors) server configuration parameter to limit the number of open cursors.
 
 
 ## <a id="topic_limits"></a>Known Issues and Limitations

--- a/gpdb-doc/markdown/admin_guide/parallel_retrieve_cursor.html.md
+++ b/gpdb-doc/markdown/admin_guide/parallel_retrieve_cursor.html.md
@@ -29,7 +29,6 @@ You can use the following functions and views to examine and manage parallel ret
 
 <div class="note">Each of these functions and views is located in the <code>pg_catalog</code> schema, and each <code>RETURNS TABLE</code>.</div>
 
-
 ## <a id="topic_using"></a>Using a Parallel Retrieve Cursor
 
 You will perform the following tasks when you use a Greenplum Database parallel retrieve cursor to read query results in parallel from Greenplum segments:
@@ -261,6 +260,11 @@ The commands return endpoint and retrieve session information in a table with th
 |cursorname|The name of the parallel retrieve cursor.|
 
 Refer to the [gp_segment_endpoints](../ref_guide/system_catalogs/gp_segment_endpoints.html#topic1) view reference page for more information about the endpoint attributes returned by these commands.
+
+
+## <a id="topic_cfg"></a>Limiting the Number of Concurrently Open Cursors
+
+By default, Greenplum Database allows an unlimited number of parallel retrieve cursors to be active in the cluster. Should you wish to limit the number of open cursors, the Greenplum Database superuser can set the [gp\_max\_parallel\_cursors](../ref_guide/config_params/guc-list.html#gp_max_parallel_cursors) server configuration parameter to the desired maximum.
 
 
 ## <a id="topic_limits"></a>Known Issues and Limitations

--- a/gpdb-doc/markdown/ref_guide/config_params/guc-list.html.md
+++ b/gpdb-doc/markdown/ref_guide/config_params/guc-list.html.md
@@ -1104,7 +1104,7 @@ Sets the tuple-serialization chunk size for the Greenplum Database interconnect.
 
 ## <a id="gp_max_parallel_cursors"></a>gp\_max\_parallel\_cursors
 
-Specifies the maximum number of active parallel retrieve cursors allowed on a Greenplum Database cluster. A parallel retrieve cursor is considered active after it has been `DECLARE`d, but before it is `CLOSE`d.
+Specifies the maximum number of active parallel retrieve cursors allowed on a Greenplum Database cluster. A parallel retrieve cursor is considered active after it has been `DECLARE`d, but before it is `CLOSE`d or returns an error.
 
 The default value is `-1`; there is no limit on the number of open parallel retrieve cursors that may be concurrently active in the cluster \(up to the maximum value of 1024\).
 

--- a/gpdb-doc/markdown/ref_guide/config_params/guc-list.html.md
+++ b/gpdb-doc/markdown/ref_guide/config_params/guc-list.html.md
@@ -1102,6 +1102,18 @@ Sets the tuple-serialization chunk size for the Greenplum Database interconnect.
 |-----------|-------|-------------------|
 |512-65536|8192|master, system, reload|
 
+## <a id="gp_max_parallel_cursors"></a>gp\_max\_parallel\_cursors
+
+Specifies the maximum number of active parallel retrieve cursors allowed on a Greenplum Database cluster. A parallel retrieve cursor is considered active after it has been `DECLARE`d, but before it is `CLOSE`d.
+
+The default value is `-1`, there is no limit on the number of open parallel retrieve cursors that may be concurrently active in the cluster.
+
+You must be a superuser to change the `gp_max_parallel_cursors` setting.
+
+|Value Range|Default|Set Classifications|
+|-----------|-------|-------------------|
+|-1 - 1024 | -1 | master, superuser, session, reload|
+
 ## <a id="gp_max_plan_size"></a>gp\_max\_plan\_size 
 
 Specifies the total maximum uncompressed size of a query execution plan multiplied by the number of Motion operators \(slices\) in the plan. If the size of the query plan exceeds the value, the query is cancelled and an error is returned. A value of 0 means that the size of the plan is not monitored.

--- a/gpdb-doc/markdown/ref_guide/config_params/guc-list.html.md
+++ b/gpdb-doc/markdown/ref_guide/config_params/guc-list.html.md
@@ -1106,7 +1106,7 @@ Sets the tuple-serialization chunk size for the Greenplum Database interconnect.
 
 Specifies the maximum number of active parallel retrieve cursors allowed on a Greenplum Database cluster. A parallel retrieve cursor is considered active after it has been `DECLARE`d, but before it is `CLOSE`d.
 
-The default value is `-1`, there is no limit on the number of open parallel retrieve cursors that may be concurrently active in the cluster.
+The default value is `-1`; there is no limit on the number of open parallel retrieve cursors that may be concurrently active in the cluster \(up to the maximum value of 1024\).
 
 You must be a superuser to change the `gp_max_parallel_cursors` setting.
 

--- a/gpdb-doc/markdown/ref_guide/config_params/guc_category-list.html.md
+++ b/gpdb-doc/markdown/ref_guide/config_params/guc_category-list.html.md
@@ -95,6 +95,10 @@ You can configure the execution cost of `VACUUM` and `ANALYZE` commands to reduc
 - [xid_stop_limit](guc-list.html#xid_stop_limit)
 - [xid_warn_limit](guc-list.html#xid_warn_limit)
 
+### <a id="topic20other"></a>Other Parameters 
+
+- [gp\_max\_parallel\_cursors](guc-list.html#gp_max_parallel_cursors)
+
 ## <a id="topic57"></a>GPORCA Parameters 
 
 These parameters control the usage of GPORCA by Greenplum Database. For information about GPORCA, see [About GPORCA](../../admin_guide/query/topics/query-piv-optimizer.html) in the *Greenplum Database Administrator Guide*.

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -4152,7 +4152,7 @@ struct config_int ConfigureNamesInt_gp[] =
 
 	{
 		{"gp_max_parallel_cursors", PGC_SUSET, RESOURCES,
-			gettext_noop("Parallel cursor concurrency control from the local cluster side, -1 means no limit, which is the default"),
+			gettext_noop("Parallel cursor concurrency control, -1 means no limit, which is the default"),
 			NULL, GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&gp_max_parallel_cursors,

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -4152,7 +4152,7 @@ struct config_int ConfigureNamesInt_gp[] =
 
 	{
 		{"gp_max_parallel_cursors", PGC_SUSET, RESOURCES,
-			gettext_noop("Parallel cursor concurrency control from the source cluster side, -1 means no limit, which is the default"),
+			gettext_noop("Parallel cursor concurrency control from the local cluster side, -1 means no limit, which is the default"),
 			NULL, GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&gp_max_parallel_cursors,


### PR DESCRIPTION
docs for https://github.com/greenplum-db/gpdb/pull/14051.

not sure if i got the set classifications correct.

(will backport to 6X_STABLE in a separate PR, as the parallel retrieve cursor functionality is a module in 6X.)
