### PR TITLE
RESET newly added GUC to pass binary swap tests

### DIFF
--- a/src/test/isolation2/input/parallel_retrieve_cursor/concurrency.source
+++ b/src/test/isolation2/input/parallel_retrieve_cursor/concurrency.source
@@ -32,5 +32,5 @@ COMMIT;
 1: DECLARE c3 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
 1: COMMIT;
 
-ALTER SYSTEM SET gp_max_parallel_cursors TO -1;
+ALTER SYSTEM RESET gp_max_parallel_cursors;
 SELECT pg_reload_conf();

--- a/src/test/isolation2/output/parallel_retrieve_cursor/concurrency.source
+++ b/src/test/isolation2/output/parallel_retrieve_cursor/concurrency.source
@@ -60,7 +60,7 @@ DECLARE
 1: COMMIT;
 COMMIT
 
-ALTER SYSTEM SET gp_max_parallel_cursors TO -1;
+ALTER SYSTEM RESET gp_max_parallel_cursors;
 ALTER
 SELECT pg_reload_conf();
  pg_reload_conf 


### PR DESCRIPTION
Temporary dev pipeline is green: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb-dev-reset_guc_6x