### PR TITLE
fix wrong results caused by over-eager constraint exclusion

### DIFF
--- a/src/backend/optimizer/util/clauses.c
+++ b/src/backend/optimizer/util/clauses.c
@@ -5659,49 +5659,6 @@ flatten_join_alias_var_optimizer(Query *query, int queryLevel)
 }
 
 /**
- * Returns true if the equality operator with the given opno
- *   values is a true equality operator (unlike some of the
- *   box/rectangle/etc. types which implement 'goofy' operators).
- *
- * This function currently only knows about built-in types, and is
- *   conservative with regard to which it returns true for (only
- *     ones which have been verified to work the right way).
- */
-bool is_builtin_true_equality_between_same_type(int opno)
-{
-	switch (opno)
-	{
-	case BitEqualOperator:
-	case BooleanEqualOperator:
-	case BPCharEqualOperator:
-	case CashEqualOperator:
-	case CharEqualOperator:
-	case CidEqualOperator:
-	case DateEqualOperator:
-	case Float4EqualOperator:
-	case Float8EqualOperator:
-	case Int2EqualOperator:
-	case Int4EqualOperator:
-	case Int8EqualOperator:
-	case IntervalEqualOperator:
-	case NameEqualOperator:
-	case NumericEqualOperator:
-	case OidEqualOperator:
-	case TextEqualOperator:
-	case TIDEqualOperator:
-	case TimeEqualOperator:
-	case TimestampEqualOperator:
-	case TimestampTZEqualOperator:
-	case TimeTZEqualOperator:
-	case XidEqualOperator:
-		return true;
-
-	default:
-		return false;
-	}
-}
-
-/**
  * Structs and Methods to support searching of matching subexpressions.
  */
 

--- a/src/include/optimizer/clauses.h
+++ b/src/include/optimizer/clauses.h
@@ -73,8 +73,6 @@ extern Query *inline_set_returning_function(PlannerInfo *root,
 extern Expr *evaluate_expr(Expr *expr, Oid result_type, int32 result_typmod,
 			  Oid result_collation);
 
-extern bool is_builtin_true_equality_between_same_type(int opno);
-
 extern bool subexpression_match(Expr *expr1, Expr *expr2);
 
 // resolve the join alias varno/varattno information to its base varno/varattno information

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -11529,7 +11529,8 @@ INSERT INTO tc0 VALUES (NULL);
 SELECT * from tc0 where a IS NULL;
  a 
 ---
-(0 rows)
+  
+(1 row)
 
 CREATE TABLE tc1 (a int check (a between 1 and 2 or a != 3 and a > 5));
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.


### PR DESCRIPTION
When checking relation exclusion by constraints, GPDB performs further
checks that if the predicate is of format expr=constant, try to evaluate
the clause by replacing every occurrence of expr with the constant. But,
this does not work for all cases.

the related issues are as follows:
https://github.com/greenplum-db/gpdb/issues/8582
https://github.com/greenplum-db/gpdb/issues/10287

remove simple_equality_predicate_refuted to fix wrong results caused by
over-eager constraint exclusion.