### PR TITLE
Fix cache lookup failed for type 0

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
@@ -186,7 +186,7 @@ CTranslatorRelcacheToDXL::RetrieveObjectGPDB(CMemoryPool *mp, IMDId *mdid,
 
 	OID oid = CMDIdGPDB::CastMdid(mdid)->Oid();
 
-	GPOS_ASSERT(0 != oid);
+	GPOS_RTL_ASSERT(0 != oid);
 
 	switch (mdtype)
 	{


### PR DESCRIPTION
Before commit a734055, Orca falls back to planner with the error `Lookup of object 0.0.0.0 in cache failed` (only when assert is disabled) or `CTranslatorDXLToExpr.cpp:498: Failed assertion:
pdxlcoldesc->MdidType()->IsValid()` (when assert is enabled), which is actually a bug that we should fix. Commit a734055 assumes that when fetching the metadata the midid is always valid, causing Orca errors out (type with OID 0 does not exist) when it hits the bug. This patch doesn't try to fix the bug (we can do it in future), but reinstates the validity check of Oid.

We can't enable trace fallback flag, because fallback messages are different with assert disabled/enabled.

