### PR TITLE
[6X] Fixing gpcheckperf error when ran with -f and -V option

### DIFF
--- a/gpMgmt/bin/gpcheckperf
+++ b/gpMgmt/bin/gpcheckperf
@@ -782,7 +782,7 @@ def runNetPerfTestMatrix():
     '''
     (netperf, hostlist, netserver_port) = setupNetPerfTest()
     if not netperf:
-        return None
+        return None, None
 
     # dict() of seglist[segname] = hostname, uniqhosts[hostname] = 1 segment name
     seglist, uniqhosts = get_host_map(hostlist)

--- a/gpMgmt/bin/gpcheckperf
+++ b/gpMgmt/bin/gpcheckperf
@@ -80,9 +80,9 @@ def strcmd(cmd):
     return reduce(lambda x, y: x + ' ' + y, map(lambda x: x.find(' ') > 0 and "'" + x + "'" or x, cmd))
 
 
-def gpssh(cmd):
+def gpssh(cmd, verbose):
     c = ['%s/bin/gpssh' % GPHOME]
-    if GV.opt['-V']:
+    if verbose:
         c.append('-v')
     if GV.opt['-f']:
         c.append('-f')
@@ -95,7 +95,8 @@ def gpssh(cmd):
 
     if GV.opt['-v']:
         print '[Info]', strcmd(c)
-    p = subprocess.Popen(c, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    # Setting universal_newlines flag so as to get output in string format and not in byte format
+    p = subprocess.Popen(c, universal_newlines=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     out = p.stdout.read(-1)
     rc = p.wait()
     return not rc, out
@@ -318,13 +319,13 @@ def runTeardown():
     for d in GV.opt['-d']:
         dirs = '%s %s/gpcheckperf_$USER' % (dirs, d)
     try:
-        gpssh('rm -rf ' + dirs)
+        gpssh('rm -rf ' + dirs, GV.opt['-V'])
     except:
         pass
 
     try:
         if GV.opt['--net']:
-            gpssh(killall(GV.opt['--netserver']))
+            gpssh(killall(GV.opt['--netserver']), GV.opt['-V'])
     except:
         pass
 
@@ -341,7 +342,7 @@ def runSetup():
         # check python reachable
         if GV.opt['-v']:
             print '[Info] verify python interpreter exists'
-        (ok, out) = gpssh('python -c print')
+        (ok, out) = gpssh('python -c print', GV.opt['-V'])
         if not ok:
             if not GV.opt['-v']:
                 print out
@@ -356,7 +357,7 @@ def runSetup():
             dirs = '%s %s/gpcheckperf_$USER' % (dirs, d)
 
         cmd = 'rm -rf %s ; mkdir -p %s' % (dirs, dirs)
-        (ok, out) = gpssh(cmd)
+        (ok, out) = gpssh(cmd, GV.opt['-V'])
         if not ok:
             print 'failed gpssh: %s' % out
             sys.exit("[Error] unable to make gpcheckperf directory. \n"
@@ -394,7 +395,7 @@ def copyExecOver(fname):
         sys.exit('[Error] command failed: gpscp %s =:%s with output: %s' % (path, target, out))
 
     # chmod +x file
-    (ok, out) = gpssh('chmod a+rx %s' % target)
+    (ok, out) = gpssh('chmod a+rx %s' % target, GV.opt['-V'])
     if not ok:
         sys.exit('[Error] command failed: chmod a+rx %s with output: %s' % (target, out))
 
@@ -444,7 +445,7 @@ def runDiskWriteTest(multidd):
         cmd = cmd + (' -B %d' % GV.opt['-B'])
     if GV.opt['-S']:
         cmd = cmd + (' -S %d' % GV.opt['-S'])
-    (ok, out) = gpssh(cmd)
+    (ok, out) = gpssh(cmd, GV.opt['-V'])
     if not ok:
         sys.exit('[Error] command failed: %s with output: %s' % (cmd, out))
     return parseMultiDDResult(out)
@@ -463,7 +464,7 @@ def runDiskReadTest(multidd):
         cmd = cmd + (' -B %d' % GV.opt['-B'])
     if GV.opt['-S']:
         cmd = cmd + (' -S %d' % GV.opt['-S'])
-    (ok, out) = gpssh(cmd)
+    (ok, out) = gpssh(cmd, GV.opt['-V'])
     if not ok:
         sys.exit('[Error] command failed: %s with output: %s' % (cmd, out))
     return parseMultiDDResult(out)
@@ -476,7 +477,7 @@ def runStreamTest():
     print '--------------------'
 
     cmd = copyExecOver('stream')
-    (ok, out) = gpssh(cmd)
+    (ok, out) = gpssh(cmd, GV.opt['-V'])
     if not ok:
         sys.exit('[Error] command failed: %s with output: %s' % (cmd, out))
     out = StringIO.StringIO(out)
@@ -498,9 +499,9 @@ def startNetServer():
     for i in xrange(5):
         if i > 0:
             print '[Warning] retrying with port %d' % port
-        (ok, out) = gpssh(killall(GV.opt['--netserver']))
+        (ok, out) = gpssh(killall(GV.opt['--netserver']), GV.opt['-V'])
 
-        (ok, out) = gpssh('%s -p %d > /dev/null 2>&1' % (rmtPath, port))
+        (ok, out) = gpssh('%s -p %d > /dev/null 2>&1' % (rmtPath, port), GV.opt['-V'])
         if ok:
             return port
 
@@ -726,13 +727,21 @@ def get_host_map(hostlist):
         uniqhosts =
             uniqhosts['apollo1'] = 'sdw1-1'
             uniqhosts['apollo2'] = 'sdw2-1'
-
     '''
     seglist = dict()  # segment list
     uniqhosts = dict()  # unique host list
 
-    # get list of hostnames
-    rc, out = gpssh('hostname')
+    '''
+     Get hostnames using non-verbose mode since verbose output makes parsing difficult with extra lines as show:
+        [WARN] Reference default values as $MASTER_DATA_DIRECTORY/gpssh.conf could not be found
+        Using delaybeforesend 0.05 and prompt_validation_timeout 1.0
+        [Reset ...]
+        [INFO] login sdw2
+        [sdw2] sdw2
+        [INFO] completed successfully
+        [Cleanup...]
+    '''
+    rc, out = gpssh('hostname', False)
     if not rc:
         raise Exception('Encountered error running hostname')
 

--- a/gpMgmt/test/behave/mgmt_utils/gpcheckperf.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpcheckperf.feature
@@ -15,3 +15,56 @@ Feature: Tests for gpcheckperf
     Then  gpcheckperf should return a return code of 0
     And   gpcheckperf should print "avg = " to stdout
     And   gpcheckperf should not print "NOTICE: -t is deprecated " to stdout
+
+   @concourse_cluster
+   Scenario: gpcheckperf runs tests by passing hostfile in extra verbose mode
+     Given the database is running
+     And create a gpcheckperf input host file
+     When  the user runs "gpcheckperf -f /tmp/hostfile1 -r M -d /data/gpdata/ --duration=3m -V"
+     Then  gpcheckperf should return a return code of 0
+     And   gpcheckperf should print "Full matrix netperf bandwidth test" to stdout
+     And   gpcheckperf should not print "IndexError: list index out of range" to stdout
+     And   gpcheckperf should print "--  NETPERF TEST" to stdout
+     And   gpcheckperf should print "TEARDOWN" to stdout
+
+  @concourse_cluster
+   Scenario: gpcheckperf runs tests by passing hostfile in verbose mode
+     Given the database is running
+     And create a gpcheckperf input host file
+     When  the user runs "gpcheckperf -f /tmp/hostfile1 -r M -d /data/gpdata/ --duration=3m -v"
+     Then  gpcheckperf should return a return code of 0
+     And   gpcheckperf should print "Full matrix netperf bandwidth test" to stdout
+     And   gpcheckperf should not print "IndexError: list index out of range" to stdout
+     And   gpcheckperf should print "--  NETPERF TEST" to stdout
+     And   gpcheckperf should print "making gpcheckperf directory on all hosts ..." to stdout
+     And   gpcheckperf should print "TEARDOWN" to stdout
+
+  @concourse_cluster
+   Scenario: gpcheckperf runs tests by passing hostfile in regular mode
+     Given the database is running
+     And create a gpcheckperf input host file
+     When  the user runs "gpcheckperf -f /tmp/hostfile1 -r M -d /data/gpdata/ --duration=3m"
+     Then  gpcheckperf should return a return code of 0
+     And   gpcheckperf should print "Full matrix netperf bandwidth test" to stdout
+     And   gpcheckperf should not print "IndexError: list index out of range" to stdout
+
+  @concourse_cluster
+   Scenario: gpcheckperf runs network test by passing hostfile in regular mode
+     Given the database is running
+     And create a gpcheckperf input host file
+     When  the user runs "gpcheckperf -f /tmp/hostfile1 -r N -d /data/gpdata/ --duration=3m"
+     Then  gpcheckperf should return a return code of 0
+     And   gpcheckperf should print "--  NETPERF TEST" to stdout
+     And   gpcheckperf should print "Netperf bisection bandwidth test" to stdout
+
+  @concourse_cluster
+   Scenario: gpcheckperf runs network test by passing hostfile in verbose mode
+     Given the database is running
+     And create a gpcheckperf input host file
+     When  the user runs "gpcheckperf -f /tmp/hostfile1 -r N -d /data/gpdata/ --duration=3m -v"
+     Then  gpcheckperf should return a return code of 0
+     And   gpcheckperf should print "--  NETPERF TEST" to stdout
+     And   gpcheckperf should print "Netperf bisection bandwidth test" to stdout
+     And   gpcheckperf should print "making gpcheckperf directory on all hosts ..." to stdout
+     And   gpcheckperf should print "TEARDOWN" to stdout
+

--- a/gpMgmt/test/behave/mgmt_utils/gpcheckperf.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpcheckperf.feature
@@ -68,3 +68,25 @@ Feature: Tests for gpcheckperf
      And   gpcheckperf should print "making gpcheckperf directory on all hosts ..." to stdout
      And   gpcheckperf should print "TEARDOWN" to stdout
 
+  @concourse_cluster
+   Scenario: gpcheckperf runs matrix test by passing single host should not throw exception
+     Given the database is running
+     And create a gpcheckperf input host file
+     When  the user runs "gpcheckperf -h cdw -r M -d /data/gpdata/ --duration=3m -v"
+     Then  gpcheckperf should return a return code of 0
+     And   gpcheckperf should print "--  NETPERF TEST" to stdout
+     And   gpcheckperf should print "single host only - abandon netperf test" to stdout
+     And   gpcheckperf should print "TEARDOWN" to stdout
+     And   gpcheckperf should not print "TypeError:" to stdout
+
+  @concourse_cluster
+   Scenario: gpcheckperf runs network test by passing single host should not throw exception
+     Given the database is running
+     And create a gpcheckperf input host file
+     When  the user runs "gpcheckperf -h cdw -r N -d /data/gpdata/ --duration=3m -v"
+     Then  gpcheckperf should return a return code of 0
+     And   gpcheckperf should print "--  NETPERF TEST" to stdout
+     And   gpcheckperf should print "single host only - abandon netperf test" to stdout
+     And   gpcheckperf should print "TEARDOWN" to stdout
+     And   gpcheckperf should not print "TypeError:" to stdout
+

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -3968,3 +3968,7 @@ def impl(context):
     cmd =  "sudo mv -f /tmp/hosts_orig /etc/hosts; rm -f /tmp/clusterConfigFile-1; rm -f /tmp/hostfile--1"
     context.execute_steps(u'''Then the user runs command "%s"''' % cmd)
 
+@given('create a gpcheckperf input host file')
+def impl(context):
+     cmd = Command(name='create input host file', cmdStr='echo sdw1 > /tmp/hostfile1;echo cdw >> /tmp/hostfile1;')
+     cmd.run(validateAfter=True)


### PR DESCRIPTION
`gpcheckperf` utility can be run in verbose mode in 2 ways : `"-v" `and `"-V"` which is **verbose mode** and **very verbose mode** respectively. 
When `gpcheckperf` ran in very verbose mode `(-V)` option, it runs `gpssh` command with `-v` option which results in the extra lines of output (see example bellow for more details). Those extra lines were leading to run-time exception. 
`gpssh` command when ran in regular mode output is as follows:
```
$ gpssh -h sdw2 hostname
[sdw2] sdw2
```
When ran gpssh in verbose mode, output is as follows: 
```
gpssh -v -h sdw2 hostname
[WARN] Reference default values as $MASTER_DATA_DIRECTORY/gpssh.conf could not be found
Using delaybeforesend 0.05 and prompt_validation_timeout 1.0

[Reset ...]
[INFO] login sdw2
[sdw2] sdw2
[INFO] completed successfully

[Cleanup...]
```

With this PR, made changes to make sure we are not running hostname command in verbose mode. 
Also fixed some errors when passing single host to command and test for the same.
Added tests for the same and minor logging improvements. 
Ran the pipeline and made sure its green.
This is cherry-pick of: https://github.com/greenplum-db/gpdb/pull/14310

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
