### PR TITLE
[WIP] fix bug: cannot execute squelched plan node of type: 211 in 6X 

### DIFF
--- a/src/backend/executor/execAmi.c
+++ b/src/backend/executor/execAmi.c
@@ -601,15 +601,15 @@ ExecSupportsBackwardScan(Plan *node)
 void
 ExecSquelchNode(PlanState *node)
 {
-	// If the whole plan does not have any motions, then we do not execute squelch at all.
-	if (((PlanState *) node)->plan->nMotionNodes < 1)
-		return;
-
 	ListCell   *lc;
 
 	if (!node)
 		return;
 
+	// If the whole plan does not have any motions, then we do not execute squelch at all.
+	if (!(node->state->es_sliceTable) || (node->state->es_sliceTable && node->state->es_sliceTable->nMotions < 1))
+		return;
+	
 	if (node->squelched)
 		return;
 

--- a/src/backend/executor/execAmi.c
+++ b/src/backend/executor/execAmi.c
@@ -601,6 +601,10 @@ ExecSupportsBackwardScan(Plan *node)
 void
 ExecSquelchNode(PlanState *node)
 {
+	// If the whole plan does not have any motions, then we do not execute squelch at all.
+	if (((PlanState *) node)->plan->nMotionNodes < 1)
+		return;
+
 	ListCell   *lc;
 
 	if (!node)

--- a/src/backend/executor/nodeHashjoin.c
+++ b/src/backend/executor/nodeHashjoin.c
@@ -519,7 +519,7 @@ ExecHashJoin(HashJoinState *node)
 
 	result = ExecHashJoin_guts(node);
 
-	if (((PlanState *) node)->plan->nMotionNodes >0 && TupIsNull(result) && !node->reuse_hashtable)
+	if (TupIsNull(result) && !node->reuse_hashtable)
 	{
 		/*
 		 * CDB: We'll read no more from inner subtree. To keep our

--- a/src/backend/executor/nodeHashjoin.c
+++ b/src/backend/executor/nodeHashjoin.c
@@ -519,7 +519,7 @@ ExecHashJoin(HashJoinState *node)
 
 	result = ExecHashJoin_guts(node);
 
-	if (TupIsNull(result) && !node->reuse_hashtable)
+	if (((PlanState *) node)->plan->nMotionNodes >0 && TupIsNull(result) && !node->reuse_hashtable)
 	{
 		/*
 		 * CDB: We'll read no more from inner subtree. To keep our

--- a/src/test/regress/expected/namespace_gp.out
+++ b/src/test/regress/expected/namespace_gp.out
@@ -96,8 +96,100 @@ WHERE nspname ~ 'test_schema_[12]';
 
 SELECT rolname
 FROM pg_authid a
-WHERE rolname ~ 'tmp_test_schema_role'
+WHERE rolname ~ 'tmp_test_schema_role';
  rolname 
 ---------
 (0 rows)
+
+SET from_collapse_limit = 1;
+SET join_collapse_limit = 1;
+EXPLAIN ANALYSE SELECT nspname, nspacl, privilege_type, rolname FROM pg_namespace
+JOIN lateral  
+(SELECT * FROM aclexplode(nspacl) x 
+JOIN pg_authid  ON x.grantee = pg_authid.oid) 
+z ON true;
+QUERY PLAN
+___________
+{
+  'child' => [
+    {
+      'id' => 2,
+      'parent' => 1,
+      'short' => 'Seq Scan on pg_namespace'
+    },
+    {
+      'child' => [
+        {
+          'id' => 4,
+          'parent' => 3,
+          'short' => 'Function Scan on aclexplode x'
+        },
+        {
+          'child' => [
+            {
+              'id' => 6,
+              'parent' => 5,
+              'short' => 'Seq Scan on pg_authid'
+            }
+          ],
+          'id' => 5,
+          'parent' => 3,
+          'short' => 'Hash'
+        }
+      ],
+      'id' => 3,
+      'parent' => 1,
+      'short' => 'Hash Join'
+    }
+  ],
+  'id' => 1,
+  'short' => 'Nested Loop'
+}
+GP_IGNORE:(14 rows)
+
+SET from_collapse_limit = 8;
+SET join_collapse_limit = 8;
+EXPLAIN ANALYSE SELECT nspname, nspacl, privilege_type, rolname FROM pg_namespace
+JOIN lateral  
+(SELECT * FROM aclexplode(nspacl) x 
+JOIN pg_authid  ON x.grantee = pg_authid.oid) 
+z ON true;
+QUERY PLAN
+___________
+{
+  'child' => [
+    {
+      'child' => [
+        {
+          'id' => 3,
+          'parent' => 2,
+          'short' => 'Seq Scan on pg_namespace'
+        },
+        {
+          'id' => 4,
+          'parent' => 2,
+          'short' => 'Function Scan on aclexplode x'
+        }
+      ],
+      'id' => 2,
+      'parent' => 1,
+      'short' => 'Nested Loop'
+    },
+    {
+      'child' => [
+        {
+          'id' => 6,
+          'parent' => 5,
+          'short' => 'Seq Scan on pg_authid'
+        }
+      ],
+      'id' => 5,
+      'parent' => 1,
+      'short' => 'Hash'
+    }
+  ],
+  'id' => 1,
+  'short' => 'Hash Join'
+}
+GP_IGNORE:(14 rows)
 

--- a/src/test/regress/sql/namespace_gp.sql
+++ b/src/test/regress/sql/namespace_gp.sql
@@ -67,4 +67,20 @@ WHERE nspname ~ 'test_schema_[12]';
 
 SELECT rolname
 FROM pg_authid a
-WHERE rolname ~ 'tmp_test_schema_role'
+WHERE rolname ~ 'tmp_test_schema_role';
+
+SET from_collapse_limit = 1;
+SET join_collapse_limit = 1;
+EXPLAIN ANALYSE SELECT nspname, nspacl, privilege_type, rolname FROM pg_namespace
+JOIN lateral  
+(SELECT * FROM aclexplode(nspacl) x 
+JOIN pg_authid  ON x.grantee = pg_authid.oid) 
+z ON true;
+
+SET from_collapse_limit = 8;
+SET join_collapse_limit = 8;
+EXPLAIN ANALYSE SELECT nspname, nspacl, privilege_type, rolname FROM pg_namespace
+JOIN lateral  
+(SELECT * FROM aclexplode(nspacl) x 
+JOIN pg_authid  ON x.grantee = pg_authid.oid) 
+z ON true;


### PR DESCRIPTION
Related issue: [issue 11673](https://github.com/greenplum-db/gpdb/issues/11673)
backport from:  [PR 14565](https://github.com/greenplum-db/gpdb/pull/14565)


#### Bug report:

```SQL
gpadmin=# set from_collapse_limit = 1; set join_collapse_limit = 1;
SET
SET
gpadmin=# explain select * from pg_namespace  join lateral  (select * from aclexplode(nspacl) x join pg_authid  on x.grantee = pg_authid.oid) z on true;
                                  QUERY PLAN
-------------------------------------------------------------------------------
 Nested Loop  (cost=10000000001.20..10000000005.06 rows=81 width=288)
   ->  Seq Scan on pg_namespace  (cost=0.00..1.09 rows=9 width=117)
   ->  Hash Join  (cost=1.21..1.42 rows=9 width=171)
         Hash Cond: (x.grantee = pg_authid.oid)
         ->  Function Scan on aclexplode x  (cost=0.00..0.10 rows=10 width=41)
         ->  Hash  (cost=1.09..1.09 rows=9 width=130)
               ->  Seq Scan on pg_authid  (cost=0.00..1.09 rows=9 width=130)
 Optimizer: Postgres query optimizer
(8 rows)
 
gpadmin=# select * from pg_namespace  join lateral  (select * from aclexplode(nspacl) x join pg_authid  on x.grantee = pg_authid.oid) z on true;
ERROR:  cannot execute squelched plan node of type: 211 (execProcnode.c:948)
```

In thie SQL plan, we only select metadata from QD. In other words, there is no Motion in this plan.
As we know, squelching is maily applied to avoid deadlock with Motion nodes.
But we squelch the node even though there is no connection with any QEs. This is the cause of the bug.


#### Solutions:
We add a judgement condition 'node->state->es_sliceTable->nMotions < 1' in 'ExecSquelchNode(PlanState *node)'.


#### Extended discussion:
If there are motions in our plan, materialize operation will help us avoid the squeching action, so the above bug will be dodged.
Please refer to the result below:


``` SQL
gpadmin=# set from_collapse_limit = 1; set join_collapse_limit = 1;
SET
SET
gpadmin=#  EXPLAIN SELECT *
FROM t_wishlist AS w,
 LATERAL (SELECT *
 FROM t_product AS p join t1
 ON p.product_id = t1.c1
 WHERE p.price < w.desired_price
 ) AS x;
                                                     QUERY PLAN
--------------------------------------------------------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000015.17..10033059132.46 rows=1072140000 width=95)
   ->  Nested Loop  (cost=10000000015.17..10018763932.46 rows=357380000 width=95)
         Join Filter: (p.price < (w.desired_price)::double precision)
         ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..590.67 rows=33400 width=68)
               ->  Seq Scan on t_wishlist w  (cost=0.00..145.33 rows=11133 width=68)
         ->  Materialize  (cost=15.17..972.04 rows=32100 width=27)  -- Please pay more attention here!!!!!!
               ->  Hash Join  (cost=15.17..811.54 rows=32100 width=27)
                     Hash Cond: (t1.c1 = p.product_id)
                     ->  Seq Scan on t1  (cost=0.00..355.00 rows=32100 width=4)
                     ->  Hash  (cost=11.00..11.00 rows=333 width=23)
                           ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..11.00 rows=333 width=23)
                                 Hash Key: p.product_id
                                 ->  Seq Scan on t_product p  (cost=0.00..4.33 rows=333 width=23)
 Optimizer: Postgres query optimizer
(14 rows)

gpadmin=# SELECT *
FROM t_wishlist AS w,
 LATERAL (SELECT *
 FROM t_product AS p join t1
 ON p.product_id = t1.c1
 WHERE p.price < w.desired_price
 ) AS x;
 wishlist_id | username | desired_price | product_id |       price        |  product  | c1
-------------+----------+---------------+------------+--------------------+-----------+----
           2 | joe      |            60 |          2 | 11.080079474208375 | product 2 |  2
           2 | joe      |            60 |          3 | 22.332092171344655 | product 3 |  3
```

**Signed-off-by**: 
Yongtao Huang <yongtaoh@vmware.com> 
and Zhenghua Lyu <zlyu@vmware.com>