### PR TITLE
docs - CUBE supports 12 elements max (6x)

### DIFF
--- a/gpdb-doc/markdown/best_practices/tuning_queries.html.md
+++ b/gpdb-doc/markdown/best_practices/tuning_queries.html.md
@@ -121,6 +121,8 @@ A `ROLLUP` grouping creates aggregate subtotals that roll up from the most detai
 
 A `CUBE` grouping creates subtotals for all of the possible combinations of the given list of grouping columns \(or expressions\). In multidimensional analysis terms, `CUBE` generates all the subtotals that could be calculated for a data cube with the specified dimensions.
 
+**Note:**  Greenplum Database supports specifying a maximum of 12 `CUBE` grouping columns.
+
 You can selectively specify the set of groups that you want to create using a `GROUPING SETS` expression. This allows precise specification across multiple dimensions without computing a whole `ROLLUP` or `CUBE`.
 
 Refer to the *Greenplum Database Reference Guide* for details of these clauses.

--- a/gpdb-doc/markdown/ref_guide/sql_commands/SELECT.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/SELECT.html.md
@@ -312,6 +312,8 @@ CUBE
 
 Notice that n elements of a `CUBE` translate to 2n grouping sets. Consider using `CUBE` in any situation requiring cross-tabular reports. `CUBE` is typically most suitable in queries that use columns from multiple dimensions rather than columns representing different levels of a single dimension. For instance, a commonly requested cross-tabulation might need subtotals for all the combinations of month, state, and product.
 
+**Note:** Greenplum Database supports specifying a maximum of 12 `CUBE` grouping columns.
+
 GROUPING SETS
 :   You can selectively specify the set of groups that you want to create using a `GROUPING SETS` expression within a `GROUP BY` clause. This allows precise specification across multiple dimensions without computing a whole `ROLLUP` or `CUBE`. For example:
 


### PR DESCRIPTION
docs for https://github.com/greenplum-db/gpdb/pull/14149.  add a note identifying the max number of CUBE grouping columns in the two doc locations where CUBE is mentioned.
