### PR TITLE
docs - add reference info for new gp_print_create_gang_time guc

### DIFF
--- a/gpdb-doc/markdown/ref_guide/config_params/guc-list.html.md
+++ b/gpdb-doc/markdown/ref_guide/config_params/guc-list.html.md
@@ -1130,6 +1130,17 @@ Sets the Postgres Planner cost estimate for a Motion operator to transfer a row 
 |-----------|-------|-------------------|
 |floating point|0|master, session, reload|
 
+## <a id="gp_print_create_gang_time"></a>gp\_print\_create\_gang\_time 
+
+Controls the display of additional information about gang creation, including gang reuse status and the shortest and longest connection establishment time to the segment.
+
+The default value is `false`, Greenplum Database does not display the additional gang creation information.
+
+|Value Range|Default|Set Classifications|
+|-----------|-------|-------------------|
+|Boolean|false|master, session, reload|
+
+
 ## <a id="gp_recursive_cte"></a>gp\_recursive\_cte 
 
 Controls the availability of the `RECURSIVE` keyword in the `WITH` clause of a `SELECT [INTO]` command, or a `DELETE`, `INSERT` or `UPDATE` command. The keyword allows a subquery in the `WITH` clause of a command to reference itself. The default value is `true`, the `RECURSIVE` keyword is allowed in the `WITH` clause of a command.

--- a/gpdb-doc/markdown/ref_guide/config_params/guc-list.html.md
+++ b/gpdb-doc/markdown/ref_guide/config_params/guc-list.html.md
@@ -1132,7 +1132,7 @@ Sets the Postgres Planner cost estimate for a Motion operator to transfer a row 
 
 ## <a id="gp_print_create_gang_time"></a>gp\_print\_create\_gang\_time 
 
-Controls the display of additional information about gang creation, including gang reuse status and the shortest and longest connection establishment time to the segment.
+When a user starts a session with Greenplum Database and issues a query, the system creates groups or 'gangs' of worker processes on each segment to do the work. `gp_print_create_gang_time` controls the display of additional information about gang creation, including gang reuse status and the shortest and longest connection establishment time to the segment.
 
 The default value is `false`, Greenplum Database does not display the additional gang creation information.
 

--- a/gpdb-doc/markdown/ref_guide/config_params/guc_category-list.html.md
+++ b/gpdb-doc/markdown/ref_guide/config_params/guc_category-list.html.md
@@ -255,6 +255,7 @@ These configuration parameters control Greenplum Database logging.
 - [log_hostname](guc-list.html#log_hostname)
 - [gp_log_endpoints](guc-list.html#gp_log_endpoints)
 - [gp_log_interconnect](guc-list.html#gp_log_interconnect)
+- [gp_print_create_gang_time](guc-list.html#gp_print_create_gang_time)
 - [log_parser_stats](guc-list.html#log_parser_stats)
 - [log_planner_stats](guc-list.html#log_planner_stats)
 - [log_statement](guc-list.html#log_statement)


### PR DESCRIPTION
docs for https://github.com/greenplum-db/gpdb/pull/14067.

will be backported to 6X_STABLE.
