### PR TITLE
 Fixed EXPLAIN ANALYZE bug when foreign scan's gang size larger than number of segments

### DIFF
--- a/contrib/postgres_fdw/expected/gp_postgres_fdw.out
+++ b/contrib/postgres_fdw/expected/gp_postgres_fdw.out
@@ -223,6 +223,19 @@ EXPLAIN (VERBOSE, COSTS FALSE) SELECT * FROM gp_ft1;
  Optimizer: Postgres query optimizer
 (6 rows)
 
+EXPLAIN ANALYZE SELECT * FROM gp_ft1;
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 4:1  (slice1; segments: 4)  (cost=100.00..2872.00 rows=133600 width=68) (actual time=25.301..25.303 rows=0 loops=1)
+   ->  Foreign Scan on gp_ft1  (cost=100.00..1202.00 rows=33400 width=68) (actual time=0.000..9.830 rows=0 loops=1)
+ Optimizer: Postgres query optimizer
+ Planning Time: 6.631 ms
+   (slice0)    Executor memory: 42K bytes.
+   (slice1)    Executor memory: 42K bytes avg x 4 workers, 42K bytes max (seg0).
+ Memory used:  128000kB
+ Execution Time: 45.320 ms
+(8 rows)
+
 EXPLAIN (COSTS FALSE) INSERT INTO gp_ft1 SELECT * FROM table_dist_rand;
                       QUERY PLAN                      
 ------------------------------------------------------

--- a/contrib/postgres_fdw/expected/gp_postgres_fdw.out
+++ b/contrib/postgres_fdw/expected/gp_postgres_fdw.out
@@ -140,6 +140,19 @@ EXPLAIN (VERBOSE, COSTS FALSE) SELECT * FROM gp_ft1;
  Settings: optimizer = 'off'
 (7 rows)
 
+EXPLAIN ANALYZE SELECT * FROM gp_ft1;
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 4:1  (slice1; segments: 4)  (cost=100.00..2872.00 rows=133600 width=68) (actual time=25.301..25.303 rows=0 loops=1)
+   ->  Foreign Scan on gp_ft1  (cost=100.00..1202.00 rows=33400 width=68) (actual time=0.000..9.830 rows=0 loops=1)
+ Optimizer: Postgres query optimizer
+ Planning Time: 6.631 ms
+   (slice0)    Executor memory: 42K bytes.
+   (slice1)    Executor memory: 42K bytes avg x 4 workers, 42K bytes max (seg0).
+ Memory used:  128000kB
+ Execution Time: 45.320 ms
+(8 rows)
+
 EXPLAIN (VERBOSE, COSTS FALSE) SELECT count(*) FROM gp_ft1;
                               QUERY PLAN                               
 -----------------------------------------------------------------------
@@ -222,19 +235,6 @@ EXPLAIN (VERBOSE, COSTS FALSE) SELECT * FROM gp_ft1;
          Remote SQL: SELECT f1, f2, f3 FROM postgres_fdw_gp."GP 1"
  Optimizer: Postgres query optimizer
 (6 rows)
-
-EXPLAIN ANALYZE SELECT * FROM gp_ft1;
-                                                            QUERY PLAN                                                             
------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 4:1  (slice1; segments: 4)  (cost=100.00..2872.00 rows=133600 width=68) (actual time=25.301..25.303 rows=0 loops=1)
-   ->  Foreign Scan on gp_ft1  (cost=100.00..1202.00 rows=33400 width=68) (actual time=0.000..9.830 rows=0 loops=1)
- Optimizer: Postgres query optimizer
- Planning Time: 6.631 ms
-   (slice0)    Executor memory: 42K bytes.
-   (slice1)    Executor memory: 42K bytes avg x 4 workers, 42K bytes max (seg0).
- Memory used:  128000kB
- Execution Time: 45.320 ms
-(8 rows)
 
 EXPLAIN (COSTS FALSE) INSERT INTO gp_ft1 SELECT * FROM table_dist_rand;
                       QUERY PLAN                      

--- a/contrib/postgres_fdw/expected/gp_postgres_fdw_optimizer.out
+++ b/contrib/postgres_fdw/expected/gp_postgres_fdw_optimizer.out
@@ -139,6 +139,19 @@ EXPLAIN (VERBOSE, COSTS FALSE) SELECT * FROM gp_ft1;
  Optimizer: Postgres query optimizer
 (6 rows)
 
+EXPLAIN ANALYZE SELECT * FROM gp_ft1;
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 4:1  (slice1; segments: 4)  (cost=100.00..2872.00 rows=133600 width=68) (actual time=25.301..25.303 rows=0 loops=1)
+   ->  Foreign Scan on gp_ft1  (cost=100.00..1202.00 rows=33400 width=68) (actual time=0.000..9.830 rows=0 loops=1)
+ Optimizer: Postgres query optimizer
+ Planning Time: 6.631 ms
+   (slice0)    Executor memory: 42K bytes.
+   (slice1)    Executor memory: 42K bytes avg x 4 workers, 42K bytes max (seg0).
+ Memory used:  128000kB
+ Execution Time: 45.320 ms
+(8 rows)
+
 EXPLAIN (VERBOSE, COSTS FALSE) SELECT count(*) FROM gp_ft1;
                               QUERY PLAN                               
 -----------------------------------------------------------------------

--- a/contrib/postgres_fdw/sql/gp_postgres_fdw.sql
+++ b/contrib/postgres_fdw/sql/gp_postgres_fdw.sql
@@ -110,6 +110,7 @@ TRUNCATE TABLE postgres_fdw_gp."GP 1";
 set search_path=postgres_fdw_gp;
 alter server loopback options(add num_segments '4');
 EXPLAIN (VERBOSE, COSTS FALSE) SELECT * FROM gp_ft1;
+EXPLAIN ANALYZE SELECT * FROM gp_ft1;
 EXPLAIN (VERBOSE, COSTS FALSE) SELECT count(*) FROM gp_ft1;
 EXPLAIN (VERBOSE, COSTS FALSE) SELECT * FROM gp_ft1 t1 INNER JOIN gp_ft1 t2 ON t1.f1 = t2.f1 LIMIT 3;
 EXPLAIN (COSTS FALSE) INSERT INTO gp_ft1 SELECT * FROM table_dist_rand;

--- a/src/backend/commands/explain_gp.c
+++ b/src/backend/commands/explain_gp.c
@@ -324,7 +324,8 @@ cdbexplain_localExecStats(struct PlanState *planstate,
 
 	/* Set up a temporary StatHdr for both collecting and depositing stats. */
 	ctx.msgptrs[0] = &ctx.send.hdr;
-	ctx.send.hdr.segindex = GpIdentity.segindex;
+	ctx.send.hdr.segindex = qe_identifier;
+	ctx.send.hdr.realsegindex = GpIdentity.segindex;
 	ctx.send.hdr.nInst = 1;
 
 	/* Set up receive context area referencing our temp StatHdr. */


### PR DESCRIPTION
This PR is try to fix the issue #14573

    When the options of the foreign table include mpp_execute as 'all segments' (for example,
    Greenplum FDW), and the number of segments in the remote cluster is greater than the
    number of local segments, executing explain analyze will fail assert/insist.

    To fix this problem, QE should uses qe_identifier instead of segindex to
    identify its own workerid.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
