### PR TITLE
[6X] Preserve gp_fastsequence during upgrade

### DIFF
--- a/contrib/pg_upgrade/greenplum/frozenxids_gp.c
+++ b/contrib/pg_upgrade/greenplum/frozenxids_gp.c
@@ -14,24 +14,24 @@
  * Segment database contains data, and the tuples should not have
  * any entry with a xmin > relfrozenxid for the table in pg_class.
  * Instead of vacuum freezing the entire data, update the relfrozenxid
- * of the relation in pg_class with the datafrozenxid from the corresponding
+ * of the relation in pg_class with the datfrozenxid from the corresponding
  * database in the old cluster. This ensures that the xmin is not > relfrozenxid
  * for any of the tuple.
- * Also, update the new segment database with the datafrozenxid
+ * Coordinator contains data entries in GPDB catalog tables like gp_fastsequence,
+ * pg_aoseg, pg_aocsseg, and pg_aovisimap that also need relfrozenxid correction.
+ * Also, update the new database with the datfrozenxid
  * from the old cluster as that indicates the lowest xid available.
  *
  * In GPDB5 datminmxid does not exist, so use the chkpnt_nxtmulti to update
  * the value in the GPDB6 cluster.
  */
 void
-update_segment_db_xids(void)
+update_db_xids(void)
 {
-	Assert(!is_greenplum_dispatcher_mode());
-
 	int			dbnum;
 	PGconn	   *conn;
 
-	prep_status("Updating xid's in new cluster segment databases");
+	prep_status("Updating xid's in new cluster databases");
 
 	for (dbnum = 0; dbnum < old_cluster.dbarr.ndbs; dbnum++)
 	{

--- a/contrib/pg_upgrade/greenplum/pg_upgrade_greenplum.h
+++ b/contrib/pg_upgrade/greenplum/pg_upgrade_greenplum.h
@@ -80,7 +80,7 @@ extern void freeze_master_data(void);
 void reset_system_identifier(void);
 
 /* frozenxids_gp.c */
-void update_segment_db_xids(void);
+void update_db_xids(void);
 
 /* aotable.c */
 

--- a/contrib/pg_upgrade/info.c
+++ b/contrib/pg_upgrade/info.c
@@ -519,7 +519,8 @@ get_rel_infos(ClusterInfo *cluster, DbInfo *dbinfo)
 			 "    n.nspname NOT IN ('gp_toolkit', 'pg_bitmapindex') AND "
 			 "	  c.oid >= %u) "
 			 "  OR (n.nspname = 'pg_catalog' AND "
-	"    relname IN ('pg_largeobject', 'pg_largeobject_loid_pn_index'%s) ));",
+	"    relname IN ('pg_largeobject', 'pg_largeobject_loid_pn_index'%s, "
+	"                'gp_fastsequence', 'gp_fastsequence_objid_objmod_index') ));",
 	/* Greenplum 5X use 'm' as aovisimap which is now matview in 6X and above. */
 			 (GET_MAJOR_VERSION(old_cluster.major_version) == 803) ?
 			 ", 'm'" : ", 'M'",

--- a/contrib/pg_upgrade/pg_upgrade.c
+++ b/contrib/pg_upgrade/pg_upgrade.c
@@ -213,7 +213,7 @@ main(int argc, char **argv)
 	 * Otherwise, vacuuming those tables once data is copied/linked will error out.
 	 */
 	if (!is_greenplum_dispatcher_mode())
-		update_segment_db_xids();
+		update_db_xids();
 
 	/*
 	 * In a segment, the data directory already contains all the objects,
@@ -224,12 +224,6 @@ main(int argc, char **argv)
 	 * server.
 	 */
 	restore_aosegment_tables();
-
-	if (is_greenplum_dispatcher_mode())
-	{
-		/* freeze master data *right before* stopping */
-		freeze_master_data();
-	}
 
 	stop_postmaster(false);
 
@@ -244,6 +238,22 @@ main(int argc, char **argv)
 
 	transfer_all_new_tablespaces(&old_cluster.dbarr, &new_cluster.dbarr,
 								 old_cluster.pgdata, new_cluster.pgdata);
+
+	/*
+	 * Tuples of gp_fastsequence are being upgraded using relfilenode transfer.
+	 * Freezing coordinator's data must happen after relfilenodes land. We also
+	 * need to fix the tuple's xmin to ensure they are lower than the
+	 * relfrozenxid. Otherwise subsequent vacuums may fail.
+	 */
+	if (is_greenplum_dispatcher_mode())
+	{
+		start_postmaster(&new_cluster, true);
+
+		update_db_xids();
+		freeze_master_data();
+
+		stop_postmaster(false);
+	}
 
 	/*
 	 * Assuming OIDs are only used in system tables, there is no need to


### PR DESCRIPTION
The gp_fastsequence catalog table must be preserved when upgrading to a newer version. Not preserving this table will likely cause duplicate ctids in ao tables when normal cluster operations resume after an upgrade.

How duplicate ctids can occur:
1. gp_fastsequence is initialized to 0 for a new ao table.
2. gp_fastsequence only increases positively in increments of 100.
3. ctids are assigned based on gp_fastsequence values.

When a tuple is inserted it consumes a gp_fastsequence value to produce a ctid to index the data. If a fastsequence value is reused, a duplicate ctid will occur. This will result in indexes returning wrong results.

When an ao table's fastsequence value is lower than the it's tuple count, gpdb's default behavior in an attempt to fix the fastsequence value is to set it to the table's tuple count on the next insert. However this not reliable since fastsequence reserves numbers in increments of 100 at a time for performance purposes. This means that even if only 1 value is inserted into the table, fastsequence will increment by 100. As a result Under normal cluster operation, fastsequence increments at a much faster rate than tuple count and setting it to a table's tuple count can still result in a duplicate ctid because there will be rows with ctids based on fastsequence values much higher than its table's tuple count.

The alternative to relfilenode approach is to do something similar to restore_aosegment_tables() where we would scan all gp_fastsequence in all databases, generate UPDATE statements to manually rebuild the catalog table.

Test is located in gpupgrade PR: https://github.com/greenplum-db/gpupgrade/pull/736

gpupgrade: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:fastsequence-test
6X: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/upgrade-gp-fastsequence
