### PR TITLE
Fix crash of AggNode in executor casued by ORCA plan

### DIFF
--- a/src/backend/executor/execExpr.c
+++ b/src/backend/executor/execExpr.c
@@ -3194,7 +3194,6 @@ ExecBuildAggTrans(AggState *aggstate, AggStatePerPhase phase,
 	ExprEvalStep scratch = {0};
 	int			transno = 0;
 	int			setoff = 0;
-	bool		isCombine = DO_AGGSPLIT_COMBINE(aggstate->aggsplit);
 	LastAttnumInfo deform = {0, 0, 0};
 
 	state->expr = (Expr *) aggstate;
@@ -3243,6 +3242,7 @@ ExecBuildAggTrans(AggState *aggstate, AggStatePerPhase phase,
 		NullableDatum *strictargs = NULL;
 		bool	   *strictnulls = NULL;
 
+		bool isCombine = DO_AGGSPLIT_COMBINE(pertrans->aggref->aggsplit);
 		/*
 		 * If filter present, emit. Do so before evaluating the input, to
 		 * avoid potentially unneeded computations, or even worse, unintended

--- a/src/backend/executor/nodeAgg.c
+++ b/src/backend/executor/nodeAgg.c
@@ -4191,7 +4191,7 @@ build_pertrans_for_aggref(AggStatePerTrans pertrans,
 	 * transfn and transfn_oid fields of pertrans refer to the combine
 	 * function rather than the transition function.
 	 */
-	if (DO_AGGSPLIT_COMBINE(aggstate->aggsplit))
+	if (DO_AGGSPLIT_COMBINE(aggref->aggsplit))
 	{
 		Expr	   *combinefnexpr;
 		size_t		numTransArgs;

--- a/src/test/regress/expected/gp_dqa.out
+++ b/src/test/regress/expected/gp_dqa.out
@@ -2336,3 +2336,65 @@ explain (verbose, costs off) select count(distinct (b)::text) as b, count(distin
  Settings: enable_groupagg = 'off', gp_motion_cost_per_row = '1'
 (19 rows)
 
+-- fix dqa bug when optimizer_force_multistage_agg is on
+set optimizer_force_multistage_agg = on;
+create table multiagg1(a int, b bigint, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table multiagg2(a int, b bigint, c numeric(8, 4));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into multiagg1 values(generate_series(1, 10), generate_series(1, 10), generate_series(1, 10));
+insert into multiagg2 values(generate_series(1, 10), generate_series(1, 10), 555.55);
+analyze;
+explain (verbose, costs off) select count(distinct b), sum(c) from multiagg1;
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Finalize Aggregate
+   Output: count(DISTINCT b), sum(c)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Output: (PARTIAL count(DISTINCT b)), (PARTIAL sum(c))
+         ->  Partial Aggregate
+               Output: PARTIAL count(DISTINCT b), PARTIAL sum(c)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Output: b, c
+                     Hash Key: b
+                     ->  Seq Scan on public.multiagg1
+                           Output: b, c
+ Optimizer: Postgres query optimizer
+ Settings: enable_groupagg = 'off', gp_motion_cost_per_row = '1', optimizer_force_multistage_agg = 'on'
+(13 rows)
+
+select count(distinct b), sum(c) from multiagg1;
+ count | sum 
+-------+-----
+    10 |  55
+(1 row)
+
+explain (verbose, costs off) select count(distinct b), sum(c) from multiagg2;
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Finalize Aggregate
+   Output: count(DISTINCT b), sum(c)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Output: (PARTIAL count(DISTINCT b)), (PARTIAL sum(c))
+         ->  Partial Aggregate
+               Output: PARTIAL count(DISTINCT b), PARTIAL sum(c)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Output: b, c
+                     Hash Key: b
+                     ->  Seq Scan on public.multiagg2
+                           Output: b, c
+ Optimizer: Postgres query optimizer
+ Settings: enable_groupagg = 'off', gp_motion_cost_per_row = '1', optimizer_force_multistage_agg = 'on'
+(13 rows)
+
+select count(distinct b), sum(c) from multiagg2;
+ count |    sum    
+-------+-----------
+    10 | 5555.5000
+(1 row)
+
+drop table multiagg1;
+drop table multiagg2;
+reset optimizer_force_multistage_agg;

--- a/src/test/regress/expected/gp_dqa_optimizer.out
+++ b/src/test/regress/expected/gp_dqa_optimizer.out
@@ -2485,3 +2485,77 @@ DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disab
  Settings: enable_groupagg = 'off', gp_motion_cost_per_row = '1'
 (19 rows)
 
+-- fix dqa bug when optimizer_force_multistage_agg is on
+set optimizer_force_multistage_agg = on;
+create table multiagg1(a int, b bigint, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table multiagg2(a int, b bigint, c numeric(8, 4));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into multiagg1 values(generate_series(1, 10), generate_series(1, 10), generate_series(1, 10));
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Unexpected target list entries in ProjectSet node
+insert into multiagg2 values(generate_series(1, 10), generate_series(1, 10), 555.55);
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Unexpected target list entries in ProjectSet node
+analyze;
+explain (verbose, costs off) select count(distinct b), sum(c) from multiagg1;
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Aggregate
+   Output: count(b), sum(c)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Output: b, (PARTIAL sum(c))
+         ->  Partial HashAggregate
+               Output: b, PARTIAL sum(c)
+               Group Key: multiagg1.b
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Output: b, (PARTIAL sum(c))
+                     Hash Key: b
+                     ->  Streaming Partial HashAggregate
+                           Output: b, PARTIAL sum(c)
+                           Group Key: multiagg1.b
+                           ->  Seq Scan on public.multiagg1
+                                 Output: b, c
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Settings: enable_groupagg = 'off', gp_motion_cost_per_row = '1', optimizer_force_multistage_agg = 'on'
+(17 rows)
+
+select count(distinct b), sum(c) from multiagg1;
+ count | sum 
+-------+-----
+    10 |  55
+(1 row)
+
+explain (verbose, costs off) select count(distinct b), sum(c) from multiagg2;
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Aggregate
+   Output: count(b), sum(c)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Output: b, (PARTIAL sum(c))
+         ->  Partial HashAggregate
+               Output: b, PARTIAL sum(c)
+               Group Key: multiagg2.b
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Output: b, (PARTIAL sum(c))
+                     Hash Key: b
+                     ->  Streaming Partial HashAggregate
+                           Output: b, PARTIAL sum(c)
+                           Group Key: multiagg2.b
+                           ->  Seq Scan on public.multiagg2
+                                 Output: b, c
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Settings: enable_groupagg = 'off', gp_motion_cost_per_row = '1', optimizer_force_multistage_agg = 'on'
+(17 rows)
+
+select count(distinct b), sum(c) from multiagg2;
+ count |    sum    
+-------+-----------
+    10 | 5555.5000
+(1 row)
+
+drop table multiagg1;
+drop table multiagg2;
+reset optimizer_force_multistage_agg;

--- a/src/test/regress/sql/gp_dqa.sql
+++ b/src/test/regress/sql/gp_dqa.sql
@@ -395,3 +395,22 @@ explain (verbose, costs off) select count(distinct (b)::text) as b, count(distin
 -- column '(a)::integer::varchar' as part of hash-key in Redistribute-Motion.
 select count(distinct (b)::text) as b, count(distinct (a)::int::varchar) as a from dqa_f3;
 explain (verbose, costs off) select count(distinct (b)::text) as b, count(distinct (a)::int::varchar) as a from dqa_f3;
+
+
+
+-- fix dqa bug when optimizer_force_multistage_agg is on
+set optimizer_force_multistage_agg = on;
+create table multiagg1(a int, b bigint, c int);
+create table multiagg2(a int, b bigint, c numeric(8, 4));
+insert into multiagg1 values(generate_series(1, 10), generate_series(1, 10), generate_series(1, 10));
+insert into multiagg2 values(generate_series(1, 10), generate_series(1, 10), 555.55);
+analyze;
+
+explain (verbose, costs off) select count(distinct b), sum(c) from multiagg1;
+select count(distinct b), sum(c) from multiagg1;
+
+explain (verbose, costs off) select count(distinct b), sum(c) from multiagg2;
+select count(distinct b), sum(c) from multiagg2;
+drop table multiagg1;
+drop table multiagg2;
+reset optimizer_force_multistage_agg;


### PR DESCRIPTION
Fix aggnode crash in executor caused by ORCA plan
origin issue: https://github.com/greenplum-db/gpdb/issues/13994

when we force optimizer_force_multistage_agg to true, orca will
generate multistage agg plan for DQA, ex sql below.
explain (verbose, costs off) select count(distinct b), sum(c) from t1;
```
                                               QUERY PLAN                                               
--------------------------------------------------------------------------------------------------------
 Aggregate
   Output: count(b), sum(c)
   ->  Gather Motion 3:1  (slice1; segments: 3)
         Output: b, (PARTIAL sum(c))
         ->  Partial HashAggregate
               Output: b, PARTIAL sum(c)
               Group Key: t1.b
               ->  Redistribute Motion 3:3  (slice2; segments: 3)
                     Output: b, (PARTIAL sum(c))
                     Hash Key: b
                     ->  Streaming Partial HashAggregate
                           Output: b, PARTIAL sum(c)
                           Group Key: t1.b
                           ->  Seq Scan on public.t1
                                 Output: b, c
 Optimizer: Pivotal Optimizer (GPORCA)
```
the top Aggregate has ouput targets of count(b) and sum(c), count(b) is plain aggref
and sum(c) is a combine aggref because of (PARTIAL sum(c)) below. 
As a result, we should build trans/combine function in executor based on Aggref split
type of output targetlist instead of using Aggnode split typle.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
