### PR TITLE
【6X】NEW SYNTAX for resource group cpuset

### DIFF
--- a/src/backend/commands/resgroupcmds.c
+++ b/src/backend/commands/resgroupcmds.c
@@ -93,7 +93,7 @@ static void createResgroupCallback(XactEvent event, void *arg);
 static void dropResgroupCallback(XactEvent event, void *arg);
 static void alterResgroupCallback(XactEvent event, void *arg);
 static int getResGroupMemAuditor(char *name);
-static bool checkCpusetSyntax(const char *cpuset);
+static void checkCpusetSyntax(const char *cpuset);
 
 /*
  * CREATE RESOURCE GROUP
@@ -242,13 +242,16 @@ CreateResourceGroup(CreateResourceGroupStmt *stmt)
 		{
 			EnsureCpusetIsAvailable(ERROR);
 
-			ResGroupOps_SetCpuSet(groupid, caps.cpuset);
 			/* reset default group, subtract new group cpu cores */
 			char defaultGroupCpuset[MaxCpuSetLength];
 			ResGroupOps_GetCpuSet(DEFAULT_CPUSET_GROUP_ID,
 								  defaultGroupCpuset,
 								  MaxCpuSetLength);
-			CpusetDifference(defaultGroupCpuset, caps.cpuset, MaxCpuSetLength);
+
+			char *cpuset = getCpuSetByRole(caps.cpuset);
+			ResGroupOps_SetCpuSet(groupid, cpuset);
+			CpusetDifference(defaultGroupCpuset, cpuset, MaxCpuSetLength);
+
 			ResGroupOps_SetCpuSet(DEFAULT_CPUSET_GROUP_ID, defaultGroupCpuset);
 		}
 		SIMPLE_FAULT_INJECTOR("create_resource_group_fail");
@@ -394,9 +397,8 @@ AlterResourceGroup(AlterResourceGroupStmt *stmt)
 	else if (limitType == RESGROUP_LIMIT_TYPE_CPUSET)
 	{
 		EnsureCpusetIsAvailable(ERROR);
-
 		cpuset = defGetString(defel);
-		checkCpusetSyntax(cpuset);
+		checkCpuSetByRole(cpuset);
 	}
 	else
 	{
@@ -1030,8 +1032,8 @@ parseStmtOptions(CreateResourceGroupStmt *stmt, ResGroupCaps *caps)
 		if (type == RESGROUP_LIMIT_TYPE_CPUSET) 
 		{
 			const char *cpuset = defGetString(defel);
-			checkCpusetSyntax(cpuset);
 			StrNCpy(caps->cpuset, cpuset, sizeof(caps->cpuset));
+			checkCpuSetByRole(cpuset);
 			caps->cpuRateLimit = CPU_RATE_LIMIT_DISABLED;
 		}
 		else 
@@ -1312,18 +1314,20 @@ validateCapabilities(Relation rel,
 		gp_resource_group_enable_cgroup_cpuset)
 	{
 		Bitmapset *bmsAll = NULL;
+		Bitmapset *bmsMissing = NULL;
 
 		/* Get all available cores */
 		ResGroupOps_GetCpuSet(RESGROUP_ROOT_ID,
 							  cpusetAll,
 							  MaxCpuSetLength);
 		bmsAll = CpusetToBitset(cpusetAll, MaxCpuSetLength);
+
 		/* Check whether the cores in this group are available */
 		if (!CpusetIsEmpty(caps->cpuset))
 		{
-			Bitmapset *bmsMissing = NULL;
+			char *cpuset = getCpuSetByRole(caps->cpuset);
+			bmsCurrent = CpusetToBitset(cpuset, MaxCpuSetLength);
 
-			bmsCurrent = CpusetToBitset(caps->cpuset, MaxCpuSetLength);
 			bmsCommon = bms_intersect(bmsCurrent, bmsAll);
 			bmsMissing = bms_difference(bmsCurrent, bmsCommon);
 
@@ -1333,8 +1337,8 @@ validateCapabilities(Relation rel,
 
 				ereport(ERROR,
 						(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-						 errmsg("cpu cores %s are unavailable on the system",
-								cpusetMissing)));
+						errmsg("cpu cores %s are unavailable on the system",
+						cpusetMissing)));
 			}
 		}
 	}
@@ -1416,7 +1420,8 @@ validateCapabilities(Relation rel,
 
 					Assert(!bms_is_empty(bmsCurrent));
 
-					bmsOther = CpusetToBitset(valueStr, MaxCpuSetLength);
+					char *cpuset = getCpuSetByRole(valueStr);
+					bmsOther = CpusetToBitset(cpuset, MaxCpuSetLength);
 					bmsCommon = bms_intersect(bmsCurrent, bmsOther);
 
 					if (!bms_is_empty(bmsCommon))
@@ -1568,16 +1573,22 @@ getResGroupMemAuditor(char *name)
 /*
  * check whether the cpuset value is syntactically right
  */
-static bool
+static void
 checkCpusetSyntax(const char *cpuset)
 {
+	if (cpuset == NULL)
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_SYNTAX_ERROR),
+				 errmsg("cpuset invalid")));
+	}
+
 	if (strlen(cpuset) >= MaxCpuSetLength)
 	{
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 				 errmsg("the length of cpuset reached the upper limit %d",
 						MaxCpuSetLength)));
-		return false;
 	}
 	if (!CpusetToBitset(cpuset,
 						 strlen(cpuset)))
@@ -1585,7 +1596,81 @@ checkCpusetSyntax(const char *cpuset)
 		ereport(ERROR,
 				(errcode(ERRCODE_SYNTAX_ERROR),
 				 errmsg("cpuset invalid")));
-		return false;
 	}
-	return true;
+
+	return;
+}
+
+/*
+ * Check Cpuset by coordinator and segment
+ */
+extern void
+checkCpuSetByRole(const char *cpuset)
+{
+	char **arraycpuset = (char **)palloc0(sizeof(char *) * CpuSetArrayLength);
+	char *copycpuset = (char *)palloc0(sizeof(char) * MaxCpuSetLength);
+	strcpy(copycpuset, cpuset);
+
+	int cnt = 0;
+	for (int i = 0; i < sizeof(cpuset); i++)
+	{
+		if (cpuset[i] == ';')
+			cnt++;
+	}
+
+	if (cnt == 0)
+	{
+		checkCpusetSyntax(copycpuset);
+		arraycpuset[0] = copycpuset;
+	}
+	else if (cnt == 1)
+	{
+		int iter = 0;
+		char *nextcpuset = strtok(copycpuset, ";");
+		while (nextcpuset != NULL)
+		{
+			arraycpuset[iter++] = nextcpuset;
+			nextcpuset = strtok(NULL, ";");
+		}
+		checkCpusetSyntax(arraycpuset[0]);
+		checkCpusetSyntax(arraycpuset[1]);
+	}
+	else
+		ereport(ERROR,
+				(errcode(ERRCODE_SYNTAX_ERROR),
+				errmsg("cpuset invalid")));
+
+	pfree(copycpuset);
+	pfree(arraycpuset);
+	return;
+}
+
+/*
+ * Seperate cpuset by coordinator and segment
+ * Return as splitcpuset
+ */
+extern char *
+getCpuSetByRole(const char *cpuset)
+{
+	int iter = 0;
+	char *splitcpuset = NULL;
+
+	char **arraycpuset = (char **)palloc0(sizeof(char *) * CpuSetArrayLength);
+	char *copycpuset = (char *)palloc0(sizeof(char) * MaxCpuSetLength);
+	strcpy(copycpuset, cpuset);
+
+	char *nextcpuset = strtok(copycpuset, ";");
+	while (nextcpuset != NULL)
+	{
+		arraycpuset[iter++] = nextcpuset;
+		nextcpuset = strtok(NULL, ";");
+	}
+
+	/* Get result cpuset by gprole, on master or segment */
+	if (Gp_role == GP_ROLE_EXECUTE && arraycpuset[1] != NULL)
+		splitcpuset = arraycpuset[1];
+	else
+		splitcpuset = arraycpuset[0];
+
+	return splitcpuset;
 }

--- a/src/backend/commands/resgroupcmds.c
+++ b/src/backend/commands/resgroupcmds.c
@@ -1032,8 +1032,8 @@ parseStmtOptions(CreateResourceGroupStmt *stmt, ResGroupCaps *caps)
 		if (type == RESGROUP_LIMIT_TYPE_CPUSET) 
 		{
 			const char *cpuset = defGetString(defel);
-			StrNCpy(caps->cpuset, cpuset, sizeof(caps->cpuset));
 			checkCpuSetByRole(cpuset);
+			StrNCpy(caps->cpuset, cpuset, sizeof(caps->cpuset));
 			caps->cpuRateLimit = CPU_RATE_LIMIT_DISABLED;
 		}
 		else 
@@ -1314,7 +1314,6 @@ validateCapabilities(Relation rel,
 		gp_resource_group_enable_cgroup_cpuset)
 	{
 		Bitmapset *bmsAll = NULL;
-		Bitmapset *bmsMissing = NULL;
 
 		/* Get all available cores */
 		ResGroupOps_GetCpuSet(RESGROUP_ROOT_ID,
@@ -1325,6 +1324,7 @@ validateCapabilities(Relation rel,
 		/* Check whether the cores in this group are available */
 		if (!CpusetIsEmpty(caps->cpuset))
 		{
+			Bitmapset *bmsMissing = NULL;
 			char *cpuset = getCpuSetByRole(caps->cpuset);
 			bmsCurrent = CpusetToBitset(cpuset, MaxCpuSetLength);
 
@@ -1607,70 +1607,83 @@ checkCpusetSyntax(const char *cpuset)
 extern void
 checkCpuSetByRole(const char *cpuset)
 {
-	char **arraycpuset = (char **)palloc0(sizeof(char *) * CpuSetArrayLength);
-	char *copycpuset = (char *)palloc0(sizeof(char) * MaxCpuSetLength);
-	strcpy(copycpuset, cpuset);
+	char *first = NULL;
+	char *last = NULL;
 
-	int cnt = 0;
-	for (int i = 0; i < sizeof(cpuset); i++)
+	if (cpuset == NULL)
 	{
-		if (cpuset[i] == ';')
-			cnt++;
-	}
-
-	if (cnt == 0)
-	{
-		checkCpusetSyntax(copycpuset);
-		arraycpuset[0] = copycpuset;
-	}
-	else if (cnt == 1)
-	{
-		int iter = 0;
-		char *nextcpuset = strtok(copycpuset, ";");
-		while (nextcpuset != NULL)
-		{
-			arraycpuset[iter++] = nextcpuset;
-			nextcpuset = strtok(NULL, ";");
-		}
-		checkCpusetSyntax(arraycpuset[0]);
-		checkCpusetSyntax(arraycpuset[1]);
-	}
-	else
 		ereport(ERROR,
 				(errcode(ERRCODE_SYNTAX_ERROR),
 				errmsg("cpuset invalid")));
+	}
 
-	pfree(copycpuset);
-	pfree(arraycpuset);
+	first = strchr(cpuset, ';');
+	last = strrchr(cpuset, ';');
+	/*
+	 * If point first not equal last, that means
+	 * ';' character exceed limit numbers.
+	 */
+	if (last != first)
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_SYNTAX_ERROR),
+				errmsg("cpuset invalid")));
+	}
+
+	if (first == NULL)
+		checkCpusetSyntax(cpuset);
+	else
+	{
+		char mcpu[MaxCpuSetLength] = {0};
+		strncpy(mcpu, cpuset, first - cpuset);
+
+		checkCpusetSyntax(mcpu);
+		checkCpusetSyntax(first + 1);
+	}
+
 	return;
 }
 
 /*
  * Seperate cpuset by coordinator and segment
  * Return as splitcpuset
+ *
+ * ex:
+ * cpuset = "1;4"
+ * then we should assign '1' to corrdinator and '4' to segment
+ * 
+ * cpuset = "1"
+ * assign '1' to both coordinator and segment
  */
 extern char *
 getCpuSetByRole(const char *cpuset)
 {
-	int iter = 0;
 	char *splitcpuset = NULL;
 
-	char **arraycpuset = (char **)palloc0(sizeof(char *) * CpuSetArrayLength);
-	char *copycpuset = (char *)palloc0(sizeof(char) * MaxCpuSetLength);
-	strcpy(copycpuset, cpuset);
-
-	char *nextcpuset = strtok(copycpuset, ";");
-	while (nextcpuset != NULL)
+	if (cpuset == NULL)
 	{
-		arraycpuset[iter++] = nextcpuset;
-		nextcpuset = strtok(NULL, ";");
+		ereport(ERROR,
+				(errcode(ERRCODE_SYNTAX_ERROR),
+				errmsg("Unexpected cpuset invalid in getCpuSetByRole")));
 	}
 
-	/* Get result cpuset by gprole, on master or segment */
-	if (Gp_role == GP_ROLE_EXECUTE && arraycpuset[1] != NULL)
-		splitcpuset = arraycpuset[1];
+	char *first = strchr(cpuset, ';');
+	if (first == NULL)
+		splitcpuset = (char *)cpuset;
 	else
-		splitcpuset = arraycpuset[0];
+	{
+		char *scpu = first + 1;
+
+		/* Get result cpuset by IS_QUERY_DISPATCHER(), on master or segment */
+		if (IS_QUERY_DISPATCHER())
+			splitcpuset = scpu;
+		else
+		{
+			char *mcpu = (char *)palloc0(sizeof(char) * MaxCpuSetLength);
+			strncpy(mcpu, cpuset, first - cpuset);
+			splitcpuset = mcpu;
+		}
+	}
 
 	return splitcpuset;
 }

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -612,7 +612,6 @@ InitResGroups(void)
 	{
 		ResGroupData	*group;
 		int cpuRateLimit;
-		Bitmapset *bmsCurrent;
 
         Oid groupId = HeapTupleGetOid(tuple);
 		GetResGroupCapabilities(relResGroupCapability, groupId, &caps);
@@ -631,7 +630,7 @@ InitResGroups(void)
 		else
 		{
 			char *cpuset = getCpuSetByRole(caps.cpuset);
-			bmsCurrent = CpusetToBitset(cpuset, MaxCpuSetLength);
+			Bitmapset *bmsCurrent = CpusetToBitset(cpuset, MaxCpuSetLength);
 
 			Bitmapset *bmsCommon = bms_intersect(bmsCurrent, bmsUnused);
 			Bitmapset *bmsMissing = bms_difference(bmsCurrent, bmsCommon);

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -612,8 +612,9 @@ InitResGroups(void)
 	{
 		ResGroupData	*group;
 		int cpuRateLimit;
-		Oid groupId = HeapTupleGetOid(tuple);
+		Bitmapset *bmsCurrent;
 
+        Oid groupId = HeapTupleGetOid(tuple);
 		GetResGroupCapabilities(relResGroupCapability, groupId, &caps);
 		cpuRateLimit = caps.cpuRateLimit;
 
@@ -629,8 +630,9 @@ InitResGroups(void)
 		}
 		else
 		{
-			Bitmapset *bmsCurrent = CpusetToBitset(caps.cpuset,
-												   MaxCpuSetLength);
+			char *cpuset = getCpuSetByRole(caps.cpuset);
+			bmsCurrent = CpusetToBitset(cpuset, MaxCpuSetLength);
+
 			Bitmapset *bmsCommon = bms_intersect(bmsCurrent, bmsUnused);
 			Bitmapset *bmsMissing = bms_difference(bmsCurrent, bmsCommon);
 
@@ -655,7 +657,8 @@ InitResGroups(void)
 				 * write cpus to corresponding file
 				 * if all the cores are available
 				 */
-				ResGroupOps_SetCpuSet(groupId, caps.cpuset);
+				char *cpuset= getCpuSetByRole(caps.cpuset);
+				ResGroupOps_SetCpuSet(groupId, cpuset);
 				bmsUnused = bms_del_members(bmsUnused, bmsCurrent);
 			}
 			else
@@ -907,8 +910,10 @@ ResGroupAlterOnCommit(const ResourceGroupCallbackContext *callbackCtx)
 		else if (callbackCtx->limittype == RESGROUP_LIMIT_TYPE_CPUSET)
 		{
 			if (gp_resource_group_enable_cgroup_cpuset)
-				ResGroupOps_SetCpuSet(callbackCtx->groupid,
-									  callbackCtx->caps.cpuset);
+			{
+				char *cpuset = getCpuSetByRole(callbackCtx->caps.cpuset);
+				ResGroupOps_SetCpuSet(callbackCtx->groupid, cpuset);
+			}
 		}
 		else if (callbackCtx->limittype != RESGROUP_LIMIT_TYPE_MEMORY_SPILL_RATIO)
 		{
@@ -933,12 +938,15 @@ ResGroupAlterOnCommit(const ResourceGroupCallbackContext *callbackCtx)
 								  MaxCpuSetLength);
 			/* Add old value to default group
 			 * sub new value from default group */
+			char *cpuset= getCpuSetByRole(callbackCtx->caps.cpuset);
+			char *oldcpuset = getCpuSetByRole(callbackCtx->oldCaps.cpuset);
 			CpusetUnion(defaultCpusetGroup,
-							callbackCtx->oldCaps.cpuset,
-							MaxCpuSetLength);
+						oldcpuset,
+						MaxCpuSetLength);
 			CpusetDifference(defaultCpusetGroup,
-							callbackCtx->caps.cpuset,
-							MaxCpuSetLength);
+						cpuset,
+						MaxCpuSetLength);
+
 			ResGroupOps_SetCpuSet(DEFAULT_CPUSET_GROUP_ID, defaultCpusetGroup);
 		}
 	}

--- a/src/include/utils/resgroup.h
+++ b/src/include/utils/resgroup.h
@@ -31,6 +31,11 @@
 #define MaxCpuSetLength 1024
 
 /*
+ * The max length of cpuset array
+ */
+#define CpuSetArrayLength 2
+
+/*
  * Default value of cpuset
  */
 #define DefaultCpuset "-1"
@@ -84,8 +89,9 @@ typedef struct ResGroupCaps
 } ResGroupCaps;
 
 /* Set 'cpuset' to an empty string, and reset all other fields to zero */
-#define ClearResGroupCaps(caps) \
-	MemSet((caps), 0, offsetof(ResGroupCaps, cpuset) + 1)
+#define ClearResGroupCaps(caps) do { \
+	MemSet((caps), 0, offsetof(ResGroupCaps, cpuset) + 1); \
+} while(0)
 
 
 /*
@@ -228,6 +234,8 @@ extern void ResGroupMoveQuery(int sessionId, Oid groupId, const char *groupName)
 extern int32 ResGroupGetSessionMemUsage(int sessionId);
 extern int32 ResGroupGetGroupAvailableMem(Oid groupId);
 extern Oid ResGroupGetGroupIdBySessionId(int sessionId);
+extern char *getCpuSetByRole(const char *cpuset);
+extern void checkCpuSetByRole(const char *cpuset);
 
 #define LOG_RESGROUP_DEBUG(...) \
 	do {if (Debug_resource_group) elog(__VA_ARGS__); } while(false);

--- a/src/include/utils/resgroup.h
+++ b/src/include/utils/resgroup.h
@@ -31,11 +31,6 @@
 #define MaxCpuSetLength 1024
 
 /*
- * The max length of cpuset array
- */
-#define CpuSetArrayLength 2
-
-/*
  * Default value of cpuset
  */
 #define DefaultCpuset "-1"

--- a/src/test/isolation2/expected/resgroup/resgroup_syntax.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_syntax.out
@@ -152,8 +152,6 @@ CREATE RESOURCE GROUP rg_test_group WITH (cpuset='3-1', memory_limit=5);
 ERROR:  cpuset invalid
 CREATE RESOURCE GROUP rg_test_group WITH (cpuset=' 0 ', memory_limit=5);
 ERROR:  cpuset invalid
-CREATE RESOURCE GROUP rg_test_group WITH (cpuset='0;3-1', memory_limit=5);
-ERROR:  cpuset invalid
 CREATE RESOURCE GROUP rg_test_group WITH (cpuset='4;a', memory_limit=5);
 ERROR:  cpuset invalid
 CREATE RESOURCE GROUP rg_test_group WITH (cpuset='-;4', memory_limit=5);
@@ -188,8 +186,6 @@ ERROR:  cpuset invalid
 ALTER RESOURCE GROUP rg_test_group set CPUSET '3-1';
 ERROR:  cpuset invalid
 ALTER RESOURCE GROUP rg_test_group set CPUSET ' 0 ';
-ERROR:  cpuset invalid
-ALTER RESOURCE GROUP rg_test_group set CPUSET '5;3-1';
 ERROR:  cpuset invalid
 ALTER RESOURCE GROUP rg_test_group set CPUSET '4;a';
 ERROR:  cpuset invalid
@@ -260,7 +256,7 @@ SELECT groupname,concurrency,cpu_rate_limit,memory_limit,memory_shared_quota,mem
 (1 row)
 DROP RESOURCE GROUP rg_test_group;
 DROP
-CREATE RESOURCE GROUP rg_test_group WITH (cpuset='1;4-5');
+CREATE RESOURCE GROUP rg_test_group WITH (cpuset='0;0-1');
 CREATE
 SELECT groupname,concurrency,cpu_rate_limit,memory_limit,memory_shared_quota,memory_spill_ratio FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_test_group';
  groupname     | concurrency | cpu_rate_limit | memory_limit | memory_shared_quota | memory_spill_ratio 
@@ -645,15 +641,5 @@ CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, me
 CREATE
 ALTER RESOURCE GROUP rg_test_group SET memory_limit 0;
 ERROR:  when memory_limit is unlimited memory_spill_ratio must be set to 0
-DROP RESOURCE GROUP rg_test_group;
-DROP
-
--- positive: test master/segment cpuset
-CREATE RESOURCE GROUP rg_test_group WITH (cpuset='1;4-5');
-CREATE
-ALTER RESOURCE GROUP rg_test_group SET CPUSET '2;4-5';
-ALTER
-ALTER RESOURCE GROUP rg_test_group SET CPUSET '3;4-5';
-ALTER
 DROP RESOURCE GROUP rg_test_group;
 DROP

--- a/src/test/isolation2/expected/resgroup/resgroup_syntax.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_syntax.out
@@ -152,6 +152,17 @@ CREATE RESOURCE GROUP rg_test_group WITH (cpuset='3-1', memory_limit=5);
 ERROR:  cpuset invalid
 CREATE RESOURCE GROUP rg_test_group WITH (cpuset=' 0 ', memory_limit=5);
 ERROR:  cpuset invalid
+CREATE RESOURCE GROUP rg_test_group WITH (cpuset='0;3-1', memory_limit=5);
+ERROR:  cpuset invalid
+CREATE RESOURCE GROUP rg_test_group WITH (cpuset='4;a', memory_limit=5);
+ERROR:  cpuset invalid
+CREATE RESOURCE GROUP rg_test_group WITH (cpuset='-;4', memory_limit=5);
+ERROR:  cpuset invalid
+CREATE RESOURCE GROUP rg_test_group WITH (cpuset=';5', memory_limit=5);
+ERROR:  cpuset invalid
+CREATE RESOURCE GROUP rg_test_group WITH (cpuset='5;', memory_limit=5);
+ERROR:  cpuset invalid
+
 ---- suppose the core numbered 1024 is not exist
 CREATE RESOURCE GROUP rg_test_group WITH (cpuset='1024', memory_limit=5);
 ERROR:  cpu cores 1024 are unavailable on the system
@@ -177,6 +188,22 @@ ERROR:  cpuset invalid
 ALTER RESOURCE GROUP rg_test_group set CPUSET '3-1';
 ERROR:  cpuset invalid
 ALTER RESOURCE GROUP rg_test_group set CPUSET ' 0 ';
+ERROR:  cpuset invalid
+ALTER RESOURCE GROUP rg_test_group set CPUSET '5;3-1';
+ERROR:  cpuset invalid
+ALTER RESOURCE GROUP rg_test_group set CPUSET '4;a';
+ERROR:  cpuset invalid
+ALTER RESOURCE GROUP rg_test_group set CPUSET '-;4';
+ERROR:  cpuset invalid
+ALTER RESOURCE GROUP rg_test_group set CPUSET ';5';
+ERROR:  cpuset invalid
+ALTER RESOURCE GROUP rg_test_group set CPUSET '5;';
+ERROR:  cpuset invalid
+ALTER RESOURCE GROUP rg_test_group set CPUSET ';';
+ERROR:  cpuset invalid
+ALTER RESOURCE GROUP rg_test_group set CPUSET '1;2;';
+ERROR:  cpuset invalid
+ALTER RESOURCE GROUP rg_test_group set CPUSET '1;2;3';
 ERROR:  cpuset invalid
 ---- suppose the core numbered 1024 is not exist
 ALTER RESOURCE GROUP rg_test_group set CPUSET '1024';
@@ -233,7 +260,15 @@ SELECT groupname,concurrency,cpu_rate_limit,memory_limit,memory_shared_quota,mem
 (1 row)
 DROP RESOURCE GROUP rg_test_group;
 DROP
-
+CREATE RESOURCE GROUP rg_test_group WITH (cpuset='1;4-5');
+CREATE
+SELECT groupname,concurrency,cpu_rate_limit,memory_limit,memory_shared_quota,memory_spill_ratio FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_test_group';
+ groupname     | concurrency | cpu_rate_limit | memory_limit | memory_shared_quota | memory_spill_ratio 
+---------------+-------------+----------------+--------------+---------------------+--------------------
+ rg_test_group | 20          | -1             | 0            | 80                  | 0                  
+(1 row)
+DROP RESOURCE GROUP rg_test_group;
+DROP
 -- ----------------------------------------------------------------------
 -- Test: boundary check in create resource group syntax
 -- ----------------------------------------------------------------------
@@ -610,5 +645,15 @@ CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, me
 CREATE
 ALTER RESOURCE GROUP rg_test_group SET memory_limit 0;
 ERROR:  when memory_limit is unlimited memory_spill_ratio must be set to 0
+DROP RESOURCE GROUP rg_test_group;
+DROP
+
+-- positive: test master/segment cpuset
+CREATE RESOURCE GROUP rg_test_group WITH (cpuset='1;4-5');
+CREATE
+ALTER RESOURCE GROUP rg_test_group SET CPUSET '2;4-5';
+ALTER
+ALTER RESOURCE GROUP rg_test_group SET CPUSET '3;4-5';
+ALTER
 DROP RESOURCE GROUP rg_test_group;
 DROP

--- a/src/test/isolation2/input/resgroup/resgroup_cpuset.source
+++ b/src/test/isolation2/input/resgroup/resgroup_cpuset.source
@@ -293,6 +293,25 @@ SELECT gp_inject_fault('create_resource_group_fail', 'reset', 1);
 DROP RESOURCE GROUP rg1_test_group;
 -- end_ignore
 
+-- test segment/master cpuset
+CREATE RESOURCE GROUP rg_multi_cpuset1 WITH (concurrency=2, cpuset='0;1-2');
+
+CREATE RESOURCE GROUP rg_multi_cpuset WITH (concurrency=2, cpuset='0;1-2');
+CREATE RESOURCE GROUP rg_multi_cpuset WITH (concurrency=2, cpuset='0');
+
+CREATE RESOURCE GROUP rg_multi_cpuset2 WITH (concurrency=2, cpuset='3;4-5');
+
+ALTER RESOURCE GROUP rg_multi_cpuset2 set CPUSET '0;1-3';
+ALTER RESOURCE GROUP rg_multi_cpuset2 set CPUSET '6';
+ALTER RESOURCE GROUP rg_multi_cpuset1 set CPUSET '3;4-5';
+ALTER RESOURCE GROUP rg_multi_cpuset2 set CPUSET '0;1-2';
+
+select groupname,cpuset from gp_toolkit.gp_resgroup_config where groupname='rg_multi_cpuset1';
+select groupname,cpuset from gp_toolkit.gp_resgroup_config where groupname='rg_multi_cpuset2';
+
+DROP RESOURCE GROUP rg_multi_cpuset1;
+DROP RESOURCE GROUP rg_multi_cpuset2;
+
 REVOKE ALL ON busy FROM role1_cpuset_test;
 DROP ROLE role1_cpuset_test;
 DROP RESOURCE GROUP rg1_cpuset_test;

--- a/src/test/isolation2/input/resgroup/resgroup_cpuset.source
+++ b/src/test/isolation2/input/resgroup/resgroup_cpuset.source
@@ -294,23 +294,11 @@ DROP RESOURCE GROUP rg1_test_group;
 -- end_ignore
 
 -- test segment/master cpuset
-CREATE RESOURCE GROUP rg_multi_cpuset1 WITH (concurrency=2, cpuset='0;1-2');
-
-CREATE RESOURCE GROUP rg_multi_cpuset WITH (concurrency=2, cpuset='0;1-2');
-CREATE RESOURCE GROUP rg_multi_cpuset WITH (concurrency=2, cpuset='0');
-
-CREATE RESOURCE GROUP rg_multi_cpuset2 WITH (concurrency=2, cpuset='3;4-5');
-
-ALTER RESOURCE GROUP rg_multi_cpuset2 set CPUSET '0;1-3';
-ALTER RESOURCE GROUP rg_multi_cpuset2 set CPUSET '6';
-ALTER RESOURCE GROUP rg_multi_cpuset1 set CPUSET '3;4-5';
-ALTER RESOURCE GROUP rg_multi_cpuset2 set CPUSET '0;1-2';
-
+CREATE RESOURCE GROUP rg_multi_cpuset1 WITH (concurrency=2, cpuset='0;0');
+ALTER RESOURCE GROUP rg_multi_cpuset1 set CPUSET '1;1';
 select groupname,cpuset from gp_toolkit.gp_resgroup_config where groupname='rg_multi_cpuset1';
-select groupname,cpuset from gp_toolkit.gp_resgroup_config where groupname='rg_multi_cpuset2';
 
 DROP RESOURCE GROUP rg_multi_cpuset1;
-DROP RESOURCE GROUP rg_multi_cpuset2;
 
 REVOKE ALL ON busy FROM role1_cpuset_test;
 DROP ROLE role1_cpuset_test;

--- a/src/test/isolation2/output/resgroup/resgroup_cpuset.source
+++ b/src/test/isolation2/output/resgroup/resgroup_cpuset.source
@@ -289,6 +289,43 @@ SELECT gp_inject_fault('create_resource_group_fail', 'reset', 1);
  Success:        
 (1 row)
 
+-- test segment/master cpuset
+CREATE RESOURCE GROUP rg_multi_cpuset1 WITH (concurrency=2, cpuset='0;1-2');
+CREATE
+
+CREATE RESOURCE GROUP rg_multi_cpuset WITH (concurrency=2, cpuset='0;1-2');
+ERROR:  cpu cores 0 are used by resource group rg_multi_cpuset1
+CREATE RESOURCE GROUP rg_multi_cpuset WITH (concurrency=2, cpuset='0');
+ERROR:  cpu cores 0 are used by resource group rg_multi_cpuset1
+
+CREATE RESOURCE GROUP rg_multi_cpuset2 WITH (concurrency=2, cpuset='3;4-5');
+CREATE
+
+ALTER RESOURCE GROUP rg_multi_cpuset2 set CPUSET '0;1-3';
+ERROR:  cpu cores 0 are used by resource group rg_multi_cpuset1
+ALTER RESOURCE GROUP rg_multi_cpuset2 set CPUSET '6';
+ALTER
+ALTER RESOURCE GROUP rg_multi_cpuset1 set CPUSET '3;4-5';
+ALTER
+ALTER RESOURCE GROUP rg_multi_cpuset2 set CPUSET '0;1-2';
+ALTER
+
+select groupname,cpuset from gp_toolkit.gp_resgroup_config where groupname='rg_multi_cpuset1';
+ groupname        | cpuset 
+------------------+--------
+ rg_multi_cpuset1 | 3;4-5  
+(1 row)
+select groupname,cpuset from gp_toolkit.gp_resgroup_config where groupname='rg_multi_cpuset2';
+ groupname        | cpuset 
+------------------+--------
+ rg_multi_cpuset2 | 0;1-2  
+(1 row)
+
+DROP RESOURCE GROUP rg_multi_cpuset1;
+DROP
+DROP RESOURCE GROUP rg_multi_cpuset2;
+DROP
+
 REVOKE ALL ON busy FROM role1_cpuset_test;
 REVOKE
 DROP ROLE role1_cpuset_test;

--- a/src/test/isolation2/output/resgroup/resgroup_cpuset.source
+++ b/src/test/isolation2/output/resgroup/resgroup_cpuset.source
@@ -290,40 +290,17 @@ SELECT gp_inject_fault('create_resource_group_fail', 'reset', 1);
 (1 row)
 
 -- test segment/master cpuset
-CREATE RESOURCE GROUP rg_multi_cpuset1 WITH (concurrency=2, cpuset='0;1-2');
+CREATE RESOURCE GROUP rg_multi_cpuset1 WITH (concurrency=2, cpuset='0;0');
 CREATE
-
-CREATE RESOURCE GROUP rg_multi_cpuset WITH (concurrency=2, cpuset='0;1-2');
-ERROR:  cpu cores 0 are used by resource group rg_multi_cpuset1
-CREATE RESOURCE GROUP rg_multi_cpuset WITH (concurrency=2, cpuset='0');
-ERROR:  cpu cores 0 are used by resource group rg_multi_cpuset1
-
-CREATE RESOURCE GROUP rg_multi_cpuset2 WITH (concurrency=2, cpuset='3;4-5');
-CREATE
-
-ALTER RESOURCE GROUP rg_multi_cpuset2 set CPUSET '0;1-3';
-ERROR:  cpu cores 0 are used by resource group rg_multi_cpuset1
-ALTER RESOURCE GROUP rg_multi_cpuset2 set CPUSET '6';
+ALTER RESOURCE GROUP rg_multi_cpuset1 set CPUSET '1;1';
 ALTER
-ALTER RESOURCE GROUP rg_multi_cpuset1 set CPUSET '3;4-5';
-ALTER
-ALTER RESOURCE GROUP rg_multi_cpuset2 set CPUSET '0;1-2';
-ALTER
-
 select groupname,cpuset from gp_toolkit.gp_resgroup_config where groupname='rg_multi_cpuset1';
  groupname        | cpuset 
 ------------------+--------
- rg_multi_cpuset1 | 3;4-5  
-(1 row)
-select groupname,cpuset from gp_toolkit.gp_resgroup_config where groupname='rg_multi_cpuset2';
- groupname        | cpuset 
-------------------+--------
- rg_multi_cpuset2 | 0;1-2  
+ rg_multi_cpuset1 | 1;1    
 (1 row)
 
 DROP RESOURCE GROUP rg_multi_cpuset1;
-DROP
-DROP RESOURCE GROUP rg_multi_cpuset2;
 DROP
 
 REVOKE ALL ON busy FROM role1_cpuset_test;

--- a/src/test/isolation2/sql/resgroup/resgroup_syntax.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_syntax.sql
@@ -77,6 +77,12 @@ CREATE RESOURCE GROUP rg_test_group WITH (cpuset='0-,', memory_limit=5);
 CREATE RESOURCE GROUP rg_test_group WITH (cpuset='-1', memory_limit=5);
 CREATE RESOURCE GROUP rg_test_group WITH (cpuset='3-1', memory_limit=5);
 CREATE RESOURCE GROUP rg_test_group WITH (cpuset=' 0 ', memory_limit=5);
+CREATE RESOURCE GROUP rg_test_group WITH (cpuset='0;3-1', memory_limit=5);
+CREATE RESOURCE GROUP rg_test_group WITH (cpuset='4;a', memory_limit=5);
+CREATE RESOURCE GROUP rg_test_group WITH (cpuset='-;4', memory_limit=5);
+CREATE RESOURCE GROUP rg_test_group WITH (cpuset=';5', memory_limit=5);
+CREATE RESOURCE GROUP rg_test_group WITH (cpuset='5;', memory_limit=5);
+
 ---- suppose the core numbered 1024 is not exist
 CREATE RESOURCE GROUP rg_test_group WITH (cpuset='1024', memory_limit=5);
 CREATE RESOURCE GROUP rg_test_group WITH (cpuset='0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,', memory_limit=5);
@@ -91,6 +97,14 @@ ALTER RESOURCE GROUP rg_test_group set CPUSET '0-';
 ALTER RESOURCE GROUP rg_test_group set CPUSET '-1';
 ALTER RESOURCE GROUP rg_test_group set CPUSET '3-1';
 ALTER RESOURCE GROUP rg_test_group set CPUSET ' 0 ';
+ALTER RESOURCE GROUP rg_test_group set CPUSET '5;3-1';
+ALTER RESOURCE GROUP rg_test_group set CPUSET '4;a';
+ALTER RESOURCE GROUP rg_test_group set CPUSET '-;4';
+ALTER RESOURCE GROUP rg_test_group set CPUSET ';5';
+ALTER RESOURCE GROUP rg_test_group set CPUSET '5;';
+ALTER RESOURCE GROUP rg_test_group set CPUSET ';';
+ALTER RESOURCE GROUP rg_test_group set CPUSET '1;2;';
+ALTER RESOURCE GROUP rg_test_group set CPUSET '1;2;3';
 ---- suppose the core numbered 1024 is not exist
 ALTER RESOURCE GROUP rg_test_group set CPUSET '1024';
 ALTER RESOURCE GROUP rg_test_group set CPUSET '0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,';
@@ -115,7 +129,10 @@ DROP RESOURCE GROUP rg_test_group;
 CREATE RESOURCE GROUP rg_test_group WITH (cpuset='0');
 SELECT groupname,concurrency,cpu_rate_limit,memory_limit,memory_shared_quota,memory_spill_ratio FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_test_group';
 DROP RESOURCE GROUP rg_test_group;
-
+CREATE RESOURCE GROUP rg_test_group WITH (cpuset='1;4-5');
+SELECT groupname,concurrency,cpu_rate_limit,memory_limit,memory_shared_quota,memory_spill_ratio
+FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_test_group';
+DROP RESOURCE GROUP rg_test_group;
 -- ----------------------------------------------------------------------
 -- Test: boundary check in create resource group syntax
 -- ----------------------------------------------------------------------
@@ -318,4 +335,10 @@ DROP RESOURCE GROUP rg_test_group;
 -- negative: memory_limit must be limited if memory_spill_ratio > 0
 CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio=10);
 ALTER RESOURCE GROUP rg_test_group SET memory_limit 0;
+DROP RESOURCE GROUP rg_test_group;
+
+-- positive: test master/segment cpuset
+CREATE RESOURCE GROUP rg_test_group WITH (cpuset='1;4-5');
+ALTER RESOURCE GROUP rg_test_group SET CPUSET '2;4-5';
+ALTER RESOURCE GROUP rg_test_group SET CPUSET '3;4-5';
 DROP RESOURCE GROUP rg_test_group;

--- a/src/test/isolation2/sql/resgroup/resgroup_syntax.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_syntax.sql
@@ -77,7 +77,6 @@ CREATE RESOURCE GROUP rg_test_group WITH (cpuset='0-,', memory_limit=5);
 CREATE RESOURCE GROUP rg_test_group WITH (cpuset='-1', memory_limit=5);
 CREATE RESOURCE GROUP rg_test_group WITH (cpuset='3-1', memory_limit=5);
 CREATE RESOURCE GROUP rg_test_group WITH (cpuset=' 0 ', memory_limit=5);
-CREATE RESOURCE GROUP rg_test_group WITH (cpuset='0;3-1', memory_limit=5);
 CREATE RESOURCE GROUP rg_test_group WITH (cpuset='4;a', memory_limit=5);
 CREATE RESOURCE GROUP rg_test_group WITH (cpuset='-;4', memory_limit=5);
 CREATE RESOURCE GROUP rg_test_group WITH (cpuset=';5', memory_limit=5);
@@ -97,7 +96,6 @@ ALTER RESOURCE GROUP rg_test_group set CPUSET '0-';
 ALTER RESOURCE GROUP rg_test_group set CPUSET '-1';
 ALTER RESOURCE GROUP rg_test_group set CPUSET '3-1';
 ALTER RESOURCE GROUP rg_test_group set CPUSET ' 0 ';
-ALTER RESOURCE GROUP rg_test_group set CPUSET '5;3-1';
 ALTER RESOURCE GROUP rg_test_group set CPUSET '4;a';
 ALTER RESOURCE GROUP rg_test_group set CPUSET '-;4';
 ALTER RESOURCE GROUP rg_test_group set CPUSET ';5';
@@ -129,7 +127,7 @@ DROP RESOURCE GROUP rg_test_group;
 CREATE RESOURCE GROUP rg_test_group WITH (cpuset='0');
 SELECT groupname,concurrency,cpu_rate_limit,memory_limit,memory_shared_quota,memory_spill_ratio FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_test_group';
 DROP RESOURCE GROUP rg_test_group;
-CREATE RESOURCE GROUP rg_test_group WITH (cpuset='1;4-5');
+CREATE RESOURCE GROUP rg_test_group WITH (cpuset='0;0-1');
 SELECT groupname,concurrency,cpu_rate_limit,memory_limit,memory_shared_quota,memory_spill_ratio
 FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_test_group';
 DROP RESOURCE GROUP rg_test_group;
@@ -335,10 +333,4 @@ DROP RESOURCE GROUP rg_test_group;
 -- negative: memory_limit must be limited if memory_spill_ratio > 0
 CREATE RESOURCE GROUP rg_test_group WITH (cpu_rate_limit=10, memory_limit=10, memory_spill_ratio=10);
 ALTER RESOURCE GROUP rg_test_group SET memory_limit 0;
-DROP RESOURCE GROUP rg_test_group;
-
--- positive: test master/segment cpuset
-CREATE RESOURCE GROUP rg_test_group WITH (cpuset='1;4-5');
-ALTER RESOURCE GROUP rg_test_group SET CPUSET '2;4-5';
-ALTER RESOURCE GROUP rg_test_group SET CPUSET '3;4-5';
 DROP RESOURCE GROUP rg_test_group;


### PR DESCRIPTION
New SYNTAX of resource group cpuset for different master and segment
Using syntax like cpuset="1;3-4" could different cpuset of master and segment by semicolon.  For example,
if we define cpuset="1;3-4", then master will use the first  cpu core, segments will use third  and fourth core.

CREATE and ALTER resource group support this new syntax.
```
postgres=# CREATE RESOURCE GROUP rg1 WITH (cpuset='1;2-3');
CREATE RESOURCE GROUP
postgres=# select groupname, cpuset from gp_toolkit.gp_resgroup_config where groupname = 'rg1';
 groupname | cpuset 
-----------+--------
 rg1       | 1;2-3
(1 row)

postgres=# ALTER resource group rg1 SET cpuset '4;5-6';
ALTER RESOURCE GROUP
postgres=# select groupname, cpuset from gp_toolkit.gp_resgroup_config where groupname = 'rg1';
 groupname | cpuset 
-----------+--------
 rg1       | 4;5-6
(1 row)
```

we didn't make too much motification on Resource group. For differentiate on mater and segment, seperating cpuset by semicolon, then apply the first half of it to master and second half to segment.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
