### PR TITLE
[6X] Always add 'true' to 'appendonly'/'appendoptimized' reloptions

### DIFF
--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -3193,7 +3193,16 @@ reloption_elem:
 				}
 			| ColLabel
 				{
-					$$ = makeDefElem($1, NULL);
+					/*
+					 * Similarly to the above, translate 'appendoptimized' to
+					 * 'appendonly'. Also, adding the implicit 'true' in case 
+					 * we don't handle that properly in parse analysis.
+					 * See: https://github.com/greenplum-db/gpdb/issues/14510.
+					 */
+					if (strcmp($1, "appendonly") == 0 || strcmp($1, "appendoptimized") == 0)
+						$$ = makeDefElem("appendonly", (Node *) makeString(pstrdup("true")));
+					else
+						$$ = makeDefElem($1, NULL);
 				}
 			| ColLabel '.' ColLabel '=' def_arg
 				{

--- a/src/test/regress/input/aocs.source
+++ b/src/test/regress/input/aocs.source
@@ -46,21 +46,23 @@ CREATE TABLE tenk_aocs3 (like tenk_heap_for_aocs) with (appendonly=true, orienta
 CREATE TABLE tenk_aocs4 (like tenk_heap_for_aocs) with (appendonly=true, orientation=column, compresslevel=1, compresstype=zlib) distributed by(unique1);
 CREATE TABLE tenk_aocs5 (like tenk_heap_for_aocs) with (appendonly=true, orientation=column, compresslevel=6, compresstype=zlib) distributed by(unique1);
 CREATE TABLE tenk_aocs6 (like tenk_heap_for_aocs) with (appendonly=true, orientation=column, compresslevel=6, compresstype=zlib, blocksize=1048576, checksum=true) distributed by(unique1);
+CREATE TABLE tenk_aocs7 (like tenk_heap_for_aocs) with (appendonly, orientation=column, compresslevel=6, checksum) distributed by(unique1);
+CREATE TABLE tenk_aocs8 (like tenk_heap_for_aocs) with (appendoptimized, orientation=column, compresslevel=6, checksum) distributed by(unique1);
 -- invalid combinations
 -- col instead of column
-CREATE TABLE tenk_aocs7 (like tenk_heap_for_aocs) with (appendonly=true, orientation=col) distributed by(unique1);
+CREATE TABLE tenk_aocs_bad (like tenk_heap_for_aocs) with (appendonly=true, orientation=col) distributed by(unique1);
 -- no parentheses surrounding storage options
-CREATE TABLE tenk_aocs8 (like tenk_heap_for_aocs) with appendonly=true, orientation=column distributed by(unique1);
+CREATE TABLE tenk_aocs_bad (like tenk_heap_for_aocs) with appendonly=true, orientation=column distributed by(unique1);
 -- no comma separating storage options
-CREATE TABLE tenk_aocs9 (like tenk_heap_for_aocs) with (appendonly=true orientation=column) distributed by(unique1);
+CREATE TABLE tenk_aocs_bad (like tenk_heap_for_aocs) with (appendonly=true orientation=column) distributed by(unique1);
 -- appendonly=false with orientation=column should not work
-CREATE TABLE tenk_aocs10 (like tenk_heap_for_aocs) with (appendonly=false, orientation=column, compresslevel=6, checksum=true) distributed by(unique1);
+CREATE TABLE tenk_aocs_bad (like tenk_heap_for_aocs) with (appendonly=false, orientation=column, compresslevel=6, checksum=true) distributed by(unique1);
 -- block size must be between 8KB and 2MB w/ 8KB multiple
-CREATE TABLE tenk_aocs11 (like tenk_heap_for_aocs) with (appendonly=true, orientation=column, blocksize=100) distributed by(unique1);
+CREATE TABLE tenk_aocs_bad (like tenk_heap_for_aocs) with (appendonly=true, orientation=column, blocksize=100) distributed by(unique1);
 -- cannot have compresslevel 0
-CREATE TABLE tenk_aocs12 (like tenk_heap_for_aocs) with (appendonly=true, orientation=column, compresslevel=0, compresstype=zlib) distributed by(unique1);
+CREATE TABLE tenk_aocs_bad (like tenk_heap_for_aocs) with (appendonly=true, orientation=column, compresslevel=0, compresstype=zlib) distributed by(unique1);
 -- orientation=column must be combined with appendonly=true
-CREATE TABLE tenk_aocs13 (like tenk_heap_for_aocs) with (orientation=column) distributed by(unique1);
+CREATE TABLE tenk_aocs_bad (like tenk_heap_for_aocs) with (orientation=column) distributed by(unique1);
 
 
 --------------------
@@ -69,6 +71,7 @@ CREATE TABLE tenk_aocs13 (like tenk_heap_for_aocs) with (orientation=column) dis
 
 -- check pg_appendonly
 SELECT c.relname, a.blocksize, a.compresstype, a.compresslevel, a.checksum FROM pg_class c, pg_appendonly a WHERE c.relname LIKE 'tenk_aocs%' AND c.oid=a.relid ORDER BY c.relname;
+SELECT c.relname, count(a.attnum) FROM pg_attribute_encoding a, pg_class c WHERE a.attrelid=c.oid AND c.relname LIKE 'tenk_aocs%' GROUP BY c.relname;
 
 --------------------
 -- supported sql

--- a/src/test/regress/output/aocs.source
+++ b/src/test/regress/output/aocs.source
@@ -42,33 +42,35 @@ CREATE TABLE tenk_aocs3 (like tenk_heap_for_aocs) with (appendonly=true, orienta
 CREATE TABLE tenk_aocs4 (like tenk_heap_for_aocs) with (appendonly=true, orientation=column, compresslevel=1, compresstype=zlib) distributed by(unique1);
 CREATE TABLE tenk_aocs5 (like tenk_heap_for_aocs) with (appendonly=true, orientation=column, compresslevel=6, compresstype=zlib) distributed by(unique1);
 CREATE TABLE tenk_aocs6 (like tenk_heap_for_aocs) with (appendonly=true, orientation=column, compresslevel=6, compresstype=zlib, blocksize=1048576, checksum=true) distributed by(unique1);
+CREATE TABLE tenk_aocs7 (like tenk_heap_for_aocs) with (appendonly, orientation=column, compresslevel=6, checksum) distributed by(unique1);
+CREATE TABLE tenk_aocs8 (like tenk_heap_for_aocs) with (appendoptimized, orientation=column, compresslevel=6, checksum) distributed by(unique1);
 -- invalid combinations
 -- col instead of column
-CREATE TABLE tenk_aocs7 (like tenk_heap_for_aocs) with (appendonly=true, orientation=col) distributed by(unique1);
+CREATE TABLE tenk_aocs_bad (like tenk_heap_for_aocs) with (appendonly=true, orientation=col) distributed by(unique1);
 ERROR:  invalid parameter value for "orientation": "col"
 -- no parentheses surrounding storage options
-CREATE TABLE tenk_aocs8 (like tenk_heap_for_aocs) with appendonly=true, orientation=column distributed by(unique1);
+CREATE TABLE tenk_aocs_bad (like tenk_heap_for_aocs) with appendonly=true, orientation=column distributed by(unique1);
 ERROR:  syntax error at or near "appendonly"
-LINE 1: ...E TABLE tenk_aocs8 (like tenk_heap_for_aocs) with appendonly...
+LINE 1: ...ABLE tenk_aocs_bad (like tenk_heap_for_aocs) with appendonly...
                                                              ^
 -- no comma separating storage options
-CREATE TABLE tenk_aocs9 (like tenk_heap_for_aocs) with (appendonly=true orientation=column) distributed by(unique1);
+CREATE TABLE tenk_aocs_bad (like tenk_heap_for_aocs) with (appendonly=true orientation=column) distributed by(unique1);
 ERROR:  syntax error at or near "orientation"
-LINE 1: ...9 (like tenk_heap_for_aocs) with (appendonly=true orientatio...
+LINE 1: ...d (like tenk_heap_for_aocs) with (appendonly=true orientatio...
                                                              ^
 -- appendonly=false with orientation=column should not work
-CREATE TABLE tenk_aocs10 (like tenk_heap_for_aocs) with (appendonly=false, orientation=column, compresslevel=6, checksum=true) distributed by(unique1);
+CREATE TABLE tenk_aocs_bad (like tenk_heap_for_aocs) with (appendonly=false, orientation=column, compresslevel=6, checksum=true) distributed by(unique1);
 ERROR:  invalid option "compresslevel" for base relation
 HINT:  Compression only valid for Append Only relations, create an AO relation to use compression.
 -- block size must be between 8KB and 2MB w/ 8KB multiple
-CREATE TABLE tenk_aocs11 (like tenk_heap_for_aocs) with (appendonly=true, orientation=column, blocksize=100) distributed by(unique1);
+CREATE TABLE tenk_aocs_bad (like tenk_heap_for_aocs) with (appendonly=true, orientation=column, blocksize=100) distributed by(unique1);
 ERROR:  value 100 out of bounds for option "blocksize"
 DETAIL:  Valid values are between "8192" and "2097152".
 -- cannot have compresslevel 0
-CREATE TABLE tenk_aocs12 (like tenk_heap_for_aocs) with (appendonly=true, orientation=column, compresslevel=0, compresstype=zlib) distributed by(unique1);
+CREATE TABLE tenk_aocs_bad (like tenk_heap_for_aocs) with (appendonly=true, orientation=column, compresslevel=0, compresstype=zlib) distributed by(unique1);
 ERROR:  compresstype "zlib" can't be used with compresslevel 0
 -- orientation=column must be combined with appendonly=true
-CREATE TABLE tenk_aocs13 (like tenk_heap_for_aocs) with (orientation=column) distributed by(unique1);
+CREATE TABLE tenk_aocs_bad (like tenk_heap_for_aocs) with (orientation=column) distributed by(unique1);
 ERROR:  invalid option "orientation" for base relation
 HINT:  Table orientation only valid for Append Only relations, create an AO relation to use table orientation.
 --------------------
@@ -84,7 +86,22 @@ SELECT c.relname, a.blocksize, a.compresstype, a.compresslevel, a.checksum FROM 
  tenk_aocs4 |     32768 | zlib         |             1 | t
  tenk_aocs5 |     32768 | zlib         |             6 | t
  tenk_aocs6 |   1048576 | zlib         |             6 | t
-(6 rows)
+ tenk_aocs7 |     32768 | zlib         |             6 | t
+ tenk_aocs8 |     32768 | zlib         |             6 | t
+(8 rows)
+
+SELECT c.relname, count(a.attnum) FROM pg_attribute_encoding a, pg_class c WHERE a.attrelid=c.oid AND c.relname LIKE 'tenk_aocs%' GROUP BY c.relname;
+  relname   | count 
+------------+-------
+ tenk_aocs1 |    16
+ tenk_aocs2 |    16
+ tenk_aocs3 |    16
+ tenk_aocs4 |    16
+ tenk_aocs5 |    16
+ tenk_aocs6 |    16
+ tenk_aocs7 |    16
+ tenk_aocs8 |    16
+(8 rows)
 
 --------------------
 -- supported sql
@@ -396,7 +413,9 @@ SELECT c.relname, a.blocksize, a.compresstype, a.compresslevel, a.checksum FROM 
  tenk_aocs4 |     32768 | zlib         |             1 | t
  tenk_aocs5 |     32768 | zlib         |             6 | t
  tenk_aocs6 |   1048576 | zlib         |             6 | t
-(6 rows)
+ tenk_aocs7 |     32768 | zlib         |             6 | t
+ tenk_aocs8 |     32768 | zlib         |             6 | t
+(8 rows)
 
 SELECT count(*) FROM tenk_aocs1;
  count 


### PR DESCRIPTION
Fix issue #14510. Always passing the implicit 'true' argument for 'appendonly' or 'appendoptimized' in case they are not handled properly anywhere in parse analysis.

Note that, we might also fix transofrmCreateStmt->is_aocs but we choose to not touch anywhere else in code. is_aocs() will be gone in 7X anyway.

The 7X PR: https://github.com/greenplum-db/gpdb/pull/14519 which just adds test coverage.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
