### PR TITLE
If QEs hit errors in explain analyze, rethrow the error before ExplainPrintPlan

### DIFF
--- a/src/backend/executor/nodeSort.c
+++ b/src/backend/executor/nodeSort.c
@@ -59,6 +59,7 @@ ExecSort(PlanState *pstate)
 
 	CHECK_FOR_INTERRUPTS();
 
+	SIMPLE_FAULT_INJECTOR("explain_analyze_sort_error");
 	/*
 	 * get state info from node
 	 */

--- a/src/test/regress/expected/explain_analyze.out
+++ b/src/test/regress/expected/explain_analyze.out
@@ -40,3 +40,41 @@ EXPLAIN (ANALYZE, TIMING OFF, COSTS OFF, SUMMARY OFF) SELECT t1.a FROM empty_tab
 (7 rows)
 
 -- explain_processing_on
+-- If all QEs hit errors when executing sort, we might not receive stat data for sort.
+-- rethrow error before print explain info.
+create extension if not exists gp_inject_fault;
+create table sort_error_test1(tc1 int, tc2 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'tc1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table sort_error_test2(tc1 int, tc2 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'tc1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into sort_error_test1 select i,i from generate_series(1,20) i;
+select gp_inject_fault('explain_analyze_sort_error', 'error', dbid)
+    from gp_segment_configuration where role = 'p' and content > -1;
+ gp_inject_fault 
+-----------------
+ Success:
+ Success:
+ Success:
+(3 rows)
+
+EXPLAIN analyze insert into sort_error_test2 select * from sort_error_test1 order by 1;
+ERROR:  fault triggered, fault name:'explain_analyze_sort_error' fault type:'error'  (seg1 127.0.1.1:7003 pid=103595)
+select count(*) from sort_error_test2;
+ count 
+-------
+     0
+(1 row)
+
+select gp_inject_fault('explain_analyze_sort_error', 'reset', dbid)
+    from gp_segment_configuration where role = 'p' and content > -1;
+ gp_inject_fault 
+-----------------
+ Success:
+ Success:
+ Success:
+(3 rows)
+
+drop table sort_error_test1;
+drop table sort_error_test2;

--- a/src/test/regress/expected/explain_analyze_optimizer.out
+++ b/src/test/regress/expected/explain_analyze_optimizer.out
@@ -41,3 +41,41 @@ EXPLAIN (ANALYZE, TIMING OFF, COSTS OFF, SUMMARY OFF) SELECT t1.a FROM empty_tab
 (8 rows)
 
 -- explain_processing_on
+-- If all QEs hit errors when executing sort, we might not receive stat data for sort.
+-- rethrow error before print explain info.
+create extension if not exists gp_inject_fault;
+create table sort_error_test1(tc1 int, tc2 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'tc1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table sort_error_test2(tc1 int, tc2 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'tc1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into sort_error_test1 select i,i from generate_series(1,20) i;
+select gp_inject_fault('explain_analyze_sort_error', 'error', dbid)
+    from gp_segment_configuration where role = 'p' and content > -1;
+ gp_inject_fault 
+-----------------
+ Success:
+ Success:
+ Success:
+(3 rows)
+
+EXPLAIN analyze insert into sort_error_test2 select * from sort_error_test1 order by 1;
+ERROR:  fault triggered, fault name:'explain_analyze_sort_error' fault type:'error'  (seg0 127.0.1.1:7002 pid=103209)
+select count(*) from sort_error_test2;
+ count 
+-------
+     0
+(1 row)
+
+select gp_inject_fault('explain_analyze_sort_error', 'reset', dbid)
+    from gp_segment_configuration where role = 'p' and content > -1;
+ gp_inject_fault 
+-----------------
+ Success:
+ Success:
+ Success:
+(3 rows)
+
+drop table sort_error_test1;
+drop table sort_error_test2;

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -59,8 +59,9 @@ test: leastsquares opr_sanity_gp decode_expr bitmapscan bitmapscan_ao case_gp li
 test: gpcopy
 
 test: orca_static_pruning orca_groupingsets_fallbacks
-test: filter gpctas gpdist gpdist_opclasses gpdist_legacy_opclasses matrix sublink table_functions olap_setup complex opclass_ddl information_schema guc_env_var gp_explain distributed_transactions explain_format olap_plans gp_copy_dtx explain_analyze
+test: filter gpctas gpdist gpdist_opclasses gpdist_legacy_opclasses matrix sublink table_functions olap_setup complex opclass_ddl information_schema guc_env_var gp_explain distributed_transactions explain_format olap_plans gp_copy_dtx
 # below test(s) inject faults so each of them need to be in a separate group
+test: explain_analyze
 test: guc_gp
 test: toast
 test: misc_jiras

--- a/src/test/regress/sql/explain_analyze.sql
+++ b/src/test/regress/sql/explain_analyze.sql
@@ -22,3 +22,18 @@ EXPLAIN (ANALYZE, TIMING OFF, COSTS OFF, SUMMARY OFF) SELECT a FROM empty_table;
 -- explain_processing_off
 EXPLAIN (ANALYZE, TIMING OFF, COSTS OFF, SUMMARY OFF) SELECT t1.a FROM empty_table t1 join empty_table t2 on t1.a = t2.a;
 -- explain_processing_on
+
+-- If all QEs hit errors when executing sort, we might not receive stat data for sort.
+-- rethrow error before print explain info.
+create extension if not exists gp_inject_fault;
+create table sort_error_test1(tc1 int, tc2 int);
+create table sort_error_test2(tc1 int, tc2 int);
+insert into sort_error_test1 select i,i from generate_series(1,20) i;
+select gp_inject_fault('explain_analyze_sort_error', 'error', dbid)
+    from gp_segment_configuration where role = 'p' and content > -1;
+EXPLAIN analyze insert into sort_error_test2 select * from sort_error_test1 order by 1;
+select count(*) from sort_error_test2;
+select gp_inject_fault('explain_analyze_sort_error', 'reset', dbid)
+    from gp_segment_configuration where role = 'p' and content > -1;
+drop table sort_error_test1;
+drop table sort_error_test2;


### PR DESCRIPTION
The execution sequence of explain analyze is as follows:
ExecutorStart
ExecutorRun                                -->dispatch plan to QEs
cdbdisp_checkDispatchResult  -->wait all QEs finished
ExplainPrintXXX                          -->print explain infos
ExecutorEnd                                -->reThrow QE's error, etc.; 

When we execute explain analyze, we might not receive stats from QEs, If some QEs hit errors.
But, In ExplainPrintXXX we will use these stats and print explain info, if we forget to do null
judgment, this may hit a null pointer exception. Finally, in ExecutorEnd we reThrow the error from QE.

If some QE throws errors, we reThrow the error before executing ExplainPrintXXX.