### PR TITLE
Fix failure when DynamicSeqScan has a subPlan

### DIFF
--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -1966,11 +1966,6 @@ typedef struct DynamicBitmapHeapScanState
 	bool		shouldCallHashSeqTerm;
 
 	/*
-	 * The first partition requires initialization of expression states,
-	 * such as qual and targetlist, regardless of whether we need to re-map varattno
-	 */
-	bool		firstPartition;
-	/*
 	 * lastRelOid is the last relation that corresponds to the
 	 * varattno mapping of qual and target list. Each time we open a new partition, we will
 	 * compare the last relation with current relation by using varattnos_map()
@@ -2241,11 +2236,6 @@ typedef struct DynamicSeqScanState
 	 */
 	bool		shouldCallHashSeqTerm;
 
-	/*
-	 * The first partition requires initialization of expression states,
-	 * such as qual and targetlist, regardless of whether we need to re-map varattno
-	 */
-	bool		firstPartition;
 	/*
 	 * lastRelOid is the last relation that corresponds to the
 	 * varattno mapping of qual and target list. Each time we open a new partition, we will

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -11583,7 +11583,7 @@ SELECT * FROM ds_part, non_part2 WHERE ds_part.c = non_part2.e AND non_part2.f =
 ---+---+---+---+---
 (0 rows)
 
-explain SELECT * FROM ds_part, non_part2 WHERE ds_part.c = non_part2.e AND non_part2.f = 10 AND a IN ( SELECT b + 1 FROM non_part1);
+explain analyze SELECT * FROM ds_part, non_part2 WHERE ds_part.c = non_part2.e AND non_part2.f = 10 AND a IN ( SELECT b + 1 FROM non_part1);
                                                   QUERY PLAN                                                   
 ---------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice3; segments: 3)  (cost=10000000004.33..10000000039.13 rows=7 width=20)

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -11687,7 +11687,7 @@ SELECT * FROM ds_part, non_part2 WHERE ds_part.c = non_part2.e AND non_part2.f =
 ---+---+---+---+---
 (0 rows)
 
-explain SELECT * FROM ds_part, non_part2 WHERE ds_part.c = non_part2.e AND non_part2.f = 10 AND a IN ( SELECT b + 1 FROM non_part1);
+explain analyze SELECT * FROM ds_part, non_part2 WHERE ds_part.c = non_part2.e AND non_part2.f = 10 AND a IN ( SELECT b + 1 FROM non_part1);
                                                      QUERY PLAN                                                     
 --------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice4; segments: 3)  (cost=0.00..1324481.28 rows=1000 width=20)

--- a/src/test/regress/expected/qp_dropped_cols.out
+++ b/src/test/regress/expected/qp_dropped_cols.out
@@ -16186,6 +16186,91 @@ select * from multi_part_mid_bitmap where date = '2017-02-05' and region = 'usa'
 ----------+------+--------+--------
 (0 rows)
 
+-- Exchange partitions with dropped columns and check subplan with attribute remapping into dynamicSeqscan
+-- start_ignore
+DROP TABLE if exists ds_main;
+NOTICE:  table "ds_main" does not exist, skipping
+DROP TABLE if exists ds_part1;
+NOTICE:  table "ds_part1" does not exist, skipping
+DROP TABLE if exists non_part1;
+NOTICE:  table "non_part1" does not exist, skipping
+DROP TABLE if exists non_part2;
+NOTICE:  table "non_part2" does not exist, skipping
+-- end_ignore
+CREATE TABLE ds_main ( a INT, b INT, c INT) PARTITION BY RANGE(c)( START(1) END (10) EVERY (2), DEFAULT PARTITION deflt);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "ds_main_1_prt_deflt" for table "ds_main"
+NOTICE:  CREATE TABLE will create partition "ds_main_1_prt_2" for table "ds_main"
+NOTICE:  CREATE TABLE will create partition "ds_main_1_prt_3" for table "ds_main"
+NOTICE:  CREATE TABLE will create partition "ds_main_1_prt_4" for table "ds_main"
+NOTICE:  CREATE TABLE will create partition "ds_main_1_prt_5" for table "ds_main"
+NOTICE:  CREATE TABLE will create partition "ds_main_1_prt_6" for table "ds_main"
+CREATE TABLE ds_part1 (a int, a1 int, b int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE non_part1 (c INT);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE non_part2 (e INT, f INT);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'e' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+SET optimizer_enforce_subplans TO ON;
+-- drop columns to get attribute remapping
+ALTER TABLE ds_part1 drop column a1;
+ALTER TABLE ds_main exchange partition for (1) with table ds_part1;
+INSERT INTO non_part1 SELECT i FROM generate_series(1, 1)i;
+INSERT INTO non_part2 SELECT i, i + 1 FROM generate_series(1, 10)i;
+INSERT INTO ds_main SELECT i, i + 1, i + 2 FROM generate_series (1, 1000)i;
+analyze ds_main;
+analyze non_part1;
+analyze non_part2;
+EXPLAIN (costs off) SELECT * FROM ds_main, non_part2 WHERE ds_main.c = non_part2.e AND a IN ( SELECT a FROM non_part1) order by a;
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)
+   Merge Key: ds_main_1_prt_deflt.a
+   ->  Sort
+         Sort Key: ds_main_1_prt_deflt.a
+         ->  Nested Loop Semi Join
+               ->  Hash Join
+                     Hash Cond: (ds_main_1_prt_deflt.c = non_part2.e)
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                           Hash Key: ds_main_1_prt_deflt.c
+                           ->  Append
+                                 ->  Seq Scan on ds_main_1_prt_deflt
+                                       Filter: (a = a)
+                                 ->  Seq Scan on ds_main_1_prt_3
+                                       Filter: (a = a)
+                                 ->  Seq Scan on ds_main_1_prt_4
+                                       Filter: (a = a)
+                                 ->  Seq Scan on ds_main_1_prt_5
+                                       Filter: (a = a)
+                                 ->  Seq Scan on ds_main_1_prt_6
+                                       Filter: (a = a)
+                                 ->  Seq Scan on ds_main_1_prt_2
+                                       Filter: (a = a)
+                     ->  Hash
+                           ->  Seq Scan on non_part2
+               ->  Materialize
+                     ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                           ->  Seq Scan on non_part1
+ Optimizer: Postgres query optimizer
+(28 rows)
+
+SELECT * FROM ds_main, non_part2 WHERE ds_main.c = non_part2.e AND a IN ( SELECT a FROM non_part1) order by a;
+ a | b | c  | e  | f  
+---+---+----+----+----
+ 1 | 2 |  3 |  3 |  4
+ 2 | 3 |  4 |  4 |  5
+ 3 | 4 |  5 |  5 |  6
+ 4 | 5 |  6 |  6 |  7
+ 5 | 6 |  7 |  7 |  8
+ 6 | 7 |  8 |  8 |  9
+ 7 | 8 |  9 |  9 | 10
+ 8 | 9 | 10 | 10 | 11
+(8 rows)
+
 -- As of this writing, pg_dump creates an invalid dump for some of the tables
 -- here. See https://github.com/greenplum-db/gpdb/issues/3598. So we must drop
 -- the tables, or the pg_upgrade test fails.

--- a/src/test/regress/expected/qp_dropped_cols_optimizer.out
+++ b/src/test/regress/expected/qp_dropped_cols_optimizer.out
@@ -16108,6 +16108,82 @@ select * from multi_part_mid_bitmap where date = '2017-02-05' and region = 'usa'
 ----------+------+--------+--------
 (0 rows)
 
+-- Exchange partitions with dropped columns and check subplan with attribute remapping into dynamicSeqscan
+-- start_ignore
+DROP TABLE if exists ds_main;
+NOTICE:  table "ds_main" does not exist, skipping
+DROP TABLE if exists ds_part1;
+NOTICE:  table "ds_part1" does not exist, skipping
+DROP TABLE if exists non_part1;
+NOTICE:  table "non_part1" does not exist, skipping
+DROP TABLE if exists non_part2;
+NOTICE:  table "non_part2" does not exist, skipping
+-- end_ignore
+CREATE TABLE ds_main ( a INT, b INT, c INT) PARTITION BY RANGE(c)( START(1) END (10) EVERY (2), DEFAULT PARTITION deflt);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "ds_main_1_prt_deflt" for table "ds_main"
+NOTICE:  CREATE TABLE will create partition "ds_main_1_prt_2" for table "ds_main"
+NOTICE:  CREATE TABLE will create partition "ds_main_1_prt_3" for table "ds_main"
+NOTICE:  CREATE TABLE will create partition "ds_main_1_prt_4" for table "ds_main"
+NOTICE:  CREATE TABLE will create partition "ds_main_1_prt_5" for table "ds_main"
+NOTICE:  CREATE TABLE will create partition "ds_main_1_prt_6" for table "ds_main"
+CREATE TABLE ds_part1 (a int, a1 int, b int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE non_part1 (c INT);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE non_part2 (e INT, f INT);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'e' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+SET optimizer_enforce_subplans TO ON;
+-- drop columns to get attribute remapping
+ALTER TABLE ds_part1 drop column a1;
+ALTER TABLE ds_main exchange partition for (1) with table ds_part1;
+INSERT INTO non_part1 SELECT i FROM generate_series(1, 1)i;
+INSERT INTO non_part2 SELECT i, i + 1 FROM generate_series(1, 10)i;
+INSERT INTO ds_main SELECT i, i + 1, i + 2 FROM generate_series (1, 1000)i;
+analyze ds_main;
+analyze non_part1;
+analyze non_part2;
+EXPLAIN (costs off) SELECT * FROM ds_main, non_part2 WHERE ds_main.c = non_part2.e AND a IN ( SELECT a FROM non_part1) order by a;
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice4; segments: 3)
+   Merge Key: ds_main.a
+   ->  Sort
+         Sort Key: ds_main.a
+         ->  Hash Join
+               Hash Cond: (ds_main.c = non_part2.e)
+               ->  Dynamic Seq Scan on ds_main (dynamic scan id: 1)
+                     Filter: ((a = a) AND (SubPlan 1))
+                     SubPlan 1  (slice4; segments: 3)
+                       ->  Materialize
+                             ->  Broadcast Motion 1:3  (slice2)
+                                   ->  Limit
+                                         ->  Gather Motion 3:1  (slice1; segments: 3)
+                                               ->  Seq Scan on non_part1
+               ->  Hash
+                     ->  Partition Selector for ds_main (dynamic scan id: 1)
+                           ->  Broadcast Motion 3:3  (slice3; segments: 3)
+                                 ->  Seq Scan on non_part2
+ Optimizer: Pivotal Optimizer (GPORCA)
+(19 rows)
+
+SELECT * FROM ds_main, non_part2 WHERE ds_main.c = non_part2.e AND a IN ( SELECT a FROM non_part1) order by a;
+ a | b | c  | e  | f  
+---+---+----+----+----
+ 1 | 2 |  3 |  3 |  4
+ 2 | 3 |  4 |  4 |  5
+ 3 | 4 |  5 |  5 |  6
+ 4 | 5 |  6 |  6 |  7
+ 5 | 6 |  7 |  7 |  8
+ 6 | 7 |  8 |  8 |  9
+ 7 | 8 |  9 |  9 | 10
+ 8 | 9 | 10 | 10 | 11
+(8 rows)
+
 -- As of this writing, pg_dump creates an invalid dump for some of the tables
 -- here. See https://github.com/greenplum-db/gpdb/issues/3598. So we must drop
 -- the tables, or the pg_upgrade test fails.

--- a/src/test/regress/sql/gporca.sql
+++ b/src/test/regress/sql/gporca.sql
@@ -2259,7 +2259,7 @@ analyze ds_part;
 analyze non_part1;
 analyze non_part2;
 SELECT * FROM ds_part, non_part2 WHERE ds_part.c = non_part2.e AND non_part2.f = 10 AND a IN ( SELECT b + 1 FROM non_part1);
-explain SELECT * FROM ds_part, non_part2 WHERE ds_part.c = non_part2.e AND non_part2.f = 10 AND a IN ( SELECT b + 1 FROM non_part1);
+explain analyze SELECT * FROM ds_part, non_part2 WHERE ds_part.c = non_part2.e AND non_part2.f = 10 AND a IN ( SELECT b + 1 FROM non_part1);
 
 SELECT *, a IN ( SELECT b + 1 FROM non_part1) FROM ds_part, non_part2 WHERE ds_part.c = non_part2.e AND non_part2.f = 10 AND a IN ( SELECT b FROM non_part1);
 CREATE INDEX ds_idx ON ds_part(a);

--- a/src/test/regress/sql/qp_dropped_cols.sql
+++ b/src/test/regress/sql/qp_dropped_cols.sql
@@ -8624,6 +8624,36 @@ explain select * from multi_part_mid_bitmap where date = '2017-02-05' and region
 -- end_ignore
 select * from multi_part_mid_bitmap where date = '2017-02-05' and region = 'usa';
 
+-- Exchange partitions with dropped columns and check subplan with attribute remapping into dynamicSeqscan
+-- start_ignore
+DROP TABLE if exists ds_main;
+DROP TABLE if exists ds_part1;
+DROP TABLE if exists non_part1;
+DROP TABLE if exists non_part2;
+-- end_ignore
+
+CREATE TABLE ds_main ( a INT, b INT, c INT) PARTITION BY RANGE(c)( START(1) END (10) EVERY (2), DEFAULT PARTITION deflt);
+CREATE TABLE ds_part1 (a int, a1 int, b int, c int);
+CREATE TABLE non_part1 (c INT);
+CREATE TABLE non_part2 (e INT, f INT);
+
+SET optimizer_enforce_subplans TO ON;
+
+-- drop columns to get attribute remapping
+ALTER TABLE ds_part1 drop column a1;
+ALTER TABLE ds_main exchange partition for (1) with table ds_part1;
+
+INSERT INTO non_part1 SELECT i FROM generate_series(1, 1)i;
+INSERT INTO non_part2 SELECT i, i + 1 FROM generate_series(1, 10)i;
+INSERT INTO ds_main SELECT i, i + 1, i + 2 FROM generate_series (1, 1000)i;
+
+analyze ds_main;
+analyze non_part1;
+analyze non_part2;
+
+EXPLAIN (costs off) SELECT * FROM ds_main, non_part2 WHERE ds_main.c = non_part2.e AND a IN ( SELECT a FROM non_part1) order by a;
+SELECT * FROM ds_main, non_part2 WHERE ds_main.c = non_part2.e AND a IN ( SELECT a FROM non_part1) order by a;
+
 -- As of this writing, pg_dump creates an invalid dump for some of the tables
 -- here. See https://github.com/greenplum-db/gpdb/issues/3598. So we must drop
 -- the tables, or the pg_upgrade test fails.


### PR DESCRIPTION
[PR to master](https://github.com/greenplum-db/gpdb/pull/14505)

## Problem description

The following scenario produces internal error:
```sql
CREATE TABLE ds_part ( a INT, b INT, c INT) PARTITION BY RANGE(c)( START(1) END (10) EVERY (2), DEFAULT PARTITION deflt);
CREATE TABLE non_part1 (c INT);
CREATE TABLE non_part2 (e INT, f INT);

INSERT INTO ds_part SELECT i, i, i FROM generate_series (1, 1000)i; 
INSERT INTO non_part1 SELECT i FROM generate_series(1, 100)i; 
INSERT INTO non_part2 SELECT i, i FROM generate_series(1, 100)i;

SET optimizer_enforce_subplans TO ON;
analyze ds_part;
analyze non_part1;
analyze non_part2;
EXPLAIN ANALYZE SELECT * FROM ds_part, non_part2 WHERE ds_part.c = non_part2.e AND non_part2.f = 10 AND a IN ( SELECT b + 1 FROM non_part1);
```
```
ERROR:  Unexpected internal error (explain_gp.c:1167)
```

Query plan of select in example above contains SubPlan under DynamicSeqScan node:
```
postgres=# EXPLAIN (costs off) SELECT * FROM ds_part, non_part2 WHERE ds_part.c = non_part2.e AND non_part2.f = 10 AND a IN ( SELECT b + 1 FROM non_part1);
                                   QUERY PLAN                                   
--------------------------------------------------------------------------------
 Gather Motion 3:1  (slice4; segments: 3)
   ->  Hash Join
         Hash Cond: (ds_part.c = non_part2.e)
         ->  Dynamic Seq Scan on ds_part (dynamic scan id: 1)
               Filter: ((a = (b + 1)) AND (SubPlan 1))
               SubPlan 1  (slice4; segments: 3)
                 ->  Materialize
                       ->  Broadcast Motion 1:3  (slice2)
                             ->  Limit
                                   ->  Gather Motion 3:1  (slice1; segments: 3)
                                         ->  Limit
                                               ->  Seq Scan on non_part1
         ->  Hash
               ->  Partition Selector for ds_part (dynamic scan id: 1)
                     ->  Broadcast Motion 3:3  (slice3; segments: 3)
                           ->  Seq Scan on non_part2
                                 Filter: (f = 10)
 Optimizer: Pivotal Optimizer (GPORCA)
(18 rows)
```

While gathering execution statistics of EXPLAIN ANALYZE from QE for slice4:
```
 Gather Motion 3:1  (slice4; segments: 3)
   ->  Hash Join
         Hash Cond: (ds_part.c = non_part2.e)
         ->  Dynamic Seq Scan on ds_part (dynamic scan id: 1)
               Filter: ((a = (b + 1)) AND (SubPlan 1))
               SubPlan 1  (slice4; segments: 3)
                 ->  Materialize
                       ->  Broadcast Motion 1:3  (slice2)
         ->  Hash
               ->  Partition Selector for ds_part (dynamic scan id: 1)
                     ->  Broadcast Motion 3:3  (slice3; segments: 3)
```

we traverse plan nodes in depth-first order and bump into inappropriate order of received messages: at `cdbexplain_depositStatsToNode` macro `Insist` fails at condition `rsi->pstype == planstate->type`. In particular, we have duplicate messages for Materialize and Broadcast Motion nodes.

```
(gdb) p ctx->msgptrs[0]->inst[1]
$80 = {pstype = T_DynamicSeqScanState, starttime = {tv_sec = 0, tv_usec = 0}, counter = {tv_sec = 0, tv_usec = 0}, firsttuple = 0, startup = 0.000301, total = 0.000301, ntuples = 0, nloops = 1, execmemused = 0, workmemused = 0, 
  workmemwanted = 0, workfileCreated = 0 '\000', firststart = {tv_sec = 1659499436, tv_usec = 21285}, peakMemBalance = 55000, numPartScanned = 1, sortMethod = UNINITIALIZED_SORT, sortSpaceType = UNINITIALIZED_SORT_SPACE_TYPE, 
  sortSpaceUsed = 0, bnotes = 61, enotes = 61}
(gdb) p ctx->msgptrs[0]->inst[2]
$81 = {pstype = T_MaterialState, starttime = {tv_sec = 0, tv_usec = 0}, counter = {tv_sec = 0, tv_usec = 0}, firsttuple = 0, startup = 0, total = 0, ntuples = 0, nloops = 0, execmemused = 0, workmemused = 0, workmemwanted = 0, 
  workfileCreated = 0 '\000', firststart = {tv_sec = 0, tv_usec = 0}, peakMemBalance = 3368, numPartScanned = 0, sortMethod = UNINITIALIZED_SORT, sortSpaceType = UNINITIALIZED_SORT_SPACE_TYPE, sortSpaceUsed = 0, bnotes = 61, 
  enotes = 61}
(gdb) p ctx->msgptrs[0]->inst[3]
$82 = {pstype = T_MotionState, starttime = {tv_sec = 0, tv_usec = 0}, counter = {tv_sec = 0, tv_usec = 0}, firsttuple = 0, startup = 0, total = 0, ntuples = 0, nloops = 0, execmemused = 0, workmemused = 0, workmemwanted = 0, 
  workfileCreated = 0 '\000', firststart = {tv_sec = 0, tv_usec = 0}, peakMemBalance = 3520, numPartScanned = 0, sortMethod = UNINITIALIZED_SORT, sortSpaceType = UNINITIALIZED_SORT_SPACE_TYPE, sortSpaceUsed = 0, bnotes = 61, 
  enotes = 61}
(gdb) p ctx->msgptrs[0]->inst[4]
$83 = {pstype = T_MaterialState, starttime = {tv_sec = 0, tv_usec = 0}, counter = {tv_sec = 0, tv_usec = 0}, firsttuple = 0, startup = 0, total = 0, ntuples = 0, nloops = 0, execmemused = 0, workmemused = 0, workmemwanted = 0, 
  workfileCreated = 0 '\000', firststart = {tv_sec = 0, tv_usec = 0}, peakMemBalance = 3368, numPartScanned = 0, sortMethod = UNINITIALIZED_SORT, sortSpaceType = UNINITIALIZED_SORT_SPACE_TYPE, sortSpaceUsed = 0, bnotes = 61, 
  enotes = 61}
(gdb) p ctx->msgptrs[0]->inst[5]
$84 = {pstype = T_MotionState, starttime = {tv_sec = 0, tv_usec = 0}, counter = {tv_sec = 0, tv_usec = 0}, firsttuple = 0, startup = 0, total = 0, ntuples = 0, nloops = 0, execmemused = 0, workmemused = 0, workmemwanted = 0, 
  workfileCreated = 0 '\000', firststart = {tv_sec = 0, tv_usec = 0}, peakMemBalance = 3520, numPartScanned = 0, sortMethod = UNINITIALIZED_SORT, sortSpaceType = UNINITIALIZED_SORT_SPACE_TYPE, sortSpaceUsed = 0, bnotes = 61, 
  enotes = 61}
(gdb) p ctx->msgptrs[0]->inst[6]
$85 = {pstype = T_HashState, starttime = {tv_sec = 0, tv_usec = 0}, counter = {tv_sec = 0, tv_usec = 0}, firsttuple = 0, startup = 0.001132, total = 0.001132, ntuples = 1, nloops = 1, execmemused = 0, workmemused = 0, 
  workmemwanted = 0, workfileCreated = 0 '\000', firststart = {tv_sec = 1659499436, tv_usec = 20153}, peakMemBalance = 2104040, numPartScanned = 0, sortMethod = UNINITIALIZED_SORT, sortSpaceType = UNINITIALIZED_SORT_SPACE_TYPE, 
  sortSpaceUsed = 0, bnotes = 61, enotes = 61}
```

This is because QE executing slice4 initializes two identical subplans for DynamicSeqScan node:
```
(gdb) p *((SubPlanState *)lsecond(planstate->subPlan))
$7 = {xprstate = {type = T_SubPlanState, expr = 0x5566209fb4b0, evalfunc = 0x5566191cb820 <ExecSubPlan>}, planstate = 0x5566209df100, testexpr = 0x0, args = 0x0, curTuple = 0x0, curArray = 0, projLeft = 0x0, projRight = 0x0, 
  hashtable = 0x0, hashnulls = 0x0, havehashrows = 0 '\000', havenullrows = 0 '\000', hashtablecxt = 0x0, hashtempcxt = 0x0, innerecontext = 0x0, keyColIdx = 0x0, tab_hash_funcs = 0x0, tab_eq_funcs = 0x0, lhs_hash_funcs = 0x0, 
  cur_eq_funcs = 0x0, ts_pos = 0x0, ts_state = 0x556620b24698}
(gdb) p *((SubPlanState *)linitial(planstate->subPlan))
$8 = {xprstate = {type = T_SubPlanState, expr = 0x5566209fb4b0, evalfunc = 0x5566191cb820 <ExecSubPlan>}, planstate = 0x5566209df100, testexpr = 0x0, args = 0x0, curTuple = 0x0, curArray = 0, projLeft = 0x0, projRight = 0x0, 
  hashtable = 0x0, hashnulls = 0x0, havehashrows = 0 '\000', havenullrows = 0 '\000', hashtablecxt = 0x0, hashtempcxt = 0x0, innerecontext = 0x0, keyColIdx = 0x0, tab_hash_funcs = 0x0, tab_eq_funcs = 0x0, lhs_hash_funcs = 0x0, 
  cur_eq_funcs = 0x0, ts_pos = 0x0, ts_state = 0x556620b10f80}
```

The fist subplan item is initialized at [executor start](https://github.com/greenplum-db/gpdb/blob/c4a3ce097f554a15ef489630928f03d19e129b39/src/backend/executor/nodeDynamicSeqscan.c#L53-L58). The second one - at execution of DynamicSeqScan node [in initNextTableToScan](https://github.com/greenplum-db/gpdb/blob/c4a3ce097f554a15ef489630928f03d19e129b39/src/backend/executor/nodeDynamicSeqscan.c#L150-L163). This duplication was caused by commit https://github.com/greenplum-db/gpdb/commit/c4a3ce097f554a15ef489630928f03d19e129b39 that added initialization of quals and targetlist at executor start alongside initialization at running stage.

Another issue with second subplan initialization is that this subplan structure is allocated in temporary memory context `partitionMemoryContext`. In particular, after targetlist remapping we end up to dangling pointer in list of subplans:
```
postgres=# create table ds2 (a int, a1 int, b int, c int);
create table ds3 (a int, b int, b1 int, c int);
alter table ds2 drop column a1;
alter table ds3 drop column b1;
alter table ds_part exchange partition for (1) with table ds2;
alter table ds_part exchange partition for (2) with table ds3;
INSERT INTO ds_part SELECT i, i, i FROM generate_series (1, 1000)i; 
EXPLAIN ANALYZE SELECT * FROM ds_part, non_part2 WHERE ds_part.c = non_part2.e AND non_part2.f < 10 AND a IN ( SELECT b + 1 FROM non_part1);
NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
CREATE TABLE
NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
CREATE TABLE
ALTER TABLE
ALTER TABLE
ALTER TABLE
ALTER TABLE
INSERT 0 1000
ERROR:  Unexpected internal error (list.c:54)  (seg0 slice4 127.0.1.1:6002 pid=41068) (list.c:54)
DETAIL:  FailedAssertion("!(list->tail->next == ((void *)0))", File: "list.c", Line: 54)
HINT:  Process 41068 will wait for gp_debug_linger=120 seconds before termination.
```

## Patch details

Remapping of attributes doesn't require valuable changes in qual list and targetlist after substitution of variables in expression tree. Also initialization of these structures at execution of DynamicSeqScan changes nothing compared to initial initialization routine at executor start. This was checked on query with explicit subplan external parameter from partitioning table:
```sql
SELECT *
FROM ds_part, non_part2
WHERE ds_part.c = non_part2.e AND non_part2.f = 10
      AND a IN (
           SELECT b + 1
           FROM non_part1
           WHERE ds_part.c = non_part1.c
      );
```

Because of this I have removed the second initalization of routine in `initNextTableToScan`.
Also I fixed the same problem at DynamicBitmapHeapscan.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
