### PR TITLE
Fix GRANT/REVOKE when some tables are partitioned and some are not

### DIFF
--- a/src/backend/catalog/aclchk.c
+++ b/src/backend/catalog/aclchk.c
@@ -879,6 +879,10 @@ objectNamesToOids(GrantObjectType objtype, List *objnames)
 				/* partOids contains relOid so concat is enough */
 				expanded = list_concat(expanded, partOids);
 			}
+			else
+			{
+				expanded = lappend_oid(expanded, relOid);
+			}
 		}
 
 		if (expanded != NIL)

--- a/src/test/regress/expected/privileges.out
+++ b/src/test/regress/expected/privileges.out
@@ -1747,7 +1747,7 @@ SELECT d.*     -- check that entries went away
 
 -- Grant on all objects of given type in a schema
 \c -
--- GPDB: Create a helper function to inspect the segment information also
+-- GPDB: Create helper functions to inspect the segment information also
 DROP FUNCTION IF EXISTS has_table_privilege_seg(u text, r text, p text);
 NOTICE:  function has_table_privilege_seg(text,text,text) does not exist, skipping
 CREATE FUNCTION has_table_privilege_seg(us text, rel text, priv text)
@@ -1762,131 +1762,122 @@ RETURNS TABLE (
 		has_table_privilege($1, $2, $3) p
 $$ LANGUAGE SQL VOLATILE
 CONTAINS SQL EXECUTE ON ALL SEGMENTS;
+DROP FUNCTION IF EXISTS has_table_privilege_cluster(u text, r text, p text);
+NOTICE:  function has_table_privilege_cluster(text,text,text) does not exist, skipping
+CREATE FUNCTION has_table_privilege_cluster(us text, rel text, priv text)
+RETURNS TABLE (
+	segid int,
+	has_table_privilege bool
+) AS $$
+	SELECT -1 as segid, has_table_privilege($1, $2, $3) union
+	SELECT * FROM has_table_privilege_seg($1, $2, $3);
+$$ LANGUAGE SQL VOLATILE;
 CREATE SCHEMA testns;
 CREATE TABLE testns.t1 (f1 int);
 CREATE TABLE testns.t2 (f1 int);
 CREATE TABLE testns.t3 (f1 int) PARTITION BY RANGE (f1) (START (2018) END (2020) EVERY (1),DEFAULT PARTITION extra );
 CREATE TABLE testns.t4 (f1 int) inherits (testns.t1);
 NOTICE:  merging column "f1" with inherited definition
-SELECT has_table_privilege('regressuser1', 'testns.t1', 'SELECT'); -- false
- has_table_privilege 
----------------------
- f
-(1 row)
-
-SELECT * FROM has_table_privilege_seg('regressuser1', 'testns.t1', 'SELECT'); -- false
+SELECT * FROM has_table_privilege_cluster('regressuser1', 'testns.t1', 'SELECT'); -- false
  segid | has_table_privilege 
 -------+---------------------
+    -1 | f
      2 | f
      0 | f
      1 | f
-(3 rows)
+(4 rows)
 
-SELECT * FROM has_table_privilege_seg('regressuser1', 'testns.t3', 'SELECT'); -- false
+SELECT * FROM has_table_privilege_cluster('regressuser1', 'testns.t3', 'SELECT'); -- false
  segid | has_table_privilege 
 -------+---------------------
+    -1 | f
      0 | f
      1 | f
      2 | f
-(3 rows)
+(4 rows)
 
-SELECT * FROM has_table_privilege_seg('regressuser1', 'testns.t3_1_prt_extra', 'SELECT'); -- false
+SELECT * FROM has_table_privilege_cluster('regressuser1', 'testns.t3_1_prt_extra', 'SELECT'); -- false
  segid | has_table_privilege 
 -------+---------------------
+    -1 | f
      0 | f
      1 | f
      2 | f
-(3 rows)
+(4 rows)
 
-SELECT * FROM has_table_privilege_seg('regressuser1', 'testns.t4', 'SELECT'); -- false
+SELECT * FROM has_table_privilege_cluster('regressuser1', 'testns.t4', 'SELECT'); -- false
  segid | has_table_privilege 
 -------+---------------------
+    -1 | f
      0 | f
      1 | f
      2 | f
-(3 rows)
+(4 rows)
 
 GRANT ALL ON ALL TABLES IN SCHEMA testns TO regressuser1;
-SELECT has_table_privilege('regressuser1', 'testns.t1', 'SELECT'); -- true
- has_table_privilege 
----------------------
- t
-(1 row)
-
-SELECT has_table_privilege('regressuser1', 'testns.t2', 'SELECT'); -- true
- has_table_privilege 
----------------------
- t
-(1 row)
-
-SELECT * FROM has_table_privilege_seg('regressuser1', 'testns.t1', 'SELECT'); -- true
+SELECT * FROM has_table_privilege_cluster('regressuser1', 'testns.t1', 'SELECT'); -- true
  segid | has_table_privilege 
 -------+---------------------
+    -1 | t
      0 | t
      1 | t
      2 | t
-(3 rows)
+(4 rows)
 
-SELECT * FROM has_table_privilege_seg('regressuser1', 'testns.t3', 'SELECT'); -- true
+SELECT * FROM has_table_privilege_cluster('regressuser1', 'testns.t3', 'SELECT'); -- true
  segid | has_table_privilege 
 -------+---------------------
+    -1 | t
      0 | t
      1 | t
      2 | t
-(3 rows)
+(4 rows)
 
-SELECT * FROM has_table_privilege_seg('regressuser1', 'testns.t3_1_prt_extra', 'SELECT'); -- true
+SELECT * FROM has_table_privilege_cluster('regressuser1', 'testns.t3_1_prt_extra', 'SELECT'); -- true
  segid | has_table_privilege 
 -------+---------------------
+    -1 | t
      0 | t
      1 | t
      2 | t
-(3 rows)
+(4 rows)
 
-SELECT * FROM has_table_privilege_seg('regressuser1', 'testns.t4', 'SELECT'); -- true
+SELECT * FROM has_table_privilege_cluster('regressuser1', 'testns.t4', 'SELECT'); -- true
  segid | has_table_privilege 
 -------+---------------------
+    -1 | t
      0 | t
      1 | t
      2 | t
-(3 rows)
+(4 rows)
 
 REVOKE ALL ON ALL TABLES IN SCHEMA testns FROM regressuser1;
-SELECT has_table_privilege('regressuser1', 'testns.t1', 'SELECT'); -- false
- has_table_privilege 
----------------------
- f
-(1 row)
-
-SELECT has_table_privilege('regressuser1', 'testns.t2', 'SELECT'); -- false
- has_table_privilege 
----------------------
- f
-(1 row)
-
-SELECT * FROM has_table_privilege_seg('regressuser1', 'testns.t3', 'SELECT'); -- false
+SELECT * FROM has_table_privilege_cluster('regressuser1', 'testns.t3', 'SELECT'); -- false
  segid | has_table_privilege 
 -------+---------------------
+    -1 | f
      0 | f
      1 | f
      2 | f
-(3 rows)
+(4 rows)
 
-SELECT * FROM has_table_privilege_seg('regressuser1', 'testns.t3_1_prt_extra', 'SELECT'); -- false
+SELECT * FROM has_table_privilege_cluster('regressuser1', 'testns.t3_1_prt_extra', 'SELECT'); -- false
  segid | has_table_privilege 
 -------+---------------------
+    -1 | f
      0 | f
      1 | f
      2 | f
-(3 rows)
+(4 rows)
 
-SELECT * FROM has_table_privilege_seg('regressuser1', 'testns.t4', 'SELECT'); -- false
+SELECT * FROM has_table_privilege_cluster('regressuser1', 'testns.t4', 'SELECT'); -- false
  segid | has_table_privilege 
 -------+---------------------
+    -1 | f
      0 | f
      1 | f
      2 | f
-(3 rows)
+(4 rows)
 
 CREATE FUNCTION testns.testfunc(int) RETURNS int AS 'select 3 * $1;' LANGUAGE sql;
 SELECT has_function_privilege('regressuser1', 'testns.testfunc(int)', 'EXECUTE'); -- true by default
@@ -1901,6 +1892,81 @@ SELECT has_function_privilege('regressuser1', 'testns.testfunc(int)', 'EXECUTE')
 ------------------------
  f
 (1 row)
+
+-- Check that GRANT works when there are not partitioned and partitioned tables in a single statement
+GRANT SELECT ON testns.t1, testns.t3, testns.t4, testns.t2 TO regressuser1;
+SELECT * FROM has_table_privilege_cluster('regressuser1', 'testns.t1', 'SELECT'); -- true
+ segid | has_table_privilege 
+-------+---------------------
+    -1 | t
+     0 | t
+     1 | t
+     2 | t
+(4 rows)
+
+SELECT * FROM has_table_privilege_cluster('regressuser1', 'testns.t2', 'SELECT'); -- true
+ segid | has_table_privilege 
+-------+---------------------
+    -1 | t
+     0 | t
+     1 | t
+     2 | t
+(4 rows)
+
+SELECT * FROM has_table_privilege_cluster('regressuser1', 'testns.t3', 'SELECT'); -- true
+ segid | has_table_privilege 
+-------+---------------------
+    -1 | t
+     0 | t
+     1 | t
+     2 | t
+(4 rows)
+
+SELECT * FROM has_table_privilege_cluster('regressuser1', 'testns.t4', 'SELECT'); -- true
+ segid | has_table_privilege 
+-------+---------------------
+    -1 | t
+     0 | t
+     1 | t
+     2 | t
+(4 rows)
+
+REVOKE SELECT ON testns.t1, testns.t3, testns.t4, testns.t2 FROM regressuser1;
+SELECT * FROM has_table_privilege_cluster('regressuser1', 'testns.t1', 'SELECT'); -- false
+ segid | has_table_privilege 
+-------+---------------------
+    -1 | f
+     0 | f
+     1 | f
+     2 | f
+(4 rows)
+
+SELECT * FROM has_table_privilege_cluster('regressuser1', 'testns.t2', 'SELECT'); -- false
+ segid | has_table_privilege 
+-------+---------------------
+    -1 | f
+     0 | f
+     1 | f
+     2 | f
+(4 rows)
+
+SELECT * FROM has_table_privilege_cluster('regressuser1', 'testns.t3', 'SELECT'); -- false
+ segid | has_table_privilege 
+-------+---------------------
+    -1 | f
+     0 | f
+     1 | f
+     2 | f
+(4 rows)
+
+SELECT * FROM has_table_privilege_cluster('regressuser1', 'testns.t4', 'SELECT'); -- false
+ segid | has_table_privilege 
+-------+---------------------
+    -1 | f
+     0 | f
+     1 | f
+     2 | f
+(4 rows)
 
 SET client_min_messages TO 'warning';
 DROP SCHEMA testns CASCADE;

--- a/src/test/regress/sql/privileges.sql
+++ b/src/test/regress/sql/privileges.sql
@@ -1045,7 +1045,7 @@ SELECT d.*     -- check that entries went away
 -- Grant on all objects of given type in a schema
 \c -
 
--- GPDB: Create a helper function to inspect the segment information also
+-- GPDB: Create helper functions to inspect the segment information also
 DROP FUNCTION IF EXISTS has_table_privilege_seg(u text, r text, p text);
 CREATE FUNCTION has_table_privilege_seg(us text, rel text, priv text)
 RETURNS TABLE (
@@ -1059,6 +1059,15 @@ RETURNS TABLE (
 		has_table_privilege($1, $2, $3) p
 $$ LANGUAGE SQL VOLATILE
 CONTAINS SQL EXECUTE ON ALL SEGMENTS;
+DROP FUNCTION IF EXISTS has_table_privilege_cluster(u text, r text, p text);
+CREATE FUNCTION has_table_privilege_cluster(us text, rel text, priv text)
+RETURNS TABLE (
+	segid int,
+	has_table_privilege bool
+) AS $$
+	SELECT -1 as segid, has_table_privilege($1, $2, $3) union
+	SELECT * FROM has_table_privilege_seg($1, $2, $3);
+$$ LANGUAGE SQL VOLATILE;
 
 CREATE SCHEMA testns;
 CREATE TABLE testns.t1 (f1 int);
@@ -1066,28 +1075,23 @@ CREATE TABLE testns.t2 (f1 int);
 CREATE TABLE testns.t3 (f1 int) PARTITION BY RANGE (f1) (START (2018) END (2020) EVERY (1),DEFAULT PARTITION extra );
 CREATE TABLE testns.t4 (f1 int) inherits (testns.t1);
 
-SELECT has_table_privilege('regressuser1', 'testns.t1', 'SELECT'); -- false
-SELECT * FROM has_table_privilege_seg('regressuser1', 'testns.t1', 'SELECT'); -- false
-SELECT * FROM has_table_privilege_seg('regressuser1', 'testns.t3', 'SELECT'); -- false
-SELECT * FROM has_table_privilege_seg('regressuser1', 'testns.t3_1_prt_extra', 'SELECT'); -- false
-SELECT * FROM has_table_privilege_seg('regressuser1', 'testns.t4', 'SELECT'); -- false
+SELECT * FROM has_table_privilege_cluster('regressuser1', 'testns.t1', 'SELECT'); -- false
+SELECT * FROM has_table_privilege_cluster('regressuser1', 'testns.t3', 'SELECT'); -- false
+SELECT * FROM has_table_privilege_cluster('regressuser1', 'testns.t3_1_prt_extra', 'SELECT'); -- false
+SELECT * FROM has_table_privilege_cluster('regressuser1', 'testns.t4', 'SELECT'); -- false
 
 GRANT ALL ON ALL TABLES IN SCHEMA testns TO regressuser1;
 
-SELECT has_table_privilege('regressuser1', 'testns.t1', 'SELECT'); -- true
-SELECT has_table_privilege('regressuser1', 'testns.t2', 'SELECT'); -- true
-SELECT * FROM has_table_privilege_seg('regressuser1', 'testns.t1', 'SELECT'); -- true
-SELECT * FROM has_table_privilege_seg('regressuser1', 'testns.t3', 'SELECT'); -- true
-SELECT * FROM has_table_privilege_seg('regressuser1', 'testns.t3_1_prt_extra', 'SELECT'); -- true
-SELECT * FROM has_table_privilege_seg('regressuser1', 'testns.t4', 'SELECT'); -- true
+SELECT * FROM has_table_privilege_cluster('regressuser1', 'testns.t1', 'SELECT'); -- true
+SELECT * FROM has_table_privilege_cluster('regressuser1', 'testns.t3', 'SELECT'); -- true
+SELECT * FROM has_table_privilege_cluster('regressuser1', 'testns.t3_1_prt_extra', 'SELECT'); -- true
+SELECT * FROM has_table_privilege_cluster('regressuser1', 'testns.t4', 'SELECT'); -- true
 
 REVOKE ALL ON ALL TABLES IN SCHEMA testns FROM regressuser1;
 
-SELECT has_table_privilege('regressuser1', 'testns.t1', 'SELECT'); -- false
-SELECT has_table_privilege('regressuser1', 'testns.t2', 'SELECT'); -- false
-SELECT * FROM has_table_privilege_seg('regressuser1', 'testns.t3', 'SELECT'); -- false
-SELECT * FROM has_table_privilege_seg('regressuser1', 'testns.t3_1_prt_extra', 'SELECT'); -- false
-SELECT * FROM has_table_privilege_seg('regressuser1', 'testns.t4', 'SELECT'); -- false
+SELECT * FROM has_table_privilege_cluster('regressuser1', 'testns.t3', 'SELECT'); -- false
+SELECT * FROM has_table_privilege_cluster('regressuser1', 'testns.t3_1_prt_extra', 'SELECT'); -- false
+SELECT * FROM has_table_privilege_cluster('regressuser1', 'testns.t4', 'SELECT'); -- false
 
 CREATE FUNCTION testns.testfunc(int) RETURNS int AS 'select 3 * $1;' LANGUAGE sql;
 
@@ -1096,6 +1100,19 @@ SELECT has_function_privilege('regressuser1', 'testns.testfunc(int)', 'EXECUTE')
 REVOKE ALL ON ALL FUNCTIONS IN SCHEMA testns FROM PUBLIC;
 
 SELECT has_function_privilege('regressuser1', 'testns.testfunc(int)', 'EXECUTE'); -- false
+
+-- Check that GRANT works when there are not partitioned and partitioned tables in a single statement
+GRANT SELECT ON testns.t1, testns.t3, testns.t4, testns.t2 TO regressuser1;
+SELECT * FROM has_table_privilege_cluster('regressuser1', 'testns.t1', 'SELECT'); -- true
+SELECT * FROM has_table_privilege_cluster('regressuser1', 'testns.t2', 'SELECT'); -- true
+SELECT * FROM has_table_privilege_cluster('regressuser1', 'testns.t3', 'SELECT'); -- true
+SELECT * FROM has_table_privilege_cluster('regressuser1', 'testns.t4', 'SELECT'); -- true
+
+REVOKE SELECT ON testns.t1, testns.t3, testns.t4, testns.t2 FROM regressuser1;
+SELECT * FROM has_table_privilege_cluster('regressuser1', 'testns.t1', 'SELECT'); -- false
+SELECT * FROM has_table_privilege_cluster('regressuser1', 'testns.t2', 'SELECT'); -- false
+SELECT * FROM has_table_privilege_cluster('regressuser1', 'testns.t3', 'SELECT'); -- false
+SELECT * FROM has_table_privilege_cluster('regressuser1', 'testns.t4', 'SELECT'); -- false
 
 SET client_min_messages TO 'warning';
 DROP SCHEMA testns CASCADE;


### PR DESCRIPTION
This one should be closing https://github.com/greenplum-db/gpdb/issues/14446
Seems to be an issue only for 6X as far as I`ve checked. There was a bug in objectNamesToOids which completely ignored(eliminated) not partitioned tables if partitioned tables are also present in the same statement.
