### PR TITLE
Revert "Consider oversized rows for stawidth computation"

### DIFF
--- a/src/backend/commands/analyze.c
+++ b/src/backend/commands/analyze.c
@@ -107,7 +107,6 @@
 #include "utils/acl.h"
 #include "utils/attoptcache.h"
 #include "utils/datum.h"
-#include "utils/fmgroids.h"
 #include "utils/guc.h"
 #include "utils/lsyscache.h"
 #include "utils/memutils.h"
@@ -175,7 +174,6 @@ static MemoryContext anl_context = NULL;
 static BufferAccessStrategy vac_strategy;
 
 Bitmapset	**acquire_func_colLargeRowIndexes;
-double		 *acquire_func_colLargeRowLength;
 
 
 static void do_analyze_rel(Relation onerel, VacuumStmt *vacstmt,
@@ -502,7 +500,6 @@ do_analyze_rel(Relation onerel, VacuumStmt *vacstmt,
 	int			save_sec_context;
 	int			save_nestlevel;
 	Bitmapset **colLargeRowIndexes;
-	double     *colLargeRowLength;
 	bool		sample_needed;
 
 	if (inh)
@@ -683,7 +680,6 @@ do_analyze_rel(Relation onerel, VacuumStmt *vacstmt,
 	 * Maintain information if the row of a column exceeds WIDTH_THRESHOLD
 	 */
 	colLargeRowIndexes = (Bitmapset **) palloc0(sizeof(Bitmapset *) * onerel->rd_att->natts);
-	colLargeRowLength = (double *)palloc0(sizeof(double) * onerel->rd_att->natts);
 
 	if ((vacstmt->options & VACOPT_FULLSCAN) != 0)
 	{
@@ -703,18 +699,10 @@ do_analyze_rel(Relation onerel, VacuumStmt *vacstmt,
 		/*
 		 * Acquire the sample rows
 		 *
-		 * colLargeRowIndexes is passed out-of-band, in a global variable,
+		 * colLargeRowindexes is passed out-of-band, in a global variable,
 		 * to avoid changing the function signature from upstream's.
-		 *
-		 * The same as colLargeRowIndexes. colLargeRowLength stores total
-		 * length of too wide rows in the sample for every attribute of
-		 * the target relation. ANALYZE ignores too wide columns during
-		 * analysis(See comments of WIDTH_THRESHOLD), the stawidth can be
-		 * far smaller than the real average width for varlena datums which
-		 * are larger than WIDTH_THRESHOLD but stored uncompressed.
 		 */
 		acquire_func_colLargeRowIndexes = colLargeRowIndexes;
-		acquire_func_colLargeRowLength = colLargeRowLength;
 		if (inh)
 			numrows = acquire_inherited_sample_rows(onerel, elevel,
 													rows, targrows,
@@ -724,7 +712,6 @@ do_analyze_rel(Relation onerel, VacuumStmt *vacstmt,
 									  rows, targrows,
 									  &totalrows, &totaldeadrows);
 		acquire_func_colLargeRowIndexes = NULL;
-		acquire_func_colLargeRowLength = NULL;
 	}
 	else
 	{
@@ -806,12 +793,6 @@ do_analyze_rel(Relation onerel, VacuumStmt *vacstmt,
 			get_attribute_options(onerel->rd_id, stats->attr->attnum);
 
 			stats->tupDesc = onerel->rd_att;
-			/*
-			 * get total length and number of too wide rows in the sample,
-			 * in case get wrong stawidth.
-			 */
-			stats->totalwidelength = colLargeRowLength[stats->attr->attnum - 1];
-			stats->widerow_num = numrows - validRowsLength;
 
 			if (validRowsLength > 0)
 			{
@@ -872,7 +853,7 @@ do_analyze_rel(Relation onerel, VacuumStmt *vacstmt,
 				// that every item was >= WIDTH_THRESHOLD in width.
 				stats->stats_valid = true;
 				stats->stanullfrac = 0.0;
-				stats->stawidth = stats->totalwidelength/numrows;
+				stats->stawidth = WIDTH_THRESHOLD;
 				stats->stadistinct = 0.0;		/* "unknown" */
 			}
 			stats->rows = rows; // Reset to original rows
@@ -2561,7 +2542,6 @@ acquire_sample_rows_dispatcher(Relation onerel, bool inh, int elevel,
 	 * global variable to avoid changing the AcquireSampleRowsFunc prototype.
 	 */
 	Bitmapset **colLargeRowIndexes = acquire_func_colLargeRowIndexes;
-	double     *colLargeRowLength = acquire_func_colLargeRowLength;
 	TupleDesc	relDesc = RelationGetDescr(onerel);
 	TupleDesc	funcTupleDesc;
 	TupleDesc	sampleTupleDesc;
@@ -2648,7 +2628,7 @@ acquire_sample_rows_dispatcher(Relation onerel, bool inh, int elevel,
 	funcTupleDesc = CreateTemplateTupleDesc(ncolumns, false);
 	TupleDescInitEntry(funcTupleDesc, (AttrNumber) 1, "", FLOAT8OID, -1, 0);
 	TupleDescInitEntry(funcTupleDesc, (AttrNumber) 2, "", FLOAT8OID, -1, 0);
-	TupleDescInitEntry(funcTupleDesc, (AttrNumber) 3, "", FLOAT8ARRAYOID, -1, 0);
+	TupleDescInitEntry(funcTupleDesc, (AttrNumber) 3, "", TEXTOID, -1, 0);
 	
 	for (i = 0; i < relDesc->natts; i++)
 	{
@@ -2747,17 +2727,12 @@ acquire_sample_rows_dispatcher(Relation onerel, bool inh, int elevel,
 				/* Read the 'toolarge' bitmap, if any */
 				if (colLargeRowIndexes && !funcRetNulls[2])
 				{
-					ArrayType  *arrayVal;
-					Datum	   *largelength;
-					bool	   *nulls;
-					int	    numelems;
-					arrayVal = DatumGetArrayTypeP(OidFunctionCall3(F_ARRAY_IN,
-											CStringGetDatum(funcRetValues[2]),
-											FLOAT8OID,
-											-1));
-					deconstruct_array(arrayVal, FLOAT8OID, 8, true, 'd',
-								&largelength, &nulls, &numelems);
+					char	   *toolarge;
+					toolarge = funcRetValues[2];
+					if (strlen(toolarge) != numLiveColumns)
+						elog(ERROR, "'toolarge' bitmap has incorrect length");
 
+					index = 0;
 					for (i = 0; i < relDesc->natts; i++)
 					{
 						Form_pg_attribute attr = relDesc->attrs[i];
@@ -2765,11 +2740,9 @@ acquire_sample_rows_dispatcher(Relation onerel, bool inh, int elevel,
 						if (attr->attisdropped)
 							continue;
 
-						if (largelength[i] != (Datum) 0)
-						{
+						if (toolarge[index] == '1')
 							colLargeRowIndexes[i] = bms_add_member(colLargeRowIndexes[i], sampleTuples);
-							colLargeRowLength[i] += DatumGetFloat8(largelength[i]);
-						}
+						index++;
 					}
 				}
 
@@ -2782,10 +2755,10 @@ acquire_sample_rows_dispatcher(Relation onerel, bool inh, int elevel,
 					if (attr->attisdropped)
 						continue;
 
-					if (funcRetNulls[FIX_ATTR_NUM + index])
+					if (funcRetNulls[3 + index])
 						values[i] = NULL;
 					else
-						values[i] = funcRetValues[FIX_ATTR_NUM + index];
+						values[i] = funcRetValues[3 + index];
 					index++; /* Move index to the next result set attribute */
 				}
 
@@ -3339,7 +3312,7 @@ compute_minimal_stats(VacAttrStatsP stats,
 		/* Do the simple null-frac and width stats */
 		stats->stanullfrac = (double) null_cnt / (double) samplerows;
 		if (is_varwidth)
-			stats->stawidth = (total_width + stats->totalwidelength) / (double) (nonnull_cnt + stats->widerow_num);
+			stats->stawidth = total_width / (double) nonnull_cnt;
 		else
 			stats->stawidth = stats->attrtype->typlen;
 
@@ -3583,7 +3556,7 @@ compute_very_minimal_stats(VacAttrStatsP stats,
 		/* Do the simple null-frac and width stats */
 		stats->stanullfrac = (double) null_cnt / (double) samplerows;
 		if (is_varwidth)
-			stats->stawidth = (total_width + stats->totalwidelength) / (double) (nonnull_cnt + stats->widerow_num);
+			stats->stawidth = total_width / (double) nonnull_cnt;
 		else
 			stats->stawidth = stats->attrtype->typlen;
 		stats->stadistinct = 0.0;	/* "unknown" */
@@ -3802,7 +3775,7 @@ compute_scalar_stats(VacAttrStatsP stats,
 		/* Do the simple null-frac and width stats */
 		stats->stanullfrac = (double) null_cnt / (double) samplerows;
 		if (is_varwidth)
-			stats->stawidth = (total_width + stats->totalwidelength) / (double) (nonnull_cnt + stats->widerow_num);
+			stats->stawidth = total_width / (double) nonnull_cnt;
 		else
 			stats->stawidth = stats->attrtype->typlen;
 
@@ -4140,7 +4113,7 @@ compute_scalar_stats(VacAttrStatsP stats,
 		/* Do the simple null-frac and width stats */
 		stats->stanullfrac = (double) null_cnt / (double) samplerows;
 		if (is_varwidth)
-			stats->stawidth = (total_width + stats->totalwidelength) / (double) (nonnull_cnt + stats->widerow_num);
+			stats->stawidth = total_width / (double) nonnull_cnt;
 		else
 			stats->stawidth = stats->attrtype->typlen;
 		/* Assume all too-wide values are distinct, so it's a unique column */

--- a/src/backend/commands/analyzefuncs.c
+++ b/src/backend/commands/analyzefuncs.c
@@ -66,11 +66,11 @@ typedef struct
  * the actual sample rows.
  *
  * To make things even more complicated, each sample row contains one extra
- * column too: oversized_cols_length. It's an array indicating which attributes
- * on the sample row were omitted and stores these omitted attributes' length,
- * because they were "too large". The omitted attributes are returned as NULLs,
- * and the array can be used to distinguish real NULLs from values that were
- * too large to be included in the sample.
+ * column too: oversized_cols_bitmap. It's a bitmap indicating which attributes
+ * on the sample row were omitted, because they were "too large". The omitted
+ * attributes are returned as NULLs, and the bitmap can be used to distinguish
+ * real NULLs from values that were too large to be included in the sample. The
+ * bitmap is represented as a text column, with '0' or '1' for every column.
  *
  * So overall, this returns a result set like this:
  *
@@ -78,16 +78,16 @@ typedef struct
  *     -- special columns
  *     totalrows pg_catalog.float8,
  *     totaldeadrows pg_catalog.float8,
- *     oversized_cols_length pg_catalog._float8,
+ *     oversized_cols_bitmap pg_catalog.text,
  *     -- columns matching the table
  *     id int4,
  *     t text
  *  );
- *  totalrows | totaldeadrows | oversized_cols_length | id  |    t
+ *  totalrows | totaldeadrows | oversized_cols_bitmap | id  |    t    
  * -----------+---------------+-----------------------+-----+---------
  *            |               |                       |   1 | foo
  *            |               |                       |   2 | bar
- *            |               | {0,3004}              |  50 |
+ *            |               | 01                    |  50 | 
  *            |               |                       | 100 | foo 100
  *          2 |             0 |                       |     | 
  *          1 |             0 |                       |     | 
@@ -95,7 +95,7 @@ typedef struct
  * (7 rows)
  *
  * The first four rows form the actual sample. One of the columns contained
- * an oversized array datum. The function is marked as EXECUTE ON SEGMENTS in
+ * an oversized text datum. The function is marked as EXECUTE ON SEGMENTS in
  * the catalog so you get one summary row *for each segment*.
  */
 Datum
@@ -171,8 +171,8 @@ gp_acquire_sample_rows(PG_FUNCTION_ARGS)
 		/* extra column to indicate oversize cols */
 		TupleDescInitEntry(outDesc,
 						   3,
-						   "oversized_cols_length",
-						   FLOAT8ARRAYOID,
+						   "oversized_cols_bitmap",
+						   TEXTOID,
 						   -1,
 						   0);
 
@@ -253,17 +253,17 @@ gp_acquire_sample_rows(PG_FUNCTION_ARGS)
 		HeapTuple	relTuple = ctx->sample_rows[ctx->index];
 		int			attno;
 		int			outattno;
-		bool		has_toolarge = false;
+		Bitmapset  *toolarge = NULL;
 		Datum	   *relvalues = (Datum *) palloc(relDesc->natts * sizeof(Datum));
 		bool	   *relnulls = (bool *) palloc(relDesc->natts * sizeof(bool));
-		Datum      *oversized_cols_length = (Datum *) palloc0(relDesc->natts * sizeof(Datum));
 
 		heap_deform_tuple(relTuple, relDesc, relvalues, relnulls);
 
 		outattno = NUM_SAMPLE_FIXED_COLS + 1;
 		for (attno = 1; attno <= relDesc->natts; attno++)
 		{
-			Form_pg_attribute relatt = TupleDescAttr(relDesc, attno - 1);
+			Form_pg_attribute relatt = (Form_pg_attribute) relDesc->attrs[attno - 1];
+			bool		is_toolarge = false;
 			Datum		relvalue;
 			bool		relnull;
 
@@ -279,8 +279,8 @@ gp_acquire_sample_rows(PG_FUNCTION_ARGS)
 
 				if (toasted_size > WIDTH_THRESHOLD)
 				{
-					oversized_cols_length[attno - 1] = Float8GetDatum((double)toasted_size);
-					has_toolarge = true;
+					toolarge = bms_add_member(toolarge, outattno - NUM_SAMPLE_FIXED_COLS);
+					is_toolarge = true;
 					relvalue = (Datum) 0;
 					relnull = true;
 				}
@@ -294,10 +294,18 @@ gp_acquire_sample_rows(PG_FUNCTION_ARGS)
 		 * If any of the attributes were oversized, construct the text datum
 		 * to represent the bitmap.
 		 */
-		if (has_toolarge)
+		if (toolarge)
 		{
-			outvalues[2] = PointerGetDatum(construct_array(oversized_cols_length, relDesc->natts,
-														FLOAT8OID, 8, true, 'd'));
+			char	   *toolarge_str;
+			int			i;
+			int			live_natts = outDesc->natts - NUM_SAMPLE_FIXED_COLS;
+
+			toolarge_str = palloc((live_natts + 1) * sizeof(char));
+			for (i = 0; i < live_natts; i++)
+				toolarge_str[i] = bms_is_member(i + 1, toolarge) ? '1' : '0';
+			toolarge_str[i] = '\0';
+
+			outvalues[2] = CStringGetTextDatum(toolarge_str);
 			outnulls[2] = false;
 		}
 		else

--- a/src/backend/tsearch/ts_typanalyze.c
+++ b/src/backend/tsearch/ts_typanalyze.c
@@ -302,7 +302,7 @@ compute_tsvector_stats(VacAttrStats *stats,
 		stats->stats_valid = true;
 		/* Do the simple null-frac and average width stats */
 		stats->stanullfrac = (double) null_cnt / (double) samplerows;
-		stats->stawidth = (total_width + stats->totalwidelength) / (double) (nonnull_cnt + stats->widerow_num);
+		stats->stawidth = total_width / (double) nonnull_cnt;
 
 		/* Assume it's a unique column (see notes above) */
 		stats->stadistinct = -1.0 * (1.0 - stats->stanullfrac);

--- a/src/backend/utils/adt/rangetypes_typanalyze.c
+++ b/src/backend/utils/adt/rangetypes_typanalyze.c
@@ -202,7 +202,7 @@ compute_range_stats(VacAttrStats *stats, AnalyzeAttrFetchFunc fetchfunc,
 		stats->stats_valid = true;
 		/* Do the simple null-frac and width stats */
 		stats->stanullfrac = (double) null_cnt / (double) samplerows;
-		stats->stawidth = (total_width + stats->totalwidelength) / (double) (non_null_cnt + stats->widerow_num);
+		stats->stawidth = total_width / (double) non_null_cnt;
 
 		/* Estimate that non-null values are unique */
 		stats->stadistinct = -1.0 * (1.0 - stats->stanullfrac);

--- a/src/include/commands/vacuum.h
+++ b/src/include/commands/vacuum.h
@@ -94,10 +94,6 @@ typedef struct VacAttrStats
 	int			minrows;		/* Minimum # of rows wanted for stats */
 	void	   *extra_data;		/* for extra type-specific data */
 
-	/* These fields are used to compute stawidth during the compute_stats routine. */
-	double                  totalwidelength;/* total length of toowide row */
-	int                     widerow_num;    /* # of toowide row */
-
 	/*
 	 * These fields are to be filled in by the compute_stats routine. (They
 	 * are initialized to zero when the struct is created.)

--- a/src/test/regress/expected/analyze.out
+++ b/src/test/regress/expected/analyze.out
@@ -817,7 +817,7 @@ ANALYZE foo_stats;
 SELECT schemaname, tablename, attname, null_frac, avg_width, n_distinct, most_common_vals, most_common_freqs, histogram_bounds FROM pg_stats WHERE tablename='foo_stats' ORDER BY attname;
  schemaname | tablename | attname | null_frac | avg_width | n_distinct |          most_common_vals           | most_common_freqs | histogram_bounds 
 ------------+-----------+---------+-----------+-----------+------------+-------------------------------------+-------------------+------------------
- public     | foo_stats | a       |         0 |      1504 |      -0.25 | {aaa}                               | {1}               | 
+ public     | foo_stats | a       |         0 |         4 |      -0.25 | {aaa}                               | {1}               | 
  public     | foo_stats | b       |         0 |         6 |       -0.5 | {"\\x6262626262","\\x626262626232"} | {0.5,0.5}         | 
  public     | foo_stats | c       |         0 |         5 |       -0.5 | {cccc,cccc2}                        | {0.5,0.5}         | 
  public     | foo_stats | d       |         0 |         4 |       -0.5 | {2,3}                               | {0.5,0.5}         | 
@@ -840,7 +840,7 @@ ANALYZE foo_stats;
 SELECT schemaname, tablename, attname, null_frac, avg_width, n_distinct, most_common_vals, most_common_freqs, histogram_bounds FROM pg_stats WHERE tablename='foo_stats' ORDER BY attname;
  schemaname | tablename | attname | null_frac | avg_width | n_distinct |  most_common_vals   | most_common_freqs | histogram_bounds 
 ------------+-----------+---------+-----------+-----------+------------+---------------------+-------------------+------------------
- public     | foo_stats | a       |         0 |      1156 |          0 |                     |                   | 
+ public     | foo_stats | a       |         0 |      1024 |          0 |                     |                   | 
  public     | foo_stats | b       |         0 |         7 |       -0.5 | {"\\x626262626232"} | {1}               | 
  public     | foo_stats | c       |         0 |         6 |       -0.5 | {cccc2}             | {1}               | 
  public     | foo_stats | d       |         0 |         4 |       -0.5 | {3}                 | {1}               | 
@@ -938,7 +938,7 @@ select attname, null_frac, avg_width, n_distinct from pg_stats where tablename =
  attname | null_frac | avg_width | n_distinct 
 ---------+-----------+-----------+------------
  a       |         0 |         2 |         -1
- c       |         0 |      5004 |          0
+ c       |         0 |      1024 |          0
  d       |         0 |         5 |         -1
 (3 rows)
 

--- a/src/test/regress/expected/incremental_analyze.out
+++ b/src/test/regress/expected/incremental_analyze.out
@@ -1532,9 +1532,9 @@ ANALYZE foo;
 SELECT * FROM pg_stats WHERE tablename like 'foo%' and attname = 'c' ORDER BY attname,tablename;
  schemaname |  tablename  | attname | inherited | null_frac | avg_width | n_distinct | most_common_vals | most_common_freqs | histogram_bounds | correlation | most_common_elems | most_common_elem_freqs | elem_count_histogram 
 ------------+-------------+---------+-----------+-----------+-----------+------------+------------------+-------------------+------------------+-------------+-------------------+------------------------+----------------------
- public     | foo         | c       | t         |         0 |      4591 |          0 |                  |                   |                  |             |                   |                        | 
- public     | foo_1_prt_1 | c       | f         |         0 |      4591 |          0 |                  |                   |                  |             |                   |                        | 
- public     | foo_1_prt_2 | c       | f         |         0 |      4591 |          0 |                  |                   |                  |             |                   |                        | 
+ public     | foo         | c       | t         |         0 |      1024 |          0 |                  |                   |                  |             |                   |                        | 
+ public     | foo_1_prt_1 | c       | f         |         0 |      1024 |          0 |                  |                   |                  |             |                   |                        | 
+ public     | foo_1_prt_2 | c       | f         |         0 |      1024 |          0 |                  |                   |                  |             |                   |                        | 
 (3 rows)
 
 -- Test ANALYZE full scan HLL


### PR DESCRIPTION
This change impacted some other components unexpectedly and caused plan changes so it needs more work before being ready to release.

This reverts commit cbc9062a384e6827cfd3fb43818727dc01a41a1f.
