### PR TITLE
[6x backport] If QEs hit errors in explain analyze, rethrow the error before ExplainPrintPlan

### DIFF
--- a/src/backend/executor/nodeSort.c
+++ b/src/backend/executor/nodeSort.c
@@ -55,6 +55,8 @@ ExecSort(SortState *node)
 	PlanState  *outerNode = NULL;
 	TupleDesc	tupDesc = NULL;
 
+	SIMPLE_FAULT_INJECTOR("explain_analyze_sort_error");
+
 	/*
 	 * get state info from node
 	 */

--- a/src/test/regress/expected/gp_explain.out
+++ b/src/test/regress/expected/gp_explain.out
@@ -483,3 +483,41 @@ from get_explain_analyze_xml_output($$
 
 reset optimizer_enable_dynamictablescan;
 reset enable_seqscan;
+-- If all QEs hit errors when executing sort, we might not receive stat data for sort.
+-- rethrow error before print explain info.
+create extension if not exists gp_inject_fault;
+create table sort_error_test1(tc1 int, tc2 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'tc1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table sort_error_test2(tc1 int, tc2 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'tc1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into sort_error_test1 select i,i from generate_series(1,20) i;
+select gp_inject_fault('explain_analyze_sort_error', 'error', dbid)
+    from gp_segment_configuration where role = 'p' and content > -1;
+ gp_inject_fault 
+-----------------
+ Success:
+ Success:
+ Success:
+(3 rows)
+
+EXPLAIN analyze insert into sort_error_test2 select * from sort_error_test1 order by 1;
+ERROR:  fault triggered, fault name:'explain_analyze_sort_error' fault type:'error'  (seg0 127.0.1.1:6002 pid=15095)
+select count(*) from sort_error_test2;
+ count 
+-------
+     0
+(1 row)
+
+select gp_inject_fault('explain_analyze_sort_error', 'reset', dbid)
+    from gp_segment_configuration where role = 'p' and content > -1;
+ gp_inject_fault 
+-----------------
+ Success:
+ Success:
+ Success:
+(3 rows)
+
+drop table sort_error_test1;
+drop table sort_error_test2;

--- a/src/test/regress/expected/gp_explain.out
+++ b/src/test/regress/expected/gp_explain.out
@@ -483,6 +483,7 @@ from get_explain_analyze_xml_output($$
 
 reset optimizer_enable_dynamictablescan;
 reset enable_seqscan;
+reset search_path;
 -- If all QEs hit errors when executing sort, we might not receive stat data for sort.
 -- rethrow error before print explain info.
 create extension if not exists gp_inject_fault;

--- a/src/test/regress/expected/gp_explain_optimizer.out
+++ b/src/test/regress/expected/gp_explain_optimizer.out
@@ -514,6 +514,7 @@ from get_explain_analyze_xml_output($$
 
 reset optimizer_enable_dynamictablescan;
 reset enable_seqscan;
+reset search_path;
 -- If all QEs hit errors when executing sort, we might not receive stat data for sort.
 -- rethrow error before print explain info.
 create extension if not exists gp_inject_fault;

--- a/src/test/regress/expected/gp_explain_optimizer.out
+++ b/src/test/regress/expected/gp_explain_optimizer.out
@@ -514,3 +514,41 @@ from get_explain_analyze_xml_output($$
 
 reset optimizer_enable_dynamictablescan;
 reset enable_seqscan;
+-- If all QEs hit errors when executing sort, we might not receive stat data for sort.
+-- rethrow error before print explain info.
+create extension if not exists gp_inject_fault;
+create table sort_error_test1(tc1 int, tc2 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'tc1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table sort_error_test2(tc1 int, tc2 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'tc1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into sort_error_test1 select i,i from generate_series(1,20) i;
+select gp_inject_fault('explain_analyze_sort_error', 'error', dbid)
+    from gp_segment_configuration where role = 'p' and content > -1;
+ gp_inject_fault 
+-----------------
+ Success:
+ Success:
+ Success:
+(3 rows)
+
+EXPLAIN analyze insert into sort_error_test2 select * from sort_error_test1 order by 1;
+ERROR:  fault triggered, fault name:'explain_analyze_sort_error' fault type:'error'  (seg0 127.0.1.1:6002 pid=14851)
+select count(*) from sort_error_test2;
+ count 
+-------
+     0
+(1 row)
+
+select gp_inject_fault('explain_analyze_sort_error', 'reset', dbid)
+    from gp_segment_configuration where role = 'p' and content > -1;
+ gp_inject_fault 
+-----------------
+ Success:
+ Success:
+ Success:
+(3 rows)
+
+drop table sort_error_test1;
+drop table sort_error_test2;

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -59,9 +59,10 @@ test: gpcopy
 # parallel test running vacuum could have trouble
 test: matview_ao
 
-test: filter gp_combocid gpctas gpdist gpdist_opclasses gpdist_legacy_opclasses matrix toast sublink table_functions olap_setup complex opclass_ddl information_schema guc_env_var gp_explain distributed_transactions explain_format direct_dispatch_explain_analyze
+test: filter gp_combocid gpctas gpdist gpdist_opclasses gpdist_legacy_opclasses matrix toast sublink table_functions olap_setup complex opclass_ddl information_schema guc_env_var distributed_transactions explain_format direct_dispatch_explain_analyze
 
 # below test(s) inject faults so each of them need to be in a separate group
+test: gp_explain
 test: guc_gp
 test: misc_jiras
 test: statement_mem_for_windowagg

--- a/src/test/regress/sql/gp_explain.sql
+++ b/src/test/regress/sql/gp_explain.sql
@@ -306,6 +306,7 @@ from get_explain_analyze_xml_output($$
 
 reset optimizer_enable_dynamictablescan;
 reset enable_seqscan;
+reset search_path;
 
 -- If all QEs hit errors when executing sort, we might not receive stat data for sort.
 -- rethrow error before print explain info.

--- a/src/test/regress/sql/gp_explain.sql
+++ b/src/test/regress/sql/gp_explain.sql
@@ -306,3 +306,18 @@ from get_explain_analyze_xml_output($$
 
 reset optimizer_enable_dynamictablescan;
 reset enable_seqscan;
+
+-- If all QEs hit errors when executing sort, we might not receive stat data for sort.
+-- rethrow error before print explain info.
+create extension if not exists gp_inject_fault;
+create table sort_error_test1(tc1 int, tc2 int);
+create table sort_error_test2(tc1 int, tc2 int);
+insert into sort_error_test1 select i,i from generate_series(1,20) i;
+select gp_inject_fault('explain_analyze_sort_error', 'error', dbid)
+    from gp_segment_configuration where role = 'p' and content > -1;
+EXPLAIN analyze insert into sort_error_test2 select * from sort_error_test1 order by 1;
+select count(*) from sort_error_test2;
+select gp_inject_fault('explain_analyze_sort_error', 'reset', dbid)
+    from gp_segment_configuration where role = 'p' and content > -1;
+drop table sort_error_test1;
+drop table sort_error_test2;


### PR DESCRIPTION
The execution sequence of explain analyze is as follows:
ExecutorStart
ExecutorRun                              -->dispatch plan to QEs
cdbdisp_checkDispatchResult -->wait all QEs finished
ExplainPrintXXX                         -->print explain infos
ExecutorEnd                                -->reThrow QE's error, etc.;

When we execute explain analyze, we might not receive stats from QEs, If some QEs hit errors.
But, In ExplainPrintXXX we will use these stats and print explain info, if we forget to do null
judgment, this may hit a null pointer exception. Finally, in ExecutorEnd we reThrow the error from QE.

If some QE throws errors, we reThrow the error before executing ExplainPrintXXX.
backport from: fc885ec747bef7896ab115b5f3abb0de63daea89
