### PR TITLE
[7X] Fix multiple definition error when linking gpdb.

### DIFF
--- a/src/backend/cdb/dispatcher/cdbdisp_query.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_query.c
@@ -50,9 +50,6 @@
 #include "cdb/cdbcopy.h"
 #include "executor/execUtils.h"
 
-extern CGroupOpsRoutine *cgroupOpsRoutine;
-extern CGroupSystemInfo *cgroupSystemInfo;
-
 #define QUERY_STRING_TRUNCATE_SIZE (1024)
 
 extern bool Test_print_direct_dispatch_info;

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -109,9 +109,6 @@
 #include "cdb/cdbutil.h"
 #include "cdb/cdbendpoint.h"
 
-extern CGroupOpsRoutine *cgroupOpsRoutine;
-extern CGroupSystemInfo *cgroupSystemInfo;
-
 #define IS_PARALLEL_RETRIEVE_CURSOR(queryDesc)	(queryDesc->ddesc &&	\
 										queryDesc->ddesc->parallelCursorName &&	\
 										strlen(queryDesc->ddesc->parallelCursorName) > 0)

--- a/src/backend/utils/resgroup/cgroup.c
+++ b/src/backend/utils/resgroup/cgroup.c
@@ -23,10 +23,6 @@
 #include <stdio.h>
 #include <mntent.h>
 
-
-CGroupOpsRoutine *cgroupOpsRoutine;
-CGroupSystemInfo *cgroupSystemInfo;
-
 /* cgroup component names. */
 const char *component_names[CGROUP_COMPONENT_COUNT] =
 {

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -76,9 +76,6 @@
 #include "utils/cgroup-ops-v1.h"
 #include "utils/cgroup-ops-dummy.h"
 
-extern CGroupOpsRoutine *cgroupOpsRoutine;
-extern CGroupSystemInfo *cgroupSystemInfo;
-
 #define InvalidSlotId	(-1)
 #define RESGROUP_MAX_SLOTS	(MaxConnections)
 
@@ -274,6 +271,9 @@ struct ResGroupControl
 bool gp_resource_group_enable_cgroup_memory = false;
 bool gp_resource_group_enable_cgroup_swap = false;
 bool gp_resource_group_enable_cgroup_cpuset = false;
+
+CGroupOpsRoutine *cgroupOpsRoutine = NULL;
+CGroupSystemInfo *cgroupSystemInfo = NULL;
 
 /* hooks */
 resgroup_assign_hook_type resgroup_assign_hook = NULL;

--- a/src/include/utils/cgroup.h
+++ b/src/include/utils/cgroup.h
@@ -228,9 +228,9 @@ typedef struct CGroupOpsRoutine
 } CGroupOpsRoutine;
 
 /* The global function handler. */
-CGroupOpsRoutine *cgroupOpsRoutine;
+extern CGroupOpsRoutine *cgroupOpsRoutine;
 
 /* The global system info. */
-CGroupSystemInfo *cgroupSystemInfo;
+extern CGroupSystemInfo *cgroupSystemInfo;
 
 #endif	/* CGROUP_H */


### PR DESCRIPTION
My linker complains that there's multiple definition of cgroupOpsRoutine and cgroupSystemInfo.

We should declare the variable in header file with an extern tag and initialize it in one of the .c file.

Since cgroupSystemInfo and cgroupOpsRoutine are required on multiple platforms, I initialize them in resgroup.c which is compiled to object files on every platform while cgroup.c is only compiled on Linux platform.
