### PR TITLE
Fix pointer address validation instead of value

### DIFF
--- a/src/backend/cdb/cdbmirroredappendonly.c
+++ b/src/backend/cdb/cdbmirroredappendonly.c
@@ -577,7 +577,7 @@ void MirroredAppendOnly_MirrorReCreate(
 				&primaryError,
 				mirrorDataLossOccurred);
 	Assert(primaryError == 0);	// No primary work here.
-	if (mirrorDataLossOccurred)
+	if (*mirrorDataLossOccurred)
 		return;
 
 	MirroredAppendOnly_FlushAndClose(


### PR DESCRIPTION
The "if (mirrorDataLossOccurred)" condition was always true, because mirrorDataLossOccurred is always not NULL. So MirroredAppendOnly_FlushAndClose was never called.