### PR TITLE
[6X] Fix pg_dumpall to dump 5X tablespaces correctly

### DIFF
--- a/src/bin/pg_dump/pg_dumpall.c
+++ b/src/bin/pg_dump/pg_dumpall.c
@@ -1451,7 +1451,7 @@ dumpTablespaces(PGconn *conn)
 	 * Greenplum, and the dump format should vary depending on if the dump is
 	 * --gp-syntax or --no-gp-syntax.
 	 */
-	if (server_version == GPDB5_MAJOR_PGVERSION)
+	if (server_version < GPDB6_MAJOR_PGVERSION)
 	{
 		filespace_to_tablespace = true;
 		/*


### PR DESCRIPTION
Commit 99dc08f introduced a regression where dumpTablespaces will no
longer choose the correct SQL to dump tablespaces on 5X.

This conditional is removed in 7X. No 7X fix needed.