### PR TITLE
[6X] use correct hash function when summing AO tuple counts

### DIFF
--- a/src/backend/cdb/dispatcher/cdbdispatchresult.c
+++ b/src/backend/cdb/dispatcher/cdbdispatchresult.c
@@ -986,10 +986,12 @@ PQprocessAoTupCounts(struct HTAB *ht, void *aotupcounts, int naotupcounts)
 				if (!ht)
 				{
 					HASHCTL	ctl;
+					MemSet(&ctl, 0, sizeof(ctl));
 
+					ctl.hash = oid_hash;
 					ctl.keysize = sizeof(Oid);
 					ctl.entrysize = sizeof(*entry);
-					ht = hash_create("AO hash map", 10, &ctl, HASH_ELEM);
+					ht = hash_create("AO hash map", 10, &ctl, HASH_ELEM | HASH_FUNCTION);
 				}
 
 				entry = hash_search(ht, &(ao->aorelid), HASH_ENTER, &found);


### PR DESCRIPTION
Use the correct hashing function oid_hash rather than the default string_hash when summing AO tuple counts for pg_aoseg entries.

This fixes an issue where multiple aorelid's can collide resulting in the same hash table entries. This lead to updating the wrong pg_aoseg entries on the coordinator segment.

This resulted in several issues:
1) Dangling pg_aoseg entries.
- This would result in pg_upgrade failing with: `could not open Append-Only segment file ""base/16410/20863.1665"": No such file or directory"`

2) Flakey tests
- These failing tests helped track down the root cause and fix the underlying issue.
- The ICW tests would intermittently fail on the pg_upgrade check for "AO/CO parent partitions with pg_aoseg entries".

Pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/fixHashingForProcessAoTupCounts_6X