### PR TITLE
[Releng] Fix missing image artifact source: gpdb7-rhel8-build

### DIFF
--- a/concourse/pipelines/templates/gpdb-tpl.yml
+++ b/concourse/pipelines/templates/gpdb-tpl.yml
@@ -1535,8 +1535,8 @@ jobs:
       - get: bin_gpdb_clients_rhel8
         trigger: true
         passed: [gate_release_candidate_start]
-      - get: gpdb7-rhel8-build
 {% endif %}
+      - get: gpdb7-rhel8-build
   - in_parallel:
       steps:
 {% if not directed_release %}


### PR DESCRIPTION
When run by `gen_pipeline.py -t prod --directed`, it will error out by missing image artifact source: gpdb7-rhel8-build

Authored-by: Shaoqi Bai <bshaoqi@vmware.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
