### PR TITLE
docs - GRANT/REVOKE ONLY keyword

### DIFF
--- a/gpdb-doc/markdown/ref_guide/sql_commands/GRANT.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/GRANT.html.md
@@ -7,13 +7,13 @@ Defines access privileges.
 ``` {#sql_command_synopsis}
 GRANT { {SELECT | INSERT | UPDATE | DELETE | REFERENCES | 
 TRIGGER | TRUNCATE } [, ...] | ALL [PRIVILEGES] }
-    ON { [TABLE] <table_name> [, ...]
+    ON { { [ONLY <table_name>] | [TABLE] <table_name> [, ...] }
          | ALL TABLES IN SCHEMA <schema_name> [, ...] }
     TO <role_specification> [, ...] [ WITH GRANT OPTION ]
 
 GRANT { { SELECT | INSERT | UPDATE | REFERENCES } ( <column_name> [, ...] )
     [, ...] | ALL [ PRIVILEGES ] ( <column_name> [, ...] ) }
-    ON [ TABLE ] <table_name> [, ...]
+    ON { [ ONLY <table_name> ] | [ TABLE ] <table_name> [, ...] }
     TO <role_specification> [, ...] [ WITH GRANT OPTION ]
 
 GRANT { {USAGE | SELECT | UPDATE} [, ...] | ALL [PRIVILEGES] }
@@ -120,6 +120,10 @@ If `WITH ADMIN OPTION` is specified, the member may in turn grant membership in 
 If `GRANTED BY` is specified, the grant is recorded as having been done by the specified role. Only database superusers may use this option, except when it names the same role executing the command.
 
 Unlike the case with privileges, membership in a role cannot be granted to `PUBLIC`. Note also that this form of the command does not allow the noise word `GROUP` in role\_specification.
+
+**GRANT on Partitioned Tables**
+
+By default, when you grant privileges to a partitioned table, Greenplum Database recurses the operation to it's child partition tables. To direct Greenplum to perform the `GRANT` on the partitioned table only, specify the `ONLY <table_name>` clause.
 
 **GRANT on Protocols**
 

--- a/gpdb-doc/markdown/ref_guide/sql_commands/GRANT.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/GRANT.html.md
@@ -7,13 +7,13 @@ Defines access privileges.
 ``` {#sql_command_synopsis}
 GRANT { {SELECT | INSERT | UPDATE | DELETE | REFERENCES | 
 TRIGGER | TRUNCATE } [, ...] | ALL [PRIVILEGES] }
-    ON { { [ONLY <table_name>] | [TABLE] <table_name> [, ...] }
+    ON { [TABLE] [[[ONLY] <table_name> [, ...]] [, ...]]
          | ALL TABLES IN SCHEMA <schema_name> [, ...] }
     TO <role_specification> [, ...] [ WITH GRANT OPTION ]
 
 GRANT { { SELECT | INSERT | UPDATE | REFERENCES } ( <column_name> [, ...] )
     [, ...] | ALL [ PRIVILEGES ] ( <column_name> [, ...] ) }
-    ON { [ ONLY <table_name> ] | [ TABLE ] <table_name> [, ...] }
+    ON [TABLE] [[[ONLY] <table_name> [, ...]] [, ...]]
     TO <role_specification> [, ...] [ WITH GRANT OPTION ]
 
 GRANT { {USAGE | SELECT | UPDATE} [, ...] | ALL [PRIVILEGES] }

--- a/gpdb-doc/markdown/ref_guide/sql_commands/GRANT.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/GRANT.html.md
@@ -88,7 +88,7 @@ The keyword `PUBLIC` indicates that the privileges are to be granted to all role
 If `WITH GRANT OPTION` is specified, the recipient of the privilege may in turn grant it to others. Without a grant option, the recipient cannot do that. Grant options cannot be granted to `PUBLIC`.
 
 There is no need to grant privileges to the owner of an object \(usually the role that created it\), as the owner has all privileges by default. \(The owner could, however, choose to revoke some of their own privileges for safety.\)
-
+it
 The right to drop an object, or to alter its definition in any way is not treated as a grantable privilege; it is inherent in the owner, and cannot be granted or revoked. \(However, a similar effect can be obtained by granting or revoking membership in the role that owns the object; see below.\) The owner implicitly has all grant options for the object, too.
 
 The possible privileges are:
@@ -123,7 +123,7 @@ Unlike the case with privileges, membership in a role cannot be granted to `PUBL
 
 **GRANT on Partitioned Tables**
 
-By default, when you grant privileges to a partitioned table, Greenplum Database recurses the operation to it's child partition tables. To direct Greenplum to perform the `GRANT` on the partitioned table only, specify the `ONLY <table_name>` clause.
+By default, when you grant privileges to a partitioned table, Greenplum Database recurses the operation to its child partition tables. To direct Greenplum to perform the `GRANT` on the partitioned table only, specify the `ONLY <table_name>` clause.
 
 **GRANT on Protocols**
 

--- a/gpdb-doc/markdown/ref_guide/sql_commands/REVOKE.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/REVOKE.html.md
@@ -105,7 +105,7 @@ If a role holds a privilege with grant option and has granted it to other roles 
 
 When you revoke privileges on a table, Greenplum Database revokes the corresponding column privileges \(if any\) on each column of the table, as well. On the other hand, if a role has been granted privileges on a table, then revoking the same privileges from individual columns will have no effect.
 
-By default, when you revoke privileges on a partitioned table, Greenplum Database recurses the operation to it's child partition tables. To direct Greenplum to perform the `REVOKE` on the partitioned table only, specify the `ONLY <table_name>` clause.
+By default, when you revoke privileges on a partitioned table, Greenplum Database recurses the operation to its child partition tables. To direct Greenplum to perform the `REVOKE` on the partitioned table only, specify the `ONLY <table_name>` clause.
 
 When revoking membership in a role, `GRANT OPTION` is instead called `ADMIN OPTION`, but the behavior is similar. This form of the command also allows a `GRANTED BY` option, but that option is currently ignored \(except for checking the existence of the named role\). Note also that this form of the command does not allow the noise word `GROUP` in role\_specification.
 

--- a/gpdb-doc/markdown/ref_guide/sql_commands/REVOKE.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/REVOKE.html.md
@@ -8,7 +8,7 @@ Removes access privileges.
 REVOKE [GRANT OPTION FOR]
        { {SELECT | INSERT | UPDATE | DELETE | REFERENCES | TRIGGER | TRUNCATE }
        [, ...] | ALL [PRIVILEGES] }
-       ON { [TABLE] <table_name> [, ...]
+       ON { { [ONLY <table_name>] | [TABLE] <table_name> [, ...] }
           | ALL TABLES IN SCHEMA schema_name [, ...] }
        FROM <role_specification> [, ...]
        [CASCADE | RESTRICT]
@@ -16,7 +16,7 @@ REVOKE [GRANT OPTION FOR]
 REVOKE [ GRANT OPTION FOR ]
        { { SELECT | INSERT | UPDATE | REFERENCES } ( <column_name> [, ...] )
        [, ...] | ALL [ PRIVILEGES ] ( <column_name> [, ...] ) }
-       ON [ TABLE ] <table_name> [, ...]
+       ON { [ ONLY <table_name> ] | [ TABLE ] <table_name> [, ...] }
        FROM <role_specification> [, ...]
        [ CASCADE | RESTRICT ]
 
@@ -104,6 +104,8 @@ If `GRANT OPTION FOR` is specified, only the grant option for the privilege is r
 If a role holds a privilege with grant option and has granted it to other roles then the privileges held by those other roles are called dependent privileges. If the privilege or the grant option held by the first role is being revoked and dependent privileges exist, those dependent privileges are also revoked if `CASCADE` is specified, else the revoke action will fail. This recursive revocation only affects privileges that were granted through a chain of roles that is traceable to the role that is the subject of this `REVOKE` command. Thus, the affected roles may effectively keep the privilege if it was also granted through other roles.
 
 When you revoke privileges on a table, Greenplum Database revokes the corresponding column privileges \(if any\) on each column of the table, as well. On the other hand, if a role has been granted privileges on a table, then revoking the same privileges from individual columns will have no effect.
+
+By default, when you revoke privileges on a partitioned table, Greenplum Database recurses the operation to it's child partition tables. To direct Greenplum to perform the `REVOKE` on the partitioned table only, specify the `ONLY <table_name>` clause.
 
 When revoking membership in a role, `GRANT OPTION` is instead called `ADMIN OPTION`, but the behavior is similar. This form of the command also allows a `GRANTED BY` option, but that option is currently ignored \(except for checking the existence of the named role\). Note also that this form of the command does not allow the noise word `GROUP` in role\_specification.
 

--- a/gpdb-doc/markdown/ref_guide/sql_commands/REVOKE.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/REVOKE.html.md
@@ -8,7 +8,7 @@ Removes access privileges.
 REVOKE [GRANT OPTION FOR]
        { {SELECT | INSERT | UPDATE | DELETE | REFERENCES | TRIGGER | TRUNCATE }
        [, ...] | ALL [PRIVILEGES] }
-       ON { { [ONLY <table_name>] | [TABLE] <table_name> [, ...] }
+       ON { { [TABLE] [[[ONLY] <table_name> [, ...]] [, ...]] }
           | ALL TABLES IN SCHEMA schema_name [, ...] }
        FROM <role_specification> [, ...]
        [CASCADE | RESTRICT]
@@ -16,7 +16,7 @@ REVOKE [GRANT OPTION FOR]
 REVOKE [ GRANT OPTION FOR ]
        { { SELECT | INSERT | UPDATE | REFERENCES } ( <column_name> [, ...] )
        [, ...] | ALL [ PRIVILEGES ] ( <column_name> [, ...] ) }
-       ON { [ ONLY <table_name> ] | [ TABLE ] <table_name> [, ...] }
+       ON { [ [TABLE] [[[ONLY] <table_name> [, ...]] [, ...]] }
        FROM <role_specification> [, ...]
        [ CASCADE | RESTRICT ]
 


### PR DESCRIPTION
docs for https://github.com/greenplum-db/gpdb/pull/14298.

i tried this out.  seems like the user can specify only a single table name with the ONLY clause, so updated the synopsis accordingly.
