### PR TITLE
docs - gporca supports CUBE

### DIFF
--- a/gpdb-doc/markdown/admin_guide/query/topics/query-piv-opt-limitations.html.md
+++ b/gpdb-doc/markdown/admin_guide/query/topics/query-piv-opt-limitations.html.md
@@ -32,7 +32,6 @@ These features are unsupported when GPORCA is enabled \(the default\):
 -   Ordered aggregations.
 -   Multi-argument `DISTINCT` qualified aggregates, for example `SELECT corr(DISTINCT a, b) FROM tbl1;`
 -   These analytics extensions:
-    -   CUBE
     -   Multiple grouping sets
 -   These scalar operators:
     -   ROW


### PR DESCRIPTION
minimal docs, just removes CUBE from the list of things GPORCA does not support.  TBD if other docs are required.


