### PR TITLE
Speed up formatter_fixedwidth's test cases

### DIFF
--- a/contrib/formatter_fixedwidth/scripts/multi_fields_generator.sh
+++ b/contrib/formatter_fixedwidth/scripts/multi_fields_generator.sh
@@ -5,11 +5,11 @@
 # Generate a multi field large file test dataset.
 # It's used by readable_query33 test case and could avoid uploading a large file.
 
-for x in {1..50000};do
+for x in {40001..50000};do
     n=$(( $x % 2 ))
     if [ $n = 0 ] ; then
-        echo `echo $x | awk '{printf("%010d2.7182.71828185",$0)}'`
+        printf "%010d2.7182.71828185\n" $x;
     else
-        echo `echo $x | awk '{printf("%010d3.1413.14159267",$0)}'`
+        printf "%010d3.1413.14159267\n" $x;
     fi
 done

--- a/contrib/formatter_fixedwidth/scripts/single_field_generator.sh
+++ b/contrib/formatter_fixedwidth/scripts/single_field_generator.sh
@@ -5,6 +5,6 @@
 # Generate a single field large file test dataset.
 # It's used by readable_query32 test case and could avoid uploading a large file.
 
-for x in {1..50000};do
-    echo `echo $x | awk '{printf("%010d",$0)}'`;
+for x in {40001..50000};do
+    printf "%010d\n" $x;
 done


### PR DESCRIPTION
readable_query32 and readable_query33 take ~500 seconds without this commit and less than 1 second with it.

1, don't `echo | awk`, just use `printf` to generate the dataset.
2, reduce the dataset size to one-fifth.
