### PR TITLE
Fix gp_dqa test to explicitly analyze tables

### DIFF
--- a/src/test/regress/expected/gp_dqa.out
+++ b/src/test/regress/expected/gp_dqa.out
@@ -2346,7 +2346,8 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 insert into multiagg1 values(generate_series(1, 10), generate_series(1, 10), generate_series(1, 10));
 insert into multiagg2 values(generate_series(1, 10), generate_series(1, 10), 555.55);
-analyze;
+analyze multiagg1;
+analyze multiagg2;
 explain (verbose, costs off) select count(distinct b), sum(c) from multiagg1;
                                                QUERY PLAN                                               
 --------------------------------------------------------------------------------------------------------

--- a/src/test/regress/expected/gp_dqa_optimizer.out
+++ b/src/test/regress/expected/gp_dqa_optimizer.out
@@ -2499,7 +2499,8 @@ DETAIL:  Feature not supported: Unexpected target list entries in ProjectSet nod
 insert into multiagg2 values(generate_series(1, 10), generate_series(1, 10), 555.55);
 INFO:  GPORCA failed to produce a plan, falling back to planner
 DETAIL:  Feature not supported: Unexpected target list entries in ProjectSet node
-analyze;
+analyze multiagg1;
+analyze multiagg2;
 explain (verbose, costs off) select count(distinct b), sum(c) from multiagg1;
                                                QUERY PLAN                                               
 --------------------------------------------------------------------------------------------------------

--- a/src/test/regress/sql/gp_dqa.sql
+++ b/src/test/regress/sql/gp_dqa.sql
@@ -404,7 +404,8 @@ create table multiagg1(a int, b bigint, c int);
 create table multiagg2(a int, b bigint, c numeric(8, 4));
 insert into multiagg1 values(generate_series(1, 10), generate_series(1, 10), generate_series(1, 10));
 insert into multiagg2 values(generate_series(1, 10), generate_series(1, 10), 555.55);
-analyze;
+analyze multiagg1;
+analyze multiagg2;
 
 explain (verbose, costs off) select count(distinct b), sum(c) from multiagg1;
 select count(distinct b), sum(c) from multiagg1;


### PR DESCRIPTION
Commit 0f4af19b71f2f31acd28c39d0d0a865cbf1d3bab added this test, but the `analyze` statement exposed an unrelated issue and caused CI to fail. We should explicitly analyze tables to reduce runtime in tests anyway.
