### PR TITLE
Record pg_controldata output of failed segment

### DIFF
--- a/gpMgmt/bin/gppylib/heapchecksum.py
+++ b/gpMgmt/bin/gppylib/heapchecksum.py
@@ -55,6 +55,8 @@ class HeapChecksum:
             result = pg_control_data.get_results()
             gparray_gpdb = pg_control_data.gparray_gpdb
             if result.rc == 0:
+                self.logger.info("Successfully finished pg_controldata {} for dbid {}:\nstdout: {}\nstderr: {}".format(
+                    gparray_gpdb.getSegmentDataDirectory(), gparray_gpdb.getSegmentDbId(), result.stdout, result.stderr))
                 try:
                     checksum = pg_control_data.get_value('Data page checksum version')
                     gparray_gpdb.heap_checksum = checksum

--- a/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
+++ b/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
@@ -362,12 +362,13 @@ class GpRecoverSegmentProgram:
 
     def validate_heap_checksum_consistency(self, gpArray, mirrorBuilder):
         live_segments = [target.getLiveSegment() for target in mirrorBuilder.getMirrorsToBuild()]
+        failed_segments = [target.getFailedSegment() for target in mirrorBuilder.getMirrorsToBuild()]
         if len(live_segments) == 0:
             self.logger.info("No checksum validation necessary when there are no segments to recover.")
             return
 
         heap_checksum = HeapChecksum(gpArray, num_workers=min(self.__options.parallelDegree, len(live_segments)), logger=self.logger)
-        successes, failures = heap_checksum.get_segments_checksum_settings(live_segments)
+        successes, failures = heap_checksum.get_segments_checksum_settings(live_segments + failed_segments)
         # go forward if we have at least one segment that has replied
         if len(successes) == 0:
             raise Exception("No segments responded to ssh query for heap checksum validation.")

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gprecoverseg.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gprecoverseg.py
@@ -142,7 +142,7 @@ class GpRecoversegTestCase(GpTestCase):
         with self.assertRaisesRegex(Exception, "Heap checksum setting differences reported on segments"):
             self.subject.run()
 
-        self.mock_get_segments_checksum_settings.assert_called_with([self.primary0])
+        self.mock_get_segments_checksum_settings.assert_called_with([self.primary0, self.mirror0])
         self.subject.logger.fatal.assert_any_call('Heap checksum setting differences reported on segments')
         self.subject.logger.fatal.assert_any_call('Failed checksum consistency validation:')
         self.subject.logger.fatal.assert_any_call('sdw1 checksum set to 0 differs from coordinator checksum set to 1')
@@ -157,7 +157,7 @@ class GpRecoversegTestCase(GpTestCase):
         with self.assertRaisesRegex(Exception, "No segments responded to ssh query for heap checksum validation."):
             self.subject.run()
 
-        self.mock_get_segments_checksum_settings.assert_called_with([self.primary0])
+        self.mock_get_segments_checksum_settings.assert_called_with([self.primary0, self.mirror0])
         mock_heap_checksum_init.assert_called_with(self.gpArrayMock, logger=self.subject.logger, num_workers=1)
 
     @patch("os._exit")

--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -113,6 +113,30 @@ Feature: gprecoverseg tests
         And the segments are synchronized
         And check segment conf: postgresql.conf
 
+    Scenario: gprecoverseg full recovery displays pg_controldata success info
+        Given the database is running
+        And all the segments are running
+        And the segments are synchronized
+        And user stops all mirror processes
+        When user can start transactions
+        And the user runs "gprecoverseg -F -a"
+        Then gprecoverseg should return a return code of 0
+        And gprecoverseg should print "Successfully finished pg_controldata.* for dbid.*" to stdout
+        And the segments are synchronized
+        And check segment conf: postgresql.conf
+
+    Scenario: gprecoverseg incremental recovery displays pg_controldata success info
+        Given the database is running
+        And all the segments are running
+        And the segments are synchronized
+        And user stops all mirror processes
+        When user can start transactions
+        And the user runs "gprecoverseg -a"
+        Then gprecoverseg should return a return code of 0
+        And gprecoverseg should print "Successfully finished pg_controldata.* for dbid.*" to stdout
+        And the segments are synchronized
+        And check segment conf: postgresql.conf
+
     Scenario: gprecoverseg mixed recovery displays pg_basebackup and rewind progress to the user
       Given the database is running
       And all the segments are running


### PR DESCRIPTION
Currently, when doing an incremental recovery in verbose mode with "gprecoverseg -v", we record the pg_controldata output of only source data directory. We can also record the pg_controldata output of the target data directory before running pg_rewind.

Context: Recently there have been multiple pg_rewind failures due to missing wal files with customers. Often times at the time of performing incremental recovery(pg_rewind), the target segments have been shutdown for quite sometime, and if the incremental recovery failed, users usually choose to perform a full recovery as a workaround to bring the target segments up. This sequence of operations would erase the clue of what had happened on the target segment before it went down in the first place. Recording the pg_controldata output of the target data directory before running pg_rewind would tell us when and what was the latest checkpoint on the target segment before it went down, and that would be very helpful for future investigations.

Fixes https://github.com/greenplum-db/gpdb/issues/14627

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
