### PR TITLE
docs - add content for new gp_max_parallel_cursors guc (6x)

### DIFF
--- a/gpdb-doc/markdown/ref_guide/config_params/guc-list.html.md
+++ b/gpdb-doc/markdown/ref_guide/config_params/guc-list.html.md
@@ -1204,6 +1204,18 @@ Sets the tuple-serialization chunk size for the Greenplum Database interconnect.
 |-----------|-------|-------------------|
 |512-65536|8192|master, system, reload|
 
+## <a id="gp_max_parallel_cursors"></a>gp\_max\_parallel\_cursors
+
+Specifies the maximum number of active parallel retrieve cursors allowed on a Greenplum Database cluster. A parallel retrieve cursor is considered active after it has been `DECLARE`d, but before it is `CLOSE`d or returns an error.
+
+The default value is `-1`; there is no limit on the number of open parallel retrieve cursors that may be concurrently active in the cluster \(up to the maximum value of 1024\).
+
+You must be a superuser to change the `gp_max_parallel_cursors` setting.
+
+|Value Range|Default|Set Classifications|
+|-----------|-------|-------------------|
+|-1 - 1024 | -1 | master, superuser, session, reload|
+
 ## <a id="gp_max_plan_size"></a>gp\_max\_plan\_size 
 
 Specifies the total maximum uncompressed size of a query execution plan multiplied by the number of Motion operators \(slices\) in the plan. If the size of the query plan exceeds the value, the query is cancelled and an error is returned. A value of 0 means that the size of the plan is not monitored.

--- a/gpdb-doc/markdown/ref_guide/config_params/guc_category-list.html.md
+++ b/gpdb-doc/markdown/ref_guide/config_params/guc_category-list.html.md
@@ -99,6 +99,11 @@ You can configure the execution cost of `VACUUM` and `ANALYZE` commands to reduc
 - [xid_stop_limit](guc-list.html#xid_stop_limit)
 - [xid_warn_limit](guc-list.html#xid_warn_limit)
 
+### <a id="topic20other"></a>Other Parameters 
+
+- [gp\_max\_parallel\_cursors](guc-list.html#gp_max_parallel_cursors)
+
+
 ## <a id="topic57"></a>GPORCA Parameters 
 
 These parameters control the usage of GPORCA by Greenplum Database. For information about GPORCA, see [About GPORCA](../../admin_guide/query/topics/query-piv-optimizer.html) in the *Greenplum Database Administrator Guide*.

--- a/gpdb-doc/markdown/ref_guide/modules/gp_parallel_retrieve_cursor.html.md
+++ b/gpdb-doc/markdown/ref_guide/modules/gp_parallel_retrieve_cursor.html.md
@@ -11,6 +11,7 @@ This topic includes the following sections:
 -   [Installing and Registering the Module](#topic_reg)
 -   [About the gp\_parallel\_retrieve\_cursor Module](#topic_about)
 -   [Using the gp\_parallel\_retrieve\_cursor Module](#topic_using)
+-   [Limiting the Number of Concurrently Open Cursors](#topic_cfg)
 -   [Known Issues and Limitations](#topic_limits)
 -   [Additional Module Documentation](#topic_addtldocs)
 -   [Example](#topic_examples)
@@ -259,11 +260,15 @@ The commands return endpoint and retrieve session information in a table with th
 
 Refer to the [gp\_segment\_endpoints](../system_catalogs/gp_segment_endpoints.html#topic1) view reference page for more information about the endpoint attributes returned by these commands.
 
+## <a id="topic_cfg"></a>Limiting the Number of Concurrently Open Cursors
+
+By default, Greenplum Database does not limit the number of parallel retrieve cursors that are active in the cluster \(up to the maximum value of 1024\). The Greenplum Database superuser can set the [gp\_max\_parallel\_cursors](../ref_guide/config_params/guc-list.html#gp_max_parallel_cursors) server configuration parameter to limit the number of open cursors.
+
 ## <a id="topic_limits"></a>Known Issues and Limitations 
 
 The `gp_parallel_retrieve_cursor` module has the following limitations:
 
--   The Tanzu Greenplum Query Optimizer \(GPORCA\) does not support queries on a parallel retrieve cursor.
+-   The Greenplum Query Optimizer \(GPORCA\) does not support queries on a parallel retrieve cursor.
 -   Greenplum Database ignores the `BINARY` clause when you declare a parallel retrieve cursor.
 -   Parallel retrieve cursors cannot be declared `WITH HOLD`.
 -   Parallel retrieve cursors do not support the `FETCH` and `MOVE` cursor operations.

--- a/gpdb-doc/markdown/ref_guide/modules/greenplum_fdw.html.md
+++ b/gpdb-doc/markdown/ref_guide/modules/greenplum_fdw.html.md
@@ -19,7 +19,7 @@ This topic includes the following sections:
 
 ## <a id="topic_reg"></a>Installing and Registering the Module 
 
-The `greenplum_fdw` module is installed when you install Greenplum Database. Before you can use this FDW, you must register the `greenplum_fdw` extension in each database in the source Greenplum Database cluster in which you plan to use it:
+The `greenplum_fdw` module is installed when you install Greenplum Database. Before you can use this FDW, you must register the `greenplum_fdw` extension in each database in the local Greenplum Database cluster in which you plan to use it:
 
 ```
 CREATE EXTENSION greenplum_fdw;
@@ -35,7 +35,7 @@ Refer to [Installing Additional Supplied Modules](../../install_guide/install_mo
 
 ## <a id="topic_about"></a>About the greenplum\_fdw Module 
 
-`greenplum_fdw` is an MPP version of the [postgres\_fdw](https://www.postgresql.org/docs/9.4/postgres-fdw.html) foreign-data wrapper. While it behaves similarly to `postgres_fdw` in many respects, `greenplum_fdw` uses a Greenplum Database parallel retrieve cursor to pull data directly from the segments of a remote Greenplum cluster to the segments in the source Greenplum cluster, in parallel.
+`greenplum_fdw` is an MPP version of the [postgres\_fdw](https://www.postgresql.org/docs/9.4/postgres-fdw.html) foreign-data wrapper. While it behaves similarly to `postgres_fdw` in many respects, `greenplum_fdw` uses a Greenplum Database parallel retrieve cursor to pull data directly from the segments of a remote Greenplum cluster to the segments in the local Greenplum cluster, in parallel.
 
 By supporting predicate pushdown, `greenplum_fdw` minimizes the amount of data transferred between the Greenplum clusters by sending a query filter condition to the remote Greenplum server where it is applied there.
 
@@ -44,7 +44,7 @@ By supporting predicate pushdown, `greenplum_fdw` minimizes the amount of data t
 You will perform the following tasks when you use `greenplum_fdw` to access data that resides in a remote Greenplum Database cluster\(s\):
 
 1.  [Create a server](#create_server) to represent each remote Greenplum database to which you want to connect.
-2.  [Create a user mapping](#user_mapping) for each \(source\) Greenplum Database user that you want to allow to access each server.
+2.  [Create a user mapping](#user_mapping) for each \(local\) Greenplum Database user that you want to allow to access each server.
 3.  [Create a foreign table](#create_ftable) for each remote Greenplum table that you want to access.
 4.  [Construct and run queries](#query_ftable).
 
@@ -72,7 +72,7 @@ in the `OPTIONS` clause when you create the server. Set num to the number of seg
 num_segments
 ```
 
-option, the default value is the number of segments on the local/source Greenplum Database cluster.
+option, the default value is the number of segments on the local Greenplum Database cluster.
 
 The following example command creates a server named `gpc1_testdb` that will be used to access tables residing in the database named `testdb` on the remote `8`-segment Greenplum Database cluster whose master is running on the host `gpc1_master`, port `5432`:
 
@@ -83,18 +83,18 @@ CREATE SERVER gpc1_testdb FOREIGN DATA WRAPPER greenplum_fdw
 
 ### <a id="user_mapping"></a>Creating a User Mapping 
 
-After you identify which users you will allow to access the remote Greenplum Database cluster, you must create one or more mappings between a source Greenplum user and a user on the remote Greenplum cluster. You create these mappings with the [CREATE USER MAPPING](../sql_commands/CREATE_USER_MAPPING.html) command.
+After you identify which users you will allow to access the remote Greenplum Database cluster, you must create one or more mappings between a local Greenplum user and a user on the remote Greenplum cluster. You create these mappings with the [CREATE USER MAPPING](../sql_commands/CREATE_USER_MAPPING.html) command.
 
 User mappings that you create may include the following `OPTIONS`:
 
 |Option Name|Description|Default Value|
 |-----------|-----------|-------------|
-|user|The name of the remote Greenplum Database user to connect as.|The name of the current Greenplum Database user.|
+|user|The name of the remote Greenplum Database user to connect as.|The name of the current \(local\) Greenplum Database user.|
 |password|The password for user on the remote Greenplum Database system.|No default value.|
 
 Only a Greenplum Database superuser may connect to a Greenplum foreign server without password authentication. Always specify the `password` option for user mappings that you create for non-superusers.
 
-The following command creates a default user mapping on the source Greenplum cluster to the user named `bill` on the remote Greenplum cluster that allows access to the database identified by the `gpc1_testdb` server. Specifying the `PUBLIC` source user name creates a mapping for all current and future users when no user-specific mapping is applicable.
+The following command creates a default user mapping on the local Greenplum cluster to the user named `bill` on the remote Greenplum cluster that allows access to the database identified by the `gpc1_testdb` server. Specifying the `PUBLIC` user name creates a mapping for all current and future users when no user-specific mapping is applicable.
 
 ```
 CREATE USER MAPPING FOR PUBLIC SERVER gpc1_testdb
@@ -168,7 +168,7 @@ Setting this option at the foreign table-level overrides a foreign server-level 
 
 The `greenplum_fdw` module has the following known issues and limitations:
 
--   The Tanzu Greenplum Query Optimizer \(GPORCA\) does not support queries on foreign tables that you create with the `greenplum_fdw` foreign-data wrapper.
+-   The Greenplum Query Optimizer \(GPORCA\) does not support queries on foreign tables that you create with the `greenplum_fdw` foreign-data wrapper.
 -   `greenplum_fdw` does not support `UPDATE` and `DELETE` operations on foreign tables.
 
 ## <a id="topic_compat"></a>Compatibility 
@@ -192,7 +192,7 @@ In this example, you query data residing in a database named `rdb` on the remote
     ```
 
 3.  Exit the session.
-4.  Initiate a `psql` session to the database named `testdb` on the source \(local in this case\) Greenplum Database master host:
+4.  Initiate a `psql` session to the database named `testdb` on the local Greenplum Database master host:
 
     ```
     $ psql -d testdb

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -4566,7 +4566,7 @@ struct config_int ConfigureNamesInt_gp[] =
 
 	{
 		{"gp_max_parallel_cursors", PGC_SUSET, RESOURCES,
-			gettext_noop("Parallel cursor concurrency control from the source cluster side, -1 means no limit, which is the default"),
+			gettext_noop("Parallel cursor concurrency control, -1 means no limit, which is the default"),
 			NULL, GUC_SUPERUSER_ONLY | GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&gp_max_parallel_cursors,


### PR DESCRIPTION
docs for https://github.com/greenplum-db/gpdb/pull/14146.  this is basically a backport of https://github.com/greenplum-db/gpdb/pull/14548 for 6X_STABLE.  the guc reference info is the same.  same updates to guc_gp.c. changes:
- parallel cursor functionality is a module in 6X_STABLE.  
- also updated the greenplum_fdw module docs to use "local" and "remote", which involved changing some references of source -> local.
