### PR TITLE
Fixing ONLY keyword for multiple tables in GRANT/REVOKE

### DIFF
--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -17653,11 +17653,11 @@ qualified_name_list_with_only:
 					$2->inh = false; 
 					$$ = list_make1($2);
 				}
-			| qualified_name_list ',' qualified_name
+			| qualified_name_list_with_only ',' qualified_name
 				{
 					$$ = lappend($1, $3);
 				}
-			| qualified_name_list ',' ONLY qualified_name
+			| qualified_name_list_with_only ',' ONLY qualified_name
 				{
 					$4->inh = false; 
 					$$ = lappend($1, $4);

--- a/src/test/regress/expected/role.out
+++ b/src/test/regress/expected/role.out
@@ -144,3 +144,36 @@ BEGIN;
 ALTER USER ALL SET application_name TO 'alter_user_all_test';
 ALTER USER ALL RESET ALL;
 ROLLBACK;
+-- Various syntax for GRANT/REVOKE with ONLY keywords.
+-- Only cover syntax correctness here, the actual grant behavior
+-- for ONLY is tested in partition.sql
+create table grant_only_syntax1 (a int);
+create table grant_only_syntax2 (a int);
+create role test_role;
+-- These should all work
+grant select on table grant_only_syntax1, grant_only_syntax2 to test_role;
+grant select on table only grant_only_syntax1, grant_only_syntax2 to test_role;
+grant select on table grant_only_syntax1, only grant_only_syntax2 to test_role;
+grant select on table only grant_only_syntax1, only grant_only_syntax2 to test_role;
+grant select on grant_only_syntax1, grant_only_syntax2 to test_role;
+grant select on only grant_only_syntax1, grant_only_syntax2 to test_role;
+grant select on grant_only_syntax1, only grant_only_syntax2 to test_role;
+grant select on only grant_only_syntax1, only grant_only_syntax2 to test_role;
+revoke select on table grant_only_syntax1, grant_only_syntax2 from test_role;
+revoke select on table only grant_only_syntax1, grant_only_syntax2 from test_role;
+NOTICE:  no privileges could be revoked
+revoke select on table grant_only_syntax1, only grant_only_syntax2 from test_role;
+NOTICE:  no privileges could be revoked
+revoke select on table only grant_only_syntax1, only grant_only_syntax2 from test_role;
+NOTICE:  no privileges could be revoked
+revoke select on grant_only_syntax1, grant_only_syntax2 from test_role;
+NOTICE:  no privileges could be revoked
+revoke select on only grant_only_syntax1, grant_only_syntax2 from test_role;
+NOTICE:  no privileges could be revoked
+revoke select on grant_only_syntax1, only grant_only_syntax2 from test_role;
+NOTICE:  no privileges could be revoked
+revoke select on only grant_only_syntax1, only grant_only_syntax2 from test_role;
+NOTICE:  no privileges could be revoked
+drop table grant_only_syntax1;
+drop table grant_only_syntax2;
+drop role test_role;

--- a/src/test/regress/sql/role.sql
+++ b/src/test/regress/sql/role.sql
@@ -122,3 +122,32 @@ BEGIN;
 ALTER USER ALL SET application_name TO 'alter_user_all_test';
 ALTER USER ALL RESET ALL;
 ROLLBACK;
+
+-- Various syntax for GRANT/REVOKE with ONLY keywords.
+-- Only cover syntax correctness here, the actual grant behavior
+-- for ONLY is tested in partition.sql
+create table grant_only_syntax1 (a int);
+create table grant_only_syntax2 (a int);
+create role test_role;
+
+-- These should all work
+grant select on table grant_only_syntax1, grant_only_syntax2 to test_role;
+grant select on table only grant_only_syntax1, grant_only_syntax2 to test_role;
+grant select on table grant_only_syntax1, only grant_only_syntax2 to test_role;
+grant select on table only grant_only_syntax1, only grant_only_syntax2 to test_role;
+grant select on grant_only_syntax1, grant_only_syntax2 to test_role;
+grant select on only grant_only_syntax1, grant_only_syntax2 to test_role;
+grant select on grant_only_syntax1, only grant_only_syntax2 to test_role;
+grant select on only grant_only_syntax1, only grant_only_syntax2 to test_role;
+revoke select on table grant_only_syntax1, grant_only_syntax2 from test_role;
+revoke select on table only grant_only_syntax1, grant_only_syntax2 from test_role;
+revoke select on table grant_only_syntax1, only grant_only_syntax2 from test_role;
+revoke select on table only grant_only_syntax1, only grant_only_syntax2 from test_role;
+revoke select on grant_only_syntax1, grant_only_syntax2 from test_role;
+revoke select on only grant_only_syntax1, grant_only_syntax2 from test_role;
+revoke select on grant_only_syntax1, only grant_only_syntax2 from test_role;
+revoke select on only grant_only_syntax1, only grant_only_syntax2 from test_role;
+
+drop table grant_only_syntax1;
+drop table grant_only_syntax2;
+drop role test_role;


### PR DESCRIPTION
Commit bc08de1cc5bb introduced ONLY keyword for GRANT/REVOKE. However there's an issue in the grammar where if the table list starts with a table with ONLY, it could not contain more tables with ONLY. Fixing it and adding test cases for all possible syntax.

Thanks to @lisakowen who found this in https://github.com/greenplum-db/gpdb/pull/14615

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
