### PR TITLE
Remove the generated 'stdin' and 'stdout' files

### DIFF
--- a/src/test/regress/.gitignore
+++ b/src/test/regress/.gitignore
@@ -9,13 +9,13 @@
 # Configure-generated files
 /GPTest.pm
 
-
 # ignore test tablespaces
 /testtablespace_default_tablespace/
 /testtablespace_temp_tablespace/
 
 twophase_pqexecparams
 
+data/part_ext.tbl
 data/wet_csv?.tbl
 data/wet_text?.tbl
 data/wet_syntax?.tbl
@@ -25,12 +25,6 @@ data/gpsd-without-hll.sql
 data/gpsd-with-hll.sql
 data/minirepro.sql
 
-regression.diffs
-regression.out
-
-stdin
-stdout
-=======
 # Note: regreesion.* are only left behind on a failure; that's why they're not ignored
 #/regression.diffs
 #/regression.out

--- a/src/test/regress/input/gpcopy.source
+++ b/src/test/regress/input/gpcopy.source
@@ -703,6 +703,8 @@ COPY segment_reject_limit_from to STDOUT log errors segment reject limit 3 rows;
 \copy segment_reject_limit_from from 'stdin';
 \copy segment_reject_limit_from to 'stdout';
 \copy segment_reject_limit_from from 'stdout';
+\!rm stdin
+\!rm stdout
 
 -- gp_initial_bad_row_limit guc test. This guc allows user to set the initial
 -- number of rows which can contain errors before the database stops loading

--- a/src/test/regress/output/gpcopy.source
+++ b/src/test/regress/output/gpcopy.source
@@ -748,6 +748,8 @@ ERROR:  COPY single row error handling only available using COPY FROM
 \copy segment_reject_limit_from from 'stdin';
 \copy segment_reject_limit_from to 'stdout';
 \copy segment_reject_limit_from from 'stdout';
+\!rm stdin
+\!rm stdout
 -- gp_initial_bad_row_limit guc test. This guc allows user to set the initial
 -- number of rows which can contain errors before the database stops loading
 -- the data. If there is a valid row within the first 'n' rows specified by


### PR DESCRIPTION
`\!rm` to test if they are located in the right directory.
