### PR TITLE
Revamp GpVars_Verbosity logging

### DIFF
--- a/src/backend/cdb/cdbvars.c
+++ b/src/backend/cdb/cdbvars.c
@@ -470,10 +470,9 @@ show_gp_role(void)
  * "OFF"	 -> only errors are logged
  * "TERSE"	 -> terse logging of routine events, e.g. creation of new qExecs
  * "VERBOSE" -> gang allocation per command is logged
- * "DEBUG"	 -> additional events are logged at severity level DEBUG1 to DEBUG5
+ * "DEBUG"	 -> additional events are logged
  *
- * The messages that are enabled by the TERSE and VERBOSE settings are
- * written with a severity level of LOG.
+ * All messages enabled by these settings have severity level of LOG.
  */
 int gp_log_gang;
 
@@ -484,10 +483,9 @@ int gp_log_gang;
  * "OFF"	 -> only errors are logged
  * "TERSE"	 -> terse logging of routine events
  * "VERBOSE" -> gang allocation per command is logged
- * "DEBUG"	 -> additional events are logged at severity level DEBUG1 to DEBUG5
+ * "DEBUG"	 -> additional events are logged
  *
- * The messages that are enabled by the TERSE and VERBOSE settings are
- * written with a severity level of LOG.
+ * All messages enabled by these settings have severity level of LOG.
  */
 int gp_log_fts;
 
@@ -498,10 +496,11 @@ int gp_log_fts;
  * "OFF"	 -> connection errors are logged
  * "TERSE"	 -> terse logging of routine events, e.g. successful connections
  * "VERBOSE" -> most interconnect setup events are logged
- * "DEBUG"	 -> additional events are logged at severity level DEBUG1 to DEBUG5.
+ * "DEBUG"	 -> additional events are logged
+ * "DEBUG2"   -> more additional events are logged
+ * "DEBUG3"   -> full additional events are logged
  *
- * The messages that are enabled by the TERSE and VERBOSE settings are
- * written with a severity level of LOG.
+ * All messages enabled by these settings have severity level of LOG.
  */
 int gp_log_interconnect;
 

--- a/src/backend/cdb/motion/ic_proxy_backend.c
+++ b/src/backend/cdb/motion/ic_proxy_backend.c
@@ -154,7 +154,7 @@ ic_proxy_backend_on_read_hello_ack(uv_stream_t *stream, ssize_t nread, const uv_
 		/* UV_EOF is expected */
 		if (nread == UV_EOF)
 		{
-			elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG1,
+			elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 				   "ic-proxy: backend %s: received EOF while receiving HELLO ACK.",
 				   ic_proxy_key_to_str(&backend->key));
 		}
@@ -233,7 +233,7 @@ ic_proxy_backend_on_sent_hello(uv_write_t *req, int status)
 
 	if (status < 0)
 	{
-		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG1,
+		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 			   "ic-proxy: backend %s: backend failed to send HELLO: %s",
 					 ic_proxy_key_to_str(&backend->key), uv_strerror(status));
 		uv_close((uv_handle_t *) &backend->pipe, ic_proxy_backend_on_close);
@@ -241,7 +241,7 @@ ic_proxy_backend_on_sent_hello(uv_write_t *req, int status)
 	}
 
 	/* recieve hello ack */
-	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG1,
+	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 		   "ic-proxy: backend %s: backend connected, receiving HELLO ACK",
 				 ic_proxy_key_to_str(&backend->key));
 
@@ -289,7 +289,7 @@ ic_proxy_backend_on_connected(uv_connect_t *conn, int status)
 	if (status < 0)
 	{
 		/* the proxy might just not get ready yet, retry later */
-		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG1,
+		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 			   "ic-proxy: backend %s: backend failed to connect: %s",
 					 ic_proxy_key_to_str(&backend->key), uv_strerror(status));
 
@@ -306,7 +306,7 @@ ic_proxy_backend_on_connected(uv_connect_t *conn, int status)
 		return;
 	}
 
-	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG1,
+	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 		   "ic-proxy: backend %s: backend connected, sending HELLO message.",
 				 ic_proxy_key_to_str(&backend->key));
 

--- a/src/backend/cdb/motion/ic_proxy_client.c
+++ b/src/backend/cdb/motion/ic_proxy_client.c
@@ -293,7 +293,7 @@ ic_proxy_client_register(ICProxyClient *client)
 		}
 
 		/* it's a placeholder, this happens if the pkts arrived before me */
-		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG3,
+		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 			   "ic-proxy: %s: replace my placeholder %s",
 					 ic_proxy_client_get_name(client),
 					 ic_proxy_client_get_name(placeholder));
@@ -304,7 +304,7 @@ ic_proxy_client_register(ICProxyClient *client)
 		 * it really happens, don't panic, nothing serious.
 		 */
 		if (placeholder->pkts == NIL)
-			elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG3,
+			elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 				   "ic-proxy: %s: no cached pkts in the placeholder %s",
 						 ic_proxy_client_get_name(client),
 						 ic_proxy_client_get_name(placeholder));
@@ -324,7 +324,7 @@ ic_proxy_client_register(ICProxyClient *client)
 			 * itself, so free it directly.
 			 */
 			ic_proxy_free(placeholder);
-			elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG5,
+			elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG3, LOG,
 				   "%s: freed my placeholder",
 						 ic_proxy_client_get_name(client));
 		}
@@ -379,7 +379,7 @@ ic_proxy_client_unregister(ICProxyClient *client)
 
 		if (client->pkts)
 		{
-			elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG3,
+			elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 				   "%s: transfer %d unhandled pkts to my successor",
 						 ic_proxy_client_get_name(client),
 						 list_length(client->pkts));
@@ -406,7 +406,7 @@ ic_proxy_client_unregister(ICProxyClient *client)
 	{
 		ICProxyClient *placeholder;
 
-		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG3,
+		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 			   "%s: transfer %d unhandled pkts to my placeholder",
 					 ic_proxy_client_get_name(client),
 					 list_length(client->pkts));
@@ -449,7 +449,7 @@ ic_proxy_client_blessed_lookup(uv_loop_t *loop, const ICProxyKey *key)
 		client->key = *key;
 		ic_proxy_client_register(client);
 
-		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG3,
+		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 			   "ic-proxy: %s: registered as a placeholder",
 					 ic_proxy_client_get_name(client));
 	}
@@ -480,7 +480,7 @@ ic_proxy_client_on_c2p_data_pkt(void *opaque, const void *data, uint16 size)
 {
 	ICProxyClient *client = opaque;
 
-	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG5,
+	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG3, LOG,
 		   "ic-proxy: %s: received B2C PKT [%d bytes] from the backend",
 				 ic_proxy_client_get_name(client), size);
 
@@ -564,7 +564,7 @@ ic_proxy_client_on_c2p_data(uv_stream_t *stream,
 					 "ic-proxy: %s: paused already, but still received DATA[%zd bytes] from the backend, state is 0x%08x",
 					 ic_proxy_client_get_name(client), nread, client->state);
 
-	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG5,
+	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG3, LOG,
 		   "%s: received DATA[%zd bytes] from the backend",
 				 ic_proxy_client_get_name(client), nread);
 
@@ -590,7 +590,7 @@ ic_proxy_client_maybe_start_read_data(ICProxyClient *client)
 		 */
 		return;
 
-	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG3,
+	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 		   "ic-proxy: %s: start receiving DATA",
 				 ic_proxy_client_get_name(client));
 
@@ -675,7 +675,7 @@ ic_proxy_client_on_hello_pkt(void *opaque, const void *data, uint16 size)
 		return;
 	}
 
-	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG1,
+	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 		   "%s: received %s from the backend",
 				 ic_proxy_client_get_name(client), ic_proxy_pkt_to_str(pkt));
 
@@ -866,7 +866,7 @@ ic_proxy_client_new(uv_loop_t *loop, bool placeholder)
 static void
 ic_proxy_client_free(ICProxyClient *client)
 {
-	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG5,
+	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG3, LOG,
 		   "ic-proxy: %s: freeing", ic_proxy_client_get_name(client));
 
 	/*
@@ -1134,7 +1134,7 @@ ic_proxy_client_on_p2c_message(ICProxyClient *client, const ICProxyPkt *pkt,
 {
 	if (ic_proxy_pkt_is(pkt, IC_PROXY_MESSAGE_BYE))
 	{
-		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG1,
+		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 			   "ic-proxy: %s: received %s",
 					 ic_proxy_client_get_name(client),
 					 ic_proxy_pkt_to_str(pkt));
@@ -1145,7 +1145,7 @@ ic_proxy_client_on_p2c_message(ICProxyClient *client, const ICProxyPkt *pkt,
 	}
 	else if (ic_proxy_pkt_is(pkt, IC_PROXY_MESSAGE_DATA_ACK))
 	{
-		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG3,
+		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 			   "ic-proxy: %s: received %s, with %d existing unack packets",
 					 ic_proxy_client_get_name(client),
 					 ic_proxy_pkt_to_str(pkt),
@@ -1199,7 +1199,7 @@ ic_proxy_client_on_p2c_data(ICProxyClient *client, ICProxyPkt *pkt,
 	{
 		if (ic_proxy_pkt_is_out_of_date(pkt, &client->key))
 		{
-			elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG3,
+			elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 				   "%s: drop out-of-date %s",
 						 ic_proxy_client_get_name(client),
 						 ic_proxy_pkt_to_str(pkt));
@@ -1210,7 +1210,7 @@ ic_proxy_client_on_p2c_data(ICProxyClient *client, ICProxyPkt *pkt,
 		{
 			Assert(ic_proxy_pkt_is_in_the_future(pkt, &client->key));
 
-			elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG3,
+			elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 				   "ic-proxy: %s: future %s",
 						 ic_proxy_client_get_name(client),
 						 ic_proxy_pkt_to_str(pkt));
@@ -1261,7 +1261,7 @@ ic_proxy_client_cache_p2c_pkt(ICProxyClient *client, ICProxyPkt *pkt)
 
 	client->pkts = lappend(client->pkts, pkt);
 
-	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG3,
+	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 		   "ic-proxy: %s: cached a %s for future use, %d in the list",
 				 ic_proxy_client_get_name(client), ic_proxy_pkt_to_str(pkt),
 				 list_length(client->pkts));
@@ -1281,7 +1281,7 @@ ic_proxy_client_cache_p2c_pkts(ICProxyClient *client, List *pkts)
 
 	client->pkts = list_concat(client->pkts, pkts);
 
-	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG3,
+	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 				 "ic-proxy: %s: cached %d pkts for future use, %d in the list",
 				 ic_proxy_client_get_name(client),
 				 list_length(pkts), list_length(client->pkts));
@@ -1334,7 +1334,7 @@ ic_proxy_client_handle_p2c_cache(ICProxyClient *client)
 	if (client->pkts == NIL)
 		return;
 
-	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG3,
+	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 		   "ic-proxy: %s: trying to consume the %d cached pkts",
 				 ic_proxy_client_get_name(client), list_length(client->pkts));
 
@@ -1359,7 +1359,7 @@ ic_proxy_client_handle_p2c_cache(ICProxyClient *client)
 		ic_proxy_client_on_p2c_data(client, pkt, NULL, NULL);
 	}
 
-	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG3,
+	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 		   "ic-proxy: %s: consumed %d cached pkts",
 				 ic_proxy_client_get_name(client), count);
 }
@@ -1370,7 +1370,7 @@ ic_proxy_client_handle_p2c_cache(ICProxyClient *client)
 static void
 ic_proxy_client_maybe_send_ack_message(ICProxyClient *client)
 {
-	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG3,
+	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 		   "ic-proxy: %s: %d unconsumed packets to the backend",
 				 ic_proxy_client_get_name(client), client->unconsumed);
 
@@ -1410,7 +1410,7 @@ ic_proxy_client_maybe_pause(ICProxyClient *client)
 		client->state |= IC_PROXY_CLIENT_STATE_PAUSED;
 		uv_read_stop((uv_stream_t *) &client->pipe);
 
-		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG1,
+		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 			   "ic-proxy: %s: paused", ic_proxy_client_get_name(client));
 	}
 }
@@ -1428,7 +1428,7 @@ ic_proxy_client_maybe_resume(ICProxyClient *client)
 
 		client->state &= ~IC_PROXY_CLIENT_STATE_PAUSED;
 
-		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG1,
+		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 			   "ic-proxy: %s: resumed", ic_proxy_client_get_name(client));
 	}
 }

--- a/src/backend/cdb/motion/ic_proxy_iobuf.c
+++ b/src/backend/cdb/motion/ic_proxy_iobuf.c
@@ -343,7 +343,7 @@ ic_proxy_obuf_push(ICProxyOBuf *obuf,
 		/* TODO: should we flush if no data in the packet? */
 		if (obuf->len == obuf->header_size)
 		{
-			elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG1,
+			elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 				   "ic-proxy: no data to flush");
 		}
 		else

--- a/src/backend/cdb/motion/ic_proxy_main.c
+++ b/src/backend/cdb/motion/ic_proxy_main.c
@@ -316,7 +316,7 @@ ic_proxy_server_client_listener_init(uv_loop_t *loop)
 	ic_proxy_build_server_sock_path(path, sizeof(path));
 
 	/* FIXME: do not unlink here */
-	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG5,
+	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG3, LOG,
 		   "ic-proxy: unlink(%s) ...", path);
 	unlink(path);
 
@@ -591,7 +591,7 @@ ic_proxy_server_main(void)
 
 	ic_proxy_build_server_sock_path(path, sizeof(path));
 #if 0
-	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG5, LOG, "unlink(%s) ...", path);
+	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG3, LOG, "unlink(%s) ...", path);
 	unlink(path);
 #endif
 

--- a/src/backend/cdb/motion/ic_proxy_peer.c
+++ b/src/backend/cdb/motion/ic_proxy_peer.c
@@ -217,7 +217,7 @@ ic_proxy_peer_register(ICProxyPeer *peer)
 		else
 		{
 			/* This is an actual placeholder */
-			elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG3,
+			elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 				   "ic-proxy: %s(state=0x%08x): found my placeholder %s(state=0x%08x)",
 						 peer->name, peer->state,
 						 placeholder->name, placeholder->state);
@@ -287,7 +287,7 @@ ic_proxy_peer_on_data_pkt(void *opaque, const void *data, uint16 size)
 	const ICProxyPkt *pkt = data;
 	ICProxyPeer *peer = opaque;
 
-	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG5,
+	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG3, LOG,
 		   "ic-proxy: %s: received %s", peer->name, ic_proxy_pkt_to_str(pkt));
 
 	if (!(peer->state & IC_PROXY_PEER_STATE_READY_FOR_DATA))
@@ -374,7 +374,7 @@ ic_proxy_peer_free(ICProxyPeer *peer)
 {
 	ListCell   *cell;
 
-	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG5,
+	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG3, LOG,
 		   "ic-proxy: %s: freeing", peer->name);
 
 	foreach(cell, peer->reqs)
@@ -501,7 +501,7 @@ ic_proxy_peer_on_sent_hello_ack(void *opaque, const ICProxyPkt *pkt, int status)
 
 	peer->state |= IC_PROXY_PEER_STATE_SENT_HELLO_ACK;
 
-	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG3,
+	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 		   "ic-proxy: %s: start receiving DATA", peer->name);
 
 	/* it's unlikely that the ibuf is non-empty, but clear it for sure */
@@ -547,7 +547,7 @@ ic_proxy_peer_on_hello_pkt(void *opaque, const void *data, uint16 size)
 	 */
 	ic_proxy_peer_register(peer);
 
-	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG1,
+	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 		   "ic-proxy: %s: received %s, sending HELLO ACK",
 				 peer->name, ic_proxy_pkt_to_str(pkt));
 
@@ -614,7 +614,7 @@ ic_proxy_peer_read_hello(ICProxyPeer *peer)
 	if (peer->state & IC_PROXY_PEER_STATE_RECEIVING_HELLO)
 		return;
 
-	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG3,
+	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 		   "%s: waiting for HELLO", peer->name);
 
 	peer->state |= IC_PROXY_PEER_STATE_RECEIVING_HELLO;
@@ -664,7 +664,7 @@ ic_proxy_peer_on_hello_ack_pkt(void *opaque, const void *data, uint16 size)
 	/* we only expect one hello ack message */
 	uv_read_stop((uv_stream_t *) &peer->tcp);
 
-	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG1,
+	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 		   "ic-proxy: %s: received %s", peer->name, ic_proxy_pkt_to_str(pkt));
 
 	peer->state |= IC_PROXY_PEER_STATE_RECEIVED_HELLO_ACK;
@@ -678,7 +678,7 @@ ic_proxy_peer_on_hello_ack_pkt(void *opaque, const void *data, uint16 size)
 	 */
 	ic_proxy_peer_handle_out_cache(peer);
 
-	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG3,
+	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 		   "ic-proxy: %s: start receiving DATA", peer->name);
 
 	/* now it's time to receive the normal data */
@@ -739,7 +739,7 @@ ic_proxy_peer_on_sent_hello(void *opaque, const ICProxyPkt *pkt, int status)
 		return;
 	}
 
-	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG1,
+	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 		   "ic-proxy: %s: waiting for HELLO ACK", peer->name);
 
 	peer->state |= IC_PROXY_PEER_STATE_SENT_HELLO;
@@ -773,7 +773,7 @@ ic_proxy_peer_on_connected(uv_connect_t *conn, int status)
 		return;
 	}
 
-	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG1,
+	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 		   "ic-proxy: %s: connected, sending HELLO", peer->name);
 
 	peer->state |= IC_PROXY_PEER_STATE_CONNECTED;
@@ -820,7 +820,7 @@ ic_proxy_peer_connect(ICProxyPeer *peer, struct sockaddr_in *dest)
 	peer->state |= IC_PROXY_PEER_STATE_CONNECTING;
 
 	uv_ip4_name(dest, name, sizeof(name));
-	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG3,
+	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 		   "%s: connecting to %s:%d",
 				 peer->name, name, ntohs(dest->sin_port));
 
@@ -851,7 +851,7 @@ ic_proxy_peer_disconnect(ICProxyPeer *peer)
 	if (!(peer->state & IC_PROXY_PEER_STATE_CONNECTING))
 		return;
 
-	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG3,
+	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 		   "%s: disconnecting", peer->name);
 	ic_proxy_peer_shutdown(peer);
 }
@@ -867,7 +867,7 @@ ic_proxy_peer_route_data(ICProxyPeer *peer, ICProxyPkt *pkt,
 	{
 		ICProxyDelay *delay;
 
-		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG3,
+		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 			   "ic-proxy: %s: caching outgoing %s",
 					 peer->name, ic_proxy_pkt_to_str(pkt));
 
@@ -919,7 +919,7 @@ ic_proxy_peer_handle_out_cache(ICProxyPeer *peer)
 	if (peer->reqs == NIL)
 		return;
 
-	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG3,
+	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 		   "ic-proxy: %s: trying to consume the %d cached outgoing pkts",
 				 peer->name, list_length(peer->reqs));
 
@@ -939,7 +939,7 @@ ic_proxy_peer_handle_out_cache(ICProxyPeer *peer)
 		ic_proxy_free(delay);
 	}
 
-	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG3,
+	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, LOG,
 		   "%s: consumed %d cached pkts",
 				 peer->name, list_length(reqs) - list_length(peer->reqs));
 

--- a/src/backend/cdb/motion/ic_proxy_pkt_cache.c
+++ b/src/backend/cdb/motion/ic_proxy_pkt_cache.c
@@ -112,7 +112,7 @@ ic_proxy_pkt_cache_alloc(size_t *pkt_size)
 	memset(cpkt, 0, ic_proxy_pkt_cache.pkt_size);
 #endif
 
-	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG5,
+	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG3, LOG,
 		   "ic-proxy: pkt-cache: allocated, %d free, %d total",
 				 ic_proxy_pkt_cache.n_free, ic_proxy_pkt_cache.n_total);
 	return cpkt;
@@ -159,7 +159,7 @@ ic_proxy_pkt_cache_free(void *pkt)
 		ic_proxy_pkt_cache.freelist = cpkt;
 		ic_proxy_pkt_cache.n_free++;
 
-		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG5,
+		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG3, LOG,
 			   "ic-proxy: pkt-cache: recycled, %d free, %d total",
 					 ic_proxy_pkt_cache.n_free, ic_proxy_pkt_cache.n_total);
 	}

--- a/src/backend/cdb/motion/ic_proxy_router.c
+++ b/src/backend/cdb/motion/ic_proxy_router.c
@@ -104,7 +104,7 @@ ic_proxy_router_loopback_on_check(uv_check_t *handle)
 		ic_proxy_key_from_p2c_pkt(&key, delay->pkt);
 		client = ic_proxy_client_blessed_lookup(handle->loop, &key);
 
-		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG5,
+		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG3, LOG,
 			   "ic-proxy: router: looped back %s to %s",
 					 ic_proxy_pkt_to_str(delay->pkt),
 					 ic_proxy_client_get_name(client));
@@ -132,7 +132,7 @@ ic_proxy_router_loopback_push(ICProxyPkt *pkt,
 {
 	ICProxyDelay *delay;
 
-	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG5,
+	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG3, LOG,
 		   "ic-proxy: router: looping back %s",
 				 ic_proxy_pkt_to_str(pkt));
 
@@ -223,7 +223,7 @@ ic_proxy_router_route(uv_loop_t *loop, ICProxyPkt *pkt,
 		ic_proxy_key_from_p2c_pkt(&key, pkt);
 		client = ic_proxy_client_blessed_lookup(loop, &key);
 
-		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG5,
+		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG3, LOG,
 			   "ic-proxy: router: routing %s to %s",
 					 ic_proxy_pkt_to_str(pkt),
 					 ic_proxy_client_get_name(client));
@@ -237,7 +237,7 @@ ic_proxy_router_route(uv_loop_t *loop, ICProxyPkt *pkt,
 		peer = ic_proxy_peer_blessed_lookup(loop,
 											pkt->dstContentId, pkt->dstDbid);
 
-		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG5,
+		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG3, LOG,
 			   "ic-proxy: router: routing %s to %s",
 					 ic_proxy_pkt_to_str(pkt), peer->name);
 
@@ -256,13 +256,13 @@ ic_proxy_router_on_write(uv_write_t *req, int status)
 
 	if (status < 0)
 	{
-		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG5,
+		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG3, LOG,
 			   "ic-proxy: router: fail to send %s: %s",
 					 ic_proxy_pkt_to_str(pkt), uv_strerror(status));
 	}
 	else
 	{
-		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG5,
+		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG3, LOG,
 			   "ic-proxy: router: sent %s",
 					 ic_proxy_pkt_to_str(pkt));
 	}
@@ -299,7 +299,7 @@ ic_proxy_router_write(uv_stream_t *stream, ICProxyPkt *pkt, int32 offset,
 	ICProxyWriteReq *wreq;
 	uv_buf_t	wbuf;
 
-	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG5,
+	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG3, LOG,
 		   "ic-proxy: router: sending %s", ic_proxy_pkt_to_str(pkt));
 
 	wreq = ic_proxy_new(ICProxyWriteReq);

--- a/src/backend/cdb/motion/ic_tcp.c
+++ b/src/backend/cdb/motion/ic_tcp.c
@@ -161,7 +161,7 @@ setupTCPListeningSocket(int backlog, int *listenerSocketFd, uint16 *listenerPort
 	{
 		Assert(interconnect_address && strlen(interconnect_address) > 0);
 		hints.ai_flags |= AI_NUMERICHOST;
-		ereportif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG3,
+		ereportif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG2, LOG,
 				  (errmsg("getaddrinfo called with unicast address: %s",
 						  interconnect_address)));
 	}
@@ -169,7 +169,7 @@ setupTCPListeningSocket(int backlog, int *listenerSocketFd, uint16 *listenerPort
 	{
 		Assert(interconnect_address == NULL);
 		hints.ai_flags |= AI_PASSIVE;
-		ereportif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG3,
+		ereportif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG2, LOG,
 				  (errmsg("getaddrinfo called with wildcard address")));
 	}
 

--- a/src/backend/cdb/motion/ic_udpifc.c
+++ b/src/backend/cdb/motion/ic_udpifc.c
@@ -1190,7 +1190,7 @@ setupUDPListeningSocket(int *listenerSocketFd, uint16 *listenerPort, int *txFami
 	{
 		Assert(interconnect_address && strlen(interconnect_address) > 0);
 		hints.ai_flags |= AI_NUMERICHOST;
-		ereportif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG3,
+		ereportif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG2, LOG,
 				  (errmsg("getaddrinfo called with unicast address: %s",
 						  interconnect_address)));
 	}
@@ -1198,7 +1198,7 @@ setupUDPListeningSocket(int *listenerSocketFd, uint16 *listenerPort, int *txFami
 	{
 		Assert(interconnect_address == NULL);
 		hints.ai_flags |= AI_PASSIVE;
-		ereportif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG3,
+		ereportif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG2, LOG,
 				  (errmsg("getaddrinfo called with wildcard address")));
 	}
 
@@ -1234,13 +1234,13 @@ setupUDPListeningSocket(int *listenerSocketFd, uint16 *listenerPort, int *txFami
 			continue;
 #endif
 
-		ereportif(++tries > 1 && gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG3,
+		ereportif(++tries > 1 && gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG2, LOG,
 				  errmsg("trying another address for UDP interconnect socket"));
 
 		ic_socket = socket(addr->ai_family, addr->ai_socktype, addr->ai_protocol);
 		if (ic_socket == PGINVALID_SOCKET)
 		{
-			ereportif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG3,
+			ereportif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG2, LOG,
 					(errcode_for_socket_access(),
 						errmsg("could not create UDP interconnect socket: %m")));
 			continue;
@@ -1252,7 +1252,7 @@ setupUDPListeningSocket(int *listenerSocketFd, uint16 *listenerPort, int *txFami
 		 */
 		if (bind(ic_socket, addr->ai_addr, addr->ai_addrlen) < 0)
 		{
-			ereportif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG3,
+			ereportif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG2, LOG,
 					(errcode_for_socket_access(),
 						errmsg("could not bind UDP interconnect socket: %m")));
 			closesocket(ic_socket);
@@ -1263,7 +1263,7 @@ setupUDPListeningSocket(int *listenerSocketFd, uint16 *listenerPort, int *txFami
 		/* Call getsockname() to eventually obtain the assigned ephemeral port */
 		if (getsockname(ic_socket, (struct sockaddr *) &listenerAddr, &listenerAddrlen) < 0)
 		{
-			ereportif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG3,
+			ereportif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG2, LOG,
 					(errcode_for_socket_access(),
 						errmsg("could not get address of socket for UDP interconnect: %m")));
 			closesocket(ic_socket);
@@ -2132,7 +2132,7 @@ setUDPSocketBufferSize(int ic_socket, int buffer_type)
 	option_len = sizeof(curr_size);
 	while (setsockopt(ic_socket, SOL_SOCKET, buffer_type, (const char *) &curr_size, option_len) < 0)
 	{
-		ereportif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG3,
+		ereportif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG2, LOG,
 				  (errmsg("UDP-IC: setsockopt %s failed to set buffer size = %d bytes: %m",
 						  buffer_type == SO_SNDBUF ? "send": "receive",
 						  curr_size)));
@@ -2141,7 +2141,7 @@ setUDPSocketBufferSize(int ic_socket, int buffer_type)
 			return -1;
 	}
 
-	ereportif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG3,
+	ereportif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG2, LOG,
 			  (errmsg("UDP-IC: socket %s current buffer size = %d bytes",
 					  buffer_type == SO_SNDBUF ? "send": "receive",
 					  curr_size)));
@@ -5976,7 +5976,7 @@ handleDataPacket(MotionConn *conn, icpkthdr *pkt, struct sockaddr_storage *peer,
 
 	if (conn->stopRequested && conn->stillActive)
 	{
-		if (gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG && DEBUG5 >= log_min_messages)
+		if (gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG3)
 			write_log("rx_thread got packet on active connection marked stopRequested. "
 					  "(flags 0x%x) node %d route %d pkt seq %d conn seq %d",
 					  pkt->flags, pkt->motNodeId, conn->route, pkt->seq, conn->conn_info.seq);

--- a/src/backend/fts/fts.c
+++ b/src/backend/fts/fts.c
@@ -331,7 +331,7 @@ void FtsLoop()
 		}
 		else
 		{
-			elogif(gp_log_fts == GPVARS_VERBOSITY_DEBUG, LOG,
+			elogif(gp_log_fts >= GPVARS_VERBOSITY_DEBUG, LOG,
 				   "FTS: starting scan with %d segments and %d contents",
 				   cdbs->total_segment_dbs,
 				   cdbs->total_segments);

--- a/src/backend/fts/ftsprobe.c
+++ b/src/backend/fts/ftsprobe.c
@@ -298,7 +298,7 @@ ftsConnect(fts_context *context)
 	for (i = 0; i < context->num_pairs; i++)
 	{
 		fts_segment_info *ftsInfo = &context->perSegInfos[i];
-		elogif(gp_log_fts == GPVARS_VERBOSITY_DEBUG, LOG,
+		elogif(gp_log_fts >= GPVARS_VERBOSITY_DEBUG, LOG,
 			   "FTS: ftsConnect (content=%d, dbid=%d) state=%d, "
 			   "retry_count=%d, conn->status=%d",
 			   ftsInfo->primary_cdbinfo->config->segindex,
@@ -336,7 +336,7 @@ ftsConnect(fts_context *context)
 							 * completed.  Next step should now be able to send
 							 * the appropriate FTS message.
 							 */
-							elogif(gp_log_fts == GPVARS_VERBOSITY_DEBUG, LOG,
+							elogif(gp_log_fts >= GPVARS_VERBOSITY_DEBUG, LOG,
 								   "FTS: established libpq connection "
 								   "(content=%d, dbid=%d) state=%d, "
 								   "retry_count=%d, conn->status=%d",
@@ -461,7 +461,7 @@ ftsPoll(fts_context *context)
 	{
 		if (errno == EINTR)
 		{
-			elogif(gp_log_fts == GPVARS_VERBOSITY_DEBUG, LOG,
+			elogif(gp_log_fts >= GPVARS_VERBOSITY_DEBUG, LOG,
 				   "FTS: ftsPoll() interrupted, nfds %d", nfds);
 		}
 		else
@@ -469,11 +469,11 @@ ftsPoll(fts_context *context)
 	}
 	else if (nready == 0)
 	{
-		elogif(gp_log_fts == GPVARS_VERBOSITY_DEBUG, LOG,
+		elogif(gp_log_fts >= GPVARS_VERBOSITY_DEBUG, LOG,
 			   "FTS: ftsPoll() timed out, nfds %d", nfds);
 	}
 
-	elogif(gp_log_fts == GPVARS_VERBOSITY_DEBUG, LOG,
+	elogif(gp_log_fts >= GPVARS_VERBOSITY_DEBUG, LOG,
 		   "FTS: ftsPoll() found %d out of %d sockets ready",
 		   nready, nfds);
 
@@ -543,7 +543,7 @@ ftsSend(fts_context *context)
 	for (i = 0; i < context->num_pairs; i++)
 	{
 		ftsInfo = &context->perSegInfos[i];
-		elogif(gp_log_fts == GPVARS_VERBOSITY_DEBUG, LOG,
+		elogif(gp_log_fts >= GPVARS_VERBOSITY_DEBUG, LOG,
 			   "FTS: ftsSend (content=%d, dbid=%d) state=%d, "
 			   "retry_count=%d, conn->asyncStatus=%d",
 			   ftsInfo->primary_cdbinfo->config->segindex,
@@ -661,7 +661,7 @@ ftsReceive(fts_context *context)
 	for (i = 0; i < context->num_pairs; i++)
 	{
 		ftsInfo = &context->perSegInfos[i];
-		elogif(gp_log_fts == GPVARS_VERBOSITY_DEBUG, LOG,
+		elogif(gp_log_fts >= GPVARS_VERBOSITY_DEBUG, LOG,
 			   "FTS: ftsReceive (content=%d, dbid=%d) state=%d, "
 			   "retry_count=%d, conn->asyncStatus=%d",
 			   ftsInfo->primary_cdbinfo->config->segindex,
@@ -800,7 +800,7 @@ retryForFtsFailed(fts_segment_info *ftsInfo, pg_time_t now)
 	else
 		ftsInfo->state = FTS_PROMOTE_RETRY_WAIT;
 	ftsInfo->retryStartTime = now;
-	elogif(gp_log_fts == GPVARS_VERBOSITY_DEBUG, LOG,
+	elogif(gp_log_fts >= GPVARS_VERBOSITY_DEBUG, LOG,
 		"FTS initialized retry start time to now "
 		"(content=%d, dbid=%d) state=%d",
 		ftsInfo->primary_cdbinfo->config->segindex,

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -531,6 +531,8 @@ static const struct config_enum_entry gp_log_verbosity[] = {
 	{"off", GPVARS_VERBOSITY_OFF},
 	{"verbose", GPVARS_VERBOSITY_VERBOSE},
 	{"debug", GPVARS_VERBOSITY_DEBUG},
+	{"debug2", GPVARS_VERBOSITY_DEBUG2},
+	{"debug3", GPVARS_VERBOSITY_DEBUG3},
 	{NULL, 0}
 };
 
@@ -4693,7 +4695,7 @@ struct config_enum ConfigureNamesEnum_gp[] =
 	{
 		{"gp_log_interconnect", PGC_USERSET, LOGGING_WHAT,
 			gettext_noop("Sets the verbosity of logged messages pertaining to connections between worker processes."),
-			gettext_noop("Valid values are \"off\", \"terse\", \"verbose\" and \"debug\"."),
+			gettext_noop("Valid values are \"off\", \"terse\", \"verbose\" , \"debug\" , \"debug2\" and \"debug3\"."),
 			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&gp_log_interconnect,

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -436,6 +436,8 @@ typedef enum GpVars_Verbosity
 	GPVARS_VERBOSITY_TERSE,
 	GPVARS_VERBOSITY_VERBOSE,
     GPVARS_VERBOSITY_DEBUG,
+	GPVARS_VERBOSITY_DEBUG2,
+	GPVARS_VERBOSITY_DEBUG3
 } GpVars_Verbosity;
 
 /* Enable single-slice single-row inserts. */
@@ -447,46 +449,8 @@ extern bool gp_enable_direct_dispatch;
 /* Name of pseudo-function to access any table as if it was randomly distributed. */
 #define GP_DIST_RANDOM_NAME "GP_DIST_RANDOM"
 
-/*
- * gp_log_gang
- *
- * Should creation, reallocation and cleanup of gangs of QE processes be logged?
- * "OFF"     -> only errors are logged
- * "TERSE"   -> terse logging of routine events, e.g. creation of new qExecs
- * "VERBOSE" -> gang allocation per command is logged
- * "DEBUG"   -> additional events are logged at severity level DEBUG1 to DEBUG5
- *
- * The messages that are enabled by the TERSE and VERBOSE settings are
- * written with a severity level of LOG.
- */
 extern int gp_log_gang;
-
-/*
- * gp_log_fts
- *
- * What kind of messages should be logged by the fault-prober
- * "OFF"     -> only errors are logged
- * "TERSE"   -> terse logging of routine events
- * "VERBOSE" -> more messages
- * "DEBUG"   -> additional events are logged at severity level DEBUG1 to DEBUG5
- *
- * The messages that are enabled by the TERSE and VERBOSE settings are
- * written with a severity level of LOG.
- */
 extern int gp_log_fts;
-
-/*
- * gp_log_interconnect
- *
- * Should connections between internal processes be logged?  (qDisp/qExec/etc)
- * "OFF"     -> connection errors are logged
- * "TERSE"   -> terse logging of routine events, e.g. successful connections
- * "VERBOSE" -> most interconnect setup events are logged
- * "DEBUG"   -> additional events are logged at severity level DEBUG1 to DEBUG5.
- *
- * The messages that are enabled by the TERSE and VERBOSE settings are
- * written with a severity level of LOG.
- */
 extern int gp_log_interconnect;
 
 /* --------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Current implementation had dependency on log_min_messages for DEBUG level logs. This facility is used for three GUCs gp_log_fts, gp_log_gang and gp_log_interconnect. Intent is using these GUCs be able to control the logging to triage issues for these components. TERSE and VERBOSE mode emitted messages with LOG level. Though DEBUG, emitted messages with DEBUG* levels. This poses problem as if wish to enable DEBUG logging for lets say gp_log_interconnect, need to also set log_min_messages to DEBUG* level. Setting log_min_messages to DEBUG* has side effect of enabling logging for more other components which don't use GpVars_Verbosity facility. Which becomes hurdle for enabling in production deployments.

Hence, for simplicity and easy let single GUC control the logging extent for these components and decouple need for setting log_min_messages to DEBUG* levels. Changed messages to all be logged now at LOG level. The GUC itself has 2 additional levels now DEBUG2 and DEBUG3.

Note:

- only gp_log_interconnect is using the additional debug log levels. So, remapped DEBUG1 -> GPVARS_VERBOSITY_DEBUG, DEBUG3 -> GPVARS_VERBOSITY_DEBUG2, and DEBUG5 -> GPVARS_VERBOSITY_DEBUG3

- gp_log_fts and gp_log_gang only use single DEBUG level. Edited some checks for gp_log_fts to make them future proof if additional debug levels are used

- ELOG_DISPATCHER_DEBUG was not following the stated semantics and was logging at LOG level anyways, so meet current implementation

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
