### PR TITLE
Remove handle RangeSubselect in checkWellFormedRecursionWalker.

### DIFF
--- a/src/backend/parser/parse_cte.c
+++ b/src/backend/parser/parse_cte.c
@@ -944,19 +944,7 @@ checkWellFormedRecursionWalker(Node *node, CteState *cstate)
 		checkWellFormedRecursionWalker(sl->testexpr, cstate);
 		return false;
 	}
-	if (IsA(node, RangeSubselect))
-	{
-		RangeSubselect *rs = (RangeSubselect *) node;
 
-		/*
-		 * we intentionally override outer context, since subquery is
-		 * independent
-		 */
-		cstate->context = RECURSION_SUBLINK;
-		checkWellFormedRecursionWalker(rs->subquery, cstate);
-		cstate->context = save_context;
-		return false;
-	}
 	return raw_expression_tree_walker(node,
 									  checkWellFormedRecursionWalker,
 									  (void *) cstate);

--- a/src/test/regress/expected/gp_recursive_cte.out
+++ b/src/test/regress/expected/gp_recursive_cte.out
@@ -620,3 +620,29 @@ select * from the_cte_here;
  4
 (4 rows)
 
+-- WTIH RECURSIVE and subquery
+with recursive cte (n) as
+(
+  select 1
+  union all
+  select * from
+  (
+    with x(n) as (select n from cte)
+    select n + 1 from x where n < 10
+  ) q
+)
+select * from cte;
+ n  
+----
+  1
+  2
+  3
+  4
+  5
+  6
+  7
+  8
+  9
+ 10
+(10 rows)
+

--- a/src/test/regress/expected/with.out
+++ b/src/test/regress/expected/with.out
@@ -1145,9 +1145,9 @@ WITH RECURSIVE foo(i) AS
           UNION ALL
        SELECT i+1 FROM foo WHERE i < 5) AS t
 ) SELECT * FROM foo;
-ERROR:  recursive reference to query "foo" must not appear within a subquery
-LINE 5:        (SELECT i+1 FROM foo WHERE i < 10
-                                ^
+ERROR:  recursive reference to query "foo" must not appear more than once
+LINE 7:        SELECT i+1 FROM foo WHERE i < 5) AS t
+                               ^
 WITH RECURSIVE foo(i) AS
     (values (1)
     UNION ALL

--- a/src/test/regress/sql/gp_recursive_cte.sql
+++ b/src/test/regress/sql/gp_recursive_cte.sql
@@ -432,3 +432,16 @@ with recursive the_cte_here(n) as (
   select n+1 from the_cte_here join t_rand_test_rcte
 	              on t_rand_test_rcte.c = the_cte_here.n)
 select * from the_cte_here;
+
+-- WTIH RECURSIVE and subquery
+with recursive cte (n) as
+(
+  select 1
+  union all
+  select * from
+  (
+    with x(n) as (select n from cte)
+    select n + 1 from x where n < 10
+  ) q
+)
+select * from cte;


### PR DESCRIPTION
Keep align with upstream.
