### PR TITLE
docs - small pgcrypto fips-related updates

### DIFF
--- a/gpdb-doc/markdown/ref_guide/modules/pgcrypto.html.md
+++ b/gpdb-doc/markdown/ref_guide/modules/pgcrypto.html.md
@@ -19,8 +19,6 @@ When this parameter is enabled, these changes occur:
 -   FIPS mode is initialized in the OpenSSL library
 -   The functions `digest()` and `hmac()` allow only the SHA encryption algorithm \(MD5 is not allowed\)
 -   The functions for the crypt and gen\_salt algorithms are disabled
--   PGP encryption and decryption functions support only AES and 3DES encryption algorithms \(other algorithms such as blowfish are not allowed\)
--   RAW encryption and decryption functions support only AES and 3DES \(other algorithms such as blowfish are not allowed\)
 
 **To enable `pgcrypto.fips`**
 


### PR DESCRIPTION
docs for https://github.com/greenplum-db/gpdb/pull/13905.

will be backported to 6X_STABLE for https://github.com/greenplum-db/gpdb/pull/14075.

i assumed that the main/6X resulted in equivalent changes to the docs, let me know if that is not the case.
