### PR TITLE
ao/co: Clarify compute_xid_horizon_for_tuples API

### DIFF
--- a/src/backend/access/aocs/aocsam_handler.c
+++ b/src/backend/access/aocs/aocsam_handler.c
@@ -1144,8 +1144,17 @@ aoco_compute_xid_horizon_for_tuples(Relation rel,
                                           ItemPointerData *tids,
                                           int nitems)
 {
-	// GPDB_12_MERGE_FIXME: vacuum related call back.
-	elog(ERROR, "not implemented yet");
+	/*
+	 * This API is only useful for hot standby snapshot conflict resolution
+	 * (for eg. see btree_xlog_delete()), in the context of index page-level
+	 * vacuums (aka page-level cleanups). This operation is only done when
+	 * IndexScanDesc->kill_prior_tuple is true, which is never for AO/CO tables
+	 * (we always return all_dead = false in the index_fetch_tuple() callback
+	 * as we don't support HOT)
+	 */
+	ereport(ERROR,
+			(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				errmsg("feature not supported on appendoptimized relations")));
 }
 
 /* ------------------------------------------------------------------------

--- a/src/backend/access/appendonly/appendonlyam_handler.c
+++ b/src/backend/access/appendonly/appendonlyam_handler.c
@@ -767,8 +767,17 @@ appendonly_compute_xid_horizon_for_tuples(Relation rel,
 										  ItemPointerData *tids,
 										  int nitems)
 {
-	// GPDB_12_MERGE_FIXME: vacuum related call back.
-	elog(ERROR, "not implemented yet");
+	/*
+	 * This API is only useful for hot standby snapshot conflict resolution
+	 * (for eg. see btree_xlog_delete()), in the context of index page-level
+	 * vacuums (aka page-level cleanups). This operation is only done when
+	 * IndexScanDesc->kill_prior_tuple is true, which is never for AO/CO tables
+	 * (we always return all_dead = false in the index_fetch_tuple() callback
+	 * as we don't support HOT)
+	 */
+	ereport(ERROR,
+			(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				errmsg("feature not supported on appendoptimized relations")));
 }
 
 /* ----------------------------------------------------------------------------


### PR DESCRIPTION
This removes FIXMEs for the compute_xid_horizon_for_tuples() API, which
was introduced in 558a9165e08.

This API is used to compute what snapshots to conflict with when
replaying WAL records for page-level index vacuums. Page-level index
vacuums don't even arise for AO/CO tables today due to absence of HOT.
Thus it is perfectly fine to leave this unimplemented.

Details:

(1) The amgettuple() routine for index AMs can optionally kill off
tuples if they are found dead in the underlying table scan. This is done
with IndexScanDesc->kill_prior_tuple. For examples: see btgettuple(),
hashgettuple() and gistgettuple().

(2) The index AMs typically have a killitems function (like
_bt_killitems()), which among other things sets a garbage flag on the
index page (like BTP_HAS_GARBAGE)

(3) Afterwards, if an index page has a garbage flag, it can undergo page
level vacuum, even inside a scan (see _bt_vacuum_one_page()). This is
where table_compute_xid_horizon_for_tuples() is typically called and the
latestRemovedXid is recorded in the WAL (eg XLOG_BTREE_DELETE).

(4) During replay on a hot standby, the latestRemovedXid is extracted
from the record and then used to ResolveRecoveryConflictWithSnapshot().

Since, AO/CO tables don't have HOT chains, in index_fetch_heap(),
all_dead is always set to false and thus the
IndexScanDesc->kill_prior_tuple is always false. Thus, we never even
perform index page-level vacuum for indexes on AO/CO tables, let alone
compute the xid horizon.