### PR TITLE
fix default value of guc gp_explain_jit to ON

### DIFF
--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -746,7 +746,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 			NULL
 		},
 		&gp_explain_jit,
-		false,
+		true,
 		NULL, NULL, NULL
 	},
 


### PR DESCRIPTION
The value of guc gp_explain_jit should be set to ON by default. As mentioned in previous [PR 14354](https://github.com/greenplum-db/gpdb/pull/14354)