### PR TITLE
Fix relcache lookup in Orca when selecting from sequence

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
@@ -2340,6 +2340,11 @@ CTranslatorRelcacheToDXL::RetrieveRelStorageType(Relation rel)
 			{
 				rel_storage_type = IMDRelation::ErelstorageForeign;
 			}
+			else
+			{
+				GPOS_RAISE(gpdxl::ExmaMD, gpdxl::ExmiMDObjUnsupported,
+						   GPOS_WSZ_LIT("Unsupported table AM"));
+			}
 			break;
 		default:
 			GPOS_RAISE(gpdxl::ExmaMD, gpdxl::ExmiMDObjUnsupported,


### PR DESCRIPTION
In d0f8614d1f1b18eb9101bb18b8e9192709bd670c, we removed an if statement that was previously catching and falling back to planner if a table AM was not recognized. Add this back, as there are cases of an unrecognized AM and otherwise we'll crash.