### PR TITLE
ao/co: Ban speculative insert in parse analysis

### DIFF
--- a/src/backend/access/aocs/aocsam_handler.c
+++ b/src/backend/access/aocs/aocsam_handler.c
@@ -940,20 +940,29 @@ aoco_tuple_insert(Relation relation, TupleTableSlot *slot, CommandId cid,
 	pgstat_count_heap_insert(relation, 1);
 }
 
+/*
+ * We don't support speculative inserts on appendoptimized tables, i.e. we don't
+ * support INSERT ON CONFLICT DO NOTHING or INSERT ON CONFLICT DO UPDATE. Thus,
+ * the following functions are left unimplemented.
+ */
+
 static void
 aoco_tuple_insert_speculative(Relation relation, TupleTableSlot *slot,
                                     CommandId cid, int options,
                                     BulkInsertState bistate, uint32 specToken)
 {
-	/* GPDB_12_MERGE_FIXME: not supported. Can this function be left out completely? Or ereport()? */
-	elog(ERROR, "speculative insertion not supported on AO_COLUMN tables");
+	ereport(ERROR,
+			(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				errmsg("speculative insert is not supported on appendoptimized relations")));
 }
 
 static void
 aoco_tuple_complete_speculative(Relation relation, TupleTableSlot *slot,
                                       uint32 specToken, bool succeeded)
 {
-	elog(ERROR, "speculative insertion not supported on AO_COLUMN tables");
+	ereport(ERROR,
+			(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				errmsg("speculative insert is not supported on appendoptimized relations")));
 }
 
 /*

--- a/src/backend/access/appendonly/appendonlyam_handler.c
+++ b/src/backend/access/appendonly/appendonlyam_handler.c
@@ -812,20 +812,29 @@ appendonly_tuple_insert(Relation relation, TupleTableSlot *slot, CommandId cid,
 	appendonly_free_memtuple(mtuple);
 }
 
+/*
+ * We don't support speculative inserts on appendoptimized tables, i.e. we don't
+ * support INSERT ON CONFLICT DO NOTHING or INSERT ON CONFLICT DO UPDATE. Thus,
+ * the following functions are left unimplemented.
+ */
+
 static void
 appendonly_tuple_insert_speculative(Relation relation, TupleTableSlot *slot,
 								CommandId cid, int options,
 								BulkInsertState bistate, uint32 specToken)
 {
- 	/* GPDB_12_MERGE_FIXME: not supported. Can this function be left out completely? Or ereport()? */
-	elog(ERROR, "speculative insertion not supported on AO tables");
+	ereport(ERROR,
+			(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				errmsg("speculative insert is not supported on appendoptimized relations")));
 }
 
 static void
 appendonly_tuple_complete_speculative(Relation relation, TupleTableSlot *slot,
 								  uint32 specToken, bool succeeded)
 {
-	elog(ERROR, "speculative insertion not supported on AO tables");
+	ereport(ERROR,
+			(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				errmsg("speculative insert is not supported on appendoptimized relations")));
 }
 
 /*

--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -672,6 +672,12 @@ transformInsertStmt(ParseState *pstate, InsertStmt *stmt)
 	icolumns = checkInsertTargets(pstate, stmt->cols, &attrnos);
 	Assert(list_length(icolumns) == list_length(attrnos));
 
+	/* GPDB: We don't support speculative insert for AO/CO tables yet */
+	if (RelationIsAppendOptimized(pstate->p_target_relation) && stmt->onConflictClause)
+		ereport(ERROR,
+				errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				errmsg("INSERT ON CONFLICT is not supported for appendoptimized relations"));
+
 	/*
 	 * Determine which variant of INSERT we have.
 	 */

--- a/src/test/regress/input/uao_dml/uao_dml.source
+++ b/src/test/regress/input/uao_dml/uao_dml.source
@@ -996,3 +996,14 @@ SELECT COUNT(*) FROM foo WHERE b = 1;
 ROLLBACK To my_savepoint;
 SELECT COUNT(*) FROM foo WHERE b = 1;
 COMMIT;
+
+-- @Description Tests that speculative inserts are not supported (for
+-- conflicting inserts and otherwise).
+--
+CREATE TABLE spec_insert(i int unique, j int) distributed by (i);
+INSERT INTO spec_insert VALUES(1, 2);
+INSERT INTO spec_insert VALUES(1, 3) ON CONFLICT(i) DO NOTHING;
+INSERT INTO spec_insert VALUES(1, 3) ON CONFLICT(i) DO UPDATE SET j = 3;
+
+INSERT INTO spec_insert VALUES(2, 3) ON CONFLICT(i) DO NOTHING;
+INSERT INTO spec_insert VALUES(2, 3) ON CONFLICT(i) DO UPDATE SET j = 4;

--- a/src/test/regress/output/uao_dml/uao_dml.source
+++ b/src/test/regress/output/uao_dml/uao_dml.source
@@ -1896,3 +1896,16 @@ SELECT COUNT(*) FROM foo WHERE b = 1;
 (1 row)
 
 COMMIT;
+-- @Description Tests that speculative inserts are not supported (for
+-- conflicting inserts and otherwise).
+--
+CREATE TABLE spec_insert(i int unique, j int) distributed by (i);
+INSERT INTO spec_insert VALUES(1, 2);
+INSERT INTO spec_insert VALUES(1, 3) ON CONFLICT(i) DO NOTHING;
+ERROR:  INSERT ON CONFLICT is not supported for appendoptimized relations
+INSERT INTO spec_insert VALUES(1, 3) ON CONFLICT(i) DO UPDATE SET j = 3;
+ERROR:  INSERT ON CONFLICT is not supported for appendoptimized relations
+INSERT INTO spec_insert VALUES(2, 3) ON CONFLICT(i) DO NOTHING;
+ERROR:  INSERT ON CONFLICT is not supported for appendoptimized relations
+INSERT INTO spec_insert VALUES(2, 3) ON CONFLICT(i) DO UPDATE SET j = 4;
+ERROR:  INSERT ON CONFLICT is not supported for appendoptimized relations


### PR DESCRIPTION
We don't support speculative insert (INSERT ON CONFLICT) for AO/CO tables yet.

This commit does two things:

(1) Confirms that its okay to keep the speculative insert APIs unimplemented, by removing the FIXMEs and adding ereport().

(2) Instead of relying on the ERROR at the table AM layer, it introduces a check at the parse analysis stage to perform the ban. This is important as we can't rely on the table AM layer always. For instance, with DO NOTHING, if there is no conflict, the table AM routine is invoked. However, if there is a conflict, then the routine doesn't get invoked and the customer would see:

INSERT INTO spec_insert VALUES(1, 3) ON CONFLICT(i) DO NOTHING; INSERT 0 0

This would lead to a false impression that it is supported. So, we ban it at the parse analysis stage.