### PR TITLE
fix regression test: ignore memory values in JSON-ed output of EXPLAIN

### DIFF
--- a/src/test/regress/expected/explain_format.out
+++ b/src/test/regress/expected/explain_format.out
@@ -733,6 +733,12 @@ Execution Time: 24.023 ms
 -- s/\"Planning Time\": \d+\.\d+/\"Planning Time\": ###/
 -- m/\"Execution Time\": \d+\.\d+/
 -- s/\"Execution Time\": \d+\.\d+/\"Execution Time\": ###/
+-- m/\"Executor Memory\": \d+/
+-- s/\"Executor Memory\": \d+/\"Executor Memory\": ###/
+-- m/\"Average\": \d+/
+-- s/\"Average\": \d+/\"Average\": ###/
+-- m/\"Maximum Memory Used\": \d+/
+-- s/\"Maximum Memory Used\": \d+/\"Maximum Memory Used\": ###/
 -- m/\"slice\": \d+/
 -- s/\"slice\": \d+/"slice": ###/
 -- m/\"functions\": \d+\.\d+/

--- a/src/test/regress/expected/explain_format_optimizer.out
+++ b/src/test/regress/expected/explain_format_optimizer.out
@@ -679,6 +679,12 @@ Execution Time: 1.597 ms
 -- s/\"Planning Time\": \d+\.\d+/\"Planning Time\": ###/
 -- m/\"Execution Time\": \d+\.\d+/
 -- s/\"Execution Time\": \d+\.\d+/\"Execution Time\": ###/
+-- m/\"Executor Memory\": \d+/
+-- s/\"Executor Memory\": \d+/\"Executor Memory\": ###/
+-- m/\"Average\": \d+/
+-- s/\"Average\": \d+/\"Average\": ###/
+-- m/\"Maximum Memory Used\": \d+/
+-- s/\"Maximum Memory Used\": \d+/\"Maximum Memory Used\": ###/
 -- m/\"slice\": \d+/
 -- s/\"slice\": \d+/"slice": ###/
 -- m/\"functions\": \d+\.\d+/

--- a/src/test/regress/sql/explain_format.sql
+++ b/src/test/regress/sql/explain_format.sql
@@ -173,6 +173,12 @@ EXPLAIN (ANALYZE) SELECT * FROM jit_explain_output LIMIT 10;
 -- s/\"Planning Time\": \d+\.\d+/\"Planning Time\": ###/
 -- m/\"Execution Time\": \d+\.\d+/
 -- s/\"Execution Time\": \d+\.\d+/\"Execution Time\": ###/
+-- m/\"Executor Memory\": \d+/
+-- s/\"Executor Memory\": \d+/\"Executor Memory\": ###/
+-- m/\"Average\": \d+/
+-- s/\"Average\": \d+/\"Average\": ###/
+-- m/\"Maximum Memory Used\": \d+/
+-- s/\"Maximum Memory Used\": \d+/\"Maximum Memory Used\": ###/
 -- m/\"slice\": \d+/
 -- s/\"slice\": \d+/"slice": ###/
 -- m/\"functions\": \d+\.\d+/


### PR DESCRIPTION
In explain_format test, The values of EXPLAIN's memory fields should be ignored.
The matchsub rules already exists but not ported to support JSON format.
Lacking of them, new test cases imported by PR #14360 would fail.

This commit set the matchsub rules for JSON format.

The failure fixed by this PR: https://prod.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb_main_without_asserts/jobs/icw_planner_rhel8/builds/447