### PR TITLE
Fix missing wal files for pg_rewind, take 2

### DIFF
--- a/src/backend/access/transam/test/xlog_test.c
+++ b/src/backend/access/transam/test/xlog_test.c
@@ -16,6 +16,8 @@ test_KeepLogSeg(void **state)
 {
 	XLogRecPtr recptr;
 	XLogSegNo  _logSegNo;
+	XLogSegNo  PriorRedoPtr;
+	bool       _keep_old_wals = false;
 	XLogCtlData xlogctl;
 
 	xlogctl.replicationSlotMinLSN = InvalidXLogRecPtr;
@@ -121,7 +123,6 @@ test_KeepLogSeg(void **state)
 	/************************************************
 	 * Do nothing if wal_keep_segments is not positive
 	 ***********************************************/
-	/* Current Delete pointer */
 	wal_keep_segments = 0;
 	_logSegNo = 9 * XLogSegmentsPerXLogId(wal_segment_size) + 45;
 
@@ -132,6 +133,220 @@ test_KeepLogSeg(void **state)
 
 	KeepLogSeg_wrapper(recptr, &_logSegNo);
 	assert_int_equal(_logSegNo, 9*XLogSegmentsPerXLogId(wal_segment_size) + 45);
+	/************************************************/
+
+	/************************************************
+	 * Replication slot is in use, AND
+	 * prior checkpoint is not available at startup, AND
+	 * so, set keep to replication slot min LSN.
+	 * Current Delete greater than what keep wants,
+	 * so, delete offset should get updated
+	 ***********************************************/
+	max_replication_slots = 1;
+	wal_keep_segments = 0;
+
+	/*
+	 * Replication slot min LSN location (2, 5)
+	 * xrecoff = seg * 67108864 (64 MB segsize)
+	 */
+	xlogctl.replicationSlotMinLSN = ((uint64) 3) << 32 | (wal_segment_size * 5);
+
+	/*
+	 * Current xlog location (4, 1)
+	 * xrecoff = seg * 67108864 (64 MB segsize)
+	 */
+	recptr = ((uint64) 4) << 32 | (wal_segment_size * 1);
+
+	/* Current Delete pointer */
+	_logSegNo = 4 * XLogSegmentsPerXLogId(wal_segment_size) + 1;
+
+	KeepLogSeg_wrapper(recptr, &_logSegNo);
+	assert_int_equal(_logSegNo, 3*XLogSegmentsPerXLogId(wal_segment_size) + 5);
+	/************************************************/
+
+	/************************************************
+	 * Replication slot is in use, AND
+	 * prior checkpoint is not available at startup,
+	 * so, set keep to replication slot min LSN.
+	 * Current Delete smaller than what keep wants,
+	 * so, delete offset should NOT get updated
+	 ***********************************************/
+	max_replication_slots = 1;
+	wal_keep_segments = 0;
+
+	/*
+	 * Replication slot min LSN location (4, 12)
+	 * xrecoff = seg * 67108864 (64 MB segsize)
+	 */
+	xlogctl.replicationSlotMinLSN = ((uint64) 4) << 32 | (wal_segment_size * 12);
+
+	/*
+	 * Current xlog location (4, 10)
+	 * xrecoff = seg * 67108864 (64 MB segsize)
+	 */
+	recptr = ((uint64) 4) << 32 | (wal_segment_size * 11);
+
+	/* Current Delete pointer */
+	_logSegNo = 4 * XLogSegmentsPerXLogId(wal_segment_size) + 11;
+
+	KeepLogSeg_wrapper(recptr, &_logSegNo);
+	assert_int_equal(_logSegNo, 4*XLogSegmentsPerXLogId(wal_segment_size) + 11);
+	/************************************************/
+
+	/************************************************
+	 * Replication slots are in use, AND
+	 * Prior checkpoint greater than Replication slots min LSN, AND
+	 * CkptRedoAfterPriorMinLSN was not initialized at segment restart, AND
+	 * CkptRedoBeforeMinLSN is not populated at segment startup
+	 * so, keep remains same as replication slot min LSN.
+	 * Current Delete greater than what keep wants,
+	 * so, delete offset should get updated, AND
+	 * _keep_old_wals should be set to true
+	 ***********************************************/
+	max_replication_slots = 1;
+	wal_keep_segments = 0;
+	_keep_old_wals = false;
+
+	/*
+	 * Replication slot min LSN location (3, 5)
+	 * xrecoff = seg * 67108864 (64 MB segsize)
+	 */
+	xlogctl.replicationSlotMinLSN = ((uint64) 3) << 32 | (wal_segment_size * 5);
+
+	/*
+	 * Current xlog location (5, 8)
+	 * xrecoff = seg * 67108864 (64 MB segsize)
+	 */
+	recptr = ((uint64) 5) << 32 | (wal_segment_size * 8);
+
+	/* Current Delete pointer */
+	_logSegNo = 5 * XLogSegmentsPerXLogId(wal_segment_size) + 8;
+
+	/*
+	 * Prior checkpoint location (4, 10)
+	 */
+	PriorRedoPtr = ((uint64) 4) << 32 | (wal_segment_size * 10);
+
+	KeepLogSeg(recptr, &_logSegNo, PriorRedoPtr, &_keep_old_wals);
+	assert_int_equal(_logSegNo, 3*XLogSegmentsPerXLogId(wal_segment_size) + 5);
+	assert_true(_keep_old_wals);
+	/************************************************/
+
+	/************************************************
+	 * Replication slots are in use, AND
+	 * Prior checkpoint greater than Replication slots min LSN, AND
+	 * CkptRedoAfterPriorMinLSN was set to PriorRedoPtr (4, 10) in previous test, AND
+	 * CkptRedoAfterPriorMinLSN greater than Replication slots min LSN, AND
+	 * CkptRedoBeforeMinLSN is still not set
+	 * so, keep remains same as replication slot min LSN.
+	 * Current Delete greater than what keep wants,
+	 * so, delete offset should get updated, AND
+	 * _keep_old_wals should be set to true
+	 ***********************************************/
+	max_replication_slots = 1;
+	wal_keep_segments = 0;
+	_keep_old_wals = false;
+
+	/*
+	 * Replication slot min LSN location (3, 11)
+	 * xrecoff = seg * 67108864 (64 MB segsize)
+	 */
+	xlogctl.replicationSlotMinLSN = ((uint64) 3) << 32 | (wal_segment_size * 11);
+
+	/*
+	 * Current xlog location (6, 3)
+	 * xrecoff = seg * 67108864 (64 MB segsize)
+	 */
+	recptr = ((uint64) 6) << 32 | (wal_segment_size * 3);
+
+	/* Current Delete pointer */
+	_logSegNo = 6 * XLogSegmentsPerXLogId(wal_segment_size) + 3;
+
+	/*
+	 * Prior checkpoint location (5, 8)
+	 */
+	PriorRedoPtr = ((uint64) 5) << 32 | (wal_segment_size * 8);
+
+	KeepLogSeg(recptr, &_logSegNo, PriorRedoPtr, &_keep_old_wals);
+	assert_int_equal(_logSegNo, 3*XLogSegmentsPerXLogId(wal_segment_size) + 11);
+	assert_true(_keep_old_wals);
+	/************************************************/
+
+	/************************************************
+	 * Replication slots are in use, AND
+	 * Prior checkpoint greater than Replication slots min LSN, AND
+	 * CkptRedoAfterPriorMinLSN was set to PriorRedoPtr (4, 10) in previous test, AND
+	 * CkptRedoAfterPriorMinLSN smaller than Replication slots min LSN, AND
+	 * CkptRedoBeforeMinLSN is still not set
+	 * so, set CkptRedoBeforeMinLSN and keep to CkptRedoAfterPriorMinLSN, AND
+	 * update CkptRedoAfterPriorMinLSN to PriorRedoPtr (5, 10) in current test
+	 * Current Delete greater than what keep wants,
+	 * so, delete offset should get updated, AND
+	 * _keep_old_wals should remain false
+	 ***********************************************/
+	max_replication_slots = 1;
+	wal_keep_segments = 0;
+	_keep_old_wals = false;
+
+	/*
+	 * Replication slot min LSN location (4, 11)
+	 * xrecoff = seg * 67108864 (64 MB segsize)
+	 */
+	xlogctl.replicationSlotMinLSN = ((uint64) 4) << 32 | (wal_segment_size * 11);
+
+	/*
+	 * Current xlog location (7, 5)
+	 * xrecoff = seg * 67108864 (64 MB segsize)
+	 */
+	recptr = ((uint64) 7) << 32 | (wal_segment_size * 5);
+
+	/* Current Delete pointer */
+	_logSegNo = 7 * XLogSegmentsPerXLogId(wal_segment_size) + 5;
+
+	/*
+	 * Prior checkpoint location (6, 3)
+	 */
+	PriorRedoPtr = ((uint64) 6) << 32 | (wal_segment_size * 3);
+
+	KeepLogSeg(recptr, &_logSegNo, PriorRedoPtr, &_keep_old_wals);
+	assert_int_equal(_logSegNo, 4*XLogSegmentsPerXLogId(wal_segment_size) + 10);
+	assert_false(_keep_old_wals);
+	/************************************************/
+
+	/************************************************
+	 * Replication slots are in use, AND
+	 * Replication slots min LSN greater than prior checkpoint,
+	 * so, set keep to prior checkpoint.
+	 * Current Delete greater than what keep wants,
+	 * so, delete offset should get updated AND
+	 * _keep_old_wals should remain false
+	 ***********************************************/
+	max_replication_slots = 1;
+	wal_keep_segments = 0;
+	_keep_old_wals = false;
+	/*
+	 * Replication slot min LSN location (7, 8)
+	 * xrecoff = seg * 67108864 (64 MB segsize)
+	 */
+	xlogctl.replicationSlotMinLSN = ((uint64) 7) << 32 | (wal_segment_size * 8);
+
+	/*
+	 * Current xlog location (7, 10)
+	 * xrecoff = seg * 67108864 (64 MB segsize)
+	 */
+	recptr = ((uint64) 7) << 32 | (wal_segment_size * 10);
+
+	/* Current Delete pointer */
+	_logSegNo = 7 * XLogSegmentsPerXLogId(wal_segment_size) + 10;
+
+	/*
+	 * Prior checkpoint location (7, 5)
+	 */
+	PriorRedoPtr = ((uint64) 7) << 32 | (wal_segment_size * 5);
+
+	KeepLogSeg(recptr, &_logSegNo, PriorRedoPtr, &_keep_old_wals);
+	assert_int_equal(_logSegNo, 7*XLogSegmentsPerXLogId(wal_segment_size) + 5);
+	assert_false(_keep_old_wals);
 	/************************************************/
 }
 


### PR DESCRIPTION
Fix missing wal files for pg_rewind, take 2

Previously, commit d0001b5f6f2fda995cd4e0c5a6f6c3b04c23817c fixed the
issue that checkpoint recycles/removes more wals than it should.
However, the fix overlooked the following scenario:

- CHECKPOINT happens very frequently, AND
- WAL replication is much slower

Resulting in replication slots' min LSN is always behind the prior
CHECKPOINT position. In this unusual but not impossible case no wal
file would ever get removed, even though both replication slots and
checkpoints are moving forward.

This patch fixes this problem by introducing one more static variable
CkptRedoAfterPriorMinLSN in KeepLogSeg() to record the smallest
CHECKPOINT position since the last time CkptRedoBeforeMinLSN (the
cutoff position) was set. This way, at some point, every now and then,
the replication slot min LSN will proceed CkptRedoAfterPriorMinLSN,
and wals before it can be recycled.

Since logic in KeepLogSeg() in Greenplum has diverged significantly
from upstream Postgres, more unit tests are added to demonstrate the
expected behaviors when replication slots are used.

While working on this fix, we also re-evaluated the difference in
KeepLogSeg() between Greenplum and upstream Postgres, and why we
chose the current approach. Here are the takeaways:

KeepLogSeg() is responsible for deciding the cutoff wal segno for
deleting old wals.

The difference (when replication slots are used):
- Upstream Postgres uses the smallest LSN among all replication slots
  as the cutoff position
- Greenplum uses the checkpoint redo position BEFORE the smallest LSN
  among all replication slots as the cutoff position

The rationale:
The checkpoint redo position BEFORE the replication slots' min LSN is
essentially the last common checkpoint of the pg_rewind source and
target segments. pg_rewind (internally used by gprecoverseg
incremental recovery) needs wal files up until this location to
present on the target segment, otherwise pg_rewind would fail fast due
to missing wal files. pg_rewind needs these wals on the target because
if the two segments diverged, the target should reply wals starting
from the last common checkpoint. This holds true for both upstream
Postgres and Greenplum.

Upstream workaround:
Started from PG13 upstream Postgres added a -c option in pg_rewind to
specify a WAL archive location from where the missing wals can be
retrieved.  However, if users don't have WAL archive setup, this
workaround is not applicable.

Alternative solution:
Can we let pg_rewind not fail if wal files between the last common
checkpoint and the divergence position are missing on the target
segment, and simply copy the same from the source segment? The answer
is no. While these wal files should be exactly the same on both
segments, there is no guarantee that these files would still exit on
the source segment by the time we run pg_rewind. As more CHECKPOINTs
could've happened and old wals could've been removed while the target
segment was disconnected.


## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
