### PR TITLE
docs - add ref info for new optimizer_skew_factor guc

### DIFF
--- a/gpdb-doc/markdown/ref_guide/config_params/guc-list.html.md
+++ b/gpdb-doc/markdown/ref_guide/config_params/guc-list.html.md
@@ -2377,7 +2377,7 @@ When GPORCA is enabled \(the default\), `optimizer_skew_factor` controls skew ra
 
 The default value is `0`, skew computation is turned off for GPORCA. To enable skew computation, set `optimizer_skew_factor` to a value between `1` and `100`, inclusive.
 
-The larger the `optimizer_skew_factor` is, the larger the cost that GPORCA assigns to redistributed hash join, such that GPORCA favors more a broadcast hash join.
+The larger the `optimizer_skew_factor`, the larger the cost that GPORCA assigns to redistributed hash join, such that GPORCA favors more a broadcast hash join.
 
 The parameter can be set for a database system, an individual database, or a session or query.
 

--- a/gpdb-doc/markdown/ref_guide/config_params/guc-list.html.md
+++ b/gpdb-doc/markdown/ref_guide/config_params/guc-list.html.md
@@ -2373,11 +2373,11 @@ This parameter can be set for a database system, an individual database, or a se
 
 ## <a id="optimizer_skew_factor"></a>optimizer\_skew\_factor 
 
-When GPORCA is enabled \(the default\), `optimizer_skew_factor` controls skew ratio computation using sampled statistics. The sampling rate is proportional to the bucket frequency; the higher the frequency, the more data GPORCA samples for that bucket.
+When GPORCA is enabled \(the default\), `optimizer_skew_factor` controls skew ratio computation.
 
 The default value is `0`, skew computation is turned off for GPORCA. To enable skew computation, set `optimizer_skew_factor` to a value between `1` and `100`, inclusive.
 
-The final skewness that GPORCA uses for plan costing is the product of the `optimizer_skew_factor` \(coefficient\) and the skew ratio \(variable\). This parameter gives you additional control over plan motions \(broadcast/gather vs. redistribution\) if you choose to emphasize the data skew.
+The larger the `optimizer_skew_factor` is, the larger the cost that GPORCA assigns to redistributed hash join, such that GPORCA favors more a broadcast hash join.
 
 The parameter can be set for a database system, an individual database, or a session or query.
 

--- a/gpdb-doc/markdown/ref_guide/config_params/guc-list.html.md
+++ b/gpdb-doc/markdown/ref_guide/config_params/guc-list.html.md
@@ -2371,6 +2371,20 @@ This parameter can be set for a database system, an individual database, or a se
 |-----------|-------|-------------------|
 |Boolean|off|master, session, reload|
 
+## <a id="optimizer_skew_factor"></a>optimizer\_skew\_factor 
+
+When GPORCA is enabled \(the default\), `optimizer_skew_factor` controls skew ratio computation using sampled statistics. The sampling rate is proportional to the bucket frequency; the higher the frequency, the more data GPORCA samples for that bucket.
+
+The default value is `0`, skew computation is turned off for GPORCA. To enable skew computation, set `optimizer_skew_factor` to a value between `1` and `100`, inclusive.
+
+The final skewness that GPORCA uses for plan costing is the product of the `optimizer_skew_factor` \(coefficient\) and the skew ratio \(variable\). This parameter gives you additional control over plan motions \(broadcast/gather vs. redistribution\) if you choose to emphasize the data skew.
+
+The parameter can be set for a database system, an individual database, or a session or query.
+
+|Value Range|Default|Set Classifications|
+|-----------|-------|-------------------|
+|integer 0-100 |0|master, session, reload|
+
 ## <a id="optimizer_sort_factor"></a>optimizer\_sort\_factor 
 
 When GPORCA is enabled \(the default\), `optimizer_sort_factor` controls the cost factor to apply to sorting operations during query optimization. The default value `1` specifies the default sort cost factor. The value is a ratio of increase or decrease from the default factor. For example, a value of `2.0` sets the cost factor at twice the default, and a value of `0.5` sets the factor at half the default.

--- a/gpdb-doc/markdown/ref_guide/config_params/guc_category-list.html.md
+++ b/gpdb-doc/markdown/ref_guide/config_params/guc_category-list.html.md
@@ -132,6 +132,7 @@ These parameters control the usage of GPORCA by Greenplum Database. For informat
 - [optimizer_penalize_skew](guc-list.html#optimizer_penalize_skew)
 - [optimizer_print_missing_stats](guc-list.html#optimizer_print_missing_stats)
 - [optimizer_print_optimization_stats](guc-list.html#optimizer_print_optimization_stats)
+- [optimizer_skew_factor](guc-list.html#optimizer_skew_factor)
 - [optimizer_sort_factor](guc-list.html#optimizer_sort_factor)
 - [optimizer_use_gpdb_allocators](guc-list.html#optimizer_use_gpdb_allocators)
 - [optimizer_xform_bind_threshold](guc-list.html#optimizer_xform_bind_threshold)


### PR DESCRIPTION
docs for https://github.com/greenplum-db/gpdb/pull/14192.  add reference info for new gporca guc optimizer_skew_factor.

this will be backported to 6X_STABLE.

doc review site link (behind vpn):  https://docs-staging.vmware.com/en/draft/VMware-Tanzu-Greenplum/newguc/greenplum-database/GUID-ref_guide-config_params-guc-list.html#optimizer_skew_factor