### PR TITLE
[6X] Do not consider certain relkinds when dumping 5X cluster

### DIFF
--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -4804,7 +4804,8 @@ getTables(Archive *fout, int *numTables)
 	 * composite type (pg_depend entries for columns of the composite type
 	 * link to the pg_class entry not the pg_type entry).
 	 */
-	appendPQExpBufferStr(query,
+	if (fout->remoteVersion >= GPDB6_MAJOR_PGVERSION)
+		appendPQExpBufferStr(query,
 						  "WHERE c.relkind IN ("
 						  CppAsString2(RELKIND_RELATION) ", "
 						  CppAsString2(RELKIND_SEQUENCE) ", "
@@ -4812,6 +4813,13 @@ getTables(Archive *fout, int *numTables)
 						  CppAsString2(RELKIND_COMPOSITE_TYPE) ", "
 						  CppAsString2(RELKIND_MATVIEW) ", "
 						  CppAsString2(RELKIND_FOREIGN_TABLE) ")\n");
+	else
+		appendPQExpBufferStr(query,
+						  "WHERE c.relkind IN ("
+						  CppAsString2(RELKIND_RELATION) ", "
+						  CppAsString2(RELKIND_SEQUENCE) ", "
+						  CppAsString2(RELKIND_VIEW) ", "
+						  CppAsString2(RELKIND_COMPOSITE_TYPE) ")\n");
 
   if (fout->remoteVersion >= 80400)
 		appendPQExpBufferStr(query,


### PR DESCRIPTION
Commit a452dbaef44059e83e5f5d3f5abb98ef754baccb introduced a regression
where pg_dump is now searching for materialized views and foreign tables
to dump. These objects do not exist on 5X and should not be considered
as dumpable objects. This is especially conflicting because relkind 'm'
is aovisimap table in 5X whereas in 6X it is materialized view.
    
This issue was caught by the gpupgrade tests where it was found that the
extra aovisimap entries due to the regression was changing the
dependency sorting expectations.

gpup: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/gpupgrade:dont-dump-mview-and-ftables
6x:   https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/dont-dump-mview-and-ftables
