### PR TITLE
Perform GP7 `without_asserts` pipeline runs on `gpdb_src` trigger.

### DIFF
--- a/concourse/vars/without_asserts_common_prod.yml
+++ b/concourse/vars/without_asserts_common_prod.yml
@@ -4,7 +4,7 @@ rc-build-type: prod
 rc-build-type-gcs: ""
 reduced-frequency-trigger-start: 1:00 AM
 reduced-frequency-trigger-stop: 2:00 AM
-reduced-frequency-trigger-flag: true
-gpdb_src-trigger-flag: false
+reduced-frequency-trigger-flag: false
+gpdb_src-trigger-flag: true
 configure_flags: "--enable-tap-tests"
 configure_flags_with_extensions: "--enable-tap-tests --enable-debug-extensions"


### PR DESCRIPTION
Change GP7 `gpdb_main_without_asserts` pipeline compilation job (`compile_gpdb_rhel8`) to use `gpdb_src` (every commit) resource trigger instead of the once per day `reduced-frequency-trigger` trigger.

The pipeline impacted is:
https://prod.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb_main_without_asserts

When this change is committed, the pipeline will need to be re-set.