### PR TITLE
[6X] pg_dump: set check constraints

### DIFF
--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -4912,6 +4912,7 @@ getTables(Archive *fout, int *numTables)
 		tblinfo[i].reltype = atooid(PQgetvalue(res, i, i_reltype));
 		tblinfo[i].relstorage = *(PQgetvalue(res, i, i_relstorage));
 		tblinfo[i].relpersistence = *(PQgetvalue(res, i, i_relpersistence));
+		tblinfo[i].ncheck = atoi(PQgetvalue(res, i, i_relchecks));
 		tblinfo[i].hasindex = (strcmp(PQgetvalue(res, i, i_relhasindex), "t") == 0);
 		tblinfo[i].hasrules = (strcmp(PQgetvalue(res, i, i_relhasrules), "t") == 0);
 		tblinfo[i].hastriggers = (strcmp(PQgetvalue(res, i, i_relhastriggers), "t") == 0);

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -6840,7 +6840,8 @@ getTableAttrs(Archive *fout, TableInfo *tblinfo, int numTables)
 		int			i_conislocal;
 		int			i_convalidated;
 
-		write_msg(NULL, "finding table check constraints\n");
+		if (g_verbose)
+			write_msg(NULL, "finding table check constraints\n");
 
 		resetPQExpBuffer(q);
 		appendPQExpBufferStr(q,


### PR DESCRIPTION
Commit a452dbae introduced a regression that removed setting nchecks on tblinfo which are the number of check constraints. Since it was never set it defaulted to zero causing no table check constraints to be dumped.

This issue was discovered by the gpupgrade upgradeable pg_upgrade acceptance tests.

Test Pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/dumpCheckConstraints
