### PR TITLE
(6x) gpexpand.status_detail  should be distributed by "table_oid"

### DIFF
--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -300,7 +300,8 @@ status_detail_table_sql = """CREATE TABLE gpexpand.status_detail
                           expansion_started timestamp,
                           expansion_finished timestamp,
                           source_bytes numeric,
-                          rel_storage text ) """
+                          rel_storage text )
+                          distributed by (table_oid) """
 # gpexpand views
 progress_view_simple_sql = """CREATE VIEW gpexpand.expansion_progress AS
 SELECT


### PR DESCRIPTION
The table gpexpand.status_detail used by gpexpand should be distributed by "table_oid", to avoid the updating workload burden of tens thounsand tables in an EDW, concentrated on only one single segment with the prior distribution policy (distributed by dbname).

	modified:   gpMgmt/bin/gpexpand

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
