### PR TITLE
Fixed gprecoverseg and gpmovemirrors flaky testcases

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -587,6 +587,7 @@ Feature: gprecoverseg tests
 #      | \S+     | [0-9]+ | incremental    | [0-9]+                 | [0-9]+             | [0-9]+\%             |
     And all files in gpAdminLogs directory are deleted on all hosts in the cluster
 
+    And the cluster is rebalanced
     And user immediately stops all primary processes for content 0,1,2
     And the user waits until mirror on content 0,1,2 is down
     And user can start transactions


### PR DESCRIPTION
Updating gprecoverseg tests case to make sure the cluster is rebalanced before bringing primaries down again.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
