### PR TITLE
[backport to 6X] Delete verbose logging of message "fetch bitmap page"

### DIFF
--- a/src/backend/access/bitmap/bitmapsearch.c
+++ b/src/backend/access/bitmap/bitmapsearch.c
@@ -294,8 +294,6 @@ read_words(Relation rel, Buffer lovBuffer, OffsetNumber lovOffset,
 		bitmapBuffer = _bitmap_getbuf(rel, *nextBlockNoP, BM_READ);
 		bitmapPage = BufferGetPage(bitmapBuffer);
 
-		elog(LOG, "fetch bitmap page");
-
 		bitmap = (BMBitmap) PageGetContentsMaxAligned(bitmapPage);
 		bo = (BMBitmapOpaque)PageGetSpecialPointer(bitmapPage);
 


### PR DESCRIPTION
Seems left over debug message by commit 22c1ec81c1ce. It floods the log files unnecessarily, when using bitmap index scans.

Reviewed-by: Bhuvnesh Chaudhary <bhuvnesh2703@gmail.com>
Reviewed-by: Jimmy Yih <jyih@vmware.com>
(cherry picked from commit 2ce4111e20e2404e12982bdf74146541cb1eccb3)

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
