### PR TITLE
Convert float8 with double instead of long double

### DIFF
--- a/src/backend/utils/adt/float.c
+++ b/src/backend/utils/adt/float.c
@@ -252,18 +252,6 @@ float4in(PG_FUNCTION_ARGS)
 					 errmsg("invalid input syntax for type %s: \"%s\"",
 							"real", orig_num)));
 	}
-#ifdef HAVE_BUGGY_SOLARIS_STRTOD
-	else
-	{
-		/*
-		 * Many versions of Solaris have a bug wherein strtod sets endptr to
-		 * point one byte beyond the end of the string when given "inf" or
-		 * "infinity".
-		 */
-		if (endptr != num && endptr[-1] == '\0')
-			endptr--;
-	}
-#endif							/* HAVE_BUGGY_SOLARIS_STRTOD */
 
 	/* skip trailing whitespace */
 	while (*endptr != '\0' && isspace((unsigned char) *endptr))
@@ -475,18 +463,6 @@ float8in_internal_opt_error(char *num, char **endptr_p,
 										 "%s: \"%s\"",
 										 type_name, orig_string))));
 	}
-#ifdef HAVE_BUGGY_SOLARIS_STRTOD
-	else
-	{
-		/*
-		 * Many versions of Solaris have a bug wherein strtod sets endptr to
-		 * point one byte beyond the end of the string when given "inf" or
-		 * "infinity".
-		 */
-		if (endptr != num && endptr[-1] == '\0')
-			endptr--;
-	}
-#endif							/* HAVE_BUGGY_SOLARIS_STRTOD */
 
 	/* skip trailing whitespace */
 	while (*endptr != '\0' && isspace((unsigned char) *endptr))

--- a/src/include/port/solaris.h
+++ b/src/include/port/solaris.h
@@ -24,15 +24,3 @@
 #if defined(__i386__)
 #include <sys/isa_defs.h>
 #endif
-
-/*
- * Many versions of Solaris have broken strtod() --- see bug #4751182.
- * This has been fixed in current versions of Solaris:
- *
- * http://sunsolve.sun.com/search/document.do?assetkey=1-21-108993-62-1&searchclause=108993-62
- * http://sunsolve.sun.com/search/document.do?assetkey=1-21-112874-34-1&searchclause=112874-34
- *
- * However, many people might not have patched versions, so
- * still use our own fix for the buggy version.
- */
-#define HAVE_BUGGY_SOLARIS_STRTOD

--- a/src/test/regress/expected/float8.out
+++ b/src/test/regress/expected/float8.out
@@ -9,27 +9,27 @@ INSERT INTO FLOAT8_TBL(f1) VALUES ('1.2345678901234e+200');
 INSERT INTO FLOAT8_TBL(f1) VALUES ('1.2345678901234e-200');
 -- test for underflow and overflow handling
 SELECT '10e400'::float8;
-ERROR:  value out of range: overflow
+ERROR:  "10e400" is out of range for type double precision
 LINE 1: SELECT '10e400'::float8;
                ^
 SELECT '-10e400'::float8;
-ERROR:  value out of range: overflow
+ERROR:  "-10e400" is out of range for type double precision
 LINE 1: SELECT '-10e400'::float8;
                ^
 SELECT '1e309'::float8;
-ERROR:  value out of range: overflow
+ERROR:  "1e309" is out of range for type double precision
 LINE 1: SELECT '1e309'::float8;
                ^
 SELECT '10e-400'::float8;
-ERROR:  value out of range: underflow
+ERROR:  "10e-400" is out of range for type double precision
 LINE 1: SELECT '10e-400'::float8;
                ^
 SELECT '-10e-400'::float8;
-ERROR:  value out of range: underflow
+ERROR:  "-10e-400" is out of range for type double precision
 LINE 1: SELECT '-10e-400'::float8;
                ^
 SELECT '1e-324'::float8;
-ERROR:  value out of range: underflow
+ERROR:  "1e-324" is out of range for type double precision
 LINE 1: SELECT '1e-324'::float8;
                ^
 SELECT '1e308'::float8;
@@ -645,27 +645,27 @@ SELECT atanh(float8 'nan');
 RESET extra_float_digits;
 -- test for over- and underflow
 INSERT INTO FLOAT8_TBL(f1) VALUES ('10e400');
-ERROR:  value out of range: overflow
+ERROR:  "10e400" is out of range for type double precision
 LINE 1: INSERT INTO FLOAT8_TBL(f1) VALUES ('10e400');
                                            ^
 INSERT INTO FLOAT8_TBL(f1) VALUES ('-10e400');
-ERROR:  value out of range: overflow
+ERROR:  "-10e400" is out of range for type double precision
 LINE 1: INSERT INTO FLOAT8_TBL(f1) VALUES ('-10e400');
                                            ^
 INSERT INTO FLOAT8_TBL(f1) VALUES ('1e309');
-ERROR:  value out of range: overflow
+ERROR:  "1e309" is out of range for type double precision
 LINE 1: INSERT INTO FLOAT8_TBL(f1) VALUES ('1e309');
                                            ^
 INSERT INTO FLOAT8_TBL(f1) VALUES ('10e-400');
-ERROR:  value out of range: underflow
+ERROR:  "10e-400" is out of range for type double precision
 LINE 1: INSERT INTO FLOAT8_TBL(f1) VALUES ('10e-400');
                                            ^
 INSERT INTO FLOAT8_TBL(f1) VALUES ('-10e-400');
-ERROR:  value out of range: underflow
+ERROR:  "-10e-400" is out of range for type double precision
 LINE 1: INSERT INTO FLOAT8_TBL(f1) VALUES ('-10e-400');
                                            ^
 INSERT INTO FLOAT8_TBL(f1) VALUES ('1e-324');
-ERROR:  value out of range: underflow
+ERROR:  "1e-324" is out of range for type double precision
 LINE 1: INSERT INTO FLOAT8_TBL(f1) VALUES ('1e-324');
                                            ^
 INSERT INTO FLOAT8_TBL(f1) VALUES ('1e308');
@@ -681,19 +681,19 @@ INSERT INTO FLOAT8_TBL(f1) VALUES ('+naN'::float8);
 INSERT INTO FLOAT8_TBL(f1) VALUES ('-naN'::float8);
 -- test for over- and underflow with update statement
 UPDATE FLOAT8_TBL SET f1='0.0'::float8 WHERE f1='1e-324'::float8;
-ERROR:  value out of range: underflow
+ERROR:  "1e-324" is out of range for type double precision
 LINE 1: UPDATE FLOAT8_TBL SET f1='0.0'::float8 WHERE f1='1e-324'::fl...
                                                         ^
 UPDATE FLOAT8_TBL SET f1='0.0'::float8 WHERE f1='1e309'::float8;
-ERROR:  value out of range: overflow
+ERROR:  "1e309" is out of range for type double precision
 LINE 1: UPDATE FLOAT8_TBL SET f1='0.0'::float8 WHERE f1='1e309'::flo...
                                                         ^
 UPDATE FLOAT8_TBL SET f1='0.0'::float8 WHERE f1='1e-400'::float8;
-ERROR:  value out of range: underflow
+ERROR:  "1e-400" is out of range for type double precision
 LINE 1: UPDATE FLOAT8_TBL SET f1='0.0'::float8 WHERE f1='1e-400'::fl...
                                                         ^
 UPDATE FLOAT8_TBL SET f1='0.0'::float8 WHERE f1='1e400'::float8;
-ERROR:  value out of range: overflow
+ERROR:  "1e400" is out of range for type double precision
 LINE 1: UPDATE FLOAT8_TBL SET f1='0.0'::float8 WHERE f1='1e400'::flo...
                                                         ^
 UPDATE FLOAT8_TBL SET f1='0.0'::float8 WHERE f1='0.0'::float8;
@@ -707,19 +707,19 @@ UPDATE FLOAT8_TBL SET f1='0.0'::float8 WHERE f1='+naN'::float8;
 UPDATE FLOAT8_TBL SET f1='0.0'::float8 WHERE f1='-naN'::float8;
 -- test for over- and underflow with delete statement
 DELETE FROM FLOAT8_TBL WHERE f1='1e-324'::float8;
-ERROR:  value out of range: underflow
+ERROR:  "1e-324" is out of range for type double precision
 LINE 1: DELETE FROM FLOAT8_TBL WHERE f1='1e-324'::float8;
                                         ^
 DELETE FROM FLOAT8_TBL WHERE f1='1e309'::float8;
-ERROR:  value out of range: overflow
+ERROR:  "1e309" is out of range for type double precision
 LINE 1: DELETE FROM FLOAT8_TBL WHERE f1='1e309'::float8;
                                         ^
 DELETE FROM FLOAT8_TBL WHERE f1='1e400'::float8;
-ERROR:  value out of range: overflow
+ERROR:  "1e400" is out of range for type double precision
 LINE 1: DELETE FROM FLOAT8_TBL WHERE f1='1e400'::float8;
                                         ^
 DELETE FROM FLOAT8_TBL WHERE f1='1e-400'::float8;
-ERROR:  value out of range: underflow
+ERROR:  "1e-400" is out of range for type double precision
 LINE 1: DELETE FROM FLOAT8_TBL WHERE f1='1e-400'::float8;
                                         ^
 DELETE FROM FLOAT8_TBL WHERE f1='0.0'::float8;

--- a/src/test/regress/expected/point.out
+++ b/src/test/regress/expected/point.out
@@ -32,7 +32,7 @@ ERROR:  invalid input syntax for type point: "(10.0,10.0"
 LINE 1: INSERT INTO POINT_TBL(f1) VALUES ('(10.0,10.0');
                                           ^
 INSERT INTO POINT_TBL(f1) VALUES ('(10.0, 1e+500)');	-- Out of range
-ERROR:  value out of range: overflow
+ERROR:  "1e+500" is out of range for type double precision
 LINE 1: INSERT INTO POINT_TBL(f1) VALUES ('(10.0, 1e+500)');
                                           ^
 SELECT '' AS six, * FROM POINT_TBL;


### PR DESCRIPTION
This is a follow-up to the PR https://github.com/greenplum-db/gpdb/pull/12485, and commit on-top to fully align float.c with upstream instead of having any GPDB-specific diff

Commentary from that PR
------
It seems that GPDB faced a glibc bug on RedHat 6 with denormalized numbers and fixed it using two-step conversion in float8in():

text to long double
long double to double after denormalized numbers validation
This differs from PG approach where we rely on libc and make the direct conversion to double. RedHat 6 seems to be an old system and there is no much sense to differ from upstream and have additional performance penalty converting long double to double in a two-step manner and making additional checks.

There is another problem with this code - long double can have problems on some architectures that are currently not supported by GPDB, but where it can be ported in the future. Originally this problem was detected as research about porting GPDB to PowerPC: it doesn't have analogue of Intel 80-bit long double with 63-bit mantissa and extended range between 1.0E-4932W and 1.0E+4932W. Instead, PowerPC has an extended double type combined from two doubles with 106-bit mantissa and the same range as double provides 1.0E−323L - 1.0E+308L. As a result, we can't use the same validation logic for the numbers near +/- infinity as it is possible to do on Intel. So this GPDB specific code doesn't help us to solve
the problem on RedHat 6 on PowerPC and fails the float test.

So, let's get rid of it and return the code to PG approach with a double.


--------
