### PR TITLE
Add multi-thread compression and transmission from gpfdist to gpdb7

### DIFF
--- a/gpMgmt/doc/gpfdist_help
+++ b/gpMgmt/doc/gpfdist_help
@@ -9,6 +9,7 @@ SYNOPSIS
 
 gpfdist [-d <directory>] [-p <http_port>] [-l <log_file>] [-t <timeout>] 
 [-S] [-w <time>] [-v | -V] [-m <max_length>] [--ssl <certificate_path>]
+[--compress] [--mthread <number_of_threads>]
 
 gpfdist [-? | --help] | --version
 
@@ -137,6 +138,29 @@ OPTIONS
  * The trusted certificate authorities, root.crt 
 
  The root directory (/) cannot be specified as certificate_path. 
+
+
+--compress
+
+ Utilizes the Zstandard (zstd) compression method for data transfer via 
+ gpfdist. Zstd is an effective compression algorithm designed to enable
+ gpfdist to transmit larger amounts of data while maintaining low network 
+ usage. However, it is important to note that compression can be a 
+ time-intensive process, which may potentially result in reduced 
+ transmission speeds.
+
+
+--mthread <number_of_threads>
+
+ Configures the maximum number of threads for compressing and transmitting 
+ data. As compression is a computationally intensive process, utilizing 
+ multi-threaded execution can help decrease the overall time required for 
+ compression. Consequently, multi-threaded compression facilitates faster 
+ data transmission while maintaining low network occupancy and high speed.
+
+ Note: The flag '--mthread' signifies enabling compression. It is permitted 
+ to use this flag in conjunction with '--compress'. However, when used 
+ together, the effect is equivalent to using '--mthread' by itself.
 
 
 -v (verbose) 

--- a/gpMgmt/doc/gpfdist_help
+++ b/gpMgmt/doc/gpfdist_help
@@ -9,7 +9,7 @@ SYNOPSIS
 
 gpfdist [-d <directory>] [-p <http_port>] [-l <log_file>] [-t <timeout>] 
 [-S] [-w <time>] [-v | -V] [-m <max_length>] [--ssl <certificate_path>]
-[--compress] [--mthread <number_of_threads>]
+[--compress] [--multi_thread <number_of_threads>]
 
 gpfdist [-? | --help] | --version
 
@@ -150,7 +150,7 @@ OPTIONS
  transmission speeds.
 
 
---mthread <number_of_threads>
+--multi_thread <number_of_threads>
 
  Configures the maximum number of threads for compressing and transmitting 
  data. As compression is a computationally intensive process, utilizing 
@@ -158,9 +158,9 @@ OPTIONS
  compression. Consequently, multi-threaded compression facilitates faster 
  data transmission while maintaining low network occupancy and high speed.
 
- Note: The flag '--mthread' signifies enabling compression. It is permitted 
+ Note: The flag '--multi_thread' signifies enabling compression. It is permitted 
  to use this flag in conjunction with '--compress'. However, when used 
- together, the effect is equivalent to using '--mthread' by itself.
+ together, the effect is equivalent to using '--multi_thread' by itself.
 
 
 -v (verbose) 

--- a/src/backend/access/external/url_curl.c
+++ b/src/backend/access/external/url_curl.c
@@ -58,18 +58,6 @@ typedef struct curlhandle_t
 	struct curlhandle_t *prev;
 } curlhandle_t;
 
-#ifdef USE_ZSTD
-typedef struct zstdcontext_t
-{
-	ZSTD_DCtx	   *zstd_dctx;		/* The zstd decompression context */
-	ZSTD_CCtx	   *zstd_cctx;		/* The zstd decompression context */
-
-	ResourceOwner owner;			/* owner of this handle */
-	struct zstdcontext_t *next;
-	struct zstdcontext_t *prev;
-} zstdcontext_t;
-#endif
-
 /*
  * Private state for a web external table, implemented with libcurl.
  *
@@ -1202,14 +1190,6 @@ url_curl_fopen(char *url, bool forwrite, extvar_t *ev, CopyState pstate)
 		RegisterResourceReleaseCallback(url_curl_abort_callback, NULL);
 		url_curl_resowner_callback_registered = true;
 	}
-
-#ifdef USE_ZSTD
-	if (!zstd_resowner_callback_registered)
-	{
-		RegisterResourceReleaseCallback(zstd_release_callback, NULL);
-		zstd_resowner_callback_registered = true;
-	}
-#endif
 
 	tmp = make_url(url, is_ipv6);
 

--- a/src/backend/access/external/url_curl.c
+++ b/src/backend/access/external/url_curl.c
@@ -1897,7 +1897,6 @@ gp_proto0_write(URL_CURL_FILE *file, CopyState pstate)
 {	
 	char*		buf;
 	int		nbytes;
-<<<<<<< HEAD
 #ifdef USE_ZSTD
 	if(file->zstd){
 		nbytes = compress_zstd_data(file);
@@ -1909,14 +1908,15 @@ gp_proto0_write(URL_CURL_FILE *file, CopyState pstate)
 		buf = file->out.ptr;
 	 	nbytes = file->out.top;
 	}
-=======
-	if(file->zstd){
+
 #ifdef USE_ZSTD
+	if(file->zstd){
 		nbytes = compress_zstd_data(file);
 		buf = file->out.cptr;
-#endif
 	}
-	else{
+	else
+#endif
+	{
 		buf = file->out.ptr;
 	 	nbytes = file->out.top;
 	}
@@ -2021,7 +2021,6 @@ curl_fwrite(char *buf, int nbytes, URL_CURL_FILE *file, CopyState pstate)
 			if (!newbuf)
 				elog(ERROR, "out of memory (curl_fwrite)");
 			file->out.ptr = newbuf;
-<<<<<<< HEAD
 			
 			if (file->zstd) 
 			{
@@ -2030,13 +2029,6 @@ curl_fwrite(char *buf, int nbytes, URL_CURL_FILE *file, CopyState pstate)
 					elog(ERROR, "out of compress memory (curl_fwrite)");
 				file->out.cptr = newbuf;
 			}
-=======
-
-			newbuf = repalloc(file->out.cptr, n);
-			if (!newbuf)
-				elog(ERROR, "out of compress memory (curl_fwrite)");
-			file->out.cptr = newbuf;
->>>>>>> add_gpdb7_to_gpfdist_compress
 
 			file->out.max = n;
 

--- a/src/backend/access/external/url_curl.c
+++ b/src/backend/access/external/url_curl.c
@@ -1300,9 +1300,7 @@ url_curl_fopen(char *url, bool forwrite, extvar_t *ev, CopyState pstate)
 		set_httpheader(file, "X-GP-PROTO", "0");
 		set_httpheader(file, "X-GP-SEQ", "1");
 		set_httpheader(file, "Content-Type", "text/xml");
-#ifdef USE_ZSTD
 		set_httpheader(file, "X-GP-ZSTD", "1");
-#endif
 	}
 	else
 	{
@@ -1442,7 +1440,6 @@ url_curl_fopen(char *url, bool forwrite, extvar_t *ev, CopyState pstate)
 		int			bufsize = writable_external_table_bufsize * 1024;
 
 		file->out.ptr = (char *) palloc(bufsize);
-		file->out.cptr = (char *) palloc(bufsize);
 		file->out.max = bufsize;
 		file->out.bot = file->out.top = 0;
 	}

--- a/src/backend/access/external/url_curl.c
+++ b/src/backend/access/external/url_curl.c
@@ -1527,6 +1527,10 @@ url_curl_fclose(URL_FILE *fileg, bool failOnError, const char *relname)
 	memset(&file->block, 0, sizeof(file->block));
 
 	pfree(file->common.url);
+#ifdef USE_ZSTD
+	if (file->zstd)
+		ZSTD_freeDCtx(file->zstd_dctx);
+#endif
 
 	pfree(file);
 }

--- a/src/backend/access/external/url_curl.c
+++ b/src/backend/access/external/url_curl.c
@@ -1897,8 +1897,6 @@ gp_proto0_write(URL_CURL_FILE *file, CopyState pstate)
 		buf = file->out.ptr;
 	 	nbytes = file->out.top;
 	}
-	
->>>>>>> add_gpdb7_to_gpfdist_compress
 
 	if (nbytes == 0)
 		return;

--- a/src/backend/access/external/url_curl.c
+++ b/src/backend/access/external/url_curl.c
@@ -1300,6 +1300,9 @@ url_curl_fopen(char *url, bool forwrite, extvar_t *ev, CopyState pstate)
 		set_httpheader(file, "X-GP-PROTO", "0");
 		set_httpheader(file, "X-GP-SEQ", "1");
 		set_httpheader(file, "Content-Type", "text/xml");
+#ifdef USE_ZSTD
+		set_httpheader(file, "X-GP-ZSTD", "1");
+#endif
 	}
 	else
 	{
@@ -1439,6 +1442,7 @@ url_curl_fopen(char *url, bool forwrite, extvar_t *ev, CopyState pstate)
 		int			bufsize = writable_external_table_bufsize * 1024;
 
 		file->out.ptr = (char *) palloc(bufsize);
+		file->out.cptr = (char *) palloc(bufsize);
 		file->out.max = bufsize;
 		file->out.bot = file->out.top = 0;
 	}

--- a/src/backend/access/external/url_curl.c
+++ b/src/backend/access/external/url_curl.c
@@ -1795,11 +1795,12 @@ gp_proto1_read(char *buf, int bufsz, URL_CURL_FILE *file, CopyState pstate, char
 			 * error. However, the error is not the real cause of the abortion. So we add a judge here,
 			 * to check if gpdb get enough data to decompress. The missing data means the network problem.
 			 */
-			if (file->lastsize > (file->in.top - file->in.bot) && file->block.datalen)
+			left_bytes = (file->in.top - file->in.bot);
+			if (file->lastsize > left_bytes && file->block.datalen)
 			{
 				ereport(ERROR,
 					(errcode(ERRCODE_CONNECTION_FAILURE),
-					 errmsg("connection to gpfdist error: stream ends suddenly")));
+					 errmsg("connection to gpfdist error: stream ends unexpectedly")));
 			}
 #endif
 		}

--- a/src/backend/access/external/url_curl.c
+++ b/src/backend/access/external/url_curl.c
@@ -1300,7 +1300,6 @@ url_curl_fopen(char *url, bool forwrite, extvar_t *ev, CopyState pstate)
 		set_httpheader(file, "X-GP-PROTO", "0");
 		set_httpheader(file, "X-GP-SEQ", "1");
 		set_httpheader(file, "Content-Type", "text/xml");
-		set_httpheader(file, "X-GP-ZSTD", "1");
 	}
 	else
 	{

--- a/src/backend/access/external/url_curl.c
+++ b/src/backend/access/external/url_curl.c
@@ -1300,9 +1300,6 @@ url_curl_fopen(char *url, bool forwrite, extvar_t *ev, CopyState pstate)
 		set_httpheader(file, "X-GP-PROTO", "0");
 		set_httpheader(file, "X-GP-SEQ", "1");
 		set_httpheader(file, "Content-Type", "text/xml");
-#ifdef USE_ZSTD
-		set_httpheader(file, "X-GP-ZSTD", "1");
-#endif
 	}
 	else
 	{
@@ -1442,7 +1439,6 @@ url_curl_fopen(char *url, bool forwrite, extvar_t *ev, CopyState pstate)
 		int			bufsize = writable_external_table_bufsize * 1024;
 
 		file->out.ptr = (char *) palloc(bufsize);
-		file->out.cptr = (char *) palloc(bufsize);
 		file->out.max = bufsize;
 		file->out.bot = file->out.top = 0;
 	}
@@ -1877,18 +1873,6 @@ gp_proto0_write(URL_CURL_FILE *file, CopyState pstate)
 {	
 	char*		buf;
 	int		nbytes;
-#ifdef USE_ZSTD
-	if(file->zstd){
-		nbytes = compress_zstd_data(file);
-		buf = file->out.cptr;
-	}
-	else
-#endif
-	{
-		buf = file->out.ptr;
-	 	nbytes = file->out.top;
-	}
-
 #ifdef USE_ZSTD
 	if(file->zstd){
 		nbytes = compress_zstd_data(file);

--- a/src/backend/access/external/url_curl.c
+++ b/src/backend/access/external/url_curl.c
@@ -1790,6 +1790,17 @@ gp_proto1_read(char *buf, int bufsz, URL_CURL_FILE *file, CopyState pstate, char
 #ifdef USE_ZSTD
 			int wantsz = ZSTD_DStreamInSize() - left_bytes;
 			fill_buffer(file, wantsz);
+			/* Gpfdist could be aborted unexpectedly. Thus gpdb would recieve the partial data, which 
+			 * is unable to be decompressed correctly. In this case, gpdb will report a decompression
+			 * error. However, the error is not the real cause of the abortion. So we add a judge here,
+			 * to check if gpdb get enough data to decompress. The missing data means the network problem.
+			 */
+			if (file->lastsize > (file->in.top - file->in.bot) && file->block.datalen)
+			{
+				ereport(ERROR,
+					(errcode(ERRCODE_CONNECTION_FAILURE),
+					 errmsg("connection to gpfdist error: stream ends suddenly")));
+			}
 #endif
 		}
 	} 

--- a/src/backend/utils/misc/fstream/gfile.c
+++ b/src/backend/utils/misc/fstream/gfile.c
@@ -1295,7 +1295,7 @@ gfile_close(gfile_t*fd)
 			* for the compressed data implementation we need to call the "close" callback. Other implementations
 			* didn't use to call this callback here and it will remain so.
 			*/
-			if (fd->compression == GZ_COMPRESSION || fd->compression == ZSTD_COMPRESSION)
+			if (fd->compression == GZ_COMPRESSION || fd->compression == ZSTD_COMPRESSION || fd->compression == BZ_COMPRESSION)
 			{
 				fd->close(fd);
 			}

--- a/src/bin/gpfdist/gpfdist.c
+++ b/src/bin/gpfdist/gpfdist.c
@@ -3257,6 +3257,10 @@ static void handle_post_request(request_t *r, int header_end)
 				}
 			}
 		}
+		if (r->zstd) 
+		{
+			r->in.cflag = data_bytes_in_req;
+		}
 	}
 
 	/*

--- a/src/bin/gpfdist/gpfdist.c
+++ b/src/bin/gpfdist/gpfdist.c
@@ -3268,9 +3268,6 @@ static void handle_post_request(request_t *r, int header_end)
 		size_t want;
 		ssize_t n = 0;
 		size_t buf_space_left = r->in.dbufmax - r->in.dbuftop;
-		if(r->zstd){
-			buf_space_left = r->in.dbufmax - r->in.cbuftop;
-		}
 
 		if (r->in.davailable > buf_space_left)
 			want = buf_space_left;
@@ -3278,14 +3275,7 @@ static void handle_post_request(request_t *r, int header_end)
 			want = r->in.davailable;
 
 		/* read from socket into data buf */
-		if (!r->zstd) 
-		{
-			n = gpfdist_receive(r, r->in.dbuf + r->in.dbuftop, want);
-		} 
-		else if (!r->in.cflag)
-		{
-			n = gpfdist_receive(r, r->in.cbuf + r->in.cbuftop, want);
-		}
+		n = gpfdist_receive(r, r->in.dbuf + r->in.dbuftop, want);
 
 		if (n < 0)
 		{
@@ -3318,15 +3308,7 @@ static void handle_post_request(request_t *r, int header_end)
 			r->bytes += n;
 			r->last = apr_time_now();
 			r->in.davailable -= n;
-			if (!r->zstd) 
-			{
-				r->in.dbuftop += n;
-			}
-			else
-			{
-				r->in.cbuftop += n;
-			}
-			
+			r->in.dbuftop += n;
 
 			/* success is a flag to check whether data is written into file successfully.
 			 * There is no need to do anything when success is less than 0, since all
@@ -3335,8 +3317,7 @@ static void handle_post_request(request_t *r, int header_end)
 			int success = 0;
 
 			/* if filled our buffer or no more data expected, write it */
-			if (r->in.dbufmax == r->in.dbuftop || r->in.davailable == 0 || 
-				(r->zstd && r->in.dbufmax == r->in.cbuftop))
+			if (r->in.dbufmax == r->in.dbuftop || r->in.davailable == 0)
 			{
 #ifdef USE_ZSTD
 				/* only write up to end of last row */

--- a/src/bin/gpfdist/gpfdist.c
+++ b/src/bin/gpfdist/gpfdist.c
@@ -19,7 +19,6 @@
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <sys/sysinfo.h>
 #ifndef WIN32
 #include <strings.h>
 #endif

--- a/src/bin/gpfdist/gpfdist.c
+++ b/src/bin/gpfdist/gpfdist.c
@@ -3234,7 +3234,7 @@ static void handle_post_request(request_t *r, int header_end)
 		r->in.davailable -= data_bytes_in_req;
 
 		/* only write it out if no more data is expected */
-		if(r->in.davailable == 0 && !r->zstd)
+		if(r->in.davailable == 0)
 		{
 #ifdef USE_ZSTD
 			if(r->zstd)
@@ -3257,17 +3257,13 @@ static void handle_post_request(request_t *r, int header_end)
 				}
 			}
 		}
-		if (r->zstd) 
-		{
-			r->in.cflag = data_bytes_in_req;
-		}
 	}
 
 	/*
 	 * we've consumed all data that came in the first buffer (with the request)
 	 * if we're still expecting more data, get it from socket now and process it.
 	 */
-	while(r->in.davailable > 0 || r->in.cflag != 0)
+	while(r->in.davailable > 0)
 	{
 		size_t want;
 		ssize_t n = 0;
@@ -3298,7 +3294,7 @@ static void handle_post_request(request_t *r, int header_end)
 				return;
 			}
 		}
-		else if (n == 0 && !r->in.cflag)
+		else if (n == 0)
 		{
 			/* socket close by peer will return 0 */
 			gwarning(r, "handle_post_request socket closed by peer");

--- a/src/bin/gpfdist/gpfdist.c
+++ b/src/bin/gpfdist/gpfdist.c
@@ -1296,8 +1296,8 @@ wait_for_thread_join(request_t *r, int *send_size)
 		*send_size = -1;
 }
 
-static int 
-send_compression_data (request_t *r)
+static 
+int send_compression_data (request_t *r)
 {
 	int osize = r->outblock.top;
 	block_t *outblock = &r->outblock;
@@ -1922,7 +1922,7 @@ static void do_write(int fd, short event, void* arg)
 		
 
 	/* Loop at most 3 blocks or until we choke on the socket */
-	for (i = 0; i < 1; i++)
+	for (i = 0; i < 3; i++)
 	{
 		/* get a block (or find a remaining block) */
 		if (r->outblock.top == r->outblock.bot)
@@ -2020,6 +2020,11 @@ static void do_write(int fd, short event, void* arg)
 		if (datablock->top != datablock->bot)
 		{ /* network chocked */
 			gdebug(r, "network full");
+			break;
+		}
+
+		if (r->multi_thread)
+		{ /* It is very essential judge!! Because local_send_with_zstd will start a thread, and loop will cause confliction */
 			break;
 		}
 	}

--- a/src/bin/gpfdist/gpfdist.c
+++ b/src/bin/gpfdist/gpfdist.c
@@ -91,7 +91,7 @@ struct block_t
 typedef struct zstd_buffer zstd_buffer;
 struct zstd_buffer
 {
-	char	*buf;
+	char		*buf;
 	int		size;
 	int		pos;	
 };

--- a/src/bin/gpfdist/gpfdist.c
+++ b/src/bin/gpfdist/gpfdist.c
@@ -3278,13 +3278,13 @@ static void handle_post_request(request_t *r, int header_end)
 			want = r->in.davailable;
 
 		/* read from socket into data buf */
-		if (r->zstd && !r->in.cflag)
-		{
-			n = gpfdist_receive(r, r->in.cbuf + r->in.cbuftop, want);
-		}
-		else
+		if (!r->zstd) 
 		{
 			n = gpfdist_receive(r, r->in.dbuf + r->in.dbuftop, want);
+		} 
+		else if (!r->in.cflag)
+		{
+			n = gpfdist_receive(r, r->in.cbuf + r->in.cbuftop, want);
 		}
 
 		if (n < 0)

--- a/src/bin/gpfdist/gpfdist.c
+++ b/src/bin/gpfdist/gpfdist.c
@@ -3234,7 +3234,7 @@ static void handle_post_request(request_t *r, int header_end)
 		r->in.davailable -= data_bytes_in_req;
 
 		/* only write it out if no more data is expected */
-		if(r->in.davailable == 0)
+		if(r->in.davailable == 0 && !r->zstd)
 		{
 #ifdef USE_ZSTD
 			if(r->zstd)
@@ -3304,7 +3304,7 @@ static void handle_post_request(request_t *r, int header_end)
 				return;
 			}
 		}
-		else if (n == 0)
+		else if (n == 0 && !r->in.cflag)
 		{
 			/* socket close by peer will return 0 */
 			gwarning(r, "handle_post_request socket closed by peer");

--- a/src/bin/gpfdist/regress/data/gpfdist2/one_column.txt
+++ b/src/bin/gpfdist/regress/data/gpfdist2/one_column.txt
@@ -1,0 +1,10 @@
+fadsfasdjfda
+fadsfasdjfda
+fadsfasdjfda
+fadsfasdjfda
+fadsfasdjfda
+fadsfasdjfda
+fadsfasdjfda
+fadsfasdjfda
+fadsfasdjfda
+fadsfasdjfda

--- a/src/bin/gpfdist/regress/input/gpfdist2_compress.source
+++ b/src/bin/gpfdist/regress/input/gpfdist2_compress.source
@@ -383,7 +383,7 @@ select * from gpfdist2_stop;
 DROP EXTERNAL WEB TABLE IF EXISTS gpfdist2_start;
 
 CREATE EXTERNAL WEB TABLE gpfdist2_start (x text)
-execute E'((@bindir@/gpfdist -p 7070 -d @abs_srcdir@/data -m 1200000 --mthread 4 </dev/null >/dev/null 2>&1 &); for i in `seq 1 30`; do curl 127.0.0.1:7070 >/dev/null 2>&1 && break; sleep 1; done; echo "starting...") '
+execute E'((@bindir@/gpfdist -p 7070 -d @abs_srcdir@/data -m 1200000 --multi_thread 4 </dev/null >/dev/null 2>&1 &); for i in `seq 1 30`; do curl 127.0.0.1:7070 >/dev/null 2>&1 && break; sleep 1; done; echo "starting...") '
 on SEGMENT 0
 FORMAT 'text' (delimiter '|');
 

--- a/src/bin/gpfdist/regress/input/gpfdist2_compress.source
+++ b/src/bin/gpfdist/regress/input/gpfdist2_compress.source
@@ -431,7 +431,7 @@ select * from gpfdist2_stop;
 DROP EXTERNAL WEB TABLE IF EXISTS gpfdist2_start;
 
 CREATE EXTERNAL WEB TABLE gpfdist2_start (x text)
-execute E'((@bindir@/gpfdist -p 7070 -d @abs_srcdir@/data --compress -m 1200000 --mthread </dev/null >/dev/null 2>&1 &); for i in `seq 1 30`; do curl 127.0.0.1:7070 >/dev/null 2>&1 && break; sleep 1; done; echo "starting...") '
+execute E'((@bindir@/gpfdist -p 7070 -d @abs_srcdir@/data --compress -m 1200000 --mthread 4 </dev/null >/dev/null 2>&1 &); for i in `seq 1 30`; do curl 127.0.0.1:7070 >/dev/null 2>&1 && break; sleep 1; done; echo "starting...") '
 on SEGMENT 0
 FORMAT 'text' (delimiter '|');
 

--- a/src/bin/gpfdist/regress/input/gpfdist2_compress.source
+++ b/src/bin/gpfdist/regress/input/gpfdist2_compress.source
@@ -375,63 +375,15 @@ SELECT count(*) FROM ext_crlf_with_lf_column;
 DROP EXTERNAL TABLE ext_crlf_with_lf_column;
 
 -- start_ignore
-select * from gpfdist2_start;
--- end_ignore
-
-
---test multi-thread transmission start
-DROP EXTERNAL WEB TABLE IF EXISTS gpfdist2_start;
-
-CREATE EXTERNAL WEB TABLE gpfdist2_start (x text)
-execute E'((@bindir@/gpfdist -p 7070 -d @abs_srcdir@/data --mthread </dev/null >/dev/null 2>&1 &); for i in `seq 1 30`; do curl 127.0.0.1:7070 >/dev/null 2>&1 && break; sleep 1; done; echo "starting...") '
-on SEGMENT 0
-FORMAT 'text' (delimiter '|');
-
--- start_ignore
-select * from gpfdist2_start;
--- end_ignore
-
--- test 2 use a bigger file.
-
-CREATE EXTERNAL TABLE ext_lineitem (
-                L_ORDERKEY INT8,
-                L_PARTKEY INTEGER,
-                L_SUPPKEY INTEGER,
-                L_LINENUMBER integer,
-                L_QUANTITY decimal,
-                L_EXTENDEDPRICE decimal,
-                L_DISCOUNT decimal,
-                L_TAX decimal,
-                L_RETURNFLAG CHAR(1),
-                L_LINESTATUS CHAR(1),
-                L_SHIPDATE date,
-                L_COMMITDATE date,
-                L_RECEIPTDATE date,
-                L_SHIPINSTRUCT CHAR(25),
-                L_SHIPMODE CHAR(10),
-                L_COMMENT VARCHAR(44)
-                )
-LOCATION
-(
-        'gpfdist://@hostname@:7070/gpfdist2/lineitem.tbl.long'
-)
-FORMAT 'text'
-(
-        DELIMITER AS '|'
-)
-;
-SELECT count(*) FROM ext_lineitem;
-DROP EXTERNAL TABLE ext_lineitem;
-
--- start_ignore
 select * from gpfdist2_stop;
 -- end_ignore
+
 
 --test multi-thread compression and transmission with bigger buffer start
 DROP EXTERNAL WEB TABLE IF EXISTS gpfdist2_start;
 
 CREATE EXTERNAL WEB TABLE gpfdist2_start (x text)
-execute E'((@bindir@/gpfdist -p 7070 -d @abs_srcdir@/data --compress -m 1200000 --mthread 4 </dev/null >/dev/null 2>&1 &); for i in `seq 1 30`; do curl 127.0.0.1:7070 >/dev/null 2>&1 && break; sleep 1; done; echo "starting...") '
+execute E'((@bindir@/gpfdist -p 7070 -d @abs_srcdir@/data -m 1200000 --mthread 4 </dev/null >/dev/null 2>&1 &); for i in `seq 1 30`; do curl 127.0.0.1:7070 >/dev/null 2>&1 && break; sleep 1; done; echo "starting...") '
 on SEGMENT 0
 FORMAT 'text' (delimiter '|');
 

--- a/src/bin/gpfdist/regress/input/gpfdist2_compress.source
+++ b/src/bin/gpfdist/regress/input/gpfdist2_compress.source
@@ -215,6 +215,7 @@ SELECT count(*) FROM ext_lineitem;
 DROP EXTERNAL TABLE ext_lineitem_w;
 DROP EXTERNAL TABLE ext_lineitem;
 
+
 -- test 3 line too long with defaults
 
 CREATE EXTERNAL TABLE ext_test (
@@ -372,3 +373,135 @@ DROP EXTERNAL TABLE ext_test;
 CREATE EXTERNAL TABLE ext_crlf_with_lf_column(c1 int, c2 text) LOCATION ('gpfdist://@hostname@:7070/gpfdist2/crlf_with_lf_column.csv') FORMAT 'csv' (NEWLINE 'CRLF');
 SELECT count(*) FROM ext_crlf_with_lf_column;
 DROP EXTERNAL TABLE ext_crlf_with_lf_column;
+
+-- start_ignore
+select * from gpfdist2_start;
+-- end_ignore
+
+
+--test multi-thread transmission start
+DROP EXTERNAL WEB TABLE IF EXISTS gpfdist2_start;
+
+CREATE EXTERNAL WEB TABLE gpfdist2_start (x text)
+execute E'((@bindir@/gpfdist -p 7070 -d @abs_srcdir@/data --mthread </dev/null >/dev/null 2>&1 &); for i in `seq 1 30`; do curl 127.0.0.1:7070 >/dev/null 2>&1 && break; sleep 1; done; echo "starting...") '
+on SEGMENT 0
+FORMAT 'text' (delimiter '|');
+
+-- start_ignore
+select * from gpfdist2_start;
+-- end_ignore
+
+-- test 2 use a bigger file.
+
+CREATE EXTERNAL TABLE ext_lineitem (
+                L_ORDERKEY INT8,
+                L_PARTKEY INTEGER,
+                L_SUPPKEY INTEGER,
+                L_LINENUMBER integer,
+                L_QUANTITY decimal,
+                L_EXTENDEDPRICE decimal,
+                L_DISCOUNT decimal,
+                L_TAX decimal,
+                L_RETURNFLAG CHAR(1),
+                L_LINESTATUS CHAR(1),
+                L_SHIPDATE date,
+                L_COMMITDATE date,
+                L_RECEIPTDATE date,
+                L_SHIPINSTRUCT CHAR(25),
+                L_SHIPMODE CHAR(10),
+                L_COMMENT VARCHAR(44)
+                )
+LOCATION
+(
+        'gpfdist://@hostname@:7070/gpfdist2/lineitem.tbl.long'
+)
+FORMAT 'text'
+(
+        DELIMITER AS '|'
+)
+;
+SELECT count(*) FROM ext_lineitem;
+DROP EXTERNAL TABLE ext_lineitem;
+
+-- start_ignore
+select * from gpfdist2_stop;
+-- end_ignore
+
+--test multi-thread compression and transmission with bigger buffer start
+DROP EXTERNAL WEB TABLE IF EXISTS gpfdist2_start;
+
+CREATE EXTERNAL WEB TABLE gpfdist2_start (x text)
+execute E'((@bindir@/gpfdist -p 7070 -d @abs_srcdir@/data --compress -m 1200000 --mthread </dev/null >/dev/null 2>&1 &); for i in `seq 1 30`; do curl 127.0.0.1:7070 >/dev/null 2>&1 && break; sleep 1; done; echo "starting...") '
+on SEGMENT 0
+FORMAT 'text' (delimiter '|');
+
+-- start_ignore
+select * from gpfdist2_start;
+-- end_ignore
+
+-- test 1 using a little file
+
+CREATE EXTERNAL TABLE ext_lineitem (
+                L_ORDERKEY INT8,
+                L_PARTKEY INTEGER,
+                L_SUPPKEY INTEGER,
+                L_LINENUMBER integer,
+                L_QUANTITY decimal,
+                L_EXTENDEDPRICE decimal,
+                L_DISCOUNT decimal,
+                L_TAX decimal,
+                L_RETURNFLAG CHAR(1),
+                L_LINESTATUS CHAR(1),
+                L_SHIPDATE date,
+                L_COMMITDATE date,
+                L_RECEIPTDATE date,
+                L_SHIPINSTRUCT CHAR(25),
+                L_SHIPMODE CHAR(10),
+                L_COMMENT VARCHAR(44)
+                )
+LOCATION
+(
+      'gpfdist://@hostname@:7070/gpfdist2/lineitem.tbl'
+)
+FORMAT 'text'
+(
+        DELIMITER AS '|'
+)
+;
+SELECT count(*) FROM ext_lineitem;
+DROP EXTERNAL TABLE ext_lineitem;
+-- test 2 use a bigger file.
+
+CREATE EXTERNAL TABLE ext_lineitem (
+                L_ORDERKEY INT8,
+                L_PARTKEY INTEGER,
+                L_SUPPKEY INTEGER,
+                L_LINENUMBER integer,
+                L_QUANTITY decimal,
+                L_EXTENDEDPRICE decimal,
+                L_DISCOUNT decimal,
+                L_TAX decimal,
+                L_RETURNFLAG CHAR(1),
+                L_LINESTATUS CHAR(1),
+                L_SHIPDATE date,
+                L_COMMITDATE date,
+                L_RECEIPTDATE date,
+                L_SHIPINSTRUCT CHAR(25),
+                L_SHIPMODE CHAR(10),
+                L_COMMENT VARCHAR(44)
+                )
+LOCATION
+(
+        'gpfdist://@hostname@:7070/gpfdist2/lineitem.tbl.long'
+)
+FORMAT 'text'
+(
+        DELIMITER AS '|'
+)
+;
+SELECT count(*) FROM ext_lineitem;
+DROP EXTERNAL TABLE ext_lineitem;
+
+-- start_ignore
+select * from gpfdist2_stop;
+-- end_ignore

--- a/src/bin/gpfdist/regress/input/gpfdist2_compress.source
+++ b/src/bin/gpfdist/regress/input/gpfdist2_compress.source
@@ -470,7 +470,24 @@ FORMAT 'text'
 ;
 SELECT count(*) FROM ext_lineitem;
 DROP EXTERNAL TABLE ext_lineitem;
--- test 2 use a bigger file.
+-- test 2 use false data.
+
+CREATE EXTERNAL TABLE ext_simple (
+                dat CHAR(25),
+                fun int
+                )
+LOCATION
+(
+      'gpfdist://@hostname@:7070/gpfdist2/one_column.txt'
+)
+FORMAT 'text'
+(
+        DELIMITER AS '|'
+)
+;
+SELECT count(*) FROM ext_simple;
+DROP EXTERNAL TABLE ext_simple;
+-- test 3 use a bigger file.
 
 CREATE EXTERNAL TABLE ext_lineitem (
                 L_ORDERKEY INT8,

--- a/src/bin/gpfdist/regress/output/gpfdist2_compress.source
+++ b/src/bin/gpfdist/regress/output/gpfdist2_compress.source
@@ -423,3 +423,160 @@ SELECT count(*) FROM ext_crlf_with_lf_column;
 (1 row)
 
 DROP EXTERNAL TABLE ext_crlf_with_lf_column;
+-- start_ignore
+select * from gpfdist2_stop;
+      x      
+-------------
+ stopping...
+(1 row)
+
+-- end_ignore
+--test multi-thread transmission start
+DROP EXTERNAL WEB TABLE IF EXISTS gpfdist2_start;
+CREATE EXTERNAL WEB TABLE gpfdist2_start (x text)
+execute E'((@bindir@/gpfdist -p 7070 -d @abs_srcdir@/data --mthread </dev/null >/dev/null 2>&1 &); for i in `seq 1 30`; do curl 127.0.0.1:7070 >/dev/null 2>&1 && break; sleep 1; done; echo "starting...") '
+on SEGMENT 0
+FORMAT 'text' (delimiter '|');
+-- start_ignore
+select * from gpfdist2_start;
+      x      
+-------------
+ starting...
+(1 row)
+
+-- end_ignore
+-- test 2 use a bigger file.
+CREATE EXTERNAL TABLE ext_lineitem (
+                L_ORDERKEY INT8,
+                L_PARTKEY INTEGER,
+                L_SUPPKEY INTEGER,
+                L_LINENUMBER integer,
+                L_QUANTITY decimal,
+                L_EXTENDEDPRICE decimal,
+                L_DISCOUNT decimal,
+                L_TAX decimal,
+                L_RETURNFLAG CHAR(1),
+                L_LINESTATUS CHAR(1),
+                L_SHIPDATE date,
+                L_COMMITDATE date,
+                L_RECEIPTDATE date,
+                L_SHIPINSTRUCT CHAR(25),
+                L_SHIPMODE CHAR(10),
+                L_COMMENT VARCHAR(44)
+                )
+LOCATION
+(
+        'gpfdist://@hostname@:7070/gpfdist2/lineitem.tbl.long'
+)
+FORMAT 'text'
+(
+        DELIMITER AS '|'
+)
+;
+SELECT count(*) FROM ext_lineitem;
+ count  
+--------
+ 100000
+(1 row)
+
+DROP EXTERNAL TABLE ext_lineitem;
+-- start_ignore
+select * from gpfdist2_stop;
+      x      
+-------------
+ stopping...
+(1 row)
+
+-- end_ignore
+--test multi-thread compression and transmission with bigger buffer start
+DROP EXTERNAL WEB TABLE IF EXISTS gpfdist2_start;
+CREATE EXTERNAL WEB TABLE gpfdist2_start (x text)
+execute E'((@bindir@/gpfdist -p 7070 -d @abs_srcdir@/data --compress -m 1200000 --mthread </dev/null >/dev/null 2>&1 &); for i in `seq 1 30`; do curl 127.0.0.1:7070 >/dev/null 2>&1 && break; sleep 1; done; echo "starting...") '
+on SEGMENT 0
+FORMAT 'text' (delimiter '|');
+-- start_ignore
+select * from gpfdist2_start;
+      x      
+-------------
+ starting...
+(1 row)
+
+-- end_ignore
+-- test 1 using a little file
+CREATE EXTERNAL TABLE ext_lineitem (
+                L_ORDERKEY INT8,
+                L_PARTKEY INTEGER,
+                L_SUPPKEY INTEGER,
+                L_LINENUMBER integer,
+                L_QUANTITY decimal,
+                L_EXTENDEDPRICE decimal,
+                L_DISCOUNT decimal,
+                L_TAX decimal,
+                L_RETURNFLAG CHAR(1),
+                L_LINESTATUS CHAR(1),
+                L_SHIPDATE date,
+                L_COMMITDATE date,
+                L_RECEIPTDATE date,
+                L_SHIPINSTRUCT CHAR(25),
+                L_SHIPMODE CHAR(10),
+                L_COMMENT VARCHAR(44)
+                )
+LOCATION
+(
+      'gpfdist://@hostname@:7070/gpfdist2/lineitem.tbl'
+)
+FORMAT 'text'
+(
+        DELIMITER AS '|'
+)
+;
+SELECT count(*) FROM ext_lineitem;
+ count 
+-------
+   256
+(1 row)
+
+DROP EXTERNAL TABLE ext_lineitem;
+-- test 2 use a bigger file.
+CREATE EXTERNAL TABLE ext_lineitem (
+                L_ORDERKEY INT8,
+                L_PARTKEY INTEGER,
+                L_SUPPKEY INTEGER,
+                L_LINENUMBER integer,
+                L_QUANTITY decimal,
+                L_EXTENDEDPRICE decimal,
+                L_DISCOUNT decimal,
+                L_TAX decimal,
+                L_RETURNFLAG CHAR(1),
+                L_LINESTATUS CHAR(1),
+                L_SHIPDATE date,
+                L_COMMITDATE date,
+                L_RECEIPTDATE date,
+                L_SHIPINSTRUCT CHAR(25),
+                L_SHIPMODE CHAR(10),
+                L_COMMENT VARCHAR(44)
+                )
+LOCATION
+(
+        'gpfdist://@hostname@:7070/gpfdist2/lineitem.tbl.long'
+)
+FORMAT 'text'
+(
+        DELIMITER AS '|'
+)
+;
+SELECT count(*) FROM ext_lineitem;
+ count  
+--------
+ 100000
+(1 row)
+
+DROP EXTERNAL TABLE ext_lineitem;
+-- start_ignore
+select * from gpfdist2_stop;
+      x      
+-------------
+ stopping...
+(1 row)
+
+-- end_ignore

--- a/src/bin/gpfdist/regress/output/gpfdist2_compress.source
+++ b/src/bin/gpfdist/regress/output/gpfdist2_compress.source
@@ -434,7 +434,7 @@ select * from gpfdist2_stop;
 --test multi-thread compression and transmission with bigger buffer start
 DROP EXTERNAL WEB TABLE IF EXISTS gpfdist2_start;
 CREATE EXTERNAL WEB TABLE gpfdist2_start (x text)
-execute E'((@bindir@/gpfdist -p 7070 -d @abs_srcdir@/data -m 1200000 --mthread 4 </dev/null >/dev/null 2>&1 &); for i in `seq 1 30`; do curl 127.0.0.1:7070 >/dev/null 2>&1 && break; sleep 1; done; echo "starting...") '
+execute E'((@bindir@/gpfdist -p 7070 -d @abs_srcdir@/data -m 1200000 --multi_thread 4 </dev/null >/dev/null 2>&1 &); for i in `seq 1 30`; do curl 127.0.0.1:7070 >/dev/null 2>&1 && break; sleep 1; done; echo "starting...") '
 on SEGMENT 0
 FORMAT 'text' (delimiter '|');
 -- start_ignore

--- a/src/bin/gpfdist/regress/output/gpfdist2_compress.source
+++ b/src/bin/gpfdist/regress/output/gpfdist2_compress.source
@@ -537,7 +537,25 @@ SELECT count(*) FROM ext_lineitem;
 (1 row)
 
 DROP EXTERNAL TABLE ext_lineitem;
--- test 2 use a bigger file.
+-- test 2 use false data.
+CREATE EXTERNAL TABLE ext_simple (
+                dat CHAR(25),
+                fun int
+                )
+LOCATION
+(
+      'gpfdist://@hostname@:7070/gpfdist2/one_column.txt'
+)
+FORMAT 'text'
+(
+        DELIMITER AS '|'
+)
+;
+SELECT count(*) FROM ext_simple;
+ERROR:  missing data for column "fun"  (seg1 slice1 127.0.0.1:7001 pid=10705)
+CONTEXT:  External table ext_simple, line 1 of gpfdist://localhost.localdomain:7070/gpfdist2/one_column.txt: "fadsfasdjfda"
+DROP EXTERNAL TABLE ext_simple;
+-- test 3 use a bigger file.
 CREATE EXTERNAL TABLE ext_lineitem (
                 L_ORDERKEY INT8,
                 L_PARTKEY INTEGER,

--- a/src/bin/gpfdist/regress/output/gpfdist2_compress.source
+++ b/src/bin/gpfdist/regress/output/gpfdist2_compress.source
@@ -431,67 +431,10 @@ select * from gpfdist2_stop;
 (1 row)
 
 -- end_ignore
---test multi-thread transmission start
-DROP EXTERNAL WEB TABLE IF EXISTS gpfdist2_start;
-CREATE EXTERNAL WEB TABLE gpfdist2_start (x text)
-execute E'((@bindir@/gpfdist -p 7070 -d @abs_srcdir@/data --mthread </dev/null >/dev/null 2>&1 &); for i in `seq 1 30`; do curl 127.0.0.1:7070 >/dev/null 2>&1 && break; sleep 1; done; echo "starting...") '
-on SEGMENT 0
-FORMAT 'text' (delimiter '|');
--- start_ignore
-select * from gpfdist2_start;
-      x      
--------------
- starting...
-(1 row)
-
--- end_ignore
--- test 2 use a bigger file.
-CREATE EXTERNAL TABLE ext_lineitem (
-                L_ORDERKEY INT8,
-                L_PARTKEY INTEGER,
-                L_SUPPKEY INTEGER,
-                L_LINENUMBER integer,
-                L_QUANTITY decimal,
-                L_EXTENDEDPRICE decimal,
-                L_DISCOUNT decimal,
-                L_TAX decimal,
-                L_RETURNFLAG CHAR(1),
-                L_LINESTATUS CHAR(1),
-                L_SHIPDATE date,
-                L_COMMITDATE date,
-                L_RECEIPTDATE date,
-                L_SHIPINSTRUCT CHAR(25),
-                L_SHIPMODE CHAR(10),
-                L_COMMENT VARCHAR(44)
-                )
-LOCATION
-(
-        'gpfdist://@hostname@:7070/gpfdist2/lineitem.tbl.long'
-)
-FORMAT 'text'
-(
-        DELIMITER AS '|'
-)
-;
-SELECT count(*) FROM ext_lineitem;
- count  
---------
- 100000
-(1 row)
-
-DROP EXTERNAL TABLE ext_lineitem;
--- start_ignore
-select * from gpfdist2_stop;
-      x      
--------------
- stopping...
-(1 row)
-
--- end_ignore
 --test multi-thread compression and transmission with bigger buffer start
 DROP EXTERNAL WEB TABLE IF EXISTS gpfdist2_start;
 CREATE EXTERNAL WEB TABLE gpfdist2_start (x text)
-execute E'((@bindir@/gpfdist -p 7070 -d @abs_srcdir@/data --compress -m 1200000 --mthread 4 </dev/null >/dev/null 2>&1 &); for i in `seq 1 30`; do curl 127.0.0.1:7070 >/dev/null 2>&1 && break; sleep 1; done; echo "starting...") '
+execute E'((@bindir@/gpfdist -p 7070 -d @abs_srcdir@/data -m 1200000 --mthread 4 </dev/null >/dev/null 2>&1 &); for i in `seq 1 30`; do curl 127.0.0.1:7070 >/dev/null 2>&1 && break; sleep 1; done; echo "starting...") '
 on SEGMENT 0
 FORMAT 'text' (delimiter '|');
 -- start_ignore

--- a/src/bin/gpfdist/regress/output/gpfdist2_compress.source
+++ b/src/bin/gpfdist/regress/output/gpfdist2_compress.source
@@ -491,7 +491,7 @@ select * from gpfdist2_stop;
 --test multi-thread compression and transmission with bigger buffer start
 DROP EXTERNAL WEB TABLE IF EXISTS gpfdist2_start;
 CREATE EXTERNAL WEB TABLE gpfdist2_start (x text)
-execute E'((@bindir@/gpfdist -p 7070 -d @abs_srcdir@/data --compress -m 1200000 --mthread </dev/null >/dev/null 2>&1 &); for i in `seq 1 30`; do curl 127.0.0.1:7070 >/dev/null 2>&1 && break; sleep 1; done; echo "starting...") '
+execute E'((@bindir@/gpfdist -p 7070 -d @abs_srcdir@/data --compress -m 1200000 --mthread 4 </dev/null >/dev/null 2>&1 &); for i in `seq 1 30`; do curl 127.0.0.1:7070 >/dev/null 2>&1 && break; sleep 1; done; echo "starting...") '
 on SEGMENT 0
 FORMAT 'text' (delimiter '|');
 -- start_ignore


### PR DESCRIPTION
Compression is very useful for data transmission with low bandwidth and high efficiency. But compression is a computationally intensive task and may increase the cost of time in the compression stage. To improve the efficiency of data transmission with compression, multi-thread data compression and transmission are introduced in this PR.

The feature makes each segment served by a single thread. In the main thread, requests are read and further parsed into specific data structures. The data is read into a buffer, then a sub-thread is created to compress data and send the compressed data.

To avoid conflict between threads, each request can be only served by one sub-thread. What's more, all public resources are accessed by a main thread to avoid waiting caused by thread synchronization. To reduce the extra cost incurred by thread switch, we limit the max number of threads according to the number of CPU cores. 

After the benchmark test in a local development environment, we proved two promotions:

1.  gpfdist saves about 60%~70% bandwidth occupation when compression is open.
2. multi-thread compression has more efficient transmission.

If you want multi-thread transmission with compression, both flag '--compress'  and '--multi_thread' is required. To gain more efficiency, we recommend setting the max-length flag (-m) to be 1M.

Co-authored by: @water32 
