### PR TITLE
dsnap: Remove dead function

### DIFF
--- a/src/backend/utils/time/snapmgr.c
+++ b/src/backend/utils/time/snapmgr.c
@@ -2595,16 +2595,3 @@ XidInMVCCSnapshot_Local(TransactionId xid, Snapshot snapshot)
 
 	return false;
 }
-
-DistributedSnapshotWithLocalMapping *
-GetCurrentDistributedSnapshotWithLocalMapping()
-{
-	if (!FirstSnapshotSet)
-		return NULL;
-
-	Assert(CurrentSnapshot);
-	if (CurrentSnapshot->haveDistribSnapshot)
-		return &CurrentSnapshot->distribSnapshotWithLocalMapping;
-
-	return NULL;
-}

--- a/src/include/utils/snapmgr.h
+++ b/src/include/utils/snapmgr.h
@@ -126,7 +126,6 @@ extern void AtSubAbort_Snapshot(int level);
 extern void AtEOXact_Snapshot(bool isCommit, bool resetXmin);
 
 extern void LogDistributedSnapshotInfo(Snapshot snapshot, const char *prefix);
-extern DistributedSnapshotWithLocalMapping *GetCurrentDistributedSnapshotWithLocalMapping(void);
 
 extern void ImportSnapshot(const char *idstr);
 extern bool XactHasExportedSnapshots(void);


### PR DESCRIPTION
GetCurrentDistributedSnapshotWithLocalMapping() has been dead since b3f300b9457.
