### PR TITLE
Fix autovacuum to drop leftover temporary tables

### DIFF
--- a/src/backend/storage/ipc/procarray.c
+++ b/src/backend/storage/ipc/procarray.c
@@ -4125,6 +4125,32 @@ FindProcByGpSessionId(long gp_session_id)
 	return NULL;
 }
 
+/*
+ * Get a list of session IDs that belong to each running process.
+ *
+ * Note that for quick grab-and-go we do not validate or deduplicate the result
+ * here (e.g. the invalid session ID "-1" could appear multiple times).
+ */
+List *
+GetRunningProcSessionIds(void)
+{
+	ProcArrayStruct *arrayP = procArray;
+	int			index;
+	List 			*list = NIL;
+
+	LWLockAcquire(ProcArrayLock, LW_SHARED);
+
+	for (index = 0; index < arrayP->numProcs; index++)
+	{
+		PGPROC	   *proc = &allProcs[arrayP->pgprocnos[index]];
+			
+		list = lappend_oid(list, proc->mppSessionId);
+	}
+		
+	LWLockRelease(ProcArrayLock);
+	return list;
+}
+
 /* ----------------------------------------------
  *		KnownAssignedTransactions sub-module
  * ----------------------------------------------

--- a/src/include/catalog/namespace.h
+++ b/src/include/catalog/namespace.h
@@ -155,6 +155,7 @@ extern bool isTempOrTempToastNamespace(Oid namespaceId);
 extern bool isAnyTempNamespace(Oid namespaceId);
 extern bool isOtherTempNamespace(Oid namespaceId);
 extern TempNamespaceStatus checkTempNamespaceStatus(Oid namespaceId);
+extern bool isTempNamespaceMustBeIdle(Oid namespaceId, HTAB *aliveSessions);
 extern bool isTempNamespaceInUse(Oid namespaceId);
 extern int	GetTempNamespaceBackendId(Oid namespaceId);
 extern Oid	GetTempToastNamespace(void);

--- a/src/include/storage/procarray.h
+++ b/src/include/storage/procarray.h
@@ -131,6 +131,7 @@ extern void XidCacheRemoveRunningXids(TransactionId xid,
 									  TransactionId latestXid);
 						  
 extern PGPROC *FindProcByGpSessionId(long gp_session_id);
+extern List *GetRunningProcSessionIds(void);
 extern void UpdateCommandIdInSnapshot(CommandId curcid);
 
 extern void updateSharedLocalSnapshot(struct DtxContextInfo *dtxContextInfo,

--- a/src/test/isolation2/expected/autovacuum-temp-table.out
+++ b/src/test/isolation2/expected/autovacuum-temp-table.out
@@ -1,0 +1,123 @@
+-- test that autovacuum cleans up orphaned temp table correctly
+
+-- speed up test
+1: alter system set autovacuum_naptime = 5;
+ALTER SYSTEM
+1: alter system set autovacuum_vacuum_threshold = 50;
+ALTER SYSTEM
+1: !\retcode gpstop -u;
+(exited with code 0)
+
+-- session 1 is going to panic on primary segment 0, creating orphaned temp table on all QEs;
+-- session 2 will remain, so the temp table on non-PANIC segment will remain too (until the session resets or exits)
+1: create temp table tt_av1(a int);
+CREATE TABLE
+2: create temp table tt_av2(a int);
+CREATE TABLE
+
+-- temp tables created in utility mode: the one on the PANIC segment will be gone, but not other segments.
+0U: create temp table ttu_av0(a int);
+CREATE TABLE
+1U: create temp table ttu_av1(a int);
+CREATE TABLE
+
+-- PANIC
+1: select gp_inject_fault('exec_mpp_query_start', 'panic', dbid) from gp_segment_configuration where content=0 and role='p';
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+1: select * from tt_av1;
+ERROR:  fault triggered, fault name:'exec_mpp_query_start' fault type:'panic'  (seg0 slice1 127.0.1.1:7002 pid=21899)
+
+0Uq: ... <quitting>
+1q: ... <quitting>
+
+-- make sure the segment restarted,
+-- also served as a third test case.
+1: create temp table tt_av3(a int);
+CREATE TABLE
+
+-- make sure the autovacuum is run at least once,
+-- it might've been run already, which is fine.
+1: select gp_inject_fault('auto_vac_worker_after_report_activity', 'skip', '', '', 'pg_class', 1, 1, 0, dbid) from gp_segment_configuration where content=0 and role='p';
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+1: begin;
+BEGIN
+1: create table bloat_tbl(i int, j int, k int, l int, m int, n int, o int, p int) distributed by (i) partition by range (j) (start (0) end (1000) every (1));
+CREATE TABLE
+1: abort;
+ROLLBACK
+-- wait for autovacuum to hit pg_class, triggering a fault
+1: select gp_wait_until_triggered_fault('auto_vac_worker_after_report_activity', 1, dbid) from gp_segment_configuration where content=0 and role='p';
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+-- clean up fault
+1: select gp_inject_fault('auto_vac_worker_after_report_activity', 'reset', dbid) from gp_segment_configuration where content=0 and role='p';
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+-- the orphaned temp table on all QEs should be cleaned up
+0U: select count(*) from pg_class where relname = 'tt_av1';
+ count 
+-------
+ 0     
+(1 row)
+1U: select count(*) from pg_class where relname = 'tt_av1';
+ count 
+-------
+ 0     
+(1 row)
+
+-- the temp table that is associated with an existing session should be gone on the PANIC'ed
+-- segment (because the QE is killed), but not other segments where QE is still there.
+0U: select count(*) from pg_class where relname = 'tt_av2';
+ count 
+-------
+ 0     
+(1 row)
+1U: select count(*) from pg_class where relname = 'tt_av2';
+ count 
+-------
+ 1     
+(1 row)
+
+-- new temp table created is not affected
+0U: select count(*) from pg_class where relname = 'tt_av3';
+ count 
+-------
+ 1     
+(1 row)
+1U: select count(*) from pg_class where relname = 'tt_av3';
+ count 
+-------
+ 1     
+(1 row)
+
+-- the utility-mode temp table on the PANIC'ed segment will be gone (because the utility connection
+-- was killed), but not other segments where utility connection is still there.
+0U: select count(*) from pg_class where relname = 'ttu_av0';
+ count 
+-------
+ 0     
+(1 row)
+1U: select count(*) from pg_class where relname = 'ttu_av1';
+ count 
+-------
+ 1     
+(1 row)
+
+-- restore settings
+1: alter system reset autovacuum_naptime;
+ALTER SYSTEM
+1: alter system reset autovacuum_vacuum_threshold;
+ALTER SYSTEM
+1: !\retcode gpstop -u;
+(exited with code 0)

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -263,6 +263,7 @@ test: segwalrep/die_commit_pending_replication
 test: enable_autovacuum
 test: idle_gang_cleaner
 # test idle_in_transaction_session_timeout
+test: autovacuum-temp-table
 
 test: copy_progress
 

--- a/src/test/isolation2/sql/autovacuum-temp-table.sql
+++ b/src/test/isolation2/sql/autovacuum-temp-table.sql
@@ -1,0 +1,60 @@
+-- test that autovacuum cleans up orphaned temp table correctly
+
+-- speed up test
+1: alter system set autovacuum_naptime = 5;
+1: alter system set autovacuum_vacuum_threshold = 50;
+1: !\retcode gpstop -u;
+
+-- session 1 is going to panic on primary segment 0, creating orphaned temp table on all QEs;
+-- session 2 will remain, so the temp table on non-PANIC segment will remain too (until the session resets or exits)
+1: create temp table tt_av1(a int);
+2: create temp table tt_av2(a int);
+
+-- temp tables created in utility mode: the one on the PANIC segment will be gone, but not other segments.
+0U: create temp table ttu_av0(a int);
+1U: create temp table ttu_av1(a int);
+
+-- PANIC
+1: select gp_inject_fault('exec_mpp_query_start', 'panic', dbid) from gp_segment_configuration where content=0 and role='p';
+1: select * from tt_av1;
+
+0Uq:
+1q:
+
+-- make sure the segment restarted,
+-- also served as a third test case.
+1: create temp table tt_av3(a int);
+
+-- make sure the autovacuum is run at least once,
+-- it might've been run already, which is fine.
+1: select gp_inject_fault('auto_vac_worker_after_report_activity', 'skip', '', '', 'pg_class', 1, 1, 0, dbid) from gp_segment_configuration where content=0 and role='p';
+1: begin;
+1: create table bloat_tbl(i int, j int, k int, l int, m int, n int, o int, p int) distributed by (i) partition by range (j) (start (0) end (1000) every (1));
+1: abort;
+-- wait for autovacuum to hit pg_class, triggering a fault
+1: select gp_wait_until_triggered_fault('auto_vac_worker_after_report_activity', 1, dbid) from gp_segment_configuration where content=0 and role='p';
+-- clean up fault
+1: select gp_inject_fault('auto_vac_worker_after_report_activity', 'reset', dbid) from gp_segment_configuration where content=0 and role='p';
+
+-- the orphaned temp table on all QEs should be cleaned up
+0U: select count(*) from pg_class where relname = 'tt_av1';
+1U: select count(*) from pg_class where relname = 'tt_av1';
+
+-- the temp table that is associated with an existing session should be gone on the PANIC'ed
+-- segment (because the QE is killed), but not other segments where QE is still there.
+0U: select count(*) from pg_class where relname = 'tt_av2';
+1U: select count(*) from pg_class where relname = 'tt_av2';
+
+-- new temp table created is not affected
+0U: select count(*) from pg_class where relname = 'tt_av3';
+1U: select count(*) from pg_class where relname = 'tt_av3';
+
+-- the utility-mode temp table on the PANIC'ed segment will be gone (because the utility connection
+-- was killed), but not other segments where utility connection is still there.
+0U: select count(*) from pg_class where relname = 'ttu_av0';
+1U: select count(*) from pg_class where relname = 'ttu_av1';
+
+-- restore settings
+1: alter system reset autovacuum_naptime;
+1: alter system reset autovacuum_vacuum_threshold;
+1: !\retcode gpstop -u;


### PR DESCRIPTION
One of important autovacuum duties in PostgreSQL is to process and drop leftover (orphan) temp tables. Usually, PostgreSQL backend handle temp tables when on exit (session end). But in some rare cases, backend may fail this step. For example, in backend is killed with `kill -9 $pid`, its temp tables will persist.

In Greenplum, temp tables uses different naming than in PostgreSQL, except tables created by UTILITY roles. So, proposed changes is to fix isTempNamespaceInUse to check if given namespace may be used by either some backend  (utility mode case) or belong to some session (dispatch case).

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [x] Document changes
- [x] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [x] Review a PR in return to support the community
