### PR TITLE
fix create index does not pass permission check for schema on QE, if the owner of s.t is not current user

### DIFF
--- a/src/test/regress/expected/gp_index.out
+++ b/src/test/regress/expected/gp_index.out
@@ -126,3 +126,32 @@ Indexes:
 Distributed by: (k)
 
 DROP TABLE tbl_create_index;
+-- before dispatch stmt to QEs, switching user to login user,
+-- so that the connection to QEs use the same user as the connection to QD.
+-- pass the permission check of schema on QEs.
+CREATE ROLE regress_minimal;
+NOTICE:  resource queue required -- using default resource queue "pg_default"
+CREATE SCHEMA s;
+create table s.t(tc1 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'tc1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+alter table s.t owner to regress_minimal;
+create index idx on s.t(tc1);
+--partition table
+create table s.part_table(a int, b varchar(40), c timestamp)
+partition by range (a) (start (1) end (1001) every (200));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "part_table_1_prt_1" for table "part_table"
+NOTICE:  CREATE TABLE will create partition "part_table_1_prt_2" for table "part_table"
+NOTICE:  CREATE TABLE will create partition "part_table_1_prt_3" for table "part_table"
+NOTICE:  CREATE TABLE will create partition "part_table_1_prt_4" for table "part_table"
+NOTICE:  CREATE TABLE will create partition "part_table_1_prt_5" for table "part_table"
+alter table s.part_table owner to regress_minimal;
+create index idx_part1 on s.part_table_1_prt_2(a);
+create index idx_part on s.part_table(a);
+drop schema s cascade;
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to table s.t
+drop cascades to table s.part_table
+drop role regress_minimal;

--- a/src/test/regress/sql/gp_index.sql
+++ b/src/test/regress/sql/gp_index.sql
@@ -62,3 +62,20 @@ ALTER TABLE tbl_create_index ADD CONSTRAINT PKEY PRIMARY KEY(i, k);
 
 DROP TABLE tbl_create_index;
 
+-- before dispatch stmt to QEs, switching user to login user,
+-- so that the connection to QEs use the same user as the connection to QD.
+-- pass the permission check of schema on QEs.
+CREATE ROLE regress_minimal;
+CREATE SCHEMA s;
+create table s.t(tc1 int);
+alter table s.t owner to regress_minimal;
+create index idx on s.t(tc1);
+
+--partition table
+create table s.part_table(a int, b varchar(40), c timestamp)
+partition by range (a) (start (1) end (1001) every (200));
+alter table s.part_table owner to regress_minimal;
+create index idx_part1 on s.part_table_1_prt_2(a);
+create index idx_part on s.part_table(a);
+drop schema s cascade;
+drop role regress_minimal;


### PR DESCRIPTION
The following SQL hits the error "permission denied for schema s" on QE.
CREATE ROLE regress_minimal;
CREATE SCHEMA s;
create table s.t(tc1 int);
alter table s.t owner to regress_minimal;
create index idx on s.t(tc1);

The owner of s is login user, but the owner of s.t is regress_minimal,
when we create index for s.t, we will switch CurrentUserId to regress_minimal,
and we use regress_minimal to establish connection with QE,
regress_minimal does not have the permission of s. 
so check permission failed.

before dispatch stmt to QEs, switching user to login user,
so that the connection to QEs use the same user as the connection to QD.
pass the permission check of schema on QEs.

The above case is ok on main branch, however, failed on 6x_stable branch,
because this is introduced by the commit: [09fde60203d78dc06c16d433a65673919a641fdd](https://github.com/greenplum-db/gpdb/commit/09fde60203d78dc06c16d433a65673919a641fdd) on 6x_stable.
which is corresponding to the commit: 7f098f7b53 on PostgreSQL.