### PR TITLE
[6X] Initialize DLOG's oldestXmin up to the latestCompletedXid+1

### DIFF
--- a/src/backend/access/transam/distributedlog.c
+++ b/src/backend/access/transam/distributedlog.c
@@ -135,10 +135,26 @@ DistributedLog_InitOldestXmin(void)
 		/* Advance to the first XID on the next page */
 		xid = AdvanceTransactionIdToNextPage(oldestXmin);
 
-		/* but don't go past oldestLocalXmin */
+		/*
+		 * But don't go past oldestLocalXmin + 1 which is the most 
+		 * we might've set the oldestXmin before restart (essentially
+		 * it's same as the 'xmax' value in GetSnapshotData()).
+		 *
+		 * Note that, stopping here means that we don't have a page
+		 * for oldestXmin, but we are fine because:
+		 *
+		 * (1) if we later assigned a new xid, that new xid is going
+		 *     to be the same as oldestXmin here. And we are guaranteed 
+		 *     to have created DLOG segment for this new xid.
+		 * (2) before we assigned any new xid, we don't really need to
+		 *     access DLOG for oldestXmin. Even if we call 
+		 *     DistributedLog_AdvanceOldestXmin(), since we don't have
+		 *     any newer xid to advance to, the call would be a no-op.
+		 */
 		if (TransactionIdFollows(xid, latestXid))
 		{
 			oldestXmin = latestXid;
+			TransactionIdAdvance(oldestXmin);
 			break;
 		}
 

--- a/src/test/isolation2/input/distributed_snapshot.source
+++ b/src/test/isolation2/input/distributed_snapshot.source
@@ -1,4 +1,10 @@
+include: helpers/server_helpers.sql;
+
 -- Distributed snapshot tests
+
+create or replace function test_consume_xids(int4) returns void
+as '@abs_srcdir@/../regress/regress.so', 'test_consume_xids'
+language C;
 
 -- Scenario1: Test to validate GetSnapshotData()'s computation of globalXmin using
 -- distributed snapshot. It mainly uses a old read-only transaction to help
@@ -7,93 +13,55 @@
 
 -- Setup
 CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
-CREATE
 CREATE TABLE distributed_snapshot_test1 (a int);
-CREATE
 
 1: BEGIN;
-BEGIN
 1: INSERT INTO distributed_snapshot_test1 values(1);
-INSERT 1
 -- Read transaction which helps to get lower globalXmin for session 3. As this
 -- will have MyProc->xmin set to transaction 1's xid.
 2: BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE;
-BEGIN
 2: SELECT * from distributed_snapshot_test1;
- a 
----
-(0 rows)
 -- Complete transaction 1, so that it no more appears in in-progress transaction
 -- list for following transactions.
 1: COMMIT;
-COMMIT
 
 -- Transaction to bump the latestCompletedXid
 1: INSERT INTO distributed_snapshot_test1 values(1);
-INSERT 1
 
 -- Hold after walking over ProcArray in GetSnpashotData(), right at start of
 -- DistributedLog_AdvanceOldestXmin()
-1: SELECT gp_inject_fault('distributedlog_advance_oldest_xmin', 'suspend', '', 'postgres', '', 1, -1, 5, dbid) from gp_segment_configuration where content = 0 and role = 'p';
- gp_inject_fault 
------------------
- Success:        
-(1 row)
-3&:@db_name postgres: SELECT count(*) > 0 from gp_dist_random('gp_id');  <waiting ...>
-1: SELECT gp_wait_until_triggered_fault('distributedlog_advance_oldest_xmin', 1, dbid) from gp_segment_configuration where content = 0 and role = 'p';
- gp_wait_until_triggered_fault 
--------------------------------
- Success:                      
-(1 row)
+1: SELECT gp_inject_fault('distributedlog_advance_oldest_xmin', 'suspend',
+   '', 'postgres', '', 1, -1, 5, dbid) from gp_segment_configuration
+   where content = 0 and role = 'p';
+3&:@db_name postgres: SELECT count(*) > 0 from gp_dist_random('gp_id');
+1: SELECT gp_wait_until_triggered_fault('distributedlog_advance_oldest_xmin', 1, dbid)
+   from gp_segment_configuration where content = 0 and role = 'p';
 2: COMMIT;
-COMMIT
 
 -- Transaction used to bump the distributed oldestXmin
 1: INSERT INTO distributed_snapshot_test1 values(1);
-INSERT 1
 -- let session 3 now move forward to compute distributed oldest xmin
-1: SELECT gp_inject_fault('distributedlog_advance_oldest_xmin', 'reset', dbid) from gp_segment_configuration where content = 0 and role = 'p';
- gp_inject_fault 
------------------
- Success:        
-(1 row)
-3<:  <... completed>
- ?column? 
-----------
- t        
-(1 row)
+1: SELECT gp_inject_fault('distributedlog_advance_oldest_xmin', 'reset', dbid)
+   from gp_segment_configuration where content = 0 and role = 'p';
+3<:
 
 -- Scenario2: This scenario tests the boundary condition for Xmax in distributed snapshot
 
 -- Setup
 CREATE TABLE distributed_snapshot_test2 (a int);
-CREATE
 
 -- start transaction assigns distributed xid.
 1: BEGIN ISOLATION LEVEL REPEATABLE READ;
-BEGIN
 -- this sets latestCompletedXid
 2: INSERT INTO distributed_snapshot_test2 VALUES(1);
-INSERT 1
 -- here, take distributed snapshot
 1: SELECT 123 AS "establish snapshot";
- establish snapshot 
---------------------
- 123                
-(1 row)
 2: INSERT INTO distributed_snapshot_test2 VALUES(2);
-INSERT 1
 -- expected to see just VALUES(1)
 1: SELECT * FROM distributed_snapshot_test2;
- a 
----
- 1 
-(1 row)
 1: COMMIT;
-COMMIT
 
 DROP TABLE distributed_snapshot_test2;
-DROP
 
 -- Scenario3: Test the one-phase commit transactions don't break repeatable read isolation.
 --
@@ -109,55 +77,21 @@ DROP
 -- protocol. Repeatable read transactions may read (100), (100,100) or
 -- (100,100,300), but not (100, 300).
 CREATE TABLE distributed_snapshot_test3 (a int);
-CREATE
 10: BEGIN ISOLATION LEVEL REPEATABLE READ;
-BEGIN
 20: BEGIN ISOLATION LEVEL REPEATABLE READ;
-BEGIN
 30: BEGIN ISOLATION LEVEL REPEATABLE READ;
-BEGIN
 40: INSERT INTO distributed_snapshot_test3 VALUES(100);
-INSERT 1
 10: SELECT gp_segment_id, * FROM distributed_snapshot_test3 where a = 100;
- gp_segment_id | a   
----------------+-----
- 2             | 100 
-(1 row)
 40: INSERT INTO distributed_snapshot_test3 VALUES(100);
-INSERT 1
 30: SELECT 123 AS "establish snapshot";
- establish snapshot 
---------------------
- 123                
-(1 row)
 40: INSERT INTO distributed_snapshot_test3 VALUES(300);
-INSERT 1
 10: SELECT gp_segment_id, * FROM distributed_snapshot_test3;
- gp_segment_id | a   
----------------+-----
- 2             | 100 
-(1 row)
 20: SELECT gp_segment_id, * FROM distributed_snapshot_test3;
- gp_segment_id | a   
----------------+-----
- 1             | 300 
- 2             | 100 
- 2             | 100 
-(3 rows)
 30: SELECT gp_segment_id, * FROM distributed_snapshot_test3;
- gp_segment_id | a   
----------------+-----
- 2             | 100 
- 2             | 100 
-(2 rows)
 10: COMMIT;
-COMMIT
 20: COMMIT;
-COMMIT
 30: COMMIT;
-COMMIT
 DROP TABLE distributed_snapshot_test3;
-DROP
 
 -- The following test cases are to test that QEs can get
 -- latest distribute snapshot to scan normal tables (not catalog).
@@ -187,317 +121,218 @@ DROP
 
 -- Now this has been fixed, the following cases are tests to check this.
 
--- Case 1: concurrently alter column type (will do rewrite heap)
+-- Case 1: concurrently alter column type (will do rewrite heap) 
 create table t_alter_snapshot_test(a int, b int, c int);
-CREATE
 insert into t_alter_snapshot_test values (1, 1, 1), (1, 1, 1);
-INSERT 2
 
 select * from t_alter_snapshot_test;
- a | b | c 
----+---+---
- 1 | 1 | 1 
- 1 | 1 | 1 
-(2 rows)
 
 1: begin;
-BEGIN
 1: alter table t_alter_snapshot_test alter column b type text;
-ALTER
 
 -- the following statement will hang
-2&: alter table t_alter_snapshot_test alter column c type text;  <waiting ...>
+2&: alter table t_alter_snapshot_test alter column c type text;
 
 1: end;
-END
 -- after 1 commit, 2 can continue, it should use latest distributed
 -- snapshot so that the data will not be lost.
-2<:  <... completed>
-ALTER
+2<:
 
 select * from t_alter_snapshot_test;
- a | b | c 
----+---+---
- 1 | 1 | 1 
- 1 | 1 | 1 
-(2 rows)
 drop table t_alter_snapshot_test;
-DROP
 
 -- Case 2: concurrently split partition
-create table t_alter_snapshot_test(id int, rank int, year int) distributed by (id) partition by range (year) ( start (0) end (20) every (4), default partition extra );
-CREATE
+create table t_alter_snapshot_test(id int, rank int, year int)
+distributed by (id)
+partition by range (year)
+( start (0) end (20) every (4), default partition extra );
 
 insert into t_alter_snapshot_test select i,i,i from generate_series(1, 100)i;
-INSERT 100
 select count(*) from t_alter_snapshot_test;
- count 
--------
- 100   
-(1 row)
 
 1: begin;
-BEGIN
 1: alter table t_alter_snapshot_test alter column rank type text;
-ALTER
 
-2&: alter table t_alter_snapshot_test split partition for (5) at (5)  into (partition pa,  partition pb);  <waiting ...>
+2&: alter table t_alter_snapshot_test split partition for (5) at (5)  into (partition pa,  partition pb);
 
 1: end;
-END
 -- after 1 commit, 2 can go on and it should not lose data
-2<:  <... completed>
-ALTER
+2<:
 
 select count(*) from t_alter_snapshot_test;
- count 
--------
- 100   
-(1 row)
 drop table t_alter_snapshot_test;
-DROP
 
 -- case 3: concurrently validate check
 create table t_alter_snapshot_test(a int, b int);
-CREATE
 insert into t_alter_snapshot_test values (1, 1), (2, 2);
-INSERT 2
 alter table t_alter_snapshot_test ADD CONSTRAINT mychk CHECK(a > 20) NOT VALID;
-ALTER
 
 1: begin;
-BEGIN
 1: alter table t_alter_snapshot_test alter column b type text;
-ALTER
 
-2&: alter table t_alter_snapshot_test validate CONSTRAINT mychk;  <waiting ...>
+2&: alter table t_alter_snapshot_test validate CONSTRAINT mychk;
 
 1: end;
-END
 -- after 1 commit, 2 can go on and it should fail
-2<:  <... completed>
-ERROR:  check constraint "mychk" is violated by some row  (seg0 127.0.1.1:6002 pid=49660)
+2<:
 
 drop table t_alter_snapshot_test;
-DROP
 
 -- case 4: concurrently domain check
 create domain domain_snapshot_test as int;
-CREATE
 create table t_alter_snapshot_test(i domain_snapshot_test, j int, k int);
-CREATE
 insert into t_alter_snapshot_test values(200,1,1);
-INSERT 1
 alter domain domain_snapshot_test ADD CONSTRAINT mychk CHECK(VALUE > 300)  NOT VALID;
-ALTER
 
 1: begin;
-BEGIN
 1: alter table t_alter_snapshot_test alter column k type text;
-ALTER
 
-2&: alter domain domain_snapshot_test validate CONSTRAINT mychk;  <waiting ...>
+2&: alter domain domain_snapshot_test validate CONSTRAINT mychk;
 
 1:end;
-END
 -- after 1 commit, 2 can go on and it should fail
-2<:  <... completed>
-ERROR:  column "i" of table "t_alter_snapshot_test" contains values that violate the new constraint  (seg2 127.0.1.1:6004 pid=49662)
+2<:
 
 drop table t_alter_snapshot_test;
-DROP
 drop domain domain_snapshot_test;
-DROP
 
 -- case 5: alter table expand table
 create table t_alter_snapshot_test(a int, b int);
-CREATE
 set allow_system_table_mods = on;
-SET
 update gp_distribution_policy set numsegments = 2 where localoid = 't_alter_snapshot_test'::regclass::oid;
-UPDATE 1
 insert into t_alter_snapshot_test select i,i from generate_series(1, 10)i;
-INSERT 10
 select gp_segment_id, * from t_alter_snapshot_test;
- gp_segment_id | a  | b  
----------------+----+----
- 0             | 2  | 2  
- 0             | 3  | 3  
- 0             | 4  | 4  
- 0             | 6  | 6  
- 0             | 7  | 7  
- 0             | 8  | 8  
- 0             | 9  | 9  
- 0             | 10 | 10 
- 1             | 1  | 1  
- 1             | 5  | 5  
-(10 rows)
 
 1: begin;
-BEGIN
 1: alter table t_alter_snapshot_test alter column b type text;
-ALTER
 
-2&: alter table t_alter_snapshot_test expand table;  <waiting ...>
+2&: alter table t_alter_snapshot_test expand table;
 
 1: end;
-END
 -- after 1 commit, 2 can go on and data should not be lost
-2<:  <... completed>
-ALTER
+2<:
 
 select gp_segment_id, * from t_alter_snapshot_test;
- gp_segment_id | a  | b  
----------------+----+----
- 1             | 1  | 1  
- 0             | 2  | 2  
- 0             | 3  | 3  
- 0             | 4  | 4  
- 0             | 7  | 7  
- 0             | 8  | 8  
- 2             | 6  | 6  
- 2             | 9  | 9  
- 2             | 10 | 10 
- 2             | 5  | 5  
-(10 rows)
 drop table t_alter_snapshot_test;
-DROP
 
 -- case 6: alter table set distributed by
 create table t_alter_snapshot_test(a int, b int) distributed randomly;
-CREATE
 insert into t_alter_snapshot_test select i,i from generate_series(1, 10)i;
-INSERT 10
 select count(*) from t_alter_snapshot_test;
- count 
--------
- 10    
-(1 row)
 
 1: begin;
-BEGIN
 1: alter table t_alter_snapshot_test alter column b type text;
-ALTER
 
-2&: alter table t_alter_snapshot_test set distributed by (a);  <waiting ...>
+2&: alter table t_alter_snapshot_test set distributed by (a);
 
 1: end;
-END
 -- after 1 commit, 2 can continue and data should not be lost
-2<:  <... completed>
-ALTER
+2<:
 
 select count(*) from t_alter_snapshot_test;
- count 
--------
- 10    
-(1 row)
 drop table t_alter_snapshot_test;
-DROP
 
 -- case 7: DML concurrent with Alter Table
 create table t_alter_snapshot_test(a int, b int);
-CREATE
 
 ---- test for insert
 1: begin;
-BEGIN
 1: insert into t_alter_snapshot_test values (1, 1);
-INSERT 1
-2&: alter table t_alter_snapshot_test alter column b type text;  <waiting ...>
+2&: alter table t_alter_snapshot_test alter column b type text;
 1: end;
-END
 -- 2 can continue, and we should not lose data
-2<:  <... completed>
-ALTER
+2<:
 select * from t_alter_snapshot_test;
- a | b 
----+---
- 1 | 1 
-(1 row)
 
 ---- test for update
 truncate t_alter_snapshot_test;
-TRUNCATE
 insert into t_alter_snapshot_test values (1, 1);
-INSERT 1
 1: begin;
-BEGIN
 1: update t_alter_snapshot_test set b = '3';
-UPDATE 1
-2&: alter table t_alter_snapshot_test alter column b type int using b::int;  <waiting ...>
+2&: alter table t_alter_snapshot_test alter column b type int using b::int;
 1: end;
-END
 -- 2 can continue and we should see the data has been updated
-2<:  <... completed>
-ALTER
+2<:
 select * from t_alter_snapshot_test;
- a | b 
----+---
- 1 | 3 
-(1 row)
 
 ---- test for delete
 truncate t_alter_snapshot_test;
-TRUNCATE
 insert into t_alter_snapshot_test values (1, 1);
-INSERT 1
 1: begin;
-BEGIN
 1: delete from t_alter_snapshot_test;
-DELETE 1
-2&: alter table t_alter_snapshot_test alter column b type text;  <waiting ...>
+2&: alter table t_alter_snapshot_test alter column b type text;
 1: end;
-END
 -- 2 can continue and we should see the data has been deleted
-2<:  <... completed>
-ALTER
+2<:
 select * from t_alter_snapshot_test;
- a | b 
----+---
-(0 rows)
 drop table t_alter_snapshot_test;
-DROP
 
 -- Case 8: Repeatable Read Isolation Level Test
 create table t_alter_snapshot_test(a int, b int);
-CREATE
 insert into t_alter_snapshot_test values (1, 1);
-INSERT 1
 1: begin;
-BEGIN
 1: insert into t_alter_snapshot_test values (1, 1);
-INSERT 1
 
 2: begin isolation level repeatable read;
-BEGIN
 2: select * from  t_alter_snapshot_test;
- a | b 
----+---
- 1 | 1 
-(1 row)
-2&: alter table t_alter_snapshot_test alter column b type text;  <waiting ...>
+2&: alter table t_alter_snapshot_test alter column b type text;
 
 1: end;
-END
 -- 2 can continue and after its alter rewrite the heap
 -- it can see all the data even under repeatable read
-2<:  <... completed>
-ALTER
+2<:
 2: select * from t_alter_snapshot_test;
- a | b 
----+---
- 1 | 1 
- 1 | 1 
-(2 rows)
 2: end;
-END
 
 select * from t_alter_snapshot_test;
- a | b 
----+---
- 1 | 1 
- 1 | 1 
-(2 rows)
 drop table t_alter_snapshot_test;
-DROP
+
+----------------------------------------
+-- Test for fixes
+----------------------------------------
+-- Case 1. Test that when we advanced DLOG's oldestXmin to the
+-- latestCompletedXid + 1, and that it is the first xid of the
+-- next segment, we would truncate all DLOG segments (all txs
+-- have completed and no longer needed). And in that case, we
+-- should still be able to advance properly after restart.
+create table distributed_snapshot_fix1(a int);
+
+-- On a primary, burn xids until the next xid is the first one of a segment,
+-- which has 4096 (ENTRIES_PER_PAGE) * 32 (SLRU_PAGES_PER_SEGMENT) = 131072 xids.
+-- Details about how we consume it:
+-- 1. Using test_consume_xids to consume what's needed - 2;
+-- 2. The current transaction consumes 1 xid;
+-- 3. Use another transaction to consume 1 more. This is to mark the last 
+--      one completed so that after restart we can start from that.
+1U: begin;
+1U: select test_consume_xids((131070 - (cur % 131072))::int) from txid_current() cur;
+1U: end;
+1U: insert into distributed_snapshot_fix1 values(1);
+1Uq:
+1q:
+
+-- Restart server, so that DistributedLogCtl->shared->latest_page_number is
+-- initialized to be the one that the next xid is on. When that happens, and
+-- when we do DistributedLog_AdvanceOldestXmin() again in the next query, we
+-- would successfully truncate the current working segment.
+select pg_ctl(datadir, 'restart') from gp_segment_configuration where role = 'p' and content = 1;
+
+-- Do a SELECT. This assigns distributed snapshot but it won't assign new xid. 
+-- Since we'll advance to the next future xid which is the first xid of the next segment, 
+-- this will get all DLOG segments truncated. 
+1: select * from distributed_snapshot_fix1;
+
+-- Checking the DLOG segments we have right now, which is none. 
+1U: select count(*) from gp_distributed_log;
+
+1Uq:
+1q:
+
+-- Restart server again. Previously DistributedLogShared->oldestXmin is initialized to 
+-- latestCompletedXid.
+select pg_ctl(datadir, 'restart') from gp_segment_configuration where role = 'p' and content = 1;
+
+-- Do a SELECT. Previously this would complain about missing segment file because we've 
+-- truncated the segment that latestCompletedXid is on. Now we don't, because we will
+-- be advancing from latestCompletedXid + 1.
+1: select * from distributed_snapshot_fix1;

--- a/src/test/isolation2/output/distributed_snapshot.source
+++ b/src/test/isolation2/output/distributed_snapshot.source
@@ -1,4 +1,10 @@
+include: helpers/server_helpers.sql;
+CREATE
+
 -- Distributed snapshot tests
+
+create or replace function test_consume_xids(int4) returns void as '@abs_srcdir@/../regress/regress.so', 'test_consume_xids' language C;
+CREATE
 
 -- Scenario1: Test to validate GetSnapshotData()'s computation of globalXmin using
 -- distributed snapshot. It mainly uses a old read-only transaction to help
@@ -7,55 +13,93 @@
 
 -- Setup
 CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+CREATE
 CREATE TABLE distributed_snapshot_test1 (a int);
+CREATE
 
 1: BEGIN;
+BEGIN
 1: INSERT INTO distributed_snapshot_test1 values(1);
+INSERT 1
 -- Read transaction which helps to get lower globalXmin for session 3. As this
 -- will have MyProc->xmin set to transaction 1's xid.
 2: BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE;
+BEGIN
 2: SELECT * from distributed_snapshot_test1;
+ a 
+---
+(0 rows)
 -- Complete transaction 1, so that it no more appears in in-progress transaction
 -- list for following transactions.
 1: COMMIT;
+COMMIT
 
 -- Transaction to bump the latestCompletedXid
 1: INSERT INTO distributed_snapshot_test1 values(1);
+INSERT 1
 
 -- Hold after walking over ProcArray in GetSnpashotData(), right at start of
 -- DistributedLog_AdvanceOldestXmin()
-1: SELECT gp_inject_fault('distributedlog_advance_oldest_xmin', 'suspend',
-   '', 'postgres', '', 1, -1, 5, dbid) from gp_segment_configuration
-   where content = 0 and role = 'p';
-3&:@db_name postgres: SELECT count(*) > 0 from gp_dist_random('gp_id');
-1: SELECT gp_wait_until_triggered_fault('distributedlog_advance_oldest_xmin', 1, dbid)
-   from gp_segment_configuration where content = 0 and role = 'p';
+1: SELECT gp_inject_fault('distributedlog_advance_oldest_xmin', 'suspend', '', 'postgres', '', 1, -1, 5, dbid) from gp_segment_configuration where content = 0 and role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+3&:@db_name postgres: SELECT count(*) > 0 from gp_dist_random('gp_id');  <waiting ...>
+1: SELECT gp_wait_until_triggered_fault('distributedlog_advance_oldest_xmin', 1, dbid) from gp_segment_configuration where content = 0 and role = 'p';
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
 2: COMMIT;
+COMMIT
 
 -- Transaction used to bump the distributed oldestXmin
 1: INSERT INTO distributed_snapshot_test1 values(1);
+INSERT 1
 -- let session 3 now move forward to compute distributed oldest xmin
-1: SELECT gp_inject_fault('distributedlog_advance_oldest_xmin', 'reset', dbid)
-   from gp_segment_configuration where content = 0 and role = 'p';
-3<:
+1: SELECT gp_inject_fault('distributedlog_advance_oldest_xmin', 'reset', dbid) from gp_segment_configuration where content = 0 and role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+3<:  <... completed>
+ ?column? 
+----------
+ t        
+(1 row)
 
 -- Scenario2: This scenario tests the boundary condition for Xmax in distributed snapshot
 
 -- Setup
 CREATE TABLE distributed_snapshot_test2 (a int);
+CREATE
 
 -- start transaction assigns distributed xid.
 1: BEGIN ISOLATION LEVEL REPEATABLE READ;
+BEGIN
 -- this sets latestCompletedXid
 2: INSERT INTO distributed_snapshot_test2 VALUES(1);
+INSERT 1
 -- here, take distributed snapshot
 1: SELECT 123 AS "establish snapshot";
+ establish snapshot 
+--------------------
+ 123                
+(1 row)
 2: INSERT INTO distributed_snapshot_test2 VALUES(2);
+INSERT 1
 -- expected to see just VALUES(1)
 1: SELECT * FROM distributed_snapshot_test2;
+ a 
+---
+ 1 
+(1 row)
 1: COMMIT;
+COMMIT
 
 DROP TABLE distributed_snapshot_test2;
+DROP
 
 -- Scenario3: Test the one-phase commit transactions don't break repeatable read isolation.
 --
@@ -71,21 +115,55 @@ DROP TABLE distributed_snapshot_test2;
 -- protocol. Repeatable read transactions may read (100), (100,100) or
 -- (100,100,300), but not (100, 300).
 CREATE TABLE distributed_snapshot_test3 (a int);
+CREATE
 10: BEGIN ISOLATION LEVEL REPEATABLE READ;
+BEGIN
 20: BEGIN ISOLATION LEVEL REPEATABLE READ;
+BEGIN
 30: BEGIN ISOLATION LEVEL REPEATABLE READ;
+BEGIN
 40: INSERT INTO distributed_snapshot_test3 VALUES(100);
+INSERT 1
 10: SELECT gp_segment_id, * FROM distributed_snapshot_test3 where a = 100;
+ gp_segment_id | a   
+---------------+-----
+ 2             | 100 
+(1 row)
 40: INSERT INTO distributed_snapshot_test3 VALUES(100);
+INSERT 1
 30: SELECT 123 AS "establish snapshot";
+ establish snapshot 
+--------------------
+ 123                
+(1 row)
 40: INSERT INTO distributed_snapshot_test3 VALUES(300);
+INSERT 1
 10: SELECT gp_segment_id, * FROM distributed_snapshot_test3;
+ gp_segment_id | a   
+---------------+-----
+ 2             | 100 
+(1 row)
 20: SELECT gp_segment_id, * FROM distributed_snapshot_test3;
+ gp_segment_id | a   
+---------------+-----
+ 1             | 300 
+ 2             | 100 
+ 2             | 100 
+(3 rows)
 30: SELECT gp_segment_id, * FROM distributed_snapshot_test3;
+ gp_segment_id | a   
+---------------+-----
+ 2             | 100 
+ 2             | 100 
+(2 rows)
 10: COMMIT;
+COMMIT
 20: COMMIT;
+COMMIT
 30: COMMIT;
+COMMIT
 DROP TABLE distributed_snapshot_test3;
+DROP
 
 -- The following test cases are to test that QEs can get
 -- latest distribute snapshot to scan normal tables (not catalog).
@@ -115,168 +193,395 @@ DROP TABLE distributed_snapshot_test3;
 
 -- Now this has been fixed, the following cases are tests to check this.
 
--- Case 1: concurrently alter column type (will do rewrite heap) 
+-- Case 1: concurrently alter column type (will do rewrite heap)
 create table t_alter_snapshot_test(a int, b int, c int);
+CREATE
 insert into t_alter_snapshot_test values (1, 1, 1), (1, 1, 1);
+INSERT 2
 
 select * from t_alter_snapshot_test;
+ a | b | c 
+---+---+---
+ 1 | 1 | 1 
+ 1 | 1 | 1 
+(2 rows)
 
 1: begin;
+BEGIN
 1: alter table t_alter_snapshot_test alter column b type text;
+ALTER
 
 -- the following statement will hang
-2&: alter table t_alter_snapshot_test alter column c type text;
+2&: alter table t_alter_snapshot_test alter column c type text;  <waiting ...>
 
 1: end;
+END
 -- after 1 commit, 2 can continue, it should use latest distributed
 -- snapshot so that the data will not be lost.
-2<:
+2<:  <... completed>
+ALTER
 
 select * from t_alter_snapshot_test;
+ a | b | c 
+---+---+---
+ 1 | 1 | 1 
+ 1 | 1 | 1 
+(2 rows)
 drop table t_alter_snapshot_test;
+DROP
 
 -- Case 2: concurrently split partition
-create table t_alter_snapshot_test(id int, rank int, year int)
-distributed by (id)
-partition by range (year)
-( start (0) end (20) every (4), default partition extra );
+create table t_alter_snapshot_test(id int, rank int, year int) distributed by (id) partition by range (year) ( start (0) end (20) every (4), default partition extra );
+CREATE
 
 insert into t_alter_snapshot_test select i,i,i from generate_series(1, 100)i;
+INSERT 100
 select count(*) from t_alter_snapshot_test;
+ count 
+-------
+ 100   
+(1 row)
 
 1: begin;
+BEGIN
 1: alter table t_alter_snapshot_test alter column rank type text;
+ALTER
 
-2&: alter table t_alter_snapshot_test split partition for (5) at (5)  into (partition pa,  partition pb);
+2&: alter table t_alter_snapshot_test split partition for (5) at (5)  into (partition pa,  partition pb);  <waiting ...>
 
 1: end;
+END
 -- after 1 commit, 2 can go on and it should not lose data
-2<:
+2<:  <... completed>
+ALTER
 
 select count(*) from t_alter_snapshot_test;
+ count 
+-------
+ 100   
+(1 row)
 drop table t_alter_snapshot_test;
+DROP
 
 -- case 3: concurrently validate check
 create table t_alter_snapshot_test(a int, b int);
+CREATE
 insert into t_alter_snapshot_test values (1, 1), (2, 2);
+INSERT 2
 alter table t_alter_snapshot_test ADD CONSTRAINT mychk CHECK(a > 20) NOT VALID;
+ALTER
 
 1: begin;
+BEGIN
 1: alter table t_alter_snapshot_test alter column b type text;
+ALTER
 
-2&: alter table t_alter_snapshot_test validate CONSTRAINT mychk;
+2&: alter table t_alter_snapshot_test validate CONSTRAINT mychk;  <waiting ...>
 
 1: end;
+END
 -- after 1 commit, 2 can go on and it should fail
-2<:
+2<:  <... completed>
+ERROR:  check constraint "mychk" is violated by some row  (seg0 127.0.1.1:6002 pid=49660)
 
 drop table t_alter_snapshot_test;
+DROP
 
 -- case 4: concurrently domain check
 create domain domain_snapshot_test as int;
+CREATE
 create table t_alter_snapshot_test(i domain_snapshot_test, j int, k int);
+CREATE
 insert into t_alter_snapshot_test values(200,1,1);
+INSERT 1
 alter domain domain_snapshot_test ADD CONSTRAINT mychk CHECK(VALUE > 300)  NOT VALID;
+ALTER
 
 1: begin;
+BEGIN
 1: alter table t_alter_snapshot_test alter column k type text;
+ALTER
 
-2&: alter domain domain_snapshot_test validate CONSTRAINT mychk;
+2&: alter domain domain_snapshot_test validate CONSTRAINT mychk;  <waiting ...>
 
 1:end;
+END
 -- after 1 commit, 2 can go on and it should fail
-2<:
+2<:  <... completed>
+ERROR:  column "i" of table "t_alter_snapshot_test" contains values that violate the new constraint  (seg2 127.0.1.1:6004 pid=49662)
 
 drop table t_alter_snapshot_test;
+DROP
 drop domain domain_snapshot_test;
+DROP
 
 -- case 5: alter table expand table
 create table t_alter_snapshot_test(a int, b int);
+CREATE
 set allow_system_table_mods = on;
+SET
 update gp_distribution_policy set numsegments = 2 where localoid = 't_alter_snapshot_test'::regclass::oid;
+UPDATE 1
 insert into t_alter_snapshot_test select i,i from generate_series(1, 10)i;
+INSERT 10
 select gp_segment_id, * from t_alter_snapshot_test;
+ gp_segment_id | a  | b  
+---------------+----+----
+ 0             | 2  | 2  
+ 0             | 3  | 3  
+ 0             | 4  | 4  
+ 0             | 6  | 6  
+ 0             | 7  | 7  
+ 0             | 8  | 8  
+ 0             | 9  | 9  
+ 0             | 10 | 10 
+ 1             | 1  | 1  
+ 1             | 5  | 5  
+(10 rows)
 
 1: begin;
+BEGIN
 1: alter table t_alter_snapshot_test alter column b type text;
+ALTER
 
-2&: alter table t_alter_snapshot_test expand table;
+2&: alter table t_alter_snapshot_test expand table;  <waiting ...>
 
 1: end;
+END
 -- after 1 commit, 2 can go on and data should not be lost
-2<:
+2<:  <... completed>
+ALTER
 
 select gp_segment_id, * from t_alter_snapshot_test;
+ gp_segment_id | a  | b  
+---------------+----+----
+ 1             | 1  | 1  
+ 0             | 2  | 2  
+ 0             | 3  | 3  
+ 0             | 4  | 4  
+ 0             | 7  | 7  
+ 0             | 8  | 8  
+ 2             | 6  | 6  
+ 2             | 9  | 9  
+ 2             | 10 | 10 
+ 2             | 5  | 5  
+(10 rows)
 drop table t_alter_snapshot_test;
+DROP
 
 -- case 6: alter table set distributed by
 create table t_alter_snapshot_test(a int, b int) distributed randomly;
+CREATE
 insert into t_alter_snapshot_test select i,i from generate_series(1, 10)i;
+INSERT 10
 select count(*) from t_alter_snapshot_test;
+ count 
+-------
+ 10    
+(1 row)
 
 1: begin;
+BEGIN
 1: alter table t_alter_snapshot_test alter column b type text;
+ALTER
 
-2&: alter table t_alter_snapshot_test set distributed by (a);
+2&: alter table t_alter_snapshot_test set distributed by (a);  <waiting ...>
 
 1: end;
+END
 -- after 1 commit, 2 can continue and data should not be lost
-2<:
+2<:  <... completed>
+ALTER
 
 select count(*) from t_alter_snapshot_test;
+ count 
+-------
+ 10    
+(1 row)
 drop table t_alter_snapshot_test;
+DROP
 
 -- case 7: DML concurrent with Alter Table
 create table t_alter_snapshot_test(a int, b int);
+CREATE
 
 ---- test for insert
 1: begin;
+BEGIN
 1: insert into t_alter_snapshot_test values (1, 1);
-2&: alter table t_alter_snapshot_test alter column b type text;
+INSERT 1
+2&: alter table t_alter_snapshot_test alter column b type text;  <waiting ...>
 1: end;
+END
 -- 2 can continue, and we should not lose data
-2<:
+2<:  <... completed>
+ALTER
 select * from t_alter_snapshot_test;
+ a | b 
+---+---
+ 1 | 1 
+(1 row)
 
 ---- test for update
 truncate t_alter_snapshot_test;
+TRUNCATE
 insert into t_alter_snapshot_test values (1, 1);
+INSERT 1
 1: begin;
+BEGIN
 1: update t_alter_snapshot_test set b = '3';
-2&: alter table t_alter_snapshot_test alter column b type int using b::int;
+UPDATE 1
+2&: alter table t_alter_snapshot_test alter column b type int using b::int;  <waiting ...>
 1: end;
+END
 -- 2 can continue and we should see the data has been updated
-2<:
+2<:  <... completed>
+ALTER
 select * from t_alter_snapshot_test;
+ a | b 
+---+---
+ 1 | 3 
+(1 row)
 
 ---- test for delete
 truncate t_alter_snapshot_test;
+TRUNCATE
 insert into t_alter_snapshot_test values (1, 1);
+INSERT 1
 1: begin;
+BEGIN
 1: delete from t_alter_snapshot_test;
-2&: alter table t_alter_snapshot_test alter column b type text;
+DELETE 1
+2&: alter table t_alter_snapshot_test alter column b type text;  <waiting ...>
 1: end;
+END
 -- 2 can continue and we should see the data has been deleted
-2<:
+2<:  <... completed>
+ALTER
 select * from t_alter_snapshot_test;
+ a | b 
+---+---
+(0 rows)
 drop table t_alter_snapshot_test;
+DROP
 
 -- Case 8: Repeatable Read Isolation Level Test
 create table t_alter_snapshot_test(a int, b int);
+CREATE
 insert into t_alter_snapshot_test values (1, 1);
+INSERT 1
 1: begin;
+BEGIN
 1: insert into t_alter_snapshot_test values (1, 1);
+INSERT 1
 
 2: begin isolation level repeatable read;
+BEGIN
 2: select * from  t_alter_snapshot_test;
-2&: alter table t_alter_snapshot_test alter column b type text;
+ a | b 
+---+---
+ 1 | 1 
+(1 row)
+2&: alter table t_alter_snapshot_test alter column b type text;  <waiting ...>
 
 1: end;
+END
 -- 2 can continue and after its alter rewrite the heap
 -- it can see all the data even under repeatable read
-2<:
+2<:  <... completed>
+ALTER
 2: select * from t_alter_snapshot_test;
+ a | b 
+---+---
+ 1 | 1 
+ 1 | 1 
+(2 rows)
 2: end;
+END
 
 select * from t_alter_snapshot_test;
+ a | b 
+---+---
+ 1 | 1 
+ 1 | 1 
+(2 rows)
 drop table t_alter_snapshot_test;
+DROP
+
+----------------------------------------
+-- Test for fixes
+----------------------------------------
+-- Case 1. Test that when we advanced DLOG's oldestXmin to the
+-- latestCompletedXid + 1, and that it is the first xid of the
+-- next segment, we would truncate all DLOG segments (all txs
+-- have completed and no longer needed). And in that case, we
+-- should still be able to advance properly after restart.
+create table distributed_snapshot_fix1(a int);
+CREATE
+
+-- On a primary, burn xids until the next xid is the first one of a segment,
+-- which has 4096 (ENTRIES_PER_PAGE) * 32 (SLRU_PAGES_PER_SEGMENT) = 131072 xids.
+-- Details about how we consume it:
+-- 1. Using test_consume_xids to consume what's needed - 2;
+-- 2. The current transaction consumes 1 xid;
+-- 3. Use another transaction to consume 1 more. This is to mark the last
+--      one completed so that after restart we can start from that.
+1U: begin;
+BEGIN
+1U: select test_consume_xids((131070 - (cur % 131072))::int) from txid_current() cur;
+ test_consume_xids 
+-------------------
+                   
+(1 row)
+1U: end;
+END
+1U: insert into distributed_snapshot_fix1 values(1);
+INSERT 1
+1Uq: ... <quitting>
+1q: ... <quitting>
+
+-- Restart server, so that DistributedLogCtl->shared->latest_page_number is
+-- initialized to be the one that the next xid is on. When that happens, and
+-- when we do DistributedLog_AdvanceOldestXmin() again in the next query, we
+-- would successfully truncate the current working segment.
+select pg_ctl(datadir, 'restart') from gp_segment_configuration where role = 'p' and content = 1;
+ pg_ctl 
+--------
+ OK     
+(1 row)
+
+-- Do a SELECT. This assigns distributed snapshot but it won't assign new xid.
+-- Since we'll advance to the next future xid which is the first xid of the next segment,
+-- this will get all DLOG segments truncated.
+1: select * from distributed_snapshot_fix1;
+ a 
+---
+ 1 
+(1 row)
+
+-- Checking the DLOG segments we have right now, which is none.
+1U: select count(*) from gp_distributed_log;
+ count 
+-------
+ 0     
+(1 row)
+
+1Uq: ... <quitting>
+1q: ... <quitting>
+
+-- Restart server again. Previously DistributedLogShared->oldestXmin is initialized to
+-- latestCompletedXid.
+select pg_ctl(datadir, 'restart') from gp_segment_configuration where role = 'p' and content = 1;
+ pg_ctl 
+--------
+ OK     
+(1 row)
+
+-- Do a SELECT. Previously this would complain about missing segment file because we've
+-- truncated the segment that latestCompletedXid is on. Now we don't, because we will
+-- be advancing from latestCompletedXid + 1.
+1: select * from distributed_snapshot_fix1;
+ a 
+---
+ 1 
+(1 row)

--- a/src/test/regress/regress_gp.c
+++ b/src/test/regress/regress_gp.c
@@ -2010,7 +2010,8 @@ test_consume_xids(PG_FUNCTION_ARGS)
 
 	xid = ReadNewTransactionId();
 
-	targetxid = xid + nxids;
+	/* xid is the "next xid" now, so minus one here */
+	targetxid = xid + nxids - 1;
 	while (targetxid < FirstNormalTransactionId)
 		targetxid++;
 


### PR DESCRIPTION
Backport from https://github.com/greenplum-db/gpdb/pull/14650 . No conflict.

PR description
==========

In DistributedLog_AdvanceOldestXmin() we advance DLOG's idea of the oldestXmin to the "globalxmin" value, and also truncate all DLOG segments that only hold xids older than the oldestXmin.

The oldestXmin can be xmax, i.e. the "latestCompletedXid" + 1, when e.g. there's no other concurrent running transactions. However, during postmaster restart we initialize the oldestXmin to be up to only latestCompletedXid. As a result, when we try to advance it again, we could try to access the segment that holds latestCompletedXid, which had been truncated before the restart.

Fixing it now by initializing oldestXmin properly. Add a test for the same. Had to move the test file to isolation/input in order to import the regress.so for the test_consume_xids() function we need.

Also fixed an issue in test_consume_xids where it consumes an extra xid than what's intended.

