### PR TITLE
fts: Refactor logic for mirror retries

### DIFF
--- a/src/include/replication/gp_replication.h
+++ b/src/include/replication/gp_replication.h
@@ -71,7 +71,9 @@ extern void FTSReplicationStatusDrop(const char* app_name);
 extern FTSReplicationStatus *RetrieveFTSReplicationStatus(const char *app_name, bool skip_warn);
 extern void FTSReplicationStatusUpdateForWalState(const char *app_name, WalSndState state);
 extern void FTSReplicationStatusMarkDisconnectForReplication(const char *app_name);
-extern pg_time_t FTSGetReplicationDisconnectTime(const char *app_name);
+extern bool FTSGetReplicationDisconnectInfo(const char *app_name,
+											pg_time_t *last_disconnected_at,
+											uint32 *reconnection_attempts);
 
 extern void GetMirrorStatus(FtsResponse *response, bool *ready_for_syncrep);
 extern void SetSyncStandbysDefined(void);


### PR DESCRIPTION
High level changes:

1. Enhanced logging and comments for various branches.
2. Inline FTSGetReplicationDisconnectTime() into its caller to prevent
the need to interpret it's complicated return value.
3. Rename is_probe_retry_needed() -> is_probe_retry_needed_for_mirror()