### PR TITLE
docs - remove refs to pxf upgrade topics

### DIFF
--- a/gpdb-doc/markdown/install_guide/migrate.html.md
+++ b/gpdb-doc/markdown/install_guide/migrate.html.md
@@ -59,8 +59,6 @@ This topic identifies known issues you may encounter when moving data from Green
 
 Following are some issues that are known to cause errors when restoring a Greenplum 4.3 or 5 backup to Greenplum 6. Keep a list of any changes you make to the Greenplum 4.3 or 5 database to enable migration so that you can fix them in Greenplum 6 after restoring the backup.
 
--   If you have configured PXF in your Greenplum Database 5 installation, review [Migrating PXF from Greenplum 5](../pxf/migrate_5to6.html) to plan for the PXF migration.
--   Greenplum Database version 6 removes support for the `gphdfs` protocol. If you have created external tables that use gphdfs, remove the external table definitions and \(optionally\) recreate them to use Greenplum Platform Extension Framework \(PXF\) before you migrate the data to Greenplum 6. Refer to [Migrating gphdfs External Tables to PXF](../pxf/gphdfs-pxf-migrate.html) in the PXF documentation for the migration procedure.
 -   References to catalog tables or their attributes can cause a restore to fail due to catalog changes from Greenplum 4.3 or 5 to Greenplum 6. Here are some catalog issues to be aware of when migrating to Greenplum 6:
     -   In the `pg_class` system table, the `reltoastidxid` column has been removed.
     -   In the `pg_stat_replication` system table, the `procpid` column is renamed to `pid`.

--- a/gpdb-doc/markdown/install_guide/upgrade_intro.html.md
+++ b/gpdb-doc/markdown/install_guide/upgrade_intro.html.md
@@ -8,8 +8,6 @@ Greenplum Database 6 supports upgrading from a Greenplum 6.x release to a newer 
 
 -   **[Upgrading from an Earlier Greenplum 6 Release](upgrading.html)**  
 The upgrade path supported for this release is Greenplum Database 6.x to a newer Greenplum Database 6.x release.
--   **[PXF Upgrade and Migration](../pxf/pxf_upgrade_migration.html)**  
-
 -   **[Migrating Data from Greenplum 4.3 or 5 to Greenplum 6](migrate.html)**  
 You can migrate data from Greenplum Database 4.3 or 5 to Greenplum 6 using the standard backup and restore procedures, `gpbackup` and `gprestore`, or by using `gpcopy` for VMware Greenplum.
 

--- a/gpdb-doc/markdown/install_guide/upgrading.html.md
+++ b/gpdb-doc/markdown/install_guide/upgrading.html.md
@@ -22,10 +22,6 @@ Before starting the upgrade process, perform the following checks.
 
     **Important:** VMware customers should ontact VMware Support if the `gpcheckcat` utility reports errors but does not generate a SQL script to fix the errors. Information for contacting VMware Support is at [https://tanzu.vmware.com/support](https://tanzu.vmware.com/support).
 
--   If you have configured the Greenplum Platform Extension Framework \(PXF\) in your previous Greenplum Database installation, you must stop the PXF service, and you might need to back up PXF configuration files before upgrading to a new version of Greenplum Database. Refer to [PXF Pre-Upgrade Actions](../pxf/upgrade_pxf_6x.html#pxfpre) for instructions.
-
-    If you have not yet configured PXF, no action is necessary.
-
 -   If you have configured and used the VMware Greenplum Streaming Server \(GPSS\) in your previous VMware Greenplum Database installation, you must stop any running GPSS jobs and service instances before you upgrade to a new version of Greenplum Database. Refer to [GPSS Pre-Upgrade Actions](https://docs.vmware.com/en/VMware-Tanzu-Greenplum-Streaming-Server/1.7/greenplum-streaming-server/GUID-upgrading-gpss.html#step1-gpss-pre-upgrade-actions) for instructions.
 
     If you do not plan to use GPSS, or you have not yet configured GPSS, no action is necessary.
@@ -125,7 +121,6 @@ An upgrade from Greenplum Database 6.x to a newer 6.x release involves stopping 
 
     Also copy any files that are used by the extensions \(such as JAR files, shared object files, and libraries\) from the previous version installation directory to the new version installation directory on the coordinator and segment host systems.
 
-12. If you configured PXF in your previous Greenplum Database installation, you may need to install PXF in your new Greenplum installation, and you may be required to re-initialize or register the PXF service after you upgrade Greenplum Database. Refer to the [Step 2](../pxf/upgrade_pxf_6x.html#pxfup) PXF upgrade procedure for instructions.
 13. For VMware Greenplum Database, if you configured GPSS in your previous installation, you may be required to perform some upgrade actions, and you must re-restart the GPSS service instances and jobs. Refer to [Step 2](https://docs.vmware.com/en/VMware-Tanzu-Greenplum-Streaming-Server/1.7/greenplum-streaming-server/GUID-upgrading-gpss.html#step2-upgrading-gpss) of the GPSS upgrade procedure for instructions.
 
 After upgrading Greenplum Database, ensure that all features work as expected. For example, test that backup and restore perform as expected, and Greenplum Database features such as user-defined functions, and extensions such as MADlib and PostGIS perform as expected.


### PR DESCRIPTION
the pxf upgrade topics that exist in the greenplum docs source are specific to greenplum 5 and greenplum 6.  remove references to these topics from main.

how we treat pxf within a greenplum 6->7 upgrade (when this is supported) is still tbd. i am retaining the actual source files for possible reuse/update.
