### PR TITLE
docs - fix a bad link in pxf migration docs (6x)

### DIFF
--- a/gpdb-doc/markdown/pxf/migrate_5to6.html.md.erb
+++ b/gpdb-doc/markdown/pxf/migrate_5to6.html.md.erb
@@ -110,7 +110,12 @@ After you upgrade to Greenplum Database 6.x, and table definitions and data from
     gpadmin@gp6master$ scp -r gpadmin@<gp5master>:/usr/local/greenplum-pxf /usr/local/
     ```
 
-3. Initialize PXF on each segment host as described in [Initializing PXF](https://docs.vmware.com/en/VMware-Tanzu-Greenplum-Platform-Extension-Framework/6.3/tanzu-greenplum-platform-extension-framework/GUID-init_pxf.html), specifying the `PXF_CONF` directory that you copied in the step above.
+3. Initialize PXF on each segment host, specifying the `PXF_CONF` directory that you copied in the step above. For example:
+
+    ``` shell
+    gpadmin@gp6master$ export JAVA_HOME=<system-java-home>
+    gpadmin@gp6master$ PXF_CONF=/usr/local/greenplum-pxf pxf cluster init
+    ```
 
 5. **If you are migrating PXF from Greenplum Database version 5.23 or earlier** and you have configured any JDBC servers that access Kerberos-secured Hive, you must now set the `hadoop.security.authentication` property in the `jdbc-site.xml` file to explicitly identify use of the Kerberos authentication method. Perform the following for each of these server configs:
 


### PR DESCRIPTION
this PR is to fix a bad link.

the topic about migrating pxf when greenplum is migrated from version 5 to version 6.  the step that i changed deals with a user who has installed pxf version 5 in their new greenplum 6 installation.  the link in question directs the user to a non-existent pxf 6 topic, when it should be directing to a pxf v5 documentation topic (which are now all pdfs).  so i removed the link and just called out the steps.

(in practice, not sure how many customers would actually install pxf 5 in their new greenplum 6 cluster when pxf 6.x is now available, but that is a question for another time.)
