### PR TITLE
Ban reindexdb --concurrently

### DIFF
--- a/src/bin/scripts/reindexdb.c
+++ b/src/bin/scripts/reindexdb.c
@@ -162,6 +162,17 @@ main(int argc, char *argv[])
 	cparams.prompt_password = prompt_password;
 	cparams.override_dbname = NULL;
 
+	if (concurrently)
+	{
+		/*
+		 * GPDB_12_MERGE_FEATURE_NOT_SUPPORTED: When we do support this feature,
+		 * a version guard against GP_VERSION_NUM should be introduced here to
+		 * ensure we don't run it against an unsupported version.
+		 */
+		pg_log_error("reindexing a database concurrently is not supported");
+		exit(1);
+	}
+
 	setup_cancel_handler();
 
 	if (alldb)
@@ -299,14 +310,6 @@ reindex_one_database(const ConnParams *cparams,
 	PGconn	   *conn;
 
 	conn = connectDatabase(cparams, progname, echo, false, false);
-
-	if (concurrently && PQserverVersion(conn) < 120000)
-	{
-		PQfinish(conn);
-		pg_log_error("cannot use the \"%s\" option on server versions older than PostgreSQL %s",
-					 "concurrently", "12");
-		exit(1);
-	}
 
 	initPQExpBuffer(&sql);
 


### PR DESCRIPTION
Concurrent index builds/rebuilds are banned in GPDB, so also extend it
to reindexdb.

Finish the job that was started by e5b0e2531a2 and leave breadcrumb for
version check which will be applicable once we do support it.