### PR TITLE
[6X] Use asynchronous connection in libpqwalreceiver 

### DIFF
--- a/src/backend/replication/walreceiverfuncs.c
+++ b/src/backend/replication/walreceiverfuncs.c
@@ -247,6 +247,7 @@ RequestXLogStreaming(TimeLineID tli, XLogRecPtr recptr, const char *conninfo,
 	volatile WalRcvData *walrcv = WalRcv;
 	bool		launch = false;
 	pg_time_t	now = (pg_time_t) time(NULL);
+	Latch		*latch;
 
 	/*
 	 * We always start at the beginning of the segment. That prevents a broken
@@ -295,12 +296,14 @@ RequestXLogStreaming(TimeLineID tli, XLogRecPtr recptr, const char *conninfo,
 	walrcv->receiveStart = recptr;
 	walrcv->receiveStartTLI = tli;
 
+	latch = walrcv->latch;
+
 	SpinLockRelease(&walrcv->mutex);
 
 	if (launch)
 		SendPostmasterSignal(PMSIGNAL_START_WALRECEIVER);
-	else
-		SetLatch(walrcv->latch);
+	else if (latch)
+		SetLatch(latch);
 }
 
 /*

--- a/src/backend/replication/walreceiverfuncs.c
+++ b/src/backend/replication/walreceiverfuncs.c
@@ -65,7 +65,7 @@ WalRcvShmemInit(void)
 		MemSet(WalRcv, 0, WalRcvShmemSize());
 		WalRcv->walRcvState = WALRCV_STOPPED;
 		SpinLockInit(&WalRcv->mutex);
-		InitSharedLatch(&WalRcv->latch);
+		WalRcv->latch = NULL;
 	}
 }
 
@@ -300,7 +300,7 @@ RequestXLogStreaming(TimeLineID tli, XLogRecPtr recptr, const char *conninfo,
 	if (launch)
 		SendPostmasterSignal(PMSIGNAL_START_WALRECEIVER);
 	else
-		SetLatch(&walrcv->latch);
+		SetLatch(walrcv->latch);
 }
 
 /*

--- a/src/include/replication/walreceiver.h
+++ b/src/include/replication/walreceiver.h
@@ -113,10 +113,10 @@ typedef struct
 
 	/*
 	 * Latch used by startup process to wake up walreceiver after telling it
-	 * where to start streaming (after setting receiveStart and
-	 * receiveStartTLI).
+	 * where to start streaming (after setting receiveStart and receiveStartTLI).
+	 * This is normally mapped to procLatch when walreceiver is running.
 	 */
-	Latch		latch;
+	Latch		*latch;
 } WalRcvData;
 
 extern WalRcvData *WalRcv;

--- a/src/include/replication/walreceiver.h
+++ b/src/include/replication/walreceiver.h
@@ -109,14 +109,14 @@ typedef struct
 	 */
 	char		slotname[NAMEDATALEN];
 
-	slock_t		mutex;			/* locks shared variables shown above */
-
 	/*
 	 * Latch used by startup process to wake up walreceiver after telling it
 	 * where to start streaming (after setting receiveStart and receiveStartTLI).
 	 * This is normally mapped to procLatch when walreceiver is running.
 	 */
 	Latch		*latch;
+
+	slock_t		mutex;			/* locks shared variables shown above */
 } WalRcvData;
 
 extern WalRcvData *WalRcv;

--- a/src/test/regress/init_file
+++ b/src/test/regress/init_file
@@ -116,6 +116,10 @@ m/ERROR:  invalid partition constraint on "[^"]+".*/
 s/ERROR:  invalid partition constraint on "[^"]+".*/ERROR:  invalid partition constraint on "[^"]+".*(cdbpartition.c:XXX)/
 m/ERROR:  FIPS enabled OpenSSL is required for strict FIPS mode .*/
 s/ERROR:  FIPS enabled OpenSSL is required for strict FIPS mode .*/ERROR:  FIPS enabled OpenSSL is required for strict FIPS mode (openssl.c:XXX)/
+m/ERROR:  could not receive data from WAL stream: connection pointer is NULL.*/
+s/ERROR:  could not receive data from WAL stream: connection pointer is NULL.*/ERROR:  could not receive data from WAL stream: connection pointer is NULL (libpqwalreceiver.c:XXX)/
+m/ERROR:  could not send data to WAL stream: connection pointer is NULL.*/
+s/ERROR:  could not send data to WAL stream: connection pointer is NULL.*/ERROR:  could not send data to WAL stream: connection pointer is NULL (libpqwalreceiver.c:XXX)/
 
 # Mask out OpenSSL behavior change in different version
 m/ERROR:  Cannot use "md5": No such hash algorithm/

--- a/src/test/walrep/Makefile
+++ b/src/test/walrep/Makefile
@@ -9,7 +9,7 @@ include $(top_builddir)/src/Makefile.global
 
 REGRESS = setup
 REGRESS += replication_views_mirrored missing_xlog walreceiver generate_ao_xlog generate_aoco_xlog
-REGRESS_OPTS = --load-extension=gp_inject_fault
+REGRESS_OPTS = --load-extension=gp_inject_fault --init-file=$(top_builddir)/src/test/regress/init_file
 
 NO_PGXS = 1
 include $(top_srcdir)/src/makefiles/pgxs.mk


### PR DESCRIPTION
This is follow up PR https://github.com/greenplum-db/gpdb/pull/11343.

The current implementation of the synchronous walreceiver connection to the walsender has a flaw.

When the master host becomes unavailable, walreceiver is trying to open a connection with the master. After an unsuccessful attempt, it dies and reborns again. During the attempt, the system call `poll()` (or `select`) is called, where walreceiver is for a long time (~2 minutes).

When we call gpactivatestandby, the promote signal is sent. postmaster tries to stop the walreceiver and sends a `SIGTERM` to it. `SIGTERM` doesn't stop `poll()`. After the signals have arrived the `poll()` continues its work. You can check this by looking at the `pqSocketCheck` function in the `fe-misc.c` file.

Here's an stack trace for walreceiver's `poll()` call:
```
#0  0x00007f0778556a20 in __poll_nocancel () from /lib64/libc.so.6
#1  0x000000000093957d in pqSocketPoll (end_time=-1, forWrite=0, forRead=0, sock=<optimized out>) at fe-misc.c:1236
#2  pqSocketCheck (conn=conn@entry=0x36a9590, forRead=forRead@entry=0, forWrite=forWrite@entry=1, end_time=end_time@entry=-1) at fe-misc.c:1178
#3  0x000000000093aa90 in pqWaitTimed (forRead=forRead@entry=0, forWrite=forWrite@entry=1, conn=conn@entry=0x36a9590, finish_time=finish_time@entry=-1)
    at fe-misc.c:1088
#4  0x000000000092ee35 in connectDBComplete (conn=0x36a9590) at fe-connect.c:1745
#5  0x000000000092fb4c in PQconnectdb (
    conninfo=conninfo@entry=0x7fff104d03e0 "user=gpadmin host=10.92.6.102 port=5432 sslmode=prefer sslcompression=1 krbsrvname=postgres application_name=gp_walreceiver dbname=replication replication=true fallback_application_name=walreceiver") at fe-connect.c:686
#6  0x0000000000a4abf6 in libpqrcv_connect (conninfo=<optimized out>) at libpqwalreceiver/libpqwalreceiver.c:109
#7  0x0000000000a40152 in WalReceiverMain () at walreceiver.c:326
#8  0x000000000079c792 in AuxiliaryProcessMain (argc=argc@entry=2, argv=argv@entry=0x7fff104d0e90) at bootstrap.c:459
#9  0x0000000000a1290d in StartChildProcess (type=WalReceiverProcess) at postmaster.c:5832
#10 MaybeStartWalReceiver () at postmaster.c:5987
#11 0x00000000006cc109 in ServerLoop () at postmaster.c:2017
#12 0x0000000000a15d17 in PostmasterMain (argc=argc@entry=6, argv=argv@entry=0x36870d0) at postmaster.c:1518
#13 0x00000000006d167b in main (argc=6, argv=0x36870d0) at main.c:245
```
gpactivatestandby tries to connect to new master and by making 50 attempts in 50 seconds. If the connection fails, this error is displayed
```
[CRITICAL]:-Error activating standby master: Either the set port is incorrect or the postmaster could not come up.
```
Since `poll()` may run for several minutes, gpactivatestandby may never connect to the new master.

To fix this, we fixed the `libpqrcv_connect` function. The implementation logic is taken from newer versions of postgres. Commit postgres/postgres@1e8a850094 changes the `libpqrcv_connect` function.

When the changes were ported, there was a problem with the `walreceiver` test.  This error appears:
```
ERROR:  cannot wait on a latch owned by another process (pg_latch.c:239)
```
The reason for the error is the following. When calling the `WaitLatchOrSocket` function in `libpqrcv_connect`, we need to pass `WalRcv->latch`, because when `SIGTERM` arrives, `SetLatch(&WalRcv->latch)` is called to end the walreceiver.  This test uses the `libpqrcv_connect` function, which calls `WaitLatchOrSocket` by passing it `WalRcv->latch` (this latch is owned by walreceiver). That is, we cannot use the `libpqrcv_connect` function outside the walreceiver. To fix this, the part of the commit postgres/postgres@597a87ccc9 was ported, where `MyProc->procLatch` and `WalRcv->latch` was mapped (like in master branch). Is it ok, that i added changes to `WalRcvData` structure?

This fix made it necessary to port postgres/postgres@45f9d08684d commit. But here another problem arises. We can't lock mutex in the signal handler, because it could cause a deadlock (we use WalRcv->latch in SIGTERM handler). So, the call of `SetLatch(&WalRcv->latch)` in SIGTERM handler is changed to `SetLatch(&MyProc->procLatch)`.

---

Also a issue with incorrect backport of postgres/postgres@a1a789e to Greenplum 6X_STABLE (master is not affected) were found. The problem is that [SetLatch() ](https://github.com/greenplum-db/gpdb/blob/cb2f8c0337640e918b646df25dc98a284531a7be/src/backend/replication/walreceiver.c#L795) in `WalRcvShutdownHandler` still has GP specific [elogif](https://github.com/greenplum-db/gpdb/blob/e2b0422bba7f0722294391b540a2d51fa1dc3cd5/src/backend/port/unix_latch.c#L527) print that can cause the same problem as backported commit tried to fix. On one hand it is a debug GUC for developers, but on the other it can cause troubles.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
