### PR TITLE
[7X] Fix warnings found by static analyzer.

### DIFF
--- a/src/backend/cdb/cdbcat.c
+++ b/src/backend/cdb/cdbcat.c
@@ -851,7 +851,6 @@ index_check_policy_compatible(GpPolicy *policy,
 		Oid			policy_typeid;
 		Oid			policy_eqop;
 		bool		found;
-		bool		found_col;
 		Oid			found_col_indclass;
 
 		/* Look up the equality operator for the distribution key opclass */
@@ -866,7 +865,6 @@ index_check_policy_compatible(GpPolicy *policy,
 		 * key.
 		 */
 		found = false;
-		found_col = false;
 		found_col_indclass = InvalidOid;
 		for (j = 0; j < nidxatts; j++)
 		{
@@ -876,7 +874,6 @@ index_check_policy_compatible(GpPolicy *policy,
 
 			if (indattr[j] != policy_attr)
 				continue;
-			found_col = true;
 
 			/*
 			 * Is the index's operator class is compatible with the

--- a/src/backend/cdb/cdbcopy.c
+++ b/src/backend/cdb/cdbcopy.c
@@ -510,7 +510,6 @@ cdbCopyEndInternal(CdbCopy *c, char *abort_msg,
 	for (seg = 0; seg < gp->size; seg++)
 	{
 		SegmentDatabaseDescriptor *q = gp->db_descriptors[seg];
-		int			result;
 		PGresult   *res;
 		int64		segment_rows_completed = 0; /* # of rows completed by this QE */
 		int64		segment_rows_rejected = 0;	/* # of rows rejected by this QE */
@@ -590,7 +589,7 @@ cdbCopyEndInternal(CdbCopy *c, char *abort_msg,
 			if (PQresultStatus(res) == PGRES_COPY_IN)
 			{
 				elog(LOG, "Segment still in copy in, retrying the putCopyEnd");
-				result = PQputCopyEnd(q->conn, NULL);
+				PQputCopyEnd(q->conn, NULL);
 			}
 			else if (PQresultStatus(res) == PGRES_COPY_OUT)
 			{

--- a/src/backend/cdb/cdbpathlocus.c
+++ b/src/backend/cdb/cdbpathlocus.c
@@ -995,10 +995,7 @@ cdbpathlocus_is_hashed_on_tlist(CdbPathLocus locus, List *tlist,
 				bool		found = false;
 
 				if (ignore_constants && CdbEquivClassIsConstant(dk_eclass))
-				{
-					found = true;
 					continue;
-				}
 
 				if (dk_eclass->ec_sortref != 0)
 				{

--- a/src/backend/cdb/cdbtm.c
+++ b/src/backend/cdb/cdbtm.c
@@ -781,18 +781,11 @@ doNotifyingAbort(void)
 		case DTX_STATE_NOTIFYING_ABORT_PREPARED:
 			{
 				DtxProtocolCommand dtxProtocolCommand;
-				char	   *abortString;
 
 				if (MyTmGxactLocal->state == DTX_STATE_NOTIFYING_ABORT_SOME_PREPARED)
-				{
 					dtxProtocolCommand = DTX_PROTOCOL_COMMAND_ABORT_SOME_PREPARED;
-					abortString = "Abort [Prepared]";
-				}
 				else
-				{
 					dtxProtocolCommand = DTX_PROTOCOL_COMMAND_ABORT_PREPARED;
-					abortString = "Abort Prepared";
-				}
 
 				savedInterruptHoldoffCount = InterruptHoldoffCount;
 

--- a/src/backend/cdb/dispatcher/cdbdisp_query.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_query.c
@@ -630,11 +630,8 @@ cdbdisp_buildPlanQueryParms(struct QueryDesc *queryDesc,
 
 	int			splan_len,
 				splan_len_uncompressed,
-				sddesc_len,
-				rootIdx;
+				sddesc_len;
 	Oid			save_userid;
-
-	rootIdx = RootSliceIndex(queryDesc->estate);
 
 	DispatchCommandQueryParms *pQueryParms = (DispatchCommandQueryParms *) palloc0(sizeof(*pQueryParms));
 

--- a/src/backend/cdb/motion/ic_common.c
+++ b/src/backend/cdb/motion/ic_common.c
@@ -309,8 +309,6 @@ SendTupleChunkToAMS(MotionLayerState *mlStates,
 	 * tcItem can actually be a chain of tcItems.  we need to send out all of
 	 * them.
 	 */
-	currItem = tcItem;
-
 	for (currItem = tcItem; currItem != NULL; currItem = currItem->p_next)
 	{
 #ifdef AMS_VERBOSE_LOGGING

--- a/src/backend/cdb/motion/ic_udpifc.c
+++ b/src/backend/cdb/motion/ic_udpifc.c
@@ -5512,7 +5512,6 @@ SendChunkUDPIFC(ChunkTransportState *transportStates,
 	{
 		/* handling stop message will make some connection not active anymore */
 		handleStopMsgs(transportStates, pEntry, motionId);
-		gotStops = false;
 		if (!conn->stillActive)
 			return true;
 	}

--- a/src/backend/optimizer/util/clauses.c
+++ b/src/backend/optimizer/util/clauses.c
@@ -4000,12 +4000,7 @@ simplify_or_arguments(List *args,
 			if (!unprocessed_args)
 				unprocessed_args = subargs;
 			else
-			{
-				List	   *oldhdr = unprocessed_args;
-
 				unprocessed_args = list_concat(subargs, unprocessed_args);
-				pfree(oldhdr);
-			}
 			continue;
 		}
 
@@ -4102,12 +4097,7 @@ simplify_and_arguments(List *args,
 			if (!unprocessed_args)
 				unprocessed_args = subargs;
 			else
-			{
-				List	   *oldhdr = unprocessed_args;
-
 				unprocessed_args = list_concat(subargs, unprocessed_args);
-				pfree(oldhdr);
-			}
 			continue;
 		}
 
@@ -5597,14 +5587,14 @@ flatten_join_alias_var_optimizer(Query *query, int queryLevel)
 	if (NIL != targetList)
 	{
 		queryNew->targetList = (List *) flatten_join_alias_vars(queryNew, (Node *) targetList);
-		pfree(targetList);
+		list_free(targetList);
 	}
 
 	List * returningList = queryNew->returningList;
 	if (NIL != returningList)
 	{
 		queryNew->returningList = (List *) flatten_join_alias_vars(queryNew, (Node *) returningList);
-		pfree(returningList);
+		list_free(returningList);
 	}
 
 	Node *havingQual = queryNew->havingQual;
@@ -5618,7 +5608,7 @@ flatten_join_alias_var_optimizer(Query *query, int queryLevel)
 	if (NIL != scatterClause)
 	{
 		queryNew->scatterClause = (List *) flatten_join_alias_vars(queryNew, (Node *) scatterClause);
-		pfree(scatterClause);
+		list_free(scatterClause);
 	}
 
 	Node *limitOffset = queryNew->limitOffset;


### PR DESCRIPTION
I'm running clang static analyzer against Greenplum source codes and found the following warnings:

1. (List *) freed by pfree().
2. Dead assinments (I only fixed those under cdb directory).

There're many warnings reported by CSA, I will continue to send small patches for easy reviewing.

