### PR TITLE
Support Direct Dispatch for a randomly distributed table, when filtered on gp_segment_id

### DIFF
--- a/src/backend/gporca/data/dxl/minidump/DirectDispatch-RandDistTable-Disjunction.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DirectDispatch-RandDistTable-Disjunction.mdp
@@ -1,0 +1,310 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Comment><![CDATA[
+       Objective:Allow direct dispatch when filtering gp_segment_id on randomly distributed table with conjunction case
+       create table foo_randDistr(col1 int, col2 int) distributed randomly;
+       insert into foo_randDistr select i,i*2 from generate_series(1, 10)i;
+       explain select gp_segment_id, * from foo_randDistr where gp_segment_id=0 or gp_segment_id=1;
+                                         QUERY PLAN
+       -------------------------------------------------------------------------------
+        Gather Motion 2:1  (slice1; segments: 2)  (cost=0.00..431.00 rows=1 width=12)
+          ->  Seq Scan on foo_randdistr  (cost=0.00..431.00 rows=1 width=12)
+                Filter: ((gp_segment_id = 0) OR (gp_segment_id = 1))
+        Optimizer: Pivotal Optimizer (GPORCA)
+       (4 rows)
+  ]]>
+  </dxl:Comment>
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="20" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0" SkewFactor="0"/>
+      <dxl:TraceFlags Value="101013,102001,102002,102003,102043,102074,102120,102144,103001,103014,103022,103026,103027,103029,103033,103038,103040,104002,104003,104004,104005,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:ColumnStatistics Mdid="1.26390.1.0.8" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2134.1.0"/>
+        <dxl:MaxAgg Mdid="0.2118.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.2227.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.3315.1.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:RelationStatistics Mdid="2.26390.1.0" Name="foo_randdistr" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
+      <dxl:Relation Mdid="6.26390.1.0" Name="foo_randdistr" IsTemporary="false" StorageType="Heap" DistributionPolicy="Random" Keys="8,2">
+        <dxl:Columns>
+          <dxl:Column Name="col1" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="col2" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:CheckConstraints/>
+      </dxl:Relation>
+      <dxl:RelationExtendedStatistics Mdid="10.26390.1.0" Name="foo_randdistr"/>
+      <dxl:MDCast Mdid="3.23.1.0;23.1.0" Name="int4" BinaryCoercible="true" SourceTypeId="0.23.1.0" DestinationTypeId="0.23.1.0" CastFuncId="0.0.0.0" CoercePathType="0"/>
+      <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.65.1.0"/>
+        <dxl:Commutator Mdid="0.96.1.0"/>
+        <dxl:InverseOp Mdid="0.518.1.0"/>
+        <dxl:HashOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7100.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.1977.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.7100.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="1" ColName="col1" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="2" ColName="col2" TypeMdid="0.23.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalSelect>
+        <dxl:Or>
+          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+            <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+          </dxl:Comparison>
+          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+            <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+          </dxl:Comparison>
+        </dxl:Or>
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="6.26390.1.0" TableName="foo_randdistr" LockMode="1">
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="col1" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="2" ColName="col2" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="4" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="5" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="9" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+      </dxl:LogicalSelect>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="1">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="431.000070" Rows="1.000000" Width="12"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="8" Alias="gp_segment_id">
+            <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="0" Alias="col1">
+            <dxl:Ident ColId="0" ColName="col1" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="1" Alias="col2">
+            <dxl:Ident ColId="1" ColName="col2" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:SortingColumnList/>
+        <dxl:Result>
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="431.000025" Rows="1.000000" Width="12"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="8" Alias="gp_segment_id">
+              <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="0" Alias="col1">
+              <dxl:Ident ColId="0" ColName="col1" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="1" Alias="col2">
+              <dxl:Ident ColId="1" ColName="col2" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:OneTimeFilter/>
+          <dxl:TableScan>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.000025" Rows="1.000000" Width="12"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="0" Alias="col1">
+                <dxl:Ident ColId="0" ColName="col1" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="1" Alias="col2">
+                <dxl:Ident ColId="1" ColName="col2" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="8" Alias="gp_segment_id">
+                <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter>
+              <dxl:Or>
+                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                  <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+                </dxl:Comparison>
+                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                  <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                </dxl:Comparison>
+              </dxl:Or>
+            </dxl:Filter>
+            <dxl:TableDescriptor Mdid="6.26390.1.0" TableName="foo_randdistr" LockMode="1">
+              <dxl:Columns>
+                <dxl:Column ColId="0" Attno="1" ColName="col1" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="1" Attno="2" ColName="col2" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="3" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="4" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="5" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="6" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="7" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="8" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
+        </dxl:Result>
+      </dxl:GatherMotion>
+      <dxl:DirectDispatchInfo IsRaw="true">
+        <dxl:KeyValue>
+          <dxl:Datum TypeMdid="0.23.1.0" Value="0"/>
+        </dxl:KeyValue>
+        <dxl:KeyValue>
+          <dxl:Datum TypeMdid="0.23.1.0" Value="1"/>
+        </dxl:KeyValue>
+      </dxl:DirectDispatchInfo>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/DirectDispatch-RandDistTable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DirectDispatch-RandDistTable.mdp
@@ -1,0 +1,294 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Comment><![CDATA[
+         Objective: Allow direct dispatch when filtering gp_segment_id on randomly distributed table
+         create table foo_randDistr(col1 int, col2 int) distributed randomly;
+         insert into foo_randDistr select i,i*2 from generate_series(1, 10)i;
+         explain select gp_segment_id, * from foo_randDistr where gp_segment_id=0;
+                                           QUERY PLAN
+         -------------------------------------------------------------------------------
+          Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..431.00 rows=1 width=12)
+            ->  Seq Scan on foo_randdistr  (cost=0.00..431.00 rows=1 width=12)
+                  Filter: (gp_segment_id = 0)
+          Optimizer: Pivotal Optimizer (GPORCA)
+         (4 rows)
+  ]]>
+  </dxl:Comment>
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="20" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0" SkewFactor="0"/>
+      <dxl:TraceFlags Value="101013,102001,102002,102003,102043,102074,102120,102144,103001,103014,103022,103026,103027,103029,103033,103038,103040,104002,104003,104004,104005,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:ColumnStatistics Mdid="1.26390.1.0.8" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2134.1.0"/>
+        <dxl:MaxAgg Mdid="0.2118.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.2227.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.3315.1.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:RelationStatistics Mdid="2.26390.1.0" Name="foo_randdistr" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
+      <dxl:Relation Mdid="6.26390.1.0" Name="foo_randdistr" IsTemporary="false" StorageType="Heap" DistributionPolicy="Random" Keys="8,2">
+        <dxl:Columns>
+          <dxl:Column Name="col1" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="col2" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:CheckConstraints/>
+      </dxl:Relation>
+      <dxl:RelationExtendedStatistics Mdid="10.26390.1.0" Name="foo_randdistr"/>
+      <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.65.1.0"/>
+        <dxl:Commutator Mdid="0.96.1.0"/>
+        <dxl:InverseOp Mdid="0.518.1.0"/>
+        <dxl:HashOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7100.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.1977.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.7100.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="1" ColName="col1" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="2" ColName="col2" TypeMdid="0.23.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalSelect>
+        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+          <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+          <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+        </dxl:Comparison>
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="6.26390.1.0" TableName="foo_randdistr" LockMode="1">
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="col1" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="2" ColName="col2" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="4" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="5" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="9" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+      </dxl:LogicalSelect>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="1">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="431.000070" Rows="1.000000" Width="12"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="8" Alias="gp_segment_id">
+            <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="0" Alias="col1">
+            <dxl:Ident ColId="0" ColName="col1" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="1" Alias="col2">
+            <dxl:Ident ColId="1" ColName="col2" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:SortingColumnList/>
+        <dxl:Result>
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="431.000025" Rows="1.000000" Width="12"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="8" Alias="gp_segment_id">
+              <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="0" Alias="col1">
+              <dxl:Ident ColId="0" ColName="col1" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="1" Alias="col2">
+              <dxl:Ident ColId="1" ColName="col2" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:OneTimeFilter/>
+          <dxl:TableScan>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.000025" Rows="1.000000" Width="12"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="0" Alias="col1">
+                <dxl:Ident ColId="0" ColName="col1" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="1" Alias="col2">
+                <dxl:Ident ColId="1" ColName="col2" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="8" Alias="gp_segment_id">
+                <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter>
+              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+              </dxl:Comparison>
+            </dxl:Filter>
+            <dxl:TableDescriptor Mdid="6.26390.1.0" TableName="foo_randdistr" LockMode="1">
+              <dxl:Columns>
+                <dxl:Column ColId="0" Attno="1" ColName="col1" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="1" Attno="2" ColName="col2" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="3" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="4" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="5" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="6" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="7" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="8" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
+        </dxl:Result>
+      </dxl:GatherMotion>
+      <dxl:DirectDispatchInfo IsRaw="true">
+        <dxl:KeyValue>
+          <dxl:Datum TypeMdid="0.23.1.0" Value="0"/>
+        </dxl:KeyValue>
+      </dxl:DirectDispatchInfo>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CDistributionSpecRandom.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CDistributionSpecRandom.h
@@ -65,6 +65,11 @@ public:
 		return "RANDOM";
 	}
 
+	CColRef *
+	GetGpSegmentId()
+	{
+		return m_gp_segment_id;
+	}
 	// is distribution duplicate sensitive
 	BOOL
 	IsDuplicateSensitive() const

--- a/src/backend/gporca/libgpopt/include/gpopt/translate/CTranslatorExprToDXLUtils.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/translate/CTranslatorExprToDXLUtils.h
@@ -85,6 +85,12 @@ private:
 		CMemoryPool *mp, CMDAccessor *md_accessor,
 		CExpressionArray *pdrgpexprHashed, CConstraint *pcnstr);
 
+	// compute the direct dispatch info  from the constraints
+	// for a randomly distributed table
+	static CDXLDirectDispatchInfo *GetDXLDirectDispatchInfoRandDist(
+		CMemoryPool *mp, CMDAccessor *md_accessor, const CColRef *pcrDistrCol,
+		CConstraint *pcnstrDistrCol);
+
 	// compute the direct dispatch info for a single distribution key from the constraints
 	// on the distribution key
 	static CDXLDirectDispatchInfo *PdxlddinfoSingleDistrKey(

--- a/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXLUtils.cpp
+++ b/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXLUtils.cpp
@@ -1234,25 +1234,64 @@ CTranslatorExprToDXLUtils::SetDirectDispatchInfo(
 	//			  |--CScalarIdent "non_dist_key"
 	//			  +--CScalarConst (5)
 
-	if (CDistributionSpec::EdtHashed == pds->Edt())
+	if (CDistributionSpec::EdtHashed == pds->Edt() ||
+		CDistributionSpec::EdtRandom == pds->Edt())
 	{
-		// direct dispatch only supported for scans over hash distributed tables
+		// direct dispatch supported for scans over
+		// hash & random distributed tables
 		for (ULONG i = 0; i < size; i++)
 		{
 			CExpression *pexprFilter = (*pexprFilterArray)[i];
 			CPropConstraint *ppc = pexprFilter->DerivePropertyConstraint();
+			CDXLDirectDispatchInfo *dxl_direct_dispatch_info = nullptr;
 
 			if (nullptr != ppc->Pcnstr())
 			{
 				GPOS_ASSERT(nullptr != ppc->Pcnstr());
 
-				CDistributionSpecHashed *pdsHashed =
-					CDistributionSpecHashed::PdsConvert(pds);
-				CExpressionArray *pdrgpexprHashed = pdsHashed->Pdrgpexpr();
+				if (CDistributionSpec::EdtHashed == pds->Edt())
+				{
+					CDistributionSpecHashed *pdsHashed =
+						CDistributionSpecHashed::PdsConvert(pds);
+					CExpressionArray *pdrgpexprHashed = pdsHashed->Pdrgpexpr();
 
-				CDXLDirectDispatchInfo *dxl_direct_dispatch_info =
-					GetDXLDirectDispatchInfo(mp, md_accessor, pdrgpexprHashed,
-											 ppc->Pcnstr());
+					dxl_direct_dispatch_info = GetDXLDirectDispatchInfo(
+						mp, md_accessor, pdrgpexprHashed, ppc->Pcnstr());
+				}
+				else if (CDistributionSpec::EdtRandom == pds->Edt())
+				{
+					CConstraint *pcnstr = ppc->Pcnstr();
+
+					CDistributionSpecRandom *pdsRandom =
+						CDistributionSpecRandom::PdsConvert(pds);
+
+					// Extracting GpSegmentID for RandDist Table
+					const CColRef *pcrDistrCol = pdsRandom->GetGpSegmentId();
+
+					if (pcrDistrCol == nullptr)
+					{
+						// Direct Dispatch not feasible for this scenario as
+						// pcrDistrCol might not exist if gp_segment_id is not defined
+						continue;
+					}
+
+					CConstraint *pcnstrDistrCol =
+						pcnstr->Pcnstr(mp, pcrDistrCol);
+
+					if (pcnstrDistrCol == nullptr)
+					{
+						// Direct Dispatch not feasible for this scenario
+						// as no constraint found on the gp_segment_id
+						// Eg: In a query on a random distribute table, if we don't
+						// have a condition on gp_segment_id, but we have a condition
+						// on another column, in that case this condition
+						// shall arise.(select * from bar_randDistr where colm1=5;)
+						continue;
+					}
+
+					dxl_direct_dispatch_info = GetDXLDirectDispatchInfoRandDist(
+						mp, md_accessor, pcrDistrCol, pcnstrDistrCol);
+				}
 
 				if (nullptr != dxl_direct_dispatch_info)
 				{
@@ -1263,7 +1302,60 @@ CTranslatorExprToDXLUtils::SetDirectDispatchInfo(
 		}
 	}
 }
+//---------------------------------------------------------------------------
+//	@function:
+//		CTranslatorExprToDXLUtils::GetDXLDirectDispatchInfoRandDist
+//
+//	@doc:
+//		Compute the direct dispatch info spec if the table is randomly
+//		distributed. Returns NULL if this is not possible
+//
+//---------------------------------------------------------------------------
+CDXLDirectDispatchInfo *
+CTranslatorExprToDXLUtils::GetDXLDirectDispatchInfoRandDist(
+	CMemoryPool *mp, CMDAccessor *md_accessor, const CColRef *pcrDistrCol,
+	CConstraint *pcnstrDistrCol)
+{
+	// For a random distributed table, we get direct gp_segment_id
+	// value in the expression, so we use it as is.
+	const BOOL useRawValues = true;
 
+	CDXLDatum2dArray *pdrgpdrgpdxldatum = nullptr;
+
+	if (CPredicateUtils::FConstColumn(pcnstrDistrCol, pcrDistrCol))
+	{
+		CDXLDatum *dxl_datum = PdxldatumFromPointConstraint(
+			mp, md_accessor, pcrDistrCol, pcnstrDistrCol);
+		GPOS_ASSERT(nullptr != dxl_datum);
+
+		if (FDirectDispatchable(md_accessor, pcrDistrCol, dxl_datum))
+		{
+			CDXLDatumArray *pdrgpdxldatum = GPOS_NEW(mp) CDXLDatumArray(mp);
+
+			dxl_datum->AddRef();
+			pdrgpdxldatum->Append(dxl_datum);
+
+			pdrgpdrgpdxldatum = GPOS_NEW(mp) CDXLDatum2dArray(mp);
+			pdrgpdrgpdxldatum->Append(pdrgpdxldatum);
+		}
+
+		dxl_datum->Release();
+	}
+	else if (CPredicateUtils::FColumnDisjunctionOfConst(pcnstrDistrCol,
+														pcrDistrCol))
+	{
+		pdrgpdrgpdxldatum = PdrgpdrgpdxldatumFromDisjPointConstraint(
+			mp, md_accessor, pcrDistrCol, pcnstrDistrCol);
+	}
+
+	CRefCount::SafeRelease(pcnstrDistrCol);
+
+	if (nullptr == pdrgpdrgpdxldatum)
+	{
+		return nullptr;
+	}
+	return GPOS_NEW(mp) CDXLDirectDispatchInfo(pdrgpdrgpdxldatum, useRawValues);
+}
 //---------------------------------------------------------------------------
 //	@function:
 //		CTranslatorExprToDXLUtils::GetDXLDirectDispatchInfo
@@ -1284,6 +1376,7 @@ CTranslatorExprToDXLUtils::GetDXLDirectDispatchInfo(
 	const ULONG ulHashExpr = pdrgpexprHashed->Size();
 	GPOS_ASSERT(0 < ulHashExpr);
 
+	// If we have single distribution key for table
 	if (1 == ulHashExpr)
 	{
 		CExpression *pexprHashed = (*pdrgpexprHashed)[0];
@@ -1293,6 +1386,7 @@ CTranslatorExprToDXLUtils::GetDXLDirectDispatchInfo(
 	BOOL fSuccess = true;
 	CDXLDatumArray *pdrgpdxldatum = GPOS_NEW(mp) CDXLDatumArray(mp);
 
+	// If we have multiple distribution keys for the table
 	for (ULONG ul = 0; ul < ulHashExpr && fSuccess; ul++)
 	{
 		CExpression *pexpr = (*pdrgpexprHashed)[ul];

--- a/src/backend/gporca/server/src/unittest/gpopt/minidump/CDirectDispatchTest.cpp
+++ b/src/backend/gporca/server/src/unittest/gpopt/minidump/CDirectDispatchTest.cpp
@@ -41,6 +41,8 @@ const CHAR *rgszDirectDispatchFileNames[] = {
 	"../data/dxl/minidump/DirectDispatch-IndexScan.mdp",
 	"../data/dxl/minidump/DirectDispatch-DynamicIndexScan.mdp",
 	"../data/dxl/minidump/InsertDirectedDispatchNullValue.mdp",
+	"../data/dxl/minidump/DirectDispatch-RandDistTable.mdp",
+	"../data/dxl/minidump/DirectDispatch-RandDistTable-Disjunction.mdp",
 };
 
 //---------------------------------------------------------------------------

--- a/src/test/regress/expected/direct_dispatch.out
+++ b/src/test/regress/expected/direct_dispatch.out
@@ -615,6 +615,168 @@ INFO:  (slice 1) Dispatch command to SINGLE content
 drop table test_prepare;
 INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
+-- Tests to check direct dispatch if the table is randomly distributed and the
+-- filter has condition on gp_segment_id
+-- NOTE: Only EXPLAIN query included, output of SELECT query is not shown.
+-- Since the table is distributed randomly, the output of SELECT query
+-- will differ everytime new table is created, and hence the during comparision
+-- the tests will fail.
+drop table if exists bar_randDistr;
+NOTICE:  table "bar_randdistr" does not exist, skipping
+INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to ALL contents: 0 1 2
+create table bar_randDistr(col1 int, col2 int) distributed randomly;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
+insert into bar_randDistr select i,i*2 from generate_series(1, 10)i;
+INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
+-- Case 1 : simple conditions on gp_segment_id
+explain (costs off) select gp_segment_id, * from bar_randDistr where gp_segment_id=0;
+                QUERY PLAN                
+------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
+   ->  Seq Scan on bar_randdistr
+         Filter: (gp_segment_id = 0)
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+explain (costs off) select gp_segment_id, * from bar_randDistr where gp_segment_id=1 or gp_segment_id=2;
+                          QUERY PLAN                          
+--------------------------------------------------------------
+ Gather Motion 2:1  (slice1; segments: 2)
+   ->  Seq Scan on bar_randdistr
+         Filter: ((gp_segment_id = 1) OR (gp_segment_id = 2))
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+explain (costs off) select gp_segment_id, count(*) from bar_randDistr group by gp_segment_id;
+                         QUERY PLAN                         
+------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Finalize HashAggregate
+         Group Key: gp_segment_id
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Hash Key: gp_segment_id
+               ->  Partial HashAggregate
+                     Group Key: gp_segment_id
+                     ->  Seq Scan on bar_randdistr
+ Optimizer: Postgres query optimizer
+(9 rows)
+
+-- Case2: Conjunction scenario with filter condition on gp_segment_id and column
+explain (costs off) select gp_segment_id, * from bar_randDistr where gp_segment_id=0 and col1 between 1 and 10;
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
+   ->  Seq Scan on bar_randdistr
+         Filter: ((col1 >= 1) AND (col1 <= 10) AND (gp_segment_id = 0))
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+-- Case3: Disjunction scenario with filter condition on gp_segment_id and column
+explain (costs off) select gp_segment_id, * from bar_randDistr where gp_segment_id=1 or (col1=6 and gp_segment_id=2);
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Gather Motion 2:1  (slice1; segments: 2)
+   ->  Seq Scan on bar_randdistr
+         Filter: ((gp_segment_id = 1) OR ((col1 = 6) AND (gp_segment_id = 2)))
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+-- Case4: Scenario with constant/variable column and constant/variable gp_segment_id
+explain (costs off) select gp_segment_id, * from bar_randDistr where col1 =3 and gp_segment_id in (0,1);
+                                 QUERY PLAN                                  
+-----------------------------------------------------------------------------
+ Gather Motion 2:1  (slice1; segments: 2)
+   ->  Seq Scan on bar_randdistr
+         Filter: ((gp_segment_id = ANY ('{0,1}'::integer[])) AND (col1 = 3))
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+explain (costs off) select gp_segment_id, * from bar_randDistr where col1 =3 and gp_segment_id <>1;
+                      QUERY PLAN                       
+-------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on bar_randdistr
+         Filter: ((gp_segment_id <> 1) AND (col1 = 3))
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+explain (costs off) select gp_segment_id, * from bar_randDistr where col1 between 1 and 5 and gp_segment_id =0;
+                              QUERY PLAN                               
+-----------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
+   ->  Seq Scan on bar_randdistr
+         Filter: ((col1 >= 1) AND (col1 <= 5) AND (gp_segment_id = 0))
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+explain (costs off) select gp_segment_id, * from bar_randDistr where col1 in (1,5) and gp_segment_id <> 0;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on bar_randdistr
+         Filter: ((col1 = ANY ('{1,5}'::integer[])) AND (gp_segment_id <> 0))
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+explain (costs off) select gp_segment_id, * from bar_randDistr where col1 in (1,5) and gp_segment_id in (0,1);
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Gather Motion 2:1  (slice1; segments: 2)
+   ->  Seq Scan on bar_randdistr
+         Filter: ((col1 = ANY ('{1,5}'::integer[])) AND (gp_segment_id = ANY ('{0,1}'::integer[])))
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+-- Case5: Scenarios with special conditions
+create function afunc() returns integer as $$ begin return 42; end; $$ language plpgsql;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
+create function immutable_func() returns integer as $$ begin return 42; end; $$ language plpgsql immutable;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
+explain (costs off) select * from bar_randDistr where col1 = 1;
+                QUERY PLAN                
+------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on bar_randdistr
+         Filter: (col1 = 1)
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+explain (costs off) select * from bar_randDistr where gp_segment_id % 2 = 0;
+                QUERY PLAN                 
+-------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on bar_randdistr
+         Filter: ((gp_segment_id % 2) = 0)
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+explain (costs off) select * from bar_randDistr where gp_segment_id=immutable_func();
+                QUERY PLAN                
+------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
+   ->  Seq Scan on bar_randdistr
+         Filter: (gp_segment_id = 42)
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+explain (costs off) select * from bar_randDistr where gp_segment_id=afunc();
+                QUERY PLAN                 
+-------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on bar_randdistr
+         Filter: (gp_segment_id = afunc())
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+drop table if exists bar_randDistr;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
 -- test direct dispatch via gp_segment_id qual
 create table t_test_dd_via_segid(id int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'id' as the Greenplum Database data distribution key for this table.

--- a/src/test/regress/expected/direct_dispatch_optimizer.out
+++ b/src/test/regress/expected/direct_dispatch_optimizer.out
@@ -632,6 +632,168 @@ INFO:  (slice 1) Dispatch command to SINGLE content
 drop table test_prepare;
 INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
+-- Tests to check direct dispatch if the table is randomly distributed and the
+-- filter has condition on gp_segment_id
+-- NOTE: Only EXPLAIN query included, output of SELECT query is not shown.
+-- Since the table is distributed randomly, the output of SELECT query
+-- will differ everytime new table is created, and hence the during comparision
+-- the tests will fail.
+drop table if exists bar_randDistr;
+NOTICE:  table "bar_randdistr" does not exist, skipping
+INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to ALL contents: 0 1 2
+create table bar_randDistr(col1 int, col2 int) distributed randomly;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
+insert into bar_randDistr select i,i*2 from generate_series(1, 10)i;
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
+-- Case 1 : simple conditions on gp_segment_id
+explain (costs off) select gp_segment_id, * from bar_randDistr where gp_segment_id=0;
+                QUERY PLAN                
+------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
+   ->  Seq Scan on bar_randdistr
+         Filter: (gp_segment_id = 0)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(4 rows)
+
+explain (costs off) select gp_segment_id, * from bar_randDistr where gp_segment_id=1 or gp_segment_id=2;
+                          QUERY PLAN                          
+--------------------------------------------------------------
+ Gather Motion 2:1  (slice1; segments: 2)
+   ->  Seq Scan on bar_randdistr
+         Filter: ((gp_segment_id = 1) OR (gp_segment_id = 2))
+ Optimizer: Pivotal Optimizer (GPORCA)
+(4 rows)
+
+explain (costs off) select gp_segment_id, count(*) from bar_randDistr group by gp_segment_id;
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  GroupAggregate
+         Group Key: gp_segment_id
+         ->  Sort
+               Sort Key: gp_segment_id
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: gp_segment_id
+                     ->  Seq Scan on bar_randdistr
+ Optimizer: Pivotal Optimizer (GPORCA)
+(9 rows)
+
+-- Case2: Conjunction scenario with filter condition on gp_segment_id and column
+explain (costs off) select gp_segment_id, * from bar_randDistr where gp_segment_id=0 and col1 between 1 and 10;
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
+   ->  Seq Scan on bar_randdistr
+         Filter: ((gp_segment_id = 0) AND (col1 >= 1) AND (col1 <= 10))
+ Optimizer: Pivotal Optimizer (GPORCA)
+(4 rows)
+
+-- Case3: Disjunction scenario with filter condition on gp_segment_id and column
+explain (costs off) select gp_segment_id, * from bar_randDistr where gp_segment_id=1 or (col1=6 and gp_segment_id=2);
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on bar_randdistr
+         Filter: ((gp_segment_id = 1) OR ((col1 = 6) AND (gp_segment_id = 2)))
+ Optimizer: Pivotal Optimizer (GPORCA)
+(4 rows)
+
+-- Case4: Scenario with constant/variable column and constant/variable gp_segment_id
+explain (costs off) select gp_segment_id, * from bar_randDistr where col1 =3 and gp_segment_id in (0,1);
+                                 QUERY PLAN                                  
+-----------------------------------------------------------------------------
+ Gather Motion 2:1  (slice1; segments: 2)
+   ->  Seq Scan on bar_randdistr
+         Filter: ((col1 = 3) AND (gp_segment_id = ANY ('{0,1}'::integer[])))
+ Optimizer: Pivotal Optimizer (GPORCA)
+(4 rows)
+
+explain (costs off) select gp_segment_id, * from bar_randDistr where col1 =3 and gp_segment_id <>1;
+                      QUERY PLAN                       
+-------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on bar_randdistr
+         Filter: ((col1 = 3) AND (gp_segment_id <> 1))
+ Optimizer: Pivotal Optimizer (GPORCA)
+(4 rows)
+
+explain (costs off) select gp_segment_id, * from bar_randDistr where col1 between 1 and 5 and gp_segment_id =0;
+                              QUERY PLAN                               
+-----------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
+   ->  Seq Scan on bar_randdistr
+         Filter: ((col1 >= 1) AND (col1 <= 5) AND (gp_segment_id = 0))
+ Optimizer: Pivotal Optimizer (GPORCA)
+(4 rows)
+
+explain (costs off) select gp_segment_id, * from bar_randDistr where col1 in (1,5) and gp_segment_id <> 0;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on bar_randdistr
+         Filter: ((col1 = ANY ('{1,5}'::integer[])) AND (gp_segment_id <> 0))
+ Optimizer: Pivotal Optimizer (GPORCA)
+(4 rows)
+
+explain (costs off) select gp_segment_id, * from bar_randDistr where col1 in (1,5) and gp_segment_id in (0,1);
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Gather Motion 2:1  (slice1; segments: 2)
+   ->  Seq Scan on bar_randdistr
+         Filter: ((col1 = ANY ('{1,5}'::integer[])) AND (gp_segment_id = ANY ('{0,1}'::integer[])))
+ Optimizer: Pivotal Optimizer (GPORCA)
+(4 rows)
+
+-- Case5: Scenarios with special conditions
+create function afunc() returns integer as $$ begin return 42; end; $$ language plpgsql;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
+create function immutable_func() returns integer as $$ begin return 42; end; $$ language plpgsql immutable;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
+explain (costs off) select * from bar_randDistr where col1 = 1;
+                QUERY PLAN                
+------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on bar_randdistr
+         Filter: (col1 = 1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(4 rows)
+
+explain (costs off) select * from bar_randDistr where gp_segment_id % 2 = 0;
+                QUERY PLAN                 
+-------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on bar_randdistr
+         Filter: ((gp_segment_id % 2) = 0)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(4 rows)
+
+explain (costs off) select * from bar_randDistr where gp_segment_id=immutable_func();
+                QUERY PLAN                
+------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
+   ->  Seq Scan on bar_randdistr
+         Filter: (gp_segment_id = 42)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(4 rows)
+
+explain (costs off) select * from bar_randDistr where gp_segment_id=afunc();
+                QUERY PLAN                 
+-------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on bar_randdistr
+         Filter: (gp_segment_id = afunc())
+ Optimizer: Pivotal Optimizer (GPORCA)
+(4 rows)
+
+drop table if exists bar_randDistr;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
 -- test direct dispatch via gp_segment_id qual
 create table t_test_dd_via_segid(id int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'id' as the Greenplum Database data distribution key for this table.


### PR DESCRIPTION
In ORCA direct dispatch was supported for Hash distributed table, with this update we are able to perform direct dispatch for a randomly distributed table with condition on gp_segment_id.

This update solves the problem described at the following link from ORCA perspective:
https://github.com/greenplum-db/gpdb/issues/13202

Consider the following example

create table foo_randDistr(col1 int, col2 int) distributed randomly;
insert into foo_randDistr select i,i*2 from generate_series(1, 10)I;

explain select gp_segment_id, * from foo_randDistr where gp_segment_id=0;
QUERY PLAN
-------------------------------------------------------------------------------
Gather Motion 1:1 (slice1; segments: 1) (cost=0.00..431.00 rows=1 width=12)
-> Seq Scan on foo_randdistr (cost=0.00..431.00 rows=1 width=12)
Filter: (gp_segment_id = 0)
Optimizer: Pivotal Optimizer (GPORCA)
(4 rows)

