### PR TITLE
psql: Ensure EXECUTE ON INITPLAN is in help text

### DIFF
--- a/doc/src/sgml/ref/create_function.sgml
+++ b/doc/src/sgml/ref/create_function.sgml
@@ -31,7 +31,7 @@ CREATE [ OR REPLACE ] FUNCTION
     | CALLED ON NULL INPUT | RETURNS NULL ON NULL INPUT | STRICT
     | [ EXTERNAL ] SECURITY INVOKER | [ EXTERNAL ] SECURITY DEFINER
     | PARALLEL { UNSAFE | RESTRICTED | SAFE }
-    | EXECUTE ON { ANY | MASTER | ALL SEGMENTS }
+    | EXECUTE ON { ANY | MASTER | ALL SEGMENTS | INITPLAN }
     | COST <replaceable class="parameter">execution_cost</replaceable>
     | ROWS <replaceable class="parameter">result_rows</replaceable>
     | SUPPORT <replaceable class="parameter">support_function</replaceable>


### PR DESCRIPTION
This ensures that create_help.pl can generate help output for CREATE
FUNCTION including the EXECUTE ON INITPLAN option.

Fixes https://github.com/greenplum-db/gpdb/issues/10269.