### PR TITLE
cluster: Update relpages,reltuples on QD

### DIFF
--- a/src/include/commands/vacuum.h
+++ b/src/include/commands/vacuum.h
@@ -18,6 +18,7 @@
 #include "catalog/pg_class.h"
 #include "catalog/pg_statistic.h"
 #include "catalog/pg_type.h"
+#include "cdb/cdbdispatchresult.h"
 #include "nodes/parsenodes.h"
 #include "storage/buf.h"
 #include "storage/lock.h"
@@ -295,6 +296,12 @@ typedef struct
 	int			totalAttr;
 } gp_acquire_correlation_context;
 
+typedef struct VacuumStatsContext
+{
+	List		*updated_stats;
+	int			nsegs;
+} VacuumStatsContext;
+
 /* GUC parameters */
 extern PGDLLIMPORT int default_statistics_target;	/* PGDLLIMPORT for PostGIS */
 extern int	vacuum_freeze_min_age;
@@ -371,5 +378,10 @@ extern Datum gp_acquire_correlations(PG_FUNCTION_ARGS);
 extern Oid gp_acquire_sample_rows_col_type(Oid typid);
 
 extern bool gp_vacuum_needs_update_stats(void);
+
+extern void vacuum_combine_stats(VacuumStatsContext *stats_context,
+								 CdbPgResults *cdb_pgresults,
+								 MemoryContext context);
+extern void vac_update_relstats_from_list(VacuumStatsContext *stats_context);
 
 #endif							/* VACUUM_H */

--- a/src/test/regress/expected/cluster.out
+++ b/src/test/regress/expected/cluster.out
@@ -533,15 +533,13 @@ SELECT * FROM rows WHERE la < a;
 BEGIN;
 SET LOCAL enable_seqscan = false;
 EXPLAIN (COSTS OFF) SELECT * FROM clstr_expression WHERE upper(b) = 'PREFIX3';
-                        QUERY PLAN                         
------------------------------------------------------------
+                             QUERY PLAN                              
+---------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  Bitmap Heap Scan on clstr_expression
-         Recheck Cond: (upper(b) = 'PREFIX3'::text)
-         ->  Bitmap Index Scan on clstr_expression_upper_b
-               Index Cond: (upper(b) = 'PREFIX3'::text)
+   ->  Index Scan using clstr_expression_upper_b on clstr_expression
+         Index Cond: (upper(b) = 'PREFIX3'::text)
  Optimizer: Postgres query optimizer
-(6 rows)
+(4 rows)
 
 SELECT * FROM clstr_expression WHERE upper(b) = 'PREFIX3';
  id | a |    b    
@@ -550,18 +548,14 @@ SELECT * FROM clstr_expression WHERE upper(b) = 'PREFIX3';
 (1 row)
 
 EXPLAIN (COSTS OFF) SELECT * FROM clstr_expression WHERE -a = -3 ORDER BY -a, b;
-                           QUERY PLAN                            
------------------------------------------------------------------
+                             QUERY PLAN                              
+---------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Merge Key: b
-   ->  Sort
-         Sort Key: b COLLATE "C"
-         ->  Bitmap Heap Scan on clstr_expression
-               Recheck Cond: ((- a) = '-3'::integer)
-               ->  Bitmap Index Scan on clstr_expression_minus_a
-                     Index Cond: ((- a) = '-3'::integer)
+   ->  Index Scan using clstr_expression_minus_a on clstr_expression
+         Index Cond: ((- a) = '-3'::integer)
  Optimizer: Postgres query optimizer
-(9 rows)
+(5 rows)
 
 SELECT * FROM clstr_expression WHERE -a = -3 ORDER BY -a, b;
  id  | a |     b     
@@ -585,15 +579,13 @@ SELECT * FROM rows WHERE upper(lb) > upper(b);
 BEGIN;
 SET LOCAL enable_seqscan = false;
 EXPLAIN (COSTS OFF) SELECT * FROM clstr_expression WHERE upper(b) = 'PREFIX3';
-                        QUERY PLAN                         
------------------------------------------------------------
+                             QUERY PLAN                              
+---------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  Bitmap Heap Scan on clstr_expression
-         Recheck Cond: (upper(b) = 'PREFIX3'::text)
-         ->  Bitmap Index Scan on clstr_expression_upper_b
-               Index Cond: (upper(b) = 'PREFIX3'::text)
+   ->  Index Scan using clstr_expression_upper_b on clstr_expression
+         Index Cond: (upper(b) = 'PREFIX3'::text)
  Optimizer: Postgres query optimizer
-(6 rows)
+(4 rows)
 
 SELECT * FROM clstr_expression WHERE upper(b) = 'PREFIX3';
  id | a |    b    
@@ -602,18 +594,14 @@ SELECT * FROM clstr_expression WHERE upper(b) = 'PREFIX3';
 (1 row)
 
 EXPLAIN (COSTS OFF) SELECT * FROM clstr_expression WHERE -a = -3 ORDER BY -a, b;
-                           QUERY PLAN                            
------------------------------------------------------------------
+                             QUERY PLAN                              
+---------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Merge Key: b
-   ->  Sort
-         Sort Key: b COLLATE "C"
-         ->  Bitmap Heap Scan on clstr_expression
-               Recheck Cond: ((- a) = '-3'::integer)
-               ->  Bitmap Index Scan on clstr_expression_minus_a
-                     Index Cond: ((- a) = '-3'::integer)
+   ->  Index Scan using clstr_expression_minus_a on clstr_expression
+         Index Cond: ((- a) = '-3'::integer)
  Optimizer: Postgres query optimizer
-(9 rows)
+(5 rows)
 
 SELECT * FROM clstr_expression WHERE -a = -3 ORDER BY -a, b;
  id  | a |     b     

--- a/src/test/regress/expected/cluster_gp.out
+++ b/src/test/regress/expected/cluster_gp.out
@@ -63,3 +63,38 @@ ABORT;
 -- try cluster again
 CLUSTER cluster_foo USING cluster_ifoo;
 DROP TABLE cluster_foo;
+-- Test that reltuples and relpages are populated on both QE and QD post-CLUSTER.
+CREATE TABLE cluster_stats(a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE INDEX ON cluster_stats(a);
+INSERT INTO cluster_stats SELECT a, a FROM generate_series(1, 100)a;
+ANALYZE cluster_stats;
+SELECT gp_segment_id, relpages, reltuples FROM gp_dist_random('pg_class')
+WHERE relname='cluster_stats'
+UNION
+SELECT -1, relpages, reltuples FROM pg_class
+WHERE relname='cluster_stats';
+ gp_segment_id | relpages | reltuples 
+---------------+----------+-----------
+             1 |        1 |        37
+            -1 |        3 |       100
+             0 |        1 |        38
+             2 |        1 |        25
+(4 rows)
+
+DELETE FROM cluster_stats where a % 3 = 1;
+CLUSTER cluster_stats USING cluster_stats_a_idx;
+SELECT gp_segment_id, relpages, reltuples FROM gp_dist_random('pg_class')
+WHERE relname='cluster_stats'
+UNION
+SELECT -1, relpages, reltuples FROM pg_class
+WHERE relname='cluster_stats';
+ gp_segment_id | relpages | reltuples 
+---------------+----------+-----------
+            -1 |        3 |        66
+             0 |        1 |        27
+             1 |        1 |        26
+             2 |        1 |        13
+(4 rows)
+

--- a/src/test/regress/expected/cluster_gp.out
+++ b/src/test/regress/expected/cluster_gp.out
@@ -64,17 +64,18 @@ ABORT;
 CLUSTER cluster_foo USING cluster_ifoo;
 DROP TABLE cluster_foo;
 -- Test that reltuples and relpages are populated on both QE and QD post-CLUSTER.
-CREATE TABLE cluster_stats(a int, b int);
+-- This test is for heap tables.
+CREATE TABLE cluster_stats_heap(a int, b int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-CREATE INDEX ON cluster_stats(a);
-INSERT INTO cluster_stats SELECT a, a FROM generate_series(1, 100)a;
-ANALYZE cluster_stats;
+CREATE INDEX ON cluster_stats_heap(a);
+INSERT INTO cluster_stats_heap SELECT a, a FROM generate_series(1, 100)a;
+ANALYZE cluster_stats_heap;
 SELECT gp_segment_id, relpages, reltuples FROM gp_dist_random('pg_class')
-WHERE relname='cluster_stats'
+WHERE relname='cluster_stats_heap'
 UNION
 SELECT -1, relpages, reltuples FROM pg_class
-WHERE relname='cluster_stats';
+WHERE relname='cluster_stats_heap';
  gp_segment_id | relpages | reltuples 
 ---------------+----------+-----------
              1 |        1 |        37
@@ -83,13 +84,83 @@ WHERE relname='cluster_stats';
              2 |        1 |        25
 (4 rows)
 
-DELETE FROM cluster_stats where a % 3 = 1;
-CLUSTER cluster_stats USING cluster_stats_a_idx;
+DELETE FROM cluster_stats_heap where a % 3 = 1;
+CLUSTER cluster_stats_heap USING cluster_stats_heap_a_idx;
 SELECT gp_segment_id, relpages, reltuples FROM gp_dist_random('pg_class')
-WHERE relname='cluster_stats'
+WHERE relname='cluster_stats_heap'
 UNION
 SELECT -1, relpages, reltuples FROM pg_class
-WHERE relname='cluster_stats';
+WHERE relname='cluster_stats_heap';
+ gp_segment_id | relpages | reltuples 
+---------------+----------+-----------
+            -1 |        3 |        66
+             0 |        1 |        27
+             1 |        1 |        26
+             2 |        1 |        13
+(4 rows)
+
+-- This test is for ao_row tables.
+CREATE TABLE cluster_stats_ao_row(a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE INDEX ON cluster_stats_ao_row(a);
+INSERT INTO cluster_stats_ao_row SELECT a, a FROM generate_series(1, 100)a;
+ANALYZE cluster_stats_ao_row;
+SELECT gp_segment_id, relpages, reltuples FROM gp_dist_random('pg_class')
+WHERE relname='cluster_stats_ao_row'
+UNION
+SELECT -1, relpages, reltuples FROM pg_class
+WHERE relname='cluster_stats_ao_row';
+ gp_segment_id | relpages | reltuples 
+---------------+----------+-----------
+             1 |        1 |        37
+            -1 |        3 |       100
+             2 |        1 |        25
+             0 |        1 |        38
+(4 rows)
+
+DELETE FROM cluster_stats_ao_row where a % 3 = 1;
+CLUSTER cluster_stats_ao_row USING cluster_stats_ao_row_a_idx;
+SELECT gp_segment_id, relpages, reltuples FROM gp_dist_random('pg_class')
+WHERE relname='cluster_stats_ao_row'
+UNION
+SELECT -1, relpages, reltuples FROM pg_class
+WHERE relname='cluster_stats_ao_row';
+ gp_segment_id | relpages | reltuples 
+---------------+----------+-----------
+            -1 |        3 |        66
+             0 |        1 |        27
+             1 |        1 |        26
+             2 |        1 |        13
+(4 rows)
+
+-- This test is for ao_column tables.
+CREATE TABLE cluster_stats_ao_column(a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE INDEX ON cluster_stats_ao_column(a);
+INSERT INTO cluster_stats_ao_column SELECT a, a FROM generate_series(1, 100)a;
+ANALYZE cluster_stats_ao_column;
+SELECT gp_segment_id, relpages, reltuples FROM gp_dist_random('pg_class')
+WHERE relname='cluster_stats_ao_column'
+UNION
+SELECT -1, relpages, reltuples FROM pg_class
+WHERE relname='cluster_stats_ao_column';
+ gp_segment_id | relpages | reltuples 
+---------------+----------+-----------
+             1 |        1 |        37
+            -1 |        3 |       100
+             2 |        1 |        25
+             0 |        1 |        38
+(4 rows)
+
+DELETE FROM cluster_stats_ao_column where a % 3 = 1;
+CLUSTER cluster_stats_ao_column USING cluster_stats_ao_column_a_idx;
+SELECT gp_segment_id, relpages, reltuples FROM gp_dist_random('pg_class')
+WHERE relname='cluster_stats_ao_column'
+UNION
+SELECT -1, relpages, reltuples FROM pg_class
+WHERE relname='cluster_stats_ao_column';
  gp_segment_id | relpages | reltuples 
 ---------------+----------+-----------
             -1 |        3 |        66

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -48,7 +48,9 @@ test: instr_in_shmem_setup
 test: instr_in_shmem
 
 test: createdb
-test: gp_aggregates gp_aggregates_costs gp_metadata variadic_parameters default_parameters function_extensions spi gp_xml shared_scan update_gp triggers_gp returning_gp gp_types gp_index cluster_gp combocid_gp gp_sort gp_prepared_xacts gp_backend_info
+# run separately, because checks for reltuples and results vary in-presence of concurrent transactions
+test: cluster_gp
+test: gp_aggregates gp_aggregates_costs gp_metadata variadic_parameters default_parameters function_extensions spi gp_xml shared_scan update_gp triggers_gp returning_gp gp_types gp_index combocid_gp gp_sort gp_prepared_xacts gp_backend_info
 test: spi_processed64bit
 test: gp_lock
 test: gp_tablespace_with_faults

--- a/src/test/regress/sql/cluster_gp.sql
+++ b/src/test/regress/sql/cluster_gp.sql
@@ -67,22 +67,65 @@ CLUSTER cluster_foo USING cluster_ifoo;
 DROP TABLE cluster_foo;
 
 -- Test that reltuples and relpages are populated on both QE and QD post-CLUSTER.
-CREATE TABLE cluster_stats(a int, b int);
-CREATE INDEX ON cluster_stats(a);
-INSERT INTO cluster_stats SELECT a, a FROM generate_series(1, 100)a;
-ANALYZE cluster_stats;
+-- This test is for heap tables.
+CREATE TABLE cluster_stats_heap(a int, b int);
+CREATE INDEX ON cluster_stats_heap(a);
+INSERT INTO cluster_stats_heap SELECT a, a FROM generate_series(1, 100)a;
+ANALYZE cluster_stats_heap;
 
 SELECT gp_segment_id, relpages, reltuples FROM gp_dist_random('pg_class')
-WHERE relname='cluster_stats'
+WHERE relname='cluster_stats_heap'
 UNION
 SELECT -1, relpages, reltuples FROM pg_class
-WHERE relname='cluster_stats';
+WHERE relname='cluster_stats_heap';
 
-DELETE FROM cluster_stats where a % 3 = 1;
-CLUSTER cluster_stats USING cluster_stats_a_idx;
+DELETE FROM cluster_stats_heap where a % 3 = 1;
+CLUSTER cluster_stats_heap USING cluster_stats_heap_a_idx;
 
 SELECT gp_segment_id, relpages, reltuples FROM gp_dist_random('pg_class')
-WHERE relname='cluster_stats'
+WHERE relname='cluster_stats_heap'
 UNION
 SELECT -1, relpages, reltuples FROM pg_class
-WHERE relname='cluster_stats';
+WHERE relname='cluster_stats_heap';
+
+-- This test is for ao_row tables.
+CREATE TABLE cluster_stats_ao_row(a int, b int);
+CREATE INDEX ON cluster_stats_ao_row(a);
+INSERT INTO cluster_stats_ao_row SELECT a, a FROM generate_series(1, 100)a;
+ANALYZE cluster_stats_ao_row;
+
+SELECT gp_segment_id, relpages, reltuples FROM gp_dist_random('pg_class')
+WHERE relname='cluster_stats_ao_row'
+UNION
+SELECT -1, relpages, reltuples FROM pg_class
+WHERE relname='cluster_stats_ao_row';
+
+DELETE FROM cluster_stats_ao_row where a % 3 = 1;
+CLUSTER cluster_stats_ao_row USING cluster_stats_ao_row_a_idx;
+
+SELECT gp_segment_id, relpages, reltuples FROM gp_dist_random('pg_class')
+WHERE relname='cluster_stats_ao_row'
+UNION
+SELECT -1, relpages, reltuples FROM pg_class
+WHERE relname='cluster_stats_ao_row';
+
+-- This test is for ao_column tables.
+CREATE TABLE cluster_stats_ao_column(a int, b int);
+CREATE INDEX ON cluster_stats_ao_column(a);
+INSERT INTO cluster_stats_ao_column SELECT a, a FROM generate_series(1, 100)a;
+ANALYZE cluster_stats_ao_column;
+
+SELECT gp_segment_id, relpages, reltuples FROM gp_dist_random('pg_class')
+WHERE relname='cluster_stats_ao_column'
+UNION
+SELECT -1, relpages, reltuples FROM pg_class
+WHERE relname='cluster_stats_ao_column';
+
+DELETE FROM cluster_stats_ao_column where a % 3 = 1;
+CLUSTER cluster_stats_ao_column USING cluster_stats_ao_column_a_idx;
+
+SELECT gp_segment_id, relpages, reltuples FROM gp_dist_random('pg_class')
+WHERE relname='cluster_stats_ao_column'
+UNION
+SELECT -1, relpages, reltuples FROM pg_class
+WHERE relname='cluster_stats_ao_column';


### PR DESCRIPTION
Even though we were sending these stats from QE->QD, we weren't
combining them, nor were we updating QD's pg_class.

Highlights:

(1) Perhaps a bit ugly, but reusing vacuum_combine_stats() and
vac_update_relstats_from_list() on the QD side, just as we reuse
vac_send_relstats_to_qd() on the QE side.

(2) vacuum_combine_stats() now accepts a MemoryContext param for any
on-heap allocation. We pass a vacuum context during vacuum and a cluster
context during cluster.

(3) dispatchCluster() routine to dispatch and update stats thereafter.

Fixes: https://github.com/greenplum-db/gpdb/issues/10489