### PR TITLE
[Releng] Fixup for use generic icw worker name

### DIFF
--- a/concourse/pipelines/templates/gpdb-tpl.yml
+++ b/concourse/pipelines/templates/gpdb-tpl.yml
@@ -430,12 +430,6 @@ resources:
     - gpdb-doc/*
     - README*
 
-- name: clang-toolchain
-  type: registry-image
-  source:
-    tag: 0.3
-    repository: gcr.io/data-orca/clang-toolchain
-
 - name: gpdb7-[[ os_type ]]-build
   type: registry-image
   source:
@@ -587,14 +581,12 @@ jobs:
   plan:
     - get: gpdb_src
       trigger: true
-    - get: clang-toolchain
     - task: check_format
       file: gpdb_src/concourse/tasks/check_format.yml
     - task: clang_tidy
-      image: clang-toolchain
       file: gpdb_src/concourse/tasks/clang_tidy.yml
       {% if use_ICW_workers %}
-      tags: [icw-[[ os_type ]]]
+      tags: [icw-worker]
       {% endif %}
 
 
@@ -711,7 +703,7 @@ jobs:
       - get: gpdb7-[[ os_type ]]-test
   - task: ic_gpdb
     {% if use_ICW_workers %}
-    tags: [icw-[[ os_type ]]]
+    tags: [icw-worker]
     {% endif %}
     file: gpdb_src/concourse/tasks/ic_gpdb.yml
     image: gpdb7-[[ os_type ]]-test
@@ -734,7 +726,7 @@ jobs:
       - get: gpdb7-[[ os_type ]]-test
   - task: ic_gpdb
     {% if use_ICW_workers %}
-    tags: [icw-[[ os_type ]]]
+    tags: [icw-worker]
     {% endif %}
     file: gpdb_src/concourse/tasks/ic_gpdb.yml
     image: gpdb7-[[ os_type ]]-test
@@ -757,7 +749,7 @@ jobs:
       - get: gpdb7-[[ os_type ]]-test
   - task: ic_gpdb
     {% if use_ICW_workers %}
-    tags: [icw-[[ os_type ]]]
+    tags: [icw-worker]
     {% endif %}
     file: gpdb_src/concourse/tasks/ic_gpdb.yml
     image: gpdb7-[[ os_type ]]-test
@@ -785,7 +777,7 @@ jobs:
       - get: gpdb7-[[ os_type ]]-test
   - task: ic_gpdb
     {% if use_ICW_workers %}
-    tags: [icw-[[ os_type ]]]
+    tags: [icw-worker]
     {% endif %}
     file: gpdb_src/concourse/tasks/ic_gpdb.yml
     image: gpdb7-[[ os_type ]]-test
@@ -808,7 +800,7 @@ jobs:
       - get: gpdb7-[[ os_type ]]-test
   - task: ic_gpdb
     {% if use_ICW_workers %}
-    tags: [icw-[[ os_type ]]]
+    tags: [icw-worker]
     {% endif %}
     file: gpdb_src/concourse/tasks/ic_gpdb.yml
     image: gpdb7-[[ os_type ]]-test
@@ -831,7 +823,7 @@ jobs:
       - get: gpdb7-[[ os_type ]]-test
   - task: ic_gpdb
     {% if use_ICW_workers %}
-    tags: [icw-[[ os_type ]]]
+    tags: [icw-worker]
     {% endif %}
     file: gpdb_src/concourse/tasks/ic_gpdb.yml
     image: gpdb7-[[ os_type ]]-test
@@ -854,7 +846,7 @@ jobs:
       - get: gpdb7-[[ os_type ]]-test
   - task: ic_gpdb
     {% if use_ICW_workers %}
-    tags: [icw-[[ os_type ]]]
+    tags: [icw-worker]
     {% endif %}
     file: gpdb_src/concourse/tasks/ic_gpdb.yml
     image: gpdb7-[[ os_type ]]-test
@@ -876,7 +868,7 @@ jobs:
       - get: gpdb7-[[ os_type ]]-test
   - task: ic_gpdb
     {% if use_ICW_workers %}
-    tags: [icw-[[ os_type ]]]
+    tags: [icw-worker]
     {% endif %}
     file: gpdb_src/concourse/tasks/ic_gpdb.yml
     image: gpdb7-[[ os_type ]]-test


### PR DESCRIPTION
The code changes is missing for:when run icw jobs, it will use generic tagged worker: icw-worker instead of icw-[os_type]

Also remove the work around for: task clang_tidy has failure: image check failed. Do not need to define the image resource since the core reason is the newly created worker has network issue, and now it is fixed, so no need for this code change

[GPR-1163]

Authored-by: Shaoqi Bai <bshaoqi@vmware.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
