### PR TITLE
Set the GPHOME_CLIENTS correctly in the script

### DIFF
--- a/gpAux/client/scripts/greenplum_clients_path.sh
+++ b/gpAux/client/scripts/greenplum_clients_path.sh
@@ -1,4 +1,29 @@
-GPHOME_CLIENTS=`pwd`
+#!/usr/bin/env bash
+
+if test -n "${ZSH_VERSION:-}"; then
+    # zsh
+    SCRIPT_PATH="${(%):-%x}"
+elif test -n "${BASH_VERSION:-}"; then
+    # bash
+    SCRIPT_PATH="${BASH_SOURCE[0]}"
+else
+    # Unknown shell, hope below works.
+    # Tested with dash
+    result=$(lsof -p $$ -Fn | tail --lines=1 | xargs --max-args=2 | cut --delimiter=' ' --fields=2)
+    SCRIPT_PATH=${result#n}
+fi
+
+if test -z "$SCRIPT_PATH"; then
+    echo "The shell cannot be identified. \$GPHOME_CLIENTS may not be set correctly." >&2
+fi
+SCRIPT_DIR="$(cd "$(dirname "${SCRIPT_PATH}")" >/dev/null 2>&1 && pwd)"
+
+if [ ! -L "${SCRIPT_DIR}" ]; then
+    GPHOME_CLIENTS=${SCRIPT_DIR}
+else
+    GPHOME_CLIENTS=$(readlink "${SCRIPT_DIR}")
+fi
+
 PATH=${GPHOME_CLIENTS}/bin:${PATH}
 PYTHONPATH=${GPHOME_CLIENTS}/bin/ext:${PYTHONPATH}
 
@@ -19,8 +44,5 @@ else
 fi
 
 if [ "$1" != "-q" ]; then
-  type python >/dev/null 2>&1
-  if [ $? -ne 0 ]; then
-    echo "Warning: Python not found.  Python-2.5.1 or better is required to run gpload."
-  fi
+  command -v python >/dev/null || echo "Warning: Python not found, which is required to run gpload."
 fi

--- a/gpAux/client/scripts/greenplum_clients_path.sh
+++ b/gpAux/client/scripts/greenplum_clients_path.sh
@@ -1,5 +1,3 @@
-#!/usr/bin/env bash
-
 if test -n "${ZSH_VERSION:-}"; then
     # zsh
     SCRIPT_PATH="${(%):-%x}"
@@ -44,5 +42,5 @@ else
 fi
 
 if [ "$1" != "-q" ]; then
-  command -v python >/dev/null || echo "Warning: Python not found, which is required to run gpload."
+  command -v python3 >/dev/null || echo "Warning: Python 3 not found, which is required to run gpload."
 fi


### PR DESCRIPTION
The greenplum_clients_path.sh could not be sourced in other directories before, copy greenplum_path.sh's codes to fix it.

```
$ cat /usr/local/greenplum-clients-devel/greenplum_clients_path.sh
GPHOME_CLIENTS=`pwd`
PATH=${GPHOME_CLIENTS}/bin:${GPHOME_CLIENTS}/ext/python/bin:${PATH}
...

$ set -x

$ . /usr/local/greenplum-clients-devel/greenplum_clients_path.sh
+ . /usr/local/greenplum-clients-devel/greenplum_clients_path.sh
+++ pwd
++ GPHOME_CLIENTS=/tmp/build/b251a50d
++ PATH=/tmp/build/b251a50d/bin:/tmp/build/b251a50d/ext/python/bin:...
...
```
