### PR TITLE
(main branch) gpexpand.status_detail should be distributed by "table_oid".

### DIFF
--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -299,7 +299,7 @@ status_detail_table_sql = """CREATE TABLE gpexpand.status_detail
                           status text,
                           expansion_started timestamp,
                           expansion_finished timestamp,
-                          source_bytes numeric ) """
+                          source_bytes numeric ) distributed by (table_oid)"""
 # gpexpand views
 progress_view_simple_sql = """CREATE VIEW gpexpand.expansion_progress AS
 SELECT


### PR DESCRIPTION
The table gpexpand.status_detail used by gpexpand should be distributed by "table_oid", to avoid the updating workload burden of tens thounsand tables in a segment, concentrated on only one single segment with the prior distribution policy (distributed by dbname).

Authored-by: Peng Han <phan@vmware.com>

------

main branch version of https://github.com/greenplum-db/gpdb/pull/14690
