### PR TITLE
Fix resgroup init error when there is a lot of cores in cpuset.cpus

### DIFF
--- a/src/backend/utils/resgroup/cgroup.c
+++ b/src/backend/utils/resgroup/cgroup.c
@@ -394,7 +394,7 @@ void
 readStr(Oid group, BaseDirType base, CGroupComponentType component,
 		const char *filename, char *str, int len)
 {
-	char data[MAX_INT_STRING_LEN];
+	char data[MAX_CGROUP_CONTENTLEN];
 	size_t data_size = sizeof(data);
 	char path[MAX_CGROUP_PATHLEN];
 	size_t path_size = sizeof(path);

--- a/src/include/utils/cgroup.h
+++ b/src/include/utils/cgroup.h
@@ -25,6 +25,7 @@
 #define GPDB_SYSTEM_CGROUP 		6441
 
 #define MAX_CGROUP_PATHLEN 256
+#define MAX_CGROUP_CONTENTLEN 1024  
 
 #define CGROUP_ERROR(...) elog(ERROR, __VA_ARGS__)
 #define CGROUP_CONFIG_ERROR(...) \


### PR DESCRIPTION
When gpdb calls `InitResGroups` to init a postgres backend,  gpdb will first call function `getcpuset_v1` to get entire cpuset given to gpdb. And then call function `setcpuset_v1` to write cpuset to cgroup path.

However `getcpuset_v1` call function `readStr`(in src/backend/utils/resgroup/cgroup.c). Function `readStr` is implemmented as this:

```
void
readStr(Oid group, BaseDirType base, CGroupComponentType component,
		const char *filename, char *str, int len)
{
	char data[MAX_INT_STRING_LEN];
	size_t data_size = sizeof(data);
	char path[MAX_CGROUP_PATHLEN];
	size_t path_size = sizeof(path);
	buildPath(group, base, component, filename, path, path_size);
	readData(path, data, data_size);
	StrNCpy(str, data, len);
}
```

**Pay Attention to: char data[MAX_INT_STRING_LEN];**
As we see from the code, the max string length can be readed by readStr is MAX_INT_STRING_LEN, which is 20.  
If the os assgin cpu set to gpdb in /sys/fs/cgroup/cpuset/gpdb/cpuset.cpus is '2,4,11,18,26-27,34,39-42',  which  string length is more than 20.  The cpuset readed by readStr will be truncated to '2,4,11,18,26-27,34,3'. Then gpdb cannot write correct cpuset to cgroup path and InitResGroups will fail.

error like this:

```
2023-01-09 22:22:55.222604 CST,,,p31761,th2097318016,,,,0,con2,,seg-1,,,,sx1,"ERROR","58M01","failed to acquire resources on one or more segments","FATAL:  can't write data to file '/sys/fs/cgroup/cpuset/gpdb/1/cpuset.cpus': Invalid argument 
 (seg1 10.0.2.33:7003)",,,,,,0,,"cdbgang_async.c",269,
```

**In the other hand, the buffer size is always MAX_CGROUP_PATHLEN in function writeStr and other places related with cgroupset process.**

```
void
writeStr(Oid group, BaseDirType base, CGroupComponentType component,
		 const char *filename, const char *strValue)
{
	char path[MAX_CGROUP_PATHLEN];
	size_t path_size = sizeof(path);
	buildPath(group, base, component, filename, path, path_size);
	writeData(path, strValue, strlen(strValue));
}

static int
lockcgroup_v1(Oid group, CGroupComponentType component, bool block)
{
	char path[MAX_CGROUP_PATHLEN];
	size_t path_size = sizeof(path);
	buildPath(group, BASEDIR_GPDB, component, "", path, path_size);
	return lockDir(path, block);
}

```

So I strongly recommend changing buffer size in readStr to MAX_CGROUP_PATHLEN. Please hava a look at this. Thanks.
