### PR TITLE
[6X] psql: Ensure EXECUTE ON INITPLAN is in help text

### DIFF
--- a/doc/src/sgml/ref/create_function.sgml
+++ b/doc/src/sgml/ref/create_function.sgml
@@ -29,7 +29,7 @@ CREATE [ OR REPLACE ] FUNCTION
     | IMMUTABLE | STABLE | VOLATILE | [ NOT ] LEAKPROOF
     | CALLED ON NULL INPUT | RETURNS NULL ON NULL INPUT | STRICT
     | [ EXTERNAL ] SECURITY INVOKER | [ EXTERNAL ] SECURITY DEFINER
-    | EXECUTE ON { ANY | MASTER | ALL SEGMENTS }
+    | EXECUTE ON { ANY | MASTER | ALL SEGMENTS | INITPLAN }
     | COST <replaceable class="parameter">execution_cost</replaceable>
     | ROWS <replaceable class="parameter">result_rows</replaceable>
     | SET <replaceable class="parameter">configuration_parameter</replaceable> { TO <replaceable class="parameter">value</replaceable> | = <replaceable class="parameter">value</replaceable> | FROM CURRENT }


### PR DESCRIPTION
This backports 7X commit: 87db41efcdf71b24319896de582847d2ed16038d
with a trivial conflict.

Original commit message follows:

This ensures that create_help.pl can generate help output for CREATE
FUNCTION including the EXECUTE ON INITPLAN option.

Fixes https://github.com/greenplum-db/gpdb/issues/10269
