### PR TITLE
[6X] flush out comment on upgrading sequences

### DIFF
--- a/contrib/pg_upgrade/version_old_8_3.c
+++ b/contrib/pg_upgrade/version_old_8_3.c
@@ -700,6 +700,10 @@ old_8_3_invalidate_bpchar_pattern_ops_indexes(ClusterInfo *cluster,
  *	value and 'is_called' from the old database.  This is safe to run
  *	by pg_upgrade because sequence files are not transferred from the old
  *	server, even in link mode.
+ *
+ *	XXX: The below script is generated "and" automatically applied by
+ *  pg_upgrade. The script upgrades sequences and preserve their current
+ *  values. The command line output "Adjusting sequences" can confirm this.
  */
 char *
 old_8_3_create_sequence_script(ClusterInfo *cluster)


### PR DESCRIPTION
Flush out the comment on upgrading sequences to make it obvious that pg_upgrade automatically applies the `adjust_sequences.sql` script. This comment can be very useful to future developers. This comment is not needed on main (7X) as the script is no longer used. 
