### PR TITLE
[Releng] [7X] Resource reduced-frequency-trigger's stop should be later than start

### DIFF
--- a/concourse/vars/common_prod.yml
+++ b/concourse/vars/common_prod.yml
@@ -18,7 +18,7 @@ gpdb-git-remote: https://github.com/greenplum-db/gpdb.git
 rc-build-type: debug
 rc-build-type-gcs: ".debug"
 reduced-frequency-trigger-start: 1:00 AM
-reduced-frequency-trigger-stop: 0:59 AM
+reduced-frequency-trigger-stop: 2:00 AM
 configure_flags: "--enable-cassert --enable-tap-tests"
 configure_flags_with_extensions: "--enable-cassert --enable-tap-tests --enable-debug-extensions"
 use_ccache: true


### PR DESCRIPTION
For time concourse resource, stop should be later than start to make it work

[GPR-1081]

Authored-by: Shaoqi Bai <bshaoqi@vmware.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
