### PR TITLE
AM: don't do ao/aoco_dml_finish() as finish_bulk_insert()

### DIFF
--- a/src/backend/access/aocs/aocsam_handler.c
+++ b/src/backend/access/aocs/aocsam_handler.c
@@ -1096,10 +1096,8 @@ aoco_tuple_lock(Relation relation, ItemPointer tid, Snapshot snapshot,
 static void
 aoco_finish_bulk_insert(Relation relation, int options)
 {
-	aoco_dml_finish(relation);
+	/* nothing for co tables */
 }
-
-
 
 
 /* ------------------------------------------------------------------------

--- a/src/backend/access/appendonly/appendonlyam_handler.c
+++ b/src/backend/access/appendonly/appendonlyam_handler.c
@@ -973,7 +973,7 @@ appendonly_tuple_lock(Relation relation, ItemPointer tid, Snapshot snapshot,
 static void
 appendonly_finish_bulk_insert(Relation relation, int options)
 {
-	appendonly_dml_finish(relation);
+	/* nothing for ao tables */
 }
 
 

--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -4747,6 +4747,9 @@ CopyFrom(CopyState cstate)
 
 	ExecCloseIndices(target_resultRelInfo);
 
+	if (target_resultRelInfo->ri_RelationDesc->rd_tableam)
+		table_dml_finish(target_resultRelInfo->ri_RelationDesc);
+
 	/* Close all the partitioned tables, leaf partitions, and their indices */
 	if (proute)
 		ExecCleanupTupleRouting(mtstate, proute);

--- a/src/backend/commands/createas.c
+++ b/src/backend/commands/createas.c
@@ -759,6 +759,9 @@ intorel_shutdown(DestReceiver *self)
 
 	table_finish_bulk_insert(myState->rel, myState->ti_options);
 
+	if (myState->rel->rd_tableam)
+		table_dml_finish(myState->rel);
+
 	/* close rel, but keep lock until commit */
 	table_close(myState->rel, NoLock);
 	myState->rel = NULL;

--- a/src/backend/commands/matview.c
+++ b/src/backend/commands/matview.c
@@ -664,6 +664,9 @@ transientrel_shutdown(DestReceiver *self)
 
 	table_finish_bulk_insert(myState->transientrel, myState->ti_options);
 
+	if (myState->transientrel->rd_tableam)
+		table_dml_finish(myState->transientrel);
+
 	/* close transientrel, but keep lock until commit */
 	table_close(myState->transientrel, NoLock);
 	myState->transientrel = NULL;

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -6599,6 +6599,9 @@ ATRewriteTable(AlteredTableInfo *tab, Oid OIDNewHeap, LOCKMODE lockmode)
 
 		table_finish_bulk_insert(newrel, ti_options);
 
+		if (newrel->rd_tableam)
+			table_dml_finish(newrel);
+
 		table_close(newrel, NoLock);
 	}
 }


### PR DESCRIPTION
They are not the same thing, ao/aoco_dml_finish() should use the new table AM API introduced by:

	commit 4f85ccb3154456ac5e5fdc6aedb30ca632b44028
	Author: Soumyadeep Chakraborty <soumyadeep2007@gmail.com>
	Date:   Sat Oct 29 17:24:19 2022 -0700

	    ao/co: Tableam functions for DML init/finish

	    Introduce dedicated dml init and finish functions to the table AM API to
	    address the special need for command-bound state that AO/CO tables have.
	    We already had the guts, this commit just provides the entry-point from
	    the table AM.
