### PR TITLE
Remove result tuple bound push down if qual

### DIFF
--- a/src/test/regress/expected/bfv_subquery.out
+++ b/src/test/regress/expected/bfv_subquery.out
@@ -511,3 +511,47 @@ select count(*) from pg_backend_pid() b(a) where b.a % 100000 in (select a from 
 (1 row)
 
 drop table t1;
+-- Test filter of RESULT node with a LIMIT parent
+-- Historically, when ORCA generates a RESULT node with a LIMIT parent, 
+-- the parent node's tuple bound is pushed down to the RESULT node's
+-- child node. This could cause the query to return a subset of the 
+-- actual result, if the RESULT node has a filter. This is because the
+-- tuple bound was applied before the filter. 
+-- Now, we allow tuple bound push down only if the RESULT node DOES NOT
+-- have a filter.
+-- start_ignore
+drop table if exists with_test1;
+NOTICE:  table "with_test1" does not exist, skipping
+drop table if exists with_test2;
+NOTICE:  table "with_test2" does not exist, skipping
+create table with_test1 (i int, value int) distributed by (i);
+insert into with_test1 select i%10, i%30 from generate_series(0, 99) i;
+create table with_test2 (i int, value int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into with_test2 select i%100, i%300 from generate_series(0, 999) i;
+-- end_ignore
+with my_group_sum(i, total) as (select i, sum(value) from with_test1 group by i)
+select with_test2.* from with_test2
+where value < all (select total from my_group_sum where my_group_sum.i = with_test2.i)
+order by 1,2
+limit 15;
+ i | value 
+---+-------
+ 0 |     0
+ 0 |     0
+ 0 |     0
+ 0 |     0
+ 1 |     1
+ 1 |     1
+ 1 |     1
+ 1 |     1
+ 2 |     2
+ 2 |     2
+ 2 |     2
+ 2 |     2
+ 2 |   102
+ 2 |   102
+ 2 |   102
+(15 rows)
+

--- a/src/test/regress/expected/bfv_subquery_optimizer.out
+++ b/src/test/regress/expected/bfv_subquery_optimizer.out
@@ -506,3 +506,47 @@ select count(*) from pg_backend_pid() b(a) where b.a % 100000 in (select a from 
 (1 row)
 
 drop table t1;
+-- Test filter of RESULT node with a LIMIT parent
+-- Historically, when ORCA generates a RESULT node with a LIMIT parent, 
+-- the parent node's tuple bound is pushed down to the RESULT node's
+-- child node. This could cause the query to return a subset of the 
+-- actual result, if the RESULT node has a filter. This is because the
+-- tuple bound was applied before the filter. 
+-- Now, we allow tuple bound push down only if the RESULT node DOES NOT
+-- have a filter.
+-- start_ignore
+drop table if exists with_test1;
+NOTICE:  table "with_test1" does not exist, skipping
+drop table if exists with_test2;
+NOTICE:  table "with_test2" does not exist, skipping
+create table with_test1 (i int, value int) distributed by (i);
+insert into with_test1 select i%10, i%30 from generate_series(0, 99) i;
+create table with_test2 (i int, value int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into with_test2 select i%100, i%300 from generate_series(0, 999) i;
+-- end_ignore
+with my_group_sum(i, total) as (select i, sum(value) from with_test1 group by i)
+select with_test2.* from with_test2
+where value < all (select total from my_group_sum where my_group_sum.i = with_test2.i)
+order by 1,2
+limit 15;
+ i | value 
+---+-------
+ 0 |     0
+ 0 |     0
+ 0 |     0
+ 0 |     0
+ 1 |     1
+ 1 |     1
+ 1 |     1
+ 1 |     1
+ 2 |     2
+ 2 |     2
+ 2 |     2
+ 2 |     2
+ 2 |   102
+ 2 |   102
+ 2 |   102
+(15 rows)
+


### PR DESCRIPTION
**Issue:**
https://github.com/greenplum-db/gpdb/issues/10803
When ORCA generates a RESULT node with a LIMIT parent, the query returns a subset of the actual result.

**Root cause:**
When ORCA generates a RESULT node with a LIMIT parent, the parent node's tuple bound is pushed down to the RESULT node's child node. This is expected unless the RESULT node has a filter. The filter is supposed to be applied before the tuple bound, instead it's currently applied after the tuple bound. This leads to the query returning a subset of the actual result.

**Example:**
Consider this plan shape --

```
->  Limit
	 ->  Result
	       Filter: (SubPlan 1)
	       ->  Sort
		     ...
	       SubPlan 1
		     ...
```

The RESULT node has a LIMIT parent and a SORT child. The correct procedure should be: (1) sort the relation, (2) apply the filter to the sorted relation and (3) apply limit to the filtered relation. But instead, the limit was applied before the filter to the relation.

**Solution:**
When executing the plan, we allow tuple bound push down only if the RESULT node DOES NOT has a filter condition. If the RESULT node has a non-NULL QUAL, we don't apply the tuple bound to its child node.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
