### PR TITLE
Fixed Resource management DDL report "WARNING: unrecognized node type" when log_statement='ddl'.

### DIFF
--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -3935,6 +3935,15 @@ GetCommandLogLevel(Node *parsetree)
 			}
 			break;
 
+		case T_CreateResourceGroupStmt:
+		case T_AlterResourceGroupStmt:
+		case T_DropResourceGroupStmt:
+		case T_CreateQueueStmt:
+		case T_AlterQueueStmt:
+		case T_DropQueueStmt:
+			lev = LOGSTMT_DDL;
+			break;
+
 		default:
 			elog(WARNING, "unrecognized node type: %d",
 				 (int) nodeTag(parsetree));

--- a/src/test/regress/expected/guc_gp.out
+++ b/src/test/regress/expected/guc_gp.out
@@ -729,3 +729,13 @@ SELECT count(nspname) FROM gp_dist_random('pg_namespace') WHERE nspname LIKE 'pg
 -- Cleanup
 DROP TABLE just_a_temp_table;
 RESET search_path;
+-- Test for resource management commands on log_statement='ddl'
+-- Modify log_statement to 'ddl'.
+SET log_statement = 'ddl';
+-- We don't really modify resources config.
+ALTER RESOURCE GROUP default_group SET concurrency -1;
+ERROR:  concurrency range is [0, 'max_connections']
+ALTER RESOURCE QUEUE pg_default ACTIVE THRESHOLD -10;
+ERROR:  active threshold cannot be less than -1 or equal to 0
+-- Reset
+RESET log_statement;

--- a/src/test/regress/sql/guc_gp.sql
+++ b/src/test/regress/sql/guc_gp.sql
@@ -422,3 +422,12 @@ SELECT count(nspname) FROM gp_dist_random('pg_namespace') WHERE nspname LIKE 'pg
 DROP TABLE just_a_temp_table;
 RESET search_path;
 
+-- Test for resource management commands on log_statement='ddl'
+-- Modify log_statement to 'ddl'.
+SET log_statement = 'ddl';
+-- We don't really modify resources config.
+ALTER RESOURCE GROUP default_group SET concurrency -1;
+ALTER RESOURCE QUEUE pg_default ACTIVE THRESHOLD -10;
+-- Reset
+RESET log_statement;
+


### PR DESCRIPTION
Fixed Resource management DDL report "WARNING: unrecognized node type" when log_statement='ddl'.

The `LogStmtLevel GetCommandLogLevel(Node *parsetree)` function lacks `NodeTag` handling for resource management commands.

Recurrence test case:

1. Modify GPDB's configurations:
```bash
# Modify log_statement to 'ddl':
gpconfig -c log_statement -v 'ddl'
# Reload configurations:
gpstop -u
```

2. Execute query:
```
postgres=# show gp_resource_manager ;
 gp_resource_manager
---------------------
 queue
(1 row)

postgres=# alter resource group admin_group set concurrency 10;
WARNING:  unrecognized node type: 659
ALTER RESOURCE GROUP

postgres=# alter resource queue pg_default without (memory_limit);
WARNING:  unrecognized node type: 655
ALTER QUEUE
```

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
