### PR TITLE
Add a new type "none" for gp_resource_manager to indicate do not use any resource manager

### DIFF
--- a/contrib/extprotocol/expected/exttableext.out
+++ b/contrib/extprotocol/expected/exttableext.out
@@ -1558,7 +1558,6 @@ ERROR:  protocol attribute "validatorproc" not recognized
     -- Create a non-privileged user demoprot_nopriv
     drop role if exists demoprot_nopriv;
     create role demoprot_nopriv with login ;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 -- Test 92: Rename existing protocol
     DROP FUNCTION IF EXISTS url_validator();
     CREATE OR REPLACE FUNCTION url_validator() RETURNS void AS

--- a/contrib/file_fdw/output/file_fdw.source
+++ b/contrib/file_fdw/output/file_fdw.source
@@ -8,9 +8,7 @@ DROP ROLE IF EXISTS regress_file_fdw_superuser, regress_file_fdw_user, regress_n
 RESET client_min_messages;
 CREATE ROLE regress_file_fdw_superuser LOGIN SUPERUSER; -- is a superuser
 CREATE ROLE regress_file_fdw_user LOGIN;                -- has priv and user mapping
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 CREATE ROLE regress_no_priv_user LOGIN;                 -- has priv but no user mapping
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 -- Install file_fdw
 CREATE EXTENSION file_fdw;
 -- regress_file_fdw_superuser owns fdw-related objects

--- a/contrib/file_fdw/output/file_fdw_optimizer.source
+++ b/contrib/file_fdw/output/file_fdw_optimizer.source
@@ -8,9 +8,7 @@ DROP ROLE IF EXISTS regress_file_fdw_superuser, regress_file_fdw_user, regress_n
 RESET client_min_messages;
 CREATE ROLE regress_file_fdw_superuser LOGIN SUPERUSER; -- is a superuser
 CREATE ROLE regress_file_fdw_user LOGIN;                -- has priv and user mapping
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 CREATE ROLE regress_no_priv_user LOGIN;                 -- has priv but no user mapping
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 -- Install file_fdw
 CREATE EXTENSION file_fdw;
 -- regress_file_fdw_superuser owns fdw-related objects

--- a/contrib/passwordcheck/expected/passwordcheck.out
+++ b/contrib/passwordcheck/expected/passwordcheck.out
@@ -1,6 +1,5 @@
 LOAD 'passwordcheck';
 CREATE USER regress_user1;
-psql:passwordcheck.sql:2: NOTICE:  resource queue required -- using default resource queue "pg_default"
 -- ok
 ALTER USER regress_user1 PASSWORD 'a_nice_long_password';
 -- error: too short

--- a/gpMgmt/bin/gpconfig
+++ b/gpMgmt/bin/gpconfig
@@ -168,8 +168,8 @@ class Guc:
                 msg = GpResGroup().validate_v2()
                 if msg is not None:
                     return msg
-            elif newval != "'queue'":
-                return "the value of gp_resource_manager must be 'group' or 'group-v2' or 'queue'"
+            elif newval != "'queue'" and newval != "'none'":
+                return "the value of gp_resource_manager must be 'none', 'queue', 'group', or 'group-v2'"
 
         elif self.name == 'unix_socket_permissions':
             if newval[0] != '0':

--- a/src/backend/cdb/cdbvars.c
+++ b/src/backend/cdb/cdbvars.c
@@ -513,6 +513,7 @@ gpvars_check_gp_resource_manager_policy(char **newval, void **extra, GucSource s
 {
 	if (*newval == NULL ||
 		*newval[0] == 0 ||
+		!pg_strcasecmp("none", *newval) ||
 		!pg_strcasecmp("queue", *newval) ||
 		!pg_strcasecmp("group", *newval) ||
 		!pg_strcasecmp("group-v2", *newval))
@@ -526,7 +527,9 @@ void
 gpvars_assign_gp_resource_manager_policy(const char *newval, void *extra)
 {
 	if (newval == NULL || newval[0] == 0)
-		Gp_resource_manager_policy = RESOURCE_MANAGER_POLICY_QUEUE;
+		Gp_resource_manager_policy = RESOURCE_MANAGER_POLICY_NONE;
+	else if (!pg_strcasecmp("none", newval))
+		Gp_resource_manager_policy = RESOURCE_MANAGER_POLICY_NONE;
 	else if (!pg_strcasecmp("queue", newval))
 		Gp_resource_manager_policy = RESOURCE_MANAGER_POLICY_QUEUE;
 	else if (!pg_strcasecmp("group", newval))
@@ -549,6 +552,8 @@ gpvars_show_gp_resource_manager_policy(void)
 {
 	switch (Gp_resource_manager_policy)
 	{
+		case RESOURCE_MANAGER_POLICY_NONE:
+			return "none";
 		case RESOURCE_MANAGER_POLICY_QUEUE:
 			return "queue";
 		case RESOURCE_MANAGER_POLICY_GROUP:

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -4380,10 +4380,10 @@ struct config_string ConfigureNamesString_gp[] =
 	{
 		{"gp_resource_manager", PGC_POSTMASTER, RESOURCES,
 			gettext_noop("Sets the type of resource manager."),
-			gettext_noop("Only support \"queue\" and \"group\" for now.")
+			gettext_noop("Only support \"none\", \"queue\", \"group\" and \"group-v2\" for now.")
 		},
 		&gp_resource_manager_str,
-		"queue",
+		"none",
 		gpvars_check_gp_resource_manager_policy,
 		gpvars_assign_gp_resource_manager_policy,
 		gpvars_show_gp_resource_manager_policy,

--- a/src/backend/utils/resource_manager/memquota.c
+++ b/src/backend/utils/resource_manager/memquota.c
@@ -28,7 +28,11 @@
 #include "parser/parsetree.h"
 #include "tcop/pquery.h"
 
-ResManagerMemoryPolicy		gp_resmanager_memory_policy_default = RESMANAGER_MEMORY_POLICY_NONE;
+/**
+ * When resource manager is none, we use statement_mem as the memory of a query,
+ * use RESMANAGER_MEMORY_POLICY_EAGER_FREE as default memory policy
+ */
+ResManagerMemoryPolicy		gp_resmanager_memory_policy_default = RESMANAGER_MEMORY_POLICY_EAGER_FREE;
 bool						gp_log_resmanager_memory_default = false;
 int							gp_resmanager_memory_policy_auto_fixed_mem_default = 100;
 bool						gp_resmanager_print_operator_memory_limits_default = false;
@@ -907,6 +911,10 @@ ResourceManagerGetQueryMemoryLimit(PlannedStmt* stmt)
 	else if (IsResGroupEnabled())
 		return ResourceGroupGetQueryMemoryLimit();
 
-	/* RG FIXME: should we return statement_mem every time? */
+	/*
+	 * we also use statment_mem to control memory if do not use any resource manager,
+	 * otherwise plan->operatorMemKB will be set to 0 and use work_mem to control memory in
+	 * agg operation, hash operation and so on.
+	 */
 	return (uint64) statement_mem * 1024L;
 }

--- a/src/include/utils/resource_manager.h
+++ b/src/include/utils/resource_manager.h
@@ -40,6 +40,7 @@
 
 typedef enum
 {
+	RESOURCE_MANAGER_POLICY_NONE,			/* Do not use any resource manager*/
 	RESOURCE_MANAGER_POLICY_QUEUE,
 	RESOURCE_MANAGER_POLICY_GROUP,			/* Linux Cgroup v1 */
 	RESOURCE_MANAGER_POLICY_GROUP_V2,		/* Linux Cgroup v2 */

--- a/src/test/isolation2/Makefile
+++ b/src/test/isolation2/Makefile
@@ -62,7 +62,7 @@ clean distclean:
 
 install: all gpdiff.pl gpstringsubs.pl
 
-installcheck: install installcheck-parallel-retrieve-cursor installcheck-ic-tcp installcheck-ic-proxy
+installcheck: install installcheck-resource-queue installcheck-parallel-retrieve-cursor installcheck-ic-tcp installcheck-ic-proxy
 	$(pg_isolation2_regress_installcheck) --init-file=$(top_builddir)/src/test/regress/init_file --init-file=./init_file_isolation2 --schedule=$(srcdir)/isolation2_schedule
 
 installcheck-resgroup: install
@@ -86,3 +86,6 @@ installcheck-ic-proxy: install
 ifeq ($(findstring gp_interconnect_type=proxy,$(PGOPTIONS)),gp_interconnect_type=proxy)
 	$(pg_isolation2_regress_installcheck) $(EXTRA_REGRESS_OPTS) --init-file=$(top_builddir)/src/test/regress/init_file --init-file=./init_file_isolation2 --bindir='$(bindir)' --inputdir=$(srcdir) --schedule=$(srcdir)/isolation2_ic_proxy_schedule
 endif
+
+installcheck-resource-queue: install
+	$(pg_isolation2_regress_installcheck) $(EXTRA_REGRESS_OPTS) --init-file=$(top_builddir)/src/test/regress/init_file --init-file=./init_file_isolation2  --bindir='$(bindir)' --inputdir=$(srcdir) --dbname=isolation2resourcequeue --schedule=$(srcdir)/isolation2_resqueue_schedule

--- a/src/test/isolation2/expected/resource_manager_restore_to_none.out
+++ b/src/test/isolation2/expected/resource_manager_restore_to_none.out
@@ -1,0 +1,36 @@
+!\retcode gpconfig -c gp_resource_manager -v none;
+-- start_ignore
+20230110:23:13:41:403282 gpconfig:ubuntu:gpadmin-[INFO]:-completed successfully with parameters '-c gp_resource_manager -v none'
+
+-- end_ignore
+(exited with code 0)
+!\retcode gpstop -ari;
+-- start_ignore
+20230110:23:13:41:403839 gpstop:ubuntu:gpadmin-[INFO]:-Starting gpstop with args: -ari
+20230110:23:13:41:403839 gpstop:ubuntu:gpadmin-[INFO]:-Gathering information and validating the environment...
+20230110:23:13:41:403839 gpstop:ubuntu:gpadmin-[INFO]:-Obtaining Greenplum Coordinator catalog information
+20230110:23:13:41:403839 gpstop:ubuntu:gpadmin-[INFO]:-Obtaining Segment details from coordinator...
+20230110:23:13:41:403839 gpstop:ubuntu:gpadmin-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 7.0.0-alpha.0+dev.16142.g1f3e5a0825 build dev'
+20230110:23:13:41:403839 gpstop:ubuntu:gpadmin-[INFO]:-Commencing Coordinator instance shutdown with mode='immediate'
+20230110:23:13:41:403839 gpstop:ubuntu:gpadmin-[INFO]:-Coordinator segment instance directory=/home/gpadmin/zxj/workspace/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
+20230110:23:13:41:403839 gpstop:ubuntu:gpadmin-[INFO]:-Attempting forceful termination of any leftover coordinator process
+20230110:23:13:41:403839 gpstop:ubuntu:gpadmin-[INFO]:-Terminating processes for segment /home/gpadmin/zxj/workspace/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
+20230110:23:13:41:403839 gpstop:ubuntu:gpadmin-[INFO]:-Stopping coordinator standby host ubuntu mode=immediate
+20230110:23:13:42:403839 gpstop:ubuntu:gpadmin-[INFO]:-Successfully shutdown standby process on ubuntu
+20230110:23:13:42:403839 gpstop:ubuntu:gpadmin-[INFO]:-Targeting dbid [2, 5, 3, 6, 4, 7] for shutdown
+20230110:23:13:42:403839 gpstop:ubuntu:gpadmin-[INFO]:-Commencing parallel primary segment instance shutdown, please wait...
+20230110:23:13:42:403839 gpstop:ubuntu:gpadmin-[INFO]:-0.00% of jobs completed
+20230110:23:13:43:403839 gpstop:ubuntu:gpadmin-[INFO]:-100.00% of jobs completed
+20230110:23:13:43:403839 gpstop:ubuntu:gpadmin-[INFO]:-Commencing parallel mirror segment instance shutdown, please wait...
+20230110:23:13:43:403839 gpstop:ubuntu:gpadmin-[INFO]:-0.00% of jobs completed
+20230110:23:13:44:403839 gpstop:ubuntu:gpadmin-[INFO]:-100.00% of jobs completed
+20230110:23:13:44:403839 gpstop:ubuntu:gpadmin-[INFO]:-----------------------------------------------------
+20230110:23:13:44:403839 gpstop:ubuntu:gpadmin-[INFO]:-   Segments stopped successfully      = 6
+20230110:23:13:44:403839 gpstop:ubuntu:gpadmin-[INFO]:-   Segments with errors during stop   = 0
+20230110:23:13:44:403839 gpstop:ubuntu:gpadmin-[INFO]:-----------------------------------------------------
+20230110:23:13:44:403839 gpstop:ubuntu:gpadmin-[INFO]:-Successfully shutdown 6 of 6 segment instances 
+20230110:23:13:44:403839 gpstop:ubuntu:gpadmin-[INFO]:-Database successfully shutdown with no errors reported
+20230110:23:13:44:403839 gpstop:ubuntu:gpadmin-[INFO]:-Restarting System...
+
+-- end_ignore
+(exited with code 0)

--- a/src/test/isolation2/expected/resource_manager_switch_to_queue.out
+++ b/src/test/isolation2/expected/resource_manager_switch_to_queue.out
@@ -1,0 +1,32 @@
+!\retcode gpconfig -c gp_resource_manager -v queue;
+-- start_ignore
+20230110:01:09:54:295845 gpconfig:ubuntu:gpadmin-[INFO]:-completed successfully with parameters '-c gp_resource_manager -v queue'
+
+-- end_ignore
+(exited with code 0)
+!\retcode gpstop -ari;
+-- start_ignore
+20230110:01:09:55:296187 gpstop:ubuntu:gpadmin-[INFO]:-Starting gpstop with args: -ari
+20230110:01:09:55:296187 gpstop:ubuntu:gpadmin-[INFO]:-Gathering information and validating the environment...
+20230110:01:09:55:296187 gpstop:ubuntu:gpadmin-[INFO]:-Obtaining Greenplum Coordinator catalog information
+20230110:01:09:55:296187 gpstop:ubuntu:gpadmin-[INFO]:-Obtaining Segment details from coordinator...
+20230110:01:09:55:296187 gpstop:ubuntu:gpadmin-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 7.0.0-alpha.0+dev.16117.g367b82d8d9 build dev'
+20230110:01:09:55:296187 gpstop:ubuntu:gpadmin-[INFO]:-Commencing Coordinator instance shutdown with mode='immediate'
+20230110:01:09:55:296187 gpstop:ubuntu:gpadmin-[INFO]:-Coordinator segment instance directory=/home/gpadmin/zxj/workspace/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
+20230110:01:09:55:296187 gpstop:ubuntu:gpadmin-[INFO]:-Attempting forceful termination of any leftover coordinator process
+20230110:01:09:55:296187 gpstop:ubuntu:gpadmin-[INFO]:-Terminating processes for segment /home/gpadmin/zxj/workspace/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
+20230110:01:09:55:296187 gpstop:ubuntu:gpadmin-[INFO]:-No standby coordinator host configured
+20230110:01:09:55:296187 gpstop:ubuntu:gpadmin-[INFO]:-Targeting dbid [2, 3, 4] for shutdown
+20230110:01:09:55:296187 gpstop:ubuntu:gpadmin-[INFO]:-Commencing parallel segment instance shutdown, please wait...
+20230110:01:09:55:296187 gpstop:ubuntu:gpadmin-[INFO]:-0.00% of jobs completed
+20230110:01:09:56:296187 gpstop:ubuntu:gpadmin-[INFO]:-100.00% of jobs completed
+20230110:01:09:56:296187 gpstop:ubuntu:gpadmin-[INFO]:-----------------------------------------------------
+20230110:01:09:56:296187 gpstop:ubuntu:gpadmin-[INFO]:-   Segments stopped successfully      = 3
+20230110:01:09:56:296187 gpstop:ubuntu:gpadmin-[INFO]:-   Segments with errors during stop   = 0
+20230110:01:09:56:296187 gpstop:ubuntu:gpadmin-[INFO]:-----------------------------------------------------
+20230110:01:09:56:296187 gpstop:ubuntu:gpadmin-[INFO]:-Successfully shutdown 3 of 3 segment instances 
+20230110:01:09:56:296187 gpstop:ubuntu:gpadmin-[INFO]:-Database successfully shutdown with no errors reported
+20230110:01:09:56:296187 gpstop:ubuntu:gpadmin-[INFO]:-Restarting System...
+
+-- end_ignore
+(exited with code 0)

--- a/src/test/isolation2/isolation2_resqueue_schedule
+++ b/src/test/isolation2/isolation2_resqueue_schedule
@@ -1,0 +1,6 @@
+test: resource_manager_switch_to_queue
+test: resource_queue
+test: resource_queue_cancel
+test: resource_queue_deadlock
+test: resource_queue_multi_portal
+test: resource_manager_restore_to_none

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -64,14 +64,8 @@ test: deadlock_under_entry_db_singleton
 #  conflict when running in parallel with other cases.
 test: misc
 
-test: starve_case pg_views_concurrent_drop alter_blocks_for_update_and_viceversa drop_rename reader_waits_for_lock resource_queue bitmap_index_ao_sparse
+test: starve_case pg_views_concurrent_drop alter_blocks_for_update_and_viceversa drop_rename reader_waits_for_lock bitmap_index_ao_sparse
 
-# Test deadlock situation when waiting on a resource queue lock
-test: resource_queue_deadlock
-
-# Test simple cancellation for resource queues and cancellation/deadlocks for
-# sessions with multiple portals.
-test: resource_queue_cancel resource_queue_multi_portal
 
 # below test(s) inject faults so each of them need to be in a separate group
 test: pg_terminate_backend

--- a/src/test/isolation2/mirrorless_schedule
+++ b/src/test/isolation2/mirrorless_schedule
@@ -9,6 +9,5 @@ test: gpdispatch
 
 # A tiny set of smoke test
 test: check_gxid
-test: resource_queue_deadlock
 test: sync_guc
 test: upgrade_numsegments

--- a/src/test/isolation2/sql/resource_manager_restore_to_none.sql
+++ b/src/test/isolation2/sql/resource_manager_restore_to_none.sql
@@ -1,0 +1,2 @@
+!\retcode gpconfig -c gp_resource_manager -v none;
+!\retcode gpstop -ari;

--- a/src/test/isolation2/sql/resource_manager_switch_to_queue.sql
+++ b/src/test/isolation2/sql/resource_manager_switch_to_queue.sql
@@ -1,0 +1,2 @@
+!\retcode gpconfig -c gp_resource_manager -v queue;
+!\retcode gpstop -ari;

--- a/src/test/regress/expected/alter_distribution_policy.out
+++ b/src/test/regress/expected/alter_distribution_policy.out
@@ -1164,7 +1164,6 @@ select * from mpp5754 order by n_nationkey;
 drop table mpp5754;
 -- MPP-5918
 create role atsdb;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 create table owner_test(i int, toast text) distributed randomly;
 alter table owner_test owner to atsdb;
 alter table owner_test set with (reorganize = true) distributed by (i);

--- a/src/test/regress/expected/aoco_privileges.out
+++ b/src/test/regress/expected/aoco_privileges.out
@@ -1,12 +1,8 @@
 -- Create roles. --
 CREATE ROLE new_aoco_table_owner;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 CREATE ROLE user_with_privileges_from_first_owner;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 CREATE ROLE user_with_privileges_from_second_owner;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 CREATE ROLE user_with_no_privileges;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 -- Create the table. --
 CREATE TABLE aoco_privileges_table (a int) WITH (appendonly=true, orientation=column) DISTRIBUTED randomly;
 -- Grant privileges to only one user

--- a/src/test/regress/expected/autostats.out
+++ b/src/test/regress/expected/autostats.out
@@ -24,7 +24,6 @@ LOG:  statement: drop user if exists autostats_nonowner;
 NOTICE:  role "autostats_nonowner" does not exist, skipping
 create user autostats_nonowner;
 LOG:  statement: create user autostats_nonowner;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 -- Make sure rel_tuples starts at zero
 select relname, reltuples from pg_class where relname='autostats_test';
 LOG:  statement: select relname, reltuples from pg_class where relname='autostats_test';

--- a/src/test/regress/expected/bfv_partition.out
+++ b/src/test/regress/expected/bfv_partition.out
@@ -1315,7 +1315,6 @@ drop table mpp4582;
 -- commands don't vary depending on current user.
 DROP USER IF EXISTS mpp3641_user;
 CREATE USER mpp3641_user;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 GRANT ALL ON SCHEMA bfv_partition TO mpp3641_user;
 SET ROLE mpp3641_user;
 CREATE TABLE mpp3641a (

--- a/src/test/regress/expected/bfv_temp.out
+++ b/src/test/regress/expected/bfv_temp.out
@@ -8,7 +8,6 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER;
 create role sec_definer_role with login ;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 grant execute on function sec_definer_create_test() to sec_definer_role;
 set role sec_definer_role;
 select sec_definer_create_test() ;

--- a/src/test/regress/expected/column_compression.out
+++ b/src/test/regress/expected/column_compression.out
@@ -1936,7 +1936,6 @@ LINE 1: alter type int[2][3] set default encoding(compresstype=RLE_T...
                       ^
 -- permissions checks
 create role typcheck;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 set session authorization typcheck;
 alter type int42 set default encoding (compresstype=zlib, compresslevel=1);
 ERROR:  must be owner of type int42

--- a/src/test/regress/expected/create_extension_fail.out
+++ b/src/test/regress/expected/create_extension_fail.out
@@ -47,7 +47,6 @@ select gp_inject_fault('create_function_fail', 'reset', dbid) from gp_segment_co
 -- Similar comments please refer above case's
 --
 create role user_12713;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 set role user_12713;
 -- the will fail due to privilege
 create extension gp_debug_numsegments;

--- a/src/test/regress/expected/create_type.out
+++ b/src/test/regress/expected/create_type.out
@@ -214,7 +214,6 @@ select format_type('bpchar'::regtype, -1);
 
 -- Create & Drop type as non-superuser
 CREATE USER user_bob;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 SET SESSION AUTHORIZATION user_bob;
 CREATE TYPE shell; -- not allowed
 ERROR:  must be superuser to create a base type

--- a/src/test/regress/expected/dboptions.out
+++ b/src/test/regress/expected/dboptions.out
@@ -31,7 +31,6 @@ order by gp_segment_id;
 alter database limitdb with connection limit 0;
 -- create a regular user as superusers are exempt from limits
 create user connlimit_test_user;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 -- add superuser to pg_hba.conf
 \! echo "local    all         connlimit_test_user         trust" >> $COORDINATOR_DATA_DIRECTORY/pg_hba.conf
 select pg_reload_conf();

--- a/src/test/regress/expected/dependency.out
+++ b/src/test/regress/expected/dependency.out
@@ -5,7 +5,6 @@ CREATE USER regress_dep_user;
 CREATE USER regress_dep_user2;
 CREATE USER regress_dep_user3;
 CREATE GROUP regress_dep_group;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 CREATE TABLE deptest (f1 serial primary key, f2 text) DISTRIBUTED BY (f1);
 GRANT SELECT ON TABLE deptest TO GROUP regress_dep_group;
 GRANT ALL ON TABLE deptest TO regress_dep_user, regress_dep_user2;

--- a/src/test/regress/expected/external_table_create_privs.out
+++ b/src/test/regress/expected/external_table_create_privs.out
@@ -3,11 +3,8 @@
 --
 CREATE ROLE exttab1_su SUPERUSER; -- SU with no privs in pg_auth
 CREATE ROLE exttab1_u1 CREATEEXTTABLE(protocol='gpfdist', type='readable'); 
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 CREATE ROLE exttab1_u2 CREATEEXTTABLE(protocol='gpfdist', type='writable'); 
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 CREATE ROLE exttab1_u3 CREATEEXTTABLE(protocol='gpfdist') NOCREATEEXTTABLE(protocol='gpfdist', type='readable'); -- fail due to conflict
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 ERROR:  conflicting specifications in CREATEEXTTABLE and NOCREATEEXTTABLE
 SET SESSION AUTHORIZATION exttab1_su;
 create readable external table auth_ext_test1(a int) location ('gpfdist://host.invalid:8000/file') format 'text';
@@ -39,7 +36,6 @@ DROP ROLE exttab1_u2;
 -- Role to create RET http
 --
 CREATE ROLE ext_u3 CREATEEXTTABLE(protocol='http', type='readable');
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 select rolname, rolcreaterextgpfd,rolcreaterexthttp,rolcreatewextgpfd from pg_authid where rolname='ext_u3';
  rolname | rolcreaterextgpfd | rolcreaterexthttp | rolcreatewextgpfd 
 ---------+-------------------+-------------------+-------------------
@@ -59,7 +55,6 @@ RESET SESSION AUTHORIZATION;
 -- Role to create RET gpfdist and create RET gpfdist
 --
 CREATE ROLE ext_u19 CREATEEXTTABLE(protocol='gpfdist') CREATEEXTTABLE(protocol='gpfdist', type='readable'); 
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 select rolname, rolcreaterextgpfd,rolcreaterexthttp,rolcreatewextgpfd from pg_authid where rolname='ext_u19';
  rolname | rolcreaterextgpfd | rolcreaterexthttp | rolcreatewextgpfd 
 ---------+-------------------+-------------------+-------------------
@@ -79,7 +74,6 @@ RESET SESSION AUTHORIZATION;
 --
 --
 CREATE ROLE ext_u22 CREATEEXTTABLE(type='readable') CREATEEXTTABLE(protocol='gpfdist', type='readable'); 
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 select rolname, rolcreaterextgpfd,rolcreaterexthttp,rolcreatewextgpfd from pg_authid where rolname='ext_u22';
  rolname | rolcreaterextgpfd | rolcreaterexthttp | rolcreatewextgpfd 
 ---------+-------------------+-------------------+-------------------
@@ -99,7 +93,6 @@ RESET SESSION AUTHORIZATION;
 -- 
 --
 CREATE ROLE ext_u25 CREATEEXTTABLE(protocol='gpfdist',type='readable') CREATEEXTTABLE(protocol='gpfdist', type='readable'); 
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 select rolname, rolcreaterextgpfd,rolcreaterexthttp,rolcreatewextgpfd from pg_authid where rolname='ext_u25';
  rolname | rolcreaterextgpfd | rolcreaterexthttp | rolcreatewextgpfd 
 ---------+-------------------+-------------------+-------------------
@@ -119,7 +112,6 @@ RESET SESSION AUTHORIZATION;
 -- Role to create RET gpfdist and create RET http
 --
 CREATE ROLE ext_u23 CREATEEXTTABLE(type='readable') CREATEEXTTABLE(protocol='http', type='readable'); 
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 select rolname, rolcreaterextgpfd,rolcreaterexthttp,rolcreatewextgpfd from pg_authid where rolname='ext_u23';
  rolname | rolcreaterextgpfd | rolcreaterexthttp | rolcreatewextgpfd 
 ---------+-------------------+-------------------+-------------------
@@ -139,7 +131,6 @@ RESET SESSION AUTHORIZATION;
 -- Role to create RET gpfdist and create RET http
 --
 CREATE ROLE ext_u29 CREATEEXTTABLE(protocol='gpfdist',type='readable') CREATEEXTTABLE(protocol='http', type='readable'); 
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 select rolname, rolcreaterextgpfd,rolcreaterexthttp,rolcreatewextgpfd from pg_authid where rolname='ext_u29';
  rolname | rolcreaterextgpfd | rolcreaterexthttp | rolcreatewextgpfd 
 ---------+-------------------+-------------------+-------------------
@@ -159,7 +150,6 @@ RESET SESSION AUTHORIZATION;
 -- 
 --
 CREATE ROLE ext_u32 CREATEEXTTABLE(protocol='http',type='readable') CREATEEXTTABLE(protocol='gpfdist', type='readable');
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 select rolname, rolcreaterextgpfd,rolcreaterexthttp,rolcreatewextgpfd from pg_authid where rolname='ext_u32';
  rolname | rolcreaterextgpfd | rolcreaterexthttp | rolcreatewextgpfd 
 ---------+-------------------+-------------------+-------------------
@@ -179,7 +169,6 @@ RESET SESSION AUTHORIZATION;
 -- Role to create RET gpfdist and create WET gpfdist
 --
 CREATE ROLE ext_u21 CREATEEXTTABLE(protocol='gpfdist') CREATEEXTTABLE(protocol='gpfdist', type='writable'); 
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 select rolname, rolcreaterextgpfd,rolcreaterexthttp,rolcreatewextgpfd from pg_authid where rolname='ext_u21';
  rolname | rolcreaterextgpfd | rolcreaterexthttp | rolcreatewextgpfd 
 ---------+-------------------+-------------------+-------------------
@@ -199,7 +188,6 @@ RESET SESSION AUTHORIZATION;
 --
 --
 CREATE ROLE ext_u28 CREATEEXTTABLE(protocol='gpfdist',type='readable') CREATEEXTTABLE(protocol='gpfdist', type='writable'); 
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 select rolname, rolcreaterextgpfd,rolcreaterexthttp,rolcreatewextgpfd from pg_authid where rolname='ext_u28';
  rolname | rolcreaterextgpfd | rolcreaterexthttp | rolcreatewextgpfd 
 ---------+-------------------+-------------------+-------------------
@@ -219,7 +207,6 @@ RESET SESSION AUTHORIZATION;
 -- 
 --
 CREATE ROLE ext_u30 CREATEEXTTABLE(protocol='gpfdist',type='writable') CREATEEXTTABLE(protocol='gpfdist', type='readable');
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 select rolname, rolcreaterextgpfd,rolcreaterexthttp,rolcreatewextgpfd from pg_authid where rolname='ext_u30';
  rolname | rolcreaterextgpfd | rolcreaterexthttp | rolcreatewextgpfd 
 ---------+-------------------+-------------------+-------------------
@@ -239,7 +226,6 @@ RESET SESSION AUTHORIZATION;
 -- Role to create RET gpfdist and NO create RET gpfdist
 --
 CREATE ROLE ext_u4 CREATEEXTTABLE(protocol='gpfdist') NOCREATEEXTTABLE(protocol='gpfdist', type='readable'); -- fail due to conflict
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 ERROR:  conflicting specifications in CREATEEXTTABLE and NOCREATEEXTTABLE
 select rolname, rolcreaterextgpfd,rolcreaterexthttp,rolcreatewextgpfd from pg_authid where rolname='ext_u4';
  rolname | rolcreaterextgpfd | rolcreaterexthttp | rolcreatewextgpfd 
@@ -247,7 +233,6 @@ select rolname, rolcreaterextgpfd,rolcreaterexthttp,rolcreatewextgpfd from pg_au
 (0 rows)
 
 CREATE ROLE ext_u7 CREATEEXTTABLE(type='readable') NOCREATEEXTTABLE(protocol='gpfdist', type='readable'); -- fail due to conflict
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 ERROR:  conflicting specifications in CREATEEXTTABLE and NOCREATEEXTTABLE
 select rolname, rolcreaterextgpfd,rolcreaterexthttp,rolcreatewextgpfd from pg_authid where rolname='ext_u7';
  rolname | rolcreaterextgpfd | rolcreaterexthttp | rolcreatewextgpfd 
@@ -255,7 +240,6 @@ select rolname, rolcreaterextgpfd,rolcreaterexthttp,rolcreatewextgpfd from pg_au
 (0 rows)
 
 CREATE ROLE ext_u10 CREATEEXTTABLE(protocol='gpfdist',type='readable') NOCREATEEXTTABLE(protocol='gpfdist', type='readable'); -- fail due to conflict
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 ERROR:  conflicting specifications in CREATEEXTTABLE and NOCREATEEXTTABLE
 select rolname, rolcreaterextgpfd,rolcreaterexthttp,rolcreatewextgpfd from pg_authid where rolname='ext_u10';
  rolname | rolcreaterextgpfd | rolcreaterexthttp | rolcreatewextgpfd 
@@ -266,7 +250,6 @@ select rolname, rolcreaterextgpfd,rolcreaterexthttp,rolcreatewextgpfd from pg_au
 -- Role to create RET gpfdist and NO create RET http
 --
 CREATE ROLE ext_u8 CREATEEXTTABLE(type='readable') NOCREATEEXTTABLE(protocol='http', type='readable'); 
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 select rolname, rolcreaterextgpfd,rolcreaterexthttp,rolcreatewextgpfd from pg_authid where rolname='ext_u8';
  rolname | rolcreaterextgpfd | rolcreaterexthttp | rolcreatewextgpfd 
 ---------+-------------------+-------------------+-------------------
@@ -286,7 +269,6 @@ RESET SESSION AUTHORIZATION;
 -- 
 --
 CREATE ROLE ext_u14 CREATEEXTTABLE(protocol='gpfdist',type='readable') NOCREATEEXTTABLE(protocol='http', type='readable'); 
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 select rolname, rolcreaterextgpfd,rolcreaterexthttp,rolcreatewextgpfd from pg_authid where rolname='ext_u14';
  rolname | rolcreaterextgpfd | rolcreaterexthttp | rolcreatewextgpfd 
 ---------+-------------------+-------------------+-------------------
@@ -306,7 +288,6 @@ RESET SESSION AUTHORIZATION;
 -- Role to create RET gpfdist and NO create WET gpfdist
 --
 CREATE ROLE ext_u6 CREATEEXTTABLE(protocol='gpfdist') NOCREATEEXTTABLE(protocol='gpfdist', type='writable'); 
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 select rolname, rolcreaterextgpfd,rolcreaterexthttp,rolcreatewextgpfd from pg_authid where rolname='ext_u6';
  rolname | rolcreaterextgpfd | rolcreaterexthttp | rolcreatewextgpfd 
 ---------+-------------------+-------------------+-------------------
@@ -326,7 +307,6 @@ RESET SESSION AUTHORIZATION;
 -- 
 --
 CREATE ROLE ext_u13 CREATEEXTTABLE(protocol='gpfdist',type='readable') NOCREATEEXTTABLE(protocol='gpfdist', type='writable'); 
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 select rolname, rolcreaterextgpfd,rolcreaterexthttp,rolcreatewextgpfd from pg_authid where rolname='ext_u13';
  rolname | rolcreaterextgpfd | rolcreaterexthttp | rolcreatewextgpfd 
 ---------+-------------------+-------------------+-------------------
@@ -346,7 +326,6 @@ RESET SESSION AUTHORIZATION;
 -- Role to create RET http and  create RET http
 --
 CREATE ROLE ext_u20 CREATEEXTTABLE(protocol='http') CREATEEXTTABLE(protocol='http', type='readable'); 
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 select rolname, rolcreaterextgpfd,rolcreaterexthttp,rolcreatewextgpfd from pg_authid where rolname='ext_u20';
  rolname | rolcreaterextgpfd | rolcreaterexthttp | rolcreatewextgpfd 
 ---------+-------------------+-------------------+-------------------
@@ -366,7 +345,6 @@ RESET SESSION AUTHORIZATION;
 -- 
 --
 CREATE ROLE ext_u27 CREATEEXTTABLE(protocol='http',type='readable') CREATEEXTTABLE(protocol='http', type='readable'); 
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 select rolname, rolcreaterextgpfd,rolcreaterexthttp,rolcreatewextgpfd from pg_authid where rolname='ext_u27';
  rolname | rolcreaterextgpfd | rolcreaterexthttp | rolcreatewextgpfd 
 ---------+-------------------+-------------------+-------------------
@@ -386,7 +364,6 @@ RESET SESSION AUTHORIZATION;
 -- Role to create RET http and NO create RET gpfdist
 --
 CREATE ROLE ext_u17 CREATEEXTTABLE(protocol='http',type='readable') NOCREATEEXTTABLE(protocol='gpfdist', type='readable');
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 select rolname, rolcreaterextgpfd,rolcreaterexthttp,rolcreatewextgpfd from pg_authid where rolname='ext_u17';
  rolname | rolcreaterextgpfd | rolcreaterexthttp | rolcreatewextgpfd 
 ---------+-------------------+-------------------+-------------------
@@ -406,7 +383,6 @@ RESET SESSION AUTHORIZATION;
 -- Role to create RET http and NO create RET http
 --
 CREATE ROLE ext_u5 CREATEEXTTABLE(protocol='http') NOCREATEEXTTABLE(protocol='http', type='readable'); -- fail due to conflict
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 ERROR:  conflicting specifications in CREATEEXTTABLE and NOCREATEEXTTABLE
 select rolname, rolcreaterextgpfd,rolcreaterexthttp,rolcreatewextgpfd from pg_authid where rolname='ext_u5';
  rolname | rolcreaterextgpfd | rolcreaterexthttp | rolcreatewextgpfd 
@@ -417,7 +393,6 @@ select rolname, rolcreaterextgpfd,rolcreaterexthttp,rolcreatewextgpfd from pg_au
 -- 
 --
 CREATE ROLE ext_u12 CREATEEXTTABLE(protocol='http',type='readable') NOCREATEEXTTABLE(protocol='http', type='readable'); -- fail due to conflict
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 ERROR:  conflicting specifications in CREATEEXTTABLE and NOCREATEEXTTABLE
 select rolname, rolcreaterextgpfd,rolcreaterexthttp,rolcreatewextgpfd from pg_authid where rolname='ext_u12';
  rolname | rolcreaterextgpfd | rolcreaterexthttp | rolcreatewextgpfd 
@@ -428,7 +403,6 @@ select rolname, rolcreaterextgpfd,rolcreaterexthttp,rolcreatewextgpfd from pg_au
 -- Role to create RET http and NO create WET gpfdist
 --
 CREATE ROLE ext_u18 CREATEEXTTABLE(protocol='http',type='readable') NOCREATEEXTTABLE(protocol='gpfdist', type='writable'); 
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 select rolname, rolcreaterextgpfd,rolcreaterexthttp,rolcreatewextgpfd from pg_authid where rolname='ext_u18';
  rolname | rolcreaterextgpfd | rolcreaterexthttp | rolcreatewextgpfd 
 ---------+-------------------+-------------------+-------------------
@@ -448,7 +422,6 @@ RESET SESSION AUTHORIZATION;
 -- Role to create WET gpfdist and create RET http
 --
 CREATE ROLE ext_u31 CREATEEXTTABLE(protocol='gpfdist',type='writable') CREATEEXTTABLE(protocol='http', type='readable'); 
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 select rolname, rolcreaterextgpfd,rolcreaterexthttp,rolcreatewextgpfd from pg_authid where rolname='ext_u31';
  rolname | rolcreaterextgpfd | rolcreaterexthttp | rolcreatewextgpfd 
 ---------+-------------------+-------------------+-------------------
@@ -468,7 +441,6 @@ RESET SESSION AUTHORIZATION;
 -- 
 --
 CREATE ROLE ext_u33 CREATEEXTTABLE(protocol='http',type='readable') CREATEEXTTABLE(protocol='gpfdist', type='writable'); 
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 select rolname, rolcreaterextgpfd,rolcreaterexthttp,rolcreatewextgpfd from pg_authid where rolname='ext_u33';
  rolname | rolcreaterextgpfd | rolcreaterexthttp | rolcreatewextgpfd 
 ---------+-------------------+-------------------+-------------------
@@ -488,7 +460,6 @@ RESET SESSION AUTHORIZATION;
 -- Role to create WET gpfdist and create WET gpfdist
 --
 CREATE ROLE ext_u24 CREATEEXTTABLE(type='writable') CREATEEXTTABLE(protocol='gpfdist', type='writable'); 
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 select rolname, rolcreaterextgpfd,rolcreaterexthttp,rolcreatewextgpfd from pg_authid where rolname='ext_u24';
  rolname | rolcreaterextgpfd | rolcreaterexthttp | rolcreatewextgpfd 
 ---------+-------------------+-------------------+-------------------
@@ -508,7 +479,6 @@ RESET SESSION AUTHORIZATION;
 -- 
 --
 CREATE ROLE ext_u26 CREATEEXTTABLE(protocol='gpfdist',type='writable') CREATEEXTTABLE(protocol='gpfdist', type='writable'); 
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 select rolname, rolcreaterextgpfd,rolcreaterexthttp,rolcreatewextgpfd from pg_authid where rolname='ext_u26';
  rolname | rolcreaterextgpfd | rolcreaterexthttp | rolcreatewextgpfd 
 ---------+-------------------+-------------------+-------------------
@@ -528,7 +498,6 @@ RESET SESSION AUTHORIZATION;
 -- Role to create WET gpfdist and NO create RET gpfdist
 --
 CREATE ROLE ext_u15 CREATEEXTTABLE(protocol='gpfdist',type='writable') NOCREATEEXTTABLE(protocol='gpfdist', type='readable');
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 select rolname, rolcreaterextgpfd,rolcreaterexthttp,rolcreatewextgpfd from pg_authid where rolname='ext_u15';
  rolname | rolcreaterextgpfd | rolcreaterexthttp | rolcreatewextgpfd 
 ---------+-------------------+-------------------+-------------------
@@ -548,7 +517,6 @@ RESET SESSION AUTHORIZATION;
 -- Role to create WET gpfdist and NO create RET http
 --
 CREATE ROLE ext_u16 CREATEEXTTABLE(protocol='gpfdist',type='writable') NOCREATEEXTTABLE(protocol='http', type='readable'); 
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 select rolname, rolcreaterextgpfd,rolcreaterexthttp,rolcreatewextgpfd from pg_authid where rolname='ext_u16';
  rolname | rolcreaterextgpfd | rolcreaterexthttp | rolcreatewextgpfd 
 ---------+-------------------+-------------------+-------------------
@@ -568,7 +536,6 @@ RESET SESSION AUTHORIZATION;
 -- Role to create WET gpfdist and NO create WET gpfdist
 --
 CREATE ROLE ext_u9 CREATEEXTTABLE(type='writable') NOCREATEEXTTABLE(protocol='gpfdist', type='writable'); -- fail due to conflict
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 ERROR:  conflicting specifications in CREATEEXTTABLE and NOCREATEEXTTABLE
 select rolname, rolcreaterextgpfd,rolcreaterexthttp,rolcreatewextgpfd from pg_authid where rolname='ext_u9';
  rolname | rolcreaterextgpfd | rolcreaterexthttp | rolcreatewextgpfd 
@@ -579,7 +546,6 @@ select rolname, rolcreaterextgpfd,rolcreaterexthttp,rolcreatewextgpfd from pg_au
 -- 
 --
 CREATE ROLE ext_u11 CREATEEXTTABLE(protocol='gpfdist',type='writable') NOCREATEEXTTABLE(protocol='gpfdist', type='writable'); -- fail due to conflict
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 ERROR:  conflicting specifications in CREATEEXTTABLE and NOCREATEEXTTABLE
 select rolname, rolcreaterextgpfd,rolcreaterexthttp,rolcreatewextgpfd from pg_authid where rolname='ext_u11';
  rolname | rolcreaterextgpfd | rolcreaterexthttp | rolcreatewextgpfd 
@@ -591,7 +557,6 @@ select rolname, rolcreaterextgpfd,rolcreaterexthttp,rolcreatewextgpfd from pg_au
 -- Role to NO create RET gpfdist and NO create RET gpfdist
 --
 CREATE ROLE ext_u34 NOCREATEEXTTABLE(protocol='gpfdist') NOCREATEEXTTABLE(protocol='gpfdist', type='readable'); 
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 select rolname, rolcreaterextgpfd,rolcreaterexthttp,rolcreatewextgpfd from pg_authid where rolname='ext_u34';
  rolname | rolcreaterextgpfd | rolcreaterexthttp | rolcreatewextgpfd 
 ---------+-------------------+-------------------+-------------------
@@ -615,7 +580,6 @@ ERROR:  foreign table "priv_ext_test3" does not exist
 RESET SESSION AUTHORIZATION;
 --
 CREATE ROLE ext_u40 NOCREATEEXTTABLE(protocol='gpfdist',type='readable') NOCREATEEXTTABLE(protocol='gpfdist', type='readable'); 
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 select rolname, rolcreaterextgpfd,rolcreaterexthttp,rolcreatewextgpfd from pg_authid where rolname='ext_u40';
  rolname | rolcreaterextgpfd | rolcreaterexthttp | rolcreatewextgpfd 
 ---------+-------------------+-------------------+-------------------
@@ -639,7 +603,6 @@ ERROR:  foreign table "priv_ext_test3" does not exist
 RESET SESSION AUTHORIZATION;
 --
 CREATE ROLE ext_u37 NOCREATEEXTTABLE(type='readable') NOCREATEEXTTABLE(protocol='gpfdist', type='readable'); 
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 select rolname, rolcreaterextgpfd,rolcreaterexthttp,rolcreatewextgpfd from pg_authid where rolname='ext_u37';
  rolname | rolcreaterextgpfd | rolcreaterexthttp | rolcreatewextgpfd 
 ---------+-------------------+-------------------+-------------------
@@ -665,7 +628,6 @@ RESET SESSION AUTHORIZATION;
 -- Role to NO create RET gpfdist and NO create RET http
 --
 CREATE ROLE ext_u38 NOCREATEEXTTABLE(type='readable') NOCREATEEXTTABLE(protocol='http', type='readable'); 
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 select rolname, rolcreaterextgpfd,rolcreaterexthttp,rolcreatewextgpfd from pg_authid where rolname='ext_u38';
  rolname | rolcreaterextgpfd | rolcreaterexthttp | rolcreatewextgpfd 
 ---------+-------------------+-------------------+-------------------
@@ -689,7 +651,6 @@ ERROR:  foreign table "priv_ext_test3" does not exist
 RESET SESSION AUTHORIZATION;
 --
 CREATE ROLE ext_u44 NOCREATEEXTTABLE(protocol='gpfdist',type='readable') NOCREATEEXTTABLE(protocol='http', type='readable'); 
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 select rolname, rolcreaterextgpfd,rolcreaterexthttp,rolcreatewextgpfd from pg_authid where rolname='ext_u44';
  rolname | rolcreaterextgpfd | rolcreaterexthttp | rolcreatewextgpfd 
 ---------+-------------------+-------------------+-------------------
@@ -716,7 +677,6 @@ RESET SESSION AUTHORIZATION;
 -- Role to NO create RET gpfdist and NO create WET gpfdist
 --
 CREATE ROLE ext_u36 NOCREATEEXTTABLE(protocol='gpfdist') NOCREATEEXTTABLE(protocol='gpfdist', type='writable'); 
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 select rolname, rolcreaterextgpfd,rolcreaterexthttp,rolcreatewextgpfd from pg_authid where rolname='ext_u36';
  rolname | rolcreaterextgpfd | rolcreaterexthttp | rolcreatewextgpfd 
 ---------+-------------------+-------------------+-------------------
@@ -740,7 +700,6 @@ ERROR:  foreign table "priv_ext_test3" does not exist
 RESET SESSION AUTHORIZATION;
 --
 CREATE ROLE ext_u41 NOCREATEEXTTABLE(protocol='gpfdist',type='writable') NOCREATEEXTTABLE(protocol='gpfdist', type='writable'); 
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 select rolname, rolcreaterextgpfd,rolcreaterexthttp,rolcreatewextgpfd from pg_authid where rolname='ext_u41';
  rolname | rolcreaterextgpfd | rolcreaterexthttp | rolcreatewextgpfd 
 ---------+-------------------+-------------------+-------------------
@@ -764,7 +723,6 @@ ERROR:  foreign table "priv_ext_test3" does not exist
 RESET SESSION AUTHORIZATION;
 --
 CREATE ROLE ext_u43 NOCREATEEXTTABLE(protocol='gpfdist',type='readable') NOCREATEEXTTABLE(protocol='gpfdist', type='writable'); 
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 select rolname, rolcreaterextgpfd,rolcreaterexthttp,rolcreatewextgpfd from pg_authid where rolname='ext_u43';
  rolname | rolcreaterextgpfd | rolcreaterexthttp | rolcreatewextgpfd 
 ---------+-------------------+-------------------+-------------------
@@ -788,7 +746,6 @@ ERROR:  foreign table "priv_ext_test3" does not exist
 RESET SESSION AUTHORIZATION;
 --
 CREATE ROLE ext_u45 NOCREATEEXTTABLE(protocol='gpfdist',type='writable') NOCREATEEXTTABLE(protocol='gpfdist', type='readable');
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 select rolname, rolcreaterextgpfd,rolcreaterexthttp,rolcreatewextgpfd from pg_authid where rolname='ext_u45';
  rolname | rolcreaterextgpfd | rolcreaterexthttp | rolcreatewextgpfd 
 ---------+-------------------+-------------------+-------------------
@@ -814,7 +771,6 @@ RESET SESSION AUTHORIZATION;
 -- Role to NO create RET http and NO create RET http
 --
 CREATE ROLE ext_u35 NOCREATEEXTTABLE(protocol='http') NOCREATEEXTTABLE(protocol='http', type='readable'); 
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 select rolname, rolcreaterextgpfd,rolcreaterexthttp,rolcreatewextgpfd from pg_authid where rolname='ext_u35';
  rolname | rolcreaterextgpfd | rolcreaterexthttp | rolcreatewextgpfd 
 ---------+-------------------+-------------------+-------------------
@@ -838,7 +794,6 @@ ERROR:  foreign table "priv_ext_test3" does not exist
 RESET SESSION AUTHORIZATION;
 --
 CREATE ROLE ext_u42 NOCREATEEXTTABLE(protocol='http',type='readable') NOCREATEEXTTABLE(protocol='http', type='readable'); 
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 select rolname, rolcreaterextgpfd,rolcreaterexthttp,rolcreatewextgpfd from pg_authid where rolname='ext_u42';
  rolname | rolcreaterextgpfd | rolcreaterexthttp | rolcreatewextgpfd 
 ---------+-------------------+-------------------+-------------------
@@ -864,7 +819,6 @@ RESET SESSION AUTHORIZATION;
 -- Role to NO create WET gpfdist and NO create RET http
 --
 CREATE ROLE ext_u46 NOCREATEEXTTABLE(protocol='gpfdist',type='writable') NOCREATEEXTTABLE(protocol='http', type='readable'); 
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 select rolname, rolcreaterextgpfd,rolcreaterexthttp,rolcreatewextgpfd from pg_authid where rolname='ext_u46';
  rolname | rolcreaterextgpfd | rolcreaterexthttp | rolcreatewextgpfd 
 ---------+-------------------+-------------------+-------------------
@@ -890,7 +844,6 @@ RESET SESSION AUTHORIZATION;
 -- Role to NO create WET gpfdist and NO create WET gpfdist
 --
 CREATE ROLE ext_u39 NOCREATEEXTTABLE(type='writable') NOCREATEEXTTABLE(protocol='gpfdist', type='writable'); 
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 select rolname, rolcreaterextgpfd,rolcreaterexthttp,rolcreatewextgpfd from pg_authid where rolname='ext_u39';
  rolname | rolcreaterextgpfd | rolcreaterexthttp | rolcreatewextgpfd 
 ---------+-------------------+-------------------+-------------------

--- a/src/test/regress/expected/function_extensions.out
+++ b/src/test/regress/expected/function_extensions.out
@@ -337,7 +337,6 @@ $$ language plpgsql EXECUTE ON ANY IMMUTABLE;
 -- Set the owner, to make the output of the \df+ tests below repeatable,
 -- regardless of the name of the current user.
 CREATE ROLE srftestuser;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 ALTER FUNCTION test_srf() OWNER TO srftestuser;
 select test_srf();
  test_srf 

--- a/src/test/regress/expected/function_extensions_optimizer.out
+++ b/src/test/regress/expected/function_extensions_optimizer.out
@@ -339,7 +339,6 @@ $$ language plpgsql EXECUTE ON ANY IMMUTABLE;
 -- Set the owner, to make the output of the \df+ tests below repeatable,
 -- regardless of the name of the current user.
 CREATE ROLE srftestuser;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 ALTER FUNCTION test_srf() OWNER TO srftestuser;
 select test_srf();
  test_srf 

--- a/src/test/regress/expected/gp_connections.out
+++ b/src/test/regress/expected/gp_connections.out
@@ -4,7 +4,6 @@
 -- create a new user
 drop user if exists user_disallowed_via_local;
 create user user_disallowed_via_local with login;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 -- cleanup previous settings if any
 \! sed -i '/user_disallowed_via_local/d' $COORDINATOR_DATA_DIRECTORY/pg_hba.conf;
 -- allow it to login via the [tcp] protocol

--- a/src/test/regress/expected/gp_toolkit.out
+++ b/src/test/regress/expected/gp_toolkit.out
@@ -5,7 +5,6 @@ create database toolkit_testdb;
 \c toolkit_testdb
 create role toolkit_admin superuser createdb;
 create role toolkit_user1 login;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 CREATE TABLE toolkit_ao (id INTEGER) WITH (appendonly = true);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'id' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
@@ -578,10 +577,9 @@ select * from gp_toolkit.gp_locks_on_resqueue;
 -- GP Resource Queue Activity for User
 set session authorization toolkit_user1;
 select resqname, resqstatus from gp_toolkit.gp_resq_activity where resqname='pg_default';
-  resqname  | resqstatus 
-------------+------------
- pg_default | running
-(1 row)
+ resqname | resqstatus 
+----------+------------
+(0 rows)
 
 reset session authorization;
 -- should be empty because the sql is completed
@@ -612,7 +610,7 @@ select 1;
 select n_queries_exec from pg_stat_resqueues where queuename = 'q';
  n_queries_exec 
 ----------------
-              1
+              0
 (1 row)
 
 reset role;

--- a/src/test/regress/expected/gp_toolkit_resqueue.out
+++ b/src/test/regress/expected/gp_toolkit_resqueue.out
@@ -1,0 +1,84 @@
+-- Tests for the functions and views in gp_toolkit
+-- Create an empty database to test in, because some of the gp_toolkit views
+-- are really slow, when there are a lot of objects in the database.
+create database toolkit_testdb;
+\c toolkit_testdb
+create role toolkit_admin superuser createdb;
+create role toolkit_user1 login;
+NOTICE:  resource queue required -- using default resource queue "pg_default"
+-- Test Resource Queue views
+-- GP Resource Queue Activity
+select * from gp_toolkit.gp_resq_activity;
+ resqprocpid | resqrole | resqoid | resqname | resqstart | resqstatus 
+-------------+----------+---------+----------+-----------+------------
+(0 rows)
+
+-- GP Resource Queue Activity by Queue
+-- There is no resource queue, so should be empty
+select * from gp_toolkit.gp_resq_activity_by_queue;
+ resqoid | resqname | resqlast | resqstatus | resqtotal 
+---------+----------+----------+------------+-----------
+(0 rows)
+
+-- gp_resq_role
+select * from gp_toolkit.gp_resq_role where rrrolname like 'toolkit%';
+   rrrolname   | rrrsqname  
+---------------+------------
+ toolkit_admin | pg_default
+ toolkit_user1 | pg_default
+(2 rows)
+
+-- gp_locks_on_resqueue
+-- Should be empty because there is no one in the queue
+select * from gp_toolkit.gp_locks_on_resqueue;
+ lorusename | lorrsqname | lorlocktype | lorobjid | lortransaction | lorpid | lormode | lorgranted | lorwaitevent | lorwaiteventtype 
+------------+------------+-------------+----------+----------------+--------+---------+------------+--------------+------------------
+(0 rows)
+
+-- GP Resource Queue Activity for User
+set session authorization toolkit_user1;
+select resqname, resqstatus from gp_toolkit.gp_resq_activity where resqname='pg_default';
+  resqname  | resqstatus 
+------------+------------
+ pg_default | running
+(1 row)
+
+reset session authorization;
+-- should be empty because the sql is completed
+select * from gp_toolkit.gp_resq_activity where resqrole = 'toolkit_user1';
+ resqprocpid | resqrole | resqoid | resqname | resqstart | resqstatus 
+-------------+----------+---------+----------+-----------+------------
+(0 rows)
+
+-- gp_pgdatabase_invalid
+-- Should be empty unless there is failure in the segment, it's a view from gp_pgdatabase
+select * from gp_toolkit.gp_pgdatabase_invalid;
+ pgdbidbid | pgdbiisprimary | pgdbicontent | pgdbivalid | pgdbidefinedprimary 
+-----------+----------------+--------------+------------+---------------------
+(0 rows)
+
+-- Test that the statistics on resource queue usage are properly updated and
+-- reflected in the pg_stat_resqueues view
+set stats_queue_level=on;
+create resource queue q with (active_statements = 10);
+create user resqueuetest with resource queue q;
+set role resqueuetest;
+select 1;
+ ?column? 
+----------
+        1
+(1 row)
+
+select n_queries_exec from pg_stat_resqueues where queuename = 'q';
+ n_queries_exec 
+----------------
+              1
+(1 row)
+
+reset role;
+drop role resqueuetest;
+drop resource queue q;
+\c regression
+drop database toolkit_testdb;
+drop role toolkit_user1;
+drop role toolkit_admin;

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -10471,7 +10471,6 @@ create rule can_set_tag_audit_update AS
   VALUES (now(), old.x, old.y, old.z);
 insert into can_set_tag_target select i, i + 1, i + 2 from generate_series(1,2) as i;
 create role unpriv;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 grant all on can_set_tag_target to unpriv;
 grant all on can_set_tag_audit to unpriv;
 set role unpriv;

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -10497,7 +10497,6 @@ create rule can_set_tag_audit_update AS
   VALUES (now(), old.x, old.y, old.z);
 insert into can_set_tag_target select i, i + 1, i + 2 from generate_series(1,2) as i;
 create role unpriv;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 grant all on can_set_tag_target to unpriv;
 grant all on can_set_tag_audit to unpriv;
 set role unpriv;

--- a/src/test/regress/expected/guc_gp.out
+++ b/src/test/regress/expected/guc_gp.out
@@ -315,7 +315,6 @@ BEGIN;
 DROP ROLE IF EXISTS guc_gp_test_role1;
 NOTICE:  role "guc_gp_test_role1" does not exist, skipping
 CREATE ROLE guc_gp_test_role1;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 SET ROLE guc_gp_test_role1;
 RESET ROLE;
 END;
@@ -330,7 +329,6 @@ BEGIN ISOLATION LEVEL REPEATABLE READ;
 DROP ROLE IF EXISTS guc_gp_test_role2;
 NOTICE:  role "guc_gp_test_role2" does not exist, skipping
 CREATE ROLE guc_gp_test_role2;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 SET ROLE guc_gp_test_role2;
 RESET ROLE;
 END;
@@ -348,7 +346,6 @@ FETCH c1;
 
 DROP ROLE IF EXISTS guc_gp_test_role1;
 CREATE ROLE guc_gp_test_role1;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 SET ROLE guc_gp_test_role1;
 RESET ROLE;
 FETCH c2;

--- a/src/test/regress/expected/inherit_optimizer.out
+++ b/src/test/regress/expected/inherit_optimizer.out
@@ -2559,7 +2559,6 @@ insert into permtest_parent
   select 1, 'a', left(md5(i::text), 5) from generate_series(0, 100) i;
 analyze permtest_parent;
 create role regress_no_child_access;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 revoke all on permtest_grandchild from regress_no_child_access;
 NOTICE:  no privileges could be revoked
 grant select on permtest_parent to regress_no_child_access;

--- a/src/test/regress/expected/misc_functions_optimizer.out
+++ b/src/test/regress/expected/misc_functions_optimizer.out
@@ -150,7 +150,6 @@ SELECT pg_log_backend_memory_contexts(pg_backend_pid());
 (1 row)
 
 CREATE ROLE regress_log_memory;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 SELECT has_function_privilege('regress_log_memory',
   'pg_log_backend_memory_contexts(integer)', 'EXECUTE'); -- no
  has_function_privilege 

--- a/src/test/regress/expected/namespace_gp.out
+++ b/src/test/regress/expected/namespace_gp.out
@@ -9,7 +9,7 @@ CREATE SCHEMA test_schema_1
 -- Test GRANT/REVOKE
 CREATE SCHEMA test_schema_2;
 CREATE TABLE test_schema_2.abc as select * from test_schema_1.abc DISTRIBUTED BY (a);
-create role tmp_test_schema_role RESOURCE QUEUE pg_default;
+create role tmp_test_schema_role;
 GRANT ALL ON SCHEMA test_schema_1 to tmp_test_schema_role;
 SET SESSION AUTHORIZATION tmp_test_schema_role;
 CREATE TABLE test_schema_1.grant_test(a int) DISTRIBUTED BY (a);

--- a/src/test/regress/expected/opclass_ddl.out
+++ b/src/test/regress/expected/opclass_ddl.out
@@ -10,11 +10,8 @@ DROP ROLE IF EXISTS regtest_alter_user2;
 DROP ROLE IF EXISTS regtest_alter_user3;
 RESET client_min_messages;
 CREATE USER regtest_alter_user3;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 CREATE USER regtest_alter_user2;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 CREATE USER regtest_alter_user1 IN ROLE regtest_alter_user3;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 CREATE SCHEMA alt_nsp1;
 GRANT ALL ON SCHEMA alt_nsp1 TO public;
 SET search_path = alt_nsp1, public;

--- a/src/test/regress/expected/partition.out
+++ b/src/test/regress/expected/partition.out
@@ -157,7 +157,6 @@ ALTER TABLE two_level_pt ALTER PARTITION FOR (1)
 ERROR:  child table is missing column "b"
 -- different owner 
 create role part_role;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 create table bar_p (i int, j int) distributed by (i);
 set session authorization part_role;
 -- should fail
@@ -248,7 +247,6 @@ select * from bar_d;
 drop table foo_p, bar_d;
 -- permissions
 create role part_role;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 create table foo_p (i int) partition by range(i) (start(1) end(10) every(1));
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
@@ -1452,7 +1450,6 @@ LINE 2: end('f'::bool));
             ^
 -- see that grant and revoke cascade to children
 create role part_role;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 create table granttest (i int, j int) partition by range(i) 
 subpartition by list(j) subpartition template (values(1, 2, 3))
 (start(1) end(4) every(1));
@@ -2010,7 +2007,6 @@ drop table k;
 -- ADD and SPLIT must get inherit permissions of the partition they're
 -- modifying
 create role part_role;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 create table a (a int, b int, c int) partition by range(a) subpartition by
 range(b) subpartition template (subpartition h start(1) end(10)) 
 subpartition by range(c)
@@ -5968,7 +5964,6 @@ DROP TABLE IF EXISTS user_prt_acl.t_part_acl;
 DROP SCHEMA IF EXISTS user_prt_acl;
 DROP ROLE IF EXISTS user_prt_acl;
 CREATE ROLE user_prt_acl;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 CREATE SCHEMA schema_part_acl;
 GRANT USAGE ON SCHEMA schema_part_acl TO user_prt_acl;
 ALTER DEFAULT PRIVILEGES IN SCHEMA schema_part_acl GRANT SELECT ON TABLES TO user_prt_acl;

--- a/src/test/regress/expected/partition_optimizer.out
+++ b/src/test/regress/expected/partition_optimizer.out
@@ -157,7 +157,6 @@ ALTER TABLE two_level_pt ALTER PARTITION FOR (1)
 ERROR:  child table is missing column "b"
 -- different owner 
 create role part_role;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 create table bar_p (i int, j int) distributed by (i);
 set session authorization part_role;
 -- should fail
@@ -248,7 +247,6 @@ select * from bar_d;
 drop table foo_p, bar_d;
 -- permissions
 create role part_role;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 create table foo_p (i int) partition by range(i) (start(1) end(10) every(1));
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
@@ -1453,7 +1451,6 @@ LINE 2: end('f'::bool));
             ^
 -- see that grant and revoke cascade to children
 create role part_role;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 create table granttest (i int, j int) partition by range(i) 
 subpartition by list(j) subpartition template (values(1, 2, 3))
 (start(1) end(4) every(1));
@@ -2011,7 +2008,6 @@ drop table k;
 -- ADD and SPLIT must get inherit permissions of the partition they're
 -- modifying
 create role part_role;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 create table a (a int, b int, c int) partition by range(a) subpartition by
 range(b) subpartition template (subpartition h start(1) end(10)) 
 subpartition by range(c)
@@ -5958,7 +5954,6 @@ DROP TABLE IF EXISTS user_prt_acl.t_part_acl;
 DROP SCHEMA IF EXISTS user_prt_acl;
 DROP ROLE IF EXISTS user_prt_acl;
 CREATE ROLE user_prt_acl;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 CREATE SCHEMA schema_part_acl;
 GRANT USAGE ON SCHEMA schema_part_acl TO user_prt_acl;
 ALTER DEFAULT PRIVILEGES IN SCHEMA schema_part_acl GRANT SELECT ON TABLES TO user_prt_acl;

--- a/src/test/regress/expected/pg_stat_last_shoperation.out
+++ b/src/test/regress/expected/pg_stat_last_shoperation.out
@@ -1,7 +1,6 @@
 -- Check if pg_stat_last_shoperation stores CREATE of global objects
 CREATE DATABASE shoperation;
 CREATE ROLE shoperation_user;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 SELECT count(*) FROM pg_stat_last_shoperation
 WHERE staactionname = 'CREATE' AND stasubtype = 'DATABASE'
 AND objid = (SELECT oid FROM pg_database WHERE datname = 'shoperation');

--- a/src/test/regress/expected/psql_gp_commands.out
+++ b/src/test/regress/expected/psql_gp_commands.out
@@ -121,7 +121,6 @@ DROP ROLE test_psql_du_e9;
 -- Create a test schema, with different kinds of relations. To make the
 -- expected output insensitive to the current username, change the owner.
 CREATE ROLE test_psql_de_role;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 CREATE FOREIGN DATA WRAPPER dummy_wrapper;
 COMMENT ON FOREIGN DATA WRAPPER dummy_wrapper IS 'useless';
 CREATE SERVER dummy_server FOREIGN DATA WRAPPER dummy_wrapper;

--- a/src/test/regress/expected/qp_misc_jiras.out
+++ b/src/test/regress/expected/qp_misc_jiras.out
@@ -189,7 +189,6 @@ tot_trk_conv bigint,
 all_conv bigint,
 rank integer);
 create role tbl4009_gpadmin;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 alter type qp_misc_jiras.tbl4009_mediageoitem owner to tbl4009_gpadmin;
 select typname, rolname as owner from pg_type,pg_authid where typname='tbl4009_mediageoitem' and pg_type.typowner=pg_authid.oid;
        typname        |      owner      

--- a/src/test/regress/expected/qp_misc_jiras_optimizer.out
+++ b/src/test/regress/expected/qp_misc_jiras_optimizer.out
@@ -188,7 +188,6 @@ tot_trk_conv bigint,
 all_conv bigint,
 rank integer);
 create role tbl4009_gpadmin;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 alter type qp_misc_jiras.tbl4009_mediageoitem owner to tbl4009_gpadmin;
 select typname, rolname as owner from pg_type,pg_authid where typname='tbl4009_mediageoitem' and pg_type.typowner=pg_authid.oid;
        typname        |      owner      

--- a/src/test/regress/expected/qp_misc_rio.out
+++ b/src/test/regress/expected/qp_misc_rio.out
@@ -601,10 +601,8 @@ drop role if exists triggertest_nopriv_b;
 -- end_ignore
 -- Create a non-privileged user triggertest_nopriv_a
 create role triggertest_nopriv_a with login ;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 -- Create another non-privileged user triggertest_nopriv_b
 create role triggertest_nopriv_b with login ;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 GRANT ALL ON SCHEMA qp_misc_rio TO triggertest_nopriv_a;
 GRANT ALL ON SCHEMA qp_misc_rio TO triggertest_nopriv_b;
 -- Connect as non-privileged user "triggertest_nopriv_a"

--- a/src/test/regress/expected/resource_group.out
+++ b/src/test/regress/expected/resource_group.out
@@ -31,14 +31,11 @@ CREATE RESOURCE GROUP rg_dump_test3 WITH (concurrency=2, cpu_hard_quota_limit=5)
 WARNING:  resource group is disabled
 HINT:  To enable set gp_resource_manager=group
 CREATE ROLE role_dump_test1 RESOURCE GROUP rg_dump_test1;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 WARNING:  resource group is disabled
 HINT:  To enable set gp_resource_manager=group
 CREATE ROLE role_dump_test2 RESOURCE GROUP rg_dump_test2;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 WARNING:  resource group is disabled
 HINT:  To enable set gp_resource_manager=group
 CREATE ROLE role_dump_test3 RESOURCE GROUP rg_dump_test3;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 WARNING:  resource group is disabled
 HINT:  To enable set gp_resource_manager=group

--- a/src/test/regress/expected/resource_manager_restore_to_none.out
+++ b/src/test/regress/expected/resource_manager_restore_to_none.out
@@ -1,0 +1,36 @@
+-- start_ignore
+\! gpconfig -c gp_resource_manager -v none
+20230110:23:11:33:399571 gpconfig:ubuntu:gpadmin-[INFO]:-completed successfully with parameters '-c gp_resource_manager -v none'
+-- end_ignore
+\! echo $?
+0
+-- start_ignore
+\! gpstop -rai
+20230110:23:11:33:400128 gpstop:ubuntu:gpadmin-[INFO]:-Starting gpstop with args: -rai
+20230110:23:11:33:400128 gpstop:ubuntu:gpadmin-[INFO]:-Gathering information and validating the environment...
+20230110:23:11:33:400128 gpstop:ubuntu:gpadmin-[INFO]:-Obtaining Greenplum Coordinator catalog information
+20230110:23:11:33:400128 gpstop:ubuntu:gpadmin-[INFO]:-Obtaining Segment details from coordinator...
+20230110:23:11:33:400128 gpstop:ubuntu:gpadmin-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 7.0.0-alpha.0+dev.16142.g1f3e5a0825 build dev'
+20230110:23:11:33:400128 gpstop:ubuntu:gpadmin-[INFO]:-Commencing Coordinator instance shutdown with mode='immediate'
+20230110:23:11:33:400128 gpstop:ubuntu:gpadmin-[INFO]:-Coordinator segment instance directory=/home/gpadmin/zxj/workspace/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
+20230110:23:11:33:400128 gpstop:ubuntu:gpadmin-[INFO]:-Attempting forceful termination of any leftover coordinator process
+20230110:23:11:33:400128 gpstop:ubuntu:gpadmin-[INFO]:-Terminating processes for segment /home/gpadmin/zxj/workspace/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
+20230110:23:11:34:400128 gpstop:ubuntu:gpadmin-[INFO]:-Stopping coordinator standby host ubuntu mode=immediate
+20230110:23:11:35:400128 gpstop:ubuntu:gpadmin-[INFO]:-Successfully shutdown standby process on ubuntu
+20230110:23:11:35:400128 gpstop:ubuntu:gpadmin-[INFO]:-Targeting dbid [2, 5, 3, 6, 4, 7] for shutdown
+20230110:23:11:35:400128 gpstop:ubuntu:gpadmin-[INFO]:-Commencing parallel primary segment instance shutdown, please wait...
+20230110:23:11:35:400128 gpstop:ubuntu:gpadmin-[INFO]:-0.00% of jobs completed
+20230110:23:11:35:400128 gpstop:ubuntu:gpadmin-[INFO]:-100.00% of jobs completed
+20230110:23:11:35:400128 gpstop:ubuntu:gpadmin-[INFO]:-Commencing parallel mirror segment instance shutdown, please wait...
+20230110:23:11:35:400128 gpstop:ubuntu:gpadmin-[INFO]:-0.00% of jobs completed
+20230110:23:11:36:400128 gpstop:ubuntu:gpadmin-[INFO]:-100.00% of jobs completed
+20230110:23:11:36:400128 gpstop:ubuntu:gpadmin-[INFO]:-----------------------------------------------------
+20230110:23:11:36:400128 gpstop:ubuntu:gpadmin-[INFO]:-   Segments stopped successfully      = 6
+20230110:23:11:36:400128 gpstop:ubuntu:gpadmin-[INFO]:-   Segments with errors during stop   = 0
+20230110:23:11:36:400128 gpstop:ubuntu:gpadmin-[INFO]:-----------------------------------------------------
+20230110:23:11:36:400128 gpstop:ubuntu:gpadmin-[INFO]:-Successfully shutdown 6 of 6 segment instances 
+20230110:23:11:36:400128 gpstop:ubuntu:gpadmin-[INFO]:-Database successfully shutdown with no errors reported
+20230110:23:11:36:400128 gpstop:ubuntu:gpadmin-[INFO]:-Restarting System...
+-- end_ignore
+\! echo $?
+0

--- a/src/test/regress/expected/resource_manager_switch_to_queue.out
+++ b/src/test/regress/expected/resource_manager_switch_to_queue.out
@@ -1,0 +1,32 @@
+-- start_ignore
+\! gpconfig -c gp_resource_manager -v queue
+20230109:22:58:10:221578 gpconfig:ubuntu:gpadmin-[INFO]:-completed successfully with parameters '-c gp_resource_manager -v queue'
+-- end_ignore
+\! echo $?
+0
+-- start_ignore
+\! gpstop -rai
+20230109:22:58:10:221895 gpstop:ubuntu:gpadmin-[INFO]:-Starting gpstop with args: -rai
+20230109:22:58:10:221895 gpstop:ubuntu:gpadmin-[INFO]:-Gathering information and validating the environment...
+20230109:22:58:10:221895 gpstop:ubuntu:gpadmin-[INFO]:-Obtaining Greenplum Coordinator catalog information
+20230109:22:58:10:221895 gpstop:ubuntu:gpadmin-[INFO]:-Obtaining Segment details from coordinator...
+20230109:22:58:10:221895 gpstop:ubuntu:gpadmin-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 7.0.0-alpha.0+dev.16117.g367b82d8d9 build dev'
+20230109:22:58:10:221895 gpstop:ubuntu:gpadmin-[INFO]:-Commencing Coordinator instance shutdown with mode='immediate'
+20230109:22:58:10:221895 gpstop:ubuntu:gpadmin-[INFO]:-Coordinator segment instance directory=/home/gpadmin/zxj/workspace/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
+20230109:22:58:10:221895 gpstop:ubuntu:gpadmin-[INFO]:-Attempting forceful termination of any leftover coordinator process
+20230109:22:58:10:221895 gpstop:ubuntu:gpadmin-[INFO]:-Terminating processes for segment /home/gpadmin/zxj/workspace/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
+20230109:22:58:10:221895 gpstop:ubuntu:gpadmin-[INFO]:-No standby coordinator host configured
+20230109:22:58:10:221895 gpstop:ubuntu:gpadmin-[INFO]:-Targeting dbid [2, 3, 4] for shutdown
+20230109:22:58:10:221895 gpstop:ubuntu:gpadmin-[INFO]:-Commencing parallel segment instance shutdown, please wait...
+20230109:22:58:10:221895 gpstop:ubuntu:gpadmin-[INFO]:-0.00% of jobs completed
+20230109:22:58:11:221895 gpstop:ubuntu:gpadmin-[INFO]:-100.00% of jobs completed
+20230109:22:58:11:221895 gpstop:ubuntu:gpadmin-[INFO]:-----------------------------------------------------
+20230109:22:58:11:221895 gpstop:ubuntu:gpadmin-[INFO]:-   Segments stopped successfully      = 3
+20230109:22:58:11:221895 gpstop:ubuntu:gpadmin-[INFO]:-   Segments with errors during stop   = 0
+20230109:22:58:11:221895 gpstop:ubuntu:gpadmin-[INFO]:-----------------------------------------------------
+20230109:22:58:11:221895 gpstop:ubuntu:gpadmin-[INFO]:-Successfully shutdown 3 of 3 segment instances 
+20230109:22:58:11:221895 gpstop:ubuntu:gpadmin-[INFO]:-Database successfully shutdown with no errors reported
+20230109:22:58:11:221895 gpstop:ubuntu:gpadmin-[INFO]:-Restarting System...
+-- end_ignore
+\! echo $?
+0

--- a/src/test/regress/expected/resource_queue.out
+++ b/src/test/regress/expected/resource_queue.out
@@ -1,4 +1,7 @@
 -- SQL coverage of RESOURCE QUEUE
+-- start_ignore
+create extension if not exists gp_inject_fault;
+-- end_ignore
 CREATE RESOURCE QUEUE regressq ACTIVE THRESHOLD 1;
 SELECT rsqname, rsqcountlimit, rsqcostlimit, rsqovercommit, rsqignorecostlimit FROM pg_resqueue WHERE rsqname='regressq';
  rsqname  | rsqcountlimit | rsqcostlimit | rsqovercommit | rsqignorecostlimit 

--- a/src/test/regress/expected/role.out
+++ b/src/test/regress/expected/role.out
@@ -14,17 +14,11 @@ DROP ROLE IF EXISTS role_setting_test_4;
 DROP ROLE IF EXISTS role_setting_test_5;
 DROP ROLE IF EXISTS role_setting_test_6;
 CREATE ROLE role_setting_test_1 NOLOGIN;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 CREATE ROLE role_setting_test_2 NOLOGIN;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 CREATE ROLE role_setting_test_3 NOLOGIN;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 CREATE ROLE role_setting_test_4 NOLOGIN;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 CREATE ROLE role_setting_test_5 NOLOGIN;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 CREATE ROLE role_setting_test_6 NOLOGIN;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 CREATE SCHEMA common_schema;
 /* Alter Role Set, with a GUC with units (statement_mem) and not (search_path) */
 ALTER ROLE role_setting_test_1 SET statement_mem TO '150MB';
@@ -62,9 +56,7 @@ ALTER ROLE role_setting_test_6 IN DATABASE regression RESET ALL;
 -- Note: Don't drop the test roles, so that they get tested with pg_dump/restore, too,
 -- if you dump the regression database.
 create role superuser;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 create role u1;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 set role superuser;
 create table t1(a int, b int constraint c check (b>=100));
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
@@ -83,9 +75,7 @@ drop role u1;
 drop role superuser;
 -- Test creating user who has been renamed before.
 CREATE USER jonathan11 WITH PASSWORD 'abc1';
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 CREATE USER jonathan12 WITH PASSWORD 'abc2';
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 ALTER USER jonathan11 RENAME TO jona11;
 NOTICE:  MD5 password cleared because of role rename
 ALTER USER jonathan12 RENAME TO jona12;
@@ -93,13 +83,11 @@ NOTICE:  MD5 password cleared because of role rename
 DROP USER jona11;
 DROP USER jona12;
 CREATE USER jonathan12 WITH PASSWORD 'abc2';
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 ALTER USER jonathan11 RENAME TO jona11;
 ERROR:  role "jonathan11" does not exist
 ALTER USER jonathan12 RENAME TO jona12;
 NOTICE:  MD5 password cleared because of role rename
 CREATE GROUP marketing WITH USER jona11,jona12;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 ERROR:  role "jona11" does not exist
 ALTER GROUP marketing RENAME TO market;
 ERROR:  role "marketing" does not exist
@@ -118,7 +106,6 @@ reset client_min_messages;
 -- Create a user with two per-user settings. One is superuser-only,
 -- and another is not.
 create user guctestrole;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 alter user guctestrole set zero_damaged_pages=off; -- PGC_SUSET
 alter user guctestrole set application_name='test'; -- PGC_USERSET
 select rolconfig from pg_roles where rolname = 'guctestrole';

--- a/src/test/regress/expected/update.out
+++ b/src/test/regress/expected/update.out
@@ -636,7 +636,6 @@ DROP FUNCTION func_parted_mod_b();
 -----------------------------------------
 ALTER TABLE range_parted ENABLE ROW LEVEL SECURITY;
 CREATE USER regress_range_parted_user;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 GRANT ALL ON range_parted, mintab TO regress_range_parted_user;
 CREATE POLICY seeall ON range_parted AS PERMISSIVE FOR SELECT USING (true);
 CREATE POLICY policy_range_parted ON range_parted for UPDATE USING (true) WITH CHECK (c % 2 = 0);

--- a/src/test/regress/expected/vacuum_gp.out
+++ b/src/test/regress/expected/vacuum_gp.out
@@ -260,7 +260,6 @@ vacuum full ao_t1;
 drop table ao_t1;
 -- superuser must be able to vacuum analyze the table
 CREATE ROLE r_priv_test;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 CREATE SCHEMA s_priv_test;
 CREATE TABLE s_priv_test.t_priv_table(a INT);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.

--- a/src/test/regress/expected/workfile/hashagg_spill.out
+++ b/src/test/regress/expected/workfile/hashagg_spill.out
@@ -41,7 +41,6 @@ insert into testhagg select i,i,i,i from
 	(select count(*) as nsegments from gp_segment_configuration where role='p' and content >= 0) foo) bar;
 analyze testhagg;
 set statement_mem="1800";
-set gp_resqueue_print_operator_memory_limits=on;
 -- the number of rows returned by the query varies depending on the number of segments, so
 -- only print the first 10
 select * from (select max(i1) from testhagg group by i2) foo order by 1 limit 10;

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -180,9 +180,6 @@ test: minirepro
 # NOTE: gporca_faults uses gp_fault_injector - so do not add to a parallel group
 test: gporca_faults
 
-# RESOURCE_QUEUE_FIXME: Do we need to modify bb_memory_quota to test resource group?
-#test: bb_memory_quota
-
 # Tests for replicated table
 test: rpt rpt_joins rpt_tpch rpt_returning
 
@@ -200,8 +197,6 @@ test: qp_misc_rio_join_small qp_correlated_query qp_targeted_dispatch qp_gist_in
 
 test: dpe qp_dpe qp_subquery qp_left_anti_semi_join qp_union_intersect qp_functions qp_functions_idf qp_regexp qp_orca_fallback gp_sync_lc_gucs
 
-#RESOURCE_QUEUE_FIXME: Do we nedd to change qp_resource_queue to qp_resource_group to test query process while using resource group?
-#test: qp_resource_queue
 test: olap_setup
 test: qp_olap_group qp_olap_group2
 
@@ -330,6 +325,16 @@ test: uao_dml/ao_unique_index_build_row uao_dml/ao_unique_index_build_column
 
 # test column projection for various operations
 test: aoco_projection
+# test resource queue, can not put other test in resource queue.
+test: resource_manager_switch_to_queue
+test: resource_queue
+test: resource_queue_stat
+test: resource_queue_with_rule
+test: bb_memory_quota
+test: qp_resource_queue
+test: resource_queue_function
+test: gp_toolkit_resqueue
+test: resource_manager_restore_to_none
 
 # test dispatch and result handling of gp_log_memory_backend_contexts
 test: gp_log_mem_dispatch

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -48,7 +48,7 @@ test: instr_in_shmem_setup
 test: instr_in_shmem
 
 test: createdb
-test: gp_aggregates gp_aggregates_costs gp_metadata variadic_parameters default_parameters function_extensions spi gp_xml shared_scan update_gp triggers_gp returning_gp resource_queue_with_rule gp_types gp_index cluster_gp combocid_gp gp_sort gp_prepared_xacts gp_backend_info
+test: gp_aggregates gp_aggregates_costs gp_metadata variadic_parameters default_parameters function_extensions spi gp_xml shared_scan update_gp triggers_gp returning_gp gp_types gp_index cluster_gp combocid_gp gp_sort gp_prepared_xacts gp_backend_info
 test: spi_processed64bit
 test: gp_lock
 test: gp_tablespace_with_faults
@@ -149,8 +149,6 @@ test: alter_table_set alter_table_gp alter_table_ao alter_table_set_am subtransa
 test: aocs
 test: ic
 
-test: resource_queue
-test: resource_queue_function
 test: disable_autovacuum
 # Check for shmem leak for instrumentation slots before gpdb restart
 test: instr_in_shmem_verify
@@ -158,7 +156,6 @@ test: instr_in_shmem_verify
 # hold locks.
 test: partition_locking
 test: vacuum_gp
-test: resource_queue_stat
 # background analyze may affect pgstat
 test: pg_stat
 test: bfv_partition qp_misc_rio
@@ -169,7 +166,6 @@ test: enable_autovacuum
 test: resource_group
 test: resource_group_cpuset
 test: resource_group_gucs
-test: wrkloadadmin
 
 # expand_table tests may affect the result of 'gp_explain', keep them below that
 test: gp_toolkit_ao_funcs trig auth_constraint role portals_updatable plpgsql_cache timeseries pg_stat_last_operation pg_stat_last_shoperation gp_numeric_agg partindex_test partition_pruning runtime_stats expand_table expand_table_ao expand_table_aoco expand_table_regression
@@ -184,7 +180,8 @@ test: minirepro
 # NOTE: gporca_faults uses gp_fault_injector - so do not add to a parallel group
 test: gporca_faults
 
-test: bb_memory_quota
+# RESOURCE_QUEUE_FIXME: Do we need to modify bb_memory_quota to test resource group?
+#test: bb_memory_quota
 
 # Tests for replicated table
 test: rpt rpt_joins rpt_tpch rpt_returning
@@ -201,8 +198,10 @@ test: qp_with_functional_inlining qp_with_functional_noinlining
 test: qp_functions_in_contexts_setup
 test: qp_misc_rio_join_small qp_correlated_query qp_targeted_dispatch qp_gist_indexes2 qp_gist_indexes3 qp_gist_indexes4 qp_query_execution qp_functions_in_from qp_functions_in_select qp_functions_in_subquery qp_functions_in_subquery_column qp_functions_in_subquery_constant qp_functions_in_with correlated_subquery
 
-test: dpe qp_dpe qp_subquery qp_left_anti_semi_join qp_union_intersect qp_functions qp_functions_idf qp_regexp qp_resource_queue qp_orca_fallback gp_sync_lc_gucs
+test: dpe qp_dpe qp_subquery qp_left_anti_semi_join qp_union_intersect qp_functions qp_functions_idf qp_regexp qp_orca_fallback gp_sync_lc_gucs
 
+#RESOURCE_QUEUE_FIXME: Do we nedd to change qp_resource_queue to qp_resource_group to test query process while using resource group?
+#test: qp_resource_queue
 test: olap_setup
 test: qp_olap_group qp_olap_group2
 

--- a/src/test/regress/output/appendonly.source
+++ b/src/test/regress/output/appendonly.source
@@ -1477,7 +1477,6 @@ SELECT * FROM appendonly_subxans_test WHERE a < 10;
 (0 rows)
 
 CREATE ROLE appendony_test_user2;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 BEGIN;
 CREATE TABLE fo(a int, b int) WITH (appendonly=true);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.

--- a/src/test/regress/output/auth_constraint.source
+++ b/src/test/regress/output/auth_constraint.source
@@ -16,7 +16,6 @@ LINE 1: SELECT check_auth_time_constraints('abc', '5');
 -- basic day level constraints
 --
 CREATE ROLE abc DENY DAY 2;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 select c.start_day, c.start_time, c.end_day, c.end_time from pg_authid a, pg_auth_time_constraint c where c.authid = a.oid and a.rolname = 'abc';
  start_day | start_time | end_day | end_time 
 -----------+------------+---------+----------
@@ -58,10 +57,8 @@ DROP ROLE abc;
 -- basic time level constraints
 --
 CREATE ROLE abc WITH LOGIN DENY DAY 'Saturday';
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 DROP ROLE abc;
 CREATE ROLE abc DENY DAY 2 TIME '13:15:34';
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 select c.start_day, c.start_time, c.end_day, c.end_time from pg_authid a, pg_auth_time_constraint c where c.authid = a.oid and a.rolname = 'abc';
  start_day | start_time | end_day | end_time 
 -----------+------------+---------+----------
@@ -91,7 +88,6 @@ DROP ROLE abc;
 -- some similar CREATE ROLE coverage
 --
 CREATE ROLE abc DENY BETWEEN DAY 2 AND DAY 3;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 select c.start_day, c.start_time, c.end_day, c.end_time from pg_authid a, pg_auth_time_constraint c where c.authid = a.oid and a.rolname = 'abc';
  start_day | start_time | end_day | end_time 
 -----------+------------+---------+----------
@@ -124,7 +120,6 @@ SELECT check_auth_time_constraints('abc', '2011-09-01 00:00:00');
 
 DROP ROLE abc;
 CREATE ROLE abc DENY BETWEEN DAY 2 TIME '05:30:30' AND DAY 3;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 select c.start_day, c.start_time, c.end_day, c.end_time from pg_authid a, pg_auth_time_constraint c where c.authid = a.oid and a.rolname = 'abc';
  start_day | start_time | end_day | end_time 
 -----------+------------+---------+----------
@@ -157,7 +152,6 @@ SELECT check_auth_time_constraints('abc', '2011-09-01 00:00:00');
 
 DROP ROLE abc;
 CREATE ROLE abc DENY BETWEEN DAY 2 AND DAY 3 TIME '11:34:53';
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 select c.start_day, c.start_time, c.end_day, c.end_time from pg_authid a, pg_auth_time_constraint c where c.authid = a.oid and a.rolname = 'abc';
  start_day | start_time | end_day | end_time 
 -----------+------------+---------+----------
@@ -190,7 +184,6 @@ SELECT check_auth_time_constraints('abc', '2011-08-31 11:34:54');
 
 DROP ROLE abc;
 CREATE ROLE abc DENY BETWEEN DAY 2 TIME '15:24:20' AND DAY 3 TIME '11:34:53';
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 select c.start_day, c.start_time, c.end_day, c.end_time from pg_authid a, pg_auth_time_constraint c where c.authid = a.oid and a.rolname = 'abc';
  start_day | start_time | end_day | end_time 
 -----------+------------+---------+----------
@@ -226,7 +219,6 @@ DROP ROLE abc;
 -- ALTER ROLE grammar coverage (some repetition here)
 --
 CREATE ROLE abc;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 ALTER ROLE abc DENY DAY 2;
 select c.start_day, c.start_time, c.end_day, c.end_time from pg_authid a, pg_auth_time_constraint c where c.authid = a.oid and a.rolname = 'abc';
  start_day | start_time | end_day | end_time 
@@ -266,7 +258,6 @@ SELECT check_auth_time_constraints('abc', '2011-08-31 00:00:00');
 
 DROP ROLE abc;
 CREATE ROLE abc;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 ALTER ROLE abc DENY DAY 2 TIME '13:15:34';
 select c.start_day, c.start_time, c.end_day, c.end_time from pg_authid a, pg_auth_time_constraint c where c.authid = a.oid and a.rolname = 'abc';
  start_day | start_time | end_day | end_time 
@@ -294,7 +285,6 @@ SELECT check_auth_time_constraints('abc', '2011-08-30 13:15:35');
 
 DROP ROLE abc;
 CREATE ROLE abc;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 ALTER ROLE abc DENY BETWEEN DAY 2 AND DAY 3;
 select c.start_day, c.start_time, c.end_day, c.end_time from pg_authid a, pg_auth_time_constraint c where c.authid = a.oid and a.rolname = 'abc';
  start_day | start_time | end_day | end_time 
@@ -328,7 +318,6 @@ SELECT check_auth_time_constraints('abc', '2011-09-01 00:00:00');
 
 DROP ROLE abc;
 CREATE ROLE abc;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 ALTER ROLE abc DENY BETWEEN DAY 2 TIME '05:30:30' AND DAY 3;
 select c.start_day, c.start_time, c.end_day, c.end_time from pg_authid a, pg_auth_time_constraint c where c.authid = a.oid and a.rolname = 'abc';
  start_day | start_time | end_day | end_time 
@@ -362,7 +351,6 @@ SELECT check_auth_time_constraints('abc', '2011-09-01 00:00:00');
 
 DROP ROLE abc;
 CREATE ROLE abc;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 ALTER ROLE abc DENY BETWEEN DAY 2 AND DAY 3 TIME '11:34:53';
 select c.start_day, c.start_time, c.end_day, c.end_time from pg_authid a, pg_auth_time_constraint c where c.authid = a.oid and a.rolname = 'abc';
  start_day | start_time | end_day | end_time 
@@ -396,7 +384,6 @@ SELECT check_auth_time_constraints('abc', '2011-08-31 11:34:54');
 
 DROP ROLE abc;
 CREATE ROLE abc;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 ALTER ROLE abc DENY BETWEEN DAY 2 TIME '15:24:20' AND DAY 3 TIME '11:34:53';
 select c.start_day, c.start_time, c.end_day, c.end_time from pg_authid a, pg_auth_time_constraint c where c.authid = a.oid and a.rolname = 'abc';
  start_day | start_time | end_day | end_time 
@@ -433,7 +420,6 @@ DROP ROLE abc;
 -- very minimal coverage of CREATE USER and ALTER USER
 --
 CREATE USER abc DENY DAY 2;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 select c.start_day, c.start_time, c.end_day, c.end_time from pg_authid a, pg_auth_time_constraint c where c.authid = a.oid and a.rolname = 'abc';
  start_day | start_time | end_day | end_time 
 -----------+------------+---------+----------
@@ -467,7 +453,6 @@ DROP USER abc;
 -- CREATE ROLE w/ multiple deny specifications
 --
 CREATE ROLE abc DENY DAY 0 DENY DAY 2 DENY BETWEEN DAY 4 AND DAY 5 TIME '13:00:00';
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 select c.start_day, c.start_time, c.end_day, c.end_time from pg_authid a, pg_auth_time_constraint c where c.authid = a.oid and a.rolname = 'abc';
  start_day | start_time | end_day | end_time 
 -----------+------------+---------+----------
@@ -553,7 +538,6 @@ DROP ROLE abc;
 -- ALTER ROLE w/ multiple deny specifications
 --
 CREATE ROLE abc;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 ALTER ROLE abc DENY DAY 0 DENY DAY 2 DENY BETWEEN DAY 4 AND DAY 5 TIME '13:00:00';
 select c.start_day, c.start_time, c.end_day, c.end_time from pg_authid a, pg_auth_time_constraint c where c.authid = a.oid and a.rolname = 'abc';
  start_day | start_time | end_day | end_time 
@@ -641,7 +625,6 @@ DROP ROLE abc;
 -- This syntax drops any rule that *overlaps* with the specified point/interval.
 --
 CREATE ROLE abc DENY DAY 2;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 select c.start_day, c.start_time, c.end_day, c.end_time from pg_authid a, pg_auth_time_constraint c where c.authid = a.oid and a.rolname = 'abc';
  start_day | start_time | end_day | end_time 
 -----------+------------+---------+----------
@@ -669,7 +652,6 @@ SELECT check_auth_time_constraints('abc', '2011-08-30 12:00:00');
 
 DROP ROLE abc;
 CREATE ROLE abc;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 ALTER ROLE abc DENY BETWEEN DAY 2 TIME '01:00' AND DAY 2 TIME '02:00';
 ALTER ROLE abc DENY BETWEEN DAY 2 TIME '23:00' AND DAY 3 TIME '03:00';
 select c.start_day, c.start_time, c.end_day, c.end_time from pg_authid a, pg_auth_time_constraint c where c.authid = a.oid and a.rolname = 'abc';
@@ -713,7 +695,6 @@ SELECT check_auth_time_constraints('abc', '2011-08-31 01:00:00');
 
 DROP ROLE abc;
 CREATE ROLE abc;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 ALTER ROLE abc DENY DAY 0 DENY DAY 1;
 ALTER ROLE abc DROP DENY FOR DAY 2;
 ERROR:  cannot find matching DENY rules for "abc"
@@ -723,7 +704,6 @@ DROP ROLE abc;
 -- This should error out, as the expected behavior isn't quite intuitive.
 --
 CREATE ROLE abc;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 ALTER ROLE abc DENY DAY 0 DENY DAY 1 DENY DAY 2 DROP DENY FOR DAY 1;
 ERROR:  conflicting or redundant options
 HINT:  DENY and DROP DENY cannot be used in the same ALTER ROLE statement.
@@ -732,7 +712,6 @@ DROP ROLE abc;
 -- DROP ROLE must release associated auth. constraints
 --
 CREATE ROLE abc DENY DAY 0 DENY DAY 1 DENY DAY 3 TIME '3:00 PM';
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 select c.start_day, c.start_time, c.end_day, c.end_time from pg_authid a, pg_auth_time_constraint c where c.authid = a.oid and a.rolname = 'abc';
  start_day | start_time | end_day | end_time 
 -----------+------------+---------+----------
@@ -753,7 +732,6 @@ select c.start_day, c.start_time, c.end_day, c.end_time from pg_authid a, pg_aut
 CREATE ROLE abc DENY BETWEEN DAY 6 TIME '12:00:00' AND DAY 0;
 ERROR:  time interval must not wrap around
 CREATE ROLE abc;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 ALTER ROLE abc DENY BETWEEN DAY 5 AND DAY 1;
 ERROR:  time interval must not wrap around
 DROP ROLE abc;
@@ -761,7 +739,6 @@ DROP ROLE abc;
 -- English days of week
 --
 CREATE ROLE abc DENY BETWEEN DAY 'Tuesday' TIME '12:00:00' AND DAY 2 TIME '1:00 PM';
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 select c.start_day, c.start_time, c.end_day, c.end_time from pg_authid a, pg_auth_time_constraint c where c.authid = a.oid and a.rolname = 'abc';
  start_day | start_time | end_day | end_time 
 -----------+------------+---------+----------
@@ -814,7 +791,6 @@ ERROR:  date/time field value out of range: "25:00"
 -- In other words, there is no way for the current time to ever be '24:00:00'.
 --
 CREATE ROLE abc DENY DAY 2 TIME '24:00:00';
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 select c.start_day, c.start_time, c.end_day, c.end_time from pg_authid a, pg_auth_time_constraint c where c.authid = a.oid and a.rolname = 'abc';
  start_day | start_time | end_day | end_time 
 -----------+------------+---------+----------
@@ -844,7 +820,6 @@ DROP ROLE abc;
 -- Inheritance of time constraints (negative)
 --
 CREATE ROLE abc DENY BETWEEN DAY 0 AND DAY 6;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 SELECT NOT check_auth_time_constraints('abc', '2011-08-31 12:00:00');
  ?column? 
 ----------
@@ -852,7 +827,6 @@ SELECT NOT check_auth_time_constraints('abc', '2011-08-31 12:00:00');
 (1 row)
 
 CREATE ROLE foo IN ROLE abc;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 SELECT check_auth_time_constraints('foo', '2011-08-31 12:00:00');
  check_auth_time_constraints 
 -----------------------------
@@ -866,7 +840,6 @@ DROP ROLE abc;
 --
 SET allow_system_table_mods=true;
 CREATE ROLE abc;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 insert into pg_auth_time_constraint (select oid, 2, '12:00:00', 3, '12:00:00' from pg_authid where rolname = 'abc');
 select c.start_day, c.start_time, c.end_day, c.end_time from pg_authid a, pg_auth_time_constraint c where c.authid = a.oid and a.rolname = 'abc';
  start_day | start_time | end_day | end_time 
@@ -947,7 +920,6 @@ RESET allow_system_table_mods;
 -- Superuser testing across CREATE ROLE, ALTER ROLE, and trigger
 --
 create role abc with login nosuperuser nocreaterole;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 drop role abc;
 create role abc superuser deny day 1;
 ERROR:  cannot create superuser with DENY rules
@@ -956,12 +928,10 @@ alter role abc deny day 1;
 ERROR:  cannot alter superuser with DENY rules
 drop role abc;
 create role abc;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 alter role abc superuser deny day 1;
 ERROR:  cannot alter superuser with DENY rules
 drop role abc;
 create role abc deny day 1;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 alter role abc superuser;
 SELECT check_auth_time_constraints('abc', '2011-08-29 12:00:00');
  check_auth_time_constraints 
@@ -986,7 +956,6 @@ RESET allow_system_table_mods;
 -- More DENY tests.
 --
 CREATE ROLE abc WITH LOGIN DENY BETWEEN DAY 'Monday' TIME '01:00:00' AND DAY 'Monday' TIME '01:30:00';;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 SELECT r.rolname, d.start_day, d.start_time, d.end_day, d.end_time
 FROM pg_auth_time_constraint d join pg_roles r ON (d.authid = r.oid)
 WHERE r.rolname = 'abc'

--- a/src/test/regress/output/bb_memory_quota.source
+++ b/src/test/regress/output/bb_memory_quota.source
@@ -1,5 +1,4 @@
 create user memquota_role1 with nosuperuser nocreatedb nocreaterole;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 GRANT ALL PRIVILEGES ON PUBLIC.heap_orders TO memquota_role1;
 create resource queue memquota_resqueue1 active threshold 4;
 alter resource queue memquota_resqueue1 with (memory_limit = '500MB');

--- a/src/test/regress/output/external_table.source
+++ b/src/test/regress/output/external_table.source
@@ -283,7 +283,6 @@ ERROR:  protocol "demoprot_untrusted2" already exists
 ALTER PROTOCOL demoprot_untrustedx RENAME TO demoprot_untrusted2; --should failed
 ERROR:  protocol "demoprot_untrustedx" does not exist
 CREATE ROLE extprotu NOSUPERUSER;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 SET SESSION AUTHORIZATION extprotu;
 CREATE WRITABLE EXTERNAL TABLE ext_w(a int) location('demoprot://demoprotfile.txt') format 'text'; -- should fail
 ERROR:  permission denied for external protocol demoprot
@@ -340,7 +339,6 @@ DROP PROTOCOL demoprot_droptest1, demoprot_droptest2;
 DROP ROLE IF EXISTS extprot_non_superuser;
 NOTICE:  role "extprot_non_superuser" does not exist, skipping
 CREATE ROLE extprot_non_superuser WITH NOSUPERUSER LOGIN CREATEDB;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 SET ROLE extprot_non_superuser;
 CREATE PROTOCOL demoprot_non_superuser (readfunc = 'read_from_file', writefunc = 'write_to_file');
 ERROR:  must be superuser to create an external protocol
@@ -351,7 +349,6 @@ RESET ROLE;
 -- GitHub Issue #12748: https://github.com/greenplum-db/gpdb/issues/12748
 CREATE TRUSTED PROTOCOL dummy_protocol_issue_12748 (readfunc = 'read_from_file', writefunc = 'write_to_file');
 CREATE ROLE test_role_issue_12748;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 GRANT ALL ON PROTOCOL dummy_protocol_issue_12748 TO test_role_issue_12748;
 DROP OWNED BY test_role_issue_12748;
 -- Clean up.
@@ -933,7 +930,6 @@ CONTEXT:  External table exttab_permissions_2, line 7 of file://@hostname@@abs_s
 -- Only superuser can do gp_truncate_error_log('*.*')
 DROP ROLE IF EXISTS exttab_non_superuser;
 CREATE ROLE exttab_non_superuser WITH NOSUPERUSER LOGIN CREATEDB;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 SET ROLE exttab_non_superuser;
 SELECT COUNT(*) FROM gp_read_error_log('exttab_permissions_1');
 ERROR:  permission denied for table exttab_permissions_1  (seg2 slice1 @hostname@:40002 pid=50448)
@@ -997,9 +993,7 @@ DROP DATABASE IF EXISTS exttab_db;
 DROP ROLE IF EXISTS exttab_user1;
 DROP ROLE IF EXISTS exttab_user2;
 CREATE ROLE exttab_user1 WITH NOSUPERUSER LOGIN;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 CREATE ROLE exttab_user2 WITH NOSUPERUSER LOGIN;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 CREATE DATABASE exttab_db WITH OWNER=exttab_user1;
 \c exttab_db
 -- generate some error logs in this db
@@ -1054,9 +1048,7 @@ SELECT * FROM gp_read_error_log('exttab_permissions_1');
 DROP ROLE IF EXISTS errlog_exttab_user3;
 DROP ROLE IF EXISTS errlog_exttab_user4;
 CREATE ROLE errlog_exttab_user3 WITH NOSUPERUSER LOGIN;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 CREATE ROLE errlog_exttab_user4 WITH NOSUPERUSER LOGIN;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 -- generate some error logs in this db
 CREATE EXTERNAL TABLE exttab_permissions_3( i int, j text )
 LOCATION ('file://@hostname@@abs_srcdir@/data/exttab_few_errors.data') FORMAT 'TEXT' (DELIMITER '|')

--- a/src/test/regress/output/external_table_optimizer.source
+++ b/src/test/regress/output/external_table_optimizer.source
@@ -283,7 +283,6 @@ ERROR:  protocol "demoprot_untrusted2" already exists
 ALTER PROTOCOL demoprot_untrustedx RENAME TO demoprot_untrusted2; --should failed
 ERROR:  protocol "demoprot_untrustedx" does not exist
 CREATE ROLE extprotu NOSUPERUSER;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 SET SESSION AUTHORIZATION extprotu;
 CREATE WRITABLE EXTERNAL TABLE ext_w(a int) location('demoprot://demoprotfile.txt') format 'text'; -- should fail
 ERROR:  permission denied for external protocol demoprot
@@ -340,7 +339,6 @@ DROP PROTOCOL demoprot_droptest1, demoprot_droptest2;
 DROP ROLE IF EXISTS extprot_non_superuser;
 NOTICE:  role "extprot_non_superuser" does not exist, skipping
 CREATE ROLE extprot_non_superuser WITH NOSUPERUSER LOGIN CREATEDB;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 SET ROLE extprot_non_superuser;
 CREATE PROTOCOL demoprot_non_superuser (readfunc = 'read_from_file', writefunc = 'write_to_file');
 ERROR:  must be superuser to create an external protocol
@@ -351,7 +349,6 @@ RESET ROLE;
 -- GitHub Issue #12748: https://github.com/greenplum-db/gpdb/issues/12748
 CREATE TRUSTED PROTOCOL dummy_protocol_issue_12748 (readfunc = 'read_from_file', writefunc = 'write_to_file');
 CREATE ROLE test_role_issue_12748;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 GRANT ALL ON PROTOCOL dummy_protocol_issue_12748 TO test_role_issue_12748;
 DROP OWNED BY test_role_issue_12748;
 -- Clean up.
@@ -933,7 +930,6 @@ CONTEXT:  External table exttab_permissions_2, line 7 of file://@hostname@@abs_s
 -- Only superuser can do gp_truncate_error_log('*.*')
 DROP ROLE IF EXISTS exttab_non_superuser;
 CREATE ROLE exttab_non_superuser WITH NOSUPERUSER LOGIN CREATEDB;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 SET ROLE exttab_non_superuser;
 SELECT COUNT(*) FROM gp_read_error_log('exttab_permissions_1');
 ERROR:  permission denied for table exttab_permissions_1  (seg2 slice1 @hostname@:40002 pid=50448)
@@ -997,9 +993,7 @@ DROP DATABASE IF EXISTS exttab_db;
 DROP ROLE IF EXISTS exttab_user1;
 DROP ROLE IF EXISTS exttab_user2;
 CREATE ROLE exttab_user1 WITH NOSUPERUSER LOGIN;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 CREATE ROLE exttab_user2 WITH NOSUPERUSER LOGIN;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 CREATE DATABASE exttab_db WITH OWNER=exttab_user1;
 \c exttab_db
 -- generate some error logs in this db
@@ -1054,9 +1048,7 @@ SELECT * FROM gp_read_error_log('exttab_permissions_1');
 DROP ROLE IF EXISTS errlog_exttab_user3;
 DROP ROLE IF EXISTS errlog_exttab_user4;
 CREATE ROLE errlog_exttab_user3 WITH NOSUPERUSER LOGIN;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 CREATE ROLE errlog_exttab_user4 WITH NOSUPERUSER LOGIN;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 -- generate some error logs in this db
 CREATE EXTERNAL TABLE exttab_permissions_3( i int, j text )
 LOCATION ('file://@hostname@@abs_srcdir@/data/exttab_few_errors.data') FORMAT 'TEXT' (DELIMITER '|')

--- a/src/test/regress/output/gp_tablespace.source
+++ b/src/test/regress/output/gp_tablespace.source
@@ -452,7 +452,6 @@ SELECT spcoptions FROM pg_tablespace WHERE spcname = 'testspace_otherloc';
 (1 row)
 
 CREATE ROLE t_owner;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 ALTER TABLESPACE testspace_otherloc OWNER TO t_owner;
 SELECT rolname from pg_roles WHERE oid in (SELECT spcowner FROM pg_tablespace WHERE spcname = 'testspace_otherloc');
  rolname 

--- a/src/test/regress/output/uao_ddl/alter_ao_table_owner.source
+++ b/src/test/regress/output/uao_ddl/alter_ao_table_owner.source
@@ -7,7 +7,6 @@ Drop role if exists uao_user2 ;
 --- stop_ignore
 --Alter table to a new owner
 Create role uao_user2;
-NOTICE:  resource queue required -- using default resource queue "pg_default"
 create table sto_alt_uao4 (i int, j char(10)) DISTRIBUTED BY (i);
 insert into sto_alt_uao4 select i , 'cc'||i from generate_series(1,5) as i;
 Alter Table sto_alt_uao4  Owner to uao_user2;

--- a/src/test/regress/sql/gp_toolkit_resqueue.sql
+++ b/src/test/regress/sql/gp_toolkit_resqueue.sql
@@ -1,0 +1,56 @@
+-- Tests for the functions and views in gp_toolkit
+
+-- Create an empty database to test in, because some of the gp_toolkit views
+-- are really slow, when there are a lot of objects in the database.
+create database toolkit_testdb;
+\c toolkit_testdb
+
+create role toolkit_admin superuser createdb;
+create role toolkit_user1 login;
+
+
+-- Test Resource Queue views
+
+
+-- GP Resource Queue Activity
+select * from gp_toolkit.gp_resq_activity;
+
+-- GP Resource Queue Activity by Queue
+-- There is no resource queue, so should be empty
+select * from gp_toolkit.gp_resq_activity_by_queue;
+
+-- gp_resq_role
+select * from gp_toolkit.gp_resq_role where rrrolname like 'toolkit%';
+
+-- gp_locks_on_resqueue
+-- Should be empty because there is no one in the queue
+select * from gp_toolkit.gp_locks_on_resqueue;
+
+-- GP Resource Queue Activity for User
+set session authorization toolkit_user1;
+
+select resqname, resqstatus from gp_toolkit.gp_resq_activity where resqname='pg_default';
+reset session authorization;
+-- should be empty because the sql is completed
+select * from gp_toolkit.gp_resq_activity where resqrole = 'toolkit_user1';
+
+-- gp_pgdatabase_invalid
+-- Should be empty unless there is failure in the segment, it's a view from gp_pgdatabase
+select * from gp_toolkit.gp_pgdatabase_invalid;
+
+-- Test that the statistics on resource queue usage are properly updated and
+-- reflected in the pg_stat_resqueues view
+set stats_queue_level=on;
+create resource queue q with (active_statements = 10);
+create user resqueuetest with resource queue q;
+set role resqueuetest;
+select 1;
+select n_queries_exec from pg_stat_resqueues where queuename = 'q';
+reset role;
+drop role resqueuetest;
+drop resource queue q;
+
+\c regression
+drop database toolkit_testdb;
+drop role toolkit_user1;
+drop role toolkit_admin;

--- a/src/test/regress/sql/namespace_gp.sql
+++ b/src/test/regress/sql/namespace_gp.sql
@@ -11,7 +11,7 @@ CREATE SCHEMA test_schema_1
 -- Test GRANT/REVOKE
 CREATE SCHEMA test_schema_2;
 CREATE TABLE test_schema_2.abc as select * from test_schema_1.abc DISTRIBUTED BY (a);
-create role tmp_test_schema_role RESOURCE QUEUE pg_default;
+create role tmp_test_schema_role;
 GRANT ALL ON SCHEMA test_schema_1 to tmp_test_schema_role;
 
 SET SESSION AUTHORIZATION tmp_test_schema_role;

--- a/src/test/regress/sql/resource_manager_restore_to_none.sql
+++ b/src/test/regress/sql/resource_manager_restore_to_none.sql
@@ -1,0 +1,11 @@
+-- start_ignore
+\! gpconfig -c gp_resource_manager -v none
+-- end_ignore
+
+\! echo $?
+
+-- start_ignore
+\! gpstop -rai
+-- end_ignore
+
+\! echo $?

--- a/src/test/regress/sql/resource_manager_switch_to_queue.sql
+++ b/src/test/regress/sql/resource_manager_switch_to_queue.sql
@@ -1,0 +1,11 @@
+-- start_ignore
+\! gpconfig -c gp_resource_manager -v queue
+-- end_ignore
+
+\! echo $?
+
+-- start_ignore
+\! gpstop -rai
+-- end_ignore
+
+\! echo $?

--- a/src/test/regress/sql/resource_queue.sql
+++ b/src/test/regress/sql/resource_queue.sql
@@ -1,5 +1,7 @@
 -- SQL coverage of RESOURCE QUEUE
-
+-- start_ignore
+create extension if not exists gp_inject_fault;
+-- end_ignore
 CREATE RESOURCE QUEUE regressq ACTIVE THRESHOLD 1;
 SELECT rsqname, rsqcountlimit, rsqcostlimit, rsqovercommit, rsqignorecostlimit FROM pg_resqueue WHERE rsqname='regressq';
 ALTER RESOURCE QUEUE regressq ACTIVE THRESHOLD 2 COST THRESHOLD 2000.00;

--- a/src/test/regress/sql/workfile/hashagg_spill.sql
+++ b/src/test/regress/sql/workfile/hashagg_spill.sql
@@ -44,7 +44,6 @@ insert into testhagg select i,i,i,i from
 analyze testhagg;
 
 set statement_mem="1800";
-set gp_resqueue_print_operator_memory_limits=on;
 
 -- the number of rows returned by the query varies depending on the number of segments, so
 -- only print the first 10


### PR DESCRIPTION
1、add a new type RESOURCE_MANAGER_POLICY_NONE for ResourceMangerPolicy to indicate do not use any resource manager.  And use none as default for gp_resource_manager.

2、modify testcases remove NOTICE: resource queue required – using default resource queue "pg_default"

3、adjust resource queue test, before these cases we change gp_resource_manager to queue and after these cases we restore gp_resource_manager to none.