### PR TITLE
[6X] backport: Fix resgroup init error when there is a lot of cores in cpuset.cpus 

### DIFF
--- a/src/backend/utils/resgroup/resgroup-ops-linux.c
+++ b/src/backend/utils/resgroup/resgroup-ops-linux.c
@@ -967,7 +967,7 @@ static void
 readStr(Oid group, BaseType base,
 		ResGroupCompType comp, const char *prop, char *str, int len)
 {
-	char data[MAX_INT_STRING_LEN];
+	char data[MAX_CGROUP_CONTENTLEN];
 	size_t datasize = sizeof(data);
 	char path[MAXPATHLEN];
 	size_t pathsize = sizeof(path);

--- a/src/include/utils/resgroup.h
+++ b/src/include/utils/resgroup.h
@@ -29,6 +29,7 @@
  * The max length of cpuset
  */
 #define MaxCpuSetLength 1024
+#define MAX_CGROUP_CONTENTLEN 1024
 
 /*
  * Default value of cpuset


### PR DESCRIPTION
This backports 7X commit: https://github.com/greenplum-db/gpdb/commit/198ae8b857b4871076280db7144e101e85540213

When gpdb calls InitResGroups to init a postgres backend, 
readStr is called to read cpuset assigned to gpdb. However the size of data buffer in readStr is too small, cpuset string readed by gpdb is truncated.

This commit change the buffer size from MAX_INT_STRING_LEN(20) to MAX_CGROUP_CONTENTLEN(1024) to fix resgroup init error when there is a lot of cores in cpuset.cpus 

Fixes https://github.com/greenplum-db/gpdb/pull/14736
Please hava a look at this. 

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
