### PR TITLE
Remove FIXME in reindexdb.c

### DIFF
--- a/src/bin/scripts/reindexdb.c
+++ b/src/bin/scripts/reindexdb.c
@@ -292,10 +292,6 @@ reindex_one_database(const char *name, const char *dbname, const char *type,
 	conn = connectDatabase(dbname, host, port, username, prompt_password,
 						   progname, echo, false, false);
 
-	/*
-	 * GPDB_12_MERGE_FIXME: do we still report this as PostgreSQL 12 or should
-	 * it say Greenplum 7?
-	 */
 	if (concurrently && PQserverVersion(conn) < 120000)
 	{
 		PQfinish(conn);


### PR DESCRIPTION
We are testing PG server version, so we should remain consistent with upstream and report the PostgreSQL version to the user, otherwise we would be carrying significant diffs across the codebase with upstream forward.

Authored-by: Brent Doil <bdoil@vmware.com>