### PR TITLE
[Releng] [6X]Fix typo in pr pipeline

### DIFF
--- a/concourse/pipelines/pr_pipeline.yml
+++ b/concourse/pipelines/pr_pipeline.yml
@@ -104,7 +104,7 @@ jobs:
       - task: icw_planner_rocky8
         tags: [icw-worker]
         file: gpdb_pr/concourse/tasks/ic_gpdb.yml
-        image: gpdb6-centos7-test
+        image: gpdb6-rocky8-test
         input_mapping:
           gpdb_src: gpdb_pr
           bin_gpdb: gpdb_artifacts


### PR DESCRIPTION
Should switch to rocky8 for pr_pipeline, the image need to be rocky8

Authored-by: Shaoqi Bai <bshaoqi@vmware.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
