### PR TITLE
docs - sql ref page updates for DEALLOCATE/EXECUTE/PREPARE

### DIFF
--- a/gpdb-doc/markdown/ref_guide/sql_commands/DEALLOCATE.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/DEALLOCATE.html.md
@@ -5,7 +5,7 @@ Deallocates a prepared statement.
 ## <a id="section2"></a>Synopsis 
 
 ``` {#sql_command_synopsis}
-DEALLOCATE [PREPARE] <name>
+DEALLOCATE [PREPARE] { <name> | ALL }
 ```
 
 ## <a id="section3"></a>Description 
@@ -22,9 +22,12 @@ PREPARE
 name
 :   The name of the prepared statement to deallocate.
 
+ALL
+:   Deallocate all prepared statements
+
 ## <a id="section5"></a>Examples 
 
-Deallocated the previously prepared statement named `insert_names`:
+Deallocate the previously prepared statement named `insert_names`:
 
 ```
 DEALLOCATE insert_names;

--- a/gpdb-doc/markdown/ref_guide/sql_commands/EXECUTE.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/EXECUTE.html.md
@@ -12,9 +12,9 @@ EXECUTE <name> [ (<parameter> [, ...] ) ]
 
 `EXECUTE` is used to run a previously prepared statement. Since prepared statements only exist for the duration of a session, the prepared statement must have been created by a `PREPARE` statement run earlier in the current session.
 
-If the `PREPARE` statement that created the statement specified some parameters, a compatible set of parameters must be passed to the `EXECUTE` statement, or else an error is raised. Note that \(unlike functions\) prepared statements are not overloaded based on the type or number of their parameters; the name of a prepared statement must be unique within a database session.
+If the `PREPARE` statement that created the statement specified some parameters, a compatible set of parameters must be passed to the `EXECUTE` statement, or else Greenplum Database raises an error. Because \(unlike functions\) prepared statements are not overloaded based on the type or number of their parameters, the name of a prepared statement must be unique within a database session.
 
-For more information on the creation and usage of prepared statements, see `PREPARE`.
+For more information on the creation and usage of prepared statements, see [PREPARE](PREPARE.html).
 
 ## <a id="section4"></a>Parameters 
 
@@ -24,13 +24,17 @@ name
 parameter
 :   The actual value of a parameter to the prepared statement. This must be an expression yielding a value that is compatible with the data type of this parameter, as was determined when the prepared statement was created.
 
+## <a id="section4b"></a>Outputs
+
+The command tag returned by `EXECUTE` is that of the prepared statement, and not `EXECUTE`.
+
 ## <a id="section5"></a>Examples 
 
 Create a prepared statement for an `INSERT` statement, and then run it:
 
 ```
-PREPARE fooplan (int, text, bool, numeric) AS INSERT INTO 
-foo VALUES($1, $2, $3, $4);
+PREPARE fooplan (int, text, bool, numeric) AS
+    INSERT INTO foo VALUES($1, $2, $3, $4);
 EXECUTE fooplan(1, 'Hunter Valley', 't', 200.00);
 ```
 

--- a/gpdb-doc/markdown/ref_guide/sql_commands/PREPARE.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/PREPARE.html.md
@@ -1,20 +1,20 @@
 # PREPARE 
 
-Prepare a statement for execution.
+Prepares a statement for execution.
 
 ## <a id="section2"></a>Synopsis 
 
 ``` {#sql_command_synopsis}
-PREPARE <name> [ (<datatype> [, ...] ) ] AS <statement>
+PREPARE <name> [ (<data_type> [, ...] ) ] AS <statement>
 ```
 
 ## <a id="section3"></a>Description 
 
 `PREPARE` creates a prepared statement. A prepared statement is a server-side object that can be used to optimize performance. When the `PREPARE` statement is run, the specified statement is parsed, analyzed, and rewritten. When an `EXECUTE` command is subsequently issued, the prepared statement is planned and run. This division of labor avoids repetitive parse analysis work, while allowing the execution plan to depend on the specific parameter values supplied.
 
-Prepared statements can take parameters, values that are substituted into the statement when it is run. When creating the prepared statement, refer to parameters by position, using `$1`, `$2`, etc. A corresponding list of parameter data types can optionally be specified. When a parameter's data type is not specified or is declared as unknown, the type is inferred from the context in which the parameter is first used \(if possible\). When running the statement, specify the actual values for these parameters in the `EXECUTE` statement.
+Prepared statements can take parameters, values that are substituted into the statement when it is run. When creating the prepared statement, refer to parameters by position, using `$1`, `$2`, etc. You can optionally specify a corresponding list of parameter data types. When a parameter's data type is not specified or is declared as `unknown`, the type is inferred from the context in which the parameter is first referenced \(if possible\). When running the statement, specify the actual values for these parameters in the [EXECUTE](EXECUTE.html) statement.
 
-Prepared statements only last for the duration of the current database session. When the session ends, the prepared statement is forgotten, so it must be recreated before being used again. This also means that a single prepared statement cannot be used by multiple simultaneous database clients; however, each client can create their own prepared statement to use. Prepared statements can be manually cleaned up using the [DEALLOCATE](DEALLOCATE.html) command.
+Prepared statements last only for the duration of the current database session. When the session ends, the prepared statement is forgotten, so it must be recreated before being used again. This also means that a single prepared statement cannot be used by multiple simultaneous database clients; however, each client can create their own prepared statement to use. You can manually clean up a prepared statement using the [DEALLOCATE](DEALLOCATE.html) command.
 
 Prepared statements have the largest performance advantage when a single session is being used to run a large number of similar statements. The performance difference will be particularly significant if the statements are complex to plan or rewrite, for example, if the query involves a join of many tables or requires the application of several rules. If the statement is relatively simple to plan and rewrite but relatively expensive to run, the performance advantage of prepared statements will be less noticeable.
 
@@ -23,8 +23,8 @@ Prepared statements have the largest performance advantage when a single session
 name
 :   An arbitrary name given to this particular prepared statement. It must be unique within a single session and is subsequently used to run or deallocate a previously prepared statement.
 
-datatype
-:   The data type of a parameter to the prepared statement. If the data type of a particular parameter is unspecified or is specified as unknown, it will be inferred from the context in which the parameter is first used. To refer to the parameters in the prepared statement itself, use `$1`, `$2`, etc.
+data\_type
+:   The data type of a parameter to the prepared statement. If the data type of a particular parameter is unspecified or is specified as `unknown`, it will be inferred from the context in which the parameter is first referenced. To refer to the parameters in the prepared statement itself, use `$1`, `$2`, etc.
 
 statement
 :   Any `SELECT`, `INSERT`, `UPDATE`, `DELETE`, or `VALUES` statement.
@@ -33,9 +33,9 @@ statement
 
 A prepared statement can be run with either a *generic plan* or a *custom plan*. A generic plan is the same across all executions, while a custom plan is generated for a specific execution using the parameter values given in that call. Use of a generic plan avoids planning overhead, but in some situations a custom plan will be much more efficient to run because the planner can make use of knowledge of the parameter values. If the prepared statement has no parameters, a generic plan is always used.
 
-By default \(with the default value, `auto`, for the server configuration parameter [plan\_cache\_mode](../config_params/guc-list.html)\), the server automatically chooses whether to use a generic or custom plan for a prepared statement that has parameters. The current rule for this is that the first five executions are done with custom plans and the average estimated cost of those plans is calculated. Then a generic plan is created and its estimated cost is compared to the average custom-plan cost. Subsequent executions use the generic plan if its cost is not so much higher than the average custom-plan cost as to make repeated replanning seem preferable.
+By default \(with the default value, `auto`, for the server configuration parameter [plan\_cache\_mode](../config_params/guc-list.html#plan_cache_mode)\), the server automatically chooses whether to use a generic or custom plan for a prepared statement that has parameters. The current rule for this is that the first five executions are done with custom plans and then Greenplum Database calculates the average estimated cost of those plans. Then a generic plan is created and its estimated cost is compared to the average custom-plan cost. Subsequent executions use the generic plan if its cost is not so much higher than the average custom-plan cost as to make repeated replanning seem preferable.
 
-This heuristic can be overridden, forcing the server to use either generic or custom plans, by setting `plan_cache_mode` to `force_generic_plan` or `force_custom_plan` respectively. This setting is primarily useful if the generic plan's cost estimate is badly off for some reason, allowing it to be chosen even though its actual cost is much more than that of a custom plan.
+You can override this heuristic, forcing the server to use either generic or custom plans, by setting `plan_cache_mode` to `force_generic_plan` or `force_custom_plan` respectively. This setting is primarily useful if the generic plan's cost estimate is badly off for some reason, allowing it to be chosen even though its actual cost is much more than that of a custom plan.
 
 To examine the query plan Greenplum Database is using for a prepared statement, use [EXPLAIN](EXPLAIN.html), for example:
 
@@ -45,27 +45,28 @@ EXPLAIN EXECUTE <name>(<parameter_values>);
 
 If a generic plan is in use, it will contain parameter symbols `$n`, while a custom plan will have the supplied parameter values substituted into it.
 
-For more information on query planning and the statistics collected by Greenplum Database for that purpose, see the `ANALYZE` documentation.
+For more information on query planning and the statistics collected by Greenplum Database for that purpose, see the [ANALYZE](ANALYZE.html) documentation.
 
-Although the main point of a prepared statement is to avoid repeated parse analysis and planning of the statement, Greenplum will force re-analysis and re-planning of the statement before using it whenever database objects used in the statement have undergone definitional \(DDL\) changes since the previous use of the prepared statement. Also, if the value of `search_path` changes from one use to the next, the statement will be re-parsed using the new search\_path. \(This latter behavior is new as of Greenplum 6.\) These rules make use of a prepared statement semantically almost equivalent to re-submitting the same query text over and over, but with a performance benefit if no object definitions are changed, especially if the best plan remains the same across uses. An example of a case where the semantic equivalence is not perfect is that if the statement refers to a table by an unqualified name, and then a new table of the same name is created in a schema appearing earlier in the `search_path`, no automatic re-parse will occur since no object used in the statement changed. However, if some other change forces a re-parse, the new table will be referenced in subsequent uses.
+Although the main point of a prepared statement is to avoid repeated parse analysis and planning of the statement, Greenplum will force re-analysis and re-planning of the statement before using it whenever database objects used in the statement have undergone definitional \(DDL\) changes since the previous use of the prepared statement. Also, if the value of [search_path](../config_params/guc-list.html#search_path) changes from one use to the next, the statement will be re-parsed using the new `search_path`. These rules make use of a prepared statement semantically almost equivalent to re-submitting the same query text over and over, but with a performance benefit if no object definitions are changed, especially if the best plan remains the same across uses. An example of a case where the semantic equivalence is not perfect is that if the statement refers to a table by an unqualified name, and then a new table of the same name is created in a schema appearing earlier in the `search_path`, no automatic re-parse will occur since no object used in the statement changed. However, if some other change forces a re-parse, the new table will be referenced in subsequent uses.
 
-You can see all prepared statements available in the session by querying the `pg_prepared_statements` system view.
+You can see all prepared statements available in the session by querying the [pg\_prepared\_statements](../system_catalogs/pg_prepared_statements.html) system view.
 
 ## <a id="section6"></a>Examples 
 
 Create a prepared statement for an `INSERT` statement, and then run it:
 
 ```
-PREPARE fooplan (int, text, bool, numeric) AS INSERT INTO 
-foo VALUES($1, $2, $3, $4);
+PREPARE fooplan (int, text, bool, numeric) AS
+    INSERT INTO foo VALUES($1, $2, $3, $4);
 EXECUTE fooplan(1, 'Hunter Valley', 't', 200.00);
 ```
 
 Create a prepared statement for a `SELECT` statement, and then run it. Note that the data type of the second parameter is not specified, so it is inferred from the context in which `$2` is used:
 
 ```
-PREPARE usrrptplan (int) AS SELECT * FROM users u, logs l 
-WHERE u.usrid=$1 AND u.usrid=l.usrid AND l.date = $2;
+PREPARE usrrptplan (int) AS
+    SELECT * FROM users u, logs l WHERE u.usrid=$1 AND u.usrid=l.usrid
+    AND l.date = $2;
 EXECUTE usrrptplan(1, current_date);
 ```
 

--- a/gpdb-doc/markdown/ref_guide/system_catalogs/catalog_ref-html.html.md
+++ b/gpdb-doc/markdown/ref_guide/system_catalogs/catalog_ref-html.html.md
@@ -154,6 +154,8 @@ System catalog table and view definitions in alphabetical order.
 
 -   [pg\_policy](../system_catalogs/pg_policy.html)  
 
+-   [pg\_prepared\_statements](../system_catalogs/pg_prepared_statements.html)  
+
 -   [pg\_proc](../system_catalogs/pg_proc.html)  
 
 -   [pg\_resgroup](../system_catalogs/pg_resgroup.html)  

--- a/gpdb-doc/markdown/ref_guide/system_catalogs/pg_prepared_statements.html.md
+++ b/gpdb-doc/markdown/ref_guide/system_catalogs/pg_prepared_statements.html.md
@@ -1,0 +1,18 @@
+# pg_prepared_statements
+
+The `pg_prepared_statements` view displays all of the prepared statements that are available in the current session. See [PREPARE](../sql_commands/PREPARE.html) for more information about prepared statements.
+
+`pg_prepared_statements` contains one row for each prepared statement. Rows are added to the view when a new prepared statement is created and removed when a prepared statement is released \(for example, with the [DEALLOCATE](../sql_commands/DEALLOCATE.html) command\).
+
+The `pg_prepared_statements` view is read-only.
+
+|name|type|description|
+|----|----|----------|-----------|
+|`name`|text|The identifier of the prepared statement.|
+|`statement`|text| The query string submitted by the client to create this prepared statement. For prepared statements created via SQL, this is the `PREPARE` statement submitted by the client. For prepared statements created via the frontend/backend protocol, this is the text of the prepared statement itself. |
+|`prepare_time`|timestamptz|The time at which the prepared statement was created.|
+|`parameter_types`|regtype[]| The expected parameter types for the prepared statement in the form of an array of `regtype`. The object identifier corresponding to an element of this array can be obtained by casting the `regtype` value to `oid`. |
+|`from_sql`|boolean|`true` if the prepared statement was created via the `PREPARE` SQL command, `false` if the statement was prepared via the frontend/backend protocol.|
+
+**Parent topic:** [System Catalogs Definitions](../system_catalogs/catalog_ref-html.html)
+

--- a/gpdb-doc/markdown/ref_guide/system_catalogs/pg_prepared_statements.html.md
+++ b/gpdb-doc/markdown/ref_guide/system_catalogs/pg_prepared_statements.html.md
@@ -7,7 +7,7 @@ The `pg_prepared_statements` view displays all of the prepared statements that a
 The `pg_prepared_statements` view is read-only.
 
 |name|type|description|
-|----|----|----------|-----------|
+|----|----|----------|
 |`name`|text|The identifier of the prepared statement.|
 |`statement`|text| The query string submitted by the client to create this prepared statement. For prepared statements created via SQL, this is the `PREPARE` statement submitted by the client. For prepared statements created via the frontend/backend protocol, this is the text of the prepared statement itself. |
 |`prepare_time`|timestamptz|The time at which the prepared statement was created.|

--- a/gpdb-doc/markdown/ref_guide/toc.md
+++ b/gpdb-doc/markdown/ref_guide/toc.md
@@ -276,6 +276,7 @@ Doc Index
             - [pg\_pltemplate](./system_catalogs/pg_pltemplate.md)
             - [pg\_policies](./system_catalogs/pg_policies.md)
             - [pg\_policy](./system_catalogs/pg_policy.md)
+            - [pg\_prepared\_statements](./system_catalogs/pg_prepared_statements.md)
             - [pg\_proc](./system_catalogs/pg_proc.md)
             - [pg\_resgroup](./system_catalogs/pg_resgroup.md)
             - [pg\_resgroupcapability](./system_catalogs/pg_resgroupcapability.md)


### PR DESCRIPTION
this PR updates the listed sql command reference pages to align with the postgres v12 ref page content. there didn't appear to be any greenplum-specific content.

i also added the pg_prepared_statements system view to the ref guide.

doc review site (behind vpn):
- DEALLOCATE (can get to the others from there):  https://docs-staging.vmware.com/en/draft/VMware-Tanzu-Greenplum/sqlref-dealexprep/greenplum-database/GUID-ref_guide-sql_commands-DEALLOCATE.html
- pg_prepared_statements:  https://docs-staging.vmware.com/en/draft/VMware-Tanzu-Greenplum/sqlref-dealexprep/greenplum-database/GUID-ref_guide-system_catalogs-pg_prepared_statements.html