### PR TITLE
(6x) gpexpand.status_detail should be distributed by "table_oid".

### DIFF
--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -290,9 +290,9 @@ status_table_sql = """CREATE TABLE gpexpand.status
                           updated timestamp ) """
 
 status_detail_table_sql = """CREATE TABLE gpexpand.status_detail
-                        ( dbname text,
+                        ( table_oid oid,
+                          dbname text,
                           fq_name text,
-                          table_oid oid,
                           root_partition_oid oid,
                           rank int,
                           external_writable bool,
@@ -300,7 +300,8 @@ status_detail_table_sql = """CREATE TABLE gpexpand.status_detail
                           expansion_started timestamp,
                           expansion_finished timestamp,
                           source_bytes numeric,
-                          rel_storage text ) """
+                          rel_storage text) distributed by (table_oid)"""
+
 # gpexpand views
 progress_view_simple_sql = """CREATE VIEW gpexpand.expansion_progress AS
 SELECT
@@ -1637,9 +1638,9 @@ class gpexpand:
 
         final_sql = """{cte_sql}
         select
+          s1.table_oid,
           s1.dbname,
           s1.fq_name,
-          s1.table_oid,
           s1.root_partition_oid,
           s1.rank,
           s1.external_writable,
@@ -1659,9 +1660,9 @@ class gpexpand:
             all other table types.
         """
         sql = """SELECT
+                   c.oid as table_oid,
                    current_database() dbname,
                    quote_ident(n.nspname) || '.' || quote_ident(c.relname) as fq_name,
-                   c.oid as table_oid,
                    NULL as root_partition_oid,
                    2 as rank,
                    pe.writable is not null as external_writable,
@@ -1752,9 +1753,9 @@ class gpexpand:
         # We need populate all leaf table to gpexpand.status_detail
         get_status_detail_cmd = """
              SELECT
+                c.oid as table_oid,
                 current_database() as dbname,
                 quote_ident(n.nspname) || '.' || quote_ident(c.relname) as fq_name,
-                c.oid as table_oid,
                 d.oid as root_partition_oid,
                 2 as rank,
                 pe.writable is not null as external_writable,
@@ -2020,7 +2021,7 @@ class ExpandTable():
     def __init__(self, options, row=None):
         self.options = options
         if row is not None:
-            (self.dbname, self.fq_name, self.table_oid,
+            (self.table_oid, self.dbname, self.fq_name,
              self.root_partition_oid,
              self.rank, self.external_writable, self.status,
              self.expansion_started, self.expansion_finished,


### PR DESCRIPTION
The table gpexpand.status_detail used by gpexpand should be distributed by "table_oid", 
to avoid the updating workload burden of tens thounsand tables in a segment, concentrated
on only one single segment with the prior distribution policy (distributed by dbname).

Authored-by: Peng Han <phan@vmware.com>
