### PR TITLE
Disallow setting the distribution policy of readable external tables

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -4864,7 +4864,7 @@ ATPrepCmd(List **wqueue, Relation rel, AlterTableCmd *cmd,
 		case AT_SetDistributedBy:	/* SET DISTRIBUTED BY */
 			ATSimplePermissions(rel, ATT_TABLE | ATT_FOREIGN_TABLE);
 
-			if ( !recursing ) /* MPP-5772, MPP-5784 */
+			if (!recursing) /* MPP-5772, MPP-5784 */
 			{
 				DistributedBy *ldistro;
 				GpPolicy   *policy;
@@ -4876,15 +4876,15 @@ ATPrepCmd(List **wqueue, Relation rel, AlterTableCmd *cmd,
 				{
 					ldistro->numsegments = rel->rd_cdbpolicy->numsegments;
 
-					policy =  getPolicyForDistributedBy(ldistro, rel->rd_att);
+					policy = getPolicyForDistributedBy(ldistro, rel->rd_att);
 					/* can't set the distribution policy of interior table */
 					if (rel->rd_rel->relkind == RELKIND_PARTITIONED_TABLE && rel->rd_rel->relispartition)
 					{
 						ereport(ERROR,
 								(errcode(ERRCODE_WRONG_OBJECT_TYPE),
-								errmsg("can't set the distribution policy of \"%s\"",
-									   RelationGetRelationName(rel)),
-								errhint("Distribution policy can not be set for an interior branch.")));
+								 errmsg("can't set the distribution policy of \"%s\"",
+										RelationGetRelationName(rel)),
+								 errhint("Distribution policy can not be set for an interior branch.")));
 					}
 					if (!GpPolicyEqual(policy, rel->rd_cdbpolicy))
 					{
@@ -16937,6 +16937,16 @@ ATExecSetDistributedBy(Relation rel, Node *node, AlterTableCmd *cmd)
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 				 errmsg("%s not supported on non-distributed tables",
 						ldistro ? "SET DISTRIBUTED BY" : "SET WITH")));
+
+		if (rel_is_external_table(RelationGetRelid(rel)))
+		{
+			ExtTableEntry *e = GetExtTableEntry(RelationGetRelid(rel));
+			if (!e->iswritable)
+				ereport(ERROR,
+						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+						 errmsg("cannot set distribution policy of readable external table \"%s\"",
+								RelationGetRelationName(rel))));
+		}
 	}
 
 	if (Gp_role == GP_ROLE_DISPATCH)
@@ -16980,6 +16990,7 @@ ATExecSetDistributedBy(Relation rel, Node *node, AlterTableCmd *cmd)
 
 			lwith = nlist;
 		}
+
 		/* External tables cannot really be re-organized. Error out if we are instructed to do so.*/
 		if (force_reorg && rel_is_external_table(RelationGetRelid(rel)))
 			ereport(ERROR,

--- a/src/test/regress/input/external_table.source
+++ b/src/test/regress/input/external_table.source
@@ -3625,6 +3625,9 @@ ALTER TABLE ext_w_dist SET DISTRIBUTED BY (b);
 SELECT policytype, distkey FROM gp_distribution_policy WHERE localoid = 'ext_w_dist'::regclass;
 ALTER TABLE ext_w_dist SET DISTRIBUTED RANDOMLY;
 SELECT policytype, distkey FROM gp_distribution_policy WHERE localoid = 'ext_w_dist'::regclass;
+CREATE EXTERNAL WEB TABLE ext_r_dist(a int) EXECUTE 'printf ${GP_SEGMENT_ID}' FORMAT 'TEXT' DISTRIBUTED BY (a);
+CREATE EXTERNAL WEB TABLE ext_r_dist(a int) EXECUTE 'printf ${GP_SEGMENT_ID}' FORMAT 'TEXT';
+ALTER TABLE ext_r_dist SET DISTRIBUTED BY (a); -- should error out altering readable external tables' distribution policy
 
 -- Testing external table as the partition child.
 CREATE TABLE part_root(a int) PARTITION BY RANGE(a);

--- a/src/test/regress/output/external_table.source
+++ b/src/test/regress/output/external_table.source
@@ -4951,6 +4951,11 @@ SELECT policytype, distkey FROM gp_distribution_policy WHERE localoid = 'ext_w_d
  p          | 
 (1 row)
 
+CREATE EXTERNAL WEB TABLE ext_r_dist(a int) EXECUTE 'printf ${GP_SEGMENT_ID}' FORMAT 'TEXT' DISTRIBUTED BY (a);
+ERROR:  readable external tables can't specify a DISTRIBUTED BY clause
+CREATE EXTERNAL WEB TABLE ext_r_dist(a int) EXECUTE 'printf ${GP_SEGMENT_ID}' FORMAT 'TEXT';
+ALTER TABLE ext_r_dist SET DISTRIBUTED BY (a); -- should error out altering readable external tables' distribution policy
+ERROR:  cannot set distribution policy of readable external table "ext_r_dist"
 -- Testing external table as the partition child.
 CREATE TABLE part_root(a int) PARTITION BY RANGE(a);
 CREATE TABLE part_child (LIKE part_root);

--- a/src/test/regress/output/external_table_optimizer.source
+++ b/src/test/regress/output/external_table_optimizer.source
@@ -4953,6 +4953,11 @@ SELECT policytype, distkey FROM gp_distribution_policy WHERE localoid = 'ext_w_d
  p          | 
 (1 row)
 
+CREATE EXTERNAL WEB TABLE ext_r_dist(a int) EXECUTE 'printf ${GP_SEGMENT_ID}' FORMAT 'TEXT' DISTRIBUTED BY (a);
+ERROR:  readable external tables can't specify a DISTRIBUTED BY clause
+CREATE EXTERNAL WEB TABLE ext_r_dist(a int) EXECUTE 'printf ${GP_SEGMENT_ID}' FORMAT 'TEXT';
+ALTER TABLE ext_r_dist SET DISTRIBUTED BY (a); -- should error out altering readable external tables' distribution policy
+ERROR:  cannot set distribution policy of readable external table "ext_r_dist"
 -- Testing external table as the partition child.
 CREATE TABLE part_root(a int) PARTITION BY RANGE(a);
 CREATE TABLE part_child (LIKE part_root);


### PR DESCRIPTION
Greenplum doesn't allow this, creating readable external tables with a
distribution policy always fails, this commit disallows it via `ALTER`.

reference:
	commit b610b10b27b3df4285b7cb677c8d665d92c4a6b1
	Author: Huansong Fu <fuhuansong@gmail.com>
	Date:   Thu Sep 29 08:12:30 2022 -0700

	    Support ALTER TABLE SET DISTRIBUTED BY for external tables

Fixes https://github.com/greenplum-db/gpdb/issues/14754