### PR TITLE
6X: set ctid on inserting AO table

### DIFF
--- a/src/backend/executor/nodeModifyTable.c
+++ b/src/backend/executor/nodeModifyTable.c
@@ -513,6 +513,7 @@ ExecInsert(TupleTableSlot *parentslot,
 
 			mtuple = ExecFetchSlotMemTuple(slot);
 			newId = appendonly_insert(resultRelInfo->ri_aoInsertDesc, mtuple, tuple_oid, (AOTupleId *) &lastTid);
+			slot_set_ctid(slot, (ItemPointer)&lastTid);
 			(resultRelInfo->ri_aoprocessed)++;
 		}
 		else if (rel_is_aocols)

--- a/src/test/regress/expected/returning_gp.out
+++ b/src/test/regress/expected/returning_gp.out
@@ -92,13 +92,6 @@ select * from returning_parttab;
 (11 rows)
 
 --
--- DELETE RETURNING is currently not supported on AO tables.
---
-CREATE TEMP TABLE returning_aotab (id int4) WITH (appendonly=true);
-INSERT INTO returning_aotab VALUES (1);
-DELETE FROM returning_aotab RETURNING *;
-ERROR:  DELETE RETURNING is not supported on appendonly tables
---
 -- Test UPDATE RETURNING with a split update, i.e. an update of the distribution
 -- key.
 --

--- a/src/test/regress/input/uao_dml/uao_dml.source
+++ b/src/test/regress/input/uao_dml/uao_dml.source
@@ -1018,10 +1018,3 @@ DELETE FROM returning_aotab RETURNING *;
 CREATE TABLE returning_ctid_aotab (f1 serial, f2 text) WITH (appendonly=true) DISTRIBUTED BY (f1);
 INSERT INTO returning_ctid_aotab (f2) VALUES ('test1') RETURNING ctid;
 DROP TABLE returning_ctid_aotab;
-
---
--- Test returning ctid for AOCO table
---
-CREATE TABLE returning_ctid_aocotab (f1 serial, f2 text) WITH (appendonly=true, orientation=column) DISTRIBUTED BY (f1);
-INSERT INTO returning_ctid_aocotab (f2) VALUES ('test1') RETURNING ctid;
-DROP TABLE returning_ctid_aocotab;

--- a/src/test/regress/input/uao_dml/uao_dml.source
+++ b/src/test/regress/input/uao_dml/uao_dml.source
@@ -1004,3 +1004,24 @@ BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE;
 SAVEPOINT my_savepoint;
 UPDATE foo SET b = 1 WHERE a < 4;
 ROLLBACK;
+
+--
+-- DELETE RETURNING is currently not supported on AO tables.
+--
+CREATE TEMP TABLE returning_aotab (id int4) WITH (appendonly=true);
+INSERT INTO returning_aotab VALUES (1);
+DELETE FROM returning_aotab RETURNING *;
+
+--
+-- Test returning ctid for AO table
+--
+CREATE TABLE returning_ctid_aotab (f1 serial, f2 text) WITH (appendonly=true) DISTRIBUTED BY (f1);
+INSERT INTO returning_ctid_aotab (f2) VALUES ('test1') RETURNING ctid;
+DROP TABLE returning_ctid_aotab;
+
+--
+-- Test returning ctid for AOCO table
+--
+CREATE TABLE returning_ctid_aocotab (f1 serial, f2 text) WITH (appendonly=true, orientation=column) DISTRIBUTED BY (f1);
+INSERT INTO returning_ctid_aocotab (f2) VALUES ('test1') RETURNING ctid;
+DROP TABLE returning_ctid_aocotab;

--- a/src/test/regress/output/uao_dml/uao_dml.source
+++ b/src/test/regress/output/uao_dml/uao_dml.source
@@ -1908,14 +1908,3 @@ INSERT INTO returning_ctid_aotab (f2) VALUES ('test1') RETURNING ctid;
 (1 row)
 
 DROP TABLE returning_ctid_aotab;
---
--- Test returning ctid for AOCO table
---
-CREATE TABLE returning_ctid_aocotab (f1 serial, f2 text) WITH (appendonly=true, orientation=column) DISTRIBUTED BY (f1);
-INSERT INTO returning_ctid_aocotab (f2) VALUES ('test1') RETURNING ctid;
-     ctid     
---------------
- (33554432,2)
-(1 row)
-
-DROP TABLE returning_ctid_aocotab;

--- a/src/test/regress/output/uao_dml/uao_dml.source
+++ b/src/test/regress/output/uao_dml/uao_dml.source
@@ -1888,3 +1888,34 @@ SAVEPOINT my_savepoint;
 UPDATE foo SET b = 1 WHERE a < 4;
 ERROR:  updates on append-only tables are not supported in serializable transactions  (seg0 gesameistd1m1.corp.emc.com:40000 pid=73392)
 ROLLBACK;
+--
+-- DELETE RETURNING is currently not supported on AO tables.
+--
+CREATE TEMP TABLE returning_aotab (id int4) WITH (appendonly=true);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'id' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO returning_aotab VALUES (1);
+DELETE FROM returning_aotab RETURNING *;
+ERROR:  DELETE RETURNING is not supported on appendonly tables  (seg1 slice1 10.117.190.244:7001 pid=3730)
+--
+-- Test returning ctid for AO table
+--
+CREATE TABLE returning_ctid_aotab (f1 serial, f2 text) WITH (appendonly=true) DISTRIBUTED BY (f1);
+INSERT INTO returning_ctid_aotab (f2) VALUES ('test1') RETURNING ctid;
+     ctid     
+--------------
+ (33554432,2)
+(1 row)
+
+DROP TABLE returning_ctid_aotab;
+--
+-- Test returning ctid for AOCO table
+--
+CREATE TABLE returning_ctid_aocotab (f1 serial, f2 text) WITH (appendonly=true, orientation=column) DISTRIBUTED BY (f1);
+INSERT INTO returning_ctid_aocotab (f2) VALUES ('test1') RETURNING ctid;
+     ctid     
+--------------
+ (33554432,2)
+(1 row)
+
+DROP TABLE returning_ctid_aocotab;

--- a/src/test/regress/sql/returning_gp.sql
+++ b/src/test/regress/sql/returning_gp.sql
@@ -42,14 +42,6 @@ delete from returning_parttab where partkey = 14 returning *;
 select * from returning_parttab;
 
 --
--- DELETE RETURNING is currently not supported on AO tables.
---
-CREATE TEMP TABLE returning_aotab (id int4) WITH (appendonly=true);
-INSERT INTO returning_aotab VALUES (1);
-DELETE FROM returning_aotab RETURNING *;
-
-
---
 -- Test UPDATE RETURNING with a split update, i.e. an update of the distribution
 -- key.
 --


### PR DESCRIPTION
Failed assertion if insert data into an AO table with returning ctid

Root cause:
         miss `slot_set_ctid()` during inserting AO table

This PR is used to fix issue #14759 

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
