### PR TITLE
Make function clauselist_selectivity have same format with upstream postgres

### DIFF
--- a/contrib/file_fdw/file_fdw.c
+++ b/contrib/file_fdw/file_fdw.c
@@ -1050,12 +1050,11 @@ estimate_size(PlannerInfo *root, RelOptInfo *baserel,
 	 * baserestrictinfo quals.
 	 */
 	nrows = ntuples *
-		clauselist_selectivity_use_damping(root,
+		clauselist_selectivity(root,
 							   baserel->baserestrictinfo,
 							   0,
 							   JOIN_INNER,
-							   NULL,
-							   false);
+							   NULL);
 
 	nrows = clamp_row_est(nrows);
 

--- a/contrib/file_fdw/file_fdw.c
+++ b/contrib/file_fdw/file_fdw.c
@@ -1050,7 +1050,7 @@ estimate_size(PlannerInfo *root, RelOptInfo *baserel,
 	 * baserestrictinfo quals.
 	 */
 	nrows = ntuples *
-		clauselist_selectivity(root,
+		clauselist_selectivity_use_damping(root,
 							   baserel->baserestrictinfo,
 							   0,
 							   JOIN_INNER,

--- a/contrib/postgres_fdw/postgres_fdw.c
+++ b/contrib/postgres_fdw/postgres_fdw.c
@@ -655,8 +655,7 @@ postgresGetForeignRelSize(PlannerInfo *root,
 													 fpinfo->local_conds,
 													 baserel->relid,
 													 JOIN_INNER,
-													 NULL,
-													 false);
+													 NULL);
 
 	cost_qual_eval(&fpinfo->local_conds_cost, fpinfo->local_conds, root);
 
@@ -2713,8 +2712,7 @@ estimate_path_cost_size(PlannerInfo *root,
 										   local_param_join_conds,
 										   foreignrel->relid,
 										   JOIN_INNER,
-										   NULL,
-										   false);
+										   NULL);
 		local_sel *= fpinfo->local_conds_sel;
 
 		rows = clamp_row_est(rows * local_sel);
@@ -2931,8 +2929,7 @@ estimate_path_cost_size(PlannerInfo *root,
 														 fpinfo->remote_conds,
 														 0,
 														 JOIN_INNER,
-														 NULL,
-														 false));
+														 NULL));
 				/* Factor in the selectivity of the locally-checked quals */
 				rows = clamp_row_est(retrieved_rows * fpinfo->local_conds_sel);
 			}
@@ -5532,8 +5529,7 @@ postgresGetForeignJoinPaths(PlannerInfo *root,
 													 fpinfo->local_conds,
 													 0,
 													 JOIN_INNER,
-													 NULL,
-													 false);
+													 NULL);
 	cost_qual_eval(&fpinfo->local_conds_cost, fpinfo->local_conds, root);
 
 	/*
@@ -5543,8 +5539,7 @@ postgresGetForeignJoinPaths(PlannerInfo *root,
 	if (!fpinfo->use_remote_estimate)
 		fpinfo->joinclause_sel = clauselist_selectivity(root, fpinfo->joinclauses,
 														0, fpinfo->jointype,
-														extra->sjinfo,
-														false);
+														extra->sjinfo);
 
 	/* Estimate costs for bare join relation */
 	estimate_path_cost_size(root, joinrel, NIL, NIL, NULL,
@@ -5931,8 +5926,7 @@ add_foreign_grouping_paths(PlannerInfo *root, RelOptInfo *input_rel,
 													 fpinfo->local_conds,
 													 0,
 													 JOIN_INNER,
-													 NULL,
-													 false);
+													 NULL);
 
 	cost_qual_eval(&fpinfo->local_conds_cost, fpinfo->local_conds, root);
 

--- a/src/backend/optimizer/path/clausesel.c
+++ b/src/backend/optimizer/path/clausesel.c
@@ -89,14 +89,14 @@ cmpSelectivity
  *
  * clauselist_selectivity is kept same as upstream here. Because this 
  * function is called by most fdw (Foreign Data Wrapper) extensions.
- * This functions just simply call clauselist_selectivity_standard() 
+ * This functions just simply call clauselist_selectivity_extended() 
  * and set use_damping to false.
  * 
  * Greenplum specific behavior:
- * Greenplum calls clauselist_selectivity_standard() directly.
+ * Greenplum calls clauselist_selectivity_extended() directly.
  * Function clauselist_selectivity() is kept for external fdw.
  *  
- * See clauselist_selectivity_standard() for more information.
+ * See clauselist_selectivity_extended() for more information.
  */
 Selectivity
 clauselist_selectivity(PlannerInfo *root,
@@ -105,13 +105,13 @@ clauselist_selectivity(PlannerInfo *root,
 					   JoinType jointype,
 					   SpecialJoinInfo *sjinfo)
 {
-	return clauselist_selectivity_standard(root, clauses, varRelid,
+	return clauselist_selectivity_extended(root, clauses, varRelid,
 											jointype, sjinfo, 
 											false);   /* use_damping, which is false by default */ 
 }
 
 /*
- * clauselist_selectivity_standard -
+ * clauselist_selectivity_extended -
  *	  Compute the selectivity of an implicitly-ANDed list of boolean
  *	  expression clauses.  The list can be empty, in which case 1.0
  *	  must be returned.  List elements may be either RestrictInfos
@@ -127,7 +127,7 @@ clauselist_selectivity(PlannerInfo *root,
  * clauselist_selectivity_simple.
  */
 Selectivity
-clauselist_selectivity_standard(PlannerInfo *root,
+clauselist_selectivity_extended(PlannerInfo *root,
 					   List *clauses,
 					   int varRelid,
 					   JoinType jointype,
@@ -838,8 +838,8 @@ clause_selectivity(PlannerInfo *root,
 	}
 	else if (is_andclause(clause))
 	{
-		/* share code with clauselist_selectivity_standard() */
-		s1 = clauselist_selectivity_standard(root,
+		/* share code with clauselist_selectivity_extended() */
+		s1 = clauselist_selectivity_extended(root,
 									((BoolExpr *) clause)->args,
 									varRelid,
 									jointype,

--- a/src/backend/optimizer/path/clausesel.c
+++ b/src/backend/optimizer/path/clausesel.c
@@ -89,14 +89,14 @@ cmpSelectivity
  *
  * clauselist_selectivity is kept same as upstream here. Because this 
  * function is called by most fdw (Foreign Data Wrapper) extensions.
- * This functions just simply call clauselist_selectivity_use_damping() 
+ * This functions just simply call clauselist_selectivity_standard() 
  * and set use_damping to false.
  * 
  * Greenplum specific behavior:
- * Greenplum calls clauselist_selectivity_use_damping() directly.
+ * Greenplum calls clauselist_selectivity_standard() directly.
  * Function clauselist_selectivity() is kept for external fdw.
  *  
- * See clauselist_selectivity_use_damping() for more information.
+ * See clauselist_selectivity_standard() for more information.
  */
 Selectivity
 clauselist_selectivity(PlannerInfo *root,
@@ -105,13 +105,13 @@ clauselist_selectivity(PlannerInfo *root,
 					   JoinType jointype,
 					   SpecialJoinInfo *sjinfo)
 {
-	return clauselist_selectivity_use_damping(root, clauses, varRelid,
+	return clauselist_selectivity_standard(root, clauses, varRelid,
 											jointype, sjinfo, 
 											false);   /* use_damping, which is false by default */ 
 }
 
 /*
- * clauselist_selectivity_use_damping -
+ * clauselist_selectivity_standard -
  *	  Compute the selectivity of an implicitly-ANDed list of boolean
  *	  expression clauses.  The list can be empty, in which case 1.0
  *	  must be returned.  List elements may be either RestrictInfos
@@ -127,7 +127,7 @@ clauselist_selectivity(PlannerInfo *root,
  * clauselist_selectivity_simple.
  */
 Selectivity
-clauselist_selectivity_use_damping(PlannerInfo *root,
+clauselist_selectivity_standard(PlannerInfo *root,
 					   List *clauses,
 					   int varRelid,
 					   JoinType jointype,
@@ -838,8 +838,8 @@ clause_selectivity(PlannerInfo *root,
 	}
 	else if (is_andclause(clause))
 	{
-		/* share code with clauselist_selectivity_use_damping() */
-		s1 = clauselist_selectivity_use_damping(root,
+		/* share code with clauselist_selectivity_standard() */
+		s1 = clauselist_selectivity_standard(root,
 									((BoolExpr *) clause)->args,
 									varRelid,
 									jointype,

--- a/src/backend/optimizer/path/clausesel.c
+++ b/src/backend/optimizer/path/clausesel.c
@@ -78,9 +78,38 @@ cmpSelectivity
 /****************************************************************************
  *		ROUTINES TO COMPUTE SELECTIVITIES
  ****************************************************************************/
-
 /*
  * clauselist_selectivity -
+ *	  Compute the selectivity of an implicitly-ANDed list of boolean
+ *	  expression clauses.  The list can be empty, in which case 1.0
+ *	  must be returned.  List elements may be either RestrictInfos
+ *	  or bare expression clauses --- the former is preferred since
+ *	  it allows caching of results. 
+ *
+ * clauselist_selectivity is kept same as upstream here. 
+ * Because this function is called by most fdw (Foreign Data Wrapper) extensions.
+ * This functions just simply call clauselist_selectivity_use_damping() and set use_damping to false.
+ * 
+ * Greenplum specific behavior:
+ * Greenplum calls clauselist_selectivity_use_damping() directly.
+ * Function clauselist_selectivity() is kept for external fdw.
+ *  
+ * See clauselist_selectivity_use_damping() for more information.
+ */
+Selectivity
+clauselist_selectivity(PlannerInfo *root,
+					   List *clauses,
+					   int varRelid,
+					   JoinType jointype,
+					   SpecialJoinInfo *sjinfo)
+{
+	return clauselist_selectivity_use_damping(root, clauses, varRelid,
+											jointype, sjinfo, 
+											false);   /* use_damping, which is false by default */ 
+}
+
+/*
+ * clauselist_selectivity_use_damping -
  *	  Compute the selectivity of an implicitly-ANDed list of boolean
  *	  expression clauses.  The list can be empty, in which case 1.0
  *	  must be returned.  List elements may be either RestrictInfos
@@ -96,7 +125,7 @@ cmpSelectivity
  * clauselist_selectivity_simple.
  */
 Selectivity
-clauselist_selectivity(PlannerInfo *root,
+clauselist_selectivity_use_damping(PlannerInfo *root,
 					   List *clauses,
 					   int varRelid,
 					   JoinType jointype,
@@ -807,8 +836,8 @@ clause_selectivity(PlannerInfo *root,
 	}
 	else if (is_andclause(clause))
 	{
-		/* share code with clauselist_selectivity() */
-		s1 = clauselist_selectivity(root,
+		/* share code with clauselist_selectivity_use_damping() */
+		s1 = clauselist_selectivity_use_damping(root,
 									((BoolExpr *) clause)->args,
 									varRelid,
 									jointype,

--- a/src/backend/optimizer/path/clausesel.c
+++ b/src/backend/optimizer/path/clausesel.c
@@ -78,6 +78,7 @@ cmpSelectivity
 /****************************************************************************
  *		ROUTINES TO COMPUTE SELECTIVITIES
  ****************************************************************************/
+
 /*
  * clauselist_selectivity -
  *	  Compute the selectivity of an implicitly-ANDed list of boolean
@@ -86,9 +87,10 @@ cmpSelectivity
  *	  or bare expression clauses --- the former is preferred since
  *	  it allows caching of results. 
  *
- * clauselist_selectivity is kept same as upstream here. 
- * Because this function is called by most fdw (Foreign Data Wrapper) extensions.
- * This functions just simply call clauselist_selectivity_use_damping() and set use_damping to false.
+ * clauselist_selectivity is kept same as upstream here. Because this 
+ * function is called by most fdw (Foreign Data Wrapper) extensions.
+ * This functions just simply call clauselist_selectivity_use_damping() 
+ * and set use_damping to false.
  * 
  * Greenplum specific behavior:
  * Greenplum calls clauselist_selectivity_use_damping() directly.

--- a/src/backend/optimizer/path/costsize.c
+++ b/src/backend/optimizer/path/costsize.c
@@ -2521,7 +2521,7 @@ cost_agg(Path *path, PlannerInfo *root,
 		total_cost += qual_cost.startup + output_tuples * qual_cost.per_tuple;
 
 		output_tuples = clamp_row_est(output_tuples *
-									  clauselist_selectivity_standard(root,
+									  clauselist_selectivity_extended(root,
 															 quals,
 															 0,
 															 JOIN_INNER,
@@ -2672,7 +2672,7 @@ cost_group(Path *path, PlannerInfo *root,
 		total_cost += qual_cost.startup + output_tuples * qual_cost.per_tuple;
 
 		output_tuples = clamp_row_est(output_tuples *
-									  clauselist_selectivity_standard(root,
+									  clauselist_selectivity_extended(root,
 															 quals,
 															 0,
 															 JOIN_INNER,
@@ -4643,7 +4643,7 @@ compute_semi_anti_join_factors(PlannerInfo *root,
 	/*
 	 * Get the JOIN_SEMI or JOIN_ANTI selectivity of the join clauses.
 	 */
-	jselec = clauselist_selectivity_standard(root,
+	jselec = clauselist_selectivity_extended(root,
 									joinquals,
 									0,
 									(jointype == JOIN_ANTI) ? JOIN_ANTI : JOIN_SEMI,
@@ -4667,7 +4667,7 @@ compute_semi_anti_join_factors(PlannerInfo *root,
 	norm_sjinfo.semi_operators = NIL;
 	norm_sjinfo.semi_rhs_exprs = NIL;
 
-	nselec = clauselist_selectivity_standard(root,
+	nselec = clauselist_selectivity_extended(root,
 									joinquals,
 									0,
 									JOIN_INNER,
@@ -4874,7 +4874,7 @@ set_baserel_size_estimates(PlannerInfo *root, RelOptInfo *rel)
 	Assert(rel->relid > 0);
 
 	nrows = rel->tuples *
-		clauselist_selectivity_standard(root,
+		clauselist_selectivity_extended(root,
 							   rel->baserestrictinfo,
 							   0,
 							   JOIN_INNER,
@@ -4994,7 +4994,7 @@ get_parameterized_baserel_size(PlannerInfo *root, RelOptInfo *rel,
 	allclauses = list_concat(list_copy(param_clauses),
 							 rel->baserestrictinfo);
 	nrows = rel->tuples *
-		clauselist_selectivity_standard(root,
+		clauselist_selectivity_extended(root,
 							   allclauses,
 							   rel->relid,	/* do not use 0! */
 							   JOIN_INNER,
@@ -5165,13 +5165,13 @@ calc_joinrel_size_estimate(PlannerInfo *root,
 		}
 
 		/* Get the separate selectivities */
-		jselec = clauselist_selectivity_standard(root,
+		jselec = clauselist_selectivity_extended(root,
 										joinquals,
 										0,
 										jointype,
 										sjinfo,
 										gp_selectivity_damping_for_joins);
-		pselec = clauselist_selectivity_standard(root,
+		pselec = clauselist_selectivity_extended(root,
 										pushedquals,
 										0,
 										jointype,
@@ -5194,7 +5194,7 @@ calc_joinrel_size_estimate(PlannerInfo *root,
 	}
 	else
 	{
-		jselec = clauselist_selectivity_standard(root,
+		jselec = clauselist_selectivity_extended(root,
 										restrictlist,
 										0,
 										jointype,

--- a/src/backend/optimizer/path/costsize.c
+++ b/src/backend/optimizer/path/costsize.c
@@ -2521,7 +2521,7 @@ cost_agg(Path *path, PlannerInfo *root,
 		total_cost += qual_cost.startup + output_tuples * qual_cost.per_tuple;
 
 		output_tuples = clamp_row_est(output_tuples *
-									  clauselist_selectivity_use_damping(root,
+									  clauselist_selectivity_standard(root,
 															 quals,
 															 0,
 															 JOIN_INNER,
@@ -2672,7 +2672,7 @@ cost_group(Path *path, PlannerInfo *root,
 		total_cost += qual_cost.startup + output_tuples * qual_cost.per_tuple;
 
 		output_tuples = clamp_row_est(output_tuples *
-									  clauselist_selectivity_use_damping(root,
+									  clauselist_selectivity_standard(root,
 															 quals,
 															 0,
 															 JOIN_INNER,
@@ -4643,7 +4643,7 @@ compute_semi_anti_join_factors(PlannerInfo *root,
 	/*
 	 * Get the JOIN_SEMI or JOIN_ANTI selectivity of the join clauses.
 	 */
-	jselec = clauselist_selectivity_use_damping(root,
+	jselec = clauselist_selectivity_standard(root,
 									joinquals,
 									0,
 									(jointype == JOIN_ANTI) ? JOIN_ANTI : JOIN_SEMI,
@@ -4667,7 +4667,7 @@ compute_semi_anti_join_factors(PlannerInfo *root,
 	norm_sjinfo.semi_operators = NIL;
 	norm_sjinfo.semi_rhs_exprs = NIL;
 
-	nselec = clauselist_selectivity_use_damping(root,
+	nselec = clauselist_selectivity_standard(root,
 									joinquals,
 									0,
 									JOIN_INNER,
@@ -4874,7 +4874,7 @@ set_baserel_size_estimates(PlannerInfo *root, RelOptInfo *rel)
 	Assert(rel->relid > 0);
 
 	nrows = rel->tuples *
-		clauselist_selectivity_use_damping(root,
+		clauselist_selectivity_standard(root,
 							   rel->baserestrictinfo,
 							   0,
 							   JOIN_INNER,
@@ -4994,7 +4994,7 @@ get_parameterized_baserel_size(PlannerInfo *root, RelOptInfo *rel,
 	allclauses = list_concat(list_copy(param_clauses),
 							 rel->baserestrictinfo);
 	nrows = rel->tuples *
-		clauselist_selectivity_use_damping(root,
+		clauselist_selectivity_standard(root,
 							   allclauses,
 							   rel->relid,	/* do not use 0! */
 							   JOIN_INNER,
@@ -5165,13 +5165,13 @@ calc_joinrel_size_estimate(PlannerInfo *root,
 		}
 
 		/* Get the separate selectivities */
-		jselec = clauselist_selectivity_use_damping(root,
+		jselec = clauselist_selectivity_standard(root,
 										joinquals,
 										0,
 										jointype,
 										sjinfo,
 										gp_selectivity_damping_for_joins);
-		pselec = clauselist_selectivity_use_damping(root,
+		pselec = clauselist_selectivity_standard(root,
 										pushedquals,
 										0,
 										jointype,
@@ -5194,7 +5194,7 @@ calc_joinrel_size_estimate(PlannerInfo *root,
 	}
 	else
 	{
-		jselec = clauselist_selectivity_use_damping(root,
+		jselec = clauselist_selectivity_standard(root,
 										restrictlist,
 										0,
 										jointype,

--- a/src/backend/optimizer/path/costsize.c
+++ b/src/backend/optimizer/path/costsize.c
@@ -2521,7 +2521,7 @@ cost_agg(Path *path, PlannerInfo *root,
 		total_cost += qual_cost.startup + output_tuples * qual_cost.per_tuple;
 
 		output_tuples = clamp_row_est(output_tuples *
-									  clauselist_selectivity(root,
+									  clauselist_selectivity_use_damping(root,
 															 quals,
 															 0,
 															 JOIN_INNER,
@@ -2672,7 +2672,7 @@ cost_group(Path *path, PlannerInfo *root,
 		total_cost += qual_cost.startup + output_tuples * qual_cost.per_tuple;
 
 		output_tuples = clamp_row_est(output_tuples *
-									  clauselist_selectivity(root,
+									  clauselist_selectivity_use_damping(root,
 															 quals,
 															 0,
 															 JOIN_INNER,
@@ -4643,7 +4643,7 @@ compute_semi_anti_join_factors(PlannerInfo *root,
 	/*
 	 * Get the JOIN_SEMI or JOIN_ANTI selectivity of the join clauses.
 	 */
-	jselec = clauselist_selectivity(root,
+	jselec = clauselist_selectivity_use_damping(root,
 									joinquals,
 									0,
 									(jointype == JOIN_ANTI) ? JOIN_ANTI : JOIN_SEMI,
@@ -4667,7 +4667,7 @@ compute_semi_anti_join_factors(PlannerInfo *root,
 	norm_sjinfo.semi_operators = NIL;
 	norm_sjinfo.semi_rhs_exprs = NIL;
 
-	nselec = clauselist_selectivity(root,
+	nselec = clauselist_selectivity_use_damping(root,
 									joinquals,
 									0,
 									JOIN_INNER,
@@ -4874,7 +4874,7 @@ set_baserel_size_estimates(PlannerInfo *root, RelOptInfo *rel)
 	Assert(rel->relid > 0);
 
 	nrows = rel->tuples *
-		clauselist_selectivity(root,
+		clauselist_selectivity_use_damping(root,
 							   rel->baserestrictinfo,
 							   0,
 							   JOIN_INNER,
@@ -4994,7 +4994,7 @@ get_parameterized_baserel_size(PlannerInfo *root, RelOptInfo *rel,
 	allclauses = list_concat(list_copy(param_clauses),
 							 rel->baserestrictinfo);
 	nrows = rel->tuples *
-		clauselist_selectivity(root,
+		clauselist_selectivity_use_damping(root,
 							   allclauses,
 							   rel->relid,	/* do not use 0! */
 							   JOIN_INNER,
@@ -5165,13 +5165,13 @@ calc_joinrel_size_estimate(PlannerInfo *root,
 		}
 
 		/* Get the separate selectivities */
-		jselec = clauselist_selectivity(root,
+		jselec = clauselist_selectivity_use_damping(root,
 										joinquals,
 										0,
 										jointype,
 										sjinfo,
 										gp_selectivity_damping_for_joins);
-		pselec = clauselist_selectivity(root,
+		pselec = clauselist_selectivity_use_damping(root,
 										pushedquals,
 										0,
 										jointype,
@@ -5194,7 +5194,7 @@ calc_joinrel_size_estimate(PlannerInfo *root,
 	}
 	else
 	{
-		jselec = clauselist_selectivity(root,
+		jselec = clauselist_selectivity_use_damping(root,
 										restrictlist,
 										0,
 										jointype,

--- a/src/backend/utils/adt/selfuncs.c
+++ b/src/backend/utils/adt/selfuncs.c
@@ -6068,7 +6068,7 @@ genericcostestimate(PlannerInfo *root,
 	}
 
 	/* Estimate the fraction of main-table tuples that will be visited */
-	indexSelectivity = clauselist_selectivity_standard(root, selectivityQuals,
+	indexSelectivity = clauselist_selectivity_extended(root, selectivityQuals,
 											  index->rel->relid,
 											  JOIN_INNER,
 											  NULL,
@@ -6403,7 +6403,7 @@ btcostestimate(PlannerInfo *root, IndexPath *path, double loop_count,
 		 */
 		selectivityQuals = add_predicate_to_index_quals(index, indexBoundQuals);
 
-		btreeSelectivity = clauselist_selectivity_standard(root, selectivityQuals,
+		btreeSelectivity = clauselist_selectivity_extended(root, selectivityQuals,
 												  index->rel->relid,
 												  JOIN_INNER,
 												  NULL,
@@ -7124,7 +7124,7 @@ gincostestimate(PlannerInfo *root, IndexPath *path, double loop_count,
 	selectivityQuals = add_predicate_to_index_quals(index, indexQuals);
 
 	/* Estimate the fraction of main-table tuples that will be visited */
-	*indexSelectivity = clauselist_selectivity_standard(root, selectivityQuals,
+	*indexSelectivity = clauselist_selectivity_extended(root, selectivityQuals,
 											   index->rel->relid,
 											   JOIN_INNER,
 											   NULL,
@@ -7547,7 +7547,7 @@ brincostestimate(PlannerInfo *root, IndexPath *path, double loop_count,
 		ReleaseVariableStats(vardata);
 	}
 
-	qualSelectivity = clauselist_selectivity_standard(root, indexQuals,
+	qualSelectivity = clauselist_selectivity_extended(root, indexQuals,
 											 baserel->relid,
 											 JOIN_INNER, NULL,
 											 false /* use_damping */);

--- a/src/backend/utils/adt/selfuncs.c
+++ b/src/backend/utils/adt/selfuncs.c
@@ -6068,7 +6068,7 @@ genericcostestimate(PlannerInfo *root,
 	}
 
 	/* Estimate the fraction of main-table tuples that will be visited */
-	indexSelectivity = clauselist_selectivity_use_damping(root, selectivityQuals,
+	indexSelectivity = clauselist_selectivity_standard(root, selectivityQuals,
 											  index->rel->relid,
 											  JOIN_INNER,
 											  NULL,
@@ -6403,7 +6403,7 @@ btcostestimate(PlannerInfo *root, IndexPath *path, double loop_count,
 		 */
 		selectivityQuals = add_predicate_to_index_quals(index, indexBoundQuals);
 
-		btreeSelectivity = clauselist_selectivity_use_damping(root, selectivityQuals,
+		btreeSelectivity = clauselist_selectivity_standard(root, selectivityQuals,
 												  index->rel->relid,
 												  JOIN_INNER,
 												  NULL,
@@ -7124,7 +7124,7 @@ gincostestimate(PlannerInfo *root, IndexPath *path, double loop_count,
 	selectivityQuals = add_predicate_to_index_quals(index, indexQuals);
 
 	/* Estimate the fraction of main-table tuples that will be visited */
-	*indexSelectivity = clauselist_selectivity_use_damping(root, selectivityQuals,
+	*indexSelectivity = clauselist_selectivity_standard(root, selectivityQuals,
 											   index->rel->relid,
 											   JOIN_INNER,
 											   NULL,
@@ -7547,7 +7547,7 @@ brincostestimate(PlannerInfo *root, IndexPath *path, double loop_count,
 		ReleaseVariableStats(vardata);
 	}
 
-	qualSelectivity = clauselist_selectivity_use_damping(root, indexQuals,
+	qualSelectivity = clauselist_selectivity_standard(root, indexQuals,
 											 baserel->relid,
 											 JOIN_INNER, NULL,
 											 false /* use_damping */);

--- a/src/backend/utils/adt/selfuncs.c
+++ b/src/backend/utils/adt/selfuncs.c
@@ -6068,7 +6068,7 @@ genericcostestimate(PlannerInfo *root,
 	}
 
 	/* Estimate the fraction of main-table tuples that will be visited */
-	indexSelectivity = clauselist_selectivity(root, selectivityQuals,
+	indexSelectivity = clauselist_selectivity_use_damping(root, selectivityQuals,
 											  index->rel->relid,
 											  JOIN_INNER,
 											  NULL,
@@ -6403,7 +6403,7 @@ btcostestimate(PlannerInfo *root, IndexPath *path, double loop_count,
 		 */
 		selectivityQuals = add_predicate_to_index_quals(index, indexBoundQuals);
 
-		btreeSelectivity = clauselist_selectivity(root, selectivityQuals,
+		btreeSelectivity = clauselist_selectivity_use_damping(root, selectivityQuals,
 												  index->rel->relid,
 												  JOIN_INNER,
 												  NULL,
@@ -7124,7 +7124,7 @@ gincostestimate(PlannerInfo *root, IndexPath *path, double loop_count,
 	selectivityQuals = add_predicate_to_index_quals(index, indexQuals);
 
 	/* Estimate the fraction of main-table tuples that will be visited */
-	*indexSelectivity = clauselist_selectivity(root, selectivityQuals,
+	*indexSelectivity = clauselist_selectivity_use_damping(root, selectivityQuals,
 											   index->rel->relid,
 											   JOIN_INNER,
 											   NULL,
@@ -7547,7 +7547,7 @@ brincostestimate(PlannerInfo *root, IndexPath *path, double loop_count,
 		ReleaseVariableStats(vardata);
 	}
 
-	qualSelectivity = clauselist_selectivity(root, indexQuals,
+	qualSelectivity = clauselist_selectivity_use_damping(root, indexQuals,
 											 baserel->relid,
 											 JOIN_INNER, NULL,
 											 false /* use_damping */);

--- a/src/include/optimizer/optimizer.h
+++ b/src/include/optimizer/optimizer.h
@@ -64,6 +64,11 @@ extern Selectivity clauselist_selectivity(PlannerInfo *root,
 										  List *clauses,
 										  int varRelid,
 										  JoinType jointype,
+										  SpecialJoinInfo *sjinfo);									  
+extern Selectivity clauselist_selectivity_use_damping(PlannerInfo *root,
+										  List *clauses,
+										  int varRelid,
+										  JoinType jointype,
 										  SpecialJoinInfo *sjinfo,
 										  bool use_damping);
 extern Selectivity clauselist_selectivity_simple(PlannerInfo *root,

--- a/src/include/optimizer/optimizer.h
+++ b/src/include/optimizer/optimizer.h
@@ -65,7 +65,7 @@ extern Selectivity clauselist_selectivity(PlannerInfo *root,
 										  int varRelid,
 										  JoinType jointype,
 										  SpecialJoinInfo *sjinfo);									  
-extern Selectivity clauselist_selectivity_use_damping(PlannerInfo *root,
+extern Selectivity clauselist_selectivity_standard(PlannerInfo *root,
 										  List *clauses,
 										  int varRelid,
 										  JoinType jointype,

--- a/src/include/optimizer/optimizer.h
+++ b/src/include/optimizer/optimizer.h
@@ -65,7 +65,7 @@ extern Selectivity clauselist_selectivity(PlannerInfo *root,
 										  int varRelid,
 										  JoinType jointype,
 										  SpecialJoinInfo *sjinfo);									  
-extern Selectivity clauselist_selectivity_standard(PlannerInfo *root,
+extern Selectivity clauselist_selectivity_extended(PlannerInfo *root,
 										  List *clauses,
 										  int varRelid,
 										  JoinType jointype,

--- a/src/include/utils/hsearch.h
+++ b/src/include/utils/hsearch.h
@@ -123,6 +123,7 @@ typedef struct
  * string_hash, tag_hash, uint32_hash, or oid_hash.  Just set HASH_BLOBS or
  * not.  Use HASH_FUNCTION only when you want something other than those.
  */
+extern uint32 tag_hash(const void *key, Size keysize);
 extern HTAB *hash_create(const char *tabname, long nelem,
 						 HASHCTL *info, int flags);
 extern void hash_destroy(HTAB *hashp);


### PR DESCRIPTION
This pr includes two commits.

**Commit 1:**
Function `clauselist_selectivity` in gpdb7 has one more parameter `use_damping` than upstream postgres.
It causes many postgres's fdw compilation failures in gpdb7(like kafka_fdw, clickhouse_fdw and arrow_fdw).

Because function `clauselist_selectivity` is a general function called by most postgres's fdw,
it's better to keep function `clauselist_selectivity` having same format with upstream postgres.

In this commit, we rename function `clauselist_selectivity` to `clauselist_selectivity_extended`  for gpdb7 internal use.
Meanwhile, we keep function `clauselist_selectivity` having same format with upstream postgres for external fdw use.

**Commit 2:**
We add function `tag_hash` declaration in src/include/utils/hsearch.h.
For function `tag_hash` declaration, gpdb7 is not consistent with postgres 12, but with a higher version.
It causes mysql_fdw compilation failures in gpdb7.

To solve this issue, we add function `tag_hash` declaration in src/include/utils/hsearch.h.