### PR TITLE
(6X_STABLE)Fix bug about functional dependency on primary key of group by clause

### DIFF
--- a/src/test/regress/expected/functional_deps.out
+++ b/src/test/regress/expected/functional_deps.out
@@ -125,6 +125,14 @@ SELECT product_id, p.name, (sum(s.units) * p.price) AS sales
 ------------+------+-------
 (0 rows)
 
+-- OK, test GPDB case
+set enable_groupagg = off;
+SELECT count(distinct name), price FROM products GROUP BY product_id;
+ count | price 
+-------+-------
+(0 rows)
+
+reset enable_groupagg;
 -- Drupal example, http://drupal.org/node/555530
 CREATE TEMP TABLE node (
     nid SERIAL,

--- a/src/test/regress/sql/functional_deps.sql
+++ b/src/test/regress/sql/functional_deps.sql
@@ -104,6 +104,10 @@ SELECT product_id, p.name, (sum(s.units) * p.price) AS sales
     FROM products p LEFT JOIN sales s USING (product_id)
     GROUP BY product_id;
 
+-- OK, test GPDB case
+set enable_groupagg = off;
+SELECT count(distinct name), price FROM products GROUP BY product_id;
+reset enable_groupagg;
 
 -- Drupal example, http://drupal.org/node/555530
 


### PR DESCRIPTION
The issue is caused by a GPDB_91_MERGE_FIXME(https://github.com/greenplum-db/gpdb-postgres-merge/commit/e94522ad93f2208eb8c56adc0dd333f00508f769),
which also manage to solve bug related pipeline failure after merging feature (https://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;h=e49ae8d3bc588294d07ce1a1272b31718cfca5ef) from upstraem.

The key reason to this issue is that there is a assumption in GP6 and not in upstream, which is columns of final targetlist must in group by clause during generating multi hashagg plan, and PR above has tried to add functional-dependency-related columns  to group by clause.
Besides adding those columns into group by clause, we also need to fill GroupColIdx and GroupOperators in AggNode struct for executing Hashagg plan, and this is what we done in this PR. 

NOTE: main branch don’t have such issues because no such assumptions in main branch.
issue relation https://github.com/greenplum-db/gpdb/issues/14817