### PR TITLE
Remove compilation warnings from statistic grammar file

### DIFF
--- a/src/backend/statistics/dependencies.c
+++ b/src/backend/statistics/dependencies.c
@@ -81,7 +81,7 @@ static bool dependency_is_compatible_clause(Node *clause, Index relid,
 static MVDependency *find_strongest_dependency(StatisticExtInfo *stats,
 											   MVDependencies *dependencies,
 											   Bitmapset *attnums);
-extern void statistics_scanner_init(const char *query_string);
+extern void statistic_scanner_init(const char *query_string);
 
 static void
 generate_dependencies_recurse(DependencyGenerator state, int index,
@@ -674,7 +674,7 @@ pg_dependencies_in(PG_FUNCTION_ARGS)
 	MVDependencies	   *mvdependencies;
 	int				parse_rc;
 
-	statistics_scanner_init(str);
+	statistic_scanner_init(str);
 	parse_rc = statistic_yyparse();
 	if (parse_rc != 0)
 		ereport(ERROR,

--- a/src/backend/statistics/mvdistinct.c
+++ b/src/backend/statistics/mvdistinct.c
@@ -44,7 +44,7 @@ static double estimate_ndistinct(double totalrows, int numrows, int d, int f1);
 static int	n_choose_k(int n, int k);
 static int	num_combinations(int n);
 
-extern void statistics_scanner_init(const char *query_string);
+extern void statistic_scanner_init(const char *query_string);
 
 /* size of the struct header fields (magic, type, nitems) */
 #define SizeOfHeader		(3 * sizeof(uint32))
@@ -353,7 +353,7 @@ pg_ndistinct_in(PG_FUNCTION_ARGS)
 	MVNDistinct	   *mvndistinct;
 	int				parse_rc;
 
-	statistics_scanner_init(str);
+	statistic_scanner_init(str);
 	parse_rc = statistic_yyparse();
 	if (parse_rc != 0)
 		ereport(ERROR,

--- a/src/backend/statistics/statistics_scanner.l
+++ b/src/backend/statistics/statistics_scanner.l
@@ -8,6 +8,9 @@
 static YY_BUFFER_STATE scanbufhandle;
 %}
 
+
+%option noinput
+%option nounput
 %option noyywrap
 %option prefix="statistic_yy"
 
@@ -54,7 +57,7 @@ yyerror(const char *message)
 }
 
 void
-statistics_scanner_init(const char *str)
+statistic_scanner_init(const char *str)
 {
 	Size		slen = strlen(str);
 	char	   *scanbuf;

--- a/src/test/regress/expected/minirepro.out
+++ b/src/test/regress/expected/minirepro.out
@@ -660,9 +660,9 @@ select count(*)=4 from pg_statistic_ext pge, pg_statistic_ext_data pgd where pge
 select stxname, stxdndistinct, stxddependencies, stxdmcv from pg_statistic_ext pge, pg_statistic_ext_data pgd where pge.oid = pgd.stxoid and pge.stxname in ('dep1', 'dep2', 'dist1', 'dist2');
  stxname | stxdndistinct |             stxddependencies             | stxdmcv 
 ---------+---------------+------------------------------------------+---------
- dep1    |               | {"1 => 2": 1.000000, "1 => 2": 1.000000} | 
+ dep1    |               | {"1 => 2": 1.000000, "2 => 1": 1.000000} | 
  dist1   | {"1, 2": 100} |                                          | 
- dep2    |               | {"1 => 2": 1.000000, "1 => 2": 1.000000} | 
+ dep2    |               | {"1 => 2": 1.000000, "2 => 1": 1.000000} | 
  dist2   | {"1, 2": 100} |                                          | 
 (4 rows)
 

--- a/src/test/regress/expected/stats_ext.out
+++ b/src/test/regress/expected/stats_ext.out
@@ -949,12 +949,14 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 insert into tbl_dependencies values (1, '{"1 => 2": 1.000000}');
 insert into tbl_dependencies values (2, '{"1 => 2": 2.000000, "1 => 3": 3.000000, "2 => 3": 2.000000, "1, 2 => 3": 3.000000}');
+insert into tbl_dependencies values (1, '{"1, 2, 3, 5 => 4": 3.000000}');
 select * from tbl_dependencies;
  i |                                         ii                                          
 ---+-------------------------------------------------------------------------------------
- 2 | {"1 => 2": 2.000000, "1 => 3": 3.000000, "2 => 3": 2.000000, "1, 2 => 3": 3.000000}
  1 | {"1 => 2": 1.000000}
-(2 rows)
+ 1 | {"1, 2, 3, 5 => 4": 3.000000}
+ 2 | {"1 => 2": 2.000000, "1 => 3": 3.000000, "2 => 3": 2.000000, "1, 2 => 3": 3.000000}
+(3 rows)
 
 -- leading space
 insert into tbl_dependencies values (1, ' {"1 => 2": 1.000000}');
@@ -1056,9 +1058,10 @@ select * from tbl_dependencies;
 ---+-------------------------------------------------------------------------------------
  2 | {"1 => 2": 2.000000, "1 => 3": 3.000000, "2 => 3": 2.000000, "1, 2 => 3": 3.000000}
  1 | {"1 => 2": 1.000000}
+ 1 | {"1, 2, 3, 5 => 4": 3.000000}
  1 | {"1 => 2": 1.000000}
  1 | {"1 => 2": 1.000000}
-(4 rows)
+(5 rows)
 
 -- Test a table with columns of type pg_ndistinct and pg_dependencies
 drop table if exists tbl_dist_dep;

--- a/src/test/regress/expected/stats_ext_optimizer.out
+++ b/src/test/regress/expected/stats_ext_optimizer.out
@@ -975,12 +975,14 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 insert into tbl_dependencies values (1, '{"1 => 2": 1.000000}');
 insert into tbl_dependencies values (2, '{"1 => 2": 2.000000, "1 => 3": 3.000000, "2 => 3": 2.000000, "1, 2 => 3": 3.000000}');
+insert into tbl_dependencies values (1, '{"1, 2, 3, 5 => 4": 3.000000}');
 select * from tbl_dependencies;
  i |                                         ii                                          
 ---+-------------------------------------------------------------------------------------
- 1 | {"1 => 2": 1.000000}
  2 | {"1 => 2": 2.000000, "1 => 3": 3.000000, "2 => 3": 2.000000, "1, 2 => 3": 3.000000}
-(2 rows)
+ 1 | {"1 => 2": 1.000000}
+ 1 | {"1, 2, 3, 5 => 4": 3.000000}
+(3 rows)
 
 -- leading space
 insert into tbl_dependencies values (1, ' {"1 => 2": 1.000000}');
@@ -1080,11 +1082,12 @@ DETAIL:  syntax error at or near """
 select * from tbl_dependencies;
  i |                                         ii                                          
 ---+-------------------------------------------------------------------------------------
+ 1 | {"1 => 2": 1.000000}
+ 1 | {"1, 2, 3, 5 => 4": 3.000000}
+ 1 | {"1 => 2": 1.000000}
+ 1 | {"1 => 2": 1.000000}
  2 | {"1 => 2": 2.000000, "1 => 3": 3.000000, "2 => 3": 2.000000, "1, 2 => 3": 3.000000}
- 1 | {"1 => 2": 1.000000}
- 1 | {"1 => 2": 1.000000}
- 1 | {"1 => 2": 1.000000}
-(4 rows)
+(5 rows)
 
 -- Test a table with columns of type pg_ndistinct and pg_dependencies
 drop table if exists tbl_dist_dep;

--- a/src/test/regress/sql/stats_ext.sql
+++ b/src/test/regress/sql/stats_ext.sql
@@ -604,6 +604,7 @@ drop table if exists tbl_dependencies;
 create table tbl_dependencies(i int, ii pg_dependencies);
 insert into tbl_dependencies values (1, '{"1 => 2": 1.000000}');
 insert into tbl_dependencies values (2, '{"1 => 2": 2.000000, "1 => 3": 3.000000, "2 => 3": 2.000000, "1, 2 => 3": 3.000000}');
+insert into tbl_dependencies values (1, '{"1, 2, 3, 5 => 4": 3.000000}');
 
 select * from tbl_dependencies;
 


### PR DESCRIPTION
Trying to remove compilation warnings from statistics grammar
```
statistics_gram.y: In function 'statistic_yyparse':
statistics_gram.y:163:75: warning: passing argument 2 of 'build_attnums_array' from incompatible pointer type [-Wincompatible-pointer-types]
  163 |                 AttrNumber *ptr = build_attnums_array($2, &$$->nattributes);
      |                                                                           ^~
      |                                                                           |
      |                                                                           AttrNumber * {aka short int *}
In file included from statistics_gram.y:4:
../../../src/include/statistics/extended_stats_internal.h:93:63: note: expected 'int *' but argument is of type 'AttrNumber *' {aka 'short int *'}
   93 | extern AttrNumber *build_attnums_array(Bitmapset *attrs, int *numattrs);
      |                                                          ~~~~~^~~~~~~~
In file included from statistics_gram.y:190:
statistics_scanner.l: At top level:
statistics_scanner.l:57:1: warning: no previous prototype for 'statistics_scanner_init' [-Wmissing-prototypes]
   57 | statistics_scanner_init(const char *str)
      | ^~~~~~~~~~~~~~~~~~~~~~~
In file included from statistics_gram.y:190:
statistics_scanner.c:1433:16: warning: 'input' defined but not used [-Wunused-function]
 1433 |     static int input  (void)
      |                ^~~~~
statistics_scanner.c:1390:17: warning: 'yyunput' defined but not used [-Wunused-function]
 1390 |     static void yyunput (int c, char * yy_bp )
      |                 ^~~~~~~
```

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
