### PR TITLE
Update RHEL 8 version requirement to v8.7

### DIFF
--- a/gpdb-doc/markdown/install_guide/platform-requirements.html.md
+++ b/gpdb-doc/markdown/install_guide/platform-requirements.html.md
@@ -23,15 +23,17 @@ This topic describes the Greenplum Database 6 platform and operating system soft
 
 Greenplum Database 6 runs on the following operating system platforms:
 
--   Red Hat Enterprise Linux 64-bit 8.x (as of Greenplum Database version 6.20)
--   Red Hat Enterprise Linux 64-bit 7.x \(See the following [Note](#7x-issue).\)
+-   Red Hat Enterprise Linux 64-bit 8.7 (As of Greenplum Database version 6.20. See the following [Note](#rhel-issues))
+-   Red Hat Enterprise Linux 64-bit 7.x \(See the following [Note](#rhel-issues).\)
 -   Red Hat Enterprise Linux 64-bit 6.x
 -   CentOS 64-bit 7.x
 -   CentOS 64-bit 6.x
 -   Ubuntu 18.04 LTS
 -   Oracle Linux 64-bit 7, using the Red Hat Compatible Kernel \(RHCK\)
 
-> **Important** Significant Greenplum Database performance degradation has been observed when enabling resource group-based workload management on RedHat 6.x and CentOS 6.x systems. This issue is caused by a Linux cgroup kernel bug. This kernel bug has been fixed in CentOS 7.x and Red Hat 7.x/8.x systems.
+<a name="rhel-issues"></a>
+> **Important** A kernel issue in Red Hat Enterprise Linux 8.5 and 8.6 can cause I/O freezes and synchronization problems with XFS filesystems. This issue is fixed in RHEL 8.7. See [RHEL8: xfs_buf deadlock between inode deletion and block allocation](https://access.redhat.com/solutions/6984334).
+> Significant Greenplum Database performance degradation has been observed when enabling resource group-based workload management on RedHat 6.x and CentOS 6.x systems. This issue is caused by a Linux cgroup kernel bug. This kernel bug has been fixed in CentOS 7.x and Red Hat 7.x/8.x systems.
 
 If you use RedHat 6 and the performance with resource groups is acceptable for your use case, upgrade your kernel to version 2.6.32-696 or higher to benefit from other fixes to the cgroups implementation.
 

--- a/gpdb-doc/markdown/install_guide/platform-requirements.html.md
+++ b/gpdb-doc/markdown/install_guide/platform-requirements.html.md
@@ -23,7 +23,7 @@ This topic describes the Greenplum Database 6 platform and operating system soft
 
 Greenplum Database 6 runs on the following operating system platforms:
 
--   Red Hat Enterprise Linux 64-bit 8.7 (As of Greenplum Database version 6.20. See the following [Note](#rhel-issues))
+-   Red Hat Enterprise Linux 64-bit 8.7 or later (As of Greenplum Database version 6.20. See the following [Note](#rhel-issues))
 -   Red Hat Enterprise Linux 64-bit 7.x \(See the following [Note](#rhel-issues).\)
 -   Red Hat Enterprise Linux 64-bit 6.x
 -   CentOS 64-bit 7.x


### PR DESCRIPTION
Bumping RHEL8 version requirement to v8.7 due to XFS bug.

Similar wording will be added to latest 6.23 release notes as known issue/important note.