### PR TITLE
(6x backport) Convert targetRoute Assert()s in SendTupleChunkToAMS() into FATALs.

### DIFF
--- a/src/backend/cdb/motion/ic_common.c
+++ b/src/backend/cdb/motion/ic_common.c
@@ -323,9 +323,12 @@ SendTupleChunkToAMS(MotionLayerState *mlStates,
 		}
 		else
 		{
+			if (targetRoute < 0 || targetRoute >= pEntry->numConns)
+			{
+				elog(FATAL, "SendTupleChunkToAMS: targetRoute is %d, must be between 0 and %d .",
+							targetRoute, pEntry->numConns);
+			}
 			/* handle pt-to-pt message. Primary */
-			Assert(targetRoute >= 0);
-			Assert(targetRoute < pEntry->numConns);
 			conn = pEntry->conns + targetRoute;
 			/* only send to interested connections */
 			if (conn->stillActive)


### PR DESCRIPTION
Currently out-of-bounds targetRoute leads to SEGFAULT and crashes the segment anyway. After this commit the problem will result only in one failed query. Though root cause of invalid targetRoute is still unknown bug. It is a sanity check to avoid crash.

Authored-by: Andrey M. Borodin <x4mmm@flight.local>
(cherry picked from commit 005ee83c4654f496276fd750c9bc0af37459479f)