### PR TITLE
(6x backport) Possible qual postponing past ANTI-JOIN/LASJ_NOTIN-JOIN

### DIFF
--- a/src/backend/optimizer/plan/initsplan.c
+++ b/src/backend/optimizer/plan/initsplan.c
@@ -1044,8 +1044,11 @@ deconstruct_recurse(PlannerInfo *root, Node *jtnode, bool below_outer_join,
 				 * semantically correct, see discussion on mailing list here:
 				 * "Regarding postponing quals past an semi join"
 				 * https://groups.google.com/a/greenplum.org/d/msg/gpdb-dev/YHYNIUZnecI/Rlum0VD3FwAJ
+				 *
+				 * MORE: In GPDB, ANTI-JOIN/LASJ_NOTIN-JOIN may come here.
 				 */
-				Assert(j->jointype == JOIN_INNER || j->jointype == JOIN_SEMI);
+				Assert(j->jointype == JOIN_INNER || j->jointype == JOIN_SEMI ||
+					   j->jointype == JOIN_ANTI || j->jointype == JOIN_LASJ_NOTIN);
 				*postponed_qual_list = lappend(*postponed_qual_list, pq);
 			}
 		}

--- a/src/test/regress/expected/bfv_joins.out
+++ b/src/test/regress/expected/bfv_joins.out
@@ -3646,6 +3646,35 @@ explain select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not disti
  Optimizer: Postgres query optimizer
 (19 rows)
 
+-- Test case from community Github PR 13722
+create table t_13722(id int, tt timestamp)
+  distributed by (id);
+-- j->jointype == join_lasj_notin
+select
+  t1.*
+from
+  t_13722 t1
+where
+  t1.id not in (select id from t_13722 where id != 4)
+  and
+  t1.tt = (select min(tt) from t_13722 where id = t1.id);
+ id | tt 
+----+----
+(0 rows)
+
+-- j->jointype == join_anti
+select
+  t1.*
+from
+  t_13722 t1
+where
+  not exists (select id from t_13722 where id != 4 and id = t1.id)
+  and t1.tt = (select min(tt) from t_13722 where id = t1.id);
+ id | tt 
+----+----
+(0 rows)
+
+drop table t_13722;
 -- Clean up. None of the objects we create are very interesting to keep around.
 reset search_path;
 set client_min_messages='warning';

--- a/src/test/regress/expected/bfv_joins_optimizer.out
+++ b/src/test/regress/expected/bfv_joins_optimizer.out
@@ -3633,6 +3633,35 @@ explain select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not disti
  Optimizer: Pivotal Optimizer (GPORCA)
 (12 rows)
 
+-- Test case from community Github PR 13722
+create table t_13722(id int, tt timestamp)
+  distributed by (id);
+-- j->jointype == join_lasj_notin
+select
+  t1.*
+from
+  t_13722 t1
+where
+  t1.id not in (select id from t_13722 where id != 4)
+  and
+  t1.tt = (select min(tt) from t_13722 where id = t1.id);
+ id | tt 
+----+----
+(0 rows)
+
+-- j->jointype == join_anti
+select
+  t1.*
+from
+  t_13722 t1
+where
+  not exists (select id from t_13722 where id != 4 and id = t1.id)
+  and t1.tt = (select min(tt) from t_13722 where id = t1.id);
+ id | tt 
+----+----
+(0 rows)
+
+drop table t_13722;
 -- Clean up. None of the objects we create are very interesting to keep around.
 reset search_path;
 set client_min_messages='warning';

--- a/src/test/regress/sql/bfv_joins.sql
+++ b/src/test/regress/sql/bfv_joins.sql
@@ -428,6 +428,31 @@ explain select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not disti
 explain select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not distinct from a3 and b2 is distinct from b3;
 explain select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not distinct from a3 and b2 = b3;
 
+-- Test case from community Github PR 13722
+create table t_13722(id int, tt timestamp)
+  distributed by (id);
+
+-- j->jointype == join_lasj_notin
+select
+  t1.*
+from
+  t_13722 t1
+where
+  t1.id not in (select id from t_13722 where id != 4)
+  and
+  t1.tt = (select min(tt) from t_13722 where id = t1.id);
+
+-- j->jointype == join_anti
+select
+  t1.*
+from
+  t_13722 t1
+where
+  not exists (select id from t_13722 where id != 4 and id = t1.id)
+  and t1.tt = (select min(tt) from t_13722 where id = t1.id);
+
+drop table t_13722;
+
 
 -- Clean up. None of the objects we create are very interesting to keep around.
 reset search_path;


### PR DESCRIPTION
When optimizer is off.

For qual (NOT(EXISTS_SUBLINK) and EXPR_SUBLINK)
  or qual (NOT(ANY_SUBLINK) AND EXPR_SUBLINK)

In pull_up_sublinks_qual(), after NOT(EXISTS_SUBLINK) is converted to Anti-JOIN (or NOT(ANY_SUBLINK) => LASJ_NOTIN-JOIN), if EXPR_SUBLINK is also successfully converted to INNER-JOIN (see convert_EXPR_to_join) , we can encounter the scenario where qual is postponed past the anti or lasj_notin join. It will trigger assertion failure:

  Assert(j->jointype == JOIN_INNER || j->jointype == JOIN_SEMI);

> FATAL:  Unexpected internal error (assert.c:48)
> DETAIL:  FailedAssertion("!(j->jointype == JOIN_INNER || j->jointype == JOIN_SEMI)", File: "initsplan.c", Line: 1018)
> server closed the connection unexpectedly
> ...

We can easily reproduce this issue in master and 6X branch:

```
CREATE TABLE A(id int, tt timestamp)
  DISTRIBUTED BY (id);

SET optimizer TO off;

-- j->jointype == JOIN_LASJ_NOTIN
SELECT
  t1.*
FROM
  A t1
WHERE
  t1.id NOT IN (SELECT id FROM A WHERE id != 4)
  AND
  t1.tt = (SELECT MIN(tt) FROM A WHERE id = t1.id);

-- j->jointype == JOIN_ANTI
SELECT
  t1.*
FROM
  A t1
WHERE
  NOT EXISTS (SELECT id FROM A WHERE id != 4 and id = t1.id)
  AND t1.tt = (SELECT MIN(tt) FROM A WHERE id = t1.id);
```

Add these two jointype into the Assert(). I made several simple tests, results are ok. However, same as the code comment said, i am also unsure if postponing quals past anti-join/lasj_notin-join is always semantically correct.