### PR TITLE
[6X_STABLE] Ressurect the lost code for archiver auto restart

### DIFF
--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -1996,6 +1996,10 @@ ServerLoop(void)
 				start_autovac_launcher = false; /* signal processed */
 		}
 
+		/* If we have lost the archiver, try to start a new one */
+		if (XLogArchivingActive() && PgArchPID == 0 && pmState == PM_RUN)
+			PgArchPID = pgarch_start();
+
 		/* If we have lost the stats collector, try to start a new one */
 		if (PgStatPID == 0 &&
 			(pmState == PM_RUN || pmState == PM_HOT_STANDBY))


### PR DESCRIPTION
Currently, if archiver dies during the postmaster startup, it won't attempt to start again. Looks like that archiver restart code has been lost in the https://github.com/greenplum-db/gpdb/commit/a453004ea1946b5c141bd26ac871ac6edde64f37. I propose to move the lost fragment back.