### PR TITLE
Reuse the epoll object to fix the dispatcher performance downgrade

### DIFF
--- a/src/backend/cdb/dispatcher/cdbdisp_async.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_async.c
@@ -217,7 +217,11 @@ cdbdisp_waitDispatchFinish_async(struct CdbDispatcherState *ds)
 	const static int DISPATCH_POLL_TIMEOUT = 500;
 	int			i;
 
-	initDispatchWaitEventSet(dispatchCount);
+	/*
+	 * DispWaitSet's lifecycle is in the whole QD process,
+	 * so alloc it in the TopMemoryContext (rather than DispatcherContext)
+	 */
+	ResetWaitEventSet(&DispWaitSet, TopMemoryContext, dispatchCount);
 
 	WaitEvent 		*revents = palloc(sizeof(WaitEvent) * dispatchCount);
 	int 			*added = palloc0(sizeof(int) * dispatchCount);
@@ -454,7 +458,7 @@ checkDispatchResult(CdbDispatcherState *ds, int timeout_sec)
 	CdbDispatchResult *dispatchResult;
 
 	int 	db_count = pParms->dispatchCount;
-	initDispatchWaitEventSet(db_count);
+	ResetWaitEventSet(&DispWaitSet, TopMemoryContext, db_count);
 	int 	*added = palloc0(db_count * sizeof(int));
 	WaitEvent *revents = palloc(sizeof(WaitEvent) * db_count);
 

--- a/src/backend/cdb/dispatcher/cdbdisp_async.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_async.c
@@ -218,21 +218,17 @@ cdbdisp_waitDispatchFinish_async(struct CdbDispatcherState *ds)
 {
 	CdbDispatchCmdAsync *pParms = (CdbDispatchCmdAsync *) ds->dispatchParams;
 	int				dispatchCount = pParms->dispatchCount;
-	WaitEventSet 	*volatile waitset = CreateWaitEventSet(CurrentMemoryContext, dispatchCount);
-
+	initDispatchWaitEventSet(dispatchCount);
 	/* Use PG_TRY() - PG_CATCH() to make sure destroy the waiteventset (close the epoll fd) */
 	PG_TRY();
 	{
-		cdbdisp_waitDispatchFinishLoop_async(ds, waitset);
+		cdbdisp_waitDispatchFinishLoop_async(ds, DispWaitSet);
 	}
 	PG_CATCH();
 	{
-		FreeWaitEventSet(waitset);
 		PG_RE_THROW();
 	}
 	PG_END_TRY();
-
-	FreeWaitEventSet(waitset);
 }
 
 static void
@@ -466,21 +462,18 @@ static void
 checkDispatchResult(CdbDispatcherState *ds, int timeout_sec)
 {
 	CdbDispatchCmdAsync *pParms = (CdbDispatchCmdAsync *) ds->dispatchParams;
-	WaitEventSet *volatile waitset = CreateWaitEventSet(CurrentMemoryContext, pParms->dispatchCount);
 
+	initDispatchWaitEventSet(pParms->dispatchCount);
 	/* Use PG_TRY() - PG_CATCH() to make sure destroy the waiteventset (close the epoll fd) */
 	PG_TRY();
 	{
-		checkDispatchResultLoop(ds, timeout_sec, waitset);
+		checkDispatchResultLoop(ds, timeout_sec, DispWaitSet);
 	}
 	PG_CATCH();
 	{
-		FreeWaitEventSet(waitset);
 		PG_RE_THROW();
 	}
 	PG_END_TRY();
-
-	FreeWaitEventSet(waitset);
 }
 
 static void

--- a/src/backend/cdb/dispatcher/cdbgang.c
+++ b/src/backend/cdb/dispatcher/cdbgang.c
@@ -98,23 +98,6 @@ cdbgang_createGang(List *segments, SegmentType segmentType)
 }
 
 /*
- * init DispWaitSet: create it in the first time and reset it later
- */
-void
-initDispatchWaitEventSet(int nevents)
-{
-	/*
-	 * its lifecycle is in the whole QD process,
-	 * so alloc it in the TopMemoryContext (rather than DispatcherContext)
-	 */
-	MemoryContext context = TopMemoryContext;
-	if (DispWaitSet == NULL)
-		DispWaitSet = CreateWaitEventSet(context, nevents);
-	else
-		ResetWaitEventSet(&DispWaitSet, context, nevents);
-}
-
-/*
  * Creates a new gang by logging on a session to each segDB involved.
  *
  * elog ERROR or return a non-NULL gang.

--- a/src/backend/cdb/dispatcher/cdbgang_async.c
+++ b/src/backend/cdb/dispatcher/cdbgang_async.c
@@ -198,14 +198,8 @@ create_gang_retry:
 								errdetail("timeout expired\n (%s)", segdbDesc->whoami)));
 
 			/*
-			 * GPDB_12_MERGE_FIXME: create and destroy waiteventset in each loop
-			 * may impact the performance, please see:
-			 * https://github.com/greenplum-db/gpdb/pull/13494#discussion_r874243725
-			 * Let's verify it later.
-			 */
-			/*
 			 * Since the set of FDs can change when we call PQconnectPoll() below,
-			 * create a new wait event set to poll on for every loop iteration.
+			 * we must init WaitEventSet to poll on for every loop iteration.
 			 */
 			initDispatchWaitEventSet(size);
 

--- a/src/backend/cdb/dispatcher/cdbgang_async.c
+++ b/src/backend/cdb/dispatcher/cdbgang_async.c
@@ -201,7 +201,7 @@ create_gang_retry:
 			 * Since the set of FDs can change when we call PQconnectPoll() below,
 			 * we must init WaitEventSet to poll on for every loop iteration.
 			 */
-			initDispatchWaitEventSet(size);
+			ResetWaitEventSet(&DispWaitSet, TopMemoryContext, size);
 
 			for (i = 0; i < size; i++)
 			{

--- a/src/backend/cdb/motion/ic_udpifc.c
+++ b/src/backend/cdb/motion/ic_udpifc.c
@@ -378,6 +378,9 @@ struct SendControlInfo
  */
 static SendControlInfo snd_control_info;
 
+/* WaitEventSet for the icudp */
+static WaitEventSet *ICWaitSet = NULL;
+
 /*
  * ICGlobalControlInfo
  *
@@ -3673,7 +3676,6 @@ receiveChunksUDPIFC(ChunkTransportState *pTransportStates, ChunkTransportStateEn
 	int 		nFds = 0;
 	int 		*waitFds = NULL;
 	int 		nevent = 0;
-	WaitEventSet	*waitset = NULL;
 	TupleChunkListItem	tcItem = NULL;
 
 #ifdef AMS_VERBOSE_LOGGING
@@ -3705,8 +3707,11 @@ receiveChunksUDPIFC(ChunkTransportState *pTransportStates, ChunkTransportStateEn
 			nevent += nFds;
 	}
 
-	/* init WaitEventSet */
-	waitset = CreateWaitEventSet(CurrentMemoryContext, nevent);
+	/* reset WaitEventSet */
+	if (ICWaitSet == NULL)
+		ICWaitSet = CreateWaitEventSet(TopMemoryContext, nevent);
+	else
+		ResetWaitEventSet(&ICWaitSet, TopMemoryContext, nevent);
 
 	/*
 	 * Use PG_TRY() - PG_CATCH() to make sure destroy the waiteventset (close the epoll fd)
@@ -3714,26 +3719,23 @@ receiveChunksUDPIFC(ChunkTransportState *pTransportStates, ChunkTransportStateEn
 	 */
 	PG_TRY();
 	{
-		AddWaitEventToSet(waitset, WL_LATCH_SET, PGINVALID_SOCKET, &ic_control_info.latch, NULL);
-		AddWaitEventToSet(waitset, WL_POSTMASTER_DEATH, PGINVALID_SOCKET, NULL, NULL);
+		AddWaitEventToSet(ICWaitSet, WL_LATCH_SET, PGINVALID_SOCKET, &ic_control_info.latch, NULL);
+		AddWaitEventToSet(ICWaitSet, WL_POSTMASTER_DEATH, PGINVALID_SOCKET, NULL, NULL);
 		for (int i = 0; i < nFds; i++)
 		{
-			AddWaitEventToSet(waitset, WL_SOCKET_READABLE, waitFds[i], NULL, NULL);
+			AddWaitEventToSet(ICWaitSet, WL_SOCKET_READABLE, waitFds[i], NULL, NULL);
 		}
 
-		tcItem = receiveChunksUDPIFCLoop(pTransportStates, pEntry, srcRoute, conn, waitset, nevent);
+		tcItem = receiveChunksUDPIFCLoop(pTransportStates, pEntry, srcRoute, conn, ICWaitSet, nevent);
 	}
 	PG_CATCH();
 	{
-		FreeWaitEventSet(waitset);
 		if (waitFds != NULL)
 			pfree(waitFds);
-
 		PG_RE_THROW();
 	}
 	PG_END_TRY();
 
-	FreeWaitEventSet(waitset);
 	if (waitFds != NULL)
 		pfree(waitFds);
 

--- a/src/backend/cdb/motion/ic_udpifc.c
+++ b/src/backend/cdb/motion/ic_udpifc.c
@@ -3708,10 +3708,7 @@ receiveChunksUDPIFC(ChunkTransportState *pTransportStates, ChunkTransportStateEn
 	}
 
 	/* reset WaitEventSet */
-	if (ICWaitSet == NULL)
-		ICWaitSet = CreateWaitEventSet(TopMemoryContext, nevent);
-	else
-		ResetWaitEventSet(&ICWaitSet, TopMemoryContext, nevent);
+	ResetWaitEventSet(&ICWaitSet, TopMemoryContext, nevent);
 
 	/*
 	 * Use PG_TRY() - PG_CATCH() to make sure destroy the waiteventset (close the epoll fd)

--- a/src/include/cdb/cdbgang.h
+++ b/src/include/cdb/cdbgang.h
@@ -18,6 +18,7 @@
 #include "executor/execdesc.h"
 #include "utils/faultinjector.h"
 #include "utils/portal.h"
+#include "storage/latch.h"
 
 struct Port;
 struct QueryDesc;
@@ -52,6 +53,8 @@ extern int ic_htab_size;
 extern MemoryContext GangContext;
 extern Gang *CurrentGangCreating;
 
+extern WaitEventSet *DispWaitSet;
+
 /*
  * cdbgang_createGang:
  *
@@ -62,6 +65,8 @@ extern Gang *CurrentGangCreating;
  */
 extern Gang *
 cdbgang_createGang(List *segments, SegmentType segmentType);
+
+extern void initDispatchWaitEventSet(int nevents);
 
 extern const char *gangTypeToString(GangType type);
 

--- a/src/include/cdb/cdbgang.h
+++ b/src/include/cdb/cdbgang.h
@@ -66,8 +66,6 @@ extern WaitEventSet *DispWaitSet;
 extern Gang *
 cdbgang_createGang(List *segments, SegmentType segmentType);
 
-extern void initDispatchWaitEventSet(int nevents);
-
 extern const char *gangTypeToString(GangType type);
 
 extern void setupCdbProcessList(ExecSlice *slice);

--- a/src/include/storage/latch.h
+++ b/src/include/storage/latch.h
@@ -176,6 +176,8 @@ extern int	WaitLatch(Latch *latch, int wakeEvents, long timeout,
 					  uint32 wait_event_info);
 extern int	WaitLatchOrSocket(Latch *latch, int wakeEvents,
 							  pgsocket sock, long timeout, uint32 wait_event_info);
+/* specifial function for gpdb */
+extern void ResetWaitEventSet(WaitEventSet **pset, MemoryContext context, int nevents);
 
 /*
  * Unix implementation uses SIGUSR1 for inter-process signaling.


### PR DESCRIPTION
In commit https://github.com/greenplum-db/gpdb/commit/e30909fccfef42a99070f080b7c06439d6d79b29, I used the "WaitEventSet" to refactor the dispatch logic.
But in the following pgbench test, we found the performance downgrade 50% due to this commit. Did a perf on it, the bottleneck is `native_queued_spin_lock_slowpath`, means there is a lot of lock contention in it. 

After investigation, we found the culprit is a large number of concurrent creation and destruction of epoll objects. And the fix idea is simple: reuse the epoll object.

Opened this PR to fix it, and:
* no need to backport to 6x, because it doesn't use WaitEventSet.
* no special test for it, the existing tests cover the whole changes.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [x] Review a PR in return to support the community
