### PR TITLE
Fix building clients for Windows

### DIFF
--- a/src/bin/pg_dump/pg_backup_db.c
+++ b/src/bin/pg_dump/pg_backup_db.c
@@ -20,7 +20,6 @@
 #include "pg_backup_db.h"
 #include "pg_backup_utils.h"
 #include "parallel.h"
-#include "libpq-int.h"
 
 #include <unistd.h>
 #include <ctype.h>

--- a/src/tools/msvc/Solution.pm
+++ b/src/tools/msvc/Solution.pm
@@ -752,12 +752,14 @@ sub AddProject
 		}
 		else
 		{
+			# The latest upstream Kerberos on Windows is installed
+			# under \lib\amd64, but our buildbot hasn't updated yet.
 			$proj->AddLibrary(
-				$self->{options}->{gss} . '\lib\amd64\krb5_64.lib');
+				$self->{options}->{gss} . '\lib\krb5_64.lib');
 			$proj->AddLibrary(
-				$self->{options}->{gss} . '\lib\amd64\comerr64.lib');
+				$self->{options}->{gss} . '\lib\comerr64.lib');
 			$proj->AddLibrary(
-				$self->{options}->{gss} . '\lib\amd64\gssapi64.lib');
+				$self->{options}->{gss} . '\lib\gssapi64.lib');
 		}
 	}
 	if ($self->{options}->{iconv})


### PR DESCRIPTION
1, the extra `libpq-int.h` involves `pthread-win32.h`, which doesn't
exist on our building machine.
2, The latest upstream Kerberos on Windows is installed under \lib\amd64,
but our building machine hasn't been updated yet.