### PR TITLE
[WIP] Introducing differential recovery option for gprecoverseg

### DIFF
--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -56,6 +56,7 @@ MAX_COORDINATOR_NUM_WORKERS=64
 # during incremental recovery. gpstate uses this to figure out when incremental
 # recovery is active.
 RECOVERY_REWIND_APPNAME = '__gprecoverseg_pg_rewind__'
+RECOVERY_DIFF_APPNAME = '__gprecoverseg_remote_sync__'
 
 PGDATABASE_FOR_COMMON_USE= 'postgres'
 

--- a/gpMgmt/bin/gppylib/programs/clsAddMirrors.py
+++ b/gpMgmt/bin/gppylib/programs/clsAddMirrors.py
@@ -110,7 +110,7 @@ class GpMirrorBuildCalculator:
 
         primary.setSegmentMode(gparray.MODE_NOT_SYNC)
 
-        resultOut.append(GpMirrorToBuild(None, primary, mirror, True))
+        resultOut.append(GpMirrorToBuild(None, primary, mirror, True, False))
 
         self.__primariesUpdatedToHaveMirrorsByHost[primary.getSegmentHostName()] += 1
         self.__mirrorsAddedByHost[targetHost] = mirrorIndexOnTargetHost + 1

--- a/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
+++ b/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
@@ -124,7 +124,7 @@ class GpRecoverSegmentProgram:
             return GpSegmentRebalanceOperation(gpEnv, gpArray, self.__options.parallelDegree, self.__options.parallelPerHost)
         else:
             instance = RecoveryTripletsFactory.instance(gpArray, self.__options.recoveryConfigFile, self.__options.newRecoverHosts, self.__options.parallelDegree)
-            segs = [GpMirrorToBuild(t.failed, t.live, t.failover, self.__options.forceFullResynchronization) for t in instance.getTriplets()]
+            segs = [GpMirrorToBuild(t.failed, t.live, t.failover, self.__options.forceFullResynchronization, self.__options.diffResynchronization) for t in instance.getTriplets()]
             return GpMirrorListToBuild(segs, self.__pool, self.__options.quiet,
                                        self.__options.parallelDegree,
                                        instance.getInterfaceHostnameWarnings(),
@@ -184,7 +184,7 @@ class GpRecoverSegmentProgram:
 
                 tabLog = TableLogger()
 
-                syncMode = "Full" if toRecover.isFullSynchronization() else "Incremental"
+                syncMode = "Full" if (toRecover.isFullSynchronization() or toRecover.isDiffSynchronization) else "Incremental"
                 tabLog.info(["Synchronization mode", "= " + syncMode])
                 programIoUtils.appendSegmentInfoForOutput("Failed", gpArray, toRecover.getFailedSegment(), tabLog)
                 programIoUtils.appendSegmentInfoForOutput("Recovery Source", gpArray, toRecover.getLiveSegment(),
@@ -260,6 +260,10 @@ class GpRecoverSegmentProgram:
             optionCnt += 1
         if optionCnt > 1:
             raise ProgramArgumentValidationException("Only one of -i, -p, and -r may be specified")
+
+        # verify "mode to recover" options
+        if self.__options.forceFullResynchronization and self.__options.diffResynchronization:
+            raise ProgramArgumentValidationException("Only one of -F and --diff may be specified")
 
         faultProberInterface.getFaultProber().initializeProber(gpEnv.getCoordinatorPort())
 
@@ -441,6 +445,10 @@ class GpRecoverSegmentProgram:
                          dest="forceFullResynchronization",
                          metavar="<forceFullResynchronization>",
                          help="Force full segment resynchronization")
+        addTo.add_option('--diff', None, default=False, action='store_true',
+                         dest="diffResynchronization",
+                         metavar="<diffResynchronization>",
+                         help="diff segment resynchronization")
         addTo.add_option("-B", None, type="int", default=gp.DEFAULT_COORDINATOR_NUM_WORKERS,
                          dest="parallelDegree",
                          metavar="<parallelDegree>",

--- a/gpMgmt/bin/gppylib/recoveryinfo.py
+++ b/gpMgmt/bin/gppylib/recoveryinfo.py
@@ -13,7 +13,7 @@ class RecoveryInfo(object):
     Note: we don't have target hostname, since an object of this class will be accessed by the target host directly
     """
     def __init__(self, target_datadir, target_port, target_segment_dbid, source_hostname, source_port,
-                 is_full_recovery, progress_file):
+                 source_datadir, is_full_recovery, is_diff_recovery,  progress_file):
         self.target_datadir = target_datadir
         self.target_port = target_port
         self.target_segment_dbid = target_segment_dbid
@@ -21,7 +21,9 @@ class RecoveryInfo(object):
         # FIXME: use address instead of hostname ?
         self.source_hostname = source_hostname
         self.source_port = source_port
+        self.source_datadir = source_datadir
         self.is_full_recovery = is_full_recovery
+        self.is_diff_recovery = is_diff_recovery
         self.progress_file = progress_file
 
     def __str__(self):
@@ -51,7 +53,8 @@ def build_recovery_info(mirrors_to_build):
         target_segment = to_recover.getFailoverSegment() or to_recover.getFailedSegment()
 
         # FIXME: move the progress file naming to gpsegrecovery
-        process_name = 'pg_basebackup' if to_recover.isFullSynchronization() else 'pg_rewind'
+        process_name = 'pg_basebackup' if to_recover.isFullSynchronization() else 'rsync' \
+            if to_recover.isDiffSynchronization() else 'pg_rewind'
         progress_file = '{}/{}.{}.dbid{}.out'.format(gplog.get_logger_dir(), process_name, timestamp,
                                                      target_segment.getSegmentDbId())
 
@@ -60,8 +63,8 @@ def build_recovery_info(mirrors_to_build):
         recovery_info_by_host[hostname].append(RecoveryInfo(
             target_segment.getSegmentDataDirectory(), target_segment.getSegmentPort(),
             target_segment.getSegmentDbId(), source_segment.getSegmentHostName(),
-            source_segment.getSegmentPort(), to_recover.isFullSynchronization(),
-            progress_file))
+            source_segment.getSegmentPort(), source_segment.getSegmentDataDirectory(),
+            to_recover.isFullSynchronization(), to_recover.isDiffSynchronization(), progress_file))
     return recovery_info_by_host
 
 
@@ -84,6 +87,7 @@ def deserialize_list(serialized_string, class_name=RecoveryInfo):
 class RecoveryErrorType(object):
     VALIDATION_ERROR = 'validation'
     REWIND_ERROR = 'incremental'
+    SYNC_ERROR = 'diff'
     BASEBACKUP_ERROR = 'full'
     START_ERROR = 'start'
     UPDATE_ERROR = 'update'

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gprecoverseg.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gprecoverseg.py
@@ -71,7 +71,7 @@ class GpRecoversegTestCase(GpTestCase):
 
         self.config_provider_mock.loadSystemConfig.return_value = self.gpArrayMock
 
-        self.mirror_to_build = GpMirrorToBuild(self.mirror0, self.primary0, None, False)
+        self.mirror_to_build = GpMirrorToBuild(self.mirror0, self.primary0, None, False, False)
         self.apply_patches([
             patch('os.environ', new=self.os_env),
             patch('gppylib.db.dbconn.connect', return_value=self.conn),

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpsegrecovery.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpsegrecovery.py
@@ -33,7 +33,8 @@ class IncrementalRecoveryTestCase(GpTestCase):
                                               m.getSegmentDbId(),
                                               p.getSegmentHostName(),
                                               p.getSegmentPort(),
-                                              False, '/tmp/test_progress_file')
+                                              p.getSegmentDataDirectory(),
+                                              False, False, '/tmp/test_progress_file')
         self.era = '1234_20211110'
 
         self.incremental_recovery_cmd = gpsegrecovery.IncrementalRecovery(
@@ -142,7 +143,8 @@ class FullRecoveryTestCase(GpTestCase):
                                               m.getSegmentDbId(),
                                               p.getSegmentHostName(),
                                               p.getSegmentPort(),
-                                              True, '/tmp/test_progress_file')
+                                              p.getSegmentDataDirectory(),
+                                              True, False, '/tmp/test_progress_file')
         self.era = '1234_20211110'
         self.full_recovery_cmd = gpsegrecovery.FullRecovery(
             name='test full recovery', recovery_info=self.seg_recovery_info,
@@ -276,13 +278,13 @@ class SegRecoveryTestCase(GpTestCase):
         self.maxDiff = None
         self.mock_logger = Mock(spec=['log', 'info', 'debug', 'error', 'warn', 'exception'])
         self.full_r1 = RecoveryInfo('target_data_dir1', 5001, 1, 'source_hostname1',
-                                    6001, True, '/tmp/progress_file1')
+                                    6001, 'source_datadair1', True, False, '/tmp/progress_file1')
         self.incr_r1 = RecoveryInfo('target_data_dir2', 5002, 2, 'source_hostname2',
-                                    6002, False, '/tmp/progress_file2')
+                                    6002, 'source_datadir2', False, False, '/tmp/progress_file2')
         self.full_r2 = RecoveryInfo('target_data_dir3', 5003, 3, 'source_hostname3',
-                                    6003, True, '/tmp/progress_file3')
+                                    6003, 'source_datadir3', True, False, '/tmp/progress_file3')
         self.incr_r2 = RecoveryInfo('target_data_dir4', 5004, 4, 'source_hostname4',
-                                    6004, False, '/tmp/progress_file4')
+                                    6004, 'source_datadir4', False, False, '/tmp/progress_file4')
         self.era = '1234_2021110'
 
         self.apply_patches([

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpsegsetuprecovery.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpsegsetuprecovery.py
@@ -25,7 +25,8 @@ class ValidationForFullRecoveryTestCase(GpTestCase):
                                               m.getSegmentDbId(),
                                               p.getSegmentHostName(),
                                               p.getSegmentPort(),
-                                              True, '/tmp/test_progress_file')
+                                              p.getSegmentDataDirectory(),
+                                              True, False, '/tmp/test_progress_file')
 
         self.validation_recovery_cmd = gpsegsetuprecovery.ValidationForFullRecovery(
             name='test validation for full recovery', recovery_info=self.seg_recovery_info,
@@ -158,7 +159,8 @@ class SetupForIncrementalRecoveryTestCase(GpTestCase):
                                               m.getSegmentDbId(),
                                               p.getSegmentHostName(),
                                               p.getSegmentPort(),
-                                              True, '/tmp/test_progress_file')
+                                              p.getSegmentDataDirectory(),
+                                              True, False, '/tmp/test_progress_file')
 
         self.setup_for_incremental_recovery_cmd = gpsegsetuprecovery.SetupForIncrementalRecovery(
             name='setup for incremental recovery', recovery_info=self.seg_recovery_info, logger=self.mock_logger)
@@ -212,13 +214,13 @@ class SegSetupRecoveryTestCase(GpTestCase):
     def setUp(self):
         self.mock_logger = Mock(spec=['log', 'info', 'debug', 'error', 'warn', 'exception'])
         self.full_r1 = RecoveryInfo('target_data_dir1', 5001, 1, 'source_hostname1',
-                                    6001, True, '/tmp/progress_file1')
+                                    6001, 'source_datadir1', True, False, '/tmp/progress_file1')
         self.incr_r1 = RecoveryInfo('target_data_dir2', 5002, 2, 'source_hostname2',
-                                    6002, False, '/tmp/progress_file2')
+                                    6002, 'source_datadir2', False, False, '/tmp/progress_file2')
         self.full_r2 = RecoveryInfo('target_data_dir3', 5003, 3, 'source_hostname3',
-                                    6003, True, '/tmp/progress_file3')
+                                    6003, 'source_datadir3', True, False, '/tmp/progress_file3')
         self.incr_r2 = RecoveryInfo('target_data_dir4', 5004, 4, 'source_hostname4',
-                                    6004, False, '/tmp/progress_file4')
+                                    6004, 'source_datadir4', False, False, '/tmp/progress_file4')
 
     def tearDown(self):
         super(SegSetupRecoveryTestCase, self).tearDown()

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_recovery_base.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_recovery_base.py
@@ -31,9 +31,9 @@ class RecoveryBaseTestCase(GpTestCase):
         self.mock_enable_verbose_logging = self.get_mock_from_apply_patch('enable_verbose_logging')
 
         self.full_r1 = RecoveryInfo('target_data_dir1', 5001, 1, 'source_hostname1',
-                                    6001, True, '/tmp/progress_file1')
+                                    6001, 'source_datadir1', True, False, '/tmp/progress_file1')
         self.incr_r2 = RecoveryInfo('target_data_dir2', 5002, 2, 'source_hostname2',
-                                    6002, False, '/tmp/progress_file2')
+                                    6002, 'source_datadir2', False, False, '/tmp/progress_file2')
         self.confinfo = gppylib.recoveryinfo.serialize_list([self.full_r1,
                                                              self.incr_r2])
 
@@ -323,7 +323,7 @@ class SetCmdResultsTestCase(GpTestCase):
             cmd.error_type = 10
             raise Exception('running the cmd failed')
 
-        recovery_info = RecoveryInfo('/tmp/datadir2', 7002, 2, None, None, None, '/tmp/progress_file2')
+        recovery_info = RecoveryInfo('/tmp/datadir2', 7002, 2, None, None, None, None, None, '/tmp/progress_file2')
         test_cmd = FullRecovery('original name', recovery_info, True,None,None)
         test_decorator(test_cmd)
         self.assertEqual('new name', test_cmd.name)
@@ -338,7 +338,7 @@ class SetCmdResultsTestCase(GpTestCase):
             cmd.name = 'new name'
             cmd.error_type = None
             raise Exception('running the cmd failed')
-        recovery_info = RecoveryInfo('/tmp/datadir2', 7002, 2, None, None, None, '/tmp/progress_file2')
+        recovery_info = RecoveryInfo('/tmp/datadir2', 7002, 2, None, None, None, None, None, '/tmp/progress_file2')
         test_cmd = FullRecovery('original name', recovery_info, True,None,None)
         test_decorator(test_cmd)
         self.assertEqual('new name', test_cmd.name)

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_recoveryinfo.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_recoveryinfo.py
@@ -5,7 +5,7 @@ from gppylib.commands.base import CommandResult
 from gppylib.commands import gp
 from gppylib.gparray import Segment
 from gppylib.operations.buildMirrorSegments import GpMirrorToBuild
-from gppylib.recoveryinfo import  build_recovery_info, RecoveryInfo, RecoveryResult
+from gppylib.recoveryinfo import build_recovery_info, RecoveryInfo, RecoveryResult
 
 
 class BuildRecoveryInfoTestCase(GpTestCase):
@@ -43,84 +43,82 @@ class BuildRecoveryInfoTestCase(GpTestCase):
         tests = [
             {
                 "name": "single_target_host_suggest_full_and_incr",
-                "mirrors_to_build": [GpMirrorToBuild(self.m3, self.p3, None, True),
-                                     GpMirrorToBuild(self.m4, self.p4, None, False)],
-                "expected": {'sdw3': [RecoveryInfo('/data/mirror3', 7000, 7, 'sdw2', 3000,
-                                                   True, '/tmp/logdir/pg_basebackup.111.dbid7.out'),
-                                      RecoveryInfo('/data/mirror4', 8000, 8, 'sdw3', 4000,
-                                                   False, '/tmp/logdir/pg_rewind.111.dbid8.out')]}
+                "mirrors_to_build": [GpMirrorToBuild(self.m3, self.p3, None, True, False),
+                                     GpMirrorToBuild(self.m4, self.p4, None, False, False)],
+                "expected": {'sdw3': [RecoveryInfo('/data/mirror3', 7000, 7, 'sdw2', 3000, '/data/primary3',
+                                                    True, False, '/tmp/logdir/pg_basebackup.111.dbid7.out'),
+                                      RecoveryInfo('/data/mirror4', 8000, 8, 'sdw3', 4000, '/data/primary4',
+                                                    False, False, '/tmp/logdir/pg_rewind.111.dbid8.out')]}
             },
             {
                 "name": "single_target_hosts_suggest_full_and_incr_with_failover",
-                "mirrors_to_build": [GpMirrorToBuild(self.m1, self.p1, self.m5, True),
-                                     GpMirrorToBuild(self.m2, self.p2, self.m6, False)],
-                "expected": {'sdw4': [RecoveryInfo('/data/mirror5', 9000, 5, 'sdw1', 1000,
-                                                   True, '/tmp/logdir/pg_basebackup.111.dbid5.out'),
-                                      RecoveryInfo('/data/mirror6', 10000, 6, 'sdw2', 2000,
-                                                   True, '/tmp/logdir/pg_basebackup.111.dbid6.out')]}
+                "mirrors_to_build": [GpMirrorToBuild(self.m1, self.p1, self.m5, True, False),
+                                     GpMirrorToBuild(self.m2, self.p2, self.m6, False, False)],
+                "expected": {'sdw4': [RecoveryInfo('/data/mirror5', 9000, 5, 'sdw1', 1000, '/data/primary1',
+                                                    True, False, '/tmp/logdir/pg_basebackup.111.dbid5.out'),
+                                      RecoveryInfo('/data/mirror6', 10000, 6, 'sdw2', 2000, '/data/primary2',
+                                                    True, False, '/tmp/logdir/pg_basebackup.111.dbid6.out')]}
             },
             {
                 "name": "multiple_target_hosts_suggest_full",
-                "mirrors_to_build": [GpMirrorToBuild(self.m1, self.p1, None, True),
-                                     GpMirrorToBuild(self.m2, self.p2, None, True)],
-                "expected": {'sdw2': [RecoveryInfo('/data/mirror1', 5000, 5, 'sdw1', 1000,
-                                                  True, '/tmp/logdir/pg_basebackup.111.dbid5.out')],
-                             'sdw1': [RecoveryInfo('/data/mirror2', 6000, 6, 'sdw2', 2000,
-                                                  True, '/tmp/logdir/pg_basebackup.111.dbid6.out')]}
+                "mirrors_to_build": [GpMirrorToBuild(self.m1, self.p1, None, True, False),
+                                     GpMirrorToBuild(self.m2, self.p2, None, True, False)],
+                "expected": {'sdw2': [RecoveryInfo('/data/mirror1', 5000, 5, 'sdw1', 1000, '/data/primary1',
+                                                    True, False, '/tmp/logdir/pg_basebackup.111.dbid5.out')],
+                             'sdw1': [RecoveryInfo('/data/mirror2', 6000, 6, 'sdw2', 2000, '/data/primary2',
+                                                    True, False, '/tmp/logdir/pg_basebackup.111.dbid6.out')]}
             },
             {
                 "name": "multiple_target_hosts_suggest_full_and_incr",
-                "mirrors_to_build": [GpMirrorToBuild(self.m1, self.p1, None, True),
-                                     GpMirrorToBuild(self.m3, self.p3, None, False),
-                                     GpMirrorToBuild(self.m4, self.p4, None, True)],
-                "expected": {'sdw2': [RecoveryInfo('/data/mirror1', 5000, 5, 'sdw1', 1000,
-                                                   True, '/tmp/logdir/pg_basebackup.111.dbid5.out')],
-                             'sdw3': [RecoveryInfo('/data/mirror3', 7000, 7, 'sdw2', 3000,
-                                                   False, '/tmp/logdir/pg_rewind.111.dbid7.out'),
-                                      RecoveryInfo('/data/mirror4', 8000, 8, 'sdw3', 4000,
-                                                   True, '/tmp/logdir/pg_basebackup.111.dbid8.out')]}
+                "mirrors_to_build": [GpMirrorToBuild(self.m1, self.p1, None, True, False),
+                                     GpMirrorToBuild(self.m3, self.p3, None, False, False),
+                                     GpMirrorToBuild(self.m4, self.p4, None, True, False)],
+                "expected": {'sdw2': [RecoveryInfo('/data/mirror1', 5000, 5, 'sdw1', 1000, '/data/primary1',
+                                                    True, False, '/tmp/logdir/pg_basebackup.111.dbid5.out')],
+                             'sdw3': [RecoveryInfo('/data/mirror3', 7000, 7, 'sdw2', 3000, '/data/primary3',
+                                                    False, False, '/tmp/logdir/pg_rewind.111.dbid7.out'),
+                                      RecoveryInfo('/data/mirror4', 8000, 8, 'sdw3', 4000, '/data/primary4',
+                                                    True, False, '/tmp/logdir/pg_basebackup.111.dbid8.out')]}
             },
             {
                 "name": "multiple_target_hosts_suggest_incr_failover_same_as_failed",
-                "mirrors_to_build": [GpMirrorToBuild(self.m1, self.p1, self.m1, False),
-                                     GpMirrorToBuild(self.m2, self.p2, self.m2, False)],
-                "expected": {'sdw2': [RecoveryInfo('/data/mirror1', 5000, 5, 'sdw1', 1000,
-                                                  True, '/tmp/logdir/pg_basebackup.111.dbid5.out')],
-                             'sdw1': [RecoveryInfo('/data/mirror2', 6000, 6, 'sdw2', 2000,
-                                                  True, '/tmp/logdir/pg_basebackup.111.dbid6.out')]}
+                "mirrors_to_build": [GpMirrorToBuild(self.m1, self.p1, self.m1, False, False),
+                                     GpMirrorToBuild(self.m2, self.p2, self.m2, False, False)],
+                "expected": {'sdw2': [RecoveryInfo('/data/mirror1', 5000, 5, 'sdw1', 1000, '/data/primary1',
+                                                    True, False, '/tmp/logdir/pg_basebackup.111.dbid5.out')],
+                             'sdw1': [RecoveryInfo('/data/mirror2', 6000, 6, 'sdw2', 2000, '/data/primary2',
+                                                    True, False, '/tmp/logdir/pg_basebackup.111.dbid6.out')]}
             },
             {
                 "name": "multiple_target_hosts_suggest_full_failover_same_as_failed",
-                "mirrors_to_build": [GpMirrorToBuild(self.m1, self.p1, self.m1, True),
-                                     GpMirrorToBuild(self.m3, self.p3, self.m3, True),
-                                     GpMirrorToBuild(self.m4, self.p4, None, True)],
-                "expected": {'sdw2': [RecoveryInfo('/data/mirror1', 5000, 5, 'sdw1', 1000,
-                                                  True, '/tmp/logdir/pg_basebackup.111.dbid5.out')],
-                             'sdw3': [RecoveryInfo('/data/mirror3', 7000, 7, 'sdw2', 3000,
-                                                   True, '/tmp/logdir/pg_basebackup.111.dbid7.out'),
-                                      RecoveryInfo('/data/mirror4', 8000, 8, 'sdw3', 4000,
-                                                   True, '/tmp/logdir/pg_basebackup.111.dbid8.out')]}
+                "mirrors_to_build": [GpMirrorToBuild(self.m1, self.p1, self.m1, True, False),
+                                     GpMirrorToBuild(self.m3, self.p3, self.m3, True, False),
+                                     GpMirrorToBuild(self.m4, self.p4, None, True, False)],
+                "expected": {'sdw2': [RecoveryInfo('/data/mirror1', 5000, 5, 'sdw1', 1000, '/data/primary1',
+                                                    True, False, '/tmp/logdir/pg_basebackup.111.dbid5.out')],
+                             'sdw3': [RecoveryInfo('/data/mirror3', 7000, 7, 'sdw2', 3000, '/data/primary3',
+                                                    True, False, '/tmp/logdir/pg_basebackup.111.dbid7.out'),
+                                      RecoveryInfo('/data/mirror4', 8000, 8, 'sdw3', 4000, '/data/primary4',
+                                                    True, False, '/tmp/logdir/pg_basebackup.111.dbid8.out')]}
             },
             {
                 "name": "multiple_target_hosts_suggest_full_and_incr",
-                "mirrors_to_build": [GpMirrorToBuild(self.m1, self.p1, self.m5, True),
-                                     GpMirrorToBuild(self.m2, self.p2, None, False),
-                                     GpMirrorToBuild(self.m3, self.p3, self.m3, False),
-                                     GpMirrorToBuild(self.m4, self.p4, self.m8, True)],
-                "expected": {'sdw4': [RecoveryInfo('/data/mirror5', 9000, 5, 'sdw1', 1000,
-                                                   True, '/tmp/logdir/pg_basebackup.111.dbid5.out'),
+                "mirrors_to_build": [GpMirrorToBuild(self.m1, self.p1, self.m5, True, False),
+                                     GpMirrorToBuild(self.m2, self.p2, None, False, False),
+                                     GpMirrorToBuild(self.m3, self.p3, self.m3, False, False),
+                                     GpMirrorToBuild(self.m4, self.p4, self.m8, True, False)],
+                "expected": {'sdw4': [RecoveryInfo('/data/mirror5', 9000, 5, 'sdw1', 1000, '/data/primary1',
+                                                    True, False, '/tmp/logdir/pg_basebackup.111.dbid5.out'),
                                       ],
-                             'sdw1': [RecoveryInfo('/data/mirror2', 6000, 6,
-                                                   'sdw2', 2000, False,
-                                                   '/tmp/logdir/pg_rewind.111.dbid6.out'),
+                             'sdw1': [RecoveryInfo('/data/mirror2', 6000, 6, 'sdw2', 2000, '/data/primary2',
+                                                    False, False, '/tmp/logdir/pg_rewind.111.dbid6.out'),
                                       RecoveryInfo('/data/mirror8', 12000, 8,
-                                                   'sdw3', 4000, True,
-                                                   '/tmp/logdir/pg_basebackup.111.dbid8.out')],
-                             'sdw3': [RecoveryInfo('/data/mirror3', 7000, 7, 'sdw2', 3000,
-                                                   True, '/tmp/logdir/pg_basebackup.111.dbid7.out')]
+                                                    'sdw3', 4000, '/data/primary4', True, False,
+                                                    '/tmp/logdir/pg_basebackup.111.dbid8.out')],
+                             'sdw3': [RecoveryInfo('/data/mirror3', 7000, 7, 'sdw2', 3000, '/data/primary3',
+                                                     True, False, '/tmp/logdir/pg_basebackup.111.dbid7.out')]
                              }
             },
-
         ]
         self.run_tests(tests)
 

--- a/gpMgmt/sbin/gpsegrecovery.py
+++ b/gpMgmt/sbin/gpsegrecovery.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python3
 
 from gppylib.recoveryinfo import RecoveryErrorType
-from gppylib.commands.pg import PgBaseBackup, PgRewind
+from gppylib.commands.pg import PgBaseBackup, PgRewind, RsyncCopy, PgReplicationSlot
 from recovery_base import RecoveryBase, set_recovery_cmd_results
-from gppylib.commands.base import Command
+from gppylib.commands.base import Command, LOCAL
 from gppylib.commands.gp import SegmentStart
 from gppylib.gparray import Segment
 from gppylib.commands.gp import ModifyConfSetting
+from contextlib import closing
+from gppylib.db import dbconn
 
 
 class FullRecovery(Command):
@@ -35,7 +37,8 @@ class FullRecovery(Command):
                            forceoverwrite=self.forceoverwrite,
                            target_gp_dbid=self.recovery_info.target_segment_dbid,
                            progress_file=self.recovery_info.progress_file)
-        self.logger.info("Running pg_basebackup with progress output temporarily in %s" % self.recovery_info.progress_file)
+        self.logger.info(
+            "Running pg_basebackup with progress output temporarily in %s" % self.recovery_info.progress_file)
         cmd.run(validateAfter=True)
         self.error_type = RecoveryErrorType.DEFAULT_ERROR
         self.logger.info("Successfully ran pg_basebackup for dbid: {}".format(
@@ -76,6 +79,133 @@ class IncrementalRecovery(Command):
         self.error_type = RecoveryErrorType.START_ERROR
         start_segment(self.recovery_info, self.logger, self.era)
 
+class DiffRecovery(Command):
+    def __init__(self, name, recovery_info, logger, era):
+        self.name = name
+        self.recovery_info = recovery_info
+        self.era = era
+        cmdStr = ''
+        Command.__init__(self, self.name, cmdStr)
+        self.logger = logger
+        self.error_type = RecoveryErrorType.DEFAULT_ERROR
+
+    @set_recovery_cmd_results
+    def run(self):
+        self.logger.info("Running rsync with progress output temporarily in %s" % self.recovery_info.progress_file)
+        self.error_type = RecoveryErrorType.SYNC_ERROR
+
+        """ drop replication slot 'internal_wal_replication_slot' """
+        replication_slot = PgReplicationSlot(self.recovery_info.source_hostname, self.recovery_info.source_port,
+                                             'internal_wal_replication_slot')
+        replication_slot.drop_slot()
+
+        """start backup with pg_start_backup()"""
+        self.pgStartBackup()
+
+        """ create replication slot pg_create_physical_replication_slot('internal_wal_replication_slot', true, false)"""
+        replication_slot.create_slot()
+
+        """ rsync data and tablespace directories including all the WAL files """
+        cmd = RsyncCopy('syncing dbid: {}'.format(self.recovery_info.target_segment_dbid),
+                        self.recovery_info.target_datadir, self.recovery_info.source_hostname,
+                        self.recovery_info.source_datadir, self.recovery_info.progress_file)
+        cmd.run(validateAfter=True)
+
+        """ rsync tablespace directories which are out of data-directory """
+        self.syncTableSpaces()
+
+        """ stop backup with pg_stop_backup() """
+        self.pgStopBackup()
+
+        """ Write the postresql.auto.conf and internal.auto.conf files """
+        self.writeConfFiles()
+
+        """ sync pg_wal directory and pg_control file just before starting the segment """
+        self.syncWalsandControlFile()
+
+        self.logger.info(
+            "Successfully ran diff recovery for dbid: {}".format(self.recovery_info.target_segment_dbid))
+
+        """ Updating port number on conf after recovery """
+        self.error_type = RecoveryErrorType.UPDATE_ERROR
+        update_port_in_conf(self.recovery_info, self.logger)
+
+        self.error_type = RecoveryErrorType.START_ERROR
+        start_segment(self.recovery_info, self.logger, self.era)
+
+    def pgStartBackup(self):
+        sql = "SELECT pg_start_backup('diff_backup');"
+        try:
+            dburl = dbconn.DbURL(hostname=self.recovery_info.source_hostname, port=self.recovery_info.source_port)
+            with closing(dbconn.connect(dburl, utility=True, encoding='UTF8')) as conn:
+                dbconn.query(conn, sql)
+        except Exception as ex:
+            raise Exception("Failed to start backup for host:{}, port:{} : {}".
+                            format(self.recovery_info.source_hostname, self.recovery_info.source_port, str(ex)))
+
+        self.logger.debug("Successfully started backup for host:{}, port:{}".
+                          format(self.recovery_info.source_hostname, self.recovery_info.source_port))
+
+    def pgStopBackup(self):
+        sql = "SELECT pg_stop_backup();"
+        try:
+            dburl = dbconn.DbURL(hostname=self.recovery_info.source_hostname, port=self.recovery_info.source_port)
+            with closing(dbconn.connect(dburl, utility=True, encoding='UTF8')) as conn:
+                dbconn.query(conn, sql)
+        except Exception as ex:
+            raise Exception("Failed to stop backup for host:{}, port:{} : {}".
+                            format(self.recovery_info.source_hostname, self.recovery_info.source_port, str(ex)))
+
+        self.logger.debug("Successfully stopped backup for host:{}, port:{}".
+                          format(self.recovery_info.source_hostname, self.recovery_info.source_port))
+
+    def writeConfFiles(self):
+        self.logger.debug("Writing recovery.conf and internal.auto.conf files")
+        cmd = PgBaseBackup(self.recovery_info.target_datadir,
+                           self.recovery_info.source_hostname,
+                           str(self.recovery_info.source_port),
+                           justWriteConfFiles=True,
+                           target_gp_dbid=self.recovery_info.target_segment_dbid,
+                           progress_file=self.recovery_info.progress_file)
+        self.logger.info("Running pg_basebackup to just write configuration files")
+        cmd.run(validateAfter=True)
+
+    def syncWalsandControlFile(self):
+        self.logger.debug("Syncing wals and pg_control")
+        cmdStr = 'rsync -aLKs -e "ssh -o BatchMode=yes -o StrictHostKeyChecking=no" %s:%s/pg_wal/ %s/pg_wal/' % (
+            self.recovery_info.source_hostname, self.recovery_info.source_datadir, self.recovery_info.target_datadir)
+        cmd = Command("sync wals", cmdStr, LOCAL)
+        cmd.run(validateAfter=True)
+
+        cmdStr = 'rsync -aLKs -e "ssh -o BatchMode=yes -o StrictHostKeyChecking=no" %s:%s/global/pg_control %s/global/pg_control' % (
+            self.recovery_info.source_hostname, self.recovery_info.source_datadir, self.recovery_info.target_datadir)
+        cmd = Command("sync pg_control", cmdStr, LOCAL)
+        cmd.run(validateAfter=True)
+
+    def getSegmentTablespaceLocations(self):
+        sql = "SELECT tblspc_loc FROM ( SELECT oid FROM pg_tablespace WHERE spcname NOT IN ('pg_default', 'pg_global')) AS q,LATERAL gp_tablespace_location(q.oid);"
+        try:
+            dburl = dbconn.DbURL(hostname=self.recovery_info.source_hostname, port=self.recovery_info.source_port)
+            with closing(dbconn.connect(dburl, utility=True, encoding='UTF8')) as conn:
+                res = dbconn.query(conn, sql).fetchall()
+        except Exception as ex:
+            raise Exception("Failed to query pg_tablsepace for segment with host:{}, port:{}: {}".format(self.recovery_info.source_hostname, self.recovery_info.source_port, str(ex)))
+
+        self.logger.debug("Successfully got tablespace locations for segment with host:{}, port:{}".
+                          format(self.recovery_info.source_hostname, self.recovery_info.source_port))
+        return res
+
+    def syncTableSpaces(self):
+        self.logger.debug("Syncing tablespaces which are outside of source data_dir")
+
+        # get the tablespaces locations
+        tablespaces = self.getSegmentTablespaceLocations()
+
+        for tablespace_location in tablespaces:
+            if not tablespace_location[0].startswith(self.recovery_info.target_datadir):
+                cmdStr = 'rsync -aLKs -e "ssh -o BatchMode=yes -o StrictHostKeyChecking=no" %s:%s %s' % (self.recovery_info.source_hostname, tablespace_location[0], tablespace_location[0])
+                cmd = Command("sync tablespace", cmdStr, LOCAL)
+                cmd.run(validateAfter=True)
 
 def start_segment(recovery_info, logger, era):
     seg = Segment(None, None, None, None, None, None, None, None,
@@ -118,11 +248,17 @@ class SegRecovery(object):
                                    forceoverwrite=forceoverwrite,
                                    logger=logger,
                                    era=era)
+            elif seg_recovery_info.is_diff_recovery:
+                cmd = DiffRecovery(name='Run rsync',
+                                          recovery_info=seg_recovery_info,
+                                          logger=logger,
+                                          era=era)
             else:
                 cmd = IncrementalRecovery(name='Run pg_rewind',
                                           recovery_info=seg_recovery_info,
                                           logger=logger,
                                           era=era)
+
             cmd_list.append(cmd)
         return cmd_list
 


### PR DESCRIPTION
Context: Full recovery is required to recover a failed segment in-case incremental recovery fails due to bug or is interrupted for some reason like n/w failure and such. Full recovery(pg_basebackup) takes backup of the whole primary data directory to mirror data directory even if a large part of the data set is not changed: for example, old partitions stored in a dedicated tablespace and so it can take ages for large dataset.

Solution:
If incremental recovery fails then instead of doing full reovery which copies the whole primary data directory, copy only the delta part of primary data and mirror data. Skip the tables/files that are identical in primary and mirror: for example, by checking checksum of the files. It would mean to perform a checksum in the file level, not in the database object level. So the whole process can be done in the file-system level and does not require access to the database.

Hence introducing a new recovery method "differential recovery" based on rsync which will only take backup of difference(delta) of primary and mirror data directory to mirror data directory, making recovery process faster than full recovery.

Co-authored-by: Rakesh Sharma <shrakesh@vmware.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
