### PR TITLE
Add .gitignore entries for distributed_snapshot test

### DIFF
--- a/src/test/isolation2/expected/.gitignore
+++ b/src/test/isolation2/expected/.gitignore
@@ -5,6 +5,7 @@
 /pg_basebackup.out
 /pg_basebackup_with_tablespaces.out
 /pt_io_in_progress_deadlock.out
+/distributed_snapshot.out
 
 # ignores including sub-directories
 autovacuum-analyze.out

--- a/src/test/isolation2/sql/.gitignore
+++ b/src/test/isolation2/sql/.gitignore
@@ -5,6 +5,7 @@
 /pg_basebackup.sql
 /pg_basebackup_with_tablespaces.sql
 /pt_io_in_progress_deadlock.sql
+/distributed_snapshot.sql
 
 # ignores including sub-directories
 autovacuum-analyze.sql


### PR DESCRIPTION
https://github.com/greenplum-db/gpdb/pull/14650 moved the distributed_snapshot test to input/output folder but missed adding the .gitignore entries so the generated .sql and .out files would appear in untracked files. Adding now.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
