### PR TITLE
[6X] Add .gitignore entries for distributed_snapshot test

### DIFF
--- a/src/test/isolation2/expected/.gitignore
+++ b/src/test/isolation2/expected/.gitignore
@@ -10,3 +10,4 @@ resgroup_bypass.out
 resgroup_bypass_optimizer.out
 resgroup_cpuset.out
 gp_collation.out
+distributed_snapshot.out

--- a/src/test/isolation2/sql/.gitignore
+++ b/src/test/isolation2/sql/.gitignore
@@ -9,3 +9,4 @@ pt_io_in_progress_deadlock.sql
 resgroup_bypass.sql
 resgroup_cpuset.sql
 gp_collation.sql
+distributed_snapshot.sql


### PR DESCRIPTION
https://github.com/greenplum-db/gpdb/pull/14707 moved the distributed_snapshot test to input/output folder but missed adding the .gitignore entries so the generated .sql and .out files would appear in untracked files. Adding now.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
