### PR TITLE
GPDB_12_MERGE_FIXME

### DIFF
--- a/src/backend/gpopt/gpdbwrappers.cpp
+++ b/src/backend/gpopt/gpdbwrappers.cpp
@@ -22,6 +22,8 @@
 
 #include "gpopt/gpdbwrappers.h"
 
+#include <limits>  // std::numeric_limits
+
 #include "gpos/base.h"
 #include "gpos/error/CAutoExceptionStack.h"
 #include "gpos/error/CException.h"
@@ -2101,7 +2103,8 @@ gpdb::HasUpdateTriggers(Oid relid)
 
 // get index op family properties
 void
-gpdb::IndexOpProperties(Oid opno, Oid opfamily, int *strategy, Oid *righttype)
+gpdb::IndexOpProperties(Oid opno, Oid opfamily, StrategyNumber *strategynumber,
+						Oid *righttype)
 {
 	GP_WRAP_START;
 	{
@@ -2110,9 +2113,15 @@ gpdb::IndexOpProperties(Oid opno, Oid opfamily, int *strategy, Oid *righttype)
 		// Only the right type is returned to the caller, the left
 		// type is simply ignored.
 		Oid lefttype;
+		INT strategy;
 
-		get_op_opfamily_properties(opno, opfamily, false, strategy, &lefttype,
+		get_op_opfamily_properties(opno, opfamily, false, &strategy, &lefttype,
 								   righttype);
+
+		// Ensure the value of strategy doesn't get truncated when converted to StrategyNumber
+		GPOS_ASSERT(strategy >= 0 &&
+					strategy <= std::numeric_limits<StrategyNumber>::max());
+		*strategynumber = static_cast<StrategyNumber>(strategy);
 		return;
 	}
 	GP_WRAP_END;

--- a/src/backend/gpopt/translate/CContextDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CContextDXLToPlStmt.cpp
@@ -518,26 +518,6 @@ CContextDXLToPlStmt::GetDistributionHashFuncForType(Oid typid)
 	return hashproc;
 }
 
-List *
-CContextDXLToPlStmt::GetStaticPruneResult(ULONG scanId)
-{
-	// GPDB_12_MERGE_FIXME: we haven't seen the scan id yet, this scan id is likely for dynamic pruning.
-	// When we can, remove this check
-	if ((scanId - 1) >= m_static_prune_results.size())
-	{
-		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiDXL2PlStmtConversion,
-				   GPOS_WSZ_LIT("dynamic pruning"));
-	}
-	return m_static_prune_results[scanId - 1];
-}
-void
-CContextDXLToPlStmt::SetStaticPruneResult(ULONG scanId,
-										  List *static_prune_result)
-{
-	m_static_prune_results.resize(scanId);
-	m_static_prune_results[scanId - 1] = static_prune_result;
-}
-
 ULONG
 CContextDXLToPlStmt::GetParamIdForSelector(OID oid_type, ULONG selectorId)
 {

--- a/src/backend/gpopt/translate/CPartPruneStepsBuilder.cpp
+++ b/src/backend/gpopt/translate/CPartPruneStepsBuilder.cpp
@@ -116,13 +116,12 @@ CPartPruneStepsBuilder::PartPruneStepFromScalarCmp(CDXLNode *node, int *step_id,
 	Oid opno = CMDIdGPDB::CastMdid(dxlop->MDId())->Oid();
 	Oid opfamily = m_relation->rd_partkey->partopfamily[0 /* col */];
 
-	// GPDB_12_MERGE_FIXME: This *should* be StrategyNumber, but IndexOpProperties takes an INT
-	INT strategy;
+	StrategyNumber strategy_num;
 	Oid righttype = InvalidOid;
 
 	// extract the strategy (<, >, = etc) of the operator in the scalar cmp
 	// and confirm that it's usable given the partition column's opfamily
-	gpdb::IndexOpProperties(opno, opfamily, &strategy, &righttype);
+	gpdb::IndexOpProperties(opno, opfamily, &strategy_num, &righttype);
 
 	if (InvalidOid == righttype)
 	{
@@ -138,7 +137,7 @@ CPartPruneStepsBuilder::PartPruneStepFromScalarCmp(CDXLNode *node, int *step_id,
 
 	PartitionPruneStepOp *step = MakeNode(PartitionPruneStepOp);
 	step->step.step_id = (*step_id)++;
-	step->opstrategy = strategy;
+	step->opstrategy = strategy_num;
 
 	// Use cmpfns from the partitioned table, since the op was confirmed
 	// to be part of partitioning column opfamily above.

--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -1158,7 +1158,7 @@ CTranslatorDXLToPlStmt::TranslateIndexConditions(
 		}
 
 		// retrieve index strategy and subtype
-		INT strategy_num = 0;
+		StrategyNumber strategy_num;
 		OID index_subtype_oid = InvalidOid;
 
 		OID cmp_operator_oid =
@@ -1172,8 +1172,8 @@ CTranslatorDXLToPlStmt::TranslateIndexConditions(
 
 		// create index qual
 		index_qual_info_array->Append(GPOS_NEW(m_mp) CIndexQualInfo(
-			attno, index_cond_expr, original_index_cond_expr,
-			(StrategyNumber) strategy_num, index_subtype_oid));
+			attno, index_cond_expr, original_index_cond_expr, strategy_num,
+			index_subtype_oid));
 	}
 
 	// the index quals much be ordered by attribute number

--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -3324,7 +3324,6 @@ ContainsSetReturningFuncOrOp(const CDXLNode *project_list_dxlnode,
 	return false;
 }
 
-// GPDB_12_MERGE_FIXME: this duplicates a check in ExecInitProjectSet
 static bool
 SanityCheckProjectSetTargetList(List *targetlist)
 {

--- a/src/include/gpopt/gpdbwrappers.h
+++ b/src/include/gpopt/gpdbwrappers.h
@@ -594,7 +594,8 @@ void CheckRTPermissions(List *rtable);
 bool HasUpdateTriggers(Oid relid);
 
 // get index operator family properties
-void IndexOpProperties(Oid opno, Oid opfamily, int *strategy, Oid *righttype);
+void IndexOpProperties(Oid opno, Oid opfamily, StrategyNumber *strategynumber,
+					   Oid *righttype);
 
 // get oids of families this operator belongs to
 List *GetOpFamiliesForScOp(Oid opno);

--- a/src/include/gpopt/translate/CContextDXLToPlStmt.h
+++ b/src/include/gpopt/translate/CContextDXLToPlStmt.h
@@ -132,9 +132,6 @@ private:
 	// CTAS distribution policy
 	GpPolicy *m_distribution_policy;
 
-	// FXIME: this uses NEW/DELETE, should we use palloc/pfree/memory pool?
-	std::vector<List *> m_static_prune_results;
-
 	UlongToUlongMap *m_part_selector_to_param_map;
 
 
@@ -251,9 +248,6 @@ public:
 	// based on decision made by DetermineDistributionHashOpclasses()
 	Oid GetDistributionHashOpclassForType(Oid typid);
 	Oid GetDistributionHashFuncForType(Oid typid);
-
-	List *GetStaticPruneResult(ULONG scanId);
-	void SetStaticPruneResult(ULONG scanId, List *static_prune_result);
 
 	ULONG GetParamIdForSelector(OID oid_type, const ULONG selectorId);
 


### PR DESCRIPTION
**Fixme:**
src/backend/gpopt/translate/CContextDXLToPlStmt.cpp: // GPDB_12_MERGE_FIXME: we haven't seen the scan id yet, this scan id is likely // for dynamic pruning.
**Action:**
Check removed

**Fixme:**
src/backend/gpopt/translate/CPartPruneStepsBuilder.cpp: // GPDB_12_MERGE_FIXME: This should be StrategyNumber, but IndexOpProperties // takes an INT
**Action:**
Explicit conversion from INT to StrategyNumber before value assigned to `PartitionPruneStepOp->opstrategy`

**Fixme:**
src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp: // GPDB_12_MERGE_FIXME: this duplicates a check in ExecInitProjectSet
**Action:**
None. Function `SanityCheckProjectSetTargetList` share some code with `ExecInitProjectSet`. But refactoring isn't trivial and will involve changes to upstream .c files

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
