### PR TITLE
Assert AO/CO exclusion for anti-wraparound vacuums

### DIFF
--- a/src/backend/postmaster/autovacuum.c
+++ b/src/backend/postmaster/autovacuum.c
@@ -3144,6 +3144,15 @@ relation_needs_vacanalyze(Oid relid,
 	xidForceLimit = recentXid - freeze_max_age;
 	if (xidForceLimit < FirstNormalTransactionId)
 		xidForceLimit -= FirstNormalTransactionId;
+	/*
+	 * GPDB: Append-optimized tables don't have any transaction IDs and don't
+	 * need to be considered for anti-wraparound vacuums. They are implicitly
+	 * excluded from anti-wraparound vacuums below since their relfrozenxid is
+	 * always InvalidTransactionId.
+	 */
+	AssertImply(IsAccessMethodAO(classForm->relam),
+				!TransactionIdIsValid(classForm->relfrozenxid));
+
 	force_vacuum = (TransactionIdIsNormal(classForm->relfrozenxid) &&
 					TransactionIdPrecedes(classForm->relfrozenxid,
 										  xidForceLimit));


### PR DESCRIPTION
Anti-wraparound autovacuums are meant primarily to update transaction
metadata and currently they are executed on user tables as well.
Executing them on AO tables is pointless from this perspective as they
don't carry any transaction metadata, and will lead to unintended cycles
spent on vacuuming their contents. Their aux tables carry it and will be
anti-wraparound autovacuumed anyway.

This is already enforced in the code, add an assert for the same.

Co-authored-by: Ashwin Agrawal <aashwin@vmware.com>

Dev-pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/awav_ao