### PR TITLE
Update mdw to cdw in gpcheckperf hostfile test

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -3854,7 +3854,7 @@ def impl(context, contentid):
 
 @given('create a gpcheckperf input host file')
 def impl(context):
-    cmd = Command(name='create input host file', cmdStr='echo sdw1 > /tmp/hostfile1;echo mdw >> /tmp/hostfile1;')
+    cmd = Command(name='create input host file', cmdStr='echo sdw1 > /tmp/hostfile1;echo cdw >> /tmp/hostfile1;')
     cmd.run(validateAfter=True)
 
 @given('backup /etc/hosts file and update hostname entry for localhost')


### PR DESCRIPTION
- We recently changed the mdw hostname to cdw for inclusive terminology. This spot was missed.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
