### PR TITLE
Fix index DDL operations are recorded in QEs' pg_last_stat_operation

### DIFF
--- a/src/backend/catalog/index.c
+++ b/src/backend/catalog/index.c
@@ -1006,6 +1006,7 @@ index_create(Relation heapRelation,
 	/* done with pg_class */
 	table_close(pg_class, RowExclusiveLock);
 
+	if (Gp_role == GP_ROLE_DISPATCH)
 	{							/* MPP-7575: track index creation */
 		bool	 doIt	= true;
 		char	*subtyp = "INDEX";
@@ -2425,8 +2426,9 @@ index_drop(Oid indexId, bool concurrent, bool concurrent_lock_mode)
 	DeleteInheritsTuple(indexId, InvalidOid);
 	
 	/* MPP-6929: metadata tracking */
-	MetaTrackDropObject(RelationRelationId, 
-						indexId);
+	if (Gp_role == GP_ROLE_DISPATCH)
+		MetaTrackDropObject(RelationRelationId,
+							indexId);
 
 	/*
 	 * We are presently too lazy to attempt to compute the new correct value
@@ -3831,6 +3833,7 @@ reindex_index(Oid indexId, bool skip_constraint_checks, char persistence,
 		table_close(pg_index, RowExclusiveLock);
 	}
 
+	if (Gp_role == GP_ROLE_DISPATCH)
 	{
 		bool	 doIt	= true;
 		char	*subtyp = "REINDEX";

--- a/src/test/regress/expected/pg_stat_last_operation.out
+++ b/src/test/regress/expected/pg_stat_last_operation.out
@@ -97,8 +97,8 @@ SELECT * FROM pg_stat_last_operation_testview WHERE actionname = 'CREATE';
  pg_stat_last_operation_test               | CREATE     | TABLE
  mdt_test_part1                            | CREATE     | TABLE
  mdt_test_part1_1_prt_1                    | CREATE     | TABLE
- mdt_test_part1_1_prt_1_2_prt_1            | CREATE     | TABLE
  mdt_test_part1_1_prt_2                    | CREATE     | TABLE
+ mdt_test_part1_1_prt_1_2_prt_1            | CREATE     | TABLE
  mdt_test_part1_1_prt_2_2_prt_1            | CREATE     | TABLE
  mdt_test_part1_1_prt_default_part         | CREATE     | TABLE
  mdt_test_part1_1_prt_default_part_2_prt_1 | CREATE     | TABLE
@@ -169,6 +169,22 @@ SELECT * FROM pg_stat_last_operation_testview WHERE actionname = 'TRUNCATE';
  pg_stat_last_operation_test | TRUNCATE   | 
 (1 row)
 
+-- CREATE INDEX
+CREATE INDEX idx_mt ON mdt_all_types (a);
+REINDEX INDEX idx_mt;
+SELECT * FROM pg_stat_last_operation_testview WHERE objname = 'idx_mt';
+ objname | actionname | subtype 
+---------+------------+---------
+ idx_mt  | CREATE     | INDEX
+ idx_mt  | VACUUM     | REINDEX
+(2 rows)
+
+-- QEs shouldn't do meta tracking stuff
+SELECT gp_execution_dbid(), * FROM gp_dist_random('pg_stat_last_operation_testview') WHERE objname = 'idx_mt';
+ gp_execution_dbid | objname | actionname | subtype 
+-------------------+---------+------------+---------
+(0 rows)
+
 -- DROP TABLE
 SELECT * FROM pg_stat_last_operation_testview WHERE actionname = 'DROP';
  objname | actionname | subtype 
@@ -179,7 +195,6 @@ SELECT * FROM pg_stat_last_operation_testview WHERE objname like ('mdt_%');
                   objname                  | actionname | subtype  
 -------------------------------------------+------------+----------
  mdt_test_part1                            | CREATE     | TABLE
- mdt_test_part1                            | PARTITION  | DROP
  mdt_test_part1_1_prt_1                    | CREATE     | TABLE
  mdt_test_part1_1_prt_1                    | PARTITION  | ATTACH
  mdt_test_part1_1_prt_2                    | CREATE     | TABLE
@@ -201,6 +216,7 @@ SELECT * FROM pg_stat_last_operation_testview WHERE objname like ('mdt_%');
  mdt_test_newpart                          | PARTITION  | ATTACH
  mdt_test_detach                           | CREATE     | TABLE
  mdt_test_detach                           | PARTITION  | DETACH
+ mdt_test_part1                            | PARTITION  | DROP
  mdt_all_types                             | PRIVILEGE  | GRANT
  mdt_all_types                             | VACUUM     | 
  mdt_all_types                             | ANALYZE    | 
@@ -211,7 +227,6 @@ SELECT * FROM pg_stat_last_operation_testview WHERE objname like ('mdt_%');
                   objname                  | actionname | subtype 
 -------------------------------------------+------------+---------
  mdt_test_part1                            | CREATE     | TABLE
- mdt_test_part1                            | PARTITION  | DROP
  mdt_test_part1_1_prt_1                    | CREATE     | TABLE
  mdt_test_part1_1_prt_1                    | PARTITION  | ATTACH
  mdt_test_part1_1_prt_2                    | CREATE     | TABLE
@@ -228,6 +243,7 @@ SELECT * FROM pg_stat_last_operation_testview WHERE objname like ('mdt_%');
  mdt_test_newpart                          | PARTITION  | ATTACH
  mdt_test_detach                           | CREATE     | TABLE
  mdt_test_detach                           | PARTITION  | DETACH
+ mdt_test_part1                            | PARTITION  | DROP
 (18 rows)
 
 DROP TABLE mdt_test_part1;

--- a/src/test/regress/sql/pg_stat_last_operation.sql
+++ b/src/test/regress/sql/pg_stat_last_operation.sql
@@ -124,6 +124,13 @@ INSERT INTO pg_stat_last_operation_test SELECT generate_series(1, 5);
 TRUNCATE pg_stat_last_operation_test;
 SELECT * FROM pg_stat_last_operation_testview WHERE actionname = 'TRUNCATE';
 
+-- CREATE INDEX
+CREATE INDEX idx_mt ON mdt_all_types (a);
+REINDEX INDEX idx_mt;
+SELECT * FROM pg_stat_last_operation_testview WHERE objname = 'idx_mt';
+-- QEs shouldn't do meta tracking stuff
+SELECT gp_execution_dbid(), * FROM gp_dist_random('pg_stat_last_operation_testview') WHERE objname = 'idx_mt';
+
 -- DROP TABLE
 SELECT * FROM pg_stat_last_operation_testview WHERE actionname = 'DROP';
 SELECT * FROM pg_stat_last_operation_testview WHERE objname like ('mdt_%');


### PR DESCRIPTION
Note that, most system catalog tables should be consistent between coordinator and segments. However, for now, meta tracking stuffs are done by coordinator only, so the changes to `pg_last_stat_operation` should only be made by coordinator. But for index DDL, changes are also made on QEs. This commit fix that.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
