### PR TITLE
[6X_Backport] gpcheckperf: Fix memory calculation function

### DIFF
--- a/gpMgmt/bin/gpcheckperf
+++ b/gpMgmt/bin/gpcheckperf
@@ -131,26 +131,27 @@ def getPlatform():
 
 
 def getMemory():
-    if getPlatform() == 'linux':
-        ok, out = run("sh -c 'cat /proc/meminfo | grep MemTotal'")
-        if not ok:
-            return 0
+    platform = getPlatform()
+
+    if platform == 'linux':
+        rc, out = run("sh -c 'cat /proc/meminfo | grep MemTotal'")
+        if rc != 0:
+            return None
         word_list = out.strip().split(' ')
         val = int(word_list[len(word_list) - 2])
         factor = word_list[len(word_list) - 1]
         if factor == 'kB':
-            return val * 1024
-        return 0
+            return val * 1024 if val else None
 
-    if getPlatform() == 'darwin':
-        ok, out = run("/usr/sbin/sysctl hw.physmem")
-        if not ok:
-            return 0
+    if platform == 'darwin':
+        rc, out = run("/usr/sbin/sysctl hw.physmem")
+        if rc != 0:
+            return None
         word_list = out.strip().split(' ')
         val = int(word_list[1])
-        return val
+        return val if val else None
 
-    return 0
+    return None
 
 
 def parseMemorySize(line):
@@ -259,7 +260,12 @@ def parseCommandLine():
         usage('Error: maximum size for -B parameter is 1MB')
 
     if GV.opt['-S'] == 0:
-        GV.opt['-S'] = 2 * getMemory() / len(GV.opt['-d'])
+        system_mem_size = getMemory()
+        if system_mem_size is not None:
+            GV.opt['-S'] = 2 * system_mem_size / len(GV.opt['-d'])
+        else:
+            sys.exit('[Error] could not get system memory size. Instead, you can use the -S option to provide the file size value')
+
     else:
         GV.opt['-S'] /= len(GV.opt['-d'])
 
@@ -922,50 +928,55 @@ def printResult(title, result):
     print
 
 
-try:
-    parseCommandLine()
-    runSetup()
-    diskWriteResult = diskReadResult = streamResult = netResult = None
-    tornDown = False
+def main():
     try:
-        if GV.opt['-r'].find('d') >= 0:
-            multidd = copyExecOver('multidd')
-            diskWriteResult = runDiskWriteTest(multidd)
-            diskReadResult = runDiskReadTest(multidd)
+        parseCommandLine()
+        runSetup()
+        diskWriteResult = diskReadResult = streamResult = netResult = None
+        tornDown = False
+        try:
+            if GV.opt['-r'].find('d') >= 0:
+                print('[Warning] Using %d bytes for disk performance test. This might take some time' % (GV.opt['-S'] * len(GV.opt['-d'])))
+                multidd = copyExecOver('multidd')
+                diskWriteResult = runDiskWriteTest(multidd)
+                diskReadResult = runDiskReadTest(multidd)
 
-        if GV.opt['-r'].find('s') >= 0:
-            streamResult = runStreamTest()
+            if GV.opt['-r'].find('s') >= 0:
+                streamResult = runStreamTest()
 
-        if GV.opt['--net'] == 'netperf':
-            netResult = runNetPerfTest()
-        elif GV.opt['--net'] == 'parallel':
-            netResult = runNetPerfTestParallel()
-        elif GV.opt['--net'] == 'matrix':
-            netResult, seglist = runNetPerfTestMatrix()
+            if GV.opt['--net'] == 'netperf':
+                netResult = runNetPerfTest()
+            elif GV.opt['--net'] == 'parallel':
+                netResult = runNetPerfTestParallel()
+            elif GV.opt['--net'] == 'matrix':
+                netResult, seglist = runNetPerfTestMatrix()
 
-        runTeardown()
+            runTeardown()
 
-    finally:
-        print
-        print '===================='
-        print '==  RESULT %s' % datetime.datetime.now().isoformat()
-        print '===================='
+        finally:
+            print
+            print '===================='
+            print '==  RESULT %s' % datetime.datetime.now().isoformat()
+            print '===================='
 
-        if diskWriteResult:
-            printResult('disk write', diskWriteResult)
+            if diskWriteResult:
+                printResult('disk write', diskWriteResult)
 
-        if diskReadResult:
-            printResult('disk read', diskReadResult)
+            if diskReadResult:
+                printResult('disk read', diskReadResult)
 
-        if streamResult:
-            printResult('stream', streamResult)
+            if streamResult:
+                printResult('stream', streamResult)
 
-        if netResult and GV.opt['--net'] == 'matrix':
-            printMatrixResult(netResult, seglist)
-        elif netResult and GV.opt['--net']:
-            printNetResult(netResult)
+            if netResult and GV.opt['--net'] == 'matrix':
+                printMatrixResult(netResult, seglist)
+            elif netResult and GV.opt['--net']:
+                printNetResult(netResult)
 
-        runTeardown()
+            runTeardown()
 
-except KeyboardInterrupt:
-    print '[Abort] Keyboard Interrupt ...'
+    except KeyboardInterrupt:
+        print '[Abort] Keyboard Interrupt ...'
+
+if __name__ == '__main__':
+    main()

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpcheckperf.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpcheckperf.py
@@ -1,0 +1,66 @@
+import imp
+import os
+import sys
+from mock import patch
+from gppylib.test.unit.gp_unittest import GpTestCase,run_tests
+
+class GpCheckPerf(GpTestCase):
+    def setUp(self):
+        gpcheckcat_file = os.path.abspath(os.path.dirname(__file__) + "/../../../gpcheckperf")
+        self.subject = imp.load_source('gpcheckperf', gpcheckcat_file)
+
+    def tearDown(self):
+        super(GpCheckPerf, self).tearDown()
+
+    @patch('gpcheckperf.getPlatform', return_value='darwin')
+    @patch('gpcheckperf.run')
+    def test_get_memory_on_darwin(self, mock_run, mock_get_platform):
+        mock_run.return_value = [1, 'hw.physmem: 1234']
+        actual_result = self.subject.getMemory()
+        self.assertEquals(actual_result, None)
+
+        mock_run.return_value = [0, 'hw.physmem: 0']
+        actual_result = self.subject.getMemory()
+        self.assertEquals(actual_result, None)
+
+        mock_run.return_value = [0, 'hw.physmem: 1234']
+        actual_result = self.subject.getMemory()
+        self.assertEquals(actual_result, 1234)
+
+    @patch('gpcheckperf.getPlatform', return_value='linux')
+    @patch('gpcheckperf.run')
+    def test_get_memory_on_linux(self, mock_run, mock_get_platform):
+        mock_run.return_value = [1, 'MemTotal:        10 kB']
+        actual_result = self.subject.getMemory()
+        self.assertEquals(actual_result, None)
+
+        mock_run.return_value = [0, 'MemTotal:        0 kB']
+        actual_result = self.subject.getMemory()
+        self.assertEquals(actual_result, None)
+
+        mock_run.return_value = [0, 'MemTotal:        10 kB']
+        actual_result = self.subject.getMemory()
+        self.assertEquals(actual_result, 10240)
+
+    @patch('gpcheckperf.getPlatform', return_value='abc')
+    def test_get_memory_on_invalid_platform(self, mock_get_platform):
+        actual_result = self.subject.getMemory()
+        self.assertEquals(actual_result, None)
+
+    @patch('gpcheckperf.getMemory', return_value=None)
+    def test_parseCommandLine_when_get_memory_fails(self, mock_get_memory):
+        sys.argv = ["gpcheckperf", "-h", "locahost", "-r", "d", "-d", "/tmp"]
+        with self.assertRaises(SystemExit) as e:
+            self.subject.parseCommandLine()
+
+        self.assertEqual(e.exception.code, '[Error] could not get system memory size. Instead, you can use the -S option to provide the file size value')
+
+    @patch('gpcheckperf.getMemory', return_value=123)
+    def test_parseCommandLine_when_get_memory_succeeds(self, mock_get_memory):
+        sys.argv = ["gpcheckperf", "-h", "locahost", "-r", "d", "-d", "/tmp"]
+        self.subject.parseCommandLine()
+        self.assertEqual(self.subject.GV.opt['-S'], 246.0)
+
+
+if __name__ == '__main__':
+    run_tests()

--- a/gpMgmt/test/behave/mgmt_utils/gpcheckperf.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpcheckperf.feature
@@ -15,3 +15,14 @@ Feature: Tests for gpcheckperf
     Then  gpcheckperf should return a return code of 0
     And   gpcheckperf should print "avg = " to stdout
     And   gpcheckperf should not print "NOTICE: -t is deprecated " to stdout
+
+  Scenario: gpcheckperf runs with -S option and prints a warning message
+    Given the database is running
+    When  the user runs "gpcheckperf -h localhost -r d -d /tmp -S 1GB"
+    Then  gpcheckperf should return a return code of 0
+    And   gpcheckperf should print "\[Warning] Using 1073741824 bytes for disk performance test. This might take some time" to stdout
+
+  Scenario: gpcheckperf errors out when invalid value is passed to the -S option
+    Given the database is running
+    When  the user runs "gpcheckperf -h localhost -r d -d /tmp -S abc"
+    Then  gpcheckperf should return a return code of 1


### PR DESCRIPTION
This is a backport from 7X PR https://github.com/greenplum-db/gpdb/pull/14865

Currently, there is a bug in the `getMemory()` function in `gpcheckperf` because of the way we check the return code of the `run()` method which is called inside `getMemory()`. The `run()` method returns an integer value of `zero` in case of success and a `non-zero` value if it fails.

We are checking this value using the condition `if not ok` which is incorrect because when the `run()` method succeeds (`ok = 0`), the condition would result as `False` causing the `getMemory()` function to assume that the `run()` method failed but in reality, it did not.

A simple fix would be to change the condition from `if not ok` to `if ok != 0` to check for any possible failure from the `run()` method.

Further, the way `getMemory()` handles errors is also incorrect. It just returns `0` whenever there is an error which can lead to the incorrect file size being used to perform disk performance tests. This is because the gpcheckperf utility internally calls `multidd` command to perform disk performance tests which also accepts a file size parameter with the -S option which when not set (or is equal to 0), uses its own default value of `2 * memory_size`, but instead of dividing it from the number of input directories, it uses this value for each directory i.e. the total file size value would be `2 * memory_size * no_of_input_directories`. Due to this, sometimes the user can meet File System Full error when the number of input directories is big.

Hence we need to properly handle the error in the `getMemory()` function and exit from the code instead of just returning `0`

Before:
```
$ gpcheckperf -d /tmp/test1 -d /tmp/test2 -d /tmp/test3 -h localhost -rd
 disk write avg time (sec): 5.46
 disk write tot bytes: 12884901888     --> is equal to 2 * memory_size * no_of_input_directories
 disk write tot bandwidth (MB/s): 2250.55
 disk write min bandwidth (MB/s): 2250.55 [localhost]
 disk write max bandwidth (MB/s): 2250.55 [localhost]
 ```
After:
```
$ gpcheckperf -d /tmp/test1 -d /tmp/test2 -d /tmp/test3 -h localhost -rd
 disk write avg time (sec): 1.87
 disk write tot bytes: 4295000064     --> is equal to 2 * memory_size
 disk write tot bandwidth (MB/s): 2190.39
 disk write min bandwidth (MB/s): 2190.39 [localhost]
 disk write max bandwidth (MB/s): 2190.39 [localhost]
```

Also added unit test cases to test the getMemory() function outputs and added a main section to the gpcheckperf code.

[Pipeline](https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb-dev-6x_gpcheckperf_mem_fix)