### PR TITLE
Fix minirepro utility to create view dependencies for explain queries

### DIFF
--- a/src/backend/utils/adt/gp_dump_oids.c
+++ b/src/backend/utils/adt/gp_dump_oids.c
@@ -122,6 +122,10 @@ gp_dump_query_oids(PG_FUNCTION_ARGS)
 
 
 		Query	*query = parse_analyze(parsetree, sqlText, NULL, 0, NULL);
+		if (query->commandType == CMD_UTILITY && IsA(query->utilityStmt, ExplainStmt))
+		{
+			query = (Query *)((ExplainStmt *) query->utilityStmt)->query;
+		}
 		query->expandMatViews = true;
 		queryTree_sublist = pg_rewrite_query(query);
 

--- a/src/test/regress/expected/gp_dump_query_oids.out
+++ b/src/test/regress/expected/gp_dump_query_oids.out
@@ -6,6 +6,7 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 create materialized view base_mv as select a from base;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entry.
+create view base_v as select a from base;
 -- The function returns OIDs. We need to replace them with something reproducable.
 CREATE FUNCTION sanitize_output(t text) RETURNS text AS $$
 declare
@@ -13,16 +14,19 @@ declare
   dumptestfunc2_oid oid;
   base_oid oid;
   base_mv_oid oid;
+  base_v_oid oid;
 begin
     dumptestfunc_oid = 'dumptestfunc'::regproc::oid;
     dumptestfunc2_oid = 'dumptestfunc2'::regproc::oid;
     base_oid = 'base'::regclass::oid;
     base_mv_oid = 'base_mv'::regclass::oid;
+    base_v_oid = 'base_v'::regclass::oid;
 
     t := replace(t, dumptestfunc_oid::text, '<dumptestfunc>');
     t := replace(t, dumptestfunc2_oid::text, '<dumptestfunc2>');
     t := replace(t, base_oid::text, '<base_table>');
     t := replace(t, base_mv_oid::text, '<base_mv>');
+    t := replace(t, base_v_oid::text, '<base_v>');
 
     RETURN t;
 end;
@@ -144,10 +148,45 @@ SELECT sanitize_output(gp_dump_query_oids('SELECT * FROM base_mv'));
  {"relids": "<base_mv>,<base_table>", "funcids": ""}
 (1 row)
 
+SELECT sanitize_output(gp_dump_query_oids('SELECT * FROM base_v'));
+                  sanitize_output                   
+----------------------------------------------------
+ {"relids": "<base_v>,<base_table>", "funcids": ""}
+(1 row)
+
+-- gp_dump_query_oids should output relids of view/materialized view and used/accessed objects when query contains explain command
+SELECT sanitize_output(gp_dump_query_oids('EXPLAIN SELECT * FROM base_mv'));
+                   sanitize_output                   
+-----------------------------------------------------
+ {"relids": "<base_mv>,<base_table>", "funcids": ""}
+(1 row)
+
+SELECT sanitize_output(gp_dump_query_oids('EXPLAIN SELECT * FROM base_v'));
+                  sanitize_output                   
+----------------------------------------------------
+ {"relids": "<base_v>,<base_table>", "funcids": ""}
+(1 row)
+
+-- gp_dump_query_oids should output relids of view/materialized view and used/accessed objects when query contains explain analyze command
+SELECT sanitize_output(gp_dump_query_oids('EXPLAIN ANALYZE SELECT * FROM base_mv'));
+                   sanitize_output                   
+-----------------------------------------------------
+ {"relids": "<base_mv>,<base_table>", "funcids": ""}
+(1 row)
+
+SELECT sanitize_output(gp_dump_query_oids('EXPLAIN ANALYZE SELECT * FROM base_v'));
+                  sanitize_output                   
+----------------------------------------------------
+ {"relids": "<base_v>,<base_table>", "funcids": ""}
+(1 row)
+
 DROP TABLE foo;
 DROP TABLE cctable;
 DROP TABLE ctable;
 DROP TABLE ptable;
 DROP TABLE minirepro_partition_test;
+DROP MATERIALIZED VIEW base_mv;
+DROP VIEW base_v;
+DROP TABLE base;
 DROP FUNCTION dumptestfunc(text);
 DROP FUNCTION dumptestfunc2(text);


### PR DESCRIPTION
Previously, when using minirepro on a query with explain command that accessed materialized views/view , the object that the materialized view/view used/accessed were not dumped with the minirepro. This was because while rewriting queries in pg_rewrite_query, the utilities were not rewritten and were dumped into a result list. Due to this in the current implementation while getting the relids of queries containing explain command , we were getting the relids of the materialized view/view and not of the used/accessed objects. With this fix we are able to fetch the relids of both the materialized view/views and the used objects. So the minirepro will be able to collect the objects DDL used in the view.

Setup:
------

```
create table foo (a int);
create view foo_view as select a from foo;
```

Current Implementation:
-----------------------

```
select pg_catalog.gp_dump_query_oids('explain select * from foo_view');
         gp_dump_query_oids
------------------------------------
 {"relids": "16388", "funcids": ""}
(1 row)

select pg_catalog.gp_dump_query_oids('select * from foo_view');
            gp_dump_query_oids
------------------------------------------
 {"relids": "16388,16385", "funcids": ""}
(1 row)
```

AfterFix:
---------

```
select pg_catalog.gp_dump_query_oids('explain select * from foo_view');
            gp_dump_query_oids
------------------------------------------
 {"relids": "47537,16385", "funcids": ""}
(1 row)

select pg_catalog.gp_dump_query_oids('select * from foo_view');
            gp_dump_query_oids
------------------------------------------
 {"relids": "47537,16385", "funcids": ""}
(1 row)
```



## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
