### PR TITLE
Fix memory corruption for AOCO add column + insert + abort

### DIFF
--- a/src/backend/access/aocs/aocssegfiles.c
+++ b/src/backend/access/aocs/aocssegfiles.c
@@ -62,8 +62,7 @@
 
 
 static AOCSFileSegInfo **GetAllAOCSFileSegInfo_pg_aocsseg_rel(
-									 int numOfColumsn,
-									 char *relationName,
+									 Relation rel,
 									 Relation pg_aocsseg_rel,
 									 Snapshot appendOnlyMetaDataSnapshot,
 									 int32 *totalseg);
@@ -123,6 +122,68 @@ InsertInitialAOCSFileSegInfo(Relation prel, int32 segno, int32 nvp, Oid segrelid
 	pfree(vpinfo);
 	pfree(nulls);
 	pfree(values);
+}
+
+/*
+ * This is a routine to extract the vpinfo underlying the untoasted datum from
+ * the pg_aocsseg relation row, given the aocs relation's relnatts, into the supplied
+ * AOCSFileSegInfo structure.
+ *
+ * Sometimes the number of columns represented in the vpinfo inside pg_aocsseg
+ * the row may not match pg_class.relnatts. For instance, when we do an ADD
+ * COLUMN operation, we will have lesser number of columns in the table row
+ * than pg_class.relnatts.
+ * On the other hand, following an aborted ADD COLUMN operation,
+ * the number of columns in the table row will be
+ * greater than pg_class.relnatts.
+ */
+static void
+deformAOCSVPInfo(Relation rel, struct varlena *v, AOCSFileSegInfo *aocs_seginfo)
+{
+	int16 relnatts = RelationGetNumberOfAttributes(rel);
+	struct varlena *dv = pg_detoast_datum(v);
+	int source_size = VARSIZE(dv);
+	int target_size = aocs_vpinfo_size(relnatts);
+
+
+	if (source_size <= target_size)
+	{
+		/* The source fits into the target, simply memcpy. */
+		memcpy(&aocs_seginfo->vpinfo, dv, source_size);
+		Assert(aocs_seginfo->vpinfo.nEntry <= relnatts);
+	}
+	else
+	{
+		/*
+		 * We have more columns represented in the vpinfo recorded inside the
+		 * pg_aocsseg row, than pg_class.relnatts. Perform additional validation
+		 * on these extra column entries and then simply copy over relnatts
+		 * worth of entries from within the datum.
+		 */
+		AOCSVPInfo *vpInfo = (AOCSVPInfo *) dv;
+
+		for (int i = relnatts; i < vpInfo->nEntry; ++i)
+		{
+			/*
+			 * These extra entries must have be the initial frozen inserts
+			 * from when InsertInitialAOCSFileSegInfo() was called during
+			 * an aborted ADD COLUMN operation. Such entries should have eofs = 0,
+			 * indicating that there is no data. If not, there is something
+			 * seriously wrong. Yell appropriately.
+			 */
+			if(vpInfo->entry[i].eof > 0 || vpInfo->entry[i].eof_uncompressed > 0)
+				ereport(ERROR,
+						(errcode(ERRCODE_INTERNAL_ERROR),
+							errmsg("For relation \"%s\" aborted column %d has non-zero eof %d or non-zero uncompressed eof %d",
+								   RelationGetRelationName(rel), i, (int) vpInfo->entry[i].eof, (int) vpInfo->entry[i].eof_uncompressed)));
+		}
+
+		memcpy(&aocs_seginfo->vpinfo, dv, aocs_vpinfo_size(relnatts));
+		aocs_seginfo->vpinfo.nEntry = relnatts;
+	}
+
+	if (dv != v)
+		pfree(dv);
 }
 
 /*
@@ -240,15 +301,9 @@ GetAOCSFileSegInfo(Relation prel,
 	seginfo   ->state = DatumGetInt16(d[Anum_pg_aocs_state - 1]);
 
 	Assert(!null[Anum_pg_aocs_vpinfo - 1]);
-	{
-		struct varlena *v = (struct varlena *) DatumGetPointer(d[Anum_pg_aocs_vpinfo - 1]);
-		struct varlena *dv = pg_detoast_datum(v);
-
-		Assert(VARSIZE(dv) <= aocs_vpinfo_size(nvp));
-		memcpy(&seginfo->vpinfo, dv, aocs_vpinfo_size(nvp));
-		if (dv != v)
-			pfree(dv);
-	}
+	deformAOCSVPInfo(prel,
+					 (struct varlena *) DatumGetPointer(d[Anum_pg_aocs_vpinfo - 1]),
+						 seginfo);
 
 	pfree(d);
 	pfree(null);
@@ -286,9 +341,7 @@ GetAllAOCSFileSegInfo(Relation prel,
 
 	pg_aocsseg_rel = relation_open(segrelid, AccessShareLock);
 
-	results = GetAllAOCSFileSegInfo_pg_aocsseg_rel(
-												   RelationGetNumberOfAttributes(prel),
-												   RelationGetRelationName(prel),
+	results = GetAllAOCSFileSegInfo_pg_aocsseg_rel(prel,
 												   pg_aocsseg_rel,
 												   appendOnlyMetaDataSnapshot,
 												   totalseg);
@@ -316,16 +369,12 @@ aocsFileSegInfoCmp(const void *left, const void *right)
 
 	return 0;
 }
-
 static AOCSFileSegInfo **
-GetAllAOCSFileSegInfo_pg_aocsseg_rel(int numOfColumns,
-									 char *relationName,
+GetAllAOCSFileSegInfo_pg_aocsseg_rel(Relation rel,
 									 Relation pg_aocsseg_rel,
 									 Snapshot snapshot,
 									 int32 *totalseg)
 {
-
-	int32		nvp = numOfColumns;
 
 	SysScanDesc scan;
 	HeapTuple	tup;
@@ -358,7 +407,7 @@ GetAllAOCSFileSegInfo_pg_aocsseg_rel(int numOfColumns,
 			allseg = (AOCSFileSegInfo **) repalloc(allseg, sizeof(AOCSFileSegInfo *) * seginfo_slot_no);
 		}
 
-		aocs_seginfo = (AOCSFileSegInfo *) palloc0(aocsfileseginfo_size(nvp));
+		aocs_seginfo = (AOCSFileSegInfo *) palloc0(aocsfileseginfo_size(RelationGetNumberOfAttributes(rel)));
 
 		allseg[cur_seg] = aocs_seginfo;
 
@@ -390,20 +439,7 @@ GetAllAOCSFileSegInfo_pg_aocsseg_rel(int numOfColumns,
 			aocs_seginfo->state = DatumGetInt16(d[Anum_pg_aocs_state - 1]);
 
 		Assert(!null[Anum_pg_aocs_vpinfo - 1]);
-		{
-			struct varlena *v = (struct varlena *) DatumGetPointer(d[Anum_pg_aocs_vpinfo - 1]);
-			struct varlena *dv = pg_detoast_datum(v);
-
-			/*
-			 * VARSIZE(dv) may be less than aocs_vpinfo_size, in case of add
-			 * column, we try to do a ctas from old table to new table.
-			 */
-			Assert(VARSIZE(dv) <= aocs_vpinfo_size(nvp));
-
-			memcpy(&aocs_seginfo->vpinfo, dv, VARSIZE(dv));
-			if (dv != v)
-				pfree(dv);
-		}
+		deformAOCSVPInfo(rel, (struct varlena *) DatumGetPointer(d[Anum_pg_aocs_vpinfo - 1]), aocs_seginfo);
 		++cur_seg;
 	}
 
@@ -1248,8 +1284,7 @@ gp_aocsseg_internal(PG_FUNCTION_ARGS, Oid aocsRelOid)
 		pg_aocsseg_rel = heap_open(segrelid, AccessShareLock);
 
 		context->aocsSegfileArray = GetAllAOCSFileSegInfo_pg_aocsseg_rel(
-																		 aocsRel->rd_rel->relnatts,
-																		 RelationGetRelationName(aocsRel),
+																		 aocsRel,
 																		 pg_aocsseg_rel,
 																		 appendOnlyMetaDataSnapshot,
 																		 &context->totalAocsSegFiles);
@@ -1462,8 +1497,7 @@ gp_aocsseg_history(PG_FUNCTION_ARGS)
 		pg_aocsseg_rel = heap_open(segrelid, AccessShareLock);
 
 		context->aocsSegfileArray = GetAllAOCSFileSegInfo_pg_aocsseg_rel(
-																		 RelationGetNumberOfAttributes(aocsRel),
-																		 RelationGetRelationName(aocsRel),
+																		 aocsRel,
 																		 pg_aocsseg_rel,
 																		 SnapshotAny, //Get ALL tuples from pg_aocsseg_ % including aborted and in - progress ones.
 																		 & context->totalAocsSegFiles);

--- a/src/include/access/aocssegfiles.h
+++ b/src/include/access/aocssegfiles.h
@@ -135,7 +135,6 @@ extern AOCSFileSegInfo *GetAOCSFileSegInfo(Relation prel,
 										   Snapshot appendOnlyMetaDataSnapshot,
 										   int32 segno, bool locked);
 
-
 extern AOCSFileSegInfo **GetAllAOCSFileSegInfo(Relation prel,
 					  Snapshot appendOnlyMetaDataSnapshot,
 					  int *totalseg,

--- a/src/test/regress/expected/alter_table_aocs.out
+++ b/src/test/regress/expected/alter_table_aocs.out
@@ -834,3 +834,93 @@ Distributed by: (a)
 Options: compresstype=rle_type, compresslevel=4, blocksize=65536
 
 DROP TABLE aocs_alter_add_col_reorganize;
+-- test case: Ensure that reads don't fail after aborting an add column + insert operation and we don't project the aborted column
+CREATE TABLE aocs_addcol_abort(a int, b int) USING ao_column;
+INSERT INTO aocs_addcol_abort SELECT i,i FROM generate_series(1,10)i;
+BEGIN;
+ALTER TABLE aocs_addcol_abort ADD COLUMN c int;
+INSERT INTO aocs_addcol_abort SELECT i,i,i FROM generate_series(1,10)i;
+-- check state of aocsseg for entries of add column + insert
+SELECT * FROM gp_toolkit.__gp_aocsseg('aocs_addcol_abort') ORDER BY segment_id, column_num;
+ segment_id | segno | column_num | physical_segno | tupcount | eof | eof_uncompressed | modcount | formatversion | state 
+------------+-------+------------+----------------+----------+-----+------------------+----------+---------------+-------
+          0 |     0 |          0 |              0 |        5 |  64 |               64 |        1 |             4 |     1
+          0 |     1 |          0 |              1 |        5 |  64 |               64 |        2 |             4 |     1
+          0 |     0 |          1 |            128 |        5 |  64 |               64 |        1 |             4 |     1
+          0 |     1 |          1 |            129 |        5 |  64 |               64 |        2 |             4 |     1
+          0 |     0 |          2 |            256 |        5 |  64 |               64 |        1 |             4 |     1
+          0 |     1 |          2 |            257 |        5 |  48 |               48 |        2 |             4 |     1
+          1 |     0 |          0 |              0 |        1 |  48 |               48 |        1 |             4 |     1
+          1 |     1 |          0 |              1 |        1 |  48 |               48 |        2 |             4 |     1
+          1 |     0 |          1 |            128 |        1 |  48 |               48 |        1 |             4 |     1
+          1 |     1 |          1 |            129 |        1 |  48 |               48 |        2 |             4 |     1
+          1 |     0 |          2 |            256 |        1 |  48 |               48 |        1 |             4 |     1
+          1 |     1 |          2 |            257 |        1 |  48 |               48 |        2 |             4 |     1
+          2 |     0 |          0 |              0 |        4 |  56 |               56 |        1 |             4 |     1
+          2 |     1 |          0 |              1 |        4 |  56 |               56 |        2 |             4 |     1
+          2 |     0 |          1 |            128 |        4 |  56 |               56 |        1 |             4 |     1
+          2 |     1 |          1 |            129 |        4 |  56 |               56 |        2 |             4 |     1
+          2 |     0 |          2 |            256 |        4 |  56 |               56 |        1 |             4 |     1
+          2 |     1 |          2 |            257 |        4 |  48 |               48 |        2 |             4 |     1
+(18 rows)
+
+SELECT * FROM aocs_addcol_abort;
+ a  | b  | c  
+----+----+----
+  5 |  5 |  5
+  6 |  6 |  6
+  9 |  9 |  9
+ 10 | 10 | 10
+  5 |  5 |   
+  6 |  6 |   
+  9 |  9 |   
+ 10 | 10 |   
+  1 |  1 |  1
+  1 |  1 |   
+  2 |  2 |  2
+  3 |  3 |  3
+  4 |  4 |  4
+  7 |  7 |  7
+  8 |  8 |  8
+  2 |  2 |   
+  3 |  3 |   
+  4 |  4 |   
+  7 |  7 |   
+  8 |  8 |   
+(20 rows)
+
+ABORT;
+-- check state of aocsseg if entries for new column are rolled back correctly
+SELECT * FROM gp_toolkit.__gp_aocsseg('aocs_addcol_abort') ORDER BY segment_id, column_num;
+ segment_id | segno | column_num | physical_segno | tupcount | eof | eof_uncompressed | modcount | formatversion | state 
+------------+-------+------------+----------------+----------+-----+------------------+----------+---------------+-------
+          0 |     0 |          0 |              0 |        0 |   0 |                0 |        0 |             4 |     1
+          0 |     1 |          0 |              1 |        5 |  64 |               64 |        1 |             4 |     1
+          0 |     0 |          1 |            128 |        0 |   0 |                0 |        0 |             4 |     1
+          0 |     1 |          1 |            129 |        5 |  64 |               64 |        1 |             4 |     1
+          1 |     0 |          0 |              0 |        0 |   0 |                0 |        0 |             4 |     1
+          1 |     1 |          0 |              1 |        1 |  48 |               48 |        1 |             4 |     1
+          1 |     0 |          1 |            128 |        0 |   0 |                0 |        0 |             4 |     1
+          1 |     1 |          1 |            129 |        1 |  48 |               48 |        1 |             4 |     1
+          2 |     0 |          0 |              0 |        0 |   0 |                0 |        0 |             4 |     1
+          2 |     1 |          0 |              1 |        4 |  56 |               56 |        1 |             4 |     1
+          2 |     0 |          1 |            128 |        0 |   0 |                0 |        0 |             4 |     1
+          2 |     1 |          1 |            129 |        4 |  56 |               56 |        1 |             4 |     1
+(12 rows)
+
+SELECT * FROM aocs_addcol_abort;
+ a  | b  
+----+----
+  5 |  5
+  6 |  6
+  9 |  9
+ 10 | 10
+  1 |  1
+  2 |  2
+  3 |  3
+  4 |  4
+  7 |  7
+  8 |  8
+(10 rows)
+
+DROP TABLE aocs_addcol_abort;


### PR DESCRIPTION
When addcolumn + insert operation is aborted on an AOCO table, pg_aocsseg.vpinfo still has the entries for the aborted column.

Before this change aocsseg during reads we were copying over the whole vpinfo for segfile with RESERVED_SEGNO which includes entries for aborted column
This creates memory corruption as we are copying over more than what is needed/commited (aborted column's vpinfo)

This change edits the read of vpinfo to limit upto committed columns.

This solves the github issue: https://github.com/greenplum-db/gpdb/issues/14518
Pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb-dev-fix_aoco_addcol_abort?group=ICW
