### PR TITLE
docs - fix markdown table not rendering correctly

### DIFF
--- a/gpdb-doc/markdown/ref_guide/SQL2008_support.html.md
+++ b/gpdb-doc/markdown/ref_guide/SQL2008_support.html.md
@@ -349,7 +349,7 @@ For information about Greenplum features and SQL compliance, see the *Greenplum 
 |S095|Array constructors by query|NO| |
 |S096|Optional array bounds|NO| |
 |S097|Array element assignment|NO| |
-|S098|`array_agg`|Partially|Supported: Using `array_agg` without a window specification, for example:<br/>`SELECT array_agg(x) FROM ...`,<br/>`SELECT array_agg (x order by y) FROM ...`<br/><br/>Not supported: Using `array_agg` as an aggregate derived window function, for example:<br/>(`SELECT array_agg(x) over (ORDER BY y) FROM ...`,<br/>`SELECT array_agg(x order by y) over (PARTITION BY z) FROM ...`,<br/>`SELECT array_agg(x order by y) over (ORDER BY z) FROM ...`|
+|S098|`array_agg`|Partially|Supported: Using `array_agg` without a window specification, for example:<br/>`SELECT array_agg(x) FROM ...`,<br/>`SELECT array_agg (x order by y) FROM ...`<br/><br/>Not supported: Using `array_agg` as an aggregate derived window function, for example:<br/>`SELECT array_agg(x) over (ORDER BY y) FROM ...`,<br/>`SELECT array_agg(x order by y) over (PARTITION BY z) FROM ...`,<br/>`SELECT array_agg(x order by y) over (ORDER BY z) FROM ...`|
 |S111|`ONLY` in query expressions|YES| |
 |S151|Type predicate|NO| |
 |S161|Subtype treatment|NO| |

--- a/gpdb-doc/markdown/ref_guide/SQL2008_support.html.md
+++ b/gpdb-doc/markdown/ref_guide/SQL2008_support.html.md
@@ -349,7 +349,7 @@ For information about Greenplum features and SQL compliance, see the *Greenplum 
 |S095|Array constructors by query|NO| |
 |S096|Optional array bounds|NO| |
 |S097|Array element assignment|NO| |
-|S098|`ARRAY_AGG`|Partially|Supported: Using array\_agg without a window specification; for example<br/><br/>SELECT array\_agg\(x\) FROM ...<br/><br/>SELECT array\_agg \(x order by y\) FROM ...<br/><br/>Not supported: Using array\_agg as an aggregate derived window function; for example<br/><br/>SELECT array\_agg\(x\) over \(ORDER BY y\) FROM ...<br/><br/>SELECT array\_agg\(x order by y\) over \(PARTITION BY z\) FROM ...<br/><br/>SELECT array\_agg\(x order by y\) over \(ORDER BY z\) FROM ...|
+|S098|`array_agg`|Partially|Supported: Using `array_agg` without a window specification, for example:<br/>`SELECT array_agg(x) FROM ...`,<br/>`SELECT array_agg (x order by y) FROM ...`<br/><br/>Not supported: Using `array_agg` as an aggregate derived window function, for example:<br/>(`SELECT array_agg(x) over (ORDER BY y) FROM ...`,<br/>`SELECT array_agg(x order by y) over (PARTITION BY z) FROM ...`,<br/>`SELECT array_agg(x order by y) over (ORDER BY z) FROM ...`|
 |S111|`ONLY` in query expressions|YES| |
 |S151|Type predicate|NO| |
 |S161|Subtype treatment|NO| |


### PR DESCRIPTION
markdown table in sql compliance topic isn't rendering correctly in both greenplum 7 and greenplum 6 docs (https://docs-staging.vmware.com/en/draft/VMware-Tanzu-Greenplum/fix-tbl/greenplum-database/GUID-ref_guide-SQL2008_support.html).  found and fixed the bad row.

correctly-formatted table on doc review site (behind vpn):  https://docs-staging.vmware.com/en/draft/VMware-Tanzu-Greenplum/fix-tbl/greenplum-database/GUID-ref_guide-SQL2008_support.html