### PR TITLE
Fix bug that nestloop join fails to materialize the inner child in some cases

### DIFF
--- a/contrib/postgres_fdw/expected/gp2pg_postgres_fdw_optimizer.out
+++ b/contrib/postgres_fdw/expected/gp2pg_postgres_fdw_optimizer.out
@@ -4955,16 +4955,13 @@ EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st1(1, 2);
    ->  Foreign Scan on public.ft1
          Output: ft1.c3
          Remote SQL: SELECT c3 FROM "S 1"."T 1" WHERE (("C 1" = 1))
-   ->  Result
+   ->  Materialize
          Output: ft2.c3
-         Filter: (ft2.c1 = 2)
-         ->  Materialize
-               Output: ft2.c1, ft2.c3
-               ->  Foreign Scan on public.ft2
-                     Output: ft2.c1, ft2.c3
-                     Remote SQL: SELECT "C 1", c3 FROM "S 1"."T 1"
+         ->  Foreign Scan on public.ft2
+               Output: ft2.c3
+               Remote SQL: SELECT c3 FROM "S 1"."T 1" WHERE (("C 1" = 2))
  Optimizer: Pivotal Optimizer (GPORCA)
-(15 rows)
+(12 rows)
 
 EXECUTE st1(1, 1);
   c3   |  c3   

--- a/contrib/postgres_fdw/expected/gp2pg_postgres_fdw_optimizer.out
+++ b/contrib/postgres_fdw/expected/gp2pg_postgres_fdw_optimizer.out
@@ -4631,25 +4631,23 @@ select sum(q.a), count(q.b) from ft4 left join (select 13, avg(ft1.c1), sum(ft2.
          ->  Foreign Scan on public.ft4
                Output: ft4.c1
                Remote SQL: SELECT c1 FROM "S 1"."T 3"
-         ->  Result
-               Output: 13, (avg(ft1.c1))
-               ->  Materialize
-                     Output: (avg(ft1.c1))
-                     ->  Aggregate
-                           Output: avg(ft1.c1)
-                           ->  Hash Left Join
+         ->  Materialize
+               Output: (13), (avg(ft1.c1))
+               ->  Aggregate
+                     Output: 13, avg(ft1.c1)
+                     ->  Hash Left Join
+                           Output: ft1.c1
+                           Hash Cond: (ft2.c1 = ft1.c1)
+                           ->  Foreign Scan on public.ft2
+                                 Output: ft2.c1
+                                 Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
+                           ->  Hash
                                  Output: ft1.c1
-                                 Hash Cond: (ft2.c1 = ft1.c1)
-                                 ->  Foreign Scan on public.ft2
-                                       Output: ft2.c1
-                                       Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
-                                 ->  Hash
+                                 ->  Foreign Scan on public.ft1
                                        Output: ft1.c1
-                                       ->  Foreign Scan on public.ft1
-                                             Output: ft1.c1
-                                             Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
+                                       Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
  Optimizer: Pivotal Optimizer (GPORCA)
-(26 rows)
+(24 rows)
 
 select sum(q.a), count(q.b) from ft4 left join (select 13, avg(ft1.c1), sum(ft2.c1) from ft1 right join ft2 on (ft1.c1 = ft2.c1)) q(a, b, c) on (ft4.c1 <= q.b);
  sum | count 

--- a/src/backend/gporca/data/dxl/minidump/AnyPredicate-Over-UnionOfConsts.mdp
+++ b/src/backend/gporca/data/dxl/minidump/AnyPredicate-Over-UnionOfConsts.mdp
@@ -167,10 +167,10 @@
         </dxl:LogicalConstTable>
       </dxl:LogicalProject>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1266">
+    <dxl:Plan Id="0" SpaceSize="1644">
       <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1724.000506" Rows="1.000000" Width="1"/>
+          <dxl:Cost StartupCost="0" TotalCost="1724.000526" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="5" Alias="?column?">
@@ -195,7 +195,7 @@
         <dxl:OneTimeFilter/>
         <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1724.000505" Rows="2.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="1724.000525" Rows="2.000000" Width="16"/>
           </dxl:Properties>
           <dxl:GroupingColumns>
             <dxl:GroupingColumn ColId="0"/>
@@ -228,7 +228,7 @@
           <dxl:Filter/>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1724.000475" Rows="2.000000" Width="6"/>
+              <dxl:Cost StartupCost="0" TotalCost="1724.000495" Rows="2.000000" Width="6"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="8" Alias="ColRef_0008">
@@ -254,7 +254,7 @@
             <dxl:OneTimeFilter/>
             <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1724.000463" Rows="2.000000" Width="6"/>
+                <dxl:Cost StartupCost="0" TotalCost="1724.000483" Rows="2.000000" Width="6"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="">
@@ -299,111 +299,125 @@
                   <dxl:OneTimeFilter/>
                 </dxl:Result>
               </dxl:Sort>
-              <dxl:Result>
+              <dxl:Materialize Eager="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="0.000051" Rows="1.000000" Width="5"/>
+                  <dxl:Cost StartupCost="0" TotalCost="0.000056" Rows="1.000000" Width="5"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="6" Alias="ColRef_0006">
-                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                    <dxl:Ident ColId="6" ColName="ColRef_0006" TypeMdid="0.16.1.0"/>
                   </dxl:ProjElem>
                   <dxl:ProjElem ColId="2" Alias="?column?">
                     <dxl:Ident ColId="2" ColName="?column?" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
-                <dxl:OneTimeFilter/>
-                <dxl:Append IsTarget="false" IsZapped="false">
+                <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="0.000046" Rows="2.000000" Width="4"/>
+                    <dxl:Cost StartupCost="0" TotalCost="0.000051" Rows="1.000000" Width="5"/>
                   </dxl:Properties>
                   <dxl:ProjList>
+                    <dxl:ProjElem ColId="6" Alias="ColRef_0006">
+                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                    </dxl:ProjElem>
                     <dxl:ProjElem ColId="2" Alias="?column?">
                       <dxl:Ident ColId="2" ColName="?column?" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:Result>
+                  <dxl:OneTimeFilter/>
+                  <dxl:Append IsTarget="false" IsZapped="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="0.000000" Rows="1.000000" Width="4"/>
+                      <dxl:Cost StartupCost="0" TotalCost="0.000046" Rows="2.000000" Width="4"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="2" Alias="?column?">
                         <dxl:Ident ColId="2" ColName="?column?" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
                     </dxl:ProjList>
-                    <dxl:Filter>
-                      <dxl:IsNotFalse>
-                        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                          <dxl:Ident ColId="2" ColName="?column?" TypeMdid="0.23.1.0"/>
-                        </dxl:Comparison>
-                      </dxl:IsNotFalse>
-                    </dxl:Filter>
-                    <dxl:OneTimeFilter/>
+                    <dxl:Filter/>
                     <dxl:Result>
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="0.000000" Rows="0.000000" Width="4"/>
+                        <dxl:Cost StartupCost="0" TotalCost="0.000000" Rows="1.000000" Width="4"/>
                       </dxl:Properties>
                       <dxl:ProjList>
-                        <dxl:ProjElem ColId="1" Alias="">
-                          <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true"/>
-                        </dxl:ProjElem>
                         <dxl:ProjElem ColId="2" Alias="?column?">
-                          <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
+                          <dxl:Ident ColId="2" ColName="?column?" TypeMdid="0.23.1.0"/>
                         </dxl:ProjElem>
                       </dxl:ProjList>
-                      <dxl:Filter/>
-                      <dxl:OneTimeFilter>
-                        <dxl:ConstValue TypeMdid="0.16.1.0" Value="false"/>
-                      </dxl:OneTimeFilter>
-                    </dxl:Result>
-                  </dxl:Result>
-                  <dxl:Result>
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="0.000038" Rows="1.000000" Width="4"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="4" Alias="?column?">
-                        <dxl:Ident ColId="4" ColName="?column?" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:Filter>
-                      <dxl:IsNotFalse>
-                        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                          <dxl:Ident ColId="4" ColName="?column?" TypeMdid="0.23.1.0"/>
-                        </dxl:Comparison>
-                      </dxl:IsNotFalse>
-                    </dxl:Filter>
-                    <dxl:OneTimeFilter/>
-                    <dxl:Result>
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
-                      </dxl:Properties>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="4" Alias="?column?">
-                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
-                      <dxl:Filter/>
+                      <dxl:Filter>
+                        <dxl:IsNotFalse>
+                          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                            <dxl:Ident ColId="2" ColName="?column?" TypeMdid="0.23.1.0"/>
+                          </dxl:Comparison>
+                        </dxl:IsNotFalse>
+                      </dxl:Filter>
                       <dxl:OneTimeFilter/>
                       <dxl:Result>
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                          <dxl:Cost StartupCost="0" TotalCost="0.000000" Rows="0.000000" Width="4"/>
                         </dxl:Properties>
                         <dxl:ProjList>
-                          <dxl:ProjElem ColId="3" Alias="">
-                            <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                          <dxl:ProjElem ColId="1" Alias="">
+                            <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="2" Alias="?column?">
+                            <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:OneTimeFilter>
+                          <dxl:ConstValue TypeMdid="0.16.1.0" Value="false"/>
+                        </dxl:OneTimeFilter>
+                      </dxl:Result>
+                    </dxl:Result>
+                    <dxl:Result>
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="0.000038" Rows="1.000000" Width="4"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="4" Alias="?column?">
+                          <dxl:Ident ColId="4" ColName="?column?" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter>
+                        <dxl:IsNotFalse>
+                          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                            <dxl:Ident ColId="4" ColName="?column?" TypeMdid="0.23.1.0"/>
+                          </dxl:Comparison>
+                        </dxl:IsNotFalse>
+                      </dxl:Filter>
+                      <dxl:OneTimeFilter/>
+                      <dxl:Result>
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="4" Alias="?column?">
+                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
                           </dxl:ProjElem>
                         </dxl:ProjList>
                         <dxl:Filter/>
                         <dxl:OneTimeFilter/>
+                        <dxl:Result>
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="3" Alias="">
+                              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:OneTimeFilter/>
+                        </dxl:Result>
                       </dxl:Result>
                     </dxl:Result>
-                  </dxl:Result>
-                </dxl:Append>
-              </dxl:Result>
+                  </dxl:Append>
+                </dxl:Result>
+              </dxl:Materialize>
             </dxl:NestedLoopJoin>
           </dxl:Result>
         </dxl:Aggregate>

--- a/src/backend/gporca/data/dxl/minidump/AnyPredicate-Over-UnionOfConsts.mdp
+++ b/src/backend/gporca/data/dxl/minidump/AnyPredicate-Over-UnionOfConsts.mdp
@@ -167,7 +167,7 @@
         </dxl:LogicalConstTable>
       </dxl:LogicalProject>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1644">
+    <dxl:Plan Id="0" SpaceSize="1518">
       <dxl:Result>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1724.000526" Rows="1.000000" Width="1"/>

--- a/src/backend/gporca/data/dxl/minidump/AnySubq-With-NonScalarSubqueryChild-1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/AnySubq-With-NonScalarSubqueryChild-1.mdp
@@ -468,7 +468,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="2643">
+    <dxl:Plan Id="0" SpaceSize="1188">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1389253302051.813232" Rows="1.000000" Width="15"/>

--- a/src/backend/gporca/data/dxl/minidump/AnySubq-With-NonScalarSubqueryChild-1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/AnySubq-With-NonScalarSubqueryChild-1.mdp
@@ -468,7 +468,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1188">
+    <dxl:Plan Id="0" SpaceSize="1110">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1389253302051.813232" Rows="1.000000" Width="15"/>

--- a/src/backend/gporca/data/dxl/minidump/AnySubq-With-NonScalarSubqueryChild-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/AnySubq-With-NonScalarSubqueryChild-2.mdp
@@ -448,7 +448,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="299">
+    <dxl:Plan Id="0" SpaceSize="202">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1356691815.392586" Rows="1.000000" Width="15"/>

--- a/src/backend/gporca/data/dxl/minidump/AnySubq-With-NonScalarSubqueryChild-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/AnySubq-With-NonScalarSubqueryChild-2.mdp
@@ -448,7 +448,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="202">
+    <dxl:Plan Id="0" SpaceSize="188">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1356691815.392586" Rows="1.000000" Width="15"/>

--- a/src/backend/gporca/data/dxl/minidump/AnySubq-With-NonScalarSubqueryChild-3.mdp
+++ b/src/backend/gporca/data/dxl/minidump/AnySubq-With-NonScalarSubqueryChild-3.mdp
@@ -417,7 +417,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="418">
+    <dxl:Plan Id="0" SpaceSize="268">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1356691560.030987" Rows="1.000000" Width="15"/>

--- a/src/backend/gporca/data/dxl/minidump/AnySubq-With-NonScalarSubqueryChild-3.mdp
+++ b/src/backend/gporca/data/dxl/minidump/AnySubq-With-NonScalarSubqueryChild-3.mdp
@@ -417,7 +417,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="268">
+    <dxl:Plan Id="0" SpaceSize="223">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1356691560.030987" Rows="1.000000" Width="15"/>

--- a/src/backend/gporca/data/dxl/minidump/BitmapIndexNLOJWithProject.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndexNLOJWithProject.mdp
@@ -1882,7 +1882,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="4">
+    <dxl:Plan Id="0" SpaceSize="3">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="868.302155" Rows="100.000000" Width="32"/>

--- a/src/backend/gporca/data/dxl/minidump/BitmapIndexNLOJWithProjectNonPart.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndexNLOJWithProjectNonPart.mdp
@@ -1272,7 +1272,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="4">
+    <dxl:Plan Id="0" SpaceSize="3">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="922.216568" Rows="1000.000000" Width="32"/>

--- a/src/backend/gporca/data/dxl/minidump/BitmapIndexScan.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndexScan.mdp
@@ -422,7 +422,7 @@ see sql/BitmapIndexScan.sql
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="27">
+    <dxl:Plan Id="0" SpaceSize="26">
       <dxl:GatherMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="6724.473435" Rows="1.000000" Width="9"/>

--- a/src/backend/gporca/data/dxl/minidump/CTAS_OrderedAgg_multiple_cols.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTAS_OrderedAgg_multiple_cols.mdp
@@ -1802,7 +1802,7 @@ EXPLAIN CREATE TABLE test AS
         </dxl:LogicalProject>
       </dxl:LogicalCTAS>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="29379751833600">
+    <dxl:Plan Id="0" SpaceSize="11764799510400">
       <dxl:PhysicalCTAS Name="fake ctas rel" IsTemporary="true" StorageType="Heap" DistributionPolicy="Random" InsertColumns="19,20,21" VarTypeModList="-1,-1,-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="2778516240645.427246" Rows="1.000000" Width="24"/>

--- a/src/backend/gporca/data/dxl/minidump/CTEWithMergedGroup.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTEWithMergedGroup.mdp
@@ -423,10 +423,10 @@
         </dxl:LogicalProject>
       </dxl:LogicalCTEAnchor>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="158660247168">
+    <dxl:Plan Id="0" SpaceSize="41793672096">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1356250696.455244" Rows="1.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="1356250698.553420" Rows="1.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="41" Alias="?column?">
@@ -437,7 +437,7 @@
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1356250696.455229" Rows="1.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="1356250698.553405" Rows="1.000000" Width="4"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="41" Alias="?column?">
@@ -448,7 +448,7 @@
           <dxl:OneTimeFilter/>
           <dxl:HashJoin JoinType="LeftAntiSemiJoin">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1356250696.455228" Rows="1.000000" Width="1"/>
+              <dxl:Cost StartupCost="0" TotalCost="1356250698.553403" Rows="1.000000" Width="1"/>
             </dxl:Properties>
             <dxl:ProjList/>
             <dxl:Filter/>
@@ -465,7 +465,7 @@
             </dxl:HashCondList>
             <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1356250265.454569" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="1356250267.552745" Rows="1.000000" Width="8"/>
               </dxl:Properties>
               <dxl:GroupingColumns>
                 <dxl:GroupingColumn ColId="15"/>
@@ -490,7 +490,7 @@
               <dxl:Filter/>
               <dxl:Sort SortDiscardDuplicates="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1356250265.454549" Rows="1.000000" Width="18"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1356250267.552725" Rows="1.000000" Width="18"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="15" Alias="d">
@@ -515,7 +515,7 @@
                 <dxl:LimitOffset/>
                 <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1356250265.454549" Rows="1.000000" Width="18"/>
+                    <dxl:Cost StartupCost="0" TotalCost="1356250267.552725" Rows="1.000000" Width="18"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="15" Alias="d">
@@ -543,7 +543,7 @@
                   </dxl:HashExprList>
                   <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="1356250265.454493" Rows="1.000000" Width="18"/>
+                      <dxl:Cost StartupCost="0" TotalCost="1356250267.552669" Rows="1.000000" Width="18"/>
                     </dxl:Properties>
                     <dxl:GroupingColumns>
                       <dxl:GroupingColumn ColId="15"/>
@@ -568,7 +568,7 @@
                     <dxl:Filter/>
                     <dxl:Sort SortDiscardDuplicates="false">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="1356250265.454465" Rows="1.000000" Width="18"/>
+                        <dxl:Cost StartupCost="0" TotalCost="1356250267.552641" Rows="1.000000" Width="18"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="15" Alias="d">
@@ -593,7 +593,7 @@
                       <dxl:LimitOffset/>
                       <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="1356250265.454465" Rows="1.000000" Width="18"/>
+                          <dxl:Cost StartupCost="0" TotalCost="1356250267.552641" Rows="1.000000" Width="18"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="15" Alias="d">
@@ -615,7 +615,7 @@
                         </dxl:JoinFilter>
                         <dxl:NestedLoopJoin JoinType="In" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="882688.136962" Rows="1.000000" Width="18"/>
+                            <dxl:Cost StartupCost="0" TotalCost="882688.137986" Rows="1.000000" Width="18"/>
                           </dxl:Properties>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="15" Alias="d">
@@ -668,149 +668,178 @@
                               </dxl:Columns>
                             </dxl:TableDescriptor>
                           </dxl:TableScan>
-                          <dxl:Result>
+                          <dxl:Materialize Eager="false">
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="0.000003" Rows="1.000000" Width="1"/>
+                              <dxl:Cost StartupCost="0" TotalCost="0.000004" Rows="1.000000" Width="1"/>
                             </dxl:Properties>
                             <dxl:ProjList>
                               <dxl:ProjElem ColId="27" Alias="?column?">
-                                <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                                <dxl:Ident ColId="27" ColName="?column?" TypeMdid="0.23.1.0"/>
                               </dxl:ProjElem>
                             </dxl:ProjList>
                             <dxl:Filter/>
-                            <dxl:OneTimeFilter/>
-                            <dxl:Limit>
+                            <dxl:Result>
                               <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="0.000002" Rows="1.000000" Width="1"/>
+                                <dxl:Cost StartupCost="0" TotalCost="0.000003" Rows="1.000000" Width="1"/>
                               </dxl:Properties>
-                              <dxl:ProjList/>
-                              <dxl:Result>
+                              <dxl:ProjList>
+                                <dxl:ProjElem ColId="27" Alias="?column?">
+                                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                                </dxl:ProjElem>
+                              </dxl:ProjList>
+                              <dxl:Filter/>
+                              <dxl:OneTimeFilter/>
+                              <dxl:Limit>
                                 <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                                  <dxl:Cost StartupCost="0" TotalCost="0.000002" Rows="1.000000" Width="1"/>
                                 </dxl:Properties>
                                 <dxl:ProjList/>
-                                <dxl:Filter/>
-                                <dxl:OneTimeFilter/>
                                 <dxl:Result>
                                   <dxl:Properties>
                                     <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
                                   </dxl:Properties>
-                                  <dxl:ProjList>
-                                    <dxl:ProjElem ColId="26" Alias="">
-                                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                                    </dxl:ProjElem>
-                                  </dxl:ProjList>
+                                  <dxl:ProjList/>
                                   <dxl:Filter/>
                                   <dxl:OneTimeFilter/>
+                                  <dxl:Result>
+                                    <dxl:Properties>
+                                      <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                                    </dxl:Properties>
+                                    <dxl:ProjList>
+                                      <dxl:ProjElem ColId="26" Alias="">
+                                        <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                                      </dxl:ProjElem>
+                                    </dxl:ProjList>
+                                    <dxl:Filter/>
+                                    <dxl:OneTimeFilter/>
+                                  </dxl:Result>
                                 </dxl:Result>
-                              </dxl:Result>
-                              <dxl:LimitCount>
-                                <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
-                              </dxl:LimitCount>
-                              <dxl:LimitOffset>
-                                <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
-                              </dxl:LimitOffset>
-                            </dxl:Limit>
-                          </dxl:Result>
+                                <dxl:LimitCount>
+                                  <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
+                                </dxl:LimitCount>
+                                <dxl:LimitOffset>
+                                  <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+                                </dxl:LimitOffset>
+                              </dxl:Limit>
+                            </dxl:Result>
+                          </dxl:Materialize>
                         </dxl:NestedLoopJoin>
-                        <dxl:NestedLoopJoin JoinType="In" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+                        <dxl:Materialize Eager="true">
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="441344.012819" Rows="1.000000" Width="1"/>
+                            <dxl:Cost StartupCost="0" TotalCost="441344.013844" Rows="1.000000" Width="1"/>
                           </dxl:Properties>
                           <dxl:ProjList/>
                           <dxl:Filter/>
-                          <dxl:JoinFilter>
-                            <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                          </dxl:JoinFilter>
-                          <dxl:Result>
+                          <dxl:NestedLoopJoin JoinType="In" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="0.000003" Rows="1.000000" Width="1"/>
+                              <dxl:Cost StartupCost="0" TotalCost="441344.013843" Rows="1.000000" Width="1"/>
                             </dxl:Properties>
-                            <dxl:ProjList>
-                              <dxl:ProjElem ColId="29" Alias="?column?">
-                                <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                              </dxl:ProjElem>
-                            </dxl:ProjList>
+                            <dxl:ProjList/>
                             <dxl:Filter/>
-                            <dxl:OneTimeFilter/>
-                            <dxl:Limit>
+                            <dxl:JoinFilter>
+                              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                            </dxl:JoinFilter>
+                            <dxl:Result>
                               <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="0.000002" Rows="1.000000" Width="1"/>
+                                <dxl:Cost StartupCost="0" TotalCost="0.000003" Rows="1.000000" Width="1"/>
                               </dxl:Properties>
-                              <dxl:ProjList/>
-                              <dxl:Result>
+                              <dxl:ProjList>
+                                <dxl:ProjElem ColId="29" Alias="?column?">
+                                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                                </dxl:ProjElem>
+                              </dxl:ProjList>
+                              <dxl:Filter/>
+                              <dxl:OneTimeFilter/>
+                              <dxl:Limit>
                                 <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                                  <dxl:Cost StartupCost="0" TotalCost="0.000002" Rows="1.000000" Width="1"/>
                                 </dxl:Properties>
                                 <dxl:ProjList/>
-                                <dxl:Filter/>
-                                <dxl:OneTimeFilter/>
                                 <dxl:Result>
                                   <dxl:Properties>
                                     <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
                                   </dxl:Properties>
-                                  <dxl:ProjList>
-                                    <dxl:ProjElem ColId="28" Alias="">
-                                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                                    </dxl:ProjElem>
-                                  </dxl:ProjList>
+                                  <dxl:ProjList/>
                                   <dxl:Filter/>
                                   <dxl:OneTimeFilter/>
+                                  <dxl:Result>
+                                    <dxl:Properties>
+                                      <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                                    </dxl:Properties>
+                                    <dxl:ProjList>
+                                      <dxl:ProjElem ColId="28" Alias="">
+                                        <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                                      </dxl:ProjElem>
+                                    </dxl:ProjList>
+                                    <dxl:Filter/>
+                                    <dxl:OneTimeFilter/>
+                                  </dxl:Result>
                                 </dxl:Result>
-                              </dxl:Result>
-                              <dxl:LimitCount>
-                                <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
-                              </dxl:LimitCount>
-                              <dxl:LimitOffset>
-                                <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
-                              </dxl:LimitOffset>
-                            </dxl:Limit>
-                          </dxl:Result>
-                          <dxl:Result>
-                            <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="0.000003" Rows="1.000000" Width="1"/>
-                            </dxl:Properties>
-                            <dxl:ProjList>
-                              <dxl:ProjElem ColId="25" Alias="?column?">
-                                <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                              </dxl:ProjElem>
-                            </dxl:ProjList>
-                            <dxl:Filter/>
-                            <dxl:OneTimeFilter/>
-                            <dxl:Limit>
+                                <dxl:LimitCount>
+                                  <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
+                                </dxl:LimitCount>
+                                <dxl:LimitOffset>
+                                  <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+                                </dxl:LimitOffset>
+                              </dxl:Limit>
+                            </dxl:Result>
+                            <dxl:Materialize Eager="false">
                               <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="0.000002" Rows="1.000000" Width="1"/>
+                                <dxl:Cost StartupCost="0" TotalCost="0.000004" Rows="1.000000" Width="1"/>
                               </dxl:Properties>
-                              <dxl:ProjList/>
+                              <dxl:ProjList>
+                                <dxl:ProjElem ColId="25" Alias="?column?">
+                                  <dxl:Ident ColId="25" ColName="?column?" TypeMdid="0.23.1.0"/>
+                                </dxl:ProjElem>
+                              </dxl:ProjList>
+                              <dxl:Filter/>
                               <dxl:Result>
                                 <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                                  <dxl:Cost StartupCost="0" TotalCost="0.000003" Rows="1.000000" Width="1"/>
                                 </dxl:Properties>
-                                <dxl:ProjList/>
+                                <dxl:ProjList>
+                                  <dxl:ProjElem ColId="25" Alias="?column?">
+                                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                                  </dxl:ProjElem>
+                                </dxl:ProjList>
                                 <dxl:Filter/>
                                 <dxl:OneTimeFilter/>
-                                <dxl:Result>
+                                <dxl:Limit>
                                   <dxl:Properties>
-                                    <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                                    <dxl:Cost StartupCost="0" TotalCost="0.000002" Rows="1.000000" Width="1"/>
                                   </dxl:Properties>
-                                  <dxl:ProjList>
-                                    <dxl:ProjElem ColId="24" Alias="">
-                                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                                    </dxl:ProjElem>
-                                  </dxl:ProjList>
-                                  <dxl:Filter/>
-                                  <dxl:OneTimeFilter/>
-                                </dxl:Result>
+                                  <dxl:ProjList/>
+                                  <dxl:Result>
+                                    <dxl:Properties>
+                                      <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                                    </dxl:Properties>
+                                    <dxl:ProjList/>
+                                    <dxl:Filter/>
+                                    <dxl:OneTimeFilter/>
+                                    <dxl:Result>
+                                      <dxl:Properties>
+                                        <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                                      </dxl:Properties>
+                                      <dxl:ProjList>
+                                        <dxl:ProjElem ColId="24" Alias="">
+                                          <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                                        </dxl:ProjElem>
+                                      </dxl:ProjList>
+                                      <dxl:Filter/>
+                                      <dxl:OneTimeFilter/>
+                                    </dxl:Result>
+                                  </dxl:Result>
+                                  <dxl:LimitCount>
+                                    <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
+                                  </dxl:LimitCount>
+                                  <dxl:LimitOffset>
+                                    <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+                                  </dxl:LimitOffset>
+                                </dxl:Limit>
                               </dxl:Result>
-                              <dxl:LimitCount>
-                                <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
-                              </dxl:LimitCount>
-                              <dxl:LimitOffset>
-                                <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
-                              </dxl:LimitOffset>
-                            </dxl:Limit>
-                          </dxl:Result>
-                        </dxl:NestedLoopJoin>
+                            </dxl:Materialize>
+                          </dxl:NestedLoopJoin>
+                        </dxl:Materialize>
                       </dxl:NestedLoopJoin>
                     </dxl:Sort>
                   </dxl:Aggregate>

--- a/src/backend/gporca/data/dxl/minidump/CannotPullGrpColAboveAgg.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CannotPullGrpColAboveAgg.mdp
@@ -3760,7 +3760,7 @@ The SQL along with the DDL are in TINC repo. In the aggregates directory under q
         </dxl:LogicalJoin>
       </dxl:LogicalProject>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="14257152">
+    <dxl:Plan Id="0" SpaceSize="13533696">
       <dxl:Result>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="57937329.740768" Rows="2959212724800.000000" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/CannotPullGrpColAboveAgg.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CannotPullGrpColAboveAgg.mdp
@@ -3760,7 +3760,7 @@ The SQL along with the DDL are in TINC repo. In the aggregates directory under q
         </dxl:LogicalJoin>
       </dxl:LogicalProject>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="15376896">
+    <dxl:Plan Id="0" SpaceSize="14257152">
       <dxl:Result>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="57937329.740768" Rows="2959212724800.000000" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/Coalesce-With-Subquery.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Coalesce-With-Subquery.mdp
@@ -845,7 +845,7 @@
         </dxl:LogicalProject>
       </dxl:LogicalLimit>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="2856">
+    <dxl:Plan Id="0" SpaceSize="4186">
       <dxl:Result>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="38915.798285" Rows="4.000000" Width="269"/>

--- a/src/backend/gporca/data/dxl/minidump/CollapseNot.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CollapseNot.mdp
@@ -296,10 +296,10 @@ SELECT 1 FROM inverse WHERE NOT (cidr <<= ANY(SELECT * FROM inverse));
         </dxl:LogicalSelect>
       </dxl:LogicalProject>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="42">
+    <dxl:Plan Id="0" SpaceSize="30">
       <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1293.001142" Rows="1.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="1293.001143" Rows="1.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="16" Alias="?column?">
@@ -310,14 +310,14 @@ SELECT 1 FROM inverse WHERE NOT (cidr <<= ANY(SELECT * FROM inverse));
         <dxl:OneTimeFilter/>
         <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1293.001138" Rows="1.000000" Width="1"/>
+            <dxl:Cost StartupCost="0" TotalCost="1293.001139" Rows="1.000000" Width="1"/>
           </dxl:Properties>
           <dxl:ProjList/>
           <dxl:Filter/>
           <dxl:SortingColumnList/>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1293.001134" Rows="1.000000" Width="1"/>
+              <dxl:Cost StartupCost="0" TotalCost="1293.001135" Rows="1.000000" Width="1"/>
             </dxl:Properties>
             <dxl:ProjList/>
             <dxl:Filter>
@@ -332,7 +332,7 @@ SELECT 1 FROM inverse WHERE NOT (cidr <<= ANY(SELECT * FROM inverse));
                       <dxl:Ident ColId="20" ColName="ColRef_0020" TypeMdid="0.20.1.0"/>
                       <dxl:Ident ColId="18" ColName="ColRef_0018" TypeMdid="0.20.1.0"/>
                     </dxl:Comparison>
-                    <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true" IsByValue="true"/>
+                    <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true"/>
                     <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
                   </dxl:If>
                   <dxl:ConstValue TypeMdid="0.16.1.0" Value="false"/>
@@ -342,7 +342,7 @@ SELECT 1 FROM inverse WHERE NOT (cidr <<= ANY(SELECT * FROM inverse));
             <dxl:OneTimeFilter/>
             <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1293.001112" Rows="1.000000" Width="16"/>
+                <dxl:Cost StartupCost="0" TotalCost="1293.001113" Rows="1.000000" Width="16"/>
               </dxl:Properties>
               <dxl:GroupingColumns>
                 <dxl:GroupingColumn ColId="0"/>
@@ -383,7 +383,7 @@ SELECT 1 FROM inverse WHERE NOT (cidr <<= ANY(SELECT * FROM inverse));
               <dxl:Filter/>
               <dxl:Sort SortDiscardDuplicates="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1293.001075" Rows="1.000000" Width="34"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1293.001076" Rows="1.000000" Width="34"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="cidr">
@@ -411,7 +411,7 @@ SELECT 1 FROM inverse WHERE NOT (cidr <<= ANY(SELECT * FROM inverse));
                 <dxl:LimitOffset/>
                 <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1293.001075" Rows="1.000000" Width="34"/>
+                    <dxl:Cost StartupCost="0" TotalCost="1293.001076" Rows="1.000000" Width="34"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="0" Alias="cidr">
@@ -442,7 +442,7 @@ SELECT 1 FROM inverse WHERE NOT (cidr <<= ANY(SELECT * FROM inverse));
                   </dxl:HashExprList>
                   <dxl:Result>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="1293.000969" Rows="1.000000" Width="34"/>
+                      <dxl:Cost StartupCost="0" TotalCost="1293.000970" Rows="1.000000" Width="34"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="0" Alias="cidr">
@@ -465,7 +465,7 @@ SELECT 1 FROM inverse WHERE NOT (cidr <<= ANY(SELECT * FROM inverse));
                     <dxl:OneTimeFilter/>
                     <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="1293.000969" Rows="1.000000" Width="34"/>
+                        <dxl:Cost StartupCost="0" TotalCost="1293.000970" Rows="1.000000" Width="34"/>
                       </dxl:Properties>
                       <dxl:GroupingColumns>
                         <dxl:GroupingColumn ColId="0"/>
@@ -506,7 +506,7 @@ SELECT 1 FROM inverse WHERE NOT (cidr <<= ANY(SELECT * FROM inverse));
                       <dxl:Filter/>
                       <dxl:Sort SortDiscardDuplicates="false">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="1293.000927" Rows="1.000000" Width="23"/>
+                          <dxl:Cost StartupCost="0" TotalCost="1293.000928" Rows="1.000000" Width="23"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="19" Alias="ColRef_0019">
@@ -534,7 +534,7 @@ SELECT 1 FROM inverse WHERE NOT (cidr <<= ANY(SELECT * FROM inverse));
                         <dxl:LimitOffset/>
                         <dxl:Result>
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="1293.000927" Rows="1.000000" Width="23"/>
+                            <dxl:Cost StartupCost="0" TotalCost="1293.000928" Rows="1.000000" Width="23"/>
                           </dxl:Properties>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="19" Alias="ColRef_0019">
@@ -566,7 +566,7 @@ SELECT 1 FROM inverse WHERE NOT (cidr <<= ANY(SELECT * FROM inverse));
                           <dxl:OneTimeFilter/>
                           <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="1293.000904" Rows="1.000000" Width="27"/>
+                              <dxl:Cost StartupCost="0" TotalCost="1293.000905" Rows="1.000000" Width="27"/>
                             </dxl:Properties>
                             <dxl:ProjList>
                               <dxl:ProjElem ColId="0" Alias="cidr">
@@ -623,30 +623,33 @@ SELECT 1 FROM inverse WHERE NOT (cidr <<= ANY(SELECT * FROM inverse));
                                 </dxl:Columns>
                               </dxl:TableDescriptor>
                             </dxl:TableScan>
-                            <dxl:Result>
+                            <dxl:Materialize Eager="false">
                               <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="431.000482" Rows="3.000000" Width="9"/>
+                                <dxl:Cost StartupCost="0" TotalCost="431.000483" Rows="3.000000" Width="9"/>
                               </dxl:Properties>
                               <dxl:ProjList>
                                 <dxl:ProjElem ColId="17" Alias="ColRef_0017">
-                                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                                  <dxl:Ident ColId="17" ColName="ColRef_0017" TypeMdid="0.16.1.0"/>
                                 </dxl:ProjElem>
                                 <dxl:ProjElem ColId="8" Alias="cidr">
                                   <dxl:Ident ColId="8" ColName="cidr" TypeMdid="0.869.1.0"/>
                                 </dxl:ProjElem>
                               </dxl:ProjList>
                               <dxl:Filter/>
-                              <dxl:OneTimeFilter/>
-                              <dxl:Materialize Eager="false">
+                              <dxl:Result>
                                 <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="431.000473" Rows="3.000000" Width="8"/>
+                                  <dxl:Cost StartupCost="0" TotalCost="431.000474" Rows="3.000000" Width="9"/>
                                 </dxl:Properties>
                                 <dxl:ProjList>
+                                  <dxl:ProjElem ColId="17" Alias="ColRef_0017">
+                                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                                  </dxl:ProjElem>
                                   <dxl:ProjElem ColId="8" Alias="cidr">
                                     <dxl:Ident ColId="8" ColName="cidr" TypeMdid="0.869.1.0"/>
                                   </dxl:ProjElem>
                                 </dxl:ProjList>
                                 <dxl:Filter/>
+                                <dxl:OneTimeFilter/>
                                 <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                                   <dxl:Properties>
                                     <dxl:Cost StartupCost="0" TotalCost="431.000465" Rows="3.000000" Width="8"/>
@@ -682,8 +685,8 @@ SELECT 1 FROM inverse WHERE NOT (cidr <<= ANY(SELECT * FROM inverse));
                                     </dxl:TableDescriptor>
                                   </dxl:TableScan>
                                 </dxl:BroadcastMotion>
-                              </dxl:Materialize>
-                            </dxl:Result>
+                              </dxl:Result>
+                            </dxl:Materialize>
                           </dxl:NestedLoopJoin>
                         </dxl:Result>
                       </dxl:Sort>

--- a/src/backend/gporca/data/dxl/minidump/CorrelatedAntiSemiJoin-True.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CorrelatedAntiSemiJoin-True.mdp
@@ -864,10 +864,10 @@ SELECT pn, cn, vn FROM sale s WHERE NOT EXISTS (SELECT * FROM customer WHERE NOT
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="4">
+    <dxl:Plan Id="0" SpaceSize="8">
       <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="2155.027572" Rows="12.000000" Width="12"/>
+          <dxl:Cost StartupCost="0" TotalCost="2155.027601" Rows="12.000000" Width="12"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="2" Alias="pn">
@@ -886,19 +886,87 @@ SELECT pn, cn, vn FROM sale s WHERE NOT EXISTS (SELECT * FROM customer WHERE NOT
             <dxl:ParamList>
               <dxl:Param ColId="2" ColName="pn" TypeMdid="0.23.1.0"/>
             </dxl:ParamList>
-            <dxl:NestedLoopJoin JoinType="LeftAntiSemiJoin" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+            <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1293.025814" Rows="4.000000" Width="4"/>
+                <dxl:Cost StartupCost="0" TotalCost="1293.025842" Rows="4.000000" Width="4"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="13" Alias="cn">
                   <dxl:Ident ColId="13" ColName="cn" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:JoinFilter>
-                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-              </dxl:JoinFilter>
+              <dxl:Filter>
+                <dxl:SubPlan TypeMdid="0.16.1.0" SubPlanType="NotExistsSubPlan">
+                  <dxl:TestExpr/>
+                  <dxl:ParamList>
+                    <dxl:Param ColId="2" ColName="pn" TypeMdid="0.23.1.0"/>
+                  </dxl:ParamList>
+                  <dxl:Result>
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.025576" Rows="1.000000" Width="4"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="23" Alias="pn">
+                        <dxl:Ident ColId="23" ColName="pn" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter>
+                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                        <dxl:Ident ColId="23" ColName="pn" TypeMdid="0.23.1.0"/>
+                        <dxl:Ident ColId="2" ColName="pn" TypeMdid="0.23.1.0"/>
+                      </dxl:Comparison>
+                    </dxl:Filter>
+                    <dxl:OneTimeFilter/>
+                    <dxl:Materialize Eager="true">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000309" Rows="8.000000" Width="4"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="23" Alias="pn">
+                          <dxl:Ident ColId="23" ColName="pn" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000277" Rows="8.000000" Width="4"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="23" Alias="pn">
+                            <dxl:Ident ColId="23" ColName="pn" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:SortingColumnList/>
+                        <dxl:TableScan>
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000103" Rows="8.000000" Width="4"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="23" Alias="pn">
+                              <dxl:Ident ColId="23" ColName="pn" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:TableDescriptor Mdid="6.29191945.1.1" TableName="product">
+                            <dxl:Columns>
+                              <dxl:Column ColId="23" Attno="1" ColName="pn" TypeMdid="0.23.1.0"/>
+                              <dxl:Column ColId="26" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                              <dxl:Column ColId="27" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                              <dxl:Column ColId="28" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                              <dxl:Column ColId="29" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                              <dxl:Column ColId="30" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                              <dxl:Column ColId="31" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                              <dxl:Column ColId="32" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                            </dxl:Columns>
+                          </dxl:TableDescriptor>
+                        </dxl:TableScan>
+                      </dxl:GatherMotion>
+                    </dxl:Materialize>
+                  </dxl:Result>
+                </dxl:SubPlan>
+              </dxl:Filter>
+              <dxl:OneTimeFilter/>
               <dxl:Materialize Eager="true">
                 <dxl:Properties>
                   <dxl:Cost StartupCost="0" TotalCost="431.000162" Rows="4.000000" Width="4"/>
@@ -945,66 +1013,7 @@ SELECT pn, cn, vn FROM sale s WHERE NOT EXISTS (SELECT * FROM customer WHERE NOT
                   </dxl:TableScan>
                 </dxl:GatherMotion>
               </dxl:Materialize>
-              <dxl:Result>
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.025576" Rows="1.000000" Width="1"/>
-                </dxl:Properties>
-                <dxl:ProjList/>
-                <dxl:Filter>
-                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                    <dxl:Ident ColId="23" ColName="pn" TypeMdid="0.23.1.0"/>
-                    <dxl:Ident ColId="2" ColName="pn" TypeMdid="0.23.1.0"/>
-                  </dxl:Comparison>
-                </dxl:Filter>
-                <dxl:OneTimeFilter/>
-                <dxl:Materialize Eager="true">
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000309" Rows="8.000000" Width="4"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="23" Alias="pn">
-                      <dxl:Ident ColId="23" ColName="pn" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000277" Rows="8.000000" Width="4"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="23" Alias="pn">
-                        <dxl:Ident ColId="23" ColName="pn" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:Filter/>
-                    <dxl:SortingColumnList/>
-                    <dxl:TableScan>
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000103" Rows="8.000000" Width="4"/>
-                      </dxl:Properties>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="23" Alias="pn">
-                          <dxl:Ident ColId="23" ColName="pn" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
-                      <dxl:Filter/>
-                      <dxl:TableDescriptor Mdid="6.29191945.1.1" TableName="product">
-                        <dxl:Columns>
-                          <dxl:Column ColId="23" Attno="1" ColName="pn" TypeMdid="0.23.1.0"/>
-                          <dxl:Column ColId="26" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                          <dxl:Column ColId="27" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                          <dxl:Column ColId="28" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                          <dxl:Column ColId="29" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                          <dxl:Column ColId="30" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                          <dxl:Column ColId="31" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                          <dxl:Column ColId="32" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                        </dxl:Columns>
-                      </dxl:TableDescriptor>
-                    </dxl:TableScan>
-                  </dxl:GatherMotion>
-                </dxl:Materialize>
-              </dxl:Result>
-            </dxl:NestedLoopJoin>
+            </dxl:Result>
           </dxl:SubPlan>
         </dxl:Filter>
         <dxl:OneTimeFilter/>

--- a/src/backend/gporca/data/dxl/minidump/CorrelatedIN-LeftSemiJoin-Limit.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CorrelatedIN-LeftSemiJoin-Limit.mdp
@@ -304,7 +304,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="192">
+    <dxl:Plan Id="0" SpaceSize="188">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1324032.151091" Rows="1.000000" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/CorrelatedIN-LeftSemiJoin-True.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CorrelatedIN-LeftSemiJoin-True.mdp
@@ -700,7 +700,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="86">
+    <dxl:Plan Id="0" SpaceSize="82">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1324039.870686" Rows="1.000000" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/CorrelatedLeftSemiNLJoinWithLimit.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CorrelatedLeftSemiNLJoinWithLimit.mdp
@@ -315,7 +315,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="88">
+    <dxl:Plan Id="0" SpaceSize="84">
       <dxl:Result>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1324032.157856" Rows="1.000000" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/CorrelatedSemiJoin-True.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CorrelatedSemiJoin-True.mdp
@@ -859,10 +859,10 @@ SELECT pn, cn, vn FROM sale s WHERE EXISTS (SELECT * FROM customer WHERE EXISTS 
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="4">
+    <dxl:Plan Id="0" SpaceSize="8">
       <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="2155.027572" Rows="12.000000" Width="12"/>
+          <dxl:Cost StartupCost="0" TotalCost="2155.027601" Rows="12.000000" Width="12"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="2" Alias="pn">
@@ -881,19 +881,87 @@ SELECT pn, cn, vn FROM sale s WHERE EXISTS (SELECT * FROM customer WHERE EXISTS 
             <dxl:ParamList>
               <dxl:Param ColId="2" ColName="pn" TypeMdid="0.23.1.0"/>
             </dxl:ParamList>
-            <dxl:NestedLoopJoin JoinType="In" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+            <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1293.025814" Rows="4.000000" Width="4"/>
+                <dxl:Cost StartupCost="0" TotalCost="1293.025842" Rows="4.000000" Width="4"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="13" Alias="cn">
                   <dxl:Ident ColId="13" ColName="cn" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:JoinFilter>
-                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-              </dxl:JoinFilter>
+              <dxl:Filter>
+                <dxl:SubPlan TypeMdid="0.16.1.0" SubPlanType="ExistsSubPlan">
+                  <dxl:TestExpr/>
+                  <dxl:ParamList>
+                    <dxl:Param ColId="2" ColName="pn" TypeMdid="0.23.1.0"/>
+                  </dxl:ParamList>
+                  <dxl:Result>
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.025576" Rows="1.000000" Width="4"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="23" Alias="pn">
+                        <dxl:Ident ColId="23" ColName="pn" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter>
+                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                        <dxl:Ident ColId="23" ColName="pn" TypeMdid="0.23.1.0"/>
+                        <dxl:Ident ColId="2" ColName="pn" TypeMdid="0.23.1.0"/>
+                      </dxl:Comparison>
+                    </dxl:Filter>
+                    <dxl:OneTimeFilter/>
+                    <dxl:Materialize Eager="true">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000309" Rows="8.000000" Width="4"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="23" Alias="pn">
+                          <dxl:Ident ColId="23" ColName="pn" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000277" Rows="8.000000" Width="4"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="23" Alias="pn">
+                            <dxl:Ident ColId="23" ColName="pn" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:SortingColumnList/>
+                        <dxl:TableScan>
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000103" Rows="8.000000" Width="4"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="23" Alias="pn">
+                              <dxl:Ident ColId="23" ColName="pn" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:TableDescriptor Mdid="6.29191945.1.1" TableName="product">
+                            <dxl:Columns>
+                              <dxl:Column ColId="23" Attno="1" ColName="pn" TypeMdid="0.23.1.0"/>
+                              <dxl:Column ColId="26" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                              <dxl:Column ColId="27" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                              <dxl:Column ColId="28" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                              <dxl:Column ColId="29" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                              <dxl:Column ColId="30" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                              <dxl:Column ColId="31" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                              <dxl:Column ColId="32" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                            </dxl:Columns>
+                          </dxl:TableDescriptor>
+                        </dxl:TableScan>
+                      </dxl:GatherMotion>
+                    </dxl:Materialize>
+                  </dxl:Result>
+                </dxl:SubPlan>
+              </dxl:Filter>
+              <dxl:OneTimeFilter/>
               <dxl:Materialize Eager="true">
                 <dxl:Properties>
                   <dxl:Cost StartupCost="0" TotalCost="431.000162" Rows="4.000000" Width="4"/>
@@ -940,66 +1008,7 @@ SELECT pn, cn, vn FROM sale s WHERE EXISTS (SELECT * FROM customer WHERE EXISTS 
                   </dxl:TableScan>
                 </dxl:GatherMotion>
               </dxl:Materialize>
-              <dxl:Result>
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.025576" Rows="1.000000" Width="1"/>
-                </dxl:Properties>
-                <dxl:ProjList/>
-                <dxl:Filter>
-                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                    <dxl:Ident ColId="23" ColName="pn" TypeMdid="0.23.1.0"/>
-                    <dxl:Ident ColId="2" ColName="pn" TypeMdid="0.23.1.0"/>
-                  </dxl:Comparison>
-                </dxl:Filter>
-                <dxl:OneTimeFilter/>
-                <dxl:Materialize Eager="true">
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000309" Rows="8.000000" Width="4"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="23" Alias="pn">
-                      <dxl:Ident ColId="23" ColName="pn" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000277" Rows="8.000000" Width="4"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="23" Alias="pn">
-                        <dxl:Ident ColId="23" ColName="pn" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:Filter/>
-                    <dxl:SortingColumnList/>
-                    <dxl:TableScan>
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000103" Rows="8.000000" Width="4"/>
-                      </dxl:Properties>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="23" Alias="pn">
-                          <dxl:Ident ColId="23" ColName="pn" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
-                      <dxl:Filter/>
-                      <dxl:TableDescriptor Mdid="6.29191945.1.1" TableName="product">
-                        <dxl:Columns>
-                          <dxl:Column ColId="23" Attno="1" ColName="pn" TypeMdid="0.23.1.0"/>
-                          <dxl:Column ColId="26" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                          <dxl:Column ColId="27" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                          <dxl:Column ColId="28" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                          <dxl:Column ColId="29" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                          <dxl:Column ColId="30" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                          <dxl:Column ColId="31" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                          <dxl:Column ColId="32" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                        </dxl:Columns>
-                      </dxl:TableDescriptor>
-                    </dxl:TableScan>
-                  </dxl:GatherMotion>
-                </dxl:Materialize>
-              </dxl:Result>
-            </dxl:NestedLoopJoin>
+            </dxl:Result>
           </dxl:SubPlan>
         </dxl:Filter>
         <dxl:OneTimeFilter/>

--- a/src/backend/gporca/data/dxl/minidump/Correlation-With-Casting-1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Correlation-With-Casting-1.mdp
@@ -431,7 +431,7 @@ AND u_folio = (SELECT max(u_folio)  FROM q68t792_temp c WHERE a.u_vtgnr = c.u_vt
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="18507">
+    <dxl:Plan Id="0" SpaceSize="12243">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="2155.684179" Rows="70.000000" Width="10"/>

--- a/src/backend/gporca/data/dxl/minidump/Correlation-With-Casting-1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Correlation-With-Casting-1.mdp
@@ -431,7 +431,7 @@ AND u_folio = (SELECT max(u_folio)  FROM q68t792_temp c WHERE a.u_vtgnr = c.u_vt
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="12243">
+    <dxl:Plan Id="0" SpaceSize="13683">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="2155.684179" Rows="70.000000" Width="10"/>

--- a/src/backend/gporca/data/dxl/minidump/DynamicBitmapIndexScan.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicBitmapIndexScan.mdp
@@ -685,7 +685,7 @@ see sql/DynamicBitmapIndexScan.sql
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="64">
+    <dxl:Plan Id="0" SpaceSize="63">
       <dxl:GatherMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="6763.875569" Rows="1.000000" Width="9"/>

--- a/src/backend/gporca/data/dxl/minidump/ExistentialSubquriesInsideScalarExpression.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ExistentialSubquriesInsideScalarExpression.mdp
@@ -438,7 +438,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="63">
+    <dxl:Plan Id="0" SpaceSize="53">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1356691750.457889" Rows="1.600000" Width="13"/>

--- a/src/backend/gporca/data/dxl/minidump/ExistsSubqInsideExpr.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ExistsSubqInsideExpr.mdp
@@ -334,7 +334,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="6">
+    <dxl:Plan Id="0" SpaceSize="5">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1324032.404069" Rows="2.250000" Width="13"/>

--- a/src/backend/gporca/data/dxl/minidump/ExtractPredicateFromDisjWithComputedColumns.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ExtractPredicateFromDisjWithComputedColumns.mdp
@@ -456,7 +456,7 @@ where (cd.dyear = 2001 and s.tickets_cnt &gt; 3) or (cd.dmoy = 4 and s.tickets_c
         </dxl:LogicalJoin>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="3190">
+    <dxl:Plan Id="0" SpaceSize="3310">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.002852" Rows="1.000000" Width="64"/>

--- a/src/backend/gporca/data/dxl/minidump/InSubqWithPrjListOuterRefNoInnerRefColumnIn.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InSubqWithPrjListOuterRefNoInnerRefColumnIn.mdp
@@ -620,7 +620,7 @@ EXPLAIN SELECT * FROM foo WHERE a IN (SELECT b+1 FROM bar);
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="86">
+    <dxl:Plan Id="0" SpaceSize="82">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.005496" Rows="40.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/InSubqWithPrjListOuterRefNoInnerRefColumnPlusConstIn.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InSubqWithPrjListOuterRefNoInnerRefColumnPlusConstIn.mdp
@@ -623,7 +623,7 @@ EXPLAIN SELECT * FROM foo WHERE 1+a IN (SELECT b+1 FROM bar);
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="86">
+    <dxl:Plan Id="0" SpaceSize="82">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.005496" Rows="40.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/InSubqWithPrjListOuterRefNoInnerRefConstIn.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InSubqWithPrjListOuterRefNoInnerRefConstIn.mdp
@@ -617,7 +617,7 @@ SELECT * FROM foo WHERE 2 IN (SELECT b+1 FROM bar);
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="86">
+    <dxl:Plan Id="0" SpaceSize="82">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.004400" Rows="40.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/Index-Join-With-Subquery-In-Pred.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Index-Join-With-Subquery-In-Pred.mdp
@@ -347,7 +347,7 @@ Optimizer: Pivotal Optimizer (GPORCA)
         </dxl:LogicalJoin>
       </dxl:LogicalProject>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="604">
+    <dxl:Plan Id="0" SpaceSize="560">
       <dxl:Result>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="888832.304151" Rows="1.000000" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/Index-Join-With-Subquery-In-Pred.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Index-Join-With-Subquery-In-Pred.mdp
@@ -347,7 +347,7 @@ Optimizer: Pivotal Optimizer (GPORCA)
         </dxl:LogicalJoin>
       </dxl:LogicalProject>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="460">
+    <dxl:Plan Id="0" SpaceSize="604">
       <dxl:Result>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="888832.304151" Rows="1.000000" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-No-Motion-Below-Join.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-No-Motion-Below-Join.mdp
@@ -397,7 +397,7 @@ Table X (int i, int j) is distributed by i, column j has index
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="21">
+    <dxl:Plan Id="0" SpaceSize="18">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="6.008187" Rows="33.333333" Width="12"/>

--- a/src/backend/gporca/data/dxl/minidump/IndexNLJ-IndexGet-OuterRef.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexNLJ-IndexGet-OuterRef.mdp
@@ -1474,7 +1474,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="10">
+    <dxl:Plan Id="0" SpaceSize="11">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="888838.913054" Rows="42.000000" Width="24"/>

--- a/src/backend/gporca/data/dxl/minidump/Join-Varchar-Equality.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Join-Varchar-Equality.mdp
@@ -4276,7 +4276,7 @@
                           </dxl:Cast>
                         </dxl:Comparison>
                       </dxl:HashCondList>
-                      <dxl:DynamicTableScan PartIndexId="1" SelectorIds="10">
+                      <dxl:DynamicTableScan SelectorIds="10">
                         <dxl:Properties>
                           <dxl:Cost StartupCost="0" TotalCost="96421.988429" Rows="5288759693.059181" Width="26"/>
                         </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/Join-Varchar-Equality.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Join-Varchar-Equality.mdp
@@ -4044,7 +4044,7 @@
     <dxl:Plan Id="0" SpaceSize="80990">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="3422679.529071" Rows="19136.250000" Width="31"/>
+          <dxl:Cost StartupCost="0" TotalCost="3422679.547303" Rows="19136.250000" Width="31"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="27" Alias="year">
@@ -4064,7 +4064,7 @@
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="3422676.865496" Rows="19136.250000" Width="31"/>
+            <dxl:Cost StartupCost="0" TotalCost="3422676.883729" Rows="19136.250000" Width="31"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="27" Alias="year">
@@ -4084,7 +4084,7 @@
           <dxl:OneTimeFilter/>
           <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="3422676.865496" Rows="19136.250000" Width="31"/>
+              <dxl:Cost StartupCost="0" TotalCost="3422676.883729" Rows="19136.250000" Width="31"/>
             </dxl:Properties>
             <dxl:GroupingColumns>
               <dxl:GroupingColumn ColId="27"/>
@@ -4119,7 +4119,7 @@
             <dxl:Filter/>
             <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="3422671.973515" Rows="19136.250000" Width="34"/>
+                <dxl:Cost StartupCost="0" TotalCost="3422671.991747" Rows="19136.250000" Width="34"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="27" Alias="year">
@@ -4156,7 +4156,7 @@
               </dxl:HashExprList>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="3422670.955275" Rows="19136.250000" Width="34"/>
+                  <dxl:Cost StartupCost="0" TotalCost="3422670.973507" Rows="19136.250000" Width="34"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="27" Alias="year">
@@ -4179,7 +4179,7 @@
                 <dxl:OneTimeFilter/>
                 <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="3422670.955275" Rows="19136.250000" Width="34"/>
+                    <dxl:Cost StartupCost="0" TotalCost="3422670.973507" Rows="19136.250000" Width="34"/>
                   </dxl:Properties>
                   <dxl:GroupingColumns>
                     <dxl:GroupingColumn ColId="27"/>
@@ -4214,7 +4214,7 @@
                   <dxl:Filter/>
                   <dxl:HashJoin JoinType="Inner">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="2087869.893271" Rows="5288759693.059181" Width="30"/>
+                      <dxl:Cost StartupCost="0" TotalCost="2087869.911503" Rows="5288759693.059181" Width="30"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="6" Alias="sales">
@@ -4352,7 +4352,7 @@
                     </dxl:HashJoin>
                     <dxl:PartitionSelector RelationMdid="6.328475.1.1" SelectorId="10" ScanId="1" Partitions="0,1,2,3">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="1552.578227" Rows="607744.000000" Width="30"/>
+                        <dxl:Cost StartupCost="0" TotalCost="1552.596459" Rows="607744.000000" Width="30"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="26" Alias="ymd">
@@ -4379,7 +4379,7 @@
                       </dxl:PartFilterExpr>
                       <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="1552.578227" Rows="607744.000000" Width="30"/>
+                          <dxl:Cost StartupCost="0" TotalCost="1552.596459" Rows="607744.000000" Width="30"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="26" Alias="ymd">
@@ -4402,7 +4402,7 @@
                         <dxl:SortingColumnList/>
                         <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="1313.962739" Rows="303872.000000" Width="30"/>
+                            <dxl:Cost StartupCost="0" TotalCost="1313.980971" Rows="303872.000000" Width="30"/>
                           </dxl:Properties>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="26" Alias="ymd">
@@ -4467,9 +4467,9 @@
                               </dxl:TableDescriptor>
                             </dxl:TableScan>
                           </dxl:BroadcastMotion>
-                          <dxl:TableScan>
+                          <dxl:Materialize Eager="false">
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="431.551944" Rows="3038.720000" Width="12"/>
+                              <dxl:Cost StartupCost="0" TotalCost="431.570177" Rows="3038.720000" Width="12"/>
                             </dxl:Properties>
                             <dxl:ProjList>
                               <dxl:ProjElem ColId="26" Alias="ymd">
@@ -4482,34 +4482,51 @@
                                 <dxl:Ident ColId="29" ColName="month" TypeMdid="0.1042.1.0"/>
                               </dxl:ProjElem>
                             </dxl:ProjList>
-                            <dxl:Filter>
-                              <dxl:And>
-                                <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.1061.1.0">
-                                  <dxl:Ident ColId="28" ColName="ym" TypeMdid="0.1042.1.0"/>
-                                  <dxl:ConstValue TypeMdid="0.1042.1.0" Value="AAAACjE5ODYwMQ==" LintValue="266216246"/>
-                                </dxl:Comparison>
-                                <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.1059.1.0">
+                            <dxl:Filter/>
+                            <dxl:TableScan>
+                              <dxl:Properties>
+                                <dxl:Cost StartupCost="0" TotalCost="431.551944" Rows="3038.720000" Width="12"/>
+                              </dxl:Properties>
+                              <dxl:ProjList>
+                                <dxl:ProjElem ColId="26" Alias="ymd">
+                                  <dxl:Ident ColId="26" ColName="ymd" TypeMdid="0.1082.1.0"/>
+                                </dxl:ProjElem>
+                                <dxl:ProjElem ColId="27" Alias="year">
                                   <dxl:Ident ColId="27" ColName="year" TypeMdid="0.1042.1.0"/>
-                                  <dxl:ConstValue TypeMdid="0.1042.1.0" Value="AAAACDE5OTc=" LintValue="123134828"/>
-                                </dxl:Comparison>
-                              </dxl:And>
-                            </dxl:Filter>
-                            <dxl:TableDescriptor Mdid="6.328293.1.1" TableName="calendar">
-                              <dxl:Columns>
-                                <dxl:Column ColId="26" Attno="1" ColName="ymd" TypeMdid="0.1082.1.0"/>
-                                <dxl:Column ColId="27" Attno="2" ColName="year" TypeMdid="0.1042.1.0" ColWidth="4"/>
-                                <dxl:Column ColId="28" Attno="3" ColName="ym" TypeMdid="0.1042.1.0" ColWidth="7"/>
-                                <dxl:Column ColId="29" Attno="4" ColName="month" TypeMdid="0.1042.1.0" ColWidth="2"/>
-                                <dxl:Column ColId="31" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                                <dxl:Column ColId="32" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                                <dxl:Column ColId="33" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                                <dxl:Column ColId="34" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                                <dxl:Column ColId="35" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                                <dxl:Column ColId="36" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                                <dxl:Column ColId="37" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                              </dxl:Columns>
-                            </dxl:TableDescriptor>
-                          </dxl:TableScan>
+                                </dxl:ProjElem>
+                                <dxl:ProjElem ColId="29" Alias="month">
+                                  <dxl:Ident ColId="29" ColName="month" TypeMdid="0.1042.1.0"/>
+                                </dxl:ProjElem>
+                              </dxl:ProjList>
+                              <dxl:Filter>
+                                <dxl:And>
+                                  <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.1061.1.0">
+                                    <dxl:Ident ColId="28" ColName="ym" TypeMdid="0.1042.1.0"/>
+                                    <dxl:ConstValue TypeMdid="0.1042.1.0" Value="AAAACjE5ODYwMQ==" LintValue="266216246"/>
+                                  </dxl:Comparison>
+                                  <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.1059.1.0">
+                                    <dxl:Ident ColId="27" ColName="year" TypeMdid="0.1042.1.0"/>
+                                    <dxl:ConstValue TypeMdid="0.1042.1.0" Value="AAAACDE5OTc=" LintValue="123134828"/>
+                                  </dxl:Comparison>
+                                </dxl:And>
+                              </dxl:Filter>
+                              <dxl:TableDescriptor Mdid="6.328293.1.1" TableName="calendar">
+                                <dxl:Columns>
+                                  <dxl:Column ColId="26" Attno="1" ColName="ymd" TypeMdid="0.1082.1.0"/>
+                                  <dxl:Column ColId="27" Attno="2" ColName="year" TypeMdid="0.1042.1.0" ColWidth="4"/>
+                                  <dxl:Column ColId="28" Attno="3" ColName="ym" TypeMdid="0.1042.1.0" ColWidth="7"/>
+                                  <dxl:Column ColId="29" Attno="4" ColName="month" TypeMdid="0.1042.1.0" ColWidth="2"/>
+                                  <dxl:Column ColId="31" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                  <dxl:Column ColId="32" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                                  <dxl:Column ColId="33" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                                  <dxl:Column ColId="34" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                                  <dxl:Column ColId="35" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                                  <dxl:Column ColId="36" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                  <dxl:Column ColId="37" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                </dxl:Columns>
+                              </dxl:TableDescriptor>
+                            </dxl:TableScan>
+                          </dxl:Materialize>
                         </dxl:NestedLoopJoin>
                       </dxl:BroadcastMotion>
                     </dxl:PartitionSelector>

--- a/src/backend/gporca/data/dxl/minidump/Join-WinFunc-Preds.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Join-WinFunc-Preds.mdp
@@ -536,7 +536,7 @@ where e < 10;
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="78">
+    <dxl:Plan Id="0" SpaceSize="64">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="8620.170543" Rows="324.000000" Width="28"/>

--- a/src/backend/gporca/data/dxl/minidump/Join-With-Subq-Preds-1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Join-With-Subq-Preds-1.mdp
@@ -781,7 +781,7 @@
         </dxl:Or>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="9720">
+    <dxl:Plan Id="0" SpaceSize="7432">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="10867.964640" Rows="10000000.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/Join-With-Subq-Preds-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Join-With-Subq-Preds-2.mdp
@@ -807,7 +807,7 @@
         </dxl:Or>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="9772576">
+    <dxl:Plan Id="0" SpaceSize="7129936">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="9312.745178" Rows="520834.333333" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/LeftJoin-DPv2-With-Select.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LeftJoin-DPv2-With-Select.mdp
@@ -345,7 +345,7 @@
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="20">
+    <dxl:Plan Id="0" SpaceSize="18">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1765376.810995" Rows="1.000000" Width="24"/>

--- a/src/backend/gporca/data/dxl/minidump/MotionHazard-NoMaterializeHashAggUnderResult.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MotionHazard-NoMaterializeHashAggUnderResult.mdp
@@ -444,7 +444,7 @@ explain select f.k, f.subq from (select tab3.k, (select tab2.k from tab2 where t
         <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="150">
+    <dxl:Plan Id="0" SpaceSize="90">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="199109.213873" Rows="9846.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/MultiLevel-CorrelatedExec.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MultiLevel-CorrelatedExec.mdp
@@ -761,7 +761,7 @@
                   <dxl:ProjElem ColId="28" Alias="sum">
                     <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="">
                       <dxl:ValuesList ParamType="aggargs">
-                      <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
+                        <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
                       </dxl:ValuesList>
                       <dxl:ValuesList ParamType="aggdirectargs"/>
                       <dxl:ValuesList ParamType="aggorder"/>
@@ -817,7 +817,7 @@
                         <dxl:ProjElem ColId="27" Alias="sum">
                           <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="">
                             <dxl:ValuesList ParamType="aggargs">
-                            <dxl:Ident ColId="18" ColName="i" TypeMdid="0.23.1.0"/>
+                              <dxl:Ident ColId="18" ColName="i" TypeMdid="0.23.1.0"/>
                             </dxl:ValuesList>
                             <dxl:ValuesList ParamType="aggdirectargs"/>
                             <dxl:ValuesList ParamType="aggorder"/>

--- a/src/backend/gporca/data/dxl/minidump/MultiLevel-CorrelatedExec.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MultiLevel-CorrelatedExec.mdp
@@ -729,10 +729,10 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="48">
+    <dxl:Plan Id="0" SpaceSize="54">
       <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1818691.526596" Rows="1000.000000" Width="12"/>
+          <dxl:Cost StartupCost="0" TotalCost="1858727.522596" Rows="1000.000000" Width="12"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="i">
@@ -754,7 +754,7 @@
               </dxl:ParamList>
               <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1817829.141818" Rows="1.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1857865.137818" Rows="1.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:GroupingColumns/>
                 <dxl:ProjList>
@@ -772,7 +772,7 @@
                 <dxl:Filter/>
                 <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1817829.141369" Rows="1001.000000" Width="4"/>
+                    <dxl:Cost StartupCost="0" TotalCost="1857865.137369" Rows="1001.000000" Width="4"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="9" Alias="i">
@@ -788,7 +788,7 @@
                   <dxl:OneTimeFilter/>
                   <dxl:Result>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="1817829.075503" Rows="1001.000000" Width="4"/>
+                      <dxl:Cost StartupCost="0" TotalCost="1857865.071503" Rows="1001.000000" Width="4"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="9" Alias="i">
@@ -806,7 +806,7 @@
                     <dxl:OneTimeFilter/>
                     <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="1817763.209703" Rows="1001.000000" Width="12"/>
+                        <dxl:Cost StartupCost="0" TotalCost="1857799.205703" Rows="1001.000000" Width="12"/>
                       </dxl:Properties>
                       <dxl:GroupingColumns>
                         <dxl:GroupingColumn ColId="9"/>
@@ -837,7 +837,7 @@
                       <dxl:Filter/>
                       <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="1817583.040983" Rows="10008999.000000" Width="18"/>
+                          <dxl:Cost StartupCost="0" TotalCost="1857619.036983" Rows="10008999.000000" Width="18"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="9" Alias="i">
@@ -949,35 +949,35 @@
                             </dxl:Sort>
                           </dxl:GatherMotion>
                         </dxl:Materialize>
-                        <dxl:Result>
+                        <dxl:Materialize Eager="true">
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="659089.361300" Rows="9999.000000" Width="4"/>
+                            <dxl:Cost StartupCost="0" TotalCost="699125.357300" Rows="9999.000000" Width="4"/>
                           </dxl:Properties>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="18" Alias="i">
                               <dxl:Ident ColId="18" ColName="i" TypeMdid="0.23.1.0"/>
                             </dxl:ProjElem>
                           </dxl:ProjList>
-                          <dxl:Filter>
-                            <dxl:Comparison ComparisonOperator="&lt;&gt;" OperatorMdid="0.518.1.0">
-                              <dxl:Ident ColId="18" ColName="i" TypeMdid="0.23.1.0"/>
-                              <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-                            </dxl:Comparison>
-                          </dxl:Filter>
-                          <dxl:OneTimeFilter/>
-                          <dxl:Materialize Eager="true">
+                          <dxl:Filter/>
+                          <dxl:Result>
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="431.361300" Rows="10000.000000" Width="4"/>
+                              <dxl:Cost StartupCost="0" TotalCost="659089.361300" Rows="9999.000000" Width="4"/>
                             </dxl:Properties>
                             <dxl:ProjList>
                               <dxl:ProjElem ColId="18" Alias="i">
                                 <dxl:Ident ColId="18" ColName="i" TypeMdid="0.23.1.0"/>
                               </dxl:ProjElem>
                             </dxl:ProjList>
-                            <dxl:Filter/>
-                            <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+                            <dxl:Filter>
+                              <dxl:Comparison ComparisonOperator="&lt;&gt;" OperatorMdid="0.518.1.0">
+                                <dxl:Ident ColId="18" ColName="i" TypeMdid="0.23.1.0"/>
+                                <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+                              </dxl:Comparison>
+                            </dxl:Filter>
+                            <dxl:OneTimeFilter/>
+                            <dxl:Materialize Eager="false">
                               <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="431.321300" Rows="10000.000000" Width="4"/>
+                                <dxl:Cost StartupCost="0" TotalCost="431.361300" Rows="10000.000000" Width="4"/>
                               </dxl:Properties>
                               <dxl:ProjList>
                                 <dxl:ProjElem ColId="18" Alias="i">
@@ -985,10 +985,9 @@
                                 </dxl:ProjElem>
                               </dxl:ProjList>
                               <dxl:Filter/>
-                              <dxl:SortingColumnList/>
-                              <dxl:TableScan>
+                              <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
                                 <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="431.104500" Rows="10000.000000" Width="4"/>
+                                  <dxl:Cost StartupCost="0" TotalCost="431.321300" Rows="10000.000000" Width="4"/>
                                 </dxl:Properties>
                                 <dxl:ProjList>
                                   <dxl:ProjElem ColId="18" Alias="i">
@@ -996,22 +995,34 @@
                                   </dxl:ProjElem>
                                 </dxl:ProjList>
                                 <dxl:Filter/>
-                                <dxl:TableDescriptor Mdid="6.761868.1.1" TableName="z">
-                                  <dxl:Columns>
-                                    <dxl:Column ColId="18" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
-                                    <dxl:Column ColId="20" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                                    <dxl:Column ColId="21" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                                    <dxl:Column ColId="22" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                                    <dxl:Column ColId="23" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                                    <dxl:Column ColId="24" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                                    <dxl:Column ColId="25" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                                    <dxl:Column ColId="26" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                                  </dxl:Columns>
-                                </dxl:TableDescriptor>
-                              </dxl:TableScan>
-                            </dxl:GatherMotion>
-                          </dxl:Materialize>
-                        </dxl:Result>
+                                <dxl:SortingColumnList/>
+                                <dxl:TableScan>
+                                  <dxl:Properties>
+                                    <dxl:Cost StartupCost="0" TotalCost="431.104500" Rows="10000.000000" Width="4"/>
+                                  </dxl:Properties>
+                                  <dxl:ProjList>
+                                    <dxl:ProjElem ColId="18" Alias="i">
+                                      <dxl:Ident ColId="18" ColName="i" TypeMdid="0.23.1.0"/>
+                                    </dxl:ProjElem>
+                                  </dxl:ProjList>
+                                  <dxl:Filter/>
+                                  <dxl:TableDescriptor Mdid="6.761868.1.1" TableName="z">
+                                    <dxl:Columns>
+                                      <dxl:Column ColId="18" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
+                                      <dxl:Column ColId="20" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                      <dxl:Column ColId="21" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                                      <dxl:Column ColId="22" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                                      <dxl:Column ColId="23" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                                      <dxl:Column ColId="24" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                                      <dxl:Column ColId="25" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                      <dxl:Column ColId="26" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                    </dxl:Columns>
+                                  </dxl:TableDescriptor>
+                                </dxl:TableScan>
+                              </dxl:GatherMotion>
+                            </dxl:Materialize>
+                          </dxl:Result>
+                        </dxl:Materialize>
                       </dxl:NestedLoopJoin>
                     </dxl:Aggregate>
                   </dxl:Result>

--- a/src/backend/gporca/data/dxl/minidump/MultipleSubqueriesInSelectClause.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MultipleSubqueriesInSelectClause.mdp
@@ -1177,7 +1177,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalProject>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="70609">
+    <dxl:Plan Id="0" SpaceSize="70119">
       <dxl:Result>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="9309.074116" Rows="3000000.000000" Width="32"/>

--- a/src/backend/gporca/data/dxl/minidump/MultipleSubqueriesInSelectClause.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MultipleSubqueriesInSelectClause.mdp
@@ -1177,7 +1177,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalProject>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="324625">
+    <dxl:Plan Id="0" SpaceSize="70609">
       <dxl:Result>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="9309.074116" Rows="3000000.000000" Width="32"/>

--- a/src/backend/gporca/data/dxl/minidump/NLJ-EqAllCol-No-Broadcast.mdp
+++ b/src/backend/gporca/data/dxl/minidump/NLJ-EqAllCol-No-Broadcast.mdp
@@ -307,33 +307,6 @@ explain select * from a1,b1 where a1.a = b1.a and a1.a = b1.b;
           </dxl:JoinFilter>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="8"/>
-            </dxl:Properties>
-            <dxl:ProjList>
-              <dxl:ProjElem ColId="0" Alias="a">
-                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="1" Alias="b">
-                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-            </dxl:ProjList>
-            <dxl:Filter/>
-            <dxl:TableDescriptor Mdid="6.49824.1.0" TableName="a1">
-              <dxl:Columns>
-                <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-                <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
-                <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-              </dxl:Columns>
-            </dxl:TableDescriptor>
-          </dxl:TableScan>
-          <dxl:TableScan>
-            <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.000102" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
@@ -361,6 +334,33 @@ explain select * from a1,b1 where a1.a = b1.a and a1.a = b1.b;
                 <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
                 <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
                 <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
+          <dxl:TableScan>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="8"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="0" Alias="a">
+                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="1" Alias="b">
+                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:TableDescriptor Mdid="6.49824.1.0" TableName="a1">
+              <dxl:Columns>
+                <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
               </dxl:Columns>
             </dxl:TableDescriptor>
           </dxl:TableScan>

--- a/src/backend/gporca/data/dxl/minidump/Nested-Setops-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Nested-Setops-2.mdp
@@ -595,7 +595,7 @@
         </dxl:LogicalProject>
       </dxl:Difference>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="177876000">
+    <dxl:Plan Id="0" SpaceSize="166212000">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="2592.974241" Rows="1.000000" Width="12"/>

--- a/src/backend/gporca/data/dxl/minidump/NestedInSubqWithPrjListOuterRefNoInnerRef.mdp
+++ b/src/backend/gporca/data/dxl/minidump/NestedInSubqWithPrjListOuterRefNoInnerRef.mdp
@@ -699,7 +699,7 @@ EXPLAIN SELECT * FROM foo WHERE foo.a IN (SELECT foo.b + 1 FROM (SELECT * FROM b
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="6340">
+    <dxl:Plan Id="0" SpaceSize="5912">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="2155.006784" Rows="40.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/OneLevel-CorrelatedExec.mdp
+++ b/src/backend/gporca/data/dxl/minidump/OneLevel-CorrelatedExec.mdp
@@ -737,7 +737,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="2890">
+    <dxl:Plan Id="0" SpaceSize="2585">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="14873.784860" Rows="400.000000" Width="12"/>

--- a/src/backend/gporca/data/dxl/minidump/OrderedAgg_multiple_diffcol.mdp
+++ b/src/backend/gporca/data/dxl/minidump/OrderedAgg_multiple_diffcol.mdp
@@ -445,7 +445,7 @@ EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a1), percentile_cont(0
         </dxl:LogicalGet>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="39440">
+    <dxl:Plan Id="0" SpaceSize="21200">
       <dxl:Sequence>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="2712060318.276298" Rows="1.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/OrderedAgg_multiple_samecol.mdp
+++ b/src/backend/gporca/data/dxl/minidump/OrderedAgg_multiple_samecol.mdp
@@ -430,7 +430,7 @@ EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a2), percentile_disc(0
         </dxl:LogicalGet>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="190">
+    <dxl:Plan Id="0" SpaceSize="130">
       <dxl:Sequence>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1324463.294825" Rows="1.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/OrderedAgg_multiple_samecol_difforderespec.mdp
+++ b/src/backend/gporca/data/dxl/minidump/OrderedAgg_multiple_samecol_difforderespec.mdp
@@ -441,7 +441,7 @@ EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a2), percentile_cont(0
         </dxl:LogicalGet>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="197200">
+    <dxl:Plan Id="0" SpaceSize="106000">
       <dxl:Sequence>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="2712060345.624441" Rows="1.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/OrderedAgg_single.mdp
+++ b/src/backend/gporca/data/dxl/minidump/OrderedAgg_single.mdp
@@ -391,7 +391,7 @@ EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a2) FROM foo;
         </dxl:LogicalGet>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="190">
+    <dxl:Plan Id="0" SpaceSize="130">
       <dxl:Sequence>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1324463.294809" Rows="1.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/OrderedAgg_skewed_data.mdp
+++ b/src/backend/gporca/data/dxl/minidump/OrderedAgg_skewed_data.mdp
@@ -352,7 +352,7 @@ EXPLAIN ANALYZE SELECT percentile_cont(0.25) WITHIN GROUP (ORDER BY a ASC nulls 
         </dxl:LogicalGet>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="190">
+    <dxl:Plan Id="0" SpaceSize="130">
       <dxl:Sequence>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1325244.228342" Rows="1.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/OrderedAgg_with_nonOrderedAgg.mdp
+++ b/src/backend/gporca/data/dxl/minidump/OrderedAgg_with_nonOrderedAgg.mdp
@@ -498,7 +498,7 @@ EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a1), percentile_disc(0
         </dxl:LogicalGet>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="2433960">
+    <dxl:Plan Id="0" SpaceSize="1311240">
       <dxl:Sequence>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1390608583331.788818" Rows="1.000000" Width="24"/>

--- a/src/backend/gporca/data/dxl/minidump/OrderedAgg_with_nonconst_fraction.mdp
+++ b/src/backend/gporca/data/dxl/minidump/OrderedAgg_with_nonconst_fraction.mdp
@@ -436,7 +436,7 @@ EXPLAIN SELECT percentile_cont(floor(random()*0.1)+0.5) WITHIN GROUP(ORDER BY a1
         </dxl:LogicalGet>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="38">
+    <dxl:Plan Id="0" SpaceSize="26">
       <dxl:Sequence>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1324463.268099" Rows="1.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-DPE-GroupBy.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-DPE-GroupBy.mdp
@@ -821,7 +821,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="781">
+    <dxl:Plan Id="0" SpaceSize="740">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.022548" Rows="99.900000" Width="14"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-MultiWayJoinWithDPE.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-MultiWayJoinWithDPE.mdp
@@ -4746,7 +4746,7 @@
         </dxl:LogicalJoin>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="16648">
+    <dxl:Plan Id="0" SpaceSize="16564">
       <dxl:HashJoin JoinType="Inner">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1749361.683589" Rows="321694266.492042" Width="355"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-SubqueryOuterRef.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-SubqueryOuterRef.mdp
@@ -818,7 +818,7 @@ explain select * from t1 where a = 1 and b in (select b from t2);
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="86">
+    <dxl:Plan Id="0" SpaceSize="82">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.004074" Rows="1.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/Project-With-NonScalar-Func.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Project-With-NonScalar-Func.mdp
@@ -195,7 +195,7 @@
     <dxl:Plan Id="0" SpaceSize="16">
       <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="441344.280304" Rows="1.000000" Width="1"/>
+          <dxl:Cost StartupCost="0" TotalCost="441344.272112" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="3" Alias="?column?">
@@ -209,7 +209,7 @@
         <dxl:OneTimeFilter/>
         <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="441344.280303" Rows="2.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="441344.272111" Rows="2.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="9" Alias="ColRef_0009">
@@ -234,7 +234,7 @@
           </dxl:Result>
           <dxl:Assert ErrorCode="P0003">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.000182" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="0.000174" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="9" Alias="ColRef_0009">
@@ -251,7 +251,7 @@
             </dxl:AssertConstraintList>
             <dxl:Window PartitionColumns="">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.000174" Rows="1.000000" Width="16"/>
+                <dxl:Cost StartupCost="0" TotalCost="0.000166" Rows="1.000000" Width="16"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="12" Alias="row_number">
@@ -262,44 +262,41 @@
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:Result>
+              <dxl:Materialize Eager="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="0.000174" Rows="1.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="0.000166" Rows="1.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="9" Alias="ColRef_0009">
-                    <dxl:If TypeMdid="0.20.1.0">
-                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.410.1.0">
-                        <dxl:Ident ColId="7" ColName="ColRef_0007" TypeMdid="0.20.1.0"/>
-                        <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
-                      </dxl:Comparison>
-                      <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
-                      <dxl:If TypeMdid="0.20.1.0">
-                        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.410.1.0">
-                          <dxl:Ident ColId="7" ColName="ColRef_0007" TypeMdid="0.20.1.0"/>
-                          <dxl:Ident ColId="8" ColName="ColRef_0008" TypeMdid="0.20.1.0"/>
-                        </dxl:Comparison>
-                        <dxl:ConstValue TypeMdid="0.20.1.0" Value="-1"/>
-                        <dxl:Ident ColId="7" ColName="ColRef_0007" TypeMdid="0.20.1.0"/>
-                      </dxl:If>
-                    </dxl:If>
+                    <dxl:Ident ColId="9" ColName="ColRef_0009" TypeMdid="0.20.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
-                <dxl:OneTimeFilter/>
-                <dxl:Materialize Eager="false">
+                <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="0.000166" Rows="1.000000" Width="16"/>
+                    <dxl:Cost StartupCost="0" TotalCost="0.000158" Rows="1.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:ProjList>
-                    <dxl:ProjElem ColId="7" Alias="ColRef_0007">
-                      <dxl:Ident ColId="7" ColName="ColRef_0007" TypeMdid="0.20.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="8" Alias="ColRef_0008">
-                      <dxl:Ident ColId="8" ColName="ColRef_0008" TypeMdid="0.20.1.0"/>
+                    <dxl:ProjElem ColId="9" Alias="ColRef_0009">
+                      <dxl:If TypeMdid="0.20.1.0">
+                        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.410.1.0">
+                          <dxl:Ident ColId="7" ColName="ColRef_0007" TypeMdid="0.20.1.0"/>
+                          <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+                        </dxl:Comparison>
+                        <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+                        <dxl:If TypeMdid="0.20.1.0">
+                          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.410.1.0">
+                            <dxl:Ident ColId="7" ColName="ColRef_0007" TypeMdid="0.20.1.0"/>
+                            <dxl:Ident ColId="8" ColName="ColRef_0008" TypeMdid="0.20.1.0"/>
+                          </dxl:Comparison>
+                          <dxl:ConstValue TypeMdid="0.20.1.0" Value="-1"/>
+                          <dxl:Ident ColId="7" ColName="ColRef_0007" TypeMdid="0.20.1.0"/>
+                        </dxl:If>
+                      </dxl:If>
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
+                  <dxl:OneTimeFilter/>
                   <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                     <dxl:Properties>
                       <dxl:Cost StartupCost="0" TotalCost="0.000150" Rows="1.000000" Width="16"/>
@@ -423,8 +420,8 @@
                       </dxl:Result>
                     </dxl:Aggregate>
                   </dxl:Aggregate>
-                </dxl:Materialize>
-              </dxl:Result>
+                </dxl:Result>
+              </dxl:Materialize>
               <dxl:WindowKeyList>
                 <dxl:WindowKey>
                   <dxl:SortingColumnList/>

--- a/src/backend/gporca/data/dxl/minidump/PushGbBelowJoin-NegativeCase.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PushGbBelowJoin-NegativeCase.mdp
@@ -405,10 +405,10 @@
         </dxl:LogicalSelect>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="9720">
+    <dxl:Plan Id="0" SpaceSize="8760">
       <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="3017.002573" Rows="1.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="3017.002597" Rows="1.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="20" Alias="c9596">
@@ -419,7 +419,7 @@
         <dxl:OneTimeFilter/>
         <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="3017.002573" Rows="1.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="3017.002597" Rows="1.000000" Width="4"/>
           </dxl:Properties>
           <dxl:GroupingColumns>
             <dxl:GroupingColumn ColId="20"/>
@@ -436,7 +436,7 @@
           <dxl:Filter/>
           <dxl:Sort SortDiscardDuplicates="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="3017.002562" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="3017.002586" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="17" Alias="max">
@@ -455,7 +455,7 @@
             <dxl:LimitOffset/>
             <dxl:HashJoin JoinType="Inner">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="3017.002562" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="3017.002586" Rows="1.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="17" Alias="max">
@@ -623,7 +623,7 @@
               </dxl:GatherMotion>
               <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="2586.001386" Rows="1.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="2586.001410" Rows="1.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="2" Alias="min">
@@ -637,30 +637,6 @@
                 <dxl:JoinFilter>
                   <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
                 </dxl:JoinFilter>
-                <dxl:Result>
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="20" Alias="?column?">
-                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:OneTimeFilter/>
-                  <dxl:Result>
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="19" Alias="">
-                        <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:Filter/>
-                    <dxl:OneTimeFilter/>
-                  </dxl:Result>
-                </dxl:Result>
                 <dxl:Result>
                   <dxl:Properties>
                     <dxl:Cost StartupCost="0" TotalCost="0.000186" Rows="1.000000" Width="4"/>
@@ -804,6 +780,41 @@
                     </dxl:LimitOffset>
                   </dxl:Limit>
                 </dxl:Result>
+                <dxl:Materialize Eager="false">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="0.000009" Rows="1.000000" Width="4"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="20" Alias="?column?">
+                      <dxl:Ident ColId="20" ColName="?column?" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:Result>
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="20" Alias="?column?">
+                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:OneTimeFilter/>
+                    <dxl:Result>
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="19" Alias="">
+                          <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:OneTimeFilter/>
+                    </dxl:Result>
+                  </dxl:Result>
+                </dxl:Materialize>
               </dxl:NestedLoopJoin>
             </dxl:HashJoin>
           </dxl:Sort>

--- a/src/backend/gporca/data/dxl/minidump/PushGbBelowJoin-NegativeCase.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PushGbBelowJoin-NegativeCase.mdp
@@ -405,7 +405,7 @@
         </dxl:LogicalSelect>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="12480">
+    <dxl:Plan Id="0" SpaceSize="9720">
       <dxl:Result>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="3017.002573" Rows="1.000000" Width="4"/>
@@ -536,7 +536,7 @@
                       <dxl:ProjElem ColId="16" Alias="avg">
                         <dxl:AggFunc AggMdid="0.2101.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="">
                           <dxl:ValuesList ParamType="aggargs">
-                          <dxl:Ident ColId="8" ColName="c504" TypeMdid="0.23.1.0"/>
+                            <dxl:Ident ColId="8" ColName="c504" TypeMdid="0.23.1.0"/>
                           </dxl:ValuesList>
                           <dxl:ValuesList ParamType="aggdirectargs"/>
                           <dxl:ValuesList ParamType="aggorder"/>
@@ -546,7 +546,7 @@
                       <dxl:ProjElem ColId="17" Alias="max">
                         <dxl:AggFunc AggMdid="0.2116.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="">
                           <dxl:ValuesList ParamType="aggargs">
-                          <dxl:Ident ColId="8" ColName="c504" TypeMdid="0.23.1.0"/>
+                            <dxl:Ident ColId="8" ColName="c504" TypeMdid="0.23.1.0"/>
                           </dxl:ValuesList>
                           <dxl:ValuesList ParamType="aggdirectargs"/>
                           <dxl:ValuesList ParamType="aggorder"/>
@@ -639,6 +639,30 @@
                 </dxl:JoinFilter>
                 <dxl:Result>
                   <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="20" Alias="?column?">
+                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:OneTimeFilter/>
+                  <dxl:Result>
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="19" Alias="">
+                        <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:OneTimeFilter/>
+                  </dxl:Result>
+                </dxl:Result>
+                <dxl:Result>
+                  <dxl:Properties>
                     <dxl:Cost StartupCost="0" TotalCost="0.000186" Rows="1.000000" Width="4"/>
                   </dxl:Properties>
                   <dxl:ProjList>
@@ -701,7 +725,7 @@
                           <dxl:ProjElem ColId="2" Alias="min">
                             <dxl:AggFunc AggMdid="0.2132.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="">
                               <dxl:ValuesList ParamType="aggargs">
-                              <dxl:Ident ColId="1" ColName="?column?" TypeMdid="0.23.1.0"/>
+                                <dxl:Ident ColId="1" ColName="?column?" TypeMdid="0.23.1.0"/>
                               </dxl:ValuesList>
                               <dxl:ValuesList ParamType="aggdirectargs"/>
                               <dxl:ValuesList ParamType="aggorder"/>
@@ -779,30 +803,6 @@
                       <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
                     </dxl:LimitOffset>
                   </dxl:Limit>
-                </dxl:Result>
-                <dxl:Result>
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="20" Alias="?column?">
-                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:OneTimeFilter/>
-                  <dxl:Result>
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="19" Alias="">
-                        <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:Filter/>
-                    <dxl:OneTimeFilter/>
-                  </dxl:Result>
                 </dxl:Result>
               </dxl:NestedLoopJoin>
             </dxl:HashJoin>

--- a/src/backend/gporca/data/dxl/minidump/PushSelectWithOuterRefBelowUnion.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PushSelectWithOuterRefBelowUnion.mdp
@@ -5451,7 +5451,7 @@
         </dxl:Or>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="8868">
+    <dxl:Plan Id="0" SpaceSize="8208">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="25984.123228" Rows="60175000.000000" Width="14"/>

--- a/src/backend/gporca/data/dxl/minidump/Select-Proj-OuterJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Select-Proj-OuterJoin.mdp
@@ -887,7 +887,7 @@
         </dxl:LogicalSelect>
       </dxl:LogicalLimit>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="16660">
+    <dxl:Plan Id="0" SpaceSize="17364">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="891.087839" Rows="3009.000000" Width="64"/>

--- a/src/backend/gporca/data/dxl/minidump/Sequence-With-Universal-Outer.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Sequence-With-Universal-Outer.mdp
@@ -102,10 +102,10 @@
         </dxl:LogicalTVF>
       </dxl:LogicalLimit>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="20">
+    <dxl:Plan Id="0" SpaceSize="32">
       <dxl:Sort SortDiscardDuplicates="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="862.256156" Rows="1000.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.256160" Rows="1000.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -132,7 +132,7 @@
             <dxl:ParamList/>
             <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000056" Rows="1.000000" Width="4"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000060" Rows="1.000000" Width="4"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="9" Alias="ColRef_0004">
@@ -143,7 +143,7 @@
               <dxl:OneTimeFilter/>
               <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000052" Rows="2.000000" Width="4"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000056" Rows="2.000000" Width="4"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="12" Alias="?column?">
@@ -166,30 +166,41 @@
                   <dxl:Filter/>
                   <dxl:OneTimeFilter/>
                 </dxl:Result>
-                <dxl:Result>
+                <dxl:Materialize Eager="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
+                    <dxl:Cost StartupCost="0" TotalCost="0.000009" Rows="1.000000" Width="4"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="12" Alias="?column?">
-                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="5"/>
+                      <dxl:Ident ColId="12" ColName="?column?" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:OneTimeFilter/>
                   <dxl:Result>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                      <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
                     </dxl:Properties>
                     <dxl:ProjList>
-                      <dxl:ProjElem ColId="11" Alias="">
-                        <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                      <dxl:ProjElem ColId="12" Alias="?column?">
+                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="5"/>
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
                     <dxl:OneTimeFilter/>
+                    <dxl:Result>
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="11" Alias="">
+                          <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:OneTimeFilter/>
+                    </dxl:Result>
                   </dxl:Result>
-                </dxl:Result>
+                </dxl:Materialize>
               </dxl:NestedLoopJoin>
             </dxl:Result>
           </dxl:SubPlan>

--- a/src/backend/gporca/data/dxl/minidump/SimplifyExistsSubquery2Limit.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SimplifyExistsSubquery2Limit.mdp
@@ -712,7 +712,7 @@ explain select * from foo where foo.a = 10 and exists (select * from bar);
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="86">
+    <dxl:Plan Id="0" SpaceSize="82">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1311.703352" Rows="1.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/Subq-With-OuterRefCol.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Subq-With-OuterRefCol.mdp
@@ -530,7 +530,7 @@ pivotal=# explain select a, c from r, s where a in (select c from r) order by a,
         </dxl:LogicalJoin>
       </dxl:LogicalLimit>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="3164">
+    <dxl:Plan Id="0" SpaceSize="3124">
       <dxl:Limit>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1724.005263" Rows="10.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/Subq2OuterRef2InJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Subq2OuterRef2InJoin.mdp
@@ -454,7 +454,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="63">
+    <dxl:Plan Id="0" SpaceSize="84">
       <dxl:Result>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1423057834895712.000000" Rows="1.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/Subq2PartialDecorrelate.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Subq2PartialDecorrelate.mdp
@@ -431,7 +431,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="67">
+    <dxl:Plan Id="0" SpaceSize="153">
       <dxl:Result>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1356692189.437047" Rows="1.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/SubqAll-InsideScalarExpression.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SubqAll-InsideScalarExpression.mdp
@@ -383,7 +383,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="23">
+    <dxl:Plan Id="0" SpaceSize="17">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1324032.428517" Rows="1.000000" Width="15"/>

--- a/src/backend/gporca/data/dxl/minidump/SubqAny-InsideScalarExpression.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SubqAny-InsideScalarExpression.mdp
@@ -379,10 +379,10 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="22">
+    <dxl:Plan Id="0" SpaceSize="16">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1324032.643711" Rows="2.000000" Width="13"/>
+          <dxl:Cost StartupCost="0" TotalCost="1324032.644735" Rows="2.000000" Width="13"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -399,7 +399,7 @@
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1324032.643615" Rows="2.000000" Width="13"/>
+            <dxl:Cost StartupCost="0" TotalCost="1324032.644639" Rows="2.000000" Width="13"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -427,7 +427,7 @@
                     <dxl:Ident ColId="23" ColName="ColRef_0023" TypeMdid="0.20.1.0"/>
                     <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.20.1.0"/>
                   </dxl:Comparison>
-                  <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true" IsByValue="true"/>
+                  <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true"/>
                   <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
                 </dxl:If>
                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="false"/>
@@ -437,7 +437,7 @@
           <dxl:OneTimeFilter/>
           <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1324032.643549" Rows="2.000000" Width="29"/>
+              <dxl:Cost StartupCost="0" TotalCost="1324032.644573" Rows="2.000000" Width="29"/>
             </dxl:Properties>
             <dxl:GroupingColumns>
               <dxl:GroupingColumn ColId="0"/>
@@ -486,7 +486,7 @@
             <dxl:Filter/>
             <dxl:Sort SortDiscardDuplicates="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1324032.643499" Rows="2.000000" Width="39"/>
+                <dxl:Cost StartupCost="0" TotalCost="1324032.644523" Rows="2.000000" Width="39"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">
@@ -520,7 +520,7 @@
               <dxl:LimitOffset/>
               <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1324032.643499" Rows="2.000000" Width="39"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1324032.644523" Rows="2.000000" Width="39"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="a">
@@ -557,7 +557,7 @@
                 </dxl:HashExprList>
                 <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1324032.643377" Rows="2.000000" Width="39"/>
+                    <dxl:Cost StartupCost="0" TotalCost="1324032.644401" Rows="2.000000" Width="39"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="0" Alias="a">
@@ -586,7 +586,7 @@
                   <dxl:OneTimeFilter/>
                   <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="1324032.643377" Rows="2.000000" Width="39"/>
+                      <dxl:Cost StartupCost="0" TotalCost="1324032.644401" Rows="2.000000" Width="39"/>
                     </dxl:Properties>
                     <dxl:GroupingColumns>
                       <dxl:GroupingColumn ColId="0"/>
@@ -635,7 +635,7 @@
                     <dxl:Filter/>
                     <dxl:Result>
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="1324032.643299" Rows="4.000000" Width="28"/>
+                        <dxl:Cost StartupCost="0" TotalCost="1324032.644323" Rows="4.000000" Width="28"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="22" Alias="ColRef_0022">
@@ -673,7 +673,7 @@
                       <dxl:OneTimeFilter/>
                       <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="1324032.643243" Rows="4.000000" Width="28"/>
+                          <dxl:Cost StartupCost="0" TotalCost="1324032.644267" Rows="4.000000" Width="28"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="0" Alias="a">
@@ -773,30 +773,33 @@
                             </dxl:TableDescriptor>
                           </dxl:TableScan>
                         </dxl:Sort>
-                        <dxl:Result>
+                        <dxl:Materialize Eager="false">
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="431.000091" Rows="3.000000" Width="5"/>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000092" Rows="3.000000" Width="5"/>
                           </dxl:Properties>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="20" Alias="ColRef_0020">
-                              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                              <dxl:Ident ColId="20" ColName="ColRef_0020" TypeMdid="0.16.1.0"/>
                             </dxl:ProjElem>
                             <dxl:ProjElem ColId="12" Alias="c">
                               <dxl:Ident ColId="12" ColName="c" TypeMdid="0.23.1.0"/>
                             </dxl:ProjElem>
                           </dxl:ProjList>
                           <dxl:Filter/>
-                          <dxl:OneTimeFilter/>
-                          <dxl:Materialize Eager="false">
+                          <dxl:Result>
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="431.000086" Rows="3.000000" Width="4"/>
+                              <dxl:Cost StartupCost="0" TotalCost="431.000087" Rows="3.000000" Width="5"/>
                             </dxl:Properties>
                             <dxl:ProjList>
+                              <dxl:ProjElem ColId="20" Alias="ColRef_0020">
+                                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                              </dxl:ProjElem>
                               <dxl:ProjElem ColId="12" Alias="c">
                                 <dxl:Ident ColId="12" ColName="c" TypeMdid="0.23.1.0"/>
                               </dxl:ProjElem>
                             </dxl:ProjList>
                             <dxl:Filter/>
+                            <dxl:OneTimeFilter/>
                             <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                               <dxl:Properties>
                                 <dxl:Cost StartupCost="0" TotalCost="431.000082" Rows="3.000000" Width="4"/>
@@ -833,8 +836,8 @@
                                 </dxl:TableDescriptor>
                               </dxl:TableScan>
                             </dxl:BroadcastMotion>
-                          </dxl:Materialize>
-                        </dxl:Result>
+                          </dxl:Result>
+                        </dxl:Materialize>
                       </dxl:NestedLoopJoin>
                     </dxl:Result>
                   </dxl:Aggregate>

--- a/src/backend/gporca/data/dxl/minidump/SubqExists-With-External-Corrs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SubqExists-With-External-Corrs.mdp
@@ -453,7 +453,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="22026">
+    <dxl:Plan Id="0" SpaceSize="22142">
       <dxl:HashJoin JoinType="Inner">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1724.001472" Rows="1.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/SubqInIndexPred.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SubqInIndexPred.mdp
@@ -516,7 +516,7 @@ ON a = c
         </dxl:LogicalJoin>
       </dxl:LogicalProject>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="48688">
+    <dxl:Plan Id="0" SpaceSize="36848">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="2206721.811317" Rows="1.000000" Width="1"/>

--- a/src/backend/gporca/data/dxl/minidump/Subquery-AnyAllAggregates.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Subquery-AnyAllAggregates.mdp
@@ -522,10 +522,10 @@
         </dxl:LogicalGet>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="218">
+    <dxl:Plan Id="0" SpaceSize="146">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1356698074.463431" Rows="1.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="1356698083.900615" Rows="1.000000" Width="16"/>
         </dxl:Properties>
         <dxl:GroupingColumns/>
         <dxl:ProjList>
@@ -553,7 +553,7 @@
         <dxl:Filter/>
         <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1356698074.463423" Rows="1.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="1356698083.900608" Rows="1.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="42" Alias="ColRef_0042">
@@ -567,7 +567,7 @@
           <dxl:SortingColumnList/>
           <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1356698074.463364" Rows="1.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="1356698083.900548" Rows="1.000000" Width="16"/>
             </dxl:Properties>
             <dxl:GroupingColumns/>
             <dxl:ProjList>
@@ -727,7 +727,7 @@
             <dxl:Filter/>
             <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1324038.433134" Rows="8.000000" Width="24"/>
+                <dxl:Cost StartupCost="0" TotalCost="1324038.442350" Rows="8.000000" Width="24"/>
               </dxl:Properties>
               <dxl:GroupingColumns>
                 <dxl:GroupingColumn ColId="0"/>
@@ -772,7 +772,7 @@
               <dxl:Filter/>
               <dxl:Sort SortDiscardDuplicates="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1324038.433008" Rows="8.000000" Width="34"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1324038.442224" Rows="8.000000" Width="34"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="a">
@@ -803,7 +803,7 @@
                 <dxl:LimitOffset/>
                 <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1324038.432280" Rows="8.000000" Width="34"/>
+                    <dxl:Cost StartupCost="0" TotalCost="1324038.441496" Rows="8.000000" Width="34"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="0" Alias="a">
@@ -837,7 +837,7 @@
                   </dxl:HashExprList>
                   <dxl:Result>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="1324038.431997" Rows="8.000000" Width="34"/>
+                      <dxl:Cost StartupCost="0" TotalCost="1324038.441213" Rows="8.000000" Width="34"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="0" Alias="a">
@@ -863,7 +863,7 @@
                     <dxl:OneTimeFilter/>
                     <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="1324038.431997" Rows="8.000000" Width="34"/>
+                        <dxl:Cost StartupCost="0" TotalCost="1324038.441213" Rows="8.000000" Width="34"/>
                       </dxl:Properties>
                       <dxl:GroupingColumns>
                         <dxl:GroupingColumn ColId="0"/>
@@ -908,7 +908,7 @@
                       <dxl:Filter/>
                       <dxl:Sort SortDiscardDuplicates="false">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="1324038.431862" Rows="10.880000" Width="23"/>
+                          <dxl:Cost StartupCost="0" TotalCost="1324038.441078" Rows="10.880000" Width="23"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="31" Alias="ColRef_0031">
@@ -939,7 +939,7 @@
                         <dxl:LimitOffset/>
                         <dxl:Result>
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="1324038.430983" Rows="10.880000" Width="23"/>
+                            <dxl:Cost StartupCost="0" TotalCost="1324038.440199" Rows="10.880000" Width="23"/>
                           </dxl:Properties>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="31" Alias="ColRef_0031">
@@ -974,7 +974,7 @@
                           <dxl:OneTimeFilter/>
                           <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="1324038.430900" Rows="10.880000" Width="23"/>
+                              <dxl:Cost StartupCost="0" TotalCost="1324038.440116" Rows="10.880000" Width="23"/>
                             </dxl:Properties>
                             <dxl:ProjList>
                               <dxl:ProjElem ColId="0" Alias="a">
@@ -1044,13 +1044,13 @@
                                 </dxl:Columns>
                               </dxl:TableDescriptor>
                             </dxl:TableScan>
-                            <dxl:Result>
+                            <dxl:Materialize Eager="false">
                               <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="431.001549" Rows="27.000000" Width="9"/>
+                                <dxl:Cost StartupCost="0" TotalCost="431.001558" Rows="27.000000" Width="9"/>
                               </dxl:Properties>
                               <dxl:ProjList>
                                 <dxl:ProjElem ColId="29" Alias="ColRef_0029">
-                                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                                  <dxl:Ident ColId="29" ColName="ColRef_0029" TypeMdid="0.16.1.0"/>
                                 </dxl:ProjElem>
                                 <dxl:ProjElem ColId="9" Alias="b">
                                   <dxl:Ident ColId="9" ColName="b" TypeMdid="0.23.1.0"/>
@@ -1060,12 +1060,14 @@
                                 </dxl:ProjElem>
                               </dxl:ProjList>
                               <dxl:Filter/>
-                              <dxl:OneTimeFilter/>
-                              <dxl:Materialize Eager="false">
+                              <dxl:Result>
                                 <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="431.001468" Rows="27.000000" Width="8"/>
+                                  <dxl:Cost StartupCost="0" TotalCost="431.001477" Rows="27.000000" Width="9"/>
                                 </dxl:Properties>
                                 <dxl:ProjList>
+                                  <dxl:ProjElem ColId="29" Alias="ColRef_0029">
+                                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                                  </dxl:ProjElem>
                                   <dxl:ProjElem ColId="9" Alias="b">
                                     <dxl:Ident ColId="9" ColName="b" TypeMdid="0.23.1.0"/>
                                   </dxl:ProjElem>
@@ -1074,6 +1076,7 @@
                                   </dxl:ProjElem>
                                 </dxl:ProjList>
                                 <dxl:Filter/>
+                                <dxl:OneTimeFilter/>
                                 <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                                   <dxl:Properties>
                                     <dxl:Cost StartupCost="0" TotalCost="431.001396" Rows="27.000000" Width="8"/>
@@ -1116,8 +1119,8 @@
                                     </dxl:TableDescriptor>
                                   </dxl:TableScan>
                                 </dxl:BroadcastMotion>
-                              </dxl:Materialize>
-                            </dxl:Result>
+                              </dxl:Result>
+                            </dxl:Materialize>
                           </dxl:NestedLoopJoin>
                         </dxl:Result>
                       </dxl:Sort>

--- a/src/backend/gporca/data/dxl/minidump/Subquery-ExistsAllAggregates.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Subquery-ExistsAllAggregates.mdp
@@ -595,10 +595,10 @@
         </dxl:LogicalGet>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="222">
+    <dxl:Plan Id="0" SpaceSize="150">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1356695741.507501" Rows="1.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="1356695750.944685" Rows="1.000000" Width="16"/>
         </dxl:Properties>
         <dxl:GroupingColumns/>
         <dxl:ProjList>
@@ -626,7 +626,7 @@
         <dxl:Filter/>
         <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1356695741.507494" Rows="1.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="1356695750.944678" Rows="1.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="52" Alias="ColRef_0052">
@@ -640,7 +640,7 @@
           <dxl:SortingColumnList/>
           <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1356695741.507435" Rows="1.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="1356695750.944618" Rows="1.000000" Width="16"/>
             </dxl:Properties>
             <dxl:GroupingColumns/>
             <dxl:ProjList>
@@ -800,7 +800,7 @@
             <dxl:Filter/>
             <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1324036.154857" Rows="8.000000" Width="24"/>
+                <dxl:Cost StartupCost="0" TotalCost="1324036.164073" Rows="8.000000" Width="24"/>
               </dxl:Properties>
               <dxl:GroupingColumns>
                 <dxl:GroupingColumn ColId="0"/>
@@ -845,7 +845,7 @@
               <dxl:Filter/>
               <dxl:Sort SortDiscardDuplicates="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1324036.154731" Rows="8.000000" Width="34"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1324036.163947" Rows="8.000000" Width="34"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="a">
@@ -876,7 +876,7 @@
                 <dxl:LimitOffset/>
                 <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1324036.154003" Rows="8.000000" Width="34"/>
+                    <dxl:Cost StartupCost="0" TotalCost="1324036.163219" Rows="8.000000" Width="34"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="0" Alias="a">
@@ -910,7 +910,7 @@
                   </dxl:HashExprList>
                   <dxl:Result>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="1324036.153719" Rows="8.000000" Width="34"/>
+                      <dxl:Cost StartupCost="0" TotalCost="1324036.162935" Rows="8.000000" Width="34"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="0" Alias="a">
@@ -936,7 +936,7 @@
                     <dxl:OneTimeFilter/>
                     <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="1324036.153719" Rows="8.000000" Width="34"/>
+                        <dxl:Cost StartupCost="0" TotalCost="1324036.162935" Rows="8.000000" Width="34"/>
                       </dxl:Properties>
                       <dxl:GroupingColumns>
                         <dxl:GroupingColumn ColId="0"/>
@@ -981,7 +981,7 @@
                       <dxl:Filter/>
                       <dxl:Sort SortDiscardDuplicates="false">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="1324036.153423" Rows="32.000000" Width="23"/>
+                          <dxl:Cost StartupCost="0" TotalCost="1324036.162639" Rows="32.000000" Width="23"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="41" Alias="ColRef_0041">
@@ -1012,7 +1012,7 @@
                         <dxl:LimitOffset/>
                         <dxl:Result>
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="1324036.148673" Rows="32.000000" Width="23"/>
+                            <dxl:Cost StartupCost="0" TotalCost="1324036.157889" Rows="32.000000" Width="23"/>
                           </dxl:Properties>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="41" Alias="ColRef_0041">
@@ -1047,7 +1047,7 @@
                           <dxl:OneTimeFilter/>
                           <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="1324036.148427" Rows="32.000000" Width="23"/>
+                              <dxl:Cost StartupCost="0" TotalCost="1324036.157643" Rows="32.000000" Width="23"/>
                             </dxl:Properties>
                             <dxl:ProjList>
                               <dxl:ProjElem ColId="0" Alias="a">
@@ -1111,30 +1111,33 @@
                                 </dxl:Columns>
                               </dxl:TableDescriptor>
                             </dxl:TableScan>
-                            <dxl:Result>
+                            <dxl:Materialize Eager="false">
                               <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="431.000810" Rows="27.000000" Width="5"/>
+                                <dxl:Cost StartupCost="0" TotalCost="431.000819" Rows="27.000000" Width="5"/>
                               </dxl:Properties>
                               <dxl:ProjList>
                                 <dxl:ProjElem ColId="39" Alias="ColRef_0039">
-                                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                                  <dxl:Ident ColId="39" ColName="ColRef_0039" TypeMdid="0.16.1.0"/>
                                 </dxl:ProjElem>
                                 <dxl:ProjElem ColId="9" Alias="b">
                                   <dxl:Ident ColId="9" ColName="b" TypeMdid="0.23.1.0"/>
                                 </dxl:ProjElem>
                               </dxl:ProjList>
                               <dxl:Filter/>
-                              <dxl:OneTimeFilter/>
-                              <dxl:Materialize Eager="false">
+                              <dxl:Result>
                                 <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="431.000765" Rows="27.000000" Width="4"/>
+                                  <dxl:Cost StartupCost="0" TotalCost="431.000774" Rows="27.000000" Width="5"/>
                                 </dxl:Properties>
                                 <dxl:ProjList>
+                                  <dxl:ProjElem ColId="39" Alias="ColRef_0039">
+                                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                                  </dxl:ProjElem>
                                   <dxl:ProjElem ColId="9" Alias="b">
                                     <dxl:Ident ColId="9" ColName="b" TypeMdid="0.23.1.0"/>
                                   </dxl:ProjElem>
                                 </dxl:ProjList>
                                 <dxl:Filter/>
+                                <dxl:OneTimeFilter/>
                                 <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                                   <dxl:Properties>
                                     <dxl:Cost StartupCost="0" TotalCost="431.000729" Rows="27.000000" Width="4"/>
@@ -1170,8 +1173,8 @@
                                     </dxl:TableDescriptor>
                                   </dxl:TableScan>
                                 </dxl:BroadcastMotion>
-                              </dxl:Materialize>
-                            </dxl:Result>
+                              </dxl:Result>
+                            </dxl:Materialize>
                           </dxl:NestedLoopJoin>
                         </dxl:Result>
                       </dxl:Sort>

--- a/src/backend/gporca/data/dxl/minidump/Subquery-ExistsAllAggregatesWithDisjuncts.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Subquery-ExistsAllAggregatesWithDisjuncts.mdp
@@ -662,10 +662,10 @@
         </dxl:LogicalGet>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1554">
+    <dxl:Plan Id="0" SpaceSize="1050">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="2712065383.057338" Rows="1.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="2712065392.494522" Rows="1.000000" Width="16"/>
         </dxl:Properties>
         <dxl:GroupingColumns/>
         <dxl:ProjList>
@@ -693,7 +693,7 @@
         <dxl:Filter/>
         <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2712065383.057331" Rows="1.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="2712065392.494514" Rows="1.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="61" Alias="ColRef_0061">
@@ -707,7 +707,7 @@
           <dxl:SortingColumnList/>
           <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="2712065383.057271" Rows="1.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="2712065392.494455" Rows="1.000000" Width="16"/>
             </dxl:Properties>
             <dxl:GroupingColumns/>
             <dxl:ProjList>
@@ -946,7 +946,7 @@
             <dxl:Filter/>
             <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1324036.154857" Rows="8.000000" Width="24"/>
+                <dxl:Cost StartupCost="0" TotalCost="1324036.164073" Rows="8.000000" Width="24"/>
               </dxl:Properties>
               <dxl:GroupingColumns>
                 <dxl:GroupingColumn ColId="0"/>
@@ -991,7 +991,7 @@
               <dxl:Filter/>
               <dxl:Sort SortDiscardDuplicates="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1324036.154731" Rows="8.000000" Width="34"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1324036.163947" Rows="8.000000" Width="34"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="a">
@@ -1022,7 +1022,7 @@
                 <dxl:LimitOffset/>
                 <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1324036.154003" Rows="8.000000" Width="34"/>
+                    <dxl:Cost StartupCost="0" TotalCost="1324036.163219" Rows="8.000000" Width="34"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="0" Alias="a">
@@ -1056,7 +1056,7 @@
                   </dxl:HashExprList>
                   <dxl:Result>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="1324036.153719" Rows="8.000000" Width="34"/>
+                      <dxl:Cost StartupCost="0" TotalCost="1324036.162935" Rows="8.000000" Width="34"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="0" Alias="a">
@@ -1082,7 +1082,7 @@
                     <dxl:OneTimeFilter/>
                     <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="1324036.153719" Rows="8.000000" Width="34"/>
+                        <dxl:Cost StartupCost="0" TotalCost="1324036.162935" Rows="8.000000" Width="34"/>
                       </dxl:Properties>
                       <dxl:GroupingColumns>
                         <dxl:GroupingColumn ColId="0"/>
@@ -1127,7 +1127,7 @@
                       <dxl:Filter/>
                       <dxl:Sort SortDiscardDuplicates="false">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="1324036.153423" Rows="32.000000" Width="23"/>
+                          <dxl:Cost StartupCost="0" TotalCost="1324036.162639" Rows="32.000000" Width="23"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="50" Alias="ColRef_0050">
@@ -1158,7 +1158,7 @@
                         <dxl:LimitOffset/>
                         <dxl:Result>
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="1324036.148673" Rows="32.000000" Width="23"/>
+                            <dxl:Cost StartupCost="0" TotalCost="1324036.157889" Rows="32.000000" Width="23"/>
                           </dxl:Properties>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="50" Alias="ColRef_0050">
@@ -1193,7 +1193,7 @@
                           <dxl:OneTimeFilter/>
                           <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="1324036.148427" Rows="32.000000" Width="23"/>
+                              <dxl:Cost StartupCost="0" TotalCost="1324036.157643" Rows="32.000000" Width="23"/>
                             </dxl:Properties>
                             <dxl:ProjList>
                               <dxl:ProjElem ColId="0" Alias="a">
@@ -1257,30 +1257,33 @@
                                 </dxl:Columns>
                               </dxl:TableDescriptor>
                             </dxl:TableScan>
-                            <dxl:Result>
+                            <dxl:Materialize Eager="false">
                               <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="431.000810" Rows="27.000000" Width="5"/>
+                                <dxl:Cost StartupCost="0" TotalCost="431.000819" Rows="27.000000" Width="5"/>
                               </dxl:Properties>
                               <dxl:ProjList>
                                 <dxl:ProjElem ColId="48" Alias="ColRef_0048">
-                                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                                  <dxl:Ident ColId="48" ColName="ColRef_0048" TypeMdid="0.16.1.0"/>
                                 </dxl:ProjElem>
                                 <dxl:ProjElem ColId="9" Alias="b">
                                   <dxl:Ident ColId="9" ColName="b" TypeMdid="0.23.1.0"/>
                                 </dxl:ProjElem>
                               </dxl:ProjList>
                               <dxl:Filter/>
-                              <dxl:OneTimeFilter/>
-                              <dxl:Materialize Eager="false">
+                              <dxl:Result>
                                 <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="431.000765" Rows="27.000000" Width="4"/>
+                                  <dxl:Cost StartupCost="0" TotalCost="431.000774" Rows="27.000000" Width="5"/>
                                 </dxl:Properties>
                                 <dxl:ProjList>
+                                  <dxl:ProjElem ColId="48" Alias="ColRef_0048">
+                                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                                  </dxl:ProjElem>
                                   <dxl:ProjElem ColId="9" Alias="b">
                                     <dxl:Ident ColId="9" ColName="b" TypeMdid="0.23.1.0"/>
                                   </dxl:ProjElem>
                                 </dxl:ProjList>
                                 <dxl:Filter/>
+                                <dxl:OneTimeFilter/>
                                 <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                                   <dxl:Properties>
                                     <dxl:Cost StartupCost="0" TotalCost="431.000729" Rows="27.000000" Width="4"/>
@@ -1317,8 +1320,8 @@
                                     </dxl:TableDescriptor>
                                   </dxl:TableScan>
                                 </dxl:BroadcastMotion>
-                              </dxl:Materialize>
-                            </dxl:Result>
+                              </dxl:Result>
+                            </dxl:Materialize>
                           </dxl:NestedLoopJoin>
                         </dxl:Result>
                       </dxl:Sort>

--- a/src/backend/gporca/data/dxl/minidump/SubqueryInsideScalarIf.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SubqueryInsideScalarIf.mdp
@@ -2459,7 +2459,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1562">
+    <dxl:Plan Id="0" SpaceSize="1166">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1356710918.164982" Rows="10002.000000" Width="12"/>

--- a/src/backend/gporca/data/dxl/minidump/SubqueryInsideScalarIf.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SubqueryInsideScalarIf.mdp
@@ -2459,7 +2459,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1166">
+    <dxl:Plan Id="0" SpaceSize="1154">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1356710918.164982" Rows="10002.000000" Width="12"/>

--- a/src/backend/gporca/data/dxl/minidump/TVFCorrelatedExecution.mdp
+++ b/src/backend/gporca/data/dxl/minidump/TVFCorrelatedExecution.mdp
@@ -91,7 +91,7 @@
         </dxl:ScalarSubquery>
       </dxl:LogicalTVF>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="48">
+    <dxl:Plan Id="0" SpaceSize="144">
       <dxl:TableValuedFunction FuncId="0.65639.1.0" Name="myfunc" TypeMdid="0.2249.1.0">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="0.008000" Rows="1000.000000" Width="8"/>
@@ -109,7 +109,7 @@
           <dxl:ParamList/>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="862.000216" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="862.000224" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="16" Alias="ColRef_0007">
@@ -120,7 +120,7 @@
             <dxl:OneTimeFilter/>
             <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="862.000216" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="862.000224" Rows="1.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="16" Alias="ColRef_0007">
@@ -134,7 +134,7 @@
               <dxl:OneTimeFilter/>
               <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="862.000208" Rows="4.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="862.000216" Rows="4.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="20" Alias="?column?">
@@ -150,7 +150,7 @@
                 </dxl:JoinFilter>
                 <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000052" Rows="2.000000" Width="4"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000056" Rows="2.000000" Width="4"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="20" Alias="?column?">
@@ -173,13 +173,59 @@
                     <dxl:Filter/>
                     <dxl:OneTimeFilter/>
                   </dxl:Result>
+                  <dxl:Materialize Eager="false">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="0.000009" Rows="1.000000" Width="4"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="20" Alias="?column?">
+                        <dxl:Ident ColId="20" ColName="?column?" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:Result>
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="20" Alias="?column?">
+                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:OneTimeFilter/>
+                      <dxl:Result>
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="19" Alias="">
+                            <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:OneTimeFilter/>
+                      </dxl:Result>
+                    </dxl:Result>
+                  </dxl:Materialize>
+                </dxl:NestedLoopJoin>
+                <dxl:Materialize Eager="false">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="0.000009" Rows="1.000000" Width="4"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="22" Alias="?column?">
+                      <dxl:Ident ColId="22" ColName="?column?" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
                   <dxl:Result>
                     <dxl:Properties>
                       <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
                     </dxl:Properties>
                     <dxl:ProjList>
-                      <dxl:ProjElem ColId="20" Alias="?column?">
-                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                      <dxl:ProjElem ColId="22" Alias="?column?">
+                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
@@ -189,7 +235,7 @@
                         <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
                       </dxl:Properties>
                       <dxl:ProjList>
-                        <dxl:ProjElem ColId="19" Alias="">
+                        <dxl:ProjElem ColId="21" Alias="">
                           <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
                         </dxl:ProjElem>
                       </dxl:ProjList>
@@ -197,31 +243,7 @@
                       <dxl:OneTimeFilter/>
                     </dxl:Result>
                   </dxl:Result>
-                </dxl:NestedLoopJoin>
-                <dxl:Result>
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="22" Alias="?column?">
-                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:OneTimeFilter/>
-                  <dxl:Result>
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="21" Alias="">
-                        <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:Filter/>
-                    <dxl:OneTimeFilter/>
-                  </dxl:Result>
-                </dxl:Result>
+                </dxl:Materialize>
               </dxl:NestedLoopJoin>
             </dxl:Result>
           </dxl:Result>
@@ -231,7 +253,7 @@
           <dxl:ParamList/>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="862.000216" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="862.000224" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="17" Alias="ColRef_0008">
@@ -242,7 +264,7 @@
             <dxl:OneTimeFilter/>
             <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="862.000216" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="862.000224" Rows="1.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="16" Alias="ColRef_0007">
@@ -256,7 +278,7 @@
               <dxl:OneTimeFilter/>
               <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="862.000208" Rows="4.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="862.000216" Rows="4.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="20" Alias="?column?">
@@ -272,7 +294,7 @@
                 </dxl:JoinFilter>
                 <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000052" Rows="2.000000" Width="4"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000056" Rows="2.000000" Width="4"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="20" Alias="?column?">
@@ -295,13 +317,59 @@
                     <dxl:Filter/>
                     <dxl:OneTimeFilter/>
                   </dxl:Result>
+                  <dxl:Materialize Eager="false">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="0.000009" Rows="1.000000" Width="4"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="20" Alias="?column?">
+                        <dxl:Ident ColId="20" ColName="?column?" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:Result>
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="20" Alias="?column?">
+                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:OneTimeFilter/>
+                      <dxl:Result>
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="19" Alias="">
+                            <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:OneTimeFilter/>
+                      </dxl:Result>
+                    </dxl:Result>
+                  </dxl:Materialize>
+                </dxl:NestedLoopJoin>
+                <dxl:Materialize Eager="false">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="0.000009" Rows="1.000000" Width="4"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="22" Alias="?column?">
+                      <dxl:Ident ColId="22" ColName="?column?" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
                   <dxl:Result>
                     <dxl:Properties>
                       <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
                     </dxl:Properties>
                     <dxl:ProjList>
-                      <dxl:ProjElem ColId="20" Alias="?column?">
-                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                      <dxl:ProjElem ColId="22" Alias="?column?">
+                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
@@ -311,7 +379,7 @@
                         <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
                       </dxl:Properties>
                       <dxl:ProjList>
-                        <dxl:ProjElem ColId="19" Alias="">
+                        <dxl:ProjElem ColId="21" Alias="">
                           <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
                         </dxl:ProjElem>
                       </dxl:ProjList>
@@ -319,31 +387,7 @@
                       <dxl:OneTimeFilter/>
                     </dxl:Result>
                   </dxl:Result>
-                </dxl:NestedLoopJoin>
-                <dxl:Result>
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="22" Alias="?column?">
-                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:OneTimeFilter/>
-                  <dxl:Result>
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="21" Alias="">
-                        <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:Filter/>
-                    <dxl:OneTimeFilter/>
-                  </dxl:Result>
-                </dxl:Result>
+                </dxl:Materialize>
               </dxl:NestedLoopJoin>
             </dxl:Result>
           </dxl:Result>

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalAgg.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalAgg.cpp
@@ -387,17 +387,14 @@ CPhysicalAgg::PrsRequired(CMemoryPool *mp, CExpressionHandle &exprhdl,
 {
 	GPOS_ASSERT(0 == child_index);
 
-	CRewindabilitySpec *prsChild =
-		PrsPassThru(mp, exprhdl, prsRequired, child_index);
 	if (prsRequired->IsOriginNLJoin())
 	{
-		CRewindabilitySpec *prs = GPOS_NEW(mp)
-			CRewindabilitySpec(CRewindabilitySpec::ErtNone, prsChild->Emht());
-		prsChild->Release();
+		CRewindabilitySpec *prs = GPOS_NEW(mp) CRewindabilitySpec(
+			CRewindabilitySpec::ErtNone, prsRequired->Emht());
 		return prs;
 	}
 
-	return prsChild;
+	return PrsPassThru(mp, exprhdl, prsRequired, child_index);
 }
 
 //---------------------------------------------------------------------------

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalComputeScalar.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalComputeScalar.cpp
@@ -261,7 +261,12 @@ CPhysicalComputeScalar::PrsRequired(CMemoryPool *mp, CExpressionHandle &exprhdl,
 ) const
 {
 	GPOS_ASSERT(0 == child_index);
-
+	if (prsRequired->IsOriginNLJoin())
+	{
+		CRewindabilitySpec *prs = GPOS_NEW(mp) CRewindabilitySpec(
+			CRewindabilitySpec::ErtNone, prsRequired->Emht());
+		return prs;
+	}
 	return PrsPassThru(mp, exprhdl, prsRequired, child_index);
 }
 

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalComputeScalar.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalComputeScalar.cpp
@@ -454,6 +454,11 @@ CEnfdProp::EPropEnforcingType
 CPhysicalComputeScalar::EpetRewindability(CExpressionHandle &exprhdl,
 										  const CEnfdRewindability *per) const
 {
+	if (per->PrsRequired()->IsOriginNLJoin())
+	{
+		return CEnfdProp::EpetRequired;
+	}
+
 	CColRefSet *pcrsUsed = exprhdl.DeriveUsedColumns(1);
 	CColRefSet *pcrsCorrelatedApply = exprhdl.DeriveCorrelatedApplyColumns();
 	if (!pcrsUsed->IsDisjoint(pcrsCorrelatedApply))

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalFilter.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalFilter.cpp
@@ -144,7 +144,12 @@ CPhysicalFilter::PrsRequired(CMemoryPool *mp, CExpressionHandle &exprhdl,
 ) const
 {
 	GPOS_ASSERT(0 == child_index);
-
+	if (prsRequired->IsOriginNLJoin())
+	{
+		CRewindabilitySpec *prs = GPOS_NEW(mp) CRewindabilitySpec(
+			CRewindabilitySpec::ErtNone, prsRequired->Emht());
+		return prs;
+	}
 	return PrsPassThru(mp, exprhdl, prsRequired, child_index);
 }
 
@@ -373,6 +378,11 @@ CEnfdProp::EPropEnforcingType
 CPhysicalFilter::EpetRewindability(CExpressionHandle &exprhdl,
 								   const CEnfdRewindability *per) const
 {
+	if (per->PrsRequired()->IsOriginNLJoin())
+	{
+		return CEnfdProp::EpetRequired;
+	}
+
 	// get rewindability delivered by the Filter node
 	CRewindabilitySpec *prs = CDrvdPropPlan::Pdpplan(exprhdl.Pdp())->Prs();
 	if (per->FCompatible(prs))

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalNLJoin.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalNLJoin.cpp
@@ -111,7 +111,7 @@ CPhysicalNLJoin::PrsRequired(CMemoryPool *mp, CExpressionHandle &exprhdl,
 		{
 			// for index nested loop joins, inner child is optimized first
 			return GPOS_NEW(mp) CRewindabilitySpec(
-				CRewindabilitySpec::ErtRewindable, prsRequired->Emht(), true);
+				CRewindabilitySpec::ErtRewindable, prsRequired->Emht(), false);
 		}
 
 		CRewindabilitySpec *prsOuter =

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalNLJoin.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalNLJoin.cpp
@@ -109,7 +109,9 @@ CPhysicalNLJoin::PrsRequired(CMemoryPool *mp, CExpressionHandle &exprhdl,
 	{
 		if (FFirstChildToOptimize(child_index))
 		{
-			// for index nested loop joins, inner child is optimized first
+			// for index nested loop joins, inner child is optimized first.
+			// we should not force materialize inner child, as we use index
+			// on inner relation and reference variables from outer relation.
 			return GPOS_NEW(mp) CRewindabilitySpec(
 				CRewindabilitySpec::ErtRewindable, prsRequired->Emht(), false);
 		}

--- a/src/test/regress/expected/bfv_planner_optimizer.out
+++ b/src/test/regress/expected/bfv_planner_optimizer.out
@@ -410,11 +410,12 @@ where x.a > random();
    ->  Nested Loop
          Join Filter: true
          ->  Seq Scan on t_hashdist
-         ->  Result
-               Filter: ((generate_series.generate_series)::double precision > random())
-               ->  Function Scan on generate_series
+         ->  Materialize
+               ->  Result
+                     Filter: ((generate_series.generate_series)::double precision > random())
+                     ->  Function Scan on generate_series
  Optimizer: Pivotal Optimizer (GPORCA)
-(8 rows)
+(9 rows)
 
 ---- join qual
 explain (costs off) select * from
@@ -548,13 +549,14 @@ explain (costs off) select * from t_hashdist cross join (select a, count(1) as s
    ->  Nested Loop
          Join Filter: true
          ->  Seq Scan on t_hashdist
-         ->  Result
-               Filter: (((count(1)))::double precision > random())
-               ->  HashAggregate
-                     Group Key: generate_series.generate_series
-                     ->  Function Scan on generate_series
+         ->  Materialize
+               ->  Result
+                     Filter: (((count(1)))::double precision > random())
+                     ->  HashAggregate
+                           Group Key: generate_series.generate_series
+                           ->  Function Scan on generate_series
  Optimizer: Pivotal Optimizer (GPORCA)
-(10 rows)
+(11 rows)
 
 -- limit
 explain (costs off) select * from t_hashdist cross join (select * from generate_series(1, 10) limit random()) x;

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -13176,7 +13176,8 @@ select * from foo join (select a, a::bigint*a::bigint as aa from tbtree) proj on
    ->  Nested Loop
          Join Filter: ((foo.a = tbtree.a) AND (foo.b = (((tbtree.a)::bigint * (tbtree.a)::bigint))))
          ->  Seq Scan on foo
-         ->  Seq Scan on tbtree
+         ->  Materialize
+               ->  Seq Scan on tbtree
  Optimizer: Pivotal Optimizer (GPORCA)
 (6 rows)
 
@@ -13203,8 +13204,8 @@ from foo l1 where b in (select ab
                                     on l2.a=tbtree_derived.a and l2.b=tbtree_derived.b
                         where l2.c = 1
                        );
-                               QUERY PLAN                               
-------------------------------------------------------------------------
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
  Result
    Filter: (SubPlan 1)
    ->  Gather Motion 3:1  (slice1; segments: 3)
@@ -13216,12 +13217,13 @@ from foo l1 where b in (select ab
                  ->  Gather Motion 3:1  (slice3; segments: 3)
                        ->  Seq Scan on foo foo_1
                              Filter: (c = 1)
-           ->  Result
-                 ->  Materialize
-                       ->  Gather Motion 3:1  (slice2; segments: 3)
-                             ->  Seq Scan on tbtree
+           ->  Materialize
+                 ->  Result
+                       ->  Materialize
+                             ->  Gather Motion 3:1  (slice2; segments: 3)
+                                   ->  Seq Scan on tbtree
  Optimizer: Pivotal Optimizer (GPORCA)
-(16 rows)
+(17 rows)
 
 -- 16 group by columns are not a superset of the distribution columns - no index scan
 explain (costs off)

--- a/src/test/regress/expected/join_hash_optimizer.out
+++ b/src/test/regress/expected/join_hash_optimizer.out
@@ -1150,8 +1150,10 @@ WHERE
                                    Filter: (((hjtest_2.c * 5)) < 55)
                                    ->  Result
                                          Output: (hjtest_2.c * 5)
-                     ->  Result
-                           Output: 1
+                     ->  Materialize
+                           Output: (1)
+                           ->  Result
+                                 Output: 1
                      SubPlan 2
                        ->  Result
                              Output: (hjtest_2.c * 5)
@@ -1178,7 +1180,7 @@ WHERE
                                          Output: (hjtest_1.b * 5)
  Optimizer: Pivotal Optimizer (GPORCA)
  Settings: enable_sort = 'off', from_collapse_limit = '1'
-(49 rows)
+(51 rows)
 
 SELECT hjtest_1.a a1, hjtest_2.a a2,hjtest_1.tableoid::regclass t1, hjtest_2.tableoid::regclass t2
 FROM hjtest_1, hjtest_2
@@ -1225,8 +1227,10 @@ WHERE
                                    Filter: (((hjtest_2.c * 5)) < 55)
                                    ->  Result
                                          Output: (hjtest_2.c * 5)
-                     ->  Result
-                           Output: 1
+                     ->  Materialize
+                           Output: (1)
+                           ->  Result
+                                 Output: 1
                      SubPlan 2
                        ->  Result
                              Output: (hjtest_2.c * 5)
@@ -1253,7 +1257,7 @@ WHERE
                                          Output: (hjtest_1.b * 5)
  Optimizer: Pivotal Optimizer (GPORCA)
  Settings: enable_sort = 'off', from_collapse_limit = '1'
-(49 rows)
+(51 rows)
 
 SELECT hjtest_1.a a1, hjtest_2.a a2,hjtest_1.tableoid::regclass t1, hjtest_2.tableoid::regclass t2
 FROM hjtest_2, hjtest_1

--- a/src/test/regress/expected/join_optimizer.out
+++ b/src/test/regress/expected/join_optimizer.out
@@ -3287,7 +3287,8 @@ where q1 = thousand or q2 = thousand;
                ->  Nested Loop
                      Join Filter: true
                      ->  Result
-                     ->  Result
+                     ->  Materialize
+                           ->  Result
                ->  Bitmap Heap Scan on tenk1
                      Recheck Cond: ((thousand = (1)) OR (thousand = (0)))
                      ->  BitmapOr
@@ -3299,7 +3300,7 @@ where q1 = thousand or q2 = thousand;
                ->  Broadcast Motion 3:3  (slice2; segments: 3)
                      ->  Seq Scan on int4_tbl
  Optimizer: Pivotal Optimizer (GPORCA)
-(20 rows)
+(21 rows)
 
 explain (costs off)
 select * from
@@ -3317,14 +3318,15 @@ where thousand = (q1 + q2);
                ->  Nested Loop
                      Join Filter: true
                      ->  Result
-                     ->  Result
+                     ->  Materialize
+                           ->  Result
                ->  Index Scan using tenk1_thous_tenthous on tenk1
                      Index Cond: (thousand = ((1) + (0)))
          ->  Hash
                ->  Broadcast Motion 3:3  (slice2; segments: 3)
                      ->  Seq Scan on int4_tbl
  Optimizer: Pivotal Optimizer (GPORCA)
-(15 rows)
+(16 rows)
 
 --
 -- test ability to generate a suitable plan for a star-schema query

--- a/src/test/regress/expected/notin_optimizer.out
+++ b/src/test/regress/expected/notin_optimizer.out
@@ -1198,11 +1198,11 @@ explain select c1 from t1 where c1::absint not in
          Filter: (NOT CASE WHEN ((count((true))) > '0'::bigint) THEN CASE WHEN ((sum((CASE WHEN (((t1.c1)::absint = ((t1n.c1n)::absint)) IS NULL) THEN 1 ELSE 0 END))) = (count((true)))) THEN NULL::boolean ELSE true END ELSE false END)
          ->  HashAggregate  (cost=0.00..1324035.89 rows=4 width=20)
                Group Key: t1.c1, t1.ctid, t1.gp_segment_id
-               ->  Nested Loop Left Join  (cost=0.00..1324035.88 rows=11 width=19)
+               ->  Nested Loop Left Join  (cost=0.00..1324035.89 rows=11 width=19)
                      Join Filter: (((t1.c1)::absint = ((t1n.c1n)::absint)) IS NOT FALSE)
                      ->  Seq Scan on t1  (cost=0.00..431.00 rows=4 width=14)
-                     ->  Result  (cost=0.00..431.00 rows=7 width=5)
-                           ->  Materialize  (cost=0.00..431.00 rows=7 width=4)
+                     ->  Materialize  (cost=0.00..431.00 rows=7 width=5)
+                           ->  Result  (cost=0.00..431.00 rows=7 width=5)
                                  ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=7 width=4)
                                        ->  Seq Scan on t1n  (cost=0.00..431.00 rows=3 width=4)
  Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0

--- a/src/test/regress/expected/pg_lsn_optimizer.out
+++ b/src/test/regress/expected/pg_lsn_optimizer.out
@@ -85,12 +85,13 @@ SELECT DISTINCT (i || '/' || j)::pg_lsn f
                      ->  Result
                            Filter: (generate_series_2.generate_series <= 10)
                            ->  Function Scan on generate_series generate_series_2
-                     ->  Result
-                           Filter: ((generate_series_1.generate_series > 0) AND (generate_series_1.generate_series <= 10))
-                           ->  Function Scan on generate_series generate_series_1
+                     ->  Materialize
+                           ->  Result
+                                 Filter: ((generate_series_1.generate_series > 0) AND (generate_series_1.generate_series <= 10))
+                                 ->  Function Scan on generate_series generate_series_1
                ->  Function Scan on generate_series
- Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
-(16 rows)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(17 rows)
 
 SELECT DISTINCT (i || '/' || j)::pg_lsn f
   FROM generate_series(1, 10) i,

--- a/src/test/regress/expected/portals_optimizer.out
+++ b/src/test/regress/expected/portals_optimizer.out
@@ -1141,9 +1141,10 @@ explain (costs off) declare c1 cursor for select (select 42) as x;
  Nested Loop Left Join
    Join Filter: true
    ->  Result
-   ->  Result
+   ->  Materialize
+         ->  Result
  Optimizer: Pivotal Optimizer (GPORCA)
-(5 rows)
+(6 rows)
 
 explain (costs off) declare c1 scroll cursor for select (select 42) as x;
               QUERY PLAN               
@@ -1151,9 +1152,10 @@ explain (costs off) declare c1 scroll cursor for select (select 42) as x;
  Nested Loop Left Join
    Join Filter: true
    ->  Result
-   ->  Result
+   ->  Materialize
+         ->  Result
  Optimizer: Pivotal Optimizer (GPORCA)
-(5 rows)
+(6 rows)
 
 declare c1 scroll cursor for select (select 42) as x;
 fetch all in c1;

--- a/src/test/regress/expected/qp_correlated_query_optimizer.out
+++ b/src/test/regress/expected/qp_correlated_query_optimizer.out
@@ -206,26 +206,27 @@ select * from A,B where exists (select * from C where B.i not in (select C.i fro
          Join Filter: true
          ->  Broadcast Motion 3:3  (slice4; segments: 3)
                ->  Seq Scan on a
-         ->  Result
-               Filter: ((SubPlan 1) > '0'::bigint)
-               ->  Seq Scan on b
-               SubPlan 1
-                 ->  Aggregate
-                       ->  Nested Loop
-                             Join Filter: true
-                             ->  Result
-                                   Filter: ((CASE WHEN (sum((CASE WHEN (b.i = c_1.i) THEN 1 ELSE 0 END)) IS NULL) THEN true WHEN (sum((CASE WHEN (c_1.i IS NULL) THEN 1 ELSE 0 END)) > '0'::bigint) THEN NULL::boolean WHEN (b.i IS NULL) THEN NULL::boolean WHEN (sum((CASE WHEN (b.i = c_1.i) THEN 1 ELSE 0 END)) = '0'::bigint) THEN true ELSE false END) = true)
-                                   ->  Aggregate
-                                         ->  Result
-                                               ->  Materialize
-                                                     ->  Broadcast Motion 3:3  (slice3; segments: 3)
-                                                           ->  Seq Scan on c c_1
-                                                                 Filter: (i <> 10)
-                             ->  Materialize
-                                   ->  Broadcast Motion 3:3  (slice2; segments: 3)
-                                         ->  Seq Scan on c
- Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
-(24 rows)
+         ->  Materialize
+               ->  Result
+                     Filter: ((SubPlan 1) > '0'::bigint)
+                     ->  Seq Scan on b
+                     SubPlan 1
+                       ->  Aggregate
+                             ->  Nested Loop
+                                   Join Filter: true
+                                   ->  Result
+                                         Filter: ((CASE WHEN (sum((CASE WHEN (b.i = c_1.i) THEN 1 ELSE 0 END)) IS NULL) THEN true WHEN (sum((CASE WHEN (c_1.i IS NULL) THEN 1 ELSE 0 END)) > '0'::bigint) THEN NULL::boolean WHEN (b.i IS NULL) THEN NULL::boolean WHEN (sum((CASE WHEN (b.i = c_1.i) THEN 1 ELSE 0 END)) = '0'::bigint) THEN true ELSE false END) = true)
+                                         ->  Aggregate
+                                               ->  Result
+                                                     ->  Materialize
+                                                           ->  Broadcast Motion 3:3  (slice3; segments: 3)
+                                                                 ->  Seq Scan on c c_1
+                                                                       Filter: (i <> 10)
+                                   ->  Materialize
+                                         ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                                               ->  Seq Scan on c
+ Optimizer: Pivotal Optimizer (GPORCA)
+(25 rows)
 
 select * from A,B where exists (select * from C where B.i not in (select C.i from C where C.i != 10));
  i  | j  | i  | j 

--- a/src/test/regress/expected/rpt_optimizer.out
+++ b/src/test/regress/expected/rpt_optimizer.out
@@ -822,10 +822,11 @@ explain (costs off) select * from t_replicate_volatile, t_hashdist where t_repli
    ->  Nested Loop
          Join Filter: true
          ->  Seq Scan on t_hashdist
-         ->  Seq Scan on t_replicate_volatile
-               Filter: ((a)::double precision > random())
+         ->  Materialize
+               ->  Seq Scan on t_replicate_volatile
+                     Filter: ((a)::double precision > random())
  Optimizer: Pivotal Optimizer (GPORCA)
-(7 rows)
+(8 rows)
 
 -- join qual
 explain (costs off) select * from t_hashdist, t_replicate_volatile x, t_replicate_volatile y where x.a + y.a > random();
@@ -950,15 +951,16 @@ explain (costs off) select * from t_hashdist cross join (select a, sum(b) as s f
    ->  Nested Loop
          Join Filter: true
          ->  Seq Scan on t_hashdist
-         ->  Result
-               Filter: (((sum(t_replicate_volatile.b)))::double precision > random())
-               ->  GroupAggregate
-                     Group Key: t_replicate_volatile.a
-                     ->  Sort
-                           Sort Key: t_replicate_volatile.a
-                           ->  Seq Scan on t_replicate_volatile
+         ->  Materialize
+               ->  Result
+                     Filter: (((sum(t_replicate_volatile.b)))::double precision > random())
+                     ->  GroupAggregate
+                           Group Key: t_replicate_volatile.a
+                           ->  Sort
+                                 Sort Key: t_replicate_volatile.a
+                                 ->  Seq Scan on t_replicate_volatile
  Optimizer: Pivotal Optimizer (GPORCA)
-(12 rows)
+(13 rows)
 
 -- insert
 explain (costs off) insert into t_replicate_volatile select random() from t_replicate_volatile;

--- a/src/test/regress/expected/subselect_gp_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_optimizer.out
@@ -193,8 +193,8 @@ explain select * from mrs_t1 where x in (select x-95 from mrs_t1) or x < 5;
                      ->  Sort  (cost=0.00..431.00 rows=7 width=14)
                            Sort Key: mrs_t1_1.x, mrs_t1_1.ctid, mrs_t1_1.gp_segment_id
                            ->  Seq Scan on mrs_t1 mrs_t1_1  (cost=0.00..431.00 rows=7 width=14)
-                     ->  Result  (cost=0.00..431.00 rows=20 width=5)
-                           ->  Materialize  (cost=0.00..431.00 rows=20 width=4)
+                     ->  Materialize  (cost=0.00..431.00 rows=20 width=5)
+                           ->  Result  (cost=0.00..431.00 rows=20 width=5)
                                  ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=20 width=4)
                                        ->  Seq Scan on mrs_t1  (cost=0.00..431.00 rows=7 width=4)
  Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
@@ -376,10 +376,10 @@ explain select * from csq_m1 where x not in (select x from csq_d1) or x < -100; 
                                              ->  Redistribute Motion 1:3  (slice3)  (cost=0.00..1293.00 rows=4 width=19)
                                                    ->  Nested Loop Left Join  (cost=0.00..1293.00 rows=2 width=19)
                                                          Join Filter: ((csq_m1.x = csq_d1.x) IS NOT FALSE)
-                                                         ->  Seq Scan on csq_m1  (cost=0.00..431.00 rows=1 width=14)
-                                                         ->  Result  (cost=0.00..431.00 rows=1 width=5)
-                                                               ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
-                                                                     ->  Gather Motion 3:1  (slice4; segments: 3)  (cost=0.00..431.00 rows=2 width=4)
+                                                         ->  Seq Scan on csq_m1  (cost=0.00..431.00 rows=3 width=14)
+                                                         ->  Materialize  (cost=0.00..431.00 rows=3 width=5)
+                                                               ->  Result  (cost=0.00..431.00 rows=3 width=5)
+                                                                     ->  Gather Motion 3:1  (slice4; segments: 3)  (cost=0.00..431.00 rows=3 width=4)
                                                                            ->  Seq Scan on csq_d1  (cost=0.00..431.00 rows=1 width=4)
  Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
 (23 rows)
@@ -406,11 +406,11 @@ explain select * from csq_d1 where x not in (select x from csq_m1) or x < -100; 
                      ->  Sort  (cost=0.00..431.00 rows=1 width=14)
                            Sort Key: csq_d1.x, csq_d1.ctid, csq_d1.gp_segment_id
                            ->  Seq Scan on csq_d1  (cost=0.00..431.00 rows=1 width=14)
-                     ->  Result  (cost=0.00..431.00 rows=3 width=5)
-                           ->  Materialize  (cost=0.00..431.00 rows=3 width=4)
-                                 ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..431.00 rows=9 width=4)
-                                       ->  Seq Scan on csq_m1  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
+                     ->  Materialize  (cost=0.00..431.00 rows=3 width=5)
+                           ->  Result  (cost=0.00..431.00 rows=3 width=5)
+                                 ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..431.00 rows=3 width=4)
+                                       ->  Seq Scan on csq_m1  (cost=0.00..431.00 rows=3 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
 (15 rows)
 
 select * from csq_d1 where x not in (select x from csq_m1) or x < -100; -- (4)
@@ -2767,8 +2767,8 @@ explain (verbose, costs off) with run_dt as (
 )
 select * from run_dt, extra_flow_dist1
 where dt < '2010-01-01'::date;
-                                         QUERY PLAN                                         
---------------------------------------------------------------------------------------------
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Output: ((SubPlan 1)), extra_flow_dist1.a, extra_flow_dist1.b
    ->  Nested Loop
@@ -2779,18 +2779,20 @@ where dt < '2010-01-01'::date;
          ->  Result
                Output: ((SubPlan 1))
                Filter: (((SubPlan 1)) < '01-01-2010'::date)
-               ->  Seq Scan on subselect_gp.extra_flow_rand
-                     Output: (SubPlan 1)
-                     SubPlan 1
-                       ->  Result
-                             Output: extra_flow_dist.c
-                             Filter: (extra_flow_dist.b = extra_flow_rand.a)
-                             ->  Materialize
-                                   Output: extra_flow_dist.b, extra_flow_dist.c
-                                   ->  Broadcast Motion 3:3  (slice2; segments: 3)
+               ->  Materialize
+                     Output: ((SubPlan 1))
+                     ->  Seq Scan on subselect_gp.extra_flow_rand
+                           Output: (SubPlan 1)
+                           SubPlan 1
+                             ->  Result
+                                   Output: extra_flow_dist.c
+                                   Filter: (extra_flow_dist.b = extra_flow_rand.a)
+                                   ->  Materialize
                                          Output: extra_flow_dist.b, extra_flow_dist.c
-                                         ->  Seq Scan on subselect_gp.extra_flow_dist
+                                         ->  Broadcast Motion 3:3  (slice2; segments: 3)
                                                Output: extra_flow_dist.b, extra_flow_dist.c
+                                               ->  Seq Scan on subselect_gp.extra_flow_dist
+                                                     Output: extra_flow_dist.b, extra_flow_dist.c
  Optimizer: Pivotal Optimizer (GPORCA)
 (23 rows)
 

--- a/src/test/regress/expected/subselect_gp_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_optimizer.out
@@ -2776,11 +2776,11 @@ where dt < '2010-01-01'::date;
          Join Filter: true
          ->  Seq Scan on subselect_gp.extra_flow_dist1
                Output: extra_flow_dist1.a, extra_flow_dist1.b
-         ->  Result
+         ->  Materialize
                Output: ((SubPlan 1))
-               Filter: (((SubPlan 1)) < '01-01-2010'::date)
-               ->  Materialize
+               ->  Result
                      Output: ((SubPlan 1))
+                     Filter: (((SubPlan 1)) < '01-01-2010'::date)
                      ->  Seq Scan on subselect_gp.extra_flow_rand
                            Output: (SubPlan 1)
                            SubPlan 1

--- a/src/test/regress/expected/subselect_optimizer.out
+++ b/src/test/regress/expected/subselect_optimizer.out
@@ -262,16 +262,19 @@ select 1 = all (select (select 1));
    Join Filter: true
    ->  Result
          Output: true
-   ->  Nested Loop Left Join
+   ->  Materialize
          Output: (1)
-         Join Filter: true
-         ->  Result
-               Output: true
-         ->  Result
-               Output: 1
+         ->  Nested Loop Left Join
+               Output: (1)
+               Join Filter: true
+               ->  Result
+                     Output: true
+               ->  Materialize
+                     Output: (1)
+                     ->  Result
+                           Output: 1
  Optimizer: Pivotal Optimizer (GPORCA)
- Settings: optimizer=on
-(14 rows)
+(17 rows)
 
 select 1 = all (select (select 1));
  ?column? 
@@ -1187,22 +1190,24 @@ select * from
   (3 not in (select * from (values (1), (2)) ss1)),
   (false)
 ) ss;
-                                                                                                                                                                QUERY PLAN                                                                                                                                                                 
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                 QUERY PLAN                                                                                                                                                                 
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Append
    ->  Nested Loop Left Join
          Output: ((CASE WHEN (sum((CASE WHEN (3 = column1) THEN 1 ELSE 0 END)) IS NULL) THEN true WHEN (sum((CASE WHEN (column1 IS NULL) THEN 1 ELSE 0 END)) > '0'::bigint) THEN NULL::boolean WHEN (3 IS NULL) THEN NULL::boolean WHEN (sum((CASE WHEN (3 = column1) THEN 1 ELSE 0 END)) = '0'::bigint) THEN true ELSE false END) = true)
          Join Filter: true
          ->  Result
                Output: true
-         ->  Aggregate
-               Output: CASE WHEN (sum((CASE WHEN (3 = column1) THEN 1 ELSE 0 END)) IS NULL) THEN true WHEN (sum((CASE WHEN (column1 IS NULL) THEN 1 ELSE 0 END)) > '0'::bigint) THEN NULL::boolean WHEN (3 IS NULL) THEN NULL::boolean WHEN (sum((CASE WHEN (3 = column1) THEN 1 ELSE 0 END)) = '0'::bigint) THEN true ELSE false END
-               ->  Values Scan on "Values"
-                     Output: CASE WHEN (3 = column1) THEN 1 ELSE 0 END, CASE WHEN (column1 IS NULL) THEN 1 ELSE 0 END
+         ->  Materialize
+               Output: (CASE WHEN (sum((CASE WHEN (3 = column1) THEN 1 ELSE 0 END)) IS NULL) THEN true WHEN (sum((CASE WHEN (column1 IS NULL) THEN 1 ELSE 0 END)) > '0'::bigint) THEN NULL::boolean WHEN (3 IS NULL) THEN NULL::boolean WHEN (sum((CASE WHEN (3 = column1) THEN 1 ELSE 0 END)) = '0'::bigint) THEN true ELSE false END)
+               ->  Aggregate
+                     Output: CASE WHEN (sum((CASE WHEN (3 = column1) THEN 1 ELSE 0 END)) IS NULL) THEN true WHEN (sum((CASE WHEN (column1 IS NULL) THEN 1 ELSE 0 END)) > '0'::bigint) THEN NULL::boolean WHEN (3 IS NULL) THEN NULL::boolean WHEN (sum((CASE WHEN (3 = column1) THEN 1 ELSE 0 END)) = '0'::bigint) THEN true ELSE false END
+                     ->  Values Scan on "Values"
+                           Output: CASE WHEN (3 = column1) THEN 1 ELSE 0 END, CASE WHEN (column1 IS NULL) THEN 1 ELSE 0 END
    ->  Result
          Output: false
  Optimizer: Pivotal Optimizer (GPORCA)
-(13 rows)
+(15 rows)
 
 select * from
 (values


### PR DESCRIPTION
If the inner child is Result node, Orca may generate a plan that does not materialize the nestloop join's inner child, which will case bad performance. This patch has fixed the issue by forcing materialize the inner child.
