### PR TITLE
[6X] pg_dump and pg_upgrade: fix/change external partition handling

### DIFF
--- a/contrib/pg_upgrade/greenplum/check_gp.c
+++ b/contrib/pg_upgrade/greenplum/check_gp.c
@@ -17,9 +17,6 @@
 #include "pg_upgrade_greenplum.h"
 #include "check_gp.h"
 
-#define RELSTORAGE_EXTERNAL	'x'
-
-static void check_external_partition(void);
 static void check_covering_aoindex(void);
 static void check_parent_partitions_with_seg_entries(void);
 static void check_partition_indexes(void);
@@ -52,7 +49,6 @@ void
 check_greenplum(void)
 {
 	check_online_expansion();
-	check_external_partition();
 	check_covering_aoindex();
 	check_parent_partitions_with_seg_entries();
     check_heterogeneous_partition();
@@ -223,87 +219,6 @@ check_unique_primary_constraint(void)
 			   "| on tables.  These constraints need to be removed\n"
 			   "| from the tables before the upgrade.  A list of\n"
 			   "| constraints to remove is in the file:\n"
-			   "| \t%s\n\n", output_path);
-	}
-	else
-		check_ok();
-}
-/*
- *	check_external_partition
- *
- *	External tables cannot be included in the partitioning hierarchy during the
- *	initial definition with CREATE TABLE, they must be defined separately and
- *	injected via ALTER TABLE EXCHANGE. The partitioning system catalogs are
- *	however not replicated onto the segments which means ALTER TABLE EXCHANGE
- *	is prohibited in utility mode. This means that pg_upgrade cannot upgrade a
- *	cluster containing external partitions, they must be handled manually
- *	before/after the upgrade.
- *
- *	Check for the existence of external partitions and refuse the upgrade if
- *	found.
- */
-static void
-check_external_partition(void)
-{
-	char		output_path[MAXPGPATH];
-	FILE	   *script = NULL;
-	bool		found = false;
-	int			dbnum;
-
-	prep_status("Checking for external tables used in partitioning");
-
-	snprintf(output_path, sizeof(output_path), "external_partitions.txt");
-	/*
-	 * We need to query the inheritance catalog rather than the partitioning
-	 * catalogs since they are not available on the segments.
-	 */
-
-	for (dbnum = 0; dbnum < old_cluster.dbarr.ndbs; dbnum++)
-	{
-		PGresult   *res;
-		int			ntups;
-		int			rowno;
-		DbInfo	   *active_db = &old_cluster.dbarr.dbs[dbnum];
-		PGconn	   *conn;
-
-		conn = connectToServer(&old_cluster, active_db->db_name);
-		res = executeQueryOrDie(conn,
-			 "SELECT cc.relname, c.relname AS partname, c.relnamespace "
-			 "FROM   pg_inherits i "
-			 "       JOIN pg_class c ON (i.inhrelid = c.oid AND c.relstorage = '%c') "
-			 "       JOIN pg_class cc ON (i.inhparent = cc.oid);",
-			 RELSTORAGE_EXTERNAL);
-
-		ntups = PQntuples(res);
-
-		if (ntups > 0)
-		{
-			found = true;
-
-			if (script == NULL && (script = fopen(output_path, "w")) == NULL)
-				pg_log(PG_FATAL, "Could not create necessary file:  %s\n",
-					   output_path);
-
-			for (rowno = 0; rowno < ntups; rowno++)
-			{
-				fprintf(script, "External partition \"%s\" in relation \"%s\"\n",
-						PQgetvalue(res, rowno, PQfnumber(res, "partname")),
-						PQgetvalue(res, rowno, PQfnumber(res, "relname")));
-			}
-		}
-
-		PQclear(res);
-		PQfinish(conn);
-	}
-	if (found)
-	{
-		fclose(script);
-		pg_log(PG_REPORT, "fatal\n");
-		gp_fatal_log(
-			   "| Your installation contains partitioned tables with external\n"
-			   "| tables as partitions.  These partitions need to be removed\n"
-			   "| from the partition hierarchy before the upgrade.  A list of\n"
-			   "| external partitions to remove is in the file:\n"
 			   "| \t%s\n\n", output_path);
 	}
 	else

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -4861,7 +4861,7 @@ ATPrepCmd(List **wqueue, Relation rel, AlterTableCmd *cmd,
 
 			ATPartitionCheck(cmd->subtype, rel, false, recursing);
 
-			if (Gp_role == GP_ROLE_UTILITY)
+			if (Gp_role == GP_ROLE_UTILITY && !IsBinaryUpgrade)
 				ereport(ERROR,
 						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
  						 errmsg("EXCHANGE is not supported in utility mode")));
@@ -16446,7 +16446,7 @@ ATPExecPartAlter(List **wqueue, AlteredTableInfo *tab, Relation *rel,
 			else if (prepExchange)
 			{
 				ATPartitionCheck(atc->subtype, *rel, false, false);
-				if (Gp_role == GP_ROLE_UTILITY)
+				if (Gp_role == GP_ROLE_UTILITY && !IsBinaryUpgrade)
 					ereport(ERROR,
 							(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 							 errmsg("EXCHANGE is not supported in utility mode")));
@@ -16821,14 +16821,14 @@ ATPExecPartExchange(AlteredTableInfo *tab, Relation rel, AlterPartitionCmd *pc)
 	List				*pcols = NIL; /* partitioned attributes of rel */
 	AlterPartitionIdType orig_pid_type = AT_AP_IDNone;	/* save for NOTICE msg at end... */
 
-	if (Gp_role == GP_ROLE_UTILITY)
+	if (Gp_role == GP_ROLE_UTILITY && !IsBinaryUpgrade)
 		return;
 
 	/* Exchange for SPLIT is different from user-requested EXCHANGE.  The special
 	 * coding to indicate SPLIT is obscure. */
 	is_split = ((AlterPartitionCmd *)pc->arg2)->arg2 != NULL;
 
-	if (Gp_role == GP_ROLE_DISPATCH)
+	if (Gp_role == GP_ROLE_DISPATCH || (Gp_role == GP_ROLE_UTILITY && IsBinaryUpgrade))
 	{
 		AlterPartitionId   *pid   = (AlterPartitionId *)pc->partid;
 		PgPartRule   	   *prule = NULL;
@@ -17132,7 +17132,7 @@ ATPExecPartExchange(AlteredTableInfo *tab, Relation rel, AlterPartitionCmd *pc)
 		}
 
 		/* fix up partitioning rule if we're on the QD*/
-		if (Gp_role == GP_ROLE_DISPATCH)
+		if (Gp_role == GP_ROLE_DISPATCH || (Gp_role == GP_ROLE_UTILITY && IsBinaryUpgrade))
 		{
 			exchange_part_rule(oldrelid, newrelid);
 			CommandCounterIncrement();
@@ -20072,7 +20072,7 @@ ATPrepExchange(Relation rel, AlterPartitionCmd *pc)
 	Relation			 oldrel = NULL;
 	Relation			 newrel = NULL;
 
-	if (Gp_role == GP_ROLE_DISPATCH)
+	if (Gp_role == GP_ROLE_DISPATCH || (Gp_role == GP_ROLE_UTILITY && IsBinaryUpgrade))
 	{
 		AlterPartitionId *pid = (AlterPartitionId *) pc->partid;
 		bool				is_split;

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -13769,87 +13769,193 @@ dumpTableSchema(Archive *fout, TableInfo *tbinfo)
 		appendPQExpBufferStr(q, ";\n");
 
 		/*
-		 * Exchange external partitions. This is an expensive process, so only
-		 * run it if we've found evidence of external partitions up above.
+		 * GPDB: Exchange external partitions. This is an expensive process,
+		 * so only run it if we've found evidence of external partitions up
+		 * above.
 		 */
 		if (hasExternalPartitions)
 		{
-			int i = 0;
-			int ntups = 0;
-			char *relname = NULL;
+			int numExternalPartitions = 0;
 			int i_relname = 0;
 			int i_parname = 0;
+			int i_parparentrule = 0;
+			int i_parlevel = 0;
 			int i_partitionrank = 0;
-			PQExpBuffer query = createPQExpBuffer();
-			PGresult   *res;
+			int j_paroid = 0;
+			int j_parlevel = 0;
+			int j_parparentrule = 0;
+			int j_parname = 0;
+			int j_partitionrank = 0;
+			char *maxExtPartLevel;
+			PQExpBuffer getExternalPartsQuery = createPQExpBuffer();
+			PQExpBuffer getPartHierarchyQuery = createPQExpBuffer();
+			PGresult   *getExternalPartsResult;
+			PGresult   *getPartHierarchyResult;
 
 			/*
-			 * The multiple JOINs below trigger an apparent planner bug which
-			 * may effectively hang the backend. This bug is present in both
-			 * released versions of GPDB and the current development tip at time
-			 * of writing. Disable nestloops temporarily as a workaround.
-			 *
-			 * TODO: when this bug is fixed, version-gate this code so that we
-			 * don't run it on well-behaved backends.
+			 * We disable nestloops here because the previous original query
+			 * that handled ALTER TABLE EXCHANGE PARTITION had multiple JOINs
+			 * (even joining on pg_partitions view which is usually a big
+			 * no-no) that would trigger an apparent planner bug which
+			 * sometimes would hang the backend. The latest query below is
+			 * much, much simpler so technically we could remove the disabling
+			 * of nestloops... but disabling nestloops actually gives a
+			 * performance boost so we'll keep it for now.
 			 */
 			ExecuteSqlStatement(fout, "SET enable_nestloop TO off");
 
-			appendPQExpBuffer(query, "SELECT DISTINCT cc.relname, ps.partitionrank, pp.parname "
-					"FROM pg_partition p "
-					"JOIN pg_class c on (p.parrelid = c.oid) "
-					"JOIN pg_partitions ps on (c.relname = ps.tablename) "
-					"JOIN pg_class cc on (ps.partitiontablename = cc.relname) "
-					"JOIN pg_partition_rule pp on (cc.oid = pp.parchildrelid) "
-					"WHERE p.parrelid = %u AND cc.relstorage = '%c';",
-					tbinfo->dobj.catId.oid, RELSTORAGE_EXTERNAL);
+			appendPQExpBuffer(getExternalPartsQuery, "SELECT c.relname, pr.parname, pr.parparentrule, p.parlevel, "
+							  "CASE "
+							  "    WHEN p.parkind <> 'r'::\"char\" OR pr.parisdefault THEN NULL::bigint "
+							  "    ELSE pr.parruleord "
+							  "END AS partitionrank "
+							  "FROM pg_class c "
+							  "    JOIN pg_partition_rule pr ON c.oid = pr.parchildrelid "
+							  "    JOIN pg_partition p ON pr.paroid = p.oid AND p.paristemplate = false "
+							  "WHERE p.parrelid = %u AND c.relstorage = '%c' "
+							  "ORDER BY p.parlevel DESC;",
+							  tbinfo->dobj.catId.oid, RELSTORAGE_EXTERNAL);
 
-			res = ExecuteSqlQuery(fout, query->data, PGRES_TUPLES_OK);
+			getExternalPartsResult = ExecuteSqlQuery(fout, getExternalPartsQuery->data, PGRES_TUPLES_OK);
 
-			ntups = PQntuples(res);
-			i_relname = PQfnumber(res, "relname");
-			i_parname = PQfnumber(res, "parname");
-			i_partitionrank = PQfnumber(res, "partitionrank");
+			numExternalPartitions = PQntuples(getExternalPartsResult);
+			if (numExternalPartitions < 1)
+				exit_horribly(NULL, "partition table %s has external partitions but unable to query more details about them\n",
+							  qualrelname);
 
-			/* FIXME: does this code handle external SUBPARTITIONs correctly? */
-			for (i = 0; i < ntups; i++)
+			i_relname = PQfnumber(getExternalPartsResult, "relname");
+			i_parname = PQfnumber(getExternalPartsResult, "parname");
+			i_parparentrule = PQfnumber(getExternalPartsResult, "parparentrule");
+			i_parlevel = PQfnumber(getExternalPartsResult, "parlevel");
+			i_partitionrank = PQfnumber(getExternalPartsResult, "partitionrank");
+
+			/*
+			 * For multi-level partition tables, we must first add ALTER
+			 * PARTITION syntax for the entire subroot hierarchy. The query
+			 * below will get all the necessary subroot information to loop
+			 * over for each external partition.
+			 */
+			maxExtPartLevel = PQgetvalue(getExternalPartsResult, 0, i_parlevel);
+			appendPQExpBuffer(getPartHierarchyQuery, "SELECT pr.oid AS paroid, p.parlevel, pr.parparentrule, pr.parname, "
+							  "CASE "
+							  "    WHEN p.parkind <> 'r'::\"char\" OR pr.parisdefault THEN NULL::bigint "
+							  "    ELSE pr.parruleord "
+							  "END AS partitionrank "
+							  "FROM pg_partition p "
+							  "    JOIN pg_partition_rule pr ON p.oid = pr.paroid AND p.paristemplate = false "
+							  "WHERE p.parrelid = %u AND p.parlevel < %s "
+							  "ORDER BY p.parlevel DESC;",
+							  tbinfo->dobj.catId.oid, maxExtPartLevel);
+			getPartHierarchyResult = ExecuteSqlQuery(fout, getPartHierarchyQuery->data, PGRES_TUPLES_OK);
+
+			j_paroid = PQfnumber(getPartHierarchyResult, "paroid");
+			j_parlevel = PQfnumber(getPartHierarchyResult, "parlevel");
+			j_parparentrule = PQfnumber(getPartHierarchyResult, "parparentrule");
+			j_parname = PQfnumber(getPartHierarchyResult, "parname");
+			j_partitionrank = PQfnumber(getPartHierarchyResult, "partitionrank");
+
+			for (int i = 0; i < numExternalPartitions; i++)
 			{
+				int maxParLevel = atoi(PQgetvalue(getExternalPartsResult, i, i_parlevel));
+				int lookupSubRootHierarchyIndex[maxParLevel];
+				char *parentOid = PQgetvalue(getExternalPartsResult, i, i_parparentrule);
+				char *relname  = pg_strdup(PQgetvalue(getExternalPartsResult, i, i_relname));
+				char *qualTmpExtTable;
 				char tmpExtTable[500] = {0};
-				relname = pg_strdup(PQgetvalue(res, i, i_relname));
-				snprintf(tmpExtTable, sizeof(tmpExtTable), "%s%s", relname, EXT_PARTITION_NAME_POSTFIX);
-				char *qualTmpExtTable = pg_strdup(fmtQualifiedId(fout->remoteVersion,
-																 tbinfo->dobj.namespace->dobj.name,
-																 tmpExtTable));
 
+				snprintf(tmpExtTable, sizeof(tmpExtTable), "%s%s", relname, EXT_PARTITION_NAME_POSTFIX);
+				qualTmpExtTable = pg_strdup(fmtQualifiedId(fout->remoteVersion,
+														   tbinfo->dobj.namespace->dobj.name,
+														   tmpExtTable));
+
+				/* Start of the ALTER TABLE EXCHANGE PARTITION statement */
 				appendPQExpBuffer(q, "ALTER TABLE %s ", qualrelname);
+
 				/*
-				 * If it is an anonymous range partition we must exchange for
-				 * the rank rather than the parname.
+				 * Populate the lookupSubRootHierarchyIndex array with the
+				 * getPartHierarchy result row numbers that make up the
+				 * partition hierarchy of a specific external partition. To do
+				 * this, we go backwards (in terms of partition level) from
+				 * the external partition's parent up to the root (ending at
+				 * partition level 0 directly below the root). Because of
+				 * that, the lookupSubRootHierarchyIndex array is actually
+				 * filled out in reverse.
 				 */
-				if (PQgetisnull(res, i, i_parname) || !strlen(PQgetvalue(res, i, i_parname)))
+				for (int j = 0; j < PQntuples(getPartHierarchyResult); j++)
+				{
+					char *currentOid;
+					int currentParLevel;
+
+					currentOid = PQgetvalue(getPartHierarchyResult, j, j_paroid);
+					if (strcmp(parentOid, currentOid) != 0)
+						continue;
+
+					currentParLevel = atoi(PQgetvalue(getPartHierarchyResult, j, j_parlevel));
+					lookupSubRootHierarchyIndex[currentParLevel] = j;
+
+					/*
+					 * Get the next parent OID to search for. If 0, we've
+					 * reached the root and can exit the loop.
+					 */
+					parentOid = PQgetvalue(getPartHierarchyResult, j, j_parparentrule);
+					if (strcmp(parentOid, "0") == 0)
+						break;
+				}
+
+				/*
+				 * Forward traverse the lookupSubRootHierarchyIndex array to
+				 * append the required ALTER PARTITION statement(s) in the
+				 * correct partition level order. If it is an anonymous range
+				 * partition we must exchange for the rank rather than the
+				 * parname.
+				 */
+				for (int parLevel = 0; parLevel < maxParLevel; parLevel++)
+				{
+					int hierarchyIndex = lookupSubRootHierarchyIndex[parLevel];
+
+					if (PQgetisnull(getPartHierarchyResult, hierarchyIndex, j_parname) ||
+						!strlen(PQgetvalue(getPartHierarchyResult, hierarchyIndex, j_parname)))
+					{
+						appendPQExpBuffer(q, "ALTER PARTITION FOR (RANK(%s)) ",
+										  PQgetvalue(getPartHierarchyResult, hierarchyIndex, j_partitionrank));
+					}
+					else
+					{
+						appendPQExpBuffer(q, "ALTER PARTITION %s ",
+										  fmtId(PQgetvalue(getPartHierarchyResult, hierarchyIndex, j_parname)));
+					}
+				}
+
+				/*
+				 * Add the actual EXCHANGE PARTITION part of the ALTER TABLE
+				 * EXCHANGE PARTITION statement. If it is an anonymous range
+				 * partition we must exchange for the rank rather than the
+				 * parname.
+				 */
+				if (PQgetisnull(getExternalPartsResult, i, i_parname) ||
+					!strlen(PQgetvalue(getExternalPartsResult, i, i_parname)))
 				{
 					appendPQExpBuffer(q, "EXCHANGE PARTITION FOR (RANK(%s)) ",
-									  PQgetvalue(res, i, i_partitionrank));
+									  PQgetvalue(getExternalPartsResult, i, i_partitionrank));
 				}
 				else
 				{
 					appendPQExpBuffer(q, "EXCHANGE PARTITION %s ",
-									  fmtId(PQgetvalue(res, i, i_parname)));
+									  fmtId(PQgetvalue(getExternalPartsResult, i, i_parname)));
 				}
-				appendPQExpBuffer(q, "WITH TABLE %s WITHOUT VALIDATION; ", qualTmpExtTable);
 
-				appendPQExpBuffer(q, "\n");
+				appendPQExpBuffer(q, "WITH TABLE %s WITHOUT VALIDATION;\n", qualTmpExtTable);
+				appendPQExpBuffer(q, "DROP TABLE %s;\n", qualTmpExtTable);
 
-				appendPQExpBuffer(q, "DROP TABLE %s; ", qualTmpExtTable);
-
-				appendPQExpBuffer(q, "\n");
 				free(relname);
 				free(qualTmpExtTable);
 			}
 
-			PQclear(res);
-			destroyPQExpBuffer(query);
+			PQclear(getPartHierarchyResult);
+			PQclear(getExternalPartsResult);
+			destroyPQExpBuffer(getPartHierarchyQuery);
+			destroyPQExpBuffer(getExternalPartsQuery);
 
-			/* TODO: version-gate this when the planner bug is fixed; see above. */
 			ExecuteSqlStatement(fout, "SET enable_nestloop TO on");
 		}
 

--- a/src/bin/pg_dump/pg_dump.h
+++ b/src/bin/pg_dump/pg_dump.h
@@ -567,7 +567,6 @@ extern char g_comment_end[10];
 
 extern char g_opaque_type[10];	/* name for the opaque type */
 
-extern const char *EXT_PARTITION_NAME_POSTFIX;
 /*
  *	common utility functions
  */


### PR DESCRIPTION
The individual commits that make upgrading external partitions work:
```
commit 1495eec10b5bc1485e7b1eaaf9f6c2a4897ce175
Author: Jimmy Yih <jyih@vmware.com>
Date:   Thu Jan 19 18:42:13 2023 -0800

    Allow EXCHANGE PARTITION to run in utility mode during upgrade

    We don't allow EXCHANGE PARTITION to run in utility mode because
    primary segments do not have the pg_partition_rule catalog information
    to be able to perform the EXCHANGE PARTITION. However, we should allow
    it to run during upgrade because only the coordinator segment is
    touched which does have the pg_partition_rule data (its catalog is
    later copied over to the primary segments as a part of the gpupgrade
    flow).

commit 0e853d6e20933d8d06c961a0181decf651f46e47
Author: Jimmy Yih <jyih@vmware.com>
Date:   Fri Jan 20 14:32:43 2023 -0800

    Remove check for external partitions

    In an old GPDB commit, external partitions were banned from being
    upgraded because ALTER TABLE EXCHANGE PARTITION was banned in utility
    mode. The ALTER TABLE EXCHANGE PARTITION code could have been modified
    to work with upgrade but the logic would not work when primary
    segments were upgraded due to their lack of pg_partition_rule
    data. Nowadays however, we only upgrade the coordinator segment and
    copy its catalog to the target primary segments as a part of gpupgrade
    logic. Because of that, we can remove the check for external
    partitions and fix the underlying ALTER TABLE EXCHANGE PARTITION issue
    instead.

    Old GPDB commit reference:
    https://github.com/greenplum-db/gpdb/commit/ceda2890a43247a4b97ee68b9970240cb04977d0

commit 3ee14a583de20f842b387c5c931bf00cf145ffa0
Author: Jimmy Yih <jyih@vmware.com>
Date:   Tue Jan 24 16:58:53 2023 -0800

    Fix pg_dump external partition logic for multi-level partition tables

    The old logic was only able to handle simple partition tables that did
    not contain subpartitions. Also, the query being used was a bit
    excessive for the result produced. To fix the issue, we now do two
    simple queries: one query that gets the external partitions of a
    partition table and another query that gets the subroot hierarchy to
    be used when dealing with a multi-level partition table. Using the two
    query results and some result parsing, we now properly output the
    ALTER TABLE EXCHANGE PARTITION to contain the required ALTER PARTITION
    syntax for each subroot.

    Fixes https://github.com/greenplum-db/gpdb/issues/5003.

    Co-authored-by: Kalen Krempely <kkrempely@vmware.com>

commit 3a0d211f8a500c6bc15fcc98fb39c4c2db704eae
Author: Jimmy Yih <jyih@vmware.com>
Date:   Tue Jan 24 17:24:56 2023 -0800

    Fix pg_dump temporary external table logic for external partitions

    When dealing with external partitions, pg_dump outputs SQL to create a
    temporary external table that will later be used in an ALTER TABLE
    EXCHANGE PARTITION. This worked fine for most pg_dump cases but did
    not work for binary upgrade scenarios where the temporary external
    table name generated was longer than NAMEDATALEN. During restore, the
    temporary external table was not able to obtain the preserved OID. The
    preserved OID is mapped to the temporary external table's full name
    but CREATE EXTERNAL TABLE truncates the name down to NAMEDATALEN which
    results in the temporary external table getting a new OID instead of
    using the preserved OID. Afterwards, pg_upgrade would error with an
    OID mismatch failure.

    To fix the issue, the logic to generate the temporary external table
    name has been changed to always be under length NAMEDATALEN while
    staying unique and identifiable to the partition. With that, the
    preserved OID will always be used during restore.
```

Test coverage PR in the gpupgrade repository:
https://github.com/greenplum-db/gpupgrade/pull/747