### PR TITLE
Fix memory leaks in auto_explain

### DIFF
--- a/contrib/auto_explain/Makefile
+++ b/contrib/auto_explain/Makefile
@@ -4,7 +4,7 @@ MODULE_big = auto_explain
 OBJS = auto_explain.o $(WIN32RES)
 PGFILEDESC = "auto_explain - logging facility for execution plans"
 
-REGRESS = auto_explain bfv_preload_auto_explain
+REGRESS = auto_explain bfv_preload_auto_explain memory_leaks
 REGRESS_OPTS = --init-file=init_file
 
 ifdef USE_PGXS

--- a/contrib/auto_explain/auto_explain.c
+++ b/contrib/auto_explain/auto_explain.c
@@ -263,8 +263,6 @@ _PG_fini(void)
 static void
 explain_ExecutorStart(QueryDesc *queryDesc, int eflags)
 {
-	instr_time		starttime;
-
 	/*
 	 * At the beginning of each top-level statement, decide whether we'll
 	 * sample this statement.  If nested-statement explaining is enabled,
@@ -298,9 +296,13 @@ explain_ExecutorStart(QueryDesc *queryDesc, int eflags)
 
 			queryDesc->instrument_options |= INSTRUMENT_CDB;
 
-			INSTR_TIME_SET_CURRENT(starttime);
-			queryDesc->showstatctx = cdbexplain_showExecStatsBegin(queryDesc,
-																   starttime);
+			if (queryDesc->showstatctx == NULL)
+			{
+				instr_time		starttime;
+				INSTR_TIME_SET_CURRENT(starttime);
+				queryDesc->showstatctx = cdbexplain_showExecStatsBegin(
+											queryDesc, starttime);
+			}
 		}
 	}
 

--- a/contrib/auto_explain/expected/memory_leaks.out
+++ b/contrib/auto_explain/expected/memory_leaks.out
@@ -1,0 +1,53 @@
+CREATE SCHEMA auto_explain_mem_leak_test;
+SET search_path=auto_explain_mem_leak_test;
+LOAD 'auto_explain';
+-- Enable auto_explain. Log all plans
+SET auto_explain.log_min_duration = 0;
+-- Log statements executed inside a function
+SET auto_explain.log_nested_statements=true;
+-- Collect data for EXPLAIN ANALYZE output. The data will be collected for every
+-- query executed inside a function
+SET auto_explain.log_analyze = true;
+CREATE OR REPLACE FUNCTION get_executor_mem(calls_num int) returns int 
+language plpgsql
+as $$
+declare
+    line text;
+    mem int[];
+    total int = 0;
+begin
+    for line in execute(
+       'EXPLAIN ANALYZE 
+        SELECT information_schema._pg_truetypid(a, t)
+        FROM (
+            SELECT a as a, t as t
+            FROM pg_type t
+                JOIN pg_attribute a ON a.atttypid = t.oid
+            WHERE typtype = ''d''
+            LIMIT 1
+        ) at 
+            JOIN generate_series(1, $1) gc ON true')
+    using calls_num	
+    loop
+        mem = regexp_matches(line, 'Executor memory: (\d+)K');
+        continue when mem is null;
+        total = total + mem[1];
+    end loop;
+
+    return total;
+end
+$$;
+-- Memory usage should not depend much on how many times a function written in 
+-- sql language, that optimizers cannot inline, is called during query execution.
+-- The information_schema._pg_truetypid() function is called here.
+-- The amount of memory used for 50,000 calls and 1000 calls should not differ
+-- by more than 10 MB.
+SELECT abs(get_executor_mem(50000) - get_executor_mem(1000)) < 10000;
+ ?column? 
+----------
+ t
+(1 row)
+
+-- clean
+DROP FUNCTION get_executor_mem(calls_num int);
+DROP SCHEMA auto_explain_mem_leak_test;

--- a/contrib/auto_explain/sql/memory_leaks.sql
+++ b/contrib/auto_explain/sql/memory_leaks.sql
@@ -1,0 +1,53 @@
+CREATE SCHEMA auto_explain_mem_leak_test;
+SET search_path=auto_explain_mem_leak_test;
+
+LOAD 'auto_explain';
+-- Enable auto_explain. Log all plans
+SET auto_explain.log_min_duration = 0;
+-- Log statements executed inside a function
+SET auto_explain.log_nested_statements=true;
+-- Collect data for EXPLAIN ANALYZE output. The data will be collected for every
+-- query executed inside a function
+SET auto_explain.log_analyze = true;
+
+CREATE OR REPLACE FUNCTION get_executor_mem(calls_num int) returns int 
+language plpgsql
+as $$
+declare
+    line text;
+    mem int[];
+    total int = 0;
+begin
+    for line in execute(
+       'EXPLAIN ANALYZE 
+        SELECT information_schema._pg_truetypid(a, t)
+        FROM (
+            SELECT a as a, t as t
+            FROM pg_type t
+                JOIN pg_attribute a ON a.atttypid = t.oid
+            WHERE typtype = ''d''
+            LIMIT 1
+        ) at 
+            JOIN generate_series(1, $1) gc ON true')
+    using calls_num	
+    loop
+        mem = regexp_matches(line, 'Executor memory: (\d+)K');
+        continue when mem is null;
+        total = total + mem[1];
+    end loop;
+
+    return total;
+end
+$$;
+
+
+-- Memory usage should not depend much on how many times a function written in 
+-- sql language, that optimizers cannot inline, is called during query execution.
+-- The information_schema._pg_truetypid() function is called here.
+-- The amount of memory used for 50,000 calls and 1000 calls should not differ
+-- by more than 10 MB.
+SELECT abs(get_executor_mem(50000) - get_executor_mem(1000)) < 10000;
+
+-- clean
+DROP FUNCTION get_executor_mem(calls_num int);
+DROP SCHEMA auto_explain_mem_leak_test;

--- a/src/backend/commands/explain.c
+++ b/src/backend/commands/explain.c
@@ -625,8 +625,6 @@ ExplainOnePlan(PlannedStmt *plannedstmt, IntoClause *into, ExplainState *es,
         queryDesc->showstatctx = cdbexplain_showExecStatsBegin(queryDesc,
 															   starttime);
     }
-	else
-		queryDesc->showstatctx = NULL;
 
 	/* Select execution options */
 	if (es->analyze)

--- a/src/backend/commands/explain_gp.c
+++ b/src/backend/commands/explain_gp.c
@@ -1392,6 +1392,27 @@ cdbexplain_showExecStatsBegin(struct QueryDesc *queryDesc,
 }								/* cdbexplain_showExecStatsBegin */
 
 /*
+ * cdbexplain_showStatCtxFree
+ *	  Release memory allocated for CdbExplain_ShowStatCtx structure and its
+ *	  internals. Memory for insides of the slices array elements is allocated
+ *	  in ExplainPrintPlan(). If ExplainPrintPlan() is called from the
+ *	  auto_explain extension, then this memory is released in
+ *	  standard_ExecutorEnd() -> FreeExecutorState() to avoid memory leak in the
+ *	  case of queries with multiple call of SQL functions.
+ *	  If ExplainPrintPlan() is called from ExplainOnePlan(), then this memory
+ *	  is released in PortalDrop().
+ */
+void
+cdbexplain_showStatCtxFree(struct CdbExplain_ShowStatCtx *ctx)
+{
+	Assert(ctx != NULL);
+
+	pfree(ctx->extratextbuf.data);
+	pfree(ctx->slices);
+	pfree(ctx);
+}
+
+/*
  * nodeSupportWorkfileCaching
  *	 Return true if a given node supports workfile caching.
  */

--- a/src/backend/tcop/pquery.c
+++ b/src/backend/tcop/pquery.c
@@ -30,6 +30,7 @@
 #include "utils/memutils.h"
 #include "utils/snapmgr.h"
 
+#include "cdb/cdbexplain.h"
 #include "cdb/ml_ipc.h"
 #include "cdb/cdbtm.h"
 #include "commands/createas.h"
@@ -116,6 +117,7 @@ CreateQueryDesc(PlannedStmt *plannedstmt,
 
 	qd->extended_query = false; /* default value */
 	qd->portal_name = NULL;
+	qd->showstatctx = NULL;
 
 	qd->ddesc = NULL;
 
@@ -140,6 +142,9 @@ FreeQueryDesc(QueryDesc *qdesc)
 	/* forget our snapshots */
 	UnregisterSnapshot(qdesc->snapshot);
 	UnregisterSnapshot(qdesc->crosscheck_snapshot);
+
+	if (qdesc->showstatctx)
+		cdbexplain_showStatCtxFree(qdesc->showstatctx);
 
 	/* Only the QueryDesc itself need be freed */
 	pfree(qdesc);

--- a/src/include/cdb/cdbexplain.h
+++ b/src/include/cdb/cdbexplain.h
@@ -124,6 +124,20 @@ struct CdbExplain_ShowStatCtx *
 cdbexplain_showExecStatsBegin(struct QueryDesc *queryDesc,
                               instr_time        querystarttime);
 
+/*
+ * cdbexplain_showStatCtxFree
+ *	  Release memory allocated for CdbExplain_ShowStatCtx structure and its
+ *	  internals. Memory for insides of the slices array elements is allocated
+ *	  in ExplainPrintPlan(). If ExplainPrintPlan() is called from the
+ *	  auto_explain extension, then this memory is released in
+ *	  standard_ExecutorEnd() -> FreeExecutorState() to avoid memory leak in the
+ *	  case of queries with multiple call of SQL functions.
+ *	  If ExplainPrintPlan() is called from ExplainOnePlan(), then this memory
+ *	  is released in PortalDrop().
+ */
+void
+cdbexplain_showStatCtxFree(struct CdbExplain_ShowStatCtx *ctx);
+
 
 
 #endif   /* CDBEXPLAIN_H */


### PR DESCRIPTION
Statistic context wasn't destroyed with query descriptor, so queries with multiple call of sql functions consumed a lot of memory.

Steps to reproduce:
```
LOAD 'auto_explain';
SET auto_explain.log_nested_statements=true;
SET auto_explain.log_min_duration = 0;
SET auto_explain.log_analyze = true;
explain analyze select information_schema._pg_truetypid(a, t) from (
    select a as a, t as t from pg_type t
    join pg_attribute a on a.atttypid = t.oid
    where typtype = 'd' limit 1
) at join generate_series(1, 9000000) gc on true;
```

Changes:
1. Add cdbexplain_showStatCtxFree() function to release memory allocated for statistic context. The function is called from FreeQueryDesc() when the statistic context exists. To check whether the context exists the assigning NULL value to the showstatctx field of query descriptor is moved from ExplainOnePlan() to CreateQueryDesc() and CreateUtilityQueryDesc().
2. Statistic context in auto_explain isn't created if the context already exists. It may be created in ExplainOnePlan().