### PR TITLE
[6X] Move single row expression handler list-concat logic to parser.

### DIFF
--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -979,16 +979,6 @@ DoCopy(const CopyStmt *stmt, const char *queryString, uint64 *processed)
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 				 errmsg("COPY single row error handling only available using COPY FROM")));
 
-/* GPDB_91_MERGE_FIXME: this should probably be done earlier, e.g. in parser */
-	/* Transfer any SREH options to the options list, so that BeginCopy can see them. */
-	if (stmt->sreh)
-	{
-		SingleRowErrorDesc *sreh = (SingleRowErrorDesc *) stmt->sreh;
-
-		options = list_copy(options);
-		options = lappend(options, makeDefElem("sreh", (Node *) sreh));
-	}
-
 	/* Disallow COPY to/from file or program except to superusers. */
 	if (!pipe && !superuser())
 	{

--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -265,7 +265,9 @@ static Node *makeIsNotDistinctFromNode(Node *expr, int position);
 		CreateExternalStmt
 		CreateQueueStmt CreateResourceGroupStmt
 		DropQueueStmt DropResourceGroupStmt
-		ExtTypedesc OptSingleRowErrorHandling ExtSingleRowErrorHandling
+		ExtTypedesc ExtSingleRowErrorHandling
+
+%type<list> 	OptSingleRowErrorHandling
 
 %type <node>    deny_login_role deny_interval deny_point deny_day_specifier
 
@@ -3892,6 +3894,7 @@ CopyStmt:	COPY opt_binary qualified_name opt_column_list opt_oids
 					n->options = NIL;
 					n->skip_ext_partition = $13;
 
+
 					/* Concatenate user-supplied flags */
 					if ($2)
 						n->options = lappend(n->options, $2);
@@ -3901,6 +3904,9 @@ CopyStmt:	COPY opt_binary qualified_name opt_column_list opt_oids
 						n->options = lappend(n->options, $9);
 					if ($11)
 						n->options = list_concat(n->options, $11);
+					if ($12) {
+						n->options = list_concat(n->options, $12);
+					}
 					$$ = (Node *)n;
 				}
 			| COPY select_with_parens TO opt_program copy_file_name opt_with copy_options
@@ -5718,7 +5724,7 @@ OptSingleRowErrorHandling:
 					   (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 						errmsg("invalid (ROWS) reject limit. Should be 2 or larger")));
 
-			$$ = (Node *)n;
+			$$ = lappend(NULL, makeDefElem("sreh", (Node *) n));
 		}
 		| /*EMPTY*/		{ $$ = NULL; }
 		;

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -1763,7 +1763,7 @@ typedef struct CopyStmt
 	bool		skip_ext_partition;		/* skip external partitions */
 	char	   *filename;		/* filename, or NULL for STDIN/STDOUT */
 	List	   *options;		/* List of DefElem nodes */
-	Node	   *sreh;			/* Single row error handling info */
+	List	   *sreh;			/* Single row error handling info */
 	/* Convenient location for dispatch of misc meta data */
 	PartitionNode *partitions;
 	List		*ao_segnos;		/* AO segno map */


### PR DESCRIPTION
This resolves GPDB_91_MERGE_FIXME in copy.c
Yacc parser rules modified so that SREH clause now return a list of options, which is later concatenated with other copy stmt options.

Removed plain C code from copy.c which does exatly the same.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [x] Document changes
- [x] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [x] Review a PR in return to support the community
