### PR TITLE
Add GUC optimizer_enable_foreign_table

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
@@ -2480,6 +2480,13 @@ CTranslatorRelcacheToDXL::RetrieveRelStorageType(Relation rel)
 			}
 			else if (rel->rd_rel->relkind == RELKIND_FOREIGN_TABLE)
 			{
+				if (!optimizer_enable_foreign_table)
+				{
+					GPOS_RAISE(
+						gpdxl::ExmaMD, gpdxl::ExmiMDObjUnsupported,
+						GPOS_WSZ_LIT(
+							"Use optimizer_enable_foreign_table to enable Orca with foreign tables"));
+				}
 				rel_storage_type = IMDRelation::ErelstorageForeign;
 			}
 			else

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -334,6 +334,7 @@ bool		optimizer_prune_unused_columns;
 bool		optimizer_enable_redistribute_nestloop_loj_inner_child;
 bool		optimizer_force_comprehensive_join_implementation;
 bool		optimizer_enable_replicated_table;
+bool		optimizer_enable_foreign_table;
 
 /* Optimizer plan enumeration related GUCs */
 bool		optimizer_enumerate_plans;
@@ -2883,20 +2884,29 @@ struct config_bool ConfigureNamesBool_gp[] =
 		 gettext_noop("Enable replicated tables."),
 		 NULL,
 		 GUC_NOT_IN_SAMPLE
-		 },
-		 &optimizer_enable_replicated_table,
-		 true,
-		 NULL, NULL, NULL
+		},
+		&optimizer_enable_replicated_table,
+		true,
+		NULL, NULL, NULL
 	},
-
+	{
+		{"optimizer_enable_foreign_table", PGC_USERSET, DEVELOPER_OPTIONS,
+		 gettext_noop("Enable foreign tables in Orca."),
+		 NULL,
+		 GUC_NOT_IN_SAMPLE
+		},
+		&optimizer_enable_foreign_table,
+		true,
+		NULL, NULL, NULL
+	},
 	{
 		{"gp_log_suboverflow_statement", PGC_SUSET, LOGGING_WHAT,
 		 gettext_noop("Enable logging of statements that cause subtransaction overflow."),
 		 NULL,
-		 },
-		 &gp_log_suboverflow_statement,
-		 false,
-		 NULL, NULL, NULL
+		},
+		&gp_log_suboverflow_statement,
+		false,
+		NULL, NULL, NULL
 	},
 
 	/* End-of-list marker */

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -508,6 +508,7 @@ extern bool optimizer_prune_unused_columns;
 extern bool optimizer_enable_redistribute_nestloop_loj_inner_child;
 extern bool optimizer_force_comprehensive_join_implementation;
 extern bool optimizer_enable_replicated_table;
+extern bool optimizer_enable_foreign_table;
 
 /* Optimizer plan enumeration related GUCs */
 extern bool optimizer_enumerate_plans;

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -373,6 +373,7 @@
 		"optimizer_enable_space_pruning",
 		"optimizer_enable_streaming_material",
 		"optimizer_enable_tablescan",
+		"optimizer_enable_foreign_table",
 		"optimizer_enforce_subplans",
 		"optimizer_enumerate_plans",
 		"optimizer_expand_fulljoin",


### PR DESCRIPTION
This adds a guc optimizer_enable_foreign_table. If enabled, Orca will generate plans involving foreign tables. Otherwise, we will fall back to planner. By default this guc is enabled.