### PR TITLE
Pass column projection array to scan_begin_extractcolumns

### DIFF
--- a/src/backend/executor/nodeSeqscan.c
+++ b/src/backend/executor/nodeSeqscan.c
@@ -77,7 +77,8 @@ SeqNext(SeqScanState *node)
 		scandesc = table_beginscan_es(node->ss.ss_currentRelation,
 									  estate->es_snapshot,
 									  node->ss.ps.plan->targetlist,
-									  node->ss.ps.plan->qual);
+									  node->ss.ps.plan->qual,
+									  NULL);
 		node->ss.ss_currentScanDesc = scandesc;
 	}
 

--- a/src/include/access/tableam.h
+++ b/src/include/access/tableam.h
@@ -206,13 +206,15 @@ typedef struct TableAmRoutine
 								 uint32 flags);
 
 	/*
-	 * GPDB: Extract columns for scan from targetlist and quals. This is mainly
-	 * for AOCS tables.
+	 * GPDB: Extract columns for scan from either a projection array
+	 * or a targetlist and quals. This is currently used for AOCO
+	 * tables.
 	 */
 	TableScanDesc	(*scan_begin_extractcolumns) (Relation rel,
 												  Snapshot snapshot,
 												  List *targetlist,
 												  List *qual,
+												  bool *proj,
 												  uint32 flags);
 
 	/*
@@ -785,14 +787,14 @@ table_beginscan(Relation rel, Snapshot snapshot,
  */
 static inline TableScanDesc
 table_beginscan_es(Relation rel, Snapshot snapshot,
-				   List *targetList, List *qual)
+				   List *targetList, List *qual, bool *proj)
 {
 	uint32		flags = SO_TYPE_SEQSCAN |
 	SO_ALLOW_STRAT | SO_ALLOW_SYNC | SO_ALLOW_PAGEMODE;
 
 	if (rel->rd_tableam->scan_begin_extractcolumns)
 		return rel->rd_tableam->scan_begin_extractcolumns(rel, snapshot,
-														  targetList, qual,
+														  targetList, qual, proj,
 														  flags);
 
 	return rel->rd_tableam->scan_begin(rel, snapshot,

--- a/src/test/regress/expected/aoco_projection.out
+++ b/src/test/regress/expected/aoco_projection.out
@@ -1,0 +1,211 @@
+-- Tests to validate column projection for various operations
+-- Tests for COPY TO (SELECT <...> FROM <aoco_table>) TO ..
+CREATE TABLE aoco(i int, j bigint, k int) USING ao_column;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO aoco SELECT 0, i, 1 FROM generate_series(1, 100000) i;
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'skip', '', '', '', 1, 100, 0, dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+-- Reads all blocks in the table as all columns are specified.
+COPY (SELECT * FROM aoco) TO '/dev/null';
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'status', dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+                                                                                                                  gp_inject_fault                                                                                                                   
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Success: fault name:'AppendOnlyStorageRead_ReadNextBlock_success' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'100' extra arg:'0' fault injection state:'triggered'  num times hit:'51' +
+ 
+(1 row)
+
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'reset', dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'skip', '', '', '', 1, 100, 0, dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+-- Reads all blocks in the table as all columns are specified.
+COPY (SELECT i,j,k FROM aoco) TO '/dev/null';
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'status', dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+                                                                                                                  gp_inject_fault                                                                                                                   
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Success: fault name:'AppendOnlyStorageRead_ReadNextBlock_success' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'100' extra arg:'0' fault injection state:'triggered'  num times hit:'51' +
+ 
+(1 row)
+
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'reset', dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'skip', '', '', '', 1, 100, 0, dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+-- Reads blocks only for cols: i int, j bigint
+COPY (SELECT i,j FROM aoco) TO '/dev/null';
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'status', dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+                                                                                                                  gp_inject_fault                                                                                                                   
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Success: fault name:'AppendOnlyStorageRead_ReadNextBlock_success' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'100' extra arg:'0' fault injection state:'triggered'  num times hit:'38' +
+ 
+(1 row)
+
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'reset', dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'skip', '', '', '', 1, 100, 0, dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+-- Reads blocks only for cols: i int
+COPY (SELECT i FROM aoco) TO '/dev/null';
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'status', dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+                                                                                                                  gp_inject_fault                                                                                                                   
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Success: fault name:'AppendOnlyStorageRead_ReadNextBlock_success' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'100' extra arg:'0' fault injection state:'triggered'  num times hit:'13' +
+ 
+(1 row)
+
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'reset', dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'skip', '', '', '', 1, 100, 0, dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+-- Tests for COPY <aoco_table> (<col_list>) TO ..
+-- Reads all blocks in the table as all columns are implicitly specified.
+1U: COPY aoco TO '/dev/null';
+ERROR:  syntax error at or near "1"
+LINE 1: 1U: COPY aoco TO '/dev/null';
+        ^
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'status', dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+                                                                                                               gp_inject_fault                                                                                                               
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Success: fault name:'AppendOnlyStorageRead_ReadNextBlock_success' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'100' extra arg:'0' fault injection state:'set'  num times hit:'0' +
+ 
+(1 row)
+
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'reset', dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'skip', '', '', '', 1, 100, 0, dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+-- Reads all blocks in the table as all columns are specified.
+1U: COPY aoco (i,j,k) TO '/dev/null';
+ERROR:  syntax error at or near "1"
+LINE 1: 1U: COPY aoco (i,j,k) TO '/dev/null';
+        ^
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'status', dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+                                                                                                               gp_inject_fault                                                                                                               
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Success: fault name:'AppendOnlyStorageRead_ReadNextBlock_success' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'100' extra arg:'0' fault injection state:'set'  num times hit:'0' +
+ 
+(1 row)
+
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'reset', dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'skip', '', '', '', 1, 100, 0, dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+-- Reads blocks only for cols: i int, j bigint
+1U: COPY aoco (i,j) TO '/dev/null';
+ERROR:  syntax error at or near "1"
+LINE 1: 1U: COPY aoco (i,j) TO '/dev/null';
+        ^
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'status', dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+                                                                                                               gp_inject_fault                                                                                                               
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Success: fault name:'AppendOnlyStorageRead_ReadNextBlock_success' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'100' extra arg:'0' fault injection state:'set'  num times hit:'0' +
+ 
+(1 row)
+
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'reset', dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'skip', '', '', '', 1, 100, 0, dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+-- Reads blocks only for cols: i int
+1U: COPY aoco (i) TO '/dev/null';
+ERROR:  syntax error at or near "1"
+LINE 1: 1U: COPY aoco (i) TO '/dev/null';
+        ^
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'status', dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+                                                                                                               gp_inject_fault                                                                                                               
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Success: fault name:'AppendOnlyStorageRead_ReadNextBlock_success' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'100' extra arg:'0' fault injection state:'set'  num times hit:'0' +
+ 
+(1 row)
+
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'reset', dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -320,4 +320,7 @@ test: uao_dml/uao_dml_unique_index_delete_row uao_dml/uao_dml_unique_index_delet
 # test CREATE UNIQUE INDEX on AO/CO tables.
 test: uao_dml/ao_unique_index_build_row uao_dml/ao_unique_index_build_column
 
+# test column projection for various operations
+test: aoco_projection
+
 # end of tests

--- a/src/test/regress/sql/aoco_projection.sql
+++ b/src/test/regress/sql/aoco_projection.sql
@@ -1,0 +1,105 @@
+-- Tests to validate column projection for various operations
+
+
+
+-- Tests for COPY TO (SELECT <...> FROM <aoco_table>) TO ..
+
+CREATE TABLE aoco(i int, j bigint, k int) USING ao_column;
+INSERT INTO aoco SELECT 0, i, 1 FROM generate_series(1, 100000) i;
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'skip', '', '', '', 1, 100, 0, dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+
+-- Reads all blocks in the table as all columns are specified.
+COPY (SELECT * FROM aoco) TO '/dev/null';
+
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'status', dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'reset', dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'skip', '', '', '', 1, 100, 0, dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+
+-- Reads all blocks in the table as all columns are specified.
+COPY (SELECT i,j,k FROM aoco) TO '/dev/null';
+
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'status', dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'reset', dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'skip', '', '', '', 1, 100, 0, dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+
+-- Reads blocks only for cols: i int, j bigint
+COPY (SELECT i,j FROM aoco) TO '/dev/null';
+
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'status', dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'reset', dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'skip', '', '', '', 1, 100, 0, dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+
+-- Reads blocks only for cols: i int
+COPY (SELECT i FROM aoco) TO '/dev/null';
+
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'status', dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'reset', dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'skip', '', '', '', 1, 100, 0, dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+
+-- Tests for COPY <aoco_table> (<col_list>) TO ..
+
+-- Reads all blocks in the table as all columns are implicitly specified.
+1U: COPY aoco TO '/dev/null';
+
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'status', dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'reset', dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'skip', '', '', '', 1, 100, 0, dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+
+-- Reads all blocks in the table as all columns are specified.
+1U: COPY aoco (i,j,k) TO '/dev/null';
+
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'status', dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'reset', dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'skip', '', '', '', 1, 100, 0, dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+
+-- Reads blocks only for cols: i int, j bigint
+1U: COPY aoco (i,j) TO '/dev/null';
+
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'status', dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'reset', dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'skip', '', '', '', 1, 100, 0, dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+
+-- Reads blocks only for cols: i int
+1U: COPY aoco (i) TO '/dev/null';
+
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'status', dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'reset', dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';


### PR DESCRIPTION
aocs_beginscan takes a projection array in the form of bool *proj. Previously, scan_begin_extractcolumns API only took a targetlist and qual that was converted to a projection array. This commit allows us to optionally pass a projection array directly to scan_begin_extractcolumns, which is pushed down to aocs_beginscan.

This change allows column projection for UTILITY statements such as COPY TO and adds test coverage for this use case.

Test on copy 1 column from 100 column wide table:

main:
```
postgres=# copy extra_wide_table (c2) to '/dev/null';
COPY 8192000
Time: 139364.596 ms (02:19.365)

```

```
-   98.07%     9.97%  postgres  postgres              [.] aocs_getnext                                                                                                  ▒
   - 88.09% aocs_getnext                                                                                                                                                ▒
      + 70.44% datumstreamread_advance                                                                                                                                  ▒
      + 17.05% datumstreamread_get 
```
         
PR:
```
postgres=# copy extra_wide_table (c2) to '/dev/null';
COPY 8192000
Time: 1167.767 ms (00:01.168)
```

```
-   27.83%     6.94%  postgres  postgres           [.] aocs_getnext                                                                                                     ▒
   - 20.89% aocs_getnext                                                                                                                                                ▒
      + 8.80% AppendOnlyVisimap_IsVisible                                                                                                                               ▒
      + 4.12% datumstreamread_get                                                                                                                                       ▒
      + 3.17% datumstreamread_advance                                                                                                                                   ▒
        2.88% AOTupleIdInit                                                                                                                                             ▒
      + 1.31% datumstreamread_nth      
```
