### PR TITLE
Fix COPY when executed via fdw on coordinator as executor

### DIFF
--- a/contrib/file_fdw/input/gp_file_fdw.source
+++ b/contrib/file_fdw/input/gp_file_fdw.source
@@ -38,8 +38,29 @@ CREATE FOREIGN TABLE text_csv_any_from_server (
 ) SERVER file_server
 OPTIONS (format 'csv', filename '@abs_srcdir@/data/text.csv');
 SELECT * FROM text_csv_any_from_server;
+CREATE FOREIGN TABLE text_csv_coordinator (
+    word1 text, word2 text, a int, b int
+) SERVER file_server
+OPTIONS (format 'csv', filename '@abs_srcdir@/data/text.csv', mpp_execute 'coordinator');
+
+-- Test append works both ways and generates valid plans. Should be able to execute
+-- coordinator fdw on coordinator under redistribute
+explain select word1 from text_csv_coordinator union all select word1 from text_csv_all;
+select word1 from text_csv_coordinator union all select word1 from text_csv_all;
+
+explain select word1 from text_csv_all union all select word1 from text_csv_coordinator;
+select word1 from text_csv_all union all select word1 from text_csv_coordinator;
+
+-- Test join with foreign scan under redistribute on coordinator works and doesn't hang
+create table bar (a text);
+insert into bar values ('AAA'),('XYZ'),('hji');
+analyze bar;
+
+explain  select word1 from text_csv_coordinator ft1, bar where ft1.word1 = bar.a;
+select word1 from text_csv_coordinator ft1, bar where ft1.word1 = bar.a;
 
 -- cleanup
+DROP TABLE bar;
 RESET ROLE;
 DROP EXTENSION file_fdw CASCADE;
 DROP ROLE file_fdw_superuser;

--- a/contrib/file_fdw/input/gp_file_fdw.source
+++ b/contrib/file_fdw/input/gp_file_fdw.source
@@ -55,7 +55,6 @@ select word1 from text_csv_all union all select word1 from text_csv_coordinator;
 create table bar (a text);
 insert into bar values ('AAA'),('XYZ'),('hji');
 analyze bar;
-
 explain  select word1 from text_csv_coordinator ft1, bar where ft1.word1 = bar.a;
 select word1 from text_csv_coordinator ft1, bar where ft1.word1 = bar.a;
 

--- a/contrib/file_fdw/output/gp_file_fdw_optimizer.source
+++ b/contrib/file_fdw/output/gp_file_fdw_optimizer.source
@@ -52,14 +52,14 @@ OPTIONS (format 'csv', filename '@abs_srcdir@/data/text.csv', mpp_execute 'coord
 explain select word1 from text_csv_coordinator union all select word1 from text_csv_all;
                                            QUERY PLAN                                           
 ------------------------------------------------------------------------------------------------
- Append  (cost=0.00..550.56 rows=10442 width=32)
-   ->  Foreign Scan on text_csv_coordinator  (cost=0.00..1.15 rows=2 width=32)
+ Append  (cost=0.00..862.00 rows=1 width=8)
+   ->  Foreign Scan on text_csv_coordinator  (cost=0.00..431.00 rows=1 width=8)
          Foreign File: @abs_srcdir@/data/text.csv
          Foreign File Size: 86 b
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..497.20 rows=10440 width=32)
-         ->  Foreign Scan on text_csv_all  (cost=0.00..358.00 rows=3480 width=32)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+         ->  Foreign Scan on text_csv_all  (cost=0.00..431.00 rows=1 width=8)
                Foreign File: @abs_srcdir@/data/text<SEGID>.csv
- Optimizer: Postgres query optimizer
+ Optimizer: Pivotal Optimizer (GPORCA)
 (8 rows)
 
 select word1 from text_csv_coordinator union all select word1 from text_csv_all;
@@ -78,15 +78,16 @@ select word1 from text_csv_coordinator union all select word1 from text_csv_all;
 explain select word1 from text_csv_all union all select word1 from text_csv_coordinator;
                                            QUERY PLAN                                           
 ------------------------------------------------------------------------------------------------
- Append  (cost=0.00..550.56 rows=10442 width=32)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..497.20 rows=10440 width=32)
-         ->  Foreign Scan on text_csv_all  (cost=0.00..358.00 rows=3480 width=32)
-               Foreign File: @abs_srcdir@/file_fdw/data/text<SEGID>.csv
-   ->  Foreign Scan on text_csv_coordinator  (cost=0.00..1.15 rows=2 width=32)
-         Foreign File: @abs_srcdir@/file_fdw/data/text.csv
-         Foreign File Size: 86 b
- Optimizer: Postgres query optimizer
-(8 rows)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
+   ->  Append  (cost=0.00..862.00 rows=1 width=8)
+         ->  Foreign Scan on text_csv_all  (cost=0.00..431.00 rows=1 width=8)
+               Foreign File: @abs_srcdir@/data/text<SEGID>.csv
+         ->  Redistribute Motion 1:3  (slice2)  (cost=0.00..431.00 rows=1 width=8)
+               ->  Foreign Scan on text_csv_coordinator  (cost=0.00..431.00 rows=1 width=8)
+                     Foreign File: @abs_srcdir@/data/text.csv
+                     Foreign File Size: 86 b
+ Optimizer: Pivotal Optimizer (GPORCA)
+(9 rows)
 
 select word1 from text_csv_all union all select word1 from text_csv_coordinator;
  word1 
@@ -110,17 +111,17 @@ analyze bar;
 explain  select word1 from text_csv_coordinator ft1, bar where ft1.word1 = bar.a;
                                           QUERY PLAN                                           
 -----------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=1.02..2.26 rows=3 width=32)
-   ->  Hash Join  (cost=1.02..2.22 rows=1 width=32)
-         Hash Cond: (ft1.word1 = bar.a)
-         ->  Redistribute Motion 1:3  (slice2)  (cost=0.00..1.18 rows=1 width=32)
-               Hash Key: ft1.word1
-               ->  Foreign Scan on text_csv_coordinator ft1  (cost=0.00..1.15 rows=2 width=32)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
+   ->  Hash Join  (cost=0.00..862.00 rows=1 width=8)
+         Hash Cond: (word1 = bar.a)
+         ->  Redistribute Motion 1:3  (slice2)  (cost=0.00..431.00 rows=1 width=8)
+               Hash Key: word1
+               ->  Foreign Scan on text_csv_coordinator  (cost=0.00..431.00 rows=1 width=8)
                      Foreign File: @abs_srcdir@/file_fdw/data/text.csv
                      Foreign File Size: 86 b
-         ->  Hash  (cost=1.01..1.01 rows=1 width=4)
-               ->  Seq Scan on bar  (cost=0.00..1.01 rows=1 width=4)
- Optimizer: Postgres query optimizer
+         ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+               ->  Seq Scan on bar  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
 (11 rows)
 
 select word1 from text_csv_coordinator ft1, bar where ft1.word1 = bar.a;

--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -4823,6 +4823,10 @@ BeginCopyFrom(ParseState *pstate,
 			 cstate->rel && cstate->rel->rd_cdbpolicy &&
 			 cstate->rel->rd_cdbpolicy->ptype != POLICYTYPE_ENTRY)
 		cstate->dispatch_mode = COPY_DISPATCH;
+	// handle case where fdw executes on coordinator while it's acting as a segment
+	// This occurs when fdw is under a redistribute on the coordinator
+	else if (Gp_role == GP_ROLE_EXECUTE && cstate->rel->rd_fdwroutine != NULL)
+		cstate->dispatch_mode = COPY_DIRECT;
 	else if (Gp_role == GP_ROLE_EXECUTE)
 		cstate->dispatch_mode = COPY_EXECUTOR;
 	else

--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -4823,9 +4823,13 @@ BeginCopyFrom(ParseState *pstate,
 			 cstate->rel && cstate->rel->rd_cdbpolicy &&
 			 cstate->rel->rd_cdbpolicy->ptype != POLICYTYPE_ENTRY)
 		cstate->dispatch_mode = COPY_DISPATCH;
-	// handle case where fdw executes on coordinator while it's acting as a segment
-	// This occurs when fdw is under a redistribute on the coordinator
-	else if (Gp_role == GP_ROLE_EXECUTE && cstate->rel->rd_fdwroutine != NULL)
+	/*
+	 * Handle case where fdw executes on coordinator while it's acting as a segment
+	 * This occurs when fdw is under a redistribute on the coordinator
+	 */
+	else if (Gp_role == GP_ROLE_EXECUTE &&
+			 cstate->rel && cstate->rel->rd_cdbpolicy &&
+			 cstate->rel->rd_cdbpolicy->ptype == POLICYTYPE_ENTRY)
 		cstate->dispatch_mode = COPY_DIRECT;
 	else if (Gp_role == GP_ROLE_EXECUTE)
 		cstate->dispatch_mode = COPY_EXECUTOR;


### PR DESCRIPTION
Previously, when using a foreign table that was created with the file fdw under a redistribute and the execution was on the coordinator, the query would hang. This happens because we were using the COPY_EXECUTOR dispatch mode, which is for receiving pre-processed data from QD. Instead, we should be using COPY_DIRECT, which is used with COPY " ON SEGMENT running on a segment, or utility mode, or non-distributed table in QD."

This fixes plans such as:
```
test=# explain select * from f_table, bar where a=c;                                                                                                                                                                                                                                             QUERY PLAN
---------------------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)  (cost=1.04..2.22 rows=3 width=16)
   ->  Hash Join  (cost=1.04..2.17 rows=1 width=16)
         Hash Cond: (f_table.a = bar.c)
         ->  Redistribute Motion 1:3  (slice2)  (cost=0.00..1.12 rows=1 width=8)
               Hash Key: f_table.a
               ->  Foreign Scan on f_table  (cost=0.00..1.10 rows=1 width=8)
                     Foreign File: /tmp/test.csv
                     Foreign File Size: 8 b
         ->  Hash  (cost=1.02..1.02 rows=2 width=8)
               ->  Seq Scan on bar  (cost=0.00..1.02 rows=2 width=8)
 Optimizer: Postgres query optimizer
(11 rows)
```

This fixes https://github.com/greenplum-db/gpdb/issues/14526