### PR TITLE
gpcheckperf: add buffer size parameter

### DIFF
--- a/gpMgmt/bin/gpcheckperf
+++ b/gpMgmt/bin/gpcheckperf
@@ -29,6 +29,7 @@ Usage: gpcheckperf <options>
     -f file    : a file listing all hosts to connect to
     --duration : how long to run network test (default 5 seconds)
     --netperf  : use netperf instead of gpnetbenchServer/gpnetbenchClient
+    --buffer-size : the size of the send buffer in kilobytes ( default 8 kilobytes)
 """
 
 import datetime
@@ -68,7 +69,7 @@ class Global():
     opt = {'-d': [], '-D': False, '-v': False, '-V': False, '-r': '',
            '-B': 1024 * 32, '-S': 0, '-h': [], '-f': None,
            '--duration': 15, '--net': None, '--netserver': 'gpnetbenchServer',
-           '--netclient': 'gpnetbenchClient'}
+           '--netclient': 'gpnetbenchClient', '--buffer-size': 0}
 
 
 GV = Global()
@@ -203,7 +204,7 @@ def print_version():
 
 def parseCommandLine():
     try:
-        (options, args) = getopt.getopt(sys.argv[1:], '?vVDd:r:B:S:p:h:f:', ['duration=', 'version', 'netperf'])
+        (options, args) = getopt.getopt(sys.argv[1:], '?vVDd:r:B:S:p:h:f:', ['duration=', 'version', 'netperf', 'buffer-size='])
     except Exception as e:
         usage('Error: ' + str(e))
         exit(1)
@@ -226,6 +227,8 @@ def parseCommandLine():
         elif switch == '--netperf':
             GV.opt['--netserver'] = 'netserver'
             GV.opt['--netclient'] = 'netperf'
+        elif switch == '--buffer-size':
+            GV.opt[switch] = int(val)
 
     # run default tests (if not specified)
     if GV.opt['-r'] == '':
@@ -274,6 +277,17 @@ def parseCommandLine():
     if GV.opt['--duration'] <= 0:
         GV.opt['--duration'] = 15
         print('[INFO] Invalid network duration specified.  Using default (15 seconds)')
+
+    if GV.opt['--netclient'].find('netperf') >= 0:
+        if GV.opt['--buffer-size']:
+            print('[Warning] --buffer-size option will be ignored when the --netperf option is enabled')
+    else:
+        if GV.opt['--buffer-size'] <= 0:
+            print('[INFO] --buffer-size value is not specified or invalid. Using default (8 kilobytes)')
+            GV.opt['--buffer-size'] = 8
+
+    if GV.opt['--buffer-size'] <= 0:
+        GV.opt['--buffer-size'] = 8
 
     # strip the last '/' from the dir
     dd = []
@@ -540,8 +554,11 @@ def spawnNetperfTestBetween(x, y, netperf_path, netserver_port, sec=5):
         cmd = ('%s -H %s -p %d -t TCP_STREAM -l %s -f M -P 0 '
                % (netperf_path, y, netserver_port, sec))
     else:
-        cmd = ('%s -H %s -p %d -l %s -P 0 '
-               % (netperf_path, y, netserver_port, sec))
+        cmd = ('%s -H %s -p %d -l %s -P 0 -b %s'
+               % (netperf_path, y, netserver_port, sec, GV.opt['--buffer-size']))
+
+    assert cmd is not None
+
     c = ['ssh', '-o', 'BatchMode yes',
          '-o', 'StrictHostKeyChecking no',
          x, cmd]

--- a/gpMgmt/bin/gpcheckperf
+++ b/gpMgmt/bin/gpcheckperf
@@ -286,9 +286,6 @@ def parseCommandLine():
             print('[INFO] --buffer-size value is not specified or invalid. Using default (8 kilobytes)')
             GV.opt['--buffer-size'] = 8
 
-    if GV.opt['--buffer-size'] <= 0:
-        GV.opt['--buffer-size'] = 8
-
     # strip the last '/' from the dir
     dd = []
     for d in GV.opt['-d']:
@@ -556,8 +553,6 @@ def spawnNetperfTestBetween(x, y, netperf_path, netserver_port, sec=5):
     else:
         cmd = ('%s -H %s -p %d -l %s -P 0 -b %s'
                % (netperf_path, y, netserver_port, sec, GV.opt['--buffer-size']))
-
-    assert cmd is not None
 
     c = ['ssh', '-o', 'BatchMode yes',
          '-o', 'StrictHostKeyChecking no',

--- a/gpMgmt/doc/gpcheckperf_help
+++ b/gpMgmt/doc/gpcheckperf_help
@@ -13,7 +13,7 @@ gpcheckperf -d <test_directory> [-d <test_directory> ...]
 
 gpcheckperf -d <temp_directory>
         {-f <hostfile_gpchecknet> | -h <hostname> [-h <hostname> ...]} 
-        [ -r n|N|M [--duration <time>] [--netperf] ] [-D] [-v|-V]
+        [ -r n|N|M [--duration <time>] [--netperf] ] [-D] [-v|-V] [--buffer-size <kbytes>]
 
 
 gpcheckperf -? 
@@ -96,6 +96,11 @@ OPTIONS
 Specifies the block size (in KB or MB) to use for disk I/O test. 
 The default is 32KB, which is the same as the Greenplum Database 
 page size. The maximum block size is 1 MB.
+
+--buffersize <kbytes>
+
+ Specifies size of the send buffer in kilobytes, which is used by gpnetbenchClient.
+ Default size is 8 kilobytes.
 
 
 -d <test_directory>

--- a/gpMgmt/test/behave/mgmt_utils/gpcheckperf.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpcheckperf.feature
@@ -76,10 +76,10 @@ Feature: Tests for gpcheckperf
   @concourse_cluster
   Scenario: gpcheckperf runs sequential network test with buffer size flag
     Given the database is running
-    When  the user runs "gpcheckperf -h cdw -h sdw1 -d /data/gpdata/ -r n --buffer-size 8"
+    When  the user runs "gpcheckperf -h cdw -h sdw1 -d /data/gpdata/ -r n --buffer-size 8 -v"
     Then  gpcheckperf should return a return code of 0
     And   gpcheckperf should print "avg = " to stdout
-    And   gpcheckperf should not print "NOTICE: -t is deprecated " to stdout
+    And   gpcheckperf should print "gpnetbenchClient -H cdw -p 23000 -l 15 -P 0 -b 8" to stdout
 
   @concourse_cluster
   Scenario: gpcheckperf runs sequential network test with buffer size flag and netperf option
@@ -92,6 +92,5 @@ Feature: Tests for gpcheckperf
     Given the database is running
     When  the user runs "gpcheckperf -h cdw -h sdw1 -d /data/gpdata/ -r n"
     Then  gpcheckperf should return a return code of 0
-    And   gpcheckperf should print "--buffer-size value is not specified or invalid. Using default (8 kilobytes)" to stdout
+    And   gpcheckperf should print "--buffer-size value is not specified or invalid. Using default \(8 kilobytes\)" to stdout
     And   gpcheckperf should print "avg = " to stdout
-    And   gpcheckperf should not print "NOTICE: -t is deprecated " to stdout

--- a/gpMgmt/test/behave/mgmt_utils/gpcheckperf.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpcheckperf.feature
@@ -73,3 +73,25 @@ Feature: Tests for gpcheckperf
     | matrix test | M        |
     | network test| N        |
 
+  @concourse_cluster
+  Scenario: gpcheckperf runs sequential network test with buffer size flag
+    Given the database is running
+    When  the user runs "gpcheckperf -h cdw -h sdw1 -d /data/gpdata/ -r n --buffer-size 8"
+    Then  gpcheckperf should return a return code of 0
+    And   gpcheckperf should print "avg = " to stdout
+    And   gpcheckperf should not print "NOTICE: -t is deprecated " to stdout
+
+  @concourse_cluster
+  Scenario: gpcheckperf runs sequential network test with buffer size flag and netperf option
+    Given the database is running
+    When  the user runs "gpcheckperf -h cdw -h sdw1 -d /data/gpdata/ -r n --buffer-size 8 --netperf"
+    Then  gpcheckperf should print "--buffer-size option will be ignored when the --netperf option is enabled" to stdout
+
+  @concourse_cluster
+  Scenario: gpcheckperf runs sequential network test without buffer size flag
+    Given the database is running
+    When  the user runs "gpcheckperf -h cdw -h sdw1 -d /data/gpdata/ -r n"
+    Then  gpcheckperf should return a return code of 0
+    And   gpcheckperf should print "--buffer-size value is not specified or invalid. Using default (8 kilobytes)" to stdout
+    And   gpcheckperf should print "avg = " to stdout
+    And   gpcheckperf should not print "NOTICE: -t is deprecated " to stdout


### PR DESCRIPTION
Use '--buffer-size' flag with size in kilobytes to set buffer size,
which will be used at gpnetbenchClient.
It is optional parameter. Default value is 8 kilobytes.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
