### PR TITLE
[6X_STABLE] Fix EPQ for DML operations (partial backport of  #14304)

### DIFF
--- a/src/backend/executor/nodeDML.c
+++ b/src/backend/executor/nodeDML.c
@@ -57,6 +57,7 @@ ExecDML(DMLState *node)
 	{
 		return NULL;
 	}
+	EvalPlanQualSetSlot(&node->dml_epqstate, slot);
 
 	bool isnull = false;
 	int action = DatumGetUInt32(slot_getattr(slot, plannode->actionColIdx, &isnull));
@@ -145,7 +146,7 @@ ExecDML(DMLState *node)
 				   segid,
 				   NULL, /* GPDB_91_MERGE_FIXME: oldTuple? */
 				   node->cleanedUpSlot,
-				   NULL /* DestReceiver */,
+				   &node->dml_epqstate,
 				   node->ps.state,
 				   !isUpdate, /* GPDB_91_MERGE_FIXME: where to get canSetTag? */
 				   PLANGEN_OPTIMIZER /* Plan origin */,
@@ -177,6 +178,8 @@ ExecInitDML(DML *node, EState *estate, int eflags)
 	CmdType operation = estate->es_plannedstmt->commandType;
 	ResultRelInfo *resultRelInfo = estate->es_result_relation_info;
 
+	EvalPlanQualInit(&dmlstate->dml_epqstate, NULL, NULL, NIL, node->epqParam);
+
 	ExecInitResultTupleSlot(estate, &dmlstate->ps);
 
 	dmlstate->ps.targetlist = (List *)
@@ -184,6 +187,7 @@ ExecInitDML(DML *node, EState *estate, int eflags)
 						(PlanState *) dmlstate);
 
 	Plan *outerPlan  = outerPlan(node);
+	EvalPlanQualSetPlan(&dmlstate->dml_epqstate, outerPlan, NULL);
 	outerPlanState(dmlstate) = ExecInitNode(outerPlan, estate, eflags);
 
 	/*
@@ -279,6 +283,7 @@ ExecEndDML(DMLState *node)
 	ExecFreeExprContext(&node->ps);
 	ExecClearTuple(node->ps.ps_ResultTupleSlot);
 	ExecClearTuple(node->cleanedUpSlot);
+	EvalPlanQualEnd(&node->dml_epqstate);
 	ExecEndNode(outerPlanState(node));
 	EndPlanStateGpmonPkt(&node->ps);
 }

--- a/src/backend/executor/nodeModifyTable.c
+++ b/src/backend/executor/nodeModifyTable.c
@@ -973,17 +973,6 @@ ldelete:;
 				{
 					TupleTableSlot *epqslot;
 
-					/*
-					 * TODO: DML node doesn't initialize `epqstate` parameter so
-					 * we exclude EPQ routine for this type of modification and
-					 * act as in RR and upper isolation levels.
-					 */
-					if (!epqstate)
-						ereport(ERROR,
-								(errcode(ERRCODE_T_R_SERIALIZATION_FAILURE),
-								 errmsg("could not serialize access due to concurrent update"),
-								 errhint("Use PostgreSQL Planner instead of Optimizer for this query via optimizer=off GUC setting")));
-
 					epqslot = EvalPlanQual(estate,
 										   epqstate,
 										   resultRelationDesc,

--- a/src/backend/gpopt/translate/CContextDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CContextDXLToPlStmt.cpp
@@ -60,6 +60,7 @@ CContextDXLToPlStmt::CContextDXLToPlStmt(
 {
 	m_cte_consumer_info = GPOS_NEW(m_mp) HMUlCTEConsumerInfo(m_mp);
 	m_num_partition_selectors_array = GPOS_NEW(m_mp) ULongPtrArray(m_mp);
+	m_used_rte_indexes = GPOS_NEW(m_mp) HMUlIndex(m_mp);
 }
 
 //---------------------------------------------------------------------------
@@ -74,6 +75,7 @@ CContextDXLToPlStmt::~CContextDXLToPlStmt()
 {
 	m_cte_consumer_info->Release();
 	m_num_partition_selectors_array->Release();
+	m_used_rte_indexes->Release();
 }
 
 //---------------------------------------------------------------------------
@@ -460,6 +462,81 @@ CContextDXLToPlStmt::GetDistributionHashFuncForType(Oid typid)
 	hashproc = gpdb::GetHashProcInOpfamily(opfamily, typid);
 
 	return hashproc;
+}
+
+RangeTblEntry *
+CContextDXLToPlStmt::GetRTEByIndex(Index index)
+{
+	return (RangeTblEntry *) gpdb::ListNth(*(m_rtable_entries_list),
+										   int(index - 1));
+}
+
+//---------------------------------------------------------------------------
+//	@function: of associated
+//		CContextDXLToPlStmt::GetRTEIndexByTableDescr
+//
+//	@doc:
+//
+//		For given table descriptor this function returns index of rte in
+//		m_rtable_entries_list for furhter processing and set a flag that
+//		rte was processed.
+//		In case of DML operations there is more than one table descr pointing
+//		to the result relation and to detect position of already processed rte
+//		`assigned_query_id_for_target_rel` of table descriptor is used.
+//---------------------------------------------------------------------------
+Index
+CContextDXLToPlStmt::GetRTEIndexByTableDescr(const CDXLTableDescr *table_descr,
+											 BOOL *is_rte_exists)
+{
+	*is_rte_exists = false;
+
+	//	`assigned_query_id_for_target_rel` is a "tag" of table descriptors, it
+	//	shows id of query structure which contains result relation. If table
+	//	descriptors have the same `assigned_query_id_for_target_rel` - these
+	//	table descriptors point to the same result relation in `ModifyTable`
+	//	operation. It's not zero (0) value (which equal to `UNASSIGNED_QUERYID`
+	//	define) if: user query is a INSERT/UPDATE/DELETE (`ModifyTable`
+	//	operation) and this table descriptor points to the result relation of
+	//	operation, for ex.:
+	//	```sql
+	//	create table b (i int, j int);
+	//	create table c (i int);
+	//	insert into b(i,j) values (1,2), (2,3), (3,4);
+	//	insert into c(i) values (1), (2);
+	//	delete from b where i in (select i from c);
+	//	```
+	//	where `b` is a result relation (table descriptors pointing to it
+	//	will have the same `assigned_query_id_for_target_rel` > 0), and
+	//	`c` is not (all table descriptors which points to `c` will have
+	//	`assigned_query_id_for_target_rel`=0 (equal to `UNASSIGNED_QUERYID`)
+	ULONG assigned_query_id_for_target_rel =
+		table_descr->GetAssignedQueryIdForTargetRel();
+	if (assigned_query_id_for_target_rel == UNASSIGNED_QUERYID)
+	{
+		return gpdb::ListLength(*(m_rtable_entries_list)) + 1;
+	}
+
+	Index *usedIndex =
+		m_used_rte_indexes->Find(&assigned_query_id_for_target_rel);
+
+	//	`usedIndex` is a non NULL value in next case: table descriptor with
+	//	the same `assigned_query_id_for_target_rel` was processed previously
+	//	(so no need to create a new index for result relation like the relation
+	//	itself)
+	if (usedIndex)
+	{
+		*is_rte_exists = true;
+		return *usedIndex;
+	}
+
+	//	`assigned_query_id_for_target_rel` of table descriptor which points to
+	//	result relation wasn't previously processed - create a new index.
+	Index new_index = gpdb::ListLength(*(m_rtable_entries_list)) + 1;
+	m_used_rte_indexes->Insert(GPOS_NEW(m_mp)
+								   ULONG(assigned_query_id_for_target_rel),
+							   GPOS_NEW(m_mp) Index(new_index));
+
+	return new_index;
 }
 
 // EOF

--- a/src/backend/gpopt/translate/CContextQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CContextQueryToDXL.cpp
@@ -26,11 +26,19 @@ CContextQueryToDXL::CContextQueryToDXL(CMemoryPool *mp)
 {
 	// map that stores gpdb att to optimizer col mapping
 	m_colid_counter = GPOS_NEW(mp) CIdGenerator(GPDXL_COL_ID_START);
+	m_queryid_counter = GPOS_NEW(mp) CIdGenerator(GPDXL_QUERY_ID_START);
 	m_cte_id_counter = GPOS_NEW(mp) CIdGenerator(GPDXL_CTE_ID_START);
 }
 
 CContextQueryToDXL::~CContextQueryToDXL()
 {
+	GPOS_DELETE(m_queryid_counter);
 	GPOS_DELETE(m_colid_counter);
 	GPOS_DELETE(m_cte_id_counter);
+}
+
+ULONG
+CContextQueryToDXL::GetNextQueryId()
+{
+	return m_queryid_counter->next_id();
 }

--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -484,19 +484,13 @@ CTranslatorDXLToPlStmt::TranslateDXLTblScan(
 	// translation context for column mappings in the base relation
 	CDXLTranslateContextBaseTable base_table_context(m_mp);
 
-	// we will add the new range table entry as the last element of the range table
-	Index index =
-		gpdb::ListLength(m_dxl_to_plstmt_context->GetRTableEntriesList()) + 1;
-
 	const CDXLTableDescr *dxl_table_descr =
 		phy_tbl_scan_dxlop->GetDXLTableDescr();
 	const IMDRelation *md_rel =
 		m_md_accessor->RetrieveRel(dxl_table_descr->MDId());
-	RangeTblEntry *rte = TranslateDXLTblDescrToRangeTblEntry(
-		dxl_table_descr, index, &base_table_context);
-	GPOS_ASSERT(NULL != rte);
-	rte->requiredPerms |= ACL_SELECT;
-	m_dxl_to_plstmt_context->AddRTE(rte);
+
+	Index index =
+		ProcessDXLTblDescr(dxl_table_descr, &base_table_context, ACL_SELECT);
 
 	Plan *plan = NULL;
 	Plan *plan_return = NULL;
@@ -658,18 +652,13 @@ CTranslatorDXLToPlStmt::TranslateDXLIndexScan(
 	// translation context for column mappings in the base relation
 	CDXLTranslateContextBaseTable base_table_context(m_mp);
 
+	const CDXLTableDescr *dxl_table_descr =
+		physical_idx_scan_dxlop->GetDXLTableDescr();
+	const IMDRelation *md_rel =
+		m_md_accessor->RetrieveRel(dxl_table_descr->MDId());
+
 	Index index =
-		gpdb::ListLength(m_dxl_to_plstmt_context->GetRTableEntriesList()) + 1;
-
-	const IMDRelation *md_rel = m_md_accessor->RetrieveRel(
-		physical_idx_scan_dxlop->GetDXLTableDescr()->MDId());
-
-	RangeTblEntry *rte = TranslateDXLTblDescrToRangeTblEntry(
-		physical_idx_scan_dxlop->GetDXLTableDescr(), index,
-		&base_table_context);
-	GPOS_ASSERT(NULL != rte);
-	rte->requiredPerms |= ACL_SELECT;
-	m_dxl_to_plstmt_context->AddRTE(rte);
+		ProcessDXLTblDescr(dxl_table_descr, &base_table_context, ACL_SELECT);
 
 	IndexScan *index_scan = NULL;
 	index_scan = MakeNode(IndexScan);
@@ -800,18 +789,11 @@ CTranslatorDXLToPlStmt::TranslateDXLIndexOnlyScan(
 	// translation context for column mappings in the base relation
 	CDXLTranslateContextBaseTable base_table_context(m_mp);
 
-	Index index =
-		gpdb::ListLength(m_dxl_to_plstmt_context->GetRTableEntriesList()) + 1;
-
 	const IMDRelation *md_rel = m_md_accessor->RetrieveRel(
 		physical_idx_scan_dxlop->GetDXLTableDescr()->MDId());
 
-	RangeTblEntry *rte = TranslateDXLTblDescrToRangeTblEntry(
-		physical_idx_scan_dxlop->GetDXLTableDescr(), index,
-		&base_table_context);
-	GPOS_ASSERT(NULL != rte);
-	rte->requiredPerms |= ACL_SELECT;
-	m_dxl_to_plstmt_context->AddRTE(rte);
+	Index index =
+		ProcessDXLTblDescr(table_desc, &base_table_context, ACL_SELECT);
 
 	IndexOnlyScan *index_scan = MakeNode(IndexOnlyScan);
 	index_scan->scan.scanrelid = index;
@@ -3937,16 +3919,8 @@ CTranslatorDXLToPlStmt::TranslateDXLDynTblScan(
 	// translation context for column mappings in the base relation
 	CDXLTranslateContextBaseTable base_table_context(m_mp);
 
-	// add the new range table entry as the last element of the range table
-	Index index =
-		gpdb::ListLength(m_dxl_to_plstmt_context->GetRTableEntriesList()) + 1;
-
-	RangeTblEntry *rte = TranslateDXLTblDescrToRangeTblEntry(
-		dyn_tbl_scan_dxlop->GetDXLTableDescr(), index, &base_table_context);
-	GPOS_ASSERT(NULL != rte);
-	rte->requiredPerms |= ACL_SELECT;
-
-	m_dxl_to_plstmt_context->AddRTE(rte);
+	Index index = ProcessDXLTblDescr(dyn_tbl_scan_dxlop->GetDXLTableDescr(),
+									 &base_table_context, ACL_SELECT);
 
 	// create dynamic scan node
 	DynamicSeqScan *dyn_seq_scan = MakeNode(DynamicSeqScan);
@@ -4004,16 +3978,11 @@ CTranslatorDXLToPlStmt::TranslateDXLDynIdxScan(
 	// translation context for column mappings in the base relation
 	CDXLTranslateContextBaseTable base_table_context(m_mp);
 
-	Index index =
-		gpdb::ListLength(m_dxl_to_plstmt_context->GetRTableEntriesList()) + 1;
+	const CDXLTableDescr *table_desc = dyn_index_scan_dxlop->GetDXLTableDescr();
+	const IMDRelation *md_rel = m_md_accessor->RetrieveRel(table_desc->MDId());
 
-	const IMDRelation *md_rel = m_md_accessor->RetrieveRel(
-		dyn_index_scan_dxlop->GetDXLTableDescr()->MDId());
-	RangeTblEntry *rte = TranslateDXLTblDescrToRangeTblEntry(
-		dyn_index_scan_dxlop->GetDXLTableDescr(), index, &base_table_context);
-	GPOS_ASSERT(NULL != rte);
-	rte->requiredPerms |= ACL_SELECT;
-	m_dxl_to_plstmt_context->AddRTE(rte);
+	Index index =
+		ProcessDXLTblDescr(table_desc, &base_table_context, ACL_SELECT);
 
 	DynamicIndexScan *dyn_idx_scan = MakeNode(DynamicIndexScan);
 
@@ -4026,9 +3995,12 @@ CTranslatorDXLToPlStmt::TranslateDXLDynIdxScan(
 		CMDIdGPDB::CastMdid(dyn_index_scan_dxlop->GetDXLIndexDescr()->MDId());
 	const IMDIndex *md_index = m_md_accessor->RetrieveIndex(mdid_index);
 	Oid index_oid = mdid_index->Oid();
+	RangeTblEntry *rte = m_dxl_to_plstmt_context->GetRTEByIndex(index);
 
 	GPOS_ASSERT(InvalidOid != index_oid);
 	dyn_idx_scan->indexscan.indexid = index_oid;
+
+	GPOS_ASSERT(NULL != rte);
 	dyn_idx_scan->logicalIndexInfo =
 		gpdb::GetLogicalIndexInfo(rte->relid, index_oid);
 
@@ -4154,22 +4126,17 @@ CTranslatorDXLToPlStmt::TranslateDXLDml(
 	// translation context for column mappings in the base relation
 	CDXLTranslateContextBaseTable base_table_context(m_mp);
 
-	// add the new range table entry as the last element of the range table
-	Index index =
-		gpdb::ListLength(m_dxl_to_plstmt_context->GetRTableEntriesList()) + 1;
-	dml->scanrelid = index;
-
-	m_result_rel_list = gpdb::LAppendInt(m_result_rel_list, index);
+	CDXLTableDescr *table_descr = phy_dml_dxlop->GetDXLTableDescr();
 
 	const IMDRelation *md_rel =
 		m_md_accessor->RetrieveRel(phy_dml_dxlop->GetDXLTableDescr()->MDId());
 
-	CDXLTableDescr *table_descr = phy_dml_dxlop->GetDXLTableDescr();
-	RangeTblEntry *rte = TranslateDXLTblDescrToRangeTblEntry(
-		table_descr, index, &base_table_context);
-	GPOS_ASSERT(NULL != rte);
-	rte->requiredPerms |= acl_mode;
-	m_dxl_to_plstmt_context->AddRTE(rte);
+	Index index =
+		ProcessDXLTblDescr(table_descr, &base_table_context, acl_mode);
+
+	dml->scanrelid = index;
+
+	m_result_rel_list = gpdb::LAppendInt(m_result_rel_list, index);
 
 	CDXLNode *project_list_dxlnode = (*dml_dxlnode)[0];
 	CDXLNode *child_dxlnode = (*dml_dxlnode)[1];
@@ -4648,39 +4615,73 @@ CTranslatorDXLToPlStmt::TranslateDXLRowTrigger(
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorDXLToPlStmt::TranslateDXLTblDescrToRangeTblEntry
+//		CTranslatorDXLToPlStmt::ProcessDXLTblDescr
 //
 //	@doc:
-//		Translates a DXL table descriptor into a range table entry. If an index
-//		descriptor is provided, we use the mapping from colids to index attnos
-//		instead of table attnos
+//		Translates a DXL table descriptor into a range table entry and stores
+//		it in m_dxl_to_plstmt_context if it's needed (in case of DML operations
+//		there is more than one table descriptors which point to the result
+//		relation, so if rte was alredy translated, this rte will be updated and
+//		index of this rte at m_dxl_to_plstmt_context->m_rtable_entries_list
+//		(shortened as "rte_list"), will be returned, if the rte wasn't
+//		translated, the newly created rte will be appended to rte_list and it's
+//		index returned). Also this function fills base_table_context for the
+//		mapping from colids to index attnos instead of table attnos.
+//		Returns index of translated range table entry at the rte_list.
 //
 //---------------------------------------------------------------------------
-RangeTblEntry *
-CTranslatorDXLToPlStmt::TranslateDXLTblDescrToRangeTblEntry(
-	const CDXLTableDescr *table_descr, Index index,
-	CDXLTranslateContextBaseTable *base_table_context)
+Index
+CTranslatorDXLToPlStmt::ProcessDXLTblDescr(
+	const CDXLTableDescr *table_descr,
+	CDXLTranslateContextBaseTable *base_table_context, AclMode acl_mode)
 {
 	GPOS_ASSERT(NULL != table_descr);
+
+	BOOL rte_was_translated = false;
+	Index index = m_dxl_to_plstmt_context->GetRTEIndexByTableDescr(
+		table_descr, &rte_was_translated);
 
 	const IMDRelation *md_rel = m_md_accessor->RetrieveRel(table_descr->MDId());
 	const ULONG num_of_non_sys_cols =
 		CTranslatorUtils::GetNumNonSystemColumns(md_rel);
 
-	RangeTblEntry *rte = MakeNode(RangeTblEntry);
-	rte->rtekind = RTE_RELATION;
-
 	// get oid for table
 	Oid oid = CMDIdGPDB::CastMdid(table_descr->MDId())->Oid();
 	GPOS_ASSERT(InvalidOid != oid);
 
-	rte->relid = oid;
-	rte->checkAsUser = table_descr->GetExecuteAsUserId();
-	rte->requiredPerms |= ACL_NO_RIGHTS;
-
 	// save oid and range index in translation context
 	base_table_context->SetOID(oid);
 	base_table_context->SetRelIndex(index);
+
+	// save mapping col id -> index in translate context
+	const ULONG arity = table_descr->Arity();
+	for (ULONG ul = 0; ul < arity; ++ul)
+	{
+		const CDXLColDescr *dxl_col_descr = table_descr->GetColumnDescrAt(ul);
+		GPOS_ASSERT(NULL != dxl_col_descr);
+
+		INT attno = dxl_col_descr->AttrNum();
+		GPOS_ASSERT(0 != attno);
+
+		(void) base_table_context->InsertMapping(dxl_col_descr->Id(), attno);
+	}
+
+	// descriptor was already processed, and translated RTE is stored at
+	// context rtable list (only update required perms of this rte is needed)
+	if (rte_was_translated)
+	{
+		RangeTblEntry *rte = m_dxl_to_plstmt_context->GetRTEByIndex(index);
+		GPOS_ASSERT(NULL != rte);
+		rte->requiredPerms |= acl_mode;
+		return index;
+	}
+
+	// create a new RTE (and it's alias) and store it at context rtable list
+	RangeTblEntry *rte = MakeNode(RangeTblEntry);
+	rte->rtekind = RTE_RELATION;
+	rte->relid = oid;
+	rte->checkAsUser = table_descr->GetExecuteAsUserId();
+	rte->requiredPerms |= acl_mode;
 
 	Alias *alias = MakeNode(Alias);
 	alias->colnames = NIL;
@@ -4690,18 +4691,11 @@ CTranslatorDXLToPlStmt::TranslateDXLTblDescrToRangeTblEntry(
 		table_descr->MdName()->GetMDName()->GetBuffer());
 
 	// get column names
-	const ULONG arity = table_descr->Arity();
-
 	INT last_attno = 0;
-
 	for (ULONG ul = 0; ul < arity; ++ul)
 	{
 		const CDXLColDescr *dxl_col_descr = table_descr->GetColumnDescrAt(ul);
-		GPOS_ASSERT(NULL != dxl_col_descr);
-
 		INT attno = dxl_col_descr->AttrNum();
-
-		GPOS_ASSERT(0 != attno);
 
 		if (0 < attno)
 		{
@@ -4724,9 +4718,6 @@ CTranslatorDXLToPlStmt::TranslateDXLTblDescrToRangeTblEntry(
 			alias->colnames = gpdb::LAppend(alias->colnames, val_colname);
 			last_attno = attno;
 		}
-
-		// save mapping col id -> index in translate context
-		(void) base_table_context->InsertMapping(dxl_col_descr->Id(), attno);
 	}
 
 	// if there are any dropped columns at the end, add those too to the RangeTblEntry
@@ -4738,7 +4729,9 @@ CTranslatorDXLToPlStmt::TranslateDXLTblDescrToRangeTblEntry(
 
 	rte->eref = alias;
 
-	return rte;
+	m_dxl_to_plstmt_context->AddRTE(rte);
+
+	return index;
 }
 
 //---------------------------------------------------------------------------
@@ -5683,18 +5676,10 @@ CTranslatorDXLToPlStmt::TranslateDXLBitmapTblScan(
 	// translation context for column mappings in the base relation
 	CDXLTranslateContextBaseTable base_table_context(m_mp);
 
-	// add the new range table entry as the last element of the range table
-	Index index =
-		gpdb::ListLength(m_dxl_to_plstmt_context->GetRTableEntriesList()) + 1;
-
 	const IMDRelation *md_rel = m_md_accessor->RetrieveRel(table_descr->MDId());
 
-	RangeTblEntry *rte = TranslateDXLTblDescrToRangeTblEntry(
-		table_descr, index, &base_table_context);
-	GPOS_ASSERT(NULL != rte);
-	rte->requiredPerms |= ACL_SELECT;
-
-	m_dxl_to_plstmt_context->AddRTE(rte);
+	Index index =
+		ProcessDXLTblDescr(table_descr, &base_table_context, ACL_SELECT);
 
 	BitmapHeapScan *bitmap_tbl_scan;
 

--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -4225,6 +4225,7 @@ CTranslatorDXLToPlStmt::TranslateDXLDml(
 	plan->lefttree = child_plan;
 	plan->nMotionNodes = child_plan->nMotionNodes;
 	plan->plan_node_id = m_dxl_to_plstmt_context->GetNextPlanId();
+	dml->epqParam = m_dxl_to_plstmt_context->GetNextParamId();
 
 	if (CMD_INSERT == m_cmd_type && 0 == plan->nMotionNodes)
 	{

--- a/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
@@ -117,6 +117,8 @@ CTranslatorQueryToDXL::CTranslatorQueryToDXL(
 	GPOS_ASSERT(NULL != query);
 	CheckSupportedCmdType(query);
 
+	m_query_id = m_context->GetNextQueryId();
+
 	CheckRangeTable(query);
 
 	// GPDB_94_MERGE_FIXME: WITH CHECK OPTION views are not supported yet.
@@ -704,8 +706,9 @@ CTranslatorQueryToDXL::TranslateInsertQueryToDXL()
 		m_query->rtable, m_query->resultRelation - 1);
 
 	CDXLTableDescr *table_descr = CTranslatorUtils::GetTableDescr(
-		m_mp, m_md_accessor, m_context->m_colid_counter, rte,
+		m_mp, m_md_accessor, m_context->m_colid_counter, rte, m_query_id,
 		&m_context->m_has_distributed_tables);
+
 	const IMDRelation *md_rel = m_md_accessor->RetrieveRel(table_descr->MDId());
 	if (!optimizer_enable_dml_triggers &&
 		CTranslatorUtils::RelHasTriggers(m_mp, m_md_accessor, md_rel,
@@ -1168,7 +1171,7 @@ CTranslatorQueryToDXL::TranslateDeleteQueryToDXL()
 		m_query->rtable, m_query->resultRelation - 1);
 
 	CDXLTableDescr *table_descr = CTranslatorUtils::GetTableDescr(
-		m_mp, m_md_accessor, m_context->m_colid_counter, rte,
+		m_mp, m_md_accessor, m_context->m_colid_counter, rte, m_query_id,
 		&m_context->m_has_distributed_tables);
 	const IMDRelation *md_rel = m_md_accessor->RetrieveRel(table_descr->MDId());
 	if (!optimizer_enable_dml_triggers &&
@@ -1235,7 +1238,7 @@ CTranslatorQueryToDXL::TranslateUpdateQueryToDXL()
 		m_query->rtable, m_query->resultRelation - 1);
 
 	CDXLTableDescr *table_descr = CTranslatorUtils::GetTableDescr(
-		m_mp, m_md_accessor, m_context->m_colid_counter, rte,
+		m_mp, m_md_accessor, m_context->m_colid_counter, rte, m_query_id,
 		&m_context->m_has_distributed_tables);
 	const IMDRelation *md_rel = m_md_accessor->RetrieveRel(table_descr->MDId());
 	if (!optimizer_enable_dml_triggers &&
@@ -3218,10 +3221,20 @@ CTranslatorQueryToDXL::TranslateRTEToDXLLogicalGet(const RangeTblEntry *rte,
 				   GPOS_WSZ_LIT("ONLY in the FROM clause"));
 	}
 
+	// query_id_for_target_rel is used to tag table descriptors assigned to target
+	// (result) relations one. In case of possible nested DML subqueries it's
+	// field points to target relation of corresponding Query structure of subquery.
+	ULONG query_id_for_target_rel = UNASSIGNED_QUERYID;
+	if (m_query->resultRelation > 0 &&
+		ULONG(m_query->resultRelation) == rt_index)
+	{
+		query_id_for_target_rel = m_query_id;
+	}
+
 	// construct table descriptor for the scan node from the range table entry
 	CDXLTableDescr *dxl_table_descr = CTranslatorUtils::GetTableDescr(
 		m_mp, m_md_accessor, m_context->m_colid_counter, rte,
-		&m_context->m_has_distributed_tables);
+		query_id_for_target_rel, &m_context->m_has_distributed_tables);
 
 	CDXLLogicalGet *dxl_op = NULL;
 	const IMDRelation *md_rel =

--- a/src/backend/gpopt/translate/CTranslatorUtils.cpp
+++ b/src/backend/gpopt/translate/CTranslatorUtils.cpp
@@ -109,6 +109,7 @@ CDXLTableDescr *
 CTranslatorUtils::GetTableDescr(CMemoryPool *mp, CMDAccessor *md_accessor,
 								CIdGenerator *id_generator,
 								const RangeTblEntry *rte,
+								ULONG assigned_query_id_for_target_rel,
 								BOOL *is_distributed_table	// output
 )
 {
@@ -133,7 +134,8 @@ CTranslatorUtils::GetTableDescr(CMemoryPool *mp, CMDAccessor *md_accessor,
 	CMDName *table_mdname = GPOS_NEW(mp) CMDName(mp, tablename);
 
 	CDXLTableDescr *table_descr =
-		GPOS_NEW(mp) CDXLTableDescr(mp, mdid, table_mdname, rte->checkAsUser);
+		GPOS_NEW(mp) CDXLTableDescr(mp, mdid, table_mdname, rte->checkAsUser,
+									assigned_query_id_for_target_rel);
 
 	const ULONG len = rel->ColumnCount();
 

--- a/src/backend/gporca/data/dxl/minidump/Delete-Check-AssignedQueryIdForTargetRel.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Delete-Check-AssignedQueryIdForTargetRel.mdp
@@ -1,0 +1,455 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Comment><![CDATA[
+    Test case: Simple delete from table. Expect AssignedQueryIdForTargetRel exists at
+               table descriptor, which points to result (target) relation
+
+  create table test as select 0 as i distributed randomly;
+  delete from test where i in (select i from test where i > 10);
+
+ 	Physical plan:
+
+                                               QUERY PLAN                                                
+---------------------------------------------------------------------------------------------------------
+ Delete  (cost=0.00..862.02 rows=1 width=1)
+   ->  Result  (cost=0.00..862.00 rows=1 width=18)
+         ->  Hash Semi Join  (cost=0.00..862.00 rows=1 width=14)
+               Hash Cond: (test.i = test_1.i)
+               ->  Seq Scan on test  (cost=0.00..431.00 rows=1 width=14)
+               ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+                     ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                           ->  Seq Scan on test test_1  (cost=0.00..431.00 rows=1 width=4)
+                                 Filter: (i > 10)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(10 rows)
+  ]]>
+  </dxl:Comment>
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint MinNumOfPartsToRequireSortOnInsert="2147483647" JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0"/>
+      <dxl:TraceFlags Value="101013,102074,102120,102146,102155,102156,103001,103014,103022,103027,103029,103038,103041,104002,104003,104004,104005,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:RelationStatistics Mdid="2.16384.1.0" Name="test" Rows="1.000000" RelPages="1" RelAllVisible="0" EmptyRelation="false"/>
+      <dxl:Relation Mdid="0.16384.1.0" Name="test" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Random" Keys="7,1" NumberLeafPartitions="0">
+        <dxl:Columns>
+          <dxl:Column Name="i" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+      </dxl:Relation>
+      <dxl:GPDBScalarOp Mdid="0.521.1.0" Name="&gt;" ComparisonType="GT" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.147.1.0"/>
+        <dxl:Commutator Mdid="0.97.1.0"/>
+        <dxl:InverseOp Mdid="0.523.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.7027.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.20.1.0" Name="Int8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.410.1.0"/>
+        <dxl:InequalityOp Mdid="0.411.1.0"/>
+        <dxl:LessThanOp Mdid="0.412.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.414.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.413.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.415.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1016.1.0"/>
+        <dxl:MinAgg Mdid="0.2131.1.0"/>
+        <dxl:MaxAgg Mdid="0.2115.1.0"/>
+        <dxl:AvgAgg Mdid="0.2100.1.0"/>
+        <dxl:SumAgg Mdid="0.2107.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.16384.1.0.0" Name="i" Width="4.000000" NullFreq="0.000000" NdvRemain="1.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+      <dxl:GPDBScalarOp Mdid="0.410.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.20.1.0"/>
+        <dxl:RightType Mdid="0.20.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.467.1.0"/>
+        <dxl:Commutator Mdid="0.410.1.0"/>
+        <dxl:InverseOp Mdid="0.411.1.0"/>
+        <dxl:HashOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7100.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.1977.1.0"/>
+          <dxl:Opfamily Mdid="0.7028.1.0"/>
+          <dxl:Opfamily Mdid="0.7100.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2134.1.0"/>
+        <dxl:MaxAgg Mdid="0.2118.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.7077.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:GPDBScalarOp Mdid="0.413.1.0" Name="&gt;" ComparisonType="GT" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.20.1.0"/>
+        <dxl:RightType Mdid="0.20.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.470.1.0"/>
+        <dxl:Commutator Mdid="0.412.1.0"/>
+        <dxl:InverseOp Mdid="0.414.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.7028.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:GPDBAgg Mdid="0.2108.1.0" Name="sum" IsSplittable="true" HashAggCapable="true">
+        <dxl:ResultType Mdid="0.20.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.20.1.0"/>
+      </dxl:GPDBAgg>
+      <dxl:MDCast Mdid="3.23.1.0;23.1.0" Name="int4" BinaryCoercible="true" SourceTypeId="0.23.1.0" DestinationTypeId="0.23.1.0" CastFuncId="0.0.0.0" CoercePathType="0"/>
+      <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.65.1.0"/>
+        <dxl:Commutator Mdid="0.96.1.0"/>
+        <dxl:InverseOp Mdid="0.518.1.0"/>
+        <dxl:HashOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7100.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.1977.1.0"/>
+          <dxl:Opfamily Mdid="0.7027.1.0"/>
+          <dxl:Opfamily Mdid="0.7100.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:GPDBAgg Mdid="0.2803.1.0" Name="count" IsSplittable="true" HashAggCapable="true">
+        <dxl:ResultType Mdid="0.20.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.20.1.0"/>
+      </dxl:GPDBAgg>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns/>
+      <dxl:CTEList/>
+      <dxl:LogicalDelete DeleteColumns="1" CtidCol="2" SegmentIdCol="8">
+        <dxl:TableDescriptor Mdid="0.16384.1.0" TableName="test" AssignedQueryIdForTargetRel="1">
+          <dxl:Columns>
+            <dxl:Column ColId="17" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="18" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+            <dxl:Column ColId="19" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="20" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="21" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="22" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="23" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+            <dxl:Column ColId="24" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+          </dxl:Columns>
+        </dxl:TableDescriptor>
+        <dxl:LogicalSelect>
+          <dxl:SubqueryAny OperatorName="=" OperatorMdid="0.96.1.0" ColId="9">
+            <dxl:Ident ColId="1" ColName="i" TypeMdid="0.23.1.0"/>
+            <dxl:LogicalSelect>
+              <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
+                <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
+              </dxl:Comparison>
+              <dxl:LogicalGet>
+                <dxl:TableDescriptor Mdid="0.16384.1.0" TableName="test">
+                  <dxl:Columns>
+                    <dxl:Column ColId="9" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="10" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                    <dxl:Column ColId="11" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="12" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="13" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="14" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="15" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="16" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:LogicalGet>
+            </dxl:LogicalSelect>
+          </dxl:SubqueryAny>
+          <dxl:LogicalGet>
+            <dxl:TableDescriptor Mdid="0.16384.1.0" TableName="test" AssignedQueryIdForTargetRel="1">
+              <dxl:Columns>
+                <dxl:Column ColId="1" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:LogicalGet>
+        </dxl:LogicalSelect>
+      </dxl:LogicalDelete>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="150">
+      <dxl:DMLDelete Columns="0" ActionCol="20" OidCol="0" CtidCol="1" SegmentIdCol="7" InputSorted="false">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="862.023818" Rows="1.000000" Width="1"/>
+        </dxl:Properties>
+        <dxl:DirectDispatchInfo/>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="0" Alias="i">
+            <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:TableDescriptor Mdid="0.16384.1.0" TableName="test" AssignedQueryIdForTargetRel="1">
+          <dxl:Columns>
+            <dxl:Column ColId="21" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="22" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+            <dxl:Column ColId="23" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="24" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="25" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="26" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="27" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+            <dxl:Column ColId="28" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+          </dxl:Columns>
+        </dxl:TableDescriptor>
+        <dxl:Result>
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="862.000380" Rows="1.000000" Width="18"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="0" Alias="i">
+              <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="1" Alias="ctid">
+              <dxl:Ident ColId="1" ColName="ctid" TypeMdid="0.27.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="7" Alias="gp_segment_id">
+              <dxl:Ident ColId="7" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="20" Alias="ColRef_0020">
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:OneTimeFilter/>
+          <dxl:HashJoin JoinType="In">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="862.000374" Rows="1.000000" Width="14"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="0" Alias="i">
+                <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="1" Alias="ctid">
+                <dxl:Ident ColId="1" ColName="ctid" TypeMdid="0.27.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="7" Alias="gp_segment_id">
+                <dxl:Ident ColId="7" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:JoinFilter/>
+            <dxl:HashCondList>
+              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+                <dxl:Ident ColId="8" ColName="i" TypeMdid="0.23.1.0"/>
+              </dxl:Comparison>
+            </dxl:HashCondList>
+            <dxl:TableScan>
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.000006" Rows="1.000000" Width="14"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="0" Alias="i">
+                  <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="1" Alias="ctid">
+                  <dxl:Ident ColId="1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="7" Alias="gp_segment_id">
+                  <dxl:Ident ColId="7" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:TableDescriptor Mdid="0.16384.1.0" TableName="test" AssignedQueryIdForTargetRel="1">
+                <dxl:Columns>
+                  <dxl:Column ColId="0" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="1" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                  <dxl:Column ColId="2" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="3" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="4" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="5" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="6" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="7" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:TableScan>
+            <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.000091" Rows="3.000000" Width="4"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="8" Alias="i">
+                  <dxl:Ident ColId="8" ColName="i" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:SortingColumnList/>
+              <dxl:TableScan>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000020" Rows="1.000000" Width="4"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="8" Alias="i">
+                    <dxl:Ident ColId="8" ColName="i" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter>
+                  <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
+                    <dxl:Ident ColId="8" ColName="i" TypeMdid="0.23.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
+                  </dxl:Comparison>
+                </dxl:Filter>
+                <dxl:TableDescriptor Mdid="0.16384.1.0" TableName="test">
+                  <dxl:Columns>
+                    <dxl:Column ColId="8" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="9" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                    <dxl:Column ColId="10" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="11" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="12" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="13" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="14" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="15" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:TableScan>
+            </dxl:BroadcastMotion>
+          </dxl:HashJoin>
+        </dxl:Result>
+      </dxl:DMLDelete>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/libgpopt/include/gpopt/metadata/CTableDescriptor.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/metadata/CTableDescriptor.h
@@ -97,13 +97,20 @@ private:
 	// returns true if this table descriptor has partial indexes
 	BOOL FDescriptorWithPartialIndexes();
 
+	// identifier of query to which current table belongs.
+	// This field is used for assigning current table entry with
+	// target one within DML operation. If descriptor doesn't point
+	// to the target (result) relation it has value UNASSIGNED_QUERYID
+	ULONG m_assigned_query_id_for_target_rel;
+
 public:
 	// ctor
 	CTableDescriptor(CMemoryPool *, IMDId *mdid, const CName &,
 					 BOOL convert_hash_to_random,
 					 IMDRelation::Ereldistrpolicy rel_distr_policy,
 					 IMDRelation::Erelstoragetype erelstoragetype,
-					 ULONG ulExecuteAsUser);
+					 ULONG ulExecuteAsUser,
+					 ULONG assigned_query_id_for_target_rel);
 
 	// dtor
 	virtual ~CTableDescriptor();
@@ -237,6 +244,12 @@ public:
 	{
 		return m_erelstoragetype == IMDRelation::ErelstorageAppendOnlyCols ||
 			   m_erelstoragetype == IMDRelation::ErelstorageAppendOnlyRows;
+	}
+
+	ULONG
+	GetAssignedQueryIdForTargetRel() const
+	{
+		return m_assigned_query_id_for_target_rel;
 	}
 
 };	// class CTableDescriptor

--- a/src/backend/gporca/libgpopt/src/metadata/CTableDescriptor.cpp
+++ b/src/backend/gporca/libgpopt/src/metadata/CTableDescriptor.cpp
@@ -37,7 +37,8 @@ FORCE_GENERATE_DBGSTR(CTableDescriptor);
 CTableDescriptor::CTableDescriptor(
 	CMemoryPool *mp, IMDId *mdid, const CName &name,
 	BOOL convert_hash_to_random, IMDRelation::Ereldistrpolicy rel_distr_policy,
-	IMDRelation::Erelstoragetype erelstoragetype, ULONG ulExecuteAsUser)
+	IMDRelation::Erelstoragetype erelstoragetype, ULONG ulExecuteAsUser,
+	ULONG assigned_query_id_for_target_rel)
 	: m_mp(mp),
 	  m_mdid(mdid),
 	  m_name(mp, name),
@@ -51,7 +52,8 @@ CTableDescriptor::CTableDescriptor(
 	  m_pdrgpbsKeys(NULL),
 	  m_num_of_partitions(0),
 	  m_execute_as_user_id(ulExecuteAsUser),
-	  m_fHasPartialIndexes(FDescriptorWithPartialIndexes())
+	  m_fHasPartialIndexes(FDescriptorWithPartialIndexes()),
+	  m_assigned_query_id_for_target_rel(assigned_query_id_for_target_rel)
 {
 	GPOS_ASSERT(NULL != mp);
 	GPOS_ASSERT(mdid->IsValid());

--- a/src/backend/gporca/libgpopt/src/translate/CTranslatorDXLToExpr.cpp
+++ b/src/backend/gporca/libgpopt/src/translate/CTranslatorDXLToExpr.cpp
@@ -2099,7 +2099,8 @@ CTranslatorDXLToExpr::Ptabdesc(CDXLTableDescr *table_descr)
 	mdid->AddRef();
 	CTableDescriptor *ptabdesc = GPOS_NEW(m_mp) CTableDescriptor(
 		m_mp, mdid, CName(m_mp, &strName), pmdrel->ConvertHashToRandom(),
-		rel_distr_policy, rel_storage_type, table_descr->GetExecuteAsUserId());
+		rel_distr_policy, rel_storage_type, table_descr->GetExecuteAsUserId(),
+		table_descr->GetAssignedQueryIdForTargetRel());
 
 	const ULONG ulColumns = table_descr->Arity();
 	for (ULONG ul = 0; ul < ulColumns; ul++)
@@ -2298,8 +2299,8 @@ CTranslatorDXLToExpr::PtabdescFromCTAS(CDXLLogicalCTAS *pdxlopCTAS)
 	CTableDescriptor *ptabdesc = GPOS_NEW(m_mp) CTableDescriptor(
 		m_mp, mdid, CName(m_mp, &strName), pmdrel->ConvertHashToRandom(),
 		rel_distr_policy, rel_storage_type,
-		0  // TODO:  - Mar 5, 2014; ulExecuteAsUser
-	);
+		0,	// TODO:  - Mar 5, 2014; ulExecuteAsUser
+		UNASSIGNED_QUERYID);
 
 	// populate column information from the dxl table descriptor
 	CDXLColDescrArray *dxl_col_descr_array =

--- a/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
+++ b/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
@@ -1366,7 +1366,8 @@ CTranslatorExprToDXL::PdxlnMultiExternalScan(
 			m_mp, extpart_mdid, extpart->Mdname().GetMDName(),
 			extpart->ConvertHashToRandom(), extpart->GetRelDistribution(),
 			extpart->RetrieveRelStorageType(),
-			multi_extscan->Ptabdesc()->GetExecuteAsUserId());
+			multi_extscan->Ptabdesc()->GetExecuteAsUserId(),
+			multi_extscan->Ptabdesc()->GetAssignedQueryIdForTargetRel());
 
 		// Each scan shares the same col descriptors as the parent partitioned table
 		// FIXME: Dropped columns break the assumption above. Handle it correctly.
@@ -7556,7 +7557,8 @@ CTranslatorExprToDXL::MakeDXLTableDescr(const CTableDescriptor *ptabdesc,
 	mdid->AddRef();
 
 	CDXLTableDescr *table_descr = GPOS_NEW(m_mp)
-		CDXLTableDescr(m_mp, mdid, pmdnameTbl, ptabdesc->GetExecuteAsUserId());
+		CDXLTableDescr(m_mp, mdid, pmdnameTbl, ptabdesc->GetExecuteAsUserId(),
+					   ptabdesc->GetAssignedQueryIdForTargetRel());
 
 	const ULONG ulColumns = ptabdesc->ColumnCount();
 	// translate col descriptors

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLTableDescr.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLTableDescr.h
@@ -20,6 +20,9 @@
 #include "naucrates/md/CMDName.h"
 #include "naucrates/md/IMDId.h"
 
+// default value for m_assigned_query_id_for_target_rel - no assigned query for table descriptor
+#define UNASSIGNED_QUERYID 0
+
 namespace gpdxl
 {
 using namespace gpmd;
@@ -53,12 +56,19 @@ private:
 	// private copy ctor
 	CDXLTableDescr(const CDXLTableDescr &);
 
+	// identifier of query to which current table belongs.
+	// This field is used for assigning current table entry with
+	// target one within DML operation. If descriptor doesn't point
+	// to the target (result) relation it has value UNASSIGNED_QUERYID
+	ULONG m_assigned_query_id_for_target_rel;
+
 	void SerializeMDId(CXMLSerializer *xml_serializer) const;
 
 public:
 	// ctor/dtor
 	CDXLTableDescr(CMemoryPool *mp, IMDId *mdid, CMDName *mdname,
-				   ULONG ulExecuteAsUser);
+				   ULONG ulExecuteAsUser,
+				   ULONG assigned_query_id_for_target_rel = UNASSIGNED_QUERYID);
 
 	virtual ~CDXLTableDescr();
 
@@ -84,6 +94,9 @@ public:
 
 	// serialize to dxl format
 	void SerializeToDXL(CXMLSerializer *xml_serializer) const;
+
+	// get assigned query id for target relation
+	ULONG GetAssignedQueryIdForTargetRel() const;
 };
 }  // namespace gpdxl
 

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/xml/dxltokens.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/xml/dxltokens.h
@@ -459,6 +459,7 @@ enum Edxltoken
 	EdxltokenIsNull,
 	EdxltokenLintValue,
 	EdxltokenDoubleValue,
+	EdxltokenAssignedQueryIdForTargetRel,
 
 	EdxltokenRelTemporary,
 	EdxltokenRelHasOids,

--- a/src/backend/gporca/libnaucrates/src/operators/CDXLOperatorFactory.cpp
+++ b/src/backend/gporca/libnaucrates/src/operators/CDXLOperatorFactory.cpp
@@ -1479,7 +1479,12 @@ CDXLOperatorFactory::MakeDXLTableDescr(CDXLMemoryManager *dxl_memory_manager,
 			EdxltokenTableDescr);
 	}
 
-	return GPOS_NEW(mp) CDXLTableDescr(mp, mdid, mdname, user_id);
+	ULONG assigned_query_id_for_target_rel = ExtractConvertAttrValueToUlong(
+		dxl_memory_manager, attrs, EdxltokenAssignedQueryIdForTargetRel,
+		EdxltokenTableDescr, true /* is_optional */, UNASSIGNED_QUERYID);
+
+	return GPOS_NEW(mp) CDXLTableDescr(mp, mdid, mdname, user_id,
+									   assigned_query_id_for_target_rel);
 }
 
 //---------------------------------------------------------------------------

--- a/src/backend/gporca/libnaucrates/src/operators/CDXLTableDescr.cpp
+++ b/src/backend/gporca/libnaucrates/src/operators/CDXLTableDescr.cpp
@@ -30,12 +30,14 @@ using namespace gpdxl;
 //
 //---------------------------------------------------------------------------
 CDXLTableDescr::CDXLTableDescr(CMemoryPool *mp, IMDId *mdid, CMDName *mdname,
-							   ULONG ulExecuteAsUser)
+							   ULONG ulExecuteAsUser,
+							   ULONG assigned_query_id_for_target_rel)
 	: m_mp(mp),
 	  m_mdid(mdid),
 	  m_mdname(mdname),
 	  m_dxl_column_descr_array(NULL),
-	  m_execute_as_user_id(ulExecuteAsUser)
+	  m_execute_as_user_id(ulExecuteAsUser),
+	  m_assigned_query_id_for_target_rel(assigned_query_id_for_target_rel)
 {
 	GPOS_ASSERT(NULL != m_mdname);
 	m_dxl_column_descr_array = GPOS_NEW(mp) CDXLColDescrArray(mp);
@@ -205,6 +207,13 @@ CDXLTableDescr::SerializeToDXL(CXMLSerializer *xml_serializer) const
 			m_execute_as_user_id);
 	}
 
+	if (UNASSIGNED_QUERYID != m_assigned_query_id_for_target_rel)
+	{
+		xml_serializer->AddAttribute(
+			CDXLTokens::GetDXLTokenStr(EdxltokenAssignedQueryIdForTargetRel),
+			m_assigned_query_id_for_target_rel);
+	}
+
 	// serialize columns
 	xml_serializer->OpenElement(
 		CDXLTokens::GetDXLTokenStr(EdxltokenNamespacePrefix),
@@ -225,6 +234,23 @@ CDXLTableDescr::SerializeToDXL(CXMLSerializer *xml_serializer) const
 	xml_serializer->CloseElement(
 		CDXLTokens::GetDXLTokenStr(EdxltokenNamespacePrefix),
 		CDXLTokens::GetDXLTokenStr(EdxltokenTableDescr));
+}
+
+
+//---------------------------------------------------------------------------
+//	@function:
+//		CDXLTableDescr::GetAssignedQueryIdForTargetRel
+//
+//	@doc:
+//		Return id of query, to which TableDescr belongs to
+//		(if this descriptor points to a result (target) entry,
+//		else UNASSIGNED_QUERYID returned)
+//
+//---------------------------------------------------------------------------
+ULONG
+CDXLTableDescr::GetAssignedQueryIdForTargetRel() const
+{
+	return m_assigned_query_id_for_target_rel;
 }
 
 // EOF

--- a/src/backend/gporca/libnaucrates/src/xml/dxltokens.cpp
+++ b/src/backend/gporca/libnaucrates/src/xml/dxltokens.cpp
@@ -506,6 +506,8 @@ CDXLTokens::Init(CMemoryPool *mp)
 		{EdxltokenIsNull, GPOS_WSZ_LIT("IsNull")},
 		{EdxltokenLintValue, GPOS_WSZ_LIT("LintValue")},
 		{EdxltokenDoubleValue, GPOS_WSZ_LIT("DoubleValue")},
+		{EdxltokenAssignedQueryIdForTargetRel,
+		 GPOS_WSZ_LIT("AssignedQueryIdForTargetRel")},
 
 		{EdxltokenRelTemporary, GPOS_WSZ_LIT("IsTemporary")},
 		{EdxltokenRelHasOids, GPOS_WSZ_LIT("HasOids")},

--- a/src/backend/gporca/server/src/unittest/CTestUtils.cpp
+++ b/src/backend/gporca/server/src/unittest/CTestUtils.cpp
@@ -196,7 +196,8 @@ CTestUtils::PtabdescPlainWithColNameFormat(
 		mp, mdid, nameTable,
 		false,	// convert_hash_to_random
 		IMDRelation::EreldistrRandom, IMDRelation::ErelstorageHeap,
-		0  // ulExecuteAsUser
+		0,	// ulExecuteAsUser
+		0	// UNASSIGNED_QUERYID
 	);
 
 	for (ULONG i = 0; i < num_cols; i++)

--- a/src/backend/gporca/server/src/unittest/dxl/statistics/CStatisticsTest.cpp
+++ b/src/backend/gporca/server/src/unittest/dxl/statistics/CStatisticsTest.cpp
@@ -317,7 +317,8 @@ CStatisticsTest::PtabdescTwoColumnSource(CMemoryPool *mp,
 		nameTable,
 		false,	// convert_hash_to_random
 		IMDRelation::EreldistrRandom, IMDRelation::ErelstorageHeap,
-		0  // ulExecuteAsUser
+		0,	// ulExecuteAsUser
+		0	// UNASSIGNED_QUERYID
 	);
 
 	for (ULONG i = 0; i < 2; i++)

--- a/src/backend/gporca/server/src/unittest/gpopt/minidump/CDMLTest.cpp
+++ b/src/backend/gporca/server/src/unittest/gpopt/minidump/CDMLTest.cpp
@@ -47,6 +47,7 @@ const CHAR *rgszDMLFileNames[] = {
 	"../data/dxl/minidump/InsertSortDistributed2MasterOnly.mdp",
 	"../data/dxl/minidump/InsertProjectSort.mdp",
 	"../data/dxl/minidump/InsertAssertSort.mdp",
+	"../data/dxl/minidump/Delete-Check-AssignedQueryIdForTargetRel.mdp",
 	"../data/dxl/minidump/UpdateRandomDistr.mdp",
 	"../data/dxl/minidump/DeleteRandomDistr.mdp",
 	"../data/dxl/minidump/DeleteRandomlyDistributedTableJoin.mdp",

--- a/src/backend/gporca/server/src/unittest/gpopt/translate/CTranslatorDXLToExprTest.cpp
+++ b/src/backend/gporca/server/src/unittest/gpopt/translate/CTranslatorDXLToExprTest.cpp
@@ -252,7 +252,8 @@ public:
 		m_ptabdesc = GPOS_NEW(mp) CTableDescriptor(
 			mp, mdid, CName(&strTableName), convert_hash_to_random,
 			CMDRelationGPDB::EreldistrMasterOnly,
-			CMDRelationGPDB::ErelstorageHeap, ulExecuteAsUser);
+			CMDRelationGPDB::ErelstorageHeap, ulExecuteAsUser,
+			0 /* UNASSIGNED_QUERYID */);
 	}
 
 	void

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -1337,6 +1337,7 @@ _copyDML(const DML *from)
 	COPY_SCALAR_FIELD(actionColIdx);
 	COPY_SCALAR_FIELD(ctidColIdx);
 	COPY_SCALAR_FIELD(tupleoidColIdx);
+	COPY_SCALAR_FIELD(epqParam);
 
 	return newnode;
 }

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -1215,6 +1215,7 @@ _outDML(StringInfo str, const DML *node)
 	WRITE_INT_FIELD(actionColIdx);
 	WRITE_INT_FIELD(ctidColIdx);
 	WRITE_INT_FIELD(tupleoidColIdx);
+	WRITE_INT_FIELD(epqParam);
 
 	_outPlanInfo(str, (Plan *) node);
 }

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -2237,6 +2237,7 @@ _readDML(void)
 	READ_INT_FIELD(actionColIdx);
 	READ_INT_FIELD(ctidColIdx);
 	READ_INT_FIELD(tupleoidColIdx);
+	READ_INT_FIELD(epqParam);
 
 	readPlanInfo((Plan *)local_node);
 

--- a/src/include/gpopt/translate/CContextDXLToPlStmt.h
+++ b/src/include/gpopt/translate/CContextDXLToPlStmt.h
@@ -90,6 +90,10 @@ private:
 					 CleanupDelete<SCTEConsumerInfo> >
 		HMUlCTEConsumerInfo;
 
+	typedef CHashMap<ULONG, Index, gpos::HashValue<ULONG>, gpos::Equals<ULONG>,
+					 CleanupDelete<ULONG>, CleanupDelete<Index> >
+		HMUlIndex;
+
 	CMemoryPool *m_mp;
 
 	// counter for generating plan ids
@@ -127,6 +131,9 @@ private:
 
 	// CTAS distribution policy
 	GpPolicy *m_distribution_policy;
+
+	// hash map of the queryid (of DML query) and the target relation index
+	HMUlIndex *m_used_rte_indexes;
 
 public:
 	// ctor/dtor
@@ -215,6 +222,12 @@ public:
 	// based on decision made by DetermineDistributionHashOpclasses()
 	Oid GetDistributionHashOpclassForType(Oid typid);
 	Oid GetDistributionHashFuncForType(Oid typid);
+
+	// get rte from m_rtable_entries_list by given index
+	RangeTblEntry *GetRTEByIndex(Index index);
+
+	Index GetRTEIndexByTableDescr(const CDXLTableDescr *table_descr,
+								  BOOL *is_rte_exists);
 };
 
 }  // namespace gpdxl

--- a/src/include/gpopt/translate/CContextQueryToDXL.h
+++ b/src/include/gpopt/translate/CContextQueryToDXL.h
@@ -22,6 +22,7 @@
 
 #define GPDXL_CTE_ID_START 1
 #define GPDXL_COL_ID_START 1
+#define GPDXL_QUERY_ID_START 1
 
 namespace gpdxl
 {
@@ -53,6 +54,9 @@ private:
 	// counter for generating unique CTE ids
 	CIdGenerator *m_cte_id_counter;
 
+	// counter for upper-level query and its subqueries
+	CIdGenerator *m_queryid_counter;
+
 	// does the query have any distributed tables?
 	BOOL m_has_distributed_tables;
 
@@ -65,6 +69,8 @@ public:
 
 	// dtor
 	~CContextQueryToDXL();
+
+	ULONG GetNextQueryId();
 };
 }  // namespace gpdxl
 #endif	// GPDXL_CContextQueryToDXL_H

--- a/src/include/gpopt/translate/CTranslatorDXLToPlStmt.h
+++ b/src/include/gpopt/translate/CTranslatorDXLToPlStmt.h
@@ -464,9 +464,9 @@ private:
 		CDXLTranslateContextBaseTable *base_table_context);
 
 	// create range table entry from a table descriptor
-	RangeTblEntry *TranslateDXLTblDescrToRangeTblEntry(
-		const CDXLTableDescr *table_descr, Index index,
-		CDXLTranslateContextBaseTable *base_table_context);
+	Index ProcessDXLTblDescr(const CDXLTableDescr *table_descr,
+							 CDXLTranslateContextBaseTable *base_table_context,
+							 AclMode acl_mode);
 
 	// translate DXL projection list into a target list
 	List *TranslateDXLProjList(

--- a/src/include/gpopt/translate/CTranslatorQueryToDXL.h
+++ b/src/include/gpopt/translate/CTranslatorQueryToDXL.h
@@ -138,6 +138,10 @@ private:
 	// CTE producer IDs defined at the current query level
 	UlongBoolHashMap *m_cteid_at_current_query_level_map;
 
+	// id of current query (and for nested queries), it's used for correct assigning
+	// of relation links to target relation of DML query
+	ULONG m_query_id;
+
 	//ctor
 	// private constructor, called from the public factory function QueryToDXLInstance
 	CTranslatorQueryToDXL(

--- a/src/include/gpopt/translate/CTranslatorUtils.h
+++ b/src/include/gpopt/translate/CTranslatorUtils.h
@@ -146,6 +146,7 @@ public:
 										 CMDAccessor *md_accessor,
 										 CIdGenerator *id_generator,
 										 const RangeTblEntry *rte,
+										 ULONG assigned_query_id_for_target_rel,
 										 BOOL *is_distributed_table = NULL);
 
 	// translate a RangeTableEntry into a CDXLLogicalTVF

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -2829,6 +2829,7 @@ typedef struct DMLState
 	JunkFilter *junkfilter;			/* filter that removes junk and dropped attributes */
 	TupleTableSlot *cleanedUpSlot;	/* holds 'final' tuple which matches the target relation schema */
 	AttrNumber	segid_attno;		/* attribute number of "gp_segment_id" */
+	EPQState dml_epqstate;
 } DMLState;
 
 /*

--- a/src/include/nodes/plannodes.h
+++ b/src/include/nodes/plannodes.h
@@ -1333,7 +1333,7 @@ typedef struct DML
 	AttrNumber	actionColIdx;	/* index of action column into the target list */
 	AttrNumber	ctidColIdx;		/* index of ctid column into the target list */
 	AttrNumber	tupleoidColIdx;	/* index of tuple oid column into the target list */
-
+	int 		epqParam;		/* ID of Param for EvalPlanQual re-eval */
 } DML;
 
 /*

--- a/src/test/isolation2/expected/gdd/concurrent_update.out
+++ b/src/test/isolation2/expected/gdd/concurrent_update.out
@@ -251,10 +251,7 @@ DROP
 1q: ... <quitting>
 2q: ... <quitting>
 
--- Currently the DML node (modification variant in ORCA) doesn't support EPQ
--- routine so concurrent modification is not possible in this case. User have
--- to be informed to fallback to postgres optimizer.
--- This test makes sense just for ORCA
+-- check that orca concurrent delete transaction won't delete tuple, updated in other transaction (which doesn't match predicate anymore)
 create table test as select 0 as i distributed randomly;
 CREATE 1
 -- in session 1, turn off the optimizer so it will invoke heap_update
@@ -267,12 +264,32 @@ UPDATE 1
 -- in session 2, in case of ORCA DML invokes EPQ
 -- the following SQL will hang due to XID lock
 2&: delete from test where i = 0;  <waiting ...>
--- commit session1's transaction so the above session2 will continue and emit
--- error about serialization failure in case of ORCA
 1: end;
 END
 2<:  <... completed>
 DELETE 0
+drop table test;
+DROP
+1q: ... <quitting>
+2q: ... <quitting>
+
+-- check that orca concurrent delete transaction will delete tuple, updated in other transaction (which still matches predicate)
+create table test as select 0 as i distributed randomly;
+CREATE 1
+-- in session 1, turn off the optimizer so it will invoke heap_update
+1: set optimizer = off;
+SET
+1: begin;
+BEGIN
+1: update test set i = i;
+UPDATE 1
+-- in session 2, in case of ORCA DML invokes EPQ
+-- the following SQL will hang due to XID lock
+2&: delete from test where i = 0;  <waiting ...>
+1: end;
+END
+2<:  <... completed>
+DELETE 1
 drop table test;
 DROP
 1q: ... <quitting>

--- a/src/test/isolation2/expected/gdd/concurrent_update_optimizer.out
+++ b/src/test/isolation2/expected/gdd/concurrent_update_optimizer.out
@@ -251,10 +251,7 @@ DROP
 1q: ... <quitting>
 2q: ... <quitting>
 
--- Currently the DML node (modification variant in ORCA) doesn't support EPQ
--- routine so concurrent modification is not possible in this case. User have
--- to be informed to fallback to postgres optimizer.
--- This test makes sense just for ORCA
+-- check that orca concurrent delete transaction won't delete tuple, updated in other transaction (which doesn't match predicate anymore)
 create table test as select 0 as i distributed randomly;
 CREATE 1
 -- in session 1, turn off the optimizer so it will invoke heap_update
@@ -267,13 +264,32 @@ UPDATE 1
 -- in session 2, in case of ORCA DML invokes EPQ
 -- the following SQL will hang due to XID lock
 2&: delete from test where i = 0;  <waiting ...>
--- commit session1's transaction so the above session2 will continue and emit
--- error about serialization failure in case of ORCA
 1: end;
 END
 2<:  <... completed>
-ERROR:  could not serialize access due to concurrent update
-HINT:  Use PostgreSQL Planner instead of Optimizer for this query via optimizer=off GUC setting
+DELETE 0
+drop table test;
+DROP
+1q: ... <quitting>
+2q: ... <quitting>
+
+-- check that orca concurrent delete transaction will delete tuple, updated in other transaction (which still matches predicate)
+create table test as select 0 as i distributed randomly;
+CREATE 1
+-- in session 1, turn off the optimizer so it will invoke heap_update
+1: set optimizer = off;
+SET
+1: begin;
+BEGIN
+1: update test set i = i;
+UPDATE 1
+-- in session 2, in case of ORCA DML invokes EPQ
+-- the following SQL will hang due to XID lock
+2&: delete from test where i = 0;  <waiting ...>
+1: end;
+END
+2<:  <... completed>
+DELETE 1
 drop table test;
 DROP
 1q: ... <quitting>

--- a/src/test/isolation2/expected/modify_table_data_corrupt_optimizer.out
+++ b/src/test/isolation2/expected/modify_table_data_corrupt_optimizer.out
@@ -193,16 +193,15 @@ ABORT
 -- test splitupdate. 6X code, both orca and planner generate splitupdate with redistribute motion
 -- so they will both error out.
 explain (costs off) update tab1 set b = b + 1;
- QUERY PLAN                                           
-------------------------------------------------------
+ QUERY PLAN                                                 
+------------------------------------------------------------
  Update                                               
    ->  Redistribute Motion 3:3  (slice1; segments: 3) 
-         Hash Key: tab1.b                             
+         Hash Key: b                                  
          ->  Split                                    
                ->  Result                             
                      ->  Seq Scan on tab1             
- Optimizer: Pivotal Optimizer (GPORCA)                
-(7 rows)
+GP_IGNORE:(7 rows)
 begin;
 BEGIN
 update tab1 set b = b + 1;

--- a/src/test/isolation2/output/uao/parallel_delete_optimizer.source
+++ b/src/test/isolation2/output/uao/parallel_delete_optimizer.source
@@ -19,15 +19,13 @@ DELETE 1
  coalesce | mode                | locktype                 | node   
 ----------+---------------------+--------------------------+--------
  ao       | AccessExclusiveLock | append-only segment file | master 
- ao       | AccessShareLock     | relation                 | master 
  ao       | ExclusiveLock       | relation                 | master 
-(3 rows)
+(2 rows)
 2: SELECT * FROM locktest_segments WHERE coalesce = 'ao';
  coalesce | mode             | locktype | node       
 ----------+------------------+----------+------------
- ao       | AccessShareLock  | relation | n segments 
  ao       | RowExclusiveLock | relation | n segments 
-(2 rows)
+(1 row)
 -- The case here should delete a tuple at the same seg with(2).
 -- Under jump hash, (2) and (3) are on the same seg(seg0).
 1&: DELETE FROM ao WHERE a = 3;  <waiting ...>

--- a/src/test/isolation2/output/uao/parallel_update_optimizer.source
+++ b/src/test/isolation2/output/uao/parallel_update_optimizer.source
@@ -19,16 +19,14 @@ UPDATE 1
  coalesce | mode                | locktype                 | node   
 ----------+---------------------+--------------------------+--------
  ao       | AccessExclusiveLock | append-only segment file | master 
- ao       | AccessShareLock     | relation                 | master 
  ao       | ExclusiveLock       | relation                 | master 
-(3 rows)
+(2 rows)
 2: SELECT * FROM locktest_segments WHERE coalesce = 'ao';
  coalesce | mode                | locktype                 | node       
 ----------+---------------------+--------------------------+------------
  ao       | AccessExclusiveLock | append-only segment file | 1 segment  
- ao       | AccessShareLock     | relation                 | n segments 
  ao       | RowExclusiveLock    | relation                 | n segments 
-(3 rows)
+(2 rows)
 -- The case here should update a tuple at the same seg with(2).
 -- Under jump hash, (2) and (3) are on the same seg(seg0).
 1&: UPDATE ao SET b = 42 WHERE a = 3;  <waiting ...>

--- a/src/test/regress/expected/ao_locks_optimizer.out
+++ b/src/test/regress/expected/ao_locks_optimizer.out
@@ -78,9 +78,8 @@ SELECT * FROM locktest_master where coalesce = 'ao_locks_table' or
     coalesce    |        mode         |         locktype         |  node  
 ----------------+---------------------+--------------------------+--------
  ao_locks_table | AccessExclusiveLock | append-only segment file | master
- ao_locks_table | AccessShareLock     | relation                 | master
  ao_locks_table | ExclusiveLock       | relation                 | master
-(3 rows)
+(2 rows)
 
 SELECT * FROM locktest_segments where coalesce = 'ao_locks_table' or
  coalesce like 'aovisimap%' or coalesce like 'aoseg%';
@@ -88,9 +87,8 @@ SELECT * FROM locktest_segments where coalesce = 'ao_locks_table' or
 -----------------+------------------+----------+------------
  aovisimap index | RowExclusiveLock | relation | 1 segment
  ao_locks_table  | RowExclusiveLock | relation | n segments
- ao_locks_table  | AccessShareLock  | relation | n segments
  aovisimap table | RowExclusiveLock | relation | 1 segment
-(4 rows)
+(3 rows)
 
 COMMIT;
 BEGIN;
@@ -100,19 +98,17 @@ SELECT * FROM locktest_master where coalesce = 'ao_locks_table' or
     coalesce    |        mode         |         locktype         |  node  
 ----------------+---------------------+--------------------------+--------
  ao_locks_table | AccessExclusiveLock | append-only segment file | master
- ao_locks_table | AccessShareLock     | relation                 | master
  ao_locks_table | ExclusiveLock       | relation                 | master
-(3 rows)
+(2 rows)
 
 SELECT * FROM locktest_segments where coalesce = 'ao_locks_table' or
  coalesce like 'aovisimap%' or coalesce like 'aoseg%';
     coalesce     |        mode         |         locktype         |    node    
 -----------------+---------------------+--------------------------+------------
- ao_locks_table  | AccessShareLock     | relation                 | n segments
  aovisimap table | RowExclusiveLock    | relation                 | 1 segment
  ao_locks_table  | AccessExclusiveLock | append-only segment file | 1 segment
  aovisimap index | RowExclusiveLock    | relation                 | 1 segment
  ao_locks_table  | RowExclusiveLock    | relation                 | n segments
-(5 rows)
+(4 rows)
 
 COMMIT;

--- a/src/test/regress/expected/bfv_dml_optimizer.out
+++ b/src/test/regress/expected/bfv_dml_optimizer.out
@@ -668,11 +668,11 @@ explain delete from foo using (select a from foo union all select b from bar) v;
    ->  Result  (cost=0.00..1765380.23 rows=67 width=18)
          ->  Nested Loop  (cost=0.00..1765380.23 rows=67 width=14)
                Join Filter: true
-               ->  Seq Scan on foo foo_1  (cost=0.00..431.00 rows=4 width=14)
+               ->  Seq Scan on foo  (cost=0.00..431.00 rows=4 width=14)
                ->  Materialize  (cost=0.00..862.00 rows=20 width=1)
                      ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..862.00 rows=20 width=1)
                            ->  Append  (cost=0.00..862.00 rows=7 width=1)
-                                 ->  Seq Scan on foo  (cost=0.00..431.00 rows=4 width=1)
+                                 ->  Seq Scan on foo foo_1  (cost=0.00..431.00 rows=4 width=1)
                                  ->  Seq Scan on bar  (cost=0.00..431.00 rows=4 width=1)
  Optimizer: Pivotal Optimizer (GPORCA)
 (11 rows)

--- a/src/test/regress/expected/partition_locking.out
+++ b/src/test/regress/expected/partition_locking.out
@@ -358,6 +358,8 @@ select * from locktest_master where coalesce not like 'gp_%' and coalesce not li
  partlockt_1_prt_9 | ExclusiveLock | relation | master
 (10 rows)
 
+-- TODO: Seems RowExclusiveLock should be also applied on index of partlock table,
+-- like it's done in vanila postgres (lock on indexes should be eqaul to locks on table).
 select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
      coalesce      |       mode       | locktype |   node    
 -------------------+------------------+----------+-----------

--- a/src/test/regress/expected/partition_locking_optimizer.out
+++ b/src/test/regress/expected/partition_locking_optimizer.out
@@ -356,13 +356,14 @@ select * from locktest_master where coalesce not like 'gp_%' and coalesce not li
  partlockt_1_prt_9 | ExclusiveLock | relation | master
 (10 rows)
 
+-- TODO: Seems RowExclusiveLock should be also applied on index of partlock table,
+-- like it's done in vanila postgres (lock on indexes should be eqaul to locks on table).
 select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
-        coalesce         |       mode       | locktype |    node    
--------------------------+------------------+----------+------------
- partlockt               | RowExclusiveLock | relation | n segments
- partlockt_1_prt_4       | AccessShareLock  | relation | n segments
- partlockt_1_prt_4_i_idx | AccessShareLock  | relation | n segments
-(3 rows)
+     coalesce      |       mode       | locktype |    node    
+-------------------+------------------+----------+------------
+ partlockt         | RowExclusiveLock | relation | n segments
+ partlockt_1_prt_4 | AccessShareLock  | relation | n segments
+(2 rows)
 
 commit;
 -- drop index

--- a/src/test/regress/expected/updatable_views_optimizer.out
+++ b/src/test/regress/expected/updatable_views_optimizer.out
@@ -368,12 +368,12 @@ EXPLAIN (costs off) UPDATE rw_view1 SET a=6 WHERE a=5;
    ->  Sort
          Sort Key: (DMLAction)
          ->  Redistribute Motion 3:3  (slice1; segments: 3)
-               Hash Key: base_tbl.a
+               Hash Key: a
                ->  Split
                      ->  Result
                            ->  Index Scan using base_tbl_pkey on base_tbl
                                  Index Cond: ((a = 5) AND (a > 0))
- Optimizer: Pivotal Optimizer (GPORCA)
+GP_IGNORE:
 (10 rows)
 
 EXPLAIN (costs off) DELETE FROM rw_view1 WHERE a=5;
@@ -447,12 +447,12 @@ EXPLAIN (costs off) UPDATE rw_view2 SET aaa=5 WHERE aaa=4;
    ->  Sort
          Sort Key: (DMLAction)
          ->  Redistribute Motion 3:3  (slice1; segments: 3)
-               Hash Key: base_tbl.a
+               Hash Key: a
                ->  Split
                      ->  Result
                            ->  Index Scan using base_tbl_pkey on base_tbl
                                  Index Cond: ((a = 4) AND (a < 10) AND (a > 0))
- Optimizer: Pivotal Optimizer (GPORCA)
+GP_IGNORE:
 (10 rows)
 
 EXPLAIN (costs off) DELETE FROM rw_view2 WHERE aaa=4;
@@ -2075,7 +2075,7 @@ EXPLAIN (costs off) INSERT INTO rw_view1 VALUES (2, 'New row 2');
          ->  Result
                ->  Nested Loop Semi Join
                      Join Filter: true
-                     ->  Index Scan using base_tbl_pkey on base_tbl base_tbl_1
+                     ->  Index Scan using base_tbl_pkey on base_tbl
                            Index Cond: (id = 2)
                      ->  Materialize
                            ->  Broadcast Motion 1:3  (slice2; segments: 1)
@@ -2083,7 +2083,7 @@ EXPLAIN (costs off) INSERT INTO rw_view1 VALUES (2, 'New row 2');
                                        ->  Result
                                              ->  Limit
                                                    ->  Gather Motion 3:1  (slice1; segments: 3)
-                                                         ->  Index Scan using base_tbl_pkey on base_tbl
+                                                         ->  Index Scan using base_tbl_pkey on base_tbl base_tbl_1
                                                                Index Cond: (id = 2)
  Optimizer: Pivotal Optimizer (GPORCA)
 (37 rows)

--- a/src/test/regress/expected/update_optimizer.out
+++ b/src/test/regress/expected/update_optimizer.out
@@ -340,11 +340,11 @@ EXPLAIN (COSTS OFF ) UPDATE tab3 SET C1 = C1 + 1, C5 = C5+1;
 ------------------------------------------------------
  Update
    ->  Redistribute Motion 3:3  (slice1; segments: 3)
-         Hash Key: tab3.c1, tab3.c2, tab3.c3
+         Hash Key: c1, c2, c3
          ->  Split
                ->  Result
                      ->  Seq Scan on tab3
- Optimizer: Pivotal Optimizer (GPORCA)
+GP_IGNORE:
 (7 rows)
 
 -- clean up

--- a/src/test/regress/sql/partition_locking.sql
+++ b/src/test/regress/sql/partition_locking.sql
@@ -142,6 +142,8 @@ begin;
 delete from partlockt where i = 4;
 -- Known_opt_diff: MPP-20936
 select * from locktest_master where coalesce not like 'gp_%' and coalesce not like 'pg_%';
+-- TODO: Seems RowExclusiveLock should be also applied on index of partlock table,
+-- like it's done in vanila postgres (lock on indexes should be eqaul to locks on table).
 select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
 commit;
 


### PR DESCRIPTION
# Problem description

Currently, `ExecDML()` [passes](https://github.com/greenplum-db/gpdb/blob/2d4a9cd4d030277505bad2983ea0aff71fe0873a/src/backend/executor/nodeDML.c#L148) `NULL` value to parameter `epqstate` in `ExecDelete()` call marking it as `DestReceiver`. As a consequence, the EPQ functionality is not possible for heap tables in case when `DML` node (instead of postgres-specific `ModifyTable`) is planned.
The `DestReceiver` name [was used](https://github.com/greenplum-db/gpdb/blob/70d06cd8994dd40fe5184cbed218b5c38b7412a6/src/include/executor/execDML.h#L41) in interface of `ExecDelete()` in gpdb-5x releases therefore we might conclude that preparing gpdb 6 the EPQ feature was not appropriately ported.

For testing we might use the following case (work when global deadlock detector is enabled):
```sql
-- Create table with one row
create table test as select 1 as i distributed randomly;

-- Start update transaction
1: begin;
1: set optimizer to off;
1: update test set i = i where i = 1;

-- Second session starts deletion of target row
-- it waits for result of update
2&: delete from test where i = 1;

-- Commit the first transaction;
-- Deletion is performed on second version of row
-- As this version is checked on predicate `i = 1` using EPQ routine we end up with:
-- ```ERROR:  could not serialize access due to concurrent update
-- HINT:  Use PostgreSQL Planner instead of Optimizer for this query via optimizer=off GUC setting```
-- Correct behavior have to successfully remove the row
1: commit;
```

This patch is splitted into two logical commits:
- first commit: added support of `EPQ` mechanism for the `orca` planner for `DML` operations: the `DML` and `DMLState` objects were extended with `epqParam` and `epqstate` fields respectively
- second commit is a [backport from 7.x](https://github.com/greenplum-db/gpdb/pull/14304) - fix to `orca` that makes target relation of `DML` operation and main scanning relation to refer to the same `RTE`. The last problem reveals in the following scenario

```sql
create table test as select 0 as i distributed randomly;

-- Start update transaction
1: begin;
1: set optimizer = off;
1: update test set i = i + 1;

-- Second session tries to delete modified row and
-- it waits for result of update
2&: delete from test where i = 0;
1: end;
-- as a result updated row was deleted - this is
-- not vaild behaviour (there must be no deletion)
DELETE 1
```

Here is a plan of `delete` query, there is a problem: `DML` and `SEQSCAN` node has different `scanrelid` (1 and 2 respectively), but they should point to the same RTE (like at pg planner).
```
{PLANNEDSTMT 
    ...
   :planTree 
      {DML 
      :scanrelid 1 
      ...
      :lefttree 
         {RESULT 
         :plan_node_id 1 
         ...
         :lefttree 
            {SEQSCAN 
            :plan_node_id 2
            ... 
            :scanrelid 2
            }
        ...
         }
      ...
      }
   :rtable (
      {RTE 
      :alias <> 
      :eref 
         {ALIAS 
         :aliasname test 
         :colnames (""i"")
         }
      :rtekind 0 
      :relid 16387 
      :requiredPerms 8 
      ...
      }
      {RTE 
      :alias <> 
      :eref 
         {ALIAS 
         :aliasname test 
         :colnames (""i"")
         }
      :rtekind 0 
      :relid 16387 
      :requiredPerms 2 
      ...
      }
   )
   :resultRelations (i 1)
   :relationOids (o 16387 16387 16387)
   ...
   }
```

EPQ mechanism through function call chain calls `ExecScanFetch`.
Due to incorrect `scanrelid` at `SEQSCAN` node next branch  ```if (estate->es_epqTupleSet[scanrelid - 1])``` won't be executed. Thus instead of working with slot from `es_epqTuple` cache - slot with an old row is returned from access method routine - `(*accessMtd) (node)` (which uses snapshot for delete operation). As a result `EvalPlanQual` returns not null slot with an old version of row to `ExecDelete`, but [tupleid points to the updated version and deletion is performed](https://github.com/greenplum-db/gpdb/blob/35f34393a56223af38c897ea16f20cdcfe24cdd7/src/backend/executor/nodeModifyTable.c#L994-L998)
```c
static inline TupleTableSlot *
ExecScanFetch(ScanState *node,
			  ExecScanAccessMtd accessMtd,
			  ExecScanRecheckMtd recheckMtd)
{
	EState	   *estate = node->ps.state;
	if (estate->es_epqTuple != NULL)
	{
		//...
		Index		scanrelid = ((Scan *) node->ps.plan)->scanrelid;
		//...
		if (estate->es_epqTupleSet[scanrelid - 1])
		{
			TupleTableSlot *slot = node->ss_ScanTupleSlot;

			/* Return empty slot if we already returned a tuple */
			if (estate->es_epqScanDone[scanrelid - 1])
				return ExecClearTuple(slot);
			//...
			/* Store test tuple in the plan node's scan slot */
			ExecStoreHeapTuple(estate->es_epqTuple[scanrelid - 1],
						   slot, InvalidBuffer, false);
			//...
			return slot;
		}
	}

	/*
	 * Run the node-type-specific access method function to get the next tuple
	 */
	return (*accessMtd) (node);
}
```

At the initial Query structure (parsed and analyzed query) we have right links to `RTE`'s, so to fix the problem with `scanrelid` - we want to transfer this information to the initial algebrized plan tree of orca. So we assign the `queryid` to each query structure (for subqueruies `queryid` assigned too) and, also, we assign `queryid` to table descriptors `CDXLTableDescr` which explicitly refers to target relation of dml. After orca planning transformations this value exposes to which target relation of `DML` operation is referred the current table descriptor. And this allows to correctly assign `RTE` indexes in result plan under transformation from `DXL` representation.

## Forced changes

There are three groups of tests which was fixed after patch changes

### Tests on locks (with one relation)
- src/test/regress/expected/ao_locks_optimizer.out ([1](https://github.com/arenadata/gpdb/blob/871c3e29b0c8b39e3beeec5e05a86cd5b6d7a51f/src/test/regress/expected/ao_locks_optimizer.out#L75), [2](https://github.com/arenadata/gpdb/blob/871c3e29b0c8b39e3beeec5e05a86cd5b6d7a51f/src/test/regress/expected/ao_locks_optimizer.out#L95))
- src/test/isolation2/output/uao/parallel_delete_optimizer.source ([1](https://github.com/arenadata/gpdb/blob/871c3e29b0c8b39e3beeec5e05a86cd5b6d7a51f/src/test/isolation2/output/uao/parallel_delete_optimizer.source#L16))
- src/test/isolation2/output/uao/parallel_update_optimizer.source )([1](https://github.com/arenadata/gpdb/blob/871c3e29b0c8b39e3beeec5e05a86cd5b6d7a51f/src/test/isolation2/output/uao/parallel_update_optimizer.source#L16))

At these tests DML operation is performed on the one table. Due to fixes of this patch, DML operations at these tests has only one (single) RTE - target relation, unlike it was before (scanrelid of DML and `*SCAN` plan nodes were different and plan contained two rtables, but there should be only one). So call [`ExecOpenScanRelation`](https://github.com/greenplum-db/gpdb/blob/35f34393a56223af38c897ea16f20cdcfe24cdd7/src/backend/executor/execUtils.c#L890) (on target relation) now doesn't set excess `AccessShareLock`, and relations still have more privileged `Exclusive` lock.

### Tests with explain (with one relation)

- src/test/regress/expected/updatable_views_optimizer.out ([1](https://github.com/arenadata/gpdb/blob/871c3e29b0c8b39e3beeec5e05a86cd5b6d7a51f/src/test/regress/expected/updatable_views_optimizer.out#L364), [2](https://github.com/arenadata/gpdb/blob/871c3e29b0c8b39e3beeec5e05a86cd5b6d7a51f/src/test/regress/expected/updatable_views_optimizer.out#L443))
- src/test/regress/expected/update_optimizer.out ([1](https://github.com/arenadata/gpdb/blob/871c3e29b0c8b39e3beeec5e05a86cd5b6d7a51f/src/test/regress/expected/update_optimizer.out#L338))
- src/test/isolation2/expected/modify_table_data_corrupt_optimizer.out ([1](https://github.com/arenadata/gpdb/blob/871c3e29b0c8b39e3beeec5e05a86cd5b6d7a51f/src/test/isolation2/expected/modify_table_data_corrupt_optimizer.out#L195))

Like at previous test group, `DML` operations at these tests performed on the one table - target relation, so now plan has correct `scanrelid` at `DML` and `*SCAN` nodes, and only one `RTE` contains at `rtable` list. Prefixes to column names at queries, that uses one table is not shown, like it is in postgres. Here is some links to code, related to showing prefix ([setting flag to show prefix](https://github.com/greenplum-db/gpdb/blob/35f34393a56223af38c897ea16f20cdcfe24cdd7/src/backend/commands/explain_gp.c#L2356), and function get_variable, where prefix [may be appended](https://github.com/greenplum-db/gpdb/blob/35f34393a56223af38c897ea16f20cdcfe24cdd7/src/backend/utils/adt/ruleutils.c#L6176)).

### Tests on partition locking

- src/test/regress/expected/partition_locking_optimizer.out ([1](https://github.com/arenadata/gpdb/blob/871c3e29b0c8b39e3beeec5e05a86cd5b6d7a51f/src/test/regress/expected/partition_locking_optimizer.out#L342))

Like at previous test group, `DML` operations at this test performed on the one table - target relation. Thus index_open [opens](https://github.com/greenplum-db/gpdb/blob/35f34393a56223af38c897ea16f20cdcfe24cdd7/src/backend/executor/nodeIndexscan.c#L556-L565) index with `NoLock`. 
 

### Tests with explain (used more than one relation)

- src/test/regress/expected/bfv_dml_optimizer.out ([1](https://github.com/arenadata/gpdb/blob/871c3e29b0c8b39e3beeec5e05a86cd5b6d7a51f/src/test/regress/expected/bfv_dml_optimizer.out#L664))
- src/test/regress/expected/updatable_views_optimizer.out ([1](https://github.com/arenadata/gpdb/blob/871c3e29b0c8b39e3beeec5e05a86cd5b6d7a51f/src/test/regress/expected/updatable_views_optimizer.out#L2049))

This test group was changed due to fixes of `scanrelid` too. `scanrelid` for DML and associated to it `*SCAN` node points to the same rte (and rtable list doesn't contain duplicate of dml target relation). Thus `ExplainPrintPlan` now [calculates](https://github.com/greenplum-db/gpdb/blob/35f34393a56223af38c897ea16f20cdcfe24cdd7/src/backend/commands/explain.c#L756-L757) list of relation names for `explain` a bit different (in comparsion to what was before) (calculation is based on `rels_used` bitmap - now it calculates correctly - there is no unused relation in a plan), so position of table names with suffixes changed due to fixes of `scanrelid`'s. 

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
