### PR TITLE
Add support for gp_autovacuum_scope guc

### DIFF
--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -4710,7 +4710,7 @@ struct config_enum ConfigureNamesEnum_gp[] =
 		{"gp_autovacuum_scope", PGC_SIGHUP, AUTOVACUUM,
 		 gettext_noop("Sets which tables are eligible for autovacuum of dead tuples."),
 		 NULL,
-		 GUC_NO_RESET_ALL | GUC_REPORT | GUC_SUPERUSER_ONLY
+		 GUC_REPORT | GUC_SUPERUSER_ONLY
 		},
 		&gp_autovacuum_scope,
 		AV_SCOPE_CATALOG, gp_autovacuum_scope_options,

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -39,6 +39,7 @@
 #include "optimizer/planmain.h"
 #include "pgstat.h"
 #include "parser/scansup.h"
+#include "postmaster/autovacuum.h"
 #include "postmaster/syslogger.h"
 #include "postmaster/fts.h"
 #include "replication/walsender.h"
@@ -545,6 +546,12 @@ static const struct config_enum_entry optimizer_join_order_options[] = {
 	{"greedy", JOIN_ORDER_GREEDY_SEARCH},
 	{"exhaustive", JOIN_ORDER_EXHAUSTIVE_SEARCH},
 	{"exhaustive2", JOIN_ORDER_EXHAUSTIVE2_SEARCH},
+	{NULL, 0}
+};
+
+static const struct config_enum_entry gp_autovacuum_scope_options[] = {
+	{"catalog", AV_SCOPE_CATALOG},
+	{"catalog_ao_aux", AV_SCOPE_CATALOG_AO_AUX},
 	{NULL, 0}
 };
 
@@ -4696,6 +4703,17 @@ struct config_enum ConfigureNamesEnum_gp[] =
 		},
 		&optimizer_join_order,
 		JOIN_ORDER_EXHAUSTIVE2_SEARCH, optimizer_join_order_options,
+		NULL, NULL, NULL
+	},
+
+	{
+		{"gp_autovacuum_scope", PGC_SIGHUP, AUTOVACUUM,
+		 gettext_noop("Sets which tables are eligible for autovacuum of dead tuples."),
+		 NULL,
+		 GUC_NO_RESET_ALL | GUC_REPORT | GUC_SUPERUSER_ONLY
+		},
+		&gp_autovacuum_scope,
+		AV_SCOPE_CATALOG, gp_autovacuum_scope_options,
 		NULL, NULL, NULL
 	},
 	/* End-of-list marker */

--- a/src/backend/utils/misc/postgresql.conf.sample
+++ b/src/backend/utils/misc/postgresql.conf.sample
@@ -604,6 +604,8 @@ optimizer_analyze_root_partition = on # stats collection on root partitions
 #autovacuum_vacuum_cost_limit = -1	# default vacuum cost limit for
 					# autovacuum, -1 means use
 					# vacuum_cost_limit
+#gp_autovacuum_scope = 'catalog' # default to autovacuuming only catalog tables
+                    # 'catalog_ao_aux' # autovacuum catalog and append-optimized auxiliary tables
 
 #------------------------------------------------------------------------------
 # CLIENT CONNECTION DEFAULTS

--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -1069,6 +1069,7 @@ static const char *const table_storage_parameters[] = {
 	"autovacuum_vacuum_scale_factor",
 	"autovacuum_vacuum_threshold",
 	"fillfactor",
+	"gp_autovacuum_scope",
 	"log_autovacuum_min_duration",
 	"parallel_workers",
 	"toast.autovacuum_enabled",

--- a/src/include/postmaster/autovacuum.h
+++ b/src/include/postmaster/autovacuum.h
@@ -40,10 +40,18 @@ extern int	autovacuum_multixact_freeze_max_age;
 extern double autovacuum_vac_cost_delay;
 extern int	autovacuum_vac_cost_limit;
 
+/*Allowed values for gp_autovacuum_scope*/
+typedef enum AutovacuumScope
+{
+	AV_SCOPE_CATALOG,
+	AV_SCOPE_CATALOG_AO_AUX,
+} AutovacuumScope;
+
 /* autovacuum launcher PID, only valid when worker is shutting down */
 extern int	AutovacuumLauncherPid;
 
-extern int	Log_autovacuum_min_duration;
+extern int  Log_autovacuum_min_duration;
+extern int	gp_autovacuum_scope;
 
 /* Status inquiry functions */
 extern bool AutoVacuumingActive(void);

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -135,6 +135,7 @@
 		"gp_autostats_mode",
 		"gp_autostats_mode_in_functions",
 		"gp_autostats_on_change_threshold",
+		"gp_autovacuum_scope",
 		"gp_cached_segworkers_threshold",
 		"gp_command_count",
 		"gp_connection_send_timeout",

--- a/src/test/regress/expected/autovacuum-ao-aux.out
+++ b/src/test/regress/expected/autovacuum-ao-aux.out
@@ -1,0 +1,80 @@
+-- Test to ensure that catalog-ao-aux autovacuum clears bloat from appendonly auxiliary tables.
+-- create and switch to database
+CREATE DATABASE av_ao_aux;
+\c av_ao_aux
+CREATE EXTENSION gp_inject_fault;
+-- speed up test
+ALTER SYSTEM SET autovacuum_naptime = 5;
+ALTER SYSTEM SET gp_autovacuum_scope = catalog_ao_aux;
+-- start_ignore
+\! gpstop -u;
+20230207:21:01:04:299967 gpstop:ajrdevbox:ajr-[INFO]:-Starting gpstop with args: -u
+20230207:21:01:04:299967 gpstop:ajrdevbox:ajr-[INFO]:-Gathering information and validating the environment...
+20230207:21:01:04:299967 gpstop:ajrdevbox:ajr-[INFO]:-Obtaining Greenplum Coordinator catalog information
+20230207:21:01:04:299967 gpstop:ajrdevbox:ajr-[INFO]:-Obtaining Segment details from coordinator...
+20230207:21:01:04:299967 gpstop:ajrdevbox:ajr-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 7.0.0-alpha.0+dev.18027.g20aa1a2c48 build dev'
+20230207:21:01:04:299967 gpstop:ajrdevbox:ajr-[INFO]:-Signalling all postmaster processes to reload
+-- end_ignore
+CREATE TABLE autovac_ao(i int, j int) USING ao_row distributed BY (i);
+-- because we don't know the name of the aux tables ahead of time, we have to
+-- jump through some hoops to identify them
+WITH tableNameCTE AS (
+    SELECT c.relname
+    FROM pg_appendonly pa, pg_class c
+    WHERE pa.visimaprelid = c.oid AND pa.relid = 'autovac_ao'::regclass
+)
+SELECT gp_inject_fault('auto_vac_worker_after_report_activity', 'skip', '', '', relname, 1, 1, 0, dbid)
+from tableNameCTE, gp_segment_configuration where role = 'p' and content != -1;
+ gp_inject_fault 
+-----------------
+ Success:
+ Success:
+ Success:
+(3 rows)
+
+-- populate test table, use a large value to ensure we're past autovacuum threshold
+INSERT INTO autovac_ao SELECT j,j FROM generate_series(1, 10000000)j;
+-- Deleting tuples from an AO table will insert rows into its visimap table.
+-- Aborting the delete should mark these inserted rows as invisible, and hence
+-- eligible for autovacuum.
+begin; delete from autovac_ao where j % 9 = 3; abort;
+-- wait for autovacuum to hit the auxiliary visimap table for autovac_ao,
+-- triggering a fault
+SELECT gp_wait_until_triggered_fault('auto_vac_worker_after_report_activity', 1, dbid)
+from gp_segment_configuration where role = 'p' and content != -1;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:
+ Success:
+ Success:
+(3 rows)
+
+-- clean up fault
+WITH tableNameCTE AS (
+    SELECT c.relname
+    FROM pg_appendonly pa, pg_class c
+    WHERE pa.visimaprelid = c.oid AND pa.relid = 'autovac_ao'::regclass
+)
+SELECT gp_inject_fault('auto_vac_worker_after_report_activity', 'reset', dbid)
+from tableNameCTE, gp_segment_configuration where role = 'p' and content != -1;
+ gp_inject_fault 
+-----------------
+ Success:
+ Success:
+ Success:
+(3 rows)
+
+ALTER SYSTEM RESET autovacuum_naptime;
+ALTER SYSTEM RESET gp_autovacuum_scope;
+-- start_ignore
+\! gpstop -u;
+20230207:21:01:16:300074 gpstop:ajrdevbox:ajr-[INFO]:-Starting gpstop with args: -u
+20230207:21:01:16:300074 gpstop:ajrdevbox:ajr-[INFO]:-Gathering information and validating the environment...
+20230207:21:01:16:300074 gpstop:ajrdevbox:ajr-[INFO]:-Obtaining Greenplum Coordinator catalog information
+20230207:21:01:16:300074 gpstop:ajrdevbox:ajr-[INFO]:-Obtaining Segment details from coordinator...
+20230207:21:01:16:300074 gpstop:ajrdevbox:ajr-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 7.0.0-alpha.0+dev.18027.g20aa1a2c48 build dev'
+20230207:21:01:16:300074 gpstop:ajrdevbox:ajr-[INFO]:-Signalling all postmaster processes to reload
+-- end_ignore
+-- clean up database
+\c regression
+DROP DATABASE av_ao_aux;

--- a/src/test/regress/expected/autovacuum-catalog.out
+++ b/src/test/regress/expected/autovacuum-catalog.out
@@ -1,0 +1,55 @@
+-- Test to ensure that catalog-only autovacuum clears catalog bloat.
+-- create and switch to database
+CREATE DATABASE av_catalog;
+\c av_catalog
+-- speed up test
+ALTER SYSTEM SET autovacuum_naptime = 5;
+-- start_ignore
+\! gpstop -u;
+20230207:20:52:47:298674 gpstop:ajrdevbox:ajr-[INFO]:-Starting gpstop with args: -u
+20230207:20:52:47:298674 gpstop:ajrdevbox:ajr-[INFO]:-Gathering information and validating the environment...
+20230207:20:52:47:298674 gpstop:ajrdevbox:ajr-[INFO]:-Obtaining Greenplum Coordinator catalog information
+20230207:20:52:47:298674 gpstop:ajrdevbox:ajr-[INFO]:-Obtaining Segment details from coordinator...
+20230207:20:52:47:298674 gpstop:ajrdevbox:ajr-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 7.0.0-alpha.0+dev.18027.g20aa1a2c48 build dev'
+20230207:20:52:47:298674 gpstop:ajrdevbox:ajr-[INFO]:-Signalling all postmaster processes to reload
+-- end_ignore
+-- create extension and set faults for testing
+CREATE EXTENSION gp_inject_fault;
+SELECT gp_inject_fault('auto_vac_worker_after_report_activity', 'skip', '', '', 'pg_class', 1, 1, 0, 1);
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+-- generate bloat on catalog tables to trigger autovacuum
+BEGIN;
+CREATE TABLE bloat_tbl(i int, j int, k int, l int, m int, n int, o int, p int) DISTRIBUTED BY (i)
+PARTITION BY RANGE (j) (START (0) END (1000) EVERY (1));
+ABORT;
+-- wait for autovacuum to hit pg_class, triggering a fault
+SELECT gp_wait_until_triggered_fault('auto_vac_worker_after_report_activity', 1, 1);
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:
+(1 row)
+
+-- clean up fault
+SELECT gp_inject_fault('auto_vac_worker_after_report_activity', 'reset', 1);
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+ALTER SYSTEM RESET autovacuum_naptime;
+-- start_ignore
+\! gpstop -u;
+20230207:20:52:59:298805 gpstop:ajrdevbox:ajr-[INFO]:-Starting gpstop with args: -u
+20230207:20:52:59:298805 gpstop:ajrdevbox:ajr-[INFO]:-Gathering information and validating the environment...
+20230207:20:52:59:298805 gpstop:ajrdevbox:ajr-[INFO]:-Obtaining Greenplum Coordinator catalog information
+20230207:20:52:59:298805 gpstop:ajrdevbox:ajr-[INFO]:-Obtaining Segment details from coordinator...
+20230207:20:52:59:298805 gpstop:ajrdevbox:ajr-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 7.0.0-alpha.0+dev.18027.g20aa1a2c48 build dev'
+20230207:20:52:59:298805 gpstop:ajrdevbox:ajr-[INFO]:-Signalling all postmaster processes to reload
+-- end_ignore
+-- clean up database
+\c regression
+DROP DATABASE av_catalog;

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -296,6 +296,8 @@ test: mirror_replay
 test: autovacuum
 test: autovacuum-segment
 test: autovacuum-template0-segment
+test: autovacuum-catalog
+test: autovacuum-ao-aux
 
 # gpexpand introduce the partial tables, check them if they can run correctly
 test: gangsize gang_reuse

--- a/src/test/regress/sql/autovacuum-ao-aux.sql
+++ b/src/test/regress/sql/autovacuum-ao-aux.sql
@@ -1,0 +1,57 @@
+-- Test to ensure that catalog-ao-aux autovacuum clears bloat from appendonly auxiliary tables.
+-- create and switch to database
+CREATE DATABASE av_ao_aux;
+\c av_ao_aux
+
+CREATE EXTENSION gp_inject_fault;
+
+-- speed up test
+ALTER SYSTEM SET autovacuum_naptime = 5;
+ALTER SYSTEM SET gp_autovacuum_scope = catalog_ao_aux;
+-- start_ignore
+\! gpstop -u;
+-- end_ignore
+
+
+CREATE TABLE autovac_ao(i int, j int) USING ao_row distributed BY (i);
+-- because we don't know the name of the aux tables ahead of time, we have to
+-- jump through some hoops to identify them
+WITH tableNameCTE AS (
+    SELECT c.relname
+    FROM pg_appendonly pa, pg_class c
+    WHERE pa.visimaprelid = c.oid AND pa.relid = 'autovac_ao'::regclass
+)
+SELECT gp_inject_fault('auto_vac_worker_after_report_activity', 'skip', '', '', relname, 1, 1, 0, dbid)
+from tableNameCTE, gp_segment_configuration where role = 'p' and content != -1;
+
+-- populate test table, use a large value to ensure we're past autovacuum threshold
+INSERT INTO autovac_ao SELECT j,j FROM generate_series(1, 10000000)j;
+
+-- Deleting tuples from an AO table will insert rows into its visimap table.
+-- Aborting the delete should mark these inserted rows as invisible, and hence
+-- eligible for autovacuum.
+begin; delete from autovac_ao where j % 9 = 3; abort;
+
+-- wait for autovacuum to hit the auxiliary visimap table for autovac_ao,
+-- triggering a fault
+SELECT gp_wait_until_triggered_fault('auto_vac_worker_after_report_activity', 1, dbid)
+from gp_segment_configuration where role = 'p' and content != -1;
+
+-- clean up fault
+WITH tableNameCTE AS (
+    SELECT c.relname
+    FROM pg_appendonly pa, pg_class c
+    WHERE pa.visimaprelid = c.oid AND pa.relid = 'autovac_ao'::regclass
+)
+SELECT gp_inject_fault('auto_vac_worker_after_report_activity', 'reset', dbid)
+from tableNameCTE, gp_segment_configuration where role = 'p' and content != -1;
+
+ALTER SYSTEM RESET autovacuum_naptime;
+ALTER SYSTEM RESET gp_autovacuum_scope;
+-- start_ignore
+\! gpstop -u;
+-- end_ignore
+
+-- clean up database
+\c regression
+DROP DATABASE av_ao_aux;

--- a/src/test/regress/sql/autovacuum-catalog.sql
+++ b/src/test/regress/sql/autovacuum-catalog.sql
@@ -1,0 +1,36 @@
+-- Test to ensure that catalog-only autovacuum clears catalog bloat.
+-- create and switch to database
+CREATE DATABASE av_catalog;
+\c av_catalog
+
+-- speed up test
+ALTER SYSTEM SET autovacuum_naptime = 5;
+-- start_ignore
+\! gpstop -u;
+-- end_ignore
+
+-- create extension and set faults for testing
+CREATE EXTENSION gp_inject_fault;
+SELECT gp_inject_fault('auto_vac_worker_after_report_activity', 'skip', '', '', 'pg_class', 1, 1, 0, 1);
+
+-- generate bloat on catalog tables to trigger autovacuum
+BEGIN;
+CREATE TABLE bloat_tbl(i int, j int, k int, l int, m int, n int, o int, p int) DISTRIBUTED BY (i)
+PARTITION BY RANGE (j) (START (0) END (1000) EVERY (1));
+ABORT;
+
+-- wait for autovacuum to hit pg_class, triggering a fault
+SELECT gp_wait_until_triggered_fault('auto_vac_worker_after_report_activity', 1, 1);
+
+-- clean up fault
+SELECT gp_inject_fault('auto_vac_worker_after_report_activity', 'reset', 1);
+
+
+ALTER SYSTEM RESET autovacuum_naptime;
+-- start_ignore
+\! gpstop -u;
+-- end_ignore
+
+-- clean up database
+\c regression
+DROP DATABASE av_catalog;


### PR DESCRIPTION
Add a guc to control which tables autovacuum will vacuum. Supported options are 'catalog' and 'catalog_ao_aux'.

Also add basic regression test coverage for autovacuum of catalog bloat and bloat in AO auxiliary tables.