### PR TITLE
Rename master instances to coordinator

### DIFF
--- a/gpMgmt/bin/gpactivatestandby
+++ b/gpMgmt/bin/gpactivatestandby
@@ -82,7 +82,7 @@ def parseargs():
 
     # Standby activation options section
     optgrp = OptionGroup(parser, 'Standby activation options')
-    optgrp.add_option('-d', '--master-data-directory', dest='coordinator_data_dir',
+    optgrp.add_option('-d', '--master-data-directory', '--coordinator-data-directory', dest='coordinator_data_dir',
                       type='string', help='standby coordinator data directory')
     optgrp.add_option('-f', '--force', action='store_true',
                       help='force activation if standby process not running')
@@ -104,7 +104,7 @@ def parseargs():
 
 
     if not options.coordinator_data_dir:
-        logger.info('Option -d or --master-data-directory not set. Checking environment variable COORDINATOR_DATA_DIRECTORY')
+        logger.info('Option -d or --master-data-directory or --coordinator-data-directory not set. Checking environment variable COORDINATOR_DATA_DIRECTORY')
         env_coordinator_data_dir = gp.get_coordinatordatadir()
         # check for environment variable COORDINATOR_DATA_DIRECTORY
         if not env_coordinator_data_dir:

--- a/gpMgmt/bin/gpdeletesystem
+++ b/gpMgmt/bin/gpdeletesystem
@@ -74,7 +74,7 @@ def parseargs():
 
     # Standby activation options section
     optgrp = OptionGroup(parser, 'Delete system options')
-    optgrp.add_option('-d', '--master-data-directory', dest='coordinator_data_dir',
+    optgrp.add_option('-d', '--master-data-directory', '--coordinator-data-directory', dest='coordinator_data_dir',
                       type='string', help='Coordinator data directory.')
     optgrp.add_option('-f', '--force', action='store_true',
                       help='Force deletion.  Ignore any database backup files.')
@@ -96,7 +96,7 @@ def parseargs():
 
     # check we got the -d option
     if not options.coordinator_data_dir:
-        logger.info('Option -d or --master-data-directory not set. Checking environment variable COORDINATOR_DATA_DIRECTORY')
+        logger.info('Option -d or --master-data-directory or --coordinator-data-directory not set. Checking environment variable COORDINATOR_DATA_DIRECTORY')
         env_coordinator_data_dir = gp.get_coordinatordatadir()
         # check for environment variable COORDINATOR_DATA_DIRECTORY
         if not env_coordinator_data_dir:

--- a/gpMgmt/bin/gpmovemirrors
+++ b/gpMgmt/bin/gpmovemirrors
@@ -67,7 +67,7 @@ def parseargs():
 
     parser.add_option('-i', '--input', dest="input_filename",
                       help="input expansion configuration file.", metavar="FILE")
-    parser.add_option('-d', '--master-data-directory', dest='coordinator_data_directory',
+    parser.add_option('-d', '--master-data-directory', '--coordinator-data-directory', dest='coordinator_data_directory',
                       help='The coordinator data directory for the system. If this option is not specified, \
                             the value is obtained from the $COORDINATOR_DATA_DIRECTORY environment variable.')
     parser.add_option('-B', '--batch-size', dest='batch_size', type='int', default=gp.DEFAULT_COORDINATOR_NUM_WORKERS, metavar="<batch_size>",
@@ -133,14 +133,14 @@ def logOptionValues(options):
     """ """
     logger.info("Option values for this invocation of gpmovemirrors are:")
     logger.info("")
-    logger.info("  --input                 = " + str(options.input_filename))
-    logger.info("  --master-data-directory = " + str(options.coordinator_data_directory))
-    logger.info("  --batch-size            = " + str(options.batch_size))
-    logger.info("  --segment-batch-size    = " + str(options.segment_batch_size))
+    logger.info("  --input                      = " + str(options.input_filename))
+    logger.info("  --coordinator-data-directory = " + str(options.coordinator_data_directory))
+    logger.info("  --batch-size                 = " + str(options.batch_size))
+    logger.info("  --segment-batch-size         = " + str(options.segment_batch_size))
     if options.verbose != None:
-        logger.info("  --verbose               = " + str(options.verbose))
+        logger.info("  --verbose                    = " + str(options.verbose))
     if options.continue_move != None:
-        logger.info("  --continue              = " + str(options.continue_move))
+        logger.info("  --continue                   = " + str(options.continue_move))
     logger.info("")
 
 

--- a/gpMgmt/bin/gppylib/mainUtils.py
+++ b/gpMgmt/bin/gppylib/mainUtils.py
@@ -414,7 +414,7 @@ def addCoordinatorDirectoryOptionForSingleClusterProgram(addTo):
     For programs that operate on multiple clusters at once, this function/option
     is not appropriate.
     """
-    addTo.add_option('-d', '--master_data_directory', type='string',
+    addTo.add_option('-d', '--master_data_directory', '--coordinator_data_directory', type='string',
                      dest="coordinatorDataDirectory",
                      metavar="<coordinator data directory>",
                      help="Optional. The coordinator host data directory. If not specified, the value set" \

--- a/gpMgmt/test/behave/mgmt_utils/gpcheckcat.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpcheckcat.feature
@@ -434,7 +434,7 @@ Feature: gpcheckcat tests
         Then gpcheckcat should print "Table pg_type has a dependency issue on oid .* at content 0" to stdout
         And the user runs "dropdb gpcheckcat_dependency"
 
-    Scenario: gpcheckcat should report no inconsistency of pg_extension between Master and Segements
+    Scenario: gpcheckcat should report no inconsistency of pg_extension between Coordinator and Segements
         Given database "pgextension_db" is dropped and recreated
         And the user runs sql "set allow_system_table_mods=true;update pg_extension set extconfig='{2130}', extcondition='{2130}';" in "pgextension_db" on first primary segment
         Then the user runs "gpcheckcat -R inconsistent pgextension_db"

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -3897,7 +3897,7 @@ def impl(context):
      cmd.run(validateAfter=True)
 
      # Update hostfile location
-     cmd = Command(name='update master hostname in config file',
+     cmd = Command(name='update coordinator hostname in config file',
                    cmdStr= "sed 's/MACHINE_LIST_FILE=.*/MACHINE_LIST_FILE=\/tmp\/hostfile--1/g' -i /tmp/clusterConfigFile-1")
      cmd.run(validateAfter=True)
 


### PR DESCRIPTION
This commit replaces the remaining places where `master` term is being used to `coordinator` and adds an alternative flag `--coordinator-data-directory` in addition to the existing flag `--master-data-directory` in some places to maintain backward compatibility.

[Pipeline](https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb-dev-master_coordinator_rename)