### PR TITLE
[6X] fix the issue of cannot create temporary table like existing table with comments

### DIFF
--- a/src/backend/catalog/namespace.c
+++ b/src/backend/catalog/namespace.c
@@ -2970,11 +2970,33 @@ makeRangeVarFromNameList(List *names)
 			break;
 		case 2:
 			rel->schemaname = strVal(linitial(names));
+
+			/* GPDB: When QD generates query tree and serializes it to string
+			 * and sends it to QE, and QE will deserialize it to a plan tree.
+			 * In this process, Greenplum will not consider the difference
+			 * between NULL and an empty string, so if the original value is
+			 * a NULL, QE may deserialize it to an empty string, which could
+			 * lead to error in the following process.
+			 */
+			if (rel->schemaname && strlen(rel->schemaname) == 0)
+				rel->schemaname = NULL;
+
 			rel->relname = strVal(lsecond(names));
 			break;
 		case 3:
 			rel->catalogname = strVal(linitial(names));
 			rel->schemaname = strVal(lsecond(names));
+
+			/* GPDB: When QD generates query tree and serializes it to string
+			 * and sends it to QE, and QE will deserialize it to a plan tree.
+			 * In this process, Greenplum will not consider the difference
+			 * between NULL and an empty string, so if the original value is
+			 * a NULL, QE may deserialize it to an empty string, which could
+			 * lead to error in the following process.
+			 */
+			if (rel->schemaname && strlen(rel->schemaname) == 0)
+				rel->schemaname = NULL;
+
 			rel->relname = strVal(lthird(names));
 			break;
 		default:

--- a/src/test/regress/expected/create_table_like_gp.out
+++ b/src/test/regress/expected/create_table_like_gp.out
@@ -86,3 +86,26 @@ CONTEXT:  SQL statement "DROP EXTERNAL TABLE IF EXISTS t_ext_r"
 PL/pgSQL function drop_and_recreate_external_table() line 4 at SQL statement
 SQL statement "SELECT drop_and_recreate_external_table()"
 PL/pgSQL function inline_code_block line 4 at PERFORM
+-- TEMP TABLE WITH COMMENTS
+-- More details can be found at https://github.com/greenplum-db/gpdb/issues/14649
+CREATE TABLE t_comments_a (a integer);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+COMMENT ON COLUMN t_comments_a.a IS 'Airflow';
+CREATE TEMPORARY TABLE t_comments_b (LIKE t_comments_a INCLUDING COMMENTS);
+NOTICE:  table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
+-- Verify the copied comment
+SELECT
+	c.column_name,
+	pgd.description
+FROM pg_catalog.pg_statio_all_tables st
+		inner join pg_catalog.pg_description pgd on (pgd.objoid=st.relid)
+		inner join information_schema.columns c on (pgd.objsubid=c.ordinal_position and c.table_schema=st.schemaname and c.table_name=st.relname)
+WHERE c.table_name = 't_comments_b';
+ column_name | description 
+-------------+-------------
+ a           | Airflow
+(1 row)
+
+DROP TABLE t_comments_a;
+DROP TABLE t_comments_b;

--- a/src/test/regress/sql/create_table_like_gp.sql
+++ b/src/test/regress/sql/create_table_like_gp.sql
@@ -61,3 +61,22 @@ begin
   end loop;
 end;
 $$;
+
+
+-- TEMP TABLE WITH COMMENTS
+-- More details can be found at https://github.com/greenplum-db/gpdb/issues/14649
+CREATE TABLE t_comments_a (a integer);
+COMMENT ON COLUMN t_comments_a.a IS 'Airflow';
+CREATE TEMPORARY TABLE t_comments_b (LIKE t_comments_a INCLUDING COMMENTS);
+
+-- Verify the copied comment
+SELECT
+	c.column_name,
+	pgd.description
+FROM pg_catalog.pg_statio_all_tables st
+		inner join pg_catalog.pg_description pgd on (pgd.objoid=st.relid)
+		inner join information_schema.columns c on (pgd.objsubid=c.ordinal_position and c.table_schema=st.schemaname and c.table_name=st.relname)
+WHERE c.table_name = 't_comments_b';
+
+DROP TABLE t_comments_a;
+DROP TABLE t_comments_b;


### PR DESCRIPTION
This is the backport of #14742 

This PR is trying to fix the issue of #14649. 

When QD generates query tree and serializes it to string and sends it to QE, 
and QE will deserialize it to a plan tree. In this process, Greenplum seems not 
to consider the difference between NULL and an empty string, so if the original 
value is a NULL, QE may deserialize it to an empty string, which could lead error 
happened.

It's hard to modify the function of `deserializeNode()`, since Greenplum does not
have the mechanism to clarify NULL and empty string during serialization and
deserialization. 

So this PR is just fixing the special issue, not for general using.
