### PR TITLE
Shortcut when joinaliasvars' element is not Var during NOT-IN pullup.

### DIFF
--- a/src/backend/cdb/cdbsubselect.c
+++ b/src/backend/cdb/cdbsubselect.c
@@ -1530,18 +1530,20 @@ convert_IN_to_antijoin(PlannerInfo *root, SubLink *sublink,
 		int			subq_indx      = add_notin_subquery_rte(parse, subselect);
 		List       *inner_exprs    = NIL;
 		List       *outer_exprs    = NIL;
-		bool        inner_nullable = true;
-		bool        outer_nullable = true;
-
-		inner_exprs = fetch_targetlist_exprs(subselect->targetList);
-		outer_exprs = fetch_outer_exprs(sublink->testexpr);
-		inner_nullable = is_exprs_nullable((Node *) inner_exprs, subselect);
-		outer_nullable = is_exprs_nullable((Node *) outer_exprs, parse);
-
-		JoinExpr   *join_expr = make_join_expr(NULL, subq_indx, JOIN_LASJ_NOTIN);
+		bool        nullable       = true;
+		JoinExpr   *join_expr      = make_join_expr(NULL, subq_indx, JOIN_LASJ_NOTIN);
 
 		join_expr->quals = make_lasj_quals(root, sublink, subq_indx);
-		if (inner_nullable || outer_nullable)
+
+		inner_exprs = fetch_targetlist_exprs(subselect->targetList);
+		nullable = is_exprs_nullable((Node *) inner_exprs, subselect);
+		if (!nullable)
+		{
+			outer_exprs = fetch_outer_exprs(sublink->testexpr);
+			nullable = is_exprs_nullable((Node *) outer_exprs, parse);
+		}
+
+		if (nullable)
 			join_expr->quals = add_null_match_clause(join_expr->quals);
 
 		return join_expr;

--- a/src/test/regress/expected/notin.out
+++ b/src/test/regress/expected/notin.out
@@ -1641,6 +1641,28 @@ from
 where a = age.c;
 drop table t1p;
 drop table t2p;
+-- test for github issue 14858
+create table t1_14858(a varchar(32), b varchar(32), c int, d int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table t2_14858(a varchar(32), b varchar(32), c int, d int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table t3_14858(a varchar(32), b varchar(32), c int, d int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create view mv_14858 as select * from t1_14858 full join
+(select a, b, count(c) from t2_14858 group by a,b union
+ select a, b, count(c) from t3_14858 group by a, b) x using (a, b);
+select * from mv_14858 where a not in (select a from t1_14858);
+ a | b | c | d | count 
+---+---+---+---+-------
+(0 rows)
+
+drop view mv_14858;
+drop table t1_14858;
+drop table t2_14858;
+drop table t3_14858;
 reset search_path;
 drop schema notin cascade;
 NOTICE:  drop cascades to 22 other objects

--- a/src/test/regress/expected/notin_optimizer.out
+++ b/src/test/regress/expected/notin_optimizer.out
@@ -1685,6 +1685,28 @@ from
 where a = age.c;
 drop table t1p;
 drop table t2p;
+-- test for github issue 14858
+create table t1_14858(a varchar(32), b varchar(32), c int, d int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table t2_14858(a varchar(32), b varchar(32), c int, d int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table t3_14858(a varchar(32), b varchar(32), c int, d int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create view mv_14858 as select * from t1_14858 full join
+(select a, b, count(c) from t2_14858 group by a,b union
+ select a, b, count(c) from t3_14858 group by a, b) x using (a, b);
+select * from mv_14858 where a not in (select a from t1_14858);
+ a | b | c | d | count 
+---+---+---+---+-------
+(0 rows)
+
+drop view mv_14858;
+drop table t1_14858;
+drop table t2_14858;
+drop table t3_14858;
 reset search_path;
 drop schema notin cascade;
 NOTICE:  drop cascades to 22 other objects

--- a/src/test/regress/sql/notin.sql
+++ b/src/test/regress/sql/notin.sql
@@ -568,5 +568,21 @@ where a = age.c;
 drop table t1p;
 drop table t2p;
 
+-- test for github issue 14858
+create table t1_14858(a varchar(32), b varchar(32), c int, d int);
+create table t2_14858(a varchar(32), b varchar(32), c int, d int);
+create table t3_14858(a varchar(32), b varchar(32), c int, d int);
+
+create view mv_14858 as select * from t1_14858 full join
+(select a, b, count(c) from t2_14858 group by a,b union
+ select a, b, count(c) from t3_14858 group by a, b) x using (a, b);
+
+select * from mv_14858 where a not in (select a from t1_14858);
+
+drop view mv_14858;
+drop table t1_14858;
+drop table t2_14858;
+drop table t3_14858;
+
 reset search_path;
 drop schema notin cascade;


### PR DESCRIPTION
Per the comments of the field joinaliasvars of struct RangeTblEntry, it might be Var
or COALESCE expr or NULL pointer. For cases other than a simple Var, return NULL
is a safe choice.

For detailes please refer to Github Issue
https://github.com/greenplum-db/gpdb/issues/14858.
