### PR TITLE
fix select with limit is slower than without limit for a greenplum_fdw table

### DIFF
--- a/src/test/isolation2/input/parallel_retrieve_cursor/status_wait.source
+++ b/src/test/isolation2/input/parallel_retrieve_cursor/status_wait.source
@@ -288,3 +288,25 @@ insert into t1 select generate_series(1,100);
 -- check no endpoint info
 2: SELECT state FROM gp_get_endpoints() WHERE cursorname='c10';
 *U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_get_segment_endpoints() WHERE cursorname='c10';
+
+0Rq:
+1Rq:
+--------- Test11: Test t1 has large amount of tuples, only retreive small number of tuples, we can still close cursor.
+1:DROP TABLE IF EXISTS t2;
+1:CREATE TABLE t2 (id integer, data text) DISTRIBUTED by (id);
+1:INSERT INTO t2 select id, 'test ' || id from generate_series(1,100000) id;
+
+1: BEGIN;
+1: DECLARE c11 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t2;
+1: @post_run 'parse_endpoint_info 11 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c11';
+0R: @pre_run 'set_endpoint_variable @ENDPOINT11': RETRIEVE 5 FROM ENDPOINT "@ENDPOINT11";
+1R: @pre_run 'set_endpoint_variable @ENDPOINT11': RETRIEVE 5 FROM ENDPOINT "@ENDPOINT11";
+2R: @pre_run 'set_endpoint_variable @ENDPOINT11': RETRIEVE 5 FROM ENDPOINT "@ENDPOINT11";
+
+1: CLOSE c11;
+1: ROLLBACK;
+
+-- check no endpoint info
+1: SELECT auth_token,state FROM gp_get_endpoints() WHERE cursorname='c11';
+-- check no token info on QE after close PARALLEL RETRIEVE CURSOR
+*U: SELECT * FROM gp_get_segment_endpoints() WHERE cursorname='c11';

--- a/src/test/isolation2/output/parallel_retrieve_cursor/status_wait.source
+++ b/src/test/isolation2/output/parallel_retrieve_cursor/status_wait.source
@@ -1434,3 +1434,93 @@ ROLLBACK
 -------
 (0 rows)
 *U: SELECT senderpid<>-1, receiverpid<>-1, state FROM gp_get_segment_endpoints() WHERE cursorname='c10';
+ ?column? | ?column? | state 
+----------+----------+-------
+(0 rows)
+
+ ?column? | ?column? | state 
+----------+----------+-------
+(0 rows)
+
+ ?column? | ?column? | state 
+----------+----------+-------
+(0 rows)
+
+ ?column? | ?column? | state 
+----------+----------+-------
+(0 rows)
+
+0Rq: ... <quitting>
+1Rq: ... <quitting>
+--------- Test11: Test t1 has large amount of tuples, only retreive small number of tuples, we can still close cursor.
+1:DROP TABLE IF EXISTS t2;
+DROP
+1:CREATE TABLE t2 (id integer, data text) DISTRIBUTED by (id);
+CREATE
+1:INSERT INTO t2 select id, 'test ' || id from generate_series(1,100000) id;
+INSERT 100000
+
+1: BEGIN;
+BEGIN
+1: DECLARE c11 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t2;
+DECLARE
+1: @post_run 'parse_endpoint_info 11 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c11';
+ endpoint_id11 | token_id | host_id | port_id | READY
+ endpoint_id11 | token_id | host_id | port_id | READY
+ endpoint_id11 | token_id | host_id | port_id | READY
+(3 rows)
+0R: @pre_run 'set_endpoint_variable @ENDPOINT11': RETRIEVE 5 FROM ENDPOINT "@ENDPOINT11";
+ id | data   
+----+--------
+ 2  | test 2 
+ 3  | test 3 
+ 4  | test 4 
+ 7  | test 7 
+ 8  | test 8 
+(5 rows)
+1R: @pre_run 'set_endpoint_variable @ENDPOINT11': RETRIEVE 5 FROM ENDPOINT "@ENDPOINT11";
+ id | data    
+----+---------
+ 1  | test 1  
+ 12 | test 12 
+ 15 | test 15 
+ 20 | test 20 
+ 23 | test 23 
+(5 rows)
+2R: @pre_run 'set_endpoint_variable @ENDPOINT11': RETRIEVE 5 FROM ENDPOINT "@ENDPOINT11";
+ id | data    
+----+---------
+ 5  | test 5  
+ 6  | test 6  
+ 9  | test 9  
+ 10 | test 10 
+ 11 | test 11 
+(5 rows)
+
+1: CLOSE c11;
+CLOSE
+1: ROLLBACK;
+ROLLBACK
+
+-- check no endpoint info
+1: SELECT auth_token,state FROM gp_get_endpoints() WHERE cursorname='c11';
+ auth_token | state 
+------------+-------
+(0 rows)
+-- check no token info on QE after close PARALLEL RETRIEVE CURSOR
+*U: SELECT * FROM gp_get_segment_endpoints() WHERE cursorname='c11';
+ auth_token | databaseid | senderpid | receiverpid | state | gp_segment_id | sessionid | username | endpointname | cursorname 
+------------+------------+-----------+-------------+-------+---------------+-----------+----------+--------------+------------
+(0 rows)
+
+ auth_token | databaseid | senderpid | receiverpid | state | gp_segment_id | sessionid | username | endpointname | cursorname 
+------------+------------+-----------+-------------+-------+---------------+-----------+----------+--------------+------------
+(0 rows)
+
+ auth_token | databaseid | senderpid | receiverpid | state | gp_segment_id | sessionid | username | endpointname | cursorname 
+------------+------------+-----------+-------------+-------+---------------+-----------+----------+--------------+------------
+(0 rows)
+
+ auth_token | databaseid | senderpid | receiverpid | state | gp_segment_id | sessionid | username | endpointname | cursorname 
+------------+------------+-----------+-------------+-------+---------------+-----------+----------+--------------+------------
+(0 rows)


### PR DESCRIPTION
select * from foreign table with limit n in local cluster is much
slower than select * from foreign table without limit clause.
select a foreign table will declare a parallel retrieve cursor in remote cluster.
then establish retrieve conn with all the endpoints and retrieve data.
if with limit n clause we only retrieve n tuples in each retrieve connection.
But if foreign table has a log of data, Senders wait in waitLatch due to
MQ does not have extra space.
After local cluster get enough data, it will close the parallel cursor, however,
Sender receive SIGUSR1 does not call setLatch because set_latch_on_sigusr1 is false.

set set_latch_on_sigusr1 to true in shm_mq_send_bytes to allow setLatch
to be called after receiving SIGUSR1.