### PR TITLE
Add stream compress for gpdb6

### DIFF
--- a/src/backend/access/external/url_curl.c
+++ b/src/backend/access/external/url_curl.c
@@ -46,7 +46,8 @@ typedef struct curlhandle_t
 {
 	CURL			*handle;		/* The curl handle */
 #ifdef HAVE_LIBZSTD
-	ZSTD_DCtx		*zstd_dctx;		/* The zstd context */
+	ZSTD_DCtx		*zstd_dctx;		/* The zstd decompression context */
+	ZSTD_CCtx		*zstd_cctx;		/* The zstd compression context */
 #endif
 	struct curl_slist *x_httpheader;	/* list of headers */
 	bool		in_multi_handle;	/* T, if the handle is in global
@@ -85,7 +86,8 @@ typedef struct
 
 	struct
 	{
-		char	   *ptr;		/* palloc-ed buffer */
+		char	   	*ptr;		/* palloc-ed buffer */
+		char		*cptr;
 		int			max;
 		int			bot,
 					top;
@@ -118,7 +120,6 @@ typedef struct
 #define HOST_NAME_SIZE 100
 #define FDIST_TIMEOUT  408
 #define MAX_TRY_WAIT_TIME 64
-
 /*
  * SSL support GUCs - should be added soon. Until then we will use stubs
  *
@@ -185,6 +186,7 @@ static curlhandle_t *open_curl_handles;
 
 static bool url_curl_resowner_callback_registered;
 
+
 static curlhandle_t *
 create_curlhandle(void)
 {
@@ -197,6 +199,7 @@ create_curlhandle(void)
 
 #ifdef HAVE_LIBZSTD
 	h->zstd_dctx = NULL;
+	h->zstd_cctx = NULL;
 #endif
 
 	h->owner = CurrentResourceOwner;
@@ -247,6 +250,11 @@ destroy_curlhandle(curlhandle_t *h)
 	{
 		ZSTD_freeDCtx(h->zstd_dctx);
 		h->zstd_dctx = NULL;
+	}
+	if (h->zstd_cctx) 
+	{
+		ZSTD_freeCCtx(h->zstd_cctx);
+		h->zstd_cctx = NULL;
 	}
 #endif
 	pfree(h);
@@ -397,7 +405,15 @@ header_callback(void *ptr_, size_t size, size_t nmemb, void *userp)
 			buf[i] = 0;
 #ifdef HAVE_LIBZSTD
 			url->zstd = strtol(buf, 0, 0);
-			if (!url->for_write && url->zstd)
+
+			if (url->for_write && url->zstd)
+			{	
+				url->curl->zstd_cctx = ZSTD_createCCtx();
+				// allocate out.cptr whose size equals to out.ptr
+				url->out.cptr = (char *) palloc(writable_external_table_bufsize * 1024);
+				url->lastsize = 0;
+			}
+			else if (url->zstd)
 			{
 				url->curl->zstd_dctx = ZSTD_createDCtx();
 				url->lastsize = ZSTD_initDStream(url->curl->zstd_dctx);
@@ -1292,6 +1308,9 @@ url_curl_fopen(char *url, bool forwrite, extvar_t *ev, CopyState pstate)
 	set_httpheader(file, "X-GP-SEGMENT-COUNT", ev->GP_SEGMENT_COUNT);
 	set_httpheader(file, "X-GP-LINE-DELIM-STR", ev->GP_LINE_DELIM_STR);
 	set_httpheader(file, "X-GP-LINE-DELIM-LENGTH", ev->GP_LINE_DELIM_LENGTH);
+#ifdef HAVE_LIBZSTD
+		set_httpheader(file, "X-GP-ZSTD", "1");
+#endif
 
 	if (forwrite)
 	{
@@ -1312,9 +1331,6 @@ url_curl_fopen(char *url, bool forwrite, extvar_t *ev, CopyState pstate)
 	{
 		/* read specific - (TODO: unclear why some of these are needed) */
 		set_httpheader(file, "X-GP-PROTO", "1");
-#ifdef HAVE_LIBZSTD
-		set_httpheader(file, "X-GP-ZSTD", "1");
-#endif
 		set_httpheader(file, "X-GP-MASTER_HOST", ev->GP_MASTER_HOST);
 		set_httpheader(file, "X-GP-MASTER_PORT", ev->GP_MASTER_PORT);
 		set_httpheader(file, "X-GP-CSVOPT", ev->GP_CSVOPT);
@@ -1519,6 +1535,13 @@ url_curl_fclose(URL_FILE *fileg, bool failOnError, const char *relname)
 		file->out.ptr = NULL;
 	}
 
+	if (file->out.cptr)
+	{
+		Assert(file->for_write);
+		pfree(file->out.cptr);
+		file->out.cptr = NULL;
+	}
+
 	file->gp_proto = 0;
 	file->error = file->eof = 0;
 	memset(&file->in, 0, sizeof(file->in));
@@ -1596,6 +1619,12 @@ decompress_zstd_data(ZSTD_DCtx* ctx, ZSTD_inBuffer* bin, ZSTD_outBuffer* bout)
 				errmsg("ZSTD_decompressStream failed, error is %s", ZSTD_getErrorName(ret))));
 	}
 	return ret;
+}
+
+static int
+compress_zstd_data(URL_CURL_FILE *file)
+{
+	return ZSTD_compressCCtx(file->curl->zstd_cctx, file->out.cptr, file->out.top, file->out.ptr, file->out.top, file->zstd);
 }
 #endif
 
@@ -1854,6 +1883,7 @@ gp_proto1_read(char *buf, int bufsz, URL_CURL_FILE *file, CopyState pstate, char
 
 	return n;
 }
+
 /*
  * gp_proto0_write
  *
@@ -1862,9 +1892,20 @@ gp_proto1_read(char *buf, int bufsz, URL_CURL_FILE *file, CopyState pstate, char
  */
 static void
 gp_proto0_write(URL_CURL_FILE *file, CopyState pstate)
-{
-	char*		buf = file->out.ptr;
-	int		nbytes = file->out.top;
+{	
+	char*		buf;
+	int		nbytes;
+#ifdef HAVE_LIBZSTD
+	if(file->zstd){
+		nbytes = compress_zstd_data(file);
+		buf = file->out.cptr;
+	}
+	else
+#endif
+	{
+		buf = file->out.ptr;
+	 	nbytes = file->out.top;
+	}
 
 	if (nbytes == 0)
 		return;
@@ -1961,11 +2002,18 @@ curl_fwrite(char *buf, int nbytes, URL_CURL_FILE *file, CopyState pstate)
 			char*	newbuf;
 
 			newbuf = repalloc(file->out.ptr, n);
-
 			if (!newbuf)
 				elog(ERROR, "out of memory (curl_fwrite)");
-
 			file->out.ptr = newbuf;
+			
+			if (file->zstd) 
+			{
+				newbuf = repalloc(file->out.cptr, n);
+				if (!newbuf)
+					elog(ERROR, "out of compress memory (curl_fwrite)");
+				file->out.cptr = newbuf;
+			}
+
 			file->out.max = n;
 
 			Assert(nbytes < file->out.max);

--- a/src/backend/access/external/url_curl.c
+++ b/src/backend/access/external/url_curl.c
@@ -30,6 +30,10 @@
 #include "utils/guc.h"
 #include "utils/resowner.h"
 #include "utils/uri.h"
+#ifdef HAVE_LIBZSTD
+#include <zstd.h>
+#include <zstd_errors.h>
+#endif
 
 /*
  * This struct encapsulates the libcurl resources that need to be explicitly
@@ -40,7 +44,10 @@
  */
 typedef struct curlhandle_t
 {
-	CURL	   *handle;		/* The curl handle */
+	CURL			*handle;		/* The curl handle */
+#ifdef HAVE_LIBZSTD
+	ZSTD_DCtx		*zstd_dctx;		/* The zstd context */
+#endif
 	struct curl_slist *x_httpheader;	/* list of headers */
 	bool		in_multi_handle;	/* T, if the handle is in global
 									 * multi_handle */
@@ -88,8 +95,11 @@ typedef struct
 	int			error,
 				eof;			/* error & eof flags */
 	int			gp_proto;
-	char	   *http_response;
-
+	
+	int 			zstd;			/* if gpfdist zstd compress is enabled, it equals 1 */
+	int 			lastsize;		/* Recording the compressed data size */
+	
+	char	   		*http_response;
 	struct
 	{
 		int			datalen;	/* remaining datablock length */
@@ -185,6 +195,10 @@ create_curlhandle(void)
 	h->x_httpheader = NULL;
 	h->in_multi_handle = false;
 
+#ifdef HAVE_LIBZSTD
+	h->zstd_dctx = NULL;
+#endif
+
 	h->owner = CurrentResourceOwner;
 	h->prev = NULL;
 	h->next = open_curl_handles;
@@ -228,7 +242,13 @@ destroy_curlhandle(curlhandle_t *h)
 		curl_easy_cleanup(h->handle);
 		h->handle = NULL;
 	}
-
+#ifdef HAVE_LIBZSTD
+	if (h->zstd_dctx) 
+	{
+		ZSTD_freeDCtx(h->zstd_dctx);
+		h->zstd_dctx = NULL;
+	}
+#endif
 	pfree(h);
 }
 
@@ -284,6 +304,8 @@ header_callback(void *ptr_, size_t size, size_t nmemb, void *userp)
 	int 		i;
 	char 		buf[20];
 
+	int proto_len = strlen("X-GP-PROTO"), zstd_len = strlen("X-GP-ZSTD");
+
 	Assert(size == 1);
 
 	/*
@@ -317,10 +339,10 @@ header_callback(void *ptr_, size_t size, size_t nmemb, void *userp)
 	/*
 	 * extract the GP-PROTO value from the HTTP header.
 	 */
-	if (len > 10 && *ptr == 'X' && 0 == strncmp("X-GP-PROTO", ptr, 10))
+	if (len > proto_len && 0 == strncmp("X-GP-PROTO", ptr, proto_len))
 	{
-		ptr += 10;
-		len -= 10;
+		ptr += proto_len;
+		len -= proto_len;
 
 		while (len > 0 && (*ptr == ' ' || *ptr == '\t'))
 		{
@@ -344,6 +366,43 @@ header_callback(void *ptr_, size_t size, size_t nmemb, void *userp)
 
 			buf[i] = 0;
 			url->gp_proto = strtol(buf, 0, 0);
+		}
+	}
+
+	if (len > zstd_len && 0 == strncmp("X-GP-ZSTD", ptr, zstd_len))
+	{
+		ptr += zstd_len;
+		len -= zstd_len;
+
+		while (len > 0 && (*ptr == ' ' || *ptr == '\t'))
+		{
+			ptr++;
+			len--;
+		}
+
+		if (len > 0 && *ptr == ':')
+		{
+			ptr++;
+			len--;
+
+			while (len > 0 && (*ptr == ' ' || *ptr == '\t'))
+			{
+				ptr++;
+				len--;
+			}
+
+			for (i = 0; i < sizeof(buf) - 1 && i < len; i++)
+				buf[i] = ptr[i];
+
+			buf[i] = 0;
+#ifdef HAVE_LIBZSTD
+			url->zstd = strtol(buf, 0, 0);
+			if (!url->for_write && url->zstd)
+			{
+				url->curl->zstd_dctx = ZSTD_createDCtx();
+				url->lastsize = ZSTD_initDStream(url->curl->zstd_dctx);
+			}
+#endif
 		}
 	}
 
@@ -1253,6 +1312,9 @@ url_curl_fopen(char *url, bool forwrite, extvar_t *ev, CopyState pstate)
 	{
 		/* read specific - (TODO: unclear why some of these are needed) */
 		set_httpheader(file, "X-GP-PROTO", "1");
+#ifdef HAVE_LIBZSTD
+		set_httpheader(file, "X-GP-ZSTD", "1");
+#endif
 		set_httpheader(file, "X-GP-MASTER_HOST", ev->GP_MASTER_HOST);
 		set_httpheader(file, "X-GP-MASTER_PORT", ev->GP_MASTER_PORT);
 		set_httpheader(file, "X-GP-CSVOPT", ev->GP_CSVOPT);
@@ -1514,6 +1576,29 @@ gp_proto0_read(char *buf, int bufsz, URL_CURL_FILE *file)
 	return n;
 }
 
+#ifdef HAVE_LIBZSTD
+int 
+decompress_zstd_data(ZSTD_DCtx* ctx, ZSTD_inBuffer* bin, ZSTD_outBuffer* bout)
+{
+	
+	size_t ret;
+	/* Ret indicates the number of bytes of next data frame to be decompressed.
+	 * And if an error occur in ZSTD_decompressStream, ret will be a error number.
+	 * If ZSTD_isError is true, the ret is a error number.
+	 * The content of the error can be got by ZSTD_getErrorName..
+	 */
+	ret = ZSTD_decompressStream(ctx, bout, bin);
+
+	if (ZSTD_isError(ret))
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_CONNECTION_FAILURE),
+				errmsg("ZSTD_decompressStream failed, error is %s", ZSTD_getErrorName(ret))));
+	}
+	return ret;
+}
+#endif
+
 /*
  * gp_proto1_read
  *
@@ -1527,7 +1612,8 @@ static size_t
 gp_proto1_read(char *buf, int bufsz, URL_CURL_FILE *file, CopyState pstate, char *buf2)
 {
 	char type;
-	int  n, len;
+	int  n = 0, len = 0;
+	int obufsz = bufsz;
 
 	/*
 	 * Loop through and get all types of messages, until we get actual data,
@@ -1674,11 +1760,41 @@ gp_proto1_read(char *buf, int bufsz, URL_CURL_FILE *file, CopyState pstate, char
 		elog(ERROR, "gpfdist error: unknown meta type %d", type);
 	}
 
-	/* read data block */
-	if (bufsz > file->block.datalen)
-		bufsz = file->block.datalen;
+	int left_bytes = file->in.top - file->in.bot;
 
-	fill_buffer(file, bufsz);
+	if (file->zstd)
+	{
+		/* 'lastsize' is the number of bytes required for next decompression.
+		 * 'left_bytes' is the number of bytes remained in 'file->in.ptr'.
+		 * If left_bytes is less than 'lastsize', the next decompression
+		 * can't complete in a decompression operation. Thus, when 
+		 * 'file->lastsize > left_bytes', we need more bytes and fill_buffer is called.
+		 * 
+		 * When the condition 'file->block.datalen == len' is met, a new
+		 * request just start. In this case lastsize is an init value, and 
+		 * cannot provide the information about how many bytes required
+		 * to finish the first frame decompression. In this case, enough
+		 * bytes(more than ZSTD_DStreamInSize() returning) should be filled
+		 * into 'file->in.ptr' to ensure that the first decompression 
+		 * completing.
+		 */
+		if (file->lastsize > left_bytes || file->block.datalen == len)
+		{
+#ifdef HAVE_LIBZSTD
+			bufsz = ZSTD_DStreamInSize() - left_bytes;
+			fill_buffer(file, bufsz);
+#endif
+		}
+	} 
+	else 
+	{
+		/* read data block */
+		if (bufsz > file->block.datalen)
+			bufsz = file->block.datalen;
+
+		fill_buffer(file, bufsz);
+	}
+
 	n = file->in.top - file->in.bot;
 
 	/* if gpfdist closed connection prematurely or died catch it here */
@@ -1698,13 +1814,46 @@ gp_proto1_read(char *buf, int bufsz, URL_CURL_FILE *file, CopyState pstate, char
 	if (n > bufsz)
 		n = bufsz;
 
+#ifdef HAVE_LIBZSTD
+	if (file->zstd && file->curl->zstd_dctx && !file->eof)
+	{
+		int ret;
+		/* It is absolutely to put the decompression code in a loop.
+		 * Since not every call of decompress_zstd_data will get data into bout.
+		 * However, even thought there is no data in bout, the call of 
+		 * decompress_zstd_data is neccersary for following decompression.
+		 * If a empty buf is returned to gpdb, the error will occur. 
+		 * So the loop ensures that we push forward the decompression until there 
+		 * is data in bout.
+		 */
+		do
+		{
+			ZSTD_inBuffer bin = {file->in.ptr + file->in.bot, file->lastsize, 0};
+			ZSTD_outBuffer bout = {buf, obufsz, 0};
+			ret = decompress_zstd_data(file->curl->zstd_dctx, &bin, &bout);
+			n = bout.pos; 
+			file->in.bot += bin.pos;
+			file->lastsize = ret;
+			if (!ret)
+			{
+				file->lastsize = ZSTD_initDStream(file->curl->zstd_dctx);
+				break;
+			}		
+		} while (n == 0);
+	}
+	else
+	{
+		memcpy(buf, file->in.ptr + file->in.bot, n);
+		file->in.bot += n;
+	}
+#else
 	memcpy(buf, file->in.ptr + file->in.bot, n);
-
 	file->in.bot += n;
+#endif
 	file->block.datalen -= n;
+
 	return n;
 }
-
 /*
  * gp_proto0_write
  *
@@ -1856,7 +2005,6 @@ url_curl_fflush(URL_FILE *file, CopyState pstate)
 {
 	gp_proto0_write((URL_CURL_FILE *) file, pstate);
 }
-
 #else /* USE_CURL */
 
 

--- a/src/bin/gpfdist/gpfdist.c
+++ b/src/bin/gpfdist/gpfdist.c
@@ -166,7 +166,6 @@ static void percent_encoding_to_char(char* p, char* pp, char* path);
 #define GPFDIST_MAX_LINE_MESSAGE     "Error: -m max row length must be between 32KB and 1MB"
 #endif
 
-
 /*	Struct of command line options */
 static struct
 {
@@ -190,7 +189,6 @@ static struct
 	int			w; /* The time used for session timeout in seconds */
 	int			compress; /* The flag to indicate whether comopression transmission is open */
 } opt = { 8080, 8080, 0, 0, 0, ".", 0, 0, -1, 5, 0, 32768, 0, 256, 0, 0, 0, 0, 0};
-
 
 typedef union address
 {
@@ -323,8 +321,6 @@ struct request_t
 	SSL			*ssl;
 #endif
 };
-
-
 
 #if APR_IS_BIGENDIAN
 #define local_htonll(n)  (n)
@@ -527,8 +523,6 @@ static unsigned short get_client_port(address_t *clientInformation)
 		return ipv6->sin6_port;
 	}
 }
-
-
 
 /* Print usage */
 static void usage_error(const char* msg, int print_usage)
@@ -934,7 +928,6 @@ static void http_continue(request_t* r)
 	local_send(r, buf, sizeof buf -1);
 }
 
-
 /* send an OK response */
 static apr_status_t http_ok(request_t* r)
 {
@@ -1058,7 +1051,6 @@ static void log_gpfdist_status()
 	}
 	printf("]\r\n");
 
-
 	gprint(NULL, "---------------------------------------\n");
 }
 
@@ -1132,7 +1124,6 @@ static apr_status_t send_gpfdist_status(request_t* r)
 										gcb.total_bytes,
 #endif
 										gcb.total_sessions);
-
 
 	if (n >= sizeof buf - 1)
 		gfatal(r, "internal error - buffer overflow during send_gpfdist_status");
@@ -1593,7 +1584,6 @@ static int session_attach(request_t* r)
 		request_end(r, 1, 0);
 		return -1;
 	}
-
 
 	/* check if such session already exists in hashtable */
 	session = apr_hash_get(gcb.session.tab, key, APR_HASH_KEY_STRING);
@@ -2158,7 +2148,6 @@ static void do_read_request(int fd, short event, void* arg)
 	}
 }
 
-
 /* Callback when the listen socket is ready to accept connections. */
 static void do_accept(int fd, short event, void* arg)
 {
@@ -2297,7 +2286,6 @@ static void do_accept(int fd, short event, void* arg)
 		r->peer = apr_psprintf(r->pool, "%s", host);
 	}
 
-
 	/* set up for callback when socket ready for reading the http request */
 	if (setup_read(r))
 	{
@@ -2326,7 +2314,6 @@ static int setup_write(request_t* r)
 	event_set(&r->ev, r->sock, EV_WRITE, do_write, r);
 	return (event_add(&r->ev, 0));
 }
-
 
 /*
  * setup_read
@@ -2439,7 +2426,6 @@ addrinfo* rearrange_addrs(struct addrinfo *head, int first_family)
 	return new_head;
 }
 
-
 static void
 print_addrinfo_list(struct addrinfo *head)
 {
@@ -2520,7 +2506,6 @@ http_setup(void)
 	/* setup event priority */
 	if (event_priority_init(10))
 		gwarning(NULL, "event_priority_init failed");
-
 
 	/* Try each possible port from opt.p to opt.last_port */
 	for (;;)
@@ -2729,7 +2714,6 @@ process_term_signal(int sig,short event,void* arg)
 			}
 		_exit(1);
 }
-
 
 static gnet_request_t*
 gnet_parse_request(const char* buf, int* len, apr_pool_t* pool)
@@ -2965,7 +2949,6 @@ void gdebug(const request_t *r, const char *fmt, ...)
 	va_end(args);
 	printf("\n");
 }
-
 
 void gfile_printf_then_putc_newline(const char *format, ...)
 {
@@ -3215,7 +3198,6 @@ static void handle_post_request(request_t *r, int header_end)
 		memcpy(r->in.dbuf, data_start, data_bytes_in_req);
 		r->in.dbuftop += data_bytes_in_req;
 
-
 		r->in.davailable -= data_bytes_in_req;
 
 		/* only write it out if no more data is expected */
@@ -3370,7 +3352,6 @@ static int request_set_path(request_t *r, const char* d, char* p, char* pp, char
 		path = p;
 
 	} while (path);
-
 
 	if (!r->path)
 	{
@@ -3626,7 +3607,6 @@ static int request_parse_gp_headers(request_t *r, int opt_g)
 
 	return 0;
 }
-
 
 #ifdef GPFXDIST
 static int request_set_transform(request_t *r)
@@ -3895,9 +3875,7 @@ int main(int argc, const char* const argv[])
 	return gpfdist_run();
 }
 
-
 #else   /* in Windows gpfdist may run as a Windows service or a console application  */
-
 
 SERVICE_STATUS          ServiceStatus;
 SERVICE_STATUS_HANDLE   hStatus;
@@ -3910,7 +3888,6 @@ int cmd_line_args;
 
 void  ServiceMain(int argc, char** argv);
 void  ControlHandler(DWORD request);
-
 
 /* gpfdist service registration on the WINDOWS command line
  * sc create gpfdist binpath= "c:\temp\gpfdist.exe param1 param2 param3"
@@ -3995,7 +3972,6 @@ void init_cmd_buffer(int argc, const char* const argv[])
 		report_event(TEXT("msg"));
 	}
 
-
 	for (i = 0; i < cmd_line_args; i++)
 	{
 		int len;
@@ -4068,7 +4044,6 @@ int main(int argc, const char* const argv[])
 			gfatal(NULL, "Initialization failed");
 		main_ret = gpfdist_run();
 	}
-
 
 	return main_ret;
 }
@@ -4285,7 +4260,6 @@ static SSL_CTX *initialize_ctx(void)
 }
 #endif
 
-
 /*
  * gpfdist_socket_send
  *
@@ -4345,7 +4319,6 @@ static int gpfdist_SSL_send(const request_t *r, const void *buf, const size_t bu
 }
 #endif
 
-
 /*
  * gpfdist_socket_receive
  *
@@ -4404,7 +4377,6 @@ static void free_SSL_resources(const request_t *r)
 	SSL_free(r->ssl);
 }
 
-
 /*
  * handle_ssl_error
  *
@@ -4449,7 +4421,6 @@ static void flush_ssl_buffer(int fd, short event, void* arg)
 	}
 }
 
-
 /*
  * setup_flush_ssl_buffer
  *
@@ -4464,7 +4435,6 @@ static void setup_flush_ssl_buffer(request_t* r)
 	(void)event_add(&r->ev, &r->tm);
 }
 #endif
-
 
 /*
  * log unsent/unacked bytes in socket buffer.
@@ -4580,7 +4550,6 @@ static void setup_do_close(request_t* r)
 	}
 }
 
-
 #ifdef USE_SSL
 /*
  * request_cleanup_and_free_SSL_resources
@@ -4597,7 +4566,6 @@ static void request_cleanup_and_free_SSL_resources(request_t *r)
 	free_SSL_resources(r);
 }
 #endif
-
 
 /*
  * free_session_cb
@@ -4750,7 +4718,7 @@ static int decompress_data(request_t* r, zstd_buffer *in, zstd_buffer *out){
 	ZSTD_outBuffer obuf = {out->buf, out->size, out->pos};
 	
 	if(!r->zstd_dctx) {
-		gwarning(stderr, "%s", "Out of memory when ZSTD_createDCtx");
+		gwarning(r, "%s", "Out of memory when ZSTD_createDCtx");
 		return -1;
 	}
 
@@ -4776,7 +4744,7 @@ static int decompress_data(request_t* r, zstd_buffer *in, zstd_buffer *out){
  * It is for compress data in buffer. Return is the length of data after compression.
  */
 
-static int compress_zstd(request_t *r, block_t *blk, int buflen)
+static int compress_zstd(const request_t *r, block_t *blk, int buflen)
 {
 	char *buf = blk->data;
 	int offset = 0;
@@ -4785,7 +4753,7 @@ static int compress_zstd(request_t *r, block_t *blk, int buflen)
 	if (!r->zstd_cctx)
 	{
 		snprintf(r->zstd_error, r->zstd_err_len, "Creating compression context failed, out of memory.");
-		gprintln(NULL, r->zstd_error);
+		gprintln(NULL, "%s", r->zstd_error);
 		return -1;
 	}
 
@@ -4793,7 +4761,7 @@ static int compress_zstd(request_t *r, block_t *blk, int buflen)
 	if (ZSTD_isError(init_result)) 
 	{
 		snprintf(r->zstd_error, r->zstd_err_len, "Creating compression context initialization failed, error is %s.", ZSTD_getErrorName(init_result));
-		gprintln(NULL, r->zstd_error);
+		gprintln(NULL, "%s", r->zstd_error);
 		return -1;
 	}
 
@@ -4808,7 +4776,7 @@ static int compress_zstd(request_t *r, block_t *blk, int buflen)
 			if (ZSTD_isError(res))
 			{
 				snprintf(r->zstd_error, r->zstd_err_len, "Compression failed, error is %s.", ZSTD_getErrorName(res));
-				gprintln(NULL, r->zstd_error);
+				gprintln(NULL, "%s", r->zstd_error);
 				return -1;
 			}
 			offset += bout.pos;
@@ -4822,7 +4790,7 @@ static int compress_zstd(request_t *r, block_t *blk, int buflen)
 	if (remainingToFlush)
 	{
 		snprintf(r->zstd_error, r->zstd_err_len, "Compression failed, error is not fully flushed.");
-		gprintln(NULL, r->zstd_error);
+		gprintln(NULL, "%s", r->zstd_error);
 		return -1;
 	}
 	offset += output.pos;

--- a/src/bin/gpfdist/gpfdist.c
+++ b/src/bin/gpfdist/gpfdist.c
@@ -86,6 +86,14 @@ struct block_t
 	char*		cdata;
 };
 
+typedef struct zstd_buffer zstd_buffer;
+struct zstd_buffer
+{
+	char	*buf;
+	int		size;
+	int		pos;	
+};
+
 /*  Get session id for this request */
 #define GET_SID(r)	((r->sid))
 
@@ -290,17 +298,23 @@ struct request_t
 		char*	dbuf;		/* buffer for raw data from a POST request */
 		int 	dbuftop; 	/* # bytes used in dbuf */
 		int 	dbufmax; 	/* size of dbuf[] */
+
+		char*  	wbuf;		/* data buf for decompressed data for writing into file,
+					         	its capacity equals to MAX_FRAME_SIZE. */
+		int 	wbuftop;	/* last index for decompressed data */
+		int 	woffset;		/* mark whether there is left data in compress ctx */
 	} in;
 
 	block_t	outblock;	/* next block to send out */
 	char*           line_delim_str;
 	int             line_delim_length;
 #ifdef HAVE_LIBZSTD
-	ZSTD_CCtx*		zstd_cctx;	/* zstd context */
+	ZSTD_CCtx*		zstd_cctx;	/* zstd compression context */
+	ZSTD_DCtx*		zstd_dctx;	/* zstd decompression context */
 #endif	
-	int				zstd;		/* request use zstd compress */
-	int				zstd_err_len; 	/* space allocate for zstd_error string */
-	char*				zstd_error;	/* string contains zstd error*/
+	int		zstd;			/* request use zstd compress */
+	int		zstd_err_len;	/* space allocate for zstd_error string */
+	char*		zstd_error;	/* string contains zstd error*/
 #ifdef USE_SSL
 	/* SSL related */
 	BIO			*io;		/* for the i.o. */
@@ -362,7 +376,10 @@ static int request_validate(request_t *r);
 static int request_set_path(request_t *r, const char* d, char* p, char* pp, char* path);
 static int request_path_validate(request_t *r, const char* path);
 #ifdef HAVE_LIBZSTD
-static int compress_zstd(request_t *r, block_t *blk, int buflen);
+static int compress_zstd(const request_t *r, block_t* block, int buflen);
+static int decompress_data(request_t *r, zstd_buffer *in, zstd_buffer *out);
+static int decompress_zstd(request_t* r, ZSTD_inBuffer* bin, ZSTD_outBuffer* bout);
+static int decompress_write_loop(request_t *r);
 #endif
 static int request_parse_gp_headers(request_t *r, int opt_g);
 static void free_session_cb(int fd, short event, void* arg);
@@ -3040,6 +3057,47 @@ static void handle_get_request(request_t *r)
 	}
 }
 
+static
+int check_output_to_file(request_t *r, int wrote)
+{
+	session_t *session = r->session;
+	char *buf;
+	int *buftop;
+	if (r->zstd) 
+	{
+		buf = r->in.wbuf;
+		buftop = &r->in.wbuftop;
+	}
+	else
+	{
+		buf = r->in.dbuf;
+		buftop = &r->in.dbuftop;
+	}
+
+	if (wrote == -1)
+	{
+		/* write error */
+		gwarning(r, "handle_post_request, write error: %s", fstream_get_error(session->fstream));
+		http_error(r, FDIST_INTERNAL_ERROR, fstream_get_error(session->fstream));
+		request_end(r, 1, 0);
+		return -1;
+	}
+	else if(wrote == *buftop)
+	{
+		/* wrote the whole buffer. clean it for next round */
+		*buftop = 0;
+	}
+	else
+	{
+		/* wrote up to last line, some data left over in buffer. move to front */
+		int bytes_left_over = *buftop - wrote;
+
+		memmove(buf, buf + wrote, bytes_left_over);
+		*buftop = bytes_left_over;
+	}	
+	return 0;
+}
+
 static void handle_post_request(request_t *r, int header_end)
 {
 	int h_count = r->in.req->hc;
@@ -3136,7 +3194,10 @@ static void handle_post_request(request_t *r, int header_end)
 	/* create a buffer to hold the incoming raw data */
 	r->in.dbufmax = opt.m; /* size of max line size */
 	r->in.dbuftop = 0;
+	r->in.wbuftop = 0;
 	r->in.dbuf = palloc_safe(r, r->pool, r->in.dbufmax, "out of memory when allocating r->in.dbuf: %d bytes", r->in.dbufmax);
+	if(r->zstd)  
+		r->in.wbuf = palloc_safe(r, r->pool, MAX_FRAME_SIZE, "out of memory when allocating r->in.wbuf: %d bytes", MAX_FRAME_SIZE);
 
 	/* if some data come along with the request, copy it first */
 	data_start = strstr(r->in.hbuf, "\r\n\r\n");
@@ -3150,21 +3211,35 @@ static void handle_post_request(request_t *r, int header_end)
 	{
 		/* we have data after the request headers. consume it */
 		/* should make sure r->in.dbuftop + data_bytes_in_req <  r->in.dbufmax */
+		
 		memcpy(r->in.dbuf, data_start, data_bytes_in_req);
 		r->in.dbuftop += data_bytes_in_req;
+
+
 		r->in.davailable -= data_bytes_in_req;
 
 		/* only write it out if no more data is expected */
 		if(r->in.davailable == 0)
 		{
-			wrote = fstream_write(session->fstream, r->in.dbuf, data_bytes_in_req, 1, r->line_delim_str, r->line_delim_length);
-			delay_watchdog_timer();
-			if(wrote == -1)
+#ifdef HAVE_LIBZSTD
+			if(r->zstd)
 			{
-				/* write error */
-				http_error(r, FDIST_INTERNAL_ERROR, fstream_get_error(session->fstream));
-				request_end(r, 1, 0);
-				return;
+				wrote = decompress_write_loop(r);
+				if (wrote == -1)
+					return;
+			}
+			else
+#endif
+			{
+				wrote = fstream_write(session->fstream, r->in.dbuf, data_bytes_in_req, 1, r->line_delim_str, r->line_delim_length);
+				delay_watchdog_timer();
+				if (wrote == -1)
+				{
+					/* write error */
+					http_error(r, FDIST_INTERNAL_ERROR, fstream_get_error(session->fstream));
+					request_end(r, 1, 0);
+					return;
+				}
 			}
 		}
 	}
@@ -3176,7 +3251,7 @@ static void handle_post_request(request_t *r, int header_end)
 	while(r->in.davailable > 0)
 	{
 		size_t want;
-		ssize_t n;
+		ssize_t n = 0;
 		size_t buf_space_left = r->in.dbufmax - r->in.dbuftop;
 
 		if (r->in.davailable > buf_space_left)
@@ -3220,36 +3295,33 @@ static void handle_post_request(request_t *r, int header_end)
 			r->in.davailable -= n;
 			r->in.dbuftop += n;
 
+			/* success is a flag to check whether data is written into file successfully.
+			 * There is no need to do anything when success is less than 0, since all
+			 * error handling has been done in 'check_output_to_file' function.
+			 */
+			int success = 0;
+
 			/* if filled our buffer or no more data expected, write it */
 			if (r->in.dbufmax == r->in.dbuftop || r->in.davailable == 0)
 			{
+#ifdef HAVE_LIBZSTD
 				/* only write up to end of last row */
-				wrote = fstream_write(session->fstream, r->in.dbuf, r->in.dbuftop, 1, r->line_delim_str, r->line_delim_length);
-				gdebug(r, "wrote %d bytes to file", wrote);
-				delay_watchdog_timer();
-
-				if (wrote == -1)
+				if(r->zstd) 
 				{
-					/* write error */
-					gwarning(r, "handle_post_request, write error: %s", fstream_get_error(session->fstream));
-					http_error(r, FDIST_INTERNAL_ERROR, fstream_get_error(session->fstream));
-					request_end(r, 1, 0);
-					return;
-				}
-				else if(wrote == r->in.dbuftop)
-				{
-					/* wrote the whole buffer. clean it for next round */
-					r->in.dbuftop = 0;
+					success = decompress_write_loop(r);
 				}
 				else
+#endif
 				{
-					/* wrote up to last line, some data left over in buffer. move to front */
-					int bytes_left_over = r->in.dbuftop - wrote;
+					wrote = fstream_write(session->fstream, r->in.dbuf, r->in.dbuftop, 1, r->line_delim_str, r->line_delim_length);
+					gdebug(r, "wrote %d bytes to file", wrote);
+					delay_watchdog_timer();
 
-					memmove(r->in.dbuf, r->in.dbuf + wrote, bytes_left_over);
-					r->in.dbuftop = bytes_left_over;
+					success = check_output_to_file(r, wrote);
 				}
 			}
+			if (success < 0)
+				return;
 		}
 
 	}
@@ -3486,6 +3558,9 @@ static int request_parse_gp_headers(request_t *r, int opt_g)
 #ifdef HAVE_LIBZSTD
 	if (r->zstd)
 	{
+		if (!r->is_get)
+			r->zstd_dctx = ZSTD_createDCtx();
+
 		OUT_BUFFER_SIZE = ZSTD_CStreamOutSize();
 		r->zstd_err_len = 1024;
 		r->outblock.cdata = palloc_safe(r, r->pool, opt.m, "out of memory when allocating buffer for compressed data: %d bytes", opt.m);
@@ -4485,6 +4560,10 @@ static void request_cleanup(request_t *r)
 	{
 		ZSTD_freeCCtx(r->zstd_cctx);
 	}
+	if ( r->zstd && !r->is_get )
+	{
+		ZSTD_freeDCtx(r->zstd_dctx);
+	}
 #endif
 }
 
@@ -4594,6 +4673,7 @@ static void delay_watchdog_timer()
 		shutdown_time = apr_time_now() + gcb.wdtimer * APR_USEC_PER_SEC;
 	}
 }
+
 #else
 static void delay_watchdog_timer()
 {
@@ -4601,6 +4681,96 @@ static void delay_watchdog_timer()
 #endif
 
 #ifdef HAVE_LIBZSTD
+
+/* decompress the data and write data to the file.
+ * Finally, the function will check the write result,
+ * and change the related value about data buffer. 
+ */
+static 
+int decompress_write_loop(request_t *r)
+{
+	session_t *session = r->session;
+	int wrote_total = 0;
+	do
+	{
+		int offset = 0;
+		if (r->in.woffset)
+			offset = r->in.woffset;
+
+		zstd_buffer in = {r->in.dbuf, r->in.dbuftop, offset};
+		zstd_buffer out = {r->in.wbuf + r->in.wbuftop, MAX_FRAME_SIZE - r->in.wbuftop, 0};
+
+		int res = decompress_data(r, &in, &out);
+
+		if (res < 0) 
+		{
+			http_error(r, FDIST_INTERNAL_ERROR, r->zstd_error);
+			request_end(r, 1, 0);
+			return res;
+		}
+
+		int wrote = fstream_write(session->fstream, r->in.wbuf, r->in.wbuftop, 0, r->line_delim_str, r->line_delim_length);
+		wrote_total += wrote;
+		gdebug(r, "wrote %d bytes to file", wrote);
+		delay_watchdog_timer();
+
+		res = check_output_to_file(r, wrote);
+		if (res < 0)
+		{
+			return -1;
+		}
+
+	} while(r->in.woffset);
+	return wrote_total;
+}
+
+static int decompress_zstd(request_t* r, ZSTD_inBuffer* bin, ZSTD_outBuffer* bout)
+{	
+	int ret;
+	/* The return code is zero if the frame is complete, but there may
+		* be multiple frames concatenated together. Zstd will automatically
+		* reset the context when a frame is complete. Still, calling
+		* ZSTD_DCtx_reset() can be useful to reset the context to a clean
+		* state, for instance if the last decompression call returned an
+		* error.
+		*/
+		 
+	ret = ZSTD_decompressStream(r->zstd_dctx, bout, bin);
+	size_t const err = ret;                          
+	if(ZSTD_isError(err)){
+		snprintf(r->zstd_error, r->zstd_err_len, "zstd decompression error, error is %s", ZSTD_getErrorName(err));
+		gwarning(NULL, "%s", r->zstd_error);
+		return -1;
+	}
+	return bout->pos;
+}
+
+static int decompress_data(request_t* r, zstd_buffer *in, zstd_buffer *out){
+	ZSTD_inBuffer inbuf = {in->buf , in->size, in->pos};
+	ZSTD_outBuffer obuf = {out->buf, out->size, out->pos};
+	
+	if(!r->zstd_dctx) {
+		gwarning(stderr, "%s", "Out of memory when ZSTD_createDCtx");
+		return -1;
+	}
+
+	int outSize = decompress_zstd(r, &inbuf, &obuf);
+	if(outSize < 0){
+		return outSize;
+	}
+
+	r->in.wbuftop += outSize;
+	if (inbuf.pos == inbuf.size) 
+	{
+		r->in.woffset = 0;
+	}
+	else
+	{
+		r->in.woffset = inbuf.pos;
+	}
+	gdebug(NULL, "decompress_zstd finished, input size = %d, output size = %d.", r->in.wbuftop, r->in.dbuftop);
+	return outSize;
+}
 /*
  * compress_zstd
  * It is for compress data in buffer. Return is the length of data after compression.
@@ -4656,6 +4826,8 @@ static int compress_zstd(request_t *r, block_t *blk, int buflen)
 		return -1;
 	}
 	offset += output.pos;
+
+	gdebug(NULL, "compress_zstd finished, input size = %d, output size = %d.", buflen, offset);
 
 	return offset;
 }

--- a/src/bin/gpfdist/gpfdist.c
+++ b/src/bin/gpfdist/gpfdist.c
@@ -54,11 +54,17 @@
 #include <pg_config.h>
 #include <pg_config_manual.h>
 #include "gpfdist_helper.h"
+#ifdef HAVE_LIBZSTD
+#include <zstd.h>
+#endif
 #ifdef USE_SSL
 #include <openssl/ssl.h>
 #include <openssl/rand.h>
 #include <openssl/err.h>
 #endif
+
+#define DEFAULT_COMPRESS_LEVEL 1
+#define MAX_FRAME_SIZE 65536
 
 /*  A data block */
 typedef struct blockhdr_t blockhdr_t;
@@ -77,6 +83,7 @@ struct block_t
 	blockhdr_t 	hdr;
 	int 		bot, top;
 	char*      	data;
+	char*		cdata;
 };
 
 /*  Get session id for this request */
@@ -84,6 +91,7 @@ struct block_t
 
 static long REQUEST_SEQ = 0;		/*  sequence number for request */
 static long SESSION_SEQ = 0;		/*  sequence number for session */
+static long OUT_BUFFER_SIZE = 0;	/* zstd out buffer size */
 
 static bool base16_decode(char* data);
 
@@ -172,7 +180,8 @@ static struct
 	struct transform* trlist; /* transforms from config file */
 	const char* ssl; /* path to certificates in case we use gpfdist with ssl */
 	int			w; /* The time used for session timeout in seconds */
-} opt = { 8080, 8080, 0, 0, 0, ".", 0, 0, -1, 5, 0, 32768, 0, 256, 0, 0, 0, 0 };
+	int			compress; /* The flag to indicate whether comopression transmission is open */
+} opt = { 8080, 8080, 0, 0, 0, ".", 0, 0, -1, 5, 0, 32768, 0, 256, 0, 0, 0, 0, 0};
 
 
 typedef union address
@@ -286,7 +295,12 @@ struct request_t
 	block_t	outblock;	/* next block to send out */
 	char*           line_delim_str;
 	int             line_delim_length;
-
+#ifdef HAVE_LIBZSTD
+	ZSTD_CCtx*		zstd_cctx;	/* zstd context */
+#endif	
+	int				zstd;		/* request use zstd compress */
+	int				zstd_err_len; 	/* space allocate for zstd_error string */
+	char*				zstd_error;	/* string contains zstd error*/
 #ifdef USE_SSL
 	/* SSL related */
 	BIO			*io;		/* for the i.o. */
@@ -347,6 +361,9 @@ static int session_active_segs_isempty(session_t* session);
 static int request_validate(request_t *r);
 static int request_set_path(request_t *r, const char* d, char* p, char* pp, char* path);
 static int request_path_validate(request_t *r, const char* path);
+#ifdef HAVE_LIBZSTD
+static int compress_zstd(request_t *r, block_t *blk, int buflen);
+#endif
 static int request_parse_gp_headers(request_t *r, int opt_g);
 static void free_session_cb(int fd, short event, void* arg);
 #ifdef GPFXDIST
@@ -385,6 +402,31 @@ static void delay_watchdog_timer(void);
 static apr_time_t shutdown_time;
 static void* watchdog_thread(void*);
 #endif
+
+static const char *EMPTY_HTTP_RES = "HTTP/1.0 200 ok\r\n"
+		"Content-type: text/plain\r\n"
+		"Content-length: 0\r\n"
+		"Expires: 0\r\n"
+		"X-GPFDIST-VERSION: " GP_VERSION "\r\n"
+		"Cache-Control: no-cache\r\n"
+		"Connection: close\r\n\r\n";
+
+static const char *HTTP_RESPONSE_ZSTD = "HTTP/1.0 200 ok\r\n"
+		"Content-type: text/plain\r\n"
+		"Expires: 0\r\n"
+		"X-GPFDIST-VERSION: " GP_VERSION "\r\n"
+		"X-GP-PROTO: %d\r\n"
+		"Cache-Control: no-cache\r\n"
+		"Connection: close\r\n"
+		"X-GP-ZSTD: %d\r\n\r\n";
+
+static const char *HTTP_RESPONSE = "HTTP/1.0 200 ok\r\n"
+		"Content-type: text/plain\r\n"
+		"Expires: 0\r\n"
+		"X-GPFDIST-VERSION: " GP_VERSION "\r\n"
+		"X-GP-PROTO: %d\r\n"
+		"Cache-Control: no-cache\r\n"
+		"Connection: close\r\n\r\n";
 
 /*
  * block_fill_header
@@ -590,6 +632,7 @@ static void parse_command_line(int argc, const char* const argv[],
 #endif
 	{ "version", 256, 0, "print version number" },
 	{ NULL, 'w', 1, "wait for session timeout in seconds" },
+	{"compress", 258, 0, "turn on compressed transmission"},
 	{ 0 } };
 
 	status = apr_getopt_init(&os, pool, argc, argv);
@@ -674,6 +717,15 @@ static void parse_command_line(int argc, const char* const argv[],
 		case 'w':
 			opt.w = atoi(arg);
 			break;
+#ifdef HAVE_LIBZSTD
+		case 258:
+			opt.compress = 1;
+			break;
+#else
+		case 258:
+			usage_error("ZSTD is not supported by this build", 0);
+			break;
+#endif
 		}
 	}
 
@@ -851,15 +903,8 @@ static void http_error(request_t* r, int code, const char* msg)
 /* send an empty response */
 static void http_empty(request_t* r)
 {
-	static const char buf[] = "HTTP/1.0 200 ok\r\n"
-		"Content-type: text/plain\r\n"
-		"Content-length: 0\r\n"
-		"Expires: 0\r\n"
-		"X-GPFDIST-VERSION: " GP_VERSION "\r\n"
-		"Cache-Control: no-cache\r\n"
-		"Connection: close\r\n\r\n";
 	gprintln(r, "HTTP EMPTY: %s %s %s - OK", r->peer, r->in.req->argv[0], r->in.req->argv[1]);
-	local_send(r, buf, sizeof buf -1);
+	local_send(r, EMPTY_HTTP_RES, strlen (EMPTY_HTTP_RES));
 }
 
 /* send a Continue response */
@@ -876,17 +921,22 @@ static void http_continue(request_t* r)
 /* send an OK response */
 static apr_status_t http_ok(request_t* r)
 {
-	const char* fmt = "HTTP/1.0 200 ok\r\n"
-		"Content-type: text/plain\r\n"
-		"Expires: 0\r\n"
-		"X-GPFDIST-VERSION: " GP_VERSION "\r\n"
-		"X-GP-PROTO: %d\r\n"
-		"Cache-Control: no-cache\r\n"
-		"Connection: close\r\n\r\n";
+
+	const char* fmt = NULL;
 	char buf[1024];
 	int m, n;
+	if (r->zstd)
+	{
+		fmt = HTTP_RESPONSE_ZSTD;
+		n = apr_snprintf(buf, sizeof(buf), fmt, r->gp_proto, r->zstd);
+	}
+	else
+	{
+		fmt = HTTP_RESPONSE;
+		n = apr_snprintf(buf, sizeof(buf), fmt, r->gp_proto);
+	}
 
-	n = apr_snprintf(buf, sizeof(buf), fmt, r->gp_proto);
+	
 	if (n >= sizeof(buf) - 1)
 		gfatal(r, "internal error - buffer overflow during http_ok");
 
@@ -1346,9 +1396,22 @@ session_get_block(const request_t* r, block_t* retblock, char* line_delim_str, i
 	}
 
 	retblock->top = size;
-
 	/* fill the block header with meta data for the client to parse and use */
 	block_fill_header(r, retblock, &fos);
+
+#ifdef HAVE_LIBZSTD
+	if (r->zstd)
+	{
+		int res = compress_zstd(r, retblock, size);
+		
+		if (res < 0)
+		{
+			return r->zstd_error;
+		}
+
+		retblock->top = res;
+	}
+#endif
 
 	return 0;
 }
@@ -1824,7 +1887,15 @@ static void do_write(int fd, short event, void* arg)
 		 * write out the block data
 		 */
 		n = datablock->top - datablock->bot;
-		n = local_send(r, datablock->data + datablock->bot, n);
+		if (r->zstd)
+		{
+			n = local_send(r, datablock->cdata + datablock->bot, n);
+		}
+		else
+		{
+			n = local_send(r, datablock->data + datablock->bot, n);
+		}
+
 		if (n < 0)
 		{
 			/*
@@ -3376,7 +3447,12 @@ static int request_parse_gp_headers(request_t *r, int opt_g)
 			r->totalsegs = atoi(r->in.req->hvalue[i]);
 		else if (0 == strcmp("X-GP-SEGMENT-ID", r->in.req->hname[i]))
 			r->segid = atoi(r->in.req->hvalue[i]);
-		else if (0 == strcmp("X-GP-LINE-DELIM-STR", r->in.req->hname[i]))
+		else if (0 == strcasecmp("X-GP-ZSTD", r->in.req->hname[i]))
+		{
+			r->zstd = atoi(r->in.req->hvalue[i]);
+			r->zstd = opt.compress ? r->zstd : 0;
+		}
+		else if (0 == strcasecmp("X-GP-LINE-DELIM-STR", r->in.req->hname[i]))
 		{
 			if (NULL == r->in.req->hvalue[i] ||  ((int)strlen(r->in.req->hvalue[i])) % 2 == 1 || !base16_decode(r->in.req->hvalue[i]))
 			{
@@ -3406,6 +3482,18 @@ static int request_parse_gp_headers(request_t *r, int opt_g)
 			}
 		}
 	}
+
+#ifdef HAVE_LIBZSTD
+	if (r->zstd)
+	{
+		OUT_BUFFER_SIZE = ZSTD_CStreamOutSize();
+		r->zstd_err_len = 1024;
+		r->outblock.cdata = palloc_safe(r, r->pool, opt.m, "out of memory when allocating buffer for compressed data: %d bytes", opt.m);
+		r->zstd_error = palloc_safe(r, r->pool, r->zstd_err_len, "out of memory when allocating error buffer for compressed data: %d bytes", r->zstd_err_len);
+		if (r->is_get)
+			r->zstd_cctx = ZSTD_createCStream();
+	}
+#endif
 
 	if (r->line_delim_length > 0)
 	{
@@ -4392,6 +4480,12 @@ static void request_cleanup(request_t *r)
 {
 	request_shutdown_sock(r);
 	setup_do_close(r);
+#ifdef HAVE_LIBZSTD
+	if ( r->zstd && r->is_get )
+	{
+		ZSTD_freeCCtx(r->zstd_cctx);
+	}
+#endif
 }
 
 static void setup_do_close(request_t* r)
@@ -4503,5 +4597,66 @@ static void delay_watchdog_timer()
 #else
 static void delay_watchdog_timer()
 {
+}
+#endif
+
+#ifdef HAVE_LIBZSTD
+/*
+ * compress_zstd
+ * It is for compress data in buffer. Return is the length of data after compression.
+ */
+
+static int compress_zstd(request_t *r, block_t *blk, int buflen)
+{
+	char *buf = blk->data;
+	int offset = 0;
+	int cursor = 0;
+
+	if (!r->zstd_cctx)
+	{
+		snprintf(r->zstd_error, r->zstd_err_len, "Creating compression context failed, out of memory.");
+		gprintln(NULL, r->zstd_error);
+		return -1;
+	}
+
+	size_t init_result = ZSTD_initCStream(r->zstd_cctx, DEFAULT_COMPRESS_LEVEL);
+	if (ZSTD_isError(init_result)) 
+	{
+		snprintf(r->zstd_error, r->zstd_err_len, "Creating compression context initialization failed, error is %s.", ZSTD_getErrorName(init_result));
+		gprintln(NULL, r->zstd_error);
+		return -1;
+	}
+
+	while(cursor < buflen){
+		int in_size = (buflen - cursor) > MAX_FRAME_SIZE ? MAX_FRAME_SIZE : (buflen - cursor);
+		ZSTD_inBuffer bin = {buf + cursor, in_size, 0};
+		int outpos = 0;
+		while(bin.pos < bin.size){
+			ZSTD_outBuffer bout = {blk->cdata + offset, OUT_BUFFER_SIZE - outpos, 0};
+			size_t res = ZSTD_compressStream(r->zstd_cctx, &bout, &bin);
+
+			if (ZSTD_isError(res))
+			{
+				snprintf(r->zstd_error, r->zstd_err_len, "Compression failed, error is %s.", ZSTD_getErrorName(res));
+				gprintln(NULL, r->zstd_error);
+				return -1;
+			}
+			offset += bout.pos;
+			outpos = bout.pos; 
+		}
+		cursor += in_size;
+	}
+
+	ZSTD_outBuffer output = { r->outblock.cdata + offset, OUT_BUFFER_SIZE, 0 };
+	size_t const remainingToFlush = ZSTD_endStream(r->zstd_cctx, &output);   /* close frame */
+	if (remainingToFlush)
+	{
+		snprintf(r->zstd_error, r->zstd_err_len, "Compression failed, error is not fully flushed.");
+		gprintln(NULL, r->zstd_error);
+		return -1;
+	}
+	offset += output.pos;
+
+	return offset;
 }
 #endif

--- a/src/bin/gpfdist/regress/Makefile
+++ b/src/bin/gpfdist/regress/Makefile
@@ -11,14 +11,10 @@ ifeq ($(with_openssl),yes)
 endif
 endif
 
-<<<<<<< HEAD
-PSQLDIR = $(prefix)/bin
-=======
 ifeq ($(with_zstd),yes)
 	REGRESS += gpfdist2_compress
 endif
 
->>>>>>> 17c3d5c... Add stream zstd compress for gpfdist to gpdb7 (#14144)
 REGRESS_OPTS = --init-file=init_file
 
 installcheck: watchdog ipv4v6_ports

--- a/src/bin/gpfdist/regress/Makefile
+++ b/src/bin/gpfdist/regress/Makefile
@@ -11,7 +11,14 @@ ifeq ($(with_openssl),yes)
 endif
 endif
 
+<<<<<<< HEAD
 PSQLDIR = $(prefix)/bin
+=======
+ifeq ($(with_zstd),yes)
+	REGRESS += gpfdist2_compress
+endif
+
+>>>>>>> 17c3d5c... Add stream zstd compress for gpfdist to gpdb7 (#14144)
 REGRESS_OPTS = --init-file=init_file
 
 installcheck: watchdog ipv4v6_ports
@@ -21,7 +28,15 @@ ifeq ($(with_openssl),yes)
 	cp data/gpfdist_ssl/certs_matching/root.crt data/gpfdist_ssl/certs_not_matching
 endif
 endif
-	$(top_builddir)/src/test/regress/pg_regress --psqldir=$(PSQLDIR) --dbname=gpfdist_regression $(REGRESS) $(REGRESS_OPTS)
+ifeq ($(with_zstd),yes)
+	rm -rf data/gpfdist2/lineitem.tbl.long
+	touch data/gpfdist2/lineitem.tbl.long
+	for name in `seq 1 1000`; \
+	do \
+		head -100 data/gpfdist2/lineitem.tbl >> data/gpfdist2/lineitem.tbl.long; \
+	done  
+endif
+	$(top_builddir)/src/test/regress/pg_regress --dbname=gpfdist_regression $(REGRESS) $(REGRESS_OPTS)
 
 watchdog:
 	sh test_watchdog.sh

--- a/src/bin/gpfdist/regress/input/gpfdist2.source
+++ b/src/bin/gpfdist/regress/input/gpfdist2.source
@@ -48,6 +48,9 @@ select * from gpfdist2_start;
 drop table if exists lineitem;
 drop external table if exists ext_lineitem;
 drop external table if exists ext_simple;
+DROP EXTERNAL TABLE IF EXISTS gz_multi_chunk_2;
+DROP EXTERNAL TABLE IF EXISTS gz_multi_chunk;
+DROP EXTERNAL TABLE IF EXISTS full_csvopt;
 -- end_ignore
 
 -- test 1 using a .gz file

--- a/src/bin/gpfdist/regress/input/gpfdist2_compress.source
+++ b/src/bin/gpfdist/regress/input/gpfdist2_compress.source
@@ -55,7 +55,69 @@ FORMAT 'text'
         DELIMITER AS '|'
 )
 ;
+CREATE TABLE lineitem (like ext_lineitem);
 SELECT count(*) FROM ext_lineitem;
+INSERT INTO lineitem SELECT * FROM ext_lineitem;
+DROP EXTERNAL TABLE ext_lineitem;
+--test 1.1 test writable table using compression
+CREATE WRITABLE EXTERNAL TABLE ext_lineitem_w (
+                L_ORDERKEY INT8,
+                L_PARTKEY INTEGER,
+                L_SUPPKEY INTEGER,
+                L_LINENUMBER integer,
+                L_QUANTITY decimal,
+                L_EXTENDEDPRICE decimal,
+                L_DISCOUNT decimal,
+                L_TAX decimal,
+                L_RETURNFLAG CHAR(1),
+                L_LINESTATUS CHAR(1),
+                L_SHIPDATE date,
+                L_COMMITDATE date,
+                L_RECEIPTDATE date,
+                L_SHIPINSTRUCT CHAR(25),
+                L_SHIPMODE CHAR(10),
+                L_COMMENT VARCHAR(44)
+                )
+LOCATION
+(
+      'gpfdist://@hostname@:7070/gpfdist2/lineitem.tbl.w'
+)
+FORMAT 'text'
+(
+        DELIMITER AS '|'
+)
+;
+CREATE EXTERNAL TABLE ext_lineitem (
+                L_ORDERKEY INT8,
+                L_PARTKEY INTEGER,
+                L_SUPPKEY INTEGER,
+                L_LINENUMBER integer,
+                L_QUANTITY decimal,
+                L_EXTENDEDPRICE decimal,
+                L_DISCOUNT decimal,
+                L_TAX decimal,
+                L_RETURNFLAG CHAR(1),
+                L_LINESTATUS CHAR(1),
+                L_SHIPDATE date,
+                L_COMMITDATE date,
+                L_RECEIPTDATE date,
+                L_SHIPINSTRUCT CHAR(25),
+                L_SHIPMODE CHAR(10),
+                L_COMMENT VARCHAR(44)
+                )
+LOCATION
+(
+      'gpfdist://@hostname@:7070/gpfdist2/lineitem.tbl.w'
+)
+FORMAT 'text'
+(
+        DELIMITER AS '|'
+)
+;
+INSERT INTO ext_lineitem_w SELECT * FROM lineitem;
+DROP TABLE lineitem;
+SELECT count(*) FROM ext_lineitem;
+DROP EXTERNAL TABLE ext_lineitem_w;
 DROP EXTERNAL TABLE ext_lineitem;
 
 -- test 2 use a bigger file.
@@ -87,7 +149,70 @@ FORMAT 'text'
         DELIMITER AS '|'
 )
 ;
+CREATE TABLE lineitem (like ext_lineitem);
 SELECT count(*) FROM ext_lineitem;
+INSERT INTO lineitem SELECT * FROM ext_lineitem;
+DROP EXTERNAL TABLE ext_lineitem;
+
+--test 2.1 test writable table using compression with big data
+CREATE WRITABLE EXTERNAL TABLE ext_lineitem_w (
+                L_ORDERKEY INT8,
+                L_PARTKEY INTEGER,
+                L_SUPPKEY INTEGER,
+                L_LINENUMBER integer,
+                L_QUANTITY decimal,
+                L_EXTENDEDPRICE decimal,
+                L_DISCOUNT decimal,
+                L_TAX decimal,
+                L_RETURNFLAG CHAR(1),
+                L_LINESTATUS CHAR(1),
+                L_SHIPDATE date,
+                L_COMMITDATE date,
+                L_RECEIPTDATE date,
+                L_SHIPINSTRUCT CHAR(25),
+                L_SHIPMODE CHAR(10),
+                L_COMMENT VARCHAR(44)
+                )
+LOCATION
+(
+      'gpfdist://@hostname@:7070/gpfdist2/lineitem.tbl.w'
+)
+FORMAT 'text'
+(
+        DELIMITER AS '|'
+)
+;
+CREATE EXTERNAL TABLE ext_lineitem (
+                L_ORDERKEY INT8,
+                L_PARTKEY INTEGER,
+                L_SUPPKEY INTEGER,
+                L_LINENUMBER integer,
+                L_QUANTITY decimal,
+                L_EXTENDEDPRICE decimal,
+                L_DISCOUNT decimal,
+                L_TAX decimal,
+                L_RETURNFLAG CHAR(1),
+                L_LINESTATUS CHAR(1),
+                L_SHIPDATE date,
+                L_COMMITDATE date,
+                L_RECEIPTDATE date,
+                L_SHIPINSTRUCT CHAR(25),
+                L_SHIPMODE CHAR(10),
+                L_COMMENT VARCHAR(44)
+                )
+LOCATION
+(
+      'gpfdist://@hostname@:7070/gpfdist2/lineitem.tbl.w'
+)
+FORMAT 'text'
+(
+        DELIMITER AS '|'
+)
+;
+INSERT INTO ext_lineitem_w SELECT * FROM lineitem;
+DROP TABLE lineitem;
+SELECT count(*) FROM ext_lineitem;
+DROP EXTERNAL TABLE ext_lineitem_w;
 DROP EXTERNAL TABLE ext_lineitem;
 
 -- test 3 line too long with defaults
@@ -193,7 +318,6 @@ FORMAT 'text'
 ;
 SELECT count(*) FROM ext_lineitem;
 DROP EXTERNAL TABLE ext_lineitem;
-
 -- test 2 use a bigger file.
 
 CREATE EXTERNAL TABLE ext_lineitem (

--- a/src/bin/gpfdist/regress/input/gpfdist2_compress.source
+++ b/src/bin/gpfdist/regress/input/gpfdist2_compress.source
@@ -1,0 +1,250 @@
+--
+-- GPFDIST test cases set 2. This test set is moved from cdbunit.
+--
+drop table if exists REG_REGION;
+set optimizer_print_missing_stats = off;
+CREATE TABLE REG_REGION (R_REGIONKEY INT, R_NAME CHAR(25), R_COMMENT VARCHAR(152)) DISTRIBUTED BY (R_REGIONKEY);
+-- start_ignore
+-- end_ignore
+-- --------------------------------------
+-- 'gpfdist' protocol
+-- --------------------------------------
+DROP EXTERNAL WEB TABLE IF EXISTS gpfdist2_start;
+DROP EXTERNAL WEB TABLE IF EXISTS gpfdist2_stop;
+CREATE EXTERNAL WEB TABLE gpfdist2_start (x text)
+execute E'((@bindir@/gpfdist -p 7070 -d @abs_srcdir@/data --compress </dev/null >/dev/null 2>&1 &); for i in `seq 1 30`; do curl 127.0.0.1:7070 >/dev/null 2>&1 && break; sleep 1; done; echo "starting...") '
+on SEGMENT 0
+FORMAT 'text' (delimiter '|');
+
+CREATE EXTERNAL WEB TABLE gpfdist2_stop (x text)
+execute E'(ps -A -o pid,comm |grep [g]pfdist |grep -v postgres: |awk \'{print $1;}\' |xargs kill) > /dev/null 2>&1; echo "stopping..."'
+on SEGMENT 0
+FORMAT 'text' (delimiter '|');
+
+-- start_ignore
+select * from gpfdist2_stop;
+select * from gpfdist2_start;
+-- end_ignore
+
+--- test 1 using a little file
+
+CREATE EXTERNAL TABLE ext_lineitem (
+                L_ORDERKEY INT8,
+                L_PARTKEY INTEGER,
+                L_SUPPKEY INTEGER,
+                L_LINENUMBER integer,
+                L_QUANTITY decimal,
+                L_EXTENDEDPRICE decimal,
+                L_DISCOUNT decimal,
+                L_TAX decimal,
+                L_RETURNFLAG CHAR(1),
+                L_LINESTATUS CHAR(1),
+                L_SHIPDATE date,
+                L_COMMITDATE date,
+                L_RECEIPTDATE date,
+                L_SHIPINSTRUCT CHAR(25),
+                L_SHIPMODE CHAR(10),
+                L_COMMENT VARCHAR(44)
+                )
+LOCATION
+(
+      'gpfdist://@hostname@:7070/gpfdist2/lineitem.tbl'
+)
+FORMAT 'text'
+(
+        DELIMITER AS '|'
+)
+;
+SELECT count(*) FROM ext_lineitem;
+DROP EXTERNAL TABLE ext_lineitem;
+
+-- test 2 use a bigger file.
+
+CREATE EXTERNAL TABLE ext_lineitem (
+                L_ORDERKEY INT8,
+                L_PARTKEY INTEGER,
+                L_SUPPKEY INTEGER,
+                L_LINENUMBER integer,
+                L_QUANTITY decimal,
+                L_EXTENDEDPRICE decimal,
+                L_DISCOUNT decimal,
+                L_TAX decimal,
+                L_RETURNFLAG CHAR(1),
+                L_LINESTATUS CHAR(1),
+                L_SHIPDATE date,
+                L_COMMITDATE date,
+                L_RECEIPTDATE date,
+                L_SHIPINSTRUCT CHAR(25),
+                L_SHIPMODE CHAR(10),
+                L_COMMENT VARCHAR(44)
+                )
+LOCATION
+(
+        'gpfdist://@hostname@:7070/gpfdist2/lineitem.tbl.long'
+)
+FORMAT 'text'
+(
+        DELIMITER AS '|'
+)
+;
+SELECT count(*) FROM ext_lineitem;
+DROP EXTERNAL TABLE ext_lineitem;
+
+-- test 3 line too long with defaults
+
+CREATE EXTERNAL TABLE ext_test (
+                id text,
+                stuff text
+                )
+LOCATION
+(
+      'gpfdist://@hostname@:7070/gpfdist2/longline.txt'
+)
+FORMAT 'text'
+(
+        DELIMITER AS ','
+) LOG ERRORS SEGMENT REJECT LIMIT 2
+;
+SELECT count(*) FROM ext_test;
+DROP EXTERNAL TABLE ext_test;
+
+--test 4 using csv data
+CREATE EXTERNAL TABLE ext_crlf_with_lf_column(c1 int, c2 text) LOCATION ('gpfdist://@hostname@:7070/gpfdist2/crlf_with_lf_column.csv') FORMAT 'csv' (NEWLINE 'CRLF');
+SELECT count(*) FROM ext_crlf_with_lf_column;
+DROP EXTERNAL TABLE ext_crlf_with_lf_column;
+
+-- test 5 use two urls.
+CREATE EXTERNAL TABLE ext_lineitem (
+                L_ORDERKEY INT8,
+                L_PARTKEY INTEGER,
+                L_SUPPKEY INTEGER,
+                L_LINENUMBER integer,
+                L_QUANTITY decimal,
+                L_EXTENDEDPRICE decimal,
+                L_DISCOUNT decimal,
+                L_TAX decimal,
+                L_RETURNFLAG CHAR(1),
+                L_LINESTATUS CHAR(1),
+                L_SHIPDATE date,
+                L_COMMITDATE date,
+                L_RECEIPTDATE date,
+                L_SHIPINSTRUCT CHAR(25),
+                L_SHIPMODE CHAR(10),
+                L_COMMENT VARCHAR(44)
+                )
+LOCATION
+(
+        'gpfdist://@hostname@:7070/gpfdist2/lineitem.tbl.long',
+        'gpfdist://@hostname@:7070/gpfdist2/lineitem.tbl'
+)
+FORMAT 'text'
+(
+        DELIMITER AS '|'
+)
+;
+SELECT count(*) FROM ext_lineitem;
+DROP EXTERNAL TABLE ext_lineitem;
+
+-- start_ignore
+select * from gpfdist2_stop;
+-- end_ignore
+
+
+--test bigger buffer start
+DROP EXTERNAL WEB TABLE IF EXISTS gpfdist2_start;
+
+CREATE EXTERNAL WEB TABLE gpfdist2_start (x text)
+execute E'((@bindir@/gpfdist -p 7070 -d @abs_srcdir@/data --compress -m 1200000 </dev/null >/dev/null 2>&1 &); for i in `seq 1 30`; do curl 127.0.0.1:7070 >/dev/null 2>&1 && break; sleep 1; done; echo "starting...") '
+on SEGMENT 0
+FORMAT 'text' (delimiter '|');
+
+-- start_ignore
+select * from gpfdist2_start;
+-- end_ignore
+
+-- test 1 using a little file
+
+CREATE EXTERNAL TABLE ext_lineitem (
+                L_ORDERKEY INT8,
+                L_PARTKEY INTEGER,
+                L_SUPPKEY INTEGER,
+                L_LINENUMBER integer,
+                L_QUANTITY decimal,
+                L_EXTENDEDPRICE decimal,
+                L_DISCOUNT decimal,
+                L_TAX decimal,
+                L_RETURNFLAG CHAR(1),
+                L_LINESTATUS CHAR(1),
+                L_SHIPDATE date,
+                L_COMMITDATE date,
+                L_RECEIPTDATE date,
+                L_SHIPINSTRUCT CHAR(25),
+                L_SHIPMODE CHAR(10),
+                L_COMMENT VARCHAR(44)
+                )
+LOCATION
+(
+      'gpfdist://@hostname@:7070/gpfdist2/lineitem.tbl'
+)
+FORMAT 'text'
+(
+        DELIMITER AS '|'
+)
+;
+SELECT count(*) FROM ext_lineitem;
+DROP EXTERNAL TABLE ext_lineitem;
+
+-- test 2 use a bigger file.
+
+CREATE EXTERNAL TABLE ext_lineitem (
+                L_ORDERKEY INT8,
+                L_PARTKEY INTEGER,
+                L_SUPPKEY INTEGER,
+                L_LINENUMBER integer,
+                L_QUANTITY decimal,
+                L_EXTENDEDPRICE decimal,
+                L_DISCOUNT decimal,
+                L_TAX decimal,
+                L_RETURNFLAG CHAR(1),
+                L_LINESTATUS CHAR(1),
+                L_SHIPDATE date,
+                L_COMMITDATE date,
+                L_RECEIPTDATE date,
+                L_SHIPINSTRUCT CHAR(25),
+                L_SHIPMODE CHAR(10),
+                L_COMMENT VARCHAR(44)
+                )
+LOCATION
+(
+        'gpfdist://@hostname@:7070/gpfdist2/lineitem.tbl.long'
+)
+FORMAT 'text'
+(
+        DELIMITER AS '|'
+)
+;
+SELECT count(*) FROM ext_lineitem;
+DROP EXTERNAL TABLE ext_lineitem;
+
+-- test 3 line too long with defaults
+
+CREATE EXTERNAL TABLE ext_test (
+                id text,
+                stuff text
+                )
+LOCATION
+(
+      'gpfdist://@hostname@:7070/gpfdist2/longline.txt'
+)
+FORMAT 'text'
+(
+        DELIMITER AS ','
+) LOG ERRORS SEGMENT REJECT LIMIT 2
+;
+SELECT count(*) FROM ext_test;
+DROP EXTERNAL TABLE ext_test;
+
+--test 4 using csv data
+CREATE EXTERNAL TABLE ext_crlf_with_lf_column(c1 int, c2 text) LOCATION ('gpfdist://@hostname@:7070/gpfdist2/crlf_with_lf_column.csv') FORMAT 'csv' (NEWLINE 'CRLF');
+SELECT count(*) FROM ext_crlf_with_lf_column;
+DROP EXTERNAL TABLE ext_crlf_with_lf_column;

--- a/src/bin/gpfdist/regress/output/gpfdist2_compress.source
+++ b/src/bin/gpfdist/regress/output/gpfdist2_compress.source
@@ -61,12 +61,80 @@ FORMAT 'text'
         DELIMITER AS '|'
 )
 ;
+CREATE TABLE lineitem (like ext_lineitem);
+NOTICE:  table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 SELECT count(*) FROM ext_lineitem;
  count 
 -------
    256
 (1 row)
 
+INSERT INTO lineitem SELECT * FROM ext_lineitem;
+DROP EXTERNAL TABLE ext_lineitem;
+--test 1.1 test writable table using compression
+CREATE WRITABLE EXTERNAL TABLE ext_lineitem_w (
+                L_ORDERKEY INT8,
+                L_PARTKEY INTEGER,
+                L_SUPPKEY INTEGER,
+                L_LINENUMBER integer,
+                L_QUANTITY decimal,
+                L_EXTENDEDPRICE decimal,
+                L_DISCOUNT decimal,
+                L_TAX decimal,
+                L_RETURNFLAG CHAR(1),
+                L_LINESTATUS CHAR(1),
+                L_SHIPDATE date,
+                L_COMMITDATE date,
+                L_RECEIPTDATE date,
+                L_SHIPINSTRUCT CHAR(25),
+                L_SHIPMODE CHAR(10),
+                L_COMMENT VARCHAR(44)
+                )
+LOCATION
+(
+      'gpfdist://@hostname@:7070/gpfdist2/lineitem.tbl.w'
+)
+FORMAT 'text'
+(
+        DELIMITER AS '|'
+)
+;
+CREATE EXTERNAL TABLE ext_lineitem (
+                L_ORDERKEY INT8,
+                L_PARTKEY INTEGER,
+                L_SUPPKEY INTEGER,
+                L_LINENUMBER integer,
+                L_QUANTITY decimal,
+                L_EXTENDEDPRICE decimal,
+                L_DISCOUNT decimal,
+                L_TAX decimal,
+                L_RETURNFLAG CHAR(1),
+                L_LINESTATUS CHAR(1),
+                L_SHIPDATE date,
+                L_COMMITDATE date,
+                L_RECEIPTDATE date,
+                L_SHIPINSTRUCT CHAR(25),
+                L_SHIPMODE CHAR(10),
+                L_COMMENT VARCHAR(44)
+                )
+LOCATION
+(
+      'gpfdist://@hostname@:7070/gpfdist2/lineitem.tbl.w'
+)
+FORMAT 'text'
+(
+        DELIMITER AS '|'
+)
+;
+INSERT INTO ext_lineitem_w SELECT * FROM lineitem;
+DROP TABLE lineitem;
+SELECT count(*) FROM ext_lineitem;
+ count 
+-------
+   256
+(1 row)
+
+DROP EXTERNAL TABLE ext_lineitem_w;
 DROP EXTERNAL TABLE ext_lineitem;
 -- test 2 use a bigger file.
 CREATE EXTERNAL TABLE ext_lineitem (
@@ -96,12 +164,79 @@ FORMAT 'text'
         DELIMITER AS '|'
 )
 ;
+CREATE TABLE lineitem (like ext_lineitem);
 SELECT count(*) FROM ext_lineitem;
  count  
 --------
  100000
 (1 row)
 
+INSERT INTO lineitem SELECT * FROM ext_lineitem;
+DROP EXTERNAL TABLE ext_lineitem;
+--test 2.1 test writable table using compression with big data
+CREATE WRITABLE EXTERNAL TABLE ext_lineitem_w (
+                L_ORDERKEY INT8,
+                L_PARTKEY INTEGER,
+                L_SUPPKEY INTEGER,
+                L_LINENUMBER integer,
+                L_QUANTITY decimal,
+                L_EXTENDEDPRICE decimal,
+                L_DISCOUNT decimal,
+                L_TAX decimal,
+                L_RETURNFLAG CHAR(1),
+                L_LINESTATUS CHAR(1),
+                L_SHIPDATE date,
+                L_COMMITDATE date,
+                L_RECEIPTDATE date,
+                L_SHIPINSTRUCT CHAR(25),
+                L_SHIPMODE CHAR(10),
+                L_COMMENT VARCHAR(44)
+                )
+LOCATION
+(
+      'gpfdist://@hostname@:7070/gpfdist2/lineitem.tbl.w'
+)
+FORMAT 'text'
+(
+        DELIMITER AS '|'
+)
+;
+CREATE EXTERNAL TABLE ext_lineitem (
+                L_ORDERKEY INT8,
+                L_PARTKEY INTEGER,
+                L_SUPPKEY INTEGER,
+                L_LINENUMBER integer,
+                L_QUANTITY decimal,
+                L_EXTENDEDPRICE decimal,
+                L_DISCOUNT decimal,
+                L_TAX decimal,
+                L_RETURNFLAG CHAR(1),
+                L_LINESTATUS CHAR(1),
+                L_SHIPDATE date,
+                L_COMMITDATE date,
+                L_RECEIPTDATE date,
+                L_SHIPINSTRUCT CHAR(25),
+                L_SHIPMODE CHAR(10),
+                L_COMMENT VARCHAR(44)
+                )
+LOCATION
+(
+      'gpfdist://@hostname@:7070/gpfdist2/lineitem.tbl.w'
+)
+FORMAT 'text'
+(
+        DELIMITER AS '|'
+)
+;
+INSERT INTO ext_lineitem_w SELECT * FROM lineitem;
+DROP TABLE lineitem;
+SELECT count(*) FROM ext_lineitem;
+ count  
+--------
+ 100256
+(1 row)
+
+DROP EXTERNAL TABLE ext_lineitem_w;
 DROP EXTERNAL TABLE ext_lineitem;
 -- test 3 line too long with defaults
 CREATE EXTERNAL TABLE ext_test (

--- a/src/bin/gpfdist/regress/output/gpfdist2_compress.source
+++ b/src/bin/gpfdist/regress/output/gpfdist2_compress.source
@@ -1,0 +1,290 @@
+--
+-- GPFDIST test cases set 2. This test set is moved from cdbunit.
+--
+drop table if exists REG_REGION;
+set optimizer_print_missing_stats = off;
+CREATE TABLE REG_REGION (R_REGIONKEY INT, R_NAME CHAR(25), R_COMMENT VARCHAR(152)) DISTRIBUTED BY (R_REGIONKEY);
+-- start_ignore
+-- end_ignore
+-- --------------------------------------
+-- 'gpfdist' protocol
+-- --------------------------------------
+DROP EXTERNAL WEB TABLE IF EXISTS gpfdist2_start;
+DROP EXTERNAL WEB TABLE IF EXISTS gpfdist2_stop;
+CREATE EXTERNAL WEB TABLE gpfdist2_start (x text)
+execute E'((@bindir@/gpfdist -p 7070 -d @abs_srcdir@/data --compress </dev/null >/dev/null 2>&1 &); for i in `seq 1 30`; do curl 127.0.0.1:7070 >/dev/null 2>&1 && break; sleep 1; done; echo "starting...") '
+on SEGMENT 0
+FORMAT 'text' (delimiter '|');
+CREATE EXTERNAL WEB TABLE gpfdist2_stop (x text)
+execute E'(ps -A -o pid,comm |grep [g]pfdist |grep -v postgres: |awk \'{print $1;}\' |xargs kill) > /dev/null 2>&1; echo "stopping..."'
+on SEGMENT 0
+FORMAT 'text' (delimiter '|');
+-- start_ignore
+select * from gpfdist2_stop;
+      x      
+-------------
+ stopping...
+(1 row)
+
+select * from gpfdist2_start;
+      x      
+-------------
+ starting...
+(1 row)
+
+-- end_ignore
+--- test 1 using a little file
+CREATE EXTERNAL TABLE ext_lineitem (
+                L_ORDERKEY INT8,
+                L_PARTKEY INTEGER,
+                L_SUPPKEY INTEGER,
+                L_LINENUMBER integer,
+                L_QUANTITY decimal,
+                L_EXTENDEDPRICE decimal,
+                L_DISCOUNT decimal,
+                L_TAX decimal,
+                L_RETURNFLAG CHAR(1),
+                L_LINESTATUS CHAR(1),
+                L_SHIPDATE date,
+                L_COMMITDATE date,
+                L_RECEIPTDATE date,
+                L_SHIPINSTRUCT CHAR(25),
+                L_SHIPMODE CHAR(10),
+                L_COMMENT VARCHAR(44)
+                )
+LOCATION
+(
+      'gpfdist://@hostname@:7070/gpfdist2/lineitem.tbl'
+)
+FORMAT 'text'
+(
+        DELIMITER AS '|'
+)
+;
+SELECT count(*) FROM ext_lineitem;
+ count 
+-------
+   256
+(1 row)
+
+DROP EXTERNAL TABLE ext_lineitem;
+-- test 2 use a bigger file.
+CREATE EXTERNAL TABLE ext_lineitem (
+                L_ORDERKEY INT8,
+                L_PARTKEY INTEGER,
+                L_SUPPKEY INTEGER,
+                L_LINENUMBER integer,
+                L_QUANTITY decimal,
+                L_EXTENDEDPRICE decimal,
+                L_DISCOUNT decimal,
+                L_TAX decimal,
+                L_RETURNFLAG CHAR(1),
+                L_LINESTATUS CHAR(1),
+                L_SHIPDATE date,
+                L_COMMITDATE date,
+                L_RECEIPTDATE date,
+                L_SHIPINSTRUCT CHAR(25),
+                L_SHIPMODE CHAR(10),
+                L_COMMENT VARCHAR(44)
+                )
+LOCATION
+(
+        'gpfdist://@hostname@:7070/gpfdist2/lineitem.tbl.long'
+)
+FORMAT 'text'
+(
+        DELIMITER AS '|'
+)
+;
+SELECT count(*) FROM ext_lineitem;
+ count  
+--------
+ 100000
+(1 row)
+
+DROP EXTERNAL TABLE ext_lineitem;
+-- test 3 line too long with defaults
+CREATE EXTERNAL TABLE ext_test (
+                id text,
+                stuff text
+                )
+LOCATION
+(
+      'gpfdist://@hostname@:7070/gpfdist2/longline.txt'
+)
+FORMAT 'text'
+(
+        DELIMITER AS ','
+) LOG ERRORS SEGMENT REJECT LIMIT 2
+;
+SELECT count(*) FROM ext_test;
+ERROR:  gpfdist error - line too long in file @abs_srcdir@/data/gpfdist2/longline.txt near (0 bytes)  (seg1 slice1 127.0.0.1:7001 pid=30337)
+CONTEXT:  External table ext_test, line 1 of file gpfdist://@hostname@:7070/gpfdist2/longline.txt
+DROP EXTERNAL TABLE ext_test;
+--test 4 using csv data
+CREATE EXTERNAL TABLE ext_crlf_with_lf_column(c1 int, c2 text) LOCATION ('gpfdist://@hostname@:7070/gpfdist2/crlf_with_lf_column.csv') FORMAT 'csv' (NEWLINE 'CRLF');
+SELECT count(*) FROM ext_crlf_with_lf_column;
+ count 
+-------
+ 10367
+(1 row)
+
+DROP EXTERNAL TABLE ext_crlf_with_lf_column;
+-- test 5 use two urls.
+CREATE EXTERNAL TABLE ext_lineitem (
+                L_ORDERKEY INT8,
+                L_PARTKEY INTEGER,
+                L_SUPPKEY INTEGER,
+                L_LINENUMBER integer,
+                L_QUANTITY decimal,
+                L_EXTENDEDPRICE decimal,
+                L_DISCOUNT decimal,
+                L_TAX decimal,
+                L_RETURNFLAG CHAR(1),
+                L_LINESTATUS CHAR(1),
+                L_SHIPDATE date,
+                L_COMMITDATE date,
+                L_RECEIPTDATE date,
+                L_SHIPINSTRUCT CHAR(25),
+                L_SHIPMODE CHAR(10),
+                L_COMMENT VARCHAR(44)
+                )
+LOCATION
+(
+        'gpfdist://@hostname@:7070/gpfdist2/lineitem.tbl.long',
+        'gpfdist://@hostname@:7070/gpfdist2/lineitem.tbl'
+)
+FORMAT 'text'
+(
+        DELIMITER AS '|'
+)
+;
+SELECT count(*) FROM ext_lineitem;
+ count  
+--------
+ 100256
+(1 row)
+
+DROP EXTERNAL TABLE ext_lineitem;
+-- start_ignore
+select * from gpfdist2_stop;
+      x      
+-------------
+ stopping...
+(1 row)
+
+-- end_ignore
+--test bigger buffer start
+DROP EXTERNAL WEB TABLE IF EXISTS gpfdist2_start;
+CREATE EXTERNAL WEB TABLE gpfdist2_start (x text)
+execute E'((@bindir@/gpfdist -p 7070 -d @abs_srcdir@/data --compress -m 1200000 </dev/null >/dev/null 2>&1 &); for i in `seq 1 30`; do curl 127.0.0.1:7070 >/dev/null 2>&1 && break; sleep 1; done; echo "starting...") '
+on SEGMENT 0
+FORMAT 'text' (delimiter '|');
+-- start_ignore
+select * from gpfdist2_start;
+      x      
+-------------
+ starting...
+(1 row)
+
+-- end_ignore
+-- test 1 using a little file
+CREATE EXTERNAL TABLE ext_lineitem (
+                L_ORDERKEY INT8,
+                L_PARTKEY INTEGER,
+                L_SUPPKEY INTEGER,
+                L_LINENUMBER integer,
+                L_QUANTITY decimal,
+                L_EXTENDEDPRICE decimal,
+                L_DISCOUNT decimal,
+                L_TAX decimal,
+                L_RETURNFLAG CHAR(1),
+                L_LINESTATUS CHAR(1),
+                L_SHIPDATE date,
+                L_COMMITDATE date,
+                L_RECEIPTDATE date,
+                L_SHIPINSTRUCT CHAR(25),
+                L_SHIPMODE CHAR(10),
+                L_COMMENT VARCHAR(44)
+                )
+LOCATION
+(
+      'gpfdist://@hostname@:7070/gpfdist2/lineitem.tbl'
+)
+FORMAT 'text'
+(
+        DELIMITER AS '|'
+)
+;
+SELECT count(*) FROM ext_lineitem;
+ count 
+-------
+   256
+(1 row)
+
+DROP EXTERNAL TABLE ext_lineitem;
+-- test 2 use a bigger file.
+CREATE EXTERNAL TABLE ext_lineitem (
+                L_ORDERKEY INT8,
+                L_PARTKEY INTEGER,
+                L_SUPPKEY INTEGER,
+                L_LINENUMBER integer,
+                L_QUANTITY decimal,
+                L_EXTENDEDPRICE decimal,
+                L_DISCOUNT decimal,
+                L_TAX decimal,
+                L_RETURNFLAG CHAR(1),
+                L_LINESTATUS CHAR(1),
+                L_SHIPDATE date,
+                L_COMMITDATE date,
+                L_RECEIPTDATE date,
+                L_SHIPINSTRUCT CHAR(25),
+                L_SHIPMODE CHAR(10),
+                L_COMMENT VARCHAR(44)
+                )
+LOCATION
+(
+        'gpfdist://@hostname@:7070/gpfdist2/lineitem.tbl.long'
+)
+FORMAT 'text'
+(
+        DELIMITER AS '|'
+)
+;
+SELECT count(*) FROM ext_lineitem;
+ count  
+--------
+ 100000
+(1 row)
+
+DROP EXTERNAL TABLE ext_lineitem;
+-- test 3 line too long with defaults
+CREATE EXTERNAL TABLE ext_test (
+                id text,
+                stuff text
+                )
+LOCATION
+(
+      'gpfdist://@hostname@:7070/gpfdist2/longline.txt'
+)
+FORMAT 'text'
+(
+        DELIMITER AS ','
+) LOG ERRORS SEGMENT REJECT LIMIT 2
+;
+SELECT count(*) FROM ext_test;
+ count 
+-------
+     1
+(1 row)
+
+DROP EXTERNAL TABLE ext_test;
+--test 4 using csv data
+CREATE EXTERNAL TABLE ext_crlf_with_lf_column(c1 int, c2 text) LOCATION ('gpfdist://@hostname@:7070/gpfdist2/crlf_with_lf_column.csv') FORMAT 'csv' (NEWLINE 'CRLF');
+SELECT count(*) FROM ext_crlf_with_lf_column;
+ count 
+-------
+ 10367
+(1 row)
+
+DROP EXTERNAL TABLE ext_crlf_with_lf_column;


### PR DESCRIPTION
Gpfdist is a high-performance ETL tool to load external data for gpdb. In practice, while gpfdist can extract the full performance of the network card, gpfdist can also affect other processes on the same host.

Especially in cloud services, multiple services may share one physical network card. If Gpfdist exclusively uses the network card, it will lead to the failure of other services.

If both high transmission efficiency and low network usage are required, transferring the data after compression is a reasonable approach. Thus this code change is about using stream compression based on zstd algorithm to transfer data from gpfdist to gpdb. The code change involves the following aspects:

The switch flag(compress) to turn on/off compression transmission for gpfdist.
The modification of the HTTP header for requests and responses for interaction between gpdb and gpfdist.
The modification of compression data(for gpfdist end) and decompressing data(for gpdb end) streamingly.
The modification of compression data(for gpdb end) and decompressing data(for gpfdist end) streamingly.

Finally, to use the zstd compression to transfer data, you can add the specific flag --compress when starting up gpfdist. For example, typing gpfdist -d /home/gpadmin -p 7070 --compress to start gpfdist, and then data would be compressed between gpfdist and gpdb.

