### PR TITLE
Cleaning untracked files

### DIFF
--- a/src/backend/Makefile
+++ b/src/backend/Makefile
@@ -323,6 +323,8 @@ maintainer-clean: distclean
 	      parser/gram.c \
 	      parser/gram.h \
 	      parser/scan.c \
+	      statistics/statistics_gram.c \
+	      statistics/statistics_scanner.c \
 	      replication/repl_gram.c \
 	      replication/repl_scanner.c \
 	      replication/syncrep_gram.c \

--- a/src/backend/statistics/.gitignore
+++ b/src/backend/statistics/.gitignore
@@ -1,0 +1,2 @@
+/statistics_gram.c
+/statistics_scanner.c

--- a/src/backend/statistics/Makefile
+++ b/src/backend/statistics/Makefile
@@ -17,3 +17,6 @@ OBJS = extended_stats.o dependencies.o mcv.o mvdistinct.o statistics_gram.o
 statistics_gram.o: statistics_scanner.c
 
 include $(top_srcdir)/src/backend/common.mk
+
+# statistics_gram.c, statistics_scanner.c are not cleaned here.
+# (Our parent Makefile takes care of them during maintainer-clean.)


### PR DESCRIPTION
Due to ext_stats commit we are seeing untracked files after every gpdb build. So trying to ignore those files using .gitignore

Untracked files:
  (use "git add <file>..." to include in what will be committed)
	src/backend/statistics/statistics_gram.c
	src/backend/statistics/statistics_scanner.c

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
