### PR TITLE
gpinitsystem: Fix bug when calling ss remotely

### DIFF
--- a/gpMgmt/bin/lib/gp_bash_functions.sh
+++ b/gpMgmt/bin/lib/gp_bash_functions.sh
@@ -889,7 +889,7 @@ GET_PG_PID_ACTIVE () {
 			if [ $RETVAL -ne 0 ];then
 				PID=0
 			else
-				PORT_ARRAY=($( REMOTE_EXECUTE_AND_GET_OUTPUT $HOST $SS -an 2>/dev/null |$AWK '{for (i =1; i<=NF ; i++) if ($i==".s.PGSQL.${PORT}") print $i}'|$AWK -F"." '{print $NF}'|$SORT -u))
+				PORT_ARRAY=($( REMOTE_EXECUTE_AND_GET_OUTPUT $HOST "$SS -an 2>/dev/null" |$AWK '{for (i =1; i<=NF ; i++) if ($i==".s.PGSQL.${PORT}") print $i}'|$AWK -F"." '{print $NF}'|$SORT -u))
 				for P_CHK in ${PORT_ARRAY[@]}
 				do
 					if [ $P_CHK -eq $PORT ];then  PG_LOCK_SS=$PORT;fi


### PR DESCRIPTION
There is a bug in `GET_PG_PID_ACTIVE()` function where the `ss` command is called remotely. The remote execution occurs through the following command - `REMOTE_EXECUTE_AND_GET_OUTPUT $HOST $SS -an 2>/dev/null`. When this is called, only the `$SS` part is passed as an argument to the `REMOTE_EXECUTE_AND_GET_OUTPUT()` function ignoring the rest. Due to this the `ss` command takes a long time to complete since there is no -n flag provided (without the -n flag, the command tries to resolve the service name of the IP addresses which can take a long time to complete).

This commit resolves this issue by simply enclosing the ss command under quotes - `REMOTE_EXECUTE_AND_GET_OUTPUT $HOST "$SS -an 2>/dev/null"`. This greatly reduces the time the `ss` command takes to execute and hence improves the overall speed of gpinitsystem.

**Time taken before the fix:**
```
$ time gpinitsystem -a -c /tmp/clusterConfigFile
real	14m32.533s
user	0m15.705s
sys	0m11.212s
```
**After the fix:**
```
$ time gpinitsystem -a -c /tmp/clusterConfigFile
real	0m43.973s
user	0m14.579s
sys	0m10.696s
```
(testing done for demo cluster setup for 2 primary and 2 mirrors)

[Pipeline](https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb-dev-7x_gpinitsystem_bug_fix)