### PR TITLE
No need pstrdup to initialize the dispatched query string

### DIFF
--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -5385,11 +5385,8 @@ PostgresMain(int argc, char *argv[],
 					/*
 					 * This is exactly like 'Q' above except we peel off and
 					 * set the snapshot information right away.
-					 *
-					 * Since PortalDefineQuery() does not take NULL query string,
-					 * we initialize it with a constant empty string.
 					 */
-					const char *query_string = pstrdup("");
+					const char *query_string = "";
 
 					const char *serializedDtxContextInfo = NULL;
 					const char *serializedPlantree = NULL;


### PR DESCRIPTION
Minor correction that we don't need to call pstrdup() when initializing the query string. exec_mpp_query() would fill in a dummy string if it is empty.

Noticed this when testing some specific workloads and seeing overheads in memory allocator caused by this. Didn't dig more into the impact but let's just fix it anyway.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
