### PR TITLE
Fix a flaky test case querying pg_class

### DIFF
--- a/src/test/regress/expected/aggregates.out
+++ b/src/test/regress/expected/aggregates.out
@@ -3153,8 +3153,9 @@ drop table agg_hash_1;
 --  drop table agg_hash_2;
 drop table agg_hash_3;
 drop table agg_hash_4;
--- fix github issue #12061 numsegments of general locus is not -1 on create_minmaxagg_path
-explain analyze select count(*) from pg_class,  (select count(*) >0 from  (select count(*) from pg_class where relname like 't%')x)y;
+-- GitHub issue https://github.com/greenplum-db/gpdb/issues/12061
+-- numsegments of the general locus should be -1 on create_minmaxagg_path
+explain analyze select count(*) from pg_class, (select count(*) > 0 from (select count(*) from pg_class where relnatts > 8) x) y;
                                                       QUERY PLAN                                                       
 -----------------------------------------------------------------------------------------------------------------------
  Aggregate  (cost=10000000025.03..10000000025.05 rows=1 width=8) (actual time=0.214..0.214 rows=1 loops=1)

--- a/src/test/regress/expected/aggregates_optimizer.out
+++ b/src/test/regress/expected/aggregates_optimizer.out
@@ -3355,8 +3355,9 @@ drop table agg_hash_1;
 --  drop table agg_hash_2;
 drop table agg_hash_3;
 drop table agg_hash_4;
--- fix github issue #12061 numsegments of general locus is not -1 on create_minmaxagg_path
-explain analyze select count(*) from pg_class,  (select count(*) >0 from  (select count(*) from pg_class where relname like 't%')x)y;
+-- GitHub issue https://github.com/greenplum-db/gpdb/issues/12061
+-- numsegments of the general locus should be -1 on create_minmaxagg_path
+explain analyze select count(*) from pg_class, (select count(*) > 0 from (select count(*) from pg_class where relnatts > 8) x) y;
 INFO:  GPORCA failed to produce a plan, falling back to planner
 DETAIL:  Feature not supported: Queries on master-only tables
                                                       QUERY PLAN                                                       

--- a/src/test/regress/sql/aggregates.sql
+++ b/src/test/regress/sql/aggregates.sql
@@ -1393,5 +1393,6 @@ drop table agg_hash_1;
 drop table agg_hash_3;
 drop table agg_hash_4;
 
--- fix github issue #12061 numsegments of general locus is not -1 on create_minmaxagg_path
-explain analyze select count(*) from pg_class,  (select count(*) >0 from  (select count(*) from pg_class where relname like 't%')x)y;
+-- GitHub issue https://github.com/greenplum-db/gpdb/issues/12061
+-- numsegments of the general locus should be -1 on create_minmaxagg_path
+explain analyze select count(*) from pg_class, (select count(*) > 0 from (select count(*) from pg_class where relnatts > 8) x) y;


### PR DESCRIPTION
`relname` of `pg_class` has an index, the stats and plan can be influenced by other tests running in parallel. Use `relnatts` instead.

```
         {
           'id' => 5,
           'parent' => 2,
-          'short' => 'Seq Scan on pg_class'
+          'short' => 'Index Only Scan using pg_class_tblspc_relfilenode_index on pg_class'
         }
       ],
       'id' => 2,
```