### PR TITLE
Fix ANALYZE's wrong behavior for FDW

### DIFF
--- a/contrib/postgres_fdw/deparse.c
+++ b/contrib/postgres_fdw/deparse.c
@@ -2098,7 +2098,7 @@ deparseAnalyzeSizeSql(StringInfo buf, Relation rel)
 
 	appendStringInfoString(buf, "SELECT pg_catalog.pg_relation_size(");
 	deparseStringLiteral(buf, relname.data);
-	appendStringInfo(buf, "::pg_catalog.regclass)");
+	appendStringInfo(buf, "::pg_catalog.regclass) / %d", BLCKSZ);
 }
 
 /*

--- a/contrib/postgres_fdw/postgres_fdw.c
+++ b/contrib/postgres_fdw/postgres_fdw.c
@@ -4439,19 +4439,7 @@ postgresAnalyzeForeignTable(Relation relation,
 
 		if (PQntuples(res) != 1 || PQnfields(res) != 1)
 			elog(ERROR, "unexpected result from deparseAnalyzeSizeSql query");
-
-        /* In GPDB, BLCKSZ is 32k by default. And in postgres, BLCKSZ is 8k by default. 
-         * When computing the totalpages of foreign table, postgres_fdw uses relSize / local BLCKSZ. 
-         * So when GPDB connects to remote postgres using postgres_fdw, 
-         * if the relSize of foreign table is smaller than GPDB BLCKSZ, the case that totalpages = 0 && totaltuples > 0 will arise. 
-         * And totalpages = 0 && titaltuples > 0 will violate GPDB's Assert and might cause GPDB crashing.
-         *
-         * So here we handle totalpages = 0 && relSize > 0 specifically to fix the issue above. 
-         */
-		unsigned long int relSize = strtoul(PQgetvalue(res, 0, 0), NULL, 10);
-		*totalpages = relSize / BLCKSZ;
-		if(*totalpages == 0 && relSize > 0)
-			*totalpages = 1;
+		*totalpages = strtoul(PQgetvalue(res, 0, 0), NULL, 10);
 
 		PQclear(res);
 		res = NULL;

--- a/src/backend/commands/vacuum.c
+++ b/src/backend/commands/vacuum.c
@@ -1433,7 +1433,7 @@ vac_update_relstats(Relation relation,
 		 * do for heap tables, too, because we don't have even a tuple count
 		 * for them. At least this is consistent.
 		 */
-		if (num_tuples >= 1.0)
+		if (get_rel_relkind(relid) != RELKIND_FOREIGN_TABLE && num_tuples >= 1.0)
 		{
 			Assert(Gp_role == GP_ROLE_UTILITY);
 			Assert(!IsSystemRelation(relation));
@@ -1441,7 +1441,6 @@ vac_update_relstats(Relation relation,
 			num_tuples = 0;
 		}
 
-		Assert(num_tuples < 1.0);
 		num_pages = 1.0;
 	}
 

--- a/src/backend/commands/vacuum.c
+++ b/src/backend/commands/vacuum.c
@@ -1435,6 +1435,18 @@ vac_update_relstats(Relation relation,
 		 */
 		if (get_rel_relkind(relid) != RELKIND_FOREIGN_TABLE && num_tuples >= 1.0)
 		{
+			/*
+			 * For many foreign tables, num_pages < 1.0 && num_tuples >= 1.0 
+			 * might arise and is reasonable.
+			 *
+			 * For example, while ANALYZE kafka_fdw foreign tables, num_pages < 1.0 
+			 * && num_tuples >= 1.0 always arises.
+			 * Because num_pages is meaningless for kafka, kafka_fdw won't compute it.
+			 * 
+			 * To avoid the crash of GPDB and ensure the quality of query plan,
+			 * we won't reset num_tuples to 0 when num_pages < 1.0 && num_tuples >= 1.0
+			 * for foreign tables.
+			 */
 			Assert(Gp_role == GP_ROLE_UTILITY);
 			Assert(!IsSystemRelation(relation));
 			Assert(RelationIsAppendOptimized(relation));

--- a/src/backend/commands/vacuum.c
+++ b/src/backend/commands/vacuum.c
@@ -1420,7 +1420,7 @@ vac_update_relstats(Relation relation,
 	 */
 	if (num_pages < 1.0)
 	{
-		/*
+		/* (1) For NOT foreign table
 		 * When running in utility mode in the QD node, we get the number of
 		 * tuples of an AO table from the pg_aoseg table, but we don't know
 		 * the file size, so that's always 0. Ignore the tuple count we got,
@@ -1432,21 +1432,21 @@ vac_update_relstats(Relation relation,
 		 * relpages/reltuples estimates in utility mode, but that's what we
 		 * do for heap tables, too, because we don't have even a tuple count
 		 * for them. At least this is consistent.
+		 *
+		 * (2) For foreign table
+		 * For many foreign tables, num_pages < 1.0 && num_tuples >= 1.0
+		 * might arise and is reasonable.
+		 *
+		 * For example, while ANALYZE kafka_fdw foreign tables, num_pages < 1.0
+		 * && num_tuples >= 1.0 always arises.
+		 * Because num_pages is meaningless for kafka, kafka_fdw won't compute it.
+		 *
+		 * To avoid the crash of GPDB and ensure the quality of query plan,
+		 * we won't reset num_tuples to 0 when num_pages < 1.0 && num_tuples >= 1.0
+		 * for foreign tables.
 		 */
 		if (get_rel_relkind(relid) != RELKIND_FOREIGN_TABLE && num_tuples >= 1.0)
 		{
-			/*
-			 * For many foreign tables, num_pages < 1.0 && num_tuples >= 1.0 
-			 * might arise and is reasonable.
-			 *
-			 * For example, while ANALYZE kafka_fdw foreign tables, num_pages < 1.0 
-			 * && num_tuples >= 1.0 always arises.
-			 * Because num_pages is meaningless for kafka, kafka_fdw won't compute it.
-			 * 
-			 * To avoid the crash of GPDB and ensure the quality of query plan,
-			 * we won't reset num_tuples to 0 when num_pages < 1.0 && num_tuples >= 1.0
-			 * for foreign tables.
-			 */
 			Assert(Gp_role == GP_ROLE_UTILITY);
 			Assert(!IsSystemRelation(relation));
 			Assert(RelationIsAppendOptimized(relation));


### PR DESCRIPTION
This pr is to solve issue https://github.com/greenplum-db/gpdb/issues/14579.

When ANALYZE foreign table, `num_pages == 0 && num_tuples > 0` may arise and is reasonable(like postgres_fdw and kafka_fdw).

For example, if ANALYZE kafka_fdw foreign table, `num_pages == 0 && num_tuples > 0` always arises.
Because kafka_fdw doesn't return `num_pages` , which is meaningless for kafka.

Since there are many possibilities causing `num_pages == 0 && num_tuples > 0`, it seems that these assertions are NOT reasonable.

```
	if (num_pages < 1.0)
	{
		if (num_tuples >= 1.0)
		{
			Assert(Gp_role == GP_ROLE_UTILITY);
			Assert(!IsSystemRelation(relation));
			Assert(RelationIsAppendOptimized(relation));
			num_tuples = 0;
		}

		Assert(num_tuples < 1.0);
		num_pages = 1.0;
	}
```

In this pr, if `num_pages == 0 && num_tuples > 0`, we will recognize the type of table further.
If it is foreign table, we won't reset `num_tuples` to 0.