### PR TITLE
[7X] Also set dependent array type encoding on ALTER TYPE ENCODING

### DIFF
--- a/src/test/regress/expected/AOCO_Compression.out
+++ b/src/test/regress/expected/AOCO_Compression.out
@@ -3622,3 +3622,17 @@ SELECT * FROM pg_compression WHERE compname='rle_type';
  rle_type | gp_rle_type_constructor | gp_rle_type_destructor | gp_rle_type_compress | gp_rle_type_decompress | gp_rle_type_validator |        10
 (1 row)
 
+-- Check ALTER TYPE SET DEFAULT ENCODING propagates to the dependent array type
+DROP type if exists mood_encoded cascade;
+CREATE TYPE mood_encoded AS ENUM ('sad', 'ok', 'happy');
+ALTER TYPE public.mood_encoded SET DEFAULT ENCODING (compresstype=zlib, blocksize=65536, compresslevel=4);
+SELECT t.typname, te.typoptions
+FROM pg_type t
+LEFT JOIN pg_type_encoding te ON (t.oid=te.typid)
+WHERE t.typname in ('mood_encoded', '_mood_encoded');
+    typname    |                     typoptions                      
+---------------+-----------------------------------------------------
+ _mood_encoded | {compresstype=zlib,blocksize=65536,compresslevel=4}
+ mood_encoded  | {compresstype=zlib,blocksize=65536,compresslevel=4}
+(2 rows)
+

--- a/src/test/regress/expected/column_compression.out
+++ b/src/test/regress/expected/column_compression.out
@@ -1959,10 +1959,14 @@ select * from pg_type_encoding;
  typid |                     typoptions                      
 -------+-----------------------------------------------------
   1043 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+  1015 | {compresstype=zlib,compresslevel=1,blocksize=32768}
   1042 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+  1014 | {compresstype=zlib,compresslevel=1,blocksize=32768}
   1184 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+  1185 | {compresstype=zlib,compresslevel=1,blocksize=32768}
     25 | {compresstype=zlib,compresslevel=1,blocksize=32768}
-(4 rows)
+  1009 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+(8 rows)
 
 -- cleanup
 deallocate ccddlcheck;

--- a/src/test/regress/sql/AOCO_Compression.sql
+++ b/src/test/regress/sql/AOCO_Compression.sql
@@ -1779,3 +1779,14 @@ create table a_aoco_table_with_rle_type_and_invalid_compression_level(col int) W
 
 -- Check that callbacks are registered
 SELECT * FROM pg_compression WHERE compname='rle_type';
+
+-- Check ALTER TYPE SET DEFAULT ENCODING propagates to the dependent array type
+DROP type if exists mood_encoded cascade;
+
+CREATE TYPE mood_encoded AS ENUM ('sad', 'ok', 'happy');
+ALTER TYPE public.mood_encoded SET DEFAULT ENCODING (compresstype=zlib, blocksize=65536, compresslevel=4);
+
+SELECT t.typname, te.typoptions
+FROM pg_type t
+LEFT JOIN pg_type_encoding te ON (t.oid=te.typid)
+WHERE t.typname in ('mood_encoded', '_mood_encoded');


### PR DESCRIPTION
Changing a type's default encoding using ALTER TYPE name SET DEFAULT
ENCODING should also set it's dependent array type to the same encoding.
This is the expected behavior if default compression encoding is
specified on CREATE TYPE. This also fixes pg_dump and pg_upgrade since
pg_dump relies on ALTER TYPE statements to set a type's default
encoding.

Without this change user defined types with their default encodings
specified on creation will set default encodings on the both type and
it's depedent array type. The ALTER TYPE SET DEFAULT ENCODING statement
from pg_dump would not restore the default encoding of the dependent
array type.

This change prohibits altering types without a dependent array type.
This was allowed under the following assumptions.
1. User defined types will always have dependent array types
2. It was fine that this prohibits some internal types that have no
   dependent array types from having their default encodings modified.
3. Forcing types and their dependent array to restore with the same
   default encoding will not break existing tables because the columns
   store their own encoding.

While this means some internal types now cannot have their default
encodings changed we will keep user defined types and their dependent
arrays types default encoding in sync.

pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/alter-encode
