### PR TITLE
[6X] Also set dependent array type encoding on ALTER TYPE ENCODING

### DIFF
--- a/src/backend/catalog/pg_type.c
+++ b/src/backend/catalog/pg_type.c
@@ -14,6 +14,7 @@
  */
 #include "postgres.h"
 
+#include "access/genam.h"
 #include "access/heapam.h"
 #include "access/htup_details.h"
 #include "access/xact.h"
@@ -71,6 +72,56 @@ add_type_encoding(Oid typid, Datum typoptions)
 	CatalogUpdateIndexes(pg_type_encoding_desc, tuple);
 
 	heap_close(pg_type_encoding_desc, RowExclusiveLock);
+}
+
+/*
+ * Update the type encoding for typid.
+ * If no entry for typid, create one.
+ */
+void
+update_type_encoding(Oid typid, Datum typoptions)
+{
+	Relation 	pgtypeenc;
+	ScanKeyData 	scankey;
+	SysScanDesc 	scan;
+	HeapTuple	tup;
+
+	/* SELECT * FROM pg_type_encoding WHERE typid = :1 FOR UPDATE */
+	pgtypeenc = heap_open(TypeEncodingRelationId, RowExclusiveLock);
+	ScanKeyInit(&scankey, Anum_pg_type_encoding_typid,
+				BTEqualStrategyNumber, F_OIDEQ,
+				ObjectIdGetDatum(typid));
+	scan = systable_beginscan(pgtypeenc, TypeEncodingTypidIndexId, true,
+							  NULL, 1, &scankey);
+
+	tup = systable_getnext(scan);
+	if (HeapTupleIsValid(tup))
+	{
+		/* update case */
+		Datum values[Natts_pg_type_encoding];
+		bool nulls[Natts_pg_type_encoding];
+		bool replaces[Natts_pg_type_encoding];
+		HeapTuple newtuple;
+
+		MemSet(values, 0, sizeof(values));
+		MemSet(nulls, false, sizeof(nulls));
+		MemSet(replaces, false, sizeof(replaces));
+
+		replaces[Anum_pg_type_encoding_typoptions - 1] = true;
+		values[Anum_pg_type_encoding_typoptions - 1] = typoptions;
+
+		newtuple = heap_modify_tuple(tup, RelationGetDescr(pgtypeenc),
+									 values, nulls, replaces);
+
+		simple_heap_update(pgtypeenc, &tup->t_self, newtuple);
+		CatalogUpdateIndexes(pgtypeenc, newtuple);
+	}
+	else
+	{
+		add_type_encoding(typid, typoptions);
+	}
+	systable_endscan(scan);
+	heap_close(pgtypeenc, NoLock);
 }
 
 /* ----------------------------------------------------------------

--- a/src/backend/utils/cache/lsyscache.c
+++ b/src/backend/utils/cache/lsyscache.c
@@ -2992,6 +2992,16 @@ type_is_range(Oid typid)
 }
 
 /*
+ * type_is_domain
+ *	  Returns true if the given type is a domain type.
+ */
+bool
+type_is_domain(Oid typid)
+{
+	return (get_typtype(typid) == TYPTYPE_DOMAIN);
+}
+
+/*
  * get_type_category_preferred
  *
  *		Given the type OID, fetch its category and preferred-type status.

--- a/src/include/catalog/pg_type_fn.h
+++ b/src/include/catalog/pg_type_fn.h
@@ -104,5 +104,6 @@ extern bool moveArrayTypeName(Oid typeOid, const char *typeName,
 				  Oid typeNamespace);
 
 extern void add_type_encoding(Oid typid, Datum typoptions);
+extern void update_type_encoding(Oid typid, Datum typoptions);
 
 #endif   /* PG_TYPE_FN_H */

--- a/src/include/utils/lsyscache.h
+++ b/src/include/utils/lsyscache.h
@@ -185,6 +185,7 @@ extern char get_typtype(Oid typid);
 extern bool type_is_rowtype(Oid typid);
 extern bool type_is_enum(Oid typid);
 extern bool type_is_range(Oid typid);
+extern bool type_is_domain(Oid typid);
 extern void get_type_category_preferred(Oid typid,
 							char *typcategory,
 							bool *typispreferred);

--- a/src/test/regress/expected/AOCO_Compression.out
+++ b/src/test/regress/expected/AOCO_Compression.out
@@ -3995,3 +3995,34 @@ SELECT * FROM pg_compression WHERE compname='rle_type';
  rle_type | gp_rle_type_constructor | gp_rle_type_destructor | gp_rle_type_compress | gp_rle_type_decompress | gp_rle_type_validator |        10
 (1 row)
 
+-- Check ALTER TYPE SET DEFAULT ENCODING propagates to the dependent arrary type
+DROP type if exists mood_encoded cascade;
+NOTICE:  type "mood_encoded" does not exist, skipping
+CREATE TYPE mood_encoded AS ENUM ('sad', 'ok', 'happy');
+ALTER TYPE public.mood_encoded SET DEFAULT ENCODING (compresstype=zlib, blocksize=65536, compresslevel=4);
+SELECT t.typname, te.typoptions
+FROM pg_type t
+LEFT JOIN pg_type_encoding te ON (t.oid=te.typid)
+WHERE t.typname in ('mood_encoded', '_mood_encoded');
+    typname    |                     typoptions                      
+---------------+-----------------------------------------------------
+ mood_encoded  | {compresstype=zlib,blocksize=65536,compresslevel=4}
+ _mood_encoded | {compresstype=zlib,blocksize=65536,compresslevel=4}
+(2 rows)
+
+-- ALTER TYPE SET DEFAULT ENCODING should still work on domain types even
+-- though they do not have a dependent array type in 6x.
+DROP type if exists us_zip_code_encoded;
+NOTICE:  type "us_zip_code_encoded" does not exist, skipping
+CREATE DOMAIN us_zip_code_encoded AS TEXT CHECK
+       ( VALUE ~ '^\d{5}$' OR VALUE ~ '^\d{5}-\d{4}$' );
+ALTER TYPE public.us_zip_code_encoded SET DEFAULT ENCODING (compresstype=zlib, blocksize=32768, compresslevel=3);
+SELECT t.typname, te.typoptions
+FROM pg_type t
+LEFT JOIN pg_type_encoding te ON (t.oid=te.typid)
+WHERE t.typname in ('us_zip_code_encoded');
+       typname       |                     typoptions                      
+---------------------+-----------------------------------------------------
+ us_zip_code_encoded | {compresstype=zlib,blocksize=32768,compresslevel=3}
+(1 row)
+

--- a/src/test/regress/expected/column_compression.out
+++ b/src/test/regress/expected/column_compression.out
@@ -1888,10 +1888,14 @@ select * from pg_type_encoding;
  typid |                     typoptions                      
 -------+-----------------------------------------------------
   1043 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+  1015 | {compresstype=zlib,compresslevel=1,blocksize=32768}
   1042 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+  1014 | {compresstype=zlib,compresslevel=1,blocksize=32768}
   1184 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+  1185 | {compresstype=zlib,compresslevel=1,blocksize=32768}
     25 | {compresstype=zlib,compresslevel=1,blocksize=32768}
-(4 rows)
+  1009 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+(8 rows)
 
 -- cleanup
 deallocate ccddlcheck;


### PR DESCRIPTION
This is a backport of main commit:
670ffac

An exception was added to the original commit to allow changing domain
type default encodings without needing a dependent array type because
dependent array types for domains are present on 7x but not 6x.

Original commit message:
Changing a type's default encoding using ALTER TYPE name SET DEFAULT
ENCODING should also set it's dependent array type to the same encoding.
This is the expected behavior when default compression encoding is
specified on CREATE TYPE. This also fixes pg_dump and pg_upgrade since
pg_dump relies on ALTER TYPE statements to set a type's default
encoding.

Without this change user defined types with their default encodings
specified on CREATE TYPE will set default encodings on the both the type
and it's depedent array type. The ALTER TYPE SET DEFAULT ENCODING
statement from pg_dump would not restore the default encoding of the
dependent array type.

This change prohibits altering types without a dependent array type.
This was allowed under the following assumptions.
1. User defined types will always have dependent array types
2. It is fine that this prohibits some internal types with no dependent
   array types from having their default encodings modified.
3. Forcing types and their dependent array to restore with the same
   default encoding will not break existing tables because columns store
   their own encoding.

While this means some internal types now cannot have their default
encodings changed, we will keep the default encodings of user defined
types and it's dependent array type in sync.

pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/6x-alter-encode