### PR TITLE
Mark columns to be projected for COPY TO on AOCO table

### DIFF
--- a/src/backend/cdb/cdbappendonlystorageread.c
+++ b/src/backend/cdb/cdbappendonlystorageread.c
@@ -28,7 +28,7 @@
 #include "cdb/cdbappendonlystorageread.h"
 #include "storage/gp_compress.h"
 #include "utils/guc.h"
-
+#include "utils/faultinjector.h"
 
 /*----------------------------------------------------------------
  * Initialization
@@ -1023,6 +1023,8 @@ AppendOnlyStorageRead_ReadNextBlock(AppendOnlyStorageRead *storageRead)
 	{
 		/* UNDONE: Finish the read for the information only header. */
 	}
+
+	SIMPLE_FAULT_INJECTOR("AppendOnlyStorageRead_ReadNextBlock_success");
 
 	return true;
 }

--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -3097,16 +3097,23 @@ CopyTo(CopyState cstate)
 				bool *proj = NULL;
 
 				int nvp = tupDesc->natts;
-				int i;
 
 				if (tupDesc->tdhasoid)
 				{
 				    elog(ERROR, "OIDS=TRUE is not allowed on tables that use column-oriented storage. Use OIDS=FALSE");
 				}
 
-				proj = palloc(sizeof(bool) * nvp);
-				for(i = 0; i < nvp; ++i)
-				    proj[i] = true;
+				proj = palloc0(sizeof(bool) * nvp);
+				/*
+				 * attnumlist is constructed after filtering out dropped
+				 * columns. Use it to mark columns to be projected.
+				 */
+				foreach(cur, cstate->attnumlist)
+				{
+					int	attnum = lfirst_int(cur);
+					Assert(attnum <= nvp);
+					proj[attnum-1] = true;
+				}
 
 				scan = aocs_beginscan(rel, GetActiveSnapshot(),
 									  GetActiveSnapshot(),

--- a/src/test/regress/expected/aoco_projection.out
+++ b/src/test/regress/expected/aoco_projection.out
@@ -1,0 +1,224 @@
+-- Tests to validate column projection for various operations
+-- Tests for COPY TO (SELECT <...> FROM <aoco_table>) TO ..
+CREATE TABLE aoco(i int, j bigint, k int) WITH (appendonly=true, orientation=column);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO aoco SELECT 0, i, 1 FROM generate_series(1, 100000) i;
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'skip', '', '', '', 1, 100, 0, dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+-- Reads all blocks in the table as all columns are specified.
+COPY (SELECT * FROM aoco) TO '/dev/null';
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'status', dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+                                                                                                                  gp_inject_fault                                                                                                                   
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Success: fault name:'AppendOnlyStorageRead_ReadNextBlock_success' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'100' extra arg:'0' fault injection state:'triggered'  num times hit:'51' +
+ 
+(1 row)
+
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'reset', dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'skip', '', '', '', 1, 100, 0, dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+-- Reads all blocks in the table as all columns are specified.
+COPY (SELECT i,j,k FROM aoco) TO '/dev/null';
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'status', dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+                                                                                                                  gp_inject_fault                                                                                                                   
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Success: fault name:'AppendOnlyStorageRead_ReadNextBlock_success' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'100' extra arg:'0' fault injection state:'triggered'  num times hit:'51' +
+ 
+(1 row)
+
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'reset', dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'skip', '', '', '', 1, 100, 0, dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+-- Reads blocks only for cols: i int, j bigint
+COPY (SELECT i,j FROM aoco) TO '/dev/null';
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'status', dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+                                                                                                                  gp_inject_fault                                                                                                                   
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Success: fault name:'AppendOnlyStorageRead_ReadNextBlock_success' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'100' extra arg:'0' fault injection state:'triggered'  num times hit:'38' +
+ 
+(1 row)
+
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'reset', dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'skip', '', '', '', 1, 100, 0, dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+-- Reads blocks only for cols: i int
+COPY (SELECT i FROM aoco) TO '/dev/null';
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'status', dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+                                                                                                                  gp_inject_fault                                                                                                                   
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Success: fault name:'AppendOnlyStorageRead_ReadNextBlock_success' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'100' extra arg:'0' fault injection state:'triggered'  num times hit:'13' +
+ 
+(1 row)
+
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'reset', dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'skip', '', '', '', 1, 100, 0, dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+-- Tests for COPY <aoco_table> (<col_list>) TO ..
+-- Reads all blocks in the table as all columns are implicitly specified.
+COPY aoco TO '/dev/null';
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'status', dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+                                                                                                                  gp_inject_fault                                                                                                                   
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Success: fault name:'AppendOnlyStorageRead_ReadNextBlock_success' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'100' extra arg:'0' fault injection state:'triggered'  num times hit:'51' +
+ 
+(1 row)
+
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'reset', dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'skip', '', '', '', 1, 100, 0, dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+-- Reads all blocks in the table as all columns are specified.
+COPY aoco (i,j,k) TO '/dev/null';
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'status', dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+                                                                                                                  gp_inject_fault                                                                                                                   
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Success: fault name:'AppendOnlyStorageRead_ReadNextBlock_success' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'100' extra arg:'0' fault injection state:'triggered'  num times hit:'51' +
+ 
+(1 row)
+
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'reset', dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'skip', '', '', '', 1, 100, 0, dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+-- Reads blocks only for cols: i int, j bigint
+COPY aoco (i,j) TO '/dev/null';
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'status', dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+                                                                                                                  gp_inject_fault                                                                                                                   
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Success: fault name:'AppendOnlyStorageRead_ReadNextBlock_success' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'100' extra arg:'0' fault injection state:'triggered'  num times hit:'38' +
+ 
+(1 row)
+
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'reset', dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'skip', '', '', '', 1, 100, 0, dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+-- Reads blocks only for cols: i int
+COPY aoco (i) TO '/dev/null';
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'status', dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+                                                                                                                  gp_inject_fault                                                                                                                   
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Success: fault name:'AppendOnlyStorageRead_ReadNextBlock_success' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'100' extra arg:'0' fault injection state:'triggered'  num times hit:'13' +
+ 
+(1 row)
+
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'reset', dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+-- Ensure that a dropped column is not scanned.
+ALTER TABLE aoco DROP COLUMN j;
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'skip', '', '', '', 1, 100, 0, dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+COPY aoco TO '/dev/null';
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'status', dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+                                                                                                                  gp_inject_fault                                                                                                                   
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Success: fault name:'AppendOnlyStorageRead_ReadNextBlock_success' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'100' extra arg:'0' fault injection state:'triggered'  num times hit:'26' +
+ 
+(1 row)
+
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'reset', dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+

--- a/src/test/regress/sql/aoco_projection.sql
+++ b/src/test/regress/sql/aoco_projection.sql
@@ -1,0 +1,118 @@
+-- Tests to validate column projection for various operations
+
+-- Tests for COPY TO (SELECT <...> FROM <aoco_table>) TO ..
+
+CREATE TABLE aoco(i int, j bigint, k int) WITH (appendonly=true, orientation=column);
+INSERT INTO aoco SELECT 0, i, 1 FROM generate_series(1, 100000) i;
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'skip', '', '', '', 1, 100, 0, dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+
+-- Reads all blocks in the table as all columns are specified.
+COPY (SELECT * FROM aoco) TO '/dev/null';
+
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'status', dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'reset', dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'skip', '', '', '', 1, 100, 0, dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+
+-- Reads all blocks in the table as all columns are specified.
+COPY (SELECT i,j,k FROM aoco) TO '/dev/null';
+
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'status', dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'reset', dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'skip', '', '', '', 1, 100, 0, dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+
+-- Reads blocks only for cols: i int, j bigint
+COPY (SELECT i,j FROM aoco) TO '/dev/null';
+
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'status', dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'reset', dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'skip', '', '', '', 1, 100, 0, dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+
+-- Reads blocks only for cols: i int
+COPY (SELECT i FROM aoco) TO '/dev/null';
+
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'status', dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'reset', dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'skip', '', '', '', 1, 100, 0, dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+
+-- Tests for COPY <aoco_table> (<col_list>) TO ..
+
+-- Reads all blocks in the table as all columns are implicitly specified.
+COPY aoco TO '/dev/null';
+
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'status', dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'reset', dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'skip', '', '', '', 1, 100, 0, dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+
+-- Reads all blocks in the table as all columns are specified.
+COPY aoco (i,j,k) TO '/dev/null';
+
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'status', dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'reset', dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'skip', '', '', '', 1, 100, 0, dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+
+-- Reads blocks only for cols: i int, j bigint
+COPY aoco (i,j) TO '/dev/null';
+
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'status', dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'reset', dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'skip', '', '', '', 1, 100, 0, dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+
+-- Reads blocks only for cols: i int
+COPY aoco (i) TO '/dev/null';
+
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'status', dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'reset', dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+
+
+-- Ensure that a dropped column is not scanned.
+ALTER TABLE aoco DROP COLUMN j;
+
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'skip', '', '', '', 1, 100, 0, dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+
+COPY aoco TO '/dev/null';
+
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'status', dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'reset', dbid)
+    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';


### PR DESCRIPTION
This commit implements the patch discussed in https://github.com/greenplum-db/gpdb/issues/6193#issuecomment-437487173 and backports the regression tests from d2623d889c18711b679626116d97ebf40e296ca6
    
In addition to improving performance by passing only the required columns for a table scan, this fixes the issue described in https://github.com/greenplum-db/gpdb/issues/6193 where COPY TO attempted to scan and decompress a dropped column without encoding information, resulting in the error

`ERROR:  decompression information missing (cdbappendonlystorageread.c:1417)`.