### PR TITLE
pfree() the pstrdup()'d string userDoption

### DIFF
--- a/src/backend/bootstrap/bootstrap.c
+++ b/src/backend/bootstrap/bootstrap.c
@@ -353,10 +353,11 @@ AuxiliaryProcessMain(int argc, char *argv[])
 		if (!SelectConfigFiles(userDoption, progname))
 			proc_exit(1);
 	}
+
 	if (userDoption)
 	{
 		/* userDoption isn't used any more */
-		free(userDoption);
+		pfree(userDoption);
 		userDoption = NULL;
 	}
 


### PR DESCRIPTION
```
$ postgres --boot -D ~/greenplum-db-data/gpseg-1
LOG:  gp_role forced to 'utility' in single-user mode
free(): invalid pointer
Aborted (core dumped)
```