### PR TITLE
Docs pg appendonly changes

### DIFF
--- a/gpdb-doc/markdown/ref_guide/system_catalogs/pg_appendonly.html.md
+++ b/gpdb-doc/markdown/ref_guide/system_catalogs/pg_appendonly.html.md
@@ -5,16 +5,9 @@ The `pg_appendonly` table contains information about the storage options and oth
 |column|type|references|description|
 |------|----|----------|-----------|
 |`relid`|oid| |The table object identifier \(OID\) of the compressed table.|
-|`blocksize`|integer| |Block size used for compression of append-optimized tables. Valid values are 8K - 2M. Default is `32K`.|
-|`compresslevel`|smallint| |The compression level, with compression ratio increasing from 1 to 19. When `quicklz`<sup>1</sup> is specified for compresstype, valid values are 1 or 3. With `zlib` specified, valid values are 1-9. When `zstd` is specified, valid values are 1-19.|
 |`majorversion`|smallint| |The major version number of the pg\_appendonly table.|
 |`minorversion`|smallint| |The minor version number of the pg\_appendonly table.|
-|`checksum`|boolean| |A checksum value that is stored to compare the state of a block of data at compression time and at scan time to ensure data integrity.|
-|`compresstype`|text| |Type of compression used to compress append-optimized tables. Valid values are:<br/><br/>-   `none` \(no compression\)<br/><br/>-   `rle_type` \(run-length encoding compression\)<br/><br/>-   `zlib` \(gzip compression\)<br/><br/>-   `zstd` \(Zstandard compression\)<br/><br/>-   `quicklz`<sup>1</sup>|
-|`segrelid`|oid| |Table on-disk segment file id.|
 |`segidxid`|oid| |Index on-disk segment file id.|
-|`blkdirrelid`|oid| |Block used for on-disk column-oriented table file.|
-|`blkdiridxid`|oid| |Block used for on-disk column-oriented index file.|
 |`visimaprelid`|oid| |Visibility map for the table.|
 |`visimapidxid`|oid| |B-tree index on the visibility map.|
 

--- a/gpdb-doc/markdown/ref_guide/system_catalogs/pg_appendonly.html.md
+++ b/gpdb-doc/markdown/ref_guide/system_catalogs/pg_appendonly.html.md
@@ -4,7 +4,7 @@ The `pg_appendonly` table contains information about the storage options and oth
 
 |column|type|references|description|
 |------|----|----------|-----------|
-|`relid`|oid| |The table object identifier \(OID\) of the compressed table.|
+|`relid`|oid| |The table object identifier \(OID\) of the table.|
 |`segrelid`|oid| |Table on-disk segment file id.|
 |`segidxid`|oid| |Index on-disk segment file id.|
 |`blkdirrelid`|oid| |Block used for on-disk column-oriented table file.|

--- a/gpdb-doc/markdown/ref_guide/system_catalogs/pg_appendonly.html.md
+++ b/gpdb-doc/markdown/ref_guide/system_catalogs/pg_appendonly.html.md
@@ -5,8 +5,6 @@ The `pg_appendonly` table contains information about the storage options and oth
 |column|type|references|description|
 |------|----|----------|-----------|
 |`relid`|oid| |The table object identifier \(OID\) of the compressed table.|
-|`majorversion`|smallint| |The major version number of the pg\_appendonly table.|
-|`minorversion`|smallint| |The minor version number of the pg\_appendonly table.|
 |`segrelid`|oid| |Table on-disk segment file id.|
 |`segidxid`|oid| |Index on-disk segment file id.|
 |`blkdirrelid`|oid| |Block used for on-disk column-oriented table file.|

--- a/gpdb-doc/markdown/ref_guide/system_catalogs/pg_appendonly.html.md
+++ b/gpdb-doc/markdown/ref_guide/system_catalogs/pg_appendonly.html.md
@@ -7,7 +7,10 @@ The `pg_appendonly` table contains information about the storage options and oth
 |`relid`|oid| |The table object identifier \(OID\) of the compressed table.|
 |`majorversion`|smallint| |The major version number of the pg\_appendonly table.|
 |`minorversion`|smallint| |The minor version number of the pg\_appendonly table.|
+|`segrelid`|oid| |Table on-disk segment file id.|
 |`segidxid`|oid| |Index on-disk segment file id.|
+|`blkdirrelid`|oid| |Block used for on-disk column-oriented table file.|
+|`blkdiridxid`|oid| |Block used for on-disk column-oriented index file.|
 |`visimaprelid`|oid| |Visibility map for the table.|
 |`visimapidxid`|oid| |B-tree index on the visibility map.|
 


### PR DESCRIPTION
Documenting the rest of the changes from PR https://github.com/greenplum-db/gpdb/pull/14713
The following columns have also been removed from pg_appendonly:
```
|`blocksize`|integer| |Block size used for compression of append-optimized tables. Valid values are 8K - 2M. Default is `32K`.|
|`compresslevel`|smallint| |The compression level, with compression ratio increasing from 1 to 19. When `quicklz`<sup>1</sup> is specified for compresstype, valid values are 1 or 3. With `zlib` specified, valid values are 1-9. When `zstd` is specified, valid values are 1-19.|
|`checksum`|boolean| |A checksum value that is stored to compare the state of a block of data at compression time and at scan time to ensure data integrity.|
|`compresstype`|text| |Type of compression used to compress append-optimized tables. Valid values are:<br/><br/>-   `none` \(no compression\)<br/><br/>-   `rle_type` \(run-length encoding compression\)<br/><br/>-   `zlib` \(gzip compression\)<br/><br/>-   `zstd` \(Zstandard compression\)<br/><br/>-   `quicklz`<sup>1</sup>|
```


