### PR TITLE
Fix syntax error with CREATE MATERIALIZED VIEW

### DIFF
--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -6551,7 +6551,7 @@ CreateMatViewStmt:
 
 					$$ = (Node *) ctas;
 				}
-		| CREATE OptNoLog MATERIALIZED VIEW IF_P NOT EXISTS create_mv_target AS SelectStmt opt_with_data
+		| CREATE OptNoLog MATERIALIZED VIEW IF_P NOT EXISTS create_mv_target AS SelectStmt opt_with_data OptDistributedBy
 				{
 					CreateTableAsStmt *ctas = makeNode(CreateTableAsStmt);
 					ctas->query = $10;
@@ -6562,6 +6562,8 @@ CreateMatViewStmt:
 					/* cram additional flags into the IntoClause */
 					$8->rel->relpersistence = $2;
 					$8->skipData = !($11);
+					ctas->into->distributedBy = $12;
+
 					$$ = (Node *) ctas;
 				}
 		;

--- a/src/test/regress/expected/matview.out
+++ b/src/test/regress/expected/matview.out
@@ -19,7 +19,7 @@ SELECT * FROM mvtest_tv ORDER BY type;
 
 -- create a materialized view with no data, and confirm correct behavior
 EXPLAIN (costs off)
-  CREATE MATERIALIZED VIEW mvtest_tm AS SELECT type, sum(amt) AS totamt FROM mvtest_t GROUP BY type WITH NO DATA distributed by(type);
+  CREATE MATERIALIZED VIEW IF NOT EXISTS mvtest_tm AS SELECT type, sum(amt) AS totamt FROM mvtest_t GROUP BY type WITH NO DATA distributed by(type);
                       QUERY PLAN                      
 ------------------------------------------------------
  HashAggregate
@@ -30,7 +30,7 @@ EXPLAIN (costs off)
  Optimizer: Postgres query optimizer
 (6 rows)
 
-CREATE MATERIALIZED VIEW mvtest_tm AS SELECT type, sum(amt) AS totamt FROM mvtest_t GROUP BY type WITH NO DATA distributed by(type);
+CREATE MATERIALIZED VIEW IF NOT EXISTS mvtest_tm AS SELECT type, sum(amt) AS totamt FROM mvtest_t GROUP BY type WITH NO DATA distributed by(type);
 SELECT relispopulated FROM pg_class WHERE oid = 'mvtest_tm'::regclass;
  relispopulated 
 ----------------

--- a/src/test/regress/expected/matview_ao.out
+++ b/src/test/regress/expected/matview_ao.out
@@ -7,7 +7,7 @@ INSERT INTO t_matview_ao VALUES
   (3, 'y', 5),
   (4, 'y', 7),
   (5, 'z', 11);
-CREATE MATERIALIZED VIEW m_heap AS SELECT type, sum(amt) AS totamt FROM t_matview_ao GROUP BY type WITH NO DATA distributed by(type);
+CREATE MATERIALIZED VIEW IF NOT EXISTS m_heap AS SELECT type, sum(amt) AS totamt FROM t_matview_ao GROUP BY type WITH NO DATA distributed by(type);
 CREATE UNIQUE INDEX m_heap_index ON m_heap(type);
 SELECT * from m_heap;
 ERROR:  materialized view "m_heap" has not been populated
@@ -54,7 +54,7 @@ SELECT * FROM m_heap;
  z    |     11
 (3 rows)
 
-CREATE MATERIALIZED VIEW m_ao with (appendonly=true) AS SELECT type, sum(amt) AS totamt FROM t_matview_ao GROUP BY type WITH NO DATA  distributed by(type);
+CREATE MATERIALIZED VIEW IF NOT EXISTS m_ao with (appendonly=true) AS SELECT type, sum(amt) AS totamt FROM t_matview_ao GROUP BY type WITH NO DATA  distributed by(type);
 SELECT * from m_ao;
 ERROR:  materialized view "m_ao" has not been populated
 HINT:  Use the REFRESH MATERIALIZED VIEW command.
@@ -80,7 +80,7 @@ SELECT * FROM m_ao;
  z    |     11
 (3 rows)
 
-CREATE MATERIALIZED VIEW m_aocs with (appendonly=true, orientation=column) AS SELECT type, sum(amt) AS totamt FROM t_matview_ao GROUP BY type WITH NO DATA  distributed by(type);
+CREATE MATERIALIZED VIEW IF NOT EXISTS m_aocs with (appendonly=true, orientation=column) AS SELECT type, sum(amt) AS totamt FROM t_matview_ao GROUP BY type WITH NO DATA  distributed by(type);
 SELECT * from m_aocs;
 ERROR:  materialized view "m_aocs" has not been populated
 HINT:  Use the REFRESH MATERIALIZED VIEW command.

--- a/src/test/regress/expected/matview_optimizer.out
+++ b/src/test/regress/expected/matview_optimizer.out
@@ -19,7 +19,7 @@ SELECT * FROM mvtest_tv ORDER BY type;
 
 -- create a materialized view with no data, and confirm correct behavior
 EXPLAIN (costs off)
-  CREATE MATERIALIZED VIEW mvtest_tm AS SELECT type, sum(amt) AS totamt FROM mvtest_t GROUP BY type WITH NO DATA distributed by(type);
+  CREATE MATERIALIZED VIEW IF NOT EXISTS mvtest_tm AS SELECT type, sum(amt) AS totamt FROM mvtest_t GROUP BY type WITH NO DATA distributed by(type);
                          QUERY PLAN                         
 ------------------------------------------------------------
  GroupAggregate
@@ -32,7 +32,7 @@ EXPLAIN (costs off)
  Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
 (8 rows)
 
-CREATE MATERIALIZED VIEW mvtest_tm AS SELECT type, sum(amt) AS totamt FROM mvtest_t GROUP BY type WITH NO DATA distributed by(type);
+CREATE MATERIALIZED VIEW IF NOT EXISTS mvtest_tm AS SELECT type, sum(amt) AS totamt FROM mvtest_t GROUP BY type WITH NO DATA distributed by(type);
 SELECT relispopulated FROM pg_class WHERE oid = 'mvtest_tm'::regclass;
  relispopulated 
 ----------------

--- a/src/test/regress/sql/matview.sql
+++ b/src/test/regress/sql/matview.sql
@@ -14,8 +14,8 @@ SELECT * FROM mvtest_tv ORDER BY type;
 
 -- create a materialized view with no data, and confirm correct behavior
 EXPLAIN (costs off)
-  CREATE MATERIALIZED VIEW mvtest_tm AS SELECT type, sum(amt) AS totamt FROM mvtest_t GROUP BY type WITH NO DATA distributed by(type);
-CREATE MATERIALIZED VIEW mvtest_tm AS SELECT type, sum(amt) AS totamt FROM mvtest_t GROUP BY type WITH NO DATA distributed by(type);
+  CREATE MATERIALIZED VIEW IF NOT EXISTS mvtest_tm AS SELECT type, sum(amt) AS totamt FROM mvtest_t GROUP BY type WITH NO DATA distributed by(type);
+CREATE MATERIALIZED VIEW IF NOT EXISTS mvtest_tm AS SELECT type, sum(amt) AS totamt FROM mvtest_t GROUP BY type WITH NO DATA distributed by(type);
 SELECT relispopulated FROM pg_class WHERE oid = 'mvtest_tm'::regclass;
 SELECT * FROM mvtest_tm ORDER BY type;
 REFRESH MATERIALIZED VIEW mvtest_tm;

--- a/src/test/regress/sql/matview_ao.sql
+++ b/src/test/regress/sql/matview_ao.sql
@@ -8,7 +8,7 @@ INSERT INTO t_matview_ao VALUES
   (4, 'y', 7),
   (5, 'z', 11);
 
-CREATE MATERIALIZED VIEW m_heap AS SELECT type, sum(amt) AS totamt FROM t_matview_ao GROUP BY type WITH NO DATA distributed by(type);
+CREATE MATERIALIZED VIEW IF NOT EXISTS m_heap AS SELECT type, sum(amt) AS totamt FROM t_matview_ao GROUP BY type WITH NO DATA distributed by(type);
 CREATE UNIQUE INDEX m_heap_index ON m_heap(type);
 SELECT * from m_heap;
 REFRESH MATERIALIZED VIEW CONCURRENTLY m_heap;
@@ -23,7 +23,7 @@ select relispopulated from gp_dist_random('pg_class') where relname = 'm_heap';
 REFRESH MATERIALIZED VIEW m_heap;
 SELECT * FROM m_heap;
 
-CREATE MATERIALIZED VIEW m_ao with (appendonly=true) AS SELECT type, sum(amt) AS totamt FROM t_matview_ao GROUP BY type WITH NO DATA  distributed by(type);
+CREATE MATERIALIZED VIEW IF NOT EXISTS m_ao with (appendonly=true) AS SELECT type, sum(amt) AS totamt FROM t_matview_ao GROUP BY type WITH NO DATA  distributed by(type);
 SELECT * from m_ao;
 REFRESH MATERIALIZED VIEW m_ao;
 SELECT * FROM m_ao;
@@ -33,7 +33,7 @@ REFRESH MATERIALIZED VIEW m_ao;
 SELECT * FROM m_ao;
 
 
-CREATE MATERIALIZED VIEW m_aocs with (appendonly=true, orientation=column) AS SELECT type, sum(amt) AS totamt FROM t_matview_ao GROUP BY type WITH NO DATA  distributed by(type);
+CREATE MATERIALIZED VIEW IF NOT EXISTS m_aocs with (appendonly=true, orientation=column) AS SELECT type, sum(amt) AS totamt FROM t_matview_ao GROUP BY type WITH NO DATA  distributed by(type);
 SELECT * from m_aocs;
 REFRESH MATERIALIZED VIEW m_aocs;
 SELECT * FROM m_aocs;


### PR DESCRIPTION
Allow DISTRIBUTED BY when using the CREATE MATERIALIZED VIEW IF NOT EXISTS SYNTAX.

Resolves error:

```
CREATE MATERIALIZED VIEW IF NOT EXISTS mvtest AS SELECT * FROM mvtest_tvvmv DISTRIBUTED RANDOMLY; 
ERROR:  syntax error at or near "DISTRIBUTED"
```