### PR TITLE
Fall back in Orca for queries with RTE of type TableFunc

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
@@ -3314,6 +3314,7 @@ CTranslatorQueryToDXL::UnsupportedRTEKind(RTEKind rtekind)
 					   GPOS_WSZ_LIT("RangeTableEntry of type Void"));
 		}
 		case RTE_TABLEFUNCTION:
+		case RTE_TABLEFUNC:
 		{
 			GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiQuery2DXLUnsupportedFeature,
 					   GPOS_WSZ_LIT("RangeTableEntry of type Table Function"));

--- a/src/test/regress/expected/qp_orca_fallback.out
+++ b/src/test/regress/expected/qp_orca_fallback.out
@@ -239,6 +239,14 @@ explain select count(*) from foo group by a;
  Optimizer: Postgres query optimizer
 (5 rows)
 
+-- Orca should fallback for RTE_TABLEFUNC RTE type
+explain SELECT * FROM xmltable('/root' passing '' COLUMNS element text);
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Table Function Scan on "xmltable"  (cost=0.00..1.00 rows=100 width=32)
+ Optimizer: Postgres query optimizer
+(2 rows)
+
 create table ext_part(a int) partition by list(a);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.

--- a/src/test/regress/expected/qp_orca_fallback_optimizer.out
+++ b/src/test/regress/expected/qp_orca_fallback_optimizer.out
@@ -285,6 +285,16 @@ DETAIL:  No plan has been computed for required properties
  Optimizer: Postgres query optimizer
 (5 rows)
 
+-- Orca should fallback for RTE_TABLEFUNC RTE type
+explain SELECT * FROM xmltable('/root' passing '' COLUMNS element text);
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: RangeTableEntry of type Table Function
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Table Function Scan on "xmltable"  (cost=0.00..1.00 rows=100 width=32)
+ Optimizer: Postgres query optimizer
+(2 rows)
+
 create table ext_part(a int) partition by list(a);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.

--- a/src/test/regress/sql/qp_orca_fallback.sql
+++ b/src/test/regress/sql/qp_orca_fallback.sql
@@ -103,6 +103,9 @@ set optimizer_enable_hashagg = off;
 set optimizer_enable_groupagg = off;
 explain select count(*) from foo group by a;
 
+-- Orca should fallback for RTE_TABLEFUNC RTE type
+explain SELECT * FROM xmltable('/root' passing '' COLUMNS element text);
+
 create table ext_part(a int) partition by list(a);
 create table p1(a int);
 create external web table p2_ext (like p1) EXECUTE 'cat something.txt' FORMAT 'TEXT';


### PR DESCRIPTION
Previously, Orca would crash if encountering this. For now, fall back similarly to what we do for RTE_TABLEFUNCTION.

Example query: explain SELECT * FROM xmltable('/root' passing '' COLUMNS element text);

This actually fell back correctly in retail build, but we were hitting a `__builtin_unreachable` call, which is undefined behavior, so we were likely just getting lucky.

Fixes issue reported in https://groups.google.com/a/greenplum.org/g/gpdb-dev/c/4F8GUSs04L8