### PR TITLE
Move oid_wraparound to the bottom of the schedule

### DIFF
--- a/src/backend/commands/schemacmds.c
+++ b/src/backend/commands/schemacmds.c
@@ -311,6 +311,10 @@ RemoveSchemaById(Oid schemaOid)
 	 * Remove all persistent error logs belonging to the the schema.
 	 */
 	PersistentErrorLogDelete(MyDatabaseId, schemaOid, NULL);
+
+	/* MPP-6929: metadata tracking */
+	if (Gp_role == GP_ROLE_DISPATCH)
+		MetaTrackDropObject(NamespaceRelationId, schemaOid);
 }
 
 

--- a/src/test/regress/expected/pg_stat_last_operation.out
+++ b/src/test/regress/expected/pg_stat_last_operation.out
@@ -15,11 +15,23 @@ FROM
 		)
 ORDER BY
 	statime;  
+CREATE VIEW
+	pg_stat_last_operation_testview_schema AS
+SELECT lo.staactionname,
+       lo.stasubtype,
+       ns.nspname
+FROM   pg_stat_last_operation lo
+       join pg_class c
+         ON lo.classid = c.oid
+       join pg_namespace ns
+         ON c.relname = 'pg_namespace'
+            AND lo.objid = ns.oid;
 SELECT * FROM pg_stat_last_operation_testview WHERE actionname = 'CREATE';
-             objname             | actionname | subtype 
----------------------------------+------------+---------
- pg_stat_last_operation_testview | CREATE     | VIEW
-(1 row)
+                objname                 | actionname | subtype 
+----------------------------------------+------------+---------
+ pg_stat_last_operation_testview        | CREATE     | VIEW
+ pg_stat_last_operation_testview_schema | CREATE     | VIEW
+(2 rows)
 
  
 -- CREATE TABLE
@@ -93,7 +105,8 @@ SELECT * FROM pg_stat_last_operation_testview WHERE actionname = 'CREATE';
  mdt_all_types_col021_seq                  | CREATE     | SEQUENCE
  mdt_all_types_col023_seq                  | CREATE     | SEQUENCE
  mdt_all_types                             | CREATE     | TABLE
-(12 rows)
+ pg_stat_last_operation_testview_schema    | CREATE     | VIEW
+(13 rows)
 
 -- CREATE TABLE .. PARTITION OF
 CREATE TABLE mdt_test_newpart PARTITION OF mdt_test_part1 FOR VALUES IN ('X');
@@ -224,4 +237,20 @@ SELECT * FROM pg_stat_last_operation_testview WHERE objname like ('mdt_%');
  mdt_test_detach | CREATE     | TABLE
  mdt_test_detach | PARTITION  | DETACH
 (2 rows)
+
+-- SCHEMA
+CREATE SCHEMA mdt_schema;
+SELECT * FROM pg_stat_last_operation_testview_schema WHERE nspname LIKE 'mdt_%';
+ staactionname | stasubtype |  nspname   
+---------------+------------+------------
+ CREATE        | SCHEMA     | mdt_schema
+ CREATE        | SCHEMA     | mdt_test
+(2 rows)
+
+DROP SCHEMA mdt_schema;
+SELECT * FROM pg_stat_last_operation_testview_schema WHERE nspname LIKE 'mdt_%';
+ staactionname | stasubtype | nspname  
+---------------+------------+----------
+ CREATE        | SCHEMA     | mdt_test
+(1 row)
 

--- a/src/test/regress/sql/pg_stat_last_operation.sql
+++ b/src/test/regress/sql/pg_stat_last_operation.sql
@@ -17,6 +17,18 @@ FROM
 ORDER BY
 	statime;  
 
+CREATE VIEW
+	pg_stat_last_operation_testview_schema AS
+SELECT lo.staactionname,
+       lo.stasubtype,
+       ns.nspname
+FROM   pg_stat_last_operation lo
+       join pg_class c
+         ON lo.classid = c.oid
+       join pg_namespace ns
+         ON c.relname = 'pg_namespace'
+            AND lo.objid = ns.oid;
+
 SELECT * FROM pg_stat_last_operation_testview WHERE actionname = 'CREATE';
  
 -- CREATE TABLE
@@ -119,3 +131,9 @@ DROP TABLE mdt_all_types;
 SELECT * FROM pg_stat_last_operation_testview WHERE objname like ('mdt_%');
 DROP TABLE mdt_test_part1;
 SELECT * FROM pg_stat_last_operation_testview WHERE objname like ('mdt_%');
+
+-- SCHEMA
+CREATE SCHEMA mdt_schema;
+SELECT * FROM pg_stat_last_operation_testview_schema WHERE nspname LIKE 'mdt_%';
+DROP SCHEMA mdt_schema;
+SELECT * FROM pg_stat_last_operation_testview_schema WHERE nspname LIKE 'mdt_%';


### PR DESCRIPTION
Updated
===========
The real issue see https://github.com/greenplum-db/gpdb/pull/14899#issuecomment-1435299158

Original PR description
===========

The test oid_wraparound consumes all remaining OIDs and wraps it around. Then, we would be reusing the OIDs we used before. That could lead to flakiness to subsequent tests such as the one we saw in `uao_dml_unique_index_update_column` (could happen to `uao_dml_unique_index_update_row` too):

```
 create schema uao_dml_unique_index_update_ao_column;
+DETAIL:  Key (classid, objid, staactionname)=(2615, 27835, CREATE) already exists. 
+ERROR:  duplicate key value violates unique constraint "pg_statlastop_classid_objid_staactionname_index"
```

We are reusing the same OID of the schema we created in a previous test 'foreign_data':

```sql
regression=# select * from pg_stat_last_operation where objid = 27835;
 classid | objid | staactionname | stasysid |        stausename         | stasubtype |            statime
---------+-------+---------------+----------+---------------------------+------------+-------------------------------
    2615 | 27835 | CREATE        |    27376 | regress_foreign_data_user | SCHEMA     | 2023-02-03 03:31:45.110291+00
(1 row)
```

Now moving the oid_wraparound test to the bottom of the greenplum schedule, which is also the last schedule to run.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
