### PR TITLE
[Releng] [6X] Run 6X_STABLE_centos7 pipeline every day

### DIFF
--- a/concourse/pipelines/templates/gpdb-tpl.yml
+++ b/concourse/pipelines/templates/gpdb-tpl.yml
@@ -198,11 +198,11 @@ anchors:
 groups:
 - name: all
   jobs:
-  - check_format
   - compile_gpdb_[[ os_type ]]
   - prepare_binary_swap_gpdb_[[ os_type ]]
   - test_gpdb_clients_[[ os_type ]]
   {% if os_type == default_os_type %}
+  - check_format
   - compile_gpdb_photon3
   - compile_gpdb_sles12
   - test_gpdb_clients_sles12
@@ -866,12 +866,14 @@ jobs:
 ##         |_|
 ## ======================================================================
 
+{% if os_type == default_os_type %}
 - name: check_format
   plan:
     - get: gpdb_src
       trigger: true
     - task: check_format
       file: gpdb_src/concourse/tasks/check_format.yml
+{% endif %}
 
 ## ======================================================================
 ##   ____                      _ _
@@ -888,7 +890,9 @@ jobs:
       steps:
       - get: gpdb_src
         passed:
+          {% if os_type == default_os_type %}
           - check_format
+          {% endif %}
         {% if os_type != default_os_type and os_type != "centos7" and pipeline_target == "prod" %}
         trigger: false
         {% else %}
@@ -1040,7 +1044,9 @@ jobs:
           {% endif %}
           - get: gpdb_src
             passed:
+              {% if os_type == default_os_type %}
               - check_format
+              {% endif %}
             {% if os_type != default_os_type and os_type != "centos7" and pipeline_target == "prod" %}
             trigger: false
             {% else %}
@@ -1073,7 +1079,9 @@ jobs:
         {% endif %}
         - get: gpdb_src
           passed:
+            {% if os_type == default_os_type %}
             - check_format
+            {% endif %}
           {% if os_type != default_os_type and os_type != "centos7" and pipeline_target == "prod" %}
           trigger: false
           {% else %}
@@ -2212,7 +2220,9 @@ jobs:
       - get: gpdb_src
         trigger: true
         passed:
+        {% if os_type == default_os_type %}
         - check_format
+        {% endif %}
         - compile_gpdb_[[ os_type ]]
         {% if os_type == default_os_type %}
         - compile_gpdb_photon3

--- a/concourse/pipelines/templates/gpdb-tpl.yml
+++ b/concourse/pipelines/templates/gpdb-tpl.yml
@@ -836,14 +836,17 @@ resources:
     regexp: gp-internal-artifacts/postgres-fdw-dependencies/postgresql-(10.4).tar.gz
 {% endif %}
 
-{% if os_type != default_os_type and os_type != "centos7" and pipeline_target == "prod" %}
+{% if os_type != default_os_type and pipeline_target == "prod" %}
 - name: reduced-frequency-trigger
   type: time
   source:
     location: America/Los_Angeles
     start: ((reduced-frequency-trigger-start-[[ os_type ]]))
     stop: ((reduced-frequency-trigger-stop-[[ os_type ]]))
-    interval: 168h
+    {% if os_type != "centos7" %}
+    days: [Monday]
+    {% else %}
+    days: [Sunday, Monday, Tuesday, Wednesday, Thursday, Friday, Saturday]
 {% endif %}
 
 ## ======================================================================
@@ -893,12 +896,12 @@ jobs:
           {% if os_type == default_os_type %}
           - check_format
           {% endif %}
-        {% if os_type != default_os_type and os_type != "centos7" and pipeline_target == "prod" %}
+        {% if os_type != default_os_type and pipeline_target == "prod" %}
         trigger: false
         {% else %}
         trigger: true
         {% endif %}
-      {% if os_type != default_os_type and os_type != "centos7" and pipeline_target == "prod" %}
+      {% if os_type != default_os_type and pipeline_target == "prod" %}
       - get: reduced-frequency-trigger
         trigger: true
       {% endif %}
@@ -1038,7 +1041,7 @@ jobs:
   plan:
     - in_parallel:
         steps:
-          {% if os_type != default_os_type and os_type != "centos7" and pipeline_target == "prod" %}
+          {% if os_type != default_os_type and pipeline_target == "prod" %}
           - get: reduced-frequency-trigger
             trigger: true
           {% endif %}
@@ -1047,7 +1050,7 @@ jobs:
               {% if os_type == default_os_type %}
               - check_format
               {% endif %}
-            {% if os_type != default_os_type and os_type != "centos7" and pipeline_target == "prod" %}
+            {% if os_type != default_os_type and pipeline_target == "prod" %}
             trigger: false
             {% else %}
             trigger: true
@@ -1073,7 +1076,7 @@ jobs:
   plan:
     - in_parallel:
         steps:
-        {% if os_type != default_os_type and os_type != "centos7" and pipeline_target == "prod" %}
+        {% if os_type != default_os_type and pipeline_target == "prod" %}
         - get: reduced-frequency-trigger
           trigger: true
         {% endif %}
@@ -1082,7 +1085,7 @@ jobs:
             {% if os_type == default_os_type %}
             - check_format
             {% endif %}
-          {% if os_type != default_os_type and os_type != "centos7" and pipeline_target == "prod" %}
+          {% if os_type != default_os_type and pipeline_target == "prod" %}
           trigger: false
           {% else %}
           trigger: true

--- a/concourse/vars/common_prod.yml
+++ b/concourse/vars/common_prod.yml
@@ -26,14 +26,14 @@ gpdb-git-branch: 6X_STABLE
 gpdb-git-remote: https://github.com/greenplum-db/gpdb.git
 rc-build-type: debug
 rc-build-type-gcs: ".debug"
-reduced-frequency-trigger-start-rhel8: 5:00 AM
-reduced-frequency-trigger-stop-rhel8: 5:59 AM
-reduced-frequency-trigger-start-ubuntu18.04: 8:00 AM
-reduced-frequency-trigger-stop-ubuntu18.04: 8:59 AM
-reduced-frequency-trigger-start-centos7: 11:00 AM
-reduced-frequency-trigger-stop-centos7: 11:59 AM
-reduced-frequency-trigger-start-centos6: 2:00 PM
-reduced-frequency-trigger-stop-centos6: 2:59 PM
+reduced-frequency-trigger-start-rhel8: 0:00 AM
+reduced-frequency-trigger-stop-rhel8: 0:59 AM
+reduced-frequency-trigger-start-ubuntu18.04: 2:00 AM
+reduced-frequency-trigger-stop-ubuntu18.04: 2:59 AM
+reduced-frequency-trigger-start-centos7: 4:00 AM
+reduced-frequency-trigger-stop-centos7: 4:59 AM
+reduced-frequency-trigger-start-centos6: 6:00 AM
+reduced-frequency-trigger-stop-centos6: 6:59 AM
 gpdb_src-trigger-flag: true
 configure_flags: "--enable-cassert --enable-tap-tests"
 configure_flags_with_extensions: "--enable-cassert --enable-tap-tests --enable-debug-extensions"


### PR DESCRIPTION
Run 6X_STABLE_centos on every day on 4:00 am
Run non default platform, and non centos7 job every Monday
6X_STABLE_rhel8:  0:00 am
6X_STABLE_ubuntu18.04:  2:00 am
6X_STABLE_centos6:  6:00 am

Only run check_format on default platform, the job are exactly same across all the supported platform, 
so there is no need to run them on all platform
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
