### PR TITLE
Fix incorrect result from hash join on char column

### DIFF
--- a/src/backend/gporca/data/dxl/minidump/HJN-DeeperOuter.mdp
+++ b/src/backend/gporca/data/dxl/minidump/HJN-DeeperOuter.mdp
@@ -353,10 +353,10 @@ SELECT z.*,x.* FROM x,y,z WHERE x.i=y.i AND x.i=z.i;
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="354">
+    <dxl:Plan Id="0" SpaceSize="326">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1293.001398" Rows="1.000000" Width="32"/>
+          <dxl:Cost StartupCost="0" TotalCost="1293.001519" Rows="1.000000" Width="32"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="18" Alias="i">
@@ -379,7 +379,7 @@ SELECT z.*,x.* FROM x,y,z WHERE x.i=y.i AND x.i=z.i;
         <dxl:SortingColumnList/>
         <dxl:HashJoin JoinType="Inner">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1293.001255" Rows="1.000000" Width="32"/>
+            <dxl:Cost StartupCost="0" TotalCost="1293.001375" Rows="1.000000" Width="32"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="18" Alias="i">
@@ -402,46 +402,15 @@ SELECT z.*,x.* FROM x,y,z WHERE x.i=y.i AND x.i=z.i;
           <dxl:JoinFilter/>
           <dxl:HashCondList>
             <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-              <dxl:Ident ColId="18" ColName="i" TypeMdid="0.23.1.0"/>
               <dxl:Cast TypeMdid="0.23.1.0" FuncId="0.313.1.0">
-                <dxl:Ident ColId="9" ColName="i" TypeMdid="0.21.1.0"/>
+                <dxl:Ident ColId="0" ColName="i" TypeMdid="0.21.1.0"/>
               </dxl:Cast>
+              <dxl:Ident ColId="18" ColName="i" TypeMdid="0.23.1.0"/>
             </dxl:Comparison>
           </dxl:HashCondList>
-          <dxl:TableScan>
-            <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000023" Rows="1.000000" Width="16"/>
-            </dxl:Properties>
-            <dxl:ProjList>
-              <dxl:ProjElem ColId="18" Alias="i">
-                <dxl:Ident ColId="18" ColName="i" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="19" Alias="j">
-                <dxl:Ident ColId="19" ColName="j" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="20" Alias="k">
-                <dxl:Ident ColId="20" ColName="k" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-            </dxl:ProjList>
-            <dxl:Filter/>
-            <dxl:TableDescriptor Mdid="6.15210514.1.1" TableName="z">
-              <dxl:Columns>
-                <dxl:Column ColId="18" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
-                <dxl:Column ColId="19" Attno="2" ColName="j" TypeMdid="0.23.1.0"/>
-                <dxl:Column ColId="20" Attno="3" ColName="k" TypeMdid="0.23.1.0"/>
-                <dxl:Column ColId="21" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                <dxl:Column ColId="22" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                <dxl:Column ColId="23" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                <dxl:Column ColId="24" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                <dxl:Column ColId="25" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                <dxl:Column ColId="26" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                <dxl:Column ColId="27" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-              </dxl:Columns>
-            </dxl:TableDescriptor>
-          </dxl:TableScan>
           <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="862.000640" Rows="1.000000" Width="24"/>
+              <dxl:Cost StartupCost="0" TotalCost="862.000620" Rows="1.000000" Width="16"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="i">
@@ -450,22 +419,19 @@ SELECT z.*,x.* FROM x,y,z WHERE x.i=y.i AND x.i=z.i;
               <dxl:ProjElem ColId="1" Alias="j">
                 <dxl:Ident ColId="1" ColName="j" TypeMdid="0.21.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="9" Alias="i">
-                <dxl:Ident ColId="9" ColName="i" TypeMdid="0.21.1.0"/>
-              </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
             <dxl:SortingColumnList/>
             <dxl:HashExprList>
               <dxl:HashExpr>
                 <dxl:Cast TypeMdid="0.23.1.0" FuncId="0.313.1.0">
-                  <dxl:Ident ColId="9" ColName="i" TypeMdid="0.21.1.0"/>
+                  <dxl:Ident ColId="0" ColName="i" TypeMdid="0.21.1.0"/>
                 </dxl:Cast>
               </dxl:HashExpr>
             </dxl:HashExprList>
             <dxl:HashJoin JoinType="Inner">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="862.000602" Rows="1.000000" Width="24"/>
+                <dxl:Cost StartupCost="0" TotalCost="862.000588" Rows="1.000000" Width="16"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="i">
@@ -473,9 +439,6 @@ SELECT z.*,x.* FROM x,y,z WHERE x.i=y.i AND x.i=z.i;
                 </dxl:ProjElem>
                 <dxl:ProjElem ColId="1" Alias="j">
                   <dxl:Ident ColId="1" ColName="j" TypeMdid="0.21.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="9" Alias="i">
-                  <dxl:Ident ColId="9" ColName="i" TypeMdid="0.21.1.0"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
@@ -538,6 +501,37 @@ SELECT z.*,x.* FROM x,y,z WHERE x.i=y.i AND x.i=z.i;
               </dxl:TableScan>
             </dxl:HashJoin>
           </dxl:RedistributeMotion>
+          <dxl:TableScan>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.000023" Rows="1.000000" Width="16"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="18" Alias="i">
+                <dxl:Ident ColId="18" ColName="i" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="19" Alias="j">
+                <dxl:Ident ColId="19" ColName="j" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="20" Alias="k">
+                <dxl:Ident ColId="20" ColName="k" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:TableDescriptor Mdid="6.15210514.1.1" TableName="z">
+              <dxl:Columns>
+                <dxl:Column ColId="18" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="19" Attno="2" ColName="j" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="20" Attno="3" ColName="k" TypeMdid="0.23.1.0"/>
+                <dxl:Column ColId="21" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                <dxl:Column ColId="22" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                <dxl:Column ColId="23" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                <dxl:Column ColId="24" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                <dxl:Column ColId="25" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                <dxl:Column ColId="26" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                <dxl:Column ColId="27" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
         </dxl:HashJoin>
       </dxl:GatherMotion>
     </dxl:Plan>

--- a/src/backend/gporca/libgpopt/include/gpopt/mdcache/CMDAccessorUtils.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/mdcache/CMDAccessorUtils.h
@@ -44,6 +44,10 @@ public:
 	static BOOL FCastExists(CMDAccessor *md_accessor, IMDId *mdid_src,
 							IMDId *mdid_dest);
 
+	// check if srctype is binary-coercible to targettype.
+	static BOOL FBinaryCoercible(CMDAccessor *md_accessor, IMDId *mdid_src,
+								 IMDId *mdid_dest);
+
 	// does a scalar comparison object between given types exist
 	static BOOL FCmpExists(CMDAccessor *md_accessor, IMDId *left_mdid,
 						   IMDId *right_mdid, IMDType::ECmpType cmp_type);

--- a/src/backend/gporca/libgpopt/src/mdcache/CMDAccessorUtils.cpp
+++ b/src/backend/gporca/libgpopt/src/mdcache/CMDAccessorUtils.cpp
@@ -23,10 +23,10 @@
 #include "naucrates/exception.h"
 #include "naucrates/md/CMDIdGPDB.h"
 #include "naucrates/md/IMDAggregate.h"
+#include "naucrates/md/IMDCast.h"
 #include "naucrates/md/IMDFunction.h"
 #include "naucrates/md/IMDScCmp.h"
 #include "naucrates/md/IMDScalarOp.h"
-
 using namespace gpmd;
 using namespace gpos;
 using namespace gpopt;
@@ -83,7 +83,7 @@ CMDAccessorUtils::FCmpExists(CMDAccessor *md_accessor, IMDId *left_mdid,
 {
 	GPOS_ASSERT(nullptr != md_accessor);
 	GPOS_ASSERT(nullptr != left_mdid);
-	GPOS_ASSERT(nullptr != left_mdid);
+	GPOS_ASSERT(nullptr != right_mdid);
 	GPOS_ASSERT(IMDType::EcmptOther > cmp_type);
 
 	GPOS_TRY
@@ -113,7 +113,7 @@ CMDAccessorUtils::GetScCmpMdid(CMDAccessor *md_accessor, IMDId *left_mdid,
 {
 	GPOS_ASSERT(nullptr != md_accessor);
 	GPOS_ASSERT(nullptr != left_mdid);
-	GPOS_ASSERT(nullptr != left_mdid);
+	GPOS_ASSERT(nullptr != right_mdid);
 	GPOS_ASSERT(IMDType::EcmptOther > cmp_type);
 
 	IMDId *sc_cmp_mdid;
@@ -331,7 +331,7 @@ CMDAccessorUtils::ApplyCastsForScCmp(CMemoryPool *mp, CMDAccessor *md_accessor,
 //		CMDAccessorUtils::FCastExists
 //
 //	@doc:
-//		Does if a cast object between given source and destination types exists
+//		Check if a cast object between given source and destination types exists
 //
 //---------------------------------------------------------------------------
 BOOL
@@ -360,6 +360,30 @@ CMDAccessorUtils::FCastExists(CMDAccessor *md_accessor, IMDId *mdid_src,
 	GPOS_CATCH_END;
 }
 
+//---------------------------------------------------------------------------
+//	@function:
+//		CMDAccessorUtils::FCoercible
+//
+//	@doc:
+//		Check if srctype is binary-coercible to targettype.
+//      A cast object existing between srctype and
+//      targettype is a necessary condition
+//
+//---------------------------------------------------------------------------
+BOOL
+CMDAccessorUtils::FBinaryCoercible(CMDAccessor *md_accessor, IMDId *mdid_src,
+								   IMDId *mdid_dest)
+{
+	if (FCastExists(md_accessor, mdid_src, mdid_dest))
+	{
+		const IMDCast *pmdcast = md_accessor->Pmdcast(mdid_src, mdid_dest);
+		if (pmdcast->IsBinaryCoercible())
+		{
+			return true;
+		}
+	}
+	return false;
+}
 
 //---------------------------------------------------------------------------
 //	@function:

--- a/src/test/regress/expected/bfv_joins.out
+++ b/src/test/regress/expected/bfv_joins.out
@@ -3558,6 +3558,62 @@ where
 (0 rows)
 
 drop table t_13722;
+-- This test is introduced to verify incorrect result
+-- from hash join of char columns is fixed
+-- foo stores 'cd' of varchar
+-- bar stores 'cd ' of char
+-- baz stores 'cd  ' of text
+-- foo join condition: 'cd' of varchar is cast to bpchar, and stays 'cd'.
+-- bar join condition: 'cd ' of char is used for comparison, and becomes 'cd'.
+-- baz join condition:
+-- (1) First, 'cd  ' of text is cast to bpchar, and becomes 'cd  '.
+-- (2) Because it's used for comparison, the trailing spaces are removed, and becomes 'cd'.
+-- 'cd' matches 'cd' matches 'cd', so 1 row is returned.
+create table foo (varchar_3 varchar(3)) distributed by (varchar_3);
+create table bar (char_3 char(3)) distributed by (char_3);
+create table baz (text_any text) distributed by (text_any);
+insert into foo values ('cd'); -- 0 trailing spaces
+insert into bar values ('cd '); -- 1 trailing space
+insert into baz values ('cd  '); -- 2 trailing spaces
+explain select varchar_3, char_3 from foo join bar on varchar_3=char_3;
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=567.25..155836.25 rows=5055210 width=32)
+   ->  Hash Join  (cost=567.25..88433.45 rows=1685070 width=32)
+         Hash Cond: ((foo.varchar_3)::bpchar = bar.char_3)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..745.00 rows=23700 width=16)
+               Hash Key: foo.varchar_3
+               ->  Seq Scan on foo  (cost=0.00..271.00 rows=23700 width=16)
+         ->  Hash  (cost=271.00..271.00 rows=23700 width=16)
+               ->  Seq Scan on bar  (cost=0.00..271.00 rows=23700 width=16)
+ Optimizer: Postgres query optimizer
+(9 rows)
+
+select varchar_3, char_3 from foo join bar on varchar_3=char_3;
+ varchar_3 | char_3 
+-----------+--------
+ cd        | cd 
+(1 row)
+
+explain select char_3, text_any from bar join baz on char_3=text_any;
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=430.00..168082.25 rows=3754080 width=48)
+   ->  Hash Join  (cost=430.00..118027.85 rows=1251360 width=48)
+         Hash Cond: ((bar.char_3)::text = baz.text_any)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..745.00 rows=23700 width=16)
+               Hash Key: (bar.char_3)::text
+               ->  Seq Scan on bar  (cost=0.00..271.00 rows=23700 width=16)
+         ->  Hash  (cost=210.00..210.00 rows=17600 width=32)
+               ->  Seq Scan on baz  (cost=0.00..210.00 rows=17600 width=32)
+ Optimizer: Postgres query optimizer
+(9 rows)
+
+select char_3, text_any from bar join baz on char_3=text_any;
+ char_3 | text_any 
+--------+----------
+(0 rows)
+
 -- Clean up. None of the objects we create are very interesting to keep around.
 reset search_path;
 set client_min_messages='warning';

--- a/src/test/regress/expected/bfv_joins_optimizer.out
+++ b/src/test/regress/expected/bfv_joins_optimizer.out
@@ -3551,6 +3551,62 @@ where
 (0 rows)
 
 drop table t_13722;
+-- This test is introduced to verify incorrect result
+-- from hash join of char columns is fixed
+-- foo stores 'cd' of varchar
+-- bar stores 'cd ' of char
+-- baz stores 'cd  ' of text
+-- foo join condition: 'cd' of varchar is cast to bpchar, and stays 'cd'.
+-- bar join condition: 'cd ' of char is used for comparison, and becomes 'cd'.
+-- baz join condition:
+-- (1) First, 'cd  ' of text is cast to bpchar, and becomes 'cd  '.
+-- (2) Because it's used for comparison, the trailing spaces are removed, and becomes 'cd'.
+-- 'cd' matches 'cd' matches 'cd', so 1 row is returned.
+create table foo (varchar_3 varchar(3)) distributed by (varchar_3);
+create table bar (char_3 char(3)) distributed by (char_3);
+create table baz (text_any text) distributed by (text_any);
+insert into foo values ('cd'); -- 0 trailing spaces
+insert into bar values ('cd '); -- 1 trailing space
+insert into baz values ('cd  '); -- 2 trailing spaces
+explain select varchar_3, char_3 from foo join bar on varchar_3=char_3;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=16)
+   ->  Hash Join  (cost=0.00..862.00 rows=1 width=16)
+         Hash Cond: ((foo.varchar_3)::bpchar = bar.char_3)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+               Hash Key: foo.varchar_3
+               ->  Seq Scan on foo  (cost=0.00..431.00 rows=1 width=8)
+         ->  Hash  (cost=431.00..431.00 rows=1 width=8)
+               ->  Seq Scan on bar  (cost=0.00..431.00 rows=1 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(9 rows)
+
+select varchar_3, char_3 from foo join bar on varchar_3=char_3;
+ varchar_3 | char_3 
+-----------+--------
+ cd        | cd 
+(1 row)
+
+explain select char_3, text_any from bar join baz on char_3=text_any;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=16)
+   ->  Hash Join  (cost=0.00..862.00 rows=1 width=16)
+         Hash Cond: ((bar.char_3)::text = baz.text_any)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+               Hash Key: (bar.char_3)::text
+               ->  Seq Scan on bar  (cost=0.00..431.00 rows=1 width=8)
+         ->  Hash  (cost=431.00..431.00 rows=1 width=8)
+               ->  Seq Scan on baz  (cost=0.00..431.00 rows=1 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(9 rows)
+
+select char_3, text_any from bar join baz on char_3=text_any;
+ char_3 | text_any 
+--------+----------
+(0 rows)
+
 -- Clean up. None of the objects we create are very interesting to keep around.
 reset search_path;
 set client_min_messages='warning';


### PR DESCRIPTION
**Issue:**
The join of two columns, one varchar and one char, of matching values with trailing spaces, generates empty output.

**Example:**
```sql
create table foo (a varchar(3)) distributed by (a);
create table bar (b char(3)) distributed by (b);
insert into foo values ('1 ');
insert into bar values ('1 ');
select a, b from foo join bar on a = b;

 a | p
---+---
(0 rows)
```

**Root cause:**
According to Postgres documentation, "Values of type character are physically padded with spaces to the specified width n, and are stored and displayed that way. However, trailing spaces are treated as semantically insignificant and disregarded when comparing two values of type character."

This means, `'1 '` of char(3) (1 trailing space) is stored as `'1  '` (2 trailing spaces). However, when it's used for comparison, such as in a join condition or filter, all the trailing spaces are removed, so it's treated as `'1'`.

In our example, the join condition `foo.a = bar.b` doesn't specify casting. Therefore, foo.a of varchar is cast to bpchar, and the join condition becomes `bar.b = (foo.a)::bpchar`. The trailing spaces are removed for both foo.a and bar.b. '1' == '1' matches, so the query should return 1 row.

However, ORCA generates an additional hash condition, where both foo.a and bar.p are cast to text. The join condition becomes `(bar.b = (foo.a)::bpchar) AND ((bar.p)::text = (foo.a)::text))`. '1 ' of varchar stays '1 ' when cast to text. However, '1  ' of char(3) becomes '1' when cast to text, cause casting is considered comparison. '1 ' doesn't match '1', so 0 rows is returned.

The derivation of additional hash conditions is designed to optimize multi-column join operations, and in itself has no fault. However, casting char to text isn't binary coercible, and should be prevented in this case.

**Solution:**
We fix this bug by preventing additional equality comparisons from being derived, if the column types involved aren't binary coercible. Because coercibility isn't necessarily bidirectional, only predicates without casting or with coercible casting would be conjucated.

Note the implementation doesn't affect the construction of scalar comparison operators, where cast could occur. This is because our goal is not to ban all incoercible casting. Instead, we only prevent it when it's used to derive implied equality predicates.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
