### PR TITLE
Removed unnecessary `pstrdup` in PostgresMain

### DIFF
--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -5389,7 +5389,7 @@ PostgresMain(int argc, char *argv[],
 					 * Since PortalDefineQuery() does not take NULL query string,
 					 * we initialize it with a constant empty string.
 					 */
-					const char *query_string = pstrdup("");
+					const char *query_string = "";
 
 					const char *serializedDtxContextInfo = NULL;
 					const char *serializedPlantree = NULL;


### PR DESCRIPTION
Removed unnecessary memory alloc in PostgresMain:

```c
const char *query_string = pstrdup("");
```

The space pointed to by `query_string` is not modified, so a const string can be used.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
