### PR TITLE
(6X backport) Fix inFunction for auto_stats in CTAS, COPY and AlterTable.

### DIFF
--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -1201,7 +1201,7 @@ DoCopy(const CopyStmt *stmt, const char *queryString, uint64 *processed)
 
 	/* Issue automatic ANALYZE if conditions are satisfied (MPP-4082). */
 	if (Gp_role == GP_ROLE_DISPATCH && is_from)
-		auto_stats(AUTOSTATS_CMDTYPE_COPY, relid, *processed, false /* inFunction */);
+		auto_stats(AUTOSTATS_CMDTYPE_COPY, relid, *processed, already_under_executor_run());
 
 	return relid;
 }

--- a/src/backend/commands/createas.c
+++ b/src/backend/commands/createas.c
@@ -455,7 +455,7 @@ ExecCreateTableAs(CreateTableAsStmt *stmt, const char *queryString,
 
 		/* MPP-14001: Running auto_stats */
 		if (Gp_role == GP_ROLE_DISPATCH)
-			auto_stats(cmdType, relationOid, queryDesc->es_processed, false /* inFunction */);
+			auto_stats(cmdType, relationOid, queryDesc->es_processed, already_under_executor_run());
 
 		/* save the rowcount if we're given a completionTag to fill */
 		if (completionTag)

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -15247,7 +15247,7 @@ ATExecExpandTableCTAS(AlterTableCmd *rootCmd, Relation rel, AlterTableCmd *cmd)
 		ExecutorFinish(queryDesc);
 		ExecutorEnd(queryDesc);
 
-		auto_stats(cmdType, relationOid, queryDesc->es_processed, false);
+		auto_stats(cmdType, relationOid, queryDesc->es_processed, already_under_executor_run());
 
 		FreeQueryDesc(queryDesc);
 
@@ -15798,10 +15798,12 @@ ATExecSetDistributedBy(Relation rel, Node *node, AlterTableCmd *cmd)
 		ExecutorEnd(queryDesc);
 
 		if (Gp_role == GP_ROLE_DISPATCH)
+		{
 			auto_stats(cmdType,
 					   relationOid,
 					   queryDesc->es_processed,
-					   false);
+					   already_under_executor_run());
+		}
 
 		FreeQueryDesc(queryDesc);
 

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -130,6 +130,41 @@ ExecutorEnd_hook_type ExecutorEnd_hook = NULL;
 /* Hook for plugin to get control in ExecCheckRTPerms() */
 ExecutorCheckPerms_hook_type ExecutorCheckPerms_hook = NULL;
 
+/*
+ * Greenplum specific code:
+ *   Greenplum introduces auto_stats for a long time, please refer to
+ *   https://groups.google.com/a/greenplum.org/g/gpdb-dev/c/bAyw2KBP6yE/m/hmoWikrPAgAJ
+ *   for details and decision of auto_stats.
+ *
+ *  auto_stats() now is invoked at the following 7 places:
+ *    1. ProcessQuery()
+ *    2. _SPI_pquery()
+ *    3. postquel_end()
+ *    4. ATExecExpandTableCTAS()
+ *    5. ATExecSetDistributedBy()
+ *    6. DoCopy()
+ *    7. ExecCreateTableAs()
+ *
+ *  Previously, Place 2, 3 is hard-coded as inside function,
+ *  Place 1, 4~7 is hard-coded as not-inside function.
+ *  Place 4~7 does not cover the case that COPY or CTAS
+ *  is called inside procedure language.
+ *
+ *  Since in future auto_stats will be removed, for now let's
+ *  just to do some simple fix instead of big refactor.
+ *
+ *  To correctly pass the inFunction parameter for auto_stats()
+ *  at Place 4~7 we introduce executor_run_nesting_level to mark
+ *  if the program is already under ExecutorRun(). Place 4~7 is
+ *  directly taken as Utility and will not call ExecutorRun() if
+ *  they are not inside procedure language. This skill is like
+ *  the extension `auto_explain`.
+ *
+ *  For Place 1~3, the context is clear we do not need to check
+ *  executor_run_nesting_level.
+ */
+static int executor_run_nesting_level = 0;
+
 /* decls for local routines only used within this module */
 static void InitPlan(QueryDesc *queryDesc, int eflags);
 static void CheckValidRowMarkRel(Relation rel, RowMarkType markType);
@@ -942,10 +977,27 @@ void
 ExecutorRun(QueryDesc *queryDesc,
 			ScanDirection direction, long count)
 {
-	if (ExecutorRun_hook)
-		(*ExecutorRun_hook) (queryDesc, direction, count);
-	else
-		standard_ExecutorRun(queryDesc, direction, count);
+	/*
+	 * Greenplum specific code:
+	 * auto_stats() needs to know if it is inside procedure call so
+	 * we maintain executor_run_nesting_level here. See detailed comments
+	 * at the definition of the static variable executor_run_nesting_level.
+	 */
+	executor_run_nesting_level++;
+	PG_TRY();
+	{
+		if (ExecutorRun_hook)
+			(*ExecutorRun_hook) (queryDesc, direction, count);
+		else
+			standard_ExecutorRun(queryDesc, direction, count);
+		executor_run_nesting_level--;
+	}
+	PG_CATCH();
+	{
+		executor_run_nesting_level--;
+		PG_RE_THROW();
+	}
+	PG_END_TRY();
 }
 
 void
@@ -5390,4 +5442,14 @@ check_epq_safe_on_qes(Plan *plan)
 				(errcode(ERRCODE_T_R_SERIALIZATION_FAILURE),
 				 errmsg("EvalPlanQual can not handle subPlan with Motion node")));
 	}
+}
+
+/*
+ * Greenplum specific code:
+ * For details, see comments at the definition of static var executor_run_nesting_level
+ */
+bool
+already_under_executor_run(void)
+{
+	return executor_run_nesting_level > 0;
 }

--- a/src/include/executor/executor.h
+++ b/src/include/executor/executor.h
@@ -497,5 +497,6 @@ extern ResultRelInfo *values_get_partition(Datum *values, bool *nulls,
 					 TupleDesc desc, EState *estate, bool openIndices);
 
 extern void SendAOTupCounts(EState *estate);
+extern bool already_under_executor_run(void);
 
 #endif   /* EXECUTOR_H  */

--- a/src/test/regress/expected/autostats.out
+++ b/src/test/regress/expected/autostats.out
@@ -155,7 +155,134 @@ select COUNT(*) from autostats_test;
 
 drop table if exists autostats_test;
 drop user autostats_nonowner;
+-- test inFunction
+create function test_auto_stats_in_function(sql text, load_data boolean, check_relname text) returns void as
+$$
+declare
+  ntuples int;
+begin
+  execute 'create table t_test_auto_stats_in_function(a int) distributed randomly';
+  set gp_autostats_mode=none;
+  set gp_autostats_mode_in_functions=none;
+  if load_data then execute 'insert into t_test_auto_stats_in_function values (1)'; end if;
+  execute sql;
+  select reltuples into ntuples from pg_class where relname = check_relname;
+  raise info 'gp_autostats_mode=none, gp_autostats_mode_in_functions=none, ntuples=%', ntuples;
+  execute 'drop table t_test_auto_stats_in_function';
+  execute 'drop table if exists tmp_test_auto_stats_in_function';
+
+  execute 'create table t_test_auto_stats_in_function(a int) distributed randomly';
+  set gp_autostats_mode=on_no_stats;
+  set gp_autostats_mode_in_functions=none;
+  if load_data then execute 'insert into t_test_auto_stats_in_function values (1)'; end if;
+  execute sql;
+  select reltuples into ntuples from pg_class where relname = check_relname;
+  raise info 'gp_autostats_mode=on_no_stats, gp_autostats_mode_in_functions=none, ntuples=%', ntuples;
+  execute 'drop table t_test_auto_stats_in_function';
+  execute 'drop table if exists tmp_test_auto_stats_in_function';
+
+  execute 'create table t_test_auto_stats_in_function(a int) distributed randomly';
+  set gp_autostats_mode=none;
+  set gp_autostats_mode_in_functions=on_no_stats;
+  if load_data then execute 'insert into t_test_auto_stats_in_function values (1)'; end if;
+  execute sql;
+  select reltuples into ntuples from pg_class where relname = check_relname;
+  raise info 'gp_autostats_mode=none, gp_autostats_mode_in_functions=on_no_stats, ntuples=%', ntuples;
+  execute 'drop table t_test_auto_stats_in_function';
+  execute 'drop table if exists tmp_test_auto_stats_in_function';
+
+  execute 'create table t_test_auto_stats_in_function(a int) distributed randomly';
+  set gp_autostats_mode=none;
+  set gp_autostats_mode_in_functions=on_no_stats;
+  if load_data then execute 'insert into t_test_auto_stats_in_function values (1)'; end if;
+  select reltuples into ntuples from pg_class where relname = check_relname;
+  raise info 'gp_autostats_mode=none, gp_autostats_mode_in_functions=on_no_stats, ntuples=%', ntuples;
+  set gp_autostats_mode_in_functions=on_change;
+  set gp_autostats_on_change_threshold=0;
+  execute sql;
+  select reltuples into ntuples from pg_class where relname = check_relname;
+  raise info 'gp_autostats_mode=none, gp_autostats_mode_in_functions=on_change, ntuples=%', ntuples;
+  execute 'drop table t_test_auto_stats_in_function';
+  execute 'drop table if exists tmp_test_auto_stats_in_function';
+end;
+$$
+language plpgsql;
+select test_auto_stats_in_function('copy t_test_auto_stats_in_function from program ''echo 1''',
+                                   false, 't_test_auto_stats_in_function');
+INFO:  gp_autostats_mode=none, gp_autostats_mode_in_functions=none, ntuples=0
+NOTICE:  table "tmp_test_auto_stats_in_function" does not exist, skipping
+CONTEXT:  SQL statement "drop table if exists tmp_test_auto_stats_in_function"
+PL/pgSQL function test_auto_stats_in_function(text,boolean,text) line 13 at EXECUTE statement
+INFO:  gp_autostats_mode=on_no_stats, gp_autostats_mode_in_functions=none, ntuples=0
+NOTICE:  table "tmp_test_auto_stats_in_function" does not exist, skipping
+CONTEXT:  SQL statement "drop table if exists tmp_test_auto_stats_in_function"
+PL/pgSQL function test_auto_stats_in_function(text,boolean,text) line 23 at EXECUTE statement
+INFO:  gp_autostats_mode=none, gp_autostats_mode_in_functions=on_no_stats, ntuples=1
+NOTICE:  table "tmp_test_auto_stats_in_function" does not exist, skipping
+CONTEXT:  SQL statement "drop table if exists tmp_test_auto_stats_in_function"
+PL/pgSQL function test_auto_stats_in_function(text,boolean,text) line 33 at EXECUTE statement
+INFO:  gp_autostats_mode=none, gp_autostats_mode_in_functions=on_no_stats, ntuples=0
+INFO:  gp_autostats_mode=none, gp_autostats_mode_in_functions=on_change, ntuples=1
+NOTICE:  table "tmp_test_auto_stats_in_function" does not exist, skipping
+CONTEXT:  SQL statement "drop table if exists tmp_test_auto_stats_in_function"
+PL/pgSQL function test_auto_stats_in_function(text,boolean,text) line 47 at EXECUTE statement
+ test_auto_stats_in_function 
+-----------------------------
+ 
+(1 row)
+
+select test_auto_stats_in_function('create table tmp_test_auto_stats_in_function as select * from t_test_auto_stats_in_function distributed randomly',
+                                   true, 'tmp_test_auto_stats_in_function');
+INFO:  gp_autostats_mode=none, gp_autostats_mode_in_functions=none, ntuples=0
+INFO:  gp_autostats_mode=on_no_stats, gp_autostats_mode_in_functions=none, ntuples=0
+INFO:  gp_autostats_mode=none, gp_autostats_mode_in_functions=on_no_stats, ntuples=1
+INFO:  gp_autostats_mode=none, gp_autostats_mode_in_functions=on_no_stats, ntuples=<NULL>
+INFO:  gp_autostats_mode=none, gp_autostats_mode_in_functions=on_change, ntuples=1
+ test_auto_stats_in_function 
+-----------------------------
+ 
+(1 row)
+
+select test_auto_stats_in_function('delete from t_test_auto_stats_in_function',
+                                   true, 't_test_auto_stats_in_function');
+INFO:  gp_autostats_mode=none, gp_autostats_mode_in_functions=none, ntuples=0
+NOTICE:  table "tmp_test_auto_stats_in_function" does not exist, skipping
+CONTEXT:  SQL statement "drop table if exists tmp_test_auto_stats_in_function"
+PL/pgSQL function test_auto_stats_in_function(text,boolean,text) line 13 at EXECUTE statement
+INFO:  gp_autostats_mode=on_no_stats, gp_autostats_mode_in_functions=none, ntuples=0
+NOTICE:  table "tmp_test_auto_stats_in_function" does not exist, skipping
+CONTEXT:  SQL statement "drop table if exists tmp_test_auto_stats_in_function"
+PL/pgSQL function test_auto_stats_in_function(text,boolean,text) line 23 at EXECUTE statement
+INFO:  gp_autostats_mode=none, gp_autostats_mode_in_functions=on_no_stats, ntuples=1
+NOTICE:  table "tmp_test_auto_stats_in_function" does not exist, skipping
+CONTEXT:  SQL statement "drop table if exists tmp_test_auto_stats_in_function"
+PL/pgSQL function test_auto_stats_in_function(text,boolean,text) line 33 at EXECUTE statement
+INFO:  gp_autostats_mode=none, gp_autostats_mode_in_functions=on_no_stats, ntuples=1
+INFO:  gp_autostats_mode=none, gp_autostats_mode_in_functions=on_change, ntuples=0
+NOTICE:  table "tmp_test_auto_stats_in_function" does not exist, skipping
+CONTEXT:  SQL statement "drop table if exists tmp_test_auto_stats_in_function"
+PL/pgSQL function test_auto_stats_in_function(text,boolean,text) line 47 at EXECUTE statement
+ test_auto_stats_in_function 
+-----------------------------
+ 
+(1 row)
+
+drop function test_auto_stats_in_function(text, boolean, text);
+create table t_test_auto_stats_in_function(a int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+set gp_autostats_mode_in_functions = none;
+set gp_autostats_mode = on_no_stats;
+copy t_test_auto_stats_in_function from program 'echo 1';
+select reltuples from pg_class where relname = 't_test_auto_stats_in_function';
+ reltuples 
+-----------
+         1
+(1 row)
+
+drop table t_test_auto_stats_in_function;
 reset gp_autostats_mode;
+reset gp_autostats_mode_in_functions;
 reset gp_autostats_on_change_threshold;
 reset log_autostats;
 reset gp_autostats_allow_nonowner;

--- a/src/test/regress/sql/autostats.sql
+++ b/src/test/regress/sql/autostats.sql
@@ -74,7 +74,78 @@ select COUNT(*) from autostats_test;
 drop table if exists autostats_test;
 drop user autostats_nonowner;
 
+
+-- test inFunction
+create function test_auto_stats_in_function(sql text, load_data boolean, check_relname text) returns void as
+$$
+declare
+  ntuples int;
+begin
+  execute 'create table t_test_auto_stats_in_function(a int) distributed randomly';
+  set gp_autostats_mode=none;
+  set gp_autostats_mode_in_functions=none;
+  if load_data then execute 'insert into t_test_auto_stats_in_function values (1)'; end if;
+  execute sql;
+  select reltuples into ntuples from pg_class where relname = check_relname;
+  raise info 'gp_autostats_mode=none, gp_autostats_mode_in_functions=none, ntuples=%', ntuples;
+  execute 'drop table t_test_auto_stats_in_function';
+  execute 'drop table if exists tmp_test_auto_stats_in_function';
+
+  execute 'create table t_test_auto_stats_in_function(a int) distributed randomly';
+  set gp_autostats_mode=on_no_stats;
+  set gp_autostats_mode_in_functions=none;
+  if load_data then execute 'insert into t_test_auto_stats_in_function values (1)'; end if;
+  execute sql;
+  select reltuples into ntuples from pg_class where relname = check_relname;
+  raise info 'gp_autostats_mode=on_no_stats, gp_autostats_mode_in_functions=none, ntuples=%', ntuples;
+  execute 'drop table t_test_auto_stats_in_function';
+  execute 'drop table if exists tmp_test_auto_stats_in_function';
+
+  execute 'create table t_test_auto_stats_in_function(a int) distributed randomly';
+  set gp_autostats_mode=none;
+  set gp_autostats_mode_in_functions=on_no_stats;
+  if load_data then execute 'insert into t_test_auto_stats_in_function values (1)'; end if;
+  execute sql;
+  select reltuples into ntuples from pg_class where relname = check_relname;
+  raise info 'gp_autostats_mode=none, gp_autostats_mode_in_functions=on_no_stats, ntuples=%', ntuples;
+  execute 'drop table t_test_auto_stats_in_function';
+  execute 'drop table if exists tmp_test_auto_stats_in_function';
+
+  execute 'create table t_test_auto_stats_in_function(a int) distributed randomly';
+  set gp_autostats_mode=none;
+  set gp_autostats_mode_in_functions=on_no_stats;
+  if load_data then execute 'insert into t_test_auto_stats_in_function values (1)'; end if;
+  select reltuples into ntuples from pg_class where relname = check_relname;
+  raise info 'gp_autostats_mode=none, gp_autostats_mode_in_functions=on_no_stats, ntuples=%', ntuples;
+  set gp_autostats_mode_in_functions=on_change;
+  set gp_autostats_on_change_threshold=0;
+  execute sql;
+  select reltuples into ntuples from pg_class where relname = check_relname;
+  raise info 'gp_autostats_mode=none, gp_autostats_mode_in_functions=on_change, ntuples=%', ntuples;
+  execute 'drop table t_test_auto_stats_in_function';
+  execute 'drop table if exists tmp_test_auto_stats_in_function';
+end;
+$$
+language plpgsql;
+
+select test_auto_stats_in_function('copy t_test_auto_stats_in_function from program ''echo 1''',
+                                   false, 't_test_auto_stats_in_function');
+select test_auto_stats_in_function('create table tmp_test_auto_stats_in_function as select * from t_test_auto_stats_in_function distributed randomly',
+                                   true, 'tmp_test_auto_stats_in_function');
+select test_auto_stats_in_function('delete from t_test_auto_stats_in_function',
+                                   true, 't_test_auto_stats_in_function');
+
+drop function test_auto_stats_in_function(text, boolean, text);
+
+create table t_test_auto_stats_in_function(a int);
+set gp_autostats_mode_in_functions = none;
+set gp_autostats_mode = on_no_stats;
+copy t_test_auto_stats_in_function from program 'echo 1';
+select reltuples from pg_class where relname = 't_test_auto_stats_in_function';
+drop table t_test_auto_stats_in_function;
+
 reset gp_autostats_mode;
+reset gp_autostats_mode_in_functions;
 reset gp_autostats_on_change_threshold;
 reset log_autostats;
 reset gp_autostats_allow_nonowner;


### PR DESCRIPTION
Greenplum introduces auto_stats for a long time, please refer to https://groups.google.com/a/greenplum.org/g/gpdb-dev/c/bAyw2KBP6yE/m/hmoWikrPAgAJ for details and decision of auto_stats.

auto_stats() now is invoked at the following 7 places:
  1. ProcessQuery()
  2. _SPI_pquery()
  3. postquel_end()
  4. ATExecExpandTableCTAS()
  5. ATExecSetDistributedBy()
  6. DoCopy()
  7. ExecCreateTableAs()

Previously, Place 2, 3 is hard-coded as inside function, Place 1, 4 ~ 7 is hard-coded as not-inside function. Place 4 ~ 7 does not cover the case that COPY or CTAS is called inside procedure language.

Since in future auto_stats will be removed, for now let's just to do some simple fix instead of big refactor.

To correctly pass the inFunction parameter for auto_stats() at Place 4 ~ 7 we introduce executor_run_nesting_level to mark if the program is already under ExecutorRun(). Place 4 ~ 7 is directly taken as Utility and will not call ExecutorRun() if they are not inside procedure language. This skill is like the extension `auto_explain`.

For Place 1~3, the context is clear we do not need to check executor_run_nesting_level.

--------

backport PR https://github.com/greenplum-db/gpdb/pull/14877 to 6X.
