### PR TITLE
[6X] Don't create a seg entry if there are no tuples to add

### DIFF
--- a/src/backend/executor/execUtils.c
+++ b/src/backend/executor/execUtils.c
@@ -1519,7 +1519,7 @@ ExecUpdateAOtupCount(ResultRelInfo *result_rels,
 									0,
 									1);
 			} 
-			else if (!was_delete)
+			else if (!was_delete && tupadded > 0)
 			{
 				UpdateMasterAosegTotals(result_rels->ri_RelationDesc,
 									result_rels->ri_aosegno,

--- a/src/test/regress/expected/alter_table_ao.out
+++ b/src/test/regress/expected/alter_table_ao.out
@@ -705,3 +705,32 @@ NOTICE:  dropped partition "p_split_tupdesc_leak_ym" for relation "split_tupdesc
 NOTICE:  CREATE TABLE will create partition "split_tupdesc_leak_1_prt_p_split_tupdesc_leak_ym_201412" for table "split_tupdesc_leak"
 NOTICE:  CREATE TABLE will create partition "split_tupdesc_leak_1_prt_p_split_tupdesc_leak_ym" for table "split_tupdesc_leak"
 DROP TABLE split_tupdesc_leak;
+-- Ensure no seg entries are created when there are no tuples to add.
+-- Note: Having empty pg_aoseg entries caused post-upgrade vacuum freeze errors.
+-- For example, while upgrading the primaries a VACUUM FREEZE on a root AOCO
+-- table with a non-empty pg_aocsseg table on the master resulted in:
+--  "ERROR","58P01","could not open Append-Only segment file
+--  ""base/16410/20863.1665"": No such file or directory",,,,,,"VACUUM
+--    (FREEZE);",0,,"aomd.c"
+-- Scenario 1: Alter Distribution of AO partition table
+CREATE TABLE alter_dist_key_for_ao_partition_table (a integer, b text, c integer)
+    WITH (APPENDONLY=TRUE) DISTRIBUTED BY (a)
+    PARTITION BY RANGE(c) (START(1) END(3) EVERY(1));
+NOTICE:  CREATE TABLE will create partition "alter_dist_key_for_ao_partition_table_1_prt_1" for table "alter_dist_key_for_ao_partition_table"
+NOTICE:  CREATE TABLE will create partition "alter_dist_key_for_ao_partition_table_1_prt_2" for table "alter_dist_key_for_ao_partition_table"
+ALTER TABLE alter_dist_key_for_ao_partition_table SET DISTRIBUTED BY (b);
+-- assert non-empty seg entries
+SELECT * FROM gp_toolkit.__gp_aoseg('alter_dist_key_for_ao_partition_table'::regclass);
+ segno | eof | tupcount | varblockcount | eof_uncompressed | modcount | formatversion | state 
+-------+-----+----------+---------------+------------------+----------+---------------+-------
+(0 rows)
+
+-- Scenario 2: Inserting an empty row into AO table
+CREATE table ao_insert_empty_row (a integer, b text, c integer) WITH (APPENDONLY=TRUE) DISTRIBUTED BY (a);
+INSERT INTO ao_insert_empty_row SELECT 1,'a',1 FROM gp_id WHERE dbid=-999;
+-- assert non-empty seg entries
+SELECT * FROM gp_toolkit.__gp_aoseg('ao_insert_empty_row'::regclass);
+ segno | eof | tupcount | varblockcount | eof_uncompressed | modcount | formatversion | state 
+-------+-----+----------+---------------+------------------+----------+---------------+-------
+(0 rows)
+

--- a/src/test/regress/expected/alter_table_aocs.out
+++ b/src/test/regress/expected/alter_table_aocs.out
@@ -871,3 +871,30 @@ ROLLBACK;
 VACUUM aocs_alter_add_col_no_compress;
 DROP TABLE aocs_alter_add_col_no_compress;
 RESET gp_default_storage_options;
+-- Ensure no seg entries are created when there are no tuples to add.
+-- Note: Having empty pg_aoseg entries caused post-upgrade vacuum freeze errors.
+-- For example, while upgrading the primaries a VACUUM FREEZE on a root AOCO
+-- table with a non-empty pg_aocsseg table on the master resulted in:
+--  "ERROR","58P01","could not open Append-Only segment file
+--  ""base/16410/20863.1665"": No such file or directory",,,,,,"VACUUM
+--    (FREEZE);",0,,"aomd.c"
+-- Scenario 1: Alter Distribution of AOCO partition table
+CREATE TABLE alter_dist_key_for_aoco_partition_table (a integer, b text, c integer)
+    WITH (APPENDONLY=TRUE, ORIENTATION=COLUMN) DISTRIBUTED BY (a)
+    PARTITION BY RANGE(c) (START(1) END(3) EVERY(1));
+ALTER TABLE alter_dist_key_for_aoco_partition_table SET DISTRIBUTED BY (b);
+-- assert non-empty seg entries
+SELECT * FROM gp_toolkit.__gp_aocsseg('alter_dist_key_for_aoco_partition_table'::regclass);
+ gp_tid | segno | column_num | physical_segno | tupcount | eof | eof_uncompressed | modcount | formatversion | state 
+--------+-------+------------+----------------+----------+-----+------------------+----------+---------------+-------
+(0 rows)
+
+-- Scenario 2: Inserting an empty row into AOCO table
+CREATE table aoco_insert_empty_row (a integer, b text, c integer) WITH (APPENDONLY=TRUE, ORIENTATION=COLUMN) DISTRIBUTED BY (a);
+INSERT INTO aoco_insert_empty_row SELECT 1,'a',1 FROM gp_id WHERE dbid=-999;
+-- assert non-empty seg entries
+SELECT * FROM gp_toolkit.__gp_aocsseg('aoco_insert_empty_row'::regclass);
+ gp_tid | segno | column_num | physical_segno | tupcount | eof | eof_uncompressed | modcount | formatversion | state 
+--------+-------+------------+----------------+----------+-----+------------------+----------+---------------+-------
+(0 rows)
+

--- a/src/test/regress/expected/table_statistics.out
+++ b/src/test/regress/expected/table_statistics.out
@@ -657,10 +657,6 @@ select  count(*) from pg_class where relname like 'stat_part_co_t3';
      1
 (1 row)
 
--- Drop table as its not supported by pg_upgrade.
--- See check_parent_partitions_with_seg_entries pg_upgrade check and associated
--- test in gpupgrade repo.
-DROP TABLE stat_part_co_t3;
 \echo '-- start_ignore'
 -- start_ignore
 drop schema stat_heap4 cascade;
@@ -908,10 +904,6 @@ select  count(*) from pg_class where relname like 'stat_part_co_t4';
      1
 (1 row)
 
--- Drop table as its not supported by pg_upgrade.
--- See check_parent_partitions_with_seg_entries pg_upgrade check and associated
--- test in gpupgrade repo.
-DROP TABLE stat_part_co_t4;
 \echo '-- start_ignore'
 -- start_ignore
 drop schema stat_heap5 cascade;
@@ -1117,10 +1109,6 @@ select  count(*) from pg_class where relname like 'stat_part_co_t5';
      1
 (1 row)
 
--- Drop table as its not supported by pg_upgrade.
--- See check_parent_partitions_with_seg_entries pg_upgrade check and associated
--- test in gpupgrade repo.
-DROP TABLE stat_part_co_t5;
 \echo '-- start_ignore'
 -- start_ignore
 drop schema stat_heap6 cascade;
@@ -1387,10 +1375,6 @@ select  count(*) from pg_class where relname like 'stat_part_co_t6';
      1
 (1 row)
 
--- Drop table as its not supported by pg_upgrade.
--- See check_parent_partitions_with_seg_entries pg_upgrade check and associated
--- test in gpupgrade repo.
-DROP TABLE stat_part_co_t6;
 \echo '-- start_ignore'
 -- start_ignore
 drop schema stat_heap7 cascade;

--- a/src/test/regress/sql/alter_table_ao.sql
+++ b/src/test/regress/sql/alter_table_ao.sql
@@ -425,3 +425,25 @@ ALTER TABLE split_tupdesc_leak SPLIT DEFAULT PARTITION AT ('201412')
 	INTO (PARTITION p_split_tupdesc_leak_ym, PARTITION p_split_tupdesc_leak_ym_201412);
 
 DROP TABLE split_tupdesc_leak;
+
+-- Ensure no seg entries are created when there are no tuples to add.
+-- Note: Having empty pg_aoseg entries caused post-upgrade vacuum freeze errors.
+-- For example, while upgrading the primaries a VACUUM FREEZE on a root AOCO
+-- table with a non-empty pg_aocsseg table on the master resulted in:
+--  "ERROR","58P01","could not open Append-Only segment file
+--  ""base/16410/20863.1665"": No such file or directory",,,,,,"VACUUM
+--    (FREEZE);",0,,"aomd.c"
+
+-- Scenario 1: Alter Distribution of AO partition table
+CREATE TABLE alter_dist_key_for_ao_partition_table (a integer, b text, c integer)
+    WITH (APPENDONLY=TRUE) DISTRIBUTED BY (a)
+    PARTITION BY RANGE(c) (START(1) END(3) EVERY(1));
+ALTER TABLE alter_dist_key_for_ao_partition_table SET DISTRIBUTED BY (b);
+-- assert non-empty seg entries
+SELECT * FROM gp_toolkit.__gp_aoseg('alter_dist_key_for_ao_partition_table'::regclass);
+
+-- Scenario 2: Inserting an empty row into AO table
+CREATE table ao_insert_empty_row (a integer, b text, c integer) WITH (APPENDONLY=TRUE) DISTRIBUTED BY (a);
+INSERT INTO ao_insert_empty_row SELECT 1,'a',1 FROM gp_id WHERE dbid=-999;
+-- assert non-empty seg entries
+SELECT * FROM gp_toolkit.__gp_aoseg('ao_insert_empty_row'::regclass);

--- a/src/test/regress/sql/alter_table_aocs.sql
+++ b/src/test/regress/sql/alter_table_aocs.sql
@@ -508,3 +508,25 @@ ROLLBACK;
 VACUUM aocs_alter_add_col_no_compress;
 DROP TABLE aocs_alter_add_col_no_compress;
 RESET gp_default_storage_options;
+
+-- Ensure no seg entries are created when there are no tuples to add.
+-- Note: Having empty pg_aoseg entries caused post-upgrade vacuum freeze errors.
+-- For example, while upgrading the primaries a VACUUM FREEZE on a root AOCO
+-- table with a non-empty pg_aocsseg table on the master resulted in:
+--  "ERROR","58P01","could not open Append-Only segment file
+--  ""base/16410/20863.1665"": No such file or directory",,,,,,"VACUUM
+--    (FREEZE);",0,,"aomd.c"
+
+-- Scenario 1: Alter Distribution of AOCO partition table
+CREATE TABLE alter_dist_key_for_aoco_partition_table (a integer, b text, c integer)
+    WITH (APPENDONLY=TRUE, ORIENTATION=COLUMN) DISTRIBUTED BY (a)
+    PARTITION BY RANGE(c) (START(1) END(3) EVERY(1));
+ALTER TABLE alter_dist_key_for_aoco_partition_table SET DISTRIBUTED BY (b);
+-- assert non-empty seg entries
+SELECT * FROM gp_toolkit.__gp_aocsseg('alter_dist_key_for_aoco_partition_table'::regclass);
+
+-- Scenario 2: Inserting an empty row into AOCO table
+CREATE table aoco_insert_empty_row (a integer, b text, c integer) WITH (APPENDONLY=TRUE, ORIENTATION=COLUMN) DISTRIBUTED BY (a);
+INSERT INTO aoco_insert_empty_row SELECT 1,'a',1 FROM gp_id WHERE dbid=-999;
+-- assert non-empty seg entries
+SELECT * FROM gp_toolkit.__gp_aocsseg('aoco_insert_empty_row'::regclass);

--- a/src/test/regress/sql/table_statistics.sql
+++ b/src/test/regress/sql/table_statistics.sql
@@ -430,11 +430,6 @@ Alter table stat_part_co_t3 set distributed by (j);
 
 select  count(*) from pg_class where relname like 'stat_part_co_t3';
 
--- Drop table as its not supported by pg_upgrade.
--- See check_parent_partitions_with_seg_entries pg_upgrade check and associated
--- test in gpupgrade repo.
-DROP TABLE stat_part_co_t3;
-
 \echo '-- start_ignore'
 drop schema stat_heap4 cascade;
 create schema stat_heap4;
@@ -597,11 +592,6 @@ Alter table stat_part_co_t4 set with (reorganize=true);
 
 select  count(*) from pg_class where relname like 'stat_part_co_t4';
 
--- Drop table as its not supported by pg_upgrade.
--- See check_parent_partitions_with_seg_entries pg_upgrade check and associated
--- test in gpupgrade repo.
-DROP TABLE stat_part_co_t4;
-
 \echo '-- start_ignore'
 drop schema stat_heap5 cascade;
 create schema stat_heap5;
@@ -740,11 +730,6 @@ select  count(*) from pg_class where relname like 'stat_part_co_t5';
 Alter table stat_part_co_t5 set distributed by (j);
 
 select  count(*) from pg_class where relname like 'stat_part_co_t5';
-
--- Drop table as its not supported by pg_upgrade.
--- See check_parent_partitions_with_seg_entries pg_upgrade check and associated
--- test in gpupgrade repo.
-DROP TABLE stat_part_co_t5;
 
 \echo '-- start_ignore'
 drop schema stat_heap6 cascade;
@@ -915,11 +900,6 @@ select  count(*) from pg_class where relname like 'stat_part_co_t6';
 Alter table stat_part_co_t6 set with (reorganize=true);
 
 select  count(*) from pg_class where relname like 'stat_part_co_t6';
-
--- Drop table as its not supported by pg_upgrade.
--- See check_parent_partitions_with_seg_entries pg_upgrade check and associated
--- test in gpupgrade repo.
-DROP TABLE stat_part_co_t6;
 
 \echo '-- start_ignore'
 drop schema stat_heap7 cascade;


### PR DESCRIPTION
Ensure no seg entries are created for AO or AOCO tables when there are no tuples to add. That is, only create a seg entry when the tupcount is greater than 0. This ensures post-upgrade vacuum freeze succeeds. Entries can be created when there are no tuples to add when altering the distribution of an AOCO partition table which does CREATE and INSERT across, or when inserting an empty row to an AO table. For full coverage test both scenarios across AO and AOCO tables.

Specifically, pg_upgrade failures can occur when AO and AOCO parent partitions contain entries in pg_aoseg or pg_aocsseg respectively. These tables should not contain any entries as parent partitions don't carry any data.

Running into such entries can cause unexpected failures during pg_upgrade (and possibly during post-upgrade activity). One such ERROR manifested when we were trying to run VACUUM FREEZE while upgrading primaries. In this case, there was a root AOCO table with a non-empty pg_aocsseg table on the master node.

  "ERROR","58P01","could not open Append-Only segment file
  ""base/16410/20863.1665"": No such file or directory",,,,,,"VACUUM
    (FREEZE);",0,,"aomd.c"

This commit partially reverts 46159ba to no longer drop tables with parent partitions with aoseg entries.

https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/aoSegEntries_6X
https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/aoSegEntries_6X_RC
