### PR TITLE
Add magic number field in the ICProxyPkt

### DIFF
--- a/src/backend/cdb/motion/ic_proxy_backend.c
+++ b/src/backend/cdb/motion/ic_proxy_backend.c
@@ -182,7 +182,7 @@ ic_proxy_backend_on_read_hello_ack(uv_stream_t *stream, ssize_t nread, const uv_
 	pkt = (ICProxyPkt *)backend->buffer;
 
 	/* sanity check: drop the packet with incorrect magic number */
-	if (!ic_proxy_pkt_is_correct_magicnumber(pkt))
+	if (!ic_proxy_pkt_is_valid(pkt))
 	{
 		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG1,
 			"ic-proxy: backend %s: received %s, dropping the invalid package (magic number mismatch)",

--- a/src/backend/cdb/motion/ic_proxy_backend.c
+++ b/src/backend/cdb/motion/ic_proxy_backend.c
@@ -180,6 +180,17 @@ ic_proxy_backend_on_read_hello_ack(uv_stream_t *stream, ssize_t nread, const uv_
 
 	/* we have received a complete HELLO ACK message */
 	pkt = (ICProxyPkt *)backend->buffer;
+
+	/* sanity check: drop the packet with invalid magic number */
+	if (pkt->magicNumber != IC_PROXY_PKT_MAGIC_NUMBER)
+	{
+		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG1,
+			"ic-proxy: backend %s: received %s, dropping an invalid package (magicnumber %u != %u)",
+					ic_proxy_key_to_str(&backend->key), ic_proxy_pkt_to_str(pkt),
+					pkt->magicNumber, IC_PROXY_PKT_MAGIC_NUMBER);
+		return;
+	}
+
 	Assert(ic_proxy_pkt_is(pkt, IC_PROXY_MESSAGE_HELLO_ACK));
 	uv_read_stop(stream);
 

--- a/src/backend/cdb/motion/ic_proxy_backend.c
+++ b/src/backend/cdb/motion/ic_proxy_backend.c
@@ -181,13 +181,12 @@ ic_proxy_backend_on_read_hello_ack(uv_stream_t *stream, ssize_t nread, const uv_
 	/* we have received a complete HELLO ACK message */
 	pkt = (ICProxyPkt *)backend->buffer;
 
-	/* sanity check: drop the packet with invalid magic number */
-	if (pkt->magicNumber != IC_PROXY_PKT_MAGIC_NUMBER)
+	/* sanity check: drop the packet with incorrect magic number */
+	if (!ic_proxy_pkt_is_correct_magicnumber(pkt))
 	{
 		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG1,
-			"ic-proxy: backend %s: received %s, dropping an invalid package (magicnumber %u != %u)",
-					ic_proxy_key_to_str(&backend->key), ic_proxy_pkt_to_str(pkt),
-					pkt->magicNumber, IC_PROXY_PKT_MAGIC_NUMBER);
+			"ic-proxy: backend %s: received %s, dropping the invalid package (magic number mismatch)",
+					ic_proxy_key_to_str(&backend->key), ic_proxy_pkt_to_str(pkt));
 		return;
 	}
 

--- a/src/backend/cdb/motion/ic_proxy_client.c
+++ b/src/backend/cdb/motion/ic_proxy_client.c
@@ -662,13 +662,12 @@ ic_proxy_client_on_hello_pkt(void *opaque, const void *data, uint16 size)
 	ICProxyKey	key;
 	ICProxyPkt *ackpkt;
 
-	/* sanity check: drop the packet with invalid magic number */
-	if (pkt->magicNumber != IC_PROXY_PKT_MAGIC_NUMBER)
+	/* sanity check: drop the packet with incorrect magic number */
+	if (!ic_proxy_pkt_is_correct_magicnumber(pkt))
 	{
 		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG1,
-			"ic-proxy: %s: received %s, dropping an invalid package (magicnumber %u != %u)",
-					ic_proxy_client_get_name(client), ic_proxy_pkt_to_str(pkt),
-					pkt->magicNumber, IC_PROXY_PKT_MAGIC_NUMBER);
+			"ic-proxy: %s: received %s, dropping the invalid package (magic number mismatch)",
+					ic_proxy_client_get_name(client), ic_proxy_pkt_to_str(pkt));
 		return;
 	}
 
@@ -1189,13 +1188,12 @@ void
 ic_proxy_client_on_p2c_data(ICProxyClient *client, ICProxyPkt *pkt,
 							ic_proxy_sent_cb callback, void *opaque)
 {
-	/* sanity check: drop the packet with invalid magic number */
-	if (pkt->magicNumber != IC_PROXY_PKT_MAGIC_NUMBER)
+	/* sanity check: drop the packet with incorrect magic number */
+	if (!ic_proxy_pkt_is_correct_magicnumber(pkt))
 	{
 		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG1,
-			"ic-proxy: %s: received %s, dropping an invalid package (magicnumber %u != %u)",
-					ic_proxy_client_get_name(client), ic_proxy_pkt_to_str(pkt),
-					pkt->magicNumber, IC_PROXY_PKT_MAGIC_NUMBER);
+			"ic-proxy: %s: received %s, dropping the invalid package (magic number mismatch)",
+					ic_proxy_client_get_name(client), ic_proxy_pkt_to_str(pkt));
 		return;
 	}
 
@@ -1279,7 +1277,8 @@ ic_proxy_client_cache_p2c_pkt(ICProxyClient *client, ICProxyPkt *pkt)
 	/* TODO: drop out-of-date pkt directly */
 	/* TODO: verify the pkt is to client */
 
-	Assert(pkt->magicNumber == IC_PROXY_PKT_MAGIC_NUMBER);
+	Assert(ic_proxy_pkt_is_correct_magicnumber(pkt));
+
 	client->pkts = lappend(client->pkts, pkt);
 
 	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG3,

--- a/src/backend/cdb/motion/ic_proxy_client.c
+++ b/src/backend/cdb/motion/ic_proxy_client.c
@@ -662,6 +662,16 @@ ic_proxy_client_on_hello_pkt(void *opaque, const void *data, uint16 size)
 	ICProxyKey	key;
 	ICProxyPkt *ackpkt;
 
+	/* sanity check: drop the packet with invalid magic number */
+	if (pkt->magicNumber != IC_PROXY_PKT_MAGIC_NUMBER)
+	{
+		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG1,
+			"ic-proxy: %s: received %s, dropping an invalid package (magicnumber %u != %u)",
+					ic_proxy_client_get_name(client), ic_proxy_pkt_to_str(pkt),
+					pkt->magicNumber, IC_PROXY_PKT_MAGIC_NUMBER);
+		return;
+	}
+
 	/* we only expect one HELLO message */
 	uv_read_stop((uv_stream_t *) &client->pipe);
 
@@ -1179,6 +1189,16 @@ void
 ic_proxy_client_on_p2c_data(ICProxyClient *client, ICProxyPkt *pkt,
 							ic_proxy_sent_cb callback, void *opaque)
 {
+	/* sanity check: drop the packet with invalid magic number */
+	if (pkt->magicNumber != IC_PROXY_PKT_MAGIC_NUMBER)
+	{
+		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG1,
+			"ic-proxy: %s: received %s, dropping an invalid package (magicnumber %u != %u)",
+					ic_proxy_client_get_name(client), ic_proxy_pkt_to_str(pkt),
+					pkt->magicNumber, IC_PROXY_PKT_MAGIC_NUMBER);
+		return;
+	}
+
 	/* A placeholder does not send any packets, it always cache them */
 	if (client->state & IC_PROXY_CLIENT_STATE_PLACEHOLDER)
 	{
@@ -1259,6 +1279,7 @@ ic_proxy_client_cache_p2c_pkt(ICProxyClient *client, ICProxyPkt *pkt)
 	/* TODO: drop out-of-date pkt directly */
 	/* TODO: verify the pkt is to client */
 
+	Assert(pkt->magicNumber == IC_PROXY_PKT_MAGIC_NUMBER);
 	client->pkts = lappend(client->pkts, pkt);
 
 	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG3,

--- a/src/backend/cdb/motion/ic_proxy_client.c
+++ b/src/backend/cdb/motion/ic_proxy_client.c
@@ -663,7 +663,7 @@ ic_proxy_client_on_hello_pkt(void *opaque, const void *data, uint16 size)
 	ICProxyPkt *ackpkt;
 
 	/* sanity check: drop the packet with incorrect magic number */
-	if (!ic_proxy_pkt_is_correct_magicnumber(pkt))
+	if (!ic_proxy_pkt_is_valid(pkt))
 	{
 		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG1,
 			"ic-proxy: %s: received %s, dropping the invalid package (magic number mismatch)",
@@ -1189,7 +1189,7 @@ ic_proxy_client_on_p2c_data(ICProxyClient *client, ICProxyPkt *pkt,
 							ic_proxy_sent_cb callback, void *opaque)
 {
 	/* sanity check: drop the packet with incorrect magic number */
-	if (!ic_proxy_pkt_is_correct_magicnumber(pkt))
+	if (!ic_proxy_pkt_is_valid(pkt))
 	{
 		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG1,
 			"ic-proxy: %s: received %s, dropping the invalid package (magic number mismatch)",
@@ -1277,7 +1277,7 @@ ic_proxy_client_cache_p2c_pkt(ICProxyClient *client, ICProxyPkt *pkt)
 	/* TODO: drop out-of-date pkt directly */
 	/* TODO: verify the pkt is to client */
 
-	Assert(ic_proxy_pkt_is_correct_magicnumber(pkt));
+	Assert(ic_proxy_pkt_is_valid(pkt));
 
 	client->pkts = lappend(client->pkts, pkt);
 

--- a/src/backend/cdb/motion/ic_proxy_packet.c
+++ b/src/backend/cdb/motion/ic_proxy_packet.c
@@ -82,6 +82,7 @@ void
 ic_proxy_message_init(ICProxyPkt *pkt, ICProxyMessageType type,
 					  const ICProxyKey *key)
 {
+	pkt->magicNumber = IC_PROXY_PKT_MAGIC_NUMBER;
 	pkt->type = type;
 	pkt->len = sizeof(*pkt);
 

--- a/src/backend/cdb/motion/ic_proxy_packet.c
+++ b/src/backend/cdb/motion/ic_proxy_packet.c
@@ -157,13 +157,14 @@ ic_proxy_pkt_to_str(const ICProxyPkt *pkt)
 	static char	buf[256];
 
 	snprintf(buf, sizeof(buf),
-			 "%s [con%d,cmd%d,slice[%hd->%hd] %hu bytes seg%hd:dbid%hu:p%d->seg%hd:dbid%hu:p%d]",
+			 "%s [con%d,cmd%d,slice[%hd->%hd] %hu bytes seg%hd:dbid%hu:p%d->seg%hd:dbid%hu:p%d magic%u]",
 			 ic_proxy_message_type_to_str(pkt->type),
 			 pkt->sessionId, pkt->commandId,
 			 pkt->sendSliceIndex, pkt->recvSliceIndex,
 			 pkt->len,
 			 pkt->srcContentId, pkt->srcDbid, pkt->srcPid,
-			 pkt->dstContentId, pkt->dstDbid, pkt->dstPid);
+			 pkt->dstContentId, pkt->dstDbid, pkt->dstPid,
+			 pkt->magicNumber);
 
 	return buf;
 }

--- a/src/backend/cdb/motion/ic_proxy_packet.h
+++ b/src/backend/cdb/motion/ic_proxy_packet.h
@@ -22,6 +22,7 @@ typedef struct ICProxyPkt ICProxyPkt;
 #include "ic_proxy_key.h"
 
 #define IC_PROXY_MAX_PKT_SIZE (Gp_max_packet_size + sizeof(ICProxyPkt))
+#define IC_PROXY_PKT_MAGIC_NUMBER (0xBA0BABEE)
 
 typedef enum
 {
@@ -41,6 +42,9 @@ typedef enum
 
 struct ICProxyPkt
 {
+	/* for the sanity check of package */
+	uint32		magicNumber;
+
 	uint16		len;
 	uint16		type;
 

--- a/src/backend/cdb/motion/ic_proxy_packet.h
+++ b/src/backend/cdb/motion/ic_proxy_packet.h
@@ -101,4 +101,11 @@ ic_proxy_pkt_is(const ICProxyPkt *pkt, ICProxyMessageType type)
 	return type == pkt->type;
 }
 
+static inline bool
+ic_proxy_pkt_is_correct_magicnumber(const ICProxyPkt *pkt)
+{
+	Assert(pkt);
+	return pkt->magicNumber == IC_PROXY_PKT_MAGIC_NUMBER;
+}
+
 #endif   /* IC_PROXY_PACKET_H */

--- a/src/backend/cdb/motion/ic_proxy_packet.h
+++ b/src/backend/cdb/motion/ic_proxy_packet.h
@@ -22,7 +22,7 @@ typedef struct ICProxyPkt ICProxyPkt;
 #include "ic_proxy_key.h"
 
 #define IC_PROXY_MAX_PKT_SIZE (Gp_max_packet_size + sizeof(ICProxyPkt))
-#define IC_PROXY_PKT_MAGIC_NUMBER (0xBA0BABEE)
+#define IC_PROXY_PKT_MAGIC_NUMBER (0xBADDCAFE)
 
 typedef enum
 {
@@ -101,8 +101,9 @@ ic_proxy_pkt_is(const ICProxyPkt *pkt, ICProxyMessageType type)
 	return type == pkt->type;
 }
 
+/* check the validity of a package by magicNumber */
 static inline bool
-ic_proxy_pkt_is_correct_magicnumber(const ICProxyPkt *pkt)
+ic_proxy_pkt_is_valid(const ICProxyPkt *pkt)
 {
 	Assert(pkt);
 	return pkt->magicNumber == IC_PROXY_PKT_MAGIC_NUMBER;

--- a/src/backend/cdb/motion/ic_proxy_peer.c
+++ b/src/backend/cdb/motion/ic_proxy_peer.c
@@ -291,7 +291,7 @@ ic_proxy_peer_on_data_pkt(void *opaque, const void *data, uint16 size)
 		   "ic-proxy: %s: received %s", peer->name, ic_proxy_pkt_to_str(pkt));
 
 	/* sanity check: drop the packet with incorrect magic number */
-	if (!ic_proxy_pkt_is_correct_magicnumber(pkt))
+	if (!ic_proxy_pkt_is_valid(pkt))
 	{
 		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG1,
 			"ic-proxy: %s: received %s, dropping the invalid package (magic number mismatch)",
@@ -539,7 +539,7 @@ ic_proxy_peer_on_hello_pkt(void *opaque, const void *data, uint16 size)
 	ICProxyKey	key;
 
 	/* sanity check: drop the packet with incorrect magic number */
-	if (!ic_proxy_pkt_is_correct_magicnumber(pkt))
+	if (!ic_proxy_pkt_is_valid(pkt))
 	{
 		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG1,
 			"ic-proxy: %s: received %s, dropping the invalid package (magic number mismatch)",
@@ -655,7 +655,7 @@ ic_proxy_peer_on_hello_ack_pkt(void *opaque, const void *data, uint16 size)
 					 peer->name, size);
 
 	/* sanity check: drop the packet with incorrect magic number */
-	if (!ic_proxy_pkt_is_correct_magicnumber(pkt))
+	if (!ic_proxy_pkt_is_valid(pkt))
 	{
 		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG1,
 			"ic-proxy: %s: received %s, dropping the invalid package (magic number mismatch)",

--- a/src/backend/cdb/motion/ic_proxy_peer.c
+++ b/src/backend/cdb/motion/ic_proxy_peer.c
@@ -290,13 +290,12 @@ ic_proxy_peer_on_data_pkt(void *opaque, const void *data, uint16 size)
 	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG5,
 		   "ic-proxy: %s: received %s", peer->name, ic_proxy_pkt_to_str(pkt));
 
-	/* sanity check: drop the packet with invalid magic number */
-	if (pkt->magicNumber != IC_PROXY_PKT_MAGIC_NUMBER)
+	/* sanity check: drop the packet with incorrect magic number */
+	if (!ic_proxy_pkt_is_correct_magicnumber(pkt))
 	{
 		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG1,
-			"ic-proxy: %s: received %s, dropping an invalid package (magicnumber %u != %u)",
-					peer->name, ic_proxy_pkt_to_str(pkt),
-					pkt->magicNumber, IC_PROXY_PKT_MAGIC_NUMBER);
+			"ic-proxy: %s: received %s, dropping the invalid package (magic number mismatch)",
+					peer->name, ic_proxy_pkt_to_str(pkt));
 		return;
 	}
 
@@ -539,13 +538,12 @@ ic_proxy_peer_on_hello_pkt(void *opaque, const void *data, uint16 size)
 	ICProxyPeer *peer = opaque;
 	ICProxyKey	key;
 
-	/* sanity check: drop the packet with invalid magic number */
-	if (pkt->magicNumber != IC_PROXY_PKT_MAGIC_NUMBER)
+	/* sanity check: drop the packet with incorrect magic number */
+	if (!ic_proxy_pkt_is_correct_magicnumber(pkt))
 	{
 		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG1,
-			"ic-proxy: %s: received %s, dropping an invalid package (magicnumber %u != %u)",
-					peer->name, ic_proxy_pkt_to_str(pkt),
-					pkt->magicNumber, IC_PROXY_PKT_MAGIC_NUMBER);
+			"ic-proxy: %s: received %s, dropping the invalid package (magic number mismatch)",
+					peer->name, ic_proxy_pkt_to_str(pkt));
 		return;
 	}
 
@@ -656,13 +654,12 @@ ic_proxy_peer_on_hello_ack_pkt(void *opaque, const void *data, uint16 size)
 		elog(ERROR, "ic-proxy: %s: received incomplete HELLO ACK: size = %d",
 					 peer->name, size);
 
-	/* sanity check: drop the packet with invalid magic number */
-	if (pkt->magicNumber != IC_PROXY_PKT_MAGIC_NUMBER)
+	/* sanity check: drop the packet with incorrect magic number */
+	if (!ic_proxy_pkt_is_correct_magicnumber(pkt))
 	{
 		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG1,
-			"ic-proxy: %s: received %s, dropping an invalid package (magicnumber %u != %u)",
-					peer->name, ic_proxy_pkt_to_str(pkt),
-					pkt->magicNumber, IC_PROXY_PKT_MAGIC_NUMBER);
+			"ic-proxy: %s: received %s, dropping the invalid package (magic number mismatch)",
+					peer->name, ic_proxy_pkt_to_str(pkt));
 		return;
 	}
 

--- a/src/backend/cdb/motion/ic_proxy_peer.c
+++ b/src/backend/cdb/motion/ic_proxy_peer.c
@@ -290,6 +290,16 @@ ic_proxy_peer_on_data_pkt(void *opaque, const void *data, uint16 size)
 	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG5,
 		   "ic-proxy: %s: received %s", peer->name, ic_proxy_pkt_to_str(pkt));
 
+	/* sanity check: drop the packet with invalid magic number */
+	if (pkt->magicNumber != IC_PROXY_PKT_MAGIC_NUMBER)
+	{
+		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG1,
+			"ic-proxy: %s: received %s, dropping an invalid package (magicnumber %u != %u)",
+					peer->name, ic_proxy_pkt_to_str(pkt),
+					pkt->magicNumber, IC_PROXY_PKT_MAGIC_NUMBER);
+		return;
+	}
+
 	if (!(peer->state & IC_PROXY_PEER_STATE_READY_FOR_DATA))
 	{
 		elog(WARNING, "ic-proxy: %s: not ready to receive DATA yet: %s",
@@ -529,6 +539,16 @@ ic_proxy_peer_on_hello_pkt(void *opaque, const void *data, uint16 size)
 	ICProxyPeer *peer = opaque;
 	ICProxyKey	key;
 
+	/* sanity check: drop the packet with invalid magic number */
+	if (pkt->magicNumber != IC_PROXY_PKT_MAGIC_NUMBER)
+	{
+		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG1,
+			"ic-proxy: %s: received %s, dropping an invalid package (magicnumber %u != %u)",
+					peer->name, ic_proxy_pkt_to_str(pkt),
+					pkt->magicNumber, IC_PROXY_PKT_MAGIC_NUMBER);
+		return;
+	}
+
 	/* we only expect one hello message */
 	uv_read_stop((uv_stream_t *) &peer->tcp);
 
@@ -635,6 +655,16 @@ ic_proxy_peer_on_hello_ack_pkt(void *opaque, const void *data, uint16 size)
 	if (size < sizeof(*pkt) || size != pkt->len)
 		elog(ERROR, "ic-proxy: %s: received incomplete HELLO ACK: size = %d",
 					 peer->name, size);
+
+	/* sanity check: drop the packet with invalid magic number */
+	if (pkt->magicNumber != IC_PROXY_PKT_MAGIC_NUMBER)
+	{
+		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG1,
+			"ic-proxy: %s: received %s, dropping an invalid package (magicnumber %u != %u)",
+					peer->name, ic_proxy_pkt_to_str(pkt),
+					pkt->magicNumber, IC_PROXY_PKT_MAGIC_NUMBER);
+		return;
+	}
 
 	if (peer->state & IC_PROXY_PEER_STATE_RECEIVED_HELLO_ACK)
 	{

--- a/src/backend/cdb/motion/ic_proxy_router.c
+++ b/src/backend/cdb/motion/ic_proxy_router.c
@@ -202,7 +202,7 @@ void
 ic_proxy_router_route(uv_loop_t *loop, ICProxyPkt *pkt,
 					  ic_proxy_sent_cb callback, void *opaque)
 {
-	Assert(pkt->magicNumber == IC_PROXY_PKT_MAGIC_NUMBER);
+	Assert(ic_proxy_pkt_is_correct_magicnumber(pkt));
 	if (pkt->dstDbid == pkt->srcDbid)
 	{
 		/*
@@ -255,7 +255,7 @@ ic_proxy_router_on_write(uv_write_t *req, int status)
 	ICProxyWriteReq *wreq = (ICProxyWriteReq *) req;
 	ICProxyPkt *pkt = req->data;
 
-	Assert(pkt->magicNumber == IC_PROXY_PKT_MAGIC_NUMBER);
+	Assert(ic_proxy_pkt_is_correct_magicnumber(pkt));
 
 	if (status < 0)
 	{

--- a/src/backend/cdb/motion/ic_proxy_router.c
+++ b/src/backend/cdb/motion/ic_proxy_router.c
@@ -202,6 +202,7 @@ void
 ic_proxy_router_route(uv_loop_t *loop, ICProxyPkt *pkt,
 					  ic_proxy_sent_cb callback, void *opaque)
 {
+	Assert(pkt->magicNumber == IC_PROXY_PKT_MAGIC_NUMBER);
 	if (pkt->dstDbid == pkt->srcDbid)
 	{
 		/*
@@ -253,6 +254,8 @@ ic_proxy_router_on_write(uv_write_t *req, int status)
 {
 	ICProxyWriteReq *wreq = (ICProxyWriteReq *) req;
 	ICProxyPkt *pkt = req->data;
+
+	Assert(pkt->magicNumber == IC_PROXY_PKT_MAGIC_NUMBER);
 
 	if (status < 0)
 	{

--- a/src/backend/cdb/motion/ic_proxy_router.c
+++ b/src/backend/cdb/motion/ic_proxy_router.c
@@ -202,7 +202,7 @@ void
 ic_proxy_router_route(uv_loop_t *loop, ICProxyPkt *pkt,
 					  ic_proxy_sent_cb callback, void *opaque)
 {
-	Assert(ic_proxy_pkt_is_correct_magicnumber(pkt));
+	Assert(ic_proxy_pkt_is_valid(pkt));
 	if (pkt->dstDbid == pkt->srcDbid)
 	{
 		/*
@@ -255,7 +255,7 @@ ic_proxy_router_on_write(uv_write_t *req, int status)
 	ICProxyWriteReq *wreq = (ICProxyWriteReq *) req;
 	ICProxyPkt *pkt = req->data;
 
-	Assert(ic_proxy_pkt_is_correct_magicnumber(pkt));
+	Assert(ic_proxy_pkt_is_valid(pkt));
 
 	if (status < 0)
 	{


### PR DESCRIPTION
icproxy processes communicate with each other with the public addr:port (see `gp_interconnect_proxy_addresses`), but no auth control here. So, any connection may connect in and send any byte, it may cause some unexpected exceptions (e.g. OOM). 

In the PR, introduces a magic number field in the `ICProxyPkt` and does a sanity check: drop the corresponding package if magic number doesn't match.

This method does not attempt to solve all problems, but only as a simple solution to avoid **internal misaccess**, looks it's good enough.

(no separated test needed, current icw_icproxy_xxx tests covered them)
(need to port to 6x later)

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [x] Review a PR in return to support the community
