### PR TITLE
Fix wrong number of maxAttrNum in TupleSplitState

### DIFF
--- a/src/backend/executor/nodeTupleSplit.c
+++ b/src/backend/executor/nodeTupleSplit.c
@@ -103,8 +103,6 @@ ExecInitTupleSplit(TupleSplit *node, EState *estate, int eflags)
 		i ++;
 	}
 
-	tup_spl_state->maxAttrNum = maxAttrNum;
-
 	/*
 	 * fetch group by expr bitmap set
 	 */
@@ -142,6 +140,15 @@ ExecInitTupleSplit(TupleSplit *node, EState *estate, int eflags)
 			bms_union(orig_bms, skip_split_bms);
 		bms_free(orig_bms);
 	}
+
+	/*
+	 * Update maxAttrNum which is used to calculate projection number
+	 * of ExecTupleSplit
+	 */
+	int x = bms_prev_member(skip_split_bms, -1);
+	if (x > maxAttrNum)
+		maxAttrNum = x;
+	tup_spl_state->maxAttrNum = maxAttrNum;
 
 	bms_free(skip_split_bms);
 

--- a/src/test/regress/expected/gp_dqa.out
+++ b/src/test/regress/expected/gp_dqa.out
@@ -2926,3 +2926,19 @@ select sum(Distinct b), count(c) filter(where c > 1), sum(a) from dqa_f3;
 (1 row)
 
 drop table dqa_f3;
+-- Test some corner case of dqa ex.NULL
+create table dqa_f4(a int, b int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into dqa_f4 values(null, null, null);
+insert into dqa_f4 values(1, 1, 1);
+insert into dqa_f4 values(2, 2, 2);
+select count(distinct a), count(distinct b) from dqa_f4 group by c;
+ count | count 
+-------+-------
+     0 |     0
+     1 |     1
+     1 |     1
+(3 rows)
+
+drop table dqa_f4;

--- a/src/test/regress/expected/gp_dqa_optimizer.out
+++ b/src/test/regress/expected/gp_dqa_optimizer.out
@@ -3157,3 +3157,21 @@ DETAIL:  Feature not supported: Aggregate functions with FILTER
 (1 row)
 
 drop table dqa_f3;
+-- Test some corner case of dqa ex.NULL
+create table dqa_f4(a int, b int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into dqa_f4 values(null, null, null);
+insert into dqa_f4 values(1, 1, 1);
+insert into dqa_f4 values(2, 2, 2);
+select count(distinct a), count(distinct b) from dqa_f4 group by c;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Multiple Distinct Qualified Aggregates are disabled in the optimizer
+ count | count 
+-------+-------
+     0 |     0
+     1 |     1
+     1 |     1
+(3 rows)
+
+drop table dqa_f4;

--- a/src/test/regress/sql/gp_dqa.sql
+++ b/src/test/regress/sql/gp_dqa.sql
@@ -541,3 +541,13 @@ explain (verbose on, costs off) select sum(Distinct b), count(c) filter(where c 
 select sum(Distinct b), count(c) filter(where c > 1), sum(a) from dqa_f3;
 
 drop table dqa_f3;
+
+-- Test some corner case of dqa ex.NULL
+create table dqa_f4(a int, b int, c int);
+insert into dqa_f4 values(null, null, null);
+insert into dqa_f4 values(1, 1, 1);
+insert into dqa_f4 values(2, 2, 2);
+
+select count(distinct a), count(distinct b) from dqa_f4 group by c;
+
+drop table dqa_f4;


### PR DESCRIPTION
we cannot get corrent number of projecting targets for executing TupleSplit Node if wrong maxAttrNum in TupleSplitState, that cause wrong results in multi-dqa sql. like sql
```
select count(distinct a), count(distinct b) from dqa_f4 group by c;

For each splited tuple, we also need to project column `c` as group column besieds
distinct column `a` and `b`. As a result, toal maxAttrNum of TupleSplit is three instead of two, 
which also decided totals projection columns of Node Tuplesplit.
```
To figure maxAttrNum correctly, we need to calculate again after we initiated all elements in TupleSplitState.


## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
