### PR TITLE
Fix the failed unit test case

### DIFF
--- a/gpMgmt/bin/gpcheckresgroupimpl
+++ b/gpMgmt/bin/gpcheckresgroupimpl
@@ -37,7 +37,7 @@ class CgroupValidation(object):
         return ""
 
 
-class CgroupValidationVersionAlpha(CgroupValidation):
+class CgroupValidationVersionOne(CgroupValidation):
     def __init__(self):
         self.mount_point = self.detect_cgroup_mount_point()
         self.tab = {"r": os.R_OK, "w": os.W_OK, "x": os.X_OK, "f": os.F_OK}
@@ -181,7 +181,7 @@ class CgroupValidationVersionAlpha(CgroupValidation):
 if __name__ == '__main__':
     if sys.platform.startswith('linux'):
         try:
-            CgroupValidationVersionAlpha().validate_all()
+            CgroupValidationVersionOne().validate_all()
         except ValidationException as e:
             exit(e.message)
     else:

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpcheckresgroupimpl.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpcheckresgroupimpl.py
@@ -30,7 +30,7 @@ class GpCheckResGroupImplCGroup(unittest.TestCase):
         os.mkdir(os.path.join(self.cgroup_mntpnt, "cpuacct"), 0o755)
         os.mkdir(os.path.join(self.cgroup_mntpnt, "cpuset"), 0o755)
 
-        self.cgroup = gpcheckresgroupimpl.cgroup()
+        self.cgroup = gpcheckresgroupimpl.CgroupValidationVersionAlpha()
         self.cgroup.mount_point = self.cgroup_mntpnt
         self.cgroup.die = self.mock_cgroup_die
         self.cgroup.compdirs = self.cgroup.fallback_comp_dirs()
@@ -116,13 +116,13 @@ class GpCheckResGroupImplCGroup(unittest.TestCase):
 
     def test_proper_setup_with_non_default_cgroup_comp_dirs(self):
         # set comp dir to comp.dir
-        compdirs = self.cgroup.compdirs
-        self.cgroup.compdirs = {}
-        for comp in list(compdirs.keys()):
-            self.cgroup.compdirs[comp] = comp + '.dir'
+        component_dirs = self.cgroup.component_dirs
+        self.cgroup.component_dirs = {}
+        for comp in list(component_dirs.keys()):
+            self.cgroup.component_dirs[comp] = comp + '.dir'
         # move /sys/fs/cgroup/comp to /sys/fs/cgroup/comp/comp.dir
-        for comp in list(self.cgroup.compdirs.keys()):
-            compdir = self.cgroup.compdirs[comp]
+        for comp in list(self.cgroup.component_dirs.keys()):
+            compdir = self.cgroup.component_dirs[comp]
             olddir = os.path.join(self.cgroup_mntpnt, comp)
             tmpdir = os.path.join(self.cgroup_mntpnt, compdir)
             shutil.move(olddir, tmpdir)

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpcheckresgroupimpl.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpcheckresgroupimpl.py
@@ -30,7 +30,7 @@ class GpCheckResGroupImplCGroup(unittest.TestCase):
         os.mkdir(os.path.join(self.cgroup_mntpnt, "cpuacct"), 0o755)
         os.mkdir(os.path.join(self.cgroup_mntpnt, "cpuset"), 0o755)
 
-        self.cgroup = gpcheckresgroupimpl.CgroupValidationVersionAlpha()
+        self.cgroup = gpcheckresgroupimpl.CgroupValidationVersionOne()
         self.cgroup.mount_point = self.cgroup_mntpnt
         self.cgroup.die = self.mock_cgroup_die
         self.cgroup.compdirs = self.cgroup.fallback_comp_dirs()


### PR DESCRIPTION
This is the negligence of PR #14733.

As the title said, this PR is just trying to fix the failed unit test of `test_unit_gpcheckresgroupimpl.py`

