### PR TITLE
Disable drop resource group `system_group`.

### DIFF
--- a/src/backend/commands/resgroupcmds.c
+++ b/src/backend/commands/resgroupcmds.c
@@ -289,7 +289,9 @@ DropResourceGroup(DropResourceGroupStmt *stmt)
 	groupid = ((Form_pg_resgroup) GETSTRUCT(tuple))->oid;
 
 	/* cannot DROP default resource groups  */
-	if (groupid == DEFAULTRESGROUP_OID || groupid == ADMINRESGROUP_OID)
+	if (groupid == DEFAULTRESGROUP_OID
+		|| groupid == ADMINRESGROUP_OID
+		|| groupid == DEFAULTAUXILIARY_OID)
 		ereport(ERROR,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 				 errmsg("cannot drop default resource group \"%s\"",

--- a/src/test/isolation2/expected/resgroup/resgroup_syntax.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_syntax.out
@@ -218,6 +218,8 @@ DROP RESOURCE GROUP default_group;
 ERROR:  cannot drop default resource group "default_group"
 DROP RESOURCE GROUP admin_group;
 ERROR:  cannot drop default resource group "admin_group"
+DROP RESOURCE GROUP system_group;
+ERROR:  cannot drop default resource group "system_group"
 DROP RESOURCE GROUP none;
 ERROR:  resource group "none" does not exist
 

--- a/src/test/isolation2/sql/resgroup/resgroup_syntax.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_syntax.sql
@@ -115,6 +115,7 @@ DROP RESOURCE GROUP non_exist_group;
 -- can't drop reserved resource groups
 DROP RESOURCE GROUP default_group;
 DROP RESOURCE GROUP admin_group;
+DROP RESOURCE GROUP system_group;
 DROP RESOURCE GROUP none;
 
 -- positive


### PR DESCRIPTION
**Disable drop resource group `system_group`.**

Test case:
```
[fairyfar@bogon gpdb]$ psql postgres
psql (12.12)
Type "help" for help.

postgres=# select version();
                                                                                                       version
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 PostgreSQL 12.12 (Greenplum Database 7.0.0-beta.1+dev.43.g8e2050682e build dev) on x86_64-pc-linux-gnu, compiled by gcc (GCC) 9.3.1 20200408 (Red Hat 9.3.1-2), 64-bit compiled on Feb  8 2023 11:40:02 Bhuvnesh C.
(1 row)

postgres=# select * from gp_toolkit.gp_resgroup_config;
 groupid |   groupname   | concurrency | cpu_hard_quota_limit | cpu_soft_priority | cpuset
---------+---------------+-------------+----------------------+-------------------+--------
    6438 | admin_group   | 10          | 10                   | 100               | -1
    6441 | system_group  | 0           | 10                   | 100               | -1
    6437 | default_group | 20          | 20                   | 100               | -1
(3 rows)

postgres=# drop resource group system_group;
DROP RESOURCE GROUP

postgres=# select * from gp_toolkit.gp_resgroup_config;
 groupid |   groupname   | concurrency | cpu_hard_quota_limit | cpu_soft_priority | cpuset
---------+---------------+-------------+----------------------+-------------------+--------
    6438 | admin_group   | 10          | 10                   | 100               | -1
    6437 | default_group | 20          | 20                   | 100               | -1
(2 rows)
```

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
