### PR TITLE
[6X Only] Use opclass to retrieve operators for partitioned table.

### DIFF
--- a/src/backend/cdb/cdbpartition.c
+++ b/src/backend/cdb/cdbpartition.c
@@ -4175,14 +4175,7 @@ cdb_retrieve_btree_op(Oid opclass, Oid lhstypid, Oid rhstypid, int16 strategy)
 {
 	Oid opfamily = get_opclass_family(opclass);
 	Oid opno = InvalidOid;
-	/*
-	 * There's no associated operator for domain types, we need to fetch the base type
-	 * of these types.
-	 */
-	Oid lbasetypid = OidIsValid(lhstypid) ? getBaseType(lhstypid) : lhstypid;
-	Oid rbasetypid = OidIsValid(rhstypid) ? getBaseType(rhstypid) : rhstypid;
-
-	opno = get_opfamily_member(opfamily, lbasetypid, rbasetypid, strategy);
+	opno = get_opfamily_member(opfamily, lhstypid, rhstypid, strategy);
 	if (!OidIsValid(opno))
 	{
 		/*
@@ -4196,7 +4189,7 @@ cdb_retrieve_btree_op(Oid opclass, Oid lhstypid, Oid rhstypid, int16 strategy)
 		 * type is 'VARCHAR'. We use IsBinaryCoercible to handle these binary-compatible types.
 		 */
 		Oid inctypid = get_opclass_input_type(opclass);
-		if (IsBinaryCoercible(lbasetypid, inctypid) && IsBinaryCoercible(rbasetypid, inctypid))
+		if (IsBinaryCoercible(lhstypid, inctypid) && IsBinaryCoercible(rhstypid, inctypid))
 			opno = get_opfamily_member(opfamily, inctypid, inctypid, strategy);
 	}
 

--- a/src/backend/cdb/cdbpartition.c
+++ b/src/backend/cdb/cdbpartition.c
@@ -4191,6 +4191,10 @@ cdb_retrieve_btree_op(Oid opclass, Oid lhstypid, Oid rhstypid, int16 strategy)
 		Oid inctypid = get_opclass_input_type(opclass);
 		if (IsBinaryCoercible(lhstypid, inctypid) && IsBinaryCoercible(rhstypid, inctypid))
 			opno = get_opfamily_member(opfamily, inctypid, inctypid, strategy);
+
+		if (!OidIsValid(opno))
+			elog(ERROR, "could not find valid operator, lhstype: %d, rhstype: %d, strategy number: %d",
+				 lhstypid, rhstypid, strategy);
 	}
 
 	return get_opcode(opno);

--- a/src/test/regress/expected/partition.out
+++ b/src/test/regress/expected/partition.out
@@ -8736,3 +8736,333 @@ create table rnd_distribution(a1 int, a int, b int, c int) distributed randomly;
 alter table rnd_distribution drop column a1;
 alter table tbl_default_distribution exchange partition for (rank(2)) with table rnd_distribution;
 ERROR:  distribution policy for "rnd_distribution" must be the same as that for "tbl_default_distribution"
+--
+-- Test that we are able to partition a table by custom created data types.
+--
+-- Create data types and operators under spefic schema.
+-- Historically, Greenplum hardcoded the operators search_path when looking up operators for partitioned tables. However, at the moment that the partitioned table is defined,
+-- the opclass used for defining the partitioned table has been recorded in the parclass column of pg_catalog.pg_partition table. We should retrieve operators according to
+-- parclass just like the behavior Greenplum 7 or PostgreSQL.
+create schema part_op_test;
+set search_path = 'part_op_test';
+create type myint;
+create function myint_in(cstring) returns myint as 'int4in' language internal immutable strict;
+NOTICE:  return type myint is only a shell
+create function myint_out(myint) returns cstring as 'int4out' language internal immutable strict;
+NOTICE:  argument type myint is only a shell
+create function myint_send(myint) returns bytea as 'int4send' language internal immutable strict;
+NOTICE:  argument type myint is only a shell
+create function myint_recv(internal) returns myint as 'int4recv' language internal immutable strict;
+NOTICE:  return type myint is only a shell
+create type myint (input=myint_in, output=myint_out, receive=myint_recv, send=myint_send, passedbyvalue, internallength=4);
+create function myint_lt(myint, myint) returns boolean as 'int4lt' language internal immutable strict;
+create function myint_le(myint, myint) returns boolean as 'int4le' language internal immutable strict;
+create function myint_gt(myint, myint) returns boolean as 'int4gt' language internal immutable strict;
+create function myint_ge(myint, myint) returns boolean as 'int4ge' language internal immutable strict;
+create function myint_eq(myint, myint) returns boolean as 'int4eq' language internal immutable strict;
+create function myint_ne(myint, myint) returns boolean as 'int4ne' language internal immutable strict;
+create operator < (leftarg=myint, rightarg=myint, procedure=myint_lt, commutator= >, negator= >=, restrict=scalarltsel, join=scalarltjoinsel);
+create operator > (leftarg=myint, rightarg=myint, procedure=myint_gt, commutator= <, negator= <=, restrict=scalargtsel, join=scalargtjoinsel);
+create operator <= (leftarg=myint, rightarg=myint, procedure=myint_le, commutator= >=, negator= >, restrict=scalarltsel, join=scalarltjoinsel);
+create operator >= (leftarg=myint, rightarg=myint, procedure=myint_ge, commutator= <=, negator= <, restrict=scalargtsel, join=scalargtjoinsel);
+create operator = (leftarg=myint, rightarg=myint, procedure=myint_eq, commutator= =, negator= <>, restrict=eqsel, join=eqjoinsel, hashes, merges);
+create operator <> (leftarg=myint, rightarg=myint, procedure=myint_ne, commutator= <>, negator= =, restrict=neqsel, join=neqjoinsel, merges);
+create function bt_myint_cmp (myint, myint) returns int as 'btint4cmp' language internal immutable strict;
+create operator class bt_myint_ops default for type myint using btree family integer_ops as
+  operator 1 <,
+  operator 2 <=,
+  operator 3 =,
+  operator 4 >=,
+  operator 5 >,
+  function 1 bt_myint_cmp (myint, myint);
+create cast (int as myint) without function as implicit;
+-- Case 1: Test table partitioned by range.
+create table issue_14941_range_part (i myint) partition by range (i) (start ('1') end ('10'));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+NOTICE:  CREATE TABLE will create partition "issue_14941_range_part_1_prt_1" for table "issue_14941_range_part"
+alter table issue_14941_range_part add partition p2 start ('11') end ('20');
+NOTICE:  CREATE TABLE will create partition "issue_14941_range_part_1_prt_p2" for table "issue_14941_range_part"
+-- Test that we're able to insert data into the partition table.
+insert into issue_14941_range_part select i from generate_series(1, 9)i;
+-- Test that we're able to do partition pruning.
+select * from issue_14941_range_part where i >= 1 and i <= 5 order by i;
+ i 
+---
+ 1
+ 2
+ 3
+ 4
+ 5
+(5 rows)
+
+explain (costs off) select * from issue_14941_range_part where i >= 1 and i <= 5 order by i;
+                              QUERY PLAN                               
+-----------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Merge Key: issue_14941_range_part_1_prt_1.i
+   ->  Sort
+         Sort Key: issue_14941_range_part_1_prt_1.i
+         ->  Append
+               ->  Seq Scan on issue_14941_range_part_1_prt_1
+                     Filter: ((i >= '1'::myint) AND (i <= '5'::myint))
+ Optimizer: Postgres query optimizer
+(8 rows)
+
+-- Change search_path, test that we're still able to insert some data into the table.
+set search_path = '';
+insert into part_op_test.issue_14941_range_part select i from generate_series(1, 9)i;
+-- Test that we're still able to do partition pruning even if the search_path has been changed.
+select * from part_op_test.issue_14941_range_part where i operator(part_op_test.>=) 1 and i operator(part_op_test.<=) 5 order by i;
+ i 
+---
+ 1
+ 1
+ 2
+ 2
+ 3
+ 3
+ 4
+ 4
+ 5
+ 5
+(10 rows)
+
+explain (costs off) select * from part_op_test.issue_14941_range_part where i operator(part_op_test.>=) 1 and i operator(part_op_test.<=) 5 order by i;
+                                                                  QUERY PLAN                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Merge Key: issue_14941_range_part_1_prt_1.i
+   ->  Sort
+         Sort Key: issue_14941_range_part_1_prt_1.i
+         ->  Append
+               ->  Seq Scan on issue_14941_range_part_1_prt_1
+                     Filter: ((i OPERATOR(part_op_test.>=) '1'::part_op_test.myint) AND (i OPERATOR(part_op_test.<=) '5'::part_op_test.myint))
+ Optimizer: Postgres query optimizer
+(8 rows)
+
+-- Case 2: Test table partitioned by list.
+set search_path = 'part_op_test';
+create table issue_14941_list_part (i myint)
+  partition by list (i)
+    (partition one values (1),
+     partition two values (2),
+     partition three values (3),
+     partition four values (4));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+NOTICE:  CREATE TABLE will create partition "issue_14941_list_part_1_prt_one" for table "issue_14941_list_part"
+NOTICE:  CREATE TABLE will create partition "issue_14941_list_part_1_prt_two" for table "issue_14941_list_part"
+NOTICE:  CREATE TABLE will create partition "issue_14941_list_part_1_prt_three" for table "issue_14941_list_part"
+NOTICE:  CREATE TABLE will create partition "issue_14941_list_part_1_prt_four" for table "issue_14941_list_part"
+-- Test that we're able to insert data into the partition table.
+insert into issue_14941_list_part select i from generate_series(1, 3)i;
+-- Test that we're able to do partition pruning.
+select * from issue_14941_list_part where i >= 1 and i <= 2 order by i;
+ i 
+---
+ 1
+ 2
+(2 rows)
+
+explain (costs off) select * from issue_14941_list_part where i >= 1 and i <= 2 order by i;
+                              QUERY PLAN                               
+-----------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Merge Key: issue_14941_list_part_1_prt_one.i
+   ->  Sort
+         Sort Key: issue_14941_list_part_1_prt_one.i
+         ->  Append
+               ->  Seq Scan on issue_14941_list_part_1_prt_one
+                     Filter: ((i >= '1'::myint) AND (i <= '2'::myint))
+               ->  Seq Scan on issue_14941_list_part_1_prt_two
+                     Filter: ((i >= '1'::myint) AND (i <= '2'::myint))
+ Optimizer: Postgres query optimizer
+(10 rows)
+
+-- Change search_path, test that we're still able to insert some data into the table.
+set search_path = '';
+insert into part_op_test.issue_14941_list_part select i from generate_series(1, 3)i;
+-- Test that we're still able to do partition pruning even if the search_path has been changed.
+select * from part_op_test.issue_14941_list_part where i operator(part_op_test.>=) 1 and i operator(part_op_test.<=) 2 order by i;
+ i 
+---
+ 1
+ 1
+ 2
+ 2
+(4 rows)
+
+explain (costs off) select * from part_op_test.issue_14941_list_part where i operator(part_op_test.>=) 1 and i operator(part_op_test.<=) 2 order by i;
+                                                                  QUERY PLAN                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Merge Key: issue_14941_list_part_1_prt_one.i
+   ->  Sort
+         Sort Key: issue_14941_list_part_1_prt_one.i
+         ->  Append
+               ->  Seq Scan on issue_14941_list_part_1_prt_one
+                     Filter: ((i OPERATOR(part_op_test.>=) '1'::part_op_test.myint) AND (i OPERATOR(part_op_test.<=) '2'::part_op_test.myint))
+               ->  Seq Scan on issue_14941_list_part_1_prt_two
+                     Filter: ((i OPERATOR(part_op_test.>=) '1'::part_op_test.myint) AND (i OPERATOR(part_op_test.<=) '2'::part_op_test.myint))
+ Optimizer: Postgres query optimizer
+(10 rows)
+
+-- Case 3: Test multiple level partitioned table.
+set search_path = 'part_op_test';
+create table issue_14941_multi_level_part (i1 myint, i2 myint)
+  partition by range (i1)
+  subpartition by list (i2)
+    (partition p1
+      start(1) end(2)
+      (subpartition sp11
+        values(1),
+       subpartition sp12
+        values(2)),
+     partition p2
+      start(2) end(3)
+      (subpartition sp21
+        values(1),
+       subpartition sp22
+        values(2)));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+NOTICE:  CREATE TABLE will create partition "issue_14941_multi_level_part_1_prt_p1" for table "issue_14941_multi_level_part"
+NOTICE:  CREATE TABLE will create partition "issue_14941_multi_level_part_1_prt_p1_2_prt_sp11" for table "issue_14941_multi_level_part_1_prt_p1"
+NOTICE:  CREATE TABLE will create partition "issue_14941_multi_level_part_1_prt_p1_2_prt_sp12" for table "issue_14941_multi_level_part_1_prt_p1"
+NOTICE:  CREATE TABLE will create partition "issue_14941_multi_level_part_1_prt_p2" for table "issue_14941_multi_level_part"
+NOTICE:  CREATE TABLE will create partition "issue_14941_multi_level_part_1_prt_p2_2_prt_sp21" for table "issue_14941_multi_level_part_1_prt_p2"
+NOTICE:  CREATE TABLE will create partition "issue_14941_multi_level_part_1_prt_p2_2_prt_sp22" for table "issue_14941_multi_level_part_1_prt_p2"
+-- Test that we're able to insert data into the partition table.
+insert into issue_14941_multi_level_part select i,i from generate_series(1, 2)i;
+-- Test that we're able to do partition pruning.
+select * from issue_14941_multi_level_part where i1<=1 and i2<=1;
+ i1 | i2 
+----+----
+ 1  | 1
+(1 row)
+
+explain (costs off) select * from issue_14941_multi_level_part where i1<=1 and i2<=1;
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Append
+         ->  Seq Scan on issue_14941_multi_level_part_1_prt_p1_2_prt_sp11
+               Filter: ((i1 <= '1'::myint) AND (i2 <= '1'::myint))
+ Optimizer: Postgres query optimizer
+(5 rows)
+
+-- Change search_path, test that we're still able to insert some data into the table.
+set search_path = '';
+insert into part_op_test.issue_14941_multi_level_part select i, i from generate_series(1, 2)i;
+-- Test that we're still able to do partition pruning even if the search_path has been changed.
+select * from part_op_test.issue_14941_multi_level_part where i1 operator(part_op_test.<=) 1 and i2 operator(part_op_test.<=) 1;
+ i1 | i2 
+----+----
+ 1  | 1
+ 1  | 1
+(2 rows)
+
+explain (costs off) select * from part_op_test.issue_14941_multi_level_part where i1 operator(part_op_test.<=) 1 and i2 operator(part_op_test.<=) 1;
+                                                                QUERY PLAN                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Append
+         ->  Seq Scan on issue_14941_multi_level_part_1_prt_p1_2_prt_sp11
+               Filter: ((i1 OPERATOR(part_op_test.<=) '1'::part_op_test.myint) AND (i2 OPERATOR(part_op_test.<=) '1'::part_op_test.myint))
+ Optimizer: Postgres query optimizer
+(5 rows)
+
+-- Case 4: Test table partitioned by multiple partition keys (range partition table doesn't support multiple partition keys).
+set search_path = 'part_op_test';
+create table issue_14941_multi_level_multi_key_part (i1 myint, i2 myint, i3 int)
+  partition by list (i1, i2)
+  subpartition by list (i3)
+    (partition p1
+      values((1, 1), (1, 2))
+      (subpartition sp11
+        values(1),
+       subpartition sp12
+        values(2)),
+     partition p2
+      values((2, 1), (2, 2))
+      (subpartition sp21
+        values(1),
+       subpartition sp22
+        values(2)));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i3' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "issue_14941_multi_level_multi_key_part_1_prt_p1" for table "issue_14941_multi_level_multi_key_part"
+NOTICE:  CREATE TABLE will create partition "issue_14941_multi_level_multi_key_part_1_prt_p1_2_prt_sp11" for table "issue_14941_multi_level_multi_key_part_1_prt_p1"
+NOTICE:  CREATE TABLE will create partition "issue_14941_multi_level_multi_key_part_1_prt_p1_2_prt_sp12" for table "issue_14941_multi_level_multi_key_part_1_prt_p1"
+NOTICE:  CREATE TABLE will create partition "issue_14941_multi_level_multi_key_part_1_prt_p2" for table "issue_14941_multi_level_multi_key_part"
+NOTICE:  CREATE TABLE will create partition "issue_14941_multi_level_multi_key_part_1_prt_p2_2_prt_sp21" for table "issue_14941_multi_level_multi_key_part_1_prt_p2"
+NOTICE:  CREATE TABLE will create partition "issue_14941_multi_level_multi_key_part_1_prt_p2_2_prt_sp22" for table "issue_14941_multi_level_multi_key_part_1_prt_p2"
+-- Test that we're able to insert data into the partition table.
+insert into issue_14941_multi_level_multi_key_part values (1, 1, 1), (2, 2, 2);
+-- Test that we're able to do partition pruning.
+select * from issue_14941_multi_level_multi_key_part where i1=2 and i2 >= 1 and i3 >= 2;
+ i1 | i2 | i3 
+----+----+----
+ 2  | 2  |  2
+(1 row)
+
+explain (costs off) select * from issue_14941_multi_level_multi_key_part where i1=2 and i2 >= 1 and i3 >= 2;
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Append
+         ->  Seq Scan on issue_14941_multi_level_multi_key_part_1_prt_p2_2_prt_sp22
+               Filter: ((i2 >= '1'::myint) AND (i3 >= 2) AND (i1 = '2'::myint))
+ Optimizer: Postgres query optimizer
+(5 rows)
+
+-- Change search_path, test that we're still able to insert some data into the table.
+set search_path = '';
+insert into part_op_test.issue_14941_multi_level_multi_key_part values (1, 1, 1), (2, 2, 2);
+-- Test that we're still able to do partition pruning even if the search_path has been changed.
+select * from part_op_test.issue_14941_multi_level_multi_key_part
+  where i1 operator(part_op_test.=) 2 and i2 operator(part_op_test.>=) 1 and i3 operator(part_op_test.>=) 2;
+ i1 | i2 | i3 
+----+----+----
+ 2  | 2  |  2
+ 2  | 2  |  2
+(2 rows)
+
+explain (costs off) select * from part_op_test.issue_14941_multi_level_multi_key_part
+  where i1 operator(part_op_test.=) 2 and i2 operator(part_op_test.>=) 1 and i3 operator(part_op_test.>=) 2;
+                                                                                                        QUERY PLAN                                                                                                         
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Append
+         ->  Seq Scan on issue_14941_multi_level_multi_key_part_1_prt_p2_2_prt_sp21
+               Filter: ((i2 OPERATOR(part_op_test.>=) '1'::part_op_test.myint) AND ((i3)::part_op_test.myint OPERATOR(part_op_test.>=) '2'::part_op_test.myint) AND (i1 OPERATOR(part_op_test.=) '2'::part_op_test.myint))
+         ->  Seq Scan on issue_14941_multi_level_multi_key_part_1_prt_p2_2_prt_sp22
+               Filter: ((i2 OPERATOR(part_op_test.>=) '1'::part_op_test.myint) AND ((i3)::part_op_test.myint OPERATOR(part_op_test.>=) '2'::part_op_test.myint) AND (i1 OPERATOR(part_op_test.=) '2'::part_op_test.myint))
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+reset search_path;
+drop schema part_op_test cascade;
+NOTICE:  drop cascades to 24 other objects
+DETAIL:  drop cascades to type part_op_test.myint
+drop cascades to function part_op_test.myint_in(cstring)
+drop cascades to function part_op_test.myint_out(part_op_test.myint)
+drop cascades to function part_op_test.myint_send(part_op_test.myint)
+drop cascades to function part_op_test.myint_recv(internal)
+drop cascades to cast from integer to part_op_test.myint
+drop cascades to function part_op_test.myint_lt(part_op_test.myint,part_op_test.myint)
+drop cascades to function part_op_test.myint_le(part_op_test.myint,part_op_test.myint)
+drop cascades to function part_op_test.myint_gt(part_op_test.myint,part_op_test.myint)
+drop cascades to function part_op_test.myint_ge(part_op_test.myint,part_op_test.myint)
+drop cascades to function part_op_test.myint_eq(part_op_test.myint,part_op_test.myint)
+drop cascades to function part_op_test.myint_ne(part_op_test.myint,part_op_test.myint)
+drop cascades to operator part_op_test.<(part_op_test.myint,part_op_test.myint)
+drop cascades to operator part_op_test.>(part_op_test.myint,part_op_test.myint)
+drop cascades to operator part_op_test.<=(part_op_test.myint,part_op_test.myint)
+drop cascades to operator part_op_test.>=(part_op_test.myint,part_op_test.myint)
+drop cascades to operator part_op_test.=(part_op_test.myint,part_op_test.myint)
+drop cascades to operator part_op_test.<>(part_op_test.myint,part_op_test.myint)
+drop cascades to function part_op_test.bt_myint_cmp(part_op_test.myint,part_op_test.myint)
+drop cascades to operator class part_op_test.bt_myint_ops for access method btree
+drop cascades to table part_op_test.issue_14941_range_part
+drop cascades to table part_op_test.issue_14941_list_part
+drop cascades to table part_op_test.issue_14941_multi_level_part
+drop cascades to table part_op_test.issue_14941_multi_level_multi_key_part

--- a/src/test/regress/expected/partition_optimizer.out
+++ b/src/test/regress/expected/partition_optimizer.out
@@ -8665,3 +8665,341 @@ create table rnd_distribution(a1 int, a int, b int, c int) distributed randomly;
 alter table rnd_distribution drop column a1;
 alter table tbl_default_distribution exchange partition for (rank(2)) with table rnd_distribution;
 ERROR:  distribution policy for "rnd_distribution" must be the same as that for "tbl_default_distribution"
+--
+-- Test that we are able to partition a table by custom created data types.
+--
+-- Create data types and operators under spefic schema.
+-- Historically, Greenplum hardcoded the operators search_path when looking up operators for partitioned tables. However, at the moment that the partitioned table is defined,
+-- the opclass used for defining the partitioned table has been recorded in the parclass column of pg_catalog.pg_partition table. We should retrieve operators according to
+-- parclass just like the behavior Greenplum 7 or PostgreSQL.
+create schema part_op_test;
+set search_path = 'part_op_test';
+create type myint;
+create function myint_in(cstring) returns myint as 'int4in' language internal immutable strict;
+NOTICE:  return type myint is only a shell
+create function myint_out(myint) returns cstring as 'int4out' language internal immutable strict;
+NOTICE:  argument type myint is only a shell
+create function myint_send(myint) returns bytea as 'int4send' language internal immutable strict;
+NOTICE:  argument type myint is only a shell
+create function myint_recv(internal) returns myint as 'int4recv' language internal immutable strict;
+NOTICE:  return type myint is only a shell
+create type myint (input=myint_in, output=myint_out, receive=myint_recv, send=myint_send, passedbyvalue, internallength=4);
+create function myint_lt(myint, myint) returns boolean as 'int4lt' language internal immutable strict;
+create function myint_le(myint, myint) returns boolean as 'int4le' language internal immutable strict;
+create function myint_gt(myint, myint) returns boolean as 'int4gt' language internal immutable strict;
+create function myint_ge(myint, myint) returns boolean as 'int4ge' language internal immutable strict;
+create function myint_eq(myint, myint) returns boolean as 'int4eq' language internal immutable strict;
+create function myint_ne(myint, myint) returns boolean as 'int4ne' language internal immutable strict;
+create operator < (leftarg=myint, rightarg=myint, procedure=myint_lt, commutator= >, negator= >=, restrict=scalarltsel, join=scalarltjoinsel);
+create operator > (leftarg=myint, rightarg=myint, procedure=myint_gt, commutator= <, negator= <=, restrict=scalargtsel, join=scalargtjoinsel);
+create operator <= (leftarg=myint, rightarg=myint, procedure=myint_le, commutator= >=, negator= >, restrict=scalarltsel, join=scalarltjoinsel);
+create operator >= (leftarg=myint, rightarg=myint, procedure=myint_ge, commutator= <=, negator= <, restrict=scalargtsel, join=scalargtjoinsel);
+create operator = (leftarg=myint, rightarg=myint, procedure=myint_eq, commutator= =, negator= <>, restrict=eqsel, join=eqjoinsel, hashes, merges);
+create operator <> (leftarg=myint, rightarg=myint, procedure=myint_ne, commutator= <>, negator= =, restrict=neqsel, join=neqjoinsel, merges);
+create function bt_myint_cmp (myint, myint) returns int as 'btint4cmp' language internal immutable strict;
+create operator class bt_myint_ops default for type myint using btree family integer_ops as
+  operator 1 <,
+  operator 2 <=,
+  operator 3 =,
+  operator 4 >=,
+  operator 5 >,
+  function 1 bt_myint_cmp (myint, myint);
+create cast (int as myint) without function as implicit;
+-- Case 1: Test table partitioned by range.
+create table issue_14941_range_part (i myint) partition by range (i) (start ('1') end ('10'));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+NOTICE:  CREATE TABLE will create partition "issue_14941_range_part_1_prt_1" for table "issue_14941_range_part"
+alter table issue_14941_range_part add partition p2 start ('11') end ('20');
+NOTICE:  CREATE TABLE will create partition "issue_14941_range_part_1_prt_p2" for table "issue_14941_range_part"
+-- Test that we're able to insert data into the partition table.
+insert into issue_14941_range_part select i from generate_series(1, 9)i;
+-- Test that we're able to do partition pruning.
+select * from issue_14941_range_part where i >= 1 and i <= 5 order by i;
+ i 
+---
+ 1
+ 2
+ 3
+ 4
+ 5
+(5 rows)
+
+explain (costs off) select * from issue_14941_range_part where i >= 1 and i <= 5 order by i;
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Merge Key: i
+   ->  Sort
+         Sort Key: i
+         ->  Sequence
+               ->  Partition Selector for issue_14941_range_part (dynamic scan id: 1)
+                     Partitions selected: 1 (out of 2)
+               ->  Dynamic Seq Scan on issue_14941_range_part (dynamic scan id: 1)
+                     Filter: ((i >= '1'::myint) AND (i <= '5'::myint))
+ Optimizer: Pivotal Optimizer (GPORCA)
+(10 rows)
+
+-- Change search_path, test that we're still able to insert some data into the table.
+set search_path = '';
+insert into part_op_test.issue_14941_range_part select i from generate_series(1, 9)i;
+-- Test that we're still able to do partition pruning even if the search_path has been changed.
+select * from part_op_test.issue_14941_range_part where i operator(part_op_test.>=) 1 and i operator(part_op_test.<=) 5 order by i;
+ i 
+---
+ 1
+ 1
+ 2
+ 2
+ 3
+ 3
+ 4
+ 4
+ 5
+ 5
+(10 rows)
+
+explain (costs off) select * from part_op_test.issue_14941_range_part where i operator(part_op_test.>=) 1 and i operator(part_op_test.<=) 5 order by i;
+                                                                  QUERY PLAN                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Merge Key: i
+   ->  Sort
+         Sort Key: i
+         ->  Sequence
+               ->  Partition Selector for issue_14941_range_part (dynamic scan id: 1)
+                     Partitions selected: 1 (out of 2)
+               ->  Dynamic Seq Scan on issue_14941_range_part (dynamic scan id: 1)
+                     Filter: ((i OPERATOR(part_op_test.>=) '1'::part_op_test.myint) AND (i OPERATOR(part_op_test.<=) '5'::part_op_test.myint))
+ Optimizer: Pivotal Optimizer (GPORCA)
+(10 rows)
+
+-- Case 2: Test table partitioned by list.
+set search_path = 'part_op_test';
+create table issue_14941_list_part (i myint)
+  partition by list (i)
+    (partition one values (1),
+     partition two values (2),
+     partition three values (3),
+     partition four values (4));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+NOTICE:  CREATE TABLE will create partition "issue_14941_list_part_1_prt_one" for table "issue_14941_list_part"
+NOTICE:  CREATE TABLE will create partition "issue_14941_list_part_1_prt_two" for table "issue_14941_list_part"
+NOTICE:  CREATE TABLE will create partition "issue_14941_list_part_1_prt_three" for table "issue_14941_list_part"
+NOTICE:  CREATE TABLE will create partition "issue_14941_list_part_1_prt_four" for table "issue_14941_list_part"
+-- Test that we're able to insert data into the partition table.
+insert into issue_14941_list_part select i from generate_series(1, 3)i;
+-- Test that we're able to do partition pruning.
+select * from issue_14941_list_part where i >= 1 and i <= 2 order by i;
+ i 
+---
+ 1
+ 2
+(2 rows)
+
+explain (costs off) select * from issue_14941_list_part where i >= 1 and i <= 2 order by i;
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Merge Key: i
+   ->  Sort
+         Sort Key: i
+         ->  Sequence
+               ->  Partition Selector for issue_14941_list_part (dynamic scan id: 1)
+                     Partitions selected: 2 (out of 4)
+               ->  Dynamic Seq Scan on issue_14941_list_part (dynamic scan id: 1)
+                     Filter: ((i >= '1'::myint) AND (i <= '2'::myint))
+ Optimizer: Pivotal Optimizer (GPORCA)
+(10 rows)
+
+-- Change search_path, test that we're still able to insert some data into the table.
+set search_path = '';
+insert into part_op_test.issue_14941_list_part select i from generate_series(1, 3)i;
+-- Test that we're still able to do partition pruning even if the search_path has been changed.
+select * from part_op_test.issue_14941_list_part where i operator(part_op_test.>=) 1 and i operator(part_op_test.<=) 2 order by i;
+ i 
+---
+ 1
+ 1
+ 2
+ 2
+(4 rows)
+
+explain (costs off) select * from part_op_test.issue_14941_list_part where i operator(part_op_test.>=) 1 and i operator(part_op_test.<=) 2 order by i;
+                                                                  QUERY PLAN                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Merge Key: i
+   ->  Sort
+         Sort Key: i
+         ->  Sequence
+               ->  Partition Selector for issue_14941_list_part (dynamic scan id: 1)
+                     Partitions selected: 2 (out of 4)
+               ->  Dynamic Seq Scan on issue_14941_list_part (dynamic scan id: 1)
+                     Filter: ((i OPERATOR(part_op_test.>=) '1'::part_op_test.myint) AND (i OPERATOR(part_op_test.<=) '2'::part_op_test.myint))
+ Optimizer: Pivotal Optimizer (GPORCA)
+(10 rows)
+
+-- Case 3: Test multiple level partitioned table.
+set search_path = 'part_op_test';
+create table issue_14941_multi_level_part (i1 myint, i2 myint)
+  partition by range (i1)
+  subpartition by list (i2)
+    (partition p1
+      start(1) end(2)
+      (subpartition sp11
+        values(1),
+       subpartition sp12
+        values(2)),
+     partition p2
+      start(2) end(3)
+      (subpartition sp21
+        values(1),
+       subpartition sp22
+        values(2)));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
+NOTICE:  CREATE TABLE will create partition "issue_14941_multi_level_part_1_prt_p1" for table "issue_14941_multi_level_part"
+NOTICE:  CREATE TABLE will create partition "issue_14941_multi_level_part_1_prt_p1_2_prt_sp11" for table "issue_14941_multi_level_part_1_prt_p1"
+NOTICE:  CREATE TABLE will create partition "issue_14941_multi_level_part_1_prt_p1_2_prt_sp12" for table "issue_14941_multi_level_part_1_prt_p1"
+NOTICE:  CREATE TABLE will create partition "issue_14941_multi_level_part_1_prt_p2" for table "issue_14941_multi_level_part"
+NOTICE:  CREATE TABLE will create partition "issue_14941_multi_level_part_1_prt_p2_2_prt_sp21" for table "issue_14941_multi_level_part_1_prt_p2"
+NOTICE:  CREATE TABLE will create partition "issue_14941_multi_level_part_1_prt_p2_2_prt_sp22" for table "issue_14941_multi_level_part_1_prt_p2"
+-- Test that we're able to insert data into the partition table.
+insert into issue_14941_multi_level_part select i,i from generate_series(1, 2)i;
+-- Test that we're able to do partition pruning.
+select * from issue_14941_multi_level_part where i1<=1 and i2<=1;
+ i1 | i2 
+----+----
+ 1  | 1
+(1 row)
+
+explain (costs off) select * from issue_14941_multi_level_part where i1<=1 and i2<=1;
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Sequence
+         ->  Partition Selector for issue_14941_multi_level_part (dynamic scan id: 1)
+               Partitions selected: 1 (out of 4)
+         ->  Dynamic Seq Scan on issue_14941_multi_level_part (dynamic scan id: 1)
+               Filter: ((i1 <= '1'::myint) AND (i2 <= '1'::myint))
+ Optimizer: Pivotal Optimizer (GPORCA)
+(7 rows)
+
+-- Change search_path, test that we're still able to insert some data into the table.
+set search_path = '';
+insert into part_op_test.issue_14941_multi_level_part select i, i from generate_series(1, 2)i;
+-- Test that we're still able to do partition pruning even if the search_path has been changed.
+select * from part_op_test.issue_14941_multi_level_part where i1 operator(part_op_test.<=) 1 and i2 operator(part_op_test.<=) 1;
+ i1 | i2 
+----+----
+ 1  | 1
+ 1  | 1
+(2 rows)
+
+explain (costs off) select * from part_op_test.issue_14941_multi_level_part where i1 operator(part_op_test.<=) 1 and i2 operator(part_op_test.<=) 1;
+                                                                QUERY PLAN                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Sequence
+         ->  Partition Selector for issue_14941_multi_level_part (dynamic scan id: 1)
+               Partitions selected: 1 (out of 4)
+         ->  Dynamic Seq Scan on issue_14941_multi_level_part (dynamic scan id: 1)
+               Filter: ((i1 OPERATOR(part_op_test.<=) '1'::part_op_test.myint) AND (i2 OPERATOR(part_op_test.<=) '1'::part_op_test.myint))
+ Optimizer: Pivotal Optimizer (GPORCA)
+(7 rows)
+
+-- Case 4: Test table partitioned by multiple partition keys (range partition table doesn't support multiple partition keys).
+set search_path = 'part_op_test';
+create table issue_14941_multi_level_multi_key_part (i1 myint, i2 myint, i3 int)
+  partition by list (i1, i2)
+  subpartition by list (i3)
+    (partition p1
+      values((1, 1), (1, 2))
+      (subpartition sp11
+        values(1),
+       subpartition sp12
+        values(2)),
+     partition p2
+      values((2, 1), (2, 2))
+      (subpartition sp21
+        values(1),
+       subpartition sp22
+        values(2)));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i3' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "issue_14941_multi_level_multi_key_part_1_prt_p1" for table "issue_14941_multi_level_multi_key_part"
+NOTICE:  CREATE TABLE will create partition "issue_14941_multi_level_multi_key_part_1_prt_p1_2_prt_sp11" for table "issue_14941_multi_level_multi_key_part_1_prt_p1"
+NOTICE:  CREATE TABLE will create partition "issue_14941_multi_level_multi_key_part_1_prt_p1_2_prt_sp12" for table "issue_14941_multi_level_multi_key_part_1_prt_p1"
+NOTICE:  CREATE TABLE will create partition "issue_14941_multi_level_multi_key_part_1_prt_p2" for table "issue_14941_multi_level_multi_key_part"
+NOTICE:  CREATE TABLE will create partition "issue_14941_multi_level_multi_key_part_1_prt_p2_2_prt_sp21" for table "issue_14941_multi_level_multi_key_part_1_prt_p2"
+NOTICE:  CREATE TABLE will create partition "issue_14941_multi_level_multi_key_part_1_prt_p2_2_prt_sp22" for table "issue_14941_multi_level_multi_key_part_1_prt_p2"
+-- Test that we're able to insert data into the partition table.
+insert into issue_14941_multi_level_multi_key_part values (1, 1, 1), (2, 2, 2);
+-- Test that we're able to do partition pruning.
+select * from issue_14941_multi_level_multi_key_part where i1=2 and i2 >= 1 and i3 >= 2;
+ i1 | i2 | i3 
+----+----+----
+ 2  | 2  |  2
+(1 row)
+
+explain (costs off) select * from issue_14941_multi_level_multi_key_part where i1=2 and i2 >= 1 and i3 >= 2;
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Append
+         ->  Seq Scan on issue_14941_multi_level_multi_key_part_1_prt_p2_2_prt_sp22
+               Filter: ((i2 >= '1'::myint) AND (i3 >= 2) AND (i1 = '2'::myint))
+ Optimizer: Postgres query optimizer
+(5 rows)
+
+-- Change search_path, test that we're still able to insert some data into the table.
+set search_path = '';
+insert into part_op_test.issue_14941_multi_level_multi_key_part values (1, 1, 1), (2, 2, 2);
+-- Test that we're still able to do partition pruning even if the search_path has been changed.
+select * from part_op_test.issue_14941_multi_level_multi_key_part
+  where i1 operator(part_op_test.=) 2 and i2 operator(part_op_test.>=) 1 and i3 operator(part_op_test.>=) 2;
+ i1 | i2 | i3 
+----+----+----
+ 2  | 2  |  2
+ 2  | 2  |  2
+(2 rows)
+
+explain (costs off) select * from part_op_test.issue_14941_multi_level_multi_key_part
+  where i1 operator(part_op_test.=) 2 and i2 operator(part_op_test.>=) 1 and i3 operator(part_op_test.>=) 2;
+                                                                                                        QUERY PLAN                                                                                                         
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Append
+         ->  Seq Scan on issue_14941_multi_level_multi_key_part_1_prt_p2_2_prt_sp21
+               Filter: ((i2 OPERATOR(part_op_test.>=) '1'::part_op_test.myint) AND ((i3)::part_op_test.myint OPERATOR(part_op_test.>=) '2'::part_op_test.myint) AND (i1 OPERATOR(part_op_test.=) '2'::part_op_test.myint))
+         ->  Seq Scan on issue_14941_multi_level_multi_key_part_1_prt_p2_2_prt_sp22
+               Filter: ((i2 OPERATOR(part_op_test.>=) '1'::part_op_test.myint) AND ((i3)::part_op_test.myint OPERATOR(part_op_test.>=) '2'::part_op_test.myint) AND (i1 OPERATOR(part_op_test.=) '2'::part_op_test.myint))
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+reset search_path;
+drop schema part_op_test cascade;
+NOTICE:  drop cascades to 24 other objects
+DETAIL:  drop cascades to type part_op_test.myint
+drop cascades to function part_op_test.myint_in(cstring)
+drop cascades to function part_op_test.myint_out(part_op_test.myint)
+drop cascades to function part_op_test.myint_send(part_op_test.myint)
+drop cascades to function part_op_test.myint_recv(internal)
+drop cascades to cast from integer to part_op_test.myint
+drop cascades to function part_op_test.myint_lt(part_op_test.myint,part_op_test.myint)
+drop cascades to function part_op_test.myint_le(part_op_test.myint,part_op_test.myint)
+drop cascades to function part_op_test.myint_gt(part_op_test.myint,part_op_test.myint)
+drop cascades to function part_op_test.myint_ge(part_op_test.myint,part_op_test.myint)
+drop cascades to function part_op_test.myint_eq(part_op_test.myint,part_op_test.myint)
+drop cascades to function part_op_test.myint_ne(part_op_test.myint,part_op_test.myint)
+drop cascades to operator part_op_test.<(part_op_test.myint,part_op_test.myint)
+drop cascades to operator part_op_test.>(part_op_test.myint,part_op_test.myint)
+drop cascades to operator part_op_test.<=(part_op_test.myint,part_op_test.myint)
+drop cascades to operator part_op_test.>=(part_op_test.myint,part_op_test.myint)
+drop cascades to operator part_op_test.=(part_op_test.myint,part_op_test.myint)
+drop cascades to operator part_op_test.<>(part_op_test.myint,part_op_test.myint)
+drop cascades to function part_op_test.bt_myint_cmp(part_op_test.myint,part_op_test.myint)
+drop cascades to operator class part_op_test.bt_myint_ops for access method btree
+drop cascades to table part_op_test.issue_14941_range_part
+drop cascades to table part_op_test.issue_14941_list_part
+drop cascades to table part_op_test.issue_14941_multi_level_part
+drop cascades to table part_op_test.issue_14941_multi_level_multi_key_part

--- a/src/test/regress/sql/partition.sql
+++ b/src/test/regress/sql/partition.sql
@@ -4185,3 +4185,139 @@ alter table tbl_default_distribution exchange partition for (rank(2)) with table
 create table rnd_distribution(a1 int, a int, b int, c int) distributed randomly;
 alter table rnd_distribution drop column a1;
 alter table tbl_default_distribution exchange partition for (rank(2)) with table rnd_distribution;
+
+--
+-- Test that we are able to partition a table by custom created data types.
+--
+-- Create data types and operators under spefic schema.
+-- Historically, Greenplum hardcoded the operators search_path when looking up operators for partitioned tables. However, at the moment that the partitioned table is defined,
+-- the opclass used for defining the partitioned table has been recorded in the parclass column of pg_catalog.pg_partition table. We should retrieve operators according to
+-- parclass just like the behavior Greenplum 7 or PostgreSQL.
+create schema part_op_test;
+set search_path = 'part_op_test';
+create type myint;
+create function myint_in(cstring) returns myint as 'int4in' language internal immutable strict;
+create function myint_out(myint) returns cstring as 'int4out' language internal immutable strict;
+create function myint_send(myint) returns bytea as 'int4send' language internal immutable strict;
+create function myint_recv(internal) returns myint as 'int4recv' language internal immutable strict;
+create type myint (input=myint_in, output=myint_out, receive=myint_recv, send=myint_send, passedbyvalue, internallength=4);
+create function myint_lt(myint, myint) returns boolean as 'int4lt' language internal immutable strict;
+create function myint_le(myint, myint) returns boolean as 'int4le' language internal immutable strict;
+create function myint_gt(myint, myint) returns boolean as 'int4gt' language internal immutable strict;
+create function myint_ge(myint, myint) returns boolean as 'int4ge' language internal immutable strict;
+create function myint_eq(myint, myint) returns boolean as 'int4eq' language internal immutable strict;
+create function myint_ne(myint, myint) returns boolean as 'int4ne' language internal immutable strict;
+create operator < (leftarg=myint, rightarg=myint, procedure=myint_lt, commutator= >, negator= >=, restrict=scalarltsel, join=scalarltjoinsel);
+create operator > (leftarg=myint, rightarg=myint, procedure=myint_gt, commutator= <, negator= <=, restrict=scalargtsel, join=scalargtjoinsel);
+create operator <= (leftarg=myint, rightarg=myint, procedure=myint_le, commutator= >=, negator= >, restrict=scalarltsel, join=scalarltjoinsel);
+create operator >= (leftarg=myint, rightarg=myint, procedure=myint_ge, commutator= <=, negator= <, restrict=scalargtsel, join=scalargtjoinsel);
+create operator = (leftarg=myint, rightarg=myint, procedure=myint_eq, commutator= =, negator= <>, restrict=eqsel, join=eqjoinsel, hashes, merges);
+create operator <> (leftarg=myint, rightarg=myint, procedure=myint_ne, commutator= <>, negator= =, restrict=neqsel, join=neqjoinsel, merges);
+create function bt_myint_cmp (myint, myint) returns int as 'btint4cmp' language internal immutable strict;
+create operator class bt_myint_ops default for type myint using btree family integer_ops as
+  operator 1 <,
+  operator 2 <=,
+  operator 3 =,
+  operator 4 >=,
+  operator 5 >,
+  function 1 bt_myint_cmp (myint, myint);
+create cast (int as myint) without function as implicit;
+
+-- Case 1: Test table partitioned by range.
+create table issue_14941_range_part (i myint) partition by range (i) (start ('1') end ('10'));
+alter table issue_14941_range_part add partition p2 start ('11') end ('20');
+-- Test that we're able to insert data into the partition table.
+insert into issue_14941_range_part select i from generate_series(1, 9)i;
+-- Test that we're able to do partition pruning.
+select * from issue_14941_range_part where i >= 1 and i <= 5 order by i;
+explain (costs off) select * from issue_14941_range_part where i >= 1 and i <= 5 order by i;
+-- Change search_path, test that we're still able to insert some data into the table.
+set search_path = '';
+insert into part_op_test.issue_14941_range_part select i from generate_series(1, 9)i;
+-- Test that we're still able to do partition pruning even if the search_path has been changed.
+select * from part_op_test.issue_14941_range_part where i operator(part_op_test.>=) 1 and i operator(part_op_test.<=) 5 order by i;
+explain (costs off) select * from part_op_test.issue_14941_range_part where i operator(part_op_test.>=) 1 and i operator(part_op_test.<=) 5 order by i;
+
+-- Case 2: Test table partitioned by list.
+set search_path = 'part_op_test';
+create table issue_14941_list_part (i myint)
+  partition by list (i)
+    (partition one values (1),
+     partition two values (2),
+     partition three values (3),
+     partition four values (4));
+-- Test that we're able to insert data into the partition table.
+insert into issue_14941_list_part select i from generate_series(1, 3)i;
+-- Test that we're able to do partition pruning.
+select * from issue_14941_list_part where i >= 1 and i <= 2 order by i;
+explain (costs off) select * from issue_14941_list_part where i >= 1 and i <= 2 order by i;
+
+-- Change search_path, test that we're still able to insert some data into the table.
+set search_path = '';
+insert into part_op_test.issue_14941_list_part select i from generate_series(1, 3)i;
+-- Test that we're still able to do partition pruning even if the search_path has been changed.
+select * from part_op_test.issue_14941_list_part where i operator(part_op_test.>=) 1 and i operator(part_op_test.<=) 2 order by i;
+explain (costs off) select * from part_op_test.issue_14941_list_part where i operator(part_op_test.>=) 1 and i operator(part_op_test.<=) 2 order by i;
+
+-- Case 3: Test multiple level partitioned table.
+set search_path = 'part_op_test';
+create table issue_14941_multi_level_part (i1 myint, i2 myint)
+  partition by range (i1)
+  subpartition by list (i2)
+    (partition p1
+      start(1) end(2)
+      (subpartition sp11
+        values(1),
+       subpartition sp12
+        values(2)),
+     partition p2
+      start(2) end(3)
+      (subpartition sp21
+        values(1),
+       subpartition sp22
+        values(2)));
+-- Test that we're able to insert data into the partition table.
+insert into issue_14941_multi_level_part select i,i from generate_series(1, 2)i;
+-- Test that we're able to do partition pruning.
+select * from issue_14941_multi_level_part where i1<=1 and i2<=1;
+explain (costs off) select * from issue_14941_multi_level_part where i1<=1 and i2<=1;
+-- Change search_path, test that we're still able to insert some data into the table.
+set search_path = '';
+insert into part_op_test.issue_14941_multi_level_part select i, i from generate_series(1, 2)i;
+-- Test that we're still able to do partition pruning even if the search_path has been changed.
+select * from part_op_test.issue_14941_multi_level_part where i1 operator(part_op_test.<=) 1 and i2 operator(part_op_test.<=) 1;
+explain (costs off) select * from part_op_test.issue_14941_multi_level_part where i1 operator(part_op_test.<=) 1 and i2 operator(part_op_test.<=) 1;
+
+-- Case 4: Test table partitioned by multiple partition keys (range partition table doesn't support multiple partition keys).
+set search_path = 'part_op_test';
+create table issue_14941_multi_level_multi_key_part (i1 myint, i2 myint, i3 int)
+  partition by list (i1, i2)
+  subpartition by list (i3)
+    (partition p1
+      values((1, 1), (1, 2))
+      (subpartition sp11
+        values(1),
+       subpartition sp12
+        values(2)),
+     partition p2
+      values((2, 1), (2, 2))
+      (subpartition sp21
+        values(1),
+       subpartition sp22
+        values(2)));
+-- Test that we're able to insert data into the partition table.
+insert into issue_14941_multi_level_multi_key_part values (1, 1, 1), (2, 2, 2);
+-- Test that we're able to do partition pruning.
+select * from issue_14941_multi_level_multi_key_part where i1=2 and i2 >= 1 and i3 >= 2;
+explain (costs off) select * from issue_14941_multi_level_multi_key_part where i1=2 and i2 >= 1 and i3 >= 2;
+-- Change search_path, test that we're still able to insert some data into the table.
+set search_path = '';
+insert into part_op_test.issue_14941_multi_level_multi_key_part values (1, 1, 1), (2, 2, 2);
+-- Test that we're still able to do partition pruning even if the search_path has been changed.
+select * from part_op_test.issue_14941_multi_level_multi_key_part
+  where i1 operator(part_op_test.=) 2 and i2 operator(part_op_test.>=) 1 and i3 operator(part_op_test.>=) 2;
+explain (costs off) select * from part_op_test.issue_14941_multi_level_multi_key_part
+  where i1 operator(part_op_test.=) 2 and i2 operator(part_op_test.>=) 1 and i3 operator(part_op_test.>=) 2;
+
+reset search_path;
+drop schema part_op_test cascade;


### PR DESCRIPTION
Historically, we hardedcode searching path in Greenplum when retrieving operators for partitioned table.  When inserting data into gpdb, it looks up operators in the 'pg_catalog' schema.  That is to say, we cannot partition a table with user defined types unless we create the type and its associated operators inside the 'pg_catalog' schema.  This patch helps resolve the problem by looking up operators using the opclass that we use when defining the partitioned table.

Fix #14941

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [x] Pass `make installcheck`
