### PR TITLE
Fix pg_dump compilation for Windows client

### DIFF
--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -13864,13 +13864,13 @@ dumpTableSchema(Archive *fout, TableInfo *tbinfo)
 			for (int i = 0; i < numExternalPartitions; i++)
 			{
 				int maxParLevel = atoi(PQgetvalue(getExternalPartsResult, i, i_parlevel));
-				int lookupSubRootHierarchyIndex[maxParLevel];
+				int *lookupSubRootHierarchyIndex = (int *) pg_malloc(maxParLevel * sizeof(int));
 				Oid relOid = atooid(PQgetvalue(getExternalPartsResult, i, i_reloid));
 				TableInfo *relInfo = findTableByOid(relOid);
 				char *parentOid = PQgetvalue(getExternalPartsResult, i, i_parparentrule);
-				char *qualTmpExtTable = qualTmpExtTable = pg_strdup(fmtQualifiedId(fout->remoteVersion,
-																				   tbinfo->dobj.namespace->dobj.name,
-																				   relInfo->dobj.name));
+				char *qualTmpExtTable = pg_strdup(fmtQualifiedId(fout->remoteVersion,
+																 tbinfo->dobj.namespace->dobj.name,
+																 relInfo->dobj.name));
 
 				/* Start of the ALTER TABLE EXCHANGE PARTITION statement */
 				appendPQExpBuffer(q, "ALTER TABLE %s ", qualrelname);
@@ -13952,6 +13952,7 @@ dumpTableSchema(Archive *fout, TableInfo *tbinfo)
 				appendPQExpBuffer(q, "DROP TABLE %s;\n", qualTmpExtTable);
 
 				free(qualTmpExtTable);
+				free(lookupSubRootHierarchyIndex);
 			}
 
 			PQclear(getPartHierarchyResult);


### PR DESCRIPTION
The recent pg_dump fixes to handle external partitions introduced some compilation failures for Windows. Specifically, the errors were:
error C2057: expected constant expression
error C2466: cannot allocate an array of constant size 0
error C2133: 'lookupSubRootHierarchyIndex': unknown size

Fix the issue by creating the int array with pg_malloc. Also fix up a minor issue where a string was being instantiated in a weird way which was the result of improper commit splitting (the two commits referenced below were once a single commit but I split them up to make it more easier to understand).

GPDB commit references:
https://github.com/greenplum-db/gpdb/commit/8ecf11fa6eb936afa6875da76fd82332dfb793d2
https://github.com/greenplum-db/gpdb/commit/ca97e829b1403a0e72914a6aa5afc788f9de4ddc
