### PR TITLE
correct fmtopts column output format of pg_exttable

### DIFF
--- a/gpcontrib/gp_exttable_fdw/gp_exttable_fdw.c
+++ b/gpcontrib/gp_exttable_fdw/gp_exttable_fdw.c
@@ -135,10 +135,9 @@ formatOptionsToTextDatum(List *options, char formattype)
 	StringInfoData cfbuf;
 
 	initStringInfo(&cfbuf);
+	bool isfirst = true;
 	if (fmttype_is_text(formattype) || fmttype_is_csv(formattype))
 	{
-		bool isfirst = true;
-
 		/*
 		 * Note: the order of the options should be same with the original
 		 * pg_exttable catalog's fmtopt field.
@@ -176,6 +175,11 @@ formatOptionsToTextDatum(List *options, char formattype)
 			DefElem    *defel = (DefElem *) lfirst(option);
 			char	   *key = defel->defname;
 			char	   *val = (char *) defGetString(defel);
+
+			if (isfirst)
+				isfirst = false;
+			else
+				appendStringInfo(&cfbuf, " ");
 
 			appendStringInfo(&cfbuf, "%s '%s'", key, val);
 		}


### PR DESCRIPTION
make each options delimited by space.

currently only csv and text fmtopts output is delimited by space. we should make all formatters align

current output of custom formatter:
```
gpadmin=# CREATE READABLE EXTERNAL TABLE tbl_ext_fixedwidth (
    s1 char(10), s2 text)
LOCATION ('file://localhost/test.tbl')
FORMAT 'CUSTOM' (formatter='fixedwidth_in', s1=10, s2=10);

gpadmin=# SELECT ext.fmtopts FROM pg_exttable AS ext, pg_class AS c WHERE ext.reloid = c.oid AND c.relname = 'tbl_ext_fixedwidth';
                  fmtopts
-------------------------------------------
 formatter 'fixedwidth_in's1 '10's2 '10'
(1 row)
```
It should be
```
gpadmin=# SELECT ext.fmtopts FROM pg_exttable AS ext, pg_class AS c WHERE ext.reloid = c.oid AND c.relname = 'tbl_ext_fixedwidth';
                  fmtopts
-------------------------------------------
 formatter 'fixedwidth_in' s1 '10' s2 '10'
(1 row)
```

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
