### PR TITLE
Only utility connections are allowed for coordinator-only clusters

### DIFF
--- a/gpMgmt/bin/gpinitsystem
+++ b/gpMgmt/bin/gpinitsystem
@@ -1143,7 +1143,7 @@ SET_LOCALE_VARS_BASED_ON_COORDINATOR() {
 	#
 	# --lc-collate=en_US.utf8 --lc-ctype=en_US.utf8 ...
 	psql_cmd="SELECT '--' || REPLACE(name, '_', '-') || '=' || setting FROM pg_settings WHERE name LIKE 'lc_%' ORDER BY name"
-	export LC_ALL_SETTINGS=$($PSQL -d template1 -X -A -t -c "$psql_cmd")
+	export LC_ALL_SETTINGS=$(env PGOPTIONS="-c gp_role=utility" $PSQL -d template1 -X -A -t -c "$psql_cmd")
 }
 
 CREATE_QD_DB () {

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -2371,7 +2371,7 @@ def impl(context, query, dbname, host, port):
 @then('The user runs psql "{psql_cmd}" against database "{dbname}" when utility mode is set to {utility_mode}')
 @given('The user runs psql "{psql_cmd}" against database "{dbname}" when utility mode is set to {utility_mode}')
 def impl(context, psql_cmd, dbname, utility_mode):
-    if utility_mode == "True":
+    if eval(utility_mode) == 'True':
         cmd = "PGOPTIONS=\'-c gp_role=utility\' psql -d \'{}\' {};".format(dbname, psql_cmd)
     else:
         cmd = "psql -d \'{}\' {};".format(dbname, psql_cmd)

--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -1015,7 +1015,13 @@ PostmasterMain(int argc, char *argv[])
 		ExitPostmaster(1);
 	}
 
-	/* If gp_role is not set, use utility role instead.*/
+	/*
+	 * If gp_role is not set, use utility role instead, and it could not be
+	 * changed by GUC commands because the source is PGC_S_OVERRIDE.
+	 *
+	 * A single node coordinator or segment is set to utility, which is not
+	 * before Greenplum 7.
+	 */
 	if (Gp_role == GP_ROLE_UNDEFINED)
 		SetConfigOption("gp_role", "utility", PGC_POSTMASTER, PGC_S_OVERRIDE);
 

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -4606,7 +4606,8 @@ process_postgres_switches(int argc, char *argv[], GucContext ctx,
 											optarg)));
 					}
 
-					if (strcmp(name, "gp_role") == 0 && strcmp(value, "utility") == 0)
+					if ((strcmp(name, "gp_role") == 0 && strcmp(value, "utility") == 0)
+						|| (strcmp(name, "gp_session_role") == 0 && strcmp(value, "utility") == 0))
 						should_reject_connection = false;
 
 					SetConfigOption(name, value, ctx, gucsource);

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -4605,6 +4605,10 @@ process_postgres_switches(int argc, char *argv[], GucContext ctx,
 									 errmsg("-c %s requires a value",
 											optarg)));
 					}
+
+					if (strcmp(name, "gp_role") == 0 && strcmp(value, "utility") == 0)
+						should_reject_connection = false;
+
 					SetConfigOption(name, value, ctx, gucsource);
 					free(name);
 					if (value)

--- a/src/backend/utils/init/globals.c
+++ b/src/backend/utils/init/globals.c
@@ -191,3 +191,6 @@ int gp_vmem_protect_gang_cache_limit = 500;
 
 /* Parallel cursor concurrency limit */
 int	gp_max_parallel_cursors = -1;
+
+/* Utility mode restriction */
+bool should_reject_connection = false;

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -4334,6 +4334,17 @@ struct config_string ConfigureNamesString_gp[] =
 	},
 
 	{
+		{"gp_session_role", PGC_BACKEND, COMPAT_OPTIONS_PREVIOUS,
+			gettext_noop("Alias of gp_role for compatibility."),
+			gettext_noop("Valid values are DISPATCH, EXECUTE, and UTILITY."),
+			GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE
+		},
+		&gp_role_string,
+		"undefined",
+		check_gp_role, assign_gp_role, show_gp_role
+	},
+
+	{
 		{"gp_role", PGC_BACKEND, GP_WORKER_IDENTITY,
 			gettext_noop("Sets the role for the session."),
 			gettext_noop("Valid values are DISPATCH, EXECUTE, and UTILITY."),

--- a/src/bin/pg_dump/pg_backup_archiver.c
+++ b/src/bin/pg_dump/pg_backup_archiver.c
@@ -416,7 +416,7 @@ RestoreArchive(Archive *AHX)
 		AHX->minRemoteVersion = 0;
 		AHX->maxRemoteVersion = 9999999;
 
-		ConnectDatabase(AHX, &ropt->cparams, false, false);
+		ConnectDatabase(AHX, &ropt->cparams, false, ropt->binary_upgrade);
 
 		/*
 		 * If we're talking to the DB directly, don't send comments since they
@@ -4220,7 +4220,7 @@ restore_toc_entries_postfork(ArchiveHandle *AH, TocEntry *pending_list)
 	/*
 	 * Now reconnect the single parent connection.
 	 */
-	ConnectDatabase((Archive *) AH, &ropt->cparams, true, false);
+	ConnectDatabase((Archive *) AH, &ropt->cparams, true, ropt->binary_upgrade);
 
 	/* re-establish fixed state */
 	_doSetFixedOutputState(AH);
@@ -4885,7 +4885,7 @@ CloneArchive(ArchiveHandle *AH)
 	 * Connect our new clone object to the database, using the same connection
 	 * parameters used for the original connection.
 	 */
-	ConnectDatabase((Archive *) clone, &clone->public.ropt->cparams, true, false);
+	ConnectDatabase((Archive *) clone, &clone->public.ropt->cparams, true, &clone->public.ropt->binary_upgrade);
 
 	/* re-establish fixed state */
 	if (AH->mode == archModeRead)

--- a/src/bin/pg_upgrade/pg_upgrade.c
+++ b/src/bin/pg_upgrade/pg_upgrade.c
@@ -539,6 +539,7 @@ create_new_objects(void)
 				  true,
 				  true,
 				  "\"%s/pg_restore\" %s %s --exit-on-error --verbose "
+				  "--binary-upgrade "
 				  "--dbname postgres \"%s\"",
 				  new_cluster.bindir,
 				  cluster_conn_opts(&new_cluster),

--- a/src/include/miscadmin.h
+++ b/src/include/miscadmin.h
@@ -567,4 +567,6 @@ extern bool has_rolreplication(Oid roleid);
 extern bool BackupInProgress(void);
 extern void CancelBackup(void);
 
+extern bool should_reject_connection;
+
 #endif							/* MISCADMIN_H */

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -238,6 +238,7 @@
 		"gp_server_version",
 		"gp_server_version_num",
 		"gp_session_id",
+		"gp_session_role",
 		"gp_set_proc_affinity",
 		"gp_statistics_pullup_from_child_partition",
 		"gp_statistics_use_fkeys",


### PR DESCRIPTION
Greenplum 7 lost this restriction after this commit:

	commit f6297b96eeb4937629bd796333f6118340613197
	Author: Paul Guo <pguo@pivotal.io>
	Date:   Mon Jun 8 11:00:32 2020 +0800

	    Retire guc gp_session_role (#9396)

To avoid users connecting to and damaging the coordinator-only clusters, get this restriction back.

Co-authored-by: Ashwin Agrawal <aashwin@vmware.com>

Fixes https://github.com/greenplum-db/gpdb/issues/12217