### PR TITLE
Removed duplicate resource group Oid definitions

### DIFF
--- a/src/backend/commands/resgroupcmds.c
+++ b/src/backend/commands/resgroupcmds.c
@@ -291,7 +291,7 @@ DropResourceGroup(DropResourceGroupStmt *stmt)
 	/* cannot DROP default resource groups  */
 	if (groupid == DEFAULTRESGROUP_OID
 		|| groupid == ADMINRESGROUP_OID
-		|| groupid == DEFAULTAUXILIARY_OID)
+		|| groupid == SYSTEMRESGROUP_OID)
 		ereport(ERROR,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 				 errmsg("cannot drop default resource group \"%s\"",

--- a/src/backend/utils/resgroup/cgroup-ops-linux-v1.c
+++ b/src/backend/utils/resgroup/cgroup-ops-linux-v1.c
@@ -611,8 +611,8 @@ initcgroup_v1(void)
 	 * the child process to limit the resource usage of the parent process
 	 * and all child processes.
 	 */
-	createcgroup_v1(GPDB_SYSTEM_CGROUP);
-	attachcgroup_v1(GPDB_SYSTEM_CGROUP, PostmasterPid, false);
+	createcgroup_v1(SYSTEMRESGROUP_OID);
+	attachcgroup_v1(SYSTEMRESGROUP_OID, PostmasterPid, false);
 }
 
 /* Adjust GUCs for this OS group implementation */
@@ -848,7 +848,7 @@ detachcgroup_v1(Oid group, CGroupComponentType component, int fd_dir)
 	if (buf_len == 0)
 		return;
 
-	buildPath(GPDB_DEFAULT_CGROUP, BASEDIR_GPDB, component, "cgroup.procs",
+	buildPath(DEFAULTRESGROUP_OID, BASEDIR_GPDB, component, "cgroup.procs",
 			  path, path_size);
 
 	fdw = open(path, O_WRONLY);

--- a/src/backend/utils/resgroup/cgroup-ops-linux-v2.c
+++ b/src/backend/utils/resgroup/cgroup-ops-linux-v2.c
@@ -340,8 +340,8 @@ initcgroup_v2(void)
 	 * the child process to limit the resource usage of the parent process
 	 * and all child processes.
 	 */
-	createcgroup_v2(GPDB_SYSTEM_CGROUP);
-	attachcgroup_v2(GPDB_SYSTEM_CGROUP, PostmasterPid, false);
+	createcgroup_v2(SYSTEMRESGROUP_OID);
+	attachcgroup_v2(SYSTEMRESGROUP_OID, PostmasterPid, false);
 }
 
 /* Adjust GUCs for this OS group implementation */
@@ -541,7 +541,7 @@ detachcgroup_v2(Oid group, CGroupComponentType component, int fd_dir)
 	if (buf_len == 0)
 		return;
 
-	buildPath(GPDB_DEFAULT_CGROUP, BASEDIR_GPDB, component, "cgroup.procs",
+	buildPath(DEFAULTRESGROUP_OID, BASEDIR_GPDB, component, "cgroup.procs",
 			  path, path_size);
 
 	fdw = open(path, O_WRONLY);

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -1200,7 +1200,7 @@ decideResGroup(ResGroupInfo *pGroupInfo)
 
 	if (!group)
 	{
-		groupId = superuser() ? GPDB_ADMIN_CGROUP : GPDB_DEFAULT_CGROUP;
+		groupId = superuser() ? ADMINRESGROUP_OID : DEFAULTRESGROUP_OID;
 		group = groupHashFind(groupId, false);
 	}
 

--- a/src/include/catalog/pg_resgroup.dat
+++ b/src/include/catalog/pg_resgroup.dat
@@ -16,7 +16,7 @@
   rsgname => 'default_group', parent => '0' },
 { oid => '6438', oid_symbol => 'ADMINRESGROUP_OID',
   rsgname => 'admin_group', parent => '0' },
-{ oid => '6441', oid_symbol => 'DEFAULTAUXILIARY_OID',
+{ oid => '6441', oid_symbol => 'SYSTEMRESGROUP_OID',
   rsgname => 'system_group', parent => '0' },
 
 ]

--- a/src/include/utils/cgroup.h
+++ b/src/include/utils/cgroup.h
@@ -17,13 +17,6 @@
 
 #include "postgres.h"
 
-/*
- * The pre-occupied group OID, do not change this!
- */
-#define GPDB_DEFAULT_CGROUP 	6437
-#define GPDB_ADMIN_CGROUP 		6438
-#define GPDB_SYSTEM_CGROUP 		6441
-
 #define MAX_CGROUP_PATHLEN 256
 #define MAX_CGROUP_CONTENTLEN 1024  
 


### PR DESCRIPTION
1. `pg_resgroup.dat` has defined reserved resource group oids. So, there is no need to redefine.
2. `DEFAULTAUXILIARY_OID` was renamed to `SYSTEMRESGROUP_OID`.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
