### PR TITLE
Update fault injector to better handle tableName argument.

### DIFF
--- a/src/backend/utils/misc/faultinjector.c
+++ b/src/backend/utils/misc/faultinjector.c
@@ -324,7 +324,7 @@ FaultInjector_InjectFaultIfSet_out_of_line(
 			/* fault injection is not set for the specified database name */
 			break;
 	
-		if (strcmp(entryShared->tableName, tableNameLocal) != 0)
+		if (strlen(entryShared->tableName) > 0 && strcmp(entryShared->tableName, tableNameLocal) != 0)
 			/* fault injection is not set for the specified table name */
 			break;
 


### PR DESCRIPTION
Calls to FaultInjector_InjectFaultIfSet that provide tableName as an argument currently break early if the tableName does not match the hash entry (set by gp_inject_fault) for the fault. This is problematic because the fault must be set with a specific table name to be triggered at all.

This commit modifies the behavior to only check for matching tableName if the hash entry has a tableName set. This allows for more targeted testing.

Example:

Setting fault without a tableName will trigger for any table:

```
postgres=# SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'skip', '', '', '', 1, 100, 0, dbid)
    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
 gp_inject_fault
-----------------
 Success:
(1 row)

postgres=# copy alter_attach_t1 to '/dev/null';
COPY 100000
postgres=# copy alter_attach_t2 to '/dev/null';
COPY 100000
postgres=# SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'status', dbid)
    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
                                                                                                                   gp_inject_fault
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Success: fault name:'AppendOnlyStorageRead_ReadNextBlock_success' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'100' extra arg:'0' fault injection state:'completed'  num times hit:'100' +
```

Setting fault with a given tableName will trigger only for that table.

```
postgres=# SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'skip', '', '', 'alter_attach_t1', 1, 100, 0, dbid)
    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
 gp_inject_fault
-----------------
 Success:
(1 row)

postgres=# copy alter_attach_t1 to '/dev/null';
COPY 100000
postgres=# copy alter_attach_t2 to '/dev/null';
COPY 100000
postgres=# SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'status', dbid)
    FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
                                                                                                                          gp_inject_fault
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Success: fault name:'AppendOnlyStorageRead_ReadNextBlock_success' fault type:'skip' ddl statement:'' database name:'' table name:'alter_attach_t1' start occurrence:'1' end occurrence:'100' extra arg:'0' fault injection state:'triggered'  num times hit:'51' +
```

Authored-by: Brent Doil <bdoil@vmware.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
