### PR TITLE
Fix bug that nestloop join fails to materialize the inner child for some cases

### DIFF
--- a/gpcontrib/gp_percentile_agg/expected/gp_percentile_agg_optimizer.out
+++ b/gpcontrib/gp_percentile_agg/expected/gp_percentile_agg_optimizer.out
@@ -162,11 +162,12 @@ explain select percentile_cont(0.2) within group (order by a) from generate_seri
                      ->  Nested Loop  (cost=0.00..1324181.29 rows=334 width=20)
                            Join Filter: true
                            ->  Shared Scan (share slice:id -1:0)  (cost=0.00..431.03 rows=334 width=12)
-                           ->  Result  (cost=0.00..431.02 rows=1 width=8)
-                                 ->  Aggregate  (cost=0.00..431.02 rows=1 width=8)
-                                       ->  Shared Scan (share slice:id -1:0)  (cost=0.00..431.02 rows=334 width=8)
+                           ->  Materialize  (cost=0.00..432.02 rows=1 width=8)
+                                 ->  Result  (cost=0.00..431.02 rows=1 width=8)
+                                       ->  Aggregate  (cost=0.00..431.02 rows=1 width=8)
+                                             ->  Shared Scan (share slice:id -1:0)  (cost=0.00..431.02 rows=334 width=8)
  Optimizer: Pivotal Optimizer (GPORCA)
-(17 rows)
+(18 rows)
 
 select percentile_cont(0.2) within group (order by a) from generate_series(1, 100)a;
  percentile_cont 

--- a/src/backend/gporca/data/dxl/minidump/AnyPredicate-Over-UnionOfConsts.mdp
+++ b/src/backend/gporca/data/dxl/minidump/AnyPredicate-Over-UnionOfConsts.mdp
@@ -167,10 +167,10 @@
         </dxl:LogicalConstTable>
       </dxl:LogicalProject>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1266">
+    <dxl:Plan Id="0" SpaceSize="1518">
       <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1724.000506" Rows="1.000000" Width="1"/>
+          <dxl:Cost StartupCost="0" TotalCost="1724.000526" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="5" Alias="?column?">
@@ -195,14 +195,14 @@
         <dxl:OneTimeFilter/>
         <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1724.000505" Rows="2.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="1724.000525" Rows="2.000000" Width="16"/>
           </dxl:Properties>
           <dxl:GroupingColumns>
             <dxl:GroupingColumn ColId="0"/>
           </dxl:GroupingColumns>
           <dxl:ProjList>
             <dxl:ProjElem ColId="7" Alias="ColRef_0007">
-              <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" >
+              <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
                 <dxl:ValuesList ParamType="aggargs">
                   <dxl:Ident ColId="6" ColName="ColRef_0006" TypeMdid="0.16.1.0"/>
                 </dxl:ValuesList>
@@ -212,7 +212,7 @@
               </dxl:AggFunc>
             </dxl:ProjElem>
             <dxl:ProjElem ColId="9" Alias="ColRef_0009">
-              <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" >
+              <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
                 <dxl:ValuesList ParamType="aggargs">
                   <dxl:Ident ColId="8" ColName="ColRef_0008" TypeMdid="0.23.1.0"/>
                 </dxl:ValuesList>
@@ -228,7 +228,7 @@
           <dxl:Filter/>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1724.000475" Rows="2.000000" Width="6"/>
+              <dxl:Cost StartupCost="0" TotalCost="1724.000495" Rows="2.000000" Width="6"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="8" Alias="ColRef_0008">
@@ -254,7 +254,7 @@
             <dxl:OneTimeFilter/>
             <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1724.000463" Rows="2.000000" Width="6"/>
+                <dxl:Cost StartupCost="0" TotalCost="1724.000483" Rows="2.000000" Width="6"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="">
@@ -299,111 +299,125 @@
                   <dxl:OneTimeFilter/>
                 </dxl:Result>
               </dxl:Sort>
-              <dxl:Result>
+              <dxl:Materialize Eager="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="0.000051" Rows="1.000000" Width="5"/>
+                  <dxl:Cost StartupCost="0" TotalCost="0.000056" Rows="1.000000" Width="5"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="6" Alias="ColRef_0006">
-                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                    <dxl:Ident ColId="6" ColName="ColRef_0006" TypeMdid="0.16.1.0"/>
                   </dxl:ProjElem>
                   <dxl:ProjElem ColId="2" Alias="?column?">
                     <dxl:Ident ColId="2" ColName="?column?" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
-                <dxl:OneTimeFilter/>
-                <dxl:Append IsTarget="false" IsZapped="false">
+                <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="0.000046" Rows="2.000000" Width="4"/>
+                    <dxl:Cost StartupCost="0" TotalCost="0.000051" Rows="1.000000" Width="5"/>
                   </dxl:Properties>
                   <dxl:ProjList>
+                    <dxl:ProjElem ColId="6" Alias="ColRef_0006">
+                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                    </dxl:ProjElem>
                     <dxl:ProjElem ColId="2" Alias="?column?">
                       <dxl:Ident ColId="2" ColName="?column?" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:Result>
+                  <dxl:OneTimeFilter/>
+                  <dxl:Append IsTarget="false" IsZapped="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="0.000000" Rows="1.000000" Width="4"/>
+                      <dxl:Cost StartupCost="0" TotalCost="0.000046" Rows="2.000000" Width="4"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="2" Alias="?column?">
                         <dxl:Ident ColId="2" ColName="?column?" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
                     </dxl:ProjList>
-                    <dxl:Filter>
-                      <dxl:IsNotFalse>
-                        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                          <dxl:Ident ColId="2" ColName="?column?" TypeMdid="0.23.1.0"/>
-                        </dxl:Comparison>
-                      </dxl:IsNotFalse>
-                    </dxl:Filter>
-                    <dxl:OneTimeFilter/>
+                    <dxl:Filter/>
                     <dxl:Result>
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="0.000000" Rows="0.000000" Width="4"/>
+                        <dxl:Cost StartupCost="0" TotalCost="0.000000" Rows="1.000000" Width="4"/>
                       </dxl:Properties>
                       <dxl:ProjList>
-                        <dxl:ProjElem ColId="1" Alias="">
-                          <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true"/>
-                        </dxl:ProjElem>
                         <dxl:ProjElem ColId="2" Alias="?column?">
-                          <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
+                          <dxl:Ident ColId="2" ColName="?column?" TypeMdid="0.23.1.0"/>
                         </dxl:ProjElem>
                       </dxl:ProjList>
-                      <dxl:Filter/>
-                      <dxl:OneTimeFilter>
-                        <dxl:ConstValue TypeMdid="0.16.1.0" Value="false"/>
-                      </dxl:OneTimeFilter>
-                    </dxl:Result>
-                  </dxl:Result>
-                  <dxl:Result>
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="0.000038" Rows="1.000000" Width="4"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="4" Alias="?column?">
-                        <dxl:Ident ColId="4" ColName="?column?" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:Filter>
-                      <dxl:IsNotFalse>
-                        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                          <dxl:Ident ColId="4" ColName="?column?" TypeMdid="0.23.1.0"/>
-                        </dxl:Comparison>
-                      </dxl:IsNotFalse>
-                    </dxl:Filter>
-                    <dxl:OneTimeFilter/>
-                    <dxl:Result>
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
-                      </dxl:Properties>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="4" Alias="?column?">
-                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
-                      <dxl:Filter/>
+                      <dxl:Filter>
+                        <dxl:IsNotFalse>
+                          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                            <dxl:Ident ColId="2" ColName="?column?" TypeMdid="0.23.1.0"/>
+                          </dxl:Comparison>
+                        </dxl:IsNotFalse>
+                      </dxl:Filter>
                       <dxl:OneTimeFilter/>
                       <dxl:Result>
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                          <dxl:Cost StartupCost="0" TotalCost="0.000000" Rows="0.000000" Width="4"/>
                         </dxl:Properties>
                         <dxl:ProjList>
-                          <dxl:ProjElem ColId="3" Alias="">
-                            <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                          <dxl:ProjElem ColId="1" Alias="">
+                            <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="2" Alias="?column?">
+                            <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:OneTimeFilter>
+                          <dxl:ConstValue TypeMdid="0.16.1.0" Value="false"/>
+                        </dxl:OneTimeFilter>
+                      </dxl:Result>
+                    </dxl:Result>
+                    <dxl:Result>
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="0.000038" Rows="1.000000" Width="4"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="4" Alias="?column?">
+                          <dxl:Ident ColId="4" ColName="?column?" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter>
+                        <dxl:IsNotFalse>
+                          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                            <dxl:Ident ColId="4" ColName="?column?" TypeMdid="0.23.1.0"/>
+                          </dxl:Comparison>
+                        </dxl:IsNotFalse>
+                      </dxl:Filter>
+                      <dxl:OneTimeFilter/>
+                      <dxl:Result>
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="4" Alias="?column?">
+                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
                           </dxl:ProjElem>
                         </dxl:ProjList>
                         <dxl:Filter/>
                         <dxl:OneTimeFilter/>
+                        <dxl:Result>
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="3" Alias="">
+                              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:OneTimeFilter/>
+                        </dxl:Result>
                       </dxl:Result>
                     </dxl:Result>
-                  </dxl:Result>
-                </dxl:Append>
-              </dxl:Result>
+                  </dxl:Append>
+                </dxl:Result>
+              </dxl:Materialize>
             </dxl:NestedLoopJoin>
           </dxl:Result>
         </dxl:Aggregate>

--- a/src/backend/gporca/data/dxl/minidump/AnySubq-With-NonScalarSubqueryChild-1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/AnySubq-With-NonScalarSubqueryChild-1.mdp
@@ -471,7 +471,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="2643">
+    <dxl:Plan Id="0" SpaceSize="1110">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1389253302051.813232" Rows="1.000000" Width="15"/>

--- a/src/backend/gporca/data/dxl/minidump/AnySubq-With-NonScalarSubqueryChild-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/AnySubq-With-NonScalarSubqueryChild-2.mdp
@@ -451,7 +451,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="299">
+    <dxl:Plan Id="0" SpaceSize="188">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1356691815.392586" Rows="1.000000" Width="15"/>

--- a/src/backend/gporca/data/dxl/minidump/AnySubq-With-NonScalarSubqueryChild-3.mdp
+++ b/src/backend/gporca/data/dxl/minidump/AnySubq-With-NonScalarSubqueryChild-3.mdp
@@ -420,7 +420,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="418">
+    <dxl:Plan Id="0" SpaceSize="223">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1356691560.030987" Rows="1.000000" Width="15"/>

--- a/src/backend/gporca/data/dxl/minidump/BitmapIndexNLOJWithProject.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndexNLOJWithProject.mdp
@@ -1600,7 +1600,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="4">
+    <dxl:Plan Id="0" SpaceSize="3">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="868.302155" Rows="100.000000" Width="32"/>

--- a/src/backend/gporca/data/dxl/minidump/BitmapIndexNLOJWithProjectNonPart.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndexNLOJWithProjectNonPart.mdp
@@ -1274,7 +1274,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="4">
+    <dxl:Plan Id="0" SpaceSize="3">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="922.216568" Rows="1000.000000" Width="32"/>

--- a/src/backend/gporca/data/dxl/minidump/BitmapIndexScan.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndexScan.mdp
@@ -425,7 +425,7 @@ see sql/BitmapIndexScan.sql
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="27">
+    <dxl:Plan Id="0" SpaceSize="26">
       <dxl:GatherMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="6724.473435" Rows="1.000000" Width="9"/>

--- a/src/backend/gporca/data/dxl/minidump/CTAS_OrderedAgg_multiple_cols.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTAS_OrderedAgg_multiple_cols.mdp
@@ -1808,7 +1808,7 @@ EXPLAIN CREATE TABLE test AS
         </dxl:LogicalProject>
       </dxl:LogicalCTAS>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="16799099328000">
+    <dxl:Plan Id="0" SpaceSize="5813341747200">
       <dxl:PhysicalCTAS Name="fake ctas rel" IsTemporary="true" HasOids="false" StorageType="Heap" DistributionPolicy="Random" InsertColumns="19,20,21" VarTypeModList="-1,-1,-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="2778516240645.427246" Rows="1.000000" Width="24"/>

--- a/src/backend/gporca/data/dxl/minidump/CTEWithMergedGroup.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTEWithMergedGroup.mdp
@@ -425,10 +425,10 @@
         </dxl:LogicalProject>
       </dxl:LogicalCTEAnchor>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="158660247168">
+    <dxl:Plan Id="0" SpaceSize="41793672096">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1356250696.455244" Rows="1.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="1356250698.553420" Rows="1.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="41" Alias="?column?">
@@ -439,7 +439,7 @@
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1356250696.455229" Rows="1.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="1356250698.553405" Rows="1.000000" Width="4"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="41" Alias="?column?">
@@ -450,7 +450,7 @@
           <dxl:OneTimeFilter/>
           <dxl:HashJoin JoinType="LeftAntiSemiJoin">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1356250696.455228" Rows="1.000000" Width="1"/>
+              <dxl:Cost StartupCost="0" TotalCost="1356250698.553403" Rows="1.000000" Width="1"/>
             </dxl:Properties>
             <dxl:ProjList/>
             <dxl:Filter/>
@@ -467,7 +467,7 @@
             </dxl:HashCondList>
             <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1356250265.454569" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="1356250267.552745" Rows="1.000000" Width="8"/>
               </dxl:Properties>
               <dxl:GroupingColumns>
                 <dxl:GroupingColumn ColId="15"/>
@@ -492,7 +492,7 @@
               <dxl:Filter/>
               <dxl:Sort SortDiscardDuplicates="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1356250265.454549" Rows="1.000000" Width="18"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1356250267.552725" Rows="1.000000" Width="18"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="15" Alias="d">
@@ -517,7 +517,7 @@
                 <dxl:LimitOffset/>
                 <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1356250265.454549" Rows="1.000000" Width="18"/>
+                    <dxl:Cost StartupCost="0" TotalCost="1356250267.552725" Rows="1.000000" Width="18"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="15" Alias="d">
@@ -545,7 +545,7 @@
                   </dxl:HashExprList>
                   <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="1356250265.454493" Rows="1.000000" Width="18"/>
+                      <dxl:Cost StartupCost="0" TotalCost="1356250267.552669" Rows="1.000000" Width="18"/>
                     </dxl:Properties>
                     <dxl:GroupingColumns>
                       <dxl:GroupingColumn ColId="15"/>
@@ -570,7 +570,7 @@
                     <dxl:Filter/>
                     <dxl:Sort SortDiscardDuplicates="false">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="1356250265.454465" Rows="1.000000" Width="18"/>
+                        <dxl:Cost StartupCost="0" TotalCost="1356250267.552641" Rows="1.000000" Width="18"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="15" Alias="d">
@@ -595,7 +595,7 @@
                       <dxl:LimitOffset/>
                       <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="1356250265.454465" Rows="1.000000" Width="18"/>
+                          <dxl:Cost StartupCost="0" TotalCost="1356250267.552641" Rows="1.000000" Width="18"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="15" Alias="d">
@@ -617,7 +617,7 @@
                         </dxl:JoinFilter>
                         <dxl:NestedLoopJoin JoinType="In" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="882688.136962" Rows="1.000000" Width="18"/>
+                            <dxl:Cost StartupCost="0" TotalCost="882688.137986" Rows="1.000000" Width="18"/>
                           </dxl:Properties>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="15" Alias="d">
@@ -670,149 +670,178 @@
                               </dxl:Columns>
                             </dxl:TableDescriptor>
                           </dxl:TableScan>
-                          <dxl:Result>
+                          <dxl:Materialize Eager="false">
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="0.000003" Rows="1.000000" Width="1"/>
+                              <dxl:Cost StartupCost="0" TotalCost="0.000004" Rows="1.000000" Width="1"/>
                             </dxl:Properties>
                             <dxl:ProjList>
                               <dxl:ProjElem ColId="27" Alias="?column?">
-                                <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                                <dxl:Ident ColId="27" ColName="?column?" TypeMdid="0.23.1.0"/>
                               </dxl:ProjElem>
                             </dxl:ProjList>
                             <dxl:Filter/>
-                            <dxl:OneTimeFilter/>
-                            <dxl:Limit>
+                            <dxl:Result>
                               <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="0.000002" Rows="1.000000" Width="1"/>
+                                <dxl:Cost StartupCost="0" TotalCost="0.000003" Rows="1.000000" Width="1"/>
                               </dxl:Properties>
-                              <dxl:ProjList/>
-                              <dxl:Result>
+                              <dxl:ProjList>
+                                <dxl:ProjElem ColId="27" Alias="?column?">
+                                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                                </dxl:ProjElem>
+                              </dxl:ProjList>
+                              <dxl:Filter/>
+                              <dxl:OneTimeFilter/>
+                              <dxl:Limit>
                                 <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                                  <dxl:Cost StartupCost="0" TotalCost="0.000002" Rows="1.000000" Width="1"/>
                                 </dxl:Properties>
                                 <dxl:ProjList/>
-                                <dxl:Filter/>
-                                <dxl:OneTimeFilter/>
                                 <dxl:Result>
                                   <dxl:Properties>
                                     <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
                                   </dxl:Properties>
-                                  <dxl:ProjList>
-                                    <dxl:ProjElem ColId="26" Alias="">
-                                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                                    </dxl:ProjElem>
-                                  </dxl:ProjList>
+                                  <dxl:ProjList/>
                                   <dxl:Filter/>
                                   <dxl:OneTimeFilter/>
+                                  <dxl:Result>
+                                    <dxl:Properties>
+                                      <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                                    </dxl:Properties>
+                                    <dxl:ProjList>
+                                      <dxl:ProjElem ColId="26" Alias="">
+                                        <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                                      </dxl:ProjElem>
+                                    </dxl:ProjList>
+                                    <dxl:Filter/>
+                                    <dxl:OneTimeFilter/>
+                                  </dxl:Result>
                                 </dxl:Result>
-                              </dxl:Result>
-                              <dxl:LimitCount>
-                                <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
-                              </dxl:LimitCount>
-                              <dxl:LimitOffset>
-                                <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
-                              </dxl:LimitOffset>
-                            </dxl:Limit>
-                          </dxl:Result>
+                                <dxl:LimitCount>
+                                  <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
+                                </dxl:LimitCount>
+                                <dxl:LimitOffset>
+                                  <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+                                </dxl:LimitOffset>
+                              </dxl:Limit>
+                            </dxl:Result>
+                          </dxl:Materialize>
                         </dxl:NestedLoopJoin>
-                        <dxl:NestedLoopJoin JoinType="In" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+                        <dxl:Materialize Eager="true">
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="441344.012819" Rows="1.000000" Width="1"/>
+                            <dxl:Cost StartupCost="0" TotalCost="441344.013844" Rows="1.000000" Width="1"/>
                           </dxl:Properties>
                           <dxl:ProjList/>
                           <dxl:Filter/>
-                          <dxl:JoinFilter>
-                            <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                          </dxl:JoinFilter>
-                          <dxl:Result>
+                          <dxl:NestedLoopJoin JoinType="In" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="0.000003" Rows="1.000000" Width="1"/>
+                              <dxl:Cost StartupCost="0" TotalCost="441344.013843" Rows="1.000000" Width="1"/>
                             </dxl:Properties>
-                            <dxl:ProjList>
-                              <dxl:ProjElem ColId="29" Alias="?column?">
-                                <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                              </dxl:ProjElem>
-                            </dxl:ProjList>
+                            <dxl:ProjList/>
                             <dxl:Filter/>
-                            <dxl:OneTimeFilter/>
-                            <dxl:Limit>
+                            <dxl:JoinFilter>
+                              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                            </dxl:JoinFilter>
+                            <dxl:Result>
                               <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="0.000002" Rows="1.000000" Width="1"/>
+                                <dxl:Cost StartupCost="0" TotalCost="0.000003" Rows="1.000000" Width="1"/>
                               </dxl:Properties>
-                              <dxl:ProjList/>
-                              <dxl:Result>
+                              <dxl:ProjList>
+                                <dxl:ProjElem ColId="29" Alias="?column?">
+                                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                                </dxl:ProjElem>
+                              </dxl:ProjList>
+                              <dxl:Filter/>
+                              <dxl:OneTimeFilter/>
+                              <dxl:Limit>
                                 <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                                  <dxl:Cost StartupCost="0" TotalCost="0.000002" Rows="1.000000" Width="1"/>
                                 </dxl:Properties>
                                 <dxl:ProjList/>
-                                <dxl:Filter/>
-                                <dxl:OneTimeFilter/>
                                 <dxl:Result>
                                   <dxl:Properties>
                                     <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
                                   </dxl:Properties>
-                                  <dxl:ProjList>
-                                    <dxl:ProjElem ColId="28" Alias="">
-                                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                                    </dxl:ProjElem>
-                                  </dxl:ProjList>
+                                  <dxl:ProjList/>
                                   <dxl:Filter/>
                                   <dxl:OneTimeFilter/>
+                                  <dxl:Result>
+                                    <dxl:Properties>
+                                      <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                                    </dxl:Properties>
+                                    <dxl:ProjList>
+                                      <dxl:ProjElem ColId="28" Alias="">
+                                        <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                                      </dxl:ProjElem>
+                                    </dxl:ProjList>
+                                    <dxl:Filter/>
+                                    <dxl:OneTimeFilter/>
+                                  </dxl:Result>
                                 </dxl:Result>
-                              </dxl:Result>
-                              <dxl:LimitCount>
-                                <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
-                              </dxl:LimitCount>
-                              <dxl:LimitOffset>
-                                <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
-                              </dxl:LimitOffset>
-                            </dxl:Limit>
-                          </dxl:Result>
-                          <dxl:Result>
-                            <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="0.000003" Rows="1.000000" Width="1"/>
-                            </dxl:Properties>
-                            <dxl:ProjList>
-                              <dxl:ProjElem ColId="25" Alias="?column?">
-                                <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                              </dxl:ProjElem>
-                            </dxl:ProjList>
-                            <dxl:Filter/>
-                            <dxl:OneTimeFilter/>
-                            <dxl:Limit>
+                                <dxl:LimitCount>
+                                  <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
+                                </dxl:LimitCount>
+                                <dxl:LimitOffset>
+                                  <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+                                </dxl:LimitOffset>
+                              </dxl:Limit>
+                            </dxl:Result>
+                            <dxl:Materialize Eager="false">
                               <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="0.000002" Rows="1.000000" Width="1"/>
+                                <dxl:Cost StartupCost="0" TotalCost="0.000004" Rows="1.000000" Width="1"/>
                               </dxl:Properties>
-                              <dxl:ProjList/>
+                              <dxl:ProjList>
+                                <dxl:ProjElem ColId="25" Alias="?column?">
+                                  <dxl:Ident ColId="25" ColName="?column?" TypeMdid="0.23.1.0"/>
+                                </dxl:ProjElem>
+                              </dxl:ProjList>
+                              <dxl:Filter/>
                               <dxl:Result>
                                 <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                                  <dxl:Cost StartupCost="0" TotalCost="0.000003" Rows="1.000000" Width="1"/>
                                 </dxl:Properties>
-                                <dxl:ProjList/>
+                                <dxl:ProjList>
+                                  <dxl:ProjElem ColId="25" Alias="?column?">
+                                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                                  </dxl:ProjElem>
+                                </dxl:ProjList>
                                 <dxl:Filter/>
                                 <dxl:OneTimeFilter/>
-                                <dxl:Result>
+                                <dxl:Limit>
                                   <dxl:Properties>
-                                    <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                                    <dxl:Cost StartupCost="0" TotalCost="0.000002" Rows="1.000000" Width="1"/>
                                   </dxl:Properties>
-                                  <dxl:ProjList>
-                                    <dxl:ProjElem ColId="24" Alias="">
-                                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                                    </dxl:ProjElem>
-                                  </dxl:ProjList>
-                                  <dxl:Filter/>
-                                  <dxl:OneTimeFilter/>
-                                </dxl:Result>
+                                  <dxl:ProjList/>
+                                  <dxl:Result>
+                                    <dxl:Properties>
+                                      <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                                    </dxl:Properties>
+                                    <dxl:ProjList/>
+                                    <dxl:Filter/>
+                                    <dxl:OneTimeFilter/>
+                                    <dxl:Result>
+                                      <dxl:Properties>
+                                        <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                                      </dxl:Properties>
+                                      <dxl:ProjList>
+                                        <dxl:ProjElem ColId="24" Alias="">
+                                          <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                                        </dxl:ProjElem>
+                                      </dxl:ProjList>
+                                      <dxl:Filter/>
+                                      <dxl:OneTimeFilter/>
+                                    </dxl:Result>
+                                  </dxl:Result>
+                                  <dxl:LimitCount>
+                                    <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
+                                  </dxl:LimitCount>
+                                  <dxl:LimitOffset>
+                                    <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+                                  </dxl:LimitOffset>
+                                </dxl:Limit>
                               </dxl:Result>
-                              <dxl:LimitCount>
-                                <dxl:ConstValue TypeMdid="0.20.1.0" Value="1"/>
-                              </dxl:LimitCount>
-                              <dxl:LimitOffset>
-                                <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
-                              </dxl:LimitOffset>
-                            </dxl:Limit>
-                          </dxl:Result>
-                        </dxl:NestedLoopJoin>
+                            </dxl:Materialize>
+                          </dxl:NestedLoopJoin>
+                        </dxl:Materialize>
                       </dxl:NestedLoopJoin>
                     </dxl:Sort>
                   </dxl:Aggregate>

--- a/src/backend/gporca/data/dxl/minidump/CannotPullGrpColAboveAgg.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CannotPullGrpColAboveAgg.mdp
@@ -3762,7 +3762,7 @@ The SQL along with the DDL are in TINC repo. In the aggregates directory under q
         </dxl:LogicalJoin>
       </dxl:LogicalProject>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="15376896">
+    <dxl:Plan Id="0" SpaceSize="13533696">
       <dxl:Result>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="57937329.740768" Rows="2959212724800.000000" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/Coalesce-With-Subquery.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Coalesce-With-Subquery.mdp
@@ -852,7 +852,7 @@
         </dxl:LogicalProject>
       </dxl:LogicalLimit>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="2856">
+    <dxl:Plan Id="0" SpaceSize="4186">
       <dxl:Result>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="38915.798285" Rows="4.000000" Width="269"/>

--- a/src/backend/gporca/data/dxl/minidump/CollapseNot.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CollapseNot.mdp
@@ -297,10 +297,10 @@ SELECT 1 FROM inverse WHERE NOT (cidr <<= ANY(SELECT * FROM inverse));
         </dxl:LogicalSelect>
       </dxl:LogicalProject>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="42">
+    <dxl:Plan Id="0" SpaceSize="30">
       <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1293.001142" Rows="1.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="1293.001143" Rows="1.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="16" Alias="?column?">
@@ -311,14 +311,14 @@ SELECT 1 FROM inverse WHERE NOT (cidr <<= ANY(SELECT * FROM inverse));
         <dxl:OneTimeFilter/>
         <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1293.001138" Rows="1.000000" Width="1"/>
+            <dxl:Cost StartupCost="0" TotalCost="1293.001139" Rows="1.000000" Width="1"/>
           </dxl:Properties>
           <dxl:ProjList/>
           <dxl:Filter/>
           <dxl:SortingColumnList/>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1293.001134" Rows="1.000000" Width="1"/>
+              <dxl:Cost StartupCost="0" TotalCost="1293.001135" Rows="1.000000" Width="1"/>
             </dxl:Properties>
             <dxl:ProjList/>
             <dxl:Filter>
@@ -333,7 +333,7 @@ SELECT 1 FROM inverse WHERE NOT (cidr <<= ANY(SELECT * FROM inverse));
                       <dxl:Ident ColId="20" ColName="ColRef_0020" TypeMdid="0.20.1.0"/>
                       <dxl:Ident ColId="18" ColName="ColRef_0018" TypeMdid="0.20.1.0"/>
                     </dxl:Comparison>
-                    <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true" IsByValue="true"/>
+                    <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true"/>
                     <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
                   </dxl:If>
                   <dxl:ConstValue TypeMdid="0.16.1.0" Value="false"/>
@@ -343,7 +343,7 @@ SELECT 1 FROM inverse WHERE NOT (cidr <<= ANY(SELECT * FROM inverse));
             <dxl:OneTimeFilter/>
             <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1293.001112" Rows="1.000000" Width="16"/>
+                <dxl:Cost StartupCost="0" TotalCost="1293.001113" Rows="1.000000" Width="16"/>
               </dxl:Properties>
               <dxl:GroupingColumns>
                 <dxl:GroupingColumn ColId="0"/>
@@ -352,7 +352,7 @@ SELECT 1 FROM inverse WHERE NOT (cidr <<= ANY(SELECT * FROM inverse));
               </dxl:GroupingColumns>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="18" Alias="ColRef_0018">
-                  <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Final" AggKind="n" >
+                  <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Final" AggKind="n">
                     <dxl:ValuesList ParamType="aggargs">
                       <dxl:Ident ColId="28" ColName="ColRef_0028" TypeMdid="0.20.1.0"/>
                     </dxl:ValuesList>
@@ -362,7 +362,7 @@ SELECT 1 FROM inverse WHERE NOT (cidr <<= ANY(SELECT * FROM inverse));
                   </dxl:AggFunc>
                 </dxl:ProjElem>
                 <dxl:ProjElem ColId="20" Alias="ColRef_0020">
-                  <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Final" AggKind="n" >
+                  <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Final" AggKind="n">
                     <dxl:ValuesList ParamType="aggargs">
                       <dxl:Ident ColId="29" ColName="ColRef_0029" TypeMdid="0.20.1.0"/>
                     </dxl:ValuesList>
@@ -384,7 +384,7 @@ SELECT 1 FROM inverse WHERE NOT (cidr <<= ANY(SELECT * FROM inverse));
               <dxl:Filter/>
               <dxl:Sort SortDiscardDuplicates="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1293.001075" Rows="1.000000" Width="34"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1293.001076" Rows="1.000000" Width="34"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="cidr">
@@ -412,7 +412,7 @@ SELECT 1 FROM inverse WHERE NOT (cidr <<= ANY(SELECT * FROM inverse));
                 <dxl:LimitOffset/>
                 <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1293.001075" Rows="1.000000" Width="34"/>
+                    <dxl:Cost StartupCost="0" TotalCost="1293.001076" Rows="1.000000" Width="34"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="0" Alias="cidr">
@@ -443,7 +443,7 @@ SELECT 1 FROM inverse WHERE NOT (cidr <<= ANY(SELECT * FROM inverse));
                   </dxl:HashExprList>
                   <dxl:Result>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="1293.000969" Rows="1.000000" Width="34"/>
+                      <dxl:Cost StartupCost="0" TotalCost="1293.000970" Rows="1.000000" Width="34"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="0" Alias="cidr">
@@ -466,7 +466,7 @@ SELECT 1 FROM inverse WHERE NOT (cidr <<= ANY(SELECT * FROM inverse));
                     <dxl:OneTimeFilter/>
                     <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="1293.000969" Rows="1.000000" Width="34"/>
+                        <dxl:Cost StartupCost="0" TotalCost="1293.000970" Rows="1.000000" Width="34"/>
                       </dxl:Properties>
                       <dxl:GroupingColumns>
                         <dxl:GroupingColumn ColId="0"/>
@@ -475,7 +475,7 @@ SELECT 1 FROM inverse WHERE NOT (cidr <<= ANY(SELECT * FROM inverse));
                       </dxl:GroupingColumns>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="28" Alias="ColRef_0028">
-                          <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" >
+                          <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Partial" AggKind="n">
                             <dxl:ValuesList ParamType="aggargs">
                               <dxl:Ident ColId="17" ColName="ColRef_0017" TypeMdid="0.16.1.0"/>
                             </dxl:ValuesList>
@@ -485,7 +485,7 @@ SELECT 1 FROM inverse WHERE NOT (cidr <<= ANY(SELECT * FROM inverse));
                           </dxl:AggFunc>
                         </dxl:ProjElem>
                         <dxl:ProjElem ColId="29" Alias="ColRef_0029">
-                          <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" >
+                          <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Partial" AggKind="n">
                             <dxl:ValuesList ParamType="aggargs">
                               <dxl:Ident ColId="19" ColName="ColRef_0019" TypeMdid="0.23.1.0"/>
                             </dxl:ValuesList>
@@ -507,7 +507,7 @@ SELECT 1 FROM inverse WHERE NOT (cidr <<= ANY(SELECT * FROM inverse));
                       <dxl:Filter/>
                       <dxl:Sort SortDiscardDuplicates="false">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="1293.000927" Rows="1.000000" Width="23"/>
+                          <dxl:Cost StartupCost="0" TotalCost="1293.000928" Rows="1.000000" Width="23"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="19" Alias="ColRef_0019">
@@ -535,7 +535,7 @@ SELECT 1 FROM inverse WHERE NOT (cidr <<= ANY(SELECT * FROM inverse));
                         <dxl:LimitOffset/>
                         <dxl:Result>
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="1293.000927" Rows="1.000000" Width="23"/>
+                            <dxl:Cost StartupCost="0" TotalCost="1293.000928" Rows="1.000000" Width="23"/>
                           </dxl:Properties>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="19" Alias="ColRef_0019">
@@ -567,7 +567,7 @@ SELECT 1 FROM inverse WHERE NOT (cidr <<= ANY(SELECT * FROM inverse));
                           <dxl:OneTimeFilter/>
                           <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="1293.000904" Rows="1.000000" Width="27"/>
+                              <dxl:Cost StartupCost="0" TotalCost="1293.000905" Rows="1.000000" Width="27"/>
                             </dxl:Properties>
                             <dxl:ProjList>
                               <dxl:ProjElem ColId="0" Alias="cidr">
@@ -624,30 +624,33 @@ SELECT 1 FROM inverse WHERE NOT (cidr <<= ANY(SELECT * FROM inverse));
                                 </dxl:Columns>
                               </dxl:TableDescriptor>
                             </dxl:TableScan>
-                            <dxl:Result>
+                            <dxl:Materialize Eager="false">
                               <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="431.000482" Rows="3.000000" Width="9"/>
+                                <dxl:Cost StartupCost="0" TotalCost="431.000483" Rows="3.000000" Width="9"/>
                               </dxl:Properties>
                               <dxl:ProjList>
                                 <dxl:ProjElem ColId="17" Alias="ColRef_0017">
-                                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                                  <dxl:Ident ColId="17" ColName="ColRef_0017" TypeMdid="0.16.1.0"/>
                                 </dxl:ProjElem>
                                 <dxl:ProjElem ColId="8" Alias="cidr">
                                   <dxl:Ident ColId="8" ColName="cidr" TypeMdid="0.869.1.0"/>
                                 </dxl:ProjElem>
                               </dxl:ProjList>
                               <dxl:Filter/>
-                              <dxl:OneTimeFilter/>
-                              <dxl:Materialize Eager="false">
+                              <dxl:Result>
                                 <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="431.000473" Rows="3.000000" Width="8"/>
+                                  <dxl:Cost StartupCost="0" TotalCost="431.000474" Rows="3.000000" Width="9"/>
                                 </dxl:Properties>
                                 <dxl:ProjList>
+                                  <dxl:ProjElem ColId="17" Alias="ColRef_0017">
+                                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                                  </dxl:ProjElem>
                                   <dxl:ProjElem ColId="8" Alias="cidr">
                                     <dxl:Ident ColId="8" ColName="cidr" TypeMdid="0.869.1.0"/>
                                   </dxl:ProjElem>
                                 </dxl:ProjList>
                                 <dxl:Filter/>
+                                <dxl:OneTimeFilter/>
                                 <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                                   <dxl:Properties>
                                     <dxl:Cost StartupCost="0" TotalCost="431.000465" Rows="3.000000" Width="8"/>
@@ -683,8 +686,8 @@ SELECT 1 FROM inverse WHERE NOT (cidr <<= ANY(SELECT * FROM inverse));
                                     </dxl:TableDescriptor>
                                   </dxl:TableScan>
                                 </dxl:BroadcastMotion>
-                              </dxl:Materialize>
-                            </dxl:Result>
+                              </dxl:Result>
+                            </dxl:Materialize>
                           </dxl:NestedLoopJoin>
                         </dxl:Result>
                       </dxl:Sort>

--- a/src/backend/gporca/data/dxl/minidump/CorrelatedAntiSemiJoin-True.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CorrelatedAntiSemiJoin-True.mdp
@@ -870,10 +870,10 @@ SELECT pn, cn, vn FROM sale s WHERE NOT EXISTS (SELECT * FROM customer WHERE NOT
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="4">
+    <dxl:Plan Id="0" SpaceSize="8">
       <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="2155.027572" Rows="12.000000" Width="12"/>
+          <dxl:Cost StartupCost="0" TotalCost="2155.027601" Rows="12.000000" Width="12"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="2" Alias="pn">
@@ -892,19 +892,87 @@ SELECT pn, cn, vn FROM sale s WHERE NOT EXISTS (SELECT * FROM customer WHERE NOT
             <dxl:ParamList>
               <dxl:Param ColId="2" ColName="pn" TypeMdid="0.23.1.0"/>
             </dxl:ParamList>
-            <dxl:NestedLoopJoin JoinType="LeftAntiSemiJoin" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+            <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1293.025814" Rows="4.000000" Width="4"/>
+                <dxl:Cost StartupCost="0" TotalCost="1293.025842" Rows="4.000000" Width="4"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="13" Alias="cn">
                   <dxl:Ident ColId="13" ColName="cn" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:JoinFilter>
-                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-              </dxl:JoinFilter>
+              <dxl:Filter>
+                <dxl:SubPlan TypeMdid="0.16.1.0" SubPlanType="NotExistsSubPlan">
+                  <dxl:TestExpr/>
+                  <dxl:ParamList>
+                    <dxl:Param ColId="2" ColName="pn" TypeMdid="0.23.1.0"/>
+                  </dxl:ParamList>
+                  <dxl:Result>
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.025576" Rows="1.000000" Width="4"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="23" Alias="pn">
+                        <dxl:Ident ColId="23" ColName="pn" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter>
+                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                        <dxl:Ident ColId="23" ColName="pn" TypeMdid="0.23.1.0"/>
+                        <dxl:Ident ColId="2" ColName="pn" TypeMdid="0.23.1.0"/>
+                      </dxl:Comparison>
+                    </dxl:Filter>
+                    <dxl:OneTimeFilter/>
+                    <dxl:Materialize Eager="true">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000309" Rows="8.000000" Width="4"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="23" Alias="pn">
+                          <dxl:Ident ColId="23" ColName="pn" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000277" Rows="8.000000" Width="4"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="23" Alias="pn">
+                            <dxl:Ident ColId="23" ColName="pn" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:SortingColumnList/>
+                        <dxl:TableScan>
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000103" Rows="8.000000" Width="4"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="23" Alias="pn">
+                              <dxl:Ident ColId="23" ColName="pn" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:TableDescriptor Mdid="6.29191945.1.1" TableName="product">
+                            <dxl:Columns>
+                              <dxl:Column ColId="23" Attno="1" ColName="pn" TypeMdid="0.23.1.0"/>
+                              <dxl:Column ColId="26" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                              <dxl:Column ColId="27" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                              <dxl:Column ColId="28" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                              <dxl:Column ColId="29" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                              <dxl:Column ColId="30" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                              <dxl:Column ColId="31" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                              <dxl:Column ColId="32" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                            </dxl:Columns>
+                          </dxl:TableDescriptor>
+                        </dxl:TableScan>
+                      </dxl:GatherMotion>
+                    </dxl:Materialize>
+                  </dxl:Result>
+                </dxl:SubPlan>
+              </dxl:Filter>
+              <dxl:OneTimeFilter/>
               <dxl:Materialize Eager="true">
                 <dxl:Properties>
                   <dxl:Cost StartupCost="0" TotalCost="431.000162" Rows="4.000000" Width="4"/>
@@ -951,66 +1019,7 @@ SELECT pn, cn, vn FROM sale s WHERE NOT EXISTS (SELECT * FROM customer WHERE NOT
                   </dxl:TableScan>
                 </dxl:GatherMotion>
               </dxl:Materialize>
-              <dxl:Result>
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.025576" Rows="1.000000" Width="1"/>
-                </dxl:Properties>
-                <dxl:ProjList/>
-                <dxl:Filter>
-                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                    <dxl:Ident ColId="23" ColName="pn" TypeMdid="0.23.1.0"/>
-                    <dxl:Ident ColId="2" ColName="pn" TypeMdid="0.23.1.0"/>
-                  </dxl:Comparison>
-                </dxl:Filter>
-                <dxl:OneTimeFilter/>
-                <dxl:Materialize Eager="true">
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000309" Rows="8.000000" Width="4"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="23" Alias="pn">
-                      <dxl:Ident ColId="23" ColName="pn" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000277" Rows="8.000000" Width="4"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="23" Alias="pn">
-                        <dxl:Ident ColId="23" ColName="pn" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:Filter/>
-                    <dxl:SortingColumnList/>
-                    <dxl:TableScan>
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000103" Rows="8.000000" Width="4"/>
-                      </dxl:Properties>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="23" Alias="pn">
-                          <dxl:Ident ColId="23" ColName="pn" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
-                      <dxl:Filter/>
-                      <dxl:TableDescriptor Mdid="6.29191945.1.1" TableName="product">
-                        <dxl:Columns>
-                          <dxl:Column ColId="23" Attno="1" ColName="pn" TypeMdid="0.23.1.0"/>
-                          <dxl:Column ColId="26" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                          <dxl:Column ColId="27" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                          <dxl:Column ColId="28" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                          <dxl:Column ColId="29" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                          <dxl:Column ColId="30" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                          <dxl:Column ColId="31" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                          <dxl:Column ColId="32" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                        </dxl:Columns>
-                      </dxl:TableDescriptor>
-                    </dxl:TableScan>
-                  </dxl:GatherMotion>
-                </dxl:Materialize>
-              </dxl:Result>
-            </dxl:NestedLoopJoin>
+            </dxl:Result>
           </dxl:SubPlan>
         </dxl:Filter>
         <dxl:OneTimeFilter/>

--- a/src/backend/gporca/data/dxl/minidump/CorrelatedIN-LeftSemiJoin-Limit.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CorrelatedIN-LeftSemiJoin-Limit.mdp
@@ -306,7 +306,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="192">
+    <dxl:Plan Id="0" SpaceSize="188">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1324032.151091" Rows="1.000000" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/CorrelatedIN-LeftSemiJoin-True.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CorrelatedIN-LeftSemiJoin-True.mdp
@@ -702,7 +702,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="86">
+    <dxl:Plan Id="0" SpaceSize="82">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1324039.870686" Rows="1.000000" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/CorrelatedLeftSemiNLJoinWithLimit.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CorrelatedLeftSemiNLJoinWithLimit.mdp
@@ -317,7 +317,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="88">
+    <dxl:Plan Id="0" SpaceSize="84">
       <dxl:Result>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1324032.157856" Rows="1.000000" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/CorrelatedSemiJoin-True.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CorrelatedSemiJoin-True.mdp
@@ -865,10 +865,10 @@ SELECT pn, cn, vn FROM sale s WHERE EXISTS (SELECT * FROM customer WHERE EXISTS 
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="4">
+    <dxl:Plan Id="0" SpaceSize="8">
       <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="2155.027572" Rows="12.000000" Width="12"/>
+          <dxl:Cost StartupCost="0" TotalCost="2155.027601" Rows="12.000000" Width="12"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="2" Alias="pn">
@@ -887,19 +887,87 @@ SELECT pn, cn, vn FROM sale s WHERE EXISTS (SELECT * FROM customer WHERE EXISTS 
             <dxl:ParamList>
               <dxl:Param ColId="2" ColName="pn" TypeMdid="0.23.1.0"/>
             </dxl:ParamList>
-            <dxl:NestedLoopJoin JoinType="In" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+            <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1293.025814" Rows="4.000000" Width="4"/>
+                <dxl:Cost StartupCost="0" TotalCost="1293.025842" Rows="4.000000" Width="4"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="13" Alias="cn">
                   <dxl:Ident ColId="13" ColName="cn" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:JoinFilter>
-                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-              </dxl:JoinFilter>
+              <dxl:Filter>
+                <dxl:SubPlan TypeMdid="0.16.1.0" SubPlanType="ExistsSubPlan">
+                  <dxl:TestExpr/>
+                  <dxl:ParamList>
+                    <dxl:Param ColId="2" ColName="pn" TypeMdid="0.23.1.0"/>
+                  </dxl:ParamList>
+                  <dxl:Result>
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.025576" Rows="1.000000" Width="4"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="23" Alias="pn">
+                        <dxl:Ident ColId="23" ColName="pn" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter>
+                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                        <dxl:Ident ColId="23" ColName="pn" TypeMdid="0.23.1.0"/>
+                        <dxl:Ident ColId="2" ColName="pn" TypeMdid="0.23.1.0"/>
+                      </dxl:Comparison>
+                    </dxl:Filter>
+                    <dxl:OneTimeFilter/>
+                    <dxl:Materialize Eager="true">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000309" Rows="8.000000" Width="4"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="23" Alias="pn">
+                          <dxl:Ident ColId="23" ColName="pn" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000277" Rows="8.000000" Width="4"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="23" Alias="pn">
+                            <dxl:Ident ColId="23" ColName="pn" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:SortingColumnList/>
+                        <dxl:TableScan>
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000103" Rows="8.000000" Width="4"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="23" Alias="pn">
+                              <dxl:Ident ColId="23" ColName="pn" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:TableDescriptor Mdid="6.29191945.1.1" TableName="product">
+                            <dxl:Columns>
+                              <dxl:Column ColId="23" Attno="1" ColName="pn" TypeMdid="0.23.1.0"/>
+                              <dxl:Column ColId="26" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                              <dxl:Column ColId="27" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                              <dxl:Column ColId="28" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                              <dxl:Column ColId="29" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                              <dxl:Column ColId="30" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                              <dxl:Column ColId="31" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                              <dxl:Column ColId="32" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                            </dxl:Columns>
+                          </dxl:TableDescriptor>
+                        </dxl:TableScan>
+                      </dxl:GatherMotion>
+                    </dxl:Materialize>
+                  </dxl:Result>
+                </dxl:SubPlan>
+              </dxl:Filter>
+              <dxl:OneTimeFilter/>
               <dxl:Materialize Eager="true">
                 <dxl:Properties>
                   <dxl:Cost StartupCost="0" TotalCost="431.000162" Rows="4.000000" Width="4"/>
@@ -946,66 +1014,7 @@ SELECT pn, cn, vn FROM sale s WHERE EXISTS (SELECT * FROM customer WHERE EXISTS 
                   </dxl:TableScan>
                 </dxl:GatherMotion>
               </dxl:Materialize>
-              <dxl:Result>
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.025576" Rows="1.000000" Width="1"/>
-                </dxl:Properties>
-                <dxl:ProjList/>
-                <dxl:Filter>
-                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                    <dxl:Ident ColId="23" ColName="pn" TypeMdid="0.23.1.0"/>
-                    <dxl:Ident ColId="2" ColName="pn" TypeMdid="0.23.1.0"/>
-                  </dxl:Comparison>
-                </dxl:Filter>
-                <dxl:OneTimeFilter/>
-                <dxl:Materialize Eager="true">
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000309" Rows="8.000000" Width="4"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="23" Alias="pn">
-                      <dxl:Ident ColId="23" ColName="pn" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000277" Rows="8.000000" Width="4"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="23" Alias="pn">
-                        <dxl:Ident ColId="23" ColName="pn" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:Filter/>
-                    <dxl:SortingColumnList/>
-                    <dxl:TableScan>
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000103" Rows="8.000000" Width="4"/>
-                      </dxl:Properties>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="23" Alias="pn">
-                          <dxl:Ident ColId="23" ColName="pn" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
-                      <dxl:Filter/>
-                      <dxl:TableDescriptor Mdid="6.29191945.1.1" TableName="product">
-                        <dxl:Columns>
-                          <dxl:Column ColId="23" Attno="1" ColName="pn" TypeMdid="0.23.1.0"/>
-                          <dxl:Column ColId="26" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                          <dxl:Column ColId="27" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                          <dxl:Column ColId="28" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                          <dxl:Column ColId="29" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                          <dxl:Column ColId="30" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                          <dxl:Column ColId="31" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                          <dxl:Column ColId="32" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                        </dxl:Columns>
-                      </dxl:TableDescriptor>
-                    </dxl:TableScan>
-                  </dxl:GatherMotion>
-                </dxl:Materialize>
-              </dxl:Result>
-            </dxl:NestedLoopJoin>
+            </dxl:Result>
           </dxl:SubPlan>
         </dxl:Filter>
         <dxl:OneTimeFilter/>

--- a/src/backend/gporca/data/dxl/minidump/Correlation-With-Casting-1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Correlation-With-Casting-1.mdp
@@ -432,7 +432,7 @@ AND u_folio = (SELECT max(u_folio)  FROM q68t792_temp c WHERE a.u_vtgnr = c.u_vt
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="18507">
+    <dxl:Plan Id="0" SpaceSize="13683">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="2155.684179" Rows="70.000000" Width="10"/>

--- a/src/backend/gporca/data/dxl/minidump/DynamicBitmapIndexScan.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicBitmapIndexScan.mdp
@@ -478,7 +478,7 @@ see sql/DynamicBitmapIndexScan.sql
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="64">
+    <dxl:Plan Id="0" SpaceSize="63">
       <dxl:GatherMotion InputSegments="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="6763.875569" Rows="1.000000" Width="9"/>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexGet-OuterRefs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexGet-OuterRefs.mdp
@@ -1298,7 +1298,7 @@
         </dxl:Or>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="7878862">
+    <dxl:Plan Id="0" SpaceSize="6945516">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1357145192.514491" Rows="1.000000" Width="1"/>

--- a/src/backend/gporca/data/dxl/minidump/ExistentialSubquriesInsideScalarExpression.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ExistentialSubquriesInsideScalarExpression.mdp
@@ -441,7 +441,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="63">
+    <dxl:Plan Id="0" SpaceSize="53">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1356691750.457889" Rows="1.600000" Width="13"/>

--- a/src/backend/gporca/data/dxl/minidump/ExistsSubqInsideExpr.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ExistsSubqInsideExpr.mdp
@@ -336,7 +336,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="6">
+    <dxl:Plan Id="0" SpaceSize="5">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1324032.404069" Rows="2.250000" Width="13"/>

--- a/src/backend/gporca/data/dxl/minidump/ExtractPredicateFromDisjWithComputedColumns.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ExtractPredicateFromDisjWithComputedColumns.mdp
@@ -459,7 +459,7 @@ where (cd.dyear = 2001 and s.tickets_cnt &gt; 3) or (cd.dmoy = 4 and s.tickets_c
         </dxl:LogicalJoin>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="3190">
+    <dxl:Plan Id="0" SpaceSize="3310">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.002852" Rows="1.000000" Width="64"/>

--- a/src/backend/gporca/data/dxl/minidump/InSubqWithPrjListOuterRefNoInnerRefColumnIn.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InSubqWithPrjListOuterRefNoInnerRefColumnIn.mdp
@@ -622,7 +622,7 @@ EXPLAIN SELECT * FROM foo WHERE a IN (SELECT b+1 FROM bar);
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="86">
+    <dxl:Plan Id="0" SpaceSize="82">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.005496" Rows="40.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/InSubqWithPrjListOuterRefNoInnerRefColumnPlusConstIn.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InSubqWithPrjListOuterRefNoInnerRefColumnPlusConstIn.mdp
@@ -625,7 +625,7 @@ EXPLAIN SELECT * FROM foo WHERE 1+a IN (SELECT b+1 FROM bar);
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="86">
+    <dxl:Plan Id="0" SpaceSize="82">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.005496" Rows="40.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/InSubqWithPrjListOuterRefNoInnerRefConstIn.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InSubqWithPrjListOuterRefNoInnerRefConstIn.mdp
@@ -619,7 +619,7 @@ SELECT * FROM foo WHERE 2 IN (SELECT b+1 FROM bar);
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="86">
+    <dxl:Plan Id="0" SpaceSize="82">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.004400" Rows="40.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/Index-Join-With-Subquery-In-Pred.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Index-Join-With-Subquery-In-Pred.mdp
@@ -349,7 +349,7 @@ Optimizer: Pivotal Optimizer (GPORCA)
         </dxl:LogicalJoin>
       </dxl:LogicalProject>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="460">
+    <dxl:Plan Id="0" SpaceSize="560">
       <dxl:Result>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="888832.304151" Rows="1.000000" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-No-Motion-Below-Join.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-No-Motion-Below-Join.mdp
@@ -399,7 +399,7 @@ Table X (int i, int j) is distributed by i, column j has index
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="21">
+    <dxl:Plan Id="0" SpaceSize="18">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="6.008187" Rows="33.333333" Width="12"/>

--- a/src/backend/gporca/data/dxl/minidump/IndexNLJ-IndexGet-OuterRef.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexNLJ-IndexGet-OuterRef.mdp
@@ -1476,7 +1476,7 @@
         </dxl:And>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="10">
+    <dxl:Plan Id="0" SpaceSize="11">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="888838.913054" Rows="42.000000" Width="24"/>

--- a/src/backend/gporca/data/dxl/minidump/Join-Varchar-Equality.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Join-Varchar-Equality.mdp
@@ -3840,7 +3840,7 @@
     <dxl:Plan Id="0" SpaceSize="82832">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="3422679.529071" Rows="19136.250000" Width="31"/>
+          <dxl:Cost StartupCost="0" TotalCost="3422679.547303" Rows="19136.250000" Width="31"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="27" Alias="year">
@@ -3860,7 +3860,7 @@
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="3422676.865496" Rows="19136.250000" Width="31"/>
+            <dxl:Cost StartupCost="0" TotalCost="3422676.883729" Rows="19136.250000" Width="31"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="27" Alias="year">
@@ -3880,7 +3880,7 @@
           <dxl:OneTimeFilter/>
           <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="3422676.865496" Rows="19136.250000" Width="31"/>
+              <dxl:Cost StartupCost="0" TotalCost="3422676.883729" Rows="19136.250000" Width="31"/>
             </dxl:Properties>
             <dxl:GroupingColumns>
               <dxl:GroupingColumn ColId="27"/>
@@ -3899,9 +3899,9 @@
                 <dxl:Ident ColId="39" ColName="shop_name" TypeMdid="0.1043.1.0"/>
               </dxl:ProjElem>
               <dxl:ProjElem ColId="52" Alias="sales">
-                <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Final" AggKind="n" >
+                <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Final" AggKind="n">
                   <dxl:ValuesList ParamType="aggargs">
-                  <dxl:Ident ColId="53" ColName="ColRef_0053" TypeMdid="0.20.1.0"/>
+                    <dxl:Ident ColId="53" ColName="ColRef_0053" TypeMdid="0.20.1.0"/>
                   </dxl:ValuesList>
                   <dxl:ValuesList ParamType="aggdirectargs"/>
                   <dxl:ValuesList ParamType="aggorder"/>
@@ -3915,7 +3915,7 @@
             <dxl:Filter/>
             <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="3422671.973515" Rows="19136.250000" Width="34"/>
+                <dxl:Cost StartupCost="0" TotalCost="3422671.991747" Rows="19136.250000" Width="34"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="27" Alias="year">
@@ -3952,7 +3952,7 @@
               </dxl:HashExprList>
               <dxl:Result>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="3422670.955275" Rows="19136.250000" Width="34"/>
+                  <dxl:Cost StartupCost="0" TotalCost="3422670.973507" Rows="19136.250000" Width="34"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="27" Alias="year">
@@ -3975,7 +3975,7 @@
                 <dxl:OneTimeFilter/>
                 <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="3422670.955275" Rows="19136.250000" Width="34"/>
+                    <dxl:Cost StartupCost="0" TotalCost="3422670.973507" Rows="19136.250000" Width="34"/>
                   </dxl:Properties>
                   <dxl:GroupingColumns>
                     <dxl:GroupingColumn ColId="27"/>
@@ -3985,9 +3985,9 @@
                   </dxl:GroupingColumns>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="53" Alias="ColRef_0053">
-                      <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" >
+                      <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Partial" AggKind="n">
                         <dxl:ValuesList ParamType="aggargs">
-                        <dxl:Ident ColId="6" ColName="sales" TypeMdid="0.23.1.0"/>
+                          <dxl:Ident ColId="6" ColName="sales" TypeMdid="0.23.1.0"/>
                         </dxl:ValuesList>
                         <dxl:ValuesList ParamType="aggdirectargs"/>
                         <dxl:ValuesList ParamType="aggorder"/>
@@ -4010,7 +4010,7 @@
                   <dxl:Filter/>
                   <dxl:HashJoin JoinType="Inner">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="2087869.893271" Rows="5288759693.059181" Width="30"/>
+                      <dxl:Cost StartupCost="0" TotalCost="2087869.911503" Rows="5288759693.059181" Width="30"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="6" Alias="sales">
@@ -4183,7 +4183,7 @@
                       </dxl:PrintableFilter>
                       <dxl:BroadcastMotion InputSegments="0,1" OutputSegments="0,1">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="1552.578227" Rows="607744.000000" Width="30"/>
+                          <dxl:Cost StartupCost="0" TotalCost="1552.596459" Rows="607744.000000" Width="30"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="26" Alias="ymd">
@@ -4206,7 +4206,7 @@
                         <dxl:SortingColumnList/>
                         <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="1313.962739" Rows="303872.000000" Width="30"/>
+                            <dxl:Cost StartupCost="0" TotalCost="1313.980971" Rows="303872.000000" Width="30"/>
                           </dxl:Properties>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="26" Alias="ymd">
@@ -4271,9 +4271,9 @@
                               </dxl:TableDescriptor>
                             </dxl:TableScan>
                           </dxl:BroadcastMotion>
-                          <dxl:TableScan>
+                          <dxl:Materialize Eager="false">
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="431.551944" Rows="3038.720000" Width="12"/>
+                              <dxl:Cost StartupCost="0" TotalCost="431.570177" Rows="3038.720000" Width="12"/>
                             </dxl:Properties>
                             <dxl:ProjList>
                               <dxl:ProjElem ColId="26" Alias="ymd">
@@ -4286,34 +4286,51 @@
                                 <dxl:Ident ColId="29" ColName="month" TypeMdid="0.1042.1.0"/>
                               </dxl:ProjElem>
                             </dxl:ProjList>
-                            <dxl:Filter>
-                              <dxl:And>
-                                <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.1061.1.0">
-                                  <dxl:Ident ColId="28" ColName="ym" TypeMdid="0.1042.1.0"/>
-                                  <dxl:ConstValue TypeMdid="0.1042.1.0" Value="AAAACjE5ODYwMQ==" LintValue="266216246"/>
-                                </dxl:Comparison>
-                                <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.1059.1.0">
+                            <dxl:Filter/>
+                            <dxl:TableScan>
+                              <dxl:Properties>
+                                <dxl:Cost StartupCost="0" TotalCost="431.551944" Rows="3038.720000" Width="12"/>
+                              </dxl:Properties>
+                              <dxl:ProjList>
+                                <dxl:ProjElem ColId="26" Alias="ymd">
+                                  <dxl:Ident ColId="26" ColName="ymd" TypeMdid="0.1082.1.0"/>
+                                </dxl:ProjElem>
+                                <dxl:ProjElem ColId="27" Alias="year">
                                   <dxl:Ident ColId="27" ColName="year" TypeMdid="0.1042.1.0"/>
-                                  <dxl:ConstValue TypeMdid="0.1042.1.0" Value="AAAACDE5OTc=" LintValue="123134828"/>
-                                </dxl:Comparison>
-                              </dxl:And>
-                            </dxl:Filter>
-                            <dxl:TableDescriptor Mdid="6.328293.1.1" TableName="calendar">
-                              <dxl:Columns>
-                                <dxl:Column ColId="26" Attno="1" ColName="ymd" TypeMdid="0.1082.1.0"/>
-                                <dxl:Column ColId="27" Attno="2" ColName="year" TypeMdid="0.1042.1.0" ColWidth="4"/>
-                                <dxl:Column ColId="28" Attno="3" ColName="ym" TypeMdid="0.1042.1.0" ColWidth="7"/>
-                                <dxl:Column ColId="29" Attno="4" ColName="month" TypeMdid="0.1042.1.0" ColWidth="2"/>
-                                <dxl:Column ColId="31" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                                <dxl:Column ColId="32" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                                <dxl:Column ColId="33" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                                <dxl:Column ColId="34" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                                <dxl:Column ColId="35" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                                <dxl:Column ColId="36" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                                <dxl:Column ColId="37" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                              </dxl:Columns>
-                            </dxl:TableDescriptor>
-                          </dxl:TableScan>
+                                </dxl:ProjElem>
+                                <dxl:ProjElem ColId="29" Alias="month">
+                                  <dxl:Ident ColId="29" ColName="month" TypeMdid="0.1042.1.0"/>
+                                </dxl:ProjElem>
+                              </dxl:ProjList>
+                              <dxl:Filter>
+                                <dxl:And>
+                                  <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.1061.1.0">
+                                    <dxl:Ident ColId="28" ColName="ym" TypeMdid="0.1042.1.0"/>
+                                    <dxl:ConstValue TypeMdid="0.1042.1.0" Value="AAAACjE5ODYwMQ==" LintValue="266216246"/>
+                                  </dxl:Comparison>
+                                  <dxl:Comparison ComparisonOperator="&lt;=" OperatorMdid="0.1059.1.0">
+                                    <dxl:Ident ColId="27" ColName="year" TypeMdid="0.1042.1.0"/>
+                                    <dxl:ConstValue TypeMdid="0.1042.1.0" Value="AAAACDE5OTc=" LintValue="123134828"/>
+                                  </dxl:Comparison>
+                                </dxl:And>
+                              </dxl:Filter>
+                              <dxl:TableDescriptor Mdid="6.328293.1.1" TableName="calendar">
+                                <dxl:Columns>
+                                  <dxl:Column ColId="26" Attno="1" ColName="ymd" TypeMdid="0.1082.1.0"/>
+                                  <dxl:Column ColId="27" Attno="2" ColName="year" TypeMdid="0.1042.1.0" ColWidth="4"/>
+                                  <dxl:Column ColId="28" Attno="3" ColName="ym" TypeMdid="0.1042.1.0" ColWidth="7"/>
+                                  <dxl:Column ColId="29" Attno="4" ColName="month" TypeMdid="0.1042.1.0" ColWidth="2"/>
+                                  <dxl:Column ColId="31" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                  <dxl:Column ColId="32" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                                  <dxl:Column ColId="33" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                                  <dxl:Column ColId="34" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                                  <dxl:Column ColId="35" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                                  <dxl:Column ColId="36" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                  <dxl:Column ColId="37" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                </dxl:Columns>
+                              </dxl:TableDescriptor>
+                            </dxl:TableScan>
+                          </dxl:Materialize>
                         </dxl:NestedLoopJoin>
                       </dxl:BroadcastMotion>
                     </dxl:PartitionSelector>

--- a/src/backend/gporca/data/dxl/minidump/Join-WinFunc-Preds.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Join-WinFunc-Preds.mdp
@@ -538,7 +538,7 @@ where e < 10;
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="78">
+    <dxl:Plan Id="0" SpaceSize="64">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="8620.170543" Rows="324.000000" Width="28"/>

--- a/src/backend/gporca/data/dxl/minidump/Join-With-Subq-Preds-1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Join-With-Subq-Preds-1.mdp
@@ -783,7 +783,7 @@
         </dxl:Or>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="9720">
+    <dxl:Plan Id="0" SpaceSize="7432">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="10867.964640" Rows="10000000.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/Join-With-Subq-Preds-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Join-With-Subq-Preds-2.mdp
@@ -809,7 +809,7 @@
         </dxl:Or>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="9772576">
+    <dxl:Plan Id="0" SpaceSize="7129936">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="9312.745178" Rows="520834.333333" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/LeftJoin-DPv2-With-Select.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LeftJoin-DPv2-With-Select.mdp
@@ -348,7 +348,7 @@
         </dxl:Comparison>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="20">
+    <dxl:Plan Id="0" SpaceSize="18">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1765376.810995" Rows="1.000000" Width="24"/>

--- a/src/backend/gporca/data/dxl/minidump/MotionHazard-NoMaterializeHashAggUnderResult.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MotionHazard-NoMaterializeHashAggUnderResult.mdp
@@ -447,7 +447,7 @@ explain select f.k, f.subq from (select tab3.k, (select tab2.k from tab2 where t
         <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="150">
+    <dxl:Plan Id="0" SpaceSize="90">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="199109.213873" Rows="9846.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/MultiLevel-CorrelatedExec.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MultiLevel-CorrelatedExec.mdp
@@ -732,10 +732,10 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="48">
+    <dxl:Plan Id="0" SpaceSize="54">
       <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1818691.526596" Rows="1000.000000" Width="12"/>
+          <dxl:Cost StartupCost="0" TotalCost="1858727.522596" Rows="1000.000000" Width="12"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="i">
@@ -757,14 +757,14 @@
               </dxl:ParamList>
               <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1817829.141818" Rows="1.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1857865.137818" Rows="1.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:GroupingColumns/>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="28" Alias="sum">
-                    <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" >
+                    <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
                       <dxl:ValuesList ParamType="aggargs">
-                      <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
+                        <dxl:Ident ColId="9" ColName="i" TypeMdid="0.23.1.0"/>
                       </dxl:ValuesList>
                       <dxl:ValuesList ParamType="aggdirectargs"/>
                       <dxl:ValuesList ParamType="aggorder"/>
@@ -775,7 +775,7 @@
                 <dxl:Filter/>
                 <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1817829.141369" Rows="1001.000000" Width="4"/>
+                    <dxl:Cost StartupCost="0" TotalCost="1857865.137369" Rows="1001.000000" Width="4"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="9" Alias="i">
@@ -791,7 +791,7 @@
                   <dxl:OneTimeFilter/>
                   <dxl:Result>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="1817829.075503" Rows="1001.000000" Width="4"/>
+                      <dxl:Cost StartupCost="0" TotalCost="1857865.071503" Rows="1001.000000" Width="4"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="9" Alias="i">
@@ -809,7 +809,7 @@
                     <dxl:OneTimeFilter/>
                     <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="1817763.209703" Rows="1001.000000" Width="12"/>
+                        <dxl:Cost StartupCost="0" TotalCost="1857799.205703" Rows="1001.000000" Width="12"/>
                       </dxl:Properties>
                       <dxl:GroupingColumns>
                         <dxl:GroupingColumn ColId="9"/>
@@ -818,9 +818,9 @@
                       </dxl:GroupingColumns>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="27" Alias="sum">
-                          <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" >
+                          <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
                             <dxl:ValuesList ParamType="aggargs">
-                            <dxl:Ident ColId="18" ColName="i" TypeMdid="0.23.1.0"/>
+                              <dxl:Ident ColId="18" ColName="i" TypeMdid="0.23.1.0"/>
                             </dxl:ValuesList>
                             <dxl:ValuesList ParamType="aggdirectargs"/>
                             <dxl:ValuesList ParamType="aggorder"/>
@@ -840,7 +840,7 @@
                       <dxl:Filter/>
                       <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="1817583.040983" Rows="10008999.000000" Width="18"/>
+                          <dxl:Cost StartupCost="0" TotalCost="1857619.036983" Rows="10008999.000000" Width="18"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="9" Alias="i">
@@ -952,35 +952,35 @@
                             </dxl:Sort>
                           </dxl:GatherMotion>
                         </dxl:Materialize>
-                        <dxl:Result>
+                        <dxl:Materialize Eager="true">
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="659089.361300" Rows="9999.000000" Width="4"/>
+                            <dxl:Cost StartupCost="0" TotalCost="699125.357300" Rows="9999.000000" Width="4"/>
                           </dxl:Properties>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="18" Alias="i">
                               <dxl:Ident ColId="18" ColName="i" TypeMdid="0.23.1.0"/>
                             </dxl:ProjElem>
                           </dxl:ProjList>
-                          <dxl:Filter>
-                            <dxl:Comparison ComparisonOperator="&lt;&gt;" OperatorMdid="0.518.1.0">
-                              <dxl:Ident ColId="18" ColName="i" TypeMdid="0.23.1.0"/>
-                              <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
-                            </dxl:Comparison>
-                          </dxl:Filter>
-                          <dxl:OneTimeFilter/>
-                          <dxl:Materialize Eager="true">
+                          <dxl:Filter/>
+                          <dxl:Result>
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="431.361300" Rows="10000.000000" Width="4"/>
+                              <dxl:Cost StartupCost="0" TotalCost="659089.361300" Rows="9999.000000" Width="4"/>
                             </dxl:Properties>
                             <dxl:ProjList>
                               <dxl:ProjElem ColId="18" Alias="i">
                                 <dxl:Ident ColId="18" ColName="i" TypeMdid="0.23.1.0"/>
                               </dxl:ProjElem>
                             </dxl:ProjList>
-                            <dxl:Filter/>
-                            <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+                            <dxl:Filter>
+                              <dxl:Comparison ComparisonOperator="&lt;&gt;" OperatorMdid="0.518.1.0">
+                                <dxl:Ident ColId="18" ColName="i" TypeMdid="0.23.1.0"/>
+                                <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+                              </dxl:Comparison>
+                            </dxl:Filter>
+                            <dxl:OneTimeFilter/>
+                            <dxl:Materialize Eager="false">
                               <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="431.321300" Rows="10000.000000" Width="4"/>
+                                <dxl:Cost StartupCost="0" TotalCost="431.361300" Rows="10000.000000" Width="4"/>
                               </dxl:Properties>
                               <dxl:ProjList>
                                 <dxl:ProjElem ColId="18" Alias="i">
@@ -988,10 +988,9 @@
                                 </dxl:ProjElem>
                               </dxl:ProjList>
                               <dxl:Filter/>
-                              <dxl:SortingColumnList/>
-                              <dxl:TableScan>
+                              <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
                                 <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="431.104500" Rows="10000.000000" Width="4"/>
+                                  <dxl:Cost StartupCost="0" TotalCost="431.321300" Rows="10000.000000" Width="4"/>
                                 </dxl:Properties>
                                 <dxl:ProjList>
                                   <dxl:ProjElem ColId="18" Alias="i">
@@ -999,22 +998,34 @@
                                   </dxl:ProjElem>
                                 </dxl:ProjList>
                                 <dxl:Filter/>
-                                <dxl:TableDescriptor Mdid="6.761868.1.1" TableName="z">
-                                  <dxl:Columns>
-                                    <dxl:Column ColId="18" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
-                                    <dxl:Column ColId="20" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                                    <dxl:Column ColId="21" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                                    <dxl:Column ColId="22" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                                    <dxl:Column ColId="23" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                                    <dxl:Column ColId="24" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                                    <dxl:Column ColId="25" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                                    <dxl:Column ColId="26" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                                  </dxl:Columns>
-                                </dxl:TableDescriptor>
-                              </dxl:TableScan>
-                            </dxl:GatherMotion>
-                          </dxl:Materialize>
-                        </dxl:Result>
+                                <dxl:SortingColumnList/>
+                                <dxl:TableScan>
+                                  <dxl:Properties>
+                                    <dxl:Cost StartupCost="0" TotalCost="431.104500" Rows="10000.000000" Width="4"/>
+                                  </dxl:Properties>
+                                  <dxl:ProjList>
+                                    <dxl:ProjElem ColId="18" Alias="i">
+                                      <dxl:Ident ColId="18" ColName="i" TypeMdid="0.23.1.0"/>
+                                    </dxl:ProjElem>
+                                  </dxl:ProjList>
+                                  <dxl:Filter/>
+                                  <dxl:TableDescriptor Mdid="6.761868.1.1" TableName="z">
+                                    <dxl:Columns>
+                                      <dxl:Column ColId="18" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
+                                      <dxl:Column ColId="20" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                      <dxl:Column ColId="21" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                                      <dxl:Column ColId="22" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                                      <dxl:Column ColId="23" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                                      <dxl:Column ColId="24" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                                      <dxl:Column ColId="25" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                      <dxl:Column ColId="26" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                    </dxl:Columns>
+                                  </dxl:TableDescriptor>
+                                </dxl:TableScan>
+                              </dxl:GatherMotion>
+                            </dxl:Materialize>
+                          </dxl:Result>
+                        </dxl:Materialize>
                       </dxl:NestedLoopJoin>
                     </dxl:Aggregate>
                   </dxl:Result>

--- a/src/backend/gporca/data/dxl/minidump/MultipleSubqueriesInSelectClause.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MultipleSubqueriesInSelectClause.mdp
@@ -1178,7 +1178,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalProject>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="324625">
+    <dxl:Plan Id="0" SpaceSize="70119">
       <dxl:Result>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="9309.074116" Rows="3000000.000000" Width="32"/>

--- a/src/backend/gporca/data/dxl/minidump/NLJ-Broadcast-DPE-Outer-Child.mdp
+++ b/src/backend/gporca/data/dxl/minidump/NLJ-Broadcast-DPE-Outer-Child.mdp
@@ -397,7 +397,7 @@ select * from bmao_part as t1 join bmao_part as t2 on t1.a < t2.a where t1.a < 5
         </dxl:LogicalJoin>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="8">
+    <dxl:Plan Id="0" SpaceSize="7">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1463.291591" Rows="799200.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/NLJ-EqAllCol-No-Broadcast.mdp
+++ b/src/backend/gporca/data/dxl/minidump/NLJ-EqAllCol-No-Broadcast.mdp
@@ -309,33 +309,6 @@ explain select * from a1,b1 where a1.a = b1.a and a1.a = b1.b;
           </dxl:JoinFilter>
           <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="8"/>
-            </dxl:Properties>
-            <dxl:ProjList>
-              <dxl:ProjElem ColId="0" Alias="a">
-                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="1" Alias="b">
-                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-            </dxl:ProjList>
-            <dxl:Filter/>
-            <dxl:TableDescriptor Mdid="6.49824.1.0" TableName="a1">
-              <dxl:Columns>
-                <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-                <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
-                <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-              </dxl:Columns>
-            </dxl:TableDescriptor>
-          </dxl:TableScan>
-          <dxl:TableScan>
-            <dxl:Properties>
               <dxl:Cost StartupCost="0" TotalCost="431.000102" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
@@ -363,6 +336,33 @@ explain select * from a1,b1 where a1.a = b1.a and a1.a = b1.b;
                 <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
                 <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
                 <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
+          <dxl:TableScan>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="8"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="0" Alias="a">
+                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="1" Alias="b">
+                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:TableDescriptor Mdid="6.49824.1.0" TableName="a1">
+              <dxl:Columns>
+                <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
               </dxl:Columns>
             </dxl:TableDescriptor>
           </dxl:TableScan>

--- a/src/backend/gporca/data/dxl/minidump/Nested-Setops-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Nested-Setops-2.mdp
@@ -597,7 +597,7 @@
         </dxl:LogicalProject>
       </dxl:Difference>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="177876000">
+    <dxl:Plan Id="0" SpaceSize="166212000">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="2592.974241" Rows="1.000000" Width="12"/>

--- a/src/backend/gporca/data/dxl/minidump/NestedInSubqWithPrjListOuterRefNoInnerRef.mdp
+++ b/src/backend/gporca/data/dxl/minidump/NestedInSubqWithPrjListOuterRefNoInnerRef.mdp
@@ -702,7 +702,7 @@ EXPLAIN SELECT * FROM foo WHERE foo.a IN (SELECT foo.b + 1 FROM (SELECT * FROM b
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="6340">
+    <dxl:Plan Id="0" SpaceSize="5912">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="2155.006784" Rows="40.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/OneLevel-CorrelatedExec.mdp
+++ b/src/backend/gporca/data/dxl/minidump/OneLevel-CorrelatedExec.mdp
@@ -740,7 +740,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="2890">
+    <dxl:Plan Id="0" SpaceSize="2585">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="14873.784860" Rows="400.000000" Width="12"/>

--- a/src/backend/gporca/data/dxl/minidump/OrderedAgg_multiple_diffcol.mdp
+++ b/src/backend/gporca/data/dxl/minidump/OrderedAgg_multiple_diffcol.mdp
@@ -450,7 +450,7 @@ EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a1), percentile_cont(0
         </dxl:LogicalGet>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="39440">
+    <dxl:Plan Id="0" SpaceSize="21200">
       <dxl:Sequence>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="2712060318.276298" Rows="1.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/OrderedAgg_multiple_samecol.mdp
+++ b/src/backend/gporca/data/dxl/minidump/OrderedAgg_multiple_samecol.mdp
@@ -434,7 +434,7 @@ EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a2), percentile_disc(0
         </dxl:LogicalGet>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="190">
+    <dxl:Plan Id="0" SpaceSize="130">
       <dxl:Sequence>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1324463.294825" Rows="1.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/OrderedAgg_multiple_samecol_difforderespec.mdp
+++ b/src/backend/gporca/data/dxl/minidump/OrderedAgg_multiple_samecol_difforderespec.mdp
@@ -446,7 +446,7 @@ EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a2), percentile_cont(0
         </dxl:LogicalGet>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="197200">
+    <dxl:Plan Id="0" SpaceSize="106000">
       <dxl:Sequence>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="2712060345.624441" Rows="1.000000" Width="16"/>

--- a/src/backend/gporca/data/dxl/minidump/OrderedAgg_single.mdp
+++ b/src/backend/gporca/data/dxl/minidump/OrderedAgg_single.mdp
@@ -395,7 +395,7 @@ EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a2) FROM foo;
         </dxl:LogicalGet>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="190">
+    <dxl:Plan Id="0" SpaceSize="130">
       <dxl:Sequence>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1324463.294809" Rows="1.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/OrderedAgg_skewed_data.mdp
+++ b/src/backend/gporca/data/dxl/minidump/OrderedAgg_skewed_data.mdp
@@ -356,7 +356,7 @@ EXPLAIN ANALYZE SELECT percentile_cont(0.25) WITHIN GROUP (ORDER BY a ASC nulls 
         </dxl:LogicalGet>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="190">
+    <dxl:Plan Id="0" SpaceSize="130">
       <dxl:Sequence>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1325244.228342" Rows="1.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/OrderedAgg_with_nonOrderedAgg.mdp
+++ b/src/backend/gporca/data/dxl/minidump/OrderedAgg_with_nonOrderedAgg.mdp
@@ -502,7 +502,7 @@ EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a1), percentile_disc(0
         </dxl:LogicalGet>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1086480">
+    <dxl:Plan Id="0" SpaceSize="588600">
       <dxl:Sequence>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1390608583331.788818" Rows="1.000000" Width="24"/>

--- a/src/backend/gporca/data/dxl/minidump/OrderedAgg_with_nonconst_fraction.mdp
+++ b/src/backend/gporca/data/dxl/minidump/OrderedAgg_with_nonconst_fraction.mdp
@@ -439,7 +439,7 @@ EXPLAIN SELECT percentile_cont(floor(random()*0.1)+0.5) WITHIN GROUP(ORDER BY a1
         </dxl:LogicalGet>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="38">
+    <dxl:Plan Id="0" SpaceSize="26">
       <dxl:Sequence>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1324463.268099" Rows="1.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-DPE-GroupBy.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-DPE-GroupBy.mdp
@@ -533,7 +533,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="772">
+    <dxl:Plan Id="0" SpaceSize="731">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="862.022556" Rows="99.900000" Width="14"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-MultiWayJoinWithDPE.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-MultiWayJoinWithDPE.mdp
@@ -3255,7 +3255,7 @@
         </dxl:LogicalJoin>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="16102">
+    <dxl:Plan Id="0" SpaceSize="16018">
       <dxl:HashJoin JoinType="Inner">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1749455.606498" Rows="321694266.492042" Width="355"/>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-SubqueryOuterRef.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-SubqueryOuterRef.mdp
@@ -433,7 +433,7 @@ explain select * from t1 where a = 1 and b in (select b from t2);
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="86">
+    <dxl:Plan Id="0" SpaceSize="82">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.004074" Rows="1.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/Project-With-NonScalar-Func.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Project-With-NonScalar-Func.mdp
@@ -195,7 +195,7 @@
     <dxl:Plan Id="0" SpaceSize="16">
       <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="441344.280304" Rows="1.000000" Width="1"/>
+          <dxl:Cost StartupCost="0" TotalCost="441344.272112" Rows="1.000000" Width="1"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="3" Alias="?column?">
@@ -209,7 +209,7 @@
         <dxl:OneTimeFilter/>
         <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="441344.280303" Rows="2.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="441344.272111" Rows="2.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="9" Alias="ColRef_0009">
@@ -234,7 +234,7 @@
           </dxl:Result>
           <dxl:Assert ErrorCode="P0003">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="0.000182" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="0.000174" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="9" Alias="ColRef_0009">
@@ -251,7 +251,7 @@
             </dxl:AssertConstraintList>
             <dxl:Window PartitionColumns="">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.000174" Rows="1.000000" Width="16"/>
+                <dxl:Cost StartupCost="0" TotalCost="0.000166" Rows="1.000000" Width="16"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="12" Alias="row_number">
@@ -262,44 +262,41 @@
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:Result>
+              <dxl:Materialize Eager="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="0.000174" Rows="1.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="0.000166" Rows="1.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="9" Alias="ColRef_0009">
-                    <dxl:If TypeMdid="0.20.1.0">
-                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.410.1.0">
-                        <dxl:Ident ColId="7" ColName="ColRef_0007" TypeMdid="0.20.1.0"/>
-                        <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
-                      </dxl:Comparison>
-                      <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
-                      <dxl:If TypeMdid="0.20.1.0">
-                        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.410.1.0">
-                          <dxl:Ident ColId="7" ColName="ColRef_0007" TypeMdid="0.20.1.0"/>
-                          <dxl:Ident ColId="8" ColName="ColRef_0008" TypeMdid="0.20.1.0"/>
-                        </dxl:Comparison>
-                        <dxl:ConstValue TypeMdid="0.20.1.0" Value="-1"/>
-                        <dxl:Ident ColId="7" ColName="ColRef_0007" TypeMdid="0.20.1.0"/>
-                      </dxl:If>
-                    </dxl:If>
+                    <dxl:Ident ColId="9" ColName="ColRef_0009" TypeMdid="0.20.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
-                <dxl:OneTimeFilter/>
-                <dxl:Materialize Eager="false">
+                <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="0.000166" Rows="1.000000" Width="16"/>
+                    <dxl:Cost StartupCost="0" TotalCost="0.000158" Rows="1.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:ProjList>
-                    <dxl:ProjElem ColId="7" Alias="ColRef_0007">
-                      <dxl:Ident ColId="7" ColName="ColRef_0007" TypeMdid="0.20.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="8" Alias="ColRef_0008">
-                      <dxl:Ident ColId="8" ColName="ColRef_0008" TypeMdid="0.20.1.0"/>
+                    <dxl:ProjElem ColId="9" Alias="ColRef_0009">
+                      <dxl:If TypeMdid="0.20.1.0">
+                        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.410.1.0">
+                          <dxl:Ident ColId="7" ColName="ColRef_0007" TypeMdid="0.20.1.0"/>
+                          <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+                        </dxl:Comparison>
+                        <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
+                        <dxl:If TypeMdid="0.20.1.0">
+                          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.410.1.0">
+                            <dxl:Ident ColId="7" ColName="ColRef_0007" TypeMdid="0.20.1.0"/>
+                            <dxl:Ident ColId="8" ColName="ColRef_0008" TypeMdid="0.20.1.0"/>
+                          </dxl:Comparison>
+                          <dxl:ConstValue TypeMdid="0.20.1.0" Value="-1"/>
+                          <dxl:Ident ColId="7" ColName="ColRef_0007" TypeMdid="0.20.1.0"/>
+                        </dxl:If>
+                      </dxl:If>
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
+                  <dxl:OneTimeFilter/>
                   <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                     <dxl:Properties>
                       <dxl:Cost StartupCost="0" TotalCost="0.000150" Rows="1.000000" Width="16"/>
@@ -423,8 +420,8 @@
                       </dxl:Result>
                     </dxl:Aggregate>
                   </dxl:Aggregate>
-                </dxl:Materialize>
-              </dxl:Result>
+                </dxl:Result>
+              </dxl:Materialize>
               <dxl:WindowKeyList>
                 <dxl:WindowKey>
                   <dxl:SortingColumnList/>

--- a/src/backend/gporca/data/dxl/minidump/PushGbBelowJoin-NegativeCase.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PushGbBelowJoin-NegativeCase.mdp
@@ -406,10 +406,10 @@
         </dxl:LogicalSelect>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="12480">
+    <dxl:Plan Id="0" SpaceSize="8760">
       <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="3017.002573" Rows="1.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="3017.002597" Rows="1.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="20" Alias="c9596">
@@ -420,7 +420,7 @@
         <dxl:OneTimeFilter/>
         <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="3017.002573" Rows="1.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="3017.002597" Rows="1.000000" Width="4"/>
           </dxl:Properties>
           <dxl:GroupingColumns>
             <dxl:GroupingColumn ColId="20"/>
@@ -437,7 +437,7 @@
           <dxl:Filter/>
           <dxl:Sort SortDiscardDuplicates="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="3017.002562" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="3017.002586" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="17" Alias="max">
@@ -456,7 +456,7 @@
             <dxl:LimitOffset/>
             <dxl:HashJoin JoinType="Inner">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="3017.002562" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="3017.002586" Rows="1.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="17" Alias="max">
@@ -535,9 +535,9 @@
                     </dxl:GroupingColumns>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="16" Alias="avg">
-                        <dxl:AggFunc AggMdid="0.2101.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" >
+                        <dxl:AggFunc AggMdid="0.2101.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
                           <dxl:ValuesList ParamType="aggargs">
-                          <dxl:Ident ColId="8" ColName="c504" TypeMdid="0.23.1.0"/>
+                            <dxl:Ident ColId="8" ColName="c504" TypeMdid="0.23.1.0"/>
                           </dxl:ValuesList>
                           <dxl:ValuesList ParamType="aggdirectargs"/>
                           <dxl:ValuesList ParamType="aggorder"/>
@@ -545,9 +545,9 @@
                         </dxl:AggFunc>
                       </dxl:ProjElem>
                       <dxl:ProjElem ColId="17" Alias="max">
-                        <dxl:AggFunc AggMdid="0.2116.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" >
+                        <dxl:AggFunc AggMdid="0.2116.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
                           <dxl:ValuesList ParamType="aggargs">
-                          <dxl:Ident ColId="8" ColName="c504" TypeMdid="0.23.1.0"/>
+                            <dxl:Ident ColId="8" ColName="c504" TypeMdid="0.23.1.0"/>
                           </dxl:ValuesList>
                           <dxl:ValuesList ParamType="aggdirectargs"/>
                           <dxl:ValuesList ParamType="aggorder"/>
@@ -624,7 +624,7 @@
               </dxl:GatherMotion>
               <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="2586.001386" Rows="1.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="2586.001410" Rows="1.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="2" Alias="min">
@@ -700,9 +700,9 @@
                         </dxl:GroupingColumns>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="2" Alias="min">
-                            <dxl:AggFunc AggMdid="0.2132.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" >
+                            <dxl:AggFunc AggMdid="0.2132.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
                               <dxl:ValuesList ParamType="aggargs">
-                              <dxl:Ident ColId="1" ColName="?column?" TypeMdid="0.23.1.0"/>
+                                <dxl:Ident ColId="1" ColName="?column?" TypeMdid="0.23.1.0"/>
                               </dxl:ValuesList>
                               <dxl:ValuesList ParamType="aggdirectargs"/>
                               <dxl:ValuesList ParamType="aggorder"/>
@@ -781,30 +781,41 @@
                     </dxl:LimitOffset>
                   </dxl:Limit>
                 </dxl:Result>
-                <dxl:Result>
+                <dxl:Materialize Eager="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
+                    <dxl:Cost StartupCost="0" TotalCost="0.000009" Rows="1.000000" Width="4"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="20" Alias="?column?">
-                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                      <dxl:Ident ColId="20" ColName="?column?" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:OneTimeFilter/>
                   <dxl:Result>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                      <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
                     </dxl:Properties>
                     <dxl:ProjList>
-                      <dxl:ProjElem ColId="19" Alias="">
-                        <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                      <dxl:ProjElem ColId="20" Alias="?column?">
+                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
                     <dxl:OneTimeFilter/>
+                    <dxl:Result>
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="19" Alias="">
+                          <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:OneTimeFilter/>
+                    </dxl:Result>
                   </dxl:Result>
-                </dxl:Result>
+                </dxl:Materialize>
               </dxl:NestedLoopJoin>
             </dxl:HashJoin>
           </dxl:Sort>

--- a/src/backend/gporca/data/dxl/minidump/PushSelectWithOuterRefBelowUnion.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PushSelectWithOuterRefBelowUnion.mdp
@@ -4981,7 +4981,7 @@
         </dxl:Or>
       </dxl:LogicalJoin>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="8868">
+    <dxl:Plan Id="0" SpaceSize="8208">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="25985.808128" Rows="60175000.000000" Width="14"/>

--- a/src/backend/gporca/data/dxl/minidump/Select-Proj-OuterJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Select-Proj-OuterJoin.mdp
@@ -889,7 +889,7 @@
         </dxl:LogicalSelect>
       </dxl:LogicalLimit>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="16660">
+    <dxl:Plan Id="0" SpaceSize="17364">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="891.087839" Rows="3009.000000" Width="64"/>

--- a/src/backend/gporca/data/dxl/minidump/Sequence-With-Universal-Outer.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Sequence-With-Universal-Outer.mdp
@@ -102,10 +102,10 @@
         </dxl:LogicalTVF>
       </dxl:LogicalLimit>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="20">
+    <dxl:Plan Id="0" SpaceSize="32">
       <dxl:Sort SortDiscardDuplicates="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="862.256156" Rows="1000.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="862.256160" Rows="1000.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -132,7 +132,7 @@
             <dxl:ParamList/>
             <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000056" Rows="1.000000" Width="4"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000060" Rows="1.000000" Width="4"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="9" Alias="ColRef_0004">
@@ -143,7 +143,7 @@
               <dxl:OneTimeFilter/>
               <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000052" Rows="2.000000" Width="4"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000056" Rows="2.000000" Width="4"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="12" Alias="?column?">
@@ -166,30 +166,41 @@
                   <dxl:Filter/>
                   <dxl:OneTimeFilter/>
                 </dxl:Result>
-                <dxl:Result>
+                <dxl:Materialize Eager="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
+                    <dxl:Cost StartupCost="0" TotalCost="0.000009" Rows="1.000000" Width="4"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="12" Alias="?column?">
-                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="5"/>
+                      <dxl:Ident ColId="12" ColName="?column?" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:OneTimeFilter/>
                   <dxl:Result>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                      <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
                     </dxl:Properties>
                     <dxl:ProjList>
-                      <dxl:ProjElem ColId="11" Alias="">
-                        <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                      <dxl:ProjElem ColId="12" Alias="?column?">
+                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="5"/>
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
                     <dxl:OneTimeFilter/>
+                    <dxl:Result>
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="11" Alias="">
+                          <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:OneTimeFilter/>
+                    </dxl:Result>
                   </dxl:Result>
-                </dxl:Result>
+                </dxl:Materialize>
               </dxl:NestedLoopJoin>
             </dxl:Result>
           </dxl:SubPlan>

--- a/src/backend/gporca/data/dxl/minidump/SimplifyExistsSubquery2Limit.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SimplifyExistsSubquery2Limit.mdp
@@ -714,7 +714,7 @@ explain select * from foo where foo.a = 10 and exists (select * from bar);
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="86">
+    <dxl:Plan Id="0" SpaceSize="82">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1311.703352" Rows="1.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/Subq-With-OuterRefCol.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Subq-With-OuterRefCol.mdp
@@ -532,7 +532,7 @@ pivotal=# explain select a, c from r, s where a in (select c from r) order by a,
         </dxl:LogicalJoin>
       </dxl:LogicalLimit>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="3164">
+    <dxl:Plan Id="0" SpaceSize="3124">
       <dxl:Limit>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1724.005263" Rows="10.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/Subq2OuterRef2InJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Subq2OuterRef2InJoin.mdp
@@ -457,7 +457,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="63">
+    <dxl:Plan Id="0" SpaceSize="84">
       <dxl:Result>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1423057834895712.000000" Rows="1.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/Subq2PartialDecorrelate.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Subq2PartialDecorrelate.mdp
@@ -434,7 +434,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="67">
+    <dxl:Plan Id="0" SpaceSize="153">
       <dxl:Result>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1356692189.437047" Rows="1.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/SubqAll-InsideScalarExpression.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SubqAll-InsideScalarExpression.mdp
@@ -385,7 +385,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="23">
+    <dxl:Plan Id="0" SpaceSize="17">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1324032.428517" Rows="1.000000" Width="15"/>

--- a/src/backend/gporca/data/dxl/minidump/SubqAny-InsideScalarExpression.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SubqAny-InsideScalarExpression.mdp
@@ -381,10 +381,10 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="22">
+    <dxl:Plan Id="0" SpaceSize="16">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1324032.643711" Rows="2.000000" Width="13"/>
+          <dxl:Cost StartupCost="0" TotalCost="1324032.644735" Rows="2.000000" Width="13"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -401,7 +401,7 @@
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1324032.643615" Rows="2.000000" Width="13"/>
+            <dxl:Cost StartupCost="0" TotalCost="1324032.644639" Rows="2.000000" Width="13"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -429,7 +429,7 @@
                     <dxl:Ident ColId="23" ColName="ColRef_0023" TypeMdid="0.20.1.0"/>
                     <dxl:Ident ColId="21" ColName="ColRef_0021" TypeMdid="0.20.1.0"/>
                   </dxl:Comparison>
-                  <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true" IsByValue="true"/>
+                  <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true"/>
                   <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
                 </dxl:If>
                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="false"/>
@@ -439,7 +439,7 @@
           <dxl:OneTimeFilter/>
           <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1324032.643549" Rows="2.000000" Width="29"/>
+              <dxl:Cost StartupCost="0" TotalCost="1324032.644573" Rows="2.000000" Width="29"/>
             </dxl:Properties>
             <dxl:GroupingColumns>
               <dxl:GroupingColumn ColId="0"/>
@@ -450,7 +450,7 @@
             </dxl:GroupingColumns>
             <dxl:ProjList>
               <dxl:ProjElem ColId="21" Alias="ColRef_0021">
-                <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Final" AggKind="n" >
+                <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Final" AggKind="n">
                   <dxl:ValuesList ParamType="aggargs">
                     <dxl:Ident ColId="31" ColName="ColRef_0031" TypeMdid="0.20.1.0"/>
                   </dxl:ValuesList>
@@ -460,7 +460,7 @@
                 </dxl:AggFunc>
               </dxl:ProjElem>
               <dxl:ProjElem ColId="23" Alias="ColRef_0023">
-                <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Final" AggKind="n" >
+                <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Final" AggKind="n">
                   <dxl:ValuesList ParamType="aggargs">
                     <dxl:Ident ColId="32" ColName="ColRef_0032" TypeMdid="0.20.1.0"/>
                   </dxl:ValuesList>
@@ -488,7 +488,7 @@
             <dxl:Filter/>
             <dxl:Sort SortDiscardDuplicates="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1324032.643499" Rows="2.000000" Width="39"/>
+                <dxl:Cost StartupCost="0" TotalCost="1324032.644523" Rows="2.000000" Width="39"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">
@@ -522,7 +522,7 @@
               <dxl:LimitOffset/>
               <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1324032.643499" Rows="2.000000" Width="39"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1324032.644523" Rows="2.000000" Width="39"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="a">
@@ -559,7 +559,7 @@
                 </dxl:HashExprList>
                 <dxl:Result>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1324032.643377" Rows="2.000000" Width="39"/>
+                    <dxl:Cost StartupCost="0" TotalCost="1324032.644401" Rows="2.000000" Width="39"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="0" Alias="a">
@@ -588,7 +588,7 @@
                   <dxl:OneTimeFilter/>
                   <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="1324032.643377" Rows="2.000000" Width="39"/>
+                      <dxl:Cost StartupCost="0" TotalCost="1324032.644401" Rows="2.000000" Width="39"/>
                     </dxl:Properties>
                     <dxl:GroupingColumns>
                       <dxl:GroupingColumn ColId="0"/>
@@ -599,7 +599,7 @@
                     </dxl:GroupingColumns>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="31" Alias="ColRef_0031">
-                        <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" >
+                        <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Partial" AggKind="n">
                           <dxl:ValuesList ParamType="aggargs">
                             <dxl:Ident ColId="20" ColName="ColRef_0020" TypeMdid="0.16.1.0"/>
                           </dxl:ValuesList>
@@ -609,7 +609,7 @@
                         </dxl:AggFunc>
                       </dxl:ProjElem>
                       <dxl:ProjElem ColId="32" Alias="ColRef_0032">
-                        <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" >
+                        <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Partial" AggKind="n">
                           <dxl:ValuesList ParamType="aggargs">
                             <dxl:Ident ColId="22" ColName="ColRef_0022" TypeMdid="0.23.1.0"/>
                           </dxl:ValuesList>
@@ -637,7 +637,7 @@
                     <dxl:Filter/>
                     <dxl:Result>
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="1324032.643299" Rows="4.000000" Width="28"/>
+                        <dxl:Cost StartupCost="0" TotalCost="1324032.644323" Rows="4.000000" Width="28"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="22" Alias="ColRef_0022">
@@ -675,7 +675,7 @@
                       <dxl:OneTimeFilter/>
                       <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="1324032.643243" Rows="4.000000" Width="28"/>
+                          <dxl:Cost StartupCost="0" TotalCost="1324032.644267" Rows="4.000000" Width="28"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="0" Alias="a">
@@ -775,30 +775,33 @@
                             </dxl:TableDescriptor>
                           </dxl:TableScan>
                         </dxl:Sort>
-                        <dxl:Result>
+                        <dxl:Materialize Eager="false">
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="431.000091" Rows="3.000000" Width="5"/>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000092" Rows="3.000000" Width="5"/>
                           </dxl:Properties>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="20" Alias="ColRef_0020">
-                              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                              <dxl:Ident ColId="20" ColName="ColRef_0020" TypeMdid="0.16.1.0"/>
                             </dxl:ProjElem>
                             <dxl:ProjElem ColId="12" Alias="c">
                               <dxl:Ident ColId="12" ColName="c" TypeMdid="0.23.1.0"/>
                             </dxl:ProjElem>
                           </dxl:ProjList>
                           <dxl:Filter/>
-                          <dxl:OneTimeFilter/>
-                          <dxl:Materialize Eager="false">
+                          <dxl:Result>
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="431.000086" Rows="3.000000" Width="4"/>
+                              <dxl:Cost StartupCost="0" TotalCost="431.000087" Rows="3.000000" Width="5"/>
                             </dxl:Properties>
                             <dxl:ProjList>
+                              <dxl:ProjElem ColId="20" Alias="ColRef_0020">
+                                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                              </dxl:ProjElem>
                               <dxl:ProjElem ColId="12" Alias="c">
                                 <dxl:Ident ColId="12" ColName="c" TypeMdid="0.23.1.0"/>
                               </dxl:ProjElem>
                             </dxl:ProjList>
                             <dxl:Filter/>
+                            <dxl:OneTimeFilter/>
                             <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                               <dxl:Properties>
                                 <dxl:Cost StartupCost="0" TotalCost="431.000082" Rows="3.000000" Width="4"/>
@@ -835,8 +838,8 @@
                                 </dxl:TableDescriptor>
                               </dxl:TableScan>
                             </dxl:BroadcastMotion>
-                          </dxl:Materialize>
-                        </dxl:Result>
+                          </dxl:Result>
+                        </dxl:Materialize>
                       </dxl:NestedLoopJoin>
                     </dxl:Result>
                   </dxl:Aggregate>

--- a/src/backend/gporca/data/dxl/minidump/SubqExists-With-External-Corrs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SubqExists-With-External-Corrs.mdp
@@ -456,7 +456,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="22026">
+    <dxl:Plan Id="0" SpaceSize="22142">
       <dxl:HashJoin JoinType="Inner">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1724.001472" Rows="1.000000" Width="8"/>

--- a/src/backend/gporca/data/dxl/minidump/SubqInIndexPred.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SubqInIndexPred.mdp
@@ -520,7 +520,7 @@ ON a = c
         </dxl:LogicalJoin>
       </dxl:LogicalProject>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="48688">
+    <dxl:Plan Id="0" SpaceSize="36848">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="2206721.811317" Rows="1.000000" Width="1"/>

--- a/src/backend/gporca/data/dxl/minidump/Subquery-AnyAllAggregates.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Subquery-AnyAllAggregates.mdp
@@ -524,15 +524,15 @@
         </dxl:LogicalGet>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="218">
+    <dxl:Plan Id="0" SpaceSize="146">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1356698074.463431" Rows="1.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="1356698083.900615" Rows="1.000000" Width="16"/>
         </dxl:Properties>
         <dxl:GroupingColumns/>
         <dxl:ProjList>
           <dxl:ProjElem ColId="18" Alias="sum">
-            <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Final" AggKind="n" >
+            <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Final" AggKind="n">
               <dxl:ValuesList ParamType="aggargs">
                 <dxl:Ident ColId="42" ColName="ColRef_0042" TypeMdid="0.20.1.0"/>
               </dxl:ValuesList>
@@ -542,7 +542,7 @@
             </dxl:AggFunc>
           </dxl:ProjElem>
           <dxl:ProjElem ColId="28" Alias="sum">
-            <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Final" AggKind="n" >
+            <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Final" AggKind="n">
               <dxl:ValuesList ParamType="aggargs">
                 <dxl:Ident ColId="43" ColName="ColRef_0043" TypeMdid="0.20.1.0"/>
               </dxl:ValuesList>
@@ -555,7 +555,7 @@
         <dxl:Filter/>
         <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1356698074.463423" Rows="1.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="1356698083.900608" Rows="1.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="42" Alias="ColRef_0042">
@@ -569,12 +569,12 @@
           <dxl:SortingColumnList/>
           <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1356698074.463364" Rows="1.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="1356698083.900548" Rows="1.000000" Width="16"/>
             </dxl:Properties>
             <dxl:GroupingColumns/>
             <dxl:ProjList>
               <dxl:ProjElem ColId="42" Alias="ColRef_0042">
-                <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" >
+                <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Partial" AggKind="n">
                   <dxl:ValuesList ParamType="aggargs">
                     <dxl:If TypeMdid="0.23.1.0">
                       <dxl:If TypeMdid="0.16.1.0">
@@ -602,7 +602,7 @@
                 </dxl:AggFunc>
               </dxl:ProjElem>
               <dxl:ProjElem ColId="43" Alias="ColRef_0043">
-                <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" >
+                <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Partial" AggKind="n">
                   <dxl:ValuesList ParamType="aggargs">
                     <dxl:If TypeMdid="0.23.1.0">
                       <dxl:SubPlan TypeMdid="0.16.1.0" SubPlanType="AllSubPlan">
@@ -729,7 +729,7 @@
             <dxl:Filter/>
             <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1324038.433134" Rows="8.000000" Width="24"/>
+                <dxl:Cost StartupCost="0" TotalCost="1324038.442350" Rows="8.000000" Width="24"/>
               </dxl:Properties>
               <dxl:GroupingColumns>
                 <dxl:GroupingColumn ColId="0"/>
@@ -739,7 +739,7 @@
               </dxl:GroupingColumns>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="30" Alias="ColRef_0030">
-                  <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Final" AggKind="n" >
+                  <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Final" AggKind="n">
                     <dxl:ValuesList ParamType="aggargs">
                       <dxl:Ident ColId="40" ColName="ColRef_0040" TypeMdid="0.20.1.0"/>
                     </dxl:ValuesList>
@@ -749,7 +749,7 @@
                   </dxl:AggFunc>
                 </dxl:ProjElem>
                 <dxl:ProjElem ColId="32" Alias="ColRef_0032">
-                  <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Final" AggKind="n" >
+                  <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Final" AggKind="n">
                     <dxl:ValuesList ParamType="aggargs">
                       <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.20.1.0"/>
                     </dxl:ValuesList>
@@ -774,7 +774,7 @@
               <dxl:Filter/>
               <dxl:Sort SortDiscardDuplicates="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1324038.433008" Rows="8.000000" Width="34"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1324038.442224" Rows="8.000000" Width="34"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="a">
@@ -805,7 +805,7 @@
                 <dxl:LimitOffset/>
                 <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1324038.432280" Rows="8.000000" Width="34"/>
+                    <dxl:Cost StartupCost="0" TotalCost="1324038.441496" Rows="8.000000" Width="34"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="0" Alias="a">
@@ -839,7 +839,7 @@
                   </dxl:HashExprList>
                   <dxl:Result>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="1324038.431997" Rows="8.000000" Width="34"/>
+                      <dxl:Cost StartupCost="0" TotalCost="1324038.441213" Rows="8.000000" Width="34"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="0" Alias="a">
@@ -865,7 +865,7 @@
                     <dxl:OneTimeFilter/>
                     <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="1324038.431997" Rows="8.000000" Width="34"/>
+                        <dxl:Cost StartupCost="0" TotalCost="1324038.441213" Rows="8.000000" Width="34"/>
                       </dxl:Properties>
                       <dxl:GroupingColumns>
                         <dxl:GroupingColumn ColId="0"/>
@@ -875,7 +875,7 @@
                       </dxl:GroupingColumns>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="40" Alias="ColRef_0040">
-                          <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" >
+                          <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Partial" AggKind="n">
                             <dxl:ValuesList ParamType="aggargs">
                               <dxl:Ident ColId="29" ColName="ColRef_0029" TypeMdid="0.16.1.0"/>
                             </dxl:ValuesList>
@@ -885,7 +885,7 @@
                           </dxl:AggFunc>
                         </dxl:ProjElem>
                         <dxl:ProjElem ColId="41" Alias="ColRef_0041">
-                          <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" >
+                          <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Partial" AggKind="n">
                             <dxl:ValuesList ParamType="aggargs">
                               <dxl:Ident ColId="31" ColName="ColRef_0031" TypeMdid="0.23.1.0"/>
                             </dxl:ValuesList>
@@ -910,7 +910,7 @@
                       <dxl:Filter/>
                       <dxl:Sort SortDiscardDuplicates="false">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="1324038.431862" Rows="10.880000" Width="23"/>
+                          <dxl:Cost StartupCost="0" TotalCost="1324038.441078" Rows="10.880000" Width="23"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="31" Alias="ColRef_0031">
@@ -941,7 +941,7 @@
                         <dxl:LimitOffset/>
                         <dxl:Result>
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="1324038.430983" Rows="10.880000" Width="23"/>
+                            <dxl:Cost StartupCost="0" TotalCost="1324038.440199" Rows="10.880000" Width="23"/>
                           </dxl:Properties>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="31" Alias="ColRef_0031">
@@ -976,7 +976,7 @@
                           <dxl:OneTimeFilter/>
                           <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="1324038.430900" Rows="10.880000" Width="23"/>
+                              <dxl:Cost StartupCost="0" TotalCost="1324038.440116" Rows="10.880000" Width="23"/>
                             </dxl:Properties>
                             <dxl:ProjList>
                               <dxl:ProjElem ColId="0" Alias="a">
@@ -1046,13 +1046,13 @@
                                 </dxl:Columns>
                               </dxl:TableDescriptor>
                             </dxl:TableScan>
-                            <dxl:Result>
+                            <dxl:Materialize Eager="false">
                               <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="431.001549" Rows="27.000000" Width="9"/>
+                                <dxl:Cost StartupCost="0" TotalCost="431.001558" Rows="27.000000" Width="9"/>
                               </dxl:Properties>
                               <dxl:ProjList>
                                 <dxl:ProjElem ColId="29" Alias="ColRef_0029">
-                                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                                  <dxl:Ident ColId="29" ColName="ColRef_0029" TypeMdid="0.16.1.0"/>
                                 </dxl:ProjElem>
                                 <dxl:ProjElem ColId="9" Alias="b">
                                   <dxl:Ident ColId="9" ColName="b" TypeMdid="0.23.1.0"/>
@@ -1062,12 +1062,14 @@
                                 </dxl:ProjElem>
                               </dxl:ProjList>
                               <dxl:Filter/>
-                              <dxl:OneTimeFilter/>
-                              <dxl:Materialize Eager="false">
+                              <dxl:Result>
                                 <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="431.001468" Rows="27.000000" Width="8"/>
+                                  <dxl:Cost StartupCost="0" TotalCost="431.001477" Rows="27.000000" Width="9"/>
                                 </dxl:Properties>
                                 <dxl:ProjList>
+                                  <dxl:ProjElem ColId="29" Alias="ColRef_0029">
+                                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                                  </dxl:ProjElem>
                                   <dxl:ProjElem ColId="9" Alias="b">
                                     <dxl:Ident ColId="9" ColName="b" TypeMdid="0.23.1.0"/>
                                   </dxl:ProjElem>
@@ -1076,6 +1078,7 @@
                                   </dxl:ProjElem>
                                 </dxl:ProjList>
                                 <dxl:Filter/>
+                                <dxl:OneTimeFilter/>
                                 <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                                   <dxl:Properties>
                                     <dxl:Cost StartupCost="0" TotalCost="431.001396" Rows="27.000000" Width="8"/>
@@ -1118,8 +1121,8 @@
                                     </dxl:TableDescriptor>
                                   </dxl:TableScan>
                                 </dxl:BroadcastMotion>
-                              </dxl:Materialize>
-                            </dxl:Result>
+                              </dxl:Result>
+                            </dxl:Materialize>
                           </dxl:NestedLoopJoin>
                         </dxl:Result>
                       </dxl:Sort>

--- a/src/backend/gporca/data/dxl/minidump/Subquery-ExistsAllAggregates.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Subquery-ExistsAllAggregates.mdp
@@ -598,15 +598,15 @@
         </dxl:LogicalGet>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="222">
+    <dxl:Plan Id="0" SpaceSize="150">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1356695741.507501" Rows="1.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="1356695750.944685" Rows="1.000000" Width="16"/>
         </dxl:Properties>
         <dxl:GroupingColumns/>
         <dxl:ProjList>
           <dxl:ProjElem ColId="28" Alias="sum">
-            <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Final" AggKind="n" >
+            <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Final" AggKind="n">
               <dxl:ValuesList ParamType="aggargs">
                 <dxl:Ident ColId="52" ColName="ColRef_0052" TypeMdid="0.20.1.0"/>
               </dxl:ValuesList>
@@ -616,7 +616,7 @@
             </dxl:AggFunc>
           </dxl:ProjElem>
           <dxl:ProjElem ColId="38" Alias="sum">
-            <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Final" AggKind="n" >
+            <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Final" AggKind="n">
               <dxl:ValuesList ParamType="aggargs">
                 <dxl:Ident ColId="53" ColName="ColRef_0053" TypeMdid="0.20.1.0"/>
               </dxl:ValuesList>
@@ -629,7 +629,7 @@
         <dxl:Filter/>
         <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1356695741.507494" Rows="1.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="1356695750.944678" Rows="1.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="52" Alias="ColRef_0052">
@@ -643,12 +643,12 @@
           <dxl:SortingColumnList/>
           <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1356695741.507435" Rows="1.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="1356695750.944618" Rows="1.000000" Width="16"/>
             </dxl:Properties>
             <dxl:GroupingColumns/>
             <dxl:ProjList>
               <dxl:ProjElem ColId="52" Alias="ColRef_0052">
-                <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" >
+                <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Partial" AggKind="n">
                   <dxl:ValuesList ParamType="aggargs">
                     <dxl:If TypeMdid="0.23.1.0">
                       <dxl:If TypeMdid="0.16.1.0">
@@ -676,7 +676,7 @@
                 </dxl:AggFunc>
               </dxl:ProjElem>
               <dxl:ProjElem ColId="53" Alias="ColRef_0053">
-                <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" >
+                <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Partial" AggKind="n">
                   <dxl:ValuesList ParamType="aggargs">
                     <dxl:If TypeMdid="0.23.1.0">
                       <dxl:SubPlan TypeMdid="0.16.1.0" SubPlanType="AllSubPlan">
@@ -803,7 +803,7 @@
             <dxl:Filter/>
             <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1324036.154857" Rows="8.000000" Width="24"/>
+                <dxl:Cost StartupCost="0" TotalCost="1324036.164073" Rows="8.000000" Width="24"/>
               </dxl:Properties>
               <dxl:GroupingColumns>
                 <dxl:GroupingColumn ColId="0"/>
@@ -813,7 +813,7 @@
               </dxl:GroupingColumns>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="40" Alias="ColRef_0040">
-                  <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Final" AggKind="n" >
+                  <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Final" AggKind="n">
                     <dxl:ValuesList ParamType="aggargs">
                       <dxl:Ident ColId="50" ColName="ColRef_0050" TypeMdid="0.20.1.0"/>
                     </dxl:ValuesList>
@@ -823,7 +823,7 @@
                   </dxl:AggFunc>
                 </dxl:ProjElem>
                 <dxl:ProjElem ColId="42" Alias="ColRef_0042">
-                  <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Final" AggKind="n" >
+                  <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Final" AggKind="n">
                     <dxl:ValuesList ParamType="aggargs">
                       <dxl:Ident ColId="51" ColName="ColRef_0051" TypeMdid="0.20.1.0"/>
                     </dxl:ValuesList>
@@ -848,7 +848,7 @@
               <dxl:Filter/>
               <dxl:Sort SortDiscardDuplicates="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1324036.154731" Rows="8.000000" Width="34"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1324036.163947" Rows="8.000000" Width="34"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="a">
@@ -879,7 +879,7 @@
                 <dxl:LimitOffset/>
                 <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1324036.154003" Rows="8.000000" Width="34"/>
+                    <dxl:Cost StartupCost="0" TotalCost="1324036.163219" Rows="8.000000" Width="34"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="0" Alias="a">
@@ -913,7 +913,7 @@
                   </dxl:HashExprList>
                   <dxl:Result>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="1324036.153719" Rows="8.000000" Width="34"/>
+                      <dxl:Cost StartupCost="0" TotalCost="1324036.162935" Rows="8.000000" Width="34"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="0" Alias="a">
@@ -939,7 +939,7 @@
                     <dxl:OneTimeFilter/>
                     <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="1324036.153719" Rows="8.000000" Width="34"/>
+                        <dxl:Cost StartupCost="0" TotalCost="1324036.162935" Rows="8.000000" Width="34"/>
                       </dxl:Properties>
                       <dxl:GroupingColumns>
                         <dxl:GroupingColumn ColId="0"/>
@@ -949,7 +949,7 @@
                       </dxl:GroupingColumns>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="50" Alias="ColRef_0050">
-                          <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" >
+                          <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Partial" AggKind="n">
                             <dxl:ValuesList ParamType="aggargs">
                               <dxl:Ident ColId="39" ColName="ColRef_0039" TypeMdid="0.16.1.0"/>
                             </dxl:ValuesList>
@@ -959,7 +959,7 @@
                           </dxl:AggFunc>
                         </dxl:ProjElem>
                         <dxl:ProjElem ColId="51" Alias="ColRef_0051">
-                          <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" >
+                          <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Partial" AggKind="n">
                             <dxl:ValuesList ParamType="aggargs">
                               <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.23.1.0"/>
                             </dxl:ValuesList>
@@ -984,7 +984,7 @@
                       <dxl:Filter/>
                       <dxl:Sort SortDiscardDuplicates="false">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="1324036.153423" Rows="32.000000" Width="23"/>
+                          <dxl:Cost StartupCost="0" TotalCost="1324036.162639" Rows="32.000000" Width="23"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="41" Alias="ColRef_0041">
@@ -1015,7 +1015,7 @@
                         <dxl:LimitOffset/>
                         <dxl:Result>
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="1324036.148673" Rows="32.000000" Width="23"/>
+                            <dxl:Cost StartupCost="0" TotalCost="1324036.157889" Rows="32.000000" Width="23"/>
                           </dxl:Properties>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="41" Alias="ColRef_0041">
@@ -1050,7 +1050,7 @@
                           <dxl:OneTimeFilter/>
                           <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="1324036.148427" Rows="32.000000" Width="23"/>
+                              <dxl:Cost StartupCost="0" TotalCost="1324036.157643" Rows="32.000000" Width="23"/>
                             </dxl:Properties>
                             <dxl:ProjList>
                               <dxl:ProjElem ColId="0" Alias="a">
@@ -1114,30 +1114,33 @@
                                 </dxl:Columns>
                               </dxl:TableDescriptor>
                             </dxl:TableScan>
-                            <dxl:Result>
+                            <dxl:Materialize Eager="false">
                               <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="431.000810" Rows="27.000000" Width="5"/>
+                                <dxl:Cost StartupCost="0" TotalCost="431.000819" Rows="27.000000" Width="5"/>
                               </dxl:Properties>
                               <dxl:ProjList>
                                 <dxl:ProjElem ColId="39" Alias="ColRef_0039">
-                                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                                  <dxl:Ident ColId="39" ColName="ColRef_0039" TypeMdid="0.16.1.0"/>
                                 </dxl:ProjElem>
                                 <dxl:ProjElem ColId="9" Alias="b">
                                   <dxl:Ident ColId="9" ColName="b" TypeMdid="0.23.1.0"/>
                                 </dxl:ProjElem>
                               </dxl:ProjList>
                               <dxl:Filter/>
-                              <dxl:OneTimeFilter/>
-                              <dxl:Materialize Eager="false">
+                              <dxl:Result>
                                 <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="431.000765" Rows="27.000000" Width="4"/>
+                                  <dxl:Cost StartupCost="0" TotalCost="431.000774" Rows="27.000000" Width="5"/>
                                 </dxl:Properties>
                                 <dxl:ProjList>
+                                  <dxl:ProjElem ColId="39" Alias="ColRef_0039">
+                                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                                  </dxl:ProjElem>
                                   <dxl:ProjElem ColId="9" Alias="b">
                                     <dxl:Ident ColId="9" ColName="b" TypeMdid="0.23.1.0"/>
                                   </dxl:ProjElem>
                                 </dxl:ProjList>
                                 <dxl:Filter/>
+                                <dxl:OneTimeFilter/>
                                 <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                                   <dxl:Properties>
                                     <dxl:Cost StartupCost="0" TotalCost="431.000729" Rows="27.000000" Width="4"/>
@@ -1173,8 +1176,8 @@
                                     </dxl:TableDescriptor>
                                   </dxl:TableScan>
                                 </dxl:BroadcastMotion>
-                              </dxl:Materialize>
-                            </dxl:Result>
+                              </dxl:Result>
+                            </dxl:Materialize>
                           </dxl:NestedLoopJoin>
                         </dxl:Result>
                       </dxl:Sort>

--- a/src/backend/gporca/data/dxl/minidump/Subquery-ExistsAllAggregatesWithDisjuncts.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Subquery-ExistsAllAggregatesWithDisjuncts.mdp
@@ -665,15 +665,15 @@
         </dxl:LogicalGet>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1554">
+    <dxl:Plan Id="0" SpaceSize="1050">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="2712065383.057338" Rows="1.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="2712065392.494522" Rows="1.000000" Width="16"/>
         </dxl:Properties>
         <dxl:GroupingColumns/>
         <dxl:ProjList>
           <dxl:ProjElem ColId="28" Alias="sum">
-            <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Final" AggKind="n" >
+            <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Final" AggKind="n">
               <dxl:ValuesList ParamType="aggargs">
                 <dxl:Ident ColId="61" ColName="ColRef_0061" TypeMdid="0.20.1.0"/>
               </dxl:ValuesList>
@@ -683,7 +683,7 @@
             </dxl:AggFunc>
           </dxl:ProjElem>
           <dxl:ProjElem ColId="47" Alias="sum">
-            <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Final" AggKind="n" >
+            <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Final" AggKind="n">
               <dxl:ValuesList ParamType="aggargs">
                 <dxl:Ident ColId="62" ColName="ColRef_0062" TypeMdid="0.20.1.0"/>
               </dxl:ValuesList>
@@ -696,7 +696,7 @@
         <dxl:Filter/>
         <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2712065383.057331" Rows="1.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="2712065392.494514" Rows="1.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="61" Alias="ColRef_0061">
@@ -710,12 +710,12 @@
           <dxl:SortingColumnList/>
           <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="2712065383.057271" Rows="1.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="2712065392.494455" Rows="1.000000" Width="16"/>
             </dxl:Properties>
             <dxl:GroupingColumns/>
             <dxl:ProjList>
               <dxl:ProjElem ColId="61" Alias="ColRef_0061">
-                <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" >
+                <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Partial" AggKind="n">
                   <dxl:ValuesList ParamType="aggargs">
                     <dxl:If TypeMdid="0.23.1.0">
                       <dxl:If TypeMdid="0.16.1.0">
@@ -743,7 +743,7 @@
                 </dxl:AggFunc>
               </dxl:ProjElem>
               <dxl:ProjElem ColId="62" Alias="ColRef_0062">
-                <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" >
+                <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Partial" AggKind="n">
                   <dxl:ValuesList ParamType="aggargs">
                     <dxl:If TypeMdid="0.23.1.0">
                       <dxl:SubPlan TypeMdid="0.16.1.0" SubPlanType="AllSubPlan">
@@ -949,7 +949,7 @@
             <dxl:Filter/>
             <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1324036.154857" Rows="8.000000" Width="24"/>
+                <dxl:Cost StartupCost="0" TotalCost="1324036.164073" Rows="8.000000" Width="24"/>
               </dxl:Properties>
               <dxl:GroupingColumns>
                 <dxl:GroupingColumn ColId="0"/>
@@ -959,7 +959,7 @@
               </dxl:GroupingColumns>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="49" Alias="ColRef_0049">
-                  <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Final" AggKind="n" >
+                  <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Final" AggKind="n">
                     <dxl:ValuesList ParamType="aggargs">
                       <dxl:Ident ColId="59" ColName="ColRef_0059" TypeMdid="0.20.1.0"/>
                     </dxl:ValuesList>
@@ -969,7 +969,7 @@
                   </dxl:AggFunc>
                 </dxl:ProjElem>
                 <dxl:ProjElem ColId="51" Alias="ColRef_0051">
-                  <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Final" AggKind="n" >
+                  <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Final" AggKind="n">
                     <dxl:ValuesList ParamType="aggargs">
                       <dxl:Ident ColId="60" ColName="ColRef_0060" TypeMdid="0.20.1.0"/>
                     </dxl:ValuesList>
@@ -994,7 +994,7 @@
               <dxl:Filter/>
               <dxl:Sort SortDiscardDuplicates="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1324036.154731" Rows="8.000000" Width="34"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1324036.163947" Rows="8.000000" Width="34"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="a">
@@ -1025,7 +1025,7 @@
                 <dxl:LimitOffset/>
                 <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1324036.154003" Rows="8.000000" Width="34"/>
+                    <dxl:Cost StartupCost="0" TotalCost="1324036.163219" Rows="8.000000" Width="34"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="0" Alias="a">
@@ -1059,7 +1059,7 @@
                   </dxl:HashExprList>
                   <dxl:Result>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="1324036.153719" Rows="8.000000" Width="34"/>
+                      <dxl:Cost StartupCost="0" TotalCost="1324036.162935" Rows="8.000000" Width="34"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="0" Alias="a">
@@ -1085,7 +1085,7 @@
                     <dxl:OneTimeFilter/>
                     <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="1324036.153719" Rows="8.000000" Width="34"/>
+                        <dxl:Cost StartupCost="0" TotalCost="1324036.162935" Rows="8.000000" Width="34"/>
                       </dxl:Properties>
                       <dxl:GroupingColumns>
                         <dxl:GroupingColumn ColId="0"/>
@@ -1095,7 +1095,7 @@
                       </dxl:GroupingColumns>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="59" Alias="ColRef_0059">
-                          <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" >
+                          <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Partial" AggKind="n">
                             <dxl:ValuesList ParamType="aggargs">
                               <dxl:Ident ColId="48" ColName="ColRef_0048" TypeMdid="0.16.1.0"/>
                             </dxl:ValuesList>
@@ -1105,7 +1105,7 @@
                           </dxl:AggFunc>
                         </dxl:ProjElem>
                         <dxl:ProjElem ColId="60" Alias="ColRef_0060">
-                          <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" >
+                          <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Partial" AggKind="n">
                             <dxl:ValuesList ParamType="aggargs">
                               <dxl:Ident ColId="50" ColName="ColRef_0050" TypeMdid="0.23.1.0"/>
                             </dxl:ValuesList>
@@ -1130,7 +1130,7 @@
                       <dxl:Filter/>
                       <dxl:Sort SortDiscardDuplicates="false">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="1324036.153423" Rows="32.000000" Width="23"/>
+                          <dxl:Cost StartupCost="0" TotalCost="1324036.162639" Rows="32.000000" Width="23"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="50" Alias="ColRef_0050">
@@ -1161,7 +1161,7 @@
                         <dxl:LimitOffset/>
                         <dxl:Result>
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="1324036.148673" Rows="32.000000" Width="23"/>
+                            <dxl:Cost StartupCost="0" TotalCost="1324036.157889" Rows="32.000000" Width="23"/>
                           </dxl:Properties>
                           <dxl:ProjList>
                             <dxl:ProjElem ColId="50" Alias="ColRef_0050">
@@ -1196,7 +1196,7 @@
                           <dxl:OneTimeFilter/>
                           <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="1324036.148427" Rows="32.000000" Width="23"/>
+                              <dxl:Cost StartupCost="0" TotalCost="1324036.157643" Rows="32.000000" Width="23"/>
                             </dxl:Properties>
                             <dxl:ProjList>
                               <dxl:ProjElem ColId="0" Alias="a">
@@ -1260,30 +1260,33 @@
                                 </dxl:Columns>
                               </dxl:TableDescriptor>
                             </dxl:TableScan>
-                            <dxl:Result>
+                            <dxl:Materialize Eager="false">
                               <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="431.000810" Rows="27.000000" Width="5"/>
+                                <dxl:Cost StartupCost="0" TotalCost="431.000819" Rows="27.000000" Width="5"/>
                               </dxl:Properties>
                               <dxl:ProjList>
                                 <dxl:ProjElem ColId="48" Alias="ColRef_0048">
-                                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                                  <dxl:Ident ColId="48" ColName="ColRef_0048" TypeMdid="0.16.1.0"/>
                                 </dxl:ProjElem>
                                 <dxl:ProjElem ColId="9" Alias="b">
                                   <dxl:Ident ColId="9" ColName="b" TypeMdid="0.23.1.0"/>
                                 </dxl:ProjElem>
                               </dxl:ProjList>
                               <dxl:Filter/>
-                              <dxl:OneTimeFilter/>
-                              <dxl:Materialize Eager="false">
+                              <dxl:Result>
                                 <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="431.000765" Rows="27.000000" Width="4"/>
+                                  <dxl:Cost StartupCost="0" TotalCost="431.000774" Rows="27.000000" Width="5"/>
                                 </dxl:Properties>
                                 <dxl:ProjList>
+                                  <dxl:ProjElem ColId="48" Alias="ColRef_0048">
+                                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                                  </dxl:ProjElem>
                                   <dxl:ProjElem ColId="9" Alias="b">
                                     <dxl:Ident ColId="9" ColName="b" TypeMdid="0.23.1.0"/>
                                   </dxl:ProjElem>
                                 </dxl:ProjList>
                                 <dxl:Filter/>
+                                <dxl:OneTimeFilter/>
                                 <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                                   <dxl:Properties>
                                     <dxl:Cost StartupCost="0" TotalCost="431.000729" Rows="27.000000" Width="4"/>
@@ -1320,8 +1323,8 @@
                                     </dxl:TableDescriptor>
                                   </dxl:TableScan>
                                 </dxl:BroadcastMotion>
-                              </dxl:Materialize>
-                            </dxl:Result>
+                              </dxl:Result>
+                            </dxl:Materialize>
                           </dxl:NestedLoopJoin>
                         </dxl:Result>
                       </dxl:Sort>

--- a/src/backend/gporca/data/dxl/minidump/SubqueryInsideScalarIf.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SubqueryInsideScalarIf.mdp
@@ -2462,7 +2462,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1562">
+    <dxl:Plan Id="0" SpaceSize="1154">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1356710918.164982" Rows="10002.000000" Width="12"/>

--- a/src/backend/gporca/data/dxl/minidump/TVFCorrelatedExecution.mdp
+++ b/src/backend/gporca/data/dxl/minidump/TVFCorrelatedExecution.mdp
@@ -91,7 +91,7 @@
         </dxl:ScalarSubquery>
       </dxl:LogicalTVF>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="48">
+    <dxl:Plan Id="0" SpaceSize="144">
       <dxl:TableValuedFunction FuncId="0.65639.1.0" Name="myfunc" TypeMdid="0.2249.1.0">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="0.008000" Rows="1000.000000" Width="8"/>
@@ -109,7 +109,7 @@
           <dxl:ParamList/>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="862.000216" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="862.000224" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="16" Alias="ColRef_0007">
@@ -120,7 +120,7 @@
             <dxl:OneTimeFilter/>
             <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="862.000216" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="862.000224" Rows="1.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="16" Alias="ColRef_0007">
@@ -134,7 +134,7 @@
               <dxl:OneTimeFilter/>
               <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="862.000208" Rows="4.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="862.000216" Rows="4.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="20" Alias="?column?">
@@ -150,7 +150,7 @@
                 </dxl:JoinFilter>
                 <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000052" Rows="2.000000" Width="4"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000056" Rows="2.000000" Width="4"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="20" Alias="?column?">
@@ -173,13 +173,59 @@
                     <dxl:Filter/>
                     <dxl:OneTimeFilter/>
                   </dxl:Result>
+                  <dxl:Materialize Eager="false">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="0.000009" Rows="1.000000" Width="4"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="20" Alias="?column?">
+                        <dxl:Ident ColId="20" ColName="?column?" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:Result>
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="20" Alias="?column?">
+                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:OneTimeFilter/>
+                      <dxl:Result>
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="19" Alias="">
+                            <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:OneTimeFilter/>
+                      </dxl:Result>
+                    </dxl:Result>
+                  </dxl:Materialize>
+                </dxl:NestedLoopJoin>
+                <dxl:Materialize Eager="false">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="0.000009" Rows="1.000000" Width="4"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="22" Alias="?column?">
+                      <dxl:Ident ColId="22" ColName="?column?" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
                   <dxl:Result>
                     <dxl:Properties>
                       <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
                     </dxl:Properties>
                     <dxl:ProjList>
-                      <dxl:ProjElem ColId="20" Alias="?column?">
-                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                      <dxl:ProjElem ColId="22" Alias="?column?">
+                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
@@ -189,7 +235,7 @@
                         <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
                       </dxl:Properties>
                       <dxl:ProjList>
-                        <dxl:ProjElem ColId="19" Alias="">
+                        <dxl:ProjElem ColId="21" Alias="">
                           <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
                         </dxl:ProjElem>
                       </dxl:ProjList>
@@ -197,31 +243,7 @@
                       <dxl:OneTimeFilter/>
                     </dxl:Result>
                   </dxl:Result>
-                </dxl:NestedLoopJoin>
-                <dxl:Result>
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="22" Alias="?column?">
-                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:OneTimeFilter/>
-                  <dxl:Result>
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="21" Alias="">
-                        <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:Filter/>
-                    <dxl:OneTimeFilter/>
-                  </dxl:Result>
-                </dxl:Result>
+                </dxl:Materialize>
               </dxl:NestedLoopJoin>
             </dxl:Result>
           </dxl:Result>
@@ -231,7 +253,7 @@
           <dxl:ParamList/>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="862.000216" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="862.000224" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="17" Alias="ColRef_0008">
@@ -242,7 +264,7 @@
             <dxl:OneTimeFilter/>
             <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="862.000216" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="862.000224" Rows="1.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="16" Alias="ColRef_0007">
@@ -256,7 +278,7 @@
               <dxl:OneTimeFilter/>
               <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="862.000208" Rows="4.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="862.000216" Rows="4.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="20" Alias="?column?">
@@ -272,7 +294,7 @@
                 </dxl:JoinFilter>
                 <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000052" Rows="2.000000" Width="4"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000056" Rows="2.000000" Width="4"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="20" Alias="?column?">
@@ -295,13 +317,59 @@
                     <dxl:Filter/>
                     <dxl:OneTimeFilter/>
                   </dxl:Result>
+                  <dxl:Materialize Eager="false">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="0.000009" Rows="1.000000" Width="4"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="20" Alias="?column?">
+                        <dxl:Ident ColId="20" ColName="?column?" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:Result>
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="20" Alias="?column?">
+                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:OneTimeFilter/>
+                      <dxl:Result>
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="19" Alias="">
+                            <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:OneTimeFilter/>
+                      </dxl:Result>
+                    </dxl:Result>
+                  </dxl:Materialize>
+                </dxl:NestedLoopJoin>
+                <dxl:Materialize Eager="false">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="0.000009" Rows="1.000000" Width="4"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="22" Alias="?column?">
+                      <dxl:Ident ColId="22" ColName="?column?" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
                   <dxl:Result>
                     <dxl:Properties>
                       <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
                     </dxl:Properties>
                     <dxl:ProjList>
-                      <dxl:ProjElem ColId="20" Alias="?column?">
-                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                      <dxl:ProjElem ColId="22" Alias="?column?">
+                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
@@ -311,7 +379,7 @@
                         <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
                       </dxl:Properties>
                       <dxl:ProjList>
-                        <dxl:ProjElem ColId="19" Alias="">
+                        <dxl:ProjElem ColId="21" Alias="">
                           <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
                         </dxl:ProjElem>
                       </dxl:ProjList>
@@ -319,31 +387,7 @@
                       <dxl:OneTimeFilter/>
                     </dxl:Result>
                   </dxl:Result>
-                </dxl:NestedLoopJoin>
-                <dxl:Result>
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="22" Alias="?column?">
-                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:OneTimeFilter/>
-                  <dxl:Result>
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="21" Alias="">
-                        <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:Filter/>
-                    <dxl:OneTimeFilter/>
-                  </dxl:Result>
-                </dxl:Result>
+                </dxl:Materialize>
               </dxl:NestedLoopJoin>
             </dxl:Result>
           </dxl:Result>

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalAgg.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalAgg.cpp
@@ -387,17 +387,14 @@ CPhysicalAgg::PrsRequired(CMemoryPool *mp, CExpressionHandle &exprhdl,
 {
 	GPOS_ASSERT(0 == child_index);
 
-	CRewindabilitySpec *prsChild =
-		PrsPassThru(mp, exprhdl, prsRequired, child_index);
 	if (prsRequired->IsOriginNLJoin())
 	{
-		CRewindabilitySpec *prs = GPOS_NEW(mp)
-			CRewindabilitySpec(CRewindabilitySpec::ErtNone, prsChild->Emht());
-		prsChild->Release();
+		CRewindabilitySpec *prs = GPOS_NEW(mp) CRewindabilitySpec(
+			CRewindabilitySpec::ErtNone, prsRequired->Emht());
 		return prs;
 	}
 
-	return prsChild;
+	return PrsPassThru(mp, exprhdl, prsRequired, child_index);
 }
 
 //---------------------------------------------------------------------------

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalComputeScalar.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalComputeScalar.cpp
@@ -263,7 +263,12 @@ CPhysicalComputeScalar::PrsRequired(CMemoryPool *mp, CExpressionHandle &exprhdl,
 ) const
 {
 	GPOS_ASSERT(0 == child_index);
-
+	if (prsRequired->IsOriginNLJoin())
+	{
+		CRewindabilitySpec *prs = GPOS_NEW(mp) CRewindabilitySpec(
+			CRewindabilitySpec::ErtNone, prsRequired->Emht());
+		return prs;
+	}
 	return PrsPassThru(mp, exprhdl, prsRequired, child_index);
 }
 
@@ -480,6 +485,11 @@ CEnfdProp::EPropEnforcingType
 CPhysicalComputeScalar::EpetRewindability(CExpressionHandle &exprhdl,
 										  const CEnfdRewindability *per) const
 {
+	if (per->PrsRequired()->IsOriginNLJoin())
+	{
+		return CEnfdProp::EpetRequired;
+	}
+
 	CColRefSet *pcrsUsed = exprhdl.DeriveUsedColumns(1);
 	CColRefSet *pcrsCorrelatedApply = exprhdl.DeriveCorrelatedApplyColumns();
 	if (!pcrsUsed->IsDisjoint(pcrsCorrelatedApply))

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalFilter.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalFilter.cpp
@@ -146,7 +146,12 @@ CPhysicalFilter::PrsRequired(CMemoryPool *mp, CExpressionHandle &exprhdl,
 ) const
 {
 	GPOS_ASSERT(0 == child_index);
-
+	if (prsRequired->IsOriginNLJoin())
+	{
+		CRewindabilitySpec *prs = GPOS_NEW(mp) CRewindabilitySpec(
+			CRewindabilitySpec::ErtNone, prsRequired->Emht());
+		return prs;
+	}
 	return PrsPassThru(mp, exprhdl, prsRequired, child_index);
 }
 
@@ -476,6 +481,11 @@ CEnfdProp::EPropEnforcingType
 CPhysicalFilter::EpetRewindability(CExpressionHandle &exprhdl,
 								   const CEnfdRewindability *per) const
 {
+	if (per->PrsRequired()->IsOriginNLJoin())
+	{
+		return CEnfdProp::EpetRequired;
+	}
+
 	// get rewindability delivered by the Filter node
 	CRewindabilitySpec *prs = CDrvdPropPlan::Pdpplan(exprhdl.Pdp())->Prs();
 	if (per->FCompatible(prs))

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalNLJoin.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalNLJoin.cpp
@@ -111,9 +111,11 @@ CPhysicalNLJoin::PrsRequired(CMemoryPool *mp, CExpressionHandle &exprhdl,
 	{
 		if (FFirstChildToOptimize(child_index))
 		{
-			// for index nested loop joins, inner child is optimized first
+			// for index nested loop joins, inner child is optimized first.
+			// we should not force materialize inner child, as we use index
+			// on inner relation and reference variables from outer relation.
 			return GPOS_NEW(mp) CRewindabilitySpec(
-				CRewindabilitySpec::ErtRewindable, prsRequired->Emht(), true);
+				CRewindabilitySpec::ErtRewindable, prsRequired->Emht(), false);
 		}
 
 		CRewindabilitySpec *prsOuter =

--- a/src/test/regress/expected/gp_unique_rowid_optimizer.out
+++ b/src/test/regress/expected/gp_unique_rowid_optimizer.out
@@ -174,17 +174,18 @@ where e.x in
    ->  Split
          ->  Result
                ->  Hash Semi Join
-                     Hash Cond: ("inner".x = t2_12512.b)
+                     Hash Cond: ("outer".x = t2_12512.b)
                      ->  Nested Loop
                            Join Filter: true
                            ->  Seq Scan on t_12512
-                           ->  Result
+                           ->  Materialize
                                  ->  Result
+                                       ->  Result
                      ->  Hash
                            ->  Broadcast Motion 3:3  (slice1; segments: 3)
                                  ->  Seq Scan on t2_12512
  Optimizer: Pivotal Optimizer (GPORCA)
-(14 rows)
+(15 rows)
 
 update t_12512 set b = 1
     from

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -13335,10 +13335,11 @@ select * from foo join (select a, a::bigint*a::bigint as aa from tbtree) proj on
    ->  Nested Loop
          Join Filter: ((foo.a = tbtree.a) AND (foo.b = (((tbtree.a)::bigint * (tbtree.a)::bigint))))
          ->  Seq Scan on foo
-         ->  Result
-               ->  Seq Scan on tbtree
+         ->  Materialize
+               ->  Result
+                     ->  Seq Scan on tbtree
  Optimizer: Pivotal Optimizer (GPORCA)
-(7 rows)
+(8 rows)
 
 -- 14 join pred accesses a projected column - no index scan
 explain (costs off)
@@ -13376,12 +13377,13 @@ from foo l1 where b in (select ab
                  ->  Gather Motion 3:1  (slice3; segments: 3)
                        ->  Seq Scan on foo foo_1
                              Filter: (c = 1)
-           ->  Result
-                 ->  Materialize
-                       ->  Gather Motion 3:1  (slice2; segments: 3)
-                             ->  Seq Scan on tbtree
+           ->  Materialize
+                 ->  Result
+                       ->  Materialize
+                             ->  Gather Motion 3:1  (slice2; segments: 3)
+                                   ->  Seq Scan on tbtree
  Optimizer: Pivotal Optimizer (GPORCA)
-(16 rows)
+(17 rows)
 
 -- 16 group by columns are not a superset of the distribution columns - no index scan
 explain (costs off)

--- a/src/test/regress/expected/join_optimizer.out
+++ b/src/test/regress/expected/join_optimizer.out
@@ -3095,13 +3095,14 @@ where q1 = thousand or q2 = thousand;
                      Join Filter: true
                      ->  Result
                            ->  Result
-                     ->  Result
+                     ->  Materialize
                            ->  Result
+                                 ->  Result
                ->  Bitmap Heap Scan on tenk1
-                     Recheck Cond: ((thousand = "inner".q1) OR (thousand = "outer".q2))
+                     Recheck Cond: ((thousand = "outer".q1) OR (thousand = "outer".q2))
                      ->  BitmapOr
                            ->  Bitmap Index Scan on tenk1_thous_tenthous
-                                 Index Cond: (thousand = "inner".q1)
+                                 Index Cond: (thousand = "outer".q1)
                            ->  Bitmap Index Scan on tenk1_thous_tenthous
                                  Index Cond: (thousand = "outer".q2)
          ->  Hash
@@ -3127,10 +3128,11 @@ where thousand = (q1 + q2);
                      Join Filter: true
                      ->  Result
                            ->  Result
-                     ->  Result
+                     ->  Materialize
                            ->  Result
+                                 ->  Result
                ->  Index Scan using tenk1_thous_tenthous on tenk1
-                     Index Cond: (thousand = ("inner".q1 + "outer".q2))
+                     Index Cond: (thousand = ("outer".q1 + "outer".q2))
          ->  Hash
                ->  Broadcast Motion 3:3  (slice1; segments: 3)
                      ->  Seq Scan on int4_tbl

--- a/src/test/regress/expected/notin_optimizer.out
+++ b/src/test/regress/expected/notin_optimizer.out
@@ -1219,8 +1219,8 @@ explain select c1 from t1 where c1::absint not in
                      ->  Nested Loop Left Join  (cost=0.00..1324035.88 rows=11 width=19)
                            Join Filter: (((t1.c1)::absint = ((t1n.c1n)::absint)) IS NOT FALSE)
                            ->  Seq Scan on t1  (cost=0.00..431.00 rows=4 width=14)
-                           ->  Result  (cost=0.00..431.00 rows=7 width=5)
-                                 ->  Materialize  (cost=0.00..431.00 rows=7 width=4)
+                           ->  Materialize  (cost=0.00..431.00 rows=7 width=5)
+                                 ->  Result  (cost=0.00..431.00 rows=7 width=5)
                                        ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=7 width=4)
                                              ->  Seq Scan on t1n  (cost=0.00..431.00 rows=3 width=4)
  Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0

--- a/src/test/regress/expected/pg_lsn_optimizer.out
+++ b/src/test/regress/expected/pg_lsn_optimizer.out
@@ -86,12 +86,13 @@ SELECT DISTINCT (i || '/' || j)::pg_lsn f
                            ->  Result
                                  Filter: ((generate_series_2.generate_series > 0) AND (generate_series_2.generate_series <= 10))
                                  ->  Function Scan on generate_series generate_series_2
-                           ->  Result
-                                 Filter: (generate_series_1.generate_series <= 10)
-                                 ->  Function Scan on generate_series generate_series_1
+                           ->  Materialize
+                                 ->  Result
+                                       Filter: (generate_series_1.generate_series <= 10)
+                                       ->  Function Scan on generate_series generate_series_1
                      ->  Function Scan on generate_series
  Optimizer: Pivotal Optimizer (GPORCA)
-(17 rows)
+(18 rows)
 
 SELECT DISTINCT (i || '/' || j)::pg_lsn f
   FROM generate_series(1, 10) i,

--- a/src/test/regress/expected/qp_correlated_query_optimizer.out
+++ b/src/test/regress/expected/qp_correlated_query_optimizer.out
@@ -205,26 +205,27 @@ select * from A,B where exists (select * from C where B.i not in (select C.i fro
          Join Filter: true
          ->  Broadcast Motion 3:3  (slice3; segments: 3)
                ->  Seq Scan on a
-         ->  Result
-               Filter: ((SubPlan 1) > '0'::bigint)
-               ->  Seq Scan on b
-               SubPlan 1  (slice4; segments: 3)
-                 ->  Aggregate
-                       ->  Nested Loop
-                             Join Filter: true
-                             ->  Result
-                                   Filter: ((CASE WHEN ((sum((CASE WHEN (b.i = c_1.i) THEN 1 ELSE 0 END))) IS NULL) THEN true WHEN ((sum((CASE WHEN (c_1.i IS NULL) THEN 1 ELSE 0 END))) > '0'::bigint) THEN NULL::boolean WHEN (b.i IS NULL) THEN NULL::boolean WHEN ((sum((CASE WHEN (b.i = c_1.i) THEN 1 ELSE 0 END))) = '0'::bigint) THEN true ELSE false END) = true)
+         ->  Materialize
+               ->  Result
+                     Filter: ((SubPlan 1) > '0'::bigint)
+                     ->  Seq Scan on b
+                     SubPlan 1  (slice4; segments: 3)
+                       ->  Aggregate
+                             ->  Nested Loop
+                                   Join Filter: true
                                    ->  Result
-                                         ->  Aggregate
-                                               ->  Result
-                                                     ->  Materialize
-                                                           ->  Broadcast Motion 3:3  (slice2; segments: 3)
-                                                                 ->  Seq Scan on c c_1
-                                                                       Filter: (i <> 10)
-                             ->  Materialize
-                                   ->  Broadcast Motion 3:3  (slice1; segments: 3)
-                                         ->  Seq Scan on c
- Optimizer: Pivotal Optimizer (GPORCA) version 3.1.0
+                                         Filter: ((CASE WHEN ((sum((CASE WHEN (b.i = c_1.i) THEN 1 ELSE 0 END))) IS NULL) THEN true WHEN ((sum((CASE WHEN (c_1.i IS NULL) THEN 1 ELSE 0 END))) > '0'::bigint) THEN NULL::boolean WHEN (b.i IS NULL) THEN NULL::boolean WHEN ((sum((CASE WHEN (b.i = c_1.i) THEN 1 ELSE 0 END))) = '0'::bigint) THEN true ELSE false END) = true)
+                                         ->  Result
+                                               ->  Aggregate
+                                                     ->  Result
+                                                           ->  Materialize
+                                                                 ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                                                                       ->  Seq Scan on c c_1
+                                                                             Filter: (i <> 10)
+                                   ->  Materialize
+                                         ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                                               ->  Seq Scan on c
+ Optimizer: Pivotal Optimizer (GPORCA)
 (26 rows)
 
 select * from A,B where exists (select * from C where B.i not in (select C.i from C where C.i != 10));

--- a/src/test/regress/expected/subselect_gp_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_optimizer.out
@@ -208,8 +208,8 @@ explain select * from mrs_t1 where x in (select x-95 from mrs_t1) or x < 5;
                            ->  Sort  (cost=0.00..431.00 rows=7 width=14)
                                  Sort Key: mrs_t1_1.x, mrs_t1_1.ctid, mrs_t1_1.gp_segment_id
                                  ->  Seq Scan on mrs_t1 mrs_t1_1  (cost=0.00..431.00 rows=7 width=14)
-                           ->  Result  (cost=0.00..431.00 rows=20 width=5)
-                                 ->  Materialize  (cost=0.00..431.00 rows=20 width=4)
+                           ->  Materialize  (cost=0.00..431.00 rows=20 width=5)
+                                 ->  Result  (cost=0.00..431.00 rows=20 width=5)
                                        ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=20 width=4)
                                              ->  Seq Scan on mrs_t1  (cost=0.00..431.00 rows=7 width=4)
  Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
@@ -388,8 +388,8 @@ explain select * from csq_m1 where x not in (select x from csq_d1) or x < -100; 
                                                          ->  Nested Loop Left Join  (cost=0.00..1293.00 rows=2 width=19)
                                                                Join Filter: ((csq_m1.x = csq_d1.x) IS NOT FALSE)
                                                                ->  Seq Scan on csq_m1  (cost=0.00..431.00 rows=1 width=14)
-                                                               ->  Result  (cost=0.00..431.00 rows=1 width=5)
-                                                                     ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
+                                                               ->  Materialize  (cost=0.00..431.00 rows=1 width=5)
+                                                                     ->  Result  (cost=0.00..431.00 rows=1 width=5)
                                                                            ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=2 width=4)
                                                                                  ->  Seq Scan on csq_d1  (cost=0.00..431.00 rows=1 width=4)
  Optimizer: Pivotal Optimizer (GPORCA) version 3.27.0
@@ -418,8 +418,8 @@ explain select * from csq_d1 where x not in (select x from csq_m1) or x < -100; 
                            ->  Sort  (cost=0.00..431.00 rows=1 width=14)
                                  Sort Key: csq_d1.x, csq_d1.ctid, csq_d1.gp_segment_id
                                  ->  Seq Scan on csq_d1  (cost=0.00..431.00 rows=1 width=14)
-                           ->  Result  (cost=0.00..431.00 rows=3 width=5)
-                                 ->  Materialize  (cost=0.00..431.00 rows=3 width=4)
+                           ->  Materialize  (cost=0.00..431.00 rows=3 width=5)
+                                 ->  Result  (cost=0.00..431.00 rows=3 width=5)
                                        ->  Broadcast Motion 1:3  (slice1)  (cost=0.00..431.00 rows=9 width=4)
                                              ->  Seq Scan on csq_m1  (cost=0.00..431.00 rows=1 width=4)
  Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
@@ -2505,26 +2505,28 @@ where dt < '2010-01-01'::date;
          Join Filter: true
          ->  Seq Scan on subselect_gp.extra_flow_dist1
                Output: extra_flow_dist1.a, extra_flow_dist1.b
-         ->  Result
+         ->  Materialize
                Output: ((SubPlan 1))
-               Filter: (((SubPlan 1)) < '01-01-2010'::date)
                ->  Result
-                     Output: (SubPlan 1)
-                     ->  Seq Scan on subselect_gp.extra_flow_rand
-                           Output: extra_flow_rand.a
-                     SubPlan 1  (slice2; segments: 3)
-                       ->  Result
-                             Output: extra_flow_dist.c
-                             Filter: (extra_flow_dist.b = extra_flow_rand.a)
-                             ->  Materialize
-                                   Output: extra_flow_dist.b, extra_flow_dist.c
-                                   ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                     Output: ((SubPlan 1))
+                     Filter: (((SubPlan 1)) < '01-01-2010'::date)
+                     ->  Result
+                           Output: (SubPlan 1)
+                           ->  Seq Scan on subselect_gp.extra_flow_rand
+                                 Output: extra_flow_rand.a
+                           SubPlan 1  (slice2; segments: 3)
+                             ->  Result
+                                   Output: extra_flow_dist.c
+                                   Filter: (extra_flow_dist.b = extra_flow_rand.a)
+                                   ->  Materialize
                                          Output: extra_flow_dist.b, extra_flow_dist.c
-                                         ->  Seq Scan on subselect_gp.extra_flow_dist
+                                         ->  Broadcast Motion 3:3  (slice1; segments: 3)
                                                Output: extra_flow_dist.b, extra_flow_dist.c
+                                               ->  Seq Scan on subselect_gp.extra_flow_dist
+                                                     Output: extra_flow_dist.b, extra_flow_dist.c
  Optimizer: Pivotal Optimizer (GPORCA)
  Settings: optimizer=on
-(26 rows)
+(28 rows)
 
 with run_dt as (
 	select

--- a/src/test/regress/expected/subselect_optimizer.out
+++ b/src/test/regress/expected/subselect_optimizer.out
@@ -718,13 +718,15 @@ explain (verbose, costs off)
                Join Filter: true
                ->  Values Scan on "Values"
                      Output: column1
-               ->  Result
-                     Output: 'regression'::name
+               ->  Materialize
+                     Output: current_database
                      ->  Result
-                           Output: true
- Optimizer: Pivotal Optimizer (GPORCA) version 3.1.0
+                           Output: 'regression'::name
+                           ->  Result
+                                 Output: true
+ Optimizer: Pivotal Optimizer (GPORCA)
  Settings: optimizer=on
-(15 rows)
+(17 rows)
 
 explain (verbose, costs off)
   select x, x from
@@ -755,13 +757,15 @@ explain (verbose, costs off)
                Join Filter: ("Values".column1 = "Values".column1)
                ->  Values Scan on "Values"
                      Output: column1
-               ->  Result
-                     Output: 'regression'::name
+               ->  Materialize
+                     Output: current_database
                      ->  Result
-                           Output: true
- Optimizer: Pivotal Optimizer (GPORCA) version 3.1.0
+                           Output: 'regression'::name
+                           ->  Result
+                                 Output: true
+ Optimizer: Pivotal Optimizer (GPORCA)
  Settings: optimizer=on
-(15 rows)
+(17 rows)
 
 explain (verbose, costs off)
   select x, x from
@@ -837,14 +841,16 @@ select * from
                Join Filter: true
                ->  Result
                      Output: true
-               ->  Result
-                     Output: CASE WHEN ((sum((CASE WHEN (3 = column1) THEN 1 ELSE 0 END))) IS NULL) THEN true WHEN ((sum((CASE WHEN (column1 IS NULL) THEN 1 ELSE 0 END))) > '0'::bigint) THEN NULL::boolean WHEN (3 IS NULL) THEN NULL::boolean WHEN ((sum((CASE WHEN (3 = column1) THEN 1 ELSE 0 END))) = '0'::bigint) THEN true ELSE false END
-                     ->  Aggregate
-                           Output: sum((CASE WHEN (3 = column1) THEN 1 ELSE 0 END)), sum((CASE WHEN (column1 IS NULL) THEN 1 ELSE 0 END))
-                           ->  Result
-                                 Output: CASE WHEN (3 = column1) THEN 1 ELSE 0 END, CASE WHEN (column1 IS NULL) THEN 1 ELSE 0 END
-                                 ->  Values Scan on "Values"
-                                       Output: column1
+               ->  Materialize
+                     Output: (CASE WHEN ((sum((CASE WHEN (3 = column1) THEN 1 ELSE 0 END))) IS NULL) THEN true WHEN ((sum((CASE WHEN (column1 IS NULL) THEN 1 ELSE 0 END))) > '0'::bigint) THEN NULL::boolean WHEN (3 IS NULL) THEN NULL::boolean WHEN ((sum((CASE WHEN (3 = column1) THEN 1 ELSE 0 END))) = '0'::bigint) THEN true ELSE false END)
+                     ->  Result
+                           Output: CASE WHEN ((sum((CASE WHEN (3 = column1) THEN 1 ELSE 0 END))) IS NULL) THEN true WHEN ((sum((CASE WHEN (column1 IS NULL) THEN 1 ELSE 0 END))) > '0'::bigint) THEN NULL::boolean WHEN (3 IS NULL) THEN NULL::boolean WHEN ((sum((CASE WHEN (3 = column1) THEN 1 ELSE 0 END))) = '0'::bigint) THEN true ELSE false END
+                           ->  Aggregate
+                                 Output: sum((CASE WHEN (3 = column1) THEN 1 ELSE 0 END)), sum((CASE WHEN (column1 IS NULL) THEN 1 ELSE 0 END))
+                                 ->  Result
+                                       Output: CASE WHEN (3 = column1) THEN 1 ELSE 0 END, CASE WHEN (column1 IS NULL) THEN 1 ELSE 0 END
+                                       ->  Values Scan on "Values"
+                                             Output: column1
    ->  Result
          Output: false
  Optimizer: Pivotal Optimizer (GPORCA)


### PR DESCRIPTION
If the inner child is Result or Filter node, Orca may generate a plan that does
not materialize the nestloop join's inner child, which will case bad
performance. This patch has fixed the issue by forcing materialize the inner
child.

Cherry-picked from a668a89d611acdf9bb0a1b6b430efb1c206fa777