### PR TITLE
Reformat extended stats build files

### DIFF
--- a/src/backend/Makefile
+++ b/src/backend/Makefile
@@ -195,6 +195,7 @@ distprep:
 	$(MAKE) -C bootstrap	bootparse.c bootscanner.c
 	$(MAKE) -C catalog	distprep
 	$(MAKE) -C replication	repl_gram.c repl_scanner.c syncrep_gram.c syncrep_scanner.c
+	$(MAKE) -C statistics statistics_gram.c statistics_scanner.c
 	$(MAKE) -C storage/lmgr	lwlocknames.h lwlocknames.c
 	$(MAKE) -C utils	distprep
 	$(MAKE) -C utils/adt	jsonpath_gram.c jsonpath_scan.c
@@ -325,6 +326,7 @@ maintainer-clean: distclean
 	      parser/scan.c \
 	      statistics/statistics_gram.c \
 	      statistics/statistics_scanner.c \
+	      statistics/statistics_gram.h \
 	      replication/repl_gram.c \
 	      replication/repl_scanner.c \
 	      replication/syncrep_gram.c \

--- a/src/backend/statistics/.gitignore
+++ b/src/backend/statistics/.gitignore
@@ -1,2 +1,4 @@
 /statistics_gram.c
 /statistics_scanner.c
+/statistics_gram.h
+

--- a/src/backend/statistics/Makefile
+++ b/src/backend/statistics/Makefile
@@ -12,11 +12,18 @@ subdir = src/backend/statistics
 top_builddir = ../../..
 include $(top_builddir)/src/Makefile.global
 
-OBJS = extended_stats.o dependencies.o mcv.o mvdistinct.o statistics_gram.o
-
-statistics_gram.o: statistics_scanner.c
+OBJS = extended_stats.o dependencies.o mcv.o mvdistinct.o statistics_gram.o statistics_scanner.o
 
 include $(top_srcdir)/src/backend/common.mk
 
-# statistics_gram.c, statistics_scanner.c are not cleaned here.
+# See notes in src/backend/parser/Makefile about the following two rules
+statistics_gram.h: statistics_gram.c
+	touch $@
+
+statistics_gram.c: BISONFLAGS += -d
+
+# Force these dependencies to be known even without dependency info built:
+statistics_gram.o statistics_scanner.o: statistics_gram.h
+
+# statistics_gram.c, statistics_scanner are not cleaned here.
 # (Our parent Makefile takes care of them during maintainer-clean.)

--- a/src/backend/statistics/dependencies.c
+++ b/src/backend/statistics/dependencies.c
@@ -693,7 +693,7 @@ pg_dependencies_in(PG_FUNCTION_ARGS)
 	statistic_scanner_finish();
 	mvdependencies = mvdependencies_parse_result;
 
-	PG_RETURN_MVNDistinct_P(statext_dependencies_serialize(mvdependencies));
+	PG_RETURN_MVDependencies_P(statext_dependencies_serialize(mvdependencies));
 }
 
 /*

--- a/src/backend/statistics/statistics_gram.y
+++ b/src/backend/statistics/statistics_gram.y
@@ -170,5 +170,3 @@ dependency_item:
 	}
 	;
 %%
-
-#include "statistics_scanner.c"

--- a/src/backend/statistics/statistics_scanner.l
+++ b/src/backend/statistics/statistics_scanner.l
@@ -4,8 +4,15 @@
 #include "utils/builtins.h"
 #include "parser/scansup.h"
 
+#include "statistics/statistics.h"
+#include "statistics_gram.h"
+
 /* Handle to the buffer that the lexer uses internally */
 static YY_BUFFER_STATE scanbufhandle;
+
+void statistic_scanner_finish(void);
+void statistic_scanner_init(const char *str);
+void statistic_yyerror(const char *message);
 %}
 
 
@@ -28,18 +35,18 @@ double			[0-9.]
 "=>"			{ return ARROW; }
 
 {digit}+		{
-				yylval.uintval = strtoul(yytext, NULL, 10);
+				statistic_yylval.uintval = strtoul(yytext, NULL, 10);
 				return UCONST;
 			}
 {double}+		{
-				yylval.doubleval = strtod(yytext, NULL);
+				statistic_yylval.doubleval = strtod(yytext, NULL);
 				return DOUBLE;
 			}
 
 %%
 
 void
-yyerror(const char *message)
+statistic_yyerror(const char *message)
 {
 	if (*yytext == YY_END_OF_BUFFER_CHAR)
 	{


### PR DESCRIPTION
Reformatting extended stats grammar, build files as per postgresql way.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
