### PR TITLE
Fix hang of multi-dqa with filter in planner

### DIFF
--- a/src/backend/executor/nodeTupleSplit.c
+++ b/src/backend/executor/nodeTupleSplit.c
@@ -202,12 +202,11 @@ ExecTupleSplit(PlanState *pstate)
 				filter_out = true;
 			}
 			else
-			{
-
 				filter_out = false;
-			}
-
 		}
+		else
+			filter_out = false;
+
 	} while(filter_out);
 
 	/* reset the isnull array to the original state */

--- a/src/test/regress/expected/gp_dqa.out
+++ b/src/test/regress/expected/gp_dqa.out
@@ -2047,6 +2047,13 @@ select count(distinct a) filter (where a > 3),count( distinct b) filter (where a
     13 |     5 |  10
 (1 row)
 
+-- fix hang of multi-dqa with filter (https://github.com/greenplum-db/gpdb/issues/14728)
+select count(distinct a) filter (where a > 3), count(distinct b) from dqa_f1;
+ count | count 
+-------+-------
+    13 |     5
+(1 row)
+
 explain select sum(distinct a) filter (where a > 0), sum(distinct b) filter (where a > 0) from dqa_f1;
                                               QUERY PLAN                                              
 ------------------------------------------------------------------------------------------------------

--- a/src/test/regress/expected/gp_dqa_optimizer.out
+++ b/src/test/regress/expected/gp_dqa_optimizer.out
@@ -2168,6 +2168,15 @@ DETAIL:  Feature not supported: Aggregate functions with FILTER
     13 |     5 |  10
 (1 row)
 
+-- fix hang of multi-dqa with filter (https://github.com/greenplum-db/gpdb/issues/14728)
+select count(distinct a) filter (where a > 3), count(distinct b) from dqa_f1;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Aggregate functions with FILTER
+ count | count 
+-------+-------
+    13 |     5
+(1 row)
+
 explain select sum(distinct a) filter (where a > 0), sum(distinct b) filter (where a > 0) from dqa_f1;
 INFO:  GPORCA failed to produce a plan, falling back to planner
 DETAIL:  Feature not supported: Aggregate functions with FILTER

--- a/src/test/regress/sql/gp_dqa.sql
+++ b/src/test/regress/sql/gp_dqa.sql
@@ -337,6 +337,9 @@ select sum(distinct a) filter (where a in (select x from dqa_f2 where x = a)), s
 
 select count(distinct a) filter (where a > 3),count( distinct b) filter (where a > 4), sum(distinct b) filter( where a > 4) from dqa_f1;
 
+-- fix hang of multi-dqa with filter (https://github.com/greenplum-db/gpdb/issues/14728)
+select count(distinct a) filter (where a > 3), count(distinct b) from dqa_f1;
+
 explain select sum(distinct a) filter (where a > 0), sum(distinct b) filter (where a > 0) from dqa_f1;
 
 explain select sum(distinct a) filter (where a > 0), sum(distinct b) filter (where a > 0) from dqa_f1 group by b;


### PR DESCRIPTION
QE will hang in `ExecTupleSplit()` while executing the following query.
```
SELECT DQA_1(expr1) filter (subquery1), DQA_2(expr2) ...
```
If a tuple is filtered out by DQA_1's filter, `filter_out` will be set to true. Because dqa2 has no filters, `filter_out` will not be set to false on the next loop. Then it's an endless loop.

The solution is simple, if current Expr has no filter, set `filter_out` to false.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
