### PR TITLE
Fix value in the cpu_usage column returned from the pg_resgroup_get_status() function

### DIFF
--- a/src/include/catalog/catversion.h
+++ b/src/include/catalog/catversion.h
@@ -56,6 +56,6 @@
  */
 
 /*							3yyymmddN */
-#define CATALOG_VERSION_NO	302302031
+#define CATALOG_VERSION_NO	302302131
 
 #endif

--- a/src/include/catalog/pg_proc.dat
+++ b/src/include/catalog/pg_proc.dat
@@ -10859,7 +10859,7 @@
    proname => 'pg_resgroup_get_status_kv', prorows => '1000', proisstrict => 'f', proretset => 't', provolatile => 'v', proparallel => 'r', prorettype => 'record', proargtypes => 'text', proallargtypes => 'text,oid,text,text', proargmodes => '{i,o,o,o}', proargnames => '{prop_in,rsgid,prop,value}', prosrc => 'pg_resgroup_get_status_kv' },
 
 { oid => 6066, descr => 'statistics: information about resource groups',
-   proexeclocation => 'c',
+   proexeclocation => 'i',
    proname => 'pg_resgroup_get_status', prorows => '1000', proisstrict => 'f', proretset => 't', provolatile => 'v', proparallel => 'r', prorettype => 'record', proargtypes => 'oid', proallargtypes => 'oid,oid,int4,int4,int8,int8,interval,json', proargmodes => '{i,o,o,o,o,o,o,o}', proargnames => '{groupid,groupid,num_running,num_queueing,num_queued,num_executed,total_queue_duration,cpu_usage}', prosrc => 'pg_resgroup_get_status' },
 
 { oid => 6036, descr => 'waiting relation information',

--- a/src/test/isolation2/expected/resgroup/resgroup_functions.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_functions.out
@@ -7,7 +7,7 @@ SELECT s.groupid, s.num_running, s.num_queueing, s.num_queued, s.num_executed FR
 CREATE TEMP TABLE resgroup_function_test(LIKE gp_toolkit.gp_resgroup_status);
 CREATE
 
-INSERT INTO resgroup_function_test(groupid, num_running, num_queueing, num_queued, num_executed) SELECT s.groupid, s.num_running, s.num_queueing, s.num_queued, s.num_executed FROM pg_resgroup_get_status(NULL::oid) s(groupid, num_running, num_queueing, num_queued, num_executed, total_queue_duration, cpu_usage) LIMIT 1;
+INSERT INTO resgroup_function_test(groupid, num_running, num_queueing, num_queued, num_executed, cpu_usage) SELECT s.groupid, s.num_running, s.num_queueing, s.num_queued, s.num_executed, cpu_usage FROM pg_resgroup_get_status(NULL::oid) s(groupid, num_running, num_queueing, num_queued, num_executed, total_queue_duration, cpu_usage) LIMIT 1;
 INSERT 1
 
 SELECT count(num_executed)>0 FROM resgroup_function_test WHERE num_executed IS NOT NULL;
@@ -15,3 +15,7 @@ SELECT count(num_executed)>0 FROM resgroup_function_test WHERE num_executed IS N
 ----------
  t        
 (1 row)
+
+-- Check that the contents of the cpu_usage field are valid JSON
+ANALYZE resgroup_function_test;
+ANALYZE

--- a/src/test/isolation2/sql/resgroup/resgroup_functions.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_functions.sql
@@ -4,8 +4,11 @@ FROM pg_resgroup_get_status(NULL::oid) s(groupid, num_running, num_queueing, num
 -- end_ignore
 CREATE TEMP TABLE resgroup_function_test(LIKE gp_toolkit.gp_resgroup_status);
 
-INSERT INTO resgroup_function_test(groupid, num_running, num_queueing, num_queued, num_executed)
-SELECT s.groupid, s.num_running, s.num_queueing, s.num_queued, s.num_executed
+INSERT INTO resgroup_function_test(groupid, num_running, num_queueing, num_queued, num_executed, cpu_usage)
+SELECT s.groupid, s.num_running, s.num_queueing, s.num_queued, s.num_executed, cpu_usage
 FROM pg_resgroup_get_status(NULL::oid) s(groupid, num_running, num_queueing, num_queued, num_executed, total_queue_duration, cpu_usage) LIMIT 1;
 
 SELECT count(num_executed)>0 FROM resgroup_function_test WHERE num_executed IS NOT NULL;
+
+-- Check that the contents of the cpu_usage field are valid JSON
+ANALYZE resgroup_function_test;


### PR DESCRIPTION
In the case of insert-select, the cpu_usage field contains information about master only. This leads to an error at the moment of analyzing the table, as the contents of the field do not correspond to json format. The error was fixed by setting the proexeclocation property of the function to i (PROEXECLOCATION_INITPLAN).
https://github.com/greenplum-db/gpdb/issues/14154