### PR TITLE
Create a copy of the path target for multi-stage aggregation

### DIFF
--- a/src/backend/cdb/cdbgroupingpaths.c
+++ b/src/backend/cdb/cdbgroupingpaths.c
@@ -2333,7 +2333,7 @@ fetch_multi_dqas_info(PlannerInfo *root,
 		/* assign an agg_expr_id value to aggref*/
 		aggref->agg_expr_id = agg_expr_id;
 
-		/* rid of filter in aggref */
+		/* rid of filter in aggref, will push them down to the TupleSplit node */
 		aggref->aggfilter = NULL;
 		aggref_final->aggfilter = NULL;
 	}

--- a/src/test/regress/expected/gp_dqa.out
+++ b/src/test/regress/expected/gp_dqa.out
@@ -2170,6 +2170,29 @@ explain select count(distinct a) filter (where a > 3),count( distinct b) filter 
  Optimizer: Postgres query optimizer
 (11 rows)
 
+-- MultiDQA with filter (enable_hashagg = off)
+-- Related issue: https://github.com/greenplum-db/gpdb/issues/14728#issuecomment-1422341729
+set enable_hashagg = off;
+set enable_groupagg = on;
+select count(distinct a) filter (where a > 3), count(distinct b) from dqa_f1;
+ count | count 
+-------+-------
+    13 |     5
+(1 row)
+
+explain (verbose, costs off)select count(distinct a) filter (where a > 3), count(distinct b) from dqa_f1;
+QUERY PLAN
+___________
+ Aggregate
+   Output: count(DISTINCT a) FILTER (WHERE (a > 3)), count(DISTINCT b)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Output: a, b
+         ->  Seq Scan on public.dqa_f1
+               Output: a, b
+GP_IGNORE:(8 rows)
+
+set enable_hashagg = on;
+set enable_groupagg = off;
 -- single DQA with agg
 -- the following SQL should use two stage agg
 explain select count(distinct a), sum(b), sum(c) from dqa_f1;

--- a/src/test/regress/expected/gp_dqa_optimizer.out
+++ b/src/test/regress/expected/gp_dqa_optimizer.out
@@ -2303,6 +2303,33 @@ DETAIL:  Feature not supported: Aggregate functions with FILTER
  Optimizer: Postgres query optimizer
 (11 rows)
 
+-- MultiDQA with filter (enable_hashagg = off)
+-- Related issue: https://github.com/greenplum-db/gpdb/issues/14728#issuecomment-1422341729
+set enable_hashagg = off;
+set enable_groupagg = on;
+select count(distinct a) filter (where a > 3), count(distinct b) from dqa_f1;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Aggregate functions with FILTER
+ count | count 
+-------+-------
+    13 |     5
+(1 row)
+
+explain (verbose, costs off)select count(distinct a) filter (where a > 3), count(distinct b) from dqa_f1;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Aggregate functions with FILTER
+QUERY PLAN
+___________
+ Aggregate
+   Output: count(DISTINCT a) FILTER (WHERE (a > 3)), count(DISTINCT b)
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Output: a, b
+         ->  Seq Scan on public.dqa_f1
+               Output: a, b
+GP_IGNORE:(8 rows)
+
+set enable_hashagg = on;
+set enable_groupagg = off;
 -- single DQA with agg
 -- the following SQL should use two stage agg
 explain select count(distinct a), sum(b), sum(c) from dqa_f1;

--- a/src/test/regress/sql/gp_dqa.sql
+++ b/src/test/regress/sql/gp_dqa.sql
@@ -349,6 +349,17 @@ explain select sum(distinct a) filter (where a in (select x from dqa_f2 where x 
 
 explain select count(distinct a) filter (where a > 3),count( distinct b) filter (where a > 4), sum(distinct b) filter( where a > 4) from dqa_f1;
 
+-- MultiDQA with filter (enable_hashagg = off)
+-- Related issue: https://github.com/greenplum-db/gpdb/issues/14728#issuecomment-1422341729
+set enable_hashagg = off;
+set enable_groupagg = on;
+
+select count(distinct a) filter (where a > 3), count(distinct b) from dqa_f1;
+
+explain (verbose, costs off)select count(distinct a) filter (where a > 3), count(distinct b) from dqa_f1;
+
+set enable_hashagg = on;
+set enable_groupagg = off;
 
 -- single DQA with agg
 -- the following SQL should use two stage agg


### PR DESCRIPTION
`fetch_multi_dqas_info()` will push the MultiDQA's filter to TupleSplit, then get rid of final and partial DQA aggref filter. If we use the same path target as single-stage aggregation, single-stage aggregation will lose the filter of MultiDQA.

For instance:
```
postgres=# set enable_hashagg = off;
SET
postgres=# explain (verbose, costs off) select count(distinct a) filter(where a>1), count(distinct b) from issue14728;
                     QUERY PLAN
-----------------------------------------------------
 Aggregate
   Output: count(DISTINCT a), count(DISTINCT b)
   ->  Gather Motion 3:1  (slice1; segments: 3)
         Output: a, b
         ->  Seq Scan on public.issue14728
               Output: a, b
 Optimizer: Postgres query optimizer
 Settings: enable_hashagg = 'off', optimizer = 'off'
(8 rows)
```

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
