### PR TITLE
Syscache lookup for pg_appendonly

### DIFF
--- a/src/backend/access/appendonly/appendonlywriter.c
+++ b/src/backend/access/appendonly/appendonlywriter.c
@@ -42,6 +42,7 @@
 #include "utils/guc.h"
 #include "utils/int8.h"
 #include "utils/snapmgr.h"
+#include "utils/syscache.h"
 
 #define SEGFILE_CAPACITY_THRESHOLD	0.9
 
@@ -332,9 +333,6 @@ ChooseSegnoForCompaction(Relation rel, List *avoid_segnos)
 static bool
 ShouldUseReservedSegno(Relation rel, choose_segno_mode mode)
 {
-	Relation pg_class;
-	ScanKeyData scankey[1];
-	SysScanDesc scan;
 	HeapTuple tuple;
 	TransactionId xmin;
 
@@ -345,21 +343,13 @@ ShouldUseReservedSegno(Relation rel, choose_segno_mode mode)
 	if (mode != CHOOSE_MODE_WRITE)
 		return false;
 
-	ScanKeyInit(&scankey[0],
-				Anum_pg_class_oid,
-				BTEqualStrategyNumber, F_OIDEQ,
-				ObjectIdGetDatum(RelationGetRelid(rel)));
-	pg_class = table_open(RelationRelationId, AccessShareLock);
-	scan = systable_beginscan(pg_class, ClassOidIndexId, true,
-							  NULL, 1, scankey);
-	tuple = systable_getnext(scan);
-	if (!tuple)
+	tuple = SearchSysCache1(RELOID, ObjectIdGetDatum(RelationGetRelid(rel)));
+	if (!HeapTupleIsValid(tuple))
 		elog(ERROR, "unable to find relation entry in pg_class for %s",
 			 RelationGetRelationName(rel));
 	
 	xmin = HeapTupleHeaderGetXmin(tuple->t_data);
-	systable_endscan(scan);
-	table_close(pg_class, NoLock);
+	ReleaseSysCache(tuple);
 
 	return TransactionIdIsCurrentTransactionId(xmin);
 }

--- a/src/backend/utils/cache/syscache.c
+++ b/src/backend/utils/cache/syscache.c
@@ -1041,6 +1041,17 @@ static const struct cachedesc cacheinfo[] = {
 			0
 		},
 		2
+	},
+	{AppendOnlyRelationId,		/* APPENDONLYOID*/
+		AppendOnlyRelidIndexId,
+		1,
+		{
+			Anum_pg_appendonly_relid,
+			0,
+			0,
+			0
+		},
+		32
 	}
 };
 

--- a/src/include/utils/syscache.h
+++ b/src/include/utils/syscache.h
@@ -113,9 +113,10 @@ enum SysCacheIdentifier
 	TYPENAMENSP,
 	TYPEOID,
 	USERMAPPINGOID,
-	USERMAPPINGUSERSERVER
+	USERMAPPINGUSERSERVER,
+	APPENDONLYOID
 
-#define SysCacheSize (USERMAPPINGUSERSERVER + 1)
+#define SysCacheSize (APPENDONLYOID + 1)
 };
 
 extern void InitCatalogCache(void);


### PR DESCRIPTION
`pg_appendonly` is scanned in many occurrences but often all we need to do is just look up by table OID. Putting it in syscache avoid unnecessary table scans which is beneficial when pg_appendonly is large (i.e. there're a lot of AO tables), especially for short queries. 

Since it is already a catalog, just need to create the syscache entry for it. For now conservatively setting the bucket size to 32.

Also take the chance to use syscache lookup for pg_class in `ShouldUseReservedSegno()`.

Some performance numbers:
```sql
-- ./configure --prefix=/usr/local/gpdb7 --with-python --enable-depend CFLAGS=-O3 -fno-omit-frame-pointer CPPFLAGS=-O3 -fno-omit-frame-pointer --enable-ic-proxy

-- Targeted case: short INSERT for AO table (but run it many times to reduce variation)
create table t1(a int) with (appendonly);
insert into t1 select * from generate_series(1,10);

-- Created many AO tables to amplify the difference:
postgres=# select count(*) from pg_appendonly;
 count
-------
 10002
(1 row)

-- w/o the patch: (HEAD a668a89d611acdf9bb0a1b6b430efb1c206fa777)

-- truncate the table to further reduce variation
postgres=# truncate t1;
TRUNCATE TABLE
Time: 10.371 ms
postgres=# do $$
begin
  for i in 1..10000
  loop
    insert into t1 select * from generate_series(1,10);
  end loop;
end$$;
DO
Time: 8600.190 ms (00:08.600)

-- w/ the patch:

postgres=# truncate t1;
TRUNCATE TABLE
postgres=# do $$
begin
  for i in 1..10000
  loop
    insert into t1 select * from generate_series(1,10);
  end loop;
end$$;
DO
Time: 8230.205 ms (00:08.230)

```

Dev pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/appendonly-syscache

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
