### PR TITLE
[Releng][6X][Windows]Set GIT_TAG from getversion

### DIFF
--- a/concourse/scripts/compile_gpdb_remote_windows.bash
+++ b/concourse/scripts/compile_gpdb_remote_windows.bash
@@ -35,8 +35,8 @@ function remote_setup() {
     pushd gpdb_src
         GIT_URI=$(git config --get remote.origin.url)
         GIT_COMMIT=$(git rev-parse HEAD)
-        GIT_TAG=$(git describe --tags --abbrev=0 | grep -E -o '[0-9]\.[0-9]+\.[0-9]+')
         GPDB_VERSION=$(./getversion --short)
+        GIT_TAG=$(echo $GPDB_VERSION | grep -E -o '[0-9]\.[0-9]+\.[0-9]+')
     popd
 }
 


### PR DESCRIPTION
There is tag can be all letter, so use getversion script to get the correct version
For example, if the tag is: `docs-archived-dita-source`, then the script will fail by get an empty value for GIT_TAG
Authored-by: Shaoqi Bai <bshaoqi@vmware.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
