### PR TITLE
[7x] Fix url_curl.c headers handling

### DIFF
--- a/src/bin/gpfdist/regress/input/exttab1.source
+++ b/src/bin/gpfdist/regress/input/exttab1.source
@@ -487,7 +487,9 @@ COPY wet_region FROM STDIN DELIMITER '|';
 3|EUROPE|ly final courts cajole furiously final excuse
 \.
 INSERT INTO wet_region VALUES(4,'MIDDLE EAST','uickly special');
-
+-- Check error correctness, if trying to insert too long row
+INSERT INTO wet_pos1(a)
+SELECT string_agg(md5(random()::text), '') from generate_series(1,1100);
 --
 -- Now use RET to see if data was exported correctly.
 -- NOTE: since we don't bother cleaning up the exported file, it may grow bigger

--- a/src/bin/gpfdist/regress/output/exttab1.source
+++ b/src/bin/gpfdist/regress/output/exttab1.source
@@ -681,6 +681,10 @@ COPY reg_region FROM STDIN DELIMITER '|';
 INSERT INTO wet_region SELECT * from reg_region;
 COPY wet_region FROM STDIN DELIMITER '|';
 INSERT INTO wet_region VALUES(4,'MIDDLE EAST','uickly special');
+-- Check error correctness, if trying to insert too long row
+INSERT INTO wet_pos1(a)
+SELECT string_agg(md5(random()::text), '') from generate_series(1,1100);
+ERROR:  http response code 500 from gpfdist (gpfdist://@hostname@:7070/wet.out): HTTP/1.0 500 no complete data row found for writing
 --
 -- Now use RET to see if data was exported correctly.
 -- NOTE: since we don't bother cleaning up the exported file, it may grow bigger


### PR DESCRIPTION
Previously, header_callback(), used to get and parse HTTP headers, took only first status header from all header blocks to show it to user. The problem is that we can have multiple messages with multiple header blocks. In case of error, only first (successful) status is shown to user, which is not informative. This patch fixes header_callback(), which now process all status headers.
___________________
Here is an example of case we faced during the testing of insertion to gpfdist.
We used a long row (more that 32K) to check how gpfdist handles it.
```
gpfdist -d /opt/gpfdist -p 8081 -l /opt/gpfdist/log8081.log

create writable external table table_ext_wr(s varchar)
location ('gpfdist://localhost:8081/out_00.csv')
format 'CSV';

insert into table_ext_wr
select string_agg(md5(random()::text), '') from generate_series(1,1100);
ERROR:  http response code 500 from gpfdist (gpfdist://localhost:8081/out_00.csv): HTTP/1.0 200 ok  (seg1 127.0.1.1:6003 pid=365416)
```
The problem is users see "some" error, but, unfortunately, have no way to debug it. The only message they see is "ok" (with HTTP/1.0 200 status).
Here are all header blocks we got on gpdb side:
```
"HTTP/1.0 200 ok\r\n"
"Content-type: text/plain\r\n"
"Expires: 0\r\n"
"X-GPFDIST-VERSION: 6.22.1_arenadata41 build dev\r\n"
"X-GP-PROTO: 0\r\n"
"Cache-Control: no-cache\r\n"
"Connection: close\r\n"
"\r\n"

"HTTP/1.1 100 Continue\r\n"
"\r\n"

"HTTP/1.0 500 no complete data row found for writing\r\n"
"Content-length: 0\r\n"
"Expires: 0\r\n"
"X-GPFDIST-VERSION: 6.22.1_arenadata41 build dev\r\n"
"Cache-Control: no-cache\r\n"
"Connection: close\r\n"
"\r\n"
```
From this patch, gpdb starting to respect latest header messages.