### PR TITLE
Fix incorrect result from hash join on char column

### DIFF
--- a/src/backend/gporca/libgpopt/src/mdcache/CMDAccessorUtils.cpp
+++ b/src/backend/gporca/libgpopt/src/mdcache/CMDAccessorUtils.cpp
@@ -83,7 +83,7 @@ CMDAccessorUtils::FCmpExists(CMDAccessor *md_accessor, IMDId *left_mdid,
 {
 	GPOS_ASSERT(nullptr != md_accessor);
 	GPOS_ASSERT(nullptr != left_mdid);
-	GPOS_ASSERT(nullptr != left_mdid);
+	GPOS_ASSERT(nullptr != right_mdid);
 	GPOS_ASSERT(IMDType::EcmptOther > cmp_type);
 
 	GPOS_TRY
@@ -113,7 +113,7 @@ CMDAccessorUtils::GetScCmpMdid(CMDAccessor *md_accessor, IMDId *left_mdid,
 {
 	GPOS_ASSERT(nullptr != md_accessor);
 	GPOS_ASSERT(nullptr != left_mdid);
-	GPOS_ASSERT(nullptr != left_mdid);
+	GPOS_ASSERT(nullptr != right_mdid);
 	GPOS_ASSERT(IMDType::EcmptOther > cmp_type);
 
 	IMDId *sc_cmp_mdid;
@@ -331,7 +331,7 @@ CMDAccessorUtils::ApplyCastsForScCmp(CMemoryPool *mp, CMDAccessor *md_accessor,
 //		CMDAccessorUtils::FCastExists
 //
 //	@doc:
-//		Does if a cast object between given source and destination types exists
+//		Check if a cast object between given source and destination types exists
 //
 //---------------------------------------------------------------------------
 BOOL

--- a/src/test/regress/expected/bfv_joins.out
+++ b/src/test/regress/expected/bfv_joins.out
@@ -3558,6 +3558,96 @@ where
 (0 rows)
 
 drop table t_13722;
+-- This test is introduced to verify incorrect result
+-- from hash join of char columns is fixed
+-- Notice when varchar/text is cast to bpchar and used for
+-- comparison, the trailing spaces are ignored
+-- When char is cast to varchar/text, it's considered
+-- comparison, and the trailing spaces are also ignored
+-- Prior to the fix, opclasses belonging to different
+-- opfamilies could be grouped as equivalent, and thence
+-- deriving incorrect equality hash join conditions
+create table foo (varchar_3 varchar(3)) distributed by (varchar_3);
+create table bar (char_3 char(3)) distributed by (char_3);
+create table baz (text_any text) distributed by (text_any);
+insert into foo values ('cd'); -- 0 trailing spaces
+insert into bar values ('cd '); -- 1 trailing space
+insert into baz values ('cd  '); -- 2 trailing spaces
+-- varchar cast to bpchar
+-- 'cd' matches 'cd', returns 1 row
+explain select varchar_3, char_3 from foo join bar on varchar_3=char_3;
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=567.25..155836.25 rows=5055210 width=32)
+   ->  Hash Join  (cost=567.25..88433.45 rows=1685070 width=32)
+         Hash Cond: ((foo.varchar_3)::bpchar = bar.char_3)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..745.00 rows=23700 width=16)
+               Hash Key: foo.varchar_3
+               ->  Seq Scan on foo  (cost=0.00..271.00 rows=23700 width=16)
+         ->  Hash  (cost=271.00..271.00 rows=23700 width=16)
+               ->  Seq Scan on bar  (cost=0.00..271.00 rows=23700 width=16)
+ Optimizer: Postgres query optimizer
+(9 rows)
+
+select varchar_3, char_3 from foo join bar on varchar_3=char_3;
+ varchar_3 | char_3 
+-----------+--------
+ cd        | cd 
+(1 row)
+
+-- char cast to text
+-- 'cd' doesn't match 'cd  ', returns 0 rows
+explain select char_3, text_any from bar join baz on char_3=text_any;
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=430.00..168082.25 rows=3754080 width=48)
+   ->  Hash Join  (cost=430.00..118027.85 rows=1251360 width=48)
+         Hash Cond: ((bar.char_3)::text = baz.text_any)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..745.00 rows=23700 width=16)
+               Hash Key: (bar.char_3)::text
+               ->  Seq Scan on bar  (cost=0.00..271.00 rows=23700 width=16)
+         ->  Hash  (cost=210.00..210.00 rows=17600 width=32)
+               ->  Seq Scan on baz  (cost=0.00..210.00 rows=17600 width=32)
+ Optimizer: Postgres query optimizer
+(9 rows)
+
+select char_3, text_any from bar join baz on char_3=text_any;
+ char_3 | text_any 
+--------+----------
+(0 rows)
+
+-- foo - bar join: varchar cast to bpchar
+-- 'cd' matches 'cd'
+-- foo - baz join: no cast
+-- 'cd' doesn't match 'cd  '
+-- returns 0 rows
+-- Notice ORCA changes join order to minimize motion
+explain select varchar_3, char_3, text_any from foo join bar on varchar_3=char_3
+join baz on varchar_3=text_any;
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=2141.25..15664266.93 rows=266915088 width=64)
+   ->  Hash Join  (cost=2141.25..12105399.09 rows=88971696 width=64)
+         Hash Cond: ((foo.varchar_3)::text = baz.text_any)
+         ->  Hash Join  (cost=567.25..88433.45 rows=1685070 width=32)
+               Hash Cond: ((foo.varchar_3)::bpchar = bar.char_3)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..745.00 rows=23700 width=16)
+                     Hash Key: foo.varchar_3
+                     ->  Seq Scan on foo  (cost=0.00..271.00 rows=23700 width=16)
+               ->  Hash  (cost=271.00..271.00 rows=23700 width=16)
+                     ->  Seq Scan on bar  (cost=0.00..271.00 rows=23700 width=16)
+         ->  Hash  (cost=914.00..914.00 rows=52800 width=32)
+               ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..914.00 rows=52800 width=32)
+                     ->  Seq Scan on baz  (cost=0.00..210.00 rows=17600 width=32)
+ Optimizer: Postgres query optimizer
+(14 rows)
+
+select varchar_3, char_3, text_any from foo join bar on varchar_3=char_3
+join baz on varchar_3=text_any;
+ varchar_3 | char_3 | text_any 
+-----------+--------+----------
+(0 rows)
+
 -- Clean up. None of the objects we create are very interesting to keep around.
 reset search_path;
 set client_min_messages='warning';

--- a/src/test/regress/expected/bfv_joins_optimizer.out
+++ b/src/test/regress/expected/bfv_joins_optimizer.out
@@ -3551,6 +3551,95 @@ where
 (0 rows)
 
 drop table t_13722;
+-- This test is introduced to verify incorrect result
+-- from hash join of char columns is fixed
+-- Notice when varchar/text is cast to bpchar and used for
+-- comparison, the trailing spaces are ignored
+-- When char is cast to varchar/text, it's considered
+-- comparison, and the trailing spaces are also ignored
+-- Prior to the fix, opclasses belonging to different
+-- opfamilies could be grouped as equivalent, and thence
+-- deriving incorrect equality hash join conditions
+create table foo (varchar_3 varchar(3)) distributed by (varchar_3);
+create table bar (char_3 char(3)) distributed by (char_3);
+create table baz (text_any text) distributed by (text_any);
+insert into foo values ('cd'); -- 0 trailing spaces
+insert into bar values ('cd '); -- 1 trailing space
+insert into baz values ('cd  '); -- 2 trailing spaces
+-- varchar cast to bpchar
+-- 'cd' matches 'cd', returns 1 row
+explain select varchar_3, char_3 from foo join bar on varchar_3=char_3;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=16)
+   ->  Hash Join  (cost=0.00..862.00 rows=1 width=16)
+         Hash Cond: ((foo.varchar_3)::bpchar = bar.char_3)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+               Hash Key: foo.varchar_3
+               ->  Seq Scan on foo  (cost=0.00..431.00 rows=1 width=8)
+         ->  Hash  (cost=431.00..431.00 rows=1 width=8)
+               ->  Seq Scan on bar  (cost=0.00..431.00 rows=1 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(9 rows)
+
+select varchar_3, char_3 from foo join bar on varchar_3=char_3;
+ varchar_3 | char_3 
+-----------+--------
+ cd        | cd 
+(1 row)
+
+-- char cast to text
+-- 'cd' doesn't match 'cd  ', returns 0 rows
+explain select char_3, text_any from bar join baz on char_3=text_any;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=16)
+   ->  Hash Join  (cost=0.00..862.00 rows=1 width=16)
+         Hash Cond: ((bar.char_3)::text = baz.text_any)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+               Hash Key: (bar.char_3)::text
+               ->  Seq Scan on bar  (cost=0.00..431.00 rows=1 width=8)
+         ->  Hash  (cost=431.00..431.00 rows=1 width=8)
+               ->  Seq Scan on baz  (cost=0.00..431.00 rows=1 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(9 rows)
+
+select char_3, text_any from bar join baz on char_3=text_any;
+ char_3 | text_any 
+--------+----------
+(0 rows)
+
+-- foo - bar join: varchar cast to bpchar
+-- 'cd' matches 'cd'
+-- foo - baz join: no cast
+-- 'cd' doesn't match 'cd  '
+-- returns 0 rows
+-- Notice ORCA changes join order to minimize motion
+explain select varchar_3, char_3, text_any from foo join bar on varchar_3=char_3
+join baz on varchar_3=text_any;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1293.00 rows=1 width=24)
+   ->  Hash Join  (cost=0.00..1293.00 rows=1 width=24)
+         Hash Cond: ((foo.varchar_3)::bpchar = bar.char_3)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=16)
+               Hash Key: foo.varchar_3
+               ->  Hash Join  (cost=0.00..862.00 rows=1 width=16)
+                     Hash Cond: ((foo.varchar_3)::text = baz.text_any)
+                     ->  Seq Scan on foo  (cost=0.00..431.00 rows=1 width=8)
+                     ->  Hash  (cost=431.00..431.00 rows=1 width=8)
+                           ->  Seq Scan on baz  (cost=0.00..431.00 rows=1 width=8)
+         ->  Hash  (cost=431.00..431.00 rows=1 width=8)
+               ->  Seq Scan on bar  (cost=0.00..431.00 rows=1 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(13 rows)
+
+select varchar_3, char_3, text_any from foo join bar on varchar_3=char_3
+join baz on varchar_3=text_any;
+ varchar_3 | char_3 | text_any 
+-----------+--------+----------
+(0 rows)
+
 -- Clean up. None of the objects we create are very interesting to keep around.
 reset search_path;
 set client_min_messages='warning';


### PR DESCRIPTION
Issue:
The join of two columns, one varchar and one char, of matching values with trailing spaces, generates empty output.

Example:
create table foo (a varchar(3)) distributed by (a); create table bar (b char(3)) distributed by (b);
insert into foo values ('1 ');
insert into bar values ('1 ');
select a, b from foo join bar on a = b;

 a | p
---+---
(0 rows)

Root cause:
According to Postgres documentation, "Values of type character are physically padded with spaces to the specified width n, and are stored and displayed that way. However, trailing spaces are treated as semantically insignificant and disregarded when comparing two values of type character."

This means, '1 ' of char(3) (1 trailing space) is stored as '1  ' (2 trailing spaces). However, when it's used for comparison, such as in a join condition or filter, all the trailing spaces are removed, so it's treated as '1'.

In our example, the join condition foo.a = bar.b doesn't specify casting. Therefore, foo.a of varchar is cast to bpchar, and the join condition becomes bar.b = (foo.a)::bpchar. The trailing spaces are removed for both foo.a and bar.b. '1' == '1' matches, so the query should return 1 row.

However, ORCA generates an additional hash condition, where both foo.a and bar.p are cast to text. The join condition becomes (bar.b = (foo.a)::bpchar) AND ((bar.p)::text = (foo.a)::text)). '1 ' of varchar stays '1 ' when cast to text. However, '1  ' of char(3) becomes '1' when cast to text, cause casting is considered comparison. '1 ' doesn't match '1', so 0 rows is returned.

The derivation of additional hash conditions is designed to optimize multi-column join operations, and in itself has no fault. However, casting char to text (ORCA's derived join condition) isn't equivalent to casting varchar to char (user's join condition). This is because hash of char and hash of varchar/text are two operator classes that belong to two different operator families. If two opclasses belong to different opfamilies, the same operator (equality in this case) invokes different internal functions. Casting foo.a to char enforces a motion on foo, whereas casting bar.b to text enforces a motion on bar.

Solution:
We fix this bug by addressing the opfamily mismatch. When deriving the equivalence classes, instead of checking if the opfamilies of post-cast types match, we check the matching of opfamilies of pre-cast types.

Reopen https://github.com/greenplum-db/gpdb/pull/14903
Instead of binary coercibility, we focus on opfamily mismatch

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
