### PR TITLE
COPY should report correct No. of inserted rows for replicated table (7X)

### DIFF
--- a/src/backend/cdb/cdbcopy.c
+++ b/src/backend/cdb/cdbcopy.c
@@ -434,10 +434,10 @@ cdbCopyEndInternal(CdbCopy *c, char *abort_msg,
 											 * QEs */
 	int64		total_rows_rejected = 0;	/* total num rows rejected by all
 											 * QEs */
-	int64		first_segment_rows_completed = 0;	/* total num rows completed by first
-											 		* QE, mainly for replicated table*/
-	int64		first_segment_rows_rejected = 0;	/* total num rows rejected by first
-													* QE, mainly for replicated table*/
+	int64		first_segment_rows_completed = -1;	/* total num rows completed by first QE,
+											 		 * mainly for replicated table */
+	int64		first_segment_rows_rejected = -1;	/* total num rows rejected by first QE,
+													 * mainly for replicated table */
 	ErrorData *first_error = NULL;
 	int			seg;
 	struct pollfd	*pollRead;
@@ -653,7 +653,7 @@ cdbCopyEndInternal(CdbCopy *c, char *abort_msg,
 				 */
 				if (c->is_replicated)
 				{
-					if (seg == 0)
+					if (first_segment_rows_rejected == -1) 
 						first_segment_rows_rejected = res->numRejected;
 					else
 					{
@@ -677,7 +677,7 @@ cdbCopyEndInternal(CdbCopy *c, char *abort_msg,
 				 */
 				if (c->is_replicated)
 				{
-					if (seg == 0)
+					if (first_segment_rows_completed == -1) 
 						first_segment_rows_completed = res->numCompleted;
 					else
 					{

--- a/src/backend/cdb/cdbcopy.c
+++ b/src/backend/cdb/cdbcopy.c
@@ -107,6 +107,7 @@ makeCdbCopy(CopyState cstate, bool is_copy_in)
 	/* fresh start */
 	c->total_segs = 0;
 	c->copy_in = is_copy_in;
+	c->is_replicated = GpPolicyIsReplicated(policy);
 	c->seglist = NIL;
 	c->dispatcherState = NULL;
 	initStringInfo(&(c->copy_out_buf));
@@ -433,6 +434,10 @@ cdbCopyEndInternal(CdbCopy *c, char *abort_msg,
 											 * QEs */
 	int64		total_rows_rejected = 0;	/* total num rows rejected by all
 											 * QEs */
+	int64		first_segment_rows_completed = 0;	/* total num rows completed by first
+											 		* QE, mainly for replicated table*/
+	int64		first_segment_rows_rejected = 0;	/* total num rows rejected by first
+													* QE, mainly for replicated table*/
 	ErrorData *first_error = NULL;
 	int			seg;
 	struct pollfd	*pollRead;
@@ -640,14 +645,48 @@ cdbCopyEndInternal(CdbCopy *c, char *abort_msg,
 
 			/* in SREH mode, check if this seg rejected (how many) rows */
 			if (res->numRejected > 0)
+			{
 				segment_rows_rejected = res->numRejected;
+				/* 
+				 * Doing COPY in replicate table, gpdb needs to ensure that  
+				 * the number of tuples rejected by each segment is consistent.
+				 */
+				if (c->is_replicated)
+				{
+					if (seg == 0)
+						first_segment_rows_rejected = res->numRejected;
+					else
+					{
+						if (first_segment_rows_rejected != res->numRejected)
+							elog(ERROR, "the number of rejected tuples in different segments mismatch \
+										when doing COPY FROM in a replicated table");
+					}
+				}
+			}
 
 			/*
 			 * When COPY FROM, need to calculate the number of this
 			 * segment's completed rows
 			 */
 			if (res->numCompleted > 0)
+			{
 				segment_rows_completed = res->numCompleted;
+				/* 
+				 * Doing COPY in replicate table, gpdb needs to ensure that  
+				 * the number of tuples inserted into each segment is consistent.
+				 */
+				if (c->is_replicated)
+				{
+					if (seg == 0)
+						first_segment_rows_completed = res->numCompleted;
+					else
+					{
+						if (first_segment_rows_completed != res->numCompleted)
+							elog(ERROR, "the number of completed tuples in different segments mismatch \
+										when doing COPY FROM in a replicated table");
+					}
+				}
+			}
 
 			/* free the PGresult object */
 			PQclear(res);
@@ -722,6 +761,13 @@ cdbCopyEndInternal(CdbCopy *c, char *abort_msg,
 					(errcode(ERRCODE_IO_ERROR),
 					 errmsg("could not complete COPY on some segments"),
 					 errdetail("%s", io_err_msg.data)));
+	}
+
+	/* Please refer to https://github.com/greenplum-db/gpdb/issues/14126 */
+	if (c->is_replicated && c->copy_in)
+	{
+		total_rows_completed = first_segment_rows_completed;
+		total_rows_rejected = first_segment_rows_rejected;
 	}
 
 	if (total_rows_completed_p != NULL)

--- a/src/include/cdb/cdbcopy.h
+++ b/src/include/cdb/cdbcopy.h
@@ -30,6 +30,7 @@ typedef struct CdbCopy
 {
 	int			total_segs;		/* total number of segments in cdb */
 	bool		copy_in;		/* direction: true for COPY FROM false for COPY TO */
+	bool		is_replicated;	/* true for relicated table, false for plain table */
 
 	StringInfoData	copy_out_buf;/* holds a chunk of data from the database */
 

--- a/src/test/isolation2/expected/ao_unique_index.out
+++ b/src/test/isolation2/expected/ao_unique_index.out
@@ -388,12 +388,12 @@ CREATE
 1: BEGIN;
 BEGIN
 1: COPY unique_index_ao_row FROM PROGRAM 'seq 1 10';
-COPY 30
+COPY 10
 -- concurrent tx inserting conflicting row should block.
 2&: COPY unique_index_ao_row FROM PROGRAM 'seq 1 1';  <waiting ...>
 -- concurrent tx inserting non-conflicting rows should be successful.
 3: COPY unique_index_ao_row FROM PROGRAM 'seq 11 20';
-COPY 30
+COPY 10
 -- inserting a conflicting row in the same transaction should ERROR out.
 1: COPY unique_index_ao_row FROM PROGRAM 'seq 1 1';
 ERROR:  duplicate key value violates unique constraint "unique_index_ao_row_a_key"
@@ -401,7 +401,7 @@ DETAIL:  Key (a)=(1) already exists.
 CONTEXT:  COPY unique_index_ao_row, line 1
 -- now that tx 1 was aborted, tx 2 is successful.
 2<:  <... completed>
-COPY 3
+COPY 1
 1: END;
 END
 

--- a/src/test/isolation2/expected/aocs_unique_index.out
+++ b/src/test/isolation2/expected/aocs_unique_index.out
@@ -388,12 +388,12 @@ CREATE
 1: BEGIN;
 BEGIN
 1: COPY unique_index_ao_column FROM PROGRAM 'seq 1 10';
-COPY 30
+COPY 10
 -- concurrent tx inserting conflicting row should block.
 2&: COPY unique_index_ao_column FROM PROGRAM 'seq 1 1';  <waiting ...>
 -- concurrent tx inserting non-conflicting rows should be successful.
 3: COPY unique_index_ao_column FROM PROGRAM 'seq 11 20';
-COPY 30
+COPY 10
 -- inserting a conflicting row in the same transaction should ERROR out.
 1: COPY unique_index_ao_column FROM PROGRAM 'seq 1 1';
 ERROR:  duplicate key value violates unique constraint "unique_index_ao_column_a_key"
@@ -401,7 +401,7 @@ DETAIL:  Key (a)=(1) already exists.
 CONTEXT:  COPY unique_index_ao_column, line 1
 -- now that tx 1 was aborted, tx 2 is successful.
 2<:  <... completed>
-COPY 3
+COPY 1
 1: END;
 END
 


### PR DESCRIPTION
This pr fixes the the bug reported in [issue-14126](https://github.com/greenplum-db/gpdb/issues/14126).

**Bug Info:**
For replicated table, COPY reports incorrect number of inserted rows. The wrong result is showed as below:
```
postgres=# create table foox(i int) distributed replicated;
CREATE TABLE
postgres=# copy foox from program 'seq 1 10';  <-------- we only insert 10 data in fact.
COPY 30                                        <-------- count multiplied by number of segments (3).
``` 

**Diagnose:**

For replicated table, gpdb stores the same data on each segment. So, when we insert _M_ tuples, we actually insert _M_ tuples into _N_ segments, totally _N_ times _M_. But we're actually only inserting _M_ valid tuples. So in this case, gpdb just needs to return the number of tuples _M_ inserted into the first Segment.



