### PR TITLE
Fix pg_dump small bug

### DIFF
--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -16981,7 +16981,7 @@ dumpTableSchema(Archive *fout, const TableInfo *tbinfo)
 		 * from <= GPDB6.
 		 */
 		if (fout->remoteVersion < GPDB7_MAJOR_PGVERSION &&
-				(*tbinfo->partclause && *tbinfo->partclause != '\0'))
+				(tbinfo->partclause && *tbinfo->partclause != '\0'))
 		{
 			/* partition by clause */
 			appendPQExpBuffer(q, " %s", tbinfo->partclause);


### PR DESCRIPTION
I met this error when I tried to use pg_dump in the main branch to dump ao table from gpdb6.
The step to reproduce is:
```
[gpadmin@localhost gpcopy] $ pg_dump --version
pg_dump (PostgreSQL) 12.12
[gpadmin@localhost gpcopy] $ pg_dump --gp-syntax -h <host-of-gp6> -p 6000 -U gpadmin -s -t '"public"."my_ao"' 'gpadmin'
Segmentation fault (core dumped)
```
The ao table structure:
```
[gpadmin@mdw ~] $ psql
psql (9.4.26)
Type "help" for help.

gpadmin=# \d+ public.my_ao
                  Append-Only Table "public.my_ao"
 Column |  Type   | Modifiers | Storage | Stats target | Description
--------+---------+-----------+---------+--------------+-------------
 c      | integer |           | plain   |              |
Compression Type: zlib
Compression Level: 5
Block Size: 32768
Checksum: t
Distributed by: (c)
Options: appendonly=true, compresslevel=5
```

It's difficult to add test cases. Please let me know if you have any suggestions.

Co-authored-by: Adam <https://github.com/adam8157>
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
