### PR TITLE
Bring back pg_appendonly to relcache

### DIFF
--- a/src/backend/access/aocs/aocsam.c
+++ b/src/backend/access/aocs/aocsam.c
@@ -547,8 +547,7 @@ aocs_beginscan_internal(Relation relation,
 								 &scan->checksum,
 								 NULL);
 
-	GetAppendOnlyEntryAuxOids(RelationGetRelid(relation),
-							  scan->appendOnlyMetaDataSnapshot,
+	GetAppendOnlyEntryAuxOids(relation,
 							  NULL, NULL, NULL,
 							  &visimaprelid, &visimapidxid);
 
@@ -840,8 +839,7 @@ aocs_insert_init(Relation rel, int segno, int64 num_rows)
                                  &nd);
     desc->compType = NameStr(nd);
 
-    GetAppendOnlyEntryAuxOids(rel->rd_id,
-                              desc->appendOnlyMetaDataSnapshot,
+    GetAppendOnlyEntryAuxOids(rel,
                               &desc->segrelid, &desc->blkdirrelid, NULL,
                               &desc->visimaprelid, &desc->visimapidxid);
 
@@ -1257,8 +1255,7 @@ aocs_fetch_init(Relation relation,
     bool checksum = true;
     Oid visimaprelid;
     Oid visimapidxid;
-    GetAppendOnlyEntryAuxOids(relation->rd_id,
-                              appendOnlyMetaDataSnapshot,
+    GetAppendOnlyEntryAuxOids(relation,
                               &aocsFetchDesc->segrelid, NULL, NULL,
                               &visimaprelid, &visimapidxid);
 
@@ -1627,8 +1624,7 @@ aocs_delete_init(Relation rel)
 
     Snapshot snapshot = GetCatalogSnapshot(InvalidOid);
 
-    GetAppendOnlyEntryAuxOids(rel->rd_id,
-                              snapshot,
+    GetAppendOnlyEntryAuxOids(rel,
                               NULL, NULL, NULL,
                               &visimaprelid, &visimapidxid);
 

--- a/src/backend/access/aocs/aocsam_handler.c
+++ b/src/backend/access/aocs/aocsam_handler.c
@@ -1255,7 +1255,6 @@ heap_truncate_one_relid(Oid relid)
 static void
 aoco_relation_nontransactional_truncate(Relation rel)
 {
-	Oid			ao_base_relid = RelationGetRelid(rel);
 	Oid			aoseg_relid = InvalidOid;
 	Oid			aoblkdir_relid = InvalidOid;
 	Oid			aovisimap_relid = InvalidOid;
@@ -1263,7 +1262,7 @@ aoco_relation_nontransactional_truncate(Relation rel)
 	ao_truncate_one_rel(rel);
 
 	/* Also truncate the aux tables */
-	GetAppendOnlyEntryAuxOids(ao_base_relid, NULL,
+	GetAppendOnlyEntryAuxOids(rel,
 	                          &aoseg_relid,
 	                          &aoblkdir_relid, NULL,
 	                          &aovisimap_relid, NULL);
@@ -1614,7 +1613,7 @@ aoco_index_build_range_scan(Relation heapRelation,
 	/*
 	 * If block directory is empty, it must also be built along with the index.
 	 */
-	GetAppendOnlyEntryAuxOids(RelationGetRelid(heapRelation), NULL, NULL,
+	GetAppendOnlyEntryAuxOids(heapRelation, NULL,
 							  &blkdirrelid, &blkidxrelid, NULL, NULL);
 
 	Relation blkdir = relation_open(blkdirrelid, AccessShareLock);

--- a/src/backend/access/aocs/aocssegfiles.c
+++ b/src/backend/access/aocs/aocssegfiles.c
@@ -219,8 +219,7 @@ GetAOCSFileSegInfo(Relation prel,
 	bool		isNull;
 
     Oid         segrelid;
-    GetAppendOnlyEntryAuxOids(prel->rd_id,
-                              appendOnlyMetaDataSnapshot,
+    GetAppendOnlyEntryAuxOids(prel,
                               &segrelid, NULL, NULL,
                               NULL, NULL);
 
@@ -327,8 +326,7 @@ GetAllAOCSFileSegInfo(Relation prel,
 
 	Assert(RelationIsAoCols(prel));
 
-	GetAppendOnlyEntryAuxOids(prel->rd_id,
-							  appendOnlyMetaDataSnapshot,
+	GetAppendOnlyEntryAuxOids(prel,
 							  &segrelid, NULL, NULL,
 							  NULL, NULL);
 
@@ -586,8 +584,7 @@ MarkAOCSFileSegInfoAwaitingDrop(Relation prel, int segno)
 	Assert(RelationIsAoCols(prel));
 
 	appendOnlyMetaDataSnapshot = RegisterSnapshot(GetCatalogSnapshot(InvalidOid));
-	GetAppendOnlyEntryAuxOids(prel->rd_id,
-							  appendOnlyMetaDataSnapshot,
+	GetAppendOnlyEntryAuxOids(prel,
 							  &segrelid, NULL, NULL,
 							  NULL, NULL);
 	UnregisterSnapshot(appendOnlyMetaDataSnapshot);
@@ -679,8 +676,7 @@ ClearAOCSFileSegInfo(Relation prel, int segno)
 		   RelationGetRelationName(prel));
 
 	appendOnlyMetaDataSnapshot = RegisterSnapshot(GetCatalogSnapshot(InvalidOid));
-	GetAppendOnlyEntryAuxOids(prel->rd_id,
-							  appendOnlyMetaDataSnapshot,
+	GetAppendOnlyEntryAuxOids(prel,
 							  &segrelid, NULL, NULL,
 							  NULL, NULL);
 	UnregisterSnapshot(appendOnlyMetaDataSnapshot);
@@ -970,8 +966,7 @@ AOCSFileSegInfoAddVpe(Relation prel, int32 segno,
 	}
 
     Oid         segrelid;
-    GetAppendOnlyEntryAuxOids(prel->rd_id,
-                              NULL,
+    GetAppendOnlyEntryAuxOids(prel,
                               &segrelid, NULL, NULL,
                               NULL, NULL);
 	segrel = heap_open(segrelid, RowExclusiveLock);
@@ -1089,8 +1084,7 @@ AOCSFileSegInfoAddCount(Relation prel, int32 segno,
 	TupleDesc	tupdesc;
 
     Oid         segrelid;
-    GetAppendOnlyEntryAuxOids(prel->rd_id,
-                              NULL,
+    GetAppendOnlyEntryAuxOids(prel,
                               &segrelid, NULL, NULL,
                               NULL, NULL);
 
@@ -1277,8 +1271,7 @@ gp_aocsseg_internal(PG_FUNCTION_ARGS, Oid aocsRelOid)
 		context->relnatts = aocsRel->rd_rel->relnatts;
 
         Oid         segrelid;
-        GetAppendOnlyEntryAuxOids(aocsRel->rd_id,
-                                  appendOnlyMetaDataSnapshot,
+        GetAppendOnlyEntryAuxOids(aocsRel,
                                   &segrelid, NULL, NULL,
                                   NULL, NULL);
 		pg_aocsseg_rel = heap_open(segrelid, AccessShareLock);
@@ -1489,8 +1482,7 @@ gp_aocsseg_history(PG_FUNCTION_ARGS)
 		context->relnatts = aocsRel->rd_rel->relnatts;
 
         Oid         segrelid;
-        GetAppendOnlyEntryAuxOids(aocsRel->rd_id,
-                                  NULL,
+        GetAppendOnlyEntryAuxOids(aocsRel,
                                   &segrelid, NULL, NULL,
                                   NULL, NULL);
 
@@ -1613,7 +1605,7 @@ aocol_compression_ratio_internal(Relation parentrel)
 
 	Oid			segrelid = InvalidOid;
 
-	GetAppendOnlyEntryAuxOids(RelationGetRelid(parentrel), NULL,
+	GetAppendOnlyEntryAuxOids(parentrel,
 							  &segrelid, NULL, NULL, NULL, NULL);
 	Assert(OidIsValid(segrelid));
 

--- a/src/backend/access/appendonly/aosegfiles.c
+++ b/src/backend/access/appendonly/aosegfiles.c
@@ -108,7 +108,7 @@ InsertInitialSegnoEntry(Relation parentrel, int segno)
 	/* New segments are always created in the latest format */
 	formatVersion = AORelationVersion_GetLatest();
 
-	GetAppendOnlyEntryAuxOids(parentrel->rd_id, NULL, &segrelid, NULL, NULL, NULL, NULL);
+	GetAppendOnlyEntryAuxOids(parentrel, &segrelid, NULL, NULL, NULL, NULL);
 
 	pg_aoseg_rel = heap_open(segrelid, RowExclusiveLock);
 
@@ -185,7 +185,7 @@ GetFileSegInfo(Relation parentrel, Snapshot appendOnlyMetaDataSnapshot, int segn
 	FileSegInfo *fsinfo;
 	Oid segrelid;
 
-	GetAppendOnlyEntryAuxOids(parentrel->rd_id, NULL, &segrelid, NULL, NULL, NULL, NULL);
+	GetAppendOnlyEntryAuxOids(parentrel, &segrelid, NULL, NULL, NULL, NULL);
 
 	/*
 	 * Check the pg_aoseg relation to be certain the ao table segment file is
@@ -351,7 +351,7 @@ GetAllFileSegInfo(Relation parentrel,
 	FileSegInfo **result;
 	Oid segrelid;
 
-	GetAppendOnlyEntryAuxOids(parentrel->rd_id, NULL, &segrelid, NULL, NULL, NULL, NULL);
+	GetAppendOnlyEntryAuxOids(parentrel, &segrelid, NULL, NULL, NULL, NULL);
 
 	if (segrelid == InvalidOid)
 		elog(ERROR, "could not find pg_aoseg aux table for AO table \"%s\"",
@@ -615,7 +615,7 @@ ClearFileSegInfo(Relation parentrel, int segno)
 	bool		isNull;
 	Oid segrelid;
 
-	GetAppendOnlyEntryAuxOids(parentrel->rd_id, NULL, &segrelid, NULL, NULL, NULL, NULL);
+	GetAppendOnlyEntryAuxOids(parentrel, &segrelid, NULL, NULL, NULL, NULL);
 
 	Assert(RelationIsAoRows(parentrel));
 
@@ -753,7 +753,7 @@ UpdateFileSegInfo_internal(Relation parentrel,
 	bool		isNull;
 	Oid segrelid;
 
-	GetAppendOnlyEntryAuxOids(parentrel->rd_id, NULL, &segrelid, NULL, NULL, NULL, NULL);
+	GetAppendOnlyEntryAuxOids(parentrel, &segrelid, NULL, NULL, NULL, NULL);
 
 	Assert(RelationIsAoRows(parentrel));
 	Assert(newState >= AOSEG_STATE_USECURRENT && newState <= AOSEG_STATE_AWAITING_DROP);
@@ -960,7 +960,7 @@ GetSegFilesTotals(Relation parentrel, Snapshot appendOnlyMetaDataSnapshot)
 
 	result = (FileSegTotals *) palloc0(sizeof(FileSegTotals));
 
-	GetAppendOnlyEntryAuxOids(parentrel->rd_id, NULL, &segrelid, NULL, NULL, NULL, NULL);
+	GetAppendOnlyEntryAuxOids(parentrel, &segrelid, NULL, NULL, NULL, NULL);
 
 	if (segrelid == InvalidOid)
 		elog(ERROR, "could not find pg_aoseg aux table for AO table \"%s\"",
@@ -1079,7 +1079,7 @@ gp_aoseg_history(PG_FUNCTION_ARGS)
 					 errmsg("'%s' is not an append-only row relation",
 							RelationGetRelationName(aocsRel))));
 
-		GetAppendOnlyEntryAuxOids(aocsRel->rd_id, NULL, &segrelid, NULL, NULL, NULL, NULL);
+		GetAppendOnlyEntryAuxOids(aocsRel, &segrelid, NULL, NULL, NULL, NULL);
 
 		pg_aoseg_rel = table_open(segrelid, AccessShareLock);
 
@@ -1231,7 +1231,7 @@ gp_aoseg(PG_FUNCTION_ARGS)
 					 errmsg("'%s' is not an append-only row relation",
 							RelationGetRelationName(aocsRel))));
 
-		GetAppendOnlyEntryAuxOids(aocsRel->rd_id, NULL, &segrelid, NULL, NULL, NULL, NULL);
+		GetAppendOnlyEntryAuxOids(aocsRel, &segrelid, NULL, NULL, NULL, NULL);
 
 		pg_aoseg_rel = table_open(segrelid, AccessShareLock);
 
@@ -1381,7 +1381,7 @@ get_ao_distribution(PG_FUNCTION_ARGS)
 					 errmsg("'%s' is not an append-only relation",
 							RelationGetRelationName(parentrel))));
 
-		GetAppendOnlyEntryAuxOids(RelationGetRelid(parentrel), NULL,
+		GetAppendOnlyEntryAuxOids(parentrel,
 								  &segrelid, NULL, NULL, NULL, NULL);
 		Assert(OidIsValid(segrelid));
 
@@ -1556,7 +1556,7 @@ aorow_compression_ratio_internal(Relation parentrel)
 
 	Assert(Gp_role == GP_ROLE_DISPATCH);
 
-	GetAppendOnlyEntryAuxOids(RelationGetRelid(parentrel), NULL,
+	GetAppendOnlyEntryAuxOids(parentrel,
 							  &segrelid,
 							  NULL, NULL, NULL, NULL);
 	Assert(OidIsValid(segrelid));

--- a/src/backend/access/appendonly/appendonly_blkdir_udf.c
+++ b/src/backend/access/appendonly/appendonly_blkdir_udf.c
@@ -97,7 +97,7 @@ gp_aoblkdir(PG_FUNCTION_ARGS)
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 						errmsg("function not supported on non append-optimized relation")));
 		sst = GetLatestSnapshot();
-		GetAppendOnlyEntryAuxOids(aoRelOid, sst,
+		GetAppendOnlyEntryAuxOids(context->aorel,
 								  NULL, &blkdirrelid, NULL,
 								  NULL, NULL);
 		sst = gp_select_invisible ? SnapshotAny : GetLatestSnapshot();

--- a/src/backend/access/appendonly/appendonly_compaction.c
+++ b/src/backend/access/appendonly/appendonly_compaction.c
@@ -131,7 +131,7 @@ AppendOnlyCompaction_ShouldCompact(Relation aoRelation,
     Oid         visimapidxid;
 
 	Assert(RelationIsAppendOptimized(aoRelation));
-    GetAppendOnlyEntryAuxOids(aoRelation->rd_id, appendOnlyMetaDataSnapshot,
+    GetAppendOnlyEntryAuxOids(aoRelation,
                               NULL, NULL, NULL,
                               &visimaprelid, &visimapidxid);
 
@@ -404,7 +404,7 @@ AppendOnlySegmentFileFullCompaction(Relation aorel,
 	}
 	relname = RelationGetRelationName(aorel);
 
-	GetAppendOnlyEntryAuxOids(aorel->rd_id, appendOnlyMetaDataSnapshot,
+	GetAppendOnlyEntryAuxOids(aorel,
 							  NULL, &blkdirrelid, NULL,
 							  &visimaprelid, &visimapidxid);
 
@@ -537,7 +537,7 @@ AppendOptimizedCollectDeadSegments(Relation aorel)
 
 	Assert(RelationIsAppendOptimized(aorel));
 
-	GetAppendOnlyEntryAuxOids(aorel->rd_id, appendOnlyMetaDataSnapshot,
+	GetAppendOnlyEntryAuxOids(aorel,
 							  &segrelid, NULL, NULL, NULL, NULL);
 	
 	pg_aoseg_rel = heap_open(segrelid, AccessShareLock);
@@ -697,7 +697,7 @@ AppendOptimizedTruncateToEOF(Relation aorel)
 	 */
 	LockRelationForExtension(aorel, ExclusiveLock);
 
-	GetAppendOnlyEntryAuxOids(aorel->rd_id, appendOnlyMetaDataSnapshot,
+	GetAppendOnlyEntryAuxOids(aorel,
 							  &segrelid, NULL, NULL, NULL, NULL);
 
 	pg_aoseg_rel = heap_open(segrelid, AccessShareLock);

--- a/src/backend/access/appendonly/appendonly_visimap.c
+++ b/src/backend/access/appendonly/appendonly_visimap.c
@@ -901,8 +901,7 @@ void AppendOnlyVisimap_Init_forUniqueCheck(
 	Assert(snapshot->snapshot_type == SNAPSHOT_DIRTY ||
 			   snapshot->snapshot_type == SNAPSHOT_SELF);
 
-	GetAppendOnlyEntryAuxOids(aoRel->rd_id,
-							  InvalidSnapshot, /* catalog snapshot is enough */
+	GetAppendOnlyEntryAuxOids(aoRel,
 							  NULL, NULL, NULL, &visimaprelid, &visimapidxid);
 	if (!OidIsValid(visimaprelid) || !OidIsValid(visimapidxid))
 		elog(ERROR, "Could not find block directory for relation: %u", aoRel->rd_id);

--- a/src/backend/access/appendonly/appendonly_visimap_udf.c
+++ b/src/backend/access/appendonly/appendonly_visimap_udf.c
@@ -89,7 +89,7 @@ gp_aovisimap(PG_FUNCTION_ARGS)
 
 		Snapshot sst = GetLatestSnapshot();
 
-        GetAppendOnlyEntryAuxOids(context->aorel->rd_id, sst,
+        GetAppendOnlyEntryAuxOids(context->aorel,
                                   NULL, NULL, NULL,
                                   &visimaprelid, &visimapidxid);
 
@@ -204,7 +204,7 @@ gp_aovisimap_hidden_info(PG_FUNCTION_ARGS)
 
         Oid segrelid;
 		snapshot = GetLatestSnapshot();
-        GetAppendOnlyEntryAuxOids(context->parentRelation->rd_id, snapshot,
+        GetAppendOnlyEntryAuxOids(context->parentRelation,
                                   &segrelid, NULL, NULL,
                                   &visimaprelid, &visimapidxid);
 
@@ -384,7 +384,7 @@ gp_aovisimap_entry(PG_FUNCTION_ARGS)
 
         Snapshot sst = GetLatestSnapshot();
 
-        GetAppendOnlyEntryAuxOids(context->parentRelation->rd_id, sst,
+        GetAppendOnlyEntryAuxOids(context->parentRelation,
                                   NULL, NULL, NULL,
                                   &visimaprelid, &visimapidxid);
 

--- a/src/backend/access/appendonly/appendonlyam.c
+++ b/src/backend/access/appendonly/appendonlyam.c
@@ -1389,7 +1389,7 @@ appendonly_beginrangescan_internal(Relation relation,
 		Oid			visimaprelid;
 		Oid			visimapidxid;
 
-		GetAppendOnlyEntryAuxOids(relation->rd_id, NULL,
+		GetAppendOnlyEntryAuxOids(relation,
 								  NULL, NULL, NULL, &visimaprelid, &visimapidxid);
 
 		AppendOnlyVisimap_Init(&scan->visibilityMap,
@@ -1921,7 +1921,7 @@ appendonly_fetch_init(Relation relation,
 	FormData_pg_appendonly			aoFormData;
 	int								segno;
 
-	GetAppendOnlyEntry(relation->rd_id, &aoFormData);
+	GetAppendOnlyEntry(relation, &aoFormData);
 
 	/*
 	 * increment relation ref count while scanning relation
@@ -2330,7 +2330,7 @@ appendonly_delete_init(Relation rel)
 	Oid visimaprelid;
 	Oid visimapidxid;
 
-	GetAppendOnlyEntryAuxOids(rel->rd_id, NULL, NULL, NULL, NULL, &visimaprelid, &visimapidxid);
+	GetAppendOnlyEntryAuxOids(rel, NULL, NULL, NULL, &visimaprelid, &visimapidxid);
 
 	AppendOnlyDeleteDesc aoDeleteDesc = palloc0(sizeof(AppendOnlyDeleteDescData));
 
@@ -2600,7 +2600,7 @@ appendonly_insert_init(Relation rel, int segno, int64 num_rows)
 	 */
 	Assert(aoInsertDesc->fsInfo->segno == segno);
 
-	GetAppendOnlyEntryAuxOids(aoInsertDesc->aoi_rel->rd_id, NULL, &aoInsertDesc->segrelid,
+	GetAppendOnlyEntryAuxOids(aoInsertDesc->aoi_rel, &aoInsertDesc->segrelid,
 			NULL, NULL, NULL, NULL);
 
 	firstSequence = GetFastSequences(aoInsertDesc->segrelid, segno, num_rows);

--- a/src/backend/access/appendonly/appendonlyam_handler.c
+++ b/src/backend/access/appendonly/appendonlyam_handler.c
@@ -1051,7 +1051,7 @@ appendonly_relation_nontransactional_truncate(Relation rel)
 	ao_truncate_one_rel(rel);
 
 	/* Also truncate the aux tables */
-	GetAppendOnlyEntryAuxOids(ao_base_relid, NULL,
+	GetAppendOnlyEntryAuxOids(rel,
 							  &aoseg_relid,
 							  &aoblkdir_relid, NULL,
 							  &aovisimap_relid, NULL);
@@ -1450,7 +1450,7 @@ appendonly_index_build_range_scan(Relation heapRelation,
 	Oid blkdirrelid;
 	Oid blkidxrelid;
 
-	GetAppendOnlyEntryAuxOids(RelationGetRelid(aoscan->aos_rd), NULL, NULL,
+	GetAppendOnlyEntryAuxOids(aoscan->aos_rd, NULL,
 							  &blkdirrelid, &blkidxrelid, NULL, NULL);
 	/*
 	 * Note that block directory is created during creation of the first
@@ -1871,7 +1871,7 @@ appendonly_relation_size(Relation rel, ForkNumber forkNumber)
 
 	result = 0;
 
-	GetAppendOnlyEntryAuxOids(rel->rd_id, NULL, &segrelid, NULL,
+	GetAppendOnlyEntryAuxOids(rel, &segrelid, NULL,
 			NULL, NULL, NULL);
 
 	if (segrelid == InvalidOid)

--- a/src/backend/access/appendonly/appendonlyblockdirectory.c
+++ b/src/backend/access/appendonly/appendonlyblockdirectory.c
@@ -181,7 +181,7 @@ AppendOnlyBlockDirectory_Init_forSearch(
 	Oid blkdiridxid;
 
 	blockDirectory->aoRel = aoRel;
-	GetAppendOnlyEntryAuxOids(aoRel->rd_id, NULL, NULL, &blkdirrelid, &blkdiridxid, NULL, NULL);
+	GetAppendOnlyEntryAuxOids(aoRel, NULL, &blkdirrelid, &blkdiridxid, NULL, NULL);
 
 	if (!OidIsValid(blkdirrelid))
 	{
@@ -251,8 +251,7 @@ AppendOnlyBlockDirectory_Init_forUniqueChecks(
 	Assert(snapshot->snapshot_type == SNAPSHOT_DIRTY ||
 			snapshot->snapshot_type == SNAPSHOT_SELF);
 
-	GetAppendOnlyEntryAuxOids(aoRel->rd_id,
-							  InvalidSnapshot, /* catalog snapshot is enough */
+	GetAppendOnlyEntryAuxOids(aoRel,
 							  NULL, &blkdirrelid, &blkdiridxid, NULL, NULL);
 
 	if (!OidIsValid(blkdirrelid) || !OidIsValid(blkdiridxid))
@@ -310,7 +309,7 @@ AppendOnlyBlockDirectory_Init_forInsert(
 	blockDirectory->aoRel = aoRel;
 	blockDirectory->appendOnlyMetaDataSnapshot = appendOnlyMetaDataSnapshot;
 
-	GetAppendOnlyEntryAuxOids(aoRel->rd_id, NULL, NULL, &blkdirrelid, &blkdiridxid, NULL, NULL);
+	GetAppendOnlyEntryAuxOids(aoRel, NULL, &blkdirrelid, &blkdiridxid, NULL, NULL);
 
 	if (!OidIsValid(blkdirrelid))
 	{
@@ -379,7 +378,7 @@ AppendOnlyBlockDirectory_Init_addCol(
 	blockDirectory->aoRel = aoRel;
 	blockDirectory->appendOnlyMetaDataSnapshot = appendOnlyMetaDataSnapshot;
 
-	GetAppendOnlyEntryAuxOids(aoRel->rd_id, NULL, NULL, &blkdirrelid, &blkdiridxid, NULL, NULL);
+	GetAppendOnlyEntryAuxOids(aoRel, NULL, &blkdirrelid, &blkdiridxid, NULL, NULL);
 
 	if (!OidIsValid(blkdirrelid))
 	{
@@ -1035,7 +1034,7 @@ AppendOnlyBlockDirectory_DeleteSegmentFile(Relation aoRel,
 	Oid blkdirrelid;
 	Oid blkdiridxid;
 
-	GetAppendOnlyEntryAuxOids(aoRel->rd_id, NULL, NULL, &blkdirrelid, &blkdiridxid, NULL, NULL);
+	GetAppendOnlyEntryAuxOids(aoRel, NULL, &blkdirrelid, &blkdiridxid, NULL, NULL);
 
 	Assert(OidIsValid(blkdirrelid));
 	Assert(OidIsValid(blkdiridxid));

--- a/src/backend/access/appendonly/appendonlywriter.c
+++ b/src/backend/access/appendonly/appendonlywriter.c
@@ -163,7 +163,7 @@ LockSegnoForWrite(Relation rel, int segno)
 	LockRelationForExtension(rel, ExclusiveLock);
 
 	appendOnlyMetaDataSnapshot = RegisterSnapshot(GetCatalogSnapshot(InvalidOid));
-	GetAppendOnlyEntryAuxOids(rel->rd_id, appendOnlyMetaDataSnapshot,
+	GetAppendOnlyEntryAuxOids(rel,
 							  &segrelid, NULL, NULL, NULL, NULL);
 	/*
 	 * Now pick a segment that is not in use, and is not over the allowed
@@ -445,7 +445,7 @@ choose_segno_internal(Relation rel, List *avoid_segnos, choose_segno_mode mode)
 		LogDistributedSnapshotInfo(snapshot, "Used snapshot: ");
 	}
 
-	GetAppendOnlyEntryAuxOids(rel->rd_id, NULL,
+	GetAppendOnlyEntryAuxOids(rel,
 							  &segrelid, NULL, NULL, NULL, NULL);
 
 	/*
@@ -648,7 +648,7 @@ choose_new_segfile(Relation rel, bool *used, List *avoid_segnos)
 			Snapshot appendOnlyMetaDataSnapshot;
 
 			appendOnlyMetaDataSnapshot = RegisterSnapshot(GetCatalogSnapshot(InvalidOid));
-			GetAppendOnlyEntryAuxOids(rel->rd_id, appendOnlyMetaDataSnapshot,
+			GetAppendOnlyEntryAuxOids(rel,
 									  &segrelid, NULL, NULL, NULL, NULL);
 			UnregisterSnapshot(appendOnlyMetaDataSnapshot);
 

--- a/src/backend/catalog/aocatalog.c
+++ b/src/backend/catalog/aocatalog.c
@@ -85,15 +85,15 @@ CreateAOAuxiliaryTable(
 	switch(relkind)
 	{
 		case RELKIND_AOVISIMAP:
-			GetAppendOnlyEntryAuxOids(relOid, NULL, NULL,
+			GetAppendOnlyEntryAuxOids(rel, NULL,
 				NULL, NULL, &aoauxiliary_relid, &aoauxiliary_idxid);
 			break;
 		case RELKIND_AOBLOCKDIR:
-			GetAppendOnlyEntryAuxOids(relOid, NULL, NULL,
+			GetAppendOnlyEntryAuxOids(rel, NULL,
 				&aoauxiliary_relid, &aoauxiliary_idxid, NULL, NULL);
 			break;
 		case RELKIND_AOSEGMENTS:
-			GetAppendOnlyEntryAuxOids(relOid, NULL,
+			GetAppendOnlyEntryAuxOids(rel,
 				&aoauxiliary_relid,
 				NULL, NULL, NULL, NULL);
 			break;

--- a/src/backend/catalog/index.c
+++ b/src/backend/catalog/index.c
@@ -4030,6 +4030,16 @@ reindex_relation(Oid relid, int flags, int options)
 		i++;
 	}
 
+	/* 
+	 * While we have the relation opened, obtain the aoseg_relid and 
+	 * aoblkdir_relid if it is an AO table.
+	 */
+	if ((flags & REINDEX_REL_PROCESS_TOAST) && relIsAO)
+		GetAppendOnlyEntryAuxOids(rel,
+								  &aoseg_relid,
+								  &aoblkdir_relid, NULL,
+								  &aovisimap_relid, NULL);
+
 	/*
 	 * Close rel, but continue to hold the lock.
 	 */
@@ -4045,13 +4055,6 @@ reindex_relation(Oid relid, int flags, int options)
 	 */
 	if ((flags & REINDEX_REL_PROCESS_TOAST) && OidIsValid(toast_relid))
 		result |= reindex_relation(toast_relid, flags, options);
-
-	/* Obtain the aoseg_relid and aoblkdir_relid if the relation is an AO table. */
-	if ((flags & REINDEX_REL_PROCESS_TOAST) && relIsAO)
-		GetAppendOnlyEntryAuxOids(relid, NULL,
-								  &aoseg_relid,
-								  &aoblkdir_relid, NULL,
-								  &aovisimap_relid, NULL);
 
 	/*
 	 * If an AO rel has a secondary segment list rel, reindex that too while we

--- a/src/backend/catalog/pg_appendonly.c
+++ b/src/backend/catalog/pg_appendonly.c
@@ -151,48 +151,18 @@ GetAppendOnlyEntryAttributes(Oid relid,
  *
  * The OIDs will be retrieved only when the corresponding output variable is
  * not NULL.
- *
- * 'appendOnlyMetaDataSnapshot' can be passed as NULL, which means use the
- * latest snapshot, like in systable_beginscan.
  */
 void
-GetAppendOnlyEntryAuxOids(Oid relid,
-						  Snapshot appendOnlyMetaDataSnapshot,
+GetAppendOnlyEntryAuxOids(Relation rel,
 						  Oid *segrelid,
 						  Oid *blkdirrelid,
 						  Oid *blkdiridxid,
 						  Oid *visimaprelid,
 						  Oid *visimapidxid)
 {
-	Relation	pg_appendonly;
-	TupleDesc	tupDesc;
-	ScanKeyData key[1];
-	SysScanDesc scan;
-	HeapTuple	tuple;
 	Form_pg_appendonly	aoForm;
 
-	/*
-	 * Check the pg_appendonly relation to be certain the ao table
-	 * is there.
-	 */
-	pg_appendonly = table_open(AppendOnlyRelationId, AccessShareLock);
-	tupDesc = RelationGetDescr(pg_appendonly);
-
-	ScanKeyInit(&key[0],
-				Anum_pg_appendonly_relid,
-				BTEqualStrategyNumber, F_OIDEQ,
-				ObjectIdGetDatum(relid));
-
-	scan = systable_beginscan(pg_appendonly, AppendOnlyRelidIndexId, true,
-							  appendOnlyMetaDataSnapshot, 1, key);
-	tuple = systable_getnext(scan);
-	if (!HeapTupleIsValid(tuple))
-		ereport(ERROR,
-				(errcode(ERRCODE_UNDEFINED_OBJECT),
-				 errmsg("missing pg_appendonly entry for relation \"%s\"",
-						get_rel_name(relid))));
-
-	aoForm = (Form_pg_appendonly) GETSTRUCT(tuple);
+	aoForm = rel->rd_appendonly;
 
 	if (segrelid != NULL)
 		*segrelid = aoForm->segrelid;
@@ -208,49 +178,15 @@ GetAppendOnlyEntryAuxOids(Oid relid,
 
 	if (visimapidxid != NULL)
 		*visimapidxid = aoForm->visimapidxid;
-
-	/* Finish up scan and close pg_appendonly catalog. */
-	systable_endscan(scan);
-	table_close(pg_appendonly, AccessShareLock);
 }
 
 void
-GetAppendOnlyEntry(Oid relid, Form_pg_appendonly aoEntry)
+GetAppendOnlyEntry(Relation rel, Form_pg_appendonly aoEntry)
 {
-	Relation	pg_appendonly;
-	TupleDesc	tupDesc;
-	ScanKeyData key[1];
-	SysScanDesc scan;
-	HeapTuple	tuple;
 	Form_pg_appendonly	aoForm;
 
-	/*
-	 * Check the pg_appendonly relation to be certain the ao table
-	 * is there.
-	 */
-	pg_appendonly = table_open(AppendOnlyRelationId, AccessShareLock);
-	tupDesc = RelationGetDescr(pg_appendonly);
-
-	ScanKeyInit(&key[0],
-				Anum_pg_appendonly_relid,
-				BTEqualStrategyNumber, F_OIDEQ,
-				ObjectIdGetDatum(relid));
-
-	scan = systable_beginscan(pg_appendonly, AppendOnlyRelidIndexId, true,
-							  NULL, 1, key);
-	tuple = systable_getnext(scan);
-	if (!HeapTupleIsValid(tuple))
-		ereport(ERROR,
-				(errcode(ERRCODE_UNDEFINED_OBJECT),
-				 errmsg("missing pg_appendonly entry for relation \"%s\"",
-						get_rel_name(relid))));
-
-	aoForm = (Form_pg_appendonly) GETSTRUCT(tuple);
+	aoForm = rel->rd_appendonly;
 	memcpy(aoEntry, aoForm, APPENDONLY_TUPLE_SIZE);
-
-	/* Finish up scan and close pg_appendonly catalog. */
-	systable_endscan(scan);
-	table_close(pg_appendonly, AccessShareLock);
 }
 
 /*

--- a/src/backend/catalog/pg_attribute_encoding.c
+++ b/src/backend/catalog/pg_attribute_encoding.c
@@ -237,7 +237,6 @@ CloneAttributeEncodings(Oid oldrelid, Oid newrelid, AttrNumber max_attno)
 										 n + 1,
 										 attoptions[n]);
 	}
-	CommandCounterIncrement();
 }
 
 void

--- a/src/backend/commands/cluster.c
+++ b/src/backend/commands/cluster.c
@@ -887,6 +887,7 @@ make_new_heap_with_colname(Oid OIDOldHeap, Oid NewTableSpace, Oid NewAccessMetho
 		CloneAttributeEncodings(OIDOldHeap,
 								OIDNewHeap,
 								RelationGetNumberOfAttributes(OldHeap));
+		CommandCounterIncrement();
 		UpdateAttributeEncodings(OIDNewHeap, NewEncodings);
 	}
 	table_close(OldHeap, NoLock);

--- a/src/backend/commands/indexcmds.c
+++ b/src/backend/commands/indexcmds.c
@@ -735,7 +735,7 @@ DefineIndex(Oid relationId,
 	rel = table_open(relationId, NoLock);
 	if (RelationIsAppendOptimized(rel))
 	{
-		GetAppendOnlyEntryAuxOids(relationId, NULL, NULL, &blkdirrelid, NULL, NULL, NULL);
+		GetAppendOnlyEntryAuxOids(rel, NULL, &blkdirrelid, NULL, NULL, NULL);
 
 		if (!OidIsValid(blkdirrelid))
 			lockmode = ShareRowExclusiveLock; /* Relation is AO, and has no block directory */

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -1813,7 +1813,7 @@ ao_aux_tables_safe_truncate(Relation rel)
 	Oid aoblkdir_relid = InvalidOid;
 	Oid aovisimap_relid = InvalidOid;
 
-	GetAppendOnlyEntryAuxOids(relid, NULL, &aoseg_relid,
+	GetAppendOnlyEntryAuxOids(rel, &aoseg_relid,
 							  &aoblkdir_relid, NULL, &aovisimap_relid,
 							  NULL);
 
@@ -14565,7 +14565,7 @@ ATExecChangeOwner(Oid relationOid, Oid newOwnerId, bool recursing, LOCKMODE lock
 		{
 			Oid segrelid, blkdirrelid;
 			Oid visimap_relid;
-			GetAppendOnlyEntryAuxOids(relationOid, NULL,
+			GetAppendOnlyEntryAuxOids(target_rel,
 									  &segrelid,
 									  &blkdirrelid, NULL,
 									  &visimap_relid, NULL);
@@ -15246,7 +15246,7 @@ ATExecSetTableSpace(Oid tableOid, Oid newTableSpace, LOCKMODE lockmode)
 
 	/* Get the ao sub objects */
 	if (RelationIsAppendOptimized(rel))
-		GetAppendOnlyEntryAuxOids(tableOid, NULL,
+		GetAppendOnlyEntryAuxOids(rel,
 								  &relaosegrelid,
 								  &relaoblkdirrelid, &relaoblkdiridxid,
 								  &relaovisimaprelid, &relaovisimapidxid);

--- a/src/backend/commands/vacuum.c
+++ b/src/backend/commands/vacuum.c
@@ -1031,9 +1031,10 @@ expand_vacuum_rel(VacuumRelation *vrel, int options)
 				classForm = (Form_pg_class) GETSTRUCT(tuple);
 				if (IsAccessMethodAO(classForm->relam))
 				{
+					Relation aorel = table_open(classForm->oid, AccessShareLock);
 					oldcontext = MemoryContextSwitchTo(vac_context);
 
-					GetAppendOnlyEntryAuxOids(classForm->oid, NULL,
+					GetAppendOnlyEntryAuxOids(aorel,
 											  &aoseg_relid,
 											  &aoblkdir_relid, NULL,
 											  &aovisimap_relid, NULL);
@@ -1047,6 +1048,7 @@ expand_vacuum_rel(VacuumRelation *vrel, int options)
 						ao_aux_vacrels = lappend(ao_aux_vacrels, makeVacuumRelation(NULL, aovisimap_relid, part_vrel->va_cols));
 
 					MemoryContextSwitchTo(oldcontext);
+					table_close(aorel, AccessShareLock);
 				}
 				else
 				{
@@ -2300,7 +2302,7 @@ vacuum_rel(Oid relid, RangeVar *relation, VacuumParams *params,
 		 * AO_AUX_ONLY option is specified
 		 */
 		Assert(!(params->options & VACOPT_AO_AUX_ONLY));
-		GetAppendOnlyEntryAuxOids(RelationGetRelid(onerel), NULL,
+		GetAppendOnlyEntryAuxOids(onerel,
 								  &aoseg_relid,
 								  &aoblkdir_relid, NULL,
 								  &aovisimap_relid, NULL);

--- a/src/backend/commands/vacuum_ao.c
+++ b/src/backend/commands/vacuum_ao.c
@@ -637,8 +637,7 @@ vacuum_appendonly_fill_stats(Relation aorel, Snapshot snapshot, int elevel,
 	num_tuples = (double)fstotal->totaltuples;
 	nblocks = (uint32)RelationGetNumberOfBlocks(aorel);
 
-	GetAppendOnlyEntryAuxOids(aorel->rd_id,
-							  snapshot, 
+	GetAppendOnlyEntryAuxOids(aorel,
 							  NULL, NULL, NULL,
 							  &visimaprelid, &visimapidxid);
 

--- a/src/backend/utils/adt/dbsize.c
+++ b/src/backend/utils/adt/dbsize.c
@@ -585,7 +585,7 @@ calculate_table_size(Relation rel)
 	if (RelationIsAppendOptimized(rel))
 	{
 		Oid	auxRelIds[3];
-		GetAppendOnlyEntryAuxOids(rel->rd_id, NULL, &auxRelIds[0],
+		GetAppendOnlyEntryAuxOids(rel, &auxRelIds[0],
 								 &auxRelIds[1], NULL,
 								 &auxRelIds[2], NULL);
 

--- a/src/backend/utils/cache/relcache.c
+++ b/src/backend/utils/cache/relcache.c
@@ -309,7 +309,7 @@ static void RelationParseRelOptions(Relation relation, HeapTuple tuple);
 static void RelationBuildTupleDesc(Relation relation);
 static Relation RelationBuildDesc(Oid targetRelId, bool insertIt);
 static void RelationInitPhysicalAddr(Relation relation);
-//static void RelationInitAppendOnlyInfo(Relation relation);
+static void RelationInitAppendOnlyInfo(Relation relation);
 static void load_critical_index(Oid indexoid, Oid heapoid);
 static TupleDesc GetPgClassDescriptor(void);
 static TupleDesc GetPgIndexDescriptor(void);
@@ -1291,6 +1291,12 @@ retry:
 			break;
 	}
 
+	/*
+	 * If it's an append-only table, get information from pg_appendonly.
+	 */
+	if (RelationIsAppendOptimized(relation))
+		RelationInitAppendOnlyInfo(relation);
+
 	/* extract reloptions if any */
 	RelationParseRelOptions(relation, pg_class_tuple);
 
@@ -2087,6 +2093,43 @@ formrdesc(const char *relationName, Oid relationReltype,
 	relation->rd_isvalid = true;
 }
 
+static void
+RelationInitAppendOnlyInfo(Relation relation)
+{
+	Relation	pg_appendonly_rel;
+	HeapTuple	tuple;
+	MemoryContext oldcontext;
+	SysScanDesc scan;
+	ScanKeyData skey;
+
+	/*
+	 * Check the pg_appendonly relation to be certain the ao table
+	 * is there.
+	 */
+	pg_appendonly_rel = heap_open(AppendOnlyRelationId, AccessShareLock);
+
+	ScanKeyInit(&skey,
+				Anum_pg_appendonly_relid,
+				BTEqualStrategyNumber, F_OIDEQ,
+				ObjectIdGetDatum(RelationGetRelid(relation)));
+	scan = systable_beginscan(pg_appendonly_rel, AppendOnlyRelidIndexId, true,
+							  NULL, 1, &skey);
+
+	tuple = systable_getnext(scan);
+	if (!tuple)
+		elog(ERROR, "could not find pg_appendonly tuple for relation \"%s\"",
+			 RelationGetRelationName(relation));
+
+	/*
+	 * Make a copy of the pg_appendonly entry for the table.
+	 */
+	oldcontext = MemoryContextSwitchTo(CacheMemoryContext);
+	relation->rd_aotuple = heap_copytuple(tuple);
+	relation->rd_appendonly = (Form_pg_appendonly) GETSTRUCT(relation->rd_aotuple);
+	MemoryContextSwitchTo(oldcontext);
+	systable_endscan(scan);
+	heap_close(pg_appendonly_rel, AccessShareLock);
+}
 
 /* ----------------------------------------------------------------
  *				 Relation Descriptor Lookup Interface
@@ -2498,6 +2541,8 @@ RelationDestroyRelation(Relation relation, bool remember_tupdesc)
 		pfree(relation->rd_options);
 	if (relation->rd_indextuple)
 		pfree(relation->rd_indextuple);
+	if (relation->rd_aotuple)
+		pfree(relation->rd_aotuple);
 	if (relation->rd_amcache)
 		pfree(relation->rd_amcache);
 	if (relation->rd_fdwroutine)

--- a/src/include/catalog/pg_appendonly.h
+++ b/src/include/catalog/pg_appendonly.h
@@ -118,8 +118,7 @@ GetAppendOnlyEntryAttributes(Oid relid,
  * not NULL.
  */
 void
-GetAppendOnlyEntryAuxOids(Oid relid,
-						  Snapshot appendOnlyMetaDataSnapshot,
+GetAppendOnlyEntryAuxOids(Relation rel,
 						  Oid *segrelid,
 						  Oid *blkdirrelid,
 						  Oid *blkdiridxid,
@@ -128,7 +127,7 @@ GetAppendOnlyEntryAuxOids(Oid relid,
 
 
 void
-GetAppendOnlyEntry(Oid relid, Form_pg_appendonly aoEntry);
+GetAppendOnlyEntry(Relation rel, Form_pg_appendonly aoEntry);
 /*
  * Update the segrelid and/or blkdirrelid if the input new values
  * are valid OIDs.

--- a/src/include/utils/rel.h
+++ b/src/include/utils/rel.h
@@ -192,6 +192,12 @@ typedef struct RelationData
 	void	   *rd_amcache;		/* available for use by index/table AM */
 
 	/*
+	 * AO table support info (used only for AO and AOCS relations)
+	 */
+	Form_pg_appendonly rd_appendonly;
+	struct HeapTupleData *rd_aotuple;		/* all of pg_appendonly tuple */
+
+	/*
 	 * foreign-table support
 	 *
 	 * rd_fdwroutine must point to a single memory chunk palloc'd in


### PR DESCRIPTION
We used to have the pg_appendonly row for the AO/CO table stored in its relcache entry, but that somehow got lost during the PG12 merge (it is still in 6X). Now bringing it back, and utilize it wherever possible.

This commit basically does similar thing as ef92bcf151f99c9152a10c8750eee0d4dde39bc1. But due to a lot of changes in the code base and also we don't need other changes in that commit, we are not cherrypicking it directly.

Relation with https://github.com/greenplum-db/gpdb/pull/14970: both have similar purpose which is to speed up pg_appendonly lookup. For most of our current needs, relcache is probably better because we often already hold the Relation reference to the AO table, so we just need a pointer dereference instead of searching in syscache. But syscache would still be useful in some cases because (1) sometimes we don't want to open the AO table, and (2) if someday we want to lookup by other pg_appendonly columns (e.g. segrelid), we can only do that easily via syscache.

dev pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/ao-aux-opt

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
