### PR TITLE
Add ifdef for fault injector call in cdbappendonlystorageread.c

### DIFF
--- a/src/backend/cdb/cdbappendonlystorageread.c
+++ b/src/backend/cdb/cdbappendonlystorageread.c
@@ -914,7 +914,9 @@ AppendOnlyStorageRead_ReadNextBlock(AppendOnlyStorageRead *storageRead)
 		/* UNDONE: Finish the read for the information only header. */
 	}
 
+#ifdef FAULT_INJECTOR
 	FaultInjector_InjectFaultIfSet("AppendOnlyStorageRead_ReadNextBlock_success", DDLNotSpecified, "", storageRead->relationName);
+#endif
 
 	return true;
 }


### PR DESCRIPTION
https://github.com/greenplum-db/gpdb/commit/bfe180def82d7ed14d3817feb0304d955c3a7ddf neglected to add an `#ifdef FAULT_INJECTOR` guard when change from `SIMPLE_FAULT_INJECTOR` macro to `FaultInjector_InjectFaultIfSet` function, causing non-assert enabled builds to fail to compile.