### PR TITLE
Use partition key opclass to get equality operator for PARTITION BY LIST

### DIFF
--- a/src/backend/utils/cache/lsyscache.c
+++ b/src/backend/utils/cache/lsyscache.c
@@ -1292,6 +1292,29 @@ get_opname(Oid opno)
 }
 
 /*
+ * get_opnamespace
+ *	  returns the oid of the operator namespace with the given opno
+ */
+Oid
+get_opnamespace(Oid opno)
+{
+	HeapTuple	tp;
+
+	tp = SearchSysCache1(OPEROID, ObjectIdGetDatum(opno));
+	if (HeapTupleIsValid(tp))
+	{
+		Form_pg_operator optup = (Form_pg_operator) GETSTRUCT(tp);
+		Oid result;
+
+		result = optup->oprnamespace;
+		ReleaseSysCache(tp);
+		return result;
+	}
+	else
+		return InvalidOid;
+}
+
+/*
  * op_input_types
  *
  *		Returns the left and right input datatypes for an operator

--- a/src/include/utils/lsyscache.h
+++ b/src/include/utils/lsyscache.h
@@ -120,6 +120,7 @@ extern Oid	get_opclass_family(Oid opclass);
 extern Oid	get_opclass_input_type(Oid opclass);
 extern RegProcedure get_opcode(Oid opno);
 extern char *get_opname(Oid opno);
+extern Oid	get_opnamespace(Oid opno);
 extern void op_input_types(Oid opno, Oid *lefttype, Oid *righttype);
 extern bool op_mergejoinable(Oid opno, Oid inputtype);
 extern bool op_hashjoinable(Oid opno, Oid inputtype);

--- a/src/test/regress/expected/partition.out
+++ b/src/test/regress/expected/partition.out
@@ -1,3 +1,7 @@
+-- start_matchsubs
+-- m/ERROR:  missing operator 3\(\d+,\d+\) in opfamily \d+ \(parse_partition.c:\d+\)/
+-- s/ERROR:  missing operator 3\(\d+,\d+\) in opfamily \d+ \(parse_partition.c:\d+\)/ERROR:  missing operator 3(XX,XX) in opfamily XX (parse_partition.c:XX)/
+-- end_matchsubs
 drop table if exists d;
 drop table if exists c;
 drop table if exists b;
@@ -9288,3 +9292,48 @@ drop cascades to table part_op_test.issue_14941_range_part
 drop cascades to table part_op_test.issue_14941_list_part
 drop cascades to table part_op_test.issue_14941_multi_level_part
 drop cascades to table part_op_test.issue_14941_multi_level_multi_key_part
+-- Test that we can list partition by a custom type where its equality
+-- operator is in a different schema.
+CREATE TYPE equal_operator_not_in_search_path_type AS (a int, b int);
+CREATE FUNCTION equal_operator_not_in_search_path_func (equal_operator_not_in_search_path_type, equal_operator_not_in_search_path_type) RETURNS boolean
+  AS 'SELECT $1.a = $2.a;'
+  LANGUAGE SQL IMMUTABLE
+  RETURNS NULL ON NULL INPUT;
+CREATE FUNCTION less_than_operator_not_in_search_path_func (equal_operator_not_in_search_path_type, equal_operator_not_in_search_path_type) RETURNS boolean
+  AS 'SELECT $1.a < $2.a;'
+  LANGUAGE SQL IMMUTABLE
+  RETURNS NULL ON NULL INPUT;
+CREATE SCHEMA equal_operator_not_in_search_path_schema;
+CREATE OPERATOR equal_operator_not_in_search_path_schema.= (
+        LEFTARG = equal_operator_not_in_search_path_type,
+        RIGHTARG = equal_operator_not_in_search_path_type,
+        PROCEDURE = equal_operator_not_in_search_path_func
+);
+CREATE OPERATOR equal_operator_not_in_search_path_schema.< (
+        LEFTARG = equal_operator_not_in_search_path_type,
+        RIGHTARG = equal_operator_not_in_search_path_type,
+        PROCEDURE = less_than_operator_not_in_search_path_func
+);
+CREATE OPERATOR CLASS equal_operator_not_in_search_path_opclass
+  DEFAULT FOR TYPE equal_operator_not_in_search_path_type
+  USING btree AS
+  OPERATOR 1 equal_operator_not_in_search_path_schema.<;
+-- this should fail because no equality operator is found for the opclass
+CREATE TABLE equal_operator_not_in_search_path_table (a int, b equal_operator_not_in_search_path_type)
+DISTRIBUTED BY (a) PARTITION BY LIST(b)
+(
+  PARTITION part1 VALUES('(1,1)')
+);
+ERROR:  missing operator 3(XX,XX) in opfamily XX (parse_partition.c:XX)
+ALTER OPERATOR FAMILY equal_operator_not_in_search_path_opclass USING btree ADD
+  OPERATOR 3 equal_operator_not_in_search_path_schema.= (equal_operator_not_in_search_path_type, equal_operator_not_in_search_path_type);
+CREATE TABLE equal_operator_not_in_search_path_table (a int, b equal_operator_not_in_search_path_type)
+DISTRIBUTED BY (a) PARTITION BY LIST(b)
+(
+  PARTITION part1 VALUES('(1,1)')
+);
+CREATE TABLE equal_operator_not_in_search_path_table_multi_key (a int, b equal_operator_not_in_search_path_type, c int)
+DISTRIBUTED BY (a) PARTITION BY LIST(b, c)
+(
+  PARTITION part1 VALUES(('(1,1)', 1))
+);

--- a/src/test/regress/expected/partition_optimizer.out
+++ b/src/test/regress/expected/partition_optimizer.out
@@ -1,3 +1,7 @@
+-- start_matchsubs
+-- m/ERROR:  missing operator 3\(\d+,\d+\) in opfamily \d+ \(parse_partition.c:\d+\)/
+-- s/ERROR:  missing operator 3\(\d+,\d+\) in opfamily \d+ \(parse_partition.c:\d+\)/ERROR:  missing operator 3(XX,XX) in opfamily XX (parse_partition.c:XX)/
+-- end_matchsubs
 drop table if exists d;
 NOTICE:  table "d" does not exist, skipping
 drop table if exists c;
@@ -9206,3 +9210,48 @@ drop cascades to table part_op_test.issue_14941_range_part
 drop cascades to table part_op_test.issue_14941_list_part
 drop cascades to table part_op_test.issue_14941_multi_level_part
 drop cascades to table part_op_test.issue_14941_multi_level_multi_key_part
+-- Test that we can list partition by a custom type where its equality
+-- operator is in a different schema.
+CREATE TYPE equal_operator_not_in_search_path_type AS (a int, b int);
+CREATE FUNCTION equal_operator_not_in_search_path_func (equal_operator_not_in_search_path_type, equal_operator_not_in_search_path_type) RETURNS boolean
+  AS 'SELECT $1.a = $2.a;'
+  LANGUAGE SQL IMMUTABLE
+  RETURNS NULL ON NULL INPUT;
+CREATE FUNCTION less_than_operator_not_in_search_path_func (equal_operator_not_in_search_path_type, equal_operator_not_in_search_path_type) RETURNS boolean
+  AS 'SELECT $1.a < $2.a;'
+  LANGUAGE SQL IMMUTABLE
+  RETURNS NULL ON NULL INPUT;
+CREATE SCHEMA equal_operator_not_in_search_path_schema;
+CREATE OPERATOR equal_operator_not_in_search_path_schema.= (
+        LEFTARG = equal_operator_not_in_search_path_type,
+        RIGHTARG = equal_operator_not_in_search_path_type,
+        PROCEDURE = equal_operator_not_in_search_path_func
+);
+CREATE OPERATOR equal_operator_not_in_search_path_schema.< (
+        LEFTARG = equal_operator_not_in_search_path_type,
+        RIGHTARG = equal_operator_not_in_search_path_type,
+        PROCEDURE = less_than_operator_not_in_search_path_func
+);
+CREATE OPERATOR CLASS equal_operator_not_in_search_path_opclass
+  DEFAULT FOR TYPE equal_operator_not_in_search_path_type
+  USING btree AS
+  OPERATOR 1 equal_operator_not_in_search_path_schema.<;
+-- this should fail because no equality operator is found for the opclass
+CREATE TABLE equal_operator_not_in_search_path_table (a int, b equal_operator_not_in_search_path_type)
+DISTRIBUTED BY (a) PARTITION BY LIST(b)
+(
+  PARTITION part1 VALUES('(1,1)')
+);
+ERROR:  missing operator 3(XX,XX) in opfamily XX (parse_partition.c:XX)
+ALTER OPERATOR FAMILY equal_operator_not_in_search_path_opclass USING btree ADD
+  OPERATOR 3 equal_operator_not_in_search_path_schema.= (equal_operator_not_in_search_path_type, equal_operator_not_in_search_path_type);
+CREATE TABLE equal_operator_not_in_search_path_table (a int, b equal_operator_not_in_search_path_type)
+DISTRIBUTED BY (a) PARTITION BY LIST(b)
+(
+  PARTITION part1 VALUES('(1,1)')
+);
+CREATE TABLE equal_operator_not_in_search_path_table_multi_key (a int, b equal_operator_not_in_search_path_type, c int)
+DISTRIBUTED BY (a) PARTITION BY LIST(b, c)
+(
+  PARTITION part1 VALUES(('(1,1)', 1))
+);

--- a/src/test/regress/sql/partition.sql
+++ b/src/test/regress/sql/partition.sql
@@ -1,3 +1,7 @@
+-- start_matchsubs
+-- m/ERROR:  missing operator 3\(\d+,\d+\) in opfamily \d+ \(parse_partition.c:\d+\)/
+-- s/ERROR:  missing operator 3\(\d+,\d+\) in opfamily \d+ \(parse_partition.c:\d+\)/ERROR:  missing operator 3(XX,XX) in opfamily XX (parse_partition.c:XX)/
+-- end_matchsubs
 
 drop table if exists d;
 drop table if exists c;
@@ -4389,3 +4393,54 @@ explain (costs off) select * from part_op_test.issue_14941_multi_level_multi_key
 
 reset search_path;
 drop schema part_op_test cascade;
+
+-- Test that we can list partition by a custom type where its equality
+-- operator is in a different schema.
+CREATE TYPE equal_operator_not_in_search_path_type AS (a int, b int);
+CREATE FUNCTION equal_operator_not_in_search_path_func (equal_operator_not_in_search_path_type, equal_operator_not_in_search_path_type) RETURNS boolean
+  AS 'SELECT $1.a = $2.a;'
+  LANGUAGE SQL IMMUTABLE
+  RETURNS NULL ON NULL INPUT;
+CREATE FUNCTION less_than_operator_not_in_search_path_func (equal_operator_not_in_search_path_type, equal_operator_not_in_search_path_type) RETURNS boolean
+  AS 'SELECT $1.a < $2.a;'
+  LANGUAGE SQL IMMUTABLE
+  RETURNS NULL ON NULL INPUT;
+
+CREATE SCHEMA equal_operator_not_in_search_path_schema;
+CREATE OPERATOR equal_operator_not_in_search_path_schema.= (
+        LEFTARG = equal_operator_not_in_search_path_type,
+        RIGHTARG = equal_operator_not_in_search_path_type,
+        PROCEDURE = equal_operator_not_in_search_path_func
+);
+CREATE OPERATOR equal_operator_not_in_search_path_schema.< (
+        LEFTARG = equal_operator_not_in_search_path_type,
+        RIGHTARG = equal_operator_not_in_search_path_type,
+        PROCEDURE = less_than_operator_not_in_search_path_func
+);
+
+CREATE OPERATOR CLASS equal_operator_not_in_search_path_opclass
+  DEFAULT FOR TYPE equal_operator_not_in_search_path_type
+  USING btree AS
+  OPERATOR 1 equal_operator_not_in_search_path_schema.<;
+
+-- this should fail because no equality operator is found for the opclass
+CREATE TABLE equal_operator_not_in_search_path_table (a int, b equal_operator_not_in_search_path_type)
+DISTRIBUTED BY (a) PARTITION BY LIST(b)
+(
+  PARTITION part1 VALUES('(1,1)')
+);
+
+ALTER OPERATOR FAMILY equal_operator_not_in_search_path_opclass USING btree ADD
+  OPERATOR 3 equal_operator_not_in_search_path_schema.= (equal_operator_not_in_search_path_type, equal_operator_not_in_search_path_type);
+
+CREATE TABLE equal_operator_not_in_search_path_table (a int, b equal_operator_not_in_search_path_type)
+DISTRIBUTED BY (a) PARTITION BY LIST(b)
+(
+  PARTITION part1 VALUES('(1,1)')
+);
+
+CREATE TABLE equal_operator_not_in_search_path_table_multi_key (a int, b equal_operator_not_in_search_path_type, c int)
+DISTRIBUTED BY (a) PARTITION BY LIST(b, c)
+(
+  PARTITION part1 VALUES(('(1,1)', 1))
+);


### PR DESCRIPTION
When partitioning by list, the PARTITION BY transformation makes a partition rule where each partition key uses an equality operator "=" that is not schema-qualified. Later on in the CREATE TABLE logic during type coercion, it tries to look up the equality operator by going through OprCacheHash which requires a hash key that contains the search_path to look in. This works for general cases but not for when the partition key is a custom type and its equality operator is in a schema that is not in the session's search_path (nor default pg_catalog). Things are even worse when dealing with pg_restore (and in relation pg_upgrade) where the search_path is always set to blank at the beginning of the SQL restore so even custom operators created in the public schema would have issues.

To fix the issue, we simply need to fully-qualify the operator name with its actual namespace name during PARTITION BY transformation so that the OprCacheKey used later on will explicitly set the search_path to the actual operator namespace.

Fixes https://github.com/greenplum-db/gpdb/issues/9405.