### PR TITLE
Add magic number field in the ICProxyPkt

### DIFF
--- a/src/backend/cdb/motion/ic_proxy_backend.c
+++ b/src/backend/cdb/motion/ic_proxy_backend.c
@@ -180,6 +180,16 @@ ic_proxy_backend_on_read_hello_ack(uv_stream_t *stream, ssize_t nread, const uv_
 
 	/* we have received a complete HELLO ACK message */
 	pkt = (ICProxyPkt *)backend->buffer;
+
+	/* sanity check: drop the packet with incorrect magic number */
+	if (!ic_proxy_pkt_is_valid(pkt))
+	{
+		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG1,
+			"ic-proxy: backend %s: received %s, dropping the invalid package (magic number mismatch)",
+					ic_proxy_key_to_str(&backend->key), ic_proxy_pkt_to_str(pkt));
+		return;
+	}
+
 	Assert(ic_proxy_pkt_is(pkt, IC_PROXY_MESSAGE_HELLO_ACK));
 	uv_read_stop(stream);
 

--- a/src/backend/cdb/motion/ic_proxy_backend.c
+++ b/src/backend/cdb/motion/ic_proxy_backend.c
@@ -181,6 +181,8 @@ ic_proxy_backend_on_read_hello_ack(uv_stream_t *stream, ssize_t nread, const uv_
 	/* we have received a complete HELLO ACK message */
 	pkt = (ICProxyPkt *)backend->buffer;
 
+	uv_read_stop(stream);
+
 	/* sanity check: drop the packet with incorrect magic number */
 	if (!ic_proxy_pkt_is_valid(pkt))
 	{
@@ -191,7 +193,6 @@ ic_proxy_backend_on_read_hello_ack(uv_stream_t *stream, ssize_t nread, const uv_
 	}
 
 	Assert(ic_proxy_pkt_is(pkt, IC_PROXY_MESSAGE_HELLO_ACK));
-	uv_read_stop(stream);
 
 	/* assign connection fd after domain socket successfully connected */
 	ret = uv_fileno((uv_handle_t *)&backend->pipe, &backend->conn->sockfd);

--- a/src/backend/cdb/motion/ic_proxy_client.c
+++ b/src/backend/cdb/motion/ic_proxy_client.c
@@ -661,6 +661,9 @@ ic_proxy_client_on_hello_pkt(void *opaque, const void *data, uint16 size)
 	ICProxyKey	key;
 	ICProxyPkt *ackpkt;
 
+	/* we only expect one HELLO message */
+	uv_read_stop((uv_stream_t *) &client->pipe);
+
 	/* sanity check: drop the packet with incorrect magic number */
 	if (!ic_proxy_pkt_is_valid(pkt))
 	{
@@ -669,9 +672,6 @@ ic_proxy_client_on_hello_pkt(void *opaque, const void *data, uint16 size)
 					ic_proxy_client_get_name(client), ic_proxy_pkt_to_str(pkt));
 		return;
 	}
-
-	/* we only expect one HELLO message */
-	uv_read_stop((uv_stream_t *) &client->pipe);
 
 	if (!ic_proxy_pkt_is(pkt, IC_PROXY_MESSAGE_HELLO))
 	{

--- a/src/backend/cdb/motion/ic_proxy_client.c
+++ b/src/backend/cdb/motion/ic_proxy_client.c
@@ -661,6 +661,15 @@ ic_proxy_client_on_hello_pkt(void *opaque, const void *data, uint16 size)
 	ICProxyKey	key;
 	ICProxyPkt *ackpkt;
 
+	/* sanity check: drop the packet with incorrect magic number */
+	if (!ic_proxy_pkt_is_valid(pkt))
+	{
+		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG1,
+			"ic-proxy: %s: received %s, dropping the invalid package (magic number mismatch)",
+					ic_proxy_client_get_name(client), ic_proxy_pkt_to_str(pkt));
+		return;
+	}
+
 	/* we only expect one HELLO message */
 	uv_read_stop((uv_stream_t *) &client->pipe);
 
@@ -1178,6 +1187,15 @@ void
 ic_proxy_client_on_p2c_data(ICProxyClient *client, ICProxyPkt *pkt,
 							ic_proxy_sent_cb callback, void *opaque)
 {
+	/* sanity check: drop the packet with incorrect magic number */
+	if (!ic_proxy_pkt_is_valid(pkt))
+	{
+		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG1,
+			"ic-proxy: %s: received %s, dropping the invalid package (magic number mismatch)",
+					ic_proxy_client_get_name(client), ic_proxy_pkt_to_str(pkt));
+		return;
+	}
+
 	/* A placeholder does not send any packets, it always cache them */
 	if (client->state & IC_PROXY_CLIENT_STATE_PLACEHOLDER)
 	{
@@ -1257,6 +1275,8 @@ ic_proxy_client_cache_p2c_pkt(ICProxyClient *client, ICProxyPkt *pkt)
 {
 	/* TODO: drop out-of-date pkt directly */
 	/* TODO: verify the pkt is to client */
+
+	Assert(ic_proxy_pkt_is_valid(pkt));
 
 	client->pkts = lappend(client->pkts, pkt);
 

--- a/src/backend/cdb/motion/ic_proxy_iobuf.c
+++ b/src/backend/cdb/motion/ic_proxy_iobuf.c
@@ -151,13 +151,14 @@ ic_proxy_ibuf_push(ICProxyIBuf *ibuf,
 			/* have a complete header now */
 
 			packet_size = ibuf->get_packet_size(ibuf->buf);
-			delta = Min(packet_size - ibuf->len, size);
-
-			memcpy(ibuf->buf + ibuf->len, data, delta);
-			ibuf->len += delta;
-			data += delta;
-			size -= delta;
-
+			if (packet_size > ibuf->len)
+			{
+				delta = Min(packet_size - ibuf->len, size);
+				memcpy(ibuf->buf + ibuf->len, data, delta);
+				ibuf->len += delta;
+				data += delta;
+				size -= delta;
+			}
 			if (ibuf->len < packet_size)
 				/* still not having a complete packet */
 				return;
@@ -175,7 +176,7 @@ ic_proxy_ibuf_push(ICProxyIBuf *ibuf,
 	{
 		packet_size = ibuf->get_packet_size(data);
 
-		if (packet_size <= size)
+		if (packet_size > 0 && packet_size <= size)
 		{
 			/* got a complete pkt */
 			callback(opaque, data, packet_size);

--- a/src/backend/cdb/motion/ic_proxy_packet.c
+++ b/src/backend/cdb/motion/ic_proxy_packet.c
@@ -82,6 +82,7 @@ void
 ic_proxy_message_init(ICProxyPkt *pkt, ICProxyMessageType type,
 					  const ICProxyKey *key)
 {
+	pkt->magicNumber = IC_PROXY_PKT_MAGIC_NUMBER;
 	pkt->type = type;
 	pkt->len = sizeof(*pkt);
 
@@ -156,13 +157,14 @@ ic_proxy_pkt_to_str(const ICProxyPkt *pkt)
 	static char	buf[256];
 
 	snprintf(buf, sizeof(buf),
-			 "%s [con%d,cmd%d,slice[%hd->%hd] %hu bytes seg%hd:dbid%hu:p%d->seg%hd:dbid%hu:p%d]",
+			 "%s [con%d,cmd%d,slice[%hd->%hd] %hu bytes seg%hd:dbid%hu:p%d->seg%hd:dbid%hu:p%d magic%u]",
 			 ic_proxy_message_type_to_str(pkt->type),
 			 pkt->sessionId, pkt->commandId,
 			 pkt->sendSliceIndex, pkt->recvSliceIndex,
 			 pkt->len,
 			 pkt->srcContentId, pkt->srcDbid, pkt->srcPid,
-			 pkt->dstContentId, pkt->dstDbid, pkt->dstPid);
+			 pkt->dstContentId, pkt->dstDbid, pkt->dstPid,
+			 pkt->magicNumber);
 
 	return buf;
 }

--- a/src/backend/cdb/motion/ic_proxy_packet.h
+++ b/src/backend/cdb/motion/ic_proxy_packet.h
@@ -22,6 +22,7 @@ typedef struct ICProxyPkt ICProxyPkt;
 #include "ic_proxy_key.h"
 
 #define IC_PROXY_MAX_PKT_SIZE (Gp_max_packet_size + sizeof(ICProxyPkt))
+#define IC_PROXY_PKT_MAGIC_NUMBER (0xBADDCAFE)
 
 typedef enum
 {
@@ -41,6 +42,9 @@ typedef enum
 
 struct ICProxyPkt
 {
+	/* for the sanity check of package */
+	uint32		magicNumber;
+
 	uint16		len;
 	uint16		type;
 
@@ -95,6 +99,14 @@ ic_proxy_pkt_is(const ICProxyPkt *pkt, ICProxyMessageType type)
 
 	/* then check the message type on demand */
 	return type == pkt->type;
+}
+
+/* check the validity of a package by magicNumber */
+static inline bool
+ic_proxy_pkt_is_valid(const ICProxyPkt *pkt)
+{
+	Assert(pkt);
+	return pkt->magicNumber == IC_PROXY_PKT_MAGIC_NUMBER;
 }
 
 #endif   /* IC_PROXY_PACKET_H */

--- a/src/backend/cdb/motion/ic_proxy_peer.c
+++ b/src/backend/cdb/motion/ic_proxy_peer.c
@@ -290,6 +290,15 @@ ic_proxy_peer_on_data_pkt(void *opaque, const void *data, uint16 size)
 	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG5,
 		   "ic-proxy: %s: received %s", peer->name, ic_proxy_pkt_to_str(pkt));
 
+	/* sanity check: drop the packet with incorrect magic number */
+	if (!ic_proxy_pkt_is_valid(pkt))
+	{
+		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG1,
+			"ic-proxy: %s: received %s, dropping the invalid package (magic number mismatch)",
+					peer->name, ic_proxy_pkt_to_str(pkt));
+		return;
+	}
+
 	if (!(peer->state & IC_PROXY_PEER_STATE_READY_FOR_DATA))
 	{
 		elog(WARNING, "ic-proxy: %s: not ready to receive DATA yet: %s",
@@ -529,6 +538,15 @@ ic_proxy_peer_on_hello_pkt(void *opaque, const void *data, uint16 size)
 	ICProxyPeer *peer = opaque;
 	ICProxyKey	key;
 
+	/* sanity check: drop the packet with incorrect magic number */
+	if (!ic_proxy_pkt_is_valid(pkt))
+	{
+		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG1,
+			"ic-proxy: %s: received %s, dropping the invalid package (magic number mismatch)",
+					peer->name, ic_proxy_pkt_to_str(pkt));
+		return;
+	}
+
 	/* we only expect one hello message */
 	uv_read_stop((uv_stream_t *) &peer->tcp);
 
@@ -635,6 +653,15 @@ ic_proxy_peer_on_hello_ack_pkt(void *opaque, const void *data, uint16 size)
 	if (size < sizeof(*pkt) || size != pkt->len)
 		elog(ERROR, "ic-proxy: %s: received incomplete HELLO ACK: size = %d",
 					 peer->name, size);
+
+	/* sanity check: drop the packet with incorrect magic number */
+	if (!ic_proxy_pkt_is_valid(pkt))
+	{
+		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG1,
+			"ic-proxy: %s: received %s, dropping the invalid package (magic number mismatch)",
+					peer->name, ic_proxy_pkt_to_str(pkt));
+		return;
+	}
 
 	if (peer->state & IC_PROXY_PEER_STATE_RECEIVED_HELLO_ACK)
 	{

--- a/src/backend/cdb/motion/ic_proxy_router.c
+++ b/src/backend/cdb/motion/ic_proxy_router.c
@@ -202,6 +202,7 @@ void
 ic_proxy_router_route(uv_loop_t *loop, ICProxyPkt *pkt,
 					  ic_proxy_sent_cb callback, void *opaque)
 {
+	Assert(ic_proxy_pkt_is_valid(pkt));
 	if (pkt->dstDbid == pkt->srcDbid)
 	{
 		/*
@@ -253,6 +254,8 @@ ic_proxy_router_on_write(uv_write_t *req, int status)
 {
 	ICProxyWriteReq *wreq = (ICProxyWriteReq *) req;
 	ICProxyPkt *pkt = req->data;
+
+	Assert(ic_proxy_pkt_is_valid(pkt));
 
 	if (status < 0)
 	{

--- a/src/test/isolation2/expected/ic_proxy_socket.out
+++ b/src/test/isolation2/expected/ic_proxy_socket.out
@@ -16,7 +16,7 @@ CREATE
 -----------------------
                        
 (1 row)
--- the query hang here before adding magic number field in the ICProxyPkt
+-- the query hung here before the commit adding the magic number field in the ICProxyPkt
 -- reason: random bytes cause icproxy OOM or hang forever
 1: SET statement_timeout = 10000;
 SET

--- a/src/test/isolation2/expected/ic_proxy_socket.out
+++ b/src/test/isolation2/expected/ic_proxy_socket.out
@@ -1,0 +1,32 @@
+-- test invalid connection request (random bytes) to ic proxy:
+-- it should be dropped due to mismatch magic number
+
+CREATE OR REPLACE LANGUAGE plpythonu;
+CREATE
+
+CREATE or REPLACE FUNCTION send_bytes_to_icproxy() RETURNS VOID as $$ import socket, struct 
+# parse host and port from gp_interconnect_proxy_addresses icproxy_host = "" icproxy_port = -1 try: res = plpy.execute("show gp_interconnect_type;", 1) if res[0]["gp_interconnect_type"] == "proxy": res = plpy.execute("show gp_interconnect_proxy_addresses;", 1) addrs = res[0]["gp_interconnect_proxy_addresses"] addr = addrs.split(",")[1] icproxy_host = addr.split(":")[2] icproxy_port = int(addr.split(":")[3]) except: # not working on icproxy mode, just return icproxy_host = "" pass if icproxy_host == "": plpy.info("no need to send request") return 
+ranstr="fSSAtMbxAzOhkTcpPwvXQq9Y45vfnTiOdo3Mk9V8QKLKWyd8SHBI59FsDRLWFqMZkFpwosqZEIkua3YfR4C8GZ6n6J4SEYCJcdamjhg2e9e1Ns7kNnnUa7OeRyKSEhIANBfau3tsT1SIR4LnXXOAxMBWJkBLtMDKHQyljfa7iQKa1H0bLBP3gOqX8jshoLE7lksNsvmngfpsGtBmKswFNwdLxR1SiMU7kDfU6gCtmLVbCScImf5AVLMosFExTmX3QdiExuuwST6mNZKS7ZdTzsaKbOSy00EWerm39vW8g305H1jrRNSNZvpRkkE2Hv3Abe9ilXZ5hNsWe0DN1i884iPDmxX0B8T8l3SL4P2NInMmcpuQCNVc4ivE7KgLkFafsKrs1igvyRjLraJcjgk88BOkMoVxSE8plK8JoQGDJylg80WFlPBfgm4vjQjRuh8E9MF0M2Ws5GKiDxQ8RcoEEvmHS6ef76kFjai0A10PRkrOPXjNaCJD7jdRPFjkbr3EyhMGNOKMJxXLaUtzuDpz0Ivc0bH9SXffughI61rzChnt71dS15rpTHm6RHodlkwUHfY0H21I3F2uj7qELJR1kb8A5rfYDf0yv8pyDpCeTxT9WjaDlP1DPT74kXZEuIcIfX2H7RvSR89n3W2DJbdgXD9WSz3DknotAzWdY1iNe7qP6hwGJLkxx0ICBD9JaanCwlL4whB1DmtfZqFARsatXPcgVQIYKquJepNoVdVTwSYTb6XBLEGFTn4S6lJXkpyOB9M6egiYIvMYt1HHgDANFmXLslpB3TIYgc3kgGZ2SKI3sjuYghv0TODOLzFZoH9OuLnDkQVXk4a17xpRgl8pal6geryP6sPGA8XHpi0a6gdnqmGiaTQY84EHeykTcgR6K37UVZm9u8Go1xyjqnHjUtcb0BVZg5uY7MUd6ciMAbvXKh837oNpsbkC27qfPawd3W9Bz0aUhxB9st3EksZSmv6b8sRTyEBOT5zwMP7A" # send the random bytes s = socket.socket(socket.AF_INET, socket.SOCK_STREAM) s.connect((icproxy_host, icproxy_port)) val = struct.pack('!i', 134591) # an invalid magic number s.send(val) message = ranstr.encode('utf-8') val = struct.pack('!i', len(message)) s.send(val) s.sendall(message) s.close() plpy.info("sent request") $$ LANGUAGE plpythonu EXECUTE ON MASTER;
+CREATE
+
+1: create table PR_14998(i int);
+CREATE
+1: SELECT send_bytes_to_icproxy();
+ send_bytes_to_icproxy 
+-----------------------
+                       
+(1 row)
+-- the query hang here before adding magic number field in the ICProxyPkt
+-- reason: random bytes cause icproxy OOM or hang forever
+1: SET statement_timeout = 10000;
+SET
+1: select count(*) from PR_14998;
+ count 
+-------
+ 0     
+(1 row)
+1: RESET statement_timeout;
+RESET
+1: drop table PR_14998;
+DROP
+1q: ... <quitting>

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -312,6 +312,10 @@ test: export_distributed_snapshot
 # gp_interconnect_address_type='unicast'
 test: motion_socket
 
+# test invalid connection to ic proxy when
+# gp_interconnect_type='proxy'
+test: ic_proxy_socket
+
 # test alter owner of partition table in utility mode
 test: alter_partition_table_owner
 

--- a/src/test/isolation2/sql/ic_proxy_socket.sql
+++ b/src/test/isolation2/sql/ic_proxy_socket.sql
@@ -42,7 +42,7 @@ $$ LANGUAGE plpythonu EXECUTE ON MASTER;
 
 1: create table PR_14998(i int);
 1: SELECT send_bytes_to_icproxy();
--- the query hang here before adding magic number field in the ICProxyPkt
+-- the query hung here before the commit adding the magic number field in the ICProxyPkt
 -- reason: random bytes cause icproxy OOM or hang forever
 1: SET statement_timeout = 10000;
 1: select count(*) from PR_14998;

--- a/src/test/isolation2/sql/ic_proxy_socket.sql
+++ b/src/test/isolation2/sql/ic_proxy_socket.sql
@@ -1,0 +1,51 @@
+-- test invalid connection request (random bytes) to ic proxy:
+-- it should be dropped due to mismatch magic number
+
+CREATE OR REPLACE LANGUAGE plpythonu;
+
+CREATE or REPLACE FUNCTION send_bytes_to_icproxy()
+    RETURNS VOID as $$
+import socket, struct
+
+# parse host and port from gp_interconnect_proxy_addresses
+icproxy_host = ""
+icproxy_port = -1
+try:
+    res = plpy.execute("show gp_interconnect_type;", 1)
+    if res[0]["gp_interconnect_type"] == "proxy":
+        res = plpy.execute("show gp_interconnect_proxy_addresses;", 1)
+        addrs = res[0]["gp_interconnect_proxy_addresses"]
+        addr = addrs.split(",")[1]
+        icproxy_host = addr.split(":")[2]
+        icproxy_port = int(addr.split(":")[3])
+except:
+    # not working on icproxy mode, just return
+    icproxy_host = ""
+    pass
+if icproxy_host == "":
+    plpy.info("no need to send request")
+    return
+
+ranstr="fSSAtMbxAzOhkTcpPwvXQq9Y45vfnTiOdo3Mk9V8QKLKWyd8SHBI59FsDRLWFqMZkFpwosqZEIkua3YfR4C8GZ6n6J4SEYCJcdamjhg2e9e1Ns7kNnnUa7OeRyKSEhIANBfau3tsT1SIR4LnXXOAxMBWJkBLtMDKHQyljfa7iQKa1H0bLBP3gOqX8jshoLE7lksNsvmngfpsGtBmKswFNwdLxR1SiMU7kDfU6gCtmLVbCScImf5AVLMosFExTmX3QdiExuuwST6mNZKS7ZdTzsaKbOSy00EWerm39vW8g305H1jrRNSNZvpRkkE2Hv3Abe9ilXZ5hNsWe0DN1i884iPDmxX0B8T8l3SL4P2NInMmcpuQCNVc4ivE7KgLkFafsKrs1igvyRjLraJcjgk88BOkMoVxSE8plK8JoQGDJylg80WFlPBfgm4vjQjRuh8E9MF0M2Ws5GKiDxQ8RcoEEvmHS6ef76kFjai0A10PRkrOPXjNaCJD7jdRPFjkbr3EyhMGNOKMJxXLaUtzuDpz0Ivc0bH9SXffughI61rzChnt71dS15rpTHm6RHodlkwUHfY0H21I3F2uj7qELJR1kb8A5rfYDf0yv8pyDpCeTxT9WjaDlP1DPT74kXZEuIcIfX2H7RvSR89n3W2DJbdgXD9WSz3DknotAzWdY1iNe7qP6hwGJLkxx0ICBD9JaanCwlL4whB1DmtfZqFARsatXPcgVQIYKquJepNoVdVTwSYTb6XBLEGFTn4S6lJXkpyOB9M6egiYIvMYt1HHgDANFmXLslpB3TIYgc3kgGZ2SKI3sjuYghv0TODOLzFZoH9OuLnDkQVXk4a17xpRgl8pal6geryP6sPGA8XHpi0a6gdnqmGiaTQY84EHeykTcgR6K37UVZm9u8Go1xyjqnHjUtcb0BVZg5uY7MUd6ciMAbvXKh837oNpsbkC27qfPawd3W9Bz0aUhxB9st3EksZSmv6b8sRTyEBOT5zwMP7A"
+# send the random bytes
+s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+s.connect((icproxy_host, icproxy_port))
+val = struct.pack('!i', 134591) # an invalid magic number
+s.send(val)
+message = ranstr.encode('utf-8')
+val = struct.pack('!i', len(message))
+s.send(val)
+s.sendall(message)
+s.close()
+plpy.info("sent request")
+$$ LANGUAGE plpythonu EXECUTE ON MASTER;
+
+1: create table PR_14998(i int);
+1: SELECT send_bytes_to_icproxy();
+-- the query hang here before adding magic number field in the ICProxyPkt
+-- reason: random bytes cause icproxy OOM or hang forever
+1: SET statement_timeout = 10000;
+1: select count(*) from PR_14998;
+1: RESET statement_timeout;
+1: drop table PR_14998;
+1q:


### PR DESCRIPTION
Port from main: https://github.com/greenplum-db/gpdb/commit/57a314073a59c6ec8ab2b0dfc7ed7f578a4568d3 https://github.com/greenplum-db/gpdb/pull/14926

--------

icproxy processes communicate with each other with the public addr:port (see gp_interconnect_proxy_addresses), but no auth control here. So, any connection may connect in and send any byte, it may cause some unexpected exceptions (e.g. OOM).

In the PR, introduces a magic number field in the ICProxyPkt and does a sanity check: drop the corresponding package if magic number doesn't match.

This method does not attempt to solve all problems, but only as a simple solution to avoid internal misaccess, looks it's good enough.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
