### PR TITLE
Remove visimapidxid and blkdiridxid fields from pg_appendonly

### DIFF
--- a/src/backend/access/aocs/aocs_compaction.c
+++ b/src/backend/access/aocs/aocs_compaction.c
@@ -235,7 +235,6 @@ AOCSSegmentFileFullCompaction(Relation aorel,
 
 	AppendOnlyVisimap_Init(&visiMap,
 						   insertDesc->visimaprelid,
-						   insertDesc->visimapidxid,
 						   ShareLock,
 						   snapshot);
 

--- a/src/backend/access/aocs/aocsam.c
+++ b/src/backend/access/aocs/aocsam.c
@@ -501,7 +501,6 @@ aocs_beginscan_internal(Relation relation,
 	AOCSScanDesc	scan;
 	AttrNumber		natts;
 	Oid				visimaprelid;
-	Oid				visimapidxid;
 
 	scan = (AOCSScanDesc) palloc0(sizeof(AOCSScanDescData));
 	scan->rs_base.rs_rd = relation;
@@ -548,13 +547,12 @@ aocs_beginscan_internal(Relation relation,
 								 NULL);
 
 	GetAppendOnlyEntryAuxOids(relation,
-							  NULL, NULL, NULL,
-							  &visimaprelid, &visimapidxid);
+							  NULL, NULL,
+							  &visimaprelid);
 
 	if (scan->total_seg != 0)
 		AppendOnlyVisimap_Init(&scan->visibilityMap,
 							   visimaprelid,
-							   visimapidxid,
 							   AccessShareLock,
 							   appendOnlyMetaDataSnapshot);
 
@@ -840,8 +838,8 @@ aocs_insert_init(Relation rel, int segno, int64 num_rows)
     desc->compType = NameStr(nd);
 
     GetAppendOnlyEntryAuxOids(rel,
-                              &desc->segrelid, &desc->blkdirrelid, NULL,
-                              &desc->visimaprelid, &desc->visimapidxid);
+                              &desc->segrelid, &desc->blkdirrelid,
+                              &desc->visimaprelid);
 
 	OpenAOCSDatumStreams(desc);
 
@@ -1251,10 +1249,9 @@ aocs_fetch_init(Relation relation,
 
     bool checksum = true;
     Oid visimaprelid;
-    Oid visimapidxid;
     GetAppendOnlyEntryAuxOids(relation,
-                              &aocsFetchDesc->segrelid, NULL, NULL,
-                              &visimaprelid, &visimapidxid);
+                              &aocsFetchDesc->segrelid, NULL,
+                              &visimaprelid);
 
     GetAppendOnlyEntryAttributes(relation->rd_id,
                                  NULL,
@@ -1343,7 +1340,6 @@ aocs_fetch_init(Relation relation,
 		pfree(opts);
 	AppendOnlyVisimap_Init(&aocsFetchDesc->visibilityMap,
 						   visimaprelid,
-						   visimapidxid,
 						   AccessShareLock,
 						   appendOnlyMetaDataSnapshot);
 
@@ -1614,7 +1610,6 @@ aocs_delete_init(Relation rel)
 	 * Get the pg_appendonly information
 	 */
 	Oid visimaprelid;
-	Oid visimapidxid;
 	AOCSDeleteDesc aoDeleteDesc = palloc0(sizeof(AOCSDeleteDescData));
 
 	aoDeleteDesc->aod_rel = rel;
@@ -1622,12 +1617,11 @@ aocs_delete_init(Relation rel)
     Snapshot snapshot = GetCatalogSnapshot(InvalidOid);
 
     GetAppendOnlyEntryAuxOids(rel,
-                              NULL, NULL, NULL,
-                              &visimaprelid, &visimapidxid);
+                              NULL, NULL,
+                              &visimaprelid);
 
 	AppendOnlyVisimap_Init(&aoDeleteDesc->visibilityMap,
 						   visimaprelid,
-						   visimapidxid,
 						   RowExclusiveLock,
 						   snapshot);
 

--- a/src/backend/access/aocs/aocsam_handler.c
+++ b/src/backend/access/aocs/aocsam_handler.c
@@ -1264,8 +1264,8 @@ aoco_relation_nontransactional_truncate(Relation rel)
 	/* Also truncate the aux tables */
 	GetAppendOnlyEntryAuxOids(rel,
 	                          &aoseg_relid,
-	                          &aoblkdir_relid, NULL,
-	                          &aovisimap_relid, NULL);
+	                          &aoblkdir_relid,
+	                          &aovisimap_relid);
 
 	heap_truncate_one_relid(aoseg_relid);
 	heap_truncate_one_relid(aoblkdir_relid);
@@ -1569,7 +1569,6 @@ aoco_index_build_range_scan(Relation heapRelation,
 	List	   *tlist = NIL;
 	List	   *qual = indexInfo->ii_Predicate;
 	Oid			blkdirrelid;
-	Oid			blkidxrelid;
 	int64 		previous_blkno = -1;
 
 	/*
@@ -1614,7 +1613,7 @@ aoco_index_build_range_scan(Relation heapRelation,
 	 * If block directory is empty, it must also be built along with the index.
 	 */
 	GetAppendOnlyEntryAuxOids(heapRelation, NULL,
-							  &blkdirrelid, &blkidxrelid, NULL, NULL);
+							  &blkdirrelid, NULL);
 
 	Relation blkdir = relation_open(blkdirrelid, AccessShareLock);
 
@@ -1979,7 +1978,7 @@ aoco_relation_get_block_sequence(Relation rel,
 {
 	Oid segrelid;
 
-	GetAppendOnlyEntryAuxOids(rel, &segrelid, NULL, NULL, NULL, NULL);
+	GetAppendOnlyEntryAuxOids(rel, &segrelid, NULL, NULL);
 	AOSegment_PopulateBlockSequence(sequence, segrelid, AOSegmentGet_segno(blkNum));
 }
 

--- a/src/backend/access/aocs/aocssegfiles.c
+++ b/src/backend/access/aocs/aocssegfiles.c
@@ -217,11 +217,10 @@ GetAOCSFileSegInfo(Relation prel,
 	Datum	   *d;
 	bool	   *null;
 	bool		isNull;
+	Oid 		segrelid;
 
-    Oid         segrelid;
-    GetAppendOnlyEntryAuxOids(prel,
-                              &segrelid, NULL, NULL,
-                              NULL, NULL);
+	GetAppendOnlyEntryAuxOids(prel,
+					&segrelid, NULL, NULL);
 
 	segrel = heap_open(segrelid, AccessShareLock);
 	tupdesc = RelationGetDescr(segrel);
@@ -327,7 +326,7 @@ GetAllAOCSFileSegInfo(Relation prel,
 	Assert(RelationIsAoCols(prel));
 
 	GetAppendOnlyEntryAuxOids(prel,
-							  &segrelid, NULL, NULL,
+							  &segrelid,
 							  NULL, NULL);
 
 	if (segrelid == InvalidOid)
@@ -585,7 +584,7 @@ MarkAOCSFileSegInfoAwaitingDrop(Relation prel, int segno)
 
 	appendOnlyMetaDataSnapshot = RegisterSnapshot(GetCatalogSnapshot(InvalidOid));
 	GetAppendOnlyEntryAuxOids(prel,
-							  &segrelid, NULL, NULL,
+							  &segrelid,
 							  NULL, NULL);
 	UnregisterSnapshot(appendOnlyMetaDataSnapshot);
 
@@ -677,7 +676,7 @@ ClearAOCSFileSegInfo(Relation prel, int segno)
 
 	appendOnlyMetaDataSnapshot = RegisterSnapshot(GetCatalogSnapshot(InvalidOid));
 	GetAppendOnlyEntryAuxOids(prel,
-							  &segrelid, NULL, NULL,
+							  &segrelid,
 							  NULL, NULL);
 	UnregisterSnapshot(appendOnlyMetaDataSnapshot);
 
@@ -967,7 +966,7 @@ AOCSFileSegInfoAddVpe(Relation prel, int32 segno,
 
     Oid         segrelid;
     GetAppendOnlyEntryAuxOids(prel,
-                              &segrelid, NULL, NULL,
+                              &segrelid,
                               NULL, NULL);
 	segrel = heap_open(segrelid, RowExclusiveLock);
 	tupdesc = RelationGetDescr(segrel);
@@ -1085,7 +1084,7 @@ AOCSFileSegInfoAddCount(Relation prel, int32 segno,
 
     Oid         segrelid;
     GetAppendOnlyEntryAuxOids(prel,
-                              &segrelid, NULL, NULL,
+                              &segrelid,
                               NULL, NULL);
 
 	segrel = heap_open(segrelid, RowExclusiveLock);
@@ -1217,6 +1216,7 @@ gp_aocsseg_internal(PG_FUNCTION_ARGS, Oid aocsRelOid)
 		Relation	aocsRel;
 		Relation	pg_aocsseg_rel;
 		Snapshot	appendOnlyMetaDataSnapshot = RegisterSnapshot(GetLatestSnapshot());
+		Oid		segrelid;
 
 		/* create a function context for cross-call persistence */
 		funcctx = SRF_FIRSTCALL_INIT();
@@ -1270,10 +1270,9 @@ gp_aocsseg_internal(PG_FUNCTION_ARGS, Oid aocsRelOid)
 		/* Remember the number of columns. */
 		context->relnatts = aocsRel->rd_rel->relnatts;
 
-        Oid         segrelid;
-        GetAppendOnlyEntryAuxOids(aocsRel,
-                                  &segrelid, NULL, NULL,
-                                  NULL, NULL);
+		GetAppendOnlyEntryAuxOids(aocsRel,
+						&segrelid,
+						NULL, NULL);
 		pg_aocsseg_rel = heap_open(segrelid, AccessShareLock);
 
 		context->aocsSegfileArray = GetAllAOCSFileSegInfo_pg_aocsseg_rel(
@@ -1425,6 +1424,7 @@ gp_aocsseg_history(PG_FUNCTION_ARGS)
 		MemoryContext oldcontext;
 		Relation	aocsRel;
 		Relation	pg_aocsseg_rel;
+		Oid		segrelid;
 
 		/* create a function context for cross-call persistence */
 		funcctx = SRF_FIRSTCALL_INIT();
@@ -1481,10 +1481,9 @@ gp_aocsseg_history(PG_FUNCTION_ARGS)
 		/* Remember the number of columns. */
 		context->relnatts = aocsRel->rd_rel->relnatts;
 
-        Oid         segrelid;
-        GetAppendOnlyEntryAuxOids(aocsRel,
-                                  &segrelid, NULL, NULL,
-                                  NULL, NULL);
+		GetAppendOnlyEntryAuxOids(aocsRel,
+						&segrelid,
+						NULL, NULL);
 
 		pg_aocsseg_rel = heap_open(segrelid, AccessShareLock);
 
@@ -1606,7 +1605,7 @@ aocol_compression_ratio_internal(Relation parentrel)
 	Oid			segrelid = InvalidOid;
 
 	GetAppendOnlyEntryAuxOids(parentrel,
-							  &segrelid, NULL, NULL, NULL, NULL);
+							  &segrelid, NULL, NULL);
 	Assert(OidIsValid(segrelid));
 
 	/*

--- a/src/backend/access/appendonly/aosegfiles.c
+++ b/src/backend/access/appendonly/aosegfiles.c
@@ -108,7 +108,7 @@ InsertInitialSegnoEntry(Relation parentrel, int segno)
 	/* New segments are always created in the latest format */
 	formatVersion = AORelationVersion_GetLatest();
 
-	GetAppendOnlyEntryAuxOids(parentrel, &segrelid, NULL, NULL, NULL, NULL);
+	GetAppendOnlyEntryAuxOids(parentrel, &segrelid, NULL, NULL);
 
 	pg_aoseg_rel = heap_open(segrelid, RowExclusiveLock);
 
@@ -185,7 +185,7 @@ GetFileSegInfo(Relation parentrel, Snapshot appendOnlyMetaDataSnapshot, int segn
 	FileSegInfo *fsinfo;
 	Oid segrelid;
 
-	GetAppendOnlyEntryAuxOids(parentrel, &segrelid, NULL, NULL, NULL, NULL);
+	GetAppendOnlyEntryAuxOids(parentrel, &segrelid, NULL, NULL);
 
 	/*
 	 * Check the pg_aoseg relation to be certain the ao table segment file is
@@ -351,7 +351,7 @@ GetAllFileSegInfo(Relation parentrel,
 	FileSegInfo **result;
 	Oid segrelid;
 
-	GetAppendOnlyEntryAuxOids(parentrel, &segrelid, NULL, NULL, NULL, NULL);
+	GetAppendOnlyEntryAuxOids(parentrel, &segrelid, NULL, NULL);
 
 	if (segrelid == InvalidOid)
 		elog(ERROR, "could not find pg_aoseg aux table for AO table \"%s\"",
@@ -615,7 +615,7 @@ ClearFileSegInfo(Relation parentrel, int segno)
 	bool		isNull;
 	Oid segrelid;
 
-	GetAppendOnlyEntryAuxOids(parentrel, &segrelid, NULL, NULL, NULL, NULL);
+	GetAppendOnlyEntryAuxOids(parentrel, &segrelid, NULL, NULL);
 
 	Assert(RelationIsAoRows(parentrel));
 
@@ -753,7 +753,7 @@ UpdateFileSegInfo_internal(Relation parentrel,
 	bool		isNull;
 	Oid segrelid;
 
-	GetAppendOnlyEntryAuxOids(parentrel, &segrelid, NULL, NULL, NULL, NULL);
+	GetAppendOnlyEntryAuxOids(parentrel, &segrelid, NULL, NULL);
 
 	Assert(RelationIsAoRows(parentrel));
 	Assert(newState >= AOSEG_STATE_USECURRENT && newState <= AOSEG_STATE_AWAITING_DROP);
@@ -960,7 +960,7 @@ GetSegFilesTotals(Relation parentrel, Snapshot appendOnlyMetaDataSnapshot)
 
 	result = (FileSegTotals *) palloc0(sizeof(FileSegTotals));
 
-	GetAppendOnlyEntryAuxOids(parentrel, &segrelid, NULL, NULL, NULL, NULL);
+	GetAppendOnlyEntryAuxOids(parentrel, &segrelid, NULL, NULL);
 
 	if (segrelid == InvalidOid)
 		elog(ERROR, "could not find pg_aoseg aux table for AO table \"%s\"",
@@ -1079,7 +1079,7 @@ gp_aoseg_history(PG_FUNCTION_ARGS)
 					 errmsg("'%s' is not an append-only row relation",
 							RelationGetRelationName(aocsRel))));
 
-		GetAppendOnlyEntryAuxOids(aocsRel, &segrelid, NULL, NULL, NULL, NULL);
+		GetAppendOnlyEntryAuxOids(aocsRel, &segrelid, NULL, NULL);
 
 		pg_aoseg_rel = table_open(segrelid, AccessShareLock);
 
@@ -1231,7 +1231,7 @@ gp_aoseg(PG_FUNCTION_ARGS)
 					 errmsg("'%s' is not an append-only row relation",
 							RelationGetRelationName(aocsRel))));
 
-		GetAppendOnlyEntryAuxOids(aocsRel, &segrelid, NULL, NULL, NULL, NULL);
+		GetAppendOnlyEntryAuxOids(aocsRel, &segrelid, NULL, NULL);
 
 		pg_aoseg_rel = table_open(segrelid, AccessShareLock);
 
@@ -1382,7 +1382,7 @@ get_ao_distribution(PG_FUNCTION_ARGS)
 							RelationGetRelationName(parentrel))));
 
 		GetAppendOnlyEntryAuxOids(parentrel,
-								  &segrelid, NULL, NULL, NULL, NULL);
+								  &segrelid, NULL, NULL);
 		Assert(OidIsValid(segrelid));
 
 		/*
@@ -1558,7 +1558,7 @@ aorow_compression_ratio_internal(Relation parentrel)
 
 	GetAppendOnlyEntryAuxOids(parentrel,
 							  &segrelid,
-							  NULL, NULL, NULL, NULL);
+							  NULL, NULL);
 	Assert(OidIsValid(segrelid));
 
 	/*

--- a/src/backend/access/appendonly/appendonly_blkdir_udf.c
+++ b/src/backend/access/appendonly/appendonly_blkdir_udf.c
@@ -98,8 +98,8 @@ gp_aoblkdir(PG_FUNCTION_ARGS)
 						errmsg("function not supported on non append-optimized relation")));
 		sst = GetLatestSnapshot();
 		GetAppendOnlyEntryAuxOids(context->aorel,
-								  NULL, &blkdirrelid, NULL,
-								  NULL, NULL);
+								  NULL, &blkdirrelid,
+								  NULL);
 		sst = gp_select_invisible ? SnapshotAny : GetLatestSnapshot();
 		if (blkdirrelid == InvalidOid)
 			ereport(ERROR,

--- a/src/backend/access/appendonly/appendonly_compaction.c
+++ b/src/backend/access/appendonly/appendonly_compaction.c
@@ -127,13 +127,12 @@ AppendOnlyCompaction_ShouldCompact(Relation aoRelation,
 	AppendOnlyVisimap visiMap;
 	int64		hiddenTupcount;
 	double		hideRatio;
-    Oid         visimaprelid;
-    Oid         visimapidxid;
+	Oid		visimaprelid;
 
 	Assert(RelationIsAppendOptimized(aoRelation));
-    GetAppendOnlyEntryAuxOids(aoRelation,
-                              NULL, NULL, NULL,
-                              &visimaprelid, &visimapidxid);
+	GetAppendOnlyEntryAuxOids(aoRelation,
+					NULL, NULL,
+					&visimaprelid);
 
 	if (!gp_appendonly_compaction)
 	{
@@ -148,7 +147,6 @@ AppendOnlyCompaction_ShouldCompact(Relation aoRelation,
 
 	AppendOnlyVisimap_Init(&visiMap,
 						   visimaprelid,
-						   visimapidxid,
 						   ShareLock,
 						   appendOnlyMetaDataSnapshot);
 	hiddenTupcount = AppendOnlyVisimap_GetSegmentFileHiddenTupleCount(
@@ -390,7 +388,6 @@ AppendOnlySegmentFileFullCompaction(Relation aorel,
 	int64		tupleCount = 0;
 	int64		tuplePerPage = INT_MAX;
     Oid         visimaprelid;
-    Oid         visimapidxid;
     Oid         blkdirrelid;
 
 	Assert(Gp_role == GP_ROLE_EXECUTE || Gp_role == GP_ROLE_UTILITY);
@@ -405,12 +402,11 @@ AppendOnlySegmentFileFullCompaction(Relation aorel,
 	relname = RelationGetRelationName(aorel);
 
 	GetAppendOnlyEntryAuxOids(aorel,
-							  NULL, &blkdirrelid, NULL,
-							  &visimaprelid, &visimapidxid);
+							  NULL, &blkdirrelid,
+							  &visimaprelid);
 
 	AppendOnlyVisimap_Init(&visiMap,
 						   visimaprelid,
-						   visimapidxid,
 						   ShareUpdateExclusiveLock,
 						   appendOnlyMetaDataSnapshot);
 
@@ -538,7 +534,7 @@ AppendOptimizedCollectDeadSegments(Relation aorel)
 	Assert(RelationIsAppendOptimized(aorel));
 
 	GetAppendOnlyEntryAuxOids(aorel,
-							  &segrelid, NULL, NULL, NULL, NULL);
+							  &segrelid, NULL, NULL);
 	
 	pg_aoseg_rel = heap_open(segrelid, AccessShareLock);
 	pg_aoseg_dsc = RelationGetDescr(pg_aoseg_rel);
@@ -698,7 +694,7 @@ AppendOptimizedTruncateToEOF(Relation aorel)
 	LockRelationForExtension(aorel, ExclusiveLock);
 
 	GetAppendOnlyEntryAuxOids(aorel,
-							  &segrelid, NULL, NULL, NULL, NULL);
+							  &segrelid, NULL, NULL);
 
 	pg_aoseg_rel = heap_open(segrelid, AccessShareLock);
 	pg_aoseg_dsc = RelationGetDescr(pg_aoseg_rel);

--- a/src/backend/access/appendonly/appendonly_visimap.c
+++ b/src/backend/access/appendonly/appendonly_visimap.c
@@ -111,7 +111,6 @@ void
 AppendOnlyVisimap_Init(
 					   AppendOnlyVisimap *visiMap,
 					   Oid visimapRelid,
-					   Oid visimapIdxid,
 					   LOCKMODE lockmode,
 					   Snapshot appendOnlyMetaDataSnapshot)
 {
@@ -119,7 +118,6 @@ AppendOnlyVisimap_Init(
 
 	Assert(visiMap);
 	Assert(OidIsValid(visimapRelid));
-	Assert(OidIsValid(visimapIdxid));
 
 	visiMap->memoryContext = AllocSetContextCreate(
 												   CurrentMemoryContext,
@@ -136,7 +134,6 @@ AppendOnlyVisimap_Init(
 
 	AppendOnlyVisimapStore_Init(&visiMap->visimapStore,
 								visimapRelid,
-								visimapIdxid,
 								lockmode,
 								appendOnlyMetaDataSnapshot,
 								visiMap->memoryContext);
@@ -287,15 +284,13 @@ void
 AppendOnlyVisimapScan_Init(
 						   AppendOnlyVisimapScan *visiMapScan,
 						   Oid visimapRelid,
-						   Oid visimapIdxid,
 						   LOCKMODE lockmode,
 						   Snapshot appendonlyMetadataSnapshot)
 {
 	Assert(visiMapScan);
 	Assert(OidIsValid(visimapRelid));
-	Assert(OidIsValid(visimapIdxid));
 
-	AppendOnlyVisimap_Init(&visiMapScan->visimap, visimapRelid, visimapIdxid,
+	AppendOnlyVisimap_Init(&visiMapScan->visimap, visimapRelid,
 						   lockmode,
 						   appendonlyMetadataSnapshot);
 	visiMapScan->indexScan = AppendOnlyVisimapStore_BeginScan(
@@ -896,24 +891,22 @@ void AppendOnlyVisimap_Init_forUniqueCheck(
 	Snapshot snapshot)
 {
 	Oid visimaprelid;
-	Oid visimapidxid;
 
 	Assert(snapshot->snapshot_type == SNAPSHOT_DIRTY ||
 			   snapshot->snapshot_type == SNAPSHOT_SELF);
 
 	GetAppendOnlyEntryAuxOids(aoRel,
-							  NULL, NULL, NULL, &visimaprelid, &visimapidxid);
-	if (!OidIsValid(visimaprelid) || !OidIsValid(visimapidxid))
+							  NULL, NULL, &visimaprelid);
+	if (!OidIsValid(visimaprelid))
 		elog(ERROR, "Could not find block directory for relation: %u", aoRel->rd_id);
 
 	ereportif(Debug_appendonly_print_visimap, LOG,
 			  (errmsg("Append-only visimap init for unique checks"),
-				  errdetail("(aoRel = %u, visimaprel = %u, visimapidxrel = %u)",
-							aoRel->rd_id, visimaprelid, visimapidxid)));
+				  errdetail("(aoRel = %u, visimaprel = %u)",
+							aoRel->rd_id, visimaprelid)));
 
 	AppendOnlyVisimap_Init(visiMap,
 						   visimaprelid,
-						   visimapidxid,
 						   AccessShareLock,
 						   InvalidSnapshot /* appendOnlyMetaDataSnapshot */);
 }

--- a/src/backend/access/appendonly/appendonly_visimap_store.c
+++ b/src/backend/access/appendonly/appendonly_visimap_store.c
@@ -16,6 +16,7 @@
 
 #include "access/genam.h"
 #include "access/table.h"
+#include "catalog/aocatalog.h"
 #include "catalog/aovisimap.h"
 #include "catalog/indexing.h"
 #include "access/appendonly_visimap_store.h"
@@ -58,23 +59,26 @@ AppendOnlyVisimapStore_Finish(AppendOnlyVisimapStore *visiMapStore,
 void
 AppendOnlyVisimapStore_Init(AppendOnlyVisimapStore *visiMapStore,
 							Oid visimapRelid,
-							Oid visimapIdxid,
 							LOCKMODE lockmode,
 							Snapshot snapshot,
 							MemoryContext memoryContext)
 {
 	TupleDesc	heapTupleDesc;
 	ScanKey		scanKey;
+	Oid 		visimapIdxid;
 
 	Assert(visiMapStore);
 	Assert(CurrentMemoryContext == memoryContext);
 	Assert(OidIsValid(visimapRelid));
-	Assert(OidIsValid(visimapIdxid));
 
 	visiMapStore->snapshot = RegisterSnapshot(snapshot);
 	visiMapStore->memoryContext = memoryContext;
 
 	visiMapStore->visimapRelation = table_open(visimapRelid, lockmode);
+
+	visimapIdxid = AppendonlyGetAuxIndex(visiMapStore->visimapRelation);
+	Assert(OidIsValid(visimapIdxid));
+
 	visiMapStore->visimapIndex = index_open(visimapIdxid, lockmode);
 
 	heapTupleDesc =

--- a/src/backend/access/appendonly/appendonly_visimap_udf.c
+++ b/src/backend/access/appendonly/appendonly_visimap_udf.c
@@ -39,7 +39,6 @@ gp_aovisimap(PG_FUNCTION_ARGS)
 	Datum		result;
 
     Oid visimaprelid;
-    Oid visimapidxid;
 	typedef struct Context
 	{
 		Relation	aorel;
@@ -89,13 +88,12 @@ gp_aovisimap(PG_FUNCTION_ARGS)
 
 		Snapshot sst = GetLatestSnapshot();
 
-        GetAppendOnlyEntryAuxOids(context->aorel,
-                                  NULL, NULL, NULL,
-                                  &visimaprelid, &visimapidxid);
+		GetAppendOnlyEntryAuxOids(context->aorel,
+							NULL, NULL,
+							&visimaprelid);
 
 		AppendOnlyVisimapScan_Init(&context->visiMapScan,
 								   visimaprelid,
-								   visimapidxid,
 								   AccessShareLock,
 								   sst);
 
@@ -147,7 +145,6 @@ gp_aovisimap_hidden_info(PG_FUNCTION_ARGS)
 	HeapTuple	tuple;
 	Datum		result;
     Oid         visimaprelid;
-    Oid         visimapidxid;
 
 	typedef struct Context
 	{
@@ -170,6 +167,7 @@ gp_aovisimap_hidden_info(PG_FUNCTION_ARGS)
 		TupleDesc	tupdesc;
 		MemoryContext oldcontext;
 		Snapshot	snapshot;
+		Oid 		segrelid;
 
 		/* create a function context for cross-call persistence */
 		funcctx = SRF_FIRSTCALL_INIT();
@@ -202,15 +200,13 @@ gp_aovisimap_hidden_info(PG_FUNCTION_ARGS)
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 					 errmsg("function not supported on relation")));
 
-        Oid segrelid;
 		snapshot = GetLatestSnapshot();
-        GetAppendOnlyEntryAuxOids(context->parentRelation,
-                                  &segrelid, NULL, NULL,
-                                  &visimaprelid, &visimapidxid);
+		GetAppendOnlyEntryAuxOids(context->parentRelation,
+								&segrelid, NULL,
+								&visimaprelid);
 
 		AppendOnlyVisimap_Init(&context->visiMap,
 							   visimaprelid,
-							   visimapidxid,
 							   AccessShareLock,
 							   snapshot);
 
@@ -328,7 +324,6 @@ gp_aovisimap_entry(PG_FUNCTION_ARGS)
 	HeapTuple	tuple;
 	Datum		result;
     Oid         visimaprelid;
-    Oid         visimapidxid;
 
 	typedef struct Context
 	{
@@ -382,15 +377,14 @@ gp_aovisimap_entry(PG_FUNCTION_ARGS)
 					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 					 errmsg("function not supported on relation")));
 
-        Snapshot sst = GetLatestSnapshot();
+		Snapshot sst = GetLatestSnapshot();
 
-        GetAppendOnlyEntryAuxOids(context->parentRelation,
-                                  NULL, NULL, NULL,
-                                  &visimaprelid, &visimapidxid);
+		GetAppendOnlyEntryAuxOids(context->parentRelation,
+								NULL, NULL,
+								&visimaprelid);
 
 		AppendOnlyVisimap_Init(&context->visiMap,
 							   visimaprelid,
-							   visimapidxid,
 							   AccessShareLock,
 							   sst);
 

--- a/src/backend/access/appendonly/appendonlyam.c
+++ b/src/backend/access/appendonly/appendonlyam.c
@@ -1387,14 +1387,12 @@ appendonly_beginrangescan_internal(Relation relation,
 	if (segfile_count > 0)
 	{
 		Oid			visimaprelid;
-		Oid			visimapidxid;
 
 		GetAppendOnlyEntryAuxOids(relation,
-								  NULL, NULL, NULL, &visimaprelid, &visimapidxid);
+								  NULL, NULL, &visimaprelid);
 
 		AppendOnlyVisimap_Init(&scan->visibilityMap,
 							   visimaprelid,
-							   visimapidxid,
 							   AccessShareLock,
 							   appendOnlyMetaDataSnapshot);
 	}
@@ -2055,7 +2053,6 @@ appendonly_fetch_init(Relation relation,
 
 	AppendOnlyVisimap_Init(&aoFetchDesc->visibilityMap,
 						   aoFormData.visimaprelid,
-						   aoFormData.visimapidxid,
 						   AccessShareLock,
 						   appendOnlyMetaDataSnapshot);
 
@@ -2328,9 +2325,8 @@ appendonly_delete_init(Relation rel)
 	Assert(!IsolationUsesXactSnapshot());
 
 	Oid visimaprelid;
-	Oid visimapidxid;
 
-	GetAppendOnlyEntryAuxOids(rel, NULL, NULL, NULL, &visimaprelid, &visimapidxid);
+	GetAppendOnlyEntryAuxOids(rel, NULL, NULL, &visimaprelid);
 
 	AppendOnlyDeleteDesc aoDeleteDesc = palloc0(sizeof(AppendOnlyDeleteDescData));
 
@@ -2339,7 +2335,6 @@ appendonly_delete_init(Relation rel)
 
 	AppendOnlyVisimap_Init(&aoDeleteDesc->visibilityMap,
 						   visimaprelid,
-						   visimapidxid,
 						   RowExclusiveLock,
 						   aoDeleteDesc->appendOnlyMetaDataSnapshot);
 
@@ -2601,7 +2596,7 @@ appendonly_insert_init(Relation rel, int segno, int64 num_rows)
 	Assert(aoInsertDesc->fsInfo->segno == segno);
 
 	GetAppendOnlyEntryAuxOids(aoInsertDesc->aoi_rel, &aoInsertDesc->segrelid,
-			NULL, NULL, NULL, NULL);
+			NULL, NULL);
 
 	firstSequence = GetFastSequences(aoInsertDesc->segrelid, segno, num_rows);
 	aoInsertDesc->numSequences = num_rows;

--- a/src/backend/access/appendonly/appendonlyam_handler.c
+++ b/src/backend/access/appendonly/appendonlyam_handler.c
@@ -1051,8 +1051,8 @@ appendonly_relation_nontransactional_truncate(Relation rel)
 	/* Also truncate the aux tables */
 	GetAppendOnlyEntryAuxOids(rel,
 							  &aoseg_relid,
-							  &aoblkdir_relid, NULL,
-							  &aovisimap_relid, NULL);
+							  &aoblkdir_relid,
+							  &aovisimap_relid);
 
 	heap_truncate_one_relid(aoseg_relid);
 	heap_truncate_one_relid(aoblkdir_relid);
@@ -1446,10 +1446,9 @@ appendonly_index_build_range_scan(Relation heapRelation,
 	 * If block directory is empty, it must also be built along with the index.
 	 */
 	Oid blkdirrelid;
-	Oid blkidxrelid;
 
 	GetAppendOnlyEntryAuxOids(aoscan->aos_rd, NULL,
-							  &blkdirrelid, &blkidxrelid, NULL, NULL);
+							  &blkdirrelid, NULL);
 	/*
 	 * Note that block directory is created during creation of the first
 	 * index.  If it is found empty, it means the block directory was created
@@ -1655,7 +1654,7 @@ appendonly_relation_size(Relation rel, ForkNumber forkNumber)
 	result = 0;
 
 	GetAppendOnlyEntryAuxOids(rel, &segrelid, NULL,
-			NULL, NULL, NULL);
+							NULL);
 
 	if (segrelid == InvalidOid)
 		elog(ERROR, "could not find pg_aoseg aux table for AO table \"%s\"",
@@ -1739,7 +1738,7 @@ appendonly_relation_get_block_sequence(Relation rel,
 {
 	Oid segrelid;
 
-	GetAppendOnlyEntryAuxOids(rel, &segrelid, NULL, NULL, NULL, NULL);
+	GetAppendOnlyEntryAuxOids(rel, &segrelid, NULL, NULL);
 	AOSegment_PopulateBlockSequence(sequence, segrelid, AOSegmentGet_segno(blkNum));
 }
 

--- a/src/backend/access/appendonly/appendonlywriter.c
+++ b/src/backend/access/appendonly/appendonlywriter.c
@@ -165,7 +165,7 @@ LockSegnoForWrite(Relation rel, int segno)
 
 	appendOnlyMetaDataSnapshot = RegisterSnapshot(GetCatalogSnapshot(InvalidOid));
 	GetAppendOnlyEntryAuxOids(rel,
-							  &segrelid, NULL, NULL, NULL, NULL);
+							  &segrelid, NULL, NULL);
 	/*
 	 * Now pick a segment that is not in use, and is not over the allowed
 	 * size threshold (90% full).
@@ -436,7 +436,7 @@ choose_segno_internal(Relation rel, List *avoid_segnos, choose_segno_mode mode)
 	}
 
 	GetAppendOnlyEntryAuxOids(rel,
-							  &segrelid, NULL, NULL, NULL, NULL);
+							  &segrelid, NULL, NULL);
 
 	/*
 	 * Now pick a segment that is not in use, and is not over the allowed
@@ -639,7 +639,7 @@ choose_new_segfile(Relation rel, bool *used, List *avoid_segnos)
 
 			appendOnlyMetaDataSnapshot = RegisterSnapshot(GetCatalogSnapshot(InvalidOid));
 			GetAppendOnlyEntryAuxOids(rel,
-									  &segrelid, NULL, NULL, NULL, NULL);
+									  &segrelid, NULL, NULL);
 			UnregisterSnapshot(appendOnlyMetaDataSnapshot);
 
 			InsertInitialAOCSFileSegInfo(rel, chosen_segno,

--- a/src/backend/catalog/aocatalog.c
+++ b/src/backend/catalog/aocatalog.c
@@ -85,17 +85,22 @@ CreateAOAuxiliaryTable(
 	switch(relkind)
 	{
 		case RELKIND_AOVISIMAP:
-			GetAppendOnlyEntryAuxOids(rel, NULL,
-				NULL, NULL, &aoauxiliary_relid, &aoauxiliary_idxid);
+			GetAppendOnlyEntryAuxOids(rel,
+							NULL,
+							NULL,
+							&aoauxiliary_relid);
 			break;
 		case RELKIND_AOBLOCKDIR:
-			GetAppendOnlyEntryAuxOids(rel, NULL,
-				&aoauxiliary_relid, &aoauxiliary_idxid, NULL, NULL);
+			GetAppendOnlyEntryAuxOids(rel,
+							NULL,
+							&aoauxiliary_relid, 
+							NULL);
 			break;
 		case RELKIND_AOSEGMENTS:
 			GetAppendOnlyEntryAuxOids(rel,
-				&aoauxiliary_relid,
-				NULL, NULL, NULL, NULL);
+							&aoauxiliary_relid,
+							NULL,
+							NULL);
 			break;
 		default:
 			elog(ERROR, "unsupported auxiliary relkind '%c'", relkind);
@@ -196,13 +201,13 @@ CreateAOAuxiliaryTable(
 	{
 		case RELKIND_AOVISIMAP:
 			UpdateAppendOnlyEntryAuxOids(relOid, InvalidOid,
-								 InvalidOid, InvalidOid,
-								 aoauxiliary_relid, aoauxiliary_idxid);
+								 InvalidOid,
+								 aoauxiliary_relid);
 			break;
 		case RELKIND_AOBLOCKDIR:
 			UpdateAppendOnlyEntryAuxOids(relOid, InvalidOid,
-								 aoauxiliary_relid, aoauxiliary_idxid,
-								 InvalidOid, InvalidOid);
+								 aoauxiliary_relid,
+								 InvalidOid);
 			break;
 		case RELKIND_AOSEGMENTS:
 			/* Add initial entries in gp_fastsequence */
@@ -210,7 +215,6 @@ CreateAOAuxiliaryTable(
 
 			UpdateAppendOnlyEntryAuxOids(relOid,
 								 aoauxiliary_relid,
-								 InvalidOid, InvalidOid,
 								 InvalidOid, InvalidOid);
 			break;
 		default:

--- a/src/backend/catalog/heap.c
+++ b/src/backend/catalog/heap.c
@@ -1711,8 +1711,6 @@ heap_create_with_catalog(const char *relname,
 		InsertAppendOnlyEntry(relid,
 							  InvalidOid,
 							  InvalidOid,
-							  InvalidOid,
-							  InvalidOid,
 							  InvalidOid);
 	}
 

--- a/src/backend/catalog/index.c
+++ b/src/backend/catalog/index.c
@@ -4037,8 +4037,8 @@ reindex_relation(Oid relid, int flags, int options)
 	if ((flags & REINDEX_REL_PROCESS_TOAST) && relIsAO)
 		GetAppendOnlyEntryAuxOids(rel,
 								  &aoseg_relid,
-								  &aoblkdir_relid, NULL,
-								  &aovisimap_relid, NULL);
+								  &aoblkdir_relid,
+								  &aovisimap_relid);
 
 	/*
 	 * Close rel, but continue to hold the lock.

--- a/src/backend/catalog/pg_appendonly.c
+++ b/src/backend/catalog/pg_appendonly.c
@@ -49,9 +49,7 @@ void
 InsertAppendOnlyEntry(Oid relid,
 					  Oid segrelid,
 					  Oid blkdirrelid,
-					  Oid blkdiridxid,
-					  Oid visimaprelid,
-					  Oid visimapidxid)
+					  Oid visimaprelid)
 {
 	Relation	pg_appendonly_rel;
 	HeapTuple	pg_appendonly_tuple = NULL;
@@ -71,9 +69,7 @@ InsertAppendOnlyEntry(Oid relid,
 	values[Anum_pg_appendonly_relid - 1] = ObjectIdGetDatum(relid);
 	values[Anum_pg_appendonly_segrelid - 1] = ObjectIdGetDatum(segrelid);
 	values[Anum_pg_appendonly_blkdirrelid - 1] = ObjectIdGetDatum(blkdirrelid);
-	values[Anum_pg_appendonly_blkdiridxid - 1] = ObjectIdGetDatum(blkdiridxid);
 	values[Anum_pg_appendonly_visimaprelid - 1] = ObjectIdGetDatum(visimaprelid);
-	values[Anum_pg_appendonly_visimapidxid - 1] = ObjectIdGetDatum(visimapidxid);
 
 	/*
 	 * form the tuple and insert it
@@ -156,9 +152,7 @@ void
 GetAppendOnlyEntryAuxOids(Relation rel,
 						  Oid *segrelid,
 						  Oid *blkdirrelid,
-						  Oid *blkdiridxid,
-						  Oid *visimaprelid,
-						  Oid *visimapidxid)
+						  Oid *visimaprelid)
 {
 	Form_pg_appendonly	aoForm;
 
@@ -170,14 +164,8 @@ GetAppendOnlyEntryAuxOids(Relation rel,
 	if (blkdirrelid != NULL)
 		*blkdirrelid = aoForm->blkdirrelid;
 
-	if (blkdiridxid != NULL)
-		*blkdiridxid = aoForm->blkdiridxid;
-
 	if (visimaprelid != NULL)
 		*visimaprelid = aoForm->visimaprelid;
-
-	if (visimapidxid != NULL)
-		*visimapidxid = aoForm->visimapidxid;
 }
 
 void
@@ -197,9 +185,7 @@ void
 UpdateAppendOnlyEntryAuxOids(Oid relid,
 							 Oid newSegrelid,
 							 Oid newBlkdirrelid,
-							 Oid newBlkdiridxid,
-							 Oid newVisimaprelid,
-							 Oid newVisimapidxid)
+							 Oid newVisimaprelid)
 {
 	Relation	pg_appendonly;
 	ScanKeyData key[1];
@@ -245,23 +231,12 @@ UpdateAppendOnlyEntryAuxOids(Oid relid,
 		newValues[Anum_pg_appendonly_blkdirrelid - 1] = newBlkdirrelid;
 	}
 	
-	if (OidIsValid(newBlkdiridxid))
-	{
-		replace[Anum_pg_appendonly_blkdiridxid - 1] = true;
-		newValues[Anum_pg_appendonly_blkdiridxid - 1] = newBlkdiridxid;
-	}
-	
 	if (OidIsValid(newVisimaprelid))
 	{
 		replace[Anum_pg_appendonly_visimaprelid - 1] = true;
 		newValues[Anum_pg_appendonly_visimaprelid - 1] = newVisimaprelid;
 	}
 	
-	if (OidIsValid(newVisimapidxid))
-	{
-		replace[Anum_pg_appendonly_visimapidxid - 1] = true;
-		newValues[Anum_pg_appendonly_visimapidxid - 1] = newVisimapidxid;
-	}
 	newTuple = heap_modify_tuple(tuple, RelationGetDescr(pg_appendonly),
 								 newValues, newNulls, replace);
 	CatalogTupleUpdate(pg_appendonly, &newTuple->t_self, newTuple);

--- a/src/backend/commands/indexcmds.c
+++ b/src/backend/commands/indexcmds.c
@@ -735,7 +735,7 @@ DefineIndex(Oid relationId,
 	rel = table_open(relationId, NoLock);
 	if (RelationIsAppendOptimized(rel))
 	{
-		GetAppendOnlyEntryAuxOids(rel, NULL, &blkdirrelid, NULL, NULL, NULL);
+		GetAppendOnlyEntryAuxOids(rel, NULL, &blkdirrelid, NULL);
 
 		if (!OidIsValid(blkdirrelid))
 			lockmode = ShareRowExclusiveLock; /* Relation is AO, and has no block directory */

--- a/src/backend/commands/vacuum.c
+++ b/src/backend/commands/vacuum.c
@@ -1036,8 +1036,8 @@ expand_vacuum_rel(VacuumRelation *vrel, int options)
 
 					GetAppendOnlyEntryAuxOids(aorel,
 											  &aoseg_relid,
-											  &aoblkdir_relid, NULL,
-											  &aovisimap_relid, NULL);
+											  &aoblkdir_relid,
+											  &aovisimap_relid);
 
 					/* make new VacuumRelations for each valid member of the 3 auxiliary tables */
 					if (OidIsValid(aoseg_relid))
@@ -2304,8 +2304,8 @@ vacuum_rel(Oid relid, RangeVar *relation, VacuumParams *params,
 		Assert(!(params->options & VACOPT_AO_AUX_ONLY));
 		GetAppendOnlyEntryAuxOids(onerel,
 								  &aoseg_relid,
-								  &aoblkdir_relid, NULL,
-								  &aovisimap_relid, NULL);
+								  &aoblkdir_relid,
+								  &aovisimap_relid);
 	}
 
 	/*

--- a/src/backend/commands/vacuum_ao.c
+++ b/src/backend/commands/vacuum_ao.c
@@ -616,7 +616,6 @@ vacuum_appendonly_fill_stats(Relation aorel, Snapshot snapshot, int elevel,
 	int64       hidden_tupcount;
 	AppendOnlyVisimap visimap;
 	Oid			visimaprelid;
-	Oid			visimapidxid;
 
 	Assert(RelationIsAoRows(aorel) || RelationIsAoCols(aorel));
 
@@ -638,12 +637,11 @@ vacuum_appendonly_fill_stats(Relation aorel, Snapshot snapshot, int elevel,
 	nblocks = (uint32)RelationGetNumberOfBlocks(aorel);
 
 	GetAppendOnlyEntryAuxOids(aorel,
-							  NULL, NULL, NULL,
-							  &visimaprelid, &visimapidxid);
+							  NULL, NULL,
+							  &visimaprelid);
 
 	AppendOnlyVisimap_Init(&visimap,
 						   visimaprelid,
-						   visimapidxid,
 						   AccessShareLock,
 						   snapshot);
 	hidden_tupcount = AppendOnlyVisimap_GetRelationHiddenTupleCount(&visimap);

--- a/src/backend/utils/adt/dbsize.c
+++ b/src/backend/utils/adt/dbsize.c
@@ -586,8 +586,8 @@ calculate_table_size(Relation rel)
 	{
 		Oid	auxRelIds[3];
 		GetAppendOnlyEntryAuxOids(rel, &auxRelIds[0],
-								 &auxRelIds[1], NULL,
-								 &auxRelIds[2], NULL);
+								 &auxRelIds[1],
+								 &auxRelIds[2]);
 
 		for (int i = 0; i < 3; i++)
 		{

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -6923,14 +6923,16 @@ getAOTableInfo(Archive *fout)
 						"ao.relid,"
 						"ao.segrelid, t1.reltype as segreltype, "
 						"ao.blkdirrelid, t3.reltype as blkdirreltype, "
-						"ao.blkdiridxid, "
+						"i1.indexrelid as blkdiridxid, "
 						"ao.visimaprelid, t2.reltype as visimapreltype, "
-						"ao.visimapidxid "
+						"i2.indexrelid as visimapidxid "
 						"\nFROM pg_catalog.pg_appendonly ao\n"
 						"LEFT JOIN pg_class c ON (c.oid=ao.relid)\n"
 						"LEFT JOIN pg_class t1 ON (t1.oid=ao.segrelid)\n"
 						"LEFT JOIN pg_class t2 ON (t2.oid=ao.visimaprelid)\n"
 						"LEFT JOIN pg_class t3 ON (t3.oid=ao.blkdirrelid and ao.blkdirrelid <> 0)\n"
+						"LEFT JOIN pg_index i1 ON (i1.indrelid=ao.blkdirrelid)\n"
+						"LEFT JOIN pg_index i2 ON (i2.indrelid=ao.visimaprelid)\n"
 						"LEFT JOIN pg_am am ON (am.oid=c.relam)\n"
 						"ORDER BY 1");
 

--- a/src/include/access/appendonly_visimap.h
+++ b/src/include/access/appendonly_visimap.h
@@ -102,7 +102,6 @@ typedef struct AppendOnlyVisimapDelete
 void AppendOnlyVisimap_Init(
 					   AppendOnlyVisimap *visiMap,
 					   Oid visimapRelid,
-					   Oid visimalIdxid,
 					   LOCKMODE lockmode,
 					   Snapshot appendonlyMetaDataSnapshot);
 
@@ -128,7 +127,6 @@ int64 AppendOnlyVisimap_GetRelationHiddenTupleCount(
 void AppendOnlyVisimapScan_Init(
 						   AppendOnlyVisimapScan *visiMapScan,
 						   Oid visimapRelid,
-						   Oid visimapIdxid,
 						   LOCKMODE lockmode,
 						   Snapshot appendonlyMetadataSnapshot);
 

--- a/src/include/access/appendonly_visimap_store.h
+++ b/src/include/access/appendonly_visimap_store.h
@@ -56,7 +56,6 @@ typedef struct AppendOnlyVisimapStore
 void AppendOnlyVisimapStore_Init(
 							AppendOnlyVisimapStore *visiMapStore,
 							Oid visimapRelId,
-							Oid visimapIdxId,
 							LOCKMODE lockmode,
 							Snapshot snapshot,
 							MemoryContext memoryContext);

--- a/src/include/catalog/aocatalog.h
+++ b/src/include/catalog/aocatalog.h
@@ -19,6 +19,23 @@
 #include "catalog/heap.h"
 #include "catalog/index.h"
 
+/* 
+ * Convenient function to get the index of the AO/CO auxiliary tables.
+ * Currently, this is only used for aoblkdir and aovisimap relations
+ * which have one and only one index. Asserting the same in order to 
+ * make sure the caller knows what they are doing.
+ */
+static inline Oid
+AppendonlyGetAuxIndex(Relation rel)
+{
+	List *oids;
+
+	oids = RelationGetIndexList(rel);
+	Assert(oids->length == 1);
+
+	return linitial_oid(oids);
+}
+
 extern bool CreateAOAuxiliaryTable(Relation rel,
 								   const char *auxiliaryNamePrefix,
 								   char relkind,

--- a/src/include/catalog/catversion.h
+++ b/src/include/catalog/catversion.h
@@ -56,6 +56,6 @@
  */
 
 /*							3yyymmddN */
-#define CATALOG_VERSION_NO	302302231
+#define CATALOG_VERSION_NO	302302241
 
 #endif

--- a/src/include/catalog/pg_appendonly.h
+++ b/src/include/catalog/pg_appendonly.h
@@ -29,9 +29,7 @@ CATALOG(pg_appendonly,6105,AppendOnlyRelationId)
 	Oid				relid;				/* relation id */
     Oid             segrelid;           /* OID of aoseg table; 0 if none */
     Oid             blkdirrelid;        /* OID of aoblkdir table; 0 if none */
-    Oid             blkdiridxid;        /* if aoblkdir table, OID of aoblkdir index */
 	Oid             visimaprelid;		/* OID of the aovisimap table */
-	Oid             visimapidxid;		/* OID of aovisimap index */
 } FormData_pg_appendonly;
 
 /* GPDB added foreign key definitions for gpcheckcat. */
@@ -42,7 +40,7 @@ FOREIGN_KEY(relid REFERENCES pg_class(oid));
  * (there are no var-length fields currentl.)
 */
 #define APPENDONLY_TUPLE_SIZE \
-	 (offsetof(FormData_pg_appendonly,visimapidxid) + sizeof(Oid))
+	 (offsetof(FormData_pg_appendonly,visimaprelid) + sizeof(Oid))
 
 /* ----------------
 *		Form_pg_appendonly corresponds to a pointer to a tuple with
@@ -99,9 +97,7 @@ extern void
 InsertAppendOnlyEntry(Oid relid,
 					  Oid segrelid,
 					  Oid blkdirrelid,
-					  Oid blkdiridxid,
-					  Oid visimaprelid,
-					  Oid visimapidxid);
+					  Oid visimaprelid);
 
 void
 GetAppendOnlyEntryAttributes(Oid relid,
@@ -121,9 +117,7 @@ void
 GetAppendOnlyEntryAuxOids(Relation rel,
 						  Oid *segrelid,
 						  Oid *blkdirrelid,
-						  Oid *blkdiridxid,
-						  Oid *visimaprelid,
-						  Oid *visimapidxid);
+						  Oid *visimaprelid);
 
 
 void
@@ -136,9 +130,7 @@ extern void
 UpdateAppendOnlyEntryAuxOids(Oid relid,
 							 Oid newSegrelid,
 							 Oid newBlkdirrelid,
-							 Oid newBlkdiridxid,
-							 Oid newVisimaprelid,
-							 Oid newVisimapidxid);
+							 Oid newVisimaprelid);
 
 extern void
 RemoveAppendonlyEntry(Oid relid);

--- a/src/include/cdb/cdbaocsam.h
+++ b/src/include/cdb/cdbaocsam.h
@@ -64,7 +64,6 @@ typedef struct AOCSInsertDescData
     Oid         segrelid;
     Oid         blkdirrelid;
     Oid         visimaprelid;
-    Oid         visimapidxid;
 	struct DatumStreamWrite **ds;
 
 	AppendOnlyBlockDirectory blockDirectory;

--- a/src/test/regress/expected/uao_catalog_tables.out
+++ b/src/test/regress/expected/uao_catalog_tables.out
@@ -35,10 +35,10 @@ $$ LANGUAGE plpgsql;
 -- Verify empty visimap for uao table
 create table uao_table_check_empty_visimap (i int, j varchar(20), k int ) with (appendonly=true) DISTRIBUTED BY (i);
 insert into uao_table_check_empty_visimap values(1,'test',2);
-SELECT 1 FROM pg_appendonly WHERE visimapidxid is not NULL AND visimapidxid is not NULL AND relid='uao_table_check_empty_visimap'::regclass;
- ?column? 
-----------
-        1
+SELECT count(i.indexrelid) FROM pg_appendonly a, pg_index i WHERE a.visimaprelid = i.indrelid AND a.relid='uao_table_check_empty_visimap'::regclass;
+ count 
+-------
+     1
 (1 row)
 
 -- Verify GUC select_invisible=true for uao tables

--- a/src/test/regress/expected/uaocs_catalog_tables.out
+++ b/src/test/regress/expected/uaocs_catalog_tables.out
@@ -22,10 +22,10 @@ $$ LANGUAGE plpgsql;
 -- Verify empty visimap for uaocs table
 create table uaocs_table_check_empty_visimap (i int, j varchar(20), k int ) with (appendonly=true, orientation=column) DISTRIBUTED BY (i);
 insert into uaocs_table_check_empty_visimap values(1,'test',2);
-select 1 from pg_appendonly where visimapidxid is not null and visimapidxid is not NULL and relid='uaocs_table_check_empty_visimap'::regclass;
- ?column? 
-----------
-        1
+SELECT count(i.indexrelid) FROM pg_appendonly a, pg_index i WHERE a.visimaprelid = i.indrelid AND a.relid='uaocs_table_check_empty_visimap'::regclass;
+ count 
+-------
+     1
 (1 row)
 
 -- Verify the hidden tup_count using UDF gp_aovisimap_hidden_info(oid) for uaocs relation after delete and vacuum

--- a/src/test/regress/input/gp_tablespace.source
+++ b/src/test/regress/input/gp_tablespace.source
@@ -21,11 +21,11 @@ BEGIN
 	when 'blockdir' then
 		select blkdirrelid into relation_id from pg_appendonly where relid = aotablename;
 	when 'blockdirindex' then
-		select blkdiridxid into relation_id from pg_appendonly where relid = aotablename;
+		select i.indexrelid into relation_id from pg_appendonly a, pg_index i where a.blkdirrelid = i.indrelid and relid = aotablename;
 	when 'visimap' then
 		select visimaprelid into relation_id from pg_appendonly where relid = aotablename;
 	when 'visimapindex' then
-		select visimapidxid into relation_id from pg_appendonly where relid = aotablename;
+		select i.indexrelid into relation_id from pg_appendonly a, pg_index i where a.visimaprelid = i.indrelid and relid = aotablename;
 	else
 		raise notice 'Invalid tabletype for has_init_file %', tabletype;
 		return false;

--- a/src/test/regress/input/uao_ddl/alter_ao_part_exch.source
+++ b/src/test/regress/input/uao_ddl/alter_ao_part_exch.source
@@ -26,8 +26,8 @@ insert into ao_part(col1, col2, col3) values
 
 analyze ao_part;
 
-select count(*) FROM pg_appendonly WHERE visimapidxid is not NULL AND
-visimapidxid is not NULL AND relid in (SELECT c.oid FROM pg_class c
+select count(*) FROM pg_appendonly a, pg_index i WHERE a.visimaprelid = i.indrelid AND
+a.relid in (SELECT c.oid FROM pg_class c
 inner join pg_namespace n ON c.relnamespace = n.oid and c.relname like
 'ao_part%' and n.nspname = 'alter_ao_part_exch_@amname@');
 

--- a/src/test/regress/input/uao_ddl/alter_ao_part_tables.source
+++ b/src/test/regress/input/uao_ddl/alter_ao_part_tables.source
@@ -144,14 +144,16 @@ select count(*) as all_tuples from sto_altap2;
 set gp_select_invisible=false;
 
 -- Check that visimaps were created properly
-select distinct a.visimaprelid is not NULL, a.visimapidxid is not NULL
- from pg_appendonly a inner join pg_class c on a.relid = c.oid and
+select distinct a.visimaprelid is not NULL, i.indexrelid is not NULL
+ from pg_appendonly a inner join pg_class c on a.relid = c.oid 
+ inner join pg_index i on a.visimaprelid = i.indrelid and
  c.relname like 'sto_alt%';
 
 -- Drop partition table, check pg_appendonly
 drop table sto_altap2;
-select distinct a.visimaprelid is NULL, a.visimapidxid is NULL
- from pg_appendonly a inner join pg_class c on a.relid = c.oid and
+select distinct a.visimaprelid is not NULL, i.indexrelid is not NULL
+ from pg_appendonly a inner join pg_class c on a.relid = c.oid 
+ inner join pg_index i on a.visimaprelid = i.indrelid and
  c.relname like 'sto_altap2%';
 
 -- Validate that the state needed by appendoptimized AM is correctly

--- a/src/test/regress/input/uao_ddl/alter_ao_part_tables_splitpartition.source
+++ b/src/test/regress/input/uao_ddl/alter_ao_part_tables_splitpartition.source
@@ -10,8 +10,8 @@ CREATE TABLE sto_alt_uao_part_splitpartition (
   PARTITION sales_Sep13 START (date '2013-09-01') INCLUSIVE
   END (date '2014-01-01') EXCLUSIVE);
 
-SELECT 1 AS VisimapPresent FROM pg_appendonly WHERE visimaprelid is
-not NULL AND visimapidxid is not NULL AND relid in (SELECT c.oid FROM
+SELECT count(i.indexrelid) AS VisimapCount FROM pg_appendonly a, pg_index i WHERE a.visimaprelid = i.indrelid AND
+a.relid in (SELECT c.oid FROM
 pg_class c join pg_namespace n on c.relnamespace = n.oid and
  c.relname like 'sto_alt_uao_part_splitpartition%' and
  n.nspname = 'alter_ao_part_tables_splitpartition_@amname@');
@@ -26,8 +26,8 @@ select count(*) from sto_alt_uao_part_splitpartition;
 -- Alter table add default partition
 Alter table sto_alt_uao_part_splitpartition
  add default partition part_others;
-select count(*) FROM pg_appendonly WHERE visimaprelid is not NULL AND
-visimapidxid is not NULL AND relid in (SELECT c.oid FROM pg_class c
+SELECT count(i.indexrelid) FROM pg_appendonly a, pg_index i WHERE a.visimaprelid = i.indrelid AND
+a.relid in (SELECT c.oid FROM pg_class c
  join pg_namespace n on c.relnamespace = n.oid and
  c.relname like 'sto_alt_uao_part_splitpartition%' and
  n.nspname = 'alter_ao_part_tables_splitpartition_@amname@');
@@ -46,8 +46,8 @@ Alter table sto_alt_uao_part_splitpartition split default partition
  start(date '2013-01-01') end(date '2013-03-01')
  into (partition p1, partition part_others);
 
-select count(*) FROM pg_appendonly WHERE visimaprelid is not NULL AND
-visimapidxid is not NULL AND relid in (SELECT c.oid FROM pg_class c
+SELECT count(i.indexrelid) FROM pg_appendonly a, pg_index i WHERE a.visimaprelid = i.indrelid AND
+a.relid in (SELECT c.oid FROM pg_class c
  join pg_namespace n on c.relnamespace = n.oid and
  c.relname like 'sto_alt_uao_part_splitpartition%' and
  n.nspname = 'alter_ao_part_tables_splitpartition_@amname@');

--- a/src/test/regress/input/uao_ddl/alter_ao_table_col_ddl.source
+++ b/src/test/regress/input/uao_ddl/alter_ao_table_col_ddl.source
@@ -32,8 +32,8 @@ insert into sto_alt_uao1 values ('2_zero', 2, '2_zero', 2, 2, 2, '{2}', 2, 2, '1
 select count(*) = 3 as passed from sto_alt_uao1;
 -- Alter table add column
 Alter Table sto_alt_uao1 ADD COLUMN added_col character varying(30) default 'default';
-SELECT 1 AS VisimapPresent FROM pg_appendonly WHERE visimaprelid is not NULL AND
- visimapidxid is not NULL AND relid='sto_alt_uao1'::regclass;
+SELECT count(i.indexrelid) = 1 AS VisimapPresent  FROM pg_appendonly a, pg_index i WHERE a.visimaprelid = i.indrelid AND
+ a.relid='sto_alt_uao1'::regclass;
 update sto_alt_uao1 set added_col = 'newly added col'  where text_col = '1_zero';
 select * from sto_alt_uao1 order by bigint_col;
 set gp_select_invisible = true;
@@ -41,8 +41,8 @@ select count(*) AS all_tuples from sto_alt_uao1;
 set gp_select_invisible = false;
 -- Drop column
 Alter Table sto_alt_uao1 DROP COLUMN date_column;
-SELECT 1 AS VisimapPresent FROM pg_appendonly WHERE visimaprelid is not NULL AND
- visimapidxid is not NULL AND relid='sto_alt_uao1'::regclass;
+SELECT count(i.indexrelid) = 1 AS VisimapPresent  FROM pg_appendonly a, pg_index i WHERE a.visimaprelid = i.indrelid AND
+ a.relid='sto_alt_uao1'::regclass;
 insert into sto_alt_uao1 values ('3_zero', 3, '0_zero', 3, 3, 3, '{3}', 0, 0, 0);
 insert into sto_alt_uao1 values ('4_zero', 4, '1_zero', 4, 4, 4, '{4}', 1, 1, 1);
 update sto_alt_uao1 set bigint_col = -bigint_col  where text_col = '3_zero';
@@ -54,8 +54,8 @@ set gp_select_invisible = false;
 -- Alter column type and rename
 Alter Table sto_alt_uao1 ALTER COLUMN numeric_col TYPE int4;
 Alter Table sto_alt_uao1 RENAME COLUMN numeric_col TO int4_col;
-SELECT 1 AS VisimapPresent FROM pg_appendonly WHERE visimaprelid is not NULL AND
- visimapidxid is not NULL AND relid='sto_alt_uao1'::regclass;
+SELECT count(i.indexrelid) = 1 AS VisimapPresent  FROM pg_appendonly a, pg_index i WHERE a.visimaprelid = i.indrelid AND
+ a.relid='sto_alt_uao1'::regclass;
 insert into sto_alt_uao1 values ('5_zero', 5, '0_zero', 5, 5, 5, '{3}', 0, 0, 0);
 update sto_alt_uao1 set int4_col = int4_col+100;
 select count(int4_col) = 5 as passed from sto_alt_uao1;

--- a/src/test/regress/input/uao_ddl/alter_ao_table_constraint.source
+++ b/src/test/regress/input/uao_ddl/alter_ao_table_constraint.source
@@ -9,8 +9,8 @@ CREATE TABLE sto_alt_uao2_constraint(
   numeric_col numeric
   ) DISTRIBUTED RANDOMLY;
 insert into sto_alt_uao2_constraint values ('1_zero', 1, '1_zero', 1);
-SELECT 1 AS VisimapPresent  FROM pg_appendonly WHERE visimapidxid is not NULL
- AND visimapidxid is not NULL AND relid='sto_alt_uao2_constraint'::regclass;
+SELECT count(i.indexrelid) = 1 AS VisimapPresent  FROM pg_appendonly a, pg_index i WHERE a.visimaprelid = i.indrelid AND
+ a.relid='sto_alt_uao2_constraint'::regclass;
 
 select * from sto_alt_uao2_constraint order by bigint_col;
 update sto_alt_uao2_constraint set numeric_col = 100 where text_col = '1_zero';

--- a/src/test/regress/input/uao_ddl/alter_ao_table_setdefault.source
+++ b/src/test/regress/input/uao_ddl/alter_ao_table_setdefault.source
@@ -22,8 +22,8 @@ insert into sto_alt_uao1_default values (2, '2_zero', 2, 2, 2, '{2}', 2, 2, '1-1
 
 -- Alter column Drop default
 Alter table sto_alt_uao1_default  alter column text_col drop default;
-SELECT 1 AS VisimapPresent FROM pg_appendonly WHERE visimaprelid is not NULL AND
- visimapidxid is not NULL AND relid='sto_alt_uao1_default'::regclass;
+SELECT count(i.indexrelid) = 1 AS VisimapPresent  FROM pg_appendonly a, pg_index i WHERE a.visimaprelid = i.indrelid AND
+ a.relid='sto_alt_uao1_default'::regclass;
 insert into sto_alt_uao1_default values (3, '3_zero', 3, 3, 3, '{3}', 3, 3, '1-1-2002', 3);
 insert into sto_alt_uao1_default values (4, '4_zero', 4, 4, 4, '{4}', 4, 4, '1-1-2002', 4,'4_zero');
 select count(*) AS only_visi_tups from sto_alt_uao1_default;
@@ -44,8 +44,8 @@ select * from sto_alt_uao1_default order by bigint_col;
 -- Alter column drop NOT NULL
 Alter Table sto_alt_uao1_default ALTER COLUMN int_col DROP NOT NULL,
  ALTER COLUMN text_col DROP NOT NULL;
-SELECT 1 AS VisimapPresent FROM pg_appendonly WHERE visimaprelid is not NULL AND
- visimapidxid is not NULL AND relid='sto_alt_uao1_default'::regclass;
+SELECT count(i.indexrelid) = 1 AS VisimapPresent  FROM pg_appendonly a, pg_index i WHERE a.visimaprelid = i.indrelid AND
+ a.relid='sto_alt_uao1_default'::regclass;
 insert into sto_alt_uao1_default values (6, '6_zero', 6, 6, 6, '{6}', 6, 6, '1-1-2002', 6);
 update sto_alt_uao1_default set date_column = '2013-08-15' where text_col = '1_zero';
 select * from sto_alt_uao1_default order by bigint_col;

--- a/src/test/regress/input/uao_ddl/alter_ao_table_setstorage.source
+++ b/src/test/regress/input/uao_ddl/alter_ao_table_setstorage.source
@@ -21,8 +21,8 @@ insert into sto_alt_uao1_setstorage values ('2_zero', 2, '2_zero', 2, 2, 2, '{2}
 
 -- Alter table SET STORAGE
 Alter Table sto_alt_uao1_setstorage ALTER char_vary_col SET STORAGE PLAIN;
-SELECT 1 AS VisimapPresent FROM pg_appendonly WHERE visimapidxid is
-not NULL AND visimapidxid is not NULL AND relid='sto_alt_uao1_setstorage'::regclass;
+SELECT count(i.indexrelid) = 1 AS VisimapPresent  FROM pg_appendonly a, pg_index i WHERE a.visimaprelid = i.indrelid AND
+ a.relid='sto_alt_uao1_setstorage'::regclass;
 insert into sto_alt_uao1_setstorage values ('2_zero', 2, '2_zero', 2, 2, 2, '{2}', 2, 2, '1-1-2002',2);
 update sto_alt_uao1_setstorage set date_column = '2013-08-16' where text_col = '1_zero';
 select * from sto_alt_uao1_setstorage order by bigint_col;
@@ -41,8 +41,8 @@ Alter Table sto_alt_uao1_setstorage set with (reorganize='true')
  distributed by (bigint_col);
 update sto_alt_uao1_setstorage set numeric_col = -bigint_col;
 select * from sto_alt_uao1_setstorage;
-SELECT 1 AS VisimapPresent FROM pg_appendonly WHERE visimapidxid is
-not NULL AND visimapidxid is not NULL AND relid='sto_alt_uao1_setstorage'::regclass;
+SELECT count(i.indexrelid) = 1 AS VisimapPresent  FROM pg_appendonly a, pg_index i WHERE a.visimaprelid = i.indrelid AND
+ a.relid='sto_alt_uao1_setstorage'::regclass;
 
 -- Run another reorganize to confirm that the relcache has been invalidated
 -- when we changed the value of this table's gp_distribution_policy. If the
@@ -62,6 +62,6 @@ select * from sto_alt_uao1_setstorage;
 set gp_select_invisible=true;
 select count(*) from sto_alt_uao1_setstorage;
 set gp_select_invisible=false;
-SELECT 1 AS VisimapPresent FROM pg_appendonly WHERE visimapidxid is
-not NULL AND visimapidxid is not NULL AND relid='sto_alt_uao1_setstorage'::regclass;
+SELECT count(i.indexrelid) = 1 AS VisimapPresent  FROM pg_appendonly a, pg_index i WHERE a.visimaprelid = i.indrelid AND
+ a.relid='sto_alt_uao1_setstorage'::regclass;
 COMMIT;

--- a/src/test/regress/input/uao_ddl/alter_ao_table_statistics.source
+++ b/src/test/regress/input/uao_ddl/alter_ao_table_statistics.source
@@ -11,8 +11,8 @@ insert into sto_alt_uao2_stats values ('1_zero', 1, '1_zero', 1);
 select * from sto_alt_uao2_stats order by bigint_col;
 -- Alter column  set statistics
 Alter table sto_alt_uao2_stats  alter column bigint_col set statistics 3;
-SELECT 1 AS VisimapPresent  FROM pg_appendonly WHERE visimapidxid is not NULL AND
- visimapidxid is not NULL AND relid='sto_alt_uao2_stats'::regclass;
+SELECT count(i.indexrelid) = 1 AS VisimapPresent  FROM pg_appendonly a, pg_index i WHERE a.visimaprelid = i.indrelid AND
+ a.relid='sto_alt_uao2_stats'::regclass;
 select * from sto_alt_uao2_stats order by bigint_col;
 update sto_alt_uao2_stats set numeric_col = 1 where text_col = '1_zero';
 insert into sto_alt_uao2_stats select i||' abc', i, 'pqr '||i, i from generate_series(1,100)i;

--- a/src/test/regress/input/uao_ddl/analyze_ao_table_every_dml.source
+++ b/src/test/regress/input/uao_ddl/analyze_ao_table_every_dml.source
@@ -17,8 +17,8 @@ set gp_autostats_mode=on_change;
 
 select count(*)  from sto_uao_city_analyze_everydml;
 select relname, reltuples from pg_class where oid='sto_uao_city_analyze_everydml'::regclass;
-SELECT 1 AS VisimapPresent FROM pg_appendonly WHERE visimaprelid is not NULL AND
- visimapidxid is not NULL AND relid='sto_uao_city_analyze_everydml'::regclass;
+SELECT count(i.indexrelid) = 1 AS VisimapPresent  FROM pg_appendonly a, pg_index i WHERE a.visimaprelid = i.indrelid AND
+ a.relid='sto_uao_city_analyze_everydml'::regclass;
 
 -- Copy 7 rows in table sto_uao_city_analyze_everydml
 COPY sto_uao_city_analyze_everydml (id, name, countrycode, district, population) FROM stdin;

--- a/src/test/regress/input/uao_ddl/blocksize.source
+++ b/src/test/regress/input/uao_ddl/blocksize.source
@@ -16,8 +16,8 @@ SELECT GENERATE_SERIES::numeric sno
 CREATE index val3_bmp_idxblocksize_upd_8k on uao_blocksize_8k
  using bitmap (val3);
 SELECT count(*) from uao_blocksize_8k;
-SELECT 1 AS VisimapPresent FROM pg_appendonly WHERE visimaprelid is
-not NULL AND visimapidxid is not NULL AND relid='uao_blocksize_8k'::regclass;
+SELECT count(i.indexrelid) = 1 AS VisimapPresent  FROM pg_appendonly a, pg_index i WHERE a.visimaprelid = i.indrelid AND
+ a.relid='uao_blocksize_8k'::regclass;
 
 select 1 as block8k_present from pg_class, unnest(reloptions) as reloption
 where oid='uao_blocksize_8k'::regclass and reloption='blocksize=8192';
@@ -50,9 +50,8 @@ SELECT GENERATE_SERIES::numeric sno
 
 SELECT count(*) from uao_blocksize_2048k;
 
-SELECT 1 AS VisimapPresent FROM pg_appendonly WHERE
-visimaprelid is not NULL AND visimapidxid is not NULL AND
-relid='uao_blocksize_2048k'::regclass;
+SELECT count(i.indexrelid) = 1 AS VisimapPresent  FROM pg_appendonly a, pg_index i WHERE a.visimaprelid = i.indrelid AND
+ a.relid='uao_blocksize_2048k'::regclass;
 
 select 1 as block2048k_present from pg_class, unnest(reloptions) as reloption WHERE
 oid='uao_blocksize_2048k'::regclass and reloption='blocksize=2097152';

--- a/src/test/regress/input/uao_ddl/compresstype.source
+++ b/src/test/regress/input/uao_ddl/compresstype.source
@@ -15,8 +15,8 @@ insert into uao_tab_compress_none values
  (1, 'abc', 1), (2, 'pqr', 2), (3, 'lmn', 3);
 delete from uao_tab_compress_none;
 select count(*) = 0 as passed from uao_tab_compress_none;
-SELECT 1 AS VisimapPresent FROM pg_appendonly WHERE visimaprelid is
-not NULL AND visimapidxid is not NULL AND relid='uao_tab_compress_none'::regclass;
+SELECT count(i.indexrelid) = 1 AS VisimapPresent  FROM pg_appendonly a, pg_index i WHERE a.visimaprelid = i.indrelid AND
+ a.relid='uao_tab_compress_none'::regclass;
 
 -- create uao table with compress=zlib COMPRESSLEVEL=1
 CREATE TABLE uao_tab_compress_zlib1 (
@@ -38,8 +38,8 @@ select count(*) from uao_tab_compress_zlib1;
 -- Decompress tuples
 select sum(length(col_text)) from uao_tab_compress_zlib1
  where col_int < 1100;
-SELECT 1 AS VisimapPresent FROM pg_appendonly WHERE visimaprelid is
-not NULL AND visimapidxid is not NULL AND relid='uao_tab_compress_zlib1'::regclass;
+SELECT count(i.indexrelid) = 1 AS VisimapPresent  FROM pg_appendonly a, pg_index i WHERE a.visimaprelid = i.indrelid AND
+ a.relid='uao_tab_compress_zlib1'::regclass;
 
 SELECT c.relname, c.reloptions from pg_class c
 join pg_namespace n on n.oid=c.relnamespace
@@ -70,8 +70,8 @@ set gp_select_invisible = true;
 select count(*) from uao_tab_compress_zlib9;
 set gp_select_invisible = false;
 
-SELECT 1 AS VisimapPresent FROM pg_appendonly WHERE visimapidxid is
-not NULL AND visimapidxid is not NULL AND relid='uao_tab_compress_zlib9'::regclass;
+SELECT count(i.indexrelid) = 1 AS VisimapPresent  FROM pg_appendonly a, pg_index i WHERE a.visimaprelid = i.indrelid AND
+ a.relid='uao_tab_compress_zlib9'::regclass;
 
 SELECT c.relname, c.reloptions from pg_class c
 join pg_namespace n on n.oid=c.relnamespace

--- a/src/test/regress/input/uao_ddl/create_ao_table_500cols.source
+++ b/src/test/regress/input/uao_ddl/create_ao_table_500cols.source
@@ -111,8 +111,8 @@ numeric(8), a493 polygon, a494 date, a495 real, a496 money, a497 cidr,
 a498 inet, a499 time, a500 text)
  DISTRIBUTED BY (id);
 
-SELECT 1 AS VisimapPresent FROM pg_appendonly WHERE visimaprelid is not NULL AND
- visimapidxid is not NULL AND relid='sto_uao_500cols'::regclass;
+SELECT count(i.indexrelid) = 1 AS VisimapPresent  FROM pg_appendonly a, pg_index i WHERE a.visimaprelid = i.indrelid AND
+ a.relid='sto_uao_500cols'::regclass;
 
 INSERT into sto_uao_500cols (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10,
 a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24,

--- a/src/test/regress/input/uao_ddl/create_ao_tables.source
+++ b/src/test/regress/input/uao_ddl/create_ao_tables.source
@@ -25,13 +25,13 @@ SELECT position('pg_aoblkdir_' in relname) FROM pg_class where oid IN
 (SELECT blkdirrelid FROM pg_appendonly WHERE relid='sto_uao_1'::regclass);
 
 SELECT position('pg_aoblkdir_' in relname) FROM pg_class where oid IN
-(SELECT blkdiridxid FROM pg_appendonly WHERE relid='sto_uao_1'::regclass);
+(SELECT i.indexrelid FROM pg_appendonly a, pg_index i WHERE a.blkdirrelid = i.indrelid AND a.relid='sto_uao_1'::regclass);
 
 SELECT position('pg_aovisimap_' in relname) FROM pg_class where oid IN
 (SELECT visimaprelid FROM pg_appendonly WHERE relid='sto_uao_1'::regclass);
 
 SELECT position('pg_aovisimap_' in relname) FROM pg_class where oid IN
-(SELECT visimapidxid FROM pg_appendonly WHERE relid='sto_uao_1'::regclass);
+(SELECT i.indexrelid FROM pg_appendonly a, pg_index i WHERE a.visimaprelid = i.indrelid AND a.relid='sto_uao_1'::regclass);
 
 insert into sto_uao_1 values
  (1,'aa',1001,101), (2,'bb',1002,102), (3,'aa',1003,103),
@@ -190,8 +190,8 @@ delete from sto_uao_9;
 set gp_select_invisible=true;
 select count(*) from sto_uao_9;
 set gp_select_invisible=false;
-SELECT 1 AS VisimapPresent FROM pg_appendonly WHERE visimaprelid is not NULL
- AND visimapidxid is not NULL AND relid='sto_uao_9'::regclass;
+SELECT count(i.indexrelid) = 1 AS VisimapPresent  FROM pg_appendonly a, pg_index i WHERE a.visimaprelid = i.indrelid AND
+ a.relid='sto_uao_9'::regclass;
 
 -- Delete using join
 delete from sto_uao_1 a using sto_uao_8 b

--- a/src/test/regress/output/gp_tablespace.source
+++ b/src/test/regress/output/gp_tablespace.source
@@ -20,11 +20,11 @@ BEGIN
 	when 'blockdir' then
 		select blkdirrelid into relation_id from pg_appendonly where relid = aotablename;
 	when 'blockdirindex' then
-		select blkdiridxid into relation_id from pg_appendonly where relid = aotablename;
+		select i.indexrelid into relation_id from pg_appendonly a, pg_index i where a.blkdirrelid = i.indrelid and relid = aotablename;
 	when 'visimap' then
 		select visimaprelid into relation_id from pg_appendonly where relid = aotablename;
 	when 'visimapindex' then
-		select visimapidxid into relation_id from pg_appendonly where relid = aotablename;
+		select i.indexrelid into relation_id from pg_appendonly a, pg_index i where a.visimaprelid = i.indrelid and relid = aotablename;
 	else
 		raise notice 'Invalid tabletype for has_init_file %', tabletype;
 		return false;

--- a/src/test/regress/output/uao_ddl/alter_ao_part_exch.source
+++ b/src/test/regress/output/uao_ddl/alter_ao_part_exch.source
@@ -23,8 +23,8 @@ insert into ao_part(col1, col2, col3) values
  (1, '2008-04-15', 'ao_row'), (1, '2008-04-15', 'heap'), (1, '2008-04-05', 'ao_col'),
  (1, '2008-05-06', 'ao_row');
 analyze ao_part;
-select count(*) FROM pg_appendonly WHERE visimapidxid is not NULL AND
-visimapidxid is not NULL AND relid in (SELECT c.oid FROM pg_class c
+select count(*) FROM pg_appendonly a, pg_index i WHERE a.visimaprelid = i.indrelid AND
+a.relid in (SELECT c.oid FROM pg_class c
 inner join pg_namespace n ON c.relnamespace = n.oid and c.relname like
 'ao_part%' and n.nspname = 'alter_ao_part_exch_@amname@');
  count 

--- a/src/test/regress/output/uao_ddl/alter_ao_part_tables.source
+++ b/src/test/regress/output/uao_ddl/alter_ao_part_tables.source
@@ -388,8 +388,9 @@ select count(*) as all_tuples from sto_altap2;
 
 set gp_select_invisible=false;
 -- Check that visimaps were created properly
-select distinct a.visimaprelid is not NULL, a.visimapidxid is not NULL
- from pg_appendonly a inner join pg_class c on a.relid = c.oid and
+select distinct a.visimaprelid is not NULL, i.indexrelid is not NULL
+ from pg_appendonly a inner join pg_class c on a.relid = c.oid 
+ inner join pg_index i on a.visimaprelid = i.indrelid and
  c.relname like 'sto_alt%';
  ?column? | ?column? 
 ----------+----------
@@ -398,8 +399,9 @@ select distinct a.visimaprelid is not NULL, a.visimapidxid is not NULL
 
 -- Drop partition table, check pg_appendonly
 drop table sto_altap2;
-select distinct a.visimaprelid is NULL, a.visimapidxid is NULL
- from pg_appendonly a inner join pg_class c on a.relid = c.oid and
+select distinct a.visimaprelid is not NULL, i.indexrelid is not NULL
+ from pg_appendonly a inner join pg_class c on a.relid = c.oid 
+ inner join pg_index i on a.visimaprelid = i.indrelid and
  c.relname like 'sto_altap2%';
  ?column? | ?column? 
 ----------+----------

--- a/src/test/regress/output/uao_ddl/alter_ao_part_tables_splitpartition.source
+++ b/src/test/regress/output/uao_ddl/alter_ao_part_tables_splitpartition.source
@@ -9,17 +9,15 @@ CREATE TABLE sto_alt_uao_part_splitpartition (
   PARTITION sales_Aug13 START (date '2013-08-01') INCLUSIVE,
   PARTITION sales_Sep13 START (date '2013-09-01') INCLUSIVE
   END (date '2014-01-01') EXCLUSIVE);
-SELECT 1 AS VisimapPresent FROM pg_appendonly WHERE visimaprelid is
-not NULL AND visimapidxid is not NULL AND relid in (SELECT c.oid FROM
+SELECT count(i.indexrelid) AS VisimapCount FROM pg_appendonly a, pg_index i WHERE a.visimaprelid = i.indrelid AND
+a.relid in (SELECT c.oid FROM
 pg_class c join pg_namespace n on c.relnamespace = n.oid and
  c.relname like 'sto_alt_uao_part_splitpartition%' and
  n.nspname = 'alter_ao_part_tables_splitpartition_@amname@');
- visimappresent 
-----------------
-              1
-              1
-              1
-(3 rows)
+ visimapcount 
+-------------
+            3
+(1 row)
 
 Insert into sto_alt_uao_part_splitpartition values(1,'2013-07-05',19.20);
 Insert into sto_alt_uao_part_splitpartition values(2,'2013-08-15',10.20);
@@ -34,8 +32,8 @@ select count(*) from sto_alt_uao_part_splitpartition;
 -- Alter table add default partition
 Alter table sto_alt_uao_part_splitpartition
  add default partition part_others;
-select count(*) FROM pg_appendonly WHERE visimaprelid is not NULL AND
-visimapidxid is not NULL AND relid in (SELECT c.oid FROM pg_class c
+SELECT count(i.indexrelid) FROM pg_appendonly a, pg_index i WHERE a.visimaprelid = i.indrelid AND
+a.relid in (SELECT c.oid FROM pg_class c
  join pg_namespace n on c.relnamespace = n.oid and
  c.relname like 'sto_alt_uao_part_splitpartition%' and
  n.nspname = 'alter_ao_part_tables_splitpartition_@amname@');
@@ -71,8 +69,8 @@ select * from sto_alt_uao_part_splitpartition;
 Alter table sto_alt_uao_part_splitpartition split default partition
  start(date '2013-01-01') end(date '2013-03-01')
  into (partition p1, partition part_others);
-select count(*) FROM pg_appendonly WHERE visimaprelid is not NULL AND
-visimapidxid is not NULL AND relid in (SELECT c.oid FROM pg_class c
+SELECT count(i.indexrelid) FROM pg_appendonly a, pg_index i WHERE a.visimaprelid = i.indrelid AND
+a.relid in (SELECT c.oid FROM pg_class c
  join pg_namespace n on c.relnamespace = n.oid and
  c.relname like 'sto_alt_uao_part_splitpartition%' and
  n.nspname = 'alter_ao_part_tables_splitpartition_@amname@');

--- a/src/test/regress/output/uao_ddl/alter_ao_table_col_ddl.source
+++ b/src/test/regress/output/uao_ddl/alter_ao_table_col_ddl.source
@@ -46,11 +46,11 @@ select count(*) = 3 as passed from sto_alt_uao1;
 
 -- Alter table add column
 Alter Table sto_alt_uao1 ADD COLUMN added_col character varying(30) default 'default';
-SELECT 1 AS VisimapPresent FROM pg_appendonly WHERE visimaprelid is not NULL AND
- visimapidxid is not NULL AND relid='sto_alt_uao1'::regclass;
+SELECT count(i.indexrelid) = 1 AS VisimapPresent  FROM pg_appendonly a, pg_index i WHERE a.visimaprelid = i.indrelid AND
+ a.relid='sto_alt_uao1'::regclass;
  visimappresent 
 ----------------
-              1
+ t
 (1 row)
 
 update sto_alt_uao1 set added_col = 'newly added col'  where text_col = '1_zero';
@@ -72,11 +72,11 @@ select count(*) AS all_tuples from sto_alt_uao1;
 set gp_select_invisible = false;
 -- Drop column
 Alter Table sto_alt_uao1 DROP COLUMN date_column;
-SELECT 1 AS VisimapPresent FROM pg_appendonly WHERE visimaprelid is not NULL AND
- visimapidxid is not NULL AND relid='sto_alt_uao1'::regclass;
+SELECT count(i.indexrelid) = 1 AS VisimapPresent  FROM pg_appendonly a, pg_index i WHERE a.visimaprelid = i.indrelid AND
+ a.relid='sto_alt_uao1'::regclass;
  visimappresent 
 ----------------
-              1
+ t
 (1 row)
 
 insert into sto_alt_uao1 values ('3_zero', 3, '0_zero', 3, 3, 3, '{3}', 0, 0, 0);
@@ -103,11 +103,11 @@ set gp_select_invisible = false;
 -- Alter column type and rename
 Alter Table sto_alt_uao1 ALTER COLUMN numeric_col TYPE int4;
 Alter Table sto_alt_uao1 RENAME COLUMN numeric_col TO int4_col;
-SELECT 1 AS VisimapPresent FROM pg_appendonly WHERE visimaprelid is not NULL AND
- visimapidxid is not NULL AND relid='sto_alt_uao1'::regclass;
+SELECT count(i.indexrelid) = 1 AS VisimapPresent  FROM pg_appendonly a, pg_index i WHERE a.visimaprelid = i.indrelid AND
+ a.relid='sto_alt_uao1'::regclass;
  visimappresent 
 ----------------
-              1
+ t
 (1 row)
 
 insert into sto_alt_uao1 values ('5_zero', 5, '0_zero', 5, 5, 5, '{3}', 0, 0, 0);

--- a/src/test/regress/output/uao_ddl/alter_ao_table_col_ddl_optimizer.source
+++ b/src/test/regress/output/uao_ddl/alter_ao_table_col_ddl_optimizer.source
@@ -46,11 +46,11 @@ select count(*) = 3 as passed from sto_alt_uao1;
 
 -- Alter table add column
 Alter Table sto_alt_uao1 ADD COLUMN added_col character varying(30) default 'default';
-SELECT 1 AS VisimapPresent FROM pg_appendonly WHERE visimaprelid is not NULL AND
- visimapidxid is not NULL AND relid='sto_alt_uao1'::regclass;
+SELECT count(i.indexrelid) = 1 AS VisimapPresent  FROM pg_appendonly a, pg_index i WHERE a.visimaprelid = i.indrelid AND
+ a.relid='sto_alt_uao1'::regclass;
  visimappresent 
 ----------------
-              1
+ t
 (1 row)
 
 update sto_alt_uao1 set added_col = 'newly added col'  where text_col = '1_zero';
@@ -72,11 +72,11 @@ select count(*) AS all_tuples from sto_alt_uao1;
 set gp_select_invisible = false;
 -- Drop column
 Alter Table sto_alt_uao1 DROP COLUMN date_column;
-SELECT 1 AS VisimapPresent FROM pg_appendonly WHERE visimaprelid is not NULL AND
- visimapidxid is not NULL AND relid='sto_alt_uao1'::regclass;
+SELECT count(i.indexrelid) = 1 AS VisimapPresent  FROM pg_appendonly a, pg_index i WHERE a.visimaprelid = i.indrelid AND
+ a.relid='sto_alt_uao1'::regclass;
  visimappresent 
 ----------------
-              1
+ t
 (1 row)
 
 insert into sto_alt_uao1 values ('3_zero', 3, '0_zero', 3, 3, 3, '{3}', 0, 0, 0);
@@ -103,11 +103,11 @@ set gp_select_invisible = false;
 -- Alter column type and rename
 Alter Table sto_alt_uao1 ALTER COLUMN numeric_col TYPE int4;
 Alter Table sto_alt_uao1 RENAME COLUMN numeric_col TO int4_col;
-SELECT 1 AS VisimapPresent FROM pg_appendonly WHERE visimaprelid is not NULL AND
- visimapidxid is not NULL AND relid='sto_alt_uao1'::regclass;
+SELECT count(i.indexrelid) = 1 AS VisimapPresent  FROM pg_appendonly a, pg_index i WHERE a.visimaprelid = i.indrelid AND
+ a.relid='sto_alt_uao1'::regclass;
  visimappresent 
 ----------------
-              1
+ t
 (1 row)
 
 insert into sto_alt_uao1 values ('5_zero', 5, '0_zero', 5, 5, 5, '{3}', 0, 0, 0);

--- a/src/test/regress/output/uao_ddl/alter_ao_table_constraint.source
+++ b/src/test/regress/output/uao_ddl/alter_ao_table_constraint.source
@@ -9,11 +9,11 @@ CREATE TABLE sto_alt_uao2_constraint(
   numeric_col numeric
   ) DISTRIBUTED RANDOMLY;
 insert into sto_alt_uao2_constraint values ('1_zero', 1, '1_zero', 1);
-SELECT 1 AS VisimapPresent  FROM pg_appendonly WHERE visimapidxid is not NULL
- AND visimapidxid is not NULL AND relid='sto_alt_uao2_constraint'::regclass;
+SELECT count(i.indexrelid) = 1 AS VisimapPresent  FROM pg_appendonly a, pg_index i WHERE a.visimaprelid = i.indrelid AND
+ a.relid='sto_alt_uao2_constraint'::regclass;
  visimappresent 
 ----------------
-              1
+ t
 (1 row)
 
 select * from sto_alt_uao2_constraint order by bigint_col;

--- a/src/test/regress/output/uao_ddl/alter_ao_table_setdefault.source
+++ b/src/test/regress/output/uao_ddl/alter_ao_table_setdefault.source
@@ -20,11 +20,11 @@ insert into sto_alt_uao1_default values (1, '1_zero', 1, 1, 1, '{1}', 1, 1, '1-1
 insert into sto_alt_uao1_default values (2, '2_zero', 2, 2, 2, '{2}', 2, 2, '1-1-2002',2);
 -- Alter column Drop default
 Alter table sto_alt_uao1_default  alter column text_col drop default;
-SELECT 1 AS VisimapPresent FROM pg_appendonly WHERE visimaprelid is not NULL AND
- visimapidxid is not NULL AND relid='sto_alt_uao1_default'::regclass;
+SELECT count(i.indexrelid) = 1 AS VisimapPresent  FROM pg_appendonly a, pg_index i WHERE a.visimaprelid = i.indrelid AND
+ a.relid='sto_alt_uao1_default'::regclass;
  visimappresent 
 ----------------
-              1
+ t
 (1 row)
 
 insert into sto_alt_uao1_default values (3, '3_zero', 3, 3, 3, '{3}', 3, 3, '1-1-2002', 3);
@@ -76,11 +76,11 @@ select * from sto_alt_uao1_default order by bigint_col;
 -- Alter column drop NOT NULL
 Alter Table sto_alt_uao1_default ALTER COLUMN int_col DROP NOT NULL,
  ALTER COLUMN text_col DROP NOT NULL;
-SELECT 1 AS VisimapPresent FROM pg_appendonly WHERE visimaprelid is not NULL AND
- visimapidxid is not NULL AND relid='sto_alt_uao1_default'::regclass;
+SELECT count(i.indexrelid) = 1 AS VisimapPresent  FROM pg_appendonly a, pg_index i WHERE a.visimaprelid = i.indrelid AND
+ a.relid='sto_alt_uao1_default'::regclass;
  visimappresent 
 ----------------
-              1
+ t
 (1 row)
 
 insert into sto_alt_uao1_default values (6, '6_zero', 6, 6, 6, '{6}', 6, 6, '1-1-2002', 6);

--- a/src/test/regress/output/uao_ddl/alter_ao_table_setstorage.source
+++ b/src/test/regress/output/uao_ddl/alter_ao_table_setstorage.source
@@ -19,11 +19,11 @@ insert into sto_alt_uao1_setstorage values ('1_zero', 1, '1_zero', 1, 1, 1, '{1}
 insert into sto_alt_uao1_setstorage values ('2_zero', 2, '2_zero', 2, 2, 2, '{2}', 2, 2, '1-1-2002',2);
 -- Alter table SET STORAGE
 Alter Table sto_alt_uao1_setstorage ALTER char_vary_col SET STORAGE PLAIN;
-SELECT 1 AS VisimapPresent FROM pg_appendonly WHERE visimapidxid is
-not NULL AND visimapidxid is not NULL AND relid='sto_alt_uao1_setstorage'::regclass;
+SELECT count(i.indexrelid) = 1 AS VisimapPresent  FROM pg_appendonly a, pg_index i WHERE a.visimaprelid = i.indrelid AND
+ a.relid='sto_alt_uao1_setstorage'::regclass;
  visimappresent 
 ----------------
-              1
+ t
 (1 row)
 
 insert into sto_alt_uao1_setstorage values ('2_zero', 2, '2_zero', 2, 2, 2, '{2}', 2, 2, '1-1-2002',2);
@@ -74,11 +74,11 @@ select * from sto_alt_uao1_setstorage;
  2_zero   |          2 | 2_zero        |          -2 |       2 |         2 | {2}           |                 2 |                   2 | 01-01-2002  |               2
 (3 rows)
 
-SELECT 1 AS VisimapPresent FROM pg_appendonly WHERE visimapidxid is
-not NULL AND visimapidxid is not NULL AND relid='sto_alt_uao1_setstorage'::regclass;
+SELECT count(i.indexrelid) = 1 AS VisimapPresent  FROM pg_appendonly a, pg_index i WHERE a.visimaprelid = i.indrelid AND
+ a.relid='sto_alt_uao1_setstorage'::regclass;
  visimappresent 
 ----------------
-              1
+ t
 (1 row)
 
 -- Run another reorganize to confirm that the relcache has been invalidated
@@ -117,11 +117,11 @@ select count(*) from sto_alt_uao1_setstorage;
 (1 row)
 
 set gp_select_invisible=false;
-SELECT 1 AS VisimapPresent FROM pg_appendonly WHERE visimapidxid is
-not NULL AND visimapidxid is not NULL AND relid='sto_alt_uao1_setstorage'::regclass;
+SELECT count(i.indexrelid) = 1 AS VisimapPresent  FROM pg_appendonly a, pg_index i WHERE a.visimaprelid = i.indrelid AND
+ a.relid='sto_alt_uao1_setstorage'::regclass;
  visimappresent 
 ----------------
-              1
+ t
 (1 row)
 
 COMMIT;

--- a/src/test/regress/output/uao_ddl/alter_ao_table_statistics.source
+++ b/src/test/regress/output/uao_ddl/alter_ao_table_statistics.source
@@ -16,11 +16,11 @@ select * from sto_alt_uao2_stats order by bigint_col;
 
 -- Alter column  set statistics
 Alter table sto_alt_uao2_stats  alter column bigint_col set statistics 3;
-SELECT 1 AS VisimapPresent  FROM pg_appendonly WHERE visimapidxid is not NULL AND
- visimapidxid is not NULL AND relid='sto_alt_uao2_stats'::regclass;
+SELECT count(i.indexrelid) = 1 AS VisimapPresent  FROM pg_appendonly a, pg_index i WHERE a.visimaprelid = i.indrelid AND
+ a.relid='sto_alt_uao2_stats'::regclass;
  visimappresent 
 ----------------
-              1
+ t
 (1 row)
 
 select * from sto_alt_uao2_stats order by bigint_col;

--- a/src/test/regress/output/uao_ddl/analyze_ao_table_every_dml.source
+++ b/src/test/regress/output/uao_ddl/analyze_ao_table_every_dml.source
@@ -25,11 +25,11 @@ select relname, reltuples from pg_class where oid='sto_uao_city_analyze_everydml
  sto_uao_city_analyze_everydml |         0
 (1 row)
 
-SELECT 1 AS VisimapPresent FROM pg_appendonly WHERE visimaprelid is not NULL AND
- visimapidxid is not NULL AND relid='sto_uao_city_analyze_everydml'::regclass;
+SELECT count(i.indexrelid) = 1 AS VisimapPresent  FROM pg_appendonly a, pg_index i WHERE a.visimaprelid = i.indrelid AND
+ a.relid='sto_uao_city_analyze_everydml'::regclass;
  visimappresent 
-----------------
-              1
+------------
+ t
 (1 row)
 
 -- Copy 7 rows in table sto_uao_city_analyze_everydml

--- a/src/test/regress/output/uao_ddl/blocksize.source
+++ b/src/test/regress/output/uao_ddl/blocksize.source
@@ -20,11 +20,11 @@ SELECT count(*) from uao_blocksize_8k;
   1000
 (1 row)
 
-SELECT 1 AS VisimapPresent FROM pg_appendonly WHERE visimaprelid is
-not NULL AND visimapidxid is not NULL AND relid='uao_blocksize_8k'::regclass;
+SELECT count(i.indexrelid) = 1 AS VisimapPresent  FROM pg_appendonly a, pg_index i WHERE a.visimaprelid = i.indrelid AND
+ a.relid='uao_blocksize_8k'::regclass;
  visimappresent 
 ----------------
-              1
+ t
 (1 row)
 
 select 1 as block8k_present from pg_class, unnest(reloptions) as reloption
@@ -89,12 +89,11 @@ SELECT count(*) from uao_blocksize_2048k;
   1000
 (1 row)
 
-SELECT 1 AS VisimapPresent FROM pg_appendonly WHERE
-visimaprelid is not NULL AND visimapidxid is not NULL AND
-relid='uao_blocksize_2048k'::regclass;
+SELECT count(i.indexrelid) = 1 AS VisimapPresent  FROM pg_appendonly a, pg_index i WHERE a.visimaprelid = i.indrelid AND
+ a.relid='uao_blocksize_2048k'::regclass;
  visimappresent 
 ----------------
-              1
+ t
 (1 row)
 
 select 1 as block2048k_present from pg_class, unnest(reloptions) as reloption WHERE

--- a/src/test/regress/output/uao_ddl/compresstype.source
+++ b/src/test/regress/output/uao_ddl/compresstype.source
@@ -20,11 +20,11 @@ select count(*) = 0 as passed from uao_tab_compress_none;
  t
 (1 row)
 
-SELECT 1 AS VisimapPresent FROM pg_appendonly WHERE visimaprelid is
-not NULL AND visimapidxid is not NULL AND relid='uao_tab_compress_none'::regclass;
+SELECT count(i.indexrelid) = 1 AS VisimapPresent  FROM pg_appendonly a, pg_index i WHERE a.visimaprelid = i.indrelid AND
+ a.relid='uao_tab_compress_none'::regclass;
  visimappresent 
 ----------------
-              1
+ t
 (1 row)
 
 -- create uao table with compress=zlib COMPRESSLEVEL=1
@@ -61,11 +61,11 @@ select sum(length(col_text)) from uao_tab_compress_zlib1
  22600
 (1 row)
 
-SELECT 1 AS VisimapPresent FROM pg_appendonly WHERE visimaprelid is
-not NULL AND visimapidxid is not NULL AND relid='uao_tab_compress_zlib1'::regclass;
+SELECT count(i.indexrelid) = 1 AS VisimapPresent  FROM pg_appendonly a, pg_index i WHERE a.visimaprelid = i.indrelid AND
+ a.relid='uao_tab_compress_zlib1'::regclass;
  visimappresent 
 ----------------
-              1
+ t
 (1 row)
 
 SELECT c.relname, c.reloptions from pg_class c
@@ -119,11 +119,11 @@ select count(*) from uao_tab_compress_zlib9;
 (1 row)
 
 set gp_select_invisible = false;
-SELECT 1 AS VisimapPresent FROM pg_appendonly WHERE visimapidxid is
-not NULL AND visimapidxid is not NULL AND relid='uao_tab_compress_zlib9'::regclass;
+SELECT count(i.indexrelid) = 1 AS VisimapPresent  FROM pg_appendonly a, pg_index i WHERE a.visimaprelid = i.indrelid AND
+ a.relid='uao_tab_compress_zlib9'::regclass;
  visimappresent 
 ----------------
-              1
+ t
 (1 row)
 
 SELECT c.relname, c.reloptions from pg_class c

--- a/src/test/regress/output/uao_ddl/create_ao_table_500cols.source
+++ b/src/test/regress/output/uao_ddl/create_ao_table_500cols.source
@@ -110,11 +110,11 @@ lseg, a488 point, a489 double precision, a490 circle, a491 int4, a492
 numeric(8), a493 polygon, a494 date, a495 real, a496 money, a497 cidr,
 a498 inet, a499 time, a500 text)
  DISTRIBUTED BY (id);
-SELECT 1 AS VisimapPresent FROM pg_appendonly WHERE visimaprelid is not NULL AND
- visimapidxid is not NULL AND relid='sto_uao_500cols'::regclass;
+SELECT count(i.indexrelid) = 1 AS VisimapPresent  FROM pg_appendonly a, pg_index i WHERE a.visimaprelid = i.indrelid AND
+ a.relid='sto_uao_500cols'::regclass;
  visimappresent 
-----------------
-              1
+------------
+ t
 (1 row)
 
 INSERT into sto_uao_500cols (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10,

--- a/src/test/regress/output/uao_ddl/create_ao_tables.source
+++ b/src/test/regress/output/uao_ddl/create_ao_tables.source
@@ -31,7 +31,7 @@ SELECT position('pg_aoblkdir_' in relname) FROM pg_class where oid IN
 (1 row)
 
 SELECT position('pg_aoblkdir_' in relname) FROM pg_class where oid IN
-(SELECT blkdiridxid FROM pg_appendonly WHERE relid='sto_uao_1'::regclass);
+(SELECT i.indexrelid FROM pg_appendonly a, pg_index i WHERE a.blkdirrelid = i.indrelid AND a.relid='sto_uao_1'::regclass);
  position 
 ----------
         1
@@ -45,7 +45,7 @@ SELECT position('pg_aovisimap_' in relname) FROM pg_class where oid IN
 (1 row)
 
 SELECT position('pg_aovisimap_' in relname) FROM pg_class where oid IN
-(SELECT visimapidxid FROM pg_appendonly WHERE relid='sto_uao_1'::regclass);
+(SELECT i.indexrelid FROM pg_appendonly a, pg_index i WHERE a.visimaprelid = i.indrelid AND a.relid='sto_uao_1'::regclass);
  position 
 ----------
         1
@@ -289,11 +289,11 @@ select count(*) from sto_uao_9;
 (1 row)
 
 set gp_select_invisible=false;
-SELECT 1 AS VisimapPresent FROM pg_appendonly WHERE visimaprelid is not NULL
- AND visimapidxid is not NULL AND relid='sto_uao_9'::regclass;
+SELECT count(i.indexrelid) = 1 AS VisimapPresent  FROM pg_appendonly a, pg_index i WHERE a.visimaprelid = i.indrelid AND
+ a.relid='sto_uao_9'::regclass;
  visimappresent 
-----------------
-              1
+------------
+ t
 (1 row)
 
 -- Delete using join

--- a/src/test/regress/sql/uao_catalog_tables.sql
+++ b/src/test/regress/sql/uao_catalog_tables.sql
@@ -38,7 +38,7 @@ $$ LANGUAGE plpgsql;
 -- Verify empty visimap for uao table
 create table uao_table_check_empty_visimap (i int, j varchar(20), k int ) with (appendonly=true) DISTRIBUTED BY (i);
 insert into uao_table_check_empty_visimap values(1,'test',2);
-SELECT 1 FROM pg_appendonly WHERE visimapidxid is not NULL AND visimapidxid is not NULL AND relid='uao_table_check_empty_visimap'::regclass;
+SELECT count(i.indexrelid) FROM pg_appendonly a, pg_index i WHERE a.visimaprelid = i.indrelid AND a.relid='uao_table_check_empty_visimap'::regclass;
 
 -- Verify GUC select_invisible=true for uao tables
 create table uao_table_check_select_invisible (i int, j varchar(20), k int ) with (appendonly=true) DISTRIBUTED BY (i);

--- a/src/test/regress/sql/uaocs_catalog_tables.sql
+++ b/src/test/regress/sql/uaocs_catalog_tables.sql
@@ -24,7 +24,7 @@ $$ LANGUAGE plpgsql;
 -- Verify empty visimap for uaocs table
 create table uaocs_table_check_empty_visimap (i int, j varchar(20), k int ) with (appendonly=true, orientation=column) DISTRIBUTED BY (i);
 insert into uaocs_table_check_empty_visimap values(1,'test',2);
-select 1 from pg_appendonly where visimapidxid is not null and visimapidxid is not NULL and relid='uaocs_table_check_empty_visimap'::regclass;
+SELECT count(i.indexrelid) FROM pg_appendonly a, pg_index i WHERE a.visimaprelid = i.indrelid AND a.relid='uaocs_table_check_empty_visimap'::regclass;
 
 -- Verify the hidden tup_count using UDF gp_aovisimap_hidden_info(oid) for uaocs relation after delete and vacuum
 create table uaocs_table_check_hidden_tup_count_after_delete(i int, j varchar(20), k int ) with (appendonly=true, orientation=column) DISTRIBUTED BY (i);


### PR DESCRIPTION
We can get indexes for blkdir and visimap from pg_index via `RelationGetIndexList`. Removing these 2 fields will reduce catalog size.

Basically, we now retrieve these two properties in a more similar way as the indexes of toast tables, where we always open the toast table first and then get its index via `RelationGetIndexList`. In fact, in majority of the places currently we already have those two aux tables opened. The only place we didn't is in ATExecSetTableSpace(), but opening them shouldn't slow down setting tablespace too much anyway.

The other notable thing is that we need to modify how we get these indexes in pg_dump - we now have to check the pg_index.


------------

Dev pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/ao-rm-aux-idx

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
