### PR TITLE
Don't scan dropped columns during ANALYZE if table AM supports col projection

### DIFF
--- a/src/include/access/tableam.h
+++ b/src/include/access/tableam.h
@@ -913,9 +913,14 @@ table_beginscan_tid(Relation rel, Snapshot snapshot)
  * the same data structure although the behavior is rather different.
  */
 static inline TableScanDesc
-table_beginscan_analyze(Relation rel)
+table_beginscan_analyze(Relation rel, bool *proj)
 {
 	uint32		flags = SO_TYPE_ANALYZE;
+
+	if (rel->rd_tableam->scan_begin_extractcolumns)
+		return rel->rd_tableam->scan_begin_extractcolumns(rel, NULL,
+														  NULL, NULL, proj, NULL,
+														  flags);
 
 	return rel->rd_tableam->scan_begin(rel, NULL, 0, NULL, NULL, flags);
 }

--- a/src/test/regress/expected/analyze.out
+++ b/src/test/regress/expected/analyze.out
@@ -942,6 +942,58 @@ select attname, null_frac, avg_width, n_distinct from pg_stats where tablename =
  d       |         0 |         5 |         -1
 (3 rows)
 
+-- Test ANALYZE on an aoco table does not scan a dropped column
+-- First record total blocks scanned for the ANALYZE, then record blocks scanned after
+-- issuing an ALTER TABLE .. DROP COLUMN.
+create table aoco_analyze_dropped_col(i int, j bigint, k int) WITH (appendonly=true, orientation=column);
+insert into aoco_analyze_dropped_col select 0, i, 1 from generate_series(1, 100000) i;
+select gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'skip', '', '', '', 1, -1, 0, dbid)
+    from gp_segment_configuration where content = 1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+analyze aoco_analyze_dropped_col;
+select gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'status', dbid)
+    from gp_segment_configuration where content = 1 AND role = 'p';
+                                                                                                                  gp_inject_fault                                                                                                                  
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Success: fault name:'AppendOnlyStorageRead_ReadNextBlock_success' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'triggered'  num times hit:'51' +
+ 
+(1 row)
+
+select gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'reset', dbid)
+    from gp_segment_configuration WHERE content = 1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+alter table aoco_analyze_dropped_col drop column j;
+select gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'skip', '', '', '', 1, -1, 0, dbid)
+    from gp_segment_configuration WHERE content = 1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
+analyze aoco_analyze_dropped_col;
+select gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'status', dbid)
+    from gp_segment_configuration WHERE content = 1 AND role = 'p';
+                                                                                                                  gp_inject_fault                                                                                                                  
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Success: fault name:'AppendOnlyStorageRead_ReadNextBlock_success' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'triggered'  num times hit:'26' +
+ 
+(1 row)
+
+select gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'reset', dbid)
+    from gp_segment_configuration WHERE content = 1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:
+(1 row)
+
 -- Test analyze without USAGE privilege on schema
 create schema test_ns;
 revoke all on schema test_ns from public;

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -81,7 +81,9 @@ test: gp_connections
 
 # bitmap_index triggers recovery, run it seperately
 test: bitmap_index
-test: gp_dump_query_oids analyze gp_owner_permission incremental_analyze truncate_gp
+# 'analyze' utilizes fault injectors so it needs to be in a group by itself
+test: analyze
+test: gp_dump_query_oids gp_owner_permission incremental_analyze truncate_gp
 test: indexjoin as_alias regex_gp gpparams with_clause transient_types gp_rules dispatch_encoding motion_gp
 
 # interconnect tests

--- a/src/test/regress/sql/analyze.sql
+++ b/src/test/regress/sql/analyze.sql
@@ -5,6 +5,9 @@
 DROP DATABASE IF EXISTS testanalyze;
 CREATE DATABASE testanalyze;
 \c testanalyze
+-- start_ignore
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+-- end_ignore
 set client_min_messages='WARNING';
 -- Case 1: Analyzing root table with GUC optimizer_analyze_root_partition and optimizer_analyze_midlevel_partition set off should only populate stats for leaf tables
 set optimizer_analyze_root_partition=off;
@@ -468,6 +471,37 @@ insert into analyze_dropped_col values('a','bbb', repeat('x', 5000), 'dddd');
 alter table analyze_dropped_col drop column b;
 analyze analyze_dropped_col;
 select attname, null_frac, avg_width, n_distinct from pg_stats where tablename ='analyze_dropped_col';
+
+-- Test ANALYZE on an aoco table does not scan a dropped column
+-- First record total blocks scanned for the ANALYZE, then record blocks scanned after
+-- issuing an ALTER TABLE .. DROP COLUMN.
+create table aoco_analyze_dropped_col(i int, j bigint, k int) WITH (appendonly=true, orientation=column);
+insert into aoco_analyze_dropped_col select 0, i, 1 from generate_series(1, 100000) i;
+
+select gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'skip', '', '', '', 1, -1, 0, dbid)
+    from gp_segment_configuration where content = 1 AND role = 'p';
+
+analyze aoco_analyze_dropped_col;
+
+select gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'status', dbid)
+    from gp_segment_configuration where content = 1 AND role = 'p';
+
+select gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'reset', dbid)
+    from gp_segment_configuration WHERE content = 1 AND role = 'p';
+
+alter table aoco_analyze_dropped_col drop column j;
+
+select gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'skip', '', '', '', 1, -1, 0, dbid)
+    from gp_segment_configuration WHERE content = 1 AND role = 'p';
+
+analyze aoco_analyze_dropped_col;
+
+select gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'status', dbid)
+    from gp_segment_configuration WHERE content = 1 AND role = 'p';
+
+select gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'reset', dbid)
+    from gp_segment_configuration WHERE content = 1 AND role = 'p';
+
 -- Test analyze without USAGE privilege on schema
 create schema test_ns;
 revoke all on schema test_ns from public;


### PR DESCRIPTION
For table AMs that support column projection (currently AOCO), we can optimize the table scan when acquiring sample rows by projecting only columns that have not been dropped to the table scan.

Authored-by: Brent Doil <bdoil@vmware.com>
