### PR TITLE
Fix segfault when calling pg_dump with --binary-upgrade

### DIFF
--- a/src/bin/pg_dump/pg_backup_db.c
+++ b/src/bin/pg_dump/pg_backup_db.c
@@ -142,14 +142,12 @@ ConnectDatabase(Archive *AHX,
 	 * Start the connection.  Loop until we have a password if requested by
 	 * backend.
 	 */
-	const char *keywords[8];
-	const char *values[8];
+	const char *keywords[9];
+	const char *values[9];
+	int			i;
 	do
 	{
-		const char *keywords[8];
-		const char *values[8];
-		int			i = 0;
-
+		i = 0;
 		/*
 		 * If dbname is a connstring, its entries can override the other
 		 * values obtained from cparams; but in turn, override_dbname can
@@ -173,9 +171,9 @@ ConnectDatabase(Archive *AHX,
 		keywords[i] = "fallback_application_name";
 		values[i++] = progname;
 		keywords[i] = NULL;
-		values[i++] = NULL;
+		values[i] = NULL;
 		Assert(i <= lengthof(keywords));
-
+	
 		new_pass = false;
 		AH->connection = PQconnectdbParams(keywords, values, true);
 
@@ -233,11 +231,12 @@ ConnectDatabase(Archive *AHX,
 	 */
 	if (binary_upgrade)
 	{
-		keywords[6] = "options";
-		values[6] = AH->public.remoteVersion < GPDB7_MAJOR_PGVERSION ?
+		keywords[i] = "options";
+		values[i] = AH->public.remoteVersion < GPDB7_MAJOR_PGVERSION ?
 								"-c gp_session_role=utility" : "-c gp_role=utility";
-		keywords[7] = NULL;
-		values[7] = NULL;
+		keywords[i] = NULL;
+		values[i++] = NULL;
+		Assert(i <= lengthof(keywords));
 		AH->connection = PQconnectdbParams(keywords, values, true);
 	}
 	PQsetNoticeProcessor(AH->connection, notice_processor, NULL);


### PR DESCRIPTION
Resolves an issue where `pg_dump` would segfault when called with `--binary-upgrade` flag and 5 or fewer total arguments. The bug was introduced during PG12_12 merge https://github.com/greenplum-db/gpdb/commit/fb93f784fc9c31f12361462653d325fdce01207d