### PR TITLE
Fix LWLockHeldByMe assert failure in SharedSnapshotDump

### DIFF
--- a/src/backend/utils/time/sharedsnapshot.c
+++ b/src/backend/utils/time/sharedsnapshot.c
@@ -381,8 +381,9 @@ retry:
 
 		if (testSlot->slotindex > arrayP->maxSlots)
 		{
+			char *slot_dump = SharedSnapshotDump();
 			LWLockRelease(SharedSnapshotLock);
-			elog(ERROR, "Shared Local Snapshots Array appears corrupted: %s", SharedSnapshotDump());
+			elog(ERROR, "Shared Local Snapshots Array appears corrupted: %s", slot_dump);
 		}
 
 		if (testSlot->slotid == slotId)


### PR DESCRIPTION
Note that when SharedSnapshotDump is called, the caller must held the SharedSnapshotLock in advance, so this commit fix the case that didn't satisfy this condition.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
