### PR TITLE
Fix duplicate portal id error in PROCEDURE when using resource queue

### DIFF
--- a/src/backend/utils/resscheduler/resqueue.c
+++ b/src/backend/utils/resscheduler/resqueue.c
@@ -54,7 +54,7 @@ static ResPortalIncrement *ResIncrementAdd(ResPortalIncrement *incSet,
 										   PROCLOCK *proclock,
 										   ResourceOwner owner,
 										   ResIncrementAddStatus *status);
-static bool ResIncrementRemove(ResPortalTag *portaltag);
+bool ResIncrementRemove(ResPortalTag *portaltag);
 
 static void ResWaitOnLock(LOCALLOCK *locallock, ResourceOwner owner, ResPortalIncrement *incrementSet);
 
@@ -1591,7 +1591,7 @@ ResIncrementFind(ResPortalTag *portaltag)
  *	The resource queue lightweight lock (ResQueueLock) *must* be held for
  *	this operation.
  */
-static bool
+bool
 ResIncrementRemove(ResPortalTag *portaltag)
 {
 	ResPortalIncrement *incrementSet;

--- a/src/backend/utils/resscheduler/resscheduler.c
+++ b/src/backend/utils/resscheduler/resscheduler.c
@@ -1031,10 +1031,28 @@ ResCreatePortalId(const char *name)
 void
 AtCommit_ResScheduler(void)
 {
+	uint32			id;
+	ResPortalTag		portalTag;
+        /* reset the portal id. */
+        if (numHoldPortals == 0)
+	{
+		/* 
+		 * Clean up remaining entry in ResPortalIncrementHash 
+		 * before resetting portalId to zero. 
+		 */
+		for (id = 1; id <= portalId; id++)
+		{
+			MemSet(&portalTag, 0, sizeof(ResPortalTag));
+			portalTag.pid = MyProc->pid;
+			portalTag.portalId = id;
+			if (ResIncrementFind(&portalTag)) 
+			{
+				ResIncrementRemove(&portalTag);
+			}
+		}
 
-	/* reset the portal id. */
-	if (numHoldPortals == 0)
-		portalId = 0;
+                portalId = 0;
+	}
 }
 
 

--- a/src/include/utils/resscheduler.h
+++ b/src/include/utils/resscheduler.h
@@ -146,6 +146,7 @@ extern void				ResRemoveFromWaitQueue(PGPROC *proc, uint32 hashcode);
 extern bool				ResCheckSelfDeadLock(LOCK *lock, PROCLOCK *proclock, ResPortalIncrement *incSet);
 
 extern ResPortalIncrement	*ResIncrementFind(ResPortalTag *portaltag);
+extern bool 			ResIncrementRemove(ResPortalTag *portaltag);
 
 extern bool					ResPortalIncrementHashTableInit(void);
 

--- a/src/test/regress/expected/create_procedure.out
+++ b/src/test/regress/expected/create_procedure.out
@@ -202,6 +202,24 @@ ALTER ROUTINE cp_testfunc1a RENAME TO cp_testfunc1;
 ALTER ROUTINE ptest1(text) RENAME TO ptest1a;
 ALTER ROUTINE ptest1a RENAME TO ptest1;
 DROP ROUTINE cp_testfunc1(int);
+-- commit in procedure
+create table procedure_tbl1(a int);
+create table procedure_tbl2(a int);
+insert into procedure_tbl1 values(1),(2),(3),(4),(5);
+CREATE OR REPLACE PROCEDURE test()
+LANGUAGE plpgsql
+AS $procedure$
+    declare tmp_a int;
+    declare queryStr varchar;
+begin
+for tmp_a in (select a from procedure_tbl1 limit 5) loop
+        queryStr := 'insert into procedure_tbl2 values (' || tmp_a || ');';
+execute(queryStr);
+commit;
+end loop;
+end;
+$procedure$;
+call test();call test();
 -- cleanup
 DROP PROCEDURE ptest1;
 DROP PROCEDURE ptest2;

--- a/src/test/regress/sql/create_procedure.sql
+++ b/src/test/regress/sql/create_procedure.sql
@@ -154,6 +154,24 @@ ALTER ROUTINE ptest1(text) RENAME TO ptest1a;
 ALTER ROUTINE ptest1a RENAME TO ptest1;
 
 DROP ROUTINE cp_testfunc1(int);
+-- commit in procedure
+create table procedure_tbl1(a int);
+create table procedure_tbl2(a int);
+insert into procedure_tbl1 values(1),(2),(3),(4),(5);
+CREATE OR REPLACE PROCEDURE test()
+LANGUAGE plpgsql
+AS $procedure$
+    declare tmp_a int;
+    declare queryStr varchar;
+begin
+for tmp_a in (select a from procedure_tbl1 limit 5) loop
+        queryStr := 'insert into procedure_tbl2 values (' || tmp_a || ');';
+execute(queryStr);
+commit;
+end loop;
+end;
+$procedure$;
+call test();call test();
 
 
 -- cleanup


### PR DESCRIPTION
**Problem Description:**
When we create a procedure with a commit command in function body, and call the procedure continuously in a session,
"duplicate portal id" error will occur, like this:


test=>CREATE OR REPLACE PROCEDURE test()
LANGUAGE plpgsql
AS $procedure$
    declare tmp_a int;
    declare queryStr varchar;
begin
    for tmp_a in (select a from t1 limit 5) loop
        queryStr := 'insert into t2 values (' || tmp_a || ');';
        execute(queryStr);
        commit;                      
    end loop;
end;
$procedure$;
test=>call test();call test();
CALL
ERROR:  duplicate portal id 1 for proc 14132 (resqueue.c:384)          
         
         
        

**The reason is as below:**

However this problem only araises when gp_resource_manager is set to queue. 
1)When the first procedure is called, a portal will be created with portalId=1, variable portalId in resscheduler.c will be set to 1;
2)The procedure will execute commit command in function body, and call CommitTransaction()->AtCommit_ResScheduler(). In this progress， local resource queue lock will be released, but entry in ResPortalIncrementHash is not removed. And variable portalId in resscheduler.c will be set to 0;
3)When the first "call test()" complete, portalDrop will be called. PortalDrop will call ResLockRelease to release lock and entries in ResPortalIncrementHash. However, because local lock is relased in AtCommit_ResScheduler() in step 2, ResLockRelease will early quit and will not remove entries in ResPortalIncrementHash.
4)When the second  "call test()" is executed in the same session, ResCreatePortalId will be called again. The portalId variable in resscheduler.c will be set to 1; When ResLockAcquire is called and try to enter a portaltag with portalId=1, gpdb will find a entry with portalId=1 already exist in ResPortalIncrementHash. "duplicate portal error" with be raised.


**Steps to reproduce:**
```
-- using resource queue as gp_resource_manager
gpconfig -c gp_resource_manager -v queue
gpstop -ar

-- execute following queries with non-superuser, so that queries can be managed by resource queue:
create table t1(a int);
create table t2(a int);
insert into t1 values(1),(2),(3),(4),(5);
CREATE OR REPLACE PROCEDURE test()
LANGUAGE plpgsql
AS $procedure$
    declare tmp_a int;
    declare queryStr varchar;
begin
    for tmp_a in (select a from t1 limit 5) loop
        queryStr := 'insert into t2 values (' || tmp_a || ');';
        execute(queryStr);
        commit;                      
    end loop;
end;
$procedure$;

call test();call test();
-- error with araise like this:
CALL
ERROR:  duplicate portal id 1 for proc 14132 (resqueue.c:384)
```



**To solve this problem**, I try to find and remove remaining entries in ResPortalIncrementHash before portalId is reset to zero in AtCommit_ResScheduler(). I also add a test case to test my code.

Please hava a look at this. As I see in this issue: #14466 , resqueue queue will not be removed from Greenplum until next major version. I strongly recommend fixing this bug because Resource Queue is still commonly used by many users. Thank you.