### PR TITLE
Don't use streaming hashtable in DAQ

### DIFF
--- a/src/backend/executor/execHHashagg.c
+++ b/src/backend/executor/execHHashagg.c
@@ -32,6 +32,7 @@
 #include "utils/elog.h"
 #include "cdb/memquota.h"
 #include "utils/workfile_mgr.h"
+#include "utils/faultinjector.h"
 
 #include "access/hash.h"
 
@@ -467,6 +468,10 @@ lookup_agg_hash_entry(AggState *aggstate,
 	uint64 bloomval;			/* bloom filter value */
    
 	Assert(mt_bind != NULL);
+
+	if (SIMPLE_FAULT_INJECTOR("force_hashagg_stream_hashtable") == FaultInjectorTypeSkip)
+		if (((Agg *) aggstate->ss.ps.plan)->streaming)
+			return NULL;
 
 	if (p_isnew != NULL)
 		*p_isnew = false;

--- a/src/backend/gporca/libgpopt/src/xforms/CXformSplitDQA.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformSplitDQA.cpp
@@ -724,8 +724,8 @@ CXformSplitDQA::PexprMultiLevelAggregation(
 	CExpressionArray *pdrgpexprLastStage = pdrgpexprPrElSecondStage;
 	if (fSplit2LevelsOnly)
 	{
-		// for scalar DQA the local aggregate is responsible for removing duplicates
-		BOOL fLocalAggGeneratesDuplicates = (0 < pdrgpcrLastStage->Size());
+		// the local aggregate is responsible for removing duplicates
+		BOOL fLocalAggGeneratesDuplicates = false;
 
 		pdrgpcrArgDQA->AddRef();
 		popFirstStage = GPOS_NEW(mp) CLogicalGbAgg(

--- a/src/test/isolation2/expected/spilling_hashagg.out
+++ b/src/test/isolation2/expected/spilling_hashagg.out
@@ -1,0 +1,62 @@
+-- start_ignore
+-- end_ignore
+
+-- Test Orca properly removes duplicates in DQA
+-- (https://github.com/greenplum-db/gpdb/issues/14993)
+
+CREATE TABLE test_src_tbl AS WITH cte1 AS ( SELECT field5 from generate_series(1,1000) field5 ) SELECT field5 % 100 AS a, field5 % 100  + 1 AS b FROM cte1 DISTRIBUTED BY (a);
+CREATE 1000
+
+
+-- Use isolation2 framework to force a streaming hash aggregate to clear the
+-- hash table and stream tuples to next stage aggregate. This is to simulate
+-- hash table spills after 100 tuples inserted any segment.
+SELECT gp_inject_fault('force_hashagg_stream_hashtable', 'skip', '', '', '', 100, 100, 0, dbid) FROM gp_segment_configuration WHERE role='p';
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+ Success:        
+(4 rows)
+CREATE TABLE test_hashagg_on AS SELECT a, COUNT(DISTINCT b) AS b FROM test_src_tbl GROUP BY a;
+CREATE 100
+EXPLAIN (costs off) SELECT a, COUNT(DISTINCT b) AS b FROM test_src_tbl GROUP BY a;
+ QUERY PLAN                                 
+--------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)   
+   ->  HashAggregate                        
+         Group Key: a                       
+         ->  HashAggregate                  
+               Group Key: a, b              
+               ->  Seq Scan on test_src_tbl 
+ Optimizer: Pivotal Optimizer (GPORCA)      
+(7 rows)
+
+-- Compare results against a group aggregate plan.
+set optimizer_enable_hashagg=off;
+SET
+CREATE TABLE test_hashagg_off AS SELECT a, COUNT(DISTINCT b) AS b FROM test_src_tbl GROUP BY a;
+CREATE 100
+EXPLAIN (costs off) SELECT a, COUNT(DISTINCT b) AS b FROM test_src_tbl GROUP BY a;
+ QUERY PLAN                                 
+--------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)   
+   ->  GroupAggregate                       
+         Group Key: a                       
+         ->  Sort                           
+               Sort Key: a                  
+               ->  Seq Scan on test_src_tbl 
+ Optimizer: Pivotal Optimizer (GPORCA)      
+(7 rows)
+
+-- Results should match
+SELECT (n_total=n_matches) AS match FROM ( SELECT COUNT(*) n_total, SUM(CASE WHEN t1.b = t2.b THEN 1 ELSE 0 END) n_matches FROM test_hashagg_on t1 JOIN test_hashagg_off t2 ON t1.a = t2.a) t;
+ match 
+-------
+ t     
+(1 row)
+
+
+-- start_ignore
+-- end_ignore

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -317,3 +317,5 @@ test: alter_partition_table_owner
 
 # test copy/insert in utility mode on partition/inheritance hierarchies
 test: copy_insert_utility_mode_hierarchies
+
+test: spilling_hashagg

--- a/src/test/isolation2/sql/spilling_hashagg.sql
+++ b/src/test/isolation2/sql/spilling_hashagg.sql
@@ -1,0 +1,44 @@
+-- start_ignore
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+DROP TABLE IF EXISTS test_src_tbl;
+DROP TABLE IF EXISTS test_hashagg_on;
+DROP TABLE IF EXISTS test_hashagg_off;
+-- end_ignore
+
+-- Test Orca properly removes duplicates in DQA
+-- (https://github.com/greenplum-db/gpdb/issues/14993)
+
+CREATE TABLE test_src_tbl AS
+WITH cte1 AS (
+    SELECT field5 from generate_series(1,1000) field5
+)
+SELECT field5 % 100 AS a, field5 % 100  + 1 AS b
+FROM cte1 DISTRIBUTED BY (a);
+
+
+-- Use isolation2 framework to force a streaming hash aggregate to clear the
+-- hash table and stream tuples to next stage aggregate. This is to simulate
+-- hash table spills after 100 tuples inserted any segment.
+SELECT gp_inject_fault('force_hashagg_stream_hashtable', 'skip', '', '', '', 100, 100, 0, dbid) FROM gp_segment_configuration WHERE role='p';
+CREATE TABLE test_hashagg_on AS
+SELECT a, COUNT(DISTINCT b) AS b FROM test_src_tbl GROUP BY a;
+EXPLAIN (costs off) SELECT a, COUNT(DISTINCT b) AS b FROM test_src_tbl GROUP BY a;
+
+-- Compare results against a group aggregate plan.
+set optimizer_enable_hashagg=off;
+CREATE TABLE test_hashagg_off AS
+SELECT a, COUNT(DISTINCT b) AS b FROM test_src_tbl GROUP BY a;
+EXPLAIN (costs off) SELECT a, COUNT(DISTINCT b) AS b FROM test_src_tbl GROUP BY a;
+
+-- Results should match
+SELECT (n_total=n_matches) AS match FROM (
+SELECT COUNT(*) n_total, SUM(CASE WHEN t1.b = t2.b THEN 1 ELSE 0 END) n_matches
+FROM test_hashagg_on t1
+JOIN test_hashagg_off t2 ON t1.a = t2.a) t;
+
+
+-- start_ignore
+SELECT gp_inject_fault('force_hashagg_stream_hashtable', 'status', '', '', '', 100, 100, 0, dbid) FROM gp_segment_configuration WHERE role='p';
+SELECT gp_inject_fault('force_hashagg_stream_hashtable', 'reset', '', '', '', 100, 100, 0, dbid) FROM gp_segment_configuration WHERE role='p';
+RESET ALL;
+-- end_ignore


### PR DESCRIPTION
Hi gp hackers, I found the root cause of https://github.com/greenplum-db/gpdb/issues/14993 . When a query like `SELECT a, COUNT(DISTINCT b) FROM t GROUP BY a` is executed with a hashagg plan like this one:
```
                                   QUERY PLAN                                   
--------------------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..3366.93 rows=7 width=12)
   ->  HashAggregate  (cost=0.00..3366.93 rows=3 width=12)
         Group Key: a
         ->  HashAggregate  (cost=0.00..3212.44 rows=1273152 width=8)
               Group Key: a, b
               ->  Seq Scan on test  (cost=0.00..640.00 rows=10000034 width=8)
 Optimizer: Pivotal Optimizer (GPORCA)
(7 rows)
```
The second `HashAggregate` uses hybrid hashtable in streaming mode. That is, when the hashtable enumerating all distinct pairs of A and B fills up, we start it over instead of spilling to disc. This results in duplicates and we get more tuples as a result of this query. 
It seems that we are using streaming hashtable, because optimizer thinks that it is okay to produce duplicates for this plan HashAggregate (`<dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">` from minidump), but it is not. The fix I have here simply prohibits the aggregate node from producing duplicates, and it resolves the problem.

However, as I'm not familiar with ORCA at all, I probably either broke something else here or there is a more natural way to fix the problem. Let me know your suggestions.

A simple way to reproduce:
```sql
drop table if exists test;
create table test as
with cte1 as (
select field5  FROM generate_series(1,30000000) field5
)
select 
       cast(random() * 6 as int) as a,
       cast(random() * 999999  as int) + 1 as b
from cte1 distributed by (a);

set optimizer=on;
select a, count(distinct b) as b from test group by a;

set optimizer=off;
select a, count(distinct b) as b from test group by a;
```
This query gives very different results with and without orca.


## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
