### PR TITLE
[6X] Drop metadata tracking info when dropping schemas

### DIFF
--- a/src/backend/commands/schemacmds.c
+++ b/src/backend/commands/schemacmds.c
@@ -270,6 +270,10 @@ RemoveSchemaById(Oid schemaOid)
 	 * Remove all persistent error logs belonging to the the schema.
 	 */
 	PersistentErrorLogDelete(MyDatabaseId, schemaOid, NULL);
+
+	/* MPP-6929: metadata tracking */
+	if (Gp_role == GP_ROLE_DISPATCH)
+		MetaTrackDropObject(NamespaceRelationId, schemaOid);
 }
 
 

--- a/src/test/regress/expected/pg_stat_last_operation.out
+++ b/src/test/regress/expected/pg_stat_last_operation.out
@@ -16,6 +16,17 @@ AND actionname = 'TRUNCATE';
 -----------+---------+------------+------------+---------
 (0 rows)
 
+CREATE VIEW
+	pg_stat_last_operation_testview_schema AS
+SELECT lo.staactionname,
+       lo.stasubtype,
+       ns.nspname
+FROM   pg_stat_last_operation lo
+       join pg_class c
+         ON lo.classid = c.oid
+       join pg_namespace ns
+         ON c.relname = 'pg_namespace'
+            AND lo.objid = ns.oid;
 insert into PG_STAT_LAST_OPERATION_TEST select generate_series(1,100);
 truncate PG_STAT_LAST_OPERATION_TEST;
 SELECT classname, objname, schemaname, actionname, subtype 
@@ -26,4 +37,18 @@ AND actionname = 'TRUNCATE';
 -----------+-----------------------------+------------+------------+---------
  pg_class  | pg_stat_last_operation_test | public     | TRUNCATE   | 
 (1 row)
+
+-- CREATE/DROP SCHEMA
+CREATE SCHEMA mdt_schema;
+SELECT * FROM pg_stat_last_operation_testview_schema WHERE nspname LIKE 'mdt_%';
+ staactionname | stasubtype |  nspname   
+---------------+------------+------------
+ CREATE        | SCHEMA     | mdt_schema
+(1 row)
+
+DROP SCHEMA mdt_schema;
+SELECT * FROM pg_stat_last_operation_testview_schema WHERE nspname LIKE 'mdt_%';
+ staactionname | stasubtype | nspname 
+---------------+------------+---------
+(0 rows)
 

--- a/src/test/regress/sql/pg_stat_last_operation.sql
+++ b/src/test/regress/sql/pg_stat_last_operation.sql
@@ -10,6 +10,18 @@ FROM pg_stat_operations WHERE schemaname = 'public'
 AND objname = 'pg_stat_last_operation_test'
 AND actionname = 'TRUNCATE';
 
+CREATE VIEW
+	pg_stat_last_operation_testview_schema AS
+SELECT lo.staactionname,
+       lo.stasubtype,
+       ns.nspname
+FROM   pg_stat_last_operation lo
+       join pg_class c
+         ON lo.classid = c.oid
+       join pg_namespace ns
+         ON c.relname = 'pg_namespace'
+            AND lo.objid = ns.oid;
+
 insert into PG_STAT_LAST_OPERATION_TEST select generate_series(1,100);
 
 truncate PG_STAT_LAST_OPERATION_TEST;
@@ -18,3 +30,9 @@ SELECT classname, objname, schemaname, actionname, subtype
 FROM pg_stat_operations WHERE schemaname = 'public' 
 AND objname = 'pg_stat_last_operation_test'
 AND actionname = 'TRUNCATE';
+
+-- CREATE/DROP SCHEMA
+CREATE SCHEMA mdt_schema;
+SELECT * FROM pg_stat_last_operation_testview_schema WHERE nspname LIKE 'mdt_%';
+DROP SCHEMA mdt_schema;
+SELECT * FROM pg_stat_last_operation_testview_schema WHERE nspname LIKE 'mdt_%';


### PR DESCRIPTION
Backport from https://github.com/greenplum-db/gpdb/pull/14899

Due to some test flakiness, we found that when we drop a schema, we were not dropping the meta tracking rows in pg_stat_last_operation associated with the schema. We used to do that in RemoveSchema: c83fb8108854. But it was lost in 4750e1b65518a5575e0cc75eb6716cc7d5594139 which got rid of RemoveSchema and only used RemoveSchemaById ever since.

Now add back MetaTrackDropObject in RemoveSchemaById. Add test case too.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
