### PR TITLE
bug fix: catalog inconsistency of relhassubclass after analyze (6X)

### DIFF
--- a/src/backend/commands/analyze.c
+++ b/src/backend/commands/analyze.c
@@ -2042,18 +2042,6 @@ acquire_inherited_sample_rows(Relation onerel, int elevel,
 	ListCell   *lc;
 
 	/*
-	 * Like in acquire_sample_rows(), if we're in the QD, fetch the sample
-	 * from segments.
-	 */
-	if (Gp_role == GP_ROLE_DISPATCH)
-	{
-		return acquire_sample_rows_dispatcher(onerel,
-											  true, /* inherited stats */
-											  elevel, rows, targrows,
-											  totalrows, totaldeadrows);
-	}
-
-	/*
 	 * Find all members of inheritance set.  We only need AccessShareLock on
 	 * the children.
 	 */
@@ -2066,6 +2054,7 @@ acquire_inherited_sample_rows(Relation onerel, int elevel,
 	 * child but no longer does.  In that case, we can clear the
 	 * relhassubclass field so as not to make the same mistake again later.
 	 * (This is safe because we hold ShareUpdateExclusiveLock.)
+	 * Please refer to https://github.com/greenplum-db/gpdb/issues/14644
 	 */
 	if (list_length(tableOIDs) < 2)
 	{
@@ -2074,7 +2063,24 @@ acquire_inherited_sample_rows(Relation onerel, int elevel,
 		SetRelationHasSubclass(RelationGetRelid(onerel), false);
 		*totalrows = 0;
 		*totaldeadrows = 0;
-		return 0;
+		ereport(elevel,
+				(errmsg("skipping analyze of \"%s.%s\" inheritance tree --- this inheritance tree contains no child tables",
+						get_namespace_name(RelationGetNamespace(onerel)),
+						RelationGetRelationName(onerel))));
+		if (Gp_role == GP_ROLE_EXECUTE)
+			return 0;
+	}
+
+	/*
+	 * Like in acquire_sample_rows(), if we're in the QD, fetch the sample
+	 * from segments.
+	 */
+	if (Gp_role == GP_ROLE_DISPATCH)
+	{
+		return acquire_sample_rows_dispatcher(onerel,
+											  true, /* inherited stats */
+											  elevel, rows, targrows,
+											  totalrows, totaldeadrows);
 	}
 
 	/*

--- a/src/test/regress/expected/analyze.out
+++ b/src/test/regress/expected/analyze.out
@@ -982,3 +982,37 @@ select * from pg_stats where tablename = 'no_eqop';
  public     | no_eqop   | c       | t         |  0.333333 |        15 |          0 |                  |                   |                  |             |                   |                        | 
 (1 row)
 
+-- Issue 14644 keep catalog inconsistency of relhassubclass after analyze
+CREATE TYPE test_type_14644 AS (a int, b text);
+CREATE TABLE test_tb_14644 OF test_type_14644;
+CREATE TABLE test_tb_14644_subclass () INHERITS (test_tb_14644);
+DROP TABLE test_tb_14644_subclass;
+select relhassubclass from pg_class where relname = 'test_tb_14644';
+ relhassubclass 
+----------------
+ t
+(1 row)
+
+select relhassubclass from gp_dist_random('pg_class') where relname = 'test_tb_14644';
+ relhassubclass 
+----------------
+ t
+ t
+ t
+(3 rows)
+
+ANALYZE;
+select relhassubclass from pg_class where relname = 'test_tb_14644';
+ relhassubclass 
+----------------
+ f
+(1 row)
+
+select relhassubclass from gp_dist_random('pg_class') where relname = 'test_tb_14644';
+ relhassubclass 
+----------------
+ f
+ f
+ f
+(3 rows)
+

--- a/src/test/regress/sql/analyze.sql
+++ b/src/test/regress/sql/analyze.sql
@@ -496,3 +496,13 @@ analyze no_eqop(c);
 -- Simply merges leaf stats. gp_acquire_sample_rows() is not executed
 analyze verbose rootpartition no_eqop(c);
 select * from pg_stats where tablename = 'no_eqop';
+-- Issue 14644 keep catalog inconsistency of relhassubclass after analyze
+CREATE TYPE test_type_14644 AS (a int, b text);
+CREATE TABLE test_tb_14644 OF test_type_14644;
+CREATE TABLE test_tb_14644_subclass () INHERITS (test_tb_14644);
+DROP TABLE test_tb_14644_subclass;
+select relhassubclass from pg_class where relname = 'test_tb_14644';
+select relhassubclass from gp_dist_random('pg_class') where relname = 'test_tb_14644';
+ANALYZE;
+select relhassubclass from pg_class where relname = 'test_tb_14644';
+select relhassubclass from gp_dist_random('pg_class') where relname = 'test_tb_14644';


### PR DESCRIPTION
This pr can fix the bug reported in [issue 14644](https://github.com/greenplum-db/gpdb/issues/14644) for 6X_STABLE.
It is backport from [pr 14978](https://github.com/greenplum-db/gpdb/pull/14978).

**Bug Detail:**
After analyzing a table with a dropped subclass, the value on the coordinator may differ from the segments. See the SQL result with bug below:
```
gpadmin=# CREATE TYPE test_type2 AS (a int, b text);
CREATE TYPE
gpadmin=# CREATE TABLE test_tbl2 OF test_type2;
CREATE TABLE
gpadmin=# CREATE TABLE test_tbl2_subclass () INHERITS (test_tbl2);
CREATE TABLE
gpadmin=# DROP TABLE test_tbl2_subclass;
DROP TABLE
gpadmin=# analyze;
ANALYZE
gpadmin=# select gp_segment_id, relhassubclass from pg_class where relname = 'test_tbl2';        
gp_segment_id | relhassubclass
---------------+----------------
            -1 | t
(1 row)
 
gpadmin=# select gp_segment_id, relhassubclass from gp_dist_random('pg_class') where relname = 'test_tbl2';
 gp_segment_id | relhassubclass
---------------+----------------
             2 | f
             1 | f
             0 | f
(3 rows)
```

**Correct Behavior:**
The value of `relhassubclass` on the coordinator should be the same as segments.
```
gpadmin=# DROP TABLE test_tbl2_subclass;
DROP TABLE
gpadmin=# analyze;
ANALYZE
gpadmin=# select gp_segment_id, relhassubclass from pg_class where relname = 'test_tbl2';        
gp_segment_id | relhassubclass
---------------+----------------
            -1 | f
(1 row)
 
gpadmin=# select gp_segment_id, relhassubclass from gp_dist_random('pg_class') where relname = 'test_tbl2';
 gp_segment_id | relhassubclass
---------------+----------------
             2 | f
             1 | f
             0 | f
(3 rows)
```
**Signed-off-by**: Yongtao Huang <yongtaoh@vmware.com>

