### PR TITLE
Remove merge fixme from transformGpPartitionDefinition()

### DIFF
--- a/src/backend/parser/parse_partition_gp.c
+++ b/src/backend/parser/parse_partition_gp.c
@@ -1672,10 +1672,6 @@ transformGpPartitionDefinition(Oid parentrelid, const char *queryString,
 		}
 		else
 		{
-			/*
-			 * GPDB_12_MERGE_FIXME: can we optimize grammar to create separate lists
-			 * for elems and encoding in encClauses.
-			 */
 			Assert(IsA(newnode, ColumnReferenceStorageDirective));
 			encClauses = lappend(encClauses, newnode);
 		}


### PR DESCRIPTION
Currently, partition definition element can have mix of partition
definitions and also COLUMN ENCODING clauses within it.

For example:
```sql
CREATE TABLE foo (a1 int, a2 char(5)) using ao_row
partition by range (a1) (
start(1) end(5) every(1),  --> partition definition
COLUMN a1 ENCODING (compresstype=zstd) --> column encoding
);
```

Due to this when GpPartitionDefinition has single list of partDefElems
which contains partition definitions and also column encodings. Fixme
was to evaluate if current grammer can be optimized to generate
separate lists and eliminate the need for separating these later in
transformGpPartitionDefinition(). So, not essentially anything to fix,
just optimize.

After looking into the details - seems not straightforward without
modifing the grammer which will be breaking change. Also, don't see
much performance benefit either from the change as current code is
looping over partDefElems to transform, so not much extra cost added
from having them together. Also, we don't expect to have huge number
of elements in this list to overpower the cost from actually creating
these many partition tables.

There is also small refactor commit in this PR for the same function,
realized while reading code for FIXME.