### PR TITLE
Remove merge fixme from isolation2 setup test

### DIFF
--- a/gpMgmt/bin/gppylib/commands/pg.py
+++ b/gpMgmt/bin/gppylib/commands/pg.py
@@ -294,10 +294,13 @@ class PgBaseBackup(Command):
 
         cmd_tokens.extend(self._xlog_arguments(replication_slot_name))
 
-        # GPDB_12_MERGE_FEATURE_NOT_SUPPORTED: avoid checking checksum for heap tables
-        # till we code logic to skip/verify checksum for
-        # appendoptimized tables. Enabling this results in basebackup
-        # failures with appendoptimized tables.
+        # GPDB_12_MERGE_FEATURE_NOT_SUPPORTED: avoid checking checksum
+        # for heap tables till we code logic to skip/verify checksum
+        # for appendoptimized tables. Enabling this results in
+        # basebackup failures with appendoptimized tables. Note: Once
+        # this feature is enabled also modify isolation2 pg_basebackup
+        # function in setup.sql to remove this flag and by default
+        # test the checksum functionality.
         cmd_tokens.append('--no-verify-checksums')
 
         if forceoverwrite:

--- a/src/test/isolation2/expected/setup.out
+++ b/src/test/isolation2/expected/setup.out
@@ -115,7 +115,7 @@ if create_slot: cmd += ' --create-slot'
 if slotname is not None: cmd += ' --slot %s' % (slotname) 
 if force_overwrite: cmd += ' --force-overwrite' 
 if xlog_method == 'stream': cmd += ' --wal-method stream' elif xlog_method == 'fetch': cmd += ' --wal-method fetch' else: plpy.error('invalid xlog method') 
-# GPDB_12_MERGE_FIXME: avoid checking checksum for heap tables # till we code logic to skip/verify checksum for # appendoptimized tables. Enabling this results in basebackup # failures with appendoptimized tables. cmd += ' --no-verify-checksums' 
+cmd += ' --no-verify-checksums' 
 try: # Unset PGAPPNAME so that the pg_stat_replication.application_name is not affected if os.getenv('PGAPPNAME') is not None: os.environ.pop('PGAPPNAME') results = subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True).replace(b'.', b'').decode() except subprocess.CalledProcessError as e: results = str(e) + "\ncommand output: " + e.output 
 return results $$ language plpython3u;
 CREATE

--- a/src/test/isolation2/sql/setup.sql
+++ b/src/test/isolation2/sql/setup.sql
@@ -348,10 +348,6 @@ create or replace function pg_basebackup(host text, dbid int, port int, create_s
     else:
         plpy.error('invalid xlog method')
 
-    # GPDB_12_MERGE_FIXME: avoid checking checksum for heap tables
-    # till we code logic to skip/verify checksum for
-    # appendoptimized tables. Enabling this results in basebackup
-    # failures with appendoptimized tables.
     cmd += ' --no-verify-checksums'
 
     try:


### PR DESCRIPTION
The fixme is for pg_basebackup --no-verify-checksums flag. This feature doesn't work and hence is not supported currently in GPDB as no way to identify based on physical files if AO or HEAP. Need to come up with some mechanism to enable this feature. Till that happens, no point having FIXME related to it in test file.

Adding breadcrumbs with GPDB_12_MERGE_FEATURE_NOT_SUPPORTED comment to fix the isolation2 setup file as well once feature is enabled. Removing the fixme from setup.sql and setup.out file.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
