### PR TITLE
gpexpand: Fix tables not copied to new segments

### DIFF
--- a/gpMgmt/bin/gppylib/gpcatalog.py
+++ b/gpMgmt/bin/gppylib/gpcatalog.py
@@ -25,9 +25,6 @@ class GPCatalogException(Exception):
 COORDINATOR_ONLY_TABLES = [
     'gp_configuration_history',
     'gp_segment_configuration',
-    'pg_auth_time_constraint',
-    'pg_description',
-    'pg_shdescription',
     'pg_stat_last_operation',
     'pg_stat_last_shoperation',
     'pg_statistic',

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -3194,6 +3194,21 @@ def impl(context, num_of_segments):
             "%s\ndump of gp_segment_configuration: %s" %
             (context.start_data_segments, end_data_segments, rows))
 
+@when('verify that {table_name} catalog table is present on new segments')
+@then('verify that {table_name} catalog table is present on new segments')
+def impl(context, table_name):
+    dbname = 'gptest'
+    with closing(dbconn.connect(dbconn.DbURL(dbname=dbname), unsetSearchPath=False)) as conn:
+        query = """SELECT count(*) from gp_segment_configuration where -1 < content and role='p'"""
+        no_of_segments = dbconn.querySingleton(conn, query)
+
+        query = """select count(distinct(gp_segment_id)) from gp_dist_random('%s')""" % table_name
+        no_segments_table_present = dbconn.querySingleton(conn, query)
+
+    if no_of_segments != no_segments_table_present:
+        raise Exception("Table %s is not present on newly expanded segments" % table_name)
+
+
 @given('the cluster is setup for an expansion on hosts "{hostnames}"')
 def impl(context, hostnames):
     hosts = hostnames.split(",")


### PR DESCRIPTION
**Issue:**
A customer reported an issue where they were unable to DROP time-based login constraints for users after running gpexpand. This was because, if there are time-based login constraints for users, there are entries in the `pg_auth_time_constraints` catalog table that are identical across all segments. However, when gpexpand was run, this table was not replicated to new segments. As a result, running the DROP command would give an error.
```
# alter user user03 drop deny for day 4 time '18:00:00' ;
NOTICE:  dropping DENY rule for "user03" between Thursday 18:00:00 and Saturday 23:59:59
ERROR:  cannot find matching DENY rules for "user03"  (seg3 192.168.50.53:6000 pid=4429)
```

**RCA:**
The reason why the table was not getting replicated is because gpexpand creates a template of the coordinator segment and uses it to create new segments in the cluster. As part of the cleanup process(since it uses coordinator template), some catalog tables present only on the coordinator are being removed from the new segments. This list of tables is defined in the `COORDINATOR_ONLY_TABLES` list in `gpcatalog.py`.

Catalog tables like `pg_auth_time_constraint`, `pg_description`, and `pg_shdescription` are also part of the `COORDINATOR_ONLY_TABLES` list, but these are present on all segments and not just on the coordinator.

**Fix:**
This commit removes the tables mentioned above from the `COORDINATOR_ONLY_TABLES` list.

Also added a behave test case to verify if these tables are present on all the newly created segments.

[Pipeline](https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb-dev-7x_gpexpand_fix)