### PR TITLE
brin: table AM API for block traversal

### DIFF
--- a/src/backend/access/appendonly/appendonlyam_handler.c
+++ b/src/backend/access/appendonly/appendonlyam_handler.c
@@ -1683,6 +1683,61 @@ appendonly_relation_size(Relation rel, ForkNumber forkNumber)
 }
 
 /*
+ * For each AO segment, get the starting heap block number and the number of
+ * heap blocks (together termed as a BlockSequence). The starting heap block
+ * number is always deterministic given a segment number. See AOtupleId.
+ *
+ * The number of heap blocks can be determined from the last row number present
+ * in the segment. See appendonlytid.h for details.
+ */
+static BlockSequence *
+appendonly_relation_get_block_sequences(Relation rel,
+										int *numSequences)
+{
+	Snapshot		snapshot;
+	Oid				segrelid;
+	int				nsegs;
+	BlockSequence	*sequences;
+	FileSegInfo 	**seginfos;
+
+	Assert(RelationIsValid(rel));
+	Assert(numSequences);
+
+	snapshot = RegisterSnapshot(GetCatalogSnapshot(InvalidOid));
+
+	seginfos = GetAllFileSegInfo(rel, snapshot, &nsegs, &segrelid);
+	Assert(nsegs <= AOTupleId_MaxSegmentFileNum);
+	sequences = (BlockSequence *) palloc(sizeof(BlockSequence) * nsegs);
+	*numSequences = nsegs;
+
+	/*
+	 * For each aoseg, the sequence starts at a fixed heap block number and
+	 * contains up to the highest numbered heap block corresponding to the
+	 * lastSequence value of that segment.
+	 */
+	for (int i = 0; i < nsegs; i++)
+	{
+		int segno = seginfos[i]->segno;
+		int64 lastSequence = ReadLastSequence(segrelid, segno);
+
+		sequences[i].startblknum = AOSegmentGet_startHeapBlock(segno);
+		sequences[i].nblocks = lastSequence / AO_MAX_TUPLES_PER_HEAP_BLOCK;
+		if (lastSequence % AO_MAX_TUPLES_PER_HEAP_BLOCK > 0)
+			sequences[i].nblocks += 1;
+	}
+
+	UnregisterSnapshot(snapshot);
+
+	if (seginfos != NULL)
+	{
+		FreeAllSegFileInfo(seginfos, nsegs);
+		pfree(seginfos);
+	}
+
+	return sequences;
+}
+
+/*
  * Check to see whether the table needs a TOAST table.  It does only if
  * (1) there are any toastable attributes, and (2) the maximum length
  * of a tuple could exceed TOAST_TUPLE_THRESHOLD.  (We don't want to
@@ -1964,6 +2019,7 @@ static const TableAmRoutine ao_row_methods = {
 	.index_validate_scan = appendonly_index_validate_scan,
 
 	.relation_size = appendonly_relation_size,
+	.relation_get_block_sequences = appendonly_relation_get_block_sequences,
 	.relation_needs_toast_table = appendonly_relation_needs_toast_table,
 
 	.relation_estimate_size = appendonly_estimate_rel_size,

--- a/src/backend/access/brin/README
+++ b/src/backend/access/brin/README
@@ -189,6 +189,30 @@ Future improvements
   summarization on blocks that have seen lots of tuple deletions.
 
 
+GPDB:
+
+We have introduced a new table AM API relation_get_block_sequences() that helps
+unify code for block-based iteration for BRIN scan and summarization, in a
+table AM agnostic manner.
+
+At its heart is the critical observation that BRIN indexes deal with chunks of
+the tid space, represented in units of heap blocks. The resultant heap block
+boundaries are physical for heap tables, but are logical for AO/CO tables
+(AO/CO tables may have holes in the tid space due to how rownumber allocation
+is done). BRIN conceptually operates on these logical boundaries for tid
+selection, and we fully exploit that.
+
+A contiguous set of these logical heap blocks is what we term as BlockSequences.
+Two BlockSequences may not be contiguous, but are contiguous within themselves.
+The table AM API expects that we return a set of such BlockSequences. Heap
+tables have only 1 block sequence, whereas AO/CO tables have 1 block sequence
+per aoseg/aocsseg. See BlockSequence for more details.
+
+Once we have the list of BlockSequences, we introduce an outer loop for
+iterating over these. Within the outer loop the existing upstream loop is
+leveraged. This applies to both bringetbitmap() and brinsummarize().
+
+
 BRIN on append only tables
 --------------------------
 

--- a/src/backend/access/brin/README
+++ b/src/backend/access/brin/README
@@ -212,6 +212,9 @@ Once we have the list of BlockSequences, we introduce an outer loop for
 iterating over these. Within the outer loop the existing upstream loop is
 leveraged. This applies to both bringetbitmap() and brinsummarize().
 
+Sometimes, an alternative API is also needed: to get the block sequence, given
+a logical heap block number. For that purpose, we have introduced
+relation_get_block_sequence().
 
 BRIN on append only tables
 --------------------------

--- a/src/backend/access/brin/brin.c
+++ b/src/backend/access/brin/brin.c
@@ -360,72 +360,6 @@ brinbeginscan(Relation r, int nkeys, int norderbys)
 	return scan;
 }
 
-static BlockNumber
-brin_ao_tid_ranges(Relation rel, BlockNumber *aoblks)
-{
-	Snapshot	snapshot;
-	BlockNumber seg_start_blk;
-	BlockNumber nblocks = 0;
-    Oid			segrelid;
-	int64		lastSequence;
-	int			segnos[AOTupleId_MaxSegmentFileNum] = {0};
-    int			nsegs;
-
-	Assert(RelationIsValid(rel));
-
-	snapshot = RegisterSnapshot(GetCatalogSnapshot(InvalidOid));
-
-	if (RelationIsAoRows(rel))
-	{
-		FileSegInfo **seginfos = GetAllFileSegInfo(rel, snapshot, &nsegs, &segrelid);
-
-		Assert(nsegs <= AOTupleId_MaxSegmentFileNum);
-
-		for (int i = 0; i < nsegs; i++)
-			segnos[i] = seginfos[i]->segno;
-
-		if (seginfos != NULL)
-		{
-			FreeAllSegFileInfo(seginfos, nsegs);
-			pfree(seginfos);
-		}
-	}	
-	else
-	{
-		AOCSFileSegInfo **seginfos = GetAllAOCSFileSegInfo(rel, snapshot, &nsegs, &segrelid);
-
-		Assert(nsegs <= AOTupleId_MaxSegmentFileNum);
-
-		for (int i = 0; i < nsegs; i++)
-			segnos[i] = seginfos[i]->segno;
-
-		if (seginfos != NULL)
-		{
-			FreeAllAOCSSegFileInfo(seginfos, nsegs);
-			pfree(seginfos);
-		}
-	}
-
-	/* call ReadLastSequence() only for segnos corresponding to the target relation */
-    for (int i = -1, segno; i < nsegs; i++)
-    {
-        /* always initailize segment 0 */
-        segno = (i < 0 ? 0 : segnos[i]);
-        lastSequence = ReadLastSequence(segrelid, segno);
-
-        seg_start_blk = segnoGetCurrentAosegStart(segno);
-        aoblks[segno] = lastSequence / 32768;
-        if (lastSequence % 32768 > 0)
-            aoblks[segno] += 1;
-        if (lastSequence > 0)
-            nblocks = seg_start_blk + aoblks[segno];
-    }
-
-    UnregisterSnapshot(snapshot);
-
-	return nblocks;
-}
-
 /*
  * Execute the index scan.
  *
@@ -448,8 +382,6 @@ bringetbitmap(IndexScanDesc scan, Node **bmNodeP)
 	Oid			heapOid;
 	Relation	heapRel;
 	BrinOpaque *opaque;
-	BlockNumber nblocks = 0;
-	BlockNumber aoBlocks[AOTupleId_MaxSegmentFileNum];
 	BlockNumber heapBlk;
 	int			totalpages = 0;
 	FmgrInfo   *consistentFn;
@@ -458,8 +390,10 @@ bringetbitmap(IndexScanDesc scan, Node **bmNodeP)
 	BrinMemTuple *dtup;
 	BrinTuple  *btup = NULL;
 	Size		btupsz = 0;
-	int			segno;
-	BlockNumber seg_start_blk;
+
+	/* GPDB: Used for iterating over the revmap */
+	int         	numSequences;
+	BlockSequence 	*sequences;
 
 	opaque = (BrinOpaque *) scan->opaque;
 	bdesc = opaque->bo_bdesc;
@@ -482,22 +416,10 @@ bringetbitmap(IndexScanDesc scan, Node **bmNodeP)
 	else
 		tbm = (TIDBitmap *)*bmNodeP;
 
-	/*
-	 * We need to know the size of the table so that we know how long to
-	 * iterate on the revmap.
-	 */
 	heapOid = IndexGetRelation(RelationGetRelid(idxRel), false);
 	heapRel = table_open(heapOid, AccessShareLock);
-
-	/*
-	 * If the data table is append only table, we need to calculate the range
-	 * of tid in each aoseg.
-	 */
-	if (RelationIsAppendOptimized(heapRel))
-		nblocks = brin_ao_tid_ranges(heapRel, aoBlocks);
-	else
-		nblocks = RelationGetNumberOfBlocks(heapRel);
-
+	sequences = table_relation_get_block_sequences(heapRel,
+												   &numSequences);
 	table_close(heapRel, AccessShareLock);
 
 	/*
@@ -520,12 +442,25 @@ bringetbitmap(IndexScanDesc scan, Node **bmNodeP)
 	oldcxt = MemoryContextSwitchTo(perRangeCxt);
 
 	/*
-	 * Now scan the revmap.  We start by querying for heap page 0,
-	 * incrementing by the number of pages per range; this gives us a full
-	 * view of the table.
+	 * GPDB: We have the notion of BlockSequences to keep the following code
+	 * section unified for AO/CO vs heap tables. Heap tables have only 1
+	 * block sequence, whereas AO/CO tables may have up to AOTupleId_MaxSegmentFileNum
+	 * number of such sequences. The outer loop is thus a GPDB addition, whereas
+	 * the inner one mostly stays the same (barring offset recalculation)
 	 */
-	segno = 0;
-	for (heapBlk = 0; heapBlk < nblocks; heapBlk += opaque->bo_pagesPerRange)
+	for (int i = 0; i < numSequences; i++)
+	{
+	/* code in the loop left unindented to prevent merge conflicts */
+
+	/*
+	 * Now scan the revmap. We start by querying for the 1st heap page in
+	 * the ith block sequence, incrementing by the number of pages per range;
+	 * this gives us a full view of each block sequence and ultimately, the
+	 * full table.
+	 */
+	BlockNumber startblknum = sequences[i].startblknum;
+	BlockNumber endblknum = sequences[i].startblknum + sequences[i].nblocks;
+	for (heapBlk = startblknum; heapBlk < endblknum; heapBlk += opaque->bo_pagesPerRange)
 	{
 		bool		addrange;
 		bool		gottuple = false;
@@ -534,23 +469,6 @@ bringetbitmap(IndexScanDesc scan, Node **bmNodeP)
 		Size		size;
 
 		CHECK_FOR_INTERRUPTS();
-
-		/*
-		 * If the largest row number of the current aoseg is scanned, switch to
-		 * the next aoseg.
-		 */
-		if (RelationIsAppendOptimized(heapRel))
-		{
-			seg_start_blk = segnoGetCurrentAosegStart(segno);
-
-			if (heapBlk >= seg_start_blk + aoBlocks[segno])
-			{
-				segno++;
-				continue;
-			}
-			if (heapBlk < seg_start_blk)
-				heapBlk = seg_start_blk;
-		}
 
 		MemoryContextResetAndDeleteChildren(perRangeCxt);
 
@@ -652,7 +570,7 @@ bringetbitmap(IndexScanDesc scan, Node **bmNodeP)
 			BlockNumber pageno;
 
 			for (pageno = heapBlk;
-				 pageno <= Min(nblocks, heapBlk + opaque->bo_pagesPerRange) - 1;
+				 pageno <= Min(endblknum, heapBlk + opaque->bo_pagesPerRange) - 1;
 				 pageno++)
 			{
 				MemoryContextSwitchTo(oldcxt);
@@ -663,8 +581,12 @@ bringetbitmap(IndexScanDesc scan, Node **bmNodeP)
 		}
 	}
 
+	/* outer loop end */
+	}
+
 	MemoryContextSwitchTo(oldcxt);
 	MemoryContextDelete(perRangeCxt);
+	pfree(sequences);
 
 	if (buf != InvalidBuffer)
 		ReleaseBuffer(buf);
@@ -1484,48 +1406,78 @@ brinsummarize(Relation index, Relation heapRel, BlockNumber pageRange,
 {
 	BrinRevmap *revmap;
 	BrinBuildState *state = NULL;
-	IndexInfo  *indexInfo = NULL;
-	BlockNumber heapNumBlocks = 0;
+	IndexInfo   *indexInfo = NULL;
 	BlockNumber pagesPerRange;
-	BlockNumber startBlk;
-	BlockNumber aoBlocks[AOTupleId_MaxSegmentFileNum] = {0};
 	Buffer		buf;
-	int			segno;
-	BlockNumber seg_start_blk;
+
+	/* GPDB: Used for iterating over the revmap */
+	int         	numSequences;
+	BlockSequence 	*sequences;
+	BlockNumber		startBlk = InvalidBlockNumber;
+	BlockNumber		endBlk = InvalidBlockNumber;
 
 	revmap = brinRevmapInitialize(index, &pagesPerRange, NULL);
 
-	/* determine range of pages to process */
+	/* determine sequence(s) of pages to process */
+	sequences = table_relation_get_block_sequences(heapRel,
+												   &numSequences);
+
+	buf = InvalidBuffer;
 
 	/*
-	 * If the data table is append only table, we need to calculate the range
-	 * of tid in each aoseg.
+	 * GPDB: We have the notion of BlockSequences to keep the following code
+	 * section unified for AO/CO vs heap tables. Heap tables have only 1
+	 * block sequence, whereas AO/CO tables may have up to AOTupleId_MaxSegmentFileNum
+	 * number of such sequences. The outer loop is thus a GPDB addition, whereas
+	 * the inner one mostly stays the same (barring offset recalculation for
+	 * both the all ranges case and specific range case)
 	 */
-	if (RelationIsAppendOptimized(heapRel))
-		heapNumBlocks = brin_ao_tid_ranges(heapRel, aoBlocks);
-	else
-		heapNumBlocks = RelationGetNumberOfBlocks(heapRel);
+
+	for (int i = 0; i < numSequences; i++)
+	{
+	/* code in the loop left unindented to prevent merge conflicts */
 
 	if (pageRange == BRIN_ALL_BLOCKRANGES)
-		startBlk = 0;
+	{
+		/* set up the start and end blocks for the next block sequence */
+		startBlk = sequences[i].startblknum;
+		endBlk = sequences[i].startblknum + sequences[i].nblocks;
+	}
 	else
 	{
+		/* we have to scan the supplied heap block in its specified range */
+
+		/*
+		 * XXX: This branch contains code that only works for heap tables, and
+		 * assumes that there is only 1 range. To support AO/CO tables, we will
+		 * need to define a table AM API:
+		 * BlockSequence * (* relation_get_block_sequence) (Relation rel,
+		 * 													BlockNumber blkNo)
+		 * with which we can find the endBlk of the specific range we have been
+		 * asked to scan.
+		 */
+
+		Assert(RelationIsHeap(heapRel));
+
+		/* should have to loop only once as there is only 1 sequence for heap */
+		Assert(numSequences == 1);
+
 		startBlk = (pageRange / pagesPerRange) * pagesPerRange;
-		heapNumBlocks = Min(heapNumBlocks, startBlk + pagesPerRange);
-	}
-	if (startBlk > heapNumBlocks)
-	{
-		/* Nothing to do if start point is beyond end of table */
-		brinRevmapTerminate(revmap);
-		return;
+		endBlk = Min(sequences[i].nblocks, startBlk + pagesPerRange);
+		if (startBlk > endBlk)
+		{
+			/* Nothing to do if start point is beyond end of table */
+			brinRevmapTerminate(revmap);
+			pfree(sequences);
+			return;
+		}
 	}
 
 	/*
-	 * Scan the revmap to find unsummarized items.
+	 * Scan the revmap to find unsummarized items for each block sequence
+	 * involved.
 	 */
-	buf = InvalidBuffer;
-	segno = 0;
-	for (; startBlk < heapNumBlocks; startBlk += pagesPerRange)
+	for (; startBlk < endBlk; startBlk += pagesPerRange)
 	{
 		BrinTuple  *tup;
 		OffsetNumber off;
@@ -1538,27 +1490,11 @@ brinsummarize(Relation index, Relation heapRel, BlockNumber pageRange,
 		 * result of arbitrarily-scheduled maintenance command (vacuuming).
 		 */
 		if (!include_partial &&
-			(startBlk + pagesPerRange > heapNumBlocks))
+			(startBlk + pagesPerRange > endBlk))
 			break;
 
 		CHECK_FOR_INTERRUPTS();
 
-		/*
-		 * If the data table is append only table, we need to calculate the range
-		 * of tid in each aoseg.
-		 */
-		if (RelationIsAppendOptimized(heapRel))
-		{
-			seg_start_blk = segnoGetCurrentAosegStart(segno);
-
-			if (startBlk >= seg_start_blk + aoBlocks[segno])
-			{
-				segno++;
-				continue;
-			}
-			if (startBlk < seg_start_blk)
-				startBlk = seg_start_blk;
-		}
 		tup = brinGetTupleForHeapBlock(revmap, startBlk, &buf, &off, NULL,
 									   BUFFER_LOCK_SHARE, NULL);
 		if (tup == NULL)
@@ -1572,7 +1508,7 @@ brinsummarize(Relation index, Relation heapRel, BlockNumber pageRange,
 												   pagesPerRange);
 				indexInfo = BuildIndexInfo(index);
 			}
-			summarize_range(indexInfo, state, heapRel, startBlk, heapNumBlocks);
+			summarize_range(indexInfo, state, heapRel, startBlk, endBlk);
 
 			/* and re-initialize state for the next range */
 			brin_memtuple_initialize(state->bs_dtuple, state->bs_bdesc);
@@ -1588,6 +1524,9 @@ brinsummarize(Relation index, Relation heapRel, BlockNumber pageRange,
 		}
 	}
 
+	/* outer loop end */
+	}
+
 	if (BufferIsValid(buf))
 		ReleaseBuffer(buf);
 
@@ -1598,6 +1537,7 @@ brinsummarize(Relation index, Relation heapRel, BlockNumber pageRange,
 		terminate_brin_buildstate(state);
 		pfree(indexInfo);
 	}
+	pfree(sequences);
 }
 
 /*

--- a/src/backend/access/brin/brin_revmap.c
+++ b/src/backend/access/brin/brin_revmap.c
@@ -832,18 +832,3 @@ heapBlockGetCurrentAosegStart(BlockNumber heapBlk)
 {
 	return heapBlk & 0xFE000000;
 }
-
-/*
- * Get the start block number of the current aoseg by seg number.
- *
- * append-optimized table logically has 128 segment files. The highest 7 bits
- * of the logical Tid represent the segment file number. So, segment file number
- * with zero after is the start block number in a segment file.
- */
-BlockNumber
-segnoGetCurrentAosegStart(int segno)
-{
-	BlockNumber blk;
-	blk = segno;
-	return blk << 25;
-}

--- a/src/backend/access/heap/heapam_handler.c
+++ b/src/backend/access/heap/heapam_handler.c
@@ -2095,6 +2095,25 @@ heapam_relation_size(Relation rel, ForkNumber forkNumber)
 }
 
 /*
+ * GPDB: Heap tables only have 1 block sequence as they don't have segments like
+ * append-optimized tables. This sequence extends from block 0 to the number of
+ * blocks in the table.
+ */
+static BlockSequence *
+heap_relation_get_block_sequences(Relation rel,
+								  int *numSequences)
+{
+	BlockSequence *blockSequence = palloc(sizeof(BlockSequence) * 1);
+	Assert(numSequences);
+	*numSequences = 1;
+
+	blockSequence->startblknum = 0;
+	blockSequence->nblocks = RelationGetNumberOfBlocks(rel);
+
+	return blockSequence;
+}
+
+/*
  * Check to see whether the table needs a TOAST table.  It does only if
  * (1) there are any toastable attributes, and (2) the maximum length
  * of a tuple could exceed TOAST_TUPLE_THRESHOLD.  (We don't want to
@@ -2731,6 +2750,7 @@ static const TableAmRoutine heapam_methods = {
 	.index_validate_scan = heapam_index_validate_scan,
 
 	.relation_size = heapam_relation_size,
+	.relation_get_block_sequences = heap_relation_get_block_sequences,
 	.relation_needs_toast_table = heapam_relation_needs_toast_table,
 
 	.relation_estimate_size = heapam_estimate_rel_size,

--- a/src/backend/access/heap/heapam_handler.c
+++ b/src/backend/access/heap/heapam_handler.c
@@ -2099,17 +2099,27 @@ heapam_relation_size(Relation rel, ForkNumber forkNumber)
  * append-optimized tables. This sequence extends from block 0 to the number of
  * blocks in the table.
  */
+static void
+heap_relation_get_block_sequence(Relation rel,
+								 BlockNumber heapBlk,
+								 BlockSequence *sequence)
+{
+	sequence->startblknum = 0;
+	sequence->nblocks = RelationGetNumberOfBlocks(rel);
+}
+
 static BlockSequence *
 heap_relation_get_block_sequences(Relation rel,
 								  int *numSequences)
 {
-	BlockSequence *blockSequence = palloc(sizeof(BlockSequence) * 1);
+	BlockSequence *blockSequence;
+
 	Assert(numSequences);
 	*numSequences = 1;
 
-	blockSequence->startblknum = 0;
-	blockSequence->nblocks = RelationGetNumberOfBlocks(rel);
+	blockSequence = palloc(sizeof(BlockSequence) * 1);
 
+	heap_relation_get_block_sequence(rel, InvalidBlockNumber, blockSequence);
 	return blockSequence;
 }
 
@@ -2751,6 +2761,7 @@ static const TableAmRoutine heapam_methods = {
 
 	.relation_size = heapam_relation_size,
 	.relation_get_block_sequences = heap_relation_get_block_sequences,
+	.relation_get_block_sequence = heap_relation_get_block_sequence,
 	.relation_needs_toast_table = heapam_relation_needs_toast_table,
 
 	.relation_estimate_size = heapam_estimate_rel_size,

--- a/src/backend/access/table/tableamapi.c
+++ b/src/backend/access/table/tableamapi.c
@@ -93,6 +93,7 @@ GetTableAmRoutine(Oid amhandler)
 	Assert(routine->index_validate_scan != NULL);
 
 	Assert(routine->relation_size != NULL);
+	Assert(routine->relation_get_block_sequences != NULL);
 	Assert(routine->relation_needs_toast_table != NULL);
 
 	Assert(routine->relation_estimate_size != NULL);

--- a/src/backend/access/table/tableamapi.c
+++ b/src/backend/access/table/tableamapi.c
@@ -94,6 +94,7 @@ GetTableAmRoutine(Oid amhandler)
 
 	Assert(routine->relation_size != NULL);
 	Assert(routine->relation_get_block_sequences != NULL);
+	Assert(routine->relation_get_block_sequence != NULL);
 	Assert(routine->relation_needs_toast_table != NULL);
 
 	Assert(routine->relation_estimate_size != NULL);

--- a/src/include/access/appendonlytid.h
+++ b/src/include/access/appendonlytid.h
@@ -63,6 +63,15 @@ typedef struct AOTupleId
  */
 #define AO_MAX_TUPLES_PER_HEAP_BLOCK	(1 << 15)
 
+/*
+ * This represents the maximum number of logical heap blocks that an AO segment
+ * file can contain. The 25 bits in the middle, describe in AOTupleId gives us
+ * this value.
+ */
+#define AO_MAX_HEAP_BLOCKS_PER_SEGMENT	(1 << 25)
+
+#define AOSegmentGet_segno(heapBlk) ((heapBlk) / AO_MAX_HEAP_BLOCKS_PER_SEGMENT)
+
 #define AOTupleIdGet_segmentFileNum(h)        ((((h)->bytes_0_1&0xFE00)>>9)) // 7 bits
 
 /*

--- a/src/include/access/appendonlytid.h
+++ b/src/include/access/appendonlytid.h
@@ -56,8 +56,24 @@ typedef struct AOTupleId
 	uint16		bytes_4_5;
 } AOTupleId;
 
-#define AO_MAX_OFFSET	32768
+/*
+ * This represents the maximum number of row numbers (or tuples) per logical
+ * heap block that an AO table can hold. The lower bytes: bytes_4_5 of AOTupleId
+ * gives us this value.
+ */
+#define AO_MAX_TUPLES_PER_HEAP_BLOCK	(1 << 15)
+
 #define AOTupleIdGet_segmentFileNum(h)        ((((h)->bytes_0_1&0xFE00)>>9)) // 7 bits
+
+/*
+ * Get the start block number of the specified aoseg.
+ *
+ * The higher order 32 bits of an AOTupleId (bytes_0_1 and bytes_2_3), form the
+ * heap block number when it is interpreted as an ItemPointer. Within that the
+ * top 7 bits form the segno. The starting heap block number is thus those
+ * combos of those 7 bits with the remaining 25 bits all being 0.
+ */
+#define AOSegmentGet_startHeapBlock(segno) ((segno) << 25)
 
 static inline uint64
 AOTupleIdGet_rowNum(AOTupleId *h)

--- a/src/include/access/brin_revmap.h
+++ b/src/include/access/brin_revmap.h
@@ -57,6 +57,5 @@ extern bool brinRevmapDesummarizeRange(Relation idxrel, BlockNumber heapBlk);
 
 extern void brin_init_upper_pages(Relation index, BlockNumber pagesPerRange);
 extern BlockNumber heapBlockGetCurrentAosegStart(BlockNumber heapBlk);
-extern BlockNumber segnoGetCurrentAosegStart(int segno);
 
 #endif							/* BRIN_REVMAP_H */

--- a/src/include/access/tableam.h
+++ b/src/include/access/tableam.h
@@ -645,6 +645,13 @@ typedef struct TableAmRoutine
 														  int *numSequences);
 
 	/*
+	 * See table_relation_get_block_sequence()
+	 */
+	void		(*relation_get_block_sequence) (Relation rel,
+												BlockNumber blkNum,
+												BlockSequence *sequence);
+
+	/*
 	 * This callback should return true if the relation requires a TOAST table
 	 * and false if it does not.  It may wish to examine the relation's tuple
 	 * descriptor before making a decision, but if it uses some other method
@@ -1780,6 +1787,18 @@ static inline BlockSequence *
 table_relation_get_block_sequences(Relation rel, int *numSequences)
 {
 	return rel->rd_tableam->relation_get_block_sequences(rel, numSequences);
+}
+
+/*
+ * GPDB: Determines the block sequence in which the supplied block number falls.
+ * See BlockSequence for details. Currently used by BRIN.
+ */
+static inline void
+table_relation_get_block_sequence(Relation rel,
+								  BlockNumber blkNumber,
+								  BlockSequence *sequence)
+{
+	rel->rd_tableam->relation_get_block_sequence(rel, blkNumber, sequence);
 }
 
 /*

--- a/src/include/catalog/aoseg.h
+++ b/src/include/catalog/aoseg.h
@@ -17,11 +17,32 @@
 #ifndef AOSEG_H
 #define AOSEG_H
 
+#include "access/appendonlytid.h"
 #include "storage/lock.h"
+#include "gp_fastsequence.h"
 
 /*
  * aoseg.c prototypes
  */
 extern void AlterTableCreateAoSegTable(Oid relOid);
+
+/*
+ * Given the aosegrel oid and segno for an append-optimized table, populate the
+ * provided BlockSequence.
+ */
+static inline void
+AOSegment_PopulateBlockSequence(BlockSequence *sequence,
+								Oid segrelid,
+								int segno)
+{
+	int64 lastSequence = ReadLastSequence(segrelid, segno);
+
+	Assert(sequence);
+	Assert(OidIsValid(segrelid));
+	Assert(segno >= 0 && segno <= AOTupleId_MaxSegmentFileNum);
+
+	sequence->startblknum = AOSegmentGet_startHeapBlock(segno);
+	FastSequenceGetNumHeapBlocks(lastSequence, &sequence->nblocks);
+}
 
 #endif   /* AOSEG_H */

--- a/src/include/catalog/gp_fastsequence.h
+++ b/src/include/catalog/gp_fastsequence.h
@@ -44,6 +44,16 @@ typedef FormData_gp_fastsequence *Form_gp_fastsequence;
 extern void InsertInitialFastSequenceEntries(Oid objid);
 
 /*
+ * Populate the number of logical heap blocks provided a lastSequence value from
+ * the gp_fastsequence catalog table.
+ */
+#define FastSequenceGetNumHeapBlocks(lastSequence, nblocks) \
+do { \
+	*(nblocks) = (lastSequence) / AO_MAX_TUPLES_PER_HEAP_BLOCK; \
+	if (lastSequence % AO_MAX_TUPLES_PER_HEAP_BLOCK > 0) \
+		*(nblocks) += 1; \
+} while (0)
+/*
  * GetFastSequences
  *
  * Get a list of consecutive sequence numbers. The starting sequence

--- a/src/test/isolation2/input/uao/brin.source
+++ b/src/test/isolation2/input/uao/brin.source
@@ -1,0 +1,47 @@
+-- Test cases with concurrency for BRIN indexes on AO/CO tables.
+
+-- Note: We use loops to populate logical heap pages in one aoseg. These logical
+-- heap blocks can start at a large number. See AOSegmentGet_startHeapBlock(segno).
+
+-- Ensure that we don't summarize the last partial range in case it was extended
+-- by another transaction, while summarization was in flight.
+
+CREATE TABLE brin_range_extended_@amname@(i int) USING @amname@;
+CREATE INDEX ON brin_range_extended_@amname@ USING brin(i) WITH (pages_per_range=5);
+-- Insert 4 blocks of data on 1 QE, in 1 aoseg; 3 blocks full, 1 block with 1 tuple.
+DO $$ /* in func */
+DECLARE curtid tid; /* in func */
+BEGIN /* in func */
+  LOOP /* in func */
+    INSERT INTO brin_range_extended_@amname@ VALUES (1) RETURNING ctid INTO curtid; /* in func */
+    EXIT WHEN curtid > tid '(33554435, 0)'; /* in func */
+  END LOOP; /* in func */
+END; /* in func */
+$$; /* in func */
+
+-- Set up to suspend execution when will attempt to summarize the final partial
+-- range below: [33554435, 33554437].
+SELECT gp_inject_fault('summarize_last_partial_range', 'suspend', dbid)
+  FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+
+1&: SELECT brin_summarize_new_values('brin_range_extended_@amname@_i_idx');
+
+SELECT gp_wait_until_triggered_fault('summarize_last_partial_range', 1, dbid)
+  FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+
+-- Extend the last partial range by 1 block.
+DO $$ /* in func */
+DECLARE curtid tid; /* in func */
+BEGIN /* in func */
+  LOOP /* in func */
+    INSERT INTO brin_range_extended_@amname@ VALUES (1) RETURNING ctid INTO curtid; /* in func */
+    EXIT WHEN curtid > tid '(33554436, 0)'; /* in func */
+  END LOOP; /* in func */
+END; /* in func */
+$$; /* in func */
+
+SELECT gp_inject_fault('summarize_last_partial_range', 'reset', dbid)
+  FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+
+-- Summarize should only have summarized the first full range: [33554432, 33554434]
+1<:

--- a/src/test/isolation2/input/uao/limit_indexscan_inits.source
+++ b/src/test/isolation2/input/uao/limit_indexscan_inits.source
@@ -5,10 +5,11 @@
 -- We are using gp_ao_or_aocs_seg() helper UDF to obtain the number of AO/CO segfiles (segnos),
 -- then plus 1 to count in segfile0 due to the implementation constraint.
 -- For BTREE index, we verify the equation: post_nscans - pre_nscans == segnos + 1;
--- for BRIN index, we verify the equation: post_nscans - pre_nscans == (segnos + 1) * 2.
+-- for BRIN index, we verify the equation: post_nscans - pre_nscans == ((segnos + 1) * 2 - 1).
 -- BRIN index doubles the number of nscans of BTREE because lastSequence was initialized twice
 -- during BRIN indexed bitmapheapscan (in index_getbitmap and ao/co fetch_init), which is probably
--- optimizable, too.
+-- optimizable, too. We also deduct 1 because gp_fastsequence is not scanned for
+-- seg0 to determine block sequences for AO/CO tables (if seg0 is absent).
 
 create or replace function test_iscan_inits_same_as_aosegs(tablename text, icol text, itype text) returns bool as $$
 declare
@@ -27,8 +28,8 @@ begin
         select post_nscans - pre_nscans = segnos + 1 into result; /* calculate the diff and compare to segnos plus 1 to count in segfile0, expect equal */
         raise notice '[BTREE] expect: post_nscans - pre_nscans == segnos + 1'; /* in func */
     elsif quote_ident(itype) = 'brin' then /* for BRIN index */
-        select post_nscans - pre_nscans = (segnos + 1) * 2 into result; /* BRIN doubles nscans(of BTREE) due to implementation constraint */
-        raise notice '[BRIN] expect: post_nscans - pre_nscans == (segnos + 1) * 2'; /* in func */
+        select post_nscans - pre_nscans = ((segnos + 1) * 2 - 1) into result; /* BRIN doubles nscans(of BTREE) due to implementation constraint */
+        raise notice '[BRIN] expect: post_nscans - pre_nscans == ((segnos + 1) * 2 - 1)'; /* in func */
     else /* in func */
         raise exception 'unexpected type of index %', itype::text; /* in func */
     end if; /* in func */

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -109,6 +109,7 @@ test: disable_autovacuum
 # Tests on Append-Optimized tables (row-oriented).
 test: concurrent_index_creation_should_not_deadlock
 test: uao/alter_while_vacuum_row uao/alter_while_vacuum2_row
+test: uao/brin_row
 test: uao/compaction_full_stats_row
 test: uao/compaction_utility_row
 test: uao/compaction_utility_insert_row
@@ -164,6 +165,7 @@ test: segwalrep/master_wal_switch
 
 # Tests on Append-Optimized tables (column-oriented).
 test: uao/alter_while_vacuum_column uao/alter_while_vacuum2_column
+test: uao/brin_column
 test: uao/compaction_full_stats_column
 test: uao/compaction_utility_column
 test: uao/compaction_utility_insert_column

--- a/src/test/isolation2/output/uao/brin.source
+++ b/src/test/isolation2/output/uao/brin.source
@@ -1,0 +1,44 @@
+-- Test cases with concurrency for BRIN indexes on AO/CO tables.
+
+-- Note: We use loops to populate logical heap pages in one aoseg. These logical
+-- heap blocks can start at a large number. See AOSegmentGet_startHeapBlock(segno).
+
+-- Ensure that we don't summarize the last partial range in case it was extended
+-- by another transaction, while summarization was in flight.
+
+CREATE TABLE brin_range_extended_@amname@(i int) USING @amname@;
+CREATE
+CREATE INDEX ON brin_range_extended_@amname@ USING brin(i) WITH (pages_per_range=5);
+CREATE
+-- Insert 4 blocks of data on 1 QE, in 1 aoseg; 3 blocks full, 1 block with 1 tuple.
+DO $$ /* in func */ DECLARE curtid tid; /* in func */ BEGIN /* in func */ LOOP /* in func */ INSERT INTO brin_range_extended_@amname@ VALUES (1) RETURNING ctid INTO curtid; /* in func */ EXIT WHEN curtid > tid '(33554435, 0)'; /* in func */ END LOOP; /* in func */ END; /* in func */ $$; /* in func */ 
+-- Set up to suspend execution when will attempt to summarize the final partial
+-- range below: [33554435, 33554437].
+SELECT gp_inject_fault('summarize_last_partial_range', 'suspend', dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+1&: SELECT brin_summarize_new_values('brin_range_extended_@amname@_i_idx');  <waiting ...>
+
+SELECT gp_wait_until_triggered_fault('summarize_last_partial_range', 1, dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
+-- Extend the last partial range by 1 block.
+DO $$ /* in func */ DECLARE curtid tid; /* in func */ BEGIN /* in func */ LOOP /* in func */ INSERT INTO brin_range_extended_@amname@ VALUES (1) RETURNING ctid INTO curtid; /* in func */ EXIT WHEN curtid > tid '(33554436, 0)'; /* in func */ END LOOP; /* in func */ END; /* in func */ $$; /* in func */ 
+SELECT gp_inject_fault('summarize_last_partial_range', 'reset', dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+-- Summarize should only have summarized the first full range: [33554432, 33554434]
+1<:  <... completed>
+ brin_summarize_new_values 
+---------------------------
+ 1                         
+(1 row)

--- a/src/test/isolation2/output/uao/limit_indexscan_inits.source
+++ b/src/test/isolation2/output/uao/limit_indexscan_inits.source
@@ -5,14 +5,15 @@
 -- We are using gp_ao_or_aocs_seg() helper UDF to obtain the number of AO/CO segfiles (segnos),
 -- then plus 1 to count in segfile0 due to the implementation constraint.
 -- For BTREE index, we verify the equation: post_nscans - pre_nscans == segnos + 1;
--- for BRIN index, we verify the equation: post_nscans - pre_nscans == (segnos + 1) * 2.
+-- for BRIN index, we verify the equation: post_nscans - pre_nscans == ((segnos + 1) * 2 - 1).
 -- BRIN index doubles the number of nscans of BTREE because lastSequence was initialized twice
 -- during BRIN indexed bitmapheapscan (in index_getbitmap and ao/co fetch_init), which is probably
--- optimizable, too.
+-- optimizable, too. We also deduct 1 because gp_fastsequence is not scanned for
+-- seg0 to determine block sequences for AO/CO tables (if seg0 is absent).
 
 create or replace function test_iscan_inits_same_as_aosegs(tablename text, icol text, itype text) returns bool as $$ declare segnos smallint; /* in func */ pre_nscans smallint; /* in func */ post_nscans smallint; /* in func */ result bool; /* in func */ begin select count(segno) into segnos from gp_ao_or_aocs_seg(tablename); /* in func */ 
 select pg_stat_get_xact_numscans('gp_fastsequence_objid_objmod_index'::regclass) into pre_nscans; /* get idx_scan before query */ execute 'select * from ' || quote_ident(tablename) || ' where ' || quote_ident(icol) || ' = 2'; /* vaule 2 is distributed to the segment with content 0 */ select pg_stat_get_xact_numscans('gp_fastsequence_objid_objmod_index'::regclass) into post_nscans; /* get idx_scan after query */ 
-if quote_ident(itype) = 'btree' then /* for BTREE index */ select post_nscans - pre_nscans = segnos + 1 into result; /* calculate the diff and compare to segnos plus 1 to count in segfile0, expect equal */ raise notice '[BTREE] expect: post_nscans - pre_nscans == segnos + 1'; /* in func */ elsif quote_ident(itype) = 'brin' then /* for BRIN index */ select post_nscans - pre_nscans = (segnos + 1) * 2 into result; /* BRIN doubles nscans(of BTREE) due to implementation constraint */ raise notice '[BRIN] expect: post_nscans - pre_nscans == (segnos + 1) * 2'; /* in func */ else /* in func */ raise exception 'unexpected type of index %', itype::text; /* in func */ end if; /* in func */ 
+if quote_ident(itype) = 'btree' then /* for BTREE index */ select post_nscans - pre_nscans = segnos + 1 into result; /* calculate the diff and compare to segnos plus 1 to count in segfile0, expect equal */ raise notice '[BTREE] expect: post_nscans - pre_nscans == segnos + 1'; /* in func */ elsif quote_ident(itype) = 'brin' then /* for BRIN index */ select post_nscans - pre_nscans = ((segnos + 1) * 2 - 1) into result; /* BRIN doubles nscans(of BTREE) due to implementation constraint */ raise notice '[BRIN] expect: post_nscans - pre_nscans == ((segnos + 1) * 2 - 1)'; /* in func */ else /* in func */ raise exception 'unexpected type of index %', itype::text; /* in func */ end if; /* in func */ 
 raise notice 'pre_nscans = %, post_nscans = %, segnos = %', pre_nscans, post_nscans, segnos; /* verbose */ 
 return result; /* in func */ end; /* in func */ $$ language plpgsql;
 CREATE

--- a/src/test/regress/expected/brin.out
+++ b/src/test/regress/expected/brin.out
@@ -1,4 +1,7 @@
-CREATE TABLE brintest (byteacol bytea,
+-- GPDB: Most of these test steps are modified such that the tables' tuples are
+-- co-located on one QE.
+CREATE TABLE brintest (id int,
+    byteacol bytea,
 	charcol "char",
 	namecol name,
 	int8col bigint,
@@ -28,6 +31,7 @@ CREATE TABLE brintest (byteacol bytea,
 	boxcol box
 ) WITH (fillfactor=10, autovacuum_enabled=off);
 INSERT INTO brintest SELECT
+	1,
 	repeat(stringu1, 8)::bytea,
 	substr(stringu1, 1, 1)::"char",
 	stringu1::name, 142857 * tenthous,
@@ -57,7 +61,8 @@ INSERT INTO brintest SELECT
 	box(point(odd, even), point(thousand, twothousand))
 FROM tenk1 ORDER BY unique2 LIMIT 100;
 -- throw in some NULL's and different values
-INSERT INTO brintest (inetcol, cidrcol, int4rangecol) SELECT
+INSERT INTO brintest (id, inetcol, cidrcol, int4rangecol) SELECT
+	1,
 	inet 'fe80::6e40:8ff:fea9:8c46' + tenthous,
 	cidr 'fe80::6e40:8ff:fea9:8c46' + tenthous,
 	'empty'::int4range
@@ -399,6 +404,7 @@ RESET enable_bitmapscan;
 RESET optimizer_enable_tablescan;
 RESET optimizer_enable_bitmapscan;
 INSERT INTO brintest SELECT
+	1,
 	repeat(stringu1, 42)::bytea,
 	substr(stringu1, 1, 1)::"char",
 	stringu1::name, 142857 * tenthous,
@@ -478,29 +484,42 @@ DO $$
 DECLARE curtid tid;
 BEGIN
   LOOP
+    -- GPDB: INSERT of value = 1 guarantees that all values are on one segment.
     INSERT INTO brin_summarize VALUES (1) RETURNING ctid INTO curtid;
-    EXIT WHEN curtid > tid '(2, 0)';
+    EXIT WHEN curtid > tid '(6, 0)';
   END LOOP;
 END;
 $$;
--- summarize one range
+-- range [0,1] is already summarized since current (at start of insert) range is
+-- summarized by the DO..INSERT above
 SELECT brin_summarize_range('brin_summarize_idx', 0);
-ERROR:  Greenplum could not summarize indicated page range  (seg0 slice1 127.0.0.1:7002 pid=11998)
--- nothing: already summarized
+ brin_summarize_range 
+----------------------
+                    0
+(1 row)
+
 SELECT brin_summarize_range('brin_summarize_idx', 1);
-ERROR:  Greenplum could not summarize indicated page range  (seg0 slice1 127.0.0.1:7002 pid=11998)
--- summarize one range
+ brin_summarize_range 
+----------------------
+                    0
+(1 row)
+
+-- summarize one range: [2,3]
 SELECT brin_summarize_range('brin_summarize_idx', 2);
-ERROR:  Greenplum could not summarize indicated page range  (seg0 slice1 127.0.0.1:7002 pid=11998)
--- summarize all pages
-SELECT brin_summarize_range('brin_summarize_idx', 4294967295);
  brin_summarize_range 
 ----------------------
                     1
 (1 row)
 
--- nothing: page doesn't exist in table
+-- summarize all pages: should summarize ranges [3,4] and [5,6] only
 SELECT brin_summarize_range('brin_summarize_idx', 4294967295);
+ brin_summarize_range 
+----------------------
+                    2
+(1 row)
+
+-- nothing: page doesn't exist in table
+SELECT brin_summarize_range('brin_summarize_idx', 5);
  brin_summarize_range 
 ----------------------
                     0

--- a/src/test/regress/expected/brin_ao.out
+++ b/src/test/regress/expected/brin_ao.out
@@ -1,4 +1,7 @@
-CREATE TABLE brintest_ao (byteacol bytea,
+-- Most of these test steps are modified such that the tables' tuples are
+-- co-located on one QE.
+CREATE TABLE brintest_ao (id int,
+	byteacol bytea,
 	charcol "char",
 	namecol name,
 	int8col bigint,
@@ -28,6 +31,7 @@ CREATE TABLE brintest_ao (byteacol bytea,
 	boxcol box
 ) WITH (appendonly = true);
 INSERT INTO brintest_ao SELECT
+	1,
 	repeat(stringu1, 8)::bytea,
 	substr(stringu1, 1, 1)::"char",
 	stringu1::name, 142857 * tenthous,
@@ -57,7 +61,8 @@ INSERT INTO brintest_ao SELECT
 	box(point(odd, even), point(thousand, twothousand))
 FROM tenk1 ORDER BY unique2 LIMIT 100;
 -- throw in some NULL's and different values
-INSERT INTO brintest_ao (inetcol, cidrcol, int4rangecol) SELECT
+INSERT INTO brintest_ao (id, inetcol, cidrcol, int4rangecol) SELECT
+	1,
 	inet 'fe80::6e40:8ff:fea9:8c46' + tenthous,
 	cidr 'fe80::6e40:8ff:fea9:8c46' + tenthous,
 	'empty'::int4range
@@ -411,6 +416,7 @@ RESET enable_bitmapscan;
 RESET optimizer_enable_tablescan;
 RESET optimizer_enable_bitmapscan;
 INSERT INTO brintest_ao SELECT
+	1,
 	repeat(stringu1, 42)::bytea,
 	substr(stringu1, 1, 1)::"char",
 	stringu1::name, 142857 * tenthous,
@@ -445,20 +451,14 @@ UPDATE brintest_ao SET textcol = '' WHERE textcol IS NOT NULL;
 -- Vaccum again so that a new segment file is created.
 VACUUM brintest_ao;
 INSERT INTO brintest_ao SELECT * FROM brintest_ao;
--- We should have two segment files per Greenplum segment (QE). 
--- start_ignore
-SELECT segment_id, segno, tupcount, state FROM gp_toolkit.__gp_aoseg('brintest_ao');
- segment_id | segno | tupcount | state 
-------------+-------+----------+-------
-          2 |     1 |      120 |     2
-          2 |     2 |       80 |     1
-          0 |     1 |      128 |     2
-          0 |     2 |      102 |     1
-          1 |     1 |      117 |     2
-          1 |     2 |       78 |     1
-(6 rows)
+-- We should have two segment files.
+SELECT segment_id, segno FROM gp_toolkit.__gp_aoseg('brintest_ao');
+ segment_id | segno 
+------------+-------
+          1 |     1
+          1 |     2
+(2 rows)
 
--- end_ignore
 -- Tests for brin_summarize_new_values
 SELECT brin_summarize_new_values('brintest_ao'); -- error, not an index
 ERROR:  "brintest_ao" is not an index
@@ -472,3 +472,7 @@ SELECT brin_summarize_new_values('brinaoidx'); -- ok, no change expected
                          0
 (1 row)
 
+-- We don't allow specific range summarization for AO tables at the moment.
+SELECT brin_summarize_range('brinaoidx', 1);
+ERROR:  cannot summarize specific page range for append-optimized tables  (seg0 slice1 192.168.0.148:7002 pid=2970354)
+CONTEXT:  SQL function "brin_summarize_range" statement 1

--- a/src/test/regress/expected/brin_ao.out
+++ b/src/test/regress/expected/brin_ao.out
@@ -1,5 +1,6 @@
 -- Most of these test steps are modified such that the tables' tuples are
 -- co-located on one QE.
+-- Test scan correctness
 CREATE TABLE brintest_ao (id int,
 	byteacol bytea,
 	charcol "char",
@@ -445,34 +446,89 @@ INSERT INTO brintest_ao SELECT
 	format('%s/%s%s', odd, even, tenthous)::pg_lsn,
 	box(point(odd, even), point(thousand, twothousand))
 FROM tenk1 ORDER BY unique2 LIMIT 5 OFFSET 5;
-VACUUM brintest_ao;  -- force a summarization cycle in brinaoidx
-UPDATE brintest_ao SET int8col = int8col * int4col;
-UPDATE brintest_ao SET textcol = '' WHERE textcol IS NOT NULL;
--- Vaccum again so that a new segment file is created.
-VACUUM brintest_ao;
-INSERT INTO brintest_ao SELECT * FROM brintest_ao;
--- We should have two segment files.
-SELECT segment_id, segno FROM gp_toolkit.__gp_aoseg('brintest_ao');
- segment_id | segno 
-------------+-------
-          1 |     1
-          1 |     2
-(2 rows)
+-- Test summarization
+-- Note: We use loops to populate logical heap pages in one aoseg. These logical
+-- heap blocks can start at a large number. See AOSegmentGet_startHeapBlock(segno).
+CREATE TABLE brin_ao_summarize(i int) USING ao_row;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE INDEX ON brin_ao_summarize USING brin(i) WITH (pages_per_range=1);
+-- There is no data, so nothing to summarize.
+SELECT brin_summarize_new_values('brin_ao_summarize_i_idx');
+ brin_summarize_new_values 
+---------------------------
+                         0
+(1 row)
 
--- Tests for brin_summarize_new_values
-SELECT brin_summarize_new_values('brintest_ao'); -- error, not an index
-ERROR:  "brintest_ao" is not an index
-CONTEXT:  SQL function "brin_summarize_new_values" statement 1
-SELECT brin_summarize_new_values('tenk1_unique1'); -- error, not a BRIN index
-ERROR:  "tenk1_unique1" is not a BRIN index
-CONTEXT:  SQL function "brin_summarize_new_values" statement 1
-SELECT brin_summarize_new_values('brinaoidx'); -- ok, no change expected
+DROP INDEX brin_ao_summarize_i_idx;
+-- Create 3 blocks all on 1 QE, in 1 aoseg: 2 blocks full, 1 block with 1 tuple.
+DO $$
+DECLARE curtid tid;
+BEGIN
+  LOOP
+    INSERT INTO brin_ao_summarize VALUES (1) RETURNING ctid INTO curtid;
+    EXIT WHEN curtid > tid '(33554434, 0)';
+  END LOOP;
+END;
+$$;
+-- Now create the index on the data inserted above.
+CREATE INDEX ON brin_ao_summarize USING brin(i) WITH (pages_per_range=1);
+-- There is nothing new to summarize - it was all done during the index build.
+SELECT brin_summarize_new_values('brin_ao_summarize_i_idx');
+ brin_summarize_new_values 
+---------------------------
+                         0
+(1 row)
+
+-- Insert more so we have 5 blocks on 1 QE, in 1 aoseg: 4 blocks full, 1 block
+-- with 1 tuple. The last and penultimate blocks will be unsummarized.
+DO $$
+DECLARE curtid tid;
+BEGIN
+  LOOP
+    INSERT INTO brin_ao_summarize VALUES (20) RETURNING ctid INTO curtid;
+    EXIT WHEN curtid > tid '(33554436, 0)';
+  END LOOP;
+END;
+$$;
+-- The last 2 blocks will be summarized.
+SELECT brin_summarize_new_values('brin_ao_summarize_i_idx');
+ brin_summarize_new_values 
+---------------------------
+                         2
+(1 row)
+
+-- Insert more so we have 7 blocks on 1 QE, in 1 aoseg: 6 blocks full, 1 page
+-- with 1 tuple. The last and penultimate blocks are unsummarized.
+DO $$
+DECLARE curtid tid;
+BEGIN
+  LOOP
+    INSERT INTO brin_ao_summarize VALUES (30) RETURNING ctid INTO curtid;
+    EXIT WHEN curtid > tid '(33554438, 0)';
+  END LOOP;
+END;
+$$;
+DELETE FROM brin_ao_summarize WHERE i = 1;
+VACUUM brin_ao_summarize;
+-- All the tuples will have been moved to one aoseg and all the tuples should
+-- have fit in one logical heap block.
+SELECT distinct(right(split_part(ctid::text, ',', 1), -1)) AS blknum
+  FROM brin_ao_summarize;
+  blknum  
+----------
+ 67108864
+(1 row)
+
+-- VACUUM should have already summarized this one logical heap block, so
+-- invoking summarization again will be a no-op.
+SELECT brin_summarize_new_values('brin_ao_summarize_i_idx');
  brin_summarize_new_values 
 ---------------------------
                          0
 (1 row)
 
 -- We don't allow specific range summarization for AO tables at the moment.
-SELECT brin_summarize_range('brinaoidx', 1);
-ERROR:  cannot summarize specific page range for append-optimized tables  (seg0 slice1 192.168.0.148:7002 pid=2970354)
+SELECT brin_summarize_range('brin_ao_summarize_i_idx', 1);
+ERROR:  cannot summarize specific page range for append-optimized tables  (seg2 slice1 192.168.0.148:7004 pid=25354)
 CONTEXT:  SQL function "brin_summarize_range" statement 1

--- a/src/test/regress/expected/brin_ao.out
+++ b/src/test/regress/expected/brin_ao.out
@@ -532,3 +532,34 @@ SELECT brin_summarize_new_values('brin_ao_summarize_i_idx');
 SELECT brin_summarize_range('brin_ao_summarize_i_idx', 1);
 ERROR:  cannot summarize specific page range for append-optimized tables  (seg2 slice1 192.168.0.148:7004 pid=25354)
 CONTEXT:  SQL function "brin_summarize_range" statement 1
+-- Test summarization of last partial range.
+CREATE TABLE brin_ao_summarize_partial(i int) USING ao_row;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE INDEX ON brin_ao_summarize_partial USING brin(i) WITH (pages_per_range=3);
+-- Insert 4 blocks of data on 1 QE, in 1 aoseg; 3 blocks full, 1 block with 1 tuple.
+-- The 1st range [33554432, 33554434] is full and the last range [33554435, 33554437]
+-- is partially full with just 1 block: 33554435.
+DO $$
+DECLARE curtid tid;
+BEGIN
+  LOOP
+    INSERT INTO brin_ao_summarize_partial VALUES (1) RETURNING ctid INTO curtid;
+    EXIT WHEN curtid > tid '(33554435, 0)';
+  END LOOP;
+END;
+$$;
+-- We should successfully summarize the last partial range.
+--
+-- Note: For an empty AO table, when INSERTing into the 1st range, we don't
+-- summarize. brininsert() -> brinGetTupleForHeapBlock() actually returns NULL
+-- in this case as revmap_get_blkno_ao() returns InvalidBlockNumber.
+-- This is contrary to heap behavior (where we return 1).
+--
+-- Thus, we will have both ranges summarized here.
+SELECT brin_summarize_new_values('brin_ao_summarize_partial_i_idx');
+ brin_summarize_new_values 
+---------------------------
+                         2
+(1 row)
+

--- a/src/test/regress/expected/brin_ao_optimizer.out
+++ b/src/test/regress/expected/brin_ao_optimizer.out
@@ -1,4 +1,7 @@
-CREATE TABLE brintest_ao (byteacol bytea,
+-- Most of these test steps are modified such that the tables' tuples are
+-- co-located on one QE.
+CREATE TABLE brintest_ao (id int,
+	byteacol bytea,
 	charcol "char",
 	namecol name,
 	int8col bigint,
@@ -28,6 +31,7 @@ CREATE TABLE brintest_ao (byteacol bytea,
 	boxcol box
 ) WITH (appendonly = true);
 INSERT INTO brintest_ao SELECT
+	1,
 	repeat(stringu1, 8)::bytea,
 	substr(stringu1, 1, 1)::"char",
 	stringu1::name, 142857 * tenthous,
@@ -57,7 +61,8 @@ INSERT INTO brintest_ao SELECT
 	box(point(odd, even), point(thousand, twothousand))
 FROM tenk1 ORDER BY unique2 LIMIT 100;
 -- throw in some NULL's and different values
-INSERT INTO brintest_ao (inetcol, cidrcol, int4rangecol) SELECT
+INSERT INTO brintest_ao (id, inetcol, cidrcol, int4rangecol) SELECT
+	1,
 	inet 'fe80::6e40:8ff:fea9:8c46' + tenthous,
 	cidr 'fe80::6e40:8ff:fea9:8c46' + tenthous,
 	'empty'::int4range
@@ -429,6 +434,7 @@ RESET enable_bitmapscan;
 RESET optimizer_enable_tablescan;
 RESET optimizer_enable_bitmapscan;
 INSERT INTO brintest_ao SELECT
+	1,
 	repeat(stringu1, 42)::bytea,
 	substr(stringu1, 1, 1)::"char",
 	stringu1::name, 142857 * tenthous,
@@ -463,20 +469,14 @@ UPDATE brintest_ao SET textcol = '' WHERE textcol IS NOT NULL;
 -- Vaccum again so that a new segment file is created.
 VACUUM brintest_ao;
 INSERT INTO brintest_ao SELECT * FROM brintest_ao;
--- We should have two segment files per Greenplum segment (QE). 
--- start_ignore
-SELECT segment_id, segno, tupcount, state FROM gp_toolkit.__gp_aoseg('brintest_ao');
- segment_id | segno | tupcount | state 
-------------+-------+----------+-------
-          2 |     1 |      120 |     2
-          2 |     2 |       80 |     1
-          0 |     1 |      128 |     2
-          0 |     2 |      102 |     1
-          1 |     1 |      117 |     2
-          1 |     2 |       78 |     1
-(6 rows)
+-- We should have two segment files.
+SELECT segment_id, segno FROM gp_toolkit.__gp_aoseg('brintest_ao');
+ segment_id | segno 
+------------+-------
+          1 |     1
+          1 |     2
+(2 rows)
 
--- end_ignore
 -- Tests for brin_summarize_new_values
 SELECT brin_summarize_new_values('brintest_ao'); -- error, not an index
 ERROR:  "brintest_ao" is not an index
@@ -490,3 +490,7 @@ SELECT brin_summarize_new_values('brinaoidx'); -- ok, no change expected
                          0
 (1 row)
 
+-- We don't allow specific range summarization for AO tables at the moment.
+SELECT brin_summarize_range('brinaoidx', 1);
+ERROR:  cannot summarize specific page range for append-optimized tables  (seg0 slice1 192.168.0.148:7002 pid=3012326)
+CONTEXT:  SQL function "brin_summarize_range" statement 1

--- a/src/test/regress/expected/brin_ao_optimizer.out
+++ b/src/test/regress/expected/brin_ao_optimizer.out
@@ -552,3 +552,34 @@ SELECT brin_summarize_new_values('brin_ao_summarize_i_idx');
 SELECT brin_summarize_range('brin_ao_summarize_i_idx', 1);
 ERROR:  cannot summarize specific page range for append-optimized tables  (seg0 slice1 192.168.0.148:7002 pid=20357)
 CONTEXT:  SQL function "brin_summarize_range" statement 1
+-- Test summarization of last partial range.
+CREATE TABLE brin_ao_summarize_partial(i int) USING ao_row;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE INDEX ON brin_ao_summarize_partial USING brin(i) WITH (pages_per_range=3);
+-- Insert 4 blocks of data on 1 QE, in 1 aoseg; 3 blocks full, 1 block with 1 tuple.
+-- The 1st range [33554432, 33554434] is full and the last range [33554435, 33554437]
+-- is partially full with just 1 block: 33554435.
+DO $$
+DECLARE curtid tid;
+BEGIN
+  LOOP
+    INSERT INTO brin_ao_summarize_partial VALUES (1) RETURNING ctid INTO curtid;
+    EXIT WHEN curtid > tid '(33554435, 0)';
+  END LOOP;
+END;
+$$;
+-- We should successfully summarize the last partial range.
+--
+-- Note: For an empty AO table, when INSERTing into the 1st range, we don't
+-- summarize. brininsert() -> brinGetTupleForHeapBlock() actually returns NULL
+-- in this case as revmap_get_blkno_ao() returns InvalidBlockNumber.
+-- This is contrary to heap behavior (where we return 1).
+--
+-- Thus, we will have both ranges summarized here.
+SELECT brin_summarize_new_values('brin_ao_summarize_partial_i_idx');
+ brin_summarize_new_values 
+---------------------------
+                         2
+(1 row)
+

--- a/src/test/regress/expected/brin_ao_optimizer.out
+++ b/src/test/regress/expected/brin_ao_optimizer.out
@@ -1,5 +1,6 @@
 -- Most of these test steps are modified such that the tables' tuples are
 -- co-located on one QE.
+-- Test scan correctness
 CREATE TABLE brintest_ao (id int,
 	byteacol bytea,
 	charcol "char",
@@ -463,34 +464,91 @@ INSERT INTO brintest_ao SELECT
 	format('%s/%s%s', odd, even, tenthous)::pg_lsn,
 	box(point(odd, even), point(thousand, twothousand))
 FROM tenk1 ORDER BY unique2 LIMIT 5 OFFSET 5;
-VACUUM brintest_ao;  -- force a summarization cycle in brinaoidx
-UPDATE brintest_ao SET int8col = int8col * int4col;
-UPDATE brintest_ao SET textcol = '' WHERE textcol IS NOT NULL;
--- Vaccum again so that a new segment file is created.
-VACUUM brintest_ao;
-INSERT INTO brintest_ao SELECT * FROM brintest_ao;
--- We should have two segment files.
-SELECT segment_id, segno FROM gp_toolkit.__gp_aoseg('brintest_ao');
- segment_id | segno 
-------------+-------
-          1 |     1
-          1 |     2
-(2 rows)
+-- Test summarization
+-- Note: We use loops to populate logical heap pages in one aoseg. These logical
+-- heap blocks can start at a large number. See AOSegmentGet_startHeapBlock(segno).
+CREATE TABLE brin_ao_summarize(i int) USING ao_row;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE INDEX ON brin_ao_summarize USING brin(i) WITH (pages_per_range=1);
+-- There is no data, so nothing to summarize.
+SELECT brin_summarize_new_values('brin_ao_summarize_i_idx');
+ brin_summarize_new_values 
+---------------------------
+                         0
+(1 row)
 
--- Tests for brin_summarize_new_values
-SELECT brin_summarize_new_values('brintest_ao'); -- error, not an index
-ERROR:  "brintest_ao" is not an index
-CONTEXT:  SQL function "brin_summarize_new_values" statement 1
-SELECT brin_summarize_new_values('tenk1_unique1'); -- error, not a BRIN index
-ERROR:  "tenk1_unique1" is not a BRIN index
-CONTEXT:  SQL function "brin_summarize_new_values" statement 1
-SELECT brin_summarize_new_values('brinaoidx'); -- ok, no change expected
+DROP INDEX brin_ao_summarize_i_idx;
+-- Create 3 blocks all on 1 QE, in 1 aoseg: 2 blocks full, 1 block with 1 tuple.
+DO $$
+DECLARE curtid tid;
+BEGIN
+  LOOP
+    INSERT INTO brin_ao_summarize VALUES (1) RETURNING ctid INTO curtid;
+    EXIT WHEN curtid > tid '(33554434, 0)';
+  END LOOP;
+END;
+$$;
+-- Now create the index on the data inserted above.
+CREATE INDEX ON brin_ao_summarize USING brin(i) WITH (pages_per_range=1);
+-- There is nothing new to summarize - it was all done during the index build.
+SELECT brin_summarize_new_values('brin_ao_summarize_i_idx');
+ brin_summarize_new_values 
+---------------------------
+                         0
+(1 row)
+
+-- Insert more so we have 5 blocks on 1 QE, in 1 aoseg: 4 blocks full, 1 block
+-- with 1 tuple. The last and penultimate blocks will be unsummarized.
+DO $$
+DECLARE curtid tid;
+BEGIN
+  LOOP
+    INSERT INTO brin_ao_summarize VALUES (20) RETURNING ctid INTO curtid;
+    EXIT WHEN curtid > tid '(33554436, 0)';
+  END LOOP;
+END;
+$$;
+-- The last 2 blocks will be summarized.
+SELECT brin_summarize_new_values('brin_ao_summarize_i_idx');
+ brin_summarize_new_values 
+---------------------------
+                         2
+(1 row)
+
+-- Insert more so we have 7 blocks on 1 QE, in 1 aoseg: 6 blocks full, 1 page
+-- with 1 tuple. The last and penultimate blocks are unsummarized.
+DO $$
+DECLARE curtid tid;
+BEGIN
+  LOOP
+    INSERT INTO brin_ao_summarize VALUES (30) RETURNING ctid INTO curtid;
+    EXIT WHEN curtid > tid '(33554438, 0)';
+  END LOOP;
+END;
+$$;
+DELETE FROM brin_ao_summarize WHERE i = 1;
+VACUUM brin_ao_summarize;
+-- All the tuples will have been moved to one aoseg and all the tuples should
+-- have fit in one logical heap block.
+SELECT distinct(right(split_part(ctid::text, ',', 1), -1)) AS blknum
+  FROM brin_ao_summarize;
+NOTICE:  One or more columns in the following table(s) do not have statistics: brin_ao_summarize
+HINT:  For non-partitioned tables, run analyze <table_name>(<column_list>). For partitioned tables, run analyze rootpartition <table_name>(<column_list>). See log for columns missing statistics.
+  blknum  
+----------
+ 67108864
+(1 row)
+
+-- VACUUM should have already summarized this one logical heap block, so
+-- invoking summarization again will be a no-op.
+SELECT brin_summarize_new_values('brin_ao_summarize_i_idx');
  brin_summarize_new_values 
 ---------------------------
                          0
 (1 row)
 
 -- We don't allow specific range summarization for AO tables at the moment.
-SELECT brin_summarize_range('brinaoidx', 1);
-ERROR:  cannot summarize specific page range for append-optimized tables  (seg0 slice1 192.168.0.148:7002 pid=3012326)
+SELECT brin_summarize_range('brin_ao_summarize_i_idx', 1);
+ERROR:  cannot summarize specific page range for append-optimized tables  (seg0 slice1 192.168.0.148:7002 pid=20357)
 CONTEXT:  SQL function "brin_summarize_range" statement 1

--- a/src/test/regress/expected/brin_aocs.out
+++ b/src/test/regress/expected/brin_aocs.out
@@ -1,4 +1,7 @@
-CREATE TABLE brintest_aocs (byteacol bytea,
+-- Most of these test steps are modified such that the tables' tuples are
+-- co-located on one QE.
+CREATE TABLE brintest_aocs (id int,
+	byteacol bytea,
 	charcol "char",
 	namecol name,
 	int8col bigint,
@@ -28,6 +31,7 @@ CREATE TABLE brintest_aocs (byteacol bytea,
 	boxcol box
 ) WITH (appendonly = true, orientation=column);
 INSERT INTO brintest_aocs SELECT
+	1,
 	repeat(stringu1, 8)::bytea,
 	substr(stringu1, 1, 1)::"char",
 	stringu1::name, 142857 * tenthous,
@@ -57,7 +61,8 @@ INSERT INTO brintest_aocs SELECT
 	box(point(odd, even), point(thousand, twothousand))
 FROM tenk1 ORDER BY unique2 LIMIT 100;
 -- throw in some NULL's and different values
-INSERT INTO brintest_aocs (inetcol, cidrcol, int4rangecol) SELECT
+INSERT INTO brintest_aocs (id, inetcol, cidrcol, int4rangecol) SELECT
+	1,
 	inet 'fe80::6e40:8ff:fea9:8c46' + tenthous,
 	cidr 'fe80::6e40:8ff:fea9:8c46' + tenthous,
 	'empty'::int4range
@@ -411,6 +416,7 @@ RESET enable_bitmapscan;
 RESET optimizer_enable_tablescan;
 RESET optimizer_enable_bitmapscan;
 INSERT INTO brintest_aocs SELECT
+	1,
 	repeat(stringu1, 42)::bytea,
 	substr(stringu1, 1, 1)::"char",
 	stringu1::name, 142857 * tenthous,
@@ -445,20 +451,70 @@ UPDATE brintest_aocs SET textcol = '' WHERE textcol IS NOT NULL;
 -- Vaccum again so that a new segment file is created.
 VACUUM brintest_aocs;
 INSERT INTO brintest_aocs SELECT * FROM brintest_aocs;
--- We should have two segment files per Greenplum segment (QE).
--- start_ignore
-SELECT segment_id, segno, tupcount, state FROM gp_toolkit.__gp_aoseg('brintest_aocs');
- segment_id | segno | tupcount | state 
-------------+-------+----------+-------
-          1 |     1 |       78 |     1
-          1 |     2 |       78 |     1
-          2 |     1 |       80 |     1
-          2 |     2 |       80 |     1
-          0 |     1 |      102 |     1
-          0 |     2 |      102 |     1
-(6 rows)
+-- We should have two segment files.
+SELECT segment_id, segno, column_num FROM gp_toolkit.__gp_aocsseg('brintest_aocs');
+ segment_id | segno | column_num 
+------------+-------+------------
+          1 |     1 |          0
+          1 |     1 |          1
+          1 |     1 |          2
+          1 |     1 |          3
+          1 |     1 |          4
+          1 |     1 |          5
+          1 |     1 |          6
+          1 |     1 |          7
+          1 |     1 |          8
+          1 |     1 |          9
+          1 |     1 |         10
+          1 |     1 |         11
+          1 |     1 |         12
+          1 |     1 |         13
+          1 |     1 |         14
+          1 |     1 |         15
+          1 |     1 |         16
+          1 |     1 |         17
+          1 |     1 |         18
+          1 |     1 |         19
+          1 |     1 |         20
+          1 |     1 |         21
+          1 |     1 |         22
+          1 |     1 |         23
+          1 |     1 |         24
+          1 |     1 |         25
+          1 |     1 |         26
+          1 |     1 |         27
+          1 |     1 |         28
+          1 |     2 |          0
+          1 |     2 |          1
+          1 |     2 |          2
+          1 |     2 |          3
+          1 |     2 |          4
+          1 |     2 |          5
+          1 |     2 |          6
+          1 |     2 |          7
+          1 |     2 |          8
+          1 |     2 |          9
+          1 |     2 |         10
+          1 |     2 |         11
+          1 |     2 |         12
+          1 |     2 |         13
+          1 |     2 |         14
+          1 |     2 |         15
+          1 |     2 |         16
+          1 |     2 |         17
+          1 |     2 |         18
+          1 |     2 |         19
+          1 |     2 |         20
+          1 |     2 |         21
+          1 |     2 |         22
+          1 |     2 |         23
+          1 |     2 |         24
+          1 |     2 |         25
+          1 |     2 |         26
+          1 |     2 |         27
+          1 |     2 |         28
+(58 rows)
 
--- end_ignore
 -- Tests for brin_summarize_new_values
 SELECT brin_summarize_new_values('brintest_aocs'); -- error, not an index
 ERROR:  "brintest_aocs" is not an index
@@ -472,3 +528,7 @@ SELECT brin_summarize_new_values('brinaocsidx'); -- ok, no change expected
                          0
 (1 row)
 
+-- We don't allow specific range summarization for AO tables at the moment.
+SELECT brin_summarize_range('brinaocsidx', 1);
+ERROR:  cannot summarize specific page range for append-optimized tables  (seg1 slice1 192.168.0.148:7003 pid=3047874)
+CONTEXT:  SQL function "brin_summarize_range" statement 1

--- a/src/test/regress/expected/brin_aocs.out
+++ b/src/test/regress/expected/brin_aocs.out
@@ -1,5 +1,6 @@
 -- Most of these test steps are modified such that the tables' tuples are
 -- co-located on one QE.
+-- Test scan correctness
 CREATE TABLE brintest_aocs (id int,
 	byteacol bytea,
 	charcol "char",
@@ -445,90 +446,89 @@ INSERT INTO brintest_aocs SELECT
 	format('%s/%s%s', odd, even, tenthous)::pg_lsn,
 	box(point(odd, even), point(thousand, twothousand))
 FROM tenk1 ORDER BY unique2 LIMIT 5 OFFSET 5;
-VACUUM brintest_aocs;  -- force a summarization cycle in brinaocsidx
-UPDATE brintest_aocs SET int8col = int8col * int4col;
-UPDATE brintest_aocs SET textcol = '' WHERE textcol IS NOT NULL;
--- Vaccum again so that a new segment file is created.
-VACUUM brintest_aocs;
-INSERT INTO brintest_aocs SELECT * FROM brintest_aocs;
--- We should have two segment files.
-SELECT segment_id, segno, column_num FROM gp_toolkit.__gp_aocsseg('brintest_aocs');
- segment_id | segno | column_num 
-------------+-------+------------
-          1 |     1 |          0
-          1 |     1 |          1
-          1 |     1 |          2
-          1 |     1 |          3
-          1 |     1 |          4
-          1 |     1 |          5
-          1 |     1 |          6
-          1 |     1 |          7
-          1 |     1 |          8
-          1 |     1 |          9
-          1 |     1 |         10
-          1 |     1 |         11
-          1 |     1 |         12
-          1 |     1 |         13
-          1 |     1 |         14
-          1 |     1 |         15
-          1 |     1 |         16
-          1 |     1 |         17
-          1 |     1 |         18
-          1 |     1 |         19
-          1 |     1 |         20
-          1 |     1 |         21
-          1 |     1 |         22
-          1 |     1 |         23
-          1 |     1 |         24
-          1 |     1 |         25
-          1 |     1 |         26
-          1 |     1 |         27
-          1 |     1 |         28
-          1 |     2 |          0
-          1 |     2 |          1
-          1 |     2 |          2
-          1 |     2 |          3
-          1 |     2 |          4
-          1 |     2 |          5
-          1 |     2 |          6
-          1 |     2 |          7
-          1 |     2 |          8
-          1 |     2 |          9
-          1 |     2 |         10
-          1 |     2 |         11
-          1 |     2 |         12
-          1 |     2 |         13
-          1 |     2 |         14
-          1 |     2 |         15
-          1 |     2 |         16
-          1 |     2 |         17
-          1 |     2 |         18
-          1 |     2 |         19
-          1 |     2 |         20
-          1 |     2 |         21
-          1 |     2 |         22
-          1 |     2 |         23
-          1 |     2 |         24
-          1 |     2 |         25
-          1 |     2 |         26
-          1 |     2 |         27
-          1 |     2 |         28
-(58 rows)
+-- Test summarization
+-- Note: We use loops to populate logical heap pages in one aoseg. These logical
+-- heap blocks can start at a large number. See AOSegmentGet_startHeapBlock(segno).
+CREATE TABLE brin_aoco_summarize(i int) USING ao_column;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE INDEX ON brin_aoco_summarize USING brin(i) WITH (pages_per_range=1);
+-- There is no data, so nothing to summarize.
+SELECT brin_summarize_new_values('brin_aoco_summarize_i_idx');
+ brin_summarize_new_values 
+---------------------------
+                         0
+(1 row)
 
--- Tests for brin_summarize_new_values
-SELECT brin_summarize_new_values('brintest_aocs'); -- error, not an index
-ERROR:  "brintest_aocs" is not an index
-CONTEXT:  SQL function "brin_summarize_new_values" statement 1
-SELECT brin_summarize_new_values('tenk1_unique1'); -- error, not a BRIN index
-ERROR:  "tenk1_unique1" is not a BRIN index
-CONTEXT:  SQL function "brin_summarize_new_values" statement 1
-SELECT brin_summarize_new_values('brinaocsidx'); -- ok, no change expected
+DROP INDEX brin_aoco_summarize_i_idx;
+-- Create 3 blocks all on 1 QE, in 1 aoseg: 2 blocks full, 1 block with 1 tuple.
+DO $$
+DECLARE curtid tid;
+BEGIN
+  LOOP
+    INSERT INTO brin_aoco_summarize VALUES (1) RETURNING ctid INTO curtid;
+    EXIT WHEN curtid > tid '(33554434, 0)';
+  END LOOP;
+END;
+$$;
+-- Now create the index on the data inserted above.
+CREATE INDEX ON brin_aoco_summarize USING brin(i) WITH (pages_per_range=1);
+-- There is nothing new to summarize - it was all done during the index build.
+SELECT brin_summarize_new_values('brin_aoco_summarize_i_idx');
+ brin_summarize_new_values 
+---------------------------
+                         0
+(1 row)
+
+-- Insert more so we have 5 blocks on 1 QE, in 1 aoseg: 4 blocks full, 1 block
+-- with 1 tuple. The last and penultimate blocks will be unsummarized.
+DO $$
+DECLARE curtid tid;
+BEGIN
+  LOOP
+    INSERT INTO brin_aoco_summarize VALUES (20) RETURNING ctid INTO curtid;
+    EXIT WHEN curtid > tid '(33554436, 0)';
+  END LOOP;
+END;
+$$;
+-- The last 2 blocks will be summarized.
+SELECT brin_summarize_new_values('brin_aoco_summarize_i_idx');
+ brin_summarize_new_values 
+---------------------------
+                         2
+(1 row)
+
+-- Insert more so we have 7 blocks on 1 QE, in 1 aoseg: 6 blocks full, 1 page
+-- with 1 tuple. The last and penultimate blocks are unsummarized.
+DO $$
+DECLARE curtid tid;
+BEGIN
+  LOOP
+    INSERT INTO brin_aoco_summarize VALUES (30) RETURNING ctid INTO curtid;
+    EXIT WHEN curtid > tid '(33554438, 0)';
+  END LOOP;
+END;
+$$;
+DELETE FROM brin_aoco_summarize WHERE i = 1;
+VACUUM brin_aoco_summarize;
+-- All the tuples will have been moved to one aoseg and all the tuples should
+-- have fit in one logical heap block.
+SELECT distinct(right(split_part(ctid::text, ',', 1), -1)) AS blknum
+FROM brin_aoco_summarize;
+  blknum  
+----------
+ 67108864
+(1 row)
+
+-- VACUUM should have already summarized this one logical heap block, so
+-- invoking summarization again will be a no-op.
+SELECT brin_summarize_new_values('brin_aoco_summarize_i_idx');
  brin_summarize_new_values 
 ---------------------------
                          0
 (1 row)
 
 -- We don't allow specific range summarization for AO tables at the moment.
-SELECT brin_summarize_range('brinaocsidx', 1);
-ERROR:  cannot summarize specific page range for append-optimized tables  (seg1 slice1 192.168.0.148:7003 pid=3047874)
+SELECT brin_summarize_range('brin_aoco_summarize_i_idx', 1);
+ERROR:  cannot summarize specific page range for append-optimized tables  (seg0 slice1 192.168.0.148:7002 pid=67650)
 CONTEXT:  SQL function "brin_summarize_range" statement 1

--- a/src/test/regress/expected/brin_aocs.out
+++ b/src/test/regress/expected/brin_aocs.out
@@ -532,3 +532,34 @@ SELECT brin_summarize_new_values('brin_aoco_summarize_i_idx');
 SELECT brin_summarize_range('brin_aoco_summarize_i_idx', 1);
 ERROR:  cannot summarize specific page range for append-optimized tables  (seg0 slice1 192.168.0.148:7002 pid=67650)
 CONTEXT:  SQL function "brin_summarize_range" statement 1
+-- Test summarization of last partial range.
+CREATE TABLE brin_aoco_summarize_partial(i int) USING ao_column;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE INDEX ON brin_aoco_summarize_partial USING brin(i) WITH (pages_per_range=3);
+-- Insert 4 blocks of data on 1 QE, in 1 aoseg; 3 blocks full, 1 block with 1 tuple.
+-- The 1st range [33554432, 33554434] is full and the last range [33554435, 33554437]
+-- is partially full with just 1 block: 33554435.
+DO $$
+DECLARE curtid tid;
+BEGIN
+  LOOP
+    INSERT INTO brin_aoco_summarize_partial VALUES (1) RETURNING ctid INTO curtid;
+    EXIT WHEN curtid > tid '(33554435, 0)';
+  END LOOP;
+END;
+$$;
+-- We should successfully summarize the last partial range.
+--
+-- Note: For an empty AOCO table, when INSERTing into the 1st range, we don't
+-- summarize. brininsert() -> brinGetTupleForHeapBlock() actually returns NULL
+-- in this case as revmap_get_blkno_ao() returns InvalidBlockNumber.
+-- This is contrary to heap behavior (where we return 1).
+--
+-- Thus, we will have both ranges summarized here.
+SELECT brin_summarize_new_values('brin_aoco_summarize_partial_i_idx');
+ brin_summarize_new_values 
+---------------------------
+                         2
+(1 row)
+

--- a/src/test/regress/expected/brin_aocs_optimizer.out
+++ b/src/test/regress/expected/brin_aocs_optimizer.out
@@ -1,4 +1,7 @@
-CREATE TABLE brintest_aocs (byteacol bytea,
+-- Most of these test steps are modified such that the tables' tuples are
+-- co-located on one QE.
+CREATE TABLE brintest_aocs (id int,
+	byteacol bytea,
 	charcol "char",
 	namecol name,
 	int8col bigint,
@@ -28,6 +31,7 @@ CREATE TABLE brintest_aocs (byteacol bytea,
 	boxcol box
 ) WITH (appendonly = true, orientation=column);
 INSERT INTO brintest_aocs SELECT
+	1,
 	repeat(stringu1, 8)::bytea,
 	substr(stringu1, 1, 1)::"char",
 	stringu1::name, 142857 * tenthous,
@@ -57,7 +61,8 @@ INSERT INTO brintest_aocs SELECT
 	box(point(odd, even), point(thousand, twothousand))
 FROM tenk1 ORDER BY unique2 LIMIT 100;
 -- throw in some NULL's and different values
-INSERT INTO brintest_aocs (inetcol, cidrcol, int4rangecol) SELECT
+INSERT INTO brintest_aocs (id, inetcol, cidrcol, int4rangecol) SELECT
+	1,
 	inet 'fe80::6e40:8ff:fea9:8c46' + tenthous,
 	cidr 'fe80::6e40:8ff:fea9:8c46' + tenthous,
 	'empty'::int4range
@@ -429,6 +434,7 @@ RESET enable_bitmapscan;
 RESET optimizer_enable_tablescan;
 RESET optimizer_enable_bitmapscan;
 INSERT INTO brintest_aocs SELECT
+	1,
 	repeat(stringu1, 42)::bytea,
 	substr(stringu1, 1, 1)::"char",
 	stringu1::name, 142857 * tenthous,
@@ -463,20 +469,70 @@ UPDATE brintest_aocs SET textcol = '' WHERE textcol IS NOT NULL;
 -- Vaccum again so that a new segment file is created.
 VACUUM brintest_aocs;
 INSERT INTO brintest_aocs SELECT * FROM brintest_aocs;
--- We should have two segment files per Greenplum segment (QE).
--- start_ignore
-SELECT segment_id, segno, tupcount, state FROM gp_toolkit.__gp_aoseg('brintest_aocs');
- segment_id | segno | tupcount | state 
-------------+-------+----------+-------
-          1 |     1 |       78 |     1
-          1 |     2 |       78 |     1
-          2 |     1 |       80 |     1
-          2 |     2 |       80 |     1
-          0 |     1 |      102 |     1
-          0 |     2 |      102 |     1
-(6 rows)
+-- We should have two segment files.
+SELECT segment_id, segno, column_num FROM gp_toolkit.__gp_aocsseg('brintest_aocs');
+ segment_id | segno | column_num 
+------------+-------+------------
+          1 |     1 |          0
+          1 |     1 |          1
+          1 |     1 |          2
+          1 |     1 |          3
+          1 |     1 |          4
+          1 |     1 |          5
+          1 |     1 |          6
+          1 |     1 |          7
+          1 |     1 |          8
+          1 |     1 |          9
+          1 |     1 |         10
+          1 |     1 |         11
+          1 |     1 |         12
+          1 |     1 |         13
+          1 |     1 |         14
+          1 |     1 |         15
+          1 |     1 |         16
+          1 |     1 |         17
+          1 |     1 |         18
+          1 |     1 |         19
+          1 |     1 |         20
+          1 |     1 |         21
+          1 |     1 |         22
+          1 |     1 |         23
+          1 |     1 |         24
+          1 |     1 |         25
+          1 |     1 |         26
+          1 |     1 |         27
+          1 |     1 |         28
+          1 |     2 |          0
+          1 |     2 |          1
+          1 |     2 |          2
+          1 |     2 |          3
+          1 |     2 |          4
+          1 |     2 |          5
+          1 |     2 |          6
+          1 |     2 |          7
+          1 |     2 |          8
+          1 |     2 |          9
+          1 |     2 |         10
+          1 |     2 |         11
+          1 |     2 |         12
+          1 |     2 |         13
+          1 |     2 |         14
+          1 |     2 |         15
+          1 |     2 |         16
+          1 |     2 |         17
+          1 |     2 |         18
+          1 |     2 |         19
+          1 |     2 |         20
+          1 |     2 |         21
+          1 |     2 |         22
+          1 |     2 |         23
+          1 |     2 |         24
+          1 |     2 |         25
+          1 |     2 |         26
+          1 |     2 |         27
+          1 |     2 |         28
+(58 rows)
 
--- end_ignore
 -- Tests for brin_summarize_new_values
 SELECT brin_summarize_new_values('brintest_aocs'); -- error, not an index
 ERROR:  "brintest_aocs" is not an index
@@ -490,3 +546,7 @@ SELECT brin_summarize_new_values('brinaocsidx'); -- ok, no change expected
                          0
 (1 row)
 
+-- We don't allow specific range summarization for AO tables at the moment.
+SELECT brin_summarize_range('brinaocsidx', 1);
+ERROR:  cannot summarize specific page range for append-optimized tables  (seg1 slice1 192.168.0.148:7003 pid=3082856)
+CONTEXT:  SQL function "brin_summarize_range" statement 1

--- a/src/test/regress/expected/brin_aocs_optimizer.out
+++ b/src/test/regress/expected/brin_aocs_optimizer.out
@@ -1,5 +1,6 @@
 -- Most of these test steps are modified such that the tables' tuples are
 -- co-located on one QE.
+-- Test scan correctness
 CREATE TABLE brintest_aocs (id int,
 	byteacol bytea,
 	charcol "char",
@@ -463,90 +464,91 @@ INSERT INTO brintest_aocs SELECT
 	format('%s/%s%s', odd, even, tenthous)::pg_lsn,
 	box(point(odd, even), point(thousand, twothousand))
 FROM tenk1 ORDER BY unique2 LIMIT 5 OFFSET 5;
-VACUUM brintest_aocs;  -- force a summarization cycle in brinaocsidx
-UPDATE brintest_aocs SET int8col = int8col * int4col;
-UPDATE brintest_aocs SET textcol = '' WHERE textcol IS NOT NULL;
--- Vaccum again so that a new segment file is created.
-VACUUM brintest_aocs;
-INSERT INTO brintest_aocs SELECT * FROM brintest_aocs;
--- We should have two segment files.
-SELECT segment_id, segno, column_num FROM gp_toolkit.__gp_aocsseg('brintest_aocs');
- segment_id | segno | column_num 
-------------+-------+------------
-          1 |     1 |          0
-          1 |     1 |          1
-          1 |     1 |          2
-          1 |     1 |          3
-          1 |     1 |          4
-          1 |     1 |          5
-          1 |     1 |          6
-          1 |     1 |          7
-          1 |     1 |          8
-          1 |     1 |          9
-          1 |     1 |         10
-          1 |     1 |         11
-          1 |     1 |         12
-          1 |     1 |         13
-          1 |     1 |         14
-          1 |     1 |         15
-          1 |     1 |         16
-          1 |     1 |         17
-          1 |     1 |         18
-          1 |     1 |         19
-          1 |     1 |         20
-          1 |     1 |         21
-          1 |     1 |         22
-          1 |     1 |         23
-          1 |     1 |         24
-          1 |     1 |         25
-          1 |     1 |         26
-          1 |     1 |         27
-          1 |     1 |         28
-          1 |     2 |          0
-          1 |     2 |          1
-          1 |     2 |          2
-          1 |     2 |          3
-          1 |     2 |          4
-          1 |     2 |          5
-          1 |     2 |          6
-          1 |     2 |          7
-          1 |     2 |          8
-          1 |     2 |          9
-          1 |     2 |         10
-          1 |     2 |         11
-          1 |     2 |         12
-          1 |     2 |         13
-          1 |     2 |         14
-          1 |     2 |         15
-          1 |     2 |         16
-          1 |     2 |         17
-          1 |     2 |         18
-          1 |     2 |         19
-          1 |     2 |         20
-          1 |     2 |         21
-          1 |     2 |         22
-          1 |     2 |         23
-          1 |     2 |         24
-          1 |     2 |         25
-          1 |     2 |         26
-          1 |     2 |         27
-          1 |     2 |         28
-(58 rows)
+-- Test summarization
+-- Note: We use loops to populate logical heap pages in one aoseg. These logical
+-- heap blocks can start at a large number. See AOSegmentGet_startHeapBlock(segno).
+CREATE TABLE brin_aoco_summarize(i int) USING ao_column;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE INDEX ON brin_aoco_summarize USING brin(i) WITH (pages_per_range=1);
+-- There is no data, so nothing to summarize.
+SELECT brin_summarize_new_values('brin_aoco_summarize_i_idx');
+ brin_summarize_new_values 
+---------------------------
+                         0
+(1 row)
 
--- Tests for brin_summarize_new_values
-SELECT brin_summarize_new_values('brintest_aocs'); -- error, not an index
-ERROR:  "brintest_aocs" is not an index
-CONTEXT:  SQL function "brin_summarize_new_values" statement 1
-SELECT brin_summarize_new_values('tenk1_unique1'); -- error, not a BRIN index
-ERROR:  "tenk1_unique1" is not a BRIN index
-CONTEXT:  SQL function "brin_summarize_new_values" statement 1
-SELECT brin_summarize_new_values('brinaocsidx'); -- ok, no change expected
+DROP INDEX brin_aoco_summarize_i_idx;
+-- Create 3 blocks all on 1 QE, in 1 aoseg: 2 blocks full, 1 block with 1 tuple.
+DO $$
+DECLARE curtid tid;
+BEGIN
+  LOOP
+    INSERT INTO brin_aoco_summarize VALUES (1) RETURNING ctid INTO curtid;
+    EXIT WHEN curtid > tid '(33554434, 0)';
+  END LOOP;
+END;
+$$;
+-- Now create the index on the data inserted above.
+CREATE INDEX ON brin_aoco_summarize USING brin(i) WITH (pages_per_range=1);
+-- There is nothing new to summarize - it was all done during the index build.
+SELECT brin_summarize_new_values('brin_aoco_summarize_i_idx');
+ brin_summarize_new_values 
+---------------------------
+                         0
+(1 row)
+
+-- Insert more so we have 5 blocks on 1 QE, in 1 aoseg: 4 blocks full, 1 block
+-- with 1 tuple. The last and penultimate blocks will be unsummarized.
+DO $$
+DECLARE curtid tid;
+BEGIN
+  LOOP
+    INSERT INTO brin_aoco_summarize VALUES (20) RETURNING ctid INTO curtid;
+    EXIT WHEN curtid > tid '(33554436, 0)';
+  END LOOP;
+END;
+$$;
+-- The last 2 blocks will be summarized.
+SELECT brin_summarize_new_values('brin_aoco_summarize_i_idx');
+ brin_summarize_new_values 
+---------------------------
+                         2
+(1 row)
+
+-- Insert more so we have 7 blocks on 1 QE, in 1 aoseg: 6 blocks full, 1 page
+-- with 1 tuple. The last and penultimate blocks are unsummarized.
+DO $$
+DECLARE curtid tid;
+BEGIN
+  LOOP
+    INSERT INTO brin_aoco_summarize VALUES (30) RETURNING ctid INTO curtid;
+    EXIT WHEN curtid > tid '(33554438, 0)';
+  END LOOP;
+END;
+$$;
+DELETE FROM brin_aoco_summarize WHERE i = 1;
+VACUUM brin_aoco_summarize;
+-- All the tuples will have been moved to one aoseg and all the tuples should
+-- have fit in one logical heap block.
+SELECT distinct(right(split_part(ctid::text, ',', 1), -1)) AS blknum
+FROM brin_aoco_summarize;
+NOTICE:  One or more columns in the following table(s) do not have statistics: brin_aoco_summarize
+HINT:  For non-partitioned tables, run analyze <table_name>(<column_list>). For partitioned tables, run analyze rootpartition <table_name>(<column_list>). See log for columns missing statistics.
+  blknum  
+----------
+ 67108864
+(1 row)
+
+-- VACUUM should have already summarized this one logical heap block, so
+-- invoking summarization again will be a no-op.
+SELECT brin_summarize_new_values('brin_aoco_summarize_i_idx');
  brin_summarize_new_values 
 ---------------------------
                          0
 (1 row)
 
 -- We don't allow specific range summarization for AO tables at the moment.
-SELECT brin_summarize_range('brinaocsidx', 1);
-ERROR:  cannot summarize specific page range for append-optimized tables  (seg1 slice1 192.168.0.148:7003 pid=3082856)
+SELECT brin_summarize_range('brin_aoco_summarize_i_idx', 1);
+ERROR:  cannot summarize specific page range for append-optimized tables  (seg0 slice1 192.168.0.148:7002 pid=75014)
 CONTEXT:  SQL function "brin_summarize_range" statement 1

--- a/src/test/regress/expected/brin_aocs_optimizer.out
+++ b/src/test/regress/expected/brin_aocs_optimizer.out
@@ -552,3 +552,34 @@ SELECT brin_summarize_new_values('brin_aoco_summarize_i_idx');
 SELECT brin_summarize_range('brin_aoco_summarize_i_idx', 1);
 ERROR:  cannot summarize specific page range for append-optimized tables  (seg0 slice1 192.168.0.148:7002 pid=75014)
 CONTEXT:  SQL function "brin_summarize_range" statement 1
+-- Test summarization of last partial range.
+CREATE TABLE brin_aoco_summarize_partial(i int) USING ao_column;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE INDEX ON brin_aoco_summarize_partial USING brin(i) WITH (pages_per_range=3);
+-- Insert 4 blocks of data on 1 QE, in 1 aoseg; 3 blocks full, 1 block with 1 tuple.
+-- The 1st range [33554432, 33554434] is full and the last range [33554435, 33554437]
+-- is partially full with just 1 block: 33554435.
+DO $$
+DECLARE curtid tid;
+BEGIN
+  LOOP
+    INSERT INTO brin_aoco_summarize_partial VALUES (1) RETURNING ctid INTO curtid;
+    EXIT WHEN curtid > tid '(33554435, 0)';
+  END LOOP;
+END;
+$$;
+-- We should successfully summarize the last partial range.
+--
+-- Note: For an empty AOCO table, when INSERTing into the 1st range, we don't
+-- summarize. brininsert() -> brinGetTupleForHeapBlock() actually returns NULL
+-- in this case as revmap_get_blkno_ao() returns InvalidBlockNumber.
+-- This is contrary to heap behavior (where we return 1).
+--
+-- Thus, we will have both ranges summarized here.
+SELECT brin_summarize_new_values('brin_aoco_summarize_partial_i_idx');
+ brin_summarize_new_values 
+---------------------------
+                         2
+(1 row)
+

--- a/src/test/regress/expected/brin_optimizer.out
+++ b/src/test/regress/expected/brin_optimizer.out
@@ -1,4 +1,7 @@
-CREATE TABLE brintest (byteacol bytea,
+-- GPDB: Most of these test steps are modified such that the tables' tuples are
+-- co-located on one QE.
+CREATE TABLE brintest (id int,
+    byteacol bytea,
 	charcol "char",
 	namecol name,
 	int8col bigint,
@@ -28,6 +31,7 @@ CREATE TABLE brintest (byteacol bytea,
 	boxcol box
 ) WITH (fillfactor=10, autovacuum_enabled=off);
 INSERT INTO brintest SELECT
+	1,
 	repeat(stringu1, 8)::bytea,
 	substr(stringu1, 1, 1)::"char",
 	stringu1::name, 142857 * tenthous,
@@ -57,7 +61,8 @@ INSERT INTO brintest SELECT
 	box(point(odd, even), point(thousand, twothousand))
 FROM tenk1 ORDER BY unique2 LIMIT 100;
 -- throw in some NULL's and different values
-INSERT INTO brintest (inetcol, cidrcol, int4rangecol) SELECT
+INSERT INTO brintest (id, inetcol, cidrcol, int4rangecol) SELECT
+	1,
 	inet 'fe80::6e40:8ff:fea9:8c46' + tenthous,
 	cidr 'fe80::6e40:8ff:fea9:8c46' + tenthous,
 	'empty'::int4range
@@ -417,6 +422,7 @@ RESET enable_bitmapscan;
 RESET optimizer_enable_tablescan;
 RESET optimizer_enable_bitmapscan;
 INSERT INTO brintest SELECT
+	1,
 	repeat(stringu1, 42)::bytea,
 	substr(stringu1, 1, 1)::"char",
 	stringu1::name, 142857 * tenthous,
@@ -496,29 +502,42 @@ DO $$
 DECLARE curtid tid;
 BEGIN
   LOOP
+    -- GPDB: INSERT of value = 1 guarantees that all values are on one segment.
     INSERT INTO brin_summarize VALUES (1) RETURNING ctid INTO curtid;
-    EXIT WHEN curtid > tid '(2, 0)';
+    EXIT WHEN curtid > tid '(6, 0)';
   END LOOP;
 END;
 $$;
--- summarize one range
+-- range [0,1] is already summarized since current (at start of insert) range is
+-- summarized by the DO..INSERT above
 SELECT brin_summarize_range('brin_summarize_idx', 0);
-ERROR:  Greenplum could not summarize indicated page range  (seg0 slice1 127.0.0.1:7002 pid=11998)
--- nothing: already summarized
+ brin_summarize_range 
+----------------------
+                    0
+(1 row)
+
 SELECT brin_summarize_range('brin_summarize_idx', 1);
-ERROR:  Greenplum could not summarize indicated page range  (seg0 slice1 127.0.0.1:7002 pid=11998)
--- summarize one range
+ brin_summarize_range 
+----------------------
+                    0
+(1 row)
+
+-- summarize one range: [2,3]
 SELECT brin_summarize_range('brin_summarize_idx', 2);
-ERROR:  Greenplum could not summarize indicated page range  (seg0 slice1 127.0.0.1:7002 pid=11998)
--- summarize all pages
-SELECT brin_summarize_range('brin_summarize_idx', 4294967295);
  brin_summarize_range 
 ----------------------
                     1
 (1 row)
 
--- nothing: page doesn't exist in table
+-- summarize all pages: should summarize ranges [3,4] and [5,6] only
 SELECT brin_summarize_range('brin_summarize_idx', 4294967295);
+ brin_summarize_range 
+----------------------
+                    2
+(1 row)
+
+-- nothing: page doesn't exist in table
+SELECT brin_summarize_range('brin_summarize_idx', 5);
  brin_summarize_range 
 ----------------------
                     0

--- a/src/test/regress/expected/privileges.out
+++ b/src/test/regress/expected/privileges.out
@@ -1424,8 +1424,11 @@ SELECT brin_desummarize_range('sro_brin', 0);
 (1 row)
 
 SELECT brin_summarize_range('sro_brin', 0);
-ERROR:  Greenplum could not summarize indicated page range  (seg0 slice1 127.0.0.1:40000 pid=1132546)
-CONTEXT:  SQL function "brin_summarize_range" statement 1
+ brin_summarize_range 
+----------------------
+                    0
+(1 row)
+
 DROP TABLE sro_tab;
 -- Check with a partitioned table
 CREATE TABLE sro_ptab (a int) PARTITION BY RANGE (a);

--- a/src/test/regress/sql/brin_ao.sql
+++ b/src/test/regress/sql/brin_ao.sql
@@ -529,3 +529,30 @@ SELECT brin_summarize_new_values('brin_ao_summarize_i_idx');
 
 -- We don't allow specific range summarization for AO tables at the moment.
 SELECT brin_summarize_range('brin_ao_summarize_i_idx', 1);
+
+-- Test summarization of last partial range.
+CREATE TABLE brin_ao_summarize_partial(i int) USING ao_row;
+CREATE INDEX ON brin_ao_summarize_partial USING brin(i) WITH (pages_per_range=3);
+
+-- Insert 4 blocks of data on 1 QE, in 1 aoseg; 3 blocks full, 1 block with 1 tuple.
+-- The 1st range [33554432, 33554434] is full and the last range [33554435, 33554437]
+-- is partially full with just 1 block: 33554435.
+DO $$
+DECLARE curtid tid;
+BEGIN
+  LOOP
+    INSERT INTO brin_ao_summarize_partial VALUES (1) RETURNING ctid INTO curtid;
+    EXIT WHEN curtid > tid '(33554435, 0)';
+  END LOOP;
+END;
+$$;
+
+-- We should successfully summarize the last partial range.
+--
+-- Note: For an empty AO table, when INSERTing into the 1st range, we don't
+-- summarize. brininsert() -> brinGetTupleForHeapBlock() actually returns NULL
+-- in this case as revmap_get_blkno_ao() returns InvalidBlockNumber.
+-- This is contrary to heap behavior (where we return 1).
+--
+-- Thus, we will have both ranges summarized here.
+SELECT brin_summarize_new_values('brin_ao_summarize_partial_i_idx');

--- a/src/test/regress/sql/brin_aocs.sql
+++ b/src/test/regress/sql/brin_aocs.sql
@@ -1,4 +1,8 @@
-CREATE TABLE brintest_aocs (byteacol bytea,
+-- Most of these test steps are modified such that the tables' tuples are
+-- co-located on one QE.
+
+CREATE TABLE brintest_aocs (id int,
+	byteacol bytea,
 	charcol "char",
 	namecol name,
 	int8col bigint,
@@ -29,6 +33,7 @@ CREATE TABLE brintest_aocs (byteacol bytea,
 ) WITH (appendonly = true, orientation=column);
 
 INSERT INTO brintest_aocs SELECT
+	1,
 	repeat(stringu1, 8)::bytea,
 	substr(stringu1, 1, 1)::"char",
 	stringu1::name, 142857 * tenthous,
@@ -59,7 +64,8 @@ INSERT INTO brintest_aocs SELECT
 FROM tenk1 ORDER BY unique2 LIMIT 100;
 
 -- throw in some NULL's and different values
-INSERT INTO brintest_aocs (inetcol, cidrcol, int4rangecol) SELECT
+INSERT INTO brintest_aocs (id, inetcol, cidrcol, int4rangecol) SELECT
+	1,
 	inet 'fe80::6e40:8ff:fea9:8c46' + tenthous,
 	cidr 'fe80::6e40:8ff:fea9:8c46' + tenthous,
 	'empty'::int4range
@@ -419,6 +425,7 @@ RESET optimizer_enable_tablescan;
 RESET optimizer_enable_bitmapscan;
 
 INSERT INTO brintest_aocs SELECT
+	1,
 	repeat(stringu1, 42)::bytea,
 	substr(stringu1, 1, 1)::"char",
 	stringu1::name, 142857 * tenthous,
@@ -456,12 +463,13 @@ UPDATE brintest_aocs SET textcol = '' WHERE textcol IS NOT NULL;
 -- Vaccum again so that a new segment file is created.
 VACUUM brintest_aocs;
 INSERT INTO brintest_aocs SELECT * FROM brintest_aocs;
--- We should have two segment files per Greenplum segment (QE).
--- start_ignore
-SELECT segment_id, segno, tupcount, state FROM gp_toolkit.__gp_aoseg('brintest_aocs');
--- end_ignore
+-- We should have two segment files.
+SELECT segment_id, segno, column_num FROM gp_toolkit.__gp_aocsseg('brintest_aocs');
 
 -- Tests for brin_summarize_new_values
 SELECT brin_summarize_new_values('brintest_aocs'); -- error, not an index
 SELECT brin_summarize_new_values('tenk1_unique1'); -- error, not a BRIN index
 SELECT brin_summarize_new_values('brinaocsidx'); -- ok, no change expected
+
+-- We don't allow specific range summarization for AO tables at the moment.
+SELECT brin_summarize_range('brinaocsidx', 1);

--- a/src/test/regress/sql/brin_aocs.sql
+++ b/src/test/regress/sql/brin_aocs.sql
@@ -1,6 +1,8 @@
 -- Most of these test steps are modified such that the tables' tuples are
 -- co-located on one QE.
 
+-- Test scan correctness
+
 CREATE TABLE brintest_aocs (id int,
 	byteacol bytea,
 	charcol "char",
@@ -455,21 +457,75 @@ INSERT INTO brintest_aocs SELECT
 	box(point(odd, even), point(thousand, twothousand))
 FROM tenk1 ORDER BY unique2 LIMIT 5 OFFSET 5;
 
-VACUUM brintest_aocs;  -- force a summarization cycle in brinaocsidx
+-- Test summarization
 
-UPDATE brintest_aocs SET int8col = int8col * int4col;
-UPDATE brintest_aocs SET textcol = '' WHERE textcol IS NOT NULL;
+-- Note: We use loops to populate logical heap pages in one aoseg. These logical
+-- heap blocks can start at a large number. See AOSegmentGet_startHeapBlock(segno).
 
--- Vaccum again so that a new segment file is created.
-VACUUM brintest_aocs;
-INSERT INTO brintest_aocs SELECT * FROM brintest_aocs;
--- We should have two segment files.
-SELECT segment_id, segno, column_num FROM gp_toolkit.__gp_aocsseg('brintest_aocs');
+CREATE TABLE brin_aoco_summarize(i int) USING ao_column;
+CREATE INDEX ON brin_aoco_summarize USING brin(i) WITH (pages_per_range=1);
 
--- Tests for brin_summarize_new_values
-SELECT brin_summarize_new_values('brintest_aocs'); -- error, not an index
-SELECT brin_summarize_new_values('tenk1_unique1'); -- error, not a BRIN index
-SELECT brin_summarize_new_values('brinaocsidx'); -- ok, no change expected
+-- There is no data, so nothing to summarize.
+SELECT brin_summarize_new_values('brin_aoco_summarize_i_idx');
+
+DROP INDEX brin_aoco_summarize_i_idx;
+
+-- Create 3 blocks all on 1 QE, in 1 aoseg: 2 blocks full, 1 block with 1 tuple.
+DO $$
+DECLARE curtid tid;
+BEGIN
+  LOOP
+    INSERT INTO brin_aoco_summarize VALUES (1) RETURNING ctid INTO curtid;
+    EXIT WHEN curtid > tid '(33554434, 0)';
+  END LOOP;
+END;
+$$;
+
+-- Now create the index on the data inserted above.
+CREATE INDEX ON brin_aoco_summarize USING brin(i) WITH (pages_per_range=1);
+
+-- There is nothing new to summarize - it was all done during the index build.
+SELECT brin_summarize_new_values('brin_aoco_summarize_i_idx');
+
+-- Insert more so we have 5 blocks on 1 QE, in 1 aoseg: 4 blocks full, 1 block
+-- with 1 tuple. The last and penultimate blocks will be unsummarized.
+DO $$
+DECLARE curtid tid;
+BEGIN
+  LOOP
+    INSERT INTO brin_aoco_summarize VALUES (20) RETURNING ctid INTO curtid;
+    EXIT WHEN curtid > tid '(33554436, 0)';
+  END LOOP;
+END;
+$$;
+
+-- The last 2 blocks will be summarized.
+SELECT brin_summarize_new_values('brin_aoco_summarize_i_idx');
+
+-- Insert more so we have 7 blocks on 1 QE, in 1 aoseg: 6 blocks full, 1 page
+-- with 1 tuple. The last and penultimate blocks are unsummarized.
+DO $$
+DECLARE curtid tid;
+BEGIN
+  LOOP
+    INSERT INTO brin_aoco_summarize VALUES (30) RETURNING ctid INTO curtid;
+    EXIT WHEN curtid > tid '(33554438, 0)';
+  END LOOP;
+END;
+$$;
+
+DELETE FROM brin_aoco_summarize WHERE i = 1;
+
+VACUUM brin_aoco_summarize;
+
+-- All the tuples will have been moved to one aoseg and all the tuples should
+-- have fit in one logical heap block.
+SELECT distinct(right(split_part(ctid::text, ',', 1), -1)) AS blknum
+FROM brin_aoco_summarize;
+
+-- VACUUM should have already summarized this one logical heap block, so
+-- invoking summarization again will be a no-op.
+SELECT brin_summarize_new_values('brin_aoco_summarize_i_idx');
 
 -- We don't allow specific range summarization for AO tables at the moment.
-SELECT brin_summarize_range('brinaocsidx', 1);
+SELECT brin_summarize_range('brin_aoco_summarize_i_idx', 1);


### PR DESCRIPTION
This PR introduces a new table AM API for unifying code for block traversal used in BRIN indexes. To ensure that the changes don't break existing functionality, we had to bring back specific-range-summarization for heap tables. Also, we extended and improved the tests significantly. Please review commits individually.

This also fixes https://github.com/greenplum-db/gpdb/issues/14843.

Co-authored-by: Ashwin Agrawal <aashwin@vmware.com>