### PR TITLE
Remove a redundant if(info == XLOG_OVERWRITE_CONTRECORD) in xlog.c

### DIFF
--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -10765,13 +10765,6 @@ xlog_redo(XLogReaderState *record)
 		memcpy(&xlrec, XLogRecGetData(record), sizeof(xl_overwrite_contrecord));
 		VerifyOverwriteContrecord(&xlrec, record);
 	}
-	else if (info == XLOG_OVERWRITE_CONTRECORD)
-	{
-		xl_overwrite_contrecord xlrec;
-
-		memcpy(&xlrec, XLogRecGetData(record), sizeof(xl_overwrite_contrecord));
-		VerifyOverwriteContrecord(&xlrec, record);
-	}
 	else if (info == XLOG_END_OF_RECOVERY)
 	{
 		xl_end_of_recovery xlrec;


### PR DESCRIPTION
The merge w/ PG 12.12 (https://github.com/greenplum-db/gpdb/pull/14790) backported an if branch in xlog.c which we cherrypicked before (commit 12e44a0eee8c). Removing it now.

Checked other parts of the original commit and this seems to be the only redundancy.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
