### PR TITLE
show memory_limit information in gp_toolkit.gp_resgroup_config view

### DIFF
--- a/src/backend/catalog/gp_toolkit.sql
+++ b/src/backend/catalog/gp_toolkit.sql
@@ -1711,10 +1711,12 @@ CREATE VIEW gp_toolkit.gp_resgroup_config AS
          , T2.value    AS cpu_hard_quota_limit
          , T3.value    AS cpu_soft_priority
          , T4.value    AS cpuset
+         , T5.value    AS memory_limit
     FROM pg_resgroup G
          JOIN pg_resgroupcapability T1 ON G.oid = T1.resgroupid AND T1.reslimittype = 1
          JOIN pg_resgroupcapability T2 ON G.oid = T2.resgroupid AND T2.reslimittype = 2
          JOIN pg_resgroupcapability T3 ON G.oid = T3.resgroupid AND T3.reslimittype = 3
+         JOIN pg_resgroupcapability T5 ON G.oid = T5.resgroupid AND T5.reslimittype = 5
          LEFT JOIN pg_resgroupcapability T4 ON G.oid = T4.resgroupid AND T4.reslimittype = 4
     ;
 

--- a/src/test/isolation2/expected/resgroup/resgroup_auxiliary_tools_v1.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_auxiliary_tools_v1.out
@@ -54,11 +54,11 @@ ERROR:  language "plpython3u" already exists
 
 -- verify the default settings
 0: SELECT * from gp_toolkit.gp_resgroup_config;
- groupid | groupname     | concurrency | cpu_hard_quota_limit | cpu_soft_priority | cpuset 
----------+---------------+-------------+----------------------+-------------------+--------
- 6437    | default_group | 20          | 20                   | 100               | -1     
- 6438    | admin_group   | 10          | 10                   | 100               | -1     
- 6441    | system_group  | 0           | 10                   | 100               | -1     
+ groupid | groupname     | concurrency | cpu_hard_quota_limit | cpu_soft_priority | cpuset | memory_limit 
+---------+---------------+-------------+----------------------+-------------------+--------+--------------
+ 6441    | system_group  | 0           | 10                   | 100               | -1     | -1           
+ 6438    | admin_group   | 10          | 10                   | 100               | -1     | -1           
+ 6437    | default_group | 20          | 20                   | 100               | -1     | -1           
 (3 rows)
 
 

--- a/src/test/isolation2/expected/resgroup/resgroup_auxiliary_tools_v2.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_auxiliary_tools_v2.out
@@ -54,11 +54,11 @@ ERROR:  language "plpython3u" already exists
 
 -- verify the default settings
 0: SELECT * from gp_toolkit.gp_resgroup_config;
- groupid | groupname     | concurrency | cpu_hard_quota_limit | cpu_soft_priority | cpuset 
----------+---------------+-------------+----------------------+-------------------+--------
- 6437    | default_group | 20          | 20                   | 100               | -1     
- 6438    | admin_group   | 10          | 10                   | 100               | -1     
- 6441    | system_group  | 0           | 10                   | 100               | -1     
+ groupid | groupname     | concurrency | cpu_hard_quota_limit | cpu_soft_priority | cpuset | memory_limit 
+---------+---------------+-------------+----------------------+-------------------+--------+--------------
+ 6437    | default_group | 20          | 20                   | 100               | -1     | -1           
+ 6438    | admin_group   | 10          | 10                   | 100               | -1     | -1           
+ 6441    | system_group  | 0           | 10                   | 100               | -1     | -1           
 (3 rows)
 
 

--- a/src/test/isolation2/expected/resgroup/resgroup_syntax.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_syntax.out
@@ -94,11 +94,11 @@ ERROR:  resource group "rg_test_group" does not exist
 --end_ignore
 
 SELECT * FROM gp_toolkit.gp_resgroup_config;
- groupid | groupname     | concurrency | cpu_hard_quota_limit | cpu_soft_priority | cpuset 
----------+---------------+-------------+----------------------+-------------------+--------
- 6441    | system_group  | 0           | 10                   | 100               | -1     
- 6438    | admin_group   | 10          | 10                   | 100               | -1     
- 6437    | default_group | 20          | 20                   | 100               | -1     
+ groupid | groupname     | concurrency | cpu_hard_quota_limit | cpu_soft_priority | cpuset | memory_limit 
+---------+---------------+-------------+----------------------+-------------------+--------+--------------
+ 6437    | default_group | 20          | 20                   | 100               | -1     | -1           
+ 6438    | admin_group   | 10          | 10                   | 100               | -1     | -1           
+ 6441    | system_group  | 0           | 10                   | 100               | -1     | -1           
 (3 rows)
 
 -- negative

--- a/src/test/isolation2/expected/resgroup/resgroup_views.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_views.out
@@ -1,7 +1,7 @@
 select * from gp_toolkit.gp_resgroup_config where groupname='default_group';
- groupid | groupname     | concurrency | cpu_hard_quota_limit | cpu_soft_priority | cpuset 
----------+---------------+-------------+----------------------+-------------------+--------
- 6437    | default_group | 20          | 20                   | 100               | -1     
+ groupid | groupname     | concurrency | cpu_hard_quota_limit | cpu_soft_priority | cpuset | memory_limit 
+---------+---------------+-------------+----------------------+-------------------+--------+--------------
+ 6437    | default_group | 20          | 20                   | 100               | -1     | -1           
 (1 row)
 
 select rsgname , groupid , num_running , num_queueing , num_queued , num_executed , cpu_usage->'-1' as qd_cpu_usage from gp_toolkit.gp_resgroup_status where rsgname='default_group';
@@ -33,11 +33,11 @@ select * from gp_toolkit.gp_resgroup_role where rrrolname='gpadmin';
 
 -- start_ignore
 select * from gp_toolkit.gp_resgroup_config;
- groupid | groupname     | concurrency | cpu_hard_quota_limit | cpu_soft_priority | cpuset 
----------+---------------+-------------+----------------------+-------------------+--------
- 6437    | default_group | 20          | 20                   | 100               | -1     
- 6441    | system_group  | 0           | 10                   | 100               | -1     
- 6438    | admin_group   | 2           | 10                   | 100               | -1     
+ groupid | groupname     | concurrency | cpu_hard_quota_limit | cpu_soft_priority | cpuset | memory_limit 
+---------+---------------+-------------+----------------------+-------------------+--------+--------------
+ 6437    | default_group | 20          | 20                   | 100               | -1     | -1           
+ 6438    | admin_group   | 10          | 10                   | 100               | -1     | -1           
+ 6441    | system_group  | 0           | 10                   | 100               | -1     | -1           
 (3 rows)
 select * from gp_toolkit.gp_resgroup_status;
  rsgname       | groupid | num_running | num_queueing | num_queued | num_executed | total_queue_duration | cpu_usage                                     


### PR DESCRIPTION
since commit c25db0c support resgroup with memory_limit, adds it to gp_resgroup_config view.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
