### PR TITLE
Double gpfdist listening to one port.

### DIFF
--- a/src/bin/gpfdist/gpfdist.c
+++ b/src/bin/gpfdist/gpfdist.c
@@ -2668,7 +2668,20 @@ http_setup(void)
 							  opt.p,
 							  saved_errno,
 							  strerror(saved_errno));
-				continue;
+
+#ifdef WIN32
+				if ( 1 )
+#else
+				if ( errno == EADDRINUSE )
+#endif
+				{
+					create_failed = true;
+					break;
+				}
+				else
+				{
+					gwarning(NULL, "%s (errno=%d), port: %d",strerror(errno), errno, opt.p);
+				}
 			}
 			gcb.listen_socks[gcb.listen_sock_count++] = f;
 


### PR DESCRIPTION
In an extreme case, two gpfdist occupy one port(ipv4/ipv6). The reason for this problem includes two aspects. The first one is that 'bind' is not mutually exclusive. And another is that when listening to a port fail, gpfdist will try the same port with a different protocol(ipv4 or ipv6). 

If you want to reproduce the condition by yourself, the following steps will help you.
1. Start two gpfdist by gdb. And do not forget to set a breakpoint on the line 'listen'.
2. At this time, you will find both gpfdist will stop on the line 'listen'.
3. You can choose the first gpfdist to continue execution before the second one, and the first one will listen on the port (ipv6) while another one will fail to listen. 
4. And two gpfdist will stop on the line 'listen' again. This time, you should continue execution for the second one before the first one.  
5. And you will find the magical phenomenon: two gpfdist are listening to the ipv4 and ipv6 ports of the same port number respectively

So the PR fixes the problem by changing the handling for failed listening behavior. 