### PR TITLE
Fix error in ATSETAM to ao_column with dropped column

### DIFF
--- a/src/backend/catalog/pg_attribute_encoding.c
+++ b/src/backend/catalog/pg_attribute_encoding.c
@@ -331,6 +331,9 @@ RelationGetAttributeOptions(Relation rel)
  *
  * Simply adds user specified ENCODING () clause information to
  * pg_attribute_encoding. Should be absolutely valid at this point.
+ *
+ * Note that we need to take dropped columns into consideration
+ * as well so we cannot use get_attnum().
  */
 void
 AddRelationAttributeEncodings(Oid relid, List *attr_encodings)
@@ -343,13 +346,22 @@ AddRelationAttributeEncodings(Oid relid, List *attr_encodings)
 		ColumnReferenceStorageDirective *c = lfirst(lc);
 		List *encoding;
 		AttrNumber attnum;
+		HeapTuple	tuple;
+		Form_pg_attribute att_tup;
 
 		Assert(IsA(c, ColumnReferenceStorageDirective));
 
-		attnum = get_attnum(relid, c->column);
-
-		if (attnum == InvalidAttrNumber)
+		tuple = SearchSysCache2(ATTNAME,
+								ObjectIdGetDatum(relid),
+								CStringGetDatum(c->column));
+		if (!HeapTupleIsValid(tuple))
 			elog(ERROR, "column \"%s\" does not exist", c->column);
+
+		att_tup = (Form_pg_attribute) GETSTRUCT(tuple);
+		attnum = att_tup->attnum;
+		Assert(attnum != InvalidAttrNumber);
+
+		ReleaseSysCache(tuple);
 
 		if (attnum < 0)
 			elog(ERROR, "column \"%s\" is a system column", c->column);

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -4383,6 +4383,14 @@ static void populate_rel_col_encodings(Relation rel, List *stenc, List *withOpti
 								att->atttypid, 
 								att->atttypmod,
 								0);
+
+		/* If the column is dropped, pass on a NULL typeName */
+		if (att->attisdropped)
+		{
+			pfree(cd->typeName);
+			cd->typeName = NULL;
+		}
+
 		colDefs = lappend(colDefs, cd);
 	}
 

--- a/src/test/regress/expected/alter_table_set_am.out
+++ b/src/test/regress/expected/alter_table_set_am.out
@@ -1428,3 +1428,82 @@ SELECT count(*) FROM heapco;
 (1 row)
 
 DROP TABLE heapco;
+-- Misc cases
+-- 
+-- ATSETAM with dropped column:
+-- The dropped column should still have an entry in pg_attribute_encoding if it is 
+-- an AOCO table, just like pg_attribute.
+CREATE TABLE atsetam_dropcol(a int, b int, c int, d int);
+INSERT INTO atsetam_dropcol VALUES(1,1,1,1);
+SELECT count(*) FROM pg_attribute WHERE attrelid = 'atsetam_dropcol'::regclass AND attnum > 0;
+ count 
+-------
+     4
+(1 row)
+
+SELECT count(*) FROM pg_attribute_encoding WHERE attrelid = 'atsetam_dropcol'::regclass;
+ count 
+-------
+     0
+(1 row)
+
+ALTER TABLE atsetam_dropcol DROP COLUMN b;
+ALTER TABLE atsetam_dropcol SET ACCESS METHOD ao_row;
+SELECT count(*) FROM pg_attribute WHERE attrelid = 'atsetam_dropcol'::regclass AND attnum > 0;
+ count 
+-------
+     4
+(1 row)
+
+SELECT count(*) FROM pg_attribute_encoding WHERE attrelid = 'atsetam_dropcol'::regclass;
+ count 
+-------
+     0
+(1 row)
+
+SELECT * FROM atsetam_dropcol;
+ a | c | d 
+---+---+---
+ 1 | 1 | 1
+(1 row)
+
+ALTER TABLE atsetam_dropcol DROP COLUMN c;
+ALTER TABLE atsetam_dropcol SET ACCESS METHOD ao_column;
+SELECT count(*) FROM pg_attribute WHERE attrelid = 'atsetam_dropcol'::regclass AND attnum > 0;
+ count 
+-------
+     4
+(1 row)
+
+SELECT count(*) FROM pg_attribute_encoding WHERE attrelid = 'atsetam_dropcol'::regclass;
+ count 
+-------
+     4
+(1 row)
+
+SELECT * FROM atsetam_dropcol;
+ a | d 
+---+---
+ 1 | 1
+(1 row)
+
+ALTER TABLE atsetam_dropcol DROP COLUMN d;
+ALTER TABLE atsetam_dropcol SET ACCESS METHOD heap;
+SELECT count(*) FROM pg_attribute WHERE attrelid = 'atsetam_dropcol'::regclass AND attnum > 0;
+ count 
+-------
+     4
+(1 row)
+
+SELECT count(*) FROM pg_attribute_encoding WHERE attrelid = 'atsetam_dropcol'::regclass;
+ count 
+-------
+     0
+(1 row)
+
+SELECT * FROM atsetam_dropcol;
+ a 
+---
+ 1
+(1 row)
+

--- a/src/test/regress/sql/alter_table_set_am.sql
+++ b/src/test/regress/sql/alter_table_set_am.sql
@@ -747,3 +747,28 @@ ALTER TABLE heapco SET ACCESS METHOD ao_column;
 -- Just checking data is intact.
 SELECT count(*) FROM heapco;
 DROP TABLE heapco;
+
+-- Misc cases
+-- 
+-- ATSETAM with dropped column:
+-- The dropped column should still have an entry in pg_attribute_encoding if it is 
+-- an AOCO table, just like pg_attribute.
+CREATE TABLE atsetam_dropcol(a int, b int, c int, d int);
+INSERT INTO atsetam_dropcol VALUES(1,1,1,1);
+SELECT count(*) FROM pg_attribute WHERE attrelid = 'atsetam_dropcol'::regclass AND attnum > 0;
+SELECT count(*) FROM pg_attribute_encoding WHERE attrelid = 'atsetam_dropcol'::regclass;
+ALTER TABLE atsetam_dropcol DROP COLUMN b;
+ALTER TABLE atsetam_dropcol SET ACCESS METHOD ao_row;
+SELECT count(*) FROM pg_attribute WHERE attrelid = 'atsetam_dropcol'::regclass AND attnum > 0;
+SELECT count(*) FROM pg_attribute_encoding WHERE attrelid = 'atsetam_dropcol'::regclass;
+SELECT * FROM atsetam_dropcol;
+ALTER TABLE atsetam_dropcol DROP COLUMN c;
+ALTER TABLE atsetam_dropcol SET ACCESS METHOD ao_column;
+SELECT count(*) FROM pg_attribute WHERE attrelid = 'atsetam_dropcol'::regclass AND attnum > 0;
+SELECT count(*) FROM pg_attribute_encoding WHERE attrelid = 'atsetam_dropcol'::regclass;
+SELECT * FROM atsetam_dropcol;
+ALTER TABLE atsetam_dropcol DROP COLUMN d;
+ALTER TABLE atsetam_dropcol SET ACCESS METHOD heap;
+SELECT count(*) FROM pg_attribute WHERE attrelid = 'atsetam_dropcol'::regclass AND attnum > 0;
+SELECT count(*) FROM pg_attribute_encoding WHERE attrelid = 'atsetam_dropcol'::regclass;
+SELECT * FROM atsetam_dropcol;


### PR DESCRIPTION
When we alter the table AM from non-AOCO to AOCO, we need to add pg_attribute_encoding entries for it. That includes checking types of the columns to decide the encoding options. But if a column is dropped, we would fail to find its type. A failure case like:

```sql
postgres=# create table ao(a int, b int) using ao_row;
CREATE TABLE
postgres=# alter table ao drop column b;
ALTER TABLE
postgres=# alter table ao set access method ao_column;
ERROR:  cache lookup failed for type 0 (format_type.c:126)
```

Now take that into consideration. Basically a dropped column will still have its entry in pg_attribute_encoding (if it's an AOCO table), until the table itself is dropped, just like pg_attribute.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
