### PR TITLE
[6X] Make LOG "autovacuum: processing database..." to be DEBUG1

### DIFF
--- a/src/backend/postmaster/autovacuum.c
+++ b/src/backend/postmaster/autovacuum.c
@@ -1734,7 +1734,7 @@ AutoVacWorkerMain(int argc, char *argv[])
 		InitPostgres(NULL, dbid, NULL, dbname);
 		SetProcessingMode(NormalProcessing);
 		set_ps_display(dbname, false);
-		ereport(LOG,
+		ereport(DEBUG1,
 				(errmsg("autovacuum: processing database \"%s\"", dbname)));
 
 		SIMPLE_FAULT_INJECTOR("auto_vac_worker_before_do_autovacuum");


### PR DESCRIPTION
It is making too much noise in the log. Let's make it DEBUG1, which is the same as upstream:
https://github.com/postgres/postgres/blob/master/src/backend/postmaster/autovacuum.c#L1707-L1708

The 7X PR: https://github.com/greenplum-db/gpdb/pull/15045

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
