### PR TITLE
Fix custom formatter handling logic.

### DIFF
--- a/gpcontrib/gp_exttable_fdw/extaccess.c
+++ b/gpcontrib/gp_exttable_fdw/extaccess.c
@@ -893,14 +893,14 @@ externalgettup_custom(FileScanDesc scan)
 	FormatterData *formatter = scan->fs_formatter;
 	MemoryContext oldctxt = CurrentMemoryContext;
 	bool need_more_data = false;
-	int infinite_loop_detect = 0;
+	bool infinite_loop_detect = false;
 
 	Assert(formatter);
 
 	/* while didn't finish processing the entire file */
 	while (formatter->fmt_databuf.len != 0 || !pstate->reached_eof)
 	{
-		if (infinite_loop_detect != 0) {
+		if (infinite_loop_detect == true) {
 			break;
 		}
 		/* need to fill our buffer with data? */
@@ -920,7 +920,7 @@ externalgettup_custom(FileScanDesc scan)
 		}
 
 		/* while there is still data in our buffer */
-		while (formatter->fmt_databuf.len != 0)
+		while (formatter->fmt_databuf.len > 0)
 		{
 			bool		error_caught = false;
 
@@ -1010,7 +1010,7 @@ externalgettup_custom(FileScanDesc scan)
 						 * to read more data into it.
 						 */
 						if (pstate->reached_eof) {
-							infinite_loop_detect++;
+							infinite_loop_detect = true;
 						}
 						need_more_data = true;
 						justifyDatabuf(&formatter->fmt_databuf);
@@ -1021,7 +1021,11 @@ externalgettup_custom(FileScanDesc scan)
 								formatter->fmt_notification);
 						break;
 				}
-				break; /* FMT_NEED_MORE_DATA */
+				/* 
+				 * Only when (formatter->fmt_notification == FMT_NEED_MORE_DATA) could we got here.
+				 * We need to get more data from external source(call external_getdata()) 
+				 */
+				break;
 			}
 			else
 			{
@@ -1390,7 +1394,7 @@ external_getdata(URL_FILE *extfile, CopyState pstate, void *outbuf, int maxread)
 	 * result in skipping the last line. But for custom protocol, it is not possible
 	 * to reach EOF when the bytesread > 0, so we need to give them a second
 	 * chance to reach EOF when the bytesread = 0, so the formatter is responsible
-	 * to deal with eof flag properly, otherwise infinite loop may be created.
+	 * for dealing with eof flag properly, otherwise infinite loop may be created.
 	 */
 	bytesread = url_fread((void *) outbuf, maxread, extfile, pstate);
 

--- a/gpcontrib/gp_exttable_fdw/extaccess.c
+++ b/gpcontrib/gp_exttable_fdw/extaccess.c
@@ -972,7 +972,6 @@ externalgettup_custom(FileScanDesc scan)
 					{
 						formatter->fmt_databuf.cursor = formatter->fmt_databuf.len;
 					}
-					justifyDatabuf(&formatter->fmt_databuf);
 				}
 
 				FILEAM_HANDLE_ERROR;
@@ -1029,6 +1028,16 @@ externalgettup_custom(FileScanDesc scan)
 				ErrorIfRejectLimitReached(pstate->cdbsreh);
 			}
 		}
+	}
+	if (formatter->fmt_databuf.len > 0)
+	{
+		/*
+		 * The formatter needs more data, but we have reached
+		 * EOF. This is an error.
+		 */
+		ereport(WARNING,
+				(errcode(ERRCODE_DATA_EXCEPTION),
+				 errmsg("unexpected end of file")));
 	}
 
 	/*

--- a/gpcontrib/gp_exttable_fdw/extaccess.c
+++ b/gpcontrib/gp_exttable_fdw/extaccess.c
@@ -900,7 +900,7 @@ externalgettup_custom(FileScanDesc scan)
 	/* while didn't finish processing the entire file */
 	while (formatter->fmt_databuf.len != 0 || !pstate->reached_eof)
 	{
-		if (infinite_loop_detect == true) {
+		if (infinite_loop_detect) {
 			break;
 		}
 		/* need to fill our buffer with data? */
@@ -1022,7 +1022,7 @@ externalgettup_custom(FileScanDesc scan)
 						break;
 				}
 				/* 
-				 * Only when (formatter->fmt_notification == FMT_NEED_MORE_DATA) could we got here.
+				 * We can only get here when (formatter->fmt_notification == FMT_NEED_MORE_DATA).
 				 * We need to get more data from external source(call external_getdata()) 
 				 */
 				break;


### PR DESCRIPTION
The function externalgettup_custom() is to handle custom formatter logic when loading data with external tables. But if custom protocol like PXF is used to loading data, the EOF is not reached when the last content of data is returned, the EOF is reached only when the last reading returns 0. So in the current logic of function externalgettup_custom(), it may lose the chance for custom formatter to handle the last line of data.

This commit removes the using of raw_buf_len, instead the formatter->fmt_databuf which provides the real data is used. So we check the length of this buffer to give custom formatter last chance to handle the last line of data. Even if the last line is not complete, it is the custom formatter's responsibility to report this.

The right way to return FMT_NEED_MORE_DATA in custom formatter is to
check EOF flag before return. But currently, a lot of custom formatter
does not implement in the right way. They just return FMT_NEED_MORE_DATA
when they need more data in the current block of line without changing
the formatter->fmt_databuf nor checking the EOF. So it will cause infinite loop.

In order to prevent infinite loop, we detect this by adding a count when
eof flag is set. So this PR enables custom protocol to handle the last
line of incomplete data if the custom formatter has taken care of the eof
flag, and also prevent infinite loop regression.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
