### PR TITLE
Fix custom formatter handling logic.

### DIFF
--- a/src/backend/access/external/fileam.c
+++ b/src/backend/access/external/fileam.c
@@ -954,7 +954,7 @@ externalgettup_custom(FileScanDesc scan)
 	/* while didn't finish processing the entire file */
 	while (formatter->fmt_databuf.len > 0 || !pstate->fe_eof)
 	{
-		if (infinite_loop_detect == true) {
+		if (infinite_loop_detect) {
 			break;
 		}
 		/* need to fill our buffer with data? */
@@ -1076,7 +1076,7 @@ externalgettup_custom(FileScanDesc scan)
 						break;
 				}
 				/*
-				 * Only when (formatter->fmt_notification == FMT_NEED_MORE_DATA) could we got here.
+				 * We can only get here when (formatter->fmt_notification == FMT_NEED_MORE_DATA).
 				 * We need to get more data from external source(call external_getdata()).
 				 */
 				break;

--- a/src/backend/access/external/fileam.c
+++ b/src/backend/access/external/fileam.c
@@ -1026,7 +1026,6 @@ externalgettup_custom(FileScanDesc scan)
 					{
 						formatter->fmt_databuf.cursor = formatter->fmt_databuf.len;
 					}
-					justifyDatabuf(&formatter->fmt_databuf);
 				}
 
 				FILEAM_HANDLE_ERROR;
@@ -1436,7 +1435,10 @@ external_getdata(URL_FILE *extfile, CopyState pstate, void *outbuf, int maxread)
 	 * CK: this code is very delicate. The caller expects this: - if url_fread
 	 * returns something, and the EOF is reached, it this call must return
 	 * with both the content and the fe_eof flag set. - failing to do so will
-	 * result in skipping the last line.
+	 * result in skipping the last line. But for custom protocol, it is not possible
+	 * to reach EOF when the bytesread > 0, so we need to give them a second
+	 * chance to reach EOF when the bytesread = 0, so the formatter is responsible
+	 * to deal with eof flag properly, otherwise infinite loop may be created.
 	 */
 	bytesread = url_fread((void *) outbuf, maxread, extfile, pstate);
 

--- a/src/include/access/relscan.h
+++ b/src/include/access/relscan.h
@@ -109,8 +109,6 @@ typedef struct FileScanDescData
 	/* current file parse state */
 	struct CopyStateData *fs_pstate;
 
-	bool		raw_buf_done;
-
 	Form_pg_attribute *attr;
 	AttrNumber	num_phys_attrs;
 	Datum	   *values;


### PR DESCRIPTION
The function externalgettup_custom() is to handle custom formatter logic when loading data with external tables. But if custom protocol like PXF is used to loading data, the EOF is not reached when the last content of data is returned, the EOF is reached only when the last reading returns 0. So in the current logic of function externalgettup_custom(), it may lose the chance for custom formatter to handle the last line of data.

This commit removes the using of raw_buf_len, instead the formatter->fmt_databuf which provides the real data is used. So we check the length of this buffer to give custom formatter last chance to handle the last line of data. Even if the last line is not complete, it is the custom formatter's responsibility to report this.

The right way to return FMT_NEED_MORE_DATA in custom formatter is to
check EOF flag before return. But currently, a lot of custom formatter
does not implement in the right way. They just return FMT_NEED_MORE_DATA
when they need more data in the current block of line without changing
the formatter->fmt_databuf nor checking the EOF. So it will cause infinite loop.

In order to prevent infinite loop, we detect this by adding a count when
eof flag is set. So this PR enables custom protocol to handle the last
line of incomplete data if the custom formatter has taken care of the eof
flag, and also prevent infinite loop regression.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
