### PR TITLE
fix bug of foreign writable table encoding (7X)

### DIFF
--- a/gpcontrib/gp_exttable_fdw/extaccess.c
+++ b/gpcontrib/gp_exttable_fdw/extaccess.c
@@ -613,9 +613,13 @@ external_insert_init(Relation rel)
 	 * don't append to entry->options directly, we only store the encoding in
 	 * entry->encoding (and ftoptions)
 	 */
+	if (fmttype_is_custom(extentry->fmtcode))
+	{
+		copyFmtOpts = NIL;
+	}
 	copyFmtOpts = appendCopyEncodingOption(list_copy(extentry->options), extentry->encoding);
 
-	extInsertDesc->ext_pstate = BeginCopyToForeignTable(rel, (fmttype_is_custom(extentry->fmtcode) ? NIL : copyFmtOpts));
+	extInsertDesc->ext_pstate = BeginCopyToForeignTable(rel, copyFmtOpts);
 	InitParseState(extInsertDesc->ext_pstate,
 				   rel,
 				   true,

--- a/gpcontrib/gp_exttable_fdw/extaccess.c
+++ b/gpcontrib/gp_exttable_fdw/extaccess.c
@@ -255,8 +255,8 @@ external_beginscan(Relation relation, uint32 scancounter,
 	/*
 	 * pass external table's encoding to copy's options
 	 *
-	 * don't append to entry->options directly, we only store the encoding in
-	 * entry->encoding (and ftoptions)
+	 * don't append to extentry->options directly, we only store the encoding in
+	 * extentry->encoding (and ftoptions)
 	 */
 	if (fmttype_is_custom(fmtType))
 	{
@@ -610,8 +610,8 @@ external_insert_init(Relation rel)
 	/*
 	 * pass external table's encoding to copy's options
 	 *
-	 * don't append to entry->options directly, we only store the encoding in
-	 * entry->encoding (and ftoptions)
+	 * don't append to extentry->options directly, we only store the encoding in
+	 * extentry->encoding (and ftoptions)
 	 */
 	if (fmttype_is_custom(extentry->fmtcode))
 	{


### PR DESCRIPTION
We fixed encoding propagation to custom formatters for READABLE EXTERNAL TABLE use case in [pr-14702](https://github.com/greenplum-db/gpdb/pull/14702). However, there is still a problem for WRITABLE EXTERNAL TABLE use case where the table encoding is not propagated.

**Author:** Yongtao Huang @hyongtao-db 
**Co-author**: Jingwen Yang @jingwen-yang-yjw 