### PR TITLE
Remove dead relid variables

### DIFF
--- a/src/backend/access/appendonly/appendonlyam_handler.c
+++ b/src/backend/access/appendonly/appendonlyam_handler.c
@@ -1042,8 +1042,6 @@ appendonly_relation_set_new_filenode(Relation rel,
 static void
 appendonly_relation_nontransactional_truncate(Relation rel)
 {
-	Oid ao_base_relid = RelationGetRelid(rel);
-
 	Oid			aoseg_relid = InvalidOid;
 	Oid			aoblkdir_relid = InvalidOid;
 	Oid			aovisimap_relid = InvalidOid;

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -1807,8 +1807,6 @@ ao_aux_tables_safe_truncate(Relation rel)
 	if (!RelationIsAppendOptimized(rel))
 		return;
 
-	Oid relid = RelationGetRelid(rel);
-
 	Oid aoseg_relid = InvalidOid;
 	Oid aoblkdir_relid = InvalidOid;
 	Oid aovisimap_relid = InvalidOid;


### PR DESCRIPTION
These were causing:

tablecmds.c: In function ‘ao_aux_tables_safe_truncate’: tablecmds.c:1810:13: warning: unused variable ‘relid’ [-Wunused-variable]
 1810 |         Oid relid = RelationGetRelid(rel);
      |             ^~~~~
appendonlyam_handler.c: In function ‘appendonly_relation_nontransactional_truncate’:
appendonlyam_handler.c:1045:13: warning: unused variable ‘ao_base_relid’ [-Wunused-variable]
 1045 |         Oid ao_base_relid = RelationGetRelid(rel);
      |

These cropped up after the relcache changes for pg_appendonly in b8ed1004f09.
