### PR TITLE
[6X] Fix wrong partition pruning plan generated by planner.

### DIFF
--- a/src/backend/cdb/cdbpartition.c
+++ b/src/backend/cdb/cdbpartition.c
@@ -482,6 +482,64 @@ rel_partition_keys_kinds_ordered(Oid relid, List **pkeys, List **pkinds)
 	list_free(kindsUnordered);
 }
 
+/*
+ * Output an integer list of the attribute numbers of the partitioning
+ * key of the partitioned table identified by the argument and an oid
+ * list of the used opclass of partitioning keys.
+ */
+void
+rel_partition_keys_attrs_with_parclass(Oid relid, List **pkeys, List **parclass)
+{
+	Relation	rel;
+	ScanKeyData key;
+	SysScanDesc scan;
+	HeapTuple	tuple;
+
+	/*
+	 * Table pg_partition is only populated on the entry database, however, we
+	 * disable calls from outside dispatch to foil use of utility mode.  (Full
+	 * UCS may may this test obsolete.)
+	 */
+	if (Gp_session_role != GP_ROLE_DISPATCH)
+		elog(ERROR, "mode not dispatch");
+
+	rel = heap_open(PartitionRelationId, AccessShareLock);
+
+	ScanKeyInit(&key,
+				Anum_pg_partition_parrelid,
+				BTEqualStrategyNumber, F_OIDEQ,
+				ObjectIdGetDatum(relid));
+
+
+	scan = systable_beginscan(rel, PartitionParrelidIndexId, true,
+							  NULL, 1, &key);
+
+	tuple = systable_getnext(scan);
+
+	while (HeapTupleIsValid(tuple))
+	{
+		Index		i;
+		Form_pg_partition p = (Form_pg_partition) GETSTRUCT(tuple);
+
+		if (p->paristemplate)
+		{
+			tuple = systable_getnext(scan);
+			continue;
+		}
+
+		for (i = 0; i < p->parnatts; i++)
+		{
+			*pkeys = lappend_int(*pkeys, p->paratts.values[i]);
+			*parclass = lappend_oid(*parclass, (Oid) p->parclass.values[i]);
+		}
+
+		tuple = systable_getnext(scan);
+	}
+
+	systable_endscan(scan);
+	heap_close(rel, AccessShareLock);
+}
+
  /*
   * Does relation have a external partition? Returns true only when the input
   * is the root partition of a partitioned table and it has external

--- a/src/backend/optimizer/prep/prepunion.c
+++ b/src/backend/optimizer/prep/prepunion.c
@@ -1571,10 +1571,11 @@ expand_inherited_rtentry(PlannerInfo *root, RangeTblEntry *rte, Index rti)
 		dsinfo->parentOid = parentOID;
 		dsinfo->rtindex = rti;
 		dsinfo->hasSelector = false;
-
+		dsinfo->partKeyAttnos = NIL;
+		dsinfo->partKeyOpclass = NIL;
 		dsinfo->children = child_relids;
 
-		dsinfo->partKeyAttnos = rel_partition_key_attrs(parentOID);
+		rel_partition_keys_attrs_with_parclass(parentOID, &dsinfo->partKeyAttnos, &dsinfo->partKeyOpclass);
 
 		root->dynamicScans = lappend(root->dynamicScans, dsinfo);
 		dsinfo->dynamicScanId = list_length(root->dynamicScans);

--- a/src/include/cdb/cdbpartition.h
+++ b/src/include/cdb/cdbpartition.h
@@ -72,6 +72,8 @@ extern List *rel_partition_key_attrs(Oid relid);
 
 extern List *rel_partition_keys_ordered(Oid relid);
 
+extern void rel_partition_keys_attrs_with_parclass(Oid relid, List **pkeys, List **parclass);
+
 extern void rel_partition_keys_kinds_ordered(Oid relid, List **pkeys, List **pkinds);
 
 extern bool rel_has_external_partition(Oid relid);

--- a/src/include/nodes/relation.h
+++ b/src/include/nodes/relation.h
@@ -360,6 +360,7 @@ typedef struct
 
 	/* Partitioning key information */
 	List	   *partKeyAttnos;
+	List	   *partKeyOpclass;
 
 	/* Set to true, if a PartitionSelector has been created for this scan */
 	bool		hasSelector;

--- a/src/test/regress/expected/partition_pruning.out
+++ b/src/test/regress/expected/partition_pruning.out
@@ -3520,4 +3520,346 @@ where  trg.key1 = src.key1
 (17 rows)
 
 DROP TABLE t_part1;
+-- Test that the dynamic partition pruning should not be performed if the partition's opclass and the
+-- join condition's operator are not in the same opfamily.
+--
+-- The main idea for this test is:
+-- 1. We define two opclasses: abs_int4_ops and abs_int8_ops, both of them belong to the same opfamily: abs_int_ops.
+-- 2. We create two partition tables, one is partitioned by int4 typed column and one is partitioned by int8.
+--    CREATE TABLE t1 (a int4, b int4) PARTITION BY LIST (b) (PARTITION p1 VALUES (1), PARTITION p2 VALUES (-1));
+--    CREATE TABLE t2 (a int8, b int8) PARTITION BY LIST (b) (PARTITION p1 VALUES (1), PARTITION p2 VALUES (-1));
+-- 3. Run the following query:
+--    SELECT * FROM t1, t2 WHERE t1.a = t2.a AND t1.b |=| t2.b AND t2.b = 1;
+-- Previously, planner is generating wrong plan for the above query:
+--    Gather Motion 3:1  (slice1; segments: 3)
+--      ->  Hash Join
+--            Hash Cond: (t1_1_prt_p1.a = t2_1_prt_p1.a)
+--            Join Filter: (t1_1_prt_p1.b |=| t2_1_prt_p1.b)
+--            ->  Append
+--                  ->  Result
+--                        One-Time Filter: PartSelected <--- t1's partitions are selected according to t2.b
+--                        ->  Seq Scan on t1_1_prt_p1
+--                  ->  Result
+--                        One-Time Filter: PartSelected <--- t1's partitions are selected according to t2.b
+--                        ->  Seq Scan on t1_1_prt_p2
+--            ->  Hash
+--                  ->  Partition Selector for t1 (dynamic scan id: 1)
+--                        Filter: t2_1_prt_p1.b
+--                        ->  Append
+--                              ->  Seq Scan on t2_1_prt_p1
+--                                    Filter: (b = 1)
+-- In the above plan, t1's partitions are dynamically pruned according to the value of t2.b. It's incorrect, because the
+-- partition selection is using the operator '=(int4, int8)' which belongs to integer_ops, but the join condition is
+-- '|=|(int4, int8)' which belongs abs_int_ops. We shouldn't perform partition pruning for such query.
+CREATE SCHEMA issue_14982;
+SET search_path TO issue_14982;
+CREATE FUNCTION abseq4(int4, int4) RETURNS BOOL AS $$ BEGIN RETURN abs($1) = abs($2); END; $$ LANGUAGE plpgsql STRICT IMMUTABLE;
+CREATE FUNCTION abslt4(int4, int4) RETURNS BOOL AS $$ BEGIN RETURN abs($1) < abs($2); END; $$ LANGUAGE plpgsql STRICT IMMUTABLE;
+CREATE FUNCTION absle4(int4, int4) RETURNS BOOL AS $$ BEGIN RETURN abs($1) <= abs($2); END; $$ LANGUAGE plpgsql STRICT IMMUTABLE;
+CREATE FUNCTION absge4(int4, int4) RETURNS BOOL AS $$ BEGIN RETURN abs($1) >= abs($2); END; $$ LANGUAGE plpgsql STRICT IMMUTABLE;
+CREATE FUNCTION absgt4(int4, int4) RETURNS BOOL AS $$ BEGIN RETURN abs($1) > abs($2); END; $$ LANGUAGE plpgsql STRICT IMMUTABLE;
+CREATE FUNCTION abscmp4(int4, int4) RETURNS INT AS $$ BEGIN RETURN btint4cmp(abs($1), abs($2)); END; $$ LANGUAGE plpgsql STRICT IMMUTABLE;
+CREATE FUNCTION abseq8(int8, int8) RETURNS BOOL AS $$ BEGIN RETURN abs($1) = abs($2); END; $$ LANGUAGE plpgsql STRICT IMMUTABLE;
+CREATE FUNCTION abslt8(int8, int8) RETURNS BOOL AS $$ BEGIN RETURN abs($1) < abs($2); END; $$ LANGUAGE plpgsql STRICT IMMUTABLE;
+CREATE FUNCTION absle8(int8, int8) RETURNS BOOL AS $$ BEGIN RETURN abs($1) <= abs($2); END; $$ LANGUAGE plpgsql STRICT IMMUTABLE;
+CREATE FUNCTION absge8(int8, int8) RETURNS BOOL AS $$ BEGIN RETURN abs($1) >= abs($2); END; $$ LANGUAGE plpgsql STRICT IMMUTABLE;
+CREATE FUNCTION absgt8(int8, int8) RETURNS BOOL AS $$ BEGIN RETURN abs($1) > abs($2); END; $$ LANGUAGE plpgsql STRICT IMMUTABLE;
+CREATE FUNCTION abscmp8(int8, int8) RETURNS INT AS $$ BEGIN RETURN btint8cmp(abs($1), abs($2)); END; $$ LANGUAGE plpgsql STRICT IMMUTABLE;
+CREATE FUNCTION abseq48(int4, int8) RETURNS BOOL AS $$ BEGIN RETURN abs($1) = abs($2); END; $$ LANGUAGE plpgsql STRICT IMMUTABLE;
+CREATE FUNCTION abslt48(int4, int8) RETURNS BOOL AS $$ BEGIN RETURN abs($1) < abs($2); END; $$ LANGUAGE plpgsql STRICT IMMUTABLE;
+CREATE FUNCTION absle48(int4, int8) RETURNS BOOL AS $$ BEGIN RETURN abs($1) <= abs($2); END; $$ LANGUAGE plpgsql STRICT IMMUTABLE;
+CREATE FUNCTION absge48(int4, int8) RETURNS BOOL AS $$ BEGIN RETURN abs($1) >= abs($2); END; $$ LANGUAGE plpgsql STRICT IMMUTABLE;
+CREATE FUNCTION absgt48(int4, int8) RETURNS BOOL AS $$ BEGIN RETURN abs($1) > abs($2); END; $$ LANGUAGE plpgsql STRICT IMMUTABLE;
+CREATE FUNCTION abscmp48(int4, int8) RETURNS INT AS $$ BEGIN RETURN btint48cmp(abs($1), abs($2)); END; $$ LANGUAGE plpgsql STRICT IMMUTABLE;
+CREATE FUNCTION abseq84(int8, int4) RETURNS BOOL AS $$ BEGIN RETURN abs($1) = abs($2); END; $$ LANGUAGE plpgsql STRICT IMMUTABLE;
+CREATE FUNCTION abslt84(int8, int4) RETURNS BOOL AS $$ BEGIN RETURN abs($1) < abs($2); END; $$ LANGUAGE plpgsql STRICT IMMUTABLE;
+CREATE FUNCTION absle84(int8, int4) RETURNS BOOL AS $$ BEGIN RETURN abs($1) <= abs($2); END; $$ LANGUAGE plpgsql STRICT IMMUTABLE;
+CREATE FUNCTION absge84(int8, int4) RETURNS BOOL AS $$ BEGIN RETURN abs($1) >= abs($2); END; $$ LANGUAGE plpgsql STRICT IMMUTABLE;
+CREATE FUNCTION absgt84(int8, int4) RETURNS BOOL AS $$ BEGIN RETURN abs($1) > abs($2); END; $$ LANGUAGE plpgsql STRICT IMMUTABLE;
+CREATE FUNCTION abscmp84(int8, int4) RETURNS INT AS $$ BEGIN RETURN btint84cmp(abs($1), abs($2)); END; $$ LANGUAGE plpgsql STRICT IMMUTABLE;
+CREATE OPERATOR |=| (procedure = abseq4, leftarg = int4, rightarg = int4, commutator = |=|, merges);
+CREATE OPERATOR |=| (procedure = abseq8, leftarg = int8, rightarg = int8, commutator = |=|, merges);
+CREATE OPERATOR |=| (procedure = abseq48, leftarg = int4, rightarg = int8, commutator = |=|, merges);
+CREATE OPERATOR |=| (procedure = abseq84, leftarg = int8, rightarg = int4, commutator = |=|, merges);
+CREATE OPERATOR |<| (procedure = abslt4, leftarg = int4, rightarg = int4, commutator = |<|);
+CREATE OPERATOR |<| (procedure = abslt8, leftarg = int8, rightarg = int8, commutator = |<|);
+CREATE OPERATOR |<| (procedure = abslt48, leftarg = int4, rightarg = int8, commutator = |<|);
+CREATE OPERATOR |<| (procedure = abslt84, leftarg = int8, rightarg = int4, commutator = |<|);
+CREATE OPERATOR |>| (procedure = absgt4, leftarg = int4, rightarg = int4, commutator = |>|);
+CREATE OPERATOR |>| (procedure = absgt8, leftarg = int8, rightarg = int8, commutator = |>|);
+CREATE OPERATOR |>| (procedure = absgt48, leftarg = int4, rightarg = int8, commutator = |>|);
+CREATE OPERATOR |>| (procedure = absgt84, leftarg = int8, rightarg = int4, commutator = |>|);
+CREATE OPERATOR |<=| (procedure = absle4, leftarg = int4, rightarg = int4, commutator = |<=|);
+CREATE OPERATOR |<=| (procedure = absle8, leftarg = int8, rightarg = int8, commutator = |<=|);
+CREATE OPERATOR |<=| (procedure = absle48, leftarg = int4, rightarg = int8, commutator = |<=|);
+CREATE OPERATOR |<=| (procedure = absle84, leftarg = int8, rightarg = int4, commutator = |<=|);
+CREATE OPERATOR |>=| (procedure = absge4, leftarg = int4, rightarg = int4, commutator = |>=|);
+CREATE OPERATOR |>=| (procedure = absge8, leftarg = int8, rightarg = int8, commutator = |>=|);
+CREATE OPERATOR |>=| (procedure = absge48, leftarg = int4, rightarg = int8, commutator = |>=|);
+CREATE OPERATOR |>=| (procedure = absge84, leftarg = int8, rightarg = int4, commutator = |>=|);
+CREATE OPERATOR FAMILY abs_int_ops USING btree;
+CREATE OPERATOR CLASS abs_int4_ops FOR TYPE int4
+  USING btree FAMILY abs_int_ops  AS
+  OPERATOR 1 |<|,
+  OPERATOR 3 |=|,
+  OPERATOR 5 |>|,
+  FUNCTION 1 abscmp4(int4, int4);
+CREATE OPERATOR CLASS abs_int8_ops FOR TYPE int8
+  USING btree FAMILY abs_int_ops AS
+  OPERATOR 1 |<|,
+  OPERATOR 3 |=|,
+  OPERATOR 5 |>|,
+  FUNCTION 1 abscmp8(int8, int8);
+ALTER OPERATOR FAMILY abs_int_ops USING btree ADD
+  -- cross-type comparisons int4 vs int8
+  OPERATOR 1 |<| (int4, int8),
+  OPERATOR 2 |<=| (int4, int8),
+  OPERATOR 3 |=| (int4, int8),
+  OPERATOR 4 |>=| (int4, int8),
+  OPERATOR 5 |>| (int4, int8),
+  FUNCTION 1 abscmp48(int4, int8),
+  
+  -- cross-type comparisons int8 vs int4
+  OPERATOR 1 |<| (int8, int4),
+  OPERATOR 2 |<=| (int8, int4),
+  OPERATOR 3 |=| (int8, int4),
+  OPERATOR 4 |>=| (int8, int4),
+  OPERATOR 5 |>| (int8, int4),
+  FUNCTION 1 abscmp84(int8, int4);
+CREATE TABLE issue_14982_t1 (a int, b int4) PARTITION BY LIST (b)
+(
+  PARTITION p1 VALUES (1),
+  PARTITION p2 VALUES (-1)
+);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "issue_14982_t1_1_prt_p1" for table "issue_14982_t1"
+NOTICE:  CREATE TABLE will create partition "issue_14982_t1_1_prt_p2" for table "issue_14982_t1"
+CREATE TABLE issue_14982_t2 (a int, b int8) PARTITION BY LIST (b)
+(
+  PARTITION p1 VALUES (1),
+  PARTITION p2 VALUES (-1)
+);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "issue_14982_t2_1_prt_p1" for table "issue_14982_t2"
+NOTICE:  CREATE TABLE will create partition "issue_14982_t2_1_prt_p2" for table "issue_14982_t2"
+-- Insert some value to make sure the result of the correct plan is distinct
+-- from the wrong plan.
+INSERT INTO issue_14982_t1 VALUES (1,1), (1,-1), (-1,1), (-1,-1);
+INSERT INTO issue_14982_t2 VALUES (1,1), (1,-1), (-1,1), (-1,-1);
+SET enable_hashjoin TO 'ON';
+SET enable_mergejoin TO 'OFF';
+-- Cannot perform dynamic partition pruning for the following query, since the opfamily of
+-- the operator in 't1.b |=| t2.b' is different from the opfamily of the operator used for
+-- defining the partitioned table.
+EXPLAIN (costs off)
+  SELECT * FROM issue_14982_t1 t1, issue_14982_t2 t2
+    WHERE t1.a = t2.a AND t1.b |=| t2.b AND t2.b = 1;
+                           QUERY PLAN                           
+----------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Join
+         Hash Cond: (t1.a = t2.a)
+         Join Filter: (t1.b |=| t2.b)
+         ->  Append
+               ->  Seq Scan on issue_14982_t1_1_prt_p1 t1
+               ->  Seq Scan on issue_14982_t1_1_prt_p2 t1_1
+         ->  Hash
+               ->  Append
+                     ->  Seq Scan on issue_14982_t2_1_prt_p1 t2
+                           Filter: (b = 1)
+ Optimizer: Postgres query optimizer
+(12 rows)
+
+SELECT * FROM issue_14982_t1 t1, issue_14982_t2 t2
+  WHERE t1.a = t2.a AND t1.b |=| t2.b AND t2.b = 1;
+ a  | b  | a  | b 
+----+----+----+---
+  1 |  1 |  1 | 1
+  1 | -1 |  1 | 1
+ -1 |  1 | -1 | 1
+ -1 | -1 | -1 | 1
+(4 rows)
+
+-- Can perform dynamic partition pruning for the following query, since the operator in
+-- 't1.b = t2.b' and the operator used for defining the partitioned table are of same opfamily.
+EXPLAIN (costs off)
+  SELECT * FROM issue_14982_t1 t1, issue_14982_t2 t2
+    WHERE t1.a = t2.a AND t1.b = t2.b AND t2.b |=| 1;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Join
+         Hash Cond: ((t1.a = t2.a) AND (t1.b = t2.b))
+         ->  Append
+               ->  Result
+                     One-Time Filter: PartSelected
+                     ->  Seq Scan on issue_14982_t1_1_prt_p1 t1
+               ->  Result
+                     One-Time Filter: PartSelected
+                     ->  Seq Scan on issue_14982_t1_1_prt_p2 t1_1
+         ->  Hash
+               ->  Partition Selector for issue_14982_t1 (dynamic scan id: 1)
+                     Filter: t2.b
+                     ->  Append
+                           ->  Seq Scan on issue_14982_t2_1_prt_p1 t2
+                                 Filter: (b |=| 1)
+                           ->  Seq Scan on issue_14982_t2_1_prt_p2 t2_1
+                                 Filter: (b |=| 1)
+ Optimizer: Postgres query optimizer
+(19 rows)
+
+SELECT * FROM issue_14982_t1 t1, issue_14982_t2 t2
+  WHERE t1.a = t2.a AND t1.b = t2.b AND t2.b |=| 1;
+ a  | b  | a  | b  
+----+----+----+----
+  1 |  1 |  1 |  1
+  1 | -1 |  1 | -1
+ -1 |  1 | -1 |  1
+ -1 | -1 | -1 | -1
+(4 rows)
+
+-- Test this behavior in range partitioned table.
+CREATE TABLE issue_14982_t1_part_range (a int, b int4) PARTITION BY RANGE (b)
+(
+  PARTITION p1 START (-2) END (0),
+  PARTITION p2 START (0)  END (2)
+);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "issue_14982_t1_part_range_1_prt_p1" for table "issue_14982_t1_part_range"
+NOTICE:  CREATE TABLE will create partition "issue_14982_t1_part_range_1_prt_p2" for table "issue_14982_t1_part_range"
+CREATE TABLE issue_14982_t2_part_range (a int, b int8) PARTITION BY RANGE (b)
+(
+  PARTITION p1 START (-2) END (0),
+  PARTITION p2 START (0)  END (2)
+);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "issue_14982_t2_part_range_1_prt_p1" for table "issue_14982_t2_part_range"
+NOTICE:  CREATE TABLE will create partition "issue_14982_t2_part_range_1_prt_p2" for table "issue_14982_t2_part_range"
+INSERT INTO issue_14982_t1_part_range VALUES (1,1), (1,-1), (-1,1), (-1,-1);
+INSERT INTO issue_14982_t2_part_range VALUES (1,1), (1,-1), (-1,1), (-1,-1);
+-- Cannot perform dynamic partition pruning for the following query, since the opfamily of
+-- the operator in 't1.b |=| t2.b' is different from the opfamily of the operator used for
+-- defining the partitioned table.
+EXPLAIN (costs off)
+  SELECT * FROM issue_14982_t1_part_range t1, issue_14982_t2_part_range t2
+    WHERE t1.a = t2.a AND t1.b |=| t2.b AND t2.b = 1;
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Join
+         Hash Cond: (t1.a = t2.a)
+         Join Filter: (t1.b |=| t2.b)
+         ->  Append
+               ->  Seq Scan on issue_14982_t1_part_range_1_prt_p1 t1
+               ->  Seq Scan on issue_14982_t1_part_range_1_prt_p2 t1_1
+         ->  Hash
+               ->  Append
+                     ->  Seq Scan on issue_14982_t2_part_range_1_prt_p2 t2
+                           Filter: (b = 1)
+ Optimizer: Postgres query optimizer
+(12 rows)
+
+SELECT * FROM issue_14982_t1_part_range t1, issue_14982_t2_part_range t2
+  WHERE t1.a = t2.a AND t1.b |=| t2.b AND t2.b = 1;
+ a  | b  | a  | b 
+----+----+----+---
+ -1 | -1 | -1 | 1
+ -1 |  1 | -1 | 1
+  1 | -1 |  1 | 1
+  1 |  1 |  1 | 1
+(4 rows)
+
+-- Can perform dynamic partition pruning for the following query, since the operator in
+-- 't1.b = t2.b' and the operator used for defining the partitioned table are of same opfamily.
+EXPLAIN (costs off)
+  SELECT * FROM issue_14982_t1_part_range t1, issue_14982_t2_part_range t2
+    WHERE t1.a = t2.a AND t1.b = t2.b AND t2.b |=| 1;
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Join
+         Hash Cond: ((t1.a = t2.a) AND (t1.b = t2.b))
+         ->  Append
+               ->  Result
+                     One-Time Filter: PartSelected
+                     ->  Seq Scan on issue_14982_t1_part_range_1_prt_p1 t1
+               ->  Result
+                     One-Time Filter: PartSelected
+                     ->  Seq Scan on issue_14982_t1_part_range_1_prt_p2 t1_1
+         ->  Hash
+               ->  Partition Selector for issue_14982_t1_part_range (dynamic scan id: 1)
+                     Filter: t2.b
+                     ->  Append
+                           ->  Seq Scan on issue_14982_t2_part_range_1_prt_p1 t2
+                                 Filter: (b |=| 1)
+                           ->  Seq Scan on issue_14982_t2_part_range_1_prt_p2 t2_1
+                                 Filter: (b |=| 1)
+ Optimizer: Postgres query optimizer
+(19 rows)
+
+SELECT * FROM issue_14982_t1_part_range t1, issue_14982_t2_part_range t2
+  WHERE t1.a = t2.a AND t1.b = t2.b AND t2.b |=| 1;
+ a  | b  | a  | b  
+----+----+----+----
+  1 | -1 |  1 | -1
+  1 |  1 |  1 |  1
+ -1 | -1 | -1 | -1
+ -1 |  1 | -1 |  1
+(4 rows)
+
+DROP SCHEMA issue_14982 CASCADE;
+NOTICE:  drop cascades to 49 other objects
+DETAIL:  drop cascades to function abseq4(integer,integer)
+drop cascades to function abslt4(integer,integer)
+drop cascades to function absle4(integer,integer)
+drop cascades to function absge4(integer,integer)
+drop cascades to function absgt4(integer,integer)
+drop cascades to function abscmp4(integer,integer)
+drop cascades to function abseq8(bigint,bigint)
+drop cascades to function abslt8(bigint,bigint)
+drop cascades to function absle8(bigint,bigint)
+drop cascades to function absge8(bigint,bigint)
+drop cascades to function absgt8(bigint,bigint)
+drop cascades to function abscmp8(bigint,bigint)
+drop cascades to function abseq48(integer,bigint)
+drop cascades to function abslt48(integer,bigint)
+drop cascades to function absle48(integer,bigint)
+drop cascades to function absge48(integer,bigint)
+drop cascades to function absgt48(integer,bigint)
+drop cascades to function abscmp48(integer,bigint)
+drop cascades to function abseq84(bigint,integer)
+drop cascades to function abslt84(bigint,integer)
+drop cascades to function absle84(bigint,integer)
+drop cascades to function absge84(bigint,integer)
+drop cascades to function absgt84(bigint,integer)
+drop cascades to function abscmp84(bigint,integer)
+drop cascades to operator |=|(integer,integer)
+drop cascades to operator |=|(bigint,bigint)
+drop cascades to operator |=|(integer,bigint)
+drop cascades to operator |=|(bigint,integer)
+drop cascades to operator |<|(integer,integer)
+drop cascades to operator |<|(bigint,bigint)
+drop cascades to operator |<|(integer,bigint)
+drop cascades to operator |<|(bigint,integer)
+drop cascades to operator |>|(integer,integer)
+drop cascades to operator |>|(bigint,bigint)
+drop cascades to operator |>|(integer,bigint)
+drop cascades to operator |>|(bigint,integer)
+drop cascades to operator |<=|(integer,integer)
+drop cascades to operator |<=|(bigint,bigint)
+drop cascades to operator |<=|(integer,bigint)
+drop cascades to operator |<=|(bigint,integer)
+drop cascades to operator |>=|(integer,integer)
+drop cascades to operator |>=|(bigint,bigint)
+drop cascades to operator |>=|(integer,bigint)
+drop cascades to operator |>=|(bigint,integer)
+drop cascades to operator family abs_int_ops for access method btree
+drop cascades to table issue_14982_t1
+drop cascades to table issue_14982_t2
+drop cascades to table issue_14982_t1_part_range
+drop cascades to table issue_14982_t2_part_range
 RESET ALL;

--- a/src/test/regress/expected/partition_pruning_optimizer.out
+++ b/src/test/regress/expected/partition_pruning_optimizer.out
@@ -3110,4 +3110,326 @@ where  trg.key1 = src.key1
 (22 rows)
 
 DROP TABLE t_part1;
+-- Test that the dynamic partition pruning should not be performed if the partition's opclass and the
+-- join condition's operator are not in the same opfamily.
+--
+-- The main idea for this test is:
+-- 1. We define two opclasses: abs_int4_ops and abs_int8_ops, both of them belong to the same opfamily: abs_int_ops.
+-- 2. We create two partition tables, one is partitioned by int4 typed column and one is partitioned by int8.
+--    CREATE TABLE t1 (a int4, b int4) PARTITION BY LIST (b) (PARTITION p1 VALUES (1), PARTITION p2 VALUES (-1));
+--    CREATE TABLE t2 (a int8, b int8) PARTITION BY LIST (b) (PARTITION p1 VALUES (1), PARTITION p2 VALUES (-1));
+-- 3. Run the following query:
+--    SELECT * FROM t1, t2 WHERE t1.a = t2.a AND t1.b |=| t2.b AND t2.b = 1;
+-- Previously, planner is generating wrong plan for the above query:
+--    Gather Motion 3:1  (slice1; segments: 3)
+--      ->  Hash Join
+--            Hash Cond: (t1_1_prt_p1.a = t2_1_prt_p1.a)
+--            Join Filter: (t1_1_prt_p1.b |=| t2_1_prt_p1.b)
+--            ->  Append
+--                  ->  Result
+--                        One-Time Filter: PartSelected <--- t1's partitions are selected according to t2.b
+--                        ->  Seq Scan on t1_1_prt_p1
+--                  ->  Result
+--                        One-Time Filter: PartSelected <--- t1's partitions are selected according to t2.b
+--                        ->  Seq Scan on t1_1_prt_p2
+--            ->  Hash
+--                  ->  Partition Selector for t1 (dynamic scan id: 1)
+--                        Filter: t2_1_prt_p1.b
+--                        ->  Append
+--                              ->  Seq Scan on t2_1_prt_p1
+--                                    Filter: (b = 1)
+-- In the above plan, t1's partitions are dynamically pruned according to the value of t2.b. It's incorrect, because the
+-- partition selection is using the operator '=(int4, int8)' which belongs to integer_ops, but the join condition is
+-- '|=|(int4, int8)' which belongs abs_int_ops. We shouldn't perform partition pruning for such query.
+CREATE SCHEMA issue_14982;
+SET search_path TO issue_14982;
+CREATE FUNCTION abseq4(int4, int4) RETURNS BOOL AS $$ BEGIN RETURN abs($1) = abs($2); END; $$ LANGUAGE plpgsql STRICT IMMUTABLE;
+CREATE FUNCTION abslt4(int4, int4) RETURNS BOOL AS $$ BEGIN RETURN abs($1) < abs($2); END; $$ LANGUAGE plpgsql STRICT IMMUTABLE;
+CREATE FUNCTION absle4(int4, int4) RETURNS BOOL AS $$ BEGIN RETURN abs($1) <= abs($2); END; $$ LANGUAGE plpgsql STRICT IMMUTABLE;
+CREATE FUNCTION absge4(int4, int4) RETURNS BOOL AS $$ BEGIN RETURN abs($1) >= abs($2); END; $$ LANGUAGE plpgsql STRICT IMMUTABLE;
+CREATE FUNCTION absgt4(int4, int4) RETURNS BOOL AS $$ BEGIN RETURN abs($1) > abs($2); END; $$ LANGUAGE plpgsql STRICT IMMUTABLE;
+CREATE FUNCTION abscmp4(int4, int4) RETURNS INT AS $$ BEGIN RETURN btint4cmp(abs($1), abs($2)); END; $$ LANGUAGE plpgsql STRICT IMMUTABLE;
+CREATE FUNCTION abseq8(int8, int8) RETURNS BOOL AS $$ BEGIN RETURN abs($1) = abs($2); END; $$ LANGUAGE plpgsql STRICT IMMUTABLE;
+CREATE FUNCTION abslt8(int8, int8) RETURNS BOOL AS $$ BEGIN RETURN abs($1) < abs($2); END; $$ LANGUAGE plpgsql STRICT IMMUTABLE;
+CREATE FUNCTION absle8(int8, int8) RETURNS BOOL AS $$ BEGIN RETURN abs($1) <= abs($2); END; $$ LANGUAGE plpgsql STRICT IMMUTABLE;
+CREATE FUNCTION absge8(int8, int8) RETURNS BOOL AS $$ BEGIN RETURN abs($1) >= abs($2); END; $$ LANGUAGE plpgsql STRICT IMMUTABLE;
+CREATE FUNCTION absgt8(int8, int8) RETURNS BOOL AS $$ BEGIN RETURN abs($1) > abs($2); END; $$ LANGUAGE plpgsql STRICT IMMUTABLE;
+CREATE FUNCTION abscmp8(int8, int8) RETURNS INT AS $$ BEGIN RETURN btint8cmp(abs($1), abs($2)); END; $$ LANGUAGE plpgsql STRICT IMMUTABLE;
+CREATE FUNCTION abseq48(int4, int8) RETURNS BOOL AS $$ BEGIN RETURN abs($1) = abs($2); END; $$ LANGUAGE plpgsql STRICT IMMUTABLE;
+CREATE FUNCTION abslt48(int4, int8) RETURNS BOOL AS $$ BEGIN RETURN abs($1) < abs($2); END; $$ LANGUAGE plpgsql STRICT IMMUTABLE;
+CREATE FUNCTION absle48(int4, int8) RETURNS BOOL AS $$ BEGIN RETURN abs($1) <= abs($2); END; $$ LANGUAGE plpgsql STRICT IMMUTABLE;
+CREATE FUNCTION absge48(int4, int8) RETURNS BOOL AS $$ BEGIN RETURN abs($1) >= abs($2); END; $$ LANGUAGE plpgsql STRICT IMMUTABLE;
+CREATE FUNCTION absgt48(int4, int8) RETURNS BOOL AS $$ BEGIN RETURN abs($1) > abs($2); END; $$ LANGUAGE plpgsql STRICT IMMUTABLE;
+CREATE FUNCTION abscmp48(int4, int8) RETURNS INT AS $$ BEGIN RETURN btint48cmp(abs($1), abs($2)); END; $$ LANGUAGE plpgsql STRICT IMMUTABLE;
+CREATE FUNCTION abseq84(int8, int4) RETURNS BOOL AS $$ BEGIN RETURN abs($1) = abs($2); END; $$ LANGUAGE plpgsql STRICT IMMUTABLE;
+CREATE FUNCTION abslt84(int8, int4) RETURNS BOOL AS $$ BEGIN RETURN abs($1) < abs($2); END; $$ LANGUAGE plpgsql STRICT IMMUTABLE;
+CREATE FUNCTION absle84(int8, int4) RETURNS BOOL AS $$ BEGIN RETURN abs($1) <= abs($2); END; $$ LANGUAGE plpgsql STRICT IMMUTABLE;
+CREATE FUNCTION absge84(int8, int4) RETURNS BOOL AS $$ BEGIN RETURN abs($1) >= abs($2); END; $$ LANGUAGE plpgsql STRICT IMMUTABLE;
+CREATE FUNCTION absgt84(int8, int4) RETURNS BOOL AS $$ BEGIN RETURN abs($1) > abs($2); END; $$ LANGUAGE plpgsql STRICT IMMUTABLE;
+CREATE FUNCTION abscmp84(int8, int4) RETURNS INT AS $$ BEGIN RETURN btint84cmp(abs($1), abs($2)); END; $$ LANGUAGE plpgsql STRICT IMMUTABLE;
+CREATE OPERATOR |=| (procedure = abseq4, leftarg = int4, rightarg = int4, commutator = |=|, merges);
+CREATE OPERATOR |=| (procedure = abseq8, leftarg = int8, rightarg = int8, commutator = |=|, merges);
+CREATE OPERATOR |=| (procedure = abseq48, leftarg = int4, rightarg = int8, commutator = |=|, merges);
+CREATE OPERATOR |=| (procedure = abseq84, leftarg = int8, rightarg = int4, commutator = |=|, merges);
+CREATE OPERATOR |<| (procedure = abslt4, leftarg = int4, rightarg = int4, commutator = |<|);
+CREATE OPERATOR |<| (procedure = abslt8, leftarg = int8, rightarg = int8, commutator = |<|);
+CREATE OPERATOR |<| (procedure = abslt48, leftarg = int4, rightarg = int8, commutator = |<|);
+CREATE OPERATOR |<| (procedure = abslt84, leftarg = int8, rightarg = int4, commutator = |<|);
+CREATE OPERATOR |>| (procedure = absgt4, leftarg = int4, rightarg = int4, commutator = |>|);
+CREATE OPERATOR |>| (procedure = absgt8, leftarg = int8, rightarg = int8, commutator = |>|);
+CREATE OPERATOR |>| (procedure = absgt48, leftarg = int4, rightarg = int8, commutator = |>|);
+CREATE OPERATOR |>| (procedure = absgt84, leftarg = int8, rightarg = int4, commutator = |>|);
+CREATE OPERATOR |<=| (procedure = absle4, leftarg = int4, rightarg = int4, commutator = |<=|);
+CREATE OPERATOR |<=| (procedure = absle8, leftarg = int8, rightarg = int8, commutator = |<=|);
+CREATE OPERATOR |<=| (procedure = absle48, leftarg = int4, rightarg = int8, commutator = |<=|);
+CREATE OPERATOR |<=| (procedure = absle84, leftarg = int8, rightarg = int4, commutator = |<=|);
+CREATE OPERATOR |>=| (procedure = absge4, leftarg = int4, rightarg = int4, commutator = |>=|);
+CREATE OPERATOR |>=| (procedure = absge8, leftarg = int8, rightarg = int8, commutator = |>=|);
+CREATE OPERATOR |>=| (procedure = absge48, leftarg = int4, rightarg = int8, commutator = |>=|);
+CREATE OPERATOR |>=| (procedure = absge84, leftarg = int8, rightarg = int4, commutator = |>=|);
+CREATE OPERATOR FAMILY abs_int_ops USING btree;
+CREATE OPERATOR CLASS abs_int4_ops FOR TYPE int4
+  USING btree FAMILY abs_int_ops  AS
+  OPERATOR 1 |<|,
+  OPERATOR 3 |=|,
+  OPERATOR 5 |>|,
+  FUNCTION 1 abscmp4(int4, int4);
+CREATE OPERATOR CLASS abs_int8_ops FOR TYPE int8
+  USING btree FAMILY abs_int_ops AS
+  OPERATOR 1 |<|,
+  OPERATOR 3 |=|,
+  OPERATOR 5 |>|,
+  FUNCTION 1 abscmp8(int8, int8);
+ALTER OPERATOR FAMILY abs_int_ops USING btree ADD
+  -- cross-type comparisons int4 vs int8
+  OPERATOR 1 |<| (int4, int8),
+  OPERATOR 2 |<=| (int4, int8),
+  OPERATOR 3 |=| (int4, int8),
+  OPERATOR 4 |>=| (int4, int8),
+  OPERATOR 5 |>| (int4, int8),
+  FUNCTION 1 abscmp48(int4, int8),
+  
+  -- cross-type comparisons int8 vs int4
+  OPERATOR 1 |<| (int8, int4),
+  OPERATOR 2 |<=| (int8, int4),
+  OPERATOR 3 |=| (int8, int4),
+  OPERATOR 4 |>=| (int8, int4),
+  OPERATOR 5 |>| (int8, int4),
+  FUNCTION 1 abscmp84(int8, int4);
+CREATE TABLE issue_14982_t1 (a int, b int4) PARTITION BY LIST (b)
+(
+  PARTITION p1 VALUES (1),
+  PARTITION p2 VALUES (-1)
+);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "issue_14982_t1_1_prt_p1" for table "issue_14982_t1"
+NOTICE:  CREATE TABLE will create partition "issue_14982_t1_1_prt_p2" for table "issue_14982_t1"
+CREATE TABLE issue_14982_t2 (a int, b int8) PARTITION BY LIST (b)
+(
+  PARTITION p1 VALUES (1),
+  PARTITION p2 VALUES (-1)
+);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "issue_14982_t2_1_prt_p1" for table "issue_14982_t2"
+NOTICE:  CREATE TABLE will create partition "issue_14982_t2_1_prt_p2" for table "issue_14982_t2"
+-- Insert some value to make sure the result of the correct plan is distinct
+-- from the wrong plan.
+INSERT INTO issue_14982_t1 VALUES (1,1), (1,-1), (-1,1), (-1,-1);
+INSERT INTO issue_14982_t2 VALUES (1,1), (1,-1), (-1,1), (-1,-1);
+SET enable_hashjoin TO 'ON';
+SET enable_mergejoin TO 'OFF';
+-- Cannot perform dynamic partition pruning for the following query, since the opfamily of
+-- the operator in 't1.b |=| t2.b' is different from the opfamily of the operator used for
+-- defining the partitioned table.
+EXPLAIN (costs off)
+  SELECT * FROM issue_14982_t1 t1, issue_14982_t2 t2
+    WHERE t1.a = t2.a AND t1.b |=| t2.b AND t2.b = 1;
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Join
+         Hash Cond: ((issue_14982_t2.a = issue_14982_t1.a) AND (issue_14982_t2.b = (issue_14982_t1.b)::bigint))
+         ->  Dynamic Seq Scan on issue_14982_t2 (dynamic scan id: 2)
+               Filter: (b = 1)
+         ->  Hash
+               ->  Partition Selector for issue_14982_t2 (dynamic scan id: 2)
+                     ->  Sequence
+                           ->  Partition Selector for issue_14982_t1 (dynamic scan id: 1)
+                                 Partitions selected: 2 (out of 2)
+                           ->  Dynamic Seq Scan on issue_14982_t1 (dynamic scan id: 1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(12 rows)
+
+SELECT * FROM issue_14982_t1 t1, issue_14982_t2 t2
+  WHERE t1.a = t2.a AND t1.b |=| t2.b AND t2.b = 1;
+ a  | b | a  | b 
+----+---+----+---
+ -1 | 1 | -1 | 1
+  1 | 1 |  1 | 1
+(2 rows)
+
+-- Can perform dynamic partition pruning for the following query, since the operator in
+-- 't1.b = t2.b' and the operator used for defining the partitioned table are of same opfamily.
+EXPLAIN (costs off)
+  SELECT * FROM issue_14982_t1 t1, issue_14982_t2 t2
+    WHERE t1.a = t2.a AND t1.b = t2.b AND t2.b |=| 1;
+                                                   QUERY PLAN                                                   
+----------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Join
+         Hash Cond: ((issue_14982_t2.a = issue_14982_t1.a) AND (issue_14982_t2.b = (issue_14982_t1.b)::bigint))
+         ->  Dynamic Seq Scan on issue_14982_t2 (dynamic scan id: 2)
+               Filter: ((b |=| 1) AND (b = 1))
+         ->  Hash
+               ->  Partition Selector for issue_14982_t2 (dynamic scan id: 2)
+                     ->  Sequence
+                           ->  Partition Selector for issue_14982_t1 (dynamic scan id: 1)
+                                 Partitions selected: 1 (out of 2)
+                           ->  Dynamic Seq Scan on issue_14982_t1 (dynamic scan id: 1)
+                                 Filter: (b = 1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(13 rows)
+
+SELECT * FROM issue_14982_t1 t1, issue_14982_t2 t2
+  WHERE t1.a = t2.a AND t1.b = t2.b AND t2.b |=| 1;
+ a  | b | a  | b 
+----+---+----+---
+ -1 | 1 | -1 | 1
+  1 | 1 |  1 | 1
+(2 rows)
+
+-- Test this behavior in range partitioned table.
+CREATE TABLE issue_14982_t1_part_range (a int, b int4) PARTITION BY RANGE (b)
+(
+  PARTITION p1 START (-2) END (0),
+  PARTITION p2 START (0)  END (2)
+);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "issue_14982_t1_part_range_1_prt_p1" for table "issue_14982_t1_part_range"
+NOTICE:  CREATE TABLE will create partition "issue_14982_t1_part_range_1_prt_p2" for table "issue_14982_t1_part_range"
+CREATE TABLE issue_14982_t2_part_range (a int, b int8) PARTITION BY RANGE (b)
+(
+  PARTITION p1 START (-2) END (0),
+  PARTITION p2 START (0)  END (2)
+);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "issue_14982_t2_part_range_1_prt_p1" for table "issue_14982_t2_part_range"
+NOTICE:  CREATE TABLE will create partition "issue_14982_t2_part_range_1_prt_p2" for table "issue_14982_t2_part_range"
+INSERT INTO issue_14982_t1_part_range VALUES (1,1), (1,-1), (-1,1), (-1,-1);
+INSERT INTO issue_14982_t2_part_range VALUES (1,1), (1,-1), (-1,1), (-1,-1);
+-- Cannot perform dynamic partition pruning for the following query, since the opfamily of
+-- the operator in 't1.b |=| t2.b' is different from the opfamily of the operator used for
+-- defining the partitioned table.
+EXPLAIN (costs off)
+  SELECT * FROM issue_14982_t1_part_range t1, issue_14982_t2_part_range t2
+    WHERE t1.a = t2.a AND t1.b |=| t2.b AND t2.b = 1;
+                                                                         QUERY PLAN                                                                         
+------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Join
+         Hash Cond: ((issue_14982_t2_part_range.a = issue_14982_t1_part_range.a) AND (issue_14982_t2_part_range.b = (issue_14982_t1_part_range.b)::bigint))
+         ->  Dynamic Seq Scan on issue_14982_t2_part_range (dynamic scan id: 2)
+               Filter: (b = 1)
+         ->  Hash
+               ->  Partition Selector for issue_14982_t2_part_range (dynamic scan id: 2)
+                     ->  Sequence
+                           ->  Partition Selector for issue_14982_t1_part_range (dynamic scan id: 1)
+                                 Partitions selected: 2 (out of 2)
+                           ->  Dynamic Seq Scan on issue_14982_t1_part_range (dynamic scan id: 1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(12 rows)
+
+SELECT * FROM issue_14982_t1_part_range t1, issue_14982_t2_part_range t2
+  WHERE t1.a = t2.a AND t1.b |=| t2.b AND t2.b = 1;
+ a  | b | a  | b 
+----+---+----+---
+ -1 | 1 | -1 | 1
+  1 | 1 |  1 | 1
+(2 rows)
+
+-- Can perform dynamic partition pruning for the following query, since the operator in
+-- 't1.b = t2.b' and the operator used for defining the partitioned table are of same opfamily.
+EXPLAIN (costs off)
+  SELECT * FROM issue_14982_t1_part_range t1, issue_14982_t2_part_range t2
+    WHERE t1.a = t2.a AND t1.b = t2.b AND t2.b |=| 1;
+                                                                         QUERY PLAN                                                                         
+------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Hash Join
+         Hash Cond: ((issue_14982_t2_part_range.a = issue_14982_t1_part_range.a) AND (issue_14982_t2_part_range.b = (issue_14982_t1_part_range.b)::bigint))
+         ->  Dynamic Seq Scan on issue_14982_t2_part_range (dynamic scan id: 2)
+               Filter: ((b |=| 1) AND (b = 1))
+         ->  Hash
+               ->  Partition Selector for issue_14982_t2_part_range (dynamic scan id: 2)
+                     ->  Sequence
+                           ->  Partition Selector for issue_14982_t1_part_range (dynamic scan id: 1)
+                                 Partitions selected: 1 (out of 2)
+                           ->  Dynamic Seq Scan on issue_14982_t1_part_range (dynamic scan id: 1)
+                                 Filter: (b = 1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(13 rows)
+
+SELECT * FROM issue_14982_t1_part_range t1, issue_14982_t2_part_range t2
+  WHERE t1.a = t2.a AND t1.b = t2.b AND t2.b |=| 1;
+ a  | b | a  | b 
+----+---+----+---
+  1 | 1 |  1 | 1
+ -1 | 1 | -1 | 1
+(2 rows)
+
+DROP SCHEMA issue_14982 CASCADE;
+NOTICE:  drop cascades to 49 other objects
+DETAIL:  drop cascades to function abseq4(integer,integer)
+drop cascades to function abslt4(integer,integer)
+drop cascades to function absle4(integer,integer)
+drop cascades to function absge4(integer,integer)
+drop cascades to function absgt4(integer,integer)
+drop cascades to function abscmp4(integer,integer)
+drop cascades to function abseq8(bigint,bigint)
+drop cascades to function abslt8(bigint,bigint)
+drop cascades to function absle8(bigint,bigint)
+drop cascades to function absge8(bigint,bigint)
+drop cascades to function absgt8(bigint,bigint)
+drop cascades to function abscmp8(bigint,bigint)
+drop cascades to function abseq48(integer,bigint)
+drop cascades to function abslt48(integer,bigint)
+drop cascades to function absle48(integer,bigint)
+drop cascades to function absge48(integer,bigint)
+drop cascades to function absgt48(integer,bigint)
+drop cascades to function abscmp48(integer,bigint)
+drop cascades to function abseq84(bigint,integer)
+drop cascades to function abslt84(bigint,integer)
+drop cascades to function absle84(bigint,integer)
+drop cascades to function absge84(bigint,integer)
+drop cascades to function absgt84(bigint,integer)
+drop cascades to function abscmp84(bigint,integer)
+drop cascades to operator |=|(integer,integer)
+drop cascades to operator |=|(bigint,bigint)
+drop cascades to operator |=|(integer,bigint)
+drop cascades to operator |=|(bigint,integer)
+drop cascades to operator |<|(integer,integer)
+drop cascades to operator |<|(bigint,bigint)
+drop cascades to operator |<|(integer,bigint)
+drop cascades to operator |<|(bigint,integer)
+drop cascades to operator |>|(integer,integer)
+drop cascades to operator |>|(bigint,bigint)
+drop cascades to operator |>|(integer,bigint)
+drop cascades to operator |>|(bigint,integer)
+drop cascades to operator |<=|(integer,integer)
+drop cascades to operator |<=|(bigint,bigint)
+drop cascades to operator |<=|(integer,bigint)
+drop cascades to operator |<=|(bigint,integer)
+drop cascades to operator |>=|(integer,integer)
+drop cascades to operator |>=|(bigint,bigint)
+drop cascades to operator |>=|(integer,bigint)
+drop cascades to operator |>=|(bigint,integer)
+drop cascades to operator family abs_int_ops for access method btree
+drop cascades to table issue_14982_t1
+drop cascades to table issue_14982_t2
+drop cascades to table issue_14982_t1_part_range
+drop cascades to table issue_14982_t2_part_range
 RESET ALL;


### PR DESCRIPTION
This patch partially fixes #14982 for planner. Greenplum generates PartitionSelector plan nodes when JOIN-ing partitioned tables without checking the partkey's opfamily and the equality operator's opfamily in the JOIN query's condition.

For example, we have two partitioned tables:

```
CREATE TABLE t1 (a int4, b int4) PARTITION BY LIST (b)
    (PARTITION p1 VALUES (1), PARTITION p2 VALUES (-1));
CREATE TABLE t2 (a int8, b int8) PARTITION BY LIST (b)
    (PARTITION p1 VALUES (1), PARTITION p2 VALUES (-1));
```

Then we define some customed operators for comparing absolute values. The complete definitions of these operators are available in my test case.

```
CREATE OPERATOR |=| (procedure = abseq4, leftarg = int4, rightarg = int4, commutator = |=|, merges);
...
CREATE OPERATOR |>=| (procedure = absge4, leftarg = int4, rightarg = int4, commutator = |>=|);
...
CREATE OPERATOR FAMILY abs_int_ops USING btree;
CREATE OPERATOR CLASS abs_int4_ops FOR TYPE int4
  USING btree FAMILY abs_int_ops  AS
  OPERATOR 1 |<|,
  OPERATOR 3 |=|,
  OPERATOR 5 |>|,
  FUNCTION 1 abscmp4(int4, int4);
...
```

When running the below query, Greenplum generates wrong plan:

```
EXPLAIN (costs off) SELECT * FROM t1, t2 WHERE t1.a = t2.a AND t1.b |=| t2.b AND t2.b = 1;
--------------------------------------------
Gather Motion 3:1  (slice1; segments: 3)
  ->  Hash Join
        Hash Cond: (t1_1_prt_p1.a = t2_1_prt_p1.a)
        Join Filter: (t1_1_prt_p1.b |=| t2_1_prt_p1.b)
        ->  Append
              ->  Result
                    One-Time Filter: PartSelected <--- t1's partitions are selected according to t2.b
                    ->  Seq Scan on t1_1_prt_p1
              ->  Result
                    One-Time Filter: PartSelected <--- t1's partitions are selected according to t2.b
                    ->  Seq Scan on t1_1_prt_p2
        ->  Hash
              ->  Partition Selector for t1 (dynamic scan id: 1)
                    Filter: t2_1_prt_p1.b
                    ->  Append
                          ->  Seq Scan on t2_1_prt_p1
                                Filter: (b = 1)
```

The root cause is that, Greenplum's planner doesn't check the opfamily of operator `|=|` (the one appeared in the JOIN condition) against the opfamily of operator `=` (the one used for defining partitioned table). Operator `=` and operator `|=|` are not semantically equivalent and they are from different opfamilies!

The fix is intuitive with the RCA. Let's check the operators opfamilies before trying to generate partition pruning plans.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [x] Pass `make installcheck`
