### PR TITLE
[6X backport]Resolve wrong result when direct dispatch, If opno of clause does not belong to opfamily of distributed key

### DIFF
--- a/src/backend/optimizer/util/predtest.c
+++ b/src/backend/optimizer/util/predtest.c
@@ -1935,7 +1935,7 @@ InvalidateOprProofCacheCallBack(Datum arg, int cacheid, uint32 hashvalue)
  * Process an AND clause -- this can do a INTERSECTION between sets learned from child clauses
  */
 static PossibleValueSet
-ProcessAndClauseForPossibleValues( PredIterInfoData *clauseInfo, Node *clause, Node *variable)
+ProcessAndClauseForPossibleValues( PredIterInfoData *clauseInfo, Node *clause, Node *variable, Oid opfamily)
 {
 	PossibleValueSet result;
 
@@ -1943,7 +1943,7 @@ ProcessAndClauseForPossibleValues( PredIterInfoData *clauseInfo, Node *clause, N
 
 	iterate_begin(child, clause, *clauseInfo)
 	{
-		PossibleValueSet childPossible = DeterminePossibleValueSet( child, variable );
+		PossibleValueSet childPossible = DeterminePossibleValueSet( child, variable, opfamily );
 		if ( childPossible.isAnyValuePossible)
 		{
 			/* any value possible, this AND member does not add any information */
@@ -1974,14 +1974,14 @@ ProcessAndClauseForPossibleValues( PredIterInfoData *clauseInfo, Node *clause, N
  * Process an OR clause -- this can do a UNION between sets learned from child clauses
  */
 static PossibleValueSet
-ProcessOrClauseForPossibleValues( PredIterInfoData *clauseInfo, Node *clause, Node *variable)
+ProcessOrClauseForPossibleValues( PredIterInfoData *clauseInfo, Node *clause, Node *variable, Oid opfamily)
 {
 	PossibleValueSet result;
 	InitPossibleValueSetData(&result);
 
 	iterate_begin(child, clause, *clauseInfo)
 	{
-		PossibleValueSet childPossible = DeterminePossibleValueSet( child, variable );
+		PossibleValueSet childPossible = DeterminePossibleValueSet( child, variable, opfamily );
 		if ( childPossible.isAnyValuePossible)
 		{
 			/* any value is possible for the entire AND */
@@ -2023,7 +2023,7 @@ ProcessOrClauseForPossibleValues( PredIterInfoData *clauseInfo, Node *clause, No
  *    possible values is within the cross-product of the two variables' sets
  */
 PossibleValueSet
-DeterminePossibleValueSet(Node *clause, Node *variable)
+DeterminePossibleValueSet(Node *clause, Node *variable, Oid opfamily)
 {
 	PredIterInfoData clauseInfo;
 	PossibleValueSet result;
@@ -2037,11 +2037,11 @@ DeterminePossibleValueSet(Node *clause, Node *variable)
 	switch (predicate_classify(clause, &clauseInfo))
 	{
 		case CLASS_AND:
-			return ProcessAndClauseForPossibleValues(&clauseInfo, clause, variable);
+			return ProcessAndClauseForPossibleValues(&clauseInfo, clause, variable, opfamily);
 		case CLASS_OR:
-			return ProcessOrClauseForPossibleValues(&clauseInfo, clause, variable);
+			return ProcessOrClauseForPossibleValues(&clauseInfo, clause, variable, opfamily);
 		case CLASS_ATOM:
-			if (TryProcessExprForPossibleValues(clause, variable, &result))
+			if (TryProcessExprForPossibleValues(clause, variable, opfamily, &result))
 			{
 				return result;
 			}

--- a/src/include/optimizer/predtest.h
+++ b/src/include/optimizer/predtest.h
@@ -47,7 +47,7 @@ typedef struct
 	bool isAnyValuePossible;
 } PossibleValueSet;
 
-extern PossibleValueSet DeterminePossibleValueSet(Node *clause, Node *variable);
+extern PossibleValueSet DeterminePossibleValueSet(Node *clause, Node *variable, Oid opfamily);
 
 /* returns a newly allocated list */
 extern Node **GetPossibleValuesAsArray(PossibleValueSet *pvs, int *numValuesOut);
@@ -58,7 +58,7 @@ extern void InitPossibleValueSetData(PossibleValueSet *pvs);
 
 extern void AddUnmatchingValues(PossibleValueSet *pvs, PossibleValueSet *toCheck);
 extern void RemoveUnmatchingValues(PossibleValueSet *pvs, PossibleValueSet *toCheck);
-extern bool TryProcessExprForPossibleValues(Node *expr, Node *variable, PossibleValueSet *resultOut);
+extern bool TryProcessExprForPossibleValues(Node *expr, Node *variable, Oid opfamily, PossibleValueSet *resultOut);
 
 /**
  * END functions and structures for determining set of possible values from a clause

--- a/src/test/regress/expected/direct_dispatch.out
+++ b/src/test/regress/expected/direct_dispatch.out
@@ -1000,6 +1000,69 @@ explain (costs off) select gp_segment_id, id from t_test_dd_via_segid where gp_s
  Optimizer: Postgres query optimizer
 (4 rows)
 
+-- https://github.com/greenplum-db/gpdb/issues/14887
+-- If opno of clause does not belong to opfamily of distributed key,
+-- do not use direct dispatch to resolve wrong result
+create table t_14887(a varchar);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
+insert into t_14887 values('a   ');
+INFO:  (slice 0) Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to SINGLE content
+explain select * from t_14887 where a = 'a'::bpchar;
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..760.00 rows=53 width=32)
+   ->  Seq Scan on t_14887  (cost=0.00..760.00 rows=18 width=32)
+         Filter: ((a)::bpchar = 'a'::bpchar)
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+select * from t_14887 where a = 'a'::bpchar;
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+  a   
+------
+ a   
+(1 row)
+
+-- texteq does not belong to the hash opfamily of the table's citext distkey.
+-- But from the implementation can deduce: texteq ==> citext_eq, and we can
+-- do the direct dispatch.
+-- But we do not have the kind of implication rule in Postgres: texteq ==> citext_eq.
+CREATE EXTENSION if not exists citext;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
+drop table t_14887;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
+create table t_14887(a citext);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
+insert into t_14887 values('A'),('a');
+INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
+explain select * from t_14887 where a = 'a'::text;
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..760.00 rows=53 width=32)
+   ->  Seq Scan on t_14887  (cost=0.00..760.00 rows=18 width=32)
+         Filter: ((a)::text = 'a'::text)
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+select * from t_14887 where a = 'a'::text;
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+ a 
+---
+ a
+(1 row)
+
 -- cleanup
 set test_print_direct_dispatch_info=off;
 begin;
@@ -1010,6 +1073,8 @@ drop table if exists direct_test_partition;
 drop table if exists direct_test_range_partition;
 drop table if exists direct_dispatch_foo;
 drop table if exists direct_dispatch_bar;
+drop table if exists t_14887;
+drop EXTENSION citext;
 drop table if exists MPP_22019_a;
 drop table if exists MPP_22019_b;
 commit;

--- a/src/test/regress/expected/direct_dispatch_optimizer.out
+++ b/src/test/regress/expected/direct_dispatch_optimizer.out
@@ -1034,6 +1034,68 @@ explain (costs off) select gp_segment_id, id from t_test_dd_via_segid where gp_s
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
 
+-- https://github.com/greenplum-db/gpdb/issues/14887
+-- If opno of clause does not belong to opfamily of distributed key,
+-- do not use direct dispatch to resolve wrong result
+create table t_14887(a varchar);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
+insert into t_14887 values('a   ');
+INFO:  (slice 0) Dispatch command to SINGLE content
+INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to SINGLE content
+explain select * from t_14887 where a = 'a'::bpchar;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+   ->  Seq Scan on t_14887  (cost=0.00..431.00 rows=1 width=8)
+         Filter: ((a)::bpchar = 'a'::bpchar)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(4 rows)
+
+select * from t_14887 where a = 'a'::bpchar;
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+  a   
+------
+ a   
+(1 row)
+
+-- texteq does not belong to the hash opfamily of the table's citext distkey.
+-- But from the implementation can deduce: texteq ==> citext_eq, and we can
+-- do the direct dispatch.
+-- But we do not have the kind of implication rule in Postgres: texteq ==> citext_eq.
+CREATE EXTENSION if not exists citext;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
+drop table t_14887;
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
+create table t_14887(a citext);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
+insert into t_14887 values('A'),('a');
+INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
+explain select * from t_14887 where a = 'a'::text;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+   ->  Seq Scan on t_14887  (cost=0.00..431.00 rows=1 width=8)
+         Filter: ((a)::text = 'a'::text)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(4 rows)
+
+select * from t_14887 where a = 'a'::text;
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+ a 
+---
+ a
+(1 row)
+
 -- cleanup
 set test_print_direct_dispatch_info=off;
 begin;
@@ -1044,6 +1106,8 @@ drop table if exists direct_test_partition;
 drop table if exists direct_test_range_partition;
 drop table if exists direct_dispatch_foo;
 drop table if exists direct_dispatch_bar;
+drop table if exists t_14887;
+drop EXTENSION citext;
 drop table if exists MPP_22019_a;
 drop table if exists MPP_22019_b;
 commit;


### PR DESCRIPTION
If opno of clause does not belong to opfamily of distributed key, and use direct dispatch we will get wrong results:
create table bar(a varchar);
insert into bar values('a   ');
explain select * from bar where a = 'a'::bpchar;
```
                                  QUERY PLAN
------------------------------------------------------------------------------
 Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..431.00 rows=1 width=8)
   ->  Seq Scan on bar  (cost=0.00..431.00 rows=1 width=8)
         Filter: ((a)::bpchar = 'a'::bpchar)
 Optimizer: Postgres query optimizer
(4 rows)

select * from bar where a = 'a'::bpchar;
 a
---
(0 rows)
```

if opno of the clause does not belong to opfamily of distributed key,
do not use direct dispatch to avoid wrong results.

There are some cases that we could use direct dispatch, but we don't after this commit.
create table t(a citext);
explain select * from t where a = 'a'::text; 
texteq does not belong to the opfamily of the table's distributed key citext type.
But from the implementation can deduce: texteq ==> citext_eq, and we can do the direct dispatch.
But we do not have the kind of implication rule in Postgres: texteq ==> citext_eq.

more details please refer to issue: https://github.com/greenplum-db/gpdb/issues/14887

This is a backport from main commit: b58ad49b36eda54b842678fba369bb12e24571ed