### PR TITLE
Added ao_aux_only option

### DIFF
--- a/gpdb-doc/markdown/ref_guide/sql_commands/VACUUM.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/VACUUM.html.md
@@ -12,7 +12,7 @@ VACUUM [FULL] [FREEZE] [VERBOSE] [<table>]
 VACUUM [FULL] [FREEZE] [VERBOSE] ANALYZE
               [<table> [(<column> [, ...] )]]
 
-VACUUM AO_AUX_ONLY <ao_table_name>
+VACUUM AO_AUX_ONLY <ao_table>
 ```
 
 ## <a id="section3"></a>Description 
@@ -61,12 +61,15 @@ INDEX_CLEANUP
 :   Specifies that `VACUUM` should attempt to remove index entries pointing to dead tuples. This is normally the desired behavior and is the default unless you override it by setting `vacuum_index_cleanup` to `false` for the table you run `VACUUM` against. Setting this option to `false` may be useful when you need to make vacuum run as quickly as possible, for example, to avoid imminent transaction ID wraparound. However, if you do not perform index cleanup regularly, performance may suffer, because as the table is modified, indexes accumulate dead tuples and the table itself accumulates dead line pointers that cannot be removed until index cleanup completes. This option has no effect for tables that do not have an index. If you use the `FULL` option, it will ignore the `INDEX_CLEANUP` option.
 
 AO_AUX_ONLY
-:   Runs `VACUUM` against all auxiliary tables of an append-optimized table. It does not run `VACUUM` against the append-optimized table.
+:   Runs `VACUUM` against all auxiliary tables of an append-optimized table. It does not run `VACUUM` against the append-optimized table. If run against a non append-optimized table without any child partitions, no action takes place. If run against a heap table with an append-only partition, it vacuums the auxiliary tables of this partition.
 
-table
+<ao_table>
+:    The name of a table to vacuum its auxiliary tables, ideally an append-optimized table.
+
+<table>
 :   The name \(optionally schema-qualified\) of a specific table to vacuum. Defaults to all tables in the current database.
 
-column
+<column>
 :   The name of a specific column to analyze. Defaults to all columns. If a column list is specified, `ANALYZE` is implied.
 
 ## <a id="section6"></a>Notes 

--- a/gpdb-doc/markdown/ref_guide/sql_commands/VACUUM.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/VACUUM.html.md
@@ -61,7 +61,7 @@ INDEX_CLEANUP
 :   Specifies that `VACUUM` should attempt to remove index entries pointing to dead tuples. This is normally the desired behavior and is the default unless you override it by setting `vacuum_index_cleanup` to `false` for the table you run `VACUUM` against. Setting this option to `false` may be useful when you need to make vacuum run as quickly as possible, for example, to avoid imminent transaction ID wraparound. However, if you do not perform index cleanup regularly, performance may suffer, because as the table is modified, indexes accumulate dead tuples and the table itself accumulates dead line pointers that cannot be removed until index cleanup completes. This option has no effect for tables that do not have an index. If you use the `FULL` option, it will ignore the `INDEX_CLEANUP` option.
 
 AO_AUX_ONLY
-:   Runs `VACUUM` against all auxiliary tables of an append-optimized table. It does not run `VACUUM` against the append-optimized table. If run against a non append-optimized table without any child partitions, no action takes place. If run against a heap table with an append-only partition, it vacuums the auxiliary tables of this partition.
+:   Runs `VACUUM` against all auxiliary tables of an append-optimized table. It does not run `VACUUM` against the append-optimized table. If run against a non append-optimized table without any child partitions, no action takes place. If run against a heap table with an append-optimized partition, it vacuums the auxiliary tables of this partition.
 
 <ao_table>
 :    The name of a table to vacuum its auxiliary tables, ideally an append-optimized table.

--- a/gpdb-doc/markdown/ref_guide/sql_commands/VACUUM.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/VACUUM.html.md
@@ -11,6 +11,8 @@ VACUUM [FULL] [FREEZE] [VERBOSE] [<table>]
 
 VACUUM [FULL] [FREEZE] [VERBOSE] ANALYZE
               [<table> [(<column> [, ...] )]]
+
+VACUUM AO_AUX_ONLY <ao_table_name>
 ```
 
 ## <a id="section3"></a>Description 
@@ -57,6 +59,9 @@ SKIP_LOCKED
 
 INDEX_CLEANUP
 :   Specifies that `VACUUM` should attempt to remove index entries pointing to dead tuples. This is normally the desired behavior and is the default unless you override it by setting `vacuum_index_cleanup` to `false` for the table you run `VACUUM` against. Setting this option to `false` may be useful when you need to make vacuum run as quickly as possible, for example, to avoid imminent transaction ID wraparound. However, if you do not perform index cleanup regularly, performance may suffer, because as the table is modified, indexes accumulate dead tuples and the table itself accumulates dead line pointers that cannot be removed until index cleanup completes. This option has no effect for tables that do not have an index. If you use the `FULL` option, it will ignore the `INDEX_CLEANUP` option.
+
+AO_AUX_ONLY
+:   Runs `VACUUM` against all auxiliary tables of an append-optimized table. It does not run `VACUUM` against the append-optimized table.
 
 table
 :   The name \(optionally schema-qualified\) of a specific table to vacuum. Defaults to all tables in the current database.

--- a/gpdb-doc/markdown/utility_guide/ref/vacuumdb.html.md
+++ b/gpdb-doc/markdown/utility_guide/ref/vacuumdb.html.md
@@ -14,8 +14,6 @@ vacuumdb [<connection-option>...] [--all | -a] [--full | -f] [-F]
     [--disable-page-skipping]
     [--skip-locked]
 
-vacuumdb --ao_aux_only <ao_table_name>
-
 vacuumdb -? | --help
 
 vacuumdb -V | --version
@@ -31,9 +29,6 @@ vacuumdb -V | --version
 
 -a \| --all
 :   Vacuums all databases.
-
---ao_aux_only
-:   Runs `VACUUM` against all auxiliary tables of an append-optimized table. It does not run `VACUUM` against the append-optimized table.
 
 \[-d\] dbname \| \[--dbname=\]dbname
 :   The name of the database to vacuum. If this is not specified and `-a` \(or `--all`\) is not used, the database name is read from the environment variable `PGDATABASE`. If that is not set, the user name specified for the connection is used.

--- a/gpdb-doc/markdown/utility_guide/ref/vacuumdb.html.md
+++ b/gpdb-doc/markdown/utility_guide/ref/vacuumdb.html.md
@@ -14,6 +14,8 @@ vacuumdb [<connection-option>...] [--all | -a] [--full | -f] [-F]
     [--disable-page-skipping]
     [--skip-locked]
 
+vacuumdb --ao_aux_only <ao_table_name>
+
 vacuumdb -? | --help
 
 vacuumdb -V | --version
@@ -29,6 +31,9 @@ vacuumdb -V | --version
 
 -a \| --all
 :   Vacuums all databases.
+
+--ao_aux_only
+:   Runs `VACUUM` against all auxiliary tables of an append-optimized table. It does not run `VACUUM` against the append-optimized table.
 
 \[-d\] dbname \| \[--dbname=\]dbname
 :   The name of the database to vacuum. If this is not specified and `-a` \(or `--all`\) is not used, the database name is read from the environment variable `PGDATABASE`. If that is not set, the user name specified for the connection is used.


### PR DESCRIPTION
Added Vacuum option ao_aux_only as per https://github.com/greenplum-db/gpdb/pull/14984
Also added reference to vacuumdb wraparound (let me know if this is correct).
Let me know if the syntax is correct, I added it as as completely different option, not sure if compatible with any of the other VACUUM options.

Review sites:
https://docs-staging.vmware.com/en/VMware-Tanzu-Greenplum/mireia-vacuum/greenplum-database/GUID-ref_guide-sql_commands-VACUUM.html
https://docs-staging.vmware.com/en/VMware-Tanzu-Greenplum/mireia-vacuum/greenplum-database/GUID-utility_guide-ref-vacuumdb.html
