### PR TITLE
Note about initialization phase

### DIFF
--- a/gpdb-doc/markdown/admin_guide/expand/expand-initialize.html.md
+++ b/gpdb-doc/markdown/admin_guide/expand/expand-initialize.html.md
@@ -6,7 +6,7 @@ Use the `gpexpand` utility to create and initialize the new segment instances an
 
 The first time you run [gpexpand](../../utility_guide/ref/gpexpand.html) with a valid input file it creates and initializes segment instances and creates the expansion schema. After these steps are completed, running `gpexpand` detects if the expansion schema has been created and, if so, performs table redistribution.
 
-> **Note** Make sure that no DDL operations are running during the initialization phase to avoid catalog inconsistency across existing and new segments.
+> **Note** To prevent catalog inconsistency across existing and new segments, be sure that no DDL operations are running during the initialization phase.
 
 -   [Creating an Input File for System Expansion](#topic23)
 -   [Running gpexpand to Initialize New Segments](#topic26)

--- a/gpdb-doc/markdown/admin_guide/expand/expand-initialize.html.md
+++ b/gpdb-doc/markdown/admin_guide/expand/expand-initialize.html.md
@@ -6,6 +6,8 @@ Use the `gpexpand` utility to create and initialize the new segment instances an
 
 The first time you run [gpexpand](../../utility_guide/ref/gpexpand.html) with a valid input file it creates and initializes segment instances and creates the expansion schema. After these steps are completed, running `gpexpand` detects if the expansion schema has been created and, if so, performs table redistribution.
 
+> **Note** Make sure that no DDL operations are running during the initialization phase to avoid catalog inconsistency across existing and new segments.
+
 -   [Creating an Input File for System Expansion](#topic23)
 -   [Running gpexpand to Initialize New Segments](#topic26)
 -   [Rolling Back a Failed Expansion Setup](#topic27)

--- a/gpdb-doc/markdown/admin_guide/expand/expand-overview.html.md
+++ b/gpdb-doc/markdown/admin_guide/expand/expand-overview.html.md
@@ -9,7 +9,7 @@ Data warehouses typically grow over time, often at a continuous pace, as additio
 When you expand your database, you should expect the following qualities:
 
 -   Scalable capacity and performance. When you add resources to a Greenplum Database, the capacity and performance are the same as if the system had been originally implemented with the added resources.
--   Uninterrupted service during expansion once past the initialization phase. Regular workloads, both scheduled and ad-hoc, are not interrupted.
+-   Uninterrupted service during expansion, once past the initialization phase. Regular workloads, both scheduled and ad-hoc, are not interrupted.
 -   Transactional consistency.
 -   Fault tolerance. During the expansion, standard fault-tolerance mechanisms—such as segment mirroring—remain active, consistent, and effective.
 -   Replication and disaster recovery. Any existing replication mechanisms continue to function during expansion. Restore mechanisms needed in case of a failure or catastrophic event remain effective.

--- a/gpdb-doc/markdown/admin_guide/expand/expand-overview.html.md
+++ b/gpdb-doc/markdown/admin_guide/expand/expand-overview.html.md
@@ -9,7 +9,7 @@ Data warehouses typically grow over time, often at a continuous pace, as additio
 When you expand your database, you should expect the following qualities:
 
 -   Scalable capacity and performance. When you add resources to a Greenplum Database, the capacity and performance are the same as if the system had been originally implemented with the added resources.
--   Uninterrupted service during expansion. Regular workloads, both scheduled and ad-hoc, are not interrupted.
+-   Uninterrupted service during expansion once past the initialization phase. Regular workloads, both scheduled and ad-hoc, are not interrupted.
 -   Transactional consistency.
 -   Fault tolerance. During the expansion, standard fault-tolerance mechanisms—such as segment mirroring—remain active, consistent, and effective.
 -   Replication and disaster recovery. Any existing replication mechanisms continue to function during expansion. Restore mechanisms needed in case of a failure or catastrophic event remain effective.


### PR DESCRIPTION
Adding a note on gpexpand initialization page and some clarification on landing page to make sure there is no confusion regarding DDL operations running during gpexpand initialization phase.

Review site:
https://docs-staging.vmware.com/en/VMware-Tanzu-Greenplum/mireia-gpexpand/greenplum-database/GUID-admin_guide-expand-expand-initialize.html
https://docs-staging.vmware.com/en/VMware-Tanzu-Greenplum/mireia-gpexpand/greenplum-database/GUID-admin_guide-expand-expand-overview.html