### PR TITLE
Resolve a FIXME for ADD COLUMN for AOCO table

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -7792,7 +7792,7 @@ ATExecAddColumn(List **wqueue, AlteredTableInfo *tab, Relation rel,
 		}
 
 		/*
-		 * Handling of default NULL for AO/CO tables.
+		 * Handling of default NULL for ao_row tables.
 		 *
 		 * Currently memtuples cannot deal with the scenario where the number of
 		 * attributes in the tuple data don't match the attnum. We will generate an
@@ -7805,19 +7805,18 @@ ATExecAddColumn(List **wqueue, AlteredTableInfo *tab, Relation rel,
 		 * workaround; see GitHub issue
 		 *     https://github.com/greenplum-db/gpdb/issues/3756
 		 *
-		 * GPDB_12_MERGE_FIXME: we used to do this only if no default was given,
-		 * but starting with PostgreSQL v11, a table doesn't need to be rewritten
-		 * even if a non-NULL default is used. That caused an assertion failure in
-		 * the 'uao_ddl/alter_ao_table_constraint_column' test. To make that go
-		 * away, always force full rewrite on AO_ROW and AO_COLUMN tables. We
-		 * should be smarter..
+		 * For ao_column tables, we won't rewrite the entire table but only the 
+		 * new column. However, we still need to generate a explicit NULL value so
+		 * we have something to write.
+		 * XXX: it would be even better if we could use pg_attribute.attmissingval 
+		 * and do not write the column at all. 
 		 */
 
-		if (RelationIsAppendOptimized(rel))
+		if (!defval && RelationIsAppendOptimized(rel))
 		{
-			if (!defval)
-				defval = (Expr *) makeNullConst(typeOid, -1, collOid);
-			tab->rewrite |= AT_REWRITE_DEFAULT_VAL;
+			defval = (Expr *) makeNullConst(typeOid, -1, collOid);
+			if (RelationIsAoRows(rel))
+				tab->rewrite |= AT_REWRITE_DEFAULT_VAL;
 		}
 
 		if (defval)
@@ -7843,6 +7842,13 @@ ATExecAddColumn(List **wqueue, AlteredTableInfo *tab, Relation rel,
 			{
 				Assert(tab->newvals != NULL);
 			}
+
+			/* 
+			 * We need to write the new column for AOCO tables. But don't do that
+			 * if we are going to rewrite the whole table anyway.
+			 */
+			if (RelationIsAoCols(rel) && tab->rewrite == 0)
+				tab->rewrite |= AT_REWRITE_NEW_COLUMNS_ONLY_AOCS;
 		}
 
 		if (DomainHasConstraints(typeOid))

--- a/src/test/regress/expected/alter_table.out
+++ b/src/test/regress/expected/alter_table.out
@@ -2639,22 +2639,43 @@ drop table at_base_table;
 -- a column requiring a default (bug #16038)
 -- ensure that rewrites aren't silently optimized away, removing the
 -- value of the test
-CREATE FUNCTION check_ddl_rewrite(p_tablename regclass, p_ddl text)
+CREATE FUNCTION check_ddl_rewrite(p_tablename text, p_ddl text)
 RETURNS boolean
 LANGUAGE plpgsql AS $$
 DECLARE
-    v_relfilenode oid;
+    v_result boolean;
 BEGIN
-    v_relfilenode := relfilenode FROM pg_class WHERE oid = p_tablename;
+    CREATE TEMP TABLE before_ddl(segid int, relfilenode oid);
+    CREATE TEMP TABLE after_ddl(segid int, relfilenode oid);
+
+    INSERT INTO before_ddl SELECT gp_segment_id segid, relfilenode FROM gp_dist_random('pg_class')
+    WHERE relname = p_tablename ORDER BY segid;
 
     EXECUTE p_ddl;
 
-    RETURN v_relfilenode <> (SELECT relfilenode FROM pg_class WHERE oid = p_tablename);
+    INSERT INTO after_ddl SELECT gp_segment_id segid, relfilenode FROM gp_dist_random('pg_class')
+    WHERE relname = p_tablename ORDER BY segid;
+
+    v_result := (SELECT count(a.*)=0 FROM before_ddl b INNER JOIN after_ddl a ON b.segid = a.segid AND b.relfilenode = a.relfilenode);
+
+    DROP TABLE before_ddl;
+    DROP TABLE after_ddl;
+
+    RETURN v_result;
 END;
 $$;
 CREATE TABLE rewrite_test(col text);
+CREATE TABLE rewrite_test_ao(col text) USING ao_row;
+CREATE TABLE rewrite_test_co(col text) USING ao_column;
 INSERT INTO rewrite_test VALUES ('something');
 INSERT INTO rewrite_test VALUES (NULL);
+INSERT INTO rewrite_test_ao VALUES ('something');
+INSERT INTO rewrite_test_ao VALUES (NULL);
+INSERT INTO rewrite_test_co VALUES ('something');
+INSERT INTO rewrite_test_co VALUES (NULL);
+-- Testing all three AMs. But note that, the comments are for the heap table ('rewrite_test')
+-- For AO table, always rewrite table in ADD COLUMN (see the FIXME in ATExecAddColumn())
+-- For AOCO table, never table rewrite (just need to write new column)
 -- empty[12] don't need rewrite, but notempty[12]_rewrite will force one
 SELECT check_ddl_rewrite('rewrite_test', $$
   ALTER TABLE rewrite_test
@@ -2676,6 +2697,46 @@ $$);
  t
 (1 row)
 
+SELECT check_ddl_rewrite('rewrite_test_ao', $$
+  ALTER TABLE rewrite_test_ao
+      ADD COLUMN empty1 text,
+      ADD COLUMN notempty1_rewrite serial;
+$$);
+ check_ddl_rewrite 
+-------------------
+ t
+(1 row)
+
+SELECT check_ddl_rewrite('rewrite_test_ao', $$
+    ALTER TABLE rewrite_test_ao
+        ADD COLUMN notempty2_rewrite serial,
+        ADD COLUMN empty2 text;
+$$);
+ check_ddl_rewrite 
+-------------------
+ t
+(1 row)
+
+SELECT check_ddl_rewrite('rewrite_test_co', $$
+  ALTER TABLE rewrite_test_co
+      ADD COLUMN empty1 text,
+      ADD COLUMN notempty1_rewrite serial;
+$$);
+ check_ddl_rewrite 
+-------------------
+ f
+(1 row)
+
+SELECT check_ddl_rewrite('rewrite_test_co', $$
+    ALTER TABLE rewrite_test_co
+        ADD COLUMN notempty2_rewrite serial,
+        ADD COLUMN empty2 text;
+$$);
+ check_ddl_rewrite 
+-------------------
+ f
+(1 row)
+
 -- also check that fast defaults cause no problem, first without rewrite
 SELECT check_ddl_rewrite('rewrite_test', $$
     ALTER TABLE rewrite_test
@@ -2689,6 +2750,46 @@ $$);
 
 SELECT check_ddl_rewrite('rewrite_test', $$
     ALTER TABLE rewrite_test
+        ADD COLUMN notempty4_norewrite int default 42,
+        ADD COLUMN empty4 text;
+$$);
+ check_ddl_rewrite 
+-------------------
+ f
+(1 row)
+
+SELECT check_ddl_rewrite('rewrite_test_ao', $$
+    ALTER TABLE rewrite_test_ao
+        ADD COLUMN empty3 text,
+        ADD COLUMN notempty3_norewrite int default 42;
+$$);
+ check_ddl_rewrite 
+-------------------
+ t
+(1 row)
+
+SELECT check_ddl_rewrite('rewrite_test_ao', $$
+    ALTER TABLE rewrite_test_ao
+        ADD COLUMN notempty4_norewrite int default 42,
+        ADD COLUMN empty4 text;
+$$);
+ check_ddl_rewrite 
+-------------------
+ t
+(1 row)
+
+SELECT check_ddl_rewrite('rewrite_test_co', $$
+    ALTER TABLE rewrite_test_co
+        ADD COLUMN empty3 text,
+        ADD COLUMN notempty3_norewrite int default 42;
+$$);
+ check_ddl_rewrite 
+-------------------
+ f
+(1 row)
+
+SELECT check_ddl_rewrite('rewrite_test_co', $$
+    ALTER TABLE rewrite_test_co
         ADD COLUMN notempty4_norewrite int default 42,
         ADD COLUMN empty4 text;
 $$);
@@ -2720,9 +2821,106 @@ $$);
  t
 (1 row)
 
+SELECT check_ddl_rewrite('rewrite_test_ao', $$
+    ALTER TABLE rewrite_test_ao
+        ADD COLUMN empty5 text,
+        ADD COLUMN notempty5_norewrite int default 42,
+        ADD COLUMN notempty5_rewrite serial;
+$$);
+ check_ddl_rewrite 
+-------------------
+ t
+(1 row)
+
+SELECT check_ddl_rewrite('rewrite_test_ao', $$
+    ALTER TABLE rewrite_test_ao
+        ADD COLUMN notempty6_rewrite serial,
+        ADD COLUMN empty6 text,
+        ADD COLUMN notempty6_norewrite int default 42;
+$$);
+ check_ddl_rewrite 
+-------------------
+ t
+(1 row)
+
+SELECT check_ddl_rewrite('rewrite_test_co', $$
+    ALTER TABLE rewrite_test_co
+        ADD COLUMN empty5 text,
+        ADD COLUMN notempty5_norewrite int default 42,
+        ADD COLUMN notempty5_rewrite serial;
+$$);
+ check_ddl_rewrite 
+-------------------
+ f
+(1 row)
+
+SELECT check_ddl_rewrite('rewrite_test_co', $$
+    ALTER TABLE rewrite_test_co
+        ADD COLUMN notempty6_rewrite serial,
+        ADD COLUMN empty6 text,
+        ADD COLUMN notempty6_norewrite int default 42;
+$$);
+ check_ddl_rewrite 
+-------------------
+ f
+(1 row)
+
+-- check changing default value won't rewrite, and won't change existing rows
+SELECT check_ddl_rewrite('rewrite_test', $$
+    ALTER TABLE rewrite_test_co
+        ALTER COLUMN notempty6_norewrite SET DEFAULT 43;
+$$);
+ check_ddl_rewrite 
+------------
+ f
+(1 row)
+
+SELECT check_ddl_rewrite('rewrite_test_ao', $$
+    ALTER TABLE rewrite_test_co
+        ALTER COLUMN notempty6_norewrite SET DEFAULT 43;
+$$);
+ check_ddl_rewrite 
+------------
+ f
+(1 row)
+
+SELECT check_ddl_rewrite('rewrite_test_co', $$
+    ALTER TABLE rewrite_test_co
+        ALTER COLUMN notempty6_norewrite SET DEFAULT 43;
+$$);
+ check_ddl_rewrite 
+------------
+ f
+(1 row)
+
+-- check the tables to make sure the data is expected
+-- note that serial order is undetermined for each column
+SELECT empty1, notempty1_rewrite in (1,2), notempty2_rewrite in (1,2), empty2, empty3, notempty3_norewrite, notempty4_norewrite, empty4, empty5, notempty5_norewrite, notempty5_rewrite in (1,2), notempty5_rewrite in (1,2), empty6, notempty6_norewrite FROM rewrite_test;
+ empty1 | ?column? | ?column? | empty2 | empty3 | notempty3_norewrite | notempty4_norewrite | empty4 | empty5 | notempty5_norewrite | ?column? | ?column? | empty6 | notempty6_norewrite 
+--------+----------+----------+--------+--------+---------------------+---------------------+--------+--------+---------------------+----------+----------+--------+---------------------
+        | t        | t        |        |        |                  42 |                  42 |        |        |                  42 | t        | t        |        |                  42
+        | t        | t        |        |        |                  42 |                  42 |        |        |                  42 | t        | t        |        |                  42
+(2 rows)
+
+SELECT empty1, notempty1_rewrite in (1,2), notempty2_rewrite in (1,2), empty2, empty3, notempty3_norewrite, notempty4_norewrite, empty4, empty5, notempty5_norewrite, notempty5_rewrite in (1,2), notempty5_rewrite in (1,2), empty6, notempty6_norewrite FROM rewrite_test_ao;
+ empty1 | ?column? | ?column? | empty2 | empty3 | notempty3_norewrite | notempty4_norewrite | empty4 | empty5 | notempty5_norewrite | ?column? | ?column? | empty6 | notempty6_norewrite 
+--------+----------+----------+--------+--------+---------------------+---------------------+--------+--------+---------------------+----------+----------+--------+---------------------
+        | t        | t        |        |        |                  42 |                  42 |        |        |                  42 | t        | t        |        |                  42
+        | t        | t        |        |        |                  42 |                  42 |        |        |                  42 | t        | t        |        |                  42
+(2 rows)
+
+SELECT empty1, notempty1_rewrite in (1,2), notempty2_rewrite in (1,2), empty2, empty3, notempty3_norewrite, notempty4_norewrite, empty4, empty5, notempty5_norewrite, notempty5_rewrite in (1,2), notempty5_rewrite in (1,2), empty6, notempty6_norewrite FROM rewrite_test_co;
+ empty1 | ?column? | ?column? | empty2 | empty3 | notempty3_norewrite | notempty4_norewrite | empty4 | empty5 | notempty5_norewrite | ?column? | ?column? | empty6 | notempty6_norewrite 
+--------+----------+----------+--------+--------+---------------------+---------------------+--------+--------+---------------------+----------+----------+--------+---------------------
+        | t        | t        |        |        |                  42 |                  42 |        |        |                  42 | t        | t        |        |                  42
+        | t        | t        |        |        |                  42 |                  42 |        |        |                  42 | t        | t        |        |                  42
+(2 rows)
+
 -- cleanup
-DROP FUNCTION check_ddl_rewrite(regclass, text);
+DROP FUNCTION check_ddl_rewrite(text, text);
 DROP TABLE rewrite_test;
+DROP TABLE rewrite_test_ao;
+DROP TABLE rewrite_test_co;
 --
 -- lock levels
 --


### PR DESCRIPTION
Description
========

This PR attempts to resolve a FIXME in `ATExecAddColumn` regarding fast ADD COLUMN w/ non-NULL default values for ao_column tables:

We disabled both AO and AOCO tables from the upstream feature of _not_ rewriting table when there's non-NULL default (commit 16828d5c0273b4fe5f10f42588005f16b415b2d8). However, we should be able to support it at least for AOCO tables by just writing the new column, which we already have the facility. Then, fetching from the table should be able to see the new values which are already written.

Note that, pg_attribute.attmissingval will be populated in such cases for AOCO tables, but they won't be used yet. We would be leveraging that field later when we are going to optimize even the column rewrite away.

Also note that, this column rewrite is supported regardless of the default value of the new column (so none/NULL default is also covered).

Note that this PR doesn't address the issue for ao_row tables. There is another FIXME in `ATExecAddColumn` that discusses the difficulty for addressing the same ao_row tables.

Adding tests for AO/CO tables too. Needed to adjust the existing test case in:
1. Modified the relfilenode checking function to check the table rewrites on primaries, which makes more sense in Greenplum.
2. Check the table result to make sure the data is expected. But have to check serial number separately because it's not fixed for each column in every test run.


Related/remaining issues
------------
1. Eventually it would be nice to even optimize the column rewrite away for AOCO tables. But it's probably good for now. We should address ao_row tables first which are of bigger problem.
2. As mentioned, there's another FIXME in `ATExecAddColumn` that is related to the same issue but for ao_row tables: https://github.com/greenplum-db/gpdb/blob/main/src/backend/commands/tablecmds.c#L7698-L7717
4. In `ATRewriteTables` (https://github.com/greenplum-db/gpdb/blob/main/src/backend/commands/tablecmds.c#L5881-L5939). The current PR is actually leveraging the thing that this FIXME is complaining about... But after all it is a different issue than what the current PR is addressing, and we can address that separately.

------------

Dev pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/fixme-tablecmds-defnull


## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
