### PR TITLE
Orca FIXME: Remove references to RelIsPartitioned

### DIFF
--- a/src/backend/gpopt/gpdbwrappers.cpp
+++ b/src/backend/gpopt/gpdbwrappers.cpp
@@ -1802,20 +1802,6 @@ gpdb::IsChildPartDistributionMismatched(Relation rel)
 	return false;
 }
 
-void
-gpdb::CdbEstimateRelationSize(RelOptInfo *relOptInfo, Relation rel,
-							  int32 *attr_widths, BlockNumber *pages,
-							  double *tuples, double *allvisfrac)
-{
-	GP_WRAP_START;
-	{
-		cdb_estimate_rel_size(relOptInfo, rel, attr_widths, pages, tuples,
-							  allvisfrac);
-		return;
-	}
-	GP_WRAP_END;
-}
-
 double
 gpdb::CdbEstimatePartitionedNumTuples(Relation rel)
 {
@@ -1956,63 +1942,6 @@ gpdb::IsTextRelatedType(Oid typid)
 	}
 	GP_WRAP_END;
 	return false;
-}
-
-
-int
-gpdb::GetIntFromValue(Node *node)
-{
-	GP_WRAP_START;
-	{
-		return intVal(node);
-	}
-	GP_WRAP_END;
-	return 0;
-}
-
-Uri *
-gpdb::ParseExternalTableUri(const char *uri)
-{
-	GP_WRAP_START;
-	{
-		return ParseExternalTableUri(uri);
-	}
-	GP_WRAP_END;
-	return nullptr;
-}
-
-CdbComponentDatabases *
-gpdb::GetComponentDatabases(void)
-{
-	GP_WRAP_START;
-	{
-		/* catalog tables: gp_segment_config */
-		return cdbcomponent_getCdbComponents();
-	}
-	GP_WRAP_END;
-	return nullptr;
-}
-
-int
-gpdb::StrCmpIgnoreCase(const char *s1, const char *s2)
-{
-	GP_WRAP_START;
-	{
-		return pg_strcasecmp(s1, s2);
-	}
-	GP_WRAP_END;
-	return 0;
-}
-
-bool *
-gpdb::ConstructRandomSegMap(int total_primaries, int total_to_skip)
-{
-	GP_WRAP_START;
-	{
-		return makeRandomSegMap(total_primaries, total_to_skip);
-	}
-	GP_WRAP_END;
-	return nullptr;
 }
 
 StringInfo
@@ -2569,26 +2498,6 @@ gpdb::ExpressionReturnsSet(Node *clause)
 	GP_WRAP_START;
 	{
 		return expression_returns_set(clause);
-	}
-	GP_WRAP_END;
-}
-
-bool
-gpdb::RelIsPartitioned(Oid relid)
-{
-	GP_WRAP_START;
-	{
-		return relation_is_partitioned(relid);
-	}
-	GP_WRAP_END;
-}
-
-bool
-gpdb::IndexIsPartitioned(Oid relid)
-{
-	GP_WRAP_START;
-	{
-		return index_is_partitioned(relid);
 	}
 	GP_WRAP_END;
 }

--- a/src/include/gpopt/gpdbwrappers.h
+++ b/src/include/gpopt/gpdbwrappers.h
@@ -486,10 +486,6 @@ Node *MutateExpressionTree(Node *node, Node *(*mutator)(), void *context);
 Node *MutateQueryOrExpressionTree(Node *node, Node *(*mutator)(), void *context,
 								  int flags);
 
-bool RelIsPartitioned(Oid relid);
-
-bool IndexIsPartitioned(Oid relid);
-
 // check whether a relation is inherited
 bool HasSubclassSlow(Oid rel_oid);
 
@@ -501,16 +497,6 @@ GpPolicy *GetDistributionPolicy(Relation rel);
 // the child partitions is randomly distributed
 gpos::BOOL IsChildPartDistributionMismatched(Relation rel);
 
-#if 0
-    // return true if the table is partitioned and any of the child partitions
-    // have a trigger of the given type
-    gpos::BOOL ChildPartHasTriggers(Oid oid, int trigger_type);
-#endif
-
-// estimate the relation size using the real number of blocks and tuple density
-void CdbEstimateRelationSize(RelOptInfo *relOptInfo, Relation rel,
-							 int32 *attr_widths, BlockNumber *pages,
-							 double *tuples, double *allvisfrac);
 double CdbEstimatePartitionedNumTuples(Relation rel);
 
 // close the given relation
@@ -549,21 +535,6 @@ bool Equals(void *p1, void *p2);
 bool IsCompositeType(Oid typid);
 
 bool IsTextRelatedType(Oid typid);
-
-// get integer value from an Integer value node
-int GetIntFromValue(Node *node);
-
-// parse external table URI
-Uri *ParseExternalTableUri(const char *uri);
-
-// returns ComponentDatabases
-CdbComponentDatabases *GetComponentDatabases(void);
-
-// compare two strings ignoring case
-int StrCmpIgnoreCase(const char *s1, const char *s2);
-
-// construct random segment map
-bool *ConstructRandomSegMap(int total_primaries, int total_to_skip);
 
 // create an empty 'StringInfoData' & return a pointer to it
 StringInfo MakeStringInfo(void);

--- a/src/include/gpopt/translate/CContextDXLToPlStmt.h
+++ b/src/include/gpopt/translate/CContextDXLToPlStmt.h
@@ -109,12 +109,6 @@ private:
 	// list of all rtable entries
 	List *m_rtable_entries_list;
 
-	// list of oids of partitioned tables
-	List *m_partitioned_tables_list;
-
-	// number of partition selectors for each dynamic scan
-	ULongPtrArray *m_num_partition_selectors_array;
-
 	// list of all subplan entries
 	List *m_subplan_entries_list;
 	List *m_subplan_sliceids_list;
@@ -179,16 +173,6 @@ public:
 		return m_rtable_entries_list;
 	}
 
-	// return list of partitioned table indexes
-	List *
-	GetPartitionedTablesList() const
-	{
-		return m_partitioned_tables_list;
-	}
-
-	// return list containing number of partition selectors for every scan id
-	List *GetNumPartitionSelectorsList() const;
-
 	List *
 	GetSubplanEntriesList() const
 	{
@@ -209,12 +193,6 @@ public:
 
 	// add a range table entry
 	void AddRTE(RangeTblEntry *rte, BOOL is_result_relation = false);
-
-	// add a partitioned table index
-	void AddPartitionedTable(OID oid);
-
-	// increment the number of partition selectors for the given scan id
-	void IncrementPartitionSelectors(ULONG scan_id);
 
 	void AddSubplan(Plan *);
 

--- a/src/include/gpopt/translate/CTranslatorRelcacheToDXL.h
+++ b/src/include/gpopt/translate/CTranslatorRelcacheToDXL.h
@@ -165,7 +165,7 @@ private:
 	);
 
 	// check and fall back for unsupported relations
-	static void CheckUnsupportedRelation(OID rel_oid);
+	static void CheckUnsupportedRelation(Relation rel);
 
 	// get type name from the relcache
 	static CMDName *GetTypeName(CMemoryPool *mp, IMDId *mdid);

--- a/src/include/utils/lsyscache.h
+++ b/src/include/utils/lsyscache.h
@@ -223,18 +223,10 @@ extern bool	get_index_isreplident(Oid index_oid);
 extern bool get_index_isvalid(Oid index_oid);
 extern bool get_index_isclustered(Oid index_oid);
 
-extern bool relation_is_partitioned(Oid oid);
-extern bool index_is_partitioned(Oid oid);
-extern List *relation_get_leaf_partitions(Oid oid);
-extern bool relation_exists(Oid oid);
-extern bool index_exists(Oid oid);
-extern bool type_exists(Oid oid);
 extern bool function_exists(Oid oid);
-extern bool operator_exists(Oid oid);
 extern bool aggregate_exists(Oid oid);
 extern Oid get_aggregate(const char *aggname, Oid oidType);
 extern List *get_relation_keys(Oid relid);
-extern bool trigger_exists(Oid oid);
 
 extern bool check_constraint_exists(Oid oidCheckconstraint);
 extern List *get_check_constraint_oids(Oid relid);


### PR DESCRIPTION
Instead, we check the relation's partdec.

In the future I'd like to optimize getting the relation for use in Orca's relcache. For example, in many cases we don't need each attribute and statistics for each attribute, and this gets expensive.

Also removes some other unused functions