### PR TITLE
Add attnum-filenum mapping in pg_attribute_encoding

### DIFF
--- a/src/backend/access/appendonly/README.md
+++ b/src/backend/access/appendonly/README.md
@@ -25,7 +25,13 @@ also be larger than 1 GB, and are not expanded in BLCKSZ-sized blocks,
 like heap segments are. Segment zero is empty unless data has been
 inserted during utility mode, in which case it's inserted into segment
 zero. Extending the table by adding attributes via ALTER TABLE will also
-push data to segment zero. Each table can have at most 127 segment files.
+push data to segment zero. Each table can have at most 128 segment files.
+
+AOCS tables can similarly have at most 128 segment files for each column.
+The range of segno is dependent on the filenum value in pg_attribute_encoding.
+`segno 0,1-127 (filenum = 1), segno 128,129-255 (filenum = 2),...`
+To find the file range for an AOCS table column, find the attnum of that column
+and then find the corresponding filenum for that attnum from pg_attribute_encoding.
 
 An append-only segfile consists of a number of variable-sized blocks
 ("varblocks"), one after another. The varblocks are aligned to 4 bytes.

--- a/src/backend/access/appendonly/appendonly_compaction.c
+++ b/src/backend/access/appendonly/appendonly_compaction.c
@@ -38,6 +38,7 @@
 #include "catalog/indexing.h"
 #include "catalog/pg_am.h"
 #include "catalog/pg_appendonly.h"
+#include "catalog/pg_attribute_encoding.h"
 #include "cdb/cdbappendonlyam.h"
 #include "cdb/cdbvars.h"
 #include "commands/progress.h"
@@ -79,7 +80,7 @@ AppendOnlyCompaction_DropSegmentFile(Relation aorel, int segno, AOVacuumRelStats
 		elog(LOG, "Drop segment file: segno %d", segno);
 
 	/* Open and truncate the relation segfile */
-	MakeAOSegmentFileName(aorel, segno, -1, &fileSegNo, filenamepath);
+	MakeAOSegmentFileName(aorel, segno, InvalidFileNumber, &fileSegNo, filenamepath);
 
 	fd = OpenAOSegmentFile(filenamepath, 0);
 	if (fd >= 0)
@@ -233,7 +234,7 @@ AppendOnlySegmentFileTruncateToEOF(Relation aorel, int segno, int64 segeof, AOVa
 	relname = RelationGetRelationName(aorel);
 
 	/* Open and truncate the relation segfile to its eof */
-	MakeAOSegmentFileName(aorel, segno, -1, &fileSegNo, filenamepath);
+	MakeAOSegmentFileName(aorel, segno, InvalidFileNumber, &fileSegNo, filenamepath);
 
 	elogif(Debug_appendonly_print_compaction, LOG,
 		   "Opening AO relation \"%s.%s\", relation id %u, relfilenode %u (physical segment file #%d, logical EOF " INT64_FORMAT ")",

--- a/src/backend/access/appendonly/appendonlyam.c
+++ b/src/backend/access/appendonly/appendonlyam.c
@@ -252,7 +252,7 @@ SetNextFileSegForRead(AppendOnlyScanDesc scan)
 		return false;
 	}
 
-	MakeAOSegmentFileName(reln, segno, -1, &fileSegNo, scan->aos_filenamepath);
+	MakeAOSegmentFileName(reln, segno, InvalidFileNumber, &fileSegNo, scan->aos_filenamepath);
 	Assert(strlen(scan->aos_filenamepath) + 1 <= scan->aos_filenamepath_maxlen);
 
 	Assert(scan->initedStorageRoutines);
@@ -326,7 +326,7 @@ SetCurrentFileSegForWrite(AppendOnlyInsertDesc aoInsertDesc)
 
 	/* Make the 'segment' file name */
 	MakeAOSegmentFileName(aoInsertDesc->aoi_rel,
-						  aoInsertDesc->cur_segno, -1,
+						  aoInsertDesc->cur_segno, InvalidFileNumber,
 						  &fileSegNo,
 						  aoInsertDesc->appendFilePathName);
 	Assert(strlen(aoInsertDesc->appendFilePathName) + 1 <= aoInsertDesc->appendFilePathNameMaxLen);
@@ -1648,7 +1648,7 @@ openFetchSegmentFile(AppendOnlyFetchDesc aoFetchDesc,
 
 	MakeAOSegmentFileName(
 						  aoFetchDesc->relation,
-						  openSegmentFileNum, -1,
+						  openSegmentFileNum, InvalidFileNumber,
 						  &fileSegNo,
 						  aoFetchDesc->segmentFileName);
 	Assert(strlen(aoFetchDesc->segmentFileName) + 1 <=

--- a/src/include/access/aomd.h
+++ b/src/include/access/aomd.h
@@ -25,14 +25,14 @@ extern int AOSegmentFilePathNameLen(Relation rel);
 extern void FormatAOSegmentFileName(
 						char *basepath,
 						int segno,
-						int col,
+						int filenum,
 						int32 *fileSegNo,
 						char *filepathname);
 
 extern void MakeAOSegmentFileName(
 					  Relation rel,
 					  int segno,
-					  int col,
+					  int filenum,
 					  int32 *fileSegNo,
 					  char *filepathname);
 

--- a/src/include/catalog/indexing.h
+++ b/src/include/catalog/indexing.h
@@ -399,6 +399,8 @@ DECLARE_INDEX(pg_attribute_encoding_attrelid_index, 6236, on pg_attribute_encodi
 #define AttributeEncodingAttrelidIndexId	6236
 DECLARE_UNIQUE_INDEX(pg_attribute_encoding_attrelid_attnum_index, 6237, on pg_attribute_encoding using btree(attrelid oid_ops, attnum int2_ops));
 #define AttributeEncodingAttrelidAttnumIndexId	6237
+DECLARE_UNIQUE_INDEX(pg_attribute_encoding_attrelid_filenum_index, 6238, on pg_attribute_encoding using btree(attrelid oid_ops, filenum int2_ops));
+#define AttributeEncodingAttrelidFilenumIndexId	6238
 
 DECLARE_UNIQUE_INDEX(pg_type_encoding_typid_index, 6207, on pg_type_encoding using btree(typid oid_ops));
 #define TypeEncodingTypidIndexId	6207

--- a/src/include/catalog/pg_attribute_encoding.h
+++ b/src/include/catalog/pg_attribute_encoding.h
@@ -22,6 +22,16 @@
 #include "catalog/pg_attribute_encoding_d.h"
 #include "utils/rel.h"
 
+/*
+ * Shorthand for range of segfiles for a specific attnum.
+ * For eg: filenum = 1 denotes a range of segfiles relfilenode.1 - relfilenode.128.
+ * FileNumbers start at 1
+ */
+typedef int16 FileNumber;
+
+#define InvalidFileNumber		0
+#define MaxFileNumber			2 * MaxHeapAttributeNumber
+
 /* ----------------
  *		pg_attribute_encoding definition.  cpp turns this into
  *		typedef struct FormData_pg_attribute_encoding
@@ -29,8 +39,9 @@
  */
 CATALOG(pg_attribute_encoding,6231,AttributeEncodingRelationId)
 {
-	Oid		attrelid;		
-	int16	attnum;			
+	Oid		attrelid;
+	int16	attnum;
+	int16   filenum;
 #ifdef CATALOG_VARLEN			/* variable-length fields start here */
 	text	attoptions[1];	
 #endif
@@ -55,6 +66,8 @@ extern void AddRelationAttributeEncodings(Oid relid, List *attr_encodings);
 extern void RemoveAttributeEncodingsByRelid(Oid relid);
 extern void CloneAttributeEncodings(Oid oldrelid, Oid newrelid, AttrNumber max_attno);
 extern void UpdateAttributeEncodings(Oid relid, List *new_attr_encodings);
+extern FileNumber GetFilenumForAttribute(Oid relid, AttrNumber attnum);
+extern List *GetNextNAvailableFilenums(Oid relid, int n);
 extern Datum *get_rel_attoptions(Oid relid, AttrNumber max_attno);
 extern List * rel_get_column_encodings(Relation rel);
 

--- a/src/include/cdb/cdbaocsam.h
+++ b/src/include/cdb/cdbaocsam.h
@@ -299,6 +299,7 @@ typedef struct IndexFetchAOCOData
 
 typedef struct AOCSHeaderScanDescData
 {
+	Oid   relid;  /* relid of the relation */
 	int32 colno;  /* chosen column number to read headers from */
 
 	AppendOnlyStorageRead ao_read;

--- a/src/test/regress/expected/AOCO_Compression.out
+++ b/src/test/regress/expected/AOCO_Compression.out
@@ -346,12 +346,12 @@ Access method: ao_column
 Options: blocksize=32768, compresslevel=0, compresstype=none, checksum=true
 
 --Select from pg_attribute_encoding to see the table entry 
-select attrelid::regclass as relname, attnum, attoptions from pg_class c, pg_attribute_encoding e  where c.relname = 'co_crtb_with_strg_dir_and_col_ref_1' and c.oid=e.attrelid  order by relname, attnum limit 3; 
-               relname               | attnum |                      attoptions                       
--------------------------------------+--------+-------------------------------------------------------
- co_crtb_with_strg_dir_and_col_ref_1 |      1 | {compresstype=zlib,blocksize=8192,compresslevel=1}
- co_crtb_with_strg_dir_and_col_ref_1 |      2 | {compresstype=zlib,compresslevel=1,blocksize=1048576}
- co_crtb_with_strg_dir_and_col_ref_1 |      3 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+select attrelid::regclass as relname, attnum, filenum, attoptions from pg_class c, pg_attribute_encoding e  where c.relname = 'co_crtb_with_strg_dir_and_col_ref_1' and c.oid=e.attrelid  order by relname, attnum limit 3;
+               relname               | attnum | filenum |                      attoptions                       
+-------------------------------------+--------+---------+-------------------------------------------------------
+ co_crtb_with_strg_dir_and_col_ref_1 |      1 |       1 | {compresstype=zlib,blocksize=8192,compresslevel=1}
+ co_crtb_with_strg_dir_and_col_ref_1 |      2 |       2 | {compresstype=zlib,compresslevel=1,blocksize=1048576}
+ co_crtb_with_strg_dir_and_col_ref_1 |      3 |       3 | {compresstype=zlib,compresslevel=1,blocksize=32768}
 (3 rows)
 
 --

--- a/src/test/regress/expected/alter_table_set.out
+++ b/src/test/regress/expected/alter_table_set.out
@@ -53,6 +53,9 @@ select count(*) > 0 as has_different_distribution from
 (1 row)
 
 -- ALTER TABLE ... SET for partition tables
+PREPARE attribute_encoding_check AS
+SELECT c.relname, a.attname, e.filenum, e.attoptions FROM pg_attribute_encoding e, pg_class c, pg_attribute a
+WHERE e.attrelid = c.oid AND e.attnum = a.attnum and e.attrelid = a.attrelid AND c.relname LIKE $1;
 CREATE TABLE part_relopt(a int, b int) WITH (fillfactor=90) PARTITION BY RANGE(a);
 CREATE TABLE part_relopt_1 partition OF part_relopt FOR VALUES FROM (1) to (100);
 CREATE TABLE part_relopt_2 partition OF part_relopt FOR VALUES FROM (100) to (200) PARTITION BY RANGE(a);
@@ -198,22 +201,21 @@ SELECT c.relname, am.amname, c.reloptions FROM pg_class c JOIN pg_am am on am.oi
  part_relopt_3   | ao_column | {compresstype=rle_type,compresslevel=1,blocksize=32768,checksum=true}
 (6 rows)
 
-SELECT c.relname, a.attname, e.attoptions FROM pg_attribute_encoding e, pg_class c, pg_attribute a
-WHERE e.attrelid = c.oid AND e.attnum = a.attnum and e.attrelid = a.attrelid AND c.relname LIKE 'part_relopt%';
-     relname     | attname |                       attoptions                        
------------------+---------+---------------------------------------------------------
- part_relopt     | a       | {compresstype=rle_type,compresslevel=2,blocksize=32768}
- part_relopt     | b       | {compresstype=zlib,compresslevel=3,blocksize=32768}
- part_relopt_1   | a       | {compresstype=rle_type,compresslevel=2,blocksize=32768}
- part_relopt_1   | b       | {compresstype=zlib,compresslevel=3,blocksize=32768}
- part_relopt_2   | a       | {compresstype=rle_type,compresslevel=2,blocksize=32768}
- part_relopt_2   | b       | {compresstype=zlib,compresslevel=3,blocksize=32768}
- part_relopt_2_1 | a       | {compresstype=rle_type,compresslevel=2,blocksize=32768}
- part_relopt_2_1 | b       | {compresstype=zlib,compresslevel=3,blocksize=32768}
- part_relopt_2_2 | a       | {compresstype=rle_type,compresslevel=2,blocksize=32768}
- part_relopt_2_2 | b       | {compresstype=zlib,compresslevel=3,blocksize=32768}
- part_relopt_3   | a       | {compresstype=rle_type,compresslevel=2,blocksize=32768}
- part_relopt_3   | b       | {compresstype=zlib,compresslevel=3,blocksize=32768}
+execute attribute_encoding_check('part_relopt%');
+     relname     | attname | filenum |                       attoptions                        
+-----------------+---------+---------+---------------------------------------------------------
+ part_relopt     | a       |       1 | {compresstype=rle_type,compresslevel=2,blocksize=32768}
+ part_relopt     | b       |       2 | {compresstype=zlib,compresslevel=3,blocksize=32768}
+ part_relopt_1   | a       |       1 | {compresstype=rle_type,compresslevel=2,blocksize=32768}
+ part_relopt_1   | b       |       2 | {compresstype=zlib,compresslevel=3,blocksize=32768}
+ part_relopt_2   | a       |       1 | {compresstype=rle_type,compresslevel=2,blocksize=32768}
+ part_relopt_2   | b       |       2 | {compresstype=zlib,compresslevel=3,blocksize=32768}
+ part_relopt_2_1 | a       |       1 | {compresstype=rle_type,compresslevel=2,blocksize=32768}
+ part_relopt_2_1 | b       |       2 | {compresstype=zlib,compresslevel=3,blocksize=32768}
+ part_relopt_2_2 | a       |       1 | {compresstype=rle_type,compresslevel=2,blocksize=32768}
+ part_relopt_2_2 | b       |       2 | {compresstype=zlib,compresslevel=3,blocksize=32768}
+ part_relopt_3   | a       |       1 | {compresstype=rle_type,compresslevel=2,blocksize=32768}
+ part_relopt_3   | b       |       2 | {compresstype=zlib,compresslevel=3,blocksize=32768}
 (12 rows)
 
 ALTER TABLE part_relopt SET (compresslevel=3);
@@ -228,121 +230,115 @@ SELECT c.relname, am.amname, c.reloptions FROM pg_class c JOIN pg_am am on am.oi
  part_relopt_3   | ao_column | {compresstype=rle_type,blocksize=32768,checksum=true,compresslevel=3}
 (6 rows)
 
-SELECT c.relname, a.attname, e.attoptions FROM pg_attribute_encoding e, pg_class c, pg_attribute a
-WHERE e.attrelid = c.oid AND e.attnum = a.attnum and e.attrelid = a.attrelid AND c.relname LIKE 'part_relopt%';
-     relname     | attname |                       attoptions                        
------------------+---------+---------------------------------------------------------
- part_relopt     | a       | {compresstype=rle_type,compresslevel=2,blocksize=32768}
- part_relopt     | b       | {compresstype=zlib,compresslevel=3,blocksize=32768}
- part_relopt_1   | a       | {compresstype=rle_type,compresslevel=2,blocksize=32768}
- part_relopt_1   | b       | {compresstype=zlib,compresslevel=3,blocksize=32768}
- part_relopt_2   | a       | {compresstype=rle_type,compresslevel=2,blocksize=32768}
- part_relopt_2   | b       | {compresstype=zlib,compresslevel=3,blocksize=32768}
- part_relopt_2_1 | a       | {compresstype=rle_type,compresslevel=2,blocksize=32768}
- part_relopt_2_1 | b       | {compresstype=zlib,compresslevel=3,blocksize=32768}
- part_relopt_2_2 | a       | {compresstype=rle_type,compresslevel=2,blocksize=32768}
- part_relopt_2_2 | b       | {compresstype=zlib,compresslevel=3,blocksize=32768}
- part_relopt_3   | a       | {compresstype=rle_type,compresslevel=2,blocksize=32768}
- part_relopt_3   | b       | {compresstype=zlib,compresslevel=3,blocksize=32768}
+execute attribute_encoding_check('part_relopt%');
+     relname     | attname | filenum |                       attoptions                        
+-----------------+---------+---------+---------------------------------------------------------
+ part_relopt     | a       |       1 | {compresstype=rle_type,compresslevel=2,blocksize=32768}
+ part_relopt     | b       |       2 | {compresstype=zlib,compresslevel=3,blocksize=32768}
+ part_relopt_1   | a       |       1 | {compresstype=rle_type,compresslevel=2,blocksize=32768}
+ part_relopt_1   | b       |       2 | {compresstype=zlib,compresslevel=3,blocksize=32768}
+ part_relopt_2   | a       |       1 | {compresstype=rle_type,compresslevel=2,blocksize=32768}
+ part_relopt_2   | b       |       2 | {compresstype=zlib,compresslevel=3,blocksize=32768}
+ part_relopt_2_1 | a       |       1 | {compresstype=rle_type,compresslevel=2,blocksize=32768}
+ part_relopt_2_1 | b       |       2 | {compresstype=zlib,compresslevel=3,blocksize=32768}
+ part_relopt_2_2 | a       |       1 | {compresstype=rle_type,compresslevel=2,blocksize=32768}
+ part_relopt_2_2 | b       |       2 | {compresstype=zlib,compresslevel=3,blocksize=32768}
+ part_relopt_3   | a       |       1 | {compresstype=rle_type,compresslevel=2,blocksize=32768}
+ part_relopt_3   | b       |       2 | {compresstype=zlib,compresslevel=3,blocksize=32768}
 (12 rows)
 
 ALTER TABLE part_relopt ALTER COLUMN a SET ENCODING (compresstype=rle_type, compresslevel=4), ALTER COLUMN b SET ENCODING (compresstype=zlib, compresslevel=5);
-SELECT c.relname, a.attname, e.attoptions FROM pg_attribute_encoding e, pg_class c, pg_attribute a
-WHERE e.attrelid = c.oid AND e.attnum = a.attnum and e.attrelid = a.attrelid AND c.relname LIKE 'part_relopt%';
-     relname     | attname |                       attoptions                        
------------------+---------+---------------------------------------------------------
- part_relopt     | a       | {compresstype=rle_type,compresslevel=4,blocksize=32768}
- part_relopt     | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt_1   | a       | {compresstype=rle_type,compresslevel=4,blocksize=32768}
- part_relopt_1   | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt_2   | a       | {compresstype=rle_type,compresslevel=4,blocksize=32768}
- part_relopt_2   | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt_2_1 | a       | {compresstype=rle_type,compresslevel=4,blocksize=32768}
- part_relopt_2_1 | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt_2_2 | a       | {compresstype=rle_type,compresslevel=4,blocksize=32768}
- part_relopt_2_2 | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt_3   | a       | {compresstype=rle_type,compresslevel=4,blocksize=32768}
- part_relopt_3   | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+execute attribute_encoding_check('part_relopt%');
+     relname     | attname | filenum |                       attoptions                        
+-----------------+---------+---------+---------------------------------------------------------
+ part_relopt     | a       |       1 | {compresstype=rle_type,compresslevel=4,blocksize=32768}
+ part_relopt     | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_1   | a       |       1 | {compresstype=rle_type,compresslevel=4,blocksize=32768}
+ part_relopt_1   | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_2   | a       |       1 | {compresstype=rle_type,compresslevel=4,blocksize=32768}
+ part_relopt_2   | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_2_1 | a       |       1 | {compresstype=rle_type,compresslevel=4,blocksize=32768}
+ part_relopt_2_1 | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_2_2 | a       |       1 | {compresstype=rle_type,compresslevel=4,blocksize=32768}
+ part_relopt_2_2 | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_3   | a       |       1 | {compresstype=rle_type,compresslevel=4,blocksize=32768}
+ part_relopt_3   | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
 (12 rows)
 
 -- Check double edit on same column
 ALTER TABLE part_relopt ALTER COLUMN a SET ENCODING (compresstype=rle_type, compresslevel=4), ALTER COLUMN a SET ENCODING (compresstype=zlib, compresslevel=5);
-SELECT c.relname, a.attname, e.attoptions FROM pg_attribute_encoding e, pg_class c, pg_attribute a
-WHERE e.attrelid = c.oid AND e.attnum = a.attnum and e.attrelid = a.attrelid AND c.relname LIKE 'part_relopt%';
-     relname     | attname |                     attoptions                      
------------------+---------+-----------------------------------------------------
- part_relopt     | a       | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt     | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt_1   | a       | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt_1   | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt_2   | a       | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt_2   | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt_2_1 | a       | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt_2_1 | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt_2_2 | a       | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt_2_2 | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt_3   | a       | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt_3   | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+execute attribute_encoding_check('part_relopt%');
+     relname     | attname | filenum |                     attoptions                      
+-----------------+---------+---------+-----------------------------------------------------
+ part_relopt     | a       |       1 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt     | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_1   | a       |       1 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_1   | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_2   | a       |       1 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_2   | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_2_1 | a       |       1 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_2_1 | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_2_2 | a       |       1 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_2_2 | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_3   | a       |       1 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_3   | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
 (12 rows)
 
 -- Check double edit of same option
 ALTER TABLE part_relopt ALTER COLUMN a SET ENCODING (compresslevel=3, compresslevel=4);
 ERROR:  parameter "compresslevel" specified more than once
-SELECT c.relname, a.attname, e.attoptions FROM pg_attribute_encoding e, pg_class c, pg_attribute a
-WHERE e.attrelid = c.oid AND e.attnum = a.attnum and e.attrelid = a.attrelid AND c.relname LIKE 'part_relopt%';
-     relname     | attname |                     attoptions                      
------------------+---------+-----------------------------------------------------
- part_relopt     | a       | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt     | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt_1   | a       | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt_1   | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt_2   | a       | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt_2   | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt_2_1 | a       | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt_2_1 | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt_2_2 | a       | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt_2_2 | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt_3   | a       | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt_3   | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+execute attribute_encoding_check('part_relopt%');
+     relname     | attname | filenum |                     attoptions                      
+-----------------+---------+---------+-----------------------------------------------------
+ part_relopt     | a       |       1 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt     | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_1   | a       |       1 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_1   | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_2   | a       |       1 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_2   | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_2_1 | a       |       1 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_2_1 | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_2_2 | a       |       1 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_2_2 | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_3   | a       |       1 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_3   | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
 (12 rows)
 
 -- Check double edit of same column different options
 ALTER TABLE part_relopt ALTER COLUMN a SET ENCODING (compresstype=zlib), ALTER COLUMN a SET ENCODING (compresslevel=7);
-SELECT c.relname, a.attname, e.attoptions FROM pg_attribute_encoding e, pg_class c, pg_attribute a
-WHERE e.attrelid = c.oid AND e.attnum = a.attnum and e.attrelid = a.attrelid AND c.relname LIKE 'part_relopt%';
-     relname     | attname |                     attoptions                      
------------------+---------+-----------------------------------------------------
- part_relopt     | a       | {compresstype=zlib,compresslevel=7,blocksize=32768}
- part_relopt     | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt_1   | a       | {compresstype=zlib,compresslevel=7,blocksize=32768}
- part_relopt_1   | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt_2   | a       | {compresstype=zlib,compresslevel=7,blocksize=32768}
- part_relopt_2   | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt_2_1 | a       | {compresstype=zlib,compresslevel=7,blocksize=32768}
- part_relopt_2_1 | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt_2_2 | a       | {compresstype=zlib,compresslevel=7,blocksize=32768}
- part_relopt_2_2 | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt_3   | a       | {compresstype=zlib,compresslevel=7,blocksize=32768}
- part_relopt_3   | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+execute attribute_encoding_check('part_relopt%');
+     relname     | attname | filenum |                     attoptions                      
+-----------------+---------+---------+-----------------------------------------------------
+ part_relopt     | a       |       1 | {compresstype=zlib,compresslevel=7,blocksize=32768}
+ part_relopt     | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_1   | a       |       1 | {compresstype=zlib,compresslevel=7,blocksize=32768}
+ part_relopt_1   | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_2   | a       |       1 | {compresstype=zlib,compresslevel=7,blocksize=32768}
+ part_relopt_2   | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_2_1 | a       |       1 | {compresstype=zlib,compresslevel=7,blocksize=32768}
+ part_relopt_2_1 | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_2_2 | a       |       1 | {compresstype=zlib,compresslevel=7,blocksize=32768}
+ part_relopt_2_2 | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_3   | a       |       1 | {compresstype=zlib,compresslevel=7,blocksize=32768}
+ part_relopt_3   | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
 (12 rows)
 
 ALTER TABLE part_relopt ALTER COLUMN a SET ENCODING (compresstype=zlib, compresslevel=5);
-SELECT c.relname, a.attname, e.attoptions FROM pg_attribute_encoding e, pg_class c, pg_attribute a
-WHERE e.attrelid = c.oid AND e.attnum = a.attnum and e.attrelid = a.attrelid AND c.relname LIKE 'part_relopt%';
-     relname     | attname |                     attoptions                      
------------------+---------+-----------------------------------------------------
- part_relopt     | a       | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt     | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt_1   | a       | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt_1   | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt_2   | a       | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt_2   | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt_2_1 | a       | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt_2_1 | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt_2_2 | a       | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt_2_2 | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt_3   | a       | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt_3   | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+execute attribute_encoding_check('part_relopt%');
+     relname     | attname | filenum |                     attoptions                      
+-----------------+---------+---------+-----------------------------------------------------
+ part_relopt     | a       |       1 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt     | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_1   | a       |       1 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_1   | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_2   | a       |       1 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_2   | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_2_1 | a       |       1 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_2_1 | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_2_2 | a       |       1 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_2_2 | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_3   | a       |       1 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_3   | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
 (12 rows)
 
 -- Data is intact
@@ -372,12 +368,11 @@ CREATE TABLE aoco_relopt(a int, b int) WITH (appendoptimized = true, orientation
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 ALTER TABLE aoco_relopt ALTER COLUMN a SET ENCODING (compresstype=rle_type, compresslevel=4), ALTER COLUMN b SET ENCODING (compresstype=zlib, compresslevel=5);
-SELECT c.relname, a.attname, e.attoptions FROM pg_attribute_encoding e, pg_class c, pg_attribute a
-WHERE e.attrelid = c.oid AND e.attnum = a.attnum and e.attrelid = a.attrelid AND c.relname LIKE 'aoco_relopt%';
-   relname   | attname |                       attoptions                        
--------------+---------+---------------------------------------------------------
- aoco_relopt | a       | {compresstype=rle_type,blocksize=32768,compresslevel=4}
- aoco_relopt | b       | {compresstype=zlib,blocksize=32768,compresslevel=5}
+execute attribute_encoding_check('aoco_relopt%');
+   relname   | attname | filenum |                       attoptions                        
+-------------+---------+---------+---------------------------------------------------------
+ aoco_relopt | a       |       1 | {compresstype=rle_type,blocksize=32768,compresslevel=4}
+ aoco_relopt | b       |       2 | {compresstype=zlib,blocksize=32768,compresslevel=5}
 (2 rows)
 
 DROP TABLE aoco_relopt;
@@ -440,18 +435,17 @@ NOTICE:  table has parent, setting distribution columns to match parent table
 CREATE TABLE part_relopt3_2_1 partition OF part_relopt3_2 FOR VALUES FROM (200) to (250);
 NOTICE:  table has parent, setting distribution columns to match parent table
 INSERT INTO part_relopt3 SELECT i,i FROM generate_series(101,249) i;
-SELECT c.relname, a.attname, e.attoptions FROM pg_attribute_encoding e, pg_class c, pg_attribute a
-WHERE e.attrelid = c.oid AND e.attnum = a.attnum and e.attrelid = a.attrelid AND c.relname LIKE 'part_relopt3%';
-     relname      | attname |                     attoptions                      
-------------------+---------+-----------------------------------------------------
- part_relopt3     | a       | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt3     | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt3_1   | a       | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt3_1   | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt3_2   | a       | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt3_2   | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt3_2_1 | a       | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt3_2_1 | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+execute attribute_encoding_check('part_relopt3%');
+     relname      | attname | filenum |                     attoptions                      
+------------------+---------+---------+-----------------------------------------------------
+ part_relopt3     | a       |       1 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt3     | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt3_1   | a       |       1 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt3_1   | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt3_2   | a       |       1 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt3_2   | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt3_2_1 | a       |       1 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt3_2_1 | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
 (8 rows)
 
 -- error out because of the first child
@@ -465,74 +459,69 @@ ALTER TABLE part_relopt3_2_1 SET ACCESS METHOD heap;
 ALTER TABLE part_relopt3 ALTER COLUMN a SET ENCODING (compresslevel=3, compresstype=zlib);
 ERROR:  ALTER COLUMN SET ENCODING operation is only applicable to AOCO tables
 DETAIL:  "part_relopt3_2_1" is not an AOCO table
-SELECT c.relname, a.attname, e.attoptions FROM pg_attribute_encoding e, pg_class c, pg_attribute a
-WHERE e.attrelid = c.oid AND e.attnum = a.attnum and e.attrelid = a.attrelid AND c.relname LIKE 'part_relopt3%';
-    relname     | attname |                     attoptions                      
-----------------+---------+-----------------------------------------------------
- part_relopt3   | a       | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt3   | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt3_1 | a       | {compresstype=none,blocksize=32768,compresslevel=0}
- part_relopt3_1 | b       | {compresstype=none,blocksize=32768,compresslevel=0}
- part_relopt3_2 | a       | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt3_2 | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+execute attribute_encoding_check('part_relopt3%');
+    relname     | attname | filenum |                     attoptions                      
+----------------+---------+---------+-----------------------------------------------------
+ part_relopt3   | a       |       1 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt3   | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt3_1 | a       |       1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ part_relopt3_1 | b       |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ part_relopt3_2 | a       |       1 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt3_2 | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
 (6 rows)
 
 ALTER TABLE part_relopt3_1 ALTER COLUMN a SET ENCODING (compresslevel=3, compresstype=zlib);
-SELECT c.relname, a.attname, e.attoptions FROM pg_attribute_encoding e, pg_class c, pg_attribute a
-WHERE e.attrelid = c.oid AND e.attnum = a.attnum and e.attrelid = a.attrelid AND c.relname LIKE 'part_relopt3%';
-    relname     | attname |                     attoptions                      
-----------------+---------+-----------------------------------------------------
- part_relopt3   | a       | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt3   | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt3_1 | a       | {compresstype=zlib,blocksize=32768,compresslevel=3}
- part_relopt3_1 | b       | {compresstype=none,blocksize=32768,compresslevel=0}
- part_relopt3_2 | a       | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt3_2 | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+execute attribute_encoding_check('part_relopt3%');
+    relname     | attname | filenum |                     attoptions                      
+----------------+---------+---------+-----------------------------------------------------
+ part_relopt3   | a       |       1 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt3   | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt3_1 | a       |       1 | {compresstype=zlib,blocksize=32768,compresslevel=3}
+ part_relopt3_1 | b       |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ part_relopt3_2 | a       |       1 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt3_2 | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
 (6 rows)
 
 ALTER TABLE part_relopt3_2_1 SET ACCESS METHOD ao_column, ALTER COLUMN a SET ENCODING (compresslevel=4, compresstype=zlib);
-SELECT c.relname, a.attname, e.attoptions FROM pg_attribute_encoding e, pg_class c, pg_attribute a
-WHERE e.attrelid = c.oid AND e.attnum = a.attnum and e.attrelid = a.attrelid AND c.relname LIKE 'part_relopt3%';
-     relname      | attname |                     attoptions                      
-------------------+---------+-----------------------------------------------------
- part_relopt3     | a       | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt3     | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt3_1   | a       | {compresstype=zlib,blocksize=32768,compresslevel=3}
- part_relopt3_1   | b       | {compresstype=none,blocksize=32768,compresslevel=0}
- part_relopt3_2   | a       | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt3_2   | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt3_2_1 | a       | {compresstype=zlib,blocksize=32768,compresslevel=4}
- part_relopt3_2_1 | b       | {compresstype=none,blocksize=32768,compresslevel=0}
+execute attribute_encoding_check('part_relopt3%');
+     relname      | attname | filenum |                     attoptions                      
+------------------+---------+---------+-----------------------------------------------------
+ part_relopt3     | a       |       1 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt3     | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt3_1   | a       |       1 | {compresstype=zlib,blocksize=32768,compresslevel=3}
+ part_relopt3_1   | b       |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ part_relopt3_2   | a       |       1 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt3_2   | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt3_2_1 | a       |       1 | {compresstype=zlib,blocksize=32768,compresslevel=4}
+ part_relopt3_2_1 | b       |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
 (8 rows)
 
 ALTER TABLE part_relopt3_2 ALTER COLUMN a SET ENCODING (compresslevel=1, compresstype=rle_type);
-SELECT c.relname, a.attname, e.attoptions FROM pg_attribute_encoding e, pg_class c, pg_attribute a
-WHERE e.attrelid = c.oid AND e.attnum = a.attnum and e.attrelid = a.attrelid AND c.relname LIKE 'part_relopt3%';
-     relname      | attname |                       attoptions                        
-------------------+---------+---------------------------------------------------------
- part_relopt3     | a       | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt3     | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt3_1   | a       | {compresstype=zlib,blocksize=32768,compresslevel=3}
- part_relopt3_1   | b       | {compresstype=none,blocksize=32768,compresslevel=0}
- part_relopt3_2   | a       | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- part_relopt3_2   | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt3_2_1 | a       | {compresstype=rle_type,blocksize=32768,compresslevel=1}
- part_relopt3_2_1 | b       | {compresstype=none,blocksize=32768,compresslevel=0}
+execute attribute_encoding_check('part_relopt3%');
+     relname      | attname | filenum |                       attoptions                        
+------------------+---------+---------+---------------------------------------------------------
+ part_relopt3     | a       |       1 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt3     | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt3_1   | a       |       1 | {compresstype=zlib,blocksize=32768,compresslevel=3}
+ part_relopt3_1   | b       |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ part_relopt3_2   | a       |       1 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ part_relopt3_2   | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt3_2_1 | a       |       1 | {compresstype=rle_type,blocksize=32768,compresslevel=1}
+ part_relopt3_2_1 | b       |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
 (8 rows)
 
 ALTER TABLE part_relopt3 ALTER COLUMN a SET ENCODING (compresslevel=4, compresstype=rle_type);
-SELECT c.relname, a.attname, e.attoptions FROM pg_attribute_encoding e, pg_class c, pg_attribute a
-WHERE e.attrelid = c.oid AND e.attnum = a.attnum and e.attrelid = a.attrelid AND c.relname LIKE 'part_relopt3%';
-     relname      | attname |                       attoptions                        
-------------------+---------+---------------------------------------------------------
- part_relopt3     | a       | {compresstype=rle_type,compresslevel=4,blocksize=32768}
- part_relopt3     | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt3_1   | a       | {compresstype=rle_type,blocksize=32768,compresslevel=4}
- part_relopt3_1   | b       | {compresstype=none,blocksize=32768,compresslevel=0}
- part_relopt3_2   | a       | {compresstype=rle_type,compresslevel=4,blocksize=32768}
- part_relopt3_2   | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt3_2_1 | a       | {compresstype=rle_type,blocksize=32768,compresslevel=4}
- part_relopt3_2_1 | b       | {compresstype=none,blocksize=32768,compresslevel=0}
+execute attribute_encoding_check('part_relopt3%');
+     relname      | attname | filenum |                       attoptions                        
+------------------+---------+---------+---------------------------------------------------------
+ part_relopt3     | a       |       1 | {compresstype=rle_type,compresslevel=4,blocksize=32768}
+ part_relopt3     | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt3_1   | a       |       1 | {compresstype=rle_type,blocksize=32768,compresslevel=4}
+ part_relopt3_1   | b       |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ part_relopt3_2   | a       |       1 | {compresstype=rle_type,compresslevel=4,blocksize=32768}
+ part_relopt3_2   | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt3_2_1 | a       |       1 | {compresstype=rle_type,blocksize=32768,compresslevel=4}
+ part_relopt3_2_1 | b       |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
 (8 rows)
 
 -- Check if table is rewritten if encoding doesn't change
@@ -543,18 +532,17 @@ WHERE relname LIKE 'part_relopt3%' ORDER BY segid;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'segid' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 ALTER TABLE part_relopt3 ALTER COLUMN a SET ENCODING (compresslevel=4, compresstype=rle_type);
-SELECT c.relname, a.attname, e.attoptions FROM pg_attribute_encoding e, pg_class c, pg_attribute a
-WHERE e.attrelid = c.oid AND e.attnum = a.attnum and e.attrelid = a.attrelid AND c.relname LIKE 'part_relopt3%';
-     relname      | attname |                       attoptions                        
-------------------+---------+---------------------------------------------------------
- part_relopt3     | a       | {compresstype=rle_type,compresslevel=4,blocksize=32768}
- part_relopt3     | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt3_1   | a       | {compresstype=rle_type,blocksize=32768,compresslevel=4}
- part_relopt3_1   | b       | {compresstype=none,blocksize=32768,compresslevel=0}
- part_relopt3_2   | a       | {compresstype=rle_type,compresslevel=4,blocksize=32768}
- part_relopt3_2   | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt3_2_1 | a       | {compresstype=rle_type,blocksize=32768,compresslevel=4}
- part_relopt3_2_1 | b       | {compresstype=none,blocksize=32768,compresslevel=0}
+execute attribute_encoding_check('part_relopt3%');
+     relname      | attname | filenum |                       attoptions                        
+------------------+---------+---------+---------------------------------------------------------
+ part_relopt3     | a       |       1 | {compresstype=rle_type,compresslevel=4,blocksize=32768}
+ part_relopt3     | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt3_1   | a       |       1 | {compresstype=rle_type,blocksize=32768,compresslevel=4}
+ part_relopt3_1   | b       |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ part_relopt3_2   | a       |       1 | {compresstype=rle_type,compresslevel=4,blocksize=32768}
+ part_relopt3_2   | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt3_2_1 | a       |       1 | {compresstype=rle_type,blocksize=32768,compresslevel=4}
+ part_relopt3_2_1 | b       |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
 (8 rows)
 
 CREATE TEMP TABLE relfileafterredo AS
@@ -571,105 +559,99 @@ SELECT * FROM relfilebeforeredo EXCEPT SELECT * FROM relfileafterredo;
 
 -- Check alter column set encoding for root partition ONLY
 ALTER TABLE ONLY part_relopt3 ALTER COLUMN a SET ENCODING (compresslevel=2, compresstype=zlib);
-SELECT c.relname, a.attname, e.attoptions FROM pg_attribute_encoding e, pg_class c, pg_attribute a
-WHERE e.attrelid = c.oid AND e.attnum = a.attnum and e.attrelid = a.attrelid AND c.relname LIKE 'part_relopt3%';
-     relname      | attname |                       attoptions                        
-------------------+---------+---------------------------------------------------------
- part_relopt3     | a       | {compresstype=zlib,compresslevel=2,blocksize=32768}
- part_relopt3     | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt3_1   | a       | {compresstype=rle_type,blocksize=32768,compresslevel=4}
- part_relopt3_1   | b       | {compresstype=none,blocksize=32768,compresslevel=0}
- part_relopt3_2   | a       | {compresstype=rle_type,compresslevel=4,blocksize=32768}
- part_relopt3_2   | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt3_2_1 | a       | {compresstype=rle_type,blocksize=32768,compresslevel=4}
- part_relopt3_2_1 | b       | {compresstype=none,blocksize=32768,compresslevel=0}
+execute attribute_encoding_check('part_relopt3%');
+     relname      | attname | filenum |                       attoptions                        
+------------------+---------+---------+---------------------------------------------------------
+ part_relopt3     | a       |       1 | {compresstype=zlib,compresslevel=2,blocksize=32768}
+ part_relopt3     | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt3_1   | a       |       1 | {compresstype=rle_type,blocksize=32768,compresslevel=4}
+ part_relopt3_1   | b       |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ part_relopt3_2   | a       |       1 | {compresstype=rle_type,compresslevel=4,blocksize=32768}
+ part_relopt3_2   | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt3_2_1 | a       |       1 | {compresstype=rle_type,blocksize=32768,compresslevel=4}
+ part_relopt3_2_1 | b       |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
 (8 rows)
 
 -- Check alter column set encoding for mid level root partition ONLY
 ALTER TABLE ONLY part_relopt3_2 ALTER COLUMN a SET ENCODING (compresslevel=3, compresstype=zlib);
-SELECT c.relname, a.attname, e.attoptions FROM pg_attribute_encoding e, pg_class c, pg_attribute a
-WHERE e.attrelid = c.oid AND e.attnum = a.attnum and e.attrelid = a.attrelid AND c.relname LIKE 'part_relopt3%';
-     relname      | attname |                       attoptions                        
-------------------+---------+---------------------------------------------------------
- part_relopt3     | a       | {compresstype=zlib,compresslevel=2,blocksize=32768}
- part_relopt3     | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt3_1   | a       | {compresstype=rle_type,blocksize=32768,compresslevel=4}
- part_relopt3_1   | b       | {compresstype=none,blocksize=32768,compresslevel=0}
- part_relopt3_2   | a       | {compresstype=zlib,compresslevel=3,blocksize=32768}
- part_relopt3_2   | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt3_2_1 | a       | {compresstype=rle_type,blocksize=32768,compresslevel=4}
- part_relopt3_2_1 | b       | {compresstype=none,blocksize=32768,compresslevel=0}
+execute attribute_encoding_check('part_relopt3%');
+     relname      | attname | filenum |                       attoptions                        
+------------------+---------+---------+---------------------------------------------------------
+ part_relopt3     | a       |       1 | {compresstype=zlib,compresslevel=2,blocksize=32768}
+ part_relopt3     | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt3_1   | a       |       1 | {compresstype=rle_type,blocksize=32768,compresslevel=4}
+ part_relopt3_1   | b       |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ part_relopt3_2   | a       |       1 | {compresstype=zlib,compresslevel=3,blocksize=32768}
+ part_relopt3_2   | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt3_2_1 | a       |       1 | {compresstype=rle_type,blocksize=32768,compresslevel=4}
+ part_relopt3_2_1 | b       |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
 (8 rows)
 
 -- altering when changing am to heap should error out for root partition
 ALTER TABLE part_relopt3 SET ACCESS METHOD heap, ALTER COLUMN a SET ENCODING (compresslevel=4, compresstype=rle_type);
 ERROR:  ALTER COLUMN SET ENCODING operation is only applicable to AOCO tables
 DETAIL:  New access method for "part_relopt3" is not AOCO
-SELECT c.relname, a.attname, e.attoptions FROM pg_attribute_encoding e, pg_class c, pg_attribute a
-WHERE e.attrelid = c.oid AND e.attnum = a.attnum and e.attrelid = a.attrelid AND c.relname LIKE 'part_relopt3%';
-     relname      | attname |                       attoptions                        
-------------------+---------+---------------------------------------------------------
- part_relopt3     | a       | {compresstype=zlib,compresslevel=2,blocksize=32768}
- part_relopt3     | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt3_1   | a       | {compresstype=rle_type,blocksize=32768,compresslevel=4}
- part_relopt3_1   | b       | {compresstype=none,blocksize=32768,compresslevel=0}
- part_relopt3_2   | a       | {compresstype=zlib,compresslevel=3,blocksize=32768}
- part_relopt3_2   | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt3_2_1 | a       | {compresstype=rle_type,blocksize=32768,compresslevel=4}
- part_relopt3_2_1 | b       | {compresstype=none,blocksize=32768,compresslevel=0}
+execute attribute_encoding_check('part_relopt3%');
+     relname      | attname | filenum |                       attoptions                        
+------------------+---------+---------+---------------------------------------------------------
+ part_relopt3     | a       |       1 | {compresstype=zlib,compresslevel=2,blocksize=32768}
+ part_relopt3     | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt3_1   | a       |       1 | {compresstype=rle_type,blocksize=32768,compresslevel=4}
+ part_relopt3_1   | b       |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ part_relopt3_2   | a       |       1 | {compresstype=zlib,compresslevel=3,blocksize=32768}
+ part_relopt3_2   | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt3_2_1 | a       |       1 | {compresstype=rle_type,blocksize=32768,compresslevel=4}
+ part_relopt3_2_1 | b       |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
 (8 rows)
 
 -- altering when changing am to heap should error out for child partition
 ALTER TABLE part_relopt3_2_1 SET ACCESS METHOD heap, ALTER COLUMN a SET ENCODING (compresslevel=4, compresstype=rle_type);
 ERROR:  ALTER COLUMN SET ENCODING operation is only applicable to AOCO tables
 DETAIL:  New access method for "part_relopt3_2_1" is not AOCO
-SELECT c.relname, a.attname, e.attoptions FROM pg_attribute_encoding e, pg_class c, pg_attribute a
-WHERE e.attrelid = c.oid AND e.attnum = a.attnum and e.attrelid = a.attrelid AND c.relname LIKE 'part_relopt3%';
-     relname      | attname |                       attoptions                        
-------------------+---------+---------------------------------------------------------
- part_relopt3     | a       | {compresstype=zlib,compresslevel=2,blocksize=32768}
- part_relopt3     | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt3_1   | a       | {compresstype=rle_type,blocksize=32768,compresslevel=4}
- part_relopt3_1   | b       | {compresstype=none,blocksize=32768,compresslevel=0}
- part_relopt3_2   | a       | {compresstype=zlib,compresslevel=3,blocksize=32768}
- part_relopt3_2   | b       | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt3_2_1 | a       | {compresstype=rle_type,blocksize=32768,compresslevel=4}
- part_relopt3_2_1 | b       | {compresstype=none,blocksize=32768,compresslevel=0}
+execute attribute_encoding_check('part_relopt3%');
+     relname      | attname | filenum |                       attoptions                        
+------------------+---------+---------+---------------------------------------------------------
+ part_relopt3     | a       |       1 | {compresstype=zlib,compresslevel=2,blocksize=32768}
+ part_relopt3     | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt3_1   | a       |       1 | {compresstype=rle_type,blocksize=32768,compresslevel=4}
+ part_relopt3_1   | b       |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ part_relopt3_2   | a       |       1 | {compresstype=zlib,compresslevel=3,blocksize=32768}
+ part_relopt3_2   | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt3_2_1 | a       |       1 | {compresstype=rle_type,blocksize=32768,compresslevel=4}
+ part_relopt3_2_1 | b       |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
 (8 rows)
 
 -- set access method and then alter column set encoding should generate same encoding values as
 -- set access method + alter column set encoding
 ALTER TABLE part_relopt3 SET ACCESS METHOD heap;
 ALTER TABLE part_relopt3 SET ACCESS METHOD ao_column, ALTER COLUMN a SET ENCODING (compresslevel=4);
-SELECT c.relname, a.attname, e.attoptions FROM pg_attribute_encoding e, pg_class c, pg_attribute a
-WHERE e.attrelid = c.oid AND e.attnum = a.attnum and e.attrelid = a.attrelid AND c.relname LIKE 'part_relopt3%';
-     relname      | attname |                     attoptions                      
-------------------+---------+-----------------------------------------------------
- part_relopt3     | a       | {compresstype=none,blocksize=32768,compresslevel=4}
- part_relopt3     | b       | {compresstype=none,blocksize=32768,compresslevel=0}
- part_relopt3_1   | a       | {compresstype=none,blocksize=32768,compresslevel=4}
- part_relopt3_1   | b       | {compresstype=none,blocksize=32768,compresslevel=0}
- part_relopt3_2   | a       | {compresstype=none,blocksize=32768,compresslevel=4}
- part_relopt3_2   | b       | {compresstype=none,blocksize=32768,compresslevel=0}
- part_relopt3_2_1 | a       | {compresstype=none,blocksize=32768,compresslevel=4}
- part_relopt3_2_1 | b       | {compresstype=none,blocksize=32768,compresslevel=0}
+execute attribute_encoding_check('part_relopt3%');
+     relname      | attname | filenum |                     attoptions                      
+------------------+---------+---------+-----------------------------------------------------
+ part_relopt3     | a       |       1 | {compresstype=none,blocksize=32768,compresslevel=4}
+ part_relopt3     | b       |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ part_relopt3_1   | a       |       1 | {compresstype=none,blocksize=32768,compresslevel=4}
+ part_relopt3_1   | b       |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ part_relopt3_2   | a       |       1 | {compresstype=none,blocksize=32768,compresslevel=4}
+ part_relopt3_2   | b       |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ part_relopt3_2_1 | a       |       1 | {compresstype=none,blocksize=32768,compresslevel=4}
+ part_relopt3_2_1 | b       |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
 (8 rows)
 
 ALTER TABLE part_relopt3 SET ACCESS METHOD heap;
 ALTER TABLE part_relopt3 SET ACCESS METHOD ao_column;
 ALTER TABLE part_relopt3 ALTER COLUMN a SET ENCODING (compresslevel=4);
-SELECT c.relname, a.attname, e.attoptions FROM pg_attribute_encoding e, pg_class c, pg_attribute a
-WHERE e.attrelid = c.oid AND e.attnum = a.attnum and e.attrelid = a.attrelid AND c.relname LIKE 'part_relopt3%';
-     relname      | attname |                     attoptions                      
-------------------+---------+-----------------------------------------------------
- part_relopt3     | a       | {compresstype=none,blocksize=32768,compresslevel=4}
- part_relopt3     | b       | {compresstype=none,blocksize=32768,compresslevel=0}
- part_relopt3_1   | a       | {compresstype=none,blocksize=32768,compresslevel=4}
- part_relopt3_1   | b       | {compresstype=none,blocksize=32768,compresslevel=0}
- part_relopt3_2   | a       | {compresstype=none,blocksize=32768,compresslevel=4}
- part_relopt3_2   | b       | {compresstype=none,blocksize=32768,compresslevel=0}
- part_relopt3_2_1 | a       | {compresstype=none,blocksize=32768,compresslevel=4}
- part_relopt3_2_1 | b       | {compresstype=none,blocksize=32768,compresslevel=0}
+execute attribute_encoding_check('part_relopt3%');
+     relname      | attname | filenum |                     attoptions                      
+------------------+---------+---------+-----------------------------------------------------
+ part_relopt3     | a       |       1 | {compresstype=none,blocksize=32768,compresslevel=4}
+ part_relopt3     | b       |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ part_relopt3_1   | a       |       1 | {compresstype=none,blocksize=32768,compresslevel=4}
+ part_relopt3_1   | b       |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ part_relopt3_2   | a       |       1 | {compresstype=none,blocksize=32768,compresslevel=4}
+ part_relopt3_2   | b       |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ part_relopt3_2_1 | a       |       1 | {compresstype=none,blocksize=32768,compresslevel=4}
+ part_relopt3_2_1 | b       |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
 (8 rows)
 
 DROP TABLE part_relopt3;

--- a/src/test/regress/expected/alter_table_set_am.out
+++ b/src/test/regress/expected/alter_table_set_am.out
@@ -741,17 +741,17 @@ SELECT * FROM gp_toolkit.__gp_aoblkdir('ao2co3');
 (0 rows)
 
 -- pg_attribute_encoding should have columns for the AOCO table
-SELECT c.relname, a.attnum, a.attoptions FROM pg_attribute_encoding a, pg_class c WHERE a.attrelid = c.oid AND c.relname LIKE 'ao2co%';
- relname | attnum |                       attoptions                        
----------+--------+---------------------------------------------------------
- ao2co   |      2 | {compresstype=zlib,blocksize=65536,compresslevel=5}
- ao2co   |      1 | {compresstype=zlib,blocksize=65536,compresslevel=5}
- ao2co2  |      2 | {compresstype=zlib,blocksize=65536,compresslevel=5}
- ao2co2  |      1 | {compresstype=zlib,blocksize=65536,compresslevel=5}
- ao2co3  |      2 | {blocksize=32768,compresstype=rle_type,compresslevel=3}
- ao2co3  |      1 | {blocksize=32768,compresstype=rle_type,compresslevel=3}
- ao2co4  |      2 | {blocksize=32768,compresstype=rle_type,compresslevel=3}
- ao2co4  |      1 | {blocksize=32768,compresstype=rle_type,compresslevel=3}
+SELECT c.relname, a.attnum, a.filenum, a.attoptions FROM pg_attribute_encoding a, pg_class c WHERE a.attrelid = c.oid AND c.relname LIKE 'ao2co%';
+ relname | attnum | filenum |                       attoptions                        
+---------+--------+---------+---------------------------------------------------------
+ ao2co   |      2 |       2 | {compresstype=zlib,blocksize=65536,compresslevel=5}
+ ao2co   |      1 |       1 | {compresstype=zlib,blocksize=65536,compresslevel=5}
+ ao2co2  |      2 |       2 | {compresstype=zlib,blocksize=65536,compresslevel=5}
+ ao2co2  |      1 |       1 | {compresstype=zlib,blocksize=65536,compresslevel=5}
+ ao2co3  |      2 |       2 | {blocksize=32768,compresstype=rle_type,compresslevel=3}
+ ao2co3  |      1 |       1 | {blocksize=32768,compresstype=rle_type,compresslevel=3}
+ ao2co4  |      2 |       2 | {blocksize=32768,compresstype=rle_type,compresslevel=3}
+ ao2co4  |      1 |       1 | {blocksize=32768,compresstype=rle_type,compresslevel=3}
 (8 rows)
 
 -- AM and reloptions changed accordingly
@@ -801,17 +801,17 @@ SELECT relname, relfrozenxid FROM pg_class WHERE relname LIKE 'co2heap%';
 (4 rows)
 
 -- Check once that the pg_attribute_encoding has entries for the AOCO tables.
-SELECT c.relname, a.attnum, attoptions FROM pg_attribute_encoding a, pg_class c WHERE a.attrelid=c.oid AND c.relname LIKE 'co2heap%';
- relname  | attnum |                     attoptions                      
-----------+--------+-----------------------------------------------------
- co2heap  |      1 | {compresstype=zlib,blocksize=65536,compresslevel=5}
- co2heap  |      2 | {compresstype=zlib,blocksize=65536,compresslevel=5}
- co2heap2 |      1 | {compresstype=zlib,blocksize=65536,compresslevel=5}
- co2heap2 |      2 | {compresstype=zlib,blocksize=65536,compresslevel=5}
- co2heap3 |      1 | {compresstype=zlib,blocksize=65536,compresslevel=5}
- co2heap3 |      2 | {compresstype=zlib,blocksize=65536,compresslevel=5}
- co2heap4 |      1 | {compresstype=zlib,blocksize=65536,compresslevel=5}
- co2heap4 |      2 | {compresstype=zlib,blocksize=65536,compresslevel=5}
+SELECT c.relname, a.attnum, a.filenum, attoptions FROM pg_attribute_encoding a, pg_class c WHERE a.attrelid=c.oid AND c.relname LIKE 'co2heap%';
+ relname  | attnum | filenum |                     attoptions                      
+----------+--------+---------+-----------------------------------------------------
+ co2heap  |      2 |       2 | {compresstype=zlib,blocksize=65536,compresslevel=5}
+ co2heap  |      1 |       1 | {compresstype=zlib,blocksize=65536,compresslevel=5}
+ co2heap2 |      2 |       2 | {compresstype=zlib,blocksize=65536,compresslevel=5}
+ co2heap2 |      1 |       1 | {compresstype=zlib,blocksize=65536,compresslevel=5}
+ co2heap3 |      2 |       2 | {compresstype=zlib,blocksize=65536,compresslevel=5}
+ co2heap3 |      1 |       1 | {compresstype=zlib,blocksize=65536,compresslevel=5}
+ co2heap4 |      2 |       2 | {compresstype=zlib,blocksize=65536,compresslevel=5}
+ co2heap4 |      1 |       1 | {compresstype=zlib,blocksize=65536,compresslevel=5}
 (8 rows)
 
 CREATE TEMP TABLE relfilebeforeco2heap AS
@@ -916,9 +916,9 @@ SELECT relname, relfrozenxid <> '0' FROM pg_class WHERE relname LIKE 'co2heap%';
 (4 rows)
 
 -- The pg_attribute_encoding entries for the altered tables should have all gone.
-SELECT c.relname, a.attnum, attoptions FROM pg_attribute_encoding a, pg_class c WHERE a.attrelid=c.oid AND c.relname LIKE 'co2heap%';
- relname | attnum | attoptions 
----------+--------+------------
+SELECT c.relname, a.attnum, a.filenum, attoptions FROM pg_attribute_encoding a, pg_class c WHERE a.attrelid=c.oid AND c.relname LIKE 'co2heap%';
+ relname | attnum | filenum | attoptions 
+---------+--------+---------+------------
 (0 rows)
 
 DROP TABLE co2heap;
@@ -948,17 +948,17 @@ SELECT relname, reloptions FROM pg_class WHERE relname LIKE 'co2ao%';
 (4 rows)
 
 -- Check once that the pg_attribute_encoding has entries for the AOCO tables.
-SELECT c.relname, a.attnum, attoptions FROM pg_attribute_encoding a, pg_class c WHERE a.attrelid=c.oid AND c.relname LIKE 'co2ao%';
- relname | attnum |                       attoptions                        
----------+--------+---------------------------------------------------------
- co2ao   |      1 | {compresstype=rle_type,compresslevel=3,blocksize=65536}
- co2ao   |      2 | {compresstype=rle_type,compresslevel=3,blocksize=65536}
- co2ao2  |      1 | {compresstype=rle_type,compresslevel=3,blocksize=65536}
- co2ao2  |      2 | {compresstype=rle_type,compresslevel=3,blocksize=65536}
- co2ao3  |      1 | {compresstype=rle_type,compresslevel=3,blocksize=65536}
- co2ao3  |      2 | {compresstype=rle_type,compresslevel=3,blocksize=65536}
- co2ao4  |      1 | {compresstype=rle_type,compresslevel=3,blocksize=65536}
- co2ao4  |      2 | {compresstype=rle_type,compresslevel=3,blocksize=65536}
+SELECT c.relname, a.attnum, a.filenum, attoptions FROM pg_attribute_encoding a, pg_class c WHERE a.attrelid=c.oid AND c.relname LIKE 'co2ao%';
+ relname | attnum | filenum |                       attoptions                        
+---------+--------+---------+---------------------------------------------------------
+ co2ao   |      2 |       2 | {compresstype=rle_type,compresslevel=3,blocksize=65536}
+ co2ao   |      1 |       1 | {compresstype=rle_type,compresslevel=3,blocksize=65536}
+ co2ao2  |      2 |       2 | {compresstype=rle_type,compresslevel=3,blocksize=65536}
+ co2ao2  |      1 |       1 | {compresstype=rle_type,compresslevel=3,blocksize=65536}
+ co2ao3  |      2 |       2 | {compresstype=rle_type,compresslevel=3,blocksize=65536}
+ co2ao3  |      1 |       1 | {compresstype=rle_type,compresslevel=3,blocksize=65536}
+ co2ao4  |      2 |       2 | {compresstype=rle_type,compresslevel=3,blocksize=65536}
+ co2ao4  |      1 |       1 | {compresstype=rle_type,compresslevel=3,blocksize=65536}
 (8 rows)
 
 -- Check once on the aoblkdirs
@@ -1102,9 +1102,9 @@ SELECT relname, reloptions FROM pg_class WHERE relname LIKE 'co2ao%';
 (4 rows)
 
 -- The pg_attribute_encoding entries for the altered tables should have all gone.
-SELECT c.relname, a.attnum, attoptions FROM pg_attribute_encoding a, pg_class c WHERE a.attrelid=c.oid AND c.relname LIKE 'co2ao%';
- relname | attnum | attoptions 
----------+--------+------------
+SELECT c.relname, a.attnum, a.filenum, attoptions FROM pg_attribute_encoding a, pg_class c WHERE a.attrelid=c.oid AND c.relname LIKE 'co2ao%';
+ relname | attnum | filenum | attoptions 
+---------+--------+---------+------------
 (0 rows)
 
 DROP TABLE co2ao;
@@ -1247,17 +1247,17 @@ SELECT count(*) FROM gp_toolkit.__gp_aocsseg('heap2co3');
 (1 row)
 
 -- pg_attribute_encoding should have columns for the AOCO table
-SELECT c.relname, a.attnum, a.attoptions FROM pg_attribute_encoding a, pg_class c WHERE a.attrelid = c.oid AND c.relname LIKE 'heap2co%';
- relname  | attnum |                     attoptions                      
-----------+--------+-----------------------------------------------------
- heap2co  |      2 | {compresstype=zlib,blocksize=65536,compresslevel=5}
- heap2co  |      1 | {compresstype=zlib,blocksize=65536,compresslevel=5}
- heap2co2 |      2 | {compresstype=zlib,blocksize=65536,compresslevel=5}
- heap2co2 |      1 | {compresstype=zlib,blocksize=65536,compresslevel=5}
- heap2co3 |      2 | {blocksize=32768,compresslevel=3,compresstype=zlib}
- heap2co3 |      1 | {blocksize=32768,compresslevel=3,compresstype=zlib}
- heap2co4 |      2 | {blocksize=32768,compresslevel=3,compresstype=zlib}
- heap2co4 |      1 | {blocksize=32768,compresslevel=3,compresstype=zlib}
+SELECT c.relname, a.attnum, a.filenum, a.attoptions FROM pg_attribute_encoding a, pg_class c WHERE a.attrelid = c.oid AND c.relname LIKE 'heap2co%';
+ relname  | attnum | filenum |                     attoptions                      
+----------+--------+---------+-----------------------------------------------------
+ heap2co  |      2 |       2 | {compresstype=zlib,blocksize=65536,compresslevel=5}
+ heap2co  |      1 |       1 | {compresstype=zlib,blocksize=65536,compresslevel=5}
+ heap2co2 |      2 |       2 | {compresstype=zlib,blocksize=65536,compresslevel=5}
+ heap2co2 |      1 |       1 | {compresstype=zlib,blocksize=65536,compresslevel=5}
+ heap2co3 |      2 |       2 | {blocksize=32768,compresslevel=3,compresstype=zlib}
+ heap2co3 |      1 |       1 | {blocksize=32768,compresslevel=3,compresstype=zlib}
+ heap2co4 |      2 |       2 | {blocksize=32768,compresslevel=3,compresstype=zlib}
+ heap2co4 |      1 |       1 | {blocksize=32768,compresslevel=3,compresstype=zlib}
 (8 rows)
 
 -- AM and reloptions changed accordingly

--- a/src/test/regress/expected/column_compression.out
+++ b/src/test/regress/expected/column_compression.out
@@ -8,7 +8,7 @@ create database column_compression;
 \c column_compression
 prepare ccddlcheck as
 select e.attrelid::regclass as relname,
-a.attname, e.attoptions from pg_class c, pg_attribute_encoding e, pg_attribute a
+a.attname, e.filenum, e.attoptions from pg_class c, pg_attribute_encoding e, pg_attribute a
 where c.relname like 'ccddl%' and c.oid=e.attrelid and e.attrelid=a.attrelid and e.attnum = a.attnum
 order by relname, e.attnum;
 -- default encoding clause
@@ -20,10 +20,10 @@ create table ccddl (
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 execute ccddlcheck;
- relname | attname |                     attoptions                      
----------+---------+-----------------------------------------------------
- ccddl   | i       | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl   | j       | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ relname | attname | filenum |                     attoptions                      
+---------+---------+---------+-----------------------------------------------------
+ ccddl   | i       |       1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl   | j       |       2 | {compresstype=zlib,compresslevel=1,blocksize=32768}
 (2 rows)
 
 -- This is enough to force compression, specially since we'll hash
@@ -144,10 +144,10 @@ create table ccddl (
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 execute ccddlcheck;
- relname | attname |                     attoptions                      
----------+---------+-----------------------------------------------------
- ccddl   | i       | {compresstype=zlib,compresslevel=5,blocksize=32768}
- ccddl   | j       | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ relname | attname | filenum |                     attoptions                      
+---------+---------+---------+-----------------------------------------------------
+ ccddl   | i       |       1 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ ccddl   | j       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
 (2 rows)
 
 drop table ccddl;
@@ -159,10 +159,10 @@ create table ccddl (
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 execute ccddlcheck;
- relname | attname |                     attoptions                      
----------+---------+-----------------------------------------------------
- ccddl   | i       | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl   | j       | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ relname | attname | filenum |                     attoptions                      
+---------+---------+---------+-----------------------------------------------------
+ ccddl   | i       |       1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl   | j       |       2 | {compresstype=zlib,compresslevel=1,blocksize=32768}
 (2 rows)
 
 -- This is enough to force compression, specially since we'll hash
@@ -278,8 +278,8 @@ drop table ccddl;
 -- We exclude the other tables leftover from other tests.
 select * from pg_attribute_encoding where
 	attrelid not in (select oid from pg_class where relname <> 'ccddl');
- attrelid | attnum | attoptions 
-----------+--------+------------
+ attrelid | attnum | filenum | attoptions 
+----------+--------+---------+------------
 (0 rows)
 
 -- mix inline and default
@@ -291,10 +291,10 @@ create table ccddl (
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 execute ccddlcheck;
- relname | attname |                       attoptions                        
----------+---------+---------------------------------------------------------
- ccddl   | i       | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl   | j       | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ relname | attname | filenum |                       attoptions                        
+---------+---------+---------+---------------------------------------------------------
+ ccddl   | i       |       1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl   | j       |       2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
 (2 rows)
 
 drop table ccddl;
@@ -308,10 +308,10 @@ create table ccddl (
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 execute ccddlcheck;
- relname | attname |                       attoptions                        
----------+---------+---------------------------------------------------------
- ccddl   | i       | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl   | j       | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ relname | attname | filenum |                       attoptions                        
+---------+---------+---------+---------------------------------------------------------
+ ccddl   | i       |       1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl   | j       |       2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
 (2 rows)
 
 drop table ccddl;
@@ -324,33 +324,33 @@ create table ccddl (
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 execute ccddlcheck;
- relname | attname |                     attoptions                      
----------+---------+-----------------------------------------------------
- ccddl   | i       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl   | j       | {compresstype=zlib,blocksize=65536,compresslevel=1}
+ relname | attname | filenum |                     attoptions                      
+---------+---------+---------+-----------------------------------------------------
+ ccddl   | i       |       1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl   | j       |       2 | {compresstype=zlib,blocksize=65536,compresslevel=1}
 (2 rows)
 
 -- Should see the encoding information for the new column
 alter table ccddl add column k timestamp default now()
 	encoding (compresstype=zlib);
 execute ccddlcheck;
- relname | attname |                     attoptions                      
----------+---------+-----------------------------------------------------
- ccddl   | i       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl   | j       | {compresstype=zlib,blocksize=65536,compresslevel=1}
- ccddl   | k       | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ relname | attname | filenum |                     attoptions                      
+---------+---------+---------+-----------------------------------------------------
+ ccddl   | i       |       1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl   | j       |       2 | {compresstype=zlib,blocksize=65536,compresslevel=1}
+ ccddl   | k       |       3 | {compresstype=zlib,compresslevel=1,blocksize=32768}
 (3 rows)
 
 -- no encoding information for this one though
 alter table ccddl add column l numeric
 	default 3.141;
 execute ccddlcheck;
- relname | attname |                     attoptions                      
----------+---------+-----------------------------------------------------
- ccddl   | i       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl   | j       | {compresstype=zlib,blocksize=65536,compresslevel=1}
- ccddl   | k       | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl   | l       | {compresstype=none,blocksize=32768,compresslevel=0}
+ relname | attname | filenum |                     attoptions                      
+---------+---------+---------+-----------------------------------------------------
+ ccddl   | i       |       1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl   | j       |       2 | {compresstype=zlib,blocksize=65536,compresslevel=1}
+ ccddl   | k       |       3 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl   | l       |       4 | {compresstype=none,blocksize=32768,compresslevel=0}
 (4 rows)
 
 drop table ccddl;
@@ -361,10 +361,10 @@ create table ccddl (i int, j int encoding(compresstype=zlib), column i encoding
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 execute ccddlcheck;
- relname | attname |                     attoptions                      
----------+---------+-----------------------------------------------------
- ccddl   | i       | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl   | j       | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ relname | attname | filenum |                     attoptions                      
+---------+---------+---------+-----------------------------------------------------
+ ccddl   | i       |       1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl   | j       |       2 | {compresstype=zlib,compresslevel=1,blocksize=32768}
 (2 rows)
 
 drop table ccddl;
@@ -374,10 +374,10 @@ compresstype=zlib);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 execute ccddlcheck;
- relname | attname |                     attoptions                      
----------+---------+-----------------------------------------------------
- ccddl   | i       | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl   | j       | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ relname | attname | filenum |                     attoptions                      
+---------+---------+---------+-----------------------------------------------------
+ ccddl   | i       |       1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl   | j       |       2 | {compresstype=zlib,compresslevel=1,blocksize=32768}
 (2 rows)
 
 drop table ccddl;
@@ -387,10 +387,10 @@ create table ccddl (i int, j int encoding (COMPRESSTYPE="ZlIb"))
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 execute ccddlcheck;
- relname | attname |                     attoptions                      
----------+---------+-----------------------------------------------------
- ccddl   | i       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl   | j       | {compresstype=ZlIb,compresslevel=1,blocksize=32768}
+ relname | attname | filenum |                     attoptions                      
+---------+---------+---------+-----------------------------------------------------
+ ccddl   | i       |       1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl   | j       |       2 | {compresstype=ZlIb,compresslevel=1,blocksize=32768}
 (2 rows)
 
 drop table ccddl;
@@ -402,9 +402,9 @@ create table ccddl_co(LIKE ccddl)
   with (appendonly = true, orientation=column);
 NOTICE:  table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 execute ccddlcheck;
- relname  | attname |                     attoptions                      
-----------+---------+-----------------------------------------------------
- ccddl_co | i       | {compresstype=none,blocksize=32768,compresslevel=0}
+ relname  | attname | filenum |                     attoptions                      
+----------+---------+---------+-----------------------------------------------------
+ ccddl_co | i       |       1 | {compresstype=none,blocksize=32768,compresslevel=0}
 (1 row)
 
 drop table ccddl_co;
@@ -412,9 +412,9 @@ create table ccddl_co(LIKE ccddl)
   with (appendonly = true, orientation=column, compresstype=zlib);
 NOTICE:  table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 execute ccddlcheck;
- relname  | attname |                     attoptions                      
-----------+---------+-----------------------------------------------------
- ccddl_co | i       | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ relname  | attname | filenum |                     attoptions                      
+----------+---------+---------+-----------------------------------------------------
+ ccddl_co | i       |       1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
 (1 row)
 
 drop table ccddl_co, ccddl;
@@ -462,9 +462,9 @@ appendonly=true, orientation=column);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 execute ccddlcheck;
- relname | attname |                       attoptions                        
----------+---------+---------------------------------------------------------
- ccddl   | i       | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ relname | attname | filenum |                       attoptions                        
+---------+---------+---------+---------------------------------------------------------
+ ccddl   | i       |       1 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
 (1 row)
 
 drop table ccddl;
@@ -506,13 +506,13 @@ NOTICE:  table has parent, setting distribution columns to match parent table
 NOTICE:  moving and merging column "parentcol" with inherited definition
 DETAIL:  User-specified column moved to the position of the inherited column.
 execute ccddlcheck;
-   relname   |  attname  |                     attoptions                      
--------------+-----------+-----------------------------------------------------
- ccddlparent | parentcol | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddlchild  | parentcol | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddlchild  | childcol  | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddlchild2 | parentcol | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddlchild2 | childcol  | {compresstype=none,blocksize=32768,compresslevel=0}
+   relname   |  attname  | filenum |                     attoptions                      
+-------------+-----------+---------+-----------------------------------------------------
+ ccddlparent | parentcol |       1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddlchild  | parentcol |       1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddlchild  | childcol  |       2 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddlchild2 | parentcol |       1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddlchild2 | childcol  |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
 (5 rows)
 
 drop table ccddlparent cascade;
@@ -538,15 +538,15 @@ NOTICE:  table has parent, setting distribution columns to match parent table
 NOTICE:  merging multiple inherited definitions of column "parentcol1"
 NOTICE:  merging multiple inherited definitions of column "parentcol2"
 execute ccddlcheck;
-   relname    |  attname   |                     attoptions                      
---------------+------------+-----------------------------------------------------
- ccddlparent1 | parentcol1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddlparent1 | parentcol2 | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddlparent2 | parentcol1 | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddlparent2 | parentcol2 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddlchild   | parentcol1 | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddlchild   | parentcol2 | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddlchild   | childcol   | {compresstype=none,blocksize=32768,compresslevel=0}
+   relname    |  attname   | filenum |                     attoptions                      
+--------------+------------+---------+-----------------------------------------------------
+ ccddlparent1 | parentcol1 |       1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddlparent1 | parentcol2 |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddlparent2 | parentcol1 |       1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddlparent2 | parentcol2 |       2 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddlchild   | parentcol1 |       1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddlchild   | parentcol2 |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddlchild   | childcol   |       3 | {compresstype=none,blocksize=32768,compresslevel=0}
 (7 rows)
 
 drop table ccddlparent1 cascade;
@@ -568,10 +568,10 @@ select 1, 1;
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 execute ccddlcheck;
- relname | attname |                     attoptions                      
----------+---------+-----------------------------------------------------
- ccddl   | a       | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl   | b       | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ relname | attname | filenum |                     attoptions                      
+---------+---------+---------+-----------------------------------------------------
+ ccddl   | a       |       1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl   | b       |       2 | {compresstype=zlib,compresslevel=1,blocksize=32768}
 (2 rows)
 
 drop table ccddl;
@@ -584,10 +584,10 @@ create table ccddl_co (like ccddl, column i encoding(compresstype=RLE_TYPE))
 with (appendonly=true, orientation=column, compresstype=zlib);
 NOTICE:  table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
 execute ccddlcheck;
- relname  | attname |                       attoptions                        
-----------+---------+---------------------------------------------------------
- ccddl_co | i       | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- ccddl_co | j       | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ relname  | attname | filenum |                       attoptions                        
+----------+---------+---------+---------------------------------------------------------
+ ccddl_co | i       |       1 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ ccddl_co | j       |       2 | {compresstype=zlib,compresslevel=1,blocksize=32768}
 (2 rows)
 
 drop table ccddl;
@@ -608,14 +608,14 @@ partition by range(j)
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 execute ccddlcheck;
-    relname     | attname |                       attoptions                        
-----------------+---------+---------------------------------------------------------
- ccddl          | i       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl          | j       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_p1 | i       | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p1 | j       | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p2 | i       | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p2 | j       | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+    relname     | attname | filenum |                       attoptions                        
+----------------+---------+---------+---------------------------------------------------------
+ ccddl          | i       |       1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl          | j       |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p1 | i       |       1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p1 | j       |       2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p2 | i       |       1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p2 | j       |       2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
 (6 rows)
 
 insert into ccddl select 1,2 from generate_series(1, 100);
@@ -743,28 +743,28 @@ partition by range(j)
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 execute ccddlcheck;
-         relname          | attname |                       attoptions                        
---------------------------+---------+---------------------------------------------------------
- ccddl                    | i       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl                    | j       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl                    | k       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl                    | l       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_p1           | i       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_p1           | j       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_p1           | k       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_p1           | l       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_p2           | i       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_p2           | j       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_p2           | k       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_p2           | l       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_p1_2_prt_sp1 | i       | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p1_2_prt_sp1 | j       | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p1_2_prt_sp1 | k       | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p1_2_prt_sp1 | l       | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p2_2_prt_sp1 | i       | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p2_2_prt_sp1 | j       | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p2_2_prt_sp1 | k       | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p2_2_prt_sp1 | l       | {compresstype=zlib,compresslevel=1,blocksize=32768}
+         relname          | attname | filenum |                       attoptions                        
+--------------------------+---------+---------+---------------------------------------------------------
+ ccddl                    | i       |       1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl                    | j       |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl                    | k       |       3 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl                    | l       |       4 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p1           | i       |       1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p1           | j       |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p1           | k       |       3 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p1           | l       |       4 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p2           | i       |       1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p2           | j       |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p2           | k       |       3 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p2           | l       |       4 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p1_2_prt_sp1 | i       |       1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p1_2_prt_sp1 | j       |       2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p1_2_prt_sp1 | k       |       3 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p1_2_prt_sp1 | l       |       4 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p2_2_prt_sp1 | i       |       1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p2_2_prt_sp1 | j       |       2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p2_2_prt_sp1 | k       |       3 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p2_2_prt_sp1 | l       |       4 | {compresstype=zlib,compresslevel=1,blocksize=32768}
 (20 rows)
 
 SELECT level, pg_get_expr(template, relid) from gp_partition_template t WHERE t.relid = 'ccddl'::regclass;
@@ -1106,62 +1106,62 @@ partition p2 start(10) end(20)
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 execute ccddlcheck;
-         relname          | attname |                       attoptions                        
---------------------------+---------+---------------------------------------------------------
- ccddl                    | i       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl                    | j       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl                    | k       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl                    | l       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_p1           | i       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_p1           | j       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_p1           | k       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_p1           | l       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_p2           | i       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_p2           | j       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_p2           | k       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_p2           | l       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_p1_2_prt_sp1 | i       | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p1_2_prt_sp1 | j       | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p1_2_prt_sp1 | k       | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p1_2_prt_sp1 | l       | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p2_2_prt_sp1 | i       | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p2_2_prt_sp1 | j       | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p2_2_prt_sp1 | k       | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p2_2_prt_sp1 | l       | {compresstype=zlib,compresslevel=1,blocksize=32768}
+         relname          | attname | filenum |                       attoptions                        
+--------------------------+---------+---------+---------------------------------------------------------
+ ccddl                    | i       |       1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl                    | j       |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl                    | k       |       3 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl                    | l       |       4 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p1           | i       |       1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p1           | j       |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p1           | k       |       3 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p1           | l       |       4 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p2           | i       |       1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p2           | j       |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p2           | k       |       3 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p2           | l       |       4 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p1_2_prt_sp1 | i       |       1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p1_2_prt_sp1 | j       |       2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p1_2_prt_sp1 | k       |       3 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p1_2_prt_sp1 | l       |       4 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p2_2_prt_sp1 | i       |       1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p2_2_prt_sp1 | j       |       2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p2_2_prt_sp1 | k       |       3 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p2_2_prt_sp1 | l       |       4 | {compresstype=zlib,compresslevel=1,blocksize=32768}
 (20 rows)
 
 alter table ccddl add partition p3 start(20) end(30);
 execute ccddlcheck;
-         relname          | attname |                       attoptions                        
---------------------------+---------+---------------------------------------------------------
- ccddl                    | i       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl                    | j       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl                    | k       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl                    | l       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_p1           | i       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_p1           | j       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_p1           | k       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_p1           | l       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_p2           | i       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_p2           | j       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_p2           | k       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_p2           | l       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_p1_2_prt_sp1 | i       | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p1_2_prt_sp1 | j       | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p1_2_prt_sp1 | k       | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p1_2_prt_sp1 | l       | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p2_2_prt_sp1 | i       | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p2_2_prt_sp1 | j       | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p2_2_prt_sp1 | k       | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p2_2_prt_sp1 | l       | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p3           | i       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_p3           | j       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_p3           | k       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_p3           | l       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_p3_2_prt_sp1 | i       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_p3_2_prt_sp1 | j       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_p3_2_prt_sp1 | k       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_p3_2_prt_sp1 | l       | {compresstype=none,blocksize=32768,compresslevel=0}
+         relname          | attname | filenum |                       attoptions                        
+--------------------------+---------+---------+---------------------------------------------------------
+ ccddl                    | i       |       1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl                    | j       |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl                    | k       |       3 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl                    | l       |       4 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p1           | i       |       1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p1           | j       |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p1           | k       |       3 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p1           | l       |       4 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p2           | i       |       1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p2           | j       |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p2           | k       |       3 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p2           | l       |       4 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p1_2_prt_sp1 | i       |       1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p1_2_prt_sp1 | j       |       2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p1_2_prt_sp1 | k       |       3 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p1_2_prt_sp1 | l       |       4 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p2_2_prt_sp1 | i       |       1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p2_2_prt_sp1 | j       |       2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p2_2_prt_sp1 | k       |       3 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p2_2_prt_sp1 | l       |       4 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p3           | i       |       1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p3           | j       |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p3           | k       |       3 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p3           | l       |       4 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p3_2_prt_sp1 | i       |       1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p3_2_prt_sp1 | j       |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p3_2_prt_sp1 | k       |       3 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p3_2_prt_sp1 | l       |       4 | {compresstype=none,blocksize=32768,compresslevel=0}
 (28 rows)
 
 drop table ccddl;
@@ -1179,14 +1179,14 @@ partition p2 start(10) end(20)
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 execute ccddlcheck;
- relname | attname | attoptions 
----------+---------+------------
+ relname | attname | filenum | attoptions 
+---------+---------+---------+------------
 (0 rows)
 
 alter table ccddl add partition p3 start(20) end(30);
 execute ccddlcheck;
- relname | attname | attoptions 
----------+---------+------------
+ relname | attname | filenum | attoptions 
+---------+---------+---------+------------
 (0 rows)
 
 drop table ccddl;
@@ -1198,19 +1198,19 @@ partition by range(i)
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 execute ccddlcheck;
-    relname     | attname |                     attoptions                      
-----------------+---------+-----------------------------------------------------
- ccddl          | i       | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p1 | i       | {compresstype=zlib,compresslevel=1,blocksize=32768}
+    relname     | attname | filenum |                     attoptions                      
+----------------+---------+---------+-----------------------------------------------------
+ ccddl          | i       |       1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p1 | i       |       1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
 (2 rows)
 
 alter table ccddl split partition p1 at (5) into (partition p2, partition p3);
 execute ccddlcheck;
-    relname     | attname |                     attoptions                      
-----------------+---------+-----------------------------------------------------
- ccddl          | i       | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p2 | i       | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p3 | i       | {compresstype=zlib,compresslevel=1,blocksize=32768}
+    relname     | attname | filenum |                     attoptions                      
+----------------+---------+---------+-----------------------------------------------------
+ ccddl          | i       |       1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p2 | i       |       1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p3 | i       |       1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
 (3 rows)
 
 drop table ccddl;
@@ -1225,14 +1225,14 @@ subpartition template (subpartition sp1 start(1) end(20),
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 execute ccddlcheck;
-         relname          | attname |                       attoptions                        
---------------------------+---------+---------------------------------------------------------
- ccddl                    | i       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl                    | j       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_p1           | i       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_p1           | j       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_p1_2_prt_sp1 | i       | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p1_2_prt_sp1 | j       | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+         relname          | attname | filenum |                       attoptions                        
+--------------------------+---------+---------+---------------------------------------------------------
+ ccddl                    | i       |       1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl                    | j       |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p1           | i       |       1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p1           | j       |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p1_2_prt_sp1 | i       |       1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p1_2_prt_sp1 | j       |       2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
 (6 rows)
 
 SELECT level, pg_get_expr(template, relid) from gp_partition_template t WHERE t.relid = 'ccddl'::regclass;
@@ -1243,32 +1243,32 @@ SELECT level, pg_get_expr(template, relid) from gp_partition_template t WHERE t.
 
 alter table ccddl alter partition p1 split partition sp1 at (10) into (partition sp2, partition sp3);
 execute ccddlcheck;
-         relname          | attname |                       attoptions                        
---------------------------+---------+---------------------------------------------------------
- ccddl                    | i       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl                    | j       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_p1           | i       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_p1           | j       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_p1_2_prt_sp2 | i       | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p1_2_prt_sp2 | j       | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p1_2_prt_sp3 | i       | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p1_2_prt_sp3 | j       | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+         relname          | attname | filenum |                       attoptions                        
+--------------------------+---------+---------+---------------------------------------------------------
+ ccddl                    | i       |       1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl                    | j       |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p1           | i       |       1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p1           | j       |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p1_2_prt_sp2 | i       |       1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p1_2_prt_sp2 | j       |       2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p1_2_prt_sp3 | i       |       1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p1_2_prt_sp3 | j       |       2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
 (8 rows)
 
 alter table ccddl alter partition p1 split partition sp2 at (5) into (partition sp2, partition sp2_5);
 execute ccddlcheck;
-          relname           | attname |                       attoptions                        
-----------------------------+---------+---------------------------------------------------------
- ccddl                      | i       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl                      | j       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_p1             | i       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_p1             | j       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_p1_2_prt_sp3   | i       | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p1_2_prt_sp3   | j       | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p1_2_prt_sp2   | i       | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p1_2_prt_sp2   | j       | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p1_2_prt_sp2_5 | i       | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p1_2_prt_sp2_5 | j       | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+          relname           | attname | filenum |                       attoptions                        
+----------------------------+---------+---------+---------------------------------------------------------
+ ccddl                      | i       |       1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl                      | j       |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p1             | i       |       1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p1             | j       |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p1_2_prt_sp3   | i       |       1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p1_2_prt_sp3   | j       |       2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p1_2_prt_sp2   | i       |       1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p1_2_prt_sp2   | j       |       2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p1_2_prt_sp2_5 | i       |       1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p1_2_prt_sp2_5 | j       |       2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
 (10 rows)
 
 drop table ccddl;
@@ -1294,28 +1294,28 @@ CREATE TABLE ccddl (id int, year int, month int, day int, region text)
 		)
 	( START (2008) END (2010) );
 execute ccddlcheck;
-             relname             | attname |                       attoptions                        
----------------------------------+---------+---------------------------------------------------------
- ccddl                           | id      | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl                           | year    | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl                           | month   | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl                           | day     | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl                           | region  | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_1                   | id      | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_1                   | year    | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_1                   | month   | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_1                   | day     | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_1                   | region  | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_1_2_prt_1           | id      | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_1_2_prt_1           | year    | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_1_2_prt_1           | month   | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- ccddl_1_prt_1_2_prt_1           | day     | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_1_2_prt_1           | region  | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_1_2_prt_1_3_prt_usa | id      | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_1_2_prt_1_3_prt_usa | year    | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_1_2_prt_1_3_prt_usa | month   | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- ccddl_1_prt_1_2_prt_1_3_prt_usa | day     | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_1_2_prt_1_3_prt_usa | region  | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+             relname             | attname | filenum |                       attoptions                        
+---------------------------------+---------+---------+---------------------------------------------------------
+ ccddl                           | id      |       1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl                           | year    |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl                           | month   |       3 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl                           | day     |       4 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl                           | region  |       5 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_1                   | id      |       1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_1                   | year    |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_1                   | month   |       3 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_1                   | day     |       4 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_1                   | region  |       5 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_1_2_prt_1           | id      |       1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_1_2_prt_1           | year    |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_1_2_prt_1           | month   |       3 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_1_2_prt_1           | day     |       4 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_1_2_prt_1           | region  |       5 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_1_2_prt_1_3_prt_usa | id      |       1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_1_2_prt_1_3_prt_usa | year    |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_1_2_prt_1_3_prt_usa | month   |       3 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_1_2_prt_1_3_prt_usa | day     |       4 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_1_2_prt_1_3_prt_usa | region  |       5 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
 (20 rows)
 
 SELECT level, pg_get_expr(template, relid) from gp_partition_template t WHERE t.relid = 'ccddl'::regclass;
@@ -1456,24 +1456,24 @@ create table ccddl (
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 execute ccddlcheck;
-    relname     | attname |                       attoptions                        
-----------------+---------+---------------------------------------------------------
- ccddl          | i       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl          | j       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl          | k       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl          | l       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_p1 | i       | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p1 | j       | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p1 | k       | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p1 | l       | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p2 | i       | {blocksize=65536,compresstype=none,compresslevel=0}
- ccddl_1_prt_p2 | j       | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p2 | k       | {blocksize=8192,compresstype=none,compresslevel=0}
- ccddl_1_prt_p2 | l       | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p3 | i       | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p3 | j       | {blocksize=8192,compresstype=none,compresslevel=0}
- ccddl_1_prt_p3 | k       | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p3 | l       | {compresstype=zlib,compresslevel=1,blocksize=32768}
+    relname     | attname | filenum |                       attoptions                        
+----------------+---------+---------+---------------------------------------------------------
+ ccddl          | i       |       1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl          | j       |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl          | k       |       3 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl          | l       |       4 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p1 | i       |       1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p1 | j       |       2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p1 | k       |       3 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p1 | l       |       4 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p2 | i       |       1 | {blocksize=65536,compresstype=none,compresslevel=0}
+ ccddl_1_prt_p2 | j       |       2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p2 | k       |       3 | {blocksize=8192,compresstype=none,compresslevel=0}
+ ccddl_1_prt_p2 | l       |       4 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p3 | i       |       1 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p3 | j       |       2 | {blocksize=8192,compresstype=none,compresslevel=0}
+ ccddl_1_prt_p3 | k       |       3 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p3 | l       |       4 | {compresstype=zlib,compresslevel=1,blocksize=32768}
 (16 rows)
 
 drop table ccddl;
@@ -1497,28 +1497,28 @@ partition by range(i) subpartition by range(j)
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 execute ccddlcheck;
-         relname          | attname |                       attoptions                        
---------------------------+---------+---------------------------------------------------------
- ccddl                    | i       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl                    | j       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl                    | k       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl                    | l       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_p1           | i       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_p1           | j       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_p1           | k       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_p1           | l       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_p2           | i       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_p2           | j       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_p2           | k       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_p2           | l       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_p1_2_prt_sp1 | i       | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p1_2_prt_sp1 | j       | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p1_2_prt_sp1 | k       | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p1_2_prt_sp1 | l       | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p2_2_prt_sp1 | i       | {blocksize=65536,compresstype=none,compresslevel=0}
- ccddl_1_prt_p2_2_prt_sp1 | j       | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p2_2_prt_sp1 | k       | {blocksize=8192,compresstype=none,compresslevel=0}
- ccddl_1_prt_p2_2_prt_sp1 | l       | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+         relname          | attname | filenum |                       attoptions                        
+--------------------------+---------+---------+---------------------------------------------------------
+ ccddl                    | i       |       1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl                    | j       |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl                    | k       |       3 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl                    | l       |       4 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p1           | i       |       1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p1           | j       |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p1           | k       |       3 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p1           | l       |       4 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p2           | i       |       1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p2           | j       |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p2           | k       |       3 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p2           | l       |       4 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_p1_2_prt_sp1 | i       |       1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p1_2_prt_sp1 | j       |       2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p1_2_prt_sp1 | k       |       3 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p1_2_prt_sp1 | l       |       4 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p2_2_prt_sp1 | i       |       1 | {blocksize=65536,compresstype=none,compresslevel=0}
+ ccddl_1_prt_p2_2_prt_sp1 | j       |       2 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p2_2_prt_sp1 | k       |       3 | {blocksize=8192,compresstype=none,compresslevel=0}
+ ccddl_1_prt_p2_2_prt_sp1 | l       |       4 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
 (20 rows)
 
 drop table ccddl;
@@ -1543,32 +1543,32 @@ create table ccddl (a int ENCODING (compresslevel=1),
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 execute ccddlcheck;
-         relname          | attname |                     attoptions                      
---------------------------+---------+-----------------------------------------------------
- ccddl                    | a       | {compresslevel=1,compresstype=zlib,blocksize=32768}
- ccddl                    | b       | {compresslevel=1,compresstype=zlib,blocksize=32768}
- ccddl                    | c       | {compresslevel=1,compresstype=zlib,blocksize=32768}
- ccddl                    | d       | {compresslevel=1,compresstype=zlib,blocksize=32768}
- ccddl                    | e       | {compresslevel=5,compresstype=zlib,blocksize=32768}
- ccddl                    | f       | {compresslevel=5,compresstype=zlib,blocksize=32768}
- ccddl                    | g       | {compresslevel=5,compresstype=zlib,blocksize=32768}
- ccddl                    | h       | {compresslevel=5,compresstype=zlib,blocksize=32768}
- ccddl_1_prt_p1           | a       | {compresslevel=2,compresstype=zlib,blocksize=32768}
- ccddl_1_prt_p1           | b       | {compresslevel=2,compresstype=zlib,blocksize=32768}
- ccddl_1_prt_p1           | c       | {compresslevel=1,compresstype=zlib,blocksize=32768}
- ccddl_1_prt_p1           | d       | {compresslevel=1,compresstype=zlib,blocksize=32768}
- ccddl_1_prt_p1           | e       | {compresslevel=2,compresstype=zlib,blocksize=32768}
- ccddl_1_prt_p1           | f       | {compresslevel=5,compresstype=zlib,blocksize=32768}
- ccddl_1_prt_p1           | g       | {compresslevel=2,compresstype=zlib,blocksize=32768}
- ccddl_1_prt_p1           | h       | {compresslevel=5,compresstype=zlib,blocksize=32768}
- ccddl_1_prt_p1_2_prt_sp1 | a       | {compresslevel=3,compresstype=zlib,blocksize=32768}
- ccddl_1_prt_p1_2_prt_sp1 | b       | {compresslevel=2,compresstype=zlib,blocksize=32768}
- ccddl_1_prt_p1_2_prt_sp1 | c       | {compresslevel=1,compresstype=zlib,blocksize=32768}
- ccddl_1_prt_p1_2_prt_sp1 | d       | {compresslevel=3,compresstype=zlib,blocksize=32768}
- ccddl_1_prt_p1_2_prt_sp1 | e       | {compresslevel=2,compresstype=zlib,blocksize=32768}
- ccddl_1_prt_p1_2_prt_sp1 | f       | {compresslevel=3,compresstype=zlib,blocksize=32768}
- ccddl_1_prt_p1_2_prt_sp1 | g       | {compresslevel=3,compresstype=zlib,blocksize=32768}
- ccddl_1_prt_p1_2_prt_sp1 | h       | {compresslevel=5,compresstype=zlib,blocksize=32768}
+         relname          | attname | filenum |                     attoptions                      
+--------------------------+---------+---------+-----------------------------------------------------
+ ccddl                    | a       |       1 | {compresslevel=1,compresstype=zlib,blocksize=32768}
+ ccddl                    | b       |       2 | {compresslevel=1,compresstype=zlib,blocksize=32768}
+ ccddl                    | c       |       3 | {compresslevel=1,compresstype=zlib,blocksize=32768}
+ ccddl                    | d       |       4 | {compresslevel=1,compresstype=zlib,blocksize=32768}
+ ccddl                    | e       |       5 | {compresslevel=5,compresstype=zlib,blocksize=32768}
+ ccddl                    | f       |       6 | {compresslevel=5,compresstype=zlib,blocksize=32768}
+ ccddl                    | g       |       7 | {compresslevel=5,compresstype=zlib,blocksize=32768}
+ ccddl                    | h       |       8 | {compresslevel=5,compresstype=zlib,blocksize=32768}
+ ccddl_1_prt_p1           | a       |       1 | {compresslevel=2,compresstype=zlib,blocksize=32768}
+ ccddl_1_prt_p1           | b       |       2 | {compresslevel=2,compresstype=zlib,blocksize=32768}
+ ccddl_1_prt_p1           | c       |       3 | {compresslevel=1,compresstype=zlib,blocksize=32768}
+ ccddl_1_prt_p1           | d       |       4 | {compresslevel=1,compresstype=zlib,blocksize=32768}
+ ccddl_1_prt_p1           | e       |       5 | {compresslevel=2,compresstype=zlib,blocksize=32768}
+ ccddl_1_prt_p1           | f       |       6 | {compresslevel=5,compresstype=zlib,blocksize=32768}
+ ccddl_1_prt_p1           | g       |       7 | {compresslevel=2,compresstype=zlib,blocksize=32768}
+ ccddl_1_prt_p1           | h       |       8 | {compresslevel=5,compresstype=zlib,blocksize=32768}
+ ccddl_1_prt_p1_2_prt_sp1 | a       |       1 | {compresslevel=3,compresstype=zlib,blocksize=32768}
+ ccddl_1_prt_p1_2_prt_sp1 | b       |       2 | {compresslevel=2,compresstype=zlib,blocksize=32768}
+ ccddl_1_prt_p1_2_prt_sp1 | c       |       3 | {compresslevel=1,compresstype=zlib,blocksize=32768}
+ ccddl_1_prt_p1_2_prt_sp1 | d       |       4 | {compresslevel=3,compresstype=zlib,blocksize=32768}
+ ccddl_1_prt_p1_2_prt_sp1 | e       |       5 | {compresslevel=2,compresstype=zlib,blocksize=32768}
+ ccddl_1_prt_p1_2_prt_sp1 | f       |       6 | {compresslevel=3,compresstype=zlib,blocksize=32768}
+ ccddl_1_prt_p1_2_prt_sp1 | g       |       7 | {compresslevel=3,compresstype=zlib,blocksize=32768}
+ ccddl_1_prt_p1_2_prt_sp1 | h       |       8 | {compresslevel=5,compresstype=zlib,blocksize=32768}
 (24 rows)
 
 insert into ccddl select 2,3 from generate_series(1, 100);
@@ -1597,14 +1597,14 @@ WITH (appendonly=true, orientation=column)
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 execute ccddlcheck;
-    relname    | attname |                       attoptions                        
----------------+---------+---------------------------------------------------------
- ccddl         | c1      | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl         | c2      | {compresstype=rle_type,blocksize=65536,compresslevel=1}
- ccddl         | c3      | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- ccddl_1_prt_1 | c1      | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_1 | c2      | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- ccddl_1_prt_1 | c3      | {compresstype=zlib,compresslevel=1,blocksize=32768}
+    relname    | attname | filenum |                       attoptions                        
+---------------+---------+---------+---------------------------------------------------------
+ ccddl         | c1      |       1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl         | c2      |       2 | {compresstype=rle_type,blocksize=65536,compresslevel=1}
+ ccddl         | c3      |       3 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_1 | c1      |       1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_1 | c2      |       2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_1 | c3      |       3 | {compresstype=zlib,compresslevel=1,blocksize=32768}
 (6 rows)
 
 drop table ccddl;
@@ -1623,12 +1623,12 @@ create table ccddl
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 execute ccddlcheck;
-    relname     | attname |                       attoptions                        
-----------------+---------+---------------------------------------------------------
- ccddl          | i       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl          | j       | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p2 | i       | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_p2 | j       | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+    relname     | attname | filenum |                       attoptions                        
+----------------+---------+---------+---------------------------------------------------------
+ ccddl          | i       |       1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl          | j       |       2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p2 | i       |       1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_p2 | j       |       2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
 (4 rows)
 
 drop table ccddl;
@@ -1646,14 +1646,14 @@ alter table ccddl add partition "s_xyz" values ('xyz')
 	WITH (appendonly=true, orientation=column,
 		  compresstype=zlib, compresslevel=1);
 execute ccddlcheck;
-      relname      | attname |                     attoptions                      
--------------------+---------+-----------------------------------------------------
- ccddl             | a       | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl             | b       | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_s_abc | a       | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_s_abc | b       | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_s_xyz | a       | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_s_xyz | b       | {compresstype=zlib,compresslevel=1,blocksize=32768}
+      relname      | attname | filenum |                     attoptions                      
+-------------------+---------+---------+-----------------------------------------------------
+ ccddl             | a       |       1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl             | b       |       2 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_s_abc | a       |       1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_s_abc | b       |       2 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_s_xyz | a       |       1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_s_xyz | b       |       2 | {compresstype=zlib,compresslevel=1,blocksize=32768}
 (6 rows)
 
 drop table ccddl;
@@ -1671,41 +1671,41 @@ alter table ccddl add partition newp
 	start('2010-01-06') end('2010-01-07')
 	with (appendonly=true, orientation=column);
 execute ccddlcheck;
-          relname           | attname |                     attoptions                      
-----------------------------+---------+-----------------------------------------------------
- ccddl                      | i       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl                      | d       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl                      | j       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_1              | i       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_1              | d       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_1              | j       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_2              | i       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_2              | d       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_2              | j       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_3              | i       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_3              | d       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_3              | j       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_4              | i       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_4              | d       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_4              | j       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_1_2_prt_sp1    | i       | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_1_2_prt_sp1    | d       | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_1_2_prt_sp1    | j       | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_2_2_prt_sp1    | i       | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_2_2_prt_sp1    | d       | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_2_2_prt_sp1    | j       | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_3_2_prt_sp1    | i       | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_3_2_prt_sp1    | d       | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_3_2_prt_sp1    | j       | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_4_2_prt_sp1    | i       | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_4_2_prt_sp1    | d       | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_4_2_prt_sp1    | j       | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_newp           | i       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_newp           | d       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_newp           | j       | {compresstype=none,blocksize=32768,compresslevel=0}
- ccddl_1_prt_newp_2_prt_sp1 | i       | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_newp_2_prt_sp1 | d       | {compresstype=zlib,compresslevel=1,blocksize=32768}
- ccddl_1_prt_newp_2_prt_sp1 | j       | {compresstype=zlib,compresslevel=1,blocksize=32768}
+          relname           | attname | filenum |                     attoptions                      
+----------------------------+---------+---------+-----------------------------------------------------
+ ccddl                      | i       |       1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl                      | d       |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl                      | j       |       3 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_1              | i       |       1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_1              | d       |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_1              | j       |       3 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_2              | i       |       1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_2              | d       |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_2              | j       |       3 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_3              | i       |       1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_3              | d       |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_3              | j       |       3 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_4              | i       |       1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_4              | d       |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_4              | j       |       3 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_1_2_prt_sp1    | i       |       1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_1_2_prt_sp1    | d       |       2 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_1_2_prt_sp1    | j       |       3 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_2_2_prt_sp1    | i       |       1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_2_2_prt_sp1    | d       |       2 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_2_2_prt_sp1    | j       |       3 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_3_2_prt_sp1    | i       |       1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_3_2_prt_sp1    | d       |       2 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_3_2_prt_sp1    | j       |       3 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_4_2_prt_sp1    | i       |       1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_4_2_prt_sp1    | d       |       2 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_4_2_prt_sp1    | j       |       3 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_newp           | i       |       1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_newp           | d       |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_newp           | j       |       3 | {compresstype=none,blocksize=32768,compresslevel=0}
+ ccddl_1_prt_newp_2_prt_sp1 | i       |       1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_newp_2_prt_sp1 | d       |       2 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ ccddl_1_prt_newp_2_prt_sp1 | j       |       3 | {compresstype=zlib,compresslevel=1,blocksize=32768}
 (33 rows)
 
 SELECT level, pg_get_expr(template, relid) from gp_partition_template t WHERE t.relid = 'ccddl'::regclass;
@@ -1757,8 +1757,8 @@ partition by range(a1)
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a1' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 execute ccddlcheck;
- relname | attname | attoptions 
----------+---------+------------
+ relname | attname | filenum | attoptions 
+---------+---------+---------+------------
 (0 rows)
 
 drop table ccddl;
@@ -1800,27 +1800,27 @@ select typoptions from pg_type_encoding where typid='public.int42'::regtype;
 create table ccddl (i int42) with(appendonly = true, orientation=column);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
 execute ccddlcheck;
- relname | attname |                     attoptions                      
----------+---------+-----------------------------------------------------
- ccddl   | i       | {compresstype=zlib,blocksize=65536,compresslevel=1}
+ relname | attname | filenum |                     attoptions                      
+---------+---------+---------+-----------------------------------------------------
+ ccddl   | i       |       1 | {compresstype=zlib,blocksize=65536,compresslevel=1}
 (1 row)
 
 alter type int42 set default encoding (compresstype=zlib);
 alter table ccddl add column j int42 default '1'::int42;
 execute ccddlcheck;
- relname | attname |                     attoptions                      
----------+---------+-----------------------------------------------------
- ccddl   | i       | {compresstype=zlib,blocksize=65536,compresslevel=1}
- ccddl   | j       | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ relname | attname | filenum |                     attoptions                      
+---------+---------+---------+-----------------------------------------------------
+ ccddl   | i       |       1 | {compresstype=zlib,blocksize=65536,compresslevel=1}
+ ccddl   | j       |       2 | {compresstype=zlib,compresslevel=1,blocksize=32768}
 (2 rows)
 
 drop table ccddl;
 create table ccddl (i int42) with(appendonly = true, orientation=column);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
 execute ccddlcheck;
- relname | attname |                     attoptions                      
----------+---------+-----------------------------------------------------
- ccddl   | i       | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ relname | attname | filenum |                     attoptions                      
+---------+---------+---------+-----------------------------------------------------
+ ccddl   | i       |       1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
 (1 row)
 
 drop table ccddl;
@@ -1828,16 +1828,16 @@ drop table ccddl;
 create table ccddl (i int42);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
 execute ccddlcheck;
- relname | attname | attoptions 
----------+---------+------------
+ relname | attname | filenum | attoptions 
+---------+---------+---------+------------
 (0 rows)
 
 drop table ccddl;
 create table ccddl (i int42) with (appendonly = true);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
 execute ccddlcheck;
- relname | attname | attoptions 
----------+---------+------------
+ relname | attname | filenum | attoptions 
+---------+---------+---------+------------
 (0 rows)
 
 drop table ccddl;
@@ -1847,10 +1847,10 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suita
 alter type int42 set default encoding (compresstype=RLE_TYPE);
 alter table ccddl add column j int42 default '1'::int42;
 execute ccddlcheck;
- relname | attname |                       attoptions                        
----------+---------+---------------------------------------------------------
- ccddl   | i       | {compresstype=none,compresslevel=0,blocksize=32768}
- ccddl   | j       | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ relname | attname | filenum |                       attoptions                        
+---------+---------+---------+---------------------------------------------------------
+ ccddl   | i       |       1 | {compresstype=none,compresslevel=0,blocksize=32768}
+ ccddl   | j       |       2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
 (2 rows)
 
 drop table ccddl;
@@ -1860,8 +1860,8 @@ alter type int42 set default encoding (compresstype=RLE_TYPE);
 alter table ccddl add column j int42 default '1'::int42;
 -- No results are returned from the attribute encoding check, as compression with rle is not supported for row tables
 execute ccddlcheck;
- relname | attname | attoptions 
----------+---------+------------
+ relname | attname | filenum | attoptions 
+---------+---------+---------+------------
 (0 rows)
 
 drop table ccddl;
@@ -1871,8 +1871,8 @@ alter type int42 set default encoding (compresstype=RLE_TYPE);
 alter table ccddl add column j int42 default '1'::int42;
 -- No results are returned from the attribute encoding check, as compression with rle is not supported for heap tables
 execute ccddlcheck;
- relname | attname | attoptions 
----------+---------+------------
+ relname | attname | filenum | attoptions 
+---------+---------+---------+------------
 (0 rows)
 
 drop table ccddl;

--- a/src/test/regress/expected/create_table_like_gp.out
+++ b/src/test/regress/expected/create_table_like_gp.out
@@ -34,18 +34,19 @@ select relname, reloptions from pg_class where relname LIKE 't_ao%' order by rel
 SELECT
 	c.relname,
 	a.attnum,
+	a.filenum,
 	a.attoptions
 FROM
 	pg_catalog.pg_class c
 		JOIN pg_catalog.pg_attribute_encoding a ON (a.attrelid = c.oid)
 WHERE
 	c.relname like 't_ao_enc%';
-  relname   | attnum |                     attoptions                      
-------------+--------+-----------------------------------------------------
- t_ao_enc   |      2 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- t_ao_enc   |      1 | {compresstype=none,blocksize=32768,compresslevel=0}
- t_ao_enc_a |      2 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- t_ao_enc_a |      1 | {compresstype=none,blocksize=32768,compresslevel=0}
+  relname   | attnum | filenum |                     attoptions                      
+------------+--------+---------+-----------------------------------------------------
+ t_ao_enc   |      2 |       2 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ t_ao_enc   |      1 |       1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ t_ao_enc_a |      2 |       2 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ t_ao_enc_a |      1 |       1 | {compresstype=none,blocksize=32768,compresslevel=0}
 (4 rows)
 
 -- EXTERNAL TABLE

--- a/src/test/regress/expected/dsp.out
+++ b/src/test/regress/expected/dsp.out
@@ -226,14 +226,14 @@ select * from t2 order by 1;
  5 | 14 | 10 | abc10
 (5 rows)
 
-select attrelid::regclass, attnum, attoptions
+select attrelid::regclass, attnum, filenum, attoptions
 	from pg_attribute_encoding order by 1,2;
- attrelid | attnum |                       attoptions                        
-----------+--------+---------------------------------------------------------
- t2       |      1 | {blocksize=65536,compresstype=zlib,compresslevel=2}
- t2       |      2 | {compresstype=zlib,compresslevel=2,blocksize=32768}
- t2       |      3 | {compresstype=rle_type,compresslevel=2,blocksize=32768}
- t2       |      4 | {compresstype=zlib,blocksize=32768,compresslevel=2}
+ attrelid | attnum | filenum |                       attoptions                        
+----------+--------+---------+---------------------------------------------------------
+ t2       |      1 |       1 | {blocksize=65536,compresstype=zlib,compresslevel=2}
+ t2       |      2 |       2 | {compresstype=zlib,compresslevel=2,blocksize=32768}
+ t2       |      3 |       3 | {compresstype=rle_type,compresslevel=2,blocksize=32768}
+ t2       |      4 |       4 | {compresstype=zlib,blocksize=32768,compresslevel=2}
 (4 rows)
 
 -- SET operation in a session has higher precedence.  Also test if
@@ -364,34 +364,34 @@ create table co7(
 	b varchar encoding(compresstype=zlib,compresslevel=6),
 	c char encoding(compresstype=rle_type))
 	with (checksum=false) distributed by (a);
-select attrelid::regclass,attnum,attoptions
+select attrelid::regclass,attnum,filenum,attoptions
 	from pg_attribute_encoding order by 1,2;
- attrelid | attnum |                       attoptions                        
-----------+--------+---------------------------------------------------------
- t2       |      1 | {blocksize=65536,compresstype=zlib,compresslevel=2}
- t2       |      2 | {compresstype=zlib,compresslevel=2,blocksize=32768}
- t2       |      3 | {compresstype=rle_type,compresslevel=2,blocksize=32768}
- t2       |      4 | {compresstype=zlib,blocksize=32768,compresslevel=2}
- co1      |      1 | {compresstype=zlib,blocksize=32768,compresslevel=1}
- co1      |      2 | {compresstype=zlib,blocksize=32768,compresslevel=1}
- co2      |      1 | {blocksize=8192,compresstype=zlib,compresslevel=1}
- co2      |      2 | {blocksize=8192,compresstype=zlib,compresslevel=1}
- co3      |      1 | {blocksize=65536,compresstype=zlib,compresslevel=1}
- co3      |      2 | {compresstype=zlib,compresslevel=6,blocksize=32768}
- co3      |      3 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- co4      |      1 | {compresslevel=5,compresstype=zlib,blocksize=32768}
- co4      |      2 | {compresslevel=5,compresstype=zlib,blocksize=32768}
- co4      |      3 | {compresslevel=5,compresstype=zlib,blocksize=32768}
- co5      |      1 | {compresslevel=5,compresstype=zlib,blocksize=32768}
- co5      |      2 | {compresslevel=5,compresstype=zlib,blocksize=32768}
- co5      |      3 | {compresslevel=0,compresstype=none,blocksize=32768}
- co6      |      1 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- co6      |      2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- co6      |      3 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- co6      |      4 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- co7      |      1 | {blocksize=8192,compresstype=none,compresslevel=0}
- co7      |      2 | {compresstype=zlib,compresslevel=6,blocksize=32768}
- co7      |      3 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ attrelid | attnum | filenum |                       attoptions                        
+----------+--------+---------+---------------------------------------------------------
+ t2       |      1 |       1 | {blocksize=65536,compresstype=zlib,compresslevel=2}
+ t2       |      2 |       2 | {compresstype=zlib,compresslevel=2,blocksize=32768}
+ t2       |      3 |       3 | {compresstype=rle_type,compresslevel=2,blocksize=32768}
+ t2       |      4 |       4 | {compresstype=zlib,blocksize=32768,compresslevel=2}
+ co1      |      1 |       1 | {compresstype=zlib,blocksize=32768,compresslevel=1}
+ co1      |      2 |       2 | {compresstype=zlib,blocksize=32768,compresslevel=1}
+ co2      |      1 |       1 | {blocksize=8192,compresstype=zlib,compresslevel=1}
+ co2      |      2 |       2 | {blocksize=8192,compresstype=zlib,compresslevel=1}
+ co3      |      1 |       1 | {blocksize=65536,compresstype=zlib,compresslevel=1}
+ co3      |      2 |       2 | {compresstype=zlib,compresslevel=6,blocksize=32768}
+ co3      |      3 |       3 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ co4      |      1 |       1 | {compresslevel=5,compresstype=zlib,blocksize=32768}
+ co4      |      2 |       2 | {compresslevel=5,compresstype=zlib,blocksize=32768}
+ co4      |      3 |       3 | {compresslevel=5,compresstype=zlib,blocksize=32768}
+ co5      |      1 |       1 | {compresslevel=5,compresstype=zlib,blocksize=32768}
+ co5      |      2 |       2 | {compresslevel=5,compresstype=zlib,blocksize=32768}
+ co5      |      3 |       3 | {compresslevel=0,compresstype=none,blocksize=32768}
+ co6      |      1 |       1 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ co6      |      2 |       2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ co6      |      3 |       3 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ co6      |      4 |       4 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ co7      |      1 |       1 | {blocksize=8192,compresstype=none,compresslevel=0}
+ co7      |      2 |       2 | {compresstype=zlib,compresslevel=6,blocksize=32768}
+ co7      |      3 |       3 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
 (24 rows)
 
 drop database if exists dsp3;
@@ -462,22 +462,22 @@ where relname in ('co1', 'co2', 'co3', 'co5') order by 1;
  co5     | ao_column | r       | {checksum=false,blocksize=32768,compresslevel=0,compresstype=none}
 (4 rows)
 
-select attrelid::regclass,attnum,attoptions
+select attrelid::regclass,attnum,filenum,attoptions
 	from pg_attribute_encoding order by 1,2;
- attrelid | attnum |                       attoptions                        
-----------+--------+---------------------------------------------------------
- co1      |      1 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- co1      |      2 | {compresslevel=5,compresstype=zlib,blocksize=32768}
- co1      |      3 | {compresslevel=0,blocksize=65536,compresstype=none}
- co1      |      4 | {compresstype=none,blocksize=32768,compresslevel=0}
- co2      |      1 | {compresstype=rle_type,compresslevel=3,blocksize=32768}
- co2      |      2 | {compresslevel=5,compresstype=zlib,blocksize=32768}
- co2      |      3 | {compresslevel=0,blocksize=65536,compresstype=none}
- co2      |      4 | {compresstype=none,compresslevel=0,blocksize=32768}
- co3      |      1 | {compresstype=none,blocksize=32768,compresslevel=0}
- co3      |      2 | {compresstype=none,blocksize=32768,compresslevel=0}
- co5      |      1 | {blocksize=8192,compresstype=none,compresslevel=0}
- co5      |      2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ attrelid | attnum | filenum |                       attoptions                        
+----------+--------+---------+---------------------------------------------------------
+ co1      |      1 |       1 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ co1      |      2 |       2 | {compresslevel=5,compresstype=zlib,blocksize=32768}
+ co1      |      3 |       3 | {compresslevel=0,blocksize=65536,compresstype=none}
+ co1      |      4 |       4 | {compresstype=none,blocksize=32768,compresslevel=0}
+ co2      |      1 |       1 | {compresstype=rle_type,compresslevel=3,blocksize=32768}
+ co2      |      2 |       2 | {compresslevel=5,compresstype=zlib,blocksize=32768}
+ co2      |      3 |       3 | {compresslevel=0,blocksize=65536,compresstype=none}
+ co2      |      4 |       4 | {compresstype=none,compresslevel=0,blocksize=32768}
+ co3      |      1 |       1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ co3      |      2 |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ co5      |      1 |       1 | {blocksize=8192,compresstype=none,compresslevel=0}
+ co5      |      2 |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
 (12 rows)
 
 -- misc tests
@@ -745,13 +745,13 @@ set default_table_access_method = ao_row;
 set gp_default_storage_options = "compresstype=NONE";
 create table co10 (a int, b int, c int) with (appendonly=true,orientation=column)
     distributed by (a);
-select attnum,attoptions from pg_attribute_encoding
+select attnum,filenum,attoptions from pg_attribute_encoding
     where attrelid = 'co10'::regclass order by attnum;
- attnum |                     attoptions                      
---------+-----------------------------------------------------
-      1 | {compresstype=none,blocksize=32768,compresslevel=0}
-      2 | {compresstype=none,blocksize=32768,compresslevel=0}
-      3 | {compresstype=none,blocksize=32768,compresslevel=0}
+ attnum | filenum |                     attoptions                      
+--------+---------+-----------------------------------------------------
+      1 |       1 | {compresstype=none,blocksize=32768,compresslevel=0}
+      2 |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
+      3 |       3 | {compresstype=none,blocksize=32768,compresslevel=0}
 (3 rows)
 
 -- compression disabled by default, enable in WITH clause

--- a/src/test/regress/expected/gp_partition_template.out
+++ b/src/test/regress/expected/gp_partition_template.out
@@ -523,7 +523,7 @@ SELECT t.*, pg_get_expr(relpartbound, oid) FROM pg_partition_tree('notemplate') 
 -- Subpartition templates with encoding clauses
 prepare encoding_check as
 select attrelid::regclass as relname,
-        attnum, attoptions from pg_class c, pg_attribute_encoding e
+        attnum, filenum,attoptions from pg_class c, pg_attribute_encoding e
 where c.relname like 'subpart_templ_encoding%' and c.oid=e.attrelid
 order by relname, attnum;
 -- Range partition with enclause
@@ -564,83 +564,83 @@ SELECT t.*, pg_get_expr(relpartbound, oid) FROM pg_partition_tree('subpart_templ
 (7 rows)
 
 EXECUTE encoding_check;
-                   relname                   | attnum |                       attoptions                        
----------------------------------------------+--------+---------------------------------------------------------
- subpart_templ_encoding                      |      1 | {compresstype=none,blocksize=32768,compresslevel=0}
- subpart_templ_encoding                      |      2 | {compresstype=none,blocksize=32768,compresslevel=0}
- subpart_templ_encoding                      |      3 | {compresstype=none,blocksize=32768,compresslevel=0}
- subpart_templ_encoding                      |      4 | {compresstype=none,blocksize=32768,compresslevel=0}
- subpart_templ_encoding_1_prt_p1             |      1 | {compresstype=none,blocksize=32768,compresslevel=0}
- subpart_templ_encoding_1_prt_p1             |      2 | {compresstype=none,blocksize=32768,compresslevel=0}
- subpart_templ_encoding_1_prt_p1             |      3 | {compresstype=none,blocksize=32768,compresslevel=0}
- subpart_templ_encoding_1_prt_p1             |      4 | {compresstype=none,blocksize=32768,compresslevel=0}
- subpart_templ_encoding_1_prt_p2             |      1 | {compresstype=none,blocksize=32768,compresslevel=0}
- subpart_templ_encoding_1_prt_p2             |      2 | {compresstype=none,blocksize=32768,compresslevel=0}
- subpart_templ_encoding_1_prt_p2             |      3 | {compresstype=none,blocksize=32768,compresslevel=0}
- subpart_templ_encoding_1_prt_p2             |      4 | {compresstype=none,blocksize=32768,compresslevel=0}
- subpart_templ_encoding_1_prt_p1_2_prt_sp1_1 |      1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- subpart_templ_encoding_1_prt_p1_2_prt_sp1_1 |      2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- subpart_templ_encoding_1_prt_p1_2_prt_sp1_1 |      3 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- subpart_templ_encoding_1_prt_p1_2_prt_sp1_1 |      4 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- subpart_templ_encoding_1_prt_p1_2_prt_sp1_2 |      1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- subpart_templ_encoding_1_prt_p1_2_prt_sp1_2 |      2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- subpart_templ_encoding_1_prt_p1_2_prt_sp1_2 |      3 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- subpart_templ_encoding_1_prt_p1_2_prt_sp1_2 |      4 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- subpart_templ_encoding_1_prt_p2_2_prt_sp1_1 |      1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- subpart_templ_encoding_1_prt_p2_2_prt_sp1_1 |      2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- subpart_templ_encoding_1_prt_p2_2_prt_sp1_1 |      3 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- subpart_templ_encoding_1_prt_p2_2_prt_sp1_1 |      4 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- subpart_templ_encoding_1_prt_p2_2_prt_sp1_2 |      1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- subpart_templ_encoding_1_prt_p2_2_prt_sp1_2 |      2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- subpart_templ_encoding_1_prt_p2_2_prt_sp1_2 |      3 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- subpart_templ_encoding_1_prt_p2_2_prt_sp1_2 |      4 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+                   relname                   | attnum | filenum |                       attoptions                        
+---------------------------------------------+--------+---------+---------------------------------------------------------
+ subpart_templ_encoding                      |      1 |       1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding                      |      2 |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding                      |      3 |       3 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding                      |      4 |       4 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p1             |      1 |       1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p1             |      2 |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p1             |      3 |       3 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p1             |      4 |       4 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p2             |      1 |       1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p2             |      2 |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p2             |      3 |       3 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p2             |      4 |       4 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p1_2_prt_sp1_1 |      1 |       1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ subpart_templ_encoding_1_prt_p1_2_prt_sp1_1 |      2 |       2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ subpart_templ_encoding_1_prt_p1_2_prt_sp1_1 |      3 |       3 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ subpart_templ_encoding_1_prt_p1_2_prt_sp1_1 |      4 |       4 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ subpart_templ_encoding_1_prt_p1_2_prt_sp1_2 |      1 |       1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ subpart_templ_encoding_1_prt_p1_2_prt_sp1_2 |      2 |       2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ subpart_templ_encoding_1_prt_p1_2_prt_sp1_2 |      3 |       3 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ subpart_templ_encoding_1_prt_p1_2_prt_sp1_2 |      4 |       4 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ subpart_templ_encoding_1_prt_p2_2_prt_sp1_1 |      1 |       1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ subpart_templ_encoding_1_prt_p2_2_prt_sp1_1 |      2 |       2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ subpart_templ_encoding_1_prt_p2_2_prt_sp1_1 |      3 |       3 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ subpart_templ_encoding_1_prt_p2_2_prt_sp1_1 |      4 |       4 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ subpart_templ_encoding_1_prt_p2_2_prt_sp1_2 |      1 |       1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ subpart_templ_encoding_1_prt_p2_2_prt_sp1_2 |      2 |       2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ subpart_templ_encoding_1_prt_p2_2_prt_sp1_2 |      3 |       3 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ subpart_templ_encoding_1_prt_p2_2_prt_sp1_2 |      4 |       4 | {compresstype=zlib,compresslevel=1,blocksize=32768}
 (28 rows)
 
 -- FIXME: the new partitions should have the encodings specified in the template
 ALTER TABLE subpart_templ_encoding ADD PARTITION p3 START (30) END (40);
 EXECUTE encoding_check;
-                   relname                   | attnum |                       attoptions                        
----------------------------------------------+--------+---------------------------------------------------------
- subpart_templ_encoding                      |      1 | {compresstype=none,blocksize=32768,compresslevel=0}
- subpart_templ_encoding                      |      2 | {compresstype=none,blocksize=32768,compresslevel=0}
- subpart_templ_encoding                      |      3 | {compresstype=none,blocksize=32768,compresslevel=0}
- subpart_templ_encoding                      |      4 | {compresstype=none,blocksize=32768,compresslevel=0}
- subpart_templ_encoding_1_prt_p1             |      1 | {compresstype=none,blocksize=32768,compresslevel=0}
- subpart_templ_encoding_1_prt_p1             |      2 | {compresstype=none,blocksize=32768,compresslevel=0}
- subpart_templ_encoding_1_prt_p1             |      3 | {compresstype=none,blocksize=32768,compresslevel=0}
- subpart_templ_encoding_1_prt_p1             |      4 | {compresstype=none,blocksize=32768,compresslevel=0}
- subpart_templ_encoding_1_prt_p2             |      1 | {compresstype=none,blocksize=32768,compresslevel=0}
- subpart_templ_encoding_1_prt_p2             |      2 | {compresstype=none,blocksize=32768,compresslevel=0}
- subpart_templ_encoding_1_prt_p2             |      3 | {compresstype=none,blocksize=32768,compresslevel=0}
- subpart_templ_encoding_1_prt_p2             |      4 | {compresstype=none,blocksize=32768,compresslevel=0}
- subpart_templ_encoding_1_prt_p1_2_prt_sp1_1 |      1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- subpart_templ_encoding_1_prt_p1_2_prt_sp1_1 |      2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- subpart_templ_encoding_1_prt_p1_2_prt_sp1_1 |      3 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- subpart_templ_encoding_1_prt_p1_2_prt_sp1_1 |      4 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- subpart_templ_encoding_1_prt_p1_2_prt_sp1_2 |      1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- subpart_templ_encoding_1_prt_p1_2_prt_sp1_2 |      2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- subpart_templ_encoding_1_prt_p1_2_prt_sp1_2 |      3 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- subpart_templ_encoding_1_prt_p1_2_prt_sp1_2 |      4 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- subpart_templ_encoding_1_prt_p2_2_prt_sp1_1 |      1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- subpart_templ_encoding_1_prt_p2_2_prt_sp1_1 |      2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- subpart_templ_encoding_1_prt_p2_2_prt_sp1_1 |      3 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- subpart_templ_encoding_1_prt_p2_2_prt_sp1_1 |      4 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- subpart_templ_encoding_1_prt_p2_2_prt_sp1_2 |      1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- subpart_templ_encoding_1_prt_p2_2_prt_sp1_2 |      2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- subpart_templ_encoding_1_prt_p2_2_prt_sp1_2 |      3 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- subpart_templ_encoding_1_prt_p2_2_prt_sp1_2 |      4 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- subpart_templ_encoding_1_prt_p3             |      1 | {compresstype=none,blocksize=32768,compresslevel=0}
- subpart_templ_encoding_1_prt_p3             |      2 | {compresstype=none,blocksize=32768,compresslevel=0}
- subpart_templ_encoding_1_prt_p3             |      3 | {compresstype=none,blocksize=32768,compresslevel=0}
- subpart_templ_encoding_1_prt_p3             |      4 | {compresstype=none,blocksize=32768,compresslevel=0}
- subpart_templ_encoding_1_prt_p3_2_prt_sp1_1 |      1 | {compresstype=none,blocksize=32768,compresslevel=0}
- subpart_templ_encoding_1_prt_p3_2_prt_sp1_1 |      2 | {compresstype=none,blocksize=32768,compresslevel=0}
- subpart_templ_encoding_1_prt_p3_2_prt_sp1_1 |      3 | {compresstype=none,blocksize=32768,compresslevel=0}
- subpart_templ_encoding_1_prt_p3_2_prt_sp1_1 |      4 | {compresstype=none,blocksize=32768,compresslevel=0}
- subpart_templ_encoding_1_prt_p3_2_prt_sp1_2 |      1 | {compresstype=none,blocksize=32768,compresslevel=0}
- subpart_templ_encoding_1_prt_p3_2_prt_sp1_2 |      2 | {compresstype=none,blocksize=32768,compresslevel=0}
- subpart_templ_encoding_1_prt_p3_2_prt_sp1_2 |      3 | {compresstype=none,blocksize=32768,compresslevel=0}
- subpart_templ_encoding_1_prt_p3_2_prt_sp1_2 |      4 | {compresstype=none,blocksize=32768,compresslevel=0}
+                   relname                   | attnum | filenum |                       attoptions                        
+---------------------------------------------+--------+---------+---------------------------------------------------------
+ subpart_templ_encoding                      |      1 |       1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding                      |      2 |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding                      |      3 |       3 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding                      |      4 |       4 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p1             |      1 |       1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p1             |      2 |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p1             |      3 |       3 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p1             |      4 |       4 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p2             |      1 |       1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p2             |      2 |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p2             |      3 |       3 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p2             |      4 |       4 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p1_2_prt_sp1_1 |      1 |       1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ subpart_templ_encoding_1_prt_p1_2_prt_sp1_1 |      2 |       2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ subpart_templ_encoding_1_prt_p1_2_prt_sp1_1 |      3 |       3 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ subpart_templ_encoding_1_prt_p1_2_prt_sp1_1 |      4 |       4 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ subpart_templ_encoding_1_prt_p1_2_prt_sp1_2 |      1 |       1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ subpart_templ_encoding_1_prt_p1_2_prt_sp1_2 |      2 |       2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ subpart_templ_encoding_1_prt_p1_2_prt_sp1_2 |      3 |       3 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ subpart_templ_encoding_1_prt_p1_2_prt_sp1_2 |      4 |       4 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ subpart_templ_encoding_1_prt_p2_2_prt_sp1_1 |      1 |       1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ subpart_templ_encoding_1_prt_p2_2_prt_sp1_1 |      2 |       2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ subpart_templ_encoding_1_prt_p2_2_prt_sp1_1 |      3 |       3 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ subpart_templ_encoding_1_prt_p2_2_prt_sp1_1 |      4 |       4 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ subpart_templ_encoding_1_prt_p2_2_prt_sp1_2 |      1 |       1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ subpart_templ_encoding_1_prt_p2_2_prt_sp1_2 |      2 |       2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ subpart_templ_encoding_1_prt_p2_2_prt_sp1_2 |      3 |       3 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ subpart_templ_encoding_1_prt_p2_2_prt_sp1_2 |      4 |       4 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ subpart_templ_encoding_1_prt_p3             |      1 |       1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p3             |      2 |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p3             |      3 |       3 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p3             |      4 |       4 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p3_2_prt_sp1_1 |      1 |       1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p3_2_prt_sp1_1 |      2 |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p3_2_prt_sp1_1 |      3 |       3 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p3_2_prt_sp1_1 |      4 |       4 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p3_2_prt_sp1_2 |      1 |       1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p3_2_prt_sp1_2 |      2 |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p3_2_prt_sp1_2 |      3 |       3 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p3_2_prt_sp1_2 |      4 |       4 | {compresstype=none,blocksize=32768,compresslevel=0}
 (40 rows)
 
 -- List partition with enclause
@@ -678,63 +678,63 @@ SELECT t.*, pg_get_expr(relpartbound, oid) FROM pg_partition_tree('subpart_templ
 (5 rows)
 
 EXECUTE encoding_check;
-                  relname                  | attnum |                       attoptions                        
--------------------------------------------+--------+---------------------------------------------------------
- subpart_templ_encoding                    |      1 | {compresstype=none,blocksize=32768,compresslevel=0}
- subpart_templ_encoding                    |      2 | {compresstype=none,blocksize=32768,compresslevel=0}
- subpart_templ_encoding                    |      3 | {compresstype=none,blocksize=32768,compresslevel=0}
- subpart_templ_encoding                    |      4 | {compresstype=none,blocksize=32768,compresslevel=0}
- subpart_templ_encoding_1_prt_p1           |      1 | {compresstype=none,blocksize=32768,compresslevel=0}
- subpart_templ_encoding_1_prt_p1           |      2 | {compresstype=none,blocksize=32768,compresslevel=0}
- subpart_templ_encoding_1_prt_p1           |      3 | {compresstype=none,blocksize=32768,compresslevel=0}
- subpart_templ_encoding_1_prt_p1           |      4 | {compresstype=none,blocksize=32768,compresslevel=0}
- subpart_templ_encoding_1_prt_p2           |      1 | {compresstype=none,blocksize=32768,compresslevel=0}
- subpart_templ_encoding_1_prt_p2           |      2 | {compresstype=none,blocksize=32768,compresslevel=0}
- subpart_templ_encoding_1_prt_p2           |      3 | {compresstype=none,blocksize=32768,compresslevel=0}
- subpart_templ_encoding_1_prt_p2           |      4 | {compresstype=none,blocksize=32768,compresslevel=0}
- subpart_templ_encoding_1_prt_p1_2_prt_sp1 |      1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- subpart_templ_encoding_1_prt_p1_2_prt_sp1 |      2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- subpart_templ_encoding_1_prt_p1_2_prt_sp1 |      3 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- subpart_templ_encoding_1_prt_p1_2_prt_sp1 |      4 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- subpart_templ_encoding_1_prt_p2_2_prt_sp1 |      1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- subpart_templ_encoding_1_prt_p2_2_prt_sp1 |      2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- subpart_templ_encoding_1_prt_p2_2_prt_sp1 |      3 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- subpart_templ_encoding_1_prt_p2_2_prt_sp1 |      4 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+                  relname                  | attnum | filenum |                       attoptions                        
+-------------------------------------------+--------+---------+---------------------------------------------------------
+ subpart_templ_encoding                    |      1 |       1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding                    |      2 |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding                    |      3 |       3 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding                    |      4 |       4 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p1           |      1 |       1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p1           |      2 |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p1           |      3 |       3 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p1           |      4 |       4 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p2           |      1 |       1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p2           |      2 |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p2           |      3 |       3 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p2           |      4 |       4 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p1_2_prt_sp1 |      1 |       1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ subpart_templ_encoding_1_prt_p1_2_prt_sp1 |      2 |       2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ subpart_templ_encoding_1_prt_p1_2_prt_sp1 |      3 |       3 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ subpart_templ_encoding_1_prt_p1_2_prt_sp1 |      4 |       4 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ subpart_templ_encoding_1_prt_p2_2_prt_sp1 |      1 |       1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ subpart_templ_encoding_1_prt_p2_2_prt_sp1 |      2 |       2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ subpart_templ_encoding_1_prt_p2_2_prt_sp1 |      3 |       3 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ subpart_templ_encoding_1_prt_p2_2_prt_sp1 |      4 |       4 | {compresstype=zlib,compresslevel=1,blocksize=32768}
 (20 rows)
 
 -- FIXME: the new partitions should have the encodings specified in the template
 ALTER TABLE subpart_templ_encoding ADD PARTITION p3 START (30) END (40);
 EXECUTE encoding_check;
-                  relname                  | attnum |                       attoptions                        
--------------------------------------------+--------+---------------------------------------------------------
- subpart_templ_encoding                    |      1 | {compresstype=none,blocksize=32768,compresslevel=0}
- subpart_templ_encoding                    |      2 | {compresstype=none,blocksize=32768,compresslevel=0}
- subpart_templ_encoding                    |      3 | {compresstype=none,blocksize=32768,compresslevel=0}
- subpart_templ_encoding                    |      4 | {compresstype=none,blocksize=32768,compresslevel=0}
- subpart_templ_encoding_1_prt_p1           |      1 | {compresstype=none,blocksize=32768,compresslevel=0}
- subpart_templ_encoding_1_prt_p1           |      2 | {compresstype=none,blocksize=32768,compresslevel=0}
- subpart_templ_encoding_1_prt_p1           |      3 | {compresstype=none,blocksize=32768,compresslevel=0}
- subpart_templ_encoding_1_prt_p1           |      4 | {compresstype=none,blocksize=32768,compresslevel=0}
- subpart_templ_encoding_1_prt_p2           |      1 | {compresstype=none,blocksize=32768,compresslevel=0}
- subpart_templ_encoding_1_prt_p2           |      2 | {compresstype=none,blocksize=32768,compresslevel=0}
- subpart_templ_encoding_1_prt_p2           |      3 | {compresstype=none,blocksize=32768,compresslevel=0}
- subpart_templ_encoding_1_prt_p2           |      4 | {compresstype=none,blocksize=32768,compresslevel=0}
- subpart_templ_encoding_1_prt_p1_2_prt_sp1 |      1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- subpart_templ_encoding_1_prt_p1_2_prt_sp1 |      2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- subpart_templ_encoding_1_prt_p1_2_prt_sp1 |      3 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- subpart_templ_encoding_1_prt_p1_2_prt_sp1 |      4 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- subpart_templ_encoding_1_prt_p2_2_prt_sp1 |      1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- subpart_templ_encoding_1_prt_p2_2_prt_sp1 |      2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- subpart_templ_encoding_1_prt_p2_2_prt_sp1 |      3 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- subpart_templ_encoding_1_prt_p2_2_prt_sp1 |      4 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- subpart_templ_encoding_1_prt_p3           |      1 | {compresstype=none,blocksize=32768,compresslevel=0}
- subpart_templ_encoding_1_prt_p3           |      2 | {compresstype=none,blocksize=32768,compresslevel=0}
- subpart_templ_encoding_1_prt_p3           |      3 | {compresstype=none,blocksize=32768,compresslevel=0}
- subpart_templ_encoding_1_prt_p3           |      4 | {compresstype=none,blocksize=32768,compresslevel=0}
- subpart_templ_encoding_1_prt_p3_2_prt_sp1 |      1 | {compresstype=none,blocksize=32768,compresslevel=0}
- subpart_templ_encoding_1_prt_p3_2_prt_sp1 |      2 | {compresstype=none,blocksize=32768,compresslevel=0}
- subpart_templ_encoding_1_prt_p3_2_prt_sp1 |      3 | {compresstype=none,blocksize=32768,compresslevel=0}
- subpart_templ_encoding_1_prt_p3_2_prt_sp1 |      4 | {compresstype=none,blocksize=32768,compresslevel=0}
+                  relname                  | attnum | filenum |                       attoptions                        
+-------------------------------------------+--------+---------+---------------------------------------------------------
+ subpart_templ_encoding                    |      1 |       1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding                    |      2 |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding                    |      3 |       3 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding                    |      4 |       4 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p1           |      1 |       1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p1           |      2 |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p1           |      3 |       3 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p1           |      4 |       4 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p2           |      1 |       1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p2           |      2 |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p2           |      3 |       3 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p2           |      4 |       4 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p1_2_prt_sp1 |      1 |       1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ subpart_templ_encoding_1_prt_p1_2_prt_sp1 |      2 |       2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ subpart_templ_encoding_1_prt_p1_2_prt_sp1 |      3 |       3 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ subpart_templ_encoding_1_prt_p1_2_prt_sp1 |      4 |       4 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ subpart_templ_encoding_1_prt_p2_2_prt_sp1 |      1 |       1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ subpart_templ_encoding_1_prt_p2_2_prt_sp1 |      2 |       2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ subpart_templ_encoding_1_prt_p2_2_prt_sp1 |      3 |       3 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ subpart_templ_encoding_1_prt_p2_2_prt_sp1 |      4 |       4 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ subpart_templ_encoding_1_prt_p3           |      1 |       1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p3           |      2 |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p3           |      3 |       3 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p3           |      4 |       4 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p3_2_prt_sp1 |      1 |       1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p3_2_prt_sp1 |      2 |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p3_2_prt_sp1 |      3 |       3 | {compresstype=none,blocksize=32768,compresslevel=0}
+ subpart_templ_encoding_1_prt_p3_2_prt_sp1 |      4 |       4 | {compresstype=none,blocksize=32768,compresslevel=0}
 (28 rows)
 
 -- Partition specific ENCODING clause is not supported in SUBPARTITION TEMPLATE

--- a/src/test/regress/expected/partition.out
+++ b/src/test/regress/expected/partition.out
@@ -5795,38 +5795,38 @@ select relname, pg_get_expr(relpartbound, oid) from pg_class where relname like 
  pt_tab_encode_1_prt_s_xyz | FOR VALUES IN ('xyz')
 (3 rows)
 
-select gp_segment_id, attrelid::regclass, attnum, attoptions from pg_attribute_encoding where attrelid = 'pt_tab_encode_1_prt_s_abc'::regclass;
- gp_segment_id |         attrelid          | attnum |                     attoptions                      
----------------+---------------------------+--------+-----------------------------------------------------
-            -1 | pt_tab_encode_1_prt_s_abc |      1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
-            -1 | pt_tab_encode_1_prt_s_abc |      2 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+select gp_segment_id, attrelid::regclass, attnum, filenum, attoptions from pg_attribute_encoding where attrelid = 'pt_tab_encode_1_prt_s_abc'::regclass;
+ gp_segment_id |         attrelid          | attnum | filenum |                     attoptions                      
+---------------+---------------------------+--------+---------+-----------------------------------------------------
+            -1 | pt_tab_encode_1_prt_s_abc |      1 |       1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+            -1 | pt_tab_encode_1_prt_s_abc |      2 |       2 | {compresstype=zlib,compresslevel=1,blocksize=32768}
 (2 rows)
 
-select gp_segment_id, attrelid::regclass, attnum, attoptions from gp_dist_random('pg_attribute_encoding') where attrelid = 'pt_tab_encode_1_prt_s_abc'::regclass order by 1,3 limit 5;
- gp_segment_id |         attrelid          | attnum |                     attoptions                      
----------------+---------------------------+--------+-----------------------------------------------------
-             0 | pt_tab_encode_1_prt_s_abc |      1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
-             0 | pt_tab_encode_1_prt_s_abc |      2 | {compresstype=zlib,compresslevel=1,blocksize=32768}
-             1 | pt_tab_encode_1_prt_s_abc |      1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
-             1 | pt_tab_encode_1_prt_s_abc |      2 | {compresstype=zlib,compresslevel=1,blocksize=32768}
-             2 | pt_tab_encode_1_prt_s_abc |      1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+select gp_segment_id, attrelid::regclass, attnum, filenum, attoptions from gp_dist_random('pg_attribute_encoding') where attrelid = 'pt_tab_encode_1_prt_s_abc'::regclass order by 1,3 limit 5;
+ gp_segment_id |         attrelid          | attnum | filenum |                     attoptions                      
+---------------+---------------------------+--------+---------+-----------------------------------------------------
+             0 | pt_tab_encode_1_prt_s_abc |      1 |       1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+             0 | pt_tab_encode_1_prt_s_abc |      2 |       2 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+             1 | pt_tab_encode_1_prt_s_abc |      1 |       1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+             1 | pt_tab_encode_1_prt_s_abc |      2 |       2 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+             2 | pt_tab_encode_1_prt_s_abc |      1 |       1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
 (5 rows)
 
-select gp_segment_id, attrelid::regclass, attnum, attoptions from pg_attribute_encoding where attrelid = 'pt_tab_encode_1_prt_s_xyz'::regclass;
- gp_segment_id |         attrelid          | attnum |                     attoptions                      
----------------+---------------------------+--------+-----------------------------------------------------
-            -1 | pt_tab_encode_1_prt_s_xyz |      1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
-            -1 | pt_tab_encode_1_prt_s_xyz |      2 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+select gp_segment_id, attrelid::regclass, attnum, filenum, attoptions from pg_attribute_encoding where attrelid = 'pt_tab_encode_1_prt_s_xyz'::regclass;
+ gp_segment_id |         attrelid          | attnum | filenum |                     attoptions                      
+---------------+---------------------------+--------+---------+-----------------------------------------------------
+            -1 | pt_tab_encode_1_prt_s_xyz |      1 |       1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+            -1 | pt_tab_encode_1_prt_s_xyz |      2 |       2 | {compresstype=zlib,compresslevel=1,blocksize=32768}
 (2 rows)
 
-select gp_segment_id, attrelid::regclass, attnum, attoptions from gp_dist_random('pg_attribute_encoding') where attrelid = 'pt_tab_encode_1_prt_s_xyz'::regclass order by 1,3 limit 5;
- gp_segment_id |         attrelid          | attnum |                     attoptions                      
----------------+---------------------------+--------+-----------------------------------------------------
-             0 | pt_tab_encode_1_prt_s_xyz |      1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
-             0 | pt_tab_encode_1_prt_s_xyz |      2 | {compresstype=zlib,compresslevel=1,blocksize=32768}
-             1 | pt_tab_encode_1_prt_s_xyz |      1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
-             1 | pt_tab_encode_1_prt_s_xyz |      2 | {compresstype=zlib,compresslevel=1,blocksize=32768}
-             2 | pt_tab_encode_1_prt_s_xyz |      1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+select gp_segment_id, attrelid::regclass, attnum, filenum, attoptions from gp_dist_random('pg_attribute_encoding') where attrelid = 'pt_tab_encode_1_prt_s_xyz'::regclass order by 1,3 limit 5;
+ gp_segment_id |         attrelid          | attnum | filenum |                     attoptions                      
+---------------+---------------------------+--------+---------+-----------------------------------------------------
+             0 | pt_tab_encode_1_prt_s_xyz |      1 |       1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+             0 | pt_tab_encode_1_prt_s_xyz |      2 |       2 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+             1 | pt_tab_encode_1_prt_s_xyz |      1 |       1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+             1 | pt_tab_encode_1_prt_s_xyz |      2 |       2 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+             2 | pt_tab_encode_1_prt_s_xyz |      1 |       1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
 (5 rows)
 
 select c.oid::regclass, relkind, amname, reloptions from pg_class c left join pg_am am on am.oid = relam where c.oid = 'pt_tab_encode_1_prt_s_abc'::regclass;

--- a/src/test/regress/expected/partition_optimizer.out
+++ b/src/test/regress/expected/partition_optimizer.out
@@ -5785,38 +5785,38 @@ select relname, pg_get_expr(relpartbound, oid) from pg_class where relname like 
  pt_tab_encode_1_prt_s_xyz | FOR VALUES IN ('xyz')
 (3 rows)
 
-select gp_segment_id, attrelid::regclass, attnum, attoptions from pg_attribute_encoding where attrelid = 'pt_tab_encode_1_prt_s_abc'::regclass;
- gp_segment_id |         attrelid          | attnum |                     attoptions                      
----------------+---------------------------+--------+-----------------------------------------------------
-            -1 | pt_tab_encode_1_prt_s_abc |      1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
-            -1 | pt_tab_encode_1_prt_s_abc |      2 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+select gp_segment_id, attrelid::regclass, attnum, filenum, attoptions from pg_attribute_encoding where attrelid = 'pt_tab_encode_1_prt_s_abc'::regclass;
+ gp_segment_id |         attrelid          | attnum | filenum |                     attoptions                      
+---------------+---------------------------+--------+---------+-----------------------------------------------------
+            -1 | pt_tab_encode_1_prt_s_abc |      1 |       1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+            -1 | pt_tab_encode_1_prt_s_abc |      2 |       2 | {compresstype=zlib,compresslevel=1,blocksize=32768}
 (2 rows)
 
-select gp_segment_id, attrelid::regclass, attnum, attoptions from gp_dist_random('pg_attribute_encoding') where attrelid = 'pt_tab_encode_1_prt_s_abc'::regclass order by 1,3 limit 5;
- gp_segment_id |         attrelid          | attnum |                     attoptions                      
----------------+---------------------------+--------+-----------------------------------------------------
-             0 | pt_tab_encode_1_prt_s_abc |      1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
-             0 | pt_tab_encode_1_prt_s_abc |      2 | {compresstype=zlib,compresslevel=1,blocksize=32768}
-             1 | pt_tab_encode_1_prt_s_abc |      1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
-             1 | pt_tab_encode_1_prt_s_abc |      2 | {compresstype=zlib,compresslevel=1,blocksize=32768}
-             2 | pt_tab_encode_1_prt_s_abc |      1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+select gp_segment_id, attrelid::regclass, attnum, filenum, attoptions from gp_dist_random('pg_attribute_encoding') where attrelid = 'pt_tab_encode_1_prt_s_abc'::regclass order by 1,3 limit 5;
+ gp_segment_id |         attrelid          | attnum | filenum |                     attoptions                      
+---------------+---------------------------+--------+---------+-----------------------------------------------------
+             0 | pt_tab_encode_1_prt_s_abc |      1 |       1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+             0 | pt_tab_encode_1_prt_s_abc |      2 |       2 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+             1 | pt_tab_encode_1_prt_s_abc |      1 |       1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+             1 | pt_tab_encode_1_prt_s_abc |      2 |       2 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+             2 | pt_tab_encode_1_prt_s_abc |      1 |       1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
 (5 rows)
 
-select gp_segment_id, attrelid::regclass, attnum, attoptions from pg_attribute_encoding where attrelid = 'pt_tab_encode_1_prt_s_xyz'::regclass;
- gp_segment_id |         attrelid          | attnum |                     attoptions                      
----------------+---------------------------+--------+-----------------------------------------------------
-            -1 | pt_tab_encode_1_prt_s_xyz |      1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
-            -1 | pt_tab_encode_1_prt_s_xyz |      2 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+select gp_segment_id, attrelid::regclass, attnum, filenum, attoptions from pg_attribute_encoding where attrelid = 'pt_tab_encode_1_prt_s_xyz'::regclass;
+ gp_segment_id |         attrelid          | attnum | filenum |                     attoptions                      
+---------------+---------------------------+--------+---------+-----------------------------------------------------
+            -1 | pt_tab_encode_1_prt_s_xyz |      1 |       1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+            -1 | pt_tab_encode_1_prt_s_xyz |      2 |       2 | {compresstype=zlib,compresslevel=1,blocksize=32768}
 (2 rows)
 
-select gp_segment_id, attrelid::regclass, attnum, attoptions from gp_dist_random('pg_attribute_encoding') where attrelid = 'pt_tab_encode_1_prt_s_xyz'::regclass order by 1,3 limit 5;
- gp_segment_id |         attrelid          | attnum |                     attoptions                      
----------------+---------------------------+--------+-----------------------------------------------------
-             0 | pt_tab_encode_1_prt_s_xyz |      1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
-             0 | pt_tab_encode_1_prt_s_xyz |      2 | {compresstype=zlib,compresslevel=1,blocksize=32768}
-             1 | pt_tab_encode_1_prt_s_xyz |      1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
-             1 | pt_tab_encode_1_prt_s_xyz |      2 | {compresstype=zlib,compresslevel=1,blocksize=32768}
-             2 | pt_tab_encode_1_prt_s_xyz |      1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+select gp_segment_id, attrelid::regclass, attnum, filenum, attoptions from gp_dist_random('pg_attribute_encoding') where attrelid = 'pt_tab_encode_1_prt_s_xyz'::regclass order by 1,3 limit 5;
+ gp_segment_id |         attrelid          | attnum | filenum |                     attoptions                      
+---------------+---------------------------+--------+---------+-----------------------------------------------------
+             0 | pt_tab_encode_1_prt_s_xyz |      1 |       1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+             0 | pt_tab_encode_1_prt_s_xyz |      2 |       2 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+             1 | pt_tab_encode_1_prt_s_xyz |      1 |       1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+             1 | pt_tab_encode_1_prt_s_xyz |      2 |       2 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+             2 | pt_tab_encode_1_prt_s_xyz |      1 |       1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
 (5 rows)
 
 select c.oid::regclass, relkind, amname, reloptions from pg_class c left join pg_am am on am.oid = relam where c.oid = 'pt_tab_encode_1_prt_s_abc'::regclass;

--- a/src/test/regress/expected/rle_delta.out
+++ b/src/test/regress/expected/rle_delta.out
@@ -23,16 +23,16 @@ Create table delta_all(
     ) with(appendonly=true, orientation=column);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a1' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-select attrelid::regclass as relname, attnum, attoptions from pg_class c, pg_attribute_encoding e  where c.relname = 'delta_all'  and c.oid=e.attrelid  order by relname, attnum;
-  relname  | attnum |                       attoptions                        
------------+--------+---------------------------------------------------------
- delta_all |      1 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- delta_all |      2 | {compresstype=rle_type,compresslevel=2,blocksize=32768}
- delta_all |      3 | {compresstype=rle_type,compresslevel=3,blocksize=32768}
- delta_all |      4 | {compresstype=rle_type,compresslevel=4,blocksize=32768}
- delta_all |      5 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- delta_all |      6 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- delta_all |      7 | {compresstype=rle_type,compresslevel=4,blocksize=32768}
+select attrelid::regclass as relname, attnum, filenum, attoptions from pg_class c, pg_attribute_encoding e  where c.relname = 'delta_all'  and c.oid=e.attrelid  order by relname, attnum;
+  relname  | attnum | filenum |                       attoptions                        
+-----------+--------+---------+---------------------------------------------------------
+ delta_all |      1 |       1 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ delta_all |      2 |       2 | {compresstype=rle_type,compresslevel=2,blocksize=32768}
+ delta_all |      3 |       3 | {compresstype=rle_type,compresslevel=3,blocksize=32768}
+ delta_all |      4 |       4 | {compresstype=rle_type,compresslevel=4,blocksize=32768}
+ delta_all |      5 |       5 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ delta_all |      6 |       6 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ delta_all |      7 |       7 | {compresstype=rle_type,compresslevel=4,blocksize=32768}
 (7 rows)
 
 \d+ delta_all
@@ -127,17 +127,17 @@ Create table delta_alter(
     ) with(appendonly=true, orientation=column);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'id' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-select attrelid::regclass as relname, attnum, attoptions from pg_class c, pg_attribute_encoding e  where c.relname = 'delta_alter'  and c.oid=e.attrelid  order by relname, attnum;
-   relname   | attnum |                       attoptions                        
--------------+--------+---------------------------------------------------------
- delta_alter |      1 | {compresstype=none,blocksize=32768,compresslevel=0}
- delta_alter |      2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- delta_alter |      3 | {compresstype=rle_type,compresslevel=2,blocksize=32768}
- delta_alter |      4 | {compresstype=rle_type,compresslevel=3,blocksize=32768}
- delta_alter |      5 | {compresstype=rle_type,compresslevel=4,blocksize=32768}
- delta_alter |      6 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- delta_alter |      7 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- delta_alter |      8 | {compresstype=rle_type,compresslevel=4,blocksize=32768}
+select attrelid::regclass as relname, attnum, filenum, attoptions from pg_class c, pg_attribute_encoding e  where c.relname = 'delta_alter'  and c.oid=e.attrelid  order by relname, attnum;
+   relname   | attnum | filenum |                       attoptions                        
+-------------+--------+---------+---------------------------------------------------------
+ delta_alter |      1 |       1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ delta_alter |      2 |       2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ delta_alter |      3 |       3 | {compresstype=rle_type,compresslevel=2,blocksize=32768}
+ delta_alter |      4 |       4 | {compresstype=rle_type,compresslevel=3,blocksize=32768}
+ delta_alter |      5 |       5 | {compresstype=rle_type,compresslevel=4,blocksize=32768}
+ delta_alter |      6 |       6 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ delta_alter |      7 |       7 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ delta_alter |      8 |       8 | {compresstype=rle_type,compresslevel=4,blocksize=32768}
 (8 rows)
 
 \d+ delta_alter
@@ -281,16 +281,16 @@ Create table delta_bitmap_ins(
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a1' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 Create index dl_ix_bt on  delta_bitmap_ins using bitmap(a1);
-select attrelid::regclass as relname, attnum, attoptions from pg_class c, pg_attribute_encoding e  where c.relname = 'delta_bitmap_ins'  and c.oid=e.attrelid  order by relname, attnum;
-     relname      | attnum |                       attoptions                        
-------------------+--------+---------------------------------------------------------
- delta_bitmap_ins |      1 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- delta_bitmap_ins |      2 | {compresstype=rle_type,compresslevel=2,blocksize=32768}
- delta_bitmap_ins |      3 | {compresstype=rle_type,compresslevel=3,blocksize=32768}
- delta_bitmap_ins |      4 | {compresstype=rle_type,compresslevel=4,blocksize=32768}
- delta_bitmap_ins |      5 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- delta_bitmap_ins |      6 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- delta_bitmap_ins |      7 | {compresstype=rle_type,compresslevel=4,blocksize=32768}
+select attrelid::regclass as relname, attnum, filenum, attoptions from pg_class c, pg_attribute_encoding e  where c.relname = 'delta_bitmap_ins'  and c.oid=e.attrelid  order by relname, attnum;
+     relname      | attnum | filenum |                       attoptions                        
+------------------+--------+---------+---------------------------------------------------------
+ delta_bitmap_ins |      1 |       1 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ delta_bitmap_ins |      2 |       2 | {compresstype=rle_type,compresslevel=2,blocksize=32768}
+ delta_bitmap_ins |      3 |       3 | {compresstype=rle_type,compresslevel=3,blocksize=32768}
+ delta_bitmap_ins |      4 |       4 | {compresstype=rle_type,compresslevel=4,blocksize=32768}
+ delta_bitmap_ins |      5 |       5 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ delta_bitmap_ins |      6 |       6 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ delta_bitmap_ins |      7 |       7 | {compresstype=rle_type,compresslevel=4,blocksize=32768}
 (7 rows)
 
 \d+ delta_bitmap_ins
@@ -361,16 +361,16 @@ Create table delta_btree_ins(
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a1' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 Create index dl_ix_br on  delta_btree_ins(a1);
-select attrelid::regclass as relname, attnum, attoptions from pg_class c, pg_attribute_encoding e  where c.relname = 'delta_btree_ins'  and c.oid=e.attrelid  order by relname, attnum;
-     relname     | attnum |                       attoptions                        
------------------+--------+---------------------------------------------------------
- delta_btree_ins |      1 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- delta_btree_ins |      2 | {compresstype=rle_type,compresslevel=2,blocksize=32768}
- delta_btree_ins |      3 | {compresstype=rle_type,compresslevel=3,blocksize=32768}
- delta_btree_ins |      4 | {compresstype=rle_type,compresslevel=4,blocksize=32768}
- delta_btree_ins |      5 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- delta_btree_ins |      6 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- delta_btree_ins |      7 | {compresstype=rle_type,compresslevel=4,blocksize=32768}
+select attrelid::regclass as relname, attnum, filenum, attoptions from pg_class c, pg_attribute_encoding e  where c.relname = 'delta_btree_ins'  and c.oid=e.attrelid  order by relname, attnum;
+     relname     | attnum | filenum |                       attoptions                        
+-----------------+--------+---------+---------------------------------------------------------
+ delta_btree_ins |      1 |       1 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ delta_btree_ins |      2 |       2 | {compresstype=rle_type,compresslevel=2,blocksize=32768}
+ delta_btree_ins |      3 |       3 | {compresstype=rle_type,compresslevel=3,blocksize=32768}
+ delta_btree_ins |      4 |       4 | {compresstype=rle_type,compresslevel=4,blocksize=32768}
+ delta_btree_ins |      5 |       5 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ delta_btree_ins |      6 |       6 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ delta_btree_ins |      7 |       7 | {compresstype=rle_type,compresslevel=4,blocksize=32768}
 (7 rows)
 
 \d+ delta_btree_ins
@@ -440,16 +440,16 @@ Create table delta_ins_bitmap(
     ) with(appendonly=true, orientation=column);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a1' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-select attrelid::regclass as relname, attnum, attoptions from pg_class c, pg_attribute_encoding e  where c.relname = 'delta_ins_bitmap'  and c.oid=e.attrelid  order by relname, attnum;
-     relname      | attnum |                       attoptions                        
-------------------+--------+---------------------------------------------------------
- delta_ins_bitmap |      1 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- delta_ins_bitmap |      2 | {compresstype=rle_type,compresslevel=2,blocksize=32768}
- delta_ins_bitmap |      3 | {compresstype=rle_type,compresslevel=3,blocksize=32768}
- delta_ins_bitmap |      4 | {compresstype=rle_type,compresslevel=4,blocksize=32768}
- delta_ins_bitmap |      5 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- delta_ins_bitmap |      6 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- delta_ins_bitmap |      7 | {compresstype=rle_type,compresslevel=4,blocksize=32768}
+select attrelid::regclass as relname, attnum, filenum, attoptions from pg_class c, pg_attribute_encoding e  where c.relname = 'delta_ins_bitmap'  and c.oid=e.attrelid  order by relname, attnum;
+     relname      | attnum | filenum |                       attoptions                        
+------------------+--------+---------+---------------------------------------------------------
+ delta_ins_bitmap |      1 |       1 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ delta_ins_bitmap |      2 |       2 | {compresstype=rle_type,compresslevel=2,blocksize=32768}
+ delta_ins_bitmap |      3 |       3 | {compresstype=rle_type,compresslevel=3,blocksize=32768}
+ delta_ins_bitmap |      4 |       4 | {compresstype=rle_type,compresslevel=4,blocksize=32768}
+ delta_ins_bitmap |      5 |       5 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ delta_ins_bitmap |      6 |       6 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ delta_ins_bitmap |      7 |       7 | {compresstype=rle_type,compresslevel=4,blocksize=32768}
 (7 rows)
 
 \d+ delta_ins_bitmap
@@ -535,16 +535,16 @@ Create table delta_ins_btree(
     ) with(appendonly=true, orientation=column);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a1' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-select attrelid::regclass as relname, attnum, attoptions from pg_class c, pg_attribute_encoding e  where c.relname = 'delta_ins_btree'  and c.oid=e.attrelid  order by relname, attnum;
-     relname     | attnum |                       attoptions                        
------------------+--------+---------------------------------------------------------
- delta_ins_btree |      1 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- delta_ins_btree |      2 | {compresstype=rle_type,compresslevel=2,blocksize=32768}
- delta_ins_btree |      3 | {compresstype=rle_type,compresslevel=3,blocksize=32768}
- delta_ins_btree |      4 | {compresstype=rle_type,compresslevel=4,blocksize=32768}
- delta_ins_btree |      5 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- delta_ins_btree |      6 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- delta_ins_btree |      7 | {compresstype=rle_type,compresslevel=4,blocksize=32768}
+select attrelid::regclass as relname, attnum, filenum, attoptions from pg_class c, pg_attribute_encoding e  where c.relname = 'delta_ins_btree'  and c.oid=e.attrelid  order by relname, attnum;
+     relname     | attnum | filenum |                       attoptions                        
+-----------------+--------+---------+---------------------------------------------------------
+ delta_ins_btree |      1 |       1 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ delta_ins_btree |      2 |       2 | {compresstype=rle_type,compresslevel=2,blocksize=32768}
+ delta_ins_btree |      3 |       3 | {compresstype=rle_type,compresslevel=3,blocksize=32768}
+ delta_ins_btree |      4 |       4 | {compresstype=rle_type,compresslevel=4,blocksize=32768}
+ delta_ins_btree |      5 |       5 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ delta_ins_btree |      6 |       6 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ delta_ins_btree |      7 |       7 | {compresstype=rle_type,compresslevel=4,blocksize=32768}
 (7 rows)
 
 \d+ delta_ins_btree
@@ -703,18 +703,18 @@ Create table delta_none(
     ) with(appendonly=true, orientation=column);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a1' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-select attrelid::regclass as relname, attnum, attoptions from pg_class c, pg_attribute_encoding e  where c.relname = 'delta_none'  and c.oid=e.attrelid  order by relname, attnum;
-  relname   | attnum |                       attoptions                        
-------------+--------+---------------------------------------------------------
- delta_none |      1 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- delta_none |      2 | {compresstype=none,compresslevel=0,blocksize=32768}
- delta_none |      3 | {compresstype=rle_type,compresslevel=2,blocksize=32768}
- delta_none |      4 | {compresstype=rle_type,compresslevel=3,blocksize=32768}
- delta_none |      5 | {compresstype=none,blocksize=32768,compresslevel=0}
- delta_none |      6 | {compresstype=none,compresslevel=0,blocksize=32768}
- delta_none |      7 | {compresstype=rle_type,compresslevel=4,blocksize=32768}
- delta_none |      8 | {compresstype=none,blocksize=32768,compresslevel=0}
- delta_none |      9 | {compresstype=rle_type,compresslevel=2,blocksize=32768}
+select attrelid::regclass as relname, attnum, filenum, attoptions from pg_class c, pg_attribute_encoding e  where c.relname = 'delta_none'  and c.oid=e.attrelid  order by relname, attnum;
+  relname   | attnum | filenum |                       attoptions                        
+------------+--------+---------+---------------------------------------------------------
+ delta_none |      1 |       1 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ delta_none |      2 |       2 | {compresstype=none,compresslevel=0,blocksize=32768}
+ delta_none |      3 |       3 | {compresstype=rle_type,compresslevel=2,blocksize=32768}
+ delta_none |      4 |       4 | {compresstype=rle_type,compresslevel=3,blocksize=32768}
+ delta_none |      5 |       5 | {compresstype=none,blocksize=32768,compresslevel=0}
+ delta_none |      6 |       6 | {compresstype=none,compresslevel=0,blocksize=32768}
+ delta_none |      7 |       7 | {compresstype=rle_type,compresslevel=4,blocksize=32768}
+ delta_none |      8 |       8 | {compresstype=none,blocksize=32768,compresslevel=0}
+ delta_none |      9 |       9 | {compresstype=rle_type,compresslevel=2,blocksize=32768}
 (9 rows)
 
 \d+ delta_none
@@ -1066,18 +1066,18 @@ Create table delta_zlib(
     ) with(appendonly=true, orientation=column);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a1' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-select attrelid::regclass as relname, attnum, attoptions from pg_class c, pg_attribute_encoding e  where c.relname = 'delta_zlib'  and c.oid=e.attrelid  order by relname, attnum;
-  relname   | attnum |                       attoptions                        
-------------+--------+---------------------------------------------------------
- delta_zlib |      1 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- delta_zlib |      2 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- delta_zlib |      3 | {compresstype=zlib,compresslevel=2,blocksize=32768}
- delta_zlib |      4 | {compresstype=zlib,compresslevel=3,blocksize=32768}
- delta_zlib |      5 | {compresstype=zlib,compresslevel=4,blocksize=32768}
- delta_zlib |      6 | {compresstype=zlib,compresslevel=5,blocksize=32768}
- delta_zlib |      7 | {compresstype=zlib,compresslevel=6,blocksize=32768}
- delta_zlib |      8 | {compresstype=zlib,compresslevel=7,blocksize=32768}
- delta_zlib |      9 | {compresstype=rle_type,compresslevel=2,blocksize=32768}
+select attrelid::regclass as relname, attnum, filenum, attoptions from pg_class c, pg_attribute_encoding e  where c.relname = 'delta_zlib'  and c.oid=e.attrelid  order by relname, attnum;
+  relname   | attnum | filenum |                       attoptions                        
+------------+--------+---------+---------------------------------------------------------
+ delta_zlib |      1 |       1 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ delta_zlib |      2 |       2 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ delta_zlib |      3 |       3 | {compresstype=zlib,compresslevel=2,blocksize=32768}
+ delta_zlib |      4 |       4 | {compresstype=zlib,compresslevel=3,blocksize=32768}
+ delta_zlib |      5 |       5 | {compresstype=zlib,compresslevel=4,blocksize=32768}
+ delta_zlib |      6 |       6 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ delta_zlib |      7 |       7 | {compresstype=zlib,compresslevel=6,blocksize=32768}
+ delta_zlib |      8 |       8 | {compresstype=zlib,compresslevel=7,blocksize=32768}
+ delta_zlib |      9 |       9 | {compresstype=rle_type,compresslevel=2,blocksize=32768}
 (9 rows)
 
 \d+ delta_zlib
@@ -1169,15 +1169,15 @@ Create table rle_type_1_delta_null(
     ) with(appendonly=true, orientation=column, compresstype=rle_type, compresslevel=1);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a1' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-select attrelid::regclass as relname, attnum, attoptions from pg_class c, pg_attribute_encoding e  where c.relname = 'rle_type_1_delta_null'  and c.oid=e.attrelid  order by relname, attnum;
-        relname        | attnum |                       attoptions                        
------------------------+--------+---------------------------------------------------------
- rle_type_1_delta_null |      1 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- rle_type_1_delta_null |      2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- rle_type_1_delta_null |      3 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- rle_type_1_delta_null |      4 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- rle_type_1_delta_null |      5 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
- rle_type_1_delta_null |      6 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+select attrelid::regclass as relname, attnum, filenum, attoptions from pg_class c, pg_attribute_encoding e  where c.relname = 'rle_type_1_delta_null'  and c.oid=e.attrelid  order by relname, attnum;
+        relname        | attnum | filenum |                       attoptions                        
+-----------------------+--------+---------+---------------------------------------------------------
+ rle_type_1_delta_null |      1 |       1 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ rle_type_1_delta_null |      2 |       2 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ rle_type_1_delta_null |      3 |       3 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ rle_type_1_delta_null |      4 |       4 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ rle_type_1_delta_null |      5 |       5 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+ rle_type_1_delta_null |      6 |       6 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
 (6 rows)
 
 \d+ rle_type_1_delta_null
@@ -1267,15 +1267,15 @@ Create table rle_type_2_delta_chkt(
     ) with(appendonly=true, orientation=column, compresstype=rle_type, compresslevel=2, checksum=true);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a1' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-select attrelid::regclass as relname, attnum, attoptions from pg_class c, pg_attribute_encoding e  where c.relname = 'rle_type_2_delta_chkt'  and c.oid=e.attrelid  order by relname, attnum;
-        relname        | attnum |                       attoptions                        
------------------------+--------+---------------------------------------------------------
- rle_type_2_delta_chkt |      1 | {compresstype=rle_type,compresslevel=2,blocksize=32768}
- rle_type_2_delta_chkt |      2 | {compresstype=rle_type,compresslevel=2,blocksize=32768}
- rle_type_2_delta_chkt |      3 | {compresstype=rle_type,compresslevel=2,blocksize=32768}
- rle_type_2_delta_chkt |      4 | {compresstype=rle_type,compresslevel=2,blocksize=32768}
- rle_type_2_delta_chkt |      5 | {compresstype=rle_type,compresslevel=2,blocksize=32768}
- rle_type_2_delta_chkt |      6 | {compresstype=rle_type,compresslevel=2,blocksize=32768}
+select attrelid::regclass as relname, attnum, filenum, attoptions from pg_class c, pg_attribute_encoding e  where c.relname = 'rle_type_2_delta_chkt'  and c.oid=e.attrelid  order by relname, attnum;
+        relname        | attnum | filenum |                       attoptions                        
+-----------------------+--------+---------+---------------------------------------------------------
+ rle_type_2_delta_chkt |      1 |       1 | {compresstype=rle_type,compresslevel=2,blocksize=32768}
+ rle_type_2_delta_chkt |      2 |       2 | {compresstype=rle_type,compresslevel=2,blocksize=32768}
+ rle_type_2_delta_chkt |      3 |       3 | {compresstype=rle_type,compresslevel=2,blocksize=32768}
+ rle_type_2_delta_chkt |      4 |       4 | {compresstype=rle_type,compresslevel=2,blocksize=32768}
+ rle_type_2_delta_chkt |      5 |       5 | {compresstype=rle_type,compresslevel=2,blocksize=32768}
+ rle_type_2_delta_chkt |      6 |       6 | {compresstype=rle_type,compresslevel=2,blocksize=32768}
 (6 rows)
 
 \d+ rle_type_2_delta_chkt
@@ -1332,15 +1332,15 @@ Create table rle_type_2_delta_chkf(
     ) with(appendonly=true, orientation=column, compresstype=rle_type, compresslevel=2, checksum=false);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a1' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-select attrelid::regclass as relname, attnum, attoptions from pg_class c, pg_attribute_encoding e  where c.relname = 'rle_type_2_delta_chkf'  and c.oid=e.attrelid  order by relname, attnum;
-        relname        | attnum |                       attoptions                        
------------------------+--------+---------------------------------------------------------
- rle_type_2_delta_chkf |      1 | {compresstype=rle_type,compresslevel=2,blocksize=32768}
- rle_type_2_delta_chkf |      2 | {compresstype=rle_type,compresslevel=2,blocksize=32768}
- rle_type_2_delta_chkf |      3 | {compresstype=rle_type,compresslevel=2,blocksize=32768}
- rle_type_2_delta_chkf |      4 | {compresstype=rle_type,compresslevel=2,blocksize=32768}
- rle_type_2_delta_chkf |      5 | {compresstype=rle_type,compresslevel=2,blocksize=32768}
- rle_type_2_delta_chkf |      6 | {compresstype=rle_type,compresslevel=2,blocksize=32768}
+select attrelid::regclass as relname, attnum, filenum, attoptions from pg_class c, pg_attribute_encoding e  where c.relname = 'rle_type_2_delta_chkf'  and c.oid=e.attrelid  order by relname, attnum;
+        relname        | attnum | filenum |                       attoptions                        
+-----------------------+--------+---------+---------------------------------------------------------
+ rle_type_2_delta_chkf |      1 |       1 | {compresstype=rle_type,compresslevel=2,blocksize=32768}
+ rle_type_2_delta_chkf |      2 |       2 | {compresstype=rle_type,compresslevel=2,blocksize=32768}
+ rle_type_2_delta_chkf |      3 |       3 | {compresstype=rle_type,compresslevel=2,blocksize=32768}
+ rle_type_2_delta_chkf |      4 |       4 | {compresstype=rle_type,compresslevel=2,blocksize=32768}
+ rle_type_2_delta_chkf |      5 |       5 | {compresstype=rle_type,compresslevel=2,blocksize=32768}
+ rle_type_2_delta_chkf |      6 |       6 | {compresstype=rle_type,compresslevel=2,blocksize=32768}
 (6 rows)
 
 \d+ rle_type_2_delta_chkf
@@ -1400,15 +1400,15 @@ Create table rle_type_2_delta_null(
     ) with(appendonly=true, orientation=column, compresstype=rle_type, compresslevel=2);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a1' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-select attrelid::regclass as relname, attnum, attoptions from pg_class c, pg_attribute_encoding e  where c.relname = 'rle_type_2_delta_null'  and c.oid=e.attrelid  order by relname, attnum;
-        relname        | attnum |                       attoptions                        
------------------------+--------+---------------------------------------------------------
- rle_type_2_delta_null |      1 | {compresstype=rle_type,compresslevel=2,blocksize=32768}
- rle_type_2_delta_null |      2 | {compresstype=rle_type,compresslevel=2,blocksize=32768}
- rle_type_2_delta_null |      3 | {compresstype=rle_type,compresslevel=2,blocksize=32768}
- rle_type_2_delta_null |      4 | {compresstype=rle_type,compresslevel=2,blocksize=32768}
- rle_type_2_delta_null |      5 | {compresstype=rle_type,compresslevel=2,blocksize=32768}
- rle_type_2_delta_null |      6 | {compresstype=rle_type,compresslevel=2,blocksize=32768}
+select attrelid::regclass as relname, attnum, filenum, attoptions from pg_class c, pg_attribute_encoding e  where c.relname = 'rle_type_2_delta_null'  and c.oid=e.attrelid  order by relname, attnum;
+        relname        | attnum | filenum |                       attoptions                        
+-----------------------+--------+---------+---------------------------------------------------------
+ rle_type_2_delta_null |      1 |       1 | {compresstype=rle_type,compresslevel=2,blocksize=32768}
+ rle_type_2_delta_null |      2 |       2 | {compresstype=rle_type,compresslevel=2,blocksize=32768}
+ rle_type_2_delta_null |      3 |       3 | {compresstype=rle_type,compresslevel=2,blocksize=32768}
+ rle_type_2_delta_null |      4 |       4 | {compresstype=rle_type,compresslevel=2,blocksize=32768}
+ rle_type_2_delta_null |      5 |       5 | {compresstype=rle_type,compresslevel=2,blocksize=32768}
+ rle_type_2_delta_null |      6 |       6 | {compresstype=rle_type,compresslevel=2,blocksize=32768}
 (6 rows)
 
 \d+ rle_type_2_delta_null
@@ -1522,15 +1522,15 @@ Create table rle_type_3_delta_null(
     ) with(appendonly=true, orientation=column, compresstype=rle_type, compresslevel=3);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a1' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-select attrelid::regclass as relname, attnum, attoptions from pg_class c, pg_attribute_encoding e  where c.relname = 'rle_type_3_delta_null'  and c.oid=e.attrelid  order by relname, attnum;
-        relname        | attnum |                       attoptions                        
------------------------+--------+---------------------------------------------------------
- rle_type_3_delta_null |      1 | {compresstype=rle_type,compresslevel=3,blocksize=32768}
- rle_type_3_delta_null |      2 | {compresstype=rle_type,compresslevel=3,blocksize=32768}
- rle_type_3_delta_null |      3 | {compresstype=rle_type,compresslevel=3,blocksize=32768}
- rle_type_3_delta_null |      4 | {compresstype=rle_type,compresslevel=3,blocksize=32768}
- rle_type_3_delta_null |      5 | {compresstype=rle_type,compresslevel=3,blocksize=32768}
- rle_type_3_delta_null |      6 | {compresstype=rle_type,compresslevel=3,blocksize=32768}
+select attrelid::regclass as relname, attnum, filenum, attoptions from pg_class c, pg_attribute_encoding e  where c.relname = 'rle_type_3_delta_null'  and c.oid=e.attrelid  order by relname, attnum;
+        relname        | attnum | filenum |                       attoptions                        
+-----------------------+--------+---------+---------------------------------------------------------
+ rle_type_3_delta_null |      1 |       1 | {compresstype=rle_type,compresslevel=3,blocksize=32768}
+ rle_type_3_delta_null |      2 |       2 | {compresstype=rle_type,compresslevel=3,blocksize=32768}
+ rle_type_3_delta_null |      3 |       3 | {compresstype=rle_type,compresslevel=3,blocksize=32768}
+ rle_type_3_delta_null |      4 |       4 | {compresstype=rle_type,compresslevel=3,blocksize=32768}
+ rle_type_3_delta_null |      5 |       5 | {compresstype=rle_type,compresslevel=3,blocksize=32768}
+ rle_type_3_delta_null |      6 |       6 | {compresstype=rle_type,compresslevel=3,blocksize=32768}
 (6 rows)
 
 \d+ rle_type_3_delta_null
@@ -1620,15 +1620,15 @@ Create table rle_type_4_delta_null(
     ) with(appendonly=true, orientation=column, compresstype=rle_type, compresslevel=4);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a1' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-select attrelid::regclass as relname, attnum, attoptions from pg_class c, pg_attribute_encoding e  where c.relname = 'rle_type_4_delta_null'  and c.oid=e.attrelid  order by relname, attnum;
-        relname        | attnum |                       attoptions                        
------------------------+--------+---------------------------------------------------------
- rle_type_4_delta_null |      1 | {compresstype=rle_type,compresslevel=4,blocksize=32768}
- rle_type_4_delta_null |      2 | {compresstype=rle_type,compresslevel=4,blocksize=32768}
- rle_type_4_delta_null |      3 | {compresstype=rle_type,compresslevel=4,blocksize=32768}
- rle_type_4_delta_null |      4 | {compresstype=rle_type,compresslevel=4,blocksize=32768}
- rle_type_4_delta_null |      5 | {compresstype=rle_type,compresslevel=4,blocksize=32768}
- rle_type_4_delta_null |      6 | {compresstype=rle_type,compresslevel=4,blocksize=32768}
+select attrelid::regclass as relname, attnum, filenum, attoptions from pg_class c, pg_attribute_encoding e  where c.relname = 'rle_type_4_delta_null'  and c.oid=e.attrelid  order by relname, attnum;
+        relname        | attnum | filenum |                       attoptions                        
+-----------------------+--------+---------+---------------------------------------------------------
+ rle_type_4_delta_null |      1 |       1 | {compresstype=rle_type,compresslevel=4,blocksize=32768}
+ rle_type_4_delta_null |      2 |       2 | {compresstype=rle_type,compresslevel=4,blocksize=32768}
+ rle_type_4_delta_null |      3 |       3 | {compresstype=rle_type,compresslevel=4,blocksize=32768}
+ rle_type_4_delta_null |      4 |       4 | {compresstype=rle_type,compresslevel=4,blocksize=32768}
+ rle_type_4_delta_null |      5 |       5 | {compresstype=rle_type,compresslevel=4,blocksize=32768}
+ rle_type_4_delta_null |      6 |       6 | {compresstype=rle_type,compresslevel=4,blocksize=32768}
 (6 rows)
 
 \d+ rle_type_4_delta_null

--- a/src/test/regress/input/aocs.source
+++ b/src/test/regress/input/aocs.source
@@ -245,7 +245,7 @@ CREATE TABLE aocs_inh_child3 (COLUMN parent_t ENCODING (compresstype=zlib))
 INHERITS (aocs_inh_parent)
 WITH (appendonly=true, orientation=column);
 
-SELECT c.relname, ae.attnum, ae.attoptions FROM pg_class c, pg_attribute_encoding ae WHERE c.relname LIKE 'aocs_inh%' AND c.oid=ae.attrelid ORDER BY 1,2;
+SELECT c.relname, ae.attnum, ae.filenum, ae.attoptions FROM pg_class c, pg_attribute_encoding ae WHERE c.relname LIKE 'aocs_inh%' AND c.oid=ae.attrelid ORDER BY 1,2;
 
 -- Multiple inheritance
 -- The ENCODING of parent_t_8k column doesn't match that of the other parent table.
@@ -258,7 +258,7 @@ CREATE TABLE aocs_inh_multichild ()
 INHERITS (aocs_inh_parent, aocs_inh_parent2)
 WITH (appendonly=true, orientation=column);
 
-SELECT c.relname, ae.attnum, ae.attoptions FROM pg_class c, pg_attribute_encoding ae WHERE c.relname LIKE 'aocs_inh_multi%' AND c.oid=ae.attrelid ORDER BY 1,2;
+SELECT c.relname, ae.attnum, ae.filenum, ae.attoptions FROM pg_class c, pg_attribute_encoding ae WHERE c.relname LIKE 'aocs_inh_multi%' AND c.oid=ae.attrelid ORDER BY 1,2;
 
 -- AOCO table inherits a heap table.
 CREATE TABLE aocs_inh2_parent_heap (parent_t text, parent_t2 text);
@@ -267,7 +267,7 @@ WITH (appendonly=true, orientation=column);
 CREATE TABLE aocs_inh2_child2 (COLUMN parent_t ENCODING (compresstype=zlib)) INHERITS (aocs_inh2_parent_heap)
 WITH (appendonly=true, orientation=column);
 
-SELECT c.relname, ae.attnum, ae.attoptions FROM pg_class c, pg_attribute_encoding ae WHERE c.relname LIKE 'aocs_inh2_%' AND c.oid=ae.attrelid ORDER BY 1,2;
+SELECT c.relname, ae.attnum, ae.filenum, ae.attoptions FROM pg_class c, pg_attribute_encoding ae WHERE c.relname LIKE 'aocs_inh2_%' AND c.oid=ae.attrelid ORDER BY 1,2;
 
 -- don't drop the tables, to also test pg_dump & restore of them.
 

--- a/src/test/regress/output/aocs.source
+++ b/src/test/regress/output/aocs.source
@@ -454,15 +454,15 @@ WITH (appendonly=true, orientation=column);
 CREATE TABLE aocs_inh_child3 (COLUMN parent_t ENCODING (compresstype=zlib))
 INHERITS (aocs_inh_parent)
 WITH (appendonly=true, orientation=column);
-SELECT c.relname, ae.attnum, ae.attoptions FROM pg_class c, pg_attribute_encoding ae WHERE c.relname LIKE 'aocs_inh%' AND c.oid=ae.attrelid ORDER BY 1,2;
-     relname     | attnum |                     attoptions                      
------------------+--------+-----------------------------------------------------
- aocs_inh_child2 |      1 | {compresstype=none,blocksize=32768,compresslevel=0}
- aocs_inh_child2 |      2 | {compresstype=none,blocksize=32768,compresslevel=0}
- aocs_inh_child3 |      1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- aocs_inh_child3 |      2 | {compresstype=none,blocksize=32768,compresslevel=0}
- aocs_inh_parent |      1 | {compresstype=none,blocksize=32768,compresslevel=0}
- aocs_inh_parent |      2 | {blocksize=8192,compresstype=none,compresslevel=0}
+SELECT c.relname, ae.attnum, ae.filenum, ae.attoptions FROM pg_class c, pg_attribute_encoding ae WHERE c.relname LIKE 'aocs_inh%' AND c.oid=ae.attrelid ORDER BY 1,2;
+     relname     | attnum | filenum |                     attoptions                      
+-----------------+--------+---------+-----------------------------------------------------
+ aocs_inh_child2 |      1 |       1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ aocs_inh_child2 |      2 |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ aocs_inh_child3 |      1 |       1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ aocs_inh_child3 |      2 |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ aocs_inh_parent |      1 |       1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ aocs_inh_parent |      2 |       2 | {blocksize=8192,compresstype=none,compresslevel=0}
 (6 rows)
 
 -- Multiple inheritance
@@ -475,12 +475,12 @@ WITH (appendonly=true, orientation=column);
 CREATE TABLE aocs_inh_multichild ()
 INHERITS (aocs_inh_parent, aocs_inh_parent2)
 WITH (appendonly=true, orientation=column);
-SELECT c.relname, ae.attnum, ae.attoptions FROM pg_class c, pg_attribute_encoding ae WHERE c.relname LIKE 'aocs_inh_multi%' AND c.oid=ae.attrelid ORDER BY 1,2;
-       relname       | attnum |                     attoptions                      
----------------------+--------+-----------------------------------------------------
- aocs_inh_multichild |      1 | {compresstype=none,blocksize=32768,compresslevel=0}
- aocs_inh_multichild |      2 | {compresstype=none,blocksize=32768,compresslevel=0}
- aocs_inh_multichild |      3 | {compresstype=none,blocksize=32768,compresslevel=0}
+SELECT c.relname, ae.attnum, ae.filenum, ae.attoptions FROM pg_class c, pg_attribute_encoding ae WHERE c.relname LIKE 'aocs_inh_multi%' AND c.oid=ae.attrelid ORDER BY 1,2;
+       relname       | attnum | filenum |                     attoptions                      
+---------------------+--------+---------+-----------------------------------------------------
+ aocs_inh_multichild |      1 |       1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ aocs_inh_multichild |      2 |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ aocs_inh_multichild |      3 |       3 | {compresstype=none,blocksize=32768,compresslevel=0}
 (3 rows)
 
 -- AOCO table inherits a heap table.
@@ -489,13 +489,13 @@ CREATE TABLE aocs_inh2_child1 () INHERITS (aocs_inh2_parent_heap)
 WITH (appendonly=true, orientation=column);
 CREATE TABLE aocs_inh2_child2 (COLUMN parent_t ENCODING (compresstype=zlib)) INHERITS (aocs_inh2_parent_heap)
 WITH (appendonly=true, orientation=column);
-SELECT c.relname, ae.attnum, ae.attoptions FROM pg_class c, pg_attribute_encoding ae WHERE c.relname LIKE 'aocs_inh2_%' AND c.oid=ae.attrelid ORDER BY 1,2;
-     relname      | attnum |                     attoptions                      
-------------------+--------+-----------------------------------------------------
- aocs_inh2_child1 |      1 | {compresstype=none,blocksize=32768,compresslevel=0}
- aocs_inh2_child1 |      2 | {compresstype=none,blocksize=32768,compresslevel=0}
- aocs_inh2_child2 |      1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
- aocs_inh2_child2 |      2 | {compresstype=none,blocksize=32768,compresslevel=0}
+SELECT c.relname, ae.attnum, ae.filenum, ae.attoptions FROM pg_class c, pg_attribute_encoding ae WHERE c.relname LIKE 'aocs_inh2_%' AND c.oid=ae.attrelid ORDER BY 1,2;
+     relname      | attnum | filenum |                     attoptions                      
+------------------+--------+---------+-----------------------------------------------------
+ aocs_inh2_child1 |      1 |       1 | {compresstype=none,blocksize=32768,compresslevel=0}
+ aocs_inh2_child1 |      2 |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
+ aocs_inh2_child2 |      1 |       1 | {compresstype=zlib,compresslevel=1,blocksize=32768}
+ aocs_inh2_child2 |      2 |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
 (4 rows)
 
 -- don't drop the tables, to also test pg_dump & restore of them.

--- a/src/test/regress/sql/AOCO_Compression.sql
+++ b/src/test/regress/sql/AOCO_Compression.sql
@@ -311,7 +311,7 @@ INSERT INTO co_crtb_with_strg_dir_and_col_ref_1_uncompr select * from co_crtb_wi
 \d+ co_crtb_with_strg_dir_and_col_ref_1
 
 --Select from pg_attribute_encoding to see the table entry 
-select attrelid::regclass as relname, attnum, attoptions from pg_class c, pg_attribute_encoding e  where c.relname = 'co_crtb_with_strg_dir_and_col_ref_1' and c.oid=e.attrelid  order by relname, attnum limit 3; 
+select attrelid::regclass as relname, attnum, filenum, attoptions from pg_class c, pg_attribute_encoding e  where c.relname = 'co_crtb_with_strg_dir_and_col_ref_1' and c.oid=e.attrelid  order by relname, attnum limit 3;
 --
 -- Compare data with uncompressed table
 --

--- a/src/test/regress/sql/alter_table_set_am.sql
+++ b/src/test/regress/sql/alter_table_set_am.sql
@@ -407,7 +407,7 @@ SELECT count(*) FROM gp_toolkit.__gp_aocsseg('ao2co3');
 SELECT * FROM gp_toolkit.__gp_aoblkdir('ao2co3');
 
 -- pg_attribute_encoding should have columns for the AOCO table
-SELECT c.relname, a.attnum, a.attoptions FROM pg_attribute_encoding a, pg_class c WHERE a.attrelid = c.oid AND c.relname LIKE 'ao2co%';
+SELECT c.relname, a.attnum, a.filenum, a.attoptions FROM pg_attribute_encoding a, pg_class c WHERE a.attrelid = c.oid AND c.relname LIKE 'ao2co%';
 
 -- AM and reloptions changed accordingly
 SELECT c.relname, a.amname, c.reloptions FROM pg_class c JOIN pg_am a ON c.relam = a.oid WHERE c.relname LIKE 'ao2co%';
@@ -437,7 +437,7 @@ SELECT relname, reloptions FROM pg_class WHERE relname LIKE 'co2heap%';
 -- Check once that the AO tables have relfrozenxid = 0
 SELECT relname, relfrozenxid FROM pg_class WHERE relname LIKE 'co2heap%';
 -- Check once that the pg_attribute_encoding has entries for the AOCO tables.
-SELECT c.relname, a.attnum, attoptions FROM pg_attribute_encoding a, pg_class c WHERE a.attrelid=c.oid AND c.relname LIKE 'co2heap%';
+SELECT c.relname, a.attnum, a.filenum, attoptions FROM pg_attribute_encoding a, pg_class c WHERE a.attrelid=c.oid AND c.relname LIKE 'co2heap%';
 
 CREATE TEMP TABLE relfilebeforeco2heap AS
     SELECT -1 segid, relfilenode FROM pg_class WHERE relname LIKE 'co2heap%'
@@ -491,7 +491,7 @@ SELECT relname, reloptions FROM pg_class WHERE relname LIKE 'co2heap%';
 SELECT relname, relfrozenxid <> '0' FROM pg_class WHERE relname LIKE 'co2heap%';
 
 -- The pg_attribute_encoding entries for the altered tables should have all gone.
-SELECT c.relname, a.attnum, attoptions FROM pg_attribute_encoding a, pg_class c WHERE a.attrelid=c.oid AND c.relname LIKE 'co2heap%';
+SELECT c.relname, a.attnum, a.filenum, attoptions FROM pg_attribute_encoding a, pg_class c WHERE a.attrelid=c.oid AND c.relname LIKE 'co2heap%';
 
 DROP TABLE co2heap;
 DROP TABLE co2heap2;
@@ -515,7 +515,7 @@ INSERT INTO co2ao4 SELECT i,i FROM generate_series(1,5) i;
 -- Check once that the AOCO tables have the custom reloptions
 SELECT relname, reloptions FROM pg_class WHERE relname LIKE 'co2ao%';
 -- Check once that the pg_attribute_encoding has entries for the AOCO tables.
-SELECT c.relname, a.attnum, attoptions FROM pg_attribute_encoding a, pg_class c WHERE a.attrelid=c.oid AND c.relname LIKE 'co2ao%';
+SELECT c.relname, a.attnum, a.filenum, attoptions FROM pg_attribute_encoding a, pg_class c WHERE a.attrelid=c.oid AND c.relname LIKE 'co2ao%';
 -- Check once on the aoblkdirs
 SELECT gp_segment_id, (gp_toolkit.__gp_aoblkdir('co2ao')).* FROM gp_dist_random('gp_id');
 SELECT gp_segment_id, (gp_toolkit.__gp_aoblkdir('co2ao3')).* FROM gp_dist_random('gp_id');
@@ -569,7 +569,7 @@ SELECT c.relname, a.amname FROM pg_class c JOIN pg_am a ON c.relam = a.oid WHERE
 SELECT relname, reloptions FROM pg_class WHERE relname LIKE 'co2ao%';
 
 -- The pg_attribute_encoding entries for the altered tables should have all gone.
-SELECT c.relname, a.attnum, attoptions FROM pg_attribute_encoding a, pg_class c WHERE a.attrelid=c.oid AND c.relname LIKE 'co2ao%';
+SELECT c.relname, a.attnum, a.filenum, attoptions FROM pg_attribute_encoding a, pg_class c WHERE a.attrelid=c.oid AND c.relname LIKE 'co2ao%';
 
 DROP TABLE co2ao;
 DROP TABLE co2ao2;
@@ -635,7 +635,7 @@ SELECT gp_segment_id, (gp_toolkit.__gp_aoblkdir('heap2co3')).* FROM gp_dist_rand
 SELECT count(*) FROM gp_toolkit.__gp_aocsseg('heap2co3');
 
 -- pg_attribute_encoding should have columns for the AOCO table
-SELECT c.relname, a.attnum, a.attoptions FROM pg_attribute_encoding a, pg_class c WHERE a.attrelid = c.oid AND c.relname LIKE 'heap2co%';
+SELECT c.relname, a.attnum, a.filenum, a.attoptions FROM pg_attribute_encoding a, pg_class c WHERE a.attrelid = c.oid AND c.relname LIKE 'heap2co%';
 
 -- AM and reloptions changed accordingly
 SELECT c.relname, a.amname, c.reloptions FROM pg_class c JOIN pg_am a ON c.relam = a.oid WHERE c.relname LIKE 'heap2co%';

--- a/src/test/regress/sql/column_compression.sql
+++ b/src/test/regress/sql/column_compression.sql
@@ -10,7 +10,7 @@ create database column_compression;
 
 prepare ccddlcheck as
 select e.attrelid::regclass as relname,
-a.attname, e.attoptions from pg_class c, pg_attribute_encoding e, pg_attribute a
+a.attname, e.filenum, e.attoptions from pg_class c, pg_attribute_encoding e, pg_attribute a
 where c.relname like 'ccddl%' and c.oid=e.attrelid and e.attrelid=a.attrelid and e.attnum = a.attnum
 order by relname, e.attnum;
 

--- a/src/test/regress/sql/create_table_like_gp.sql
+++ b/src/test/regress/sql/create_table_like_gp.sql
@@ -19,6 +19,7 @@ select relname, reloptions from pg_class where relname LIKE 't_ao%' order by rel
 SELECT
 	c.relname,
 	a.attnum,
+	a.filenum,
 	a.attoptions
 FROM
 	pg_catalog.pg_class c

--- a/src/test/regress/sql/dsp.sql
+++ b/src/test/regress/sql/dsp.sql
@@ -97,7 +97,7 @@ create table t2 (
 SELECT am.amname FROM pg_class c LEFT JOIN pg_am am ON (c.relam = am.oid) WHERE c.relname = 't2';
 insert into t2 select i, 71/i, 2*i, 'abc'||2*i from generate_series(1,5)i;
 select * from t2 order by 1;
-select attrelid::regclass, attnum, attoptions
+select attrelid::regclass, attnum, filenum, attoptions
 	from pg_attribute_encoding order by 1,2;
 -- SET operation in a session has higher precedence.  Also test if
 -- compresstype is correctly inferred based on compress level.
@@ -173,7 +173,7 @@ create table co7(
 	b varchar encoding(compresstype=zlib,compresslevel=6),
 	c char encoding(compresstype=rle_type))
 	with (checksum=false) distributed by (a);
-select attrelid::regclass,attnum,attoptions
+select attrelid::regclass,attnum,filenum,attoptions
 	from pg_attribute_encoding order by 1,2;
 drop database if exists dsp3;
 create database dsp3;
@@ -209,7 +209,7 @@ create table co5 (a int encoding (blocksize=8192), b float)
 	with (appendonly=true,orientation=column, checksum=false) distributed by (a);
 select c.relname, am.amname, c.relkind, c.reloptions from pg_class c left join pg_am am on (c.relam=am.oid)
 where relname in ('co1', 'co2', 'co3', 'co5') order by 1;
-select attrelid::regclass,attnum,attoptions
+select attrelid::regclass,attnum,filenum,attoptions
 	from pg_attribute_encoding order by 1,2;
 
 -- misc tests
@@ -314,7 +314,7 @@ set default_table_access_method = ao_row;
 set gp_default_storage_options = "compresstype=NONE";
 create table co10 (a int, b int, c int) with (appendonly=true,orientation=column)
     distributed by (a);
-select attnum,attoptions from pg_attribute_encoding
+select attnum,filenum,attoptions from pg_attribute_encoding
     where attrelid = 'co10'::regclass order by attnum;
 
 -- compression disabled by default, enable in WITH clause

--- a/src/test/regress/sql/gp_partition_template.sql
+++ b/src/test/regress/sql/gp_partition_template.sql
@@ -187,7 +187,7 @@ SELECT t.*, pg_get_expr(relpartbound, oid) FROM pg_partition_tree('notemplate') 
 
 prepare encoding_check as
 select attrelid::regclass as relname,
-        attnum, attoptions from pg_class c, pg_attribute_encoding e
+        attnum, filenum,attoptions from pg_class c, pg_attribute_encoding e
 where c.relname like 'subpart_templ_encoding%' and c.oid=e.attrelid
 order by relname, attnum;
 

--- a/src/test/regress/sql/partition.sql
+++ b/src/test/regress/sql/partition.sql
@@ -3725,11 +3725,11 @@ alter table pt_tab_encode add partition "s_xyz" values ('xyz') WITH (appendonly=
 
 select relname, pg_get_expr(relpartbound, oid) from pg_class where relname like 'pt_tab_encode%';
 
-select gp_segment_id, attrelid::regclass, attnum, attoptions from pg_attribute_encoding where attrelid = 'pt_tab_encode_1_prt_s_abc'::regclass;
-select gp_segment_id, attrelid::regclass, attnum, attoptions from gp_dist_random('pg_attribute_encoding') where attrelid = 'pt_tab_encode_1_prt_s_abc'::regclass order by 1,3 limit 5;
+select gp_segment_id, attrelid::regclass, attnum, filenum, attoptions from pg_attribute_encoding where attrelid = 'pt_tab_encode_1_prt_s_abc'::regclass;
+select gp_segment_id, attrelid::regclass, attnum, filenum, attoptions from gp_dist_random('pg_attribute_encoding') where attrelid = 'pt_tab_encode_1_prt_s_abc'::regclass order by 1,3 limit 5;
 
-select gp_segment_id, attrelid::regclass, attnum, attoptions from pg_attribute_encoding where attrelid = 'pt_tab_encode_1_prt_s_xyz'::regclass;
-select gp_segment_id, attrelid::regclass, attnum, attoptions from gp_dist_random('pg_attribute_encoding') where attrelid = 'pt_tab_encode_1_prt_s_xyz'::regclass order by 1,3 limit 5;
+select gp_segment_id, attrelid::regclass, attnum, filenum, attoptions from pg_attribute_encoding where attrelid = 'pt_tab_encode_1_prt_s_xyz'::regclass;
+select gp_segment_id, attrelid::regclass, attnum, filenum, attoptions from gp_dist_random('pg_attribute_encoding') where attrelid = 'pt_tab_encode_1_prt_s_xyz'::regclass order by 1,3 limit 5;
 
 select c.oid::regclass, relkind, amname, reloptions from pg_class c left join pg_am am on am.oid = relam where c.oid = 'pt_tab_encode_1_prt_s_abc'::regclass;
 select c.oid::regclass, relkind, amname, reloptions from pg_class c left join pg_am am on am.oid = relam where c.oid = 'pt_tab_encode_1_prt_s_xyz'::regclass;

--- a/src/test/regress/sql/rle_delta.sql
+++ b/src/test/regress/sql/rle_delta.sql
@@ -26,7 +26,7 @@ Create table delta_all(
     a7 text ENCODING (compresstype=rle_type,compresslevel=4)
     ) with(appendonly=true, orientation=column);
 
-select attrelid::regclass as relname, attnum, attoptions from pg_class c, pg_attribute_encoding e  where c.relname = 'delta_all'  and c.oid=e.attrelid  order by relname, attnum;
+select attrelid::regclass as relname, attnum, filenum, attoptions from pg_class c, pg_attribute_encoding e  where c.relname = 'delta_all'  and c.oid=e.attrelid  order by relname, attnum;
 
 \d+ delta_all
 
@@ -70,7 +70,7 @@ Create table delta_alter(
     a7 text ENCODING (compresstype=rle_type,compresslevel=4)
     ) with(appendonly=true, orientation=column);
 
-select attrelid::regclass as relname, attnum, attoptions from pg_class c, pg_attribute_encoding e  where c.relname = 'delta_alter'  and c.oid=e.attrelid  order by relname, attnum;
+select attrelid::regclass as relname, attnum, filenum, attoptions from pg_class c, pg_attribute_encoding e  where c.relname = 'delta_alter'  and c.oid=e.attrelid  order by relname, attnum;
 
 \d+ delta_alter
 
@@ -127,7 +127,7 @@ Create table delta_bitmap_ins(
 
 Create index dl_ix_bt on  delta_bitmap_ins using bitmap(a1);
 
-select attrelid::regclass as relname, attnum, attoptions from pg_class c, pg_attribute_encoding e  where c.relname = 'delta_bitmap_ins'  and c.oid=e.attrelid  order by relname, attnum;
+select attrelid::regclass as relname, attnum, filenum, attoptions from pg_class c, pg_attribute_encoding e  where c.relname = 'delta_bitmap_ins'  and c.oid=e.attrelid  order by relname, attnum;
 
 \d+ delta_bitmap_ins
 
@@ -175,7 +175,7 @@ Create table delta_btree_ins(
 
 Create index dl_ix_br on  delta_btree_ins(a1);
 
-select attrelid::regclass as relname, attnum, attoptions from pg_class c, pg_attribute_encoding e  where c.relname = 'delta_btree_ins'  and c.oid=e.attrelid  order by relname, attnum;
+select attrelid::regclass as relname, attnum, filenum, attoptions from pg_class c, pg_attribute_encoding e  where c.relname = 'delta_btree_ins'  and c.oid=e.attrelid  order by relname, attnum;
 
 \d+ delta_btree_ins
 
@@ -220,7 +220,7 @@ Create table delta_ins_bitmap(
     a7 text ENCODING (compresstype=rle_type,compresslevel=4)
     ) with(appendonly=true, orientation=column);
 
-select attrelid::regclass as relname, attnum, attoptions from pg_class c, pg_attribute_encoding e  where c.relname = 'delta_ins_bitmap'  and c.oid=e.attrelid  order by relname, attnum;
+select attrelid::regclass as relname, attnum, filenum, attoptions from pg_class c, pg_attribute_encoding e  where c.relname = 'delta_ins_bitmap'  and c.oid=e.attrelid  order by relname, attnum;
 
 \d+ delta_ins_bitmap
 
@@ -270,7 +270,7 @@ Create table delta_ins_btree(
     ) with(appendonly=true, orientation=column);
 
 
-select attrelid::regclass as relname, attnum, attoptions from pg_class c, pg_attribute_encoding e  where c.relname = 'delta_ins_btree'  and c.oid=e.attrelid  order by relname, attnum;
+select attrelid::regclass as relname, attnum, filenum, attoptions from pg_class c, pg_attribute_encoding e  where c.relname = 'delta_ins_btree'  and c.oid=e.attrelid  order by relname, attnum;
 
 \d+ delta_ins_btree
 
@@ -373,7 +373,7 @@ Create table delta_none(
     a9 text ENCODING (compresstype=rle_type,compresslevel=2)
     ) with(appendonly=true, orientation=column);
 
-select attrelid::regclass as relname, attnum, attoptions from pg_class c, pg_attribute_encoding e  where c.relname = 'delta_none'  and c.oid=e.attrelid  order by relname, attnum;
+select attrelid::regclass as relname, attnum, filenum, attoptions from pg_class c, pg_attribute_encoding e  where c.relname = 'delta_none'  and c.oid=e.attrelid  order by relname, attnum;
 
 \d+ delta_none
 
@@ -566,7 +566,7 @@ Create table delta_zlib(
     a9 text ENCODING (compresstype=rle_type,compresslevel=2)
     ) with(appendonly=true, orientation=column);
 
-select attrelid::regclass as relname, attnum, attoptions from pg_class c, pg_attribute_encoding e  where c.relname = 'delta_zlib'  and c.oid=e.attrelid  order by relname, attnum;
+select attrelid::regclass as relname, attnum, filenum, attoptions from pg_class c, pg_attribute_encoding e  where c.relname = 'delta_zlib'  and c.oid=e.attrelid  order by relname, attnum;
 
 \d+ delta_zlib
 
@@ -602,7 +602,7 @@ Create table rle_type_1_delta_null(
     a6 timestamp with time zone
     ) with(appendonly=true, orientation=column, compresstype=rle_type, compresslevel=1);
 
-select attrelid::regclass as relname, attnum, attoptions from pg_class c, pg_attribute_encoding e  where c.relname = 'rle_type_1_delta_null'  and c.oid=e.attrelid  order by relname, attnum;
+select attrelid::regclass as relname, attnum, filenum, attoptions from pg_class c, pg_attribute_encoding e  where c.relname = 'rle_type_1_delta_null'  and c.oid=e.attrelid  order by relname, attnum;
 
 \d+ rle_type_1_delta_null
 
@@ -648,7 +648,7 @@ Create table rle_type_2_delta_chkt(
     a6 timestamp with time zone
     ) with(appendonly=true, orientation=column, compresstype=rle_type, compresslevel=2, checksum=true);
 
-select attrelid::regclass as relname, attnum, attoptions from pg_class c, pg_attribute_encoding e  where c.relname = 'rle_type_2_delta_chkt'  and c.oid=e.attrelid  order by relname, attnum;
+select attrelid::regclass as relname, attnum, filenum, attoptions from pg_class c, pg_attribute_encoding e  where c.relname = 'rle_type_2_delta_chkt'  and c.oid=e.attrelid  order by relname, attnum;
 
 \d+ rle_type_2_delta_chkt
 
@@ -677,7 +677,7 @@ Create table rle_type_2_delta_chkf(
     a6 timestamp with time zone
     ) with(appendonly=true, orientation=column, compresstype=rle_type, compresslevel=2, checksum=false);
 
-select attrelid::regclass as relname, attnum, attoptions from pg_class c, pg_attribute_encoding e  where c.relname = 'rle_type_2_delta_chkf'  and c.oid=e.attrelid  order by relname, attnum;
+select attrelid::regclass as relname, attnum, filenum, attoptions from pg_class c, pg_attribute_encoding e  where c.relname = 'rle_type_2_delta_chkf'  and c.oid=e.attrelid  order by relname, attnum;
 
 \d+ rle_type_2_delta_chkf
 
@@ -709,7 +709,7 @@ Create table rle_type_2_delta_null(
     a6 timestamp with time zone
     ) with(appendonly=true, orientation=column, compresstype=rle_type, compresslevel=2);
 
-select attrelid::regclass as relname, attnum, attoptions from pg_class c, pg_attribute_encoding e  where c.relname = 'rle_type_2_delta_null'  and c.oid=e.attrelid  order by relname, attnum;
+select attrelid::regclass as relname, attnum, filenum, attoptions from pg_class c, pg_attribute_encoding e  where c.relname = 'rle_type_2_delta_null'  and c.oid=e.attrelid  order by relname, attnum;
 
 \d+ rle_type_2_delta_null
 
@@ -757,7 +757,7 @@ Create table rle_type_3_delta_null(
     a6 timestamp with time zone
     ) with(appendonly=true, orientation=column, compresstype=rle_type, compresslevel=3);
 
-select attrelid::regclass as relname, attnum, attoptions from pg_class c, pg_attribute_encoding e  where c.relname = 'rle_type_3_delta_null'  and c.oid=e.attrelid  order by relname, attnum;
+select attrelid::regclass as relname, attnum, filenum, attoptions from pg_class c, pg_attribute_encoding e  where c.relname = 'rle_type_3_delta_null'  and c.oid=e.attrelid  order by relname, attnum;
 
 \d+ rle_type_3_delta_null
 
@@ -803,7 +803,7 @@ Create table rle_type_4_delta_null(
     a6 timestamp with time zone
     ) with(appendonly=true, orientation=column, compresstype=rle_type, compresslevel=4);
 
-select attrelid::regclass as relname, attnum, attoptions from pg_class c, pg_attribute_encoding e  where c.relname = 'rle_type_4_delta_null'  and c.oid=e.attrelid  order by relname, attnum;
+select attrelid::regclass as relname, attnum, filenum, attoptions from pg_class c, pg_attribute_encoding e  where c.relname = 'rle_type_4_delta_null'  and c.oid=e.attrelid  order by relname, attnum;
 
 \d+ rle_type_4_delta_null
 


### PR DESCRIPTION
First commit introduces a new field filenum in pg_attribute_enconding

For CO tables, today, each column is tied to an implicit "filenum", which is a
shorthand for the file range that the column is assigned. This means segfiles
for columns are of the form:

attnum 1: relfilenode, relfilenode.1 .. relfilenode.127 (implicit filenum = 1)
attnum 2: relfilenode.128, relfilenode.129 .. relfilenode.255 (implicit filenum = 2)
attnum 3: relfilenode.256, relfilenode.257 .. relfilenode.383 (implicit filenum = 3)
...

The range of relfiles for a column depends on this implicit "filenum", which is
always equal to the attnum.

We want to decouple the implicit filenum from the attnum. To illustrate,
segfiles can now be of the form:

attnum 1: relfilenode.256, relfilenode.257 .. relfilenode.383 (explicit filenum = 3)
attnum 2: relfilenode, relfilenode.1 .. relfilenode.127  (explicit filenum = 1)
attnum 3: relfilenode.128, relfilenode.129 .. relfilenode.255 (explicit filenum = 2)
...

This commit does exactly that by introducing pg_attribute_encoding.filenum, so
we can have a mapping between attnum and filenum.

We will leverage this decoupling in future commits. For instance, to support
column-only rewrites, we would need a way to create a "rewritten" relfile for an
existing column i and then swap them in the catalog, while supporting MVCC
semantics etc.

It is also now worth observing that the filenum no longer needs to range from
1..1600 (MaxHeapAttributeNumber). It can now go beyond 1600, with more alter operations.

Also, we have edited the tests to include the new filenum field.
Some tests don't need to check filenum, but keeping the field to check if further commits/changes affect it
