### PR TITLE
Fix flaky aggregates test

### DIFF
--- a/src/test/regress/expected/aggregates.out
+++ b/src/test/regress/expected/aggregates.out
@@ -3155,6 +3155,8 @@ drop table agg_hash_3;
 drop table agg_hash_4;
 -- GitHub issue https://github.com/greenplum-db/gpdb/issues/12061
 -- numsegments of the general locus should be -1 on create_minmaxagg_path
+-- This test can be nondeterministic depending on the number of entries in pg_class
+set enable_indexonlyscan=off;
 explain analyze select count(*) from pg_class, (select count(*) > 0 from (select count(*) from pg_class where relnatts > 8) x) y;
                                                       QUERY PLAN                                                       
 -----------------------------------------------------------------------------------------------------------------------
@@ -3170,3 +3172,4 @@ explain analyze select count(*) from pg_class, (select count(*) > 0 from (select
  Execution Time: 0.302 ms
 (10 rows)
 
+reset enable_indexonlyscan;

--- a/src/test/regress/expected/aggregates_optimizer.out
+++ b/src/test/regress/expected/aggregates_optimizer.out
@@ -3357,6 +3357,8 @@ drop table agg_hash_3;
 drop table agg_hash_4;
 -- GitHub issue https://github.com/greenplum-db/gpdb/issues/12061
 -- numsegments of the general locus should be -1 on create_minmaxagg_path
+-- This test can be nondeterministic depending on the number of entries in pg_class
+set enable_indexonlyscan=off;
 explain analyze select count(*) from pg_class, (select count(*) > 0 from (select count(*) from pg_class where relnatts > 8) x) y;
 INFO:  GPORCA failed to produce a plan, falling back to planner
 DETAIL:  Feature not supported: Queries on master-only tables
@@ -3375,3 +3377,4 @@ DETAIL:  Feature not supported: Queries on master-only tables
  Execution Time: 0.198 ms
 (10 rows)
 
+reset enable_indexonlyscan;

--- a/src/test/regress/sql/aggregates.sql
+++ b/src/test/regress/sql/aggregates.sql
@@ -1395,4 +1395,7 @@ drop table agg_hash_4;
 
 -- GitHub issue https://github.com/greenplum-db/gpdb/issues/12061
 -- numsegments of the general locus should be -1 on create_minmaxagg_path
+-- This test can be nondeterministic depending on the number of entries in pg_class
+set enable_indexonlyscan=off;
 explain analyze select count(*) from pg_class, (select count(*) > 0 from (select count(*) from pg_class where relnatts > 8) x) y;
+reset enable_indexonlyscan;


### PR DESCRIPTION
This test case needs to be a on a coordinator-only table, but using pg_class is flaky as we'll sometimes choose an index-only scan and other times a seq scan.