### PR TITLE
Fix incorrect result from hash join on char column

### DIFF
--- a/src/backend/gporca/libgpopt/src/base/CConstraint.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CConstraint.cpp
@@ -433,8 +433,10 @@ CConstraint::PcnstrFromScalarCmp(
 		const CColRef *pcrLeft = popScIdLeft->Pcr();
 		const CColRef *pcrRight = popScIdRight->Pcr();
 
-		if (!CUtils::FConstrainableType(pcrLeft->RetrieveType()->MDId()) ||
-			!CUtils::FConstrainableType(pcrRight->RetrieveType()->MDId()))
+		IMDId *left_mdid = pcrLeft->RetrieveType()->MDId();
+		IMDId *right_mdid = pcrRight->RetrieveType()->MDId();
+		if (!CUtils::FConstrainableType(left_mdid) ||
+			!CUtils::FConstrainableType(right_mdid))
 		{
 			return NULL;
 		}
@@ -445,12 +447,22 @@ CConstraint::PcnstrFromScalarCmp(
 			CScalarCmp *sc_cmp = CScalarCmp::PopConvert(pexpr->Pop());
 			const IMDScalarOp *op = mda->RetrieveScOp(sc_cmp->MdIdOp());
 
-			IMDId *left_mdid =
-				CScalar::PopConvert(pexprLeft->Pop())->MdidType();
+			// The left type and right type are both scalar ident types
+			// In case of casting, such as
+			// --CScalarCast
+			//   +--CScalarIdent "a" (0)
+			// We look at the data type before casting, instead of after
+			// This is because equivalent classes are built with columns
+			// based on their input types
+
+			// Eg. foo.a -- varchar, bar.b -- char
+			// Joining foo and bar on foo.a = bar.b requires casting
+			// foo.a to bpchar. But since hash of varchar (before cast)
+			// and hash of char don't belong to the same opfamily, we
+			// cannot generate equivalent classes with foo.a and bar.b
+
 			const IMDType *left_type = mda->RetrieveType(left_mdid);
 
-			IMDId *right_mdid =
-				CScalar::PopConvert(pexprRight->Pop())->MdidType();
 			const IMDType *right_type = mda->RetrieveType(right_mdid);
 
 			// Build constraint (e.g for equivalent classes) only when the hash families

--- a/src/backend/gporca/libgpopt/src/mdcache/CMDAccessorUtils.cpp
+++ b/src/backend/gporca/libgpopt/src/mdcache/CMDAccessorUtils.cpp
@@ -83,7 +83,7 @@ CMDAccessorUtils::FCmpExists(CMDAccessor *md_accessor, IMDId *left_mdid,
 {
 	GPOS_ASSERT(NULL != md_accessor);
 	GPOS_ASSERT(NULL != left_mdid);
-	GPOS_ASSERT(NULL != left_mdid);
+	GPOS_ASSERT(NULL != right_mdid);
 	GPOS_ASSERT(IMDType::EcmptOther > cmp_type);
 
 	GPOS_TRY
@@ -113,7 +113,7 @@ CMDAccessorUtils::GetScCmpMdid(CMDAccessor *md_accessor, IMDId *left_mdid,
 {
 	GPOS_ASSERT(NULL != md_accessor);
 	GPOS_ASSERT(NULL != left_mdid);
-	GPOS_ASSERT(NULL != left_mdid);
+	GPOS_ASSERT(NULL != right_mdid);
 	GPOS_ASSERT(IMDType::EcmptOther > cmp_type);
 
 	CAutoTraceFlag atf1(EtraceSimulateOOM, false);
@@ -336,7 +336,7 @@ CMDAccessorUtils::ApplyCastsForScCmp(CMemoryPool *mp, CMDAccessor *md_accessor,
 //		CMDAccessorUtils::FCastExists
 //
 //	@doc:
-//		Does if a cast object between given source and destination types exists
+//		Check if a cast object between given source and destination types exists
 //
 //---------------------------------------------------------------------------
 BOOL

--- a/src/test/regress/expected/bfv_joins.out
+++ b/src/test/regress/expected/bfv_joins.out
@@ -3675,6 +3675,109 @@ where
 (0 rows)
 
 drop table t_13722;
+-- This test is introduced to verify incorrect result
+-- from hash join of char columns is fixed
+-- Notice when varchar/text is cast to bpchar and used for
+-- comparison, the trailing spaces are ignored
+-- When char is cast to varchar/text, it's considered
+-- comparison, and the trailing spaces are also ignored
+-- Prior to the fix, opclasses belonging to different
+-- opfamilies could be grouped as equivalent, and thence
+-- deriving incorrect equality hash join conditions
+create table foo (varchar_3 varchar(3)) distributed by (varchar_3);
+create table bar (char_3 char(3)) distributed by (char_3);
+create table baz (text_any text) distributed by (text_any);
+insert into foo values ('cd'); -- 0 trailing spaces
+insert into bar values ('cd '); -- 1 trailing space
+insert into baz values ('cd  '); -- 2 trailing spaces
+-- varchar cast to bpchar
+-- 'cd' matches 'cd', returns 1 row
+explain select varchar_3, char_3 from foo join bar on varchar_3=char_3;
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=20000000002.06..20000000002.08 rows=4 width=7)
+   ->  Merge Join  (cost=20000000002.06..20000000002.08 rows=2 width=7)
+         Merge Cond: ((foo.varchar_3)::bpchar = bar.char_3)
+         ->  Sort  (cost=10000000001.04..10000000001.05 rows=1 width=3)
+               Sort Key: foo.varchar_3
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=10000000000.00..10000000001.03 rows=1 width=3)
+                     Hash Key: foo.varchar_3
+                     ->  Seq Scan on foo  (cost=10000000000.00..10000000001.01 rows=1 width=3)
+         ->  Sort  (cost=10000000001.02..10000000001.02 rows=1 width=4)
+               Sort Key: bar.char_3
+               ->  Seq Scan on bar  (cost=10000000000.00..10000000001.01 rows=1 width=4)
+ Optimizer: Postgres query optimizer
+(12 rows)
+
+select varchar_3, char_3 from foo join bar on varchar_3=char_3;
+ varchar_3 | char_3 
+-----------+--------
+ cd        | cd 
+(1 row)
+
+-- char cast to text
+-- 'cd' doesn't match 'cd  ', returns 0 rows
+explain select char_3, text_any from bar join baz on char_3=text_any;
+                                                          QUERY PLAN                                                          
+------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=20000000002.06..20000000002.09 rows=4 width=9)
+   ->  Merge Join  (cost=20000000002.06..20000000002.09 rows=2 width=9)
+         Merge Cond: (((bar.char_3)::text) = baz.text_any)
+         ->  Sort  (cost=10000000001.04..10000000001.05 rows=1 width=4)
+               Sort Key: ((bar.char_3)::text)
+               ->  Result  (cost=10000000000.00..10000000001.03 rows=1 width=4)
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=10000000000.00..10000000001.03 rows=1 width=4)
+                           Hash Key: (bar.char_3)::text
+                           ->  Seq Scan on bar  (cost=10000000000.00..10000000001.01 rows=1 width=4)
+         ->  Sort  (cost=10000000001.02..10000000001.02 rows=1 width=5)
+               Sort Key: baz.text_any
+               ->  Seq Scan on baz  (cost=10000000000.00..10000000001.01 rows=1 width=5)
+ Optimizer: Postgres query optimizer
+(13 rows)
+
+select char_3, text_any from bar join baz on char_3=text_any;
+ char_3 | text_any 
+--------+----------
+(0 rows)
+
+-- foo - bar join: varchar cast to bpchar
+-- 'cd' matches 'cd'
+-- foo - baz join: no cast
+-- 'cd' doesn't match 'cd  '
+-- returns 0 rows
+-- Notice ORCA changes join order to minimize motion
+explain select varchar_3, char_3, text_any from foo join bar on varchar_3=char_3
+join baz on varchar_3=text_any;
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=30000000003.19..30000000003.35 rows=4 width=12)
+   ->  Merge Join  (cost=30000000003.19..30000000003.35 rows=2 width=12)
+         Merge Cond: ((foo.varchar_3)::text = baz.text_any)
+         ->  Sort  (cost=20000000002.11..20000000002.12 rows=2 width=7)
+               Sort Key: foo.varchar_3
+               ->  Merge Join  (cost=20000000002.06..20000000002.08 rows=2 width=7)
+                     Merge Cond: ((foo.varchar_3)::bpchar = bar.char_3)
+                     ->  Sort  (cost=10000000001.04..10000000001.05 rows=1 width=3)
+                           Sort Key: foo.varchar_3
+                           ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=10000000000.00..10000000001.03 rows=1 width=3)
+                                 Hash Key: foo.varchar_3
+                                 ->  Seq Scan on foo  (cost=10000000000.00..10000000001.01 rows=1 width=3)
+                     ->  Sort  (cost=10000000001.02..10000000001.02 rows=1 width=4)
+                           Sort Key: bar.char_3
+                           ->  Seq Scan on bar  (cost=10000000000.00..10000000001.01 rows=1 width=4)
+         ->  Sort  (cost=10000000001.07..10000000001.08 rows=1 width=5)
+               Sort Key: baz.text_any
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=10000000000.00..10000000001.05 rows=1 width=5)
+                     ->  Seq Scan on baz  (cost=10000000000.00..10000000001.01 rows=1 width=5)
+ Optimizer: Postgres query optimizer
+(20 rows)
+
+select varchar_3, char_3, text_any from foo join bar on varchar_3=char_3
+join baz on varchar_3=text_any;
+ varchar_3 | char_3 | text_any 
+-----------+--------+----------
+(0 rows)
+
 -- Clean up. None of the objects we create are very interesting to keep around.
 reset search_path;
 set client_min_messages='warning';

--- a/src/test/regress/expected/bfv_joins_optimizer.out
+++ b/src/test/regress/expected/bfv_joins_optimizer.out
@@ -3662,6 +3662,93 @@ where
 (0 rows)
 
 drop table t_13722;
+-- This test is introduced to verify incorrect result
+-- from hash join of char columns is fixed
+-- Notice when varchar/text is cast to bpchar and used for
+-- comparison, the trailing spaces are ignored
+-- When char is cast to varchar/text, it's considered
+-- comparison, and the trailing spaces are also ignored
+-- Prior to the fix, opclasses belonging to different
+-- opfamilies could be grouped as equivalent, and thence
+-- deriving incorrect equality hash join conditions
+create table foo (varchar_3 varchar(3)) distributed by (varchar_3);
+create table bar (char_3 char(3)) distributed by (char_3);
+create table baz (text_any text) distributed by (text_any);
+insert into foo values ('cd'); -- 0 trailing spaces
+insert into bar values ('cd '); -- 1 trailing space
+insert into baz values ('cd  '); -- 2 trailing spaces
+-- varchar cast to bpchar
+-- 'cd' matches 'cd', returns 1 row
+explain select varchar_3, char_3 from foo join bar on varchar_3=char_3;
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Hash Join  (cost=0.00..862.00 rows=1 width=7)
+   Hash Cond: (bar.char_3 = (foo.varchar_3)::bpchar)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+         ->  Seq Scan on bar  (cost=0.00..431.00 rows=1 width=4)
+   ->  Hash  (cost=431.00..431.00 rows=1 width=3)
+         ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=3)
+               ->  Seq Scan on foo  (cost=0.00..431.00 rows=1 width=3)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(8 rows)
+
+select varchar_3, char_3 from foo join bar on varchar_3=char_3;
+ varchar_3 | char_3 
+-----------+--------
+ cd        | cd 
+(1 row)
+
+-- char cast to text
+-- 'cd' doesn't match 'cd  ', returns 0 rows
+explain select char_3, text_any from bar join baz on char_3=text_any;
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Hash Join  (cost=0.00..862.00 rows=1 width=9)
+   Hash Cond: (baz.text_any = (bar.char_3)::text)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=5)
+         ->  Seq Scan on baz  (cost=0.00..431.00 rows=1 width=5)
+   ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+         ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+               ->  Seq Scan on bar  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(8 rows)
+
+select char_3, text_any from bar join baz on char_3=text_any;
+ char_3 | text_any 
+--------+----------
+(0 rows)
+
+-- foo - bar join: varchar cast to bpchar
+-- 'cd' matches 'cd'
+-- foo - baz join: no cast
+-- 'cd' doesn't match 'cd  '
+-- returns 0 rows
+-- Notice ORCA changes join order to minimize motion
+explain select varchar_3, char_3, text_any from foo join bar on varchar_3=char_3
+join baz on varchar_3=text_any;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Hash Join  (cost=0.00..1293.00 rows=1 width=12)
+   Hash Cond: ((foo.varchar_3)::bpchar = bar.char_3)
+   ->  Hash Join  (cost=0.00..862.00 rows=1 width=8)
+         Hash Cond: (baz.text_any = (foo.varchar_3)::text)
+         ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=5)
+               ->  Seq Scan on baz  (cost=0.00..431.00 rows=1 width=5)
+         ->  Hash  (cost=431.00..431.00 rows=1 width=3)
+               ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=3)
+                     ->  Seq Scan on foo  (cost=0.00..431.00 rows=1 width=3)
+   ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+         ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+               ->  Seq Scan on bar  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(13 rows)
+
+select varchar_3, char_3, text_any from foo join bar on varchar_3=char_3
+join baz on varchar_3=text_any;
+ varchar_3 | char_3 | text_any 
+-----------+--------+----------
+(0 rows)
+
 -- Clean up. None of the objects we create are very interesting to keep around.
 reset search_path;
 set client_min_messages='warning';

--- a/src/test/regress/sql/bfv_joins.sql
+++ b/src/test/regress/sql/bfv_joins.sql
@@ -453,6 +453,49 @@ where
 
 drop table t_13722;
 
+-- This test is introduced to verify incorrect result
+-- from hash join of char columns is fixed
+-- Notice when varchar/text is cast to bpchar and used for
+-- comparison, the trailing spaces are ignored
+-- When char is cast to varchar/text, it's considered
+-- comparison, and the trailing spaces are also ignored
+
+-- Prior to the fix, opclasses belonging to different
+-- opfamilies could be grouped as equivalent, and thence
+-- deriving incorrect equality hash join conditions
+
+--start_ignore
+drop table foo;
+drop table bar;
+drop table baz;
+--end_ignore
+create table foo (varchar_3 varchar(3)) distributed by (varchar_3);
+create table bar (char_3 char(3)) distributed by (char_3);
+create table baz (text_any text) distributed by (text_any);
+insert into foo values ('cd'); -- 0 trailing spaces
+insert into bar values ('cd '); -- 1 trailing space
+insert into baz values ('cd  '); -- 2 trailing spaces
+
+-- varchar cast to bpchar
+-- 'cd' matches 'cd', returns 1 row
+explain select varchar_3, char_3 from foo join bar on varchar_3=char_3;
+select varchar_3, char_3 from foo join bar on varchar_3=char_3;
+
+-- char cast to text
+-- 'cd' doesn't match 'cd  ', returns 0 rows
+explain select char_3, text_any from bar join baz on char_3=text_any;
+select char_3, text_any from bar join baz on char_3=text_any;
+
+-- foo - bar join: varchar cast to bpchar
+-- 'cd' matches 'cd'
+-- foo - baz join: no cast
+-- 'cd' doesn't match 'cd  '
+-- returns 0 rows
+-- Notice ORCA changes join order to minimize motion
+explain select varchar_3, char_3, text_any from foo join bar on varchar_3=char_3
+join baz on varchar_3=text_any;
+select varchar_3, char_3, text_any from foo join bar on varchar_3=char_3
+join baz on varchar_3=text_any;
 
 -- Clean up. None of the objects we create are very interesting to keep around.
 reset search_path;


### PR DESCRIPTION
Issue:
The join of two columns, one varchar and one char, of matching values with trailing spaces, generates empty output.

Example:
create table foo (a varchar(3)) distributed by (a); create table bar (b char(3)) distributed by (b);
insert into foo values ('1 ');
insert into bar values ('1 ');
select a, b from foo join bar on a = b;

 a | p
---+---
(0 rows)

Root cause:
According to Postgres documentation, "Values of type character are physically padded with spaces to the specified width n, and are stored and displayed that way. However, trailing spaces are treated as semantically insignificant and disregarded when comparing two values of type character."

This means, '1 ' of char(3) (1 trailing space) is stored as '1  ' (2 trailing spaces). However, when it's used for comparison, such as in a join condition or filter, all the trailing spaces are removed, so it's treated as '1'.

In our example, the join condition foo.a = bar.b doesn't specify casting. Therefore, foo.a of varchar is cast to bpchar, and the join condition becomes bar.b = (foo.a)::bpchar. The trailing spaces are removed for both foo.a and bar.b. '1' == '1' matches, so the query should return 1 row.

However, ORCA generates an additional hash condition, where both foo.a and bar.p are cast to text. The join condition becomes (bar.b = (foo.a)::bpchar) AND ((bar.p)::text = (foo.a)::text)). '1 ' of varchar stays '1 ' when cast to text. However, '1  ' of char(3) becomes '1' when cast to text, cause casting is considered comparison. '1 ' doesn't match '1', so 0 rows is returned.

The derivation of additional hash conditions is designed to optimize multi-column join operations, and in itself has no fault. However, casting char to text (ORCA's derived join condition) isn't equivalent to casting varchar to char (user's join condition). This is because hash of char and hash of varchar/text are two operator classes that belong to two different operator families. If two opclasses belong to different opfamilies, the same operator (equality in this case) invokes different internal functions. Casting foo.a to char enforces a motion on foo, whereas casting bar.b to text enforces a motion on bar.

Solution:
We fix this bug by addressing the opfamily mismatch. When deriving the equivalence classes, instead of checking if the opfamilies of post-cast types match, we check the matching of opfamilies of pre-cast types.

(cherry picked from commit 3dd1aeb976)

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
