### PR TITLE
Force two-stage local aggregate to remove duplicates

### DIFF
--- a/src/backend/executor/execHHashagg.c
+++ b/src/backend/executor/execHHashagg.c
@@ -32,6 +32,7 @@
 #include "utils/elog.h"
 #include "cdb/memquota.h"
 #include "utils/workfile_mgr.h"
+#include "utils/faultinjector.h"
 
 #include "access/hash.h"
 
@@ -467,6 +468,10 @@ lookup_agg_hash_entry(AggState *aggstate,
 	uint64 bloomval;			/* bloom filter value */
    
 	Assert(mt_bind != NULL);
+
+	if (SIMPLE_FAULT_INJECTOR("force_hashagg_stream_hashtable") == FaultInjectorTypeSkip)
+		if (((Agg *) aggstate->ss.ps.plan)->streaming)
+			return NULL;
 
 	if (p_isnew != NULL)
 		*p_isnew = false;

--- a/src/backend/gporca/data/dxl/minidump/AggregateWithSkew.mdp
+++ b/src/backend/gporca/data/dxl/minidump/AggregateWithSkew.mdp
@@ -708,7 +708,7 @@ group by b;
                 <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>
-            <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
+            <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
               <dxl:Properties>
                 <dxl:Cost StartupCost="0" TotalCost="715.260000" Rows="2000000.000000" Width="8"/>
               </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/DQA-GroupBy-HashAggregate1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DQA-GroupBy-HashAggregate1.mdp
@@ -289,7 +289,7 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
+            <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
               <dxl:Properties>
                 <dxl:Cost StartupCost="0" TotalCost="431.000161" Rows="3.000000" Width="8"/>
               </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/DQA-GroupBy-HashAggregate2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DQA-GroupBy-HashAggregate2.mdp
@@ -365,7 +365,7 @@
                   <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>
-              <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
+              <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
                 <dxl:Properties>
                   <dxl:Cost StartupCost="0" TotalCost="431.001880" Rows="20.000000" Width="8"/>
                 </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/DQA-InnerJoin-GroupBy-HashAggregate.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DQA-InnerJoin-GroupBy-HashAggregate.mdp
@@ -556,7 +556,7 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
+            <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
               <dxl:Properties>
                 <dxl:Cost StartupCost="0" TotalCost="862.003697" Rows="10.000001" Width="16"/>
               </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/DqaNoRedistribute.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DqaNoRedistribute.mdp
@@ -707,7 +707,7 @@
     <dxl:Plan Id="0" SpaceSize="16">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.972943" Rows="101.000000" Width="12"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.965888" Rows="101.000000" Width="12"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -721,7 +721,7 @@
         <dxl:SortingColumnList/>
         <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.968426" Rows="101.000000" Width="12"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.961371" Rows="101.000000" Width="12"/>
           </dxl:Properties>
           <dxl:GroupingColumns>
             <dxl:GroupingColumn ColId="0"/>
@@ -744,7 +744,7 @@
           <dxl:Filter/>
           <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.945220" Rows="568.125000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.938165" Rows="568.125000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -761,9 +761,9 @@
                 <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
               </dxl:HashExpr>
             </dxl:HashExprList>
-            <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
+            <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.940478" Rows="568.125000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.933423" Rows="568.125000" Width="8"/>
               </dxl:Properties>
               <dxl:GroupingColumns>
                 <dxl:GroupingColumn ColId="0"/>

--- a/src/backend/gporca/data/dxl/minidump/MultiColumnDQA-InnerJoin-GroupBy-HashAggregate.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MultiColumnDQA-InnerJoin-GroupBy-HashAggregate.mdp
@@ -507,7 +507,7 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
+            <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
               <dxl:Properties>
                 <dxl:Cost StartupCost="0" TotalCost="862.004184" Rows="10.000001" Width="20"/>
               </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/ScalarDQAWithNonScalarAgg.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ScalarDQAWithNonScalarAgg.mdp
@@ -1498,7 +1498,7 @@
                   <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>
-              <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
+              <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
                 <dxl:Properties>
                   <dxl:Cost StartupCost="0" TotalCost="441.310000" Rows="100000.000000" Width="8"/>
                 </dxl:Properties>

--- a/src/backend/gporca/data/dxl/minidump/ThreeStageAgg-DistinctOnDistrCol.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ThreeStageAgg-DistinctOnDistrCol.mdp
@@ -264,7 +264,7 @@
     <dxl:Plan Id="0" SpaceSize="38">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="572.182073" Rows="4.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="571.058696" Rows="4.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="10" Alias="sum">
@@ -275,7 +275,7 @@
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="572.181930" Rows="4.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="571.058552" Rows="4.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="10" Alias="sum">
@@ -286,7 +286,7 @@
           <dxl:OneTimeFilter/>
           <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="572.181930" Rows="4.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="571.058552" Rows="4.000000" Width="8"/>
             </dxl:Properties>
             <dxl:GroupingColumns>
               <dxl:GroupingColumn ColId="1"/>
@@ -309,7 +309,7 @@
             <dxl:Filter/>
             <dxl:Sort SortDiscardDuplicates="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="572.181903" Rows="4.500000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="571.058525" Rows="4.500000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">
@@ -327,7 +327,7 @@
               <dxl:LimitOffset/>
               <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="572.181783" Rows="4.500000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="571.058406" Rows="4.500000" Width="8"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="a">
@@ -344,9 +344,9 @@
                     <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>
-                <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
+                <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="572.181727" Rows="4.500000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="571.058350" Rows="4.500000" Width="8"/>
                   </dxl:Properties>
                   <dxl:GroupingColumns>
                     <dxl:GroupingColumn ColId="1"/>

--- a/src/backend/gporca/data/dxl/minidump/ThreeStageAgg-GbMultipleCol-DistinctOnDistrCol.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ThreeStageAgg-GbMultipleCol-DistinctOnDistrCol.mdp
@@ -265,7 +265,7 @@
     <dxl:Plan Id="0" SpaceSize="38">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="637.664977" Rows="11.250000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="635.979922" Rows="11.250000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="10" Alias="sum">
@@ -276,7 +276,7 @@
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="637.664573" Rows="11.250000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="635.979518" Rows="11.250000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="10" Alias="sum">
@@ -287,7 +287,7 @@
           <dxl:OneTimeFilter/>
           <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="637.664573" Rows="11.250000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="635.979518" Rows="11.250000" Width="8"/>
             </dxl:Properties>
             <dxl:GroupingColumns>
               <dxl:GroupingColumn ColId="1"/>
@@ -314,7 +314,7 @@
             <dxl:Filter/>
             <dxl:Sort SortDiscardDuplicates="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="637.664480" Rows="11.250000" Width="12"/>
+                <dxl:Cost StartupCost="0" TotalCost="635.979425" Rows="11.250000" Width="12"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">
@@ -336,7 +336,7 @@
               <dxl:LimitOffset/>
               <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="637.663526" Rows="11.250000" Width="12"/>
+                  <dxl:Cost StartupCost="0" TotalCost="635.978472" Rows="11.250000" Width="12"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="a">
@@ -359,9 +359,9 @@
                     <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
                   </dxl:HashExpr>
                 </dxl:HashExprList>
-                <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
+                <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="637.663315" Rows="11.250000" Width="12"/>
+                    <dxl:Cost StartupCost="0" TotalCost="635.978260" Rows="11.250000" Width="12"/>
                   </dxl:Properties>
                   <dxl:GroupingColumns>
                     <dxl:GroupingColumn ColId="1"/>

--- a/src/backend/gporca/data/dxl/minidump/ThreeStageAgg-GbandDistinctOnDistrCol.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ThreeStageAgg-GbandDistinctOnDistrCol.mdp
@@ -264,7 +264,7 @@
     <dxl:Plan Id="0" SpaceSize="11">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="507.148781" Rows="2.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="506.587091" Rows="2.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="10" Alias="sum">
@@ -275,7 +275,7 @@
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="507.148709" Rows="2.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="506.587019" Rows="2.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="10" Alias="sum">
@@ -286,7 +286,7 @@
           <dxl:OneTimeFilter/>
           <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="507.148709" Rows="2.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="506.587019" Rows="2.000000" Width="8"/>
             </dxl:Properties>
             <dxl:GroupingColumns>
               <dxl:GroupingColumn ColId="0"/>
@@ -309,7 +309,7 @@
             <dxl:Filter/>
             <dxl:Sort SortDiscardDuplicates="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="507.148701" Rows="2.000000" Width="4"/>
+                <dxl:Cost StartupCost="0" TotalCost="506.587011" Rows="2.000000" Width="4"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">
@@ -322,9 +322,9 @@
               </dxl:SortingColumnList>
               <dxl:LimitCount/>
               <dxl:LimitOffset/>
-              <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
+              <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="507.148701" Rows="2.000000" Width="4"/>
+                  <dxl:Cost StartupCost="0" TotalCost="506.587011" Rows="2.000000" Width="4"/>
                 </dxl:Properties>
                 <dxl:GroupingColumns>
                   <dxl:GroupingColumn ColId="0"/>

--- a/src/backend/gporca/data/dxl/minidump/retail_28.mdp
+++ b/src/backend/gporca/data/dxl/minidump/retail_28.mdp
@@ -4372,7 +4372,7 @@ ORDER BY to_char(order_datetime,'YYYY-Q')
                   <dxl:Ident ColId="6" ColName="item_shipment_status_code" TypeMdid="0.1043.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>
-              <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
+              <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
                 <dxl:Properties>
                   <dxl:Cost StartupCost="0" TotalCost="852034.836509" Rows="246206051.943378" Width="27"/>
                 </dxl:Properties>

--- a/src/backend/gporca/libgpopt/src/xforms/CXformSplitDQA.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformSplitDQA.cpp
@@ -724,13 +724,11 @@ CXformSplitDQA::PexprMultiLevelAggregation(
 	CExpressionArray *pdrgpexprLastStage = pdrgpexprPrElSecondStage;
 	if (fSplit2LevelsOnly)
 	{
-		// for scalar DQA the local aggregate is responsible for removing duplicates
-		BOOL fLocalAggGeneratesDuplicates = (0 < pdrgpcrLastStage->Size());
-
+		// the local aggregate is responsible for removing duplicates
 		pdrgpcrArgDQA->AddRef();
 		popFirstStage = GPOS_NEW(mp) CLogicalGbAgg(
 			mp, pdrgpcrLocal, COperator::EgbaggtypeLocal,
-			fLocalAggGeneratesDuplicates, pdrgpcrArgDQA, aggStage);
+			false /* fGeneratesDuplicates */, pdrgpcrArgDQA, aggStage);
 		pdrgpcrLastStage->AddRef();
 		popSecondStage = GPOS_NEW(mp) CLogicalGbAgg(
 			mp, pdrgpcrLastStage, COperator::EgbaggtypeGlobal, /* egbaggtype */

--- a/src/test/isolation2/expected/spilling_hashagg.out
+++ b/src/test/isolation2/expected/spilling_hashagg.out
@@ -1,0 +1,64 @@
+-- start_ignore
+-- end_ignore
+
+-- Test Orca properly removes duplicates in DQA
+-- (https://github.com/greenplum-db/gpdb/issues/14993)
+
+CREATE TABLE test_src_tbl AS WITH cte1 AS ( SELECT field5 from generate_series(1,1000) field5 ) SELECT field5 % 100 AS a, field5 % 100  + 1 AS b FROM cte1 DISTRIBUTED BY (a);
+CREATE 1000
+ANALYZE test_src_tbl;
+ANALYZE
+
+
+-- Use isolation2 framework to force a streaming hash aggregate to clear the
+-- hash table and stream tuples to next stage aggregate. This is to simulate
+-- hash table spills after 100 tuples inserted any segment.
+SELECT gp_inject_fault('force_hashagg_stream_hashtable', 'skip', '', '', '', 100, 100, 0, dbid) FROM gp_segment_configuration WHERE role='p';
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+ Success:        
+(4 rows)
+CREATE TABLE test_hashagg_on AS SELECT a, COUNT(DISTINCT b) AS b FROM test_src_tbl GROUP BY a;
+CREATE 100
+EXPLAIN (costs off) SELECT a, COUNT(DISTINCT b) AS b FROM test_src_tbl GROUP BY a;
+ QUERY PLAN                                 
+--------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)   
+   ->  GroupAggregate                       
+         Group Key: a                       
+         ->  Sort                           
+               Sort Key: a                  
+               ->  Seq Scan on test_src_tbl 
+ Optimizer: Postgres query optimizer        
+(7 rows)
+
+-- Compare results against a group aggregate plan.
+set optimizer_enable_hashagg=off;
+SET
+CREATE TABLE test_hashagg_off AS SELECT a, COUNT(DISTINCT b) AS b FROM test_src_tbl GROUP BY a;
+CREATE 100
+EXPLAIN (costs off) SELECT a, COUNT(DISTINCT b) AS b FROM test_src_tbl GROUP BY a;
+ QUERY PLAN                                 
+--------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)   
+   ->  GroupAggregate                       
+         Group Key: a                       
+         ->  Sort                           
+               Sort Key: a                  
+               ->  Seq Scan on test_src_tbl 
+ Optimizer: Postgres query optimizer        
+(7 rows)
+
+-- Results should match
+SELECT (n_total=n_matches) AS match FROM ( SELECT COUNT(*) n_total, SUM(CASE WHEN t1.b = t2.b THEN 1 ELSE 0 END) n_matches FROM test_hashagg_on t1 JOIN test_hashagg_off t2 ON t1.a = t2.a) t;
+ match 
+-------
+ t     
+(1 row)
+
+
+-- start_ignore
+-- end_ignore

--- a/src/test/isolation2/expected/spilling_hashagg_optimizer.out
+++ b/src/test/isolation2/expected/spilling_hashagg_optimizer.out
@@ -1,0 +1,64 @@
+-- start_ignore
+-- end_ignore
+
+-- Test Orca properly removes duplicates in DQA
+-- (https://github.com/greenplum-db/gpdb/issues/14993)
+
+CREATE TABLE test_src_tbl AS WITH cte1 AS ( SELECT field5 from generate_series(1,1000) field5 ) SELECT field5 % 100 AS a, field5 % 100  + 1 AS b FROM cte1 DISTRIBUTED BY (a);
+CREATE 1000
+ANALYZE test_src_tbl;
+ANALYZE
+
+
+-- Use isolation2 framework to force a streaming hash aggregate to clear the
+-- hash table and stream tuples to next stage aggregate. This is to simulate
+-- hash table spills after 100 tuples inserted any segment.
+SELECT gp_inject_fault('force_hashagg_stream_hashtable', 'skip', '', '', '', 100, 100, 0, dbid) FROM gp_segment_configuration WHERE role='p';
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+ Success:        
+(4 rows)
+CREATE TABLE test_hashagg_on AS SELECT a, COUNT(DISTINCT b) AS b FROM test_src_tbl GROUP BY a;
+CREATE 100
+EXPLAIN (costs off) SELECT a, COUNT(DISTINCT b) AS b FROM test_src_tbl GROUP BY a;
+ QUERY PLAN                                 
+--------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)   
+   ->  HashAggregate                        
+         Group Key: a                       
+         ->  HashAggregate                  
+               Group Key: a, b              
+               ->  Seq Scan on test_src_tbl 
+ Optimizer: Pivotal Optimizer (GPORCA)      
+(7 rows)
+
+-- Compare results against a group aggregate plan.
+set optimizer_enable_hashagg=off;
+SET
+CREATE TABLE test_hashagg_off AS SELECT a, COUNT(DISTINCT b) AS b FROM test_src_tbl GROUP BY a;
+CREATE 100
+EXPLAIN (costs off) SELECT a, COUNT(DISTINCT b) AS b FROM test_src_tbl GROUP BY a;
+ QUERY PLAN                                 
+--------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)   
+   ->  GroupAggregate                       
+         Group Key: a                       
+         ->  Sort                           
+               Sort Key: a                  
+               ->  Seq Scan on test_src_tbl 
+ Optimizer: Pivotal Optimizer (GPORCA)      
+(7 rows)
+
+-- Results should match
+SELECT (n_total=n_matches) AS match FROM ( SELECT COUNT(*) n_total, SUM(CASE WHEN t1.b = t2.b THEN 1 ELSE 0 END) n_matches FROM test_hashagg_on t1 JOIN test_hashagg_off t2 ON t1.a = t2.a) t;
+ match 
+-------
+ t     
+(1 row)
+
+
+-- start_ignore
+-- end_ignore

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -323,3 +323,5 @@ test: alter_partition_table_owner
 
 # test copy/insert in utility mode on partition/inheritance hierarchies
 test: copy_insert_utility_mode_hierarchies
+
+test: spilling_hashagg

--- a/src/test/isolation2/sql/spilling_hashagg.sql
+++ b/src/test/isolation2/sql/spilling_hashagg.sql
@@ -1,0 +1,45 @@
+-- start_ignore
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+DROP TABLE IF EXISTS test_src_tbl;
+DROP TABLE IF EXISTS test_hashagg_on;
+DROP TABLE IF EXISTS test_hashagg_off;
+-- end_ignore
+
+-- Test Orca properly removes duplicates in DQA
+-- (https://github.com/greenplum-db/gpdb/issues/14993)
+
+CREATE TABLE test_src_tbl AS
+WITH cte1 AS (
+    SELECT field5 from generate_series(1,1000) field5
+)
+SELECT field5 % 100 AS a, field5 % 100  + 1 AS b
+FROM cte1 DISTRIBUTED BY (a);
+ANALYZE test_src_tbl;
+
+
+-- Use isolation2 framework to force a streaming hash aggregate to clear the
+-- hash table and stream tuples to next stage aggregate. This is to simulate
+-- hash table spills after 100 tuples inserted any segment.
+SELECT gp_inject_fault('force_hashagg_stream_hashtable', 'skip', '', '', '', 100, 100, 0, dbid) FROM gp_segment_configuration WHERE role='p';
+CREATE TABLE test_hashagg_on AS
+SELECT a, COUNT(DISTINCT b) AS b FROM test_src_tbl GROUP BY a;
+EXPLAIN (costs off) SELECT a, COUNT(DISTINCT b) AS b FROM test_src_tbl GROUP BY a;
+
+-- Compare results against a group aggregate plan.
+set optimizer_enable_hashagg=off;
+CREATE TABLE test_hashagg_off AS
+SELECT a, COUNT(DISTINCT b) AS b FROM test_src_tbl GROUP BY a;
+EXPLAIN (costs off) SELECT a, COUNT(DISTINCT b) AS b FROM test_src_tbl GROUP BY a;
+
+-- Results should match
+SELECT (n_total=n_matches) AS match FROM (
+SELECT COUNT(*) n_total, SUM(CASE WHEN t1.b = t2.b THEN 1 ELSE 0 END) n_matches
+FROM test_hashagg_on t1
+JOIN test_hashagg_off t2 ON t1.a = t2.a) t;
+
+
+-- start_ignore
+SELECT gp_inject_fault('force_hashagg_stream_hashtable', 'status', '', '', '', 100, 100, 0, dbid) FROM gp_segment_configuration WHERE role='p';
+SELECT gp_inject_fault('force_hashagg_stream_hashtable', 'reset', '', '', '', 100, 100, 0, dbid) FROM gp_segment_configuration WHERE role='p';
+RESET ALL;
+-- end_ignore


### PR DESCRIPTION
In a two-stage hash aggregate plan, if the local stage aggregate hash table fills up then it has one of two options:

 1) spill to disk
 2) stream to next stage aggregate.

Issue is if we stream a DQA to next stage and the next stage isn't prepared to handle duplicates, then we could encounter wrong results. That was observed in the following plan:

    SELECT a, COUNT(DISTINCT b) FROM t GROUP BY a;

                                       QUERY PLAN
    --------------------------------------------------------------------------------
     Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..3366.93 rows=7 width=12)
       ->  HashAggregate  (cost=0.00..3366.93 rows=3 width=12)
             Group Key: a
             ->  HashAggregate  (cost=0.00..3212.44 rows=1273152 width=8)
                   Group Key: a, b
                   ->  Seq Scan on test  (cost=0.00..640.00 rows=10000034 width=8)
     Optimizer: Pivotal Optimizer (GPORCA)
    (7 rows)

The second HashAggregate used hybrid hashtable in streaming mode. That is, when the hashtable enumerating all distinct pairs of A and B fills up, we start it over instead of spilling to disc. This results in duplicates and we get more tuples as a result of this query.

It seems that we are using streaming hashtable, because optimizer thinks that it is okay to produce duplicates for this plan HashAggregate (<dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true"> from minidump), but it is not. The fix here simply prohibits the aggregate node from producing duplicates, and it resolves the problem.

Authored-by: Smyatkin Maxim (with minor edits by David Kimura)

(cherry picked from commit 701291cbab42f032bdb6ec70023f4b6d2f53abdc)