### PR TITLE
Throws ERROR when statement_mem is set to greater than max_statement_mem

### DIFF
--- a/src/backend/cdb/cdbvars.c
+++ b/src/backend/cdb/cdbvars.c
@@ -571,6 +571,7 @@ gpvars_check_statement_mem(int *newval, void **extra, GucSource source)
 	{
 		GUC_check_errmsg("Invalid input for statement_mem, must be less than max_statement_mem (%d kB)",
 						 max_statement_mem);
+		return false;
 	}
 
 	return true;

--- a/src/test/regress/expected/guc_gp.out
+++ b/src/test/regress/expected/guc_gp.out
@@ -739,3 +739,7 @@ ALTER RESOURCE QUEUE pg_default ACTIVE THRESHOLD -10;
 ERROR:  active threshold cannot be less than -1 or equal to 0
 -- Reset
 RESET log_statement;
+-- Try to set statement_mem > max_statement_mem
+SET statement_mem = '4000MB';
+ERROR:  Invalid input for statement_mem, must be less than max_statement_mem (2048000 kB)
+RESET statement_mem;

--- a/src/test/regress/sql/guc_gp.sql
+++ b/src/test/regress/sql/guc_gp.sql
@@ -431,3 +431,7 @@ ALTER RESOURCE QUEUE pg_default ACTIVE THRESHOLD -10;
 -- Reset
 RESET log_statement;
 
+-- Try to set statement_mem > max_statement_mem
+SET statement_mem = '4000MB';
+RESET statement_mem;
+


### PR DESCRIPTION
## Summary

The GPDB's document says that:
> `statement_mem`
> Sets the maximum memory limit for a query. Helps avoid out-of-memory errors on a segment host during query processing as a result of setting statement_mem too high.

However, there is no any ERROR when I set `statement_mem` to greater than `max_statement_mem`.
So, `max_statement_mem` loses protection for `statement_mem`.

## Test Case

```sql
postgres=# select version();
                                                                                                       version
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 PostgreSQL 12.12 (Greenplum Database 7.0.0-beta.1+dev.90.g7ac8734891 build dev) on x86_64-pc-linux-gnu, compiled by gcc (GCC) 9.3.1 20200408 (Red Hat 9.3.1-2), 64-bit compiled on Feb 17 2023 10:00:04 Bhuvnesh C.
(1 row)

postgres=# show max_statement_mem;
 max_statement_mem
-------------------
 2000MB
(1 row)

postgres=# show statement_mem;
 statement_mem
---------------
 125MB
(1 row)

-- Set statement_mem > max_statement_mem,
-- but no ERROR reported.
postgres=# set statement_mem = '4000MB';
SET
postgres=# show statement_mem;
 statement_mem
---------------
 4000MB
(1 row)

-- The 'Memory used' of query is 4000MB(4096000kB)
postgres=# explain analyze select 1;
                                     QUERY PLAN
------------------------------------------------------------------------------------
 Result  (cost=0.00..0.00 rows=1 width=1) (actual time=0.002..0.002 rows=1 loops=1)
 Optimizer: Pivotal Optimizer (GPORCA)
 Planning Time: 1.447 ms
   (slice0)    Executor memory: 4K bytes.
 Memory used:  4096000kB
 Execution Time: 0.034 ms
(6 rows)
```


## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
