### PR TITLE
remove reduant invocation of `mdinit()` at `smgr_init_standard()`

### DIFF
--- a/src/backend/storage/smgr/smgr.c
+++ b/src/backend/storage/smgr/smgr.c
@@ -120,7 +120,6 @@ smgr_init_standard(void)
 		if (smgrsw[i].smgr_init)
 			smgrsw[i].smgr_init();
 	}
-	mdinit();
 }
 
 


### PR DESCRIPTION
This PR is trying to fix the issue of #14561, we should not invoke `mdinit()`
directly at the end of the function `smgr_init_standard()`.

No more tests are needed, cause current tests are enough to cover.