### PR TITLE
[7X] Fix hardcoded schema in partition creation DDL.

### DIFF
--- a/src/backend/parser/parse_partition_gp.c
+++ b/src/backend/parser/parse_partition_gp.c
@@ -1530,9 +1530,12 @@ transformGpPartDefElemWithRangeSpec(ParseState *pstate, Relation parentrel, GpPa
 		param->paramcollid = part_col_collation;
 		param->location = -1;
 
-		/* Look up + operator */
+		/*
+		 * Look up the '+' operator in the current searching path (controlled by search_path parameter).
+		 * Just like what we do for the 'BETWEEN ... AND ...' clause.
+		 */
 		plusexpr = (Node *) make_op(pstate,
-									list_make2(makeString("pg_catalog"), makeString("+")),
+									list_make1(makeString("+")),
 									(Node *) param,
 									(Node *) transformExpr(pstate, every, EXPR_KIND_PARTITION_BOUND),
 									pstate->p_last_srf,

--- a/src/test/regress/expected/bfv_partition.out
+++ b/src/test/regress/expected/bfv_partition.out
@@ -698,7 +698,7 @@ create table mpp3058 (a char(1), b date, d char(3))
   (           
     partition aa start ('2008-01-01') end ('2009-01-01') every( '1 day')  
      );
-ERROR:  operator is not unique: date pg_catalog.+ unknown
+ERROR:  operator is not unique: date + unknown
 LINE 5: ...aa start ('2008-01-01') end ('2009-01-01') every( '1 day')  
                                                              ^
 HINT:  Could not choose a best candidate operator. You might need to add explicit type casts.

--- a/src/test/regress/expected/partition1.out
+++ b/src/test/regress/expected/partition1.out
@@ -2856,3 +2856,82 @@ create table hashpart_gpspec (a int, b int) partition by hash (b) (partition p1 
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 ERROR:  Not supported partition strategy
+-- Test (START (VAL1) END (VAL2) EVERY (INTERVAL_VAL)) syntax against customed types.
+CREATE SCHEMA part_op_test;
+SET search_path = 'part_op_test';
+CREATE TYPE myint;
+CREATE FUNCTION myint_in(cstring) RETURNS myint AS 'int4in' LANGUAGE INTERNAL IMMUTABLE STRICT;
+NOTICE:  return type myint is only a shell
+CREATE FUNCTION myint_out(myint) RETURNS cstring AS 'int4out' LANGUAGE INTERNAL IMMUTABLE STRICT;
+NOTICE:  argument type myint is only a shell
+CREATE TYPE myint (INPUT=myint_in, OUTPUT=myint_out, passedbyvalue, internallength=4);
+CREATE FUNCTION myint_lt(myint, myint) RETURNS boolean AS 'int4lt' LANGUAGE INTERNAL IMMUTABLE STRICT;
+CREATE FUNCTION myint_le(myint, myint) RETURNS boolean AS 'int4le' LANGUAGE INTERNAL IMMUTABLE STRICT;
+CREATE FUNCTION myint_gt(myint, myint) RETURNS boolean AS 'int4gt' LANGUAGE INTERNAL IMMUTABLE STRICT;
+CREATE FUNCTION myint_ge(myint, myint) RETURNS boolean AS 'int4ge' LANGUAGE INTERNAL IMMUTABLE STRICT;
+CREATE FUNCTION myint_eq(myint, myint) RETURNS boolean AS 'int4eq' LANGUAGE INTERNAL IMMUTABLE STRICT;
+CREATE FUNCTION myint_ne(myint, myint) RETURNS boolean AS 'int4ne' LANGUAGE INTERNAL IMMUTABLE STRICT;
+CREATE FUNCTION myint_pl_myint(myint, myint) RETURNS myint   AS 'int4pl' LANGUAGE INTERNAL IMMUTABLE STRICT;
+CREATE OPERATOR < (LEFTARG=myint, RIGHTARG=myint, PROCEDURE=myint_lt, COMMUTATOR= >, NEGATOR= >=, RESTRICT=scalarltsel, JOIN=scalarltjoinsel);
+CREATE OPERATOR > (LEFTARG=myint, RIGHTARG=myint, PROCEDURE=myint_gt, COMMUTATOR= <, negator= <=, RESTRICT=scalargtsel, JOIN=scalargtjoinsel);
+CREATE OPERATOR <= (LEFTARG=myint, RIGHTARG=myint, PROCEDURE=myint_le, COMMUTATOR= >=, NEGATOR= >, RESTRICT=scalarltsel, JOIN=scalarltjoinsel);
+CREATE OPERATOR >= (LEFTARG=myint, RIGHTARG=myint, PROCEDURE=myint_ge, COMMUTATOR= <=, NEGATOR= <, RESTRICT=scalargtsel, JOIN=scalargtjoinsel);
+CREATE OPERATOR = (LEFTARG=myint, RIGHTARG=myint, PROCEDURE=myint_eq, COMMUTATOR= =, NEGATOR= <>, RESTRICT=eqsel, JOIN=eqjoinsel, hashes, merges);
+CREATE OPERATOR <> (LEFTARG=myint, RIGHTARG=myint, PROCEDURE=myint_ne, COMMUTATOR= <>, NEGATOR= =, RESTRICT=neqsel, JOIN=neqjoinsel, merges);
+CREATE FUNCTION bt_myint_cmp (myint, myint) RETURNS int AS 'btint4cmp' LANGUAGE INTERNAL IMMUTABLE STRICT;
+CREATE OPERATOR CLASS bt_myint_ops DEFAULT FOR TYPE myint USING btree family integer_ops AS
+  operator 1 <,
+  operator 2 <=,
+  operator 3 =,
+  operator 4 >=,
+  operator 5 >,
+  FUNCTION 1 bt_myint_cmp (myint, myint);
+CREATE CAST (int AS myint) WITHOUT FUNCTION AS IMPLICIT;
+-- We don't have operator +(myint, myint), failure expected.
+CREATE TABLE issue_14956_part_table_with_customed_type
+(
+  col1 int4,
+  col2 myint
+)
+DISTRIBUTED BY (col1)
+PARTITION BY RANGE (col2)
+  (START (1) END (10) EVERY (1::myint));
+ERROR:  operator does not exist: myint + myint
+LINE 8:   (START (1) END (10) EVERY (1::myint));
+                                     ^
+HINT:  No operator matches the given name and argument types. You might need to add explicit type casts.
+CREATE OPERATOR + (LEFTARG = myint, RIGHTARG = myint, PROCEDURE = myint_pl_myint, COMMUTATOR = + );
+-- Now, we can create the partitioned table with Greenplum syntax.
+CREATE TABLE issue_14956_part_table_with_customed_type
+(
+  col1 int4,
+  col2 myint
+)
+DISTRIBUTED BY (col1)
+PARTITION BY RANGE (col2)
+  (START (1) END (10) EVERY (1::myint));
+INSERT INTO issue_14956_part_table_with_customed_type VALUES (1, 2), (2, 3);
+-- Clean up.
+DROP SCHEMA part_op_test CASCADE;
+NOTICE:  drop cascades to 21 other objects
+DETAIL:  drop cascades to function myint_out(myint)
+drop cascades to type myint
+drop cascades to function myint_in(cstring)
+drop cascades to cast from integer to myint
+drop cascades to function myint_lt(myint,myint)
+drop cascades to function myint_le(myint,myint)
+drop cascades to function myint_gt(myint,myint)
+drop cascades to function myint_ge(myint,myint)
+drop cascades to function myint_eq(myint,myint)
+drop cascades to function myint_ne(myint,myint)
+drop cascades to function myint_pl_myint(myint,myint)
+drop cascades to operator >(myint,myint)
+drop cascades to operator >=(myint,myint)
+drop cascades to operator <(myint,myint)
+drop cascades to operator <=(myint,myint)
+drop cascades to operator <>(myint,myint)
+drop cascades to operator =(myint,myint)
+drop cascades to function bt_myint_cmp(myint,myint)
+drop cascades to operator class bt_myint_ops for access method btree
+drop cascades to operator +(myint,myint)
+drop cascades to table issue_14956_part_table_with_customed_type

--- a/src/test/regress/output/partition_ddl.source
+++ b/src/test/regress/output/partition_ddl.source
@@ -15,7 +15,7 @@ PARTITION BY LIST (gender)
 SUBPARTITION BY RANGE (year) 
 SUBPARTITION TEMPLATE (start ('2000') end ('2006') every (interval '1')) 
 (PARTITION girls VALUES ('F'), PARTITION boys VALUES ('M'));
-ERROR:  operator does not exist: smallint pg_catalog.+ interval
+ERROR:  operator does not exist: smallint + interval
 LINE 4: ...TION TEMPLATE (start ('2000') end ('2006') every (interval '...
                                                              ^
 HINT:  No operator matches the given name and argument types. You might need to add explicit type casts.


### PR DESCRIPTION
Historically, Greenplum is hardcoding the schema when looking up the '+' operator for the range partitioned table creation DDL `(START (XXX) END (YYY) EVERY (ZZZ))`.

This patch simply removes the hardcoded schema name which is similar to the logic behind processing `BETWEEN XXX AND YYY` syntax. When evaluating the `BETWEEN XXX AND YYY` clause, PostgreSQL looks up the `'>='` and `'<='` operators in the current searching path.

e.g.,

```
CREATE TYPE myint;
CREATE FUNCTION myint_in(cstring) RETURNS myint AS 'int4in' LANGUAGE INTERNAL IMMUTABLE STRICT;
CREATE FUNCTION myint_out(myint) RETURNS cstring AS 'int4out' LANGUAGE INTERNAL IMMUTABLE STRICT;
CREATE TYPE myint (INPUT=myint_in, OUTPUT=myint_out, passedbyvalue, internallength=4);
CREATE FUNCTION myint_lt(myint, myint) RETURNS boolean AS 'int4lt' LANGUAGE INTERNAL IMMUTABLE STRICT;
CREATE FUNCTION myint_le(myint, myint) RETURNS boolean AS 'int4le' LANGUAGE INTERNAL IMMUTABLE STRICT;
CREATE FUNCTION myint_gt(myint, myint) RETURNS boolean AS 'int4gt' LANGUAGE INTERNAL IMMUTABLE STRICT;
CREATE FUNCTION myint_ge(myint, myint) RETURNS boolean AS 'int4ge' LANGUAGE INTERNAL IMMUTABLE STRICT;
CREATE FUNCTION myint_eq(myint, myint) RETURNS boolean AS 'int4eq' LANGUAGE INTERNAL IMMUTABLE STRICT;
CREATE FUNCTION myint_ne(myint, myint) RETURNS boolean AS 'int4ne' LANGUAGE INTERNAL IMMUTABLE STRICT;
CREATE FUNCTION myint_pl_myint(myint, myint) RETURNS myint   AS 'int4pl' LANGUAGE INTERNAL IMMUTABLE STRICT;
CREATE OPERATOR < (LEFTARG=myint, RIGHTARG=myint, PROCEDURE=myint_lt, COMMUTATOR= >, NEGATOR= >=, RESTRICT=scalarltsel, JOIN=scalarltjoinsel);
CREATE OPERATOR > (LEFTARG=myint, RIGHTARG=myint, PROCEDURE=myint_gt, COMMUTATOR= <, negator= <=, RESTRICT=scalargtsel, JOIN=scalargtjoinsel);
CREATE OPERATOR <= (LEFTARG=myint, RIGHTARG=myint, PROCEDURE=myint_le, COMMUTATOR= >=, NEGATOR= >, RESTRICT=scalarltsel, JOIN=scalarltjoinsel);
CREATE OPERATOR >= (LEFTARG=myint, RIGHTARG=myint, PROCEDURE=myint_ge, COMMUTATOR= <=, NEGATOR= <, RESTRICT=scalargtsel, JOIN=scalargtjoinsel);
CREATE OPERATOR = (LEFTARG=myint, RIGHTARG=myint, PROCEDURE=myint_eq, COMMUTATOR= =, NEGATOR= <>, RESTRICT=eqsel, JOIN=eqjoinsel, hashes, merges);
CREATE OPERATOR <> (LEFTARG=myint, RIGHTARG=myint, PROCEDURE=myint_ne, COMMUTATOR= <>, NEGATOR= =, RESTRICT=neqsel, JOIN=neqjoinsel, merges);
CREATE FUNCTION bt_myint_cmp (myint, myint) RETURNS int AS 'btint4cmp' LANGUAGE INTERNAL IMMUTABLE STRICT;
CREATE OPERATOR CLASS bt_myint_ops DEFAULT FOR TYPE myint USING btree family integer_ops AS
  operator 1 <,
  operator 2 <=,
  operator 3 =,
  operator 4 >=,
  operator 5 >,
  FUNCTION 1 bt_myint_cmp (myint, myint);
CREATE CAST (int AS myint) WITHOUT FUNCTION AS IMPLICIT;

CREATE TABLE t(i myint);

-- Operator '<=' and '>=' exist in the current search_path.
SELECT * FROM t WHERE i BETWEEN 1 AND 2;

-- Change the search_path and PostgreSQL cannot find the operator.
SET search_path TO '';
SELECT * FROM public.t WHERE i BETWEEN 1::public.myint AND 2::public.myint;

ERROR:  operator does not exist: public.myint >= public.myint
```

Partially fix #14956 for main branch.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [x] Pass `make installcheck`
