### PR TITLE
Fix coredump when use group by with jit enabled

### DIFF
--- a/src/backend/jit/llvm/llvmjit_expr.c
+++ b/src/backend/jit/llvm/llvmjit_expr.c
@@ -1939,7 +1939,7 @@ llvm_compile_expr(ExprState *state)
 
 					/* Copy aggstate->group_id to the result */
 					v_group_id_p = l_ptr_const(&aggstate->group_id,
-											  l_ptr(LLVMInt32Type()));
+											  l_ptr(TypeSizeT));
 					v_group_id = LLVMBuildLoad(b, v_group_id_p, "v_group_id");
 
 					/* and store result */
@@ -1958,7 +1958,7 @@ llvm_compile_expr(ExprState *state)
 
 					/* Copy aggstate->gset_id to the result */
 					v_gset_id_p = l_ptr_const(&aggstate->gset_id,
-											  l_ptr(LLVMInt32Type()));
+											  l_ptr(TypeSizeT));
 					v_gset_id = LLVMBuildLoad(b, v_gset_id_p, "v_gset_id");
 
 					/* and store result */
@@ -1977,7 +1977,7 @@ llvm_compile_expr(ExprState *state)
 
 					/* Copy tsstate->currentExprId to the result */
 					v_currentExprId_p = l_ptr_const(&tsstate->currentExprId,
-											  l_ptr(LLVMInt32Type()));
+											  l_ptr(TypeSizeT));
 					v_currentExprId = LLVMBuildLoad(b, v_currentExprId_p, "v_currentExprId");
 
 					/* and store result */


### PR DESCRIPTION
## How to reproduce
Test latest master, it's a serious coredump problem.

Default compile and start a demo-cluster.
```shell
psql postgres
postgres=# create table T (a int, b int, g int);
postgres=# insert into T values (1, 3, 9),(2, 5, 8), (8,7,6),(10,3,2);
INSERT 0 4
postgres=# set jit=on;
postgres=# set jit_inline_above_cost = 0;
SET
postgres=# set jit_above_cost = 0;
SET
postgres=# select g, sum(distinct a), SUM(distinct b) from T group by g;
server closed the connection unexpectedly
        This probably means the server terminated abnormally
        before or while processing the request.
The connection to the server was lost. Attempting reset: Succeeded.
```

## Problem
crash stack into llvm assert:
![image](https://user-images.githubusercontent.com/106943008/222164323-6e93620d-4c81-46c4-92b2-83f12e3231f2.png)


when we want to store a value into a pointer like `LLVMBuildStore(b, v_group_id, v_resvaluep);` , we need to make sure the v_group_id's type is same with v_resvaluep's type and v_resvaluep-element-type，or we will met assert, it's llvm's constraint.
```c
│   1417        void StoreInst::AssertOK() {                                                                                                                                                                                                                  │
│   1418          assert(getOperand(0) && getOperand(1) && "Both operands must be non-null!");                                                                                                                                                                │
│   1419          assert(getOperand(1)->getType()->isPointerTy() &&                                                                                                                                                                                           │
│   1420                 "Ptr must have pointer type!");                                                                                                                                                                                                      │
│  >1421          assert(getOperand(0)->getType() ==                                                                                                                                                                                                          │
│   1422                         cast<PointerType>(getOperand(1)->getType())->getElementType()                                                                                                                                                                │
│   1423                 && "Ptr must be a pointer to Val type!");                                                                                                                                                                                            │
│   1424          assert(!(isAtomic() && getAlignment() == 0) &&                                                                                                                                                                                              │
│   1425                 "Alignment required for atomic store");                                                                                                                                                                                              │
│   1426        }
```
For details type info : https://discourse.llvm.org/t/crashed-assert-at-ptr-must-be-a-pointer-to-val-type-when-use-llvmbuildstore-c-api/67489