### PR TITLE
Fix the pg_resgroup_get_status_kv() function

### DIFF
--- a/src/include/catalog/catversion.h
+++ b/src/include/catalog/catversion.h
@@ -56,6 +56,6 @@
  */
 
 /*							3yyymmddN */
-#define CATALOG_VERSION_NO	302302251
+#define CATALOG_VERSION_NO	302303081
 
 #endif

--- a/src/include/catalog/pg_proc.dat
+++ b/src/include/catalog/pg_proc.dat
@@ -10878,7 +10878,7 @@
    prosrc => 'pg_resgroup_move_query' },
 
 { oid => 6065, descr => 'statistics: information about resource groups in key-value style',
-   proexeclocation => 'c',
+   proexeclocation => 'i',
    proname => 'pg_resgroup_get_status_kv', prorows => '1000', proisstrict => 'f', proretset => 't', provolatile => 'v', proparallel => 'r', prorettype => 'record', proargtypes => 'text', proallargtypes => 'text,oid,text,text', proargmodes => '{i,o,o,o}', proargnames => '{prop_in,rsgid,prop,value}', prosrc => 'pg_resgroup_get_status_kv' },
 
 { oid => 6066, descr => 'statistics: information about resource groups',

--- a/src/test/isolation2/expected/resgroup/resgroup_dumpinfo.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_dumpinfo.out
@@ -16,7 +16,9 @@ groups = [g for g in qd_info["groups"] if g["group_id"] > 6441] #validate user c
 return True 
 conn = pg.connect(dbname="postgres") 
 r = conn.query("select count(*) from gp_segment_configuration where  role = 'p';") n = r.getresult()[0][0] 
-r = conn.query("select value from pg_resgroup_get_status_kv('dump');") json_text =  r.getresult()[0][0] json_obj = json.loads(json_text) 
+# The pg_resgroup_get_status_kv() function must output valid result in CTAS # and simple select queries 
+r = conn.query("select value from pg_resgroup_get_status_kv('dump');") json_text =  r.getresult()[0][0] json_obj = json.loads(json_text) if not validate(json_obj, n): return False 
+conn.query("""CREATE TEMPORARY TABLE t_pg_resgroup_get_status_kv AS SELECT * FROM pg_resgroup_get_status_kv('dump');""") r = conn.query("SELECT value FROM t_pg_resgroup_get_status_kv;") json_text =  r.getresult()[0][0] json_obj = json.loads(json_text) 
 return validate(json_obj, n) 
 $$ LANGUAGE plpython3u;
 CREATE
@@ -65,6 +67,19 @@ ERROR:  only superusers can call this function
 
 RESET ROLE;
 RESET
+
+-- Now 'dump' is the only value at which the function outputs tuples, but the
+-- function must correctly handle any value
+SELECT count(*) FROM pg_resgroup_get_status_kv('not_dump');
+ count 
+-------
+ 0     
+(1 row)
+SELECT count(*) FROM pg_resgroup_get_status_kv(NULL);
+ count 
+-------
+ 0     
+(1 row)
 
 DROP ROLE role_dumpinfo_test;
 DROP


### PR DESCRIPTION
In the case of insert-select, the value column contained information about coordinator only. The error was fixed by setting the proexeclocation property of the function to i (PROEXECLOCATION_INITPLAN).
https://github.com/greenplum-db/gpdb/issues/14154

Execution of the "SELECT * FROM pg_resgroup_get_status_kv(NULL);" query resulted in a segmentation fault. NULL check has been added.

The dumpResGroupInfo() function was called 2 times per query. Now it is called only once.

Simplification of the function code.
