### PR TITLE
Fix a gpcheckcat query after removing blkdiridxid

### DIFF
--- a/gpMgmt/bin/gpcheckcat
+++ b/gpMgmt/bin/gpcheckcat
@@ -1069,9 +1069,10 @@ def checkOwners():
                     a.rolname, m.rolname as coordinator_rolname
     from gp_dist_random('pg_class') r
       join pg_class c on (c.oid = r.oid)
+      left join pg_index i on (c.oid = i.indexrelid)
       left join pg_appendonly ao on (c.oid = ao.segrelid or
                                      c.oid = ao.blkdirrelid or
-                                     c.oid = ao.blkdiridxid)
+                                     i.indrelid = ao.blkdirrelid)
       left join pg_class o on (o.oid = ao.relid or
                                o.reltoastrelid = c.oid)
       join pg_authid a on (a.oid = r.relowner)


### PR DESCRIPTION
After we removed blkdiridxid and visimapidxid from pg_appendonly (commti c16943a6e1e528acb6a8f360119a7f7ab3e3d860), we can no longer query them directly from pg_appendonly. The above commit missed addressing one in gpcheckcat. Address now.

This fix just makes the query identical as before. However, when I tested this it seems that the query (including the original) could not actually achieve what it wants to achieve (find out different owners) for block directory relation AND its index. I feel that it's a quite outdated query and we should update it. Will create issue to address it separately.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
