### PR TITLE
Fix ATSETAM to heap that doesn't clear reloptions for partitioned root

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -5577,8 +5577,10 @@ ATExecCmd(List **wqueue, AlteredTableInfo *tab, Relation rel,
 			{
 				bool aoopt_changed = false;
 				Datum newOptions;
+				/* discard existing reloptions if we are going to change AM */
+				AlterTableType op = OidIsValid(tab->newAccessMethod) ? AT_ReplaceRelOptions : AT_SetRelOptions; 
 
-				newOptions = ATExecSetRelOptions(rel, (List *) cmd->def, cmd->subtype, &aoopt_changed, tab->newAccessMethod, lockmode);
+				newOptions = ATExecSetRelOptions(rel, (List *) cmd->def, op, &aoopt_changed, tab->newAccessMethod, lockmode);
 				CommandCounterIncrement(); /* make reloptions change visiable */
 
 				/* 

--- a/src/test/regress/expected/alter_table_set_am.out
+++ b/src/test/regress/expected/alter_table_set_am.out
@@ -1383,51 +1383,266 @@ DROP TABLE atsetam_part;
 -- 1. Heap->AO->Heap->AO
 -- 2. AO->AOCO->AO->AOCO
 -- 3. Heap->AOCO->Heap->AOCO
+-- create helper function
+CREATE FUNCTION check_atsetam(p_tablename text, p_am text, p_reloptions text, p_expect_empty_reloptions bool, p_expect_relfile_change bool)
+RETURNS boolean
+LANGUAGE plpgsql AS $$
+DECLARE
+    v_result boolean;
+    v_ddl text;
+BEGIN
+    IF p_reloptions = '' THEN
+      v_ddl := 'ALTER TABLE ' || p_tablename || ' SET ACCESS METHOD ' || p_am;
+    ELSE
+      v_ddl := 'ALTER TABLE ' || p_tablename || ' SET ACCESS METHOD ' || p_am || ' WITH (' || p_reloptions || ')';
+    END IF;
+    CREATE TEMP TABLE before_ddl(segid int, relfilenode oid);
+    CREATE TEMP TABLE after_ddl(segid int, relfilenode oid);
+
+    INSERT INTO before_ddl SELECT gp_segment_id segid, relfilenode FROM gp_dist_random('pg_class')
+    WHERE relname = p_tablename ORDER BY segid;
+
+    EXECUTE v_ddl;
+
+    INSERT INTO after_ddl SELECT gp_segment_id segid, relfilenode FROM gp_dist_random('pg_class')
+    WHERE relname = p_tablename ORDER BY segid;
+
+    -- check table rewrite
+    IF p_expect_relfile_change THEN
+      v_result := (SELECT count(a.*)=0 FROM before_ddl b INNER JOIN after_ddl a ON b.segid = a.segid AND b.relfilenode = a.relfilenode);
+    ELSE
+      v_result := (SELECT count(a.*)=0 FROM before_ddl b, after_ddl a WHERE b.segid = a.segid AND b.relfilenode != a.relfilenode);
+    END IF;
+
+    -- check AM
+    v_result := v_result AND (SELECT count(c.*)=1 FROM pg_class c, pg_am a WHERE c.relname = p_tablename AND c.relam = a.oid AND a.amname = p_am);
+
+    -- check reloptions. If not expecting NULL, then just check if what we just set is there.
+    IF p_expect_empty_reloptions THEN
+      v_result := v_result AND (SELECT reloptions IS NULL FROM pg_class WHERE relname = p_tablename);
+    ELSIF p_reloptions != '' THEN
+      v_result := v_result AND (SELECT count(*)=1 FROM pg_class WHERE relname = p_tablename AND p_reloptions = ANY(reloptions));
+    END IF;
+
+    DROP TABLE before_ddl;
+    DROP TABLE after_ddl;
+
+    RETURN v_result;
+END;
+$$;
 -- 1. Heap->AO->Heap->AO
 CREATE TABLE heapao(a int, b int);
 CREATE INDEX heapaoindex ON heapao(b);
-INSERT INTO heapao SELECT i,i FROM generate_series(1,5) i;
-ALTER TABLE heapao SET ACCESS METHOD ao_row;
-ALTER TABLE heapao SET ACCESS METHOD heap;
-ALTER TABLE heapao SET ACCESS METHOD ao_row;
--- Just checking data is intact. 
-SELECT count(*) FROM heapao;
- count 
--------
-     5
+INSERT INTO heapao SELECT i,i FROM generate_series(1,100) i;
+-- check partitioned table and one child too
+CREATE TABLE heapao_part(a int, b int) PARTITION BY RANGE (b);
+CREATE TABLE heapao_part_p1 PARTITION OF heapao_part FOR VALUES FROM (0) TO (200);
+INSERT INTO heapao_part SELECT i,i FROM generate_series(1,100) i;
+SELECT check_atsetam('heapao', 'ao_row', 'compresslevel=3', false, true);
+ check_atsetam 
+------------
+ t
+(1 row)
+
+SELECT check_atsetam('heapao', 'heap', '', true, true);
+ check_atsetam 
+------------
+ t
+(1 row)
+
+SELECT check_atsetam('heapao', 'ao_row', '', false, true);
+ check_atsetam 
+------------
+ t
+(1 row)
+
+SELECT check_atsetam('heapao_part', 'ao_row', 'compresslevel=3', false, false);
+ check_atsetam 
+------------
+ t
+(1 row)
+
+SELECT check_atsetam('heapao_part', 'heap', '', true, false);
+ check_atsetam 
+------------
+ t
+(1 row)
+
+SELECT check_atsetam('heapao_part_p1', 'ao_row', 'compresslevel=3', false, true);
+ check_atsetam 
+------------
+ t
+(1 row)
+
+SELECT check_atsetam('heapao_part_p1', 'heap', 'fillfactor=70', false, true);
+ check_atsetam 
+------------
+ t
+(1 row)
+
+SELECT check_atsetam('heapao_part_p1', 'ao_row', '', false, true);
+ check_atsetam 
+------------
+ t
+(1 row)
+
+-- Just checking data is intact
+SELECT sum(a)+sum(b) FROM heapao;
+ ?column? 
+----------
+    10100
+(1 row)
+
+SELECT sum(a)+sum(b) FROM heapao_part;
+ ?column? 
+----------
+    10100
 (1 row)
 
 DROP TABLE heapao;
+DROP TABLE heapao_part;
 -- 2. AO->AOCO->AO->AOCO
 CREATE TABLE aoco(a int, b int) with (appendoptimized=true);
 CREATE INDEX aocoindex ON aoco(b);
-INSERT INTO aoco SELECT i,i FROM generate_series(1,5) i;
-ALTER TABLE aoco SET ACCESS METHOD ao_column;
-ALTER TABLE aoco SET ACCESS METHOD ao_row;
-ALTER TABLE aoco SET ACCESS METHOD ao_column;
--- Just checking data is intact.
-SELECT count(*) FROM aoco;
- count 
--------
-     5
+INSERT INTO aoco SELECT i,i FROM generate_series(1,100) i;
+-- check partitioned table and one child too
+CREATE TABLE aoco_part(a int, b int) PARTITION BY RANGE (b) with (appendoptimized=true);
+CREATE TABLE aoco_part_p1 PARTITION OF aoco_part FOR VALUES FROM (0) TO (200);
+INSERT INTO aoco_part SELECT i,i FROM generate_series(1,100) i;
+SELECT check_atsetam('aoco', 'ao_column', 'compresslevel=5', false, true);
+ check_atsetam 
+------------
+ t
+(1 row)
+
+SELECT check_atsetam('aoco', 'ao_row', 'compresslevel=7', false, true);
+ check_atsetam 
+------------
+ t
+(1 row)
+
+SELECT check_atsetam('aoco', 'ao_column', '', false, true);
+ check_atsetam 
+------------
+ t
+(1 row)
+
+SELECT check_atsetam('aoco_part', 'ao_column', 'compresslevel=5', false, false);
+ check_atsetam 
+------------
+ t
+(1 row)
+
+SELECT check_atsetam('aoco_part', 'ao_row', '', false, false);
+ check_atsetam 
+------------
+ t
+(1 row)
+
+SELECT check_atsetam('aoco_part_p1', 'ao_column', 'compresslevel=3', false, true);
+ check_atsetam 
+------------
+ t
+(1 row)
+
+SELECT check_atsetam('aoco_part_p1', 'ao_row', 'compresslevel=7', false, true);
+ check_atsetam 
+------------
+ t
+(1 row)
+
+SELECT check_atsetam('aoco_part_p1', 'ao_column', '', false, true);
+ check_atsetam 
+------------
+ t
+(1 row)
+
+-- Just checking data is intact
+SELECT sum(a)+sum(b) FROM aoco;
+ ?column? 
+----------
+    10100
+(1 row)
+
+SELECT sum(a)+sum(b) FROM aoco_part;
+ ?column? 
+----------
+    10100
 (1 row)
 
 DROP TABLE aoco;
+DROP TABLE aoco_part;
 -- 3. Heap->AOCO->Heap->AOCO
 CREATE TABLE heapco(a int, b int);
 CREATE INDEX heapcoindex ON heapco(b);
-INSERT INTO heapco SELECT i,i FROM generate_series(1,5) i;
-ALTER TABLE heapco SET ACCESS METHOD ao_column;
-ALTER TABLE heapco SET ACCESS METHOD heap;
-ALTER TABLE heapco SET ACCESS METHOD ao_column;
--- Just checking data is intact.
-SELECT count(*) FROM heapco;
- count 
--------
-     5
+INSERT INTO heapco SELECT i,i FROM generate_series(1,100) i;
+-- check partitioned table and one child too
+CREATE TABLE heapco_part(a int, b int) PARTITION BY RANGE (b);
+CREATE TABLE heapco_part_p1 PARTITION OF heapco_part FOR VALUES FROM (0) TO (200);
+INSERT INTO heapco_part SELECT i,i FROM generate_series(1,100) i;
+SELECT check_atsetam('heapco', 'ao_column', 'compresslevel=3', false, true);
+ check_atsetam 
+------------
+ t
+(1 row)
+
+SELECT check_atsetam('heapco', 'heap', '', true, true);
+ check_atsetam 
+------------
+ t
+(1 row)
+
+SELECT check_atsetam('heapco', 'ao_row', '', false, true);
+ check_atsetam 
+------------
+ t
+(1 row)
+
+SELECT check_atsetam('heapco_part', 'ao_row', 'compresslevel=3', false, false);
+ check_atsetam 
+------------
+ t
+(1 row)
+
+SELECT check_atsetam('heapco_part', 'heap', '', true, false);
+ check_atsetam 
+------------
+ t
+(1 row)
+
+SELECT check_atsetam('heapco_part_p1', 'ao_row', 'compresslevel=3', false, true);
+ check_atsetam 
+------------
+ t
+(1 row)
+
+SELECT check_atsetam('heapco_part_p1', 'heap', 'fillfactor=70', false, true);
+ check_atsetam 
+------------
+ t
+(1 row)
+
+SELECT check_atsetam('heapco_part_p1', 'ao_row', '', false, true);
+ check_atsetam 
+------------
+ t
+(1 row)
+
+-- Just checking data is intact
+SELECT sum(a)+sum(b) FROM heapco;
+ ?column? 
+----------
+    10100
+(1 row)
+
+SELECT sum(a)+sum(b) FROM heapco_part;
+ ?column? 
+----------
+    10100
 (1 row)
 
 DROP TABLE heapco;
+DROP TABLE heapco_part;
 -- Misc cases
 -- 
 -- ATSETAM with dropped column:

--- a/src/test/regress/sql/alter_table_set_am.sql
+++ b/src/test/regress/sql/alter_table_set_am.sql
@@ -709,44 +709,125 @@ DROP TABLE atsetam_part;
 -- 2. AO->AOCO->AO->AOCO
 -- 3. Heap->AOCO->Heap->AOCO
 
+-- create helper function
+CREATE FUNCTION check_atsetam(p_tablename text, p_am text, p_reloptions text, p_expect_empty_reloptions bool, p_expect_relfile_change bool)
+RETURNS boolean
+LANGUAGE plpgsql AS $$
+DECLARE
+    v_result boolean;
+    v_ddl text;
+BEGIN
+    IF p_reloptions = '' THEN
+      v_ddl := 'ALTER TABLE ' || p_tablename || ' SET ACCESS METHOD ' || p_am;
+    ELSE
+      v_ddl := 'ALTER TABLE ' || p_tablename || ' SET ACCESS METHOD ' || p_am || ' WITH (' || p_reloptions || ')';
+    END IF;
+    CREATE TEMP TABLE before_ddl(segid int, relfilenode oid);
+    CREATE TEMP TABLE after_ddl(segid int, relfilenode oid);
+
+    INSERT INTO before_ddl SELECT gp_segment_id segid, relfilenode FROM gp_dist_random('pg_class')
+    WHERE relname = p_tablename ORDER BY segid;
+
+    EXECUTE v_ddl;
+
+    INSERT INTO after_ddl SELECT gp_segment_id segid, relfilenode FROM gp_dist_random('pg_class')
+    WHERE relname = p_tablename ORDER BY segid;
+
+    -- check table rewrite
+    IF p_expect_relfile_change THEN
+      v_result := (SELECT count(a.*)=0 FROM before_ddl b INNER JOIN after_ddl a ON b.segid = a.segid AND b.relfilenode = a.relfilenode);
+    ELSE
+      v_result := (SELECT count(a.*)=0 FROM before_ddl b, after_ddl a WHERE b.segid = a.segid AND b.relfilenode != a.relfilenode);
+    END IF;
+
+    -- check AM
+    v_result := v_result AND (SELECT count(c.*)=1 FROM pg_class c, pg_am a WHERE c.relname = p_tablename AND c.relam = a.oid AND a.amname = p_am);
+
+    -- check reloptions. If not expecting NULL, then just check if what we just set is there.
+    IF p_expect_empty_reloptions THEN
+      v_result := v_result AND (SELECT reloptions IS NULL FROM pg_class WHERE relname = p_tablename);
+    ELSIF p_reloptions != '' THEN
+      v_result := v_result AND (SELECT count(*)=1 FROM pg_class WHERE relname = p_tablename AND p_reloptions = ANY(reloptions));
+    END IF;
+
+    DROP TABLE before_ddl;
+    DROP TABLE after_ddl;
+
+    RETURN v_result;
+END;
+$$;
+
 -- 1. Heap->AO->Heap->AO
 CREATE TABLE heapao(a int, b int);
 CREATE INDEX heapaoindex ON heapao(b);
-INSERT INTO heapao SELECT i,i FROM generate_series(1,5) i;
+INSERT INTO heapao SELECT i,i FROM generate_series(1,100) i;
+-- check partitioned table and one child too
+CREATE TABLE heapao_part(a int, b int) PARTITION BY RANGE (b);
+CREATE TABLE heapao_part_p1 PARTITION OF heapao_part FOR VALUES FROM (0) TO (200);
+INSERT INTO heapao_part SELECT i,i FROM generate_series(1,100) i;
 
-ALTER TABLE heapao SET ACCESS METHOD ao_row;
-ALTER TABLE heapao SET ACCESS METHOD heap;
-ALTER TABLE heapao SET ACCESS METHOD ao_row;
+SELECT check_atsetam('heapao', 'ao_row', 'compresslevel=3', false, true);
+SELECT check_atsetam('heapao', 'heap', '', true, true);
+SELECT check_atsetam('heapao', 'ao_row', '', false, true);
+SELECT check_atsetam('heapao_part', 'ao_row', 'compresslevel=3', false, false);
+SELECT check_atsetam('heapao_part', 'heap', '', true, false);
+SELECT check_atsetam('heapao_part_p1', 'ao_row', 'compresslevel=3', false, true);
+SELECT check_atsetam('heapao_part_p1', 'heap', 'fillfactor=70', false, true);
+SELECT check_atsetam('heapao_part_p1', 'ao_row', '', false, true);
 
--- Just checking data is intact. 
-SELECT count(*) FROM heapao;
+-- Just checking data is intact
+SELECT sum(a)+sum(b) FROM heapao;
+SELECT sum(a)+sum(b) FROM heapao_part;
 DROP TABLE heapao;
+DROP TABLE heapao_part;
 
 -- 2. AO->AOCO->AO->AOCO
 CREATE TABLE aoco(a int, b int) with (appendoptimized=true);
 CREATE INDEX aocoindex ON aoco(b);
-INSERT INTO aoco SELECT i,i FROM generate_series(1,5) i;
+INSERT INTO aoco SELECT i,i FROM generate_series(1,100) i;
+-- check partitioned table and one child too
+CREATE TABLE aoco_part(a int, b int) PARTITION BY RANGE (b) with (appendoptimized=true);
+CREATE TABLE aoco_part_p1 PARTITION OF aoco_part FOR VALUES FROM (0) TO (200);
+INSERT INTO aoco_part SELECT i,i FROM generate_series(1,100) i;
 
-ALTER TABLE aoco SET ACCESS METHOD ao_column;
-ALTER TABLE aoco SET ACCESS METHOD ao_row;
-ALTER TABLE aoco SET ACCESS METHOD ao_column;
+SELECT check_atsetam('aoco', 'ao_column', 'compresslevel=5', false, true);
+SELECT check_atsetam('aoco', 'ao_row', 'compresslevel=7', false, true);
+SELECT check_atsetam('aoco', 'ao_column', '', false, true);
+SELECT check_atsetam('aoco_part', 'ao_column', 'compresslevel=5', false, false);
+SELECT check_atsetam('aoco_part', 'ao_row', '', false, false);
+SELECT check_atsetam('aoco_part_p1', 'ao_column', 'compresslevel=3', false, true);
+SELECT check_atsetam('aoco_part_p1', 'ao_row', 'compresslevel=7', false, true);
+SELECT check_atsetam('aoco_part_p1', 'ao_column', '', false, true);
 
--- Just checking data is intact.
-SELECT count(*) FROM aoco;
+-- Just checking data is intact
+SELECT sum(a)+sum(b) FROM aoco;
+SELECT sum(a)+sum(b) FROM aoco_part;
 DROP TABLE aoco;
+DROP TABLE aoco_part;
 
 -- 3. Heap->AOCO->Heap->AOCO
 CREATE TABLE heapco(a int, b int);
 CREATE INDEX heapcoindex ON heapco(b);
-INSERT INTO heapco SELECT i,i FROM generate_series(1,5) i;
+INSERT INTO heapco SELECT i,i FROM generate_series(1,100) i;
+-- check partitioned table and one child too
+CREATE TABLE heapco_part(a int, b int) PARTITION BY RANGE (b);
+CREATE TABLE heapco_part_p1 PARTITION OF heapco_part FOR VALUES FROM (0) TO (200);
+INSERT INTO heapco_part SELECT i,i FROM generate_series(1,100) i;
 
-ALTER TABLE heapco SET ACCESS METHOD ao_column;
-ALTER TABLE heapco SET ACCESS METHOD heap;
-ALTER TABLE heapco SET ACCESS METHOD ao_column;
+SELECT check_atsetam('heapco', 'ao_column', 'compresslevel=3', false, true);
+SELECT check_atsetam('heapco', 'heap', '', true, true);
+SELECT check_atsetam('heapco', 'ao_row', '', false, true);
+SELECT check_atsetam('heapco_part', 'ao_row', 'compresslevel=3', false, false);
+SELECT check_atsetam('heapco_part', 'heap', '', true, false);
+SELECT check_atsetam('heapco_part_p1', 'ao_row', 'compresslevel=3', false, true);
+SELECT check_atsetam('heapco_part_p1', 'heap', 'fillfactor=70', false, true);
+SELECT check_atsetam('heapco_part_p1', 'ao_row', '', false, true);
 
--- Just checking data is intact.
-SELECT count(*) FROM heapco;
+-- Just checking data is intact
+SELECT sum(a)+sum(b) FROM heapco;
+SELECT sum(a)+sum(b) FROM heapco_part;
 DROP TABLE heapco;
+DROP TABLE heapco_part;
 
 -- Misc cases
 -- 


### PR DESCRIPTION
When change AM to heap, the exisiting reloptions were not cleared. The root cause is that we would skip setting reloptions if there's no reloptions being passed in with the ATSETAM command. Note that we only skip such for heap table, but not AO table, which is why this issue only existed for heap.

The fix is to always replace the reloptions when AM changed.

Also add the missing test case and a lot more.

Resolve issue #15080.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
