### PR TITLE
Change GetAppendOnlyEntryAuxOids/GetAppendOnlyEntry to macros

### DIFF
--- a/src/backend/access/appendonly/appendonlyam.c
+++ b/src/backend/access/appendonly/appendonlyam.c
@@ -2403,10 +2403,11 @@ appendonly_fetch_init(Relation relation,
 	AppendOnlyStorageAttributes	   *attr;
 	PGFunction					   *fns;
 	StringInfoData					titleBuf;
-	FormData_pg_appendonly			aoFormData;
+	Oid 					segrelid;
+	Oid 					visimaprelid;
 	int								segno;
 
-	GetAppendOnlyEntry(relation, &aoFormData);
+	GetAppendOnlyEntryAuxOids(relation, &segrelid, NULL, &visimaprelid);
 
 	/*
 	 * increment relation ref count while scanning relation
@@ -2489,7 +2490,7 @@ appendonly_fetch_init(Relation relation,
 		/* always initailize segment 0 */
 		segno = (i < 0 ? 0 : aoFetchDesc->segmentFileInfo[i]->segno);
 		/* set corresponding bit for target segment */
-		aoFetchDesc->lastSequence[segno] = ReadLastSequence(aoFormData.segrelid, segno);
+		aoFetchDesc->lastSequence[segno] = ReadLastSequence(segrelid, segno);
 	}
 
 	AppendOnlyStorageRead_Init(
@@ -2539,7 +2540,7 @@ appendonly_fetch_init(Relation relation,
 											NULL);
 
 	AppendOnlyVisimap_Init(&aoFetchDesc->visibilityMap,
-						   aoFormData.visimaprelid,
+						   visimaprelid,
 						   AccessShareLock,
 						   appendOnlyMetaDataSnapshot);
 

--- a/src/backend/catalog/pg_appendonly.c
+++ b/src/backend/catalog/pg_appendonly.c
@@ -136,57 +136,6 @@ GetAppendOnlyEntryAttributes(Oid relid,
 }
 
 /*
- * Get the OIDs of the auxiliary relations and their indexes for an appendonly
- * relation. This should only be called on tables with pg_appendonly entries,
- * which currently are just non-partitioned AO/CO tables.
- *
- * The OIDs will be retrieved only when the corresponding output variable is
- * not NULL.
- */
-void
-GetAppendOnlyEntryAuxOids(Relation rel,
-						  Oid *segrelid,
-						  Oid *blkdirrelid,
-						  Oid *visimaprelid)
-{
-	Form_pg_appendonly	aoForm;
-
-	/* the relation has to be a non-partitioned AO/CO table */
-	Assert(RelationStorageIsAO(rel));
-
-	aoForm = rel->rd_appendonly;
-
-	if (segrelid != NULL)
-		*segrelid = aoForm->segrelid;
-
-	if (blkdirrelid != NULL)
-		*blkdirrelid = aoForm->blkdirrelid;
-
-	if (visimaprelid != NULL)
-		*visimaprelid = aoForm->visimaprelid;
-}
-
-/*
- * Get the pg_appendonly entry for the relation. This should only be called on 
- * tables with pg_appendonly entries, which currently are just non-partitioned
- * AO/CO tables. The pg_appendonly data is copied into the Form_pg_appendonly
- * pointer which should be valid.
- */
-void
-GetAppendOnlyEntry(Relation rel, Form_pg_appendonly aoEntry)
-{
-	Form_pg_appendonly	aoForm;
-
-	/* the relation has to be a non-partitioned AO/CO table and the aoEntry is valid */
-	Assert(RelationStorageIsAO(rel));
-	Assert(aoEntry);
-
-	aoForm = rel->rd_appendonly;
-
-	memcpy(aoEntry, aoForm, APPENDONLY_TUPLE_SIZE);
-}
-
-/*
  * Update the segrelid and/or blkdirrelid if the input new values
  * are valid OIDs.
  */

--- a/src/include/catalog/pg_appendonly.h
+++ b/src/include/catalog/pg_appendonly.h
@@ -119,28 +119,34 @@ InsertAppendOnlyEntry(Oid relid,
 					  Oid visimaprelid,
 					  int16 version);
 
-void
+extern void 
 GetAppendOnlyEntryAttributes(Oid relid,
 							 int32 *blocksize,
 							 int16 *compresslevel,
 							 bool *checksum,
 							 NameData *compresstype);
-
 /*
- * Get the OIDs of the auxiliary relations and their indexes for an appendonly
- * relation.
+ * Get the OIDs of the auxiliary relations for an appendonly relation. This 
+ * should only be called on tables with pg_appendonly entries, which currently 
+ * are just non-partitioned AO/CO tables.
  *
  * The OIDs will be retrieved only when the corresponding output variable is
  * not NULL.
  */
-void
-GetAppendOnlyEntryAuxOids(Relation rel,
-						  Oid *segrelid,
-						  Oid *blkdirrelid,
-						  Oid *visimaprelid);
-
-void
-GetAppendOnlyEntry(Relation rel, Form_pg_appendonly aoEntry);
+#define GetAppendOnlyEntryAuxOids(rel, \
+						  segrelid_ptr, \
+						  blkdirrelid_ptr, \
+						  visimaprelid_ptr) \
+do { \
+	Form_pg_appendonly aoForm = (rel)->rd_appendonly; \
+	Assert(RelationStorageIsAO(rel)); \
+	if ((segrelid_ptr) != NULL) \
+		*((Oid*)segrelid_ptr) = aoForm->segrelid; \
+	if ((blkdirrelid_ptr) != NULL) \
+		*((Oid*)blkdirrelid_ptr) = aoForm->blkdirrelid; \
+	if ((visimaprelid_ptr) != NULL) \
+		*((Oid*)visimaprelid_ptr) = aoForm->visimaprelid; \
+} while (0)
 
 /*
  * Update the segrelid and/or blkdirrelid if the input new values


### PR DESCRIPTION
After moving pg_appendonly tuples into relcache, it seems that we no longer need to incur function calls just for some memory copy/dereference. Change them to macros now.

Per discussion in https://github.com/greenplum-db/gpdb/pull/15027#discussion_r1120460866

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
