### PR TITLE
In binary upgrade, dump the encoding clause for dropped columns

### DIFF
--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -16809,7 +16809,15 @@ dumpTableSchema(Archive *fout, const TableInfo *tbinfo)
 						 * clean things up later.
 						 */
 						appendPQExpBufferStr(q, " INTEGER /* dummy */");
-						/* and skip to the next column */
+
+						/* Dropped columns are dumped during binary upgrade.
+						 * Dump the encoding clause also to maintain a consistent
+						 * catalog entry in pg_attribute_encoding post upgrade.
+						 */
+						if (tbinfo->attencoding[j] != NULL)
+							appendPQExpBuffer(q, " ENCODING (%s)", tbinfo->attencoding[j]);
+
+						/* Skip all the rest */
 						continue;
 					}
 


### PR DESCRIPTION
The encoding clause is necessary to maintain catalog consistency for dropped columns in pg_attribute_encoding across major version upgrades. Without this, the column encoding will be set to the hardcoded server default in the new cluster. If the encoding was modified from the default in the old cluster, an error would occur if the column needed to be scanned for any reason.

Resolves the issue `ERROR:  decompression information missing` after a column is dropped from an AO/CO table and the table is run through pg_upgrade

Authored-by: Brent Doil <bdoil@vmware.com>
