### PR TITLE
[6X] remove reduant invocation of `mdinit()` at `smgr_init_standard()`

### DIFF
--- a/src/backend/storage/smgr/smgr.c
+++ b/src/backend/storage/smgr/smgr.c
@@ -101,7 +101,6 @@ smgr_init_standard(void)
 		if (smgrsw[i].smgr_init)
 			smgrsw[i].smgr_init();
 	}
-	mdinit();
 }
 
 


### PR DESCRIPTION
This is the backport of  #15091

This PR is trying to fix the issue of #14561, we should not invoke `mdinit()` directly at 
the end of the function `smgr_init_standard()`.

No more tests are needed, cause current tests are enough to cover.

