### PR TITLE
[6X] support dumping external tables with serial column types

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -3651,7 +3651,6 @@ ATVerifyObject(AlterTableStmt *stmt, Relation rel)
 			switch(cmd->subtype)
 			{
 				/* EXTERNAL tables don't support the following AT */
-				case AT_ColumnDefault:
 				case AT_ColumnDefaultRecurse:
 				case AT_DropNotNull:
 				case AT_SetNotNull:

--- a/src/bin/gpfdist/regress/.gitignore
+++ b/src/bin/gpfdist/regress/.gitignore
@@ -8,5 +8,7 @@ data/gpfdist_ssl/tbl2.tbl
 data/gpfdist_ssl/certs_matching
 data/gpfdist_ssl/certs_multiCA
 data/gpfdist_ssl/certs_not_matching/root.crt
+data/external_table_with_serial_column_type.csv
+data/external_table_with_user_type_and_default_value.csv
 regression.diffs
 regression.out

--- a/src/bin/gpfdist/regress/input/exttab1.source
+++ b/src/bin/gpfdist/regress/input/exttab1.source
@@ -590,6 +590,61 @@ select * from exttab1_gpfdist_stop;
 -- end_ignore
 -- End Test external table sreh output in gp_read_error_log() print rawbytes with \0 in it.
 
+-- truncate output files from any previous runs
+\! > @abs_srcdir@/data/external_table_with_serial_column_type.csv
+\! > @abs_srcdir@/data/external_table_with_user_type_and_default_value.csv
+-- start_ignore
+select * from exttab1_gpfdist_stop;
+select * from exttab1_gpfdist_start;
+-- end_ignore
+-- Scenario 1: external table with serial column type can be altered
+CREATE WRITABLE EXTERNAL TABLE writable_external_table_with_serial_column_type (a INT, b BIGSERIAL)
+    LOCATION ('gpfdist://@hostname@:7070/external_table_with_serial_column_type.csv')
+    FORMAT 'CSV' (DELIMITER ',' NULL '' ESCAPE '"' QUOTE '"') ENCODING 'UTF8' DISTRIBUTED RANDOMLY;
+
+CREATE READABLE EXTERNAL TABLE readable_external_table_with_serial_column_type(LIKE writable_external_table_with_serial_column_type)
+    LOCATION ('gpfdist://@hostname@:7070/external_table_with_serial_column_type.csv')
+    FORMAT 'CSV' (DELIMITER ',' NULL '' ESCAPE '"' QUOTE '"') ENCODING 'UTF8';
+
+INSERT INTO writable_external_table_with_serial_column_type VALUES (1);
+SELECT setval('writable_external_table_with_serial_column_type_b_seq'::regclass, 99);
+ALTER EXTERNAL TABLE writable_external_table_with_serial_column_type ALTER COLUMN b SET DEFAULT nextval('writable_external_table_with_serial_column_type_b_seq'::regclass);
+INSERT INTO writable_external_table_with_serial_column_type VALUES (1);
+SELECT * FROM readable_external_table_with_serial_column_type;
+
+-- Scenario 2: can create external table with user defined type containing default value
+CREATE TYPE user_type_with_default_value;
+
+CREATE FUNCTION user_type_with_default_value_in(cstring)
+    RETURNS user_type_with_default_value AS 'int4in'
+    LANGUAGE internal IMMUTABLE STRICT;
+
+CREATE FUNCTION user_type_with_default_value_out(user_type_with_default_value)
+    RETURNS cstring AS 'int4out'
+    LANGUAGE internal IMMUTABLE STRICT;
+
+CREATE TYPE user_type_with_default_value(
+    input = user_type_with_default_value_in,
+    output = user_type_with_default_value_out,
+    internallength = 4,
+    default = 99,
+    passedbyvalue);
+
+CREATE WRITABLE EXTERNAL TABLE writable_external_table_with_user_type_and_default_value (a INT, b user_type_with_default_value)
+    LOCATION ('gpfdist://@hostname@:7070/external_table_with_user_type_and_default_value.csv')
+    FORMAT 'CSV' (DELIMITER ',' NULL '' ESCAPE '"' QUOTE '"') ENCODING 'UTF8' DISTRIBUTED RANDOMLY;
+
+CREATE READABLE EXTERNAL TABLE readable_external_table_with_user_type_and_default_value(LIKE writable_external_table_with_user_type_and_default_value)
+    LOCATION ('gpfdist://@hostname@:7070/external_table_with_user_type_and_default_value.csv')
+    FORMAT 'CSV' (DELIMITER ',' NULL '' ESCAPE '"' QUOTE '"') ENCODING 'UTF8';
+
+INSERT INTO writable_external_table_with_user_type_and_default_value VALUES (1);
+SELECT * FROM readable_external_table_with_user_type_and_default_value;
+
+-- start_ignore
+select * from exttab1_gpfdist_stop;
+-- end_ignore
+
 drop external table ext_whois;
 drop external table exttab1_gpfdist_start;
 drop external table gpfdist_csv_start;

--- a/src/bin/gpfdist/regress/output/exttab1.source
+++ b/src/bin/gpfdist/regress/output/exttab1.source
@@ -791,6 +791,83 @@ select * from exttab1_gpfdist_stop;
 
 -- end_ignore
 -- End Test external table sreh output in gp_read_error_log() print rawbytes with \0 in it.
+-- truncate output files from any previous runs
+\! > @abs_srcdir@/data/external_table_with_serial_column_type.csv
+\! > @abs_srcdir@/data/external_table_with_user_type_and_default_value.csv
+-- start_ignore
+select * from exttab1_gpfdist_stop;
+      x      
+-------------
+ stopping...
+(1 row)
+
+select * from exttab1_gpfdist_start;
+      x      
+-------------
+ starting...
+(1 row)
+
+-- end_ignore
+-- Scenario 1: external table with serial column type can be altered
+CREATE WRITABLE EXTERNAL TABLE writable_external_table_with_serial_column_type (a INT, b BIGSERIAL)
+    LOCATION ('gpfdist://@hostname@:7070/external_table_with_serial_column_type.csv')
+    FORMAT 'CSV' (DELIMITER ',' NULL '' ESCAPE '"' QUOTE '"') ENCODING 'UTF8' DISTRIBUTED RANDOMLY;
+CREATE READABLE EXTERNAL TABLE readable_external_table_with_serial_column_type(LIKE writable_external_table_with_serial_column_type)
+    LOCATION ('gpfdist://@hostname@:7070/external_table_with_serial_column_type.csv')
+    FORMAT 'CSV' (DELIMITER ',' NULL '' ESCAPE '"' QUOTE '"') ENCODING 'UTF8';
+INSERT INTO writable_external_table_with_serial_column_type VALUES (1);
+SELECT setval('writable_external_table_with_serial_column_type_b_seq'::regclass, 99);
+ setval 
+--------
+     99
+(1 row)
+
+ALTER EXTERNAL TABLE writable_external_table_with_serial_column_type ALTER COLUMN b SET DEFAULT nextval('writable_external_table_with_serial_column_type_b_seq'::regclass);
+INSERT INTO writable_external_table_with_serial_column_type VALUES (1);
+SELECT * FROM readable_external_table_with_serial_column_type;
+ a |  b  
+---+-----
+ 1 |   1
+ 1 | 100
+(2 rows)
+
+-- Scenario 2: can create external table with user defined type containing default value
+CREATE TYPE user_type_with_default_value;
+CREATE FUNCTION user_type_with_default_value_in(cstring)
+    RETURNS user_type_with_default_value AS 'int4in'
+    LANGUAGE internal IMMUTABLE STRICT;
+NOTICE:  return type user_type_with_default_value is only a shell
+CREATE FUNCTION user_type_with_default_value_out(user_type_with_default_value)
+    RETURNS cstring AS 'int4out'
+    LANGUAGE internal IMMUTABLE STRICT;
+NOTICE:  argument type user_type_with_default_value is only a shell
+CREATE TYPE user_type_with_default_value(
+    input = user_type_with_default_value_in,
+    output = user_type_with_default_value_out,
+    internallength = 4,
+    default = 99,
+    passedbyvalue);
+CREATE WRITABLE EXTERNAL TABLE writable_external_table_with_user_type_and_default_value (a INT, b user_type_with_default_value)
+    LOCATION ('gpfdist://@hostname@:7070/external_table_with_user_type_and_default_value.csv')
+    FORMAT 'CSV' (DELIMITER ',' NULL '' ESCAPE '"' QUOTE '"') ENCODING 'UTF8' DISTRIBUTED RANDOMLY;
+CREATE READABLE EXTERNAL TABLE readable_external_table_with_user_type_and_default_value(LIKE writable_external_table_with_user_type_and_default_value)
+    LOCATION ('gpfdist://@hostname@:7070/external_table_with_user_type_and_default_value.csv')
+    FORMAT 'CSV' (DELIMITER ',' NULL '' ESCAPE '"' QUOTE '"') ENCODING 'UTF8';
+INSERT INTO writable_external_table_with_user_type_and_default_value VALUES (1);
+SELECT * FROM readable_external_table_with_user_type_and_default_value;
+ a | b  
+---+----
+ 1 | 99
+(1 row)
+
+-- start_ignore
+select * from exttab1_gpfdist_stop;
+      x      
+-------------
+ stopping...
+(1 row)
+
+-- end_ignore
 drop external table ext_whois;
 drop external table exttab1_gpfdist_start;
 drop external table gpfdist_csv_start;

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -13098,35 +13098,19 @@ dumpExternal(Archive *fout, TableInfo *tbinfo, PQExpBuffer q, PQExpBuffer delq)
 		int j;
 		for (j = 0; j < tbinfo->numatts; j++)
 		{
-			/* Is the attribute not dropped? */
-			if (shouldPrintColumn(tbinfo, j))
-			{
-				/* Format properly if not first attr */
-				if (actual_atts > 0)
-					appendPQExpBufferChar(q, ',');
-				appendPQExpBufferStr(q, "\n    ");
+			if (!shouldPrintColumn(tbinfo, j) || tbinfo->attisdropped[j])
+				continue;
 
-				/* Attribute name */
-				appendPQExpBuffer(q, "%s ", fmtId(tbinfo->attnames[j]));
+			/* Format properly if not first attr */
+			if (actual_atts > 0)
+				appendPQExpBufferChar(q, ',');
+			appendPQExpBufferStr(q, "\n    ");
 
-				/* Attribute type */
-				if (tbinfo->attisdropped[j])
-				{
-					/*
-					 * ALTER TABLE DROP COLUMN clears
-					 * pg_attribute.atttypid, so we will not have gotten a
-					 * valid type name; insert INTEGER as a stopgap. We'll
-					 * clean things up later.
-					 */
-					appendPQExpBufferStr(q, " INTEGER /* dummy */");
-				}
-				else
-				{
-					appendPQExpBufferStr(q, tbinfo->atttypnames[j]);
-				}
+			/* Attribute name */
+			appendPQExpBuffer(q, "%s ", fmtId(tbinfo->attnames[j]));
+			appendPQExpBufferStr(q, tbinfo->atttypnames[j]);
 
-				actual_atts++;
-			}
+			actual_atts++;
 		}
 
 		appendPQExpBufferStr(q, "\n)");

--- a/src/test/regress/expected/pg_dump_binary_upgrade.out
+++ b/src/test/regress/expected/pg_dump_binary_upgrade.out
@@ -16,9 +16,13 @@ CREATE EXTERNAL TABLE dump_this_schema.external_table_with_dropped_columns_does_
     b int,
     c int
 ) LOCATION ('gpfdist://1.1.1.1:8082/xxxx.csv') FORMAT 'csv';
-ALTER EXTERNAL TABLE dump_this_schema.external_table_with_dropped_columns DROP COLUMN a;
-ALTER EXTERNAL TABLE dump_this_schema.external_table_with_dropped_columns DROP COLUMN b;
--- 2) Scenario 1: Create homogeneous partition table where the root
+ALTER EXTERNAL TABLE dump_this_schema.external_table_with_dropped_columns_does_not_print_alter_ddl DROP COLUMN a;
+ALTER EXTERNAL TABLE dump_this_schema.external_table_with_dropped_columns_does_not_print_alter_ddl DROP COLUMN b;
+-- Scenario 1b: External table with serial data type correctly alters the column to set default
+CREATE WRITABLE EXTERNAL TABLE dump_this_schema.writable_external_table_with_serial_column_type (a INT, b BIGSERIAL)
+    LOCATION ('gpfdist://localhost:8081/xxx.csv')
+    FORMAT 'CSV' (DELIMITER ',' NULL '' ESCAPE '"' QUOTE '"') ENCODING 'UTF8' DISTRIBUTED RANDOMLY;
+-- Scenario 2a: Create homogeneous partition table where the root
 -- partition and ALL of its child partitions have the dropped column
 -- reference.
 CREATE TABLE dump_this_schema.dropped_column_homogeneous_partition_table (
@@ -51,7 +55,7 @@ WHERE a.attisdropped = true AND relname LIKE 'dropped_column_homogeneous_partiti
  dropped_column_homogeneous_partition_table          | ........pg.dropped.3........
 (3 rows)
 
--- 2) Scenario 2: Create homogeneous partition table where only the root
+-- Scenario 2b: Create homogeneous partition table where only the root
 -- partition has the dropped column reference (as defined by
 -- pg_upgrade heterogeneous partition check function).
 CREATE TABLE dump_this_schema.dropped_column_special_homogeneous_partition_table (
@@ -85,7 +89,7 @@ WHERE a.attisdropped = true AND relname LIKE 'dropped_column_special_homogeneous
  dropped_column_special_homogeneous_partition_table | ........pg.dropped.3........
 (1 row)
 
--- 2) Scenario 3: Create homogeneous partition table where only the root
+-- Scenario 2c: Create homogeneous partition table where only the root
 -- and subroot partition has the dropped column reference (as defined
 -- by pg_upgrade heterogeneous partition check function).
 CREATE TABLE dump_this_schema.dropped_column_special_homogeneous_partition_with_subpart (
@@ -132,9 +136,11 @@ WHERE a.attisdropped = true AND relname LIKE 'dropped_column_special_homogeneous
 -- because we do not preserve drop columns for external tables.
 \! pg_dump --binary-upgrade --schema dump_this_schema regression | grep ' DROP COLUMN \| SET DEFAULT '
 ALTER TABLE dump_this_schema.dropped_column_homogeneous_partition_table DROP COLUMN "........pg.dropped.3........";
+ALTER TABLE ONLY dump_this_schema.writable_external_table_with_serial_column_type ALTER COLUMN b SET DEFAULT nextval('dump_this_schema.writable_external_table_with_serial_column_type_b_seq'::regclass);
 DROP SCHEMA dump_this_schema CASCADE;
-NOTICE:  drop cascades to 4 other objects
-DETAIL:  drop cascades to external table dump_this_schema.external_table_with_dropped_columns
+NOTICE:  drop cascades to 5 other objects
+DETAIL:  drop cascades to external table dump_this_schema.external_table_with_dropped_columns_does_not_print_alter_ddl
+drop cascades to external table dump_this_schema.writable_external_table_with_serial_column_type
 drop cascades to table dump_this_schema.dropped_column_homogeneous_partition_table
 drop cascades to table dump_this_schema.dropped_column_special_homogeneous_partition_table
 drop cascades to table dump_this_schema.dropped_column_special_homogeneous_partition_with_subpart

--- a/src/test/regress/expected/pg_dump_binary_upgrade.out
+++ b/src/test/regress/expected/pg_dump_binary_upgrade.out
@@ -10,8 +10,8 @@
 -- pg_upgrade's check_gp.c for more details on homogeneous and
 -- heterogeneous partitions.
 CREATE SCHEMA dump_this_schema;
--- 1) External tables with dropped columns is dumped correctly.
-CREATE EXTERNAL TABLE dump_this_schema.external_table_with_dropped_columns (
+-- Scenario 1a: External tables with dropped columns is dumped correctly.
+CREATE EXTERNAL TABLE dump_this_schema.external_table_with_dropped_columns_does_not_print_alter_ddl (
     a int,
     b int,
     c int
@@ -128,7 +128,9 @@ WHERE a.attisdropped = true AND relname LIKE 'dropped_column_special_homogeneous
 -- Run pg_dump and expect to see an ALTER TABLE DROP COLUMN output
 -- only for the homogeneous partition table where the entire partition
 -- table has the same dropped column reference.
-\! pg_dump --binary-upgrade --schema dump_this_schema regression | grep " DROP COLUMN "
+-- We do not expect to see ALTER TABLE DROP COLUMN output for external tables
+-- because we do not preserve drop columns for external tables.
+\! pg_dump --binary-upgrade --schema dump_this_schema regression | grep ' DROP COLUMN \| SET DEFAULT '
 ALTER TABLE dump_this_schema.dropped_column_homogeneous_partition_table DROP COLUMN "........pg.dropped.3........";
 DROP SCHEMA dump_this_schema CASCADE;
 NOTICE:  drop cascades to 4 other objects

--- a/src/test/regress/input/external_table.source
+++ b/src/test/regress/input/external_table.source
@@ -187,7 +187,7 @@ alter external table ext add column a int; -- pass
 alter external table ext drop column a; -- pass
 alter external table ext add column extnewcol int not null; -- should fail (constraints not allowed)
 alter external table ext add column extnewcol int; -- pass
-alter external table ext alter column extnewcol set default 1; -- should fail (unsupported alter type)
+alter external table ext alter column extnewcol set default 1; -- should pass
 
 alter external table ext alter column x type integer using 123; -- should fail (USING doesn't make sense on external table)
 alter external table ext alter column x type integer; -- pass

--- a/src/test/regress/output/external_table.source
+++ b/src/test/regress/output/external_table.source
@@ -241,8 +241,7 @@ alter external table ext add column extnewcol int not null; -- should fail (cons
 ERROR:  unsupported ALTER command for external table
 DETAIL:  No constraints allowed.
 alter external table ext add column extnewcol int; -- pass
-alter external table ext alter column extnewcol set default 1; -- should fail (unsupported alter type)
-ERROR:  unsupported ALTER command for external table
+alter external table ext alter column extnewcol set default 1; -- should pass
 alter external table ext alter column x type integer using 123; -- should fail (USING doesn't make sense on external table)
 ERROR:  cannot specify a USING expression when altering an external table
 alter external table ext alter column x type integer; -- pass

--- a/src/test/regress/sql/pg_dump_binary_upgrade.sql
+++ b/src/test/regress/sql/pg_dump_binary_upgrade.sql
@@ -13,8 +13,8 @@
 
 CREATE SCHEMA dump_this_schema;
 
--- 1) External tables with dropped columns is dumped correctly.
-CREATE EXTERNAL TABLE dump_this_schema.external_table_with_dropped_columns (
+-- Scenario 1a: External tables with dropped columns is dumped correctly.
+CREATE EXTERNAL TABLE dump_this_schema.external_table_with_dropped_columns_does_not_print_alter_ddl (
     a int,
     b int,
     c int
@@ -107,6 +107,8 @@ WHERE a.attisdropped = true AND relname LIKE 'dropped_column_special_homogeneous
 -- Run pg_dump and expect to see an ALTER TABLE DROP COLUMN output
 -- only for the homogeneous partition table where the entire partition
 -- table has the same dropped column reference.
-\! pg_dump --binary-upgrade --schema dump_this_schema regression | grep " DROP COLUMN "
+-- We do not expect to see ALTER TABLE DROP COLUMN output for external tables
+-- because we do not preserve drop columns for external tables.
+\! pg_dump --binary-upgrade --schema dump_this_schema regression | grep ' DROP COLUMN \| SET DEFAULT '
 
 DROP SCHEMA dump_this_schema CASCADE;

--- a/src/test/regress/sql/pg_dump_binary_upgrade.sql
+++ b/src/test/regress/sql/pg_dump_binary_upgrade.sql
@@ -20,10 +20,15 @@ CREATE EXTERNAL TABLE dump_this_schema.external_table_with_dropped_columns_does_
     c int
 ) LOCATION ('gpfdist://1.1.1.1:8082/xxxx.csv') FORMAT 'csv';
 
-ALTER EXTERNAL TABLE dump_this_schema.external_table_with_dropped_columns DROP COLUMN a;
-ALTER EXTERNAL TABLE dump_this_schema.external_table_with_dropped_columns DROP COLUMN b;
+ALTER EXTERNAL TABLE dump_this_schema.external_table_with_dropped_columns_does_not_print_alter_ddl DROP COLUMN a;
+ALTER EXTERNAL TABLE dump_this_schema.external_table_with_dropped_columns_does_not_print_alter_ddl DROP COLUMN b;
 
--- 2) Scenario 1: Create homogeneous partition table where the root
+-- Scenario 1b: External table with serial data type correctly alters the column to set default
+CREATE WRITABLE EXTERNAL TABLE dump_this_schema.writable_external_table_with_serial_column_type (a INT, b BIGSERIAL)
+    LOCATION ('gpfdist://localhost:8081/xxx.csv')
+    FORMAT 'CSV' (DELIMITER ',' NULL '' ESCAPE '"' QUOTE '"') ENCODING 'UTF8' DISTRIBUTED RANDOMLY;
+
+-- Scenario 2a: Create homogeneous partition table where the root
 -- partition and ALL of its child partitions have the dropped column
 -- reference.
 CREATE TABLE dump_this_schema.dropped_column_homogeneous_partition_table (
@@ -46,7 +51,7 @@ SELECT c.relname, a.attname
 FROM pg_class c JOIN pg_attribute a ON c.oid = a.attrelid
 WHERE a.attisdropped = true AND relname LIKE 'dropped_column_homogeneous_partition_table%';
 
--- 2) Scenario 2: Create homogeneous partition table where only the root
+-- Scenario 2b: Create homogeneous partition table where only the root
 -- partition has the dropped column reference (as defined by
 -- pg_upgrade heterogeneous partition check function).
 CREATE TABLE dump_this_schema.dropped_column_special_homogeneous_partition_table (
@@ -73,7 +78,7 @@ SELECT c.relname, a.attname
 FROM pg_class c JOIN pg_attribute a ON c.oid = a.attrelid
 WHERE a.attisdropped = true AND relname LIKE 'dropped_column_special_homogeneous_partition_table%';
 
--- 2) Scenario 3: Create homogeneous partition table where only the root
+-- Scenario 2c: Create homogeneous partition table where only the root
 -- and subroot partition has the dropped column reference (as defined
 -- by pg_upgrade heterogeneous partition check function).
 CREATE TABLE dump_this_schema.dropped_column_special_homogeneous_partition_with_subpart (


### PR DESCRIPTION
1) Don’t dump dropped columns for external tables

Dropped columns are preserved to create binary-compatible files on-disk. That is pg_dump must ensure the same physical column order, including dropped columns, as in the original. However, since the external table DDL needs to map directly to the underlying data there is no need to preserve dropped columns. Simplify by removing this logic.

2) Support dumping external tables with serial column types

Serial column types are dumped in components and added together. The CREATE TABLE is dumped, followed by the CREATE SEQUENCE, and then attached to the table column with ALTER TABLE ONLY public.foobar ALTER COLUMN b SET DEFAULT nextval('public.foobar_b_seq'::regclass);

The restore fails with “unsupported ALTER command for external table” causing pg_upgrade to fail. Specifically, the pg_dump SQL contains the following ALTER which is not supported for external tables: `ALTER TABLE ONLY public.foobar ALTER COLUMN b SET DEFAULT nextval('public.foobar_b_seq'::regclass);`

This commit removes the restriction in ATVerifyObject to allow the above ALTER TABLE … ALTER COLUMN .. SET DEFAULT. This allows pg_upgrade and gpbackup to support serial column types such as bigserial on external tables.

It's important to note that serial column types implicitly add a default value with SET DEFAULT nextval('public.foobar_b_seq'::regclass) which should have been supported all along for external tables.

Removing the above restriction to allow ALTER TABLE … ALTER COLUMN .. SET DEFAULT will still not allow users to set a DEFAULT column value in the CREATE EXTERNAL TABLE syntax even though they can set it with ALTER TABLE. Thus, users can't create the table with defaults, but can only change it afterwards with ALTER. This is okay given the tradeoff that changing the CREATE EXTERNAL TABLE syntax is non-trivial and adding this syntax would not be backwards compatible in some downgrade scenarios when involving DDL for dump and restore.

3) Associated pg_upgrade acceptance tests
https://github.com/greenplum-db/gpupgrade/pull/764

Test Pipelines: 
https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/externalTablesWithSerialCols_6X
https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/externalTablesWithSerialCols_6X_RC