### PR TITLE
[5X] Refactor parserOpenTable, to match upstream better.

### DIFF
--- a/src/backend/parser/parse_relation.c
+++ b/src/backend/parser/parse_relation.c
@@ -748,30 +748,47 @@ static Relation
 parserOpenTable(ParseState *pstate, const RangeVar *relation,
 				int lockmode, bool *lockUpgraded)
 {
-	Relation rel = NULL;
-	
-	PG_TRY();
+	Relation	rel;
+	ParseCallbackState pcbstate;
+	Oid			relid;
+
+	setup_parser_errposition_callback(&pcbstate, pstate, relation->location);
+
+	/* Look up the appropriate relation using namespace search */
+	relid = RangeVarGetRelid(relation, true);
+	if (relid == InvalidOid)
 	{
-		rel = CdbOpenRelationRv(relation, lockmode, NULL);
-	}
-	PG_CATCH();
-	{
-		if (relation->schemaname == NULL &&
-			isFutureCTE(pstate, relation->relname))
-		{
+		if (relation->schemaname)
 			ereport(ERROR,
 					(errcode(ERRCODE_UNDEFINED_TABLE),
-					 errmsg("relation \"%s\" does not exist",
-							relation->relname),
-					 errdetail("There is a WITH item named \"%s\", but it cannot be referenced from this part of the query.",
-							   relation->relname),
-					 errhint("Re-order the WITH items to remove forward references.")));
+					 errmsg("relation \"%s.%s\" does not exist",
+							relation->schemaname, relation->relname)));
+		else
+		{
+			/*
+			 * An unqualified name might have been meant as a reference to
+			 * some not-yet-in-scope CTE.  The bare "does not exist" message
+			 * has proven remarkably unhelpful for figuring out such problems,
+			 * so we take pains to offer a specific hint.
+			 */
+			if (isFutureCTE(pstate, relation->relname))
+				ereport(ERROR,
+						(errcode(ERRCODE_UNDEFINED_TABLE),
+						 errmsg("relation \"%s\" does not exist",
+								relation->relname),
+						 errdetail("There is a WITH item named \"%s\", but it cannot be referenced from this part of the query.",
+								   relation->relname),
+						 errhint("Re-order the WITH items to remove forward references.")));
+			else
+				ereport(ERROR,
+						(errcode(ERRCODE_UNDEFINED_TABLE),
+						 errmsg("relation \"%s\" does not exist",
+								relation->relname)));
 		}
-
-		PG_RE_THROW();
 	}
-	PG_END_TRY();
+	rel = CdbOpenRelationRv(relation, lockmode, NULL);
 
+	cancel_parser_errposition_callback(&pcbstate);
 	return rel;
 }
 

--- a/src/backend/parser/parse_relation.c
+++ b/src/backend/parser/parse_relation.c
@@ -34,6 +34,7 @@
 #include "parser/parse_type.h"
 #include "parser/parse_coerce.h"
 #include "utils/builtins.h"
+#include "utils/faultinjector.h"
 #include "utils/lsyscache.h"
 #include "utils/syscache.h"
 
@@ -787,6 +788,13 @@ parserOpenTable(ParseState *pstate, const RangeVar *relation,
 		}
 	}
 	rel = CdbOpenRelationRv(relation, lockmode, NULL);
+
+#ifdef FAULT_INJECTOR
+	FaultInjector_InjectFaultNameIfSet("parse_open_table_cancel_query",
+								  DDLNotSpecified,
+											   "",	// databaseName
+											   ""); // tableName
+#endif
 
 	cancel_parser_errposition_callback(&pcbstate);
 	return rel;

--- a/src/test/regress/expected/parse_open_table_cancel_query.out
+++ b/src/test/regress/expected/parse_open_table_cancel_query.out
@@ -1,0 +1,60 @@
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+drop table if exists _tmp_table;
+NOTICE:  table "_tmp_table" does not exist, skipping
+create table _tmp_table (i1 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into _tmp_table select i from generate_series(0, 999) i;
+SELECT gp_inject_fault('parse_open_table_cancel_query', 'reset', 1);
+NOTICE:  Success:
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
+SELECT gp_inject_fault('parse_open_table_cancel_query', 'suspend', 1);
+NOTICE:  Success:
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
+SELECT * from _tmp_table order by i1 limit 10;
+ i1 
+----
+  0
+  1
+  2
+  3
+  4
+  5
+  6
+  7
+  8
+  9
+(10 rows)
+
+SELECT pg_cancel_backend(pg_backend_pid());
+ERROR:  canceling statement due to user request
+SELECT gp_inject_fault('parse_open_table_cancel_query', 'status', 1);
+NOTICE:  Success: fault name:'parse_open_table_cancel_query' fault type:'suspend' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'set'  num times hit:'0'
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
+SELECT gp_inject_fault('parse_open_table_cancel_query', 'resume', 1);
+NOTICE:  Success:
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
+SELECT gp_inject_fault('parse_open_table_cancel_query', 'reset', 1);
+NOTICE:  Success:
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
+drop table _tmp_table;

--- a/src/test/regress/expected/parse_open_table_cancel_query_optimizer.out
+++ b/src/test/regress/expected/parse_open_table_cancel_query_optimizer.out
@@ -1,0 +1,60 @@
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+drop table if exists _tmp_table;
+NOTICE:  table "_tmp_table" does not exist, skipping
+create table _tmp_table (i1 int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into _tmp_table select i from generate_series(0, 999) i;
+SELECT gp_inject_fault('parse_open_table_cancel_query', 'reset', 1);
+NOTICE:  Success:
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
+SELECT gp_inject_fault('parse_open_table_cancel_query', 'suspend', 1);
+NOTICE:  Success:
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
+SELECT * from _tmp_table order by i1 limit 10;
+ i1 
+----
+  0
+  1
+  2
+  3
+  4
+  5
+  6
+  7
+  8
+  9
+(10 rows)
+
+SELECT pg_cancel_backend(pg_backend_pid());
+ERROR:  canceling statement due to user request
+SELECT gp_inject_fault('parse_open_table_cancel_query', 'status', 1);
+NOTICE:  Success: fault name:'parse_open_table_cancel_query' fault type:'suspend' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'set'  num times hit:'0'
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
+SELECT gp_inject_fault('parse_open_table_cancel_query', 'resume', 1);
+NOTICE:  Success:
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
+SELECT gp_inject_fault('parse_open_table_cancel_query', 'reset', 1);
+NOTICE:  Success:
+ gp_inject_fault 
+-----------------
+ t
+(1 row)
+
+drop table _tmp_table;

--- a/src/test/regress/sql/parse_open_table_cancel_query.sql
+++ b/src/test/regress/sql/parse_open_table_cancel_query.sql
@@ -1,0 +1,17 @@
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+
+drop table if exists _tmp_table;
+create table _tmp_table (i1 int);
+insert into _tmp_table select i from generate_series(0, 999) i;
+
+SELECT gp_inject_fault('parse_open_table_cancel_query', 'reset', 1);
+SELECT gp_inject_fault('parse_open_table_cancel_query', 'suspend', 1);
+
+SELECT * from _tmp_table order by i1 limit 10;
+SELECT pg_cancel_backend(pg_backend_pid());
+
+SELECT gp_inject_fault('parse_open_table_cancel_query', 'status', 1);
+SELECT gp_inject_fault('parse_open_table_cancel_query', 'resume', 1);
+SELECT gp_inject_fault('parse_open_table_cancel_query', 'reset', 1);
+
+drop table _tmp_table;


### PR DESCRIPTION
To solve the issue:  _**Master went into recovery from SIGSEGV**_ #15112 , we need to backport this commit in 6X_STABLE branch to 5X_STABLE branch to avoid the unnecessary  `PG_RE_THROW()`:

https://github.com/greenplum-db/gpdb/commit/c97c0927ddbd492634bbb004514448ad3625552e


This seems like a more clear and robust way to do this, and matches the upstream code more closely, too.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
