### PR TITLE
[6X] ORCA: inject tableoid to targetlist for Delete/Update operation when runtime partition pruning occurs

### DIFF
--- a/src/backend/executor/nodeDML.c
+++ b/src/backend/executor/nodeDML.c
@@ -130,6 +130,13 @@ ExecDML(DMLState *node)
 
 		Assert(!isnull);
 
+		Oid tableoid = InvalidOid;
+		if (AttributeNumberIsValid(plannode->tableoidColIdx))
+		{
+			Datum dtableoid = slot_getattr(slot, plannode->tableoidColIdx, &isnull);
+			tableoid = isnull ? InvalidOid : DatumGetObjectId(dtableoid);
+		}
+
 		ItemPointer  tupleid = (ItemPointer) DatumGetPointer(ctid);
 		ItemPointerData tuple_ctid = *tupleid;
 		tupleid = &tuple_ctid;
@@ -149,7 +156,8 @@ ExecDML(DMLState *node)
 				   node->ps.state,
 				   !isUpdate, /* GPDB_91_MERGE_FIXME: where to get canSetTag? */
 				   PLANGEN_OPTIMIZER /* Plan origin */,
-				   isUpdate);
+				   isUpdate,
+				   tableoid);
 	}
 
 	return slot;

--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -4207,6 +4207,19 @@ CTranslatorDXLToPlStmt::TranslateDXLDml(
 	dml->ctidColIdx = AddTargetEntryForColId(&dml_target_list, &child_context,
 											 phy_dml_dxlop->GetCtIdColId(),
 											 true /*is_resjunk*/);
+
+	if (phy_dml_dxlop->GetTableOidColId() != 0)
+	{
+		dml->tableoidColIdx = AddTargetEntryForColId(
+			&dml_target_list, &child_context, phy_dml_dxlop->GetTableOidColId(),
+			true /*is_resjunk*/);
+	} else if (md_rel->IsPartitioned() && 
+		(CMD_UPDATE == m_cmd_type || CMD_DELETE == m_cmd_type))
+	{
+		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiDXL2PlStmtConversion,
+				   GPOS_WSZ_LIT("TableOid coulumn missed for partitioned table"));
+	}
+
 	if (phy_dml_dxlop->IsOidsPreserved())
 	{
 		dml->tupleoidColIdx = AddTargetEntryForColId(

--- a/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorQueryToDXL.cpp
@@ -1096,51 +1096,22 @@ CTranslatorQueryToDXL::ExtractStorageOptionStr(DefElem *def_elem)
 
 //---------------------------------------------------------------------------
 //	@function:
-//		CTranslatorQueryToDXL::GetCtidAndSegmentId
+//		CTranslatorUtils::GetSystemColId
 //
 //	@doc:
-//		Obtains the ids of the ctid and segmentid columns for the target
-//		table of a DML query
-//
-//---------------------------------------------------------------------------
-void
-CTranslatorQueryToDXL::GetCtidAndSegmentId(ULONG *ctid, ULONG *segment_id)
-{
-	// ctid column id
-	IMDId *mdid = CTranslatorUtils::GetSystemColType(
-		m_mp, SelfItemPointerAttributeNumber);
-	*ctid = CTranslatorUtils::GetColId(m_query_level, m_query->resultRelation,
-									   SelfItemPointerAttributeNumber, mdid,
-									   m_var_to_colid_map);
-	mdid->Release();
-
-	// segmentid column id
-	mdid = CTranslatorUtils::GetSystemColType(m_mp, GpSegmentIdAttributeNumber);
-	*segment_id = CTranslatorUtils::GetColId(
-		m_query_level, m_query->resultRelation, GpSegmentIdAttributeNumber,
-		mdid, m_var_to_colid_map);
-	mdid->Release();
-}
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CTranslatorQueryToDXL::GetTupleOidColId
-//
-//	@doc:
-//		Obtains the id of the tuple oid column for the target table of a DML
-//		update
+//		returns the corresponding ColId for the given system
+//		attribute numbber
 //
 //---------------------------------------------------------------------------
 ULONG
-CTranslatorQueryToDXL::GetTupleOidColId()
+CTranslatorQueryToDXL::GetSystemColId(INT attribute_number)
 {
-	IMDId *mdid =
-		CTranslatorUtils::GetSystemColType(m_mp, ObjectIdAttributeNumber);
-	ULONG tuple_oid_colid = CTranslatorUtils::GetColId(
-		m_query_level, m_query->resultRelation, ObjectIdAttributeNumber, mdid,
-		m_var_to_colid_map);
+	IMDId *mdid = CTranslatorUtils::GetSystemColType(m_mp, attribute_number);
+	ULONG res =
+		CTranslatorUtils::GetColId(m_query_level, m_query->resultRelation,
+								   attribute_number, mdid, m_var_to_colid_map);
 	mdid->Release();
-	return tuple_oid_colid;
+	return res;
 }
 
 //---------------------------------------------------------------------------
@@ -1182,9 +1153,14 @@ CTranslatorQueryToDXL::TranslateDeleteQueryToDXL()
 	// make note of the operator classes used in the distribution key
 	NoteDistributionPolicyOpclasses(rte);
 
-	ULONG ctid_colid = 0;
-	ULONG segid_colid = 0;
-	GetCtidAndSegmentId(&ctid_colid, &segid_colid);
+	ULONG ctid_colid = GetSystemColId(SelfItemPointerAttributeNumber);
+	ULONG segid_colid = GetSystemColId(GpSegmentIdAttributeNumber);
+
+	ULONG tableoid_colid = 0;
+	if (gpdb::RelPartIsRoot(rte->relid))
+	{
+		tableoid_colid = GetSystemColId(TableOidAttributeNumber);
+	}
 
 	ULongPtrArray *delete_colid_array = GPOS_NEW(m_mp) ULongPtrArray(m_mp);
 
@@ -1203,8 +1179,9 @@ CTranslatorQueryToDXL::TranslateDeleteQueryToDXL()
 		delete_colid_array->Append(GPOS_NEW(m_mp) ULONG(colid));
 	}
 
-	CDXLLogicalDelete *delete_dxlop = GPOS_NEW(m_mp) CDXLLogicalDelete(
-		m_mp, table_descr, ctid_colid, segid_colid, delete_colid_array);
+	CDXLLogicalDelete *delete_dxlop = GPOS_NEW(m_mp)
+		CDXLLogicalDelete(m_mp, table_descr, ctid_colid, segid_colid,
+						  delete_colid_array, tableoid_colid);
 
 	return GPOS_NEW(m_mp) CDXLNode(m_mp, delete_dxlop, query_dxlnode);
 }
@@ -1255,18 +1232,21 @@ CTranslatorQueryToDXL::TranslateUpdateQueryToDXL()
 
 	// make note of the operator classes used in the distribution key
 	NoteDistributionPolicyOpclasses(rte);
+	
+	ULONG ctid_colid = GetSystemColId(SelfItemPointerAttributeNumber);
+	ULONG segmentid_colid = GetSystemColId(GpSegmentIdAttributeNumber);
 
-	ULONG ctid_colid = 0;
-	ULONG segmentid_colid = 0;
-	GetCtidAndSegmentId(&ctid_colid, &segmentid_colid);
+	ULONG tableoid_colid = 0;
+	if (gpdb::RelPartIsRoot(rte->relid))
+	{
+		tableoid_colid = GetSystemColId(TableOidAttributeNumber);
+	}
 
 	ULONG tuple_oid_colid = 0;
-
-
 	BOOL has_oids = md_rel->HasOids();
 	if (has_oids)
 	{
-		tuple_oid_colid = GetTupleOidColId();
+		tuple_oid_colid = GetSystemColId(ObjectIdAttributeNumber);
 	}
 
 	// get (resno -> colId) mapping of columns to be updated
@@ -1308,7 +1288,7 @@ CTranslatorQueryToDXL::TranslateUpdateQueryToDXL()
 	update_column_map->Release();
 	CDXLLogicalUpdate *pdxlopupdate = GPOS_NEW(m_mp) CDXLLogicalUpdate(
 		m_mp, table_descr, ctid_colid, segmentid_colid, delete_colid_array,
-		insert_colid_array, has_oids, tuple_oid_colid);
+		insert_colid_array, has_oids, tuple_oid_colid, tableoid_colid);
 
 	return GPOS_NEW(m_mp) CDXLNode(m_mp, pdxlopupdate, query_dxlnode);
 }

--- a/src/backend/gporca/data/dxl/minidump/PartitionedDelete.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartitionedDelete.mdp
@@ -1,0 +1,382 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Comment><![CDATA[
+    Test case: Simple delete data from partition table. Expected that OidCol
+    (table oid) will be requested at plan.
+
+    create table test(i int, j int) partition by range(j)
+    (start (1) end(3) every(2), default partition extra);
+    explain delete from test where j = 1;
+                                                QUERY PLAN
+----------------------------------------------------------------------------------------------------------
+ Delete  (cost=0.00..431.03 rows=1 width=1)
+   ->  Result  (cost=0.00..431.00 rows=1 width=26)
+         ->  Sequence  (cost=0.00..431.00 rows=1 width=22)
+               ->  Partition Selector for test (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
+                     Partitions selected: 1 (out of 2)
+               ->  Dynamic Seq Scan on test (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=22)
+                     Filter: (j = 1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(8 rows)
+      ]]>
+  </dxl:Comment>
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0" SkewFactor="0"/>
+      <dxl:TraceFlags Value="101013,102074,102120,102146,102155,102156,103001,103014,103022,103027,103029,103038,103041,104002,104003,104004,104005,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:RelationStatistics Mdid="2.16438.1.0" Name="test" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
+      <dxl:Relation Mdid="6.16438.1.0" Name="test" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="7,8,2" PartitionColumns="1" PartitionTypes="r" NumberLeafPartitions="2">
+        <dxl:Columns>
+          <dxl:Column Name="i" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="j" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint DefaultPartition="0" Unbounded="true" ExprAbsent="true"/>
+      </dxl:Relation>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2134.1.0"/>
+        <dxl:MaxAgg Mdid="0.2118.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.7077.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.16438.1.0.1" Name="j" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.16438.1.0.0" Name="i" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.65.1.0"/>
+        <dxl:Commutator Mdid="0.96.1.0"/>
+        <dxl:InverseOp Mdid="0.518.1.0"/>
+        <dxl:HashOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7100.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.1977.1.0"/>
+          <dxl:Opfamily Mdid="0.7027.1.0"/>
+          <dxl:Opfamily Mdid="0.7100.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns/>
+      <dxl:CTEList/>
+      <dxl:LogicalDelete DeleteColumns="1,2" CtidCol="3" SegmentIdCol="9" OidCol="8">
+        <dxl:TableDescriptor Mdid="6.16438.1.0" TableName="test">
+          <dxl:Columns>
+            <dxl:Column ColId="10" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="11" Attno="2" ColName="j" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="12" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+            <dxl:Column ColId="13" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="14" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="15" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="16" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="17" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+            <dxl:Column ColId="18" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+          </dxl:Columns>
+        </dxl:TableDescriptor>
+        <dxl:LogicalSelect>
+          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+            <dxl:Ident ColId="2" ColName="j" TypeMdid="0.23.1.0"/>
+            <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+          </dxl:Comparison>
+          <dxl:LogicalGet>
+            <dxl:TableDescriptor Mdid="6.16438.1.0" TableName="test">
+              <dxl:Columns>
+                <dxl:Column ColId="1" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="2" Attno="2" ColName="j" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:LogicalGet>
+        </dxl:LogicalSelect>
+      </dxl:LogicalDelete>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="2">
+      <dxl:DMLDelete Columns="0,1" ActionCol="9" CtidCol="2" OidCol="7" SegmentIdCol="8">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="431.033894" Rows="1.000000" Width="1"/>
+        </dxl:Properties>
+        <dxl:DirectDispatchInfo/>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="0" Alias="i">
+            <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="1" Alias="j">
+            <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:TableDescriptor Mdid="6.16438.1.0" TableName="test">
+          <dxl:Columns>
+            <dxl:Column ColId="10" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="11" Attno="2" ColName="j" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="12" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+            <dxl:Column ColId="13" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="14" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="15" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="16" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="17" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+            <dxl:Column ColId="18" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+          </dxl:Columns>
+        </dxl:TableDescriptor>
+        <dxl:Result>
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="431.000040" Rows="1.000000" Width="26"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="0" Alias="i">
+              <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="1" Alias="j">
+              <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="2" Alias="ctid">
+              <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="7" Alias="tableoid">
+              <dxl:Ident ColId="7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="8" Alias="gp_segment_id">
+              <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="9" Alias="ColRef_0009">
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:OneTimeFilter/>
+          <dxl:Sequence>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.000032" Rows="1.000000" Width="22"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="0" Alias="i">
+                <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="1" Alias="j">
+                <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="2" Alias="ctid">
+                <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="7" Alias="tableoid">
+                <dxl:Ident ColId="7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="8" Alias="gp_segment_id">
+                <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:PartitionSelector RelationMdid="6.16438.1.0" PartitionLevels="1" ScanId="1">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="10" TotalCost="100" Rows="100" Width="4"/>
+              </dxl:Properties>
+              <dxl:ProjList/>
+              <dxl:PartEqFilters>
+                <dxl:PartEqFilterElems>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                </dxl:PartEqFilterElems>
+              </dxl:PartEqFilters>
+              <dxl:PartFilters>
+                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+              </dxl:PartFilters>
+              <dxl:ResidualFilter>
+                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+              </dxl:ResidualFilter>
+              <dxl:PropagationExpression>
+                <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+              </dxl:PropagationExpression>
+              <dxl:PrintableFilter>
+                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                  <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                </dxl:Comparison>
+              </dxl:PrintableFilter>
+            </dxl:PartitionSelector>
+            <dxl:DynamicTableScan PartIndexId="1">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.000032" Rows="1.000000" Width="22"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="0" Alias="i">
+                  <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="1" Alias="j">
+                  <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="2" Alias="ctid">
+                  <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="7" Alias="tableoid">
+                  <dxl:Ident ColId="7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="8" Alias="gp_segment_id">
+                  <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter>
+                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                  <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                </dxl:Comparison>
+              </dxl:Filter>
+              <dxl:TableDescriptor Mdid="6.16438.1.0" TableName="test">
+                <dxl:Columns>
+                  <dxl:Column ColId="0" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="1" Attno="2" ColName="j" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                  <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:DynamicTableScan>
+          </dxl:Sequence>
+        </dxl:Result>
+      </dxl:DMLDelete>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/PartitionedInsert.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartitionedInsert.mdp
@@ -1,0 +1,314 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Comment><![CDATA[
+    Test case: Simple insert data to partition table. Expected that OidCol
+    (table oid) won't be requested at plan.
+
+    create table test(i int, j int) partition by range(j)
+    (start (1) end(3) every(2), default partition extra);
+    explain insert into test values (0, 1);
+                            QUERY PLAN
+------------------------------------------------------------------
+ Insert  (cost=0.00..0.02 rows=1 width=8)
+   ->  Result  (cost=0.00..0.00 rows=1 width=12)
+         ->  Result  (cost=0.00..0.00 rows=1 width=8)
+               ->  Result  (cost=0.00..0.00 rows=1 width=8)
+                     ->  Result  (cost=0.00..0.00 rows=1 width=1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(6 rows)
+      ]]>
+  </dxl:Comment>
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0" SkewFactor="0"/>
+      <dxl:TraceFlags Value="101013,102074,102120,102146,102155,102156,103001,103014,103022,103027,103029,103038,103041,104002,104003,104004,104005,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:Relation Mdid="6.16438.1.0" Name="test" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="7,8,2" PartitionColumns="1" PartitionTypes="r" NumberLeafPartitions="2">
+        <dxl:Columns>
+          <dxl:Column Name="i" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="j" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint DefaultPartition="0" Unbounded="true" ExprAbsent="true"/>
+      </dxl:Relation>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2134.1.0"/>
+        <dxl:MaxAgg Mdid="0.2118.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.7077.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="2" ColName="i" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="3" ColName="j" TypeMdid="0.23.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalInsert InsertColumns="2,3">
+        <dxl:TableDescriptor Mdid="6.16438.1.0" TableName="test">
+          <dxl:Columns>
+            <dxl:Column ColId="4" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="5" Attno="2" ColName="j" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="6" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+            <dxl:Column ColId="7" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="8" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="9" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="10" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="11" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+            <dxl:Column ColId="12" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+          </dxl:Columns>
+        </dxl:TableDescriptor>
+        <dxl:LogicalProject>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="2" Alias="i">
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="3" Alias="j">
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:LogicalConstTable>
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="" TypeMdid="0.16.1.0"/>
+            </dxl:Columns>
+            <dxl:ConstTuple>
+              <dxl:Datum TypeMdid="0.16.1.0" Value="true"/>
+            </dxl:ConstTuple>
+          </dxl:LogicalConstTable>
+        </dxl:LogicalProject>
+      </dxl:LogicalInsert>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="3">
+      <dxl:DMLInsert Columns="1,2" ActionCol="3" CtidCol="0" SegmentIdCol="0">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="0.015659" Rows="1.000000" Width="8"/>
+        </dxl:Properties>
+        <dxl:DirectDispatchInfo>
+          <dxl:KeyValue>
+            <dxl:Datum TypeMdid="0.23.1.0" Value="0"/>
+          </dxl:KeyValue>
+        </dxl:DirectDispatchInfo>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="1" Alias="i">
+            <dxl:Ident ColId="1" ColName="i" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="2" Alias="j">
+            <dxl:Ident ColId="2" ColName="j" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:TableDescriptor Mdid="6.16438.1.0" TableName="test">
+          <dxl:Columns>
+            <dxl:Column ColId="4" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="5" Attno="2" ColName="j" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="6" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+            <dxl:Column ColId="7" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="8" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="9" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="10" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="11" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+            <dxl:Column ColId="12" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+          </dxl:Columns>
+        </dxl:TableDescriptor>
+        <dxl:Result>
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="0.000034" Rows="1.000000" Width="12"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="1" Alias="i">
+              <dxl:Ident ColId="1" ColName="i" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="2" Alias="j">
+              <dxl:Ident ColId="2" ColName="j" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="3" Alias="ColRef_0003">
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:OneTimeFilter/>
+          <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1,2" DuplicateSensitive="true">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="0.000030" Rows="1.000000" Width="8"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="1" Alias="i">
+                <dxl:Ident ColId="1" ColName="i" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="2" Alias="j">
+                <dxl:Ident ColId="2" ColName="j" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:SortingColumnList/>
+            <dxl:HashExprList>
+              <dxl:HashExpr Opfamily="0.1977.1.0">
+                <dxl:Ident ColId="1" ColName="i" TypeMdid="0.23.1.0"/>
+              </dxl:HashExpr>
+            </dxl:HashExprList>
+            <dxl:Result>
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="0.000009" Rows="1.000000" Width="8"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="1" Alias="i">
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="2" Alias="j">
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:OneTimeFilter/>
+              <dxl:Result>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="0" Alias="">
+                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:OneTimeFilter/>
+              </dxl:Result>
+            </dxl:Result>
+          </dxl:RedistributeMotion>
+        </dxl:Result>
+      </dxl:DMLInsert>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/PartitionedUpdate.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartitionedUpdate.mdp
@@ -1,0 +1,451 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Comment><![CDATA[
+    Test case: Simple update data at partition table. Expected that OidCol
+    (table oid) will be requested at plan.
+
+    create table test(i int, j int) partition by range(j)
+    (start (1) end(3) every(2), default partition extra);
+    explain update test set i = 123 where j = 1;
+                                                      QUERY PLAN
+----------------------------------------------------------------------------------------------------------------------
+ Update  (cost=0.00..431.07 rows=1 width=1)
+   ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=26)
+         Hash Key: test.i
+         ->  Split  (cost=0.00..431.00 rows=1 width=26)
+               ->  Result  (cost=0.00..431.00 rows=1 width=26)
+                     ->  Sequence  (cost=0.00..431.00 rows=1 width=22)
+                           ->  Partition Selector for test (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
+                                 Partitions selected: 1 (out of 2)
+                           ->  Dynamic Seq Scan on test (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=22)
+                                 Filter: (j = 1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(11 rows)
+      ]]>
+  </dxl:Comment>
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0" SkewFactor="0"/>
+      <dxl:TraceFlags Value="101013,102074,102120,102146,102155,102156,103001,103014,103022,103027,103029,103038,103041,104002,104003,104004,104005,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:RelationStatistics Mdid="2.16438.1.0" Name="test" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
+      <dxl:Relation Mdid="6.16438.1.0" Name="test" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="7,8,2" PartitionColumns="1" PartitionTypes="r" NumberLeafPartitions="2">
+        <dxl:Columns>
+          <dxl:Column Name="i" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="j" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint DefaultPartition="0" Unbounded="true" ExprAbsent="true"/>
+      </dxl:Relation>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2134.1.0"/>
+        <dxl:MaxAgg Mdid="0.2118.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.7077.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.16438.1.0.1" Name="j" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.16438.1.0.0" Name="i" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.65.1.0"/>
+        <dxl:Commutator Mdid="0.96.1.0"/>
+        <dxl:InverseOp Mdid="0.518.1.0"/>
+        <dxl:HashOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7100.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.1977.1.0"/>
+          <dxl:Opfamily Mdid="0.7027.1.0"/>
+          <dxl:Opfamily Mdid="0.7100.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="10" ColName="i" TypeMdid="0.23.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalUpdate DeleteColumns="1,2" InsertColumns="10,2" CtidCol="3" SegmentIdCol="9" PreserveOids="false" OidCol="8">
+        <dxl:TableDescriptor Mdid="6.16438.1.0" TableName="test">
+          <dxl:Columns>
+            <dxl:Column ColId="11" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="12" Attno="2" ColName="j" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+            <dxl:Column ColId="14" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="15" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="16" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="17" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="18" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+            <dxl:Column ColId="19" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+          </dxl:Columns>
+        </dxl:TableDescriptor>
+        <dxl:LogicalProject>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="10" Alias="i">
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="123"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:LogicalSelect>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+              <dxl:Ident ColId="2" ColName="j" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+            </dxl:Comparison>
+            <dxl:LogicalGet>
+              <dxl:TableDescriptor Mdid="6.16438.1.0" TableName="test">
+                <dxl:Columns>
+                  <dxl:Column ColId="1" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="2" Attno="2" ColName="j" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                  <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:LogicalGet>
+          </dxl:LogicalSelect>
+        </dxl:LogicalProject>
+      </dxl:LogicalUpdate>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="1">
+      <dxl:DMLUpdate Columns="0,1" ActionCol="10" CtidCol="2" OidCol="7" SegmentIdCol="8" PreserveOids="false">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="431.067820" Rows="1.000000" Width="1"/>
+        </dxl:Properties>
+        <dxl:DirectDispatchInfo/>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="0" Alias="i">
+            <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="1" Alias="j">
+            <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:TableDescriptor Mdid="6.16438.1.0" TableName="test">
+          <dxl:Columns>
+            <dxl:Column ColId="11" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="12" Attno="2" ColName="j" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+            <dxl:Column ColId="14" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="15" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="16" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="17" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="18" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+            <dxl:Column ColId="19" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+          </dxl:Columns>
+        </dxl:TableDescriptor>
+        <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="431.000112" Rows="2.000000" Width="26"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="0" Alias="i">
+              <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="1" Alias="j">
+              <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="2" Alias="ctid">
+              <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="7" Alias="tableoid">
+              <dxl:Ident ColId="7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="8" Alias="gp_segment_id">
+              <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="10" Alias="ColRef_0010">
+              <dxl:Ident ColId="10" ColName="ColRef_0010" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:SortingColumnList/>
+          <dxl:HashExprList>
+            <dxl:HashExpr Opfamily="0.1977.1.0">
+              <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+            </dxl:HashExpr>
+          </dxl:HashExprList>
+          <dxl:Split DeleteColumns="0,1" InsertColumns="9,1" ActionCol="10" CtidCol="2" SegmentIdCol="8" PreserveOids="false">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.000058" Rows="2.000000" Width="26"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="0" Alias="i">
+                <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="1" Alias="j">
+                <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="2" Alias="ctid">
+                <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="7" Alias="tableoid">
+                <dxl:Ident ColId="7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="8" Alias="gp_segment_id">
+                <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="10" Alias="ColRef_0010">
+                <dxl:DMLAction/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Result>
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.000040" Rows="1.000000" Width="26"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="0" Alias="i">
+                  <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="1" Alias="j">
+                  <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="9" Alias="i">
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="123"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="2" Alias="ctid">
+                  <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="7" Alias="tableoid">
+                  <dxl:Ident ColId="7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="8" Alias="gp_segment_id">
+                  <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:OneTimeFilter/>
+              <dxl:Sequence>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000032" Rows="1.000000" Width="22"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="0" Alias="i">
+                    <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="1" Alias="j">
+                    <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="2" Alias="ctid">
+                    <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="7" Alias="tableoid">
+                    <dxl:Ident ColId="7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="8" Alias="gp_segment_id">
+                    <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:PartitionSelector RelationMdid="6.16438.1.0" PartitionLevels="1" ScanId="1">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="10" TotalCost="100" Rows="100" Width="4"/>
+                  </dxl:Properties>
+                  <dxl:ProjList/>
+                  <dxl:PartEqFilters>
+                    <dxl:PartEqFilterElems>
+                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                    </dxl:PartEqFilterElems>
+                  </dxl:PartEqFilters>
+                  <dxl:PartFilters>
+                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                  </dxl:PartFilters>
+                  <dxl:ResidualFilter>
+                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                  </dxl:ResidualFilter>
+                  <dxl:PropagationExpression>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                  </dxl:PropagationExpression>
+                  <dxl:PrintableFilter>
+                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                      <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
+                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                    </dxl:Comparison>
+                  </dxl:PrintableFilter>
+                </dxl:PartitionSelector>
+                <dxl:DynamicTableScan PartIndexId="1">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000032" Rows="1.000000" Width="22"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="0" Alias="i">
+                      <dxl:Ident ColId="0" ColName="i" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="1" Alias="j">
+                      <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="2" Alias="ctid">
+                      <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="7" Alias="tableoid">
+                      <dxl:Ident ColId="7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="8" Alias="gp_segment_id">
+                      <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter>
+                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                      <dxl:Ident ColId="1" ColName="j" TypeMdid="0.23.1.0"/>
+                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                    </dxl:Comparison>
+                  </dxl:Filter>
+                  <dxl:TableDescriptor Mdid="6.16438.1.0" TableName="test">
+                    <dxl:Columns>
+                      <dxl:Column ColId="0" Attno="1" ColName="i" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="1" Attno="2" ColName="j" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                      <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    </dxl:Columns>
+                  </dxl:TableDescriptor>
+                </dxl:DynamicTableScan>
+              </dxl:Sequence>
+            </dxl:Result>
+          </dxl:Split>
+        </dxl:RedistributeMotion>
+      </dxl:DMLUpdate>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalDML.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalDML.h
@@ -58,6 +58,10 @@ private:
 	// action column
 	CColRef *m_pcrAction;
 
+	// table oid column (has value NULL for Update/Delete operations on non partitioned
+	// tables and for all Insert operations)
+	CColRef *m_pcrTableOid;
+
 	// ctid column
 	CColRef *m_pcrCtid;
 
@@ -78,7 +82,7 @@ public:
 	CLogicalDML(CMemoryPool *mp, EDMLOperator edmlop,
 				CTableDescriptor *ptabdesc, CColRefArray *colref_array,
 				CBitSet *pbsModified, CColRef *pcrAction, CColRef *pcrCtid,
-				CColRef *pcrSegmentId, CColRef *pcrTupleOid);
+				CColRef *pcrSegmentId, CColRef *pcrTupleOid, CColRef *pcrTableOid);
 
 	// dtor
 	virtual ~CLogicalDML();
@@ -123,6 +127,13 @@ public:
 	PcrAction() const
 	{
 		return m_pcrAction;
+	}
+
+	// table oid column
+	CColRef *
+	PcrTableOid() const
+	{
+		return m_pcrTableOid;
 	}
 
 	// ctid column

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalDelete.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalDelete.h
@@ -43,6 +43,9 @@ private:
 	// segmentId column
 	CColRef *m_pcrSegmentId;
 
+	// table oid column (has value NULL in case of on non partitioned tables)
+	CColRef *m_pcrTableOid;
+
 	// private copy ctor
 	CLogicalDelete(const CLogicalDelete &);
 
@@ -53,7 +56,7 @@ public:
 	// ctor
 	CLogicalDelete(CMemoryPool *mp, CTableDescriptor *ptabdesc,
 				   CColRefArray *colref_array, CColRef *pcrCtid,
-				   CColRef *pcrSegmentId);
+				   CColRef *pcrSegmentId, CColRef *pcrTableOid);
 
 	// dtor
 	virtual ~CLogicalDelete();
@@ -91,6 +94,13 @@ public:
 	PcrSegmentId() const
 	{
 		return m_pcrSegmentId;
+	}
+
+	// table oid column
+	CColRef *
+	PcrTableOid() const
+	{
+		return m_pcrTableOid;
 	}
 
 	// return table's descriptor

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalUpdate.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalUpdate.h
@@ -46,8 +46,11 @@ private:
 	// segmentId column
 	CColRef *m_pcrSegmentId;
 
-	// tuple oid column
+	// table oid column (has value NULL in case of on non partitioned tables)
 	CColRef *m_pcrTupleOid;
+
+	// table oid column
+	CColRef *m_pcrTableOid;
 
 	// private copy ctor
 	CLogicalUpdate(const CLogicalUpdate &);
@@ -60,7 +63,7 @@ public:
 	CLogicalUpdate(CMemoryPool *mp, CTableDescriptor *ptabdesc,
 				   CColRefArray *pdrgpcrDelete, CColRefArray *pdrgpcrInsert,
 				   CColRef *pcrCtid, CColRef *pcrSegmentId,
-				   CColRef *pcrTupleOid);
+				   CColRef *pcrTupleOid, CColRef *pcrTableOid);
 
 	// dtor
 	virtual ~CLogicalUpdate();
@@ -112,6 +115,13 @@ public:
 	PcrTupleOid() const
 	{
 		return m_pcrTupleOid;
+	}
+
+	// table oid column
+	CColRef *
+	PcrTableOid() const
+	{
+		return m_pcrTableOid;
 	}
 
 	// return table's descriptor

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalDML.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalDML.h
@@ -48,6 +48,10 @@ private:
 	// action column
 	CColRef *m_pcrAction;
 
+	// table oid column (has value NULL for Update/Delete operations on non partitioned
+	// tables and for all Insert operations)
+	CColRef *m_pcrTableOid;
+
 	// ctid column
 	CColRef *m_pcrCtid;
 
@@ -80,7 +84,7 @@ public:
 	CPhysicalDML(CMemoryPool *mp, CLogicalDML::EDMLOperator edmlop,
 				 CTableDescriptor *ptabdesc, CColRefArray *pdrgpcrSource,
 				 CBitSet *pbsModified, CColRef *pcrAction, CColRef *pcrCtid,
-				 CColRef *pcrSegmentId, CColRef *pcrTupleOid);
+				 CColRef *pcrSegmentId, CColRef *pcrTupleOid, CColRef *prcTableOid);
 
 	// dtor
 	virtual ~CPhysicalDML();
@@ -118,6 +122,13 @@ public:
 	PcrAction() const
 	{
 		return m_pcrAction;
+	}
+
+	// table oid column
+	CColRef *
+	PcrTableOid() const
+	{
+		return m_pcrTableOid;
 	}
 
 	// ctid column

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformUtils.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformUtils.h
@@ -423,7 +423,8 @@ public:
 	static CExpression *PexprLogicalDMLOverProject(
 		CMemoryPool *mp, CExpression *pexprChild,
 		CLogicalDML::EDMLOperator edmlop, CTableDescriptor *ptabdesc,
-		CColRefArray *colref_array, CColRef *pcrCtid, CColRef *pcrSegmentId);
+		CColRefArray *colref_array, CColRef *pcrCtid, CColRef *pcrSegmentId,
+		CColRef *pcrTableOid);
 
 	// check whether there are any BEFORE or AFTER triggers on the
 	// given table that match the given DML operation

--- a/src/backend/gporca/libgpopt/src/operators/CLogicalDML.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CLogicalDML.cpp
@@ -39,6 +39,7 @@ CLogicalDML::CLogicalDML(CMemoryPool *mp)
 	  m_pdrgpcrSource(NULL),
 	  m_pbsModified(NULL),
 	  m_pcrAction(NULL),
+	  m_pcrTableOid(NULL),
 	  m_pcrCtid(NULL),
 	  m_pcrSegmentId(NULL),
 	  m_pcrTupleOid(NULL)
@@ -58,13 +59,14 @@ CLogicalDML::CLogicalDML(CMemoryPool *mp, EDMLOperator edmlop,
 						 CTableDescriptor *ptabdesc,
 						 CColRefArray *pdrgpcrSource, CBitSet *pbsModified,
 						 CColRef *pcrAction, CColRef *pcrCtid,
-						 CColRef *pcrSegmentId, CColRef *pcrTupleOid)
+						 CColRef *pcrSegmentId, CColRef *pcrTupleOid, CColRef *pcrTableOid)
 	: CLogical(mp),
 	  m_edmlop(edmlop),
 	  m_ptabdesc(ptabdesc),
 	  m_pdrgpcrSource(pdrgpcrSource),
 	  m_pbsModified(pbsModified),
 	  m_pcrAction(pcrAction),
+	  m_pcrTableOid(pcrTableOid),
 	  m_pcrCtid(pcrCtid),
 	  m_pcrSegmentId(pcrSegmentId),
 	  m_pcrTupleOid(pcrTupleOid)
@@ -79,6 +81,11 @@ CLogicalDML::CLogicalDML(CMemoryPool *mp, EDMLOperator edmlop,
 
 	m_pcrsLocalUsed->Include(m_pdrgpcrSource);
 	m_pcrsLocalUsed->Include(m_pcrAction);
+	if (NULL != m_pcrTableOid)
+	{
+		m_pcrsLocalUsed->Include(m_pcrTableOid);
+	}
+
 	if (NULL != m_pcrCtid)
 	{
 		m_pcrsLocalUsed->Include(m_pcrCtid);
@@ -130,6 +137,7 @@ CLogicalDML::Matches(COperator *pop) const
 	CLogicalDML *popDML = CLogicalDML::PopConvert(pop);
 
 	return m_pcrAction == popDML->PcrAction() &&
+		   m_pcrTableOid == popDML->PcrTableOid() &&
 		   m_pcrCtid == popDML->PcrCtid() &&
 		   m_pcrSegmentId == popDML->PcrSegmentId() &&
 		   m_pcrTupleOid == popDML->PcrTupleOid() &&
@@ -153,6 +161,7 @@ CLogicalDML::HashValue() const
 	ulHash = gpos::CombineHashes(ulHash, gpos::HashPtr<CColRef>(m_pcrAction));
 	ulHash =
 		gpos::CombineHashes(ulHash, CUtils::UlHashColArray(m_pdrgpcrSource));
+	ulHash = gpos::CombineHashes(ulHash, gpos::HashPtr<CColRef>(m_pcrTableOid));
 
 	if (EdmlDelete == m_edmlop || EdmlUpdate == m_edmlop)
 	{
@@ -182,6 +191,13 @@ CLogicalDML::PopCopyWithRemappedColumns(CMemoryPool *mp,
 	CColRef *pcrAction =
 		CUtils::PcrRemap(m_pcrAction, colref_mapping, must_exist);
 
+	CColRef *pcrTableOid = NULL;
+	if (NULL != m_pcrTableOid)
+	{
+		pcrTableOid =
+			CUtils::PcrRemap(m_pcrTableOid, colref_mapping, must_exist);
+	}
+
 	// no need to remap modified columns bitset as it represent column indexes
 	// and not actual columns
 	m_pbsModified->AddRef();
@@ -210,7 +226,7 @@ CLogicalDML::PopCopyWithRemappedColumns(CMemoryPool *mp,
 
 	return GPOS_NEW(mp)
 		CLogicalDML(mp, m_edmlop, m_ptabdesc, colref_array, m_pbsModified,
-					pcrAction, pcrCtid, pcrSegmentId, pcrTupleOid);
+					pcrAction, pcrCtid, pcrSegmentId, pcrTupleOid, pcrTableOid);
 }
 
 //---------------------------------------------------------------------------
@@ -353,6 +369,13 @@ CLogicalDML::OsPrint(IOstream &os) const
 	os << "], Action: (";
 	m_pcrAction->OsPrint(os);
 	os << ")";
+
+	if (NULL != m_pcrTableOid)
+	{
+		os << ", Oid: (";
+		m_pcrTableOid->OsPrint(os);
+		os << ")";
+	}
 
 	if (EdmlDelete == m_edmlop || EdmlUpdate == m_edmlop)
 	{

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalDML.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalDML.cpp
@@ -38,13 +38,14 @@ CPhysicalDML::CPhysicalDML(CMemoryPool *mp, CLogicalDML::EDMLOperator edmlop,
 						   CTableDescriptor *ptabdesc,
 						   CColRefArray *pdrgpcrSource, CBitSet *pbsModified,
 						   CColRef *pcrAction, CColRef *pcrCtid,
-						   CColRef *pcrSegmentId, CColRef *pcrTupleOid)
+						   CColRef *pcrSegmentId, CColRef *pcrTupleOid, CColRef *pcrTableOid)
 	: CPhysical(mp),
 	  m_edmlop(edmlop),
 	  m_ptabdesc(ptabdesc),
 	  m_pdrgpcrSource(pdrgpcrSource),
 	  m_pbsModified(pbsModified),
 	  m_pcrAction(pcrAction),
+	  m_pcrTableOid(pcrTableOid),
 	  m_pcrCtid(pcrCtid),
 	  m_pcrSegmentId(pcrSegmentId),
 	  m_pcrTupleOid(pcrTupleOid),
@@ -403,6 +404,7 @@ CPhysicalDML::HashValue() const
 	ULONG ulHash = gpos::CombineHashes(COperator::HashValue(),
 									   m_ptabdesc->MDId()->HashValue());
 	ulHash = gpos::CombineHashes(ulHash, gpos::HashPtr<CColRef>(m_pcrAction));
+	ulHash = gpos::CombineHashes(ulHash, gpos::HashPtr<CColRef>(m_pcrTableOid));
 	ulHash =
 		gpos::CombineHashes(ulHash, CUtils::UlHashColArray(m_pdrgpcrSource));
 
@@ -433,6 +435,7 @@ CPhysicalDML::Matches(COperator *pop) const
 		CPhysicalDML *popDML = CPhysicalDML::PopConvert(pop);
 
 		return m_pcrAction == popDML->PcrAction() &&
+			   m_pcrTableOid == popDML->PcrTableOid() &&
 			   m_pcrCtid == popDML->PcrCtid() &&
 			   m_pcrSegmentId == popDML->PcrSegmentId() &&
 			   m_pcrTupleOid == popDML->PcrTupleOid() &&
@@ -540,6 +543,11 @@ CPhysicalDML::ComputeRequiredLocalColumns(CMemoryPool *mp)
 	m_pcrsRequiredLocal->Include(m_pdrgpcrSource);
 	m_pcrsRequiredLocal->Include(m_pcrAction);
 
+	if (NULL != m_pcrTableOid)
+	{
+		m_pcrsRequiredLocal->Include(m_pcrTableOid);
+	}
+
 	if (CLogicalDML::EdmlDelete == m_edmlop ||
 		CLogicalDML::EdmlUpdate == m_edmlop)
 	{
@@ -578,6 +586,13 @@ CPhysicalDML::OsPrint(IOstream &os) const
 	m_pcrAction->OsPrint(os);
 	os << ")";
 
+	if (NULL != m_pcrTableOid)
+	{
+		os << ", Oid: (";
+		m_pcrTableOid->OsPrint(os);
+		os << ")";
+	}
+
 	if (CLogicalDML::EdmlDelete == m_edmlop ||
 		CLogicalDML::EdmlUpdate == m_edmlop)
 	{
@@ -586,7 +601,6 @@ CPhysicalDML::OsPrint(IOstream &os) const
 		os << ", ";
 		m_pcrSegmentId->OsPrint(os);
 	}
-
 
 	return os;
 }

--- a/src/backend/gporca/libgpopt/src/translate/CTranslatorDXLToExpr.cpp
+++ b/src/backend/gporca/libgpopt/src/translate/CTranslatorDXLToExpr.cpp
@@ -1427,9 +1427,16 @@ CTranslatorDXLToExpr::PexprLogicalDelete(const CDXLNode *dxlnode)
 
 	ULONG ctid_colid = pdxlopDelete->GetCtIdColId();
 	ULONG segid_colid = pdxlopDelete->GetSegmentIdColId();
+	ULONG tableoid_colid = pdxlopDelete->GeTableOidColId();
 
 	CColRef *pcrCtid = LookupColRef(m_phmulcr, ctid_colid);
 	CColRef *pcrSegmentId = LookupColRef(m_phmulcr, segid_colid);
+	CColRef *pcrTableOid = NULL;
+
+	if (0 != tableoid_colid)
+	{
+		pcrTableOid = LookupColRef(m_phmulcr, tableoid_colid);
+	}
 
 	ULongPtrArray *pdrgpulCols = pdxlopDelete->GetDeletionColIdArray();
 	CColRefArray *colref_array =
@@ -1437,8 +1444,8 @@ CTranslatorDXLToExpr::PexprLogicalDelete(const CDXLNode *dxlnode)
 
 	return GPOS_NEW(m_mp) CExpression(
 		m_mp,
-		GPOS_NEW(m_mp)
-			CLogicalDelete(m_mp, ptabdesc, colref_array, pcrCtid, pcrSegmentId),
+		GPOS_NEW(m_mp) CLogicalDelete(m_mp, ptabdesc, colref_array, pcrCtid,
+									  pcrSegmentId, pcrTableOid),
 		pexprChild);
 }
 
@@ -1471,9 +1478,16 @@ CTranslatorDXLToExpr::PexprLogicalUpdate(const CDXLNode *dxlnode)
 
 	ULONG ctid_colid = pdxlopUpdate->GetCtIdColId();
 	ULONG segid_colid = pdxlopUpdate->GetSegmentIdColId();
+	ULONG tableoid_colid = pdxlopUpdate->GetTableOidColId();
 
 	CColRef *pcrCtid = LookupColRef(m_phmulcr, ctid_colid);
 	CColRef *pcrSegmentId = LookupColRef(m_phmulcr, segid_colid);
+	CColRef *pcrTableOid = NULL;
+
+	if (0 != tableoid_colid)
+	{
+		pcrTableOid = LookupColRef(m_phmulcr, tableoid_colid);
+	}
 
 	ULongPtrArray *pdrgpulInsertCols = pdxlopUpdate->GetInsertionColIdArray();
 	CColRefArray *pdrgpcrInsert =
@@ -1490,12 +1504,12 @@ CTranslatorDXLToExpr::PexprLogicalUpdate(const CDXLNode *dxlnode)
 		pcrTupleOid = LookupColRef(m_phmulcr, tuple_oid);
 	}
 
-	return GPOS_NEW(m_mp)
-		CExpression(m_mp,
-					GPOS_NEW(m_mp) CLogicalUpdate(m_mp, ptabdesc, pdrgpcrDelete,
-												  pdrgpcrInsert, pcrCtid,
-												  pcrSegmentId, pcrTupleOid),
-					pexprChild);
+	return GPOS_NEW(m_mp) CExpression(
+		m_mp,
+		GPOS_NEW(m_mp)
+			CLogicalUpdate(m_mp, ptabdesc, pdrgpcrDelete, pdrgpcrInsert,
+						   pcrCtid, pcrSegmentId, pcrTupleOid, pcrTableOid),
+		pexprChild);
 }
 
 //---------------------------------------------------------------------------

--- a/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
+++ b/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
@@ -5738,6 +5738,7 @@ CTranslatorExprToDXL::PdxlnDML(CExpression *pexpr,
 	GPOS_ASSERT(1 == pexpr->Arity());
 
 	ULONG action_colid = 0;
+	ULONG tableoid_colid = 0;
 	ULONG ctid_colid = 0;
 	ULONG segid_colid = 0;
 
@@ -5758,6 +5759,12 @@ CTranslatorExprToDXL::PdxlnDML(CExpression *pexpr,
 	CColRef *pcrAction = popDML->PcrAction();
 	GPOS_ASSERT(NULL != pcrAction);
 	action_colid = pcrAction->Id();
+
+	CColRef *pcrTableOid = popDML->PcrTableOid();
+	if (NULL != pcrTableOid)
+	{
+		tableoid_colid = pcrTableOid->Id();
+	}
 
 	CColRef *pcrCtid = popDML->PcrCtid();
 	CColRef *pcrSegmentId = popDML->PcrSegmentId();
@@ -5789,7 +5796,7 @@ CTranslatorExprToDXL::PdxlnDML(CExpression *pexpr,
 		GetDXLDirectDispatchInfo(pexpr);
 	CDXLPhysicalDML *pdxlopDML = GPOS_NEW(m_mp) CDXLPhysicalDML(
 		m_mp, dxl_dml_type, table_descr, pdrgpul, action_colid, ctid_colid,
-		segid_colid, preserve_oids, tuple_oid, dxl_direct_dispatch_info);
+		segid_colid, preserve_oids, tuple_oid, tableoid_colid, dxl_direct_dispatch_info);
 
 	// project list
 	CColRefSet *pcrsOutput = pexpr->Prpp()->PcrsRequired();

--- a/src/backend/gporca/libgpopt/src/xforms/CXformDelete2DML.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformDelete2DML.cpp
@@ -84,6 +84,8 @@ CXformDelete2DML::Transform(CXformContext *pxfctxt, CXformResult *pxfres,
 
 	CColRef *pcrSegmentId = popDelete->PcrSegmentId();
 
+	CColRef *pcrTableOid = popDelete->PcrTableOid();
+
 	// child of delete operator
 	CExpression *pexprChild = (*pexpr)[0];
 	pexprChild->AddRef();
@@ -91,7 +93,7 @@ CXformDelete2DML::Transform(CXformContext *pxfctxt, CXformResult *pxfres,
 	// create logical DML
 	CExpression *pexprAlt = CXformUtils::PexprLogicalDMLOverProject(
 		mp, pexprChild, CLogicalDML::EdmlDelete, ptabdesc, colref_array,
-		pcrCtid, pcrSegmentId);
+		pcrCtid, pcrSegmentId, pcrTableOid);
 
 	// add alternative to transformation result
 	pxfres->Add(pexprAlt);

--- a/src/backend/gporca/libgpopt/src/xforms/CXformImplementDML.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformImplementDML.cpp
@@ -86,6 +86,7 @@ CXformImplementDML::Transform(CXformContext *pxfctxt, CXformResult *pxfres,
 	pbsModified->AddRef();
 
 	CColRef *pcrAction = popDML->PcrAction();
+	CColRef *pcrTableOid = popDML->PcrTableOid();
 	CColRef *pcrCtid = popDML->PcrCtid();
 	CColRef *pcrSegmentId = popDML->PcrSegmentId();
 	CColRef *pcrTupleOid = popDML->PcrTupleOid();
@@ -99,7 +100,7 @@ CXformImplementDML::Transform(CXformContext *pxfctxt, CXformResult *pxfres,
 		mp,
 		GPOS_NEW(mp)
 			CPhysicalDML(mp, edmlop, ptabdesc, pdrgpcrSource, pbsModified,
-						 pcrAction, pcrCtid, pcrSegmentId, pcrTupleOid),
+						 pcrAction, pcrCtid, pcrSegmentId, pcrTupleOid, pcrTableOid),
 		pexprChild);
 	// add alternative to transformation result
 	pxfres->Add(pexprAlt);

--- a/src/backend/gporca/libgpopt/src/xforms/CXformInsert2DML.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformInsert2DML.cpp
@@ -88,7 +88,8 @@ CXformInsert2DML::Transform(CXformContext *pxfctxt, CXformResult *pxfres,
 	CExpression *pexprAlt = CXformUtils::PexprLogicalDMLOverProject(
 		mp, pexprChild, CLogicalDML::EdmlInsert, ptabdesc, pdrgpcrSource,
 		NULL,  //pcrCtid
-		NULL   //pcrSegmentId
+		NULL,  //pcrSegmentId
+		NULL   //pcrTable
 	);
 
 	// add alternative to transformation result

--- a/src/backend/gporca/libgpopt/src/xforms/CXformUpdate2DML.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformUpdate2DML.cpp
@@ -87,6 +87,7 @@ CXformUpdate2DML::Transform(CXformContext *pxfctxt, CXformResult *pxfres,
 	CColRef *pcrCtid = popUpdate->PcrCtid();
 	CColRef *pcrSegmentId = popUpdate->PcrSegmentId();
 	CColRef *pcrTupleOid = popUpdate->PcrTupleOid();
+	CColRef *pcrTableOid = popUpdate->PcrTableOid();
 
 	// child of update operator
 	CExpression *pexprChild = (*pexpr)[0];
@@ -163,7 +164,7 @@ CXformUpdate2DML::Transform(CXformContext *pxfctxt, CXformResult *pxfres,
 		mp,
 		GPOS_NEW(mp) CLogicalDML(mp, CLogicalDML::EdmlUpdate, ptabdesc,
 								 pdrgpcrDelete, pbsModified, pcrAction, pcrCtid,
-								 pcrSegmentId, pcrTupleOid),
+								 pcrSegmentId, pcrTupleOid, pcrTableOid),
 		pexprAssertConstraints);
 
 	// TODO:  - Oct 30, 2012; detect and handle AFTER triggers on update

--- a/src/backend/gporca/libgpopt/src/xforms/CXformUtils.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformUtils.cpp
@@ -1316,12 +1316,10 @@ CXformUtils::PexprLogicalPartitionSelector(CMemoryPool *mp,
 //
 //---------------------------------------------------------------------------
 CExpression *
-CXformUtils::PexprLogicalDMLOverProject(CMemoryPool *mp,
-										CExpression *pexprChild,
-										CLogicalDML::EDMLOperator edmlop,
-										CTableDescriptor *ptabdesc,
-										CColRefArray *colref_array,
-										CColRef *pcrCtid, CColRef *pcrSegmentId)
+CXformUtils::PexprLogicalDMLOverProject(
+	CMemoryPool *mp, CExpression *pexprChild, CLogicalDML::EDMLOperator edmlop,
+	CTableDescriptor *ptabdesc, CColRefArray *colref_array, CColRef *pcrCtid,
+	CColRef *pcrSegmentId, CColRef *pcrTableOid)
 {
 	GPOS_ASSERT(CLogicalDML::EdmlInsert == edmlop ||
 				CLogicalDML::EdmlDelete == edmlop);
@@ -1364,7 +1362,7 @@ CXformUtils::PexprLogicalDMLOverProject(CMemoryPool *mp,
 		GPOS_NEW(mp)
 			CLogicalDML(mp, edmlop, ptabdesc, colref_array,
 						GPOS_NEW(mp) CBitSet(mp) /*pbsModified*/, pcrAction,
-						pcrCtid, pcrSegmentId, NULL /*pcrTupleOid*/),
+						pcrCtid, pcrSegmentId, NULL /*pcrTupleOid*/, pcrTableOid),
 		pexprProject);
 
 	CExpression *pexprOutput = pexprDML;

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLLogicalDelete.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLLogicalDelete.h
@@ -46,6 +46,9 @@ private:
 	// list of deletion column ids
 	ULongPtrArray *m_deletion_colid_array;
 
+	// table oid column (has value 0 in case of non partitioned tables)
+	ULONG m_table_oid_colid;
+
 	// private copy ctor
 	CDXLLogicalDelete(const CDXLLogicalDelete &);
 
@@ -53,7 +56,7 @@ public:
 	// ctor
 	CDXLLogicalDelete(CMemoryPool *mp, CDXLTableDescr *table_descr,
 					  ULONG ctid_colid, ULONG segid_colid,
-					  ULongPtrArray *delete_colid_array);
+					  ULongPtrArray *delete_colid_array, ULONG table_oid_colid);
 
 	// dtor
 	virtual ~CDXLLogicalDelete();
@@ -83,6 +86,13 @@ public:
 	GetSegmentIdColId() const
 	{
 		return m_segid_colid;
+	}
+
+	// table oid column
+	ULONG
+	GeTableOidColId() const
+	{
+		return m_table_oid_colid;
 	}
 
 	// deletion column ids

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLLogicalUpdate.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLLogicalUpdate.h
@@ -55,6 +55,9 @@ private:
 	// tuple oid column id
 	ULONG m_tuple_oid;
 
+	// table oid column (has value 0 in case of non partitioned tables)
+	ULONG m_table_oid;
+
 	// private copy ctor
 	CDXLLogicalUpdate(const CDXLLogicalUpdate &);
 
@@ -64,7 +67,7 @@ public:
 					  ULONG ctid_colid, ULONG segid_colid,
 					  ULongPtrArray *delete_colid_array,
 					  ULongPtrArray *insert_colid_array, BOOL preserve_oids,
-					  ULONG tuple_oid);
+					  ULONG tuple_oid, ULONG table_oid);
 
 	// dtor
 	virtual ~CDXLLogicalUpdate();
@@ -122,6 +125,13 @@ public:
 	GetTupleOid() const
 	{
 		return m_tuple_oid;
+	}
+
+	// table oid column
+	ULONG
+	GetTableOidColId() const
+	{
+		return m_table_oid;
 	}
 
 #ifdef GPOS_DEBUG

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLPhysicalDML.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLPhysicalDML.h
@@ -54,6 +54,10 @@ private:
 	// action column id
 	ULONG m_action_colid;
 
+	// table oid column (has value 0 for Update/Delete operations on non partitioned
+	// tables and for all Insert operations)
+	ULONG m_table_oid_colid;
+
 	// ctid column id
 	ULONG m_ctid_colid;
 
@@ -78,7 +82,7 @@ public:
 					CDXLTableDescr *table_descr,
 					ULongPtrArray *src_colids_array, ULONG action_colid,
 					ULONG ctid_colid, ULONG segid_colid, BOOL preserve_oids,
-					ULONG tuple_oid,
+					ULONG tuple_oid, ULONG table_oid,
 					CDXLDirectDispatchInfo *dxl_direct_dispatch_info);
 
 	// dtor
@@ -116,6 +120,13 @@ public:
 	ActionColId() const
 	{
 		return m_action_colid;
+	}
+
+	// oid column id
+	ULONG
+	GetTableOidColId() const
+	{
+		return m_table_oid_colid;
 	}
 
 	// ctid column id

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/parser/CParseHandlerLogicalDelete.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/parser/CParseHandlerLogicalDelete.h
@@ -40,6 +40,9 @@ private:
 	// segmentId column id
 	ULONG m_segid_colid;
 
+	// table oid column (has value 0 in case of non partitioned tables)
+	ULONG m_table_oid_colid;
+
 	// delete col ids
 	ULongPtrArray *m_deletion_colid_array;
 

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/parser/CParseHandlerLogicalUpdate.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/parser/CParseHandlerLogicalUpdate.h
@@ -52,6 +52,9 @@ private:
 	// tuple oid column id
 	ULONG m_tuple_oid_col_oid;
 
+	// table oid column (has value 0 in case of non partitioned tables)
+	ULONG m_table_oid_col_oid;
+
 	// private copy ctor
 	CParseHandlerLogicalUpdate(const CParseHandlerLogicalUpdate &);
 

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/parser/CParseHandlerPhysicalDML.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/parser/CParseHandlerPhysicalDML.h
@@ -41,6 +41,10 @@ private:
 	// source col ids
 	ULongPtrArray *m_src_colids_array;
 
+	// table oid column (has value 0 for Update/Delete operations on non partitioned
+	// tables and for all Insert operations)
+	ULONG m_table_oid_colid;
+
 	// action column id
 	ULONG m_action_colid;
 

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/xml/dxltokens.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/xml/dxltokens.h
@@ -363,6 +363,7 @@ enum Edxltoken
 	EdxltokenGpSegmentIdColName,
 
 	EdxltokenActionColId,
+	EdxltokenOidColId,
 	EdxltokenCtidColId,
 	EdxltokenGpSegmentIdColId,
 	EdxltokenTupleOidColId,

--- a/src/backend/gporca/libnaucrates/src/operators/CDXLLogicalDelete.cpp
+++ b/src/backend/gporca/libnaucrates/src/operators/CDXLLogicalDelete.cpp
@@ -32,12 +32,14 @@ using namespace gpdxl;
 CDXLLogicalDelete::CDXLLogicalDelete(CMemoryPool *mp,
 									 CDXLTableDescr *table_descr,
 									 ULONG ctid_colid, ULONG segid_colid,
-									 ULongPtrArray *delete_colid_array)
+									 ULongPtrArray *delete_colid_array,
+									 ULONG table_oid_colid)
 	: CDXLLogical(mp),
 	  m_dxl_table_descr(table_descr),
 	  m_ctid_colid(ctid_colid),
 	  m_segid_colid(segid_colid),
-	  m_deletion_colid_array(delete_colid_array)
+	  m_deletion_colid_array(delete_colid_array),
+	  m_table_oid_colid(table_oid_colid)
 {
 	GPOS_ASSERT(NULL != table_descr);
 	GPOS_ASSERT(NULL != delete_colid_array);
@@ -111,6 +113,12 @@ CDXLLogicalDelete::SerializeToDXL(CXMLSerializer *xml_serializer,
 								 m_ctid_colid);
 	xml_serializer->AddAttribute(
 		CDXLTokens::GetDXLTokenStr(EdxltokenGpSegmentIdColId), m_segid_colid);
+
+	if (0 != m_table_oid_colid)
+	{
+		xml_serializer->AddAttribute(
+			CDXLTokens::GetDXLTokenStr(EdxltokenOidColId), m_table_oid_colid);
+	}
 
 	m_dxl_table_descr->SerializeToDXL(xml_serializer);
 	node->SerializeChildrenToDXL(xml_serializer);

--- a/src/backend/gporca/libnaucrates/src/operators/CDXLLogicalUpdate.cpp
+++ b/src/backend/gporca/libnaucrates/src/operators/CDXLLogicalUpdate.cpp
@@ -34,7 +34,8 @@ CDXLLogicalUpdate::CDXLLogicalUpdate(CMemoryPool *mp,
 									 ULONG ctid_colid, ULONG segid_colid,
 									 ULongPtrArray *delete_colid_array,
 									 ULongPtrArray *insert_colid_array,
-									 BOOL preserve_oids, ULONG tuple_oid)
+									 BOOL preserve_oids, ULONG tuple_oid,
+									 ULONG table_oid)
 	: CDXLLogical(mp),
 	  m_dxl_table_descr(table_descr),
 	  m_ctid_colid(ctid_colid),
@@ -42,7 +43,8 @@ CDXLLogicalUpdate::CDXLLogicalUpdate(CMemoryPool *mp,
 	  m_deletion_colid_array(delete_colid_array),
 	  m_insert_colid_array(insert_colid_array),
 	  m_preserve_oids(preserve_oids),
-	  m_tuple_oid(tuple_oid)
+	  m_tuple_oid(tuple_oid),
+	  m_table_oid(table_oid)
 {
 	GPOS_ASSERT(NULL != table_descr);
 	GPOS_ASSERT(NULL != delete_colid_array);
@@ -132,6 +134,12 @@ CDXLLogicalUpdate::SerializeToDXL(CXMLSerializer *xml_serializer,
 	{
 		xml_serializer->AddAttribute(
 			CDXLTokens::GetDXLTokenStr(EdxltokenTupleOidColId), m_tuple_oid);
+	}
+
+	if (0 != m_table_oid)
+	{
+		xml_serializer->AddAttribute(
+			CDXLTokens::GetDXLTokenStr(EdxltokenOidColId), m_table_oid);
 	}
 
 	m_dxl_table_descr->SerializeToDXL(xml_serializer);

--- a/src/backend/gporca/libnaucrates/src/operators/CDXLPhysicalDML.cpp
+++ b/src/backend/gporca/libnaucrates/src/operators/CDXLPhysicalDML.cpp
@@ -32,12 +32,13 @@ CDXLPhysicalDML::CDXLPhysicalDML(
 	CMemoryPool *mp, const EdxlDmlType dxl_dml_type,
 	CDXLTableDescr *table_descr, ULongPtrArray *src_colids_array,
 	ULONG action_colid, ULONG ctid_colid, ULONG segid_colid, BOOL preserve_oids,
-	ULONG tuple_oid, CDXLDirectDispatchInfo *dxl_direct_dispatch_info)
+	ULONG tuple_oid, ULONG table_oid, CDXLDirectDispatchInfo *dxl_direct_dispatch_info)
 	: CDXLPhysical(mp),
 	  m_dxl_dml_type(dxl_dml_type),
 	  m_dxl_table_descr(table_descr),
 	  m_src_colids_array(src_colids_array),
 	  m_action_colid(action_colid),
+	  m_table_oid_colid(table_oid),
 	  m_ctid_colid(ctid_colid),
 	  m_segid_colid(segid_colid),
 	  m_preserve_oids(preserve_oids),
@@ -127,6 +128,13 @@ CDXLPhysicalDML::SerializeToDXL(CXMLSerializer *xml_serializer,
 		CDXLTokens::GetDXLTokenStr(EdxltokenActionColId), m_action_colid);
 	xml_serializer->AddAttribute(CDXLTokens::GetDXLTokenStr(EdxltokenCtidColId),
 								 m_ctid_colid);
+
+	if (0 != m_table_oid_colid)
+	{
+		xml_serializer->AddAttribute(CDXLTokens::GetDXLTokenStr(EdxltokenOidColId),
+								 m_table_oid_colid);
+	}
+
 	xml_serializer->AddAttribute(
 		CDXLTokens::GetDXLTokenStr(EdxltokenGpSegmentIdColId), m_segid_colid);
 

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerLogicalDelete.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerLogicalDelete.cpp
@@ -68,6 +68,10 @@ CParseHandlerLogicalDelete::StartElement(const XMLCh *const,  // element_uri,
 		m_parse_handler_mgr->GetDXLMemoryManager(), attrs,
 		EdxltokenGpSegmentIdColId, EdxltokenLogicalDelete);
 
+	m_table_oid_colid = CDXLOperatorFactory::ExtractConvertAttrValueToUlong(
+		m_parse_handler_mgr->GetDXLMemoryManager(), attrs, EdxltokenOidColId,
+		EdxltokenLogicalDelete, true, 0);
+
 	const XMLCh *deletion_colids = CDXLOperatorFactory::ExtractAttrValue(
 		attrs, EdxltokenDeleteCols, EdxltokenLogicalDelete);
 	m_deletion_colid_array = CDXLOperatorFactory::ExtractIntsToUlongArray(
@@ -133,7 +137,7 @@ CParseHandlerLogicalDelete::EndElement(const XMLCh *const,	// element_uri,
 	m_dxl_node = GPOS_NEW(m_mp)
 		CDXLNode(m_mp, GPOS_NEW(m_mp) CDXLLogicalDelete(
 						   m_mp, table_descr, m_ctid_colid, m_segid_colid,
-						   m_deletion_colid_array));
+						   m_deletion_colid_array, m_table_oid_colid));
 
 	AddChildFromParseHandler(logical_op_parse_handler);
 

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerLogicalUpdate.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerLogicalUpdate.cpp
@@ -39,7 +39,8 @@ CParseHandlerLogicalUpdate::CParseHandlerLogicalUpdate(
 	  m_deletion_colid_array(NULL),
 	  m_insert_colid_array(NULL),
 	  m_preserve_oids(false),
-	  m_tuple_oid_col_oid(0)
+	  m_tuple_oid_col_oid(0),
+	  m_table_oid_col_oid(0)
 {
 }
 
@@ -103,6 +104,10 @@ CParseHandlerLogicalUpdate::StartElement(const XMLCh *const,  // element_uri,
 				EdxltokenTupleOidColId, EdxltokenLogicalUpdate);
 	}
 
+	m_table_oid_col_oid = CDXLOperatorFactory::ExtractConvertAttrValueToUlong(
+		m_parse_handler_mgr->GetDXLMemoryManager(), attrs, EdxltokenOidColId,
+		EdxltokenLogicalUpdate, true, 0);
+
 	// parse handler for logical operator
 	CParseHandlerBase *child_parse_handler =
 		CParseHandlerFactory::GetParseHandler(
@@ -159,11 +164,11 @@ CParseHandlerLogicalUpdate::EndElement(const XMLCh *const,	// element_uri,
 	CDXLTableDescr *table_descr = table_descr_parse_handler->GetDXLTableDescr();
 	table_descr->AddRef();
 
-	m_dxl_node = GPOS_NEW(m_mp)
-		CDXLNode(m_mp, GPOS_NEW(m_mp) CDXLLogicalUpdate(
-						   m_mp, table_descr, m_ctid_colid, m_segid_colid,
-						   m_deletion_colid_array, m_insert_colid_array,
-						   m_preserve_oids, m_tuple_oid_col_oid));
+	m_dxl_node = GPOS_NEW(m_mp) CDXLNode(
+		m_mp, GPOS_NEW(m_mp) CDXLLogicalUpdate(
+				  m_mp, table_descr, m_ctid_colid, m_segid_colid,
+				  m_deletion_colid_array, m_insert_colid_array, m_preserve_oids,
+				  m_tuple_oid_col_oid, m_table_oid_col_oid));
 
 	AddChildFromParseHandler(child_parse_handler);
 

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerPhysicalDML.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerPhysicalDML.cpp
@@ -39,6 +39,7 @@ CParseHandlerPhysicalDML::CParseHandlerPhysicalDML(
 	: CParseHandlerPhysicalOp(mp, parse_handler_mgr, parse_handler_root),
 	  m_dxl_dml_type(Edxldmlinsert),
 	  m_src_colids_array(NULL),
+	  m_table_oid_colid(0),
 	  m_action_colid(0),
 	  m_ctid_colid(0),
 	  m_segid_colid(0),
@@ -102,6 +103,11 @@ CParseHandlerPhysicalDML::StartElement(const XMLCh *const,	// element_uri,
 	m_action_colid = CDXLOperatorFactory::ExtractConvertAttrValueToUlong(
 		m_parse_handler_mgr->GetDXLMemoryManager(), attrs, EdxltokenActionColId,
 		token_type);
+
+	m_table_oid_colid = CDXLOperatorFactory::ExtractConvertAttrValueToUlong(
+		m_parse_handler_mgr->GetDXLMemoryManager(), attrs, EdxltokenOidColId,
+		token_type, true, 0);
+
 	m_ctid_colid = CDXLOperatorFactory::ExtractConvertAttrValueToUlong(
 		m_parse_handler_mgr->GetDXLMemoryManager(), attrs, EdxltokenCtidColId,
 		token_type);
@@ -224,7 +230,7 @@ CParseHandlerPhysicalDML::EndElement(const XMLCh *const,  // element_uri,
 	dxl_direct_dispatch_info->AddRef();
 	CDXLPhysicalDML *dxl_op = GPOS_NEW(m_mp) CDXLPhysicalDML(
 		m_mp, m_dxl_dml_type, table_descr, m_src_colids_array, m_action_colid,
-		m_ctid_colid, m_segid_colid, m_preserve_oids, m_tuple_oid_colid,
+		m_ctid_colid, m_segid_colid, m_preserve_oids, m_tuple_oid_colid, m_table_oid_colid,
 		dxl_direct_dispatch_info);
 	m_dxl_node = GPOS_NEW(m_mp) CDXLNode(m_mp, dxl_op);
 

--- a/src/backend/gporca/libnaucrates/src/xml/dxltokens.cpp
+++ b/src/backend/gporca/libnaucrates/src/xml/dxltokens.cpp
@@ -412,6 +412,7 @@ CDXLTokens::Init(CMemoryPool *mp)
 		{EdxltokenGpSegmentIdColName, GPOS_WSZ_LIT("gp_segment_id")},
 
 		{EdxltokenActionColId, GPOS_WSZ_LIT("ActionCol")},
+		{EdxltokenOidColId, GPOS_WSZ_LIT("OidCol")},
 		{EdxltokenCtidColId, GPOS_WSZ_LIT("CtidCol")},
 		{EdxltokenGpSegmentIdColId, GPOS_WSZ_LIT("SegmentIdCol")},
 		{EdxltokenTupleOidColId, GPOS_WSZ_LIT("TupleOidCol")},

--- a/src/backend/gporca/server/src/unittest/CTestUtils.cpp
+++ b/src/backend/gporca/server/src/unittest/CTestUtils.cpp
@@ -1779,7 +1779,8 @@ CTestUtils::PexprLogicalDelete(CMemoryPool *mp)
 
 	return GPOS_NEW(mp) CExpression(
 		mp,
-		GPOS_NEW(mp) CLogicalDelete(mp, ptabdesc, colref_array, colref, colref),
+		GPOS_NEW(mp)
+			CLogicalDelete(mp, ptabdesc, colref_array, colref, colref, NULL),
 		pexprGet);
 }
 
@@ -1813,7 +1814,7 @@ CTestUtils::PexprLogicalUpdate(CMemoryPool *mp)
 	return GPOS_NEW(mp) CExpression(
 		mp,
 		GPOS_NEW(mp) CLogicalUpdate(mp, ptabdesc, pdrgpcrDelete, pdrgpcrInsert,
-									colref, colref, NULL /*pcrTupleOid*/),
+									colref, colref, NULL /*pcrTupleOid*/, NULL),
 		pexprGet);
 }
 

--- a/src/backend/gporca/server/src/unittest/gpopt/minidump/CDMLTest.cpp
+++ b/src/backend/gporca/server/src/unittest/gpopt/minidump/CDMLTest.cpp
@@ -96,6 +96,9 @@ const CHAR *rgszDMLFileNames[] = {
 	"../data/dxl/minidump/DML-Volatile-Function.mdp",
 	"../data/dxl/minidump/UpdateWindowGatherMerge.mdp",
 	"../data/dxl/minidump/UpdateDistKeyWithNestedJoin.mdp",
+	"../data/dxl/minidump/PartitionedInsert.mdp",
+	"../data/dxl/minidump/PartitionedDelete.mdp",
+	"../data/dxl/minidump/PartitionedUpdate.mdp"
 };
 
 //---------------------------------------------------------------------------

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -1337,6 +1337,7 @@ _copyDML(const DML *from)
 	COPY_SCALAR_FIELD(actionColIdx);
 	COPY_SCALAR_FIELD(ctidColIdx);
 	COPY_SCALAR_FIELD(tupleoidColIdx);
+	COPY_SCALAR_FIELD(tableoidColIdx);
 
 	return newnode;
 }

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -1215,6 +1215,7 @@ _outDML(StringInfo str, const DML *node)
 	WRITE_INT_FIELD(actionColIdx);
 	WRITE_INT_FIELD(ctidColIdx);
 	WRITE_INT_FIELD(tupleoidColIdx);
+	WRITE_INT_FIELD(tableoidColIdx);
 
 	_outPlanInfo(str, (Plan *) node);
 }

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -2237,6 +2237,7 @@ _readDML(void)
 	READ_INT_FIELD(actionColIdx);
 	READ_INT_FIELD(ctidColIdx);
 	READ_INT_FIELD(tupleoidColIdx);
+	READ_INT_FIELD(tableoidColIdx);
 
 	readPlanInfo((Plan *)local_node);
 

--- a/src/include/executor/execDML.h
+++ b/src/include/executor/execDML.h
@@ -46,7 +46,8 @@ ExecDelete(ItemPointer tupleid,
 		   EState *estate,
 		   bool canSetTag,
 		   PlanGenerator planGen,
-		   bool isUpdate);
+		   bool isUpdate,
+		   Oid tableoid);
 
 extern TupleTableSlot *
 ExecUpdate(ItemPointer tupleid,

--- a/src/include/gpopt/translate/CTranslatorQueryToDXL.h
+++ b/src/include/gpopt/translate/CTranslatorQueryToDXL.h
@@ -390,14 +390,6 @@ private:
 	// return resno -> colId mapping of columns to be updated
 	IntToUlongMap *UpdatedColumnMapping();
 
-	// obtain the ids of the ctid and segmentid columns for the target
-	// table of a DML query
-	void GetCtidAndSegmentId(ULONG *ctid, ULONG *segment_id);
-
-	// obtain the column id for the tuple oid column of the target table
-	// of a DML statement
-	ULONG GetTupleOidColId();
-
 	// translate a grouping func expression
 	CDXLNode *TranslateGroupingFuncToDXL(
 		const Expr *expr, CBitSet *bitset,
@@ -427,6 +419,9 @@ private:
 
 	// true iff this query or one of its ancestors is a DML query
 	BOOL IsDMLQuery();
+
+	// returns the corresponding ColId for the given system attribute numbber
+	ULONG GetSystemColId(INT attribute_number);
 
 public:
 	// dtor

--- a/src/include/nodes/plannodes.h
+++ b/src/include/nodes/plannodes.h
@@ -1333,7 +1333,7 @@ typedef struct DML
 	AttrNumber	actionColIdx;	/* index of action column into the target list */
 	AttrNumber	ctidColIdx;		/* index of ctid column into the target list */
 	AttrNumber	tupleoidColIdx;	/* index of tuple oid column into the target list */
-
+	AttrNumber	tableoidColIdx; /* index of table oid column into the target list */
 } DML;
 
 /*

--- a/src/test/regress/expected/partition_pruning.out
+++ b/src/test/regress/expected/partition_pruning.out
@@ -3862,4 +3862,274 @@ drop cascades to table issue_14982_t1
 drop cascades to table issue_14982_t2
 drop cascades to table issue_14982_t1_part_range
 drop cascades to table issue_14982_t2_part_range
+set search_path to partition_pruning;
+-- Tests of partition pruning for case when default partition was exchanged without validation
+-- and contains rows, that satisfy constraints of other partition
+--
+-- Simple delete test case from default partition. Delete operation has
+-- not to perform partition pruning.
+--
+create table test(i int, j int) partition by range(j) (start (1) end(3) every(2), default partition extra);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "test_1_prt_extra" for table "test"
+NOTICE:  CREATE TABLE will create partition "test_1_prt_2" for table "test"
+-- check that insert into partition table won't fallback in pg optimizer and won't request tableoid
+explain verbose insert into test values (0, 1);
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Insert on partition_pruning.test  (cost=0.00..0.01 rows=1 width=0)
+   ->  Result  (cost=0.00..0.01 rows=1 width=0)
+         Output: 0, 1
+ Optimizer: Postgres query optimizer
+ Settings: enable_bitmapscan=on, enable_hashjoin=off, enable_indexscan=on, enable_mergejoin=on, enable_seqscan=off, optimizer=off
+(5 rows)
+
+insert into test values (0, 1);
+-- Create table for exchange with default partition and insert another possible
+-- value corresponding to range partition
+create table test_extra_exchanged(like test);
+NOTICE:  table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
+insert into test_extra_exchanged values (0, 2);
+-- Perform exchange without validation
+set gp_enable_exchange_default_partition to on;
+alter table test exchange default partition with table test_extra_exchanged without validation;
+WARNING:  Exchanging default partition may result in unexpected query results if the data being exchanged should have been inserted into a different partition
+NOTICE:  exchanged partition "extra" of relation "test" with relation "test_extra_exchanged"
+-- Check tuples in partitioned table. Two tuples have the same tupleid and value in partitioning
+-- key corresponding to `test_1_prt_2` partition
+select tableoid::regclass, ctid, i, j from test;
+     tableoid     | ctid  | i | j 
+------------------+-------+---+---
+ test_1_prt_2     | (0,1) | 0 | 1
+ test_1_prt_extra | (0,1) | 0 | 2
+(2 rows)
+
+-- We have to delete the row (0, 2) from default partition
+explain (verbose, costs off) delete from test_1_prt_extra where j = 2;
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Delete on partition_pruning.test_1_prt_extra
+   ->  Seq Scan on partition_pruning.test_1_prt_extra
+         Output: ctid, gp_segment_id
+         Filter: (test_1_prt_extra.j = 2)
+ Optimizer: Postgres query optimizer
+ Settings: enable_bitmapscan=on, enable_hashjoin=off, enable_indexscan=on, enable_mergejoin=on, enable_seqscan=off, optimizer=off
+(6 rows)
+
+delete from test_1_prt_extra where j = 2;
+-- Check that deletion performed correctly
+select tableoid::regclass, ctid, i, j from test;
+   tableoid   | ctid  | i | j 
+--------------+-------+---+---
+ test_1_prt_2 | (0,1) | 0 | 1
+(1 row)
+
+drop table test, test_extra_exchanged;
+--
+-- Delete test case with predicate from partitioned table. Delete operation has
+-- to perform partition pruning
+--
+create table test(i int, j int) partition by range(j) (start (1) end(3) every(2), default partition extra);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "test_1_prt_extra" for table "test"
+NOTICE:  CREATE TABLE will create partition "test_1_prt_2" for table "test"
+insert into test values (0, 1);
+-- Create table for exchange with default partition and insert another possible
+-- value corresponding to range partition
+create table test_extra_exchanged(like test);
+NOTICE:  table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
+insert into test_extra_exchanged values (0, 2);
+-- Perform exchange without validation
+set gp_enable_exchange_default_partition to on;
+alter table test exchange default partition with table test_extra_exchanged without validation;
+WARNING:  Exchanging default partition may result in unexpected query results if the data being exchanged should have been inserted into a different partition
+NOTICE:  exchanged partition "extra" of relation "test" with relation "test_extra_exchanged"
+-- Check tuples in partitioned table. Two tuples have the same tupleid and value in partitioning
+-- key corresponding to `test_1_prt_2` partition
+select tableoid::regclass, ctid, i, j from test;
+     tableoid     | ctid  | i | j 
+------------------+-------+---+---
+ test_1_prt_2     | (0,1) | 0 | 1
+ test_1_prt_extra | (0,1) | 0 | 2
+(2 rows)
+
+-- Create test table that will be used in delete query inside `NOT EXISTS` predicate
+create table test_in_predicate(i int, j int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into test_in_predicate values (0, 1);
+-- We have to delete the row (0, 2) from default partition
+explain (verbose, costs off) delete from test where not exists(
+  select 1 from test_in_predicate where test.i = test_in_predicate.i and test.j = test_in_predicate.j
+);
+                                                                      QUERY PLAN                                                                      
+------------------------------------------------------------------------------------------------------------------------------------------------
+ Delete on partition_pruning.test_1_prt_2
+   ->  Hash Anti Join
+         Output: test_1_prt_2.ctid, test_1_prt_2.gp_segment_id, test_1_prt_2.tableoid, test_in_predicate.ctid
+         Hash Cond: ((test_1_prt_2.i = test_in_predicate.i) AND (test_1_prt_2.j = test_in_predicate.j))
+         ->  Seq Scan on partition_pruning.test_1_prt_2
+               Output: test_1_prt_2.ctid, test_1_prt_2.gp_segment_id, test_1_prt_2.tableoid, test_1_prt_2.i, test_1_prt_2.j
+         ->  Hash
+               Output: test_in_predicate.ctid, test_in_predicate.i, test_in_predicate.j
+               ->  Seq Scan on partition_pruning.test_in_predicate
+                     Output: test_in_predicate.ctid, test_in_predicate.i, test_in_predicate.j
+   ->  Hash Anti Join
+         Output: test_1_prt_extra.ctid, test_1_prt_extra.gp_segment_id, test_1_prt_extra.tableoid, test_in_predicate.ctid
+         Hash Cond: ((test_1_prt_extra.i = test_in_predicate.i) AND (test_1_prt_extra.j = test_in_predicate.j))
+         ->  Seq Scan on partition_pruning.test_1_prt_extra
+               Output: test_1_prt_extra.ctid, test_1_prt_extra.gp_segment_id, test_1_prt_extra.tableoid, test_1_prt_extra.i, test_1_prt_extra.j
+         ->  Hash
+               Output: test_in_predicate.ctid, test_in_predicate.i, test_in_predicate.j
+               ->  Seq Scan on partition_pruning.test_in_predicate
+                     Output: test_in_predicate.ctid, test_in_predicate.i, test_in_predicate.j
+ Optimizer: Postgres query optimizer
+ Settings: enable_bitmapscan=on, enable_hashjoin=on, enable_indexscan=on, enable_mergejoin=off, enable_seqscan=off, optimizer=off
+(21 rows)
+
+delete from test where not exists(
+  select 1 from test_in_predicate where test.i = test_in_predicate.i and test.j = test_in_predicate.j
+);
+-- Check that deletion performed correctly
+select tableoid::regclass, ctid, i, j from test;
+   tableoid   | ctid  | i | j 
+--------------+-------+---+---
+ test_1_prt_2 | (0,1) | 0 | 1
+(1 row)
+
+drop table test, test_extra_exchanged, test_in_predicate;
+--
+-- Simple update test case from default partition. Update operation has
+-- not to perform partition pruning
+--
+create table test(i int, j int, k int) partition by range(j) (start (1) end(3) every(2), default partition extra);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "test_1_prt_extra" for table "test"
+NOTICE:  CREATE TABLE will create partition "test_1_prt_2" for table "test"
+insert into test values (0, 1, 0);
+-- Create table for exchange with default partition and insert another possible
+-- value corresponding to range partition
+create table test_extra_exchanged(like test);
+NOTICE:  table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
+insert into test_extra_exchanged values (0, 2, 0);
+-- Perform exchange without validation
+set gp_enable_exchange_default_partition to on;
+alter table test exchange default partition with table test_extra_exchanged without validation;
+WARNING:  Exchanging default partition may result in unexpected query results if the data being exchanged should have been inserted into a different partition
+NOTICE:  exchanged partition "extra" of relation "test" with relation "test_extra_exchanged"
+-- Check tuples in partitioned table. Two tuples have the same tupleid and value in partitioning
+-- key corresponding to `test_1_prt_2` partition
+select tableoid::regclass, ctid, i, j, k from test;
+     tableoid     | ctid  | i | j | k 
+------------------+-------+---+---+---
+ test_1_prt_2     | (0,1) | 0 | 1 | 0
+ test_1_prt_extra | (0,1) | 0 | 2 | 0
+(2 rows)
+
+-- start_matchsubs
+-- m/'\d+'::oid/
+-- s/'\d+'::oid/'table_oid'::oid/
+-- end_matchsubs
+-- We have to update the row (0, 2) from default partition
+explain (verbose, costs off) update test_1_prt_extra set k = 10 where j = 2; 
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Update on partition_pruning.test_1_prt_extra
+   ->  Seq Scan on partition_pruning.test_1_prt_extra
+         Output: i, j, 10, ctid, gp_segment_id
+         Filter: (test_1_prt_extra.j = 2)
+ Optimizer: Postgres query optimizer
+ Settings: enable_bitmapscan=on, enable_hashjoin=off, enable_indexscan=on, enable_mergejoin=on, enable_seqscan=off, optimizer=off
+(6 rows)
+
+update test_1_prt_extra set k = 10 where j = 2;
+ERROR:  moving tuple from partition "test_1_prt_extra" to partition "test_1_prt_2" not supported  (seg1 127.0.1.1:6003 pid=56966)
+-- Check that update performed correctly and tuple moved to correct partition
+select tableoid::regclass, ctid, i, j, k from test;
+     tableoid     | ctid  | i | j | k 
+------------------+-------+---+---+---
+ test_1_prt_2     | (0,1) | 0 | 1 | 0
+ test_1_prt_extra | (0,1) | 0 | 2 | 0
+(2 rows)
+
+drop table test, test_extra_exchanged;
+--
+-- Update test case with predicate from partitioned table. Update operation has
+-- to perform partition pruning
+--
+create table test(i int, j int, k int) partition by range(j) (start (1) end(3) every(2), default partition extra);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "test_1_prt_extra" for table "test"
+NOTICE:  CREATE TABLE will create partition "test_1_prt_2" for table "test"
+insert into test values (0, 1, 0);
+-- Create table for exchange with default partition and insert another possible
+-- value corresponding to range partition
+create table test_extra_exchanged(like test);
+NOTICE:  table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
+insert into test_extra_exchanged values (0, 2, 0);
+-- Perform exchange without validation
+set gp_enable_exchange_default_partition to on;
+alter table test exchange default partition with table test_extra_exchanged without validation;
+WARNING:  Exchanging default partition may result in unexpected query results if the data being exchanged should have been inserted into a different partition
+NOTICE:  exchanged partition "extra" of relation "test" with relation "test_extra_exchanged"
+-- Create test table that will be used in delete query inside `NOT EXISTS` predicate
+create table test_in_predicate(i int, j int, k int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into test_in_predicate values (0, 1, 0);
+-- Check tuples in partitioned table. Two tuples have the same tupleid and value in partitioning
+-- key corresponding to `test_1_prt_2` partition
+select tableoid::regclass, ctid, i, j, k from test;
+     tableoid     | ctid  | i | j | k 
+------------------+-------+---+---+---
+ test_1_prt_2     | (0,1) | 0 | 1 | 0
+ test_1_prt_extra | (0,1) | 0 | 2 | 0
+(2 rows)
+
+-- We have to update the row (0, 2) from default partition
+explain (verbose, costs off) update test set k = 10  where not exists(
+  select 1 from test_in_predicate where test.i = test_in_predicate.i and test.j = test_in_predicate.j
+);
+                                                                              QUERY PLAN                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Update on partition_pruning.test_1_prt_2
+   ->  Hash Anti Join
+         Output: test_1_prt_2.i, test_1_prt_2.j, 10, test_1_prt_2.ctid, test_1_prt_2.gp_segment_id, test_1_prt_2.tableoid, test_in_predicate.ctid
+         Hash Cond: ((test_1_prt_2.i = test_in_predicate.i) AND (test_1_prt_2.j = test_in_predicate.j))
+         ->  Seq Scan on partition_pruning.test_1_prt_2
+               Output: test_1_prt_2.i, test_1_prt_2.j, test_1_prt_2.ctid, test_1_prt_2.gp_segment_id, test_1_prt_2.tableoid
+         ->  Hash
+               Output: test_in_predicate.ctid, test_in_predicate.i, test_in_predicate.j
+               ->  Seq Scan on partition_pruning.test_in_predicate
+                     Output: test_in_predicate.ctid, test_in_predicate.i, test_in_predicate.j
+   ->  Hash Anti Join
+         Output: test_1_prt_extra.i, test_1_prt_extra.j, 10, test_1_prt_extra.ctid, test_1_prt_extra.gp_segment_id, test_1_prt_extra.tableoid, test_in_predicate.ctid
+         Hash Cond: ((test_1_prt_extra.i = test_in_predicate.i) AND (test_1_prt_extra.j = test_in_predicate.j))
+         ->  Seq Scan on partition_pruning.test_1_prt_extra
+               Output: test_1_prt_extra.i, test_1_prt_extra.j, test_1_prt_extra.ctid, test_1_prt_extra.gp_segment_id, test_1_prt_extra.tableoid
+         ->  Hash
+               Output: test_in_predicate.ctid, test_in_predicate.i, test_in_predicate.j
+               ->  Seq Scan on partition_pruning.test_in_predicate
+                     Output: test_in_predicate.ctid, test_in_predicate.i, test_in_predicate.j
+ Optimizer: Postgres query optimizer
+ Settings: enable_bitmapscan=on, enable_hashjoin=on, enable_indexscan=on, enable_mergejoin=off, enable_seqscan=off, optimizer=off
+(21 rows)
+
+update test set k = 10  where not exists(
+  select 1 from test_in_predicate where test.i = test_in_predicate.i and test.j = test_in_predicate.j
+);
+ERROR:  moving tuple from partition "test_1_prt_extra" to partition "test_1_prt_2" not supported  (seg1 127.0.1.1:6003 pid=56966)
+-- Check that update performed correctly and tuple moved to correct partition
+select tableoid::regclass, ctid, i, j, k from test;
+     tableoid     | ctid  | i | j | k 
+------------------+-------+---+---+---
+ test_1_prt_2     | (0,1) | 0 | 1 | 0
+ test_1_prt_extra | (0,1) | 0 | 2 | 0
+(2 rows)
+
+drop table test, test_extra_exchanged, test_in_predicate;
 RESET ALL;

--- a/src/test/regress/expected/partition_pruning_optimizer.out
+++ b/src/test/regress/expected/partition_pruning_optimizer.out
@@ -3432,4 +3432,313 @@ drop cascades to table issue_14982_t1
 drop cascades to table issue_14982_t2
 drop cascades to table issue_14982_t1_part_range
 drop cascades to table issue_14982_t2_part_range
+set search_path to partition_pruning;
+-- Tests of partition pruning for case when default partition was exchanged without validation
+-- and contains rows, that satisfy constraints of other partition
+--
+-- Simple delete test case from default partition. Delete operation has
+-- not to perform partition pruning.
+--
+create table test(i int, j int) partition by range(j) (start (1) end(3) every(2), default partition extra);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "test_1_prt_extra" for table "test"
+NOTICE:  CREATE TABLE will create partition "test_1_prt_2" for table "test"
+-- check that insert into partition table won't fallback in pg optimizer and won't request tableoid
+explain verbose insert into test values (0, 1);
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
+ Insert  (cost=0.00..0.02 rows=1 width=8)
+   Output: i, j, ColRef_0003
+   ->  Result  (cost=0.00..0.00 rows=1 width=12)
+         Output: i, j, 1
+         ->  Result  (cost=0.00..0.00 rows=1 width=8)
+               Output: i, j
+               ->  Result  (cost=0.00..0.00 rows=1 width=8)
+                     Output: 0, 1
+                     ->  Result  (cost=0.00..0.00 rows=1 width=1)
+                           Output: true
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Settings: enable_bitmapscan=on, enable_hashjoin=off, enable_indexscan=on, enable_mergejoin=on, enable_seqscan=off
+(12 rows)
+
+insert into test values (0, 1);
+-- Create table for exchange with default partition and insert another possible
+-- value corresponding to range partition
+create table test_extra_exchanged(like test);
+NOTICE:  table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
+insert into test_extra_exchanged values (0, 2);
+-- Perform exchange without validation
+set gp_enable_exchange_default_partition to on;
+alter table test exchange default partition with table test_extra_exchanged without validation;
+WARNING:  Exchanging default partition may result in unexpected query results if the data being exchanged should have been inserted into a different partition
+NOTICE:  exchanged partition "extra" of relation "test" with relation "test_extra_exchanged"
+-- Check tuples in partitioned table. Two tuples have the same tupleid and value in partitioning
+-- key corresponding to `test_1_prt_2` partition
+select tableoid::regclass, ctid, i, j from test;
+NOTICE:  One or more columns in the following table(s) do not have statistics: test
+HINT:  For non-partitioned tables, run analyze <table_name>(<column_list>). For partitioned tables, run analyze rootpartition <table_name>(<column_list>). See log for columns missing statistics.
+     tableoid     | ctid  | i | j 
+------------------+-------+---+---
+ test_1_prt_2     | (0,1) | 0 | 1
+ test_1_prt_extra | (0,1) | 0 | 2
+(2 rows)
+
+-- We have to delete the row (0, 2) from default partition
+explain (verbose, costs off) delete from test_1_prt_extra where j = 2;
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Delete
+   Output: test_1_prt_extra.i, test_1_prt_extra.j, "outer".ColRef_0009, test_1_prt_extra.ctid
+   ->  Result
+         Output: test_1_prt_extra.i, test_1_prt_extra.j, test_1_prt_extra.ctid, test_1_prt_extra.gp_segment_id, 0
+         ->  Seq Scan on partition_pruning.test_1_prt_extra
+               Output: test_1_prt_extra.i, test_1_prt_extra.j, test_1_prt_extra.ctid, test_1_prt_extra.gp_segment_id
+               Filter: (test_1_prt_extra.j = 2)
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Settings: enable_bitmapscan=on, enable_hashjoin=off, enable_indexscan=on, enable_mergejoin=on, enable_seqscan=off
+(9 rows)
+
+delete from test_1_prt_extra where j = 2;
+-- Check that deletion performed correctly
+select tableoid::regclass, ctid, i, j from test;
+NOTICE:  One or more columns in the following table(s) do not have statistics: test
+HINT:  For non-partitioned tables, run analyze <table_name>(<column_list>). For partitioned tables, run analyze rootpartition <table_name>(<column_list>). See log for columns missing statistics.
+   tableoid   | ctid  | i | j 
+--------------+-------+---+---
+ test_1_prt_2 | (0,1) | 0 | 1
+(1 row)
+
+drop table test, test_extra_exchanged;
+--
+-- Delete test case with predicate from partitioned table. Delete operation has
+-- to perform partition pruning
+--
+create table test(i int, j int) partition by range(j) (start (1) end(3) every(2), default partition extra);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "test_1_prt_extra" for table "test"
+NOTICE:  CREATE TABLE will create partition "test_1_prt_2" for table "test"
+insert into test values (0, 1);
+-- Create table for exchange with default partition and insert another possible
+-- value corresponding to range partition
+create table test_extra_exchanged(like test);
+NOTICE:  table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
+insert into test_extra_exchanged values (0, 2);
+-- Perform exchange without validation
+set gp_enable_exchange_default_partition to on;
+alter table test exchange default partition with table test_extra_exchanged without validation;
+WARNING:  Exchanging default partition may result in unexpected query results if the data being exchanged should have been inserted into a different partition
+NOTICE:  exchanged partition "extra" of relation "test" with relation "test_extra_exchanged"
+-- Check tuples in partitioned table. Two tuples have the same tupleid and value in partitioning
+-- key corresponding to `test_1_prt_2` partition
+select tableoid::regclass, ctid, i, j from test;
+NOTICE:  One or more columns in the following table(s) do not have statistics: test
+HINT:  For non-partitioned tables, run analyze <table_name>(<column_list>). For partitioned tables, run analyze rootpartition <table_name>(<column_list>). See log for columns missing statistics.
+     tableoid     | ctid  | i | j 
+------------------+-------+---+---
+ test_1_prt_2     | (0,1) | 0 | 1
+ test_1_prt_extra | (0,1) | 0 | 2
+(2 rows)
+
+-- Create test table that will be used in delete query inside `NOT EXISTS` predicate
+create table test_in_predicate(i int, j int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into test_in_predicate values (0, 1);
+-- We have to delete the row (0, 2) from default partition
+explain (verbose, costs off) delete from test where not exists(
+  select 1 from test_in_predicate where test.i = test_in_predicate.i and test.j = test_in_predicate.j
+);
+NOTICE:  One or more columns in the following table(s) do not have statistics: test
+HINT:  For non-partitioned tables, run analyze <table_name>(<column_list>). For partitioned tables, run analyze rootpartition <table_name>(<column_list>). See log for columns missing statistics.
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
+ Delete
+   Output: test.i, test.j, "outer".ColRef_0025, test.ctid, test.tableoid
+   ->  Result
+         Output: test.i, test.j, test.ctid, test.tableoid, test.gp_segment_id, 0
+         ->  Hash Anti Join
+               Output: test.i, test.j, test.ctid, test.tableoid, test.gp_segment_id
+               Hash Cond: ((test.i = test_in_predicate.i) AND (test.j = test_in_predicate.j))
+               ->  Sequence
+                     Output: test.i, test.j, test.ctid, test.tableoid, test.gp_segment_id
+                     ->  Partition Selector for test (dynamic scan id: 1)
+                           Partitions selected: 2 (out of 2)
+                     ->  Dynamic Seq Scan on partition_pruning.test (dynamic scan id: 1)
+                           Output: test.i, test.j, test.ctid, test.tableoid, test.gp_segment_id
+               ->  Hash
+                     Output: "outer".?column?, test_in_predicate.i, test_in_predicate.j
+                     ->  Result
+                           Output: 1, test_in_predicate.i, test_in_predicate.j
+                           ->  Seq Scan on partition_pruning.test_in_predicate
+                                 Output: test_in_predicate.i, test_in_predicate.j
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Settings: enable_bitmapscan=on, enable_hashjoin=off, enable_indexscan=on, enable_mergejoin=on, enable_seqscan=off
+(21 rows)
+
+delete from test where not exists(
+  select 1 from test_in_predicate where test.i = test_in_predicate.i and test.j = test_in_predicate.j
+);
+NOTICE:  One or more columns in the following table(s) do not have statistics: test
+HINT:  For non-partitioned tables, run analyze <table_name>(<column_list>). For partitioned tables, run analyze rootpartition <table_name>(<column_list>). See log for columns missing statistics.
+-- Check that deletion performed correctly
+select tableoid::regclass, ctid, i, j from test;
+NOTICE:  One or more columns in the following table(s) do not have statistics: test
+HINT:  For non-partitioned tables, run analyze <table_name>(<column_list>). For partitioned tables, run analyze rootpartition <table_name>(<column_list>). See log for columns missing statistics.
+   tableoid   | ctid  | i | j 
+--------------+-------+---+---
+ test_1_prt_2 | (0,1) | 0 | 1
+(1 row)
+
+drop table test, test_extra_exchanged, test_in_predicate;
+--
+-- Simple update test case from default partition. Update operation has
+-- not to perform partition pruning
+--
+create table test(i int, j int, k int) partition by range(j) (start (1) end(3) every(2), default partition extra);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "test_1_prt_extra" for table "test"
+NOTICE:  CREATE TABLE will create partition "test_1_prt_2" for table "test"
+insert into test values (0, 1, 0);
+-- Create table for exchange with default partition and insert another possible
+-- value corresponding to range partition
+create table test_extra_exchanged(like test);
+NOTICE:  table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
+insert into test_extra_exchanged values (0, 2, 0);
+-- Perform exchange without validation
+set gp_enable_exchange_default_partition to on;
+alter table test exchange default partition with table test_extra_exchanged without validation;
+WARNING:  Exchanging default partition may result in unexpected query results if the data being exchanged should have been inserted into a different partition
+NOTICE:  exchanged partition "extra" of relation "test" with relation "test_extra_exchanged"
+-- Check tuples in partitioned table. Two tuples have the same tupleid and value in partitioning
+-- key corresponding to `test_1_prt_2` partition
+select tableoid::regclass, ctid, i, j, k from test;
+NOTICE:  One or more columns in the following table(s) do not have statistics: test
+HINT:  For non-partitioned tables, run analyze <table_name>(<column_list>). For partitioned tables, run analyze rootpartition <table_name>(<column_list>). See log for columns missing statistics.
+     tableoid     | ctid  | i | j | k 
+------------------+-------+---+---+---
+ test_1_prt_2     | (0,1) | 0 | 1 | 0
+ test_1_prt_extra | (0,1) | 0 | 2 | 0
+(2 rows)
+
+-- start_matchsubs
+-- m/'\d+'::oid/
+-- s/'\d+'::oid/'table_oid'::oid/
+-- end_matchsubs
+-- We have to update the row (0, 2) from default partition
+explain (verbose, costs off) update test_1_prt_extra set k = 10 where j = 2; 
+                                                                  QUERY PLAN                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------
+ Update
+   Output: test_1_prt_extra.i, test_1_prt_extra.j, test_1_prt_extra.k, (DMLAction), test_1_prt_extra.ctid
+   ->  Split
+         Output: test_1_prt_extra.i, test_1_prt_extra.j, test_1_prt_extra.k, test_1_prt_extra.ctid, test_1_prt_extra.gp_segment_id, DMLAction
+         ->  Result
+               Output: test_1_prt_extra.i, test_1_prt_extra.j, test_1_prt_extra.k, 10, test_1_prt_extra.ctid, test_1_prt_extra.gp_segment_id
+               ->  Seq Scan on partition_pruning.test_1_prt_extra
+                     Output: test_1_prt_extra.i, test_1_prt_extra.j, test_1_prt_extra.k, test_1_prt_extra.ctid, test_1_prt_extra.gp_segment_id
+                     Filter: (test_1_prt_extra.j = 2)
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Settings: enable_bitmapscan=on, enable_hashjoin=off, enable_indexscan=on, enable_mergejoin=on, enable_seqscan=off
+(11 rows)
+
+update test_1_prt_extra set k = 10 where j = 2;
+-- Check that update performed correctly and tuple moved to correct partition
+select tableoid::regclass, ctid, i, j, k from test;
+NOTICE:  One or more columns in the following table(s) do not have statistics: test
+HINT:  For non-partitioned tables, run analyze <table_name>(<column_list>). For partitioned tables, run analyze rootpartition <table_name>(<column_list>). See log for columns missing statistics.
+   tableoid   | ctid  | i | j | k  
+--------------+-------+---+---+----
+ test_1_prt_2 | (0,1) | 0 | 1 |  0
+ test_1_prt_2 | (0,2) | 0 | 2 | 10
+(2 rows)
+
+drop table test, test_extra_exchanged;
+--
+-- Update test case with predicate from partitioned table. Update operation has
+-- to perform partition pruning
+--
+create table test(i int, j int, k int) partition by range(j) (start (1) end(3) every(2), default partition extra);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+NOTICE:  CREATE TABLE will create partition "test_1_prt_extra" for table "test"
+NOTICE:  CREATE TABLE will create partition "test_1_prt_2" for table "test"
+insert into test values (0, 1, 0);
+-- Create table for exchange with default partition and insert another possible
+-- value corresponding to range partition
+create table test_extra_exchanged(like test);
+NOTICE:  table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
+insert into test_extra_exchanged values (0, 2, 0);
+-- Perform exchange without validation
+set gp_enable_exchange_default_partition to on;
+alter table test exchange default partition with table test_extra_exchanged without validation;
+WARNING:  Exchanging default partition may result in unexpected query results if the data being exchanged should have been inserted into a different partition
+NOTICE:  exchanged partition "extra" of relation "test" with relation "test_extra_exchanged"
+-- Create test table that will be used in delete query inside `NOT EXISTS` predicate
+create table test_in_predicate(i int, j int, k int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into test_in_predicate values (0, 1, 0);
+-- Check tuples in partitioned table. Two tuples have the same tupleid and value in partitioning
+-- key corresponding to `test_1_prt_2` partition
+select tableoid::regclass, ctid, i, j, k from test;
+NOTICE:  One or more columns in the following table(s) do not have statistics: test
+HINT:  For non-partitioned tables, run analyze <table_name>(<column_list>). For partitioned tables, run analyze rootpartition <table_name>(<column_list>). See log for columns missing statistics.
+     tableoid     | ctid  | i | j | k 
+------------------+-------+---+---+---
+ test_1_prt_2     | (0,1) | 0 | 1 | 0
+ test_1_prt_extra | (0,1) | 0 | 2 | 0
+(2 rows)
+
+-- We have to update the row (0, 2) from default partition
+explain (verbose, costs off) update test set k = 10  where not exists(
+  select 1 from test_in_predicate where test.i = test_in_predicate.i and test.j = test_in_predicate.j
+);
+NOTICE:  One or more columns in the following table(s) do not have statistics: test
+HINT:  For non-partitioned tables, run analyze <table_name>(<column_list>). For partitioned tables, run analyze rootpartition <table_name>(<column_list>). See log for columns missing statistics.
+                                                    QUERY PLAN                                                     
+-------------------------------------------------------------------------------------------------------------------
+ Update
+   Output: test.i, test.j, test.k, (DMLAction), test.ctid, test.tableoid
+   ->  Split
+         Output: test.i, test.j, test.k, test.ctid, test.tableoid, test.gp_segment_id, DMLAction
+         ->  Result
+               Output: test.i, test.j, test.k, 10, test.ctid, test.tableoid, test.gp_segment_id
+               ->  Hash Anti Join
+                     Output: test.i, test.j, test.k, test.ctid, test.tableoid, test.gp_segment_id
+                     Hash Cond: ((test.i = test_in_predicate.i) AND (test.j = test_in_predicate.j))
+                     ->  Sequence
+                           Output: test.i, test.j, test.k, test.ctid, test.tableoid, test.gp_segment_id
+                           ->  Partition Selector for test (dynamic scan id: 1)
+                                 Partitions selected: 2 (out of 2)
+                           ->  Dynamic Seq Scan on partition_pruning.test (dynamic scan id: 1)
+                                 Output: test.i, test.j, test.k, test.ctid, test.tableoid, test.gp_segment_id
+                     ->  Hash
+                           Output: "outer".?column?, test_in_predicate.i, test_in_predicate.j
+                           ->  Result
+                                 Output: 1, test_in_predicate.i, test_in_predicate.j
+                                 ->  Seq Scan on partition_pruning.test_in_predicate
+                                       Output: test_in_predicate.i, test_in_predicate.j
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Settings: enable_bitmapscan=on, enable_hashjoin=off, enable_indexscan=on, enable_mergejoin=on, enable_seqscan=off
+(23 rows)
+
+update test set k = 10  where not exists(
+  select 1 from test_in_predicate where test.i = test_in_predicate.i and test.j = test_in_predicate.j
+);
+NOTICE:  One or more columns in the following table(s) do not have statistics: test
+HINT:  For non-partitioned tables, run analyze <table_name>(<column_list>). For partitioned tables, run analyze rootpartition <table_name>(<column_list>). See log for columns missing statistics.
+-- Check that update performed correctly and tuple moved to correct partition
+select tableoid::regclass, ctid, i, j, k from test;
+NOTICE:  One or more columns in the following table(s) do not have statistics: test
+HINT:  For non-partitioned tables, run analyze <table_name>(<column_list>). For partitioned tables, run analyze rootpartition <table_name>(<column_list>). See log for columns missing statistics.
+   tableoid   | ctid  | i | j | k  
+--------------+-------+---+---+----
+ test_1_prt_2 | (0,1) | 0 | 1 |  0
+ test_1_prt_2 | (0,2) | 0 | 2 | 10
+(2 rows)
+
+drop table test, test_extra_exchanged, test_in_predicate;
 RESET ALL;

--- a/src/test/regress/sql/partition_pruning.sql
+++ b/src/test/regress/sql/partition_pruning.sql
@@ -1163,4 +1163,149 @@ SELECT * FROM issue_14982_t1_part_range t1, issue_14982_t2_part_range t2
 
 DROP SCHEMA issue_14982 CASCADE;
 
+set search_path to partition_pruning;
+
+-- Tests of partition pruning for case when default partition was exchanged without validation
+-- and contains rows, that satisfy constraints of other partition
+
+--
+-- Simple delete test case from default partition. Delete operation has
+-- not to perform partition pruning.
+--
+create table test(i int, j int) partition by range(j) (start (1) end(3) every(2), default partition extra);
+
+-- check that insert into partition table won't fallback in pg optimizer and won't request tableoid
+explain verbose insert into test values (0, 1);
+insert into test values (0, 1);
+
+-- Create table for exchange with default partition and insert another possible
+-- value corresponding to range partition
+create table test_extra_exchanged(like test);
+insert into test_extra_exchanged values (0, 2);
+
+-- Perform exchange without validation
+set gp_enable_exchange_default_partition to on;
+alter table test exchange default partition with table test_extra_exchanged without validation;
+
+-- Check tuples in partitioned table. Two tuples have the same tupleid and value in partitioning
+-- key corresponding to `test_1_prt_2` partition
+select tableoid::regclass, ctid, i, j from test;
+
+-- We have to delete the row (0, 2) from default partition
+explain (verbose, costs off) delete from test_1_prt_extra where j = 2;
+delete from test_1_prt_extra where j = 2;
+
+-- Check that deletion performed correctly
+select tableoid::regclass, ctid, i, j from test;
+
+drop table test, test_extra_exchanged;
+
+--
+-- Delete test case with predicate from partitioned table. Delete operation has
+-- to perform partition pruning
+--
+create table test(i int, j int) partition by range(j) (start (1) end(3) every(2), default partition extra);
+insert into test values (0, 1);
+
+-- Create table for exchange with default partition and insert another possible
+-- value corresponding to range partition
+create table test_extra_exchanged(like test);
+insert into test_extra_exchanged values (0, 2);
+
+-- Perform exchange without validation
+set gp_enable_exchange_default_partition to on;
+alter table test exchange default partition with table test_extra_exchanged without validation;
+
+-- Check tuples in partitioned table. Two tuples have the same tupleid and value in partitioning
+-- key corresponding to `test_1_prt_2` partition
+select tableoid::regclass, ctid, i, j from test;
+
+-- Create test table that will be used in delete query inside `NOT EXISTS` predicate
+create table test_in_predicate(i int, j int);
+insert into test_in_predicate values (0, 1);
+
+-- We have to delete the row (0, 2) from default partition
+explain (verbose, costs off) delete from test where not exists(
+  select 1 from test_in_predicate where test.i = test_in_predicate.i and test.j = test_in_predicate.j
+);
+delete from test where not exists(
+  select 1 from test_in_predicate where test.i = test_in_predicate.i and test.j = test_in_predicate.j
+);
+
+-- Check that deletion performed correctly
+select tableoid::regclass, ctid, i, j from test;
+
+drop table test, test_extra_exchanged, test_in_predicate;
+
+--
+-- Simple update test case from default partition. Update operation has
+-- not to perform partition pruning
+--
+create table test(i int, j int, k int) partition by range(j) (start (1) end(3) every(2), default partition extra);
+insert into test values (0, 1, 0);
+
+-- Create table for exchange with default partition and insert another possible
+-- value corresponding to range partition
+create table test_extra_exchanged(like test);
+insert into test_extra_exchanged values (0, 2, 0);
+
+-- Perform exchange without validation
+set gp_enable_exchange_default_partition to on;
+alter table test exchange default partition with table test_extra_exchanged without validation;
+
+-- Check tuples in partitioned table. Two tuples have the same tupleid and value in partitioning
+-- key corresponding to `test_1_prt_2` partition
+select tableoid::regclass, ctid, i, j, k from test;
+
+-- start_matchsubs
+-- m/'\d+'::oid/
+-- s/'\d+'::oid/'table_oid'::oid/
+-- end_matchsubs
+
+-- We have to update the row (0, 2) from default partition
+explain (verbose, costs off) update test_1_prt_extra set k = 10 where j = 2; 
+update test_1_prt_extra set k = 10 where j = 2;
+
+-- Check that update performed correctly and tuple moved to correct partition
+select tableoid::regclass, ctid, i, j, k from test;
+
+drop table test, test_extra_exchanged;
+
+--
+-- Update test case with predicate from partitioned table. Update operation has
+-- to perform partition pruning
+--
+create table test(i int, j int, k int) partition by range(j) (start (1) end(3) every(2), default partition extra);
+insert into test values (0, 1, 0);
+
+-- Create table for exchange with default partition and insert another possible
+-- value corresponding to range partition
+create table test_extra_exchanged(like test);
+insert into test_extra_exchanged values (0, 2, 0);
+
+-- Perform exchange without validation
+set gp_enable_exchange_default_partition to on;
+alter table test exchange default partition with table test_extra_exchanged without validation;
+
+-- Create test table that will be used in delete query inside `NOT EXISTS` predicate
+create table test_in_predicate(i int, j int, k int);
+insert into test_in_predicate values (0, 1, 0);
+
+-- Check tuples in partitioned table. Two tuples have the same tupleid and value in partitioning
+-- key corresponding to `test_1_prt_2` partition
+select tableoid::regclass, ctid, i, j, k from test;
+
+-- We have to update the row (0, 2) from default partition
+explain (verbose, costs off) update test set k = 10  where not exists(
+  select 1 from test_in_predicate where test.i = test_in_predicate.i and test.j = test_in_predicate.j
+);
+update test set k = 10  where not exists(
+  select 1 from test_in_predicate where test.i = test_in_predicate.i and test.j = test_in_predicate.j
+);
+
+-- Check that update performed correctly and tuple moved to correct partition
+select tableoid::regclass, ctid, i, j, k from test;
+
+drop table test, test_extra_exchanged, test_in_predicate;
+
 RESET ALL;


### PR DESCRIPTION
## Problem description

Now, `Update/Delete` operation for partitioned tables and child ones [performs](https://github.com/greenplum-db/gpdb/blob/62b58c7634050be5c947e7151592725bd5fc82be/src/backend/executor/nodeModifyTable.c#L664-L681) hidden partition pruning that might lead to corruption when target relation from which tuple is extracted doesn't correspond to relation defined after partition pruning inside Update/Delete operation. That is, we perform removing of row using tupleid extracted from some lower node after scanning of right target relation but Update/Delete node doesn't have any info about that relation and tries to define it based on incoming partitioning key value via regular partition pruning routine. If target row to delete was located in wrong partition (e.g. after `ALTER TABLE EXCHANGE PARTITION WITHOUT VALIDATION` operation) then deletion will be issued using tupleid from that wrong partition on another right partition. This scenario in worth case ends up to deletion of some wrong row, i.e., data corruption.

For example:
```sql
-- Create partitioned table with one range and default partitions. Range partition is able to store two different values in partitioning key attribute. Now it stores one value.
create table test(i int, j int) partition by range(j) (start (1) end(3) every(2), default partition extra);
\d+ test
                         Table "public.test"
 Column |  Type   | Modifiers | Storage | Stats target | Description 
--------+---------+-----------+---------+--------------+-------------
 i      | integer |           | plain   |              | 
 j      | integer |           | plain   |              | 
Child tables: test_1_prt_2,
              test_1_prt_extra
Distributed by: (i)
Partition by: (j)
insert into test values (0, 1);

-- Create table for exchange with default partition and insert another possible value corresponding to range partition
create table test_extra_exchanged(like test);
insert into test_extra_exchanged values (0, 2);

-- Perform exchange without validation
set gp_enable_exchange_default_partition to on;
alter table test exchange default partition with table test_extra_exchanged without validation;

-- Check tuples in partitioned table. Two tuples have the same tupleid and value in partitioning key corresponding to `test_1_prt_2` partition
select tableoid::regclass, ctid, j from test;
     tableoid     | ctid  | j 
------------------+-------+---
 test_1_prt_extra | (0,1) | 2
 test_1_prt_2     | (0,1) | 1
(2 rows)

-- Create test table that will be used in delete query inside `NOT EXISTS` predicate
create table test_in_predicate(i int, j int);
insert into test_in_predicate values (0, 1);

-- We have to delete the row (0, 2) from default partition
explain (costs off, verbose)
delete from test where not exists(
  select 1 from test_in_predicate where test.i = test_in_predicate.i and test.j = test_in_predicate.j
);
                                             QUERY PLAN                                             
----------------------------------------------------------------------------------------------------
 Delete
   Output: test.i, test.j, "outer".ColRef_0026, test.ctid
   ->  Result
         Output: test.i, test.j, test.ctid, test.gp_segment_id, 0
         ->  Partition Selector for test
               Output: test.i, test.j, test.ctid, test.gp_segment_id
               ->  Hash Anti Join
                     Output: test.i, test.j, test.ctid, test.gp_segment_id
                     Hash Cond: ((test.i = test_in_predicate.i) AND (test.j = test_in_predicate.j))
                     ->  Sequence
                           Output: test.i, test.j, test.ctid, test.gp_segment_id
                           ->  Partition Selector for test (dynamic scan id: 1)
                                 Partitions selected: 2 (out of 2)
                           ->  Dynamic Seq Scan on public.test (dynamic scan id: 1)
                                 Output: test.i, test.j, test.ctid, test.gp_segment_id
                     ->  Hash
                           Output: "outer".?column?, test_in_predicate.i, test_in_predicate.j
                           ->  Result
                                 Output: 1, test_in_predicate.i, test_in_predicate.j
                                 ->  Seq Scan on public.test_in_predicate
                                       Output: test_in_predicate.i, test_in_predicate.j
 Optimizer: Pivotal Optimizer (GPORCA)
(22 rows)

delete from test where not exists(select 1 from test_in_predicate where test.i = test_in_predicate.i and test.j = test_in_predicate.j);
DELETE 1

-- But in fact the row from range partition was removed. This is corruption!
select tableoid::regclass, ctid, j from test;
     tableoid     | ctid  | j 
------------------+-------+---
 test_1_prt_extra | (0,1) | 2
(1 row)
```

The solution is based on patch from postgres which fixes the issue described above. When `Update/Delete` operation performs on the root table - `tableoid` value in extra colum is passed from the lower scanning node along with column containing tupleid value, this allows to detect partition correctly (like it's [done at postgres](https://github.com/postgres/postgres/blob/82699edbfe75534b3b6f6f4321339a432b7b8ff2/src/backend/executor/nodeModifyTable.c#L3533-L3572)).
In case of `Update/Delete` opeartion performed on the partition(section) there is no need in partition pruning, because the target relation already specified in metadata of execution state.

Also, ORCA part has changes too - partially returned work with `table Oid`, which was removed by the [PR 14578](https://github.com/greenplum-db/gpdb/pull/14578)

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
