### PR TITLE
Fix ic_proxy compilation for when HOST_NAME_MAX is unavailable

### DIFF
--- a/src/backend/cdb/motion/ic_proxy_addr.h
+++ b/src/backend/cdb/motion/ic_proxy_addr.h
@@ -12,6 +12,13 @@
 #ifndef IC_PROXY_ADDR_H
 #define IC_PROXY_ADDR_H
 
+/*
+ * Some systems like FreeBSD or MacOS do not define HOST_NAME_MAX. In general,
+ * 255 seems to be a safe fallback value and is POSIX.
+ */
+#ifndef HOST_NAME_MAX
+#define HOST_NAME_MAX 255
+#endif
 
 typedef struct ICProxyAddr ICProxyAddr;
 


### PR DESCRIPTION
When compiling proxy interconnect code on MacOS, it fails to compile with the following error:
```
In file included from ic_proxy_main.c:23:
./ic_proxy_addr.h:35:17: error: use of undeclared identifier 'HOST_NAME_MAX'
        char            hostname[HOST_NAME_MAX];        /* hostname or IP */
                                 ^
ic_proxy_main.c:112:14: error: use of undeclared identifier 'HOST_NAME_MAX'
                char            name[HOST_NAME_MAX];
                                     ^
ic_proxy_main.c:168:14: error: use of undeclared identifier 'HOST_NAME_MAX'
                char            name[HOST_NAME_MAX] = "unknown";
```

Some systems like FreeBSD or MacOS do not define HOST_NAME_MAX so we need to define it ourselves. Using the POSIX value of 255 seems to be a safe fallback value so define it as such if HOST_NAME_MAX is unavailable.

Will need to backport this to 6X_STABLE as well.