### PR TITLE
Fix smgr

### DIFF
--- a/src/backend/storage/smgr/smgr.c
+++ b/src/backend/storage/smgr/smgr.c
@@ -71,7 +71,7 @@ static const f_smgr smgrsw[] = {
 	 * Append-optimized relation files currently fall in this category.
 	 */
 	{
-		.smgr_init = mdinit,
+		.smgr_init = NULL,
 		.smgr_shutdown = NULL,
 		.smgr_close = mdclose,
 		.smgr_create = mdcreate,

--- a/src/backend/storage/smgr/smgr.c
+++ b/src/backend/storage/smgr/smgr.c
@@ -120,7 +120,6 @@ smgr_init_standard(void)
 		if (smgrsw[i].smgr_init)
 			smgrsw[i].smgr_init();
 	}
-	mdinit();
 }
 
 


### PR DESCRIPTION
Since we will use a loop to invoke the function `smgr_init()` at `smgr_init_standard()`, and we add
another storage manager in array `smgrsw`, and this AO storage manager has the same `smgr_init`
function with heap table, this could lead to create MdSmgr twice, so we set the AO tables's `smgr_init()`
to NULL.