### PR TITLE
pg_attribute_encoding: Use correct scan regproc

### DIFF
--- a/src/backend/catalog/pg_attribute_encoding.c
+++ b/src/backend/catalog/pg_attribute_encoding.c
@@ -89,7 +89,7 @@ update_attribute_encoding_entry(Oid relid, AttrNumber attnum, Datum newattoption
 				ObjectIdGetDatum(relid));
 	ScanKeyInit(&skey[1],
 				Anum_pg_attribute_encoding_attnum,
-				BTEqualStrategyNumber, F_OIDEQ,
+				BTEqualStrategyNumber, F_INT2EQ,
 				Int16GetDatum(attnum));
 	scan = systable_beginscan(rel, AttributeEncodingAttrelidAttnumIndexId, true,
 							  NULL, 2, skey);


### PR DESCRIPTION
Anum_pg_attribute_encoding_attnum is effectively an int16. We should use
F_INT2EQ and not F_OIDEQ, as oids are uint32.