### PR TITLE
Use ERROR for dispatcher liveness checks

### DIFF
--- a/src/backend/cdb/motion/ic_udpifc.c
+++ b/src/backend/cdb/motion/ic_udpifc.c
@@ -5788,7 +5788,7 @@ dispatcherAYT(void)
 
 	if (MyProcPort->sock == PGINVALID_SOCKET)
 	{
-		ereport(COMMERROR,
+		ereport(ERROR,
 				(errcode(ERRCODE_GP_INTERCONNECTION_ERROR),
 					errmsg("backend socket is invalid (recv)"),
 					errdetail("it could already have been closed")));
@@ -5802,7 +5802,7 @@ dispatcherAYT(void)
 
 	if (ret == 0)				/* socket has been closed. EOF */
 	{
-		ereport(COMMERROR,
+		ereport(ERROR,
 				(errcode(ERRCODE_GP_INTERCONNECTION_ERROR),
 					errmsg("dispatch connection lost (recv)"),
 					errdetail("peer socket has been closed, eof received")));
@@ -5813,7 +5813,7 @@ dispatcherAYT(void)
 		if (errno == EAGAIN || errno == EINPROGRESS)
 			return;		/* connection intact, no data available */
 		else			/* unrecoverable error */
-			ereport(COMMERROR,
+			ereport(ERROR,
 					(errcode(ERRCODE_GP_INTERCONNECTION_ERROR),
 						errmsg("dispatch connection lost (recv): %m")));
 	}


### PR DESCRIPTION
COMMERROR doesn't fail the query. ERROR does. This was an oversight in
fbde68090e7.