### PR TITLE
Fix schemaname in populate partitioned_tables

### DIFF
--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -1767,7 +1767,7 @@ class gpexpand:
             FROM
                 pg_class c
                 JOIN pg_inherits a on (a.inhrelid = c.oid)
-                JOIN pg_partitions pa on (c.oid = (quote_ident(pa.schemaname) || '.' || quote_ident(pa.partitiontablename))::regclass::oid)
+                JOIN pg_partitions pa on (c.oid = (quote_ident(pa.partitionschemaname) || '.' || quote_ident(pa.partitiontablename))::regclass::oid)
                 JOIN pg_class d on (a.inhparent = d.oid)
                 JOIN pg_namespace n on (c.relnamespace = n.oid)
                 LEFT JOIN pg_exttable pe on (c.oid=pe.reloid and pe.writable)


### PR DESCRIPTION
pa.schemaname and pa.partitionschemaname can be differ, and even more - specific object may exists only in partitionschemaname and in these case construct ::regclass::oid will throw an Error "relation "schemaname.partitiontablename" does not exist"

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
