### PR TITLE
add permission check to file /sys/fs/cgroup/cgroup.procs

### DIFF
--- a/gpMgmt/bin/gpcheckresgroupv2impl
+++ b/gpMgmt/bin/gpcheckresgroupv2impl
@@ -25,7 +25,7 @@ class CgroupValidation(object):
         return ""
 
 
-class CgroupValidationVersionBeta(CgroupValidation):
+class CgroupValidationVersionTwo(CgroupValidation):
     def __init__(self):
         self.mount_point = self.detect_cgroup_mount_point()
         self.tab = {"r": os.R_OK, "w": os.W_OK, "x": os.X_OK, "f": os.F_OK}
@@ -83,6 +83,6 @@ class CgroupValidationVersionBeta(CgroupValidation):
 
 if __name__ == '__main__':
     try:
-        CgroupValidationVersionBeta().validate_all()
+        CgroupValidationVersionTwo().validate_all()
     except ValidationException as e:
         exit(e.message)

--- a/gpMgmt/bin/gpcheckresgroupv2impl
+++ b/gpMgmt/bin/gpcheckresgroupv2impl
@@ -41,6 +41,8 @@ class CgroupValidationVersionBeta(CgroupValidation):
         if not self.mount_point:
             self.die("failed to detect cgroup v2 mount point.")
 
+        self.validate_permission("cgroup.procs", "rw")
+
         self.validate_permission("gpdb/", "rwx")
         self.validate_permission("gpdb/cgroup.procs", "rw")
 


### PR DESCRIPTION
As the PR title said, just add permission check to file /sys/fs/cgroup/cgroup.procs.

Make sure `gpstart -rai` will definitely succeed if the customer uses `gpconfig` to set the
gp_resource_manager to group-v2.