### PR TITLE
[6X] Fix pg_rewind when pg_log is a symlink

### DIFF
--- a/src/bin/pg_rewind/filemap.c
+++ b/src/bin/pg_rewind/filemap.c
@@ -218,11 +218,11 @@ process_source_file(const char *path, file_type_t type, size_t size,
 	Assert(filemap->array == NULL);
 
 	/*
-	 * Pretend that pg_xlog is a directory, even if it's really a symlink.
+	 * Pretend that pg_xlog/pg_log is a directory, even if it's really a symlink.
 	 * We don't want to mess with the symlink itself, nor complain if it's a
 	 * symlink in source but not in target or vice versa.
 	 */
-	if (strcmp(path, "pg_xlog") == 0 && type == FILE_TYPE_SYMLINK)
+	if (((strcmp(path, "pg_xlog") == 0 || strcmp(path, "pg_log") == 0)) && type == FILE_TYPE_SYMLINK)
 		type = FILE_TYPE_DIRECTORY;
 
 	/*
@@ -304,9 +304,9 @@ process_target_file(const char *path, file_type_t type, size_t size,
 	}
 
 	/*
-	 * Like in process_source_file, pretend that xlog is always a directory.
+	 * Like in process_source_file, pretend that pg_xlog/pg_log is always a directory.
 	 */
-	if (strcmp(path, "pg_xlog") == 0 && type == FILE_TYPE_SYMLINK)
+	if (((strcmp(path, "pg_xlog") == 0 || strcmp(path, "pg_log") == 0)) && type == FILE_TYPE_SYMLINK)
 		type = FILE_TYPE_DIRECTORY;
 
 	/* Remember this target file */


### PR DESCRIPTION
Backported from 7X commit: b9adc4e with log turned into pg_log and
conflicts resolved by changing pg_wal to pg_xlog

Original commit message follows:

The log directory can often be symlinked in the same way the pg_wal
directory is. Today, even if BOTH the source and target servers have
their log directories symlinked, pg_rewind will run into the error:

"log" is of different type in source and target

This is because when we use the libpq query to fetch the filemap from
the source server, we consider the log directory as a directory, even if
it is a symlink. This is because pg_stat_file() is used in that query in
libpqProcessFileList() and pg_stat_file() returns isdir=t for symlinks
to directories.

This shortcoming is somewhat called out:

 * XXX: There is no backend function to get a symbolic link's target in
 * general, so if the admin has put any custom symbolic links in the data
 * directory, they won't be copied correctly.

We could fix the query and/or pg_stat_file(). However, we would also
like to support deployments where only one of the primaries and/or
standbys have the symlink. That is not hard to conceive, given primaries
and standbys can have drastically disparate log volume and/or log
collection requirements.

So, we decide to extend the log directory the same courtesy as was done
for pg_wal (pg_xlog) in 0e42397f42b.