### PR TITLE
Fixed the string comparison warning

### DIFF
--- a/src/bin/pg_rewind/pg_rewind.c
+++ b/src/bin/pg_rewind/pg_rewind.c
@@ -309,17 +309,20 @@ main(int argc, char **argv)
 
 	sanityChecks();
 
+#ifdef FAULT_INJECTOR
 	/*
 	 * SUSPEND_PG_REWIND is used for testing purposes. If set to true, the pg_rewind process will be
-	 * suspended indefinitely, so that it's entry can be checked in the pg_stat_activity table. The goal
-	 * being that we can run another instance of gprecoverseg and assert that it ignores recovery for
-	 * segments that already have an active pg_rewind process.
+	 * suspended for 120 seconds, so that it's entry can be checked in the pg_stat_activity table.
+	 * The goal being that we can run another instance of gprecoverseg and assert that it ignores
+	 * recovery for segments that already have an active pg_rewind process.
 	 */
-	while(getenv("SUSPEND_PG_REWIND") != NULL && getenv("SUSPEND_PG_REWIND") == "true")
+	char* suspend_pg_rewind = getenv("SUSPEND_PG_REWIND");
+	if(suspend_pg_rewind != NULL && strcmp(suspend_pg_rewind, "true") == 0)
 	{
-		sleep(1);
 		pg_log_info("pg_rewind suspended");
+		sleep(120);
 	}
+#endif
 
 	/*
 	 * If both clusters are already on the same timeline, there's nothing to


### PR DESCRIPTION
* Due to commit eb4db09544bcb8b6ea52f47effe8e30b0f736a97 string comparison was giving below warning, fixed the string comparison code

  pg_rewind.c: In function ‘main’: pg_rewind.c:318:75: warning: comparison with string literal results in unspecified behavior [-Waddress] 318 |  while(getenv("SUSPEND_PG_REWIND") != NULL && getenv("SUSPEND_PG_REWIND") == "true") |

* Also placed the suspend pg_rewind code block under #ifdef FAULT_INJECTOR to avoid shipping this in production build as suggested in https://github.com/greenplum-db/gpdb/pull/14476#discussion_r1110459120

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
