### PR TITLE
Fix IC bugs in ic_proxy_ibuf_push()

### DIFF
--- a/src/backend/cdb/motion/ic_proxy_backend.c
+++ b/src/backend/cdb/motion/ic_proxy_backend.c
@@ -181,6 +181,8 @@ ic_proxy_backend_on_read_hello_ack(uv_stream_t *stream, ssize_t nread, const uv_
 	/* we have received a complete HELLO ACK message */
 	pkt = (ICProxyPkt *)backend->buffer;
 
+	uv_read_stop(stream);
+
 	/* sanity check: drop the packet with incorrect magic number */
 	if (!ic_proxy_pkt_is_valid(pkt))
 	{
@@ -191,7 +193,6 @@ ic_proxy_backend_on_read_hello_ack(uv_stream_t *stream, ssize_t nread, const uv_
 	}
 
 	Assert(ic_proxy_pkt_is(pkt, IC_PROXY_MESSAGE_HELLO_ACK));
-	uv_read_stop(stream);
 
 	/* assign connection fd after domain socket successfully connected */
 	ret = uv_fileno((uv_handle_t *)&backend->pipe, &backend->conn->sockfd);

--- a/src/backend/cdb/motion/ic_proxy_client.c
+++ b/src/backend/cdb/motion/ic_proxy_client.c
@@ -662,6 +662,9 @@ ic_proxy_client_on_hello_pkt(void *opaque, const void *data, uint16 size)
 	ICProxyKey	key;
 	ICProxyPkt *ackpkt;
 
+	/* we only expect one HELLO message */
+	uv_read_stop((uv_stream_t *) &client->pipe);
+
 	/* sanity check: drop the packet with incorrect magic number */
 	if (!ic_proxy_pkt_is_valid(pkt))
 	{
@@ -670,9 +673,6 @@ ic_proxy_client_on_hello_pkt(void *opaque, const void *data, uint16 size)
 					ic_proxy_client_get_name(client), ic_proxy_pkt_to_str(pkt));
 		return;
 	}
-
-	/* we only expect one HELLO message */
-	uv_read_stop((uv_stream_t *) &client->pipe);
 
 	if (!ic_proxy_pkt_is(pkt, IC_PROXY_MESSAGE_HELLO))
 	{

--- a/src/backend/cdb/motion/ic_proxy_iobuf.c
+++ b/src/backend/cdb/motion/ic_proxy_iobuf.c
@@ -151,13 +151,14 @@ ic_proxy_ibuf_push(ICProxyIBuf *ibuf,
 			/* have a complete header now */
 
 			packet_size = ibuf->get_packet_size(ibuf->buf);
-			delta = Min(packet_size - ibuf->len, size);
-
-			memcpy(ibuf->buf + ibuf->len, data, delta);
-			ibuf->len += delta;
-			data += delta;
-			size -= delta;
-
+			if (packet_size > ibuf->len)
+			{
+				delta = Min(packet_size - ibuf->len, size);
+				memcpy(ibuf->buf + ibuf->len, data, delta);
+				ibuf->len += delta;
+				data += delta;
+				size -= delta;
+			}
 			if (ibuf->len < packet_size)
 				/* still not having a complete packet */
 				return;
@@ -175,7 +176,7 @@ ic_proxy_ibuf_push(ICProxyIBuf *ibuf,
 	{
 		packet_size = ibuf->get_packet_size(data);
 
-		if (packet_size <= size)
+		if (packet_size > 0 && packet_size <= size)
 		{
 			/* got a complete pkt */
 			callback(opaque, data, packet_size);

--- a/src/test/regress/expected/ic_proxy_socket.out
+++ b/src/test/regress/expected/ic_proxy_socket.out
@@ -1,32 +1,57 @@
 -- test invalid connection request (random bytes) to ic proxy:
 -- it should be dropped due to mismatch magic number
+CREATE OR REPLACE LANGUAGE plpython3u;
+CREATE OR REPLACE FUNCTION send_bytes_to_icproxy()
+    RETURNS VOID as $$
+import socket, struct
 
-CREATE OR REPLACE LANGUAGE plpythonu;
-CREATE
+# parse host and port from gp_interconnect_proxy_addresses
+icproxy_host = ""
+icproxy_port = -1
+try:
+    res = plpy.execute("show gp_interconnect_type;", 1)
+    if res[0]["gp_interconnect_type"] == "proxy":
+        res = plpy.execute("show gp_interconnect_proxy_addresses;", 1)
+        addrs = res[0]["gp_interconnect_proxy_addresses"]
+        addr = addrs.split(",")[1]
+        icproxy_host = addr.split(":")[2]
+        icproxy_port = int(addr.split(":")[3])
+except:
+    # not working on icproxy mode, just return
+    icproxy_host = ""
+    pass
+if icproxy_host == "":
+    return
 
-CREATE or REPLACE FUNCTION send_bytes_to_icproxy() RETURNS VOID as $$ import socket, struct 
-# parse host and port from gp_interconnect_proxy_addresses icproxy_host = "" icproxy_port = -1 try: res = plpy.execute("show gp_interconnect_type;", 1) if res[0]["gp_interconnect_type"] == "proxy": res = plpy.execute("show gp_interconnect_proxy_addresses;", 1) addrs = res[0]["gp_interconnect_proxy_addresses"] addr = addrs.split(",")[1] icproxy_host = addr.split(":")[2] icproxy_port = int(addr.split(":")[3]) except: # not working on icproxy mode, just return icproxy_host = "" pass if icproxy_host == "": plpy.info("no need to send request") return 
-ranstr="fSSAtMbxAzOhkTcpPwvXQq9Y45vfnTiOdo3Mk9V8QKLKWyd8SHBI59FsDRLWFqMZkFpwosqZEIkua3YfR4C8GZ6n6J4SEYCJcdamjhg2e9e1Ns7kNnnUa7OeRyKSEhIANBfau3tsT1SIR4LnXXOAxMBWJkBLtMDKHQyljfa7iQKa1H0bLBP3gOqX8jshoLE7lksNsvmngfpsGtBmKswFNwdLxR1SiMU7kDfU6gCtmLVbCScImf5AVLMosFExTmX3QdiExuuwST6mNZKS7ZdTzsaKbOSy00EWerm39vW8g305H1jrRNSNZvpRkkE2Hv3Abe9ilXZ5hNsWe0DN1i884iPDmxX0B8T8l3SL4P2NInMmcpuQCNVc4ivE7KgLkFafsKrs1igvyRjLraJcjgk88BOkMoVxSE8plK8JoQGDJylg80WFlPBfgm4vjQjRuh8E9MF0M2Ws5GKiDxQ8RcoEEvmHS6ef76kFjai0A10PRkrOPXjNaCJD7jdRPFjkbr3EyhMGNOKMJxXLaUtzuDpz0Ivc0bH9SXffughI61rzChnt71dS15rpTHm6RHodlkwUHfY0H21I3F2uj7qELJR1kb8A5rfYDf0yv8pyDpCeTxT9WjaDlP1DPT74kXZEuIcIfX2H7RvSR89n3W2DJbdgXD9WSz3DknotAzWdY1iNe7qP6hwGJLkxx0ICBD9JaanCwlL4whB1DmtfZqFARsatXPcgVQIYKquJepNoVdVTwSYTb6XBLEGFTn4S6lJXkpyOB9M6egiYIvMYt1HHgDANFmXLslpB3TIYgc3kgGZ2SKI3sjuYghv0TODOLzFZoH9OuLnDkQVXk4a17xpRgl8pal6geryP6sPGA8XHpi0a6gdnqmGiaTQY84EHeykTcgR6K37UVZm9u8Go1xyjqnHjUtcb0BVZg5uY7MUd6ciMAbvXKh837oNpsbkC27qfPawd3W9Bz0aUhxB9st3EksZSmv6b8sRTyEBOT5zwMP7A" # send the random bytes s = socket.socket(socket.AF_INET, socket.SOCK_STREAM) s.connect((icproxy_host, icproxy_port)) val = struct.pack('!i', 134591) # an invalid magic number s.send(val) message = ranstr.encode('utf-8') val = struct.pack('!i', len(message)) s.send(val) s.sendall(message) s.close() plpy.info("sent request") $$ LANGUAGE plpythonu EXECUTE ON MASTER;
-CREATE
-
-1: create table PR_14998(i int);
-CREATE
-1: SELECT send_bytes_to_icproxy();
+ranstr="fSSAtMbxAzOhkTcpPwvXQq9Y45vfnTiOdo3Mk9V8QKLKWyd8SHBI59FsDRLWFqMZkFpwosqZEIkua3YfR4C8GZ6n6J4SEYCJcdamjhg2e9e1Ns7kNnnUa7OeRyKSEhIANBfau3tsT1SIR4LnXXOAxMBWJkBLtMDKHQyljfa7iQKa1H0bLBP3gOqX8jshoLE7lksNsvmngfpsGtBmKswFNwdLxR1SiMU7kDfU6gCtmLVbCScImf5AVLMosFExTmX3QdiExuuwST6mNZKS7ZdTzsaKbOSy00EWerm39vW8g305H1jrRNSNZvpRkkE2Hv3Abe9ilXZ5hNsWe0DN1i884iPDmxX0B8T8l3SL4P2NInMmcpuQCNVc4ivE7KgLkFafsKrs1igvyRjLraJcjgk88BOkMoVxSE8plK8JoQGDJylg80WFlPBfgm4vjQjRuh8E9MF0M2Ws5GKiDxQ8RcoEEvmHS6ef76kFjai0A10PRkrOPXjNaCJD7jdRPFjkbr3EyhMGNOKMJxXLaUtzuDpz0Ivc0bH9SXffughI61rzChnt71dS15rpTHm6RHodlkwUHfY0H21I3F2uj7qELJR1kb8A5rfYDf0yv8pyDpCeTxT9WjaDlP1DPT74kXZEuIcIfX2H7RvSR89n3W2DJbdgXD9WSz3DknotAzWdY1iNe7qP6hwGJLkxx0ICBD9JaanCwlL4whB1DmtfZqFARsatXPcgVQIYKquJepNoVdVTwSYTb6XBLEGFTn4S6lJXkpyOB9M6egiYIvMYt1HHgDANFmXLslpB3TIYgc3kgGZ2SKI3sjuYghv0TODOLzFZoH9OuLnDkQVXk4a17xpRgl8pal6geryP6sPGA8XHpi0a6gdnqmGiaTQY84EHeykTcgR6K37UVZm9u8Go1xyjqnHjUtcb0BVZg5uY7MUd6ciMAbvXKh837oNpsbkC27qfPawd3W9Bz0aUhxB9st3EksZSmv6b8sRTyEBOT5zwMP7A"
+# send the random bytes
+s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+s.connect((icproxy_host, icproxy_port))
+val = struct.pack('!i', 134591) # an invalid magic number
+s.send(val)
+message = ranstr.encode('utf-8')
+val = struct.pack('!i', len(message))
+s.send(val)
+s.sendall(message)
+s.close()
+$$ LANGUAGE plpython3u;
+create table PR_14998(i int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+SELECT send_bytes_to_icproxy();
  send_bytes_to_icproxy 
 -----------------------
-                       
+ 
 (1 row)
--- the query hang here before adding magic number field in the ICProxyPkt
+
+-- the query hung here before the commit adding the magic number field in the ICProxyPkt
 -- reason: random bytes cause icproxy OOM or hang forever
-1: SET statement_timeout = 10000;
-SET
-1: select count(*) from PR_14998;
+SET statement_timeout = 10000;
+select count(*) from PR_14998;
  count 
 -------
- 0     
+     0
 (1 row)
-1: RESET statement_timeout;
-RESET
-1: drop table PR_14998;
-DROP
-1q: ... <quitting>
+
+RESET statement_timeout;
+drop table PR_14998;

--- a/src/test/regress/expected/ic_proxy_socket.out
+++ b/src/test/regress/expected/ic_proxy_socket.out
@@ -1,0 +1,32 @@
+-- test invalid connection request (random bytes) to ic proxy:
+-- it should be dropped due to mismatch magic number
+
+CREATE OR REPLACE LANGUAGE plpythonu;
+CREATE
+
+CREATE or REPLACE FUNCTION send_bytes_to_icproxy() RETURNS VOID as $$ import socket, struct 
+# parse host and port from gp_interconnect_proxy_addresses icproxy_host = "" icproxy_port = -1 try: res = plpy.execute("show gp_interconnect_type;", 1) if res[0]["gp_interconnect_type"] == "proxy": res = plpy.execute("show gp_interconnect_proxy_addresses;", 1) addrs = res[0]["gp_interconnect_proxy_addresses"] addr = addrs.split(",")[1] icproxy_host = addr.split(":")[2] icproxy_port = int(addr.split(":")[3]) except: # not working on icproxy mode, just return icproxy_host = "" pass if icproxy_host == "": plpy.info("no need to send request") return 
+ranstr="fSSAtMbxAzOhkTcpPwvXQq9Y45vfnTiOdo3Mk9V8QKLKWyd8SHBI59FsDRLWFqMZkFpwosqZEIkua3YfR4C8GZ6n6J4SEYCJcdamjhg2e9e1Ns7kNnnUa7OeRyKSEhIANBfau3tsT1SIR4LnXXOAxMBWJkBLtMDKHQyljfa7iQKa1H0bLBP3gOqX8jshoLE7lksNsvmngfpsGtBmKswFNwdLxR1SiMU7kDfU6gCtmLVbCScImf5AVLMosFExTmX3QdiExuuwST6mNZKS7ZdTzsaKbOSy00EWerm39vW8g305H1jrRNSNZvpRkkE2Hv3Abe9ilXZ5hNsWe0DN1i884iPDmxX0B8T8l3SL4P2NInMmcpuQCNVc4ivE7KgLkFafsKrs1igvyRjLraJcjgk88BOkMoVxSE8plK8JoQGDJylg80WFlPBfgm4vjQjRuh8E9MF0M2Ws5GKiDxQ8RcoEEvmHS6ef76kFjai0A10PRkrOPXjNaCJD7jdRPFjkbr3EyhMGNOKMJxXLaUtzuDpz0Ivc0bH9SXffughI61rzChnt71dS15rpTHm6RHodlkwUHfY0H21I3F2uj7qELJR1kb8A5rfYDf0yv8pyDpCeTxT9WjaDlP1DPT74kXZEuIcIfX2H7RvSR89n3W2DJbdgXD9WSz3DknotAzWdY1iNe7qP6hwGJLkxx0ICBD9JaanCwlL4whB1DmtfZqFARsatXPcgVQIYKquJepNoVdVTwSYTb6XBLEGFTn4S6lJXkpyOB9M6egiYIvMYt1HHgDANFmXLslpB3TIYgc3kgGZ2SKI3sjuYghv0TODOLzFZoH9OuLnDkQVXk4a17xpRgl8pal6geryP6sPGA8XHpi0a6gdnqmGiaTQY84EHeykTcgR6K37UVZm9u8Go1xyjqnHjUtcb0BVZg5uY7MUd6ciMAbvXKh837oNpsbkC27qfPawd3W9Bz0aUhxB9st3EksZSmv6b8sRTyEBOT5zwMP7A" # send the random bytes s = socket.socket(socket.AF_INET, socket.SOCK_STREAM) s.connect((icproxy_host, icproxy_port)) val = struct.pack('!i', 134591) # an invalid magic number s.send(val) message = ranstr.encode('utf-8') val = struct.pack('!i', len(message)) s.send(val) s.sendall(message) s.close() plpy.info("sent request") $$ LANGUAGE plpythonu EXECUTE ON MASTER;
+CREATE
+
+1: create table PR_14998(i int);
+CREATE
+1: SELECT send_bytes_to_icproxy();
+ send_bytes_to_icproxy 
+-----------------------
+                       
+(1 row)
+-- the query hang here before adding magic number field in the ICProxyPkt
+-- reason: random bytes cause icproxy OOM or hang forever
+1: SET statement_timeout = 10000;
+SET
+1: select count(*) from PR_14998;
+ count 
+-------
+ 0     
+(1 row)
+1: RESET statement_timeout;
+RESET
+1: drop table PR_14998;
+DROP
+1q: ... <quitting>

--- a/src/test/regress/expected/ic_proxy_socket.out
+++ b/src/test/regress/expected/ic_proxy_socket.out
@@ -3,7 +3,7 @@
 CREATE OR REPLACE LANGUAGE plpython3u;
 CREATE OR REPLACE FUNCTION send_bytes_to_icproxy()
     RETURNS VOID as $$
-import socket, struct
+import socket, struct, random
 
 # parse host and port from gp_interconnect_proxy_addresses
 icproxy_host = ""
@@ -23,17 +23,27 @@ except:
 if icproxy_host == "":
     return
 
-ranstr="fSSAtMbxAzOhkTcpPwvXQq9Y45vfnTiOdo3Mk9V8QKLKWyd8SHBI59FsDRLWFqMZkFpwosqZEIkua3YfR4C8GZ6n6J4SEYCJcdamjhg2e9e1Ns7kNnnUa7OeRyKSEhIANBfau3tsT1SIR4LnXXOAxMBWJkBLtMDKHQyljfa7iQKa1H0bLBP3gOqX8jshoLE7lksNsvmngfpsGtBmKswFNwdLxR1SiMU7kDfU6gCtmLVbCScImf5AVLMosFExTmX3QdiExuuwST6mNZKS7ZdTzsaKbOSy00EWerm39vW8g305H1jrRNSNZvpRkkE2Hv3Abe9ilXZ5hNsWe0DN1i884iPDmxX0B8T8l3SL4P2NInMmcpuQCNVc4ivE7KgLkFafsKrs1igvyRjLraJcjgk88BOkMoVxSE8plK8JoQGDJylg80WFlPBfgm4vjQjRuh8E9MF0M2Ws5GKiDxQ8RcoEEvmHS6ef76kFjai0A10PRkrOPXjNaCJD7jdRPFjkbr3EyhMGNOKMJxXLaUtzuDpz0Ivc0bH9SXffughI61rzChnt71dS15rpTHm6RHodlkwUHfY0H21I3F2uj7qELJR1kb8A5rfYDf0yv8pyDpCeTxT9WjaDlP1DPT74kXZEuIcIfX2H7RvSR89n3W2DJbdgXD9WSz3DknotAzWdY1iNe7qP6hwGJLkxx0ICBD9JaanCwlL4whB1DmtfZqFARsatXPcgVQIYKquJepNoVdVTwSYTb6XBLEGFTn4S6lJXkpyOB9M6egiYIvMYt1HHgDANFmXLslpB3TIYgc3kgGZ2SKI3sjuYghv0TODOLzFZoH9OuLnDkQVXk4a17xpRgl8pal6geryP6sPGA8XHpi0a6gdnqmGiaTQY84EHeykTcgR6K37UVZm9u8Go1xyjqnHjUtcb0BVZg5uY7MUd6ciMAbvXKh837oNpsbkC27qfPawd3W9Bz0aUhxB9st3EksZSmv6b8sRTyEBOT5zwMP7A"
-# send the random bytes
-s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-s.connect((icproxy_host, icproxy_port))
-val = struct.pack('!i', 134591) # an invalid magic number
-s.send(val)
-message = ranstr.encode('utf-8')
-val = struct.pack('!i', len(message))
-s.send(val)
-s.sendall(message)
-s.close()
+def ranstr(num):
+    H = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
+    salt = ''
+    for i in range(num):
+        salt += random.choice(H)
+    return salt
+
+for i in range(10):
+    # send the random bytes
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.connect((icproxy_host, icproxy_port))
+    val = struct.pack('!i', 134591) # an invalid magic number
+    s.send(val)
+
+    message_len = random.randint(100, 10000)
+    message = ranstr(message_len).encode('utf-8')
+    val = struct.pack('!i', message_len)
+    s.send(val)
+    s.sendall(message)
+    s.close()
+
 $$ LANGUAGE plpython3u;
 create table PR_14998(i int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -315,6 +315,9 @@ test: create_extension_fail
 # test if motion sockets are created with the gp_segment_configuration.address
 test: motion_socket
 
+# test invalid connection to ic proxy when gp_interconnect_type='proxy'
+test: ic_proxy_socket
+
 # subtransaction overflow test
 test: subtrx_overflow
 

--- a/src/test/regress/sql/ic_proxy_socket.sql
+++ b/src/test/regress/sql/ic_proxy_socket.sql
@@ -5,7 +5,7 @@ CREATE OR REPLACE LANGUAGE plpython3u;
 
 CREATE OR REPLACE FUNCTION send_bytes_to_icproxy()
     RETURNS VOID as $$
-import socket, struct
+import socket, struct, random
 
 # parse host and port from gp_interconnect_proxy_addresses
 icproxy_host = ""
@@ -25,17 +25,27 @@ except:
 if icproxy_host == "":
     return
 
-ranstr="fSSAtMbxAzOhkTcpPwvXQq9Y45vfnTiOdo3Mk9V8QKLKWyd8SHBI59FsDRLWFqMZkFpwosqZEIkua3YfR4C8GZ6n6J4SEYCJcdamjhg2e9e1Ns7kNnnUa7OeRyKSEhIANBfau3tsT1SIR4LnXXOAxMBWJkBLtMDKHQyljfa7iQKa1H0bLBP3gOqX8jshoLE7lksNsvmngfpsGtBmKswFNwdLxR1SiMU7kDfU6gCtmLVbCScImf5AVLMosFExTmX3QdiExuuwST6mNZKS7ZdTzsaKbOSy00EWerm39vW8g305H1jrRNSNZvpRkkE2Hv3Abe9ilXZ5hNsWe0DN1i884iPDmxX0B8T8l3SL4P2NInMmcpuQCNVc4ivE7KgLkFafsKrs1igvyRjLraJcjgk88BOkMoVxSE8plK8JoQGDJylg80WFlPBfgm4vjQjRuh8E9MF0M2Ws5GKiDxQ8RcoEEvmHS6ef76kFjai0A10PRkrOPXjNaCJD7jdRPFjkbr3EyhMGNOKMJxXLaUtzuDpz0Ivc0bH9SXffughI61rzChnt71dS15rpTHm6RHodlkwUHfY0H21I3F2uj7qELJR1kb8A5rfYDf0yv8pyDpCeTxT9WjaDlP1DPT74kXZEuIcIfX2H7RvSR89n3W2DJbdgXD9WSz3DknotAzWdY1iNe7qP6hwGJLkxx0ICBD9JaanCwlL4whB1DmtfZqFARsatXPcgVQIYKquJepNoVdVTwSYTb6XBLEGFTn4S6lJXkpyOB9M6egiYIvMYt1HHgDANFmXLslpB3TIYgc3kgGZ2SKI3sjuYghv0TODOLzFZoH9OuLnDkQVXk4a17xpRgl8pal6geryP6sPGA8XHpi0a6gdnqmGiaTQY84EHeykTcgR6K37UVZm9u8Go1xyjqnHjUtcb0BVZg5uY7MUd6ciMAbvXKh837oNpsbkC27qfPawd3W9Bz0aUhxB9st3EksZSmv6b8sRTyEBOT5zwMP7A"
-# send the random bytes
-s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-s.connect((icproxy_host, icproxy_port))
-val = struct.pack('!i', 134591) # an invalid magic number
-s.send(val)
-message = ranstr.encode('utf-8')
-val = struct.pack('!i', len(message))
-s.send(val)
-s.sendall(message)
-s.close()
+def ranstr(num):
+    H = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
+    salt = ''
+    for i in range(num):
+        salt += random.choice(H)
+    return salt
+
+for i in range(10):
+    # send the random bytes
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.connect((icproxy_host, icproxy_port))
+    val = struct.pack('!i', 134591) # an invalid magic number
+    s.send(val)
+
+    message_len = random.randint(100, 10000)
+    message = ranstr(message_len).encode('utf-8')
+    val = struct.pack('!i', message_len)
+    s.send(val)
+    s.sendall(message)
+    s.close()
+
 $$ LANGUAGE plpython3u;
 
 create table PR_14998(i int);

--- a/src/test/regress/sql/ic_proxy_socket.sql
+++ b/src/test/regress/sql/ic_proxy_socket.sql
@@ -1,9 +1,9 @@
 -- test invalid connection request (random bytes) to ic proxy:
 -- it should be dropped due to mismatch magic number
 
-CREATE OR REPLACE LANGUAGE plpythonu;
+CREATE OR REPLACE LANGUAGE plpython3u;
 
-CREATE or REPLACE FUNCTION send_bytes_to_icproxy()
+CREATE OR REPLACE FUNCTION send_bytes_to_icproxy()
     RETURNS VOID as $$
 import socket, struct
 
@@ -23,7 +23,6 @@ except:
     icproxy_host = ""
     pass
 if icproxy_host == "":
-    plpy.info("no need to send request")
     return
 
 ranstr="fSSAtMbxAzOhkTcpPwvXQq9Y45vfnTiOdo3Mk9V8QKLKWyd8SHBI59FsDRLWFqMZkFpwosqZEIkua3YfR4C8GZ6n6J4SEYCJcdamjhg2e9e1Ns7kNnnUa7OeRyKSEhIANBfau3tsT1SIR4LnXXOAxMBWJkBLtMDKHQyljfa7iQKa1H0bLBP3gOqX8jshoLE7lksNsvmngfpsGtBmKswFNwdLxR1SiMU7kDfU6gCtmLVbCScImf5AVLMosFExTmX3QdiExuuwST6mNZKS7ZdTzsaKbOSy00EWerm39vW8g305H1jrRNSNZvpRkkE2Hv3Abe9ilXZ5hNsWe0DN1i884iPDmxX0B8T8l3SL4P2NInMmcpuQCNVc4ivE7KgLkFafsKrs1igvyRjLraJcjgk88BOkMoVxSE8plK8JoQGDJylg80WFlPBfgm4vjQjRuh8E9MF0M2Ws5GKiDxQ8RcoEEvmHS6ef76kFjai0A10PRkrOPXjNaCJD7jdRPFjkbr3EyhMGNOKMJxXLaUtzuDpz0Ivc0bH9SXffughI61rzChnt71dS15rpTHm6RHodlkwUHfY0H21I3F2uj7qELJR1kb8A5rfYDf0yv8pyDpCeTxT9WjaDlP1DPT74kXZEuIcIfX2H7RvSR89n3W2DJbdgXD9WSz3DknotAzWdY1iNe7qP6hwGJLkxx0ICBD9JaanCwlL4whB1DmtfZqFARsatXPcgVQIYKquJepNoVdVTwSYTb6XBLEGFTn4S6lJXkpyOB9M6egiYIvMYt1HHgDANFmXLslpB3TIYgc3kgGZ2SKI3sjuYghv0TODOLzFZoH9OuLnDkQVXk4a17xpRgl8pal6geryP6sPGA8XHpi0a6gdnqmGiaTQY84EHeykTcgR6K37UVZm9u8Go1xyjqnHjUtcb0BVZg5uY7MUd6ciMAbvXKh837oNpsbkC27qfPawd3W9Bz0aUhxB9st3EksZSmv6b8sRTyEBOT5zwMP7A"
@@ -37,15 +36,13 @@ val = struct.pack('!i', len(message))
 s.send(val)
 s.sendall(message)
 s.close()
-plpy.info("sent request")
-$$ LANGUAGE plpythonu EXECUTE ON MASTER;
+$$ LANGUAGE plpython3u;
 
-1: create table PR_14998(i int);
-1: SELECT send_bytes_to_icproxy();
--- the query hang here before adding magic number field in the ICProxyPkt
+create table PR_14998(i int);
+SELECT send_bytes_to_icproxy();
+-- the query hung here before the commit adding the magic number field in the ICProxyPkt
 -- reason: random bytes cause icproxy OOM or hang forever
-1: SET statement_timeout = 10000;
-1: select count(*) from PR_14998;
-1: RESET statement_timeout;
-1: drop table PR_14998;
-1q:
+SET statement_timeout = 10000;
+select count(*) from PR_14998;
+RESET statement_timeout;
+drop table PR_14998;

--- a/src/test/regress/sql/ic_proxy_socket.sql
+++ b/src/test/regress/sql/ic_proxy_socket.sql
@@ -1,0 +1,51 @@
+-- test invalid connection request (random bytes) to ic proxy:
+-- it should be dropped due to mismatch magic number
+
+CREATE OR REPLACE LANGUAGE plpythonu;
+
+CREATE or REPLACE FUNCTION send_bytes_to_icproxy()
+    RETURNS VOID as $$
+import socket, struct
+
+# parse host and port from gp_interconnect_proxy_addresses
+icproxy_host = ""
+icproxy_port = -1
+try:
+    res = plpy.execute("show gp_interconnect_type;", 1)
+    if res[0]["gp_interconnect_type"] == "proxy":
+        res = plpy.execute("show gp_interconnect_proxy_addresses;", 1)
+        addrs = res[0]["gp_interconnect_proxy_addresses"]
+        addr = addrs.split(",")[1]
+        icproxy_host = addr.split(":")[2]
+        icproxy_port = int(addr.split(":")[3])
+except:
+    # not working on icproxy mode, just return
+    icproxy_host = ""
+    pass
+if icproxy_host == "":
+    plpy.info("no need to send request")
+    return
+
+ranstr="fSSAtMbxAzOhkTcpPwvXQq9Y45vfnTiOdo3Mk9V8QKLKWyd8SHBI59FsDRLWFqMZkFpwosqZEIkua3YfR4C8GZ6n6J4SEYCJcdamjhg2e9e1Ns7kNnnUa7OeRyKSEhIANBfau3tsT1SIR4LnXXOAxMBWJkBLtMDKHQyljfa7iQKa1H0bLBP3gOqX8jshoLE7lksNsvmngfpsGtBmKswFNwdLxR1SiMU7kDfU6gCtmLVbCScImf5AVLMosFExTmX3QdiExuuwST6mNZKS7ZdTzsaKbOSy00EWerm39vW8g305H1jrRNSNZvpRkkE2Hv3Abe9ilXZ5hNsWe0DN1i884iPDmxX0B8T8l3SL4P2NInMmcpuQCNVc4ivE7KgLkFafsKrs1igvyRjLraJcjgk88BOkMoVxSE8plK8JoQGDJylg80WFlPBfgm4vjQjRuh8E9MF0M2Ws5GKiDxQ8RcoEEvmHS6ef76kFjai0A10PRkrOPXjNaCJD7jdRPFjkbr3EyhMGNOKMJxXLaUtzuDpz0Ivc0bH9SXffughI61rzChnt71dS15rpTHm6RHodlkwUHfY0H21I3F2uj7qELJR1kb8A5rfYDf0yv8pyDpCeTxT9WjaDlP1DPT74kXZEuIcIfX2H7RvSR89n3W2DJbdgXD9WSz3DknotAzWdY1iNe7qP6hwGJLkxx0ICBD9JaanCwlL4whB1DmtfZqFARsatXPcgVQIYKquJepNoVdVTwSYTb6XBLEGFTn4S6lJXkpyOB9M6egiYIvMYt1HHgDANFmXLslpB3TIYgc3kgGZ2SKI3sjuYghv0TODOLzFZoH9OuLnDkQVXk4a17xpRgl8pal6geryP6sPGA8XHpi0a6gdnqmGiaTQY84EHeykTcgR6K37UVZm9u8Go1xyjqnHjUtcb0BVZg5uY7MUd6ciMAbvXKh837oNpsbkC27qfPawd3W9Bz0aUhxB9st3EksZSmv6b8sRTyEBOT5zwMP7A"
+# send the random bytes
+s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+s.connect((icproxy_host, icproxy_port))
+val = struct.pack('!i', 134591) # an invalid magic number
+s.send(val)
+message = ranstr.encode('utf-8')
+val = struct.pack('!i', len(message))
+s.send(val)
+s.sendall(message)
+s.close()
+plpy.info("sent request")
+$$ LANGUAGE plpythonu EXECUTE ON MASTER;
+
+1: create table PR_14998(i int);
+1: SELECT send_bytes_to_icproxy();
+-- the query hang here before adding magic number field in the ICProxyPkt
+-- reason: random bytes cause icproxy OOM or hang forever
+1: SET statement_timeout = 10000;
+1: select count(*) from PR_14998;
+1: RESET statement_timeout;
+1: drop table PR_14998;
+1q:


### PR DESCRIPTION
My previous comment 57a314073a59c6ec8ab2b0dfc7ed7f578a4568d3 added magic number field in the ICProxyPkt. Some bugs are found in the process of porting it to 6x: they are related to the invalid value of ICProxyPkt field, current code doesn't handle them since they don't exist in the normal package.

All of them have been fixed in the 6x PR: https://github.com/greenplum-db/gpdb/pull/14998, so this PR backport the fix code and test cases into main branch.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
