### PR TITLE
fix format error of the lib name on Mac m1

### DIFF
--- a/gpMgmt/bin/Makefile
+++ b/gpMgmt/bin/Makefile
@@ -104,7 +104,7 @@ pyyaml:
 	@echo "--- pyyaml"
 	cd $(PYLIB_SRC_EXT)/ && $(TAR) xzf $(PYYAML_DIR).tar.gz
 	cd $(PYLIB_SRC_EXT)/$(PYYAML_DIR)/ && env -u CC python3 setup.py build
-	cp -r $(PYLIB_SRC_EXT)/$(PYYAML_DIR)/build/lib*-3.*/* $(PYLIB_DIR)
+	cp -r $(PYLIB_SRC_EXT)/$(PYYAML_DIR)/build/lib*-3*/* $(PYLIB_DIR)/
 
 #
 # PYLINT


### PR DESCRIPTION
An error occurred when `make install` on Mac m1:
  "PyYAML-5.3.1/build/lib*-3.*/*: No such file or directory"

Since the lib name format on Mac m1 is different from x86,
it is 'xx-cpython-**3.8**.so' on x86 and 'xx-cpython-**38**.so' on Mac m1.

This patch we removed the unnecessary '.', so both x86 and arm will be fine.
