### PR TITLE
gprecoverseg differential recovery(rsync based)

### DIFF
--- a/gpMgmt/bin/gppylib/commands/pg.py
+++ b/gpMgmt/bin/gppylib/commands/pg.py
@@ -143,6 +143,16 @@ def getPostmasterPID(db):
     sout=cmd.get_results().stdout.lstrip(' ')
     return int(sout.split()[1])
 
+
+def removePostmasterPid(datadir):
+    cmd = Command(name='remove the postmaster.pid file',
+                  cmdStr='rm -f {}'.format(os.path.join(datadir, "postmaster.pid")))
+    cmd.run()
+    return_code = cmd.get_return_code()
+    if return_code != 0:
+        raise ExecutionError("Failed while trying to remove postmaster.pid.", cmd)
+
+
 def killPgProc(db,procname,signal):
     postmasterPID=getPostmasterPID(db)
     hostname=db.getSegmentHostName()

--- a/gpMgmt/bin/gppylib/operations/Makefile
+++ b/gpMgmt/bin/gppylib/operations/Makefile
@@ -7,7 +7,8 @@ PROGRAMS= initstandby.py test_utils_helper.py
 
 DATA= __init__.py buildMirrorSegments.py deletesystem.py detect_unreachable_hosts.py \
 	package.py rebalanceSegments.py reload.py segment_reconfigurer.py startSegments.py \
-	unix.py update_pg_hba_on_segments.py utils.py segment_tablespace_locations.py
+	unix.py update_pg_hba_on_segments.py utils.py segment_tablespace_locations.py \
+	get_segments_in_recovery.py
 
 installdirs:
 	$(MKDIR_P) '$(DESTDIR)$(libdir)/python/gppylib/operations'

--- a/gpMgmt/bin/gppylib/operations/buildMirrorSegments.py
+++ b/gpMgmt/bin/gppylib/operations/buildMirrorSegments.py
@@ -514,7 +514,7 @@ class GpMirrorListToBuild:
     def _run_recovery(self, action_name, recovery_info_by_host, gpEnv):
         completed_recovery_results = self._do_recovery(recovery_info_by_host, gpEnv)
         recovery_results = RecoveryResult(action_name, completed_recovery_results, self.__logger)
-        recovery_results.print_bb_rewind_update_and_start_errors()
+        recovery_results.print_bb_rewind_differential_update_and_start_errors()
 
         self._remove_progress_files(recovery_info_by_host, recovery_results)
         return recovery_results

--- a/gpMgmt/bin/gppylib/operations/get_segments_in_recovery.py
+++ b/gpMgmt/bin/gppylib/operations/get_segments_in_recovery.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+
+from gppylib import gplog
+from gppylib.db.catalog import RemoteQueryCommand
+
+logger = gplog.get_default_logger()
+
+
+def is_seg_in_backup_mode(hostname, port):
+    """
+    To check if segment is already in backup mode. If yes, then differential recovery might be running already
+    to recover it's mirror. And in that case the mirror should be skipped from being recovered again.
+
+    Also if source is in backup already, pg_start_backup() will throw exception which is a mandatory operation to
+    perform during differential recovery.
+
+    Parameters:
+        hostname: host name of source server
+        port: port of source server
+
+    Returns:
+         boolean: true if backup is in progress for the segment
+    """
+    logger.debug(
+        "Checking if backup is already in progress for the source server with host {} and port {}".format(
+            hostname, port))
+
+    sql = "SELECT pg_is_in_backup()"
+    try:
+        query_cmd = RemoteQueryCommand("pg_is_in_backup", sql, hostname, port)
+        query_cmd.run()
+        res = query_cmd.get_results()
+
+    except Exception as e:
+        raise Exception("Failed to query pg_is_in_backup() for segment with hostname {}, port {}, error: {}".format(
+            hostname, str(port), str(e)))
+
+    return res[0][0]

--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_get_segments_in_recovery.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_get_segments_in_recovery.py
@@ -1,0 +1,54 @@
+from mock import Mock, patch, call
+from gppylib.test.unit.gp_unittest import GpTestCase, run_tests, FakeCursor
+from gppylib.operations.get_segments_in_recovery import is_seg_in_backup_mode
+
+
+class GetSegmentInrecoveryTestCase(GpTestCase):
+    def setUp(self):
+        mock_logger = Mock(spec=['log', 'warn', 'info', 'debug', 'error', 'warning', 'fatal'])
+        self.apply_patches([
+            patch('gppylib.operations.get_segments_in_recovery.logger', return_value=mock_logger),
+        ])
+
+        self.mock_logger = self.get_mock_from_apply_patch('logger')
+
+    def tearDown(self):
+        super(GetSegmentInrecoveryTestCase, self).tearDown()
+
+    @patch('gppylib.db.dbconn.connect', side_effect=Exception())
+    def test_is_seg_in_backup_mode_conn_exception(self, mock1):
+        with self.assertRaises(Exception) as ex:
+            is_seg_in_backup_mode("sdw1", 6001)
+        self.assertEqual('Failed to query pg_is_in_backup() for segment with hostname sdw1, port 6001, error: ',
+                         str(ex.exception))
+
+    @patch('gppylib.db.dbconn.connect', autospec=True)
+    @patch('gppylib.db.dbconn.query', side_effect=Exception())
+    def test_is_seg_in_bakup_mode_query_exception(self, mock1, mock2):
+        with self.assertRaises(Exception) as ex:
+            is_seg_in_backup_mode("sdw1", 6001)
+        self.assertEqual('Failed to query pg_is_in_backup() for segment with hostname sdw1, port 6001, error: ',
+                         str(ex.exception))
+
+    @patch('gppylib.db.dbconn.connect', autospec=True)
+    @patch('gppylib.db.dbconn.query', return_value=FakeCursor(my_list=[[True]]))
+    def test_is_seg_in_backup_mode_returns_true(self, mock1, mock2):
+        backup_in_progress = is_seg_in_backup_mode("sdw1", 6001)
+        self.assertEqual(1, self.mock_logger.debug.call_count)
+        self.assertEqual([call("Checking if backup is already in progress for the source server with host sdw1 and "
+                               "port 6001")], self.mock_logger.debug.call_args_list)
+
+        self.assertEqual(backup_in_progress, True)
+
+    @patch('gppylib.db.dbconn.connect', autospec=True)
+    @patch('gppylib.db.dbconn.query', return_value=FakeCursor(my_list=[[False]]))
+    def test_is_seg_in_backup_mode_returns_false(self, mock1, mock2):
+        backup_in_progress = is_seg_in_backup_mode("sdw1", 6001)
+        self.assertEqual(1, self.mock_logger.debug.call_count)
+        self.assertEqual([call("Checking if backup is already in progress for the source server with host sdw1 and "
+                               "port 6001")], self.mock_logger.debug.call_args_list)
+        self.assertEqual(backup_in_progress, False)
+
+
+if __name__ == '__main__':
+    run_tests()

--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_segment_tablespace_locations.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_segment_tablespace_locations.py
@@ -1,18 +1,23 @@
 #!/usr/bin/env python3
 
 
-from mock import Mock, patch
-from gppylib.operations.segment_tablespace_locations import get_tablespace_locations
+from mock import Mock, patch, call
+from gppylib.operations.segment_tablespace_locations import get_tablespace_locations, get_segment_tablespace_locations
 from test.unit.gp_unittest import GpTestCase
+
 
 class GetTablespaceDirTestCase(GpTestCase):
 
     def setUp(self):
         self.mock_query = Mock(return_value=[])
+        mock_logger = Mock(spec=['log', 'warn', 'info', 'debug', 'error', 'warning', 'fatal'])
+
         self.apply_patches([
             patch('gppylib.operations.segment_tablespace_locations.dbconn.connect'),
-            patch('gppylib.operations.segment_tablespace_locations.dbconn.query', self.mock_query)
+            patch('gppylib.operations.segment_tablespace_locations.dbconn.query', self.mock_query),
+            patch('gppylib.operations.segment_tablespace_locations.logger', return_value=mock_logger),
         ])
+        self.mock_logger = self.get_mock_from_apply_patch('logger')
 
     def tearDown(self):
         super(GetTablespaceDirTestCase, self).tearDown()
@@ -34,3 +39,20 @@ class GetTablespaceDirTestCase(GpTestCase):
         expected = [('sdw1', 1, '/data/tblsp1')]
         mirror_data_directory = '/data/tblsp1'
         self.assertEqual(expected, get_tablespace_locations(False, mirror_data_directory))
+
+    @patch('gppylib.db.catalog.RemoteQueryCommand.run', side_effect=Exception())
+    def test_get_segment_tablespace_locations_exception(self, mock1):
+        with self.assertRaises(Exception) as ex:
+            get_segment_tablespace_locations('sdw1', 40000)
+        self.assertEqual(0, self.mock_logger.debug.call_count)
+        self.assertTrue('Failed to get segment tablespace locations for segment with host sdw1 and port 40000'
+                        in str(ex.exception))
+
+    @patch('gppylib.db.catalog.RemoteQueryCommand.__init__', return_value=None)
+    @patch('gppylib.db.catalog.RemoteQueryCommand.run')
+    @patch('gppylib.db.catalog.RemoteQueryCommand.get_results')
+    def test_get_segment_tablespace_locations_success(self, mock1, mock2, mock3):
+        get_segment_tablespace_locations('sdw1', 40000)
+        self.assertEqual(1, self.mock_logger.debug.call_count)
+        self.assertEqual([call('Successfully got tablespace locations for segment with host sdw1, port 40000')],
+                         self.mock_logger.debug.call_args_list)

--- a/gpMgmt/bin/gppylib/programs/clsAddMirrors.py
+++ b/gpMgmt/bin/gppylib/programs/clsAddMirrors.py
@@ -110,7 +110,7 @@ class GpMirrorBuildCalculator:
 
         primary.setSegmentMode(gparray.MODE_NOT_SYNC)
 
-        resultOut.append(GpMirrorToBuild(None, primary, mirror, True))
+        resultOut.append(GpMirrorToBuild(None, primary, mirror, True, False))
 
         self.__primariesUpdatedToHaveMirrorsByHost[primary.getSegmentHostName()] += 1
         self.__mirrorsAddedByHost[targetHost] = mirrorIndexOnTargetHost + 1

--- a/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
+++ b/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
@@ -46,27 +46,6 @@ from gppylib.programs.clsRecoverSegment_triples import RecoveryTripletsFactory
 
 logger = gplog.get_default_logger()
 
-# -------------------------------------------------------------------------
-
-class RemoteQueryCommand(Command):
-    def __init__(self, qname, query, hostname, port, dbname=None):
-        self.qname = qname
-        self.query = query
-        self.hostname = hostname
-        self.port = port
-        self.dbname = dbname or os.environ.get('PGDATABASE', None) or 'template1'
-        self.res = None
-
-    def get_results(self):
-        return self.res
-
-    def run(self):
-        logger.debug('Executing query (%s:%s) for segment (%s:%s) on database (%s)' % (
-            self.qname, self.query, self.hostname, self.port, self.dbname))
-        with closing(dbconn.connect(dbconn.DbURL(hostname=self.hostname, port=self.port, dbname=self.dbname),
-                            utility=True)) as conn:
-            self.res = dbconn.query(conn, self.query).fetchall()
-# -------------------------------------------------------------------------
 
 class GpRecoverSegmentProgram:
     #

--- a/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
+++ b/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
@@ -103,7 +103,7 @@ class GpRecoverSegmentProgram:
             return GpSegmentRebalanceOperation(gpEnv, gpArray, self.__options.parallelDegree, self.__options.parallelPerHost)
         else:
             instance = RecoveryTripletsFactory.instance(gpArray, self.__options.recoveryConfigFile, self.__options.newRecoverHosts, self.__options.parallelDegree)
-            segs = [GpMirrorToBuild(t.failed, t.live, t.failover, self.__options.forceFullResynchronization) for t in instance.getTriplets()]
+            segs = [GpMirrorToBuild(t.failed, t.live, t.failover, self.__options.forceFullResynchronization, self.__options.differentialResynchronization) for t in instance.getTriplets()]
             return GpMirrorListToBuild(segs, self.__pool, self.__options.quiet,
                                        self.__options.parallelDegree,
                                        instance.getInterfaceHostnameWarnings(),
@@ -163,7 +163,11 @@ class GpRecoverSegmentProgram:
 
                 tabLog = TableLogger()
 
-                syncMode = "Full" if toRecover.isFullSynchronization() else "Incremental"
+                syncMode = "Incremental"
+                if toRecover.isFullSynchronization():
+                    syncMode = "Full"
+                elif toRecover.isDifferentialSynchronization():
+                    syncMode = "Differential"
                 tabLog.info(["Synchronization mode", "= " + syncMode])
                 programIoUtils.appendSegmentInfoForOutput("Failed", gpArray, toRecover.getFailedSegment(), tabLog)
                 programIoUtils.appendSegmentInfoForOutput("Recovery Source", gpArray, toRecover.getLiveSegment(),
@@ -237,8 +241,18 @@ class GpRecoverSegmentProgram:
             optionCnt += 1
         if self.__options.rebalanceSegments:
             optionCnt += 1
+        if self.__options.differentialResynchronization:
+            optionCnt += 1
         if optionCnt > 1:
-            raise ProgramArgumentValidationException("Only one of -i, -p, and -r may be specified")
+            raise ProgramArgumentValidationException("Only one of -i, -p, -r and --differential may be specified")
+
+        # verify "mode to recover" options
+        if self.__options.forceFullResynchronization and self.__options.differentialResynchronization:
+            raise ProgramArgumentValidationException("Only one of -F and --differential may be specified")
+
+        # verify differential supported options
+        if self.__options.differentialResynchronization and self.__options.outputSampleConfigFile:
+            raise ProgramArgumentValidationException("Invalid -o provided with --differential argument")
 
         faultProberInterface.getFaultProber().initializeProber(gpEnv.getCoordinatorPort())
 
@@ -327,7 +341,11 @@ class GpRecoverSegmentProgram:
             contentsToUpdate = [seg.getLiveSegment().getSegmentContentId() for seg in mirrorBuilder.getMirrorsToBuild()]
             update_pg_hba_on_segments(gpArray, self.__options.hba_hostnames, self.__options.parallelDegree, contentsToUpdate)
             if not mirrorBuilder.recover_mirrors(gpEnv, gpArray):
-                self.logger.error("gprecoverseg failed. Please check the output for more details.")
+                if self.__options.differentialResynchronization:
+                    self.logger.error("gprecoverseg differential recovery failed. Please check the gpsegrecovery.py log"
+                                      " file and rsync log file for more details.")
+                else:
+                    self.logger.error("gprecoverseg failed. Please check the output for more details.")
                 sys.exit(1)
 
             self.logger.info("********************************")
@@ -420,6 +438,10 @@ class GpRecoverSegmentProgram:
                          dest="forceFullResynchronization",
                          metavar="<forceFullResynchronization>",
                          help="Force full segment resynchronization")
+        addTo.add_option('--differential', None, default=False, action='store_true',
+                         dest="differentialResynchronization",
+                         metavar="<differentialResynchronization>",
+                         help="differential segment resynchronization")
         addTo.add_option("-B", None, type="int", default=gp.DEFAULT_COORDINATOR_NUM_WORKERS,
                          dest="parallelDegree",
                          metavar="<parallelDegree>",

--- a/gpMgmt/bin/gppylib/recoveryinfo.py
+++ b/gpMgmt/bin/gppylib/recoveryinfo.py
@@ -92,6 +92,7 @@ def deserialize_list(serialized_string, class_name=RecoveryInfo):
 class RecoveryErrorType(object):
     VALIDATION_ERROR = 'validation'
     REWIND_ERROR = 'incremental'
+    DIFFERENTIAL_ERROR = 'differential'
     BASEBACKUP_ERROR = 'full'
     START_ERROR = 'start'
     UPDATE_ERROR = 'update'
@@ -122,7 +123,8 @@ class RecoveryResult(object):
         self._setup_recovery_errors = defaultdict(list)
         self._bb_errors = defaultdict(list)
         self._rewind_errors = defaultdict(list)
-        self._dbids_that_failed_bb_rewind = set()
+        self._differential_errors = defaultdict(list)
+        self._dbids_that_failed_bb_rewind_differential = set()
         self._start_errors = defaultdict(list)
         self._update_errors = defaultdict(list)
         self._parse_results(results)
@@ -141,10 +143,13 @@ class RecoveryResult(object):
                     continue
                 if error.error_type == RecoveryErrorType.BASEBACKUP_ERROR:
                     self._bb_errors[host_result.remoteHost].append(error)
-                    self._dbids_that_failed_bb_rewind.add(error.dbid)
+                    self._dbids_that_failed_bb_rewind_differential.add(error.dbid)
                 elif error.error_type == RecoveryErrorType.REWIND_ERROR:
-                    self._dbids_that_failed_bb_rewind.add(error.dbid)
+                    self._dbids_that_failed_bb_rewind_differential.add(error.dbid)
                     self._rewind_errors[host_result.remoteHost].append(error)
+                elif error.error_type == RecoveryErrorType.DIFFERENTIAL_ERROR:
+                    self._dbids_that_failed_bb_rewind_differential.add(error.dbid)
+                    self._differential_errors[host_result.remoteHost].append(error)
                 elif error.error_type == RecoveryErrorType.START_ERROR:
                     self._start_errors[host_result.remoteHost].append(error)
                 elif error.error_type == RecoveryErrorType.VALIDATION_ERROR:
@@ -167,10 +172,10 @@ class RecoveryResult(object):
 
     def recovery_successful(self):
         return len(self._setup_recovery_errors) == 0 and len(self._bb_errors) == 0 and len(self._rewind_errors) == 0 and \
-               len(self._start_errors) == 0 and len(self._invalid_recovery_errors) == 0 and len(self._update_errors) == 0
+               len(self._differential_errors) == 0 and len(self._start_errors) == 0 and len(self._invalid_recovery_errors) == 0 and len(self._update_errors) == 0
 
-    def was_bb_rewind_successful(self, dbid):
-        return dbid not in self._dbids_that_failed_bb_rewind
+    def was_bb_rewind_rsync_successful(self, dbid):
+        return dbid not in self._dbids_that_failed_bb_rewind_differential
 
     def print_setup_recovery_errors(self):
         setup_recovery_error_pattern = " hostname: {}; port: {}; error: {}"
@@ -182,22 +187,30 @@ class RecoveryResult(object):
                     self._logger.error(setup_recovery_error_pattern.format(hostname, error.port, error.error_msg))
         self._print_invalid_errors()
 
-    def print_bb_rewind_update_and_start_errors(self):
-        bb_rewind_error_pattern = " hostname: {}; port: {}; logfile: {}; recoverytype: {}"
-        if len(self._bb_errors) > 0 or len(self._rewind_errors) > 0:
+    def print_bb_rewind_differential_update_and_start_errors(self):
+        bb_rewind_differential_error_pattern = " hostname: {}; port: {}; logfile: {}; recoverytype: {}"
+        if len(self._bb_errors) > 0 or len(self._rewind_errors) > 0 or len(self._differential_errors) > 0:
             self._logger.info("----------------------------------------------------------")
             if len(self._rewind_errors) > 0:
-                self._logger.info("Failed to {} the following segments. You must run gprecoverseg -F for "
-                                  "all incremental failures".format(self.action_name))
+                self._logger.info("Failed to {} the following segments. You must run either gprecoverseg --differential"
+                                  " or gprecoverseg -F for all incremental failures".format(self.action_name))
+            elif len(self._differential_errors) > 0:
+                self._logger.info("Failed to {} the following segments. You must run either gprecoverseg --differential"
+                                  " or gprecoverseg -F for all differential failures".format(self.action_name))
             else:
                 self._logger.info("Failed to {} the following segments".format(self.action_name))
             for hostname, errors in self._rewind_errors.items():
                 for error in errors:
-                    self._logger.info(bb_rewind_error_pattern.format(hostname, error.port, error.progress_file,
+                    self._logger.info(bb_rewind_differential_error_pattern.format(hostname, error.port, error.progress_file,
+                                                                     error.error_type))
+
+            for hostname, errors in self._differential_errors.items():
+                for error in errors:
+                    self._logger.info(bb_rewind_differential_error_pattern.format(hostname, error.port, error.progress_file,
                                                                      error.error_type))
             for hostname, errors in self._bb_errors.items():
                 for error in errors:
-                    self._logger.info(bb_rewind_error_pattern.format(hostname, error.port, error.progress_file,
+                    self._logger.info(bb_rewind_differential_error_pattern.format(hostname, error.port, error.progress_file,
                                                                  error.error_type))
 
         if len(self._start_errors) > 0:

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gprecoverseg.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gprecoverseg.py
@@ -28,6 +28,7 @@ class Options:
         self.parallelDegree = 1
         self.parallelPerHost = 1
         self.forceFullResynchronization = None
+        self.differentialResynchronization = None
         self.persistent_check = None
         self.quiet = None
         self.interactive = False
@@ -71,7 +72,7 @@ class GpRecoversegTestCase(GpTestCase):
 
         self.config_provider_mock.loadSystemConfig.return_value = self.gpArrayMock
 
-        self.mirror_to_build = GpMirrorToBuild(self.mirror0, self.primary0, None, False)
+        self.mirror_to_build = GpMirrorToBuild(self.mirror0, self.primary0, None, False, False)
         self.apply_patches([
             patch('os.environ', new=self.os_env),
             patch('gppylib.db.dbconn.connect', return_value=self.conn),

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpsegrecovery.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpsegrecovery.py
@@ -3,13 +3,13 @@ from mock import call, Mock, patch, ANY
 import io
 import sys
 
-from .gp_unittest import GpTestCase
+from .gp_unittest import GpTestCase, FakeCursor
 import gpsegrecovery
 from gpsegrecovery import SegRecovery
 import gppylib
 from gppylib import gplog
 from gppylib.gparray import Segment
-from gppylib.recoveryinfo import RecoveryInfo
+from gppylib.recoveryinfo import RecoveryInfo, RecoveryErrorType
 
 
 class IncrementalRecoveryTestCase(GpTestCase):
@@ -33,7 +33,8 @@ class IncrementalRecoveryTestCase(GpTestCase):
                                               m.getSegmentDbId(),
                                               p.getSegmentHostName(),
                                               p.getSegmentPort(),
-                                              False, '/tmp/test_progress_file')
+                                              p.getSegmentDataDirectory(),
+                                              False, False, '/tmp/test_progress_file')
         self.era = '1234_20211110'
 
         self.incremental_recovery_cmd = gpsegrecovery.IncrementalRecovery(
@@ -142,7 +143,8 @@ class FullRecoveryTestCase(GpTestCase):
                                               m.getSegmentDbId(),
                                               p.getSegmentHostName(),
                                               p.getSegmentPort(),
-                                              True, '/tmp/test_progress_file')
+                                              p.getSegmentDataDirectory(),
+                                              True, False, '/tmp/test_progress_file')
         self.era = '1234_20211110'
         self.full_recovery_cmd = gpsegrecovery.FullRecovery(
             name='test full recovery', recovery_info=self.seg_recovery_info,
@@ -276,13 +278,17 @@ class SegRecoveryTestCase(GpTestCase):
         self.maxDiff = None
         self.mock_logger = Mock(spec=['log', 'info', 'debug', 'error', 'warn', 'exception'])
         self.full_r1 = RecoveryInfo('target_data_dir1', 5001, 1, 'source_hostname1',
-                                    6001, True, '/tmp/progress_file1')
+                                    6001, 'source_datadair1', True, False, '/tmp/progress_file1')
         self.incr_r1 = RecoveryInfo('target_data_dir2', 5002, 2, 'source_hostname2',
-                                    6002, False, '/tmp/progress_file2')
+                                    6002, 'source_datadir2', False, False, '/tmp/progress_file2')
         self.full_r2 = RecoveryInfo('target_data_dir3', 5003, 3, 'source_hostname3',
-                                    6003, True, '/tmp/progress_file3')
+                                    6003, 'source_datadir3', True, False, '/tmp/progress_file3')
         self.incr_r2 = RecoveryInfo('target_data_dir4', 5004, 4, 'source_hostname4',
-                                    6004, False, '/tmp/progress_file4')
+                                    6004, 'source_datadir4', False, False, '/tmp/progress_file4')
+        self.diff_r1 = RecoveryInfo('target_data_dir5', 5005, 5, 'source_hostname5',
+                                    6005, 'source_datadir5', False, True, '/tmp/progress_file5')
+        self.diff_r2 = RecoveryInfo('target_data_dir6', 5006, 6, 'source_hostname6',
+                                    6006, 'source_datadir6', False, True, '/tmp/progress_file6')
         self.era = '1234_2021110'
 
         self.apply_patches([
@@ -372,6 +378,14 @@ class SegRecoveryTestCase(GpTestCase):
         self.assertEqual(self.era, cmd.era)
         self.assertEqual(self.mock_logger, cmd.logger)
 
+    def _assert_setup_diff_call(self, cmd, expected_recovery_info):
+        self.assertTrue(
+            isinstance(cmd, gpsegrecovery.DifferentialRecovery))
+        self.assertIn('rsync', cmd.name)
+        self.assertEqual(expected_recovery_info, cmd.recovery_info)
+        self.assertEqual(self.era, cmd.era)
+        self.assertEqual(self.mock_logger, cmd.logger)
+
     def test_empty_recovery_info_list(self):
         cmd_list = SegRecovery().get_recovery_cmds([], False, None, self.era)
         self.assertEqual([], cmd_list)
@@ -386,16 +400,23 @@ class SegRecoveryTestCase(GpTestCase):
         self._assert_setup_incr_call(cmd_list[0], self.incr_r1)
         self._assert_setup_incr_call(cmd_list[1], self.incr_r2)
 
+    def test_get_recovery_cmds_diff_recoveryinfo(self):
+        cmd_list = SegRecovery().get_recovery_cmds([self.diff_r1, self.diff_r2], False, self.mock_logger, self.era)
+        self._assert_setup_diff_call(cmd_list[0], self.diff_r1)
+        self._assert_setup_diff_call(cmd_list[1], self.diff_r2)
+
     def test_get_recovery_cmds_mix_recoveryinfo(self):
-        cmd_list = SegRecovery().get_recovery_cmds([self.full_r1, self.incr_r2], False, self.mock_logger, self.era)
+        cmd_list = SegRecovery().get_recovery_cmds([self.full_r1, self.incr_r2, self.diff_r1], False, self.mock_logger, self.era)
         self._assert_validation_full_call(cmd_list[0], self.full_r1)
         self._assert_setup_incr_call(cmd_list[1], self.incr_r2)
+        self._assert_setup_diff_call(cmd_list[2], self.diff_r1)
 
     def test_get_recovery_cmds_mix_recoveryinfo_forceoverwrite(self):
-        cmd_list = SegRecovery().get_recovery_cmds([self.full_r1, self.incr_r2], True, self.mock_logger, self.era)
+        cmd_list = SegRecovery().get_recovery_cmds([self.full_r1, self.incr_r2, self.diff_r1], True, self.mock_logger, self.era)
         self._assert_validation_full_call(cmd_list[0], self.full_r1,
                                           expected_forceoverwrite=True)
         self._assert_setup_incr_call(cmd_list[1], self.incr_r2)
+        self._assert_setup_diff_call(cmd_list[2], self.diff_r1)
 
     @patch('gpsegrecovery.SegmentStart.__init__', return_value=None)
     @patch('gpsegrecovery.SegmentStart.run')
@@ -406,3 +427,368 @@ class SegRecoveryTestCase(GpTestCase):
         mock_init.assert_called_once()
         self.assertEqual(1, self.mock_logger.info.call_count)
         mock_run.assert_called_once_with(validateAfter=True)
+
+
+class DifferentialRecoveryClsTestCase(GpTestCase):
+    def setUp(self):
+        self.mock_logger = Mock(spec=['log', 'info', 'debug', 'error', 'warn', 'exception'])
+        self.apply_patches([
+               patch('gppylib.commands.unix.Rsync.__init__', return_value=None),
+               patch('gppylib.commands.unix.Rsync.run'),
+               patch('gppylib.db.dbconn.connect', autospec=True)
+        ])
+
+        self.mock_rsync_init = self.get_mock_from_apply_patch('__init__')
+        self.mock_rsync_run = self.get_mock_from_apply_patch('run')
+
+        p = Segment.initFromString("1|0|p|p|s|u|sdw1|sdw1|40000|/data/primary0")
+        m = Segment.initFromString("2|0|m|m|s|u|sdw2|sdw2|50000|/data/mirror0")
+        self.seg_recovery_info = RecoveryInfo(m.getSegmentDataDirectory(),
+                                              m.getSegmentPort(),
+                                              m.getSegmentDbId(),
+                                              p.getSegmentHostName(),
+                                              p.getSegmentPort(),
+                                              p.getSegmentDataDirectory(),
+                                              False, True, '/tmp/test_progress_file')
+        self.era = '1234_20211110'
+        self.diff_recovery_cmd = gpsegrecovery.DifferentialRecovery(
+            name='test differential recovery', recovery_info=self.seg_recovery_info,
+            logger=self.mock_logger, era=self.era)
+
+    @patch('gppylib.db.catalog.RemoteQueryCommand.run', side_effect=Exception())
+    def test_pg_start_backup_conn_exception(self, mock1):
+        with self.assertRaises(Exception) as ex:
+            self.diff_recovery_cmd.pg_start_backup()
+        self.assertTrue('Failed to query pg_start_backup() for segment with host sdw1 and port 40000'
+                        in str(ex.exception))
+
+    @patch('gppylib.db.catalog.RemoteQueryCommand.__init__', return_value=None)
+    @patch('gppylib.db.catalog.RemoteQueryCommand.run')
+    def test_pg_start_backup_success(self, mock1, mock2):
+        self.diff_recovery_cmd.pg_start_backup()
+        self.assertEqual(1, self.mock_logger.debug.call_count)
+        self.assertEqual([call('Successfully ran pg_start_backup for segment on host sdw1, port 40000')],
+                         self.mock_logger.debug.call_args_list)
+
+    @patch('gppylib.db.catalog.RemoteQueryCommand.run', side_effect=Exception())
+    def test_pg_stop_backup_conn_exception(self, mock1):
+        with self.assertRaises(Exception) as ex:
+            self.diff_recovery_cmd.pg_stop_backup()
+        self.assertTrue('Failed to query pg_stop_backup() for segment with host sdw1 and port 40000'
+                        in str(ex.exception))
+
+    @patch('gppylib.db.catalog.RemoteQueryCommand.__init__', return_value=None)
+    @patch('gppylib.db.catalog.RemoteQueryCommand.run')
+    def test_pg_stop_backup_success(self, mock1, mock2):
+        self.diff_recovery_cmd.pg_stop_backup()
+        self.assertEqual(1, self.mock_logger.debug.call_count)
+        self.assertEqual([call('Successfully ran pg_stop_backup for segment on host sdw1, port 40000')],
+                         self.mock_logger.debug.call_args_list)
+
+    @patch('gppylib.db.catalog.RemoteQueryCommand.get_results',
+           return_value=[['/data/mytblspace1'], ['/data/mytblspace2']])
+    def test_sync_tablespaces_outside_data_dir(self, mock):
+        self.diff_recovery_cmd.sync_tablespaces()
+        self.assertEqual(2, self.mock_rsync_init.call_count)
+        self.assertEqual(2, self.mock_rsync_run.call_count)
+        self.assertEqual(call(validateAfter=True), self.mock_rsync_run.call_args)
+        self.assertEqual([call('Syncing tablespaces of dbid 2 which are outside of data_dir')],
+                         self.mock_logger.debug.call_args_list)
+
+    @patch('gppylib.db.catalog.RemoteQueryCommand.get_results',
+           return_value=[['/data/mirror0']])
+    def test_sync_tablespaces_within_data_dir(self, mock):
+        self.diff_recovery_cmd.sync_tablespaces()
+        self.assertEqual(0, self.mock_rsync_init.call_count)
+        self.assertEqual(0, self.mock_rsync_run.call_count)
+        self.assertEqual([call('Syncing tablespaces of dbid 2 which are outside of data_dir')],
+                         self.mock_logger.debug.call_args_list)
+
+    @patch('gppylib.db.catalog.RemoteQueryCommand.get_results',
+           return_value=[['/data/mirror0'], ['/data/mytblspace1']])
+    def test_sync_tablespaces_mix_data_dir(self, mock):
+        self.diff_recovery_cmd.sync_tablespaces()
+        self.assertEqual(1, self.mock_rsync_init.call_count)
+        self.assertEqual(1, self.mock_rsync_run.call_count)
+        self.assertEqual(call(validateAfter=True), self.mock_rsync_run.call_args)
+        self.assertEqual([call('Syncing tablespaces of dbid 2 which are outside of data_dir')],
+                         self.mock_logger.debug.call_args_list)
+
+    def test_sync_wals_and_control_file_success(self):
+        self.diff_recovery_cmd.sync_wals_and_control_file()
+        self.assertEqual(2, self.mock_rsync_init.call_count)
+        self.assertEqual(2, self.mock_rsync_run.call_count)
+        self.assertEqual(call(validateAfter=True), self.mock_rsync_run.call_args)
+        self.assertEqual([call('Syncing pg_wal directory of dbid 2'),
+                          call('Syncing pg_control file of dbid 2')],
+                         self.mock_logger.debug.call_args_list)
+
+    def test_sync_pg_data_success(self):
+        self.diff_recovery_cmd.sync_pg_data()
+        self.assertEqual(1, self.mock_rsync_init.call_count)
+        self.assertEqual(1, self.mock_rsync_run.call_count)
+        self.assertEqual(call(validateAfter=True), self.mock_rsync_run.call_args)
+        self.assertEqual([call('Syncing pg_data of dbid 2')],
+                         self.mock_logger.debug.call_args_list)
+
+    def tearDown(self):
+        super(DifferentialRecoveryClsTestCase, self).tearDown()
+
+
+class DifferentialRecoveryRunTestCase(GpTestCase):
+    def setUp(self):
+        # TODO should we mock the set_recovery_cmd_results decorator and not worry about
+        # testing the command results in this test class
+        self.maxDiff = None
+        self.mock_logger = Mock(spec=['log', 'info', 'debug', 'error', 'warn', 'exception'])
+        self.apply_patches([
+            patch('gpsegrecovery.DifferentialRecovery.sync_tablespaces', return_value = Mock()),
+            patch('gpsegrecovery.DifferentialRecovery.pg_start_backup', return_value=Mock()),
+            patch('gpsegrecovery.DifferentialRecovery.pg_stop_backup', return_value=Mock()),
+            patch('gpsegrecovery.ModifyConfSetting', return_value=Mock()),
+            patch('gpsegrecovery.start_segment', return_value=Mock()),
+            patch('gppylib.commands.pg.PgReplicationSlot.slot_exists', return_value=Mock()),
+            patch('gppylib.commands.pg.PgReplicationSlot.drop_slot', return_value=Mock()),
+            patch('gppylib.commands.pg.PgReplicationSlot.create_slot', return_value=Mock()),
+            patch('gppylib.commands.pg.PgBaseBackup.__init__', return_value=None),
+            patch('gppylib.commands.pg.PgBaseBackup.run'),
+            patch('gppylib.db.dbconn.connect', autospec=True),
+            patch('gppylib.db.dbconn.query', return_value=FakeCursor(my_list=[[True]])),
+        ])
+
+        self.mock_pgbasebackup_modifyconfsetting = self.get_mock_from_apply_patch('ModifyConfSetting')
+        self.mock_sync_tablespaces = self.get_mock_from_apply_patch('sync_tablespaces')
+        self.mock_pg_start_backup = self.get_mock_from_apply_patch('pg_start_backup')
+        self.mock_pg_stop_backup = self.get_mock_from_apply_patch('pg_stop_backup')
+        self.mock_pgbasebackup_init = self.get_mock_from_apply_patch('__init__')
+        self.mock_pgbasebackup_run = self.get_mock_from_apply_patch('run')
+
+        p = Segment.initFromString("1|0|p|p|s|u|sdw1|sdw1|40000|/data/primary0")
+        m = Segment.initFromString("2|0|m|m|s|u|sdw2|sdw2|50000|/data/mirror0")
+        self.seg_recovery_info = RecoveryInfo(m.getSegmentDataDirectory(),
+                                              m.getSegmentPort(),
+                                              m.getSegmentDbId(),
+                                              p.getSegmentHostName(),
+                                              p.getSegmentPort(),
+                                              p.getSegmentDataDirectory(),
+                                              False, True, '/tmp/test_progress_file')
+        self.era = '1234_20211110'
+        self.diff_recovery_cmd = gpsegrecovery.DifferentialRecovery(
+            name='test differential recovery', recovery_info=self.seg_recovery_info,
+            logger=self.mock_logger, era=self.era)
+
+    def tearDown(self):
+        super(DifferentialRecoveryRunTestCase, self).tearDown()
+
+    def _assert_rsync_runs(self):
+        self.assertEqual(3, self.mock_rsync_init.call_count)
+        self.assertEqual(3, self.mock_rsync_run.call_count)
+        self.assertEqual(call(validateAfter=True), self.mock_rsync_run.call_args)
+        expected_logger_info_args = [
+            call('Running differential recovery with progress output temporarily in /tmp/test_progress_file'),
+            call("Successfully ran differential recovery for dbid 2"),
+            call("Updating /data/mirror0/postgresql.conf")]
+        self.assertEqual(expected_logger_info_args, self.mock_logger.info.call_args_list)
+        self.mock_pgbasebackup_modifyconfsetting.assert_called_once_with(
+            'Updating %s/postgresql.conf' % self.seg_recovery_info.target_datadir,
+            "{}/{}".format(self.seg_recovery_info.target_datadir, 'postgresql.conf'),
+            'port', self.seg_recovery_info.target_port, optType='number')
+        self.assertEqual(1, self.mock_pgbasebackup_modifyconfsetting.call_count)
+        gpsegrecovery.start_segment.assert_called_once_with(self.seg_recovery_info, self.mock_logger, self.era)
+
+    def _assert_basebackup_runs(self, expected_init_args):
+        self.assertEqual(1, self.mock_pgbasebackup_init.call_count)
+        self.assertEqual(expected_init_args, self.mock_pgbasebackup_init.call_args)
+        self.assertEqual(1, self.mock_pgbasebackup_run.call_count)
+        self.assertEqual(1, self.mock_pgbasebackup_modifyconfsetting.call_count)
+        self.mock_pgbasebackup_modifyconfsetting.assert_called_once_with(
+            'Updating %s/postgresql.conf' % self.seg_recovery_info.target_datadir,
+            "{}/{}".format(self.seg_recovery_info.target_datadir, 'postgresql.conf'),
+            'port', self.seg_recovery_info.target_port, optType='number')
+        self.assertEqual(call(validateAfter=True), self.mock_pgbasebackup_run.call_args)
+        expected_logger_info_args = [call('Running differential recovery with progress output temporarily in /tmp/test_progress_file'),
+                                     call("Successfully ran differential recovery for dbid 2"),
+                                     call("Updating /data/mirror0/postgresql.conf")]
+        self.assertEqual(expected_logger_info_args, self.mock_logger.info.call_args_list)
+        gpsegrecovery.start_segment.assert_called_once_with(self.seg_recovery_info, self.mock_logger, self.era)
+
+    def _assert_cmd_passed(self):
+        self.assertEqual(0, self.diff_recovery_cmd.get_results().rc)
+        self.assertEqual('', self.diff_recovery_cmd.get_results().stdout)
+        self.assertEqual('', self.diff_recovery_cmd.get_results().stderr)
+        self.assertTrue(self.diff_recovery_cmd.get_results().wasSuccessful())
+
+    def _assert_cmd_failed(self):
+        self.assertEqual(1, self.diff_recovery_cmd.get_results().rc)
+        self.assertEqual('', self.diff_recovery_cmd.get_results().stdout)
+        self.assertEqual('', self.diff_recovery_cmd.get_results().stderr)
+        self.assertFalse(self.diff_recovery_cmd.get_results().wasSuccessful())
+
+    @patch('gpsegrecovery.DifferentialRecovery.write_conf_files', return_value=Mock())
+    @patch('gppylib.commands.unix.Rsync.__init__', return_value=None)
+    @patch('gppylib.commands.unix.Rsync.run')
+    def test_rsync_run_passes(self, run, init, mock1):
+        self.mock_rsync_run = run
+        self.mock_rsync_init = init
+        self.diff_recovery_cmd.run()
+        self._assert_rsync_runs()
+        self._assert_cmd_passed()
+
+    @patch('gppylib.commands.unix.Rsync.__init__', return_value=None)
+    @patch('gppylib.commands.unix.Rsync.run')
+    def test_basebackup_run_passes(self, mock1, mock2):
+        self.diff_recovery_cmd.run()
+        expected_init_args = call("/data/mirror0", "sdw1", '40000', writeconffilesonly=True,
+                                  target_gp_dbid=2, recovery_mode=False)
+        self._assert_basebackup_runs(expected_init_args)
+        self._assert_cmd_passed()
+
+    @patch('gppylib.commands.pg.PgReplicationSlot.slot_exists', side_effect=Exception())
+    def test_diff_recovery_slot_exists_exception(self, mock1):
+        self.diff_recovery_cmd.run()
+        self.assertEqual(1, self.mock_logger.info.call_count)
+        self.assertEqual([call('Running differential recovery with progress output temporarily in /tmp/test_progress_file')],
+                         self.mock_logger.info.call_args_list)
+
+    @patch('gppylib.commands.pg.PgReplicationSlot.drop_slot', side_effect=Exception())
+    def test_diff_recovery_drop_slot_exception(self, mock1):
+        self.diff_recovery_cmd.run()
+        self.assertEqual(1, self.mock_logger.info.call_count)
+        self.assertEqual([call('Running differential recovery with progress output temporarily in /tmp/test_progress_file')],
+                         self.mock_logger.info.call_args_list)
+
+    def test_diff_recovery_pg_start_backup_exception(self):
+        self.mock_pg_start_backup.side_effect = Exception()
+        self.diff_recovery_cmd.run()
+        self.assertEqual(1, self.mock_logger.info.call_count)
+        self.assertEqual([call('Running differential recovery with progress output temporarily in /tmp/test_progress_file')],
+                         self.mock_logger.info.call_args_list)
+
+    @patch('gppylib.commands.pg.PgReplicationSlot.create_slot', side_effect=Exception())
+    def test_diff_recovery_create_slot_exception(self, mock1):
+        self.diff_recovery_cmd.run()
+        self.assertEqual(1, self.mock_pg_stop_backup.call_count)
+        self.assertEqual(1, self.mock_logger.info.call_count)
+        self.assertEqual([call('Running differential recovery with progress output temporarily in /tmp/test_progress_file')],
+                         self.mock_logger.info.call_args_list)
+
+    @patch('gpsegrecovery.DifferentialRecovery.sync_pg_data', side_effect=Exception())
+    def test_diff_recovery_sync_pg_data_exception(self, mock1):
+        self.diff_recovery_cmd.run()
+        self.assertEqual(1, self.mock_pg_stop_backup.call_count)
+        self.assertEqual(1, self.mock_logger.info.call_count)
+        self.assertEqual(
+            [call('Running differential recovery with progress output temporarily in /tmp/test_progress_file')],
+            self.mock_logger.info.call_args_list)
+
+    def test_diff_recovery_sync_tablespaces_exception(self):
+        self.mock_sync_tablespaces.side_effect = Exception()
+        self.diff_recovery_cmd.run()
+        self.assertEqual(1, self.mock_pg_stop_backup.call_count)
+        self.assertEqual(1, self.mock_logger.debug.call_count)
+        self.assertEqual([call('Syncing pg_data of dbid 2')],
+                         self.mock_logger.debug.call_args_list)
+        self.assertEqual(1, self.mock_logger.info.call_count)
+        self.assertEqual(
+            [call('Running differential recovery with progress output temporarily in /tmp/test_progress_file')],
+            self.mock_logger.info.call_args_list)
+
+    @patch('gpsegrecovery.DifferentialRecovery.sync_pg_data', return_value=Mock())
+    def test_diff_recovery_pg_stop_backup_exception(self, mock1):
+        self.mock_pg_stop_backup.side_effect = Exception()
+        self.diff_recovery_cmd.run()
+        self.assertEqual(1, self.mock_logger.info.call_count)
+        self.assertEqual(
+            [call('Running differential recovery with progress output temporarily in /tmp/test_progress_file')],
+            self.mock_logger.info.call_args_list)
+
+    @patch('gpsegrecovery.DifferentialRecovery.sync_pg_data', return_value=Mock())
+    @patch('gpsegrecovery.DifferentialRecovery.write_conf_files', side_effect=Exception())
+    def test_diff_recovery_write_conf_files_exception(self, mock1, mock2):
+        self.diff_recovery_cmd.run()
+        self.assertEqual(1, self.mock_logger.info.call_count)
+        self.assertEqual(
+            [call('Running differential recovery with progress output temporarily in /tmp/test_progress_file')],
+            self.mock_logger.info.call_args_list)
+
+    @patch('gpsegrecovery.DifferentialRecovery.sync_pg_data', return_value=Mock())
+    @patch('gpsegrecovery.DifferentialRecovery.sync_wals_and_control_file', side_effect=Exception())
+    @patch('gpsegrecovery.DifferentialRecovery.write_conf_files', return_value=Mock())
+    def test_diff_recovery_sync_wals_and_control_file_exception(self, mock1, mock2,mock3):
+        self.diff_recovery_cmd.run()
+        self.assertEqual(1, self.mock_logger.info.call_count)
+        self.assertEqual(
+            [call('Running differential recovery with progress output temporarily in /tmp/test_progress_file')],
+            self.mock_logger.info.call_args_list)
+
+    @patch('gpsegrecovery.DifferentialRecovery.sync_pg_data', return_value=Mock())
+    @patch('gpsegrecovery.DifferentialRecovery.sync_wals_and_control_file', return_value=Mock())
+    def test_diff_recovery_modify_conf_setting_exception(self,mock1,mock2):
+        self.mock_pgbasebackup_modifyconfsetting.side_effect = [Exception('modify conf port failed'), Mock()]
+        self.diff_recovery_cmd.run()
+
+        self.assertEqual(1, self.mock_pgbasebackup_init.call_count)
+        self.assertEqual(1, self.mock_pgbasebackup_run.call_count)
+        self.mock_pgbasebackup_modifyconfsetting.assert_called_once_with('Updating %s/postgresql.conf' % self.seg_recovery_info.target_datadir,
+                                                                          "{}/{}".format(self.seg_recovery_info.target_datadir, 'postgresql.conf'),
+                                                                          'port', self.seg_recovery_info.target_port, optType='number')
+        self.assertEqual(1, self.mock_pgbasebackup_modifyconfsetting.call_count)
+        self.assertEqual(0, gpsegrecovery.start_segment.call_count)
+        self.assertEqual(2, self.mock_logger.debug.call_count)
+        self.assertEqual([call('Writing recovery.conf and internal.auto.conf files for dbid 2'),
+                          call('Running pg_basebackup to only write configuration files')],
+                         self.mock_logger.debug.call_args_list)
+        self.assertEqual(3, self.mock_logger.info.call_count)
+        self.assertEqual(
+            [call('Running differential recovery with progress output temporarily in /tmp/test_progress_file'),
+             call('Successfully ran differential recovery for dbid 2'),
+             call('Updating /data/mirror0/postgresql.conf')],
+            self.mock_logger.info.call_args_list)
+
+    @patch('gpsegrecovery.DifferentialRecovery.sync_pg_data', return_value=Mock())
+    @patch('gpsegrecovery.DifferentialRecovery.sync_wals_and_control_file', return_value=Mock())
+    def test_diff_recovery_start_segment_exception(self,mock1,mock2):
+        gpsegrecovery.start_segment.side_effect = [Exception('pg_ctl start failed'), Mock()]
+
+        self.diff_recovery_cmd.run()
+        self.assertEqual(1, self.mock_pgbasebackup_init.call_count)
+        self.assertEqual(1, self.mock_pgbasebackup_run.call_count)
+        gpsegrecovery.start_segment.assert_called_once_with(self.seg_recovery_info, self.mock_logger, self.era)
+
+    @patch('gpsegrecovery.DifferentialRecovery.sync_pg_data', return_value=Mock())
+    @patch('gpsegrecovery.DifferentialRecovery.sync_wals_and_control_file', return_value=Mock())
+    def test_diff_recovery_basebackup_run_one_exception(self,mock1,mock2):
+        self.mock_pgbasebackup_run.side_effect = [Exception('backup failed once'), Mock()]
+
+        self.diff_recovery_cmd.run()
+
+        expected_init_args = call("/data/mirror0", "sdw1", '40000', writeconffilesonly=True,
+                                  target_gp_dbid=2, recovery_mode=False)
+
+        self.assertEqual(1, self.mock_pgbasebackup_init.call_count)
+        self.assertEqual([expected_init_args], self.mock_pgbasebackup_init.call_args_list)
+        self.assertEqual(1, self.mock_pgbasebackup_run.call_count)
+        self.assertEqual([call(validateAfter=True)], self.mock_pgbasebackup_run.call_args_list)
+        self.mock_logger.info.any_call('Running pg_basebackup failed: backup failed once')
+        self.assertEqual(0, gpsegrecovery.start_segment.call_count)
+        self.assertEqual(2, self.mock_logger.debug.call_count)
+        self.assertEqual([call('Writing recovery.conf and internal.auto.conf files for dbid 2'),
+                          call('Running pg_basebackup to only write configuration files')],
+                         self.mock_logger.debug.call_args_list)
+
+    @patch('gpsegrecovery.DifferentialRecovery.sync_pg_data', return_value=Mock())
+    @patch('gpsegrecovery.DifferentialRecovery.sync_wals_and_control_file', return_value=Mock())
+    def test_diff_recovery_basebackup_init_exception(self,mock1,mock2):
+        self.mock_pgbasebackup_init.side_effect = [Exception('backup init failed')]
+
+        self.diff_recovery_cmd.run()
+        expected_init_args = call("/data/mirror0", "sdw1", '40000', writeconffilesonly=True,
+                                  target_gp_dbid=2, recovery_mode=False)
+        self.assertEqual(1, self.mock_pgbasebackup_init.call_count)
+        self.assertEqual(expected_init_args, self.mock_pgbasebackup_init.call_args)
+        self.assertEqual(0, self.mock_pgbasebackup_run.call_count)
+        self.assertEqual(0, gpsegrecovery.start_segment.call_count)
+        self.assertEqual(0, self.mock_logger.exception.call_count)
+        self.assertEqual(1, self.mock_logger.debug.call_count)
+        self.assertEqual([call('Writing recovery.conf and internal.auto.conf files for dbid 2')],
+                         self.mock_logger.debug.call_args_list)

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_recovery_base.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_recovery_base.py
@@ -31,9 +31,9 @@ class RecoveryBaseTestCase(GpTestCase):
         self.mock_enable_verbose_logging = self.get_mock_from_apply_patch('enable_verbose_logging')
 
         self.full_r1 = RecoveryInfo('target_data_dir1', 5001, 1, 'source_hostname1',
-                                    6001, True, '/tmp/progress_file1')
+                                    6001, 'source_datadir1', True, False, '/tmp/progress_file1')
         self.incr_r2 = RecoveryInfo('target_data_dir2', 5002, 2, 'source_hostname2',
-                                    6002, False, '/tmp/progress_file2')
+                                    6002, 'source_datadir2', False, False, '/tmp/progress_file2')
         self.confinfo = gppylib.recoveryinfo.serialize_list([self.full_r1,
                                                              self.incr_r2])
 
@@ -323,7 +323,7 @@ class SetCmdResultsTestCase(GpTestCase):
             cmd.error_type = 10
             raise Exception('running the cmd failed')
 
-        recovery_info = RecoveryInfo('/tmp/datadir2', 7002, 2, None, None, None, '/tmp/progress_file2')
+        recovery_info = RecoveryInfo('/tmp/datadir2', 7002, 2, None, None, None, None, None, '/tmp/progress_file2')
         test_cmd = FullRecovery('original name', recovery_info, True,None,None)
         test_decorator(test_cmd)
         self.assertEqual('new name', test_cmd.name)
@@ -338,7 +338,7 @@ class SetCmdResultsTestCase(GpTestCase):
             cmd.name = 'new name'
             cmd.error_type = None
             raise Exception('running the cmd failed')
-        recovery_info = RecoveryInfo('/tmp/datadir2', 7002, 2, None, None, None, '/tmp/progress_file2')
+        recovery_info = RecoveryInfo('/tmp/datadir2', 7002, 2, None, None, None, None, None, '/tmp/progress_file2')
         test_cmd = FullRecovery('original name', recovery_info, True,None,None)
         test_decorator(test_cmd)
         self.assertEqual('new name', test_cmd.name)

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_recoveryinfo.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_recoveryinfo.py
@@ -5,7 +5,7 @@ from gppylib.commands.base import CommandResult
 from gppylib.commands import gp
 from gppylib.gparray import Segment
 from gppylib.operations.buildMirrorSegments import GpMirrorToBuild
-from gppylib.recoveryinfo import  build_recovery_info, RecoveryInfo, RecoveryResult
+from gppylib.recoveryinfo import build_recovery_info, RecoveryInfo, RecoveryResult
 
 
 class BuildRecoveryInfoTestCase(GpTestCase):
@@ -42,85 +42,98 @@ class BuildRecoveryInfoTestCase(GpTestCase):
         # Each recoveryInfo object holds source_host (live segment), but not the target_host.
         tests = [
             {
-                "name": "single_target_host_suggest_full_and_incr",
-                "mirrors_to_build": [GpMirrorToBuild(self.m3, self.p3, None, True),
-                                     GpMirrorToBuild(self.m4, self.p4, None, False)],
-                "expected": {'sdw3': [RecoveryInfo('/data/mirror3', 7000, 7, 'sdw2', 3000,
-                                                   True, '/tmp/logdir/pg_basebackup.111.dbid7.out'),
-                                      RecoveryInfo('/data/mirror4', 8000, 8, 'sdw3', 4000,
-                                                   False, '/tmp/logdir/pg_rewind.111.dbid8.out')]}
+                "name": "single_target_host_suggest_full_and_incr_and_differential",
+                "mirrors_to_build": [GpMirrorToBuild(self.m3, self.p3, None, True, False),
+                                     GpMirrorToBuild(self.m4, self.p4, None, False, False),
+                                     GpMirrorToBuild(self.m3, self.p3, None, False, True)],
+                "expected": {'sdw3': [RecoveryInfo('/data/mirror3', 7000, 7, 'sdw2', 3000, '/data/primary3',
+                                                    True, False, '/tmp/logdir/pg_basebackup.111.dbid7.out'),
+                                      RecoveryInfo('/data/mirror4', 8000, 8, 'sdw3', 4000, '/data/primary4',
+                                                    False, False, '/tmp/logdir/pg_rewind.111.dbid8.out'),
+                                      RecoveryInfo('/data/mirror3', 7000, 7, 'sdw2', 3000, '/data/primary3',
+                                                    False, True, '/tmp/logdir/rsync.111.dbid7.out')]}
             },
             {
                 "name": "single_target_hosts_suggest_full_and_incr_with_failover",
-                "mirrors_to_build": [GpMirrorToBuild(self.m1, self.p1, self.m5, True),
-                                     GpMirrorToBuild(self.m2, self.p2, self.m6, False)],
-                "expected": {'sdw4': [RecoveryInfo('/data/mirror5', 9000, 5, 'sdw1', 1000,
-                                                   True, '/tmp/logdir/pg_basebackup.111.dbid5.out'),
-                                      RecoveryInfo('/data/mirror6', 10000, 6, 'sdw2', 2000,
-                                                   True, '/tmp/logdir/pg_basebackup.111.dbid6.out')]}
+                "mirrors_to_build": [GpMirrorToBuild(self.m1, self.p1, self.m5, True, False),
+                                     GpMirrorToBuild(self.m2, self.p2, self.m6, False, False)],
+                "expected": {'sdw4': [RecoveryInfo('/data/mirror5', 9000, 5, 'sdw1', 1000, '/data/primary1',
+                                                    True, False, '/tmp/logdir/pg_basebackup.111.dbid5.out'),
+                                      RecoveryInfo('/data/mirror6', 10000, 6, 'sdw2', 2000, '/data/primary2',
+                                                    True, False, '/tmp/logdir/pg_basebackup.111.dbid6.out')]}
             },
             {
                 "name": "multiple_target_hosts_suggest_full",
-                "mirrors_to_build": [GpMirrorToBuild(self.m1, self.p1, None, True),
-                                     GpMirrorToBuild(self.m2, self.p2, None, True)],
-                "expected": {'sdw2': [RecoveryInfo('/data/mirror1', 5000, 5, 'sdw1', 1000,
-                                                  True, '/tmp/logdir/pg_basebackup.111.dbid5.out')],
-                             'sdw1': [RecoveryInfo('/data/mirror2', 6000, 6, 'sdw2', 2000,
-                                                  True, '/tmp/logdir/pg_basebackup.111.dbid6.out')]}
+                "mirrors_to_build": [GpMirrorToBuild(self.m1, self.p1, None, True, False),
+                                     GpMirrorToBuild(self.m2, self.p2, None, True, False)],
+                "expected": {'sdw2': [RecoveryInfo('/data/mirror1', 5000, 5, 'sdw1', 1000, '/data/primary1',
+                                                    True, False, '/tmp/logdir/pg_basebackup.111.dbid5.out')],
+                             'sdw1': [RecoveryInfo('/data/mirror2', 6000, 6, 'sdw2', 2000, '/data/primary2',
+                                                    True, False, '/tmp/logdir/pg_basebackup.111.dbid6.out')]}
             },
             {
-                "name": "multiple_target_hosts_suggest_full_and_incr",
-                "mirrors_to_build": [GpMirrorToBuild(self.m1, self.p1, None, True),
-                                     GpMirrorToBuild(self.m3, self.p3, None, False),
-                                     GpMirrorToBuild(self.m4, self.p4, None, True)],
-                "expected": {'sdw2': [RecoveryInfo('/data/mirror1', 5000, 5, 'sdw1', 1000,
-                                                   True, '/tmp/logdir/pg_basebackup.111.dbid5.out')],
-                             'sdw3': [RecoveryInfo('/data/mirror3', 7000, 7, 'sdw2', 3000,
-                                                   False, '/tmp/logdir/pg_rewind.111.dbid7.out'),
-                                      RecoveryInfo('/data/mirror4', 8000, 8, 'sdw3', 4000,
-                                                   True, '/tmp/logdir/pg_basebackup.111.dbid8.out')]}
+                "name": "multiple_target_hosts_suggest_differential",
+                "mirrors_to_build": [GpMirrorToBuild(self.m1, self.p1, None, False, True),
+                                     GpMirrorToBuild(self.m2, self.p2, None, False, True)],
+                "expected": {'sdw2': [RecoveryInfo('/data/mirror1', 5000, 5, 'sdw1', 1000, '/data/primary1',
+                                                   False, True, '/tmp/logdir/rsync.111.dbid5.out')],
+                             'sdw1': [RecoveryInfo('/data/mirror2', 6000, 6, 'sdw2', 2000, '/data/primary2',
+                                                   False, True, '/tmp/logdir/rsync.111.dbid6.out')]}
+            },
+            {
+                "name": "multiple_target_hosts_suggest_full_and_incr_and_differential",
+                "mirrors_to_build": [GpMirrorToBuild(self.m1, self.p1, None, True, False),
+                                     GpMirrorToBuild(self.m3, self.p3, None, False, False),
+                                     GpMirrorToBuild(self.m4, self.p4, None, True, False),
+                                     GpMirrorToBuild(self.m2, self.p2, None, False, True)],
+                "expected": {'sdw2': [RecoveryInfo('/data/mirror1', 5000, 5, 'sdw1', 1000, '/data/primary1',
+                                                    True, False, '/tmp/logdir/pg_basebackup.111.dbid5.out')],
+                             'sdw3': [RecoveryInfo('/data/mirror3', 7000, 7, 'sdw2', 3000, '/data/primary3',
+                                                    False, False, '/tmp/logdir/pg_rewind.111.dbid7.out'),
+                                      RecoveryInfo('/data/mirror4', 8000, 8, 'sdw3', 4000, '/data/primary4',
+                                                    True, False, '/tmp/logdir/pg_basebackup.111.dbid8.out')],
+                             'sdw1': [RecoveryInfo('/data/mirror2', 6000, 6, 'sdw2', 2000, '/data/primary2',
+                                                   False, True, '/tmp/logdir/rsync.111.dbid6.out'),]}
             },
             {
                 "name": "multiple_target_hosts_suggest_incr_failover_same_as_failed",
-                "mirrors_to_build": [GpMirrorToBuild(self.m1, self.p1, self.m1, False),
-                                     GpMirrorToBuild(self.m2, self.p2, self.m2, False)],
-                "expected": {'sdw2': [RecoveryInfo('/data/mirror1', 5000, 5, 'sdw1', 1000,
-                                                  True, '/tmp/logdir/pg_basebackup.111.dbid5.out')],
-                             'sdw1': [RecoveryInfo('/data/mirror2', 6000, 6, 'sdw2', 2000,
-                                                  True, '/tmp/logdir/pg_basebackup.111.dbid6.out')]}
+                "mirrors_to_build": [GpMirrorToBuild(self.m1, self.p1, self.m1, False, False),
+                                     GpMirrorToBuild(self.m2, self.p2, self.m2, False, False)],
+                "expected": {'sdw2': [RecoveryInfo('/data/mirror1', 5000, 5, 'sdw1', 1000, '/data/primary1',
+                                                    True, False, '/tmp/logdir/pg_basebackup.111.dbid5.out')],
+                             'sdw1': [RecoveryInfo('/data/mirror2', 6000, 6, 'sdw2', 2000, '/data/primary2',
+                                                    True, False, '/tmp/logdir/pg_basebackup.111.dbid6.out')]}
             },
             {
                 "name": "multiple_target_hosts_suggest_full_failover_same_as_failed",
-                "mirrors_to_build": [GpMirrorToBuild(self.m1, self.p1, self.m1, True),
-                                     GpMirrorToBuild(self.m3, self.p3, self.m3, True),
-                                     GpMirrorToBuild(self.m4, self.p4, None, True)],
-                "expected": {'sdw2': [RecoveryInfo('/data/mirror1', 5000, 5, 'sdw1', 1000,
-                                                  True, '/tmp/logdir/pg_basebackup.111.dbid5.out')],
-                             'sdw3': [RecoveryInfo('/data/mirror3', 7000, 7, 'sdw2', 3000,
-                                                   True, '/tmp/logdir/pg_basebackup.111.dbid7.out'),
-                                      RecoveryInfo('/data/mirror4', 8000, 8, 'sdw3', 4000,
-                                                   True, '/tmp/logdir/pg_basebackup.111.dbid8.out')]}
+                "mirrors_to_build": [GpMirrorToBuild(self.m1, self.p1, self.m1, True, False),
+                                     GpMirrorToBuild(self.m3, self.p3, self.m3, True, False),
+                                     GpMirrorToBuild(self.m4, self.p4, None, True, False)],
+                "expected": {'sdw2': [RecoveryInfo('/data/mirror1', 5000, 5, 'sdw1', 1000, '/data/primary1',
+                                                    True, False, '/tmp/logdir/pg_basebackup.111.dbid5.out')],
+                             'sdw3': [RecoveryInfo('/data/mirror3', 7000, 7, 'sdw2', 3000, '/data/primary3',
+                                                    True, False, '/tmp/logdir/pg_basebackup.111.dbid7.out'),
+                                      RecoveryInfo('/data/mirror4', 8000, 8, 'sdw3', 4000, '/data/primary4',
+                                                    True, False, '/tmp/logdir/pg_basebackup.111.dbid8.out')]}
             },
             {
                 "name": "multiple_target_hosts_suggest_full_and_incr",
-                "mirrors_to_build": [GpMirrorToBuild(self.m1, self.p1, self.m5, True),
-                                     GpMirrorToBuild(self.m2, self.p2, None, False),
-                                     GpMirrorToBuild(self.m3, self.p3, self.m3, False),
-                                     GpMirrorToBuild(self.m4, self.p4, self.m8, True)],
-                "expected": {'sdw4': [RecoveryInfo('/data/mirror5', 9000, 5, 'sdw1', 1000,
-                                                   True, '/tmp/logdir/pg_basebackup.111.dbid5.out'),
+                "mirrors_to_build": [GpMirrorToBuild(self.m1, self.p1, self.m5, True, False),
+                                     GpMirrorToBuild(self.m2, self.p2, None, False, False),
+                                     GpMirrorToBuild(self.m3, self.p3, self.m3, False, False),
+                                     GpMirrorToBuild(self.m4, self.p4, self.m8, True, False)],
+                "expected": {'sdw4': [RecoveryInfo('/data/mirror5', 9000, 5, 'sdw1', 1000, '/data/primary1',
+                                                    True, False, '/tmp/logdir/pg_basebackup.111.dbid5.out'),
                                       ],
-                             'sdw1': [RecoveryInfo('/data/mirror2', 6000, 6,
-                                                   'sdw2', 2000, False,
-                                                   '/tmp/logdir/pg_rewind.111.dbid6.out'),
+                             'sdw1': [RecoveryInfo('/data/mirror2', 6000, 6, 'sdw2', 2000, '/data/primary2',
+                                                    False, False, '/tmp/logdir/pg_rewind.111.dbid6.out'),
                                       RecoveryInfo('/data/mirror8', 12000, 8,
-                                                   'sdw3', 4000, True,
-                                                   '/tmp/logdir/pg_basebackup.111.dbid8.out')],
-                             'sdw3': [RecoveryInfo('/data/mirror3', 7000, 7, 'sdw2', 3000,
-                                                   True, '/tmp/logdir/pg_basebackup.111.dbid7.out')]
+                                                    'sdw3', 4000, '/data/primary4', True, False,
+                                                    '/tmp/logdir/pg_basebackup.111.dbid8.out')],
+                             'sdw3': [RecoveryInfo('/data/mirror3', 7000, 7, 'sdw2', 3000, '/data/primary3',
+                                                     True, False, '/tmp/logdir/pg_basebackup.111.dbid7.out')]
                              }
             },
-
         ]
         self.run_tests(tests)
 
@@ -288,7 +301,7 @@ class RecoveryResultTestCase(GpTestCase):
                                '{"error_type": "incremental", "error_msg":"some error for dbid 3", "dbid": 3, "datadir": "/datadir3", "port": 7003, "progress_file": "/tmp/progress3"}]',
                 "host2_error": '[{"error_type": "incremental", "error_msg":"some error for dbid 4", "dbid": 4, "datadir": "/datadir4", "port": 7005, "progress_file": "/tmp/progress4"}]',
                 "expected_info_msgs": [call(Contains('-----')),
-                                       call('Failed to action_recover the following segments. You must run gprecoverseg -F for all incremental failures'),
+                                       call('Failed to action_recover the following segments. You must run either gprecoverseg --differential or gprecoverseg -F for all incremental failures'),
                                        call(self._msg('host1', 7001, logfile='/tmp/progress2', type='incremental')),
                                        call(self._msg('host1', 7003, logfile='/tmp/progress3', type='incremental')),
                                        call(self._msg('host2', 7005, logfile='/tmp/progress4', type='incremental'))],
@@ -299,27 +312,46 @@ class RecoveryResultTestCase(GpTestCase):
                 "dbids_that_failed_bb_rewind": [2, 3, 4]
             },
             {
-                "name": "run_recovery_all_dbids_fail_only_bb_rewind_errors",
+                "name": "run_recovery_all_dbids_fail_only_differential_errors",
+                "host1_error": '[{"error_type": "differential", "error_msg":"some error for dbid 2", "dbid": 2, "datadir": "/datadir2", "port": 7001, "progress_file": "/tmp/progress2"}, ' \
+                               '{"error_type": "differential", "error_msg":"some error for dbid 3", "dbid": 3, "datadir": "/datadir3", "port": 7003, "progress_file": "/tmp/progress3"}]',
+                "host2_error": '[{"error_type": "differential", "error_msg":"some error for dbid 4", "dbid": 4, "datadir": "/datadir4", "port": 7005, "progress_file": "/tmp/progress4"}]',
+                "expected_info_msgs": [call(Contains('-----')),
+                                       call(
+                                           'Failed to action_recover the following segments. You must run either gprecoverseg --differential or gprecoverseg -F for all differential failures'),
+                                       call(self._msg('host1', 7001, logfile='/tmp/progress2', type='differential')),
+                                       call(self._msg('host1', 7003, logfile='/tmp/progress3', type='differential')),
+                                       call(self._msg('host2', 7005, logfile='/tmp/progress4', type='differential'))],
+                "expected_error_msgs": [],
+                "setup_successful": True,
+                "full_recovery_successful": True,
+                "recovery_successful": False,
+                "dbids_that_failed_bb_rewind": [2, 3, 4]
+            },
+            {
+                "name": "run_recovery_all_dbids_fail_only_bb_rewind_differential_errors",
                 "host1_error": '[{"error_type": "full", "error_msg":"some error for dbid 2", "dbid": 2, "datadir": "/datadir2", "port": 7001, "progress_file": "/tmp/progress2"}, ' \
                               '{"error_type": "incremental", "error_msg":"some error for dbid 3", "dbid": 3, "datadir": "/datadir3", "port": 7003, "progress_file": "/tmp/progress3"}]',
-                "host2_error": '[{"error_type": "full", "error_msg":"some error for dbid 4", "dbid": 4, "datadir": "/datadir4", "port": 7005, "progress_file": "/tmp/progress4"}]',
+                "host2_error": '[{"error_type": "full", "error_msg":"some error for dbid 4", "dbid": 4, "datadir": "/datadir4", "port": 7005, "progress_file": "/tmp/progress4"},'
+                               '{"error_type": "differential", "error_msg":"some error for dbid 5", "dbid": 5, "datadir": "/datadir5", "port": 7006, "progress_file": "/tmp/progress5"}]',
                 "expected_info_msgs": [call(Contains('-----')),
-                                       call(Contains('Failed to action_recover the following segments. You must run gprecoverseg -F for all incremental failures')),
+                                       call(Contains('Failed to action_recover the following segments. You must run either gprecoverseg --differential or gprecoverseg -F for all incremental failures')),
                                        call(self._msg('host1', 7003, logfile='/tmp/progress3', type='incremental')),
+                                       call(self._msg('host2', 7006, logfile='/tmp/progress5', type='differential')),
                                        call(self._msg('host1', 7001, logfile='/tmp/progress2', type='full')),
                                        call(self._msg('host2', 7005, logfile='/tmp/progress4', type='full'))],
                 "expected_error_msgs": [],
                 "setup_successful": True,
                 "full_recovery_successful": False,
                 "recovery_successful": False,
-                "dbids_that_failed_bb_rewind": [2, 3, 4]
+                "dbids_that_failed_bb_rewind": [2, 3, 4, 5]
             },
             {
                 "name": "run_recovery_some_dbids_fail_only_bb_rewind_errors",
                 "host1_error": '[{"error_type": "incremental", "error_msg":"some error for dbid 2", "dbid": 2, "datadir": "/datadir2", "port": 7001, "progress_file": "/tmp/progress2"}]',
                 "host2_error": '[{"error_type": "full", "error_msg":"some error for dbid 4", "dbid": 4, "datadir": "/datadir4", "port": 7005, "progress_file": "/tmp/progress4"}]',
                 "expected_info_msgs": [call(Contains('-----')),
-                                       call(Contains('Failed to action_recover the following segments. You must run gprecoverseg -F for all incremental failures')),
+                                       call(Contains('Failed to action_recover the following segments. You must run either gprecoverseg --differential or gprecoverseg -F for all incremental failures')),
                                        call(self._msg('host1', 7001, logfile='/tmp/progress2', type='incremental')),
                                        call(self._msg('host2', 7005, logfile='/tmp/progress4', type='full'))],
                 "expected_error_msgs": [],
@@ -362,9 +394,11 @@ class RecoveryResultTestCase(GpTestCase):
                 "name": "run_recovery_all_dbids_fail_both_recovery_and_start_errors",
                 "host1_error": '[{"error_type": "full",  "error_msg":"some error for dbid 2", "dbid": 2, "datadir": "/datadir2", "port": 7001, "progress_file": "/tmp/progress2"}, ' \
                               '{"error_type": "start",  "error_msg":"some error for dbid 3", "dbid": 3, "datadir": "/datadir3", "port": 7003, "progress_file": "/tmp/progress3"}]',
-                "host2_error": '[{"error_type": "full",  "error_msg":"some error for dbid 4", "dbid": 4, "datadir": "/datadir4", "port": 7005, "progress_file": "/tmp/progress4"}]',
+                "host2_error": '[{"error_type": "full",  "error_msg":"some error for dbid 4", "dbid": 4, "datadir": "/datadir4", "port": 7005, "progress_file": "/tmp/progress4"},'
+                               '{"error_type": "differential", "error_msg":"some error for dbid 5", "dbid": 5, "datadir": "/datadir5", "port": 7006, "progress_file": "/tmp/progress5"}]',
                 "expected_info_msgs": [call(Contains('-----')),
                                        call(Contains('Failed to action_recover the following segments')),
+                                       call(self._msg('host2', 7006, logfile='/tmp/progress5', type='differential')),
                                        call(self._msg('host1', 7001, logfile='/tmp/progress2', type='full')),
                                        call(self._msg('host2', 7005, logfile='/tmp/progress4', type='full')),
                                        call(Contains('-----')),
@@ -374,7 +408,7 @@ class RecoveryResultTestCase(GpTestCase):
                 "setup_successful": True,
                 "full_recovery_successful": False,
                 "recovery_successful": False,
-                "dbids_that_failed_bb_rewind": [2, 4]
+                "dbids_that_failed_bb_rewind": [2, 4, 5]
             },
             {
                 "name": "run_recovery_all_dbids_fail_both_recovery_and_default_errors",
@@ -427,9 +461,11 @@ class RecoveryResultTestCase(GpTestCase):
                 "name": "run_recovery_some_dbids_fail_recovery_and_update_errors",
                 "host1_error": '[{"error_type": "full",  "error_msg":"some error for dbid 2", "dbid": 2, "datadir": "/datadir2", "port": 7001, "progress_file": "/tmp/progress2"}, ' \
                                '{"error_type": "default",  "error_msg":"some error for dbid 3", "dbid": 3, "datadir": "/datadir3", "port": 7003, "progress_file": "/tmp/progress3"}]',
-                "host2_error": '[{"error_type": "update", "error_msg":"some error for dbid 4", "dbid": 4, "datadir": "/datadir4", "port": 7005, "progress_file": "/tmp/progress4"}]',
+                "host2_error": '[{"error_type": "update", "error_msg":"some error for dbid 4", "dbid": 4, "datadir": "/datadir4", "port": 7005, "progress_file": "/tmp/progress4"},'
+                               '{"error_type": "differential", "error_msg":"some error for dbid 5", "dbid": 5, "datadir": "/datadir5", "port": 7006, "progress_file": "/tmp/progress5"}]',
                 "expected_info_msgs": [call(Contains('-----')),
                                        call(Contains('Failed to action_recover the following segments')),
+                                       call(self._msg('host2', 7006, logfile='/tmp/progress5', type='differential')),
                                        call(self._msg('host1', 7001, logfile='/tmp/progress2', type='full')),
                                        call(Contains('-----')),
                                        call(Contains('Did not start the following segments due to failure while updating the port.')),
@@ -438,7 +474,7 @@ class RecoveryResultTestCase(GpTestCase):
                 "setup_successful": True,
                 "full_recovery_successful": False,
                 "recovery_successful": False,
-                "dbids_that_failed_bb_rewind": [2]
+                "dbids_that_failed_bb_rewind": [2, 5]
             },
         ]
         self.run_tests(tests, run_recovery=True)
@@ -467,7 +503,7 @@ class RecoveryResultTestCase(GpTestCase):
                 self.assertEqual(r.recovery_successful(), test["recovery_successful"])
 
                 if run_recovery:
-                    r.print_bb_rewind_update_and_start_errors()
+                    r.print_bb_rewind_differential_update_and_start_errors()
                 else:
                     r.print_setup_recovery_errors()
 
@@ -476,7 +512,7 @@ class RecoveryResultTestCase(GpTestCase):
 
                 dbids_that_failed_bb_rewind = test.get("dbids_that_failed_bb_rewind", [])
                 for failed_dbid in dbids_that_failed_bb_rewind:
-                    self.assertFalse(r.was_bb_rewind_successful(failed_dbid))
+                    self.assertFalse(r.was_bb_rewind_rsync_successful(failed_dbid))
                 dbids_that_passed_bb_rewind = self.all_dbids - set(dbids_that_failed_bb_rewind)
                 for pass_dbid in dbids_that_passed_bb_rewind:
-                    self.assertTrue(r.was_bb_rewind_successful(pass_dbid))
+                    self.assertTrue(r.was_bb_rewind_rsync_successful(pass_dbid))

--- a/gpMgmt/doc/gprecoverseg_help
+++ b/gpMgmt/doc/gprecoverseg_help
@@ -10,7 +10,7 @@ Synopsis
 gprecoverseg [-p <new_recover_host>[,...]]
              |-i <recover_config_file> 
              [-d <coordinator_data_directory>]
-             [-B <batch_size>] [-b <segment_batch_size>]
+             [-B <batch_size>] [-b <segment_batch_size>] [--differential]
              [-F] [-a] [-q] [-s] [--no-progress] [-l <logfile_directory>]
 
 
@@ -137,6 +137,12 @@ Optional. Perform a full copy of the active segment instance
 in order to recover the failed segment. The default is to 
 only copy over the incremental changes that occurred while 
 the segment was down.
+
+--differential
+
+Optional. Perform a differential copy of the active segment instance
+in order to recover the failed segment. The default is to only copy
+over the incremental changes that occurred while the segment was down.
 
 
 -i <recover_config_file>

--- a/gpMgmt/sbin/gpsegrecovery.py
+++ b/gpMgmt/sbin/gpsegrecovery.py
@@ -12,7 +12,7 @@ from gppylib.commands.gp import SegmentStart
 from gppylib.gparray import Segment
 from gppylib.commands.gp import ModifyConfSetting
 from gppylib.db.catalog import RemoteQueryCommand
-from gppylib.programs.clsRecoverSegment_triples import is_backup_in_progress
+from gppylib.operations.get_segments_in_recovery import is_seg_in_backup_mode
 from gppylib.operations.segment_tablespace_locations import get_segment_tablespace_locations
 
 
@@ -121,7 +121,7 @@ class DifferentialRecovery(Command):
         finally:
             # Backup is completed, now run pg_stop_backup which will also remove backup_label file from
             # primary data_dir
-            if is_backup_in_progress(self.recovery_info.source_hostname, self.recovery_info.source_port):
+            if is_seg_in_backup_mode(self.recovery_info.source_hostname, self.recovery_info.source_port):
                 self.pg_stop_backup()
 
         """ Write the postresql.auto.conf and internal.auto.conf files """
@@ -196,7 +196,7 @@ class DifferentialRecovery(Command):
         # os.path.join(dir, "") will append a '/' at the end of dir. When using "/" at the end of source,
         # rsync will copy the content of the last directory. When not using "/" at the end of source, rsync
         # will copy the last directory and the content of the directory.
-        cmd = Rsync(name="Sync pg_data dir", srcFile=os.path.join(self.recovery_info.source_datadir, ""),
+        cmd = Rsync(name="Sync pg data_dir", srcFile=os.path.join(self.recovery_info.source_datadir, ""),
                     dstFile=self.recovery_info.target_datadir,
                     srcHost=self.recovery_info.source_hostname, exclude_list=rsync_exclude_list,
                     delete=True, checksum=True, progress=True, progress_file=self.recovery_info.progress_file)

--- a/gpMgmt/sbin/gpsegrecovery.py
+++ b/gpMgmt/sbin/gpsegrecovery.py
@@ -1,12 +1,19 @@
 #!/usr/bin/env python3
 
+import os
+import sys
+
 from gppylib.recoveryinfo import RecoveryErrorType
-from gppylib.commands.pg import PgBaseBackup, PgRewind
+from gppylib.commands.pg import PgBaseBackup, PgRewind, PgReplicationSlot
+from gppylib.commands.unix import Rsync
 from recovery_base import RecoveryBase, set_recovery_cmd_results
-from gppylib.commands.base import Command
+from gppylib.commands.base import Command, LOCAL
 from gppylib.commands.gp import SegmentStart
 from gppylib.gparray import Segment
 from gppylib.commands.gp import ModifyConfSetting
+from gppylib.db.catalog import RemoteQueryCommand
+from gppylib.programs.clsRecoverSegment_triples import is_backup_in_progress
+from gppylib.operations.segment_tablespace_locations import get_segment_tablespace_locations
 
 
 class FullRecovery(Command):
@@ -77,6 +84,205 @@ class IncrementalRecovery(Command):
         start_segment(self.recovery_info, self.logger, self.era)
 
 
+class DifferentialRecovery(Command):
+    def __init__(self, name, recovery_info, logger, era):
+        self.name = name
+        self.recovery_info = recovery_info
+        self.era = era
+        self.logger = logger
+        self.error_type = RecoveryErrorType.DEFAULT_ERROR
+        self.replication_slot = PgReplicationSlot(self.recovery_info.source_hostname, self.recovery_info.source_port,
+                                                  'internal_wal_replication_slot')
+
+    @set_recovery_cmd_results
+    def run(self):
+
+        self.logger.info("Running differential recovery with progress output temporarily in {}".format(
+            self.recovery_info.progress_file))
+        self.error_type = RecoveryErrorType.DIFFERENTIAL_ERROR
+
+        """ Drop replication slot 'internal_wal_replication_slot' """
+        if self.replication_slot.slot_exists() and not self.replication_slot.drop_slot():
+            raise Exception("Failed to drop replication slot")
+
+        """ start backup with label differential_backup """
+        self.pg_start_backup()
+
+        try:
+            if not self.replication_slot.create_slot():
+                raise Exception("Failed to create replication slot")
+
+            """ rsync pg_data and tablespace directories including all the WAL files """
+            self.sync_pg_data()
+
+            """ rsync tablespace directories which are out of pg-data-directory """
+            self.sync_tablespaces()
+
+        finally:
+            # Backup is completed, now run pg_stop_backup which will also remove backup_label file from
+            # primary data_dir
+            if is_backup_in_progress(self.recovery_info.source_hostname, self.recovery_info.source_port):
+                self.pg_stop_backup()
+
+        """ Write the postresql.auto.conf and internal.auto.conf files """
+        self.write_conf_files()
+
+        """ sync pg_wal directory and pg_control file just before starting the segment """
+        self.sync_wals_and_control_file()
+
+        self.logger.info(
+            "Successfully ran differential recovery for dbid {}".format(self.recovery_info.target_segment_dbid))
+
+        """ Updating port number on conf after recovery """
+        self.error_type = RecoveryErrorType.UPDATE_ERROR
+        update_port_in_conf(self.recovery_info, self.logger)
+
+        self.error_type = RecoveryErrorType.START_ERROR
+        start_segment(self.recovery_info, self.logger, self.era)
+
+    def sync_pg_data(self):
+        self.logger.debug('Syncing pg_data of dbid {}'.format(self.recovery_info.target_segment_dbid))
+
+        """
+            rsync_exclude_list:
+            1. List containing directories and files that should be excluded while taking backup. This list is prepared
+               based on excludeDirContents and excludeFiles consts from postgres source file src/backend/backup/basebackup.c
+            
+            2. backup_label is present in excludeFiles list in src/backend/backup/basebackup.c as in case of 
+               pg_basebackup, pg_start_backup() is queried in non-exclusive mode. pg_start_backup() in non-exclusive 
+               mode does not create backup_label file so the backup_label (if present) belongs to other user who ran 
+               pg_start_backup() in exclusive mode. backup_label is required by mirror to retrieve the wal location it 
+               has to replay wals from so it's sent to mirror with tar files.
+            
+            3. backup_label has not been added in rsync_exclude_list that means it is sent to mirror during pg_data sync. 
+               Reasons behind not excluding backup_label from pg_data sync:
+                1. pg_start_backup() is executed in exclusive mode only by differential recovery which creates
+                   backup_label on primary.
+                2. So It's safe to copy backup_label file to mirror knowing that it is created by differential recovery 
+                   as no other greenplum utility executes pg_start_backup() in exclusive mode at present.
+                   
+            4. In future we will have to add backup_label in rsync_exclude_list if pg_start_backup needs be started in
+               non-exclusive mode for differential recovery.
+        """
+        rsync_exclude_list = [
+            "/log",  # logs are segment specific so it can be skipped
+            "pgsql_tmp",
+            "postgresql.auto.conf.tmp",
+            "current_logfiles.tmp",
+            "postmaster.pid",
+            "postmaster.opts",
+            "pg_dynshmem",
+            "pg_notify/*",
+            "pg_replslot/*",
+            "pg_serial/*",
+            "pg_stat_tmp/*",
+            "pg_snapshots/*",
+            "pg_subtrans/*",
+            "backups/*",
+            "/db_dumps",  # as we exclude during pg_basebackup
+            "/promote",  # Need to check why do we exclude it during pg_basebackup
+        ]
+        """
+            Rsync options used:
+                srcFile: source datadir
+                dstFile: destination datadir or file that needs to be synced
+                srcHost: source host
+                exclude_list: to exclude specified files and directories to copied or synced with target
+                delete: delete the files on target which does not exist on source
+                checksum: to skip files being synced based on checksum, not modification time and size
+                progress: to show the progress of rsync execution, like % transferred
+        """
+
+        # os.path.join(dir, "") will append a '/' at the end of dir. When using "/" at the end of source,
+        # rsync will copy the content of the last directory. When not using "/" at the end of source, rsync
+        # will copy the last directory and the content of the directory.
+        cmd = Rsync(name="Sync pg_data dir", srcFile=os.path.join(self.recovery_info.source_datadir, ""),
+                    dstFile=self.recovery_info.target_datadir,
+                    srcHost=self.recovery_info.source_hostname, exclude_list=rsync_exclude_list,
+                    delete=True, checksum=True, progress=True, progress_file=self.recovery_info.progress_file)
+        cmd.run(validateAfter=True)
+
+    def pg_start_backup(self):
+        sql = "SELECT pg_start_backup('differential_backup');"
+        try:
+            RemoteQueryCommand("Start backup", sql, self.recovery_info.source_hostname,
+                               self.recovery_info.source_port).run()
+        except Exception as e:
+            raise Exception("Failed to query pg_start_backup() for segment with host {} and port {} : {}".format(
+                self.recovery_info.source_hostname,
+                self.recovery_info.source_port, str(e)))
+        self.logger.debug("Successfully ran pg_start_backup for segment on host {}, port {}".
+                          format(self.recovery_info.source_hostname, self.recovery_info.source_port))
+
+    def pg_stop_backup(self):
+        sql = "SELECT pg_stop_backup();"
+        try:
+            RemoteQueryCommand("Stop backup", sql, self.recovery_info.source_hostname,
+                               self.recovery_info.source_port).run()
+        except Exception as e:
+            raise Exception("Failed to query pg_stop_backup() for segment with host {} and port {} : {}".
+                            format(self.recovery_info.source_hostname, self.recovery_info.source_port, str(e)))
+
+        self.logger.debug("Successfully ran pg_stop_backup for segment on host {}, port {}".
+                          format(self.recovery_info.source_hostname, self.recovery_info.source_port))
+
+    def write_conf_files(self):
+        self.logger.debug(
+            "Writing recovery.conf and internal.auto.conf files for dbid {}".format(
+                self.recovery_info.target_segment_dbid))
+        cmd = PgBaseBackup(self.recovery_info.target_datadir,
+                           self.recovery_info.source_hostname,
+                           str(self.recovery_info.source_port),
+                           writeconffilesonly=True,
+                           target_gp_dbid=self.recovery_info.target_segment_dbid,
+                           recovery_mode=False)
+        self.logger.debug("Running pg_basebackup to only write configuration files")
+        cmd.run(validateAfter=True)
+
+    def sync_wals_and_control_file(self):
+        self.logger.debug("Syncing pg_wal directory of dbid {}".format(self.recovery_info.target_segment_dbid))
+        # os.path.join(dir, "") will append a '/' at the end of dir. When using "/" at the end of source,
+        # rsync will copy the content of the last directory. When not using "/" at the end of source, rsync
+        # will copy the last directory and the content of the directory.
+        cmd = Rsync(name="Sync pg_wal files", srcFile=os.path.join(self.recovery_info.source_datadir, "pg_wal", ""),
+                    dstFile=os.path.join(self.recovery_info.target_datadir, "pg_wal", ""), progress=True, checksum=True,
+                    srcHost=self.recovery_info.source_hostname,
+                    progress_file=self.recovery_info.progress_file)
+        cmd.run(validateAfter=True)
+
+        self.logger.debug("Syncing pg_control file of dbid {}".format(self.recovery_info.target_segment_dbid))
+        cmd = Rsync(name="Sync pg_control file",
+                    srcFile=os.path.join(self.recovery_info.source_datadir, "global", "pg_control"),
+                    dstFile=os.path.join(self.recovery_info.target_datadir, "global", "pg_control"), progress=True,
+                    checksum=True,
+                    srcHost=self.recovery_info.source_hostname, progress_file=self.recovery_info.progress_file)
+        cmd.run(validateAfter=True)
+
+    def sync_tablespaces(self):
+        self.logger.debug(
+            "Syncing tablespaces of dbid {} which are outside of data_dir".format(
+                self.recovery_info.target_segment_dbid))
+
+        # get the tablespace locations
+        tablespaces = get_segment_tablespace_locations(self.recovery_info.source_hostname,
+                                                       self.recovery_info.source_port)
+
+        for tablespace_location in tablespaces:
+            if tablespace_location[0].startswith(self.recovery_info.target_datadir):
+                continue
+            # os.path.join(dir, "") will append a '/' at the end of dir. When using "/" at the end of source,
+            # rsync will copy the content of the last directory. When not using "/" at the end of source, rsync
+            # will copy the last directory and the content of the directory.
+            cmd = Rsync(name="Sync tablespace",
+                        srcFile=os.path.join(tablespace_location[0], ""),
+                        dstFile=tablespace_location[0],
+                        srcHost=self.recovery_info.source_hostname,
+                        progress=True,
+                        checksum=True,
+                        progress_file=self.recovery_info.progress_file)
+            cmd.run(validateAfter=True)
+
+
 def start_segment(recovery_info, logger, era):
     seg = Segment(None, None, None, None, None, None, None, None,
                   recovery_info.target_port, recovery_info.target_datadir)
@@ -118,11 +324,17 @@ class SegRecovery(object):
                                    forceoverwrite=forceoverwrite,
                                    logger=logger,
                                    era=era)
+            elif seg_recovery_info.is_differential_recovery:
+                cmd = DifferentialRecovery(name='Run rsync',
+                                           recovery_info=seg_recovery_info,
+                                           logger=logger,
+                                           era=era)
             else:
                 cmd = IncrementalRecovery(name='Run pg_rewind',
                                           recovery_info=seg_recovery_info,
                                           logger=logger,
                                           era=era)
+
             cmd_list.append(cmd)
         return cmd_list
 

--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -1,45 +1,114 @@
 @gprecoverseg
 Feature: gprecoverseg tests
 
-    Scenario: incremental recovery works with tablespaces
+    Scenario Outline: <scenario> recovery works with tablespaces
         Given the database is running
           And a tablespace is created with data
           And user stops all primary processes
           And user can start transactions
+         When the user runs "gprecoverseg <args>"
+         Then gprecoverseg should return a return code of 0
+          And the segments are synchronized
+          And the tablespace is valid
+
+        Given another tablespace is created with data
+         When the user runs "gprecoverseg -ra"
+         Then gprecoverseg should return a return code of 0
+          And the segments are synchronized
+          And the tablespace is valid
+          And the other tablespace is valid
+      Examples:
+        | scenario     | args               |
+        | incremental  | -a                 |
+        | differential | -a --differential  |
+        | full         | -aF                |
+
+
+    @demo_cluster
+    @concourse_cluster
+    Scenario: differential recovery runs successfully
+        Given the database is running
+          And the segments are synchronized
+          And verify replication slot internal_wal_replication_slot is available on all the segments
+          And user stops all primary processes
+          And user can start transactions
+         When the user runs "gprecoverseg -av --differential"
+         Then gprecoverseg should return a return code of 0
+          And gprecoverseg should print "Successfully dropped replication slot internal_wal_replication_slot" to stdout
+          And gprecoverseg should print "Successfully created replication slot internal_wal_replication_slot" to stdout
+          And gprecoverseg should print "Segments successfully recovered" to stdout
+          And the user waits until mirror on content 0,1,2 is up
+          And verify replication slot internal_wal_replication_slot is available on all the segments
+          And the segments are synchronized
+          And the cluster is rebalanced
+
+
+    Scenario: differential recovery shows error message if run with the wrong argument
+      Given the database is running
+        And user stops all primary processes
+        And user can start transactions
+        And a gprecoverseg directory under '/tmp' with mode '0700' is created
+        And a gprecoverseg input file is created
+       When the user runs "gprecoverseg -a --differential -F"
+       Then gprecoverseg should return a return code of 2
+        And gprecoverseg should print "Only one of -F and --differential may be specified" to stdout
+       When the user runs "gprecoverseg -a --differential -p localhost"
+       Then gprecoverseg should return a return code of 2
+        And gprecoverseg should print "Only one of -i, -p, -r and --differential may be specified" to stdout
+       When the user runs gprecoverseg with input file and additional args "-a --differential"
+       Then gprecoverseg should return a return code of 2
+        And gprecoverseg should print "Only one of -i, -p, -r and --differential may be specified" to stdout
+       When the user runs "gprecoverseg -a --differential -o outputConfigFile"
+       Then gprecoverseg should return a return code of 2
+        And gprecoverseg should print "Invalid -o provided with --differential argument" to stdout
+       When the user runs "gprecoverseg -a --differential"
+       Then gprecoverseg should return a return code of 0
+        And the segments are synchronized
+        And the cluster is rebalanced
+
+
+    @demo_cluster
+    @concourse_cluster
+    Scenario: Differential recovery succeeds if previous incremental recovery failed
+        Given the database is running
+          And user stops all primary processes
+          And user can start transactions
+          And all files in pg_wal directory are deleted from data directory of preferred primary of content 0,1,2
          When the user runs "gprecoverseg -a"
+         Then gprecoverseg should return a return code of 1
+          And user can start transactions
+          And verify that mirror on content 0,1,2 is down
+         When the user runs "gprecoverseg -a --differential"
          Then gprecoverseg should return a return code of 0
-          And the segments are synchronized
-          And the tablespace is valid
+          And verify that mirror on content 0,1,2 is up
+          And the cluster is rebalanced
 
-        Given another tablespace is created with data
-         When the user runs "gprecoverseg -ra"
-         Then gprecoverseg should return a return code of 0
-          And the segments are synchronized
-          And the tablespace is valid
-          And the other tablespace is valid
-
-    Scenario: full recovery works with tablespaces
+    @demo_cluster
+    @concourse_cluster
+    Scenario: Differential recovery succeeds if previous full recovery failed
         Given the database is running
-          And a tablespace is created with data
           And user stops all primary processes
           And user can start transactions
-         When the user runs "gprecoverseg -a -F"
+          And a gprecoverseg directory under '/tmp' with mode '0700' is created
+          And a gprecoverseg input file is created
+          And edit the input file to recover mirror with content 0 incremental
+          And edit the input file to recover mirror with content 1 full inplace
+          And edit the input file to recover mirror with content 2 to a new directory on remote host with mode 0000
+         When the user runs gprecoverseg with input file and additional args "-a"
+         Then gprecoverseg should return a return code of 1
+          And user can start transactions
+          And verify that mirror on content 0,1 is up
+          And verify that mirror on content 2 is down
+         When the user runs "gprecoverseg -a --differential"
          Then gprecoverseg should return a return code of 0
-          And the segments are synchronized
-          And the tablespace is valid
-
-        Given another tablespace is created with data
-         When the user runs "gprecoverseg -ra"
-         Then gprecoverseg should return a return code of 0
-          And the segments are synchronized
-          And the tablespace is valid
-          And the other tablespace is valid
+          And verify that mirror on content 0,1,2 is up
+          And the cluster is rebalanced
 
     Scenario Outline: full recovery limits number of parallel processes correctly
-        Given a standard local demo cluster is created
+        Given the database is running
         And 2 gprecoverseg directory under '/tmp/recoverseg' with mode '0700' is created
         And a good gprecoverseg input file is created for moving 2 mirrors
-        When the user runs gprecoverseg with input file and additional args "-a -F -v <args>"
+        When the user runs gprecoverseg with input file and additional args "-a -v <args>"
         Then gprecoverseg should return a return code of 0
         And gprecoverseg should only spawn up to <coordinator_workers> workers in WorkerPool
         And check if gprecoverseg ran "$GPHOME/sbin/gpsegsetuprecovery.py" 1 times with args "-b <segHost_workers>"
@@ -55,6 +124,21 @@ Feature: gprecoverseg tests
         | -B 1 -b 1 |  1                  |  1              |
         | -B 2 -b 1 |  2                  |  1              |
         | -B 1 -b 2 |  1                  |  2              |
+
+    Scenario: Differential recovery limits number of parallel processes correctly
+        Given the database is running
+        And user immediately stops all primary processes for content 0,1,2
+        And user can start transactions
+        When the user runs "gprecoverseg -av --differential -B 1 -b 2"
+        Then gprecoverseg should return a return code of 0
+        And gprecoverseg should only spawn up to 1 workers in WorkerPool
+        And check if gprecoverseg ran "$GPHOME/sbin/gpsegsetuprecovery.py" 1 times with args "-b 2"
+        And check if gprecoverseg ran "$GPHOME/sbin/gpsegrecovery.py" 1 times with args "-b 2"
+        And gpsegsetuprecovery should only spawn up to 2 workers in WorkerPool
+        And gpsegrecovery should only spawn up to 2 workers in WorkerPool
+        And the segments are synchronized
+        And check segment conf: postgresql.conf
+        And the cluster is rebalanced
 
     Scenario Outline: Rebalance correctly limits the number of concurrent processes
       Given the database is running
@@ -99,6 +183,7 @@ Feature: gprecoverseg tests
         Given the database is running
         And all the segments are running
         And the segments are synchronized
+        And all files in gpAdminLogs directory are deleted on all hosts in the cluster
         And user stops all mirror processes
         When user can start transactions
         And the user runs "gprecoverseg -F -a -s"
@@ -113,29 +198,24 @@ Feature: gprecoverseg tests
         And the segments are synchronized
         And check segment conf: postgresql.conf
 
-    Scenario: gprecoverseg full recovery displays pg_controldata success info
+
+    Scenario Outline: gprecoverseg <scenario> recovery displays pg_controldata success info
         Given the database is running
         And all the segments are running
         And the segments are synchronized
         And user stops all mirror processes
         When user can start transactions
-        And the user runs "gprecoverseg -F -a"
+        And the user runs "gprecoverseg <args>"
         Then gprecoverseg should return a return code of 0
         And gprecoverseg should print "Successfully finished pg_controldata.* for dbid.*" to stdout
         And the segments are synchronized
         And check segment conf: postgresql.conf
 
-    Scenario: gprecoverseg incremental recovery displays pg_controldata success info
-        Given the database is running
-        And all the segments are running
-        And the segments are synchronized
-        And user stops all mirror processes
-        When user can start transactions
-        And the user runs "gprecoverseg -a"
-        Then gprecoverseg should return a return code of 0
-        And gprecoverseg should print "Successfully finished pg_controldata.* for dbid.*" to stdout
-        And the segments are synchronized
-        And check segment conf: postgresql.conf
+      Examples:
+        | scenario     | args               |
+        | incremental  | -a                 |
+        | differential | -a --differential  |
+        | full         | -aF                |
 
     Scenario: gprecoverseg mixed recovery displays pg_basebackup and rewind progress to the user
       Given the database is running
@@ -201,6 +281,48 @@ Feature: gprecoverseg tests
         And gpAdminLogs directory has no "pg_basebackup*" files
         And all the segments are running
         And the segments are synchronized
+
+    Scenario: gprecoverseg differential recovery displays rsync progress to the user
+        Given the database is running
+        And all the segments are running
+        And the segments are synchronized
+        And all files in gpAdminLogs directory are deleted on all hosts in the cluster
+        And user stops all mirror processes
+        When user can start transactions
+        And the user runs "gprecoverseg --differential -a -s"
+        Then gprecoverseg should return a return code of 0
+        And gprecoverseg should print "Initiating segment recovery. Upon completion, will start the successfully recovered segments" to stdout
+        And gprecoverseg should print "total size" to stdout for each mirror
+        And gprecoverseg should print "Segments successfully recovered" to stdout
+        And gpAdminLogs directory has no "pg_basebackup*" files on all segment hosts
+        And gpAdminLogs directory has no "pg_rewind*" files on all segment hosts
+        And gpAdminLogs directory has no "rsync*" files on all segment hosts
+        And gpAdminLogs directory has "gpsegrecovery*" files
+        And gpAdminLogs directory has "gpsegsetuprecovery*" files
+        And all the segments are running
+        And the segments are synchronized
+        And check segment conf: postgresql.conf
+
+    Scenario: gprecoverseg does not display rsync progress to the user when --no-progress option is specified
+        Given the database is running
+        And all the segments are running
+        And the segments are synchronized
+        And all files in gpAdminLogs directory are deleted on all hosts in the cluster
+        And user stops all mirror processes
+        When user can start transactions
+        And the user runs "gprecoverseg --differential -a -s --no-progress"
+        Then gprecoverseg should return a return code of 0
+        And gprecoverseg should print "Initiating segment recovery. Upon completion, will start the successfully recovered segments" to stdout
+        And gprecoverseg should not print "total size is .*  speedup is .*" to stdout
+        And gprecoverseg should print "Segments successfully recovered" to stdout
+        And gpAdminLogs directory has no "pg_basebackup*" files on all segment hosts
+        And gpAdminLogs directory has no "pg_rewind*" files on all segment hosts
+        And gpAdminLogs directory has no "rsync*" files on all segment hosts
+        And gpAdminLogs directory has "gpsegrecovery*" files
+        And gpAdminLogs directory has "gpsegsetuprecovery*" files
+        And all the segments are running
+        And the segments are synchronized
+        And check segment conf: postgresql.conf
 
     Scenario: When gprecoverseg incremental recovery uses pg_rewind to recover and an existing postmaster.pid on the killed primary segment corresponds to a non postgres process
         Given the database is running
@@ -299,7 +421,7 @@ Feature: gprecoverseg tests
         And the segments are synchronized
         And the cluster is rebalanced
 
-    Scenario: gprecoverseg should not try to drop slot if slot does not exist
+    Scenario Outline: <scenario> recovery should not try to drop slot if slot does not exist
         Given the database is running
         And all the segments are running
         And the segments are synchronized
@@ -308,18 +430,22 @@ Feature: gprecoverseg tests
         And user can start transactions
         And the status of the mirror on content 0 should be "d"
         And the user runs sql "select pg_drop_replication_slot('internal_wal_replication_slot');" in "postgres" on first primary segment
-        When the user runs "gprecoverseg -a -F -v"
+        When the user runs "gprecoverseg <args>"
         Then gprecoverseg should return a return code of 0
         And gprecoverseg should print "Checking if slot internal_wal_replication_slot exists" to stdout
         And gprecoverseg should print "Slot internal_wal_replication_slot does not exist" to stdout
         And gprecoverseg should not print "Successfully dropped replication slot internal_wal_replication_slot" to stdout
-        And gprecoverseg should print "pg_basebackup: base backup completed" to stdout
         And gprecoverseg should print "Segments successfully recovered" to stdout
         And the user waits until mirror on content 0 is up
         And verify replication slot internal_wal_replication_slot is available on all the segments
         And all the segments are running
         And the segments are synchronized
         And the cluster is rebalanced
+
+      Examples:
+        | scenario     | args                |
+        | differential | -av --differential  |
+        | full         | -avF                |
 
     @backup_restore_bashrc
     Scenario: gprecoverseg should not return error when banner configured on host
@@ -375,17 +501,18 @@ Feature: gprecoverseg tests
       And the cluster is returned to a good state
 
       Examples:
-        | scenario    | args |
-        | incremental | -a   |
-        | full        | -aF  |
+        | scenario     | args               |
+        | incremental  | -a                 |
+        | differential | -a --differential  |
+        | full         | -aF                |
 
   @concourse_cluster
-  Scenario: incremental recovery works with tablespaces on a multi-host environment
+  Scenario Outline: <scenario> recovery works with tablespaces on a multi-host environment
     Given the database is running
     And a tablespace is created with data
     And user stops all primary processes
     And user can start transactions
-    When the user runs "gprecoverseg -a"
+    When the user runs "gprecoverseg <args>"
     Then gprecoverseg should return a return code of 0
     And the segments are synchronized
     And the tablespace is valid
@@ -397,23 +524,11 @@ Feature: gprecoverseg tests
     And the tablespace is valid
     And the other tablespace is valid
 
-  @concourse_cluster
-  Scenario: full recovery works with tablespaces on a multi-host environment
-    Given the database is running
-    And a tablespace is created with data
-    And user stops all primary processes
-    And user can start transactions
-    When the user runs "gprecoverseg -a -F"
-    Then gprecoverseg should return a return code of 0
-    And the segments are synchronized
-    And the tablespace is valid
-
-    Given another tablespace is created with data
-    When the user runs "gprecoverseg -ra"
-    Then gprecoverseg should return a return code of 0
-    And the segments are synchronized
-    And the tablespace is valid
-    And the other tablespace is valid
+    Examples:
+        | scenario     | args               |
+        | incremental  | -a                 |
+        | differential | -a --differential  |
+        | full         | -aF                |
 
   @concourse_cluster
   Scenario: recovering a host with tablespaces succeeds
@@ -549,6 +664,22 @@ Feature: gprecoverseg tests
     And user can start transactions
     And all files in "/tmp/custom_logdir" directory are deleted on all hosts in the cluster
 
+  @demo_cluster
+  @concourse_cluster
+  Scenario: gprecoverseg creates recovery_progress.file in gpAdminLogs for differential recovery of mirrors
+    Given the database is running
+    And all files in gpAdminLogs directory are deleted on all hosts in the cluster
+    And user immediately stops all mirror processes for content 0,1,2
+    And the user waits until mirror on content 0,1,2 is down
+    And user can start transactions
+    When the user asynchronously runs "gprecoverseg -a --differential" and the process is saved
+    Then the user waits until recovery_progress.file is created in gpAdminLogs and verifies its format
+    And verify that lines from recovery_progress.file are present in segment progress files in gpAdminLogs
+    And the user waits until saved async process is completed
+    And recovery_progress.file should not exist in gpAdminLogs
+    And the user waits until mirror on content 0,1,2 is up
+    And user can start transactions
+    And all files in gpAdminLogs directory are deleted on all hosts in the cluster
 
   @demo_cluster
   @concourse_cluster
@@ -600,6 +731,28 @@ Feature: gprecoverseg tests
     And the user waits until mirror on content 0,1,2 is up
     And verify that lines from recovery_progress.file are present in segment progress files in gpAdminLogs
     And the cluster is rebalanced
+
+  @demo_cluster
+  @concourse_cluster
+  Scenario:  SIGINT on gprecoverseg differential recovery should delete the progress file
+    Given the database is running
+    And all the segments are running
+    And the segments are synchronized
+    And all files in gpAdminLogs directory are deleted on all hosts in the cluster
+    And user immediately stops all primary processes for content 0,1,2
+    And user can start transactions
+    When the user asynchronously runs "gprecoverseg -a --differential" and the process is saved
+    Then the user waits until recovery_progress.file is created in gpAdminLogs and verifies its format
+    And verify that lines from recovery_progress.file are present in segment progress files in gpAdminLogs
+    Then verify if the gprecoverseg.lock directory is present in coordinator_data_directory
+    When the user asynchronously sets up to end gprecoverseg process with SIGINT
+    And the user waits until saved async process is completed
+    Then recovery_progress.file should not exist in gpAdminLogs
+    Then the gprecoverseg lock directory is removed
+    And an FTS probe is triggered
+    And the user waits until mirror on content 0,1,2 is up
+    And the cluster is rebalanced
+
 
   @demo_cluster
   @concourse_cluster
@@ -843,7 +996,7 @@ Feature: gprecoverseg tests
     And user can start transactions
 
     And check if incremental recovery failed for mirrors with content 0 for gprecoverseg
-    And gprecoverseg should print "Failed to recover the following segments. You must run gprecoverseg -F for all incremental failures" to stdout
+    And gprecoverseg should print "Failed to recover the following segments. You must run either gprecoverseg --differential or gprecoverseg -F for all incremental failures" to stdout
     And check if incremental recovery was successful for mirrors with content 1,2
     And gpAdminLogs directory has no "pg_basebackup*" files on all segment hosts
     And gpAdminLogs directory has "gpsegsetuprecovery*" files on all segment hosts
@@ -851,6 +1004,36 @@ Feature: gprecoverseg tests
 
     And the cluster is recovered in full and rebalanced
     And the row count from table "test_recoverseg" in "postgres" is verified against the saved data
+
+  @demo_cluster
+  Scenario Outline: gprecoverseg differential recovery segments come up even if recovery for one segment fails
+    Given the database is running
+    And all the segments are running
+    And the segments are synchronized
+    And all files in gpAdminLogs directory are deleted on all hosts in the cluster
+    And user immediately stops all primary processes for content 0,1,2
+    And user can start transactions
+    And sql "DROP TABLE if exists test_recoverseg; CREATE TABLE test_recoverseg AS SELECT generate_series(1,10000) AS i" is executed in "postgres" db
+    And the "test_recoverseg" table row count in "postgres" is saved
+    And a temporary directory with mode '0000' is created under data_dir of primary with content 0
+    When the user runs "gprecoverseg -av --differential"
+    Then gprecoverseg should return a return code of 1
+    And user can start transactions
+    And check if differential recovery failed for mirrors with content 0 for gprecoverseg
+    And gprecoverseg should print "Failed to recover the following segments. You must run either gprecoverseg --differential or gprecoverseg -F for all differential failures" to stdout
+    And verify that mirror on content 1,2 is up
+    And the segments are synchronized for content 1,2
+    And gpAdminLogs directory has no "pg_basebackup*" files on all segment hosts
+    And gpAdminLogs directory has "gpsegsetuprecovery*" files on all segment hosts
+    And gpAdminLogs directory has "gpsegrecovery*" files on all segment hosts
+    And the temporary directory is removed
+    And the cluster is recovered <args> and rebalanced
+    And the row count from table "test_recoverseg" in "postgres" is verified against the saved data
+
+    Examples:
+      | scenario     | args               |
+      | differential | using differential |
+      | full         | in full            |
 
   @concourse_cluster
     Scenario: Propagating env var
@@ -992,7 +1175,7 @@ Feature: gprecoverseg tests
     And an FTS probe is triggered
     And the user waits until mirror on content 0,1,2 is up
     And the cluster is rebalanced
-    
+
   @concourse_cluster
   Scenario: gprecoverseg -i gives warning if pg_rewind already running for all of the failed segments
     Given the database is running
@@ -1164,6 +1347,68 @@ Feature: gprecoverseg tests
     And check segment conf: postgresql.conf
     And the row count from table "test_recoverseg" in "postgres" is verified against the saved data
 
+  @demo_cluster
+  @concourse_cluster
+  Scenario: gprecoverseg differential recovery gives warning if any of the failed segment's source is in backup already
+    Given the database is running
+    And all the segments are running
+    And the segments are synchronized
+    And all files in gpAdminLogs directory are deleted on all hosts in the cluster
+    And user immediately stops all primary processes for content 0,1,2
+    And user can start transactions
+    And the user runs sql "select pg_start_backup('test')" in "postgres" on primary segment with content 0
+    When the user runs "gprecoverseg -a --differential"
+    Then gprecoverseg should return a return code of 0
+    And the user waits until mirror on content 1,2 is up
+    And verify that mirror on content 0 is down
+    Then gprecoverseg should print "Found differential recovery running for segments with contentIds [0], skipping recovery of these segments" to logfile
+    And the user runs sql "select pg_stop_backup()" in "postgres" on primary segment with content 0
+    When the user runs "gprecoverseg -av --differential"
+    Then gprecoverseg should return a return code of 0
+    And the user waits until mirror on content 0,1,2 is up
+    And the cluster is rebalanced
+
+  @demo_cluster
+  @concourse_cluster
+  Scenario: gprecoverseg differential recovery gives warning if some of the failed segment's source is in backup already
+    Given the database is running
+    And all the segments are running
+    And the segments are synchronized
+    And all files in gpAdminLogs directory are deleted on all hosts in the cluster
+    And user immediately stops all primary processes for content 0,1,2
+    And user can start transactions
+    And the user runs sql "select pg_start_backup('test')" in "postgres" on primary segment with content 0,1
+    When the user runs "gprecoverseg -a --differential"
+    Then gprecoverseg should return a return code of 0
+    And the user waits until mirror on content 2 is up
+    And verify that mirror on content 0,1 is down
+    Then gprecoverseg should print "Found differential recovery running for segments with contentIds [0, 1], skipping recovery of these segments" to logfile
+    And the user runs sql "select pg_stop_backup()" in "postgres" on primary segment with content 0,1
+    When the user runs "gprecoverseg -av --differential"
+    Then gprecoverseg should return a return code of 0
+    And the user waits until mirror on content 0,1,2 is up
+    And the cluster is rebalanced
+
+  @demo_cluster
+  @concourse_cluster
+  Scenario: gprecoverseg differential recovery gives warning if all of the failed segment's source is in backup already
+    Given the database is running
+    And all the segments are running
+    And the segments are synchronized
+    And all files in gpAdminLogs directory are deleted on all hosts in the cluster
+    And user immediately stops all primary processes for content 0,1,2
+    And user can start transactions
+    And the user runs sql "select pg_start_backup('test')" in "postgres" on primary segment with content 0,1,2
+    When the user runs "gprecoverseg -a --differential"
+    Then gprecoverseg should return a return code of 0
+    And verify that mirror on content 0,1,2 is down
+    Then gprecoverseg should print "Found differential recovery running for segments with contentIds [0, 1, 2], skipping recovery of these segments" to logfile
+    And the user runs sql "select pg_stop_backup()" in "postgres" on primary segment with content 0,1,2
+    When the user runs "gprecoverseg -av --differential"
+    Then gprecoverseg should return a return code of 0
+    And the user waits until mirror on content 0,1,2 is up
+    And the cluster is rebalanced
+
   @concourse_cluster
     Scenario: gprecoverseg behave test requires a cluster with at least 2 hosts
         Given the database is running
@@ -1171,7 +1416,7 @@ Feature: gprecoverseg tests
         And the information of a "mirror" segment on a remote host is saved
 
     @concourse_cluster
-    Scenario: When gprecoverseg full recovery is executed and an existing postmaster.pid on the killed primary segment corresponds to a non postgres process
+    Scenario Outline: When gprecoverseg <scenario> recovery is executed and an existing postmaster.pid on the killed primary segment corresponds to a non postgres process
         Given the database is running
         And all the segments are running
         And the segments are synchronized
@@ -1181,7 +1426,7 @@ Feature: gprecoverseg tests
         When user can start transactions
         And we run a sample background script to generate a pid on "primary" segment
         And we generate the postmaster.pid file with the background pid on "primary" segment
-        And the user runs "gprecoverseg -F -a"
+        And the user runs "gprecoverseg <args>"
         Then gprecoverseg should return a return code of 0
         And gprecoverseg should not print "Unhandled exception in thread started by <bound method Worker.__bootstrap" to stdout
         And gprecoverseg should print "Skipping to stop segment.* on host.* since it is not a postgres process" to stdout
@@ -1193,6 +1438,11 @@ Feature: gprecoverseg tests
         And the segments are synchronized
         And the backup pid file is deleted on "primary" segment
         And the background pid is killed on "primary" segment
+
+      Examples:
+        | scenario     | args               |
+        | differential | -a --differential  |
+        | full         | -aF                |
 
     @concourse_cluster
     Scenario: gprecoverseg full recovery testing
@@ -1268,6 +1518,27 @@ Feature: gprecoverseg tests
         And all the segments are running
         And the segments are synchronized
         # validate the new segment has the correct setting by getting admin connection to that segment
+        Then the saved primary segment reports the same value for sql "show data_checksums" db "template1" as was saved
+
+    @concourse_cluster
+    Scenario: gprecoverseg should use the same setting for data_checksums for a differential recovery
+        Given the database is running
+        And results of the sql "show data_checksums" db "template1" are stored in the context
+        And all the segments are running
+        And the segments are synchronized
+        And the information of a "mirror" segment on a remote host is saved
+        And the information of the corresponding primary segment on a remote host is saved
+        When user kills a "primary" process with the saved information
+        And user can start transactions
+        Then the saved "primary" segment is marked down in config
+        When the user runs "gprecoverseg --differential -a"
+        Then gprecoverseg should return a return code of 0
+        And gprecoverseg should print "Heap checksum setting is consistent between coordinator and the segments that are candidates for recoverseg" to stdout
+        When the user runs "gprecoverseg -ra"
+        Then gprecoverseg should return a return code of 0
+        And gprecoverseg should print "Heap checksum setting is consistent between coordinator and the segments that are candidates for recoverseg" to stdout
+        And all the segments are running
+        And the segments are synchronized
         Then the saved primary segment reports the same value for sql "show data_checksums" db "template1" as was saved
 
   @concourse_cluster
@@ -1456,4 +1727,3 @@ Feature: gprecoverseg tests
          Then gprecoverseg should return a return code of 0
           And all the segments are running
           And the segments are synchronized
-

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -138,6 +138,19 @@ def impl(context, dbname, psql_cmd):
         raise Exception('%s' % context.error_message)
 
 
+@given('the user runs sql "{query}" in "{db}" on primary segment with content {contentids}')
+@when('the user runs sql "{query}" in "{db}" on primary segment with content {contentids}')
+@then('the user runs sql "{query}" in "{db}" on primary segment with content {contentids}')
+def impl(context, query, db, contentids):
+    content_ids = [int(i) for i in contentids.split(',')]
+
+    for content in content_ids:
+        host, port = get_primary_segment_host_port_for_content(content)
+        psql_cmd = "PGDATABASE=\'%s\' PGOPTIONS=\'-c gp_role=utility\' psql -h %s -p %s -c \"%s\"; " % (
+            db, host, port, query)
+        Command(name='Running Remote command: %s' % psql_cmd, cmdStr=psql_cmd).run(validateAfter=True)
+
+
 @given('the user connects to "{dbname}" with named connection "{cname}"')
 def impl(context, dbname, cname):
     if not hasattr(context, 'named_conns'):
@@ -447,9 +460,9 @@ def impl(context, logdir):
                 context.recovery_lines = fp.readlines()
             for line in context.recovery_lines:
                 recovery_type, dbid, progress = line.strip().split(':', 2)
-                progress_pattern = re.compile(get_recovery_progress_pattern())
+                progress_pattern = re.compile(get_recovery_progress_pattern(recovery_type))
                 # TODO: assert progress line in the actual hosts bb/rewind progress file
-                if re.search(progress_pattern, progress) and dbid.isdigit() and recovery_type in ['full', 'incremental']:
+                if re.search(progress_pattern, progress) and dbid.isdigit() and recovery_type in ['full', 'differential', 'incremental']:
                     return
                 else:
                     raise Exception('File present but incorrect format line "{}"'.format(line))
@@ -481,7 +494,13 @@ def impl(context, logdir):
         seg_dbid = seg.getSegmentDbId()
         if seg_dbid in all_progress_lines_by_dbid:
             recovery_type, line_from_combined_progress_file = all_progress_lines_by_dbid[seg_dbid]
-            process_name = 'pg_basebackup' if recovery_type == 'full' else 'pg_rewind'
+            if recovery_type == "full":
+                process_name = 'pg_basebackup'
+            elif recovery_type == "differential":
+                process_name = 'rsync'
+            else:
+                process_name = 'pg_rewind'
+
             seg_progress_file = '{}/{}.*.dbid{}.out'.format(log_dir, process_name, seg_dbid)
             check_cmd_str = 'grep "{}" {}'.format(line_from_combined_progress_file, seg_progress_file)
             check_cmd = Command(name='check line in segment progress file',
@@ -3350,7 +3369,7 @@ def impl(context, table1, table2, dbname):
 
 def _get_row_count_per_segment(table, dbname):
     with closing(dbconn.connect(dbconn.DbURL(dbname=dbname), unsetSearchPath=False)) as conn:
-        query = "SELECT gp_segment_id,COUNT(i) FROM %s GROUP BY gp_segment_id ORDER BY gp_segment_id;" % table
+        query = "SELECT gp_segment_id,COUNT(*) FROM %s GROUP BY gp_segment_id ORDER BY gp_segment_id;" % table
         cursor = dbconn.query(conn, query)
         rows = cursor.fetchall()
     return [row[1] for row in rows] # indices are the gp segment id's, so no need to store them explicitly
@@ -3852,7 +3871,7 @@ def impl(context, slot):
     query = "SELECT count(*) FROM pg_catalog.pg_replication_slots WHERE slot_name = '{}'".format(slot)
 
     for seg in segments:
-        if seg.isSegmentPrimary():
+        if seg.isSegmentPrimary(current_role=True):
             host = seg.getSegmentHostName()
             port = seg.getSegmentPort()
             with closing(dbconn.connect(dbconn.DbURL(dbname=dbname, port=port, hostname=host),
@@ -3894,6 +3913,7 @@ def impl(context):
 
     with closing(dbconn.connect(dbconn.DbURL(dbname=dbname), unsetSearchPath=False)) as conn:
         dbconn.execSQL(conn, query)
+
 
 @given('running postgres processes are saved in context')
 @when('running postgres processes are saved in context')

--- a/gpMgmt/test/behave/mgmt_utils/steps/mirrors_mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mirrors_mgmt_utils.py
@@ -553,6 +553,31 @@ def impl(context, content_id, recovery_host):
                 fd.write('{}\n'.format(valid_config))
             break
 
+
+@given("a temporary directory with mode '{mode}' is created under data_dir of primary with content {content}")
+@when("a temporary directory with mode '{mode}' is created under data_dir of primary with content {content}")
+@then("a temporary directory with mode '{mode}' is created under data_dir of primary with content {content}")
+def impl(context, mode, content):
+    all_segments = GpArray.initFromCatalog(dbconn.DbURL()).getDbList()
+    primary_segment = list(filter(lambda seg: seg.getSegmentRole() == ROLE_PRIMARY and
+                                  seg.getSegmentContentId() == int(content), all_segments))[0]
+    mirror_segment = list(filter(lambda seg: seg.getSegmentRole() == ROLE_MIRROR and
+                                             seg.getSegmentContentId() == int(content), all_segments))[0]
+    make_temp_dir(context, primary_segment.getSegmentDataDirectory(), mode=mode)
+    context.mirror_datadir = mirror_segment.getSegmentDataDirectory()
+
+
+@when('the temporary directory is removed')
+@then('the temporary directory is removed')
+def impl(context):
+    if 'temp_base_dir' in context and os.path.exists(context.temp_base_dir):
+        base = os.path.basename(context.temp_base_dir)
+        os.chmod(context.temp_base_dir, 0o700)
+        os.chmod(os.path.join(context.mirror_datadir, base), 0o700)
+        shutil.rmtree(context.temp_base_dir)
+        shutil.rmtree(os.path.join(context.mirror_datadir, base))
+
+
 @given("{num} {utility} directory under '{parent_dir}' with mode '{mode}' is created")
 @when("{num} {utility} directory under '{parent_dir}' with mode '{mode}' is created")
 @then("{num} {utility} directory under '{parent_dir}' with mode '{mode}' is created")
@@ -810,6 +835,16 @@ def impl(context):
 def impl(context):
     context.execute_steps(u'''
         Then the user runs "gprecoverseg -aF"
+        And gprecoverseg should return a return code of 0
+        And user can start transactions
+        And the segments are synchronized
+        And the cluster is rebalanced
+        ''')
+
+@then('the cluster is recovered using differential and rebalanced')
+def impl(context):
+    context.execute_steps(u'''
+        Then the user runs "gprecoverseg -a --differential"
         And gprecoverseg should return a return code of 0
         And user can start transactions
         And the segments are synchronized

--- a/gpdb-doc/markdown/utility_guide/ref/gprecoverseg.html.md
+++ b/gpdb-doc/markdown/utility_guide/ref/gprecoverseg.html.md
@@ -6,7 +6,7 @@ Recovers a primary or mirror segment instance that has been marked as down \(if 
 
 ```
 gprecoverseg [[-p <new_recover_host>[,...]] | -i <recover_config_file>] [-d <coordinator_data_directory>] 
-             [-b <segment_batch_size>] [-B <batch_size>] [-F [-s]] [-a] [-q] 
+             [-b <segment_batch_size>] [-B <batch_size>] [-F [-s]] [-a] [-q] [--differential]
 	      [--hba-hostnames <boolean>] 
              [--no-progress] [-l <logfile_directory>]
 
@@ -88,6 +88,9 @@ The recovery process marks the segment as up again in the Greenplum Database sys
     Also, for a full recovery, the utility does not restore custom files that are stored in the segment instance data directory even if the custom files are also in the active segment instance. You must restore the custom files manually. For example, when using the `gpfdists` protocol \(`gpfdist` with SSL encryption\) to manage external data, client certificate files are required in the segment instance `$PGDATA/gpfdists` directory. These files are not restored. For information about configuring `gpfdists`, see [Encrypting gpfdist Connections](../../security-guide/topics/Encryption.html).
 
     Use the `-s` option to output a new line once per second for each segment. Alternatively, use the `--no-progress` option to completely deactivate progress reports.
+
+--differential \(Differential recovery\)
+:   Optional. Perform a differential copy of the active segment instance in order to recover the failed segment. The default is to only copy over the incremental changes that occurred while the segment was down.
 
 --hba-hostnames boolean
 :   Optional. Controls whether this utility uses IP addresses or host names in the `pg_hba.conf` file when updating this file with addresses that can connect to Greenplum Database. When set to 0 -- the default value -- this utility uses IP addresses when updating this file. When set to 1, this utility uses host names when updating this file. For consistency, use the same value that was specified for `HBA_HOSTNAMES` when the Greenplum Database system was initialized. For information about how Greenplum Database resolves host names in the `pg_hba.conf` file, see [Configuring Client Authentication](../../admin_guide/client_auth.html).


### PR DESCRIPTION
**Context:**
Greenplum so far has 2 modes for mirror recovery: FULL and INCREMENTAL. Incremental happens in 2 flavors based on the situation purely WAL based or pg_rewind based. Existing mirror disconnecting and reconnecting back is purely WAL based incremental recovery. When for a segment, preferred roles is same as actual role on running gprecoverseg, incremental pg_rewind based recovery happens

**Challenge:**
In some situations, incremental recovery could fail like due to missing WAL logs (because of GUC max_slot_wal_keep_size or space constraints) or pg_rewind interrupted. Postgres does not recommend running pg_rewind again upon failure (https://www.postgresql.org/docs/current/app-pgrewind.html). FULL recovery is the only fallback option in these cases. GPDB's majority of use cases are for very large data and FULL recovery takes a long time and resources, especially in case of host failures and such where multiple segments for a single host have to be recreated. It becomes very suboptimal for systems where a large part of the data set has not changed, is already present on the mirror, and still during recovery via FULL has to be deleted from the mirror and brought back over n/w.

Full recovery also may fail let's say after completing 70% of the job due to a n/w glitch or something else. Even for those cases will be helpful to avoid recopy of already copied data.

**Solution:**
It would be extremely helpful to have a third option for mirror recovery. Performing filesystem level diff between primary and mirror, copying over only stuff that has changed on primary to mirror. This would skip files that are identical, saving huge n/w and disk IO consumption. In terms of speed and resource consumption, this option will fall in-between current FULL and INCREMENTAL recoveries. Named as differential recovery as an option in gprecoverseg. And best used when INCREMENTAL fails for whatever reason.

**Implementation:**
* Using RSYNC tool to implement the solution. It's famous for its delta-transfer algorithm, which reduces the amount of data sent over the network by sending only the differences between the source files and the existing files in the destination. Plus, rsync already is a dependency for Greenplum as used to perform in-place upgrade revert work.
* Using functionalities of pg_basebackup code to write configuration files like internal.auto.conf and recovery.conf. And to use just these specific functionalities, have introduced a new flag --write-recovery-conf-only in pg_basebackup. 


**High-level Flow for single mirror recovery (Algorithm)**
1. On source: Skip differential recovery if the segment is already in backup else proceeds to step 2.
2. On source: drop the replication slot if exists.
3. On source: start backup: pg_start_backup(‘differential_backup’)
4. On source: create a replication slot.
5. On target: sync pg_data of the mirror with its primary using rsync.
6. On target: sync table space created outside the data directory.
7. On source: stop backup: pg_stop_backup()
8. On target: write configuration file: pg_basebackup -D <backup_dir> --write-conf-files-only
9. On target: sync wal and pg_control file.
10. On target: update port in the configuration
11. On target: start segment.
12. On Source: if any exception is raised during steps 2 to 11 the program should stop the backup if it is stuck in the backup.

**Usage:**
Option: --differential
gprecoverseg --differential

**rsync options utilized by differential recovery:**
 * --exclude, to exclude certain unnecessary directories from being copied
 * -a, Archive mode
 * -v, Verbose mode to increase verbosity for debugging purposes
 * --checksum, Checksum flag to skip the files based on checksum, not modification time and size
 * --progress, to show the progress of rsync
 * --stats, to show file transfer stats
 * --bwlimit, to control file transfer I/O if required
 * --dry-run, to show what would have been transferred
 * --compress, to compress file data during the transfer
 

**Suggested code review in the following order of commits:**

- Main code:
  - [Setup for differential recovery](https://github.com/greenplum-db/gpdb/pull/15146/commits/e7f419e3782fff93b1332901208aa164729300ba)
  - [gprecoverseg differential recovery](https://github.com/greenplum-db/gpdb/pull/15146/commits/dbb1a3438462511c6904691cc39f843554d3b55c) 
  -  [Error handling for differential recovery](https://github.com/greenplum-db/gpdb/pull/15146/commits/82cff990ebba7ae07bef43b9491a6c323e05ad4b) 
  - [Skip differential recovery if backup already in progress](https://github.com/greenplum-db/gpdb/pull/15146/commits/1594727798c19a8a465e3b348c667fc09d2de571) contain main code related to differential recovery

- Code restructuring and utilities required for differential recovery:
  - [Added support for more rsync options](https://github.com/greenplum-db/gpdb/pull/15146/commits/5b48ca51c1e4f8c20574834088cf86ab4f18628a)
  - [Added function to create replication slot and --write-conf-file-only …](https://github.com/greenplum-db/gpdb/pull/15146/commits/f239f21053aacf95dd85f8af876632cb318653bf) 
  - [Moved RemoteQueryCommand class to catalog.py](https://github.com/greenplum-db/gpdb/pull/15146/commits/b3ac5a571e8aeae3dce8b31d41846f513390fa1c)   
  
- Help Doc:
  - [Updated gprecoverseg help doc](https://github.com/greenplum-db/gpdb/pull/15146/commits/c3fec6944190237d081a91df4674624de2ae3605) is help doc update
 
- Tests:
  - [Unit tests for differential recovery](https://github.com/greenplum-db/gpdb/pull/15146/commits/e2990d497dc2866a92e037c735c8d39194fd2a7c)
  - [Behave tests for differetial recovery](https://github.com/greenplum-db/gpdb/pull/15146/commits/c1965501c2adee2e6b52386ded7859313af2e9f4)

gpdb-dev mailing list - https://groups.google.com/a/greenplum.org/g/gpdb-dev/c/3w9rR8O6VPM?pli=1

Co-authored-by: Rakesh Sharma <shrakesh@vmware.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
