### PR TITLE
[ORCA] Fix flaky "Invalid key is inaccessible" fallback

### DIFF
--- a/src/backend/gporca/libgpos/include/gpos/memory/CMemoryPool.h
+++ b/src/backend/gporca/libgpos/include/gpos/memory/CMemoryPool.h
@@ -25,6 +25,9 @@
 #ifndef GPOS_CMemoryPool_H
 #define GPOS_CMemoryPool_H
 
+#include <limits>
+#include <random>
+
 #include "gpos/assert.h"
 #include "gpos/common/CLink.h"
 #include "gpos/common/CStackDescriptor.h"
@@ -75,7 +78,11 @@ class CMemoryPool
 	friend class CMemoryPoolManager;
 
 private:
-	// hash key is only set by pool manager
+	// psudo random hash key generator
+	std::mt19937 m_generator;
+	std::uniform_int_distribution<ULONG> m_distribution;
+
+	// hash key for this memory pool
 	ULONG_PTR m_hash_key;
 
 #ifdef GPOS_DEBUG
@@ -97,6 +104,13 @@ public:
 		EatSingleton = 0x7f,
 		EatArray = 0x7e
 	};
+
+	CMemoryPool()
+		// MAX LONG is invalid hash key, so skip that hash value.
+		: m_distribution(0, std::numeric_limits<ULONG>::max() - 1),
+		  m_hash_key(m_distribution(m_generator))
+	{
+	}
 
 	// dtor
 	virtual ~CMemoryPool() = default;


### PR DESCRIPTION
In CI pipeline there were occassional test failures due to ORCA fallback with following stacktrace.

    ```
    +INFO:  GPORCA failed to produce a plan, falling back to planner
    +DETAIL:  CSyncHashtable.h:109: Failed assertion: IsValid(key) && "Invalid key is inaccessible"
    +Stack trace:
    +1    gpos::CException::Raise + 227
    +2    <symbol not found> + 15235666
    +3    gpos::CMemoryPoolManager::CreateMemoryPool + 653
    +4    gpos::CAutoMemoryPool::CAutoMemoryPool + 34
    +5    gpopt::CColumnFactory::CColumnFactory + 80
    +6    gpopt::COptCtxt::PoctxtCreate + 77
    +7    gpopt::CAutoOptCtxt::CAutoOptCtxt + 54
    +8    gpopt::COptimizer::PdxlnOptimize + 411
    +9    COptTasks::OptimizeTask + 850
    +10   gpos::CTask::Execute + 52
    +11   gpos::CWorker::Execute + 36
    +12   gpos::CAutoTaskProxy::Execute + 97
    +13   gpos_exec + 557
    ```

Core dump of failure showed CMemoryPool::m_hash_key had invalid key value 0xffffffff. Hence, the query raised an assertion error and fell back to PLANNER.

Issue is that CMemoryPool::m_hash_key was never directly initialized. This suggests that it was using uninitialized memory to produce randomness in the key. When that memory contains 0xffffffff in just the right place, then the value of the CMemoryPool::m_hash_key is an invalid key and ORCA falls back.

Following is patch that demonstrates the issue:
    ```
    diff src/backend/utils/mmgr/aset.c
    @@ -989,6 +989,8 @@ AllocSetAlloc(MemoryContext context, Size size)

                    MEMORY_ACCOUNT_INC_ALLOCATED(set, chunk->size);

    +               memset((char *) AllocChunkGetPointer(chunk), 0xFFFFFFFF, size);
    +
                    return AllocChunkGetPointer(chunk);
            }
    ```

A few lines above that patch, you can see that when compiled with RANDOMIZE_ALLOCATED_MEMORY the memory is randomly initialied. So we can make no assumptions about the uninitialied memory; meaning that 0xffffff is valid.

Note: Seemed this failure manifested more commonly with JIT ICW runs.