### PR TITLE
gpstop: Fix kill_9_segment_processes function

### DIFF
--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -81,6 +81,32 @@ def getPostmasterPID(hostname, datadir):
     except:
         return -1
 
+
+"""
+Given the segment data directory and the hostname,
+return all the postgres processes associated
+with that segment as a list.
+Returns an empty list if there is any error.
+"""
+def get_postgres_segment_processes(datadir, host):
+    postmaster_pid = getPostmasterPID(host, datadir)
+    if postmaster_pid == -1:
+        return []
+
+    postgres_pids = [postmaster_pid]
+    cmd = Command("get children pids", ("pgrep -P {0}".format(postmaster_pid)), ctxt=REMOTE, remoteHost=host)
+    cmd.run()
+
+    if cmd.get_results().rc == 0:
+        pids = cmd.get_results().stdout.split()
+        for pid in pids:
+            try:
+                postgres_pids.append(int(pid))
+            except ValueError:
+                pass # Ignore any error while converting to int from str
+
+    return postgres_pids
+
 #-----------------------------------------------
 
 class CmdArgs(list):

--- a/gpMgmt/bin/gppylib/commands/test/unit/test_unit_unix.py
+++ b/gpMgmt/bin/gppylib/commands/test/unit/test_unit_unix.py
@@ -1,0 +1,69 @@
+from mock import Mock, patch, call
+
+from gppylib.commands import unix
+from gppylib.commands.base import CommandResult
+from gppylib.test.unit.gp_unittest import GpTestCase, run_tests
+
+
+class UnixCommandTestCase(GpTestCase):
+    def setUp(self):
+        self.subject = unix
+        self.subject.logger = Mock(spec=['log', 'warn', 'info', 'debug', 'error', 'warning', 'fatal'])
+
+        self.apply_patches([
+            patch('gppylib.commands.unix.check_pid_on_remotehost'),
+            patch('gppylib.commands.unix.Command')
+        ])
+
+        self.mock_check_pid = self.get_mock_from_apply_patch('check_pid_on_remotehost')
+        self.mock_cmd = self.get_mock_from_apply_patch('Command')
+
+    def tearDown(self):
+        super(UnixCommandTestCase, self).tearDown()
+
+    def test_kill_9_segment_processes_info_msg(self):
+        self.subject.kill_9_segment_processes('/data/primary/gpseg0', [], 'sdw1')
+        self.subject.logger.info.assert_called_once_with('Terminating processes for segment /data/primary/gpseg0')
+
+    def test_kill_9_segment_processes_empty_pid_list(self):
+        self.subject.kill_9_segment_processes('/data/primary/gpseg0', [], 'sdw1')
+
+        self.subject.logger.info.assert_called_once_with('Terminating processes for segment /data/primary/gpseg0')
+        self.assertFalse(self.mock_cmd.called)
+
+    def test_kill_9_segment_processes_multiple_pids(self):
+        self.mock_check_pid.return_value = True
+        self.subject.kill_9_segment_processes('/data/primary/gpseg0', [123, 456], 'sdw1')
+
+        call_expected = [call('kill -9 process', 'kill -9 123', ctxt=2, remoteHost='sdw1'),
+                         call('kill -9 process', 'kill -9 456', ctxt=2, remoteHost='sdw1')]
+
+        self.subject.logger.info.assert_called_once_with('Terminating processes for segment /data/primary/gpseg0')
+        self.assertEqual(self.mock_cmd.call_count, 2)
+        self.assertIn(call_expected, self.mock_cmd.call_args_list)
+
+    def test_kill_9_segment_processes_some_pids_do_not_exist(self):
+        self.mock_check_pid.side_effect = [True, False, True]
+        self.subject.kill_9_segment_processes('/data/primary/gpseg0', [123, 456, 789], 'sdw1')
+        self.subject.logger.info.assert_called_once_with('Terminating processes for segment /data/primary/gpseg0')
+
+        call_expected = [call('kill -9 process', 'kill -9 123', ctxt=2, remoteHost='sdw1'),
+                         call('kill -9 process', 'kill -9 789', ctxt=2, remoteHost='sdw1')]
+
+        self.assertEqual(self.mock_cmd.call_count, 2)
+        self.assertIn(call_expected, self.mock_cmd.call_args_list)
+
+    def test_kill_9_segment_processes_kill_error(self):
+        self.mock_check_pid.return_value = True
+        mc = self.mock_cmd.return_value
+        mc.get_results.side_effect = [CommandResult(0, b"", b"", True, False),
+                                                                     CommandResult(0, b"", b"", True, False),
+                                                                     CommandResult(1, b"", b"Kill Error", False, False),
+                                                                     CommandResult(1, b"", b"Kill Error", False, False)]
+        self.subject.kill_9_segment_processes('/data/primary/gpseg0', [123, 456, 789], 'sdw1')
+
+        self.subject.logger.info.assert_called_once_with('Terminating processes for segment /data/primary/gpseg0')
+        self.subject.logger.error.assert_called_once_with('Failed to kill process 789 for segment /data/primary/gpseg0: Kill Error')
+
+if __name__ == '__main__':
+    run_tests()

--- a/gpMgmt/bin/gpstop
+++ b/gpMgmt/bin/gpstop
@@ -419,6 +419,10 @@ class GpStop:
         e = GpEraFile(self.coordinator_datadir, logger=get_logger_if_verbose())
         e.end_era()
 
+        # Get a list of postgres processes running before stopping the server
+        postgres_pids = gp.get_postgres_segment_processes(self.coordinator_datadir, self.gparray.coordinator.hostname)
+        logger.debug("Postgres processes running on coordinator host: {0}".format(postgres_pids))
+
         try:
             if self.mode == 'smart':
                 self._stop_coordinator_smart()
@@ -450,10 +454,10 @@ class GpStop:
                         if os.path.exists(lockfile):
                             logger.info("Clearing segment instance lock files")
                             os.remove(lockfile)
+
+        # Use the process list and make sure that all the processes are killed at the end
         logger.info('Attempting forceful termination of any leftover coordinator process')
-        (succeeded, mypid, file_datadir) = pg.ReadPostmasterTempFile.local("Read coordinator tmp file",
-                                                                           self.dburl.pgport).getResults()
-        unix.kill_9_segment_processes(self.coordinator_datadir, self.dburl.pgport, mypid)
+        unix.kill_9_segment_processes(self.coordinator_datadir, postgres_pids, self.gparray.coordinator.hostname)
 
         logger.debug("Successfully shutdown the Coordinator instance in admin mode")
 
@@ -469,6 +473,10 @@ class GpStop:
             if get_unreachable_segment_hosts([standby.hostname], 1):
                 logger.warning("Standby is unreachable, skipping shutdown on standby")
                 return True
+
+            # Get a list of postgres processes running before stopping the server
+            postgres_pids = gp.get_postgres_segment_processes(standby.datadir, standby.hostname)
+            logger.debug("Postgres processes running on standby host: {0}".format(postgres_pids))
 
             logger.info("Stopping coordinator standby host %s mode=%s" % (standby.hostname, self.mode))
             try:
@@ -499,10 +507,10 @@ class GpStop:
                     return True
                 else:
                     logger.error('Failed to stop standby. Attempting forceful termination of standby process')
-                    (succeeded, mypid, file_datadir) = pg.ReadPostmasterTempFile.remote("Read standby tmp file",
-                                                                                        self.dburl.pgport,
-                                                                                        standby.hostname).getResults()
-                    unix.kill_9_segment_processes(self.coordinator_datadir, self.dburl.pgport, mypid)
+
+                    # Use the process list and make sure that all the processes are killed at the end
+                    unix.kill_9_segment_processes(standby.datadir, postgres_pids, standby.hostname)
+
                     if not pg.DbStatus.remote('checking status of standby coordinator instance', standby, standby.hostname):
                         logger.info("Successfully shutdown coordinator standby process on %s" % standby.hostname)
                         return True

--- a/gpMgmt/test/behave/mgmt_utils/gpstop.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpstop.feature
@@ -5,28 +5,34 @@ Feature: gpstop behave tests
     @demo_cluster
     Scenario: gpstop succeeds
         Given the database is running
+          And running postgres processes are saved in context
          When the user runs "gpstop -a"
          Then gpstop should return a return code of 0
+         And verify no postgres process is running on all hosts
 
     @concourse_cluster
     @demo_cluster
     Scenario: when there are user connections gpstop waits to shutdown until user switches to fast mode
         Given the database is running
           And the user asynchronously runs "psql postgres" and the process is saved
+          And running postgres processes are saved in context
          When the user runs gpstop -a -t 4 --skipvalidation and selects f
           And gpstop should print "'\(s\)mart_mode', '\(f\)ast_mode', '\(i\)mmediate_mode'" to stdout
          Then gpstop should return a return code of 0
+         And verify no postgres process is running on all hosts
 
     @concourse_cluster
     @demo_cluster
     Scenario: when there are user connections gpstop waits to shutdown until user connections are disconnected
         Given the database is running
           And the user asynchronously runs "psql postgres" and the process is saved
-          And the user asynchronously sets up to end that process in 6 seconds
+          And the user asynchronously sets up to end that process in 15 seconds
+          And running postgres processes are saved in context
          When the user runs gpstop -a -t 2 --skipvalidation and selects s
           And gpstop should print "There were 1 user connections at the start of the shutdown" to stdout
           And gpstop should print "'\(s\)mart_mode', '\(f\)ast_mode', '\(i\)mmediate_mode'" to stdout
          Then gpstop should return a return code of 0
+         And verify no postgres process is running on all hosts
 
     @demo_cluster
     Scenario: gpstop succeeds even if the standby host is unreachable
@@ -37,3 +43,25 @@ Feature: gpstop behave tests
          Then gpstop should print "Standby is unreachable, skipping shutdown on standby" to stdout
           And gpstop should return a return code of 0
           And the standby host is made reachable
+
+    @demo_cluster
+    Scenario: gpstop succeeds when pg_ctl command fails
+        Given the database is running
+          And the user runs psql with "-c "CREATE EXTENSION IF NOT EXISTS gp_inject_fault;"" against database "postgres"
+          And the user runs psql with "-c "SELECT gp_inject_fault('checkpoint', 'sleep', '', '', '', 1, -1, 3600, dbid) FROM gp_segment_configuration"" against database "postgres"
+          And running postgres processes are saved in context
+         When the user runs "gpstop -a -M fast"
+          And gpstop should print "Failed to shutdown coordinator with pg_ctl." to stdout
+          And gpstop should return a return code of 0
+          And verify no postgres process is running on all hosts
+
+    @demo_cluster
+    Scenario: gpstop succeeds with immediate option
+        Given the database is running
+          And the user asynchronously runs "psql postgres" and the process is saved
+          And the user asynchronously sets up to end that process in 15 seconds
+          And running postgres processes are saved in context
+         When the user runs "gpstop -a -M immediate"
+          And gpstop should print "Commencing Coordinator instance shutdown with mode='immediate'" to stdout
+         Then gpstop should return a return code of 0
+          And verify no postgres process is running on all hosts

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -22,7 +22,7 @@ from contextlib import closing
 
 from gppylib.gparray import GpArray, ROLE_PRIMARY, ROLE_MIRROR
 from gppylib.commands.gp import SegmentStart, GpStandbyStart, CoordinatorStop
-from gppylib.commands import gp
+from gppylib.commands import gp, unix
 from gppylib.commands.pg import PgBaseBackup
 from gppylib.operations.startSegments import MIRROR_MODE_MIRRORLESS
 from gppylib.operations.buildMirrorSegments import get_recovery_progress_pattern
@@ -4026,3 +4026,34 @@ def impl(context, contentids):
 
      if not no_basebackup:
          raise Exception("pg_basebackup entry was found for contents %s in gp_stat_replication after %d retries" % (contentids, retries))
+
+
+@given('running postgres processes are saved in context')
+@when('running postgres processes are saved in context')
+@then('running postgres processes are saved in context')
+def impl(context):
+
+    # Store the pids in a dictionary where key will be the hostname and the
+    # value will be the pids of all the postgres processes running on that host
+    host_to_pid_map = dict()
+    segs = GpArray.initFromCatalog(dbconn.DbURL()).getDbList()
+    for seg in segs:
+        pids = gp.get_postgres_segment_processes(seg.datadir, seg.hostname)
+        if seg.hostname not in host_to_pid_map:
+            host_to_pid_map[seg.hostname] = pids
+        else:
+            host_to_pid_map[seg.hostname].extend(pids)
+
+    context.host_to_pid_map = host_to_pid_map
+
+
+@given('verify no postgres process is running on all hosts')
+@when('verify no postgres process is running on all hosts')
+@then('verify no postgres process is running on all hosts')
+def impl(context):
+    host_to_pid_map = context.host_to_pid_map
+
+    for host in host_to_pid_map:
+        for pid in host_to_pid_map[host]:
+            if unix.check_pid_on_remotehost(pid, host):
+                raise Exception("Postgres process {0} not killed on {1}.".format(pid, host))


### PR DESCRIPTION
There was an issue reported and fixed by #11378 where the `kill_9_segment_processes` function had a bug and could not get the postgres pids to kill (more details in the mentioned PR). Even though the fix was correct, it has some issues - 
- It is not reliable to use the grep command `ps ux | grep "[p]ostgres:\s*%s" | awk \'{print $2}\'` to get a list of postgres processes since the pattern can be changed in the future and the output of the command also depends on the OS.
- The function never considered the case for executing on remote hosts. So the function would never work in case of standby shutdown when standby is on another host.

To address the above issues following changes are made - 
- Use the postmaster pid to get the list of all its child processes (implemented using `get_postgres_segment_processes`) before stopping the postgres server which will be used by the `kill_9_segment_processes` function at the end instead of the grep command.
- Modify the `kill_9_segment_processes` so that it can be executed remotely as well.

#### Testing
- Added unit test cases for the functions `kill_9_segment_processes` and `get_postgres_segment_processes`.
- Added a new behave test case where gpstop will succeed even when the pg_ctl stop command fails to stop the server.
- Added steps in existing cases to check for any postgres processes running at the end of gpstop to make sure all the processes are getting terminated and there are no false positives.

[Pipeline](https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb-dev-7x_gpstop_fix)