### PR TITLE
Send rows in binary mode for ANALYZE

### DIFF
--- a/src/backend/commands/analyze.c
+++ b/src/backend/commands/analyze.c
@@ -134,7 +134,8 @@
 #include "utils/hyperloglog/gp_hyperloglog.h"
 #include "utils/snapmgr.h"
 #include "utils/typcache.h"
-
+#include "executor/tstoreReceiver.h"
+#include "tcop/utility.h"
 
 /*
  * For Hyperloglog, we define an error margin of 0.3%. If the number of
@@ -2130,7 +2131,7 @@ parse_record_to_string(char *string, TupleDesc tupdesc, char** values, bool *nul
 	Assert(string != NULL);
 	Assert(values != NULL);
 	Assert(nulls != NULL);
-	
+
 	ncolumns = tupdesc->natts;
 	needComma = false;
 
@@ -2261,15 +2262,73 @@ parse_record_to_string(char *string, TupleDesc tupdesc, char** values, bool *nul
 }
 
 /*
- * Collect a sample from segments.
- *
- * Calls the gp_acquire_sample_rows() helper function on each segment,
- * and merges the results.
+ * Build a querydesc for a sql, set "dest" to portal->holdStore
  */
+static QueryDesc *build_querydesc(Portal portal, char *sql)
+{
+	List	   *raw_parsetree_list;
+	RawStmt	   *parsetree;
+	List	   *querytree_list;
+	List	   *plantree_list;
+	PlannedStmt *plan_stmt;
+	DestReceiver *destReceiver;
+	QueryDesc  *queryDesc = NULL;
+	destReceiver = CreateDestReceiver(DestTuplestore);
+	SetTuplestoreDestReceiverParams(destReceiver,
+									portal->holdStore,
+									portal->holdContext,
+									false);
+
+	/*
+	 * Parse the SQL string into a list of raw parse trees.
+	 */
+	raw_parsetree_list = pg_parse_query(sql);
+
+	/*
+	 * Do parse analysis, rule rewrite, planning, and execution for each raw
+	 * parsetree.
+	 */
+
+	/* There is only one element in list due to simple select. */
+	Assert(list_length(raw_parsetree_list) == 1);
+	parsetree = (RawStmt *) linitial(raw_parsetree_list);
+
+	querytree_list = pg_analyze_and_rewrite(parsetree,
+											sql,
+											NULL,
+											0,
+											NULL);
+	plantree_list = pg_plan_queries(querytree_list, 0, NULL);
+
+	/* There is only one statement in list due to simple select. */
+	Assert(list_length(plantree_list) == 1);
+	plan_stmt = (PlannedStmt *) linitial(plantree_list);
+
+	queryDesc = CreateQueryDesc(plan_stmt,
+								sql,
+								GetActiveSnapshot(),
+								InvalidSnapshot,
+								destReceiver,
+								NULL,
+								NULL,
+								INSTRUMENT_NONE);
+
+
+
+	list_free_deep(querytree_list);
+	list_free_deep(raw_parsetree_list);
+
+	return queryDesc;
+}
+
 static int
-acquire_sample_rows_dispatcher(Relation onerel, bool inh, int elevel,
-							   HeapTuple *rows, int targrows,
-							   double *totalrows, double *totaldeadrows)
+process_sample_rows(Portal portal,
+					QueryDesc  *queryDesc,
+					Relation onerel,
+					HeapTuple *rows,
+					int targrows,
+					double *totalrows,
+					double *totaldeadrows)
 {
 	/*
 	 * 'colLargeRowIndexes' is essentially an argument, but it's passed via a
@@ -2280,39 +2339,17 @@ acquire_sample_rows_dispatcher(Relation onerel, bool inh, int elevel,
 	TupleDesc	relDesc = RelationGetDescr(onerel);
 	TupleDesc	funcTupleDesc;
 	TupleDesc	sampleTupleDesc;
-	AttInMetadata *attinmeta;
-	StringInfoData str;
 	int			sampleTuples;	/* 32 bit - assume that number of tuples will not > 2B */
-	char	  **funcRetValues;
+	Datum	   *funcRetValues;
 	bool	   *funcRetNulls;
-	char	  **values;
-	int			numLiveColumns;
-	int			perseg_targrows;
 	int			ncolumns;
-	CdbPgResults cdb_pgresults = {NULL, 0};
+	AttInMetadata *attinmeta;
+	int			numLiveColumns;
 	int			i;
 	int			index = 0;
-
-	Assert(targrows > 0.0);
-
-	/*
-	 * Acquire an evenly-sized sample from each segment.
-	 *
-	 * XXX: If there's a significant bias between the segments, i.e. some
-	 * segments have a lot more rows than others, the sample will biased, too.
-	 * Would be nice to improve that, but it's not clear how. We could issue
-	 * another query to get the table size from each segment first, and use
-	 * those to weigh the sample size to get from each segment. But that'd
-	 * require an extra round-trip, which is also not good. The caller
-	 * actually already did that, to get the total relation size, but it
-	 * doesn't pass that down to us, let alone the per-segment sizes.
-	 */
-	if (GpPolicyIsReplicated(onerel->rd_cdbpolicy))
-		perseg_targrows = targrows;
-	else if (GpPolicyIsPartitioned(onerel->rd_cdbpolicy))
-		perseg_targrows = targrows / onerel->rd_cdbpolicy->numsegments;
-	else
-		elog(ERROR, "acquire_sample_rows_dispatcher() cannot be used on a non-distributed table");
+	TupleTableSlot *slot;
+	Datum	   *dvalues;
+	bool	   *dnulls;
 
 	/*
 	 * Count the number of columns, excluding dropped columns. We'll need that
@@ -2330,26 +2367,6 @@ acquire_sample_rows_dispatcher(Relation onerel, bool inh, int elevel,
 	}
 
 	/*
-	 * Construct SQL command to dispatch to segments.
-	 *
-	 * Did not use 'select * from pg_catalog.gp_acquire_sample_rows(...) as (..);'
-	 * here. Because it requires to specify columns explicitly which leads to
-	 * permission check on each columns. This is not consistent with GPDB5 and
-	 * may result in different behaviour under different acl configuration.
-	 */
-	initStringInfo(&str);
-	appendStringInfo(&str, "select pg_catalog.gp_acquire_sample_rows(%u, %d, '%s');",
-					 RelationGetRelid(onerel),
-					 perseg_targrows,
-					 inh ? "t" : "f");
-
-	/*
-	 * Execute it.
-	 */
-	elog(elevel, "Executing SQL: %s", str.data);
-	CdbDispatchCommand(str.data, DF_WITH_SNAPSHOT | DF_CANCEL_ON_ERROR, &cdb_pgresults);
-
-	/*
 	 * Build a modified tuple descriptor for the table.
 	 *
 	 * Some datatypes need special treatment, so we cannot use the relation's
@@ -2364,11 +2381,11 @@ acquire_sample_rows_dispatcher(Relation onerel, bool inh, int elevel,
 	TupleDescInitEntry(funcTupleDesc, (AttrNumber) 1, "", FLOAT8OID, -1, 0);
 	TupleDescInitEntry(funcTupleDesc, (AttrNumber) 2, "", FLOAT8OID, -1, 0);
 	TupleDescInitEntry(funcTupleDesc, (AttrNumber) 3, "", FLOAT8ARRAYOID, -1, 0);
-	
+
 	for (i = 0; i < relDesc->natts; i++)
 	{
 		Form_pg_attribute attr = TupleDescAttr(relDesc, i);
-		
+
 		Oid			typid = gp_acquire_sample_rows_col_type(attr->atttypid);
 
 		TupleDescAttr(sampleTupleDesc, i)->atttypid = typid;
@@ -2377,7 +2394,7 @@ acquire_sample_rows_dispatcher(Relation onerel, bool inh, int elevel,
 		{
 			TupleDescInitEntry(funcTupleDesc, (AttrNumber) 4 + index, "",
 							   typid, attr->atttypmod, attr->attndims);
-		
+
 			index++;
 		}
 	}
@@ -2392,66 +2409,91 @@ acquire_sample_rows_dispatcher(Relation onerel, bool inh, int elevel,
 	 * Read the result set from each segment. Gather the sample rows *rows,
 	 * and sum up the summary rows for grand 'totalrows' and 'totaldeadrows'.
 	 */
-	funcRetValues = (char **) palloc0(funcTupleDesc->natts * sizeof(char *));
-	funcRetNulls = (bool *) palloc(funcTupleDesc->natts * sizeof(bool));
-	values = (char **) palloc0(relDesc->natts * sizeof(char *));
+	funcRetValues = (Datum *) palloc0(funcTupleDesc->natts * sizeof(Datum));
+	funcRetNulls = (bool *) palloc0(funcTupleDesc->natts * sizeof(bool));
+	dvalues = (Datum *) palloc0(relDesc->natts * sizeof(Datum));
+	dnulls = (bool *) palloc0(relDesc->natts * sizeof(bool));
 	sampleTuples = 0;
 	*totalrows = 0;
 	*totaldeadrows = 0;
-	for (int resultno = 0; resultno < cdb_pgresults.numResults; resultno++)
+
+	slot = MakeSingleTupleTableSlot(queryDesc->tupDesc, &TTSOpsMinimalTuple);
+
+	for (;;)
 	{
-		struct pg_result *pgresult = cdb_pgresults.pg_results[resultno];
-		bool		got_summary = false;
+		bool		ok;
+		TupleDesc	typeinfo;
+		int			natts;
+		Datum		attr;
+		bool		isnull;
 		double		this_totalrows = 0;
 		double		this_totaldeadrows = 0;
 
-		if (PQresultStatus(pgresult) != PGRES_TUPLES_OK)
+		CHECK_FOR_INTERRUPTS();
+
+		ok = tuplestore_gettupleslot(portal->holdStore, true, false, slot);
+
+		if (!ok)
+			break;
+
+		typeinfo = slot->tts_tupleDescriptor;
+		natts = typeinfo->natts;
+
+		/* There should be only one attribute with OID RECORDOID. */
+		if (1 != natts)
 		{
-			cdbdisp_clearCdbPgResults(&cdb_pgresults);
-			ereport(ERROR,
-					(errmsg("unexpected result from segment: %d",
-							PQresultStatus(pgresult))));
+			elog(ERROR,
+				"wrong number of attributes %d when 1 expected",
+				natts);
 		}
 
-		if (GpPolicyIsReplicated(onerel->rd_cdbpolicy))
+		if (RECORDOID != typeinfo->attrs[0].atttypid)
 		{
-			/*
-			 * A replicated table has the same data in all segments. Arbitrarily,
-			 * use the sample from the first segment, and discard the rest.
-			 * (This is rather inefficient, of course. It would be better to
-			 * dispatch to only one segment, but there is no easy API for that
-			 * in the dispatcher.)
-			 */
-			if (resultno > 0)
-				continue;
+			elog(ERROR,
+				"wrong attribute OID %d, RECORDOID %d is expected",
+				typeinfo->attrs[0].atttypid, RECORDOID);
+
 		}
 
-		for (int rowno = 0; rowno < PQntuples(pgresult); rowno++)
+		/* Make sure the tuple is fully deconstructed */
+		slot_getallattrs(slot);
+
+		/* There should be only one attribute with OID RECORDOID */
+		attr = slot_getattr(slot, 1, &isnull);
+		if (isnull)
 		{
-			/*
-			 * We cannot use record_in function to get row record here.
-			 * Since the result row may contain just the totalrows info where the data columns
-			 * are NULLs. Consider domain: 'create domain dnotnull varchar(15) NOT NULL;'
-			 * NULLs are not allowed in data columns.
-			 */
-			char * rowStr = PQgetvalue(pgresult, rowno, 0);
+			elog(ERROR,
+				"null value for attribute in tuple");
+		}
 
-			if (rowStr == NULL)
-				elog(ERROR, "got NULL pointer from return value of gp_acquire_sample_rows");
+		/* Get record from attribute and parse it */
+		{
+			HeapTupleHeader rec = (HeapTupleHeader) PG_DETOAST_DATUM(attr);
+			Oid			tupType;
+			int32		tupTypmod;
+			TupleDesc	tupdesc;
+			HeapTupleData tuple;
 
-			parse_record_to_string(rowStr, funcTupleDesc, funcRetValues, funcRetNulls);
+			/* Extract type info from the tuple itself */
+			tupType = HeapTupleHeaderGetTypeId(rec);
+			tupTypmod = HeapTupleHeaderGetTypMod(rec);
+			tupdesc = lookup_rowtype_tupdesc(tupType, tupTypmod);
+
+			/* Build a temporary HeapTuple control structure */
+			tuple.t_len = HeapTupleHeaderGetDatumLength(rec);
+			ItemPointerSetInvalid(&(tuple.t_self));
+			tuple.t_data = rec;
+
+			/* Break down the tuple into fields */
+			heap_deform_tuple(&tuple, tupdesc, funcRetValues, funcRetNulls);
 
 			if (!funcRetNulls[0])
 			{
 				/* This is a summary row. */
-				if (got_summary)
-					elog(ERROR, "got duplicate summary row from gp_acquire_sample_rows");
-
-				this_totalrows = DatumGetFloat8(DirectFunctionCall1(float8in,
-																	CStringGetDatum(funcRetValues[0])));
-				this_totaldeadrows = DatumGetFloat8(DirectFunctionCall1(float8in,
-																		CStringGetDatum(funcRetValues[1])));
-				got_summary = true;
+				this_totalrows = DatumGetFloat8(funcRetValues[0]);
+				this_totaldeadrows = DatumGetFloat8(funcRetValues[1]);
+				(*totalrows) += this_totalrows;
+				(*totaldeadrows) += this_totaldeadrows;
 			}
 			else
 			{
@@ -2466,10 +2508,7 @@ acquire_sample_rows_dispatcher(Relation onerel, bool inh, int elevel,
 					Datum	   *largelength;
 					bool	   *nulls;
 					int	    numelems;
-					arrayVal = DatumGetArrayTypeP(OidFunctionCall3(F_ARRAY_IN,
-											CStringGetDatum(funcRetValues[2]),
-											FLOAT8OID,
-											-1));
+					arrayVal = DatumGetArrayTypeP(funcRetValues[2]);
 					deconstruct_array(arrayVal, FLOAT8OID, 8, true, 'd',
 								&largelength, &nulls, &numelems);
 
@@ -2495,16 +2534,22 @@ acquire_sample_rows_dispatcher(Relation onerel, bool inh, int elevel,
 					Form_pg_attribute attr = TupleDescAttr(relDesc, i);
 
 					if (attr->attisdropped)
+					{
+						dnulls[i] = true;
 						continue;
+					}
 
-					if (funcRetNulls[FIX_ATTR_NUM + index])
-						values[i] = NULL;
-					else
-						values[i] = funcRetValues[FIX_ATTR_NUM + index];
-					index++; /* Move index to the next result set attribute */
+					dnulls[i] = funcRetNulls[FIX_ATTR_NUM + index];
+					dvalues[i] = funcRetValues[FIX_ATTR_NUM + index];
+					index++;	/* Move index to the next result set attribute */
 				}
 
-				rows[sampleTuples] = BuildTupleFromCStrings(attinmeta, values);
+				/*
+				* Form a tuple
+				*/
+				rows[sampleTuples] = heap_form_tuple(attinmeta->tupdesc,
+													dvalues,
+													dnulls);
 				sampleTuples++;
 
 				/*
@@ -2512,35 +2557,122 @@ acquire_sample_rows_dispatcher(Relation onerel, bool inh, int elevel,
 				 * collect stats for them
 				 */
 			}
+			ReleaseTupleDesc(tupdesc);
 		}
 
-		if (!got_summary)
-			elog(ERROR, "did not get summary row from gp_acquire_sample_rows");
-
-		if (resultno >= onerel->rd_cdbpolicy->numsegments)
-		{
-			/*
-			 * This result is for a segment that's not holding any data for this
-			 * table. Should get 0 rows.
-			 */
-			if (this_totalrows != 0)
-				elog(WARNING, "table \"%s\" contains rows in segment %d, which is outside the # of segments for the table's policy (%d segments)",
-					 RelationGetRelationName(onerel), resultno, onerel->rd_cdbpolicy->numsegments);
-		}
-
-		(*totalrows) += this_totalrows;
-		(*totaldeadrows) += this_totaldeadrows;
+		ExecClearTuple(slot);
 	}
-	for (i = 0; i < funcTupleDesc->natts; i++)
-	{
-		if (funcRetValues[i])
-			pfree(funcRetValues[i]);
-	}
+	ExecDropSingleTupleTableSlot(slot);
 	pfree(funcRetValues);
 	pfree(funcRetNulls);
-	pfree(values);
+	pfree(dvalues);
+	pfree(dnulls);
 
-	cdbdisp_clearCdbPgResults(&cdb_pgresults);
+	return sampleTuples;
+}
+
+/*
+ * Collect a sample from segments.
+ *
+ * Calls the gp_acquire_sample_rows() helper function on each segment,
+ * and merges the results.
+ */
+static int
+acquire_sample_rows_dispatcher(Relation onerel, bool inh, int elevel,
+							   HeapTuple *rows, int targrows,
+							   double *totalrows, double *totaldeadrows)
+{
+	StringInfoData str;
+	int			perseg_targrows;
+	int			sampleTuples;	/* 32 bit - assume that number of tuples will not > 2B */
+	char	   *sql;
+	Portal		portal;
+	QueryDesc  *queryDesc = NULL;
+
+	Assert(targrows > 0.0);
+
+	/*
+	 * Step1: Construct SQL command to dispatch to segments.
+	 *
+	 * Acquire an evenly-sized sample from each segment.
+	 *
+	 * XXX: If there's a significant bias between the segments, i.e. some
+	 * segments have a lot more rows than others, the sample will biased, too.
+	 * Would be nice to improve that, but it's not clear how. We could issue
+	 * another query to get the table size from each segment first, and use
+	 * those to weigh the sample size to get from each segment. But that'd
+	 * require an extra round-trip, which is also not good. The caller
+	 * actually already did that, to get the total relation size, but it
+	 * doesn't pass that down to us, let alone the per-segment sizes.
+	 */
+	if (GpPolicyIsReplicated(onerel->rd_cdbpolicy))
+		perseg_targrows = targrows;
+	else if (GpPolicyIsPartitioned(onerel->rd_cdbpolicy))
+		perseg_targrows = targrows / onerel->rd_cdbpolicy->numsegments;
+	else
+		elog(ERROR, "acquire_sample_rows_dispatcher() cannot be used on a non-distributed table");
+
+	/*
+	 * Did not use 'select * from pg_catalog.gp_acquire_sample_rows(...) as (..);'
+	 * here. Because it requires to specify columns explicitly which leads to
+	 * permission check on each columns. This is not consistent with GPDB5 and
+	 * may result in different behaviour under different acl configuration.
+	 */
+	initStringInfo(&str);
+	appendStringInfo(&str, "select pg_catalog.gp_acquire_sample_rows(%u, %d, '%s');",
+					 RelationGetRelid(onerel),
+					 perseg_targrows,
+					 inh ? "t" : "f");
+
+	/*
+	 * Step2: Execute the constructed SQL.
+	 *
+	 * Do not use SPI here, because there might be a large number of wide rows
+	 * returned and stored in memory, SPI cannot spill data to disk which may
+	 * lead to OOM easily.
+	 *
+	 * Do not use SPI cusror either, because we should use SPI_cursor_fetch to fetch
+	 * results in batches, which may have bad performance.
+	 *
+	 * Use ExecutorStart|ExecutorRun|ExecutorEnd to execute a plan and store results
+	 * into tuplestore could handle this situation well.
+	 *
+	 * Execute the given query and store the results into portal->holdStore to
+	 * avoid memory error.
+	 */
+	elog(elevel, "Executing SQL: %s", str.data);
+	sql = str.data;
+	/* Create a new portal to run the query in */
+	portal = CreateNewPortal();
+	/* Don't display the portal in pg_cursors, it is for internal use only */
+	portal->visible = false;
+	/* use a tuplestore to store received tuples to avoid out of memory error */
+	PortalCreateHoldStore(portal);
+	queryDesc = build_querydesc(portal, sql);
+
+	/* Call ExecutorStart to prepare the plan for execution */
+	ExecutorStart(queryDesc, 0);
+
+	/* Run the plan  */
+	ExecutorRun(queryDesc, ForwardScanDirection, 0L, true);
+
+	/* Wait for completion of all qExec processes. */
+	if (queryDesc->estate->dispatcherState
+		&& queryDesc->estate->dispatcherState->primaryResults)
+	{
+		cdbdisp_checkDispatchResult(queryDesc->estate->dispatcherState, DISPATCH_WAIT_NONE);
+	}
+
+	ExecutorFinish(queryDesc);
+	/*
+	 * Step3: process results.
+	 */
+	sampleTuples = process_sample_rows(portal, queryDesc, onerel, rows,
+									targrows, totalrows, totaldeadrows);
+
+	ExecutorEnd(queryDesc);
+	FreeQueryDesc(queryDesc);
+	PortalDrop(portal, false);
 
 	return sampleTuples;
 }

--- a/src/backend/commands/analyzefuncs.c
+++ b/src/backend/commands/analyzefuncs.c
@@ -205,6 +205,15 @@ gp_acquire_sample_rows(PG_FUNCTION_ARGS)
 
 		ctx->index = 0;
 		ctx->summary_sent = false;
+		/*
+		 * we only get sample data from segindex 0 for replicated table
+		 */
+		if (Gp_role == GP_ROLE_EXECUTE && GpPolicyIsReplicated(onerel->rd_cdbpolicy)
+									   && GpIdentity.segindex > 0)
+		{
+			ctx->index = ctx->num_sample_rows;
+			ctx->summary_sent = true;
+		}
 
 		MemoryContextSwitchTo(oldcontext);
 	}

--- a/src/test/regress/expected/analyze.out
+++ b/src/test/regress/expected/analyze.out
@@ -1149,8 +1149,39 @@ SELECT correlation FROM pg_stats WHERE tablename ='analyze_table';
 (2 rows)
 
 -- test6: randomly table
+-- we use weighted mean algorithm to calculate correlations.
+-- the formula for calculating the weighted mean is:
+-- sum(correlationOnSeg[i] * (totalRowsOnSeg[i] / totalRows))
+-- i is from 0 to N. N is the number of segments.
+-- however, for randomly table the data in each segment may diff each time.
+-- it will affect the value of correlation.
+-- So ignore the results
 drop table analyze_table;
 create table analyze_table(tc1 int,tc2 int) distributed randomly;
+insert into analyze_table select i,i from generate_series(1,100) i;
+analyze analyze_table;
+-- start_ignore
+SELECT correlation FROM pg_stats WHERE tablename ='analyze_table';
+ correlation 
+-------------
+           1
+           1
+(2 rows)
+
+-- end_ignore
+alter table analyze_table drop column tc1;
+analyze analyze_table;
+-- start_ignore
+SELECT correlation FROM pg_stats WHERE tablename ='analyze_table';
+ correlation 
+-------------
+           1
+(1 row)
+
+-- end_ignore
+-- test7: replicated table
+drop table analyze_table;
+create table analyze_table(tc1 int,tc2 int) distributed replicated;
 insert into analyze_table select i,i from generate_series(1,100) i;
 analyze analyze_table;
 SELECT correlation FROM pg_stats WHERE tablename ='analyze_table';
@@ -1160,15 +1191,15 @@ SELECT correlation FROM pg_stats WHERE tablename ='analyze_table';
            1
 (2 rows)
 
-alter table analyze_table drop column tc1;
 analyze analyze_table;
 SELECT correlation FROM pg_stats WHERE tablename ='analyze_table';
  correlation 
 -------------
            1
-(1 row)
+           1
+(2 rows)
 
--- test7: inherit table
+-- test8: inherit table
 drop table analyze_parent cascade;
 ERROR:  table "analyze_parent" does not exist
 create table analyze_parent (tc1 int,tc2 int);
@@ -1191,7 +1222,7 @@ SELECT correlation,attname,inherited FROM pg_stats WHERE tablename ='analyze_chi
 -------------+---------+-----------
 (0 rows)
 
--- test8: partition table test
+-- test9: partition table test
 CREATE TABLE partition_table (
     tc1 int,
     tc2 int
@@ -1242,3 +1273,23 @@ SELECT correlation,attname,inherited FROM pg_stats WHERE tablename ='partition_t
            1 | tc2     | f
 (2 rows)
 
+--
+-- Test analyze for table with maximum float8 value 1.7976931348623157e+308
+-- There should be no "ERROR:  value out of range: overflow"
+--
+set extra_float_digits to 0;
+create table test_max_float8(a double precision);
+insert into test_max_float8 values(1.7976931348623157e+308);
+analyze test_max_float8;
+drop table test_max_float8;
+reset extra_float_digits;
+-- test analyze when table has large column
+create table ttt_large_column(tc1 int,tc2 char(1500),tc3 char(1500));
+insert into ttt_large_column select i,repeat('wwweereeer',150),repeat('ssddbbbbbb',150) from generate_series(1,5) i;
+analyze ttt_large_column;
+drop table ttt_large_column;
+--test analyze replicated table
+create table analyze_replicated(tc1 int,tc2 int) distributed replicated;
+insert into analyze_replicated select i, i from generate_series(1,1000) i;
+analyze analyze_replicated;
+drop table analyze_replicated;

--- a/src/test/regress/expected/bfv_dd.out
+++ b/src/test/regress/expected/bfv_dd.out
@@ -19,6 +19,7 @@ insert into dd_singlecol_1 values(null, null);
 INFO:  (slice 0) Dispatch command to SINGLE content
 INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to SINGLE content
 analyze dd_singlecol_1;
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 -- ctas tests
 create table dd_ctas_1 as select * from dd_singlecol_1 where a=1 distributed by (a);
 INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
@@ -316,7 +317,9 @@ insert into dd_singlecol_idx2 values(null, null);
 INFO:  (slice 0) Dispatch command to SINGLE content
 INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to SINGLE content
 analyze dd_singlecol_idx;
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 analyze dd_singlecol_idx2;
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 -- disjunction with index scans
 select * from dd_singlecol_idx where (a=1 or a=2) and b<2;
 INFO:  (slice 1) Dispatch command to PARTIAL contents: 1 0
@@ -365,6 +368,7 @@ insert into dd_singlecol_bitmap_idx values(null, null);
 INFO:  (slice 0) Dispatch command to SINGLE content
 INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to SINGLE content
 analyze dd_singlecol_bitmap_idx;
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 -- disjunction with bitmap index scans
 select * from dd_singlecol_bitmap_idx where (a=1 or a=2) and b<2;
 INFO:  (slice 1) Dispatch command to PARTIAL contents: 1 0
@@ -441,6 +445,12 @@ insert into dd_singlecol_part_bitmap_idx values(null, null);
 INFO:  (slice 0) Dispatch command to SINGLE content
 INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to SINGLE content
 analyze dd_singlecol_part_bitmap_idx;
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 -- bitmap indexes on partitioned tables
 select * from dd_singlecol_part_bitmap_idx where a=1 and b=0;
 INFO:  (slice 1) Dispatch command to SINGLE content
@@ -486,6 +496,7 @@ insert into dd_multicol_idx values(null, null);
 INFO:  (slice 0) Dispatch command to SINGLE content
 INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to SINGLE content
 analyze dd_multicol_idx;
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 select count(*) from dd_multicol_idx;
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
  count 
@@ -609,7 +620,19 @@ insert into dd_singlecol_part_idx2 values(null, null);
 INFO:  (slice 0) Dispatch command to SINGLE content
 INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to SINGLE content
 analyze dd_singlecol_part_idx;
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 analyze dd_singlecol_part_idx2;
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 -- indexes on partitioned tables
 select * from dd_singlecol_part_idx where a=1 and b>0;
 INFO:  (slice 1) Dispatch command to SINGLE content

--- a/src/test/regress/expected/bfv_dd_multicolumn.out
+++ b/src/test/regress/expected/bfv_dd_multicolumn.out
@@ -29,6 +29,7 @@ insert into dd_multicol_1 values(null, 1);
 INFO:  (slice 0) Dispatch command to SINGLE content
 INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to SINGLE content
 analyze dd_multicol_1;
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 insert into dd_multicol_2 select g, g%2 from generate_series(1, 100) g;
 INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
 INFO:  (slice 1) Dispatch command to SINGLE content

--- a/src/test/regress/expected/bfv_dd_multicolumn_optimizer.out
+++ b/src/test/regress/expected/bfv_dd_multicolumn_optimizer.out
@@ -31,6 +31,7 @@ INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
 INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
 analyze dd_multicol_1;
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 insert into dd_multicol_2 select g, g%2 from generate_series(1, 100) g;
 INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
 INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2

--- a/src/test/regress/expected/bfv_dd_optimizer.out
+++ b/src/test/regress/expected/bfv_dd_optimizer.out
@@ -18,6 +18,7 @@ insert into dd_singlecol_1 values(null, null);
 INFO:  (slice 0) Dispatch command to SINGLE content
 INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to SINGLE content
 analyze dd_singlecol_1;
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 -- ctas tests
 create table dd_ctas_1 as select * from dd_singlecol_1 where a=1 distributed by (a);
 INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
@@ -312,7 +313,9 @@ insert into dd_singlecol_idx2 values(null, null);
 INFO:  (slice 0) Dispatch command to SINGLE content
 INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to SINGLE content
 analyze dd_singlecol_idx;
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 analyze dd_singlecol_idx2;
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 -- disjunction with index scans
 select * from dd_singlecol_idx where (a=1 or a=2) and b<2;
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
@@ -360,6 +363,7 @@ insert into dd_singlecol_bitmap_idx values(null, null);
 INFO:  (slice 0) Dispatch command to SINGLE content
 INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to SINGLE content
 analyze dd_singlecol_bitmap_idx;
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 -- disjunction with bitmap index scans
 select * from dd_singlecol_bitmap_idx where (a=1 or a=2) and b<2;
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
@@ -435,6 +439,12 @@ insert into dd_singlecol_part_bitmap_idx values(null, null);
 INFO:  (slice 0) Dispatch command to SINGLE content
 INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to SINGLE content
 analyze dd_singlecol_part_bitmap_idx;
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 -- bitmap indexes on partitioned tables
 select * from dd_singlecol_part_bitmap_idx where a=1 and b=0;
 INFO:  (slice 1) Dispatch command to SINGLE content
@@ -480,6 +490,7 @@ INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
 INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
 analyze dd_multicol_idx;
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 select count(*) from dd_multicol_idx;
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
  count 
@@ -601,7 +612,19 @@ insert into dd_singlecol_part_idx2 values(null, null);
 INFO:  (slice 0) Dispatch command to SINGLE content
 INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to SINGLE content
 analyze dd_singlecol_part_idx;
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 analyze dd_singlecol_part_idx2;
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
 -- indexes on partitioned tables
 select * from dd_singlecol_part_idx where a=1 and b>0;
 INFO:  (slice 1) Dispatch command to SINGLE content

--- a/src/test/regress/sql/analyze.sql
+++ b/src/test/regress/sql/analyze.sql
@@ -577,16 +577,36 @@ analyze analyze_table;
 SELECT correlation FROM pg_stats WHERE tablename ='analyze_table';
 
 -- test6: randomly table
+-- we use weighted mean algorithm to calculate correlations.
+-- the formula for calculating the weighted mean is:
+-- sum(correlationOnSeg[i] * (totalRowsOnSeg[i] / totalRows))
+-- i is from 0 to N. N is the number of segments.
+-- however, for randomly table the data in each segment may diff each time.
+-- it will affect the value of correlation.
+-- So ignore the results
 drop table analyze_table;
 create table analyze_table(tc1 int,tc2 int) distributed randomly;
 insert into analyze_table select i,i from generate_series(1,100) i;
 analyze analyze_table;
+-- start_ignore
 SELECT correlation FROM pg_stats WHERE tablename ='analyze_table';
+-- end_ignore
 alter table analyze_table drop column tc1;
+analyze analyze_table;
+-- start_ignore
+SELECT correlation FROM pg_stats WHERE tablename ='analyze_table';
+-- end_ignore
+
+-- test7: replicated table
+drop table analyze_table;
+create table analyze_table(tc1 int,tc2 int) distributed replicated;
+insert into analyze_table select i,i from generate_series(1,100) i;
+analyze analyze_table;
+SELECT correlation FROM pg_stats WHERE tablename ='analyze_table';
 analyze analyze_table;
 SELECT correlation FROM pg_stats WHERE tablename ='analyze_table';
 
--- test7: inherit table
+-- test8: inherit table
 drop table analyze_parent cascade;
 create table analyze_parent (tc1 int,tc2 int);
 create table analyze_child(tc3 int,tc4 int)inherits (analyze_parent);
@@ -597,7 +617,7 @@ analyze analyze_parent;
 SELECT correlation,attname,inherited FROM pg_stats WHERE tablename ='analyze_parent';
 SELECT correlation,attname,inherited FROM pg_stats WHERE tablename ='analyze_child';
 
--- test8: partition table test
+-- test9: partition table test
 CREATE TABLE partition_table (
     tc1 int,
     tc2 int
@@ -615,3 +635,25 @@ SELECT correlation,attname,inherited FROM pg_stats WHERE tablename ='partition_t
 SELECT correlation,attname,inherited FROM pg_stats WHERE tablename ='partition_table_1_prt_3';
 SELECT correlation,attname,inherited FROM pg_stats WHERE tablename ='partition_table_1_prt_4';
 SELECT correlation,attname,inherited FROM pg_stats WHERE tablename ='partition_table_1_prt_5';
+--
+-- Test analyze for table with maximum float8 value 1.7976931348623157e+308
+-- There should be no "ERROR:  value out of range: overflow"
+--
+set extra_float_digits to 0;
+create table test_max_float8(a double precision);
+insert into test_max_float8 values(1.7976931348623157e+308);
+analyze test_max_float8;
+drop table test_max_float8;
+reset extra_float_digits;
+
+-- test analyze when table has large column
+create table ttt_large_column(tc1 int,tc2 char(1500),tc3 char(1500));
+insert into ttt_large_column select i,repeat('wwweereeer',150),repeat('ssddbbbbbb',150) from generate_series(1,5) i;
+analyze ttt_large_column;
+drop table ttt_large_column;
+
+--test analyze replicated table
+create table analyze_replicated(tc1 int,tc2 int) distributed replicated;
+insert into analyze_replicated select i, i from generate_series(1,1000) i;
+analyze analyze_replicated;
+drop table analyze_replicated;


### PR DESCRIPTION
Send results of select pg_catalog.gp_acquire_sample_rows query in binary mode.
That allows to avoid overflow for max double.

For example, if run the following prior to this fix:

set extra_float_digits to 0;
create table t (a double precision);
insert into t values (1.7976931348623157e+308);
analyze t;
the following message will be printed:
ERROR:  value out of range: overflow

For text mode (default) when analyze for table is performed the
master calls gp_acquire_sample_rows() helper function on each
segment. That eventually calls float8out function on segment to
converts float8 number to a string with snprintf:

int	ndig = DBL_DIG + extra_float_digits; 
snprintf(ascii, MAXDOUBLEWIDTH + 1, "%.*g", ndig, num); 
When ndig is 15 the maximum float8 value 1.7976931348623157e+308 is
rounded to "1.79769313486232e+308" that has no representation.

And on master acquire_sample_rows_dispatcher function
process gp_acquire_sample_rows result and eventually float8in
function is called to convert string to float8 with strtold:
val = strtold(num, &endptr); 
This is where overflow for "1.79769313486232e+308" happens but works
fine for "1.7976931348623157e+308".

Transferring in binary mode allows to avoid conversion from double to
string on segments and then back to double on master. And this will
much faster than before.

Using CdbDispatchPlan instead of CdbDispatchCommand allows
to receive data in binary mode in MemTuple, and this is much faster than before.

Using tuplestore to store received tuples to avoid use too many memory.

This pr is referenced to #12607. And base on it, I made the following modifications:
1. #12607 is opened on 2021, I merged it with latest codes.

2. fix analyze replicated table issue.
    after we use CdbDispatchPlan instead of CdbDispatchCommand, we get tuples from segments by motion.
    And we can not control the order of data arrives from each segments. 
    when we get the summary row from one segment, we may get some sample rows from other segments.
    and which hit the error "too many sample rows received from gp_acquire_sample_rows".

    So when the table is replicated, only the first segment send the sample and summary tuples.

3. fix QD will panic when hit out of memory error.
    if a tuple is large and we set default_statistics_target to a large value, acquire_sample_rows_dispatcher
    needs a lot of memory to store tuples into variable rows, When memory is not sufficient, it will hit out of
    memory error, then call AtAbort_Portals-->MemoryContextDeleteChildren to delete MotionLayerMemCtxt
    and other memoryContext, after that we call ResourceOwnerReleaseInternal-->DestroyTupleRemapper to
    pfree a memory be allocated from MotionLayerMemCtxt and cause panic.

    this has been resolved by #15340.

4. After this pr, some cases failed, because of correlation of pg_stats changed.
    The introduce of correlation is as follows:
    Statistical correlation between physical row ordering and logical ordering of the column values. 
    This ranges from -1 to +1. When the value is near -1 or +1, an index scan on the column will be
    estimated to be cheaper than when it is near zero, due to reduction of random access to the disk. 
   
    After this pr we can not control the order of data arrives from each segments. 
    So the physical row ordering is not fixed and lead to correlation is unstable.

    But I find the correlation in pg_stats for GreenPlum is not correctly calculated.
    We cannot use the same method as PostgreSQL does to calculate the correlation in QD.
    when we collect data from segments to QD, this will change the physical order
    of the data.
    such as  in segment 1 the data is 1,3,5,7,9. And in segment 2 the data is 2,4,6,8,10.
    In each segment the data is ordered, and we can connect to segment use utility mode
    to see correlation is 1.
    But after we collect the data to QD, it may be 1,3,5,2,4,7,9,6,8,10. And the correlation is 0.3 or
    something else and it is not stable. And this will increase the cost of index scan which is shouldn't
    be done.

    such as:
    create table t_rep(tc1 int) distributed replicated;
    insert into t_rep select generate_series(1,10000);
    analyze t_rep;
    SELECT * FROM pg_stats WHERE tablename ='t_rep';
    the correlation of tc1 is 1. this indicate the physical order is the same as sorted order, and this is reasonable.

    But we change the distributed by clause to randomly or hash.
    create table t_randomly(tc1 int) distributed randomly;
    insert into t_randomly select generate_series(1,10000);
    analyze t_randomly;
    SELECT * FROM pg_stats WHERE tablename ='t_randomly';
    the correlation of tc1 is 0.3 or something else and it is not stable.
    This will affect the cost of index scan.

    The correlation should be calculated in segments and summarized in QD .
    The final value of correlation should be stable. And we plan to modify it in another pr.