### PR TITLE
Skip pq_endmessage() for bgworker.

### DIFF
--- a/src/backend/cdb/dispatcher/cdbconn.c
+++ b/src/backend/cdb/dispatcher/cdbconn.c
@@ -863,6 +863,10 @@ forwardQENotices(void)
 			{
 				pq_endmessage(&msgbuf);
 			}
+			else
+			{
+				elog(WARNING, "%s", msgbuf.data);
+			}
 			free(notice);
 		}
 		PG_CATCH();

--- a/src/test/modules/Makefile
+++ b/src/test/modules/Makefile
@@ -21,6 +21,7 @@ SUBDIRS = \
 		  test_rls_hooks \
 		  test_shm_mq \
 		  unsafe_tests \
+		  gp_worker_spi \
 		  worker_spi
 
 # GPDB subdirs

--- a/src/test/modules/gp_worker_spi/.gitignore
+++ b/src/test/modules/gp_worker_spi/.gitignore
@@ -1,0 +1,6 @@
+# Generated subdirectories
+/log/
+/results/
+/tmp_check/
+regression.diffs
+regression.out

--- a/src/test/modules/gp_worker_spi/Makefile
+++ b/src/test/modules/gp_worker_spi/Makefile
@@ -1,0 +1,19 @@
+# src/test/modules/gp_worker_spi/Makefile
+
+MODULES = gp_worker_spi
+
+REGRESS = gp_worker_spi
+
+# enable our module in shared_preload_libraries for dynamic bgworkers
+REGRESS_OPTS = --dbname=contrib_regression
+
+ifdef USE_PGXS
+PG_CONFIG = pg_config
+PGXS := $(shell $(PG_CONFIG) --pgxs)
+include $(PGXS)
+else
+subdir = src/test/modules/gp_worker_spi
+top_builddir = ../../../..
+include $(top_builddir)/src/Makefile.global
+include $(top_srcdir)/contrib/contrib-global.mk
+endif

--- a/src/test/modules/gp_worker_spi/expected/gp_worker_spi.out
+++ b/src/test/modules/gp_worker_spi/expected/gp_worker_spi.out
@@ -1,0 +1,126 @@
+-- initialize database
+-- start_ignore
+DROP TABLE IF EXISTS worker_spi.counted1;
+NOTICE:  schema "worker_spi" does not exist, skipping
+NOTICE:  schema "worker_spi" does not exist, skipping  (seg2 127.0.0.1:7004 pid=6450)
+NOTICE:  schema "worker_spi" does not exist, skipping  (seg1 127.0.0.1:7003 pid=6451)
+NOTICE:  schema "worker_spi" does not exist, skipping  (seg0 127.0.0.1:7002 pid=6449)
+DROP SCHEMA IF EXISTS worker_spi;
+NOTICE:  schema "worker_spi" does not exist, skipping
+-- end_ignore
+CREATE SCHEMA worker_spi;
+CREATE TABLE worker_spi.counted1(val int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'val' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- create raise notice function
+CREATE FUNCTION raise_notice_func(gp_segment_id int) RETURNS int LANGUAGE plpgsql AS $$
+DECLARE
+BEGIN
+RAISE NOTICE 'this is raise function';
+RETURN gp_segment_id;
+END;
+$$;
+-- start_ignore
+\! gpconfig -c shared_preload_libraries -v 'gp_worker_spi'
+20230315:11:32:01:006455 gpconfig:zhrt:zhrt-[INFO]:-completed successfully with parameters '-c shared_preload_libraries -v gp_worker_spi'
+\! gpstop -raf
+20230315:11:32:02:006640 gpstop:zhrt:zhrt-[INFO]:-Starting gpstop with args: -raf
+20230315:11:32:02:006640 gpstop:zhrt:zhrt-[INFO]:-Gathering information and validating the environment...
+20230315:11:32:02:006640 gpstop:zhrt:zhrt-[INFO]:-Obtaining Greenplum Coordinator catalog information
+20230315:11:32:02:006640 gpstop:zhrt:zhrt-[INFO]:-Obtaining Segment details from coordinator...
+20230315:11:32:02:006640 gpstop:zhrt:zhrt-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 7.0.0-beta.1+dev.224.g3ce875dab5 build dev'
+20230315:11:32:02:006640 gpstop:zhrt:zhrt-[INFO]:-Commencing Coordinator instance shutdown with mode='fast'
+20230315:11:32:02:006640 gpstop:zhrt:zhrt-[INFO]:-Coordinator segment instance directory=/home/zhrt/workspace/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
+20230315:11:32:02:006640 gpstop:zhrt:zhrt-[INFO]:-Attempting forceful termination of any leftover coordinator process
+20230315:11:32:02:006640 gpstop:zhrt:zhrt-[INFO]:-Terminating processes for segment /home/zhrt/workspace/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
+20230315:11:32:02:006640 gpstop:zhrt:zhrt-[INFO]:-Stopping coordinator standby host zhrt mode=fast
+20230315:11:32:02:006640 gpstop:zhrt:zhrt-[INFO]:-Successfully shutdown standby process on zhrt
+20230315:11:32:02:006640 gpstop:zhrt:zhrt-[INFO]:-Targeting dbid [2, 5, 3, 6, 4, 7] for shutdown
+20230315:11:32:02:006640 gpstop:zhrt:zhrt-[INFO]:-Commencing parallel primary segment instance shutdown, please wait...
+20230315:11:32:02:006640 gpstop:zhrt:zhrt-[INFO]:-0.00% of jobs completed
+20230315:11:32:03:006640 gpstop:zhrt:zhrt-[INFO]:-100.00% of jobs completed
+20230315:11:32:03:006640 gpstop:zhrt:zhrt-[INFO]:-Commencing parallel mirror segment instance shutdown, please wait...
+20230315:11:32:03:006640 gpstop:zhrt:zhrt-[INFO]:-0.00% of jobs completed
+20230315:11:32:03:006640 gpstop:zhrt:zhrt-[INFO]:-100.00% of jobs completed
+20230315:11:32:03:006640 gpstop:zhrt:zhrt-[INFO]:-----------------------------------------------------
+20230315:11:32:03:006640 gpstop:zhrt:zhrt-[INFO]:-   Segments stopped successfully      = 6
+20230315:11:32:03:006640 gpstop:zhrt:zhrt-[INFO]:-   Segments with errors during stop   = 0
+20230315:11:32:03:006640 gpstop:zhrt:zhrt-[INFO]:-----------------------------------------------------
+20230315:11:32:03:006640 gpstop:zhrt:zhrt-[INFO]:-Successfully shutdown 6 of 6 segment instances 
+20230315:11:32:03:006640 gpstop:zhrt:zhrt-[INFO]:-Database successfully shutdown with no errors reported
+20230315:11:32:03:006640 gpstop:zhrt:zhrt-[INFO]:-Restarting System...
+-- end_ignore
+\c
+-- wait until the worker completes its initialization
+DO $$
+DECLARE
+	visible bool;
+	loops int := 0;
+BEGIN
+	LOOP
+		visible := table_name IS NOT NULL
+			FROM information_schema.tables
+			WHERE table_name = 'counted1';
+		IF visible OR loops > 120 * 10 THEN EXIT; END IF;
+		PERFORM pg_sleep(0.1);
+		loops := loops + 1;
+	END LOOP;
+END
+$$;
+-- wait until the worker has processed the tuple
+DO $$
+DECLARE
+	count int;
+	loops int := 0;
+BEGIN
+	LOOP
+		count := count(*) FROM worker_spi.counted1;
+		IF count > 0 OR loops > 120 * 10 THEN EXIT; END IF;
+		PERFORM pg_sleep(0.1);
+		loops := loops + 1;
+	END LOOP;
+END
+$$;
+-- the result should be (0, 1, 2)
+SELECT DISTINCT val FROM worker_spi.counted1 ORDER BY val;
+ val 
+-----
+   0
+   1
+   2
+(3 rows)
+
+-- clean database
+DROP FUNCTION raise_notice_func(gp_segment_id int);
+DROP TABLE worker_spi.counted1;
+DROP SCHEMA worker_spi;
+-- start_ignore
+\! gpconfig -c shared_preload_libraries -v ''
+20230315:11:32:06:007504 gpconfig:zhrt:zhrt-[INFO]:-completed successfully with parameters '-c shared_preload_libraries -v '''
+\! gpstop -raf
+20230315:11:32:06:007720 gpstop:zhrt:zhrt-[INFO]:-Starting gpstop with args: -raf
+20230315:11:32:06:007720 gpstop:zhrt:zhrt-[INFO]:-Gathering information and validating the environment...
+20230315:11:32:06:007720 gpstop:zhrt:zhrt-[INFO]:-Obtaining Greenplum Coordinator catalog information
+20230315:11:32:06:007720 gpstop:zhrt:zhrt-[INFO]:-Obtaining Segment details from coordinator...
+20230315:11:32:06:007720 gpstop:zhrt:zhrt-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 7.0.0-beta.1+dev.224.g3ce875dab5 build dev'
+20230315:11:32:06:007720 gpstop:zhrt:zhrt-[INFO]:-Commencing Coordinator instance shutdown with mode='fast'
+20230315:11:32:06:007720 gpstop:zhrt:zhrt-[INFO]:-Coordinator segment instance directory=/home/zhrt/workspace/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
+20230315:11:32:07:007720 gpstop:zhrt:zhrt-[INFO]:-Attempting forceful termination of any leftover coordinator process
+20230315:11:32:07:007720 gpstop:zhrt:zhrt-[INFO]:-Terminating processes for segment /home/zhrt/workspace/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
+20230315:11:32:07:007720 gpstop:zhrt:zhrt-[INFO]:-Stopping coordinator standby host zhrt mode=fast
+20230315:11:32:07:007720 gpstop:zhrt:zhrt-[INFO]:-Successfully shutdown standby process on zhrt
+20230315:11:32:07:007720 gpstop:zhrt:zhrt-[INFO]:-Targeting dbid [2, 5, 3, 6, 4, 7] for shutdown
+20230315:11:32:07:007720 gpstop:zhrt:zhrt-[INFO]:-Commencing parallel primary segment instance shutdown, please wait...
+20230315:11:32:07:007720 gpstop:zhrt:zhrt-[INFO]:-0.00% of jobs completed
+20230315:11:32:08:007720 gpstop:zhrt:zhrt-[INFO]:-100.00% of jobs completed
+20230315:11:32:08:007720 gpstop:zhrt:zhrt-[INFO]:-Commencing parallel mirror segment instance shutdown, please wait...
+20230315:11:32:08:007720 gpstop:zhrt:zhrt-[INFO]:-0.00% of jobs completed
+20230315:11:32:08:007720 gpstop:zhrt:zhrt-[INFO]:-100.00% of jobs completed
+20230315:11:32:08:007720 gpstop:zhrt:zhrt-[INFO]:-----------------------------------------------------
+20230315:11:32:08:007720 gpstop:zhrt:zhrt-[INFO]:-   Segments stopped successfully      = 6
+20230315:11:32:08:007720 gpstop:zhrt:zhrt-[INFO]:-   Segments with errors during stop   = 0
+20230315:11:32:08:007720 gpstop:zhrt:zhrt-[INFO]:-----------------------------------------------------
+20230315:11:32:08:007720 gpstop:zhrt:zhrt-[INFO]:-Successfully shutdown 6 of 6 segment instances 
+20230315:11:32:08:007720 gpstop:zhrt:zhrt-[INFO]:-Database successfully shutdown with no errors reported
+20230315:11:32:08:007720 gpstop:zhrt:zhrt-[INFO]:-Restarting System...
+-- end_ignore

--- a/src/test/modules/gp_worker_spi/gp_worker_spi.c
+++ b/src/test/modules/gp_worker_spi/gp_worker_spi.c
@@ -1,0 +1,268 @@
+/*-------------------------------------------------------------------------
+ *
+ * gp_worker_spi.c
+ *
+ * Portions Copyright (c) 2023-Present VMware, Inc. or its affiliates.
+ *
+ *
+ * IDENTIFICATION
+ *	   src/test/modules/gp_worker_spi/gp_worker_spi.c
+ *
+ *-------------------------------------------------------------------------
+ */
+#include "postgres.h"
+
+/* These are always necessary for a bgworker */
+#include "miscadmin.h"
+#include "postmaster/bgworker.h"
+#include "storage/ipc.h"
+#include "storage/latch.h"
+#include "storage/lwlock.h"
+#include "storage/proc.h"
+#include "storage/shmem.h"
+
+/* these headers are used by this particular worker's code */
+#include "access/xact.h"
+#include "executor/spi.h"
+#include "fmgr.h"
+#include "lib/stringinfo.h"
+#include "pgstat.h"
+#include "utils/builtins.h"
+#include "utils/snapmgr.h"
+#include "tcop/utility.h"
+
+PG_MODULE_MAGIC;
+
+void _PG_init(void);
+void gp_worker_spi_main(Datum) pg_attribute_noreturn();
+
+/* flags set by signal handlers */
+static volatile sig_atomic_t got_sighup = false;
+static volatile sig_atomic_t got_sigterm = false;
+
+/* GUC variables */
+static int gp_worker_spi_naptime = 10;
+static int gp_worker_spi_total_workers = 1;
+static char *gp_worker_spi_database = NULL;
+
+typedef struct worktable
+{
+	const char *name;
+} worktable;
+
+/*
+ * Signal handler for SIGTERM
+ *		Set a flag to let the main loop to terminate, and set our latch to wake
+ *		it up.
+ */
+static void
+gp_worker_spi_sigterm(SIGNAL_ARGS)
+{
+	int save_errno = errno;
+
+	got_sigterm = true;
+	SetLatch(MyLatch);
+
+	errno = save_errno;
+}
+
+/*
+ * Signal handler for SIGHUP
+ *		Set a flag to tell the main loop to reread the config file, and set
+ *		our latch to wake it up.
+ */
+static void
+gp_worker_spi_sighup(SIGNAL_ARGS)
+{
+	int save_errno = errno;
+
+	got_sighup = true;
+	SetLatch(MyLatch);
+
+	errno = save_errno;
+}
+
+/*
+ * Entrypoint of this module.
+ *
+ * We register more than one worker process here, to demonstrate how that can
+ * be done.
+ */
+void _PG_init(void)
+{
+	BackgroundWorker worker;
+	unsigned int i;
+
+	/* get the configuration */
+	DefineCustomIntVariable("gp_worker_spi.naptime",
+							"Duration between each check (in seconds).",
+							NULL,
+							&gp_worker_spi_naptime,
+							10,
+							1,
+							INT_MAX,
+							PGC_SIGHUP,
+							0,
+							NULL,
+							NULL,
+							NULL);
+
+	if (!process_shared_preload_libraries_in_progress)
+		return;
+
+	DefineCustomIntVariable("gp_worker_spi.total_workers",
+							"Number of workers.",
+							NULL,
+							&gp_worker_spi_total_workers,
+							1,
+							1,
+							100,
+							PGC_POSTMASTER,
+							0,
+							NULL,
+							NULL,
+							NULL);
+
+	DefineCustomStringVariable("gp_worker_spi.database",
+							   "Database to connect to.",
+							   NULL,
+							   &gp_worker_spi_database,
+							   "contrib_regression",
+							   PGC_POSTMASTER,
+							   0,
+							   NULL, NULL, NULL);
+
+	/* set up common data for all our workers */
+	memset(&worker, 0, sizeof(worker));
+	worker.bgw_flags = BGWORKER_SHMEM_ACCESS |
+					   BGWORKER_BACKEND_DATABASE_CONNECTION;
+	worker.bgw_start_time = BgWorkerStart_RecoveryFinished;
+	worker.bgw_restart_time = BGW_NEVER_RESTART;
+	sprintf(worker.bgw_library_name, "gp_worker_spi");
+	sprintf(worker.bgw_function_name, "gp_worker_spi_main");
+	worker.bgw_notify_pid = 0;
+	worker.bgw_start_rule = NULL;
+
+	/*
+	 * Now fill in worker-specific data, and do the actual registrations.
+	 */
+	for (i = 1; i <= gp_worker_spi_total_workers; i++)
+	{
+		snprintf(worker.bgw_name, BGW_MAXLEN, "gp_worker_spi worker %d", i);
+		snprintf(worker.bgw_type, BGW_MAXLEN, "gp_worker_spi");
+		worker.bgw_main_arg = Int32GetDatum(i);
+
+		RegisterBackgroundWorker(&worker);
+	}
+}
+
+void gp_worker_spi_main(Datum main_arg)
+{
+	int index = DatumGetInt32(main_arg);
+	worktable *table;
+	StringInfoData buf;
+	char name[20];
+
+	table = palloc(sizeof(worktable));
+	sprintf(name, "counted%d", index);
+	table->name = pstrdup(name);
+
+	/* Establish signal handlers before unblocking signals. */
+	pqsignal(SIGHUP, gp_worker_spi_sighup);
+	pqsignal(SIGTERM, gp_worker_spi_sigterm);
+
+	/* We're now ready to receive signals */
+	BackgroundWorkerUnblockSignals();
+
+	/* Connect to our database */
+	elog(WARNING, "xxxx %s", gp_worker_spi_database);
+	BackgroundWorkerInitializeConnection(gp_worker_spi_database, NULL, 0);
+
+	/*
+	 * Quote identifiers passed to us. Note that this must be done after
+	 * gp_initialize_worker_spi, because that routine assumes the names are not
+	 * quoted.
+	 *
+	 * Note some memory might be leaked here.
+	 */
+	table->name = quote_identifier(table->name);
+
+	initStringInfo(&buf);
+	appendStringInfo(&buf,
+					 "WITH notic AS ("
+					 "SELECT raise_notice_func(gp_segment_id) AS r "
+					 "FROM gp_dist_random('gp_id')) "
+					 "INSERT INTO worker_spi.%s(val) SELECT r FROM notic",
+					 table->name, table->name);
+
+	/*
+	 * Main loop: do this until the SIGTERM handler tells us to terminate
+	 */
+	while (!got_sigterm)
+	{
+		int ret;
+
+		/*
+		 * Background workers mustn't call usleep() or any direct equivalent:
+		 * instead, they may wait on their process latch, which sleeps as
+		 * necessary, but is awakened if postmaster dies.  That way the
+		 * background process goes away immediately in an emergency.
+		 */
+		(void)WaitLatch(MyLatch,
+						WL_LATCH_SET | WL_TIMEOUT | WL_EXIT_ON_PM_DEATH,
+						gp_worker_spi_naptime * 1000L,
+						PG_WAIT_EXTENSION);
+		ResetLatch(MyLatch);
+
+		CHECK_FOR_INTERRUPTS();
+
+		/*
+		 * In case of a SIGHUP, just reload the configuration.
+		 */
+		if (got_sighup)
+		{
+			got_sighup = false;
+			ProcessConfigFile(PGC_SIGHUP);
+		}
+
+		/*
+		 * Start a transaction on which we can run queries.  Note that each
+		 * StartTransactionCommand() call should be preceded by a
+		 * SetCurrentStatementStartTimestamp() call, which sets both the time
+		 * for the statement we're about the run, and also the transaction
+		 * start time.  Also, each other query sent to SPI should probably be
+		 * preceded by SetCurrentStatementStartTimestamp(), so that statement
+		 * start time is always up to date.
+		 *
+		 * The SPI_connect() call lets us run queries through the SPI manager,
+		 * and the PushActiveSnapshot() call creates an "active" snapshot
+		 * which is necessary for queries to have MVCC data to work on.
+		 *
+		 * The pgstat_report_activity() call makes our activity visible
+		 * through the pgstat views.
+		 */
+		SetCurrentStatementStartTimestamp();
+		StartTransactionCommand();
+		SPI_connect();
+		PushActiveSnapshot(GetTransactionSnapshot());
+		pgstat_report_activity(STATE_RUNNING, buf.data);
+
+		/* We can now execute queries via SPI */
+		ret = SPI_execute(buf.data, false, 0);
+
+		if (ret != SPI_OK_INSERT)
+			elog(FATAL, "cannot select from table worker_spi.%s: error code %d",
+				 table->name, ret);
+
+		/*
+		 * And finish our transaction.
+		 */
+		SPI_finish();
+		PopActiveSnapshot();
+		CommitTransactionCommand();
+		pgstat_report_stat(false);
+		pgstat_report_activity(STATE_IDLE, NULL);
+	}
+
+	proc_exit(1);
+}

--- a/src/test/modules/gp_worker_spi/sql/gp_worker_spi.sql
+++ b/src/test/modules/gp_worker_spi/sql/gp_worker_spi.sql
@@ -1,0 +1,67 @@
+-- initialize database
+-- start_ignore
+DROP TABLE IF EXISTS worker_spi.counted1;
+DROP SCHEMA IF EXISTS worker_spi;
+-- end_ignore
+CREATE SCHEMA worker_spi;
+CREATE TABLE worker_spi.counted1(val int);
+
+-- create raise notice function
+CREATE FUNCTION raise_notice_func(gp_segment_id int) RETURNS int LANGUAGE plpgsql AS $$
+DECLARE
+BEGIN
+RAISE NOTICE 'this is raise function';
+RETURN gp_segment_id;
+END;
+$$;
+
+-- start_ignore
+\! gpconfig -c shared_preload_libraries -v 'gp_worker_spi'
+\! gpstop -raf
+-- end_ignore
+
+\c
+
+-- wait until the worker completes its initialization
+DO $$
+DECLARE
+	visible bool;
+	loops int := 0;
+BEGIN
+	LOOP
+		visible := table_name IS NOT NULL
+			FROM information_schema.tables
+			WHERE table_name = 'counted1';
+		IF visible OR loops > 120 * 10 THEN EXIT; END IF;
+		PERFORM pg_sleep(0.1);
+		loops := loops + 1;
+	END LOOP;
+END
+$$;
+
+-- wait until the worker has processed the tuple
+DO $$
+DECLARE
+	count int;
+	loops int := 0;
+BEGIN
+	LOOP
+		count := count(*) FROM worker_spi.counted1;
+		IF count > 0 OR loops > 120 * 10 THEN EXIT; END IF;
+		PERFORM pg_sleep(0.1);
+		loops := loops + 1;
+	END LOOP;
+END
+$$;
+
+-- the result should be (0, 1, 2)
+SELECT DISTINCT val FROM worker_spi.counted1 ORDER BY val;
+
+-- clean database
+DROP FUNCTION raise_notice_func(gp_segment_id int);
+DROP TABLE worker_spi.counted1;
+DROP SCHEMA worker_spi;
+-- start_ignore
+\! gpconfig -c shared_preload_libraries -v ''
+\! gpstop -raf
+-- end_ignore


### PR DESCRIPTION
## Problem
A notice will be generated when a primary segment shutdown and QD executes a query by SPI_execute(). But the bgworker connecting to the specified database does not establish pq with the client, which causes dead loop in internal_putbytes(). 

A dead loop will happen following these steps:
- Bgworker executes a query by SPI_execute().
- Some QE's generate notices(for example, the crash of this server) and pass them to QD(bgworker).
- The bgworker wants to forward notices to the client in SPI_execute(). But there's no client for bgworker to establish the pq connection, which will cause a dead loop for bgworker.

So that bgworker will not run anymore. For example, the diskquota bgworker will always wait for internal_putbytes(), and can not update table size.

## Solve
We should skip pq_endmessage() when QD is a bgworker.

## Backport
We should backport this PR to 6X_STABLE.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
