### PR TITLE
Disallow the execution of pg_resgroup_get_status and pg_resgroup_get_status_kv functions on entryDB

### DIFF
--- a/src/backend/utils/resgroup/resgroup_helper.c
+++ b/src/backend/utils/resgroup/resgroup_helper.c
@@ -206,6 +206,21 @@ pg_resgroup_get_status(PG_FUNCTION_ARGS)
 	FuncCallContext *funcctx;
 	ResGroupStatCtx *ctx;
 
+	if (is_entry_db())
+	{
+		ereport(ERROR,
+			(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+			 errmsg ("Cannot execute the %s function in entrydb, this query is"
+					 " not currently supported by GPDB.", __func__),
+			 errhint("Call the function in subquery wrapped with"
+					 " unnest(array()). For example:\n"
+					 "insert into tst_json\n"
+					 "select * from unnest(array(\n"
+					 "\tselect cpu_usage\n"
+					 "\tfrom pg_resgroup_get_status(NULL::oid)\n"
+					 "));")));
+	}
+
 	if (SRF_IS_FIRSTCALL())
 	{
 		MemoryContext oldcontext;
@@ -342,6 +357,21 @@ pg_resgroup_get_status_kv(PG_FUNCTION_ARGS)
 	FuncCallContext *funcctx;
 	StringInfoData   str;
 	bool             do_dump;
+
+	if (is_entry_db())
+	{
+		ereport(ERROR,
+			(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+			 errmsg ("Cannot execute the %s function in entrydb, this query is"
+					 " not currently supported by GPDB.", __func__),
+			 errhint("Call the function in subquery wrapped with"
+					 " unnest(array()). For example:\n"
+					 "insert into t\n"
+					 "select * from unnest(array(\n"
+					 "\tselect value\n"
+					 "\tfrom pg_resgroup_get_status_kv('dump')\n"
+					 "));")));
+	}
 
 	do_dump = (strncmp(text_to_cstring(PG_GETARG_TEXT_P(0)), "dump", 4) == 0);
 	

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -909,6 +909,11 @@ extern int get_dbid_string_length(void);
 #define UNINITIALIZED_GP_IDENTITY_VALUE (-10000)
 #define IS_QUERY_DISPATCHER() (GpIdentity.segindex == MASTER_CONTENT_ID)
 
+static inline bool is_entry_db()
+{
+	return IS_QUERY_DISPATCHER() && Gp_role == GP_ROLE_EXECUTE;
+}
+
 /* Stores the listener port that this process uses to listen for incoming
  * Interconnect connections from other Motion nodes.
  */

--- a/src/test/isolation2/expected/resgroup/resgroup_dumpinfo.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_dumpinfo.out
@@ -66,6 +66,17 @@ ERROR:  only superusers can call this function
 RESET ROLE;
 RESET
 
+create temp table t1 as select value from pg_resgroup_get_status_kv('dump');
+ERROR:  Cannot execute the pg_resgroup_get_status_kv function in entrydb, this query is not currently supported by GPDB.  (entry db 127.0.0.1:6000 pid=93315)
+HINT:  Call the function in subquery wrapped with unnest(array()). For example:
+insert into t
+select * from unnest(array(
+	select value
+	from pg_resgroup_get_status_kv('dump')
+));
+create temp table t1 as select * from unnest(array( select value from pg_resgroup_get_status_kv('dump') ));
+CREATE 1
+
 DROP ROLE role_dumpinfo_test;
 DROP
 DROP ROLE role_permission;

--- a/src/test/isolation2/expected/resgroup/resgroup_functions.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_functions.out
@@ -8,6 +8,15 @@ CREATE TEMP TABLE resgroup_function_test(LIKE gp_toolkit.gp_resgroup_status);
 CREATE
 
 INSERT INTO resgroup_function_test(groupid, num_running, num_queueing, num_queued, num_executed) SELECT s.groupid, s.num_running, s.num_queueing, s.num_queued, s.num_executed FROM pg_resgroup_get_status(NULL::oid) s(groupid, num_running, num_queueing, num_queued, num_executed, total_queue_duration, cpu_usage, memory_usage) LIMIT 1;
+ERROR:  Cannot execute the pg_resgroup_get_status function in entrydb, this query is not currently supported by GPDB.  (entry db 127.0.0.1:6000 pid=93256)
+HINT:  Call the function in subquery wrapped with unnest(array()). For example:
+insert into tst_json
+select * from unnest(array(
+	select cpu_usage
+	from pg_resgroup_get_status(NULL::oid)
+));
+
+INSERT INTO resgroup_function_test(groupid, num_running, num_queueing, num_queued, num_executed) SELECT (unnest).groupid, (unnest).num_running, (unnest).num_queueing, (unnest).num_queued, (unnest).num_executed FROM ( SELECT unnest(array( SELECT row('', groupid, num_running, num_queueing, num_queued, num_executed, total_queue_duration, cpu_usage, memory_usage)::resgroup_function_test FROM pg_resgroup_get_status(NULL::oid) LIMIT 1 )) ) a;
 INSERT 1
 
 SELECT count(num_executed)>0 FROM resgroup_function_test WHERE num_executed IS NOT NULL;
@@ -15,3 +24,9 @@ SELECT count(num_executed)>0 FROM resgroup_function_test WHERE num_executed IS N
 ----------
  t        
 (1 row)
+
+CREATE TEMP TABLE tst_json (cpu_usage json);
+CREATE
+
+INSERT INTO tst_json SELECT * FROM unnest(array( SELECT cpu_usage FROM pg_resgroup_get_status(NULL::oid) ));
+INSERT 2

--- a/src/test/isolation2/sql/resgroup/resgroup_dumpinfo.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_dumpinfo.sql
@@ -86,6 +86,11 @@ select value from pg_resgroup_get_status_kv('dump');
 
 RESET ROLE;
 
+create temp table t1 as select value from pg_resgroup_get_status_kv('dump');
+create temp table t1 as select * from unnest(array(
+	select value from pg_resgroup_get_status_kv('dump')
+));
+
 DROP ROLE role_dumpinfo_test;
 DROP ROLE role_permission;
 DROP RESOURCE GROUP rg_dumpinfo_test;

--- a/src/test/isolation2/sql/resgroup/resgroup_functions.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_functions.sql
@@ -8,4 +8,22 @@ INSERT INTO resgroup_function_test(groupid, num_running, num_queueing, num_queue
 SELECT s.groupid, s.num_running, s.num_queueing, s.num_queued, s.num_executed
 FROM pg_resgroup_get_status(NULL::oid) s(groupid, num_running, num_queueing, num_queued, num_executed, total_queue_duration, cpu_usage, memory_usage) LIMIT 1;
 
+INSERT INTO resgroup_function_test(groupid, num_running, num_queueing, num_queued, num_executed)
+SELECT (unnest).groupid, (unnest).num_running, (unnest).num_queueing, (unnest).num_queued, (unnest).num_executed 
+FROM (
+  SELECT unnest(array(
+    SELECT row('', groupid, num_running, num_queueing, num_queued, num_executed, total_queue_duration, cpu_usage, memory_usage)::resgroup_function_test
+    FROM pg_resgroup_get_status(NULL::oid)
+	LIMIT 1
+  ))
+) a;
+
 SELECT count(num_executed)>0 FROM resgroup_function_test WHERE num_executed IS NOT NULL;
+
+CREATE TEMP TABLE tst_json (cpu_usage json);
+
+INSERT INTO tst_json
+SELECT * FROM unnest(array(
+    SELECT cpu_usage
+    FROM pg_resgroup_get_status(NULL::oid)
+));


### PR DESCRIPTION
The pg_resgroup_get_status and pg_resgroup_get_status_kv functions returned invalid values when they was called in insert-select queries. The reason for the error was that the functions was called on entry db only. They should be called on all segments.
The error can be fixed by setting the proexeclocation property of the functions to 'i' (PROEXECLOCATION_INITPLAN). But changing catalog for stable release is something we should avoid unless absolutely necessary for critical issues. So the execution of pg_resgroup_get_status and pg_resgroup_get_status_kv functions is disallowed on entryDB. User will get error message and hint how to call the functions.

https://github.com/greenplum-db/gpdb/issues/14154