### PR TITLE
gpcheckperf - Update a Python 3 reference of "python" to "python3"

### DIFF
--- a/gpMgmt/bin/gpcheckperf
+++ b/gpMgmt/bin/gpcheckperf
@@ -346,14 +346,14 @@ def runSetup():
         print('--------------------')
     okCount = 0
     try:
-        # check python reachable
+        # Verify python3 is accessible
         if GV.opt['-v']:
-            print('[Info] verify python interpreter exists')
-        (ok, out) = gpssh('python -c print')
+            print('[Info] verify python3 interpreter exists')
+        (ok, out) = gpssh('python3 -c print')
         if not ok:
             if not GV.opt['-v']:
                 print(out)
-            sys.exit("[Error] unable to find python interpreter on some hosts\n"
+            sys.exit("[Error] unable to find python3 interpreter on some hosts\n"
                      + "        verify PATH variables on the hosts")
 
             # mkdir cperf


### PR DESCRIPTION
In gpcheckperf, a remaining "python" reference exists. This commit renames it to "python3" and allows it to run when the symbolic link /usr/bin/python pointing to /usr/bin/python3 does not exist.

Tl;dr - An attempt was made to update all Greenplum utilities to reference 'python3'. A reference was left unchanged in gpcheckperf.

Python 3 installations by default do not create the symbolic link /usr/bin/python --> /usr/bin/python3. This has been observed in Python 3 installation3 on Rockylinux 8 & 9 and Ubuntu 20.04 & 22.04.

In the case of gpcheckperf, when invoked, the output below reveals the "Error" a user receives when /usr/bin/python does not exist:

```
gpadmin@cdw:~$ /usr/local/gp7/bin/gpcheckperf -h cdw -d /data -r d -S 1 -v
--------------------
  SETUP 2023-03-12T17:26:27.967030
--------------------
[Info] verify python interpreter exists
[Info] /usr/local/gp7/bin/gpssh -h cdw 'python -c print'
--------------------
  TEARDOWN
--------------------
[Info] /usr/local/gp7/bin/gpssh -h cdw 'rm -rf  /data/gpcheckperf_$USER'
[Error] unable to find python interpreter on some hosts
        verify PATH variables on the hosts
gpadmin@cdw:~$
```