### PR TITLE
Fix 2 compiler warnings.

### DIFF
--- a/src/backend/commands/vacuum_ao.c
+++ b/src/backend/commands/vacuum_ao.c
@@ -161,7 +161,7 @@ static int vacuum_appendonly_indexes(Relation aoRelation, int options, Bitmapset
 									 BufferAccessStrategy bstrategy, AOVacuumRelStats *vacrelstats);
 static void ao_vacuum_rel_recycle_dead_segments(Relation onerel, VacuumParams *params,
 												BufferAccessStrategy bstrategy, AOVacuumRelStats *vacrelstats);
-static AOVacuumRelStats *init_vacrelstats();
+static AOVacuumRelStats *init_vacrelstats(void);
 static void cleanup_vacrelstats(AOVacuumRelStats **vacrelstatsp);
 
 static void

--- a/src/backend/gpopt/translate/CPartPruneStepsBuilder.cpp
+++ b/src/backend/gpopt/translate/CPartPruneStepsBuilder.cpp
@@ -80,7 +80,7 @@ CPartPruneStepsBuilder::CreatePartPruneInfoForOneLevel(CDXLNode *filterNode)
 	// partitions that survived static partition pruning; iterate over this list
 	// to populate pinfo->subplan_map, pinfo->relid_map & pinfo->present_parts
 	ULONG part_ptr = 0;
-	for (ULONG i = 0; i < pinfo->nparts; ++i)
+	for (ULONG i = 0; (int) i < pinfo->nparts; ++i)
 	{
 		pinfo->subpart_map[i] = -1;
 		if (part_ptr < m_part_indexes->Size() &&


### PR DESCRIPTION
This commit fixes the following compiler warnings:

vacuum_ao.c:738:1: warning: ‘init_vacrelstats’ was used with no prototype before its definition [-Wmissing-prototypes]
  738 | init_vacrelstats()
      | ^~~~~~~~~~~~~~~~
CPartPruneStepsBuilder.cpp: In member function ‘PartitionedRelPruneInfo* gpdxl::CPartPruneStepsBuilder::CreatePartPruneInfoForOneLevel(gpdxl::CDXLNode*)’: CPartPruneStepsBuilder.cpp:83:29: warning: comparison of integer expressions of different signedness: ‘gpos::ULONG’ {aka ‘unsigned int’} and ‘int’ [-Wsign-compare]
   83 |         for (ULONG i = 0; i < pinfo->nparts; ++i)
      |                           ~~^~~~~~~~~~~~~~~

