### PR TITLE
gprecoverseg: Fix rebalance may block postmaster.

### DIFF
--- a/gpMgmt/bin/gppylib/operations/segment_reconfigurer.py
+++ b/gpMgmt/bin/gppylib/operations/segment_reconfigurer.py
@@ -40,6 +40,7 @@ class SegmentReconfigurer:
                 conn.cursor().execute('CREATE TEMP TABLE temp_test(a int)')
                 conn.cursor().execute('COMMIT')
             except Exception as e:
+                conn.close()
                 now = time.time()
                 if now < start_time + self.timeout:
                     continue


### PR DESCRIPTION
![823ad49a-899c-4766-8bdf-668744216e28](https://user-images.githubusercontent.com/8388185/224916597-dc97df36-5fe9-4302-a441-1155fe33f94f.jpeg)

When segment is recovering and can't handle message from FTS, Then postmaster can't deal sql correctly.
1. gprecoverseg will keep sending sql `BEGIN;CREATE TEMP TABLE temp_test(a int);COMMIT;`
2. master will return with `create gang failed`
3. gprecoverseg will got exception in `def reconfigure(self):` without connection close.
4. postmaster will be block with abort transaction 


