### PR TITLE
bug fix: unable to understand 'IS NOT DISTINCT' (7X)

### DIFF
--- a/src/backend/nodes/outfast.c
+++ b/src/backend/nodes/outfast.c
@@ -559,6 +559,10 @@ _outAExpr(StringInfo str, A_Expr *node)
 
 			WRITE_NODE_FIELD(name);
 			break;
+		case AEXPR_NOT_DISTINCT:
+
+			WRITE_NODE_FIELD(name);
+			break;
 		case AEXPR_NULLIF:
 
 			WRITE_NODE_FIELD(name);

--- a/src/backend/nodes/readfast.c
+++ b/src/backend/nodes/readfast.c
@@ -541,6 +541,10 @@ _readAExpr(void)
 
 			READ_NODE_FIELD(name);
 			break;
+		case AEXPR_NOT_DISTINCT:
+
+			READ_NODE_FIELD(name);
+			break;
 		case AEXPR_NULLIF:
 
 			READ_NODE_FIELD(name);

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -1259,14 +1259,14 @@ _readAExpr(void)
 		local_node->kind = AEXPR_OP_ALL;
 		READ_NODE_FIELD(name);
 	}
-	else if (strncmp(token,"NOT_DISTINCT",length)==0)
-	{
-		local_node->kind = AEXPR_NOT_DISTINCT;
-		READ_NODE_FIELD(name);
-	}
 	else if (strncmp(token,"DISTINCT",length)==0)
 	{
 		local_node->kind = AEXPR_DISTINCT;
+		READ_NODE_FIELD(name);
+	}
+	else if (strncmp(token,"NOT_DISTINCT",length)==0)
+	{
+		local_node->kind = AEXPR_NOT_DISTINCT;
 		READ_NODE_FIELD(name);
 	}
 	else if (strncmp(token,"NULLIF",length)==0)

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -1259,6 +1259,11 @@ _readAExpr(void)
 		local_node->kind = AEXPR_OP_ALL;
 		READ_NODE_FIELD(name);
 	}
+	else if (strncmp(token,"NOT_DISTINCT",length)==0)
+	{
+		local_node->kind = AEXPR_NOT_DISTINCT;
+		READ_NODE_FIELD(name);
+	}
 	else if (strncmp(token,"DISTINCT",length)==0)
 	{
 		local_node->kind = AEXPR_DISTINCT;

--- a/src/test/regress/expected/select_distinct.out
+++ b/src/test/regress/expected/select_distinct.out
@@ -534,3 +534,21 @@ DROP TABLE capitals;
 DROP TABLE cities;
 set gp_statistics_pullup_from_child_partition to off;
 -- gpdb end: test inherit/partition table distinct when gp_statistics_pullup_from_child_partition is on
+-- please refer to https://github.com/greenplum-db/gpdb/issues/15033
+CREATE TABLE t1_issue_15033(c DECIMAL CHECK (0.4 IS DISTINCT FROM 0.3));
+CREATE TABLE t2_issue_15033(c DECIMAL CHECK (0.4 IS NOT DISTINCT FROM 0.3));
+INSERT INTO t1_issue_15033 VALUES(10);
+SELECT * FROM t1_issue_15033;
+ c  
+----
+ 10
+(1 row)
+
+INSERT INTO t2_issue_15033 VALUES(10);
+DETAIL:  Failing row contains (10).
+ERROR:  new row for relation "t2_issue_15033" violates check constraint "t2_issue_15033_check"
+SELECT * FROM t2_issue_15033;
+ c 
+---
+(0 rows)
+

--- a/src/test/regress/expected/select_distinct_optimizer.out
+++ b/src/test/regress/expected/select_distinct_optimizer.out
@@ -537,3 +537,21 @@ DROP TABLE capitals;
 DROP TABLE cities;
 set gp_statistics_pullup_from_child_partition to off;
 -- gpdb end: test inherit/partition table distinct when gp_statistics_pullup_from_child_partition is on
+-- please refer to https://github.com/greenplum-db/gpdb/issues/15033
+CREATE TABLE t1_issue_15033(c DECIMAL CHECK (0.4 IS DISTINCT FROM 0.3));
+CREATE TABLE t2_issue_15033(c DECIMAL CHECK (0.4 IS NOT DISTINCT FROM 0.3));
+INSERT INTO t1_issue_15033 VALUES(10);
+SELECT * FROM t1_issue_15033;
+ c  
+----
+ 10
+(1 row)
+
+INSERT INTO t2_issue_15033 VALUES(10);
+DETAIL:  Failing row contains (10).
+ERROR:  new row for relation "t2_issue_15033" violates check constraint "t2_issue_15033_check"
+SELECT * FROM t2_issue_15033;
+ c 
+---
+(0 rows)
+

--- a/src/test/regress/sql/select_distinct.sql
+++ b/src/test/regress/sql/select_distinct.sql
@@ -200,3 +200,11 @@ DROP TABLE capitals;
 DROP TABLE cities;
 set gp_statistics_pullup_from_child_partition to off;
 -- gpdb end: test inherit/partition table distinct when gp_statistics_pullup_from_child_partition is on
+
+-- please refer to https://github.com/greenplum-db/gpdb/issues/15033
+CREATE TABLE t1_issue_15033(c DECIMAL CHECK (0.4 IS DISTINCT FROM 0.3));
+CREATE TABLE t2_issue_15033(c DECIMAL CHECK (0.4 IS NOT DISTINCT FROM 0.3));
+INSERT INTO t1_issue_15033 VALUES(10);
+SELECT * FROM t1_issue_15033;
+INSERT INTO t2_issue_15033 VALUES(10);
+SELECT * FROM t2_issue_15033;


### PR DESCRIPTION
This pr can fix the bug reported in [issue 15033](https://github.com/greenplum-db/gpdb/issues/15033)

Add identification of `NOT DISTINCT` node as `DISTINCT` under `src/backend/nodes`.

**Signed-off-by**: Yongtao Huang <yongtaoh@vmware.com>