### PR TITLE
bug fix: 'unrecognized node type: 145'

### DIFF
--- a/src/backend/parser/parse_expr.c
+++ b/src/backend/parser/parse_expr.c
@@ -287,6 +287,11 @@ transformExprRecurse(ParseState *pstate, Node *expr)
 				result = expr;
 				break;
 			}
+		case T_OpExpr:
+			{
+				result = (Node *) expr;
+				break;
+			}
 
 		case T_SubLink:
 			result = transformSubLink(pstate, (SubLink *) expr);

--- a/src/test/regress/expected/alter_table.out
+++ b/src/test/regress/expected/alter_table.out
@@ -4773,6 +4773,10 @@ select c.relname, r.rolname from pg_class c join pg_roles r on c.relowner = r.oi
  atown_part_1_prt_p1 | atown_r1
 (3 rows)
 
+-- please refer to:  https://github.com/greenplum-db/gpdb/issues/15034
+create table transform_r1(c DECIMAL);
+alter table transform_r1 alter c SET DEFAULT (((0.1)>(0.9) IS UNKNOWN)::INT)::MONEY;
+drop table transform_r1;
 drop table atown_part;
 reset role;
 drop role atown_r1;

--- a/src/test/regress/expected/alter_table.out
+++ b/src/test/regress/expected/alter_table.out
@@ -4774,9 +4774,9 @@ select c.relname, r.rolname from pg_class c join pg_roles r on c.relowner = r.oi
 (3 rows)
 
 -- please refer to:  https://github.com/greenplum-db/gpdb/issues/15034
-create table transform_r1(c DECIMAL);
-alter table transform_r1 alter c SET DEFAULT (((0.1)>(0.9) IS UNKNOWN)::INT)::MONEY;
-drop table transform_r1;
+create table transform_issue_15034(c DECIMAL);
+alter table transform_issue_15034 alter c SET DEFAULT (((0.1)>(0.9) IS UNKNOWN)::INT)::MONEY;
+drop table transform_issue_15034;
 drop table atown_part;
 reset role;
 drop role atown_r1;

--- a/src/test/regress/sql/alter_table.sql
+++ b/src/test/regress/sql/alter_table.sql
@@ -3145,6 +3145,10 @@ select c.relname, r.rolname from pg_class c join pg_roles r on c.relowner = r.oi
 alter table only atown_part owner to atown_r2;
 select c.relname, r.rolname from pg_class c join pg_roles r on c.relowner = r.oid where relname like 'atown_part%';
 
+-- please refer to:  https://github.com/greenplum-db/gpdb/issues/15034
+create table transform_r1(c DECIMAL);
+alter table transform_r1 alter c SET DEFAULT (((0.1)>(0.9) IS UNKNOWN)::INT)::MONEY;
+drop table transform_r1;
 drop table atown_part;
 reset role;
 drop role atown_r1;

--- a/src/test/regress/sql/alter_table.sql
+++ b/src/test/regress/sql/alter_table.sql
@@ -3146,9 +3146,9 @@ alter table only atown_part owner to atown_r2;
 select c.relname, r.rolname from pg_class c join pg_roles r on c.relowner = r.oid where relname like 'atown_part%';
 
 -- please refer to:  https://github.com/greenplum-db/gpdb/issues/15034
-create table transform_r1(c DECIMAL);
-alter table transform_r1 alter c SET DEFAULT (((0.1)>(0.9) IS UNKNOWN)::INT)::MONEY;
-drop table transform_r1;
+create table transform_issue_15034(c DECIMAL);
+alter table transform_issue_15034 alter c SET DEFAULT (((0.1)>(0.9) IS UNKNOWN)::INT)::MONEY;
+drop table transform_issue_15034;
 drop table atown_part;
 reset role;
 drop role atown_r1;


### PR DESCRIPTION
* This tiny merge request is used to fix this issue : https://github.com/greenplum-db/gpdb/issues/15034
* Added `T_OpExpr` case to transform expression(`src/backend`).
* Added some test cases in `regress/alter_table`