### PR TITLE
docs - new pg_aggregate column for safe aggs

### DIFF
--- a/doc/src/sgml/ref/create_aggregate.sgml
+++ b/doc/src/sgml/ref/create_aggregate.sgml
@@ -42,6 +42,7 @@ CREATE [ OR REPLACE ] AGGREGATE <replaceable class="parameter">name</replaceable
     [ , MINITCOND = <replaceable class="parameter">minitial_condition</replaceable> ]
     [ , SORTOP = <replaceable class="parameter">sort_operator</replaceable> ]
     [ , PARALLEL = { SAFE | RESTRICTED | UNSAFE } ]
+    [ , REPSAFE = <boolean> ]
 )
 
 CREATE [ OR REPLACE ] AGGREGATE <replaceable class="parameter">name</replaceable> ( [ [ <replaceable class="parameter">argmode</replaceable> ] [ <replaceable class="parameter">argname</replaceable> ] <replaceable class="parameter">arg_data_type</replaceable> [ , ... ] ]
@@ -58,6 +59,7 @@ CREATE [ OR REPLACE ] AGGREGATE <replaceable class="parameter">name</replaceable
     [ , DESERIALFUNC = <replaceable class="parameter">deserialfunc</replaceable> ]
     [ , INITCOND = <replaceable class="parameter">initial_condition</replaceable> ]
     [ , PARALLEL = { SAFE | RESTRICTED | UNSAFE } ]
+    [ , REPSAFE = <boolean> ]
     [ , HYPOTHETICAL ]
 )
 
@@ -651,6 +653,17 @@ SELECT col FROM tab ORDER BY col USING sortop LIMIT 1;
       Note that the parallel-safety markings of the aggregate's support
       functions are not consulted by the planner, only the marking of the
       aggregate itself.
+     </para>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry>
+    <term><literal>REPSAVE =</literal> <replaceable class="parameter">boolean</replaceable></term>
+    <listitem>
+     <para>
+      Specifies whether or not the aggregate can be safely executed on
+      replicated slices. An order-agnostic aggregate would be considered
+      safe in this context. The default value is <literal>false</literal>.
      </para>
     </listitem>
    </varlistentry>

--- a/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_AGGREGATE.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_AGGREGATE.html.md
@@ -211,6 +211,9 @@ PARALLEL = { SAFE | RESTRICTED | UNSAFE }
 
 REPSAFE = boolean
 :   Specifies whether or not the aggregate can be safely executed on replicated slices. An order-agnostic aggregate would be considered safe in this context. The default value is `false`.
+:   Setting `REPSAFE = true` instructs the optimizer to perform additional optimizations that specifically suppress certain broadcast motions.
+
+    > **Caution** Incorrectly setting `REPSAFE = true` for an order-dependent aggregate may produce incorrect results.
 
 HYPOTHETICAL
 :   For ordered-set aggregates only, this flag specifies that the aggregate arguments are to be processed according to the requirements for hypothetical-set aggregates: that is, the last few direct arguments must match the data types of the aggregated \(`WITHIN GROUP`\) arguments. The `HYPOTHETICAL` flag has no effect on run-time behavior, only on parse-time resolution of the data types and collations of the aggregate's arguments.

--- a/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_AGGREGATE.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_AGGREGATE.html.md
@@ -26,6 +26,7 @@ CREATE [ OR REPLACE ] AGGREGATE <name> ( [ <argmode> ] [ <argname> ] <arg_data_t
     [ , MINITCOND = <minitial_condition> ]
     [ , SORTOP = <sort_operator> ]
     [ , PARALLEL = { SAFE | RESTRICTED | UNSAFE } ]
+    [ , REPSAFE = <boolean> ]
   )
   
   CREATE [ OR REPLACE ] AGGREGATE <name> ( [ [ <argmode> ] [ <argname> ] <arg_data_type> [ , ... ] ]
@@ -39,6 +40,7 @@ CREATE [ OR REPLACE ] AGGREGATE <name> ( [ <argmode> ] [ <argname> ] <arg_data_t
     [ , COMBINEFUNC = <combinefunc> ]
     [ , INITCOND = <initial_condition> ]
     [ , PARALLEL = { SAFE | RESTRICTED | UNSAFE } ]
+    [ , REPSAFE = <boolean> ]
     [ , HYPOTHETICAL ]
   )
   
@@ -65,6 +67,7 @@ CREATE [ OR REPLACE ] AGGREGATE <name> ( [ <argmode> ] [ <argname> ] <arg_data_t
     [ , MFINALFUNC_MODIFY = { READ_ONLY | SHAREABLE | READ_WRITE } ]
     [ , MINITCOND = <minitial_condition> ]
     [ , SORTOP = <sort_operator> ]
+    [ , REPSAFE = <boolean> ]
   )
 ```
 
@@ -205,6 +208,9 @@ sort\_operator
 
 PARALLEL = { SAFE | RESTRICTED | UNSAFE }
 :   The meanings of `PARALLEL SAFE`, `PARALLEL RESTRICTED`, and `PARALLEL UNSAFE` are the same as in [CREATE FUNCTION](CREATE_FUNCTION.html). An aggregate will not be considered for parallelization if it is marked `PARALLEL UNSAFE` (which is the default!) or `PARALLEL RESTRICTED`. Note that the parallel-safety markings of the aggregate's support functions are not consulted by the planner, only the marking of the aggregate itself.
+
+REPSAFE = boolean
+:   Specifies whether or not the aggregate can be safely executed on replicated slices. An order-agnostic aggregate would be considered safe in this context. The default value is `false`.
 
 HYPOTHETICAL
 :   For ordered-set aggregates only, this flag specifies that the aggregate arguments are to be processed according to the requirements for hypothetical-set aggregates: that is, the last few direct arguments must match the data types of the aggregated \(`WITHIN GROUP`\) arguments. The `HYPOTHETICAL` flag has no effect on run-time behavior, only on parse-time resolution of the data types and collations of the aggregate's arguments.

--- a/gpdb-doc/markdown/ref_guide/system_catalogs/pg_aggregate.html.md
+++ b/gpdb-doc/markdown/ref_guide/system_catalogs/pg_aggregate.html.md
@@ -24,6 +24,7 @@ The `pg_aggregate` table stores information about aggregate functions. An aggreg
 |`aggmtransspace`|int4| |Approximate average size \(in bytes\) of the transition state data for moving-aggregate mode, or zero to use a default estimate|
 |`agginitval`|text| |The initial value of the transition state. This is a text field containing the initial value in its external string representation. If this field is NULL, the transition state value starts out NULL.|
 |`aggminitval`|text| |The initial value of the transition state for moving- aggregate mode. This is a text field containing the initial value in its external string representation. If this field is NULL, the transition state value starts out NULL.|
+|`aggrepsafeexec`|bool| | True to specify that the aggregate can be safely executed on replicated slices. An order-agnostic aggregate would be considered safe in this context. |
 
 **Parent topic:** [System Catalogs Definitions](../system_catalogs/catalog_ref-html.html)
 


### PR DESCRIPTION
docs for https://github.com/greenplum-db/gpdb/pull/14811.

in this PR:
- add aggrepsafeexec field/description to pg_aggregate ref page
- add the REPSAFE clause to CREATE AGGREGATE sql ref page
- update the sgml ref page so that the new REPSAFE clause is included in psql help text

question:  should i call this out as supported only by GPORCA, or do we plan to add or have planner support for this?
