### PR TITLE
Fix obsolete references to SnapshotNow in comment.

### DIFF
--- a/src/backend/access/aocs/aocssegfiles.c
+++ b/src/backend/access/aocs/aocssegfiles.c
@@ -591,10 +591,6 @@ MarkAOCSFileSegInfoAwaitingDrop(Relation prel, int segno)
 	segrel = heap_open(segrelid, RowExclusiveLock);
 	tupdesc = RelationGetDescr(segrel);
 
-	/*
-	 * Since we have the segment-file entry under lock (with
-	 * LockRelationAppendOnlySegmentFile) we can use SnapshotNow.
-	 */
 	scan = table_beginscan_catalog(segrel, 0, NULL);
 	while (segno != tuple_segno && (oldtup = heap_getnext(scan, ForwardScanDirection)) != NULL)
 	{
@@ -683,10 +679,6 @@ ClearAOCSFileSegInfo(Relation prel, int segno)
 	segrel = heap_open(segrelid, RowExclusiveLock);
 	tupdesc = RelationGetDescr(segrel);
 
-	/*
-	 * Since we have the segment-file entry under lock (with
-	 * LockRelationAppendOnlySegmentFile) we can use SnapshotNow.
-	 */
 	scan = table_beginscan_catalog(segrel, 0, NULL);
 	while (segno != tuple_segno && (oldtup = heap_getnext(scan, ForwardScanDirection)) != NULL)
 	{
@@ -774,10 +766,6 @@ UpdateAOCSFileSegInfo(AOCSInsertDesc idesc)
 	segrel = heap_open(idesc->segrelid, RowExclusiveLock);
 	tupdesc = RelationGetDescr(segrel);
 
-	/*
-	 * Since we have the segment-file entry under lock (with
-	 * LockRelationAppendOnlySegmentFile) we can use SnapshotNow.
-	 */
 	scan = systable_beginscan(segrel, InvalidOid, false, idesc->appendOnlyMetaDataSnapshot, 0, NULL);
 	while (idesc->cur_segno != tuple_segno && (oldtup = systable_getnext(scan)) != NULL)
 	{
@@ -971,10 +959,6 @@ AOCSFileSegInfoAddVpe(Relation prel, int32 segno,
 	segrel = heap_open(segrelid, RowExclusiveLock);
 	tupdesc = RelationGetDescr(segrel);
 
-	/*
-	 * Since we have the segment-file entry under lock (with
-	 * LockRelationAppendOnlySegmentFile) we can use SnapshotNow.
-	 */
 	scan = systable_beginscan(segrel, InvalidOid, false, NULL, 0, NULL);
 	while (segno != tuple_segno && (oldtup = systable_getnext(scan)) != NULL)
 	{
@@ -1090,10 +1074,6 @@ AOCSFileSegInfoAddCount(Relation prel, int32 segno,
 	segrel = heap_open(segrelid, RowExclusiveLock);
 	tupdesc = RelationGetDescr(segrel);
 
-	/*
-	 * Since we have the segment-file entry under lock (with
-	 * LockRelationAppendOnlySegmentFile) we can use SnapshotNow.
-	 */
 	scan = systable_beginscan(segrel, InvalidOid, false, NULL, 0, NULL);
 	while (segno != tuple_segno && (oldtup = systable_getnext(scan)) != NULL)
 	{

--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -2890,11 +2890,6 @@ CommitTransaction(void)
 	 * signals (which may attempt to abort our now partially-completed
 	 * transaction) until we've notified the QEs.
 	 *
-	 * Very important that PGPROC still thinks the transaction is still in progress so
-	 * SnapshotNow reader don't jump to the conclusion this distributed transaction is
-	 * finished.  So, notifyCommittedDtxTransaction will take responsbility to clear
-	 * PGPROC under the ProcArrayLock after the broadcast.  MPP-16087.
-	 *
 	 * And, that we have not master released locks, yet, too.
 	 *
 	 * Note:  do this BEFORE clearing the resource owner, as the dispatch

--- a/src/test/isolation/specs/ao-insert-eof.spec
+++ b/src/test/isolation/specs/ao-insert-eof.spec
@@ -10,9 +10,6 @@
 # written without serializable by using fault-injector, by suspending insert
 # statement after acquiring snapshot but before reaching segment file selection
 # logic for AO.
-# Without the fix for using SnapshotNow to read aoseg during inserts, it used to
-# overwrite and corrupt the data in some cases or error out inserts hiting the
-# sanity checks.
 
 setup
 {


### PR DESCRIPTION
SnapshotNow has been deleted on 9.4.
Instead, using MVCC snapshot to scan tables,
so the related race condition issues are gone.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
