### PR TITLE
Bring the pipeline centos6 and centos7 back

### DIFF
--- a/concourse/pipelines/gen_pipeline.py
+++ b/concourse/pipelines/gen_pipeline.py
@@ -151,8 +151,8 @@ def create_pipeline(args, git_remote, git_branch):
 
     variables_type = args.pipeline_target
     os_username = {
-        "rhel6" : "centos",
-        "rhel7" : "centos",
+        "centos6" : "centos",
+        "centos7" : "centos",
         "rhel8" : "rhel",
         "ubuntu18.04" : "ubuntu",
         "rocky8" : "rocky",
@@ -160,8 +160,8 @@ def create_pipeline(args, git_remote, git_branch):
         "oel7" : "oel"
     }
     test_os = {
-        "rhel6" : "centos",
-        "rhel7" : "centos",
+        "centos6" : "centos",
+        "centos7" : "centos",
         "rhel8" : "centos",
         "ubuntu18.04" : "ubuntu",
         "rocky8" : "centos",
@@ -169,12 +169,21 @@ def create_pipeline(args, git_remote, git_branch):
         "oel7" : "centos"
     }
     dist = {
-        "rhel6" : "rhel6",
-        "rhel7" : "rhel7",
+        "centos6" : "rhel6",
+        "centos7" : "rhel7",
         "rhel8" : "el8",
         "ubuntu18.04" : "ubuntu18.04",
         "rocky8" : "el8",
         "oel8" : "el8",
+        "oel7" : "oel7"
+    }
+    rpm_platform = {
+        "centos6" : "rhel6",
+        "centos7" : "rhel7",
+        "rhel8" : "rhel8",
+        "ubuntu18.04" : "ubuntu18.04",
+        "rocky8" : "rocky8",
+        "oel8" : "oel8",
         "oel7" : "oel7"
     }
     context = {
@@ -186,6 +195,7 @@ def create_pipeline(args, git_remote, git_branch):
         'os_username': os_username[args.os_type],
         'test_os': test_os[args.os_type],
         'dist': dist[args.os_type],
+        'rpm_platform': rpm_platform[args.os_type],
         'pipeline_target': args.pipeline_target,
         'test_sections': args.test_sections,
         'pipeline_configuration': args.pipeline_configuration,
@@ -332,7 +342,7 @@ def main():
         action='store',
         dest='os_type',
         default=default_os_type,
-        choices=['rhel6', 'rhel7', 'rhel8','ubuntu18.04', 'rocky8', 'oel8', 'oel7'],
+        choices=['centos6', 'centos7', 'rhel8','ubuntu18.04', 'rocky8', 'oel8', 'oel7'],
         help='OS value to support'
     )
 

--- a/concourse/pipelines/templates/gpdb-tpl.yml
+++ b/concourse/pipelines/templates/gpdb-tpl.yml
@@ -2555,7 +2555,7 @@ jobs:
     output_mapping:
       gpdb_rpm_installer: gpdb_rpm_[[ os_type ]]
     params:
-      PLATFORM: [[ os_type ]]
+      PLATFORM: [[ rpm_platform ]]
       GPDB_NAME: greenplum-db-6
       GPDB_RELEASE: 1
       GPDB_LICENSE: Pivotal Software EULA

--- a/concourse/pipelines/templates/gpdb-tpl.yml
+++ b/concourse/pipelines/templates/gpdb-tpl.yml
@@ -672,6 +672,15 @@ resources:
 {% endif %}
 {% endif %}
 
+{% if os_type == default_os_type %}
+- name: bin_gpdb_centos7_rc
+  type: gcs
+  source:
+    bucket: ((gcs-bucket))
+    json_key: ((concourse-gcs-resources-service-account-key))
+    regexp: server/published/gpdb6/server-rc-(.*)-rhel7_x86_64((rc-build-type-gcs)).tar.gz
+{% endif %}
+
 {% if pipeline_configuration == "prod" or build_test_rc_rpm %}
 {% if os_type != "ubuntu18.04" and os_type != "rhel8" and os_type != "oel8" %}
 - name: gpdb_rpm_installer_[[ os_type ]]
@@ -1218,7 +1227,7 @@ jobs:
       - get: bin_gpdb_clients_windows
         passed: [compile_gpdb_clients_windows]
       - get: bin_gpdb
-        resource: bin_gpdb_[[ os_type ]]_rc
+        resource: bin_gpdb_centos7_rc
       - get: terraform.d
         params:
           unpack: true

--- a/concourse/vars/common_prod.yml
+++ b/concourse/vars/common_prod.yml
@@ -30,10 +30,10 @@ reduced-frequency-trigger-start-rhel8: 0:00 AM
 reduced-frequency-trigger-stop-rhel8: 0:59 AM
 reduced-frequency-trigger-start-ubuntu18.04: 2:00 AM
 reduced-frequency-trigger-stop-ubuntu18.04: 2:59 AM
-reduced-frequency-trigger-start-rhel7: 4:00 AM
-reduced-frequency-trigger-stop-rhel7: 4:59 AM
-reduced-frequency-trigger-start-rhel6: 6:00 AM
-reduced-frequency-trigger-stop-rhel6: 6:59 AM
+reduced-frequency-trigger-start-centos7: 4:00 AM
+reduced-frequency-trigger-stop-centos7: 4:59 AM
+reduced-frequency-trigger-start-centos6: 6:00 AM
+reduced-frequency-trigger-stop-centos6: 6:59 AM
 reduced-frequency-trigger-start-oel8: 8:00 AM
 reduced-frequency-trigger-stop-oel8: 8:59 AM
 reduced-frequency-trigger-start-oel7: 10:00 AM


### PR DESCRIPTION
This PR includes two pipeline changes:

- Bring the centos6 and centos7 pipeline back
- Update the test_gpdb_clients_windows resource to use bin_gpdb_centos7_rc

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
