### PR TITLE
Enable `COPY partitioned_table TO file` for better performence

### DIFF
--- a/src/backend/access/aocs/aocsam_handler.c
+++ b/src/backend/access/aocs/aocsam_handler.c
@@ -527,6 +527,7 @@ aoco_beginscan_extractcolumns(Relation rel, Snapshot snapshot,
 							  List *targetlist, List *qual, bool *proj,
 							  List* constraintList, uint32 flags)
 {
+	bool needFree = false;
 	AOCSScanDesc	aoscan;
 
 	AssertImply(list_length(targetlist) || list_length(qual) || list_length(constraintList), !proj);
@@ -546,13 +547,15 @@ aoco_beginscan_extractcolumns(Relation rel, Snapshot snapshot,
 		*/
 		if (!found)
 			proj[0] = true;
+		needFree = true;
 	}
 	aoscan = aocs_beginscan(rel,
 							snapshot,
 							proj,
 							flags);
 
-	pfree(proj);
+	if (needFree)
+		pfree(proj);
 	return (TableScanDesc)aoscan;
 }
 

--- a/src/test/regress/input/gpcopy.source
+++ b/src/test/regress/input/gpcopy.source
@@ -1211,6 +1211,7 @@ ALTER TABLE sales EXCHANGE PARTITION dec17 WITH TABLE ext_dec17;
 DROP TABLE ext_dec17;
 COPY sales TO PROGRAM 'cat > /tmp/test_sales_all' IGNORE EXTERNAL PARTITIONS;
 COPY sales TO PROGRAM 'cat > /tmp/test_sales_with_external';
+COPY (SELECT * FROM sales) TO PROGRAM 'cat > /tmp/test_sales_with_external';
 COPY sales TO PROGRAM 'cat > /tmp/test_sales_<SEGID>' ON SEGMENT IGNORE EXTERNAL PARTITIONS;
 
 -- Verify that the files don't contain the row from the external partition.

--- a/src/test/regress/output/gpcopy.source
+++ b/src/test/regress/output/gpcopy.source
@@ -1438,9 +1438,14 @@ ALTER TABLE
 DROP TABLE ext_dec17;
 DROP TABLE
 COPY sales TO PROGRAM 'cat > /tmp/test_sales_all' IGNORE EXTERNAL PARTITIONS;
-NOTICE:  COPY ignores external partition(s)
+NOTICE:  COPY ignores external partition(s)  (seg1 10.117.190.237:7003 pid=9154)
+NOTICE:  COPY ignores external partition(s)  (seg2 10.117.190.237:7004 pid=9155)
+NOTICE:  COPY ignores external partition(s)  (seg0 10.117.190.237:7002 pid=9153)
 COPY 24
 COPY sales TO PROGRAM 'cat > /tmp/test_sales_with_external';
+ERROR:  cannot copy from relation "sales" which has external partition(s)
+HINT:  Try the COPY (SELECT ...) TO variant.
+COPY (SELECT * FROM sales) TO PROGRAM 'cat > /tmp/test_sales_with_external';
 COPY 25
 COPY sales TO PROGRAM 'cat > /tmp/test_sales_<SEGID>' ON SEGMENT IGNORE EXTERNAL PARTITIONS;
 NOTICE:  COPY ignores external partition(s)


### PR DESCRIPTION
PostgreSQL does not support copying partitioned tables to files. Refer to: https://www.postgresql.org/docs/12/sql-copy.html

> COPY TO can only be used with plain tables, not views, and does not copy rows from child tables or child partitions.
> For example, COPY table TO copies the same rows as SELECT * FROM ONLY table. The syntax COPY (SELECT * FROM table)
> TO ... can be used to dump all of the rows in an inheritance hierarchy, partitioned table, or view.

```
postgres=# copy rank to '/tmp/test1';
ERROR:  cannot copy from partitioned table "rank"
HINT:  Try the COPY (SELECT ...) TO variant.
```
In GPDB 7, partitioning was replaced with an upstream implementation. To ensure forward compatibility, `COPY partitioned_table TO file` is converted to `COPY (SELECT * FROM partitioned_table) TO file`.

---

When executing these two statements separately in GPDB 6, we can see that the performance of `COPY (SELECT * FROM partitioned_table) TO file` is much worse.

```
postgres=# SELECT COUNT(*) FROM rank;
   count
-----------
 100000000
(1 row)
postgres=# \timing
Timing is on.
postgres=# COPY rank TO '/tmp/test1';
COPY 100000000
Time: 34176.985 ms
postgres=# COPY (SELECT * FROM rank) TO '/tmp/test2';
COPY 100000000
Time: 128893.366 ms

```

The reason for this performance difference is that `COPY partitioned_table TO file` converts tuples to text on each QE and sends them to QD before writing to the file. On the other hand, `COPY (SELECT * FROM partitioned_table) TO file` requires executing a query to gather all tuples to QD before converting them to text and writing to the file. In other words, `COPY partitioned_table TO file` performs tuple-to-text conversion in parallel.

To improve performance, this commit re-implements `COPY partitioned_table TO file` by traversing all sub-tables on QE. If there are external tables with partitions, users need to explicitly declare `IGNORE EXTERNAL PARTITIONS`, otherwise an error will be reported and the user will be prompted to modify the command to COPY (SELECT * FROM partitioned_table) TO file (consistent with the behavior of GPDB6).

Related issue: https://github.com/greenplum-db/gpdb/issues/14948.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
