### PR TITLE
[6X] Fixing gpcheckperf error when ran with -f and -V option

### DIFF
--- a/gpMgmt/bin/gpcheckperf
+++ b/gpMgmt/bin/gpcheckperf
@@ -80,9 +80,9 @@ def strcmd(cmd):
     return reduce(lambda x, y: x + ' ' + y, map(lambda x: x.find(' ') > 0 and "'" + x + "'" or x, cmd))
 
 
-def gpssh(cmd):
+def gpssh(cmd, verbose):
     c = ['%s/bin/gpssh' % GPHOME]
-    if GV.opt['-V']:
+    if verbose:
         c.append('-v')
     if GV.opt['-f']:
         c.append('-f')
@@ -324,13 +324,13 @@ def runTeardown():
     for d in GV.opt['-d']:
         dirs = '%s %s/gpcheckperf_$USER' % (dirs, d)
     try:
-        gpssh('rm -rf ' + dirs)
+        gpssh('rm -rf ' + dirs, GV.opt['-V'])
     except:
         pass
 
     try:
         if GV.opt['--net']:
-            gpssh(killall(GV.opt['--netserver']))
+            gpssh(killall(GV.opt['--netserver']), GV.opt['-V'])
     except:
         pass
 
@@ -347,7 +347,7 @@ def runSetup():
         # check python reachable
         if GV.opt['-v']:
             print '[Info] verify python interpreter exists'
-        (ok, out) = gpssh('python -c print')
+        (ok, out) = gpssh('python -c print', GV.opt['-V'])
         if not ok:
             if not GV.opt['-v']:
                 print out
@@ -362,7 +362,7 @@ def runSetup():
             dirs = '%s %s/gpcheckperf_$USER' % (dirs, d)
 
         cmd = 'rm -rf %s ; mkdir -p %s' % (dirs, dirs)
-        (ok, out) = gpssh(cmd)
+        (ok, out) = gpssh(cmd, GV.opt['-V'])
         if not ok:
             print 'failed gpssh: %s' % out
             sys.exit("[Error] unable to make gpcheckperf directory. \n"
@@ -400,7 +400,7 @@ def copyExecOver(fname):
         sys.exit('[Error] command failed: gpscp %s =:%s with output: %s' % (path, target, out))
 
     # chmod +x file
-    (ok, out) = gpssh('chmod a+rx %s' % target)
+    (ok, out) = gpssh('chmod a+rx %s' % target, GV.opt['-V'])
     if not ok:
         sys.exit('[Error] command failed: chmod a+rx %s with output: %s' % (target, out))
 
@@ -450,7 +450,7 @@ def runDiskWriteTest(multidd):
         cmd = cmd + (' -B %d' % GV.opt['-B'])
     if GV.opt['-S']:
         cmd = cmd + (' -S %d' % GV.opt['-S'])
-    (ok, out) = gpssh(cmd)
+    (ok, out) = gpssh(cmd, GV.opt['-V'])
     if not ok:
         sys.exit('[Error] command failed: %s with output: %s' % (cmd, out))
     return parseMultiDDResult(out)
@@ -469,7 +469,7 @@ def runDiskReadTest(multidd):
         cmd = cmd + (' -B %d' % GV.opt['-B'])
     if GV.opt['-S']:
         cmd = cmd + (' -S %d' % GV.opt['-S'])
-    (ok, out) = gpssh(cmd)
+    (ok, out) = gpssh(cmd, GV.opt['-V'])
     if not ok:
         sys.exit('[Error] command failed: %s with output: %s' % (cmd, out))
     return parseMultiDDResult(out)
@@ -482,7 +482,7 @@ def runStreamTest():
     print '--------------------'
 
     cmd = copyExecOver('stream')
-    (ok, out) = gpssh(cmd)
+    (ok, out) = gpssh(cmd, GV.opt['-V'])
     if not ok:
         sys.exit('[Error] command failed: %s with output: %s' % (cmd, out))
     out = StringIO.StringIO(out)
@@ -504,9 +504,9 @@ def startNetServer():
     for i in xrange(5):
         if i > 0:
             print '[Warning] retrying with port %d' % port
-        (ok, out) = gpssh(killall(GV.opt['--netserver']))
+        (ok, out) = gpssh(killall(GV.opt['--netserver']), GV.opt['-V'])
 
-        (ok, out) = gpssh('%s -p %d > /dev/null 2>&1' % (rmtPath, port))
+        (ok, out) = gpssh('%s -p %d > /dev/null 2>&1' % (rmtPath, port), GV.opt['-V'])
         if ok:
             return port
 
@@ -732,13 +732,22 @@ def get_host_map(hostlist):
         uniqhosts =
             uniqhosts['apollo1'] = 'sdw1-1'
             uniqhosts['apollo2'] = 'sdw2-1'
-
     '''
     seglist = dict()  # segment list
     uniqhosts = dict()  # unique host list
 
-    # get list of hostnames
-    rc, out = gpssh('hostname')
+    '''
+     Get hostnames using non-verbose mode since verbose output makes parsing difficult with extra lines as show:
+        $gpssh -v -h sdw2 hostname
+        [WARN] Reference default values as $MASTER_DATA_DIRECTORY/gpssh.conf could not be found
+        Using delaybeforesend 0.05 and prompt_validation_timeout 1.0
+        [Reset ...]
+        [INFO] login sdw2
+        [sdw2] sdw2
+        [INFO] completed successfully
+        [Cleanup...]
+    '''
+    rc, out = gpssh('hostname', False)
     if not rc:
         raise Exception('Encountered error running hostname')
 

--- a/gpMgmt/bin/gpcheckperf
+++ b/gpMgmt/bin/gpcheckperf
@@ -788,7 +788,7 @@ def runNetPerfTestMatrix():
     '''
     (netperf, hostlist, netserver_port) = setupNetPerfTest()
     if not netperf:
-        return None
+        return None, None
 
     # dict() of seglist[segname] = hostname, uniqhosts[hostname] = 1 segment name
     seglist, uniqhosts = get_host_map(hostlist)

--- a/gpMgmt/test/behave/mgmt_utils/gpcheckperf.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpcheckperf.feature
@@ -69,3 +69,18 @@ Feature: Tests for gpcheckperf
     | matrix    | verbose       | M          | -v           | -f          | Full matrix netperf bandwidth test |
     | matrix    | extra verbose | M          | -V           | -v -f       | Full matrix netperf bandwidth test |
 
+  @concourse_cluster
+  Scenario Outline: running gpcheckperf single host <test_name> test case
+     Given the database is running
+     And create a gpcheckperf input host file
+     When  the user runs "gpcheckperf -h cdw -r <cmd_param> -d /data/gpdata/ --duration=10s -v"
+     Then  gpcheckperf should return a return code of 0
+     And   gpcheckperf should print "--  NETPERF TEST" to stdout
+     And   gpcheckperf should print "single host only - abandon netperf test" to stdout
+     And   gpcheckperf should print "TEARDOWN" to stdout
+
+  Examples:
+    | test_name   | cmd_param|
+    | matrix test | M        |
+    | network test| N        |
+

--- a/gpMgmt/test/behave/mgmt_utils/gpcheckperf.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpcheckperf.feature
@@ -26,3 +26,46 @@ Feature: Tests for gpcheckperf
     Given the database is running
     When  the user runs "gpcheckperf -h localhost -r d -d /tmp -S abc"
     Then  gpcheckperf should return a return code of 1
+
+  @concourse_cluster
+  Scenario Outline: gpcheckperf run <test_type> test by passing hostfile in regular mode
+    Given the database is running
+    And create a gpcheckperf input host file
+    When  the user runs "gpcheckperf -f /tmp/hostfile1 -r <cmd_param> -d /data/gpdata/ --duration=10s"
+    Then  gpcheckperf should return a return code of 0
+    And   gpcheckperf should print "--  NETPERF TEST" to stdout
+    And   gpcheckperf should print "<print_message>" to stdout
+    And   gpcheckperf should print "Summary:" to stdout
+    And   gpcheckperf should print "sum =" to stdout
+    And   gpcheckperf should print "min =" to stdout
+    And   gpcheckperf should print "max =" to stdout
+    And   gpcheckperf should print "avg =" to stdout
+    And   gpcheckperf should print "median =" to stdout
+
+  Examples:
+    | test_type | cmd_param | print_message                      |
+    | network   | N         | Netperf bisection bandwidth test   |
+    | matrix    | M         | Full matrix netperf bandwidth test |
+
+  @concourse_cluster
+  Scenario Outline: gpcheckperf runs <test_type> test with hostfile in <verbosity> mode
+     Given the database is running
+     And create a gpcheckperf input host file
+     When  the user runs "gpcheckperf -f /tmp/hostfile1 -r <cmd_param> -d /data/gpdata/ --duration=10s <verbose_flag>"
+     Then  gpcheckperf should return a return code of 0
+     And   gpcheckperf should print "--  NETPERF TEST" to stdout
+     And   gpcheckperf should print "<print_message>" to stdout
+     And   gpcheckperf should print "making gpcheckperf directory on all hosts ..." to stdout
+     And   gpcheckperf should print "[Info].*gpssh <gpssh_param> .*hostfile1 .*gpnetbenchClient." to stdout
+     And   gpcheckperf should print "[Info].*gpssh <gpssh_param> .*hostfile1 .*gpnetbenchServer." to stdout
+     And   gpcheckperf should print "==  RESULT*" to stdout
+     And   gpcheckperf should print "Summary:" to stdout
+     And   gpcheckperf should print "TEARDOWN" to stdout
+
+  Examples:
+    | test_type | verbosity     | cmd_param  | verbose_flag | gpssh_param | print_message                      |
+    | network   | verbose       | N          | -v           | -f          | Netperf bisection bandwidth test   |
+    | network   | extra verbose | N          | -V           | -v -f       | Netperf bisection bandwidth test   |
+    | matrix    | verbose       | M          | -v           | -f          | Full matrix netperf bandwidth test |
+    | matrix    | extra verbose | M          | -V           | -v -f       | Full matrix netperf bandwidth test |
+

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -3968,3 +3968,7 @@ def impl(context):
     cmd =  "sudo mv -f /tmp/hosts_orig /etc/hosts; rm -f /tmp/clusterConfigFile-1; rm -f /tmp/hostfile--1"
     context.execute_steps(u'''Then the user runs command "%s"''' % cmd)
 
+@given('create a gpcheckperf input host file')
+def impl(context):
+     cmd = Command(name='create input host file', cmdStr='echo sdw1 > /tmp/hostfile1;echo cdw >> /tmp/hostfile1;')
+     cmd.run(validateAfter=True)


### PR DESCRIPTION
gpcheckperf utility can be run in verbose mode in 2 ways : "-v" and "-V" which is verbose mode and very verbose mode respectively. In very verbose mode, any commands called through gpcheckperf are also run in verbose mode. 
 
 **Problem:**   
When gpcheckperf ran in very verbose mode (-V) option, it runs gpssh command with -v option which results in the extra lines of output (see example bellow for more details). Those extra lines were leading to run-time exception.
   gpssh command when ran in regular mode output is as follows:

   ```
   $ gpssh -h sdw2 hostname
   [sdw2] sdw2
   ```

   When ran gpssh in verbose mode, output is as follows:
   ```
   gpssh -v -h sdw2 hostname
   [WARN] Reference default values as $MASTER_DATA_DIRECTORY/gpssh.conf could not be found
   Using delaybeforesend 0.05 and prompt_validation_timeout 1.0
   [Reset ...]
   [INFO] login sdw2
   [sdw2] sdw2
   [INFO] completed successfully
   [Cleanup...]

   ```

**Solution:** 
   With this PR, made changes to make sure we are not running hostname command in verbose mode.
   
 **Other:**  
While testing we realised gpcheckperf if passed single host, exits with an exception. 
As part of this PR, we have fixed exception thrown when single host is passed to matrix test and added functional tests for the same.
Function `runNetPerfTestMatrix ()` was returning single value on empty output while expected was two values which Is resulting in the exception. 
Here's the sample output before fix:  
   ```
   $ gpcheckperf -h cdw  -r M -d /data/gpdata/ --duration=3m
   /usr/local/greenplum-db-devel/bin/gpcheckperf -h cdw -r M -d /data/gpdata/ --duration=3m
   -------------------
   --  NETPERF TEST
   -------------------
   [Warning] single host only - abandon netperf test

   ====================
   ==  RESULT 2023-03-15T09:52:39.962721
   ====================
   Traceback (most recent call last):
     File "/usr/local/greenplum-db-devel/bin/gpcheckperf", line 1005, in <module>
       main()
     File "/usr/local/greenplum-db-devel/bin/gpcheckperf", line 975, in main
       netResult, seglist = runNetPerfTestMatrix()
   TypeError: cannot unpack non-iterable NoneType object
   ```

This PR also adds functional tests for testing matrix and network tests when passed single host.
Ran the pipeline and made sure its green.
This is cherry-pick of: https://github.com/greenplum-db/gpdb/pull/14310
For main/7X some parity changes are required and will be raising a PR for the same. main branch also has an issue with gpssh as which also needs to be fixed. to unblock customers we have raised 6X PR on priority and 7X PR will be followed after gpssh fix. More context related to this changes and discussion can be found on: https://github.com/greenplum-db/gpdb/pull/14564
   ## Here are some reminders before you submit the pull request
   - [ ] Add tests for the change
   - [ ] Document changes
   - [ ] Communicate in the mailing list if needed
   - [ ] Pass `make installcheck`
   - [ ] Review a PR in return to support the community
