### PR TITLE
mods

### DIFF
--- a/gpdb-doc/markdown/install_guide/platform-requirements-overview.html.md
+++ b/gpdb-doc/markdown/install_guide/platform-requirements-overview.html.md
@@ -40,6 +40,7 @@ Greenplum Database 7 requires the following software packages on RHEL systems. T
 -   openssl
 -   openssl-libs
 -   perl
+-   python39
 -   readline
 -   rsync
 -   R
@@ -53,8 +54,6 @@ VMware Greenplum Database 7 client software requires these operating system pack
 -   apr-util
 -   libyaml
 -   libevent
-
-Greenplum Database 7 uses Python 2.7.12, which is included with the product installation \(and not installed as a package dependency\).
 
 > **Important** SSL is supported only on the Greenplum Database coordinator host system. It cannot be used on the segment host systems.
 


### PR DESCRIPTION
Listing python39 as a package dependency and removing statement about Python 2.7.13 which is no longer correct.
