### PR TITLE
bug fix: access method hash is missing support function

### DIFF
--- a/src/backend/utils/cache/partcache.c
+++ b/src/backend/utils/cache/partcache.c
@@ -189,6 +189,14 @@ RelationBuildPartitionKey(Relation relation)
 								   opclassform->opcintype,
 								   opclassform->opcintype,
 								   procnum);
+
+		if (!OidIsValid(funcid) && key->strategy == PARTITION_STRATEGY_HASH)
+			/* Try to switch the proc number when missing the support function */
+			funcid = get_opfamily_proc(opclassform->opcfamily,
+									   opclassform->opcintype,
+									   opclassform->opcintype,
+									   HASHSTANDARD_PROC);
+
 		if (!OidIsValid(funcid))
 			ereport(ERROR,
 					(errcode(ERRCODE_INVALID_OBJECT_DEFINITION),

--- a/src/test/regress/expected/create_table.out
+++ b/src/test/regress/expected/create_table.out
@@ -1251,3 +1251,9 @@ Indexes:
     "part_column_drop_1_10_expr_idx1" btree ((d = 2))
 
 drop table part_column_drop;
+-- please refer to: https://github.com/greenplum-db/gpdb/issues/15036
+CREATE UNLOGGED TABLE t0_issue_15034(c0 BIT VARYING(209),c1 BIT VARYING(3)) PARTITION BY HASH((t0_issue_15034.c0), (t0_issue_15034.c1));
+CREATE TEMP TABLE t1_issue_15034(c0 int4range , c1 BIT VARYING(241) ) PARTITION BY HASH((t1_issue_15034.c1));
+CREATE TEMP TABLE t2_issue_15034(c0 FLOAT , c1 money  NULL) PARTITION BY HASH((t2_issue_15034.c0)cdbhash_float8_ops);
+CREATE TABLE t3_issue_15034(c0 integer , c1 BIT VARYING(43) ) PARTITION BY HASH((t3_issue_15034.c0)cdbhash_oid_ops);
+CREATE TABLE t4_issue_15034(c0 BIT) PARTITION BY HASH((t4_issue_15034.c0));

--- a/src/test/regress/sql/create_table.sql
+++ b/src/test/regress/sql/create_table.sql
@@ -955,3 +955,10 @@ create table part_column_drop_1_10 partition of
 \d part_column_drop
 \d part_column_drop_1_10
 drop table part_column_drop;
+
+-- please refer to: https://github.com/greenplum-db/gpdb/issues/15036
+CREATE UNLOGGED TABLE t0_issue_15034(c0 BIT VARYING(209),c1 BIT VARYING(3)) PARTITION BY HASH((t0_issue_15034.c0), (t0_issue_15034.c1));
+CREATE TEMP TABLE t1_issue_15034(c0 int4range , c1 BIT VARYING(241) ) PARTITION BY HASH((t1_issue_15034.c1));
+CREATE TEMP TABLE t2_issue_15034(c0 FLOAT , c1 money  NULL) PARTITION BY HASH((t2_issue_15034.c0)cdbhash_float8_ops);
+CREATE TABLE t3_issue_15034(c0 integer , c1 BIT VARYING(43) ) PARTITION BY HASH((t3_issue_15034.c0)cdbhash_oid_ops);
+CREATE TABLE t4_issue_15034(c0 BIT) PARTITION BY HASH((t4_issue_15034.c0));


### PR DESCRIPTION
* This merge request is used to fix this issue: https://github.com/greenplum-db/gpdb/issues/15036
* Function `RelationBuildPartitionKey` cannot match some of the data in the system tables(pg_amproc), and in some cases may produce wrong results.
* When an invalid `funcid` is read, modify the variable `procnum` and try to read it again
* Some possible types involved:
![image](https://user-images.githubusercontent.com/24492354/225363371-f8f19b87-4ad1-43b2-9ebd-36a63d68a071.png)
