### PR TITLE
Fix set -dev pipeline error .

### DIFF
--- a/concourse/pipelines/templates/gpdb-tpl.yml
+++ b/concourse/pipelines/templates/gpdb-tpl.yml
@@ -672,7 +672,7 @@ resources:
 {% endif %}
 {% endif %}
 
-{% if os_type == default_os_type %}
+{% if os_type == default_os_type and pipeline_configuration == "prod" and not directed_release %}
 - name: bin_gpdb_centos7_rc
   type: gcs
   source:


### PR DESCRIPTION
error: invalid pipeline config:
invalid resources:
	resource 'bin_gpdb_centos7_rc' is not used

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
