### PR TITLE
Removed dead code in DistributedSnapshot_Copy

### DIFF
--- a/src/backend/cdb/cdbdistributedsnapshot.c
+++ b/src/backend/cdb/cdbdistributedsnapshot.c
@@ -260,16 +260,6 @@ DistributedSnapshot_Copy(DistributedSnapshot *target,
 	if (source->count == 0)
 		return;
 
-	if (target->inProgressXidArray == NULL)
-	{
-		target->inProgressXidArray =
-			(DistributedTransactionId*) malloc(GetMaxSnapshotDistributedXidCount() * sizeof(DistributedTransactionId));
-		if (target->inProgressXidArray == NULL)
-			ereport(ERROR,
-					(errcode(ERRCODE_OUT_OF_MEMORY),
-					 errmsg("out of memory")));
-	}
-
 	Assert(source->count <= GetMaxSnapshotDistributedXidCount());
 	memcpy(target->inProgressXidArray,
 			source->inProgressXidArray,


### PR DESCRIPTION

The code:
```c
	if (target->inProgressXidArray == NULL)
	{
		target->inProgressXidArray =
			(DistributedTransactionId*) malloc(GetMaxSnapshotDistributedXidCount() * sizeof(DistributedTransactionId));
		if (target->inProgressXidArray == NULL)
			ereport(ERROR,
					(errcode(ERRCODE_OUT_OF_MEMORY),
					 errmsg("out of memory")));
	}
```
in `DistributedSnapshot_Copy` is dead code, because we do the same thing in `DistributedSnapshot_Reset`.

It could be a history problem caused by code changes.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
