### PR TITLE
[6X Backport] gpexpand: Fix tables not copied to new segments

### DIFF
--- a/gpMgmt/bin/gppylib/gpcatalog.py
+++ b/gpMgmt/bin/gppylib/gpcatalog.py
@@ -26,15 +26,12 @@ MASTER_ONLY_TABLES = [
     'gp_segment_configuration',
     'gp_configuration_history',
     'gp_segment_configuration',
-    'pg_description',
     'pg_partition',
     'pg_partition_rule',
-    'pg_shdescription',
     'pg_stat_last_operation',
     'pg_stat_last_shoperation',
     'pg_statistic',
     'pg_partition_encoding',
-    'pg_auth_time_constraint',
     ]
 
 # Hard coded tables that have different values on every segment

--- a/gpMgmt/test/behave/mgmt_utils/gpexpand.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpexpand.feature
@@ -588,3 +588,25 @@ Feature: expand the cluster by adding more segments
         When the user runs gpexpand with a static inputfile for a single-node cluster with mirrors without ret code check
         Then gpexpand should return a return code of 0
         And gpexpand should print "One or more segments are either down or not in preferred role." to stdout
+
+    @gpexpand_no_mirrors
+    @gpexpand_segment
+    Scenario: expand a cluster and verify necessary catalog tables are copied to new segments
+        Given the database is not running
+        And a working directory of the test as '/data/gpdata/gpexpand'
+        And a temporary directory under "/data/gpdata/gpexpand/expandedData" to expand into
+        And a cluster is created with no mirrors on "cdw" and "sdw1"
+        And database "gptest" exists
+        And the user runs psql with "-c 'CREATE ROLE abc; ALTER ROLE abc DENY DAY 0 DENY DAY 2 DENY BETWEEN DAY 4 AND DAY 5;'" against database "gptest"
+        And there are no gpexpand_inputfiles
+        And the cluster is setup for an expansion on hosts "cdw,sdw1"
+        When the user runs gpexpand interview to add 2 new segment and 0 new host "ignored.host"
+        Then the number of segments have been saved
+        When the user runs gpexpand with the latest gpexpand_inputfile with additional parameters "--silent"
+        Then verify that the cluster has 2 new segments
+        And verify that "pg_description" catalog table is present on new segments
+        And verify that "pg_shdescription" catalog table is present on new segments
+        And verify that "pg_auth_time_constraint" catalog table is present on new segments
+        When the user runs "gpcheckcat gptest"
+        Then gpcheckcat should return a return code of 0
+        And the user runs psql with "-c 'DROP ROLE abc'" against database "gptest"

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -3195,6 +3195,21 @@ def impl(context, num_of_segments):
             "%s\ndump of gp_segment_configuration: %s" %
             (context.start_data_segments, end_data_segments, rows))
 
+@when('verify that {table_name} catalog table is present on new segments')
+@then('verify that {table_name} catalog table is present on new segments')
+def impl(context, table_name):
+    dbname = 'gptest'
+    with closing(dbconn.connect(dbconn.DbURL(dbname=dbname), unsetSearchPath=False)) as conn:
+        query = """SELECT count(*) from gp_segment_configuration where -1 < content and role='p'"""
+        no_of_segments = dbconn.execSQLForSingleton(conn, query)
+
+        query = """select count(distinct(gp_segment_id)) from gp_dist_random('%s')""" % table_name
+        no_segments_table_present = dbconn.execSQLForSingleton(conn, query)
+
+    if no_of_segments != no_segments_table_present:
+        raise Exception("Table %s is not present on newly expanded segments" % table_name)
+
+
 @given('the cluster is setup for an expansion on hosts "{hostnames}"')
 def impl(context, hostnames):
     hosts = hostnames.split(",")


### PR DESCRIPTION
This is a backport of #15025

**Issue:**
A customer reported an issue where they were unable to DROP time-based login constraints for users after running gpexpand. This was because, if there are time-based login constraints for users, there are entries in the `pg_auth_time_constraints` catalog table that are identical across all segments. However, when gpexpand was run, this table was not replicated to new segments. As a result, running the DROP command would give an error.
```
NOTICE:  dropping DENY rule for "user03" between Thursday 18:00:00 and Saturday 23:59:59
ERROR:  cannot find matching DENY rules for "user03"  (seg3 192.168.50.53:6000 pid=4429)
```

**RCA:**
The reason why the table was not getting replicated is because gpexpand creates a template of the master segment and uses it to create new segments in the cluster. As part of the cleanup process(since it uses master template), some catalog tables present only on the master are being removed from the new segments. This list of tables is defined in the `MASTER_ONLY_TABLES` list in `gpcatalog.py`.

Catalog tables like `pg_auth_time_constraint`, `pg_description`, and `pg_shdescription` are also part of the `MASTER_ONLY_TABLES` list, but these are present on all segments and not just on the master.

**Fix:**
This commit removes the tables mentioned above from the `MASTER_ONLY_TABLES` list.

Also added a behave test case to verify if these tables are present on all the newly created segments.

[Pipeline](https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb-dev-6x_gpexpand_fix-rhel8)
