### PR TITLE
[7X] ORCA produces bogus plan for queries with CTE during handling distribution for Sequence children

### DIFF
--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalFilter.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalFilter.cpp
@@ -125,9 +125,11 @@ CPhysicalFilter::PdsRequired(CMemoryPool *mp, CExpressionHandle &exprhdl,
 		return pdsRequired;
 	}
 
-	if (CDistributionSpec::EdtNonSingleton == pdsRequired->Edt() &&
-		!CDistributionSpecNonSingleton::PdsConvert(pdsRequired)
-			 ->FAllowReplicated())
+	if ((CDistributionSpec::EdtSingleton == pdsRequired->Edt() &&
+		 CDistributionSpecSingleton::PdssConvert(pdsRequired)->FOnMaster()) ||
+		(CDistributionSpec::EdtNonSingleton == pdsRequired->Edt() &&
+		 !CDistributionSpecNonSingleton::PdsConvert(pdsRequired)
+			  ->FAllowReplicated()))
 	{
 		// this situation arises when we have Filter instead inlined CTE,
 		// in this case, we need to push down non-singleton with not allowed replicated through Filter


### PR DESCRIPTION
Condition https://github.com/greenplum-db/gpdb/pull/14896/files#diff-9a5d13807de05c94a00aab51a48dfa9e4ea0b7244223dafc62dd8a89fe37cda3R269-R273 does not work in case of inlining outer CTE by filter.
```sql
CREATE TABLE d (a int, b int, c int) DISTRIBUTED BY (b);
CREATE TABLE r (a int, b int, c char(255)) DISTRIBUTED REPLICATED;

insert into d select 1,generate_series(1,1),1;
insert into r select 1,2,generate_series(1,1);

EXPLAIN (ANALYZE off, COSTS off, VERBOSE off)
with s as (WITH e AS (
    SELECT b FROM d LIMIT 2
), h AS (
    SELECT a FROM d JOIN e f USING (b) JOIN e USING (b)
) SELECT * FROM r JOIN h USING (a) JOIN h i USING (a)) select * from s;
FATAL:  Unexpected internal error (assert.c:44)
DETAIL:  FailedAssertion("!(pMotion->numHashSegments < motion_recv)", File: "explain.c", Line: 2576)
server closed the connection unexpectedly
	This probably means the server terminated abnormally
	before or while processing the request.
The connection to the server was lost. Attempting reset: Failed.
```
and without explain
```sql
WARNING:  terminating connection because of crash of another server process  (seg0 slice7 172.19.0.3:7434 pid=22329)
DETAIL:  The postmaster has commanded this server process to roll back the current transaction and exit, because another server process exited abnormally and possibly corrupted shared memory.
HINT:  In a moment you should be able to reconnect to the database and repeat your command.
WARNING:  terminating connection because of crash of another server process  (seg1 slice7 172.19.0.3:7435 pid=22330)
DETAIL:  The postmaster has commanded this server process to roll back the current transaction and exit, because another server process exited abnormally and possibly corrupted shared memory.
HINT:  In a moment you should be able to reconnect to the database and repeat your command.
WARNING:  terminating connection because of crash of another server process  (seg2 slice7 172.19.0.3:7436 pid=22331)
DETAIL:  The postmaster has commanded this server process to roll back the current transaction and exit, because another server process exited abnormally and possibly corrupted shared memory.
HINT:  In a moment you should be able to reconnect to the database and repeat your command.
WARNING:  terminating connection because of crash of another server process  (seg0 slice6 172.19.0.3:7434 pid=22323)
DETAIL:  The postmaster has commanded this server process to roll back the current transaction and exit, because another server process exited abnormally and possibly corrupted shared memory.
HINT:  In a moment you should be able to reconnect to the database and repeat your command.
WARNING:  terminating connection because of crash of another server process  (seg1 slice6 172.19.0.3:7435 pid=22324)
DETAIL:  The postmaster has commanded this server process to roll back the current transaction and exit, because another server process exited abnormally and possibly corrupted shared memory.
HINT:  In a moment you should be able to reconnect to the database and repeat your command.
WARNING:  terminating connection because of crash of another server process  (seg2 slice6 172.19.0.3:7436 pid=22325)
DETAIL:  The postmaster has commanded this server process to roll back the current transaction and exit, because another server process exited abnormally and possibly corrupted shared memory.
HINT:  In a moment you should be able to reconnect to the database and repeat your command.
WARNING:  terminating connection because of crash of another server process  (seg0 slice1 172.19.0.3:7434 pid=22301)
DETAIL:  The postmaster has commanded this server process to roll back the current transaction and exit, because another server process exited abnormally and possibly corrupted shared memory.
HINT:  In a moment you should be able to reconnect to the database and repeat your command.
WARNING:  terminating connection because of crash of another server process
DETAIL:  The postmaster has commanded this server process to roll back the current transaction and exit, because another server process exited abnormally and possibly corrupted shared memory.
HINT:  In a moment you should be able to reconnect to the database and repeat your command.
server closed the connection unexpectedly
	This probably means the server terminated abnormally
	before or while processing the request.
The connection to the server was lost. Attempting reset: Failed.
```
and without assert
```sql
  ->  Sequence
         ->  Shared Scan (share slice:id 1:1)
               ->  Redistribute Motion 1:1  (slice2)
                     Hash Module: 3
                     ->  Limit
                           ->  Gather Motion 3:1  (slice3; segments: 3)
                                 ->  Seq Scan on d
         ->  Sequence
               ->  Shared Scan (share slice:id 1:2)
                     ->  Hash Join
                           Hash Cond: (d_1.b = share1_ref2.b)
                           ->  Hash Join
                                 Hash Cond: (d_1.b = share1_ref3.b)
                                 ->  Seq Scan on d d_1
                                 ->  Hash
                                       ->  Redistribute Motion 3:1  (slice4; segments: 3)
                                             Hash Key: share1_ref3.b
                                             Hash Module: 3
                                             ->  Shared Scan (share slice:id 4:1)
                           ->  Hash
                                 ->  Redistribute Motion 3:1  (slice5; segments: 3)
                                       Hash Key: share1_ref2.b
                                       Hash Module: 3
                                       ->  Shared Scan (share slice:id 5:1)
               ->  Hash Join
                     Hash Cond: (r.a = share2_ref3.a)
                     ->  Seq Scan on r
                     ->  Hash
                           ->  Broadcast Motion 3:1  (slice6; segments: 3)
                                 ->  Hash Join
                                       Hash Cond: (share2_ref3.a = share2_ref2.a)
                                       ->  Shared Scan (share slice:id 6:2)
                                       ->  Hash
                                             ->  Broadcast Motion 3:3  (slice7; segments: 3)
                                                   ->  Shared Scan (share slice:id 7:2)
 Optimizer: Pivotal Optimizer (GPORCA)
(37 rows)
```
Because I add addition condition, passing distribution through filter in such cases.
```sql
 Sequence
   ->  Shared Scan (share slice:id 0:1)
         ->  Limit
               ->  Gather Motion 3:1  (slice1; segments: 3)
                     ->  Seq Scan on d
   ->  Sequence
         ->  Shared Scan (share slice:id 0:2)
               ->  Hash Join
                     Hash Cond: (d_1.b = share1_ref3.b)
                     ->  Gather Motion 3:1  (slice2; segments: 3)
                           ->  Seq Scan on d d_1
                     ->  Hash
                           ->  Hash Join
                                 Hash Cond: (share1_ref3.b = share1_ref2.b)
                                 ->  Shared Scan (share slice:id 0:1)
                                 ->  Hash
                                       ->  Shared Scan (share slice:id 0:1)
         ->  Hash Join
               Hash Cond: (r.a = share2_ref3.a)
               ->  Gather Motion 1:1  (slice3; segments: 1)
                     ->  Seq Scan on r
               ->  Hash
                     ->  Hash Join
                           Hash Cond: (share2_ref3.a = share2_ref2.a)
                           ->  Shared Scan (share slice:id 0:2)
                           ->  Hash
                                 ->  Shared Scan (share slice:id 0:2)
 Optimizer: Pivotal Optimizer (GPORCA)
(28 rows)
```