### PR TITLE
[6X] ORCA produces bogus plan for queries with CTE during handling distribution for Sequence children

### DIFF
--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalFilter.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalFilter.cpp
@@ -127,9 +127,12 @@ CPhysicalFilter::PdsRequired(CMemoryPool *mp, CExpressionHandle &exprhdl,
 		return pdsRequired;
 	}
 
-	if (CDistributionSpec::EdtNonSingleton == pdsRequired->Edt() &&
-		!CDistributionSpecNonSingleton::PdsConvert(pdsRequired)
-			 ->FAllowReplicated())
+
+	if ((CDistributionSpec::EdtSingleton == pdsRequired->Edt() &&
+		 CDistributionSpecSingleton::PdssConvert(pdsRequired)->FOnMaster()) ||
+		(CDistributionSpec::EdtNonSingleton == pdsRequired->Edt() &&
+		 !CDistributionSpecNonSingleton::PdsConvert(pdsRequired)
+			  ->FAllowReplicated()))
 	{
 		// this situation arises when we have Filter instead inlined CTE,
 		// in this case, we need to push down non-singleton with not allowed replicated through Filter


### PR DESCRIPTION
Condition https://github.com/greenplum-db/gpdb/pull/15124/files#diff-9a5d13807de05c94a00aab51a48dfa9e4ea0b7244223dafc62dd8a89fe37cda3R291-R295 does not work in case of inlining outer CTE by filter.
```sql
CREATE TABLE d (a int, b int, c int) DISTRIBUTED BY (b);
CREATE TABLE r (a int, b int, c char(255)) DISTRIBUTED REPLICATED;

insert into d select 1,generate_series(1,1),1;
insert into r select 1,2,generate_series(1,1);

EXPLAIN (ANALYZE off, COSTS off, VERBOSE off)
with s as (WITH e AS (
    SELECT b FROM d LIMIT 2
), h AS (
    SELECT a FROM d JOIN e f USING (b) JOIN e USING (b)
) SELECT * FROM r JOIN h USING (a) JOIN h i USING (a)) select * from s;
                                         QUERY PLAN                                          
---------------------------------------------------------------------------------------------
 Gather Motion 1:1  (slice7; segments: 1)
   ->  Sequence
         ->  Shared Scan (share slice:id 7:1)
               ->  Materialize
                     ->  Redistribute Motion 1:1  (slice6)
                           ->  Limit
                                 ->  Gather Motion 3:1  (slice5; segments: 3)
                                       ->  Seq Scan on d d_1
         ->  Sequence
               ->  Shared Scan (share slice:id 7:2)
                     ->  Materialize
                           ->  Hash Join
                                 Hash Cond: (d.b = share1_ref2.b)
                                 ->  Hash Join
                                       Hash Cond: (d.b = share1_ref3.b)
                                       ->  Seq Scan on d
                                       ->  Hash
                                             ->  Broadcast Motion 3:1  (slice3; segments: 3)
                                                   ->  Shared Scan (share slice:id 3:1)
                                 ->  Hash
                                       ->  Broadcast Motion 3:1  (slice4; segments: 3)
                                             ->  Shared Scan (share slice:id 4:1)
               ->  Hash Join
                     Hash Cond: ((r.a = share2_ref3.a) AND (r.a = share2_ref2.a))
                     ->  Seq Scan on r
                     ->  Hash
                           ->  Broadcast Motion 3:1  (slice2; segments: 3)
                                 ->  Hash Join
                                       Hash Cond: (share2_ref3.a = share2_ref2.a)
                                       ->  Shared Scan (share slice:id 2:2)
                                       ->  Hash
                                             ->  Broadcast Motion 3:3  (slice1; segments: 3)
                                                   ->  Shared Scan (share slice:id 1:2)
 Optimizer: Pivotal Optimizer (GPORCA)
(34 rows)

EXPLAIN (ANALYZE on, COSTS off, VERBOSE off)
with s as (WITH e AS (
    SELECT b FROM d LIMIT 2
), h AS (
    SELECT a FROM d JOIN e f USING (b) JOIN e USING (b)
) SELECT * FROM r JOIN h USING (a) JOIN h i USING (a)) select * from s;
ERROR:  SendTupleChunkToAMS: targetRoute is 2, must be between 0 and 1 . (ic_common.c:328)  (entry db 172.19.0.2:6432 pid=352094) (ic_common.c:328)
HINT:  Process 352094 will wait for gp_debug_linger=120 seconds before termination.
Note that its locks and other resources will not be released until then.
```
Because I add addition condition, passing distribution through filter in such cases.
```sql
EXPLAIN (ANALYZE off, COSTS off, VERBOSE off)
with s as (WITH e AS (
    SELECT b FROM d LIMIT 2
), h AS (
    SELECT a FROM d JOIN e f USING (b) JOIN e USING (b)
) SELECT * FROM r JOIN h USING (a) JOIN h i USING (a)) select * from s;
                                  QUERY PLAN                                  
------------------------------------------------------------------------------
 Sequence
   ->  Shared Scan (share slice:id 0:1)
         ->  Materialize
               ->  Limit
                     ->  Gather Motion 3:1  (slice3; segments: 3)
                           ->  Seq Scan on d d_1
   ->  Sequence
         ->  Shared Scan (share slice:id 0:2)
               ->  Materialize
                     ->  Hash Join
                           Hash Cond: (d.b = share1_ref2.b)
                           ->  Hash Join
                                 Hash Cond: (d.b = share1_ref3.b)
                                 ->  Gather Motion 3:1  (slice2; segments: 3)
                                       ->  Seq Scan on d
                                 ->  Hash
                                       ->  Shared Scan (share slice:id 0:1)
                           ->  Hash
                                 ->  Shared Scan (share slice:id 0:1)
         ->  Hash Join
               Hash Cond: ((r.a = share2_ref3.a) AND (r.a = share2_ref2.a))
               ->  Gather Motion 1:1  (slice1; segments: 1)
                     ->  Seq Scan on r
               ->  Hash
                     ->  Hash Join
                           Hash Cond: (share2_ref3.a = share2_ref2.a)
                           ->  Shared Scan (share slice:id 0:2)
                           ->  Hash
                                 ->  Shared Scan (share slice:id 0:2)
 Optimizer: Pivotal Optimizer (GPORCA)
(30 rows)
```