### PR TITLE
ASSERT relation is AO in GetAppendOnlyEntryAuxOids/GetAppendOnlyEntry

### DIFF
--- a/src/backend/catalog/pg_appendonly.c
+++ b/src/backend/catalog/pg_appendonly.c
@@ -145,7 +145,8 @@ GetAppendOnlyEntryAttributes(Oid relid,
 
 /*
  * Get the OIDs of the auxiliary relations and their indexes for an appendonly
- * relation.
+ * relation. This should only be called on tables with pg_appendonly entries,
+ * which currently are just non-partitioned AO/CO tables.
  *
  * The OIDs will be retrieved only when the corresponding output variable is
  * not NULL.
@@ -157,6 +158,9 @@ GetAppendOnlyEntryAuxOids(Relation rel,
 						  Oid *visimaprelid)
 {
 	Form_pg_appendonly	aoForm;
+
+	/* the relation has to be a non-partitioned AO/CO table */
+	Assert(RelationIsAppendOptimized(rel));
 
 	aoForm = rel->rd_appendonly;
 
@@ -170,12 +174,23 @@ GetAppendOnlyEntryAuxOids(Relation rel,
 		*visimaprelid = aoForm->visimaprelid;
 }
 
+/*
+ * Get the pg_appendonly entry for the relation. This should only be called on 
+ * tables with pg_appendonly entries, which currently are just non-partitioned
+ * AO/CO tables. The pg_appendonly data is copied into the Form_pg_appendonly
+ * pointer which should be valid.
+ */
 void
 GetAppendOnlyEntry(Relation rel, Form_pg_appendonly aoEntry)
 {
 	Form_pg_appendonly	aoForm;
 
+	/* the relation has to be a non-partitioned AO/CO table and the aoEntry is valid */
+	Assert(RelationIsAppendOptimized(rel));
+	Assert(aoEntry);
+
 	aoForm = rel->rd_appendonly;
+
 	memcpy(aoEntry, aoForm, APPENDONLY_TUPLE_SIZE);
 }
 


### PR DESCRIPTION
Updated Description:
-------------
GetAppendOnlyEntryAuxOids / GetAppendOnlyEntry should only be called on a non-partitioned AO/CO table. Otherwise, there's no pg_appendonly entry and the relation's relcache also doesn't carry any pg_appendonly entry data. Putting a strong assert there.

Original Description:
-------------
It normally shouldn't happen, but if GetAppendOnlyEntryAuxOids or GetAppendOnlyEntry is called on a non-AO table or an AO table w/o storage (e.g. partitioned table), we wouldn't be able to get the pg_appendonly tuple from relcache. As a result of that, we would get segfault when we try to dereference rd_appendonly.

Now error out in such case. We probably don't want Assert either because although rare, the above scenario could still exist. And also it's good to report exactly what's wrong.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
