### PR TITLE
Fix compilation warning in ic_proxy_peer.c

### DIFF
--- a/src/backend/cdb/motion/ic_proxy.h
+++ b/src/backend/cdb/motion/ic_proxy.h
@@ -20,7 +20,7 @@
 #include "postmaster/postmaster.h"
 
 #define IC_PROXY_BACKLOG 1024
-#define IC_PROXY_INVALID_CONTENT ((uint16) -2)
+#define IC_PROXY_INVALID_CONTENT ((int16) -2)
 #define IC_PROXY_INVALID_DBID ((int16) 0)
 /* pause the sender when the unack packet increase to this threshold */
 #define IC_PROXY_TRESHOLD_UNACK_PACKET_PAUSE 100


### PR DESCRIPTION
My previous PR https://github.com/greenplum-db/gpdb/pull/15139 introduced a warning: https://prod.ci.gpdb.pivotal.io/builds/1733638
```
ic_proxy_peer.c:159:17: warning: result of comparison of constant 65534 with expression of type 'int16' (aka 'short') is always false [-Wtautological-constant-out-of-range-compare]
                peer->content == IC_PROXY_INVALID_CONTENT)
                ~~~~~~~~~~~~~ ^  ~~~~~~~~~~~~~~~~~~~~~~~~
1 warning generated.
```

This PR fix it: change `IC_PROXY_INVALID_CONTENT` to int16 (align its type to `ICProxyPeer.content` field).

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [x] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
