### PR TITLE
Changing IC_PROXY_INVALID_CONTENT to int16

### DIFF
--- a/src/backend/cdb/motion/ic_proxy.h
+++ b/src/backend/cdb/motion/ic_proxy.h
@@ -20,7 +20,7 @@
 #include "postmaster/postmaster.h"
 
 #define IC_PROXY_BACKLOG 1024
-#define IC_PROXY_INVALID_CONTENT ((uint16) -2)
+#define IC_PROXY_INVALID_CONTENT ((int16) -2)
 #define IC_PROXY_INVALID_DBID ((int16) 0)
 /* pause the sender when the unack packet increase to this threshold */
 #define IC_PROXY_TRESHOLD_UNACK_PACKET_PAUSE 100


### PR DESCRIPTION
Port https://github.com/greenplum-db/gpdb/pull/15219 to 6X.

Keep the code consistent though no such a compilation warning in 6x (may related to compiler/os version).


## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [x] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
