### PR TITLE
fix tids are not in order when building bitmap index

### DIFF
--- a/src/backend/access/bitmap/bitmap.c
+++ b/src/backend/access/bitmap/bitmap.c
@@ -144,7 +144,7 @@ bmbuild(Relation heap, Relation index, IndexInfo *indexInfo)
 	_bitmap_init_buildstate(index, &bmstate);
 
 	/* do the heap scan */
-	reltuples = table_index_build_scan(heap, index, indexInfo, true, true,
+	reltuples = table_index_build_scan(heap, index, indexInfo, false, true,
 									   bmbuildCallback, (void *) &bmstate,
 									   NULL);
 	/* clean up the build state */

--- a/src/backend/access/bitmap/bitmapinsert.c
+++ b/src/backend/access/bitmap/bitmapinsert.c
@@ -1793,7 +1793,13 @@ buf_add_tid(Relation rel, BMTidBuildBuf *tids, uint64 tidnum,
 
 		if (tidnum < buf->last_tid)
 		{
-			/* Scan through the bitmap vector, and update the bit in tidnum */
+			/*
+			 * Usually, tidnum is greater than lovItem->bm_last_setbit.
+			 * However, if this is not the case this should be called while
+			 * doing insertion after 'vacuum'. In this, we try to update 
+			 * this bit in the corresponding bitmap.
+			 * Scan through the bitmap vector, and update the bit in tidnum.
+			 */
 			updatesetbit(rel, lovbuf, off, tidnum, state->use_wal);
 		}
 		else
@@ -1829,7 +1835,13 @@ buf_add_tid(Relation rel, BMTidBuildBuf *tids, uint64 tidnum,
 
 		if (tidnum < lovitem->bm_last_setbit)
 		{
-			/* Scan through the bitmap vector, and update the bit in tidnum */
+			/*
+			 * Usually, tidnum is greater than lovItem->bm_last_setbit.
+			 * However, if this is not the case this should be called while
+			 * doing insertion after 'vacuum'. In this, we try to update 
+			 * this bit in the corresponding bitmap.
+			 * Scan through the bitmap vector, and update the bit in tidnum.
+			 */
 			updatesetbit(rel, lovbuf, off, tidnum, state->use_wal);
 		}
 		else

--- a/src/test/isolation2/expected/bitmap_index_create.out
+++ b/src/test/isolation2/expected/bitmap_index_create.out
@@ -1,0 +1,69 @@
+create table bm_test (i int, t text);
+CREATE
+insert into bm_test select i % 3000, (i % 3000)::text  from generate_series(1, 30000) i;
+INSERT 30000
+
+1: select * from bm_test limit 10 offset 20;
+ i  | t  
+----+----
+ 54 | 54 
+ 55 | 55 
+ 59 | 59 
+ 60 | 60 
+ 65 | 65 
+ 66 | 66 
+ 70 | 70 
+ 75 | 75 
+ 77 | 77 
+ 80 | 80 
+(10 rows)
+2: select * from bm_test limit 10 offset 20;
+ i  | t  
+----+----
+ 54 | 54 
+ 55 | 55 
+ 59 | 59 
+ 60 | 60 
+ 65 | 65 
+ 66 | 66 
+ 70 | 70 
+ 75 | 75 
+ 77 | 77 
+ 80 | 80 
+(10 rows)
+3: select * from bm_test limit 10 offset 20;
+ i  | t  
+----+----
+ 54 | 54 
+ 55 | 55 
+ 59 | 59 
+ 60 | 60 
+ 65 | 65 
+ 66 | 66 
+ 70 | 70 
+ 75 | 75 
+ 77 | 77 
+ 80 | 80 
+(10 rows)
+
+create index bm_idx on bm_test using bitmap(t);
+CREATE
+
+drop index bm_idx;
+DROP
+
+1: delete from bm_test where i = 1024;
+DELETE 10
+2: update bm_test set i = 2048 where i = 256;
+UPDATE 10
+3: vacuum bm_test;
+VACUUM
+4: insert into bm_test select i % 3000, (i % 3000)::text  from generate_series(1, 30000) i;
+INSERT 30000
+
+create index bm_idx on bm_test using bitmap(t);
+CREATE
+
+-- clean up
+drop table bm_test;
+DROP

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -91,6 +91,7 @@ test: bitmap_index_concurrent
 test: bitmap_index_crash
 test: bitmap_update_words_backup_block
 test: bitmap_index_inspect
+test: bitmap_index_create
 
 # below test utilizes fault injectors so it needs to be in a group by itself
 test: external_table

--- a/src/test/isolation2/sql/bitmap_index_create.sql
+++ b/src/test/isolation2/sql/bitmap_index_create.sql
@@ -1,0 +1,20 @@
+create table bm_test (i int, t text);
+insert into bm_test select i % 3000, (i % 3000)::text  from generate_series(1, 30000) i;
+
+1: select * from bm_test limit 10 offset 20;
+2: select * from bm_test limit 10 offset 20;
+3: select * from bm_test limit 10 offset 20;
+
+create index bm_idx on bm_test using bitmap(t);
+
+drop index bm_idx;
+
+1: delete from bm_test where i = 1024;
+2: update bm_test set i = 2048 where i = 256;
+3: vacuum bm_test;
+4: insert into bm_test select i % 3000, (i % 3000)::text  from generate_series(1, 30000) i;
+
+create index bm_idx on bm_test using bitmap(t);
+
+-- clean up
+drop table bm_test;


### PR DESCRIPTION
This PR is trying to fix issue #14275.

----------------------------------------------------------------------

When we build a bitmap index on a heap table, we need to scan all the 
tuples. Usually, it'll start at block 0 to the end. But if we allow sync scan, 
it'll scan the table circularly, from block X up to the end and then from 
block 0 to X-1, to ensure we visit all rows while still participating in the 
common scan. This could lead tids are not in order when building bitmap 
index, which will throw an error in the current implementation.

So this PR forbids sync scan when building bitmap index.

Besides the above fact, if we build a bitmap index when `VACUUM` is 
running on the table, the tids we scanned could not be in order even if 
we disable sync scan. In this situation, we should update the bitmap
vector directly. 