### PR TITLE
[WIP] [6X BKPT] Fix RR transaction misuse snapshot on aoblkdir.

### DIFF
--- a/src/backend/access/appendonly/appendonlyblockdirectory.c
+++ b/src/backend/access/appendonly/appendonlyblockdirectory.c
@@ -16,6 +16,7 @@
 
 #include "cdb/cdbappendonlyblockdirectory.h"
 #include "catalog/aoblkdir.h"
+#include "catalog/aocatalog.h"
 #include "access/heapam.h"
 #include "access/genam.h"
 #include "catalog/indexing.h"
@@ -205,7 +206,8 @@ AppendOnlyBlockDirectory_Init_forSearch(
 	blockDirectory->segmentFileInfo = segmentFileInfo;
 	blockDirectory->totalSegfiles = totalSegfiles;
 	blockDirectory->aoRel = aoRel;
-	blockDirectory->appendOnlyMetaDataSnapshot = appendOnlyMetaDataSnapshot;
+	blockDirectory->appendOnlyMetaDataSnapshot = DetermineAOAuxSnapshot(RELKIND_AOBLOCKDIR,
+																		appendOnlyMetaDataSnapshot);
 	blockDirectory->numColumnGroups = numColumnGroups;
 	blockDirectory->isAOCol = isAOCol;
 	blockDirectory->currentSegmentFileNum = -1;

--- a/src/backend/catalog/aocatalog.c
+++ b/src/backend/catalog/aocatalog.c
@@ -27,6 +27,7 @@
 #include "miscadmin.h"
 #include "storage/lmgr.h"
 #include "utils/builtins.h"
+#include "utils/snapmgr.h"
 #include "catalog/gp_fastsequence.h"
 
 /*
@@ -244,4 +245,26 @@ IsAppendonlyMetadataRelkind(const char relkind) {
 	return (relkind == RELKIND_AOSEGMENTS ||
 			relkind == RELKIND_AOBLOCKDIR ||
 			relkind == RELKIND_AOVISIMAP);
+}
+
+Snapshot
+DetermineAOAuxSnapshot(const char relkind, Snapshot in_snapshot)
+{
+	Snapshot out_snapshot = in_snapshot;
+
+	switch (relkind)
+	{
+		case RELKIND_AOSEGMENTS:
+			break;
+
+		case RELKIND_AOBLOCKDIR:
+			if (IsolationUsesXactSnapshot())
+				out_snapshot = SnapshotSelf;
+			break;
+
+		case RELKIND_AOVISIMAP:
+			break;
+	}
+
+	return out_snapshot;
 }

--- a/src/include/catalog/aocatalog.h
+++ b/src/include/catalog/aocatalog.h
@@ -32,4 +32,6 @@ extern bool CreateAOAuxiliaryTable(
 
 extern bool IsAppendonlyMetadataRelkind(const char relkind);
 
+extern Snapshot DetermineAOAuxSnapshot(const char relkind, Snapshot in_snapshot);
+
 #endif   /* AOCATALOG_H */

--- a/src/test/isolation2/input/uao/snapshot_index_corruption.source
+++ b/src/test/isolation2/input/uao/snapshot_index_corruption.source
@@ -32,3 +32,81 @@ insert into test_ao select generate_series(1,100);
 -- For the repeatable read isolation level row still there (false before fix).
 2: explain (costs off) select i from test_ao where i = 100;
 2: select i from test_ao where i = 100;
+
+-- Test 3
+-- Start RR transaction before AO tuple update,
+-- create block directory (by create index) before AO tuple update,
+-- expect dead tuple visible in bitmapscan.
+1q:
+2q:
+1: drop table if exists test_ao;
+1: create table test_ao(i bigint) with (appendonly=true, orientation=@orientation@) distributed by (i);
+1: insert into test_ao select generate_series(1,10);
+
+-- create block directory here
+2: create index test_ao_idx on test_ao(i);
+2: set enable_seqscan=off;
+2: explain (costs off) select i from test_ao where i = 1;
+2: select i from test_ao where i = 1;
+
+1: drop index test_ao_idx;
+
+2: explain select i from test_ao where i = 1;
+2: select i from test_ao where i = 1;
+2: begin isolation level repeatable read;
+2: select 1;
+
+-- update row selected above and create a new index
+1: update test_ao set i = 2 where i = 1;
+1: create index test_ao_idx on test_ao(i);
+
+-- for the repeatable read isolation level row still there,
+-- because blkdir.tuple.xmin < RR transaction xid, blkdir
+-- scan in RR transaction should be able to see the entry
+-- containing the corresponding dead tuple
+2: explain (costs off) select i from test_ao where i = 1;
+2: select i from test_ao where i = 1;
+-- compare with seqscan, expect bitmapscan result to be same as seqscan
+2: set enable_bitmapscan to off;
+2: reset enable_seqscan;
+2: explain (costs off) select i from test_ao where i = 1;
+2: select i from test_ao where i = 1;
+2: end;
+
+-- Test 4
+-- Start RR transaction before AO tuple update,
+-- create block directory after AO tuple update,
+-- expect dead tuple visible in bitmapscan.
+1q:
+2q:
+1: drop table if exists test_ao;
+1: create table test_ao(i bigint) with (appendonly=true, orientation=@orientation@) distributed by (i);
+1: insert into test_ao select generate_series(1,10);
+
+2: set enable_seqscan=off;
+2: explain (costs off) select i from test_ao where i = 1;
+2: select i from test_ao where i = 1;
+2: begin isolation level repeatable read;
+2: select 1;
+
+-- update row selected above and create new index
+1: update test_ao set i = 2 where i = 1;
+-- create block directory after update,
+-- so blkdir.tuple.xmin > RR transaction xid
+1: create index test_ao_idx on test_ao(i);
+
+-- for the repeatable read isolation level row still there,
+-- because blkdir scan in RR transaction should use SnapshotSelf
+-- to make the dead tuple visibile
+2: explain (costs off) select i from test_ao where i = 1;
+2: select i from test_ao where i = 1;
+-- compare with seqscan, expect bitmapscan result to be same as seqscan
+2: set enable_bitmapscan to off;
+2: reset enable_seqscan;
+2: explain (costs off) select i from test_ao where i = 1;
+2: select i from test_ao where i = 1;
+2: end;
+
+1: drop table test_ao;
+1q:
+2q:

--- a/src/test/isolation2/output/uao/snapshot_index_corruption.source
+++ b/src/test/isolation2/output/uao/snapshot_index_corruption.source
@@ -76,3 +76,195 @@ CREATE
 -----
  100 
 (1 row)
+
+-- Test 3
+-- Start RR transaction before AO tuple update,
+-- create block directory (by create index) before AO tuple update,
+-- expect dead tuple visible in bitmapscan.
+1q: ... <quitting>
+2q: ... <quitting>
+1: drop table if exists test_ao;
+DROP
+1: create table test_ao(i bigint) with (appendonly=true, orientation=@orientation@) distributed by (i);
+CREATE
+1: insert into test_ao select generate_series(1,10);
+INSERT 10
+
+-- create block directory here
+2: create index test_ao_idx on test_ao(i);
+CREATE
+2: set enable_seqscan=off;
+SET
+2: explain (costs off) select i from test_ao where i = 1;
+ QUERY PLAN                                   
+----------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)     
+   ->  Bitmap Heap Scan on test_ao            
+         Recheck Cond: (i = 1)                
+         ->  Bitmap Index Scan on test_ao_idx 
+               Index Cond: (i = 1)            
+ Optimizer: Postgres query optimizer          
+(6 rows)
+2: select i from test_ao where i = 1;
+ i 
+---
+ 1 
+(1 row)
+
+1: drop index test_ao_idx;
+DROP
+
+2: explain select i from test_ao where i = 1;
+ QUERY PLAN                                                                                      
+-------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=10000000000.00..10000000393.90 rows=86 width=8) 
+   ->  Seq Scan on test_ao  (cost=10000000000.00..10000000392.75 rows=29 width=8)                
+         Filter: (i = 1)                                                                         
+ Optimizer: Postgres query optimizer                                                             
+(4 rows)
+2: select i from test_ao where i = 1;
+ i 
+---
+ 1 
+(1 row)
+2: begin isolation level repeatable read;
+BEGIN
+2: select 1;
+ ?column? 
+----------
+ 1        
+(1 row)
+
+-- update row selected above and create a new index
+1: update test_ao set i = 2 where i = 1;
+UPDATE 1
+1: create index test_ao_idx on test_ao(i);
+CREATE
+
+-- for the repeatable read isolation level row still there,
+-- because blkdir.tuple.xmin < RR transaction xid, blkdir
+-- scan in RR transaction should be able to see the entry
+-- containing the corresponding dead tuple
+2: explain (costs off) select i from test_ao where i = 1;
+ QUERY PLAN                                   
+----------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)     
+   ->  Bitmap Heap Scan on test_ao            
+         Recheck Cond: (i = 1)                
+         ->  Bitmap Index Scan on test_ao_idx 
+               Index Cond: (i = 1)            
+ Optimizer: Postgres query optimizer          
+(6 rows)
+2: select i from test_ao where i = 1;
+ i 
+---
+ 1 
+(1 row)
+-- compare with seqscan, expect bitmapscan result to be same as seqscan
+2: set enable_bitmapscan to off;
+SET
+2: reset enable_seqscan;
+RESET
+2: explain (costs off) select i from test_ao where i = 1;
+ QUERY PLAN                               
+------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1) 
+   ->  Seq Scan on test_ao                
+         Filter: (i = 1)                  
+ Optimizer: Postgres query optimizer      
+(4 rows)
+2: select i from test_ao where i = 1;
+ i 
+---
+ 1 
+(1 row)
+2: end;
+END
+
+-- Test 4
+-- Start RR transaction before AO tuple update,
+-- create block directory after AO tuple update,
+-- expect dead tuple visible in bitmapscan.
+1q: ... <quitting>
+2q: ... <quitting>
+1: drop table if exists test_ao;
+DROP
+1: create table test_ao(i bigint) with (appendonly=true, orientation=@orientation@) distributed by (i);
+CREATE
+1: insert into test_ao select generate_series(1,10);
+INSERT 10
+
+2: set enable_seqscan=off;
+SET
+2: explain (costs off) select i from test_ao where i = 1;
+ QUERY PLAN                               
+------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1) 
+   ->  Seq Scan on test_ao                
+         Filter: (i = 1)                  
+ Optimizer: Postgres query optimizer      
+(4 rows)
+2: select i from test_ao where i = 1;
+ i 
+---
+ 1 
+(1 row)
+2: begin isolation level repeatable read;
+BEGIN
+2: select 1;
+ ?column? 
+----------
+ 1        
+(1 row)
+
+-- update row selected above and create new index
+1: update test_ao set i = 2 where i = 1;
+UPDATE 1
+-- create block directory after update,
+-- so blkdir.tuple.xmin > RR transaction xid
+1: create index test_ao_idx on test_ao(i);
+CREATE
+
+-- for the repeatable read isolation level row still there,
+-- because blkdir scan in RR transaction should use SnapshotSelf
+-- to make the dead tuple visibile
+2: explain (costs off) select i from test_ao where i = 1;
+ QUERY PLAN                                   
+----------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)     
+   ->  Bitmap Heap Scan on test_ao            
+         Recheck Cond: (i = 1)                
+         ->  Bitmap Index Scan on test_ao_idx 
+               Index Cond: (i = 1)            
+ Optimizer: Postgres query optimizer          
+(6 rows)
+2: select i from test_ao where i = 1;
+ i 
+---
+ 1 
+(1 row)
+-- compare with seqscan, expect bitmapscan result to be same as seqscan
+2: set enable_bitmapscan to off;
+SET
+2: reset enable_seqscan;
+RESET
+2: explain (costs off) select i from test_ao where i = 1;
+ QUERY PLAN                               
+------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1) 
+   ->  Seq Scan on test_ao                
+         Filter: (i = 1)                  
+ Optimizer: Postgres query optimizer      
+(4 rows)
+2: select i from test_ao where i = 1;
+ i 
+---
+ 1 
+(1 row)
+2: end;
+END
+
+1: drop table test_ao;
+DROP
+1q: ... <quitting>
+2q: ... <quitting>


### PR DESCRIPTION
Backport https://github.com/greenplum-db/gpdb/pull/15182.

This is intended to fix issue greenplum-db#12969.
In Repeatable Read (RR) transaction, should use SnapshotSelf to scan aoblkdir, rather than MVCC snapshot because blkdir may be created after RR transaction started, using MVCC snapshot could make blkdir tuple invisible by RR transaction, leading to returning a wrong result.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
