### PR TITLE
Cherry pick some commits from gpdb7 to make pgaudit extension work

### DIFF
--- a/doc/src/sgml/sources.sgml
+++ b/doc/src/sgml/sources.sgml
@@ -353,6 +353,15 @@ ereport(ERROR,
      includes the current statement already.
     </para>
    </listitem>
+   <listitem>
+    <para>
+     <function>errhidecontext(bool hide_ctx)</function> can be called to
+     specify suppression of the <literal>CONTEXT:</> portion of a message in
+     the postmaster log.  This should only be used for verbose debugging
+     messages where the repeated inclusion of context would bloat the log
+     volume too much.
+    </para>
+   </listitem>
   </itemizedlist>
    </para>
 

--- a/src/backend/utils/error/elog.c
+++ b/src/backend/utils/error/elog.c
@@ -1403,7 +1403,7 @@ errhidestmt(bool hide_stmt)
 }
 
 /*
- * errhidestmt --- optionally suppress CONTEXT: field of log entry
+ * errhidecontext --- optionally suppress CONTEXT: field of log entry
  *
  * This should only be used for verbose debugging messages where the repeated
  * inclusion of CONTEXT: bloats the log volume too much.

--- a/src/backend/utils/error/elog.c
+++ b/src/backend/utils/error/elog.c
@@ -1402,6 +1402,25 @@ errhidestmt(bool hide_stmt)
 	return 0;					/* return value does not matter */
 }
 
+/*
+ * errhidestmt --- optionally suppress CONTEXT: field of log entry
+ *
+ * This should only be used for verbose debugging messages where the repeated
+ * inclusion of CONTEXT: bloats the log volume too much.
+ */
+int
+errhidecontext(bool hide_ctx)
+{
+	ErrorData  *edata = &errordata[errordata_stack_depth];
+
+	/* we don't bother incrementing recursion_depth */
+	CHECK_STACK_DEPTH();
+
+	edata->hide_ctx = hide_ctx;
+
+	return 0;					/* return value does not matter */
+}
+
 
 /*
  * errfunction --- add reporting function name to the current error
@@ -3475,7 +3494,8 @@ write_csvlog(ErrorData *edata)
 	appendStringInfoChar(&buf, ',');
 
 	/* errcontext */
-	appendCSVLiteral(&buf, edata->context);
+	if (!edata->hide_ctx)
+		appendCSVLiteral(&buf, edata->context);
 	appendStringInfoChar(&buf, ',');
 
 	/* user query --- only reported if not disabled by the caller */
@@ -4238,7 +4258,7 @@ send_message_to_server_log(ErrorData *edata)
 												edata->cursorpos,
 												edata->internalpos,
 												edata->internalquery,
-												edata->context,
+												edata->hide_ctx ? NULL : edata->context,
 												edata->funcname,
 												edata->show_funcname,
 												edata->filename,
@@ -4346,7 +4366,7 @@ send_message_to_server_log(ErrorData *edata)
 			append_with_tabs(&buf, edata->internalquery);
 			appendStringInfoChar(&buf, '\n');
 		}
-		if (edata->context)
+		if (edata->context && !edata->hide_ctx)
 		{
 			log_line_prefix(&buf, edata);
 			appendStringInfoString(&buf, _("CONTEXT:  "));

--- a/src/backend/utils/error/elog.c
+++ b/src/backend/utils/error/elog.c
@@ -1406,7 +1406,7 @@ errhidestmt(bool hide_stmt)
  * errhidecontext --- optionally suppress CONTEXT: field of log entry
  *
  * This should only be used for verbose debugging messages where the repeated
- * inclusion of CONTEXT: bloats the log volume too much.
+ * inclusion of context would bloat the log volume too much.
  */
 int
 errhidecontext(bool hide_ctx)

--- a/src/backend/utils/mmgr/mcxt.c
+++ b/src/backend/utils/mmgr/mcxt.c
@@ -83,6 +83,8 @@ MemoryContext OptimizerMemoryContext = NULL;
 /* This is a transient link to the active portal's memory context: */
 MemoryContext PortalContext = NULL;
 
+static void MemoryContextCallResetCallbacks(MemoryContext context);
+
 /*
  * You should not do memory allocations within a critical section, because
  * an out-of-memory error will be escalated to a PANIC. To enforce that
@@ -157,7 +159,9 @@ MemoryContextInit(void)
 	 * require it to contain at least 8K at all times. This is the only case
 	 * where retained memory in a context is *essential* --- we want to be
 	 * sure ErrorContext still has some memory even if we've run out
-	 * elsewhere!
+	 * elsewhere! Also, allow allocations in ErrorContext within a critical
+	 * section. Otherwise a PANIC will cause an assertion failure in the error
+	 * reporting code, before printing out the real cause of the failure.
 	 *
 	 * This should be the last step in this function, as elog.c assumes memory
 	 * management works once ErrorContext is non-null.
@@ -191,6 +195,7 @@ MemoryContextReset(MemoryContext context)
 	/* Nothing to do if no pallocs since startup or last reset */
 	if (!context->isReset)
 	{
+		MemoryContextCallResetCallbacks(context);
 		(*context->methods.reset) (context);
 		context->isReset = true;
 		VALGRIND_DESTROY_MEMPOOL(context);
@@ -242,6 +247,14 @@ MemoryContextDeleteImpl(MemoryContext context, const char* sfile, const char *fu
 	MemoryContextDeleteChildren(context);
 
 	/*
+	 * It's not entirely clear whether 'tis better to do this before or after
+	 * delinking the context; but an error in a callback will likely result in
+	 * leaking the whole context (if it's not a root context) if we do it
+	 * after, so let's do it before.
+	 */
+	MemoryContextCallResetCallbacks(context);
+
+	/*
 	 * We delink the context from its parent before deleting it, so that if
 	 * there's an error we won't have deleted/busted contexts still attached
 	 * to the context tree.  Better a leak than a crash.
@@ -286,6 +299,56 @@ MemoryContextResetAndDeleteChildren(MemoryContext context)
 
 	MemoryContextDeleteChildren(context);
 	MemoryContextReset(context);
+}
+
+/*
+ * MemoryContextRegisterResetCallback
+ *		Register a function to be called before next context reset/delete.
+ *		Such callbacks will be called in reverse order of registration.
+ *
+ * The caller is responsible for allocating a MemoryContextCallback struct
+ * to hold the info about this callback request, and for filling in the
+ * "func" and "arg" fields in the struct to show what function to call with
+ * what argument.  Typically the callback struct should be allocated within
+ * the specified context, since that means it will automatically be freed
+ * when no longer needed.
+ *
+ * There is no API for deregistering a callback once registered.  If you
+ * want it to not do anything anymore, adjust the state pointed to by its
+ * "arg" to indicate that.
+ */
+void
+MemoryContextRegisterResetCallback(MemoryContext context,
+								   MemoryContextCallback *cb)
+{
+	AssertArg(MemoryContextIsValid(context));
+
+	/* Push onto head so this will be called before older registrants. */
+	cb->next = context->reset_cbs;
+	context->reset_cbs = cb;
+	/* Mark the context as non-reset (it probably is already). */
+	context->isReset = false;
+}
+
+/*
+ * MemoryContextCallResetCallbacks
+ *		Internal function to call all registered callbacks for context.
+ */
+static void
+MemoryContextCallResetCallbacks(MemoryContext context)
+{
+	MemoryContextCallback *cb;
+
+	/*
+	 * We pop each callback from the list before calling.  That way, if an
+	 * error occurs inside the callback, we won't try to call it a second time
+	 * in the likely event that we reset or delete the context later.
+	 */
+	while ((cb = context->reset_cbs) != NULL)
+	{
+		context->reset_cbs = cb->next;
+		(*cb->func) (cb->arg);
+	}
 }
 
 /*

--- a/src/include/nodes/memnodes.h
+++ b/src/include/nodes/memnodes.h
@@ -19,22 +19,6 @@
 #include "nodes/nodes.h"
 
 /*
- * A memory context can have callback functions registered on it.  Any such
- * function will be called once just before the context is next reset or
- * deleted.  The MemoryContextCallback struct describing such a callback
- * typically would be allocated within the context itself, thereby avoiding
- * any need to manage it explicitly (the reset/delete action will free it).
- */
-typedef void (*MemoryContextCallbackFunction) (void *arg);
-
-typedef struct MemoryContextCallback
-{
-	MemoryContextCallbackFunction func; /* function to call */
-	void	   *arg;			/* argument to pass it */
-	struct MemoryContextCallback *next; /* next in list of callbacks */
-} MemoryContextCallback;
-
-/*
  * MemoryContext
  *		A logical context in which memory allocations occur.
  *

--- a/src/include/nodes/memnodes.h
+++ b/src/include/nodes/memnodes.h
@@ -19,6 +19,22 @@
 #include "nodes/nodes.h"
 
 /*
+ * A memory context can have callback functions registered on it.  Any such
+ * function will be called once just before the context is next reset or
+ * deleted.  The MemoryContextCallback struct describing such a callback
+ * typically would be allocated within the context itself, thereby avoiding
+ * any need to manage it explicitly (the reset/delete action will free it).
+ */
+typedef void (*MemoryContextCallbackFunction) (void *arg);
+
+typedef struct MemoryContextCallback
+{
+	MemoryContextCallbackFunction func; /* function to call */
+	void	   *arg;			/* argument to pass it */
+	struct MemoryContextCallback *next; /* next in list of callbacks */
+} MemoryContextCallback;
+
+/*
  * MemoryContext
  *		A logical context in which memory allocations occur.
  *
@@ -73,6 +89,7 @@ typedef struct MemoryContextData
     const char *callerFile;     /* __FILE__ of most recent caller */
     int         callerLine;     /* __LINE__ of most recent caller */
 #endif
+	MemoryContextCallback *reset_cbs;	/* list of reset/delete callbacks */
 } MemoryContextData;
 
 /* utils/palloc.h contains typedef struct MemoryContextData *MemoryContext */

--- a/src/include/utils/elog.h
+++ b/src/include/utils/elog.h
@@ -290,6 +290,7 @@ errcontext_msg(const char *fmt,...)
 __attribute__((format(PG_PRINTF_ATTRIBUTE, 1, 2)));
 
 extern int	errhidestmt(bool hide_stmt);
+extern int	errhidecontext(bool hide_ctx);
 
 extern int	errfunction(const char *funcname);
 extern int	errposition(int cursorpos);
@@ -497,6 +498,7 @@ typedef struct ErrorData
 
 	/* context containing associated non-constant strings */
 	struct MemoryContextData *assoc_context;
+	bool		hide_ctx;		/* true to prevent CONTEXT: inclusion */
 } ErrorData;
 
 extern void EmitErrorReport(void);

--- a/src/include/utils/memutils.h
+++ b/src/include/utils/memutils.h
@@ -201,8 +201,6 @@ extern void MemoryContextReset(MemoryContext context);
 extern void MemoryContextResetChildren(MemoryContext context);
 extern void MemoryContextDeleteChildren(MemoryContext context);
 extern void MemoryContextResetAndDeleteChildren(MemoryContext context);
-extern void MemoryContextRegisterResetCallback(MemoryContext context,
-								   MemoryContextCallback *cb);
 extern void MemoryContextSetParent(MemoryContext context,
 					   MemoryContext new_parent);
 extern Size GetMemoryChunkSpace(void *pointer);

--- a/src/include/utils/memutils.h
+++ b/src/include/utils/memutils.h
@@ -201,6 +201,8 @@ extern void MemoryContextReset(MemoryContext context);
 extern void MemoryContextResetChildren(MemoryContext context);
 extern void MemoryContextDeleteChildren(MemoryContext context);
 extern void MemoryContextResetAndDeleteChildren(MemoryContext context);
+extern void MemoryContextRegisterResetCallback(MemoryContext context,
+								   MemoryContextCallback *cb);
 extern void MemoryContextSetParent(MemoryContext context,
 					   MemoryContext new_parent);
 extern Size GetMemoryChunkSpace(void *pointer);

--- a/src/include/utils/palloc.h
+++ b/src/include/utils/palloc.h
@@ -94,6 +94,22 @@ typedef uint32 OOMTimeType;
 typedef struct MemoryContextData *MemoryContext;
 
 /*
+ * A memory context can have callback functions registered on it.  Any such
+ * function will be called once just before the context is next reset or
+ * deleted.  The MemoryContextCallback struct describing such a callback
+ * typically would be allocated within the context itself, thereby avoiding
+ * any need to manage it explicitly (the reset/delete action will free it).
+ */
+typedef void (*MemoryContextCallbackFunction) (void *arg);
+
+typedef struct MemoryContextCallback
+{
+	MemoryContextCallbackFunction func; /* function to call */
+	void	   *arg;			/* argument to pass it */
+	struct MemoryContextCallback *next; /* next in list of callbacks */
+} MemoryContextCallback;
+
+/*
  * CurrentMemoryContext is the default allocation context for palloc().
  * Avoid accessing it directly!  Instead, use MemoryContextSwitchTo()
  * to change the setting.
@@ -160,6 +176,10 @@ MemoryContextSwitchTo(MemoryContext context)
 }
 #endif   /* PG_USE_INLINE || MCXT_INCLUDE_DEFINITIONS */
 #endif   /* FRONTEND */
+
+/* Registration of memory context reset/delete callbacks */
+extern void MemoryContextRegisterResetCallback(MemoryContext context,
+								   MemoryContextCallback *cb);
 
 /*
  * These are like standard strdup() except the copied string is


### PR DESCRIPTION
Cherry-pick a total of 5 commits from  gpdb7 to make pgaudit extension work on gpdb_6X.

The oldest pg version that the pgaudit extension can support is 9.5. So there are a couple
of compiling errors on gpdb_6X, as pgaudit depends on the following 2 new features from gpdb7:

1. Invent a memory context reset/delete callback mechanism 
2. Add capability to suppress CONTEXT: messages to elog machinery 

So cherry-pick those commits.


## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
