### PR TITLE
[6X] Fix flaky idle_gang_cleaner case

### DIFF
--- a/src/test/isolation2/input/idle_gang_cleaner.source
+++ b/src/test/isolation2/input/idle_gang_cleaner.source
@@ -4,8 +4,6 @@
 -- clean up the idle writer gangs after the timeout, 
 -- no snapshot collision error should occur.
 
-CREATE OR REPLACE FUNCTION cleanupAllGangs() RETURNS BOOL
-AS '@abs_builddir@/../regress/regress.so', 'cleanupAllGangs' LANGUAGE C;
 set gp_vmem_idle_resource_timeout to '1s';
 set gp_snapshotadd_timeout to 0;
 
@@ -13,7 +11,6 @@ create table target_session_id_t(target_session_id int) DISTRIBUTED REPLICATED;
 insert into target_session_id_t values(current_setting('gp_session_id')::int);
 
 create table idle_gang_cleaner_t (c1 int, c2 int);
-select cleanupAllGangs();
 
 0U: select gp_inject_fault('proc_kill', 'suspend', 2, target_session_id) from target_session_id_t;
 

--- a/src/test/isolation2/output/idle_gang_cleaner.source
+++ b/src/test/isolation2/output/idle_gang_cleaner.source
@@ -4,8 +4,6 @@
 -- clean up the idle writer gangs after the timeout,
 -- no snapshot collision error should occur.
 
-CREATE OR REPLACE FUNCTION cleanupAllGangs() RETURNS BOOL AS '@abs_builddir@/../regress/regress@DLSUFFIX@', 'cleanupAllGangs' LANGUAGE C;
-CREATE
 set gp_vmem_idle_resource_timeout to '1s';
 SET
 set gp_snapshotadd_timeout to 0;
@@ -18,11 +16,6 @@ INSERT 1
 
 create table idle_gang_cleaner_t (c1 int, c2 int);
 CREATE
-select cleanupAllGangs();
- cleanupallgangs 
------------------
- t               
-(1 row)
 
 0U: select gp_inject_fault('proc_kill', 'suspend', 2, target_session_id) from target_session_id_t;
  gp_inject_fault 


### PR DESCRIPTION
After calling `cleanupAllGangs()`, there is a chance of encountering the FATAL "writer segworker group shared snapshot collision" error when executing a query. The reason is that if the writer gang cannot exit before a new command starts, it will find the same session id in the shared snapshot and collision will happen. Additionally, since the session only have the writer gangs before executing the target query, there is no need to call `cleanupAllGangs()` before executing the query.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
