### PR TITLE
docs - add content about automatically inlined CTEs

### DIFF
--- a/gpdb-doc/markdown/admin_guide/query/topics/CTE-query.html.md
+++ b/gpdb-doc/markdown/admin_guide/query/topics/CTE-query.html.md
@@ -2,28 +2,24 @@
 title: WITH Queries (Common Table Expressions) 
 ---
 
-The `WITH` clause provides a way to use subqueries or perform a data modifying operation in a larger `SELECT` query. You can also use the `WITH` clause in an `INSERT`, `UPDATE`, or `DELETE` command.
+The `WITH` clause provides a way to write auxiliary statements for use in a larger query. These statements, which are often referred to as Common Table Expressions or CTEs, can be thought of as defining temporary tables that exist just for one query.
 
-See [SELECT in a WITH Clause](#topic_xyn_dgh_5gb) for information about using `SELECT` in a `WITH` clause.
-
-See [Data-Modifying Statements in a WITH clause](#topic_zg3_bgh_5gb), for information about using `INSERT`, `UPDATE`, or `DELETE` in a `WITH` clause.
-
-> **Note** These are limitations for using a `WITH` clause.
-
--   For a `SELECT` command that includes a `WITH` clause, the clause can contain at most a single clause that modifies table data \(`INSERT`, `UPDATE`, or `DELETE` command\).
--   For a data-modifying command \(`INSERT`, `UPDATE`, or `DELETE`\) that includes a `WITH` clause, the clause can only contain a `SELECT` command, the `WITH` clause cannot contain a data-modifying command.
-
-By default, the `RECURSIVE` keyword for the `WITH` clause is enabled. `RECURSIVE` can be deactivated by setting the server configuration parameter [gp\_recursive\_cte](../../../ref_guide/config_params/guc-list.html) to `false`.
+> **Note** Limitations when using a `WITH` clause in Greenplum Database include:
+> 
+> -   For a `SELECT` command that includes a `WITH` clause, the clause can contain at most a single clause that modifies table data \(`INSERT`, `UPDATE`, or `DELETE` command\).
+> -   For a data-modifying command \(`INSERT`, `UPDATE`, or `DELETE`\) that includes a `WITH` clause, the clause can only contain a `SELECT` command, it cannot contain a data-modifying command.
+ 
+By default, Greenplum Database enables the `RECURSIVE` keyword for the `WITH` clause. `RECURSIVE` can be deactivated by setting the server configuration parameter [gp\_recursive\_cte](../../../ref_guide/config_params/guc-list.html) to `false`.
 
 **Parent topic:** [Querying Data](../../query/topics/query.html)
 
 ## <a id="topic_xyn_dgh_5gb"></a>SELECT in a WITH Clause 
 
-The subqueries, which are often referred to as Common Table Expressions or CTEs, can be thought of as defining temporary tables that exist just for the query. These examples show the `WITH` clause being used with a `SELECT` command. The example `WITH` clauses can be used the same way with `INSERT`, `UPDATE`, or `DELETE`. In each case, the `WITH` clause effectively provides temporary tables that can be referred to in the main command.
+One use of CTEs is to break down complicated queries into simpler parts. The examples in this section show the `WITH` clause being used with a `SELECT` command. The example `WITH` clauses can be used the same manner with `INSERT`, `UPDATE`, or `DELETE`.
 
 A `SELECT` command in the `WITH` clause is evaluated only once per execution of the parent query, even if it is referred to more than once by the parent query or sibling `WITH` clauses. Thus, expensive calculations that are needed in multiple places can be placed within a `WITH` clause to avoid redundant work. Another possible application is to prevent unwanted multiple evaluations of functions with side-effects. However, the other side of this coin is that the optimizer is less able to push restrictions from the parent query down into a `WITH` query than an ordinary sub-query. The `WITH` query will generally be evaluated as written, without suppression of rows that the parent query might discard afterwards. However, evaluation might stop early if the references to the query demand only a limited number of rows.
 
-One use of this feature is to break down complicated queries into simpler parts. This example query displays per-product sales totals in only the top sales regions:
+The following example query displays per-product sales totals in only the top sales regions:
 
 ```
 WITH regional_sales AS (
@@ -45,9 +41,9 @@ GROUP BY region, product;
 
 ```
 
-The query could have been written without the `WITH` clause, but would have required two levels of nested sub-SELECTs. It is easier to follow with the `WITH` clause.
+The `WITH` clause defines two auxiliary statements named `regional_sales` and `top_regions`, where the output of `regional_sales` is used in `top_regions` and the output of `top_regions` is used in the primary `SELECT` query. The query could have been written without the `WITH` clause, but would have required two levels of nested sub-`SELECT`s.
 
-When the optional `RECURSIVE` keyword is enabled, the `WITH` clause can accomplish things not otherwise possible in standard SQL. Using `RECURSIVE`, a query in the `WITH` clause can refer to its own output. This is a simple example that computes the sum of integers from 1 through 100:
+When you specify the optional `RECURSIVE` keyword, the `WITH` clause can accomplish operations not otherwise possible in standard SQL. Using `RECURSIVE`, a `WITH` query can refer to its own output. This simple example computes the sum of integers from 1 through 100:
 
 ```
 WITH RECURSIVE t(n) AS (
@@ -56,102 +52,97 @@ WITH RECURSIVE t(n) AS (
     SELECT n+1 FROM t WHERE n < 100
 )
 SELECT sum(n) FROM t;
-
 ```
 
-The general form of a recursive `WITH` clause \(a `WITH` clause that uses a the `RECURSIVE` keyword\) is a *non-recursive term*, followed by a `UNION` \(or `UNION ALL`\), and then a *recursive term*, where only the *recursive term* can contain a reference to the query output.
+The general form of a recursive `WITH` query always follows the pattern of: a *non-recursive term*, followed by a `UNION` \(or `UNION ALL`\), and then a *recursive term*, where only the *recursive term* can contain a reference to the query output.
 
 ```
 <non_recursive_term> UNION [ ALL ] <recursive_term>
 ```
 
-A recursive `WITH` query that contains a `UNION [ ALL ]` is run as follows:
+A recursive `WITH` query that contains a `UNION [ ALL ]` is evaluated as follows:
 
 1.  Evaluate the non-recursive term. For `UNION` \(but not `UNION ALL`\), discard duplicate rows. Include all remaining rows in the result of the recursive query, and also place them in a temporary *working table*.
 2.  As long as the working table is not empty, repeat these steps:
     1.  Evaluate the recursive term, substituting the current contents of the working table for the recursive self-reference. For `UNION` \(but not `UNION ALL`\), discard duplicate rows and rows that duplicate any previous result row. Include all remaining rows in the result of the recursive query, and also place them in a temporary *intermediate table*.
     2.  Replace the contents of the *working table* with the contents of the *intermediate table*, then empty the *intermediate table*.
 
-> **Note** Strictly speaking, the process is iteration not recursion, but `RECURSIVE` is the terminology chosen by the SQL standards committee.
+    > **Note** While `RECURSIVE` allows queries to be specified recursively, Greenplum Database evaluates such queries iteratively internally.
 
-Recursive `WITH` queries are typically used to deal with hierarchical or tree-structured data. An example is this query to find all the direct and indirect sub-parts of a product, given only a table that shows immediate inclusions:
+In the example above, the working table has just a single row in each step, and it takes on the values from 1 through 100 in successive steps. In the 100th step, there is no output because of the `WHERE` clause, and so the query terminates.
+
+Recursive `WITH` queries are typically used to deal with hierarchical or tree-structured data. For example, this query locates all of the direct and indirect sub-parts of a product, given only a table that shows immediate inclusions:
 
 ```
 WITH RECURSIVE included_parts(sub_part, part, quantity) AS (
     SELECT sub_part, part, quantity FROM parts WHERE part = 'our_product'
   UNION ALL
-    SELECT p.sub_part, p.part, p.quantity
+    SELECT p.sub_part, p.part, p.quantity * pr.quantity
     FROM included_parts pr, parts p
     WHERE p.part = pr.sub_part
-  )
+)
 SELECT sub_part, SUM(quantity) as total_quantity
 FROM included_parts
-GROUP BY sub_part ;
-
+GROUP BY sub_part;
 ```
 
-When working with recursive `WITH` queries, you must ensure that the recursive part of the query eventually returns no tuples, or else the query loops indefinitely. In the example that computes the sum of integers, the working table contains a single row in each step, and it takes on the values from 1 through 100 in successive steps. In the 100th step, there is no output because of the `WHERE` clause, and the query terminates.
-
-For some queries, using `UNION` instead of `UNION ALL` can ensure that the recursive part of the query eventually returns no tuples by discarding rows that duplicate previous output rows. However, often a cycle does not involve output rows that are complete duplicates: it might be sufficient to check just one or a few fields to see if the same point has been reached before. The standard method for handling such situations is to compute an array of the visited values. For example, consider the following query that searches a table graph using a link field:
+When working with recursive `WITH` queries, you must ensure that the recursive part of the query eventually returns no tuples, or else the query loops indefinitely. For some queries, using `UNION` instead of `UNION ALL` can ensure that the recursive part of the query eventually returns no tuples by discarding rows that duplicate previous output rows. However, often a cycle does not involve output rows that are complete duplicates: it might be sufficient to check just one or a few fields to see if the same point has been reached before. The standard method for handling such situations is to compute an array of the visited values. For example, consider the following query that searches a table `graph` using a `link` field:
 
 ```
 WITH RECURSIVE search_graph(id, link, data, depth) AS (
-        SELECT g.id, g.link, g.data, 1
-        FROM graph g
-      UNION ALL
-        SELECT g.id, g.link, g.data, sg.depth + 1
-        FROM graph g, search_graph sg
-        WHERE g.id = sg.link
+    SELECT g.id, g.link, g.data, 1
+    FROM graph g
+  UNION ALL
+    SELECT g.id, g.link, g.data, sg.depth + 1
+    FROM graph g, search_graph sg
+    WHERE g.id = sg.link
 )
 SELECT * FROM search_graph;
-
 ```
 
-This query loops if the link relationships contain cycles. Because the query requires a `depth` output, changing `UNION ALL` to `UNION` does not eliminate the looping. Instead the query needs to recognize whether it has reached the same row again while following a particular path of links. This modified query adds two columns, `path` and `cycle`, to the loop-prone query:
+This query loops if the `link` relationships contain cycles. Because the query requires a `depth` output, changing `UNION ALL` to `UNION` does not eliminate the looping. Instead the query needs to recognize whether it has reached the same row again while following a particular path of links. This modified query adds two columns, `path` and `cycle`, to the loop-prone query:
 
 ```
 WITH RECURSIVE search_graph(id, link, data, depth, path, cycle) AS (
-        SELECT g.id, g.link, g.data, 1,
-          ARRAY[g.id],
-          false
-        FROM graph g
-      UNION ALL
-        SELECT g.id, g.link, g.data, sg.depth + 1,
-          path || g.id,
-          g.id = ANY(path)
-        FROM graph g, search_graph sg
-        WHERE g.id = sg.link AND NOT cycle
+    SELECT g.id, g.link, g.data, 1,
+      ARRAY[g.id],
+      false
+    FROM graph g
+  UNION ALL
+    SELECT g.id, g.link, g.data, sg.depth + 1,
+      path || g.id,
+      g.id = ANY(path)
+    FROM graph g, search_graph sg
+    WHERE g.id = sg.link AND NOT cycle
 )
 SELECT * FROM search_graph;
-
 ```
 
-Aside from detecting cycles, the array value of `path` is useful in its own right since it represents the path taken to reach any particular row.
+Aside from detecting cycles, the array value is useful in its own right since it represents the "path" taken to reach any particular row.
 
-In the general case where more than one field needs to be checked to recognize a cycle, an array of rows can be used. For example, if we needed to compare fields `f1` and `f2`:
+In the general case where more than one field needs to be checked to recognize a cycle, use an array of rows. For example, if we needed to compare fields `f1` and `f2`:
 
 ```
 WITH RECURSIVE search_graph(id, link, data, depth, path, cycle) AS (
-        SELECT g.id, g.link, g.data, 1,
-          ARRAY[ROW(g.f1, g.f2)],
-          false
-        FROM graph g
-      UNION ALL
-        SELECT g.id, g.link, g.data, sg.depth + 1,
-          path || ROW(g.f1, g.f2),
-          ROW(g.f1, g.f2) = ANY(path)
-        FROM graph g, search_graph sg
-        WHERE g.id = sg.link AND NOT cycle
+    SELECT g.id, g.link, g.data, 1,
+      ARRAY[ROW(g.f1, g.f2)],
+      false
+    FROM graph g
+  UNION ALL
+    SELECT g.id, g.link, g.data, sg.depth + 1,
+      path || ROW(g.f1, g.f2),
+      ROW(g.f1, g.f2) = ANY(path)
+    FROM graph g, search_graph sg
+    WHERE g.id = sg.link AND NOT cycle
 )
 SELECT * FROM search_graph;
-
 ```
 
-**Tip:** Omit the `ROW()` syntax in the case where only one field needs to be checked to recognize a cycle. This uses a simple array rather than a composite-type array, gaining efficiency.
+**Tip:** Omit the `ROW()` syntax in the case where only one field must be checked to recognize a cycle. This uses a simple array rather than a composite-type array, gaining efficiency.
 
-**Tip:** The recursive query evaluation algorithm produces its output in breadth-first search order. You can display the results in depth-first search order by making the outer query `ORDER BY` a path column constructed in this way.
+**Tip:** The recursive query evaluation algorithm produces its output in breadth-first search order. You can display the results in depth-first search order by making the outer query `ORDER BY` a "path" column constructed in this way.
 
-A helpful technique for testing a query when you are not certain if it might loop indefinitely is to place a `LIMIT` in the parent query. For example, this query would loop forever without the `LIMIT` clause:
+A helpful technique for testing a query when you are not certain if it might loop indefinitely is to place a `LIMIT` in the parent query. For example, the following query would loop forever without the `LIMIT` clause:
 
 ```
 WITH RECURSIVE t(n) AS (
@@ -162,7 +153,60 @@ WITH RECURSIVE t(n) AS (
 SELECT n FROM t LIMIT 100;
 ```
 
-The technique works because the recursive `WITH` implementation evaluates only as many rows of a `WITH` query as are actually fetched by the parent query. Using this technique in production is not recommended, because other systems might work differently. Also, the technique might not work if the outer query sorts the recursive `WITH` results or join the results to another table.
+This technique works because Greenplum Database evaluates only as many rows of a `WITH` query as are actually fetched by the parent query. *Using this technique in production environments is not recommended*, because other systems might work differently. Also, the technique might not work if the outer query sorts the recursive `WITH` results or joins the results to another table, because in such cases the outer query will usually try to fetch all of the `WITH` query's output anyway.
+
+A useful property of `WITH` queries is that they are normally evaluated only once per execution of the parent query, even if they are referred to more than once by the parent query or sibling `WITH` queries. Thus, expensive calculations that are needed in multiple places can be placed within a `WITH` query to avoid redundant work. Another possible application is to prevent unwanted multiple evaluations of functions with side-effects. However, the other side of this coin is that the optimizer is not able to push restrictions from the parent query down into a multiply-referenced `WITH` query, since that might affect all uses of the `WITH` query's output when it should affect only one. Greenplum Database evalues the multiply-referenced `WITH` query as written, without suppression of rows that the parent query might discard afterwards. (But, as mentioned above, evaluation might stop early if the reference(s) to the query demand only a limited number of rows.)
+
+If a `WITH` query is non-recursive and side-effect-free (that is, it is a `SELECT` containing no volatile functions) then it can be folded into the parent query, allowing joint optimization of the two query levels. By default, this happens if the parent query references the `WITH` query just once, but not if it references the `WITH` query more than once. You can override that decision by specifying `MATERIALIZED` to force separate calculation of the `WITH` query, or by specifying `NOT MATERIALIZED` to force it to be merged into the parent query. The latter choice risks duplicate computation of the `WITH` query, but it can still give a net savings if each usage of the `WITH` query needs only a small part of the `WITH` query's full output.
+
+A simple example of these rules follows:
+
+``` sql
+WITH w AS (
+    SELECT * FROM big_table
+)
+SELECT * FROM w WHERE key = 123;
+```
+
+This `WITH` query will be folded, producing the same execution plan as:
+
+``` sql
+SELECT * FROM big_table WHERE key = 123;
+```
+
+In particular, if there's an index on `key`, Greenplum Database uses it to fetch just the rows having `key = 123`. On the other hand, in:
+
+``` sql
+WITH w AS (
+    SELECT * FROM big_table
+)
+SELECT * FROM w AS w1 JOIN w AS w2 ON w1.key = w2.ref
+WHERE w2.key = 123;
+```
+
+the `WITH` query will be materialized, producing a temporary copy of `big_table` that is then joined with itself — without benefit of any index. This query will run much more efficiently if written as:
+
+``` sql
+WITH w AS NOT MATERIALIZED (
+    SELECT * FROM big_table
+)
+SELECT * FROM w AS w1 JOIN w AS w2 ON w1.key = w2.ref
+WHERE w2.key = 123;
+```
+
+so that the parent query's restrictions can be applied directly to scans of `big_table`.
+
+An example where `NOT MATERIALIZED` could be undesirable is:
+
+``` sql
+WITH w AS (
+    SELECT key, very_expensive_function(val) as f FROM some_table
+)
+SELECT * FROM w AS w1 JOIN w AS w2 ON w1.f = w2.f;
+```
+
+Here, materialization of the `WITH` query ensures that Greenplum Database evaluations `very_expensive_function` only once per table row, not twice.
+
 
 ## <a id="topic_zg3_bgh_5gb"></a>Data-Modifying Statements in a WITH clause 
 
@@ -183,9 +227,9 @@ WITH deleted_rows AS (
 SELECT * FROM deleted_rows;
 ```
 
-Data-modifying statements in a `WITH` clause must have `RETURNING` clauses, as shown in the previous example. It is the output of the `RETURNING` clause, not the target table of the data-modifying statement, that forms the temporary table that can be referred to by the rest of the query. If a data-modifying statement in a `WITH` lacks a `RETURNING` clause, an error is returned.
+Data-modifying statements in a `WITH` clause must have `RETURNING` clauses, as shown in the previous example. It is the output of the `RETURNING` clause, *not* the target table of the data-modifying statement, that forms the temporary table that can be referred to by the rest of the query. If a data-modifying statement in a `WITH` lacks a `RETURNING` clause, then it forms no temporary table and cannot be referred to in the rest of the query. Greenplum Database runs such a statement nonetheless.
 
-If the optional `RECURSIVE` keyword is enabled, recursive self-references in data-modifying statements are not allowed. In some cases it is possible to work around this limitation by referring to the output of a recursive `WITH`. For example, this query would remove all direct and indirect subparts of a product.
+If the optional `RECURSIVE` keyword is enabled, recursive self-references in data-modifying statements are not allowed. In some cases it is possible to work around this limitation by referring to the output of a recursive `WITH`. For example, this query would remove all direct and indirect subparts of a product:
 
 ```
 WITH RECURSIVE included_parts(sub_part, part) AS (
@@ -199,7 +243,9 @@ DELETE FROM parts
   WHERE part IN (SELECT part FROM included_parts);
 ```
 
-The sub-statements in a `WITH` clause are run concurrently with each other and with the main query. Therefore, when using a data-modifying statement in a `WITH`, the statement is run in a *snapshot*. The effects of the statement are not visible on the target tables. The `RETURNING` data is the only way to communicate changes between different `WITH` sub-statements and the main query. In this example, the outer `SELECT` returns the original prices before the action of the `UPDATE` in the `WITH` clause.
+The sub-statements in a `WITH` clause are run concurrently with each other and with the main query. Therefore, when using a data-modifying statement in a `WITH`, the order in which the specified updates actually happen is unpredictable. All of the statements are run wth the same *snapshot*. The effects of the statement are not visible on the target tables. This alleviates the effects of the unpredictability of the actual order of row updates, and means thats the `RETURNING` data is the only way to communicate changes between different `WITH` sub-statements and the main query.
+
+In this example, the outer `SELECT` returns the original prices before the action of the `UPDATE` in the `WITH` clause:
 
 ```
 WITH t AS (
@@ -209,7 +255,7 @@ WITH t AS (
 SELECT * FROM products;
 ```
 
-In this example the outer `SELECT` returns the updated data.
+In this example, the outer `SELECT` returns the updated data:
 
 ```
 WITH t AS (
@@ -221,5 +267,21 @@ SELECT * FROM t;
 
 Updating the same row twice in a single statement is not supported. The effects of such a statement will not be predictable. Only one of the modifications takes place, but it is not easy \(and sometimes not possible\) to predict which modification occurs.
 
-Any table used as the target of a data-modifying statement in a `WITH` clause must not have a conditional rule, or an `ALSO` rule, or an `INSTEAD` rule that expands to multiple statements.
+Any table used as the target of a data-modifying statement in a `WITH` clause must not have a conditional rule, nor an `ALSO` rule, nor an `INSTEAD` rule that expands to multiple statements.
+
+
+## <a id="consider"></a>Considerations
+
+When constructing `WITH` queries, keep the following in mind:
+
+- `SELECT FOR UPDATE` cannot be inlined.
+- Greenplum Database inlines multiply-referenced CTEs only when requested.
+- Multiply-referenced CTEs cannot be inlined if they contain outer self-references.
+- Greenplum Database does not inline when the CTE includes a volatile function.
+- An `ORDER BY` in the subquery or CTE does not force an ordering for the whole query.
+- Greenplum Database always materializes a CTE term in a query. Due to this:
+
+    - A query that should touch a small amount of data may instead read a whole table, and possibly spill to a temporary file.
+    - `UPDATE` or `DELETE FROM` statements are not permitted in a CTE term, as it acts more like a read-only temporary table than a dynamic view. 
+- While inlining is generally a huge win, there are certain boundary cases where it is not; for example, when a non-trivial expression will be inlined in multiple places.
 

--- a/gpdb-doc/markdown/admin_guide/query/topics/query-piv-opt-notes.html.md
+++ b/gpdb-doc/markdown/admin_guide/query/topics/query-piv-opt-notes.html.md
@@ -18,7 +18,7 @@ If the partitioned table contains more than 20,000 partitions, consider a redesi
 
 These server configuration parameters affect GPORCA query processing.
 
--   `optimizer_cte_inlining_bound` controls the amount of inlining performed for common table expression \(CTE\) queries \(queries that contain a `WHERE` clause\).
+-   `optimizer_cte_inlining_bound` controls the amount of inlining performed for common table expression \(CTE\) queries \(queries that contain a `WITH` clause\).
 -   `optimizer_force_comprehensive_join_implementation` affects GPORCA's consideration of nested loop join and hash join alternatives. When the value is `false` \(the default\), GPORCA does not consider nested loop join alternatives when a hash join is available.
 -   `optimizer_force_multistage_agg` forces GPORCA to choose a multi-stage aggregate plan for a scalar distinct qualified aggregate. When the value is `off` \(the default\), GPORCA chooses between a one-stage and two-stage aggregate plan based on cost.
 -   `optimizer_force_three_stage_scalar_dqa` forces GPORCA to choose a plan with multistage aggregates when such a plan alternative is generated.

--- a/gpdb-doc/markdown/ref_guide/config_params/guc-list.html.md
+++ b/gpdb-doc/markdown/ref_guide/config_params/guc-list.html.md
@@ -2212,7 +2212,7 @@ The default cost model, `calibrated`, is more likely to choose a faster bitmap i
 
 ## <a id="optimizer_cte_inlining_bound"></a>optimizer\_cte\_inlining\_bound 
 
-When GPORCA is enabled \(the default\), this parameter controls the amount of inlining performed for common table expression \(CTE\) queries \(queries that contain a `WHERE` clause\). The default value, 0, deactivates inlining.
+When GPORCA is enabled \(the default\), this parameter controls the amount of inlining performed for common table expression \(CTE\) queries \(queries that contain a `WITH` clause\). The default value, 0, deactivates inlining.
 
 The parameter can be set for a database system, an individual database, or a session or query.
 


### PR DESCRIPTION
update the WITH queries doc content.  in this PR:  
- update existing greenplum CTE docs based on https://www.postgresql.org/docs/12/queries-with.html.
- add a "Considerations" section to the topic.  got a good chunk of the info for this section from the code/tests.
- not documenting gp_cte_sharing guc at the moment.
- a few misc edits in gporca docs

notes:  greenplum 6 docs stated that for a SELECT command, the WITH clause can contain only a single data-modifying command, and that a data-modifing command can include only a SELECT clause in the WITH clause (no data-modifying in the WITH). after trying out on a build, this appeared to hold true for greenplum 7. LET ME KNOW IF THIS IS NOT THE CASE.

questions:  
1.  are there any gporca considerations w.r.t. this feature?
2.  greenplum 6 docs state that RECURSIVE is the default.  is this true?  is it (still) true in greenplum 7?

doc review site link (behind vpn):  https://docs-staging.vmware.com/en/draft/VMware-Tanzu-Greenplum/aicte/greenplum-database/GUID-admin_guide-query-topics-CTE-query.html
