### PR TITLE
6X: Introduce GUC gp_count_host_segments_using_address.

### DIFF
--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -3104,6 +3104,15 @@ struct config_bool ConfigureNamesBool_gp[] =
 	},
 
 	{
+		{"gp_count_host_segments_using_address", PGC_POSTMASTER, RESOURCES,
+		   gettext_noop("Count the number segments on a host using the address field in gp_segment_configuration"),
+		   gettext_noop("If false, count it using gp_segment_configuration.hostname instead")
+		},
+		&gp_count_host_segments_using_address,
+		false, NULL, NULL
+	},
+
+	{
 		{"stats_queue_level", PGC_SUSET, STATS_COLLECTOR,
 			gettext_noop("Collects resource queue-level statistics on database activity."),
 			NULL

--- a/src/include/cdb/cdbutil.h
+++ b/src/include/cdb/cdbutil.h
@@ -204,6 +204,9 @@ extern GpSegConfigEntry *dbid_get_dbinfo(int16 dbid);
 extern int16 contentid_get_dbid(int16 contentid, char role, bool getPreferredRoleNotCurrentRole);
 
 extern int numsegmentsFromQD;
+
+extern bool gp_count_host_segments_using_address;
+
 /*
  * Returns the number of segments
  */

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -152,6 +152,7 @@
 		"gp_connection_send_timeout",
 		"gp_contentid",
 		"gp_cost_hashjoin_chainwalk",
+		"gp_count_host_segments_using_address",
 		"gp_create_table_random_default_distribution",
 		"gp_cte_sharing",
 		"gp_dbid",


### PR DESCRIPTION
Neither hosts and IP addr can make sure everything is correct.
Sometimes users do want to use IP to compute the N segments on
a host. This commit introduces a GUC gp_count_host_segments_using_address,
its default value is false:

  * when it is false, nsegments on a host is computed using hostname
    as key,
  * when it is true, nsegments on a host is computed using ip addr as
  key.

Test locally using as below using two hosts to build a 4-segment
cluster with no mirrros and no standby:

  gpadmin=# select content, port, hostname, address from gp_segment_configuration ;
   content | port |  hostname  |  address
  ---------+------+------------+------------
        -1 | 5432 | zlv-ubuntu | zlv-ubuntu
         0 | 6000 | test       | rr1
         1 | 6001 | test       | rr1
         2 | 6002 | test       | rr2
         3 | 6003 | test       | rr2
  (5 rows)

The above configuration is made by utility mode into master and
manually modified.

When the GUC is set false, a QE's memory content is:

  (gdb) p host_segments
  $1 = 4
  (gdb) p pResGroupControl->totalChunks
  $2 = 6125
  (gdb)

When the GUC is set true, a QE's memory content is:
  (gdb) p host_segments
  $1 = 2
  (gdb) p pResGroupControl->totalChunks
  $2 = 12250
  (gdb)