### PR TITLE
[7x]: Fixing gpcheckperf failure parity changes and gpssh fix

### DIFF
--- a/gpMgmt/bin/gpcheckperf
+++ b/gpMgmt/bin/gpcheckperf
@@ -82,9 +82,9 @@ def strcmd(cmd):
     return reduce(lambda x, y: x + ' ' + y, map(lambda x: x.find(' ') > 0 and "'" + x + "'" or x, cmd))
 
 
-def gpssh(cmd, call_verbose=True):
+def gpssh(cmd, verbose):
     c = ['%s/bin/gpssh' % GPHOME]
-    if GV.opt['-V'] and call_verbose:
+    if verbose:
         c.append('-v')
     if GV.opt['-f']:
         c.append('-f')
@@ -326,13 +326,13 @@ def runTeardown():
     for d in GV.opt['-d']:
         dirs = '%s %s/gpcheckperf_$USER' % (dirs, d)
     try:
-        gpssh('rm -rf ' + dirs)
+        gpssh('rm -rf ' + dirs, GV.opt['-V'])
     except:
         pass
 
     try:
         if GV.opt['--net']:
-            gpssh(killall(GV.opt['--netserver']))
+            gpssh(killall(GV.opt['--netserver']), GV.opt['-V'])
     except:
         pass
 
@@ -349,7 +349,7 @@ def runSetup():
         # Verify python3 is accessible
         if GV.opt['-v']:
             print('[Info] verify python3 interpreter exists')
-        (ok, out) = gpssh('python3 -c print')
+        (ok, out) = gpssh('python3 -c print', GV.opt['-V'])
         if not ok:
             if not GV.opt['-v']:
                 print(out)
@@ -364,7 +364,7 @@ def runSetup():
             dirs = '%s %s/gpcheckperf_$USER' % (dirs, d)
 
         cmd = 'rm -rf %s ; mkdir -p %s' % (dirs, dirs)
-        (ok, out) = gpssh(cmd)
+        (ok, out) = gpssh(cmd, GV.opt['-V'])
         if not ok:
             print('failed gpssh: %s' % out)
             sys.exit("[Error] unable to make gpcheckperf directory. \n"
@@ -402,7 +402,7 @@ def copyExecOver(fname):
         sys.exit('[Error] command failed: gpsync %s =:%s with output: %s' % (path, target, out))
 
     # chmod +x file
-    (ok, out) = gpssh('chmod a+rx %s' % target)
+    (ok, out) = gpssh('chmod a+rx %s' % target, GV.opt['-V'])
     if not ok:
         sys.exit('[Error] command failed: chmod a+rx %s with output: %s' % (target, out))
 
@@ -458,7 +458,7 @@ def runDiskWriteTest(multidd):
         cmd = cmd + (' -B %d' % GV.opt['-B'])
     if GV.opt['-S']:
         cmd = cmd + (' -S %d' % GV.opt['-S'])
-    (ok, out) = gpssh(cmd)
+    (ok, out) = gpssh(cmd, GV.opt['-V'])
     if not ok:
         sys.exit('[Error] command failed: %s with output: %s' % (cmd, out))
     return parseMultiDDResult(out)
@@ -477,7 +477,7 @@ def runDiskReadTest(multidd):
         cmd = cmd + (' -B %d' % GV.opt['-B'])
     if GV.opt['-S']:
         cmd = cmd + (' -S %d' % GV.opt['-S'])
-    (ok, out) = gpssh(cmd)
+    (ok, out) = gpssh(cmd, GV.opt['-V'])
     if not ok:
         sys.exit('[Error] command failed: %s with output: %s' % (cmd, out))
     return parseMultiDDResult(out)
@@ -490,7 +490,7 @@ def runStreamTest():
     print('--------------------')
 
     cmd = copyExecOver('stream')
-    (ok, out) = gpssh(cmd)
+    (ok, out) = gpssh(cmd, GV.opt['-V'])
     if not ok:
         sys.exit('[Error] command failed: %s with output: %s' % (cmd, out))
     out = io.StringIO(out)
@@ -512,9 +512,9 @@ def startNetServer():
     for i in range(5):
         if i > 0:
             print('[Warning] retrying with port %d' % port)
-        (ok, out) = gpssh(killall(GV.opt['--netserver']))
+        (ok, out) = gpssh(killall(GV.opt['--netserver']), GV.opt['-V'])
 
-        (ok, out) = gpssh('%s -p %d > /dev/null 2>&1' % (rmtPath, port))
+        (ok, out) = gpssh('%s -p %d > /dev/null 2>&1' % (rmtPath, port), GV.opt['-V'])
         if ok:
             return port
 
@@ -745,8 +745,15 @@ def get_host_map(hostlist):
     seglist = dict()  # segment list
     uniqhosts = dict()  # unique host list
 
-    # get list of hostnames
-    # disabling verbose mode for gpssh as it is adding extra lines of output
+    '''
+     Get hostnames using non-verbose mode since verbose output makes parsing difficult with extra lines as show:
+        Using delaybeforesend 0.05 and prompt_validation_timeout 1.0
+        [Reset ...]
+        [INFO] login sdw2
+        [sdw2] sdw2
+        [INFO] completed successfully
+        [Cleanup...]
+    '''
     rc, out = gpssh('hostname', False)
 
     if not rc:
@@ -760,9 +767,6 @@ def get_host_map(hostlist):
     # get unique hostname list
     for line in out.splitlines():
         seg, host = line.translate(str.maketrans('','','[]')).split()
-        # removing \r and b coming in the output of the command in hostname
-        host = host.replace('\\r\'', '')
-        host = host.replace('b\'', '')
         uniqhosts[host] = seg
 
     # get list of segments associated with each host (can't use gpssh since it de-dupes hosts)
@@ -771,7 +775,7 @@ def get_host_map(hostlist):
 
         proc = None
         try:
-            if GV.opt['-v'] or GV.opt['-V']:
+            if GV.opt['-v']:
                 print('[Info]', strcmd(cmd))
             proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
             out = proc.stdout.read(-1)
@@ -824,8 +828,6 @@ def runNetPerfTestMatrix():
 
 
 def printMatrixResult(result, seglist):
-    if not result:
-        return
     print('Full matrix netperf bandwidth test')
 
     # sum up Rx/Tx rate for each host
@@ -882,8 +884,6 @@ def printMatrixResult(result, seglist):
 
 
 def printNetResult(result):
-    if not result:
-        return
     print('Netperf bisection bandwidth test')
     for h in result:
         print('%s -> %s = %f' % (h[0], h[1], h[6]))
@@ -915,8 +915,6 @@ def printNetResult(result):
 
 
 def printResult(title, result):
-    if not result:
-        return
     totTime = 0
     totBytes = 0
     totMBPS = 0

--- a/gpMgmt/bin/gpcheckperf
+++ b/gpMgmt/bin/gpcheckperf
@@ -420,7 +420,7 @@ def parseMultiDDResult(out):
         o = line[i + 2:]
 
 
-        if o.find('multidd total bytes ') > 0:
+        if o.find('multidd total bytes ') >= 0:
             h = line[1:i]
             o = o.split()
             m = re.search("(^\d+)", o[-1])
@@ -429,7 +429,7 @@ def parseMultiDDResult(out):
             bytes = int(m.group(1))
             continue
 
-        if o.find('real') > 0:
+        if o.find('real') >= 0:
             h = line[1:i]
             o = o.split()
             m = re.search("(^\d+.\d+)", o[1])

--- a/gpMgmt/bin/gppylib/util/ssh_utils.py
+++ b/gpMgmt/bin/gppylib/util/ssh_utils.py
@@ -283,8 +283,9 @@ class Session(cmd.Cmd):
 
         for s in self.pxssh_list:
             # Split the output into an array of lines so that we can add text to the beginning of
-            #    each line
-            output = s.before.split(b'\n')
+            # each line. Decoding string as we are getting bytecode string in s.before
+            # Removing \r characters in each line by strip
+            output = [x.strip() for x in s.before.decode().split('\n')]
             output = output[1:-1]
 
             commandoutput.append(output)

--- a/gpMgmt/test/behave/mgmt_utils/gpcheckperf.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpcheckperf.feature
@@ -17,48 +17,59 @@ Feature: Tests for gpcheckperf
     And   gpcheckperf should not print "NOTICE: -t is deprecated " to stdout
 
   @concourse_cluster
-  Scenario: gpcheckperf runs tests by passing hostfile in super verbose mode
+  Scenario Outline: gpcheckperf run <test_type> test by passing hostfile in regular mode
     Given the database is running
-    And   create a gpcheckperf input host file
-    When  the user runs "gpcheckperf -f /tmp/hostfile1 -r M -d /data/gpdata/ --duration=3m -V"
+    And create a gpcheckperf input host file
+    When  the user runs "gpcheckperf -f /tmp/hostfile1 -r <cmd_param> -d /data/gpdata/ --duration=10s"
     Then  gpcheckperf should return a return code of 0
-    And   gpcheckperf should print "Full matrix netperf bandwidth test" to stdout
-    And   gpcheckperf should not print "IndexError: list index out of range" to stdout
+    And   gpcheckperf should print "--  NETPERF TEST" to stdout
+    And   gpcheckperf should print "<print_message>" to stdout
+    And   gpcheckperf should print "Summary:" to stdout
+    And   gpcheckperf should print "sum =" to stdout
+    And   gpcheckperf should print "min =" to stdout
+    And   gpcheckperf should print "max =" to stdout
+    And   gpcheckperf should print "avg =" to stdout
+    And   gpcheckperf should print "median =" to stdout
 
- @concourse_cluster
-  Scenario: gpcheckperf runs tests by passing hostfile in verbose mode
-    Given the database is running
-    And   create a gpcheckperf input host file
-    When  the user runs "gpcheckperf -f /tmp/hostfile1 -r M -d /data/gpdata/ --duration=3m -v"
-    Then  gpcheckperf should return a return code of 0
-    And   gpcheckperf should print "Full matrix netperf bandwidth test" to stdout
-    And   gpcheckperf should not print "IndexError: list index out of range" to stdout
-
- @concourse_cluster
-  Scenario: gpcheckperf runs tests by passing hostfile in regular mode
-    Given the database is running
-    And   create a gpcheckperf input host file
-    When  the user runs "gpcheckperf -f /tmp/hostfile1 -r M -d /data/gpdata/ --duration=3m"
-    Then  gpcheckperf should return a return code of 0
-    And   gpcheckperf should print "Full matrix netperf bandwidth test" to stdout
-    And   gpcheckperf should not print "IndexError: list index out of range" to stdout
+  Examples:
+    | test_type | cmd_param | print_message                      |
+    | network   | N         | Netperf bisection bandwidth test   |
+    | matrix    | M         | Full matrix netperf bandwidth test |
 
   @concourse_cluster
-  Scenario: gpcheckperf does not throws typeerror when run with single host
-    Given the database is running
-    And   create a gpcheckperf input host file
-    When  the user runs "gpcheckperf -h sdw1 -r M -d /data/gpdata/ --duration=3m"
-    Then  gpcheckperf should return a return code of 0
-    And   gpcheckperf should print "single host only - abandon netperf test" to stdout
-    And gpcheckperf should not print "TypeError:" to stdout
+  Scenario Outline: gpcheckperf runs <test_type> test with hostfile in <verbosity> mode
+     Given the database is running
+     And create a gpcheckperf input host file
+     When  the user runs "gpcheckperf -f /tmp/hostfile1 -r <cmd_param> -d /data/gpdata/ --duration=10s <verbose_flag>"
+     Then  gpcheckperf should return a return code of 0
+     And   gpcheckperf should print "--  NETPERF TEST" to stdout
+     And   gpcheckperf should print "<print_message>" to stdout
+     And   gpcheckperf should print "making gpcheckperf directory on all hosts ..." to stdout
+     And   gpcheckperf should print "[Info].*gpssh <gpssh_param> .*hostfile1 .*gpnetbenchClient." to stdout
+     And   gpcheckperf should print "[Info].*gpssh <gpssh_param> .*hostfile1 .*gpnetbenchServer." to stdout
+     And   gpcheckperf should print "==  RESULT*" to stdout
+     And   gpcheckperf should print "Summary:" to stdout
+     And   gpcheckperf should print "TEARDOWN" to stdout
 
-  Scenario: gpcheckperf runs with -S option and prints a warning message
-    Given the database is running
-    When  the user runs "gpcheckperf -h localhost -r d -d /tmp -S 1GB"
-    Then  gpcheckperf should return a return code of 0
-    And   gpcheckperf should print "\[Warning] Using 1073741824 bytes for disk performance test. This might take some time" to stdout
+  Examples:
+    | test_type | verbosity     | cmd_param  | verbose_flag | gpssh_param | print_message                      |
+    | network   | verbose       | N          | -v           | -f          | Netperf bisection bandwidth test   |
+    | network   | extra verbose | N          | -V           | -v -f       | Netperf bisection bandwidth test   |
+    | matrix    | verbose       | M          | -v           | -f          | Full matrix netperf bandwidth test |
+    | matrix    | extra verbose | M          | -V           | -v -f       | Full matrix netperf bandwidth test |
 
-  Scenario: gpcheckperf errors out when invalid value is passed to the -S option
-    Given the database is running
-    When  the user runs "gpcheckperf -h localhost -r d -d /tmp -S abc"
-    Then  gpcheckperf should return a return code of 1
+  @concourse_cluster
+  Scenario Outline: running gpcheckperf single host <test_name> test case
+     Given the database is running
+     And create a gpcheckperf input host file
+     When  the user runs "gpcheckperf -h cdw -r <cmd_param> -d /data/gpdata/ --duration=10s -v"
+     Then  gpcheckperf should return a return code of 0
+     And   gpcheckperf should print "--  NETPERF TEST" to stdout
+     And   gpcheckperf should print "single host only - abandon netperf test" to stdout
+     And   gpcheckperf should print "TEARDOWN" to stdout
+
+  Examples:
+    | test_name   | cmd_param|
+    | matrix test | M        |
+    | network test| N        |
+


### PR DESCRIPTION
This PR contains the following changes: 
1. Changes related to fixing gpssh to return a string instead of the mix of string+bytes. 
2. Changes related to gpcheckperf failured after gpssh changes due to string parsing. 
3. Backporting changes from 6X PR for gpcheckperf: https://github.com/greenplum-db/gpdb/pull/15192 

All changes are combined in this PR as they are related to each other. 

**Details:** 
**1.Issue-1: gpssh fix:** Before this change, gpssh was returning command output mix of string + bytes and had characters like b and \r. 

Sample command output before the fix: 
```
$ gpssh -h sdw1 hostname
  [sdw1] b'sdw1\r'
```

**RCA:**
When gpssh reads output from pexpect.before, it is in byte format.
We need to convert this output into the string format. Also, carriage return characters (\r) need to be removed.

**Fix:**
When the output is returned from gpssh, made sure that we are converting bytes to string.
To remove \r characters, striping the lines.


Sample output after the fix:
```
$ gpssh -h sdw1 hostname
 [sdw1] sdw1
```
**Issue 2 gpcheckperf string parsing correction:** After updating gpssh to return string output, gpcheckperf failed to parse results.

**RCA:**
String before gpssh changes: "'multidd total bytes '" (note the extra single quotes)
String after gpssh fix: "multidd total bytes "
In parseMultiDDResult(), str.Find() before gpssh changes was returning index 1 as it was getting string starting with a single quote. 
Post gpssh changes, the substring is at the beginning of the string hence returning index 0.

**Fix:**
str.find() returns -1 if the substring is not found otherwise returns the start index where the substring is found.
As the substring searched in parseMultiDDResult() is appearing at index zero, corrected condition to include index zero.

**Issue 3: Parity changes from 6x:** Parity changes from 6X PR: https://github.com/greenplum-db/gpdb/pull/15192
More discussion on gpssh issue can be found at: https://github.com/greenplum-db/gpdb/pull/14564#discussion_r1130572826
Previous 7X PR which introduced gpcheckperf changes: https://github.com/greenplum-db/gpdb/pull/14310
Parity Changes are as follows:

1.   Controlling verbosity of gpssh() function through verbose parameter
2.   Updating gpssh calls with verbose parameter
3.   Removing non-required checks in print*Results()
4.   Removing regex removal for b' and \r characters when getting hostnames as it is fixed in gpssh.
5.   Re-structured test cases for gpcheckperf


**Testing Done:** 

1. Ran the pipeline and made sure gpssh, gpcheckperf and all other jobs are green. 
2. Manually tested gpssh output for single line and multi-line output. 

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
