### PR TITLE
Fix a couple of memory leak in AO/AOCS vacuum/compaction code

### DIFF
--- a/src/backend/access/aocs/aocs_compaction.c
+++ b/src/backend/access/aocs/aocs_compaction.c
@@ -116,16 +116,19 @@ AOCSSegmentFileTruncateToEOF(Relation aorel,
 		AOCSVPInfoEntry *entry;
 		File		fd;
 		int32		fileSegNo;
+		char		*nspname;
 
 		entry = getAOCSVPEntry(fsinfo, j);
 		segeof = entry->eof;
+
+		nspname = get_namespace_name(RelationGetNamespace(aorel));
 
 		/* Open and truncate the relation segfile to its eof */
 		MakeAOSegmentFileName(aorel, segno, j, &fileSegNo, filenamepath);
 
 		elogif(Debug_appendonly_print_compaction, LOG,
 			   "Opening AO COL relation \"%s.%s\", relation id %u, relfilenode %u column #%d, logical segment #%d (physical segment file #%d, logical EOF " INT64_FORMAT ")",
-			   get_namespace_name(RelationGetNamespace(aorel)),
+			   nspname,
 			   relname,
 			   aorel->rd_id,
 			   aorel->rd_node.relNode,
@@ -142,7 +145,7 @@ AOCSSegmentFileTruncateToEOF(Relation aorel,
 
 			elogif(Debug_appendonly_print_compaction, LOG,
 				   "Successfully truncated AO COL relation \"%s.%s\", relation id %u, relfilenode %u column #%d, logical segment #%d (physical segment file #%d, logical EOF " INT64_FORMAT ")",
-				   get_namespace_name(RelationGetNamespace(aorel)),
+				   nspname,
 				   relname,
 				   aorel->rd_id,
 				   aorel->rd_node.relNode,
@@ -155,7 +158,7 @@ AOCSSegmentFileTruncateToEOF(Relation aorel,
 		{
 			elogif(Debug_appendonly_print_compaction, LOG,
 				   "No gp_relation_node entry for AO COL relation \"%s.%s\", relation id %u, relfilenode %u column #%d, logical segment #%d (physical segment file #%d, logical EOF " INT64_FORMAT ")",
-				   get_namespace_name(RelationGetNamespace(aorel)),
+				   nspname,
 				   relname,
 				   aorel->rd_id,
 				   aorel->rd_node.relNode,
@@ -164,6 +167,7 @@ AOCSSegmentFileTruncateToEOF(Relation aorel,
 				   fileSegNo,
 				   segeof);
 		}
+		pfree(nspname);
 	}
 }
 

--- a/src/backend/access/appendonly/appendonly_compaction.c
+++ b/src/backend/access/appendonly/appendonly_compaction.c
@@ -220,6 +220,7 @@ AppendOnlySegmentFileTruncateToEOF(Relation aorel,
 	char		filenamepath[MAXPGPATH];
 	int			segno;
 	int64		segeof;
+	char 		*nspname;
 
 	Assert(fsinfo);
 	Assert(RelationIsAoRows(aorel));
@@ -231,9 +232,11 @@ AppendOnlySegmentFileTruncateToEOF(Relation aorel,
 	/* Open and truncate the relation segfile to its eof */
 	MakeAOSegmentFileName(aorel, segno, -1, &fileSegNo, filenamepath);
 
+	nspname = get_namespace_name(RelationGetNamespace(aorel));
+
 	elogif(Debug_appendonly_print_compaction, LOG,
 		   "Opening AO relation \"%s.%s\", relation id %u, relfilenode %u (physical segment file #%d, logical EOF " INT64_FORMAT ")",
-		   get_namespace_name(RelationGetNamespace(aorel)),
+		   nspname,
 		   relname,
 		   aorel->rd_id,
 		   aorel->rd_node.relNode,
@@ -248,7 +251,7 @@ AppendOnlySegmentFileTruncateToEOF(Relation aorel,
 
 		elogif(Debug_appendonly_print_compaction, LOG,
 			   "Successfully truncated AO ROW relation \"%s.%s\", relation id %u, relfilenode %u (physical segment file #%d, logical EOF " INT64_FORMAT ")",
-			   get_namespace_name(RelationGetNamespace(aorel)),
+			   nspname,
 			   relname,
 			   aorel->rd_id,
 			   aorel->rd_node.relNode,
@@ -259,13 +262,15 @@ AppendOnlySegmentFileTruncateToEOF(Relation aorel,
 	{
 		elogif(Debug_appendonly_print_compaction, LOG,
 			   "No gp_relation_node entry for AO ROW relation \"%s.%s\", relation id %u, relfilenode %u (physical segment file #%d, logical EOF " INT64_FORMAT ")",
-			   get_namespace_name(RelationGetNamespace(aorel)),
+			   nspname,
 			   relname,
 			   aorel->rd_id,
 			   aorel->rd_node.relNode,
 			   segno,
 			   segeof);
 	}
+
+	pfree(nspname);
 }
 
 static void

--- a/src/backend/commands/vacuumlazy.c
+++ b/src/backend/commands/vacuumlazy.c
@@ -1948,14 +1948,17 @@ void
 vacuum_appendonly_rel(Relation aorel, VacuumStmt *vacstmt)
 {
 	char	   *relname;
+	char       *nspname;
 
 	Assert(RelationIsAppendOptimized(aorel));
 
 	relname = RelationGetRelationName(aorel);
+	nspname = get_namespace_name(RelationGetNamespace(aorel));
 	ereport(elevel,
 			(errmsg("vacuuming \"%s.%s\"",
-					get_namespace_name(RelationGetNamespace(aorel)),
+					nspname,
 					relname)));
+	pfree(nspname);
 
 	if (Gp_role == GP_ROLE_DISPATCH)
 		return;
@@ -1971,6 +1974,7 @@ vacuum_appendonly_rel(Relation aorel, VacuumStmt *vacstmt)
 	}
 	else
 		ao_vacuum_rel_compact(aorel, vacstmt);
+
 }
 
 /*


### PR DESCRIPTION
Since get_namespace_name returns palloc`d copy of namespace name, this memory should be released after use

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [x] Document changes
- [x] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [x] Review a PR in return to support the community
