### PR TITLE
docs - updates to SET/RESET/SHOW sql ref pages

### DIFF
--- a/gpdb-doc/markdown/ref_guide/sql_commands/RESET.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/RESET.html.md
@@ -1,6 +1,6 @@
 # RESET 
 
-Restores the value of a system configuration parameter to the default value.
+Restores the value of a run-time system configuration parameter to the default value.
 
 ## <a id="section2"></a>Synopsis 
 
@@ -12,17 +12,25 @@ RESET ALL
 
 ## <a id="section3"></a>Description 
 
-`RESET` restores system configuration parameters to their default values. `RESET` is an alternative spelling for `SET configuration\_parameter TO DEFAULT`.
+`RESET` restores system configuration parameters to their default values. `RESET` is an equivalent command for
 
-The default value is defined as the value that the parameter would have had, had no `SET` ever been issued for it in the current session. The actual source of this value might be a compiled-in default, the coordinator `postgresql.conf` configuration file, command-line options, or per-database or per-user default settings. See [Server Configuration Parameters](../config_params/guc_config.html) for more information.
+``` sql
+SET <configuration_parameter> TO DEFAULT
+```
+
+Refer to [SET](SET.html) for details.
+
+The default value is defined as the value that the parameter would have had, had no `SET` ever been issued for it in the current session. The actual source of this value might be a compiled-in default, the coordinator `postgresql.conf` configuration file, command-line options, or per-database or per-user default settings. This is subtly different from defining it as "the value that the parameter had at session start", because if the value came from the configuration file, it will be reset to whatever is specified by the configuration file now. See [Server Configuration Parameters](../config_params/guc_config.html) for more information.
+
+The transactional behavior of `RESET` is the same as `SET`: its effects will be undone by transaction rollback.
 
 ## <a id="section4"></a>Parameters 
 
 configuration\_parameter
-:   The name of a system configuration parameter. See [Server Configuration Parameters](../config_params/guc_config.html) for details.
+:   The name of a settable run-time system configuration parameter. See [Server Configuration Parameters](../config_params/guc_config.html) for details.
 
 ALL
-:   Resets all settable configuration parameters to their default values.
+:   Resets all settable run-time configuration parameters to their default values.
 
 ## <a id="section5"></a>Examples 
 
@@ -38,7 +46,7 @@ RESET statement_mem;
 
 ## <a id="section7"></a>See Also 
 
-[SET](SET.html)
+[SET](SET.html), [SHOW](SHOW.html)
 
 **Parent topic:** [SQL Commands](../sql_commands/sql_ref.html)
 

--- a/gpdb-doc/markdown/ref_guide/sql_commands/SET.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/SET.html.md
@@ -43,7 +43,19 @@ value
 There are a few configuration parameters that can only be adjusted using the `SET` command or that have a special syntax:
 
 SCHEMA
-:    `SET SCHEMA '<value>'` is an alias for `SET <search_path> TO <value>`. Only one schema may be specified using this syntax.
+:   `SET SCHEMA '<value>'` is an alias for `SET <search_path> TO <value>`. Only one schema may be specified using this syntax.
+
+NAMES
+:   `SET NAMES <value>` is an alias for `SET client_encoding TO <value>`.
+
+SEED
+:   Sets the internal seed for the random number generator (the function `random()`). Allowed values are floating-point numbers between -1 and 1 inclusive.
+
+:   You can also set the seed by invoking the `setseed()` function:
+
+    ```
+    SELECT setseed(value);
+    ```
 
 TIME ZONE
 :   `SET TIME ZONE <value>` is an alias for `SET timezone TO <value>`. The syntax `SET TIME ZONE` allows special syntax for the time zone specification. Examples of valid values follow:

--- a/gpdb-doc/markdown/ref_guide/sql_commands/SET.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/SET.html.md
@@ -1,58 +1,63 @@
 # SET 
 
-Changes the value of a Greenplum Database configuration parameter.
+Changes the value of a run-time Greenplum Database configuration parameter.
 
 ## <a id="section2"></a>Synopsis 
 
 ``` {#sql_command_synopsis}
-SET [SESSION | LOCAL] <configuration_parameter> {TO | =} <value> | 
-    '<value>' | DEFAULT}
+SET [ SESSION | LOCAL ] <configuration_parameter> { TO | = } { <value> | '<value>' | DEFAULT }
 
-SET [SESSION | LOCAL] TIME ZONE {<timezone> | LOCAL | DEFAULT}
+SET [SESSION | LOCAL] TIME ZONE { <value> | '<value>' |  LOCAL | DEFAULT }
 ```
 
 ## <a id="section3"></a>Description 
 
-The `SET` command changes server configuration parameters. Any configuration parameter classified as a session parameter can be changed on-the-fly with `SET`. `SET` affects only the value used by the current session.
+The `SET` command changes server configuration parameters. Any configuration parameter classified as a session parameter can be changed on-the-fly with `SET`. (Some require superuser privileges to change, and others cannot be changed after server or session start.) `SET` affects only the value used by the current session.
 
 If `SET` or `SET SESSION` is issued within a transaction that is later cancelled, the effects of the `SET` command disappear when the transaction is rolled back. Once the surrounding transaction is committed, the effects will persist until the end of the session, unless overridden by another `SET`.
 
 The effects of `SET LOCAL` last only till the end of the current transaction, whether committed or not. A special case is `SET` followed by `SET LOCAL` within a single transaction: the `SET LOCAL` value will be seen until the end of the transaction, but afterwards \(if the transaction is committed\) the `SET` value will take effect.
 
+The effects of `SET` or `SET LOCAL` are also canceled by rolling back to a savepoint that is earlier than the command.
+
 If `SET LOCAL` is used within a function that includes a `SET` option for the same configuration parameter \(see [CREATE FUNCTION](CREATE_FUNCTION.html)\), the effects of the `SET LOCAL` command disappear at function exit; the value in effect when the function was called is restored anyway. This allows `SET LOCAL` to be used for dynamic or repeated changes of a parameter within a function, while retaining the convenience of using the `SET` option to save and restore the caller's value. Note that a regular `SET` command overrides any surrounding function's `SET` option; its effects persist unless rolled back.
 
-If you create a cursor with the `DECLARE` command in a transaction, you cannot use the `SET` command in the transaction until you close the cursor with the `CLOSE` command.
+XXX If you create a cursor with the `DECLARE` command in a transaction, you cannot use the `SET` command in the transaction until you close the cursor with the `CLOSE` command.
 
 See [Server Configuration Parameters](../config_params/guc_config.html) for information about server parameters.
 
 ## <a id="section4"></a>Parameters 
 
 SESSION
-:   Specifies that the command takes effect for the current session. This is the default.
+:   Specifies that the command takes effect for the current session. This is the default if neither `SESSION` nor `LOCAL` appears.
 
 LOCAL
-:   Specifies that the command takes effect for only the current transaction. After `COMMIT` or `ROLLBACK`, the session-level setting takes effect again. Note that `SET LOCAL` will appear to have no effect if it is run outside of a transaction.
+:   Specifies that the command takes effect for only the current transaction. After `COMMIT` or `ROLLBACK`, the session-level setting takes effect again. Issuing this outside of a transaction block emits a warning and otherwise has no effect.
 
 configuration\_parameter
-:   The name of a Greenplum Database configuration parameter. Only parameters classified as *session* can be changed with `SET`. See [Server Configuration Parameters](../config_params/guc_config.html) for details.
+:   The name of a settable Greenplum Database run-time configuration parameter. Only parameters classified as *session* can be changed with `SET`. See [Server Configuration Parameters](../config_params/guc_config.html) for details.
 
 value
-:   New value of parameter. Values can be specified as string constants, identifiers, numbers, or comma-separated lists of these. `DEFAULT` can be used to specify resetting the parameter to its default value. If specifying memory sizing or time units, enclose the value in single quotes.
+:   New value of the parameter. Values can be specified as string constants, identifiers, numbers, or comma-separated lists of these, as appropriate for the particular parameter. `DEFAULT` can be used to specify resetting the parameter to its default value (that is, whatever value it would have had if no `SET` had been issued in the current session). If specifying memory sizing or time units, enclose the value in single quotes.
+
+There are a few configuration parameters that can only be adjusted using the `SET` command or that have a special syntax:
+
+SCHEMA
+:    `SET SCHEMA '<value>'` is an alias for `SET <search_path> TO <value>`. Only one schema may be specified using this syntax.
 
 TIME ZONE
-:   `SET TIME ZONE` value is an alias for `SET timezone TO value`. The syntax `SET TIME ZONE` allows special syntax for the time zone specification. Here are examples of valid values:
+:   `SET TIME ZONE <value>` is an alias for `SET timezone TO <value>`. The syntax `SET TIME ZONE` allows special syntax for the time zone specification. Examples of valid values follow:
 
-:   `'PST8PDT'`
+    - `'PST8PDT'`
+    - `'Europe/Rome'`
+    - `-7` \(time zone 7 hours west from UTC\)
+    - `INTERVAL '-08:00' HOUR TO MINUTE` \(time zone 8 hours west from UTC\).
 
-:   `'Europe/Rome'`
+    LOCAL
+    DEFAULT
+    :   Set the time zone to your local time zone \(that is, server's default value of timezone\).
 
-:   `-7` \(time zone 7 hours west from UTC\)
-
-:   `INTERVAL '-08:00' HOUR TO MINUTE` \(time zone 8 hours west from UTC\).
-
-LOCAL
-DEFAULT
-:   Set the time zone to your local time zone \(that is, server's default value of timezone\). See the [Time zone section of the PostgreSQL documentation](https://www.postgresql.org/docs/12/datatype-datetime.html#DATATYPE-TIMEZONES) for more information about time zones in Greenplum Database.
+    See the [Time Zones](https://www.postgresql.org/docs/12/datatype-datetime.html#DATATYPE-TIMEZONES) section of the PostgreSQL documentation for more information about time zones in Greenplum Database.
 
 ## <a id="section5"></a>Examples 
 

--- a/gpdb-doc/markdown/ref_guide/sql_commands/SET.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/SET.html.md
@@ -22,8 +22,6 @@ The effects of `SET` or `SET LOCAL` are also canceled by rolling back to a savep
 
 If `SET LOCAL` is used within a function that includes a `SET` option for the same configuration parameter \(see [CREATE FUNCTION](CREATE_FUNCTION.html)\), the effects of the `SET LOCAL` command disappear at function exit; the value in effect when the function was called is restored anyway. This allows `SET LOCAL` to be used for dynamic or repeated changes of a parameter within a function, while retaining the convenience of using the `SET` option to save and restore the caller's value. Note that a regular `SET` command overrides any surrounding function's `SET` option; its effects persist unless rolled back.
 
-XXX If you create a cursor with the `DECLARE` command in a transaction, you cannot use the `SET` command in the transaction until you close the cursor with the `CLOSE` command.
-
 See [Server Configuration Parameters](../config_params/guc_config.html) for information about server parameters.
 
 ## <a id="section4"></a>Parameters 

--- a/gpdb-doc/markdown/ref_guide/sql_commands/SHOW.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/SHOW.html.md
@@ -1,26 +1,48 @@
 # SHOW 
 
-Shows the value of a system configuration parameter.
+Shows the value of a run-time system configuration parameter.
 
 ## <a id="section2"></a>Synopsis 
 
 ``` {#sql_command_synopsis}
-SHOW <configuration_parameter>
+SHOW <name>
 
 SHOW ALL
 ```
 
 ## <a id="section3"></a>Description 
 
-`SHOW` displays the current settings of Greenplum Database system configuration parameters. You can set these parameters with the `SET` statement, or by editing the `postgresql.conf` configuration file of the Greenplum Database coordinator. Note that some parameters viewable by `SHOW` are read-only — their values can be viewed but not set. See the Greenplum Database Reference Guide for details.
+`SHOW` displays the current settings of Greenplum Database run-time system configuration parameters. You can set these parameters with the `SET` statement, by editing the `postgresql.conf` configuration file of the Greenplum Database coordinator, through the `PGOPTIONS` environment variable (when using libpq or a libpq-based application), or through command-line flags when starting the Greenplum server.
+
 
 ## <a id="section4"></a>Parameters 
 
-configuration\_parameter
-:   The name of a system configuration parameter.
+name
+:   The name of a run-time system configuration parameter.
+
+:   Some parameters viewable by `SHOW` are read-only — you can view their values but not set them:
+
+    SERVER_VERSION
+    :   Shows the version number of the Greenplum Database server.
+
+    SERVER_ENCODING
+    :   Shows the server-side character set encoding. You can show, but not set, this parameter because the encoding is determined at database creation time.
+
+    LC_COLLATE
+    :   Shows the database's locale setting for collation (text ordering). You can show, but not set, this parameter because the setting is determined at database creation time.
+
+    LC_CTYPE
+    :   Shows the database's locale setting for character classification; You can show, but not set, this parameter because the setting is determined at database creation time.
+
+    IS_SUPERUSER
+    :   True if the current role has superuser privileges.
 
 ALL
-:   Shows the current value of all configuration parameters.
+:   Shows the current value of all configuration parameters, with descriptions.
+
+## <a id="section4n"></a>Notes
+
+The function `current_setting()` produces equivalent output; see [System Administration Functions](https://www.postgresql.org/docs/12/functions-admin.html) in the PostgreSQL documentation. Also, the [pg_settings](https://www.postgresql.org/docs/12/view-pg-settings.html) system view produces the same information.
 
 ## <a id="section5"></a>Examples 
 
@@ -32,16 +54,15 @@ SHOW DateStyle;
 -----------
  ISO, MDY
 (1 row)
-
 ```
 
-Show the current setting of the parameter geqo:
+Show the current setting of the parameter `row_security`:
 
 ```
-SHOW geqo;
- geqo
-------
- off
+SHOW row_security;
+ row_security
+--------------
+ on
 (1 row)
 ```
 
@@ -50,19 +71,19 @@ Show the current setting of all parameters:
 ```
 SHOW ALL;
        name       | setting |                  description
-------------------+---------+----------------------------------------------------
+-----------------+---------+----------------------------------------------------
  application_name | psql    | Sets the application name to be reported in sta...
-       .
-       .
-       .
+
+ ...
+
  xmlbinary        | base64  | Sets how binary values are to be encoded in XML.
  xmloption        | content | Sets whether XML data in implicit parsing and s...
-(331 rows)
+(473 rows)
 ```
 
 ## <a id="section6"></a>Compatibility 
 
-`SHOW` is a Greenplum Database extension.
+The `SHOW` command is a Greenplum Database extension.
 
 ## <a id="section7"></a>See Also 
 


### PR DESCRIPTION
bring SET/RESET/SHOW sql ref pages up to postgres 12 content. there appears to be some greenplum-specific info on the SET page, and some postgres info on pages that wasn't in the original/6x docs.

questions:

1. on the SET page, is the statement about the DECLARE command that is preceeded by XXX still true?
2. the postgres SET reference page (https://www.postgresql.org/docs/12/sql-set.html) identifies some config params with a special syntax (like SET SEED, SET NAMES, SET SCHEMA, SET TIME ZONE).  only SET TIMEZONE is currently documented.  i tried the others on a greenplum 7 install, SET SEED and SET NAMES did not work (i may have invoked them incorrectly).  SET SCHEMA did work so i added it to the docs. i am not sure why it wasn't previously documented.  LET ME KNOW IF THIS SHOULD NOT BE IN THE DOCS, OR WE DO ACTUALLY SUPPORT SET SEED/NAMES.

doc review site links (behind vpn):
- SET ref page (can navigate to the others from there):  https://docs-staging.vmware.com/en/draft/VMware-Tanzu-Greenplum/sqlref-setx/greenplum-database/GUID-ref_guide-sql_commands-SET.html
