### PR TITLE
docs - updates to RELEASE/ROLLBACK TO... SAVEPOINT sql ref pages

### DIFF
--- a/gpdb-doc/markdown/ref_guide/sql_commands/RELEASE_SAVEPOINT.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/RELEASE_SAVEPOINT.html.md
@@ -21,6 +21,14 @@ Destroying a savepoint makes it unavailable as a rollback point, but it has no o
 savepoint\_name
 :   The name of the savepoint to destroy.
 
+## <a id="section_notes"></a>Notes
+
+Specifying a savepoint name that was not previously defined is an error.
+
+It is not possible to release a savepoint when the transaction is in an aborted state.
+
+If multiple savepoints have the same name, Greenplum Database releases only the most recently defined unreleased savepoint. Repeated commands release progressively older savepoints.
+
 ## <a id="section5"></a>Examples 
 
 To establish and later destroy a savepoint:
@@ -34,7 +42,7 @@ BEGIN;
 COMMIT;
 ```
 
-The above transaction will insert both 3 and 4.
+The above transaction inserts both 3 and 4.
 
 ## <a id="section6"></a>Compatibility 
 
@@ -42,7 +50,7 @@ This command conforms to the SQL standard. The standard specifies that the key w
 
 ## <a id="section7"></a>See Also 
 
-[BEGIN](BEGIN.html), [SAVEPOINT](SAVEPOINT.html), [ROLLBACK TO SAVEPOINT](ROLLBACK_TO_SAVEPOINT.html), [COMMIT](COMMIT.html)
+[BEGIN](BEGIN.html), [COMMIT](COMMIT.html), [ROLLBACK](ROLLBACK.html), [ROLLBACK TO SAVEPOINT](ROLLBACK_TO_SAVEPOINT.html), [SAVEPOINT](SAVEPOINT.html)
 
 **Parent topic:** [SQL Commands](../sql_commands/sql_ref.html)
 

--- a/gpdb-doc/markdown/ref_guide/sql_commands/ROLLBACK_TO_SAVEPOINT.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/ROLLBACK_TO_SAVEPOINT.html.md
@@ -5,12 +5,12 @@ Rolls back the current transaction to a savepoint.
 ## <a id="section2"></a>Synopsis 
 
 ``` {#sql_command_synopsis}
-ROLLBACK [WORK | TRANSACTION] TO [SAVEPOINT] <savepoint_name>
+ROLLBACK [ WORK | TRANSACTION ] TO [ SAVEPOINT ] <savepoint_name>
 ```
 
 ## <a id="section3"></a>Description 
 
-This command will roll back all commands that were run after the savepoint was established. The savepoint remains valid and can be rolled back to again later, if needed.
+This command roll backs all commands that were run after the savepoint was established. The savepoint remains valid and can be rolled back to again later, if needed.
 
 `ROLLBACK TO SAVEPOINT` implicitly destroys all savepoints that were established after the named savepoint.
 
@@ -21,15 +21,15 @@ TRANSACTION
 :   Optional key words. They have no effect.
 
 savepoint\_name
-:   The name of a savepoint to roll back to.
+:   The name of the savepoint to roll back to.
 
 ## <a id="section5"></a>Notes 
 
-Use `RELEASE SAVEPOINT` to destroy a savepoint without discarding the effects of commands run after it was established.
+Use [RELEASE SAVEPOINT](RELEASE_SAVEPOINT.html) to destroy a savepoint without discarding the effects of commands run after it was established.
 
 Specifying a savepoint name that has not been established is an error.
 
-Cursors have somewhat non-transactional behavior with respect to savepoints. Any cursor that is opened inside a savepoint will be closed when the savepoint is rolled back. If a previously opened cursor is affected by a `FETCH` command inside a savepoint that is later rolled back, the cursor remains at the position that `FETCH` left it pointing to \(that is, cursor motion caused by `FETCH` is not rolled back\). Closing a cursor is not undone by rolling back, either. However, other side-effects caused by the cursor's query \(such as side-effects of volatile functions called by the query\) are rolled back if they occur during a savepoint that is later rolled back. A cursor whose execution causes a transaction to end prematurely is put in a cannot-execute state, so while the transaction can be restored using `ROLLBACK TO SAVEPOINT`, the cursor can no longer be used.
+Cursors have somewhat non-transactional behavior with respect to savepoints. Any cursor that is opened inside a savepoint will be closed when the savepoint is rolled back. If a previously opened cursor is affected by a `FETCH` command inside a savepoint that is later rolled back, the cursor remains at the position that `FETCH` left it pointing to \(that is, cursor motion caused by `FETCH` is not rolled back\). Closing a cursor is not undone by rolling back, either. However, other side-effects caused by the cursor's query \(such as side-effects of volatile functions called by the query\) *are* rolled back if they occur during a savepoint that is later rolled back. A cursor whose execution causes a transaction to end prematurely is put in a cannot-execute state, so while the transaction can be restored using `ROLLBACK TO SAVEPOINT`, the cursor can no longer be used.
 
 ## <a id="section6"></a>Examples 
 
@@ -49,11 +49,13 @@ FETCH 1 FROM foo;
 column 
 ----------
         1
+
 ROLLBACK TO SAVEPOINT foo;
 FETCH 1 FROM foo;
 column 
 ----------
         2
+
 COMMIT;
 ```
 
@@ -63,7 +65,7 @@ The SQL standard specifies that the key word `SAVEPOINT` is mandatory, but Green
 
 ## <a id="section8"></a>See Also 
 
-[BEGIN](BEGIN.html), [COMMIT](COMMIT.html), [SAVEPOINT](SAVEPOINT.html), [RELEASE SAVEPOINT](RELEASE_SAVEPOINT.html), [ROLLBACK](ROLLBACK.html)
+[BEGIN](BEGIN.html), [COMMIT](COMMIT.html), [RELEASE SAVEPOINT](RELEASE_SAVEPOINT.html), [ROLLBACK](ROLLBACK.html), [SAVEPOINT](SAVEPOINT.html)
 
 **Parent topic:** [SQL Commands](../sql_commands/sql_ref.html)
 

--- a/gpdb-doc/markdown/ref_guide/sql_commands/ROLLBACK_TO_SAVEPOINT.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/ROLLBACK_TO_SAVEPOINT.html.md
@@ -10,7 +10,7 @@ ROLLBACK [ WORK | TRANSACTION ] TO [ SAVEPOINT ] <savepoint_name>
 
 ## <a id="section3"></a>Description 
 
-This command roll backs all commands that were run after the savepoint was established. The savepoint remains valid and can be rolled back to again later, if needed.
+This command rolls back all commands that were run after the savepoint was established. The savepoint remains valid and can be rolled back to again later, if needed.
 
 `ROLLBACK TO SAVEPOINT` implicitly destroys all savepoints that were established after the named savepoint.
 

--- a/gpdb-doc/markdown/ref_guide/sql_commands/SAVEPOINT.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/SAVEPOINT.html.md
@@ -17,13 +17,13 @@ A savepoint is a special mark inside a transaction that allows all commands that
 ## <a id="section4"></a>Parameters 
 
 savepoint\_name
-:   The name of the new savepoint.
+:   The name of the new savepoint. If savepoints with the same name already exist, they are inaccessible until newer identically-named savepoints are released.
 
 ## <a id="section5"></a>Notes 
 
 Use [ROLLBACK TO SAVEPOINT](ROLLBACK_TO_SAVEPOINT.html) to rollback to a savepoint. Use [RELEASE SAVEPOINT](RELEASE_SAVEPOINT.html) to destroy a savepoint, keeping the effects of commands run after it was established.
 
-Savepoints can only be established when inside a transaction block. There can be multiple savepoints defined within a transaction.
+Savepoints can be established only inside a transaction block. You can define multiple savepoints within a transaction.
 
 ## <a id="section6"></a>Examples 
 
@@ -39,7 +39,7 @@ BEGIN;
 COMMIT;
 ```
 
-The above transaction will insert the values 1 and 3, but not 2.
+The above transaction inserts the values 1 and 3, but not 2.
 
 To establish and later destroy a savepoint:
 
@@ -52,15 +52,40 @@ BEGIN;
 COMMIT;
 ```
 
-The above transaction will insert both 3 and 4.
+The above transaction inserts both 3 and 4.
+
+To use a single savepoint name:
+
+``` sql
+BEGIN;
+    INSERT INTO table1 VALUES (1);
+    SAVEPOINT my_savepoint;
+    INSERT INTO table1 VALUES (2);
+    SAVEPOINT my_savepoint;
+    INSERT INTO table1 VALUES (3);
+
+    -- rollback to the second savepoint
+    ROLLBACK TO SAVEPOINT my_savepoint;
+    SELECT * FROM table1;               -- shows rows 1 and 2
+
+    -- release the second savepoint
+    RELEASE SAVEPOINT my_savepoint;
+
+    -- rollback to the first savepoint
+    ROLLBACK TO SAVEPOINT my_savepoint;
+    SELECT * FROM table1;               -- shows only row 1
+COMMIT;
+```
+
+The above transaction shows row 3 being rolled back first, then row 2.
 
 ## <a id="section7"></a>Compatibility 
 
-SQL requires a savepoint to be destroyed automatically when another savepoint with the same name is established. In Greenplum Database, the old savepoint is kept, though only the more recent one will be used when rolling back or releasing. \(Releasing the newer savepoint will cause the older one to again become accessible to [ROLLBACK TO SAVEPOINT](ROLLBACK_TO_SAVEPOINT.html) and [RELEASE SAVEPOINT](RELEASE_SAVEPOINT.html).\) Otherwise, `SAVEPOINT` is fully SQL conforming.
+SQL requires a savepoint to be destroyed automatically when another savepoint with the same name is established. In Greenplum Database, the old savepoint is kept, though only the more recent one is used when rolling back or releasing. \(Releasing the newer savepoint will cause the older one to again become accessible to [ROLLBACK TO SAVEPOINT](ROLLBACK_TO_SAVEPOINT.html) and [RELEASE SAVEPOINT](RELEASE_SAVEPOINT.html).\) Otherwise, `SAVEPOINT` is fully SQL conforming.
 
 ## <a id="section8"></a>See Also 
 
-[BEGIN](BEGIN.html), [COMMIT](COMMIT.html), [ROLLBACK](ROLLBACK.html), [RELEASE SAVEPOINT](RELEASE_SAVEPOINT.html), [ROLLBACK TO SAVEPOINT](ROLLBACK_TO_SAVEPOINT.html)
+[BEGIN](BEGIN.html), [COMMIT](COMMIT.html), [RELEASE SAVEPOINT](RELEASE_SAVEPOINT.html), [ROLLBACK](ROLLBACK.html), [ROLLBACK TO SAVEPOINT](ROLLBACK_TO_SAVEPOINT.html)
 
 **Parent topic:** [SQL Commands](../sql_commands/sql_ref.html)
 


### PR DESCRIPTION
bring SAVEPOINT, RELEASE SAVEPOINT, and ROLLBACK TO SAVEPOINT sql ref pages up to postgres 12 content.  didnt notice any greenplum-specific content on the pages.

doc review site links (behind vpn):
- SAVEPOINT (can navigate to others from here):  https://docs-staging.vmware.com/en/draft/VMware-Tanzu-Greenplum/sqlref-savepoint/greenplum-database/GUID-ref_guide-sql_commands-SAVEPOINT.html