### PR TITLE
set forceDistRandom=false for gp_dist_random() in utility mode

### DIFF
--- a/src/backend/catalog/gp_toolkit.sql
+++ b/src/backend/catalog/gp_toolkit.sql
@@ -8,6 +8,9 @@
 
 BEGIN;
 
+-- Allow gp_dist_random() to work properly in this file
+SET gp_allow_dist_random_in_utility = ON;
+
 CREATE SCHEMA gp_toolkit;
 
 GRANT USAGE ON SCHEMA gp_toolkit TO public;
@@ -2513,6 +2516,8 @@ FROM gp_toolkit.__check_missing_files; -- not checking ext on coordinator
 GRANT SELECT ON gp_toolkit.gp_check_missing_files_ext TO public;
 
 --------------------------------------------------------------------------------
+
+RESET gp_allow_dist_random_in_utility;
 
 -- Finalize install
 COMMIT;

--- a/src/backend/catalog/system_views.sql
+++ b/src/backend/catalog/system_views.sql
@@ -16,6 +16,9 @@
  * string literal (including a function body!) or a multiline comment.
  */
 
+-- Allow gp_dist_random() to work properly in this file
+SET gp_allow_dist_random_in_utility = ON;
+
 CREATE VIEW pg_roles AS
     SELECT
         rolname,
@@ -1892,3 +1895,5 @@ CREATE VIEW gp_suboverflowed_backend(segid, pids) AS
   SELECT -1, gp_get_suboverflowed_backends()
 UNION ALL
   SELECT gp_segment_id, gp_get_suboverflowed_backends() FROM gp_dist_random('gp_id') order by 1;
+
+RESET gp_allow_dist_random_in_utility;

--- a/src/backend/parser/parse_clause.c
+++ b/src/backend/parser/parse_clause.c
@@ -675,8 +675,16 @@ transformRangeFunction(ParseState *pstate, RangeFunction *r)
 
 					rte = addRangeTableEntry(pstate, rel, r->alias, false, true);
 
-					/* Now we set our special attribute in the rte. */
-					rte->forceDistRandom = true;
+					/*
+					 * Now we set our special attribute in the rte.
+					 * In utility mode we ignore gp_dist_random unless 
+					 * gp_allow_dist_random_in_utility is set to ON.
+					 */
+					if (Gp_role == GP_ROLE_UTILITY && !gp_allow_dist_random_in_utility)
+						rte->forceDistRandom = false;
+					else
+						rte->forceDistRandom = true;
+
 
 					return rte;
 				}

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -248,6 +248,9 @@ bool		gp_ignore_error_table = false;
  */
 bool		dml_ignore_target_partition_check = false;
 
+/* allow gp_dist_random (i.e. don't ignore it) in utility mode */
+bool 		gp_allow_dist_random_in_utility = false;
+
 /* Planner gucs */
 bool		gp_enable_hashjoin_size_heuristic = false;
 bool		gp_enable_predicate_propagation = false;
@@ -2927,7 +2930,16 @@ struct config_bool ConfigureNamesBool_gp[] =
 		false,
 		NULL, NULL, NULL
 	},
-
+	{
+		{"gp_allow_dist_random_in_utility", PGC_USERSET, CUSTOM_OPTIONS,
+			gettext_noop("Allow gp_dist_random and not ignore it in utility mode."),
+			NULL,
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+		},
+		&gp_allow_dist_random_in_utility,
+		false,
+		NULL, NULL, NULL
+	},
 	/* End-of-list marker */
 	{
 		{NULL, 0, 0, NULL, NULL}, NULL, false, NULL, NULL

--- a/src/bin/pg_dump/pg_backup_archiver.c
+++ b/src/bin/pg_dump/pg_backup_archiver.c
@@ -3127,6 +3127,12 @@ _doSetFixedOutputState(ArchiveHandle *AH)
 	 */
 	ahprintf(AH, "SET gp_default_storage_options = '';\n");
 
+	/*
+	 * We need to respect gp_dist_random even in utility mode, for things like
+	 * CREATE VIEW ... AS SELECT ... FROM gp_dist_random('...');
+	 */
+	ahprintf(AH, "SET gp_allow_dist_random_in_utility= 'ON';\n");
+
 	RestoreOptions *ropt = AH->public.ropt;
 
 	/*

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -328,6 +328,8 @@ extern bool allow_segment_DML;
 
 extern bool gp_ignore_error_table;
 
+extern bool gp_allow_dist_random_in_utility;
+
 extern bool	Debug_dtm_action_primary;
 
 extern bool gp_log_optimization_time;

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -129,6 +129,7 @@
 		"geqo_selection_bias",
 		"geqo_threshold",
 		"gp_adjust_selectivity_for_outerjoins",
+		"gp_allow_dist_random_in_utility",
 		"gp_allow_non_uniform_partitioning_ddl",
 		"gp_auth_time_override",
 		"gp_autostats_allow_nonowner",

--- a/src/test/isolation2/expected/misc.out
+++ b/src/test/isolation2/expected/misc.out
@@ -66,3 +66,21 @@ CREATE
 -----------------
  pg_toast_temp_0 
 (1 row)
+
+--
+-- gp_dist_random('<view>') should not crash in utility mode
+--
+create or replace view misc_v as select 1;
+CREATE
+0U: select 1 from gp_dist_random('misc_v') union select 1 from misc_v;
+ ?column? 
+----------
+ 1        
+(1 row)
+0U: select count(*) from gp_dist_random('misc_v');
+ count 
+-------
+ 1     
+(1 row)
+drop view misc_v;
+DROP

--- a/src/test/isolation2/sql/misc.sql
+++ b/src/test/isolation2/sql/misc.sql
@@ -40,3 +40,11 @@
       JOIN pg_namespace n2
         ON n2.nspname = 'pg_toast_temp_0' || substring(n1.nspname FROM 10)
      WHERE c.relname = 'utilitymode_tmp_tab';
+
+--
+-- gp_dist_random('<view>') should not crash in utility mode
+-- 
+create or replace view misc_v as select 1;
+0U: select 1 from gp_dist_random('misc_v') union select 1 from misc_v;
+0U: select count(*) from gp_dist_random('misc_v');
+drop view misc_v;


### PR DESCRIPTION
Currently the RTE's `forceDistRandom` is always true for `gp_dist_random()`. However, we don't really need to do that in utility mode. And in some cases, that caused server crash because we would create motion for it, which we don't expect and couldn't deal with in utility mode (see #15238 for such cases). 

Now fixing this by setting forceDistRandom=false for gp_dist_random() in utility mode. However, we couldn't always do that because when we are creating system views or dumping existing views, we do not want the views to ignore any gp_dist_random() that it selects from. So adding a GUC gp_allow_dist_random_in_utility to specifically allow

Fixed #15238.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
