### PR TITLE
Fix concurrent update core of partiton table in Dynamic scan

### DIFF
--- a/src/backend/executor/execPartition.c
+++ b/src/backend/executor/execPartition.c
@@ -585,9 +585,18 @@ ExecInitPartitionInfo(ModifyTableState *mtstate, EState *estate,
 	partrel = table_open(dispatch->partdesc->oids[partidx], RowExclusiveLock);
 
 	leaf_part_rri = makeNode(ResultRelInfo);
-	InitResultRelInfo(leaf_part_rri,
+
+    /*
+     * Init leaf partition ResultRelInfo
+     * Here ResultRelInfo->ri_RangeTableIndex is a dummy element, because we
+     * will rebuild ri_RelationDesc later. So we assign 1 for it instead of 0
+     * which cause failure in EPQ process, and fwd scenarios should still keep 0
+     * since it will handle 0 in their own fwd process.
+     * related issue https://github.com/greenplum-db/gpdb/issues/14935
+     */ 
+    InitResultRelInfo(leaf_part_rri,
 					  partrel,
-					  0,
+					  partrel->rd_rel->relkind != RELKIND_FOREIGN_TABLE ? 1 : 0,
 					  rootResultRelInfo,
 					  estate->es_instrument);
 
@@ -1019,6 +1028,12 @@ ExecInitRoutingInfo(ModifyTableState *mtstate,
 
 	partRelInfo->ri_PartitionInfo = partrouteinfo;
 	partRelInfo->ri_CopyMultiInsertBuffer = NULL;
+
+	/*
+	 * If junkFilter is NULL then we try to inherit it from rootRelInfo.
+	 */
+	if (partRelInfo->ri_junkFilter == NULL)
+		partRelInfo->ri_junkFilter = rootRelInfo->ri_junkFilter;
 
 	/*
 	 * Keep track of it in the PartitionTupleRouting->partitions array.

--- a/src/test/isolation2/expected/gdd/concurrent_update.out
+++ b/src/test/isolation2/expected/gdd/concurrent_update.out
@@ -307,6 +307,36 @@ DROP
 1q: ... <quitting>
 2q: ... <quitting>
 
+-- test ORCA partition table
+-- related github issue https://github.com/greenplum-db/gpdb/issues/14935
+create table test(a int, b int, c int) partition by range(b) (start (1) end (7) every (3));
+CREATE
+insert into test values (1, 1, 1), (1, 2, 1);
+INSERT 2
+1: begin;
+BEGIN
+1: update test set c = 1;
+UPDATE 2
+-- in session 2, in case of ORCA DML invokes EPQ
+-- the following SQL will hang due to XID lock
+2&: update test set c = 1;  <waiting ...>
+1: end;
+END
+2<:  <... completed>
+UPDATE 2
+
+0: select * from test;
+ a | b | c 
+---+---+---
+ 1 | 1 | 1 
+ 1 | 2 | 1 
+(2 rows)
+0: drop table test;
+DROP
+0q: ... <quitting>
+1q: ... <quitting>
+2q: ... <quitting>
+
 -- split update is to implement updating on hash keys,
 -- it deletes the tuple and insert a new tuple in a
 -- new segment, so it is not easy for other transaction

--- a/src/test/isolation2/expected/gdd/concurrent_update_optimizer.out
+++ b/src/test/isolation2/expected/gdd/concurrent_update_optimizer.out
@@ -307,6 +307,36 @@ DROP
 1q: ... <quitting>
 2q: ... <quitting>
 
+-- test ORCA partition table
+-- related github issue https://github.com/greenplum-db/gpdb/issues/14935
+create table test(a int, b int, c int) partition by range(b) (start (1) end (7) every (3));
+CREATE
+insert into test values (1, 1, 1), (1, 2, 1);
+INSERT 2
+1: begin;
+BEGIN
+1: update test set c = 1;
+UPDATE 2
+-- in session 2, in case of ORCA DML invokes EPQ
+-- the following SQL will hang due to XID lock
+2&: update test set c = 1;  <waiting ...>
+1: end;
+END
+2<:  <... completed>
+UPDATE 2
+
+0: select * from test;
+ a | b | c 
+---+---+---
+ 1 | 1 | 1 
+ 1 | 2 | 1 
+(2 rows)
+0: drop table test;
+DROP
+0q: ... <quitting>
+1q: ... <quitting>
+2q: ... <quitting>
+
 -- split update is to implement updating on hash keys,
 -- it deletes the tuple and insert a new tuple in a
 -- new segment, so it is not easy for other transaction

--- a/src/test/isolation2/sql/gdd/concurrent_update.sql
+++ b/src/test/isolation2/sql/gdd/concurrent_update.sql
@@ -174,6 +174,24 @@ insert into test values (1, 1, 1);
 1q:
 2q:
 
+-- test ORCA partition table
+-- related github issue https://github.com/greenplum-db/gpdb/issues/14935
+create table test(a int, b int, c int) partition by range(b) (start (1) end (7) every (3));
+insert into test values (1, 1, 1), (1, 2, 1);
+1: begin;
+1: update test set c = 1;
+-- in session 2, in case of ORCA DML invokes EPQ
+-- the following SQL will hang due to XID lock
+2&: update test set c = 1;
+1: end;
+2<:
+
+0: select * from test;
+0: drop table test;
+0q:
+1q:
+2q:
+
 -- split update is to implement updating on hash keys,
 -- it deletes the tuple and insert a new tuple in a
 -- new segment, so it is not easy for other transaction


### PR DESCRIPTION
Once GDD is enabled, heap tuples can be concurrently updated on segment. ORCA will generate
Dynamic Scan for Partition table instead of multi subplans in planner. For concurrent update, Executor 
nitialized EPQ state and table describer called resultRelInfo which always generated for each partitions.
But in Dynamic Scan, we only have one resultRelInfo for table not partitions here, and will fill Dynamic
Scan infos before IUD operations. So we need to adapt Dynamic Scan to EPQ which used to be based on planner.

Here There are two places needed to fix.
- As we ExecInitPartitionInfo for partition table, we assign 1 to ResultRelInfo->ri_RangeTableIndex instead of 0, and
we could make EPQ work in this way. But in FDW scenario, we choose to keep 0 for ri_RangeTableIndex
since FWD has its own process dealing with ResultRelInfo->ri_RangeTableIndex 0.

- Inherit `resultRelInfo->ri_junkFilter `infos for partitioned resultRelInfo from root main table resultRelInfo.

NOTE: No need to concern about subpartition, which not support in ORCA.
related issue: https://github.com/greenplum-db/gpdb/issues/14935

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
