### PR TITLE
fix regex for etc/environment.d

### DIFF
--- a/gpMgmt/bin/generate-greenplum-path.sh
+++ b/gpMgmt/bin/generate-greenplum-path.sh
@@ -45,7 +45,7 @@ export OPENSSL_CONF
 if [ -d "${GPHOME}/etc/environment.d" ]; then
 	LOGGER=$(which logger 2> /dev/null || which true)
 	set -o allexport
-	for env in $(find "${GPHOME}/etc/environment.d" -regextype sed -regex '.*/[0-9][0-9]-*.\.conf$' -type f | sort -n); do
+	for env in $(find "${GPHOME}/etc/environment.d" -regextype sed -regex '.*\/[0-9][0-9]-.*\.conf$' -type f | sort -n); do
 		$LOGGER -t "greenplum-path.sh" "loading environment from ${env}"
 		source "${env}"
 	done


### PR DESCRIPTION
fix for #14327

`'.*/[0-9][0-9]-*.\.conf$'`

example input:

```
etc/environment.d/
etc/environment.d/10-pljava.conf
etc/environment.d/10-add-python-path-gpdb.conf
```

`.*` will match until the last '/', `[0-9][0-9]-` is the file prefix `00-`. then the file name. and the name should ends with `.conf`.