### PR TITLE
Check partition key opfamily in partition pruning

### DIFF
--- a/src/backend/gpopt/gpdbwrappers.cpp
+++ b/src/backend/gpopt/gpdbwrappers.cpp
@@ -1156,6 +1156,18 @@ gpdb::GetDefaultDistributionOpfamilyForType(Oid typid)
 }
 
 Oid
+gpdb::GetDefaultPartitionOpfamilyForType(Oid typid)
+{
+	GP_WRAP_START;
+	{
+		/* catalog tables: pg_type, pg_opclass */
+		return default_partition_opfamily_for_type(typid);
+	}
+	GP_WRAP_END;
+	return false;
+}
+
+Oid
 gpdb::GetHashProcInOpfamily(Oid opfamily, Oid typid)
 {
 	GP_WRAP_START;

--- a/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
@@ -1226,13 +1226,21 @@ CTranslatorRelcacheToDXL::RetrieveType(CMemoryPool *mp, IMDId *mdid)
 			GPOS_NEW(mp) CMDIdGPDB(IMDId::EmdidGeneral, legacy_opfamily);
 	}
 
+	OID part_opfamily = gpdb::GetDefaultPartitionOpfamilyForType(oid_type);
+	CMDIdGPDB *mdid_part_opfamily = nullptr;
+	if (part_opfamily != InvalidOid)
+	{
+		mdid_part_opfamily =
+			GPOS_NEW(mp) CMDIdGPDB(IMDId::EmdidGeneral, part_opfamily);
+	}
+
 	mdid->AddRef();
 	return GPOS_NEW(mp) CMDTypeGenericGPDB(
 		mp, mdid, mdname, is_redistributable, is_fixed_length, length,
 		is_passed_by_value, mdid_distr_opfamily, mdid_legacy_distr_opfamily,
-		mdid_op_eq, mdid_op_neq, mdid_op_lt, mdid_op_leq, mdid_op_gt,
-		mdid_op_geq, mdid_op_cmp, mdid_min, mdid_max, mdid_avg, mdid_sum,
-		mdid_count, is_hashable, is_merge_joinable, is_composite_type,
+		mdid_part_opfamily, mdid_op_eq, mdid_op_neq, mdid_op_lt, mdid_op_leq,
+		mdid_op_gt, mdid_op_geq, mdid_op_cmp, mdid_min, mdid_max, mdid_avg,
+		mdid_sum, mdid_count, is_hashable, is_merge_joinable, is_composite_type,
 		is_text_related_type, mdid_type_relid, mdid_type_array, ptce->typlen);
 }
 

--- a/src/backend/gporca/data/dxl/minidump/CTE-NoPushProperties.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTE-NoPushProperties.mdp
@@ -1714,7 +1714,7 @@
         </dxl:LogicalJoin>
       </dxl:LogicalCTEAnchor>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="24">
+    <dxl:Plan Id="0" SpaceSize="52">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.483722" Rows="1000.000000" Width="26"/>
@@ -1780,7 +1780,7 @@
                 <dxl:Ident ColId="2" ColName="c" TypeMdid="0.1700.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
-            <dxl:DynamicTableScan PartIndexId="1" SelectorIds="">
+            <dxl:DynamicTableScan SelectorIds="">
               <dxl:Properties>
                 <dxl:Cost StartupCost="0" TotalCost="431.007883" Rows="1000.000000" Width="13"/>
               </dxl:Properties>
@@ -1853,17 +1853,59 @@
             <dxl:JoinFilter/>
             <dxl:HashCondList>
               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1752.1.0">
-                <dxl:Ident ColId="22" ColName="c" TypeMdid="0.1700.1.0"/>
                 <dxl:Ident ColId="12" ColName="c" TypeMdid="0.1700.1.0"/>
+                <dxl:Ident ColId="22" ColName="c" TypeMdid="0.1700.1.0"/>
               </dxl:Comparison>
               <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1752.1.0">
+                <dxl:Ident ColId="11" ColName="b" TypeMdid="0.1700.1.0"/>
                 <dxl:OpExpr OperatorName="+" OperatorMdid="0.1758.1.0" OperatorType="0.1700.1.0">
                   <dxl:Ident ColId="21" ColName="b" TypeMdid="0.1700.1.0"/>
                   <dxl:ConstValue TypeMdid="0.1700.1.0" Value="AAAACACAAQA=" DoubleValue="1.000000"/>
                 </dxl:OpExpr>
-                <dxl:Ident ColId="11" ColName="b" TypeMdid="0.1700.1.0"/>
               </dxl:Comparison>
             </dxl:HashCondList>
+            <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.024007" Rows="1000.000000" Width="13"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="10" Alias="a">
+                  <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="11" Alias="b">
+                  <dxl:Ident ColId="11" ColName="b" TypeMdid="0.1700.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="12" Alias="c">
+                  <dxl:Ident ColId="12" ColName="c" TypeMdid="0.1700.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:SortingColumnList/>
+              <dxl:HashExprList>
+                <dxl:HashExpr Opfamily="0.1998.1.0">
+                  <dxl:Ident ColId="12" ColName="c" TypeMdid="0.1700.1.0"/>
+                </dxl:HashExpr>
+                <dxl:HashExpr Opfamily="0.1998.1.0">
+                  <dxl:Ident ColId="11" ColName="b" TypeMdid="0.1700.1.0"/>
+                </dxl:HashExpr>
+              </dxl:HashExprList>
+              <dxl:CTEConsumer CTEId="0" Columns="10,11,12">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.010443" Rows="1000.000000" Width="13"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="10" Alias="a">
+                    <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="11" Alias="b">
+                    <dxl:Ident ColId="11" ColName="b" TypeMdid="0.1700.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="12" Alias="c">
+                    <dxl:Ident ColId="12" ColName="c" TypeMdid="0.1700.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+              </dxl:CTEConsumer>
+            </dxl:RedistributeMotion>
             <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
               <dxl:Properties>
                 <dxl:Cost StartupCost="0" TotalCost="431.024007" Rows="1000.000000" Width="13"/>
@@ -1905,48 +1947,6 @@
                   </dxl:ProjElem>
                   <dxl:ProjElem ColId="22" Alias="c">
                     <dxl:Ident ColId="22" ColName="c" TypeMdid="0.1700.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-              </dxl:CTEConsumer>
-            </dxl:RedistributeMotion>
-            <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.024007" Rows="1000.000000" Width="13"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="10" Alias="a">
-                  <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="11" Alias="b">
-                  <dxl:Ident ColId="11" ColName="b" TypeMdid="0.1700.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="12" Alias="c">
-                  <dxl:Ident ColId="12" ColName="c" TypeMdid="0.1700.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:SortingColumnList/>
-              <dxl:HashExprList>
-                <dxl:HashExpr Opfamily="0.1998.1.0">
-                  <dxl:Ident ColId="12" ColName="c" TypeMdid="0.1700.1.0"/>
-                </dxl:HashExpr>
-                <dxl:HashExpr Opfamily="0.1998.1.0">
-                  <dxl:Ident ColId="11" ColName="b" TypeMdid="0.1700.1.0"/>
-                </dxl:HashExpr>
-              </dxl:HashExprList>
-              <dxl:CTEConsumer CTEId="0" Columns="10,11,12">
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.010443" Rows="1000.000000" Width="13"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="10" Alias="a">
-                    <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="11" Alias="b">
-                    <dxl:Ident ColId="11" ColName="b" TypeMdid="0.1700.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="12" Alias="c">
-                    <dxl:Ident ColId="12" ColName="c" TypeMdid="0.1700.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
               </dxl:CTEConsumer>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-DPE-Opfamily.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-DPE-Opfamily.mdp
@@ -1,0 +1,710 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+<dxl:Comment><![CDATA[
+Setup:
+
+create table t3 (a int, b varchar(1))
+partition by list (b)
+(
+  partition p1 values ('a'),
+  partition p2 values ('b')
+);
+
+create table t4 (a int, b char(1))
+partition by list (b)
+(
+  partition p1 values ('a'),
+  partition p2 values ('b')
+);
+
+insert into t3 values (1,'a'), (1,'a'), (-1,'b'), (-1,'b');
+insert into t4 values (1,'a'), (1,'a'), (-1,'b'), (-1,'b');
+
+explain select * from t3, t4 where t3.b = t4.b;
+
+Objective:
+Dynamic partition pruning/elimination (DPE) requires the operator's opfamily matches that of the left/right arguments'.
+In this case, t3.b is of type varchar. It has to be cast to bpchar to be compared to t4.b, which is of type char.
+This is because there's no default equality operator that handles varchar/char cross-type comparison.
+Column t3.b belongs to varchar btree opfamily. Column t4.b belong to char btree opfamily.
+Because the operator's opfamily (char btree opfamily) doesn't match that of the left argument's,
+this query isn't eligible for DPE.
+
+                                              QUERY PLAN
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=24)
+   ->  Hash Join  (cost=0.00..862.00 rows=1 width=24)
+         Hash Cond: ((t3.b)::bpchar = t4.b)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
+               Hash Key: t3.b
+               ->  Dynamic Seq Scan on t3  (cost=0.00..431.00 rows=1 width=12)
+                     Number of partitions to scan: 2 (out of 2)
+         ->  Hash  (cost=431.00..431.00 rows=1 width=12)
+               ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
+                     Hash Key: t4.b
+                     ->  Dynamic Seq Scan on t4  (cost=0.00..431.00 rows=1 width=12)
+                           Number of partitions to scan: 2 (out of 2)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(13 rows)
+]]>
+</dxl:Comment>
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="20" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0" SkewFactor="0"/>
+      <dxl:TraceFlags Value="101013,102001,102002,102003,102043,102074,102120,102144,103001,103014,103022,103026,103027,103029,103033,103038,103040,104002,104003,104004,104005,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:PartOpfamily Mdid="0.424.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.1042.1.0" Name="bpchar" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="true" IsFixedLength="false" Length="-1" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.427.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7106.1.0"/>
+        <dxl:PartOpfamily Mdid="0.426.1.0"/>
+        <dxl:EqualityOp Mdid="0.1054.1.0"/>
+        <dxl:InequalityOp Mdid="0.1057.1.0"/>
+        <dxl:LessThanOp Mdid="0.1058.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1059.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.1060.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1061.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1078.1.0"/>
+        <dxl:ArrayType Mdid="0.1014.1.0"/>
+        <dxl:MinAgg Mdid="0.2245.1.0"/>
+        <dxl:MaxAgg Mdid="0.2244.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.1043.1.0" Name="varchar" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="true" IsFixedLength="false" Length="-1" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.1995.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7105.1.0"/>
+        <dxl:PartOpfamily Mdid="0.1994.1.0"/>
+        <dxl:EqualityOp Mdid="0.98.1.0"/>
+        <dxl:InequalityOp Mdid="0.531.1.0"/>
+        <dxl:LessThanOp Mdid="0.664.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.665.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.666.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.667.1.0"/>
+        <dxl:ComparisonOp Mdid="0.360.1.0"/>
+        <dxl:ArrayType Mdid="0.1015.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:PartOpfamily Mdid="0.1976.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.16385.1.0.1" Name="b" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.16385.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:PartOpfamily Mdid="0.1989.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2134.1.0"/>
+        <dxl:MaxAgg Mdid="0.2118.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.2227.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:PartOpfamily Mdid="0.2789.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:MDCast Mdid="3.1043.1.0;1042.1.0" Name="bpchar" BinaryCoercible="true" SourceTypeId="0.1043.1.0" DestinationTypeId="0.1042.1.0" CastFuncId="0.0.0.0" CoercePathType="0"/>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.3315.1.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:GPDBScalarOp Mdid="0.1054.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.1042.1.0"/>
+        <dxl:RightType Mdid="0.1042.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.1048.1.0"/>
+        <dxl:Commutator Mdid="0.1054.1.0"/>
+        <dxl:InverseOp Mdid="0.1057.1.0"/>
+        <dxl:HashOpfamily Mdid="0.427.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7106.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.426.1.0"/>
+          <dxl:Opfamily Mdid="0.427.1.0"/>
+          <dxl:Opfamily Mdid="0.2097.1.0"/>
+          <dxl:Opfamily Mdid="0.2231.1.0"/>
+          <dxl:Opfamily Mdid="0.4076.1.0"/>
+          <dxl:Opfamily Mdid="0.7106.1.0"/>
+          <dxl:Opfamily Mdid="0.10003.1.0"/>
+          <dxl:Opfamily Mdid="0.10023.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:Relation Mdid="6.16400.1.0" Name="t4_1_prt_p2" IsTemporary="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.1042.1.0" TypeModifier="5" Nullable="true" ColWidth="1">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint>
+          <dxl:And>
+            <dxl:IsNotNull>
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.1042.1.0" TypeModifier="5"/>
+            </dxl:IsNotNull>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1054.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.1042.1.0" TypeModifier="5"/>
+              <dxl:ConstValue TypeMdid="0.1042.1.0" TypeModifier="5" Value="AAAABWI=" LintValue="4226146208"/>
+            </dxl:Comparison>
+          </dxl:And>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+      <dxl:RelationStatistics Mdid="2.16385.1.0" Name="t3" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
+      <dxl:Relation Mdid="6.16385.1.0" Name="t3" IsTemporary="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="7,8,2" PartitionColumns="1" PartitionTypes="l">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.1043.1.0" TypeModifier="5" Nullable="true" ColWidth="1">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:Partitions>
+          <dxl:Partition Mdid="6.16388.1.0"/>
+          <dxl:Partition Mdid="6.16391.1.0"/>
+        </dxl:Partitions>
+      </dxl:Relation>
+      <dxl:Relation Mdid="6.16391.1.0" Name="t3_1_prt_p2" IsTemporary="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.1043.1.0" TypeModifier="5" Nullable="true" ColWidth="1">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint>
+          <dxl:And>
+            <dxl:IsNotNull>
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.1043.1.0" TypeModifier="5"/>
+            </dxl:IsNotNull>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.98.1.0">
+              <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.0.0.0">
+                <dxl:Ident ColId="2" ColName="b" TypeMdid="0.1043.1.0" TypeModifier="5"/>
+              </dxl:Cast>
+              <dxl:ConstValue TypeMdid="0.1043.1.0" TypeModifier="5" Value="AAAABWI=" LintValue="4226146208"/>
+            </dxl:Comparison>
+          </dxl:And>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+      <dxl:Relation Mdid="6.16388.1.0" Name="t3_1_prt_p1" IsTemporary="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.1043.1.0" TypeModifier="5" Nullable="true" ColWidth="1">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint>
+          <dxl:And>
+            <dxl:IsNotNull>
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.1043.1.0" TypeModifier="5"/>
+            </dxl:IsNotNull>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.98.1.0">
+              <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.0.0.0">
+                <dxl:Ident ColId="2" ColName="b" TypeMdid="0.1043.1.0" TypeModifier="5"/>
+              </dxl:Cast>
+              <dxl:ConstValue TypeMdid="0.1043.1.0" TypeModifier="5" Value="AAAABWE=" LintValue="1075015857"/>
+            </dxl:Comparison>
+          </dxl:And>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+      <dxl:RelationStatistics Mdid="2.16394.1.0" Name="t4" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
+      <dxl:Relation Mdid="6.16394.1.0" Name="t4" IsTemporary="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="7,8,2" PartitionColumns="1" PartitionTypes="l">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.1042.1.0" TypeModifier="5" Nullable="true" ColWidth="1">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:Partitions>
+          <dxl:Partition Mdid="6.16397.1.0"/>
+          <dxl:Partition Mdid="6.16400.1.0"/>
+        </dxl:Partitions>
+      </dxl:Relation>
+      <dxl:MDCast Mdid="3.1042.1.0;1042.1.0" Name="bpchar" BinaryCoercible="true" SourceTypeId="0.1042.1.0" DestinationTypeId="0.1042.1.0" CastFuncId="0.0.0.0" CoercePathType="0"/>
+      <dxl:Relation Mdid="6.16397.1.0" Name="t4_1_prt_p1" IsTemporary="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.1042.1.0" TypeModifier="5" Nullable="true" ColWidth="1">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:PartConstraint>
+          <dxl:And>
+            <dxl:IsNotNull>
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.1042.1.0" TypeModifier="5"/>
+            </dxl:IsNotNull>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1054.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.1042.1.0" TypeModifier="5"/>
+              <dxl:ConstValue TypeMdid="0.1042.1.0" TypeModifier="5" Value="AAAABWE=" LintValue="1075015857"/>
+            </dxl:Comparison>
+          </dxl:And>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+      <dxl:ColumnStatistics Mdid="1.16394.1.0.1" Name="b" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.16394.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:RelationExtendedStatistics Mdid="10.16385.1.0" Name="t3"/>
+      <dxl:RelationExtendedStatistics Mdid="10.16394.1.0" Name="t4"/>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="2" ColName="b" TypeMdid="0.1043.1.0" TypeModifier="5"/>
+        <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="11" ColName="b" TypeMdid="0.1042.1.0" TypeModifier="5"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalJoin JoinType="Inner">
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="6.16385.1.0" TableName="t3" LockMode="1">
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.1043.1.0" TypeModifier="5" ColWidth="1"/>
+              <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="4" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="5" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="9" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="6.16394.1.0" TableName="t4" LockMode="1">
+            <dxl:Columns>
+              <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="11" Attno="2" ColName="b" TypeMdid="0.1042.1.0" TypeModifier="5" ColWidth="1"/>
+              <dxl:Column ColId="12" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="13" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="14" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="15" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="16" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="17" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="18" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1054.1.0">
+          <dxl:Cast TypeMdid="0.1042.1.0" FuncId="0.0.0.0">
+            <dxl:Ident ColId="2" ColName="b" TypeMdid="0.1043.1.0" TypeModifier="5"/>
+          </dxl:Cast>
+          <dxl:Ident ColId="11" ColName="b" TypeMdid="0.1042.1.0" TypeModifier="5"/>
+        </dxl:Comparison>
+      </dxl:LogicalJoin>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="7">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="862.000737" Rows="1.000000" Width="24"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="0" Alias="a">
+            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="1" Alias="b">
+            <dxl:Ident ColId="1" ColName="b" TypeMdid="0.1043.1.0" TypeModifier="5"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="9" Alias="a">
+            <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="10" Alias="b">
+            <dxl:Ident ColId="10" ColName="b" TypeMdid="0.1042.1.0" TypeModifier="5"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:SortingColumnList/>
+        <dxl:HashJoin JoinType="Inner">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="862.000647" Rows="1.000000" Width="24"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="0" Alias="a">
+              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="1" Alias="b">
+              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.1043.1.0" TypeModifier="5"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="9" Alias="a">
+              <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="10" Alias="b">
+              <dxl:Ident ColId="10" ColName="b" TypeMdid="0.1042.1.0" TypeModifier="5"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:JoinFilter/>
+          <dxl:HashCondList>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1054.1.0">
+              <dxl:Cast TypeMdid="0.1042.1.0" FuncId="0.0.0.0">
+                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.1043.1.0" TypeModifier="5"/>
+              </dxl:Cast>
+              <dxl:Ident ColId="10" ColName="b" TypeMdid="0.1042.1.0" TypeModifier="5"/>
+            </dxl:Comparison>
+          </dxl:HashCondList>
+          <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.000033" Rows="1.000000" Width="12"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="0" Alias="a">
+                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="1" Alias="b">
+                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.1043.1.0" TypeModifier="5"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:SortingColumnList/>
+            <dxl:HashExprList>
+              <dxl:HashExpr Opfamily="0.427.1.0">
+                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.1043.1.0" TypeModifier="5"/>
+              </dxl:HashExpr>
+            </dxl:HashExprList>
+            <dxl:DynamicTableScan SelectorIds="">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.000006" Rows="1.000000" Width="12"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="0" Alias="a">
+                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="1" Alias="b">
+                  <dxl:Ident ColId="1" ColName="b" TypeMdid="0.1043.1.0" TypeModifier="5"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:Partitions>
+                <dxl:Partition Mdid="6.16388.1.0"/>
+                <dxl:Partition Mdid="6.16391.1.0"/>
+              </dxl:Partitions>
+              <dxl:TableDescriptor Mdid="6.16385.1.0" TableName="t3" LockMode="1">
+                <dxl:Columns>
+                  <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.1043.1.0" TypeModifier="5" ColWidth="1"/>
+                  <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                  <dxl:Column ColId="3" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="4" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="5" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="6" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="7" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="8" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:DynamicTableScan>
+          </dxl:RedistributeMotion>
+          <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.000033" Rows="1.000000" Width="12"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="9" Alias="a">
+                <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="10" Alias="b">
+                <dxl:Ident ColId="10" ColName="b" TypeMdid="0.1042.1.0" TypeModifier="5"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:SortingColumnList/>
+            <dxl:HashExprList>
+              <dxl:HashExpr Opfamily="0.427.1.0">
+                <dxl:Ident ColId="10" ColName="b" TypeMdid="0.1042.1.0" TypeModifier="5"/>
+              </dxl:HashExpr>
+            </dxl:HashExprList>
+            <dxl:DynamicTableScan SelectorIds="">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.000006" Rows="1.000000" Width="12"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="9" Alias="a">
+                  <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="10" Alias="b">
+                  <dxl:Ident ColId="10" ColName="b" TypeMdid="0.1042.1.0" TypeModifier="5"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:Partitions>
+                <dxl:Partition Mdid="6.16397.1.0"/>
+                <dxl:Partition Mdid="6.16400.1.0"/>
+              </dxl:Partitions>
+              <dxl:TableDescriptor Mdid="6.16394.1.0" TableName="t4" LockMode="1">
+                <dxl:Columns>
+                  <dxl:Column ColId="9" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="10" Attno="2" ColName="b" TypeMdid="0.1042.1.0" TypeModifier="5" ColWidth="1"/>
+                  <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                  <dxl:Column ColId="12" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="13" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="14" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="15" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="16" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="17" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:DynamicTableScan>
+          </dxl:RedistributeMotion>
+        </dxl:HashJoin>
+      </dxl:GatherMotion>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/parse_tests/q26-Metadata.xml
+++ b/src/backend/gporca/data/dxl/parse_tests/q26-Metadata.xml
@@ -190,6 +190,7 @@
       <dxl:CountAgg Mdid="0.2147.1.0"/>
     </dxl:Type>
     <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+      <dxl:PartOpfamily Mdid="0.1976.1.0"/>
       <dxl:EqualityOp Mdid="0.96.1.0"/>
       <dxl:InequalityOp Mdid="0.518.1.0"/>
       <dxl:LessThanOp Mdid="0.97.1.0"/>

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CConstraint.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CConstraint.h
@@ -19,6 +19,7 @@
 
 #include "gpopt/base/CColRef.h"
 #include "gpopt/base/CColRefSet.h"
+#include "naucrates/md/IMDIndex.h"
 
 namespace gpopt
 {
@@ -101,10 +102,10 @@ private:
 											BOOL infer_nulls_as = false);
 
 	// create constraint from scalar boolean expression
-	static CConstraint *PcnstrFromScalarBoolOp(CMemoryPool *mp,
-											   CExpression *pexpr,
-											   CColRefSetArray **ppdrgpcrs,
-											   BOOL infer_nulls_as = false);
+	static CConstraint *PcnstrFromScalarBoolOp(
+		CMemoryPool *mp, CExpression *pexpr, CColRefSetArray **ppdrgpcrs,
+		BOOL infer_nulls_as = false,
+		IMDIndex::EmdindexType access_method = IMDIndex::EmdindSentinel);
 
 	// create conjunction/disjunction from array of constraints
 	static CConstraint *PcnstrConjDisj(CMemoryPool *mp,
@@ -241,10 +242,10 @@ public:
 
 	// create constraint from scalar expression and pass back any discovered
 	// equivalence classes
-	static CConstraint *PcnstrFromScalarExpr(CMemoryPool *mp,
-											 CExpression *pexpr,
-											 CColRefSetArray **ppdrgpcrs,
-											 BOOL infer_nulls_as = false);
+	static CConstraint *PcnstrFromScalarExpr(
+		CMemoryPool *mp, CExpression *pexpr, CColRefSetArray **ppdrgpcrs,
+		BOOL infer_nulls_as = false,
+		IMDIndex::EmdindexType access_method = IMDIndex::EmdindSentinel);
 
 	// create constraint from EXISTS/ANY scalar subquery
 	static CConstraint *PcnstrFromExistsAnySubquery(

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CConstraintInterval.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CConstraintInterval.h
@@ -22,6 +22,7 @@
 #include "gpopt/operators/CScalarArrayCmp.h"
 #include "gpopt/operators/CScalarConst.h"
 #include "naucrates/dxl/xml/dxltokens.h"
+#include "naucrates/md/IMDIndex.h"
 #include "naucrates/traceflags/traceflags.h"
 
 namespace gpopt
@@ -83,7 +84,8 @@ private:
 	// create interval from scalar comparison expression
 	static CConstraintInterval *PciIntervalFromScalarCmp(
 		CMemoryPool *mp, CExpression *pexpr, CColRef *colref,
-		BOOL infer_nulls_as = false);
+		BOOL infer_nulls_as = false,
+		IMDIndex::EmdindexType access_method = IMDIndex::EmdindSentinel);
 
 	static CConstraintInterval *PciIntervalFromScalarIDF(CMemoryPool *mp,
 														 CExpression *pexpr,
@@ -92,17 +94,20 @@ private:
 	// create interval from scalar bool operator
 	static CConstraintInterval *PciIntervalFromScalarBoolOp(
 		CMemoryPool *mp, CExpression *pexpr, CColRef *colref,
-		BOOL infer_nulls_as = false);
+		BOOL infer_nulls_as = false,
+		IMDIndex::EmdindexType access_method = IMDIndex::EmdindSentinel);
 
 	// create interval from scalar bool AND
 	static CConstraintInterval *PciIntervalFromScalarBoolAnd(
 		CMemoryPool *mp, CExpression *pexpr, CColRef *colref,
-		BOOL infer_nulls_as = false);
+		BOOL infer_nulls_as = false,
+		IMDIndex::EmdindexType access_method = IMDIndex::EmdindSentinel);
 
 	// create interval from scalar bool OR
 	static CConstraintInterval *PciIntervalFromScalarBoolOr(
 		CMemoryPool *mp, CExpression *pexpr, CColRef *colref,
-		BOOL infer_nulls_as = false);
+		BOOL infer_nulls_as = false,
+		IMDIndex::EmdindexType access_method = IMDIndex::EmdindSentinel);
 
 	// create interval from scalar null test
 	static CConstraintInterval *PciIntervalFromScalarNullTest(
@@ -243,7 +248,8 @@ public:
 	// create interval from scalar expression
 	static CConstraintInterval *PciIntervalFromScalarExpr(
 		CMemoryPool *mp, CExpression *pexpr, CColRef *colref,
-		BOOL infer_nulls_as = false);
+		BOOL infer_nulls_as = false,
+		IMDIndex::EmdindexType access_method = IMDIndex::EmdindSentinel);
 
 	// create interval from any general constraint that references
 	// only one column

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPredicateUtils.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPredicateUtils.h
@@ -17,6 +17,8 @@
 #include "gpopt/mdcache/CMDAccessor.h"
 #include "gpopt/operators/CExpression.h"
 #include "gpopt/operators/CScalarBoolOp.h"
+#include "gpopt/operators/CScalarIdent.h"
+#include "naucrates/md/IMDIndex.h"
 
 namespace gpopt
 {
@@ -348,6 +350,18 @@ public:
 		CMemoryPool *mp, CExpression *pexprScalar,
 		CColRef2dArray *pdrgpdrgpcrPartKeys, CColRefSet *pcrsAllowedRefs,
 		BOOL fUseConstraints, const IMDRelation *pmdrel = nullptr);
+
+	// checks if the operator belongs to the column's opfamily
+	static BOOL FOpInOpfamily(CColRef *colref, CExpression *pexpr,
+							  IMDIndex::EmdindexType access_method);
+
+	// checks if the operator belongs to the scalar expression's opfamily
+	static BOOL FOpInOpfamily(CExpression *pexprScalar, CExpression *pexpr,
+							  IMDIndex::EmdindexType access_method);
+
+	// checks if the operator belongs to the column's opfamily
+	static BOOL FOpInOpfamily(IMDId *col_mdid, CExpression *pexpr,
+							  IMDIndex::EmdindexType access_method);
 
 	// extract the constraint on the given column and return the corresponding
 	// scalar expression

--- a/src/backend/gporca/libgpopt/src/mdcache/CMDAccessor.cpp
+++ b/src/backend/gporca/libgpopt/src/mdcache/CMDAccessor.cpp
@@ -972,7 +972,7 @@ CMDAccessor::Pmdsccmp(IMDId *left_mdid, IMDId *right_mdid,
 					  IMDType::ECmpType cmp_type)
 {
 	GPOS_ASSERT(nullptr != left_mdid);
-	GPOS_ASSERT(nullptr != left_mdid);
+	GPOS_ASSERT(nullptr != right_mdid);
 	GPOS_ASSERT(IMDType::EcmptOther > cmp_type);
 
 	left_mdid->AddRef();

--- a/src/backend/gporca/libgpopt/src/operators/CExpressionPreprocessor.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CExpressionPreprocessor.cpp
@@ -2806,8 +2806,10 @@ CExpressionPreprocessor::PrunePartitions(CMemoryPool *mp, CExpression *expr)
 			CLogicalDynamicGet::PopConvert((*expr)[0]->Pop());
 
 		CColRefSetArray *pdrgpcrsChild = nullptr;
-		CConstraint *pred_cnstr =
-			CConstraint::PcnstrFromScalarExpr(mp, filter_pred, &pdrgpcrsChild);
+		// As of now, partition's default opfamily is btree
+		// ORCA doesn't support hash partition yet
+		CConstraint *pred_cnstr = CConstraint::PcnstrFromScalarExpr(
+			mp, filter_pred, &pdrgpcrsChild, false, IMDIndex::EmdindBtree);
 		CRefCount::SafeRelease(pdrgpcrsChild);
 
 		IMdIdArray *selected_partition_mdids = GPOS_NEW(mp) IMdIdArray(mp);
@@ -2957,9 +2959,12 @@ CExpressionPreprocessor::PcnstrFromChildPartition(
 	GPOS_ASSERT(CUtils::FPredicate(part_constraint_expr));
 
 	CColRefSetArray *pdrgpcrsChild = nullptr;
-	CConstraint *cnstr = CConstraint::PcnstrFromScalarExpr(
-		mp, part_constraint_expr, &pdrgpcrsChild, true /* infer_nulls_as */);
-
+	CConstraint *cnstr;
+	// As of now, partition's default opfamily is btree
+	// ORCA doesn't support hash partition yet
+	cnstr = CConstraint::PcnstrFromScalarExpr(
+		mp, part_constraint_expr, &pdrgpcrsChild, true /* infer_nulls_as */,
+		IMDIndex::EmdindBtree);
 	CRefCount::SafeRelease(part_constraint_expr);
 	CRefCount::SafeRelease(pdrgpcrsChild);
 	GPOS_ASSERT(cnstr);

--- a/src/backend/gporca/libgpopt/src/operators/CExpressionPreprocessor.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CExpressionPreprocessor.cpp
@@ -2809,7 +2809,8 @@ CExpressionPreprocessor::PrunePartitions(CMemoryPool *mp, CExpression *expr)
 		// As of now, partition's default opfamily is btree
 		// ORCA doesn't support hash partition yet
 		CConstraint *pred_cnstr = CConstraint::PcnstrFromScalarExpr(
-			mp, filter_pred, &pdrgpcrsChild, false, IMDIndex::EmdindBtree);
+			mp, filter_pred, &pdrgpcrsChild, false /* infer_nulls_as*/,
+			IMDIndex::EmdindBtree);
 		CRefCount::SafeRelease(pdrgpcrsChild);
 
 		IMdIdArray *selected_partition_mdids = GPOS_NEW(mp) IMdIdArray(mp);

--- a/src/backend/gporca/libgpopt/src/operators/CPredicateUtils.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPredicateUtils.cpp
@@ -1682,6 +1682,7 @@ CPredicateUtils::FOpInOpfamily(IMDId *col_mdid, CExpression *pexpr,
 		}
 		else
 		{
+			GPOS_ASSERT(IMDIndex::EmdindSentinel == access_method);
 			// In case of IMDIndex::EmdindSentinel
 			// We extract both hash and btree opfamilies,
 			// cause we cannot be sure if the predicate will be
@@ -1695,7 +1696,7 @@ CPredicateUtils::FOpInOpfamily(IMDId *col_mdid, CExpression *pexpr,
 		ULONG opfamily_count = op->OpfamiliesCount();
 
 		// If an operator doesn't belong to any opfamily,
-		// it means it's compatible with to any opfamily.
+		// it means it's compatible with any opfamily.
 		// So we return true. Eg. operators  <> or !=,
 		// with op oid 19493, is compatible with any opfamily.
 		if (0 == opfamily_count)

--- a/src/backend/gporca/libgpopt/src/operators/CPredicateUtils.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPredicateUtils.cpp
@@ -1589,16 +1589,23 @@ CPredicateUtils::PexprExtractPredicatesOnPartKeys(
 			isKnownToBeListPartitioned /* allowNotEqualPreds */);
 		CRefCount::SafeRelease(pexprCol);
 		GPOS_ASSERT_IMP(
-			nullptr != pexprCmp &&
-				COperator::EopScalarCmp == pexprCmp->Pop()->Eopid(),
+			nullptr != pexprCmp && CUtils::FScalarCmp(pexprCmp),
 			IMDType::EcmptOther !=
 				CScalarCmp::PopConvert(pexprCmp->Pop())->ParseCmpType());
 
+		// include comparison predicate if it is non-trivial
 		if (nullptr != pexprCmp && !CUtils::FScalarConstTrue(pexprCmp))
 		{
-			// include comparison predicate if it is non-trivial
-			pexprCmp->AddRef();
-			pdrgpexpr->Append(pexprCmp);
+			// The trace flag is ONLY used here to pass the icw tests,
+			// due to the difficulty in reverse engineering a bunch of
+			// mdp tests that don't include the original query.
+			if (!GPOS_FTRACE(EopttraceConsiderOpfamiliesForDistribution) ||
+				FOpInOpfamily(colref, pexprCmp, IMDIndex::EmdindBtree))
+			{
+				// operator has to belong to the column's btree (partition) opfamily
+				pexprCmp->AddRef();
+				pdrgpexpr->Append(pexprCmp);
+			}
 		}
 		CRefCount::SafeRelease(pexprCmp);
 	}
@@ -1613,6 +1620,124 @@ CPredicateUtils::PexprExtractPredicatesOnPartKeys(
 	}
 
 	return PexprConjunction(mp, pdrgpexpr);
+}
+
+// checks if the operator belongs to the column's opfamily
+BOOL
+CPredicateUtils::FOpInOpfamily(CColRef *colref, CExpression *pexpr,
+							   IMDIndex::EmdindexType access_method)
+{
+	IMDId *col_mdid = colref->RetrieveType()->MDId();
+	return FOpInOpfamily(col_mdid, pexpr, access_method);
+}
+
+// checks if the operator belongs to the scalar expression's opfamily
+BOOL
+CPredicateUtils::FOpInOpfamily(CExpression *pexprScalar, CExpression *pexpr,
+							   IMDIndex::EmdindexType access_method)
+{
+	GPOS_ASSERT(nullptr != pexprScalar);
+
+	// We look at the data type before casting, instead of after.
+	// Be it distribution or partition, it's performed based on
+	// the input data type
+	if (CCastUtils::FScalarCast(pexprScalar))
+	{
+		return FOpInOpfamily((*pexprScalar)[0], pexpr, access_method);
+	}
+
+	GPOS_ASSERT(CUtils::FScalarIdent(pexprScalar) ||
+				CUtils::FScalarConst(pexprScalar));
+
+	IMDId *col_mdid = CScalar::PopConvert(pexprScalar->Pop())->MdidType();
+	return FOpInOpfamily(col_mdid, pexpr, access_method);
+}
+
+// checks if the operator belongs to the column's opfamily
+BOOL
+CPredicateUtils::FOpInOpfamily(IMDId *col_mdid, CExpression *pexpr,
+							   IMDIndex::EmdindexType access_method)
+{
+	GPOS_ASSERT(nullptr != pexpr);
+
+	// base case: expression has a comparison operator
+	if (CUtils::FScalarCmp(pexpr))
+	{
+		CMDAccessor *mda = COptCtxt::PoctxtFromTLS()->Pmda();
+
+		// retrieve scalar operator
+		CScalarCmp *popScCmp = CScalarCmp::PopConvert(pexpr->Pop());
+		const IMDScalarOp *op = mda->RetrieveScOp(popScCmp->MdIdOp());
+
+		// retieve column's opfamily
+		const IMDType *col_type = mda->RetrieveType(col_mdid);
+		const IMDId *col_dist_opfamily = nullptr, *col_part_opfamily = nullptr;
+		if (IMDIndex::EmdindHash == access_method)
+		{
+			col_dist_opfamily = col_type->GetDistrOpfamilyMdid();
+		}
+		else if (IMDIndex::EmdindBtree == access_method)
+		{
+			col_part_opfamily = col_type->GetPartOpfamilyMdid();
+		}
+		else
+		{
+			// In case of IMDIndex::EmdindSentinel
+			// We extract both hash and btree opfamilies,
+			// cause we cannot be sure if the predicate will be
+			// used for distribution or partition. We aim to be
+			// as specific as possible in the caller function.
+			// Here we have to be open to both options.
+			col_dist_opfamily = col_type->GetDistrOpfamilyMdid();
+			col_part_opfamily = col_type->GetPartOpfamilyMdid();
+		}
+
+		ULONG opfamily_count = op->OpfamiliesCount();
+
+		// If an operator doesn't belong to any opfamily,
+		// it means it's compatible with to any opfamily.
+		// So we return true. Eg. operators  <> or !=,
+		// with op oid 19493, is compatible with any opfamily.
+		if (0 == opfamily_count)
+		{
+			return true;
+		}
+
+
+		// An operator may belong to multiple opfamilies,
+		// associated with different access methods.
+		// Eg. Hash and btree both support equality
+		// We iterate through the opfamilies array and
+		// compare each opfamily to the column's opfamily.
+		// We return true if a match is found.
+		for (ULONG ul = 0; ul < opfamily_count; ul++)
+		{
+			IMDId *op_opfamily = op->OpfamilyMdidAt(ul);
+
+			// Return true if either hash or btree opfamily matches
+			if (CUtils::Equals(op_opfamily, col_dist_opfamily) ||
+				CUtils::Equals(op_opfamily, col_part_opfamily))
+			{
+				return true;
+			}
+		}
+		return false;
+	}
+
+	// recursive case: expression has a boolean operator
+	GPOS_ASSERT(CUtils::FScalarBoolOp(pexpr));
+
+	const ULONG arity = pexpr->Arity();
+
+	for (ULONG ul = 0; ul < arity; ul++)
+	{
+		CExpression *pexprChild = (*pexpr)[ul];
+		if (!FOpInOpfamily(col_mdid, pexprChild, access_method))
+		{
+			return false;
+		}
+	}
+	return true;
 }
 
 // extract the constraint on the given column and return the corresponding scalar expression
@@ -2280,8 +2405,8 @@ CPredicateUtils::PexprRemoveImpliedConjuncts(CMemoryPool *mp,
 
 		// add predicate to current equivalence classes
 		CColRefSetArray *pdrgpcrsConj = nullptr;
-		CConstraint *pcnstr =
-			CConstraint::PcnstrFromScalarExpr(mp, pexprConj, &pdrgpcrsConj);
+		CConstraint *pcnstr = CConstraint::PcnstrFromScalarExpr(
+			mp, pexprConj, &pdrgpcrsConj, false, IMDIndex::EmdindHash);
 		CRefCount::SafeRelease(pcnstr);
 		if (nullptr != pdrgpcrsConj)
 		{

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/parser/CParseHandlerMDType.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/parser/CParseHandlerMDType.h
@@ -54,6 +54,9 @@ private:
 	// default legacy distribution (hash) opfamily
 	IMDId *m_legacy_distr_opfamily;
 
+	// default partition (btree) opfamily
+	IMDId *m_part_opfamily;
+
 	// type name
 	CMDName *m_mdname;
 

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/xml/dxltokens.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/xml/dxltokens.h
@@ -554,6 +554,7 @@ enum Edxltoken
 	EdxltokenMDTypeByValue,
 	EdxltokenMDTypeDistrOpfamily,
 	EdxltokenMDTypeLegacyDistrOpfamily,
+	EdxltokenMDTypePartOpfamily,
 	EdxltokenMDTypeEqOp,
 	EdxltokenMDTypeNEqOp,
 	EdxltokenMDTypeLTOp,

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/CGPDBTypeHelper.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/CGPDBTypeHelper.h
@@ -84,6 +84,10 @@ public:
 			xml_serializer,
 			CDXLTokens::GetDXLTokenStr(EdxltokenMDTypeLegacyDistrOpfamily),
 			mdtype->m_legacy_distr_opfamily);
+		mdtype->SerializeMDIdAsElem(
+			xml_serializer,
+			CDXLTokens::GetDXLTokenStr(EdxltokenMDTypePartOpfamily),
+			mdtype->m_part_opfamily);
 
 		mdtype->SerializeMDIdAsElem(
 			xml_serializer, CDXLTokens::GetDXLTokenStr(EdxltokenMDTypeEqOp),

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/CMDTypeBoolGPDB.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/CMDTypeBoolGPDB.h
@@ -23,6 +23,7 @@
 #define GPDB_BOOL_OID OID(16)
 #define GPDB_BOOL_OPFAMILY OID(2222)
 #define GPDB_BOOL_LEGACY_OPFAMILY OID(7124)
+#define GPDB_BOOL_PART_OPFAMILY OID(424)
 #define GPDB_BOOL_LENGTH 1
 #define GPDB_BOOL_EQ_OP OID(91)
 #define GPDB_BOOL_NEQ_OP OID(85)
@@ -70,6 +71,7 @@ private:
 	IMDId *m_mdid;
 	IMDId *m_distr_opfamily;
 	IMDId *m_legacy_distr_opfamily;
+	IMDId *m_part_opfamily;
 
 	// mdids of different operators
 	IMDId *m_mdid_op_eq;
@@ -126,6 +128,8 @@ public:
 	IMDId *MDId() const override;
 
 	IMDId *GetDistrOpfamilyMdid() const override;
+
+	IMDId *GetPartOpfamilyMdid() const override;
 
 	// type name
 	CMDName Mdname() const override;

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/CMDTypeGenericGPDB.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/CMDTypeGenericGPDB.h
@@ -83,6 +83,8 @@ private:
 
 	IMDId *m_legacy_distr_opfamily;
 
+	IMDId *m_part_opfamily;
+
 	// id of equality operator for type
 	IMDId *m_mdid_op_eq;
 
@@ -151,12 +153,13 @@ public:
 		CMemoryPool *mp, IMDId *mdid, CMDName *mdname, BOOL is_redistributable,
 		BOOL is_fixed_length, ULONG length, BOOL is_passed_by_value,
 		IMDId *mdid_distr_opfamily, IMDId *mdid_legacy_distr_opfamily,
-		IMDId *mdid_op_eq, IMDId *mdid_op_neq, IMDId *mdid_op_lt,
-		IMDId *mdid_op_leq, IMDId *mdid_op_gt, IMDId *mdid_op_geq,
-		IMDId *mdid_op_cmp, IMDId *pmdidMin, IMDId *pmdidMax, IMDId *pmdidAvg,
-		IMDId *pmdidSum, IMDId *pmdidCount, BOOL is_hashable,
-		BOOL is_merge_joinable, BOOL is_composite_type, BOOL is_text_related,
-		IMDId *mdid_base_relation, IMDId *mdid_type_array, INT gpdb_length);
+		IMDId *mdid_part_opfamily, IMDId *mdid_op_eq, IMDId *mdid_op_neq,
+		IMDId *mdid_op_lt, IMDId *mdid_op_leq, IMDId *mdid_op_gt,
+		IMDId *mdid_op_geq, IMDId *mdid_op_cmp, IMDId *pmdidMin,
+		IMDId *pmdidMax, IMDId *pmdidAvg, IMDId *pmdidSum, IMDId *pmdidCount,
+		BOOL is_hashable, BOOL is_merge_joinable, BOOL is_composite_type,
+		BOOL is_text_related, IMDId *mdid_base_relation, IMDId *mdid_type_array,
+		INT gpdb_length);
 
 	// dtor
 	~CMDTypeGenericGPDB() override;
@@ -245,6 +248,8 @@ public:
 	}
 
 	IMDId *GetDistrOpfamilyMdid() const override;
+
+	IMDId *GetPartOpfamilyMdid() const override;
 
 	// serialize object in DXL format
 	void Serialize(gpdxl::CXMLSerializer *xml_serializer) const override;

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/CMDTypeInt2GPDB.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/CMDTypeInt2GPDB.h
@@ -22,6 +22,7 @@
 #define GPDB_INT2_OID OID(21)
 #define GPDB_INT2_OPFAMILY OID(1977)
 #define GPDB_INT2_LEGACY_OPFAMILY OID(7100)
+#define GPDB_INT2_PART_OPFAMILY OID(1976)
 #define GPDB_INT2_LENGTH 2
 #define GPDB_INT2_EQ_OP OID(94)
 #define GPDB_INT2_NEQ_OP OID(519)
@@ -75,6 +76,7 @@ private:
 	IMDId *m_mdid;
 	IMDId *m_distr_opfamily;
 	IMDId *m_legacy_distr_opfamily;
+	IMDId *m_part_opfamily;
 
 	// mdids of different operators
 	IMDId *m_mdid_op_eq;
@@ -135,6 +137,8 @@ public:
 	IMDId *MDId() const override;
 
 	IMDId *GetDistrOpfamilyMdid() const override;
+
+	IMDId *GetPartOpfamilyMdid() const override;
 
 	// accessor of type name
 	CMDName Mdname() const override;

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/CMDTypeInt4GPDB.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/CMDTypeInt4GPDB.h
@@ -22,6 +22,7 @@
 #define GPDB_INT4_OID OID(23)
 #define GPDB_INT4_OPFAMILY OID(1977)
 #define GPDB_INT4_LEGACY_OPFAMILY OID(7100)
+#define GPDB_INT4_PART_OPFAMILY OID(1976)
 #define GPDB_INT4_LENGTH 4
 #define GPDB_INT4_EQ_OP OID(96)
 #define GPDB_INT4_NEQ_OP OID(518)
@@ -75,6 +76,7 @@ private:
 	IMDId *m_mdid;
 	IMDId *m_distr_opfamily;
 	IMDId *m_legacy_distr_opfamily;
+	IMDId *m_part_opfamily;
 
 	// mdids of different operators
 	IMDId *m_mdid_op_eq;
@@ -134,6 +136,8 @@ public:
 	IMDId *MDId() const override;
 
 	IMDId *GetDistrOpfamilyMdid() const override;
+
+	IMDId *GetPartOpfamilyMdid() const override;
 
 	CMDName Mdname() const override;
 

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/CMDTypeInt8GPDB.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/CMDTypeInt8GPDB.h
@@ -22,6 +22,7 @@
 #define GPDB_INT8_OID OID(20)
 #define GPDB_INT8_OPFAMILY OID(1977)
 #define GPDB_INT8_LEGACY_OPFAMILY OID(7100)
+#define GPDB_INT8_PART_OPFAMILY OID(1976)
 #define GPDB_INT8_LENGTH 8
 #define GPDB_INT8_EQ_OP OID(410)
 #define GPDB_INT8_NEQ_OP OID(411)
@@ -76,6 +77,7 @@ private:
 	IMDId *m_mdid;
 	IMDId *m_distr_opfamily;
 	IMDId *m_legacy_distr_opfamily;
+	IMDId *m_part_opfamily;
 
 	// mdids of different operators
 	IMDId *m_mdid_op_eq;
@@ -135,6 +137,8 @@ public:
 	IMDId *MDId() const override;
 
 	IMDId *GetDistrOpfamilyMdid() const override;
+
+	IMDId *GetPartOpfamilyMdid() const override;
 
 	// type name
 	CMDName Mdname() const override;

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/CMDTypeOidGPDB.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/CMDTypeOidGPDB.h
@@ -20,6 +20,7 @@
 #define GPDB_OID_OID OID(26)
 #define GPDB_OID_OPFAMILY OID(1990)
 #define GPDB_OID_LEGACY_OPFAMILY OID(7109)
+#define GPDB_OID_PART_OPFAMILY OID(1989)
 #define GPDB_OID_LENGTH 4
 #define GPDB_OID_EQ_OP OID(607)
 #define GPDB_OID_NEQ_OP OID(608)
@@ -74,6 +75,7 @@ private:
 	IMDId *m_mdid;
 	IMDId *m_distr_opfamily;
 	IMDId *m_legacy_distr_opfamily;
+	IMDId *m_part_opfamily;
 
 	// mdids of different comparison operators
 	IMDId *m_mdid_op_eq;
@@ -131,6 +133,8 @@ public:
 	IMDId *MDId() const override;
 
 	IMDId *GetDistrOpfamilyMdid() const override;
+
+	IMDId *GetPartOpfamilyMdid() const override;
 
 	CMDName Mdname() const override;
 

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/IMDType.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/IMDType.h
@@ -92,6 +92,8 @@ public:
 
 	virtual IMDId *GetDistrOpfamilyMdid() const = 0;
 
+	virtual IMDId *GetPartOpfamilyMdid() const = 0;
+
 	// md id of cache object
 	IMDId *MDId() const override = 0;
 

--- a/src/backend/gporca/libnaucrates/src/md/CMDTypeBoolGPDB.cpp
+++ b/src/backend/gporca/libnaucrates/src/md/CMDTypeBoolGPDB.cpp
@@ -51,6 +51,8 @@ CMDTypeBoolGPDB::CMDTypeBoolGPDB(CMemoryPool *mp) : m_mp(mp)
 		m_distr_opfamily = nullptr;
 		m_legacy_distr_opfamily = nullptr;
 	}
+	m_part_opfamily =
+		GPOS_NEW(mp) CMDIdGPDB(IMDId::EmdidGeneral, GPDB_BOOL_PART_OPFAMILY);
 	m_mdid_op_eq = GPOS_NEW(mp) CMDIdGPDB(IMDId::EmdidGeneral, GPDB_BOOL_EQ_OP);
 	m_mdid_op_neq =
 		GPOS_NEW(mp) CMDIdGPDB(IMDId::EmdidGeneral, GPDB_BOOL_NEQ_OP);
@@ -95,6 +97,7 @@ CMDTypeBoolGPDB::~CMDTypeBoolGPDB()
 	m_mdid->Release();
 	CRefCount::SafeRelease(m_distr_opfamily);
 	CRefCount::SafeRelease(m_legacy_distr_opfamily);
+	CRefCount::SafeRelease(m_part_opfamily);
 	m_mdid_op_eq->Release();
 	m_mdid_op_neq->Release();
 	m_mdid_op_lt->Release();
@@ -215,6 +218,11 @@ CMDTypeBoolGPDB::GetDistrOpfamilyMdid() const
 	}
 }
 
+IMDId *
+CMDTypeBoolGPDB::GetPartOpfamilyMdid() const
+{
+	return m_part_opfamily;
+}
 //---------------------------------------------------------------------------
 //	@function:
 //		CMDTypeBoolGPDB::Mdname

--- a/src/backend/gporca/libnaucrates/src/md/CMDTypeGenericGPDB.cpp
+++ b/src/backend/gporca/libnaucrates/src/md/CMDTypeGenericGPDB.cpp
@@ -47,13 +47,14 @@ CMDTypeGenericGPDB::CMDTypeGenericGPDB(
 	CMemoryPool *mp, IMDId *mdid, CMDName *mdname, BOOL is_redistributable,
 	BOOL is_fixed_length, ULONG length GPOS_ASSERTS_ONLY,
 	BOOL is_passed_by_value, IMDId *mdid_distr_opfamily,
-	IMDId *mdid_legacy_distr_opfamily, IMDId *mdid_op_eq, IMDId *mdid_op_neq,
-	IMDId *mdid_op_lt, IMDId *mdid_op_leq, IMDId *mdid_op_gt,
-	IMDId *mdid_op_geq, IMDId *mdid_op_cmp, IMDId *mdid_op_min,
-	IMDId *mdid_op_max, IMDId *mdid_op_avg, IMDId *mdid_op_sum,
-	IMDId *mdid_op_count, BOOL is_hashable, BOOL is_merge_joinable,
-	BOOL is_composite_type, BOOL is_text_related, IMDId *mdid_base_relation,
-	IMDId *mdid_type_array, INT gpdb_length)
+	IMDId *mdid_legacy_distr_opfamily, IMDId *mdid_part_opfamily,
+	IMDId *mdid_op_eq, IMDId *mdid_op_neq, IMDId *mdid_op_lt,
+	IMDId *mdid_op_leq, IMDId *mdid_op_gt, IMDId *mdid_op_geq,
+	IMDId *mdid_op_cmp, IMDId *mdid_op_min, IMDId *mdid_op_max,
+	IMDId *mdid_op_avg, IMDId *mdid_op_sum, IMDId *mdid_op_count,
+	BOOL is_hashable, BOOL is_merge_joinable, BOOL is_composite_type,
+	BOOL is_text_related, IMDId *mdid_base_relation, IMDId *mdid_type_array,
+	INT gpdb_length)
 	: m_mp(mp),
 	  m_mdid(mdid),
 	  m_mdname(mdname),
@@ -65,6 +66,7 @@ CMDTypeGenericGPDB::CMDTypeGenericGPDB(
 	  m_is_passed_by_value(is_passed_by_value),
 	  m_distr_opfamily(mdid_distr_opfamily),
 	  m_legacy_distr_opfamily(mdid_legacy_distr_opfamily),
+	  m_part_opfamily(mdid_part_opfamily),
 	  m_mdid_op_eq(mdid_op_eq),
 	  m_mdid_op_neq(mdid_op_neq),
 	  m_mdid_op_lt(mdid_op_lt),
@@ -110,6 +112,7 @@ CMDTypeGenericGPDB::~CMDTypeGenericGPDB()
 	m_mdid->Release();
 	CRefCount::SafeRelease(m_distr_opfamily);
 	CRefCount::SafeRelease(m_legacy_distr_opfamily);
+	CRefCount::SafeRelease(m_part_opfamily);
 	m_mdid_op_eq->Release();
 	m_mdid_op_neq->Release();
 	m_mdid_op_lt->Release();
@@ -557,6 +560,12 @@ CMDTypeGenericGPDB::GetDistrOpfamilyMdid() const
 	{
 		return m_distr_opfamily;
 	}
+}
+
+IMDId *
+CMDTypeGenericGPDB::GetPartOpfamilyMdid() const
+{
+	return m_part_opfamily;
 }
 
 BOOL

--- a/src/backend/gporca/libnaucrates/src/md/CMDTypeInt2GPDB.cpp
+++ b/src/backend/gporca/libnaucrates/src/md/CMDTypeInt2GPDB.cpp
@@ -51,6 +51,8 @@ CMDTypeInt2GPDB::CMDTypeInt2GPDB(CMemoryPool *mp) : m_mp(mp)
 		m_distr_opfamily = nullptr;
 		m_legacy_distr_opfamily = nullptr;
 	}
+	m_part_opfamily =
+		GPOS_NEW(mp) CMDIdGPDB(IMDId::EmdidGeneral, GPDB_INT2_PART_OPFAMILY);
 	m_mdid_op_eq = GPOS_NEW(mp) CMDIdGPDB(IMDId::EmdidGeneral, GPDB_INT2_EQ_OP);
 	m_mdid_op_neq =
 		GPOS_NEW(mp) CMDIdGPDB(IMDId::EmdidGeneral, GPDB_INT2_NEQ_OP);
@@ -93,6 +95,7 @@ CMDTypeInt2GPDB::~CMDTypeInt2GPDB()
 	m_mdid->Release();
 	CRefCount::SafeRelease(m_distr_opfamily);
 	CRefCount::SafeRelease(m_legacy_distr_opfamily);
+	CRefCount::SafeRelease(m_part_opfamily);
 	m_mdid_op_eq->Release();
 	m_mdid_op_neq->Release();
 	m_mdid_op_lt->Release();
@@ -152,6 +155,12 @@ CMDTypeInt2GPDB::GetDistrOpfamilyMdid() const
 	{
 		return m_distr_opfamily;
 	}
+}
+
+IMDId *
+CMDTypeInt2GPDB::GetPartOpfamilyMdid() const
+{
+	return m_part_opfamily;
 }
 
 //---------------------------------------------------------------------------

--- a/src/backend/gporca/libnaucrates/src/md/CMDTypeInt4GPDB.cpp
+++ b/src/backend/gporca/libnaucrates/src/md/CMDTypeInt4GPDB.cpp
@@ -51,6 +51,8 @@ CMDTypeInt4GPDB::CMDTypeInt4GPDB(CMemoryPool *mp) : m_mp(mp)
 		m_distr_opfamily = nullptr;
 		m_legacy_distr_opfamily = nullptr;
 	}
+	m_part_opfamily =
+		GPOS_NEW(mp) CMDIdGPDB(IMDId::EmdidGeneral, GPDB_INT4_PART_OPFAMILY);
 	m_mdid_op_eq = GPOS_NEW(mp) CMDIdGPDB(IMDId::EmdidGeneral, GPDB_INT4_EQ_OP);
 	m_mdid_op_neq =
 		GPOS_NEW(mp) CMDIdGPDB(IMDId::EmdidGeneral, GPDB_INT4_NEQ_OP);
@@ -93,6 +95,7 @@ CMDTypeInt4GPDB::~CMDTypeInt4GPDB()
 	m_mdid->Release();
 	CRefCount::SafeRelease(m_distr_opfamily);
 	CRefCount::SafeRelease(m_legacy_distr_opfamily);
+	CRefCount::SafeRelease(m_part_opfamily);
 	m_mdid_op_eq->Release();
 	m_mdid_op_neq->Release();
 	m_mdid_op_lt->Release();
@@ -150,6 +153,12 @@ CMDTypeInt4GPDB::GetDistrOpfamilyMdid() const
 	{
 		return m_distr_opfamily;
 	}
+}
+
+IMDId *
+CMDTypeInt4GPDB::GetPartOpfamilyMdid() const
+{
+	return m_part_opfamily;
 }
 
 //---------------------------------------------------------------------------

--- a/src/backend/gporca/libnaucrates/src/md/CMDTypeInt8GPDB.cpp
+++ b/src/backend/gporca/libnaucrates/src/md/CMDTypeInt8GPDB.cpp
@@ -57,6 +57,8 @@ CMDTypeInt8GPDB::CMDTypeInt8GPDB(CMemoryPool *mp) : m_mp(mp)
 		m_distr_opfamily = nullptr;
 		m_legacy_distr_opfamily = nullptr;
 	}
+	m_part_opfamily =
+		GPOS_NEW(mp) CMDIdGPDB(IMDId::EmdidGeneral, GPDB_INT8_PART_OPFAMILY);
 	m_mdid_op_eq = GPOS_NEW(mp) CMDIdGPDB(IMDId::EmdidGeneral, GPDB_INT8_EQ_OP);
 	m_mdid_op_neq =
 		GPOS_NEW(mp) CMDIdGPDB(IMDId::EmdidGeneral, GPDB_INT8_NEQ_OP);
@@ -100,6 +102,7 @@ CMDTypeInt8GPDB::~CMDTypeInt8GPDB()
 	m_mdid->Release();
 	CRefCount::SafeRelease(m_distr_opfamily);
 	CRefCount::SafeRelease(m_legacy_distr_opfamily);
+	CRefCount::SafeRelease(m_part_opfamily);
 	m_mdid_op_eq->Release();
 	m_mdid_op_neq->Release();
 	m_mdid_op_lt->Release();
@@ -159,6 +162,12 @@ CMDTypeInt8GPDB::GetDistrOpfamilyMdid() const
 	{
 		return m_distr_opfamily;
 	}
+}
+
+IMDId *
+CMDTypeInt8GPDB::GetPartOpfamilyMdid() const
+{
+	return m_part_opfamily;
 }
 
 //---------------------------------------------------------------------------

--- a/src/backend/gporca/libnaucrates/src/md/CMDTypeOidGPDB.cpp
+++ b/src/backend/gporca/libnaucrates/src/md/CMDTypeOidGPDB.cpp
@@ -51,6 +51,8 @@ CMDTypeOidGPDB::CMDTypeOidGPDB(CMemoryPool *mp) : m_mp(mp)
 		m_distr_opfamily = nullptr;
 		m_legacy_distr_opfamily = nullptr;
 	}
+	m_part_opfamily =
+		GPOS_NEW(mp) CMDIdGPDB(IMDId::EmdidGeneral, GPDB_OID_PART_OPFAMILY);
 	m_mdid_op_eq = GPOS_NEW(mp) CMDIdGPDB(IMDId::EmdidGeneral, GPDB_OID_EQ_OP);
 	m_mdid_op_neq =
 		GPOS_NEW(mp) CMDIdGPDB(IMDId::EmdidGeneral, GPDB_OID_NEQ_OP);
@@ -94,6 +96,7 @@ CMDTypeOidGPDB::~CMDTypeOidGPDB()
 	m_mdid->Release();
 	CRefCount::SafeRelease(m_distr_opfamily);
 	CRefCount::SafeRelease(m_legacy_distr_opfamily);
+	CRefCount::SafeRelease(m_part_opfamily);
 	m_mdid_op_eq->Release();
 	m_mdid_op_neq->Release();
 	m_mdid_op_lt->Release();
@@ -152,6 +155,12 @@ CMDTypeOidGPDB::GetDistrOpfamilyMdid() const
 	{
 		return m_distr_opfamily;
 	}
+}
+
+IMDId *
+CMDTypeOidGPDB::GetPartOpfamilyMdid() const
+{
+	return m_part_opfamily;
 }
 
 //---------------------------------------------------------------------------

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerMDType.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerMDType.cpp
@@ -43,6 +43,7 @@ CParseHandlerMDType::CParseHandlerMDType(
 	  m_mdid(nullptr),
 	  m_distr_opfamily(nullptr),
 	  m_legacy_distr_opfamily(nullptr),
+	  m_part_opfamily(nullptr),
 	  m_mdname(nullptr),
 	  m_mdid_eq_op(nullptr),
 	  m_mdid_neq_op(nullptr),
@@ -84,6 +85,7 @@ CParseHandlerMDType::~CParseHandlerMDType()
 	m_mdid->Release();
 	CRefCount::SafeRelease(m_distr_opfamily);
 	CRefCount::SafeRelease(m_legacy_distr_opfamily);
+	CRefCount::SafeRelease(m_part_opfamily);
 	m_mdid_eq_op->Release();
 	m_mdid_neq_op->Release();
 	m_mdid_lt_op->Release();
@@ -243,6 +245,7 @@ CParseHandlerMDType::ParseMdid(const XMLCh *element_local_name,
 		{EdxltokenMDTypeAggCount, &m_mdid_count_op},
 		{EdxltokenMDTypeDistrOpfamily, &m_distr_opfamily},
 		{EdxltokenMDTypeLegacyDistrOpfamily, &m_legacy_distr_opfamily},
+		{EdxltokenMDTypePartOpfamily, &m_part_opfamily},
 	};
 
 	Edxltoken token_type = EdxltokenSentinel;
@@ -361,6 +364,10 @@ CParseHandlerMDType::EndElement(const XMLCh *const,	 // element_uri,
 				{
 					m_legacy_distr_opfamily->AddRef();
 				}
+				if (nullptr != m_part_opfamily)
+				{
+					m_part_opfamily->AddRef();
+				}
 				m_mdid_eq_op->AddRef();
 				m_mdid_neq_op->AddRef();
 				m_mdid_lt_op->AddRef();
@@ -387,13 +394,13 @@ CParseHandlerMDType::EndElement(const XMLCh *const,	 // element_uri,
 				m_imd_obj = GPOS_NEW(m_mp) CMDTypeGenericGPDB(
 					m_mp, m_mdid, m_mdname, m_is_redistributable,
 					m_istype_fixed_Length, length, m_type_passed_by_value,
-					m_distr_opfamily, m_legacy_distr_opfamily, m_mdid_eq_op,
-					m_mdid_neq_op, m_mdid_lt_op, m_mdid_lteq_op, m_mdid_gt_op,
-					m_mdid_gteq_op, m_mdid_cmp_op, m_mdid_min_op, m_mdid_max_op,
-					m_mdid_avg_op, m_mdid_sum_op, m_mdid_count_op,
-					m_is_hashable, m_is_merge_joinable, m_is_composite,
-					m_is_text_related, m_mdid_base_rel, m_mdid_array_type,
-					m_type_length);
+					m_distr_opfamily, m_legacy_distr_opfamily, m_part_opfamily,
+					m_mdid_eq_op, m_mdid_neq_op, m_mdid_lt_op, m_mdid_lteq_op,
+					m_mdid_gt_op, m_mdid_gteq_op, m_mdid_cmp_op, m_mdid_min_op,
+					m_mdid_max_op, m_mdid_avg_op, m_mdid_sum_op,
+					m_mdid_count_op, m_is_hashable, m_is_merge_joinable,
+					m_is_composite, m_is_text_related, m_mdid_base_rel,
+					m_mdid_array_type, m_type_length);
 				break;
 		}
 

--- a/src/backend/gporca/libnaucrates/src/xml/dxltokens.cpp
+++ b/src/backend/gporca/libnaucrates/src/xml/dxltokens.cpp
@@ -612,6 +612,7 @@ CDXLTokens::Init(CMemoryPool *mp)
 		{EdxltokenMDTypeDistrOpfamily, GPOS_WSZ_LIT("DistrOpfamily")},
 		{EdxltokenMDTypeLegacyDistrOpfamily,
 		 GPOS_WSZ_LIT("LegacyDistrOpfamily")},
+		{EdxltokenMDTypePartOpfamily, GPOS_WSZ_LIT("PartOpfamily")},
 		{EdxltokenMDTypeEqOp, GPOS_WSZ_LIT("EqualityOp")},
 		{EdxltokenMDTypeNEqOp, GPOS_WSZ_LIT("InequalityOp")},
 		{EdxltokenMDTypeLTOp, GPOS_WSZ_LIT("LessThanOp")},

--- a/src/backend/gporca/server/CMakeLists.txt
+++ b/src/backend/gporca/server/CMakeLists.txt
@@ -235,7 +235,7 @@ PartTbl-DPE PartTbl-DPE-GroupBy PartTbl-DPE-Limit
 DPE-with-unsupported-pred DPE-SemiJoin DPE-IN DPE-NOT-IN HJN-DPE-Bitmap-Outer-Child
 NLJ-Broadcast-DPE-Outer-Child PartTbl-MultiWayJoinWithDPE PartTbl-MultiWayJoinWithDPE-2
 PartTbl-LeftOuterHashJoin-DPE-IsNull PartTbl-LeftOuterNLJoin-DPE-IsNull
-PartTbl-List-DPE-Int-Predicates JoinOrderDPE;
+PartTbl-List-DPE-Int-Predicates JoinOrderDPE PartTbl-DPE-Opfamily;
 
 CPartTblSPETest:
 PartTbl-SPE-DynamicTableScan-Range-Cost1 PartTbl-SPE-DynamicTableScan-Range-Cost2

--- a/src/backend/utils/cache/lsyscache.c
+++ b/src/backend/utils/cache/lsyscache.c
@@ -4452,6 +4452,25 @@ get_index_opfamilies(Oid oidIndex)
 }
 
 /*
+ * Return the default operator opfamily to use for the partition key.
+ */
+Oid
+default_partition_opfamily_for_type(Oid typeoid)
+{
+    TypeCacheEntry *tcache;
+
+    tcache = lookup_type_cache(typeoid, TYPECACHE_EQ_OPR | TYPECACHE_LT_OPR | TYPECACHE_GT_OPR |
+                                        TYPECACHE_CMP_PROC |
+                                        TYPECACHE_EQ_OPR_FINFO | TYPECACHE_CMP_PROC_FINFO |
+                                        TYPECACHE_BTREE_OPFAMILY);
+
+    if (!tcache->btree_opf)
+        return InvalidOid;
+
+    return tcache->btree_opf;
+}
+
+/*
  *  relation_policy
  *  Return the distribution policy of a table. 
  */

--- a/src/backend/utils/cache/lsyscache.c
+++ b/src/backend/utils/cache/lsyscache.c
@@ -4459,12 +4459,21 @@ default_partition_opfamily_for_type(Oid typeoid)
 {
     TypeCacheEntry *tcache;
 
+    // flags required for or applicable to btree opfamily
+    // required: TYPECACHE_CMP_PROC, TYPECACHE_CMP_PROC_FINFO, TYPECACHE_BTREE_OPFAMILY
+    // applicable: TYPECACHE_EQ_OPR, TYPECACHE_LT_OPR, TYPECACHE_GT_OPR, TYPECACHE_EQ_OPR_FINFO
+    // Note we don't need all the flags to obtain the btree opfamily
+    // But applying all the flags allows us to abstract away the lookup_type_cache call
     tcache = lookup_type_cache(typeoid, TYPECACHE_EQ_OPR | TYPECACHE_LT_OPR | TYPECACHE_GT_OPR |
                                         TYPECACHE_CMP_PROC |
                                         TYPECACHE_EQ_OPR_FINFO | TYPECACHE_CMP_PROC_FINFO |
                                         TYPECACHE_BTREE_OPFAMILY);
 
     if (!tcache->btree_opf)
+        return InvalidOid;
+    if (!tcache->cmp_proc)
+        return InvalidOid;
+    if (!tcache->eq_opr && !tcache->lt_opr && !tcache->gt_opr)
         return InvalidOid;
 
     return tcache->btree_opf;

--- a/src/backend/utils/cache/test/Makefile
+++ b/src/backend/utils/cache/test/Makefile
@@ -8,5 +8,6 @@ include $(top_srcdir)/src/backend/mock.mk
 
 lsyscache.t: \
 	$(MOCK_DIR)/backend/utils/cache/syscache_mock.o \
+	$(MOCK_DIR)/backend/utils/cache/typcache_mock.o \
 	$(MOCK_DIR)/backend/access/hash/hash_mock.o \
 	$(MOCK_DIR)/backend/utils/fmgr/fmgr_mock.o \

--- a/src/include/gpopt/gpdbwrappers.h
+++ b/src/include/gpopt/gpdbwrappers.h
@@ -321,6 +321,7 @@ Oid GetColumnDefOpclassForType(List *opclassName, Oid typid);
 
 // get the default hash opfamily for type
 Oid GetDefaultDistributionOpfamilyForType(Oid typid);
+Oid GetDefaultPartitionOpfamilyForType(Oid typid);
 
 // get the hash function in an opfamily for given datatype
 Oid GetHashProcInOpfamily(Oid opfamily, Oid typid);

--- a/src/include/utils/lsyscache.h
+++ b/src/include/utils/lsyscache.h
@@ -246,6 +246,7 @@ extern CmpType get_comparison_type(Oid oidOp);
 
 extern List *get_operator_opfamilies(Oid opno);
 extern List *get_index_opfamilies(Oid oidIndex);
+extern Oid default_partition_opfamily_for_type(Oid typeoid);
 
 #define type_is_array(typid)  (get_element_type(typid) != InvalidOid)
 /* type_is_array_domain accepts both plain arrays and domains over arrays */

--- a/src/test/regress/expected/direct_dispatch.out
+++ b/src/test/regress/expected/direct_dispatch.out
@@ -1266,7 +1266,11 @@ INFO:  (slice 1) Dispatch command to SINGLE content
              2 | 97           |        6
 (1 row)
 
--- explicit cast using "char", generates a scenario of cast function from Dist Colm to datum in CTranslatorExprToDXLUtils::FDirectDispatchable(,,)
+-- varchar hash and bpchar hash belong to different opfamilies
+-- hash distribution of col1_varchar and col1_varchar::bpchar
+-- could assign values to different segments. Therefore, the
+-- gather motion applies to all 3 segments, and no direct
+-- dispatch occurs.
 explain (costs off) select gp_segment_id,  * from t1_varchar where col1_varchar = 'c'::char;
                           QUERY PLAN                          
 --------------------------------------------------------------
@@ -1356,6 +1360,10 @@ INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
 INFO:  (slice 1) Dispatch command to SINGLE content
 INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
+-- text hash/btree and citext hash/btree belong to different opfamilies
+-- hash distribution of name and name::text could assign values to
+-- different segments. Therefore, the gather motion applies to all 3
+-- segments, and no direct dispatch occurs.
 explain (costs off) select LOWER(name) as aba FROM srt_dd WHERE name = 'ABA'::text;
                   QUERY PLAN                  
 ----------------------------------------------
@@ -1606,7 +1614,6 @@ set allow_system_table_mods=off;
 -- https://github.com/greenplum-db/gpdb/issues/14887
 -- If opno of clause does not belong to opfamily of distributed key,
 -- do not use direct dispatch to resolve wrong result
--- FIXME: orca still has wrong results
 create table t_14887(a varchar);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.

--- a/src/test/regress/expected/direct_dispatch_optimizer.out
+++ b/src/test/regress/expected/direct_dispatch_optimizer.out
@@ -1278,18 +1278,22 @@ INFO:  (slice 1) Dispatch command to SINGLE content
              2 | 97           |        6
 (1 row)
 
--- explicit cast using "char", generates a scenario of cast function from Dist Colm to datum in CTranslatorExprToDXLUtils::FDirectDispatchable(,,)
+-- varchar hash and bpchar hash belong to different opfamilies
+-- hash distribution of col1_varchar and col1_varchar::bpchar
+-- could assign values to different segments. Therefore, the
+-- gather motion applies to all 3 segments, and no direct
+-- dispatch occurs.
 explain (costs off) select gp_segment_id,  * from t1_varchar where col1_varchar = 'c'::char;
                           QUERY PLAN                          
 --------------------------------------------------------------
- Gather Motion 1:1  (slice1; segments: 1)
+ Gather Motion 3:1  (slice1; segments: 3)
    ->  Seq Scan on t1_varchar
          Filter: ((col1_varchar)::bpchar = 'c'::character(1))
  Optimizer: Pivotal Optimizer (GPORCA)
 (4 rows)
 
 select gp_segment_id,  * from t1_varchar where col1_varchar = 'c'::char;
-INFO:  (slice 1) Dispatch command to SINGLE content
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
  gp_segment_id | col1_varchar | col2_int 
 ---------------+--------------+----------
              2 | c            |        3
@@ -1298,14 +1302,14 @@ INFO:  (slice 1) Dispatch command to SINGLE content
 explain (costs off) select gp_segment_id,  * from t1_varchar where col1_varchar = '2'::char;
                           QUERY PLAN                          
 --------------------------------------------------------------
- Gather Motion 1:1  (slice1; segments: 1)
+ Gather Motion 3:1  (slice1; segments: 3)
    ->  Seq Scan on t1_varchar
          Filter: ((col1_varchar)::bpchar = '2'::character(1))
  Optimizer: Pivotal Optimizer (GPORCA)
 (4 rows)
 
 select gp_segment_id,  * from t1_varchar where col1_varchar = '2'::char;
-INFO:  (slice 1) Dispatch command to SINGLE content
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
  gp_segment_id | col1_varchar | col2_int 
 ---------------+--------------+----------
 (0 rows)
@@ -1367,17 +1371,21 @@ VALUES ('abb'),
 INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
 INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
 INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
+-- text hash/btree and citext hash/btree belong to different opfamilies
+-- hash distribution of name and name::text could assign values to
+-- different segments. Therefore, the gather motion applies to all 3
+-- segments, and no direct dispatch occurs.
 explain (costs off) select LOWER(name) as aba FROM srt_dd WHERE name = 'ABA'::text;
                   QUERY PLAN                  
 ----------------------------------------------
- Gather Motion 1:1  (slice1; segments: 1)
+ Gather Motion 3:1  (slice1; segments: 3)
    ->  Seq Scan on srt_dd
          Filter: ((name)::text = 'ABA'::text)
  Optimizer: Pivotal Optimizer (GPORCA)
 (4 rows)
 
 select LOWER(name) as aba FROM srt_dd WHERE name = 'ABA'::text;
-INFO:  (slice 1) Dispatch command to SINGLE content
+INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
  aba 
 -----
  aba
@@ -1393,8 +1401,9 @@ explain (costs off) delete from srt_dd where name='ABA'::text;
 (4 rows)
 
 delete from srt_dd where name='ABA'::text;
-INFO:  (slice 0) Dispatch command to SINGLE content
-INFO:  Distributed transaction command 'Distributed Commit (one-phase)' to SINGLE content
+INFO:  (slice 0) Dispatch command to ALL contents: 0 1 2
+INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
+INFO:  Distributed transaction command 'Distributed Commit Prepared' to ALL contents: 0 1 2
 drop extension if exists citext cascade;
 NOTICE:  drop cascades to table srt_dd
 INFO:  Distributed transaction command 'Distributed Prepare' to ALL contents: 0 1 2
@@ -1626,7 +1635,6 @@ set allow_system_table_mods=off;
 -- https://github.com/greenplum-db/gpdb/issues/14887
 -- If opno of clause does not belong to opfamily of distributed key,
 -- do not use direct dispatch to resolve wrong result
--- FIXME: orca still has wrong results
 create table t_14887(a varchar);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
@@ -1634,16 +1642,17 @@ insert into t_14887 values('a   ');
 explain select * from t_14887 where a = 'a'::bpchar;
                                   QUERY PLAN                                  
 ------------------------------------------------------------------------------
- Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..431.00 rows=1 width=8)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
    ->  Seq Scan on t_14887  (cost=0.00..431.00 rows=1 width=8)
          Filter: ((a)::bpchar = 'a'::bpchar)
  Optimizer: Pivotal Optimizer (GPORCA)
 (4 rows)
 
 select * from t_14887 where a = 'a'::bpchar;
- a 
----
-(0 rows)
+  a   
+------
+ a   
+(1 row)
 
 -- texteq does not belong to the hash opfamily of the table's citext distkey.
 -- But from the implementation can deduce: texteq ==> citext_eq, and we can
@@ -1660,7 +1669,7 @@ insert into t_14887 values('A'),('a');
 explain select * from t_14887 where a = 'a'::text;
                                   QUERY PLAN                                  
 ------------------------------------------------------------------------------
- Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..431.00 rows=1 width=8)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
    ->  Seq Scan on t_14887  (cost=0.00..431.00 rows=1 width=8)
          Filter: ((a)::text = 'a'::text)
  Optimizer: Pivotal Optimizer (GPORCA)

--- a/src/test/regress/expected/equivclass_optimizer.out
+++ b/src/test/regress/expected/equivclass_optimizer.out
@@ -116,14 +116,13 @@ explain (costs off)
 
 explain (costs off)
   select * from ec0 where ff = f1 and f1 = '42'::int8alias1;
-                 QUERY PLAN                  
----------------------------------------------
+                       QUERY PLAN                        
+---------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  Index Scan using ec0_pkey on ec0
-         Index Cond: (ff = '42'::int8alias1)
-         Filter: (f1 = '42'::int8alias1)
- Optimizer: Postgres query optimizer
-(5 rows)
+   ->  Seq Scan on ec0
+         Filter: ((ff = f1) AND (f1 = '42'::int8alias1))
+ Optimizer: Pivotal Optimizer (GPORCA)
+(4 rows)
 
 explain (costs off)
   select * from ec1 where ff = f1 and f1 = '42'::int8alias1;
@@ -165,12 +164,12 @@ explain (costs off)
 ---------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Nested Loop
+         Join Filter: true
          ->  Broadcast Motion 3:3  (slice2; segments: 3)
-               ->  Index Scan using ec1_pkey on ec1
-                     Index Cond: (ff = '42'::int8alias1)
-         ->  Seq Scan on ec2
-               Filter: (x1 = '42'::int8alias1)
- Optimizer: Postgres query optimizer
+               ->  Seq Scan on ec2
+         ->  Index Scan using ec1_pkey on ec1
+               Index Cond: ((ff = ec2.x1) AND (ff = '42'::int8alias1))
+ Optimizer: Pivotal Optimizer (GPORCA)
 (8 rows)
 
 explain (costs off)
@@ -445,14 +444,13 @@ explain (costs off)
 ---------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Nested Loop
-         ->  Index Scan using ec0_pkey on ec0 a
+         Join Filter: true
+         ->  Index Scan using ec0_pkey on ec0
                Index Cond: (ff = '43'::int8alias1)
-         ->  Materialize
-               ->  Broadcast Motion 3:3  (slice2; segments: 3)
-                     ->  Index Scan using ec1_pkey on ec1 b
-                           Index Cond: (ff = '43'::int8alias1)
- Optimizer: Postgres query optimizer
-(9 rows)
+         ->  Index Scan using ec1_pkey on ec1
+               Index Cond: (ff = ec0.ff)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(8 rows)
 
 set session authorization regress_user_ectest;
 -- with RLS active, the non-leakproof a.ff = 43 clause is not treated

--- a/src/test/regress/expected/partition_prune_opfamily.out
+++ b/src/test/regress/expected/partition_prune_opfamily.out
@@ -1,0 +1,370 @@
+-- https://gist.github.com/kainwen/df7c0d3149684e1256d31b5c39e02de7#file-gp7-sql
+-- This test is included in https://github.com/greenplum-db/gpdb/issues/14982
+-- The test creates an operator that performs absolute value comparisons of the input data.
+-- The operator belongs to a customized btree opfamily 16433, which supports cross-type (20, 23) comparisons.
+-- The test then creates two tables, t1 and t2.
+-- Both are distributed by column a, and partitioned by column b.
+-- t1.a is of type int, belonging to hash opfamily 1977, which supports cross-type (20, 21, 23) comparisons.
+-- t2.a is of type int, belonging to hash opfamily 1977, which supports cross-type (20, 21, 23) comparisons.
+-- t1.b is of type int4, belonging to btree opfamily 1976, which supports cross-type (20, 21, 23) comparisons.
+-- t2.b is of type int8, belonging to btree opfamily 1976, which supports cross-type (20, 21, 23) comparisons.
+-- As of now, ORCA doesn't consider partition key's opfamily when performing partition pruning
+-- Internally, operator |=| of opfamily 16433 is treated as operator = of opfamily 1977 or 1976, and generated
+-- incorrect hash join condition and unjustified partition pruning. This fix compares the operator to the
+-- column's opfamily, thence deriving correct properties from the predicates.
+-- greenplum
+create schema partition_prune_opfamily;
+set search_path=bfv_partition_plans;
+SET optimizer_trace_fallback=on;
+-- start_ignore
+create language plpython3u;
+-- end_ignore
+-- proc for int4
+create function abseq4(a int4, b int4) returns bool as $$
+return abs(a) == abs(b)
+$$ language plpython3u strict immutable;
+ERROR:  no schema has been selected to create in
+create function abslt4(a int4, b int4) returns bool as $$
+return abs(a) < abs(b)
+$$ language plpython3u strict immutable;
+ERROR:  no schema has been selected to create in
+create function absle4(a int4, b int4) returns bool as $$
+return abs(a) <= abs(b)
+$$ language plpython3u strict immutable;
+ERROR:  no schema has been selected to create in
+create function absgt4(a int4, b int4) returns bool as $$
+return abs(a) > abs(b)
+$$ language plpython3u strict immutable;
+ERROR:  no schema has been selected to create in
+create function absge4(a int4, b int4) returns bool as $$
+return abs(a) >= abs(b)
+$$ language plpython3u strict immutable;
+ERROR:  no schema has been selected to create in
+create function abscmp4(a int4, b int4) returns int as $$
+if abs(a) < abs(b):
+    return -1
+if abs(a) > abs(b):
+    return 1
+return 0
+$$ language plpython3u strict immutable;
+ERROR:  no schema has been selected to create in
+-- procs for int8
+create function abseq8(a int8, b int8) returns bool as $$
+return abs(a) == abs(b)
+$$ language plpython3u strict immutable;
+ERROR:  no schema has been selected to create in
+create function abslt8(a int8, b int8) returns bool as $$
+return abs(a) < abs(b)
+$$ language plpython3u strict immutable;
+ERROR:  no schema has been selected to create in
+create function absle8(a int8, b int8) returns bool as $$
+return abs(a) <= abs(b)
+$$ language plpython3u strict immutable;
+ERROR:  no schema has been selected to create in
+create function absgt8(a int8, b int8) returns bool as $$
+return abs(a) > abs(b)
+$$ language plpython3u strict immutable;
+ERROR:  no schema has been selected to create in
+create function absge8(a int8, b int8) returns bool as $$
+return abs(a) >= abs(b)
+$$ language plpython3u strict immutable;
+ERROR:  no schema has been selected to create in
+create function abscmp8(a int8, b int8) returns int as $$
+if abs(a) < abs(b):
+    return -1
+if abs(a) > abs(b):
+    return 1
+return 0
+$$ language plpython3u strict immutable;
+ERROR:  no schema has been selected to create in
+-- procs for cross type int4 int8
+create function abseq48(a int4, b int8) returns bool as $$
+return abs(a) == abs(b)
+$$ language plpython3u strict immutable;
+ERROR:  no schema has been selected to create in
+create function abslt48(a int4, b int8) returns bool as $$
+return abs(a) < abs(b)
+$$ language plpython3u strict immutable;
+ERROR:  no schema has been selected to create in
+create function absle48(a int4, b int8) returns bool as $$
+return abs(a) <= abs(b)
+$$ language plpython3u strict immutable;
+ERROR:  no schema has been selected to create in
+create function absgt48(a int4, b int8) returns bool as $$
+return abs(a) > abs(b)
+$$ language plpython3u strict immutable;
+ERROR:  no schema has been selected to create in
+create function absge48(a int4, b int8) returns bool as $$
+return abs(a) >= abs(b)
+$$ language plpython3u strict immutable;
+ERROR:  no schema has been selected to create in
+create function abscmp48(a int4, b int8) returns int as $$
+if abs(a) < abs(b):
+    return -1
+if abs(a) > abs(b):
+    return 1
+return 0
+$$ language plpython3u strict immutable;
+ERROR:  no schema has been selected to create in
+--procs for cross type int8 int4
+create function abseq84(a int8, b int4) returns bool as $$
+return abs(a) == abs(b)
+$$ language plpython3u strict immutable;
+ERROR:  no schema has been selected to create in
+create function abslt84(a int8, b int4) returns bool as $$
+return abs(a) < abs(b)
+$$ language plpython3u strict immutable;
+ERROR:  no schema has been selected to create in
+create function absle84(a int8, b int4) returns bool as $$
+return abs(a) <= abs(b)
+$$ language plpython3u strict immutable;
+ERROR:  no schema has been selected to create in
+create function absgt84(a int8, b int4) returns bool as $$
+return abs(a) > abs(b)
+$$ language plpython3u strict immutable;
+ERROR:  no schema has been selected to create in
+create function absge84(a int8, b int4) returns bool as $$
+return abs(a) >= abs(b)
+$$ language plpython3u strict immutable;
+ERROR:  no schema has been selected to create in
+create function abscmp84(a int8, b int4) returns int as $$
+if abs(a) < abs(b):
+    return -1
+if abs(a) > abs(b):
+    return 1
+return 0
+$$ language plpython3u strict immutable;
+ERROR:  no schema has been selected to create in
+-- |=|
+create operator |=| (
+  procedure = abseq4,
+  leftarg = int4,
+  rightarg = int4,
+  commutator = |=|,
+  merges);
+ERROR:  no schema has been selected to create in
+create operator |=| (
+  procedure = abseq8,
+  leftarg = int8,
+  rightarg = int8,
+  commutator = |=|,
+  merges);
+ERROR:  no schema has been selected to create in
+create operator |=| (
+  procedure = abseq48,
+  leftarg = int4,
+  rightarg = int8,
+  commutator = |=|,
+  merges);
+ERROR:  no schema has been selected to create in
+create operator |=| (
+  procedure = abseq84,
+  leftarg = int8,
+  rightarg = int4,
+  commutator = |=|,
+  merges);
+ERROR:  no schema has been selected to create in
+-- |<|
+create operator |<| (
+  procedure = abslt4,
+  leftarg = int4,
+  rightarg = int4,
+  commutator = |<|);
+ERROR:  no schema has been selected to create in
+create operator |<| (
+  procedure = abslt8,
+  leftarg = int8,
+  rightarg = int8,
+  commutator = |<|);
+ERROR:  no schema has been selected to create in
+create operator |<| (
+  procedure = abslt48,
+  leftarg = int4,
+  rightarg = int8,
+  commutator = |<|);
+ERROR:  no schema has been selected to create in
+create operator |<| (
+  procedure = abslt84,
+  leftarg = int8,
+  rightarg = int4,
+  commutator = |<|);
+ERROR:  no schema has been selected to create in
+-- |>|
+create operator |>| (
+  procedure = absgt4,
+  leftarg = int4,
+  rightarg = int4,
+  commutator = |>|);
+ERROR:  no schema has been selected to create in
+create operator |>| (
+  procedure = absgt8,
+  leftarg = int8,
+  rightarg = int8,
+  commutator = |>|);
+ERROR:  no schema has been selected to create in
+create operator |>| (
+  procedure = absgt48,
+  leftarg = int4,
+  rightarg = int8,
+  commutator = |>|);
+ERROR:  no schema has been selected to create in
+create operator |>| (
+  procedure = absgt84,
+  leftarg = int8,
+  rightarg = int4,
+  commutator = |>|);
+ERROR:  no schema has been selected to create in
+-- |<=|
+create operator |<=| (
+  procedure = absle4,
+  leftarg = int4,
+  rightarg = int4,
+  commutator = |<=|);
+ERROR:  no schema has been selected to create in
+create operator |<=| (
+  procedure = absle8,
+  leftarg = int8,
+  rightarg = int8,
+  commutator = |<=|);
+ERROR:  no schema has been selected to create in
+create operator |<=| (
+  procedure = absle48,
+  leftarg = int4,
+  rightarg = int8,
+  commutator = |<=|);
+ERROR:  no schema has been selected to create in
+ 
+create operator |<=| (
+  procedure = absle84,
+  leftarg = int8,
+  rightarg = int4,
+  commutator = |<=|);
+ERROR:  no schema has been selected to create in
+-- |>=|
+create operator |>=| (
+  procedure = absge4,
+  leftarg = int4,
+  rightarg = int4,
+  commutator = |>=|);
+ERROR:  no schema has been selected to create in
+create operator |>=| (
+  procedure = absge8,
+  leftarg = int8,
+  rightarg = int8,
+  commutator = |>=|);
+ERROR:  no schema has been selected to create in
+create operator |>=| (
+  procedure = absge48,
+  leftarg = int4,
+  rightarg = int8,
+  commutator = |>=|);
+ERROR:  no schema has been selected to create in
+create operator |>=| (
+  procedure = absge84,
+  leftarg = int8,
+  rightarg = int4,
+  commutator = |>=|);
+ERROR:  no schema has been selected to create in
+--------
+create operator family abs_int_ops using btree;
+ERROR:  no schema has been selected to create in
+create operator class abs_int4_ops for type int4
+  using btree FAMILY abs_int_ops  as
+  operator 1 |<|,
+  operator 3 |=|,
+  operator 5 |>|,
+  function 1 abscmp4(int4, int4);
+ERROR:  no schema has been selected to create in
+create operator class abs_int8_ops for type int8
+  using btree FAMILY abs_int_ops as
+  operator 1 |<|,
+  operator 3 |=|,
+  operator 5 |>|,
+  function 1 abscmp8(int8, int8);
+ERROR:  no schema has been selected to create in
+alter operator family abs_int_ops using btree add
+  -- cross-type comparisons int4 vs int8
+  operator 1 |<| (int4, int8),
+  operator 2 |<=| (int4, int8),
+  operator 3 |=| (int4, int8),
+  operator 4 |>=| (int4, int8),
+  operator 5 |>| (int4, int8),
+  function 1 abscmp48(int4, int8),
+  
+  -- cross-type comparisons int8 vs int4
+  operator 1 |<| (int8, int4),
+  operator 2 |<=| (int8, int4),
+  operator 3 |=| (int8, int4),
+  operator 4 |>=| (int8, int4),
+  operator 5 |>| (int8, int4),
+  function 1 abscmp84(int8, int4);
+ERROR:  operator family "abs_int_ops" does not exist for access method "btree"
+--gpdb
+--start_ignore
+DROP TABLE t1;
+ERROR:  table "t1" does not exist
+DROP TABLE t2;
+ERROR:  table "t2" does not exist
+create table t1 (a int, b int4)
+partition by list (b)
+(
+  partition p1 values (1),
+  partition p2 values (-1)
+);
+ERROR:  no schema has been selected to create in
+LINE 1: create table t1 (a int, b int4)
+                     ^
+create table t2 (a int, b int8)
+partition by list (b)
+(
+  partition p1 values (1),
+  partition p2 values (-1)
+);
+ERROR:  no schema has been selected to create in
+LINE 1: create table t2 (a int, b int8)
+                     ^
+insert into t1 values (1,1), (1,-1), (-1,1), (-1,-1);
+ERROR:  relation "t1" does not exist
+LINE 1: insert into t1 values (1,1), (1,-1), (-1,1), (-1,-1);
+                    ^
+insert into t2 values (1,1), (1,-1), (-1,1), (-1,-1);
+ERROR:  relation "t2" does not exist
+LINE 1: insert into t2 values (1,1), (1,-1), (-1,1), (-1,-1);
+                    ^
+--end_ignore
+explain select * from t1 where t1.b |=| 1;
+ERROR:  relation "t1" does not exist
+LINE 1: explain select * from t1 where t1.b |=| 1;
+                              ^
+select * from t1 where t1.b |=| 1;
+ERROR:  relation "t1" does not exist
+LINE 1: select * from t1 where t1.b |=| 1;
+                      ^
+explain select * from t1, t2 where t1.b = t2.b and t2.b |=| 1;
+ERROR:  relation "t1" does not exist
+LINE 1: explain select * from t1, t2 where t1.b = t2.b and t2.b |=| ...
+                              ^
+select * from t1, t2 where t1.b = t2.b and t2.b |=| 1;
+ERROR:  relation "t1" does not exist
+LINE 1: select * from t1, t2 where t1.b = t2.b and t2.b |=| 1;
+                      ^
+explain select * from t1, t2 where t1.a = t2.a and t1.b |=| t2.b;
+ERROR:  relation "t1" does not exist
+LINE 1: explain select * from t1, t2 where t1.a = t2.a and t1.b |=| ...
+                              ^
+select * from t1, t2 where t1.a = t2.a and t1.b |=| t2.b;
+ERROR:  relation "t1" does not exist
+LINE 1: select * from t1, t2 where t1.a = t2.a and t1.b |=| t2.b;
+                      ^
+explain select * from t1, t2 where t1.a = t2.a and t1.b |=| t2.b and t2.b = 1;
+ERROR:  relation "t1" does not exist
+LINE 1: explain select * from t1, t2 where t1.a = t2.a and t1.b |=| ...
+                              ^
+select * from t1, t2 where t1.a = t2.a and t1.b |=| t2.b and t2.b = 1;
+ERROR:  relation "t1" does not exist
+LINE 1: select * from t1, t2 where t1.a = t2.a and t1.b |=| t2.b and...
+                      ^
+-- CLEANUP
+-- start_ignore
+drop schema if exists partition_prune_opfamily cascade;
+-- end_ignore

--- a/src/test/regress/expected/partition_prune_opfamily.out
+++ b/src/test/regress/expected/partition_prune_opfamily.out
@@ -14,7 +14,7 @@
 -- column's opfamily, thence deriving correct properties from the predicates.
 -- greenplum
 create schema partition_prune_opfamily;
-set search_path=bfv_partition_plans;
+set search_path=partition_prune_opfamily;
 SET optimizer_trace_fallback=on;
 -- start_ignore
 create language plpython3u;
@@ -23,23 +23,18 @@ create language plpython3u;
 create function abseq4(a int4, b int4) returns bool as $$
 return abs(a) == abs(b)
 $$ language plpython3u strict immutable;
-ERROR:  no schema has been selected to create in
 create function abslt4(a int4, b int4) returns bool as $$
 return abs(a) < abs(b)
 $$ language plpython3u strict immutable;
-ERROR:  no schema has been selected to create in
 create function absle4(a int4, b int4) returns bool as $$
 return abs(a) <= abs(b)
 $$ language plpython3u strict immutable;
-ERROR:  no schema has been selected to create in
 create function absgt4(a int4, b int4) returns bool as $$
 return abs(a) > abs(b)
 $$ language plpython3u strict immutable;
-ERROR:  no schema has been selected to create in
 create function absge4(a int4, b int4) returns bool as $$
 return abs(a) >= abs(b)
 $$ language plpython3u strict immutable;
-ERROR:  no schema has been selected to create in
 create function abscmp4(a int4, b int4) returns int as $$
 if abs(a) < abs(b):
     return -1
@@ -47,28 +42,22 @@ if abs(a) > abs(b):
     return 1
 return 0
 $$ language plpython3u strict immutable;
-ERROR:  no schema has been selected to create in
 -- procs for int8
 create function abseq8(a int8, b int8) returns bool as $$
 return abs(a) == abs(b)
 $$ language plpython3u strict immutable;
-ERROR:  no schema has been selected to create in
 create function abslt8(a int8, b int8) returns bool as $$
 return abs(a) < abs(b)
 $$ language plpython3u strict immutable;
-ERROR:  no schema has been selected to create in
 create function absle8(a int8, b int8) returns bool as $$
 return abs(a) <= abs(b)
 $$ language plpython3u strict immutable;
-ERROR:  no schema has been selected to create in
 create function absgt8(a int8, b int8) returns bool as $$
 return abs(a) > abs(b)
 $$ language plpython3u strict immutable;
-ERROR:  no schema has been selected to create in
 create function absge8(a int8, b int8) returns bool as $$
 return abs(a) >= abs(b)
 $$ language plpython3u strict immutable;
-ERROR:  no schema has been selected to create in
 create function abscmp8(a int8, b int8) returns int as $$
 if abs(a) < abs(b):
     return -1
@@ -76,28 +65,22 @@ if abs(a) > abs(b):
     return 1
 return 0
 $$ language plpython3u strict immutable;
-ERROR:  no schema has been selected to create in
 -- procs for cross type int4 int8
 create function abseq48(a int4, b int8) returns bool as $$
 return abs(a) == abs(b)
 $$ language plpython3u strict immutable;
-ERROR:  no schema has been selected to create in
 create function abslt48(a int4, b int8) returns bool as $$
 return abs(a) < abs(b)
 $$ language plpython3u strict immutable;
-ERROR:  no schema has been selected to create in
 create function absle48(a int4, b int8) returns bool as $$
 return abs(a) <= abs(b)
 $$ language plpython3u strict immutable;
-ERROR:  no schema has been selected to create in
 create function absgt48(a int4, b int8) returns bool as $$
 return abs(a) > abs(b)
 $$ language plpython3u strict immutable;
-ERROR:  no schema has been selected to create in
 create function absge48(a int4, b int8) returns bool as $$
 return abs(a) >= abs(b)
 $$ language plpython3u strict immutable;
-ERROR:  no schema has been selected to create in
 create function abscmp48(a int4, b int8) returns int as $$
 if abs(a) < abs(b):
     return -1
@@ -105,28 +88,22 @@ if abs(a) > abs(b):
     return 1
 return 0
 $$ language plpython3u strict immutable;
-ERROR:  no schema has been selected to create in
 --procs for cross type int8 int4
 create function abseq84(a int8, b int4) returns bool as $$
 return abs(a) == abs(b)
 $$ language plpython3u strict immutable;
-ERROR:  no schema has been selected to create in
 create function abslt84(a int8, b int4) returns bool as $$
 return abs(a) < abs(b)
 $$ language plpython3u strict immutable;
-ERROR:  no schema has been selected to create in
 create function absle84(a int8, b int4) returns bool as $$
 return abs(a) <= abs(b)
 $$ language plpython3u strict immutable;
-ERROR:  no schema has been selected to create in
 create function absgt84(a int8, b int4) returns bool as $$
 return abs(a) > abs(b)
 $$ language plpython3u strict immutable;
-ERROR:  no schema has been selected to create in
 create function absge84(a int8, b int4) returns bool as $$
 return abs(a) >= abs(b)
 $$ language plpython3u strict immutable;
-ERROR:  no schema has been selected to create in
 create function abscmp84(a int8, b int4) returns int as $$
 if abs(a) < abs(b):
     return -1
@@ -134,7 +111,6 @@ if abs(a) > abs(b):
     return 1
 return 0
 $$ language plpython3u strict immutable;
-ERROR:  no schema has been selected to create in
 -- |=|
 create operator |=| (
   procedure = abseq4,
@@ -142,146 +118,123 @@ create operator |=| (
   rightarg = int4,
   commutator = |=|,
   merges);
-ERROR:  no schema has been selected to create in
 create operator |=| (
   procedure = abseq8,
   leftarg = int8,
   rightarg = int8,
   commutator = |=|,
   merges);
-ERROR:  no schema has been selected to create in
 create operator |=| (
   procedure = abseq48,
   leftarg = int4,
   rightarg = int8,
   commutator = |=|,
   merges);
-ERROR:  no schema has been selected to create in
 create operator |=| (
   procedure = abseq84,
   leftarg = int8,
   rightarg = int4,
   commutator = |=|,
   merges);
-ERROR:  no schema has been selected to create in
 -- |<|
 create operator |<| (
   procedure = abslt4,
   leftarg = int4,
   rightarg = int4,
   commutator = |<|);
-ERROR:  no schema has been selected to create in
 create operator |<| (
   procedure = abslt8,
   leftarg = int8,
   rightarg = int8,
   commutator = |<|);
-ERROR:  no schema has been selected to create in
 create operator |<| (
   procedure = abslt48,
   leftarg = int4,
   rightarg = int8,
   commutator = |<|);
-ERROR:  no schema has been selected to create in
 create operator |<| (
   procedure = abslt84,
   leftarg = int8,
   rightarg = int4,
   commutator = |<|);
-ERROR:  no schema has been selected to create in
 -- |>|
 create operator |>| (
   procedure = absgt4,
   leftarg = int4,
   rightarg = int4,
   commutator = |>|);
-ERROR:  no schema has been selected to create in
 create operator |>| (
   procedure = absgt8,
   leftarg = int8,
   rightarg = int8,
   commutator = |>|);
-ERROR:  no schema has been selected to create in
 create operator |>| (
   procedure = absgt48,
   leftarg = int4,
   rightarg = int8,
   commutator = |>|);
-ERROR:  no schema has been selected to create in
 create operator |>| (
   procedure = absgt84,
   leftarg = int8,
   rightarg = int4,
   commutator = |>|);
-ERROR:  no schema has been selected to create in
 -- |<=|
 create operator |<=| (
   procedure = absle4,
   leftarg = int4,
   rightarg = int4,
   commutator = |<=|);
-ERROR:  no schema has been selected to create in
 create operator |<=| (
   procedure = absle8,
   leftarg = int8,
   rightarg = int8,
   commutator = |<=|);
-ERROR:  no schema has been selected to create in
 create operator |<=| (
   procedure = absle48,
   leftarg = int4,
   rightarg = int8,
   commutator = |<=|);
-ERROR:  no schema has been selected to create in
  
 create operator |<=| (
   procedure = absle84,
   leftarg = int8,
   rightarg = int4,
   commutator = |<=|);
-ERROR:  no schema has been selected to create in
 -- |>=|
 create operator |>=| (
   procedure = absge4,
   leftarg = int4,
   rightarg = int4,
   commutator = |>=|);
-ERROR:  no schema has been selected to create in
 create operator |>=| (
   procedure = absge8,
   leftarg = int8,
   rightarg = int8,
   commutator = |>=|);
-ERROR:  no schema has been selected to create in
 create operator |>=| (
   procedure = absge48,
   leftarg = int4,
   rightarg = int8,
   commutator = |>=|);
-ERROR:  no schema has been selected to create in
 create operator |>=| (
   procedure = absge84,
   leftarg = int8,
   rightarg = int4,
   commutator = |>=|);
-ERROR:  no schema has been selected to create in
 --------
 create operator family abs_int_ops using btree;
-ERROR:  no schema has been selected to create in
 create operator class abs_int4_ops for type int4
   using btree FAMILY abs_int_ops  as
   operator 1 |<|,
   operator 3 |=|,
   operator 5 |>|,
   function 1 abscmp4(int4, int4);
-ERROR:  no schema has been selected to create in
 create operator class abs_int8_ops for type int8
   using btree FAMILY abs_int_ops as
   operator 1 |<|,
   operator 3 |=|,
   operator 5 |>|,
   function 1 abscmp8(int8, int8);
-ERROR:  no schema has been selected to create in
 alter operator family abs_int_ops using btree add
   -- cross-type comparisons int4 vs int8
   operator 1 |<| (int4, int8),
@@ -298,73 +251,140 @@ alter operator family abs_int_ops using btree add
   operator 4 |>=| (int8, int4),
   operator 5 |>| (int8, int4),
   function 1 abscmp84(int8, int4);
-ERROR:  operator family "abs_int_ops" does not exist for access method "btree"
---gpdb
---start_ignore
+-- gpdb
+-- start_ignore
 DROP TABLE t1;
 ERROR:  table "t1" does not exist
 DROP TABLE t2;
 ERROR:  table "t2" does not exist
+-- end_ignore
 create table t1 (a int, b int4)
 partition by list (b)
 (
   partition p1 values (1),
   partition p2 values (-1)
 );
-ERROR:  no schema has been selected to create in
-LINE 1: create table t1 (a int, b int4)
-                     ^
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 create table t2 (a int, b int8)
 partition by list (b)
 (
   partition p1 values (1),
   partition p2 values (-1)
 );
-ERROR:  no schema has been selected to create in
-LINE 1: create table t2 (a int, b int8)
-                     ^
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 insert into t1 values (1,1), (1,-1), (-1,1), (-1,-1);
-ERROR:  relation "t1" does not exist
-LINE 1: insert into t1 values (1,1), (1,-1), (-1,1), (-1,-1);
-                    ^
 insert into t2 values (1,1), (1,-1), (-1,1), (-1,-1);
-ERROR:  relation "t2" does not exist
-LINE 1: insert into t2 values (1,1), (1,-1), (-1,1), (-1,-1);
-                    ^
---end_ignore
 explain select * from t1 where t1.b |=| 1;
-ERROR:  relation "t1" does not exist
-LINE 1: explain select * from t1 where t1.b |=| 1;
-                              ^
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..16283.50 rows=86100 width=8)
+   ->  Append  (cost=0.00..15135.50 rows=28700 width=8)
+         ->  Seq Scan on t1_1_prt_p2  (cost=0.00..7496.00 rows=14350 width=8)
+               Filter: (b |=| 1)
+         ->  Seq Scan on t1_1_prt_p1  (cost=0.00..7496.00 rows=14350 width=8)
+               Filter: (b |=| 1)
+ Optimizer: Postgres query optimizer
+(7 rows)
+
 select * from t1 where t1.b |=| 1;
-ERROR:  relation "t1" does not exist
-LINE 1: select * from t1 where t1.b |=| 1;
-                      ^
+ a  | b  
+----+----
+  1 | -1
+  1 |  1
+ -1 | -1
+ -1 |  1
+(4 rows)
+
 explain select * from t1, t2 where t1.b = t2.b and t2.b |=| 1;
-ERROR:  relation "t1" does not exist
-LINE 1: explain select * from t1, t2 where t1.b = t2.b and t2.b |=| ...
-                              ^
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=2794.50..426963.08 rows=13414380 width=20)
+   ->  Hash Join  (cost=2794.50..248104.68 rows=4471460 width=20)
+         Hash Cond: (t2_1_prt_p2.b = t1_1_prt_p2.b)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..14219.83 rows=25967 width=12)
+               Hash Key: t2_1_prt_p2.b
+               ->  Append  (cost=0.00..13700.50 rows=25967 width=12)
+                     ->  Seq Scan on t2_1_prt_p2  (cost=0.00..6785.33 rows=12983 width=12)
+                           Filter: (b |=| 1)
+                     ->  Seq Scan on t2_1_prt_p1  (cost=0.00..6785.33 rows=12983 width=12)
+                           Filter: (b |=| 1)
+         ->  Hash  (cost=2077.00..2077.00 rows=57400 width=8)
+               ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..2077.00 rows=57400 width=8)
+                     Hash Key: t1_1_prt_p2.b
+                     ->  Append  (cost=0.00..929.00 rows=57400 width=8)
+                           ->  Seq Scan on t1_1_prt_p2  (cost=0.00..321.00 rows=28700 width=8)
+                           ->  Seq Scan on t1_1_prt_p1  (cost=0.00..321.00 rows=28700 width=8)
+ Optimizer: Postgres query optimizer
+(17 rows)
+
 select * from t1, t2 where t1.b = t2.b and t2.b |=| 1;
-ERROR:  relation "t1" does not exist
-LINE 1: select * from t1, t2 where t1.b = t2.b and t2.b |=| 1;
-                      ^
+ a  | b  | a  | b  
+----+----+----+----
+ -1 | -1 |  1 | -1
+  1 | -1 |  1 | -1
+ -1 | -1 | -1 | -1
+  1 | -1 | -1 | -1
+ -1 |  1 |  1 |  1
+  1 |  1 |  1 |  1
+ -1 |  1 | -1 |  1
+  1 |  1 | -1 |  1
+(8 rows)
+
 explain select * from t1, t2 where t1.a = t2.a and t1.b |=| t2.b;
-ERROR:  relation "t1" does not exist
-LINE 1: explain select * from t1, t2 where t1.a = t2.a and t1.b |=| ...
-                              ^
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=1496.17..1344006.67 rows=13414380 width=20)
+   ->  Hash Join  (cost=1496.17..1165148.27 rows=4471460 width=20)
+         Hash Cond: (t1_1_prt_p2.a = t2_1_prt_p2.a)
+         Join Filter: (t1_1_prt_p2.b |=| t2_1_prt_p2.b)
+         ->  Append  (cost=0.00..929.00 rows=57400 width=8)
+               ->  Seq Scan on t1_1_prt_p2  (cost=0.00..321.00 rows=28700 width=8)
+               ->  Seq Scan on t1_1_prt_p1  (cost=0.00..321.00 rows=28700 width=8)
+         ->  Hash  (cost=847.00..847.00 rows=51933 width=12)
+               ->  Append  (cost=0.00..847.00 rows=51933 width=12)
+                     ->  Seq Scan on t2_1_prt_p2  (cost=0.00..293.67 rows=25967 width=12)
+                     ->  Seq Scan on t2_1_prt_p1  (cost=0.00..293.67 rows=25967 width=12)
+ Optimizer: Postgres query optimizer
+(12 rows)
+
 select * from t1, t2 where t1.a = t2.a and t1.b |=| t2.b;
-ERROR:  relation "t1" does not exist
-LINE 1: select * from t1, t2 where t1.a = t2.a and t1.b |=| t2.b;
-                      ^
+ a  | b  | a  | b  
+----+----+----+----
+ -1 | -1 | -1 |  1
+ -1 | -1 | -1 | -1
+ -1 |  1 | -1 |  1
+ -1 |  1 | -1 | -1
+  1 | -1 |  1 |  1
+  1 | -1 |  1 | -1
+  1 |  1 |  1 |  1
+  1 |  1 |  1 | -1
+(8 rows)
+
 explain select * from t1, t2 where t1.a = t2.a and t1.b |=| t2.b and t2.b = 1;
-ERROR:  relation "t1" does not exist
-LINE 1: explain select * from t1, t2 where t1.a = t2.a and t1.b |=| ...
-                              ^
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=358.91..1921.43 rows=6707 width=20)
+   ->  Hash Join  (cost=358.91..1832.00 rows=2236 width=20)
+         Hash Cond: (t1_1_prt_p2.a = t2_1_prt_p1.a)
+         Join Filter: (t1_1_prt_p2.b |=| t2_1_prt_p1.b)
+         ->  Append  (cost=0.00..929.00 rows=57400 width=8)
+               ->  Seq Scan on t1_1_prt_p2  (cost=0.00..321.00 rows=28700 width=8)
+               ->  Seq Scan on t1_1_prt_p1  (cost=0.00..321.00 rows=28700 width=8)
+         ->  Hash  (cost=358.58..358.58 rows=26 width=12)
+               ->  Seq Scan on t2_1_prt_p1  (cost=0.00..358.58 rows=26 width=12)
+                     Filter: (b = 1)
+ Optimizer: Postgres query optimizer
+(11 rows)
+
 select * from t1, t2 where t1.a = t2.a and t1.b |=| t2.b and t2.b = 1;
-ERROR:  relation "t1" does not exist
-LINE 1: select * from t1, t2 where t1.a = t2.a and t1.b |=| t2.b and...
-                      ^
+ a  | b  | a  | b 
+----+----+----+---
+  1 | -1 |  1 | 1
+  1 |  1 |  1 | 1
+ -1 | -1 | -1 | 1
+ -1 |  1 | -1 | 1
+(4 rows)
+
 -- CLEANUP
--- start_ignore
-drop schema if exists partition_prune_opfamily cascade;
--- end_ignore

--- a/src/test/regress/expected/partition_prune_opfamily_optimizer.out
+++ b/src/test/regress/expected/partition_prune_opfamily_optimizer.out
@@ -1,0 +1,370 @@
+-- https://gist.github.com/kainwen/df7c0d3149684e1256d31b5c39e02de7#file-gp7-sql
+-- This test is included in https://github.com/greenplum-db/gpdb/issues/14982
+-- The test creates an operator that performs absolute value comparisons of the input data.
+-- The operator belongs to a customized btree opfamily 16433, which supports cross-type (20, 23) comparisons.
+-- The test then creates two tables, t1 and t2.
+-- Both are distributed by column a, and partitioned by column b.
+-- t1.a is of type int, belonging to hash opfamily 1977, which supports cross-type (20, 21, 23) comparisons.
+-- t2.a is of type int, belonging to hash opfamily 1977, which supports cross-type (20, 21, 23) comparisons.
+-- t1.b is of type int4, belonging to btree opfamily 1976, which supports cross-type (20, 21, 23) comparisons.
+-- t2.b is of type int8, belonging to btree opfamily 1976, which supports cross-type (20, 21, 23) comparisons.
+-- As of now, ORCA doesn't consider partition key's opfamily when performing partition pruning
+-- Internally, operator |=| of opfamily 16433 is treated as operator = of opfamily 1977 or 1976, and generated
+-- incorrect hash join condition and unjustified partition pruning. This fix compares the operator to the
+-- column's opfamily, thence deriving correct properties from the predicates.
+-- greenplum
+create schema partition_prune_opfamily;
+set search_path=bfv_partition_plans;
+SET optimizer_trace_fallback=on;
+-- start_ignore
+create language plpython3u;
+-- end_ignore
+-- proc for int4
+create function abseq4(a int4, b int4) returns bool as $$
+return abs(a) == abs(b)
+$$ language plpython3u strict immutable;
+ERROR:  no schema has been selected to create in
+create function abslt4(a int4, b int4) returns bool as $$
+return abs(a) < abs(b)
+$$ language plpython3u strict immutable;
+ERROR:  no schema has been selected to create in
+create function absle4(a int4, b int4) returns bool as $$
+return abs(a) <= abs(b)
+$$ language plpython3u strict immutable;
+ERROR:  no schema has been selected to create in
+create function absgt4(a int4, b int4) returns bool as $$
+return abs(a) > abs(b)
+$$ language plpython3u strict immutable;
+ERROR:  no schema has been selected to create in
+create function absge4(a int4, b int4) returns bool as $$
+return abs(a) >= abs(b)
+$$ language plpython3u strict immutable;
+ERROR:  no schema has been selected to create in
+create function abscmp4(a int4, b int4) returns int as $$
+if abs(a) < abs(b):
+    return -1
+if abs(a) > abs(b):
+    return 1
+return 0
+$$ language plpython3u strict immutable;
+ERROR:  no schema has been selected to create in
+-- procs for int8
+create function abseq8(a int8, b int8) returns bool as $$
+return abs(a) == abs(b)
+$$ language plpython3u strict immutable;
+ERROR:  no schema has been selected to create in
+create function abslt8(a int8, b int8) returns bool as $$
+return abs(a) < abs(b)
+$$ language plpython3u strict immutable;
+ERROR:  no schema has been selected to create in
+create function absle8(a int8, b int8) returns bool as $$
+return abs(a) <= abs(b)
+$$ language plpython3u strict immutable;
+ERROR:  no schema has been selected to create in
+create function absgt8(a int8, b int8) returns bool as $$
+return abs(a) > abs(b)
+$$ language plpython3u strict immutable;
+ERROR:  no schema has been selected to create in
+create function absge8(a int8, b int8) returns bool as $$
+return abs(a) >= abs(b)
+$$ language plpython3u strict immutable;
+ERROR:  no schema has been selected to create in
+create function abscmp8(a int8, b int8) returns int as $$
+if abs(a) < abs(b):
+    return -1
+if abs(a) > abs(b):
+    return 1
+return 0
+$$ language plpython3u strict immutable;
+ERROR:  no schema has been selected to create in
+-- procs for cross type int4 int8
+create function abseq48(a int4, b int8) returns bool as $$
+return abs(a) == abs(b)
+$$ language plpython3u strict immutable;
+ERROR:  no schema has been selected to create in
+create function abslt48(a int4, b int8) returns bool as $$
+return abs(a) < abs(b)
+$$ language plpython3u strict immutable;
+ERROR:  no schema has been selected to create in
+create function absle48(a int4, b int8) returns bool as $$
+return abs(a) <= abs(b)
+$$ language plpython3u strict immutable;
+ERROR:  no schema has been selected to create in
+create function absgt48(a int4, b int8) returns bool as $$
+return abs(a) > abs(b)
+$$ language plpython3u strict immutable;
+ERROR:  no schema has been selected to create in
+create function absge48(a int4, b int8) returns bool as $$
+return abs(a) >= abs(b)
+$$ language plpython3u strict immutable;
+ERROR:  no schema has been selected to create in
+create function abscmp48(a int4, b int8) returns int as $$
+if abs(a) < abs(b):
+    return -1
+if abs(a) > abs(b):
+    return 1
+return 0
+$$ language plpython3u strict immutable;
+ERROR:  no schema has been selected to create in
+--procs for cross type int8 int4
+create function abseq84(a int8, b int4) returns bool as $$
+return abs(a) == abs(b)
+$$ language plpython3u strict immutable;
+ERROR:  no schema has been selected to create in
+create function abslt84(a int8, b int4) returns bool as $$
+return abs(a) < abs(b)
+$$ language plpython3u strict immutable;
+ERROR:  no schema has been selected to create in
+create function absle84(a int8, b int4) returns bool as $$
+return abs(a) <= abs(b)
+$$ language plpython3u strict immutable;
+ERROR:  no schema has been selected to create in
+create function absgt84(a int8, b int4) returns bool as $$
+return abs(a) > abs(b)
+$$ language plpython3u strict immutable;
+ERROR:  no schema has been selected to create in
+create function absge84(a int8, b int4) returns bool as $$
+return abs(a) >= abs(b)
+$$ language plpython3u strict immutable;
+ERROR:  no schema has been selected to create in
+create function abscmp84(a int8, b int4) returns int as $$
+if abs(a) < abs(b):
+    return -1
+if abs(a) > abs(b):
+    return 1
+return 0
+$$ language plpython3u strict immutable;
+ERROR:  no schema has been selected to create in
+-- |=|
+create operator |=| (
+  procedure = abseq4,
+  leftarg = int4,
+  rightarg = int4,
+  commutator = |=|,
+  merges);
+ERROR:  no schema has been selected to create in
+create operator |=| (
+  procedure = abseq8,
+  leftarg = int8,
+  rightarg = int8,
+  commutator = |=|,
+  merges);
+ERROR:  no schema has been selected to create in
+create operator |=| (
+  procedure = abseq48,
+  leftarg = int4,
+  rightarg = int8,
+  commutator = |=|,
+  merges);
+ERROR:  no schema has been selected to create in
+create operator |=| (
+  procedure = abseq84,
+  leftarg = int8,
+  rightarg = int4,
+  commutator = |=|,
+  merges);
+ERROR:  no schema has been selected to create in
+-- |<|
+create operator |<| (
+  procedure = abslt4,
+  leftarg = int4,
+  rightarg = int4,
+  commutator = |<|);
+ERROR:  no schema has been selected to create in
+create operator |<| (
+  procedure = abslt8,
+  leftarg = int8,
+  rightarg = int8,
+  commutator = |<|);
+ERROR:  no schema has been selected to create in
+create operator |<| (
+  procedure = abslt48,
+  leftarg = int4,
+  rightarg = int8,
+  commutator = |<|);
+ERROR:  no schema has been selected to create in
+create operator |<| (
+  procedure = abslt84,
+  leftarg = int8,
+  rightarg = int4,
+  commutator = |<|);
+ERROR:  no schema has been selected to create in
+-- |>|
+create operator |>| (
+  procedure = absgt4,
+  leftarg = int4,
+  rightarg = int4,
+  commutator = |>|);
+ERROR:  no schema has been selected to create in
+create operator |>| (
+  procedure = absgt8,
+  leftarg = int8,
+  rightarg = int8,
+  commutator = |>|);
+ERROR:  no schema has been selected to create in
+create operator |>| (
+  procedure = absgt48,
+  leftarg = int4,
+  rightarg = int8,
+  commutator = |>|);
+ERROR:  no schema has been selected to create in
+create operator |>| (
+  procedure = absgt84,
+  leftarg = int8,
+  rightarg = int4,
+  commutator = |>|);
+ERROR:  no schema has been selected to create in
+-- |<=|
+create operator |<=| (
+  procedure = absle4,
+  leftarg = int4,
+  rightarg = int4,
+  commutator = |<=|);
+ERROR:  no schema has been selected to create in
+create operator |<=| (
+  procedure = absle8,
+  leftarg = int8,
+  rightarg = int8,
+  commutator = |<=|);
+ERROR:  no schema has been selected to create in
+create operator |<=| (
+  procedure = absle48,
+  leftarg = int4,
+  rightarg = int8,
+  commutator = |<=|);
+ERROR:  no schema has been selected to create in
+ 
+create operator |<=| (
+  procedure = absle84,
+  leftarg = int8,
+  rightarg = int4,
+  commutator = |<=|);
+ERROR:  no schema has been selected to create in
+-- |>=|
+create operator |>=| (
+  procedure = absge4,
+  leftarg = int4,
+  rightarg = int4,
+  commutator = |>=|);
+ERROR:  no schema has been selected to create in
+create operator |>=| (
+  procedure = absge8,
+  leftarg = int8,
+  rightarg = int8,
+  commutator = |>=|);
+ERROR:  no schema has been selected to create in
+create operator |>=| (
+  procedure = absge48,
+  leftarg = int4,
+  rightarg = int8,
+  commutator = |>=|);
+ERROR:  no schema has been selected to create in
+create operator |>=| (
+  procedure = absge84,
+  leftarg = int8,
+  rightarg = int4,
+  commutator = |>=|);
+ERROR:  no schema has been selected to create in
+--------
+create operator family abs_int_ops using btree;
+ERROR:  no schema has been selected to create in
+create operator class abs_int4_ops for type int4
+  using btree FAMILY abs_int_ops  as
+  operator 1 |<|,
+  operator 3 |=|,
+  operator 5 |>|,
+  function 1 abscmp4(int4, int4);
+ERROR:  no schema has been selected to create in
+create operator class abs_int8_ops for type int8
+  using btree FAMILY abs_int_ops as
+  operator 1 |<|,
+  operator 3 |=|,
+  operator 5 |>|,
+  function 1 abscmp8(int8, int8);
+ERROR:  no schema has been selected to create in
+alter operator family abs_int_ops using btree add
+  -- cross-type comparisons int4 vs int8
+  operator 1 |<| (int4, int8),
+  operator 2 |<=| (int4, int8),
+  operator 3 |=| (int4, int8),
+  operator 4 |>=| (int4, int8),
+  operator 5 |>| (int4, int8),
+  function 1 abscmp48(int4, int8),
+  
+  -- cross-type comparisons int8 vs int4
+  operator 1 |<| (int8, int4),
+  operator 2 |<=| (int8, int4),
+  operator 3 |=| (int8, int4),
+  operator 4 |>=| (int8, int4),
+  operator 5 |>| (int8, int4),
+  function 1 abscmp84(int8, int4);
+ERROR:  operator family "abs_int_ops" does not exist for access method "btree"
+--gpdb
+--start_ignore
+DROP TABLE t1;
+ERROR:  table "t1" does not exist
+DROP TABLE t2;
+ERROR:  table "t2" does not exist
+create table t1 (a int, b int4)
+partition by list (b)
+(
+  partition p1 values (1),
+  partition p2 values (-1)
+);
+ERROR:  no schema has been selected to create in
+LINE 1: create table t1 (a int, b int4)
+                     ^
+create table t2 (a int, b int8)
+partition by list (b)
+(
+  partition p1 values (1),
+  partition p2 values (-1)
+);
+ERROR:  no schema has been selected to create in
+LINE 1: create table t2 (a int, b int8)
+                     ^
+insert into t1 values (1,1), (1,-1), (-1,1), (-1,-1);
+ERROR:  relation "t1" does not exist
+LINE 1: insert into t1 values (1,1), (1,-1), (-1,1), (-1,-1);
+                    ^
+insert into t2 values (1,1), (1,-1), (-1,1), (-1,-1);
+ERROR:  relation "t2" does not exist
+LINE 1: insert into t2 values (1,1), (1,-1), (-1,1), (-1,-1);
+                    ^
+--end_ignore
+explain select * from t1 where t1.b |=| 1;
+ERROR:  relation "t1" does not exist
+LINE 1: explain select * from t1 where t1.b |=| 1;
+                              ^
+select * from t1 where t1.b |=| 1;
+ERROR:  relation "t1" does not exist
+LINE 1: select * from t1 where t1.b |=| 1;
+                      ^
+explain select * from t1, t2 where t1.b = t2.b and t2.b |=| 1;
+ERROR:  relation "t1" does not exist
+LINE 1: explain select * from t1, t2 where t1.b = t2.b and t2.b |=| ...
+                              ^
+select * from t1, t2 where t1.b = t2.b and t2.b |=| 1;
+ERROR:  relation "t1" does not exist
+LINE 1: select * from t1, t2 where t1.b = t2.b and t2.b |=| 1;
+                      ^
+explain select * from t1, t2 where t1.a = t2.a and t1.b |=| t2.b;
+ERROR:  relation "t1" does not exist
+LINE 1: explain select * from t1, t2 where t1.a = t2.a and t1.b |=| ...
+                              ^
+select * from t1, t2 where t1.a = t2.a and t1.b |=| t2.b;
+ERROR:  relation "t1" does not exist
+LINE 1: select * from t1, t2 where t1.a = t2.a and t1.b |=| t2.b;
+                      ^
+explain select * from t1, t2 where t1.a = t2.a and t1.b |=| t2.b and t2.b = 1;
+ERROR:  relation "t1" does not exist
+LINE 1: explain select * from t1, t2 where t1.a = t2.a and t1.b |=| ...
+                              ^
+select * from t1, t2 where t1.a = t2.a and t1.b |=| t2.b and t2.b = 1;
+ERROR:  relation "t1" does not exist
+LINE 1: select * from t1, t2 where t1.a = t2.a and t1.b |=| t2.b and...
+                      ^
+-- CLEANUP
+-- start_ignore
+drop schema if exists partition_prune_opfamily cascade;
+-- end_ignore

--- a/src/test/regress/expected/partition_prune_opfamily_optimizer.out
+++ b/src/test/regress/expected/partition_prune_opfamily_optimizer.out
@@ -14,7 +14,7 @@
 -- column's opfamily, thence deriving correct properties from the predicates.
 -- greenplum
 create schema partition_prune_opfamily;
-set search_path=bfv_partition_plans;
+set search_path=partition_prune_opfamily;
 SET optimizer_trace_fallback=on;
 -- start_ignore
 create language plpython3u;
@@ -23,23 +23,18 @@ create language plpython3u;
 create function abseq4(a int4, b int4) returns bool as $$
 return abs(a) == abs(b)
 $$ language plpython3u strict immutable;
-ERROR:  no schema has been selected to create in
 create function abslt4(a int4, b int4) returns bool as $$
 return abs(a) < abs(b)
 $$ language plpython3u strict immutable;
-ERROR:  no schema has been selected to create in
 create function absle4(a int4, b int4) returns bool as $$
 return abs(a) <= abs(b)
 $$ language plpython3u strict immutable;
-ERROR:  no schema has been selected to create in
 create function absgt4(a int4, b int4) returns bool as $$
 return abs(a) > abs(b)
 $$ language plpython3u strict immutable;
-ERROR:  no schema has been selected to create in
 create function absge4(a int4, b int4) returns bool as $$
 return abs(a) >= abs(b)
 $$ language plpython3u strict immutable;
-ERROR:  no schema has been selected to create in
 create function abscmp4(a int4, b int4) returns int as $$
 if abs(a) < abs(b):
     return -1
@@ -47,28 +42,22 @@ if abs(a) > abs(b):
     return 1
 return 0
 $$ language plpython3u strict immutable;
-ERROR:  no schema has been selected to create in
 -- procs for int8
 create function abseq8(a int8, b int8) returns bool as $$
 return abs(a) == abs(b)
 $$ language plpython3u strict immutable;
-ERROR:  no schema has been selected to create in
 create function abslt8(a int8, b int8) returns bool as $$
 return abs(a) < abs(b)
 $$ language plpython3u strict immutable;
-ERROR:  no schema has been selected to create in
 create function absle8(a int8, b int8) returns bool as $$
 return abs(a) <= abs(b)
 $$ language plpython3u strict immutable;
-ERROR:  no schema has been selected to create in
 create function absgt8(a int8, b int8) returns bool as $$
 return abs(a) > abs(b)
 $$ language plpython3u strict immutable;
-ERROR:  no schema has been selected to create in
 create function absge8(a int8, b int8) returns bool as $$
 return abs(a) >= abs(b)
 $$ language plpython3u strict immutable;
-ERROR:  no schema has been selected to create in
 create function abscmp8(a int8, b int8) returns int as $$
 if abs(a) < abs(b):
     return -1
@@ -76,28 +65,22 @@ if abs(a) > abs(b):
     return 1
 return 0
 $$ language plpython3u strict immutable;
-ERROR:  no schema has been selected to create in
 -- procs for cross type int4 int8
 create function abseq48(a int4, b int8) returns bool as $$
 return abs(a) == abs(b)
 $$ language plpython3u strict immutable;
-ERROR:  no schema has been selected to create in
 create function abslt48(a int4, b int8) returns bool as $$
 return abs(a) < abs(b)
 $$ language plpython3u strict immutable;
-ERROR:  no schema has been selected to create in
 create function absle48(a int4, b int8) returns bool as $$
 return abs(a) <= abs(b)
 $$ language plpython3u strict immutable;
-ERROR:  no schema has been selected to create in
 create function absgt48(a int4, b int8) returns bool as $$
 return abs(a) > abs(b)
 $$ language plpython3u strict immutable;
-ERROR:  no schema has been selected to create in
 create function absge48(a int4, b int8) returns bool as $$
 return abs(a) >= abs(b)
 $$ language plpython3u strict immutable;
-ERROR:  no schema has been selected to create in
 create function abscmp48(a int4, b int8) returns int as $$
 if abs(a) < abs(b):
     return -1
@@ -105,28 +88,22 @@ if abs(a) > abs(b):
     return 1
 return 0
 $$ language plpython3u strict immutable;
-ERROR:  no schema has been selected to create in
 --procs for cross type int8 int4
 create function abseq84(a int8, b int4) returns bool as $$
 return abs(a) == abs(b)
 $$ language plpython3u strict immutable;
-ERROR:  no schema has been selected to create in
 create function abslt84(a int8, b int4) returns bool as $$
 return abs(a) < abs(b)
 $$ language plpython3u strict immutable;
-ERROR:  no schema has been selected to create in
 create function absle84(a int8, b int4) returns bool as $$
 return abs(a) <= abs(b)
 $$ language plpython3u strict immutable;
-ERROR:  no schema has been selected to create in
 create function absgt84(a int8, b int4) returns bool as $$
 return abs(a) > abs(b)
 $$ language plpython3u strict immutable;
-ERROR:  no schema has been selected to create in
 create function absge84(a int8, b int4) returns bool as $$
 return abs(a) >= abs(b)
 $$ language plpython3u strict immutable;
-ERROR:  no schema has been selected to create in
 create function abscmp84(a int8, b int4) returns int as $$
 if abs(a) < abs(b):
     return -1
@@ -134,7 +111,6 @@ if abs(a) > abs(b):
     return 1
 return 0
 $$ language plpython3u strict immutable;
-ERROR:  no schema has been selected to create in
 -- |=|
 create operator |=| (
   procedure = abseq4,
@@ -142,146 +118,123 @@ create operator |=| (
   rightarg = int4,
   commutator = |=|,
   merges);
-ERROR:  no schema has been selected to create in
 create operator |=| (
   procedure = abseq8,
   leftarg = int8,
   rightarg = int8,
   commutator = |=|,
   merges);
-ERROR:  no schema has been selected to create in
 create operator |=| (
   procedure = abseq48,
   leftarg = int4,
   rightarg = int8,
   commutator = |=|,
   merges);
-ERROR:  no schema has been selected to create in
 create operator |=| (
   procedure = abseq84,
   leftarg = int8,
   rightarg = int4,
   commutator = |=|,
   merges);
-ERROR:  no schema has been selected to create in
 -- |<|
 create operator |<| (
   procedure = abslt4,
   leftarg = int4,
   rightarg = int4,
   commutator = |<|);
-ERROR:  no schema has been selected to create in
 create operator |<| (
   procedure = abslt8,
   leftarg = int8,
   rightarg = int8,
   commutator = |<|);
-ERROR:  no schema has been selected to create in
 create operator |<| (
   procedure = abslt48,
   leftarg = int4,
   rightarg = int8,
   commutator = |<|);
-ERROR:  no schema has been selected to create in
 create operator |<| (
   procedure = abslt84,
   leftarg = int8,
   rightarg = int4,
   commutator = |<|);
-ERROR:  no schema has been selected to create in
 -- |>|
 create operator |>| (
   procedure = absgt4,
   leftarg = int4,
   rightarg = int4,
   commutator = |>|);
-ERROR:  no schema has been selected to create in
 create operator |>| (
   procedure = absgt8,
   leftarg = int8,
   rightarg = int8,
   commutator = |>|);
-ERROR:  no schema has been selected to create in
 create operator |>| (
   procedure = absgt48,
   leftarg = int4,
   rightarg = int8,
   commutator = |>|);
-ERROR:  no schema has been selected to create in
 create operator |>| (
   procedure = absgt84,
   leftarg = int8,
   rightarg = int4,
   commutator = |>|);
-ERROR:  no schema has been selected to create in
 -- |<=|
 create operator |<=| (
   procedure = absle4,
   leftarg = int4,
   rightarg = int4,
   commutator = |<=|);
-ERROR:  no schema has been selected to create in
 create operator |<=| (
   procedure = absle8,
   leftarg = int8,
   rightarg = int8,
   commutator = |<=|);
-ERROR:  no schema has been selected to create in
 create operator |<=| (
   procedure = absle48,
   leftarg = int4,
   rightarg = int8,
   commutator = |<=|);
-ERROR:  no schema has been selected to create in
  
 create operator |<=| (
   procedure = absle84,
   leftarg = int8,
   rightarg = int4,
   commutator = |<=|);
-ERROR:  no schema has been selected to create in
 -- |>=|
 create operator |>=| (
   procedure = absge4,
   leftarg = int4,
   rightarg = int4,
   commutator = |>=|);
-ERROR:  no schema has been selected to create in
 create operator |>=| (
   procedure = absge8,
   leftarg = int8,
   rightarg = int8,
   commutator = |>=|);
-ERROR:  no schema has been selected to create in
 create operator |>=| (
   procedure = absge48,
   leftarg = int4,
   rightarg = int8,
   commutator = |>=|);
-ERROR:  no schema has been selected to create in
 create operator |>=| (
   procedure = absge84,
   leftarg = int8,
   rightarg = int4,
   commutator = |>=|);
-ERROR:  no schema has been selected to create in
 --------
 create operator family abs_int_ops using btree;
-ERROR:  no schema has been selected to create in
 create operator class abs_int4_ops for type int4
   using btree FAMILY abs_int_ops  as
   operator 1 |<|,
   operator 3 |=|,
   operator 5 |>|,
   function 1 abscmp4(int4, int4);
-ERROR:  no schema has been selected to create in
 create operator class abs_int8_ops for type int8
   using btree FAMILY abs_int_ops as
   operator 1 |<|,
   operator 3 |=|,
   operator 5 |>|,
   function 1 abscmp8(int8, int8);
-ERROR:  no schema has been selected to create in
 alter operator family abs_int_ops using btree add
   -- cross-type comparisons int4 vs int8
   operator 1 |<| (int4, int8),
@@ -298,73 +251,131 @@ alter operator family abs_int_ops using btree add
   operator 4 |>=| (int8, int4),
   operator 5 |>| (int8, int4),
   function 1 abscmp84(int8, int4);
-ERROR:  operator family "abs_int_ops" does not exist for access method "btree"
---gpdb
---start_ignore
+-- gpdb
+-- start_ignore
 DROP TABLE t1;
 ERROR:  table "t1" does not exist
 DROP TABLE t2;
 ERROR:  table "t2" does not exist
+-- end_ignore
 create table t1 (a int, b int4)
 partition by list (b)
 (
   partition p1 values (1),
   partition p2 values (-1)
 );
-ERROR:  no schema has been selected to create in
-LINE 1: create table t1 (a int, b int4)
-                     ^
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 create table t2 (a int, b int8)
 partition by list (b)
 (
   partition p1 values (1),
   partition p2 values (-1)
 );
-ERROR:  no schema has been selected to create in
-LINE 1: create table t2 (a int, b int8)
-                     ^
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 insert into t1 values (1,1), (1,-1), (-1,1), (-1,-1);
-ERROR:  relation "t1" does not exist
-LINE 1: insert into t1 values (1,1), (1,-1), (-1,1), (-1,-1);
-                    ^
 insert into t2 values (1,1), (1,-1), (-1,1), (-1,-1);
-ERROR:  relation "t2" does not exist
-LINE 1: insert into t2 values (1,1), (1,-1), (-1,1), (-1,-1);
-                    ^
---end_ignore
 explain select * from t1 where t1.b |=| 1;
-ERROR:  relation "t1" does not exist
-LINE 1: explain select * from t1 where t1.b |=| 1;
-                              ^
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+   ->  Dynamic Seq Scan on t1  (cost=0.00..431.00 rows=1 width=8)
+         Number of partitions to scan: 2 (out of 2)
+         Filter: (b |=| 1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(5 rows)
+
 select * from t1 where t1.b |=| 1;
-ERROR:  relation "t1" does not exist
-LINE 1: select * from t1 where t1.b |=| 1;
-                      ^
+ a  | b  
+----+----
+ -1 | -1
+ -1 |  1
+  1 | -1
+  1 |  1
+(4 rows)
+
 explain select * from t1, t2 where t1.b = t2.b and t2.b |=| 1;
-ERROR:  relation "t1" does not exist
-LINE 1: explain select * from t1, t2 where t1.b = t2.b and t2.b |=| ...
-                              ^
+                                               QUERY PLAN                                                
+---------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=20)
+   ->  Hash Join  (cost=0.00..862.00 rows=1 width=20)
+         Hash Cond: (t2.b = (t1.b)::bigint)
+         ->  Dynamic Seq Scan on t2  (cost=0.00..431.00 rows=1 width=12)
+               Number of partitions to scan: 2 (out of 2)
+               Filter: (b |=| 1)
+         ->  Hash  (cost=431.00..431.00 rows=1 width=8)
+               ->  Partition Selector (selector id: $0)  (cost=0.00..431.00 rows=1 width=8)
+                     ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                           ->  Dynamic Seq Scan on t1  (cost=0.00..431.00 rows=1 width=8)
+                                 Number of partitions to scan: 2 (out of 2)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(12 rows)
+
 select * from t1, t2 where t1.b = t2.b and t2.b |=| 1;
-ERROR:  relation "t1" does not exist
-LINE 1: select * from t1, t2 where t1.b = t2.b and t2.b |=| 1;
-                      ^
+ a  | b  | a  | b  
+----+----+----+----
+ -1 | -1 | -1 | -1
+  1 | -1 | -1 | -1
+ -1 |  1 | -1 |  1
+  1 |  1 | -1 |  1
+ -1 | -1 |  1 | -1
+  1 | -1 |  1 | -1
+ -1 |  1 |  1 |  1
+  1 |  1 |  1 |  1
+(8 rows)
+
 explain select * from t1, t2 where t1.a = t2.a and t1.b |=| t2.b;
-ERROR:  relation "t1" does not exist
-LINE 1: explain select * from t1, t2 where t1.a = t2.a and t1.b |=| ...
-                              ^
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=20)
+   ->  Hash Join  (cost=0.00..862.00 rows=1 width=20)
+         Hash Cond: (t2.a = t1.a)
+         Join Filter: (t1.b |=| t2.b)
+         ->  Dynamic Seq Scan on t2  (cost=0.00..431.00 rows=1 width=12)
+               Number of partitions to scan: 2 (out of 2)
+         ->  Hash  (cost=431.00..431.00 rows=1 width=8)
+               ->  Dynamic Seq Scan on t1  (cost=0.00..431.00 rows=1 width=8)
+                     Number of partitions to scan: 2 (out of 2)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(10 rows)
+
 select * from t1, t2 where t1.a = t2.a and t1.b |=| t2.b;
-ERROR:  relation "t1" does not exist
-LINE 1: select * from t1, t2 where t1.a = t2.a and t1.b |=| t2.b;
-                      ^
+ a  | b  | a  | b  
+----+----+----+----
+  1 |  1 |  1 | -1
+  1 | -1 |  1 | -1
+  1 |  1 |  1 |  1
+  1 | -1 |  1 |  1
+ -1 |  1 | -1 | -1
+ -1 | -1 | -1 | -1
+ -1 |  1 | -1 |  1
+ -1 | -1 | -1 |  1
+(8 rows)
+
 explain select * from t1, t2 where t1.a = t2.a and t1.b |=| t2.b and t2.b = 1;
-ERROR:  relation "t1" does not exist
-LINE 1: explain select * from t1, t2 where t1.a = t2.a and t1.b |=| ...
-                              ^
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=20)
+   ->  Hash Join  (cost=0.00..862.00 rows=1 width=20)
+         Hash Cond: (t2.a = t1.a)
+         Join Filter: (t1.b |=| t2.b)
+         ->  Dynamic Seq Scan on t2  (cost=0.00..431.00 rows=1 width=12)
+               Number of partitions to scan: 1 (out of 2)
+               Filter: (b = 1)
+         ->  Hash  (cost=431.00..431.00 rows=1 width=8)
+               ->  Dynamic Seq Scan on t1  (cost=0.00..431.00 rows=1 width=8)
+                     Number of partitions to scan: 2 (out of 2)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(11 rows)
+
 select * from t1, t2 where t1.a = t2.a and t1.b |=| t2.b and t2.b = 1;
-ERROR:  relation "t1" does not exist
-LINE 1: select * from t1, t2 where t1.a = t2.a and t1.b |=| t2.b and...
-                      ^
+ a  | b  | a  | b 
+----+----+----+---
+ -1 |  1 | -1 | 1
+ -1 | -1 | -1 | 1
+  1 |  1 |  1 | 1
+  1 | -1 |  1 | 1
+(4 rows)
+
 -- CLEANUP
--- start_ignore
-drop schema if exists partition_prune_opfamily cascade;
--- end_ignore

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -189,7 +189,7 @@ test: rpt rpt_joins rpt_tpch rpt_returning
 # temp tables
 test: bfv_cte bfv_joins bfv_subquery bfv_planner bfv_legacy bfv_temp bfv_dml
 
-test: qp_olap_mdqa qp_misc gp_recursive_cte qp_dml_joins qp_skew qp_select
+test: qp_olap_mdqa qp_misc gp_recursive_cte qp_dml_joins qp_skew qp_select partition_prune_opfamily
 
 test: qp_misc_jiras qp_with_clause qp_executor qp_olap_windowerr qp_olap_window qp_derived_table qp_bitmapscan qp_dropped_cols
 test: qp_with_functional_inlining qp_with_functional_noinlining

--- a/src/test/regress/sql/partition_prune_opfamily.sql
+++ b/src/test/regress/sql/partition_prune_opfamily.sql
@@ -18,7 +18,7 @@
 
 -- greenplum
 create schema partition_prune_opfamily;
-set search_path=bfv_partition_plans;
+set search_path=partition_prune_opfamily;
 SET optimizer_trace_fallback=on;
 
 -- start_ignore
@@ -305,11 +305,12 @@ alter operator family abs_int_ops using btree add
   operator 5 |>| (int8, int4),
   function 1 abscmp84(int8, int4);
 
---gpdb
---start_ignore
+-- gpdb
 
+-- start_ignore
 DROP TABLE t1;
 DROP TABLE t2;
+-- end_ignore
 
 create table t1 (a int, b int4)
 partition by list (b)
@@ -327,7 +328,6 @@ partition by list (b)
 
 insert into t1 values (1,1), (1,-1), (-1,1), (-1,-1);
 insert into t2 values (1,1), (1,-1), (-1,1), (-1,-1);
---end_ignore
 
 explain select * from t1 where t1.b |=| 1;
 select * from t1 where t1.b |=| 1;
@@ -342,6 +342,7 @@ explain select * from t1, t2 where t1.a = t2.a and t1.b |=| t2.b and t2.b = 1;
 select * from t1, t2 where t1.a = t2.a and t1.b |=| t2.b and t2.b = 1;
 
 -- CLEANUP
+
 -- start_ignore
 drop schema if exists partition_prune_opfamily cascade;
 -- end_ignore

--- a/src/test/regress/sql/partition_prune_opfamily.sql
+++ b/src/test/regress/sql/partition_prune_opfamily.sql
@@ -1,0 +1,347 @@
+-- https://gist.github.com/kainwen/df7c0d3149684e1256d31b5c39e02de7#file-gp7-sql
+-- This test is included in https://github.com/greenplum-db/gpdb/issues/14982
+
+-- The test creates an operator that performs absolute value comparisons of the input data.
+-- The operator belongs to a customized btree opfamily 16433, which supports cross-type (20, 23) comparisons.
+
+-- The test then creates two tables, t1 and t2.
+-- Both are distributed by column a, and partitioned by column b.
+-- t1.a is of type int, belonging to hash opfamily 1977, which supports cross-type (20, 21, 23) comparisons.
+-- t2.a is of type int, belonging to hash opfamily 1977, which supports cross-type (20, 21, 23) comparisons.
+-- t1.b is of type int4, belonging to btree opfamily 1976, which supports cross-type (20, 21, 23) comparisons.
+-- t2.b is of type int8, belonging to btree opfamily 1976, which supports cross-type (20, 21, 23) comparisons.
+
+-- As of now, ORCA doesn't consider partition key's opfamily when performing partition pruning
+-- Internally, operator |=| of opfamily 16433 is treated as operator = of opfamily 1977 or 1976, and generated
+-- incorrect hash join condition and unjustified partition pruning. This fix compares the operator to the
+-- column's opfamily, thence deriving correct properties from the predicates.
+
+-- greenplum
+create schema partition_prune_opfamily;
+set search_path=bfv_partition_plans;
+SET optimizer_trace_fallback=on;
+
+-- start_ignore
+create language plpython3u;
+-- end_ignore
+
+-- proc for int4
+create function abseq4(a int4, b int4) returns bool as $$
+return abs(a) == abs(b)
+$$ language plpython3u strict immutable;
+
+create function abslt4(a int4, b int4) returns bool as $$
+return abs(a) < abs(b)
+$$ language plpython3u strict immutable;
+
+create function absle4(a int4, b int4) returns bool as $$
+return abs(a) <= abs(b)
+$$ language plpython3u strict immutable;
+
+create function absgt4(a int4, b int4) returns bool as $$
+return abs(a) > abs(b)
+$$ language plpython3u strict immutable;
+
+create function absge4(a int4, b int4) returns bool as $$
+return abs(a) >= abs(b)
+$$ language plpython3u strict immutable;
+
+create function abscmp4(a int4, b int4) returns int as $$
+if abs(a) < abs(b):
+    return -1
+if abs(a) > abs(b):
+    return 1
+return 0
+$$ language plpython3u strict immutable;
+
+-- procs for int8
+create function abseq8(a int8, b int8) returns bool as $$
+return abs(a) == abs(b)
+$$ language plpython3u strict immutable;
+
+create function abslt8(a int8, b int8) returns bool as $$
+return abs(a) < abs(b)
+$$ language plpython3u strict immutable;
+
+create function absle8(a int8, b int8) returns bool as $$
+return abs(a) <= abs(b)
+$$ language plpython3u strict immutable;
+
+create function absgt8(a int8, b int8) returns bool as $$
+return abs(a) > abs(b)
+$$ language plpython3u strict immutable;
+
+create function absge8(a int8, b int8) returns bool as $$
+return abs(a) >= abs(b)
+$$ language plpython3u strict immutable;
+
+create function abscmp8(a int8, b int8) returns int as $$
+if abs(a) < abs(b):
+    return -1
+if abs(a) > abs(b):
+    return 1
+return 0
+$$ language plpython3u strict immutable;
+
+-- procs for cross type int4 int8
+create function abseq48(a int4, b int8) returns bool as $$
+return abs(a) == abs(b)
+$$ language plpython3u strict immutable;
+
+create function abslt48(a int4, b int8) returns bool as $$
+return abs(a) < abs(b)
+$$ language plpython3u strict immutable;
+
+create function absle48(a int4, b int8) returns bool as $$
+return abs(a) <= abs(b)
+$$ language plpython3u strict immutable;
+
+create function absgt48(a int4, b int8) returns bool as $$
+return abs(a) > abs(b)
+$$ language plpython3u strict immutable;
+
+create function absge48(a int4, b int8) returns bool as $$
+return abs(a) >= abs(b)
+$$ language plpython3u strict immutable;
+
+create function abscmp48(a int4, b int8) returns int as $$
+if abs(a) < abs(b):
+    return -1
+if abs(a) > abs(b):
+    return 1
+return 0
+$$ language plpython3u strict immutable;
+
+--procs for cross type int8 int4
+create function abseq84(a int8, b int4) returns bool as $$
+return abs(a) == abs(b)
+$$ language plpython3u strict immutable;
+
+create function abslt84(a int8, b int4) returns bool as $$
+return abs(a) < abs(b)
+$$ language plpython3u strict immutable;
+
+create function absle84(a int8, b int4) returns bool as $$
+return abs(a) <= abs(b)
+$$ language plpython3u strict immutable;
+
+create function absgt84(a int8, b int4) returns bool as $$
+return abs(a) > abs(b)
+$$ language plpython3u strict immutable;
+
+create function absge84(a int8, b int4) returns bool as $$
+return abs(a) >= abs(b)
+$$ language plpython3u strict immutable;
+
+create function abscmp84(a int8, b int4) returns int as $$
+if abs(a) < abs(b):
+    return -1
+if abs(a) > abs(b):
+    return 1
+return 0
+$$ language plpython3u strict immutable;
+
+-- |=|
+create operator |=| (
+  procedure = abseq4,
+  leftarg = int4,
+  rightarg = int4,
+  commutator = |=|,
+  merges);
+
+create operator |=| (
+  procedure = abseq8,
+  leftarg = int8,
+  rightarg = int8,
+  commutator = |=|,
+  merges);
+
+create operator |=| (
+  procedure = abseq48,
+  leftarg = int4,
+  rightarg = int8,
+  commutator = |=|,
+  merges);
+
+create operator |=| (
+  procedure = abseq84,
+  leftarg = int8,
+  rightarg = int4,
+  commutator = |=|,
+  merges);
+
+-- |<|
+create operator |<| (
+  procedure = abslt4,
+  leftarg = int4,
+  rightarg = int4,
+  commutator = |<|);
+
+create operator |<| (
+  procedure = abslt8,
+  leftarg = int8,
+  rightarg = int8,
+  commutator = |<|);
+
+create operator |<| (
+  procedure = abslt48,
+  leftarg = int4,
+  rightarg = int8,
+  commutator = |<|);
+
+create operator |<| (
+  procedure = abslt84,
+  leftarg = int8,
+  rightarg = int4,
+  commutator = |<|);
+
+-- |>|
+create operator |>| (
+  procedure = absgt4,
+  leftarg = int4,
+  rightarg = int4,
+  commutator = |>|);
+
+create operator |>| (
+  procedure = absgt8,
+  leftarg = int8,
+  rightarg = int8,
+  commutator = |>|);
+
+create operator |>| (
+  procedure = absgt48,
+  leftarg = int4,
+  rightarg = int8,
+  commutator = |>|);
+
+create operator |>| (
+  procedure = absgt84,
+  leftarg = int8,
+  rightarg = int4,
+  commutator = |>|);
+
+-- |<=|
+create operator |<=| (
+  procedure = absle4,
+  leftarg = int4,
+  rightarg = int4,
+  commutator = |<=|);
+
+create operator |<=| (
+  procedure = absle8,
+  leftarg = int8,
+  rightarg = int8,
+  commutator = |<=|);
+
+create operator |<=| (
+  procedure = absle48,
+  leftarg = int4,
+  rightarg = int8,
+  commutator = |<=|);
+ 
+create operator |<=| (
+  procedure = absle84,
+  leftarg = int8,
+  rightarg = int4,
+  commutator = |<=|);
+
+-- |>=|
+create operator |>=| (
+  procedure = absge4,
+  leftarg = int4,
+  rightarg = int4,
+  commutator = |>=|);
+
+create operator |>=| (
+  procedure = absge8,
+  leftarg = int8,
+  rightarg = int8,
+  commutator = |>=|);
+
+create operator |>=| (
+  procedure = absge48,
+  leftarg = int4,
+  rightarg = int8,
+  commutator = |>=|);
+
+create operator |>=| (
+  procedure = absge84,
+  leftarg = int8,
+  rightarg = int4,
+  commutator = |>=|);
+
+--------
+
+create operator family abs_int_ops using btree;
+
+create operator class abs_int4_ops for type int4
+  using btree FAMILY abs_int_ops  as
+  operator 1 |<|,
+  operator 3 |=|,
+  operator 5 |>|,
+  function 1 abscmp4(int4, int4);
+
+create operator class abs_int8_ops for type int8
+  using btree FAMILY abs_int_ops as
+  operator 1 |<|,
+  operator 3 |=|,
+  operator 5 |>|,
+  function 1 abscmp8(int8, int8);
+
+alter operator family abs_int_ops using btree add
+  -- cross-type comparisons int4 vs int8
+  operator 1 |<| (int4, int8),
+  operator 2 |<=| (int4, int8),
+  operator 3 |=| (int4, int8),
+  operator 4 |>=| (int4, int8),
+  operator 5 |>| (int4, int8),
+  function 1 abscmp48(int4, int8),
+  
+  -- cross-type comparisons int8 vs int4
+  operator 1 |<| (int8, int4),
+  operator 2 |<=| (int8, int4),
+  operator 3 |=| (int8, int4),
+  operator 4 |>=| (int8, int4),
+  operator 5 |>| (int8, int4),
+  function 1 abscmp84(int8, int4);
+
+--gpdb
+--start_ignore
+
+DROP TABLE t1;
+DROP TABLE t2;
+
+create table t1 (a int, b int4)
+partition by list (b)
+(
+  partition p1 values (1),
+  partition p2 values (-1)
+);
+
+create table t2 (a int, b int8)
+partition by list (b)
+(
+  partition p1 values (1),
+  partition p2 values (-1)
+);
+
+insert into t1 values (1,1), (1,-1), (-1,1), (-1,-1);
+insert into t2 values (1,1), (1,-1), (-1,1), (-1,-1);
+--end_ignore
+
+explain select * from t1 where t1.b |=| 1;
+select * from t1 where t1.b |=| 1;
+
+explain select * from t1, t2 where t1.b = t2.b and t2.b |=| 1;
+select * from t1, t2 where t1.b = t2.b and t2.b |=| 1;
+
+explain select * from t1, t2 where t1.a = t2.a and t1.b |=| t2.b;
+select * from t1, t2 where t1.a = t2.a and t1.b |=| t2.b;
+
+explain select * from t1, t2 where t1.a = t2.a and t1.b |=| t2.b and t2.b = 1;
+select * from t1, t2 where t1.a = t2.a and t1.b |=| t2.b and t2.b = 1;
+
+-- CLEANUP
+-- start_ignore
+drop schema if exists partition_prune_opfamily cascade;
+-- end_ignore


### PR DESCRIPTION
**Issue**
As of now, ORCA's constraint framework takes limited consideration for opfamilies while deriving properties from predicates. This has caused issues like missing motion, incorrect direct dispatch, incorrect static and dynamic partition pruning.

**Root cause**
In order for the query planning to take advantage of the existing data distribution or partition, i.e. avoid unnecessary motions or partition scanning, we have to ensure the predicate's operator belongs to distribution or partition key's opfamily. When this check is missing, we could end up with incorrect plans and results, by failing to trigger necessary motions, or scan required partitions.

**Solution**
The core idea is, compare the operator to the distribution key's opfamily when evaluating a hash join condition; and compare the operator to the partition key's opfamily when evaluating a partition filter.

**Implementation**
The implementation is much more pervasive than the summary above. This is because the same predicate is evaluated many times for different purposes in query planning. This PR addresses four areas:
1. Building equivalence class to optimize join order and join conditions (refactoring PR #14986)
2. Explicit cast of hash join condition
3. Extract predicates on partition keys, used in dynamic partition pruning
4. Deriving interval from const predicate, used in direct dispatch and static partition pruning

As of now, the metadata only has information on a column's distribution opfamily. So our first step is to include the partition opfamily. For ease of review, the PR is split into three commits. It will be merged as a single commit.
1. Derive column's partition (btree) opfamily
2. Compare the operator to the column's opfamily. Depending on whether the predicate is used as a hash join condition, or a partition filter, we look at the column's hash or btree opfamily.
3. Tests

**Future work**
This PR addresses a few queries that failed for not considering the distribution or partition key's opfamily in logical planning. We expect to find similar errors in the constraint framework and scalar expression evaluation, and we will address them case by case. Going from logical to physical planning, we need to keep checking opfamilies to not miss critical motions.

Fix https://github.com/greenplum-db/gpdb/issues/14887
Fix https://github.com/greenplum-db/gpdb/issues/14982