### PR TITLE
Collect vacuum stats for append-optimized tables

### DIFF
--- a/src/backend/commands/vacuum_ao.c
+++ b/src/backend/commands/vacuum_ao.c
@@ -156,7 +156,7 @@ static bool appendonly_tid_reaped(ItemPointer itemptr, void *state);
 
 static void vacuum_appendonly_fill_stats(Relation aorel, Snapshot snapshot, int elevel,
 										 BlockNumber *rel_pages, double *rel_tuples,
-										 bool *relhasindex);
+										 double *dead_tuples, bool *relhasindex);
 static int vacuum_appendonly_indexes(Relation aoRelation, int options, Bitmapset *dead_segs,
 									 BufferAccessStrategy bstrategy, AOVacuumRelStats *vacrelstats);
 static void ao_vacuum_rel_recycle_dead_segments(Relation onerel, VacuumParams *params,
@@ -235,6 +235,7 @@ ao_vacuum_rel_post_cleanup(Relation onerel, VacuumParams *params, BufferAccessSt
 {
 	BlockNumber	relpages;
 	double		reltuples;
+	double		deadtuples;
 	bool		relhasindex;
 	int			elevel;
 	int			options = params->options;
@@ -277,6 +278,7 @@ ao_vacuum_rel_post_cleanup(Relation onerel, VacuumParams *params, BufferAccessSt
 								 elevel,
 								 &relpages,
 								 &reltuples,
+								 &deadtuples,
 								 &relhasindex);
 
 	vacuum_set_xid_limits(onerel,
@@ -297,6 +299,12 @@ ao_vacuum_rel_post_cleanup(Relation onerel, VacuumParams *params, BufferAccessSt
 						MultiXactCutoff,
 						false,
 						true /* isvacuum */);
+
+	/* report results to the stats collector, too */
+	pgstat_report_vacuum(RelationGetRelid(onerel),
+						 onerel->rd_rel->relisshared,
+						 reltuples,
+						 deadtuples);
 
 	SIMPLE_FAULT_INJECTOR("vacuum_ao_post_cleanup_end");
 }
@@ -675,7 +683,7 @@ appendonly_tid_reaped(ItemPointer itemptr, void *state)
 static void
 vacuum_appendonly_fill_stats(Relation aorel, Snapshot snapshot, int elevel,
 							 BlockNumber *rel_pages, double *rel_tuples,
-							 bool *relhasindex)
+							 double *dead_tuples, bool *relhasindex)
 {
 	FileSegTotals *fstotal;
 	BlockNumber nblocks;
@@ -726,6 +734,7 @@ vacuum_appendonly_fill_stats(Relation aorel, Snapshot snapshot, int elevel,
 
 	*rel_pages = nblocks;
 	*rel_tuples = num_tuples;
+	*dead_tuples = hidden_tupcount;
 	*relhasindex = aorel->rd_rel->relhasindex;
 
 	ereport(elevel,

--- a/src/test/isolation2/expected/setup.out
+++ b/src/test/isolation2/expected/setup.out
@@ -135,3 +135,7 @@ CREATE
 -- to accept connections for a while despite undergoing PANIC.
 CREATE OR REPLACE FUNCTION wait_till_master_shutsdown() RETURNS void AS $$ DECLARE i int; /* in func */ BEGIN i := 0; /* in func */ while i < 120 loop i := i + 1; /* in func */ PERFORM pg_sleep(.5); /* in func */ end loop; /* in func */ END; /* in func */ $$ LANGUAGE plpgsql;
 CREATE
+
+-- Helper function that ensures stats collector receives stat from the latest operation.
+create or replace function wait_until_dead_tup_change_to(relid oid, stat_val_expected bigint) returns text as $$ declare stat_val int; /* in func */ i int; /* in func */ begin i := 0; /* in func */ while i < 1200 loop select pg_stat_get_dead_tuples(relid) into stat_val; /* in func */ if stat_val = stat_val_expected then /* in func */ return 'OK'; /* in func */ end if; /* in func */ perform pg_sleep(0.1); /* in func */ perform pg_stat_clear_snapshot(); /* in func */ i := i + 1; /* in func */ end loop; /* in func */ return 'Fail'; /* in func */ end; /* in func */ $$ language plpgsql;
+CREATE

--- a/src/test/isolation2/expected/vacuum_progress_column.out
+++ b/src/test/isolation2/expected/vacuum_progress_column.out
@@ -4,10 +4,6 @@
 set default_table_access_method=ao_column;
 SET
 
--- Helper function that ensures stats collector receives stat from the latest operation.
-create or replace function wait_until_dead_tup_change_to(relid oid, stat_val_expected bigint) returns text as $$ declare stat_val int; /* in func */ i int; /* in func */ begin i := 0; /* in func */ while i < 1200 loop select pg_stat_get_dead_tuples(relid) into stat_val; /* in func */ if stat_val = stat_val_expected then /* in func */ return 'OK'; /* in func */ end if; /* in func */ perform pg_sleep(0.1); /* in func */ perform pg_stat_clear_snapshot(); /* in func */ i := i + 1; /* in func */ end loop; /* in func */ return 'Fail'; /* in func */ end; /* in func */ $$ language plpgsql;
-CREATE
-
 -- Setup the append-optimized table to be vacuumed
 DROP TABLE IF EXISTS vacuum_progress_ao_column;
 DROP

--- a/src/test/isolation2/expected/vacuum_progress_column.out
+++ b/src/test/isolation2/expected/vacuum_progress_column.out
@@ -4,6 +4,10 @@
 set default_table_access_method=ao_column;
 SET
 
+-- Helper function that ensures stats collector receives stat from the latest operation.
+create or replace function wait_until_dead_tup_change_to(relid oid, stat_val_expected bigint) returns text as $$ declare stat_val int; /* in func */ i int; /* in func */ begin i := 0; /* in func */ while i < 1200 loop select pg_stat_get_dead_tuples(relid) into stat_val; /* in func */ if stat_val = stat_val_expected then /* in func */ return 'OK'; /* in func */ end if; /* in func */ perform pg_sleep(0.1); /* in func */ perform pg_stat_clear_snapshot(); /* in func */ i := i + 1; /* in func */ end loop; /* in func */ return 'Fail'; /* in func */ end; /* in func */ $$ language plpgsql;
+CREATE
+
 -- Setup the append-optimized table to be vacuumed
 DROP TABLE IF EXISTS vacuum_progress_ao_column;
 DROP
@@ -44,6 +48,18 @@ ABORT
 -- Also delete half of the tuples evenly before the EOF of segno 2.
 DELETE FROM vacuum_progress_ao_column where j % 2 = 0;
 DELETE 50000
+
+-- Lookup pg_class and collected stats view before VACUUM
+SELECT relpages, reltuples, relallvisible FROM pg_class where relname = 'vacuum_progress_ao_column';
+ relpages | reltuples | relallvisible 
+----------+-----------+---------------
+ 0        | 0         | 0             
+(1 row)
+SELECT n_live_tup, n_dead_tup, vacuum_count FROM pg_stat_all_tables WHERE relname = 'vacuum_progress_ao_column';
+ n_live_tup | n_dead_tup | vacuum_count 
+------------+------------+--------------
+ 100000     | 200000     | 0            
+(1 row)
 
 -- Perform VACUUM and observe the progress
 
@@ -145,6 +161,24 @@ SELECT gp_inject_fault('vacuum_ao_post_cleanup_end', 'reset', dbid) FROM gp_segm
 1<:  <... completed>
 VACUUM
 
+-- pg_class and collected stats view should be updated after the 1st VACUUM
+1U: SELECT wait_until_dead_tup_change_to('vacuum_progress_ao_column'::regclass::oid, 0);
+ wait_until_dead_tup_change_to 
+-------------------------------
+ OK                            
+(1 row)
+SELECT relpages, reltuples, relallvisible FROM pg_class where relname = 'vacuum_progress_ao_column';
+ relpages | reltuples | relallvisible 
+----------+-----------+---------------
+ 37       | 50000     | 0             
+(1 row)
+SELECT n_live_tup, n_dead_tup, vacuum_count FROM pg_stat_all_tables WHERE relname = 'vacuum_progress_ao_column';
+ n_live_tup | n_dead_tup | vacuum_count 
+------------+------------+--------------
+ 50000      | 0          | 1            
+(1 row)
+
+
 -- Perform VACUUM again to recycle the remaining awaiting drop segment marked by the previous run.
 SELECT gp_inject_fault('vacuum_ao_after_index_delete', 'suspend', dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
  gp_inject_fault 
@@ -206,6 +240,23 @@ VACUUM
  relname | phase | heap_blks_total | heap_blks_scanned | heap_blks_vacuumed | index_vacuum_count | max_dead_tuples | num_dead_tuples 
 ---------+-------+-----------------+-------------------+--------------------+--------------------+-----------------+-----------------
 (0 rows)
+
+-- pg_class and collected stats view should be updated after the 2nd VACUUM
+1U: SELECT wait_until_dead_tup_change_to('vacuum_progress_ao_column'::regclass::oid, 0);
+ wait_until_dead_tup_change_to 
+-------------------------------
+ OK                            
+(1 row)
+SELECT relpages, reltuples, relallvisible FROM pg_class where relname = 'vacuum_progress_ao_column';
+ relpages | reltuples | relallvisible 
+----------+-----------+---------------
+ 13       | 50000     | 0             
+(1 row)
+SELECT n_live_tup, n_dead_tup, vacuum_count FROM pg_stat_all_tables WHERE relname = 'vacuum_progress_ao_column';
+ n_live_tup | n_dead_tup | vacuum_count 
+------------+------------+--------------
+ 50000      | 0          | 2            
+(1 row)
 
 -- Cleanup
 SELECT gp_inject_fault_infinite('all', 'reset', dbid) FROM gp_segment_configuration;

--- a/src/test/isolation2/expected/vacuum_progress_column.out
+++ b/src/test/isolation2/expected/vacuum_progress_column.out
@@ -51,10 +51,10 @@ SELECT relpages, reltuples, relallvisible FROM pg_class where relname = 'vacuum_
 ----------+-----------+---------------
  0        | 0         | 0             
 (1 row)
-SELECT n_live_tup, n_dead_tup, vacuum_count FROM pg_stat_all_tables WHERE relname = 'vacuum_progress_ao_column';
- n_live_tup | n_dead_tup | vacuum_count 
-------------+------------+--------------
- 100000     | 200000     | 0            
+SELECT n_live_tup, n_dead_tup, last_vacuum, vacuum_count FROM pg_stat_all_tables WHERE relname = 'vacuum_progress_ao_column';
+ n_live_tup | n_dead_tup | last_vacuum | vacuum_count 
+------------+------------+-------------+--------------
+ 100000     | 200000     |             | 0            
 (1 row)
 
 -- Perform VACUUM and observe the progress
@@ -168,10 +168,10 @@ SELECT relpages, reltuples, relallvisible FROM pg_class where relname = 'vacuum_
 ----------+-----------+---------------
  37       | 50000     | 0             
 (1 row)
-SELECT n_live_tup, n_dead_tup, vacuum_count FROM pg_stat_all_tables WHERE relname = 'vacuum_progress_ao_column';
- n_live_tup | n_dead_tup | vacuum_count 
-------------+------------+--------------
- 50000      | 0          | 1            
+SELECT n_live_tup, n_dead_tup, last_vacuum is not null as has_last_vacuum, vacuum_count FROM pg_stat_all_tables WHERE relname = 'vacuum_progress_ao_column';
+ n_live_tup | n_dead_tup | has_last_vacuum | vacuum_count 
+------------+------------+-----------------+--------------
+ 50000      | 0          | t               | 1            
 (1 row)
 
 
@@ -248,10 +248,10 @@ SELECT relpages, reltuples, relallvisible FROM pg_class where relname = 'vacuum_
 ----------+-----------+---------------
  13       | 50000     | 0             
 (1 row)
-SELECT n_live_tup, n_dead_tup, vacuum_count FROM pg_stat_all_tables WHERE relname = 'vacuum_progress_ao_column';
- n_live_tup | n_dead_tup | vacuum_count 
-------------+------------+--------------
- 50000      | 0          | 2            
+SELECT n_live_tup, n_dead_tup, last_vacuum is not null as has_last_vacuum, vacuum_count FROM pg_stat_all_tables WHERE relname = 'vacuum_progress_ao_column';
+ n_live_tup | n_dead_tup | has_last_vacuum | vacuum_count 
+------------+------------+-----------------+--------------
+ 50000      | 0          | t               | 2            
 (1 row)
 
 -- Cleanup

--- a/src/test/isolation2/expected/vacuum_progress_row.out
+++ b/src/test/isolation2/expected/vacuum_progress_row.out
@@ -4,10 +4,6 @@
 set default_table_access_method=ao_row;
 SET
 
--- Helper function that ensures stats collector receives stat from the latest operation.
-create or replace function wait_until_dead_tup_change_to(relid oid, stat_val_expected bigint) returns text as $$ declare stat_val int; /* in func */ i int; /* in func */ begin i := 0; /* in func */ while i < 1200 loop select pg_stat_get_dead_tuples(relid) into stat_val; /* in func */ if stat_val = stat_val_expected then /* in func */ return 'OK'; /* in func */ end if; /* in func */ perform pg_sleep(0.1); /* in func */ perform pg_stat_clear_snapshot(); /* in func */ i := i + 1; /* in func */ end loop; /* in func */ return 'Fail'; /* in func */ end; /* in func */ $$ language plpgsql;
-CREATE
-
 -- Setup the append-optimized table to be vacuumed
 DROP TABLE IF EXISTS vacuum_progress_ao_row;
 DROP

--- a/src/test/isolation2/expected/vacuum_progress_row.out
+++ b/src/test/isolation2/expected/vacuum_progress_row.out
@@ -4,6 +4,10 @@
 set default_table_access_method=ao_row;
 SET
 
+-- Helper function that ensures stats collector receives stat from the latest operation.
+create or replace function wait_until_dead_tup_change_to(relid oid, stat_val_expected bigint) returns text as $$ declare stat_val int; /* in func */ i int; /* in func */ begin i := 0; /* in func */ while i < 1200 loop select pg_stat_get_dead_tuples(relid) into stat_val; /* in func */ if stat_val = stat_val_expected then /* in func */ return 'OK'; /* in func */ end if; /* in func */ perform pg_sleep(0.1); /* in func */ perform pg_stat_clear_snapshot(); /* in func */ i := i + 1; /* in func */ end loop; /* in func */ return 'Fail'; /* in func */ end; /* in func */ $$ language plpgsql;
+CREATE
+
 -- Setup the append-optimized table to be vacuumed
 DROP TABLE IF EXISTS vacuum_progress_ao_row;
 DROP
@@ -44,6 +48,18 @@ ABORT
 -- Also delete half of the tuples evenly before the EOF of segno 2.
 DELETE FROM vacuum_progress_ao_row where j % 2 = 0;
 DELETE 50000
+
+-- Lookup pg_class and collected stats view before VACUUM
+SELECT relpages, reltuples, relallvisible FROM pg_class where relname = 'vacuum_progress_ao_row';
+ relpages | reltuples | relallvisible 
+----------+-----------+---------------
+ 0        | 0         | 0             
+(1 row)
+SELECT n_live_tup, n_dead_tup, vacuum_count FROM pg_stat_all_tables WHERE relname = 'vacuum_progress_ao_row';
+ n_live_tup | n_dead_tup | vacuum_count 
+------------+------------+--------------
+ 100000     | 200000     | 0            
+(1 row)
 
 -- Perform VACUUM and observe the progress
 
@@ -145,6 +161,23 @@ SELECT gp_inject_fault('vacuum_ao_post_cleanup_end', 'reset', dbid) FROM gp_segm
 1<:  <... completed>
 VACUUM
 
+-- pg_class and collected stats view should be updated after the 1st VACUUM
+1U: SELECT wait_until_dead_tup_change_to('vacuum_progress_ao_row'::regclass::oid, 0);
+ wait_until_dead_tup_change_to 
+-------------------------------
+ OK                            
+(1 row)
+SELECT relpages, reltuples, relallvisible FROM pg_class where relname = 'vacuum_progress_ao_row';
+ relpages | reltuples | relallvisible 
+----------+-----------+---------------
+ 83       | 50000     | 0             
+(1 row)
+SELECT n_live_tup, n_dead_tup, vacuum_count FROM pg_stat_all_tables WHERE relname = 'vacuum_progress_ao_row';
+ n_live_tup | n_dead_tup | vacuum_count 
+------------+------------+--------------
+ 50000      | 0          | 1            
+(1 row)
+
 -- Perform VACUUM again to recycle the remaining awaiting drop segment marked by the previous run.
 SELECT gp_inject_fault('vacuum_ao_after_index_delete', 'suspend', dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
  gp_inject_fault 
@@ -201,11 +234,28 @@ SELECT gp_inject_fault('appendonly_after_truncate_segment_file', 'reset', dbid) 
 1<:  <... completed>
 VACUUM
 
--- Vacuum has finished, nothing should show up in the view.
+-- Vacuum has finished, nothing should show up in the progress view.
 1U: select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, heap_blks_vacuumed, index_vacuum_count, max_dead_tuples, num_dead_tuples from pg_stat_progress_vacuum;
  relname | phase | heap_blks_total | heap_blks_scanned | heap_blks_vacuumed | index_vacuum_count | max_dead_tuples | num_dead_tuples 
 ---------+-------+-----------------+-------------------+--------------------+--------------------+-----------------+-----------------
 (0 rows)
+
+-- pg_class and collected stats view should be updated after the 2nd VACUUM
+1U: SELECT wait_until_dead_tup_change_to('vacuum_progress_ao_row'::regclass::oid, 0);
+ wait_until_dead_tup_change_to 
+-------------------------------
+ OK                            
+(1 row)
+SELECT relpages, reltuples, relallvisible FROM pg_class where relname = 'vacuum_progress_ao_row';
+ relpages | reltuples | relallvisible 
+----------+-----------+---------------
+ 28       | 50000     | 0             
+(1 row)
+SELECT n_live_tup, n_dead_tup, vacuum_count FROM pg_stat_all_tables WHERE relname = 'vacuum_progress_ao_row';
+ n_live_tup | n_dead_tup | vacuum_count 
+------------+------------+--------------
+ 50000      | 0          | 2            
+(1 row)
 
 -- Cleanup
 SELECT gp_inject_fault_infinite('all', 'reset', dbid) FROM gp_segment_configuration;

--- a/src/test/isolation2/expected/vacuum_progress_row.out
+++ b/src/test/isolation2/expected/vacuum_progress_row.out
@@ -51,10 +51,10 @@ SELECT relpages, reltuples, relallvisible FROM pg_class where relname = 'vacuum_
 ----------+-----------+---------------
  0        | 0         | 0             
 (1 row)
-SELECT n_live_tup, n_dead_tup, vacuum_count FROM pg_stat_all_tables WHERE relname = 'vacuum_progress_ao_row';
- n_live_tup | n_dead_tup | vacuum_count 
-------------+------------+--------------
- 100000     | 200000     | 0            
+SELECT n_live_tup, n_dead_tup, last_vacuum, vacuum_count FROM pg_stat_all_tables WHERE relname = 'vacuum_progress_ao_row';
+ n_live_tup | n_dead_tup | last_vacuum | vacuum_count 
+------------+------------+-------------+--------------
+ 100000     | 200000     |             | 0            
 (1 row)
 
 -- Perform VACUUM and observe the progress
@@ -168,10 +168,10 @@ SELECT relpages, reltuples, relallvisible FROM pg_class where relname = 'vacuum_
 ----------+-----------+---------------
  83       | 50000     | 0             
 (1 row)
-SELECT n_live_tup, n_dead_tup, vacuum_count FROM pg_stat_all_tables WHERE relname = 'vacuum_progress_ao_row';
- n_live_tup | n_dead_tup | vacuum_count 
-------------+------------+--------------
- 50000      | 0          | 1            
+SELECT n_live_tup, n_dead_tup, last_vacuum is not null as has_last_vacuum, vacuum_count FROM pg_stat_all_tables WHERE relname = 'vacuum_progress_ao_row';
+ n_live_tup | n_dead_tup | has_last_vacuum | vacuum_count 
+------------+------------+-----------------+--------------
+ 50000      | 0          | t               | 1            
 (1 row)
 
 -- Perform VACUUM again to recycle the remaining awaiting drop segment marked by the previous run.
@@ -247,10 +247,10 @@ SELECT relpages, reltuples, relallvisible FROM pg_class where relname = 'vacuum_
 ----------+-----------+---------------
  28       | 50000     | 0             
 (1 row)
-SELECT n_live_tup, n_dead_tup, vacuum_count FROM pg_stat_all_tables WHERE relname = 'vacuum_progress_ao_row';
- n_live_tup | n_dead_tup | vacuum_count 
-------------+------------+--------------
- 50000      | 0          | 2            
+SELECT n_live_tup, n_dead_tup, last_vacuum is not null as has_last_vacuum, vacuum_count FROM pg_stat_all_tables WHERE relname = 'vacuum_progress_ao_row';
+ n_live_tup | n_dead_tup | has_last_vacuum | vacuum_count 
+------------+------------+-----------------+--------------
+ 50000      | 0          | t               | 2            
 (1 row)
 
 -- Cleanup

--- a/src/test/isolation2/sql/setup.sql
+++ b/src/test/isolation2/sql/setup.sql
@@ -399,3 +399,24 @@ $$
     end loop; /* in func */
   END; /* in func */
 $$ LANGUAGE plpgsql;
+
+-- Helper function that ensures stats collector receives stat from the latest operation.
+create or replace function wait_until_dead_tup_change_to(relid oid, stat_val_expected bigint)
+    returns text as $$
+declare
+    stat_val int; /* in func */
+    i int; /* in func */
+begin
+    i := 0; /* in func */
+    while i < 1200 loop
+            select pg_stat_get_dead_tuples(relid) into stat_val; /* in func */
+            if stat_val = stat_val_expected then /* in func */
+                return 'OK'; /* in func */
+            end if; /* in func */
+            perform pg_sleep(0.1); /* in func */
+            perform pg_stat_clear_snapshot(); /* in func */
+            i := i + 1; /* in func */
+        end loop; /* in func */
+    return 'Fail'; /* in func */
+end; /* in func */
+$$ language plpgsql;

--- a/src/test/isolation2/sql/vacuum_progress_column.sql
+++ b/src/test/isolation2/sql/vacuum_progress_column.sql
@@ -3,27 +3,6 @@
 
 set default_table_access_method=ao_column;
 
--- Helper function that ensures stats collector receives stat from the latest operation.
-create or replace function wait_until_dead_tup_change_to(relid oid, stat_val_expected bigint)
-    returns text as $$
-declare
-    stat_val int; /* in func */
-    i int; /* in func */
-begin
-    i := 0; /* in func */
-    while i < 1200 loop
-            select pg_stat_get_dead_tuples(relid) into stat_val; /* in func */
-            if stat_val = stat_val_expected then /* in func */
-                return 'OK'; /* in func */
-            end if; /* in func */
-            perform pg_sleep(0.1); /* in func */
-            perform pg_stat_clear_snapshot(); /* in func */
-            i := i + 1; /* in func */
-        end loop; /* in func */
-    return 'Fail'; /* in func */
-end; /* in func */
-$$ language plpgsql;
-
 -- Setup the append-optimized table to be vacuumed
 DROP TABLE IF EXISTS vacuum_progress_ao_column;
 CREATE TABLE vacuum_progress_ao_column(i int, j int);

--- a/src/test/isolation2/sql/vacuum_progress_column.sql
+++ b/src/test/isolation2/sql/vacuum_progress_column.sql
@@ -32,7 +32,7 @@ DELETE FROM vacuum_progress_ao_column where j % 2 = 0;
 
 -- Lookup pg_class and collected stats view before VACUUM
 SELECT relpages, reltuples, relallvisible FROM pg_class where relname = 'vacuum_progress_ao_column';
-SELECT n_live_tup, n_dead_tup, vacuum_count FROM pg_stat_all_tables WHERE relname = 'vacuum_progress_ao_column';
+SELECT n_live_tup, n_dead_tup, last_vacuum, vacuum_count FROM pg_stat_all_tables WHERE relname = 'vacuum_progress_ao_column';
 
 -- Perform VACUUM and observe the progress
 
@@ -71,7 +71,7 @@ SELECT gp_inject_fault('vacuum_ao_post_cleanup_end', 'reset', dbid) FROM gp_segm
 -- pg_class and collected stats view should be updated after the 1st VACUUM
 1U: SELECT wait_until_dead_tup_change_to('vacuum_progress_ao_column'::regclass::oid, 0);
 SELECT relpages, reltuples, relallvisible FROM pg_class where relname = 'vacuum_progress_ao_column';
-SELECT n_live_tup, n_dead_tup, vacuum_count FROM pg_stat_all_tables WHERE relname = 'vacuum_progress_ao_column';
+SELECT n_live_tup, n_dead_tup, last_vacuum is not null as has_last_vacuum, vacuum_count FROM pg_stat_all_tables WHERE relname = 'vacuum_progress_ao_column';
 
 
 -- Perform VACUUM again to recycle the remaining awaiting drop segment marked by the previous run.
@@ -99,7 +99,7 @@ SELECT gp_inject_fault('appendonly_after_truncate_segment_file', 'reset', dbid) 
 -- pg_class and collected stats view should be updated after the 2nd VACUUM
 1U: SELECT wait_until_dead_tup_change_to('vacuum_progress_ao_column'::regclass::oid, 0);
 SELECT relpages, reltuples, relallvisible FROM pg_class where relname = 'vacuum_progress_ao_column';
-SELECT n_live_tup, n_dead_tup, vacuum_count FROM pg_stat_all_tables WHERE relname = 'vacuum_progress_ao_column';
+SELECT n_live_tup, n_dead_tup, last_vacuum is not null as has_last_vacuum, vacuum_count FROM pg_stat_all_tables WHERE relname = 'vacuum_progress_ao_column';
 
 -- Cleanup
 SELECT gp_inject_fault_infinite('all', 'reset', dbid) FROM gp_segment_configuration;

--- a/src/test/isolation2/sql/vacuum_progress_row.sql
+++ b/src/test/isolation2/sql/vacuum_progress_row.sql
@@ -32,7 +32,7 @@ DELETE FROM vacuum_progress_ao_row where j % 2 = 0;
 
 -- Lookup pg_class and collected stats view before VACUUM
 SELECT relpages, reltuples, relallvisible FROM pg_class where relname = 'vacuum_progress_ao_row';
-SELECT n_live_tup, n_dead_tup, vacuum_count FROM pg_stat_all_tables WHERE relname = 'vacuum_progress_ao_row';
+SELECT n_live_tup, n_dead_tup, last_vacuum, vacuum_count FROM pg_stat_all_tables WHERE relname = 'vacuum_progress_ao_row';
 
 -- Perform VACUUM and observe the progress
 
@@ -71,7 +71,7 @@ SELECT gp_inject_fault('vacuum_ao_post_cleanup_end', 'reset', dbid) FROM gp_segm
 -- pg_class and collected stats view should be updated after the 1st VACUUM
 1U: SELECT wait_until_dead_tup_change_to('vacuum_progress_ao_row'::regclass::oid, 0);
 SELECT relpages, reltuples, relallvisible FROM pg_class where relname = 'vacuum_progress_ao_row';
-SELECT n_live_tup, n_dead_tup, vacuum_count FROM pg_stat_all_tables WHERE relname = 'vacuum_progress_ao_row';
+SELECT n_live_tup, n_dead_tup, last_vacuum is not null as has_last_vacuum, vacuum_count FROM pg_stat_all_tables WHERE relname = 'vacuum_progress_ao_row';
 
 -- Perform VACUUM again to recycle the remaining awaiting drop segment marked by the previous run.
 SELECT gp_inject_fault('vacuum_ao_after_index_delete', 'suspend', dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
@@ -98,7 +98,7 @@ SELECT gp_inject_fault('appendonly_after_truncate_segment_file', 'reset', dbid) 
 -- pg_class and collected stats view should be updated after the 2nd VACUUM
 1U: SELECT wait_until_dead_tup_change_to('vacuum_progress_ao_row'::regclass::oid, 0);
 SELECT relpages, reltuples, relallvisible FROM pg_class where relname = 'vacuum_progress_ao_row';
-SELECT n_live_tup, n_dead_tup, vacuum_count FROM pg_stat_all_tables WHERE relname = 'vacuum_progress_ao_row';
+SELECT n_live_tup, n_dead_tup, last_vacuum is not null as has_last_vacuum, vacuum_count FROM pg_stat_all_tables WHERE relname = 'vacuum_progress_ao_row';
 
 -- Cleanup
 SELECT gp_inject_fault_infinite('all', 'reset', dbid) FROM gp_segment_configuration;

--- a/src/test/isolation2/sql/vacuum_progress_row.sql
+++ b/src/test/isolation2/sql/vacuum_progress_row.sql
@@ -3,27 +3,6 @@
 
 set default_table_access_method=ao_row;
 
--- Helper function that ensures stats collector receives stat from the latest operation.
-create or replace function wait_until_dead_tup_change_to(relid oid, stat_val_expected bigint)
-    returns text as $$
-declare
-    stat_val int; /* in func */
-    i int; /* in func */
-begin
-    i := 0; /* in func */
-    while i < 1200 loop
-            select pg_stat_get_dead_tuples(relid) into stat_val; /* in func */
-            if stat_val = stat_val_expected then /* in func */
-                return 'OK'; /* in func */
-            end if; /* in func */
-            perform pg_sleep(0.1); /* in func */
-            perform pg_stat_clear_snapshot(); /* in func */
-            i := i + 1; /* in func */
-        end loop; /* in func */
-    return 'Fail'; /* in func */
-end; /* in func */
-$$ language plpgsql;
-
 -- Setup the append-optimized table to be vacuumed
 DROP TABLE IF EXISTS vacuum_progress_ao_row;
 CREATE TABLE vacuum_progress_ao_row(i int, j int);

--- a/src/test/isolation2/sql/vacuum_progress_row.sql
+++ b/src/test/isolation2/sql/vacuum_progress_row.sql
@@ -3,6 +3,27 @@
 
 set default_table_access_method=ao_row;
 
+-- Helper function that ensures stats collector receives stat from the latest operation.
+create or replace function wait_until_dead_tup_change_to(relid oid, stat_val_expected bigint)
+    returns text as $$
+declare
+    stat_val int; /* in func */
+    i int; /* in func */
+begin
+    i := 0; /* in func */
+    while i < 1200 loop
+            select pg_stat_get_dead_tuples(relid) into stat_val; /* in func */
+            if stat_val = stat_val_expected then /* in func */
+                return 'OK'; /* in func */
+            end if; /* in func */
+            perform pg_sleep(0.1); /* in func */
+            perform pg_stat_clear_snapshot(); /* in func */
+            i := i + 1; /* in func */
+        end loop; /* in func */
+    return 'Fail'; /* in func */
+end; /* in func */
+$$ language plpgsql;
+
 -- Setup the append-optimized table to be vacuumed
 DROP TABLE IF EXISTS vacuum_progress_ao_row;
 CREATE TABLE vacuum_progress_ao_row(i int, j int);
@@ -29,6 +50,10 @@ CREATE INDEX on vacuum_progress_ao_row(j);
 
 -- Also delete half of the tuples evenly before the EOF of segno 2.
 DELETE FROM vacuum_progress_ao_row where j % 2 = 0;
+
+-- Lookup pg_class and collected stats view before VACUUM
+SELECT relpages, reltuples, relallvisible FROM pg_class where relname = 'vacuum_progress_ao_row';
+SELECT n_live_tup, n_dead_tup, vacuum_count FROM pg_stat_all_tables WHERE relname = 'vacuum_progress_ao_row';
 
 -- Perform VACUUM and observe the progress
 
@@ -64,6 +89,11 @@ SELECT gp_wait_until_triggered_fault('vacuum_ao_post_cleanup_end', 1, dbid) FROM
 SELECT gp_inject_fault('vacuum_ao_post_cleanup_end', 'reset', dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
 1<:
 
+-- pg_class and collected stats view should be updated after the 1st VACUUM
+1U: SELECT wait_until_dead_tup_change_to('vacuum_progress_ao_row'::regclass::oid, 0);
+SELECT relpages, reltuples, relallvisible FROM pg_class where relname = 'vacuum_progress_ao_row';
+SELECT n_live_tup, n_dead_tup, vacuum_count FROM pg_stat_all_tables WHERE relname = 'vacuum_progress_ao_row';
+
 -- Perform VACUUM again to recycle the remaining awaiting drop segment marked by the previous run.
 SELECT gp_inject_fault('vacuum_ao_after_index_delete', 'suspend', dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
 1&: VACUUM vacuum_progress_ao_row;
@@ -83,8 +113,13 @@ SELECT gp_wait_until_triggered_fault('appendonly_after_truncate_segment_file', 1
 SELECT gp_inject_fault('appendonly_after_truncate_segment_file', 'reset', dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
 1<:
 
--- Vacuum has finished, nothing should show up in the view.
+-- Vacuum has finished, nothing should show up in the progress view.
 1U: select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, heap_blks_vacuumed, index_vacuum_count, max_dead_tuples, num_dead_tuples from pg_stat_progress_vacuum;
+
+-- pg_class and collected stats view should be updated after the 2nd VACUUM
+1U: SELECT wait_until_dead_tup_change_to('vacuum_progress_ao_row'::regclass::oid, 0);
+SELECT relpages, reltuples, relallvisible FROM pg_class where relname = 'vacuum_progress_ao_row';
+SELECT n_live_tup, n_dead_tup, vacuum_count FROM pg_stat_all_tables WHERE relname = 'vacuum_progress_ao_row';
 
 -- Cleanup
 SELECT gp_inject_fault_infinite('all', 'reset', dbid) FROM gp_segment_configuration;


### PR DESCRIPTION
The following fields of pg_stat_all_tables view now have stats available for append-optimized tables:

n_live_tup
n_dead_tup
last_vacuum
vacuum_count

Note that n_dead_tup only accounts for dead tuples in non-awaiting-drop segment files.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
