### PR TITLE
Do not force gp_dist_random in set_subquery_pathlist in utility mode

### DIFF
--- a/src/backend/optimizer/path/allpaths.c
+++ b/src/backend/optimizer/path/allpaths.c
@@ -57,6 +57,7 @@
 #include "cdb/cdbmutate.h"		/* cdbmutate_warn_ctid_without_segid */
 #include "cdb/cdbpath.h"		/* cdbpath_rows() */
 #include "cdb/cdbutil.h"
+#include "cdb/cdbvars.h"
 
 // TODO: these planner gucs need to be refactored into PlannerConfig.
 bool		gp_enable_sort_limit = false;
@@ -2463,7 +2464,11 @@ set_subquery_pathlist(PlannerInfo *root, RelOptInfo *rel,
 	 */
 	required_outer = rel->lateral_relids;
 
-	forceDistRand = rte->forceDistRandom;
+	/* In utility mode, don't force the gp_dist_random. Otherwise check the RTE. */
+	if (Gp_role == GP_ROLE_UTILITY)
+		forceDistRand = false;
+	else
+		forceDistRand = rte->forceDistRandom;
 
 	/* CDB: Could be a preplanned subquery from window_planner. */
 	if (rte->subquery_root == NULL)

--- a/src/test/isolation2/expected/misc.out
+++ b/src/test/isolation2/expected/misc.out
@@ -66,3 +66,37 @@ CREATE
 -----------------
  pg_toast_temp_0 
 (1 row)
+
+--
+-- gp_dist_random('<view>') should not crash in utility mode
+--
+create or replace view misc_v as select 1;
+CREATE
+0U: select 1 from gp_dist_random('misc_v') union select 1 from misc_v;
+ ?column? 
+----------
+ 1        
+(1 row)
+0U: select count(*) from gp_dist_random('misc_v');
+ count 
+-------
+ 1     
+(1 row)
+-- But views created in utility mode should not throw away gp_dist_random
+0U: create or replace view misc_v2 as select 1 from gp_dist_random('pg_class');
+CREATE
+0U: select definition from pg_views where viewname = 'misc_v2';
+ definition                                                  
+------------
+   FROM gp_dist_random('pg_class'); 
+  SELECT 1 AS "?column?"
+(1 row)
+0U: select count(*) > 0 from gp_dist_random('misc_v2');
+ ?column? 
+----------
+ t        
+(1 row)
+0U: drop view misc_v2;
+DROP
+drop view misc_v;
+DROP

--- a/src/test/isolation2/sql/misc.sql
+++ b/src/test/isolation2/sql/misc.sql
@@ -40,3 +40,16 @@
       JOIN pg_namespace n2
         ON n2.nspname = 'pg_toast_temp_0' || substring(n1.nspname FROM 10)
      WHERE c.relname = 'utilitymode_tmp_tab';
+
+--
+-- gp_dist_random('<view>') should not crash in utility mode
+-- 
+create or replace view misc_v as select 1;
+0U: select 1 from gp_dist_random('misc_v') union select 1 from misc_v;
+0U: select count(*) from gp_dist_random('misc_v');
+-- But views created in utility mode should not throw away gp_dist_random
+0U: create or replace view misc_v2 as select 1 from gp_dist_random('pg_class');
+0U: select definition from pg_views where viewname = 'misc_v2';
+0U: select count(*) > 0 from gp_dist_random('misc_v2');
+0U: drop view misc_v2;
+drop view misc_v;


### PR DESCRIPTION
Re-worked approach to https://github.com/greenplum-db/gpdb/pull/15252

-------------

Currently when we plan a subquery, we refer to the subquery RTE's forceDistRandom field in order to understand if it is a gp_dist_random. If so we will set its locus to CdbLocusType_Strewn. In utility mode, that could result in motion being created which it couldn't handle (see #15238).

Therefore, now we don't force the random distribution in utility mode and let the subquery decide its own locus (which might involve gp_dist_random again but we'll follow the same logic here again).

Fixed #15238

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
