### PR TITLE
Fix InterruptHoldoffCount value not being reset to zero in abnormal

### DIFF
--- a/src/backend/cdb/cdbcopy.c
+++ b/src/backend/cdb/cdbcopy.c
@@ -752,7 +752,7 @@ cdbCopyEndInternal(CdbCopy *c, char *abort_msg,
 		if (first_error)
 		{
 			FlushErrorState();
-			ReThrowError(first_error);
+			ThrowErrorData(first_error);
 		}
 
 		/* errors that occurred in the COPY itself */

--- a/src/backend/cdb/cdbtm.c
+++ b/src/backend/cdb/cdbtm.c
@@ -1255,7 +1255,7 @@ doDispatchDtxProtocolCommand(DtxProtocolCommand dtxProtocolCommand,
 		else
 		{
 			FlushErrorState();
-			ReThrowError(qeError);
+			ThrowErrorData(qeError);
 		}
 		return false;
 	}

--- a/src/backend/cdb/dispatcher/cdbdisp.c
+++ b/src/backend/cdb/dispatcher/cdbdisp.c
@@ -280,7 +280,7 @@ CdbDispatchHandleError(struct CdbDispatcherState *ds)
 			if (error != NULL)
 			{
 				FlushErrorState();
-				ReThrowError(error);
+				ThrowErrorData(error);
 			}
 		}
 		PG_CATCH();

--- a/src/backend/cdb/dispatcher/cdbdisp_query.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_query.c
@@ -358,7 +358,7 @@ CdbDispatchSetCommand(const char *strCommand, bool cancelOnError)
 	{
 
 		FlushErrorState();
-		ReThrowError(qeError);
+		ThrowErrorData(qeError);
 	}
 
 	cdbdisp_destroyDispatcherState(ds);
@@ -513,7 +513,7 @@ cdbdisp_dispatchCommandInternal(DispatchCommandQueryParms *pQueryParms,
 	if (qeError)
 	{
 		FlushErrorState();
-		ReThrowError(qeError);
+		ThrowErrorData(qeError);
 	}
 
 	/* collect pgstat from QEs for current transaction level */
@@ -1216,7 +1216,7 @@ cdbdisp_dispatchX(QueryDesc* queryDesc,
 		if (qeError)
 		{
 			FlushErrorState();
-			ReThrowError(qeError);
+			ThrowErrorData(qeError);
 		}
 
 		/*
@@ -1367,7 +1367,7 @@ CdbDispatchCopyStart(struct CdbCopy *cdbCopy, Node *stmt, int flags)
 	if (!cdbdisp_getDispatchResults(ds, &error))
 	{
 		FlushErrorState();
-		ReThrowError(error);
+		ThrowErrorData(error);
 	}
 
 	/*

--- a/src/backend/cdb/endpoint/cdbendpointutils.c
+++ b/src/backend/cdb/endpoint/cdbendpointutils.c
@@ -158,7 +158,7 @@ check_parallel_retrieve_cursor_errors(EState *estate)
 		estate->dispatcherState = NULL;
 		cdbdisp_cancelDispatch(ds);
 		FlushErrorState();
-		ReThrowError(qeError);
+		ThrowErrorData(qeError);
 	}
 }
 

--- a/src/backend/commands/explain.c
+++ b/src/backend/commands/explain.c
@@ -668,7 +668,7 @@ ExplainOnePlan(PlannedStmt *plannedstmt, IntoClause *into, ExplainState *es,
 			if (qeError)
 			{
 				FlushErrorState();
-				ReThrowError(qeError);
+				ThrowErrorData(qeError);
 			}
 		}
 

--- a/src/backend/executor/execUtils.c
+++ b/src/backend/executor/execUtils.c
@@ -1682,7 +1682,7 @@ void mppExecutorFinishup(QueryDesc *queryDesc)
 		{
 			estate->dispatcherState = NULL;
 			FlushErrorState();
-			ReThrowError(qeError);
+			ThrowErrorData(qeError);
 		}
 
 		/* collect pgstat from QEs for current transaction level */

--- a/src/backend/executor/nodeSubplan.c
+++ b/src/backend/executor/nodeSubplan.c
@@ -1405,7 +1405,7 @@ PG_TRY();
 		{
 			queryDesc->estate->dispatcherState = NULL;
 			FlushErrorState();
-			ReThrowError(qeError);
+			ThrowErrorData(qeError);
 		}
 
 		/* collect pgstat from QEs for current transaction level */


### PR DESCRIPTION
cases(#15278)

This commit addresses issue #15278, where the InterruptHoldoffCount value was not always resetting to zero in certain abnormal scenarios. This issue had the potential to impact the proper functioning of the ProcessInterrupts process. The fix ensures that the InterruptHoldoffCount value is properly reset to zero in all cases.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
