### PR TITLE
docs - memory context view and sys admin log functions

### DIFF
--- a/gpdb-doc/markdown/admin_guide/managing/monitor.html.md
+++ b/gpdb-doc/markdown/admin_guide/managing/monitor.html.md
@@ -318,7 +318,7 @@ The command:
 SELECT pg_log_backend_memory_contexts( pg_backend_pid() );
 ```
 
-triggered the dumping of the following (subset of) memory context messages to the server log file:
+triggered the dumping of the following (subset of) memory context messages to the local server log file:
 
 ``` pre
 2023-03-23 16:45:57.228512 UTC,"gpadmin","testdb",p16389,th-557447104,"[local]",,2023-03-23 15:57:32 UTC,0,,cmd10,seg-1,,,,sx1,"LOG","00000","logging memory contexts of PID 16389",,,,,,"SELECT pg_log_backend_memory_contexts(pg_backend_pid());",0,,"mcxt.c",1278,

--- a/gpdb-doc/markdown/admin_guide/managing/monitor.html.md
+++ b/gpdb-doc/markdown/admin_guide/managing/monitor.html.md
@@ -23,6 +23,7 @@ As a Greenplum Database administrator, you must monitor the system for problem e
 -   [Checking for Data Distribution Skew](#topic20)
 -   [Viewing Metadata Information about Database Objects](#topic24)
 -   [Viewing Session Memory Usage Information](#topic_slt_ddv_1q)
+-   [Viewing and Logging Per-Process Memory Usage Information](#topic_memcontext)
 -   [Viewing Query Workfile Usage Information](#topic27)
 
 ## <a id="topic12"></a>Checking System State 
@@ -267,6 +268,65 @@ The `is_runaway`, `runaway_vmem_mb`, and `runaway_command_cnt` columns are not a
 |`runaway_vmem_mb`|integer| |Amount of vmem memory that the session was consuming when it was marked as a runaway session.|
 |`runaway_command_cnt`|integer| |Command count for the session when it was marked as a runaway session.|
 |`idle_start`|timestamptz| |The last time a query process in this session became idle.|
+
+## <a id="topic_memcontext"></a>Viewing and Logging Per-Process Memory Usage Information
+
+Greenplum Database allocates all memory within memory contexts. Memory contexts provide a convenient way to manage allocations made in different places that need to live for differing amounts of time. Destroying a context releases all of the memory that was allocated in it.
+
+Tracking the amount of memory used by a server process or a long-running query can help detect the source of a potential out-of-memory condition. Greenplum Database provides a system view and administration functions that you can use for this purpose.
+
+### <a id="topic_memcontext_view"></a>About the pg_backend_memory_contexts View
+
+To display the memory usage of all active memory contexts in the server process attached to the current session, use the [pg_backend_memory_contexts](../../ref_guide/system_catalogs/pg_backend_memory_contexts.html) system view. This view is restricted to superusers, but access may be granted to other roles.
+
+``` sql
+SELECT * FROM pg_backend_memory_contexts;
+```
+
+### <a id="topic_memcontext_func"></a>About the Memory Context Admin Functions
+
+You can use the system administration function `pg_log_backend_memory_contexts()` to instruct Greenplum Database to dump the memory usage of other sessions running on the coordinator host into the server log. Execution of this function is restricted to superusers only, and cannot be granted to other roles.
+
+The signature of `pg_log_backend_memory_contexts()` function follows:
+
+``` pre
+pg_log_backend_memory_contexts( pid integer )
+```
+
+where `pid` identifies the process whose memory contexts you want dumped.
+
+`pg_log_backend_memory_contexts()` returns `true` when memory context logging is successfully activated for the process on the local host. When logging is activated, Greenplum writes one message to the log for each memory context at the `LOG` message level. The log messages appear in the server log based on the log configuration set; refer to [Error Reporting and Logging](https://www.postgresql.org/docs/12/runtime-config-logging.html) in the PostgreSQL documentation for more information. *The memory context log messages are not sent to the client*.
+
+Memory context logging functions that dump memory usage across all Greenplum segments, or dump usage for a specific segment are named `gp_log_backend_memory_contexts()`.
+
+`gp_log_backend_memory_contexts()` has two signatures:
+
+``` pre
+gp_log_backend_memory_contexts( sess_id integer )
+gp_log_backend_memory_contexts( sess_id integer, contentId integer )
+```
+
+where `sess_id` is the Greenplum Database identifier assigned to the session (typically obtained from the `pg_stat_activity` view), and `contentID` in the second signature identifies the segment instance of interest.
+
+When you invoke `gp_log_backend_memory_contexts()` on the Greenplum Database coordinator host, it invokes `pg_log_backend_memory_contexts()` on the individual segments, which in turn triggers a memory usage dump to each segment log. The functions return an integer identifying the number of segments on which memory context logging was successfully activated.
+
+### <a id="topic_memcontext_samplelog"></a>Sample Log Messages
+
+The command:
+
+``` sql
+SELECT pg_log_backend_memory_contexts( pg_backend_pid() );
+```
+
+triggered the dumping of the following (subset of) memory context messages to the server log file:
+
+``` pre
+2023-03-23 16:45:57.228512 UTC,"gpadmin","testdb",p16389,th-557447104,"[local]",,2023-03-23 15:57:32 UTC,0,,cmd10,seg-1,,,,sx1,"LOG","00000","logging memory contexts of PID 16389",,,,,,"SELECT pg_log_backend_memory_contexts(pg_backend_pid());",0,,"mcxt.c",1278,
+2023-03-23 16:45:57.229275 UTC,"gpadmin","testdb",p16389,th-557447104,"[local]",,2023-03-23 15:57:32 UTC,0,,cmd10,seg-1,,,,sx1,"LOG","00000","level: 0; TopMemoryContext: 108384 total in 6 blocks; 23248 free (21 chunks); 85136 used",,,,,,,0,,"mcxt.c",884,
+2023-03-23 16:45:57.229822 UTC,"gpadmin","testdb",p16389,th-557447104,"[local]",,2023-03-23 15:57:32 UTC,0,,cmd10,seg-1,,,,sx1,"LOG","00000","level: 1; pgstat TabStatusArray lookup hash table: 8192 total in 1 blocks; 1416 free (0 chunks); 6776 used",,,,,,,0,,"mcxt.c",884,
+2023-03-23 16:45:57.230387 UTC,"gpadmin","testdb",p16389,th-557447104,"[local]",,2023-03-23 15:57:32 UTC,0,,cmd10,seg-1,,,,sx1,"LOG","00000","level: 1; TopTransactionContext: 8192 total in 1 blocks; 7576 free (1 chunks); 616 used",,,,,,,0,,"mcxt.c",884,
+2023-03-23 16:45:57.230961 UTC,"gpadmin","testdb",p16389,th-557447104,"[local]",,2023-03-23 15:57:32 UTC,0,,cmd10,seg-1,,,,sx1,"LOG","00000","level: 1; TableSpace cache: 8192 total in 1 blocks; 2056 free (0 chunks); 6136 used",,,,,,,0,,"mcxt.c",884,
+```
 
 ## <a id="topic27"></a>Viewing Query Workfile Usage Information 
 

--- a/gpdb-doc/markdown/ref_guide/system_catalogs/catalog_ref-html.html.md
+++ b/gpdb-doc/markdown/ref_guide/system_catalogs/catalog_ref-html.html.md
@@ -81,6 +81,7 @@ System catalog table and view definitions in alphabetical order.
 -   [pg\_available\_extension\_versions](../system_catalogs/pg_available_extension_versions.html)  
 
 -   [pg\_available\_extensions](../system_catalogs/pg_available_extensions.html)  
+-   [pg_backend_memory_contexts](../system_catalogs/pg_backend_memory_contexts.html)  
 
 -   [pg\_cast](../system_catalogs/pg_cast.html)  
 

--- a/gpdb-doc/markdown/ref_guide/system_catalogs/catalog_ref-views.html.md
+++ b/gpdb-doc/markdown/ref_guide/system_catalogs/catalog_ref-views.html.md
@@ -15,6 +15,7 @@ Greenplum Database provides the following system views.
 -   [gp_session_endpoints](gp_session_endpoints.html)
 -   [gp_transaction_log](gp_transaction_log.html)
 -   [gpexpand.expansion_progress](gpexpand_expansion_progress.html)
+-   [pg_backend_memory_contexts](pg_backend_memory_contexts.html)
 -   [pg_cursors](pg_cursors.html)
 -   [pg_matviews](pg_matviews.html)
 -   [pg_max_external_files](pg_max_external_files.html)

--- a/gpdb-doc/markdown/ref_guide/system_catalogs/pg_backend_memory_contexts.html.md
+++ b/gpdb-doc/markdown/ref_guide/system_catalogs/pg_backend_memory_contexts.html.md
@@ -11,7 +11,7 @@ The `pg_backend_memory_contexts` system view displays all of the memory contexts
 |`parent`|text| The name of the parent of this memory context.|
 |`level`|int4| The distance from `TopMemoryContext` in context tree.|
 |`total_bytes`|int8| The total number of bytes allocated for this memory context.|
-|`total_nblocks`|int8| The total number of blocks allocated for this memory context1.|
+|`total_nblocks`|int8| The total number of blocks allocated for this memory context.|
 |`free_bytes`|int8| Free space in bytes.|
 |`free_chunks`|int8| The total number of free chunks.|
 |`used_bytes`|int8| Used space in bytes.|

--- a/gpdb-doc/markdown/ref_guide/system_catalogs/pg_backend_memory_contexts.html.md
+++ b/gpdb-doc/markdown/ref_guide/system_catalogs/pg_backend_memory_contexts.html.md
@@ -1,0 +1,22 @@
+# pg_backend_memory_contexts
+
+The `pg_backend_memory_contexts` system view displays all of the memory contexts in use by the server process attached to the current session.
+
+`pg_backend_memory_contexts` contains one row for each memory context.
+
+|column|type|description|
+|------|----|-----------|
+|`name`|text| The name of the memory context.|
+|`ident`|text| Identification information of the memory context. This field is truncated at 1024 bytes.|
+|`parent`|text| The name of the parent of this memory context.|
+|`level`|int4| The distance from `TopMemoryContext` in context tree.|
+|`total_bytes`|int8| The total number of bytes allocated for this memory context.|
+|`total_nblocks`|int8| The total number of blocks allocated for this memory context1.|
+|`free_bytes`|int8| Free space in bytes.|
+|`free_chunks`|int8| The total number of free chunks.|
+|`used_bytes`|int8| Used space in bytes.|
+
+By default, the `pg_backend_memory_contexts` view can be read only by superusers or by roles with the privileges of the `pg_read_all_stats` role.
+
+**Parent topic:** [System Catalogs Definitions](../system_catalogs/catalog_ref-html.html)
+

--- a/gpdb-doc/markdown/ref_guide/toc.md
+++ b/gpdb-doc/markdown/ref_guide/toc.md
@@ -252,6 +252,7 @@ Doc Index
             - [pg\_authid](./system_catalogs/pg_authid.md)
             - [pg\_available\_extension\_versions](./system_catalogs/pg_available_extension_versions.md)
             - [pg\_available\_extensions](./system_catalogs/pg_available_extensions.md)
+            - [pg_backend_memory_contexts](./system_catalogs/pg_backend_memory_contexts.md)
             - [pg\_cast](./system_catalogs/pg_cast.md)
             - [pg\_class](./system_catalogs/pg_class.md)
             - [pg\_compression](./system_catalogs/pg_compression.md)


### PR DESCRIPTION
docs for https://github.com/greenplum-db/gpdb/pull/15145.

in this PR:
- port the postgres v15 pg_backend_memory_contexts system view reference (https://www.postgresql.org/docs/15/view-pg-backend-memory-contexts.html)
- add topic "Viewing and Logging Per-Process Memory Usage Information" that discusses the view and the new sys admin functions to the admin guide monitoring page.  i choose this page because this new info seemed aligned with an existing topic there named "Viewing Session Memory Usage Information".

question:  how/does this new feature relate to the `session_level_memory_consumption` view mentioned in the "Viewing Session Memory Usage Information" topic?

doc review site links (behind vpn):
- new catalog view: https://docs-staging.vmware.com/en/draft/VMware-Tanzu-Greenplum/memctx/greenplum-database/GUID-ref_guide-system_catalogs-pg_backend_memory_contexts.html
- new topic:  https://docs-staging.vmware.com/en/draft/VMware-Tanzu-Greenplum/memctx/greenplum-database/GUID-admin_guide-managing-monitor.html#viewing-and-logging-per-process-memory-usage-information
