### PR TITLE
Fix gpconfig ssh retry undefined param issue.

### DIFF
--- a/gpMgmt/bin/gppylib/commands/base.py
+++ b/gpMgmt/bin/gppylib/commands/base.py
@@ -508,16 +508,16 @@ class RemoteExecutionContext(LocalExecutionContext):
                                                                  cmdstr=cmd.cmdStr)
         LocalExecutionContext.execute(self, cmd, pickled=pickled)
         if (cmd.get_results().stderr.startswith('ssh_exchange_identification: Connection closed by remote host')):
-            self.__retry(cmd)
+            self.__retry(cmd, 0, pickled)
         pass
 
-    def __retry(self, cmd, count=0):
+    def __retry(self, cmd, count, pickled):
         if count == SSH_MAX_RETRY:
             return
         time.sleep(SSH_RETRY_DELAY)
-        LocalExecutionContext.execute(self, cmd, pickled=pickled)
+        LocalExecutionContext.execute(self, cmd, pickled)
         if (cmd.get_results().stderr.startswith('ssh_exchange_identification: Connection closed by remote host')):
-            self.__retry(cmd, count + 1)
+            self.__retry(cmd, count + 1, pickled)
 
 class Command(object):
     """ TODO:


### PR DESCRIPTION
This fix https://github.com/greenplum-db/gpdb/issues/15282

When gpssh retry due to connection failed, will get error like:

NameError: name 'pickled' is not defined
20230329:08:20:21:020634 gpconfig:ip-192-168-216-122:gpadmin-[ERROR]:-name 'pickled' is not defined Traceback (most recent call last):
  File "/usr/local/gpdb/lib/python/gppylib/commands/base.py", line 278, in run
    self.cmd.run()
  File "/usr/local/gpdb/lib/python/gppylib/commands/base.py", line 555, in run
    self.exec_context.execute(self, pickled=self.pickled)
  File "/usr/local/gpdb/lib/python/gppylib/commands/base.py", line 512, in execute
    self.__retry(cmd)
  File "/usr/local/gpdb/lib/python/gppylib/commands/base.py", line 519, in __retry
    LocalExecutionContext.execute(self, cmd, pickled=pickled)
NameError: name 'pickled' is not defined

Authored-by: Zhang Mingli avamingli@gmail.com

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
