### PR TITLE
docs - gporca supports planning queries on foreign tables

### DIFF
--- a/gpdb-doc/markdown/admin_guide/external/g-foreign.html.md
+++ b/gpdb-doc/markdown/admin_guide/external/g-foreign.html.md
@@ -12,8 +12,6 @@ If none of the existing PostgreSQL or Greenplum Database foreign-data wrappers s
 
 To access foreign data, you create a *foreign server* object, which defines how to connect to a particular remote data source according to the set of options used by its supporting foreign-data wrapper. Then you create one or more *foreign tables*, which define the structure of the remote data. A foreign table can be used in queries just like a normal table, but a foreign table has no storage in the Greenplum Database server. Whenever a foreign table is accessed, Greenplum Database asks the foreign-data wrapper to fetch data from, or update data in \(if supported by the wrapper\), the remote source.
 
-> **Note** GPORCA does not support foreign tables, a query on a foreign table always falls back to the Postgres Planner.
-
 Accessing remote data may require authenticating to the remote data source. This information can be provided by a *user mapping*, which can provide additional data such as a user name and password based on the current Greenplum Database role.
 
 For additional information, refer to the [CREATE FOREIGN DATA WRAPPER](../../ref_guide/sql_commands/CREATE_FOREIGN_DATA_WRAPPER.html), [CREATE SERVER](../../ref_guide/sql_commands/CREATE_SERVER.html), [CREATE USER MAPPING](../../ref_guide/sql_commands/CREATE_USER_MAPPING.html), and [CREATE FOREIGN TABLE](../../ref_guide/sql_commands/CREATE_FOREIGN_TABLE.html) SQL reference pages.
@@ -22,14 +20,13 @@ For additional information, refer to the [CREATE FOREIGN DATA WRAPPER](../../ref
 
 Most PostgreSQL foreign-data wrappers should work with Greenplum Database. However, PostgreSQL foreign-data wrappers connect only through the Greenplum Database coordinator by default and do not access the Greenplum Database segment instances directly.
 
-Greenplum Database adds an `mpp_execute` option to FDW-related SQL commands. If the foreign-data wrapper supports it, you can specify `mpp_execute '*value*'` in the `OPTIONS` clause when you create the FDW, server, or foreign table to identify the Greenplum host from which the foreign-data wrapper reads or writes data. Valid `*value*`s are:
+Greenplum Database adds an `mpp_execute` option to FDW-related SQL commands. If the foreign-data wrapper supports it, you can specify `mpp_execute '<value>'` in the `OPTIONS` clause when you create the FDW, server, or foreign table to identify the Greenplum host from which the foreign-data wrapper reads or writes data. Valid `<value>`s are:
 
--   `master` \(the default\)—Read or write data from the coordinator host.
--   `any`—Read data from either the coordinator host or any one segment, depending on which path costs less.
--   `all segments`—Read or write data from all segments. If a foreign-data wrapper supports this value, for correct results it should have a policy that matches segments to data.
+-   `master` \(the default\) - Read or write data from the coordinator host.
+-   `any` - Read data from either the coordinator host or any one segment, depending on which path costs less.
+-   `all segments` - Read or write data from all segments. If a foreign-data wrapper supports this value, for correct results it should have a policy that matches segments to data.
 
 \(A PostgreSQL foreign-data wrapper may work with the various `mpp_execute` option settings, but the results are not guaranteed to be correct. For example, a segment may not be able to connect to the foriegn server, or segments may receive overlapping results resulting in duplicate rows.\)
 
-> **Note** GPORCA does not support foreign tables, a query on a foreign table always falls back to the Postgres Planner.
 
 **Parent topic:** [Working with External Data](../external/g-working-with-file-based-ext-tables.html)

--- a/gpdb-doc/markdown/admin_guide/query/topics/query-piv-opt-changed.html.md
+++ b/gpdb-doc/markdown/admin_guide/query/topics/query-piv-opt-changed.html.md
@@ -7,9 +7,6 @@ There are changes to Greenplum Database behavior with the GPORCA optimizer enabl
 -   UPDATE operations on distribution keys are allowed.
 -   UPDATE operations on partitioned keys are allowed.
 -   Queries against uniform partitioned tables are supported.
--   Except for `INSERT`, DML operations directly on partition \(child table\) of a partitioned table are not supported.
-
-    For the `INSERT` command, you can specify a leaf child table of the partitioned table to insert data into a partitioned table. An error is returned if the data is not valid for the specified leaf child table. Specifying a child table that is not a leaf child table is not supported.
 
 -   The command CREATE TABLE AS distributes table data randomly if the DISTRIBUTED BY clause is not specified and no primary or unique keys are specified.
 -   Non-deterministic updates not allowed. The following UPDATE command returns an error.

--- a/gpdb-doc/markdown/admin_guide/query/topics/query-piv-opt-changed.html.md
+++ b/gpdb-doc/markdown/admin_guide/query/topics/query-piv-opt-changed.html.md
@@ -7,7 +7,6 @@ There are changes to Greenplum Database behavior with the GPORCA optimizer enabl
 -   UPDATE operations on distribution keys are allowed.
 -   UPDATE operations on partitioned keys are allowed.
 -   Queries against uniform partitioned tables are supported.
--   Queries against partitioned tables that are altered to use an external table as a leaf child partition fall back to the Postgres Planner.
 -   Except for `INSERT`, DML operations directly on partition \(child table\) of a partitioned table are not supported.
 
     For the `INSERT` command, you can specify a leaf child table of the partitioned table to insert data into a partitioned table. An error is returned if the data is not valid for the specified leaf child table. Specifying a child table that is not a leaf child table is not supported.

--- a/gpdb-doc/markdown/admin_guide/query/topics/query-piv-opt-limitations.html.md
+++ b/gpdb-doc/markdown/admin_guide/query/topics/query-piv-opt-limitations.html.md
@@ -25,9 +25,7 @@ These features are unsupported when GPORCA is enabled \(the default\):
 -   Indexed expressions \(an index defined as expression based on one or more columns of the table\)
 -   SP-GiST indexing method. GPORCA supports only B-tree, bitmap, GIN, and GiST indexes. GPORCA ignores indexes created with unsupported methods.
 -   External parameters
--   These types of partitioned tables:
-    -   Non-uniform partitioned tables.
-    -   Partitioned tables that have been altered to use an external table as a leaf child partition.
+-   Non-uniform partitioned tables.
 -   SortMergeJoin \(SMJ\).
 -   Ordered aggregations.
 -   Multi-argument `DISTINCT` qualified aggregates, for example `SELECT corr(DISTINCT a, b) FROM tbl1;`
@@ -49,6 +47,7 @@ These features are unsupported when GPORCA is enabled \(the default\):
 -   Queries that contain UNICODE characters in metadata names, such as table names, and the characters are not compatible with the host system locale.
 -   `SELECT`, `UPDATE`, and `DELETE` commands where a table name is qualified by the `ONLY` keyword.
 -   Per-column collation. GPORCA supports collation only when all columns in the query use the same collation. If columns in the query use different collations, then Greenplum uses the Postgres Planner.
+-   DML and `COPY ... FROM` operations on foreign tables.
 
 ## <a id="topic_u4t_vxl_vp"></a>Performance Regressions 
 

--- a/gpdb-doc/markdown/ref_guide/config_params/guc-list.html.md
+++ b/gpdb-doc/markdown/ref_guide/config_params/guc-list.html.md
@@ -2283,6 +2283,14 @@ For information about GPORCA, see [About GPORCA](../../admin_guide/query/topics/
 |-----------|-------|-------------------|
 |Boolean|true|master, session, reload|
 
+## <a id="optimizer_enable_foreign_table"></a>optimizer\_enable\_foreign\_table
+
+When GPORCA is enabled \(the default\) and this configuration parameter is `true` \(the default\), GPORCA generates plans for queries that involve foreign tables. When `false`, queries that include foreign tables fall back to the Postgres Planner.
+
+|Value Range|Default|Set Classifications|
+|-----------|-------|-------------------|
+|Boolean|true|master, session, reload|
+
 ## <a id="optimizer_enable_indexonlyscan"></a>optimizer\_enable\_indexonlyscan 
 
 When GPORCA is enabled \(the default\) and this parameter is `true` \(the default\), GPORCA can generate index-only scan plan types for B-tree indexes. GPORCA accesses the index values only, not the data blocks of the relation. This provides a query execution performance improvement, particularly when the table has been vacuumed, has wide columns, and GPORCA does not need to fetch any data blocks \(for example, they are visible\).

--- a/gpdb-doc/markdown/ref_guide/config_params/guc_category-list.html.md
+++ b/gpdb-doc/markdown/ref_guide/config_params/guc_category-list.html.md
@@ -116,6 +116,7 @@ These parameters control the usage of GPORCA by Greenplum Database. For informat
 - [optimizer_discard_redistribute_hashjoin](guc-list.html#optimizer_discard_redistribute_hashjoin)
 - [optimizer_enable_associativity](guc-list.html#optimizer_enable_associativity)
 - [optimizer_enable_dml](guc-list.html#optimizer_enable_dml)
+- [optimizer_enable_foreign_table](guc-list.html#optimizer_enable_foreign_table)
 - [optimizer_enable_indexonlyscan](guc-list.html#optimizer_enable_indexonlyscan)
 - [optimizer_enable_master_only_queries](guc-list.html#optimizer_enable_master_only_queries)
 - [optimizer_enable_multiple_distinct_aggs](guc-list.html#optimizer_enable_multiple_distinct_aggs)


### PR DESCRIPTION
docs for https://github.com/greenplum-db/gpdb/pull/14287, https://github.com/greenplum-db/gpdb/pull/14844, https://github.com/greenplum-db/gpdb/pull/14890

in this PR:
- remove notes that gporca doesn't support foreign tables, misc edits on the page
- update the gporca limitations section to include DML and COPY ops on foreign tables
- remove some fallback to planner references for partitions that are external tables
- add ref info for new optimizer_enable_foreign_table guc

future task/PR:  review the existing gporca docs before release.  they are currently framed around new features/changes in gp6, and we should call out new gp7 features.  also, explain plans have changed, and the docs include a bit of EXPLAIN output.
