### PR TITLE
set resource group's minimum query memory limit to statement_mem

### DIFF
--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -3374,13 +3374,8 @@ ResourceGroupGetQueryMemoryLimit(void)
 	if (bypassedGroup)
 		return 0;
 
-	if (gp_resgroup_memory_query_fixed_mem)
-	{
-		/*
-		 * If user requests more than statement_mem, grant that.
-		 */
-		return Max((uint64) gp_resgroup_memory_query_fixed_mem * 1024L, stateMem);
-	}
+	if (gp_resgroup_memory_query_fixed_mem > 0)
+		return (uint64) gp_resgroup_memory_query_fixed_mem * 1024L;
 
 	Assert(selfIsAssigned());
 

--- a/src/test/isolation2/expected/resgroup/resgroup_memory_limit.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_memory_limit.out
@@ -19,27 +19,33 @@ CREATE ROLE role_memory_test RESOURCE GROUP rg_memory_test;
 CREATE
 
 -- session1: explain memory used by query
+-- user requests less than statement_mem, set query's memory limit to statement_mem
 1: SET ROLE TO role_memory_test;
 SET
 1: CREATE TABLE t_memory_limit(a int);
 CREATE
 1: BEGIN;
 BEGIN
+1: SHOW statement_mem;
+ statement_mem 
+---------------
+ 125MB         
+(1 row)
 1: SELECT func_memory_test('SELECT * FROM t_memory_limit');
  func_memory_test 
 ------------------
- 51200kB          
+ 128000kB         
 (1 row)
 
 -- session2: test alter resource group's memory limit
-2:ALTER RESOURCE GROUP rg_memory_test SET memory_limit 200;
+2:ALTER RESOURCE GROUP rg_memory_test SET memory_limit 1000;
 ALTER
 
--- memory used will grow up to 100 Mb
+-- memory used will grow up to 500 Mb
 1: SELECT func_memory_test('SELECT * FROM t_memory_limit');
  func_memory_test 
 ------------------
- 102400kB         
+ 512000kB         
 (1 row)
 1: END;
 END

--- a/src/test/isolation2/sql/resgroup/resgroup_memory_limit.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_memory_limit.sql
@@ -31,15 +31,17 @@ CREATE RESOURCE GROUP rg_memory_test WITH(memory_limit=100, cpu_hard_quota_limit
 CREATE ROLE role_memory_test RESOURCE GROUP rg_memory_test;
 
 -- session1: explain memory used by query
+-- user requests less than statement_mem, set query's memory limit to statement_mem
 1: SET ROLE TO role_memory_test;
 1: CREATE TABLE t_memory_limit(a int);
 1: BEGIN;
+1: SHOW statement_mem;
 1: SELECT func_memory_test('SELECT * FROM t_memory_limit');
 
 -- session2: test alter resource group's memory limit
-2:ALTER RESOURCE GROUP rg_memory_test SET memory_limit 200;
+2:ALTER RESOURCE GROUP rg_memory_test SET memory_limit 1000;
 
--- memory used will grow up to 100 Mb
+-- memory used will grow up to 500 Mb
 1: SELECT func_memory_test('SELECT * FROM t_memory_limit');
 1: END;
 -- set gp_resgroup_memory_query_fixed_mem to 200MB


### PR DESCRIPTION
In resource group mode, if user requests more than statement_mem, grant that, otherwise set the statement_mem to the query's memory limit.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
