### PR TITLE
Added column filenum to pg_attribute_encoding

### DIFF
--- a/gpdb-doc/markdown/ref_guide/system_catalogs/catalog_ref-tables.html.md
+++ b/gpdb-doc/markdown/ref_guide/system_catalogs/catalog_ref-tables.html.md
@@ -19,6 +19,7 @@
 -   pg\_appendonly\_alter\_column \(not supported\)
 -   [pg\_attrdef](pg_attrdef.html)
 -   [pg\_attribute](pg_attribute.html)
+-   [pg\_attribute_encoding](pg_attribute_encoding.html)
 -   [pg\_auth\_members](pg_auth_members.html)
 -   [pg\_authid](pg_authid.html)
 -   pg\_autovacuum \(not supported\)

--- a/gpdb-doc/markdown/ref_guide/system_catalogs/pg_attribute_encoding.html.md
+++ b/gpdb-doc/markdown/ref_guide/system_catalogs/pg_attribute_encoding.html.md
@@ -7,6 +7,7 @@ The `pg_attribute_encoding` system catalog table contains column storage informa
 |`attrelid`|oid|not null|plain|Foreign key to `pg_attribute.attrelid`|
 |`attnum`|smallint|not null|plain|Foreign key to `pg_attribute.attnum`|
 |`attoptions`|text \[ \]| |extended|The options|
+|`filenum`|smallint|not null|plain|Range of files for the column|
 
 **Parent topic:** [System Catalogs Definitions](../system_catalogs/catalog_ref-html.html)
 

--- a/gpdb-doc/markdown/ref_guide/system_catalogs/pg_attribute_encoding.html.md
+++ b/gpdb-doc/markdown/ref_guide/system_catalogs/pg_attribute_encoding.html.md
@@ -9,7 +9,7 @@ The `pg_attribute_encoding` system catalog table contains column storage informa
 |`filenum`|smallint|not null|plain|Shorthand for the file range assigned to the column|
 |`attoptions`|text \[ \]| |extended|The options|
 
-For a column with `filenum` = *f*, the column files on disk use the suffix `(f - 1)*128 to f*128 - 1`. For example:
+For a column with `filenum = f`, the column files on disk use the suffix `(f - 1)*128 to f*128 - 1`. For example:
 
 - Column with `filenum` = 1 has files `relfilenode`, `relfilenode.1` .. `relfilenode.127`.
 - Column with `filenum` = 2 has files `relfilenode.128`, `relfilenode.129` .. `relfilenode.255`.

--- a/gpdb-doc/markdown/ref_guide/system_catalogs/pg_attribute_encoding.html.md
+++ b/gpdb-doc/markdown/ref_guide/system_catalogs/pg_attribute_encoding.html.md
@@ -9,7 +9,7 @@ The `pg_attribute_encoding` system catalog table contains column storage informa
 |`filenum`|smallint|not null|plain|Shorthand for the file range assigned to the column|
 |`attoptions`|text \[ \]| |extended|The options|
 
-For a column with `filenum`= *f*, the column files on disk use the suffix (*f* - 1)*128 to *f**128 - 1. For example:
+For a column with `filenum` = *f*, the column files on disk use the suffix `(f - 1)*128 to f*128 - 1`. For example:
 
 - Column with `filenum` = 1 has files `relfilenode`, `relfilenode.1` .. `relfilenode.127`.
 - Column with `filenum` = 2 has files `relfilenode.128`, `relfilenode.129` .. `relfilenode.255`.

--- a/gpdb-doc/markdown/ref_guide/system_catalogs/pg_attribute_encoding.html.md
+++ b/gpdb-doc/markdown/ref_guide/system_catalogs/pg_attribute_encoding.html.md
@@ -11,9 +11,9 @@ The `pg_attribute_encoding` system catalog table contains column storage informa
 
 For a column with `filenum = f`, the column files on disk use the suffix `(f - 1)*128 to f*128 - 1`. For example:
 
-- Column with `filenum` = 1 has files `relfilenode`, `relfilenode.1` .. `relfilenode.127`.
-- Column with `filenum` = 2 has files `relfilenode.128`, `relfilenode.129` .. `relfilenode.255`.
-- Column with `filenum` = 3 has files `relfilenode.256`, `relfilenode.257` .. `relfilenode.383`.
+- Column with `filenum = 1` has files `relfilenode`, `relfilenode.1` .. `relfilenode.127`.
+- Column with `filenum = 2` has files `relfilenode.128`, `relfilenode.129` .. `relfilenode.255`.
+- Column with `filenum = 3` has files `relfilenode.256`, `relfilenode.257` .. `relfilenode.383`.
 
 **Parent topic:** [System Catalogs Definitions](../system_catalogs/catalog_ref-html.html)
 

--- a/gpdb-doc/markdown/ref_guide/system_catalogs/pg_attribute_encoding.html.md
+++ b/gpdb-doc/markdown/ref_guide/system_catalogs/pg_attribute_encoding.html.md
@@ -6,8 +6,14 @@ The `pg_attribute_encoding` system catalog table contains column storage informa
 |------|----|--------|-------|-----------|
 |`attrelid`|oid|not null|plain|Foreign key to `pg_attribute.attrelid`|
 |`attnum`|smallint|not null|plain|Foreign key to `pg_attribute.attnum`|
+|`filenum`|smallint|not null|plain|Shorthand for the file range assigned to the column|
 |`attoptions`|text \[ \]| |extended|The options|
-|`filenum`|smallint|not null|plain|Range of files for the column|
+
+For a column with `filenum`= *f*, the column files on disk use the suffix (*f* - 1)*128 to *f**128 - 1. For example:
+
+- Column with `filenum` = 1 has files `relfilenode`, `relfilenode.1` .. `relfilenode.127`.
+- Column with `filenum` = 2 has files `relfilenode.128`, `relfilenode.129` .. `relfilenode.255`.
+- Column with `filenum` = 3 has files `relfilenode.256`, `relfilenode.257` .. `relfilenode.383`.
 
 **Parent topic:** [System Catalogs Definitions](../system_catalogs/catalog_ref-html.html)
 


### PR DESCRIPTION
This PR adds the column filenum to the table pg_attribute_encoding, based on https://github.com/greenplum-db/gpdb/pull/15074).
