### PR TITLE
[6X Backport] gpstop: Fix kill_9_segment_processes function

### DIFF
--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -81,6 +81,32 @@ def getPostmasterPID(hostname, datadir):
     except:
         return -1
 
+
+"""
+Given the segment data directory and the hostname,
+return all the postgres processes associated
+with that segment as a list.
+Returns an empty list if there is any error.
+"""
+def get_postgres_segment_processes(datadir, host):
+    postmaster_pid = getPostmasterPID(host, datadir)
+    if postmaster_pid == -1:
+        return []
+
+    postgres_pids = [postmaster_pid]
+    cmd = Command("get children pids", ("pgrep -P {0}".format(postmaster_pid)), ctxt=REMOTE, remoteHost=host)
+    cmd.run()
+
+    if cmd.get_results().rc == 0:
+        pids = cmd.get_results().stdout.split()
+        for pid in pids:
+            try:
+                postgres_pids.append(int(pid))
+            except ValueError:
+                pass # Ignore any error while converting to int from str
+
+    return postgres_pids
+
 #-----------------------------------------------
 
 class CmdArgs(list):

--- a/gpMgmt/bin/gppylib/commands/test/unit/test_unit_gp.py
+++ b/gpMgmt/bin/gppylib/commands/test/unit/test_unit_gp.py
@@ -6,7 +6,7 @@
 from gppylib.commands.base import CommandResult
 from mock import patch
 
-from gppylib.commands.gp import is_pid_postmaster, get_postmaster_pid_locally
+from gppylib.commands.gp import is_pid_postmaster, get_postmaster_pid_locally, get_postgres_segment_processes
 from test.unit.gp_unittest import GpTestCase, run_tests
 
 
@@ -157,6 +157,32 @@ class GpCommandTestCase(GpTestCase):
     @patch('gppylib.commands.gp.Command.run', return_value=CommandResult(0, "", "", True, False))
     def test_get_postmaster_pid_locally_empty(self, mock1):
         self.assertEqual(get_postmaster_pid_locally('/tmp'), -1)
+
+    @patch('gppylib.commands.gp.getPostmasterPID', return_value=-1)
+    def test_get_postgres_segment_processes_no_postmaster(self, mock1):
+        result = get_postgres_segment_processes('/data/primary/gpseg0', 'sdw1')
+        self.assertEqual(result, [])
+
+    @patch('gppylib.commands.gp.getPostmasterPID', return_value=1234)
+    @patch('gppylib.commands.gp.Command.run')
+    @patch('gppylib.commands.gp.Command.get_results', return_value=CommandResult(0, b"\n111\n222\n333", b"", True, False))
+    def test_get_postgres_segment_processes_succeeds(self, mock1, mock2, mock3):
+        result = get_postgres_segment_processes('/data/primary/gpseg0', 'sdw1')
+        self.assertEqual(result, [1234, 111, 222, 333])
+
+    @patch('gppylib.commands.gp.getPostmasterPID', return_value=1234)
+    @patch('gppylib.commands.gp.Command.run')
+    @patch('gppylib.commands.gp.Command.get_results', return_value=CommandResult(0, b"\n111\nabc\n222\n", b"", True, False))
+    def test_get_postgres_segment_processes_with_str_pgrep_output(self, mock1, mock2, mock3):
+        result = get_postgres_segment_processes('/data/primary/gpseg0', 'sdw1')
+        self.assertEqual(result, [1234, 111, 222])
+
+    @patch('gppylib.commands.gp.getPostmasterPID', return_value=1234)
+    @patch('gppylib.commands.gp.Command.run')
+    @patch('gppylib.commands.gp.Command.get_results', return_value=CommandResult(1, b"", b"", False, False))
+    def test_get_postgres_segment_processes_when_pgrep_fails(self, mock1, mock2, mock3):
+        result = get_postgres_segment_processes('/data/primary/gpseg0', 'sdw1')
+        self.assertEqual(result, [1234])
 
 if __name__ == '__main__':
     run_tests()

--- a/gpMgmt/bin/gppylib/commands/test/unit/test_unit_unix.py
+++ b/gpMgmt/bin/gppylib/commands/test/unit/test_unit_unix.py
@@ -1,0 +1,69 @@
+from mock import Mock, patch, call
+
+from gppylib.commands import unix
+from gppylib.commands.base import CommandResult
+from gppylib.test.unit.gp_unittest import GpTestCase, run_tests
+
+
+class UnixCommandTestCase(GpTestCase):
+    def setUp(self):
+        self.subject = unix
+        self.subject.logger = Mock(spec=['log', 'warn', 'info', 'debug', 'error', 'warning', 'fatal'])
+
+        self.apply_patches([
+            patch('gppylib.commands.unix.check_pid_on_remotehost'),
+            patch('gppylib.commands.unix.Command')
+        ])
+
+        self.mock_check_pid = self.get_mock_from_apply_patch('check_pid_on_remotehost')
+        self.mock_cmd = self.get_mock_from_apply_patch('Command')
+
+    def tearDown(self):
+        super(UnixCommandTestCase, self).tearDown()
+
+    def test_kill_9_segment_processes_info_msg(self):
+        self.subject.kill_9_segment_processes('/data/primary/gpseg0', [], 'sdw1')
+        self.subject.logger.info.assert_called_once_with('Terminating processes for segment /data/primary/gpseg0')
+
+    def test_kill_9_segment_processes_empty_pid_list(self):
+        self.subject.kill_9_segment_processes('/data/primary/gpseg0', [], 'sdw1')
+
+        self.subject.logger.info.assert_called_once_with('Terminating processes for segment /data/primary/gpseg0')
+        self.assertFalse(self.mock_cmd.called)
+
+    def test_kill_9_segment_processes_multiple_pids(self):
+        self.mock_check_pid.return_value = True
+        self.subject.kill_9_segment_processes('/data/primary/gpseg0', [123, 456], 'sdw1')
+
+        call_expected = [call('kill -9 process', 'kill -9 123', ctxt=2, remoteHost='sdw1'),
+                         call('kill -9 process', 'kill -9 456', ctxt=2, remoteHost='sdw1')]
+
+        self.subject.logger.info.assert_called_once_with('Terminating processes for segment /data/primary/gpseg0')
+        self.assertEqual(self.mock_cmd.call_count, 2)
+        self.assertIn(call_expected, self.mock_cmd.call_args_list)
+
+    def test_kill_9_segment_processes_some_pids_do_not_exist(self):
+        self.mock_check_pid.side_effect = [True, False, True]
+        self.subject.kill_9_segment_processes('/data/primary/gpseg0', [123, 456, 789], 'sdw1')
+        self.subject.logger.info.assert_called_once_with('Terminating processes for segment /data/primary/gpseg0')
+
+        call_expected = [call('kill -9 process', 'kill -9 123', ctxt=2, remoteHost='sdw1'),
+                         call('kill -9 process', 'kill -9 789', ctxt=2, remoteHost='sdw1')]
+
+        self.assertEqual(self.mock_cmd.call_count, 2)
+        self.assertIn(call_expected, self.mock_cmd.call_args_list)
+
+    def test_kill_9_segment_processes_kill_error(self):
+        self.mock_check_pid.return_value = True
+        mc = self.mock_cmd.return_value
+        mc.get_results.side_effect = [CommandResult(0, b"", b"", True, False),
+                                                                     CommandResult(0, b"", b"", True, False),
+                                                                     CommandResult(1, b"", b"Kill Error", False, False),
+                                                                     CommandResult(1, b"", b"Kill Error", False, False)]
+        self.subject.kill_9_segment_processes('/data/primary/gpseg0', [123, 456, 789], 'sdw1')
+
+        self.subject.logger.info.assert_called_once_with('Terminating processes for segment /data/primary/gpseg0')
+        self.subject.logger.error.assert_called_once_with('Failed to kill process 789 for segment /data/primary/gpseg0: Kill Error')
+
+if __name__ == '__main__':
+    run_tests()

--- a/gpMgmt/bin/gppylib/commands/unix.py
+++ b/gpMgmt/bin/gppylib/commands/unix.py
@@ -107,50 +107,20 @@ def check_pid(pid):
 
 
 """
-Given the data directory, port and pid for a segment, 
-kill -9 all the processes associated with that segment.
-If pid is -1, then the postmaster is already stopped, 
-so we check for any leftover processes for that segment 
-and kill -9 those processes
-E.g postgres: port 45002, logger process
-    postgres: port 45002, sweeper process
-    postgres: port 45002, checkpoint process
+Given the data directory, pid list and host,
+kill -9 all the processes from the pid list.
 """
+def kill_9_segment_processes(datadir, pids, host):
+    logger.info('Terminating processes for segment {0}'.format(datadir))
 
+    for pid in pids:
+        if check_pid_on_remotehost(pid, host):
 
-def kill_9_segment_processes(datadir, port, pid):
-    logger.info('Terminating processes for segment %s' % datadir)
+            cmd = Command("kill -9 process", ("kill -9 {0}".format(pid)), ctxt=REMOTE, remoteHost=host)
+            cmd.run()
 
-    pid_list = []
-
-    # pid is the pid of the postgres process.
-    # pid can be -1 if the process is down already
-    if pid != -1:
-        pid_list = [pid]
-
-    cmd = Command('get a list of processes to kill -9',
-                  cmdStr='ps ux | grep "[p]ostgres:\s*port\s*%s" | awk \'{print $2}\'' % (port))
-
-    try:
-        cmd.run(validateAfter=True)
-    except Exception as e:
-        logger.warning('Unable to get the pid list of processes for segment %s: (%s)' % (datadir, str(e)))
-        return
-
-    results = cmd.get_results()
-    results = results.stdout.strip().split('\n')
-
-    for result in results:
-        if result:
-            pid_list.append(int(result))
-
-    for pid in pid_list:
-        # Try to kill -9 the process.
-        # We ignore any errors 
-        try:
-            os.kill(pid, signal.SIGKILL)
-        except Exception as e:
-            logger.error('Failed to kill processes for segment %s: (%s)' % (datadir, str(e)))
+            if cmd.get_results().rc != 0:
+                logger.error('Failed to kill process {0} for segment {1}: {2}'.format(pid, datadir, cmd.get_results().stderr))
 
 
 def logandkill(pid, sig):

--- a/gpMgmt/bin/gpstop
+++ b/gpMgmt/bin/gpstop
@@ -532,6 +532,10 @@ class GpStop:
         e = GpEraFile(self.master_datadir, logger=get_logger_if_verbose())
         e.end_era()
 
+        # Get a list of postgres processes running before stopping the server
+        postgres_pids = gp.get_postgres_segment_processes(self.master_datadir, self.gparray.master.hostname)
+        logger.debug("Postgres processes running on master host: {0}".format(postgres_pids))
+
         try:
             if self.mode == 'smart':
                 self._stop_master_smart()
@@ -563,10 +567,10 @@ class GpStop:
                         if os.path.exists(lockfile):
                             logger.info("Clearing segment instance lock files")
                             os.remove(lockfile)
+
+        # Use the process list and make sure that all the processes are killed at the end
         logger.info('Attempting forceful termination of any leftover master process')
-        (succeeded, mypid, file_datadir) = pg.ReadPostmasterTempFile.local("Read master tmp file",
-                                                                           self.dburl.pgport).getResults()
-        unix.kill_9_segment_processes(self.master_datadir, self.dburl.pgport, mypid)
+        unix.kill_9_segment_processes(self.master_datadir, postgres_pids, self.gparray.master.hostname)
 
         logger.debug("Successfully shutdown the Master instance in admin mode")
 
@@ -583,7 +587,11 @@ class GpStop:
                 logger.warning("Standby is unreachable, skipping shutdown on standby")
                 return True
 
-            logger.info("Stopping master standby host %s mode=fast" % standby.hostname)
+            # Get a list of postgres processes running before stopping the server
+            postgres_pids = gp.get_postgres_segment_processes(standby.datadir, standby.hostname)
+            logger.debug("Postgres processes running on standby host: {0}".format(postgres_pids))
+
+            logger.info("Stopping master standby host %s mode=%s" % (standby.hostname, self.mode))
             try:
                 cmd = SegmentStop("stopping master standby",
                                      standby.datadir, mode='fast',
@@ -612,10 +620,10 @@ class GpStop:
                     return True
                 else:
                     logger.error('Failed to stop standby. Attempting forceful termination of standby process')
-                    (succeeded, mypid, file_datadir) = pg.ReadPostmasterTempFile.remote("Read standby tmp file",
-                                                                                        self.dburl.pgport,
-                                                                                        standby.hostname).getResults()
-                    unix.kill_9_segment_processes(self.master_datadir, self.dburl.pgport, mypid)
+
+                    # Use the process list and make sure that all the processes are killed at the end
+                    unix.kill_9_segment_processes(standby.datadir, postgres_pids, standby.hostname)
+
                     if not pg.DbStatus.remote('checking status of standby master instance', standby, standby.hostname):
                         logger.info("Successfully shutdown master standby process on %s" % standby.hostname)
                         return True

--- a/gpMgmt/sbin/gpsegstop.py
+++ b/gpMgmt/sbin/gpsegstop.py
@@ -70,6 +70,11 @@ class SegStop(base.Command):
         try:
             self.datadir, self.port = self.get_datadir_and_port()
 
+            # Get a list of postgres processes running before stopping the server
+            # Use localhost since gpsegstop is run locally on segment hosts
+            postgres_pids = gp.get_postgres_segment_processes(self.datadir, 'localhost')
+            logger.debug("Postgres processes running for segment %s: %s", self.datadir, postgres_pids)
+
             cmd = gp.SegmentStop('segment shutdown', self.datadir, mode=self.mode, timeout=self.timeout)
             cmd.run()
 
@@ -115,7 +120,9 @@ class SegStop(base.Command):
                                        results.rc, results.stdout, results.stderr))
 
             try:
-                unix.kill_9_segment_processes(self.datadir, self.port, mypid)
+                # Use the process list and make sure that all the processes are killed at the end
+                # Use localhost since gpsegstop is run locally on segment hosts
+                unix.kill_9_segment_processes(self.datadir, postgres_pids, 'localhost')
 
                 if unix.check_pid(mypid) and mypid != -1:
                     status = SegStopStatus(self.datadir, False,

--- a/gpMgmt/test/behave/mgmt_utils/gpstop.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpstop.feature
@@ -5,28 +5,34 @@ Feature: gpstop behave tests
     @demo_cluster
     Scenario: gpstop succeeds
         Given the database is running
+          And running postgres processes are saved in context
          When the user runs "gpstop -a"
          Then gpstop should return a return code of 0
+         And verify no postgres process is running on all hosts
 
     @concourse_cluster
     @demo_cluster
     Scenario: when there are user connections gpstop waits to shutdown until user switches to fast mode
         Given the database is running
           And the user asynchronously runs "psql postgres" and the process is saved
+          And running postgres processes are saved in context
          When the user runs gpstop -a -t 4 --skipvalidation and selects f
           And gpstop should print "'\(s\)mart_mode', '\(f\)ast_mode', '\(i\)mmediate_mode'" to stdout
          Then gpstop should return a return code of 0
+         And verify no postgres process is running on all hosts
 
     @concourse_cluster
     @demo_cluster
     Scenario: when there are user connections gpstop waits to shutdown until user connections are disconnected
         Given the database is running
           And the user asynchronously runs "psql postgres" and the process is saved
-          And the user asynchronously sets up to end that process in 6 seconds
+          And the user asynchronously sets up to end that process in 15 seconds
+          And running postgres processes are saved in context
          When the user runs gpstop -a -t 2 --skipvalidation and selects s
           And gpstop should print "There were 1 user connections at the start of the shutdown" to stdout
           And gpstop should print "'\(s\)mart_mode', '\(f\)ast_mode', '\(i\)mmediate_mode'" to stdout
          Then gpstop should return a return code of 0
+         And verify no postgres process is running on all hosts
 
     @demo_cluster
     Scenario: gpstop succeeds even if the standby host is unreachable
@@ -38,3 +44,25 @@ Feature: gpstop behave tests
           And gpstop should print "invalid_host is unreachable.Skipping cleaning shared memory." to stdout
           And gpstop should return a return code of 0
           And the standby host is made reachable
+
+    @demo_cluster
+    Scenario: gpstop succeeds when pg_ctl command fails
+        Given the database is running
+          And the user runs psql with "-c "CREATE EXTENSION IF NOT EXISTS gp_inject_fault;"" against database "postgres"
+          And the user runs psql with "-c "SELECT gp_inject_fault('checkpoint', 'sleep', '', '', '', 1, -1, 3600, dbid) FROM gp_segment_configuration"" against database "postgres"
+          And running postgres processes are saved in context
+         When the user runs "gpstop -a -M fast"
+          And gpstop should print "Failed to shutdown master with pg_ctl." to stdout
+          And gpstop should return a return code of 0
+          And verify no postgres process is running on all hosts
+
+    @demo_cluster
+    Scenario: gpstop succeeds with immediate option
+        Given the database is running
+          And the user asynchronously runs "psql postgres" and the process is saved
+          And the user asynchronously sets up to end that process in 15 seconds
+          And running postgres processes are saved in context
+         When the user runs "gpstop -a -M immediate"
+          And gpstop should print "Commencing Master instance shutdown with mode='immediate'" to stdout
+         Then gpstop should return a return code of 0
+          And verify no postgres process is running on all hosts


### PR DESCRIPTION
This is a backport of https://github.com/greenplum-db/gpdb/pull/15148

There was an issue reported and fixed by #11378 where the `kill_9_segment_processes` function had a bug and could not get the postgres pids to kill (more details in the mentioned PR). Even though the fix was correct, it has some issues - 
- It is not reliable to use the grep command `ps ux | grep "[p]ostgres:\s*%s" | awk \'{print $2}\'` to get a list of postgres processes since the pattern can be changed in the future and the output of the command also depends on the OS.
- The function never considered the case for executing on remote hosts. So the function would never work in case of standby shutdown when standby is on another host.

To address the above issues following changes are made - 
- Use the postmaster pid to get the list of all its child processes (implemented using `get_postgres_segment_processes`) before stopping the postgres server which will be used by the `kill_9_segment_processes` function at the end instead of the grep command.
- Modify the `kill_9_segment_processes` so that it can be executed remotely as well.

#### Testing
- Added unit test cases for the functions `kill_9_segment_processes` and `get_postgres_segment_processes`.
- Added a new behave test case where gpstop will succeed even when the pg_ctl stop command fails to stop the server.
- Added steps in existing cases to check for any postgres processes running at the end of gpstop to make sure all the processes are getting terminated and there are no false positives.
- Added a new test case when gpstop is run with immediate option.

[Pipeline](https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb-dev-6x_gpstop_fix-rhel8)