### PR TITLE
Replace os.getlogin with getpass.getuser in gen_pipeline.py [7X]

### DIFF
--- a/concourse/README.md
+++ b/concourse/README.md
@@ -32,7 +32,7 @@ There should be just a handful of pipelines in this directory:
   [pipelines/templates/gpdb-tpl.yml](pipelines/templates/gpdb-tpl.yml)
   should be edited and the utility
   [pipelines/gen_pipeline.py](pipelines/gen_pipeline.py) should be
-  used to generate production and developer pipeliens. Please review
+  used to generate production and developer pipelines. Please review
   the pipelines [README.md](pipelines/README.md) for additional
   information.
 * `dev_generate_installer.yml` which compiles and generates an installer for

--- a/concourse/pipelines/gen_pipeline.py
+++ b/concourse/pipelines/gen_pipeline.py
@@ -29,6 +29,7 @@ from __future__ import print_function
 
 import argparse
 import datetime
+import getpass
 import os
 import re
 import subprocess
@@ -274,7 +275,7 @@ def main():
         '--user',
         action='store',
         dest='user',
-        default=os.getlogin(),
+        default=getpass.getuser(),
         help='Developer userid to use for pipeline name and filename.'
     )
 
@@ -315,7 +316,7 @@ def main():
         raise Exception('--directed flag can be used only with prod target')
 
     output_path_is_set = os.path.basename(args.output_filepath) != default_output_filename
-    if (args.user != os.getlogin() and output_path_is_set):
+    if (args.user != getpass.getuser() and output_path_is_set):
         print("You can only use one of --output or --user.")
         exit(1)
 
@@ -338,7 +339,7 @@ def main():
     # don't overwrite the main pipeline
     if args.pipeline_target != 'prod' and not output_path_is_set:
         pipeline_file_suffix = suggested_git_branch()
-        if args.user != os.getlogin():
+        if args.user != getpass.getuser():
             pipeline_file_suffix = args.user
         default_dev_output_filename = 'gpdb-' + args.pipeline_target + '-' + pipeline_file_suffix + '-' + args.os_type + '.yml'
         args.output_filepath = os.path.join(PIPELINES_DIR, default_dev_output_filename)


### PR DESCRIPTION
`os.getlogin` will get the following error when creating pipeline:

```
Traceback (most recent call last):
  File "./gen_pipeline.py", line 505, in <module>
    main()
  File "./gen_pipeline.py", line 413, in main
    default=os.getlogin(),
OSError: [Errno 6] No such device or address
```

`getpass.getuser` is more recommended according to the [Python API manual](https://docs.python.org/3/library/os.html#os.getlogin).

Port #15296 to gpdb7