### PR TITLE
Remove element connofs from PQconninfoOption

### DIFF
--- a/src/backend/tcop/dest.c
+++ b/src/backend/tcop/dest.c
@@ -262,11 +262,11 @@ ReadyForQuery(CommandDest dest)
 
 				if (Gp_role == GP_ROLE_EXECUTE)
 				{
-					pq_beginmessage(&buf, 'k');
+					pq_beginmessage(&buf, 'k'); /* mop_high_watermark */
 					pq_sendint64(&buf, VmemTracker_GetMaxReservedVmemBytes());
 					pq_endmessage(&buf);
 
-					pq_beginmessage(&buf, 'x');
+					pq_beginmessage(&buf, 'x'); /* wrote_xlog */
 					pq_sendbyte(&buf, TransactionDidWriteXLog());
 					pq_endmessage(&buf);
 				}

--- a/src/interfaces/libpq/fe-exec.c
+++ b/src/interfaces/libpq/fe-exec.c
@@ -1246,7 +1246,7 @@ pqRowProcessor(PGconn *conn, const char **errmsgp)
 
 	return 1;
 
-	fail:
+fail:
 	/* release locally allocated PGresult, if we made one */
 	if (res != conn->result)
 		PQclear(res);

--- a/src/interfaces/libpq/libpq-fe.h
+++ b/src/interfaces/libpq/libpq-fe.h
@@ -223,10 +223,6 @@ typedef struct _PQconninfoOption
 								 * hide value "D"  Debug option - don't show
 								 * by default */
 	int			dispsize;		/* Field size in characters for dialog	*/
-#ifndef FRONTEND  /* modules other than backend have this macro */
-	off_t		connofs;		/* Offset into PGconn struct, -1 if not there
-								 * (Greenplum specified) */
-#endif
 } PQconninfoOption;
 
 /* ----------------

--- a/src/interfaces/libpq/libpq-int.h
+++ b/src/interfaces/libpq/libpq-int.h
@@ -475,7 +475,7 @@ struct pg_conn
 	int			be_pid;			/* PID of backend --- needed for cancels */
 	int			be_key;			/* key of backend --- needed for cancels */
 
-    int64      mop_high_watermark;   /* highwater mark for mop */
+	int64      mop_high_watermark;   /* highwater mark for mop */
 
 	pgParameterStatus *pstatus; /* ParameterStatus data */
 	int			client_encoding;	/* encoding id */


### PR DESCRIPTION
Before this commit, Greenplum didn't take `internalPQconninfoOption` and
`PQconninfoOption` differently on the backend side, that's why we had
`connofs` in `PQconninfoOption`, nowadays it's not needed and not
actually being used, just remove.

	commit 510a20b6c2ea8f7c6f9319ff904aea83a00a1ffc
	Author: Adam Lee <ali@pivotal.io>
	Date:   Mon Oct 23 14:40:11 2017 +0800

	    Retire gp_libpq_fe part 1, libpq itself

Fix #14462