### PR TITLE
Update flakey av ao aux test.

### DIFF
--- a/src/test/regress/expected/autovacuum-ao-aux.out
+++ b/src/test/regress/expected/autovacuum-ao-aux.out
@@ -8,12 +8,12 @@ ALTER SYSTEM SET autovacuum_naptime = 5;
 ALTER SYSTEM SET gp_autovacuum_scope = catalog_ao_aux;
 -- start_ignore
 \! gpstop -u;
-20230207:21:01:04:299967 gpstop:ajrdevbox:ajr-[INFO]:-Starting gpstop with args: -u
-20230207:21:01:04:299967 gpstop:ajrdevbox:ajr-[INFO]:-Gathering information and validating the environment...
-20230207:21:01:04:299967 gpstop:ajrdevbox:ajr-[INFO]:-Obtaining Greenplum Coordinator catalog information
-20230207:21:01:04:299967 gpstop:ajrdevbox:ajr-[INFO]:-Obtaining Segment details from coordinator...
-20230207:21:01:04:299967 gpstop:ajrdevbox:ajr-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 7.0.0-alpha.0+dev.18027.g20aa1a2c48 build dev'
-20230207:21:01:04:299967 gpstop:ajrdevbox:ajr-[INFO]:-Signalling all postmaster processes to reload
+20230403:14:05:43:574687 gpstop:ajrdevbox:ajr-[INFO]:-Starting gpstop with args: -u
+20230403:14:05:43:574687 gpstop:ajrdevbox:ajr-[INFO]:-Gathering information and validating the environment...
+20230403:14:05:43:574687 gpstop:ajrdevbox:ajr-[INFO]:-Obtaining Greenplum Coordinator catalog information
+20230403:14:05:43:574687 gpstop:ajrdevbox:ajr-[INFO]:-Obtaining Segment details from coordinator...
+20230403:14:05:43:574687 gpstop:ajrdevbox:ajr-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 7.0.0-beta.2+dev.73.gda1d38d4d0 build dev'
+20230403:14:05:43:574687 gpstop:ajrdevbox:ajr-[INFO]:-Signalling all postmaster processes to reload
 -- end_ignore
 CREATE TABLE autovac_ao(i int, j int) USING ao_row distributed BY (i);
 -- because we don't know the name of the aux tables ahead of time, we have to
@@ -37,7 +37,23 @@ INSERT INTO autovac_ao SELECT j,j FROM generate_series(1, 10000000)j;
 -- Deleting tuples from an AO table will insert rows into its visimap table.
 -- Aborting the delete should mark these inserted rows as invisible, and hence
 -- eligible for autovacuum.
-begin; delete from autovac_ao where j % 9 = 3; abort;
+BEGIN;
+DELETE FROM autovac_ao WHERE j % 9 = 3;
+ABORT;
+-- give stats a chance to update.  Waiting for fault blocks the sending of stat updates, and so vacuum
+-- is never allowed to run if we race ahead to the wait.
+select pg_sleep(1);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+select 1 as one from autovac_ao limit 1;
+ one 
+-----
+   1
+(1 row)
+
 -- wait for autovacuum to hit the auxiliary visimap table for autovac_ao,
 -- triggering a fault
 SELECT gp_wait_until_triggered_fault('auto_vac_worker_after_report_activity', 1, dbid)
@@ -68,12 +84,12 @@ ALTER SYSTEM RESET autovacuum_naptime;
 ALTER SYSTEM RESET gp_autovacuum_scope;
 -- start_ignore
 \! gpstop -u;
-20230207:21:01:16:300074 gpstop:ajrdevbox:ajr-[INFO]:-Starting gpstop with args: -u
-20230207:21:01:16:300074 gpstop:ajrdevbox:ajr-[INFO]:-Gathering information and validating the environment...
-20230207:21:01:16:300074 gpstop:ajrdevbox:ajr-[INFO]:-Obtaining Greenplum Coordinator catalog information
-20230207:21:01:16:300074 gpstop:ajrdevbox:ajr-[INFO]:-Obtaining Segment details from coordinator...
-20230207:21:01:16:300074 gpstop:ajrdevbox:ajr-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 7.0.0-alpha.0+dev.18027.g20aa1a2c48 build dev'
-20230207:21:01:16:300074 gpstop:ajrdevbox:ajr-[INFO]:-Signalling all postmaster processes to reload
+20230403:14:05:50:574748 gpstop:ajrdevbox:ajr-[INFO]:-Starting gpstop with args: -u
+20230403:14:05:50:574748 gpstop:ajrdevbox:ajr-[INFO]:-Gathering information and validating the environment...
+20230403:14:05:50:574748 gpstop:ajrdevbox:ajr-[INFO]:-Obtaining Greenplum Coordinator catalog information
+20230403:14:05:50:574748 gpstop:ajrdevbox:ajr-[INFO]:-Obtaining Segment details from coordinator...
+20230403:14:05:50:574748 gpstop:ajrdevbox:ajr-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 7.0.0-beta.2+dev.73.gda1d38d4d0 build dev'
+20230403:14:05:50:574748 gpstop:ajrdevbox:ajr-[INFO]:-Signalling all postmaster processes to reload
 -- end_ignore
 -- clean up database
 \c regression


### PR DESCRIPTION
Waiting for fault blocks stats updates sent from the same connection.  There was a race condition in the test where if we got to the wait before the stats were updated they'd never be received and so autovacuum would never run and the test would fail on timeout.

This was only visible in greenplum configurations that are faster, most debug builds never observed this.  The JIT pipeline reliably reproduced it, however.