### PR TITLE
pg_stat_*_user_* views shouldn't include AO aux tables

### DIFF
--- a/src/backend/catalog/system_views.sql
+++ b/src/backend/catalog/system_views.sql
@@ -696,17 +696,17 @@ CREATE VIEW pg_stat_xact_sys_tables AS
 
 CREATE VIEW pg_stat_user_tables AS
     SELECT * FROM pg_stat_all_tables
-    WHERE schemaname NOT IN ('pg_catalog', 'information_schema') AND
+    WHERE schemaname NOT IN ('pg_catalog', 'information_schema', 'pg_aoseg') AND
           schemaname !~ '^pg_toast';
 
 CREATE VIEW gp_stat_user_tables_summary AS
     SELECT * FROM gp_stat_all_tables_summary
-    WHERE schemaname NOT IN ('pg_catalog', 'information_schema') AND
+    WHERE schemaname NOT IN ('pg_catalog', 'information_schema', 'pg_aoseg') AND
           schemaname !~ '^pg_toast';
 
 CREATE VIEW pg_stat_xact_user_tables AS
     SELECT * FROM pg_stat_xact_all_tables
-    WHERE schemaname NOT IN ('pg_catalog', 'information_schema') AND
+    WHERE schemaname NOT IN ('pg_catalog', 'information_schema', 'pg_aoseg') AND
           schemaname !~ '^pg_toast';
 
 CREATE VIEW pg_statio_all_tables AS
@@ -741,7 +741,7 @@ CREATE VIEW pg_statio_sys_tables AS
 
 CREATE VIEW pg_statio_user_tables AS
     SELECT * FROM pg_statio_all_tables
-    WHERE schemaname NOT IN ('pg_catalog', 'information_schema') AND
+    WHERE schemaname NOT IN ('pg_catalog', 'information_schema', 'pg_aoseg') AND
           schemaname !~ '^pg_toast';
 
 CREATE VIEW pg_stat_all_indexes AS
@@ -805,12 +805,12 @@ CREATE VIEW pg_stat_sys_indexes AS
 
 CREATE VIEW pg_stat_user_indexes AS
     SELECT * FROM pg_stat_all_indexes
-    WHERE schemaname NOT IN ('pg_catalog', 'information_schema') AND
+    WHERE schemaname NOT IN ('pg_catalog', 'information_schema', 'pg_aoseg') AND
           schemaname !~ '^pg_toast';
 
 CREATE VIEW gp_stat_user_indexes_summary AS
     SELECT * FROM gp_stat_all_indexes_summary
-    WHERE schemaname NOT IN ('pg_catalog', 'information_schema') AND
+    WHERE schemaname NOT IN ('pg_catalog', 'information_schema', 'pg_aoseg') AND
           schemaname !~ '^pg_toast';
 
 CREATE VIEW pg_statio_all_indexes AS
@@ -836,7 +836,7 @@ CREATE VIEW pg_statio_sys_indexes AS
 
 CREATE VIEW pg_statio_user_indexes AS
     SELECT * FROM pg_statio_all_indexes
-    WHERE schemaname NOT IN ('pg_catalog', 'information_schema') AND
+    WHERE schemaname NOT IN ('pg_catalog', 'information_schema', 'pg_aoseg') AND
           schemaname !~ '^pg_toast';
 
 CREATE VIEW pg_statio_all_sequences AS
@@ -853,12 +853,12 @@ CREATE VIEW pg_statio_all_sequences AS
 
 CREATE VIEW pg_statio_sys_sequences AS
     SELECT * FROM pg_statio_all_sequences
-    WHERE schemaname IN ('pg_catalog', 'information_schema') OR
+    WHERE schemaname IN ('pg_catalog', 'information_schema', 'pg_aoseg') OR
           schemaname ~ '^pg_toast';
 
 CREATE VIEW pg_statio_user_sequences AS
     SELECT * FROM pg_statio_all_sequences
-    WHERE schemaname NOT IN ('pg_catalog', 'information_schema') AND
+    WHERE schemaname NOT IN ('pg_catalog', 'information_schema', 'pg_aoseg') AND
           schemaname !~ '^pg_toast';
 
 CREATE VIEW pg_stat_activity AS

--- a/src/test/regress/expected/pg_stat.out
+++ b/src/test/regress/expected/pg_stat.out
@@ -94,3 +94,228 @@ from gp_stat_user_indexes_summary where relname = 'pg_stat_test';
 (1 row)
 
 reset optimizer;
+------------
+-- "user" views should exclude AO/CO auxiliary tables, and "sys" views should include them
+------------
+create table pg_stat_ao(a int) using ao_row;
+create table pg_stat_co(a int) using ao_column;
+create index pg_stat_ao_ind on pg_stat_ao(a);
+create index pg_stat_co_ind on pg_stat_co(a);
+-- "user" views:
+select c.relname from pg_stat_user_tables s join pg_class c on s.relid = c.oid where c.relkind in ('o', 'b', 'M');
+ relname 
+---------
+(0 rows)
+
+select c.relname from gp_stat_user_tables s join pg_class c on s.relid = c.oid where c.relkind in ('o', 'b', 'M');
+ relname 
+---------
+(0 rows)
+
+select c.relname from gp_stat_user_tables_summary s join pg_class c on s.relid = c.oid where c.relkind in ('o', 'b', 'M');
+ relname 
+---------
+(0 rows)
+
+select c.relname from pg_stat_xact_user_tables s join pg_class c on s.relid = c.oid where c.relkind in ('o', 'b', 'M');
+ relname 
+---------
+(0 rows)
+
+select c.relname from gp_stat_xact_user_tables s join pg_class c on s.relid = c.oid where c.relkind in ('o', 'b', 'M');
+ relname 
+---------
+(0 rows)
+
+select c.relname from pg_stat_user_indexes s join pg_class c on s.relid = c.oid where c.relkind in ('o', 'b', 'M');
+ relname 
+---------
+(0 rows)
+
+select c.relname from gp_stat_user_indexes s join pg_class c on s.relid = c.oid where c.relkind in ('o', 'b', 'M');
+ relname 
+---------
+(0 rows)
+
+select c.relname from gp_stat_user_indexes_summary s join pg_class c on s.relid = c.oid where c.relkind in ('o', 'b', 'M');
+ relname 
+---------
+(0 rows)
+
+select c.relname from pg_statio_user_indexes s join pg_class c on s.relid = c.oid where c.relkind in ('o', 'b', 'M');
+ relname 
+---------
+(0 rows)
+
+select c.relname from gp_statio_user_indexes s join pg_class c on s.relid = c.oid where c.relkind in ('o', 'b', 'M');
+ relname 
+---------
+(0 rows)
+
+-- no AO/CO aux tables are sequence, but test it anyway 
+select c.relname from pg_statio_user_sequences s join pg_class c on s.relid = c.oid where c.relkind in ('o', 'b', 'M');
+ relname 
+---------
+(0 rows)
+
+select c.relname from gp_statio_user_sequences s join pg_class c on s.relid = c.oid where c.relkind in ('o', 'b', 'M');
+ relname 
+---------
+(0 rows)
+
+-- "sys" views:
+-- for cluster-wise views, just test output of one segment.
+-- also take a fixed part of the aux table names to avoid different column length because of OIDs.
+select c.relname as aorelname, substring(s.relname, 1, 9) as aoauxrelname 
+from pg_stat_sys_tables s 
+join pg_appendonly a on s.relid = a.segrelid or s.relid = a.blkdirrelid or s.relid = a.visimaprelid 
+join pg_class c on a.relid = c.oid 
+where c.relname like 'pg_stat_%';
+ aorelname  | aoauxrelname 
+------------+--------------
+ pg_stat_ao | pg_aoblkd
+ pg_stat_ao | pg_aoseg_
+ pg_stat_ao | pg_aovisi
+ pg_stat_co | pg_aoblkd
+ pg_stat_co | pg_aocsse
+ pg_stat_co | pg_aovisi
+(6 rows)
+
+select c.relname as aorelname, substring(s.relname, 1, 9) as aoauxrelname 
+from gp_stat_sys_tables s 
+join pg_appendonly a on s.relid = a.segrelid or s.relid = a.blkdirrelid or s.relid = a.visimaprelid 
+join pg_class c on a.relid = c.oid 
+where c.relname like 'pg_stat_%' and segment_id = 0;
+ aorelname  | aoauxrelname 
+------------+--------------
+ pg_stat_ao | pg_aoblkd
+ pg_stat_ao | pg_aoseg_
+ pg_stat_ao | pg_aovisi
+ pg_stat_co | pg_aoblkd
+ pg_stat_co | pg_aocsse
+ pg_stat_co | pg_aovisi
+(6 rows)
+
+select c.relname as aorelname, substring(s.relname, 1, 9) as aoauxrelname 
+from pg_stat_xact_sys_tables s 
+join pg_appendonly a on s.relid = a.segrelid or s.relid = a.blkdirrelid or s.relid = a.visimaprelid 
+join pg_class c on a.relid = c.oid 
+where c.relname like 'pg_stat_%';
+ aorelname  | aoauxrelname 
+------------+--------------
+ pg_stat_ao | pg_aoblkd
+ pg_stat_ao | pg_aoseg_
+ pg_stat_ao | pg_aovisi
+ pg_stat_co | pg_aoblkd
+ pg_stat_co | pg_aocsse
+ pg_stat_co | pg_aovisi
+(6 rows)
+
+select c.relname as aorelname, substring(s.relname, 1, 9) as aoauxrelname 
+from gp_stat_xact_sys_tables s 
+join pg_appendonly a on s.relid = a.segrelid or s.relid = a.blkdirrelid or s.relid = a.visimaprelid 
+join pg_class c on a.relid = c.oid 
+where c.relname like 'pg_stat_%' and segment_id = 0;
+ aorelname  | aoauxrelname 
+------------+--------------
+ pg_stat_ao | pg_aoblkd
+ pg_stat_ao | pg_aoseg_
+ pg_stat_ao | pg_aovisi
+ pg_stat_co | pg_aoblkd
+ pg_stat_co | pg_aocsse
+ pg_stat_co | pg_aovisi
+(6 rows)
+
+select c.relname as aorelname, substring(s.relname, 1, 9) as aoauxrelname 
+from pg_statio_sys_tables s 
+join pg_appendonly a on s.relid = a.segrelid or s.relid = a.blkdirrelid or s.relid = a.visimaprelid 
+join pg_class c on a.relid = c.oid 
+where c.relname like 'pg_stat_%';
+ aorelname  | aoauxrelname 
+------------+--------------
+ pg_stat_ao | pg_aoblkd
+ pg_stat_ao | pg_aoseg_
+ pg_stat_ao | pg_aovisi
+ pg_stat_co | pg_aoblkd
+ pg_stat_co | pg_aocsse
+ pg_stat_co | pg_aovisi
+(6 rows)
+
+select c.relname as aorelname, substring(s.relname, 1, 9) as aoauxrelname 
+from gp_statio_sys_tables s 
+join pg_appendonly a on s.relid = a.segrelid or s.relid = a.blkdirrelid or s.relid = a.visimaprelid 
+join pg_class c on a.relid = c.oid 
+where c.relname like 'pg_stat_%' and segment_id = 0;
+ aorelname  | aoauxrelname 
+------------+--------------
+ pg_stat_ao | pg_aoblkd
+ pg_stat_ao | pg_aoseg_
+ pg_stat_ao | pg_aovisi
+ pg_stat_co | pg_aoblkd
+ pg_stat_co | pg_aocsse
+ pg_stat_co | pg_aovisi
+(6 rows)
+
+select c.relname as aorelname, substring(s.relname, 1, 9) as aoauxrelname 
+from pg_stat_sys_indexes s 
+join pg_appendonly a on s.relid = a.segrelid or s.relid = a.blkdirrelid or s.relid = a.visimaprelid 
+join pg_class c on a.relid = c.oid 
+where c.relname like 'pg_stat_%';
+ aorelname  | aoauxrelname 
+------------+--------------
+ pg_stat_ao | pg_aoblkd
+ pg_stat_ao | pg_aovisi
+ pg_stat_co | pg_aoblkd
+ pg_stat_co | pg_aovisi
+(4 rows)
+
+select c.relname as aorelname, substring(s.relname, 1, 9) as aoauxrelname 
+from gp_stat_sys_indexes s 
+join pg_appendonly a on s.relid = a.segrelid or s.relid = a.blkdirrelid or s.relid = a.visimaprelid 
+join pg_class c on a.relid = c.oid 
+where c.relname like 'pg_stat_%' and segment_id = 0;
+ aorelname  | aoauxrelname 
+------------+--------------
+ pg_stat_ao | pg_aoblkd
+ pg_stat_ao | pg_aovisi
+ pg_stat_co | pg_aoblkd
+ pg_stat_co | pg_aovisi
+(4 rows)
+
+select c.relname as aorelname, substring(s.relname, 1, 9) as aoauxrelname 
+from pg_statio_sys_indexes s 
+join pg_appendonly a on s.relid = a.segrelid or s.relid = a.blkdirrelid or s.relid = a.visimaprelid 
+join pg_class c on a.relid = c.oid 
+where c.relname like 'pg_stat_%';
+ aorelname  | aoauxrelname 
+------------+--------------
+ pg_stat_ao | pg_aoblkd
+ pg_stat_ao | pg_aovisi
+ pg_stat_co | pg_aoblkd
+ pg_stat_co | pg_aovisi
+(4 rows)
+
+select c.relname as aorelname, substring(s.relname, 1, 9) as aoauxrelname 
+from gp_statio_sys_indexes s 
+join pg_appendonly a on s.relid = a.segrelid or s.relid = a.blkdirrelid or s.relid = a.visimaprelid 
+join pg_class c on a.relid = c.oid 
+where c.relname like 'pg_stat_%' and segment_id = 0;
+ aorelname  | aoauxrelname 
+------------+--------------
+ pg_stat_ao | pg_aoblkd
+ pg_stat_ao | pg_aovisi
+ pg_stat_co | pg_aoblkd
+ pg_stat_co | pg_aovisi
+(4 rows)
+
+-- no AO/CO aux tables are sequence, but test it anyway 
+select c.relname from pg_statio_sys_sequences s join pg_class c on s.relid = c.oid where c.relkind in ('o', 'b', 'M');
+ relname 
+---------
+(0 rows)
+
+select c.relname from gp_statio_sys_sequences s join pg_class c on s.relid = c.oid where c.relkind in ('o', 'b', 'M');
+ relname 
+---------
+(0 rows)
+

--- a/src/test/regress/sql/pg_stat.sql
+++ b/src/test/regress/sql/pg_stat.sql
@@ -54,3 +54,93 @@ select
 from gp_stat_user_indexes_summary where relname = 'pg_stat_test';
 
 reset optimizer;
+
+---------------------------------------------------------------------------
+-- "user" views should exclude AO/CO auxiliary tables, and "sys" views should include them
+---------------------------------------------------------------------------
+create table pg_stat_ao(a int) using ao_row;
+create table pg_stat_co(a int) using ao_column;
+create index pg_stat_ao_ind on pg_stat_ao(a);
+create index pg_stat_co_ind on pg_stat_co(a);
+
+-- "user" views:
+select c.relname from pg_stat_user_tables s join pg_class c on s.relid = c.oid where c.relkind in ('o', 'b', 'M');
+select c.relname from gp_stat_user_tables s join pg_class c on s.relid = c.oid where c.relkind in ('o', 'b', 'M');
+select c.relname from gp_stat_user_tables_summary s join pg_class c on s.relid = c.oid where c.relkind in ('o', 'b', 'M');
+select c.relname from pg_stat_xact_user_tables s join pg_class c on s.relid = c.oid where c.relkind in ('o', 'b', 'M');
+select c.relname from gp_stat_xact_user_tables s join pg_class c on s.relid = c.oid where c.relkind in ('o', 'b', 'M');
+select c.relname from pg_stat_user_indexes s join pg_class c on s.relid = c.oid where c.relkind in ('o', 'b', 'M');
+select c.relname from gp_stat_user_indexes s join pg_class c on s.relid = c.oid where c.relkind in ('o', 'b', 'M');
+select c.relname from gp_stat_user_indexes_summary s join pg_class c on s.relid = c.oid where c.relkind in ('o', 'b', 'M');
+select c.relname from pg_statio_user_indexes s join pg_class c on s.relid = c.oid where c.relkind in ('o', 'b', 'M');
+select c.relname from gp_statio_user_indexes s join pg_class c on s.relid = c.oid where c.relkind in ('o', 'b', 'M');
+-- no AO/CO aux tables are sequence, but test it anyway 
+select c.relname from pg_statio_user_sequences s join pg_class c on s.relid = c.oid where c.relkind in ('o', 'b', 'M');
+select c.relname from gp_statio_user_sequences s join pg_class c on s.relid = c.oid where c.relkind in ('o', 'b', 'M');
+
+-- "sys" views:
+-- for cluster-wise views, just test output of one segment.
+-- also take a fixed part of the aux table names to avoid different column length because of OIDs.
+select c.relname as aorelname, substring(s.relname, 1, 9) as aoauxrelname 
+from pg_stat_sys_tables s 
+join pg_appendonly a on s.relid = a.segrelid or s.relid = a.blkdirrelid or s.relid = a.visimaprelid 
+join pg_class c on a.relid = c.oid 
+where c.relname like 'pg_stat_%';
+
+select c.relname as aorelname, substring(s.relname, 1, 9) as aoauxrelname 
+from gp_stat_sys_tables s 
+join pg_appendonly a on s.relid = a.segrelid or s.relid = a.blkdirrelid or s.relid = a.visimaprelid 
+join pg_class c on a.relid = c.oid 
+where c.relname like 'pg_stat_%' and segment_id = 0;
+
+select c.relname as aorelname, substring(s.relname, 1, 9) as aoauxrelname 
+from pg_stat_xact_sys_tables s 
+join pg_appendonly a on s.relid = a.segrelid or s.relid = a.blkdirrelid or s.relid = a.visimaprelid 
+join pg_class c on a.relid = c.oid 
+where c.relname like 'pg_stat_%';
+
+select c.relname as aorelname, substring(s.relname, 1, 9) as aoauxrelname 
+from gp_stat_xact_sys_tables s 
+join pg_appendonly a on s.relid = a.segrelid or s.relid = a.blkdirrelid or s.relid = a.visimaprelid 
+join pg_class c on a.relid = c.oid 
+where c.relname like 'pg_stat_%' and segment_id = 0;
+
+select c.relname as aorelname, substring(s.relname, 1, 9) as aoauxrelname 
+from pg_statio_sys_tables s 
+join pg_appendonly a on s.relid = a.segrelid or s.relid = a.blkdirrelid or s.relid = a.visimaprelid 
+join pg_class c on a.relid = c.oid 
+where c.relname like 'pg_stat_%';
+
+select c.relname as aorelname, substring(s.relname, 1, 9) as aoauxrelname 
+from gp_statio_sys_tables s 
+join pg_appendonly a on s.relid = a.segrelid or s.relid = a.blkdirrelid or s.relid = a.visimaprelid 
+join pg_class c on a.relid = c.oid 
+where c.relname like 'pg_stat_%' and segment_id = 0;
+
+select c.relname as aorelname, substring(s.relname, 1, 9) as aoauxrelname 
+from pg_stat_sys_indexes s 
+join pg_appendonly a on s.relid = a.segrelid or s.relid = a.blkdirrelid or s.relid = a.visimaprelid 
+join pg_class c on a.relid = c.oid 
+where c.relname like 'pg_stat_%';
+
+select c.relname as aorelname, substring(s.relname, 1, 9) as aoauxrelname 
+from gp_stat_sys_indexes s 
+join pg_appendonly a on s.relid = a.segrelid or s.relid = a.blkdirrelid or s.relid = a.visimaprelid 
+join pg_class c on a.relid = c.oid 
+where c.relname like 'pg_stat_%' and segment_id = 0;
+
+select c.relname as aorelname, substring(s.relname, 1, 9) as aoauxrelname 
+from pg_statio_sys_indexes s 
+join pg_appendonly a on s.relid = a.segrelid or s.relid = a.blkdirrelid or s.relid = a.visimaprelid 
+join pg_class c on a.relid = c.oid 
+where c.relname like 'pg_stat_%';
+
+select c.relname as aorelname, substring(s.relname, 1, 9) as aoauxrelname 
+from gp_statio_sys_indexes s 
+join pg_appendonly a on s.relid = a.segrelid or s.relid = a.blkdirrelid or s.relid = a.visimaprelid 
+join pg_class c on a.relid = c.oid 
+where c.relname like 'pg_stat_%' and segment_id = 0;
+
+-- no AO/CO aux tables are sequence, but test it anyway 
+select c.relname from pg_statio_sys_sequences s join pg_class c on s.relid = c.oid where c.relkind in ('o', 'b', 'M');
+select c.relname from gp_statio_sys_sequences s join pg_class c on s.relid = c.oid where c.relkind in ('o', 'b', 'M');


### PR DESCRIPTION
A followup task of https://github.com/greenplum-db/gpdb/pull/15239 . Kudos to @l-wang who found it.

-----------

Since 0a926711a446, we've included AO aux tables in the pg stat views. We include them in the *_sys_* views. However we should also exclude them from the *_user_* views. Add test cases too.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
