### PR TITLE
Avoid Motion when SELECT INTO without any columns.

### DIFF
--- a/src/test/regress/expected/create_table.out
+++ b/src/test/regress/expected/create_table.out
@@ -1251,3 +1251,64 @@ Indexes:
     "part_column_drop_1_10_expr_idx1" btree ((d = 2))
 
 drop table part_column_drop;
+-- Test SELECT INTO without any columns
+begin;
+set local optimizer = off;
+create table t1(x int, y int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'x' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into t1 select i, i from generate_series(1, 10) i;
+explain(costs off) select into t2 from t1;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named '' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+             QUERY PLAN              
+-------------------------------------
+ Seq Scan on t1
+ Optimizer: Postgres query optimizer
+(2 rows)
+
+select into t2 from t1;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column(s) named '' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+select gp_segment_id from t1 order by gp_segment_id;
+ gp_segment_id 
+---------------
+             0
+             0
+             0
+             0
+             0
+             1
+             2
+             2
+             2
+             2
+(10 rows)
+
+select gp_segment_id from t2 order by gp_segment_id;
+ gp_segment_id 
+---------------
+             0
+             0
+             0
+             0
+             0
+             1
+             2
+             2
+             2
+             2
+(10 rows)
+
+-- don't disturb distributed randomly, a motion should be added.
+explain(costs off) create table t3 as select * from t1 distributed randomly;
+                   QUERY PLAN                   
+------------------------------------------------
+ Redistribute Motion 3:3  (slice1; segments: 3)
+   ->  Seq Scan on t1
+ Optimizer: Postgres query optimizer
+(3 rows)
+
+drop table t1;
+drop table t2;
+abort;

--- a/src/test/regress/sql/create_table.sql
+++ b/src/test/regress/sql/create_table.sql
@@ -955,3 +955,18 @@ create table part_column_drop_1_10 partition of
 \d part_column_drop
 \d part_column_drop_1_10
 drop table part_column_drop;
+
+-- Test SELECT INTO without any columns
+begin;
+set local optimizer = off;
+create table t1(x int, y int);
+insert into t1 select i, i from generate_series(1, 10) i;
+explain(costs off) select into t2 from t1;
+select into t2 from t1;
+select gp_segment_id from t1 order by gp_segment_id;
+select gp_segment_id from t2 order by gp_segment_id;
+-- don't disturb distributed randomly, a motion should be added.
+explain(costs off) create table t3 as select * from t1 distributed randomly;
+drop table t1;
+drop table t2;
+abort;


### PR DESCRIPTION
GPDB will add a Motion when SELECT INTO without any columns.

So that, in current GPDB, SELECT * INTO and SELECT INTO have different distributions.
```sql
gpadmin=# set optimizer=off;
SET
gpadmin=# create table t1(x int, y int);
CREATE TABLE

gpadmin=# insert into t1 select i, i from generate_series(1, 10) i;
INSERT 0 10

gpadmin=# explain select * into t2 from t1;
                       QUERY PLAN
--------------------------------------------------------
 Seq Scan on t1  (cost=0.00..321.00 rows=28700 width=8)
 Optimizer: Postgres query optimizer
(2 rows)

gpadmin=# explain select  into t3 from t1;
                                       QUERY PLAN
----------------------------------------------------------------------------------------
 Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..895.00 rows=28700 width=0)
   ->  Seq Scan on t1  (cost=0.00..321.00 rows=28700 width=0)
 Optimizer: Postgres query optimizer
(3 rows)
```
```sql
gpadmin=# select gp_segment_id from t2 order by gp_segment_id;
 gp_segment_id
---------------
             0
             0
             0
             0
             0
             1
             2
             2
             2
             2
(10 rows)

gpadmin=# select gp_segment_id from t3 order by gp_segment_id;
 gp_segment_id
---------------
             0
             0
             0
             1
             1
             1
             1
             2
             2
             2
(10 rows)
```

But is a Motion needed when ```SELECT INTO``` with empty columns?

We could let the new table distributed by the same with the selected table, and let the insertions happen where they are.
It seems doesn't matter what the distribution is for an empty column table.

The motivation of this pr is, when I exec ```SELECT INTO``` without columns or a star by mistake(which is valid, see [upstream discussion](https://www.postgresql.org/message-id/06046abe-0179-44e0-8770-b1243765c079@Spark)) , GPDB takes much more time than ```SELECT * INTO``` due to the motion.

After this change:

```sql
explain(costs off) select into t2 from t1;
             QUERY PLAN
-------------------------------------
 Seq Scan on t1
 Optimizer: Postgres query optimizer
(2 rows)
```


## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community