### PR TITLE
Fix unit test failure in gpstate on rocky8/centos7

### DIFF
--- a/gpMgmt/bin/gppylib/commands/test/unit/test_unit_unix.py
+++ b/gpMgmt/bin/gppylib/commands/test/unit/test_unit_unix.py
@@ -8,7 +8,7 @@ from gppylib.test.unit.gp_unittest import GpTestCase, run_tests
 class UnixCommandTestCase(GpTestCase):
     def setUp(self):
         self.subject = unix
-        self.subject.logger = Mock(spec=['log', 'warn', 'info', 'debug', 'error', 'warning', 'fatal'])
+        self.subject.logger = Mock(spec=['log', 'warn', 'info', 'debug', 'error', 'warning', 'fatal', 'critical'])
 
         self.apply_patches([
             patch('gppylib.commands.unix.check_pid_on_remotehost'),


### PR DESCRIPTION
After merging https://github.com/greenplum-db/gpdb/pull/15294, `test_PgPortIsActive_no_netstat_ss` gpstate unit test case started failing for rocky8 and centos7 platforms on prod pipeline with the error -
```
File "/tmp/build/9a968038/gpdb_src/gpMgmt/bin/gppylib/commands/unix.py", line 587, in __init__
logger.critical(
AttributeError: Mock object has no attribute 'critical'
```

The reason for this is that we have mocked the logger framework in the previous PR https://github.com/greenplum-db/gpdb/blob/dd223740668f8f84eed8b468e760704c94b73b76/gpMgmt/bin/gppylib/commands/test/unit/test_unit_unix.py#L11 and this mock is not cleaned up for subsequent unit test runs on these platforms (not sure why). Since we have not mocked the `critical` attribute, we see the above error.

This commit fixes this by adding the `critical` attribute to the list.

Pipeline - [rocky8](https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb-dev-6x_gpstop_pipeline_fix-rocky8/jobs/check_rocky8/builds/20), [centos7](https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb-dev-6x_gpstop_pipeline_fix-centos7/jobs/check_centos7/builds/12)