### PR TITLE
Improve optimization time for partitioned tables in Orca

### DIFF
--- a/src/backend/gpopt/gpdbwrappers.cpp
+++ b/src/backend/gpopt/gpdbwrappers.cpp
@@ -762,6 +762,18 @@ gpdb::GetAttStats(Oid relid, AttrNumber attnum)
 	return nullptr;
 }
 
+int32
+gpdb::GetAttAvgWidth(Oid relid, AttrNumber attnum)
+{
+	GP_WRAP_START;
+	{
+		/* catalog tables: pg_statistic */
+		return get_attavgwidth(relid, attnum);
+	}
+	GP_WRAP_END;
+	return 0;
+}
+
 List *
 gpdb::GetExtStats(Relation rel)
 {

--- a/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
@@ -2508,7 +2508,6 @@ CTranslatorRelcacheToDXL::RetrievePartKeysAndTypes(CMemoryPool *mp,
 {
 	GPOS_ASSERT(nullptr != rel);
 
-	// FIXME: isn't it faster to check rel.rd_partkey?
 	if (!rel->rd_partdesc)
 	{
 		// not a partitioned table

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalDynamicGetBase.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalDynamicGetBase.h
@@ -70,6 +70,11 @@ protected:
 	static ColRefToUlongMapArray *ConstructRootColMappingPerPart(
 		CMemoryPool *mp, CColRefArray *root_cols, IMdIdArray *partition_mdids);
 
+	using ColNameToIndexMap =
+		CHashMap<const CWStringConst, ULONG, CWStringConst::HashValue,
+				 CWStringConst::Equals, CleanupNULL<const CWStringConst>,
+				 CleanupDelete<ULONG>>;
+
 public:
 	// ctors
 	explicit CLogicalDynamicGetBase(CMemoryPool *mp);

--- a/src/backend/gporca/libgpos/include/gpos/string/CWStringConst.h
+++ b/src/backend/gporca/libgpos/include/gpos/string/CWStringConst.h
@@ -46,6 +46,16 @@ public:
 
 	// returns the wide character buffer storing the string
 	const WCHAR *GetBuffer() const override;
+
+	// equality
+	static BOOL Equals(const CWStringConst *string1,
+					   const CWStringConst *string2);
+
+	// hash function
+	static ULONG HashValue(const CWStringConst *string);
+
+	// checks whether the string is byte-wise equal to another string
+	BOOL Equals(const CWStringBase *str) const override;
 };
 }  // namespace gpos
 

--- a/src/backend/gporca/libgpos/src/string/CWStringConst.cpp
+++ b/src/backend/gporca/libgpos/src/string/CWStringConst.cpp
@@ -13,6 +13,7 @@
 
 #include "gpos/base.h"
 #include "gpos/common/clibwrapper.h"
+#include "gpos/utils.h"
 
 using namespace gpos;
 
@@ -118,4 +119,31 @@ CWStringConst::GetBuffer() const
 	return m_w_str_buffer;
 }
 
+// equality
+BOOL
+CWStringConst::Equals(const CWStringConst *string1,
+					  const CWStringConst *string2)
+{
+	ULONG length = GPOS_WSZ_LENGTH(string1->GetBuffer());
+	return length == GPOS_WSZ_LENGTH(string2->GetBuffer()) &&
+		   0 == clib::Wcsncmp(string1->GetBuffer(), string2->GetBuffer(),
+							  length);
+}
+
+// hash function
+ULONG
+CWStringConst::HashValue(const CWStringConst *string)
+{
+	return gpos::HashByteArray(
+		(BYTE *) string->GetBuffer(),
+		GPOS_WSZ_LENGTH(string->GetBuffer()) * GPOS_SIZEOF(WCHAR));
+}
+
+// checks whether the string is byte-wise equal to another string
+BOOL
+CWStringConst::Equals(const CWStringBase *str) const
+{
+	GPOS_ASSERT(nullptr != str);
+	return CWStringBase::Equals(str->GetBuffer());
+}
 // EOF

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/CDXLColStats.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/CDXLColStats.h
@@ -70,7 +70,7 @@ private:
 	BOOL m_is_col_stats_missing;
 
 	// DXL string for object
-	CWStringDynamic *m_dxl_str;
+	CWStringDynamic *m_dxl_str = nullptr;
 
 public:
 	CDXLColStats(const CDXLColStats &) = delete;
@@ -92,7 +92,7 @@ public:
 	CMDName Mdname() const override;
 
 	// DXL string representation of cache object
-	const CWStringDynamic *GetStrRepr() const override;
+	const CWStringDynamic *GetStrRepr() override;
 
 	// number of buckets
 	ULONG Buckets() const override;

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/CDXLExtStats.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/CDXLExtStats.h
@@ -52,7 +52,7 @@ private:
 	CMDName *m_mdname;
 
 	// DXL string for object
-	CWStringDynamic *m_dxl_str;
+	CWStringDynamic *m_dxl_str = nullptr;
 
 	CMDDependencyArray *m_dependency_array;
 
@@ -74,7 +74,7 @@ public:
 	CMDName Mdname() const override;
 
 	// DXL string representation of cache object
-	const CWStringDynamic *GetStrRepr() const override;
+	const CWStringDynamic *GetStrRepr() override;
 
 	// serialize relation stats in DXL format given a serializer object
 	void Serialize(gpdxl::CXMLSerializer *) const override;

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/CDXLExtStatsInfo.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/CDXLExtStatsInfo.h
@@ -52,7 +52,7 @@ private:
 	CMDName *m_mdname;
 
 	// DXL string for object
-	CWStringDynamic *m_dxl_str;
+	CWStringDynamic *m_dxl_str = nullptr;
 
 	CMDExtStatsInfoArray *m_extstats_info_array;
 
@@ -71,7 +71,7 @@ public:
 	CMDName Mdname() const override;
 
 	// DXL string representation of cache object
-	const CWStringDynamic *GetStrRepr() const override;
+	const CWStringDynamic *GetStrRepr() override;
 
 	// serialize relation stats in DXL format given a serializer object
 	void Serialize(gpdxl::CXMLSerializer *) const override;

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/CDXLRelStats.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/CDXLRelStats.h
@@ -58,7 +58,7 @@ private:
 	BOOL m_empty;
 
 	// DXL string for object
-	CWStringDynamic *m_dxl_str;
+	CWStringDynamic *m_dxl_str = nullptr;
 
 	// number of blocks (not always up to-to-date)
 	ULONG m_relpages;
@@ -82,7 +82,7 @@ public:
 	CMDName Mdname() const override;
 
 	// DXL string representation of cache object
-	const CWStringDynamic *GetStrRepr() const override;
+	const CWStringDynamic *GetStrRepr() override;
 
 	// number of rows
 	CDouble Rows() const override;

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/CMDAggregateGPDB.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/CMDAggregateGPDB.h
@@ -40,7 +40,7 @@ class CMDAggregateGPDB : public IMDAggregate
 	CMemoryPool *m_mp;
 
 	// DXL for object
-	const CWStringDynamic *m_dxl_str;
+	const CWStringDynamic *m_dxl_str = nullptr;
 
 	// aggregate id
 	IMDId *m_mdid;
@@ -80,11 +80,7 @@ public:
 	~CMDAggregateGPDB() override;
 
 	// string representation of object
-	const CWStringDynamic *
-	GetStrRepr() const override
-	{
-		return m_dxl_str;
-	}
+	const CWStringDynamic *GetStrRepr() override;
 
 	// aggregate id
 	IMDId *MDId() const override;

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/CMDArrayCoerceCastGPDB.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/CMDArrayCoerceCastGPDB.h
@@ -27,7 +27,7 @@ class CMDArrayCoerceCastGPDB : public CMDCastGPDB
 {
 private:
 	// DXL for object
-	const CWStringDynamic *m_dxl_str;
+	const CWStringDynamic *m_dxl_str = nullptr;
 
 	// type mod
 	INT m_type_modifier;
@@ -58,12 +58,9 @@ public:
 	// dtor
 	~CMDArrayCoerceCastGPDB() override;
 
+
 	// accessors
-	virtual const CWStringDynamic *
-	Pstr() const
-	{
-		return m_dxl_str;
-	}
+	virtual const CWStringDynamic *Pstr();
 
 	// return type modifier
 	virtual INT TypeModifier() const;

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/CMDCastGPDB.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/CMDCastGPDB.h
@@ -37,7 +37,7 @@ protected:
 	CMemoryPool *m_mp;
 
 	// DXL for object
-	const CWStringDynamic *m_dxl_str;
+	const CWStringDynamic *m_dxl_str = nullptr;
 
 	// func id
 	IMDId *m_mdid;
@@ -72,11 +72,7 @@ public:
 	~CMDCastGPDB() override;
 
 	// accessors
-	const CWStringDynamic *
-	GetStrRepr() const override
-	{
-		return m_dxl_str;
-	}
+	const CWStringDynamic *GetStrRepr() override;
 
 	// cast object id
 	IMDId *MDId() const override;

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/CMDCheckConstraintGPDB.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/CMDCheckConstraintGPDB.h
@@ -56,7 +56,7 @@ private:
 	CDXLNode *m_dxl_node;
 
 	// DXL for object
-	const CWStringDynamic *m_dxl_str;
+	const CWStringDynamic *m_dxl_str = nullptr;
 
 public:
 	// ctor
@@ -88,11 +88,7 @@ public:
 	}
 
 	// DXL string for check constraint
-	const CWStringDynamic *
-	GetStrRepr() const override
-	{
-		return m_dxl_str;
-	}
+	const CWStringDynamic *GetStrRepr() override;
 
 	// the scalar expression of the check constraint
 	CExpression *GetCheckConstraintExpr(

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/CMDFunctionGPDB.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/CMDFunctionGPDB.h
@@ -37,7 +37,7 @@ private:
 	CMemoryPool *m_mp;
 
 	// DXL for object
-	const CWStringDynamic *m_dxl_str;
+	const CWStringDynamic *m_dxl_str = nullptr;
 
 	// func id
 	IMDId *m_mdid;
@@ -101,11 +101,7 @@ public:
 	~CMDFunctionGPDB() override;
 
 	// accessors
-	const CWStringDynamic *
-	GetStrRepr() const override
-	{
-		return m_dxl_str;
-	}
+	const CWStringDynamic *GetStrRepr() override;
 
 	// function id
 	IMDId *MDId() const override;

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/CMDIndexGPDB.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/CMDIndexGPDB.h
@@ -68,7 +68,7 @@ private:
 	IMdIdArray *m_mdid_opfamilies_array;
 
 	// DXL for object
-	const CWStringDynamic *m_dxl_str;
+	const CWStringDynamic *m_dxl_str = nullptr;
 
 	// Child index oids
 	IMdIdArray *m_child_index_oids;
@@ -122,11 +122,7 @@ public:
 	ULONG GetIncludedColPos(ULONG column) const override;
 
 	// DXL string for index
-	const CWStringDynamic *
-	GetStrRepr() const override
-	{
-		return m_dxl_str;
-	}
+	const CWStringDynamic *GetStrRepr() override;
 
 	// serialize MD index in DXL format given a serializer object
 	void Serialize(gpdxl::CXMLSerializer *) const override;

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/CMDRelationCtasGPDB.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/CMDRelationCtasGPDB.h
@@ -48,7 +48,7 @@ private:
 	CMemoryPool *m_mp;
 
 	// DXL for object
-	const CWStringDynamic *m_dxl_str;
+	const CWStringDynamic *m_dxl_str = nullptr;
 
 	// relation mdid
 	IMDId *m_mdid;
@@ -119,11 +119,7 @@ public:
 	~CMDRelationCtasGPDB() override;
 
 	// accessors
-	const CWStringDynamic *
-	GetStrRepr() const override
-	{
-		return m_dxl_str;
-	}
+	const CWStringDynamic *GetStrRepr() override;
 
 	// the metadata id
 	IMDId *MDId() const override;

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/CMDRelationGPDB.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/CMDRelationGPDB.h
@@ -48,7 +48,7 @@ private:
 	CMemoryPool *m_mp;
 
 	// DXL for object
-	const CWStringDynamic *m_dxl_str;
+	const CWStringDynamic *m_dxl_str = nullptr;
 
 	// relation mdid
 	IMDId *m_mdid;
@@ -140,11 +140,7 @@ public:
 	~CMDRelationGPDB() override;
 
 	// accessors
-	const CWStringDynamic *
-	GetStrRepr() const override
-	{
-		return m_dxl_str;
-	}
+	const CWStringDynamic *GetStrRepr() override;
 
 	// the metadata id
 	IMDId *MDId() const override;

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/CMDScCmpGPDB.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/CMDScCmpGPDB.h
@@ -37,7 +37,7 @@ private:
 	CMemoryPool *m_mp;
 
 	// DXL for object
-	const CWStringDynamic *m_dxl_str;
+	const CWStringDynamic *m_dxl_str = nullptr;
 
 	// object id
 	IMDId *m_mdid;
@@ -69,11 +69,7 @@ public:
 	~CMDScCmpGPDB() override;
 
 	// accessors
-	const CWStringDynamic *
-	GetStrRepr() const override
-	{
-		return m_dxl_str;
-	}
+	const CWStringDynamic *GetStrRepr() override;
 
 	// copmarison object id
 	IMDId *MDId() const override;

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/CMDScalarOpGPDB.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/CMDScalarOpGPDB.h
@@ -38,7 +38,7 @@ private:
 	CMemoryPool *m_mp;
 
 	// DXL for object
-	const CWStringDynamic *m_dxl_str;
+	const CWStringDynamic *m_dxl_str = nullptr;
 
 	// operator id
 	IMDId *m_mdid;
@@ -99,11 +99,7 @@ public:
 	~CMDScalarOpGPDB() override;
 
 	// accessors
-	const CWStringDynamic *
-	GetStrRepr() const override
-	{
-		return m_dxl_str;
-	}
+	const CWStringDynamic *GetStrRepr() override;
 
 	// operator id
 	IMDId *MDId() const override;

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/CMDTypeBoolGPDB.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/CMDTypeBoolGPDB.h
@@ -99,7 +99,7 @@ private:
 	IMDId *m_mdid_count;
 
 	// DXL for object
-	const CWStringDynamic *m_dxl_str;
+	const CWStringDynamic *m_dxl_str = nullptr;
 
 	// type name and id
 	static CWStringConst m_str;
@@ -118,11 +118,7 @@ public:
 	~CMDTypeBoolGPDB() override;
 
 	// accessors
-	const CWStringDynamic *
-	GetStrRepr() const override
-	{
-		return m_dxl_str;
-	}
+	const CWStringDynamic *GetStrRepr() override;
 
 	// type id
 	IMDId *MDId() const override;

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/CMDTypeGenericGPDB.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/CMDTypeGenericGPDB.h
@@ -56,7 +56,7 @@ private:
 	CMemoryPool *m_mp;
 
 	// DXL for object
-	const CWStringDynamic *m_dxl_str;
+	const CWStringDynamic *m_dxl_str = nullptr;
 
 	// metadata id
 	IMDId *m_mdid;
@@ -165,11 +165,7 @@ public:
 	~CMDTypeGenericGPDB() override;
 
 	// accessors
-	const CWStringDynamic *
-	GetStrRepr() const override
-	{
-		return m_dxl_str;
-	}
+	const CWStringDynamic *GetStrRepr() override;
 
 	IMDId *MDId() const override;
 

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/CMDTypeInt2GPDB.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/CMDTypeInt2GPDB.h
@@ -104,7 +104,7 @@ private:
 	IMDId *m_mdid_count;
 
 	// DXL for object
-	const CWStringDynamic *m_dxl_str;
+	const CWStringDynamic *m_dxl_str = nullptr;
 
 	// type name and type
 	static CWStringConst m_str;
@@ -127,11 +127,7 @@ public:
 								BOOL is_null) const override;
 
 	// accessors
-	const CWStringDynamic *
-	GetStrRepr() const override
-	{
-		return m_dxl_str;
-	}
+	const CWStringDynamic *GetStrRepr() override;
 
 	// accessor of metadata id
 	IMDId *MDId() const override;

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/CMDTypeInt4GPDB.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/CMDTypeInt4GPDB.h
@@ -104,7 +104,7 @@ private:
 	IMDId *m_mdid_count;
 
 	// DXL for object
-	const CWStringDynamic *m_dxl_str;
+	const CWStringDynamic *m_dxl_str = nullptr;
 
 	// type name and type
 	static CWStringConst m_str;
@@ -127,11 +127,7 @@ public:
 								BOOL is_null) const override;
 
 	// accessors
-	const CWStringDynamic *
-	GetStrRepr() const override
-	{
-		return m_dxl_str;
-	}
+	const CWStringDynamic *GetStrRepr() override;
 
 	IMDId *MDId() const override;
 

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/CMDTypeInt8GPDB.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/CMDTypeInt8GPDB.h
@@ -105,7 +105,7 @@ private:
 	IMDId *m_mdid_count;
 
 	// DXL for object
-	const CWStringDynamic *m_dxl_str;
+	const CWStringDynamic *m_dxl_str = nullptr;
 
 	// type name
 	static CWStringConst m_str;
@@ -127,11 +127,7 @@ public:
 								BOOL is_null) const override;
 
 	// accessors
-	const CWStringDynamic *
-	GetStrRepr() const override
-	{
-		return m_dxl_str;
-	}
+	const CWStringDynamic *GetStrRepr() override;
 
 	// type id
 	IMDId *MDId() const override;

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/CMDTypeOidGPDB.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/CMDTypeOidGPDB.h
@@ -102,7 +102,7 @@ private:
 	// count aggregate
 	IMDId *m_mdid_count;
 	// DXL for object
-	const CWStringDynamic *m_dxl_str;
+	const CWStringDynamic *m_dxl_str = nullptr;
 
 	// type name and type
 	static CWStringConst m_str;
@@ -124,11 +124,7 @@ public:
 							  BOOL is_null) const override;
 
 	// accessors
-	const CWStringDynamic *
-	GetStrRepr() const override
-	{
-		return m_dxl_str;
-	}
+	const CWStringDynamic *GetStrRepr() override;
 
 	IMDId *MDId() const override;
 

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/IMDCacheObject.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/IMDCacheObject.h
@@ -90,7 +90,7 @@ public:
 	virtual void Serialize(gpdxl::CXMLSerializer *) const = 0;
 
 	// DXL string representation of cache object
-	virtual const CWStringDynamic *GetStrRepr() const = 0;
+	virtual const CWStringDynamic *GetStrRepr() = 0;
 
 
 	// serialize the metadata id information as the attributes of an

--- a/src/backend/gporca/libnaucrates/src/md/CDXLColStats.cpp
+++ b/src/backend/gporca/libnaucrates/src/md/CDXLColStats.cpp
@@ -47,8 +47,6 @@ CDXLColStats::CDXLColStats(CMemoryPool *mp, CMDIdColStats *mdid_col_stats,
 {
 	GPOS_ASSERT(mdid_col_stats->IsValid());
 	GPOS_ASSERT(nullptr != dxl_stats_bucket_array);
-	m_dxl_str = CDXLUtils::SerializeMDObj(
-		m_mp, this, false /*fSerializeHeader*/, false /*indentation*/);
 }
 
 //---------------------------------------------------------------------------
@@ -62,9 +60,23 @@ CDXLColStats::CDXLColStats(CMemoryPool *mp, CMDIdColStats *mdid_col_stats,
 CDXLColStats::~CDXLColStats()
 {
 	GPOS_DELETE(m_mdname);
-	GPOS_DELETE(m_dxl_str);
+	if (nullptr != m_dxl_str)
+	{
+		GPOS_DELETE(m_dxl_str);
+	}
 	m_mdid_col_stats->Release();
 	m_dxl_stats_bucket_array->Release();
+}
+
+const CWStringDynamic *
+CDXLColStats::GetStrRepr()
+{
+	if (nullptr == m_dxl_str)
+	{
+		m_dxl_str = CDXLUtils::SerializeMDObj(
+			m_mp, this, false /*fSerializeHeader*/, false /*indentation*/);
+	}
+	return m_dxl_str;
 }
 
 //---------------------------------------------------------------------------
@@ -93,20 +105,6 @@ CMDName
 CDXLColStats::Mdname() const
 {
 	return *m_mdname;
-}
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CDXLColStats::GetMDName
-//
-//	@doc:
-//		Returns the DXL string for this object
-//
-//---------------------------------------------------------------------------
-const CWStringDynamic *
-CDXLColStats::GetStrRepr() const
-{
-	return m_dxl_str;
 }
 
 //---------------------------------------------------------------------------

--- a/src/backend/gporca/libnaucrates/src/md/CDXLExtStats.cpp
+++ b/src/backend/gporca/libnaucrates/src/md/CDXLExtStats.cpp
@@ -33,14 +33,15 @@ CDXLExtStats::CDXLExtStats(CMemoryPool *mp, IMDId *rel_stats_mdid,
 	  m_ndistinct_array(ndistinct_array)
 {
 	GPOS_ASSERT(rel_stats_mdid->IsValid());
-	m_dxl_str = CDXLUtils::SerializeMDObj(
-		m_mp, this, false /*fSerializeHeader*/, false /*indentation*/);
 }
 
 CDXLExtStats::~CDXLExtStats()
 {
 	GPOS_DELETE(m_mdname);
-	GPOS_DELETE(m_dxl_str);
+	if (nullptr != m_dxl_str)
+	{
+		GPOS_DELETE(m_dxl_str);
+	}
 	m_rel_stats_mdid->Release();
 	m_dependency_array->Release();
 	m_ndistinct_array->Release();
@@ -83,8 +84,13 @@ CDXLExtStats::Mdname() const
 //
 //---------------------------------------------------------------------------
 const CWStringDynamic *
-CDXLExtStats::GetStrRepr() const
+CDXLExtStats::GetStrRepr()
 {
+	if (nullptr == m_dxl_str)
+	{
+		m_dxl_str = CDXLUtils::SerializeMDObj(
+			m_mp, this, false /*fSerializeHeader*/, false /*indentation*/);
+	}
 	return m_dxl_str;
 }
 

--- a/src/backend/gporca/libnaucrates/src/md/CDXLExtStatsInfo.cpp
+++ b/src/backend/gporca/libnaucrates/src/md/CDXLExtStatsInfo.cpp
@@ -32,14 +32,15 @@ CDXLExtStatsInfo::CDXLExtStatsInfo(CMemoryPool *mp, IMDId *mdid,
 	  m_extstats_info_array(extstats_info_array)
 {
 	GPOS_ASSERT(mdid->IsValid());
-	m_dxl_str = CDXLUtils::SerializeMDObj(
-		m_mp, this, false /*fSerializeHeader*/, false /*indentation*/);
 }
 
 CDXLExtStatsInfo::~CDXLExtStatsInfo()
 {
 	GPOS_DELETE(m_mdname);
-	GPOS_DELETE(m_dxl_str);
+	if (nullptr != m_dxl_str)
+	{
+		GPOS_DELETE(m_dxl_str);
+	}
 	m_mdid->Release();
 	m_extstats_info_array->Release();
 }
@@ -81,8 +82,13 @@ CDXLExtStatsInfo::Mdname() const
 //
 //---------------------------------------------------------------------------
 const CWStringDynamic *
-CDXLExtStatsInfo::GetStrRepr() const
+CDXLExtStatsInfo::GetStrRepr()
 {
+	if (nullptr == m_dxl_str)
+	{
+		m_dxl_str = CDXLUtils::SerializeMDObj(
+			m_mp, this, false /*fSerializeHeader*/, false /*indentation*/);
+	}
 	return m_dxl_str;
 }
 

--- a/src/backend/gporca/libnaucrates/src/md/CDXLRelStats.cpp
+++ b/src/backend/gporca/libnaucrates/src/md/CDXLRelStats.cpp
@@ -42,8 +42,6 @@ CDXLRelStats::CDXLRelStats(CMemoryPool *mp, CMDIdRelStats *rel_stats_mdid,
 	  m_relallvisible(relallvisible)
 {
 	GPOS_ASSERT(rel_stats_mdid->IsValid());
-	m_dxl_str = CDXLUtils::SerializeMDObj(
-		m_mp, this, false /*fSerializeHeader*/, false /*indentation*/);
 }
 
 //---------------------------------------------------------------------------
@@ -57,8 +55,22 @@ CDXLRelStats::CDXLRelStats(CMemoryPool *mp, CMDIdRelStats *rel_stats_mdid,
 CDXLRelStats::~CDXLRelStats()
 {
 	GPOS_DELETE(m_mdname);
-	GPOS_DELETE(m_dxl_str);
+	if (nullptr != m_dxl_str)
+	{
+		GPOS_DELETE(m_dxl_str);
+	}
 	m_rel_stats_mdid->Release();
+}
+
+const CWStringDynamic *
+CDXLRelStats::GetStrRepr()
+{
+	if (nullptr == m_dxl_str)
+	{
+		m_dxl_str = CDXLUtils::SerializeMDObj(
+			m_mp, this, false /*fSerializeHeader*/, false /*indentation*/);
+	}
+	return m_dxl_str;
 }
 
 //---------------------------------------------------------------------------
@@ -87,20 +99,6 @@ CMDName
 CDXLRelStats::Mdname() const
 {
 	return *m_mdname;
-}
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CDXLRelStats::GetMDName
-//
-//	@doc:
-//		Returns the DXL string for this object
-//
-//---------------------------------------------------------------------------
-const CWStringDynamic *
-CDXLRelStats::GetStrRepr() const
-{
-	return m_dxl_str;
 }
 
 //---------------------------------------------------------------------------

--- a/src/backend/gporca/libnaucrates/src/md/CMDAggregateGPDB.cpp
+++ b/src/backend/gporca/libnaucrates/src/md/CMDAggregateGPDB.cpp
@@ -45,9 +45,6 @@ CMDAggregateGPDB::CMDAggregateGPDB(CMemoryPool *mp, IMDId *mdid,
 	  m_is_repsafe(is_repsafe)
 {
 	GPOS_ASSERT(mdid->IsValid());
-
-	m_dxl_str = CDXLUtils::SerializeMDObj(
-		m_mp, this, false /*fSerializeHeader*/, false /*indentation*/);
 }
 
 //---------------------------------------------------------------------------
@@ -64,7 +61,21 @@ CMDAggregateGPDB::~CMDAggregateGPDB()
 	m_mdid_type_intermediate->Release();
 	m_mdid_type_result->Release();
 	GPOS_DELETE(m_mdname);
-	GPOS_DELETE(m_dxl_str);
+	if (nullptr != m_dxl_str)
+	{
+		GPOS_DELETE(m_dxl_str);
+	}
+}
+
+const CWStringDynamic *
+CMDAggregateGPDB::GetStrRepr()
+{
+	if (nullptr == m_dxl_str)
+	{
+		m_dxl_str = CDXLUtils::SerializeMDObj(
+			m_mp, this, false /*fSerializeHeader*/, false /*indentation*/);
+	}
+	return m_dxl_str;
 }
 
 //---------------------------------------------------------------------------

--- a/src/backend/gporca/libnaucrates/src/md/CMDArrayCoerceCastGPDB.cpp
+++ b/src/backend/gporca/libnaucrates/src/md/CMDArrayCoerceCastGPDB.cpp
@@ -35,17 +35,28 @@ CMDArrayCoerceCastGPDB::CMDArrayCoerceCastGPDB(
 	  m_location(location),
 	  m_mdid_src_elemtype(mdid_src_elemtype)
 {
-	m_dxl_str = CDXLUtils::SerializeMDObj(mp, this, false /*fSerializeHeader*/,
-										  false /*indentation*/);
 }
 
 // dtor
 CMDArrayCoerceCastGPDB::~CMDArrayCoerceCastGPDB()
 {
-	GPOS_DELETE(m_dxl_str);
+	if (nullptr != m_dxl_str)
+	{
+		GPOS_DELETE(m_dxl_str);
+	}
 	m_mdid_src_elemtype->Release();
 }
-
+// accessors
+const CWStringDynamic *
+CMDArrayCoerceCastGPDB::Pstr()
+{
+	if (nullptr == m_dxl_str)
+	{
+		m_dxl_str = CDXLUtils::SerializeMDObj(
+			m_mp, this, false /*fSerializeHeader*/, false /*indentation*/);
+	}
+	return m_dxl_str;
+}
 // return type modifier
 INT
 CMDArrayCoerceCastGPDB::TypeModifier() const

--- a/src/backend/gporca/libnaucrates/src/md/CMDCastGPDB.cpp
+++ b/src/backend/gporca/libnaucrates/src/md/CMDCastGPDB.cpp
@@ -47,9 +47,6 @@ CMDCastGPDB::CMDCastGPDB(CMemoryPool *mp, IMDId *mdid, CMDName *mdname,
 	GPOS_ASSERT(m_mdid_dest->IsValid());
 	GPOS_ASSERT_IMP(!is_binary_coercible && m_path_type != EmdtCoerceViaIO,
 					m_mdid_cast_func->IsValid());
-
-	m_dxl_str = CDXLUtils::SerializeMDObj(
-		m_mp, this, false /*fSerializeHeader*/, false /*indentation*/);
 }
 
 //---------------------------------------------------------------------------
@@ -67,9 +64,22 @@ CMDCastGPDB::~CMDCastGPDB()
 	m_mdid_dest->Release();
 	CRefCount::SafeRelease(m_mdid_cast_func);
 	GPOS_DELETE(m_mdname);
-	GPOS_DELETE(m_dxl_str);
+	if (nullptr != m_dxl_str)
+	{
+		GPOS_DELETE(m_dxl_str);
+	}
 }
 
+const CWStringDynamic *
+CMDCastGPDB::GetStrRepr()
+{
+	if (nullptr == m_dxl_str)
+	{
+		m_dxl_str = CDXLUtils::SerializeMDObj(
+			m_mp, this, false /*fSerializeHeader*/, false /*indentation*/);
+	}
+	return m_dxl_str;
+}
 
 //---------------------------------------------------------------------------
 //	@function:

--- a/src/backend/gporca/libnaucrates/src/md/CMDCheckConstraintGPDB.cpp
+++ b/src/backend/gporca/libnaucrates/src/md/CMDCheckConstraintGPDB.cpp
@@ -41,9 +41,6 @@ CMDCheckConstraintGPDB::CMDCheckConstraintGPDB(CMemoryPool *mp, IMDId *mdid,
 	GPOS_ASSERT(rel_mdid->IsValid());
 	GPOS_ASSERT(nullptr != mdname);
 	GPOS_ASSERT(nullptr != dxlnode);
-
-	m_dxl_str = CDXLUtils::SerializeMDObj(
-		m_mp, this, false /*fSerializeHeader*/, false /*indentation*/);
 }
 
 //---------------------------------------------------------------------------
@@ -57,12 +54,25 @@ CMDCheckConstraintGPDB::CMDCheckConstraintGPDB(CMemoryPool *mp, IMDId *mdid,
 CMDCheckConstraintGPDB::~CMDCheckConstraintGPDB()
 {
 	GPOS_DELETE(m_mdname);
-	GPOS_DELETE(m_dxl_str);
+	if (nullptr != m_dxl_str)
+	{
+		GPOS_DELETE(m_dxl_str);
+	}
 	m_mdid->Release();
 	m_rel_mdid->Release();
 	m_dxl_node->Release();
 }
 
+const CWStringDynamic *
+CMDCheckConstraintGPDB::GetStrRepr()
+{
+	if (nullptr == m_dxl_str)
+	{
+		m_dxl_str = CDXLUtils::SerializeMDObj(
+			m_mp, this, false /*fSerializeHeader*/, false /*indentation*/);
+	}
+	return m_dxl_str;
+}
 //---------------------------------------------------------------------------
 //	@function:
 //		CMDCheckConstraintGPDB::GetCheckConstraintExpr

--- a/src/backend/gporca/libnaucrates/src/md/CMDFunctionGPDB.cpp
+++ b/src/backend/gporca/libnaucrates/src/md/CMDFunctionGPDB.cpp
@@ -52,8 +52,6 @@ CMDFunctionGPDB::CMDFunctionGPDB(CMemoryPool *mp, IMDId *mdid, CMDName *mdname,
 	GPOS_ASSERT(EfdaSentinel > func_data_access);
 
 	InitDXLTokenArrays();
-	m_dxl_str = CDXLUtils::SerializeMDObj(
-		m_mp, this, false /*fSerializeHeader*/, false /*indentation*/);
 }
 
 //---------------------------------------------------------------------------
@@ -70,9 +68,22 @@ CMDFunctionGPDB::~CMDFunctionGPDB()
 	m_mdid_type_result->Release();
 	CRefCount::SafeRelease(m_mdid_types_array);
 	GPOS_DELETE(m_mdname);
-	GPOS_DELETE(m_dxl_str);
+	if (nullptr != m_dxl_str)
+	{
+		GPOS_DELETE(m_dxl_str);
+	}
 }
 
+const CWStringDynamic *
+CMDFunctionGPDB::GetStrRepr()
+{
+	if (nullptr == m_dxl_str)
+	{
+		m_dxl_str = CDXLUtils::SerializeMDObj(
+			m_mp, this, false /*fSerializeHeader*/, false /*indentation*/);
+	}
+	return m_dxl_str;
+}
 //---------------------------------------------------------------------------
 //	@function:
 //		CMDFunctionGPDB::InitDXLTokenArrays

--- a/src/backend/gporca/libnaucrates/src/md/CMDIndexGPDB.cpp
+++ b/src/backend/gporca/libnaucrates/src/md/CMDIndexGPDB.cpp
@@ -65,9 +65,6 @@ CMDIndexGPDB::CMDIndexGPDB(CMemoryPool *mp, IMDId *mdid, CMDName *mdname,
 	GPOS_ASSERT_IMP(IMDIndex::EmdindBitmap == index_type,
 					nullptr != mdid_item_type && mdid_item_type->IsValid());
 	GPOS_ASSERT(nullptr != mdid_opfamilies_array);
-
-	m_dxl_str = CDXLUtils::SerializeMDObj(
-		m_mp, this, false /*fSerializeHeader*/, false /*indentation*/);
 }
 
 //---------------------------------------------------------------------------
@@ -81,7 +78,10 @@ CMDIndexGPDB::CMDIndexGPDB(CMemoryPool *mp, IMDId *mdid, CMDName *mdname,
 CMDIndexGPDB::~CMDIndexGPDB()
 {
 	GPOS_DELETE(m_mdname);
-	GPOS_DELETE(m_dxl_str);
+	if (nullptr != m_dxl_str)
+	{
+		GPOS_DELETE(m_dxl_str);
+	}
 	m_mdid->Release();
 	CRefCount::SafeRelease(m_mdid_item_type);
 	m_index_key_cols_array->Release();
@@ -90,6 +90,16 @@ CMDIndexGPDB::~CMDIndexGPDB()
 	CRefCount::SafeRelease(m_child_index_oids);
 }
 
+const CWStringDynamic *
+CMDIndexGPDB::GetStrRepr()
+{
+	if (nullptr == m_dxl_str)
+	{
+		m_dxl_str = CDXLUtils::SerializeMDObj(
+			m_mp, this, false /*fSerializeHeader*/, false /*indentation*/);
+	}
+	return m_dxl_str;
+}
 //---------------------------------------------------------------------------
 //	@function:
 //		CMDIndexGPDB::MDId

--- a/src/backend/gporca/libnaucrates/src/md/CMDRelationCtasGPDB.cpp
+++ b/src/backend/gporca/libnaucrates/src/md/CMDRelationCtasGPDB.cpp
@@ -84,8 +84,6 @@ CMDRelationCtasGPDB::CMDRelationCtasGPDB(
 
 		m_col_width_array->Append(GPOS_NEW(mp) CDouble(mdcol->Length()));
 	}
-	m_dxl_str = CDXLUtils::SerializeMDObj(
-		m_mp, this, false /*fSerializeHeader*/, false /*indentation*/);
 }
 
 //---------------------------------------------------------------------------
@@ -100,7 +98,10 @@ CMDRelationCtasGPDB::~CMDRelationCtasGPDB()
 {
 	GPOS_DELETE(m_mdname_schema);
 	GPOS_DELETE(m_mdname);
-	GPOS_DELETE(m_dxl_str);
+	if (nullptr != m_dxl_str)
+	{
+		GPOS_DELETE(m_dxl_str);
+	}
 	m_mdid->Release();
 	m_md_col_array->Release();
 	m_keyset_array->Release();
@@ -112,6 +113,17 @@ CMDRelationCtasGPDB::~CMDRelationCtasGPDB()
 	m_vartypemod_array->Release();
 	m_distr_opfamilies->Release();
 	m_distr_opclasses->Release();
+}
+
+const CWStringDynamic *
+CMDRelationCtasGPDB::GetStrRepr()
+{
+	if (nullptr == m_dxl_str)
+	{
+		m_dxl_str = CDXLUtils::SerializeMDObj(
+			m_mp, this, false /*fSerializeHeader*/, false /*indentation*/);
+	}
+	return m_dxl_str;
 }
 
 //---------------------------------------------------------------------------

--- a/src/backend/gporca/libnaucrates/src/md/CMDRelationGPDB.cpp
+++ b/src/backend/gporca/libnaucrates/src/md/CMDRelationGPDB.cpp
@@ -111,8 +111,6 @@ CMDRelationGPDB::CMDRelationGPDB(
 
 		m_col_width_array->Append(GPOS_NEW(mp) CDouble(mdcol->Length()));
 	}
-	m_dxl_str = CDXLUtils::SerializeMDObj(
-		m_mp, this, false /*fSerializeHeader*/, false /*indentation*/);
 }
 
 //---------------------------------------------------------------------------
@@ -126,7 +124,10 @@ CMDRelationGPDB::CMDRelationGPDB(
 CMDRelationGPDB::~CMDRelationGPDB()
 {
 	GPOS_DELETE(m_mdname);
-	GPOS_DELETE(m_dxl_str);
+	if (nullptr != m_dxl_str)
+	{
+		GPOS_DELETE(m_dxl_str);
+	}
 	m_mdid->Release();
 	m_md_col_array->Release();
 	CRefCount::SafeRelease(m_distr_col_array);
@@ -143,6 +144,17 @@ CMDRelationGPDB::~CMDRelationGPDB()
 	CRefCount::SafeRelease(m_colpos_nondrop_colpos_map);
 	CRefCount::SafeRelease(m_attrno_nondrop_col_pos_map);
 	CRefCount::SafeRelease(m_nondrop_col_pos_array);
+}
+
+const CWStringDynamic *
+CMDRelationGPDB::GetStrRepr()
+{
+	if (nullptr == m_dxl_str)
+	{
+		m_dxl_str = CDXLUtils::SerializeMDObj(
+			m_mp, this, false /*fSerializeHeader*/, false /*indentation*/);
+	}
+	return m_dxl_str;
 }
 
 //---------------------------------------------------------------------------

--- a/src/backend/gporca/libnaucrates/src/md/CMDScCmpGPDB.cpp
+++ b/src/backend/gporca/libnaucrates/src/md/CMDScCmpGPDB.cpp
@@ -45,9 +45,6 @@ CMDScCmpGPDB::CMDScCmpGPDB(CMemoryPool *mp, IMDId *mdid, CMDName *mdname,
 	GPOS_ASSERT(m_mdid_right->IsValid());
 	GPOS_ASSERT(m_mdid_op->IsValid());
 	GPOS_ASSERT(IMDType::EcmptOther != m_comparision_type);
-
-	m_dxl_str = CDXLUtils::SerializeMDObj(
-		m_mp, this, false /*fSerializeHeader*/, false /*indentation*/);
 }
 
 //---------------------------------------------------------------------------
@@ -65,9 +62,22 @@ CMDScCmpGPDB::~CMDScCmpGPDB()
 	m_mdid_right->Release();
 	m_mdid_op->Release();
 	GPOS_DELETE(m_mdname);
-	GPOS_DELETE(m_dxl_str);
+	if (nullptr != m_dxl_str)
+	{
+		GPOS_DELETE(m_dxl_str);
+	}
 }
 
+const CWStringDynamic *
+CMDScCmpGPDB::GetStrRepr()
+{
+	if (nullptr == m_dxl_str)
+	{
+		m_dxl_str = CDXLUtils::SerializeMDObj(
+			m_mp, this, false /*fSerializeHeader*/, false /*indentation*/);
+	}
+	return m_dxl_str;
+}
 
 //---------------------------------------------------------------------------
 //	@function:

--- a/src/backend/gporca/libnaucrates/src/md/CMDScalarOpGPDB.cpp
+++ b/src/backend/gporca/libnaucrates/src/md/CMDScalarOpGPDB.cpp
@@ -53,8 +53,6 @@ CMDScalarOpGPDB::CMDScalarOpGPDB(
 	  m_is_ndv_preserving(is_ndv_preserving)
 {
 	GPOS_ASSERT(nullptr != mdid_opfamilies_array);
-	m_dxl_str = CDXLUtils::SerializeMDObj(
-		m_mp, this, false /*fSerializeHeader*/, false /*indentation*/);
 }
 
 
@@ -80,8 +78,22 @@ CMDScalarOpGPDB::~CMDScalarOpGPDB()
 	CRefCount::SafeRelease(m_mdid_legacy_hash_opfamily);
 
 	GPOS_DELETE(m_mdname);
-	GPOS_DELETE(m_dxl_str);
+	if (nullptr != m_dxl_str)
+	{
+		GPOS_DELETE(m_dxl_str);
+	}
 	m_mdid_opfamilies_array->Release();
+}
+
+const CWStringDynamic *
+CMDScalarOpGPDB::GetStrRepr()
+{
+	if (nullptr == m_dxl_str)
+	{
+		m_dxl_str = CDXLUtils::SerializeMDObj(
+			m_mp, this, false /*fSerializeHeader*/, false /*indentation*/);
+	}
+	return m_dxl_str;
 }
 
 //---------------------------------------------------------------------------

--- a/src/backend/gporca/libnaucrates/src/md/CMDTypeBoolGPDB.cpp
+++ b/src/backend/gporca/libnaucrates/src/md/CMDTypeBoolGPDB.cpp
@@ -74,9 +74,6 @@ CMDTypeBoolGPDB::CMDTypeBoolGPDB(CMemoryPool *mp) : m_mp(mp)
 	m_mdid_count =
 		GPOS_NEW(mp) CMDIdGPDB(IMDId::EmdidGeneral, GPDB_BOOL_AGG_COUNT);
 
-	m_dxl_str = CDXLUtils::SerializeMDObj(
-		m_mp, this, false /*fSerializeHeader*/, false /*indentation*/);
-
 	m_mdid->AddRef();
 
 	GPOS_ASSERT(GPDB_BOOL_OID == CMDIdGPDB::CastMdid(m_mdid)->Oid());
@@ -113,7 +110,21 @@ CMDTypeBoolGPDB::~CMDTypeBoolGPDB()
 	m_mdid_sum->Release();
 	m_mdid_count->Release();
 	m_datum_null->Release();
-	GPOS_DELETE(m_dxl_str);
+	if (nullptr != m_dxl_str)
+	{
+		GPOS_DELETE(m_dxl_str);
+	}
+}
+
+const CWStringDynamic *
+CMDTypeBoolGPDB::GetStrRepr()
+{
+	if (nullptr == m_dxl_str)
+	{
+		m_dxl_str = CDXLUtils::SerializeMDObj(
+			m_mp, this, false /*fSerializeHeader*/, false /*indentation*/);
+	}
+	return m_dxl_str;
 }
 
 //---------------------------------------------------------------------------

--- a/src/backend/gporca/libnaucrates/src/md/CMDTypeGenericGPDB.cpp
+++ b/src/backend/gporca/libnaucrates/src/md/CMDTypeGenericGPDB.cpp
@@ -90,8 +90,6 @@ CMDTypeGenericGPDB::CMDTypeGenericGPDB(
 {
 	GPOS_ASSERT_IMP(m_is_fixed_length, 0 < m_length);
 	GPOS_ASSERT_IMP(!m_is_fixed_length, 0 > m_gpdb_length);
-	m_dxl_str = CDXLUtils::SerializeMDObj(
-		m_mp, this, false /*fSerializeHeader*/, false /*indentation*/);
 
 	m_mdid->AddRef();
 	m_datum_null = GPOS_NEW(m_mp) CDatumGenericGPDB(
@@ -128,10 +126,23 @@ CMDTypeGenericGPDB::~CMDTypeGenericGPDB()
 	m_mdid_count->Release();
 	CRefCount::SafeRelease(m_mdid_base_relation);
 	GPOS_DELETE(m_mdname);
-	GPOS_DELETE(m_dxl_str);
+	if (nullptr != m_dxl_str)
+	{
+		GPOS_DELETE(m_dxl_str);
+	}
 	m_datum_null->Release();
 }
 
+const CWStringDynamic *
+CMDTypeGenericGPDB::GetStrRepr()
+{
+	if (nullptr == m_dxl_str)
+	{
+		m_dxl_str = CDXLUtils::SerializeMDObj(
+			m_mp, this, false /*fSerializeHeader*/, false /*indentation*/);
+	}
+	return m_dxl_str;
+}
 
 //---------------------------------------------------------------------------
 //	@function:

--- a/src/backend/gporca/libnaucrates/src/md/CMDTypeInt2GPDB.cpp
+++ b/src/backend/gporca/libnaucrates/src/md/CMDTypeInt2GPDB.cpp
@@ -73,9 +73,6 @@ CMDTypeInt2GPDB::CMDTypeInt2GPDB(CMemoryPool *mp) : m_mp(mp)
 	m_mdid_count =
 		GPOS_NEW(mp) CMDIdGPDB(IMDId::EmdidGeneral, GPDB_INT2_AGG_COUNT);
 
-	m_dxl_str = CDXLUtils::SerializeMDObj(
-		m_mp, this, false /*fSerializeHeader*/, false /*indentation*/);
-
 	GPOS_ASSERT(GPDB_INT2_OID == CMDIdGPDB::CastMdid(m_mdid)->Oid());
 	m_mdid->AddRef();
 	m_datum_null =
@@ -110,8 +107,21 @@ CMDTypeInt2GPDB::~CMDTypeInt2GPDB()
 	m_mdid_sum->Release();
 	m_mdid_count->Release();
 	m_datum_null->Release();
+	if (nullptr != m_dxl_str)
+	{
+		GPOS_DELETE(m_dxl_str);
+	}
+}
 
-	GPOS_DELETE(m_dxl_str);
+const CWStringDynamic *
+CMDTypeInt2GPDB::GetStrRepr()
+{
+	if (nullptr == m_dxl_str)
+	{
+		m_dxl_str = CDXLUtils::SerializeMDObj(
+			m_mp, this, false /*fSerializeHeader*/, false /*indentation*/);
+	}
+	return m_dxl_str;
 }
 
 //---------------------------------------------------------------------------

--- a/src/backend/gporca/libnaucrates/src/md/CMDTypeInt4GPDB.cpp
+++ b/src/backend/gporca/libnaucrates/src/md/CMDTypeInt4GPDB.cpp
@@ -73,9 +73,6 @@ CMDTypeInt4GPDB::CMDTypeInt4GPDB(CMemoryPool *mp) : m_mp(mp)
 	m_mdid_count =
 		GPOS_NEW(mp) CMDIdGPDB(IMDId::EmdidGeneral, GPDB_INT4_AGG_COUNT);
 
-	m_dxl_str = CDXLUtils::SerializeMDObj(
-		m_mp, this, false /*fSerializeHeader*/, false /*indentation*/);
-
 	GPOS_ASSERT(GPDB_INT4_OID == CMDIdGPDB::CastMdid(m_mdid)->Oid());
 	m_mdid->AddRef();
 	m_datum_null =
@@ -110,8 +107,21 @@ CMDTypeInt4GPDB::~CMDTypeInt4GPDB()
 	m_mdid_sum->Release();
 	m_mdid_count->Release();
 	m_datum_null->Release();
+	if (nullptr != m_dxl_str)
+	{
+		GPOS_DELETE(m_dxl_str);
+	}
+}
 
-	GPOS_DELETE(m_dxl_str);
+const CWStringDynamic *
+CMDTypeInt4GPDB::GetStrRepr()
+{
+	if (nullptr == m_dxl_str)
+	{
+		m_dxl_str = CDXLUtils::SerializeMDObj(
+			m_mp, this, false /*fSerializeHeader*/, false /*indentation*/);
+	}
+	return m_dxl_str;
 }
 
 //---------------------------------------------------------------------------

--- a/src/backend/gporca/libnaucrates/src/md/CMDTypeInt8GPDB.cpp
+++ b/src/backend/gporca/libnaucrates/src/md/CMDTypeInt8GPDB.cpp
@@ -80,9 +80,6 @@ CMDTypeInt8GPDB::CMDTypeInt8GPDB(CMemoryPool *mp) : m_mp(mp)
 	m_mdid_count =
 		GPOS_NEW(mp) CMDIdGPDB(IMDId::EmdidGeneral, GPDB_INT8_AGG_COUNT);
 
-	m_dxl_str = CDXLUtils::SerializeMDObj(
-		m_mp, this, false /*fSerializeHeader*/, false /*indentation*/);
-
 	GPOS_ASSERT(GPDB_INT8_OID == CMDIdGPDB::CastMdid(m_mdid)->Oid());
 	m_mdid->AddRef();
 	m_datum_null =
@@ -118,8 +115,21 @@ CMDTypeInt8GPDB::~CMDTypeInt8GPDB()
 	m_mdid_sum->Release();
 	m_mdid_count->Release();
 	m_datum_null->Release();
+	if (nullptr != m_dxl_str)
+	{
+		GPOS_DELETE(m_dxl_str);
+	}
+}
 
-	GPOS_DELETE(m_dxl_str);
+const CWStringDynamic *
+CMDTypeInt8GPDB::GetStrRepr()
+{
+	if (nullptr == m_dxl_str)
+	{
+		m_dxl_str = CDXLUtils::SerializeMDObj(
+			m_mp, this, false /*fSerializeHeader*/, false /*indentation*/);
+	}
+	return m_dxl_str;
 }
 
 //---------------------------------------------------------------------------

--- a/src/backend/gporca/libnaucrates/src/md/CMDTypeOidGPDB.cpp
+++ b/src/backend/gporca/libnaucrates/src/md/CMDTypeOidGPDB.cpp
@@ -74,9 +74,6 @@ CMDTypeOidGPDB::CMDTypeOidGPDB(CMemoryPool *mp) : m_mp(mp)
 	m_mdid_count =
 		GPOS_NEW(mp) CMDIdGPDB(IMDId::EmdidGeneral, GPDB_OID_AGG_COUNT);
 
-	m_dxl_str = CDXLUtils::SerializeMDObj(
-		m_mp, this, false /*fSerializeHeader*/, false /*indentation*/);
-
 	GPOS_ASSERT(GPDB_OID_OID == CMDIdGPDB::CastMdid(m_mdid)->Oid());
 	m_mdid->AddRef();
 	m_datum_null =
@@ -113,9 +110,22 @@ CMDTypeOidGPDB::~CMDTypeOidGPDB()
 	m_mdid_count->Release();
 	m_datum_null->Release();
 
-	GPOS_DELETE(m_dxl_str);
+	if (nullptr != m_dxl_str)
+	{
+		GPOS_DELETE(m_dxl_str);
+	}
 }
 
+const CWStringDynamic *
+CMDTypeOidGPDB::GetStrRepr()
+{
+	if (nullptr == m_dxl_str)
+	{
+		m_dxl_str = CDXLUtils::SerializeMDObj(
+			m_mp, this, false /*fSerializeHeader*/, false /*indentation*/);
+	}
+	return m_dxl_str;
+}
 //---------------------------------------------------------------------------
 //	@function:
 //		CMDTypeOidGPDB::GetDatum

--- a/src/include/gpopt/gpdbwrappers.h
+++ b/src/include/gpopt/gpdbwrappers.h
@@ -208,6 +208,9 @@ void FreeAttrStatsSlot(AttStatsSlot *sslot);
 // attribute statistics
 HeapTuple GetAttStats(Oid relid, AttrNumber attnum);
 
+// attribute width
+int32 GetAttAvgWidth(Oid relid, AttrNumber attnum);
+
 List *GetExtStats(Relation rel);
 
 char *GetExtStatsName(Oid statOid);


### PR DESCRIPTION
With the GPDB7 partitioning work, Orca reads each individual partition's information instead of only the top level partition. This allows us to perform static elimination and is needed to construct the constraints for each child partition (and the column mapping for those constraints). However, this means that for a table with 1000 partitions and 1000 columns, we're doing much more processing than before. We're reading 1000 tables from the catalog, and 1000*1000 columns. Certain operations that were negligible before now take significant time and relcache space. The 3 optimizations in the commits here bring the optimization time down much more closely to the 6X numbers.

Together, these changes bring the optimization time for a simple select * from part_tbl with 1200 partitions and 200 int columns down from 6s to 1.1s for an empty relcache, and 560ms to 110ms with the tables in the relcache. In 6X, these numbers are closer to 200ms with an empty relcache, and 30ms within the relcache. There's still some other areas we can improve (reading the table names into a CmdName takes 250ms for example), but these are the major ones I found.

Fixes https://github.com/greenplum-db/gpdb/issues/14169