### PR TITLE
Add gp_stat_progress_*_summary system views

### DIFF
--- a/src/backend/catalog/Makefile
+++ b/src/backend/catalog/Makefile
@@ -158,6 +158,7 @@ install-data: bki-stamp installdirs
 	$(INSTALL_DATA) $(call vpathsearch,postgres.shdescription) '$(DESTDIR)$(datadir)/postgres.shdescription'
 	$(INSTALL_DATA) $(srcdir)/system_views.sql '$(DESTDIR)$(datadir)/system_views.sql'
 	$(INSTALL_DATA) $(srcdir)/$(GP_SYSVIEW_SQL) '$(DESTDIR)$(datadir)/$(GP_SYSVIEW_SQL)'
+	$(INSTALL_DATA) $(srcdir)/system_views_gp_summary.sql '$(DESTDIR)$(datadir)/system_views_gp_summary.sql'
 	$(INSTALL_DATA) $(srcdir)/information_schema.sql '$(DESTDIR)$(datadir)/information_schema.sql'
 	$(INSTALL_DATA) $(call vpathsearch,cdb_schema.sql) '$(DESTDIR)$(datadir)/cdb_init.d/cdb_schema.sql'
 	$(INSTALL_DATA) $(srcdir)/sql_features.txt '$(DESTDIR)$(datadir)/sql_features.txt'
@@ -169,7 +170,7 @@ installdirs:
 
 .PHONY: uninstall-data
 uninstall-data:
-	rm -f $(addprefix '$(DESTDIR)$(datadir)'/, $(BKIFILES) system_views.sql $(GP_SYSVIEW_SQL) information_schema.sql cdb_init.d/cdb_schema.sql sql_features.txt)
+	rm -f $(addprefix '$(DESTDIR)$(datadir)'/, $(BKIFILES) system_views.sql $(GP_SYSVIEW_SQL) system_views_gp_summary.sql information_schema.sql cdb_init.d/cdb_schema.sql sql_features.txt)
 
 # postgres.bki, postgres.description, postgres.shdescription,
 # and the generated headers are in the distribution tarball,

--- a/src/backend/catalog/system_views.sql
+++ b/src/backend/catalog/system_views.sql
@@ -1517,6 +1517,8 @@ CREATE VIEW pg_stat_progress_copy AS
         S.relid AS relid,
         CASE S.param5 WHEN 1 THEN 'COPY FROM'
                       WHEN 2 THEN 'COPY TO'
+                      WHEN 3 THEN 'COPY FROM ON SEGMENT'
+                      WHEN 4 THEN 'COPY TO ON SEGMENT'
                       END AS command,
         CASE S.param6 WHEN 1 THEN 'FILE'
                       WHEN 2 THEN 'PROGRAM'

--- a/src/backend/catalog/system_views_gp_summary.sql
+++ b/src/backend/catalog/system_views_gp_summary.sql
@@ -150,3 +150,14 @@ FROM gp_stat_progress_copy gspc
     LEFT JOIN gp_stat_progress_copy gspc1 ON gspc.pid = gspc1.pid AND gspc1.gp_segment_id = -1
     LEFT JOIN gp_stat_progress_copy gspc2 ON gspc.pid = gspc2.pid AND gspc2.gp_segment_id = 0
 GROUP BY gspc.datid, gspc.datname, gspc.relid, gspc.command, ac.sess_id, d.policytype, d.numsegments;
+
+CREATE OR REPLACE VIEW gp_stat_progress_basebackup_summary AS
+SELECT
+    coalesce((select pid from gp_stat_progress_basebackup limit 1), NULL) as pid,
+    a.phase,
+    sum(a.backup_total) as backup_total,
+    sum(a.backup_streamed) as backup_streamed,
+    avg(a.tablespaces_total) as tablespaces_total,
+    avg(a.tablespaces_streamed) as tablespaces_streamed
+FROM gp_stat_progress_basebackup a
+GROUP BY a.phase;

--- a/src/backend/catalog/system_views_gp_summary.sql
+++ b/src/backend/catalog/system_views_gp_summary.sql
@@ -1,0 +1,109 @@
+/*
+ * Greenplum System Summary Views
+ *
+ * Portions Copyright (c) 2006-2010, Greenplum inc.
+ * Portions Copyright (c) 2012-Present VMware, Inc. or its affiliates.
+ * Copyright (c) 1996-2019, PostgreSQL Global Development Group
+ *
+ * src/backend/catalog/system_views_gp_summary.sql
+ *
+
+ * This file contains summary views for various Greenplum system catalog
+ * views. These summary views are designed to provide aggregated or averaged
+ * information for partitioned and replicated tables, considering multiple
+ * segments in a Greenplum database.
+ *
+ * Note: this file is read in single-user -j mode, which means that the
+ * command terminator is semicolon-newline-newline; whenever the backend
+ * sees that, it stops and executes what it's got.  If you write a lot of
+ * statements without empty lines between, they'll all get quoted to you
+ * in any error message about one of them, so don't do that.  Also, you
+ * cannot write a semicolon immediately followed by an empty line in a
+ * string literal (including a function body!) or a multiline comment.
+ */
+
+CREATE VIEW gp_stat_progress_vacuum_summary AS
+SELECT
+    max(coalesce(a1.pid, 0)) as pid,
+    a.datid,
+    a.datname,
+    a.relid,
+    a.phase,
+    case when d.policytype = 'r' then (sum(a.heap_blks_total)/d.numsegments)::bigint else sum(a.heap_blks_total) end heap_blks_total,
+    case when d.policytype = 'r' then (sum(a.heap_blks_scanned)/d.numsegments)::bigint else sum(a.heap_blks_scanned) end heap_blks_scanned,
+    case when d.policytype = 'r' then (sum(a.heap_blks_vacuumed)/d.numsegments)::bigint else sum(a.heap_blks_vacuumed) end heap_blks_vacuumed,
+    case when d.policytype = 'r' then (sum(a.index_vacuum_count)/d.numsegments)::bigint else sum(a.index_vacuum_count) end index_vacuum_count,
+    case when d.policytype = 'r' then (sum(a.max_dead_tuples)/d.numsegments)::bigint else sum(a.max_dead_tuples) end max_dead_tuples,
+    case when d.policytype = 'r' then (sum(a.num_dead_tuples)/d.numsegments)::bigint else sum(a.num_dead_tuples) end num_dead_tuples
+FROM gp_stat_progress_vacuum a
+    JOIN pg_class c ON a.relid = c.oid
+    LEFT JOIN gp_distribution_policy d ON c.oid = d.localoid
+    LEFT JOIN gp_stat_progress_vacuum a1 ON a.pid = a1.pid AND a1.gp_segment_id = -1
+WHERE a.gp_segment_id > -1
+GROUP BY a.datid, a.datname, a.relid, a.phase, d.policytype, d.numsegments;
+
+CREATE OR REPLACE VIEW gp_stat_progress_analyze_summary AS
+SELECT
+    max(coalesce(a1.pid, 0)) as pid,
+    a.datid,
+    a.datname,
+    a.relid,
+    a.phase,
+    case when d.policytype = 'r' then (sum(a.sample_blks_total)/d.numsegments)::bigint else sum(a.sample_blks_total) end sample_blks_total,
+    case when d.policytype = 'r' then (sum(a.sample_blks_scanned)/d.numsegments)::bigint else sum(a.sample_blks_scanned) end sample_blks_scanned,
+    case when d.policytype = 'r' then (sum(a.ext_stats_total)/d.numsegments)::bigint else sum(a.ext_stats_total) end ext_stats_total,
+    case when d.policytype = 'r' then (sum(a.ext_stats_computed)/d.numsegments)::bigint else sum(a.ext_stats_computed) end ext_stats_computed,
+    case when d.policytype = 'r' then (sum(a.child_tables_total)/d.numsegments)::bigint else sum(a.child_tables_total) end child_tables_total,
+    case when d.policytype = 'r' then (sum(a.child_tables_done)/d.numsegments)::bigint else sum(a.child_tables_done) end child_tables_done
+FROM gp_stat_progress_analyze a
+    JOIN pg_class c ON a.relid = c.oid
+    LEFT JOIN gp_distribution_policy d ON c.oid = d.localoid
+    LEFT JOIN gp_stat_progress_analyze a1 ON a.pid = a1.pid AND a1.gp_segment_id = -1
+WHERE a.gp_segment_id > -1
+GROUP BY a.datid, a.datname, a.relid, a.phase, d.policytype, d.numsegments;
+
+CREATE OR REPLACE VIEW gp_stat_progress_cluster_summary AS
+SELECT
+    max(coalesce(a1.pid, 0)) as pid,
+    a.datid,
+    a.datname,
+    a.relid,
+    a.command,
+    a.phase,
+    a.cluster_index_relid,
+    case when d.policytype = 'r' then (sum(a.heap_tuples_scanned)/d.numsegments)::bigint else sum(a.heap_tuples_scanned) end heap_tuples_scanned,
+    case when d.policytype = 'r' then (sum(a.heap_tuples_written)/d.numsegments)::bigint else sum(a.heap_tuples_written) end heap_tuples_written,
+    case when d.policytype = 'r' then (sum(a.heap_blks_total)/d.numsegments)::bigint else sum(a.heap_blks_total) end heap_blks_total,
+    case when d.policytype = 'r' then (sum(a.heap_blks_scanned)/d.numsegments)::bigint else sum(a.heap_blks_scanned) end heap_blks_scanned,
+    case when d.policytype = 'r' then (sum(a.index_rebuild_count)/d.numsegments)::bigint else sum(a.index_rebuild_count) end index_rebuild_count
+FROM gp_stat_progress_cluster a
+    JOIN pg_class c ON a.relid = c.oid
+    LEFT JOIN gp_distribution_policy d ON c.oid = d.localoid
+    LEFT JOIN gp_stat_progress_cluster a1 ON a.pid = a1.pid AND a1.gp_segment_id = -1
+WHERE a.gp_segment_id > -1
+GROUP BY a.datid, a.datname, a.relid, a.command, a.phase, a.cluster_index_relid, d.policytype, d.numsegments;
+
+CREATE OR REPLACE VIEW gp_stat_progress_create_index_summary AS
+SELECT
+    max(coalesce(a1.pid, 0)) as pid,
+    a.datid,
+    a.datname,
+    a.relid,
+    a.index_relid,
+    a.command,
+    a.phase,
+    case when d.policytype = 'r' then (sum(a.lockers_total)/d.numsegments)::bigint else sum(a.lockers_total) end lockers_total,
+    case when d.policytype = 'r' then (sum(a.lockers_done)/d.numsegments)::bigint else sum(a.lockers_done) end lockers_done,
+    max(a.current_locker_pid) as current_locker_pid,
+    case when d.policytype = 'r' then (sum(a.blocks_total)/d.numsegments)::bigint else sum(a.blocks_total) end blocks_total,
+    case when d.policytype = 'r' then (sum(a.blocks_done)/d.numsegments)::bigint else sum(a.blocks_done) end blocks_done,
+    case when d.policytype = 'r' then (sum(a.tuples_total)/d.numsegments)::bigint else sum(a.tuples_total) end tuples_total,
+    case when d.policytype = 'r' then (sum(a.tuples_done)/d.numsegments)::bigint else sum(a.tuples_done) end tuples_done,
+    case when d.policytype = 'r' then (sum(a.partitions_total)/d.numsegments)::bigint else sum(a.partitions_total) end partitions_total,
+    case when d.policytype = 'r' then (sum(a.partitions_done)/d.numsegments)::bigint else sum(a.partitions_done) end partitions_done
+FROM gp_stat_progress_create_index a
+    JOIN pg_class c ON a.relid = c.oid
+    LEFT JOIN gp_distribution_policy d ON c.oid = d.localoid
+    LEFT JOIN gp_stat_progress_create_index a1 ON a.pid = a1.pid AND a1.gp_segment_id = -1
+WHERE a.gp_segment_id > -1
+GROUP BY a.datid, a.datname, a.relid, a.index_relid, a.command, a.phase, d.policytype, d.numsegments;

--- a/src/backend/commands/analyze.c
+++ b/src/backend/commands/analyze.c
@@ -1596,6 +1596,7 @@ acquire_sample_rows(Relation onerel, int elevel,
 
 		pgstat_progress_update_param(PROGRESS_ANALYZE_BLOCKS_DONE,
 									 ++blksdone);
+		SIMPLE_FAULT_INJECTOR("analyze_block");
 	}
 
 	ExecDropSingleTupleTableSlot(slot);

--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -2593,6 +2593,9 @@ BeginCopyTo(ParseState *pstate,
 					   options, NULL);
 	oldcontext = MemoryContextSwitchTo(cstate->copycontext);
 
+	if (cstate->on_segment)
+		progress_vals[0] = PROGRESS_COPY_COMMAND_TO_ON_SEGMENT;
+
 	/* Determine the mode */
 	if (Gp_role == GP_ROLE_DISPATCH && !cstate->on_segment &&
 		cstate->rel && cstate->rel->rd_cdbpolicy)
@@ -4932,6 +4935,9 @@ BeginCopyFrom(ParseState *pstate,
 
 	cstate = BeginCopy(pstate, true, rel, NULL, InvalidOid, attnamelist, options, NULL);
 	oldcontext = MemoryContextSwitchTo(cstate->copycontext);
+
+	if (cstate->on_segment)
+		progress_vals[0] = PROGRESS_COPY_COMMAND_FROM_ON_SEGMENT;
 
 	/*
 	 * Determine the mode

--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -3235,6 +3235,10 @@ CopyTo(CopyState cstate)
 						*/
 						pgstat_progress_update_param(PROGRESS_COPY_TUPLES_PROCESSED,
 													 ++processed);
+#ifdef FAULT_INJECTOR
+						if (processed == 2)
+							SIMPLE_FAULT_INJECTOR("copy_processed_two_tuples");
+#endif
 					}
 					ExecDropSingleTupleTableSlot(slot);
 					table_endscan(scandesc);
@@ -4756,6 +4760,10 @@ CopyFrom(CopyState cstate)
 			 */
 			pgstat_progress_update_param(PROGRESS_COPY_TUPLES_PROCESSED,
 										 ++processed);
+#ifdef FAULT_INJECTOR
+			if (processed == 2)
+				SIMPLE_FAULT_INJECTOR("copy_processed_two_tuples");
+#endif
 			if (cstate->cdbsreh)
 				cstate->cdbsreh->processed++;
 		}

--- a/src/backend/replication/basebackup.c
+++ b/src/backend/replication/basebackup.c
@@ -480,6 +480,7 @@ perform_base_backup(basebackup_options *opt)
 			tblspc_streamed++;
 			pgstat_progress_update_param(PROGRESS_BASEBACKUP_TBLSPC_STREAMED,
 										 tblspc_streamed);
+			SIMPLE_FAULT_INJECTOR("basebackup_progress_tablespace_streamed");
 		}
 
 		pgstat_progress_update_param(PROGRESS_BASEBACKUP_PHASE,
@@ -752,6 +753,7 @@ perform_base_backup(basebackup_options *opt)
 				 errmsg("checksum verification failure during base backup")));
 	}
 
+	SIMPLE_FAULT_INJECTOR("basebackup_progress_end");
 	pgstat_progress_end_command();
 }
 

--- a/src/bin/initdb/initdb.c
+++ b/src/bin/initdb/initdb.c
@@ -164,6 +164,7 @@ static char *cdb_init_d_dir;
 static char *features_file;
 static char *system_views_file;
 static char *system_views_gp_file;
+static char *system_views_gp_summary_file;
 static bool success = false;
 static bool made_new_pgdata = false;
 static bool found_existing_pgdata = false;
@@ -1723,6 +1724,19 @@ setup_sysviews(FILE *cmdfd)
 	PG_CMD_PUTS("\n\n");
 
 	free(sysviews_setup);
+
+	/* system_views_gp_summary.sql */
+	sysviews_setup = readfile(system_views_gp_summary_file);
+
+	for (line = sysviews_setup; *line != NULL; line++)
+	{
+		PG_CMD_PUTS(*line);
+		free(*line);
+	}
+
+	PG_CMD_PUTS("\n\n");
+
+	free(sysviews_setup);
 }
 
 /*
@@ -2870,6 +2884,7 @@ setup_data_file_paths(void)
 	set_input(&features_file, "sql_features.txt");
 	set_input(&system_views_file, "system_views.sql");
 	set_input(&system_views_gp_file, "system_views_gp.sql");
+	set_input(&system_views_gp_summary_file, "system_views_gp_summary.sql");
 
 	set_input(&cdb_init_d_dir, "cdb_init.d");
 
@@ -2903,6 +2918,7 @@ setup_data_file_paths(void)
 	check_input(features_file);
 	check_input(system_views_file);
 	check_input(system_views_gp_file);
+	check_input(system_views_gp_summary_file);
 }
 
 

--- a/src/include/catalog/catversion.h
+++ b/src/include/catalog/catversion.h
@@ -56,6 +56,6 @@
  */
 
 /*							3yyymmddN */
-#define CATALOG_VERSION_NO	302305022
+#define CATALOG_VERSION_NO	302305023
 
 #endif

--- a/src/include/catalog/catversion.h
+++ b/src/include/catalog/catversion.h
@@ -56,6 +56,6 @@
  */
 
 /*							3yyymmddN */
-#define CATALOG_VERSION_NO	302305021
+#define CATALOG_VERSION_NO	302305022
 
 #endif

--- a/src/include/catalog/catversion.h
+++ b/src/include/catalog/catversion.h
@@ -56,6 +56,6 @@
  */
 
 /*							3yyymmddN */
-#define CATALOG_VERSION_NO	302305023
+#define CATALOG_VERSION_NO	302305024
 
 #endif

--- a/src/include/commands/progress.h
+++ b/src/include/commands/progress.h
@@ -151,6 +151,9 @@
 /* Commands of COPY (as advertised via PROGRESS_COPY_COMMAND) */
 #define PROGRESS_COPY_COMMAND_FROM 1
 #define PROGRESS_COPY_COMMAND_TO 2
+/* GPDB specific */
+#define PROGRESS_COPY_COMMAND_FROM_ON_SEGMENT 3
+#define PROGRESS_COPY_COMMAND_TO_ON_SEGMENT 4
 
 /* Types of COPY commands (as advertised via PROGRESS_COPY_TYPE) */
 #define PROGRESS_COPY_TYPE_FILE 1

--- a/src/test/isolation2/expected/analyze_progress.out
+++ b/src/test/isolation2/expected/analyze_progress.out
@@ -1,0 +1,95 @@
+-- Test gp_stat_progress_analyze_summary
+-- setup hash distributed table
+CREATE TABLE t_analyze_part (a INT, b INT) DISTRIBUTED BY (a);
+CREATE
+INSERT INTO t_analyze_part SELECT i, i FROM generate_series(1, 100000) i;
+INSERT 100000
+
+-- Suspend analyze after scanning 20 blocks on each segment
+SELECT gp_inject_fault('analyze_block', 'suspend', '', '', '', 20, 20, 0, dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+(3 rows)
+
+-- session 1: analyze the table
+1&: ANALYZE t_analyze_part;  <waiting ...>
+SELECT gp_wait_until_triggered_fault('analyze_block', 1, dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+ Success:                      
+ Success:                      
+(3 rows)
+
+-- session 2: query pg_stat_progress_analyze while the analyze is running, the view should indicate 60 blocks have been scanned as aggregated progress of 3 segments
+2: SELECT pid IS NOT NULL as has_pid, datname, relid::regclass, phase, sample_blks_total, sample_blks_scanned FROM gp_stat_progress_analyze_summary;
+ has_pid | datname        | relid          | phase                 | sample_blks_total | sample_blks_scanned 
+---------+----------------+----------------+-----------------------+-------------------+---------------------
+ t       | isolation2test | t_analyze_part | acquiring sample rows | 111               | 60                  
+(1 row)
+
+-- Reset fault injector
+SELECT gp_inject_fault('analyze_block', 'reset', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+(3 rows)
+1<:  <... completed>
+ANALYZE
+
+-- teardown
+DROP TABLE t_analyze_part;
+DROP
+
+-- setup replicated table
+CREATE TABLE t_analyze_repl (a INT, b INT) DISTRIBUTED REPLICATED;
+CREATE
+INSERT INTO t_analyze_repl SELECT i, i FROM generate_series(1, 100000) i;
+INSERT 100000
+
+-- Suspend analyze after scanning 20 blocks on each segment
+SELECT gp_inject_fault('analyze_block', 'suspend', '', '', '', 20, 20, 0, dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+(3 rows)
+
+-- session 1: analyze the table
+1&: ANALYZE t_analyze_repl;  <waiting ...>
+SELECT gp_wait_until_triggered_fault('analyze_block', 1, dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+ Success:                      
+ Success:                      
+(3 rows)
+
+-- session 2: query pg_stat_progress_analyze while the analyze is running, the view should indicate 20 blocks have been scanned as average progress of 3 segments
+2: SELECT pid IS NOT NULL as has_pid, datname, relid::regclass, phase, sample_blks_total, sample_blks_scanned FROM gp_stat_progress_analyze_summary;
+ has_pid | datname        | relid          | phase                 | sample_blks_total | sample_blks_scanned 
+---------+----------------+----------------+-----------------------+-------------------+---------------------
+ t       | isolation2test | t_analyze_repl | acquiring sample rows | 111               | 20                  
+(1 row)
+
+-- Reset fault injector
+SELECT gp_inject_fault('analyze_block', 'reset', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+(3 rows)
+1<:  <... completed>
+ANALYZE
+
+-- teardown
+DROP TABLE t_analyze_repl;
+DROP
+

--- a/src/test/isolation2/expected/ao_index_build_progress.out
+++ b/src/test/isolation2/expected/ao_index_build_progress.out
@@ -8,36 +8,52 @@ CREATE
 -- Insert all tuples to seg1.
 INSERT INTO ao_index_build_progress SELECT 0, i FROM generate_series(1, 100000) i;
 INSERT 100000
+INSERT INTO ao_index_build_progress SELECT 2, i FROM generate_series(1, 100000) i;
+INSERT 100000
+INSERT INTO ao_index_build_progress SELECT 5, i FROM generate_series(1, 100000) i;
+INSERT 100000
 
 -- Suspend execution when some blocks have been read.
-SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'suspend', '', '', '', 10, 10, 0, dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'suspend', '', '', '', 10, 10, 0, dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
  gp_inject_fault 
 -----------------
  Success:        
-(1 row)
+ Success:        
+ Success:        
+(3 rows)
 
 1&: CREATE INDEX ON ao_index_build_progress(i);  <waiting ...>
 
 -- Wait until some AO varblocks have been read.
-SELECT gp_wait_until_triggered_fault('AppendOnlyStorageRead_ReadNextBlock_success', 10, dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+SELECT gp_wait_until_triggered_fault('AppendOnlyStorageRead_ReadNextBlock_success', 10, dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
  gp_wait_until_triggered_fault 
 -------------------------------
  Success:                      
-(1 row)
+ Success:                      
+ Success:                      
+(3 rows)
 
 -- By now, we should have reported some blocks (of size 'block_size') as "done",
 -- as well as a total number of blocks that matches the relation's on-disk size.
-1U: SELECT command, phase, (pg_relation_size('ao_index_build_progress') + (current_setting('block_size')::int - 1)) / current_setting('block_size')::int AS blocks_total_actual, blocks_total AS blocks_total_reported, blocks_done AS blocks_done_reported FROM pg_stat_progress_create_index WHERE relid = 'ao_index_build_progress'::regclass;
+SELECT command, phase, (pg_relation_size('ao_index_build_progress') + (current_setting('block_size')::int - 1)) / current_setting('block_size')::int AS blocks_total_actual, blocks_total AS blocks_total_reported, blocks_done AS blocks_done_reported FROM gp_stat_progress_create_index WHERE gp_segment_id = 1 AND relid = 'ao_index_build_progress'::regclass;
  command      | phase                          | blocks_total_actual | blocks_total_reported | blocks_done_reported 
 --------------+--------------------------------+---------------------+-----------------------+----------------------
  CREATE INDEX | building index: scanning table | 10                  | 10                    | 2                    
 (1 row)
+-- The same should be true for the summary view, and the total number of blocks should be tripled.
+SELECT command, phase, blocks_total, blocks_done FROM gp_stat_progress_create_index_summary WHERE relid = 'ao_index_build_progress'::regclass;
+ command      | phase                          | blocks_total | blocks_done 
+--------------+--------------------------------+--------------+-------------
+ CREATE INDEX | building index: scanning table | 30           | 6           
+(1 row)
 
-SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'reset', dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'reset', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
  gp_inject_fault 
 -----------------
  Success:        
-(1 row)
+ Success:        
+ Success:        
+(3 rows)
 
 1<:  <... completed>
 CREATE
@@ -49,38 +65,54 @@ CREATE
 -- Insert all tuples to seg1.
 INSERT INTO aoco_index_build_progress SELECT 0, i FROM generate_series(1, 100000) i;
 INSERT 100000
+INSERT INTO aoco_index_build_progress SELECT 2, i FROM generate_series(1, 100000) i;
+INSERT 100000
+INSERT INTO aoco_index_build_progress SELECT 5, i FROM generate_series(1, 100000) i;
+INSERT 100000
 
 -- Suspend execution when some blocks have been read.
-SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'suspend', '', '', '', 5, 5, 0, dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'suspend', '', '', '', 5, 5, 0, dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
  gp_inject_fault 
 -----------------
  Success:        
-(1 row)
+ Success:        
+ Success:        
+(3 rows)
 
 1&: CREATE INDEX ON aoco_index_build_progress(i);  <waiting ...>
 
 -- Wait until some AOCO varblocks have been read.
-SELECT gp_wait_until_triggered_fault('AppendOnlyStorageRead_ReadNextBlock_success', 5, dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+SELECT gp_wait_until_triggered_fault('AppendOnlyStorageRead_ReadNextBlock_success', 5, dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
  gp_wait_until_triggered_fault 
 -------------------------------
  Success:                      
-(1 row)
+ Success:                      
+ Success:                      
+(3 rows)
 
 -- By now, we should have reported some blocks (of size 'block_size') as "done",
 -- as well as a total number of blocks that matches the relation's on-disk size.
 -- Note: all blocks for the relation have to be scanned as we are building an
 -- index for the first time and a block directory has to be created.
-1U: SELECT command, phase, (pg_relation_size('aoco_index_build_progress') + (current_setting('block_size')::int - 1)) / current_setting('block_size')::int AS blocks_total_actual, blocks_total AS blocks_total_reported, blocks_done AS blocks_done_reported FROM pg_stat_progress_create_index WHERE relid = 'aoco_index_build_progress'::regclass;
+SELECT command, phase, (pg_relation_size('aoco_index_build_progress') + (current_setting('block_size')::int - 1)) / current_setting('block_size')::int AS blocks_total_actual, blocks_total AS blocks_total_reported, blocks_done AS blocks_done_reported FROM gp_stat_progress_create_index WHERE gp_segment_id = 1 AND relid = 'aoco_index_build_progress'::regclass;
  command      | phase                          | blocks_total_actual | blocks_total_reported | blocks_done_reported 
 --------------+--------------------------------+---------------------+-----------------------+----------------------
  CREATE INDEX | building index: scanning table | 20                  | 20                    | 4                    
 (1 row)
+-- The same should be true for the summary view, and the total number of blocks should be tripled.
+SELECT command, phase, blocks_total, blocks_done FROM gp_stat_progress_create_index_summary WHERE relid = 'aoco_index_build_progress'::regclass;
+ command      | phase                          | blocks_total | blocks_done 
+--------------+--------------------------------+--------------+-------------
+ CREATE INDEX | building index: scanning table | 60           | 12          
+(1 row)
 
-SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'reset', dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'reset', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
  gp_inject_fault 
 -----------------
  Success:        
-(1 row)
+ Success:        
+ Success:        
+(3 rows)
 
 1<:  <... completed>
 CREATE
@@ -88,36 +120,48 @@ CREATE
 -- Repeat the test for another index build
 
 -- Suspend execution when some blocks have been read.
-SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'suspend', '', '', '', 5, 5, 0, dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'suspend', '', '', '', 5, 5, 0, dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
  gp_inject_fault 
 -----------------
  Success:        
-(1 row)
+ Success:        
+ Success:        
+(3 rows)
 
 1&: CREATE INDEX ON aoco_index_build_progress(j);  <waiting ...>
 
 -- Wait until some AOCO varblocks have been read.
-SELECT gp_wait_until_triggered_fault('AppendOnlyStorageRead_ReadNextBlock_success', 5, dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+SELECT gp_wait_until_triggered_fault('AppendOnlyStorageRead_ReadNextBlock_success', 5, dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
  gp_wait_until_triggered_fault 
 -------------------------------
  Success:                      
-(1 row)
+ Success:                      
+ Success:                      
+(3 rows)
 
 -- By now, we should have reported some blocks (of size 'block_size') as "done",
 -- as well as a total number of blocks that matches the size of col j's segfile.
 -- Note: since we already had a block directory prior to the index build on
 -- column 'j', only column 'j' will be scanned.
-1U: SELECT command, phase, ((pg_stat_file(pg_relation_filepath('aoco_index_build_progress') || '.' || 129)).size + (current_setting('block_size')::int - 1)) / current_setting('block_size')::int AS col_j_blocks, blocks_total AS blocks_total_reported, blocks_done AS blocks_done_reported FROM pg_stat_progress_create_index WHERE relid = 'aoco_index_build_progress'::regclass;
+1U: SELECT command, phase, ((pg_stat_file(pg_relation_filepath('aoco_index_build_progress') || '.' || 129)).size + (current_setting('block_size')::int - 1)) / current_setting('block_size')::int AS col_j_blocks, blocks_total AS blocks_total_reported, blocks_done AS blocks_done_reported FROM gp_stat_progress_create_index WHERE gp_segment_id = 1 AND relid = 'aoco_index_build_progress'::regclass;
  command      | phase                          | col_j_blocks | blocks_total_reported | blocks_done_reported 
 --------------+--------------------------------+--------------+-----------------------+----------------------
  CREATE INDEX | building index: scanning table | 8            | 8                     | 3                    
 (1 row)
+-- The same should be true for the summary view, and the total number of blocks should be tripled.
+SELECT command, phase, blocks_total, blocks_done FROM gp_stat_progress_create_index_summary WHERE relid = 'aoco_index_build_progress'::regclass;
+ command      | phase                          | blocks_total | blocks_done 
+--------------+--------------------------------+--------------+-------------
+ CREATE INDEX | building index: scanning table | 24           | 9           
+(1 row)
 
-SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'reset', dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+SELECT gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'reset', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
  gp_inject_fault 
 -----------------
  Success:        
-(1 row)
+ Success:        
+ Success:        
+(3 rows)
 
 1<:  <... completed>
 CREATE

--- a/src/test/isolation2/expected/basebackup_progress.out
+++ b/src/test/isolation2/expected/basebackup_progress.out
@@ -1,0 +1,206 @@
+!\retcode rm -rf /tmp/basebackup_progress_tablespace;
+-- start_ignore
+
+-- end_ignore
+(exited with code 0)
+!\retcode mkdir -p /tmp/basebackup_progress_tablespace;
+-- start_ignore
+
+-- end_ignore
+(exited with code 0)
+CREATE TABLESPACE basebackuptest_space LOCATION '/tmp/basebackup_progress_tablespace';
+CREATE
+
+-- Inject fault after checkpoint creation in basebackup
+SELECT gp_inject_fault('basebackup_progress_tablespace_streamed', 'suspend', dbid) FROM gp_segment_configuration WHERE content >= -1 and role='p';
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+ Success:        
+(4 rows)
+
+-- Run pg_basebackup which should trigger and suspend at the fault
+1&: SELECT pg_basebackup(hostname, 100+content, port, false, NULL, '/tmp/baseback_progress_test' || content, true, 'fetch', true) from gp_segment_configuration where content = -1 and role = 'p';  <waiting ...>
+2&: SELECT pg_basebackup(hostname, 100+content, port, false, NULL, '/tmp/baseback_progress_test' || content, true, 'fetch', true) from gp_segment_configuration where content = 0 and role = 'p';  <waiting ...>
+3&: SELECT pg_basebackup(hostname, 100+content, port, false, NULL, '/tmp/baseback_progress_test' || content, true, 'fetch', true) from gp_segment_configuration where content = 1 and role = 'p';  <waiting ...>
+4&: SELECT pg_basebackup(hostname, 100+content, port, false, NULL, '/tmp/baseback_progress_test' || content, true, 'fetch', true) from gp_segment_configuration where content = 2 and role = 'p';  <waiting ...>
+
+-- Wait until fault has been triggered
+SELECT gp_wait_until_triggered_fault('basebackup_progress_tablespace_streamed', 1, dbid) FROM gp_segment_configuration WHERE content >= -1 and role='p';
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+ Success:                      
+ Success:                      
+ Success:                      
+(4 rows)
+
+-- See that pg_basebackup is still running
+SELECT application_name, state FROM pg_stat_replication;
+ application_name | state     
+------------------+-----------
+ gp_walreceiver   | streaming 
+ pg_basebackup    | backup    
+(2 rows)
+SELECT gp_segment_id, pid is not null as has_pid, phase, (backup_total > backup_streamed and tablespaces_total >= tablespaces_streamed) as is_streaming_tablespaces, tablespaces_streamed = 1 FROM gp_stat_progress_basebackup ORDER BY gp_segment_id ASC;
+ gp_segment_id | has_pid | phase                    | is_streaming_tablespaces | ?column? 
+---------------+---------+--------------------------+--------------------------+----------
+ -1            | t       | streaming database files | t                        | t        
+ 0             | t       | streaming database files | t                        | t        
+ 1             | t       | streaming database files | t                        | t        
+ 2             | t       | streaming database files | t                        | t        
+(4 rows)
+SELECT s.pid is not null as has_pid, s.phase, (s.backup_total = (select sum(backup_total) from gp_stat_progress_basebackup)) as sum_backup_total, (s.backup_streamed = (select sum(backup_streamed) from gp_stat_progress_basebackup)) as sum_backup_streamed, (s.tablespaces_total = (select avg(tablespaces_total) from gp_stat_progress_basebackup)) as avg_tablespace_total, (s.tablespaces_streamed = (select avg(tablespaces_streamed) from gp_stat_progress_basebackup)) as avg_tablespace_streamed FROM gp_stat_progress_basebackup_summary s;
+ has_pid | phase                    | sum_backup_total | sum_backup_streamed | avg_tablespace_total | avg_tablespace_streamed 
+---------+--------------------------+------------------+---------------------+----------------------+-------------------------
+ t       | streaming database files | t                | t                   | t                    | t                       
+(1 row)
+
+-- Resume basebackup
+SELECT gp_inject_fault('basebackup_progress_end', 'suspend', dbid) FROM gp_segment_configuration WHERE content >= -1 and role='p';
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+ Success:        
+(4 rows)
+SELECT gp_inject_fault('basebackup_progress_tablespace_streamed', 'reset', dbid) FROM gp_segment_configuration WHERE content >= -1 and role='p';
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+ Success:        
+(4 rows)
+
+-- Wait until fault has been triggered
+SELECT gp_wait_until_triggered_fault('basebackup_progress_end', 1, dbid) FROM gp_segment_configuration WHERE content >= -1 and role='p';
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+ Success:                      
+ Success:                      
+ Success:                      
+(4 rows)
+
+-- See that pg_basebackup is still running
+SELECT application_name, state FROM pg_stat_replication;
+ application_name | state     
+------------------+-----------
+ gp_walreceiver   | streaming 
+ pg_basebackup    | backup    
+(2 rows)
+SELECT gp_segment_id, pid is not null as has_pid, phase, (backup_total = backup_streamed and tablespaces_total = tablespaces_streamed) as backup_all FROM gp_stat_progress_basebackup ORDER BY gp_segment_id ASC;
+ gp_segment_id | has_pid | phase                  | backup_all 
+---------------+---------+------------------------+------------
+ -1            | t       | transferring wal files | t          
+ 0             | t       | transferring wal files | t          
+ 1             | t       | transferring wal files | t          
+ 2             | t       | transferring wal files | t          
+(4 rows)
+SELECT s.pid is not null as has_pid, s.phase, (s.backup_total = (select sum(backup_total) from gp_stat_progress_basebackup)) as sum_backup_total, (s.backup_streamed = (select sum(backup_streamed) from gp_stat_progress_basebackup)) as sum_backup_streamed, (s.tablespaces_total = (select avg(tablespaces_total) from gp_stat_progress_basebackup)) as avg_tablespace_total, (s.tablespaces_streamed = (select avg(tablespaces_streamed) from gp_stat_progress_basebackup)) as avg_tablespace_streamed FROM gp_stat_progress_basebackup_summary s;
+ has_pid | phase                  | sum_backup_total | sum_backup_streamed | avg_tablespace_total | avg_tablespace_streamed 
+---------+------------------------+------------------+---------------------+----------------------+-------------------------
+ t       | transferring wal files | t                | t                   | t                    | t                       
+(1 row)
+
+-- Resume basebackup
+SELECT gp_inject_fault('basebackup_progress_end', 'reset', dbid) FROM gp_segment_configuration WHERE content >= -1 and role='p';
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+ Success:        
+(4 rows)
+
+-- Wait until basebackup finishes
+--start_ignore
+1<:  <... completed>
+ pg_basebackup                                                                                                                                                                                                                     
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ waiting for checkpoint
+     0/104217 kB (0%), 0/2 tablespaces
+ 80426/104217 kB (77%), 1/2 tablespaces
+169764/169764 kB (100%), 1/2 tablespaces
+169764/169764 kB (100%), 1/2 tablespaces
+169764/169764 kB (100%), 2/2 tablespaces
+ 
+(1 row)
+2<:  <... completed>
+ pg_basebackup                                                                                                                                                                                                                    
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ waiting for checkpoint
+     0/103792 kB (0%), 0/2 tablespaces
+   252/103792 kB (0%), 1/2 tablespaces
+169338/169338 kB (100%), 1/2 tablespaces
+169339/169339 kB (100%), 1/2 tablespaces
+169339/169339 kB (100%), 2/2 tablespaces
+ 
+(1 row)
+3<:  <... completed>
+ pg_basebackup                                                                                                                                                                                                                     
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ waiting for checkpoint
+     0/103792 kB (0%), 0/2 tablespaces
+ 79127/103792 kB (76%), 1/2 tablespaces
+169338/169338 kB (100%), 1/2 tablespaces
+169339/169339 kB (100%), 1/2 tablespaces
+169339/169339 kB (100%), 2/2 tablespaces
+ 
+(1 row)
+4<:  <... completed>
+ pg_basebackup                                                                                                                                                                                                                    
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ waiting for checkpoint
+     0/103792 kB (0%), 0/2 tablespaces
+   771/103792 kB (0%), 1/2 tablespaces
+169338/169338 kB (100%), 1/2 tablespaces
+169339/169339 kB (100%), 1/2 tablespaces
+169339/169339 kB (100%), 2/2 tablespaces
+ 
+(1 row)
+--end_ignore
+
+-- The summary view should be empty after basebackup finishes
+select * from gp_stat_progress_basebackup_summary;
+ pid | phase | backup_total | backup_streamed | tablespaces_total | tablespaces_streamed 
+-----+-------+--------------+-----------------+-------------------+----------------------
+(0 rows)
+
+drop tablespace basebackuptest_space;
+DROP
+
+-- loop while segments come in sync
+select wait_until_all_segments_synchronized();
+ wait_until_all_segments_synchronized 
+--------------------------------------
+ OK                                   
+(1 row)
+
+--start_ignore
+-- cleanup
+!\retcode rm -rf /tmp/baseback_progress_test-1;
+-- start_ignore
+
+-- end_ignore
+(exited with code 0)
+!\retcode rm -rf /tmp/baseback_progress_test0;
+-- start_ignore
+
+-- end_ignore
+(exited with code 0)
+!\retcode rm -rf /tmp/baseback_progress_test1;
+-- start_ignore
+
+-- end_ignore
+(exited with code 0)
+!\retcode rm -rf /tmp/baseback_progress_test2;
+-- start_ignore
+
+-- end_ignore
+(exited with code 0)
+--end_ignore

--- a/src/test/isolation2/expected/copy_progress.out
+++ b/src/test/isolation2/expected/copy_progress.out
@@ -1,0 +1,229 @@
+-- Test COPY progress summary view
+
+-- setup replicated table and data files for COPY
+CREATE TABLE t_copy_repl (a INT, b INT) DISTRIBUTED REPLICATED;
+CREATE
+INSERT INTO t_copy_repl VALUES (2, 2), (0, 0), (5, 5);
+INSERT 3
+COPY t_copy_repl TO '/tmp/t_copy_relp<SEGID>' ON SEGMENT;
+COPY 9
+-- setup DISTRIBUTED table and data files for COPY
+CREATE TABLE t_copy_d (a INT, b INT);
+CREATE
+INSERT INTO t_copy_d select i, i from generate_series(1, 12) i;
+INSERT 12
+COPY t_copy_d TO '/tmp/t_copy_d<SEGID>' ON SEGMENT;
+COPY 12
+
+-- Suspend copy after processed 2 tuples on each segment (3 segments)
+select gp_inject_fault_infinite('copy_processed_two_tuples', 'suspend', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+ Success:                 
+ Success:                 
+(3 rows)
+
+-- It is intentional to run same query twice in 2 sessions. The progress summary
+-- view should record the progress of each session in separate rows.
+
+-- session 1 and 2: Replicated table COPY TO FILE ON SEGMENT
+1&: COPY t_copy_repl TO '/tmp/t_copy_to_relp<SEGID>' ON SEGMENT;  <waiting ...>
+2&: COPY t_copy_repl TO '/tmp/t_copy_to_relp<SEGID>' ON SEGMENT;  <waiting ...>
+-- session 3 and 4: Replicated table COPY FROM STDIN
+3&: COPY t_copy_repl FROM PROGRAM 'for i in `seq 1 3`; do echo $i $i; done' WITH DELIMITER ' ';  <waiting ...>
+4&: COPY t_copy_repl FROM PROGRAM 'for i in `seq 1 3`; do echo $i $i; done' WITH DELIMITER ' ';  <waiting ...>
+-- session 5 & 6: Replicated table COPY FROM FILE ON SEGMENT
+5&: COPY t_copy_repl FROM '/tmp/t_copy_relp<SEGID>' ON SEGMENT;  <waiting ...>
+6&: COPY t_copy_repl FROM '/tmp/t_copy_relp<SEGID>' ON SEGMENT;  <waiting ...>
+-- session 7 & 8: Distributed table COPY TO STDOUT
+7&: COPY t_copy_d TO STDOUT;  <waiting ...>
+8&: COPY t_copy_d TO STDOUT;  <waiting ...>
+-- session 9 & 10: Distributed table COPY TO FILE ON SEGMENT
+9&: COPY t_copy_d TO '/tmp/t_copy_to_d<SEGID>' ON SEGMENT;  <waiting ...>
+10&: COPY t_copy_d TO '/tmp/t_copy_to_d<SEGID>' ON SEGMENT;  <waiting ...>
+-- session 11 & 12: Distributed table COPY FROM PROGRAM
+11&: COPY t_copy_d FROM PROGRAM 'for i in `seq 1 12`; do echo $i $i; done' WITH DELIMITER ' ';  <waiting ...>
+12&: COPY t_copy_d FROM PROGRAM 'for i in `seq 1 12`; do echo $i $i; done' WITH DELIMITER ' ';  <waiting ...>
+-- session 13 & 14: Distributed table COPY FROM FILE ON SEGMENT
+13&: COPY t_copy_d FROM '/tmp/t_copy_d<SEGID>' ON SEGMENT;  <waiting ...>
+14&: COPY t_copy_d FROM '/tmp/t_copy_d<SEGID>' ON SEGMENT;  <waiting ...>
+
+SELECT gp_wait_until_triggered_fault('copy_processed_two_tuples', 1, dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+ Success:                      
+ Success:                      
+(3 rows)
+
+-- Verify the progress views
+SELECT gspc.gp_segment_id, gspc.datname, gspc.relid::regclass, gspc.command, gspc."type", gspc.bytes_processed, gspc.bytes_total, gspc.tuples_processed, gspc.tuples_excluded FROM gp_stat_progress_copy gspc JOIN gp_stat_activity ac USING (pid) ORDER BY (ac.sess_id, gspc.gp_segment_id);
+ gp_segment_id | datname        | relid       | command              | type    | bytes_processed | bytes_total | tuples_processed | tuples_excluded 
+---------------+----------------+-------------+----------------------+---------+-----------------+-------------+------------------+-----------------
+ -1            | isolation2test | t_copy_repl | COPY TO ON SEGMENT   |         | 0               | 0           | 0                | 0               
+ 0             | isolation2test | t_copy_repl | COPY TO ON SEGMENT   | FILE    | 8               | 0           | 2                | 0               
+ 1             | isolation2test | t_copy_repl | COPY TO ON SEGMENT   | FILE    | 8               | 0           | 2                | 0               
+ 2             | isolation2test | t_copy_repl | COPY TO ON SEGMENT   | FILE    | 8               | 0           | 2                | 0               
+ -1            | isolation2test | t_copy_repl | COPY TO ON SEGMENT   |         | 0               | 0           | 0                | 0               
+ 0             | isolation2test | t_copy_repl | COPY TO ON SEGMENT   | FILE    | 8               | 0           | 2                | 0               
+ 1             | isolation2test | t_copy_repl | COPY TO ON SEGMENT   | FILE    | 8               | 0           | 2                | 0               
+ 2             | isolation2test | t_copy_repl | COPY TO ON SEGMENT   | FILE    | 8               | 0           | 2                | 0               
+ -1            | isolation2test | t_copy_repl | COPY FROM            | PROGRAM | 12              | 0           | 0                | 0               
+ 0             | isolation2test | t_copy_repl | COPY FROM            | PIPE    | 0               | 0           | 2                | 0               
+ 1             | isolation2test | t_copy_repl | COPY FROM            | PIPE    | 0               | 0           | 2                | 0               
+ 2             | isolation2test | t_copy_repl | COPY FROM            | PIPE    | 0               | 0           | 2                | 0               
+ -1            | isolation2test | t_copy_repl | COPY FROM            | PROGRAM | 12              | 0           | 0                | 0               
+ 0             | isolation2test | t_copy_repl | COPY FROM            | PIPE    | 0               | 0           | 2                | 0               
+ 1             | isolation2test | t_copy_repl | COPY FROM            | PIPE    | 0               | 0           | 2                | 0               
+ 2             | isolation2test | t_copy_repl | COPY FROM            | PIPE    | 0               | 0           | 2                | 0               
+ -1            | isolation2test | t_copy_repl | COPY FROM ON SEGMENT |         | 0               | 0           | 0                | 0               
+ 0             | isolation2test | t_copy_repl | COPY FROM ON SEGMENT | FILE    | 12              | 12          | 2                | 0               
+ 1             | isolation2test | t_copy_repl | COPY FROM ON SEGMENT | FILE    | 12              | 12          | 2                | 0               
+ 2             | isolation2test | t_copy_repl | COPY FROM ON SEGMENT | FILE    | 12              | 12          | 2                | 0               
+ -1            | isolation2test | t_copy_repl | COPY FROM ON SEGMENT |         | 0               | 0           | 0                | 0               
+ 0             | isolation2test | t_copy_repl | COPY FROM ON SEGMENT | FILE    | 12              | 12          | 2                | 0               
+ 1             | isolation2test | t_copy_repl | COPY FROM ON SEGMENT | FILE    | 12              | 12          | 2                | 0               
+ 2             | isolation2test | t_copy_repl | COPY FROM ON SEGMENT | FILE    | 12              | 12          | 2                | 0               
+ -1            | isolation2test | t_copy_d    | COPY TO              | PIPE    | 0               | 0           | 0                | 0               
+ 0             | isolation2test | t_copy_d    | COPY TO              | PIPE    | 8               | 0           | 2                | 0               
+ 1             | isolation2test | t_copy_d    | COPY TO              | PIPE    | 10              | 0           | 2                | 0               
+ 2             | isolation2test | t_copy_d    | COPY TO              | PIPE    | 8               | 0           | 2                | 0               
+ -1            | isolation2test | t_copy_d    | COPY TO              | PIPE    | 0               | 0           | 0                | 0               
+ 0             | isolation2test | t_copy_d    | COPY TO              | PIPE    | 8               | 0           | 2                | 0               
+ 1             | isolation2test | t_copy_d    | COPY TO              | PIPE    | 10              | 0           | 2                | 0               
+ 2             | isolation2test | t_copy_d    | COPY TO              | PIPE    | 8               | 0           | 2                | 0               
+ -1            | isolation2test | t_copy_d    | COPY TO ON SEGMENT   |         | 0               | 0           | 0                | 0               
+ 0             | isolation2test | t_copy_d    | COPY TO ON SEGMENT   | FILE    | 8               | 0           | 2                | 0               
+ 1             | isolation2test | t_copy_d    | COPY TO ON SEGMENT   | FILE    | 10              | 0           | 2                | 0               
+ 2             | isolation2test | t_copy_d    | COPY TO ON SEGMENT   | FILE    | 8               | 0           | 2                | 0               
+ -1            | isolation2test | t_copy_d    | COPY TO ON SEGMENT   |         | 0               | 0           | 0                | 0               
+ 0             | isolation2test | t_copy_d    | COPY TO ON SEGMENT   | FILE    | 8               | 0           | 2                | 0               
+ 1             | isolation2test | t_copy_d    | COPY TO ON SEGMENT   | FILE    | 10              | 0           | 2                | 0               
+ 2             | isolation2test | t_copy_d    | COPY TO ON SEGMENT   | FILE    | 8               | 0           | 2                | 0               
+ -1            | isolation2test | t_copy_d    | COPY FROM            | PROGRAM | 54              | 0           | 0                | 0               
+ 0             | isolation2test | t_copy_d    | COPY FROM            | PIPE    | 0               | 0           | 2                | 0               
+ 1             | isolation2test | t_copy_d    | COPY FROM            | PIPE    | 0               | 0           | 2                | 0               
+ 2             | isolation2test | t_copy_d    | COPY FROM            | PIPE    | 0               | 0           | 2                | 0               
+ -1            | isolation2test | t_copy_d    | COPY FROM            | PROGRAM | 54              | 0           | 0                | 0               
+ 0             | isolation2test | t_copy_d    | COPY FROM            | PIPE    | 0               | 0           | 2                | 0               
+ 1             | isolation2test | t_copy_d    | COPY FROM            | PIPE    | 0               | 0           | 2                | 0               
+ 2             | isolation2test | t_copy_d    | COPY FROM            | PIPE    | 0               | 0           | 2                | 0               
+ -1            | isolation2test | t_copy_d    | COPY FROM ON SEGMENT |         | 0               | 0           | 0                | 0               
+ 0             | isolation2test | t_copy_d    | COPY FROM ON SEGMENT | FILE    | 20              | 20          | 2                | 0               
+ 1             | isolation2test | t_copy_d    | COPY FROM ON SEGMENT | FILE    | 10              | 10          | 2                | 0               
+ 2             | isolation2test | t_copy_d    | COPY FROM ON SEGMENT | FILE    | 24              | 24          | 2                | 0               
+ -1            | isolation2test | t_copy_d    | COPY FROM ON SEGMENT |         | 0               | 0           | 0                | 0               
+ 0             | isolation2test | t_copy_d    | COPY FROM ON SEGMENT | FILE    | 20              | 20          | 2                | 0               
+ 1             | isolation2test | t_copy_d    | COPY FROM ON SEGMENT | FILE    | 10              | 10          | 2                | 0               
+ 2             | isolation2test | t_copy_d    | COPY FROM ON SEGMENT | FILE    | 24              | 24          | 2                | 0               
+(56 rows)
+
+SELECT ac.gp_segment_id = -1 as has_coordinator_pid, gspcs.datname, gspcs.relid::regclass, gspcs.command, gspcs."type", gspcs.bytes_processed, gspcs.bytes_total, gspcs.tuples_processed, gspcs.tuples_excluded FROM gp_stat_progress_copy_summary gspcs JOIN gp_stat_activity ac USING (pid) ORDER BY ac.sess_id;
+ has_coordinator_pid | datname        | relid       | command              | type    | bytes_processed | bytes_total | tuples_processed | tuples_excluded 
+---------------------+----------------+-------------+----------------------+---------+-----------------+-------------+------------------+-----------------
+ t                   | isolation2test | t_copy_repl | COPY TO ON SEGMENT   | FILE    | 24              | 0           | 6                | 0               
+ t                   | isolation2test | t_copy_repl | COPY TO ON SEGMENT   | FILE    | 24              | 0           | 6                | 0               
+ t                   | isolation2test | t_copy_repl | COPY FROM            | PROGRAM | 4               | 0           | 2                | 0               
+ t                   | isolation2test | t_copy_repl | COPY FROM            | PROGRAM | 4               | 0           | 2                | 0               
+ t                   | isolation2test | t_copy_repl | COPY FROM ON SEGMENT | FILE    | 36              | 36          | 6                | 0               
+ t                   | isolation2test | t_copy_repl | COPY FROM ON SEGMENT | FILE    | 36              | 36          | 6                | 0               
+ t                   | isolation2test | t_copy_d    | COPY TO              | PIPE    | 26              | 0           | 6                | 0               
+ t                   | isolation2test | t_copy_d    | COPY TO              | PIPE    | 26              | 0           | 6                | 0               
+ t                   | isolation2test | t_copy_d    | COPY TO ON SEGMENT   | FILE    | 26              | 0           | 6                | 0               
+ t                   | isolation2test | t_copy_d    | COPY TO ON SEGMENT   | FILE    | 26              | 0           | 6                | 0               
+ t                   | isolation2test | t_copy_d    | COPY FROM            | PROGRAM | 54              | 0           | 6                | 0               
+ t                   | isolation2test | t_copy_d    | COPY FROM            | PROGRAM | 54              | 0           | 6                | 0               
+ t                   | isolation2test | t_copy_d    | COPY FROM ON SEGMENT | FILE    | 54              | 54          | 6                | 0               
+ t                   | isolation2test | t_copy_d    | COPY FROM ON SEGMENT | FILE    | 54              | 54          | 6                | 0               
+(14 rows)
+
+SELECT gp_inject_fault('copy_processed_two_tuples', 'reset', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+(3 rows)
+1<:  <... completed>
+COPY 9
+2<:  <... completed>
+COPY 9
+3<:  <... completed>
+COPY 3
+4<:  <... completed>
+COPY 3
+5<:  <... completed>
+COPY 9
+6<:  <... completed>
+COPY 9
+7<:  <... completed>
+COPY
+8<:  <... completed>
+COPY
+9<:  <... completed>
+COPY 12
+10<:  <... completed>
+COPY 12
+11<:  <... completed>
+COPY 12
+12<:  <... completed>
+COPY 12
+13<:  <... completed>
+COPY 12
+14<:  <... completed>
+COPY 12
+
+-- Test COPY TO STDOUT
+-- We need to run this test separately because the COPY TO with replicated table
+-- only copies data from on segment 0.
+
+-- Suspend copy after processing 2 tuples on segment 0 only
+select gp_inject_fault_infinite('copy_processed_two_tuples', 'suspend', dbid) FROM gp_segment_configuration WHERE content = 0 AND role = 'p';
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+
+-- session 1: copy table to pipe
+1&: COPY t_copy_repl TO STDOUT;  <waiting ...>
+-- session 2: copy same table to pipe
+2&: COPY t_copy_repl TO STDOUT;  <waiting ...>
+SELECT gp_wait_until_triggered_fault('copy_processed_two_tuples', 1, dbid) FROM gp_segment_configuration WHERE content = 0 AND role = 'p';
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
+-- session 2: query gp_stat_progress_copy while the copy is running, the view should indicate 2 tuples have been processed for segment 0 only
+SELECT gp_segment_id, datname, relid::regclass, command, "type", bytes_processed, bytes_total, tuples_processed, tuples_excluded FROM gp_stat_progress_copy;
+ gp_segment_id | datname        | relid       | command | type | bytes_processed | bytes_total | tuples_processed | tuples_excluded 
+---------------+----------------+-------------+---------+------+-----------------+-------------+------------------+-----------------
+ 0             | isolation2test | t_copy_repl | COPY TO | PIPE | 8               | 0           | 2                | 0               
+ 0             | isolation2test | t_copy_repl | COPY TO | PIPE | 8               | 0           | 2                | 0               
+ -1            | isolation2test | t_copy_repl | COPY TO | PIPE | 0               | 0           | 0                | 0               
+ -1            | isolation2test | t_copy_repl | COPY TO | PIPE | 0               | 0           | 0                | 0               
+(4 rows)
+SELECT pid IS NOT NULL as has_pid, datname, relid::regclass, command, "type", bytes_processed, bytes_total, tuples_processed, tuples_excluded FROM gp_stat_progress_copy_summary;
+ has_pid | datname        | relid       | command | type | bytes_processed | bytes_total | tuples_processed | tuples_excluded 
+---------+----------------+-------------+---------+------+-----------------+-------------+------------------+-----------------
+ t       | isolation2test | t_copy_repl | COPY TO | PIPE | 8               | 0           | 2                | 0               
+ t       | isolation2test | t_copy_repl | COPY TO | PIPE | 8               | 0           | 2                | 0               
+(2 rows)
+
+-- Reset fault injector
+SELECT gp_inject_fault('copy_processed_two_tuples', 'reset', dbid) FROM gp_segment_configuration WHERE content = 0 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+1<:  <... completed>
+COPY
+2<:  <... completed>
+COPY
+
+-- teardown
+DROP TABLE t_copy_repl;
+DROP
+DROP TABLE t_copy_d;
+DROP

--- a/src/test/isolation2/expected/setup.out
+++ b/src/test/isolation2/expected/setup.out
@@ -110,7 +110,8 @@ CREATE
 --
 -- usage: `select pg_basebackup('somehost', 12345, 'some_slot_name', '/some/destination/data/directory')`
 --
-create or replace function pg_basebackup(host text, dbid int, port int, create_slot boolean, slotname text, datadir text, force_overwrite boolean, xlog_method text) returns text as $$ import subprocess import os cmd = 'pg_basebackup --no-sync --checkpoint=fast -h %s -p %d -R -D %s --target-gp-dbid %d' % (host, port, datadir, dbid) 
+create or replace function pg_basebackup(host text, dbid int, port int, create_slot boolean, slotname text, datadir text, force_overwrite boolean, xlog_method text, progress boolean DEFAULT false) returns text as $$ import subprocess import os cmd = 'pg_basebackup --no-sync --checkpoint=fast -h %s -p %d -R -D %s --target-gp-dbid %d' % (host, port, datadir, dbid) 
+if progress: cmd += ' --progress' 
 if create_slot: cmd += ' --create-slot' 
 if slotname is not None: cmd += ' --slot %s' % (slotname) 
 if force_overwrite: cmd += ' --force-overwrite' 

--- a/src/test/isolation2/expected/setup.out
+++ b/src/test/isolation2/expected/setup.out
@@ -143,3 +143,7 @@ CREATE
 -- Helper function that ensures mirror of the specified contentid is down.
 create or replace function wait_for_mirror_down(contentid smallint, timeout_sec integer) returns bool as $$ declare i int; /* in func */ begin /* in func */ i := 0; /* in func */ loop /* in func */ perform gp_request_fts_probe_scan(); /* in func */ if (select count(1) from gp_segment_configuration where role='m' and content=$1 and status='d') = 1 then /* in func */ return true; /* in func */ end if; /* in func */ if i >= 2 * $2 then /* in func */ return false; /* in func */ end if; /* in func */ perform pg_sleep(0.5); /* in func */ i = i + 1; /* in func */ end loop; /* in func */ end; /* in func */ $$ language plpgsql;
 CREATE
+
+-- Helper function that ensures stats collector receives stat from the latest operation.
+create or replace function wait_until_vacuum_count_change_to(relid oid, stat_val_expected bigint) returns text as $$ declare stat_val int; /* in func */ i int; /* in func */ begin i := 0; /* in func */ while i < 1200 loop select pg_stat_get_vacuum_count(relid) into stat_val; /* in func */ if stat_val = stat_val_expected then /* in func */ return 'OK'; /* in func */ end if; /* in func */ perform pg_sleep(0.1); /* in func */ perform pg_stat_clear_snapshot(); /* in func */ i := i + 1; /* in func */ end loop; /* in func */ return 'Fail'; /* in func */ end; /* in func */ $$ language plpgsql;
+CREATE

--- a/src/test/isolation2/expected/vacuum_progress_column.out
+++ b/src/test/isolation2/expected/vacuum_progress_column.out
@@ -45,18 +45,6 @@ ABORT
 DELETE FROM vacuum_progress_ao_column where j % 2 = 0;
 DELETE 50000
 
--- Lookup pg_class and collected stats view before VACUUM
-SELECT relpages, reltuples, relallvisible FROM pg_class where relname = 'vacuum_progress_ao_column';
- relpages | reltuples | relallvisible 
-----------+-----------+---------------
- 0        | 0         | 0             
-(1 row)
-SELECT n_live_tup, n_dead_tup, last_vacuum, vacuum_count FROM gp_stat_all_tables WHERE relname = 'vacuum_progress_ao_column' and gp_segment_id = 1;
- n_live_tup | n_dead_tup | last_vacuum | vacuum_count 
-------------+------------+-------------+--------------
- 100000     | 200000     |             | 0            
-(1 row)
-
 -- Perform VACUUM and observe the progress
 
 -- Suspend execution at pre-cleanup phase after truncating both segfiles to their logical EOF.

--- a/src/test/isolation2/expected/vacuum_progress_row.out
+++ b/src/test/isolation2/expected/vacuum_progress_row.out
@@ -16,22 +16,21 @@ CREATE
 CREATE INDEX on vacuum_progress_ao_row(j);
 CREATE
 
--- Insert all tuples to seg1 from two current sessions so that data are stored
--- in two segment files.
+-- Insert from two current sessions so that data are stored in two segment files.
 1: BEGIN;
 BEGIN
 2: BEGIN;
 BEGIN
-1: INSERT INTO vacuum_progress_ao_row SELECT 0, i FROM generate_series(1, 100000) i;
+1: INSERT INTO vacuum_progress_ao_row SELECT i, i FROM generate_series(1, 100000) i;
 INSERT 100000
-2: INSERT INTO vacuum_progress_ao_row SELECT 0, i FROM generate_series(1, 100000) i;
+2: INSERT INTO vacuum_progress_ao_row SELECT i, i FROM generate_series(1, 100000) i;
 INSERT 100000
 -- Commit so that the logical EOF of segno 2 is non-zero.
 2: COMMIT;
 COMMIT
 2: BEGIN;
 BEGIN
-2: INSERT INTO vacuum_progress_ao_row SELECT 0, i FROM generate_series(1, 100000) i;
+2: INSERT INTO vacuum_progress_ao_row SELECT i, i FROM generate_series(1, 100000) i;
 INSERT 100000
 -- Abort so that segno 2 has dead tuples after its logical EOF
 2: ABORT;
@@ -54,17 +53,24 @@ SELECT relpages, reltuples, relallvisible FROM pg_class where relname = 'vacuum_
 SELECT n_live_tup, n_dead_tup, last_vacuum, vacuum_count FROM gp_stat_all_tables WHERE relname = 'vacuum_progress_ao_row' and gp_segment_id = 1;
  n_live_tup | n_dead_tup | last_vacuum | vacuum_count 
 ------------+------------+-------------+--------------
+ 33327      | 66654      |             | 0            
+(1 row)
+SELECT n_live_tup, n_dead_tup, last_vacuum, vacuum_count FROM gp_stat_all_tables_summary WHERE relname = 'vacuum_progress_ao_row';
+ n_live_tup | n_dead_tup | last_vacuum | vacuum_count 
+------------+------------+-------------+--------------
  100000     | 200000     |             | 0            
 (1 row)
 
 -- Perform VACUUM and observe the progress
 
 -- Suspend execution at pre-cleanup phase after truncating both segfiles to their logical EOF.
-SELECT gp_inject_fault('appendonly_after_truncate_segment_file', 'suspend', '', '', '', 2, 2, 0, dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+SELECT gp_inject_fault('appendonly_after_truncate_segment_file', 'suspend', '', '', '', 2, 2, 0, dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
  gp_inject_fault 
 -----------------
  Success:        
-(1 row)
+ Success:        
+ Success:        
+(3 rows)
 
 1: set Debug_appendonly_print_compaction to on;
 SET
@@ -75,85 +81,120 @@ SELECT gp_wait_until_triggered_fault('appendonly_after_truncate_segment_file', 2
  Success:                      
 (1 row)
 -- We are in pre_cleanup phase and some blocks should've been vacuumed by now
-1U: select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, heap_blks_vacuumed, index_vacuum_count, max_dead_tuples, num_dead_tuples from pg_stat_progress_vacuum;
+select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, heap_blks_vacuumed, index_vacuum_count, max_dead_tuples, num_dead_tuples from gp_stat_progress_vacuum where gp_segment_id = 1;
  relname                | phase                        | heap_blks_total | heap_blks_scanned | heap_blks_vacuumed | index_vacuum_count | max_dead_tuples | num_dead_tuples 
 ------------------------+------------------------------+-----------------+-------------------+--------------------+--------------------+-----------------+-----------------
- vacuum_progress_ao_row | append-optimized pre-cleanup | 165             | 0                 | 110                | 0                  | 100000          | 0               
+ vacuum_progress_ao_row | append-optimized pre-cleanup | 55              | 0                 | 37                 | 0                  | 33327           | 0               
+(1 row)
+select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, heap_blks_vacuumed, index_vacuum_count, max_dead_tuples, num_dead_tuples from gp_stat_progress_vacuum_summary;
+ relname                | phase                        | heap_blks_total | heap_blks_scanned | heap_blks_vacuumed | index_vacuum_count | max_dead_tuples | num_dead_tuples 
+------------------------+------------------------------+-----------------+-------------------+--------------------+--------------------+-----------------+-----------------
+ vacuum_progress_ao_row | append-optimized pre-cleanup | 166             | 0                 | 111                | 0                  | 100000          | 0               
 (1 row)
 
 -- Resume execution and suspend again in the middle of compact phase
-SELECT gp_inject_fault('appendonly_insert', 'suspend', '', '', '', 200, 200, 0, dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+SELECT gp_inject_fault('appendonly_insert', 'suspend', '', '', '', 200, 200, 0, dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
  gp_inject_fault 
 -----------------
  Success:        
-(1 row)
-SELECT gp_inject_fault('appendonly_after_truncate_segment_file', 'reset', dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+ Success:        
+ Success:        
+(3 rows)
+SELECT gp_inject_fault('appendonly_after_truncate_segment_file', 'reset', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
  gp_inject_fault 
 -----------------
  Success:        
-(1 row)
+ Success:        
+ Success:        
+(3 rows)
 SELECT gp_wait_until_triggered_fault('appendonly_insert', 200, dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
  gp_wait_until_triggered_fault 
 -------------------------------
  Success:                      
 (1 row)
 -- We are in compact phase. num_dead_tuples should increase as we move and count tuples, one by one.
-1U: select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, heap_blks_vacuumed, index_vacuum_count, max_dead_tuples, num_dead_tuples from pg_stat_progress_vacuum;
+select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, heap_blks_vacuumed, index_vacuum_count, max_dead_tuples, num_dead_tuples from gp_stat_progress_vacuum where gp_segment_id = 1;
  relname                | phase                    | heap_blks_total | heap_blks_scanned | heap_blks_vacuumed | index_vacuum_count | max_dead_tuples | num_dead_tuples 
 ------------------------+--------------------------+-----------------+-------------------+--------------------+--------------------+-----------------+-----------------
- vacuum_progress_ao_row | append-optimized compact | 165             | 0                 | 110                | 0                  | 100000          | 199             
+ vacuum_progress_ao_row | append-optimized compact | 55              | 0                 | 37                 | 0                  | 33327           | 227             
+(1 row)
+select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, heap_blks_vacuumed, index_vacuum_count, max_dead_tuples, num_dead_tuples from gp_stat_progress_vacuum_summary;
+ relname                | phase                    | heap_blks_total | heap_blks_scanned | heap_blks_vacuumed | index_vacuum_count | max_dead_tuples | num_dead_tuples 
+------------------------+--------------------------+-----------------+-------------------+--------------------+--------------------+-----------------+-----------------
+ vacuum_progress_ao_row | append-optimized compact | 166             | 0                 | 111                | 0                  | 100000          | 594             
 (1 row)
 
 -- Resume execution and suspend again after compacting all segfiles
-SELECT gp_inject_fault('vacuum_ao_after_compact', 'suspend', dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+SELECT gp_inject_fault('vacuum_ao_after_compact', 'suspend', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
  gp_inject_fault 
 -----------------
  Success:        
-(1 row)
-SELECT gp_inject_fault('appendonly_insert', 'reset', dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+ Success:        
+ Success:        
+(3 rows)
+SELECT gp_inject_fault('appendonly_insert', 'reset', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
  gp_inject_fault 
 -----------------
  Success:        
-(1 row)
+ Success:        
+ Success:        
+(3 rows)
 SELECT gp_wait_until_triggered_fault('vacuum_ao_after_compact', 1, dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
  gp_wait_until_triggered_fault 
 -------------------------------
  Success:                      
 (1 row)
 -- After compacting all segfiles we expect 50000 dead tuples
-1U: select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, heap_blks_vacuumed, index_vacuum_count, max_dead_tuples, num_dead_tuples from pg_stat_progress_vacuum;
+select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, heap_blks_vacuumed, index_vacuum_count, max_dead_tuples, num_dead_tuples from gp_stat_progress_vacuum where gp_segment_id = 1;
  relname                | phase                    | heap_blks_total | heap_blks_scanned | heap_blks_vacuumed | index_vacuum_count | max_dead_tuples | num_dead_tuples 
 ------------------------+--------------------------+-----------------+-------------------+--------------------+--------------------+-----------------+-----------------
- vacuum_progress_ao_row | append-optimized compact | 165             | 55                | 110                | 0                  | 100000          | 50000           
+ vacuum_progress_ao_row | append-optimized compact | 55              | 19                | 37                 | 0                  | 33327           | 16622           
+(1 row)
+select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, heap_blks_vacuumed, index_vacuum_count, max_dead_tuples, num_dead_tuples from gp_stat_progress_vacuum_summary;
+ relname                | phase                    | heap_blks_total | heap_blks_scanned | heap_blks_vacuumed | index_vacuum_count | max_dead_tuples | num_dead_tuples 
+------------------------+--------------------------+-----------------+-------------------+--------------------+--------------------+-----------------+-----------------
+ vacuum_progress_ao_row | append-optimized compact | 166             | 57                | 111                | 0                  | 100000          | 50000           
 (1 row)
 
 -- Resume execution and entering post_cleaup phase, suspend at the end of it.
-SELECT gp_inject_fault('vacuum_ao_post_cleanup_end', 'suspend', dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+SELECT gp_inject_fault('vacuum_ao_post_cleanup_end', 'suspend', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
  gp_inject_fault 
 -----------------
  Success:        
-(1 row)
-SELECT gp_inject_fault('vacuum_ao_after_compact', 'reset', dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+ Success:        
+ Success:        
+(3 rows)
+SELECT gp_inject_fault('vacuum_ao_after_compact', 'reset', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
  gp_inject_fault 
 -----------------
  Success:        
-(1 row)
+ Success:        
+ Success:        
+(3 rows)
 SELECT gp_wait_until_triggered_fault('vacuum_ao_post_cleanup_end', 1, dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
  gp_wait_until_triggered_fault 
 -------------------------------
  Success:                      
 (1 row)
 -- We should have skipped recycling the awaiting drop segment because the segment was still visible to the SELECT gp_wait_until_triggered_fault query.
-1U: select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, heap_blks_vacuumed, index_vacuum_count, max_dead_tuples, num_dead_tuples from pg_stat_progress_vacuum;
+select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, heap_blks_vacuumed, index_vacuum_count, max_dead_tuples, num_dead_tuples from gp_stat_progress_vacuum where gp_segment_id = 1;
  relname                | phase                         | heap_blks_total | heap_blks_scanned | heap_blks_vacuumed | index_vacuum_count | max_dead_tuples | num_dead_tuples 
 ------------------------+-------------------------------+-----------------+-------------------+--------------------+--------------------+-----------------+-----------------
- vacuum_progress_ao_row | append-optimized post-cleanup | 165             | 55                | 110                | 0                  | 100000          | 50000           
+ vacuum_progress_ao_row | append-optimized post-cleanup | 55              | 19                | 37                 | 0                  | 33327           | 16622           
 (1 row)
-SELECT gp_inject_fault('vacuum_ao_post_cleanup_end', 'reset', dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, heap_blks_vacuumed, index_vacuum_count, max_dead_tuples, num_dead_tuples from gp_stat_progress_vacuum_summary;
+ relname                | phase                         | heap_blks_total | heap_blks_scanned | heap_blks_vacuumed | index_vacuum_count | max_dead_tuples | num_dead_tuples 
+------------------------+-------------------------------+-----------------+-------------------+--------------------+--------------------+-----------------+-----------------
+ vacuum_progress_ao_row | append-optimized post-cleanup | 166             | 57                | 111                | 0                  | 100000          | 50000           
+(1 row)
+
+SELECT gp_inject_fault('vacuum_ao_post_cleanup_end', 'reset', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
  gp_inject_fault 
 -----------------
  Success:        
-(1 row)
+ Success:        
+ Success:        
+(3 rows)
 1<:  <... completed>
 VACUUM
 
@@ -166,63 +207,68 @@ VACUUM
 SELECT relpages, reltuples, relallvisible FROM pg_class where relname = 'vacuum_progress_ao_row';
  relpages | reltuples | relallvisible 
 ----------+-----------+---------------
- 83       | 50000     | 0             
+ 84       | 50000     | 0             
 (1 row)
 SELECT n_live_tup, n_dead_tup, last_vacuum is not null as has_last_vacuum, vacuum_count FROM gp_stat_all_tables WHERE relname = 'vacuum_progress_ao_row' and gp_segment_id = 1;
  n_live_tup | n_dead_tup | has_last_vacuum | vacuum_count 
 ------------+------------+-----------------+--------------
- 50000      | 0          | t               | 1            
+ 16705      | 0          | t               | 1            
 (1 row)
 
 -- Perform VACUUM again to recycle the remaining awaiting drop segment marked by the previous run.
-SELECT gp_inject_fault('vacuum_ao_after_index_delete', 'suspend', dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+SELECT gp_inject_fault('vacuum_ao_after_index_delete', 'suspend', dbid) FROM gp_segment_configuration WHERE content = 0 AND role = 'p';
  gp_inject_fault 
 -----------------
  Success:        
 (1 row)
+SELECT gp_inject_fault('appendonly_after_truncate_segment_file', 'suspend', dbid) FROM gp_segment_configuration WHERE content > 0 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+(2 rows)
 1&: VACUUM vacuum_progress_ao_row;  <waiting ...>
--- Resume execution and entering pre_cleanup phase, suspend at vacuuming indexes.
-SELECT gp_inject_fault('vacuum_ao_after_compact', 'reset', dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
- gp_inject_fault 
------------------
- Success:        
-(1 row)
-SELECT gp_wait_until_triggered_fault('vacuum_ao_after_index_delete', 1, dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+-- Resume execution and entering pre_cleanup phase, suspend at vacuuming indexes for segment 0.
+SELECT gp_wait_until_triggered_fault('vacuum_ao_after_index_delete', 1, dbid) FROM gp_segment_configuration WHERE content = 0 AND role = 'p';
  gp_wait_until_triggered_fault 
 -------------------------------
  Success:                      
 (1 row)
--- We are in vacuuming indexes phase (part of ao pre_cleanup phase), index_vacuum_count should increase to 1.
-1U: select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, heap_blks_vacuumed, index_vacuum_count, max_dead_tuples, num_dead_tuples from pg_stat_progress_vacuum;
+-- Resume execution and moving on to truncate segments that were marked as AWAITING_DROP for segment 1 and 2, there should be only 1.
+SELECT gp_wait_until_triggered_fault('appendonly_after_truncate_segment_file', 1, dbid) FROM gp_segment_configuration WHERE content > 0 AND role = 'p';
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+ Success:                      
+(2 rows)
+-- Segment 0 is in vacuuming indexes phase (part of ao pre_cleanup phase), index_vacuum_count should increase to 1.
+select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, heap_blks_vacuumed, index_vacuum_count, max_dead_tuples, num_dead_tuples from gp_stat_progress_vacuum where gp_segment_id = 0;
  relname                | phase             | heap_blks_total | heap_blks_scanned | heap_blks_vacuumed | index_vacuum_count | max_dead_tuples | num_dead_tuples 
 ------------------------+-------------------+-----------------+-------------------+--------------------+--------------------+-----------------+-----------------
- vacuum_progress_ao_row | vacuuming indexes | 83              | 0                 | 0                  | 1                  | 50000           | 0               
+ vacuum_progress_ao_row | vacuuming indexes | 28              | 0                 | 0                  | 1                  | 16737           | 0               
 (1 row)
-
--- Resume execution and moving on to truncate segments that were marked as AWAITING_DROP, there should be only 1.
-SELECT gp_inject_fault('appendonly_after_truncate_segment_file', 'suspend', dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
- gp_inject_fault 
------------------
- Success:        
-(1 row)
-SELECT gp_inject_fault('vacuum_ao_after_index_delete', 'reset', dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
- gp_inject_fault 
------------------
- Success:        
-(1 row)
-SELECT gp_wait_until_triggered_fault('appendonly_after_truncate_segment_file', 1, dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
- gp_wait_until_triggered_fault 
--------------------------------
- Success:                      
-(1 row)
--- We are in post_cleanup phase and should have truncated the old segfile. Both indexes should be vacuumed by now, and heap_blks_vacuumed should also increased
-1U: select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, heap_blks_vacuumed, index_vacuum_count, max_dead_tuples, num_dead_tuples from pg_stat_progress_vacuum;
+-- Segment 1 and 2 are in truncate segments phase (part of ao post_cleanup phase), heap_blks_vacuumed should increase to 1.
+select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, heap_blks_vacuumed, index_vacuum_count, max_dead_tuples, num_dead_tuples from gp_stat_progress_vacuum where gp_segment_id > 0;
  relname                | phase                        | heap_blks_total | heap_blks_scanned | heap_blks_vacuumed | index_vacuum_count | max_dead_tuples | num_dead_tuples 
 ------------------------+------------------------------+-----------------+-------------------+--------------------+--------------------+-----------------+-----------------
- vacuum_progress_ao_row | append-optimized pre-cleanup | 83              | 0                 | 55                 | 2                  | 50000           | 0               
-(1 row)
+ vacuum_progress_ao_row | append-optimized pre-cleanup | 28              | 0                 | 19                 | 2                  | 16558           | 0               
+ vacuum_progress_ao_row | append-optimized pre-cleanup | 28              | 0                 | 19                 | 2                  | 16705           | 0               
+(2 rows)
+select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, heap_blks_vacuumed, index_vacuum_count, max_dead_tuples, num_dead_tuples from gp_stat_progress_vacuum_summary;
+ relname                | phase                        | heap_blks_total | heap_blks_scanned | heap_blks_vacuumed | index_vacuum_count | max_dead_tuples | num_dead_tuples 
+------------------------+------------------------------+-----------------+-------------------+--------------------+--------------------+-----------------+-----------------
+ vacuum_progress_ao_row | append-optimized pre-cleanup | 56              | 0                 | 38                 | 4                  | 33263           | 0               
+ vacuum_progress_ao_row | vacuuming indexes            | 28              | 0                 | 0                  | 1                  | 16737           | 0               
+(2 rows)
 
-SELECT gp_inject_fault('appendonly_after_truncate_segment_file', 'reset', dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+SELECT gp_inject_fault('appendonly_after_truncate_segment_file', 'reset', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+(3 rows)
+SELECT gp_inject_fault('vacuum_ao_after_index_delete', 'reset', dbid) FROM gp_segment_configuration WHERE content = 0 AND role = 'p';
  gp_inject_fault 
 -----------------
  Success:        
@@ -230,24 +276,33 @@ SELECT gp_inject_fault('appendonly_after_truncate_segment_file', 'reset', dbid) 
 1<:  <... completed>
 VACUUM
 
--- Vacuum has finished, nothing should show up in the progress view.
-1U: select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, heap_blks_vacuumed, index_vacuum_count, max_dead_tuples, num_dead_tuples from pg_stat_progress_vacuum;
+-- Vacuum has finished, nothing should show up in the view.
+select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, heap_blks_vacuumed, index_vacuum_count, max_dead_tuples, num_dead_tuples from gp_stat_progress_vacuum where gp_segment_id = 1;
+ relname | phase | heap_blks_total | heap_blks_scanned | heap_blks_vacuumed | index_vacuum_count | max_dead_tuples | num_dead_tuples 
+---------+-------+-----------------+-------------------+--------------------+--------------------+-----------------+-----------------
+(0 rows)
+select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, heap_blks_vacuumed, index_vacuum_count, max_dead_tuples, num_dead_tuples from gp_stat_progress_vacuum_summary;
  relname | phase | heap_blks_total | heap_blks_scanned | heap_blks_vacuumed | index_vacuum_count | max_dead_tuples | num_dead_tuples 
 ---------+-------+-----------------+-------------------+--------------------+--------------------+-----------------+-----------------
 (0 rows)
 
 -- pg_class and collected stats view should be updated after the 2nd VACUUM
-1U: SELECT wait_until_dead_tup_change_to('vacuum_progress_ao_row'::regclass::oid, 0);
- wait_until_dead_tup_change_to 
--------------------------------
- OK                            
+1U: SELECT wait_until_vacuum_count_change_to('vacuum_progress_ao_row'::regclass::oid, 2);
+ wait_until_vacuum_count_change_to 
+-----------------------------------
+ OK                                
 (1 row)
 SELECT relpages, reltuples, relallvisible FROM pg_class where relname = 'vacuum_progress_ao_row';
  relpages | reltuples | relallvisible 
 ----------+-----------+---------------
- 28       | 50000     | 0             
+ 30       | 50000     | 0             
 (1 row)
 SELECT n_live_tup, n_dead_tup, last_vacuum is not null as has_last_vacuum, vacuum_count FROM gp_stat_all_tables WHERE relname = 'vacuum_progress_ao_row' and gp_segment_id = 1;
+ n_live_tup | n_dead_tup | has_last_vacuum | vacuum_count 
+------------+------------+-----------------+--------------
+ 16705      | 0          | t               | 2            
+(1 row)
+SELECT n_live_tup, n_dead_tup, last_vacuum is not null as has_last_vacuum, vacuum_count FROM gp_stat_all_tables_summary WHERE relname = 'vacuum_progress_ao_row';
  n_live_tup | n_dead_tup | has_last_vacuum | vacuum_count 
 ------------+------------+-----------------+--------------
  50000      | 0          | t               | 2            

--- a/src/test/isolation2/expected/vacuum_progress_row.out
+++ b/src/test/isolation2/expected/vacuum_progress_row.out
@@ -44,23 +44,6 @@ ABORT
 DELETE FROM vacuum_progress_ao_row where j % 2 = 0;
 DELETE 50000
 
--- Lookup pg_class and collected stats view before VACUUM
-SELECT relpages, reltuples, relallvisible FROM pg_class where relname = 'vacuum_progress_ao_row';
- relpages | reltuples | relallvisible 
-----------+-----------+---------------
- 0        | 0         | 0             
-(1 row)
-SELECT n_live_tup, n_dead_tup, last_vacuum, vacuum_count FROM gp_stat_all_tables WHERE relname = 'vacuum_progress_ao_row' and gp_segment_id = 1;
- n_live_tup | n_dead_tup | last_vacuum | vacuum_count 
-------------+------------+-------------+--------------
- 33327      | 66654      |             | 0            
-(1 row)
-SELECT n_live_tup, n_dead_tup, last_vacuum, vacuum_count FROM gp_stat_all_tables_summary WHERE relname = 'vacuum_progress_ao_row';
- n_live_tup | n_dead_tup | last_vacuum | vacuum_count 
-------------+------------+-------------+--------------
- 100000     | 200000     |             | 0            
-(1 row)
-
 -- Perform VACUUM and observe the progress
 
 -- Suspend execution at pre-cleanup phase after truncating both segfiles to their logical EOF.

--- a/src/test/isolation2/input/uao/cluster_progress.source
+++ b/src/test/isolation2/input/uao/cluster_progress.source
@@ -7,6 +7,8 @@ set default_table_access_method=@amname@;
 CREATE TABLE cluster_progress_ao(i int, j int);
 -- Insert all tuples to seg1
 INSERT INTO cluster_progress_ao SELECT 0, i FROM generate_series(1, 100000) i;
+INSERT INTO cluster_progress_ao SELECT 2, i FROM generate_series(1, 100000) i;
+INSERT INTO cluster_progress_ao SELECT 5, i FROM generate_series(1, 100000) i;
 -- Create two btree indexes
 CREATE INDEX idx_cluster_progress_ao_i on cluster_progress_ao(i);
 CREATE INDEX idx_cluster_progress_ao_j on cluster_progress_ao(j);
@@ -15,54 +17,62 @@ DELETE FROM cluster_progress_ao where j % 5 = 0;
 
 -- Create a helper table that records storage-dependent static numbers.
 CREATE TABLE helper_table AS
-SELECT 0::int AS seg1,
-       (pg_relation_size('cluster_progress_ao') + (current_setting('block_size')::int - 1)) / current_setting('block_size')::int AS heap_blks_total_before,
-       CASE current_setting('default_table_access_method') WHEN 'ao_row' THEN 1 ELSE 2 END AS n_segfiles_per_tuple;
+SELECT gp_segment_id AS segid,
+       (pg_relation_size(oid) + (current_setting('block_size')::int - 1)) / current_setting('block_size')::int AS heap_blks_total_before,
+       CASE current_setting('default_table_access_method') WHEN 'ao_row' THEN 1 ELSE 2 END AS n_segfiles_per_tuple
+FROM gp_dist_random('pg_class')
+WHERE relname = 'cluster_progress_ao';
 
 -- Perform cluster and observe the progress
 
-SELECT gp_inject_fault('cluster_ao_seq_scan_begin', 'suspend', dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+SELECT gp_inject_fault('cluster_ao_seq_scan_begin', 'suspend', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
 
 1&: CLUSTER cluster_progress_ao USING idx_cluster_progress_ao_j;
-SELECT gp_wait_until_triggered_fault('cluster_ao_seq_scan_begin', 1, dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+SELECT gp_wait_until_triggered_fault('cluster_ao_seq_scan_begin', 1, dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
 -- We are in "seq scanning ao" phase and "heap_blks_total" should be available
-1U: select datname, relid::regclass, command, phase, cluster_index_relid::regclass, heap_tuples_scanned, heap_tuples_written, heap_blks_total = (SELECT heap_blks_total_before FROM helper_table) AS heap_blks_total_all, heap_blks_scanned, index_rebuild_count from pg_stat_progress_cluster;
+select datname, relid::regclass, command, phase, cluster_index_relid::regclass, heap_tuples_scanned, heap_tuples_written, heap_blks_total = (SELECT heap_blks_total_before FROM helper_table WHERE segid = 1) AS heap_blks_total_all, heap_blks_scanned, index_rebuild_count from gp_stat_progress_cluster where gp_segment_id = 1;
+select datname, relid::regclass, command, phase, cluster_index_relid::regclass, heap_tuples_scanned, heap_tuples_written, heap_blks_total = (SELECT SUM(heap_blks_total_before) FROM helper_table) AS heap_blks_total_all, heap_blks_scanned, index_rebuild_count from gp_stat_progress_cluster_summary;
 
 -- Resume execution and suspend again in the middle of scanning old table
-SELECT gp_inject_fault('cluster_ao_scanning_tuples', 'suspend', '', '', '', 200, 200, 0, dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
-SELECT gp_inject_fault('cluster_ao_seq_scan_begin', 'reset', dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
-SELECT gp_wait_until_triggered_fault('cluster_ao_scanning_tuples', 200, dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+SELECT gp_inject_fault('cluster_ao_scanning_tuples', 'suspend', '', '', '', 200, 200, 0, dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+SELECT gp_inject_fault('cluster_ao_seq_scan_begin', 'reset', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+SELECT gp_wait_until_triggered_fault('cluster_ao_scanning_tuples', 200, dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
 -- We are in "seq scanning ao" phase. "heap_tuples_scanned" should be updated
 -- every time we scan an old live tuple. "heap_blks_scanned" should be updated
 -- every time we finish scanning a heap-block size worth of old tuples.
-1U: select datname, relid::regclass, command, phase, cluster_index_relid::regclass, heap_tuples_scanned, heap_tuples_written, heap_blks_total = (SELECT heap_blks_total_before FROM helper_table) AS heap_blks_total_all, heap_blks_scanned / (SELECT n_segfiles_per_tuple FROM helper_table) AS heap_blks_scanned_per_col, index_rebuild_count from pg_stat_progress_cluster;
+select datname, relid::regclass, command, phase, cluster_index_relid::regclass, heap_tuples_scanned, heap_tuples_written, heap_blks_total = (SELECT heap_blks_total_before FROM helper_table WHERE segid = 1) AS heap_blks_total_all, heap_blks_scanned / (SELECT n_segfiles_per_tuple FROM helper_table LIMIT 1) AS heap_blks_scanned_per_col, index_rebuild_count from gp_stat_progress_cluster where gp_segment_id = 1;
+select datname, relid::regclass, command, phase, cluster_index_relid::regclass, heap_tuples_scanned, heap_tuples_written, heap_blks_total = (SELECT SUM(heap_blks_total_before) FROM helper_table) AS heap_blks_total_all, heap_blks_scanned / (SELECT n_segfiles_per_tuple FROM helper_table LIMIT 1) AS heap_blks_scanned_per_col, index_rebuild_count from gp_stat_progress_cluster_summary;
 
 -- Resume execution and suspend again before we start sorting tuples
-SELECT gp_inject_fault('cluster_ao_sorting_tuples', 'suspend', dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
-SELECT gp_inject_fault('cluster_ao_scanning_tuples', 'reset', dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
-SELECT gp_wait_until_triggered_fault('cluster_ao_sorting_tuples', 1, dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+SELECT gp_inject_fault('cluster_ao_sorting_tuples', 'suspend', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+SELECT gp_inject_fault('cluster_ao_scanning_tuples', 'reset', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+SELECT gp_wait_until_triggered_fault('cluster_ao_sorting_tuples', 1, dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
 -- We are in "sorting tuples" phase.
-1U: select datname, relid::regclass, command, phase, cluster_index_relid::regclass, heap_tuples_scanned, heap_tuples_written, heap_blks_total = (SELECT heap_blks_total_before FROM helper_table) AS heap_blks_total_all, heap_blks_scanned = (SELECT heap_blks_total_before FROM helper_table) AS heap_blks_scanned_all, index_rebuild_count from pg_stat_progress_cluster;
+select datname, relid::regclass, command, phase, cluster_index_relid::regclass, heap_tuples_scanned, heap_tuples_written, heap_blks_total = (SELECT heap_blks_total_before FROM helper_table WHERE segid = 1) AS heap_blks_total_all, heap_blks_scanned = (SELECT heap_blks_total_before FROM helper_table WHERE segid = 1) AS heap_blks_scanned_all, index_rebuild_count from gp_stat_progress_cluster where gp_segment_id = 1;
+select datname, relid::regclass, command, phase, cluster_index_relid::regclass, heap_tuples_scanned, heap_tuples_written, heap_blks_total = (SELECT SUM(heap_blks_total_before) FROM helper_table) AS heap_blks_total_all, heap_blks_scanned = (SELECT SUM(heap_blks_total_before) FROM helper_table) AS heap_blks_scanned_all, index_rebuild_count from gp_stat_progress_cluster_summary;
 
 -- Resume execution and suspend again before we start writing tuples
-SELECT gp_inject_fault('cluster_ao_write_begin', 'suspend', dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
-SELECT gp_inject_fault('cluster_ao_sorting_tuples', 'reset', dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
-SELECT gp_wait_until_triggered_fault('cluster_ao_write_begin', 1, dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+SELECT gp_inject_fault('cluster_ao_write_begin', 'suspend', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+SELECT gp_inject_fault('cluster_ao_sorting_tuples', 'reset', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+SELECT gp_wait_until_triggered_fault('cluster_ao_write_begin', 1, dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
 -- We are in "writing new ao" phase.
-1U: select datname, relid::regclass, command, phase, cluster_index_relid::regclass, heap_tuples_scanned, heap_tuples_written, heap_blks_total = (SELECT heap_blks_total_before FROM helper_table) AS heap_blks_total_all, heap_blks_scanned = (SELECT heap_blks_total_before FROM helper_table) AS heap_blks_scanned_all, index_rebuild_count from pg_stat_progress_cluster;
+select datname, relid::regclass, command, phase, cluster_index_relid::regclass, heap_tuples_scanned, heap_tuples_written, heap_blks_total = (SELECT heap_blks_total_before FROM helper_table WHERE segid = 1) AS heap_blks_total_all, heap_blks_scanned = (SELECT heap_blks_total_before FROM helper_table WHERE segid = 1) AS heap_blks_scanned_all, index_rebuild_count from gp_stat_progress_cluster where gp_segment_id = 1;
+select datname, relid::regclass, command, phase, cluster_index_relid::regclass, heap_tuples_scanned, heap_tuples_written, heap_blks_total = (SELECT SUM(heap_blks_total_before) FROM helper_table) AS heap_blks_total_all, heap_blks_scanned = (SELECT SUM(heap_blks_total_before) FROM helper_table) AS heap_blks_scanned_all, index_rebuild_count from gp_stat_progress_cluster_summary;
 
 -- Resume execution and suspend again in the middle of writing new table
-SELECT gp_inject_fault('cluster_ao_writing_tuples', 'suspend', '', '', '', 200, 200, 0, dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
-SELECT gp_inject_fault('cluster_ao_write_begin', 'reset', dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
-SELECT gp_wait_until_triggered_fault('cluster_ao_writing_tuples', 200, dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+SELECT gp_inject_fault('cluster_ao_writing_tuples', 'suspend', '', '', '', 200, 200, 0, dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+SELECT gp_inject_fault('cluster_ao_write_begin', 'reset', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+SELECT gp_wait_until_triggered_fault('cluster_ao_writing_tuples', 200, dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
 -- We are in "writing new ao" phase. "heap_tuples_written" should be updated
-1U: select datname, relid::regclass, command, phase, cluster_index_relid::regclass, heap_tuples_scanned, heap_tuples_written, heap_blks_total = (SELECT heap_blks_total_before FROM helper_table) AS heap_blks_total_all, heap_blks_scanned = (SELECT heap_blks_total_before FROM helper_table) AS heap_blks_scanned_all, index_rebuild_count from pg_stat_progress_cluster;
+select datname, relid::regclass, command, phase, cluster_index_relid::regclass, heap_tuples_scanned, heap_tuples_written, heap_blks_total = (SELECT heap_blks_total_before FROM helper_table WHERE segid = 1) AS heap_blks_total_all, heap_blks_scanned = (SELECT heap_blks_total_before FROM helper_table WHERE segid = 1) AS heap_blks_scanned_all, index_rebuild_count from gp_stat_progress_cluster where gp_segment_id = 1;
+select datname, relid::regclass, command, phase, cluster_index_relid::regclass, heap_tuples_scanned, heap_tuples_written, heap_blks_total = (SELECT SUM(heap_blks_total_before) FROM helper_table) AS heap_blks_total_all, heap_blks_scanned = (SELECT SUM(heap_blks_total_before) FROM helper_table) AS heap_blks_scanned_all, index_rebuild_count from gp_stat_progress_cluster_summary;
 
-SELECT gp_inject_fault('cluster_ao_writing_tuples', 'reset', dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+SELECT gp_inject_fault('cluster_ao_writing_tuples', 'reset', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
 1<:
 
 -- cluster has finished, nothing should show up in the view.
-1U: select datname, relid::regclass, command, phase, cluster_index_relid::regclass, heap_tuples_scanned, heap_tuples_written, heap_blks_total, heap_blks_scanned, index_rebuild_count from pg_stat_progress_cluster;
+select datname, relid::regclass, command, phase, cluster_index_relid::regclass, heap_tuples_scanned, heap_tuples_written, heap_blks_total, heap_blks_scanned, index_rebuild_count from gp_stat_progress_cluster where gp_segment_id = 1;
+select datname, relid::regclass, command, phase, cluster_index_relid::regclass, heap_tuples_scanned, heap_tuples_written, heap_blks_total, heap_blks_scanned, index_rebuild_count from gp_stat_progress_cluster_summary;
 
 -- Cleanup
 SELECT gp_inject_fault_infinite('all', 'reset', dbid) FROM gp_segment_configuration;

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -237,6 +237,7 @@ test: workfile_mgr_test
 test: pg_basebackup
 test: pg_basebackup_with_tablespaces
 test: pg_basebackup_large_database_oid
+test: basebackup_progress
 test: vacuum_progress_row
 test: vacuum_progress_column
 test: enable_autovacuum

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -245,6 +245,7 @@ test: idle_gang_cleaner
 
 test: ao_index_build_progress
 test: analyze_progress
+test: copy_progress
 
 test: segwalrep/die_commit_pending_replication
 

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -244,6 +244,7 @@ test: idle_gang_cleaner
 # test idle_in_transaction_session_timeout
 
 test: ao_index_build_progress
+test: analyze_progress
 
 test: segwalrep/die_commit_pending_replication
 

--- a/src/test/isolation2/output/uao/cluster_progress.source
+++ b/src/test/isolation2/output/uao/cluster_progress.source
@@ -10,6 +10,10 @@ CREATE
 -- Insert all tuples to seg1
 INSERT INTO cluster_progress_ao SELECT 0, i FROM generate_series(1, 100000) i;
 INSERT 100000
+INSERT INTO cluster_progress_ao SELECT 2, i FROM generate_series(1, 100000) i;
+INSERT 100000
+INSERT INTO cluster_progress_ao SELECT 5, i FROM generate_series(1, 100000) i;
+INSERT 100000
 -- Create two btree indexes
 CREATE INDEX idx_cluster_progress_ao_i on cluster_progress_ao(i);
 CREATE
@@ -17,137 +21,196 @@ CREATE INDEX idx_cluster_progress_ao_j on cluster_progress_ao(j);
 CREATE
 -- Delete some tuples
 DELETE FROM cluster_progress_ao where j % 5 = 0;
-DELETE 20000
+DELETE 60000
 
 -- Create a helper table that records storage-dependent static numbers.
-CREATE TABLE helper_table AS SELECT 0::int AS seg1, (pg_relation_size('cluster_progress_ao') + (current_setting('block_size')::int - 1)) / current_setting('block_size')::int AS heap_blks_total_before, CASE current_setting('default_table_access_method') WHEN 'ao_row' THEN 1 ELSE 2 END AS n_segfiles_per_tuple;
-CREATE 1
+CREATE TABLE helper_table AS SELECT gp_segment_id AS segid, (pg_relation_size(oid) + (current_setting('block_size')::int - 1)) / current_setting('block_size')::int AS heap_blks_total_before, CASE current_setting('default_table_access_method') WHEN 'ao_row' THEN 1 ELSE 2 END AS n_segfiles_per_tuple FROM gp_dist_random('pg_class') WHERE relname = 'cluster_progress_ao';
+CREATE 3
 
 -- Perform cluster and observe the progress
 
-SELECT gp_inject_fault('cluster_ao_seq_scan_begin', 'suspend', dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+SELECT gp_inject_fault('cluster_ao_seq_scan_begin', 'suspend', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
  gp_inject_fault 
 -----------------
  Success:        
-(1 row)
+ Success:        
+ Success:        
+(3 rows)
 
 1&: CLUSTER cluster_progress_ao USING idx_cluster_progress_ao_j;  <waiting ...>
-SELECT gp_wait_until_triggered_fault('cluster_ao_seq_scan_begin', 1, dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+SELECT gp_wait_until_triggered_fault('cluster_ao_seq_scan_begin', 1, dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
  gp_wait_until_triggered_fault 
 -------------------------------
  Success:                      
-(1 row)
+ Success:                      
+ Success:                      
+(3 rows)
 -- We are in "seq scanning ao" phase and "heap_blks_total" should be available
-1U: select datname, relid::regclass, command, phase, cluster_index_relid::regclass, heap_tuples_scanned, heap_tuples_written, heap_blks_total = (SELECT heap_blks_total_before FROM helper_table) AS heap_blks_total_all, heap_blks_scanned, index_rebuild_count from pg_stat_progress_cluster;
+select datname, relid::regclass, command, phase, cluster_index_relid::regclass, heap_tuples_scanned, heap_tuples_written, heap_blks_total = (SELECT heap_blks_total_before FROM helper_table WHERE segid = 1) AS heap_blks_total_all, heap_blks_scanned, index_rebuild_count from gp_stat_progress_cluster where gp_segment_id = 1;
+ datname        | relid               | command | phase                         | cluster_index_relid | heap_tuples_scanned | heap_tuples_written | heap_blks_total_all | heap_blks_scanned | index_rebuild_count 
+----------------+---------------------+---------+-------------------------------+---------------------+---------------------+---------------------+---------------------+-------------------+---------------------
+ isolation2test | cluster_progress_ao | CLUSTER | seq scanning append-optimized | -                   | 0                   | 0                   | t                   | 0                 | 0                   
+(1 row)
+select datname, relid::regclass, command, phase, cluster_index_relid::regclass, heap_tuples_scanned, heap_tuples_written, heap_blks_total = (SELECT SUM(heap_blks_total_before) FROM helper_table) AS heap_blks_total_all, heap_blks_scanned, index_rebuild_count from gp_stat_progress_cluster_summary;
  datname        | relid               | command | phase                         | cluster_index_relid | heap_tuples_scanned | heap_tuples_written | heap_blks_total_all | heap_blks_scanned | index_rebuild_count 
 ----------------+---------------------+---------+-------------------------------+---------------------+---------------------+---------------------+---------------------+-------------------+---------------------
  isolation2test | cluster_progress_ao | CLUSTER | seq scanning append-optimized | -                   | 0                   | 0                   | t                   | 0                 | 0                   
 (1 row)
 
 -- Resume execution and suspend again in the middle of scanning old table
-SELECT gp_inject_fault('cluster_ao_scanning_tuples', 'suspend', '', '', '', 200, 200, 0, dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+SELECT gp_inject_fault('cluster_ao_scanning_tuples', 'suspend', '', '', '', 200, 200, 0, dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
  gp_inject_fault 
 -----------------
  Success:        
-(1 row)
-SELECT gp_inject_fault('cluster_ao_seq_scan_begin', 'reset', dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+ Success:        
+ Success:        
+(3 rows)
+SELECT gp_inject_fault('cluster_ao_seq_scan_begin', 'reset', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
  gp_inject_fault 
 -----------------
  Success:        
-(1 row)
-SELECT gp_wait_until_triggered_fault('cluster_ao_scanning_tuples', 200, dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+ Success:        
+ Success:        
+(3 rows)
+SELECT gp_wait_until_triggered_fault('cluster_ao_scanning_tuples', 200, dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
  gp_wait_until_triggered_fault 
 -------------------------------
  Success:                      
-(1 row)
+ Success:                      
+ Success:                      
+(3 rows)
 -- We are in "seq scanning ao" phase. "heap_tuples_scanned" should be updated
 -- every time we scan an old live tuple. "heap_blks_scanned" should be updated
 -- every time we finish scanning a heap-block size worth of old tuples.
-1U: select datname, relid::regclass, command, phase, cluster_index_relid::regclass, heap_tuples_scanned, heap_tuples_written, heap_blks_total = (SELECT heap_blks_total_before FROM helper_table) AS heap_blks_total_all, heap_blks_scanned / (SELECT n_segfiles_per_tuple FROM helper_table) AS heap_blks_scanned_per_col, index_rebuild_count from pg_stat_progress_cluster;
+select datname, relid::regclass, command, phase, cluster_index_relid::regclass, heap_tuples_scanned, heap_tuples_written, heap_blks_total = (SELECT heap_blks_total_before FROM helper_table WHERE segid = 1) AS heap_blks_total_all, heap_blks_scanned / (SELECT n_segfiles_per_tuple FROM helper_table LIMIT 1) AS heap_blks_scanned_per_col, index_rebuild_count from gp_stat_progress_cluster where gp_segment_id = 1;
  datname        | relid               | command | phase                         | cluster_index_relid | heap_tuples_scanned | heap_tuples_written | heap_blks_total_all | heap_blks_scanned_per_col | index_rebuild_count 
 ----------------+---------------------+---------+-------------------------------+---------------------+---------------------+---------------------+---------------------+---------------------------+---------------------
  isolation2test | cluster_progress_ao | CLUSTER | seq scanning append-optimized | -                   | 200                 | 0                   | t                   | 1                         | 0                   
 (1 row)
+select datname, relid::regclass, command, phase, cluster_index_relid::regclass, heap_tuples_scanned, heap_tuples_written, heap_blks_total = (SELECT SUM(heap_blks_total_before) FROM helper_table) AS heap_blks_total_all, heap_blks_scanned / (SELECT n_segfiles_per_tuple FROM helper_table LIMIT 1) AS heap_blks_scanned_per_col, index_rebuild_count from gp_stat_progress_cluster_summary;
+ datname        | relid               | command | phase                         | cluster_index_relid | heap_tuples_scanned | heap_tuples_written | heap_blks_total_all | heap_blks_scanned_per_col | index_rebuild_count 
+----------------+---------------------+---------+-------------------------------+---------------------+---------------------+---------------------+---------------------+---------------------------+---------------------
+ isolation2test | cluster_progress_ao | CLUSTER | seq scanning append-optimized | -                   | 600                 | 0                   | t                   | 3.0000000000000000        | 0                   
+(1 row)
 
 -- Resume execution and suspend again before we start sorting tuples
-SELECT gp_inject_fault('cluster_ao_sorting_tuples', 'suspend', dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+SELECT gp_inject_fault('cluster_ao_sorting_tuples', 'suspend', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
  gp_inject_fault 
 -----------------
  Success:        
-(1 row)
-SELECT gp_inject_fault('cluster_ao_scanning_tuples', 'reset', dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+ Success:        
+ Success:        
+(3 rows)
+SELECT gp_inject_fault('cluster_ao_scanning_tuples', 'reset', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
  gp_inject_fault 
 -----------------
  Success:        
-(1 row)
-SELECT gp_wait_until_triggered_fault('cluster_ao_sorting_tuples', 1, dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+ Success:        
+ Success:        
+(3 rows)
+SELECT gp_wait_until_triggered_fault('cluster_ao_sorting_tuples', 1, dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
  gp_wait_until_triggered_fault 
 -------------------------------
  Success:                      
-(1 row)
+ Success:                      
+ Success:                      
+(3 rows)
 -- We are in "sorting tuples" phase.
-1U: select datname, relid::regclass, command, phase, cluster_index_relid::regclass, heap_tuples_scanned, heap_tuples_written, heap_blks_total = (SELECT heap_blks_total_before FROM helper_table) AS heap_blks_total_all, heap_blks_scanned = (SELECT heap_blks_total_before FROM helper_table) AS heap_blks_scanned_all, index_rebuild_count from pg_stat_progress_cluster;
+select datname, relid::regclass, command, phase, cluster_index_relid::regclass, heap_tuples_scanned, heap_tuples_written, heap_blks_total = (SELECT heap_blks_total_before FROM helper_table WHERE segid = 1) AS heap_blks_total_all, heap_blks_scanned = (SELECT heap_blks_total_before FROM helper_table WHERE segid = 1) AS heap_blks_scanned_all, index_rebuild_count from gp_stat_progress_cluster where gp_segment_id = 1;
  datname        | relid               | command | phase          | cluster_index_relid | heap_tuples_scanned | heap_tuples_written | heap_blks_total_all | heap_blks_scanned_all | index_rebuild_count 
 ----------------+---------------------+---------+----------------+---------------------+---------------------+---------------------+---------------------+-----------------------+---------------------
  isolation2test | cluster_progress_ao | CLUSTER | sorting tuples | -                   | 80000               | 0                   | t                   | t                     | 0                   
 (1 row)
+select datname, relid::regclass, command, phase, cluster_index_relid::regclass, heap_tuples_scanned, heap_tuples_written, heap_blks_total = (SELECT SUM(heap_blks_total_before) FROM helper_table) AS heap_blks_total_all, heap_blks_scanned = (SELECT SUM(heap_blks_total_before) FROM helper_table) AS heap_blks_scanned_all, index_rebuild_count from gp_stat_progress_cluster_summary;
+ datname        | relid               | command | phase          | cluster_index_relid | heap_tuples_scanned | heap_tuples_written | heap_blks_total_all | heap_blks_scanned_all | index_rebuild_count 
+----------------+---------------------+---------+----------------+---------------------+---------------------+---------------------+---------------------+-----------------------+---------------------
+ isolation2test | cluster_progress_ao | CLUSTER | sorting tuples | -                   | 240000              | 0                   | t                   | t                     | 0                   
+(1 row)
 
 -- Resume execution and suspend again before we start writing tuples
-SELECT gp_inject_fault('cluster_ao_write_begin', 'suspend', dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+SELECT gp_inject_fault('cluster_ao_write_begin', 'suspend', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
  gp_inject_fault 
 -----------------
  Success:        
-(1 row)
-SELECT gp_inject_fault('cluster_ao_sorting_tuples', 'reset', dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+ Success:        
+ Success:        
+(3 rows)
+SELECT gp_inject_fault('cluster_ao_sorting_tuples', 'reset', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
  gp_inject_fault 
 -----------------
  Success:        
-(1 row)
-SELECT gp_wait_until_triggered_fault('cluster_ao_write_begin', 1, dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+ Success:        
+ Success:        
+(3 rows)
+SELECT gp_wait_until_triggered_fault('cluster_ao_write_begin', 1, dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
  gp_wait_until_triggered_fault 
 -------------------------------
  Success:                      
-(1 row)
+ Success:                      
+ Success:                      
+(3 rows)
 -- We are in "writing new ao" phase.
-1U: select datname, relid::regclass, command, phase, cluster_index_relid::regclass, heap_tuples_scanned, heap_tuples_written, heap_blks_total = (SELECT heap_blks_total_before FROM helper_table) AS heap_blks_total_all, heap_blks_scanned = (SELECT heap_blks_total_before FROM helper_table) AS heap_blks_scanned_all, index_rebuild_count from pg_stat_progress_cluster;
+select datname, relid::regclass, command, phase, cluster_index_relid::regclass, heap_tuples_scanned, heap_tuples_written, heap_blks_total = (SELECT heap_blks_total_before FROM helper_table WHERE segid = 1) AS heap_blks_total_all, heap_blks_scanned = (SELECT heap_blks_total_before FROM helper_table WHERE segid = 1) AS heap_blks_scanned_all, index_rebuild_count from gp_stat_progress_cluster where gp_segment_id = 1;
  datname        | relid               | command | phase                        | cluster_index_relid | heap_tuples_scanned | heap_tuples_written | heap_blks_total_all | heap_blks_scanned_all | index_rebuild_count 
 ----------------+---------------------+---------+------------------------------+---------------------+---------------------+---------------------+---------------------+-----------------------+---------------------
  isolation2test | cluster_progress_ao | CLUSTER | writing new append-optimized | -                   | 80000               | 0                   | t                   | t                     | 0                   
 (1 row)
+select datname, relid::regclass, command, phase, cluster_index_relid::regclass, heap_tuples_scanned, heap_tuples_written, heap_blks_total = (SELECT SUM(heap_blks_total_before) FROM helper_table) AS heap_blks_total_all, heap_blks_scanned = (SELECT SUM(heap_blks_total_before) FROM helper_table) AS heap_blks_scanned_all, index_rebuild_count from gp_stat_progress_cluster_summary;
+ datname        | relid               | command | phase                        | cluster_index_relid | heap_tuples_scanned | heap_tuples_written | heap_blks_total_all | heap_blks_scanned_all | index_rebuild_count 
+----------------+---------------------+---------+------------------------------+---------------------+---------------------+---------------------+---------------------+-----------------------+---------------------
+ isolation2test | cluster_progress_ao | CLUSTER | writing new append-optimized | -                   | 240000              | 0                   | t                   | t                     | 0                   
+(1 row)
 
 -- Resume execution and suspend again in the middle of writing new table
-SELECT gp_inject_fault('cluster_ao_writing_tuples', 'suspend', '', '', '', 200, 200, 0, dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+SELECT gp_inject_fault('cluster_ao_writing_tuples', 'suspend', '', '', '', 200, 200, 0, dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
  gp_inject_fault 
 -----------------
  Success:        
-(1 row)
-SELECT gp_inject_fault('cluster_ao_write_begin', 'reset', dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+ Success:        
+ Success:        
+(3 rows)
+SELECT gp_inject_fault('cluster_ao_write_begin', 'reset', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
  gp_inject_fault 
 -----------------
  Success:        
-(1 row)
-SELECT gp_wait_until_triggered_fault('cluster_ao_writing_tuples', 200, dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+ Success:        
+ Success:        
+(3 rows)
+SELECT gp_wait_until_triggered_fault('cluster_ao_writing_tuples', 200, dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
  gp_wait_until_triggered_fault 
 -------------------------------
  Success:                      
-(1 row)
+ Success:                      
+ Success:                      
+(3 rows)
 -- We are in "writing new ao" phase. "heap_tuples_written" should be updated
-1U: select datname, relid::regclass, command, phase, cluster_index_relid::regclass, heap_tuples_scanned, heap_tuples_written, heap_blks_total = (SELECT heap_blks_total_before FROM helper_table) AS heap_blks_total_all, heap_blks_scanned = (SELECT heap_blks_total_before FROM helper_table) AS heap_blks_scanned_all, index_rebuild_count from pg_stat_progress_cluster;
+select datname, relid::regclass, command, phase, cluster_index_relid::regclass, heap_tuples_scanned, heap_tuples_written, heap_blks_total = (SELECT heap_blks_total_before FROM helper_table WHERE segid = 1) AS heap_blks_total_all, heap_blks_scanned = (SELECT heap_blks_total_before FROM helper_table WHERE segid = 1) AS heap_blks_scanned_all, index_rebuild_count from gp_stat_progress_cluster where gp_segment_id = 1;
  datname        | relid               | command | phase                        | cluster_index_relid | heap_tuples_scanned | heap_tuples_written | heap_blks_total_all | heap_blks_scanned_all | index_rebuild_count 
 ----------------+---------------------+---------+------------------------------+---------------------+---------------------+---------------------+---------------------+-----------------------+---------------------
  isolation2test | cluster_progress_ao | CLUSTER | writing new append-optimized | -                   | 80000               | 200                 | t                   | t                     | 0                   
 (1 row)
+select datname, relid::regclass, command, phase, cluster_index_relid::regclass, heap_tuples_scanned, heap_tuples_written, heap_blks_total = (SELECT SUM(heap_blks_total_before) FROM helper_table) AS heap_blks_total_all, heap_blks_scanned = (SELECT SUM(heap_blks_total_before) FROM helper_table) AS heap_blks_scanned_all, index_rebuild_count from gp_stat_progress_cluster_summary;
+ datname        | relid               | command | phase                        | cluster_index_relid | heap_tuples_scanned | heap_tuples_written | heap_blks_total_all | heap_blks_scanned_all | index_rebuild_count 
+----------------+---------------------+---------+------------------------------+---------------------+---------------------+---------------------+---------------------+-----------------------+---------------------
+ isolation2test | cluster_progress_ao | CLUSTER | writing new append-optimized | -                   | 240000              | 600                 | t                   | t                     | 0                   
+(1 row)
 
-SELECT gp_inject_fault('cluster_ao_writing_tuples', 'reset', dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+SELECT gp_inject_fault('cluster_ao_writing_tuples', 'reset', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
  gp_inject_fault 
 -----------------
  Success:        
-(1 row)
+ Success:        
+ Success:        
+(3 rows)
 1<:  <... completed>
 CLUSTER
 
 -- cluster has finished, nothing should show up in the view.
-1U: select datname, relid::regclass, command, phase, cluster_index_relid::regclass, heap_tuples_scanned, heap_tuples_written, heap_blks_total, heap_blks_scanned, index_rebuild_count from pg_stat_progress_cluster;
+select datname, relid::regclass, command, phase, cluster_index_relid::regclass, heap_tuples_scanned, heap_tuples_written, heap_blks_total, heap_blks_scanned, index_rebuild_count from gp_stat_progress_cluster where gp_segment_id = 1;
+ datname | relid | command | phase | cluster_index_relid | heap_tuples_scanned | heap_tuples_written | heap_blks_total | heap_blks_scanned | index_rebuild_count 
+---------+-------+---------+-------+---------------------+---------------------+---------------------+-----------------+-------------------+---------------------
+(0 rows)
+select datname, relid::regclass, command, phase, cluster_index_relid::regclass, heap_tuples_scanned, heap_tuples_written, heap_blks_total, heap_blks_scanned, index_rebuild_count from gp_stat_progress_cluster_summary;
  datname | relid | command | phase | cluster_index_relid | heap_tuples_scanned | heap_tuples_written | heap_blks_total | heap_blks_scanned | index_rebuild_count 
 ---------+-------+---------+-------+---------------------+---------------------+---------------------+-----------------+-------------------+---------------------
 (0 rows)

--- a/src/test/isolation2/sql/analyze_progress.sql
+++ b/src/test/isolation2/sql/analyze_progress.sql
@@ -1,0 +1,42 @@
+-- Test gp_stat_progress_analyze_summary
+-- setup hash distributed table
+CREATE TABLE t_analyze_part (a INT, b INT) DISTRIBUTED BY (a);
+INSERT INTO t_analyze_part SELECT i, i FROM generate_series(1, 100000) i;
+
+-- Suspend analyze after scanning 20 blocks on each segment
+SELECT gp_inject_fault('analyze_block', 'suspend', '', '', '', 20, 20, 0, dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+
+-- session 1: analyze the table
+1&: ANALYZE t_analyze_part;
+SELECT gp_wait_until_triggered_fault('analyze_block', 1, dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+
+-- session 2: query pg_stat_progress_analyze while the analyze is running, the view should indicate 60 blocks have been scanned as aggregated progress of 3 segments
+2: SELECT pid IS NOT NULL as has_pid, datname, relid::regclass, phase, sample_blks_total, sample_blks_scanned FROM gp_stat_progress_analyze_summary;
+
+-- Reset fault injector
+SELECT gp_inject_fault('analyze_block', 'reset', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+1<:
+
+-- teardown
+DROP TABLE t_analyze_part;
+
+-- setup replicated table
+CREATE TABLE t_analyze_repl (a INT, b INT) DISTRIBUTED REPLICATED;
+INSERT INTO t_analyze_repl SELECT i, i FROM generate_series(1, 100000) i;
+
+-- Suspend analyze after scanning 20 blocks on each segment
+SELECT gp_inject_fault('analyze_block', 'suspend', '', '', '', 20, 20, 0, dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+
+-- session 1: analyze the table
+1&: ANALYZE t_analyze_repl;
+SELECT gp_wait_until_triggered_fault('analyze_block', 1, dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+
+-- session 2: query pg_stat_progress_analyze while the analyze is running, the view should indicate 20 blocks have been scanned as average progress of 3 segments
+2: SELECT pid IS NOT NULL as has_pid, datname, relid::regclass, phase, sample_blks_total, sample_blks_scanned FROM gp_stat_progress_analyze_summary;
+
+-- Reset fault injector
+SELECT gp_inject_fault('analyze_block', 'reset', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+1<:
+
+-- teardown
+DROP TABLE t_analyze_repl;

--- a/src/test/isolation2/sql/analyze_progress.sql
+++ b/src/test/isolation2/sql/analyze_progress.sql
@@ -40,3 +40,4 @@ SELECT gp_inject_fault('analyze_block', 'reset', dbid) FROM gp_segment_configura
 
 -- teardown
 DROP TABLE t_analyze_repl;
+

--- a/src/test/isolation2/sql/basebackup_progress.sql
+++ b/src/test/isolation2/sql/basebackup_progress.sql
@@ -1,0 +1,85 @@
+!\retcode rm -rf /tmp/basebackup_progress_tablespace;
+!\retcode mkdir -p /tmp/basebackup_progress_tablespace;
+CREATE TABLESPACE basebackuptest_space LOCATION '/tmp/basebackup_progress_tablespace';
+
+-- Inject fault after checkpoint creation in basebackup
+SELECT gp_inject_fault('basebackup_progress_tablespace_streamed', 'suspend', dbid)
+FROM gp_segment_configuration WHERE content >= -1 and role='p';
+
+-- Run pg_basebackup which should trigger and suspend at the fault
+1&: SELECT pg_basebackup(hostname, 100+content, port, false, NULL,
+                         '/tmp/baseback_progress_test' || content, true, 'fetch', true)
+    from gp_segment_configuration where content = -1 and role = 'p';
+2&: SELECT pg_basebackup(hostname, 100+content, port, false, NULL,
+                         '/tmp/baseback_progress_test' || content, true, 'fetch', true)
+    from gp_segment_configuration where content = 0 and role = 'p';
+3&: SELECT pg_basebackup(hostname, 100+content, port, false, NULL,
+                         '/tmp/baseback_progress_test' || content, true, 'fetch', true)
+    from gp_segment_configuration where content = 1 and role = 'p';
+4&: SELECT pg_basebackup(hostname, 100+content, port, false, NULL,
+                         '/tmp/baseback_progress_test' || content, true, 'fetch', true)
+    from gp_segment_configuration where content = 2 and role = 'p';
+
+-- Wait until fault has been triggered
+SELECT gp_wait_until_triggered_fault('basebackup_progress_tablespace_streamed', 1, dbid)
+FROM gp_segment_configuration WHERE content >= -1 and role='p';
+
+-- See that pg_basebackup is still running
+SELECT application_name, state FROM pg_stat_replication;
+SELECT gp_segment_id, pid is not null as has_pid, phase, (backup_total > backup_streamed and tablespaces_total >= tablespaces_streamed) as is_streaming_tablespaces, tablespaces_streamed = 1 FROM gp_stat_progress_basebackup ORDER BY gp_segment_id ASC;
+SELECT s.pid is not null as has_pid,
+       s.phase,
+       (s.backup_total = (select sum(backup_total) from gp_stat_progress_basebackup)) as sum_backup_total,
+       (s.backup_streamed = (select sum(backup_streamed) from gp_stat_progress_basebackup)) as sum_backup_streamed,
+       (s.tablespaces_total = (select avg(tablespaces_total) from gp_stat_progress_basebackup)) as avg_tablespace_total,
+       (s.tablespaces_streamed = (select avg(tablespaces_streamed) from gp_stat_progress_basebackup)) as avg_tablespace_streamed
+        FROM gp_stat_progress_basebackup_summary s;
+
+-- Resume basebackup
+SELECT gp_inject_fault('basebackup_progress_end', 'suspend', dbid)
+FROM gp_segment_configuration WHERE content >= -1 and role='p';
+SELECT gp_inject_fault('basebackup_progress_tablespace_streamed', 'reset', dbid)
+FROM gp_segment_configuration WHERE content >= -1 and role='p';
+
+-- Wait until fault has been triggered
+SELECT gp_wait_until_triggered_fault('basebackup_progress_end', 1, dbid)
+FROM gp_segment_configuration WHERE content >= -1 and role='p';
+
+-- See that pg_basebackup is still running
+SELECT application_name, state FROM pg_stat_replication;
+SELECT gp_segment_id, pid is not null as has_pid, phase, (backup_total = backup_streamed and tablespaces_total = tablespaces_streamed) as backup_all FROM gp_stat_progress_basebackup ORDER BY gp_segment_id ASC;
+SELECT s.pid is not null as has_pid,
+       s.phase,
+       (s.backup_total = (select sum(backup_total) from gp_stat_progress_basebackup)) as sum_backup_total,
+       (s.backup_streamed = (select sum(backup_streamed) from gp_stat_progress_basebackup)) as sum_backup_streamed,
+       (s.tablespaces_total = (select avg(tablespaces_total) from gp_stat_progress_basebackup)) as avg_tablespace_total,
+       (s.tablespaces_streamed = (select avg(tablespaces_streamed) from gp_stat_progress_basebackup)) as avg_tablespace_streamed
+FROM gp_stat_progress_basebackup_summary s;
+
+-- Resume basebackup
+SELECT gp_inject_fault('basebackup_progress_end', 'reset', dbid)
+FROM gp_segment_configuration WHERE content >= -1 and role='p';
+
+-- Wait until basebackup finishes
+--start_ignore
+1<:
+2<:
+3<:
+4<:
+--end_ignore
+
+-- The summary view should be empty after basebackup finishes
+select * from gp_stat_progress_basebackup_summary;
+
+drop tablespace basebackuptest_space;
+
+-- loop while segments come in sync
+select wait_until_all_segments_synchronized();
+
+--start_ignore
+-- cleanup
+!\retcode rm -rf /tmp/baseback_progress_test-1;
+!\retcode rm -rf /tmp/baseback_progress_test0;
+!\retcode rm -rf /tmp/baseback_progress_test1;
+!\retcode rm -rf /tmp/baseback_progress_test2;
+--end_ignore

--- a/src/test/isolation2/sql/copy_progress.sql
+++ b/src/test/isolation2/sql/copy_progress.sql
@@ -1,0 +1,111 @@
+-- Test COPY progress summary view
+
+-- setup replicated table and data files for COPY
+CREATE TABLE t_copy_repl (a INT, b INT) DISTRIBUTED REPLICATED;
+INSERT INTO t_copy_repl VALUES (2, 2), (0, 0), (5, 5);
+COPY t_copy_repl TO '/tmp/t_copy_relp<SEGID>' ON SEGMENT;
+-- setup DISTRIBUTED table and data files for COPY
+CREATE TABLE t_copy_d (a INT, b INT);
+INSERT INTO t_copy_d select i, i from generate_series(1, 12) i;
+COPY t_copy_d TO '/tmp/t_copy_d<SEGID>' ON SEGMENT;
+
+-- Suspend copy after processed 2 tuples on each segment (3 segments)
+select gp_inject_fault_infinite('copy_processed_two_tuples', 'suspend', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+
+-- It is intentional to run same query twice in 2 sessions. The progress summary
+-- view should record the progress of each session in separate rows.
+
+-- session 1 and 2: Replicated table COPY TO FILE ON SEGMENT
+1&: COPY t_copy_repl TO '/tmp/t_copy_to_relp<SEGID>' ON SEGMENT;
+2&: COPY t_copy_repl TO '/tmp/t_copy_to_relp<SEGID>' ON SEGMENT;
+-- session 3 and 4: Replicated table COPY FROM STDIN
+3&: COPY t_copy_repl FROM PROGRAM 'for i in `seq 1 3`; do echo $i $i; done' WITH DELIMITER ' ';
+4&: COPY t_copy_repl FROM PROGRAM 'for i in `seq 1 3`; do echo $i $i; done' WITH DELIMITER ' ';
+-- session 5 & 6: Replicated table COPY FROM FILE ON SEGMENT
+5&: COPY t_copy_repl FROM '/tmp/t_copy_relp<SEGID>' ON SEGMENT;
+6&: COPY t_copy_repl FROM '/tmp/t_copy_relp<SEGID>' ON SEGMENT;
+-- session 7 & 8: Distributed table COPY TO STDOUT
+7&: COPY t_copy_d TO STDOUT;
+8&: COPY t_copy_d TO STDOUT;
+-- session 9 & 10: Distributed table COPY TO FILE ON SEGMENT
+9&: COPY t_copy_d TO '/tmp/t_copy_to_d<SEGID>' ON SEGMENT;
+10&: COPY t_copy_d TO '/tmp/t_copy_to_d<SEGID>' ON SEGMENT;
+-- session 11 & 12: Distributed table COPY FROM PROGRAM
+11&: COPY t_copy_d FROM PROGRAM 'for i in `seq 1 12`; do echo $i $i; done' WITH DELIMITER ' ';
+12&: COPY t_copy_d FROM PROGRAM 'for i in `seq 1 12`; do echo $i $i; done' WITH DELIMITER ' ';
+-- session 13 & 14: Distributed table COPY FROM FILE ON SEGMENT
+13&: COPY t_copy_d FROM '/tmp/t_copy_d<SEGID>' ON SEGMENT;
+14&: COPY t_copy_d FROM '/tmp/t_copy_d<SEGID>' ON SEGMENT;
+
+SELECT gp_wait_until_triggered_fault('copy_processed_two_tuples', 1, dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+
+-- Verify the progress views
+SELECT
+    gspc.gp_segment_id,
+    gspc.datname,
+    gspc.relid::regclass,
+    gspc.command,
+    gspc."type",
+    gspc.bytes_processed,
+    gspc.bytes_total,
+    gspc.tuples_processed,
+    gspc.tuples_excluded
+FROM gp_stat_progress_copy gspc
+    JOIN gp_stat_activity ac USING (pid)
+ORDER BY (ac.sess_id, gspc.gp_segment_id);
+
+SELECT
+    ac.gp_segment_id = -1 as has_coordinator_pid,
+    gspcs.datname,
+    gspcs.relid::regclass,
+    gspcs.command,
+    gspcs."type",
+    gspcs.bytes_processed,
+    gspcs.bytes_total,
+    gspcs.tuples_processed,
+    gspcs.tuples_excluded
+FROM gp_stat_progress_copy_summary gspcs
+    JOIN gp_stat_activity ac USING (pid)
+ORDER BY ac.sess_id;
+
+SELECT gp_inject_fault('copy_processed_two_tuples', 'reset', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+1<:
+2<:
+3<:
+4<:
+5<:
+6<:
+7<:
+8<:
+9<:
+10<:
+11<:
+12<:
+13<:
+14<:
+
+-- Test COPY TO STDOUT
+-- We need to run this test separately because the COPY TO with replicated table
+-- only copies data from on segment 0.
+
+-- Suspend copy after processing 2 tuples on segment 0 only
+select gp_inject_fault_infinite('copy_processed_two_tuples', 'suspend', dbid) FROM gp_segment_configuration WHERE content = 0 AND role = 'p';
+
+-- session 1: copy table to pipe
+1&: COPY t_copy_repl TO STDOUT;
+-- session 2: copy same table to pipe
+2&: COPY t_copy_repl TO STDOUT;
+SELECT gp_wait_until_triggered_fault('copy_processed_two_tuples', 1, dbid) FROM gp_segment_configuration WHERE content = 0 AND role = 'p';
+
+-- session 2: query gp_stat_progress_copy while the copy is running, the view should indicate 2 tuples have been processed for segment 0 only
+SELECT gp_segment_id, datname, relid::regclass, command, "type", bytes_processed, bytes_total, tuples_processed, tuples_excluded FROM gp_stat_progress_copy;
+SELECT pid IS NOT NULL as has_pid, datname, relid::regclass, command, "type", bytes_processed, bytes_total, tuples_processed, tuples_excluded FROM gp_stat_progress_copy_summary;
+
+-- Reset fault injector
+SELECT gp_inject_fault('copy_processed_two_tuples', 'reset', dbid) FROM gp_segment_configuration WHERE content = 0 AND role = 'p';
+1<:
+2<:
+
+-- teardown
+DROP TABLE t_copy_repl;
+DROP TABLE t_copy_d;

--- a/src/test/isolation2/sql/setup.sql
+++ b/src/test/isolation2/sql/setup.sql
@@ -440,3 +440,24 @@ begin /* in func */
     end loop; /* in func */
 end; /* in func */
 $$ language plpgsql;
+
+-- Helper function that ensures stats collector receives stat from the latest operation.
+create or replace function wait_until_vacuum_count_change_to(relid oid, stat_val_expected bigint)
+    returns text as $$
+declare
+    stat_val int; /* in func */
+    i int; /* in func */
+begin
+    i := 0; /* in func */
+    while i < 1200 loop
+            select pg_stat_get_vacuum_count(relid) into stat_val; /* in func */
+            if stat_val = stat_val_expected then /* in func */
+                return 'OK'; /* in func */
+            end if; /* in func */
+            perform pg_sleep(0.1); /* in func */
+            perform pg_stat_clear_snapshot(); /* in func */
+            i := i + 1; /* in func */
+        end loop; /* in func */
+    return 'Fail'; /* in func */
+end; /* in func */
+$$ language plpgsql;

--- a/src/test/isolation2/sql/setup.sql
+++ b/src/test/isolation2/sql/setup.sql
@@ -327,10 +327,13 @@ $$ language plpgsql;
 --
 -- usage: `select pg_basebackup('somehost', 12345, 'some_slot_name', '/some/destination/data/directory')`
 --
-create or replace function pg_basebackup(host text, dbid int, port int, create_slot boolean, slotname text, datadir text, force_overwrite boolean, xlog_method text) returns text as $$
+create or replace function pg_basebackup(host text, dbid int, port int, create_slot boolean, slotname text, datadir text, force_overwrite boolean, xlog_method text, progress boolean DEFAULT false) returns text as $$
     import subprocess
     import os
     cmd = 'pg_basebackup --no-sync --checkpoint=fast -h %s -p %d -R -D %s --target-gp-dbid %d' % (host, port, datadir, dbid)
+
+    if progress:
+        cmd += ' --progress'
 
     if create_slot:
         cmd += ' --create-slot'

--- a/src/test/isolation2/sql/vacuum_progress_column.sql
+++ b/src/test/isolation2/sql/vacuum_progress_column.sql
@@ -30,10 +30,6 @@ CREATE INDEX on vacuum_progress_ao_column(j);
 -- Also delete half of the tuples evenly before the EOF of segno 2.
 DELETE FROM vacuum_progress_ao_column where j % 2 = 0;
 
--- Lookup pg_class and collected stats view before VACUUM
-SELECT relpages, reltuples, relallvisible FROM pg_class where relname = 'vacuum_progress_ao_column';
-SELECT n_live_tup, n_dead_tup, last_vacuum, vacuum_count FROM gp_stat_all_tables WHERE relname = 'vacuum_progress_ao_column' and gp_segment_id = 1;
-
 -- Perform VACUUM and observe the progress
 
 -- Suspend execution at pre-cleanup phase after truncating both segfiles to their logical EOF.

--- a/src/test/isolation2/sql/vacuum_progress_row.sql
+++ b/src/test/isolation2/sql/vacuum_progress_row.sql
@@ -11,16 +11,15 @@ CREATE TABLE vacuum_progress_ao_row(i int, j int);
 CREATE INDEX on vacuum_progress_ao_row(i);
 CREATE INDEX on vacuum_progress_ao_row(j);
 
--- Insert all tuples to seg1 from two current sessions so that data are stored
--- in two segment files.
+-- Insert from two current sessions so that data are stored in two segment files.
 1: BEGIN;
 2: BEGIN;
-1: INSERT INTO vacuum_progress_ao_row SELECT 0, i FROM generate_series(1, 100000) i;
-2: INSERT INTO vacuum_progress_ao_row SELECT 0, i FROM generate_series(1, 100000) i;
+1: INSERT INTO vacuum_progress_ao_row SELECT i, i FROM generate_series(1, 100000) i;
+2: INSERT INTO vacuum_progress_ao_row SELECT i, i FROM generate_series(1, 100000) i;
 -- Commit so that the logical EOF of segno 2 is non-zero.
 2: COMMIT;
 2: BEGIN;
-2: INSERT INTO vacuum_progress_ao_row SELECT 0, i FROM generate_series(1, 100000) i;
+2: INSERT INTO vacuum_progress_ao_row SELECT i, i FROM generate_series(1, 100000) i;
 -- Abort so that segno 2 has dead tuples after its logical EOF
 2: ABORT;
 2q:
@@ -33,39 +32,45 @@ DELETE FROM vacuum_progress_ao_row where j % 2 = 0;
 -- Lookup pg_class and collected stats view before VACUUM
 SELECT relpages, reltuples, relallvisible FROM pg_class where relname = 'vacuum_progress_ao_row';
 SELECT n_live_tup, n_dead_tup, last_vacuum, vacuum_count FROM gp_stat_all_tables WHERE relname = 'vacuum_progress_ao_row' and gp_segment_id = 1;
+SELECT n_live_tup, n_dead_tup, last_vacuum, vacuum_count FROM gp_stat_all_tables_summary WHERE relname = 'vacuum_progress_ao_row';
 
 -- Perform VACUUM and observe the progress
 
 -- Suspend execution at pre-cleanup phase after truncating both segfiles to their logical EOF.
-SELECT gp_inject_fault('appendonly_after_truncate_segment_file', 'suspend', '', '', '', 2, 2, 0, dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+SELECT gp_inject_fault('appendonly_after_truncate_segment_file', 'suspend', '', '', '', 2, 2, 0, dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
 
 1: set Debug_appendonly_print_compaction to on;
 1&: VACUUM vacuum_progress_ao_row;
 SELECT gp_wait_until_triggered_fault('appendonly_after_truncate_segment_file', 2, dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
 -- We are in pre_cleanup phase and some blocks should've been vacuumed by now
-1U: select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, heap_blks_vacuumed, index_vacuum_count, max_dead_tuples, num_dead_tuples from pg_stat_progress_vacuum;
+select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, heap_blks_vacuumed, index_vacuum_count, max_dead_tuples, num_dead_tuples from gp_stat_progress_vacuum where gp_segment_id = 1;
+select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, heap_blks_vacuumed, index_vacuum_count, max_dead_tuples, num_dead_tuples from gp_stat_progress_vacuum_summary;
 
 -- Resume execution and suspend again in the middle of compact phase
-SELECT gp_inject_fault('appendonly_insert', 'suspend', '', '', '', 200, 200, 0, dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
-SELECT gp_inject_fault('appendonly_after_truncate_segment_file', 'reset', dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+SELECT gp_inject_fault('appendonly_insert', 'suspend', '', '', '', 200, 200, 0, dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+SELECT gp_inject_fault('appendonly_after_truncate_segment_file', 'reset', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
 SELECT gp_wait_until_triggered_fault('appendonly_insert', 200, dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
 -- We are in compact phase. num_dead_tuples should increase as we move and count tuples, one by one.
-1U: select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, heap_blks_vacuumed, index_vacuum_count, max_dead_tuples, num_dead_tuples from pg_stat_progress_vacuum;
+select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, heap_blks_vacuumed, index_vacuum_count, max_dead_tuples, num_dead_tuples from gp_stat_progress_vacuum where gp_segment_id = 1;
+select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, heap_blks_vacuumed, index_vacuum_count, max_dead_tuples, num_dead_tuples from gp_stat_progress_vacuum_summary;
 
 -- Resume execution and suspend again after compacting all segfiles
-SELECT gp_inject_fault('vacuum_ao_after_compact', 'suspend', dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
-SELECT gp_inject_fault('appendonly_insert', 'reset', dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+SELECT gp_inject_fault('vacuum_ao_after_compact', 'suspend', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+SELECT gp_inject_fault('appendonly_insert', 'reset', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
 SELECT gp_wait_until_triggered_fault('vacuum_ao_after_compact', 1, dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
 -- After compacting all segfiles we expect 50000 dead tuples
-1U: select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, heap_blks_vacuumed, index_vacuum_count, max_dead_tuples, num_dead_tuples from pg_stat_progress_vacuum;
+select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, heap_blks_vacuumed, index_vacuum_count, max_dead_tuples, num_dead_tuples from gp_stat_progress_vacuum where gp_segment_id = 1;
+select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, heap_blks_vacuumed, index_vacuum_count, max_dead_tuples, num_dead_tuples from gp_stat_progress_vacuum_summary;
 
 -- Resume execution and entering post_cleaup phase, suspend at the end of it.
-SELECT gp_inject_fault('vacuum_ao_post_cleanup_end', 'suspend', dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
-SELECT gp_inject_fault('vacuum_ao_after_compact', 'reset', dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+SELECT gp_inject_fault('vacuum_ao_post_cleanup_end', 'suspend', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+SELECT gp_inject_fault('vacuum_ao_after_compact', 'reset', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
 SELECT gp_wait_until_triggered_fault('vacuum_ao_post_cleanup_end', 1, dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
 -- We should have skipped recycling the awaiting drop segment because the segment was still visible to the SELECT gp_wait_until_triggered_fault query.
-1U: select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, heap_blks_vacuumed, index_vacuum_count, max_dead_tuples, num_dead_tuples from pg_stat_progress_vacuum;
-SELECT gp_inject_fault('vacuum_ao_post_cleanup_end', 'reset', dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, heap_blks_vacuumed, index_vacuum_count, max_dead_tuples, num_dead_tuples from gp_stat_progress_vacuum where gp_segment_id = 1;
+select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, heap_blks_vacuumed, index_vacuum_count, max_dead_tuples, num_dead_tuples from gp_stat_progress_vacuum_summary;
+
+SELECT gp_inject_fault('vacuum_ao_post_cleanup_end', 'reset', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
 1<:
 
 -- pg_class and collected stats view should be updated after the 1st VACUUM
@@ -74,31 +79,32 @@ SELECT relpages, reltuples, relallvisible FROM pg_class where relname = 'vacuum_
 SELECT n_live_tup, n_dead_tup, last_vacuum is not null as has_last_vacuum, vacuum_count FROM gp_stat_all_tables WHERE relname = 'vacuum_progress_ao_row' and gp_segment_id = 1;
 
 -- Perform VACUUM again to recycle the remaining awaiting drop segment marked by the previous run.
-SELECT gp_inject_fault('vacuum_ao_after_index_delete', 'suspend', dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+SELECT gp_inject_fault('vacuum_ao_after_index_delete', 'suspend', dbid) FROM gp_segment_configuration WHERE content = 0 AND role = 'p';
+SELECT gp_inject_fault('appendonly_after_truncate_segment_file', 'suspend', dbid) FROM gp_segment_configuration WHERE content > 0 AND role = 'p';
 1&: VACUUM vacuum_progress_ao_row;
--- Resume execution and entering pre_cleanup phase, suspend at vacuuming indexes.
-SELECT gp_inject_fault('vacuum_ao_after_compact', 'reset', dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
-SELECT gp_wait_until_triggered_fault('vacuum_ao_after_index_delete', 1, dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
--- We are in vacuuming indexes phase (part of ao pre_cleanup phase), index_vacuum_count should increase to 1.
-1U: select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, heap_blks_vacuumed, index_vacuum_count, max_dead_tuples, num_dead_tuples from pg_stat_progress_vacuum;
+-- Resume execution and entering pre_cleanup phase, suspend at vacuuming indexes for segment 0.
+SELECT gp_wait_until_triggered_fault('vacuum_ao_after_index_delete', 1, dbid) FROM gp_segment_configuration WHERE content = 0 AND role = 'p';
+-- Resume execution and moving on to truncate segments that were marked as AWAITING_DROP for segment 1 and 2, there should be only 1.
+SELECT gp_wait_until_triggered_fault('appendonly_after_truncate_segment_file', 1, dbid) FROM gp_segment_configuration WHERE content > 0 AND role = 'p';
+-- Segment 0 is in vacuuming indexes phase (part of ao pre_cleanup phase), index_vacuum_count should increase to 1.
+select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, heap_blks_vacuumed, index_vacuum_count, max_dead_tuples, num_dead_tuples from gp_stat_progress_vacuum where gp_segment_id = 0;
+-- Segment 1 and 2 are in truncate segments phase (part of ao post_cleanup phase), heap_blks_vacuumed should increase to 1.
+select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, heap_blks_vacuumed, index_vacuum_count, max_dead_tuples, num_dead_tuples from gp_stat_progress_vacuum where gp_segment_id > 0;
+select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, heap_blks_vacuumed, index_vacuum_count, max_dead_tuples, num_dead_tuples from gp_stat_progress_vacuum_summary;
 
--- Resume execution and moving on to truncate segments that were marked as AWAITING_DROP, there should be only 1.
-SELECT gp_inject_fault('appendonly_after_truncate_segment_file', 'suspend', dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
-SELECT gp_inject_fault('vacuum_ao_after_index_delete', 'reset', dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
-SELECT gp_wait_until_triggered_fault('appendonly_after_truncate_segment_file', 1, dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
--- We are in post_cleanup phase and should have truncated the old segfile. Both indexes should be vacuumed by now, and heap_blks_vacuumed should also increased
-1U: select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, heap_blks_vacuumed, index_vacuum_count, max_dead_tuples, num_dead_tuples from pg_stat_progress_vacuum;
-
-SELECT gp_inject_fault('appendonly_after_truncate_segment_file', 'reset', dbid) FROM gp_segment_configuration WHERE content = 1 AND role = 'p';
+SELECT gp_inject_fault('appendonly_after_truncate_segment_file', 'reset', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+SELECT gp_inject_fault('vacuum_ao_after_index_delete', 'reset', dbid) FROM gp_segment_configuration WHERE content = 0 AND role = 'p';
 1<:
 
--- Vacuum has finished, nothing should show up in the progress view.
-1U: select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, heap_blks_vacuumed, index_vacuum_count, max_dead_tuples, num_dead_tuples from pg_stat_progress_vacuum;
+-- Vacuum has finished, nothing should show up in the view.
+select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, heap_blks_vacuumed, index_vacuum_count, max_dead_tuples, num_dead_tuples from gp_stat_progress_vacuum where gp_segment_id = 1;
+select relid::regclass as relname, phase, heap_blks_total, heap_blks_scanned, heap_blks_vacuumed, index_vacuum_count, max_dead_tuples, num_dead_tuples from gp_stat_progress_vacuum_summary;
 
 -- pg_class and collected stats view should be updated after the 2nd VACUUM
-1U: SELECT wait_until_dead_tup_change_to('vacuum_progress_ao_row'::regclass::oid, 0);
+1U: SELECT wait_until_vacuum_count_change_to('vacuum_progress_ao_row'::regclass::oid, 2);
 SELECT relpages, reltuples, relallvisible FROM pg_class where relname = 'vacuum_progress_ao_row';
 SELECT n_live_tup, n_dead_tup, last_vacuum is not null as has_last_vacuum, vacuum_count FROM gp_stat_all_tables WHERE relname = 'vacuum_progress_ao_row' and gp_segment_id = 1;
+SELECT n_live_tup, n_dead_tup, last_vacuum is not null as has_last_vacuum, vacuum_count FROM gp_stat_all_tables_summary WHERE relname = 'vacuum_progress_ao_row';
 
 -- Cleanup
 SELECT gp_inject_fault_infinite('all', 'reset', dbid) FROM gp_segment_configuration;

--- a/src/test/isolation2/sql/vacuum_progress_row.sql
+++ b/src/test/isolation2/sql/vacuum_progress_row.sql
@@ -29,11 +29,6 @@ CREATE INDEX on vacuum_progress_ao_row(j);
 -- Also delete half of the tuples evenly before the EOF of segno 2.
 DELETE FROM vacuum_progress_ao_row where j % 2 = 0;
 
--- Lookup pg_class and collected stats view before VACUUM
-SELECT relpages, reltuples, relallvisible FROM pg_class where relname = 'vacuum_progress_ao_row';
-SELECT n_live_tup, n_dead_tup, last_vacuum, vacuum_count FROM gp_stat_all_tables WHERE relname = 'vacuum_progress_ao_row' and gp_segment_id = 1;
-SELECT n_live_tup, n_dead_tup, last_vacuum, vacuum_count FROM gp_stat_all_tables_summary WHERE relname = 'vacuum_progress_ao_row';
-
 -- Perform VACUUM and observe the progress
 
 -- Suspend execution at pre-cleanup phase after truncating both segfiles to their logical EOF.


### PR DESCRIPTION
Created the following system views for greenplum specific progress reporting

- gp_stat_progress_vacuum_summary
- gp_stat_progress_analyze_summary
- gp_stat_progress_cluster_summary
- gp_stat_progress_create_index_summary
- gp_stat_progress_copy_summary
- gp_stat_progress_basebackup_summary

For reviewer:
- It is better to review commit-by-commit
- Things we are looking for feedback
  1. Replicated table are handled differently in most cases
  2. Do we calculate average among just primaries or also include the coordinator (mostly only applied to pg_basebackup)?
  3. For COPY command, ON SEGMENT commands and replicated tables are handled differently
  4. How to define the "pid" column? We report an arbitrary pid from a segment right now. 

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
