### PR TITLE
Added deprecation notices

### DIFF
--- a/gpdb-doc/markdown/analytics/greenplum_r_client.html.md
+++ b/gpdb-doc/markdown/analytics/greenplum_r_client.html.md
@@ -2,6 +2,8 @@
 title: Greenplum Database R Client 
 ---
 
+> *Note* Greenplum Database R Client is deprecated and will be removed in a future Greenplum Database release.
+
 This chapter contains the following information:
 
 -   [About Greenplum R](#about)

--- a/gpdb-doc/markdown/analytics/pl_container.html.md
+++ b/gpdb-doc/markdown/analytics/pl_container.html.md
@@ -42,6 +42,8 @@ The container connection is closed by closing the Greenplum Database session tha
 
 ### <a id="section_d32_nv1_rqb"></a>About PL/Container 3 Beta 
 
+> *Note* PL/Container 3 Beta is deprecated and will be removed in a future Greenplum Database release.
+
 Greenplum Database 6.5 introduces PL/Container version 3 Beta, which:
 
 -   Provides support for the new GreenplumR interface.

--- a/gpdb-doc/markdown/utility_guide/ref/gpmapreduce.html.md
+++ b/gpdb-doc/markdown/utility_guide/ref/gpmapreduce.html.md
@@ -2,6 +2,8 @@
 
 Runs Greenplum MapReduce jobs as defined in a YAML specification document.
 
+> *Note* Greenplum MapReduce is deprecated and will be removed in a future Greenplum Database release.
+
 ## <a id="section2"></a>Synopsis 
 
 ```


### PR DESCRIPTION
Added deprecation notice for Greenplum MapReduce, PL/Container 3 Beta and GreenplumR client (deprecated since 6.24.0).
