### PR TITLE
Run preprocessing methods in ExplainDXL

### DIFF
--- a/src/backend/optimizer/plan/orca.c
+++ b/src/backend/optimizer/plan/orca.c
@@ -43,8 +43,6 @@
 /* GPORCA entry point */
 extern PlannedStmt * GPOPTOptimizedPlan(Query *parse, bool *had_unexpected_failure);
 
-static Node *transformGroupedWindows(Node *node, void *context);
-
 static Plan *remove_redundant_results(PlannerInfo *root, Plan *plan);
 static Node *remove_redundant_results_mutator(Node *node, void *);
 static bool can_replace_tlist(Plan *plan);
@@ -126,7 +124,6 @@ optimize_query(Query *parse, int cursorOptions, ParamListInfo boundParams)
 	glob->share.qdShares = NULL;
 	/* these will be filled in below, in the pre- and post-processing steps */
 	glob->finalrtable = NIL;
-	glob->subplans = NIL;
 	glob->relationOids = NIL;
 	glob->invalItems = NIL;
 
@@ -490,7 +487,7 @@ static Alias *make_replacement_alias(Query *qry, const char *aname);
 static char *generate_positional_name(AttrNumber attrno);
 static List *generate_alternate_vars(Var *var, grouped_window_ctx * ctx);
 
-static Node *
+Node *
 transformGroupedWindows(Node *node, void *context)
 {
 	if (node == NULL)

--- a/src/include/optimizer/orca.h
+++ b/src/include/optimizer/orca.h
@@ -22,6 +22,7 @@
 #ifdef USE_ORCA
 
 extern PlannedStmt * optimize_query(Query *parse, int cursorOptions, ParamListInfo boundParams);
+extern Node *transformGroupedWindows(Node *node, void *context);
 
 #else
 


### PR DESCRIPTION
Previously, we didn't run some of the query preprocessing methods to fold constants and transform window functions during ExplainDXL. While this doesn't affect production code or creating minidumps, it did make the DXL explain plan different from what was produced in minidumps. This adds the same logic to unify the behavior.

The following query produced a different explain (dxl) and minidump output because constants were not folded in explain (dxl): `select format(‘|%20s|’, ‘ten’) union all select format(‘|%10s%10s|’, variadic array[‘first’, ‘second’]);`