### PR TITLE
Replace "frozen insert" with "insert & freeze" across GPDB

### DIFF
--- a/src/backend/access/aocs/aocssegfiles.c
+++ b/src/backend/access/aocs/aocssegfiles.c
@@ -96,7 +96,8 @@ InsertInitialAOCSFileSegInfo(Relation prel, int32 segno, int32 nvp, Oid segrelid
 
 	segtup = heap_form_tuple(RelationGetDescr(segrel), values, nulls);
 
-	CatalogTupleInsertFrozen(segrel, segtup);
+	CatalogTupleInsert(segrel, segtup);
+	heap_freeze_tuple_wal_logged(segrel, segtup);
 
 	/*
 	 * Lock the tuple so that a concurrent insert transaction will not

--- a/src/backend/access/appendonly/appendonlyam.c
+++ b/src/backend/access/appendonly/appendonlyam.c
@@ -2721,7 +2721,6 @@ appendonly_insert(AppendOnlyInsertDesc aoInsertDesc,
 		tup = toast_insert_or_update_memtup(relation, instup,
 											NULL, aoInsertDesc->mt_bind,
 											aoInsertDesc->toast_tuple_target,
-											false,	/* errtbl is never AO */
 											0);
 	else
 		tup = instup;

--- a/src/backend/access/heap/heapam.c
+++ b/src/backend/access/heap/heapam.c
@@ -81,7 +81,7 @@ static TM_Result heap_update_internal(Relation relation, ItemPointer otid, HeapT
 									  TM_FailureData *tmfd, LockTupleMode *lockmode, bool simple);
 
 static HeapTuple heap_prepare_insert(Relation relation, HeapTuple tup,
-									 TransactionId xid, CommandId cid, int options, bool isFrozen);
+									 TransactionId xid, CommandId cid, int options);
 static XLogRecPtr log_heap_update(Relation reln, Buffer oldbuf,
 								  Buffer newbuf, HeapTuple oldtup,
 								  HeapTuple newtup, HeapTuple old_key_tup,
@@ -1964,7 +1964,6 @@ void
 heap_insert(Relation relation, HeapTuple tup, CommandId cid,
 			int options, BulkInsertState bistate, TransactionId xid)
 {
-	bool		isFrozen = (xid == FrozenTransactionId);
 	HeapTuple	heaptup;
 	Buffer		buffer;
 	Buffer		vmbuffer = InvalidBuffer;
@@ -1989,7 +1988,7 @@ heap_insert(Relation relation, HeapTuple tup, CommandId cid,
 	 * Note: below this point, heaptup is the data we actually intend to store
 	 * into the relation; tup is the caller's original untoasted data.
 	 */
-	heaptup = heap_prepare_insert(relation, tup, xid, cid, options, isFrozen);
+	heaptup = heap_prepare_insert(relation, tup, xid, cid, options);
 
 	/*
 	 * Find buffer to insert this tuple into.  If the page is all visible,
@@ -2115,10 +2114,7 @@ heap_insert(Relation relation, HeapTuple tup, CommandId cid,
 		/* filtering by origin on a row level is much more efficient */
 		XLogSetRecordFlags(XLOG_INCLUDE_ORIGIN);
 
-		if (!isFrozen)
-			recptr = XLogInsert(RM_HEAP_ID, info);
-		else
-			recptr = XLogInsert_OverrideXid(RM_HEAP_ID, info, FrozenTransactionId);
+		recptr = XLogInsert(RM_HEAP_ID, info);
 
 		PageSetLSN(page, recptr);
 	}
@@ -2163,7 +2159,7 @@ heap_insert(Relation relation, HeapTuple tup, CommandId cid,
  */
 static HeapTuple
 heap_prepare_insert(Relation relation, HeapTuple tup, TransactionId xid,
-					CommandId cid, int options, bool isFrozen)
+					CommandId cid, int options)
 {
 	/*
 	 * Parallel operations are required to be strictly read-only in a parallel
@@ -2179,8 +2175,6 @@ heap_prepare_insert(Relation relation, HeapTuple tup, TransactionId xid,
 				 errmsg("cannot insert tuples in a parallel worker")));
 
 	tup->t_data->t_infomask &= ~(HEAP_XACT_MASK);
-	if (isFrozen)
-		tup->t_data->t_infomask |= HEAP_XMIN_COMMITTED;
 	tup->t_data->t_infomask2 &= ~(HEAP2_XACT_MASK);
 	tup->t_data->t_infomask |= HEAP_XMAX_INVALID;
 	HeapTupleHeaderSetXmin(tup->t_data, xid);
@@ -2204,7 +2198,7 @@ heap_prepare_insert(Relation relation, HeapTuple tup, TransactionId xid,
 	}
 	else if (HeapTupleHasExternal(tup) || tup->t_len > TOAST_TUPLE_THRESHOLD)
 		return toast_insert_or_update(relation, tup, NULL,
-									  TOAST_TUPLE_TARGET, isFrozen,
+									  TOAST_TUPLE_TARGET,
 									  options);
 	else
 		return tup;
@@ -2226,7 +2220,6 @@ heap_multi_insert(Relation relation, TupleTableSlot **slots, int ntuples,
 				  CommandId cid, int options, BulkInsertState bistate)
 {
 	TransactionId xid = GetCurrentTransactionId();
-	bool        isFrozen = false;
 	HeapTuple  *heaptuples;
 	int			i;
 	int			ndone;
@@ -2254,7 +2247,7 @@ heap_multi_insert(Relation relation, TupleTableSlot **slots, int ntuples,
 		slots[i]->tts_tableOid = RelationGetRelid(relation);
 		tuple->t_tableOid = slots[i]->tts_tableOid;
 		heaptuples[i] = heap_prepare_insert(relation, tuple, xid, cid,
-											options, isFrozen);
+											options);
 	}
 
 	/*
@@ -3664,7 +3657,7 @@ l2:
 		{
 			/* Note we always use WAL and FSM during updates */
 			heaptup = toast_insert_or_update(relation, newtup, &oldtup,
-											 TOAST_TUPLE_TARGET, false, 0);
+											 TOAST_TUPLE_TARGET, 0);
 			newtupsize = MAXALIGN(heaptup->t_len);
 		}
 		else

--- a/src/backend/access/heap/heapam.c
+++ b/src/backend/access/heap/heapam.c
@@ -6642,7 +6642,6 @@ void
 heap_freeze_tuple_wal_logged(Relation rel, HeapTuple tup)
 {
 	xl_heap_freeze_tuple 	frozen = {0};
-	XLogRecPtr      	recptr;
 	Buffer 			buffer;
 	Page 			page;
 	HeapTupleHeader		htup;
@@ -6676,9 +6675,14 @@ heap_freeze_tuple_wal_logged(Relation rel, HeapTuple tup)
 	heap_execute_freeze_tuple(htup, &frozen);
 
 	/* WAL logging */
-	recptr = log_heap_freeze(rel, buffer, InvalidTransactionId /* cutoff_xid */,
-								&frozen, 1 /*ntuples*/);
-	PageSetLSN(page, recptr);
+	if (RelationNeedsWAL(rel))
+	{
+		XLogRecPtr      	recptr;
+
+		recptr = log_heap_freeze(rel, buffer, InvalidTransactionId /* cutoff_xid */,
+									&frozen, 1 /*ntuples*/);
+		PageSetLSN(page, recptr);
+	}
 
 	END_CRIT_SECTION();
 

--- a/src/backend/access/heap/rewriteheap.c
+++ b/src/backend/access/heap/rewriteheap.c
@@ -666,7 +666,6 @@ raw_heap_insert(RewriteState state, HeapTuple tup)
 
 		heaptup = toast_insert_or_update(state->rs_new_rel, tup, NULL,
 										 TOAST_TUPLE_TARGET,
-										 false,
 										 options);
 	}
 	else

--- a/src/backend/access/heap/tuptoaster.c
+++ b/src/backend/access/heap/tuptoaster.c
@@ -70,7 +70,7 @@ typedef struct toast_compress_header
 	(((toast_compress_header *) (ptr))->rawsize = (len))
 
 static Datum toast_save_datum(Relation rel, Datum value,
-							  struct varlena *oldexternal, bool isFrozen, int options);
+							  struct varlena *oldexternal, int options);
 static bool toastrel_valueid_exists(Relation toastrel, Oid valueid);
 static bool toastid_valueid_exists(Oid toastrelid, Oid valueid);
 static struct varlena *toast_fetch_datum(struct varlena *attr);
@@ -682,7 +682,7 @@ compute_dest_tuplen(TupleDesc tupdesc, MemTupleBinding *pbind, bool hasnull, Dat
 static void *
 toast_insert_or_update_generic(Relation rel, void *newtup, void *oldtup,
 							   MemTupleBinding *pbind, int toast_tuple_target,
-							   bool isFrozen, int options, bool ismemtuple)
+							   int options, bool ismemtuple)
 {
 	void	   *result_gtuple;
 	TupleDesc	tupleDesc;
@@ -981,7 +981,7 @@ toast_insert_or_update_generic(Relation rel, void *newtup, void *oldtup,
 			old_value = toast_values[i];
 			toast_action[i] = 'p';
 			toast_values[i] = toast_save_datum(rel, toast_values[i],
-											   toast_oldexternal[i], isFrozen, options);
+											   toast_oldexternal[i], options);
 			if (toast_free[i])
 				pfree(DatumGetPointer(old_value));
 			toast_free[i] = true;
@@ -1034,7 +1034,7 @@ toast_insert_or_update_generic(Relation rel, void *newtup, void *oldtup,
 		old_value = toast_values[i];
 		toast_action[i] = 'p';
 		toast_values[i] = toast_save_datum(rel, toast_values[i],
-										   toast_oldexternal[i], isFrozen, options);
+										   toast_oldexternal[i], options);
 		if (toast_free[i])
 			pfree(DatumGetPointer(old_value));
 		toast_free[i] = true;
@@ -1156,7 +1156,7 @@ toast_insert_or_update_generic(Relation rel, void *newtup, void *oldtup,
 		old_value = toast_values[i];
 		toast_action[i] = 'p';
 		toast_values[i] = toast_save_datum(rel, toast_values[i],
-										   toast_oldexternal[i], isFrozen, options);
+										   toast_oldexternal[i], options);
 		if (toast_free[i])
 			pfree(DatumGetPointer(old_value));
 		toast_free[i] = true;
@@ -1261,14 +1261,13 @@ toast_insert_or_update_generic(Relation rel, void *newtup, void *oldtup,
 HeapTuple
 toast_insert_or_update(Relation rel, HeapTuple newtup, HeapTuple oldtup,
 					   int toast_tuple_target,
-					   bool isFrozen, int options)
+					   int options)
 {
 	return (HeapTuple) toast_insert_or_update_generic(rel,
 													  (void *) newtup,
 													  (void *) oldtup,
 													  NULL,
 													  toast_tuple_target,
-													  isFrozen,
 													  options,
 													  false);
 }
@@ -1276,14 +1275,13 @@ toast_insert_or_update(Relation rel, HeapTuple newtup, HeapTuple oldtup,
 MemTuple
 toast_insert_or_update_memtup(Relation rel, MemTuple newtup, MemTuple oldtup,
 					   MemTupleBinding *pbind, int toast_tuple_target,
-					   bool isFrozen, int options)
+					   int options)
 {
 	return (MemTuple) toast_insert_or_update_generic(rel,
 													 (void *) newtup,
 													 (void *) oldtup,
 													 pbind,
 													 toast_tuple_target,
-													 isFrozen,
 													 options,
 													 true);
 }
@@ -1675,7 +1673,7 @@ toast_get_valid_index(Oid toastoid, LOCKMODE lock)
  */
 static Datum
 toast_save_datum(Relation rel, Datum value,
-				 struct varlena *oldexternal, bool isFrozen, int options)
+				 struct varlena *oldexternal, int options)
 {
 	Relation	toastrel;
 	Relation   *toastidxs;
@@ -1912,17 +1910,9 @@ toast_save_datum(Relation rel, Datum value,
 		memcpy(VARDATA(&chunk_data), data_p, chunk_size);
 		toasttup = heap_form_tuple(toasttupDesc, t_values, t_isnull);
 
-		if (!isFrozen)
-		{
-			/* the normal case. regular insert */
-			heap_insert(toastrel, toasttup, mycid, options, NULL, myxid);
-		}
-		else
-		{
-			/* insert and freeze the tuple. used for errtables and their related toast data */
-			frozen_heap_insert(toastrel, toasttup);
-		}
-			
+		/* the normal case. regular insert */
+		heap_insert(toastrel, toasttup, mycid, options, NULL, myxid);
+
 		/*
 		 * Create the index entry.  We cheat a little here by not using
 		 * FormIndexDatum: this relies on the knowledge that the index columns

--- a/src/backend/access/transam/xloginsert.c
+++ b/src/backend/access/transam/xloginsert.c
@@ -424,12 +424,6 @@ XLogInsert(RmgrId rmid, uint8 info)
 	return XLogInsert_Internal(rmid, info, GetCurrentTransactionIdIfAny());
 }
 
-XLogRecPtr
-XLogInsert_OverrideXid(RmgrId rmid, uint8 info, TransactionId overrideXid)
-{
-	return XLogInsert_Internal(rmid, info, overrideXid);
-}
-
 static XLogRecPtr
 XLogInsert_Internal(RmgrId rmid, uint8 info, TransactionId headerXid)
 {

--- a/src/backend/catalog/indexing.c
+++ b/src/backend/catalog/indexing.c
@@ -328,21 +328,3 @@ CatalogTupleDelete(Relation heapRel, ItemPointer tid)
 {
 	simple_heap_delete(heapRel, tid);
 }
-
-/*
- * Greenplum: this interface is used to insert tuples into gp_fastsequence
- * and aoseg relations during an appendoptimized (row as well as column)
- * insert transaction.
- */
-void
-CatalogTupleInsertFrozen(Relation heapRel, HeapTuple tup)
-{
-	CatalogIndexState indstate;
-
-	indstate = CatalogOpenIndexes(heapRel);
-
-	frozen_heap_insert(heapRel, tup);
-
-	CatalogIndexInsert(indstate, tup);
-	CatalogCloseIndexes(indstate);
-}

--- a/src/include/access/tuptoaster.h
+++ b/src/include/access/tuptoaster.h
@@ -149,12 +149,12 @@ do { \
 extern HeapTuple toast_insert_or_update(Relation rel,
 										HeapTuple newtup, HeapTuple oldtup,
 										int toast_tuple_target,
-										bool isFrozen, int options);
+										int options);
 
 extern MemTuple toast_insert_or_update_memtup(Relation rel,
 											  MemTuple newtup, MemTuple oldtup,
 											  MemTupleBinding *pbind, int toast_tuple_target,
-											  bool isFrozen, int options);
+											  int options);
 
 /* ----------
  * toast_delete -

--- a/src/include/access/xloginsert.h
+++ b/src/include/access/xloginsert.h
@@ -42,7 +42,6 @@
 extern void XLogBeginInsert(void);
 extern void XLogSetRecordFlags(uint8 flags);
 extern XLogRecPtr XLogInsert(RmgrId rmid, uint8 info);
-extern XLogRecPtr XLogInsert_OverrideXid(RmgrId rmid, uint8 info, TransactionId overrideXid);
 extern void XLogEnsureRecordSpace(int nbuffers, int ndatas);
 extern void XLogRegisterData(char *data, int len);
 extern void XLogRegisterBuffer(uint8 block_id, Buffer buffer, uint8 flags);

--- a/src/include/catalog/indexing.h
+++ b/src/include/catalog/indexing.h
@@ -45,8 +45,6 @@ extern void CatalogTupleUpdateWithInfo(Relation heapRel,
 									   CatalogIndexState indstate);
 extern void CatalogTupleDelete(Relation heapRel, ItemPointer tid);
 
-extern void CatalogTupleInsertFrozen(Relation heapRel, HeapTuple tup);
-
 /*
  * These macros are just to keep the C compiler from spitting up on the
  * upcoming commands for Catalog.pm.

--- a/src/test/isolation2/expected/frozen_insert_crash.out
+++ b/src/test/isolation2/expected/frozen_insert_crash.out
@@ -6,7 +6,8 @@
 --
 -- And the above behavior should remain consistent using seqscan or indexscan.
 --
--- We test gp_fastsequence here since it does frozen insert and has an index.
+-- We test gp_fastsequence and bitmap here since they do frozen insert and
+-- normal index insert, so that the inconsistency could exist.
 
 -- Case 1. crash after the regular MVCC insert has made to disk, but not
 -- the WAL record responsible for updating it to frozen.
@@ -199,6 +200,206 @@ RESET
 
 1: drop table tab_fi;
 DROP
+
+
+-- Same set of tests for bitmap LOV insert.
+create extension if not exists pageinspect;
+CREATE
+
+-- Function to check the bitmap lov content regarding the column 'b'
+-- which is the table column that we will have bitmap created on.
+-- Basically, we want to see if "SELECT b FROM pg_bitmapindex.pg_bm_xxx"
+-- returns the same result in seqscan and indexscan.
+CREATE OR REPLACE FUNCTION insert_bm_lov_res() RETURNS void AS $$ DECLARE lov_table text; /* in func */ sql text; /* in func */ BEGIN /* in func */ drop table if exists bm_lov_res; /* in func */ create temp table bm_lov_res(b int); /* in func */ SELECT c.relname INTO lov_table /* in func */ FROM bm_metap('tab_fi_idx') b /* in func */ JOIN pg_class c ON b.auxrelid = c.oid; /* in func */ sql := format('INSERT INTO bm_lov_res SELECT b FROM pg_bitmapindex.%I', lov_table); /* in func */ EXECUTE sql; /* in func */ END; /* in func */ $$ LANGUAGE plpgsql;
+CREATE
+
+1: create table tab_fi(a int, b int) with (appendoptimized=true) distributed replicated;
+CREATE
+1: create index tab_fi_idx on tab_fi using bitmap(b);
+CREATE
+1: insert into tab_fi values(1, 1);
+INSERT 1
+-- switch WAL on seg0 to reduce flakiness
+1: select gp_segment_id, pg_switch_wal() is not null from gp_dist_random('gp_id') where gp_segment_id = 0;
+ gp_segment_id | ?column? 
+---------------+----------
+ 0             | t        
+(1 row)
+
+-- case 1: suspend and flush WAL before freezing the tuple
+
+-- suspend right after the insert into the bitmap lov table and its index
+-- during a table insert, but before freezing the tuple
+1: select gp_inject_fault('insert_bmlov_before_freeze', 'suspend', dbid) from gp_segment_configuration where role = 'p' and content = 0;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+2>: insert into tab_fi values(2, 2);  <waiting ...>
+1: select gp_wait_until_triggered_fault('insert_bmlov_before_freeze', 1, dbid) from gp_segment_configuration where role = 'p' and content = 0;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+-- switch WAL on seg0, so the new row gets flushed (including its index)
+1: select gp_segment_id, pg_switch_wal() is not null from gp_dist_random('gp_id') where gp_segment_id = 0;
+ gp_segment_id | ?column? 
+---------------+----------
+ 0             | t        
+(1 row)
+-- inject a panic, and resume the insert. The WAL for the freeze operation is not
+-- going to be made to disk (we just flushed WALs), so we won't replay it during restart later.
+-- skip FTS probe to prevent unexpected mirror promotion
+1: select gp_inject_fault_infinite('fts_probe', 'skip', dbid) from gp_segment_configuration where role='p' and content=-1;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+1: select gp_inject_fault('qe_exec_finished', 'panic', dbid) from gp_segment_configuration where role = 'p' and content = 0;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+1: select gp_inject_fault('insert_bmlov_before_freeze', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = 0;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+1: select gp_inject_fault('fts_probe', 'reset', dbid) from gp_segment_configuration where role='p' and content=-1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+2<:  <... completed>
+ERROR:  fault triggered, fault name:'qe_exec_finished' fault type:'panic'
+1q: ... <quitting>
+-- check the lov table content w/ table vs index scan, neither should see the
+-- new inserted row (b=2)
+0U: set enable_indexscan = on;
+SET
+0U: set enable_seqscan = off;
+SET
+0U: select insert_bm_lov_res();
+ insert_bm_lov_res 
+-------------------
+                   
+(1 row)
+0U: select * from bm_lov_res;
+ b 
+---
+ 1 
+(1 row)
+0U: set enable_indexscan = off;
+SET
+0U: set enable_seqscan = on;
+SET
+0U: select insert_bm_lov_res();
+ insert_bm_lov_res 
+-------------------
+                   
+(1 row)
+0U: select * from bm_lov_res;
+ b 
+---
+ 1 
+(1 row)
+0Uq: ... <quitting>
+1: drop table tab_fi;
+DROP
+
+-- case 2: suspend and flush WAL after freezing the tuple
+
+1: create table tab_fi(a int, b int) with (appendoptimized=true) distributed replicated;
+CREATE
+1: create index tab_fi_idx on tab_fi using bitmap(b);
+CREATE
+1: insert into tab_fi values(1, 1);
+INSERT 1
+-- switch WAL on seg0 to reduce flakiness
+1: select gp_segment_id, pg_switch_wal() is not null from gp_dist_random('gp_id') where gp_segment_id = 0;
+ gp_segment_id | ?column? 
+---------------+----------
+ 0             | t        
+(1 row)
+-- suspend right after freezing the tuple
+1: select gp_inject_fault('insert_bmlov_after_freeze', 'suspend', dbid) from gp_segment_configuration where role = 'p' and content = 0;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+2>: insert into tab_fi values(2, 2);  <waiting ...>
+1: select gp_wait_until_triggered_fault('insert_bmlov_after_freeze', 1, dbid) from gp_segment_configuration where role = 'p' and content = 0;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+-- switch WAL on seg0, so the freeze record gets flushed
+1: select gp_segment_id, pg_switch_wal() is not null from gp_dist_random('gp_id') where gp_segment_id = 0;
+ gp_segment_id | ?column? 
+---------------+----------
+ 0             | t        
+(1 row)
+-- While we are on it, check the wal record for the freeze operation.
+! seg0_datadir=$(psql -At -c "select datadir from gp_segment_configuration where content = 0 and role = 'p'" postgres) && seg0_last_wal_file=$(psql -At -c "SELECT pg_walfile_name(pg_current_wal_lsn()) from gp_dist_random('gp_id') where gp_segment_id = 0" postgres) && pg_waldump ${seg0_last_wal_file} -p ${seg0_datadir}/pg_wal | grep FREEZE_PAGE;
+rmgr: Heap2       len (rec/tot):     64/    64, tx: ##, lsn: #/########, prev #/########, desc: FREEZE_PAGE cutoff xid 0 ntuples 1, blkref #0: rel ####/######/###### blk 0
+
+-- inject a panic and resume in same way as Case 1. But this time we will be able to replay the frozen insert.
+-- skip FTS probe to prevent unexpected mirror promotion
+1: select gp_inject_fault_infinite('fts_probe', 'skip', dbid) from gp_segment_configuration where role='p' and content=-1;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+1: select gp_inject_fault('qe_exec_finished', 'panic', dbid) from gp_segment_configuration where role = 'p' and content = 0;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+1: select gp_inject_fault('insert_bmlov_after_freeze', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = 0;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+1: select gp_inject_fault('fts_probe', 'reset', dbid) from gp_segment_configuration where role='p' and content=-1;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+2<:  <... completed>
+ERROR:  fault triggered, fault name:'qe_exec_finished' fault type:'panic'
+1q: ... <quitting>
+-- check the lov table content w/ table vs index scan, both should see the
+-- new inserted row (b=2)
+0U: set enable_indexscan = on;
+SET
+0U: set enable_seqscan = off;
+SET
+0U: select insert_bm_lov_res();
+ insert_bm_lov_res 
+-------------------
+                   
+(1 row)
+0U: select * from bm_lov_res;
+ b 
+---
+ 1 
+ 2 
+(2 rows)
+0U: set enable_indexscan = off;
+SET
+0U: set enable_seqscan = on;
+SET
+0U: select insert_bm_lov_res();
+ insert_bm_lov_res 
+-------------------
+                   
+(1 row)
+0U: select * from bm_lov_res;
+ b 
+---
+ 1 
+ 2 
+(2 rows)
 
 -- validate that we've actually tested desired scan method
 -- for some reason this disrupts the output of subsequent queries so

--- a/src/test/isolation2/expected/frozen_insert_crash.out
+++ b/src/test/isolation2/expected/frozen_insert_crash.out
@@ -142,6 +142,7 @@ CREATE
 -- has changed, and if we should initialize any new field in heap_freeze_tuple_no_cutoff().
 ! seg0_datadir=$(psql -At -c "select datadir from gp_segment_configuration where content = 0 and role = 'p'" postgres) && seg0_last_wal_file=$(psql -At -c "SELECT pg_walfile_name(pg_current_wal_lsn()) from gp_dist_random('gp_id') where gp_segment_id = 0" postgres) && pg_waldump ${seg0_last_wal_file} -p ${seg0_datadir}/pg_wal | grep FREEZE_PAGE;
 rmgr: Heap2       len (rec/tot):     64/    64, tx: ##, lsn: #/########, prev #/########, desc: FREEZE_PAGE cutoff xid 0 ntuples 1, blkref #0: rel ####/######/###### blk 0
+rmgr: Heap2       len (rec/tot):     64/    64, tx: ##, lsn: #/########, prev #/########, desc: FREEZE_PAGE cutoff xid 0 ntuples 1, blkref #0: rel ####/######/###### blk 0
 
 
 -- inject a panic and resume in same way as Case 1. But this time we will be able to replay the frozen insert.
@@ -399,6 +400,50 @@ SET
 ---
  1 
  2 
+(2 rows)
+
+1: drop extension pageinspect;
+DROP
+
+-- Test for aoseg: suspend the insert into aoseg table before we mark the row frozen.
+-- Another session should still be able to choose a different segno.
+1: create table tab_aoseg(a int) using ao_row;
+CREATE
+1: select gp_inject_fault('insert_aoseg_before_freeze', 'suspend', dbid) from gp_segment_configuration where role = 'p' and content = 0;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+1: begin;
+BEGIN
+1>: insert into tab_aoseg select * from generate_series(1,10);  <waiting ...>
+-- wait until the aoseg record is inserted but not yet frozen
+2: select gp_wait_until_triggered_fault('insert_aoseg_before_freeze', 1, dbid) from gp_segment_configuration where role = 'p' and content = 0;
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+2: begin;
+BEGIN
+2>: insert into tab_aoseg select * from generate_series(1,10);  <waiting ...>
+3: select gp_inject_fault('insert_aoseg_before_freeze', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = 0;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+1<:  <... completed>
+INSERT 10
+2<:  <... completed>
+INSERT 10
+1: end;
+END
+2: end;
+END
+3: select segment_id, segno, eof from gp_toolkit.__gp_aoseg('tab_aoseg') where segment_id = 0;
+ segment_id | segno | eof 
+------------+-------+-----
+ 0          | 1     | 88  
+ 0          | 2     | 88  
 (2 rows)
 
 -- validate that we've actually tested desired scan method


### PR DESCRIPTION
Similar to #15127, now apply the same approach for all the "frozen insert" logic in GPDB, for two purposes:
1. Solve the remaining inconsistency hazard. For example, the bitmap LOV could still see the same problem (a repro shown below).
2. Align core function interface with upstream, including things like `heap_prepare_insert` and `toast_save_datum`. With that we also removed GPDB-specific function such as `frozen_heap_insert` and `XLogInsert_OverrideXid`.

Please review each commit individually.

A repro for the inconsistency in bitmap LOV table:
```sql
-- on session 1, do
create extension pageinspect;
drop table if exists tab_fi;
create table tab_fi(a int, b int) with (appendoptimized=true) distributed replicated;
create index tab_fi_idx on tab_fi using bitmap(b);
insert into tab_fi values(1, 1); 
select gp_segment_id, pg_switch_wal() is not null from gp_dist_random('gp_id') where gp_segment_id = 0;

-- launch GDB and attach to one of the QE process, say seg0 here.
-- breakpoint on frozen_heap_insert(), continue

-- on session 1, do
insert into tab_fi values(2, 2); 

-- on GDB session, step through frozen_heap_insert()

-- on another session 2, do
select gp_segment_id, pg_switch_wal() is not null from gp_dist_random('gp_id') where gp_segment_id = 0;
select gp_inject_fault('qe_exec_finished', 'panic', '', '', '', 1, -1, 0, dbid) from gp_segment_configuration where role = 'p' and content = 0;

-- exit the GDB session

-- connect to seg0 in utility mode, do:
set enable_indexscan = on;
set enable_seqscan = off;
select c.relname from bm_metap('tab_fi_idx') b join pg_class c on b.auxrelid = c.oid \gset
select b from pg_bitmapindex.:relname;
set enable_indexscan = off;
set enable_seqscan = on;
select b from pg_bitmapindex.:relname;

-- the two SELECTs above would show different results: the second one has one more row
```

dev pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/frozen-insert

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
