### PR TITLE
[6X] fix tids are not in order when building bitmap index

### DIFF
--- a/src/backend/access/bitmap/bitmapinsert.c
+++ b/src/backend/access/bitmap/bitmapinsert.c
@@ -1787,8 +1787,24 @@ buf_add_tid(Relation rel, BMTidBuildBuf *tids, uint64 tidnum,
 		buf = lov_buf->bufs[off - 1];
 
 		Buffer lovbuf = _bitmap_getbuf(rel, lov_block, BM_WRITE);
-		buf_add_tid_with_fill(rel, buf, lovbuf, off,
-							  tidnum, state->use_wal);
+
+		if (tidnum < buf->last_tid)
+		{
+			/*
+			 * Usually, tidnum is greater than lovItem->bm_last_setbit.
+			 * However, if we build bitmap index on a heap table, there could
+			 * have HOT-chain, and it'll return the root tuple's tid, which could
+			 * lead to the TIDs we scanned are not in order, so we need to scan
+			 * through the bitmap vector, and update the bit in tidnum directly.
+			 */
+			_bitmap_write_new_bitmapwords(rel, lovbuf, off, buf, state->use_wal);
+			_bitmap_free_tidbuf(buf);
+
+			updatesetbit(rel, lovbuf, off, tidnum, state->use_wal);
+		}
+		else
+			buf_add_tid_with_fill(rel, buf, lovbuf, off, tidnum, state->use_wal);
+
 		_bitmap_relbuf(lovbuf);
 	}
 	else

--- a/src/test/regress/expected/bitmap_index.out
+++ b/src/test/regress/expected/bitmap_index.out
@@ -924,3 +924,30 @@ select * from foo where a = 1 or a = any(null::int[]);
 drop table foo;
 SET enable_seqscan = ON;
 SET enable_bitmapscan = ON;
+-- test create bitmap index and there have HOT chains.
+drop table if exists bm_test;
+NOTICE:  table "bm_test" does not exist, skipping
+create table bm_test(a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- insert some data into a one segment
+insert into bm_test values (1, 1); 
+insert into bm_test values (1, 2); 
+insert into bm_test values (1, 3); 
+insert into bm_test values (12, 1); 
+-- update the first tuple using HOT, since this page
+-- just have 4 tuples, there have full free space to
+-- use HOT update.
+update bm_test set b = 1 where a = 1 and b = 1;
+-- After the update, the tids that the value of b is equal to 1
+-- we scanned will not be in order, due to HOT.
+create index idx_bm_test on bm_test using bitmap(b);
+select * from bm_test where b = 1;
+ a  | b 
+----+---
+ 12 | 1
+  1 | 1
+(2 rows)
+
+-- clean up
+drop table bm_test;

--- a/src/test/regress/expected/bitmap_index.out
+++ b/src/test/regress/expected/bitmap_index.out
@@ -931,10 +931,10 @@ create table bm_test(a int, b int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 -- insert some data into a one segment
-insert into bm_test values (1, 1); 
-insert into bm_test values (1, 2); 
-insert into bm_test values (1, 3); 
-insert into bm_test values (12, 1); 
+insert into bm_test values (1, 1);
+insert into bm_test values (1, 2);
+insert into bm_test values (1, 3);
+insert into bm_test values (12, 1);
 -- update the first tuple using HOT, since this page
 -- just have 4 tuples, there have full free space to
 -- use HOT update.

--- a/src/test/regress/expected/bitmap_index_optimizer.out
+++ b/src/test/regress/expected/bitmap_index_optimizer.out
@@ -929,3 +929,30 @@ select * from foo where a = 1 or a = any(null::int[]);
 drop table foo;
 SET enable_seqscan = ON;
 SET enable_bitmapscan = ON;
+-- test create bitmap index and there have HOT chains.
+drop table if exists bm_test;
+NOTICE:  table "bm_test" does not exist, skipping
+create table bm_test(a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- insert some data into a one segment
+insert into bm_test values (1, 1);
+insert into bm_test values (1, 2);
+insert into bm_test values (1, 3);
+insert into bm_test values (12, 1);
+-- update the first tuple using HOT, since this page
+-- just have 4 tuples, there have full free space to
+-- use HOT update.
+update bm_test set b = 1 where a = 1 and b = 1;
+-- After the update, the tids that the value of b is equal to 1
+-- we scanned will not be in order, due to HOT.
+create index idx_bm_test on bm_test using bitmap(b);
+select * from bm_test where b = 1;
+ a  | b 
+----+---
+ 12 | 1
+  1 | 1
+(2 rows)
+
+-- clean up
+drop table bm_test;

--- a/src/test/regress/sql/bitmap_index.sql
+++ b/src/test/regress/sql/bitmap_index.sql
@@ -391,3 +391,25 @@ drop table foo;
 SET enable_seqscan = ON;
 SET enable_bitmapscan = ON;
 
+-- test create bitmap index and there have HOT chains.
+drop table if exists bm_test;
+create table bm_test(a int, b int);
+
+-- insert some data into a one segment
+insert into bm_test values (1, 1);
+insert into bm_test values (1, 2);
+insert into bm_test values (1, 3);
+insert into bm_test values (12, 1);
+
+-- update the first tuple using HOT, since this page
+-- just have 4 tuples, there have full free space to
+-- use HOT update.
+update bm_test set b = 1 where a = 1 and b = 1;
+
+-- After the update, the tids that the value of b is equal to 1
+-- we scanned will not be in order, due to HOT.
+create index idx_bm_test on bm_test using bitmap(b);
+select * from bm_test where b = 1;
+
+-- clean up
+drop table bm_test;


### PR DESCRIPTION
This is the backport of #15271.

------

If we build bitmap index on a heap table, there could have HOT-chain, 
and it'll return the root tuple's tid, which could lead to the TIDs we 
scanned are not in order.
