### PR TITLE
[6X] Add views/functions to check missing and orphaned data files

### DIFF
--- a/gpcontrib/Makefile
+++ b/gpcontrib/Makefile
@@ -24,7 +24,8 @@ ifeq "$(enable_debug_extensions)" "yes"
                gp_array_agg \
                gp_percentile_agg \
                gp_error_handling \
-               gp_subtransaction_overflow
+               gp_subtransaction_overflow \
+               gp_check_functions
 else
 	recurse_targets = gp_sparse_vector \
                gp_distribution_policy \
@@ -35,7 +36,8 @@ else
                gp_array_agg \
                gp_percentile_agg \
                gp_error_handling \
-               gp_subtransaction_overflow
+               gp_subtransaction_overflow \
+               gp_check_functions
 endif
 
 ifeq "$(with_zstd)" "yes"
@@ -99,3 +101,4 @@ installcheck:
 	$(MAKE) -C gp_sparse_vector installcheck
 	$(MAKE) -C gp_percentile_agg installcheck
 	$(MAKE) -C gp_subtransaction_overflow installcheck
+	$(MAKE) -C gp_check_functions installcheck

--- a/gpcontrib/gp_check_functions/Makefile
+++ b/gpcontrib/gp_check_functions/Makefile
@@ -1,0 +1,15 @@
+EXTENSION = gp_check_functions
+DATA = gp_check_functions--1.0.0.sql
+MODULES = gp_check_functions
+# REGRESS testing is covered by the main suite test 'gp_check_files' as we need the custom tablespace directory support
+
+ifdef USE_PGXS
+PG_CONFIG = pg_config
+PGXS := $(shell $(PG_CONFIG) --pgxs)
+include $(PGXS)
+else
+subdir = gpcontrib/gp_check_functions
+top_builddir = ../..
+include $(top_builddir)/src/Makefile.global
+include $(top_srcdir)/contrib/contrib-global.mk
+endif

--- a/gpcontrib/gp_check_functions/gp_check_functions--1.0.0.sql
+++ b/gpcontrib/gp_check_functions/gp_check_functions--1.0.0.sql
@@ -1,0 +1,366 @@
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "CREATE EXTENSION gp_check_functions" to load this file. \quit
+
+CREATE OR REPLACE FUNCTION get_tablespace_version_directory_name()
+RETURNS text
+AS '$libdir/gp_check_functions'
+LANGUAGE C;
+
+--------------------------------------------------------------------------------
+-- @function:
+--        __get_ao_segno_list
+--
+-- @in:
+--
+-- @out:
+--        oid - relation oid
+--        int - segment number
+--
+-- @doc:
+--        UDF to retrieve AO segment file numbers for each ao_row table
+--
+--------------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION __get_ao_segno_list()
+RETURNS TABLE (relid oid, segno int) AS
+$$
+DECLARE
+  table_name text;
+  rec record;
+  cur refcursor;
+  row record;
+BEGIN
+  -- iterate over the aoseg relations
+  FOR rec IN SELECT sc.relname segrel, tc.oid tableoid 
+             FROM pg_appendonly a 
+             JOIN pg_class tc ON a.relid = tc.oid 
+             JOIN pg_class sc ON a.segrelid = sc.oid 
+             WHERE tc.relstorage = 'a' 
+  LOOP
+    table_name := rec.segrel;
+    -- Fetch and return each row from the aoseg table
+    BEGIN
+      OPEN cur FOR EXECUTE format('SELECT segno FROM pg_aoseg.%I', table_name);
+      SELECT rec.tableoid INTO relid;
+      LOOP
+        FETCH cur INTO row;
+        EXIT WHEN NOT FOUND;
+        segno := row.segno;
+        IF segno <> 0 THEN -- there's no '.0' file, it means the file w/o extension
+          RETURN NEXT;
+        END IF;
+      END LOOP;
+      CLOSE cur;
+    EXCEPTION
+      -- If failed to open the aoseg table (e.g. the table itself is missing), continue
+      WHEN OTHERS THEN
+      RAISE WARNING 'Failed to read %: %', table_name, SQLERRM;
+    END;
+  END LOOP;
+  RETURN;
+END;
+$$
+LANGUAGE plpgsql;
+
+GRANT EXECUTE ON FUNCTION __get_ao_segno_list() TO public;
+
+--------------------------------------------------------------------------------
+-- @function:
+--        __get_aoco_segno_list
+--
+-- @in:
+--
+-- @out:
+--        oid - relation oid
+--        int - segment number
+--
+-- @doc:
+--        UDF to retrieve AOCO segment file numbers for each ao_column table
+--
+--------------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION __get_aoco_segno_list()
+RETURNS TABLE (relid oid, segno int) AS
+$$
+DECLARE
+  table_name text;
+  rec record;
+  cur refcursor;
+  row record;
+BEGIN
+  -- iterate over the aocoseg relations
+  FOR rec IN SELECT sc.relname segrel, tc.oid tableoid
+             FROM pg_appendonly a
+             JOIN pg_class tc ON a.relid = tc.oid
+             JOIN pg_class sc ON a.segrelid = sc.oid
+             WHERE tc.relstorage = 'c'
+  LOOP
+    table_name := rec.segrel;
+    -- Fetch and return each extended segno corresponding to attnum and segno in the aocoseg table
+    BEGIN
+      OPEN cur FOR EXECUTE format('SELECT ((a.attnum - 1) * 128 + s.segno) as segno '
+                                  'FROM (SELECT * FROM pg_attribute_encoding '
+                                  'WHERE attrelid = %s) a CROSS JOIN pg_aoseg.%I s', 
+                                   rec.tableoid, table_name);
+      SELECT rec.tableoid INTO relid;
+      LOOP
+        FETCH cur INTO row;
+        EXIT WHEN NOT FOUND;
+        segno := row.segno;
+        IF segno <> 0 THEN -- there's no '.0' file, it means the file w/o extension
+          RETURN NEXT;
+        END IF;
+      END LOOP;
+      CLOSE cur;
+    EXCEPTION
+      -- If failed to open the aocoseg table (e.g. the table itself is missing), continue
+      WHEN OTHERS THEN
+      RAISE WARNING 'Failed to read %: %', table_name, SQLERRM;
+    END;
+  END LOOP;
+  RETURN;
+END;
+$$
+LANGUAGE plpgsql;
+
+GRANT EXECUTE ON FUNCTION __get_aoco_segno_list() TO public;
+
+--------------------------------------------------------------------------------
+-- @view:
+--        __get_exist_files
+--
+-- @doc:
+--        Retrieve a list of all existing data files in the default
+--        and user tablespaces.
+--
+--------------------------------------------------------------------------------
+-- return the list of existing files in the database
+CREATE OR REPLACE VIEW __get_exist_files AS
+-- 1. List of files in the default tablespace
+SELECT 0 AS tablespace, filename 
+FROM pg_ls_dir('base/' || (
+  SELECT d.oid::text
+  FROM pg_database d
+  WHERE d.datname = current_database()
+))
+AS filename
+UNION
+-- 2. List of files in the global tablespace
+SELECT 1664 AS tablespace, filename
+FROM pg_ls_dir('global/') 
+AS filename
+UNION
+-- 3. List of files in user-defined tablespaces
+SELECT ts.oid AS tablespace,
+       pg_ls_dir('pg_tblspc/' || ts.oid::text || '/' || get_tablespace_version_directory_name() || '/' || 
+         (SELECT d.oid::text FROM pg_database d WHERE d.datname = current_database()), true/*missing_ok*/,false/*include_dot*/) AS filename
+FROM pg_tablespace ts
+WHERE ts.oid > 1664; 
+
+GRANT SELECT ON __get_exist_files TO public;
+
+--------------------------------------------------------------------------------
+-- @view:
+--        __get_expect_files
+--
+-- @doc:
+--        Retrieve a list of expected data files in the database,
+--        using the knowledge from catalogs. This does not include
+--        any extended data files, nor does it include external,
+--        foreign or virtual tables.
+--
+--------------------------------------------------------------------------------
+CREATE OR REPLACE VIEW __get_expect_files AS
+SELECT s.reltablespace AS tablespace, s.relname, s.relstorage,
+       (CASE WHEN s.relfilenode != 0 THEN s.relfilenode ELSE pg_relation_filenode(s.oid) END)::text AS filename
+FROM pg_class s
+WHERE s.relstorage NOT IN ('x', 'v', 'f');
+
+GRANT SELECT ON __get_expect_files TO public;
+
+--------------------------------------------------------------------------------
+-- @view:
+--        __get_expect_files_ext
+--
+-- @doc:
+--        Retrieve a list of expected data files in the database,
+--        using the knowledge from catalogs. This includes all
+--        the extended data files for AO/CO tables, nor does it
+--        include external, foreign or virtual tables.
+--
+--------------------------------------------------------------------------------
+CREATE OR REPLACE VIEW __get_expect_files_ext AS
+SELECT s.reltablespace AS tablespace, s.relname, s.relstorage,
+       (CASE WHEN s.relfilenode != 0 THEN s.relfilenode ELSE pg_relation_filenode(s.oid) END)::text AS filename
+FROM pg_class s 
+WHERE s.relstorage NOT IN ('x', 'v', 'f')
+UNION
+-- AO extended files
+SELECT c.reltablespace AS tablespace, c.relname, c.relstorage,
+       format(c.relfilenode::text || '.' || s.segno::text) AS filename
+FROM __get_ao_segno_list() s
+JOIN pg_class c ON s.relid = c.oid
+WHERE c.relstorage NOT IN ('x', 'v', 'f')
+UNION
+-- CO extended files
+SELECT c.reltablespace AS tablespace, c.relname, c.relstorage,
+       format(c.relfilenode::text || '.' || s.segno::text) AS filename
+FROM __get_aoco_segno_list() s
+JOIN pg_class c ON s.relid = c.oid
+WHERE c.relstorage NOT IN ('x', 'v', 'f');
+
+GRANT SELECT ON __get_expect_files_ext TO public;
+
+--------------------------------------------------------------------------------
+-- @view:
+--        __check_orphaned_files
+--
+-- @doc:
+--        Check orphaned data files on default and user tablespaces,
+--        not including extended files.
+--
+--------------------------------------------------------------------------------
+CREATE OR REPLACE VIEW __check_orphaned_files AS
+SELECT f1.tablespace, f1.filename
+from __get_exist_files f1
+LEFT JOIN __get_expect_files f2
+ON f1.tablespace = f2.tablespace AND f1.filename = f2.filename
+WHERE f2.tablespace IS NULL
+  AND f1.filename SIMILAR TO '[0-9]+';
+
+GRANT SELECT ON __check_orphaned_files TO public;
+
+--------------------------------------------------------------------------------
+-- @view:
+--        __check_orphaned_files_ext
+--
+-- @doc:
+--        Check orphaned data files on default and user tablespaces,
+--        including extended files.
+--
+--------------------------------------------------------------------------------
+CREATE OR REPLACE VIEW __check_orphaned_files_ext AS
+SELECT f1.tablespace, f1.filename
+FROM __get_exist_files f1
+LEFT JOIN __get_expect_files_ext f2
+ON f1.tablespace = f2.tablespace AND f1.filename = f2.filename
+WHERE f2.tablespace IS NULL
+  AND f1.filename SIMILAR TO '[0-9]+(\.[0-9]+)?'
+  AND NOT EXISTS (
+    -- XXX: not supporting heap for now, do not count them
+    SELECT 1 FROM pg_class c 
+    WHERE c.relfilenode::text = split_part(f1.filename, '.', 1) 
+        AND c.relstorage = 'h'
+  );
+
+GRANT SELECT ON __check_orphaned_files_ext TO public;
+
+--------------------------------------------------------------------------------
+-- @view:
+--        __check_missing_files
+--
+-- @doc:
+--        Check missing data files on default and user tablespaces,
+--        not including extended files.
+--
+--------------------------------------------------------------------------------
+CREATE OR REPLACE VIEW __check_missing_files AS
+SELECT f1.tablespace, f1.relname, f1.filename
+from __get_expect_files f1
+LEFT JOIN __get_exist_files f2
+ON f1.tablespace = f2.tablespace AND f1.filename = f2.filename
+WHERE f2.tablespace IS NULL
+  AND f1.filename SIMILAR TO '[0-9]+';
+
+GRANT SELECT ON __check_missing_files TO public;
+
+--------------------------------------------------------------------------------
+-- @view:
+--        __check_missing_files_ext
+--
+-- @doc:
+--        Check missing data files on default and user tablespaces,
+--        including extended files.
+--
+--------------------------------------------------------------------------------
+CREATE OR REPLACE VIEW __check_missing_files_ext AS
+SELECT f1.tablespace, f1.relname, f1.filename
+FROM __get_expect_files_ext f1
+LEFT JOIN __get_exist_files f2
+ON f1.tablespace = f2.tablespace AND f1.filename = f2.filename
+WHERE f2.tablespace IS NULL
+  AND f1.filename SIMILAR TO '[0-9]+(\.[0-9]+)?';
+
+GRANT SELECT ON __check_missing_files_ext TO public;
+
+--------------------------------------------------------------------------------
+-- @view:
+--        gp_check_orphaned_files
+--
+-- @doc:
+--        User-facing view of __check_orphaned_files. 
+--        Gather results from coordinator and all segments.
+--
+--------------------------------------------------------------------------------
+CREATE OR REPLACE VIEW gp_check_orphaned_files AS 
+SELECT pg_catalog.gp_execution_segment() AS gp_segment_id, *
+FROM gp_dist_random('__check_orphaned_files')
+UNION ALL 
+SELECT -1 AS gp_segment_id, *
+FROM __check_orphaned_files;
+
+GRANT SELECT ON gp_check_orphaned_files TO public;
+
+--------------------------------------------------------------------------------
+-- @view:
+--        gp_check_orphaned_files_ext
+--
+-- @doc:
+--        User-facing view of __check_orphaned_files_ext.
+--        Gather results from coordinator and all segments.
+--
+--------------------------------------------------------------------------------
+CREATE OR REPLACE VIEW gp_check_orphaned_files_ext AS 
+SELECT pg_catalog.gp_execution_segment() AS gp_segment_id, *
+FROM gp_dist_random('__check_orphaned_files_ext')
+UNION ALL 
+SELECT -1 AS gp_segment_id, *
+FROM __check_orphaned_files; -- not checking ext on coordinator
+
+GRANT SELECT ON gp_check_orphaned_files_ext TO public;
+
+--------------------------------------------------------------------------------
+-- @view:
+--        gp_check_missing_files
+--
+-- @doc:
+--        User-facing view of __check_missing_files. 
+--        Gather results from coordinator and all segments.
+--
+--------------------------------------------------------------------------------
+CREATE OR REPLACE VIEW gp_check_missing_files AS 
+SELECT pg_catalog.gp_execution_segment() AS gp_segment_id, *
+FROM gp_dist_random('__check_missing_files')
+UNION ALL 
+SELECT -1 AS gp_segment_id, *
+FROM __check_missing_files;
+
+GRANT SELECT ON gp_check_missing_files TO public;
+
+--------------------------------------------------------------------------------
+-- @view:
+--        gp_check_missing_files_ext
+--
+-- @doc:
+--        User-facing view of __check_missing_files_ext.
+--        Gather results from coordinator and all segments.
+--
+--------------------------------------------------------------------------------
+CREATE OR REPLACE VIEW gp_check_missing_files_ext AS 
+SELECT pg_catalog.gp_execution_segment() AS gp_segment_id, *
+FROM gp_dist_random('__check_missing_files_ext')
+UNION ALL 
+SELECT -1 AS gp_segment_id, *
+FROM __check_missing_files; -- not checking ext on coordinator
+
+GRANT SELECT ON gp_check_missing_files_ext TO public;

--- a/gpcontrib/gp_check_functions/gp_check_functions.c
+++ b/gpcontrib/gp_check_functions/gp_check_functions.c
@@ -1,0 +1,33 @@
+/*-------------------------------------------------------------------------
+ *
+ * gp_check_functions.c
+ *	  GPDB helper functions for checking various system fact/status.
+ *
+ *
+ * Copyright (c) 2022-Present VMware Software, Inc.
+ *
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#include "postgres.h"
+
+#include "fmgr.h"
+#include "funcapi.h"
+#include "catalog/catalog.h"
+#include "utils/builtins.h"
+
+Datum get_tablespace_version_directory_name(PG_FUNCTION_ARGS);
+
+PG_MODULE_MAGIC;
+PG_FUNCTION_INFO_V1(get_tablespace_version_directory_name);
+
+/*
+ * get the GPDB-specific directory name for user tablespace
+ */
+Datum
+get_tablespace_version_directory_name(PG_FUNCTION_ARGS)
+{
+	PG_RETURN_TEXT_P(CStringGetTextDatum(GP_TABLESPACE_VERSION_DIRECTORY));
+}
+

--- a/gpcontrib/gp_check_functions/gp_check_functions.control
+++ b/gpcontrib/gp_check_functions/gp_check_functions.control
@@ -1,0 +1,5 @@
+# gp_check_functions extension
+
+comment = 'various GPDB helper views/functions'
+default_version = '1.0.0'
+relocatable = true

--- a/src/test/isolation2/expected/misc.out
+++ b/src/test/isolation2/expected/misc.out
@@ -51,3 +51,22 @@ CREATE
 --
 0U: create table utilitymode_pt_lt_tab (col1 int, col2 decimal) distributed by (col1) partition by list(col2) (partition part1 values(1));
 ERROR:  cannot create partition table in utility mode
+
+--
+-- gp_check_orphaned_files should not be running with concurrent transaction (even idle)
+--
+-- use a different database to do the test, otherwise we might be reporting tons
+-- of orphaned files produced by the many intential PANICs/restarts in the isolation2 tests.
+create database check_orphaned_db;
+CREATE
+1:@db_name check_orphaned_db: create extension gp_check_functions;
+CREATE
+1:@db_name check_orphaned_db: begin;
+BEGIN
+2:@db_name check_orphaned_db: select * from gp_check_orphaned_files;
+ERROR:  There is a client session running on one or more segment. Aborting...
+1q: ... <quitting>
+2q: ... <quitting>
+
+drop database check_orphaned_db;
+DROP

--- a/src/test/isolation2/sql/misc.sql
+++ b/src/test/isolation2/sql/misc.sql
@@ -38,3 +38,17 @@
 --
 0U: create table utilitymode_pt_lt_tab (col1 int, col2 decimal)
 	distributed by (col1) partition by list(col2) (partition part1 values(1));
+
+--
+-- gp_check_orphaned_files should not be running with concurrent transaction (even idle)
+--
+-- use a different database to do the test, otherwise we might be reporting tons 
+-- of orphaned files produced by the many intential PANICs/restarts in the isolation2 tests.
+create database check_orphaned_db;
+1:@db_name check_orphaned_db: create extension gp_check_functions;
+1:@db_name check_orphaned_db: begin;
+2:@db_name check_orphaned_db: select * from gp_check_orphaned_files;
+1q:
+2q:
+
+drop database check_orphaned_db;

--- a/src/test/regress/expected/.gitignore
+++ b/src/test/regress/expected/.gitignore
@@ -14,6 +14,7 @@ dispatch.out
 external_table.out
 filespace.out
 gpcopy.out
+gp_check_files.out
 gptokencheck.out
 /gp_transactions.out
 /gp_tablespace_with_faults.out

--- a/src/test/regress/expected/truncate_gp.out
+++ b/src/test/regress/expected/truncate_gp.out
@@ -109,9 +109,3 @@ select stat_table_segfile_size('regression', 'truncate_with_create_heap');
  (4,segfile:16384/19220,0)
 (3 rows)
 
--- It is a known issue that extended datafiles won't be removed in such case (see #15342),
--- but since they have 0 size 0 it shouldn't really matter.
--- However, we do not want these file to create false alarms in the gp_check_files test
--- later, so drop them now.
-drop table truncate_with_create_ao;
-drop table truncate_with_create_aocs;

--- a/src/test/regress/expected/truncate_gp.out
+++ b/src/test/regress/expected/truncate_gp.out
@@ -109,3 +109,9 @@ select stat_table_segfile_size('regression', 'truncate_with_create_heap');
  (4,segfile:16384/19220,0)
 (3 rows)
 
+-- It is a known issue that extended datafiles won't be removed in such case (see #15342),
+-- but since they have 0 size 0 it shouldn't really matter.
+-- However, we do not want these file to create false alarms in the gp_check_files test
+-- later, so drop them now.
+drop table truncate_with_create_ao;
+drop table truncate_with_create_aocs;

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -44,6 +44,7 @@ test: shared_scan
 test: spi_processed64bit
 test: python_processed64bit
 test: gp_tablespace_with_faults
+test: gp_check_files
 # below test(s) inject faults so each of them need to be in a separate group
 test: gp_tablespace
 

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -44,7 +44,6 @@ test: shared_scan
 test: spi_processed64bit
 test: python_processed64bit
 test: gp_tablespace_with_faults
-test: gp_check_files
 # below test(s) inject faults so each of them need to be in a separate group
 test: gp_tablespace
 
@@ -302,5 +301,8 @@ test: create_extension_fail
 
 # check syslogger (since GP syslogger code is divergent from upstream)
 test: syslogger_gp
+
+# run this at the end of the schedule for more chance to catch abnormalies
+test: gp_check_files
 
 # end of tests

--- a/src/test/regress/input/alter_db_set_tablespace.source
+++ b/src/test/regress/input/alter_db_set_tablespace.source
@@ -15,10 +15,8 @@ CREATE SCHEMA adst;
 
 SET search_path TO adst,public;
 
-CREATE OR REPLACE FUNCTION get_tablespace_version_directory_name()
-    RETURNS TEXT
-AS '@abs_builddir@/regress.so', 'get_tablespace_version_directory_name'
-    LANGUAGE C;
+-- to get function get_tablespace_version_directory_name()
+CREATE EXTENSION gp_check_functions;
 
 -- start_ignore
 CREATE LANGUAGE plpythonu;

--- a/src/test/regress/input/gp_check_files.source
+++ b/src/test/regress/input/gp_check_files.source
@@ -1,0 +1,87 @@
+-- Test views/functions to check missing/orphaned data files
+
+-- start_matchsubs
+-- m/aoseg_\d+/
+-- s/aoseg_\d+/aoseg_xxx/g
+-- m/aocsseg_\d+/
+-- s/aocsseg_\d+/aocsseg_xxx/g
+-- m/aovisimap_\d+/
+-- s/aovisimap_\d+/aovisimap_xxx/g
+-- end_matchsubs
+
+checkpoint;
+
+create extension gp_check_functions;
+
+-- we'll use a specific tablespace to test
+CREATE TABLESPACE checkfile_ts LOCATION '@testtablespace@';
+set default_tablespace = checkfile_ts;
+
+-- create a table that we'll delete the files 
+CREATE TABLE checkmissing_heap(a int, b int, c int);
+insert into checkmissing_heap select i,i,i from generate_series(1,100)i;
+
+-- go to seg1's data directory for the tablespace we just created
+\cd @testtablespace@
+select dbid from gp_segment_configuration where content = 1 and role = 'p' \gset
+\cd :dbid
+select get_tablespace_version_directory_name() as version_dir \gset
+\cd :version_dir
+select oid from pg_database where datname = current_database() \gset
+\cd :oid
+
+-- Now remove the data file for the table we just created.
+-- But check to see if the working directory is what we expect (under
+-- the test tablespace). Also just delete one and only one file that
+-- is number-named.
+\! if pwd | grep -q "^@testtablespace@/.*$"; then find . -maxdepth 1 -type f -regex '.*\/[0-9]+' -exec rm {} \; -quit; fi
+
+-- now create AO/CO tables and delete only their extended files
+CREATE TABLE checkmissing_ao(a int, b int, c int) WITH (appendonly=true, orientation=row);
+CREATE TABLE checkmissing_co(a int, b int, c int) WITH (appendonly=true, orientation=column);
+insert into checkmissing_ao select i,i,i from generate_series(1,100)i;
+insert into checkmissing_co select i,i,i from generate_series(1,100)i;
+
+-- Now remove the extended data file '.1' for the AO/CO tables we just created.
+-- Still, check to see if the working directory is what we expect, and only
+-- delete exact two '.1' files.
+\! if pwd | grep -q "^@testtablespace@/.*$"; then find . -maxdepth 1 -type f -regex '.*\/[0-9]+\.1' -exec rm {} \; -quit; fi
+\! if pwd | grep -q "^@testtablespace@/.*$"; then find . -maxdepth 1 -type f -regex '.*\/[0-9]+\.1' -exec rm {} \; -quit; fi
+
+-- create some orphaned files
+\! touch 987654
+\! touch 987654.3
+
+-- create some normal tables
+CREATE TABLE checknormal_heap(a int, b int, c int);
+CREATE TABLE checknormal_ao(a int, b int, c int) WITH (appendonly=true, orientation=row);
+CREATE TABLE checknormal_co(a int, b int, c int) WITH (appendonly=true, orientation=column);
+insert into checknormal_heap select i,i,i from generate_series(1,100)i;
+insert into checknormal_ao select i,i,i from generate_series(1,100)i;
+insert into checknormal_co select i,i,i from generate_series(1,100)i;
+
+-- check non-extended files
+select gp_segment_id, filename from gp_check_orphaned_files;
+select gp_segment_id, regexp_replace(filename, '\d+', 'x'), relname from gp_check_missing_files;
+
+SET client_min_messages = ERROR;
+
+-- check extended files
+select gp_segment_id, filename from gp_check_orphaned_files_ext;
+select gp_segment_id, regexp_replace(filename, '\d+', 'x'), relname from gp_check_missing_files_ext;
+
+RESET client_min_messages;
+
+-- cleanup
+drop table checkmissing_heap;
+drop table checkmissing_ao;
+drop table checkmissing_co;
+drop table checknormal_heap;
+drop table checknormal_ao;
+drop table checknormal_co;
+
+\! rm -rf @testtablespace@/*;
+
+DROP TABLESPACE checkfile_ts;
+DROP EXTENSION gp_check_functions;
+

--- a/src/test/regress/input/gp_check_files.source
+++ b/src/test/regress/input/gp_check_files.source
@@ -9,10 +9,32 @@
 -- s/aovisimap_\d+/aovisimap_xxx/g
 -- end_matchsubs
 
--- start from a clean state
-checkpoint;
-
 create extension gp_check_functions;
+
+-- helper function to repeatedly run gp_check_orphaned_files for up to 10 minutes,
+-- in case any flakiness happens (like background worker makes LOCK pg_class unsuccessful etc.)
+CREATE OR REPLACE FUNCTION run_orphaned_files_view()
+RETURNS TABLE(gp_segment_id INT, filename TEXT) AS $$
+DECLARE
+    retry_counter INT := 0;
+BEGIN
+    WHILE retry_counter < 120 LOOP
+        BEGIN
+            RETURN QUERY SELECT q.gp_segment_id, q.filename FROM gp_check_orphaned_files q;
+            RETURN; -- If successful
+        EXCEPTION
+            WHEN OTHERS THEN
+                RAISE LOG 'attempt failed % with error: %', retry_counter + 1, SQLERRM;
+                -- When an exception occurs, wait for 5 seconds and then retry
+                PERFORM pg_sleep(5);
+                retry_counter := retry_counter + 1;
+        END;
+    END LOOP;
+
+    -- all retries failed
+    RAISE EXCEPTION 'failed to retrieve orphaned files after 10 minutes of retries.';
+END;
+$$ LANGUAGE plpgsql;
 
 -- we'll use a specific tablespace to test
 CREATE TABLESPACE checkfile_ts LOCATION '@testtablespace@';
@@ -30,6 +52,19 @@ select get_tablespace_version_directory_name() as version_dir \gset
 \cd :version_dir
 select oid from pg_database where datname = current_database() \gset
 \cd :oid
+
+-- create some orphaned files
+\! touch 987654
+\! touch 987654.3
+
+-- check orphaned files, note that this forces a checkpoint internally.
+set client_min_messages = ERROR;
+select gp_segment_id, filename from run_orphaned_files_view();
+reset client_min_messages;
+
+-- remove the orphaned files so not affect subsequent tests
+\! rm 987654
+\! rm 987654.3
 
 -- Now remove the data file for the table we just created.
 -- But check to see if the working directory is what we expect (under
@@ -49,10 +84,6 @@ insert into checkmissing_co select i,i,i from generate_series(1,100)i;
 \! if pwd | grep -q "^@testtablespace@/.*$"; then find . -maxdepth 1 -type f -regex '.*\/[0-9]+\.1' -exec rm {} \; -quit; fi
 \! if pwd | grep -q "^@testtablespace@/.*$"; then find . -maxdepth 1 -type f -regex '.*\/[0-9]+\.1' -exec rm {} \; -quit; fi
 
--- create some orphaned files
-\! touch 987654
-\! touch 987654.3
-
 -- create some normal tables
 CREATE TABLE checknormal_heap(a int, b int, c int);
 CREATE TABLE checknormal_ao(a int, b int, c int) WITH (appendonly=true, orientation=row);
@@ -67,7 +98,6 @@ select gp_segment_id, regexp_replace(filename, '\d+', 'x'), relname from gp_chec
 SET client_min_messages = ERROR;
 
 -- check extended files
-select gp_segment_id, filename from gp_check_orphaned_files;
 select gp_segment_id, regexp_replace(filename, '\d+', 'x'), relname from gp_check_missing_files_ext;
 
 RESET client_min_messages;

--- a/src/test/regress/input/gp_check_files.source
+++ b/src/test/regress/input/gp_check_files.source
@@ -9,6 +9,7 @@
 -- s/aovisimap_\d+/aovisimap_xxx/g
 -- end_matchsubs
 
+-- start from a clean state
 checkpoint;
 
 create extension gp_check_functions;
@@ -61,13 +62,12 @@ insert into checknormal_ao select i,i,i from generate_series(1,100)i;
 insert into checknormal_co select i,i,i from generate_series(1,100)i;
 
 -- check non-extended files
-select gp_segment_id, filename from gp_check_orphaned_files;
 select gp_segment_id, regexp_replace(filename, '\d+', 'x'), relname from gp_check_missing_files;
 
 SET client_min_messages = ERROR;
 
 -- check extended files
-select gp_segment_id, filename from gp_check_orphaned_files_ext;
+select gp_segment_id, filename from gp_check_orphaned_files;
 select gp_segment_id, regexp_replace(filename, '\d+', 'x'), relname from gp_check_missing_files_ext;
 
 RESET client_min_messages;

--- a/src/test/regress/input/gp_tablespace.source
+++ b/src/test/regress/input/gp_tablespace.source
@@ -35,10 +35,8 @@ BEGIN
 END;
 $$ language plpgsql;
 
-CREATE OR REPLACE FUNCTION get_tablespace_version_directory_name()
-	RETURNS TEXT
-	AS '@abs_builddir@/regress.so', 'get_tablespace_version_directory_name'
-    LANGUAGE C;
+-- to get function get_tablespace_version_directory_name()
+CREATE EXTENSION gp_check_functions;
 
 
 -- create tablespaces we can use
@@ -211,4 +209,5 @@ CREATE TABLE t_dir_empty(a int);
 \! rm -rf @testtablespace@/*;
 DROP TABLE IF EXISTS t_dir_empty;
 DROP TABLESPACE testspace_dir_empty;
+DROP EXTENSION gp_check_functions;
 

--- a/src/test/regress/output/alter_db_set_tablespace.source
+++ b/src/test/regress/output/alter_db_set_tablespace.source
@@ -11,10 +11,8 @@
 -- end_ignore
 CREATE SCHEMA adst;
 SET search_path TO adst,public;
-CREATE OR REPLACE FUNCTION get_tablespace_version_directory_name()
-    RETURNS TEXT
-AS '@abs_builddir@/regress.so', 'get_tablespace_version_directory_name'
-    LANGUAGE C;
+-- to get function get_tablespace_version_directory_name()
+CREATE EXTENSION gp_check_functions;
 -- start_ignore
 CREATE LANGUAGE plpythonu;
 -- end_ignore
@@ -1431,7 +1429,7 @@ DROP TABLESPACE adst_destination_tablespace;
 -- Final cleanup
 DROP SCHEMA adst CASCADE;
 NOTICE:  drop cascades to 5 other objects
-DETAIL:  drop cascades to function get_tablespace_version_directory_name()
+DETAIL:  drop cascades to extension gp_check_functions
 drop cascades to function setup_tablespace_location_dir_for_test(text)
 drop cascades to function setup()
 drop cascades to function list_db_tablespace(text,text)

--- a/src/test/regress/output/gp_check_files.source
+++ b/src/test/regress/output/gp_check_files.source
@@ -7,9 +7,31 @@
 -- m/aovisimap_\d+/
 -- s/aovisimap_\d+/aovisimap_xxx/g
 -- end_matchsubs
--- start from a clean state
-checkpoint;
 create extension gp_check_functions;
+-- helper function to repeatedly run gp_check_orphaned_files for up to 10 minutes,
+-- in case any flakiness happens (like background worker makes LOCK pg_class unsuccessful etc.)
+CREATE OR REPLACE FUNCTION run_orphaned_files_view()
+RETURNS TABLE(gp_segment_id INT, filename TEXT) AS $$
+DECLARE
+    retry_counter INT := 0;
+BEGIN
+    WHILE retry_counter < 120 LOOP
+        BEGIN
+            RETURN QUERY SELECT q.gp_segment_id, q.filename FROM gp_check_orphaned_files q;
+            RETURN; -- If successful
+        EXCEPTION
+            WHEN OTHERS THEN
+                RAISE LOG 'attempt failed % with error: %', retry_counter + 1, SQLERRM;
+                -- When an exception occurs, wait for 5 seconds and then retry
+                PERFORM pg_sleep(5);
+                retry_counter := retry_counter + 1;
+        END;
+    END LOOP;
+
+    -- all retries failed
+    RAISE EXCEPTION 'failed to retrieve orphaned files after 10 minutes of retries.';
+END;
+$$ LANGUAGE plpgsql;
 -- we'll use a specific tablespace to test
 CREATE TABLESPACE checkfile_ts LOCATION '@testtablespace@';
 set default_tablespace = checkfile_ts;
@@ -24,6 +46,22 @@ select get_tablespace_version_directory_name() as version_dir \gset
 \cd :version_dir
 select oid from pg_database where datname = current_database() \gset
 \cd :oid
+-- create some orphaned files
+\! touch 987654
+\! touch 987654.3
+-- check orphaned files, note that this forces a checkpoint internally.
+set client_min_messages = ERROR;
+select gp_segment_id, filename from run_orphaned_files_view();
+ gp_segment_id | filename 
+---------------+----------
+             1 | 987654.3
+             1 | 987654
+(2 rows)
+
+reset client_min_messages;
+-- remove the orphaned files so not affect subsequent tests
+\! rm 987654
+\! rm 987654.3
 -- Now remove the data file for the table we just created.
 -- But check to see if the working directory is what we expect (under
 -- the test tablespace). Also just delete one and only one file that
@@ -39,9 +77,6 @@ insert into checkmissing_co select i,i,i from generate_series(1,100)i;
 -- delete exact two '.1' files.
 \! if pwd | grep -q "^@testtablespace@/.*$"; then find . -maxdepth 1 -type f -regex '.*\/[0-9]+\.1' -exec rm {} \; -quit; fi
 \! if pwd | grep -q "^@testtablespace@/.*$"; then find . -maxdepth 1 -type f -regex '.*\/[0-9]+\.1' -exec rm {} \; -quit; fi
--- create some orphaned files
-\! touch 987654
-\! touch 987654.3
 -- create some normal tables
 CREATE TABLE checknormal_heap(a int, b int, c int);
 CREATE TABLE checknormal_ao(a int, b int, c int) WITH (appendonly=true, orientation=row);
@@ -58,13 +93,6 @@ select gp_segment_id, regexp_replace(filename, '\d+', 'x'), relname from gp_chec
 
 SET client_min_messages = ERROR;
 -- check extended files
-select gp_segment_id, filename from gp_check_orphaned_files;
- gp_segment_id | filename 
----------------+----------
-             1 | 987654
-             1 | 987654.3
-(2 rows)
-
 select gp_segment_id, regexp_replace(filename, '\d+', 'x'), relname from gp_check_missing_files_ext;
  gp_segment_id | regexp_replace |      relname      
 ---------------+----------------+-------------------

--- a/src/test/regress/output/gp_check_files.source
+++ b/src/test/regress/output/gp_check_files.source
@@ -1,0 +1,91 @@
+-- Test views/functions to check missing/orphaned data files
+-- start_matchsubs
+-- m/aoseg_\d+/
+-- s/aoseg_\d+/aoseg_xxx/g
+-- m/aocsseg_\d+/
+-- s/aocsseg_\d+/aocsseg_xxx/g
+-- m/aovisimap_\d+/
+-- s/aovisimap_\d+/aovisimap_xxx/g
+-- end_matchsubs
+checkpoint;
+create extension gp_check_functions;
+-- we'll use a specific tablespace to test
+CREATE TABLESPACE checkfile_ts LOCATION '@testtablespace@';
+set default_tablespace = checkfile_ts;
+-- create a table that we'll delete the files 
+CREATE TABLE checkmissing_heap(a int, b int, c int);
+insert into checkmissing_heap select i,i,i from generate_series(1,100)i;
+-- go to seg1's data directory for the tablespace we just created
+\cd @testtablespace@
+select dbid from gp_segment_configuration where content = 1 and role = 'p' \gset
+\cd :dbid
+select get_tablespace_version_directory_name() as version_dir \gset
+\cd :version_dir
+select oid from pg_database where datname = current_database() \gset
+\cd :oid
+-- Now remove the data file for the table we just created.
+-- But check to see if the working directory is what we expect (under
+-- the test tablespace). Also just delete one and only one file that
+-- is number-named.
+\! if pwd | grep -q "^@testtablespace@/.*$"; then find . -maxdepth 1 -type f -regex '.*\/[0-9]+' -exec rm {} \; -quit; fi
+-- now create AO/CO tables and delete only their extended files
+CREATE TABLE checkmissing_ao(a int, b int, c int) WITH (appendonly=true, orientation=row);
+CREATE TABLE checkmissing_co(a int, b int, c int) WITH (appendonly=true, orientation=column);
+insert into checkmissing_ao select i,i,i from generate_series(1,100)i;
+insert into checkmissing_co select i,i,i from generate_series(1,100)i;
+-- Now remove the extended data file '.1' for the AO/CO tables we just created.
+-- Still, check to see if the working directory is what we expect, and only
+-- delete exact two '.1' files.
+\! if pwd | grep -q "^@testtablespace@/.*$"; then find . -maxdepth 1 -type f -regex '.*\/[0-9]+\.1' -exec rm {} \; -quit; fi
+\! if pwd | grep -q "^@testtablespace@/.*$"; then find . -maxdepth 1 -type f -regex '.*\/[0-9]+\.1' -exec rm {} \; -quit; fi
+-- create some orphaned files
+\! touch 987654
+\! touch 987654.3
+-- create some normal tables
+CREATE TABLE checknormal_heap(a int, b int, c int);
+CREATE TABLE checknormal_ao(a int, b int, c int) WITH (appendonly=true, orientation=row);
+CREATE TABLE checknormal_co(a int, b int, c int) WITH (appendonly=true, orientation=column);
+insert into checknormal_heap select i,i,i from generate_series(1,100)i;
+insert into checknormal_ao select i,i,i from generate_series(1,100)i;
+insert into checknormal_co select i,i,i from generate_series(1,100)i;
+-- check non-extended files
+select gp_segment_id, filename from gp_check_orphaned_files;
+ gp_segment_id | filename 
+---------------+----------
+             1 | 987654
+(1 row)
+
+select gp_segment_id, regexp_replace(filename, '\d+', 'x'), relname from gp_check_missing_files;
+ gp_segment_id | regexp_replace |      relname      
+---------------+----------------+-------------------
+             1 | x              | checkmissing_heap
+(1 row)
+
+SET client_min_messages = ERROR;
+-- check extended files
+select gp_segment_id, filename from gp_check_orphaned_files_ext;
+ gp_segment_id | filename 
+---------------+----------
+             1 | 987654
+             1 | 987654.3
+(2 rows)
+
+select gp_segment_id, regexp_replace(filename, '\d+', 'x'), relname from gp_check_missing_files_ext;
+ gp_segment_id | regexp_replace |      relname      
+---------------+----------------+-------------------
+             1 | x              | checkmissing_heap
+             1 | x.1            | checkmissing_ao
+             1 | x.1            | checkmissing_co
+(3 rows)
+
+RESET client_min_messages;
+-- cleanup
+drop table checkmissing_heap;
+drop table checkmissing_ao;
+drop table checkmissing_co;
+drop table checknormal_heap;
+drop table checknormal_ao;
+drop table checknormal_co;
+\! rm -rf @testtablespace@/*;
+DROP TABLESPACE checkfile_ts;
+DROP EXTENSION gp_check_functions;

--- a/src/test/regress/output/gp_check_files.source
+++ b/src/test/regress/output/gp_check_files.source
@@ -7,6 +7,7 @@
 -- m/aovisimap_\d+/
 -- s/aovisimap_\d+/aovisimap_xxx/g
 -- end_matchsubs
+-- start from a clean state
 checkpoint;
 create extension gp_check_functions;
 -- we'll use a specific tablespace to test
@@ -49,12 +50,6 @@ insert into checknormal_heap select i,i,i from generate_series(1,100)i;
 insert into checknormal_ao select i,i,i from generate_series(1,100)i;
 insert into checknormal_co select i,i,i from generate_series(1,100)i;
 -- check non-extended files
-select gp_segment_id, filename from gp_check_orphaned_files;
- gp_segment_id | filename 
----------------+----------
-             1 | 987654
-(1 row)
-
 select gp_segment_id, regexp_replace(filename, '\d+', 'x'), relname from gp_check_missing_files;
  gp_segment_id | regexp_replace |      relname      
 ---------------+----------------+-------------------
@@ -63,7 +58,7 @@ select gp_segment_id, regexp_replace(filename, '\d+', 'x'), relname from gp_chec
 
 SET client_min_messages = ERROR;
 -- check extended files
-select gp_segment_id, filename from gp_check_orphaned_files_ext;
+select gp_segment_id, filename from gp_check_orphaned_files;
  gp_segment_id | filename 
 ---------------+----------
              1 | 987654

--- a/src/test/regress/output/gp_tablespace.source
+++ b/src/test/regress/output/gp_tablespace.source
@@ -33,10 +33,8 @@ BEGIN
 	return has_init_file_for_oid(relation_id);
 END;
 $$ language plpgsql;
-CREATE OR REPLACE FUNCTION get_tablespace_version_directory_name()
-	RETURNS TEXT
-	AS '@abs_builddir@/regress.so', 'get_tablespace_version_directory_name'
-    LANGUAGE C;
+-- to get function get_tablespace_version_directory_name()
+CREATE EXTENSION gp_check_functions;
 -- create tablespaces we can use
 CREATE TABLESPACE testspace LOCATION '@testtablespace@';
 CREATE TABLESPACE ul_testspace LOCATION '@testtablespace@_unlogged';
@@ -385,3 +383,4 @@ CREATE TABLE t_dir_empty(a int);
 \! rm -rf @testtablespace@/*;
 DROP TABLE IF EXISTS t_dir_empty;
 DROP TABLESPACE testspace_dir_empty;
+DROP EXTENSION gp_check_functions;

--- a/src/test/regress/regress_gp.c
+++ b/src/test/regress/regress_gp.c
@@ -2149,13 +2149,6 @@ broken_int4out(PG_FUNCTION_ARGS)
 	return DirectFunctionCall1(int4out, Int32GetDatum(arg));
 }
 
-PG_FUNCTION_INFO_V1(get_tablespace_version_directory_name);
-Datum
-get_tablespace_version_directory_name(PG_FUNCTION_ARGS)
-{
-	PG_RETURN_TEXT_P(CStringGetTextDatum(GP_TABLESPACE_VERSION_DIRECTORY));
-}
-
 PG_FUNCTION_INFO_V1(gp_tablespace_temptablespaceOid);
 Datum
 gp_tablespace_temptablespaceOid(PG_FUNCTION_ARGS)

--- a/src/test/regress/sql/.gitignore
+++ b/src/test/regress/sql/.gitignore
@@ -38,6 +38,7 @@ bb_mpph.sql
 transient_types.sql
 hooktest.sql
 gpcopy.sql
+gp_check_files.sql
 trigger_sets_oid.sql
 query_info_hook_test.sql
 gp_tablespace.sql

--- a/src/test/regress/sql/truncate_gp.sql
+++ b/src/test/regress/sql/truncate_gp.sql
@@ -86,3 +86,10 @@ end;
 
 -- the heap table segment file size after truncate should be zero
 select stat_table_segfile_size('regression', 'truncate_with_create_heap');
+
+-- It is a known issue that extended datafiles won't be removed in such case (see #15342),
+-- but since they have 0 size 0 it shouldn't really matter.
+-- However, we do not want these file to create false alarms in the gp_check_files test
+-- later, so drop them now.
+drop table truncate_with_create_ao;
+drop table truncate_with_create_aocs;

--- a/src/test/regress/sql/truncate_gp.sql
+++ b/src/test/regress/sql/truncate_gp.sql
@@ -87,9 +87,3 @@ end;
 -- the heap table segment file size after truncate should be zero
 select stat_table_segfile_size('regression', 'truncate_with_create_heap');
 
--- It is a known issue that extended datafiles won't be removed in such case (see #15342),
--- but since they have 0 size 0 it shouldn't really matter.
--- However, we do not want these file to create false alarms in the gp_check_files test
--- later, so drop them now.
-drop table truncate_with_create_ao;
-drop table truncate_with_create_aocs;


### PR DESCRIPTION
Backport from 6bbafd96d698740e3b8706de8c292ec0daa3a295 (original view), #15480 and #16428 (improvements).

-----------------

For 6X, we create a new extension called `gp_check_functions` instead of burning the function/views into `gp_toolkit`. The main reason is to avoid requiring existing 6X users to reinstall gp_toolkit which might have many objects depending on. Correspondingly, the views will be created under the default namespace. To use:

```sql 
create extension if not exists gp_check_functions;

select * from gp_check_missing_files; -- only checks main relation files
select * from gp_check_missing_files_ext; -- checks extended relation files too

select * from gp_check_orphaned_files; -- checks both main and extended files
```

Other adjustments:

* In 6X, external, foreign and virtual tables could have valid relfilenode but they do not have datafiles stored in the common tablespaces. Skipping them by checking pg_class.relstorage.

* In 6X, it is known that extended datafiles created and truncated in the same transaction won't be removed (see #15342). Unfortunately, our orphaned file checking scripts could not differentiate such a false alarm case with other cases (but it is debatable whether such datafiles should really be counted as false alarm). So in order to not mess up with the test, now we drop the tables in test truncate_gp so that those datafiles will be removed.

* We create function get_tablespace_version_directory_name() in the
    new extension. With that, we remove the same defition in regress test
    and adjust the tests accordingly.

Original commit message:

1. Add views to get "existing" relation files in the database, including the default, global and user tablespaces. Note that this won't expose files outside of the data directory as we only use pg_ls_dir to get the file list, which won't have reach to any files outside the data directories (including the user tablespace directory).

2. Add views to get "expected" relation files in the database, using the knowledge from the catalog.

3. Using 1 and 2, construct views to get the missing files (i.e. files that are expected but not existed) and orphaned files (i.e. files that are there unexpectedly).

4. Create views to run the above views in MPP. Also, we support checking extended data files for AO/CO tables

5. Add regress tests.

To use:
```
  -- checking non-extended files
  select * from gp_toolkit.gp_check_missing_files;
  select * from gp_toolkit.gp_check_orphaned_files;

  -- checking all data files including the extended data files
  -- (e.g. 12345.1, 99999.2). These do not count supporting files
  -- such as .fsm .vm etc. And currently we only support checking
  -- extended data files for AO/CO tables, not heap.
  select * from gp_toolkit.gp_check_missing_files_ext;
  select * from gp_toolkit.gp_check_orphaned_files_ext;
```

Note:
* As mentioned, currently support checking all the non-extended data files and the extended data files of AO/CO tables. The main reason to separate these two is performance: constructing expected file list for AO/CO segments runs dynamic SQL on each aoseg/aocsseg table and could be slow. So only do that if really required.
* For heap tables, currently have no way to get the expected number of datafiles for a certain table: we cannot use pg_relation_size because that is in turn dependent on the number of datafiels itself. So always skip its extended files for now.

Dev pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/missing-orphaned-files

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
