### PR TITLE
Fix double free remapper->typmodmap in TeardownUDPIFCInterconnect() 

### DIFF
--- a/src/backend/cdb/motion/tupleremap.c
+++ b/src/backend/cdb/motion/tupleremap.c
@@ -122,7 +122,7 @@ struct TupleRemapInfo
  */
 struct TupleRemapper
 {
-	MemoryContext mycontext;	/* context containing TupleRemapper */
+	MemoryContext mycontext;	/* context containing TupleRemapper (with typmodmap and field_remapinfo) */
 	int32	   *typmodmap;		/* typmod map from remote to local */
 	int			typmodmapsize;	/* size of typmodmap */
 	TupleDesc	tupledesc;		/* current top-level tuple descriptor */
@@ -221,6 +221,7 @@ TRHandleTypeLists(TupleRemapper *remapper, List *typelist)
 	ListCell   *cell;
 	int			mapsize = remapper->typmodmapsize + list_length(typelist);
 
+	/* alloc typmodmap in remapper->mycontext, usually it's InterconnectContext */
 	MemoryContext oldcontext = MemoryContextSwitchTo(remapper->mycontext);
 	if (remapper->typmodmap)
 		remapper->typmodmap = repalloc(remapper->typmodmap, mapsize * sizeof(int32));

--- a/src/backend/cdb/motion/tupleremap.c
+++ b/src/backend/cdb/motion/tupleremap.c
@@ -37,6 +37,7 @@
 #include "utils/rangetypes.h"
 #include "utils/syscache.h"
 #include "utils/typcache.h"
+#include "utils/faultinjector.h"
 
 /*
  * When a tuple is received on the motion receiver, the typmod of RECORDOID
@@ -220,10 +221,12 @@ TRHandleTypeLists(TupleRemapper *remapper, List *typelist)
 	ListCell   *cell;
 	int			mapsize = remapper->typmodmapsize + list_length(typelist);
 
+	MemoryContext oldcontext = MemoryContextSwitchTo(remapper->mycontext);
 	if (remapper->typmodmap)
 		remapper->typmodmap = repalloc(remapper->typmodmap, mapsize * sizeof(int32));
 	else
 		remapper->typmodmap = palloc(mapsize * sizeof(int32));
+	MemoryContextSwitchTo(oldcontext);
 
 	for (j = 0; j < list_length(typelist); j++)
 		remapper->typmodmap[remapper->typmodmapsize + j] = -1;
@@ -253,6 +256,7 @@ TRHandleTypeLists(TupleRemapper *remapper, List *typelist)
 		if (!remapper->remap_needed && local_typmod != remote_typmod)
 			remapper->remap_needed = true;
 	}
+	SIMPLE_FAULT_INJECTOR("handled_typmodmap");
 }
 
 

--- a/src/test/isolation2/expected/free_remapper_fatal.out
+++ b/src/test/isolation2/expected/free_remapper_fatal.out
@@ -18,7 +18,7 @@ CREATE
 -- PR-15340 fixes it.
 
 -- create udt type
-1:create table tbl_pr15340 as select i as id from generate_series(1,8) i;
+1:create table tbl_pr15352 as select i as id from generate_series(1,8) i;
 CREATE 8
 1:drop type if exists myudt;
 DROP
@@ -31,19 +31,22 @@ CREATE
 --------------------------
  Success:                 
 (1 row)
-1:select row((1,'a')::myudt), row((2,'b')::myudt, 2) from tbl_pr15340;
+1:select row((1,'a')::myudt), row((2,'b')::myudt, 2) from tbl_pr15352;
 FATAL:  fault triggered, fault name:'handled_typmodmap' fault type:'fatal'
 server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
 1<:  <... completed>
 FAILED:  Execution failed
+-- cleanup
 2:select gp_inject_fault_infinite('handled_typmodmap', 'reset', 1);
  gp_inject_fault_infinite 
 --------------------------
  Success:                 
 (1 row)
-2:drop table tbl_pr15340;
+2:drop table tbl_pr15352;
+DROP
+2:drop type if exists myudt;
 DROP
 2<:  <... completed>
 FAILED:  Execution failed

--- a/src/test/isolation2/expected/free_remapper_fatal.out
+++ b/src/test/isolation2/expected/free_remapper_fatal.out
@@ -1,0 +1,49 @@
+-- start_ignore
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+CREATE
+-- end_ignore
+
+-- Test: free remapper's memory correctly in FATAL
+-- Here is the background:
+-- When the query with "record type cache" raises a FATAL, it runs into the following routine:
+-- FATAL->AbortTransaction()
+--     AtAbort_Portals()
+--         MemoryContextDeleteChildren()     // delete ExecutorState memory context
+--     ResourceOwnerRelease()
+--         cleanup_interconnect_handle()
+--             TeardownUDPIFCInterconnect()
+--                 DestroyTupleRemapper()          // pfree remapper->typmodmap
+-- It may cause SIGSEGV: remapper->typmodmap is alloced in MotionLayerMemCtxt,
+-- but the memory context has been deleted in AtAbort_Portals() (it's the child of ExecutorState).
+-- PR-15340 fixes it.
+
+-- create udt type
+1:create table tbl_pr15340 as select i as id from generate_series(1,8) i;
+CREATE 8
+1:drop type if exists myudt;
+DROP
+1:create type myudt as (i int, c char);
+CREATE
+
+-- should encounter the inject fatal rather than SIGSEGV
+1:select gp_inject_fault_infinite('handled_typmodmap', 'fatal', 1);
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+1:select row((1,'a')::myudt), row((2,'b')::myudt, 2) from tbl_pr15340;
+FATAL:  fault triggered, fault name:'handled_typmodmap' fault type:'fatal'
+server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+1<:  <... completed>
+FAILED:  Execution failed
+2:select gp_inject_fault_infinite('handled_typmodmap', 'reset', 1);
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+2:drop table tbl_pr15340;
+DROP
+2<:  <... completed>
+FAILED:  Execution failed

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -328,4 +328,7 @@ test: alter_partition_table_owner
 # test copy/insert in utility mode on partition/inheritance hierarchies
 test: copy_insert_utility_mode_hierarchies
 
+# test for free remapper's memory correctly in FATAL
+test: free_remapper_fatal
+
 test: spilling_hashagg

--- a/src/test/isolation2/sql/free_remapper_fatal.sql
+++ b/src/test/isolation2/sql/free_remapper_fatal.sql
@@ -17,14 +17,16 @@ CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
 -- PR-15340 fixes it.
 
 -- create udt type
-1:create table tbl_pr15340 as select i as id from generate_series(1,8) i;
+1:create table tbl_pr15352 as select i as id from generate_series(1,8) i;
 1:drop type if exists myudt;
 1:create type myudt as (i int, c char);
 
 -- should encounter the inject fatal rather than SIGSEGV
 1:select gp_inject_fault_infinite('handled_typmodmap', 'fatal', 1);
-1:select row((1,'a')::myudt), row((2,'b')::myudt, 2) from tbl_pr15340;
+1:select row((1,'a')::myudt), row((2,'b')::myudt, 2) from tbl_pr15352;
 1<:
+-- cleanup
 2:select gp_inject_fault_infinite('handled_typmodmap', 'reset', 1);
-2:drop table tbl_pr15340;
+2:drop table tbl_pr15352;
+2:drop type if exists myudt;
 2<:

--- a/src/test/isolation2/sql/free_remapper_fatal.sql
+++ b/src/test/isolation2/sql/free_remapper_fatal.sql
@@ -1,0 +1,30 @@
+-- start_ignore
+CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
+-- end_ignore
+
+-- Test: free remapper's memory correctly in FATAL
+-- Here is the background:
+-- When the query with "record type cache" raises a FATAL, it runs into the following routine:
+-- FATAL->AbortTransaction()
+--     AtAbort_Portals()
+--         MemoryContextDeleteChildren()     // delete ExecutorState memory context
+--     ResourceOwnerRelease()
+--         cleanup_interconnect_handle()
+--             TeardownUDPIFCInterconnect()
+--                 DestroyTupleRemapper()          // pfree remapper->typmodmap
+-- It may cause SIGSEGV: remapper->typmodmap is alloced in MotionLayerMemCtxt,
+-- but the memory context has been deleted in AtAbort_Portals() (it's the child of ExecutorState).
+-- PR-15340 fixes it.
+
+-- create udt type
+1:create table tbl_pr15340 as select i as id from generate_series(1,8) i;
+1:drop type if exists myudt;
+1:create type myudt as (i int, c char);
+
+-- should encounter the inject fatal rather than SIGSEGV
+1:select gp_inject_fault_infinite('handled_typmodmap', 'fatal', 1);
+1:select row((1,'a')::myudt), row((2,'b')::myudt, 2) from tbl_pr15340;
+1<:
+2:select gp_inject_fault_infinite('handled_typmodmap', 'reset', 1);
+2:drop table tbl_pr15340;
+2<:


### PR DESCRIPTION
This PR backports https://github.com/greenplum-db/gpdb/pull/15340 to 6X.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
