### PR TITLE
Fix flaky test fsync_ao

### DIFF
--- a/src/test/isolation2/expected/fsync_ao.out
+++ b/src/test/isolation2/expected/fsync_ao.out
@@ -100,13 +100,17 @@ select gp_wait_until_triggered_fault('restartpoint_guts', 2, dbid) from gp_segme
 (1 row)
 
 -- Validate that the number of files fsync'ed by checkpointer (on
--- mirror).  `num times hit` is corresponding to the number of files
--- synced by `ao_fsync_counter` fault.
+-- mirror).  This should match the number of files for fsync_ao and fsync_co.
+select gp_wait_until_triggered_fault('ao_fsync_counter', 3, dbid) from gp_segment_configuration where content=0 and role='m';
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
 select gp_inject_fault('ao_fsync_counter', 'status', dbid) from gp_segment_configuration where content=0 and role='m';
  gp_inject_fault                                                                                                                                                                                                        
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Success: fault name:'ao_fsync_counter' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'triggered'  num times hit:'3' 
  
+ Success: fault name:'ao_fsync_counter' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'triggered'  num times hit:'3' 
 (1 row)
 
 -- Test vacuum compaction with more than one segment file per table.
@@ -203,6 +207,11 @@ select gp_wait_until_triggered_fault('restartpoint_guts', 3, dbid) from gp_segme
 (1 row)
 
 -- Expect the segment files that were updated by vacuum to be fsync'ed.
+select gp_wait_until_triggered_fault('ao_fsync_counter', 12, dbid) from gp_segment_configuration where content=0 and role='m';
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
 select gp_inject_fault('ao_fsync_counter', 'status', dbid) from gp_segment_configuration where content=0 and role='m';
  gp_inject_fault                                                                                                                                                                                                         
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -244,6 +253,11 @@ select gp_wait_until_triggered_fault('restartpoint_guts', 4, dbid) from gp_segme
 
 -- Expect that fsync is only performed for fsync_ao table (1 file) but
 -- not for fsync_co table because it was dropped after being updated.
+select gp_wait_until_triggered_fault('ao_fsync_counter', 13, dbid) from gp_segment_configuration where content=0 and role='m';
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
 select gp_inject_fault('ao_fsync_counter', 'status', dbid) from gp_segment_configuration where content=0 and role='m';
  gp_inject_fault                                                                                                                                                                                                         
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/src/test/isolation2/sql/fsync_ao.sql
+++ b/src/test/isolation2/sql/fsync_ao.sql
@@ -58,8 +58,9 @@ select gp_wait_until_triggered_fault('restartpoint_guts', 2, dbid)
 	from gp_segment_configuration where content=0 and role='m';
 
 -- Validate that the number of files fsync'ed by checkpointer (on
--- mirror).  `num times hit` is corresponding to the number of files
--- synced by `ao_fsync_counter` fault.
+-- mirror).  This should match the number of files for fsync_ao and fsync_co.
+select gp_wait_until_triggered_fault('ao_fsync_counter', 3, dbid)
+	from gp_segment_configuration where content=0 and role='m';
 select gp_inject_fault('ao_fsync_counter', 'status', dbid)
 	from gp_segment_configuration where content=0 and role='m';
 
@@ -94,6 +95,8 @@ select gp_wait_until_triggered_fault('restartpoint_guts', 3, dbid)
 	from gp_segment_configuration where content=0 and role='m';
 
 -- Expect the segment files that were updated by vacuum to be fsync'ed.
+select gp_wait_until_triggered_fault('ao_fsync_counter', 12, dbid)
+	from gp_segment_configuration where content=0 and role='m';
 select gp_inject_fault('ao_fsync_counter', 'status', dbid)
 	from gp_segment_configuration where content=0 and role='m';
 
@@ -118,6 +121,8 @@ select gp_wait_until_triggered_fault('restartpoint_guts', 4, dbid)
 
 -- Expect that fsync is only performed for fsync_ao table (1 file) but
 -- not for fsync_co table because it was dropped after being updated.
+select gp_wait_until_triggered_fault('ao_fsync_counter', 13, dbid)
+	from gp_segment_configuration where content=0 and role='m';
 select gp_inject_fault('ao_fsync_counter', 'status', dbid)
 	from gp_segment_configuration where content=0 and role='m';
 


### PR DESCRIPTION
The test was flaky w/ a diff like this:

```
	--- /tmp/build/e18b2f02/gpdb_src/src/test/isolation2/expected/fsync_ao.out	2023-04-10 11:51:22.694100534 +0000
	+++ /tmp/build/e18b2f02/gpdb_src/src/test/isolation2/results/fsync_ao.out	2023-04-10 11:51:22.706101385 +0000
	@@ -107,7 +107,7 @@
	  gp_inject_fault
	 ------------

	- Success: fault name:'ao_fsync_counter' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'triggered'  num times hit:'3'
	+ Success: fault name:'ao_fsync_counter' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'triggered'  num times hit:'2' (1 row)
```

The reason seems to be that there's one additional checkpoint being replayed by mirror:

```
2023-04-10 11:51:19.727230 UTC,,,p156225,th-269391744,,,,0,,,seg0,,,,,"LOG","XX009","fault triggered, fault name:'restartpoint_guts' fault type:'skip' ",,,,,,,0,,"faultinjector.c",475,
2023-04-10 11:51:19.925646 UTC,,,p156225,th-269391744,,,,0,,,seg0,,,,,"LOG","XX009","fault triggered, fault name:'restartpoint_guts' fault type:'skip' ",,,,,,,0,,"faultinjector.c",475,

-- Mirror expects 2 hits at this point, so it got passed immediately
2023-04-10 11:51:19.946292 UTC,"gpadmin",,p158165,th-269391744,"10.254.0.26","56534",2023-04-10 11:51:19 UTC,0,,,seg0,,,,,"LOG","00000","Success: fault name:'ao_fsync_counter' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'triggered'  num times hit:'2'
",,,,,,,0,,"faultinjector.c",898,

-- But there's one more checkpoint going on currently, and it only sync'ed
-- two files which resulted in the test failure. Here's the last one file to be sync'ed:
2023-04-10 11:51:19.946619 UTC,,,p156225,th-269391744,,,,0,,,seg0,,,,,"LOG","XX009","fault triggered, fault name:'ao_fsync_counter' fault type:'skip' ",,,,,,,0,,"faultinjector.c",475,
2023-04-10 11:51:19.946633 UTC,,,p156225,th-269391744,,,,0,,,seg0,,,,,"LOG","00000","checkpoint performing fsync for 1663/73824/327686.1",,,,,,,0,,"sync.c",354,
2023-04-10 11:51:20.394318 UTC,,,p156225,th-269391744,,,,0,,,seg0,,,,,"LOG","XX009","fault triggered, fault name:'restartpoint_guts' fault type:'skip' ",,,,,,,0,,"faultinjector.c",475,
```

The exact reason for the additional checkpoint is unknown, but if I were to guess, most probably the mirror was slow in relaying records and it replayed a checkpoint generated from a previous test after the fault 'restartpoint_guts' was inserted.

The cause above would be hard to prevent. However, we should be able to fix the flakiness by waiting until the faults 'ao_fsync_counter' is being hit the exact same times as we expect.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
