### PR TITLE
Address Fixme related to ArrayCoerceExpr

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
@@ -2087,11 +2087,13 @@ CTranslatorRelcacheToDXL::RetrieveCast(CMemoryPool *mp, IMDId *mdid)
 	{
 		case COERCION_PATH_ARRAYCOERCE:
 		{
+			IMDId *src_elem_mdid = GPOS_NEW(mp)
+				CMDIdGPDB(IMDId::EmdidGeneral, gpdb::GetElementType(src_oid));
 			return GPOS_NEW(mp) CMDArrayCoerceCastGPDB(
 				mp, mdid, mdname, mdid_src, mdid_dest, is_binary_coercible,
 				GPOS_NEW(mp) CMDIdGPDB(IMDId::EmdidGeneral, cast_fn_oid),
 				IMDCast::EmdtArrayCoerce, default_type_modifier, false,
-				EdxlcfImplicitCast, -1);
+				EdxlcfImplicitCast, -1, src_elem_mdid);
 		}
 		break;
 		case COERCION_PATH_FUNC:

--- a/src/backend/gporca/data/dxl/minidump/ArrayCoerceCast.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ArrayCoerceCast.mdp
@@ -88,7 +88,25 @@
         <dxl:SumAgg Mdid="0.2108.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:ArrayCoerceCast Mdid="3.1007.1.0;1022.1.0" Name="float8" CoercePathType="3" BinaryCoercible="false" SourceTypeId="0.1007.1.0" DestinationTypeId="0.1022.1.0" CastFuncId="0.316.1.0" IsExplicit="false" CoercionForm="2" Location="-1"/>
+      <dxl:Type Mdid="0.701.1.0" Name="float8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:EqualityOp Mdid="0.670.1.0"/>
+        <dxl:InequalityOp Mdid="0.671.1.0"/>
+        <dxl:LessThanOp Mdid="0.672.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.673.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.674.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.675.1.0"/>
+        <dxl:ComparisonOp Mdid="0.355.1.0"/>
+        <dxl:ArrayType Mdid="0.1022.1.0"/>
+        <dxl:MinAgg Mdid="0.2136.1.0"/>
+        <dxl:MaxAgg Mdid="0.2120.1.0"/>
+        <dxl:AvgAgg Mdid="0.2105.1.0"/>
+        <dxl:SumAgg Mdid="0.2111.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:GPDBFunc Mdid="0.316.1.0" Name="float8" ReturnsSet="false" Stability="Immutable" DataAccess="NoSQL" IsStrict="true">
+        <dxl:ResultType Mdid="0.701.1.0"/>
+      </dxl:GPDBFunc>
+      <dxl:ArrayCoerceCast Mdid="3.1007.1.0;1022.1.0" Name="float8" CoercePathType="3" BinaryCoercible="false" SourceTypeId="0.1007.1.0" DestinationTypeId="0.1022.1.0" CastFuncId="0.316.1.0" IsExplicit="false" CoercionForm="2" Location="-1" SourceElemTypeId="0.23.1.0"/>
       <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="true" Length="4" PassByValue="true">
         <dxl:EqualityOp Mdid="0.607.1.0"/>
         <dxl:InequalityOp Mdid="0.608.1.0"/>
@@ -282,7 +300,10 @@
               <dxl:ProjElem ColId="11" Alias="cont_features">
                 <dxl:ArrayCoerceExpr ElementFunc="0.316.1.0" TypeMdid="0.1022.1.0" IsExplicit="false" CoercionForm="2" Location="-1">
                   <dxl:Ident ColId="10" ColName="cont_features" TypeMdid="0.1007.1.0"/>
-                </dxl:ArrayCoerceExpr>
+                  <dxl:FuncExpr FuncId="0.316.1.0" FuncRetSet="false" TypeMdid="0.701.1.0">
+                    <dxl:CaseTest TypeMdid="0.23.1.0"/>
+                  </dxl:FuncExpr>
+	        </dxl:ArrayCoerceExpr>
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>

--- a/src/backend/gporca/data/dxl/minidump/ArrayCoerceExpr.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ArrayCoerceExpr.mdp
@@ -193,11 +193,14 @@ explain select * from foo where d in ('a', 'b');
           <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.0.0.0">
             <dxl:Ident ColId="2" ColName="d" TypeMdid="0.1043.1.0"/>
           </dxl:Cast>
-          <dxl:ArrayCoerceExpr ElementFunc="0.0.0.0" TypeMdid="0.1009.1.0" IsExplicit="false" CoercionForm="2" Location="0">
+          <dxl:ArrayCoerceExpr TypeMdid="0.1009.1.0" CoercionForm="2" Location="0">
             <dxl:Array ArrayType="0.1015.1.0" ElementType="0.1043.1.0" MultiDimensional="false">
               <dxl:ConstValue TypeMdid="0.1043.1.0" Value="AAAABWE=" LintValue="160440876"/>
               <dxl:ConstValue TypeMdid="0.1043.1.0" Value="AAAABWI=" LintValue="160449068"/>
             </dxl:Array>
+	    <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.0.0.0">
+             <dxl:CaseTest TypeMdid="0.1043.1.0"/>
+            </dxl:Cast>
           </dxl:ArrayCoerceExpr>
         </dxl:ArrayComp>
         <dxl:LogicalGet>
@@ -249,12 +252,15 @@ explain select * from foo where d in ('a', 'b');
               <dxl:Cast TypeMdid="0.25.1.0" FuncId="0.0.0.0">
                 <dxl:Ident ColId="1" ColName="d" TypeMdid="0.1043.1.0"/>
               </dxl:Cast>
-              <dxl:ArrayCoerceExpr ElementFunc="0.0.0.0" TypeMdid="0.1009.1.0" IsExplicit="false" CoercionForm="2" Location="0">
+              <dxl:ArrayCoerceExpr TypeMdid="0.1009.1.0" CoercionForm="2" Location="0">
                 <dxl:Array ArrayType="0.1015.1.0" ElementType="0.1043.1.0" MultiDimensional="false">
                   <dxl:ConstValue TypeMdid="0.1043.1.0" Value="AAAABWE=" LintValue="160440876"/>
                   <dxl:ConstValue TypeMdid="0.1043.1.0" Value="AAAABWI=" LintValue="160449068"/>
                 </dxl:Array>
-              </dxl:ArrayCoerceExpr>
+		<dxl:Cast TypeMdid="0.25.1.0" FuncId="0.0.0.0">
+                 <dxl:CaseTest TypeMdid="0.1043.1.0"/>
+                </dxl:Cast>
+	      </dxl:ArrayCoerceExpr>
             </dxl:ArrayComp>
           </dxl:Filter>
           <dxl:TableDescriptor Mdid="6.97283.1.1" TableName="foo">

--- a/src/backend/gporca/data/dxl/minidump/ArrayCoerceImplicitCast.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ArrayCoerceImplicitCast.mdp
@@ -1,5 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Comment><![CDATA[
+  Objective: Ensure ORCA doesn't fake an explicit cast inplace of an
+  implicit one.
+  In the below example the column b in foo has a different length than b.
+  While inserting data from bar into foo, ORCA should translate the cast
+  function as part of ArrayCoerceExpr.
+  This will error out while execution as the length of col b mismatches between
+  foo and bar.
+
+  create table foo (a int, b varchar(2)[]);
+  create table bar (a int, b varchar(10)[]);
+
+  insert into bar values (1, ARRAY['abcde']);
+  explain insert into foo select * from bar;
+  ]]>
+  </dxl:Comment>
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>

--- a/src/backend/gporca/data/dxl/minidump/ArrayCoerceImplicitCast.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ArrayCoerceImplicitCast.mdp
@@ -1,0 +1,364 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="20" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0" SkewFactor="0"/>
+      <dxl:TraceFlags Value="102001,102002,102003,102043,102074,102120,102144,103001,103014,103022,103026,103027,103029,103033,103038,103040,104002,104003,104004,104005,105000,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.1043.1.0" Name="varchar" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="true" IsFixedLength="false" Length="-1" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.1995.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7105.1.0"/>
+        <dxl:EqualityOp Mdid="0.98.1.0"/>
+        <dxl:InequalityOp Mdid="0.531.1.0"/>
+        <dxl:LessThanOp Mdid="0.664.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.665.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.666.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.667.1.0"/>
+        <dxl:ComparisonOp Mdid="0.360.1.0"/>
+        <dxl:ArrayType Mdid="0.1015.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2134.1.0"/>
+        <dxl:MaxAgg Mdid="0.2118.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.2227.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.3315.1.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:GPDBFunc Mdid="0.669.1.0" Name="varchar" ReturnsSet="false" Stability="Immutable" DataAccess="NoSQL" IsStrict="true" IsNDVPreserving="false" IsAllowedForPS="false">
+        <dxl:ResultType Mdid="0.1043.1.0"/>
+      </dxl:GPDBFunc>
+      <dxl:Relation Mdid="6.16387.1.0" Name="foo" IsTemporary="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.1015.1.0" TypeModifier="6" Nullable="true" ColWidth="8">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:RelationStatistics Mdid="2.16393.1.0" Name="bar" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
+      <dxl:Relation Mdid="6.16393.1.0" Name="bar" IsTemporary="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.1015.1.0" TypeModifier="14" Nullable="true" ColWidth="8">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:RelationExtendedStatistics Mdid="10.16393.1.0" Name="bar"/>
+      <dxl:ColumnStatistics Mdid="1.16393.1.0.1" Name="b" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.16393.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:Type Mdid="0.1015.1.0" Name="_varchar" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="false" Length="-1" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.627.1.0"/>
+        <dxl:EqualityOp Mdid="0.1070.1.0"/>
+        <dxl:InequalityOp Mdid="0.1071.1.0"/>
+        <dxl:LessThanOp Mdid="0.1072.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1074.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.1073.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1075.1.0"/>
+        <dxl:ComparisonOp Mdid="0.382.1.0"/>
+        <dxl:ArrayType Mdid="0.0.0.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="10" ColName="b" TypeMdid="0.1015.1.0" TypeModifier="6"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalInsert InsertColumns="1,10">
+        <dxl:TableDescriptor Mdid="6.16387.1.0" TableName="foo" LockMode="3" AssignedQueryIdForTargetRel="1">
+          <dxl:Columns>
+            <dxl:Column ColId="11" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="12" Attno="2" ColName="b" TypeMdid="0.1015.1.0" TypeModifier="6" ColWidth="8"/>
+            <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+            <dxl:Column ColId="14" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="15" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="16" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="17" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="18" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+            <dxl:Column ColId="19" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+          </dxl:Columns>
+        </dxl:TableDescriptor>
+        <dxl:LogicalProject>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="10" Alias="b">
+              <dxl:ArrayCoerceExpr TypeMdid="0.1015.1.0" TypeModifier="6" CoercionForm="2" Location="-1">
+                <dxl:Ident ColId="2" ColName="b" TypeMdid="0.1015.1.0" TypeModifier="14"/>
+                <dxl:FuncExpr FuncId="0.669.1.0" FuncRetSet="false" TypeMdid="0.1043.1.0" FuncVariadic="false" TypeModifier="6">
+                  <dxl:CaseTest TypeMdid="0.1043.1.0"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="6"/>
+                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="false"/>
+                </dxl:FuncExpr>
+              </dxl:ArrayCoerceExpr>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:LogicalGet>
+            <dxl:TableDescriptor Mdid="6.16393.1.0" TableName="bar" LockMode="1">
+              <dxl:Columns>
+                <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.1015.1.0" TypeModifier="14" ColWidth="8"/>
+                <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="4" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="5" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="6" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="7" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="8" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="9" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:LogicalGet>
+        </dxl:LogicalProject>
+      </dxl:LogicalInsert>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="5">
+      <dxl:DMLInsert Columns="0,9" ActionCol="10" CtidCol="0" SegmentIdCol="0">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="431.020854" Rows="1.000000" Width="12"/>
+        </dxl:Properties>
+        <dxl:DirectDispatchInfo/>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="0" Alias="a">
+            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="9" Alias="b">
+            <dxl:Ident ColId="9" ColName="b" TypeMdid="0.1015.1.0" TypeModifier="6"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:TableDescriptor Mdid="6.16387.1.0" TableName="foo" LockMode="3" AssignedQueryIdForTargetRel="1">
+          <dxl:Columns>
+            <dxl:Column ColId="11" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="12" Attno="2" ColName="b" TypeMdid="0.1015.1.0" TypeModifier="6" ColWidth="8"/>
+            <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+            <dxl:Column ColId="14" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="15" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="16" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="17" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="18" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+            <dxl:Column ColId="19" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+          </dxl:Columns>
+        </dxl:TableDescriptor>
+        <dxl:Result>
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="431.000020" Rows="1.000000" Width="16"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="0" Alias="a">
+              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="9" Alias="b">
+              <dxl:ArrayCoerceExpr TypeMdid="0.1015.1.0" TypeModifier="6" CoercionForm="2" Location="-1">
+                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.1015.1.0" TypeModifier="14"/>
+                <dxl:FuncExpr FuncId="0.669.1.0" FuncRetSet="false" TypeMdid="0.1043.1.0" FuncVariadic="false" TypeModifier="6">
+                  <dxl:CaseTest TypeMdid="0.1043.1.0"/>
+                  <dxl:ConstValue TypeMdid="0.23.1.0" Value="6"/>
+                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="false"/>
+                </dxl:FuncExpr>
+              </dxl:ArrayCoerceExpr>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="10" Alias="ColRef_0010">
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:OneTimeFilter/>
+          <dxl:TableScan>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.000008" Rows="1.000000" Width="12"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="0" Alias="a">
+                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="1" Alias="b">
+                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.1015.1.0" TypeModifier="14"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:TableDescriptor Mdid="6.16393.1.0" TableName="bar" LockMode="1">
+              <dxl:Columns>
+                <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.1015.1.0" TypeModifier="14" ColWidth="8"/>
+                <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="3" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="4" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="5" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="6" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="7" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="8" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
+        </dxl:Result>
+      </dxl:DMLInsert>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/SimpleArrayCoerceCast.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SimpleArrayCoerceCast.mdp
@@ -61,7 +61,25 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:ArrayCoerceCast Mdid="3.1007.1.0;1231.1.0" Name="numeric" CoercePathType="3" BinaryCoercible="false" SourceTypeId="0.1007.1.0" DestinationTypeId="0.1231.1.0" CastFuncId="0.1740.1.0" IsExplicit="false" CoercionForm="2" Location="-1"/>
+      <dxl:Type Mdid="0.1700.1.0" Name="numeric" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsFixedLength="false" Length="-1" PassByValue="false">
+        <dxl:EqualityOp Mdid="0.1752.1.0"/>
+        <dxl:InequalityOp Mdid="0.1753.1.0"/>
+        <dxl:LessThanOp Mdid="0.1754.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1755.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.1756.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1757.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1769.1.0"/>
+        <dxl:ArrayType Mdid="0.1231.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.0.0.0"/>
+      </dxl:Type>
+      <dxl:GPDBFunc Mdid="0.1740.1.0" Name="numeric" ReturnsSet="false" Stability="Immutable" DataAccess="NoSQL" IsStrict="true">
+        <dxl:ResultType Mdid="0.1700.1.0"/>
+      </dxl:GPDBFunc>
+      <dxl:ArrayCoerceCast Mdid="3.1007.1.0;1231.1.0" Name="numeric" CoercePathType="3" BinaryCoercible="false" SourceTypeId="0.1007.1.0" DestinationTypeId="0.1231.1.0" CastFuncId="0.1740.1.0" IsExplicit="false" CoercionForm="2" Location="-1" SourceElemTypeId="0.23.1.0"/>
       <dxl:Type Mdid="0.1007.1.0" Name="_int4" IsRedistributable="true" IsHashable="false" IsMergeJoinable="false" IsComposite="false" IsFixedLength="false" Length="-1" PassByValue="false">
         <dxl:EqualityOp Mdid="0.1070.1.0"/>
         <dxl:InequalityOp Mdid="0.1071.1.0"/>
@@ -162,7 +180,10 @@
             <dxl:ProjElem ColId="4" Alias="array">
               <dxl:ArrayCoerceExpr ElementFunc="0.1740.1.0" TypeMdid="0.1231.1.0" IsExplicit="false" CoercionForm="2" Location="-1">
                 <dxl:Ident ColId="3" ColName="array" TypeMdid="0.1007.1.0"/>
-              </dxl:ArrayCoerceExpr>
+                <dxl:FuncExpr FuncId="0.1740.1.0" FuncRetSet="false" TypeMdid="0.1700.1.0">
+                  <dxl:CaseTest TypeMdid="0.23.1.0"/>
+                </dxl:FuncExpr>
+	      </dxl:ArrayCoerceExpr>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>

--- a/src/backend/gporca/data/dxl/parse_tests/q26-Metadata.xml
+++ b/src/backend/gporca/data/dxl/parse_tests/q26-Metadata.xml
@@ -3,7 +3,7 @@
   <dxl:Metadata>
     <dxl:MDCast Mdid="3.23.1.0;20.1.0" Name="int8" BinaryCoercible="false" SourceTypeId="0.23.1.0" DestinationTypeId="0.20.1.0" CastFuncId="0.481.1.0" CoercePathType="1"/>
     <dxl:MDCast Mdid="3.23.1.0;26.1.0" Name="int" BinaryCoercible="true" SourceTypeId="0.23.1.0" DestinationTypeId="0.26.1.0" CastFuncId="0.0.0.0" CoercePathType="0"/>
-    <dxl:ArrayCoerceCast Mdid="3.1007.1.0;1022.1.0" Name="float8" CoercePathType="3" BinaryCoercible="false" SourceTypeId="0.1007.1.0" DestinationTypeId="0.1022.1.0" CastFuncId="0.316.1.0" IsExplicit="false" CoercionForm="2" Location="-1"/>
+    <dxl:ArrayCoerceCast Mdid="3.1007.1.0;1022.1.0" Name="float8" CoercePathType="3" BinaryCoercible="false" SourceTypeId="0.1007.1.0" DestinationTypeId="0.1022.1.0" CastFuncId="0.316.1.0" SourceElemTypeId="0.23.1.0" IsExplicit="false" CoercionForm="2" Location="-1"/>
     <dxl:MDScalarComparison Mdid="4.23.1.0;20.1.0;0" Name="=" ComparisonType="Eq" LeftType="0.23.1.0" RightType="0.20.1.0" OperatorMdid="0.416.1.0"/>
     <dxl:RelationStatistics Mdid="2.1234.1.2" Name="T" Rows="1234.123400" RelPages="0" RelAllVisible="0" EmptyRelation="false"/>
     <dxl:ColumnStatistics Mdid="1.1234.1.2.1" Name="T.a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CUtils.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CUtils.h
@@ -875,6 +875,12 @@ public:
 	static CExpression *PexprCast(CMemoryPool *mp, CMDAccessor *md_accessor,
 								  CExpression *pexpr, IMDId *mdid_dest);
 
+	// construct a func element expr for array coerce
+	static CExpression *PexprFuncElemExpr(CMemoryPool *mp,
+										  CMDAccessor *md_accessor,
+										  IMDId *mdid_func,
+										  IMDId *mdid_elem_type, INT typmod);
+
 	// construct a logical join expression of the given type, with the given children
 	static CExpression *PexprLogicalJoin(CMemoryPool *mp,
 										 EdxlJoinType edxljointype,

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CScalarArrayCoerceExpr.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CScalarArrayCoerceExpr.h
@@ -38,28 +38,16 @@ using namespace gpos;
 class CScalarArrayCoerceExpr : public CScalarCoerceBase
 {
 private:
-	// catalog MDId of the element function
-	IMDId *m_pmdidElementFunc;
-
-	// conversion semantics flag to pass to func
-	BOOL m_is_explicit;
-
 public:
 	CScalarArrayCoerceExpr(const CScalarArrayCoerceExpr &) = delete;
 
 	// ctor
-	CScalarArrayCoerceExpr(CMemoryPool *mp, IMDId *element_func,
-						   IMDId *result_type_mdid, INT type_modifier,
-						   BOOL is_explicit, ECoercionForm dxl_coerce_format,
+	CScalarArrayCoerceExpr(CMemoryPool *mp, IMDId *result_type_mdid,
+						   INT type_modifier, ECoercionForm dxl_coerce_format,
 						   INT location);
 
 	// dtor
-	~CScalarArrayCoerceExpr() override;
-
-	// return metadata id of element coerce function
-	IMDId *PmdidElementFunc() const;
-
-	BOOL IsExplicit() const;
+	~CScalarArrayCoerceExpr() override = default;
 
 	EOperatorId Eopid() const override;
 

--- a/src/backend/gporca/libgpopt/src/base/CCastUtils.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CCastUtils.cpp
@@ -134,9 +134,7 @@ CCastUtils::PexprCast(CMemoryPool *mp, CMDAccessor *md_accessor,
 		pexpr = GPOS_NEW(mp) CExpression(
 			mp,
 			GPOS_NEW(mp) CScalarArrayCoerceExpr(
-				mp, parrayCoerceCast->GetCastFuncMdId(), mdid_dest,
-				parrayCoerceCast->TypeModifier(),
-				parrayCoerceCast->IsExplicit(),
+				mp, mdid_dest, parrayCoerceCast->TypeModifier(),
 				(COperator::ECoercionForm) parrayCoerceCast->GetCoercionForm(),
 				parrayCoerceCast->Location()),
 			CUtils::PexprScalarIdent(mp, colref));
@@ -331,9 +329,7 @@ CCastUtils::PexprCast(CMemoryPool *mp, CMDAccessor *md_accessor,
 		pexprCast = GPOS_NEW(mp) CExpression(
 			mp,
 			GPOS_NEW(mp) CScalarArrayCoerceExpr(
-				mp, parrayCoerceCast->GetCastFuncMdId(), mdid_dest,
-				parrayCoerceCast->TypeModifier(),
-				parrayCoerceCast->IsExplicit(),
+				mp, mdid_dest, parrayCoerceCast->TypeModifier(),
 				(COperator::ECoercionForm) parrayCoerceCast->GetCoercionForm(),
 				parrayCoerceCast->Location()),
 			pexpr);

--- a/src/backend/gporca/libgpopt/src/base/CCastUtils.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CCastUtils.cpp
@@ -131,13 +131,18 @@ CCastUtils::PexprCast(CMemoryPool *mp, CMDAccessor *md_accessor,
 	{
 		CMDArrayCoerceCastGPDB *parrayCoerceCast =
 			(CMDArrayCoerceCastGPDB *) pmdcast;
+		IMDId *mdid_func = pmdcast->GetCastFuncMdId();
+
 		pexpr = GPOS_NEW(mp) CExpression(
 			mp,
 			GPOS_NEW(mp) CScalarArrayCoerceExpr(
 				mp, mdid_dest, parrayCoerceCast->TypeModifier(),
 				(COperator::ECoercionForm) parrayCoerceCast->GetCoercionForm(),
 				parrayCoerceCast->Location()),
-			CUtils::PexprScalarIdent(mp, colref));
+			CUtils::PexprScalarIdent(mp, colref),
+			CUtils::PexprFuncElemExpr(mp, md_accessor, mdid_func,
+									  parrayCoerceCast->GetSrcElemTypeMdId(),
+									  parrayCoerceCast->TypeModifier()));
 	}
 	else
 	{

--- a/src/backend/gporca/libgpopt/src/base/CUtils.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CUtils.cpp
@@ -51,6 +51,7 @@
 #include "gpopt/operators/CPredicateUtils.h"
 #include "gpopt/operators/CScalarArray.h"
 #include "gpopt/operators/CScalarArrayCoerceExpr.h"
+#include "gpopt/operators/CScalarCaseTest.h"
 #include "gpopt/operators/CScalarCast.h"
 #include "gpopt/operators/CScalarCmp.h"
 #include "gpopt/operators/CScalarCoerceViaIO.h"
@@ -3784,13 +3785,18 @@ CUtils::PexprCast(CMemoryPool *mp, CMDAccessor *md_accessor, CExpression *pexpr,
 	{
 		CMDArrayCoerceCastGPDB *parrayCoerceCast =
 			(CMDArrayCoerceCastGPDB *) pmdcast;
+		IMDId *mdid_func = pmdcast->GetCastFuncMdId();
+
 		pexprCast = GPOS_NEW(mp) CExpression(
 			mp,
 			GPOS_NEW(mp) CScalarArrayCoerceExpr(
 				mp, mdid_dest, parrayCoerceCast->TypeModifier(),
 				(COperator::ECoercionForm) parrayCoerceCast->GetCoercionForm(),
 				parrayCoerceCast->Location()),
-			pexpr);
+			pexpr,
+			CUtils::PexprFuncElemExpr(mp, md_accessor, mdid_func,
+									  parrayCoerceCast->GetSrcElemTypeMdId(),
+									  parrayCoerceCast->TypeModifier()));
 	}
 	else if (pmdcast->GetMDPathType() == IMDCast::EmdtCoerceViaIO)
 	{
@@ -3808,6 +3814,27 @@ CUtils::PexprCast(CMemoryPool *mp, CMDAccessor *md_accessor, CExpression *pexpr,
 	}
 
 	return pexprCast;
+}
+
+// construct a func element expr for array coerce
+CExpression *
+CUtils::PexprFuncElemExpr(CMemoryPool *mp, CMDAccessor *md_accessor,
+						  IMDId *mdid_func, IMDId *mdid_elem_type, INT typmod)
+{
+	const IMDFunction *cast_func = md_accessor->RetrieveFunc(mdid_func);
+	const CWStringConst *pstrFunc = GPOS_NEW(mp)
+		CWStringConst(mp, (cast_func->Mdname().GetMDName())->GetBuffer());
+	mdid_func->AddRef();
+	cast_func->GetResultTypeMdid()->AddRef();
+	CScalarFunc *popCastScalarFunc =
+		GPOS_NEW(mp) CScalarFunc(mp, mdid_func, cast_func->GetResultTypeMdid(),
+								 typmod, pstrFunc, false /* funcvariadic */);
+	mdid_elem_type->AddRef();
+	CExpression *pexprCaseTest = GPOS_NEW(mp)
+		CExpression(mp, GPOS_NEW(mp) CScalarCaseTest(mp, mdid_elem_type));
+	CExpression *pexpr =
+		GPOS_NEW(mp) CExpression(mp, popCastScalarFunc, pexprCaseTest);
+	return pexpr;
 }
 
 // check whether a colref array contains repeated items

--- a/src/backend/gporca/libgpopt/src/base/CUtils.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CUtils.cpp
@@ -3787,9 +3787,7 @@ CUtils::PexprCast(CMemoryPool *mp, CMDAccessor *md_accessor, CExpression *pexpr,
 		pexprCast = GPOS_NEW(mp) CExpression(
 			mp,
 			GPOS_NEW(mp) CScalarArrayCoerceExpr(
-				mp, parrayCoerceCast->GetCastFuncMdId(), mdid_dest,
-				parrayCoerceCast->TypeModifier(),
-				parrayCoerceCast->IsExplicit(),
+				mp, mdid_dest, parrayCoerceCast->TypeModifier(),
 				(COperator::ECoercionForm) parrayCoerceCast->GetCoercionForm(),
 				parrayCoerceCast->Location()),
 			pexpr);

--- a/src/backend/gporca/libgpopt/src/operators/CScalarArrayCoerceExpr.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CScalarArrayCoerceExpr.cpp
@@ -31,57 +31,12 @@ using namespace gpmd;
 //		Ctor
 //
 //---------------------------------------------------------------------------
-CScalarArrayCoerceExpr::CScalarArrayCoerceExpr(
-	CMemoryPool *mp, IMDId *element_func, IMDId *result_type_mdid,
-	INT type_modifier, BOOL is_explicit, ECoercionForm ecf, INT location)
-	: CScalarCoerceBase(mp, result_type_mdid, type_modifier, ecf, location),
-	  m_pmdidElementFunc(element_func),
-	  m_is_explicit(is_explicit)
+CScalarArrayCoerceExpr::CScalarArrayCoerceExpr(CMemoryPool *mp,
+											   IMDId *result_type_mdid,
+											   INT type_modifier,
+											   ECoercionForm ecf, INT location)
+	: CScalarCoerceBase(mp, result_type_mdid, type_modifier, ecf, location)
 {
-	GPOS_ASSERT(nullptr != element_func);
-}
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CScalarArrayCoerceExpr::~CScalarArrayCoerceExpr
-//
-//	@doc:
-//		dtor
-//
-//---------------------------------------------------------------------------
-CScalarArrayCoerceExpr::~CScalarArrayCoerceExpr()
-{
-	m_pmdidElementFunc->Release();
-}
-
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CScalarArrayCoerceExpr::PmdidElementFunc
-//
-//	@doc:
-//		Return metadata id of element coerce function
-//
-//---------------------------------------------------------------------------
-IMDId *
-CScalarArrayCoerceExpr::PmdidElementFunc() const
-{
-	return m_pmdidElementFunc;
-}
-
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CScalarArrayCoerceExpr::IsExplicit
-//
-//	@doc:
-//		Conversion semantics flag to pass to func
-//
-//---------------------------------------------------------------------------
-BOOL
-CScalarArrayCoerceExpr::IsExplicit() const
-{
-	return m_is_explicit;
 }
 
 
@@ -133,10 +88,8 @@ CScalarArrayCoerceExpr::Matches(COperator *pop) const
 
 	CScalarArrayCoerceExpr *popCoerce = CScalarArrayCoerceExpr::PopConvert(pop);
 
-	return popCoerce->PmdidElementFunc()->Equals(m_pmdidElementFunc) &&
-		   popCoerce->MdidType()->Equals(MdidType()) &&
+	return popCoerce->MdidType()->Equals(MdidType()) &&
 		   popCoerce->TypeModifier() == TypeModifier() &&
-		   popCoerce->IsExplicit() == m_is_explicit &&
 		   popCoerce->Ecf() == Ecf() && popCoerce->Location() == Location();
 }
 

--- a/src/backend/gporca/libgpopt/src/translate/CTranslatorDXLToExpr.cpp
+++ b/src/backend/gporca/libgpopt/src/translate/CTranslatorDXLToExpr.cpp
@@ -797,14 +797,20 @@ CTranslatorDXLToExpr::PexprCastPrjElem(IMDId *pmdidSource, IMDId *mdid_dest,
 	{
 		CMDArrayCoerceCastGPDB *parrayCoerceCast =
 			(CMDArrayCoerceCastGPDB *) pmdcast;
+		IMDId *mdid_func = pmdcast->GetCastFuncMdId();
+		CExpression *pexprCastScalarFunc = CUtils::PexprFuncElemExpr(
+			m_mp, m_pmda, mdid_func, parrayCoerceCast->GetSrcElemTypeMdId(),
+			parrayCoerceCast->TypeModifier());
+
 		pexprCast = GPOS_NEW(m_mp) CExpression(
 			m_mp,
 			GPOS_NEW(m_mp) CScalarArrayCoerceExpr(
 				m_mp, mdid_dest, parrayCoerceCast->TypeModifier(),
 				(COperator::ECoercionForm) parrayCoerceCast->GetCoercionForm(),
 				parrayCoerceCast->Location()),
-			GPOS_NEW(m_mp) CExpression(
-				m_mp, GPOS_NEW(m_mp) CScalarIdent(m_mp, pcrToCast)));
+			GPOS_NEW(m_mp)
+				CExpression(m_mp, GPOS_NEW(m_mp) CScalarIdent(m_mp, pcrToCast)),
+			pexprCastScalarFunc);
 	}
 	else
 	{
@@ -3673,13 +3679,18 @@ CTranslatorDXLToExpr::PexprScalarCast(const CDXLNode *pdxlnCast)
 	{
 		CMDArrayCoerceCastGPDB *parrayCoerceCast =
 			(CMDArrayCoerceCastGPDB *) pmdcast;
+		IMDId *mdid_func = pmdcast->GetCastFuncMdId();
+		CExpression *pexprCastScalarFunc = CUtils::PexprFuncElemExpr(
+			m_mp, m_pmda, mdid_func, parrayCoerceCast->GetSrcElemTypeMdId(),
+			parrayCoerceCast->TypeModifier());
+
 		pexpr = GPOS_NEW(m_mp) CExpression(
 			m_mp,
 			GPOS_NEW(m_mp) CScalarArrayCoerceExpr(
 				m_mp, mdid_type, parrayCoerceCast->TypeModifier(),
 				(COperator::ECoercionForm) parrayCoerceCast->GetCoercionForm(),
 				parrayCoerceCast->Location()),
-			pexprChild);
+			pexprChild, pexprCastScalarFunc);
 	}
 	else
 	{

--- a/src/backend/gporca/libgpopt/src/translate/CTranslatorDXLToExpr.cpp
+++ b/src/backend/gporca/libgpopt/src/translate/CTranslatorDXLToExpr.cpp
@@ -800,9 +800,7 @@ CTranslatorDXLToExpr::PexprCastPrjElem(IMDId *pmdidSource, IMDId *mdid_dest,
 		pexprCast = GPOS_NEW(m_mp) CExpression(
 			m_mp,
 			GPOS_NEW(m_mp) CScalarArrayCoerceExpr(
-				m_mp, parrayCoerceCast->GetCastFuncMdId(), mdid_dest,
-				parrayCoerceCast->TypeModifier(),
-				parrayCoerceCast->IsExplicit(),
+				m_mp, mdid_dest, parrayCoerceCast->TypeModifier(),
 				(COperator::ECoercionForm) parrayCoerceCast->GetCoercionForm(),
 				parrayCoerceCast->Location()),
 			GPOS_NEW(m_mp) CExpression(
@@ -2974,9 +2972,7 @@ CTranslatorDXLToExpr::PexprScalarFunc(const CDXLNode *pdxlnFunc)
 			CMDArrayCoerceCastGPDB *parrayCoerceCast =
 				(CMDArrayCoerceCastGPDB *) pmdcast;
 			pop = GPOS_NEW(m_mp) CScalarArrayCoerceExpr(
-				m_mp, parrayCoerceCast->GetCastFuncMdId(), mdid_return_type,
-				parrayCoerceCast->TypeModifier(),
-				parrayCoerceCast->IsExplicit(),
+				m_mp, mdid_return_type, parrayCoerceCast->TypeModifier(),
 				(COperator::ECoercionForm) parrayCoerceCast->GetCoercionForm(),
 				parrayCoerceCast->Location());
 		}
@@ -3680,9 +3676,7 @@ CTranslatorDXLToExpr::PexprScalarCast(const CDXLNode *pdxlnCast)
 		pexpr = GPOS_NEW(m_mp) CExpression(
 			m_mp,
 			GPOS_NEW(m_mp) CScalarArrayCoerceExpr(
-				m_mp, parrayCoerceCast->GetCastFuncMdId(), mdid_type,
-				parrayCoerceCast->TypeModifier(),
-				parrayCoerceCast->IsExplicit(),
+				m_mp, mdid_type, parrayCoerceCast->TypeModifier(),
 				(COperator::ECoercionForm) parrayCoerceCast->GetCoercionForm(),
 				parrayCoerceCast->Location()),
 			pexprChild);
@@ -3789,12 +3783,11 @@ CTranslatorDXLToExpr::PexprScalarArrayCoerceExpr(
 	CDXLScalarArrayCoerceExpr *dxl_op =
 		CDXLScalarArrayCoerceExpr::Cast(pdxlnArrayCoerceExpr->GetOperator());
 
-	GPOS_ASSERT(1 == pdxlnArrayCoerceExpr->Arity());
+	GPOS_ASSERT(2 == pdxlnArrayCoerceExpr->Arity());
 	CDXLNode *child_dxlnode = (*pdxlnArrayCoerceExpr)[0];
+	CDXLNode *elemexpr_dxlnode = (*pdxlnArrayCoerceExpr)[1];
 	CExpression *pexprChild = Pexpr(child_dxlnode);
-
-	IMDId *element_func = dxl_op->GetCoerceFuncMDid();
-	element_func->AddRef();
+	CExpression *pexprElem = Pexpr(elemexpr_dxlnode);
 
 	IMDId *result_type_mdid = dxl_op->GetResultTypeMdId();
 	result_type_mdid->AddRef();
@@ -3804,12 +3797,11 @@ CTranslatorDXLToExpr::PexprScalarArrayCoerceExpr(
 	return GPOS_NEW(m_mp) CExpression(
 		m_mp,
 		GPOS_NEW(m_mp) CScalarArrayCoerceExpr(
-			m_mp, element_func, result_type_mdid, dxl_op->TypeModifier(),
-			dxl_op->IsExplicit(),
+			m_mp, result_type_mdid, dxl_op->TypeModifier(),
 			(COperator::ECoercionForm)
 				dxl_coerce_format,	// map Coercion Form directly based on position in enum
 			dxl_op->GetLocation()),
-		pexprChild);
+		pexprChild, pexprElem);
 }
 
 //---------------------------------------------------------------------------

--- a/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
+++ b/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
@@ -6162,25 +6162,25 @@ CTranslatorExprToDXL::PdxlnScArrayCoerceExpr(CExpression *pexprArrayCoerceExpr)
 	CScalarArrayCoerceExpr *popScArrayCoerceExpr =
 		CScalarArrayCoerceExpr::PopConvert(pexprArrayCoerceExpr->Pop());
 
-	IMDId *pmdidElemFunc = popScArrayCoerceExpr->PmdidElementFunc();
-	pmdidElemFunc->AddRef();
 	IMDId *mdid = popScArrayCoerceExpr->MdidType();
 	mdid->AddRef();
 
 	CDXLNode *pdxlnArrayCoerceExpr = GPOS_NEW(m_mp) CDXLNode(
 		m_mp,
 		GPOS_NEW(m_mp) CDXLScalarArrayCoerceExpr(
-			m_mp, pmdidElemFunc, mdid, popScArrayCoerceExpr->TypeModifier(),
-			popScArrayCoerceExpr->IsExplicit(),
+			m_mp, mdid, popScArrayCoerceExpr->TypeModifier(),
 			(EdxlCoercionForm) popScArrayCoerceExpr
 				->Ecf(),  // map Coercion Form directly based on position in enum
 			popScArrayCoerceExpr->Location()));
 
 	// translate child
-	GPOS_ASSERT(1 == pexprArrayCoerceExpr->Arity());
+	GPOS_ASSERT(2 == pexprArrayCoerceExpr->Arity());
 	CExpression *pexprChild = (*pexprArrayCoerceExpr)[0];
+	CExpression *pexprElemExpr = (*pexprArrayCoerceExpr)[1];
 	CDXLNode *child_dxlnode = PdxlnScalar(pexprChild);
+	CDXLNode *elemexpr_dxlnode = PdxlnScalar(pexprElemExpr);
 	pdxlnArrayCoerceExpr->AddChild(child_dxlnode);
+	pdxlnArrayCoerceExpr->AddChild(elemexpr_dxlnode);
 
 	return pdxlnArrayCoerceExpr;
 }

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLScalarArrayCoerceExpr.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/operators/CDXLScalarArrayCoerceExpr.h
@@ -38,43 +38,20 @@ using namespace gpmd;
 class CDXLScalarArrayCoerceExpr : public CDXLScalarCoerceBase
 {
 private:
-	// catalog MDId of element coerce function
-	IMDId *m_coerce_func_mdid;
-
-	// conversion semantics flag to pass to func
-	BOOL m_explicit;
-
 public:
 	CDXLScalarArrayCoerceExpr(const CDXLScalarArrayCoerceExpr &) = delete;
 
-	CDXLScalarArrayCoerceExpr(CMemoryPool *mp, IMDId *coerce_func_mdid,
-							  IMDId *result_type_mdid, INT type_modifier,
-							  BOOL is_explicit, EdxlCoercionForm coerce_format,
+	CDXLScalarArrayCoerceExpr(CMemoryPool *mp, IMDId *result_type_mdid,
+							  INT type_modifier, EdxlCoercionForm coerce_format,
 							  INT location);
 
-	~CDXLScalarArrayCoerceExpr() override
-	{
-		m_coerce_func_mdid->Release();
-	}
+	~CDXLScalarArrayCoerceExpr() override = default;
 
 	// ident accessor
 	Edxlopid
 	GetDXLOperator() const override
 	{
 		return EdxlopScalarArrayCoerceExpr;
-	}
-
-	// return metadata id of element coerce function
-	IMDId *
-	GetCoerceFuncMDid() const
-	{
-		return m_coerce_func_mdid;
-	}
-
-	BOOL
-	IsExplicit() const
-	{
-		return m_explicit;
 	}
 
 	// name of the DXL operator name

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/xml/dxltokens.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/xml/dxltokens.h
@@ -618,6 +618,7 @@ enum Edxltoken
 	EdxltokenGPDBCastSrcType,
 	EdxltokenGPDBCastDestType,
 	EdxltokenGPDBCastFuncId,
+	EdxltokenGPDBCastSrcElemType,
 	EdxltokenGPDBCastCoercePathType,
 	EdxltokenGPDBArrayCoerceCast,
 

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/xml/dxltokens.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/xml/dxltokens.h
@@ -279,7 +279,6 @@ enum Edxltoken
 	EdxltokenTypeMod,
 	EdxltokenCoercionForm,
 	EdxltokenLocation,
-	EdxltokenElementFunc,
 	EdxltokenIsExplicit,
 
 	EdxltokenJoinType,

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/CMDArrayCoerceCastGPDB.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/CMDArrayCoerceCastGPDB.h
@@ -41,6 +41,9 @@ private:
 	// location
 	INT m_location;
 
+	// Src element MDId
+	IMDId *m_mdid_src_elemtype;
+
 public:
 	CMDArrayCoerceCastGPDB(const CMDArrayCoerceCastGPDB &) = delete;
 
@@ -50,7 +53,7 @@ public:
 						   BOOL is_binary_coercible, IMDId *mdid_cast_func,
 						   EmdCoercepathType path_type, INT type_modifier,
 						   BOOL is_explicit, EdxlCoercionForm dxl_coerce_format,
-						   INT location);
+						   INT location, IMDId *mdid_src_elemtype);
 
 	// dtor
 	~CMDArrayCoerceCastGPDB() override;
@@ -72,6 +75,9 @@ public:
 
 	// return token location
 	virtual INT Location() const;
+
+	// return src element type
+	virtual IMDId *GetSrcElemTypeMdId() const;
 
 	// serialize object in DXL format
 	void Serialize(gpdxl::CXMLSerializer *xml_serializer) const override;

--- a/src/backend/gporca/libnaucrates/src/md/CMDArrayCoerceCastGPDB.cpp
+++ b/src/backend/gporca/libnaucrates/src/md/CMDArrayCoerceCastGPDB.cpp
@@ -26,13 +26,14 @@ CMDArrayCoerceCastGPDB::CMDArrayCoerceCastGPDB(
 	CMemoryPool *mp, IMDId *mdid, CMDName *mdname, IMDId *mdid_src,
 	IMDId *mdid_dest, BOOL is_binary_coercible, IMDId *mdid_cast_func,
 	EmdCoercepathType path_type, INT type_modifier, BOOL is_explicit,
-	EdxlCoercionForm dxl_coerce_format, INT location)
+	EdxlCoercionForm dxl_coerce_format, INT location, IMDId *mdid_src_elemtype)
 	: CMDCastGPDB(mp, mdid, mdname, mdid_src, mdid_dest, is_binary_coercible,
 				  mdid_cast_func, path_type),
 	  m_type_modifier(type_modifier),
 	  m_is_explicit(is_explicit),
 	  m_dxl_coerce_format(dxl_coerce_format),
-	  m_location(location)
+	  m_location(location),
+	  m_mdid_src_elemtype(mdid_src_elemtype)
 {
 	m_dxl_str = CDXLUtils::SerializeMDObj(mp, this, false /*fSerializeHeader*/,
 										  false /*indentation*/);
@@ -42,6 +43,7 @@ CMDArrayCoerceCastGPDB::CMDArrayCoerceCastGPDB(
 CMDArrayCoerceCastGPDB::~CMDArrayCoerceCastGPDB()
 {
 	GPOS_DELETE(m_dxl_str);
+	m_mdid_src_elemtype->Release();
 }
 
 // return type modifier
@@ -72,6 +74,13 @@ CMDArrayCoerceCastGPDB::Location() const
 	return m_location;
 }
 
+// return src basetype mdid
+IMDId *
+CMDArrayCoerceCastGPDB::GetSrcElemTypeMdId() const
+{
+	return m_mdid_src_elemtype;
+}
+
 // serialize function metadata in DXL format
 void
 CMDArrayCoerceCastGPDB::Serialize(CXMLSerializer *xml_serializer) const
@@ -99,6 +108,9 @@ CMDArrayCoerceCastGPDB::Serialize(CXMLSerializer *xml_serializer) const
 		xml_serializer, CDXLTokens::GetDXLTokenStr(EdxltokenGPDBCastDestType));
 	m_mdid_cast_func->Serialize(
 		xml_serializer, CDXLTokens::GetDXLTokenStr(EdxltokenGPDBCastFuncId));
+	m_mdid_src_elemtype->Serialize(
+		xml_serializer,
+		CDXLTokens::GetDXLTokenStr(EdxltokenGPDBCastSrcElemType));
 
 	if (default_type_modifier != TypeModifier())
 	{

--- a/src/backend/gporca/libnaucrates/src/operators/CDXLOperatorFactory.cpp
+++ b/src/backend/gporca/libnaucrates/src/operators/CDXLOperatorFactory.cpp
@@ -947,18 +947,12 @@ CDXLOperatorFactory::MakeDXLArrayCoerceExpr(
 {
 	CMemoryPool *mp = dxl_memory_manager->Pmp();
 
-	IMDId *element_func = ExtractConvertAttrValueToMdId(
-		dxl_memory_manager, attrs, EdxltokenElementFunc,
-		EdxltokenScalarArrayCoerceExpr);
 	IMDId *mdid_type = ExtractConvertAttrValueToMdId(
 		dxl_memory_manager, attrs, EdxltokenTypeId,
 		EdxltokenScalarArrayCoerceExpr);
 	INT type_modifier = ExtractConvertAttrValueToInt(
 		dxl_memory_manager, attrs, EdxltokenTypeMod,
 		EdxltokenScalarArrayCoerceExpr, true, default_type_modifier);
-	BOOL is_explicit = ExtractConvertAttrValueToBool(
-		dxl_memory_manager, attrs, EdxltokenIsExplicit,
-		EdxltokenScalarArrayCoerceExpr);
 	ULONG coercion_form = ExtractConvertAttrValueToUlong(
 		dxl_memory_manager, attrs, EdxltokenCoercionForm,
 		EdxltokenScalarArrayCoerceExpr);
@@ -966,9 +960,9 @@ CDXLOperatorFactory::MakeDXLArrayCoerceExpr(
 												EdxltokenLocation,
 												EdxltokenScalarArrayCoerceExpr);
 
-	return GPOS_NEW(mp) CDXLScalarArrayCoerceExpr(
-		mp, element_func, mdid_type, type_modifier, is_explicit,
-		(EdxlCoercionForm) coercion_form, location);
+	return GPOS_NEW(mp)
+		CDXLScalarArrayCoerceExpr(mp, mdid_type, type_modifier,
+								  (EdxlCoercionForm) coercion_form, location);
 }
 
 //---------------------------------------------------------------------------

--- a/src/backend/gporca/libnaucrates/src/operators/CDXLScalarArrayCoerceExpr.cpp
+++ b/src/backend/gporca/libnaucrates/src/operators/CDXLScalarArrayCoerceExpr.cpp
@@ -33,15 +33,11 @@ using namespace gpdxl;
 //
 //---------------------------------------------------------------------------
 CDXLScalarArrayCoerceExpr::CDXLScalarArrayCoerceExpr(
-	CMemoryPool *mp, IMDId *coerce_func_mdid, IMDId *result_type_mdid,
-	INT type_modifier, BOOL is_explicit, EdxlCoercionForm coerce_format,
-	INT location)
+	CMemoryPool *mp, IMDId *result_type_mdid, INT type_modifier,
+	EdxlCoercionForm coerce_format, INT location)
 	: CDXLScalarCoerceBase(mp, result_type_mdid, type_modifier, coerce_format,
-						   location),
-	  m_coerce_func_mdid(coerce_func_mdid),
-	  m_explicit(is_explicit)
+						   location)
 {
-	GPOS_ASSERT(nullptr != coerce_func_mdid);
 }
 
 //---------------------------------------------------------------------------
@@ -75,8 +71,6 @@ CDXLScalarArrayCoerceExpr::SerializeToDXL(CXMLSerializer *xml_serializer,
 	xml_serializer->OpenElement(
 		CDXLTokens::GetDXLTokenStr(EdxltokenNamespacePrefix), element_name);
 
-	m_coerce_func_mdid->Serialize(
-		xml_serializer, CDXLTokens::GetDXLTokenStr(EdxltokenElementFunc));
 	GetResultTypeMdId()->Serialize(xml_serializer,
 								   CDXLTokens::GetDXLTokenStr(EdxltokenTypeId));
 
@@ -85,8 +79,6 @@ CDXLScalarArrayCoerceExpr::SerializeToDXL(CXMLSerializer *xml_serializer,
 		xml_serializer->AddAttribute(
 			CDXLTokens::GetDXLTokenStr(EdxltokenTypeMod), TypeModifier());
 	}
-	xml_serializer->AddAttribute(
-		CDXLTokens::GetDXLTokenStr(EdxltokenIsExplicit), m_explicit);
 	xml_serializer->AddAttribute(
 		CDXLTokens::GetDXLTokenStr(EdxltokenCoercionForm),
 		(ULONG) GetDXLCoercionForm());

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerMDArrayCoerceCast.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerMDArrayCoerceCast.cpp
@@ -101,10 +101,15 @@ CParseHandlerMDArrayCoerceCast::StartElement(
 		m_parse_handler_mgr->GetDXLMemoryManager(), attrs, EdxltokenLocation,
 		EdxltokenGPDBArrayCoerceCast);
 
+	IMDId *mdid_src_elemtype =
+		CDXLOperatorFactory::ExtractConvertAttrValueToMdId(
+			m_parse_handler_mgr->GetDXLMemoryManager(), attrs,
+			EdxltokenGPDBCastSrcElemType, EdxltokenGPDBArrayCoerceCast);
+
 	m_imd_obj = GPOS_NEW(m_mp) CMDArrayCoerceCastGPDB(
 		m_mp, mdid, mdname, mdid_src, mdid_dest, is_binary_coercible,
 		mdid_cast_func, coerce_path_type, type_modifier, is_explicit,
-		dxl_coercion_form, location);
+		dxl_coercion_form, location, mdid_src_elemtype);
 }
 
 // invoked by Xerces to process a closing tag

--- a/src/backend/gporca/libnaucrates/src/parser/CParseHandlerScalarArrayCoerceExpr.cpp
+++ b/src/backend/gporca/libnaucrates/src/parser/CParseHandlerScalarArrayCoerceExpr.cpp
@@ -85,7 +85,15 @@ CParseHandlerScalarArrayCoerceExpr::StartElement(
 				m_parse_handler_mgr, this);
 		m_parse_handler_mgr->ActivateParseHandler(child_parse_handler);
 
+		// parse handler for exprelem scalar node
+		CParseHandlerBase *exprelem_parse_handler =
+			CParseHandlerFactory::GetParseHandler(
+				m_mp, CDXLTokens::XmlstrToken(EdxltokenScalar),
+				m_parse_handler_mgr, this);
+		m_parse_handler_mgr->ActivateParseHandler(exprelem_parse_handler);
+
 		// store parse handler
+		this->Append(exprelem_parse_handler);
 		this->Append(child_parse_handler);
 	}
 	else
@@ -121,12 +129,15 @@ CParseHandlerScalarArrayCoerceExpr::EndElement(
 		GPOS_RAISE(gpdxl::ExmaDXL, gpdxl::ExmiDXLUnexpectedTag,
 				   str->GetBuffer());
 	}
-	GPOS_ASSERT(1 == this->Length());
+	GPOS_ASSERT(2 == this->Length());
 
 	// add constructed child from child parse handlers
 	CParseHandlerScalarOp *child_parse_handler =
 		dynamic_cast<CParseHandlerScalarOp *>((*this)[0]);
 	AddChildFromParseHandler(child_parse_handler);
+	CParseHandlerScalarOp *elemexpr_parse_handler =
+		dynamic_cast<CParseHandlerScalarOp *>((*this)[1]);
+	AddChildFromParseHandler(elemexpr_parse_handler);
 
 	// deactivate handler
 	m_parse_handler_mgr->DeactivateHandler();

--- a/src/backend/gporca/libnaucrates/src/xml/dxltokens.cpp
+++ b/src/backend/gporca/libnaucrates/src/xml/dxltokens.cpp
@@ -688,6 +688,7 @@ CDXLTokens::Init(CMemoryPool *mp)
 		{EdxltokenGPDBCastSrcType, GPOS_WSZ_LIT("SourceTypeId")},
 		{EdxltokenGPDBCastDestType, GPOS_WSZ_LIT("DestinationTypeId")},
 		{EdxltokenGPDBCastFuncId, GPOS_WSZ_LIT("CastFuncId")},
+		{EdxltokenGPDBCastSrcElemType, GPOS_WSZ_LIT("SourceElemTypeId")},
 		{EdxltokenGPDBCastCoercePathType, GPOS_WSZ_LIT("CoercePathType")},
 		{EdxltokenGPDBArrayCoerceCast, GPOS_WSZ_LIT("ArrayCoerceCast")},
 

--- a/src/backend/gporca/libnaucrates/src/xml/dxltokens.cpp
+++ b/src/backend/gporca/libnaucrates/src/xml/dxltokens.cpp
@@ -275,7 +275,6 @@ CDXLTokens::Init(CMemoryPool *mp)
 		{EdxltokenTypeMod, GPOS_WSZ_LIT("TypeModifier")},
 		{EdxltokenCoercionForm, GPOS_WSZ_LIT("CoercionForm")},
 		{EdxltokenLocation, GPOS_WSZ_LIT("Location")},
-		{EdxltokenElementFunc, GPOS_WSZ_LIT("ElementFunc")},
 		{EdxltokenIsExplicit, GPOS_WSZ_LIT("IsExplicit")},
 
 		{EdxltokenJoinType, GPOS_WSZ_LIT("JoinType")},

--- a/src/backend/gporca/server/src/unittest/gpopt/minidump/CCastTest.cpp
+++ b/src/backend/gporca/server/src/unittest/gpopt/minidump/CCastTest.cpp
@@ -35,6 +35,7 @@ const CHAR *rgszCastMdpFiles[] = {
 	"../data/dxl/minidump/CoerceViaIO.mdp",
 	"../data/dxl/minidump/ArrayCoerceCast.mdp",
 	"../data/dxl/minidump/SimpleArrayCoerceCast.mdp",
+	"../data/dxl/minidump/ArrayCoerceImplicitCast.mdp",
 	"../data/dxl/minidump/EstimateJoinRowsForCastPredicates.mdp",
 	"../data/dxl/minidump/HashJoinOnRelabeledColumns.mdp",
 	"../data/dxl/minidump/Correlation-With-Casting-1.mdp",

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -14459,3 +14459,21 @@ explain select * from ts_tbl where ts = to_timestamp('99991231'::text, 'YYYYMMDD
  Optimizer: Postgres query optimizer
 (4 rows)
 
+-- Test ORCA support for implicit array coerce cast
+create table array_coerce_foo (a int, b varchar(2)[]);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table array_coerce_bar (a int, b varchar(10)[]);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into array_coerce_bar values (1, ARRAY['abcde']);
+explain insert into array_coerce_foo select * from array_coerce_bar;
+                                 QUERY PLAN                                  
+-----------------------------------------------------------------------------
+ Insert on array_coerce_foo  (cost=0.00..654.00 rows=16533 width=36)
+   ->  Seq Scan on array_coerce_bar  (cost=0.00..654.00 rows=16533 width=36)
+ Optimizer: Postgres query optimizer
+(3 rows)
+
+insert into array_coerce_foo select * from array_coerce_bar;
+ERROR:  value too long for type character varying(2)  (seg1 127.0.0.1:7003 pid=55908)

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -14460,6 +14460,8 @@ explain select * from ts_tbl where ts = to_timestamp('99991231'::text, 'YYYYMMDD
 (4 rows)
 
 -- Test ORCA support for implicit array coerce cast
+-- ORCA should generate a valid plan passing along the cast function as part of ArrayCoerceExpr
+-- While execution thin insert query fails due to the mismatch of column length.
 create table array_coerce_foo (a int, b varchar(2)[]);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -14576,3 +14576,21 @@ explain select * from ts_tbl where ts = to_timestamp('99991231'::text, 'YYYYMMDD
  Optimizer: Pivotal Optimizer (GPORCA)
 (4 rows)
 
+-- Test ORCA support for implicit array coerce cast
+create table array_coerce_foo (a int, b varchar(2)[]);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table array_coerce_bar (a int, b varchar(10)[]);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into array_coerce_bar values (1, ARRAY['abcde']);
+explain insert into array_coerce_foo select * from array_coerce_bar;
+                               QUERY PLAN                                
+-------------------------------------------------------------------------
+ Insert on array_coerce_foo  (cost=0.00..431.02 rows=1 width=12)
+   ->  Seq Scan on array_coerce_bar  (cost=0.00..431.00 rows=1 width=12)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(3 rows)
+
+insert into array_coerce_foo select * from array_coerce_bar;
+ERROR:  value too long for type character varying(2)  (seg1 127.0.0.1:7003 pid=51460)

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -14577,6 +14577,8 @@ explain select * from ts_tbl where ts = to_timestamp('99991231'::text, 'YYYYMMDD
 (4 rows)
 
 -- Test ORCA support for implicit array coerce cast
+-- ORCA should generate a valid plan passing along the cast function as part of ArrayCoerceExpr
+-- While execution thin insert query fails due to the mismatch of column length.
 create table array_coerce_foo (a int, b varchar(2)[]);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.

--- a/src/test/regress/sql/gporca.sql
+++ b/src/test/regress/sql/gporca.sql
@@ -3490,6 +3490,8 @@ analyze ts_tbl;
 explain select * from ts_tbl where ts = to_timestamp('99991231'::text, 'YYYYMMDD'::text);
 
 -- Test ORCA support for implicit array coerce cast
+-- ORCA should generate a valid plan passing along the cast function as part of ArrayCoerceExpr
+-- While execution thin insert query fails due to the mismatch of column length.
 create table array_coerce_foo (a int, b varchar(2)[]);
 create table array_coerce_bar (a int, b varchar(10)[]);
 

--- a/src/test/regress/sql/gporca.sql
+++ b/src/test/regress/sql/gporca.sql
@@ -3489,6 +3489,13 @@ insert into ts_tbl select to_timestamp('99991231'::text, 'YYYYMMDD'::text) from 
 analyze ts_tbl;
 explain select * from ts_tbl where ts = to_timestamp('99991231'::text, 'YYYYMMDD'::text);
 
+-- Test ORCA support for implicit array coerce cast
+create table array_coerce_foo (a int, b varchar(2)[]);
+create table array_coerce_bar (a int, b varchar(10)[]);
+
+insert into array_coerce_bar values (1, ARRAY['abcde']);
+explain insert into array_coerce_foo select * from array_coerce_bar;
+insert into array_coerce_foo select * from array_coerce_bar;
 
 -- start_ignore
 DROP SCHEMA orca CASCADE;


### PR DESCRIPTION
As part of GP6 and older versions, ArrayCoerceExpr struct held the
information of the cast function as function oid and a boolean
isExplicit for representing if its an explicit or implicit cast.
Starting PG11 this was changed to an Expr elemexpr.
This PR updates the representation of CDXLScalarArrayCoerceExpr in
ORCA so that we can correctly roundtrip the Expr *elemexpr.
Thus addressing the 2 FIXME's that are removed as part of this PR.
