### PR TITLE
Modified table entry for alter column type and aoco tables

### DIFF
--- a/gpdb-doc/markdown/ref_guide/sql_commands/ALTER_TABLE.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/ALTER_TABLE.html.md
@@ -432,7 +432,7 @@ This table lists the `ALTER TABLE` operations that require a table rewrite when 
 
 |Operation \(See Note\)|Append-Optimized, Column-Oriented|Append-Optimized|Heap|
 |----------------------|---------------------------------|----------------|----|
-|`ALTER COLUMN TYPE`|Yes|Yes|Yes|
+|`ALTER COLUMN TYPE`|No|Yes|Yes|
 |`ADD COLUMN`|No|Yes|Yes|
 | `ALTER COLUMN SET ENCODING`|Yes|N/A|N/A|
 

--- a/gpdb-doc/markdown/ref_guide/sql_commands/ALTER_TABLE.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/ALTER_TABLE.html.md
@@ -201,7 +201,7 @@ Although you can specify the table's access method using the <code>appendoptimiz
 
     > **Note** GPORCA supports collation only when all columns in the query use the same collation. If columns in the query use different collations, then Greenplum uses the Postgres Planner.
 
-    Changing a column data type requires a table rewrite. For information about table rewrites performed by `ALTER TABLE`, see [Notes](#section5).
+    Changing a column data type may require a table rewrite. For information about table rewrites performed by `ALTER TABLE`, see [Notes](#section5).
 
 -   **SET/DROP DEFAULT** — Sets or removes the default value for a column. Default values only apply in subsequent `INSERT` or `UPDATE` commands; they do not cause rows already in the table to change.
 -   **SET/DROP NOT NULL** — Changes whether a column is marked to allow null values or to reject null values. You can only use `SET NOT NULL` when the column contains no null values.


### PR DESCRIPTION
Documentation update after https://github.com/greenplum-db/gpdb/pull/15344
`ALTER COLUMN TYPE` does not require a table rewrite for AO/CO tables.
