### PR TITLE
Fixing up pg_stat test: segment_id -> gp_segment_id

### DIFF
--- a/src/test/regress/expected/pg_stat.out
+++ b/src/test/regress/expected/pg_stat.out
@@ -164,7 +164,7 @@ select c.relname from gp_statio_user_sequences s join pg_class c on s.relid = c.
 (0 rows)
 
 -- "sys" views:
--- for cluster-wise views, just test output of one segment.
+-- for cluster-wide views, just test output of one segment.
 -- also take a fixed part of the aux table names to avoid different column length because of OIDs.
 select c.relname as aorelname, substring(s.relname, 1, 9) as aoauxrelname 
 from pg_stat_sys_tables s 
@@ -185,7 +185,7 @@ select c.relname as aorelname, substring(s.relname, 1, 9) as aoauxrelname
 from gp_stat_sys_tables s 
 join pg_appendonly a on s.relid = a.segrelid or s.relid = a.blkdirrelid or s.relid = a.visimaprelid 
 join pg_class c on a.relid = c.oid 
-where c.relname like 'pg_stat_%' and segment_id = 0;
+where c.relname like 'pg_stat_%' and gp_segment_id = 0;
  aorelname  | aoauxrelname 
 ------------+--------------
  pg_stat_ao | pg_aoblkd
@@ -215,7 +215,7 @@ select c.relname as aorelname, substring(s.relname, 1, 9) as aoauxrelname
 from gp_stat_xact_sys_tables s 
 join pg_appendonly a on s.relid = a.segrelid or s.relid = a.blkdirrelid or s.relid = a.visimaprelid 
 join pg_class c on a.relid = c.oid 
-where c.relname like 'pg_stat_%' and segment_id = 0;
+where c.relname like 'pg_stat_%' and gp_segment_id = 0;
  aorelname  | aoauxrelname 
 ------------+--------------
  pg_stat_ao | pg_aoblkd
@@ -245,7 +245,7 @@ select c.relname as aorelname, substring(s.relname, 1, 9) as aoauxrelname
 from gp_statio_sys_tables s 
 join pg_appendonly a on s.relid = a.segrelid or s.relid = a.blkdirrelid or s.relid = a.visimaprelid 
 join pg_class c on a.relid = c.oid 
-where c.relname like 'pg_stat_%' and segment_id = 0;
+where c.relname like 'pg_stat_%' and gp_segment_id = 0;
  aorelname  | aoauxrelname 
 ------------+--------------
  pg_stat_ao | pg_aoblkd
@@ -273,7 +273,7 @@ select c.relname as aorelname, substring(s.relname, 1, 9) as aoauxrelname
 from gp_stat_sys_indexes s 
 join pg_appendonly a on s.relid = a.segrelid or s.relid = a.blkdirrelid or s.relid = a.visimaprelid 
 join pg_class c on a.relid = c.oid 
-where c.relname like 'pg_stat_%' and segment_id = 0;
+where c.relname like 'pg_stat_%' and gp_segment_id = 0;
  aorelname  | aoauxrelname 
 ------------+--------------
  pg_stat_ao | pg_aoblkd
@@ -299,7 +299,7 @@ select c.relname as aorelname, substring(s.relname, 1, 9) as aoauxrelname
 from gp_statio_sys_indexes s 
 join pg_appendonly a on s.relid = a.segrelid or s.relid = a.blkdirrelid or s.relid = a.visimaprelid 
 join pg_class c on a.relid = c.oid 
-where c.relname like 'pg_stat_%' and segment_id = 0;
+where c.relname like 'pg_stat_%' and gp_segment_id = 0;
  aorelname  | aoauxrelname 
 ------------+--------------
  pg_stat_ao | pg_aoblkd

--- a/src/test/regress/sql/pg_stat.sql
+++ b/src/test/regress/sql/pg_stat.sql
@@ -79,7 +79,7 @@ select c.relname from pg_statio_user_sequences s join pg_class c on s.relid = c.
 select c.relname from gp_statio_user_sequences s join pg_class c on s.relid = c.oid where c.relkind in ('o', 'b', 'M');
 
 -- "sys" views:
--- for cluster-wise views, just test output of one segment.
+-- for cluster-wide views, just test output of one segment.
 -- also take a fixed part of the aux table names to avoid different column length because of OIDs.
 select c.relname as aorelname, substring(s.relname, 1, 9) as aoauxrelname 
 from pg_stat_sys_tables s 
@@ -91,7 +91,7 @@ select c.relname as aorelname, substring(s.relname, 1, 9) as aoauxrelname
 from gp_stat_sys_tables s 
 join pg_appendonly a on s.relid = a.segrelid or s.relid = a.blkdirrelid or s.relid = a.visimaprelid 
 join pg_class c on a.relid = c.oid 
-where c.relname like 'pg_stat_%' and segment_id = 0;
+where c.relname like 'pg_stat_%' and gp_segment_id = 0;
 
 select c.relname as aorelname, substring(s.relname, 1, 9) as aoauxrelname 
 from pg_stat_xact_sys_tables s 
@@ -103,7 +103,7 @@ select c.relname as aorelname, substring(s.relname, 1, 9) as aoauxrelname
 from gp_stat_xact_sys_tables s 
 join pg_appendonly a on s.relid = a.segrelid or s.relid = a.blkdirrelid or s.relid = a.visimaprelid 
 join pg_class c on a.relid = c.oid 
-where c.relname like 'pg_stat_%' and segment_id = 0;
+where c.relname like 'pg_stat_%' and gp_segment_id = 0;
 
 select c.relname as aorelname, substring(s.relname, 1, 9) as aoauxrelname 
 from pg_statio_sys_tables s 
@@ -115,7 +115,7 @@ select c.relname as aorelname, substring(s.relname, 1, 9) as aoauxrelname
 from gp_statio_sys_tables s 
 join pg_appendonly a on s.relid = a.segrelid or s.relid = a.blkdirrelid or s.relid = a.visimaprelid 
 join pg_class c on a.relid = c.oid 
-where c.relname like 'pg_stat_%' and segment_id = 0;
+where c.relname like 'pg_stat_%' and gp_segment_id = 0;
 
 select c.relname as aorelname, substring(s.relname, 1, 9) as aoauxrelname 
 from pg_stat_sys_indexes s 
@@ -127,7 +127,7 @@ select c.relname as aorelname, substring(s.relname, 1, 9) as aoauxrelname
 from gp_stat_sys_indexes s 
 join pg_appendonly a on s.relid = a.segrelid or s.relid = a.blkdirrelid or s.relid = a.visimaprelid 
 join pg_class c on a.relid = c.oid 
-where c.relname like 'pg_stat_%' and segment_id = 0;
+where c.relname like 'pg_stat_%' and gp_segment_id = 0;
 
 select c.relname as aorelname, substring(s.relname, 1, 9) as aoauxrelname 
 from pg_statio_sys_indexes s 
@@ -139,7 +139,7 @@ select c.relname as aorelname, substring(s.relname, 1, 9) as aoauxrelname
 from gp_statio_sys_indexes s 
 join pg_appendonly a on s.relid = a.segrelid or s.relid = a.blkdirrelid or s.relid = a.visimaprelid 
 join pg_class c on a.relid = c.oid 
-where c.relname like 'pg_stat_%' and segment_id = 0;
+where c.relname like 'pg_stat_%' and gp_segment_id = 0;
 
 -- no AO/CO aux tables are sequence, but test it anyway 
 select c.relname from pg_statio_sys_sequences s join pg_class c on s.relid = c.oid where c.relkind in ('o', 'b', 'M');


### PR DESCRIPTION
Commit 580250229423c5475dcf6fed90a00ab89cf82072 added a few test cases in pg_stat which used outdated column name 'segment_id' in pg_stat_sys_tables. The original PR https://github.com/greenplum-db/gpdb/pull/15306 was not rebased before merge which resulted this error. Also added a missed comment to address in the original PR ("cluster-wise" to "cluster-wide").

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
