### PR TITLE
Ignore "optimizer = 'off'" in 'explain_format' test.

### DIFF
--- a/src/test/regress/expected/explain_format.out
+++ b/src/test/regress/expected/explain_format.out
@@ -127,6 +127,9 @@ EXPLAIN (ANALYZE) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.appl
 -- m/Memory used: \d+/
 -- s/Memory used: \d+/Memory used: ###/
 -- end_matchsubs
+-- start_matchignore
+-- m/\s*optimizer:\s*"off"/
+-- end_matchignore
 -- Check Explain YAML output
 EXPLAIN (FORMAT YAML) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;
 QUERY PLAN
@@ -300,7 +303,6 @@ QUERY PLAN
   Optimizer: "Postgres query optimizer"
   Settings: 
     cpu_index_tuple_cost: "0.1"
-    optimizer: "off"
     random_page_cost: "1"
 (1 row)
 -- ignore variable JIT gucs which can be showed when SETTINGS=ON
@@ -347,7 +349,6 @@ QUERY PLAN
   Settings: 
     cpu_index_tuple_cost: "0.1"
     random_page_cost: "1"
-    optimizer: "off"
 (1 row)
 --- Check Explain Analyze YAML output that include the slices information
 -- explain_processing_off
@@ -561,12 +562,14 @@ QUERY PLAN
 -- m/Executor Memory: \d+kB  Segments: 3  Max: \d+kB \(segment \d\)/
 -- s/Executor Memory: \d+kB  Segments: 3  Max: \d+kB \(segment \d\)/Executor Memory: ###kB  Segments: 3  Max: ##kB (segment #)/
 -- end_matchsubs
--- ignore the variable JIT gucs in Settings (unaligned mode + text format)
+-- ignore the variable JIT gucs and "optimizer = 'off'" in Settings (unaligned mode + text format)
 -- start_matchsubs
 -- m/^Settings:.*/
 -- s/,?\s*jit\w*\s*=\s*[^,\n]+//g
 -- m/^Settings:.*/
 -- s/^Settings:[,\s]*/Settings: /
+-- m/^Settings:.*/
+-- s/,?\s*optimizer\w*\s*=\s*'off'//g
 -- end_matchsubs
 --- Check explain analyze sort infomation in verbose mode
 EXPLAIN (ANALYZE, VERBOSE) SELECT * from boxes ORDER BY apple_id;
@@ -583,7 +586,7 @@ Gather Motion 3:1  (slice1; segments: 3)  (cost=2197.59..3301.17 rows=77900 widt
         ->  Seq Scan on public.boxes  (cost=0.00..293.67 rows=25967 width=12) (actual time=0.000..0.010 rows=0 loops=1)
               Output: id, apple_id, location_id
 Optimizer: Postgres query optimizer
-Settings: cpu_index_tuple_cost = '0.1', optimizer = 'off', random_page_cost = '1'
+Settings: cpu_index_tuple_cost = '0.1', random_page_cost = '1'
 Planning Time: 0.397 ms
   (slice0)    Executor memory: 40K bytes.
   (slice1)    Executor memory: 59K bytes avg x 3 workers, 59K bytes max (seg0).  Work_mem: 59K bytes max.

--- a/src/test/regress/expected/explain_format_optimizer.out
+++ b/src/test/regress/expected/explain_format_optimizer.out
@@ -125,6 +125,9 @@ EXPLAIN (ANALYZE) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.appl
 -- m/Memory used: \d+/
 -- s/Memory used: \d+/Memory used: ###/
 -- end_matchsubs
+-- start_matchignore
+-- m/\s*optimizer:\s*"off"/
+-- end_matchignore
 -- Check Explain YAML output
 EXPLAIN (FORMAT YAML) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;
 QUERY PLAN
@@ -509,12 +512,14 @@ QUERY PLAN
 -- m/Executor Memory: \d+kB  Segments: 3  Max: \d+kB \(segment \d\)/
 -- s/Executor Memory: \d+kB  Segments: 3  Max: \d+kB \(segment \d\)/Executor Memory: ###kB  Segments: 3  Max: ##kB (segment #)/
 -- end_matchsubs
--- ignore the variable JIT gucs in Settings (unaligned mode + text format)
+-- ignore the variable JIT gucs and "optimizer = 'off'" in Settings (unaligned mode + text format)
 -- start_matchsubs
 -- m/^Settings:.*/
 -- s/,?\s*jit\w*\s*=\s*[^,\n]+//g
 -- m/^Settings:.*/
 -- s/^Settings:[,\s]*/Settings: /
+-- m/^Settings:.*/
+-- s/,?\s*optimizer\w*\s*=\s*'off'//g
 -- end_matchsubs
 --- Check explain analyze sort infomation in verbose mode
 EXPLAIN (ANALYZE, VERBOSE) SELECT * from boxes ORDER BY apple_id;

--- a/src/test/regress/sql/explain_format.sql
+++ b/src/test/regress/sql/explain_format.sql
@@ -82,6 +82,9 @@ EXPLAIN (ANALYZE) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.appl
 -- m/Memory used: \d+/
 -- s/Memory used: \d+/Memory used: ###/
 -- end_matchsubs
+-- start_matchignore
+-- m/\s*optimizer:\s*"off"/
+-- end_matchignore
 -- Check Explain YAML output
 EXPLAIN (FORMAT YAML) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.apple_id LEFT JOIN box_locations ON box_locations.id = boxes.location_id;
 SET random_page_cost = 1;
@@ -101,12 +104,14 @@ EXPLAIN (ANALYZE, FORMAT YAML) SELECT * from boxes LEFT JOIN apples ON apples.id
 -- m/Executor Memory: \d+kB  Segments: 3  Max: \d+kB \(segment \d\)/
 -- s/Executor Memory: \d+kB  Segments: 3  Max: \d+kB \(segment \d\)/Executor Memory: ###kB  Segments: 3  Max: ##kB (segment #)/
 -- end_matchsubs
--- ignore the variable JIT gucs in Settings (unaligned mode + text format)
+-- ignore the variable JIT gucs and "optimizer = 'off'" in Settings (unaligned mode + text format)
 -- start_matchsubs
 -- m/^Settings:.*/
 -- s/,?\s*jit\w*\s*=\s*[^,\n]+//g
 -- m/^Settings:.*/
 -- s/^Settings:[,\s]*/Settings: /
+-- m/^Settings:.*/
+-- s/,?\s*optimizer\w*\s*=\s*'off'//g
 -- end_matchsubs
 --- Check explain analyze sort infomation in verbose mode
 EXPLAIN (ANALYZE, VERBOSE) SELECT * from boxes ORDER BY apple_id;


### PR DESCRIPTION
When explain queries, Greenplum prints non-default GUC parameters. However, when build Greenplum without ORCA, the default value for `'optimizer'` is `'off'`; when build Greenplum with ORCA, the default value is `'on'`. The explain_format test will fail in Greenplum w/o ORCA build. This patch helps fix it.

Failed test:

```diff
diff -I HINT: -I CONTEXT: -I GP_IGNORE: -U3 /home/v/workspace/gpdb7/src/test/regress/expected/explain_format.out /home/v/workspace/gpdb7/src/test/regress/results/explain_format.out
--- /home/v/workspace/gpdb7/src/test/regress/expected/explain_format.out        2023-04-19 14:09:17.475129547 +0800
+++ /home/v/workspace/gpdb7/src/test/regress/results/explain_format.out 2023-04-19 14:09:17.501796392 +0800
@@ -299,7 +299,6 @@
   Optimizer: "Postgres query optimizer"
   Settings:
     cpu_index_tuple_cost: "0.1"
-    optimizer: "off"
     random_page_cost: "1"
 (1 row)
 -- ignore variable JIT gucs which can be showed when SETTINGS=ON
@@ -347,7 +346,6 @@
   Settings:
     cpu_index_tuple_cost: "0.1"
     random_page_cost: "1"
-    optimizer: "off"
 (1 row)
 --- Check Explain Analyze YAML output that include the slices information
 -- explain_processing_off
@@ -585,7 +583,7 @@
         ->  Seq Scan on public.boxes  (cost=##.###..##.### rows=### width=###) (actual time=##.###..##.### rows=# loops=#)
               Output: id, apple_id, location_id
 Optimizer: Postgres query optimizer
-Settings: cpu_index_tuple_cost = '0.1', optimizer = 'off', random_page_cost = '1'
+Settings: cpu_index_tuple_cost = '0.1', random_page_cost = '1'
 Planning Time: ##.### ms
   (slice0)    Executor memory: (#####)K bytes.
   (slice1)    Executor memory: ####K bytes avg x #### workers, ####K bytes max (seg#).  Work_mem: ###K bytes max.
```

## Here are some reminders before you submit the pull request
- [x] Pass `make installcheck`
