### PR TITLE
Fix bug in pg_backup_archiver

### DIFF
--- a/src/bin/pg_dump/pg_backup_archiver.c
+++ b/src/bin/pg_dump/pg_backup_archiver.c
@@ -4885,7 +4885,7 @@ CloneArchive(ArchiveHandle *AH)
 	 * Connect our new clone object to the database, using the same connection
 	 * parameters used for the original connection.
 	 */
-	ConnectDatabase((Archive *) clone, &clone->public.ropt->cparams, true, &clone->public.ropt->binary_upgrade);
+	ConnectDatabase((Archive *) clone, &clone->public.ropt->cparams, true, clone->public.ropt->binary_upgrade);
 
 	/* re-establish fixed state */
 	if (AH->mode == archModeRead)


### PR DESCRIPTION
We're checking the address instead of the bool value for the binary_upgrade value. This will result in us always trying to connect in binary_upgrade mode.

Resolves

```
pg_backup_archiver.c:4888:94: warning: address of 'clone->public.ropt->binary_upgrade' will always evaluate to 'true' [-Wpointer-bool-conversion]
        ConnectDatabase((Archive *) clone, &clone->public.ropt->cparams, true, &clone->public.ropt->binary_upgrade);
```