### PR TITLE
[6X] add movetoMutex to protect moveto* fields in PGPROC

### DIFF
--- a/src/backend/storage/ipc/procarray.c
+++ b/src/backend/storage/ipc/procarray.c
@@ -4946,10 +4946,9 @@ ResGroupSignalMoveQuery(int sessionId, void *slot, Oid groupId)
 		pid = proc->pid;
 		backendId = proc->backendId;
 
-		SpinLockAcquire(&proc->movetoMutex);
-
 		if (Gp_role == GP_ROLE_DISPATCH)
 		{
+			SpinLockAcquire(&proc->movetoMutex);
 			Assert(proc->movetoResSlot == NULL);
 			Assert(slot != NULL);
 			proc->movetoResSlot = slot;
@@ -4959,6 +4958,7 @@ ResGroupSignalMoveQuery(int sessionId, void *slot, Oid groupId)
 		}
 		else if (Gp_role == GP_ROLE_EXECUTE)
 		{
+			SpinLockAcquire(&proc->movetoMutex);
 			Assert(groupId != InvalidOid);
 			Assert(proc->movetoGroupId == InvalidOid);
 			proc->movetoGroupId = groupId;

--- a/src/backend/storage/lmgr/proc.c
+++ b/src/backend/storage/lmgr/proc.c
@@ -443,6 +443,7 @@ InitProcess(void)
 	MyProc->waitLock = NULL;
 	MyProc->waitProcLock = NULL;
 	MyProc->resSlot = NULL;
+	SpinLockInit(&MyProc->movetoMutex);
 	MyProc->movetoResSlot = NULL;
 	MyProc->movetoGroupId = InvalidOid;
 

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -4687,9 +4687,11 @@ HandleMoveResourceGroup(void)
 
 	if (Gp_role == GP_ROLE_DISPATCH)
 	{
+		SpinLockAcquire(&MyProc->movetoMutex);
 		slot = (ResGroupSlotData *)MyProc->movetoResSlot;
 		group = slot->group;
 		MyProc->movetoResSlot = NULL;
+		SpinLockRelease(&MyProc->movetoMutex);
 
 		/* unassign the old resource group and release the old slot */
 		UnassignResGroup(true);
@@ -4717,8 +4719,10 @@ HandleMoveResourceGroup(void)
 	}
 	else if (Gp_role == GP_ROLE_EXECUTE)
 	{
+		SpinLockAcquire(&MyProc->movetoMutex);
 		Oid groupId = MyProc->movetoGroupId;
 		MyProc->movetoGroupId = InvalidOid;
+		SpinLockRelease(&MyProc->movetoMutex);
 
 		slot = sessionGetSlot();
 		Assert(slot != NULL);

--- a/src/include/storage/proc.h
+++ b/src/include/storage/proc.h
@@ -187,6 +187,7 @@ struct PGPROC
 	void		*resSlot;	/* the resource group slot granted.
 							 * NULL indicates the resource group is
 							 * locked for drop. */
+	slock_t		movetoMutex;	/* spinlock to protect moveto* fields below */
 	void		*movetoResSlot; /* the resource group slot move to, valid only on QD */
 	Oid			movetoGroupId;  /* the resource group id move to */
 


### PR DESCRIPTION
Actually, this PR is part of #13481, cause I consider that PR is too complicated
to merge directly, I decided to divide them and keep the core fix.

This PR is quite simple, just added a SpinLock to protect the field of `movetoResSlot`
and `movetoGroupId`, nothing else to say.

----

Since the race condition is not easy to add a test case to trigger it every time. If we
add inject_fault every time we find a race condition, the codes will be bulky.
