### PR TITLE
Fix coordinator crash in MPPnoticeReceiver

### DIFF
--- a/src/backend/cdb/dispatcher/cdbconn.c
+++ b/src/backend/cdb/dispatcher/cdbconn.c
@@ -518,7 +518,7 @@ struct QENotice
 	char		sqlstate[6];
 	char		severity[10];
 	char	   *file;
-	char		line[10];
+	char	   *line;
 	char	   *func;
 	char	   *message;
 	char	   *detail;
@@ -550,9 +550,9 @@ MPPnoticeReceiver(void *arg, const PGresult *res)
 	int			elevel = INFO;
 	char	   *sqlstate = "00000";
 	char	   *severity = "WARNING";
-	char	   *file = "";
+	char	   *file = NULL;
 	char	   *line = NULL;
-	char	   *func = "";
+	char	   *func = NULL;
 	char		message[1024];
 	char	   *detail = NULL;
 	char	   *hint = NULL;
@@ -646,6 +646,7 @@ MPPnoticeReceiver(void *arg, const PGresult *res)
 		uint64		size;
 		char	   *bufptr;
 		int			file_len;
+		int			line_len;
 		int			func_len;
 		int			message_len;
 		int			detail_len;
@@ -674,6 +675,7 @@ MPPnoticeReceiver(void *arg, const PGresult *res)
 
 		size = offsetof(QENotice, buf);
 		SIZE_VARLEN_FIELD(file);
+		SIZE_VARLEN_FIELD(line);
 		SIZE_VARLEN_FIELD(func);
 		SIZE_VARLEN_FIELD(message);
 		SIZE_VARLEN_FIELD(detail);
@@ -714,7 +716,7 @@ MPPnoticeReceiver(void *arg, const PGresult *res)
 		strlcpy(notice->sqlstate, sqlstate, sizeof(notice->sqlstate));
 		strlcpy(notice->severity, severity, sizeof(notice->severity));
 		COPY_VARLEN_FIELD(file);
-		strlcpy(notice->line, line, sizeof(notice->line));
+		COPY_VARLEN_FIELD(line);
 		COPY_VARLEN_FIELD(func);
 		COPY_VARLEN_FIELD(message);
 		COPY_VARLEN_FIELD(detail);


### PR DESCRIPTION
Duplicate of PR https://github.com/greenplum-db/gpdb/pull/15372 which I accidentally closed.
Should fix https://github.com/greenplum-db/gpdb/issues/15194

Reason: line number is initialized with NULL and we get segfault when copying it to QENotice.
Solution: initialize line with "0". We cannot use emptry string here like we do in other places because line is supposed to be an integer number. But "0" should be fine, as valid line numbers start with one. Negative integers are risky as there might be tools expecting it being positive.

I don't have an idea how to test or even reproduce it, tough. Have only seen it happening in production twice so far.