### PR TITLE
Inclusive language

### DIFF
--- a/contrib/postgres_fdw/postgres_fdw.h
+++ b/contrib/postgres_fdw/postgres_fdw.h
@@ -78,7 +78,7 @@ typedef struct PgFdwRelationInfo
 	bool		use_remote_estimate;
 	Cost		fdw_startup_cost;
 	Cost		fdw_tuple_cost;
-	List	   *shippable_extensions;	/* OIDs of whitelisted extensions */
+	List	   *shippable_extensions;	/* OIDs of shippable extensions */
 
 	/* Cached catalog information. */
 	ForeignTable *table;

--- a/contrib/postgres_fdw/shippable.c
+++ b/contrib/postgres_fdw/shippable.c
@@ -7,7 +7,7 @@
  * data types are shippable to a remote server for execution --- that is,
  * do they exist and have the same behavior remotely as they do locally?
  * Built-in objects are generally considered shippable.  Other objects can
- * be shipped if they are white-listed by the user.
+ * be shipped if they are declared as such by the user.
  *
  * Note: there are additional filter rules that prevent shipping mutable
  * functions or functions using nonportable collations.  Those considerations
@@ -113,7 +113,7 @@ InitializeShippableCache(void)
  *
  * Right now "shippability" is exclusively a function of whether the object
  * belongs to an extension declared by the user.  In the future we could
- * additionally have a whitelist of functions/operators declared one at a time.
+ * additionally have a list of functions/operators declared one at a time.
  */
 static bool
 lookup_shippable(Oid objectId, Oid classId, PgFdwRelationInfo *fpinfo)

--- a/src/backend/access/hash/hashvalidate.c
+++ b/src/backend/access/hash/hashvalidate.c
@@ -305,7 +305,7 @@ check_hash_func_signature(Oid funcid, int16 amprocnum, Oid argtype)
 		 * that are different from but physically compatible with the opclass
 		 * datatype.  In some of these cases, even a "binary coercible" check
 		 * fails because there's no relevant cast.  For the moment, fix it by
-		 * having a whitelist of allowed cases.  Test the specific function
+		 * having a list of allowed cases.  Test the specific function
 		 * identity, not just its input type, because hashvarlena() takes
 		 * INTERNAL and allowing any such function seems too scary.
 		 */

--- a/src/backend/access/transam/parallel.c
+++ b/src/backend/access/transam/parallel.c
@@ -73,7 +73,7 @@
 #define PARALLEL_KEY_SESSION_DSM			UINT64CONST(0xFFFFFFFFFFFF000A)
 #define PARALLEL_KEY_REINDEX_STATE			UINT64CONST(0xFFFFFFFFFFFF000B)
 #define PARALLEL_KEY_RELMAPPER_STATE		UINT64CONST(0xFFFFFFFFFFFF000C)
-#define PARALLEL_KEY_ENUMBLACKLIST			UINT64CONST(0xFFFFFFFFFFFF000D)
+#define PARALLEL_KEY_UNCOMMITTEDENUMS		UINT64CONST(0xFFFFFFFFFFFF000D)
 
 /* Fixed-size parallel state. */
 typedef struct FixedParallelState
@@ -204,7 +204,7 @@ InitializeParallelDSM(ParallelContext *pcxt)
 	Size		tstatelen = 0;
 	Size		reindexlen = 0;
 	Size		relmapperlen = 0;
-	Size		enumblacklistlen = 0;
+	Size		uncommittedenumslen = 0;
 	Size		segsize = 0;
 	int			i;
 	FixedParallelState *fps;
@@ -261,8 +261,8 @@ InitializeParallelDSM(ParallelContext *pcxt)
 		shm_toc_estimate_chunk(&pcxt->estimator, reindexlen);
 		relmapperlen = EstimateRelationMapSpace();
 		shm_toc_estimate_chunk(&pcxt->estimator, relmapperlen);
-		enumblacklistlen = EstimateEnumBlacklistSpace();
-		shm_toc_estimate_chunk(&pcxt->estimator, enumblacklistlen);
+		uncommittedenumslen = EstimateUncommittedEnumsSpace();
+		shm_toc_estimate_chunk(&pcxt->estimator, uncommittedenumslen);
 		/* If you add more chunks here, you probably need to add keys. */
 		shm_toc_estimate_keys(&pcxt->estimator, 10);
 
@@ -341,7 +341,7 @@ InitializeParallelDSM(ParallelContext *pcxt)
 		char	   *error_queue_space;
 		char	   *session_dsm_handle_space;
 		char	   *entrypointstate;
-		char	   *enumblacklistspace;
+		char	   *uncommittedenumsspace;
 		Size		lnamelen;
 
 		/* Serialize shared libraries we have loaded. */
@@ -399,11 +399,12 @@ InitializeParallelDSM(ParallelContext *pcxt)
 		shm_toc_insert(pcxt->toc, PARALLEL_KEY_RELMAPPER_STATE,
 					   relmapperspace);
 
-		/* Serialize enum blacklist state. */
-		enumblacklistspace = shm_toc_allocate(pcxt->toc, enumblacklistlen);
-		SerializeEnumBlacklist(enumblacklistspace, enumblacklistlen);
-		shm_toc_insert(pcxt->toc, PARALLEL_KEY_ENUMBLACKLIST,
-					   enumblacklistspace);
+		/* Serialize uncommitted enum state. */
+		uncommittedenumsspace = shm_toc_allocate(pcxt->toc,
+												 uncommittedenumslen);
+		SerializeUncommittedEnums(uncommittedenumsspace, uncommittedenumslen);
+		shm_toc_insert(pcxt->toc, PARALLEL_KEY_UNCOMMITTEDENUMS,
+					   uncommittedenumsspace);
 
 		/* Allocate space for worker information. */
 		pcxt->worker = palloc0(sizeof(ParallelWorkerInfo) * pcxt->nworkers);
@@ -1234,7 +1235,7 @@ ParallelWorkerMain(Datum main_arg)
 	char	   *tstatespace;
 	char	   *reindexspace;
 	char	   *relmapperspace;
-	char	   *enumblacklistspace;
+	char	   *uncommittedenumsspace;
 	StringInfoData msgbuf;
 	char	   *session_dsm_handle_space;
 	Snapshot	tsnapshot;
@@ -1434,10 +1435,10 @@ ParallelWorkerMain(Datum main_arg)
 	relmapperspace = shm_toc_lookup(toc, PARALLEL_KEY_RELMAPPER_STATE, false);
 	RestoreRelationMap(relmapperspace);
 
-	/* Restore enum blacklist. */
-	enumblacklistspace = shm_toc_lookup(toc, PARALLEL_KEY_ENUMBLACKLIST,
-										false);
-	RestoreEnumBlacklist(enumblacklistspace);
+	/* Restore uncommitted enums. */
+	uncommittedenumsspace = shm_toc_lookup(toc, PARALLEL_KEY_UNCOMMITTEDENUMS,
+										   false);
+	RestoreUncommittedEnums(uncommittedenumsspace);
 
 	/* Attach to the leader's serializable transaction, if SERIALIZABLE. */
 	AttachSerializableXact(fps->serializable_xact_handle);

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -590,11 +590,12 @@ typedef struct XLogCtlInsert
 	char		pad[PG_CACHE_LINE_SIZE];
 
 	/*
-	 * fullPageWrites is the master copy used by all backends to determine
-	 * whether to write full-page to WAL, instead of using process-local one.
-	 * This is required because, when full_page_writes is changed by SIGHUP,
-	 * we must WAL-log it before it actually affects WAL-logging by backends.
-	 * Checkpointer sets at startup or after SIGHUP.
+	 * fullPageWrites is the authoritative value used by all backends to
+	 * determine whether to write full-page image to WAL. This shared value,
+	 * instead of the process-local fullPageWrites, is required because, when
+	 * full_page_writes is changed by SIGHUP, we must WAL-log it before it
+	 * actually affects WAL-logging by backends.  Checkpointer sets at startup
+	 * or after SIGHUP.
 	 *
 	 * To read these fields, you must hold an insertion lock. To modify them,
 	 * you must hold ALL the locks.
@@ -8806,8 +8807,9 @@ GetRedoRecPtr(void)
 
 	/*
 	 * The possibly not up-to-date copy in XlogCtl is enough. Even if we
-	 * grabbed a WAL insertion lock to read the master copy, someone might
-	 * update it just after we've released the lock.
+	 * grabbed a WAL insertion lock to read the authoritative value in
+	 * Insert->RedoRecPtr, someone might update it just after we've released
+	 * the lock.
 	 */
 	SpinLockAcquire(&XLogCtl->info_lck);
 	ptr = XLogCtl->RedoRecPtr;

--- a/src/backend/catalog/index.c
+++ b/src/backend/catalog/index.c
@@ -4054,7 +4054,7 @@ reindex_relation(Oid relid, int flags, int options)
 
 	/*
 	 * If the relation has a secondary toast rel, reindex that too while we
-	 * still hold the lock on the master table.
+	 * still hold the lock on the main table.
 	 */
 	if ((flags & REINDEX_REL_PROCESS_TOAST) && OidIsValid(toast_relid))
 		result |= reindex_relation(toast_relid, flags, options);

--- a/src/backend/catalog/pg_enum.c
+++ b/src/backend/catalog/pg_enum.c
@@ -42,10 +42,11 @@
  * committed; otherwise, they might get into indexes where we can't clean
  * them up, and then if the transaction rolls back we have a broken index.
  * (See comments for check_safe_enum_use() in enum.c.)  Values created by
- * EnumValuesCreate are *not* blacklisted; we assume those are created during
- * CREATE TYPE, so they can't go away unless the enum type itself does.
+ * EnumValuesCreate are *not* entered into the table; we assume those are
+ * created during CREATE TYPE, so they can't go away unless the enum type
+ * itself does.
  */
-static HTAB *enum_blacklist = NULL;
+static HTAB *uncommitted_enums = NULL;
 
 static void RenumberEnumType(Relation pg_enum, HeapTuple *existing, int nelems);
 static int	sort_order_cmp(const void *p1, const void *p2);
@@ -200,10 +201,10 @@ EnumValuesDelete(Oid enumTypeOid)
 }
 
 /*
- * Initialize the enum blacklist for this transaction.
+ * Initialize the uncommitted enum table for this transaction.
  */
 static void
-init_enum_blacklist(void)
+init_uncommitted_enums(void)
 {
 	HASHCTL		hash_ctl;
 
@@ -211,10 +212,10 @@ init_enum_blacklist(void)
 	hash_ctl.keysize = sizeof(Oid);
 	hash_ctl.entrysize = sizeof(Oid);
 	hash_ctl.hcxt = TopTransactionContext;
-	enum_blacklist = hash_create("Enum value blacklist",
-								 32,
-								 &hash_ctl,
-								 HASH_ELEM | HASH_BLOBS | HASH_CONTEXT);
+	uncommitted_enums = hash_create("Uncommitted enums",
+									32,
+									&hash_ctl,
+									HASH_ELEM | HASH_BLOBS | HASH_CONTEXT);
 }
 
 /*
@@ -499,12 +500,12 @@ restart:
 
 	table_close(pg_enum, RowExclusiveLock);
 
-	/* Set up the blacklist hash if not already done in this transaction */
-	if (enum_blacklist == NULL)
-		init_enum_blacklist();
+	/* Set up the uncommitted enum table if not already done in this tx */
+	if (uncommitted_enums == NULL)
+		init_uncommitted_enums();
 
-	/* Add the new value to the blacklist */
-	(void) hash_search(enum_blacklist, &newOid, HASH_ENTER, NULL);
+	/* Add the new value to the table */
+	(void) hash_search(uncommitted_enums, &newOid, HASH_ENTER, NULL);
 }
 
 
@@ -593,19 +594,19 @@ RenameEnumLabel(Oid enumTypeOid,
 
 
 /*
- * Test if the given enum value is on the blacklist
+ * Test if the given enum value is in the table of uncommitted enums.
  */
 bool
-EnumBlacklisted(Oid enum_id)
+EnumUncommitted(Oid enum_id)
 {
 	bool		found;
 
-	/* If we've made no blacklist table, all values are safe */
-	if (enum_blacklist == NULL)
+	/* If we've made no uncommitted table, all values are safe */
+	if (uncommitted_enums == NULL)
 		return false;
 
 	/* Else, is it in the table? */
-	(void) hash_search(enum_blacklist, &enum_id, HASH_FIND, &found);
+	(void) hash_search(uncommitted_enums, &enum_id, HASH_FIND, &found);
 	return found;
 }
 
@@ -617,11 +618,11 @@ void
 AtEOXact_Enum(void)
 {
 	/*
-	 * Reset the blacklist table, as all our enum values are now committed.
+	 * Reset the uncommitted table, as all our enum values are now committed.
 	 * The memory will go away automatically when TopTransactionContext is
 	 * freed; it's sufficient to clear our pointer.
 	 */
-	enum_blacklist = NULL;
+	uncommitted_enums = NULL;
 }
 
 
@@ -700,12 +701,12 @@ sort_order_cmp(const void *p1, const void *p2)
 }
 
 Size
-EstimateEnumBlacklistSpace(void)
+EstimateUncommittedEnumsSpace(void)
 {
 	size_t		entries;
 
-	if (enum_blacklist)
-		entries = hash_get_num_entries(enum_blacklist);
+	if (uncommitted_enums)
+		entries = hash_get_num_entries(uncommitted_enums);
 	else
 		entries = 0;
 
@@ -714,7 +715,7 @@ EstimateEnumBlacklistSpace(void)
 }
 
 void
-SerializeEnumBlacklist(void *space, Size size)
+SerializeUncommittedEnums(void *space, Size size)
 {
 	Oid		   *serialized = (Oid *) space;
 
@@ -722,15 +723,15 @@ SerializeEnumBlacklist(void *space, Size size)
 	 * Make sure the hash table hasn't changed in size since the caller
 	 * reserved the space.
 	 */
-	Assert(size == EstimateEnumBlacklistSpace());
+	Assert(size == EstimateUncommittedEnumsSpace());
 
 	/* Write out all the values from the hash table, if there is one. */
-	if (enum_blacklist)
+	if (uncommitted_enums)
 	{
 		HASH_SEQ_STATUS status;
 		Oid		   *value;
 
-		hash_seq_init(&status, enum_blacklist);
+		hash_seq_init(&status, uncommitted_enums);
 		while ((value = (Oid *) hash_seq_search(&status)))
 			*serialized++ = *value;
 	}
@@ -746,11 +747,11 @@ SerializeEnumBlacklist(void *space, Size size)
 }
 
 void
-RestoreEnumBlacklist(void *space)
+RestoreUncommittedEnums(void *space)
 {
 	Oid		   *serialized = (Oid *) space;
 
-	Assert(!enum_blacklist);
+	Assert(!uncommitted_enums);
 
 	/*
 	 * As a special case, if the list is empty then don't even bother to
@@ -761,9 +762,9 @@ RestoreEnumBlacklist(void *space)
 		return;
 
 	/* Read all the values into a new hash table. */
-	init_enum_blacklist();
+	init_uncommitted_enums();
 	do
 	{
-		hash_search(enum_blacklist, serialized++, HASH_ENTER, NULL);
+		hash_search(uncommitted_enums, serialized++, HASH_ENTER, NULL);
 	} while (OidIsValid(*serialized));
 }

--- a/src/backend/catalog/toasting.c
+++ b/src/backend/catalog/toasting.c
@@ -375,8 +375,8 @@ create_toast_table(Relation rel, Oid toastOid, Oid toastIndexOid,
 	table_close(class_rel, RowExclusiveLock);
 
 	/*
-	 * Register dependency from the toast table to the master, so that the
-	 * toast table will be deleted if the master is.  Skip this in bootstrap
+	 * Register dependency from the toast table to the main, so that the
+	 * toast table will be deleted if the main is.  Skip this in bootstrap
 	 * mode.
 	 */
 	if (!IsBootstrapProcessingMode())

--- a/src/backend/commands/vacuum.c
+++ b/src/backend/commands/vacuum.c
@@ -2529,7 +2529,7 @@ vacuum_rel(Oid relid, RangeVar *relation, VacuumParams *params,
 
 	/*
 	 * If the relation has a secondary toast rel, vacuum that too while we
-	 * still hold the session lock on the master table.  Note however that
+	 * still hold the session lock on the main table.  Note however that
 	 * "analyze" will not get done on the toast table.  This is good, because
 	 * the toaster always uses hardcoded index access and statistics are
 	 * totally unimportant for toast relations.
@@ -2604,7 +2604,7 @@ vacuum_rel(Oid relid, RangeVar *relation, VacuumParams *params,
 	}
 
 	/*
-	 * Now release the session-level lock on the master table.
+	 * Now release the session-level lock on the main table.
 	 */
 	UnlockRelationIdForSession(&onerelid, lmode);
 

--- a/src/backend/executor/nodeDynamicBitmapIndexscan.c
+++ b/src/backend/executor/nodeDynamicBitmapIndexscan.c
@@ -13,7 +13,7 @@
  *
  * This is somewhat different from a Dynamic Index Scan. While a Dynamic
  * Index Scan needs to iterate through all the active partitions, a Dynamic
- * Bitmap Index Scan works as a slave of a dynamic Bitmap Heap Scan node
+ * Bitmap Index Scan works as a subsidiary of a dynamic Bitmap Heap Scan node
  * above it. It scans only one partition at a time, but the partition
  * can change at a rescan.
  *

--- a/src/backend/libpq/hba.c
+++ b/src/backend/libpq/hba.c
@@ -145,7 +145,7 @@ static List *tokenize_inc_file(List *tokens, const char *outer_filename,
 static bool parse_hba_auth_opt(char *name, char *val, HbaLine *hbaline,
 							   int elevel, char **err_msg);
 static bool verify_option_list_length(List *options, const char *optionname,
-									  List *masters, const char *mastername, int line_num);
+									  List *comparelist, const char *comparename, int line_num);
 static ArrayType *gethba_options(HbaLine *hba);
 static void fill_hba_line(Tuplestorestate *tuple_store, TupleDesc tupdesc,
 						  int lineno, HbaLine *hba, const char *err_msg);
@@ -1659,11 +1659,13 @@ parse_hba_line(TokenizedLine *tok_line, int elevel)
 
 
 static bool
-verify_option_list_length(List *options, const char *optionname, List *masters, const char *mastername, int line_num)
+verify_option_list_length(List *options, const char *optionname,
+						  List *comparelist, const char *comparename,
+						  int line_num)
 {
 	if (list_length(options) == 0 ||
 		list_length(options) == 1 ||
-		list_length(options) == list_length(masters))
+		list_length(options) == list_length(comparelist))
 		return true;
 
 	ereport(LOG,
@@ -1671,8 +1673,8 @@ verify_option_list_length(List *options, const char *optionname, List *masters, 
 			 errmsg("the number of %s (%d) must be 1 or the same as the number of %s (%d)",
 					optionname,
 					list_length(options),
-					mastername,
-					list_length(masters)
+					comparename,
+					list_length(comparelist)
 					),
 			 errcontext("line %d of configuration file \"%s\"",
 						line_num, HbaFileName)));

--- a/src/backend/libpq/pqcomm.c
+++ b/src/backend/libpq/pqcomm.c
@@ -745,8 +745,8 @@ Setup_AF_UNIX(char *sock_path)
  *		server port.  Set port->sock to the FD of the new connection.
  *
  * ASSUME: that this doesn't need to be non-blocking because
- *		the Postmaster uses select() to tell when the server master
- *		socket is ready for accept().
+ *		the Postmaster uses select() to tell when the socket is ready for
+ *		accept().
  *
  * RETURNS: STATUS_OK or STATUS_ERROR
  */

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -2088,7 +2088,7 @@ inheritance_planner(PlannerInfo *root)
 	else
 	{
 		/*
-		 * Put back the final adjusted rtable into the master copy of the
+		 * Put back the final adjusted rtable into the original copy of the
 		 * Query.  (We mustn't do this if we found no non-excluded children,
 		 * since we never saved an adjusted rtable at all.)
 		 */
@@ -2097,7 +2097,7 @@ inheritance_planner(PlannerInfo *root)
 		root->simple_rel_array = save_rel_array;
 		root->append_rel_array = save_append_rel_array;
 
-		/* Must reconstruct master's simple_rte_array, too */
+		/* Must reconstruct original's simple_rte_array, too */
 		root->simple_rte_array = (RangeTblEntry **)
 			palloc0((list_length(final_rtable) + 1) * sizeof(RangeTblEntry *));
 		rti = 1;

--- a/src/backend/snowball/README
+++ b/src/backend/snowball/README
@@ -22,8 +22,8 @@ At least on Linux, no platform-specific adjustment is needed.
 Postgres' files under src/backend/snowball/libstemmer/ and
 src/include/snowball/libstemmer/ are taken directly from the Snowball
 files, with only some minor adjustments of file inclusions.  Note
-that most of these files are in fact derived files, not master source.
-The master sources are in the Snowball language, and are built using
+that most of these files are in fact derived files, not original source.
+The original sources are in the Snowball language, and are built using
 the Snowball-to-C compiler that is also part of the Snowball project.
 We choose to include the derived files in the PostgreSQL distribution
 because most installations will not have the Snowball compiler available.

--- a/src/backend/utils/adt/enum.c
+++ b/src/backend/utils/adt/enum.c
@@ -83,12 +83,12 @@ check_safe_enum_use(HeapTuple enumval_tup)
 		return;
 
 	/*
-	 * Check if the enum value is blacklisted.  If not, it's safe, because it
+	 * Check if the enum value is uncommitted.  If not, it's safe, because it
 	 * was made during CREATE TYPE AS ENUM and can't be shorter-lived than its
 	 * owning type.  (This'd also be false for values made by other
 	 * transactions; but the previous tests should have handled all of those.)
 	 */
-	if (!EnumBlacklisted(en->oid))
+	if (!EnumUncommitted(en->oid))
 		return;
 
 	/*

--- a/src/backend/utils/adt/lockfuncs.c
+++ b/src/backend/utils/adt/lockfuncs.c
@@ -914,7 +914,7 @@ pg_isolation_test_session_is_blocked(PG_FUNCTION_ARGS)
 	/*
 	 * Check if blocked_pid is waiting for a safe snapshot.  We could in
 	 * theory check the resulting array of blocker PIDs against the
-	 * interesting PIDs whitelist, but since there is no danger of autovacuum
+	 * interesting PIDs list, but since there is no danger of autovacuum
 	 * blocking GetSafeSnapshot there seems to be no point in expending cycles
 	 * on allocating a buffer and searching for overlap; so it's presently
 	 * sufficient for the isolation tester's purposes to use a single element

--- a/src/backend/utils/time/snapmgr.c
+++ b/src/backend/utils/time/snapmgr.c
@@ -2429,9 +2429,9 @@ RestoreSnapshot(char *start_address)
  * the declaration for PGPROC.
  */
 void
-RestoreTransactionSnapshot(Snapshot snapshot, void *master_pgproc)
+RestoreTransactionSnapshot(Snapshot snapshot, void *source_pgproc)
 {
-	SetTransactionSnapshot(snapshot, NULL, InvalidPid, master_pgproc);
+	SetTransactionSnapshot(snapshot, NULL, InvalidPid, source_pgproc);
 }
 
 /*

--- a/src/include/catalog/pg_enum.h
+++ b/src/include/catalog/pg_enum.h
@@ -56,10 +56,10 @@ extern void AddEnumLabel(Oid enumTypeOid, const char *newVal,
 						 bool skipIfExists);
 extern void RenameEnumLabel(Oid enumTypeOid,
 							const char *oldVal, const char *newVal);
-extern bool EnumBlacklisted(Oid enum_id);
-extern Size EstimateEnumBlacklistSpace(void);
-extern void SerializeEnumBlacklist(void *space, Size size);
-extern void RestoreEnumBlacklist(void *space);
+extern bool EnumUncommitted(Oid enum_id);
+extern Size EstimateUncommittedEnumsSpace(void);
+extern void SerializeUncommittedEnums(void *space, Size size);
+extern void RestoreUncommittedEnums(void *space);
 extern void AtEOXact_Enum(void);
 
 #endif							/* PG_ENUM_H */

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -524,7 +524,7 @@ typedef struct ResultRelInfo
 /* ----------------
  *	  EState information
  *
- * Master working state for an Executor invocation
+ * Working state for an Executor invocation
  * ----------------
  */
 typedef struct EState

--- a/src/include/utils/snapmgr.h
+++ b/src/include/utils/snapmgr.h
@@ -164,6 +164,6 @@ extern bool HistoricSnapshotActive(void);
 extern Size EstimateSnapshotSpace(Snapshot snapshot);
 extern void SerializeSnapshot(Snapshot snapshot, char *start_address);
 extern Snapshot RestoreSnapshot(char *start_address);
-extern void RestoreTransactionSnapshot(Snapshot snapshot, void *master_pgproc);
+extern void RestoreTransactionSnapshot(Snapshot snapshot, void *source_pgproc);
 
 #endif							/* SNAPMGR_H */

--- a/src/pl/plpgsql/src/expected/plpgsql_trap.out
+++ b/src/pl/plpgsql/src/expected/plpgsql_trap.out
@@ -186,15 +186,15 @@ NOTICE:  should see this only if -100 fits in smallint
 --
 -- test foreign key error trapping
 --
-create temp table master(f1 int primary key);
-create temp table slave(f1 int references master deferrable);
-insert into master values(1);
-insert into slave values(1);
-insert into slave values(2);	-- fails
+create temp table root(f1 int primary key);
+create temp table leaf(f1 int references root deferrable);
+insert into root values(1);
+insert into leaf values(1);
+insert into leaf values(2);	-- fails
 create function trap_foreign_key(int) returns int as $$
 begin
 	begin	-- start a subtransaction
-		insert into slave values($1);
+		insert into leaf values($1);
 	exception
 		when foreign_key_violation then
 			raise notice 'caught foreign_key_violation';

--- a/src/pl/plpgsql/src/sql/plpgsql_trap.sql
+++ b/src/pl/plpgsql/src/sql/plpgsql_trap.sql
@@ -127,18 +127,18 @@ select test_variable_storage();
 -- test foreign key error trapping
 --
 
-create temp table master(f1 int primary key);
+create temp table root(f1 int primary key);
 
-create temp table slave(f1 int references master deferrable);
+create temp table leaf(f1 int references root deferrable);
 
-insert into master values(1);
-insert into slave values(1);
-insert into slave values(2);	-- fails
+insert into root values(1);
+insert into leaf values(1);
+insert into leaf values(2);	-- fails
 
 create function trap_foreign_key(int) returns int as $$
 begin
 	begin	-- start a subtransaction
-		insert into slave values($1);
+		insert into leaf values($1);
 	exception
 		when foreign_key_violation then
 			raise notice 'caught foreign_key_violation';

--- a/src/pl/tcl/pltcl.c
+++ b/src/pl/tcl/pltcl.c
@@ -431,9 +431,9 @@ _PG_init(void)
 	 * stdout and stderr on DeleteInterp
 	 ************************************************************/
 	if ((pltcl_hold_interp = Tcl_CreateInterp()) == NULL)
-		elog(ERROR, "could not create master Tcl interpreter");
+		elog(ERROR, "could not create dummy Tcl interpreter");
 	if (Tcl_Init(pltcl_hold_interp) == TCL_ERROR)
-		elog(ERROR, "could not initialize master Tcl interpreter");
+		elog(ERROR, "could not initialize dummy Tcl interpreter");
 
 	/************************************************************
 	 * Create the hash table for working interpreters
@@ -488,14 +488,14 @@ pltcl_init_interp(pltcl_interp_desc *interp_desc, Oid prolang, bool pltrusted)
 	char		interpname[32];
 
 	/************************************************************
-	 * Create the Tcl interpreter as a slave of pltcl_hold_interp.
+	 * Create the Tcl interpreter subsidiary to pltcl_hold_interp.
 	 * Note: Tcl automatically does Tcl_Init in the untrusted case,
 	 * and it's not wanted in the trusted case.
 	 ************************************************************/
-	snprintf(interpname, sizeof(interpname), "slave_%u", interp_desc->user_id);
+	snprintf(interpname, sizeof(interpname), "subsidiary_%u", interp_desc->user_id);
 	if ((interp = Tcl_CreateSlave(pltcl_hold_interp, interpname,
 								  pltrusted ? 1 : 0)) == NULL)
-		elog(ERROR, "could not create slave Tcl interpreter");
+		elog(ERROR, "could not create subsidiary Tcl interpreter");
 
 	/************************************************************
 	 * Initialize the query hash table associated with interpreter

--- a/src/tools/pgindent/pgindent
+++ b/src/tools/pgindent/pgindent
@@ -54,12 +54,12 @@ $excludes ||= "$code_base/src/tools/pgindent/exclude_file_patterns"
 # some names we want to treat like typedefs, e.g. "bool" (which is a macro
 # according to <stdbool.h>), and may include some names we don't want
 # treated as typedefs, although various headers that some builds include
-# might make them so.  For the moment we just hardwire a whitelist of names
-# to add and a blacklist of names to remove; eventually this may need to be
+# might make them so.  For the moment we just hardwire a list of names
+# to add and a list of names to exclude; eventually this may need to be
 # easier to configure.  Note that the typedefs need trailing newlines.
-my @whitelist = ("bool\n");
+my @additional = ("bool\n");
 
-my %blacklist = map { +"$_\n" => 1 } qw(
+my %excluded = map { +"$_\n" => 1 } qw(
   ANY FD_SET U abs allocfunc boolean date digit ilist interval iterator other
   pointer printfunc reference string timestamp type wrap
 );
@@ -134,11 +134,11 @@ sub load_typedefs
 		}
 	}
 
-	# add whitelisted entries
-	push(@typedefs, @whitelist);
+	# add additional entries
+	push(@typedefs, @additional);
 
-	# remove blacklisted entries
-	@typedefs = grep { !$blacklist{$_} } @typedefs;
+	# remove excluded entries
+	@typedefs = grep { !$excluded{$_} } @typedefs;
 
 	# write filtered typedefs
 	my $filter_typedefs_fh = new File::Temp(TEMPLATE => "pgtypedefXXXXX");


### PR DESCRIPTION
Backport multiple commits removing uninclusive terms listed below.  Manually remove all additional uses of those terms.

This PR removes all remaining in-tree uses of the terms:
- slave
- blacklist
- whitelist

A follow-up PR will reduce uses of the term "master", to the extent practically possible.

Backports: 
* b0d184e99f047204a43a81be79f2f3d0c8f29867 -- removes some usages of "master" and "slave" from code/tests/comments
* 800714dab76275efefd2f55b0b64126e44d9269e -- removes some usages of "master" and "slave" from tests
* 845d9e66c9cae80eec290de914c819980968a9c2 -- removes some usages of "master" and "slave" from tests
* 845d9e66c9cae80eec290de914c819980968a9c2 -- removes usages of "whitelist" from comments
* 40710e085fd56e2f75c422efb6e500cff5afa4ec -- removes some usages of "whitelist" and "blacklist" from tests
* c237042ca6bc5b6b1184678268e2aaf5b5102fb2 -- removes some usages of "blacklist" from code/comments

GPDB-Only Commits:
* 800714dab76275efefd2f55b0b64126e44d9269e -- removes usages of "slave" from tests