### PR TITLE
Fix a flakiness in test gpdispatch

### DIFF
--- a/gpcontrib/gp_inject_fault/README
+++ b/gpcontrib/gp_inject_fault/README
@@ -142,3 +142,7 @@ many backends, such as in parallel regress tests.
 
 * Be sure to "reset" all fault points at the end of a test that
 associates actions with them.
+
+* We let some background process ignore all but a few faults. If one wants
+to test fault injection in background processese, add the exception in
+checkBgProcessSkipFault().

--- a/gpcontrib/gp_inject_fault/gp_inject_fault--1.0.sql
+++ b/gpcontrib/gp_inject_fault/gp_inject_fault--1.0.sql
@@ -3,6 +3,7 @@
 -- complain if script is sourced in psql, rather than via CREATE EXTENSION
 \echo Use "CREATE EXTENSION gp_fault_inject" to load this file. \quit
 
+-- NOTE: we let some background process ignore all but a few faults (check checkBgProcessSkipFault()).
 CREATE FUNCTION @extschema@.gp_inject_fault(
   faultname text,
   type text,

--- a/src/backend/cdb/cdbdtxrecovery.c
+++ b/src/backend/cdb/cdbdtxrecovery.c
@@ -67,6 +67,11 @@ static void doAbortInDoubt(char *gid);
 static bool doNotifyCommittedInDoubt(char *gid);
 static void AbortOrphanedPreparedTransactions(void);
 
+bool IsDtxRecoveryProcess()
+{
+	return getpid() == DtxRecoveryPID();
+}
+
 static bool
 doNotifyCommittedInDoubt(char *gid)
 {

--- a/src/include/cdb/cdbtm.h
+++ b/src/include/cdb/cdbtm.h
@@ -284,6 +284,8 @@ extern slock_t *shmGxidGenLock;
 extern DistributedTransactionId *shmCommittedGxidArray;
 extern volatile int *shmNumCommittedGxacts;
 
+extern bool IsDtxRecoveryProcess(void);
+
 extern char *DtxStateToString(DtxState state);
 extern char *DtxProtocolCommandToString(DtxProtocolCommand command);
 extern char *DtxContextToString(DtxContext context);


### PR DESCRIPTION
The test was flaky with a diff:
```
@@ -25,8 +25,10 @@

 -- session1 will be fatal.
 1: select count(*) > 0 from gp_dist_random('pg_class');
-FATAL:  could not allocate resources for segworker communication
-server closed the connection unexpectedly
+ ?column?
+----------
+ t
+(1 row)
```

The reason is that the DTX recovery process got ahead and detonate it first...
```
2023-04-20 17:03:26.380438 UTC,,,p119165,th1614203008,,,,0,con2,,seg-1,,,,sx1,"LOG","00000","DTM Started",,,,,,,0,,"cdbdtxrecovery.c”,155
...
2023-04-20 17:04:18.184150 UTC,,,p119165,th1614203008,,,,0,con2,,seg-1,,,,sx1,"LOG","XX009","fault triggered, fault name:'make_dispatch_result_error' fault type:'skip' ",,,,,,,0,,"faultinjector.c",475,
2023-04-20 17:04:18.292955 UTC,,,p119165,th1614203008,,,,0,con2,,seg-1,,,,sx1,"FATAL","XX000","could not allocate resources for segworker communication
2023-04-20 17:04:18.293370 UTC,,,p119165,th1614203008,,,,0,con132,,seg-1,,,,sx1,"LOG","00000","The previous session was reset because its gang was disconnected (session id = 2). The new session id = 132
```
...so the intended backend didn't:
```
3-04-20 17:04:18.175160 UTC,"gpadmin","isolation2test",p122404,th1614203008,"[local]",,2023-04-20 17:04:18 UTC,0,con129,cmd2,seg-1,,,,sx1,"LOG","00000","injected fault 'make_dispatch_result_error' type 'skip'",,,,,,"select gp_inject_fault('make_dispatch_result_error', 'skip', dbid) from gp_segment_configuration where role = 'p' and content = -1;",0,,"faultinjector.c",1077,
...
2023-04-20 17:04:18.187420 UTC,"gpadmin","isolation2test",p122404,th1614203008,"[local]",,2023-04-20 17:04:18 UTC,0,con129,cmd3,seg-1,,,,sx1,"LOG","00000","statement: select count(*) > 0 from gp_dist_random('pg_class');",,,,,,,0,,"postgres.c",1729
```

Let's exclude the background worker from getting that fault.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
