### PR TITLE
Update VACUUM ANALYZE to correctly store relallvisible

### DIFF
--- a/src/backend/commands/vacuum.c
+++ b/src/backend/commands/vacuum.c
@@ -1557,8 +1557,8 @@ vac_update_relstats(Relation relation,
 		dirty = true;
 	}
 
-	elog(DEBUG2, "Vacuum oid=%u pages=%d tuples=%f",
-		 relid, pgcform->relpages, pgcform->reltuples);
+	elog(DEBUG2, "Vacuum oid=%u pages=%d tuples=%f visible pages=%d",
+		 relid, pgcform->relpages, pgcform->reltuples, pgcform->relallvisible);
 
 	/* Apply DDL updates, but not inside an outer transaction (see above) */
 

--- a/src/backend/commands/vacuum.c
+++ b/src/backend/commands/vacuum.c
@@ -1557,7 +1557,7 @@ vac_update_relstats(Relation relation,
 		dirty = true;
 	}
 
-	elog(DEBUG2, "Vacuum oid=%u pages=%d tuples=%f visible pages=%d",
+	elog(DEBUG2, "Vacuum oid=%u pages=%d tuples=%f allvisible pages=%d",
 		 relid, pgcform->relpages, pgcform->reltuples, pgcform->relallvisible);
 
 	/* Apply DDL updates, but not inside an outer transaction (see above) */

--- a/src/test/regress/expected/subselect_gp_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_optimizer.out
@@ -1749,24 +1749,25 @@ EXPLAIN select count(*) from
    where unique1 IN (select hundred from tenk1 b)) ss;
                                                           QUERY PLAN                                                           
 -------------------------------------------------------------------------------------------------------------------------------
- Finalize Aggregate  (cost=0.00..864.07 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..864.07 rows=1 width=8)
-         ->  Partial Aggregate  (cost=0.00..864.07 rows=1 width=8)
-               ->  Hash Join  (cost=0.00..864.07 rows=34 width=1)
-                     Hash Cond: tenk1.unique1 = tenk1_1.hundred
-                     ->  Seq Scan on tenk1  (cost=0.00..431.51 rows=3334 width=4)
-                     ->  Hash  (cost=431.94..431.94 rows=34 width=4)
+ Finalize Aggregate  (cost=0.00..431.98 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.98 rows=1 width=8)
+         ->  Partial Aggregate  (cost=0.00..431.98 rows=1 width=8)
+               ->  Nested Loop  (cost=0.00..431.98 rows=34 width=1)
+                     Join Filter: true
+                     ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.94 rows=100 width=4)
                            ->  GroupAggregate  (cost=0.00..431.94 rows=34 width=4)
-                                 Group Key: tenk1_1.hundred
+                                 Group Key: tenk1.hundred
                                  ->  Sort  (cost=0.00..431.94 rows=34 width=4)
-                                       Sort Key: tenk1_1.hundred
-                                       ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.94 rows=34 width=4)
-                                             Hash Key: tenk1_1.hundred
-                                             ->  Streaming HashAggregate  (cost=0.00..431.94 rows=34 width=4)
-                                                   Group Key: tenk1_1.hundred
-                                                   ->  Seq Scan on tenk1 tenk1_1  (cost=0.00..431.51 rows=3334 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.75.0
-(17 rows)
+                                       Sort Key: tenk1.hundred
+                                       ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.93 rows=34 width=4)
+                                             Hash Key: tenk1.hundred
+                                             ->  Streaming HashAggregate  (cost=0.00..431.93 rows=34 width=4)
+                                                   Group Key: tenk1.hundred
+                                                   ->  Seq Scan on tenk1  (cost=0.00..431.50 rows=3334 width=4)
+                     ->  Index Only Scan using tenk1_unique1 on tenk1 tenk1_1  (cost=0.00..0.04 rows=1 width=1)
+                           Index Cond: (unique1 = tenk1.hundred)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(18 rows)
 
 EXPLAIN select count(distinct ss.ten) from
   (select ten from tenk1 a
@@ -1806,24 +1807,25 @@ EXPLAIN select count(*) from
    where unique1 IN (select distinct hundred from tenk1 b)) ss;
                                                           QUERY PLAN                                                           
 -------------------------------------------------------------------------------------------------------------------------------
- Finalize Aggregate  (cost=0.00..864.07 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..864.07 rows=1 width=8)
-         ->  Partial Aggregate  (cost=0.00..864.07 rows=1 width=8)
-               ->  Hash Semi Join  (cost=0.00..864.07 rows=34 width=1)
-                     Hash Cond: tenk1.unique1 = tenk1_1.hundred
-                     ->  Seq Scan on tenk1  (cost=0.00..431.51 rows=3334 width=4)
-                     ->  Hash  (cost=431.94..431.94 rows=34 width=4)
+ Finalize Aggregate  (cost=0.00..431.98 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.98 rows=1 width=8)
+         ->  Partial Aggregate  (cost=0.00..431.98 rows=1 width=8)
+               ->  Nested Loop  (cost=0.00..431.98 rows=34 width=1)
+                     Join Filter: true
+                     ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.94 rows=100 width=4)
                            ->  GroupAggregate  (cost=0.00..431.94 rows=34 width=4)
-                                 Group Key: tenk1_1.hundred
+                                 Group Key: tenk1.hundred
                                  ->  Sort  (cost=0.00..431.94 rows=34 width=4)
-                                       Sort Key: tenk1_1.hundred
-                                       ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.94 rows=34 width=4)
-                                             Hash Key: tenk1_1.hundred
-                                             ->  Streaming HashAggregate  (cost=0.00..431.94 rows=34 width=4)
-                                                   Group Key: tenk1_1.hundred
-                                                   ->  Seq Scan on tenk1 tenk1_1  (cost=0.00..431.51 rows=3334 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 2.75.0
-(17 rows)
+                                       Sort Key: tenk1.hundred
+                                       ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.93 rows=34 width=4)
+                                             Hash Key: tenk1.hundred
+                                             ->  Streaming HashAggregate  (cost=0.00..431.93 rows=34 width=4)
+                                                   Group Key: tenk1.hundred
+                                                   ->  Seq Scan on tenk1  (cost=0.00..431.50 rows=3334 width=4)
+                     ->  Index Only Scan using tenk1_unique1 on tenk1 tenk1_1  (cost=0.00..0.04 rows=1 width=1)
+                           Index Cond: (unique1 = tenk1.hundred)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(18 rows)
 
 EXPLAIN select count(distinct ss.ten) from
   (select ten from tenk1 a

--- a/src/test/regress/expected/vacuum_gp.out
+++ b/src/test/regress/expected/vacuum_gp.out
@@ -270,6 +270,25 @@ VACUUM ANALYZE s_priv_test.t_priv_table;
 DROP SCHEMA s_priv_test CASCADE;
 NOTICE:  drop cascades to table s_priv_test.t_priv_table
 DROP ROLE r_priv_test;
+-- Check how reltuples/relpages/relallvisible are updated on a table, on
+-- VACUUM ANALYZE.
+set gp_autostats_mode='none';
+CREATE TABLE vacuum_gp (a int) DISTRIBUTED BY (a);
+INSERT INTO vacuum_gp SELECT i FROM generate_series(1, 12)i;
+SELECT relname, reltuples, relpages, relallvisible FROM pg_catalog.pg_class WHERE relname like 'vacuum_gp%';
+  relname  | reltuples | relpages | relallvisible 
+-----------+-----------+----------+---------------
+ vacuum_gp |         0 |        0 |             0
+(1 row)
+
+VACUUM ANALYZE vacuum_gp;
+SELECT relname, reltuples, relpages, relallvisible FROM pg_catalog.pg_class WHERE relname like 'vacuum_gp%';
+  relname  | reltuples | relpages | relallvisible 
+-----------+-----------+----------+---------------
+ vacuum_gp |        12 |        3 |             3
+(1 row)
+
+reset gp_autostats_mode;
 -- Check how reltuples/relpages are updated on a partitioned table, on
 -- VACUUM and ANALYZE.
 set gp_autostats_mode='none';

--- a/src/test/regress/sql/vacuum_gp.sql
+++ b/src/test/regress/sql/vacuum_gp.sql
@@ -190,6 +190,16 @@ VACUUM ANALYZE s_priv_test.t_priv_table;
 DROP SCHEMA s_priv_test CASCADE;
 DROP ROLE r_priv_test;
 
+-- Check how reltuples/relpages/relallvisible are updated on a table, on
+-- VACUUM ANALYZE.
+set gp_autostats_mode='none';
+CREATE TABLE vacuum_gp (a int) DISTRIBUTED BY (a);
+INSERT INTO vacuum_gp SELECT i FROM generate_series(1, 12)i;
+SELECT relname, reltuples, relpages, relallvisible FROM pg_catalog.pg_class WHERE relname like 'vacuum_gp%';
+VACUUM ANALYZE vacuum_gp;
+SELECT relname, reltuples, relpages, relallvisible FROM pg_catalog.pg_class WHERE relname like 'vacuum_gp%';
+reset gp_autostats_mode;
+
 -- Check how reltuples/relpages are updated on a partitioned table, on
 -- VACUUM and ANALYZE.
 set gp_autostats_mode='none';


### PR DESCRIPTION
After running VACUUM ANALYZE, the pg_class catalog does not contain
correct values for relallvisible. Underlying issue is that, unlike
standard Postgres nodes, GPDB coordinator nodes do not actually contain
data (e.g. visibility maps). Instead, relevant info is gathered through
dispatch requests.

In the case of VACUUM ANALYZE, the coordinator does dispatchVacuum()
from vacuum_rel() and aggregates the stats, but then checked an empty
visibility map and overwrote the result. This commit resolves the issue
by reading the info that was previously saved in the catalog.
