### PR TITLE
revert 6X: Don't scan dropped columns during ANALYZE for AOCO tables.

### DIFF
--- a/src/backend/commands/analyze.c
+++ b/src/backend/commands/analyze.c
@@ -1731,10 +1731,6 @@ acquire_sample_rows_ao(Relation onerel, int elevel,
 	int			numrows = 0;	/* # rows now in reservoir */
 	double		samplerows = 0; /* total # rows collected */
 	double		rowstoskip = -1;	/* -1 means not set yet */
-	int natts = RelationGetNumberOfAttributes(onerel);
-	bool *proj = palloc0(sizeof(bool) * natts);
-
-	Assert(RelationIsAppendOptimized(onerel));
 
 	/*
 	 * the append-only meta data should never be fetched with
@@ -1749,14 +1745,13 @@ acquire_sample_rows_ao(Relation onerel, int elevel,
 										  0, NULL);
 	else
 	{
-		/* Build column projection excluding dropped columns and pass to table scan */
-		for(int i = 0; i < natts; i++)
-		{
-			Form_pg_attribute attr = onerel->rd_att->attrs[i];
+		int			natts = RelationGetNumberOfAttributes(onerel);
+		bool	   *proj = (bool *) palloc(natts * sizeof(bool));
+		int			i;
 
-		if (!attr->attisdropped)
-				proj[i] = true;
-		}
+		for(i = 0; i < natts; i++)
+			proj[i] = true;
+
 		Assert(RelationIsAoCols(onerel));
 		aocsScanDesc = aocs_beginscan(onerel,
 									  SnapshotSelf,

--- a/src/test/regress/expected/analyze.out
+++ b/src/test/regress/expected/analyze.out
@@ -942,58 +942,6 @@ select attname, null_frac, avg_width, n_distinct from pg_stats where tablename =
  d       |         0 |         5 |         -1
 (3 rows)
 
--- Test ANALYZE on an aoco table does not scan a dropped column
--- First record total blocks scanned for the ANALYZE, then record blocks scanned after
--- issuing an ALTER TABLE .. DROP COLUMN.
-create table aoco_analyze_dropped_col(i int, j bigint, k int) WITH (appendonly=true, orientation=column);
-insert into aoco_analyze_dropped_col select 0, i, 1 from generate_series(1, 100000) i;
-select gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'skip', '', '', '', 1, -1, 0, dbid)
-    from gp_segment_configuration where content = 1 AND role = 'p';
- gp_inject_fault 
------------------
- Success:
-(1 row)
-
-analyze aoco_analyze_dropped_col;
-select gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'status', dbid)
-    from gp_segment_configuration where content = 1 AND role = 'p';
-                                                                                                                  gp_inject_fault                                                                                                                  
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Success: fault name:'AppendOnlyStorageRead_ReadNextBlock_success' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'triggered'  num times hit:'51' +
- 
-(1 row)
-
-select gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'reset', dbid)
-    from gp_segment_configuration WHERE content = 1 AND role = 'p';
- gp_inject_fault 
------------------
- Success:
-(1 row)
-
-alter table aoco_analyze_dropped_col drop column j;
-select gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'skip', '', '', '', 1, -1, 0, dbid)
-    from gp_segment_configuration WHERE content = 1 AND role = 'p';
- gp_inject_fault 
------------------
- Success:
-(1 row)
-
-analyze aoco_analyze_dropped_col;
-select gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'status', dbid)
-    from gp_segment_configuration WHERE content = 1 AND role = 'p';
-                                                                                                                  gp_inject_fault                                                                                                                  
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Success: fault name:'AppendOnlyStorageRead_ReadNextBlock_success' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'triggered'  num times hit:'26' +
- 
-(1 row)
-
-select gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'reset', dbid)
-    from gp_segment_configuration WHERE content = 1 AND role = 'p';
- gp_inject_fault 
------------------
- Success:
-(1 row)
-
 -- Test analyze without USAGE privilege on schema
 create schema test_ns;
 revoke all on schema test_ns from public;

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -75,9 +75,7 @@ test: gp_connections
 
 # bitmap_index triggers recovery, run it seperately
 test: bitmap_index
-# 'analyze' utilizes fault injectors so it needs to be in a group by itself
-test: analyze
-test: gp_dump_query_oids gp_owner_permission incremental_analyze
+test: gp_dump_query_oids analyze gp_owner_permission incremental_analyze
 test: indexjoin as_alias regex_gp gpparams with_clause transient_types gp_rules dispatch_encoding motion_gp
 # dispatch should always run seperately from other cases.
 test: dispatch

--- a/src/test/regress/sql/analyze.sql
+++ b/src/test/regress/sql/analyze.sql
@@ -6,9 +6,6 @@
 DROP DATABASE IF EXISTS testanalyze;
 CREATE DATABASE testanalyze;
 \c testanalyze
--- start_ignore
-CREATE EXTENSION IF NOT EXISTS gp_inject_fault;
--- end_ignore
 set client_min_messages='WARNING';
 -- Case 1: Analyzing root table with GUC optimizer_analyze_root_partition and optimizer_analyze_midlevel_partition set off should only populate stats for leaf tables
 set optimizer_analyze_root_partition=off;
@@ -472,37 +469,6 @@ insert into analyze_dropped_col values('a','bbb', repeat('x', 5000), 'dddd');
 alter table analyze_dropped_col drop column b;
 analyze analyze_dropped_col;
 select attname, null_frac, avg_width, n_distinct from pg_stats where tablename ='analyze_dropped_col';
-
--- Test ANALYZE on an aoco table does not scan a dropped column
--- First record total blocks scanned for the ANALYZE, then record blocks scanned after
--- issuing an ALTER TABLE .. DROP COLUMN.
-create table aoco_analyze_dropped_col(i int, j bigint, k int) WITH (appendonly=true, orientation=column);
-insert into aoco_analyze_dropped_col select 0, i, 1 from generate_series(1, 100000) i;
-
-select gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'skip', '', '', '', 1, -1, 0, dbid)
-    from gp_segment_configuration where content = 1 AND role = 'p';
-
-analyze aoco_analyze_dropped_col;
-
-select gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'status', dbid)
-    from gp_segment_configuration where content = 1 AND role = 'p';
-
-select gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'reset', dbid)
-    from gp_segment_configuration WHERE content = 1 AND role = 'p';
-
-alter table aoco_analyze_dropped_col drop column j;
-
-select gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'skip', '', '', '', 1, -1, 0, dbid)
-    from gp_segment_configuration WHERE content = 1 AND role = 'p';
-
-analyze aoco_analyze_dropped_col;
-
-select gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'status', dbid)
-    from gp_segment_configuration WHERE content = 1 AND role = 'p';
-
-select gp_inject_fault('AppendOnlyStorageRead_ReadNextBlock_success', 'reset', dbid)
-    from gp_segment_configuration WHERE content = 1 AND role = 'p';
-
 -- Test analyze without USAGE privilege on schema
 create schema test_ns;
 revoke all on schema test_ns from public;


### PR DESCRIPTION
This reverts commit 93acc3eaf3d6545ee7ba5f3b588b11ff22ce9d4e.

This commit introduced a regression when running ANALYZE on an AOCO table having dropped columns of a fixed length.

ExecCopySlotHeapTuple does conversion from virtual tuple to heap tuple and it's referencing the dropped columns, but the slot values have not been initialized for the dropped columns.

```
#0  0x00007f80581d54fb in raise () from /home/gpadmin/cases/ALL/345767/packcore-postgres.695501.181669.core/lib64/libpthread.so.0
#1  0x0000000000c03f90 in StandardHandlerForSigillSigsegvSigbus_OnMainThread (processName=<optimized out>, postgres_signal_arg=11) at elog.c:5581
#2  <signal handler called>
#3  heap_compute_data_size (tupleDesc=tupleDesc@entry=0x7f801c545df8, values=0x313fe78, isnull=isnull@entry=0x32e0ad8 "") at heaptuple.c:115
#4  0x00000000006c3e44 in heaptuple_form_to (tupleDescriptor=0x7f801c545df8, values=0x313fe78, isnull=0x32e0ad8 "", dst=dst@entry=0x0, dstlen=dstlen@entry=0x0)
    at heaptuple.c:759
#5  0x00000000008d57f3 in heap_form_tuple (isnull=<optimized out>, values=<optimized out>, tupleDescriptor=<optimized out>)
    at ../../../src/include/access/htup_details.h:806
#6  ExecCopySlotHeapTuple (slot=slot@entry=0x3147228) at execTuples.c:610
#7  0x0000000000824d8c in acquire_sample_rows_ao (elevel=14, totaldeadrows=0x7ffc1ad3af98, totalrows=0x7ffc1ad3af90, targrows=187, rows=0x3045dc8, 
    onerel=0x7f801c545ad8) at analyze.c:1800
```

