### PR TITLE
Fix pg_dump binary-upgrade dollar quoting on table names ending with $

### DIFF
--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -4693,7 +4693,7 @@ binary_upgrade_set_namespace_oid(Archive *fout, PQExpBuffer upgrade_buffer,
 	}
 	appendPQExpBuffer(upgrade_buffer,
 						"SELECT binary_upgrade_set_next_pg_namespace_oid('%u'::pg_catalog.oid, "
-						"$$%s$$::text);\n\n",
+						"$_GPDB_$%s$_GPDB_$::text);\n\n",
 						pg_namespace_oid, pg_nspname);
 	PQclear(upgrade_res);
 	destroyPQExpBuffer(upgrade_query);
@@ -4716,7 +4716,7 @@ binary_upgrade_set_type_oids_by_type_oid(Archive *fout,
 	appendPQExpBufferStr(upgrade_buffer, "\n-- For binary upgrade, must preserve pg_type oid\n");
 	appendPQExpBuffer(upgrade_buffer,
 						"SELECT pg_catalog.binary_upgrade_set_next_pg_type_oid('%u'::pg_catalog.oid, "
-						"'%u'::pg_catalog.oid, $$%s$$::text);\n\n",
+						"'%u'::pg_catalog.oid, $_GPDB_$%s$_GPDB_$::text);\n\n",
 						tyinfo->dobj.catId.oid, tyinfo->dobj.namespace->dobj.catId.oid, tyinfo->dobj.name);
 
 	if (!OidIsValid(pg_type_array_oid) && force_array_type)
@@ -4757,7 +4757,7 @@ binary_upgrade_set_type_oids_by_type_oid(Archive *fout,
 							 "\n-- For binary upgrade, must preserve pg_type array oid\n");
 		appendPQExpBuffer(upgrade_buffer,
 						  "SELECT pg_catalog.binary_upgrade_set_next_array_pg_type_oid('%u'::pg_catalog.oid, "
-						  "'%u'::pg_catalog.oid, $$%s$$::text);\n\n",
+						  "'%u'::pg_catalog.oid, $_GPDB_$%s$_GPDB_$::text);\n\n",
 						  pg_type_array_oid, pg_type_array_ns_oid,
 						  pg_type_array_name);
 	}
@@ -4788,7 +4788,7 @@ binary_upgrade_set_pg_class_oids(Archive *fout,
 						"\n-- For binary upgrade, must preserve pg_class oids\n");
 		appendPQExpBuffer(upgrade_buffer,
 						  "SELECT pg_catalog.binary_upgrade_set_next_heap_pg_class_oid('%u'::pg_catalog.oid, "
-						  "'%u'::pg_catalog.oid, $$%s$$::text);\n",
+						  "'%u'::pg_catalog.oid, $_GPDB_$%s$_GPDB_$::text);\n",
 						  tblinfo->dobj.catId.oid, tblinfo->dobj.namespace->dobj.catId.oid, tblinfo->dobj.name);
 		/* Only tables have toast tables, not indexes
 		 * Starting GPDB7 CO tables no longer have TOAST tables. Hence, ignore
@@ -4810,7 +4810,7 @@ binary_upgrade_set_pg_class_oids(Archive *fout,
 		simple_oid_list_append(&preassigned_oids, pg_class_oid);
 		appendPQExpBuffer(upgrade_buffer,
 						  "SELECT pg_catalog.binary_upgrade_set_next_index_pg_class_oid('%u'::pg_catalog.oid, "
-							"'%u'::pg_catalog.oid, $$%s$$::text);\n",
+							"'%u'::pg_catalog.oid, $_GPDB_$%s$_GPDB_$::text);\n",
 						  idxinfo->dobj.catId.oid, idxinfo->dobj.namespace->dobj.catId.oid, idxinfo->dobj.name);
 
 		/* Set up bitmap index auxiliary tables */
@@ -10996,7 +10996,7 @@ dumpEnumType(Archive *fout, const TypeInfo *tyinfo)
 			if (i == 0)
 				appendPQExpBufferStr(q, "\n-- For binary upgrade, must preserve pg_enum oids\n");
 			appendPQExpBuffer(q,
-							  "SELECT pg_catalog.binary_upgrade_set_next_pg_enum_oid('%u'::pg_catalog.oid, '%u'::pg_catalog.oid, $$%s$$::text);\n",
+							  "SELECT pg_catalog.binary_upgrade_set_next_pg_enum_oid('%u'::pg_catalog.oid, '%u'::pg_catalog.oid, $_GPDB_$%s$_GPDB_$::text);\n",
 							  enum_oid, tyinfo->dobj.catId.oid, label);
 			appendPQExpBuffer(q, "ALTER TYPE %s ADD VALUE ", qualtypname);
 			appendStringLiteralAH(q, label, fout);


### PR DESCRIPTION
During upgrade, pg_dump will dump table names with sql syntax dollar
quoting to escape table names with special characters. However, using
just $$ as our tag means we do not handle the edge cases of tables
ending in $. This will cause upgrade to fail when pg_restore fails to
bring back such tables. Replace the `$$` tag with `$_GPDB_$`. Tag collision
will still happen on quoted table names containing `$_GPDB_$`, but since
it should be extremely unlikely with this 8 character sequence.
