### PR TITLE
Disallow dbconnlimit checking on segments

### DIFF
--- a/src/backend/utils/init/postinit.c
+++ b/src/backend/utils/init/postinit.c
@@ -422,8 +422,12 @@ CheckMyDatabase(const char *name, bool am_superuser, bool override_allow_connect
 		 * ideally one should succeed and one fail.  Getting that to work
 		 * exactly seems more trouble than it is worth, however; instead we
 		 * just document that the connection limit is approximate.
+		 *
+		 * We do not want to do this for QEs since a single QD might initialise
+		 * many connections to each segment to execute a non-trivial plan and
+		 * the db connection limit does not map, semantically, to that idea.
 		 */
-		if (dbform->datconnlimit >= 0 &&
+		if (Gp_role == GP_ROLE_DISPATCH && dbform->datconnlimit >= 0 &&
 			!am_superuser &&
 			CountDBConnections(MyDatabaseId) > dbform->datconnlimit)
 			ereport(FATAL,

--- a/src/test/regress/expected/dboptions.out
+++ b/src/test/regress/expected/dboptions.out
@@ -2,6 +2,16 @@
 -- Test create/alter database options
 --
 -- Test CONNECTION LIMIT
+-- create a regular user as superusers are exempt from limits
+create user connlimit_test_user;
+-- add created user to pg_hba.conf
+\! echo "local    all         connlimit_test_user         trust" >> $COORDINATOR_DATA_DIRECTORY/pg_hba.conf
+select pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t
+(1 row)
+
 create database limitdb connection limit 1;
 select -1 as gp_segment_id, datconnlimit from pg_database where datname='limitdb'
 union
@@ -14,6 +24,19 @@ order by gp_segment_id;
              1 |            1
              2 |            1
 (4 rows)
+
+-- Ensure that the db connection limit is not enforced on the segment. We check
+-- this by ensuring that a multi-slice plan, exceeding the connection limit on
+-- the segment can execute.
+\! psql limitdb -U connlimit_test_user -c 'create table tbl(i int);'
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE
+\! psql limitdb -U connlimit_test_user -c 'select count(*) from tbl t1, tbl t2;'
+ count 
+-------
+     0
+(1 row)
 
 alter database limitdb connection limit 2;
 select -1 as gp_segment_id, datconnlimit from pg_database where datname='limitdb'
@@ -29,16 +52,6 @@ order by gp_segment_id;
 (4 rows)
 
 alter database limitdb with connection limit 0;
--- create a regular user as superusers are exempt from limits
-create user connlimit_test_user;
--- add superuser to pg_hba.conf
-\! echo "local    all         connlimit_test_user         trust" >> $COORDINATOR_DATA_DIRECTORY/pg_hba.conf
-select pg_reload_conf();
- pg_reload_conf 
-----------------
- t
-(1 row)
-
 -- should fail, because the connection limit is 0
 \! psql limitdb -c "select 'connected'" -U connlimit_test_user
 psql: error: FATAL:  too many connections for database "limitdb"

--- a/src/test/regress/sql/dboptions.sql
+++ b/src/test/regress/sql/dboptions.sql
@@ -3,11 +3,24 @@
 --
 
 -- Test CONNECTION LIMIT
+
+-- create a regular user as superusers are exempt from limits
+create user connlimit_test_user;
+-- add created user to pg_hba.conf
+\! echo "local    all         connlimit_test_user         trust" >> $COORDINATOR_DATA_DIRECTORY/pg_hba.conf
+select pg_reload_conf();
+
 create database limitdb connection limit 1;
 select -1 as gp_segment_id, datconnlimit from pg_database where datname='limitdb'
 union
 select gp_segment_id, datconnlimit from gp_dist_random('pg_database') where datname='limitdb'
 order by gp_segment_id;
+
+-- Ensure that the db connection limit is not enforced on the segment. We check
+-- this by ensuring that a multi-slice plan, exceeding the connection limit on
+-- the segment can execute.
+\! psql limitdb -U connlimit_test_user -c 'create table tbl(i int);'
+\! psql limitdb -U connlimit_test_user -c 'select count(*) from tbl t1, tbl t2;'
 
 alter database limitdb connection limit 2;
 select -1 as gp_segment_id, datconnlimit from pg_database where datname='limitdb'
@@ -16,12 +29,6 @@ select gp_segment_id, datconnlimit from gp_dist_random('pg_database') where datn
 order by gp_segment_id;
 
 alter database limitdb with connection limit 0;
-
--- create a regular user as superusers are exempt from limits
-create user connlimit_test_user;
--- add superuser to pg_hba.conf
-\! echo "local    all         connlimit_test_user         trust" >> $COORDINATOR_DATA_DIRECTORY/pg_hba.conf
-select pg_reload_conf();
 
 -- should fail, because the connection limit is 0
 \! psql limitdb -c "select 'connected'" -U connlimit_test_user


### PR DESCRIPTION
It is difficult for users to anticipate how many connections will hit a
database on a segment (multi-slice plans and what not). So, only enforce
a database's connection limit on the coordinator (like for role
connection limits)