### PR TITLE
[6x backport] Fix InterruptHoldoffCount not being reset issue

### DIFF
--- a/src/backend/cdb/cdbcopy.c
+++ b/src/backend/cdb/cdbcopy.c
@@ -721,7 +721,7 @@ cdbCopyEndInternal(CdbCopy *c, char *abort_msg,
 		if (first_error)
 		{
 			FlushErrorState();
-			ReThrowError(first_error);
+			ThrowErrorData(first_error);
 		}
 
 		/* errors that occurred in the COPY itself */

--- a/src/backend/cdb/cdbtm.c
+++ b/src/backend/cdb/cdbtm.c
@@ -1326,7 +1326,7 @@ doDispatchDtxProtocolCommand(DtxProtocolCommand dtxProtocolCommand,
 		else
 		{
 			FlushErrorState();
-			ReThrowError(qeError);
+			ThrowErrorData(qeError);
 		}
 		return false;
 	}

--- a/src/backend/cdb/dispatcher/cdbdisp.c
+++ b/src/backend/cdb/dispatcher/cdbdisp.c
@@ -277,7 +277,7 @@ CdbDispatchHandleError(struct CdbDispatcherState *ds)
 			if (error != NULL)
 			{
 				FlushErrorState();
-				ReThrowError(error);
+				ThrowErrorData(error);
 			}
 		}
 		PG_CATCH();

--- a/src/backend/cdb/dispatcher/cdbdisp_query.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_query.c
@@ -339,7 +339,7 @@ CdbDispatchSetCommand(const char *strCommand, bool cancelOnError)
 	{
 
 		FlushErrorState();
-		ReThrowError(qeError);
+		ThrowErrorData(qeError);
 	}
 
 	cdbdisp_destroyDispatcherState(ds);
@@ -477,7 +477,7 @@ cdbdisp_dispatchCommandInternal(DispatchCommandQueryParms *pQueryParms,
 	if (qeError)
 	{
 		FlushErrorState();
-		ReThrowError(qeError);
+		ThrowErrorData(qeError);
 	}
 
 	cdbdisp_returnResults(pr, cdb_pgresults);
@@ -1239,7 +1239,7 @@ cdbdisp_dispatchX(QueryDesc* queryDesc,
 		if (qeError)
 		{
 			FlushErrorState();
-			ReThrowError(qeError);
+			ThrowErrorData(qeError);
 		}
 
 		/*
@@ -1509,7 +1509,7 @@ CdbDispatchCopyStart(struct CdbCopy *cdbCopy, Node *stmt, int flags)
 	if (!cdbdisp_getDispatchResults(ds, &error))
 	{
 		FlushErrorState();
-		ReThrowError(error);
+		ThrowErrorData(error);
 	}
 
 	/*

--- a/src/backend/cdb/endpoint/cdbendpointutils.c
+++ b/src/backend/cdb/endpoint/cdbendpointutils.c
@@ -90,7 +90,7 @@ check_parallel_retrieve_cursor_errors(EState *estate)
 		estate->dispatcherState = NULL;
 		cdbdisp_cancelDispatch(ds);
 		FlushErrorState();
-		ReThrowError(qeError);
+		ThrowErrorData(qeError);
 	}
 }
 

--- a/src/backend/commands/explain.c
+++ b/src/backend/commands/explain.c
@@ -613,7 +613,7 @@ ExplainOnePlan(PlannedStmt *plannedstmt, IntoClause *into, ExplainState *es,
 			if (qeError)
 			{
 				FlushErrorState();
-				ReThrowError(qeError);
+				ThrowErrorData(qeError);
 			}
 		}
 

--- a/src/backend/executor/execUtils.c
+++ b/src/backend/executor/execUtils.c
@@ -2243,7 +2243,7 @@ void mppExecutorFinishup(QueryDesc *queryDesc)
 		{
 			estate->dispatcherState = NULL;
 			FlushErrorState();
-			ReThrowError(qeError);
+			ThrowErrorData(qeError);
 		}
 
 		/* If top slice was delegated to QEs, get num of rows processed. */

--- a/src/backend/executor/nodeSubplan.c
+++ b/src/backend/executor/nodeSubplan.c
@@ -1230,7 +1230,7 @@ PG_TRY();
 		{
 			queryDesc->estate->dispatcherState = NULL;
 			FlushErrorState();
-			ReThrowError(qeError);
+			ThrowErrorData(qeError);
 		}
 
 		/* If EXPLAIN ANALYZE, collect execution stats from qExecs. */

--- a/src/include/utils/elog.h
+++ b/src/include/utils/elog.h
@@ -504,6 +504,7 @@ extern ErrorData *CopyErrorData(void);
 extern void FreeErrorData(ErrorData *edata);
 extern void FlushErrorState(void);
 extern void ReThrowError(ErrorData *edata)  __attribute__((__noreturn__));
+extern void ThrowErrorData(ErrorData *edata);
 extern void pg_re_throw(void) __attribute__((noreturn));
 
 extern char *GetErrorContextStack(void);

--- a/src/test/regress/expected/interrupt_holdoff_count.out
+++ b/src/test/regress/expected/interrupt_holdoff_count.out
@@ -1,0 +1,18 @@
+-- test for Github Issue 15278
+-- QD should reset InterruptHoldoffCount
+create table t_15278(a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into t_15278 values (-1,1);
+begin;
+declare c1 cursor for select count(*) from t_15278 group by sqrt(a);
+abort;
+ERROR:  cannot take square root of a negative number  (seg2 slice2 127.0.1.1:7004 pid=489428)
+-- Without fix, the above transaction will lead
+-- QD's global var InterruptHoldoffCount not reset to 0
+-- thus the below SQL will return t. After fixing, now
+-- the below SQL will print an error message, this is
+-- the correct behavior.
+select pg_cancel_backend(pg_backend_pid());
+ERROR:  canceling statement due to user request
+drop table t_15278;

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -161,7 +161,7 @@ test: gp_toolkit_ao_funcs trig auth_constraint role portals_updatable plpgsql_ca
 test: rle rle_delta dsp not_out_of_shmem_exit_slots
 
 # direct dispatch tests
-test: direct_dispatch bfv_dd bfv_dd_multicolumn bfv_dd_types
+test: direct_dispatch bfv_dd bfv_dd_multicolumn bfv_dd_types interrupt_holdoff_count
 
 # catalog test uses pg_get_constraintdef which may report ERROR when executed
 # concurrently with other tests. Cause pg_get_constraintdef() looks up

--- a/src/test/regress/sql/interrupt_holdoff_count.sql
+++ b/src/test/regress/sql/interrupt_holdoff_count.sql
@@ -1,0 +1,18 @@
+-- test for Github Issue 15278
+-- QD should reset InterruptHoldoffCount
+create table t_15278(a int, b int);
+insert into t_15278 values (-1,1);
+
+begin;
+declare c1 cursor for select count(*) from t_15278 group by sqrt(a);
+abort;
+
+-- Without fix, the above transaction will lead
+-- QD's global var InterruptHoldoffCount not reset to 0
+-- thus the below SQL will return t. After fixing, now
+-- the below SQL will print an error message, this is
+-- the correct behavior.
+select pg_cancel_backend(pg_backend_pid());
+
+drop table t_15278;
+


### PR DESCRIPTION
cases(#15278)

This commit addresses issue #15278, where the InterruptHoldoffCount value was not always resetting to zero in certain abnormal scenarios. This issue had the potential to impact the proper functioning of the ProcessInterrupts process. The fix ensures that the InterruptHoldoffCount value is properly reset to zero in all cases.

this issue is found in #15203 , we will add test cases in pr #15203 

backport form https://github.com/greenplum-db/gpdb/pull/15279
