### PR TITLE
[7x] Added --checksum option in rsync

### DIFF
--- a/concourse/pipelines/templates/gpdb-tpl.yml
+++ b/concourse/pipelines/templates/gpdb-tpl.yml
@@ -46,6 +46,9 @@
                        'use_concourse_cluster': true},
                       {'name': 'gpstop',
                        'use_concourse_cluster': true},
+                      { 'name': 'gpsync',
+                        'use_concourse_cluster': true,
+                        'additional_ccp_vars': 'number_of_nodes: 3'},
                     ] %}
 
 ## ======================================================================

--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -460,7 +460,8 @@ class GpExpandStatus():
         cpCmd = Rsync('gpexpand copying status file to coordinator mirror',
                     srcFile=self._status_filename,
                     dstFile=self._status_standby_filename,
-                    dstHost=self._coordinator_mirror.getSegmentHostName())
+                    dstHost=self._coordinator_mirror.getSegmentHostName(),
+                    checksum=True)
         cpCmd.run(validateAfter=True)
 
     def set_status(self, status, status_info=None, force=False):
@@ -530,7 +531,8 @@ class GpExpandStatus():
             cpCmd = Rsync('gpexpand copying segment configuration backup file to coordinator mirror',
                         srcFile=self._gp_segment_configuration_backup,
                         dstFile=self._segment_configuration_standby_filename,
-                        dstHost=self._coordinator_mirror.getSegmentHostName())
+                        dstHost=self._coordinator_mirror.getSegmentHostName(),
+                        checksum=True)
             cpCmd.run(validateAfter=True)
 
     def get_temp_dir(self):
@@ -775,7 +777,8 @@ class SegmentTemplate:
             cpCmd = Rsync(name='gpexpand distribute tar file to new hosts',
                         srcFile=self.schema_tar_file,
                         dstFile=self.segTarDir,
-                        dstHost=host)
+                        dstHost=host,
+                        checksum=True)
             self.pool.addCommand(cpCmd)
 
         self.pool.join()
@@ -863,7 +866,7 @@ class SegmentTemplate:
                   % (self.srcSegHostname, self.srcSegDataDir)
         cpCmd = Rsync(name=cmdName, srcFile=self.srcSegDataDir + '/postgresql.conf',
             dstFile=self.tempDir, dstHost=localHostname, ctxt=REMOTE,
-            remoteHost=self.srcSegHostname)
+            remoteHost=self.srcSegHostname, checksum=True)
         cpCmd.run(validateAfter=True)
 
         self.logger.info('Copying pg_hba.conf from existing segment into template')
@@ -871,7 +874,7 @@ class SegmentTemplate:
                   % (self.srcSegHostname, self.srcSegDataDir)
         cpCmd = Rsync(name=cmdName, srcFile=self.srcSegDataDir + '/pg_hba.conf',
                     dstFile=self.tempDir, dstHost=localHostname,ctxt=REMOTE,
-                    remoteHost=self.srcSegHostname)
+                    remoteHost=self.srcSegHostname, checksum=True)
         cpCmd.run(validateAfter=True)
 
     def _tar_template(self):

--- a/gpMgmt/bin/gpmemwatcher
+++ b/gpMgmt/bin/gpmemwatcher
@@ -171,7 +171,7 @@ def stopProcesses(host, workdir):
         return
 
     try:
-        subprocess.check_call('rsync -q %s:%s/%s ./%s.%s' % (host, dest_dir, ps_file, host, ps_file), shell=True)
+        subprocess.check_call('rsync -q -c %s:%s/%s ./%s.%s' % (host, dest_dir, ps_file, host, ps_file), shell=True)
     except subprocess.CalledProcessError as e:
         print('Error retrieving data from host: ' + host, file=sys.stderr)
         print(e)

--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -1167,7 +1167,7 @@ def distribute_tarball(queue,list,tarball):
             hostname = db.getSegmentHostName()
             datadir = db.getSegmentDataDirectory()
             (head,tail)=os.path.split(datadir)
-            rsync_cmd=Rsync(name="copy coordinator",srcFile=tarball,dstHost=hostname,dstFile=head)
+            rsync_cmd=Rsync(name="copy coordinator",srcFile=tarball,dstHost=hostname,dstFile=head, checksum=True)
             queue.addCommand(rsync_cmd)
         queue.join()
         queue.check_results()

--- a/gpMgmt/bin/gppylib/operations/package.py
+++ b/gpMgmt/bin/gppylib/operations/package.py
@@ -121,7 +121,7 @@ class SyncPackages(Operation):
                 Rsync(name='Syncing {} to localhost'.format(package),
                       srcFile=remote_package_metadata,
                       dstFile=remove_package_metadata,
-                      srcHost=self.host).run(validateAfter=True)
+                      srcHost=self.host, checksum=True).run(validateAfter=True)
                 remove_list = get_package_file_list(package)
                 for file_ in remove_list:
                     RemoveRemoteFile(os.path.join(GPHOME, file_), self.host).run()

--- a/gpMgmt/bin/gpssh-exkeys
+++ b/gpMgmt/bin/gpssh-exkeys
@@ -751,7 +751,7 @@ try:
 
 
         for h in GV.newHosts:
-            cmd = ('rsync -q -e "ssh -o BatchMode=yes -o NumberOfPasswordPrompts=0" ' +
+            cmd = ('rsync -q -c -e "ssh -o BatchMode=yes -o NumberOfPasswordPrompts=0" ' +
                    '%s %s %s %s %s:.ssh/ 2>&1'
                    % (GV.authorized_keys_fname,
                       GV.known_hosts_fname,
@@ -792,7 +792,7 @@ try:
                     remoteIdentity = GV.id_rsa_fname
                     remoteIdentityPub = GV.id_rsa_pub_fname
 
-                cmd = ('rsync -q -e "ssh -o BatchMode=yes -o NumberOfPasswordPrompts=0" ' +
+                cmd = ('rsync -q -c -e "ssh -o BatchMode=yes -o NumberOfPasswordPrompts=0" ' +
                        '%s %s %s %s %s:.ssh/ 2>&1'
                        % (remoteAuthKeysFile,
                           remoteKnownHostsFile,

--- a/gpMgmt/bin/gpsync
+++ b/gpMgmt/bin/gpsync
@@ -38,6 +38,7 @@ class Global:
     opt['-J'] = '=:'
     opt['-r'] = False
     opt['-a'] = False
+    opt['-c'] = False
     filePath = []
 
 
@@ -63,7 +64,7 @@ def print_version():
 #############
 def parseCommandLine():
     try:
-        (options, args) = getopt.getopt(sys.argv[1:], '?vraJ:p:u:h:f:', ['version'])
+        (options, args) = getopt.getopt(sys.argv[1:], '?cvraJ:p:u:h:f:', ['version'])
     except Exception as e:
         usage('Error: ' + str(e))
 
@@ -81,6 +82,8 @@ def parseCommandLine():
         elif (switch == '-r'):
             GV.opt[switch] = True
         elif (switch == '-a'):
+            GV.opt[switch] = True
+        elif (switch == '-c'):
             GV.opt[switch] = True
         elif (switch == '--version'):
             print_version()
@@ -116,6 +119,7 @@ try:
     rsync = 'rsync -e "ssh -o BatchMode=yes -o StrictHostKeyChecking=no"'
     if GV.opt['-r']:  rsync += ' -r'
     if GV.opt['-a']:  rsync += ' -a'
+    if GV.opt['-c']:  rsync += ' -c'
 
     proc = []
     for peer in GV.opt['-h']:

--- a/gpMgmt/doc/gpsync_help
+++ b/gpMgmt/doc/gpsync_help
@@ -7,7 +7,7 @@ SYNOPSIS
 *****************************************************
 
 gpsync { -f <hostfile_gpssh> | -h <hostname> [-h <hostname> ...] } 
-[-a] [-J <character>] [-v] [[<user>@]<hostname>:]<file_to_copy> [...]
+[-a] [-r] [-c] [-J <character>] [-v] [[<user>@]<hostname>:]<file_to_copy> [...]
 [[<user>@]<hostname>:]<copy_to_path>
 
 gpsync -? 
@@ -74,6 +74,15 @@ specify multiple host names.
 -a (archive mode)
 
 Sync source and target directories in archive mode.
+
+-r
+
+Copies data recursively (but don’t preserve timestamps and permission while transferring data).
+
+-c
+
+Copy the files that have identical sizes and modification times,
+skip to copy files based on checksum, not modification time and size.
 
 -J <character>
 

--- a/gpMgmt/test/behave/mgmt_utils/gpsync.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpsync.feature
@@ -1,0 +1,12 @@
+@gpsync
+Feature: gpsync tests
+
+  @concourse_cluster
+    Scenario: gpsync -c copy files which have identical sizes and modification time but different content
+        Given the user runs "gpssh -h sdw1 -h sdw2 -v -e 'hostname > tmp.txt | touch -a -m -t 202305161056.00 tmp.txt'"
+         When the user runs remote command "gpsync  -h sdw2 tmp.txt =:tmp.txt" on host "sdw1"
+         Then check "tmp.txt" "could not" be copied from "sdw1" to "sdw2"
+         When the user runs remote command "gpsync -c -h sdw2 tmp.txt =:tmp.txt" on host "sdw1"
+         Then check "tmp.txt" "could" be copied from "sdw1" to "sdw2"
+          And the user runs "gpssh -h sdw1 -h sdw2 -v -e 'rm -rf tmp.txt'"
+

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -4012,3 +4012,22 @@ def impl(context):
         else:
             context.stdout_message
             raise Exception("segment process not running in execute mode for DBID:{0}".format(dbid))
+
+
+
+@then('check {file} "{action}" be copied from {src_host} to {target_host}')
+def impl(context, file, action, src_host, target_host):
+    """
+    Check the differences in the files on source and destination hosts, based on the action provided check that the
+    file content is updated from source to destination hosts
+    """
+    cmd_str = "diff <(ssh {0} cat {1}) <(ssh {2} cat {1})".format(src_host, file, target_host)
+    cmd = Command("get the file diff", cmdStr=cmd_str, ctxt=REMOTE, remoteHost=src_host)
+    cmd.run()
+    rc = cmd.get_return_code()
+    if action == 'could not' and rc == 0:
+        raise Exception('successfully copied file from {0} to {1} without -c flag'.format(src_host, target_host))
+    if action == 'could' and rc == 1:
+        raise Exception('failed to copy file from {0} to {1} with -c flag'.format(src_host, target_host))
+
+        

--- a/gpdb-doc/markdown/utility_guide/ref/gpsync.html.md
+++ b/gpdb-doc/markdown/utility_guide/ref/gpsync.html.md
@@ -4,9 +4,9 @@ Copies files between multiple hosts at once.
 
 ## <a id="section2"></a>Synopsis 
 
-```
+``` 
 gpsync { -f <hostfile_gpssh> | -h <hostname> [-h <hostname> ...] } 
-      [-a][-J <character>] [-v] [[<user>@]<hostname>:]<file_to_copy> [...]
+      [-a] [-r] [-c] [-J <character>] [-v] [[<user>@]<hostname>:]<file_to_copy> [...]
       [[<user>@]<hostname>:]<copy_to_path> 
 
 gpsync -? 
@@ -42,6 +42,12 @@ Before using `gpsync`, you must have a trusted host setup between the hosts invo
 
 -a 
 :   Sync source and target directories in archival mode.
+
+-r
+:    Copies data recursively (but don’t preserve timestamps and permission while transferring data).
+
+-c
+:   Copy the files that have identical sizes and modification times, skip to copy files based on checksum, not modification time and size.
 
 -J character
 :   The `-J` option allows you to specify a single character to substitute for the hostname in the `copy from` and `copy to` destination strings. If `-J` is not specified, the default substitution character is an equal sign \(`=`\).


### PR DESCRIPTION
Fixes https://github.com/greenplum-db/gpdb/issues/14744

Problem :
rsync skips to copy files when the files have identical sizes and modification times on the source and destination hosts

Solution :
rysnc with -c or --checksum option can be used to copy the files that have identical sizes and modification times on the source and destination hosts. It modifies the file-times-and-sizes heuristic, but here it ignores times and examines only sizes. Files on the source and destination hosts with either a changed size or a changed checksum are selected for transfer.

Implementation :
Added the -c or --checksum option with rsync command everywhere in cm utlity codebase

Added behave tests for the below manual test steps :
    1.     create a file with "hostname > tmp.txt" on all the hosts using gpssh
    2.     get the modification time of tmp.txt on source host with "stat -c '%y'  tmp.txt",
    3.     update the modification time of tmp.txt on target host with "touch  -m -d "date_time" tmp.txt 
    4.     run gpsync of tmp.txt file on all the hosts without checksum flag
    5.     make sure that files are not synced
    6.     run gpsync of tmp.txt file on all the hosts with checksum flag
    7.     make sure files are synced

## Here are some reminders before you submit the pull request

- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
