### PR TITLE
Modifications to JIT documentation page

### DIFF
--- a/gpdb-doc/markdown/admin_guide/query/topics/just-in-time.html.md
+++ b/gpdb-doc/markdown/admin_guide/query/topics/just-in-time.html.md
@@ -70,16 +70,16 @@ The JIT workflow can also handle executor fault tolerance: if JIT fails to load 
 
 ## <a id="topic4"></a>Examples
 
-In the examples below, the configuration parameter `jit_above_cost` was modified so it would trigger JIT compilation. The use of JIT affects the cost of the plan, which can or cannot be bigger than the potential savings. JIT was used, but inlining and expensive optimization were not. If `jit_inline_above_cost` or `jit_optimize_above_cost` were also lowered, they could be triggered.
+In the examples below, the configuration parameter `jit_above_cost` was modified so it would trigger JIT compilation. Note that the use of JIT might add more overhead than the potential savings. JIT was used, but inlining and expensive optimization were not. If `jit_inline_above_cost` or `jit_optimize_above_cost` were also lowered, they could be triggered.
 
 You may enable the configuration parameter [gp_explain_jit](../../../ref_guide/config_params/guc-list.html#gp_explain_jit) to display summarized JIT information from all query executions when running the `EXPLAIN` command. You must turn disable it when running regression tests
 
-Note that the output from `EXPLAIN` provides information on JIT such as the slice average timing spent in JIT, what segment the maximum vector comes from, or how many JIT functions are created and total time spent in JIT tasks. This information can be helpful when tuning JIT or debugging a timing problem. Set the configuration parameters `log_min_messages`, `client_min_messages` to `DEBUG 5` to view this information.
+Note that the output from `EXPLAIN` provides information on JIT such as the slice average timing spent in JIT, what segment the maximum vector comes from, or how many JIT functions are created and total time spent in JIT tasks. This information can be helpful when tuning JIT or debugging a timing problem. Run `EXPLAIN ANALYZE VERBOSE` to view this information.
 
 With Postgres Planner:
 
 ```
-EXPLAIN (ANALYZE) SELECT * FROM jit_explain_output LIMIT 10;
+EXPLAIN ANALYZE SELECT * FROM jit_explain_output LIMIT 10;
 QUERY PLAN
 Limit  (cost=35.50..35.67 rows=10 width=4) (actual time=13.199..13.310 rows=10 loops=1)
   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=35.50..36.01 rows=30 width=4) (actual time=11.848..11.890 rows=10 loops=1)
@@ -101,7 +101,7 @@ Execution Time: 24.023 ms
 With GPORCA:
 
 ```
-EXPLAIN (ANALYZE) SELECT * FROM jit_explain_output LIMIT 10;
+EXPLAIN ANALYZE SELECT * FROM jit_explain_output LIMIT 10;
 QUERY PLAN
 Limit  (cost=0.00..431.00 rows=1 width=4) (actual time=1.103..1.107 rows=10 loops=1)
   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4) (actual time=0.013..0.014 rows=10 loops=1)

--- a/gpdb-doc/markdown/admin_guide/query/topics/just-in-time.html.md
+++ b/gpdb-doc/markdown/admin_guide/query/topics/just-in-time.html.md
@@ -72,14 +72,14 @@ The JIT workflow can also handle executor fault tolerance: if JIT fails to load 
 
 In the examples below, the configuration parameter `jit_above_cost` was modified so it would trigger JIT compilation. Note that the use of JIT might add more overhead than the potential savings. JIT was used, but inlining and expensive optimization were not. If `jit_inline_above_cost` or `jit_optimize_above_cost` were also lowered, they could be triggered.
 
-You may enable the configuration parameter [gp_explain_jit](../../../ref_guide/config_params/guc-list.html#gp_explain_jit) to display summarized JIT information from all query executions when running the `EXPLAIN` command. You must turn disable it when running regression tests
+You may enable the configuration parameter [gp_explain_jit](../../../ref_guide/config_params/guc-list.html#gp_explain_jit) to display summarized JIT information from all query executions when running the `EXPLAIN` command. You must turn it off when running regression tests.
 
-Note that the output from `EXPLAIN` provides information on JIT such as the slice average timing spent in JIT, what segment the maximum vector comes from, or how many JIT functions are created and total time spent in JIT tasks. This information can be helpful when tuning JIT or debugging a timing problem. Run `EXPLAIN ANALYZE VERBOSE` to view this information.
+Note that the output from `EXPLAIN` provides information on JIT such as the slice average timing spent in JIT, what segment the maximum vector comes from, or how many JIT functions are created and total time spent in JIT tasks. This information can be helpful when tuning JIT or debugging a timing problem. Run `EXPLAIN (ANALYZE, VERBOSE)` to view this information.
 
 With Postgres Planner:
 
 ```
-EXPLAIN ANALYZE SELECT * FROM jit_explain_output LIMIT 10;
+EXPLAIN (ANALYZE) SELECT * FROM jit_explain_output LIMIT 10;
 QUERY PLAN
 Limit  (cost=35.50..35.67 rows=10 width=4) (actual time=13.199..13.310 rows=10 loops=1)
   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=35.50..36.01 rows=30 width=4) (actual time=11.848..11.890 rows=10 loops=1)
@@ -101,7 +101,7 @@ Execution Time: 24.023 ms
 With GPORCA:
 
 ```
-EXPLAIN ANALYZE SELECT * FROM jit_explain_output LIMIT 10;
+EXPLAIN (ANALYZE) SELECT * FROM jit_explain_output LIMIT 10;
 QUERY PLAN
 Limit  (cost=0.00..431.00 rows=1 width=4) (actual time=1.103..1.107 rows=10 loops=1)
   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4) (actual time=0.013..0.014 rows=10 loops=1)


### PR DESCRIPTION
Running `EXPLAIN ANALYZE VERBOSE` now displays further information about JIT compilation. Edited documentation to match these changes. Also a couple of more edits.