### PR TITLE
Fix gpdiff.pl should ignore infomation when explain ignore costs.

### DIFF
--- a/src/test/isolation2/input/parallel_retrieve_cursor/explain.source
+++ b/src/test/isolation2/input/parallel_retrieve_cursor/explain.source
@@ -43,8 +43,8 @@ EXPLAIN (VERBOSE, COSTS false) DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT * 
 -- Test: explain output: Endpoint info (on coordinator/on some segments/on all segments)
 -- Here because replicated table will execute on seg id: session_id % segment_number
 -- Just replace the random specific seg id to SEGIDX for the output
-1: @post_run 'create_sub  "Endpoint: on segments: contentid \[[0-9]+\]" " Endpoint: on segments: contentid [SEGIDX]" ':EXPLAIN (VERBOSE, COSTS false) DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM rt1;
-1: @post_run 'create_sub  "Endpoint: on segments: contentid \[[0-9]+\]" " Endpoint: on segments: contentid [SEGIDX]" ':EXPLAIN (VERBOSE, COSTS false) DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM rt1 ORDER BY a;
-1: @post_run 'create_sub  "Endpoint: on segments: contentid \[[0-9]+\]" " Endpoint: on segments: contentid [SEGIDX]" ':EXPLAIN (VERBOSE, COSTS false) DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM rt1 WHERE a=1;
-1: @post_run 'create_sub  "Endpoint: on segments: contentid \[[0-9]+\]" " Endpoint: on segments: contentid [SEGIDX]" ':EXPLAIN (VERBOSE, COSTS false) DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM rt1 WHERE a=1 OR a=2;
+1: @post_run 'create_sub  "on segment: contentid \[[0-9]+\]" "on segment: contentid [SEGIDX]" ':EXPLAIN (VERBOSE, COSTS false) DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM rt1;
+1: @post_run 'create_sub  "on segment: contentid \[[0-9]+\]" "on segment: contentid [SEGIDX]" ':EXPLAIN (VERBOSE, COSTS false) DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM rt1 ORDER BY a;
+1: @post_run 'create_sub  "on segment: contentid \[[0-9]+\]" "on segment: contentid [SEGIDX]" ':EXPLAIN (VERBOSE, COSTS false) DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM rt1 WHERE a=1;
+1: @post_run 'create_sub  "on segment: contentid \[[0-9]+\]" "on segment: contentid [SEGIDX]" ':EXPLAIN (VERBOSE, COSTS false) DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM rt1 WHERE a=1 OR a=2;
 

--- a/src/test/isolation2/output/parallel_retrieve_cursor/explain.source
+++ b/src/test/isolation2/output/parallel_retrieve_cursor/explain.source
@@ -19,22 +19,22 @@ INSERT 0 100
 
 -- PARALLEL RETRIEVE CURSOR with other options (WITH HOLD/SCROLL) is not supported
 EXPLAIN (COSTS false) DECLARE c1 PARALLEL RETRIEVE CURSOR WITHOUT HOLD FOR SELECT * FROM t1;
- QUERY PLAN                          
--------------------------------------
- Seq Scan on t1                      
- Endpoint: on all 3 segments         
- Optimizer: Postgres query optimizer 
+ QUERY PLAN                        
+-----------------------------------
+ Seq Scan on t1                    
+ Optimizer: Postgres-based planner 
+ Endpoint: on all 3 segments       
 (3 rows)
 EXPLAIN (COSTS false) DECLARE c1 PARALLEL RETRIEVE CURSOR WITH HOLD FOR SELECT * FROM t1;
 ERROR:  DECLARE PARALLEL RETRIEVE CURSOR WITH HOLD ... is not supported
 DETAIL:  Holdable cursors can not be parallel
 
 EXPLAIN (COSTS false) DECLARE c1 NO SCROLL PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
- QUERY PLAN                          
--------------------------------------
- Seq Scan on t1                      
- Endpoint: on all 3 segments         
- Optimizer: Postgres query optimizer 
+ QUERY PLAN                        
+-----------------------------------
+ Seq Scan on t1                    
+ Optimizer: Postgres-based planner 
+ Endpoint: on all 3 segments       
 (3 rows)
 EXPLAIN (COSTS false) DECLARE c1 SCROLL PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
 ERROR:  SCROLL is not allowed for the PARALLEL RETRIEVE CURSORs
@@ -42,12 +42,12 @@ DETAIL:  Scrollable cursors can not be parallel
 
 -- Test: explain output: Endpoint info (on coordinator/on some segments/on all segments)
 EXPLAIN (VERBOSE, COSTS false) DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
- QUERY PLAN                          
--------------------------------------
- Seq Scan on public.t1               
-   Output: a                         
- Endpoint: on all 3 segments         
- Optimizer: Postgres query optimizer 
+ QUERY PLAN                        
+-----------------------------------
+ Seq Scan on public.t1             
+   Output: a                       
+ Optimizer: Postgres-based planner 
+ Endpoint: on all 3 segments       
 (4 rows)
 EXPLAIN (VERBOSE, COSTS false) DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1 ORDER BY a;
  QUERY PLAN                               
@@ -84,12 +84,12 @@ EXPLAIN (VERBOSE, COSTS false) DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT * 
 
 -- Test: Locus CdbLocusType_Strewn
 EXPLAIN (VERBOSE, COSTS false) DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t2;
- QUERY PLAN                          
--------------------------------------
- Seq Scan on public.t2               
-   Output: a                         
- Endpoint: on all 3 segments         
- Optimizer: Postgres query optimizer 
+ QUERY PLAN                        
+-----------------------------------
+ Seq Scan on public.t2             
+   Output: a                       
+ Optimizer: Postgres-based planner 
+ Endpoint: on all 3 segments       
 (4 rows)
 
 -- Test for system table which is accessible on coordinator
@@ -186,7 +186,7 @@ EXPLAIN (VERBOSE, COSTS false) DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT * 
 -- Test: explain output: Endpoint info (on coordinator/on some segments/on all segments)
 -- Here because replicated table will execute on seg id: session_id % segment_number
 -- Just replace the random specific seg id to SEGIDX for the output
-1: @post_run 'create_sub  "Endpoint: on segments: contentid \[[0-9]+\]" " Endpoint: on segments: contentid [SEGIDX]" ':EXPLAIN (VERBOSE, COSTS false) DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM rt1;
+1: @post_run 'create_sub  "on segment: contentid \[[0-9]+\]" "on segment: contentid [SEGIDX]" ':EXPLAIN (VERBOSE, COSTS false) DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM rt1;
  QUERY PLAN
 ---------------------------------------
  Seq Scan on public.rt1
@@ -194,7 +194,7 @@ EXPLAIN (VERBOSE, COSTS false) DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT * 
  Endpoint: "on segment: contentid [SEGIDX]"
  Optimizer: Postgres query optimizer
 (4 rows)
-1: @post_run 'create_sub  "Endpoint: on segments: contentid \[[0-9]+\]" " Endpoint: on segments: contentid [SEGIDX]" ':EXPLAIN (VERBOSE, COSTS false) DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM rt1 ORDER BY a;
+1: @post_run 'create_sub  "on segment: contentid \[[0-9]+\]" "on segment: contentid [SEGIDX]" ':EXPLAIN (VERBOSE, COSTS false) DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM rt1 ORDER BY a;
  QUERY PLAN
 ---------------------------------------
  Sort
@@ -205,7 +205,7 @@ EXPLAIN (VERBOSE, COSTS false) DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT * 
  Endpoint: "on segment: contentid [SEGIDX]"
  Optimizer: Postgres query optimizer
 (7 rows)
-1: @post_run 'create_sub  "Endpoint: on segments: contentid \[[0-9]+\]" " Endpoint: on segments: contentid [SEGIDX]" ':EXPLAIN (VERBOSE, COSTS false) DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM rt1 WHERE a=1;
+1: @post_run 'create_sub  "on segment: contentid \[[0-9]+\]" "on segment: contentid [SEGIDX]" ':EXPLAIN (VERBOSE, COSTS false) DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM rt1 WHERE a=1;
  QUERY PLAN
 ---------------------------------------
  Seq Scan on public.rt1
@@ -214,7 +214,7 @@ EXPLAIN (VERBOSE, COSTS false) DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT * 
  Endpoint: "on segment: contentid [SEGIDX]"
  Optimizer: Postgres query optimizer
 (5 rows)
-1: @post_run 'create_sub  "Endpoint: on segments: contentid \[[0-9]+\]" " Endpoint: on segments: contentid [SEGIDX]" ':EXPLAIN (VERBOSE, COSTS false) DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM rt1 WHERE a=1 OR a=2;
+1: @post_run 'create_sub  "on segment: contentid \[[0-9]+\]" "on segment: contentid [SEGIDX]" ':EXPLAIN (VERBOSE, COSTS false) DECLARE c1 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM rt1 WHERE a=1 OR a=2;
  QUERY PLAN
 ----------------------------------------
  Seq Scan on public.rt1

--- a/src/test/regress/atmsort.pm
+++ b/src/test/regress/atmsort.pm
@@ -1198,9 +1198,7 @@ sub atmsort_bigloop
             }
 
             # EXPLAIN (COSTS OFF/FALSE/0) ...
-            if (($ini =~ m/explain\s*\(.*costs\s+off.*\)/i) ||
-                ($ini =~ m/explain\s*\(.*costs\s+false.*\)/i) ||
-                ($ini =~ m/explain\s*\(.*costs\s+0.*\)/i))
+            if ($ini =~ m/explain\s*\(.*costs\s+(?:off|false|0).*\)/i)
             {
                 $directive->{explain} = "costs_off";
             }

--- a/src/test/regress/atmsort.pm
+++ b/src/test/regress/atmsort.pm
@@ -1197,8 +1197,10 @@ sub atmsort_bigloop
                 next;
             }
 
-            # EXPLAIN (COSTS OFF) ...
-            if ($ini =~ m/explain\s*\(.*costs\s+off.*\)/i)
+            # EXPLAIN (COSTS OFF/FALSE/0) ...
+            if (($ini =~ m/explain\s*\(.*costs\s+off.*\)/i) ||
+                ($ini =~ m/explain\s*\(.*costs\s+false.*\)/i) ||
+                ($ini =~ m/explain\s*\(.*costs\s+0.*\)/i))
             {
                 $directive->{explain} = "costs_off";
             }


### PR DESCRIPTION
I got some plan header diffs when running regression with different GUCs, like:

<img width="1519" alt="image" src="https://user-images.githubusercontent.com/17311022/234281350-2cbea6d1-b031-4d8a-acf9-ebc778e124ea.png">

which is not expected, the root cause is we only match `costs off` in atmsort.pm and miss other valid boolean values.

SQL like: EXPLAIN (COSTS OFF) will ignore segment info, other valid boolean values should also be recognized. ex:
  EXPLAIN (COSTS OFF/FALSE/0).

I wouldn't say it's a bug, but it seems reasonable to make up.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
