### PR TITLE
Inclusive language updates to reduce usage of "master"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,11 +45,11 @@ To improve the odds of the right discussion of your patch or idea happening, pay
 
 Once you are ready to share your work with the Greenplum core team and the rest of the Greenplum community, you should push all the commits to a branch in your own repository forked from the official Greenplum and send us a pull request.
 
-We require all pull requests to be submitted against the main master branch (clearly stating if the change needs to be back-ported to STABLE branches). If the change is ONLY applicable to given STABLE branch, you may decide to submit your pull requests against an active STABLE release branch.
+We require all pull requests to be submitted against the main branch (clearly stating if the change needs to be back-ported to STABLE branches). If the change is ONLY applicable to given STABLE branch, you may decide to submit your pull requests against an active STABLE release branch.
 
 Things which slow down patch approval
  - missing to accompany tests (or reproducible steps at minimum)
- - submitting the patch against STABLE branch where the fix also applies to main master branch
+ - submitting the patch against STABLE branch where the fix also applies to main branch
 
 ## Submissions against 5X_STABLE
 

--- a/README.macOS.bash
+++ b/README.macOS.bash
@@ -8,7 +8,7 @@ if hash brew 2>/dev/null; then
 	echo "Homebrew is already installed!"
 else
 	echo "Installing Homebrew..."
-	ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+	ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/main/install)"
 fi
 
 brew install bash-completion

--- a/README.macOS.bash
+++ b/README.macOS.bash
@@ -8,7 +8,7 @@ if hash brew 2>/dev/null; then
 	echo "Homebrew is already installed!"
 else
 	echo "Installing Homebrew..."
-	ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/main/install)"
+	ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 fi
 
 brew install bash-completion

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ source /usr/local/gpdb/greenplum_path.sh
 
 # Start demo cluster
 make create-demo-cluster
-# (gpdemo-env.sh contains __PGPORT__ and __MASTER_DATA_DIRECTORY__ values)
+# (gpdemo-env.sh contains __PGPORT__ and __COORDINATOR_DATA_DIRECTORY__ values)
 source gpAux/gpdemo/gpdemo-env.sh
 ```
 

--- a/gpMgmt/test/behave/mgmt_utils/steps/gpstart.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/gpstart.py
@@ -45,7 +45,7 @@ def impl(context):
     cleanup(context)
 
 """
-Reverses the changes done by change_hostname() function by starting up cluster in master-only utility mode. 
+Reverses the changes done by change_hostname() function by starting up cluster in coordinator-only utility mode. 
 Since the standby host is incorrect, a regular gpstart call won't work.
 """
 def cleanup(context):

--- a/gpdb-doc/markdown/admin_guide/highavail/topics/g-overview-of-high-availability-in-greenplum-database.html.md
+++ b/gpdb-doc/markdown/admin_guide/highavail/topics/g-overview-of-high-availability-in-greenplum-database.html.md
@@ -11,7 +11,7 @@ With Greenplum Database, fault tolerance and data availability is achieved with:
 -   [Hardware level RAID storage protection](#raid)
 -   [Data storage checksums](#checksums)
 -   [Greenplum segment mirroring](#segment_mirroring)
--   [Coordinator mirroring](#master_mirroring)
+-   [Coordinator mirroring](#coordinator_mirroring)
 -   [Dual clusters](#dual_clusters)
 -   [Database backup and restore](#backup_restore)
 
@@ -60,7 +60,7 @@ Greenplum Database stores data in multiple segment instances, each of which is a
 
 The mirror instance for each segment is usually initialized with the `gpinitsystem` utility or the `gpexpand` utility. As a best practice, the mirror runs on a different host than the primary instance to protect from a single machine failure. There are different strategies for assigning mirrors to hosts. When choosing the layout of the primaries and mirrors, it is important to consider the failure scenarios to ensure that processing skew is minimized in the case of a single machine failure.
 
-## <a id="master_mirroring"></a>Coordinator Mirroring 
+## <a id="coordinator_mirroring"></a>Coordinator Mirroring 
 
 There are two coordinator instances in a highly available cluster, a *primary* and a *standby*. As with segments, the coordinator and standby should be deployed on different hosts so that the cluster can tolerate a single host failure. Clients connect to the primary coordinator and queries can be run only on the primary coordinator. The standby coordinator is kept up to date with the primary coordinator using Write-Ahead Logging \(WAL\)-based streaming replication. See [Overview of Coordinator Mirroring](g-overview-of-master-mirroring.html).
 

--- a/gpdb-doc/markdown/admin_guide/intro/about_ha.html.md
+++ b/gpdb-doc/markdown/admin_guide/intro/about_ha.html.md
@@ -30,7 +30,7 @@ If the coordinator cannot connect to a segment instance, it marks that segment i
 
 If you do not have mirroring enabled, the system will automatically shut down if a segment instance becomes invalid. You must recover all failed segments before operations can continue.
 
-## <a id="master_mirroring"></a>About Coordinator Mirroring 
+## <a id="coordinator_mirroring"></a>About Coordinator Mirroring 
 
 You can also optionally deploy a backup or mirror of the coordinator instance on a separate host from the coordinator host. The backup coordinator instance \(the *standby coordinator*\) serves as a *warm standby* in the event that the primary coordinator host becomes non-operational. The standby coordinator is kept current by a transaction log replication process, which synchronizes the data between the primary and standby coordinator.
 

--- a/gpdb-doc/markdown/admin_guide/intro/arch_overview.html.md
+++ b/gpdb-doc/markdown/admin_guide/intro/arch_overview.html.md
@@ -30,13 +30,13 @@ Greenplum Database stores and processes large amounts of data by distributing th
 
 The following topics describe the components that make up a Greenplum Database system and how they work together.
 
--   [About the Greenplum Coordinator](#arch_master)
+-   [About the Greenplum Coordinator](#arch_coordinator)
 -   [About the Greenplum Segments](#arch_segments)
 -   [About the Greenplum Interconnect](#arch_interconnect)
 -   [About ETL Hosts for Data Loading](#topic13)
 -   [About VMware Greenplum Performance Monitoring](#topic_e5t_whm_kbb)
 
-## <a id="arch_master"></a>About the Greenplum Coordinator 
+## <a id="arch_coordinator"></a>About the Greenplum Coordinator 
 
 The Greenplum Database coordinator is the entry to the Greenplum Database system, accepting client connections and SQL queries, and distributing work to the segment instances.
 

--- a/gpdb-doc/markdown/admin_guide/query/topics/functions-operators.html.md
+++ b/gpdb-doc/markdown/admin_guide/query/topics/functions-operators.html.md
@@ -17,7 +17,7 @@ Description of user-defined and built-in functions and operators in Greenplum Da
 
 When you invoke a function in Greenplum Database, function attributes control the execution of the function. The volatility attributes \(`IMMUTABLE`, `STABLE`, `VOLATILE`\) and the `EXECUTE ON` attributes control two different aspects of function execution. In general, volatility indicates when the function is run, and `EXECUTE ON` indicates where it is run. The volatility attributes are PostgreSQL based attributes, the `EXECUTE ON` attributes are Greenplum Database attributes.
 
-For example, a function defined with the `IMMUTABLE` attribute can be run at query planning time, while a function with the `VOLATILE` attribute must be run for every row in the query. A function with the `EXECUTE ON MASTER` attribute runs only on the coordinator instance, and a function with the `EXECUTE ON ALL SEGMENTS` attribute runs on all primary segment instances \(not the coordinator\).
+For example, a function defined with the `IMMUTABLE` attribute can be run at query planning time, while a function with the `VOLATILE` attribute must be run for every row in the query. A function with the `EXECUTE ON COORDINATOR` attribute runs only on the coordinator instance, and a function with the `EXECUTE ON ALL SEGMENTS` attribute runs on all primary segment instances \(not the coordinator\).
 
 These tables summarize what Greenplum Database assumes about function execution based on the attribute.
 
@@ -30,7 +30,7 @@ These tables summarize what Greenplum Database assumes about function execution 
 |Function Attribute|Description|Comments|
 |------------------|-----------|--------|
 |EXECUTE ON ANY|Indicates that the function can be run on the coordinator, or any segment instance, and it returns the same result regardless of where it runs. This is the default attribute.|Greenplum Database determines where the function runs.|
-|EXECUTE ON MASTER|Indicates that the function must be run on the coordinator instance.|Specify this attribute if the user-defined function runs queries to access tables.|
+|EXECUTE ON COORDINATOR|Indicates that the function must be run on the coordinator instance.|Specify this attribute if the user-defined function runs queries to access tables.|
 |EXECUTE ON ALL SEGMENTS|Indicates that for each invocation, the function must be run on all primary segment instances, but not the coordinator.| |
 |EXECUTE ON INITPLAN|Indicates that the function contains an SQL command that dispatches queries to the segment instances and requires special processing on the coordinator instance by Greenplum Database when possible.| |
 
@@ -71,7 +71,7 @@ Greenplum Database supports user-defined functions. See [Extending SQL](https://
 
 Use the `CREATE FUNCTION` statement to register user-defined functions that are used as described in [Using Functions in Greenplum Database](#topic27). By default, user-defined functions are declared as `VOLATILE`, so if your user-defined function is `IMMUTABLE` or `STABLE`, you must specify the correct volatility level when you register your function.
 
-By default, user-defined functions are declared as `EXECUTE ON ANY`. A function that runs queries to access tables is supported only when the function runs on the coordinator instance, except that a function can run `SELECT` commands that access only replicated tables on the segment instances. A function that accesses hash-distributed or randomly distributed tables must be defined with the `EXECUTE ON MASTER` attribute. Otherwise, the function might return incorrect results when the function is used in a complicated query. Without the attribute, planner optimization might determine it would be beneficial to push the function invocation to segment instances.
+By default, user-defined functions are declared as `EXECUTE ON ANY`. A function that runs queries to access tables is supported only when the function runs on the coordinator instance, except that a function can run `SELECT` commands that access only replicated tables on the segment instances. A function that accesses hash-distributed or randomly distributed tables must be defined with the `EXECUTE ON COORDINATOR` attribute. Otherwise, the function might return incorrect results when the function is used in a complicated query. Without the attribute, planner optimization might determine it would be beneficial to push the function invocation to segment instances.
 
 When you create user-defined functions, avoid using fatal errors or destructive calls. Greenplum Database may respond to such errors with a sudden shutdown or restart.
 

--- a/gpdb-doc/markdown/admin_guide/query/topics/query-piv-opt-enable.html.md
+++ b/gpdb-doc/markdown/admin_guide/query/topics/query-piv-opt-enable.html.md
@@ -22,7 +22,7 @@ Set the server configuration parameter optimizer for the Greenplum Database syst
 2.  Set the values of the server configuration parameters. These Greenplum Database gpconfig utility commands sets the value of the parameters to `on`:
 
     ```
-    $ gpconfig -c optimizer -v on --masteronly
+    $ gpconfig -c optimizer -v on --coordinatoronly
     ```
 
 3.  Restart Greenplum Database. This Greenplum Database gpstop utility command reloads the `postgresql.conf` files of the coordinator and segments without shutting down Greenplum Database.

--- a/gpdb-doc/markdown/admin_guide/query/topics/query-piv-opt-limitations.html.md
+++ b/gpdb-doc/markdown/admin_guide/query/topics/query-piv-opt-limitations.html.md
@@ -43,7 +43,7 @@ These features are unsupported when GPORCA is enabled \(the default\):
 -   Multiple Distinct Qualified Aggregates, such as `SELECT count(DISTINCT a), sum(DISTINCT b) FROM foo`, are not supported by default. They can be enabled with the `optimizer_enable_multiple_distinct_aggs` [Configuration Parameter](../../../ref_guide/config_params/guc-list.html).
 -   percentile\_\* window functions \(ordered-set aggregate functions\).
 -   Inverse distribution functions.
--   Queries that run functions that are defined with the `ON MASTER` or `ON ALL SEGMENTS` attribute.
+-   Queries that run functions that are defined with the `ON COORDINATOR` or `ON ALL SEGMENTS` attribute.
 -   Queries that contain UNICODE characters in metadata names, such as table names, and the characters are not compatible with the host system locale.
 -   `SELECT`, `UPDATE`, and `DELETE` commands where a table name is qualified by the `ONLY` keyword.
 -   Per-column collation. GPORCA supports collation only when all columns in the query use the same collation. If columns in the query use different collations, then Greenplum uses the Postgres Planner.

--- a/gpdb-doc/markdown/admin_guide/query/topics/query-piv-opt-root-partition.html.md
+++ b/gpdb-doc/markdown/admin_guide/query/topics/query-piv-opt-root-partition.html.md
@@ -37,7 +37,7 @@ If you do not intend to run queries on partitioned tables with GPORCA \(setting 
 2.  Set the values of the server configuration parameters. These Greenplum Database `gpconfig` utility commands sets the value of the parameters to `off`:
 
     ```
-    $ gpconfig -c optimizer_analyze_root_partition -v off --masteronly
+    $ gpconfig -c optimizer_analyze_root_partition -v off --coordinatoronly
     ```
 
 3.  Restart Greenplum Database. This Greenplum Database `gpstop` utility command reloads the `postgresql.conf` files of the coordinator and segments without shutting down Greenplum Database.

--- a/gpdb-doc/markdown/admin_guide/topics/g-about-greenplum-master-and-local-parameters.html.md
+++ b/gpdb-doc/markdown/admin_guide/topics/g-about-greenplum-master-and-local-parameters.html.md
@@ -6,9 +6,9 @@ Server configuration files contain parameters that configure server behavior. Th
 
 The coordinator and each segment instance have their own postgresql.conf file. Some parameters are *local*: each segment instance examines its postgresql.conf file to get the value of that parameter. Set local parameters on the coordinator and on each segment instance.
 
-Other parameters are *master* parameters that you set on the coordinator instance. The value is passed down to \(or in some cases ignored by\) the segment instances at query run time.
+Other parameters are *coordinator* parameters that you set on the coordinator instance. The value is passed down to \(or in some cases ignored by\) the segment instances at query run time.
 
-See the *Greenplum Database Reference Guide* for information about *local* and *master* server configuration parameters.
+See the *Greenplum Database Reference Guide* for information about *local* and *coordinator* server configuration parameters.
 
 **Parent topic:** [Configuring the Greenplum Database System](../topics/g-configuring-the-greenplum-system.html)
 

--- a/gpdb-doc/markdown/analytics/madlib.html.md
+++ b/gpdb-doc/markdown/analytics/madlib.html.md
@@ -65,7 +65,7 @@ If you have GPUs installed on some or across all hosts in the cluster, then the 
 
 ### <a id="topic4"></a>Installing the Greenplum Database MADlib Package 
 
-Before you install the MADlib package, make sure that your Greenplum database is running, you have sourced `greenplum_path.sh`, and that the`$MASTER_DATA_DIRECTORY` and `$GPHOME` variables are set.
+Before you install the MADlib package, make sure that your Greenplum database is running, you have sourced `greenplum_path.sh`, and that the`$COORDINATOR_DATA_DIRECTORY` and `$GPHOME` variables are set.
 
 1.  Download the MADlib extension package from [VMware Tanzu Network](https://network.pivotal.io/products/pivotal-gpdb).
 2.  Copy the MADlib package to the Greenplum Database coordinator host.

--- a/gpdb-doc/markdown/analytics/pl_java.html.md
+++ b/gpdb-doc/markdown/analytics/pl_java.html.md
@@ -130,7 +130,7 @@ To install and use PL/Java:
 
 ### <a id="topic5"></a>Installing the Greenplum PL/Java Extension 
 
-Before you install the PL/Java extension, make sure that your Greenplum database is running, you have sourced `greenplum_path.sh`, and that the `$MASTER_DATA_DIRECTORY` and `$GPHOME` variables are set.
+Before you install the PL/Java extension, make sure that your Greenplum database is running, you have sourced `greenplum_path.sh`, and that the `$COORDINATOR_DATA_DIRECTORY` and `$GPHOME` variables are set.
 
 1.  Download the PL/Java extension package from [VMware Tanzu Network](https://network.pivotal.io/products/pivotal-gpdb) then copy it to the coordinator host.
 2.  Follow the instructions in [Verifying the Greenplum Database Software Download](../install_guide/verify_sw.html) to verify the integrity of the **Greenplum Procedural Languages PL/Java** software.

--- a/gpdb-doc/markdown/analytics/pl_perl.html.md
+++ b/gpdb-doc/markdown/analytics/pl_perl.html.md
@@ -48,7 +48,7 @@ Before you enable or remove PL/Perl support in a database, ensure that:
 
 -   Your Greenplum Database is running.
 -   You have sourced `greenplum_path.sh`.
--   You have set the `$MASTER_DATA_DIRECTORY` and `$GPHOME` environment variables.
+-   You have set the `$COORDINATOR_DATA_DIRECTORY` and `$GPHOME` environment variables.
 
 ### <a id="topic61"></a>Enabling PL/Perl Support 
 
@@ -147,7 +147,7 @@ CREATE OR REPLACE FUNCTION return_match(varchar) RETURNS SETOF test AS $$
         }
     }
     return undef;
-$$ LANGUAGE plperl EXECUTE ON MASTER ;
+$$ LANGUAGE plperl EXECUTE ON COORDINATOR ;
 
 SELECT return_match( 'iff' );
  return_match

--- a/gpdb-doc/markdown/analytics/pl_python.html.md
+++ b/gpdb-doc/markdown/analytics/pl_python.html.md
@@ -664,7 +664,7 @@ AS $$
   region =[]
   region.append(rv[a]["region"])
   return region
-$$ language plpythonu EXECUTE ON MASTER;
+$$ language plpythonu EXECUTE ON COORDINATOR;
 ```
 
 Running this `SELECT` statement returns the `REGION` column value from the third row of the result set.

--- a/gpdb-doc/markdown/analytics/pl_r.html.md
+++ b/gpdb-doc/markdown/analytics/pl_r.html.md
@@ -64,7 +64,7 @@ The [gppkg](../utility_guide/ref/gppkg.html) utility installs Greenplum Database
 
 #### <a id="topic4"></a>Installing the Extension Package 
 
-Before you install the PL/R extension, make sure that your Greenplum Database is running, you have sourced `greenplum_path.sh`, and that the `$MASTER_DATA_DIRECTORY` and `$GPHOME` variables are set.
+Before you install the PL/R extension, make sure that your Greenplum Database is running, you have sourced `greenplum_path.sh`, and that the `$COORDINATOR_DATA_DIRECTORY` and `$GPHOME` variables are set.
 
 1.  Download the PL/R extension package from [VMware Tanzu Network](https://network.pivotal.io/products/pivotal-gpdb).
 2.  Follow the instructions in [Verifying the Greenplum Database Software Download](../install_guide/verify_sw.html) to verify the integrity of the **Greenplum Procedural Languages PL/R** software.

--- a/gpdb-doc/markdown/best_practices/logfiles.html.md
+++ b/gpdb-doc/markdown/best_practices/logfiles.html.md
@@ -7,7 +7,7 @@ Know the location and content of system log files and monitor them on a regular 
 The following table shows the locations of the various Greenplum Database log files. In file paths:
 
 -   `$GPADMIN_HOME` refers to the home directory of the `gpadmin` operating system user.
--   `$MASTER_DATA_DIRECTORY` refers to the coordinator data directory on the Greenplum Database coordinator host.
+-   `$COORDINATOR_DATA_DIRECTORY` refers to the coordinator data directory on the Greenplum Database coordinator host.
 -   `$GPDATA_DIR` refers to a data directory on the Greenplum Database segment host.
 -   `host` identifies the Greenplum Database segment host name.
 -   `segprefix` identifies the segment prefix.
@@ -24,8 +24,8 @@ The following table shows the locations of the various Greenplum Database log fi
 |`$GPADMIN_HOME/gpAdminLogs/gpstop_date.log`|stop log|
 |`$GPADMIN_HOME/gpAdminLogs/gpsegstart.py_host:gpadmin_date.log`|segment host start log|
 |`$GPADMIN_HOME/gpAdminLogs/gpsegstop.py_host:gpadmin_date.log`|segment host stop log|
-|`$MASTER_DATA_DIRECTORY/log/startup.log`, `$GPDATA_DIR/segprefixN/log/startup.log`|segment instance start log|
-|`$MASTER_DATA_DIRECTORY/log/*.csv`, `$GPDATA_DIR/segprefixN/log/*.csv`|coordinator and segment database logs|
+|`$COORDINATOR_DATA_DIRECTORY/log/startup.log`, `$GPDATA_DIR/segprefixN/log/startup.log`|segment instance start log|
+|`$COORDINATOR_DATA_DIRECTORY/log/*.csv`, `$GPDATA_DIR/segprefixN/log/*.csv`|coordinator and segment database logs|
 |`$GPDATA_DIR/mirror/segprefixN/log/*.csv`|mirror segment database logs|
 |`$GPDATA_DIR/primary/segprefixN/log/*.csv`|primary segment database logs|
 |`/var/log/messages`|Global Linux system messages|

--- a/gpdb-doc/markdown/install_guide/env_var_ref.html.md
+++ b/gpdb-doc/markdown/install_guide/env_var_ref.html.md
@@ -46,13 +46,13 @@ LD_LIBRARY_PATH=$GPHOME/lib
 export LD_LIBRARY_PATH
 ```
 
-### <a id="topic6"></a>MASTER\_DATA\_DIRECTORY 
+### <a id="topic6"></a>COORDINATOR\_DATA\_DIRECTORY 
 
 This should point to the directory created by the gpinitsystem utility in the coordinator data directory location. For example:
 
 ```
-MASTER_DATA_DIRECTORY=/data/coordinator/gpseg-1
-export MASTER_DATA_DIRECTORY
+COORDINATOR_DATA_DIRECTORY=/data/coordinator/gpseg-1
+export COORDINATOR_DATA_DIRECTORY
 ```
 
 ## <a id="topic7"></a>Optional Environment Variables 

--- a/gpdb-doc/markdown/install_guide/init_gpdb.html.md
+++ b/gpdb-doc/markdown/install_guide/init_gpdb.html.md
@@ -96,9 +96,9 @@ Your Greenplum Database configuration file tells the [gpinitsystem](../utility_g
     SEG_PREFIX=gpseg
     PORT_BASE=6000 
     declare -a DATA_DIRECTORY=(/data1/primary /data1/primary /data1/primary /data2/primary /data2/primary /data2/primary)
-    MASTER_HOSTNAME=cdw 
-    MASTER_DIRECTORY=/data/coordinator 
-    MASTER_PORT=5432 
+    COORDINATOR_HOSTNAME=cdw 
+    COORDINATOR_DIRECTORY=/data/coordinator 
+    COORDINATOR_PORT=5432 
     TRUSTED SHELL=ssh
     CHECK_POINT_SEGMENTS=8
     ENCODING=UNICODE
@@ -201,7 +201,7 @@ For more information about the Greenplum Database timezone, see [Configuring Tim
 
 You must set environment variables in the Greenplum Database user \(`gpadmin`\) environment that runs Greenplum Database on the Greenplum Database coordinator and standby coordinator hosts. A `greenplum_path.sh` file is provided in the Greenplum Database installation directory with environment variable settings for Greenplum Database.
 
-The Greenplum Database management utilities also require that the `MASTER_DATA_DIRECTORY` environment variable be set. This should point to the directory created by the `gpinitsystem` utility in the coordinator data directory location.
+The Greenplum Database management utilities also require that the `COORDINATOR_DATA_DIRECTORY` environment variable be set. This should point to the directory created by the `gpinitsystem` utility in the coordinator data directory location.
 
 > **Note** The `greenplum_path.sh` script changes the operating environment in order to support running the Greenplum Database-specific utilities. These same changes to the environment can negatively affect the operation of other system-level utilities, such as `ps` or `yum`. Use separate accounts for performing system administration and database administration, instead of attempting to perform both functions as `gpadmin`.
 

--- a/gpdb-doc/markdown/install_guide/install_python_dsmod.html.md
+++ b/gpdb-doc/markdown/install_guide/install_python_dsmod.html.md
@@ -274,7 +274,7 @@ The following table lists the modules that are provided in the Data Science Pack
 
 ## <a id="topic_instpdsm"></a>Installing a Data Science Package for Python 
 
-Before you install a Data Science Package for Python, make sure that your Greenplum Database is running, you have sourced `greenplum_path.sh`, and that the `$MASTER_DATA_DIRECTORY` and `$GPHOME` environment variables are set.
+Before you install a Data Science Package for Python, make sure that your Greenplum Database is running, you have sourced `greenplum_path.sh`, and that the `$COORDINATOR_DATA_DIRECTORY` and `$GPHOME` environment variables are set.
 
 > **Note** The `PyMC3` module depends on `Tk`. If you want to use `PyMC3`, you must install the `tk` OS package on every node in your cluster. For example:
 

--- a/gpdb-doc/markdown/install_guide/install_r_dslib.html.md
+++ b/gpdb-doc/markdown/install_guide/install_r_dslib.html.md
@@ -152,7 +152,7 @@ Libraries provided in the R Data Science package include:
 
 ## <a id="topic_instpdsl"></a>Installing the R Data Science Library Package 
 
-Before you install the R Data Science Library package, make sure that your Greenplum Database is running, you have sourced `greenplum_path.sh`, and that the `$MASTER_DATA_DIRECTORY` and `$GPHOME` environment variables are set.
+Before you install the R Data Science Library package, make sure that your Greenplum Database is running, you have sourced `greenplum_path.sh`, and that the `COORDINATOR_DATA_DIRECTORY` and `$GPHOME` environment variables are set.
 
 1.  Locate the R Data Science library package that you built or downloaded.
 

--- a/gpdb-doc/markdown/ref_guide/config_params/guc-list.html.md
+++ b/gpdb-doc/markdown/ref_guide/config_params/guc-list.html.md
@@ -8,7 +8,7 @@ Sets the application name for a client session. For example, if connecting via `
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|string| |master, session, reload|
+|string| |coordinator, session, reload|
 
 ## <a id="array_nulls"></a>array\_nulls 
 
@@ -16,7 +16,7 @@ This controls whether the array input parser recognizes unquoted NULL as specify
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|on|master, session, reload|
+|Boolean|on|coordinator, session, reload|
 
 ## <a id="authentication_timeout"></a>authentication\_timeout 
 
@@ -35,7 +35,7 @@ When enabled, Greenplum Database starts up the autovacuum daemon, which operates
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|on|master, system, restart|
+|Boolean|on|coordinator, system, restart|
 
 ## <a id="autovacuum_naptime"></a>autovacuum\_naptime
 
@@ -47,7 +47,7 @@ This parameter may be set only in the `postgresql.conf` file or on the server co
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|1 - INT_MAX/1000 | 60 |master, system, restart|
+|1 - INT_MAX/1000 | 60 |coordinator, system, restart|
 
 
 ## <a id="backslash_quote"></a>backslash\_quote 
@@ -56,7 +56,7 @@ This controls whether a quote mark can be represented by \\' in a string literal
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|on \(allow \\' always\), off \(reject always\), safe\_encoding \(allow only if client encoding does not allow ASCII \\ within a multibyte character\)|safe\_encoding|master, session, reload|
+|on \(allow \\' always\), off \(reject always\), safe\_encoding \(allow only if client encoding does not allow ASCII \\ within a multibyte character\)|safe\_encoding|coordinator, session, reload|
 
 ## <a id="block_size"></a>block\_size 
 
@@ -72,7 +72,7 @@ Specifies the Bonjour broadcast name. By default, the computer name is used, spe
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|string|unset|master, system, restart|
+|string|unset|coordinator, system, restart|
 
 ## <a id="check_function_bodies"></a>check\_function\_bodies 
 
@@ -80,7 +80,7 @@ When set to off, deactivates validation of the function body string during `CREA
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|on|master, session, reload|
+|Boolean|on|coordinator, session, reload|
 
 ## <a id="client_connection_check_interval"></a>client\_connection\_check\_interval 
 
@@ -88,7 +88,7 @@ Sets the time interval between optional checks that the client is still connecte
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|number of milliseconds|0|master, session, reload|
+|number of milliseconds|0|coordinator, session, reload|
 
 ## <a id="client_encoding"></a>client\_encoding 
 
@@ -96,7 +96,7 @@ Sets the client-side encoding \(character set\). The default is to use the same 
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|character set|UTF8|master, session, reload|
+|character set|UTF8|coordinator, session, reload|
 
 ## <a id="client_min_messages"></a>client\_min\_messages 
 
@@ -104,7 +104,7 @@ Controls which message levels are sent to the client. Each level includes all th
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|DEBUG5, DEBUG4, DEBUG3, DEBUG2, DEBUG1, LOG, NOTICE, WARNING, ERROR, FATAL, PANIC|NOTICE|master, session, reload|
+|DEBUG5, DEBUG4, DEBUG3, DEBUG2, DEBUG1, LOG, NOTICE, WARNING, ERROR, FATAL, PANIC|NOTICE|coordinator, session, reload|
 
 `INFO` level messages are always sent to the client.
 
@@ -114,7 +114,7 @@ For the Postgres Planner, sets the estimate of the cost of processing each index
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|floating point|0.005|master, session, reload|
+|floating point|0.005|coordinator, session, reload|
 
 ## <a id="cpu_operator_cost"></a>cpu\_operator\_cost 
 
@@ -122,7 +122,7 @@ For the Postgres Planner, sets the estimate of the cost of processing each opera
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|floating point|0.0025|master, session, reload|
+|floating point|0.0025|coordinator, session, reload|
 
 ## <a id="cpu_tuple_cost"></a>cpu\_tuple\_cost 
 
@@ -130,7 +130,7 @@ For the Postgres Planner, Sets the estimate of the cost of processing each row d
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|floating point|0.01|master, session, reload|
+|floating point|0.01|coordinator, session, reload|
 
 ## <a id="cursor_tuple_fraction"></a>cursor\_tuple\_fraction 
 
@@ -138,7 +138,7 @@ Tells the Postgres Planner how many rows are expected to be fetched in a cursor 
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|integer|1|master, session, reload|
+|integer|1|coordinator, session, reload|
 
 ## <a id="data_checksums"></a>data\_checksums 
 
@@ -160,7 +160,7 @@ Sets the display format for date and time values, as well as the rules for inter
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|<format\>, <date style\><br/><br/>where:<br/><br/><format\> is ISO, Postgres, SQL, or German<br/><br/><date style\> is DMY, MDY, or YMD|ISO, MDY|master, session, reload|
+|<format\>, <date style\><br/><br/>where:<br/><br/><format\> is ISO, Postgres, SQL, or German<br/><br/><date style\> is DMY, MDY, or YMD|ISO, MDY|coordinator, session, reload|
 
 ## <a id="db_user_namespace"></a>db\_user\_namespace 
 
@@ -192,7 +192,7 @@ Indents debug output to produce a more readable but much longer output format. *
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|on|master, session, reload|
+|Boolean|on|coordinator, session, reload|
 
 ## <a id="debug_print_parse"></a>debug\_print\_parse 
 
@@ -200,7 +200,7 @@ For each query run, prints the resulting parse tree. *client\_min\_messages* or 
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|off|master, session, reload|
+|Boolean|off|coordinator, session, reload|
 
 ## <a id="debug_print_plan"></a>debug\_print\_plan 
 
@@ -208,7 +208,7 @@ For each query run, prints the Greenplum parallel query execution plan. *client\
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|off|master, session, reload|
+|Boolean|off|coordinator, session, reload|
 
 ## <a id="debug_print_prelim_plan"></a>debug\_print\_prelim\_plan 
 
@@ -216,7 +216,7 @@ For each query run, prints the preliminary query plan. *client\_min\_messages* o
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|off|master, session, reload|
+|Boolean|off|coordinator, session, reload|
 
 ## <a id="debug_print_rewritten"></a>debug\_print\_rewritten 
 
@@ -224,7 +224,7 @@ For each query run, prints the query rewriter output. *client\_min\_messages* or
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|off|master, session, reload|
+|Boolean|off|coordinator, session, reload|
 
 ## <a id="debug_print_slice_table"></a>debug\_print\_slice\_table 
 
@@ -232,7 +232,7 @@ For each query run, prints the Greenplum query slice plan. *client\_min\_message
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|off|master, session, reload|
+|Boolean|off|coordinator, session, reload|
 
 ## <a id="default_statistics_target"></a>default\_statistics\_target 
 
@@ -243,7 +243,7 @@ For more information on the use of statistics by the Postgres Planner, refer to 
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|0 \> Integer \> 10000|100|master, session, reload|
+|0 \> Integer \> 10000|100|coordinator, session, reload|
 
 ## <a id="default_table_access_method"></a>default_table_access_method
 
@@ -251,7 +251,7 @@ Sets the default table access method when a `CREATE TABLE` command does not expl
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|heap, ao_row, ao_column|heap|master, session|
+|heap, ao_row, ao_column|heap|coordinator, session|
 
 ## <a id="default_tablespace"></a>default\_tablespace 
 
@@ -259,7 +259,7 @@ The default tablespace in which to create objects \(tables and indexes\) when a 
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|name of a tablespace|unset|master, session, reload|
+|name of a tablespace|unset|coordinator, session, reload|
 
 ## <a id="default_text_search_config"></a>default\_text\_search\_config 
 
@@ -267,7 +267,7 @@ Selects the text search configuration that is used by those variants of the text
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|The name of a text search configuration.|`pg_catalog.simple`|master, session, reload|
+|The name of a text search configuration.|`pg_catalog.simple`|coordinator, session, reload|
 
 ## <a id="default_transaction_deferrable"></a>default\_transaction\_deferrable 
 
@@ -279,7 +279,7 @@ This parameter controls the default deferrable status of each new transaction. I
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|off|master, session, reload|
+|Boolean|off|coordinator, session, reload|
 
 ## <a id="default_transaction_isolation"></a>default\_transaction\_isolation 
 
@@ -287,7 +287,7 @@ Controls the default isolation level of each new transaction. Greenplum Database
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|read committed, read uncommitted, repeatable read, serializable|read committed|master, session, reload|
+|read committed, read uncommitted, repeatable read, serializable|read committed|coordinator, session, reload|
 
 ## <a id="default_transaction_read_only"></a>default\_transaction\_read\_only 
 
@@ -295,7 +295,7 @@ Controls the default read-only status of each new transaction. A read-only SQL t
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|off|master, session, reload|
+|Boolean|off|coordinator, session, reload|
 
 ## <a id="dynamic_library_path"></a>dynamic\_library\_path 
 
@@ -313,7 +313,7 @@ Set this parameter to a number of [block\_size](#backslash_quote) blocks \(defau
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|1 - INT\_MAX *or* number and unit|524288 \(16GB\)|master, session, reload|
+|1 - INT\_MAX *or* number and unit|524288 \(16GB\)|coordinator, session, reload|
 
 ## <a id="enable_bitmapscan"></a>enable\_bitmapscan 
 
@@ -321,7 +321,7 @@ Set this parameter to a number of [block\_size](#backslash_quote) blocks \(defau
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|on|master, session, reload|
+|Boolean|on|coordinator, session, reload|
 
 ## <a id="enable_groupagg"></a>enable\_groupagg 
 
@@ -329,7 +329,7 @@ Set this parameter to a number of [block\_size](#backslash_quote) blocks \(defau
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|on|master, session, reload|
+|Boolean|on|coordinator, session, reload|
 
 ## <a id="enable_hashagg"></a>enable\_hashagg 
 
@@ -337,7 +337,7 @@ Set this parameter to a number of [block\_size](#backslash_quote) blocks \(defau
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|on|master, session, reload|
+|Boolean|on|coordinator, session, reload|
 
 ## <a id="enable_hashjoin"></a>enable\_hashjoin 
 
@@ -345,7 +345,7 @@ Set this parameter to a number of [block\_size](#backslash_quote) blocks \(defau
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|on|master, session, reload|
+|Boolean|on|coordinator, session, reload|
 
 ## <a id="enable_indexscan"></a>enable\_indexscan 
 
@@ -353,7 +353,7 @@ Set this parameter to a number of [block\_size](#backslash_quote) blocks \(defau
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|on|master, session, reload|
+|Boolean|on|coordinator, session, reload|
 
 ## <a id="enable_mergejoin"></a>enable\_mergejoin 
 
@@ -361,7 +361,7 @@ Set this parameter to a number of [block\_size](#backslash_quote) blocks \(defau
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|off|master, session, reload|
+|Boolean|off|coordinator, session, reload|
 
 ## <a id="enable_nestloop"></a>enable\_nestloop 
 
@@ -369,7 +369,7 @@ Set this parameter to a number of [block\_size](#backslash_quote) blocks \(defau
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|off|master, session, reload|
+|Boolean|off|coordinator, session, reload|
 
 ## <a id="enable_partition_pruning"></a>enable_partition_pruning 
 
@@ -377,7 +377,7 @@ Set this parameter to a number of [block\_size](#backslash_quote) blocks \(defau
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|on|master, session, reload|
+|Boolean|on|coordinator, session, reload|
 
 
 ## <a id="enable_seqscan"></a>enable\_seqscan 
@@ -386,7 +386,7 @@ Set this parameter to a number of [block\_size](#backslash_quote) blocks \(defau
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|on|master, session, reload|
+|Boolean|on|coordinator, session, reload|
 
 ## <a id="enable_sort"></a>enable\_sort 
 
@@ -394,7 +394,7 @@ Set this parameter to a number of [block\_size](#backslash_quote) blocks \(defau
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|on|master, session, reload|
+|Boolean|on|coordinator, session, reload|
 
 ## <a id="enable_tidscan"></a>enable\_tidscan 
 
@@ -402,7 +402,7 @@ Set this parameter to a number of [block\_size](#backslash_quote) blocks \(defau
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|on|master, session, reload|
+|Boolean|on|coordinator, session, reload|
 
 ## <a id="escape_string_warning"></a>escape\_string\_warning 
 
@@ -410,7 +410,7 @@ When on, a warning is issued if a backslash \(\\\) appears in an ordinary string
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|on|master, session, reload|
+|Boolean|on|coordinator, session, reload|
 
 ## <a id="explain_pretty_print"></a>explain\_pretty\_print 
 
@@ -418,7 +418,7 @@ Determines whether EXPLAIN VERBOSE uses the indented or non-indented format for 
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|on|master, session, reload|
+|Boolean|on|coordinator, session, reload|
 
 ## <a id="extra_float_digits"></a>extra\_float\_digits 
 
@@ -426,7 +426,7 @@ Adjusts the number of digits displayed for floating-point values, including floa
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|integer \(-15 to 3\)|0|master, session, reload|
+|integer \(-15 to 3\)|0|coordinator, session, reload|
 
 ## <a id="from_collapse_limit"></a>from\_collapse\_limit 
 
@@ -434,7 +434,7 @@ The Postgres Planner will merge sub-queries into upper queries if the resulting 
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|1-*n*|20|master, session, reload|
+|1-*n*|20|coordinator, session, reload|
 
 ## <a id="gin_pending_list_limit"></a>gin\_pending\_list\_limit
 
@@ -446,7 +446,7 @@ You can override this setting for individual GIN indexes by changing index stora
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|64 - `MAX_KILOBYTES` |4096|master, session, reload|
+|64 - `MAX_KILOBYTES` |4096|coordinator, session, reload|
 
 ## <a id="gp_adjust_selectivity_for_outerjoins"></a>gp\_adjust\_selectivity\_for\_outerjoins 
 
@@ -454,7 +454,7 @@ Enables the selectivity of NULL tests over outer joins.
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|on|master, session, reload|
+|Boolean|on|coordinator, session, reload|
 
 ## <a id="gp_appendonly_compaction"></a>gp\_appendonly\_compaction 
 
@@ -462,7 +462,7 @@ Enables compacting segment files during `VACUUM` commands. When deactivated, `VA
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|on|master, session, reload|
+|Boolean|on|coordinator, session, reload|
 
 ## <a id="gp_appendonly_compaction_threshold"></a>gp\_appendonly\_compaction\_threshold 
 
@@ -470,7 +470,7 @@ Specifies the threshold ratio \(as a percentage\) of hidden rows to total rows t
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|integer \(%\)|10|master, session, reload|
+|integer \(%\)|10|coordinator, session, reload|
 
 ## <a id="gp_autostats_allow_nonowner"></a>gp\_autostats\_allow\_nonowner 
 
@@ -487,7 +487,7 @@ The `gp_autostats_allow_nonowner` configuration parameter can be changed only by
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|false|master, session, reload, superuser|
+|Boolean|false|coordinator, session, reload, superuser|
 
 ## <a id="gp_autostats_mode"></a>gp\_autostats\_mode 
 
@@ -513,7 +513,7 @@ Automatic statistics collection is triggered if data is inserted directly in a l
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|none, on\_change, on\_no\_stats, |on\_no\_ stats|master, session, reload|
+|none, on\_change, on\_no\_stats, |on\_no\_ stats|coordinator, session, reload|
 
 ## <a id="gp_autostats_mode_in_functions"></a>gp\_autostats\_mode\_in\_functions 
 
@@ -533,7 +533,7 @@ The `on_change` option triggers statistics collection only when the number of ro
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|none, on\_change, on\_no\_stats, |none|master, session, reload|
+|none, on\_change, on\_no\_stats, |none|coordinator, session, reload|
 
 ## <a id="gp_autostats_on_change_threshold"></a>gp\_autostats\_on\_change\_threshold 
 
@@ -541,7 +541,7 @@ Specifies the threshold for automatic statistics collection when `gp_autostats_m
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|integer|2147483647|master, session, reload|
+|integer|2147483647|coordinator, session, reload|
 
 ## <a id="gp_autovacuum_scope"></a>gp\_autovacuum\_scope
 
@@ -554,7 +554,7 @@ Only superusers can change this setting.
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|catalog, catalog_ao_aux | catalog |master, system, reload|
+|catalog, catalog_ao_aux | catalog |coordinator, system, reload|
 
 ## <a id="gp_cached_segworkers_threshold"></a>gp\_cached\_segworkers\_threshold 
 
@@ -562,7 +562,7 @@ When a user starts a session with Greenplum Database and issues a query, the sys
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|integer \> 0|5|master, session, reload|
+|integer \> 0|5|coordinator, session, reload|
 
 ## <a id="gp_command_count"></a>gp\_command\_count 
 
@@ -582,7 +582,7 @@ Could not send data to client: Connection timed out.
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|number of seconds|3600 \(1 hour\)|master, system, reload|
+|number of seconds|3600 \(1 hour\)|coordinator, system, reload|
 
 ## <a id="gp_content"></a>gp\_content 
 
@@ -617,7 +617,7 @@ For information about the Postgres Planner and GPORCA, see "Querying Data" in th
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|boolean|off|master, session, reload|
+|boolean|off|coordinator, session, reload|
 
 ## <a id="gp_dbid"></a>gp\_dbid 
 
@@ -633,7 +633,7 @@ Number of seconds for a Greenplum process to linger after a fatal internal error
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Any valid time expression \(number and unit\)|0|master, session, reload|
+|Any valid time expression \(number and unit\)|0|coordinator, session, reload|
 
 ## <a id="gp_default_storage_options"></a>gp\_default\_storage\_options 
 
@@ -686,7 +686,7 @@ gpconfig -s 'gp_default_storage_options'
 
 |Value Range|Default|Set Classifications<sup>1</sup>|
 |-----------|-------|---------------------|
-|`appendoptimized`= `TRUE` or `FALSE`<br/><br/>`blocksize`= integer between 8192 and 2097152<br/><br/>`checksum`= `TRUE` or `FALSE`<br/><br/>`compresstype`= `ZLIB` or `ZSTD` or `QUICKLZ`<sup>2</sup> or `RLE`\_`TYPE` or `NONE`<br/><br/>`compresslevel`= integer between 0 and 19<br/><br/>`orientation`= `ROW` \| `COLUMN`|`appendoptimized`=`FALSE`<br/><br/>`blocksize`=`32768`<br/><br/>`checksum`=`TRUE`<br/><br/>`compresstype`=`none`<br/><br/>`compresslevel`=`0`<br/><br/>`orientation`=`ROW`|master, session, reload|
+|`appendoptimized`= `TRUE` or `FALSE`<br/><br/>`blocksize`= integer between 8192 and 2097152<br/><br/>`checksum`= `TRUE` or `FALSE`<br/><br/>`compresstype`= `ZLIB` or `ZSTD` or `QUICKLZ`<sup>2</sup> or `RLE`\_`TYPE` or `NONE`<br/><br/>`compresslevel`= integer between 0 and 19<br/><br/>`orientation`= `ROW` \| `COLUMN`|`appendoptimized`=`FALSE`<br/><br/>`blocksize`=`32768`<br/><br/>`checksum`=`TRUE`<br/><br/>`compresstype`=`none`<br/><br/>`compresslevel`=`0`<br/><br/>`orientation`=`ROW`|coordinator, session, reload|
 
 > **Note** <sup>1</sup>The set classification when the parameter is set at the system level with the `gpconfig` utility.
 
@@ -698,7 +698,7 @@ Maximum number of TCP keepalive retransmits from a Greenplum Query Dispatcher to
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|0 to 127|0 \(it uses the system default\)|master, system, restart|
+|0 to 127|0 \(it uses the system default\)|coordinator, system, restart|
 
 ## <a id="gp_dispatch_keepalives_idle"></a>gp\_dispatch\_keepalives\_idle 
 
@@ -706,7 +706,7 @@ Time in seconds between issuing TCP keepalives from a Greenplum Query Dispatcher
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|0 to 32767|0 \(it uses the system default\)|master, system, restart|
+|0 to 32767|0 \(it uses the system default\)|coordinator, system, restart|
 
 ## <a id="gp_dispatch_keepalives_interval"></a>gp\_dispatch\_keepalives\_interval 
 
@@ -714,7 +714,7 @@ Time in seconds between TCP keepalive retransmits from a Greenplum Query Dispatc
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|0 to 32767|0 \(it uses the system default\)|master, system, restart|
+|0 to 32767|0 \(it uses the system default\)|coordinator, system, restart|
 
 ## <a id="gp_dynamic_partition_pruning"></a>gp\_dynamic\_partition\_pruning 
 
@@ -722,7 +722,7 @@ Enables plans that can dynamically eliminate the scanning of partitions.
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|on|master, session, reload|
+|Boolean|on|coordinator, session, reload|
 
 ## <a id="gp_eager_two_phase_agg"></a>gp\_eager\_two\_phase\_agg
 
@@ -732,7 +732,7 @@ The default value is `off`; the Planner chooses the best aggregate path for a qu
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|off|master, session, reload|
+|Boolean|off|coordinator, session, reload|
 
 ## <a id="gp_enable_agg_distinct"></a>gp\_enable\_agg\_distinct 
 
@@ -740,7 +740,7 @@ The default value is `off`; the Planner chooses the best aggregate path for a qu
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|on|master, session, reload|
+|Boolean|on|coordinator, session, reload|
 
 ## <a id="gp_enable_agg_distinct_pruning"></a>gp\_enable\_agg\_distinct\_pruning 
 
@@ -748,7 +748,7 @@ The default value is `off`; the Planner chooses the best aggregate path for a qu
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|on|master, session, reload|
+|Boolean|on|coordinator, session, reload|
 
 ## <a id="gp_enable_direct_dispatch"></a>gp\_enable\_direct\_dispatch 
 
@@ -756,7 +756,7 @@ The default value is `off`; the Planner chooses the best aggregate path for a qu
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|on|master, session, reload|
+|Boolean|on|coordinator, session, reload|
 
 ## <a id="gp_enable_fast_sri"></a>gp\_enable\_fast\_sri 
 
@@ -764,7 +764,7 @@ When set to `on`, the Postgres Planner plans single row inserts so that they are
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|on|master, session, reload|
+|Boolean|on|coordinator, session, reload|
 
 ## <a id="gp_enable_global_deadlock_detector"></a>gp\_enable\_global\_deadlock\_detector 
 
@@ -776,7 +776,7 @@ If the Global Deadlock Detector is enabled, concurrent updates are permitted and
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|off|master, system, restart|
+|Boolean|off|coordinator, system, restart|
 
 ## <a id="gp_enable_groupext_distinct_gather"></a>gp\_enable\_groupext\_distinct\_gather 
 
@@ -784,7 +784,7 @@ If the Global Deadlock Detector is enabled, concurrent updates are permitted and
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|on|master, session, reload|
+|Boolean|on|coordinator, session, reload|
 
 ## <a id="gp_enable_groupext_distinct_pruning"></a>gp\_enable\_groupext\_distinct\_pruning 
 
@@ -792,7 +792,7 @@ If the Global Deadlock Detector is enabled, concurrent updates are permitted and
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|on|master, session, reload|
+|Boolean|on|coordinator, session, reload|
 
 ## <a id="gp_enable_multiphase_agg"></a>gp\_enable\_multiphase\_agg 
 
@@ -800,7 +800,7 @@ If the Global Deadlock Detector is enabled, concurrent updates are permitted and
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|on|master, session, reload|
+|Boolean|on|coordinator, session, reload|
 
 ## <a id="gp_enable_predicate_propagation"></a>gp\_enable\_predicate\_propagation 
 
@@ -808,7 +808,7 @@ When enabled, the Postgres Planner applies query predicates to both table expres
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|on|master, session, reload|
+|Boolean|on|coordinator, session, reload|
 
 ## <a id="gp_enable_preunique"></a>gp\_enable\_preunique 
 
@@ -816,7 +816,7 @@ Enables two-phase duplicate removal for `SELECT DISTINCT` queries \(not `SELECT 
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|on|master, session, reload|
+|Boolean|on|coordinator, session, reload|
 
 ## <a id="gp_enable_query_metrics"></a>gp\_enable\_query\_metrics 
 
@@ -830,7 +830,7 @@ The Greenplum Database metrics collection extension, when enabled, sends the col
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|off|master, system, restart|
+|Boolean|off|coordinator, system, restart|
 
 ## <a id="gp_enable_relsize_collection"></a>gp\_enable\_relsize\_collection 
 
@@ -840,7 +840,7 @@ This parameter is ignored for a root partition of a partitioned table. When GPOR
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|off|master, session, reload|
+|Boolean|off|coordinator, session, reload|
 
 ## <a id="gp_enable_segment_copy_checking"></a>gp\_enable\_segment\_copy\_checking 
 
@@ -852,7 +852,7 @@ The parameter can be set for a database system or a session. The parameter canno
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|true|master, session, reload|
+|Boolean|true|coordinator, session, reload|
 
 ## <a id="gp_enable_sort_limit"></a>gp\_enable\_sort\_limit 
 
@@ -860,7 +860,7 @@ Enable `LIMIT` operation to be performed while sorting. Sorts more efficiently w
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|on|master, session, reload|
+|Boolean|on|coordinator, session, reload|
 
 ## <a id="gp_external_enable_exec"></a>gp\_external\_enable\_exec 
 
@@ -868,7 +868,7 @@ Enable `LIMIT` operation to be performed while sorting. Sorts more efficiently w
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|on|master, system, restart|
+|Boolean|on|coordinator, system, restart|
 
 ## <a id="gp_explain_jit"></a>gp\_explain\_jit
 
@@ -884,7 +884,7 @@ Sets the number of segments that will scan external table data during an externa
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|integer|64|master, session, reload|
+|integer|64|coordinator, session, reload|
 
 ## <a id="gp_external_enable_filter_pushdown"></a>gp\_external\_enable\_filter\_pushdown 
 
@@ -892,7 +892,7 @@ Enable filter pushdown when reading data from external tables. If pushdown fails
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|on|master, session, reload|
+|Boolean|on|coordinator, session, reload|
 
 ## <a id="gp_fts_probe_interval"></a>gp\_fts\_probe\_interval 
 
@@ -900,7 +900,7 @@ Specifies the polling interval for the fault detection process \(`ftsprobe`\). T
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|10 - 3600 seconds|1min|master, system, reload|
+|10 - 3600 seconds|1min|coordinator, system, reload|
 
 ## <a id="gp_fts_probe_retries"></a>gp\_fts\_probe\_retries 
 
@@ -908,7 +908,7 @@ Specifies the number of times the fault detection process \(`ftsprobe`\) attempt
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|integer|5|master, system, reload|
+|integer|5|coordinator, system, reload|
 
 ## <a id="gp_fts_probe_timeout"></a>gp\_fts\_probe\_timeout 
 
@@ -916,7 +916,7 @@ Specifies the allowed timeout for the fault detection process \(`ftsprobe`\) to 
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|10 - 3600 seconds|20 secs|master, system, reload|
+|10 - 3600 seconds|20 secs|coordinator, system, reload|
 
 ## <a id="gp_fts_replication_attempt_count"></a>gp\_fts\_replication\_attempt\_count 
 
@@ -924,7 +924,7 @@ Specifies the maximum number of times that Greenplum Database attempts to establ
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|0 - 100|10|master, system, reload|
+|0 - 100|10|coordinator, system, reload|
 
 ## <a id="gp_global_deadlock_detector_period"></a>gp\_global\_deadlock\_detector\_period 
 
@@ -932,7 +932,7 @@ Specifies the executing interval \(in seconds\) of the global deadlock detector 
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|5 - `INT_MAX` secs|120 secs|master, system, reload|
+|5 - `INT_MAX` secs|120 secs|coordinator, system, reload|
 
 ## <a id="gp_log_endpoints"></a>gp\_log\_endpoints
 
@@ -942,7 +942,7 @@ The default value is `false`, Greenplum Database does not log endpoint details t
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|false|master, session, reload|
+|Boolean|false|coordinator, session, reload|
 
 
 ## <a id="gp_log_fts"></a>gp\_log\_fts 
@@ -951,7 +951,7 @@ Controls the amount of detail the fault detection process \(`ftsprobe`\) writes 
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|OFF, TERSE, VERBOSE, DEBUG|TERSE|master, system, restart|
+|OFF, TERSE, VERBOSE, DEBUG|TERSE|coordinator, system, restart|
 
 ## <a id="gp_log_interconnect"></a>gp\_log\_interconnect 
 
@@ -961,7 +961,7 @@ Increasing the amount of logging could affect performance and increase disk spac
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|off,  terse,  verbose,  debug|terse|master, session, reload|
+|off,  terse,  verbose,  debug|terse|coordinator, session, reload|
 
 ## <a id="gp_log_gang"></a>gp\_log\_gang 
 
@@ -969,7 +969,7 @@ Controls the amount of information that is written to the log file about query w
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|OFF, TERSE, VERBOSE, DEBUG|OFF|master, session, restart|
+|OFF, TERSE, VERBOSE, DEBUG|OFF|coordinator, session, restart|
 
 ## <a id="gp_hashjoin_tuples_per_bucket"></a>gp\_hashjoin\_tuples\_per\_bucket 
 
@@ -977,7 +977,7 @@ Sets the target density of the hash table used by HashJoin operations. A smaller
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|integer|5|master, session, reload|
+|integer|5|coordinator, session, reload|
 
 ## <a id="gp_ignore_error_table"></a>gp\_ignore\_error\_table 
 
@@ -993,7 +993,7 @@ You can set this value to `true` to avoid the Greenplum Database error when you 
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|false|master, session, reload|
+|Boolean|false|coordinator, session, reload|
 
 ## <a id="topic_lvm_ttc_3p"></a>gp\_initial\_bad\_row\_limit 
 
@@ -1007,7 +1007,7 @@ The `SEGMENT REJECT LIMIT` clause can also be specified for the `COPY` command o
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|integer 0 - `INT_MAX`|1000|master, session, reload|
+|integer 0 - `INT_MAX`|1000|coordinator, session, reload|
 
 ## <a id="gp_instrument_shmem_size"></a>gp\_instrument\_shmem\_size 
 
@@ -1015,7 +1015,7 @@ The amount of shared memory, in kilobytes, allocated for query metrics. The defa
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|integer `0 - 131072`|5120|master, system, restart|
+|integer `0 - 131072`|5120|coordinator, system, restart|
 
 ## <a id="gp_interconnect_address_type"></a>gp_interconnect_address_type
 
@@ -1040,7 +1040,7 @@ The log messages contain information about the interconnect communication betwee
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|1 =< Integer < 4096|10|master, session, reload|
+|1 =< Integer < 4096|10|coordinator, session, reload|
 
 ## <a id="gp_interconnect_fc_method"></a>gp\_interconnect\_fc\_method 
 
@@ -1052,7 +1052,7 @@ Loss based flow control is based on capacity based flow control, and also tunes 
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|CAPACITY, LOSS|LOSS|master, session, reload|
+|CAPACITY, LOSS|LOSS|coordinator, session, reload|
 
 ## <a id="gp_interconnect_proxy_addresses"></a>gp\_interconnect\_proxy\_addresses 
 
@@ -1091,7 +1091,7 @@ Sets the amount of data per-peer to be queued by the Greenplum Database intercon
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|1-2048|4|master, session, reload|
+|1-2048|4|coordinator, session, reload|
 
 ## <a id="gp_interconnect_setup_timeout"></a>gp\_interconnect\_setup\_timeout 
 
@@ -1099,7 +1099,7 @@ Specifies the amount of time, in seconds, that Greenplum Database waits for the 
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|0 - 7200 seconds|7200 seconds \(2 hours\)|master, session, reload|
+|0 - 7200 seconds|7200 seconds \(2 hours\)|coordinator, session, reload|
 
 ## <a id="gp_interconnect_snd_queue_depth"></a>gp\_interconnect\_snd\_queue\_depth 
 
@@ -1107,7 +1107,7 @@ Sets the amount of data per-peer to be queued by the default UDPIFC interconnect
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|1 - 4096|2|master, session, reload|
+|1 - 4096|2|coordinator, session, reload|
 
 ## <a id="gp_interconnect_transmit_timeout"></a>gp\_interconnect\_transmit\_timeout 
 
@@ -1115,7 +1115,7 @@ Specifies the amount of time, in seconds, that Greenplum Database waits for netw
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|1 - 7200 seconds|3600 seconds \(1 hour\)|master, session, reload|
+|1 - 7200 seconds|3600 seconds \(1 hour\)|coordinator, session, reload|
 
 ## <a id="gp_interconnect_type"></a>gp_interconnect_type 
 
@@ -1157,7 +1157,7 @@ Sets the tuple-serialization chunk size for the Greenplum Database interconnect.
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|512-65536|8192|master, system, reload|
+|512-65536|8192|coordinator, system, reload|
 
 ## <a id="gp_max_parallel_cursors"></a>gp\_max\_parallel\_cursors
 
@@ -1169,7 +1169,7 @@ You must be a superuser to change the `gp_max_parallel_cursors` setting.
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|-1 - 1024 | -1 | master, superuser, session, reload|
+|-1 - 1024 | -1 | coordinator, superuser, session, reload|
 
 ## <a id="gp_max_plan_size"></a>gp\_max\_plan\_size 
 
@@ -1179,7 +1179,7 @@ You can specify a value in `kB`, `MB`, or `GB`. The default unit is `kB`. For ex
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|integer|0|master, superuser, session, reload|
+|integer|0|coordinator, superuser, session, reload|
 
 ## <a id="gp_max_slices"></a>gp\_max\_slices 
 
@@ -1189,7 +1189,7 @@ Running a query that generates a large number of slices might affect Greenplum D
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|0 - INT\_MAX|0|master, session, reload|
+|0 - INT\_MAX|0|coordinator, session, reload|
 
 ## <a id="max_slot_wal_keep_size"></a>max_slot_wal_keep_size 
 
@@ -1211,7 +1211,7 @@ Sets the Postgres Planner cost estimate for a Motion operator to transfer a row 
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|floating point|0|master, session, reload|
+|floating point|0|coordinator, session, reload|
 
 ## <a id="gp_print_create_gang_time"></a>gp\_print\_create\_gang\_time 
 
@@ -1221,7 +1221,7 @@ The default value is `false`, Greenplum Database does not display the additional
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|false|master, session, reload|
+|Boolean|false|coordinator, session, reload|
 
 
 ## <a id="gp_recursive_cte"></a>gp\_recursive\_cte 
@@ -1236,7 +1236,7 @@ The parameter can be set for a database system, an individual database, or a ses
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|true|master, session, restart|
+|Boolean|true|coordinator, session, restart|
 
 ## <a id="gp_reject_percent_threshold"></a>gp\_reject\_percent\_threshold 
 
@@ -1244,7 +1244,7 @@ For single row error handling on COPY and external table SELECTs, sets the numbe
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|1-*n*|300|master, session, reload|
+|1-*n*|300|coordinator, session, reload|
 
 ## <a id="gp_reraise_signal"></a>gp\_reraise\_signal 
 
@@ -1252,7 +1252,7 @@ If enabled, will attempt to dump core if a fatal server error occurs.
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|on|master, session, reload|
+|Boolean|on|coordinator, session, reload|
 
 ## <a id="gp_resgroup_memory_policy"></a>gp\_resgroup\_memory\_policy 
 
@@ -1344,7 +1344,7 @@ Specifies whether or not Greenplum Database recalculates the maximum amount of m
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|true|master, session, reload|
+|Boolean|true|coordinator, session, reload|
 
 ## <a id="gp_resource_group_memory_limit"></a>gp\_resource\_group\_memory\_limit 
 
@@ -1375,7 +1375,7 @@ Cancel a transaction queued in a resource group that waits longer than the speci
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|0 - `INT_MAX` millisecs|0 millisecs|master, session, reload|
+|0 - `INT_MAX` millisecs|0 millisecs|coordinator, session, reload|
 
 ## <a id="gp_resource_manager"></a>gp\_resource\_manager 
 
@@ -1465,7 +1465,7 @@ Sets the number of primary segment instances for the Postgres Planner to assume 
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|0-*n*|0|master, session, reload|
+|0-*n*|0|coordinator, session, reload|
 
 ## <a id="gp_server_version"></a>gp\_server\_version 
 
@@ -1497,7 +1497,7 @@ If enabled, when a Greenplum server process \(postmaster\) is started it will bi
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|off|master, system, restart|
+|Boolean|off|coordinator, system, restart|
 
 ## <a id="gp_set_read_only"></a>gp\_set\_read\_only 
 
@@ -1505,7 +1505,7 @@ Set to on to deactivate writes to the database. Any in progress transactions mus
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|off|master, system, restart|
+|Boolean|off|coordinator, system, restart|
 
 ## <a id="gp_statistics_pullup_from_child_partition"></a>gp\_statistics\_pullup\_from\_child\_partition 
 
@@ -1517,7 +1517,7 @@ When set to `on`, the Planner attempts to use the statistics from the largest ch
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|off|master, session, reload|
+|Boolean|off|coordinator, session, reload|
 
 ## <a id="gp_statistics_use_fkeys"></a>gp\_statistics\_use\_fkeys 
 
@@ -1527,7 +1527,7 @@ When enabled, the Postgres Planner will use the statistics of the referenced col
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|off|master, session, reload|
+|Boolean|off|coordinator, session, reload|
 
 ## <a id="gp_use_legacy_hashops"></a>gp\_use\_legacy\_hashops 
 
@@ -1537,7 +1537,7 @@ Setting the value to `true` uses the modulo hash algorithm that is compatible wi
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|false|master, session, reload|
+|Boolean|false|coordinator, session, reload|
 
 ## <a id="gp_vmem_idle_resource_timeout"></a>gp\_vmem\_idle\_resource\_timeout 
 
@@ -1545,7 +1545,7 @@ If a database session is idle for longer than the time specified, the session wi
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Any valid time expression \(number and unit\)|18s|master, session, reload|
+|Any valid time expression \(number and unit\)|18s|coordinator, session, reload|
 
 ## <a id="gp_vmem_protect_limit"></a>gp\_vmem\_protect\_limit 
 
@@ -1627,7 +1627,7 @@ If your Greenplum Database installation uses serial ATA \(SATA\) disk drives, en
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|off|master, session, reload|
+|Boolean|off|coordinator, session, reload|
 
 ## <a id="gp_workfile_limit_files_per_query"></a>gp\_workfile\_limit\_files\_per\_query 
 
@@ -1637,7 +1637,7 @@ Set the value to 0 \(zero\) to allow an unlimited number of spill files. coordin
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|integer|100000|master, session, reload|
+|integer|100000|coordinator, session, reload|
 
 ## <a id="gp_workfile_limit_per_query"></a>gp\_workfile\_limit\_per\_query 
 
@@ -1645,7 +1645,7 @@ Sets the maximum disk size an individual query is allowed to use for creating te
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|kilobytes|0|master, session, reload|
+|kilobytes|0|coordinator, session, reload|
 
 ## <a id="gp_workfile_limit_per_segment"></a>gp\_workfile\_limit\_per\_segment 
 
@@ -1697,7 +1697,7 @@ The value *iso\_8601* will produce output matching the time interval *format wit
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|postgres, postgres\_verbose, sql\_standard, iso\_8601|postgres|master, session, reload|
+|postgres, postgres\_verbose, sql\_standard, iso\_8601|postgres|coordinator, session, reload|
 
 ## <a id="jit"></a>jit
 
@@ -1785,7 +1785,7 @@ The Postgres Planner will rewrite explicit inner `JOIN` constructs into lists of
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|1-*n*|20|master, session, reload|
+|1-*n*|20|coordinator, session, reload|
 
 ## <a id="krb_caseins_users"></a>krb\_caseins\_users 
 
@@ -1793,7 +1793,7 @@ Sets whether Kerberos user names should be treated case-insensitively. The defau
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|off|master, system, reload|
+|Boolean|off|coordinator, system, reload|
 
 ## <a id="krb_server_keyfile"></a>krb\_server\_keyfile 
 
@@ -1801,7 +1801,7 @@ Sets the location of the Kerberos server key file.
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|path and file name|unset|master, system, restart|
+|path and file name|unset|coordinator, system, restart|
 
 ## <a id="lc_collate"></a>lc\_collate 
 
@@ -1857,7 +1857,7 @@ Specifies the TCP/IP address\(es\) on which the server is to listen for connecti
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|localhost, host names, IP addresses, \* \(all available IP interfaces\)|\*|master, system, restart|
+|localhost, host names, IP addresses, \* \(all available IP interfaces\)|\*|coordinator, system, restart|
 
 ## <a id="local_preload_libraries"></a>local\_preload\_libraries 
 
@@ -1879,7 +1879,7 @@ Greenplum Database uses the [deadlock\_timeout](#deadlock_timeout) and [gp\_glob
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|0 - `INT_MAX` millisecs|0 millisecs|master, session, reload|
+|0 - `INT_MAX` millisecs|0 millisecs|coordinator, session, reload|
 
 ## <a id="log_autostats"></a>log\_autostats 
 
@@ -1887,7 +1887,7 @@ Logs information about automatic `ANALYZE` operations related to [gp\_autostats\
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|off|master, session, reload, superuser|
+|Boolean|off|coordinator, session, reload, superuser|
 
 ## <a id="log_connections"></a>log\_connections 
 
@@ -1919,7 +1919,7 @@ Causes the duration of every completed statement which satisfies *log\_statement
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|off|master, session, reload, superuser|
+|Boolean|off|coordinator, session, reload, superuser|
 
 ## <a id="log_error_verbosity"></a>log\_error\_verbosity 
 
@@ -1927,7 +1927,7 @@ Controls the amount of detail written in the server log for each message that is
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|TERSE, DEFAULT, VERBOSE|DEFAULT|master, session, reload, superuser|
+|TERSE, DEFAULT, VERBOSE|DEFAULT|coordinator, session, reload, superuser|
 
 ## <a id="log_executor_stats"></a>log\_executor\_stats 
 
@@ -1951,7 +1951,7 @@ By default, connection log messages only show the IP address of the connecting h
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|off|master, system, reload|
+|Boolean|off|coordinator, system, reload|
 
 ## <a id="log_min_duration_statement"></a>log\_min\_duration\_statement 
 
@@ -1959,7 +1959,7 @@ Logs the statement and its duration on a single log line if its duration is grea
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|number of milliseconds, 0, -1|-1|master, session, reload, superuser|
+|number of milliseconds, 0, -1|-1|coordinator, session, reload, superuser|
 
 ## <a id="log_min_error_statement"></a>log\_min\_error\_statement 
 
@@ -1967,7 +1967,7 @@ Controls whether or not the SQL statement that causes an error condition will al
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|DEBUG5, DEBUG4, DEBUG3, DEBUG2, DEBUG1, INFO, NOTICE, WARNING, ERROR, FATAL, PANIC|ERROR|master, session, reload, superuser|
+|DEBUG5, DEBUG4, DEBUG3, DEBUG2, DEBUG1, INFO, NOTICE, WARNING, ERROR, FATAL, PANIC|ERROR|coordinator, session, reload, superuser|
 
 ## <a id="log_min_messages"></a>log\_min\_messages 
 
@@ -1977,7 +1977,7 @@ If the Greenplum Database PL/Container extension is installed. This parameter al
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|DEBUG5, DEBUG4, DEBUG3, DEBUG2, DEBUG1, INFO, NOTICE, WARNING, LOG, ERROR, FATAL, PANIC|WARNING|master, session, reload, superuser|
+|DEBUG5, DEBUG4, DEBUG3, DEBUG2, DEBUG1, INFO, NOTICE, WARNING, LOG, ERROR, FATAL, PANIC|WARNING|coordinator, session, reload, superuser|
 
 ## <a id="log_parser_stats"></a>log\_parser\_stats 
 
@@ -1985,7 +1985,7 @@ For each query, write performance statistics of the query parser to the server l
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|off|master, session, reload, superuser|
+|Boolean|off|coordinator, session, reload, superuser|
 
 ## <a id="log_planner_stats"></a>log\_planner\_stats 
 
@@ -1993,7 +1993,7 @@ For each query, write performance statistics of the Postgres Planner to the serv
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|off|master, session, reload, superuser|
+|Boolean|off|coordinator, session, reload, superuser|
 
 ## <a id="log_rotation_age"></a>log\_rotation\_age 
 
@@ -2019,7 +2019,7 @@ Controls which SQL statements are logged. DDL logs all data definition commands 
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|NONE, DDL, MOD, ALL|ALL|master, session, reload, superuser|
+|NONE, DDL, MOD, ALL|ALL|coordinator, session, reload, superuser|
 
 ## <a id="log_statement_stats"></a>log\_statement\_stats 
 
@@ -2027,7 +2027,7 @@ For each query, write total performance statistics of the query parser, planner,
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|off|master, session, reload, superuser|
+|Boolean|off|coordinator, session, reload, superuser|
 
 ## <a id="log_temp_files"></a>log\_temp\_files 
 
@@ -2069,7 +2069,7 @@ Increasing this parameter may cause Greenplum Database to request more shared me
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|10 - 262143|250 on master750 on segments
+|10 - 262143|250 on coordinator750 on segments
 
 |local, system, restart|
 
@@ -2129,7 +2129,7 @@ Sets the maximum number of simultaneously open user-declared cursors allowed per
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|integer|64|master, system, restart|
+|integer|64|coordinator, system, restart|
 
 ## <a id="max_resource_queues"></a>max\_resource\_queues 
 
@@ -2139,7 +2139,7 @@ Sets the maximum number of resource queues that can be created in a Greenplum Da
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|integer|9|master, system, restart|
+|integer|9|coordinator, system, restart|
 
 ## <a id="max_stack_depth"></a>max\_stack\_depth 
 
@@ -2161,7 +2161,7 @@ When changing both `max_statement_mem` and `statement_mem`, `max_statement_mem` 
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|number of kilobytes|2000MB|master, session, reload, superuser|
+|number of kilobytes|2000MB|coordinator, session, reload, superuser|
 
 ## <a id="memory_spill_ratio"></a>memory\_spill\_ratio 
 
@@ -2175,7 +2175,7 @@ You can specify an integer percentage value from 0 to 100 inclusive. If you spec
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|0 - 100|20|master, session, reload|
+|0 - 100|20|coordinator, session, reload|
 
 ## <a id="optimizer"></a>optimizer 
 
@@ -2189,7 +2189,7 @@ For information about the Postgres Planner and GPORCA, see [Querying Data](../..
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|on|master, session, reload|
+|Boolean|on|coordinator, session, reload|
 
 ## <a id="optimizer_analyze_root_partition"></a>optimizer\_analyze\_root\_partition 
 
@@ -2203,7 +2203,7 @@ For information about the Postgres Planner and GPORCA, see [Querying Data](../..
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|on|master, session, reload|
+|Boolean|on|coordinator, session, reload|
 
 ## <a id="optimizer_array_expansion_threshold"></a>optimizer\_array\_expansion\_threshold 
 
@@ -2219,7 +2219,7 @@ The parameter can be set for a database system, an individual database, or a ses
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Integer \> 0|20|master, session, reload|
+|Integer \> 0|20|coordinator, session, reload|
 
 ## <a id="optimizer_control"></a>optimizer\_control 
 
@@ -2227,7 +2227,7 @@ Controls whether the server configuration parameter optimizer can be changed wit
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|on|master, session, reload, superuser|
+|Boolean|on|coordinator, session, reload, superuser|
 
 ## <a id="optimizer_cost_model"></a>optimizer\_cost\_model 
 
@@ -2241,7 +2241,7 @@ The default cost model, `calibrated`, is more likely to choose a faster bitmap i
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|legacy, calibrated, experimental|calibrated|master, session, reload|
+|legacy, calibrated, experimental|calibrated|coordinator, session, reload|
 
 ## <a id="optimizer_cte_inlining_bound"></a>optimizer\_cte\_inlining\_bound 
 
@@ -2251,7 +2251,7 @@ The parameter can be set for a database system, an individual database, or a ses
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Decimal \>= 0|0|master, session, reload|
+|Decimal \>= 0|0|coordinator, session, reload|
 
 ## <a id="optimizer_dpe_stats"></a>optimizer\_dpe\_stats 
 
@@ -2261,7 +2261,7 @@ The parameter can be set for a database system, an individual database, or a ses
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|true|master, session, reload|
+|Boolean|true|coordinator, session, reload|
 
 ## <a id="optimizer_discard_redistribute_hashjoin"></a>optimizer\_discard\_redistribute\_hashjoin
 
@@ -2271,7 +2271,7 @@ The default setting is `off`, GPORCA considers all plan alternatives, including 
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|off|master, session, reload|
+|Boolean|off|coordinator, session, reload|
 
 
 ## <a id="optimizer_enable_associativity"></a>optimizer\_enable\_associativity 
@@ -2286,7 +2286,7 @@ For information about GPORCA, see [About GPORCA](../../admin_guide/query/topics/
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|off|master, session, reload|
+|Boolean|off|coordinator, session, reload|
 
 ## <a id="optimizer_enable_dml"></a>optimizer\_enable\_dml 
 
@@ -2300,7 +2300,7 @@ For information about GPORCA, see [About GPORCA](../../admin_guide/query/topics/
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|true|master, session, reload|
+|Boolean|true|coordinator, session, reload|
 
 ## <a id="optimizer_enable_foreign_table"></a>optimizer\_enable\_foreign\_table
 
@@ -2308,7 +2308,7 @@ When GPORCA is enabled \(the default\) and this configuration parameter is `true
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|true|master, session, reload|
+|Boolean|true|coordinator, session, reload|
 
 ## <a id="optimizer_enable_indexonlyscan"></a>optimizer\_enable\_indexonlyscan 
 
@@ -2322,7 +2322,7 @@ For information about GPORCA, see [About GPORCA](../../admin_guide/query/topics/
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|true|master, session, reload|
+|Boolean|true|coordinator, session, reload|
 
 ## <a id="optimizer_enable_master_only_queries"></a>optimizer\_enable\_master\_only\_queries 
 
@@ -2336,7 +2336,7 @@ For information about GPORCA, see [About GPORCA](../../admin_guide/query/topics/
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|off|master, session, reload|
+|Boolean|off|coordinator, session, reload|
 
 ## <a id="optimizer_enable_multiple_distinct_aggs"></a>optimizer\_enable\_multiple\_distinct\_aggs 
 
@@ -2348,7 +2348,7 @@ For information about GPORCA, see [About GPORCA](../../admin_guide/query/topics/
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|off|master, session, reload|
+|Boolean|off|coordinator, session, reload|
 
 ## <a id="optimizer_enable_replicated_table"></a>optimizer\_enable\_replicated\_table 
 
@@ -2362,7 +2362,7 @@ For information about GPORCA, see [About GPORCA](../../admin_guide/query/topics/
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|on|master, session, reload|
+|Boolean|on|coordinator, session, reload|
 
 ## <a id="optimizer_force_agg_skew_avoidance"></a>optimizer\_force\_agg\_skew\_avoidance 
 
@@ -2374,7 +2374,7 @@ For information about GPORCA, see [About GPORCA](../../admin_guide/query/topics/
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|true|master, session, reload|
+|Boolean|true|coordinator, session, reload|
 
 ## <a id="optimizer_force_comprehensive_join_implementation"></a>optimizer\_force\_comprehensive\_join\_implementation 
 
@@ -2384,7 +2384,7 @@ The default value is `false`, GPORCA does not consider nested loop join alternat
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|false|master, session, reload|
+|Boolean|false|coordinator, session, reload|
 
 ## <a id="optimizer_force_multistage_agg"></a>optimizer\_force\_multistage\_agg 
 
@@ -2394,7 +2394,7 @@ The parameter can be set for a database system, an individual database, or a ses
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|true|master, session, reload|
+|Boolean|true|coordinator, session, reload|
 
 ## <a id="optimizer_force_three_stage_scalar_dqa"></a>optimizer\_force\_three\_stage\_scalar\_dqa 
 
@@ -2404,7 +2404,7 @@ The parameter can be set for a database system, an individual database, or a ses
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|true|master, session, reload|
+|Boolean|true|coordinator, session, reload|
 
 ## <a id="optimizer_join_arity_for_associativity_commutativity"></a>optimizer\_join\_arity\_for\_associativity\_commutativity 
 
@@ -2436,7 +2436,7 @@ This parameter can be set for an individual database, a session, or a query.
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|query, greedy, exhaustive|exhaustive|master, session, reload|
+|query, greedy, exhaustive|exhaustive|coordinator, session, reload|
 
 ## <a id="optimizer_join_order_threshold"></a>optimizer\_join\_order\_threshold 
 
@@ -2446,7 +2446,7 @@ This parameter has no effect when the `optimizer_join_query` parameter is set to
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|0 - 12|10|master, session, reload|
+|0 - 12|10|coordinator, session, reload|
 
 ## <a id="optimizer_mdcache_size"></a>optimizer\_mdcache\_size 
 
@@ -2460,7 +2460,7 @@ This parameter can be set for a database system, an individual database, or a se
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Integer \>= 0|16384|master, session, reload|
+|Integer \>= 0|16384|coordinator, session, reload|
 
 ## <a id="optimizer_metadata_caching"></a>optimizer\_metadata\_caching 
 
@@ -2474,7 +2474,7 @@ The server configuration parameter [optimizer\_mdcache\_size](#optimizer_mdcache
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|on|master, session, reload|
+|Boolean|on|coordinator, session, reload|
 
 ## <a id="optimizer_minidump"></a>optimizer\_minidump 
 
@@ -2496,7 +2496,7 @@ For information about GPORCA, see [About GPORCA](../../admin_guide/query/topics/
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|ONERROR, ALWAYS|ONERROR|master, session, reload|
+|ONERROR, ALWAYS|ONERROR|coordinator, session, reload|
 
 ## <a id="optimizer_nestloop_factor"></a>optimizer\_nestloop\_factor 
 
@@ -2506,7 +2506,7 @@ The parameter can be set for a database system, an individual database, or a ses
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|INT\_MAX \> 1|1024|master, session, reload|
+|INT\_MAX \> 1|1024|coordinator, session, reload|
 
 ## <a id="optimizer_parallel_union"></a>optimizer\_parallel\_union 
 
@@ -2520,7 +2520,7 @@ The parameter can be set for a database system, an individual database, or a ses
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|boolean|off|master, session, reload|
+|boolean|off|coordinator, session, reload|
 
 ## <a id="optimizer_penalize_broadcast_threshold"></a>optimizer_penalize_skew_broadcast_threshold
 
@@ -2530,7 +2530,7 @@ When this parameter is set to `0`, GPORCA sets this broadcast threshold to unlim
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|integer >= 0|100K rows|master, session, reload|
+|integer >= 0|100K rows|coordinator, session, reload|
 
 ## <a id="optimizer_penalize_skew"></a>optimizer\_penalize\_skew 
 
@@ -2544,7 +2544,7 @@ For information about GPORCA, see [About GPORCA](../../admin_guide/query/topics/
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|true|master, session, reload|
+|Boolean|true|coordinator, session, reload|
 
 ## <a id="optimizer_print_missing_stats"></a>optimizer\_print\_missing\_stats 
 
@@ -2556,7 +2556,7 @@ The parameter can be set for a database system, an individual database, or a ses
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|true|master, session, reload|
+|Boolean|true|coordinator, session, reload|
 
 ## <a id="optimizer_print_optimization_stats"></a>optimizer\_print\_optimization\_stats 
 
@@ -2571,7 +2571,7 @@ This parameter can be set for a database system, an individual database, or a se
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|off|master, session, reload|
+|Boolean|off|coordinator, session, reload|
 
 ## <a id="optimizer_skew_factor"></a>optimizer\_skew\_factor 
 
@@ -2585,7 +2585,7 @@ The parameter can be set for a database system, an individual database, or a ses
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|integer 0-100 |0|master, session, reload|
+|integer 0-100 |0|coordinator, session, reload|
 
 ## <a id="optimizer_sort_factor"></a>optimizer\_sort\_factor 
 
@@ -2595,7 +2595,7 @@ The parameter can be set for a database system, an individual database, or a ses
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Decimal \> 0|1|master, session, reload|
+|Decimal \> 0|1|coordinator, session, reload|
 
 ## <a id="optimizer_use_gpdb_allocators"></a>optimizer\_use\_gpdb\_allocators 
 
@@ -2605,7 +2605,7 @@ For information about GPORCA, see [About GPORCA](../../admin_guide/query/topics/
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|true|master, system, restart|
+|Boolean|true|coordinator, system, restart|
 
 ## <a id="optimizer_xform_bind_threshold"></a>optimizer\_xform\_bind\_threshold 
 
@@ -2615,7 +2615,7 @@ The default value is `0`, GPORCA produces an unlimited set of bindings.
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|0 - INT\_MAX|0|master, session, reload|
+|0 - INT\_MAX|0|coordinator, session, reload|
 
 ## <a id="password_encryption"></a>password\_encryption 
 
@@ -2623,7 +2623,7 @@ When a password is specified in CREATE USER or ALTER USER without writing either
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|on|master, session, reload|
+|Boolean|on|coordinator, session, reload|
 
 ## <a id="plan_cache_mode"></a>plan\_cache\_mode 
 
@@ -2635,7 +2635,7 @@ The parameter can be set for a database system, an individual database, a sessio
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|auto, force\_custom\_plan, force\_generic\_plan|auto|master, session, reload|
+|auto, force\_custom\_plan, force\_generic\_plan|auto|coordinator, session, reload|
 
 ## <a id="pljava_classpath"></a>pljava\_classpath 
 
@@ -2651,7 +2651,7 @@ If [pljava\_classpath\_insecure](#pljava_classpath_insecure) is `false`, setting
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|string| |master, session, reload, superuser|
+|string| |coordinator, session, reload, superuser|
 
 ## <a id="pljava_classpath_insecure"></a>pljava\_classpath\_insecure 
 
@@ -2661,7 +2661,7 @@ Controls whether the server configuration parameter [pljava\_classpath](#pljava_
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|false|master, session, reload, superuser|
+|Boolean|false|coordinator, session, reload, superuser|
 
 ## <a id="pljava_statement_cache_size"></a>pljava\_statement\_cache\_size 
 
@@ -2669,7 +2669,7 @@ Sets the size in KB of the JRE MRU \(Most Recently Used\) cache for prepared sta
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|number of kilobytes|10|master, system, reload, superuser|
+|number of kilobytes|10|coordinator, system, reload, superuser|
 
 ## <a id="pljava_release_lingering_savepoints"></a>pljava\_release\_lingering\_savepoints 
 
@@ -2677,7 +2677,7 @@ If true, lingering savepoints used in PL/Java functions will be released on func
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|true|master, system, reload, superuser|
+|Boolean|true|coordinator, system, reload, superuser|
 
 ## <a id="pljava_vmoptions"></a>pljava\_vmoptions 
 
@@ -2685,7 +2685,7 @@ Defines the startup options for the Java VM. The default value is an empty strin
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|string| |master, system, reload, superuser|
+|string| |coordinator, system, reload, superuser|
 
 ## <a id="port"></a>port 
 
@@ -2709,7 +2709,7 @@ Sets the estimate of the cost of a nonsequentially fetched disk page for the Pos
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|floating point|100|master, session, reload|
+|floating point|100|coordinator, session, reload|
 
 ## <a id="readable_external_table_timeout"></a>readable\_external\_table\_timeout 
 
@@ -2721,7 +2721,7 @@ If queries that use gpfdist run a long time and then return the error "intermitt
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|integer \>= 0|0|master, system, reload|
+|integer \>= 0|0|coordinator, system, reload|
 
 ## <a id="repl_catchup_within_range"></a>repl\_catchup\_within\_range 
 
@@ -2731,7 +2731,7 @@ If the number of segment files does not exceed the value, Greenplum Database blo
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|0 - 64|1|master, system, reload, superuser|
+|0 - 64|1|coordinator, system, reload, superuser|
 
 ## <a id="replication_timeout"></a>wal\_sender\_timeout 
 
@@ -2741,7 +2741,7 @@ The [wal\_receiver\_status\_interval](#wal_receiver_status_interval) controls th
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|0 - INT\_MAX|60000 ms \(60 seconds\)|master, system, reload, superuser|
+|0 - INT\_MAX|60000 ms \(60 seconds\)|coordinator, system, reload, superuser|
 
 ## <a id="resource_cleanup_gangs_on_wait"></a>resource\_cleanup\_gangs\_on\_wait 
 
@@ -2751,7 +2751,7 @@ If a statement is submitted through a resource queue, clean up any idle query ex
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|on|master, session, reload|
+|Boolean|on|coordinator, session, reload|
 
 ## <a id="resource_select_only"></a>resource\_select\_only 
 
@@ -2761,7 +2761,7 @@ Sets the types of queries managed by resource queues. If set to on, then `SELECT
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|off|master, system, restart|
+|Boolean|off|coordinator, system, restart|
 
 ## <a id="row_security"></a>row\_security
 
@@ -2775,7 +2775,7 @@ For more information about row-level security policies, see [CREATE POLICY](../s
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|on|master, system, restart|
+|Boolean|on|coordinator, system, restart|
 
 ## <a id="runaway_detector_activation_percent"></a>runaway\_detector\_activation\_percent 
 
@@ -2811,7 +2811,7 @@ Specifies the order in which schemas are searched when an object is referenced b
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|a comma-separated list of schema names|$user,public|master, session, reload|
+|a comma-separated list of schema names|$user,public|coordinator, session, reload|
 
 ## <a id="seq_page_cost"></a>seq\_page\_cost 
 
@@ -2819,7 +2819,7 @@ For the Postgres Planner, sets the estimate of the cost of a disk page fetch tha
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|floating point|1|master, session, reload|
+|floating point|1|coordinator, session, reload|
 
 ## <a id="server_encoding"></a>server\_encoding 
 
@@ -2893,7 +2893,7 @@ Enables SSL connections.
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|off|master, system, restart|
+|Boolean|off|coordinator, system, restart|
 
 ## <a id="ssl_ciphers"></a>ssl\_ciphers 
 
@@ -2905,7 +2905,7 @@ See the openssl manual page for a list of supported ciphers.
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|string|ALL:!ADH:!LOW:!EXP:!MD5:@STRENGTH|master, system, restart|
+|string|ALL:!ADH:!LOW:!EXP:!MD5:@STRENGTH|coordinator, system, restart|
 
 ## <a id="standard_conforming_strings"></a>standard\_conforming\_strings 
 
@@ -2913,7 +2913,7 @@ Determines whether ordinary string literals \('...'\) treat backslashes literall
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|on|master, session, reload|
+|Boolean|on|coordinator, session, reload|
 
 ## <a id="statement_mem"></a>statement\_mem 
 
@@ -2950,7 +2950,7 @@ When changing both `max_statement_mem` and `statement_mem`, `max_statement_mem` 
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|number of kilobytes|128MB|master, session, reload|
+|number of kilobytes|128MB|coordinator, session, reload|
 
 ## <a id="statement_timeout"></a>statement\_timeout 
 
@@ -2958,7 +2958,7 @@ Abort any statement that takes over the specified number of milliseconds. 0 turn
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|number of milliseconds|0|master, session, reload|
+|number of milliseconds|0|coordinator, session, reload|
 
 ## <a id="stats_queue_level"></a>stats\_queue\_level 
 
@@ -2968,7 +2968,7 @@ Collects resource queue statistics on database activity.
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|off|master, session, reload|
+|Boolean|off|coordinator, session, reload|
 
 ## <a id="superuser_reserved_connections"></a>superuser\_reserved\_connections 
 
@@ -3016,7 +3016,7 @@ You can set this parameter to the number of 32K blocks \(for example, `1024` to 
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|integer|1024 \(32MB\)|master, session, reload|
+|integer|1024 \(32MB\)|coordinator, session, reload|
 
 ## <a id="topic_k52_fqm_f3b"></a>temp\_tablespaces 
 
@@ -3032,7 +3032,7 @@ See also [default\_tablespace](#default_tablespace).
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|one or more tablespace names|unset|master, session, reload|
+|one or more tablespace names|unset|coordinator, session, reload|
 
 ## <a id="TimeZone"></a>TimeZone 
 
@@ -3055,7 +3055,7 @@ To configure Greenplum Database to use a custom collection of timezones, copy th
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|string|Default|master, session, reload|
+|string|Default|coordinator, session, reload|
 
 ## <a id="track_activities"></a>track\_activities 
 
@@ -3065,7 +3065,7 @@ Enables the collection of information on the currently executing command of each
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|true|master, session, reload, superuser|
+|Boolean|true|coordinator, session, reload, superuser|
 
 ## <a id="track_activity_query_size"></a>track\_activity\_query\_size 
 
@@ -3081,7 +3081,7 @@ Collects information about executing commands. Enables the collection of informa
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|true|master, session, reload, superuser|
+|Boolean|true|coordinator, session, reload, superuser|
 
 ## <a id="track_wal_io_timing"></a>track_wal_io_timing
 
@@ -3097,7 +3097,7 @@ Sets the current transaction's isolation level.
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|read committed, serializable|read committed|master, session, reload|
+|read committed, serializable|read committed|coordinator, session, reload|
 
 ## <a id="transaction_read_only"></a>transaction\_read\_only 
 
@@ -3105,7 +3105,7 @@ Sets the current transaction's read-only status.
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|off|master, session, reload|
+|Boolean|off|coordinator, session, reload|
 
 ## <a id="transform_null_equals"></a>transform\_null\_equals 
 
@@ -3113,7 +3113,7 @@ When on, expressions of the form expr = NULL \(or NULL = expr\) are treated as e
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|off|master, session, reload|
+|Boolean|off|coordinator, session, reload|
 
 ## <a id="unix_socket_directory"></a>unix\_socket\_directories 
 
@@ -3219,7 +3219,7 @@ If Greenplum Database detects a corruption in the free TID list, the free TID li
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|true|master, session, reload|
+|Boolean|true|coordinator, session, reload|
 
 ## <a id="verify_gpfdists_cert"></a>verify\_gpfdists\_cert 
 
@@ -3242,7 +3242,7 @@ For information about the `gpfdists` protocol, see [gpfdists:// Protocol](../../
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|true|master, session, reload|
+|Boolean|true|coordinator, session, reload|
 
 ## <a id="vmem_process_interrupt"></a>vmem\_process\_interrupt 
 
@@ -3250,7 +3250,7 @@ Enables checking for interrupts before reserving vmem memory for a query during 
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|Boolean|off|master, session, reload|
+|Boolean|off|coordinator, session, reload|
 
 ## <a id="wait_for_replication_threshold"></a>wait\_for\_replication\_threshold 
 
@@ -3262,7 +3262,7 @@ If you set the value to 0, database performance issues might occur under heavy l
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|0 - MAX-INT / 1024|1024|master, system, reload|
+|0 - MAX-INT / 1024|1024|coordinator, system, reload|
 
 ## <a id="wal_keep_size"></a>wal_keep_size 
 
@@ -3274,7 +3274,7 @@ If this value is specified without units, it is taken as megabytes.
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|integer|5 times the default size of the write-ahead log file|master, system, reload, superuser|
+|integer|5 times the default size of the write-ahead log file|coordinator, system, reload, superuser|
 
 ## <a id="wal_receiver_status_interval"></a>wal\_receiver\_status\_interval 
 
@@ -3284,7 +3284,7 @@ The value of [wal\_sender\_timeout](#replication_timeout) controls the time that
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|integer 0- INT\_MAX/1000|10 sec|master, system, reload, superuser|
+|integer 0- INT\_MAX/1000|10 sec|coordinator, system, reload, superuser|
 
 ## <a id="writable_external_table_bufsize"></a>writable\_external\_table\_bufsize 
 
@@ -3318,7 +3318,7 @@ The parameter can be set for a database system, an individual database, or a ses
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|base64, hex|base64|master, session, reload|
+|base64, hex|base64|coordinator, session, reload|
 
 ## <a id="xmloption"></a>xmloption 
 
@@ -3338,5 +3338,5 @@ SET XML OPTION { DOCUMENT | CONTENT }
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-|document, content|content|master, session, reload|
+|document, content|content|coordinator, session, reload|
 

--- a/gpdb-doc/markdown/ref_guide/gp_toolkit.html.md
+++ b/gpdb-doc/markdown/ref_guide/gp_toolkit.html.md
@@ -501,7 +501,7 @@ This view is accessible to all users.
 |memory\_shared\_quota|The shared memory quota \(`MEMORY_SHARED_QUOTA`\) value specified for the resource group.|
 |memory\_spill\_ratio|The memory spill ratio \(`MEMORY_SPILL_RATIO`\) value specified for the resource group.|
 |memory\_auditor|The memory auditor for the resource group.|
-|cpuset|The CPU cores reserved for the resource group on the master host and segment hosts, or -1.|
+|cpuset|The CPU cores reserved for the resource group on the coordinator host and segment hosts, or -1.|
 
 ### <a id="topic31x"></a>gp\_resgroup\_status 
 

--- a/gpdb-doc/markdown/ref_guide/sql_commands/ALTER_FUNCTION.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/ALTER_FUNCTION.html.md
@@ -27,7 +27,7 @@ where <action> is one of:
     [ NOT ] LEAKPROOF
     { [EXTERNAL] SECURITY INVOKER | [EXTERNAL] SECURITY DEFINER }
     PARALLEL { UNSAFE | RESTRICTED | SAFE }
-    EXECUTE ON { ANY | MASTER | ALL SEGMENTS | INITPLAN }
+    EXECUTE ON { ANY | COORDINATOR | ALL SEGMENTS | INITPLAN }
     COST <execution_cost>
     ROWS <result_rows>
     SUPPORT <support_function>
@@ -90,14 +90,14 @@ LEAKPROOF
 :   Change whether the function is considered leakproof or not. See [CREATE FUNCTION](CREATE_FUNCTION.html) for more information about this capability.
 
 EXECUTE ON ANY
-EXECUTE ON MASTER
+EXECUTE ON COORDINATOR
 EXECUTE ON ALL SEGMENTS
 EXECUTE ON INITPLAN
 :   The `EXECUTE ON` attributes specify where \(coordinator or segment instance\) a function runs when it is invoked during the query execution process.
 
 :   `EXECUTE ON ANY` \(the default\) indicates that the function can be run on the coordinator, or any segment instance, and it returns the same result regardless of where it is run. Greenplum Database determines where the function runs.
 
-:   `EXECUTE ON MASTER` indicates that the function must run only on the coordinator instance.
+:   `EXECUTE ON COORDINATOR` indicates that the function must run only on the coordinator instance.
 
 :   `EXECUTE ON ALL SEGMENTS` indicates that the function must run on all primary segment instances, but not the coordinator, for each invocation. The overall result of the function is the `UNION ALL` of the results from all segment instances.
 

--- a/gpdb-doc/markdown/ref_guide/sql_commands/ALTER_ROUTINE.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/ALTER_ROUTINE.html.md
@@ -26,7 +26,7 @@ where <action> is one of (depending on the type of routine):
     [ NOT ] LEAKPROOF
     { [EXTERNAL] SECURITY INVOKER | [EXTERNAL] SECURITY DEFINER }
     PARALLEL { UNSAFE | RESTRICTED | SAFE }
-    EXECUTE ON { ANY | MASTER | ALL SEGMENTS | INITPLAN }
+    EXECUTE ON { ANY | COORDINATOR | ALL SEGMENTS | INITPLAN }
     COST <execution_cost>
     ROWS <result_rows>
     SET <configuration_parameter> { TO | = } { <value> | DEFAULT }

--- a/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_AGGREGATE.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_AGGREGATE.html.md
@@ -124,9 +124,9 @@ Further assumptions are that the aggregate function ignores null inputs, and tha
 
 To be able to create an aggregate function, you must have `USAGE` privilege on the argument types, the state type\(s\), and the return type, as well as `EXECUTE` privilege on the supporting functions.
 
-You can specify `combinefunc` as a method for optimizing aggregate execution. By specifying `combinefunc`, the aggregate can be run in parallel on segments first and then on the master. When a two-level execution is performed, the `sfunc` is run on the segments to generate partial aggregate results, and `combinefunc` is run on the master to aggregate the partial results from segments. If single-level aggregation is performed, all the rows are sent to the master and the `sfunc` is applied to the rows.
+You can specify `combinefunc` as a method for optimizing aggregate execution. By specifying `combinefunc`, the aggregate can be run in parallel on segments first and then on the coordinator. When a two-level execution is performed, the `sfunc` is run on the segments to generate partial aggregate results, and `combinefunc` is run on the coordinator to aggregate the partial results from segments. If single-level aggregation is performed, all the rows are sent to the coordinator and the `sfunc` is applied to the rows.
 
-Single-level aggregation and two-level aggregation are equivalent execution strategies. Either type of aggregation can be implemented in a query plan. When you implement the functions `combinefunc` and `sfunc`, you must ensure that the invocation of the `sfunc` on the segment instances followed by `combinefunc` on the master produce the same result as single-level aggregation that sends all the rows to the master and then applies only the `sfunc` to the rows.
+Single-level aggregation and two-level aggregation are equivalent execution strategies. Either type of aggregation can be implemented in a query plan. When you implement the functions `combinefunc` and `sfunc`, you must ensure that the invocation of the `sfunc` on the segment instances followed by `combinefunc` on the coordinator produce the same result as single-level aggregation that sends all the rows to the coordinator and then applies only the `sfunc` to the rows.
 
 ## <a id="section5"></a>Parameters 
 

--- a/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_EXTERNAL_TABLE.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_EXTERNAL_TABLE.html.md
@@ -14,7 +14,7 @@ CREATE [READABLE] EXTERNAL [TEMPORARY | TEMP] TABLE <table_name>     
            [, ...])
        | ('pxf://<path-to-data>?PROFILE=<profile_name>[&SERVER=<server_name>][&<custom-option>=<value>[...]]'))
        | ('s3://<S3_endpoint>[:<port>]/<bucket_name>/[<S3_prefix>] [region=<S3-region>] [config=<config_file> | config_server=<url>]')
-     [ON MASTER]
+     [ON COORDINATOR]
      FORMAT 'TEXT' 
            [( [HEADER]
               [DELIMITER [AS] '<delimiter>' | 'OFF']
@@ -41,7 +41,7 @@ CREATE [READABLE] EXTERNAL WEB [TEMPORARY | TEMP] TABLE <table_name>     
    ( <column_name> <data_type> [, ...] | LIKE <other_table >)
       LOCATION ('http://<webhost>[:<port>]/<path>/<file>' [, ...])
     | EXECUTE '<command>' [ON ALL 
-                          | MASTER
+                          | COORDINATOR
                           | <number_of_segments>
                           | HOST ['<segment_hostname>'] 
                           | SEGMENT <segment_id> ]
@@ -92,7 +92,7 @@ CREATE WRITABLE EXTERNAL [TEMPORARY | TEMP] TABLE <table_name>
 CREATE WRITABLE EXTERNAL [TEMPORARY | TEMP] TABLE <table_name>
     ( <column_name> <data_type> [, ...] | LIKE <other_table >)
      LOCATION('s3://<S3_endpoint>[:<port>]/<bucket_name>/[<S3_prefix>] [region=<S3-region>] [config=<config_file> | config_server=<url>]')
-      [ON MASTER]
+      [ON COORDINATOR]
       FORMAT 'TEXT' 
                [( [DELIMITER [AS] '<delimiter>']
                [NULL [AS] '<null string>']
@@ -169,7 +169,7 @@ LOCATION \('protocol://\[host\[:port\]\]/path/file' \[, ...\]\)
 
     ```
     'gpfdist://filehost:8081/*'
-    'gpfdist://masterhost/my_load_file'
+    'gpfdist://coordinatorhost/my_load_file'
     'file://seghost1/dbfast1/external/myfile.txt'
     'http://intranet.example.com/finance/expenses.csv'
     ```
@@ -185,17 +185,17 @@ LOCATION \('protocol://\[host\[:port\]\]/path/file' \[, ...\]\)
 
     With the option `#transform=trans\_name`, you can specify a transform to apply when loading or extracting data. The trans\_name is the name of the transform in the YAML configuration file you specify with the you run the `gpfdist` utility. For information about specifying a transform, see [`gpfdist`](../../utility_guide/ref/gpfdist.html) in the *Greenplum Utility Guide*.
 
-ON MASTER
-:   Restricts all table-related operations to the Greenplum coordinator segment. Permitted only on readable and writable external tables created with the `s3` or custom protocols. The `gpfdist`, `gpfdists`, `pxf`, and `file` protocols do not support `ON MASTER`.
+ON COORDINATOR
+:   Restricts all table-related operations to the Greenplum coordinator segment. Permitted only on readable and writable external tables created with the `s3` or custom protocols. The `gpfdist`, `gpfdists`, `pxf`, and `file` protocols do not support `ON COORDINATOR`.
 
-:   > **Note** Be aware of potential resource impacts when reading from or writing to external tables you create with the `ON MASTER` clause. You may encounter performance issues when you restrict table operations solely to the Greenplum coordinator segment.
+:   > **Note** Be aware of potential resource impacts when reading from or writing to external tables you create with the `ON COORDINATOR` clause. You may encounter performance issues when you restrict table operations solely to the Greenplum coordinator segment.
 
 EXECUTE 'command' \[ON ...\]
 :   Allowed for readable external web tables or writable external tables only. For readable external web tables, specifies the OS command to be run by the segment instances. The command can be a single OS command or a script. The `ON` clause is used to specify which segment instances will run the given command.
 
     -   ON ALL is the default. The command will be run by every active \(primary\) segment instance on all segment hosts in the Greenplum Database system. If the command runs a script, that script must reside in the same location on all of the segment hosts and be executable by the Greenplum superuser \(`gpadmin`\).
-    -   ON MASTER runs the command on the coordinator host only.
-        > **Note** Logging is not supported for external web tables when the `ON MASTER` clause is specified.
+    -   ON COORDINATOR runs the command on the coordinator host only.
+        > **Note** Logging is not supported for external web tables when the `ON COORDINATOR` clause is specified.
 
     -   ON number means the command will be run by the specified number of segments. The particular segments are chosen randomly at runtime by the Greenplum Database system. If the command runs a script, that script must reside in the same location on all of the segment hosts and be executable by the Greenplum superuser \(`gpadmin`\).
     -   HOST means the command will be run by one segment on each segment host \(once per segment host\), regardless of the number of active segment instances per host.

--- a/gpdb-doc/markdown/security-guide/topics/Authenticate.html.md
+++ b/gpdb-doc/markdown/security-guide/topics/Authenticate.html.md
@@ -105,7 +105,7 @@ This example shows how to edit the `pg_hba.conf` file on the coordinator host 
 
 To edit `pg_hba.conf`:
 
-1.  Open the file `$MASTER_DATA_DIRECTORY/pg_hba.conf` in a text editor.
+1.  Open the file `$COORDINATOR_DATA_DIRECTORY/pg_hba.conf` in a text editor.
 2.  Add a line to the file for each type of connection you want to allow. Records are read sequentially, so the order of the records is significant. Typically, earlier records will have tight connection match parameters and weaker authentication methods, while later records will have looser match parameters and stronger authentication methods. For example:
 
     ```
@@ -222,7 +222,7 @@ Following are the recommended steps for configuring your system for LDAP authent
 1.   Set up the LDAP server with the database users/roles to be authenticated via LDAP.
 2.  On the database:
     1.  Verify that the database users to be authenticated via LDAP exist on the database. LDAP is only used for verifying username/password pairs, so the roles should exist in the database.
-    2.  Update the `pg_hba.conf` file in the `$MASTER_DATA_DIRECTORY` to use LDAP as the authentication method for the respective users. Note that the first entry to match the user/role in the `pg_hba.conf` file will be used as the authentication mechanism, so the position of the entry in the file is important.
+    2.  Update the `pg_hba.conf` file in the `$COORDINATOR_DATA_DIRECTORY` to use LDAP as the authentication method for the respective users. Note that the first entry to match the user/role in the `pg_hba.conf` file will be used as the authentication mechanism, so the position of the entry in the file is important.
     3.  Reload the server for the `pg_hba.conf` configuration settings to take effect \(`gpstop -u`\).
 
 Specify the following parameter `auth-options`.
@@ -360,14 +360,14 @@ The following Server settings need to be specified in the `postgresql.conf` con
     It is possible to have authentication without encryption overhead by using `NULL-SHA` or `NULL-MD5` ciphers. However, a man-in-the-middle could read and pass communications between client and server. Also, encryption overhead is minimal compared to the overhead of authentication. For these reasons, NULL ciphers should not be used.
 
 
-The default location for the following SSL server files is the Greenplum Database coordinator data directory \(`$MASTER_DATA_DIRECTORY`\):
+The default location for the following SSL server files is the Greenplum Database coordinator data directory \(`$COORDINATOR_DATA_DIRECTORY`\):
 
 -   `server.crt` - Server certificate.
 -   `server.key` - Server private key.
 -   `root.crt` - Trusted certificate authorities.
 -   `root.crl` - Certificates revoked by certificate authorities.
 
-If Greenplum Database coordinator mirroring is enabled with SSL client authentication, the SSL server files *should not be placed* in the default directory `$MASTER_DATA_DIRECTORY`. If a `gpinitstandby` operation is performed, the contents of `$MASTER_DATA_DIRECTORY` is copied from the coordinator to the standby coordinator and the incorrect SSL key, and cert files \(the coordinator files, and not the standby coordinator files\) will prevent standby coordinator start up.
+If Greenplum Database coordinator mirroring is enabled with SSL client authentication, the SSL server files *should not be placed* in the default directory `$COORDINATOR_DATA_DIRECTORY`. If a `gpinitstandby` operation is performed, the contents of `$COORDINATOR_DATA_DIRECTORY` is copied from the coordinator to the standby coordinator and the incorrect SSL key, and cert files \(the coordinator files, and not the standby coordinator files\) will prevent standby coordinator start up.
 
 You can specify a different directory for the location of the SSL server files with the `postgresql.conf` parameters `sslcert`, `sslkey`, `sslrootcert`, and `sslcrl`.
 
@@ -388,16 +388,16 @@ sslmode
 :   Only use an SSL connection. Verify that the server certificate is issued by a trusted CA and that the server host name matches that in the certificate.
 
 sslcert
-:   The file name of the client SSL certificate. The default is `$MASTER_DATA_DIRECTORY/postgresql.crt`.
+:   The file name of the client SSL certificate. The default is `$COORDINATOR_DATA_DIRECTORY/postgresql.crt`.
 
 sslkey
-:   The secret key used for the client certificate. The default is `$MASTER_DATA_DIRECTORY/postgresql.key`.
+:   The secret key used for the client certificate. The default is `$COORDINATOR_DATA_DIRECTORY/postgresql.key`.
 
 sslrootcert
-:   The name of a file containing SSL Certificate Authority certificate\(s\). The default is `$MASTER_DATA_DIRECTORY/root.crt`.
+:   The name of a file containing SSL Certificate Authority certificate\(s\). The default is `$COORDINATOR_DATA_DIRECTORY/root.crt`.
 
 sslcrl
-:   The name of the SSL certificate revocation list. The default is `$MASTER_DATA_DIRECTORY/root.crl`.
+:   The name of the SSL certificate revocation list. The default is `$COORDINATOR_DATA_DIRECTORY/root.crl`.
 
 The client connection parameters can be set using the following environment variables:
 
@@ -407,7 +407,7 @@ The client connection parameters can be set using the following environment vari
 -   `sslrootcert` – `PGSSLROOTCERT`
 -   `sslcrl` – `PGSSLCRL` 
 
-For example, run the following command to connect to the `postgres` database from `localhost` and verify the certificate present in the default location under `$MASTER_DATA_DIRECTORY`:
+For example, run the following command to connect to the `postgres` database from `localhost` and verify the certificate present in the default location under `$COORDINATOR_DATA_DIRECTORY`:
 
 ```
 psql "sslmode=verify-ca host=localhost dbname=postgres"
@@ -426,8 +426,8 @@ Greenplum Database does not install a PAM configuration file. If you choose to u
 1.  Log in to the Greenplum Database coordinator host and set up your environment. For example:
 
     ```
-    $ ssh gpadmin@<gpmaster>
-    gpadmin@gpmaster$ . /usr/local/greenplum-db/greenplum_path.sh
+    $ ssh gpadmin@<gpcoord>
+    gpadmin@gpcoord$ . /usr/local/greenplum-db/greenplum_path.sh
     ```
 
 2.  Identify the `pamservice` name for Greenplum Database. In this procedure, we choose the name `greenplum`.
@@ -499,7 +499,7 @@ To limit the number of active concurrent sessions to your Greenplum Database sys
 
 When you set `max_connections`, you must also set the dependent parameter `max_prepared_transactions`. This value must be at least as large as the value of `max_connections` on the coordinator, and segment instances should be set to the same value as the coordinator.
 
-In `$MASTER_DATA_DIRECTORY/postgresql.conf` \(including standby coordinator\):
+In `$COORDINATOR_DATA_DIRECTORY/postgresql.conf` \(including standby coordinator\):
 
 ```
 max_connections=100
@@ -523,7 +523,7 @@ To change the number of allowed connections:
     $ gpstop
     ```
 
-2.  On the coordinator host, edit `$MASTER_DATA_DIRECTORY/postgresql.conf` and change the following two parameters:
+2.  On the coordinator host, edit `$COORDINATOR_DATA_DIRECTORY/postgresql.conf` and change the following two parameters:
     -   `max_connections` – the number of active user sessions you want to allow plus the number of `superuser_reserved_connections`.
     -   `max_prepared_transactions` – must be greater than or equal to `max_connections`.
 3.  On each segment instance, edit `SEGMENT_DATA_DIRECTORY/postgresql.conf` and change the following two parameters:

--- a/gpdb-doc/markdown/utility_guide/ref/createdb.html.md
+++ b/gpdb-doc/markdown/utility_guide/ref/createdb.html.md
@@ -88,10 +88,10 @@ To create the database `test` using the default options:
 createdb test
 ```
 
-To create the database `demo` using the Greenplum coordinator on host `gpmaster`, port `54321`, using the `LATIN1` encoding scheme:
+To create the database `demo` using the Greenplum coordinator on host `gpcoord`, port `54321`, using the `LATIN1` encoding scheme:
 
 ```
-createdb -p 54321 -h gpmaster -E LATIN1 demo
+createdb -p 54321 -h gpcoord -E LATIN1 demo
 ```
 
 ## <a id="section7"></a>See Also 

--- a/gpdb-doc/markdown/utility_guide/ref/gpinitsystem.html.md
+++ b/gpdb-doc/markdown/utility_guide/ref/gpinitsystem.html.md
@@ -165,13 +165,13 @@ declare -a DATA_DIRECTORY=(/data1/primary /data1/primary
 /data1/primary /data2/primary /data2/primary /data2/primary)
 ```
 
-MASTER\_HOSTNAME
+COORDINATOR\_HOSTNAME
 :   **Required.** The host name of the coordinator instance. This host name must exactly match the configured host name of the machine \(run the `hostname` command to determine the correct hostname\).
 
-MASTER\_DIRECTORY
+COORDINATOR\_DIRECTORY
 :   **Required.** This specifies the location where the data directory will be created on the coordinator host. You must make sure that the user who runs `gpinitsystem` \(for example, the `gpadmin` user\) has permissions to write to this directory.
 
-MASTER\_PORT
+COORDINATOR\_PORT
 :   **Required.** The port number for the coordinator instance. This is the port number that users and client connections will use when accessing the Greenplum Database system.
 
 TRUSTED\_SHELL

--- a/gpdb-doc/markdown/utility_guide/ref/gprecoverseg.html.md
+++ b/gpdb-doc/markdown/utility_guide/ref/gprecoverseg.html.md
@@ -78,7 +78,7 @@ The recovery process marks the segment as up again in the Greenplum Database sys
 :   The number of hosts to work on in parallel. If not specified, the utility will start working on up to 16 hosts in parallel. Valid values are `1` to `64`.
 
 -d coordinator\_data\_directory
-:   Optional. The coordinator host data directory. If not specified, the value set for `$MASTER_DATA_DIRECTORY` will be used.
+:   Optional. The coordinator host data directory. If not specified, the value set for `$COORDINATOR_DATA_DIRECTORY` will be used.
 
 -F \(full recovery\)
 :   Optional. Perform a full copy of the active segment instance in order to recover the failed segment. The default is to only copy over the incremental changes that occurred while the segment was down.

--- a/src/backend/cdb/dispatcher/README.md
+++ b/src/backend/cdb/dispatcher/README.md
@@ -1,16 +1,16 @@
 ## Dispatcher API
 This document illustrates the interfaces of a GPDB component called dispatcher, which is responsible for
-1) building connections from master node to segments,
+1) building connections from coordinator node to segments,
 2) managing query/plan dispatching, and
 3) collecting query execution results.
 
 The implementation of dispatcher is mainly located under this directory.
 
 ### Terms Used:
-* QD: Query Dispatcher, a backend forked by master with role GP_ROLE_DISPATCH who dispatches plan/command to QEs and get the results from QEs.
-* QE: Query Executor, a backend forked by master/segments with role GP_ROLE_EXECUTOR who gets plan/command from QD and pick a piece of it to execute.
+* QD: Query Dispatcher, a backend forked by coordinator with role GP_ROLE_DISPATCH who dispatches plan/command to QEs and get the results from QEs.
+* QE: Query Executor, a backend forked by coordinator/segments with role GP_ROLE_EXECUTOR who gets plan/command from QD and pick a piece of it to execute.
 * Gang: Gang refers to a group of processes on segments. There are 4 types of Gang:
-	* `GANGTYPE_ENTRYDB_READER`: consist of one single process on master node
+	* `GANGTYPE_ENTRYDB_READER`: consist of one single process on coordinator node
 	* `GANGTYPE_SINGLETON_READER`: consist of one single process on a segment node
 	* `GANGTYPE_PRIMARY_READER`: consist of N (number of segments) processes, each process is on a different segment
 	* `GANGTYPE_PRIMARY_WRITER`: like `GANGTYPE_PRIMARY_READER`, while it can update segment databases, and is responsible for DTM (Distributed Transaction Management). A session can have at most one Gang of this type, and reader Gangs cannot exist without a writer Gang

--- a/src/backend/utils/gdd/README.md
+++ b/src/backend/utils/gdd/README.md
@@ -199,7 +199,7 @@ while true:
 if count_vertices_not_deleted() > 0:
     # detected at least one cycle
     # the cycles are only reliable if all the contained vertices
-    # are valid transactions on master
+    # are valid transactions on coordinator
     if all_vertices_are_valid():
         # choose a vertex and cancel it
 ```
@@ -261,12 +261,12 @@ select * from gp_dist_wait_status();
 The local wait-relationship graphs collected from each segment are generated
 asynchronously. We have to take the impact into account.
 
-- if a transaction A is valid on master then it's valid on all segments;
-- transaction A's solid in edges are all valid as long as A is valid on master;
+- if a transaction A is valid on coordinator then it's valid on all segments;
+- transaction A's solid in edges are all valid as long as A is valid on coordinator;
 - if there is a solid edge from B to A on a segment, then B is valid as long as
   A is valid;
 - further more, if there is a solid edge from B to A on a segment, then B is
-  valid on all segments as long as A is valid on master;
+  valid on all segments as long as A is valid on coordinator;
 - if there is a dotted edge from B to A on a segment, then this edge is valid
   unless A's status changed;
 - if there is a solid edge from B to A then all the vertices wait for B
@@ -274,11 +274,11 @@ asynchronously. We have to take the impact into account.
 
 Our algorithm reduces all the edges that are possible to change. On each
 segment the reduced graph's end vertices (vertices whose local out degree is
-0) must only have solid in edges. We can validate these transactions on master,
+0) must only have solid in edges. We can validate these transactions on coordinator,
 if they are all valid then those solid edges to them are also valid, so the
 transactions waiting for them directly or indirectly are valid, so the graphs
 are valid and the detected deadlock cycles are true; if any of the
-transactions is invalid on master then the graphs are not reliable and we
+transactions is invalid on coordinator then the graphs are not reliable and we
 should retry later.
 
 So our algorithm only requires the edges information to be consistent at
@@ -304,7 +304,7 @@ edge.
 
 Let's run the new algorithm on an actual case to understand how does it work.
 
-The testing cluster has 3 segments: seg -1, seg 0 and seg 1. Master is on seg
+The testing cluster has 3 segments: seg -1, seg 0 and seg 1. Coordinator is on seg
 -1.  A table `t1` is created as below:
 
 ```sql

--- a/src/interfaces/gppc/README.md
+++ b/src/interfaces/gppc/README.md
@@ -199,11 +199,11 @@ SELECT * FROM transform(
 ```
 
 The more examples of using GPPC table function are listed in  
-https://github.com/greenplum-db/gpdb/tree/master/src/interfaces/gppc/test/tabfunc_gppc_demo.c
+https://github.com/greenplum-db/gpdb/tree/main/src/interfaces/gppc/test/tabfunc_gppc_demo.c
 
 ### Reference
 https://www.postgresql.org/docs/devel/xfunc-c.html  
-https://github.com/greenplum-db/gpdb/blob/master/src/include/gppc/gppc.h  
-https://github.com/greenplum-db/gpdb/tree/master/src/interfaces/gppc/test/gppc_demo.c  
-https://github.com/greenplum-db/gpdb/tree/master/src/interfaces/gppc/test/tabfunc_gppc_demo.c
+https://github.com/greenplum-db/gpdb/blob/main/src/include/gppc/gppc.h  
+https://github.com/greenplum-db/gpdb/tree/main/src/interfaces/gppc/test/gppc_demo.c  
+https://github.com/greenplum-db/gpdb/tree/main/src/interfaces/gppc/test/tabfunc_gppc_demo.c
 

--- a/src/test/isolation2/expected/check_gxid.out
+++ b/src/test/isolation2/expected/check_gxid.out
@@ -15,7 +15,7 @@ select gp_segment_id,gp_get_next_gxid() on_seg, (select gp_get_next_gxid() on_co
 (3 rows)
 -- end_ignore
 
--- trigger master panic and wait until master down before running any new query.
+-- trigger coordinator panic and wait until coordinator down before running any new query.
 1&: SELECT wait_till_master_shutsdown();  <waiting ...>
 2: SELECT gp_inject_fault('before_read_command', 'panic', 1);
  gp_inject_fault 
@@ -32,7 +32,7 @@ server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
 
--- wait until master is up for querying.
+-- wait until coordinator is up for querying.
 3: SELECT 1;
  ?column? 
 ----------

--- a/src/test/isolation2/expected/commit_transaction_block_checkpoint.out
+++ b/src/test/isolation2/expected/commit_transaction_block_checkpoint.out
@@ -37,7 +37,7 @@ COMMIT
 1U<:  <... completed>
 CHECKPOINT
 
--- TEST 2: block checkpoint on master
+-- TEST 2: block checkpoint on coordinator
 
 -- pause the CommitTransaction right before persistent table cleanup after
 -- notifyCommittedDtxTransaction()
@@ -63,7 +63,7 @@ select gp_wait_until_triggered_fault('onephase_transaction_commit', 1, 1);
  Success:                      
 (1 row)
 
--- do checkpoint on master in utility mode, and it should block
+-- do checkpoint on coordinator in utility mode, and it should block
 -1U&: checkpoint;  <waiting ...>
 
 -- resume the 2PC

--- a/src/test/isolation2/expected/crash_recovery.out
+++ b/src/test/isolation2/expected/crash_recovery.out
@@ -75,7 +75,7 @@ CHECKPOINT
 -----------------
  Success:        
 (1 row)
--- verify master panic happens. The PANIC message does not emit sometimes so
+-- verify coordinator panic happens. The PANIC message does not emit sometimes so
 -- mask it.
 -- start_matchsubs
 -- m/PANIC:  fault triggered, fault name:'exec_simple_query_start' fault type:'panic'\n/

--- a/src/test/isolation2/expected/crash_recovery_dtm.out
+++ b/src/test/isolation2/expected/crash_recovery_dtm.out
@@ -34,14 +34,14 @@ select pg_reload_conf();
  p    | p              | 2       | u      | t              
 (4 rows)
 -- Scenario 1: Test to fail broadcasting of COMMIT PREPARED to one
--- segment and hence trigger PANIC in master while after completing
--- phase 2 of 2PC. Master's recovery cycle should correctly broadcast
--- COMMIT PREPARED again because master should find distributed commit
+-- segment and hence trigger PANIC in coordinator while after completing
+-- phase 2 of 2PC. Coordinator's recovery cycle should correctly broadcast
+-- COMMIT PREPARED again because coordinator should find distributed commit
 -- record in its xlog during recovery. Verify that the transaction is
 -- committed after recovery. This scenario used to create cluster
 -- inconsistency due to bug fixed now, as transaction used to get
 -- committed on all segments except one where COMMIT PREPARED
--- broadcast failed before recovery. Master used to miss sending the
+-- broadcast failed before recovery. Coordinator used to miss sending the
 -- COMMIT PREPARED across restart and instead abort the transaction
 -- after querying in-doubt prepared transactions from segments.
 -- Inject fault to fail the COMMIT PREPARED on one segment.
@@ -57,7 +57,7 @@ SET
 -----------------
  Success:        
 (1 row)
--- Start looping in background, till master panics and closes the session
+-- Start looping in background, till coordinator panics and closes the session
 3&: SELECT wait_till_master_shutsdown();  <waiting ...>
 -- Start transaction which should hit PANIC as COMMIT PREPARED will fail to one segment
 1: CREATE TABLE commit_phase1_panic(a int, b int);
@@ -74,12 +74,12 @@ server closed the connection unexpectedly
  Success:        
 (1 row)
 -1Uq: ... <quitting>
--- Join back to know master has completed postmaster reset.
+-- Join back to know coordinator has completed postmaster reset.
 3<:  <... completed>
 server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
--- Start a session on master which would complete the DTM recovery and hence COMMIT PREPARED
+-- Start a session on coordinator which would complete the DTM recovery and hence COMMIT PREPARED
 4: SELECT * from commit_phase1_panic;
  a | b 
 ---+---
@@ -92,14 +92,14 @@ INSERT 10
  10    
 (1 row)
 
--- Scenario 2: Inject FATAL on master after recording commit but
+-- Scenario 2: Inject FATAL on coordinator after recording commit but
 -- before broadcasting COMMIT_PREPARED to segments. FATAL must convert
 -- to PANIC and make sure to complete the 2PC processing and not leave
 -- dangling prepared transaction. There used to bug as a result the
--- master backend process would just die, leaving dangling prepared
--- transaction on segment but commited on master.
+-- coordinator backend process would just die, leaving dangling prepared
+-- transaction on segment but commited on coordinator.
 
--- Start looping in background, till master panics and closes the
+-- Start looping in background, till coordinator panics and closes the
 -- session
 5&: SELECT wait_till_master_shutsdown();  <waiting ...>
 6: SELECT gp_inject_fault('dtm_broadcast_commit_prepared', 'fatal', dbid) from gp_segment_configuration where role='p' and content=-1;
@@ -116,7 +116,7 @@ server closed the connection unexpectedly
 server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
--- Start a session on master which would complete the DTM recovery and hence COMMIT PREPARED
+-- Start a session on coordinator which would complete the DTM recovery and hence COMMIT PREPARED
 7: SELECT count(*) from commit_fatal_fault_test_table;
  count 
 -------
@@ -133,14 +133,14 @@ server closed the connection unexpectedly
 (1 row)
 
 -- Scenario 3: Inject ERROR after prepare phase has completed to
--- trigger abort. Then on abort inject FATAL on master before sending
+-- trigger abort. Then on abort inject FATAL on coordinator before sending
 -- ABORT_PREPARED. FATAL must convert to PANIC and make sure to
 -- complete the 2PC processing and not leave dangling prepared
--- transaction. There used to bug as a result the master backend
+-- transaction. There used to bug as a result the coordinator backend
 -- process would just die, leaving dangling prepared transaction on
--- segment but aborted on master.
+-- segment but aborted on coordinator.
 
--- Start looping in background, till master panics and closes the
+-- Start looping in background, till coordinator panics and closes the
 -- session
 8&: SELECT wait_till_master_shutsdown();  <waiting ...>
 9: SELECT gp_inject_fault('transaction_abort_after_distributed_prepared', 'error', dbid) from gp_segment_configuration where role='p' and content=-1;
@@ -183,7 +183,7 @@ LINE 1: SELECT count(*) from abort_fatal_fault_test_table;
 (1 row)
 
 -- Scenario 4: QE panics after writing prepare xlog record. This
--- should cause master to broadcast abort and QEs handle the abort in
+-- should cause coordinator to broadcast abort and QEs handle the abort in
 -- DTX_CONTEXT_LOCAL_ONLY context.
 11: CREATE TABLE QE_panic_test_table(a int, b int);
 CREATE
@@ -263,7 +263,7 @@ ALTER
 
 -- Scenario 5: QD panics when a QE process is doing prepare but not yet finished.
 -- This should cause dtx recovery finally aborts the orphaned prepared transaction.
-15: CREATE TABLE master_reset(a int);
+15: CREATE TABLE coordinator_reset(a int);
 CREATE
 15: SELECT gp_inject_fault_infinite('before_xlog_xact_prepare', 'suspend', dbid) from gp_segment_configuration where role = 'p' and content = 1;
  gp_inject_fault_infinite 
@@ -275,7 +275,7 @@ CREATE
 --------------------------
  Success:                 
 (1 row)
-16&: INSERT INTO master_reset SELECT a from generate_series(1, 10) a;  <waiting ...>
+16&: INSERT INTO coordinator_reset SELECT a from generate_series(1, 10) a;  <waiting ...>
 15: SELECT gp_wait_until_triggered_fault('before_xlog_xact_prepare', 1, dbid) from gp_segment_configuration where role = 'p' and content = 1;
  gp_wait_until_triggered_fault 
 -------------------------------
@@ -293,7 +293,7 @@ ALTER
  t              
 (1 row)
 
--- trigger master panic and wait until master down before running any new query.
+-- trigger coordinator panic and wait until coordinator down before running any new query.
 17&: SELECT wait_till_master_shutsdown();  <waiting ...>
 18: SELECT gp_inject_fault('exec_simple_query_start', 'panic', current_setting('gp_dbid')::smallint);
  gp_inject_fault 
@@ -314,14 +314,14 @@ server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
 
--- wait until master is up for querying.
+-- wait until coordinator is up for querying.
 19: SELECT 1;
  ?column? 
 ----------
  1        
 (1 row)
 
--- master suspends before running periodical checking of orphaned prepared transactions.
+-- coordinator suspends before running periodical checking of orphaned prepared transactions.
 19: SELECT gp_inject_fault_infinite('before_orphaned_check', 'suspend', dbid) from gp_segment_configuration where role = 'p' and content = -1;
  gp_inject_fault_infinite 
 --------------------------
@@ -365,7 +365,7 @@ server closed the connection unexpectedly
 --------------------------
  Success:                 
 (1 row)
-19: DROP TABLE master_reset;
+19: DROP TABLE coordinator_reset;
 DROP
 19: ALTER SYSTEM RESET gp_dtx_recovery_interval;
 ALTER
@@ -402,7 +402,7 @@ ALTER
 20: CREATE TABLE test_retry_abort(a int);
 CREATE
 
--- master: set fault to trigger abort prepare
+-- coordinator: set fault to trigger abort prepare
 -- primary 0: set fault so that retry prepared abort fails.
 20: SELECT gp_inject_fault('dtm_broadcast_prepare', 'error', dbid) from gp_segment_configuration where role = 'p' and content = -1;
  gp_inject_fault 

--- a/src/test/isolation2/expected/crash_recovery_redundant_dtx.out
+++ b/src/test/isolation2/expected/crash_recovery_redundant_dtx.out
@@ -56,7 +56,7 @@ CHECKPOINT
 -----------------
  Success:        
 (1 row)
--- verify master panic happens. The PANIC message does not emit sometimes so
+-- verify coordinator panic happens. The PANIC message does not emit sometimes so
 -- mask it.
 -- start_matchsubs
 -- m/PANIC:  fault triggered, fault name:'exec_simple_query_start' fault type:'panic'\n/

--- a/src/test/isolation2/expected/drop_rename.out
+++ b/src/test/isolation2/expected/drop_rename.out
@@ -1,5 +1,5 @@
 -- Test if ALTER RENAME followed by ANALYZE executed concurrently with
--- DROP does not introduce inconsistency between master and segments.
+-- DROP does not introduce inconsistency between coordinator and segments.
 -- DROP should be blocked because of ALTER-ANALYZE.  After being
 -- unblocked, DROP should lookup the old name again and fail with
 -- relation does not exist error.
@@ -55,7 +55,7 @@ ERROR:  table "t2" does not exist
 (1 row)
 
 -- The same, but with DROP IF EXISTS. (We used to have a bug, where the DROP
--- command found and drop the relation in the segments, but not in master.)
+-- command found and drop the relation in the segments, but not in coordinator.)
 1:drop table if exists t3;
 DROP
 1:create table t3 (a int, b text) distributed by (a);

--- a/src/test/isolation2/expected/execute_on_utilitymode.out
+++ b/src/test/isolation2/expected/execute_on_utilitymode.out
@@ -4,7 +4,7 @@
 
 -- First, create test functions with different EXECUTE ON options
 
-create function srf_on_master () returns setof text as $$ begin	/* in func */ return next 'foo ' || current_setting('gp_contentid');	/* in func */ return next 'bar ' || current_setting('gp_contentid');	/* in func */ end;	/* in func */ $$ language plpgsql EXECUTE ON COORDINATOR;
+create function srf_on_coordinator () returns setof text as $$ begin	/* in func */ return next 'foo ' || current_setting('gp_contentid');	/* in func */ return next 'bar ' || current_setting('gp_contentid');	/* in func */ end;	/* in func */ $$ language plpgsql EXECUTE ON COORDINATOR;
 CREATE
 
 create function srf_on_all_segments () returns setof text as $$ begin	/* in func */ return next 'foo ' || current_setting('gp_contentid');	/* in func */ return next 'bar ' || current_setting('gp_contentid');	/* in func */ end;	/* in func */ $$ language plpgsql EXECUTE ON ALL SEGMENTS;
@@ -16,7 +16,7 @@ CREATE
 create function srf_on_initplan () returns setof text as $$ begin	/* in func */ return next 'foo ' || current_setting('gp_contentid');	/* in func */ return next 'bar ' || current_setting('gp_contentid');	/* in func */ end;	/* in func */ $$ language plpgsql EXECUTE ON INITPLAN;
 CREATE
 
--- Now try executing them in utility mode, in the master node and on a
+-- Now try executing them in utility mode, in the coordinator node and on a
 -- segment. The expected behavior is that the function runs on the node
 -- we're connected to, ignoring the EXECUTE ON directives.
 --
@@ -27,7 +27,7 @@ CREATE
 insert into fewrows select g from generate_series(1, 10) g;
 INSERT 10
 
--1U: select * from srf_on_master()       as srf (x) left join fewrows on x = t;
+-1U: select * from srf_on_coordinator()       as srf (x) left join fewrows on x = t;
  x      | t 
 --------+---
  foo -1 |   
@@ -52,17 +52,17 @@ INSERT 10
  bar -1 |   
 (2 rows)
 
-1U: select * from srf_on_master(),       fewrows;
- srf_on_master | t 
----------------+---
- foo 1         | 2 
- foo 1         | 3 
- foo 1         | 4 
- foo 1         | 7 
- bar 1         | 2 
- bar 1         | 3 
- bar 1         | 4 
- bar 1         | 7 
+1U: select * from srf_on_coordinator(),       fewrows;
+ srf_on_coordinator | t 
+--------------------+---
+ foo 1              | 2 
+ foo 1              | 3 
+ foo 1              | 4 
+ foo 1              | 7 
+ bar 1              | 2 
+ bar 1              | 3 
+ bar 1              | 4 
+ bar 1              | 7 
 (8 rows)
 1U: select * from srf_on_all_segments(), fewrows;
  srf_on_all_segments | t 

--- a/src/test/isolation2/expected/fts_dns_error.out
+++ b/src/test/isolation2/expected/fts_dns_error.out
@@ -1,8 +1,8 @@
 -- Tests FTS can handle DNS error.
 -- to make test deterministic and fast
-!\retcode gpconfig -c gp_fts_probe_retries -v 2 --masteronly;
+!\retcode gpconfig -c gp_fts_probe_retries -v 2 --coordinatoronly;
 -- start_ignore
-20180815:04:37:38:022354 gpconfig:gpdbvm:gpadmin-[INFO]:-completed successfully with parameters '-c gp_fts_probe_retries -v 2 --masteronly'
+20180815:04:37:38:022354 gpconfig:gpdbvm:gpadmin-[INFO]:-completed successfully with parameters '-c gp_fts_probe_retries -v 2 --coordinatoronly'
 
 -- end_ignore
 (exited with code 0)
@@ -11,15 +11,15 @@
 -- gprecoverseg BEGIN failures due to gang creation failure as some primaries
 -- are not up. Setting these increase the number of retries in gang creation in
 -- case segment is in recovery. Approximately we want to wait 30 seconds.
-!\retcode gpconfig -c gp_gang_creation_retry_count -v 127 --skipvalidation --masteronly;
+!\retcode gpconfig -c gp_gang_creation_retry_count -v 127 --skipvalidation --coordinatoronly;
 -- start_ignore
-20180815:04:37:38:022446 gpconfig:gpdbvm:gpadmin-[INFO]:-completed successfully with parameters '-c gp_gang_creation_retry_count -v 127 --skipvalidation --masteronly'
+20180815:04:37:38:022446 gpconfig:gpdbvm:gpadmin-[INFO]:-completed successfully with parameters '-c gp_gang_creation_retry_count -v 127 --skipvalidation --coordinatoronly'
 
 -- end_ignore
 (exited with code 0)
-!\retcode gpconfig -c gp_gang_creation_retry_timer -v 250 --skipvalidation --masteronly;
+!\retcode gpconfig -c gp_gang_creation_retry_timer -v 250 --skipvalidation --coordinatoronly;
 -- start_ignore
-20180815:04:37:39:022532 gpconfig:gpdbvm:gpadmin-[INFO]:-completed successfully with parameters '-c gp_gang_creation_retry_timer -v 250 --skipvalidation --masteronly'
+20180815:04:37:39:022532 gpconfig:gpdbvm:gpadmin-[INFO]:-completed successfully with parameters '-c gp_gang_creation_retry_timer -v 250 --skipvalidation --coordinatoronly'
 
 -- end_ignore
 (exited with code 0)
@@ -27,8 +27,8 @@
 -- start_ignore
 20180815:04:37:39:022618 gpstop:gpdbvm:gpadmin-[INFO]:-Starting gpstop with args: -u
 20180815:04:37:39:022618 gpstop:gpdbvm:gpadmin-[INFO]:-Gathering information and validating the environment...
-20180815:04:37:39:022618 gpstop:gpdbvm:gpadmin-[INFO]:-Obtaining Greenplum Master catalog information
-20180815:04:37:39:022618 gpstop:gpdbvm:gpadmin-[INFO]:-Obtaining Segment details from master...
+20180815:04:37:39:022618 gpstop:gpdbvm:gpadmin-[INFO]:-Obtaining Greenplum Coordinator catalog information
+20180815:04:37:39:022618 gpstop:gpdbvm:gpadmin-[INFO]:-Obtaining Segment details from coordinator...
 20180815:04:37:39:022618 gpstop:gpdbvm:gpadmin-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 6.0.0-alpha.0+dev.7526.g2508fd0 build dev-oss'
 20180815:04:37:39:022618 gpstop:gpdbvm:gpadmin-[INFO]:-Signalling all postmaster processes to reload
 . 
@@ -81,9 +81,9 @@ select count(*) from gp_segment_configuration where status = 'd';
 -- start_ignore
 20180815:04:37:43:022680 gprecoverseg:gpdbvm:gpadmin-[INFO]:-Starting gprecoverseg with args: -aF
 20180815:04:37:43:022680 gprecoverseg:gpdbvm:gpadmin-[INFO]:-local Greenplum Version: 'postgres (Greenplum Database) 6.0.0-alpha.0+dev.7526.g2508fd0 build dev-oss'
-20180815:04:37:43:022680 gprecoverseg:gpdbvm:gpadmin-[INFO]:-master Greenplum Version: 'PostgreSQL 9.1beta2 (Greenplum Database 6.0.0-alpha.0+dev.7526.g2508fd0 build dev-oss) on x86_64-pc-linux-gnu, compiled by gcc (GCC) 4.8.5 20150623 (Red Hat 4.8.5-16), 64-bit compiled on Aug 15 2018 00:06:20 (with assert checking)'
-20180815:04:37:43:022680 gprecoverseg:gpdbvm:gpadmin-[INFO]:-Obtaining Segment details from master...
-20180815:04:37:43:022680 gprecoverseg:gpdbvm:gpadmin-[INFO]:-Heap checksum setting is consistent between master and the segments that are candidates for recoverseg
+20180815:04:37:43:022680 gprecoverseg:gpdbvm:gpadmin-[INFO]:-coordinator Greenplum Version: 'PostgreSQL 9.1beta2 (Greenplum Database 6.0.0-alpha.0+dev.7526.g2508fd0 build dev-oss) on x86_64-pc-linux-gnu, compiled by gcc (GCC) 4.8.5 20150623 (Red Hat 4.8.5-16), 64-bit compiled on Aug 15 2018 00:06:20 (with assert checking)'
+20180815:04:37:43:022680 gprecoverseg:gpdbvm:gpadmin-[INFO]:-Obtaining Segment details from coordinator...
+20180815:04:37:43:022680 gprecoverseg:gpdbvm:gpadmin-[INFO]:-Heap checksum setting is consistent between coordinator and the segments that are candidates for recoverseg
 20180815:04:37:43:022680 gprecoverseg:gpdbvm:gpadmin-[INFO]:-Greenplum instance recovery parameters
 20180815:04:37:43:022680 gprecoverseg:gpdbvm:gpadmin-[INFO]:----------------------------------------------------------
 20180815:04:37:43:022680 gprecoverseg:gpdbvm:gpadmin-[INFO]:-Recovery type              = Standard
@@ -135,8 +135,8 @@ DO
 -- start_ignore
 20180815:04:37:51:023173 gprecoverseg:gpdbvm:gpadmin-[INFO]:-Starting gprecoverseg with args: -ar
 20180815:04:37:51:023173 gprecoverseg:gpdbvm:gpadmin-[INFO]:-local Greenplum Version: 'postgres (Greenplum Database) 6.0.0-alpha.0+dev.7526.g2508fd0 build dev-oss'
-20180815:04:37:52:023173 gprecoverseg:gpdbvm:gpadmin-[INFO]:-master Greenplum Version: 'PostgreSQL 9.1beta2 (Greenplum Database 6.0.0-alpha.0+dev.7526.g2508fd0 build dev-oss) on x86_64-pc-linux-gnu, compiled by gcc (GCC) 4.8.5 20150623 (Red Hat 4.8.5-16), 64-bit compiled on Aug 15 2018 00:06:20 (with assert checking)'
-20180815:04:37:52:023173 gprecoverseg:gpdbvm:gpadmin-[INFO]:-Obtaining Segment details from master...
+20180815:04:37:52:023173 gprecoverseg:gpdbvm:gpadmin-[INFO]:-coordinator Greenplum Version: 'PostgreSQL 9.1beta2 (Greenplum Database 6.0.0-alpha.0+dev.7526.g2508fd0 build dev-oss) on x86_64-pc-linux-gnu, compiled by gcc (GCC) 4.8.5 20150623 (Red Hat 4.8.5-16), 64-bit compiled on Aug 15 2018 00:06:20 (with assert checking)'
+20180815:04:37:52:023173 gprecoverseg:gpdbvm:gpadmin-[INFO]:-Obtaining Segment details from coordinator...
 20180815:04:37:52:023173 gprecoverseg:gpdbvm:gpadmin-[INFO]:-Greenplum instance recovery parameters
 20180815:04:37:52:023173 gprecoverseg:gpdbvm:gpadmin-[INFO]:----------------------------------------------------------
 20180815:04:37:52:023173 gprecoverseg:gpdbvm:gpadmin-[INFO]:-Recovery type              = Rebalance
@@ -166,9 +166,9 @@ DO
 20180815:04:37:55:023173 gprecoverseg:gpdbvm:gpadmin-[INFO]:-Starting segment synchronization
 20180815:04:37:55:023173 gprecoverseg:gpdbvm:gpadmin-[INFO]:-=============================START ANOTHER RECOVER=========================================
 20180815:04:37:55:023173 gprecoverseg:gpdbvm:gpadmin-[INFO]:-local Greenplum Version: 'postgres (Greenplum Database) 6.0.0-alpha.0+dev.7526.g2508fd0 build dev-oss'
-20180815:04:37:55:023173 gprecoverseg:gpdbvm:gpadmin-[INFO]:-master Greenplum Version: 'PostgreSQL 9.1beta2 (Greenplum Database 6.0.0-alpha.0+dev.7526.g2508fd0 build dev-oss) on x86_64-pc-linux-gnu, compiled by gcc (GCC) 4.8.5 20150623 (Red Hat 4.8.5-16), 64-bit compiled on Aug 15 2018 00:06:20 (with assert checking)'
-20180815:04:37:55:023173 gprecoverseg:gpdbvm:gpadmin-[INFO]:-Obtaining Segment details from master...
-20180815:04:37:55:023173 gprecoverseg:gpdbvm:gpadmin-[INFO]:-Heap checksum setting is consistent between master and the segments that are candidates for recoverseg
+20180815:04:37:55:023173 gprecoverseg:gpdbvm:gpadmin-[INFO]:-coordinator Greenplum Version: 'PostgreSQL 9.1beta2 (Greenplum Database 6.0.0-alpha.0+dev.7526.g2508fd0 build dev-oss) on x86_64-pc-linux-gnu, compiled by gcc (GCC) 4.8.5 20150623 (Red Hat 4.8.5-16), 64-bit compiled on Aug 15 2018 00:06:20 (with assert checking)'
+20180815:04:37:55:023173 gprecoverseg:gpdbvm:gpadmin-[INFO]:-Obtaining Segment details from coordinator...
+20180815:04:37:55:023173 gprecoverseg:gpdbvm:gpadmin-[INFO]:-Heap checksum setting is consistent between coordinator and the segments that are candidates for recoverseg
 20180815:04:37:55:023173 gprecoverseg:gpdbvm:gpadmin-[INFO]:-Greenplum instance recovery parameters
 20180815:04:37:55:023173 gprecoverseg:gpdbvm:gpadmin-[INFO]:----------------------------------------------------------
 20180815:04:37:55:023173 gprecoverseg:gpdbvm:gpadmin-[INFO]:-Recovery type              = Standard
@@ -226,21 +226,21 @@ select count(*) from gp_segment_configuration where status = 'd';
  0     
 (1 row)
 
-!\retcode gpconfig -r gp_fts_probe_retries --masteronly;
+!\retcode gpconfig -r gp_fts_probe_retries --coordinatoronly;
 -- start_ignore
-20180815:04:38:01:023620 gpconfig:gpdbvm:gpadmin-[INFO]:-completed successfully with parameters '-r gp_fts_probe_retries --masteronly'
+20180815:04:38:01:023620 gpconfig:gpdbvm:gpadmin-[INFO]:-completed successfully with parameters '-r gp_fts_probe_retries --coordinatoronly'
 
 -- end_ignore
 (exited with code 0)
-!\retcode gpconfig -r gp_gang_creation_retry_count --skipvalidation --masteronly;
+!\retcode gpconfig -r gp_gang_creation_retry_count --skipvalidation --coordinatoronly;
 -- start_ignore
-20180815:04:38:02:023710 gpconfig:gpdbvm:gpadmin-[INFO]:-completed successfully with parameters '-r gp_gang_creation_retry_count --skipvalidation --masteronly'
+20180815:04:38:02:023710 gpconfig:gpdbvm:gpadmin-[INFO]:-completed successfully with parameters '-r gp_gang_creation_retry_count --skipvalidation --coordinatoronly'
 
 -- end_ignore
 (exited with code 0)
-!\retcode gpconfig -r gp_gang_creation_retry_timer --skipvalidation --masteronly;
+!\retcode gpconfig -r gp_gang_creation_retry_timer --skipvalidation --coordinatoronly;
 -- start_ignore
-20180815:04:38:03:023794 gpconfig:gpdbvm:gpadmin-[INFO]:-completed successfully with parameters '-r gp_gang_creation_retry_timer --skipvalidation --masteronly'
+20180815:04:38:03:023794 gpconfig:gpdbvm:gpadmin-[INFO]:-completed successfully with parameters '-r gp_gang_creation_retry_timer --skipvalidation --coordinatoronly'
 
 -- end_ignore
 (exited with code 0)
@@ -248,8 +248,8 @@ select count(*) from gp_segment_configuration where status = 'd';
 -- start_ignore
 20180815:04:38:03:023878 gpstop:gpdbvm:gpadmin-[INFO]:-Starting gpstop with args: -u
 20180815:04:38:03:023878 gpstop:gpdbvm:gpadmin-[INFO]:-Gathering information and validating the environment...
-20180815:04:38:03:023878 gpstop:gpdbvm:gpadmin-[INFO]:-Obtaining Greenplum Master catalog information
-20180815:04:38:03:023878 gpstop:gpdbvm:gpadmin-[INFO]:-Obtaining Segment details from master...
+20180815:04:38:03:023878 gpstop:gpdbvm:gpadmin-[INFO]:-Obtaining Greenplum Coordinator catalog information
+20180815:04:38:03:023878 gpstop:gpdbvm:gpadmin-[INFO]:-Obtaining Segment details from coordinator...
 20180815:04:38:03:023878 gpstop:gpdbvm:gpadmin-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 6.0.0-alpha.0+dev.7526.g2508fd0 build dev-oss'
 20180815:04:38:03:023878 gpstop:gpdbvm:gpadmin-[INFO]:-Signalling all postmaster processes to reload
 . 

--- a/src/test/isolation2/expected/fts_errors.out
+++ b/src/test/isolation2/expected/fts_errors.out
@@ -10,7 +10,7 @@
 -- end_matchsubs
 
 -- to make test deterministic and fast
-!\retcode gpconfig -c gp_fts_probe_retries -v 2 --masteronly;
+!\retcode gpconfig -c gp_fts_probe_retries -v 2 --coordinatoronly;
 -- start_ignore
 -- end_ignore
 (exited with code 0)
@@ -19,11 +19,11 @@
 -- gprecoverseg BEGIN failures due to gang creation failure as some primaries
 -- are not up. Setting these increase the number of retries in gang creation in
 -- case segment is in recovery. Approximately we want to wait 120 seconds.
-!\retcode gpconfig -c gp_gang_creation_retry_count -v 120 --skipvalidation --masteronly;
+!\retcode gpconfig -c gp_gang_creation_retry_count -v 120 --skipvalidation --coordinatoronly;
 -- start_ignore
 -- end_ignore
 (exited with code 0)
-!\retcode gpconfig -c gp_gang_creation_retry_timer -v 1000 --skipvalidation --masteronly;
+!\retcode gpconfig -c gp_gang_creation_retry_timer -v 1000 --skipvalidation --coordinatoronly;
 -- start_ignore
 -- end_ignore
 (exited with code 0)
@@ -203,15 +203,15 @@ select count(*) from gp_segment_configuration where status = 'd';
  0     
 (1 row)
 
-!\retcode gpconfig -r gp_fts_probe_retries --masteronly;
+!\retcode gpconfig -r gp_fts_probe_retries --coordinatoronly;
 -- start_ignore
 -- end_ignore
 (exited with code 0)
-!\retcode gpconfig -r gp_gang_creation_retry_count --skipvalidation --masteronly;
+!\retcode gpconfig -r gp_gang_creation_retry_count --skipvalidation --coordinatoronly;
 -- start_ignore
 -- end_ignore
 (exited with code 0)
-!\retcode gpconfig -r gp_gang_creation_retry_timer --skipvalidation --masteronly;
+!\retcode gpconfig -r gp_gang_creation_retry_timer --skipvalidation --coordinatoronly;
 -- start_ignore
 -- end_ignore
 (exited with code 0)

--- a/src/test/isolation2/expected/fts_errors_1.out
+++ b/src/test/isolation2/expected/fts_errors_1.out
@@ -10,7 +10,7 @@
 -- end_matchsubs
 
 -- to make test deterministic and fast
-!\retcode gpconfig -c gp_fts_probe_retries -v 2 --masteronly;
+!\retcode gpconfig -c gp_fts_probe_retries -v 2 --coordinatoronly;
 -- start_ignore
 -- end_ignore
 (exited with code 0)
@@ -19,11 +19,11 @@
 -- gprecoverseg BEGIN failures due to gang creation failure as some primaries
 -- are not up. Setting these increase the number of retries in gang creation in
 -- case segment is in recovery. Approximately we want to wait 120 seconds.
-!\retcode gpconfig -c gp_gang_creation_retry_count -v 120 --skipvalidation --masteronly;
+!\retcode gpconfig -c gp_gang_creation_retry_count -v 120 --skipvalidation --coordinatoronly;
 -- start_ignore
 -- end_ignore
 (exited with code 0)
-!\retcode gpconfig -c gp_gang_creation_retry_timer -v 1000 --skipvalidation --masteronly;
+!\retcode gpconfig -c gp_gang_creation_retry_timer -v 1000 --skipvalidation --coordinatoronly;
 -- start_ignore
 -- end_ignore
 (exited with code 0)
@@ -205,15 +205,15 @@ select count(*) from gp_segment_configuration where status = 'd';
  0     
 (1 row)
 
-!\retcode gpconfig -r gp_fts_probe_retries --masteronly;
+!\retcode gpconfig -r gp_fts_probe_retries --coordinatoronly;
 -- start_ignore
 -- end_ignore
 (exited with code 0)
-!\retcode gpconfig -r gp_gang_creation_retry_count --skipvalidation --masteronly;
+!\retcode gpconfig -r gp_gang_creation_retry_count --skipvalidation --coordinatoronly;
 -- start_ignore
 -- end_ignore
 (exited with code 0)
-!\retcode gpconfig -r gp_gang_creation_retry_timer --skipvalidation --masteronly;
+!\retcode gpconfig -r gp_gang_creation_retry_timer --skipvalidation --coordinatoronly;
 -- start_ignore
 -- end_ignore
 (exited with code 0)

--- a/src/test/isolation2/expected/fts_segment_reset.out
+++ b/src/test/isolation2/expected/fts_segment_reset.out
@@ -7,13 +7,13 @@
 -- end_matchsubs
 
 -- Let FTS detect/declare failure sooner
-!\retcode gpconfig -c gp_fts_probe_interval -v 10 --masteronly;
+!\retcode gpconfig -c gp_fts_probe_interval -v 10 --coordinatoronly;
 (exited with code 0)
 -- Because after RESET, it still takes a little while for the primary
 -- to restart, and potentially makes FTS think it's in "recovery not
 -- in progress" stage and promote the mirror, we would need the FTS
 -- to make that decision a bit less frequently.
-!\retcode gpconfig -c gp_fts_probe_retries -v 15 --masteronly;
+!\retcode gpconfig -c gp_fts_probe_retries -v 15 --coordinatoronly;
 (exited with code 0)
 !\retcode gpstop -u;
 (exited with code 0)
@@ -92,9 +92,9 @@ DROP
 -- In case anything goes wrong, we don't want to affect other tests. So rebalance the cluster anyway.
 !\retcode gprecoverseg -aF !\retcode gprecoverseg -ar 
 -- restore parameters
-!\retcode gpconfig -r gp_fts_probe_interval --masteronly;
+!\retcode gpconfig -r gp_fts_probe_interval --coordinatoronly;
 (exited with code 127)
-!\retcode gpconfig -r gp_fts_probe_retries --masteronly;
+!\retcode gpconfig -r gp_fts_probe_retries --coordinatoronly;
 (exited with code 0)
 !\retcode gpstop -u;
 (exited with code 0)

--- a/src/test/isolation2/expected/gdd/concurrent_update.out
+++ b/src/test/isolation2/expected/gdd/concurrent_update.out
@@ -28,7 +28,7 @@ UPDATE 1
 DROP TABLE t_concurrent_update;
 DROP
 
--- Test the concurrent update transaction order on the segment is reflected on master
+-- Test the concurrent update transaction order on the segment is reflected on coordinator
 1: CREATE TABLE t_concurrent_update(a int, b int);
 CREATE
 1: INSERT INTO t_concurrent_update VALUES(1,1);
@@ -59,7 +59,7 @@ SET
 -------------------------------
  Success:                      
 (1 row)
--- transaction 3 should wait transaction 2 commit on master
+-- transaction 3 should wait transaction 2 commit on coordinator
 3<:  <... completed>
 UPDATE 1
 3&: END;  <waiting ...>

--- a/src/test/isolation2/expected/gdd/concurrent_update_optimizer.out
+++ b/src/test/isolation2/expected/gdd/concurrent_update_optimizer.out
@@ -28,7 +28,7 @@ UPDATE 1
 DROP TABLE t_concurrent_update;
 DROP
 
--- Test the concurrent update transaction order on the segment is reflected on master
+-- Test the concurrent update transaction order on the segment is reflected on coordinator
 1: CREATE TABLE t_concurrent_update(a int, b int);
 CREATE
 1: INSERT INTO t_concurrent_update VALUES(1,1);
@@ -59,7 +59,7 @@ SET
 -------------------------------
  Success:                      
 (1 row)
--- transaction 3 should wait transaction 2 commit on master
+-- transaction 3 should wait transaction 2 commit on coordinator
 3<:  <... completed>
 UPDATE 1
 3&: END;  <waiting ...>

--- a/src/test/isolation2/expected/gdd/end.out
+++ b/src/test/isolation2/expected/gdd/end.out
@@ -3,7 +3,7 @@ ALTER
 ALTER SYSTEM RESET gp_global_deadlock_detector_period;
 ALTER
 
--- Use utility session on seg 0 to restart master. This way avoids the
+-- Use utility session on seg 0 to restart coordinator. This way avoids the
 -- situation where session issuing the restart doesn't disappear
 -- itself.
 1U:SELECT pg_ctl(dir, 'restart') from datadir;
@@ -11,7 +11,7 @@ ALTER
 --------
  OK     
 (1 row)
--- Start new session on master to make sure it has fully completed
+-- Start new session on coordinator to make sure it has fully completed
 -- recovery and up and running again.
 1: SHOW gp_enable_global_deadlock_detector;
  gp_enable_global_deadlock_detector 

--- a/src/test/isolation2/expected/gdd/prepare.out
+++ b/src/test/isolation2/expected/gdd/prepare.out
@@ -22,7 +22,7 @@ CREATE OR REPLACE FUNCTION segid(seg int, idx int) RETURNS int AS $$ SELECT id F
 CREATE
 
 -- In some of the testcases the execution order of two background queries
--- must be enforced not only on master but also on segments, for example
+-- must be enforced not only on coordinator but also on segments, for example
 -- in below case the order of 10 and 20 on segments results in different
 -- waiting relations:
 --
@@ -61,7 +61,7 @@ SELECT segid(2,10) is not null;
 
 --enable GDD
 
--- table to just store the master's data directory path on segment.
+-- table to just store the coordinator's data directory path on segment.
 CREATE TABLE datadir(a int, dir text);
 CREATE
 INSERT INTO datadir select 1,datadir from gp_segment_configuration where role='p' and content=-1;
@@ -72,7 +72,7 @@ ALTER
 ALTER SYSTEM SET gp_global_deadlock_detector_period TO 5;
 ALTER
 
--- Use utility session on seg 0 to restart master. This way avoids the
+-- Use utility session on seg 0 to restart coordinator. This way avoids the
 -- situation where session issuing the restart doesn't disappear
 -- itself.
 1U:SELECT pg_ctl(dir, 'restart') from datadir;
@@ -80,7 +80,7 @@ ALTER
 --------
  OK     
 (1 row)
--- Start new session on master to make sure it has fully completed
+-- Start new session on coordinator to make sure it has fully completed
 -- recovery and up and running again.
 1: SHOW gp_enable_global_deadlock_detector;
  gp_enable_global_deadlock_detector 

--- a/src/test/isolation2/expected/gpdispatch.out
+++ b/src/test/isolation2/expected/gpdispatch.out
@@ -1,7 +1,7 @@
 -- Try to verify that a session fatal due to OOM should have no effect on other sessions.
 -- Report on https://github.com/greenplum-db/gpdb/issues/12399
 
--- Because the number of errors reported to master can depend on ic types (i.e. ic-tcp and ic-proxy have one
+-- Because the number of errors reported to coordinator can depend on ic types (i.e. ic-tcp and ic-proxy have one
 -- additional error from the backend on seg0 which is trying to tear down TCP connection), we have to ignore
 -- all of them.
 -- start_matchignore

--- a/src/test/isolation2/expected/gpdispatch_1.out
+++ b/src/test/isolation2/expected/gpdispatch_1.out
@@ -1,7 +1,7 @@
 -- Try to verify that a session fatal due to OOM should have no effect on other sessions.
 -- Report on https://github.com/greenplum-db/gpdb/issues/12399
 
--- Because the number of errors reported to master can depend on ic types (i.e. ic-tcp and ic-proxy have one
+-- Because the number of errors reported to coordinator can depend on ic types (i.e. ic-tcp and ic-proxy have one
 -- additional error from the backend on seg0 which is trying to tear down TCP connection), we have to ignore
 -- all of them.
 -- start_matchignore

--- a/src/test/isolation2/expected/instr_in_shmem_terminate.out
+++ b/src/test/isolation2/expected/instr_in_shmem_terminate.out
@@ -16,9 +16,9 @@ CREATE
 GRANT SELECT ON TABLE __gp_localid TO public;
 GRANT
 
-CREATE EXTERNAL WEB TABLE __gp_masterid ( masterid    int ) EXECUTE E'echo $GP_SEGMENT_ID' ON COORDINATOR FORMAT 'TEXT';
+CREATE EXTERNAL WEB TABLE __gp_coordinatorid ( coordinatorid    int ) EXECUTE E'echo $GP_SEGMENT_ID' ON COORDINATOR FORMAT 'TEXT';
 CREATE
-GRANT SELECT ON TABLE __gp_masterid TO public;
+GRANT SELECT ON TABLE __gp_coordinatorid TO public;
 GRANT
 
 CREATE FUNCTION gp_instrument_shmem_detail_f() RETURNS SETOF RECORD AS '$libdir/gp_instrument_shmem', 'gp_instrument_shmem_detail' LANGUAGE C IMMUTABLE;
@@ -26,7 +26,7 @@ CREATE
 GRANT EXECUTE ON FUNCTION gp_instrument_shmem_detail_f() TO public;
 GRANT
 
-CREATE VIEW gp_instrument_shmem_detail AS WITH all_entries AS ( SELECT C.* FROM __gp_localid, gp_instrument_shmem_detail_f() as C ( tmid int4,ssid int4,ccnt int2,segid int2,pid int4 ,nid int2,tuplecount int8,nloops int8,ntuples int8 ) UNION ALL SELECT C.* FROM __gp_masterid, gp_instrument_shmem_detail_f() as C ( tmid int4,ssid int4,ccnt int2,segid int2,pid int4 ,nid int2,tuplecount int8,nloops int8,ntuples int8 )) SELECT tmid, ssid, ccnt,segid, pid, nid, tuplecount, nloops, ntuples FROM all_entries ORDER BY segid;
+CREATE VIEW gp_instrument_shmem_detail AS WITH all_entries AS ( SELECT C.* FROM __gp_localid, gp_instrument_shmem_detail_f() as C ( tmid int4,ssid int4,ccnt int2,segid int2,pid int4 ,nid int2,tuplecount int8,nloops int8,ntuples int8 ) UNION ALL SELECT C.* FROM __gp_coordinatorid, gp_instrument_shmem_detail_f() as C ( tmid int4,ssid int4,ccnt int2,segid int2,pid int4 ,nid int2,tuplecount int8,nloops int8,ntuples int8 )) SELECT tmid, ssid, ccnt,segid, pid, nid, tuplecount, nloops, ntuples FROM all_entries ORDER BY segid;
 CREATE
 
 CREATE TABLE a (id int, c char) DISTRIBUTED BY (id);

--- a/src/test/isolation2/expected/invalidated_toast_index.out
+++ b/src/test/isolation2/expected/invalidated_toast_index.out
@@ -22,7 +22,7 @@ INSERT 1
 -- start_ignore
 --
 -- Invalidate the index of the toast table for our relation. Because this is a
--- catalog change, we have to execute it on the master and all segments.
+-- catalog change, we have to execute it on the coordinator and all segments.
 --
 -- This is done in an ignore block so it can run correctly with any number of
 -- segments.

--- a/src/test/isolation2/expected/lockmodes.out
+++ b/src/test/isolation2/expected/lockmodes.out
@@ -1,4 +1,4 @@
--- table to just store the master's data directory path on segment.
+-- table to just store the coordinator's data directory path on segment.
 CREATE TABLE lockmodes_datadir(a int, dir text);
 CREATE
 INSERT INTO lockmodes_datadir select 1,datadir from gp_segment_configuration where role='p' and content=-1;
@@ -1138,7 +1138,7 @@ ROLLBACK
 -- enable gdd
 ALTER SYSTEM SET gp_enable_global_deadlock_detector TO on;
 ALTER
--- Use utility session on seg 0 to restart master. This way avoids the
+-- Use utility session on seg 0 to restart coordinator. This way avoids the
 -- situation where session issuing the restart doesn't disappear
 -- itself.
 1U:SELECT pg_ctl(dir, 'restart') from lockmodes_datadir;

--- a/src/test/isolation2/expected/lockmodes_optimizer.out
+++ b/src/test/isolation2/expected/lockmodes_optimizer.out
@@ -1,4 +1,4 @@
--- table to just store the master's data directory path on segment.
+-- table to just store the coordinator's data directory path on segment.
 CREATE TABLE lockmodes_datadir(a int, dir text);
 CREATE
 INSERT INTO lockmodes_datadir select 1,datadir from gp_segment_configuration where role='p' and content=-1;
@@ -1137,7 +1137,7 @@ ROLLBACK
 -- enable gdd
 ALTER SYSTEM SET gp_enable_global_deadlock_detector TO on;
 ALTER
--- Use utility session on seg 0 to restart master. This way avoids the
+-- Use utility session on seg 0 to restart coordinator. This way avoids the
 -- situation where session issuing the restart doesn't disappear
 -- itself.
 1U:SELECT pg_ctl(dir, 'restart') from lockmodes_datadir;

--- a/src/test/isolation2/expected/misc.out
+++ b/src/test/isolation2/expected/misc.out
@@ -1,7 +1,7 @@
 --
 -- Validate GPDB can create unique index on a table created in utility mode
 --
--- NOTICE: we must connect to master in utility mode because the oid of table is
+-- NOTICE: we must connect to coordinator in utility mode because the oid of table is
 -- preassigned in QD, if we create a table in utility mode in QE, the oid might
 -- conflict with preassigned oid.
 -1U: create table utilitymode_primary_key_tab (c1 int);

--- a/src/test/isolation2/expected/packcore.out
+++ b/src/test/isolation2/expected/packcore.out
@@ -12,7 +12,7 @@ def check_call(cmds): ret = subprocess.Popen(cmds, stdout=subprocess.PIPE, stder
 # verify that binary and shared libraries are included assert os.path.exists('{}/postgres'.format(dirname)) assert os.path.exists('{}/lib64/ld-linux-x86-64.so.2'.format(dirname)) 
 if os.path.exists('/usr/bin/gdb'): # load the coredump and run some simple gdb commands os.chdir(dirname) # remove LD_LIBRARY_PATH before invoking gdb ld_library_path = None if 'LD_LIBRARY_PATH' in os.environ: ld_library_path = os.environ.pop('LD_LIBRARY_PATH') check_call(['./runGDB.sh', '--batch', '--nx', '--eval-command=bt', '--eval-command=p main', '--eval-command=p fork']) # restore LD_LIBRARY_PATH to its previous value if ld_library_path is not None: os.environ['LD_LIBRARY_PATH'] = ld_library_path os.chdir('..') 
 # gzip runs much faster with -1 os.putenv('GZIP', '-1') 
-# do not put the packcore results under master data, that will cause # failures in other tests os.chdir('/tmp') 
+# do not put the packcore results under coordinator data, that will cause # failures in other tests os.chdir('/tmp') 
 gphome = os.getenv('GPHOME') assert gphome 
 postgres = '{}/bin/postgres'.format(gphome) assert os.path.exists(postgres) 
 packcore = '{}/sbin/packcore'.format(gphome) assert os.path.exists(packcore) 

--- a/src/test/isolation2/expected/prevent_ao_wal.out
+++ b/src/test/isolation2/expected/prevent_ao_wal.out
@@ -73,10 +73,10 @@ pg_waldump: fatal: error in WAL record at 0/10081FB8: invalid record length at 0
 
 
 -- *********** Set wal_level=minimal **************
-!\retcode gpconfig -c wal_level -v minimal --masteronly;
+!\retcode gpconfig -c wal_level -v minimal --coordinatoronly;
 (exited with code 0)
 -- Set max_wal_senders to 0 because a non-zero value requires wal_level >= 'archive'
-!\retcode gpconfig -c max_wal_senders -v 0 --masteronly;
+!\retcode gpconfig -c max_wal_senders -v 0 --coordinatoronly;
 (exited with code 0)
 -- Restart QD
 !\retcode pg_ctl -l /dev/null -D $COORDINATOR_DATA_DIRECTORY restart -w -t 600 -m fast;
@@ -115,10 +115,10 @@ DROP
 DROP
 
 -- Reset wal_level
-!\retcode gpconfig -r wal_level --masteronly;
+!\retcode gpconfig -r wal_level --coordinatoronly;
 (exited with code 0)
 -- Reset max_wal_senders
-!\retcode gpconfig -r max_wal_senders --masteronly;
+!\retcode gpconfig -r max_wal_senders --coordinatoronly;
 (exited with code 0)
 -- Restart QD
 !\retcode pg_ctl -l /dev/null -D $COORDINATOR_DATA_DIRECTORY restart -w -t 600 -m fast;

--- a/src/test/isolation2/expected/prevent_ao_wal_1.out
+++ b/src/test/isolation2/expected/prevent_ao_wal_1.out
@@ -56,10 +56,10 @@ VACUUM
 
 
 -- *********** Set wal_level=minimal **************
-!\retcode gpconfig -c wal_level -v minimal --masteronly;
+!\retcode gpconfig -c wal_level -v minimal --coordinatoronly;
 (exited with code 0)
 -- Set max_wal_senders to 0 because a non-zero value requires wal_level >= 'archive'
-!\retcode gpconfig -c max_wal_senders -v 0 --masteronly;
+!\retcode gpconfig -c max_wal_senders -v 0 --coordinatoronly;
 (exited with code 0)
 -- Restart QD
 !\retcode pg_ctl -l /dev/null -D $COORDINATOR_DATA_DIRECTORY restart -w -t 600 -m fast;
@@ -98,10 +98,10 @@ DROP
 DROP
 
 -- Reset wal_level
-!\retcode gpconfig -r wal_level --masteronly;
+!\retcode gpconfig -r wal_level --coordinatoronly;
 (exited with code 0)
 -- Reset max_wal_senders
-!\retcode gpconfig -r max_wal_senders --masteronly;
+!\retcode gpconfig -r max_wal_senders --coordinatoronly;
 (exited with code 0)
 -- Restart QD
 !\retcode pg_ctl -l /dev/null -D $COORDINATOR_DATA_DIRECTORY restart -w -t 600 -m fast;

--- a/src/test/isolation2/expected/reindex/serializable_reindex_with_drop_column_heap.out
+++ b/src/test/isolation2/expected/reindex/serializable_reindex_with_drop_column_heap.out
@@ -44,7 +44,7 @@ SET
 ALTER
 1: COMMIT;
 COMMIT
--- Remember index relfilenodes from master and segments before
+-- Remember index relfilenodes from coordinator and segments before
 -- reindex.
 2: create temp table old_relfilenodes as (select gp_segment_id as dbid, relfilenode, oid, relname from gp_dist_random('pg_class') where relname like 'idx%_reindex_serialize_tab_heap' union all select gp_segment_id as dbid, relfilenode, oid, relname from pg_class where relname like 'idx%_reindex_serialize_tab_heap');
 CREATE 28
@@ -52,7 +52,7 @@ CREATE 28
 REINDEX
 2: COMMIT;
 COMMIT
--- Validate that reindex changed all index relfilenodes on master as well as
+-- Validate that reindex changed all index relfilenodes on coordinator as well as
 -- segments.  The following query should return 0 tuples.
 2: select oldrels.* from old_relfilenodes oldrels join (select gp_segment_id as dbid, relfilenode, relname from gp_dist_random('pg_class') where relname like 'idx%_reindex_serialize_tab_heap' union all select gp_segment_id as dbid, relfilenode, relname from pg_class where relname like 'idx%_reindex_serialize_tab_heap') newrels on oldrels.relfilenode = newrels.relfilenode and oldrels.dbid = newrels.dbid and oldrels.relname = newrels.relname;
  dbid | relfilenode | oid | relname 

--- a/src/test/isolation2/expected/reindex/serializable_reindex_with_drop_index_ao.out
+++ b/src/test/isolation2/expected/reindex/serializable_reindex_with_drop_index_ao.out
@@ -44,7 +44,7 @@ SET
 DROP
 1: COMMIT;
 COMMIT
--- Remember index relfilenodes from master and segments before
+-- Remember index relfilenodes from coordinator and segments before
 -- reindex.
 2: create table old_ao_relfilenodes as (select gp_segment_id as dbid, relfilenode, oid, relname from gp_dist_random('pg_class') where relname like 'idx%_reindex_serialize_tab_ao' union all select gp_segment_id as dbid, relfilenode, oid, relname from pg_class where relname like 'idx%_reindex_serialize_tab_ao');
 CREATE 28
@@ -52,7 +52,7 @@ CREATE 28
 REINDEX
 2: COMMIT;
 COMMIT
--- Validate that reindex changed all index relfilenodes on master as well as
+-- Validate that reindex changed all index relfilenodes on coordinator as well as
 -- segments.  The following query should return 0 tuples.
 2: select oldrels.* from old_ao_relfilenodes oldrels join (select gp_segment_id as dbid, relfilenode, relname from gp_dist_random('pg_class') where relname like 'idx%_reindex_serialize_tab_ao' union all select gp_segment_id as dbid, relfilenode, relname from pg_class where relname like 'idx%_reindex_serialize_tab_ao') newrels on oldrels.relfilenode = newrels.relfilenode and oldrels.dbid = newrels.dbid and oldrels.relname = newrels.relname;
  dbid | relfilenode | oid | relname 

--- a/src/test/isolation2/expected/reindex/serializable_reindex_with_drop_index_heap.out
+++ b/src/test/isolation2/expected/reindex/serializable_reindex_with_drop_index_heap.out
@@ -41,7 +41,7 @@ SET
 DROP
 1: COMMIT;
 COMMIT
--- Remember index relfilenodes from master and segments before
+-- Remember index relfilenodes from coordinator and segments before
 -- reindex.
 2: create table old_heap_relfilenodes as (select gp_segment_id as dbid, relfilenode, oid, relname from gp_dist_random('pg_class') where relname like 'idx%_reindex_dropindex_serialize_tab_heap' union all select gp_segment_id as dbid, relfilenode, oid, relname from pg_class where relname like 'idx%_reindex_dropindex_serialize_tab_heap');
 CREATE 28
@@ -49,7 +49,7 @@ CREATE 28
 REINDEX
 2: COMMIT;
 COMMIT
--- Validate that reindex changed all index relfilenodes on master as well as
+-- Validate that reindex changed all index relfilenodes on coordinator as well as
 -- segments.  The following query should return 0 tuples.
 2: select oldrels.* from old_heap_relfilenodes oldrels join (select gp_segment_id as dbid, relfilenode, relname from gp_dist_random('pg_class') where relname like 'idx%_reindex_dropindex_serialize_tab_heap' union all select gp_segment_id as dbid, relfilenode, relname from pg_class where relname like 'idx%_reindex_dropindex_serialize_tab_heap') newrels on oldrels.relfilenode = newrels.relfilenode and oldrels.dbid = newrels.dbid and oldrels.relname = newrels.relname;
  dbid | relfilenode | oid | relname 

--- a/src/test/isolation2/expected/reindex/vacuum_analyze_while_reindex_ao_btree.out
+++ b/src/test/isolation2/expected/reindex/vacuum_analyze_while_reindex_ao_btree.out
@@ -27,7 +27,7 @@ DELETE FROM reindex_ao WHERE a < 128;
 DELETE 254
 1: BEGIN;
 BEGIN
--- Remember index relfilenodes from master and segments before
+-- Remember index relfilenodes from coordinator and segments before
 -- reindex.
 1: create temp table old_relfilenodes as (select gp_segment_id as dbid, relfilenode, oid, relname from gp_dist_random('pg_class') where relname = 'idx_btree_reindex_vacuum_analyze_ao' union all select gp_segment_id as dbid, relfilenode, oid, relname from pg_class where relname = 'idx_btree_reindex_vacuum_analyze_ao');
 CREATE 4
@@ -38,7 +38,7 @@ REINDEX
 COMMIT
 2<:  <... completed>
 VACUUM
--- Validate that reindex changed all index relfilenodes on master as well as
+-- Validate that reindex changed all index relfilenodes on coordinator as well as
 -- segments.  The following query should return 0 tuples.
 1: select oldrels.* from old_relfilenodes oldrels join (select gp_segment_id as dbid, relfilenode, relname from gp_dist_random('pg_class') where relname = 'idx_btree_reindex_vacuum_analyze_ao' union all select gp_segment_id as dbid, relfilenode, relname from pg_class where relname = 'idx_btree_reindex_vacuum_analyze_ao') newrels on oldrels.relfilenode = newrels.relfilenode and oldrels.dbid = newrels.dbid and oldrels.relname = newrels.relname;
  dbid | relfilenode | oid | relname 

--- a/src/test/isolation2/expected/reindex/vacuum_while_reindex_ao_bitmap.out
+++ b/src/test/isolation2/expected/reindex/vacuum_while_reindex_ao_bitmap.out
@@ -16,7 +16,7 @@ DELETE FROM reindex_ao WHERE a < 128;
 DELETE 254
 1: BEGIN;
 BEGIN
--- Remember index relfilenodes from master and segments before
+-- Remember index relfilenodes from coordinator and segments before
 -- reindex.
 1: create temp table old_relfilenodes as (select gp_segment_id as dbid, relfilenode, oid, relname from gp_dist_random('pg_class') where relname = 'idx_bitmap_reindex_ao' union all select gp_segment_id as dbid, relfilenode, oid, relname from pg_class where relname = 'idx_bitmap_reindex_ao');
 CREATE 4
@@ -27,7 +27,7 @@ REINDEX
 COMMIT
 2<:  <... completed>
 VACUUM
--- Validate that reindex changed all index relfilenodes on master as well as
+-- Validate that reindex changed all index relfilenodes on coordinator as well as
 -- segments.  The following query should return 0 tuples.
 1: select oldrels.* from old_relfilenodes oldrels join (select gp_segment_id as dbid, relfilenode, relname from gp_dist_random('pg_class') where relname = 'idx_bitmap_reindex_ao' union all select gp_segment_id as dbid, relfilenode, relname from pg_class where relname = 'idx_bitmap_reindex_ao') newrels on oldrels.relfilenode = newrels.relfilenode and oldrels.dbid = newrels.dbid and oldrels.relname = newrels.relname;
  dbid | relfilenode | oid | relname 

--- a/src/test/isolation2/expected/reindex/vacuum_while_reindex_heap_btree.out
+++ b/src/test/isolation2/expected/reindex/vacuum_while_reindex_heap_btree.out
@@ -16,7 +16,7 @@ DELETE FROM reindex_heap WHERE a < 128;
 DELETE 254
 1: BEGIN;
 BEGIN
--- Remember index relfilenodes from master and segments before
+-- Remember index relfilenodes from coordinator and segments before
 -- reindex.
 1: create temp table old_relfilenodes as (select gp_segment_id as dbid, relfilenode, oid, relname from gp_dist_random('pg_class') where relname = 'idx_btree_reindex_heap' union all select gp_segment_id as dbid, relfilenode, oid, relname from pg_class where relname = 'idx_btree_reindex_heap');
 CREATE 4
@@ -27,7 +27,7 @@ REINDEX
 COMMIT
 2<:  <... completed>
 VACUUM
--- Validate that reindex changed all index relfilenodes on master as well as
+-- Validate that reindex changed all index relfilenodes on coordinator as well as
 -- segments.  The following query should return 0 tuples.
 1: select oldrels.* from old_relfilenodes oldrels join (select gp_segment_id as dbid, relfilenode, relname from gp_dist_random('pg_class') where relname = 'idx_btree_reindex_heap' union all select gp_segment_id as dbid, relfilenode, relname from pg_class where relname = 'idx_btree_reindex_heap') newrels on oldrels.relfilenode = newrels.relfilenode and oldrels.dbid = newrels.dbid and oldrels.relname = newrels.relname;
  dbid | relfilenode | oid | relname 

--- a/src/test/isolation2/expected/reindex/vacuum_while_reindex_heap_btree_toast.out
+++ b/src/test/isolation2/expected/reindex/vacuum_while_reindex_heap_btree_toast.out
@@ -16,7 +16,7 @@ DELETE FROM reindex_toast_heap WHERE b % 4 = 0 ;
 DELETE 25
 1: BEGIN;
 BEGIN
--- Remember index relfilenodes from master and segments before
+-- Remember index relfilenodes from coordinator and segments before
 -- reindex.
 1: create temp table old_relfilenodes as (select gp_segment_id as dbid, relfilenode, oid, relname from gp_dist_random('pg_class') where relname = 'idx_btree_reindex_toast_heap' union all select gp_segment_id as dbid, relfilenode, oid, relname from pg_class where relname = 'idx_btree_reindex_toast_heap');
 CREATE 4
@@ -27,7 +27,7 @@ REINDEX
 COMMIT
 2<:  <... completed>
 VACUUM
--- Validate that reindex changed all index relfilenodes on master as well as
+-- Validate that reindex changed all index relfilenodes on coordinator as well as
 -- segments.  The following query should return 0 tuples.
 1: select oldrels.* from old_relfilenodes oldrels join (select gp_segment_id as dbid, relfilenode, relname from gp_dist_random('pg_class') where relname = 'idx_btree_reindex_toast_heap' union all select gp_segment_id as dbid, relfilenode, relname from pg_class where relname = 'idx_btree_reindex_toast_heap') newrels on oldrels.relfilenode = newrels.relfilenode and oldrels.dbid = newrels.dbid and oldrels.relname = newrels.relname;
  dbid | relfilenode | oid | relname 

--- a/src/test/isolation2/expected/resgroup/resgroup_cpuset.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_cpuset.out
@@ -272,7 +272,7 @@ DROP RESOURCE GROUP rg1_test_group;
 ERROR:  resource group "rg1_test_group" does not exist
 -- end_ignore
 
--- test segment/master cpuset
+-- test segment/coordinator cpuset
 CREATE RESOURCE GROUP rg_multi_cpuset1 WITH (concurrency=2, cpuset='0;0');
 CREATE
 ALTER RESOURCE GROUP rg_multi_cpuset1 set CPUSET '1;1';

--- a/src/test/isolation2/expected/resgroup/resgroup_move_query.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_move_query.out
@@ -3,7 +3,7 @@
 -- m/ERROR:  process \d+ is in IDLE state/
 -- s/\d+/XXX/g
 --
--- m/ERROR:  group \d+ doesn't have enough memory on master, expect:\d+, available:\d+/
+-- m/ERROR:  group \d+ doesn't have enough memory on coordinator, expect:\d+, available:\d+/
 -- s/\d+/XXX/g
 --
 -- m/ERROR:  group \d+ doesn't have enough memory on segment, expect:\d+, available:\d+/

--- a/src/test/isolation2/expected/segwalrep/commit_blocking_on_standby.out
+++ b/src/test/isolation2/expected/segwalrep/commit_blocking_on_standby.out
@@ -1,13 +1,13 @@
 --
--- Master/standby commit blocking scenarios.  These are different from
+-- Coordinator/standby commit blocking scenarios.  These are different from
 -- primary/mirror commit blocking because there is no FTS or a
--- third-party as external arbiter in case of master/standby.
+-- third-party as external arbiter in case of coordinator/standby.
 --
 -- Scenario1: Commits should block until standby confirms WAL flush
 -- up to commit LSN.
 
 -- Check that are starting with a clean slate, standby must be in sync
--- with master.
+-- with coordinator.
 
 select application_name, state from pg_stat_replication;
  application_name | state     
@@ -77,7 +77,7 @@ INSERT 1
 -- has caught up within range.  And thereafter, commits should start
 -- blocking.
 
--- In order to get master and standby in CATCHUP state, existing
+-- In order to get coordinator and standby in CATCHUP state, existing
 -- connection, which is in STREAMING state must be closed.  A new
 -- connection will then be initiated by standby, beginning in STARTUP
 -- then CATCHUP to STREAMING.  Faults are used to suspend WAL sender
@@ -209,7 +209,7 @@ select wait_until_standby_in_state('streaming');
 
 -- Scenario3: verify repl_catchup_within_range is enabled on segment.
 -- It is similar as Scenario2, just running the test against primary/mirror
--- instead of master/standby.
+-- instead of coordinator/standby.
 
 select gp_inject_fault_infinite('wal_sender_loop', 'infinite_loop', dbid) from gp_segment_configuration where content=0 and role='p';
  gp_inject_fault_infinite 

--- a/src/test/isolation2/expected/segwalrep/coordinator_wal_switch.out
+++ b/src/test/isolation2/expected/segwalrep/coordinator_wal_switch.out
@@ -9,7 +9,7 @@ SELECT gp_inject_fault('base_backup_post_create_checkpoint', 'suspend', dbid) FR
 (1 row)
 
 -- Run pg_basebackup which should trigger and suspend at the fault
-1&: SELECT pg_basebackup(hostname, 100, port, false, NULL, '/tmp/master_wal_switch_test', true, 'fetch') from gp_segment_configuration where content=-1 and role='p';  <waiting ...>
+1&: SELECT pg_basebackup(hostname, 100, port, false, NULL, '/tmp/coordinator_wal_switch_test', true, 'fetch') from gp_segment_configuration where content=-1 and role='p';  <waiting ...>
 
 -- Wait until fault has been triggered
 SELECT gp_wait_until_triggered_fault('base_backup_post_create_checkpoint', 1, dbid) FROM gp_segment_configuration WHERE content=-1 and role='p';
@@ -33,7 +33,7 @@ CREATE TEMP TABLE walfile(fname text) DISTRIBUTED BY (fname);
 CREATE
 INSERT INTO walfile SELECT pg_walfile_name(pg_switch_wal());
 INSERT 1
-CREATE TABLE master_wal_dummy();
+CREATE TABLE coordinator_wal_dummy();
 CREATE
 -- This should return false, indicating current WAL segment is
 -- different than what was previously recorded walfile table.
@@ -68,10 +68,10 @@ SELECT application_name, state FROM pg_stat_replication;
 ------------------+-----------
  gp_walreceiver   | streaming 
 (1 row)
-!\retcode ls /tmp/master_wal_switch_test/postgresql.auto.conf /tmp/master_wal_switch_test/standby.signal;
+!\retcode ls /tmp/coordinator_wal_switch_test/postgresql.auto.conf /tmp/coordinator_wal_switch_test/standby.signal;
 -- start_ignore
-/tmp/master_wal_switch_test/postgresql.auto.conf
-/tmp/master_wal_switch_test/standby.signal
+/tmp/coordinator_wal_switch_test/postgresql.auto.conf
+/tmp/coordinator_wal_switch_test/standby.signal
 
 -- end_ignore
 (exited with code 0)

--- a/src/test/isolation2/expected/segwalrep/dtm_recovery_on_standby.out
+++ b/src/test/isolation2/expected/segwalrep/dtm_recovery_on_standby.out
@@ -1,7 +1,7 @@
 -- Validate that standby performs DTM recovery upon promotion.
 
 -- Check that are starting with a clean slate, standby must be in sync
--- with master.
+-- with coordinator.
 select application_name, state, sync_state from pg_stat_replication;
  application_name | state     | sync_state 
 ------------------+-----------+------------
@@ -9,9 +9,9 @@ select application_name, state, sync_state from pg_stat_replication;
 (1 row)
 
 -- Scenario1: standby broadcasts commit-prepared for a transaction
--- that was prepared on master.
+-- that was prepared on coordinator.
 
--- Suspend master backend before it sends commit-prepared
+-- Suspend coordinator backend before it sends commit-prepared
 select gp_inject_fault('dtm_broadcast_commit_prepared', 'suspend', dbid) from gp_segment_configuration where content = -1 and role = 'p';
  gp_inject_fault 
 -----------------
@@ -103,7 +103,7 @@ select pg_ctl(datadir, 'stop', 'immediate') from gp_segment_configuration where 
 -- by gpinitstandby needs access exclusive lock and the backend for
 -- this isolation spec is already holding an access share lock on
 -- gp_segment_configuration.
--- NOTE: the select query should fail since the gang for master has been
+-- NOTE: the select query should fail since the gang for coordinator has been
 -- terminated by the dtx recovery process on standby during standby promote. We
 -- do not test the result of the select query; just expect it fail so that the
 -- next mpp query could recreate the gang and succeed.
@@ -114,7 +114,7 @@ ERROR:  terminating connection due to administrator command  (seg0 slice1 192.16
 create table standby_config as (select hostname, datadir, port, role from gp_segment_configuration where content = -1) distributed by (hostname);
 CREATE 2
 
-create or replace function reinitialize_standby() returns text as $$ import subprocess rv = plpy.execute("select hostname, datadir, port from standby_config order by role", 2) standby = rv[0] # role = 'm' master = rv[1] # role = 'p' try: cmd = 'rm -rf %s.dtm_recovery && cp -R %s %s.dtm_recovery' % (standby['datadir'], standby['datadir'], standby['datadir']) remove_output = subprocess.check_output(cmd, shell=True, stderr=subprocess.STDOUT).decode('ascii') cmd = 'gpinitstandby -ar -P %d' % master['port'] remove_output += subprocess.check_output(cmd, shell=True, stderr=subprocess.STDOUT).decode('ascii') cmd = 'export PGPORT=%d; gpinitstandby -a -s %s -S %s -P %d' % (master['port'], standby['hostname'], standby['datadir'], standby['port']) init_output = subprocess.check_output(cmd, shell=True, stderr=subprocess.STDOUT).decode('ascii') except subprocess.CalledProcessError as e: plpy.info(e.output) raise 
+create or replace function reinitialize_standby() returns text as $$ import subprocess rv = plpy.execute("select hostname, datadir, port from standby_config order by role", 2) standby = rv[0] # role = 'c' coordinator = rv[1] # role = 'p' try: cmd = 'rm -rf %s.dtm_recovery && cp -R %s %s.dtm_recovery' % (standby['datadir'], standby['datadir'], standby['datadir']) remove_output = subprocess.check_output(cmd, shell=True, stderr=subprocess.STDOUT).decode('ascii') cmd = 'gpinitstandby -ar -P %d' % coordinator['port'] remove_output += subprocess.check_output(cmd, shell=True, stderr=subprocess.STDOUT).decode('ascii') cmd = 'export PGPORT=%d; gpinitstandby -a -s %s -S %s -P %d' % (coordinator['port'], standby['hostname'], standby['datadir'], standby['port']) init_output = subprocess.check_output(cmd, shell=True, stderr=subprocess.STDOUT).decode('ascii') except subprocess.CalledProcessError as e: plpy.info(e.output) raise 
 if "ERROR" not in remove_output and "FATAL" not in remove_output and \ "ERROR" not in init_output and "FATAL" not in init_output: return "standby initialized" 
 return remove_output + "\n" + init_output $$ language plpython3u;
 CREATE
@@ -125,7 +125,7 @@ select reinitialize_standby();
  standby initialized  
 (1 row)
 
--- Sync state between master and standby must be restored at the end.
+-- Sync state between coordinator and standby must be restored at the end.
 select wait_until_standby_in_state('streaming');
  wait_until_standby_in_state 
 -----------------------------

--- a/src/test/isolation2/expected/segwalrep/dtx_recovery_wait_lsn.out
+++ b/src/test/isolation2/expected/segwalrep/dtx_recovery_wait_lsn.out
@@ -1,6 +1,6 @@
 -- Test this scenario:
--- mirror has latency replaying the WAL from the primary, the master is reset
--- from PANIC, master will start the DTX recovery process to recover the
+-- mirror has latency replaying the WAL from the primary, the coordinator is reset
+-- from PANIC, coordinator will start the DTX recovery process to recover the
 -- in-progress two-phase transactions.
 -- The FTS process should be able to continue probe and 'sync off' the mirror
 -- while the 'dtx recovery' process is hanging recovering distributed transactions.
@@ -57,13 +57,13 @@ CREATE
 --------
  OK     
 (1 row)
--- trigger master reset
+-- trigger coordinator reset
 3: select gp_inject_fault('exec_simple_query_start', 'panic', current_setting('gp_dbid')::smallint);
  gp_inject_fault 
 -----------------
  Success:        
 (1 row)
--- verify master panic happens. The PANIC message does not emit sometimes so
+-- verify coordinator panic happens. The PANIC message does not emit sometimes so
 -- mask it.
 -- start_matchsubs
 -- m/PANIC:  fault triggered, fault name:'exec_simple_query_start' fault type:'panic'\n/
@@ -75,7 +75,7 @@ server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
 
--- wait for master finish crash recovery
+-- wait for coordinator finish crash recovery
 -1U: select wait_until_standby_in_state('streaming');
  wait_until_standby_in_state 
 -----------------------------
@@ -101,9 +101,9 @@ server closed the connection unexpectedly
 -- start_ignore
 20200123:08:12:02:395970 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Starting gprecoverseg with args: -a
 20200123:08:12:02:395970 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-local Greenplum Version: 'postgres (Greenplum Database) 7.0.0-alpha.0+dev.5441.g9dc261e1f2 build dev'
-20200123:08:12:02:395970 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-master Greenplum Version: 'PostgreSQL 9.6beta4 (Greenplum Database 7.0.0-alpha.0+dev.5441.g9dc261e1f2 build dev) on x86_64-unknown-linux-gnu, compiled by gcc (GCC) 6.2.0, 64-bit compiled on Jan 23 2020 07:13:04'
-20200123:08:12:02:395970 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Obtaining Segment details from master...
-20200123:08:12:02:395970 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Heap checksum setting is consistent between master and the segments that are candidates for recoverseg
+20200123:08:12:02:395970 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-coordinator Greenplum Version: 'PostgreSQL 9.6beta4 (Greenplum Database 7.0.0-alpha.0+dev.5441.g9dc261e1f2 build dev) on x86_64-unknown-linux-gnu, compiled by gcc (GCC) 6.2.0, 64-bit compiled on Jan 23 2020 07:13:04'
+20200123:08:12:02:395970 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Obtaining Segment details from coordinator...
+20200123:08:12:02:395970 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Heap checksum setting is consistent between coordinator and the segments that are candidates for recoverseg
 20200123:08:12:02:395970 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Greenplum instance recovery parameters
 20200123:08:12:02:395970 gprecoverseg:09c5497cf854:gpadmin-[INFO]:----------------------------------------------------------
 20200123:08:12:02:395970 gprecoverseg:09c5497cf854:gpadmin-[INFO]:-Recovery type              = Standard

--- a/src/test/isolation2/expected/segwalrep/failover_with_many_records.out
+++ b/src/test/isolation2/expected/segwalrep/failover_with_many_records.out
@@ -2,11 +2,11 @@
 -- gprecoverseg BEGIN failures due to gang creation failure as some primaries
 -- are not up. Setting these increase the number of retries in gang creation in
 -- case segment is in recovery. Approximately we want to wait 30 seconds.
-!\retcode gpconfig -c gp_gang_creation_retry_count -v 120 --skipvalidation --masteronly;
+!\retcode gpconfig -c gp_gang_creation_retry_count -v 120 --skipvalidation --coordinatoronly;
 -- start_ignore
 -- end_ignore
 (exited with code 0)
-!\retcode gpconfig -c gp_gang_creation_retry_timer -v 1000 --skipvalidation --masteronly;
+!\retcode gpconfig -c gp_gang_creation_retry_timer -v 1000 --skipvalidation --coordinatoronly;
 -- start_ignore
 -- end_ignore
 (exited with code 0)
@@ -100,11 +100,11 @@ select wait_until_all_segments_synchronized();
  0     
 (1 row)
 
-!\retcode gpconfig -r gp_gang_creation_retry_count --skipvalidation --masteronly;
+!\retcode gpconfig -r gp_gang_creation_retry_count --skipvalidation --coordinatoronly;
 -- start_ignore
 -- end_ignore
 (exited with code 0)
-!\retcode gpconfig -r gp_gang_creation_retry_timer --skipvalidation --masteronly;
+!\retcode gpconfig -r gp_gang_creation_retry_timer --skipvalidation --coordinatoronly;
 -- start_ignore
 -- end_ignore
 (exited with code 0)

--- a/src/test/isolation2/expected/segwalrep/twophase_tolerance_with_mirror_promotion.out
+++ b/src/test/isolation2/expected/segwalrep/twophase_tolerance_with_mirror_promotion.out
@@ -6,7 +6,7 @@
 --   2) if the transaction is already prepared, then it should complete commit
 --      on the mirror
 --   3) if the transaction has committed on the primary, but not acknowledged
---      to the master then it should complete the commit on the mirror
+--      to the coordinator then it should complete the commit on the mirror
 
 -- Test setup: This test needs a minimum of 3 primary/mirror pairs. In order to
 -- minimize test time, each scenario is created on a different segment. Each
@@ -22,7 +22,7 @@
 --
 -- end_matchsubs
 
-!\retcode gpconfig -c gp_fts_probe_retries -v 2 --masteronly;
+!\retcode gpconfig -c gp_fts_probe_retries -v 2 --coordinatoronly;
 -- start_ignore
 -- end_ignore
 (exited with code 0)
@@ -30,11 +30,11 @@
 -- gprecoverseg BEGIN failures due to gang creation failure as some primaries
 -- are not up. Setting these increase the number of retries in gang creation in
 -- case segment is in recovery. Approximately we want to wait 30 seconds.
-!\retcode gpconfig -c gp_gang_creation_retry_count -v 127 --skipvalidation --masteronly;
+!\retcode gpconfig -c gp_gang_creation_retry_count -v 127 --skipvalidation --coordinatoronly;
 -- start_ignore
 -- end_ignore
 (exited with code 0)
-!\retcode gpconfig -c gp_gang_creation_retry_timer -v 250 --skipvalidation --masteronly;
+!\retcode gpconfig -c gp_gang_creation_retry_timer -v 250 --skipvalidation --coordinatoronly;
 -- start_ignore
 -- end_ignore
 (exited with code 0)
@@ -164,7 +164,7 @@ CREATE
 1:INSERT INTO tolerance_test_table VALUES(42);
 INSERT 1
 
--- Scenario 3: Commit-Prepare received on primary but not acknowledged to master
+-- Scenario 3: Commit-Prepare received on primary but not acknowledged to coordinator
 -- NOTICE: Don't use session 2 again because it's cached gang is invalid
 1:SELECT gp_inject_fault_infinite('finish_prepared_start_of_function', 'infinite_loop', dbid) FROM gp_segment_configuration WHERE content = 2 AND role = 'p';
  gp_inject_fault_infinite 
@@ -196,9 +196,9 @@ INSERT 1
 1<:  <... completed>
 DROP
 
--- Use new connection session. This helps is to make sure master is up and
+-- Use new connection session. This helps is to make sure coordinator is up and
 -- running, even if in worst case the above Drop command commit-prepared retries
--- are exhausted and PANICs the master.
+-- are exhausted and PANICs the coordinator.
 5:SELECT role, preferred_role FROM gp_segment_configuration WHERE content = 2;
  role | preferred_role 
 ------+----------------
@@ -216,15 +216,15 @@ DROP
 -- end_ignore
 (exited with code 0)
 
-!\retcode gpconfig -r gp_fts_probe_retries --masteronly;
+!\retcode gpconfig -r gp_fts_probe_retries --coordinatoronly;
 -- start_ignore
 -- end_ignore
 (exited with code 0)
-!\retcode gpconfig -r gp_gang_creation_retry_count --skipvalidation --masteronly;
+!\retcode gpconfig -r gp_gang_creation_retry_count --skipvalidation --coordinatoronly;
 -- start_ignore
 -- end_ignore
 (exited with code 0)
-!\retcode gpconfig -r gp_gang_creation_retry_timer --skipvalidation --masteronly;
+!\retcode gpconfig -r gp_gang_creation_retry_timer --skipvalidation --coordinatoronly;
 -- start_ignore
 -- end_ignore
 (exited with code 0)

--- a/src/test/isolation2/expected/setup.out
+++ b/src/test/isolation2/expected/setup.out
@@ -11,7 +11,7 @@ CREATE
 CREATE OR REPLACE FUNCTION gp_ao_or_aocs_seg(rel regclass, segment_id OUT integer, segno OUT integer, tupcount OUT bigint, modcount OUT bigint, formatversion OUT smallint, state OUT smallint) RETURNS SETOF record as $$ declare amname_var text;	/* in func */ begin	/* in func */ select amname into amname_var from pg_class c, pg_am am where c.relam = am.oid and c.oid = rel; /* in func */ if amname_var = 'ao_column' then	/* in func */ for segment_id, segno, tupcount, modcount, formatversion, state in SELECT DISTINCT x.segment_id, x.segno, x.tupcount, x.modcount, x.formatversion, x.state FROM gp_toolkit.__gp_aocsseg(rel) x loop	/* in func */ return next;	/* in func */ end loop;	/* in func */ elsif amname_var = 'ao_row' then	/* in func */ for segment_id, segno, tupcount, modcount, formatversion, state in SELECT x.segment_id, x.segno, x.tupcount, x.modcount, x.formatversion, x.state FROM gp_toolkit.__gp_aoseg(rel) x loop	/* in func */ return next;	/* in func */ end loop;	/* in func */ else	/* in func */ raise '% is not an AO_ROW or AO_COLUMN table', rel::text;	/* in func */ end if;	/* in func */ end;	/* in func */ $$ LANGUAGE plpgsql;
 CREATE
 
--- Show locks in master and in segments. Because the number of segments
+-- Show locks in coordinator and in segments. Because the number of segments
 -- in the cluster depends on configuration, we print only summary information
 -- of the locks in segments. If a relation is locked only on one segment,
 -- we print that as a special case, but otherwise we just print "n segments",
@@ -129,9 +129,9 @@ CREATE
 create or replace function validate_tablespace_symlink(datadir text, tablespacedir text, dbid int, tablespace_oid oid) returns boolean as $$ import os return os.readlink('%s/pg_tblspc/%d' % (datadir, tablespace_oid)) == ('%s/%d' % (tablespacedir, dbid)) $$ language plpython3u;
 CREATE
 
--- This function is used to loop until master shutsdown, to make sure
+-- This function is used to loop until coordinator shutsdown, to make sure
 -- next command executed is only after restart and doesn't go through
--- while PANIC is still being processed by master, as master continues
+-- while PANIC is still being processed by coordinator, as coordinator continues
 -- to accept connections for a while despite undergoing PANIC.
 CREATE OR REPLACE FUNCTION wait_till_master_shutsdown() RETURNS void AS $$ DECLARE i int; /* in func */ BEGIN i := 0; /* in func */ while i < 120 loop i := i + 1; /* in func */ PERFORM pg_sleep(.5); /* in func */ end loop; /* in func */ END; /* in func */ $$ LANGUAGE plpgsql;
 CREATE

--- a/src/test/isolation2/expected/uao_crash_compaction_column.out
+++ b/src/test/isolation2/expected/uao_crash_compaction_column.out
@@ -284,9 +284,9 @@ UPDATE 1
 (12 rows)
 
 --
--- Setup tables to test crash at different points on master now
+-- Setup tables to test crash at different points on coordinator now
 --
--- for crash_master_before_cleanup_phase
+-- for crash_coordinator_before_cleanup_phase
 2:set default_table_access_method = ao_column;
 SET
 2:show default_table_access_method;
@@ -294,24 +294,24 @@ SET
 -----------------------------
  ao_column                   
 (1 row)
-2:DROP TABLE IF EXISTS crash_master_before_cleanup_phase CASCADE;
+2:DROP TABLE IF EXISTS crash_coordinator_before_cleanup_phase CASCADE;
 DROP
-2:CREATE TABLE crash_master_before_cleanup_phase (a INT, b INT, c CHAR(20));
+2:CREATE TABLE crash_coordinator_before_cleanup_phase (a INT, b INT, c CHAR(20));
 CREATE
-2:CREATE INDEX crash_master_before_cleanup_phase_index ON crash_master_before_cleanup_phase(b);
+2:CREATE INDEX crash_coordinator_before_cleanup_phase_index ON crash_coordinator_before_cleanup_phase(b);
 CREATE
-2:INSERT INTO crash_master_before_cleanup_phase SELECT i AS a, 1 AS b, 'hello world' AS c FROM generate_series(1, 10) AS i;
+2:INSERT INTO crash_coordinator_before_cleanup_phase SELECT i AS a, 1 AS b, 'hello world' AS c FROM generate_series(1, 10) AS i;
 INSERT 10
-2:DELETE FROM crash_master_before_cleanup_phase WHERE a < 4;
+2:DELETE FROM crash_coordinator_before_cleanup_phase WHERE a < 4;
 DELETE 3
 
 -- inject panic fault
-2:SELECT gp_inject_fault('compaction_before_cleanup_phase', 'panic', '', '', 'crash_master_before_cleanup_phase', 1, -1, 0, 1);
+2:SELECT gp_inject_fault('compaction_before_cleanup_phase', 'panic', '', '', 'crash_coordinator_before_cleanup_phase', 1, -1, 0, 1);
  gp_inject_fault 
 -----------------
  Success:        
 (1 row)
-2:VACUUM crash_master_before_cleanup_phase;
+2:VACUUM crash_coordinator_before_cleanup_phase;
 PANIC:  fault triggered, fault name:'compaction_before_cleanup_phase' fault type:'panic'
 server closed the connection unexpectedly
 	This probably means the server terminated abnormally
@@ -325,8 +325,8 @@ server closed the connection unexpectedly
 (1 row)
 
 -- perform post crash validation checks
--- for crash_master_before_cleanup_phase
-4:SELECT segno,column_num,physical_segno,tupcount,modcount,state FROM gp_toolkit.__gp_aocsseg('crash_master_before_cleanup_phase');
+-- for crash_coordinator_before_cleanup_phase
+4:SELECT segno,column_num,physical_segno,tupcount,modcount,state FROM gp_toolkit.__gp_aocsseg('crash_coordinator_before_cleanup_phase');
  segno | column_num | physical_segno | tupcount | modcount | state 
 -------+------------+----------------+----------+----------+-------
  1     | 0          | 1              | 1        | 2        | 2     
@@ -345,11 +345,11 @@ server closed the connection unexpectedly
  2     | 2          | 258            | 0        | 0        | 1     
  2     | 2          | 258            | 3        | 0        | 1     
 (15 rows)
-4:INSERT INTO crash_master_before_cleanup_phase VALUES(1, 1, 'c'), (25, 6, 'c');
+4:INSERT INTO crash_coordinator_before_cleanup_phase VALUES(1, 1, 'c'), (25, 6, 'c');
 INSERT 2
-4:UPDATE crash_master_before_cleanup_phase SET b = b+10 WHERE a=25;
+4:UPDATE crash_coordinator_before_cleanup_phase SET b = b+10 WHERE a=25;
 UPDATE 1
-4:SELECT * FROM crash_master_before_cleanup_phase ORDER BY a,b;
+4:SELECT * FROM crash_coordinator_before_cleanup_phase ORDER BY a,b;
  a  | b  | c                    
 ----+----+----------------------
  1  | 1  | c                    
@@ -362,7 +362,7 @@ UPDATE 1
  10 | 1  | hello world          
  25 | 16 | c                    
 (9 rows)
-4:SELECT segno,column_num,physical_segno,tupcount,modcount,state FROM gp_toolkit.__gp_aocsseg('crash_master_before_cleanup_phase');
+4:SELECT segno,column_num,physical_segno,tupcount,modcount,state FROM gp_toolkit.__gp_aocsseg('crash_coordinator_before_cleanup_phase');
  segno | column_num | physical_segno | tupcount | modcount | state 
 -------+------------+----------------+----------+----------+-------
  1     | 0          | 1              | 1        | 2        | 2     
@@ -381,9 +381,9 @@ UPDATE 1
  2     | 2          | 258            | 1        | 1        | 1     
  2     | 2          | 258            | 3        | 0        | 1     
 (15 rows)
-4:VACUUM crash_master_before_cleanup_phase;
+4:VACUUM crash_coordinator_before_cleanup_phase;
 VACUUM
-4:SELECT segno,column_num,physical_segno,tupcount,modcount,state FROM gp_toolkit.__gp_aocsseg('crash_master_before_cleanup_phase');
+4:SELECT segno,column_num,physical_segno,tupcount,modcount,state FROM gp_toolkit.__gp_aocsseg('crash_coordinator_before_cleanup_phase');
  segno | column_num | physical_segno | tupcount | modcount | state 
 -------+------------+----------------+----------+----------+-------
  1     | 0          | 1              | 0        | 2        | 1     
@@ -405,11 +405,11 @@ VACUUM
  2     | 2          | 258            | 3        | 0        | 1     
  2     | 2          | 258            | 5        | 0        | 1     
 (18 rows)
-4:INSERT INTO crash_master_before_cleanup_phase VALUES(21, 1, 'c'), (26, 1, 'c');
+4:INSERT INTO crash_coordinator_before_cleanup_phase VALUES(21, 1, 'c'), (26, 1, 'c');
 INSERT 2
-4:UPDATE crash_master_before_cleanup_phase SET b = b+10 WHERE a=26;
+4:UPDATE crash_coordinator_before_cleanup_phase SET b = b+10 WHERE a=26;
 UPDATE 1
-4:SELECT * FROM crash_master_before_cleanup_phase ORDER BY a,b;
+4:SELECT * FROM crash_coordinator_before_cleanup_phase ORDER BY a,b;
  a  | b  | c                    
 ----+----+----------------------
  1  | 1  | c                    

--- a/src/test/isolation2/expected/uao_crash_compaction_row.out
+++ b/src/test/isolation2/expected/uao_crash_compaction_row.out
@@ -229,9 +229,9 @@ UPDATE 1
 (12 rows)
 
 --
--- Setup tables to test crash at different points on master now
+-- Setup tables to test crash at different points on coordinator now
 --
--- for crash_master_before_cleanup_phase
+-- for crash_coordinator_before_cleanup_phase
 2:set default_table_access_method = ao_row;
 SET
 2:show default_table_access_method;
@@ -239,24 +239,24 @@ SET
 -----------------------------
  ao_row                      
 (1 row)
-2:DROP TABLE IF EXISTS crash_master_before_cleanup_phase CASCADE;
+2:DROP TABLE IF EXISTS crash_coordinator_before_cleanup_phase CASCADE;
 DROP
-2:CREATE TABLE crash_master_before_cleanup_phase (a INT, b INT, c CHAR(20));
+2:CREATE TABLE crash_coordinator_before_cleanup_phase (a INT, b INT, c CHAR(20));
 CREATE
-2:CREATE INDEX crash_master_before_cleanup_phase_index ON crash_master_before_cleanup_phase(b);
+2:CREATE INDEX crash_coordinator_before_cleanup_phase_index ON crash_coordinator_before_cleanup_phase(b);
 CREATE
-2:INSERT INTO crash_master_before_cleanup_phase SELECT i AS a, 1 AS b, 'hello world' AS c FROM generate_series(1, 10) AS i;
+2:INSERT INTO crash_coordinator_before_cleanup_phase SELECT i AS a, 1 AS b, 'hello world' AS c FROM generate_series(1, 10) AS i;
 INSERT 10
-2:DELETE FROM crash_master_before_cleanup_phase WHERE a < 4;
+2:DELETE FROM crash_coordinator_before_cleanup_phase WHERE a < 4;
 DELETE 3
 
 -- suspend at intended points
-2:SELECT gp_inject_fault('compaction_before_cleanup_phase', 'panic', '', '', 'crash_master_before_cleanup_phase', 1, -1, 0, 1);
+2:SELECT gp_inject_fault('compaction_before_cleanup_phase', 'panic', '', '', 'crash_coordinator_before_cleanup_phase', 1, -1, 0, 1);
  gp_inject_fault 
 -----------------
  Success:        
 (1 row)
-2:VACUUM crash_master_before_cleanup_phase;
+2:VACUUM crash_coordinator_before_cleanup_phase;
 PANIC:  fault triggered, fault name:'compaction_before_cleanup_phase' fault type:'panic'
 server closed the connection unexpectedly
 	This probably means the server terminated abnormally
@@ -270,8 +270,8 @@ server closed the connection unexpectedly
 (1 row)
 
 -- perform post crash validation checks
--- for crash_master_before_cleanup_phase
-4:SELECT * FROM gp_toolkit.__gp_aoseg('crash_master_before_cleanup_phase');
+-- for crash_coordinator_before_cleanup_phase
+4:SELECT * FROM gp_toolkit.__gp_aoseg('crash_coordinator_before_cleanup_phase');
  segment_id | segno | eof | tupcount | varblockcount | eof_uncompressed | modcount | formatversion | state 
 ------------+-------+-----+----------+---------------+------------------+----------+---------------+-------
  0          | 1     | 248 | 5        | 1             | 248              | 2        | 3             | 2     
@@ -280,11 +280,11 @@ server closed the connection unexpectedly
  1          | 2     | 0   | 0        | 0             | 0                | 0        | 3             | 1     
  2          | 1     | 200 | 4        | 1             | 200              | 1        | 3             | 1     
 (5 rows)
-4:INSERT INTO crash_master_before_cleanup_phase VALUES(1, 1, 'c'), (25, 6, 'c');
+4:INSERT INTO crash_coordinator_before_cleanup_phase VALUES(1, 1, 'c'), (25, 6, 'c');
 INSERT 2
-4:UPDATE crash_master_before_cleanup_phase SET b = b+10 WHERE a=25;
+4:UPDATE crash_coordinator_before_cleanup_phase SET b = b+10 WHERE a=25;
 UPDATE 1
-4:SELECT * FROM crash_master_before_cleanup_phase ORDER BY a,b;
+4:SELECT * FROM crash_coordinator_before_cleanup_phase ORDER BY a,b;
  a  | b  | c                    
 ----+----+----------------------
  1  | 1  | c                    
@@ -297,7 +297,7 @@ UPDATE 1
  10 | 1  | hello world          
  25 | 16 | c                    
 (9 rows)
-4:SELECT * FROM gp_toolkit.__gp_aoseg('crash_master_before_cleanup_phase');
+4:SELECT * FROM gp_toolkit.__gp_aoseg('crash_coordinator_before_cleanup_phase');
  segment_id | segno | eof | tupcount | varblockcount | eof_uncompressed | modcount | formatversion | state 
 ------------+-------+-----+----------+---------------+------------------+----------+---------------+-------
  0          | 1     | 248 | 5        | 1             | 248              | 2        | 3             | 2     
@@ -306,9 +306,9 @@ UPDATE 1
  1          | 2     | 64  | 1        | 1             | 64               | 1        | 3             | 1     
  2          | 1     | 328 | 6        | 3             | 328              | 3        | 3             | 1     
 (5 rows)
-4:VACUUM crash_master_before_cleanup_phase;
+4:VACUUM crash_coordinator_before_cleanup_phase;
 VACUUM
-4:SELECT * FROM gp_toolkit.__gp_aoseg('crash_master_before_cleanup_phase');
+4:SELECT * FROM gp_toolkit.__gp_aoseg('crash_coordinator_before_cleanup_phase');
  segment_id | segno | eof | tupcount | varblockcount | eof_uncompressed | modcount | formatversion | state 
 ------------+-------+-----+----------+---------------+------------------+----------+---------------+-------
  0          | 1     | 0   | 0        | 0             | 0                | 2        | 3             | 1     
@@ -318,11 +318,11 @@ VACUUM
  2          | 1     | 0   | 0        | 0             | 0                | 3        | 3             | 1     
  2          | 2     | 248 | 5        | 1             | 248              | 0        | 3             | 1     
 (6 rows)
-4:INSERT INTO crash_master_before_cleanup_phase VALUES(21, 1, 'c'), (26, 1, 'c');
+4:INSERT INTO crash_coordinator_before_cleanup_phase VALUES(21, 1, 'c'), (26, 1, 'c');
 INSERT 2
-4:UPDATE crash_master_before_cleanup_phase SET b = b+10 WHERE a=26;
+4:UPDATE crash_coordinator_before_cleanup_phase SET b = b+10 WHERE a=26;
 UPDATE 1
-4:SELECT * FROM crash_master_before_cleanup_phase ORDER BY a,b;
+4:SELECT * FROM crash_coordinator_before_cleanup_phase ORDER BY a,b;
  a  | b  | c                    
 ----+----+----------------------
  1  | 1  | c                    

--- a/src/test/isolation2/expected/udf_exception_blocks_panic_scenarios.out
+++ b/src/test/isolation2/expected/udf_exception_blocks_panic_scenarios.out
@@ -14,7 +14,7 @@
 
 -- debug_dtm_action_target: Allows to set target for specified
 -- dtm_action should it be DTM protocol command or SQL command from
--- master to segment.
+-- coordinator to segment.
 
 -- debug_dtm_action_protocol: Allows to specify sub-type of DTM
 -- protocol for which to perform specified dtm_action (like prepare,

--- a/src/test/isolation2/expected/vacuum_skip_locked_onseg.out
+++ b/src/test/isolation2/expected/vacuum_skip_locked_onseg.out
@@ -2,7 +2,7 @@
 -- The test focuses on the vacuum behavior when the table is locked
 -- on segments. There is another test vacuum-skip-locked in
 -- isolation dir which focuses on regular test cases (table is locked
--- on master).
+-- on coordinator).
 
 1: CREATE TABLE vacuum_tbl (c1 int) DISTRIBUTED BY (c1);
 CREATE

--- a/src/test/isolation2/input/autovacuum-analyze.source
+++ b/src/test/isolation2/input/autovacuum-analyze.source
@@ -1,5 +1,5 @@
 -- Enable auto-ANALYZE only on AUTOVACUUM launcher. When set `autovacuum` to
--- true on Master, the launcher will take care of databases' analyze job on Master.
+-- true on Coordinator, the launcher will take care of databases' analyze job on Coordinator.
 -- VACUUM anti-XID wraparounds of 'template0' is not changed.
 
 -- Speed up test.
@@ -18,7 +18,7 @@ select * from pg_reload_conf();
 -- Prepare the table to be ANALYZEd
 1: CREATE TABLE anatest (id bigint);
 
--- Track report gpstat on master
+-- Track report gpstat on coordinator
 SELECT gp_inject_fault('gp_pgstat_report_on_master', 'suspend', '', '', 'anatest', 1, -1, 0, 1);
 -- Track that we have updated the attributes stats in pg_statistic when finished
 SELECT gp_inject_fault('analyze_finished_one_relation', 'skip', '', '', 'anatest', 1, -1, 0, 1);
@@ -27,7 +27,7 @@ SELECT gp_inject_fault('auto_vac_worker_after_report_activity', 'suspend', '', '
 
 1&: INSERT INTO anatest select i from generate_series(1, 1000) as i;
 
--- Wait until report pgstat on master
+-- Wait until report pgstat on coordinator
 SELECT gp_wait_until_triggered_fault('gp_pgstat_report_on_master', 1, 1);
 SELECT gp_inject_fault('gp_pgstat_report_on_master', 'reset', 1);
 
@@ -54,7 +54,7 @@ select relpages, reltuples from pg_class where oid = 'anatest'::regclass;
 -- Prepare the table to be ANALYZEd
 1: CREATE TABLE rankpart (id int, rank int, product int) DISTRIBUTED BY (id) PARTITION BY RANGE (rank) ( START (1) END (10) EVERY (2), DEFAULT PARTITION extra );
 
--- Track report gpstat on master
+-- Track report gpstat on coordinator
 SELECT gp_inject_fault('gp_pgstat_report_on_master', 'suspend', '', '', 'rankpart_1_prt_extra', 1, -1, 0, 1);
 -- Track that we have updated the attributes stats in pg_statistic when finished
 SELECT gp_inject_fault('analyze_finished_one_relation', 'skip', '', '', 'rankpart_1_prt_5', 1, -1, 0, 1);
@@ -64,7 +64,7 @@ SELECT gp_inject_fault('auto_vac_worker_after_report_activity', 'suspend', '', '
 -- No data inserted into rankpart_1_prt_6
 1&: insert into rankpart select i, i % 8, i from generate_series(1, 1000)i;
 
--- Wait until report pgstat on master
+-- Wait until report pgstat on coordinator
 SELECT gp_wait_until_triggered_fault('gp_pgstat_report_on_master', 1, 1);
 SELECT gp_inject_fault('gp_pgstat_report_on_master', 'reset', 1);
 
@@ -103,7 +103,7 @@ select relpages, reltuples from pg_class where oid = 'rankpart'::regclass;
 
 1: CREATE TABLE anaabort(id int);
 
--- Track report gpstat on master
+-- Track report gpstat on coordinator
 SELECT gp_inject_fault('gp_pgstat_report_on_master', 'suspend', '', '', 'anaabort', 1, -1, 0, 1);
 -- Suspend the autovacuum worker from analyze before
 SELECT gp_inject_fault('auto_vac_worker_after_report_activity', 'suspend', '', '', 'anaabort', 1, -1, 0, 1);
@@ -114,7 +114,7 @@ SELECT gp_inject_fault('auto_vac_worker_abort', 'skip', '', '', 'anaabort', 1, -
 
 1&: INSERT INTO anaabort select i from generate_series(1, 1000) as i;
 
--- Wait until report pgstat on master
+-- Wait until report pgstat on coordinator
 SELECT gp_wait_until_triggered_fault('gp_pgstat_report_on_master', 1, 1);
 SELECT gp_inject_fault('gp_pgstat_report_on_master', 'reset', 1);
 

--- a/src/test/isolation2/input/fts_manual_probe.source
+++ b/src/test/isolation2/input/fts_manual_probe.source
@@ -26,7 +26,7 @@ create temp table fts_probe_results(seq serial, seq_name varchar(20),
                                     current_started int, expected_start_delta int,
                                     current_done int, expected_done_delta int);
 
--- create extension only on coordinator since the fts process is only on master
+-- create extension only on coordinator since the fts process is only on coordinator
 create or replace function fts_probe_stats() returns table (
     start_count int,
     done_count int,

--- a/src/test/isolation2/input/parallel_retrieve_cursor/privilege.source
+++ b/src/test/isolation2/input/parallel_retrieve_cursor/privilege.source
@@ -136,7 +136,7 @@ RESET SESSION AUTHORIZATION;
 1: DECLARE c4 PARALLEL RETRIEVE CURSOR FOR SELECT * FROM t1;
 1: @post_run 'parse_endpoint_info 5 1 2 3 4' : SELECT endpointname,auth_token,hostname,port,state FROM gp_get_endpoints() WHERE cursorname='c4';
 
---- u2 is not able to see u1's endpoints on master
+--- u2 is not able to see u1's endpoints on coordinator
 1: SET SESSION AUTHORIZATION u2;
 1: SELECT * from gp_get_endpoints();
 

--- a/src/test/isolation2/input/parallel_retrieve_cursor/status_check.source
+++ b/src/test/isolation2/input/parallel_retrieve_cursor/status_check.source
@@ -226,7 +226,7 @@ insert into t1 select generate_series(1,100);
 0U: @pre_run 'kill -s QUIT ${PID71}&& sleep 5 && echo "${RAW_STR}" ': SELECT 1;
 -- check it can cancel the "gp_wait_parallel_retrieve_cursor"
 1<:
--- quit all sessions on the master, because connect lost
+-- quit all sessions on the coordinator, because connect lost
 1q:
 2q:
 -1Uq:

--- a/src/test/isolation2/input/parallel_retrieve_cursor/status_wait.source
+++ b/src/test/isolation2/input/parallel_retrieve_cursor/status_wait.source
@@ -209,7 +209,7 @@ insert into t1 select generate_series(1,100);
 0U: @pre_run 'kill -s QUIT ${PID71}&& sleep 5 && echo "${RAW_STR}" ': SELECT 1;
 -- check it can cancel the "gp_wait_parallel_retrieve_cursor"
 1<:
--- quit all sessions on the master, because connect lost
+-- quit all sessions on the coordinator, because connect lost
 1q:
 2q:
 -1Uq:
@@ -275,7 +275,7 @@ insert into t1 select generate_series(1,100);
 2: select pg_terminate_backend(pid) from pg_stat_activity where query like 'SELECT * FROM gp_wait_parallel_retrieve_cursor(''c10'', -1);';
 -- check it can cancel the "gp_wait_parallel_retrieve_cursor"
 1<:
--- quit all sessions on the master, because connect lost
+-- quit all sessions on the coordinator, because connect lost
 1q:
 2q:
 -1Uq:

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -164,7 +164,7 @@ test: uao/collected_stats_views_row
 
 test: reorganize_after_ao_vacuum_skip_drop truncate_after_ao_vacuum_skip_drop mark_all_aoseg_await_drop
 # below test(s) inject faults so each of them need to be in a separate group
-test: segwalrep/master_wal_switch
+test: segwalrep/coordinator_wal_switch
 
 # Tests on Append-Optimized tables (column-oriented).
 test: uao/alter_while_vacuum_column uao/alter_while_vacuum2_column

--- a/src/test/isolation2/output/autovacuum-analyze.source
+++ b/src/test/isolation2/output/autovacuum-analyze.source
@@ -1,5 +1,5 @@
 -- Enable auto-ANALYZE only on AUTOVACUUM launcher. When set `autovacuum` to
--- true on Master, the launcher will take care of databases' analyze job on Master.
+-- true on Coordinator, the launcher will take care of databases' analyze job on Coordinator.
 -- VACUUM anti-XID wraparounds of 'template0' is not changed.
 
 -- Speed up test.
@@ -25,7 +25,7 @@ ANALYZE
 1: CREATE TABLE anatest (id bigint);
 CREATE
 
--- Track report gpstat on master
+-- Track report gpstat on coordinator
 SELECT gp_inject_fault('gp_pgstat_report_on_master', 'suspend', '', '', 'anatest', 1, -1, 0, 1);
  gp_inject_fault 
 -----------------
@@ -46,7 +46,7 @@ SELECT gp_inject_fault('auto_vac_worker_after_report_activity', 'suspend', '', '
 
 1&: INSERT INTO anatest select i from generate_series(1, 1000) as i;  <waiting ...>
 
--- Wait until report pgstat on master
+-- Wait until report pgstat on coordinator
 SELECT gp_wait_until_triggered_fault('gp_pgstat_report_on_master', 1, 1);
  gp_wait_until_triggered_fault 
 -------------------------------
@@ -112,7 +112,7 @@ select relpages, reltuples from pg_class where oid = 'anatest'::regclass;
 1: CREATE TABLE rankpart (id int, rank int, product int) DISTRIBUTED BY (id) PARTITION BY RANGE (rank) ( START (1) END (10) EVERY (2), DEFAULT PARTITION extra );
 CREATE
 
--- Track report gpstat on master
+-- Track report gpstat on coordinator
 SELECT gp_inject_fault('gp_pgstat_report_on_master', 'suspend', '', '', 'rankpart_1_prt_extra', 1, -1, 0, 1);
  gp_inject_fault 
 -----------------
@@ -134,7 +134,7 @@ SELECT gp_inject_fault('auto_vac_worker_after_report_activity', 'suspend', '', '
 -- No data inserted into rankpart_1_prt_6
 1&: insert into rankpart select i, i % 8, i from generate_series(1, 1000)i;  <waiting ...>
 
--- Wait until report pgstat on master
+-- Wait until report pgstat on coordinator
 SELECT gp_wait_until_triggered_fault('gp_pgstat_report_on_master', 1, 1);
  gp_wait_until_triggered_fault 
 -------------------------------
@@ -260,7 +260,7 @@ select relpages, reltuples from pg_class where oid = 'rankpart'::regclass;
 1: CREATE TABLE anaabort(id int);
 CREATE
 
--- Track report gpstat on master
+-- Track report gpstat on coordinator
 SELECT gp_inject_fault('gp_pgstat_report_on_master', 'suspend', '', '', 'anaabort', 1, -1, 0, 1);
  gp_inject_fault 
 -----------------
@@ -287,7 +287,7 @@ SELECT gp_inject_fault('auto_vac_worker_abort', 'skip', '', '', 'anaabort', 1, -
 
 1&: INSERT INTO anaabort select i from generate_series(1, 1000) as i;  <waiting ...>
 
--- Wait until report pgstat on master
+-- Wait until report pgstat on coordinator
 SELECT gp_wait_until_triggered_fault('gp_pgstat_report_on_master', 1, 1);
  gp_wait_until_triggered_fault 
 -------------------------------

--- a/src/test/isolation2/output/fts_manual_probe.source
+++ b/src/test/isolation2/output/fts_manual_probe.source
@@ -29,7 +29,7 @@ select gp_inject_fault('all', 'reset', 1) from master();
 create temp table fts_probe_results(seq serial, seq_name varchar(20), current_started int, expected_start_delta int, current_done int, expected_done_delta int);
 CREATE
 
--- create extension only on coordinator since the fts process is only on master
+-- create extension only on coordinator since the fts process is only on coordinator
 create or replace function fts_probe_stats() returns table ( start_count int, done_count int, status_version int2 ) as '/@abs_builddir@/../regress/regress.so', 'gp_fts_probe_stats' language c execute on coordinator reads sql data;
 CREATE
 
@@ -55,8 +55,8 @@ CREATE
 -- start_ignore
 20190730:11:15:27:045929 gpstop:office-5-75:dkrieger-[INFO]:-Starting gpstop with args: -u
 20190730:11:15:27:045929 gpstop:office-5-75:dkrieger-[INFO]:-Gathering information and validating the environment...
-20190730:11:15:27:045929 gpstop:office-5-75:dkrieger-[INFO]:-Obtaining Greenplum Master catalog information
-20190730:11:15:27:045929 gpstop:office-5-75:dkrieger-[INFO]:-Obtaining Segment details from master...
+20190730:11:15:27:045929 gpstop:office-5-75:dkrieger-[INFO]:-Obtaining Greenplum Coordinator catalog information
+20190730:11:15:27:045929 gpstop:office-5-75:dkrieger-[INFO]:-Obtaining Segment details from coordinator...
 20190730:11:15:27:045929 gpstop:office-5-75:dkrieger-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 7.0.0-alpha.0+dev.575.g59811832fc build dev'
 20190730:11:15:27:045929 gpstop:office-5-75:dkrieger-[INFO]:-Signalling all postmaster processes to reload
 
@@ -273,8 +273,8 @@ select * from get_raw_stats;
 -- start_ignore
 20190730:11:15:35:046018 gpstop:office-5-75:dkrieger-[INFO]:-Starting gpstop with args: -u
 20190730:11:15:35:046018 gpstop:office-5-75:dkrieger-[INFO]:-Gathering information and validating the environment...
-20190730:11:15:35:046018 gpstop:office-5-75:dkrieger-[INFO]:-Obtaining Greenplum Master catalog information
-20190730:11:15:35:046018 gpstop:office-5-75:dkrieger-[INFO]:-Obtaining Segment details from master...
+20190730:11:15:35:046018 gpstop:office-5-75:dkrieger-[INFO]:-Obtaining Greenplum Coordinator catalog information
+20190730:11:15:35:046018 gpstop:office-5-75:dkrieger-[INFO]:-Obtaining Segment details from coordinator...
 20190730:11:15:35:046018 gpstop:office-5-75:dkrieger-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 7.0.0-alpha.0+dev.575.g59811832fc build dev'
 20190730:11:15:35:046018 gpstop:office-5-75:dkrieger-[INFO]:-Signalling all postmaster processes to reload
 

--- a/src/test/isolation2/output/parallel_retrieve_cursor/privilege.source
+++ b/src/test/isolation2/output/parallel_retrieve_cursor/privilege.source
@@ -347,7 +347,7 @@ DECLARE
  endpoint_id5 | token_id | host_id | port_id | READY
 (3 rows)
 
---- u2 is not able to see u1's endpoints on master
+--- u2 is not able to see u1's endpoints on coordinator
 1: SET SESSION AUTHORIZATION u2;
 SET
 1: SELECT * from gp_get_endpoints();

--- a/src/test/isolation2/output/parallel_retrieve_cursor/status_check.source
+++ b/src/test/isolation2/output/parallel_retrieve_cursor/status_check.source
@@ -1297,7 +1297,7 @@ DECLARE
 server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
--- quit all sessions on the master, because connect lost
+-- quit all sessions on the coordinator, because connect lost
 1q: ... <quitting>
 2q: ... <quitting>
 -1Uq: ... <quitting>

--- a/src/test/isolation2/output/parallel_retrieve_cursor/status_wait.source
+++ b/src/test/isolation2/output/parallel_retrieve_cursor/status_wait.source
@@ -1211,7 +1211,7 @@ DECLARE
 server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
--- quit all sessions on the master, because connect lost
+-- quit all sessions on the coordinator, because connect lost
 1q: ... <quitting>
 2q: ... <quitting>
 -1Uq: ... <quitting>
@@ -1400,7 +1400,7 @@ FATAL:  terminating connection due to administrator command
 server closed the connection unexpectedly
 	This probably means the server terminated abnormally
 	before or while processing the request.
--- quit all sessions on the master, because connect lost
+-- quit all sessions on the coordinator, because connect lost
 1q: ... <quitting>
 2q: ... <quitting>
 -1Uq: ... <quitting>

--- a/src/test/isolation2/output/uao/compaction_utility_insert_2.source
+++ b/src/test/isolation2/output/uao/compaction_utility_insert_2.source
@@ -24,7 +24,7 @@ INSERT 1
  0     | 2        | 1     
  1     | 1        | 1     
 (2 rows)
--- We know that the master does update its tupcount yet
+-- We know that the coordinator does update its tupcount yet
 SELECT segno, tupcount, state FROM gp_ao_or_aocs_seg('foo');
  segno | tupcount | state 
 -------+----------+-------

--- a/src/test/isolation2/output/workfile_mgr_test.source
+++ b/src/test/isolation2/output/workfile_mgr_test.source
@@ -34,14 +34,14 @@ CREATE
 -- start_ignore
 20200923:12:05:57:014232 gpstop:mdw:gpadmin-[INFO]:-Starting gpstop with args: -ari
 20200923:12:05:57:014232 gpstop:mdw:gpadmin-[INFO]:-Gathering information and validating the environment...
-20200923:12:05:57:014232 gpstop:mdw:gpadmin-[INFO]:-Obtaining Greenplum Master catalog information
-20200923:12:05:57:014232 gpstop:mdw:gpadmin-[INFO]:-Obtaining Segment details from master...
+20200923:12:05:57:014232 gpstop:mdw:gpadmin-[INFO]:-Obtaining Greenplum Coordinator catalog information
+20200923:12:05:57:014232 gpstop:mdw:gpadmin-[INFO]:-Obtaining Segment details from coordinator...
 20200923:12:05:58:014232 gpstop:mdw:gpadmin-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 7.0.0-alpha.0+dev.7339.g02578435d1 build dev'
-20200923:12:05:58:014232 gpstop:mdw:gpadmin-[INFO]:-Commencing Master instance shutdown with mode='immediate'
-20200923:12:05:58:014232 gpstop:mdw:gpadmin-[INFO]:-Master segment instance directory=/home/gpadmin/Documents/workspace/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
-20200923:12:05:58:014232 gpstop:mdw:gpadmin-[INFO]:-Attempting forceful termination of any leftover master process
+20200923:12:05:58:014232 gpstop:mdw:gpadmin-[INFO]:-Commencing Coordinator instance shutdown with mode='immediate'
+20200923:12:05:58:014232 gpstop:mdw:gpadmin-[INFO]:-Coordinator segment instance directory=/home/gpadmin/Documents/workspace/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
+20200923:12:05:58:014232 gpstop:mdw:gpadmin-[INFO]:-Attempting forceful termination of any leftover coordinator process
 20200923:12:05:58:014232 gpstop:mdw:gpadmin-[INFO]:-Terminating processes for segment /home/gpadmin/Documents/workspace/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
-20200923:12:05:58:014232 gpstop:mdw:gpadmin-[INFO]:-Stopping master standby host mdw mode=immediate
+20200923:12:05:58:014232 gpstop:mdw:gpadmin-[INFO]:-Stopping coordinator standby host mdw mode=immediate
 20200923:12:05:58:014232 gpstop:mdw:gpadmin-[INFO]:-Successfully shutdown standby process on mdw
 20200923:12:05:58:014232 gpstop:mdw:gpadmin-[INFO]:-Targeting dbid [2, 5, 3, 6, 4, 7] for shutdown
 20200923:12:05:58:014232 gpstop:mdw:gpadmin-[INFO]:-Commencing parallel primary segment instance shutdown, please wait...
@@ -176,14 +176,14 @@ DROP
 -- start_ignore
 20200923:12:08:05:016154 gpstop:mdw:gpadmin-[INFO]:-Starting gpstop with args: -ari
 20200923:12:08:05:016154 gpstop:mdw:gpadmin-[INFO]:-Gathering information and validating the environment...
-20200923:12:08:05:016154 gpstop:mdw:gpadmin-[INFO]:-Obtaining Greenplum Master catalog information
-20200923:12:08:05:016154 gpstop:mdw:gpadmin-[INFO]:-Obtaining Segment details from master...
+20200923:12:08:05:016154 gpstop:mdw:gpadmin-[INFO]:-Obtaining Greenplum Coordinator catalog information
+20200923:12:08:05:016154 gpstop:mdw:gpadmin-[INFO]:-Obtaining Segment details from coordinator...
 20200923:12:08:05:016154 gpstop:mdw:gpadmin-[INFO]:-Greenplum Version: 'postgres (Greenplum Database) 7.0.0-alpha.0+dev.7339.g02578435d1 build dev'
-20200923:12:08:05:016154 gpstop:mdw:gpadmin-[INFO]:-Commencing Master instance shutdown with mode='immediate'
-20200923:12:08:05:016154 gpstop:mdw:gpadmin-[INFO]:-Master segment instance directory=/home/gpadmin/Documents/workspace/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
-20200923:12:08:05:016154 gpstop:mdw:gpadmin-[INFO]:-Attempting forceful termination of any leftover master process
+20200923:12:08:05:016154 gpstop:mdw:gpadmin-[INFO]:-Commencing Coordinator instance shutdown with mode='immediate'
+20200923:12:08:05:016154 gpstop:mdw:gpadmin-[INFO]:-Coordinator segment instance directory=/home/gpadmin/Documents/workspace/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
+20200923:12:08:05:016154 gpstop:mdw:gpadmin-[INFO]:-Attempting forceful termination of any leftover coordinator process
 20200923:12:08:05:016154 gpstop:mdw:gpadmin-[INFO]:-Terminating processes for segment /home/gpadmin/Documents/workspace/gpdb/gpAux/gpdemo/datadirs/qddir/demoDataDir-1
-20200923:12:08:05:016154 gpstop:mdw:gpadmin-[INFO]:-Stopping master standby host mdw mode=immediate
+20200923:12:08:05:016154 gpstop:mdw:gpadmin-[INFO]:-Stopping coordinator standby host mdw mode=immediate
 20200923:12:08:05:016154 gpstop:mdw:gpadmin-[INFO]:-Successfully shutdown standby process on mdw
 20200923:12:08:05:016154 gpstop:mdw:gpadmin-[INFO]:-Targeting dbid [2, 5, 3, 6, 4, 7] for shutdown
 20200923:12:08:05:016154 gpstop:mdw:gpadmin-[INFO]:-Commencing parallel primary segment instance shutdown, please wait...

--- a/src/test/isolation2/sql/check_gxid.sql
+++ b/src/test/isolation2/sql/check_gxid.sql
@@ -3,13 +3,13 @@ select gp_segment_id, gp_get_next_gxid() < (select gp_get_next_gxid()) from gp_d
 select gp_segment_id,gp_get_next_gxid() on_seg, (select gp_get_next_gxid() on_cor) from gp_dist_random('gp_id');
 -- end_ignore
 
--- trigger master panic and wait until master down before running any new query.
+-- trigger coordinator panic and wait until coordinator down before running any new query.
 1&: SELECT wait_till_master_shutsdown();
 2: SELECT gp_inject_fault('before_read_command', 'panic', 1);
 2: SELECT 1;
 1<:
 
--- wait until master is up for querying.
+-- wait until coordinator is up for querying.
 3: SELECT 1;
 
 3: select gp_segment_id, gp_get_next_gxid() < (select gp_get_next_gxid()) from gp_dist_random('gp_id');

--- a/src/test/isolation2/sql/commit_transaction_block_checkpoint.sql
+++ b/src/test/isolation2/sql/commit_transaction_block_checkpoint.sql
@@ -20,7 +20,7 @@ select gp_inject_fault('before_xlog_xact_commit_prepared', 'reset', 3);
 2<:
 1U<:
 
--- TEST 2: block checkpoint on master
+-- TEST 2: block checkpoint on coordinator
 
 -- pause the CommitTransaction right before persistent table cleanup after
 -- notifyCommittedDtxTransaction()
@@ -35,7 +35,7 @@ select gp_inject_fault_infinite('onephase_transaction_commit', 'suspend', 1);
 -- wait for the fault to trigger since following checkpoint could be faster
 select gp_wait_until_triggered_fault('onephase_transaction_commit', 1, 1);
 
--- do checkpoint on master in utility mode, and it should block
+-- do checkpoint on coordinator in utility mode, and it should block
 -1U&: checkpoint;
 
 -- resume the 2PC

--- a/src/test/isolation2/sql/crash_recovery.sql
+++ b/src/test/isolation2/sql/crash_recovery.sql
@@ -34,7 +34,7 @@ FROM gp_segment_configuration g1 where role = 'p';
 
 -- trigger crash on QD
 1:select gp_inject_fault('exec_simple_query_start', 'panic', current_setting('gp_dbid')::smallint);
--- verify master panic happens. The PANIC message does not emit sometimes so
+-- verify coordinator panic happens. The PANIC message does not emit sometimes so
 -- mask it.
 -- start_matchsubs
 -- m/PANIC:  fault triggered, fault name:'exec_simple_query_start' fault type:'panic'\n/

--- a/src/test/isolation2/sql/crash_recovery_redundant_dtx.sql
+++ b/src/test/isolation2/sql/crash_recovery_redundant_dtx.sql
@@ -25,7 +25,7 @@ FROM gp_segment_configuration g1 where role = 'p';
 1:select gp_wait_until_triggered_fault('dtm_broadcast_commit_prepared', 1, 1);
 -- trigger crash on QD
 1:select gp_inject_fault('exec_simple_query_start', 'panic', current_setting('gp_dbid')::smallint);
--- verify master panic happens. The PANIC message does not emit sometimes so
+-- verify coordinator panic happens. The PANIC message does not emit sometimes so
 -- mask it.
 -- start_matchsubs
 -- m/PANIC:  fault triggered, fault name:'exec_simple_query_start' fault type:'panic'\n/

--- a/src/test/isolation2/sql/drop_rename.sql
+++ b/src/test/isolation2/sql/drop_rename.sql
@@ -1,5 +1,5 @@
 -- Test if ALTER RENAME followed by ANALYZE executed concurrently with
--- DROP does not introduce inconsistency between master and segments.
+-- DROP does not introduce inconsistency between coordinator and segments.
 -- DROP should be blocked because of ALTER-ANALYZE.  After being
 -- unblocked, DROP should lookup the old name again and fail with
 -- relation does not exist error.
@@ -30,7 +30,7 @@
 2:select count(*) from newt2;
 
 -- The same, but with DROP IF EXISTS. (We used to have a bug, where the DROP
--- command found and drop the relation in the segments, but not in master.)
+-- command found and drop the relation in the segments, but not in coordinator.)
 1:drop table if exists t3;
 1:create table t3 (a int, b text) distributed by (a);
 1:insert into t3 select i, '123 '||i from generate_series(1,10)i;

--- a/src/test/isolation2/sql/execute_on_utilitymode.sql
+++ b/src/test/isolation2/sql/execute_on_utilitymode.sql
@@ -4,7 +4,7 @@
 
 -- First, create test functions with different EXECUTE ON options
 
-create function srf_on_master () returns setof text as $$
+create function srf_on_coordinator () returns setof text as $$
 begin	/* in func */
   return next 'foo ' || current_setting('gp_contentid');	/* in func */
   return next 'bar ' || current_setting('gp_contentid');	/* in func */
@@ -32,7 +32,7 @@ begin	/* in func */
 end;	/* in func */
 $$ language plpgsql EXECUTE ON INITPLAN;
 
--- Now try executing them in utility mode, in the master node and on a
+-- Now try executing them in utility mode, in the coordinator node and on a
 -- segment. The expected behavior is that the function runs on the node
 -- we're connected to, ignoring the EXECUTE ON directives.
 --
@@ -41,12 +41,12 @@ $$ language plpgsql EXECUTE ON INITPLAN;
 create table fewrows (t text) distributed by (t);
 insert into fewrows select g from generate_series(1, 10) g;
 
--1U: select * from srf_on_master()       as srf (x) left join fewrows on x = t;
+-1U: select * from srf_on_coordinator()       as srf (x) left join fewrows on x = t;
 -1U: select * from srf_on_all_segments() as srf (x) left join fewrows on x = t;
 -1U: select * from srf_on_any()          as srf (x) left join fewrows on x = t;
 -1U: select * from srf_on_initplan()     as srf (x) left join fewrows on x = t;
 
-1U: select * from srf_on_master(),       fewrows;
+1U: select * from srf_on_coordinator(),       fewrows;
 1U: select * from srf_on_all_segments(), fewrows;
 1U: select * from srf_on_any(),          fewrows;
 1U: select * from srf_on_initplan(),     fewrows;

--- a/src/test/isolation2/sql/fts_dns_error.sql
+++ b/src/test/isolation2/sql/fts_dns_error.sql
@@ -1,14 +1,14 @@
 -- Tests FTS can handle DNS error.
 
 -- to make test deterministic and fast
-!\retcode gpconfig -c gp_fts_probe_retries -v 2 --masteronly;
+!\retcode gpconfig -c gp_fts_probe_retries -v 2 --coordinatoronly;
 
 -- Allow extra time for mirror promotion to complete recovery to avoid
 -- gprecoverseg BEGIN failures due to gang creation failure as some primaries
 -- are not up. Setting these increase the number of retries in gang creation in
 -- case segment is in recovery. Approximately we want to wait 30 seconds.
-!\retcode gpconfig -c gp_gang_creation_retry_count -v 127 --skipvalidation --masteronly;
-!\retcode gpconfig -c gp_gang_creation_retry_timer -v 250 --skipvalidation --masteronly;
+!\retcode gpconfig -c gp_gang_creation_retry_count -v 127 --skipvalidation --coordinatoronly;
+!\retcode gpconfig -c gp_gang_creation_retry_timer -v 250 --skipvalidation --coordinatoronly;
 !\retcode gpstop -u;
 
 -- no down segment in the beginning
@@ -41,9 +41,9 @@ select wait_until_all_segments_synchronized()
 -- verify no segment is down after recovery
 select count(*) from gp_segment_configuration where status = 'd';
 
-!\retcode gpconfig -r gp_fts_probe_retries --masteronly;
-!\retcode gpconfig -r gp_gang_creation_retry_count --skipvalidation --masteronly;
-!\retcode gpconfig -r gp_gang_creation_retry_timer --skipvalidation --masteronly;
+!\retcode gpconfig -r gp_fts_probe_retries --coordinatoronly;
+!\retcode gpconfig -r gp_gang_creation_retry_count --skipvalidation --coordinatoronly;
+!\retcode gpconfig -r gp_gang_creation_retry_timer --skipvalidation --coordinatoronly;
 !\retcode gpstop -u;
 
 

--- a/src/test/isolation2/sql/fts_errors.sql
+++ b/src/test/isolation2/sql/fts_errors.sql
@@ -10,14 +10,14 @@
 -- end_matchsubs
 
 -- to make test deterministic and fast
-!\retcode gpconfig -c gp_fts_probe_retries -v 2 --masteronly;
+!\retcode gpconfig -c gp_fts_probe_retries -v 2 --coordinatoronly;
 
 -- Allow extra time for mirror promotion to complete recovery to avoid
 -- gprecoverseg BEGIN failures due to gang creation failure as some primaries
 -- are not up. Setting these increase the number of retries in gang creation in
 -- case segment is in recovery. Approximately we want to wait 120 seconds.
-!\retcode gpconfig -c gp_gang_creation_retry_count -v 120 --skipvalidation --masteronly;
-!\retcode gpconfig -c gp_gang_creation_retry_timer -v 1000 --skipvalidation --masteronly;
+!\retcode gpconfig -c gp_gang_creation_retry_count -v 120 --skipvalidation --coordinatoronly;
+!\retcode gpconfig -c gp_gang_creation_retry_timer -v 1000 --skipvalidation --coordinatoronly;
 !\retcode gpstop -u;
 
 -- Helper function
@@ -135,9 +135,9 @@ select wait_until_all_segments_synchronized();
 -- verify no segment is down after recovery
 select count(*) from gp_segment_configuration where status = 'd';
 
-!\retcode gpconfig -r gp_fts_probe_retries --masteronly;
-!\retcode gpconfig -r gp_gang_creation_retry_count --skipvalidation --masteronly;
-!\retcode gpconfig -r gp_gang_creation_retry_timer --skipvalidation --masteronly;
+!\retcode gpconfig -r gp_fts_probe_retries --coordinatoronly;
+!\retcode gpconfig -r gp_gang_creation_retry_count --skipvalidation --coordinatoronly;
+!\retcode gpconfig -r gp_gang_creation_retry_timer --skipvalidation --coordinatoronly;
 !\retcode gpstop -u;
 
 

--- a/src/test/isolation2/sql/fts_segment_reset.sql
+++ b/src/test/isolation2/sql/fts_segment_reset.sql
@@ -7,12 +7,12 @@
 -- end_matchsubs
 
 -- Let FTS detect/declare failure sooner 
-!\retcode gpconfig -c gp_fts_probe_interval -v 10 --masteronly;
+!\retcode gpconfig -c gp_fts_probe_interval -v 10 --coordinatoronly;
 -- Because after RESET, it still takes a little while for the primary
 -- to restart, and potentially makes FTS think it's in "recovery not
 -- in progress" stage and promote the mirror, we would need the FTS
 -- to make that decision a bit less frequently.
-!\retcode gpconfig -c gp_fts_probe_retries -v 15 --masteronly;
+!\retcode gpconfig -c gp_fts_probe_retries -v 15 --coordinatoronly;
 !\retcode gpstop -u;
 
 -- Let the background writer sleep 17 seconds to delay the resetting.
@@ -59,6 +59,6 @@ drop table fts_reset_t3;
 !\retcode gprecoverseg -ar
 
 -- restore parameters
-!\retcode gpconfig -r gp_fts_probe_interval --masteronly;
-!\retcode gpconfig -r gp_fts_probe_retries --masteronly;
+!\retcode gpconfig -r gp_fts_probe_interval --coordinatoronly;
+!\retcode gpconfig -r gp_fts_probe_retries --coordinatoronly;
 !\retcode gpstop -u;

--- a/src/test/isolation2/sql/gdd/concurrent_update.sql
+++ b/src/test/isolation2/sql/gdd/concurrent_update.sql
@@ -15,7 +15,7 @@ INSERT INTO t_concurrent_update VALUES(1,1,'test');
 
 DROP TABLE t_concurrent_update;
 
--- Test the concurrent update transaction order on the segment is reflected on master
+-- Test the concurrent update transaction order on the segment is reflected on coordinator
 1: CREATE TABLE t_concurrent_update(a int, b int);
 1: INSERT INTO t_concurrent_update VALUES(1,1);
 
@@ -31,7 +31,7 @@ DROP TABLE t_concurrent_update;
 2: select gp_inject_fault('before_xact_end_procarray', 'suspend', '', 'isolation2test', '', 1, 1, 0, dbid) FROM gp_segment_configuration WHERE role='p' AND content=-1;
 2&: END;
 1: select gp_wait_until_triggered_fault('before_xact_end_procarray', 1, dbid) FROM gp_segment_configuration WHERE role='p' AND content=-1;
--- transaction 3 should wait transaction 2 commit on master
+-- transaction 3 should wait transaction 2 commit on coordinator
 3<:
 3&: END;
 -- the query should not get the incorrect distributed snapshot: transaction 1 in-progress

--- a/src/test/isolation2/sql/gdd/end.sql
+++ b/src/test/isolation2/sql/gdd/end.sql
@@ -1,11 +1,11 @@
 ALTER SYSTEM RESET gp_enable_global_deadlock_detector;
 ALTER SYSTEM RESET gp_global_deadlock_detector_period;
 
--- Use utility session on seg 0 to restart master. This way avoids the
+-- Use utility session on seg 0 to restart coordinator. This way avoids the
 -- situation where session issuing the restart doesn't disappear
 -- itself.
 1U:SELECT pg_ctl(dir, 'restart') from datadir;
--- Start new session on master to make sure it has fully completed
+-- Start new session on coordinator to make sure it has fully completed
 -- recovery and up and running again.
 1: SHOW gp_enable_global_deadlock_detector;
 1: SHOW gp_global_deadlock_detector_period;

--- a/src/test/isolation2/sql/gdd/prepare.sql
+++ b/src/test/isolation2/sql/gdd/prepare.sql
@@ -20,7 +20,7 @@ RETURNS int AS $$
 $$ LANGUAGE sql;
 
 -- In some of the testcases the execution order of two background queries
--- must be enforced not only on master but also on segments, for example
+-- must be enforced not only on coordinator but also on segments, for example
 -- in below case the order of 10 and 20 on segments results in different
 -- waiting relations:
 --
@@ -49,18 +49,18 @@ SELECT segid(2,10) is not null;
 
 --enable GDD
 
--- table to just store the master's data directory path on segment.
+-- table to just store the coordinator's data directory path on segment.
 CREATE TABLE datadir(a int, dir text);
 INSERT INTO datadir select 1,datadir from gp_segment_configuration where role='p' and content=-1;
 
 ALTER SYSTEM SET gp_enable_global_deadlock_detector TO on;
 ALTER SYSTEM SET gp_global_deadlock_detector_period TO 5;
 
--- Use utility session on seg 0 to restart master. This way avoids the
+-- Use utility session on seg 0 to restart coordinator. This way avoids the
 -- situation where session issuing the restart doesn't disappear
 -- itself.
 1U:SELECT pg_ctl(dir, 'restart') from datadir;
--- Start new session on master to make sure it has fully completed
+-- Start new session on coordinator to make sure it has fully completed
 -- recovery and up and running again.
 1: SHOW gp_enable_global_deadlock_detector;
 1: SHOW gp_global_deadlock_detector_period;

--- a/src/test/isolation2/sql/gpdispatch.sql
+++ b/src/test/isolation2/sql/gpdispatch.sql
@@ -1,7 +1,7 @@
 -- Try to verify that a session fatal due to OOM should have no effect on other sessions.
 -- Report on https://github.com/greenplum-db/gpdb/issues/12399
 
--- Because the number of errors reported to master can depend on ic types (i.e. ic-tcp and ic-proxy have one 
+-- Because the number of errors reported to coordinator can depend on ic types (i.e. ic-tcp and ic-proxy have one 
 -- additional error from the backend on seg0 which is trying to tear down TCP connection), we have to ignore
 -- all of them.
 -- start_matchignore

--- a/src/test/isolation2/sql/instr_in_shmem_terminate.sql
+++ b/src/test/isolation2/sql/instr_in_shmem_terminate.sql
@@ -15,12 +15,12 @@ CREATE EXTERNAL WEB TABLE __gp_localid
 EXECUTE E'echo $GP_SEGMENT_ID' FORMAT 'TEXT';
 GRANT SELECT ON TABLE __gp_localid TO public;
 
-CREATE EXTERNAL WEB TABLE __gp_masterid
+CREATE EXTERNAL WEB TABLE __gp_coordinatorid
 (
-    masterid    int
+    coordinatorid    int
 )
 EXECUTE E'echo $GP_SEGMENT_ID' ON COORDINATOR FORMAT 'TEXT';
-GRANT SELECT ON TABLE __gp_masterid TO public;
+GRANT SELECT ON TABLE __gp_coordinatorid TO public;
 
 CREATE FUNCTION gp_instrument_shmem_detail_f()
 RETURNS SETOF RECORD
@@ -37,7 +37,7 @@ WITH all_entries AS (
     )
   UNION ALL
   SELECT C.*
-    FROM __gp_masterid, gp_instrument_shmem_detail_f() as C (
+    FROM __gp_coordinatorid, gp_instrument_shmem_detail_f() as C (
       tmid int4,ssid int4,ccnt int2,segid int2,pid int4
       ,nid int2,tuplecount int8,nloops int8,ntuples int8
     ))

--- a/src/test/isolation2/sql/invalidated_toast_index.sql
+++ b/src/test/isolation2/sql/invalidated_toast_index.sql
@@ -17,7 +17,7 @@ INSERT INTO toastable_heap VALUES(repeat('A',100000), repeat('B',100001), 2);
 -- start_ignore
 --
 -- Invalidate the index of the toast table for our relation. Because this is a
--- catalog change, we have to execute it on the master and all segments.
+-- catalog change, we have to execute it on the coordinator and all segments.
 --
 -- This is done in an ignore block so it can run correctly with any number of
 -- segments.

--- a/src/test/isolation2/sql/lockmodes.sql
+++ b/src/test/isolation2/sql/lockmodes.sql
@@ -1,4 +1,4 @@
--- table to just store the master's data directory path on segment.
+-- table to just store the coordinator's data directory path on segment.
 CREATE TABLE lockmodes_datadir(a int, dir text);
 INSERT INTO lockmodes_datadir select 1,datadir from gp_segment_configuration where role='p' and content=-1;
 
@@ -384,7 +384,7 @@ create table t_lockmods_ao1 (c int) with (appendonly=true) distributed randomly;
 
 -- enable gdd
 ALTER SYSTEM SET gp_enable_global_deadlock_detector TO on;
--- Use utility session on seg 0 to restart master. This way avoids the
+-- Use utility session on seg 0 to restart coordinator. This way avoids the
 -- situation where session issuing the restart doesn't disappear
 -- itself.
 1U:SELECT pg_ctl(dir, 'restart') from lockmodes_datadir;

--- a/src/test/isolation2/sql/misc.sql
+++ b/src/test/isolation2/sql/misc.sql
@@ -1,7 +1,7 @@
 --
 -- Validate GPDB can create unique index on a table created in utility mode
 --
--- NOTICE: we must connect to master in utility mode because the oid of table is
+-- NOTICE: we must connect to coordinator in utility mode because the oid of table is
 -- preassigned in QD, if we create a table in utility mode in QE, the oid might
 -- conflict with preassigned oid.
 -1U: create table utilitymode_primary_key_tab (c1 int);

--- a/src/test/isolation2/sql/packcore.sql
+++ b/src/test/isolation2/sql/packcore.sql
@@ -71,7 +71,7 @@ stderr: {stderr}
     # gzip runs much faster with -1
     os.putenv('GZIP', '-1')
 
-    # do not put the packcore results under master data, that will cause
+    # do not put the packcore results under coordinator data, that will cause
     # failures in other tests
     os.chdir('/tmp')
 

--- a/src/test/isolation2/sql/prevent_ao_wal.sql
+++ b/src/test/isolation2/sql/prevent_ao_wal.sql
@@ -41,9 +41,9 @@
 ! last_wal_file=$(psql -At -c "SELECT pg_walfile_name(pg_current_wal_lsn())" postgres) && pg_waldump ${last_wal_file} -p ${COORDINATOR_DATA_DIRECTORY}/pg_wal -r appendonly;
 
 -- *********** Set wal_level=minimal **************
-!\retcode gpconfig -c wal_level -v minimal --masteronly;
+!\retcode gpconfig -c wal_level -v minimal --coordinatoronly;
 -- Set max_wal_senders to 0 because a non-zero value requires wal_level >= 'archive'
-!\retcode gpconfig -c max_wal_senders -v 0 --masteronly;
+!\retcode gpconfig -c max_wal_senders -v 0 --coordinatoronly;
 -- Restart QD
 !\retcode pg_ctl -l /dev/null -D $COORDINATOR_DATA_DIRECTORY restart -w -t 600 -m fast;
 
@@ -67,8 +67,8 @@
 -1U: DROP TABLE aoco_foo;
 
 -- Reset wal_level
-!\retcode gpconfig -r wal_level --masteronly;
+!\retcode gpconfig -r wal_level --coordinatoronly;
 -- Reset max_wal_senders
-!\retcode gpconfig -r max_wal_senders --masteronly;
+!\retcode gpconfig -r max_wal_senders --coordinatoronly;
 -- Restart QD
 !\retcode pg_ctl -l /dev/null -D $COORDINATOR_DATA_DIRECTORY restart -w -t 600 -m fast;

--- a/src/test/isolation2/sql/reindex/serializable_reindex_with_drop_column_heap.sql
+++ b/src/test/isolation2/sql/reindex/serializable_reindex_with_drop_column_heap.sql
@@ -21,7 +21,7 @@ SET gp_create_table_random_default_distribution=off;
 2: select 'dummy select to establish snapshot';
 1: alter table reindex_serialize_tab_heap drop column c;
 1: COMMIT;
--- Remember index relfilenodes from master and segments before
+-- Remember index relfilenodes from coordinator and segments before
 -- reindex.
 2: create temp table old_relfilenodes as
    (select gp_segment_id as dbid, relfilenode, oid, relname from gp_dist_random('pg_class')
@@ -31,7 +31,7 @@ SET gp_create_table_random_default_distribution=off;
     where relname like 'idx%_reindex_serialize_tab_heap');
 2: reindex table reindex_serialize_tab_heap;
 2: COMMIT;
--- Validate that reindex changed all index relfilenodes on master as well as
+-- Validate that reindex changed all index relfilenodes on coordinator as well as
 -- segments.  The following query should return 0 tuples.
 2: select oldrels.* from old_relfilenodes oldrels join
    (select gp_segment_id as dbid, relfilenode, relname from gp_dist_random('pg_class')

--- a/src/test/isolation2/sql/reindex/serializable_reindex_with_drop_index_ao.sql
+++ b/src/test/isolation2/sql/reindex/serializable_reindex_with_drop_index_ao.sql
@@ -21,7 +21,7 @@ SET gp_create_table_random_default_distribution=off;
 2: select 'dummy select to establish snapshot';
 1: drop index idxg_reindex_serialize_tab_ao;
 1: COMMIT;
--- Remember index relfilenodes from master and segments before
+-- Remember index relfilenodes from coordinator and segments before
 -- reindex.
 2: create table old_ao_relfilenodes as
    (select gp_segment_id as dbid, relfilenode, oid, relname from gp_dist_random('pg_class')
@@ -31,7 +31,7 @@ SET gp_create_table_random_default_distribution=off;
     where relname like 'idx%_reindex_serialize_tab_ao');
 2: reindex table reindex_serialize_tab_ao;
 2: COMMIT;
--- Validate that reindex changed all index relfilenodes on master as well as
+-- Validate that reindex changed all index relfilenodes on coordinator as well as
 -- segments.  The following query should return 0 tuples.
 2: select oldrels.* from old_ao_relfilenodes oldrels join
    (select gp_segment_id as dbid, relfilenode, relname from gp_dist_random('pg_class')

--- a/src/test/isolation2/sql/reindex/serializable_reindex_with_drop_index_heap.sql
+++ b/src/test/isolation2/sql/reindex/serializable_reindex_with_drop_index_heap.sql
@@ -19,7 +19,7 @@ SET gp_create_table_random_default_distribution=off;
 2: select 'dummy select to establish snapshot';
 1: drop index idxg_reindex_dropindex_serialize_tab_heap;
 1: COMMIT;
--- Remember index relfilenodes from master and segments before
+-- Remember index relfilenodes from coordinator and segments before
 -- reindex.
 2: create table old_heap_relfilenodes as
    (select gp_segment_id as dbid, relfilenode, oid, relname from gp_dist_random('pg_class')
@@ -29,7 +29,7 @@ SET gp_create_table_random_default_distribution=off;
     where relname like 'idx%_reindex_dropindex_serialize_tab_heap');
 2: reindex table reindex_dropindex_serialize_tab_heap;
 2: COMMIT;
--- Validate that reindex changed all index relfilenodes on master as well as
+-- Validate that reindex changed all index relfilenodes on coordinator as well as
 -- segments.  The following query should return 0 tuples.
 2: select oldrels.* from old_heap_relfilenodes oldrels join
    (select gp_segment_id as dbid, relfilenode, relname from gp_dist_random('pg_class')

--- a/src/test/isolation2/sql/reindex/vacuum_analyze_while_reindex_ao_btree.sql
+++ b/src/test/isolation2/sql/reindex/vacuum_analyze_while_reindex_ao_btree.sql
@@ -12,7 +12,7 @@ create index idx_btree_reindex_vacuum_analyze_ao on reindex_ao(a);
 
 DELETE FROM reindex_ao WHERE a < 128;
 1: BEGIN;
--- Remember index relfilenodes from master and segments before
+-- Remember index relfilenodes from coordinator and segments before
 -- reindex.
 1: create temp table old_relfilenodes as
    (select gp_segment_id as dbid, relfilenode, oid, relname from gp_dist_random('pg_class')
@@ -24,7 +24,7 @@ DELETE FROM reindex_ao WHERE a < 128;
 2&: VACUUM ANALYZE reindex_ao;
 1: COMMIT;
 2<:
--- Validate that reindex changed all index relfilenodes on master as well as
+-- Validate that reindex changed all index relfilenodes on coordinator as well as
 -- segments.  The following query should return 0 tuples.
 1: select oldrels.* from old_relfilenodes oldrels join
    (select gp_segment_id as dbid, relfilenode, relname from gp_dist_random('pg_class')

--- a/src/test/isolation2/sql/reindex/vacuum_while_reindex_ao_bitmap.sql
+++ b/src/test/isolation2/sql/reindex/vacuum_while_reindex_ao_bitmap.sql
@@ -9,7 +9,7 @@ create index idx_bitmap_reindex_ao on reindex_ao USING bitmap(a);
 
 DELETE FROM reindex_ao WHERE a < 128;
 1: BEGIN;
--- Remember index relfilenodes from master and segments before
+-- Remember index relfilenodes from coordinator and segments before
 -- reindex.
 1: create temp table old_relfilenodes as
    (select gp_segment_id as dbid, relfilenode, oid, relname from gp_dist_random('pg_class')
@@ -21,7 +21,7 @@ DELETE FROM reindex_ao WHERE a < 128;
 2&: VACUUM reindex_ao;
 1: COMMIT;
 2<:
--- Validate that reindex changed all index relfilenodes on master as well as
+-- Validate that reindex changed all index relfilenodes on coordinator as well as
 -- segments.  The following query should return 0 tuples.
 1: select oldrels.* from old_relfilenodes oldrels join
    (select gp_segment_id as dbid, relfilenode, relname from gp_dist_random('pg_class')

--- a/src/test/isolation2/sql/reindex/vacuum_while_reindex_heap_btree.sql
+++ b/src/test/isolation2/sql/reindex/vacuum_while_reindex_heap_btree.sql
@@ -9,7 +9,7 @@ create index idx_btree_reindex_heap on reindex_heap(a);
 
 DELETE FROM reindex_heap WHERE a < 128;
 1: BEGIN;
--- Remember index relfilenodes from master and segments before
+-- Remember index relfilenodes from coordinator and segments before
 -- reindex.
 1: create temp table old_relfilenodes as
    (select gp_segment_id as dbid, relfilenode, oid, relname from gp_dist_random('pg_class')
@@ -21,7 +21,7 @@ DELETE FROM reindex_heap WHERE a < 128;
 2&: VACUUM reindex_heap;
 1: COMMIT;
 2<:
--- Validate that reindex changed all index relfilenodes on master as well as
+-- Validate that reindex changed all index relfilenodes on coordinator as well as
 -- segments.  The following query should return 0 tuples.
 1: select oldrels.* from old_relfilenodes oldrels join
    (select gp_segment_id as dbid, relfilenode, relname from gp_dist_random('pg_class')

--- a/src/test/isolation2/sql/reindex/vacuum_while_reindex_heap_btree_toast.sql
+++ b/src/test/isolation2/sql/reindex/vacuum_while_reindex_heap_btree_toast.sql
@@ -9,7 +9,7 @@ create index idx_btree_reindex_toast_heap on reindex_toast_heap(b);
 
 DELETE FROM reindex_toast_heap WHERE b % 4 = 0 ;
 1: BEGIN;
--- Remember index relfilenodes from master and segments before
+-- Remember index relfilenodes from coordinator and segments before
 -- reindex.
 1: create temp table old_relfilenodes as
    (select gp_segment_id as dbid, relfilenode, oid, relname from gp_dist_random('pg_class')
@@ -21,7 +21,7 @@ DELETE FROM reindex_toast_heap WHERE b % 4 = 0 ;
 2&: VACUUM reindex_toast_heap;
 1: COMMIT;
 2<:
--- Validate that reindex changed all index relfilenodes on master as well as
+-- Validate that reindex changed all index relfilenodes on coordinator as well as
 -- segments.  The following query should return 0 tuples.
 1: select oldrels.* from old_relfilenodes oldrels join
    (select gp_segment_id as dbid, relfilenode, relname from gp_dist_random('pg_class')

--- a/src/test/isolation2/sql/resgroup/resgroup_cpuset.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_cpuset.sql
@@ -147,7 +147,7 @@ SELECT gp_inject_fault('create_resource_group_fail', 'reset', 1);
 DROP RESOURCE GROUP rg1_test_group;
 -- end_ignore
 
--- test segment/master cpuset
+-- test segment/coordinator cpuset
 CREATE RESOURCE GROUP rg_multi_cpuset1 WITH (concurrency=2, cpuset='0;0');
 ALTER RESOURCE GROUP rg_multi_cpuset1 set CPUSET '1;1';
 select groupname,cpuset from gp_toolkit.gp_resgroup_config where groupname='rg_multi_cpuset1';

--- a/src/test/isolation2/sql/resgroup/resgroup_move_query.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_move_query.sql
@@ -3,7 +3,7 @@
 -- m/ERROR:  process \d+ is in IDLE state/
 -- s/\d+/XXX/g
 --
--- m/ERROR:  group \d+ doesn't have enough memory on master, expect:\d+, available:\d+/
+-- m/ERROR:  group \d+ doesn't have enough memory on coordinator, expect:\d+, available:\d+/
 -- s/\d+/XXX/g
 --
 -- m/ERROR:  group \d+ doesn't have enough memory on segment, expect:\d+, available:\d+/

--- a/src/test/isolation2/sql/segwalrep/commit_blocking_on_standby.sql
+++ b/src/test/isolation2/sql/segwalrep/commit_blocking_on_standby.sql
@@ -1,13 +1,13 @@
 --
--- Master/standby commit blocking scenarios.  These are different from
+-- Coordinator/standby commit blocking scenarios.  These are different from
 -- primary/mirror commit blocking because there is no FTS or a
--- third-party as external arbiter in case of master/standby.
+-- third-party as external arbiter in case of coordinator/standby.
 --
 -- Scenario1: Commits should block until standby confirms WAL flush
 -- up to commit LSN.
 
 -- Check that are starting with a clean slate, standby must be in sync
--- with master.
+-- with coordinator.
 
 select application_name, state from pg_stat_replication;
 
@@ -70,7 +70,7 @@ insert into commit_blocking_on_standby_t1 values (1);
 -- has caught up within range.  And thereafter, commits should start
 -- blocking.
 
--- In order to get master and standby in CATCHUP state, existing
+-- In order to get coordinator and standby in CATCHUP state, existing
 -- connection, which is in STREAMING state must be closed.  A new
 -- connection will then be initiated by standby, beginning in STARTUP
 -- then CATCHUP to STREAMING.  Faults are used to suspend WAL sender
@@ -150,7 +150,7 @@ select wait_until_standby_in_state('streaming');
 
 -- Scenario3: verify repl_catchup_within_range is enabled on segment.
 -- It is similar as Scenario2, just running the test against primary/mirror
--- instead of master/standby.
+-- instead of coordinator/standby.
 
 select gp_inject_fault_infinite('wal_sender_loop', 'infinite_loop', dbid)
        from gp_segment_configuration where content=0 and role='p';

--- a/src/test/isolation2/sql/segwalrep/coordinator_wal_switch.sql
+++ b/src/test/isolation2/sql/segwalrep/coordinator_wal_switch.sql
@@ -7,7 +7,7 @@ FROM gp_segment_configuration WHERE content=-1 and role='p';
 
 -- Run pg_basebackup which should trigger and suspend at the fault
 1&: SELECT pg_basebackup(hostname, 100, port, false, NULL,
-        '/tmp/master_wal_switch_test', true, 'fetch')
+        '/tmp/coordinator_wal_switch_test', true, 'fetch')
     from gp_segment_configuration where content=-1 and role='p';
 
 -- Wait until fault has been triggered
@@ -22,7 +22,7 @@ SELECT application_name, state FROM pg_stat_replication;
 -- suffice to generate new WAL file.
 CREATE TEMP TABLE walfile(fname text) DISTRIBUTED BY (fname);
 INSERT INTO walfile SELECT pg_walfile_name(pg_switch_wal());
-CREATE TABLE master_wal_dummy();
+CREATE TABLE coordinator_wal_dummy();
 -- This should return false, indicating current WAL segment is
 -- different than what was previously recorded walfile table.
 SELECT fname = pg_walfile_name(pg_switch_wal()) FROM walfile;
@@ -40,4 +40,4 @@ FROM gp_segment_configuration WHERE content=-1 and role='p';
 -- Verify if basebackup completed successfully
 -- See if recovery.conf exists (Yes - Pass)
 SELECT application_name, state FROM pg_stat_replication;
-!\retcode ls /tmp/master_wal_switch_test/postgresql.auto.conf /tmp/master_wal_switch_test/standby.signal;
+!\retcode ls /tmp/coordinator_wal_switch_test/postgresql.auto.conf /tmp/coordinator_wal_switch_test/standby.signal;

--- a/src/test/isolation2/sql/segwalrep/dtx_recovery_wait_lsn.sql
+++ b/src/test/isolation2/sql/segwalrep/dtx_recovery_wait_lsn.sql
@@ -1,6 +1,6 @@
 -- Test this scenario:
--- mirror has latency replaying the WAL from the primary, the master is reset
--- from PANIC, master will start the DTX recovery process to recover the
+-- mirror has latency replaying the WAL from the primary, the coordinator is reset
+-- from PANIC, coordinator will start the DTX recovery process to recover the
 -- in-progress two-phase transactions. 
 -- The FTS process should be able to continue probe and 'sync off' the mirror
 -- while the 'dtx recovery' process is hanging recovering distributed transactions.
@@ -26,9 +26,9 @@
 
 -- stop mirror
 3: SELECT pg_ctl(datadir, 'stop', 'immediate') FROM gp_segment_configuration WHERE content=0 AND role = 'm';
--- trigger master reset
+-- trigger coordinator reset
 3: select gp_inject_fault('exec_simple_query_start', 'panic', current_setting('gp_dbid')::smallint);
--- verify master panic happens. The PANIC message does not emit sometimes so
+-- verify coordinator panic happens. The PANIC message does not emit sometimes so
 -- mask it.
 -- start_matchsubs
 -- m/PANIC:  fault triggered, fault name:'exec_simple_query_start' fault type:'panic'\n/
@@ -36,7 +36,7 @@
 -- end_matchsubs
 3: select 1;
 
--- wait for master finish crash recovery
+-- wait for coordinator finish crash recovery
 -1U: select wait_until_standby_in_state('streaming');
 
 -- wait for FTS to 'sync off' the mirror, meanwhile, dtx recovery process will

--- a/src/test/isolation2/sql/segwalrep/failover_with_many_records.sql
+++ b/src/test/isolation2/sql/segwalrep/failover_with_many_records.sql
@@ -2,8 +2,8 @@
 -- gprecoverseg BEGIN failures due to gang creation failure as some primaries
 -- are not up. Setting these increase the number of retries in gang creation in
 -- case segment is in recovery. Approximately we want to wait 30 seconds.
-!\retcode gpconfig -c gp_gang_creation_retry_count -v 120 --skipvalidation --masteronly;
-!\retcode gpconfig -c gp_gang_creation_retry_timer -v 1000 --skipvalidation --masteronly;
+!\retcode gpconfig -c gp_gang_creation_retry_count -v 120 --skipvalidation --coordinatoronly;
+!\retcode gpconfig -c gp_gang_creation_retry_timer -v 1000 --skipvalidation --coordinatoronly;
 !\retcode gpstop -u;
 
 1:CREATE TABLE t(a int, b int);
@@ -44,6 +44,6 @@ select wait_until_all_segments_synchronized();
 -- verify no segment is down after recovery
 1:SELECT COUNT(*) FROM gp_segment_configuration WHERE status = 'd';
 
-!\retcode gpconfig -r gp_gang_creation_retry_count --skipvalidation --masteronly;
-!\retcode gpconfig -r gp_gang_creation_retry_timer --skipvalidation --masteronly;
+!\retcode gpconfig -r gp_gang_creation_retry_count --skipvalidation --coordinatoronly;
+!\retcode gpconfig -r gp_gang_creation_retry_timer --skipvalidation --coordinatoronly;
 !\retcode gpstop -u;

--- a/src/test/isolation2/sql/setup.sql
+++ b/src/test/isolation2/sql/setup.sql
@@ -33,7 +33,7 @@ begin	/* in func */
 end;	/* in func */
 $$ LANGUAGE plpgsql;
 
--- Show locks in master and in segments. Because the number of segments
+-- Show locks in coordinator and in segments. Because the number of segments
 -- in the cluster depends on configuration, we print only summary information
 -- of the locks in segments. If a relation is locked only on one segment,
 -- we print that as a special case, but otherwise we just print "n segments",
@@ -382,9 +382,9 @@ create or replace function validate_tablespace_symlink(datadir text, tablespaced
     return os.readlink('%s/pg_tblspc/%d' % (datadir, tablespace_oid)) == ('%s/%d' % (tablespacedir, dbid))
 $$ language plpython3u;
 
--- This function is used to loop until master shutsdown, to make sure
+-- This function is used to loop until coordinator shutsdown, to make sure
 -- next command executed is only after restart and doesn't go through
--- while PANIC is still being processed by master, as master continues
+-- while PANIC is still being processed by coordinator, as coordinator continues
 -- to accept connections for a while despite undergoing PANIC.
 CREATE OR REPLACE FUNCTION wait_till_master_shutsdown()
 RETURNS void AS

--- a/src/test/isolation2/sql/uao_crash_compaction_column.sql
+++ b/src/test/isolation2/sql/uao_crash_compaction_column.sql
@@ -81,36 +81,36 @@
 1:SELECT * FROM crash_vacuum_in_appendonly_insert ORDER BY a,b;
 
 --
--- Setup tables to test crash at different points on master now
+-- Setup tables to test crash at different points on coordinator now
 --
--- for crash_master_before_cleanup_phase
+-- for crash_coordinator_before_cleanup_phase
 2:set default_table_access_method = ao_column;
 2:show default_table_access_method;
-2:DROP TABLE IF EXISTS crash_master_before_cleanup_phase CASCADE;
-2:CREATE TABLE crash_master_before_cleanup_phase (a INT, b INT, c CHAR(20));
-2:CREATE INDEX crash_master_before_cleanup_phase_index ON crash_master_before_cleanup_phase(b);
-2:INSERT INTO crash_master_before_cleanup_phase SELECT i AS a, 1 AS b, 'hello world' AS c FROM generate_series(1, 10) AS i;
-2:DELETE FROM crash_master_before_cleanup_phase WHERE a < 4;
+2:DROP TABLE IF EXISTS crash_coordinator_before_cleanup_phase CASCADE;
+2:CREATE TABLE crash_coordinator_before_cleanup_phase (a INT, b INT, c CHAR(20));
+2:CREATE INDEX crash_coordinator_before_cleanup_phase_index ON crash_coordinator_before_cleanup_phase(b);
+2:INSERT INTO crash_coordinator_before_cleanup_phase SELECT i AS a, 1 AS b, 'hello world' AS c FROM generate_series(1, 10) AS i;
+2:DELETE FROM crash_coordinator_before_cleanup_phase WHERE a < 4;
 
 -- inject panic fault 
-2:SELECT gp_inject_fault('compaction_before_cleanup_phase', 'panic', '', '', 'crash_master_before_cleanup_phase', 1, -1, 0, 1);
-2:VACUUM crash_master_before_cleanup_phase;
+2:SELECT gp_inject_fault('compaction_before_cleanup_phase', 'panic', '', '', 'crash_coordinator_before_cleanup_phase', 1, -1, 0, 1);
+2:VACUUM crash_coordinator_before_cleanup_phase;
 
 -- reset faults as protection incase tests failed and panic didn't happen
 4:SELECT gp_inject_fault('compaction_before_cleanup_phase', 'reset', 1);
 
 -- perform post crash validation checks
--- for crash_master_before_cleanup_phase
-4:SELECT segno,column_num,physical_segno,tupcount,modcount,state FROM gp_toolkit.__gp_aocsseg('crash_master_before_cleanup_phase');
-4:INSERT INTO crash_master_before_cleanup_phase VALUES(1, 1, 'c'), (25, 6, 'c');
-4:UPDATE crash_master_before_cleanup_phase SET b = b+10 WHERE a=25;
-4:SELECT * FROM crash_master_before_cleanup_phase ORDER BY a,b;
-4:SELECT segno,column_num,physical_segno,tupcount,modcount,state FROM gp_toolkit.__gp_aocsseg('crash_master_before_cleanup_phase');
-4:VACUUM crash_master_before_cleanup_phase;
-4:SELECT segno,column_num,physical_segno,tupcount,modcount,state FROM gp_toolkit.__gp_aocsseg('crash_master_before_cleanup_phase');
-4:INSERT INTO crash_master_before_cleanup_phase VALUES(21, 1, 'c'), (26, 1, 'c');
-4:UPDATE crash_master_before_cleanup_phase SET b = b+10 WHERE a=26;
-4:SELECT * FROM crash_master_before_cleanup_phase ORDER BY a,b;
+-- for crash_coordinator_before_cleanup_phase
+4:SELECT segno,column_num,physical_segno,tupcount,modcount,state FROM gp_toolkit.__gp_aocsseg('crash_coordinator_before_cleanup_phase');
+4:INSERT INTO crash_coordinator_before_cleanup_phase VALUES(1, 1, 'c'), (25, 6, 'c');
+4:UPDATE crash_coordinator_before_cleanup_phase SET b = b+10 WHERE a=25;
+4:SELECT * FROM crash_coordinator_before_cleanup_phase ORDER BY a,b;
+4:SELECT segno,column_num,physical_segno,tupcount,modcount,state FROM gp_toolkit.__gp_aocsseg('crash_coordinator_before_cleanup_phase');
+4:VACUUM crash_coordinator_before_cleanup_phase;
+4:SELECT segno,column_num,physical_segno,tupcount,modcount,state FROM gp_toolkit.__gp_aocsseg('crash_coordinator_before_cleanup_phase');
+4:INSERT INTO crash_coordinator_before_cleanup_phase VALUES(21, 1, 'c'), (26, 1, 'c');
+4:UPDATE crash_coordinator_before_cleanup_phase SET b = b+10 WHERE a=26;
+4:SELECT * FROM crash_coordinator_before_cleanup_phase ORDER BY a,b;
 
 -- Scenario for validating mirror replays fine and doesn't crash on
 -- truncate record replay even if file is missing.

--- a/src/test/isolation2/sql/uao_crash_compaction_row.sql
+++ b/src/test/isolation2/sql/uao_crash_compaction_row.sql
@@ -76,33 +76,33 @@
 1:SELECT * FROM crash_vacuum_in_appendonly_insert ORDER BY a,b;
 
 --
--- Setup tables to test crash at different points on master now
+-- Setup tables to test crash at different points on coordinator now
 --
--- for crash_master_before_cleanup_phase
+-- for crash_coordinator_before_cleanup_phase
 2:set default_table_access_method = ao_row;
 2:show default_table_access_method;
-2:DROP TABLE IF EXISTS crash_master_before_cleanup_phase CASCADE;
-2:CREATE TABLE crash_master_before_cleanup_phase (a INT, b INT, c CHAR(20));
-2:CREATE INDEX crash_master_before_cleanup_phase_index ON crash_master_before_cleanup_phase(b);
-2:INSERT INTO crash_master_before_cleanup_phase SELECT i AS a, 1 AS b, 'hello world' AS c FROM generate_series(1, 10) AS i;
-2:DELETE FROM crash_master_before_cleanup_phase WHERE a < 4;
+2:DROP TABLE IF EXISTS crash_coordinator_before_cleanup_phase CASCADE;
+2:CREATE TABLE crash_coordinator_before_cleanup_phase (a INT, b INT, c CHAR(20));
+2:CREATE INDEX crash_coordinator_before_cleanup_phase_index ON crash_coordinator_before_cleanup_phase(b);
+2:INSERT INTO crash_coordinator_before_cleanup_phase SELECT i AS a, 1 AS b, 'hello world' AS c FROM generate_series(1, 10) AS i;
+2:DELETE FROM crash_coordinator_before_cleanup_phase WHERE a < 4;
 
 -- suspend at intended points
-2:SELECT gp_inject_fault('compaction_before_cleanup_phase', 'panic', '', '', 'crash_master_before_cleanup_phase', 1, -1, 0, 1);
-2:VACUUM crash_master_before_cleanup_phase;
+2:SELECT gp_inject_fault('compaction_before_cleanup_phase', 'panic', '', '', 'crash_coordinator_before_cleanup_phase', 1, -1, 0, 1);
+2:VACUUM crash_coordinator_before_cleanup_phase;
 
 -- reset faults as protection incase tests failed and panic didn't happen
 4:SELECT gp_inject_fault('compaction_before_cleanup_phase', 'reset', 1);
 
 -- perform post crash validation checks
--- for crash_master_before_cleanup_phase
-4:SELECT * FROM gp_toolkit.__gp_aoseg('crash_master_before_cleanup_phase');
-4:INSERT INTO crash_master_before_cleanup_phase VALUES(1, 1, 'c'), (25, 6, 'c');
-4:UPDATE crash_master_before_cleanup_phase SET b = b+10 WHERE a=25;
-4:SELECT * FROM crash_master_before_cleanup_phase ORDER BY a,b;
-4:SELECT * FROM gp_toolkit.__gp_aoseg('crash_master_before_cleanup_phase');
-4:VACUUM crash_master_before_cleanup_phase;
-4:SELECT * FROM gp_toolkit.__gp_aoseg('crash_master_before_cleanup_phase');
-4:INSERT INTO crash_master_before_cleanup_phase VALUES(21, 1, 'c'), (26, 1, 'c');
-4:UPDATE crash_master_before_cleanup_phase SET b = b+10 WHERE a=26;
-4:SELECT * FROM crash_master_before_cleanup_phase ORDER BY a,b;
+-- for crash_coordinator_before_cleanup_phase
+4:SELECT * FROM gp_toolkit.__gp_aoseg('crash_coordinator_before_cleanup_phase');
+4:INSERT INTO crash_coordinator_before_cleanup_phase VALUES(1, 1, 'c'), (25, 6, 'c');
+4:UPDATE crash_coordinator_before_cleanup_phase SET b = b+10 WHERE a=25;
+4:SELECT * FROM crash_coordinator_before_cleanup_phase ORDER BY a,b;
+4:SELECT * FROM gp_toolkit.__gp_aoseg('crash_coordinator_before_cleanup_phase');
+4:VACUUM crash_coordinator_before_cleanup_phase;
+4:SELECT * FROM gp_toolkit.__gp_aoseg('crash_coordinator_before_cleanup_phase');
+4:INSERT INTO crash_coordinator_before_cleanup_phase VALUES(21, 1, 'c'), (26, 1, 'c');
+4:UPDATE crash_coordinator_before_cleanup_phase SET b = b+10 WHERE a=26;
+4:SELECT * FROM crash_coordinator_before_cleanup_phase ORDER BY a,b;

--- a/src/test/isolation2/sql/udf_exception_blocks_panic_scenarios.sql
+++ b/src/test/isolation2/sql/udf_exception_blocks_panic_scenarios.sql
@@ -14,7 +14,7 @@
 
 -- debug_dtm_action_target: Allows to set target for specified
 -- dtm_action should it be DTM protocol command or SQL command from
--- master to segment.
+-- coordinator to segment.
 
 -- debug_dtm_action_protocol: Allows to specify sub-type of DTM
 -- protocol for which to perform specified dtm_action (like prepare,

--- a/src/test/isolation2/sql/vacuum_skip_locked_onseg.sql
+++ b/src/test/isolation2/sql/vacuum_skip_locked_onseg.sql
@@ -2,7 +2,7 @@
 -- The test focuses on the vacuum behavior when the table is locked
 -- on segments. There is another test vacuum-skip-locked in
 -- isolation dir which focuses on regular test cases (table is locked
--- on master).
+-- on coordinator).
 
 1: CREATE TABLE vacuum_tbl (c1 int) DISTRIBUTED BY (c1);
 

--- a/src/test/isolation2/sql_isolation_testcase.py
+++ b/src/test/isolation2/sql_isolation_testcase.py
@@ -591,7 +591,7 @@ class SQLIsolationExecutor(object):
 
     def get_all_primary_contentids(self, dbname):
         """
-        Retrieves all primary content IDs (including the master). Intended for
+        Retrieves all primary content IDs (including the coordinator). Intended for
         use by *U queries.
         """
         if not dbname:
@@ -852,11 +852,11 @@ class SQLIsolationTestCase:
            followed by U (for utility-mode connections) or R (for retrieve-mode
            connection). In 'U' mode or 'R' mode, the
            content-id can alternatively be an asterisk '*' to perform a
-           utility-mode/retrieve-mode query on the master and all primary segments.
+           utility-mode/retrieve-mode query on the coordinator and all primary segments.
            If you want to create multiple connections to the same content-id, just
            increase N in: "content-id + {gpdb segment node number} * N",
            e.g. if gpdb cluster segment number is 3, then:
-           (1) the master utility connections can be: -1U, -4U, -7U;
+           (1) the coordinator utility connections can be: -1U, -4U, -7U;
            (2) the seg0 connections can be: 0U, 3U, 6U;
            (3) the seg1 connections can be: 1U, 4U, 7U;
            (4) the seg2 connections can be: 2U, 5U, 8U;
@@ -986,7 +986,7 @@ class SQLIsolationTestCase:
 
         Some tests are easier to write if it's possible to modify a system
         catalog across the *entire* cluster. To perform a utility-mode query on
-        all segments and the master, you can use *U commands:
+        all segments and the coordinator, you can use *U commands:
 
         *U: SET allow_system_table_mods = true;
         *U: UPDATE pg_catalog.<table> SET <column> = <value> WHERE <cond>;

--- a/src/test/isolation2/test_parallel_retrieve_cursor_extended_query_error.c
+++ b/src/test/isolation2/test_parallel_retrieve_cursor_extended_query_error.c
@@ -11,15 +11,15 @@
 #include <unistd.h>
 #include "libpq-fe.h"
 
-#define MASTER_CONNECT_INDEX -1
+#define COORDINATOR_CONNECT_INDEX -1
 
 static void
-finish_conn_nicely(PGconn *master_conn, PGconn *endpoint_conns[], size_t endpoint_conns_num)
+finish_conn_nicely(PGconn *coordinator_conn, PGconn *endpoint_conns[], size_t endpoint_conns_num)
 {
 	int			i;
 
-	if (master_conn)
-		PQfinish(master_conn);
+	if (coordinator_conn)
+		PQfinish(coordinator_conn);
 
 	for (i = 0; i < endpoint_conns_num; i++)
 	{
@@ -44,7 +44,7 @@ check_prepare_conn(PGconn *conn, const char *dbName, int conn_idx)
 		exit(1);
 	}
 
-	if (conn_idx == MASTER_CONNECT_INDEX)
+	if (conn_idx == COORDINATOR_CONNECT_INDEX)
 	{
 		/*
 		 * Set always-secure search path, so malicous users can't take
@@ -68,8 +68,8 @@ exec_sql_without_resultset(PGconn *conn, const char *sql, int conn_idx)
 {
 	PGresult   *res1;
 
-	if (conn_idx == MASTER_CONNECT_INDEX)
-		printf("\nExec SQL on Master:\n\t> %s\n", sql);
+	if (conn_idx == COORDINATOR_CONNECT_INDEX)
+		printf("\nExec SQL on Coordinator:\n\t> %s\n", sql);
 	else
 		printf("\nExec SQL on EndPoint[%d]:\n\t> %s\n", conn_idx, sql);
 
@@ -101,8 +101,8 @@ exec_sql_with_resultset_in_extended_query_protocol(PGconn *conn, const char *sql
 
 	paramValues[0] = "0";
 
-	if (conn_idx == MASTER_CONNECT_INDEX)
-		printf("\nExec SQL on Master:\n\t> %s\n", sql);
+	if (conn_idx == COORDINATOR_CONNECT_INDEX)
+		printf("\nExec SQL on Coordinator:\n\t> %s\n", sql);
 	else
 		printf("\nExec SQL on EndPoint[%d]:\n\t> %s\n", conn_idx, sql);
 
@@ -189,8 +189,8 @@ exec_sql_with_resultset(PGconn *conn, const char *sql, int conn_idx)
 	int			i,
 				j;
 
-	if (conn_idx == MASTER_CONNECT_INDEX)
-		printf("\nExec SQL on Master:\n\t> %s\n", sql);
+	if (conn_idx == COORDINATOR_CONNECT_INDEX)
+		printf("\nExec SQL on Coordinator:\n\t> %s\n", sql);
 	else
 		printf("\nExec SQL on EndPoint[%d]:\n\t> %s\n", conn_idx, sql);;
 
@@ -220,9 +220,9 @@ exec_sql_with_resultset(PGconn *conn, const char *sql, int conn_idx)
 	return 0;
 }
 
-/* this function is in the master connection */
+/* this function is in the coordinator connection */
 static int
-exec_check_parallel_cursor(PGconn *master_conn, int isCheckFinish)
+exec_check_parallel_cursor(PGconn *coordinator_conn, int isCheckFinish)
 {
 	int			result = 0;
 	PGresult   *res1;
@@ -233,12 +233,12 @@ exec_check_parallel_cursor(PGconn *master_conn, int isCheckFinish)
 	/* call wait mode monitor UDF and it will wait for finish retrieving. */
 	if (!isCheckFinish)
 	{
-		result = exec_sql_with_resultset(master_conn, check_sql, MASTER_CONNECT_INDEX);
+		result = exec_sql_with_resultset(coordinator_conn, check_sql, COORDINATOR_CONNECT_INDEX);
 	}
 	else
 	{
-		printf("\nExec SQL on Master:\n\t> %s\n", check_sql);
-		res1 = PQexec(master_conn, check_sql);
+		printf("\nExec SQL on Coordinator:\n\t> %s\n", check_sql);
+		res1 = PQexec(coordinator_conn, check_sql);
 		if (PQresultStatus(res1) != PGRES_TUPLES_OK)
 		{
 			fprintf(stderr, "\"%s\" didn't return tuples properly\n", check_sql);
@@ -280,7 +280,7 @@ main(int argc, char **argv)
 	int			i;
 	int			retVal;			/* return value for this func */
 
-	PGconn	   *master_conn,
+	PGconn	   *coordinator_conn,
 			  **endpoint_conns = NULL;
 	size_t		endpoint_conns_num = 0;
 	char	  **tokens = NULL,
@@ -315,24 +315,24 @@ main(int argc, char **argv)
 	pgtty = NULL;				/* debugging tty for the backend */
 
 	/* make a connection to the database */
-	master_conn = PQsetdb(pghost, pgport, pgoptions, pgtty, dbName);
-	check_prepare_conn(master_conn, dbName, MASTER_CONNECT_INDEX);
+	coordinator_conn = PQsetdb(pghost, pgport, pgoptions, pgtty, dbName);
+	check_prepare_conn(coordinator_conn, dbName, COORDINATOR_CONNECT_INDEX);
 
 	/* do some preparation for test */
-	if (exec_sql_without_resultset(master_conn, "DROP TABLE IF EXISTS public.tab_parallel_cursor;", MASTER_CONNECT_INDEX) != 0)
+	if (exec_sql_without_resultset(coordinator_conn, "DROP TABLE IF EXISTS public.tab_parallel_cursor;", COORDINATOR_CONNECT_INDEX) != 0)
 		goto LABEL_ERR;
-	if (exec_sql_without_resultset(master_conn, "CREATE TABLE public.tab_parallel_cursor AS SELECT id FROM pg_catalog.generate_series(1,100) id;", MASTER_CONNECT_INDEX) != 0)
+	if (exec_sql_without_resultset(coordinator_conn, "CREATE TABLE public.tab_parallel_cursor AS SELECT id FROM pg_catalog.generate_series(1,100) id;", COORDINATOR_CONNECT_INDEX) != 0)
 		goto LABEL_ERR;
 
 	/*
 	 * start a transaction block because PARALLEL RETRIEVE CURSOR only support
 	 * WITHOUT HOLD option
 	 */
-	if (exec_sql_without_resultset(master_conn, "BEGIN;", MASTER_CONNECT_INDEX) != 0)
+	if (exec_sql_without_resultset(coordinator_conn, "BEGIN;", COORDINATOR_CONNECT_INDEX) != 0)
 		goto LABEL_ERR;
 
 	/* declare PARALLEL RETRIEVE CURSOR for this table */
-	if (exec_sql_without_resultset(master_conn, "DECLARE myportal PARALLEL RETRIEVE CURSOR FOR select * from public.tab_parallel_cursor;", MASTER_CONNECT_INDEX) != 0)
+	if (exec_sql_without_resultset(coordinator_conn, "DECLARE myportal PARALLEL RETRIEVE CURSOR FOR select * from public.tab_parallel_cursor;", COORDINATOR_CONNECT_INDEX) != 0)
 		goto LABEL_ERR;
 
 	/*
@@ -340,8 +340,8 @@ main(int argc, char **argv)
 	 */
 	const char *sql1 = "select hostname,port,auth_token,endpointname from pg_catalog.gp_get_endpoints() where cursorname='myportal';";
 
-	printf("\nExec SQL on Master:\n\t> %s\n", sql1);
-	res1 = PQexec(master_conn, sql1);
+	printf("\nExec SQL on Coordinator:\n\t> %s\n", sql1);
+	res1 = PQexec(coordinator_conn, sql1);
 	if (PQresultStatus(res1) != PGRES_TUPLES_OK)
 	{
 		fprintf(stderr, "Cannot find the endpoint for parallel retrieve cursor myportal\n");
@@ -394,10 +394,10 @@ main(int argc, char **argv)
 
 		/*
 		 * Run nowait mode monitor UDF to check the parallel retrieve cursor
-		 * status at specific time in master connection, so that if any error
+		 * status at specific time in coordinator connection, so that if any error
 		 * occurs, it will detect ASAP.
 		 */
-		if (exec_check_parallel_cursor(master_conn, 0))
+		if (exec_check_parallel_cursor(coordinator_conn, 0))
 		{
 			fprintf(stderr, "Error when checking the PARALLEL RETRIEVE CURSOR\n");
 			goto LABEL_ERR;
@@ -424,18 +424,18 @@ main(int argc, char **argv)
 	}
 
 	/* Check the status returns not finished */
-	if (!exec_check_parallel_cursor(master_conn, 1))
+	if (!exec_check_parallel_cursor(coordinator_conn, 1))
 	{
 		fprintf(stderr, "Error during check the PARALLEL RETRIEVE CURSOR\n");
 		goto LABEL_ERR;
 	}
 
 	/* close the cursor */
-	if (exec_sql_without_resultset(master_conn, "CLOSE myportal;", MASTER_CONNECT_INDEX) != 0)
+	if (exec_sql_without_resultset(coordinator_conn, "CLOSE myportal;", COORDINATOR_CONNECT_INDEX) != 0)
 		goto LABEL_ERR;
 
 	/* end the transaction */
-	if (exec_sql_without_resultset(master_conn, "END;", MASTER_CONNECT_INDEX) != 0)
+	if (exec_sql_without_resultset(coordinator_conn, "END;", COORDINATOR_CONNECT_INDEX) != 0)
 		goto LABEL_ERR;
 
 
@@ -448,7 +448,7 @@ LABEL_ERR:
 
 LABEL_FINISH:
 	/* close the connections to the database and cleanup */
-	finish_conn_nicely(master_conn, endpoint_conns, endpoint_conns_num);
+	finish_conn_nicely(coordinator_conn, endpoint_conns, endpoint_conns_num);
 
 	if (tokens)
 	{


### PR DESCRIPTION
These are gpdb-only commits that reduce the usage of the term "master" in our codebase.  The term "postmaster" has been left in, per guidance.

* 3ca0f590ed4ac85a969be0d7d1ba9e43d77b841a -- This commit removes "master" from our markdown files.  These are primarily for documentation.  Review should consider whether these changes harm understanding offered by the documentation.
* 62dfa1fc0355845d850479e8a1848dd9311828b6 -- This commit removes "master" from our python files.  This is a very small commit, and all of the changes are in comments.
* 4588371dfe55f83c0f8434511990b0f09dbdd7ce -- This commit removes "master" from our isolation2 test suite.  This is a large change, but should be semantically null from a test coverage perspective.  CI passing should be sufficient review, but it would be good to look through to confirm.  