### PR TITLE
Enabling JIT with Orca costing (7X)

### DIFF
--- a/src/backend/jit/jit.c
+++ b/src/backend/jit/jit.c
@@ -59,9 +59,9 @@ static bool file_exists(const char *name);
 Datum
 pg_jit_available(PG_FUNCTION_ARGS)
 {
-        if (((optimizer && optimizer_jit) || (!optimizer && jit_enabled)) && provider_init())
-                PG_RETURN_BOOL(true);
-        else  PG_RETURN_BOOL(false);
+	if (((optimizer && optimizer_jit) || (!optimizer && jit_enabled)) && provider_init())
+		PG_RETURN_BOOL(true);
+	else	PG_RETURN_BOOL(false);
 }
 
 
@@ -76,7 +76,7 @@ provider_init(void)
 	JitProviderInit init;
 
 	/* don't even try to load if not enabled */
-        if (!optimizer_jit && !jit_enabled)
+	if (!optimizer_jit && !jit_enabled)
 		return false;
 
 	/*

--- a/src/backend/jit/jit.c
+++ b/src/backend/jit/jit.c
@@ -59,9 +59,7 @@ static bool file_exists(const char *name);
 Datum
 pg_jit_available(PG_FUNCTION_ARGS)
 {
-	if (((optimizer && optimizer_jit) || (!optimizer && jit_enabled)) && provider_init())
-		PG_RETURN_BOOL(true);
-	else	PG_RETURN_BOOL(false);
+	PG_RETURN_BOOL(provider_init());
 }
 
 

--- a/src/backend/jit/jit.c
+++ b/src/backend/jit/jit.c
@@ -43,6 +43,7 @@ double		jit_above_cost = 100000;
 double		jit_inline_above_cost = 500000;
 double		jit_optimize_above_cost = 500000;
 
+extern bool	optimizer;
 static JitProviderCallbacks provider;
 static bool provider_successfully_loaded = false;
 static bool provider_failed_loading = false;
@@ -58,7 +59,9 @@ static bool file_exists(const char *name);
 Datum
 pg_jit_available(PG_FUNCTION_ARGS)
 {
-	PG_RETURN_BOOL(provider_init());
+        if (((optimizer && optimizer_jit) || (!optimizer && jit_enabled)) && provider_init())
+                PG_RETURN_BOOL(true);
+        else  PG_RETURN_BOOL(false);
 }
 
 
@@ -73,7 +76,7 @@ provider_init(void)
 	JitProviderInit init;
 
 	/* don't even try to load if not enabled */
-	if (!jit_enabled)
+        if (!optimizer_jit && !jit_enabled)
 		return false;
 
 	/*

--- a/src/backend/jit/jit.c
+++ b/src/backend/jit/jit.c
@@ -43,7 +43,6 @@ double		jit_above_cost = 100000;
 double		jit_inline_above_cost = 500000;
 double		jit_optimize_above_cost = 500000;
 
-extern bool	optimizer;
 static JitProviderCallbacks provider;
 static bool provider_successfully_loaded = false;
 static bool provider_failed_loading = false;
@@ -74,7 +73,7 @@ provider_init(void)
 	JitProviderInit init;
 
 	/* don't even try to load if not enabled */
-	if (!optimizer_jit && !jit_enabled)
+	if (!optimizer_jit_enabled && !jit_enabled)
 		return false;
 
 	/*

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -8632,7 +8632,7 @@ static void compute_jit_flags(PlannedStmt* pstmt, bool use_gporca)
 	{
 
 		/*
-		 * True means, we have to set values for ORCA
+		 * True means, we have to set values for ORCA.
 		 */
 		jit_on = optimizer_jit_enabled;
 		above_cost = optimizer_jit_above_cost;
@@ -8643,7 +8643,7 @@ static void compute_jit_flags(PlannedStmt* pstmt, bool use_gporca)
 	{
 
 		/*
-		 * False means, we have to set values for Planner
+		 * False means, we have to set values for Planner.
 		 */
 		jit_on = jit_enabled;
 		above_cost = jit_above_cost;

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -757,8 +757,8 @@ standard_planner(Query *parse, int cursorOptions, ParamListInfo boundParams)
 	result->stmt_len = parse->stmt_len;
 
 	/* GPDB: JIT flags are set in wrapper function */
-	/* False in the following call means we are setting Jit flags for planner  */
-	compute_jit_flags(result,false /* use_gporca */);
+	/* False in the following call means that we are setting Jit flags for planner */
+	compute_jit_flags(result, false /* use_gporca */);
 
 	if (glob->partition_directory != NULL)
 		DestroyPartitionDirectory(glob->partition_directory);

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -8610,7 +8610,7 @@ make_new_rollups_for_hash_grouping_set(PlannerInfo        *root,
  * (Planner cost usually higher), setting the JIT flags based on the
  * common JIT costing GUCs could lead to false triggering of JIT.
  *
- * To prevent this situation, separate Costing GUCs are created
+ * To prevent this situation, separate  costing GUCs are created
  * for Optimizer and used here for setting the JIT flags.
  *
  */
@@ -8634,7 +8634,7 @@ static void compute_jit_flags(PlannedStmt* pstmt, bool use_gporca)
 		/*
 		 * True means, we have to set values for ORCA
 		 */
-		jit_on = optimizer_jit;
+		jit_on = optimizer_jit_enabled;
 		above_cost = optimizer_jit_above_cost;
 		inline_above_cost = optimizer_jit_inline_above_cost;
 		optimize_above_cost = optimizer_jit_optimize_above_cost;

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -2966,17 +2966,16 @@ struct config_bool ConfigureNamesBool_gp[] =
 		false,
 		NULL, NULL, NULL
 	},
-        {
-            {"optimizer_jit", PGC_USERSET, QUERY_TUNING_OTHER,
-                gettext_noop("Allow Optimizer based JIT compilation."),
-                NULL,
-                GUC_EXPLAIN
-
-            },
-            &optimizer_jit,
-            false,
-            NULL, NULL, NULL
-        },
+	{
+		{"optimizer_jit", PGC_USERSET, QUERY_TUNING_OTHER,
+		 gettext_noop("Allow Optimizer based JIT compilation."),
+		 NULL,
+		 GUC_EXPLAIN
+		},
+		&optimizer_jit,
+		false,
+		NULL, NULL, NULL
+	},
 	{
 		{"gp_quicklz_fallback", PGC_SUSET, APPENDONLY_TABLES,
 		 gettext_noop("Fallback to valid compression type if quicklz table compression is requested."),
@@ -4350,36 +4349,36 @@ struct config_real ConfigureNamesReal_gp[] =
 		1.0, 0.0, DBL_MAX,
 		NULL, NULL, NULL
 	},
-        {
-            {"optimizer_jit_above_cost",PGC_USERSET, QUERY_TUNING_COST,
-             gettext_noop("Perform JIT compilation if query is more expensive."),
-             gettext_noop("-1 disables JIT compilation."),
-             GUC_EXPLAIN
-            },
-            &optimizer_jit_above_cost,
-            1000000, -1, DBL_MAX,
-            NULL, NULL, NULL
-        },
-        {
-            {"optimizer_jit_optimize_above_cost",PGC_USERSET, QUERY_TUNING_COST,
-             gettext_noop("Optimize JITed functions if query is more expensive."),
-             gettext_noop("-1 disables JIT optimization."),
-             GUC_EXPLAIN
-            },
-            &optimizer_jit_optimize_above_cost,
-            5000000, -1, DBL_MAX,
-            NULL, NULL, NULL
-        },
-        {
-            {"optimizer_jit_inline_above_cost",PGC_USERSET, QUERY_TUNING_COST,
-             gettext_noop("Perform JIT inlining if query is more expensive."),
-             gettext_noop("-1 disables inlining."),
-             GUC_EXPLAIN
-            },
-            &optimizer_jit_inline_above_cost,
-            5000000, -1, DBL_MAX,
-            NULL, NULL, NULL
-        },
+	{
+		{"optimizer_jit_above_cost",PGC_USERSET, QUERY_TUNING_COST,
+			gettext_noop("Perform JIT compilation if query is more expensive."),
+			gettext_noop("-1 disables JIT compilation."),
+			GUC_EXPLAIN
+		},
+		&optimizer_jit_above_cost,
+		1000000, -1, DBL_MAX,
+		NULL, NULL, NULL
+	},
+	{
+		{"optimizer_jit_optimize_above_cost",PGC_USERSET, QUERY_TUNING_COST,
+			gettext_noop("Optimize JITed functions if query is more expensive."),
+			gettext_noop("-1 disables JIT optimization."),
+			GUC_EXPLAIN
+		},
+		&optimizer_jit_optimize_above_cost,
+		5000000, -1, DBL_MAX,
+		NULL, NULL, NULL
+	},
+	{
+		{"optimizer_jit_inline_above_cost",PGC_USERSET, QUERY_TUNING_COST,
+			gettext_noop("Perform JIT inlining if query is more expensive."),
+			gettext_noop("-1 disables inlining."),
+			GUC_EXPLAIN
+		},
+		&optimizer_jit_inline_above_cost,
+		5000000, -1, DBL_MAX,
+		NULL, NULL, NULL
+	},
 
 	/* End-of-list marker */
 	{

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -435,7 +435,7 @@ bool		gp_log_endpoints = false;
 bool		gp_allow_date_field_width_5digits = false;
 
 /* GUCs for Just In Time (JIT) compilation */
-bool		optimizer_jit;
+bool		optimizer_jit_enabled;
 double		optimizer_jit_above_cost;
 double		optimizer_jit_inline_above_cost;
 double		optimizer_jit_optimize_above_cost;
@@ -2972,7 +2972,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		 NULL,
 		 GUC_EXPLAIN
 		},
-		&optimizer_jit,
+		&optimizer_jit_enabled,
 		false,
 		NULL, NULL, NULL
 	},

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -4356,7 +4356,7 @@ struct config_real ConfigureNamesReal_gp[] =
 			GUC_EXPLAIN
 		},
 		&optimizer_jit_above_cost,
-		1000000, -1, DBL_MAX,
+		7500, -1, DBL_MAX,
 		NULL, NULL, NULL
 	},
 	{
@@ -4366,7 +4366,7 @@ struct config_real ConfigureNamesReal_gp[] =
 			GUC_EXPLAIN
 		},
 		&optimizer_jit_optimize_above_cost,
-		5000000, -1, DBL_MAX,
+		37500, -1, DBL_MAX,
 		NULL, NULL, NULL
 	},
 	{
@@ -4376,7 +4376,7 @@ struct config_real ConfigureNamesReal_gp[] =
 			GUC_EXPLAIN
 		},
 		&optimizer_jit_inline_above_cost,
-		5000000, -1, DBL_MAX,
+		37500, -1, DBL_MAX,
 		NULL, NULL, NULL
 	},
 

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -434,6 +434,12 @@ bool		gp_log_endpoints = false;
 /* optional reject to  parse ambigous 5-digits date in YYYMMDD format */
 bool		gp_allow_date_field_width_5digits = false;
 
+/* GUCs for Just In Time (JIT) compilation */
+bool		optimizer_jit;
+double		optimizer_jit_above_cost;
+double		optimizer_jit_inline_above_cost;
+double		optimizer_jit_optimize_above_cost;
+
 static const struct config_enum_entry gp_log_format_options[] = {
 	{"text", 0},
 	{"csv", 1},
@@ -2960,6 +2966,17 @@ struct config_bool ConfigureNamesBool_gp[] =
 		false,
 		NULL, NULL, NULL
 	},
+        {
+            {"optimizer_jit", PGC_USERSET, QUERY_TUNING_OTHER,
+                gettext_noop("Allow Optimizer based JIT compilation."),
+                NULL,
+                GUC_EXPLAIN
+
+            },
+            &optimizer_jit,
+            false,
+            NULL, NULL, NULL
+        },
 	{
 		{"gp_quicklz_fallback", PGC_SUSET, APPENDONLY_TABLES,
 		 gettext_noop("Fallback to valid compression type if quicklz table compression is requested."),
@@ -4333,6 +4350,36 @@ struct config_real ConfigureNamesReal_gp[] =
 		1.0, 0.0, DBL_MAX,
 		NULL, NULL, NULL
 	},
+        {
+            {"optimizer_jit_above_cost",PGC_USERSET, QUERY_TUNING_COST,
+             gettext_noop("Perform JIT compilation if query is more expensive."),
+             gettext_noop("-1 disables JIT compilation."),
+             GUC_EXPLAIN
+            },
+            &optimizer_jit_above_cost,
+            1000000, -1, DBL_MAX,
+            NULL, NULL, NULL
+        },
+        {
+            {"optimizer_jit_optimize_above_cost",PGC_USERSET, QUERY_TUNING_COST,
+             gettext_noop("Optimize JITed functions if query is more expensive."),
+             gettext_noop("-1 disables JIT optimization."),
+             GUC_EXPLAIN
+            },
+            &optimizer_jit_optimize_above_cost,
+            5000000, -1, DBL_MAX,
+            NULL, NULL, NULL
+        },
+        {
+            {"optimizer_jit_inline_above_cost",PGC_USERSET, QUERY_TUNING_COST,
+             gettext_noop("Perform JIT inlining if query is more expensive."),
+             gettext_noop("-1 disables inlining."),
+             GUC_EXPLAIN
+            },
+            &optimizer_jit_inline_above_cost,
+            5000000, -1, DBL_MAX,
+            NULL, NULL, NULL
+        },
 
 	/* End-of-list marker */
 	{

--- a/src/include/jit/jit.h
+++ b/src/include/jit/jit.h
@@ -91,7 +91,7 @@ extern double jit_inline_above_cost;
 extern double jit_optimize_above_cost;
 
 /* Optimizer specific JIT GUCs */
-extern bool optimizer_jit;
+extern bool optimizer_jit_enabled;
 extern double optimizer_jit_above_cost;
 extern double optimizer_jit_inline_above_cost;
 extern double optimizer_jit_optimize_above_cost;

--- a/src/include/jit/jit.h
+++ b/src/include/jit/jit.h
@@ -90,6 +90,11 @@ extern double jit_above_cost;
 extern double jit_inline_above_cost;
 extern double jit_optimize_above_cost;
 
+/* Optimizer specific JIT GUCs */
+extern bool optimizer_jit;
+extern double optimizer_jit_above_cost;
+extern double optimizer_jit_inline_above_cost;
+extern double optimizer_jit_optimize_above_cost;
 
 extern void jit_reset_after_error(void);
 extern void jit_release_context(JitContext *context);

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -517,7 +517,7 @@ extern int	optimizer_plan_id;
 extern int	optimizer_samples_number;
 
 /* Optimizer Just In Time (JIT) compilation related GUCs*/
-extern  bool  optimizer_jit;
+extern  bool	optimizer_jit_enabled;
 extern  double  optimizer_jit_above_cost;
 extern  double  optimizer_jit_inline_above_cost;
 extern  double  optimizer_jit_optimize_above_cost;

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -516,6 +516,12 @@ extern bool optimizer_sample_plans;
 extern int	optimizer_plan_id;
 extern int	optimizer_samples_number;
 
+/* Optimizer Just In Time (JIT) compilation related GUCs*/
+extern  bool  optimizer_jit;
+extern  double  optimizer_jit_above_cost;
+extern  double  optimizer_jit_inline_above_cost;
+extern  double  optimizer_jit_optimize_above_cost;
+
 /* Cardinality estimation related GUCs used by the Optimizer */
 extern bool optimizer_extract_dxl_stats;
 extern bool optimizer_extract_dxl_stats_all_nodes;

--- a/src/include/utils/sync_guc_name.h
+++ b/src/include/utils/sync_guc_name.h
@@ -171,7 +171,3 @@
 		"wal_sender_timeout",
 		"work_mem",
 		"zero_damaged_pages",
-		"optimizer_jit",
-		"optimizer_jit_above_cost",
-		"optimizer_jit_inline_above_cost",
-		"optimizer_jit_optimize_above_cost",

--- a/src/include/utils/sync_guc_name.h
+++ b/src/include/utils/sync_guc_name.h
@@ -171,3 +171,7 @@
 		"wal_sender_timeout",
 		"work_mem",
 		"zero_damaged_pages",
+		"optimizer_jit",
+		"optimizer_jit_above_cost",
+		"optimizer_jit_inline_above_cost",
+		"optimizer_jit_optimize_above_cost",

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -557,3 +557,7 @@
 		"xmlbinary",
 		"xmloption",
 		"max_slot_wal_keep_size",
+		"optimizer_jit",
+		"optimizer_jit_above_cost",
+		"optimizer_jit_inline_above_cost",
+		"optimizer_jit_optimize_above_cost",

--- a/src/test/regress/expected/explain_format.out
+++ b/src/test/regress/expected/explain_format.out
@@ -693,6 +693,9 @@ INSERT INTO jit_explain_output SELECT generate_series(1,100);
 SET jit = on;
 SET jit_above_cost = 0;
 SET gp_explain_jit = on;
+-- ORCA GUCs to enable JIT
+set optimizer_jit to on;
+set optimizer_jit_above_cost to 1;
 -- explain_processing_off
 EXPLAIN SELECT * FROM jit_explain_output LIMIT 10;
 QUERY PLAN
@@ -894,6 +897,8 @@ QUERY PLAN
 RESET jit;
 RESET jit_above_cost;
 RESET gp_explain_jit;
+RESET optimizer_jit;
+RESET optimizer_jit_above_cost;
 -- Cleanup
 DROP TABLE boxes;
 DROP TABLE apples;

--- a/src/test/regress/expected/explain_format_optimizer.out
+++ b/src/test/regress/expected/explain_format_optimizer.out
@@ -644,6 +644,9 @@ INSERT INTO jit_explain_output SELECT generate_series(1,100);
 SET jit = on;
 SET jit_above_cost = 0;
 SET gp_explain_jit = on;
+-- ORCA GUCs to enable JIT
+set optimizer_jit to on;
+set optimizer_jit_above_cost to 1;
 -- explain_processing_off
 EXPLAIN SELECT * FROM jit_explain_output LIMIT 10;
 QUERY PLAN
@@ -809,6 +812,8 @@ QUERY PLAN
 RESET jit;
 RESET jit_above_cost;
 RESET gp_explain_jit;
+RESET optimizer_jit;
+RESET optimizer_jit_above_cost;
 -- Cleanup
 DROP TABLE boxes;
 DROP TABLE apples;

--- a/src/test/regress/sql/explain_format.sql
+++ b/src/test/regress/sql/explain_format.sql
@@ -158,6 +158,10 @@ SET jit = on;
 SET jit_above_cost = 0;
 SET gp_explain_jit = on;
 
+-- ORCA GUCs to enable JIT
+set optimizer_jit to on;
+set optimizer_jit_above_cost to 1;
+
 -- explain_processing_off
 EXPLAIN SELECT * FROM jit_explain_output LIMIT 10;
 -- explain_processing_on
@@ -209,6 +213,8 @@ EXPLAIN (ANALYZE, FORMAT json) SELECT * FROM jit_explain_output LIMIT 10;
 RESET jit;
 RESET jit_above_cost;
 RESET gp_explain_jit;
+RESET optimizer_jit;
+RESET optimizer_jit_above_cost;
 -- Cleanup
 DROP TABLE boxes;
 DROP TABLE apples;


### PR DESCRIPTION
Through this PR, we shall enable JIT using ORCA costing model. 

CODE CHANGES 

1. Adding new GUCs for ORCA

We are adding following GUCs for ORCA specifically for JIT compilation:

```
            1. optimizer_jit
            2. optimizer_jit_above_cost
            3. optimizer_jit_inline_above_cost
            4. optimizer_jit_optimize_above_cost
```

2. Including the logic so that, JIT flags can be set using ORCA specific JIT GUCs or Planner specific JIT GUCs.

JIT compilation is triggered based on the cost of a plan. Earlier, the cost of plan generated by ORCA/planner was compared with the following JIT specific costing GUCs (defined for planner):
```
            1.  jit_above_cost
            2.  jit_optimize_above_cost
            3.  jit_inline_above_cost
```

Based on the certain conditions, JIT flags were set in the planned statement. Thus, we did not have individual control for ORCA and planner, as there were common GUCs for them. 

Since the costing model of ORCA and Planner are different (Planner cost usually higher), setting the JIT flags based on the  common JIT costing GUCs could lead to false triggering of JIT. To prevent such situations and gain control over triggering of JIT compilation for ORCA/planner, separate Costing GUCs are created for ORCA.

3. Estimated and assigned default values to JIT GUCs for ORCA (credit : @khannaekta ).

<img width="379" alt="image" src="https://github.com/greenplum-db/gpdb/assets/99574850/0e6bf220-18c6-4e43-b685-10581605fb18">
