### PR TITLE
[Releng]Add without-asserts testing job to gp7 pr pipeline

### DIFF
--- a/concourse/pipelines/pr_pipeline.yml
+++ b/concourse/pipelines/pr_pipeline.yml
@@ -50,18 +50,21 @@ jobs:
 
   - put: gpdb_pr
     params:
+      base_context: compile_and_test_gpdb
       path: gpdb_pr
       status: pending
   - # "do" the remaining steps with these hooks:
     on_failure:
       put: gpdb_pr
       params:
+        base_context: compile_and_test_gpdb
         path: gpdb_pr
         status: failure
     on_success:
       put: report_pr_success
       resource: gpdb_pr
       params:
+        base_context: compile_and_test_gpdb
         path: gpdb_pr
         status: success
     do:
@@ -130,4 +133,85 @@ jobs:
         input_mapping:
           gpdb_src: gpdb_pr
         timeout: 1h
+
+- name: compile_and_test_gpdb_without_assert
+  public: true
+  max_in_flight: 10
+  plan:
+  - in_parallel:
+    - get: gpdb_pr
+      trigger: true
+      version: every
+    - get: gpdb7-rocky8-build
+    - get: gpdb7-rocky8-test
+
+  - put: gpdb_pr
+    params:
+      base_context: compile_and_test_gpdb_without_assert
+      path: gpdb_pr
+      status: pending
+  - # "do" the remaining steps with these hooks:
+    on_failure:
+      put: gpdb_pr
+      params:
+        base_context: compile_and_test_gpdb_without_assert
+        path: gpdb_pr
+        status: failure
+    on_success:
+      put: report_pr_success
+      resource: gpdb_pr
+      params:
+        base_context: compile_and_test_gpdb_without_assert
+        path: gpdb_pr
+        status: success
+    do:
+    - task: init gpdb_src  # Fetch tags and submodules, because the PR resource doesn't.
+      image: gpdb7-rocky8-build
+      config:
+        platform: linux
+        run:
+          path: bash
+          args:
+          - -c
+          - |
+            git clone gpdb_pr gpdb_src &&
+            cd gpdb_src &&
+            git fetch https://github.com/greenplum-db/gpdb.git --tags &&
+            git submodule update --init --recursive
+        inputs: [{ name: gpdb_pr }]
+        outputs: [{ name: gpdb_src }]
+    - task: compile_gpdb_rocky8
+      file: gpdb_pr/concourse/tasks/compile_gpdb.yml
+      image: gpdb7-rocky8-build
+      params:
+        CONFIGURE_FLAGS: "--disable-cassert --enable-tap-tests --enable-debug-extensions"
+        BLD_TARGETS: "clients loaders"
+      timeout: 30m
+
+    - in_parallel:
+      - task: icw_planner_rocky8
+        tags: [icw-worker]
+        file: gpdb_pr/concourse/tasks/ic_gpdb.yml
+        image: gpdb7-rocky8-test
+        input_mapping:
+          gpdb_src: gpdb_pr
+          bin_gpdb: gpdb_artifacts
+        params:
+          MAKE_TEST_COMMAND: PGOPTIONS='-c optimizer=off' installcheck-world
+          TEST_OS: centos
+          CONFIGURE_FLAGS: "--disable-cassert --enable-tap-tests"
+        timeout: 3h
+
+      - task: icw_gporca_rocky8
+        tags: [icw-worker]
+        file: gpdb_pr/concourse/tasks/ic_gpdb.yml
+        image: gpdb7-rocky8-test
+        input_mapping:
+          gpdb_src: gpdb_pr
+          bin_gpdb: gpdb_artifacts
+        params:
+          MAKE_TEST_COMMAND: PGOPTIONS='-c optimizer=on' installcheck-world
+          TEST_OS: centos
+          CONFIGURE_FLAGS: "--disable-cassert --enable-tap-tests"
+        timeout: 5h
 


### PR DESCRIPTION
This will add the job compile_and_test_gpdb_without_assert, it is the same with compile_and_test_gpdb, except the configure has option --disable-cassert, and do not run check_format, clang_tidy, unit_tests_gporca_rocky8
task in the job, since it is already exist in the job compile_and_test_gpdb

[GPR-1309]

Authored-by: Shaoqi Bai <bshaoqi@vmware.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
