### PR TITLE
Add a new lock for CDC

### DIFF
--- a/src/backend/storage/lmgr/lwlocknames.txt
+++ b/src/backend/storage/lmgr/lwlocknames.txt
@@ -66,3 +66,4 @@ ShareInputScanLock				56
 FTSReplicationStatusLock			57
 GxidBumpLock						58
 ParallelCursorEndpointLock			59
+TransactionStartLock			    60


### PR DESCRIPTION
To start CDC, we must create a scenario where no distributed transactions are running on the master.

We introduce a new lock called `transaction-start-lock`, placed at the beginning of the function `StartTransaction`.

We also implemented two functions named `gp_acquire_transaction_start_lock` and `gp_release_transaction_start_lock`, their implementation is simple:
```
Datum
gp_aquire_transaction_start_lock(PG_FUNCTION_ARGS)
{
	LWLockAcquire(TransactionStartLock, LW_EXCLUSIVE);
}

Datum
gp_release_transaction_start_lock(PG_FUNCTION_ARGS)
{
	LWLockRelease(TransactionStartLock);
}
```

We added these functions to GP using the `CREATE FUNCTION` command before launching CDC, so they are not shown in this PR.

Here is the timeline how we use the lock and the functions:
<img width="1357" alt="image-2023-4-17_18-42-0" src="https://user-images.githubusercontent.com/13758273/235019839-5f99a810-0775-49d8-b757-d6f332812d8c.png">
When cdc_controller sends `gp_acquire_transaction_start_lock` command to master, new incoming distributed transactions will be blocked afterwards. Then cdc_controller sends `gp_wait_running_transaction_end` to the master, when the command returns, there is no running distributed transaction on the master now, We can send `CREATE-REPLICATION-SLOT` commands to the master and segments, which can create distributed-transaction-consistent slots.

The figure below shows this process timeline. We assume that transaction-1 is the only distributed transaction running on the master, and it acquires the transaction-start-lock before the master receives the `gp_acquire_transaction_start_lock` command from the cdc_controller, so it will not be blocked. transaction-2 starts after master receives `gp_acquire_transaction_start_lock` command, so it will be blocked.

I'm writing the doc describing the details about these, the doc will be finshed in these few days.