### PR TITLE
(6x) Add missing nodes for function raw_expression_tree_walker().

### DIFF
--- a/src/backend/nodes/nodeFuncs.c
+++ b/src/backend/nodes/nodeFuncs.c
@@ -3583,6 +3583,14 @@ raw_expression_tree_walker(Node *node,
 			return walker(((WithClause *) node)->ctes, context);
 		case T_CommonTableExpr:
 			return walker(((CommonTableExpr *) node)->ctequery, context);
+		case T_GroupingFunc:
+			return walker(((GroupingFunc *) node)->args, context);
+		case T_GroupingClause:
+			return walker(((GroupingClause *) node)->groupsets, context);
+		case T_GroupId:
+			break;
+		case T_TableValueExpr:
+			return walker(((TableValueExpr *) node)->subquery, context);
 		default:
 			elog(ERROR, "unrecognized node type: %d",
 				 (int) nodeTag(node));

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -3101,7 +3101,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 			NULL
 		},
 		&gp_resource_group_bypass_catalog_query,
-		true, NULL, NULL
+		false, NULL, NULL
 	},
 
 	{

--- a/src/test/isolation2/expected/resgroup/resgroup_bypass_catalog.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_bypass_catalog.out
@@ -68,9 +68,41 @@ COMMIT
  1        
 (2 rows)
 
+-- test for Github Issue 15416
+-- following SQLs should not throw "unrecognized node type" error.
+create table t_15416(s int);
+CREATE
+-- test for T_GroupingFunc
+select count(), grouping(s) from t_15416 group by s;
+ count | grouping 
+-------+----------
+(0 rows)
+-- test for T_GroupingClause
+select 1 from pg_catalog.pg_class group by rollup(1);
+ ?column? 
+----------
+ 1        
+          
+(2 rows)
+-- test for T_TableValueExpr
+-- don't want spend time on create a UDF below, the below SQL
+-- should not throw  "unrecognized node type" error, this is the test point.
+select count(1) from anytable_out( table(select * from t_15416 scatter by s) );
+ERROR:  cannot display a value of type anytable  (seg0 slice1 127.0.1.1:6002 pid=1922087)
+-- test for T_GroupId
+select group_id() from t_15416;
+ ?column? 
+----------
+(0 rows)
+
 -- cleanup
 -- start_ignore
 DROP ROLE role_test_catalog;
+DROP
 DROP RESOURCE GROUP rg_test_catalog;
-DROP FUNCTION rg_test_udf;
+DROP
+DROP FUNCTION rg_test_udf();
+DROP
+DROP TABLE t_15416;
+DROP
 -- end_ignore

--- a/src/test/isolation2/input/resgroup/disable_resgroup.source
+++ b/src/test/isolation2/input/resgroup/disable_resgroup.source
@@ -6,6 +6,7 @@
 -- start_ignore
 ! gpconfig -r gp_resource_manager;
 ! gpconfig -r gp_resource_group_memory_limit;
+! gpconfig -r gp_resource_group_bypass_catalog_query;
 ! gpstop -rai;
 -- end_ignore
 

--- a/src/test/isolation2/input/resgroup/enable_resgroup.source
+++ b/src/test/isolation2/input/resgroup/enable_resgroup.source
@@ -46,6 +46,7 @@ $$;
 -- start_ignore
 ! gpconfig -c gp_resource_manager -v group;
 ! gpconfig -c gp_resource_group_cpu_limit -v 0.9;
+! gpconfig -c gp_resource_group_bypass_catalog_query -v on;
 ! gpconfig -c max_connections -v 250 -m 25;
 ! gpconfig -c runaway_detector_activation_percent -v 100;
 ! gpstop -rai;

--- a/src/test/isolation2/sql/resgroup/resgroup_bypass_catalog.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_bypass_catalog.sql
@@ -38,9 +38,24 @@ RETURNS integer AS $$ SELECT 1; $$ LANGUAGE SQL;
 5: COMMIT;
 6<:
 
+-- test for Github Issue 15416
+-- following SQLs should not throw "unrecognized node type" error.
+create table t_15416(s int);
+-- test for T_GroupingFunc
+select count(), grouping(s) from t_15416 group by s;
+-- test for T_GroupingClause
+select 1 from pg_catalog.pg_class group by rollup(1);
+-- test for T_TableValueExpr
+-- don't want spend time on create a UDF below, the below SQL
+-- should not throw  "unrecognized node type" error, this is the test point.
+select count(1) from anytable_out( table(select * from t_15416 scatter by s) );
+-- test for T_GroupId
+select group_id() from t_15416;
+
 -- cleanup
 -- start_ignore
 DROP ROLE role_test_catalog;
 DROP RESOURCE GROUP rg_test_catalog;
-DROP FUNCTION rg_test_udf;
+DROP FUNCTION rg_test_udf();
+DROP TABLE t_15416;
 -- end_ignore


### PR DESCRIPTION
Per the comments of raw_expression_tree_walker():

  > Currently, the node type coverage extends to SelectStmt and everything
  > that could appear under it, but not other statement types.

There are some node types introduced by Greenplum and do not put in raw_expression_tree_walker:

  * T_GroupingFunc
  * T_TableValueExpr
  * T_GroupingClause
  * T_CaseWhen
  * T_GroupId
  * T_Value

I get the above list using:

  1. hack the code to log node tag value for SelectStmt during parsing
  2. run the full test with the hack code
  3. go to log to fetch all node tag value for SelectStmt
  4. See what is missing in raw_expression_tree_walker()

No need to consider T_CaseWhen because it is substruct of T_Case which is already handled.

No need to consider T_Value because it will always be changed to other type.

See Github Issue https://github.com/greenplum-db/gpdb/issues/15416
