### PR TITLE
Remove some dead code in memtuple.c

### DIFF
--- a/src/include/access/memtup.h
+++ b/src/include/access/memtup.h
@@ -39,10 +39,7 @@ typedef struct MemTupleBindingCols
 {
 	uint32 var_start; 	/* varlen fields start */
 	MemTupleAttrBinding *bindings; /* bindings for attrs (cols) */
-	short *null_saves;				/* saved space from each attribute when null */
-	short *null_saves_aligned;		/* saved space from each attribute when null - uses aligned length */
-	bool has_null_saves_alignment_mismatch;		/* true if one or more attributes has mismatching alignment and length  */
-	bool has_dropped_attr_alignment_mismatch;	/* true if one or more dropped attributes has mismatching alignment and length */
+	short *null_saves;		/* saved space from each attribute when null - uses aligned length */
 } MemTupleBindingCols;
 
 typedef struct MemTupleBinding
@@ -79,11 +76,6 @@ static inline bool is_len_memtuplen(uint32 len)
 static inline bool memtuple_lead_bit_set(MemTuple tup)
 {
 	return (tup->PRIVATE_mt_len & MEMTUP_LEAD_BIT) != 0;
-}
-static inline uint32 memtuple_size_from_uint32(uint32 len)
-{
-	Assert ((len & MEMTUP_LEAD_BIT) != 0);
-	return len & MEMTUP_LEN_MASK;
 }
 static inline uint32 memtuple_get_size(MemTuple mtup)
 {


### PR DESCRIPTION
The main change is to remove the code that handles of the old nul_saves array which is no longer used. And use the name "null_saves" to indicate the new/existing format (which was "null_saves_aligned"). Some archaeology:

* The original code was added in 1a80ef70aa19 to support old format.
* Later, in 53210fb2a848962155c5d57b69e367fd7fa27ed5 the support was reduced to read-only. All new memtuples were new format since then.
* In f6c74df57e7e9dcb26f3c58b7d3871d0d2e7f717, even the upgrade support was removed. The old format-related code should be completely irrelevant to 7X now.

Also made two smaller changes:
1. memtuple_size_from_uint32 not used anywhere. Removed.
2. memtuple_get_nullp doesn’t need to pass pbind. Reduced.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
