### PR TITLE
Remove non-default collation fixme

### DIFF
--- a/src/test/regress/expected/select_parallel_optimizer.out
+++ b/src/test/regress/expected/select_parallel_optimizer.out
@@ -228,9 +228,6 @@ select sp_parallel_restricted(unique1) from tenk1
  Settings: optimizer=on, parallel_setup_cost=0, parallel_tuple_cost=0
 (11 rows)
 
--- start_ignore
--- GPDB_12_MERGE_FIXME: None default collation fallback
--- end_ignore
 -- test parallel plan when group by expression is in target list.
 explain (costs off)
 	select length(stringu1) from tenk1 group by length(stringu1);


### PR DESCRIPTION
Non-default collation fallbacks is a known issue that will be addressed in the future, but isn't specific to the PG12 merge. Remove this FIXME as it's not a blocker.
