### PR TITLE
FIX BUG: skip transforming volatile EC with sortref in cdbpathlocus_from_subquery (7X)

### DIFF
--- a/src/backend/cdb/cdbpathlocus.c
+++ b/src/backend/cdb/cdbpathlocus.c
@@ -485,6 +485,19 @@ cdbpathlocus_from_subquery(struct PlannerInfo *root,
 				EquivalenceClass *sub_ec = (EquivalenceClass *) lfirst(ec_cell);
 				EquivalenceClass *outer_ec;
 
+				/*
+				 * Since the results of volatile functions are unpredictable, 
+				 * an EquivalenceClass containing volatile functions should not 
+				 * be considered for pull-up optimization.
+				 */
+				if (sub_ec->ec_has_volatile)
+				{
+					if (sub_ec->ec_sortref != 0)
+						continue;
+					else
+						elog(ERROR, "volatile EquivalenceClass has no sortref");
+				}
+
 				outer_ec = cdb_pull_up_eclass(root,
 											  sub_ec,
 											  rel->relids,

--- a/src/backend/optimizer/path/pathkeys.c
+++ b/src/backend/optimizer/path/pathkeys.c
@@ -1504,6 +1504,9 @@ cdb_pull_up_eclass(PlannerInfo *root,
 	Assert(!newvarlist ||
 		   list_length(newvarlist) == list_length(targetlist));
 
+	if (eclass->ec_has_volatile && eclass->ec_sortref != 0)
+		return NULL;
+
 	/* Find an expr that we can rewrite to use the projected columns. */
 	sub_distkeyexpr = cdbpullup_findEclassInTargetList(eclass, targetlist, InvalidOid);
 

--- a/src/backend/optimizer/path/pathkeys.c
+++ b/src/backend/optimizer/path/pathkeys.c
@@ -1504,9 +1504,6 @@ cdb_pull_up_eclass(PlannerInfo *root,
 	Assert(!newvarlist ||
 		   list_length(newvarlist) == list_length(targetlist));
 
-	if (eclass->ec_has_volatile && eclass->ec_sortref != 0)
-		return NULL;
-
 	/* Find an expr that we can rewrite to use the projected columns. */
 	sub_distkeyexpr = cdbpullup_findEclassInTargetList(eclass, targetlist, InvalidOid);
 

--- a/src/test/regress/expected/equivclass.out
+++ b/src/test/regress/expected/equivclass.out
@@ -522,3 +522,16 @@ explain (costs off)  -- this should not require a sort
  Optimizer: Postgres query optimizer
 (4 rows)
 
+-- please refer to https://github.com/greenplum-db/gpdb/issues/15079 
+CREATE TABLE IF NOT EXISTS issue_15079(c0 REAL , c1 boolean );
+SELECT BOOL_OR(issue_15079.c1) FROM issue_15079 GROUP BY random();
+ bool_or 
+---------
+(0 rows)
+
+SELECT * FROM (SELECT BOOL_OR(issue_15079.c1) FROM issue_15079 GROUP BY random()) as result;
+ bool_or 
+---------
+(0 rows)
+
+DROP TABLE issue_15079;

--- a/src/test/regress/expected/equivclass_optimizer.out
+++ b/src/test/regress/expected/equivclass_optimizer.out
@@ -513,3 +513,16 @@ explain (costs off)  -- this should not require a sort
  Optimizer: Postgres query optimizer
 (4 rows)
 
+-- please refer to https://github.com/greenplum-db/gpdb/issues/15079 
+CREATE TABLE IF NOT EXISTS issue_15079(c0 REAL , c1 boolean );
+SELECT BOOL_OR(issue_15079.c1) FROM issue_15079 GROUP BY random();
+ bool_or 
+---------
+(0 rows)
+
+SELECT * FROM (SELECT BOOL_OR(issue_15079.c1) FROM issue_15079 GROUP BY random()) as result;
+ bool_or 
+---------
+(0 rows)
+
+DROP TABLE issue_15079;

--- a/src/test/regress/sql/equivclass.sql
+++ b/src/test/regress/sql/equivclass.sql
@@ -269,3 +269,9 @@ create temp view overview as
   select f1::information_schema.sql_identifier as sqli, f2 from undername;
 explain (costs off)  -- this should not require a sort
   select * from overview where sqli = 'foo' order by sqli;
+
+-- please refer to https://github.com/greenplum-db/gpdb/issues/15079 
+CREATE TABLE IF NOT EXISTS issue_15079(c0 REAL , c1 boolean );
+SELECT BOOL_OR(issue_15079.c1) FROM issue_15079 GROUP BY random();
+SELECT * FROM (SELECT BOOL_OR(issue_15079.c1) FROM issue_15079 GROUP BY random()) as result;
+DROP TABLE issue_15079;


### PR DESCRIPTION
**Long log:**
This commit can fix bug reported in [issue 15079](https://github.com/greenplum-db/gpdb/issues/15079)

Since the results of volatile functions are unpredictable, an EquivalenceClass (**EC**) containing volatile functions can only be applied as a single information carrier. It should not used to derive new constraints or join conditions. In this case, it should not be considered for pull-up optimization and key expr transformer, peculiarly.
Let's consider it in two conditions:
- **1st**: ec_has_volatile=true && ec_sortref=0
Error out directly, _volatile EquivalenceClass has no sortref_
- **2nd**: ec_has_volatile=true && ec_sortref! =0
skip pull-up and continue in function _cdbpathlocus_from_subquery()_

**Signed-off-by:** Yongtao Huang <yongtaoh@vmware.com>