### PR TITLE
Update python version in build script used by ORCA

### DIFF
--- a/concourse/scripts/build_gpdb.py
+++ b/concourse/scripts/build_gpdb.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/python3
 
 import glob
 import optparse


### PR DESCRIPTION
GPDB 7X uses python3. 7X explain pipeline broke for failing to locate python interpreter.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
