### PR TITLE
FIX BUG: gpcheckcat owner with AO return wrong results (7X)

### DIFF
--- a/gpMgmt/bin/gpcheckcat
+++ b/gpMgmt/bin/gpcheckcat
@@ -1065,14 +1065,16 @@ def checkOwners():
     #    to pg_appendonly.
     db = connect2(GV.cfg[GV.coordinator_dbid], utilityMode=False)
     qry = '''
-    select distinct n.nspname, r.relname as relname,
+    select distinct n.nspname, coalesce(o.relname, c.relname) as relname,
                     a.rolname, m.rolname as coordinator_rolname
     from gp_dist_random('pg_class') r
       join pg_class c on (c.oid = r.oid)
       left join pg_index i on (c.oid = i.indexrelid)
       left join pg_appendonly ao on (c.oid = ao.segrelid or
                                      c.oid = ao.blkdirrelid or
-                                     i.indrelid = ao.blkdirrelid)
+                                     c.oid = ao.visimaprelid or
+                                     i.indrelid = ao.blkdirrelid or
+                                     i.indrelid = ao.visimaprelid)
       left join pg_class o on (o.oid = ao.relid or
                                o.reltoastrelid = c.oid)
       join pg_authid a on (a.oid = r.relowner)

--- a/gpMgmt/bin/gpcheckcat
+++ b/gpMgmt/bin/gpcheckcat
@@ -1065,7 +1065,7 @@ def checkOwners():
     #    to pg_appendonly.
     db = connect2(GV.cfg[GV.coordinator_dbid], utilityMode=False)
     qry = '''
-    select distinct n.nspname, coalesce(r.relname, o.relname) as relname,
+    select distinct n.nspname, r.relname as relname,
                     a.rolname, m.rolname as coordinator_rolname
     from gp_dist_random('pg_class') r
       join pg_class c on (c.oid = r.oid)

--- a/gpMgmt/bin/gpcheckcat
+++ b/gpMgmt/bin/gpcheckcat
@@ -1065,7 +1065,7 @@ def checkOwners():
     #    to pg_appendonly.
     db = connect2(GV.cfg[GV.coordinator_dbid], utilityMode=False)
     qry = '''
-    select distinct n.nspname, coalesce(o.relname, c.relname) as relname,
+    select distinct n.nspname, coalesce(r.relname, o.relname) as relname,
                     a.rolname, m.rolname as coordinator_rolname
     from gp_dist_random('pg_class') r
       join pg_class c on (c.oid = r.oid)


### PR DESCRIPTION
**Long log:**

This commit can fix bug reported in [issue 15104](https://github.com/greenplum-db/gpdb/issues/15104)
If we do` gpcheckcat -R owner postgres`, it can identify the 
- AO table/index; 
- aovisimap table/index;

In fact, we don't need to identify `aovisimap table/index`.
So we rewrite the SQL query in function `checkOwners()`.

Signed-off-by: Yongtao Huang <yongtaoh@vmware.com>
Co-authored-by: Huansong Fu <fhuansong@vmware.com>
Co-authored-by: Xing Guo <guxing@vmware.com>