### PR TITLE
Fix wrong results by ORCA when NULL TEST on LOJ

### DIFF
--- a/src/backend/gporca/data/dxl/minidump/LOJ-With-Single-Pred-On-Outer.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-With-Single-Pred-On-Outer.mdp
@@ -1,0 +1,395 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Comment><![CDATA[
+            Objective: LOJ with single predicate uses columns of outer child only
+            CREATE TABLE t1 (a int, b int, c int not null);
+            CREATE TABLE t2 (a int not null, b int);
+            explain select t1.* from t1 left outer join t2 on t1.b=1;
+                                                        QUERY PLAN
+            ---------------------------------------------------------------------------------------------------
+             Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1324032.10 rows=1 width=12)
+               ->  Nested Loop Left Join  (cost=0.00..1324032.10 rows=1 width=12)
+                     Join Filter: (t1.b = 1)
+                     ->  Seq Scan on t1  (cost=0.00..431.00 rows=1 width=12)
+                     ->  Materialize  (cost=0.00..431.00 rows=1 width=1)
+                           ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
+                                 ->  Seq Scan on t2  (cost=0.00..431.00 rows=1 width=1)
+             Optimizer: Pivotal Optimizer (GPORCA)
+            (8 rows)
+  ]]>
+  </dxl:Comment>
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="20" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0" SkewFactor="0"/>
+      <dxl:TraceFlags Value="101013,102001,102002,102003,102043,102074,102120,102144,103001,103014,103022,103026,103027,103029,103033,103038,103040,104002,104003,104004,104005,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:PartOpfamily Mdid="0.424.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:PartOpfamily Mdid="0.1976.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:PartOpfamily Mdid="0.1989.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2134.1.0"/>
+        <dxl:MaxAgg Mdid="0.2118.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.2227.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:PartOpfamily Mdid="0.2789.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.3315.1.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:RelationExtendedStatistics Mdid="10.27647.1.0" Name="t2"/>
+      <dxl:RelationExtendedStatistics Mdid="10.27644.1.0" Name="t1"/>
+      <dxl:ColumnStatistics Mdid="1.27647.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:RelationStatistics Mdid="2.27647.1.0" Name="t2" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
+      <dxl:Relation Mdid="6.27647.1.0" Name="t2" IsTemporary="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:RelationStatistics Mdid="2.27644.1.0" Name="t1" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
+      <dxl:Relation Mdid="6.27644.1.0" Name="t1" IsTemporary="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:MDCast Mdid="3.23.1.0;23.1.0" Name="int4" BinaryCoercible="true" SourceTypeId="0.23.1.0" DestinationTypeId="0.23.1.0" CastFuncId="0.0.0.0" CoercePathType="1"/>
+      <dxl:ColumnStatistics Mdid="1.27644.1.0.1" Name="b" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.27644.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.65.1.0"/>
+        <dxl:Commutator Mdid="0.96.1.0"/>
+        <dxl:InverseOp Mdid="0.518.1.0"/>
+        <dxl:HashOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7100.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.1977.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.7100.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="3" ColName="c" TypeMdid="0.23.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalJoin JoinType="Left">
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="6.27644.1.0" TableName="t1" LockMode="1">
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="3" Attno="3" ColName="c" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="4" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="5" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="9" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="10" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="6.27647.1.0" TableName="t2" LockMode="1">
+            <dxl:Columns>
+              <dxl:Column ColId="11" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="12" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="14" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="15" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="16" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="17" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="18" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="19" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+          <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+          <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+        </dxl:Comparison>
+      </dxl:LogicalJoin>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="1">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="1324032.101215" Rows="1.000000" Width="12"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="0" Alias="a">
+            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="1" Alias="b">
+            <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="2" Alias="c">
+            <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:SortingColumnList/>
+        <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="1324032.101171" Rows="1.000000" Width="12"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="0" Alias="a">
+              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="1" Alias="b">
+              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="2" Alias="c">
+              <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:JoinFilter>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+            </dxl:Comparison>
+          </dxl:JoinFilter>
+          <dxl:TableScan>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.000008" Rows="1.000000" Width="12"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="0" Alias="a">
+                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="1" Alias="b">
+                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="2" Alias="c">
+                <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:TableDescriptor Mdid="6.27644.1.0" TableName="t1" LockMode="1">
+              <dxl:Columns>
+                <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="2" Attno="3" ColName="c" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="4" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="5" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="6" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="7" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="8" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="9" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
+          <dxl:Materialize Eager="false">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.000026" Rows="3.000000" Width="1"/>
+            </dxl:Properties>
+            <dxl:ProjList/>
+            <dxl:Filter/>
+            <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.000025" Rows="3.000000" Width="1"/>
+              </dxl:Properties>
+              <dxl:ProjList/>
+              <dxl:Filter/>
+              <dxl:SortingColumnList/>
+              <dxl:TableScan>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000007" Rows="1.000000" Width="1"/>
+                </dxl:Properties>
+                <dxl:ProjList/>
+                <dxl:Filter/>
+                <dxl:TableDescriptor Mdid="6.27647.1.0" TableName="t2" LockMode="1">
+                  <dxl:Columns>
+                    <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="12" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                    <dxl:Column ColId="13" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="14" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="15" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="16" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="17" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="18" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:TableScan>
+            </dxl:BroadcastMotion>
+          </dxl:Materialize>
+        </dxl:NestedLoopJoin>
+      </dxl:GatherMotion>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/LOJ-With-Single-Pred-On-Outer.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-With-Single-Pred-On-Outer.mdp
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
-  <dxl:Comment><![CDATA[
+<dxl:Comment><![CDATA[
             Objective: LOJ with single predicate uses columns of outer child only
             CREATE TABLE t1 (a int, b int, c int not null);
             CREATE TABLE t2 (a int not null, b int);
@@ -29,14 +29,13 @@
           <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
         </dxl:CostParams>
       </dxl:CostModelConfig>
-      <dxl:Hint JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="20" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0" SkewFactor="0"/>
-      <dxl:TraceFlags Value="101013,102001,102002,102003,102043,102074,102120,102144,103001,103014,103022,103026,103027,103029,103033,103038,103040,104002,104003,104004,104005,106000"/>
+      <dxl:Hint JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0" SkewFactor="0"/>
+      <dxl:TraceFlags Value="101013,102074,102120,102146,102155,102156,103001,103014,103022,103027,103029,103038,103041,104002,104003,104004,104005,106000"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
       <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
         <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
         <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
-        <dxl:PartOpfamily Mdid="0.424.1.0"/>
         <dxl:EqualityOp Mdid="0.91.1.0"/>
         <dxl:InequalityOp Mdid="0.85.1.0"/>
         <dxl:LessThanOp Mdid="0.58.1.0"/>
@@ -54,7 +53,6 @@
       <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
         <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
         <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
-        <dxl:PartOpfamily Mdid="0.1976.1.0"/>
         <dxl:EqualityOp Mdid="0.96.1.0"/>
         <dxl:InequalityOp Mdid="0.518.1.0"/>
         <dxl:LessThanOp Mdid="0.97.1.0"/>
@@ -72,7 +70,6 @@
       <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
         <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
         <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
-        <dxl:PartOpfamily Mdid="0.1989.1.0"/>
         <dxl:EqualityOp Mdid="0.607.1.0"/>
         <dxl:InequalityOp Mdid="0.608.1.0"/>
         <dxl:LessThanOp Mdid="0.609.1.0"/>
@@ -88,9 +85,8 @@
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
       <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
-        <dxl:DistrOpfamily Mdid="0.2227.1.0"/>
+        <dxl:DistrOpfamily Mdid="0.7077.1.0"/>
         <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
-        <dxl:PartOpfamily Mdid="0.2789.1.0"/>
         <dxl:EqualityOp Mdid="0.387.1.0"/>
         <dxl:InequalityOp Mdid="0.402.1.0"/>
         <dxl:LessThanOp Mdid="0.2799.1.0"/>
@@ -105,6 +101,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.82160.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
         <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
         <dxl:EqualityOp Mdid="0.385.1.0"/>
@@ -124,7 +121,7 @@
       <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
         <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
         <dxl:EqualityOp Mdid="0.352.1.0"/>
-        <dxl:InequalityOp Mdid="0.3315.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
         <dxl:LessThanOp Mdid="0.0.0.0"/>
         <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
         <dxl:GreaterThanOp Mdid="0.0.0.0"/>
@@ -137,11 +134,8 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:RelationExtendedStatistics Mdid="10.27647.1.0" Name="t2"/>
-      <dxl:RelationExtendedStatistics Mdid="10.27644.1.0" Name="t1"/>
-      <dxl:ColumnStatistics Mdid="1.27647.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:RelationStatistics Mdid="2.27647.1.0" Name="t2" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
-      <dxl:Relation Mdid="6.27647.1.0" Name="t2" IsTemporary="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2">
+      <dxl:RelationStatistics Mdid="2.82160.1.0" Name="t2" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
+      <dxl:Relation Mdid="6.82160.1.0" Name="t2" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2" NumberLeafPartitions="0">
         <dxl:Columns>
           <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
             <dxl:DefaultValue/>
@@ -152,33 +146,35 @@
           <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
             <dxl:DefaultValue/>
           </dxl:Column>
-          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
             <dxl:DefaultValue/>
           </dxl:Column>
-          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
             <dxl:DefaultValue/>
           </dxl:Column>
-          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
             <dxl:DefaultValue/>
           </dxl:Column>
-          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
             <dxl:DefaultValue/>
           </dxl:Column>
-          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
             <dxl:DefaultValue/>
           </dxl:Column>
-          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
             <dxl:DefaultValue/>
           </dxl:Column>
         </dxl:Columns>
         <dxl:IndexInfoList/>
+        <dxl:Triggers/>
         <dxl:CheckConstraints/>
         <dxl:DistrOpfamilies>
           <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
         </dxl:DistrOpfamilies>
       </dxl:Relation>
-      <dxl:RelationStatistics Mdid="2.27644.1.0" Name="t1" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
-      <dxl:Relation Mdid="6.27644.1.0" Name="t1" IsTemporary="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3">
+      <dxl:MDCast Mdid="3.23.1.0;23.1.0" Name="int4" BinaryCoercible="true" SourceTypeId="0.23.1.0" DestinationTypeId="0.23.1.0" CastFuncId="0.0.0.0" CoercePathType="0"/>
+      <dxl:RelationStatistics Mdid="2.82157.1.0" Name="t1" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
+      <dxl:Relation Mdid="6.82157.1.0" Name="t1" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
         <dxl:Columns>
           <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
             <dxl:DefaultValue/>
@@ -192,34 +188,32 @@
           <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
             <dxl:DefaultValue/>
           </dxl:Column>
-          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
             <dxl:DefaultValue/>
           </dxl:Column>
-          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
             <dxl:DefaultValue/>
           </dxl:Column>
-          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
             <dxl:DefaultValue/>
           </dxl:Column>
-          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
             <dxl:DefaultValue/>
           </dxl:Column>
-          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
             <dxl:DefaultValue/>
           </dxl:Column>
-          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
             <dxl:DefaultValue/>
           </dxl:Column>
         </dxl:Columns>
         <dxl:IndexInfoList/>
+        <dxl:Triggers/>
         <dxl:CheckConstraints/>
         <dxl:DistrOpfamilies>
           <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
         </dxl:DistrOpfamilies>
       </dxl:Relation>
-      <dxl:MDCast Mdid="3.23.1.0;23.1.0" Name="int4" BinaryCoercible="true" SourceTypeId="0.23.1.0" DestinationTypeId="0.23.1.0" CastFuncId="0.0.0.0" CoercePathType="1"/>
-      <dxl:ColumnStatistics Mdid="1.27644.1.0.1" Name="b" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:ColumnStatistics Mdid="1.27644.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
         <dxl:LeftType Mdid="0.23.1.0"/>
         <dxl:RightType Mdid="0.23.1.0"/>
@@ -232,11 +226,12 @@
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1977.1.0"/>
-          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.7027.1.0"/>
           <dxl:Opfamily Mdid="0.7100.1.0"/>
-          <dxl:Opfamily Mdid="0.10009.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
+      <dxl:ColumnStatistics Mdid="1.82157.1.0.1" Name="b" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.82157.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
     </dxl:Metadata>
     <dxl:Query>
       <dxl:OutputColumns>
@@ -247,33 +242,33 @@
       <dxl:CTEList/>
       <dxl:LogicalJoin JoinType="Left">
         <dxl:LogicalGet>
-          <dxl:TableDescriptor Mdid="6.27644.1.0" TableName="t1" LockMode="1">
+          <dxl:TableDescriptor Mdid="6.82157.1.0" TableName="t1">
             <dxl:Columns>
               <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
               <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
               <dxl:Column ColId="3" Attno="3" ColName="c" TypeMdid="0.23.1.0" ColWidth="4"/>
               <dxl:Column ColId="4" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-              <dxl:Column ColId="5" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-              <dxl:Column ColId="6" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-              <dxl:Column ColId="7" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-              <dxl:Column ColId="8" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-              <dxl:Column ColId="9" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-              <dxl:Column ColId="10" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="5" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="9" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="10" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
             </dxl:Columns>
           </dxl:TableDescriptor>
         </dxl:LogicalGet>
         <dxl:LogicalGet>
-          <dxl:TableDescriptor Mdid="6.27647.1.0" TableName="t2" LockMode="1">
+          <dxl:TableDescriptor Mdid="6.82160.1.0" TableName="t2">
             <dxl:Columns>
               <dxl:Column ColId="11" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
               <dxl:Column ColId="12" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
               <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-              <dxl:Column ColId="14" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-              <dxl:Column ColId="15" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-              <dxl:Column ColId="16" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-              <dxl:Column ColId="17" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-              <dxl:Column ColId="18" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-              <dxl:Column ColId="19" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="14" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="15" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="16" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="17" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="18" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="19" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
             </dxl:Columns>
           </dxl:TableDescriptor>
         </dxl:LogicalGet>
@@ -339,18 +334,18 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:TableDescriptor Mdid="6.27644.1.0" TableName="t1" LockMode="1">
+            <dxl:TableDescriptor Mdid="6.82157.1.0" TableName="t1">
               <dxl:Columns>
                 <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
                 <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
                 <dxl:Column ColId="2" Attno="3" ColName="c" TypeMdid="0.23.1.0" ColWidth="4"/>
                 <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                <dxl:Column ColId="4" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                <dxl:Column ColId="5" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                <dxl:Column ColId="6" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                <dxl:Column ColId="7" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                <dxl:Column ColId="8" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                <dxl:Column ColId="9" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
               </dxl:Columns>
             </dxl:TableDescriptor>
           </dxl:TableScan>
@@ -373,16 +368,16 @@
                 </dxl:Properties>
                 <dxl:ProjList/>
                 <dxl:Filter/>
-                <dxl:TableDescriptor Mdid="6.27647.1.0" TableName="t2" LockMode="1">
+                <dxl:TableDescriptor Mdid="6.82160.1.0" TableName="t2">
                   <dxl:Columns>
                     <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
                     <dxl:Column ColId="12" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                    <dxl:Column ColId="13" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="14" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="15" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="16" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="17" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="18" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="13" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="14" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="15" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="16" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="17" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="18" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
                   </dxl:Columns>
                 </dxl:TableDescriptor>
               </dxl:TableScan>

--- a/src/backend/gporca/data/dxl/minidump/LOJ_NULLTEST-On-SelfCheck-Pred.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ_NULLTEST-On-SelfCheck-Pred.mdp
@@ -1,0 +1,434 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Comment><![CDATA[
+            Objective: LOJ with null-filtering on self check conditions
+            CREATE TABLE t1 (a int, b int, c int not null);
+            CREATE TABLE t2 (a int not null, b int);
+            explain select t1.c FROM t1 LEFT OUTER JOIN t2 ON t2.b > t2.a WHERE t2.a = t2.a IS NULL;
+                                                           QUERY PLAN
+            ---------------------------------------------------------------------------------------------------------
+             Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1324032.36 rows=1 width=4)
+               ->  Result  (cost=0.00..1324032.36 rows=1 width=4)
+                     Filter: ((t2.a = t2.a) IS NULL)
+                     ->  Nested Loop Left Join  (cost=0.00..1324032.36 rows=1 width=8)
+                           Join Filter: true
+                           ->  Seq Scan on t1  (cost=0.00..431.00 rows=1 width=4)
+                           ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
+                                 ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                                       ->  Seq Scan on t2  (cost=0.00..431.00 rows=1 width=4)
+                                             Filter: (b > a)
+             Optimizer: Pivotal Optimizer (GPORCA)
+            (11 rows)
+  ]]>
+  </dxl:Comment>
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="20" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0" SkewFactor="0"/>
+      <dxl:TraceFlags Value="101013,102001,102002,102003,102043,102074,102120,102144,103001,103014,103022,103026,103027,103029,103033,103038,103040,104002,104003,104004,104005,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:GPDBScalarOp Mdid="0.521.1.0" Name="&gt;" ComparisonType="GT" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.147.1.0"/>
+        <dxl:Commutator Mdid="0.97.1.0"/>
+        <dxl:InverseOp Mdid="0.523.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:PartOpfamily Mdid="0.424.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:PartOpfamily Mdid="0.1976.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:PartOpfamily Mdid="0.1989.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2134.1.0"/>
+        <dxl:MaxAgg Mdid="0.2118.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.2227.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:PartOpfamily Mdid="0.2789.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.3315.1.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:RelationExtendedStatistics Mdid="10.27647.1.0" Name="t2"/>
+      <dxl:RelationExtendedStatistics Mdid="10.27644.1.0" Name="t1"/>
+      <dxl:ColumnStatistics Mdid="1.27647.1.0.1" Name="b" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.27647.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:RelationStatistics Mdid="2.27647.1.0" Name="t2" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
+      <dxl:Relation Mdid="6.27647.1.0" Name="t2" IsTemporary="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:RelationStatistics Mdid="2.27644.1.0" Name="t1" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
+      <dxl:Relation Mdid="6.27644.1.0" Name="t1" IsTemporary="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:ColumnStatistics Mdid="1.27644.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.65.1.0"/>
+        <dxl:Commutator Mdid="0.96.1.0"/>
+        <dxl:InverseOp Mdid="0.518.1.0"/>
+        <dxl:HashOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7100.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.1977.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.7100.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="3" ColName="c" TypeMdid="0.23.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalSelect>
+        <dxl:IsNull>
+          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+            <dxl:Ident ColId="11" ColName="a" TypeMdid="0.23.1.0"/>
+            <dxl:Ident ColId="11" ColName="a" TypeMdid="0.23.1.0"/>
+          </dxl:Comparison>
+        </dxl:IsNull>
+        <dxl:LogicalJoin JoinType="Left">
+          <dxl:LogicalGet>
+            <dxl:TableDescriptor Mdid="6.27644.1.0" TableName="t1" LockMode="1">
+              <dxl:Columns>
+                <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="3" Attno="3" ColName="c" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="4" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="5" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="6" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="7" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="8" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="9" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="10" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:LogicalGet>
+          <dxl:LogicalGet>
+            <dxl:TableDescriptor Mdid="6.27647.1.0" TableName="t2" LockMode="1">
+              <dxl:Columns>
+                <dxl:Column ColId="11" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="12" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="14" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="15" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="16" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="17" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="18" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="19" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:LogicalGet>
+          <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
+            <dxl:Ident ColId="12" ColName="b" TypeMdid="0.23.1.0"/>
+            <dxl:Ident ColId="11" ColName="a" TypeMdid="0.23.1.0"/>
+          </dxl:Comparison>
+        </dxl:LogicalJoin>
+      </dxl:LogicalSelect>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="1">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="1324032.364306" Rows="1.000000" Width="4"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="2" Alias="c">
+            <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:SortingColumnList/>
+        <dxl:Result>
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="1324032.364292" Rows="1.000000" Width="4"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="2" Alias="c">
+              <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter>
+            <dxl:IsNull>
+              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
+                <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:Comparison>
+            </dxl:IsNull>
+          </dxl:Filter>
+          <dxl:OneTimeFilter/>
+          <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="1324032.364270" Rows="2.000000" Width="8"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="2" Alias="c">
+                <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="10" Alias="a">
+                <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:JoinFilter>
+              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+            </dxl:JoinFilter>
+            <dxl:TableScan>
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.000008" Rows="1.000000" Width="4"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="2" Alias="c">
+                  <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:TableDescriptor Mdid="6.27644.1.0" TableName="t1" LockMode="1">
+                <dxl:Columns>
+                  <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="2" Attno="3" ColName="c" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                  <dxl:Column ColId="4" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="5" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="6" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="7" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="8" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="9" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:TableScan>
+            <dxl:Materialize Eager="false">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.000320" Rows="3.000000" Width="4"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="10" Alias="a">
+                  <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000316" Rows="3.000000" Width="4"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="10" Alias="a">
+                    <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:SortingColumnList/>
+                <dxl:TableScan>
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000102" Rows="1.000000" Width="4"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="10" Alias="a">
+                      <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter>
+                    <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
+                      <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
+                      <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
+                    </dxl:Comparison>
+                  </dxl:Filter>
+                  <dxl:TableDescriptor Mdid="6.27647.1.0" TableName="t2" LockMode="1">
+                    <dxl:Columns>
+                      <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="11" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="12" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                      <dxl:Column ColId="13" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="14" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="15" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="16" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="17" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="18" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    </dxl:Columns>
+                  </dxl:TableDescriptor>
+                </dxl:TableScan>
+              </dxl:BroadcastMotion>
+            </dxl:Materialize>
+          </dxl:NestedLoopJoin>
+        </dxl:Result>
+      </dxl:GatherMotion>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/LOJ_NULLTEST-On-SelfCheck-Pred.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ_NULLTEST-On-SelfCheck-Pred.mdp
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
-  <dxl:Comment><![CDATA[
+<dxl:Comment><![CDATA[
             Objective: LOJ with null-filtering on self check conditions
             CREATE TABLE t1 (a int, b int, c int not null);
             CREATE TABLE t2 (a int not null, b int);
-            explain select t1.c FROM t1 LEFT OUTER JOIN t2 ON t2.b > t2.a WHERE t2.a = t2.a IS NULL;
+            explain select t1.c FROM t1 LEFT OUTER JOIN t2 ON t2.b > t2.a WHERE (t2.a = t2.a) IS NULL;
                                                            QUERY PLAN
             ---------------------------------------------------------------------------------------------------------
              Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1324032.36 rows=1 width=4)
@@ -32,8 +32,8 @@
           <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
         </dxl:CostParams>
       </dxl:CostModelConfig>
-      <dxl:Hint JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="20" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0" SkewFactor="0"/>
-      <dxl:TraceFlags Value="101013,102001,102002,102003,102043,102074,102120,102144,103001,103014,103022,103026,103027,103029,103033,103038,103040,104002,104003,104004,104005,106000"/>
+      <dxl:Hint JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0" SkewFactor="0"/>
+      <dxl:TraceFlags Value="101013,102074,102120,102146,102155,102156,103001,103014,103022,103027,103029,103038,103041,104002,104003,104004,104005,106000"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
       <dxl:GPDBScalarOp Mdid="0.521.1.0" Name="&gt;" ComparisonType="GT" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
@@ -45,14 +45,12 @@
         <dxl:InverseOp Mdid="0.523.1.0"/>
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
-          <dxl:Opfamily Mdid="0.4054.1.0"/>
-          <dxl:Opfamily Mdid="0.10009.1.0"/>
+          <dxl:Opfamily Mdid="0.7027.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
       <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
         <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
         <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
-        <dxl:PartOpfamily Mdid="0.424.1.0"/>
         <dxl:EqualityOp Mdid="0.91.1.0"/>
         <dxl:InequalityOp Mdid="0.85.1.0"/>
         <dxl:LessThanOp Mdid="0.58.1.0"/>
@@ -70,7 +68,6 @@
       <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
         <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
         <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
-        <dxl:PartOpfamily Mdid="0.1976.1.0"/>
         <dxl:EqualityOp Mdid="0.96.1.0"/>
         <dxl:InequalityOp Mdid="0.518.1.0"/>
         <dxl:LessThanOp Mdid="0.97.1.0"/>
@@ -88,7 +85,6 @@
       <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
         <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
         <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
-        <dxl:PartOpfamily Mdid="0.1989.1.0"/>
         <dxl:EqualityOp Mdid="0.607.1.0"/>
         <dxl:InequalityOp Mdid="0.608.1.0"/>
         <dxl:LessThanOp Mdid="0.609.1.0"/>
@@ -104,9 +100,8 @@
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
       <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
-        <dxl:DistrOpfamily Mdid="0.2227.1.0"/>
+        <dxl:DistrOpfamily Mdid="0.7077.1.0"/>
         <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
-        <dxl:PartOpfamily Mdid="0.2789.1.0"/>
         <dxl:EqualityOp Mdid="0.387.1.0"/>
         <dxl:InequalityOp Mdid="0.402.1.0"/>
         <dxl:LessThanOp Mdid="0.2799.1.0"/>
@@ -121,6 +116,8 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.82160.1.0.1" Name="b" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.82160.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
         <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
         <dxl:EqualityOp Mdid="0.385.1.0"/>
@@ -140,7 +137,7 @@
       <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
         <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
         <dxl:EqualityOp Mdid="0.352.1.0"/>
-        <dxl:InequalityOp Mdid="0.3315.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
         <dxl:LessThanOp Mdid="0.0.0.0"/>
         <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
         <dxl:GreaterThanOp Mdid="0.0.0.0"/>
@@ -153,12 +150,8 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:RelationExtendedStatistics Mdid="10.27647.1.0" Name="t2"/>
-      <dxl:RelationExtendedStatistics Mdid="10.27644.1.0" Name="t1"/>
-      <dxl:ColumnStatistics Mdid="1.27647.1.0.1" Name="b" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:ColumnStatistics Mdid="1.27647.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:RelationStatistics Mdid="2.27647.1.0" Name="t2" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
-      <dxl:Relation Mdid="6.27647.1.0" Name="t2" IsTemporary="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2">
+      <dxl:RelationStatistics Mdid="2.82160.1.0" Name="t2" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
+      <dxl:Relation Mdid="6.82160.1.0" Name="t2" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2" NumberLeafPartitions="0">
         <dxl:Columns>
           <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
             <dxl:DefaultValue/>
@@ -169,33 +162,34 @@
           <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
             <dxl:DefaultValue/>
           </dxl:Column>
-          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
             <dxl:DefaultValue/>
           </dxl:Column>
-          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
             <dxl:DefaultValue/>
           </dxl:Column>
-          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
             <dxl:DefaultValue/>
           </dxl:Column>
-          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
             <dxl:DefaultValue/>
           </dxl:Column>
-          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
             <dxl:DefaultValue/>
           </dxl:Column>
-          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
             <dxl:DefaultValue/>
           </dxl:Column>
         </dxl:Columns>
         <dxl:IndexInfoList/>
+        <dxl:Triggers/>
         <dxl:CheckConstraints/>
         <dxl:DistrOpfamilies>
           <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
         </dxl:DistrOpfamilies>
       </dxl:Relation>
-      <dxl:RelationStatistics Mdid="2.27644.1.0" Name="t1" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
-      <dxl:Relation Mdid="6.27644.1.0" Name="t1" IsTemporary="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3">
+      <dxl:RelationStatistics Mdid="2.82157.1.0" Name="t1" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
+      <dxl:Relation Mdid="6.82157.1.0" Name="t1" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3" NumberLeafPartitions="0">
         <dxl:Columns>
           <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
             <dxl:DefaultValue/>
@@ -209,32 +203,32 @@
           <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
             <dxl:DefaultValue/>
           </dxl:Column>
-          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
             <dxl:DefaultValue/>
           </dxl:Column>
-          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
             <dxl:DefaultValue/>
           </dxl:Column>
-          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
             <dxl:DefaultValue/>
           </dxl:Column>
-          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
             <dxl:DefaultValue/>
           </dxl:Column>
-          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
             <dxl:DefaultValue/>
           </dxl:Column>
-          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
             <dxl:DefaultValue/>
           </dxl:Column>
         </dxl:Columns>
         <dxl:IndexInfoList/>
+        <dxl:Triggers/>
         <dxl:CheckConstraints/>
         <dxl:DistrOpfamilies>
           <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
         </dxl:DistrOpfamilies>
       </dxl:Relation>
-      <dxl:ColumnStatistics Mdid="1.27644.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
         <dxl:LeftType Mdid="0.23.1.0"/>
         <dxl:RightType Mdid="0.23.1.0"/>
@@ -247,11 +241,11 @@
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1977.1.0"/>
-          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.7027.1.0"/>
           <dxl:Opfamily Mdid="0.7100.1.0"/>
-          <dxl:Opfamily Mdid="0.10009.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
+      <dxl:ColumnStatistics Mdid="1.82157.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
     </dxl:Metadata>
     <dxl:Query>
       <dxl:OutputColumns>
@@ -267,33 +261,33 @@
         </dxl:IsNull>
         <dxl:LogicalJoin JoinType="Left">
           <dxl:LogicalGet>
-            <dxl:TableDescriptor Mdid="6.27644.1.0" TableName="t1" LockMode="1">
+            <dxl:TableDescriptor Mdid="6.82157.1.0" TableName="t1">
               <dxl:Columns>
                 <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
                 <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
                 <dxl:Column ColId="3" Attno="3" ColName="c" TypeMdid="0.23.1.0" ColWidth="4"/>
                 <dxl:Column ColId="4" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                <dxl:Column ColId="5" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                <dxl:Column ColId="6" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                <dxl:Column ColId="7" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                <dxl:Column ColId="8" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                <dxl:Column ColId="9" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                <dxl:Column ColId="10" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="5" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="6" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="7" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="8" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="9" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="10" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
               </dxl:Columns>
             </dxl:TableDescriptor>
           </dxl:LogicalGet>
           <dxl:LogicalGet>
-            <dxl:TableDescriptor Mdid="6.27647.1.0" TableName="t2" LockMode="1">
+            <dxl:TableDescriptor Mdid="6.82160.1.0" TableName="t2">
               <dxl:Columns>
                 <dxl:Column ColId="11" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
                 <dxl:Column ColId="12" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
                 <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                <dxl:Column ColId="14" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                <dxl:Column ColId="15" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                <dxl:Column ColId="16" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                <dxl:Column ColId="17" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                <dxl:Column ColId="18" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                <dxl:Column ColId="19" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="14" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="15" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="16" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="17" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="18" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="19" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
               </dxl:Columns>
             </dxl:TableDescriptor>
           </dxl:LogicalGet>
@@ -360,17 +354,17 @@
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:TableDescriptor Mdid="6.27644.1.0" TableName="t1" LockMode="1">
+              <dxl:TableDescriptor Mdid="6.82157.1.0" TableName="t1">
                 <dxl:Columns>
                   <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
                   <dxl:Column ColId="2" Attno="3" ColName="c" TypeMdid="0.23.1.0" ColWidth="4"/>
                   <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                  <dxl:Column ColId="4" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="5" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="6" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="7" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="8" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                  <dxl:Column ColId="9" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
                 </dxl:Columns>
               </dxl:TableDescriptor>
             </dxl:TableScan>
@@ -410,17 +404,17 @@
                       <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
                     </dxl:Comparison>
                   </dxl:Filter>
-                  <dxl:TableDescriptor Mdid="6.27647.1.0" TableName="t2" LockMode="1">
+                  <dxl:TableDescriptor Mdid="6.82160.1.0" TableName="t2">
                     <dxl:Columns>
                       <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
                       <dxl:Column ColId="11" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
                       <dxl:Column ColId="12" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                      <dxl:Column ColId="13" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="14" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="15" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="16" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="17" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="18" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="13" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="14" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="15" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="16" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="17" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                      <dxl:Column ColId="18" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
                     </dxl:Columns>
                   </dxl:TableDescriptor>
                 </dxl:TableScan>

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CExpressionPreprocessor.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CExpressionPreprocessor.h
@@ -79,7 +79,8 @@ private:
 
 	// eliminate self comparisons
 	static CExpression *PexprEliminateSelfComparison(CMemoryPool *mp,
-													 CExpression *pexpr);
+													 CExpression *pexpr,
+													 CColRefSet *pcrsNotNull);
 
 	// trim superfluos equality
 	static CExpression *PexprPruneSuperfluousEquality(CMemoryPool *mp,

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPredicateUtils.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPredicateUtils.h
@@ -132,11 +132,13 @@ public:
 	static BOOL FPlainEquality(CExpression *pexpr);
 
 	// is the given expression a self comparison on some column
-	static BOOL FSelfComparison(CExpression *pexpr, IMDType::ECmpType *pecmpt);
+	static BOOL FSelfComparison(CExpression *pexpr, IMDType::ECmpType *pecmpt,
+								CColRefSet *pcrsNotNull);
 
 	// eliminate self comparison if possible
 	static CExpression *PexprEliminateSelfComparison(CMemoryPool *mp,
-													 CExpression *pexpr);
+													 CExpression *pexpr,
+													 CColRefSet *pcrsNotNull);
 
 	// is the given expression in the form (col1 Is NOT DISTINCT FROM col2)
 	static BOOL FINDFScalarIdents(CExpression *pexpr);

--- a/src/backend/gporca/libgpopt/src/operators/CExpressionPreprocessor.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CExpressionPreprocessor.cpp
@@ -73,7 +73,8 @@ static CExpression *SubstituteConstantIdentifier(
 // eliminate self comparisons in the given expression
 CExpression *
 CExpressionPreprocessor::PexprEliminateSelfComparison(CMemoryPool *mp,
-													  CExpression *pexpr)
+													  CExpression *pexpr,
+													  CColRefSet *pcrsNotNull)
 {
 	// protect against stack overflow during recursion
 	GPOS_CHECK_STACK_SIZE;
@@ -82,7 +83,8 @@ CExpressionPreprocessor::PexprEliminateSelfComparison(CMemoryPool *mp,
 
 	if (CUtils::FScalarCmp(pexpr))
 	{
-		return CPredicateUtils::PexprEliminateSelfComparison(mp, pexpr);
+		return CPredicateUtils::PexprEliminateSelfComparison(mp, pexpr,
+															 pcrsNotNull);
 	}
 
 	// recursively process children
@@ -91,7 +93,7 @@ CExpressionPreprocessor::PexprEliminateSelfComparison(CMemoryPool *mp,
 	for (ULONG ul = 0; ul < arity; ul++)
 	{
 		CExpression *pexprChild =
-			PexprEliminateSelfComparison(mp, (*pexpr)[ul]);
+			PexprEliminateSelfComparison(mp, (*pexpr)[ul], pcrsNotNull);
 		pdrgpexprChildren->Append(pexprChild);
 	}
 
@@ -3142,8 +3144,8 @@ CExpressionPreprocessor::PexprPreprocess(
 	pexprConvert2In->Release();
 
 	// (12) eliminate self comparisons
-	CExpression *pexprSelfCompEliminated =
-		PexprEliminateSelfComparison(mp, pexprInferredPreds);
+	CExpression *pexprSelfCompEliminated = PexprEliminateSelfComparison(
+		mp, pexprInferredPreds, pexprInferredPreds->DeriveNotNullColumns());
 	GPOS_CHECK_ABORT;
 	pexprInferredPreds->Release();
 

--- a/src/backend/gporca/libgpopt/src/operators/CPredicateUtils.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPredicateUtils.cpp
@@ -851,7 +851,8 @@ CPredicateUtils::FPlainEquality(CExpression *pexpr)
 
 // is an expression a self comparison on some column
 BOOL
-CPredicateUtils::FSelfComparison(CExpression *pexpr, IMDType::ECmpType *pecmpt)
+CPredicateUtils::FSelfComparison(CExpression *pexpr, IMDType::ECmpType *pecmpt,
+								 CColRefSet *pcrsNotNull)
 {
 	GPOS_ASSERT(NULL != pexpr);
 	GPOS_ASSERT(NULL != pecmpt);
@@ -877,8 +878,8 @@ CPredicateUtils::FSelfComparison(CExpression *pexpr, IMDType::ECmpType *pecmpt)
 		CColRef *colref =
 			const_cast<CColRef *>(CScalarIdent::PopConvert(popLeft)->Pcr());
 
-		return CColRef::EcrtTable == colref->Ecrt() &&
-			   !CColRefTable::PcrConvert(colref)->IsNullable();
+		// return true if column is a member of NotNull columns(pcrsNotNull) of parent expression
+		return pcrsNotNull->FMember(colref);
 	}
 
 	return false;
@@ -887,14 +888,15 @@ CPredicateUtils::FSelfComparison(CExpression *pexpr, IMDType::ECmpType *pecmpt)
 // eliminate self comparison and replace it with True or False if possible
 CExpression *
 CPredicateUtils::PexprEliminateSelfComparison(CMemoryPool *mp,
-											  CExpression *pexpr)
+											  CExpression *pexpr,
+											  CColRefSet *pcrsNotNull)
 {
 	GPOS_ASSERT(pexpr->Pop()->FScalar());
 
 	pexpr->AddRef();
 	CExpression *pexprNew = pexpr;
 	IMDType::ECmpType cmp_type = IMDType::EcmptOther;
-	if (FSelfComparison(pexpr, &cmp_type))
+	if (FSelfComparison(pexpr, &cmp_type, pcrsNotNull))
 	{
 		switch (cmp_type)
 		{

--- a/src/backend/gporca/libgpopt/src/xforms/CXformUtils.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformUtils.cpp
@@ -158,12 +158,6 @@ CXformUtils::ExfpExpandJoinOrder(CExpressionHandle &exprhdl,
 		return CXform::ExfpNone;
 	}
 
-#ifdef GPOS_DEBUG
-	CAutoMemoryPool amp;
-	GPOS_ASSERT(!FJoinPredOnSingleChild(amp.Pmp(), exprhdl) &&
-				"join predicates are not pushed down");
-#endif	// GPOS_DEBUG
-
 	if (NULL != exprhdl.Pgexpr())
 	{
 		// if handle is attached to a group expression, transformation is applied

--- a/src/backend/gporca/server/CMakeLists.txt
+++ b/src/backend/gporca/server/CMakeLists.txt
@@ -275,7 +275,8 @@ LeftJoinNullsNotColocated InnerJoinBroadcastTableHashSpec LeftJoinBroadcastTable
 COuterJoin2Test:
 LOJ-IsNullPred Select-Proj-OuterJoin OuterJoin-With-OuterRefs Join-Disj-Subqs
 EffectOfLocalPredOnJoin EffectOfLocalPredOnJoin2 EffectOfLocalPredOnJoin3
-LeftJoin-UnsupportedFilter-Cardinality LeftOuter2InnerUnionAllAntiSemiJoin;
+LeftJoin-UnsupportedFilter-Cardinality LeftOuter2InnerUnionAllAntiSemiJoin
+LOJ-With-Single-Pred-On-Outer LOJ_NULLTEST-On-SelfCheck-Pred;
 
 COuterJoin3Test:
 LOJ_IDF_no_convert_outer_ref_predicate_with_NULL

--- a/src/test/regress/expected/bfv_joins.out
+++ b/src/test/regress/expected/bfv_joins.out
@@ -629,54 +629,54 @@ SELECT * from x left join y on True where func_x(y.a) > 0;
 (100 rows)
 
 SELECT * FROM t1 LEFT OUTER JOIN t2 ON t1.a = t2.a WHERE t1.b IS DISTINCT FROM t2.b;
- a | b | c | a | b
+ a | b | c | a | b 
 ---+---+---+---+---
  2 | 1 | 2 | 2 | 3
- 1 | 1 | 1 |   |
+ 1 | 1 | 1 |   |  
 (2 rows)
 
 SELECT * FROM t1 LEFT OUTER JOIN t2 ON t1.a = t2.a WHERE t1.b IS DISTINCT FROM NULL;
- a | b | c | a | b
+ a | b | c | a | b 
 ---+---+---+---+---
  2 | 1 | 2 | 2 | 3
- 1 | 1 | 1 |   |
+ 1 | 1 | 1 |   |  
 (2 rows)
 
 SELECT * FROM t1 LEFT OUTER JOIN t2 ON t1.a = t2.a WHERE t2.b IS DISTINCT FROM NULL;
- a | b | c | a | b
+ a | b | c | a | b 
 ---+---+---+---+---
  2 | 1 | 2 | 2 | 3
 (1 row)
 
 SELECT * FROM t1 LEFT OUTER JOIN t2 ON t1.a = t2.a WHERE t2.b IS NOT DISTINCT FROM NULL;
- a | b | c | a | b
+ a | b | c | a | b 
 ---+---+---+---+---
- 1 | 1 | 1 |   |
- 3 |   | 3 |   |
+ 3 |   | 3 |   |  
+ 1 | 1 | 1 |   |  
 (2 rows)
 
 SELECT * FROM t1 LEFT OUTER JOIN t2 ON t1.a = t2.a WHERE t1.b IS NOT DISTINCT FROM NULL;
- a | b | c | a | b
+ a | b | c | a | b 
 ---+---+---+---+---
- 3 |   | 3 |   |
+ 3 |   | 3 |   |  
 (1 row)
 
 --- Tests for LOJ with single predicate uses columns of outer child only
 explain select t1.* from t1 left outer join t3 on t1.b=1;
-                                               QUERY PLAN
+                                               QUERY PLAN                                               
 --------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..10059962503.02 rows=6068410 width=12)
-   ->  Nested Loop Left Join  (cost=10000000000.00..10059881590.89 rows=2022803 width=12)
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=10000000000.00..10000014318.78 rows=155801 width=12)
+   ->  Nested Loop Left Join  (cost=10000000000.00..10000014318.78 rows=51934 width=12)
          Join Filter: (t1.b = 1)
-         ->  Seq Scan on t1  (cost=0.00..293.67 rows=25967 width=12)
-         ->  Materialize  (cost=0.00..1721.83 rows=77900 width=0)
-               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1332.33 rows=77900 width=0)
-                     ->  Seq Scan on t3  (cost=0.00..293.67 rows=25967 width=0)
+         ->  Seq Scan on t1  (cost=0.00..2.03 rows=1 width=12)
+         ->  Materialize  (cost=0.00..5163.50 rows=77900 width=0)
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..3995.00 rows=77900 width=0)
+                     ->  Seq Scan on t3  (cost=0.00..879.00 rows=25967 width=0)
  Optimizer: Postgres query optimizer
 (8 rows)
 
 select t1.* from t1 left outer join t3 on t1.b=1;
- a | b | c
+ a | b | c 
 ---+---+---
  1 | 1 | 1
  2 | 1 | 2
@@ -684,20 +684,20 @@ select t1.* from t1 left outer join t3 on t1.b=1;
 (3 rows)
 
 explain select t1.* from t1 left outer join t3 on t1.c=1;
-                                               QUERY PLAN
+                                               QUERY PLAN                                               
 --------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..10059962503.02 rows=6068410 width=12)
-   ->  Nested Loop Left Join  (cost=10000000000.00..10059881590.89 rows=2022803 width=12)
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=10000000000.00..10000014318.78 rows=77900 width=12)
+   ->  Nested Loop Left Join  (cost=10000000000.00..10000014318.78 rows=25967 width=12)
          Join Filter: (t1.c = 1)
-         ->  Seq Scan on t1  (cost=0.00..293.67 rows=25967 width=12)
-         ->  Materialize  (cost=0.00..1721.83 rows=77900 width=0)
-               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1332.33 rows=77900 width=0)
-                     ->  Seq Scan on t3  (cost=0.00..293.67 rows=25967 width=0)
+         ->  Seq Scan on t1  (cost=0.00..2.03 rows=1 width=12)
+         ->  Materialize  (cost=0.00..5163.50 rows=77900 width=0)
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..3995.00 rows=77900 width=0)
+                     ->  Seq Scan on t3  (cost=0.00..879.00 rows=25967 width=0)
  Optimizer: Postgres query optimizer
 (8 rows)
 
 select t1.* from t1 left outer join t3 on t1.c=1;
- a | b | c
+ a | b | c 
 ---+---+---
  1 | 1 | 1
  2 | 1 | 2
@@ -706,234 +706,235 @@ select t1.* from t1 left outer join t3 on t1.c=1;
 
 --- Tests for LOJ with null-filtering on self check conditions.
 --- make sure that we dont optimize the equality checks of inner table of LOJ.
-explain SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t3.a = t3.a IS NULL;
-                                               QUERY PLAN
----------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..10040215447.37 rows=1011401667 width=4)
-   ->  Nested Loop Left Join  (cost=10000000000.00..10026730091.81 rows=337133889 width=4)
+explain SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE (t3.a = t3.a) IS NULL;
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=10000000000.00..10000005555.03 rows=38950 width=4)
+   ->  Nested Loop Left Join  (cost=10000000000.00..10000005555.03 rows=12984 width=4)
          Filter: ((t3.a = t3.a) IS NULL)
-         ->  Seq Scan on t1  (cost=0.00..293.67 rows=25967 width=4)
-         ->  Materialize  (cost=0.00..834.64 rows=25967 width=4)
-               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..704.81 rows=25967 width=4)
-                     ->  Seq Scan on t3  (cost=0.00..358.58 rows=8656 width=4)
+         ->  Seq Scan on t1  (cost=0.00..2.03 rows=1 width=4)
+         ->  Materialize  (cost=0.00..2501.92 rows=25967 width=4)
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..2112.42 rows=25967 width=4)
+                     ->  Seq Scan on t3  (cost=0.00..1073.75 rows=8656 width=4)
                            Filter: (b > a)
  Optimizer: Postgres query optimizer
 (9 rows)
 
-SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t3.a = t3.a IS NULL;
- c
+SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE (t3.a = t3.a) IS NULL;
+ c 
 ---
  2
  3
  1
 (3 rows)
 
-explain SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t1.c = t1.c IS NULL;
-                                              QUERY PLAN
--------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..10000052373.42 rows=2022803 width=4)
-   ->  Nested Loop Left Join  (cost=10000000000.00..10000025402.71 rows=674268 width=4)
-         ->  Seq Scan on t1  (cost=0.00..358.58 rows=26 width=4)
+explain SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE (t1.c = t1.c) IS NULL;
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=10000000000.00..10000003282.95 rows=25967 width=4)
+   ->  Nested Loop Left Join  (cost=10000000000.00..10000003282.95 rows=8656 width=4)
+         ->  Seq Scan on t1  (cost=0.00..2.04 rows=1 width=4)
                Filter: ((c = c) IS NULL)
-         ->  Materialize  (cost=0.00..834.64 rows=25967 width=0)
-               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..704.81 rows=25967 width=0)
-                     ->  Seq Scan on t3  (cost=0.00..358.58 rows=8656 width=0)
+         ->  Materialize  (cost=0.00..2501.92 rows=25967 width=0)
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..2112.42 rows=25967 width=0)
+                     ->  Seq Scan on t3  (cost=0.00..1073.75 rows=8656 width=0)
                            Filter: (b > a)
  Optimizer: Postgres query optimizer
 (9 rows)
 
-SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t1.c = t1.c IS NULL;
- c
+SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE (t1.c = t1.c) IS NULL;
+ c 
 ---
 (0 rows)
 
-explain SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t3.a = t3.a IS NULL and t3.b=2;
-                                             QUERY PLAN
------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..10000002619.50 rows=101101 width=4)
-   ->  Nested Loop  (cost=10000000000.00..10000001271.49 rows=33700 width=4)
-         ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..553.36 rows=1 width=0)
-               ->  Seq Scan on t3  (cost=0.00..553.33 rows=1 width=0)
-                     Filter: ((b > a) AND ((a = a) IS NULL) AND (2 > a) AND (b = 2))
-         ->  Seq Scan on t1  (cost=0.00..293.67 rows=25967 width=4)
+explain SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE (t3.a = t3.a) IS NULL and t3.b=2;
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=10000000000.00..10000001660.22 rows=4 width=4)
+   ->  Nested Loop  (cost=10000000000.00..10000001660.22 rows=2 width=4)
+         ->  Seq Scan on t1  (cost=0.00..2.03 rows=1 width=4)
+         ->  Materialize  (cost=0.00..1658.07 rows=2 width=0)
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..1658.05 rows=2 width=0)
+                     ->  Seq Scan on t3  (cost=0.00..1658.00 rows=1 width=0)
+                           Filter: ((b > a) AND ((a = a) IS NULL) AND (2 > a) AND (b = 2))
  Optimizer: Postgres query optimizer
-(7 rows)
+(8 rows)
 
-SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t3.a = t3.a IS NULL and t3.a=2;
- c
+SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE (t3.a = t3.a) IS NULL and t3.a=2;
+ c 
 ---
 (0 rows)
 
-explain SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t3.a = t3.a IS NULL and t1.b=1;
-                                              QUERY PLAN
--------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..10000040573.74 rows=1011402 width=4)
-   ->  Nested Loop Left Join  (cost=10000000000.00..10000027088.38 rows=337134 width=4)
+explain SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE (t3.a = t3.a) IS NULL and t1.b=1;
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=10000000000.00..10000004516.37 rows=25967 width=4)
+   ->  Nested Loop Left Join  (cost=10000000000.00..10000004516.37 rows=8656 width=4)
          Filter: ((t3.a = t3.a) IS NULL)
-         ->  Seq Scan on t1  (cost=0.00..358.58 rows=26 width=4)
+         ->  Seq Scan on t1  (cost=0.00..2.04 rows=1 width=4)
                Filter: (b = 1)
-         ->  Materialize  (cost=0.00..834.64 rows=25967 width=4)
-               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..704.81 rows=25967 width=4)
-                     ->  Seq Scan on t3  (cost=0.00..358.58 rows=8656 width=4)
+         ->  Materialize  (cost=0.00..2501.92 rows=25967 width=4)
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..2112.42 rows=25967 width=4)
+                     ->  Seq Scan on t3  (cost=0.00..1073.75 rows=8656 width=4)
                            Filter: (b > a)
  Optimizer: Postgres query optimizer
 (10 rows)
 
-SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t3.a = t3.a IS NULL and t1.b=1;
- c
+SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE (t3.a = t3.a) IS NULL and t1.b=1;
+ c 
 ---
  2
  1
 (2 rows)
 
-explain SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t3.a = t3.a IS NULL or t3.a is NULL;
-                                               QUERY PLAN
----------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..10046958125.15 rows=1517102500 width=4)
-   ->  Nested Loop Left Join  (cost=10000000000.00..10026730091.81 rows=505700833 width=4)
+explain SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE (t3.a = t3.a) IS NULL or t3.a is NULL;
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=10000000000.00..10000005555.03 rows=58425 width=4)
+   ->  Nested Loop Left Join  (cost=10000000000.00..10000005555.03 rows=19475 width=4)
          Filter: (((t3.a = t3.a) IS NULL) OR (t3.a IS NULL))
-         ->  Seq Scan on t1  (cost=0.00..293.67 rows=25967 width=4)
-         ->  Materialize  (cost=0.00..834.64 rows=25967 width=4)
-               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..704.81 rows=25967 width=4)
-                     ->  Seq Scan on t3  (cost=0.00..358.58 rows=8656 width=4)
+         ->  Seq Scan on t1  (cost=0.00..2.03 rows=1 width=4)
+         ->  Materialize  (cost=0.00..2501.92 rows=25967 width=4)
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..2112.42 rows=25967 width=4)
+                     ->  Seq Scan on t3  (cost=0.00..1073.75 rows=8656 width=4)
                            Filter: (b > a)
  Optimizer: Postgres query optimizer
 (9 rows)
 
-SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t3.a = t3.a IS NULL or t3.a is NULL;
- c
+SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE (t3.a = t3.a) IS NULL or t3.a is NULL;
+ c 
 ---
  2
  3
  1
 (3 rows)
 
-explain SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t3.a = t3.a IS NULL or t3.b=2;
-                                               QUERY PLAN
----------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..10041914602.17 rows=1012413068 width=4)
-   ->  Nested Loop Left Join  (cost=10000000000.00..10028415761.26 rows=337471023 width=4)
+explain SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE (t3.a = t3.a) IS NULL or t3.b=2;
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=10000000000.00..10000006139.28 rows=38989 width=4)
+   ->  Nested Loop Left Join  (cost=10000000000.00..10000006139.28 rows=12997 width=4)
          Filter: (((t3.a = t3.a) IS NULL) OR (t3.b = 2))
-         ->  Seq Scan on t1  (cost=0.00..293.67 rows=25967 width=4)
-         ->  Materialize  (cost=0.00..834.64 rows=25967 width=8)
-               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..704.81 rows=25967 width=8)
-                     ->  Seq Scan on t3  (cost=0.00..358.58 rows=8656 width=8)
+         ->  Seq Scan on t1  (cost=0.00..2.03 rows=1 width=4)
+         ->  Materialize  (cost=0.00..2501.92 rows=25967 width=8)
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..2112.42 rows=25967 width=8)
+                     ->  Seq Scan on t3  (cost=0.00..1073.75 rows=8656 width=8)
                            Filter: (b > a)
  Optimizer: Postgres query optimizer
 (9 rows)
 
-SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t3.a = t3.a IS NULL or t3.b=2;
- c
+SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE (t3.a = t3.a) IS NULL or t3.b=2;
+ c 
 ---
  2
  3
  1
 (3 rows)
 
-explain SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t3.a = t3.a IS NULL or t1.a=1;
-                                               QUERY PLAN
----------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..10041914602.17 rows=1012413068 width=4)
-   ->  Nested Loop Left Join  (cost=10000000000.00..10028415761.26 rows=337471023 width=4)
+explain SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE (t3.a = t3.a) IS NULL or t1.a=1;
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=10000000000.00..10000006139.28 rows=51934 width=4)
+   ->  Nested Loop Left Join  (cost=10000000000.00..10000006139.28 rows=17312 width=4)
          Filter: (((t3.a = t3.a) IS NULL) OR (t1.a = 1))
-         ->  Seq Scan on t1  (cost=0.00..293.67 rows=25967 width=8)
-         ->  Materialize  (cost=0.00..834.64 rows=25967 width=4)
-               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..704.81 rows=25967 width=4)
-                     ->  Seq Scan on t3  (cost=0.00..358.58 rows=8656 width=4)
+         ->  Seq Scan on t1  (cost=0.00..2.03 rows=1 width=8)
+         ->  Materialize  (cost=0.00..2501.92 rows=25967 width=4)
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..2112.42 rows=25967 width=4)
+                     ->  Seq Scan on t3  (cost=0.00..1073.75 rows=8656 width=4)
                            Filter: (b > a)
  Optimizer: Postgres query optimizer
 (9 rows)
 
-SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t3.a = t3.a IS NULL or t1.a=1;
- c
+SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE (t3.a = t3.a) IS NULL or t1.a=1;
+ c 
 ---
  2
  3
  1
 (3 rows)
 
-explain SELECT t.c FROM (select t1.*, t1.a+t1.b as cc from t1)t LEFT OUTER JOIN t3 ON t.cc = t.cc IS NULL;
-                                               QUERY PLAN
----------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..10110451674.22 rows=3034205000 width=4)
-   ->  Nested Loop Left Join  (cost=10000000000.00..10069995607.56 rows=1011401667 width=4)
+explain SELECT t.c FROM (select t1.*, t1.a+t1.b as cc from t1)t LEFT OUTER JOIN t3 ON (t.cc = t.cc) IS NULL;
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=10000000000.00..10000017824.28 rows=116850 width=4)
+   ->  Nested Loop Left Join  (cost=10000000000.00..10000017824.28 rows=38950 width=4)
          Join Filter: (((t1.a + t1.b) = (t1.a + t1.b)) IS NULL)
-         ->  Seq Scan on t1  (cost=0.00..293.67 rows=25967 width=12)
-         ->  Materialize  (cost=0.00..1721.83 rows=77900 width=0)
-               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1332.33 rows=77900 width=0)
-                     ->  Seq Scan on t3  (cost=0.00..293.67 rows=25967 width=0)
+         ->  Seq Scan on t1  (cost=0.00..2.03 rows=1 width=12)
+         ->  Materialize  (cost=0.00..5163.50 rows=77900 width=0)
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..3995.00 rows=77900 width=0)
+                     ->  Seq Scan on t3  (cost=0.00..879.00 rows=25967 width=0)
  Optimizer: Postgres query optimizer
 (8 rows)
 
-SELECT t.c FROM (select t1.*, t1.a+t1.b as cc from t1)t LEFT OUTER JOIN t3 ON t.cc = t.cc IS NULL;
- c
+SELECT t.c FROM (select t1.*, t1.a+t1.b as cc from t1)t LEFT OUTER JOIN t3 ON (t.cc = t.cc) IS NULL;
+ c 
 ---
  2
  3
  1
 (3 rows)
 
-explain SELECT t.c FROM (select t1.*, t1.a+t1.b as cc from t1)t LEFT OUTER JOIN t3 ON t3.a > t3.b where t.cc = t.cc IS NULL;
-                                              QUERY PLAN
--------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..10000052503.26 rows=2022803 width=4)
-   ->  Nested Loop Left Join  (cost=10000000000.00..10000025532.55 rows=674268 width=4)
-         ->  Seq Scan on t1  (cost=0.00..488.42 rows=26 width=4)
+explain SELECT t.c FROM (select t1.*, t1.a+t1.b as cc from t1)t LEFT OUTER JOIN t3 ON t3.a > t3.b where (t.cc = t.cc) IS NULL;
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=10000000000.00..10000003282.97 rows=25967 width=4)
+   ->  Nested Loop Left Join  (cost=10000000000.00..10000003282.97 rows=8656 width=4)
+         ->  Seq Scan on t1  (cost=0.00..2.05 rows=1 width=4)
                Filter: (((a + b) = (a + b)) IS NULL)
-         ->  Materialize  (cost=0.00..834.64 rows=25967 width=0)
-               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..704.81 rows=25967 width=0)
-                     ->  Seq Scan on t3  (cost=0.00..358.58 rows=8656 width=0)
+         ->  Materialize  (cost=0.00..2501.92 rows=25967 width=0)
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..2112.42 rows=25967 width=0)
+                     ->  Seq Scan on t3  (cost=0.00..1073.75 rows=8656 width=0)
                            Filter: (a > b)
  Optimizer: Postgres query optimizer
 (9 rows)
 
-SELECT t.c FROM (select t1.*, t1.a+t1.b as cc from t1)t LEFT OUTER JOIN t3 ON t3.a > t3.b where t.cc = t.cc IS NULL;
- c
+SELECT t.c FROM (select t1.*, t1.a+t1.b as cc from t1)t LEFT OUTER JOIN t3 ON t3.a > t3.b where (t.cc = t.cc) IS NULL;
+ c 
 ---
  3
 (1 row)
 
-explain SELECT t1.c FROM t1 LEFT OUTER JOIN (select t3.*, t3.a+t3.b as cc from t3)t ON t.cc = t.cc IS NULL;
-                                              QUERY PLAN
-------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..10012810957.32 rows=6068410 width=4)
-   ->  Nested Loop Left Join  (cost=10000000000.00..10012730045.19 rows=2022803 width=4)
-         ->  Seq Scan on t1  (cost=0.00..293.67 rows=25967 width=4)
-         ->  Materialize  (cost=0.00..489.84 rows=78 width=0)
-               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..489.46 rows=78 width=0)
-                     ->  Seq Scan on t3  (cost=0.00..488.42 rows=26 width=0)
+explain SELECT t1.c FROM t1 LEFT OUTER JOIN (select t3.*, t3.a+t3.b as cc from t3)t ON (t.cc = t.cc) IS NULL;
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=10000000000.00..10000001476.97 rows=234 width=4)
+   ->  Nested Loop Left Join  (cost=10000000000.00..10000001476.97 rows=78 width=4)
+         ->  Seq Scan on t1  (cost=0.00..2.03 rows=1 width=4)
+         ->  Materialize  (cost=0.00..1467.53 rows=78 width=0)
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..1466.37 rows=78 width=0)
+                     ->  Seq Scan on t3  (cost=0.00..1463.25 rows=26 width=0)
                            Filter: (((a + b) = (a + b)) IS NULL)
  Optimizer: Postgres query optimizer
 (8 rows)
 
-SELECT t1.c FROM t1 LEFT OUTER JOIN (select t3.*, t3.a+t3.b as cc from t3)t ON t.cc = t.cc IS NULL;
- c
+SELECT t1.c FROM t1 LEFT OUTER JOIN (select t3.*, t3.a+t3.b as cc from t3)t ON (t.cc = t.cc) IS NULL;
+ c 
 ---
+ 1
  2
  3
- 1
 (3 rows)
 
-explain SELECT t1.c FROM t1 LEFT OUTER JOIN (select t3.*, t3.a+t3.b as cc from t3)t ON t.b > t.a WHERE t.cc = t.cc IS NULL;
-                                               QUERY PLAN
----------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..10043586786.26 rows=1011401667 width=4)
-   ->  Nested Loop Left Join  (cost=10000000000.00..10030101430.70 rows=337133889 width=4)
+explain SELECT t1.c FROM t1 LEFT OUTER JOIN (select t3.*, t3.a+t3.b as cc from t3)t ON t.b > t.a WHERE (t.cc = t.cc) IS NULL;
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=10000000000.00..10000006723.53 rows=38950 width=4)
+   ->  Nested Loop Left Join  (cost=10000000000.00..10000006723.53 rows=12984 width=4)
          Filter: (((t3.a + t3.b) = (t3.a + t3.b)) IS NULL)
-         ->  Seq Scan on t1  (cost=0.00..293.67 rows=25967 width=4)
-         ->  Materialize  (cost=0.00..834.64 rows=25967 width=8)
-               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..704.81 rows=25967 width=8)
-                     ->  Seq Scan on t3  (cost=0.00..358.58 rows=8656 width=8)
+         ->  Seq Scan on t1  (cost=0.00..2.03 rows=1 width=4)
+         ->  Materialize  (cost=0.00..2501.92 rows=25967 width=8)
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..2112.42 rows=25967 width=8)
+                     ->  Seq Scan on t3  (cost=0.00..1073.75 rows=8656 width=8)
                            Filter: (b > a)
  Optimizer: Postgres query optimizer
 (9 rows)
 
-SELECT t1.c FROM t1 LEFT OUTER JOIN (select t3.*, t3.a+t3.b as cc from t3)t ON t.b > t.a WHERE t.cc = t.cc IS NULL;
- c
+SELECT t1.c FROM t1 LEFT OUTER JOIN (select t3.*, t3.a+t3.b as cc from t3)t ON t.b > t.a WHERE (t.cc = t.cc) IS NULL;
+ c 
 ---
+ 1
  2
  3
- 1
 (3 rows)
 
 -- Test for unexpected NLJ qual
@@ -3295,7 +3296,7 @@ SELECT count(*)
 FROM mpp25537_facttable1 ft, mpp25537_dimdate dt, mpp25537_dimtabl1 dt1
 WHERE ft.wk_id = dt.wk_id
 AND ft.id = dt1.id;
- count
+ count 
 -------
      4
 (1 row)
@@ -3615,7 +3616,7 @@ explain select a.*, b.i, c.* from a, b, c where ((mt_col).x > a.i or b.i = a.i) 
 (13 rows)
 
 select a.*, b.i, c.* from a, b, c where ((mt_col).x > a.i or b.i = a.i) and (a.i + b.i) = c.j;
- i | i | i | j
+ i | i | i | j 
 ---+---+---+---
  1 | 1 | 2 | 2
 (1 row)
@@ -3796,10 +3797,10 @@ select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not distinct from
   6 |  6 |    |    |    | 20
   9 |  9 |    |    |    | 20
  10 | 10 |    |    |    | 20
- 11 | 11 | 11 |    |    |
- 13 | 13 | 13 |    |    |
- 14 | 14 | 14 |    |    |
- 17 | 17 | 17 |    |    |
+ 11 | 11 | 11 |    |    |   
+ 13 | 13 | 13 |    |    |   
+ 14 | 14 | 14 |    |    |   
+ 17 | 17 | 17 |    |    |   
   2 |  2 |    |    |    | 20
   3 |  3 |    |    |    | 20
   4 |  4 |    |    |    | 20
@@ -3807,7 +3808,7 @@ select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not distinct from
   8 |  8 |    |    |    | 20
  16 | 16 | 16 |    |    |   
  18 | 18 | 18 |    |    |   
- 19 | 19 | 19 |    |    |
+ 19 | 19 | 19 |    |    |   
 (20 rows)
 
 select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not distinct from a3 and b2 is distinct from b3;
@@ -3818,9 +3819,9 @@ select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not distinct from
   4 |  4 |    |    |    | 20
   7 |  7 |    |    |    | 20
   8 |  8 |    |    |    | 20
- 16 | 16 | 16 |    |    |
- 18 | 18 | 18 |    |    |
- 19 | 19 | 19 |    |    |
+ 16 | 16 | 16 |    |    |   
+ 18 | 18 | 18 |    |    |   
+ 19 | 19 | 19 |    |    |   
   1 |  1 |    |    |    | 20
  12 | 12 | 12 |    |    |   
  15 | 15 | 15 |    |    |   
@@ -3832,32 +3833,32 @@ select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not distinct from
  11 | 11 | 11 |    |    |   
  13 | 13 | 13 |    |    |   
  14 | 14 | 14 |    |    |   
- 17 | 17 | 17 |    |    |
+ 17 | 17 | 17 |    |    |   
 (20 rows)
 
 select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not distinct from a3 and b2 = b3;
  a1 | b1 | a2 | b2 | a3 | b3 
 ----+----+----+----+----+----
-  1 |  1 |    |    |    |
- 12 | 12 | 12 |    |    |
+  2 |  2 |    |    |    |   
+  3 |  3 |    |    |    |   
+  4 |  4 |    |    |    |   
+  7 |  7 |    |    |    |   
+  8 |  8 |    |    |    |   
+ 16 | 16 | 16 |    |    |   
+ 18 | 18 | 18 |    |    |   
+ 19 | 19 | 19 |    |    |   
+  1 |  1 |    |    |    |   
+ 12 | 12 | 12 |    |    |   
  15 | 15 | 15 |    |    |   
  20 | 20 | 20 |    |    |   
-  5 |  5 |    |    |    |
-  6 |  6 |    |    |    |
-  9 |  9 |    |    |    |
- 10 | 10 |    |    |    |
+  5 |  5 |    |    |    |   
+  6 |  6 |    |    |    |   
+  9 |  9 |    |    |    |   
+ 10 | 10 |    |    |    |   
  11 | 11 | 11 |    |    |   
  13 | 13 | 13 |    |    |   
  14 | 14 | 14 |    |    |   
  17 | 17 | 17 |    |    |   
-  2 |  2 |    |    |    |
-  3 |  3 |    |    |    |
-  4 |  4 |    |    |    |
-  7 |  7 |    |    |    |
-  8 |  8 |    |    |    |
- 16 | 16 | 16 |    |    |
- 18 | 18 | 18 |    |    |
- 19 | 19 | 19 |    |    |
 (20 rows)
 
 explain select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not distinct from a3;

--- a/src/test/regress/expected/bfv_joins.out
+++ b/src/test/regress/expected/bfv_joins.out
@@ -3346,7 +3346,7 @@ INNER JOIN member_subgroup
 ON member_group.group_id = member_subgroup.group_id
 LEFT OUTER JOIN region
 ON (member_group.group_id IN (12,13,14,15) AND member_subgroup.subgroup_name = region.county_name);
-                                               QUERY PLAN
+                                               QUERY PLAN                                                
 ---------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice5; segments: 3)
    ->  Hash Left Join
@@ -3687,7 +3687,7 @@ EXPLAIN SELECT a, b FROM gp_float1 JOIN gp_float2 ON a = c AND b = float8 '3.0';
 -- datatype is compatible with the distribution key, the other's is not. We can
 -- redistribute based on the compatible constant.
 EXPLAIN SELECT a, b FROM gp_float1 JOIN gp_float2 ON a = c AND b = float8 '3.0' AND b = float4 '3.0';
-                                             QUERY PLAN
+                                             QUERY PLAN                                             
 ----------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)  (cost=2.21..5.49 rows=5 width=8)
    ->  Hash Join  (cost=2.21..5.39 rows=2 width=8)
@@ -3728,7 +3728,7 @@ set enable_seqscan = off;
 set enable_bitmapscan = off;
 analyze t_9427;
 explain (costs off) select * from t_9427 where a in (select a from t_9427 where c < 100 ) and a < 200;
-                                                                  QUERY PLAN
+                                                                  QUERY PLAN                                                                   
 -----------------------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Merge Join
@@ -3839,14 +3839,6 @@ select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not distinct from
 select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not distinct from a3 and b2 = b3;
  a1 | b1 | a2 | b2 | a3 | b3 
 ----+----+----+----+----+----
-  2 |  2 |    |    |    |   
-  3 |  3 |    |    |    |   
-  4 |  4 |    |    |    |   
-  7 |  7 |    |    |    |   
-  8 |  8 |    |    |    |   
- 16 | 16 | 16 |    |    |   
- 18 | 18 | 18 |    |    |   
- 19 | 19 | 19 |    |    |   
   1 |  1 |    |    |    |   
  12 | 12 | 12 |    |    |   
  15 | 15 | 15 |    |    |   
@@ -3859,10 +3851,18 @@ select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not distinct from
  13 | 13 | 13 |    |    |   
  14 | 14 | 14 |    |    |   
  17 | 17 | 17 |    |    |   
+  2 |  2 |    |    |    |   
+  3 |  3 |    |    |    |   
+  4 |  4 |    |    |    |   
+  7 |  7 |    |    |    |   
+  8 |  8 |    |    |    |   
+ 16 | 16 | 16 |    |    |   
+ 18 | 18 | 18 |    |    |   
+ 19 | 19 | 19 |    |    |   
 (20 rows)
 
 explain select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not distinct from a3;
-                                                     QUERY PLAN
+                                                     QUERY PLAN                                                      
 ---------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)  (cost=40000000007.26..40000000009.47 rows=20 width=24)
    ->  Nested Loop Left Join  (cost=40000000007.26..40000000009.47 rows=7 width=24)
@@ -3882,7 +3882,7 @@ explain select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not disti
 (15 rows)
 
 explain select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not distinct from a3 and b2 is distinct from b3;
-                                                     QUERY PLAN
+                                                     QUERY PLAN                                                      
 ---------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)  (cost=40000000007.26..40000000009.62 rows=20 width=24)
    ->  Nested Loop Left Join  (cost=40000000007.26..40000000009.62 rows=7 width=24)
@@ -3902,7 +3902,7 @@ explain select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not disti
 (15 rows)
 
 explain select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not distinct from a3 and b2 = b3;
-                                                     QUERY PLAN
+                                                     QUERY PLAN                                                      
 ---------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)  (cost=30000000009.12..30000000009.25 rows=20 width=24)
    ->  Merge Left Join  (cost=30000000009.12..30000000009.25 rows=7 width=24)
@@ -3972,7 +3972,7 @@ insert into baz values ('cd  '); -- 2 trailing spaces
 -- varchar cast to bpchar
 -- 'cd' matches 'cd', returns 1 row
 explain select varchar_3, char_3 from foo join bar on varchar_3=char_3;
-                                                       QUERY PLAN
+                                                       QUERY PLAN                                                       
 ------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)  (cost=20000000002.06..20000000002.08 rows=4 width=7)
    ->  Merge Join  (cost=20000000002.06..20000000002.08 rows=2 width=7)
@@ -3997,7 +3997,7 @@ select varchar_3, char_3 from foo join bar on varchar_3=char_3;
 -- char cast to text
 -- 'cd' doesn't match 'cd  ', returns 0 rows
 explain select char_3, text_any from bar join baz on char_3=text_any;
-                                                          QUERY PLAN
+                                                          QUERY PLAN                                                          
 ------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)  (cost=20000000002.06..20000000002.09 rows=4 width=9)
    ->  Merge Join  (cost=20000000002.06..20000000002.09 rows=2 width=9)
@@ -4027,7 +4027,7 @@ select char_3, text_any from bar join baz on char_3=text_any;
 -- Notice ORCA changes join order to minimize motion
 explain select varchar_3, char_3, text_any from foo join bar on varchar_3=char_3
 join baz on varchar_3=text_any;
-                                                             QUERY PLAN
+                                                             QUERY PLAN                                                             
 ------------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice3; segments: 3)  (cost=30000000003.19..30000000003.35 rows=4 width=12)
    ->  Merge Join  (cost=30000000003.19..30000000003.35 rows=2 width=12)

--- a/src/test/regress/expected/bfv_joins.out
+++ b/src/test/regress/expected/bfv_joins.out
@@ -11,13 +11,16 @@ create table y (a int, b int, c int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 insert into y (select * from x);
-CREATE TABLE t1 (a int, b int);
+CREATE TABLE t1 (a int, b int, c int not null);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 CREATE TABLE t2 (a int, b int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-INSERT INTO t1 VALUES (1,1),(2,1),(3,NULL);
+CREATE TABLE t3 (a int not null, b int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO t1 VALUES (1,1,1),(2,1,2),(3,NULL,3);
 INSERT INTO t2 VALUES (2,3);
 CREATE FUNCTION func_x(x int) RETURNS int AS $$
 BEGIN
@@ -626,37 +629,312 @@ SELECT * from x left join y on True where func_x(y.a) > 0;
 (100 rows)
 
 SELECT * FROM t1 LEFT OUTER JOIN t2 ON t1.a = t2.a WHERE t1.b IS DISTINCT FROM t2.b;
- a | b | a | b 
----+---+---+---
- 1 | 1 |   |  
- 2 | 1 | 2 | 3
+ a | b | c | a | b
+---+---+---+---+---
+ 2 | 1 | 2 | 2 | 3
+ 1 | 1 | 1 |   |
 (2 rows)
 
 SELECT * FROM t1 LEFT OUTER JOIN t2 ON t1.a = t2.a WHERE t1.b IS DISTINCT FROM NULL;
- a | b | a | b 
----+---+---+---
- 1 | 1 |   |  
- 2 | 1 | 2 | 3
+ a | b | c | a | b
+---+---+---+---+---
+ 2 | 1 | 2 | 2 | 3
+ 1 | 1 | 1 |   |
 (2 rows)
 
 SELECT * FROM t1 LEFT OUTER JOIN t2 ON t1.a = t2.a WHERE t2.b IS DISTINCT FROM NULL;
- a | b | a | b 
----+---+---+---
- 2 | 1 | 2 | 3
+ a | b | c | a | b
+---+---+---+---+---
+ 2 | 1 | 2 | 2 | 3
 (1 row)
 
 SELECT * FROM t1 LEFT OUTER JOIN t2 ON t1.a = t2.a WHERE t2.b IS NOT DISTINCT FROM NULL;
- a | b | a | b 
----+---+---+---
- 1 | 1 |   |  
- 3 |   |   |  
+ a | b | c | a | b
+---+---+---+---+---
+ 1 | 1 | 1 |   |
+ 3 |   | 3 |   |
 (2 rows)
 
 SELECT * FROM t1 LEFT OUTER JOIN t2 ON t1.a = t2.a WHERE t1.b IS NOT DISTINCT FROM NULL;
- a | b | a | b 
----+---+---+---
- 3 |   |   |  
+ a | b | c | a | b
+---+---+---+---+---
+ 3 |   | 3 |   |
 (1 row)
+
+--- Tests for LOJ with single predicate uses columns of outer child only
+explain select t1.* from t1 left outer join t3 on t1.b=1;
+                                               QUERY PLAN
+--------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..10059962503.02 rows=6068410 width=12)
+   ->  Nested Loop Left Join  (cost=10000000000.00..10059881590.89 rows=2022803 width=12)
+         Join Filter: (t1.b = 1)
+         ->  Seq Scan on t1  (cost=0.00..293.67 rows=25967 width=12)
+         ->  Materialize  (cost=0.00..1721.83 rows=77900 width=0)
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1332.33 rows=77900 width=0)
+                     ->  Seq Scan on t3  (cost=0.00..293.67 rows=25967 width=0)
+ Optimizer: Postgres query optimizer
+(8 rows)
+
+select t1.* from t1 left outer join t3 on t1.b=1;
+ a | b | c
+---+---+---
+ 1 | 1 | 1
+ 2 | 1 | 2
+ 3 |   | 3
+(3 rows)
+
+explain select t1.* from t1 left outer join t3 on t1.c=1;
+                                               QUERY PLAN
+--------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..10059962503.02 rows=6068410 width=12)
+   ->  Nested Loop Left Join  (cost=10000000000.00..10059881590.89 rows=2022803 width=12)
+         Join Filter: (t1.c = 1)
+         ->  Seq Scan on t1  (cost=0.00..293.67 rows=25967 width=12)
+         ->  Materialize  (cost=0.00..1721.83 rows=77900 width=0)
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1332.33 rows=77900 width=0)
+                     ->  Seq Scan on t3  (cost=0.00..293.67 rows=25967 width=0)
+ Optimizer: Postgres query optimizer
+(8 rows)
+
+select t1.* from t1 left outer join t3 on t1.c=1;
+ a | b | c
+---+---+---
+ 1 | 1 | 1
+ 2 | 1 | 2
+ 3 |   | 3
+(3 rows)
+
+--- Tests for LOJ with null-filtering on self check conditions.
+--- make sure that we dont optimize the equality checks of inner table of LOJ.
+explain SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t3.a = t3.a IS NULL;
+                                               QUERY PLAN
+---------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..10040215447.37 rows=1011401667 width=4)
+   ->  Nested Loop Left Join  (cost=10000000000.00..10026730091.81 rows=337133889 width=4)
+         Filter: ((t3.a = t3.a) IS NULL)
+         ->  Seq Scan on t1  (cost=0.00..293.67 rows=25967 width=4)
+         ->  Materialize  (cost=0.00..834.64 rows=25967 width=4)
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..704.81 rows=25967 width=4)
+                     ->  Seq Scan on t3  (cost=0.00..358.58 rows=8656 width=4)
+                           Filter: (b > a)
+ Optimizer: Postgres query optimizer
+(9 rows)
+
+SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t3.a = t3.a IS NULL;
+ c
+---
+ 2
+ 3
+ 1
+(3 rows)
+
+explain SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t1.c = t1.c IS NULL;
+                                              QUERY PLAN
+-------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..10000052373.42 rows=2022803 width=4)
+   ->  Nested Loop Left Join  (cost=10000000000.00..10000025402.71 rows=674268 width=4)
+         ->  Seq Scan on t1  (cost=0.00..358.58 rows=26 width=4)
+               Filter: ((c = c) IS NULL)
+         ->  Materialize  (cost=0.00..834.64 rows=25967 width=0)
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..704.81 rows=25967 width=0)
+                     ->  Seq Scan on t3  (cost=0.00..358.58 rows=8656 width=0)
+                           Filter: (b > a)
+ Optimizer: Postgres query optimizer
+(9 rows)
+
+SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t1.c = t1.c IS NULL;
+ c
+---
+(0 rows)
+
+explain SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t3.a = t3.a IS NULL and t3.b=2;
+                                             QUERY PLAN
+-----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..10000002619.50 rows=101101 width=4)
+   ->  Nested Loop  (cost=10000000000.00..10000001271.49 rows=33700 width=4)
+         ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..553.36 rows=1 width=0)
+               ->  Seq Scan on t3  (cost=0.00..553.33 rows=1 width=0)
+                     Filter: ((b > a) AND ((a = a) IS NULL) AND (2 > a) AND (b = 2))
+         ->  Seq Scan on t1  (cost=0.00..293.67 rows=25967 width=4)
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t3.a = t3.a IS NULL and t3.a=2;
+ c
+---
+(0 rows)
+
+explain SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t3.a = t3.a IS NULL and t1.b=1;
+                                              QUERY PLAN
+-------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..10000040573.74 rows=1011402 width=4)
+   ->  Nested Loop Left Join  (cost=10000000000.00..10000027088.38 rows=337134 width=4)
+         Filter: ((t3.a = t3.a) IS NULL)
+         ->  Seq Scan on t1  (cost=0.00..358.58 rows=26 width=4)
+               Filter: (b = 1)
+         ->  Materialize  (cost=0.00..834.64 rows=25967 width=4)
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..704.81 rows=25967 width=4)
+                     ->  Seq Scan on t3  (cost=0.00..358.58 rows=8656 width=4)
+                           Filter: (b > a)
+ Optimizer: Postgres query optimizer
+(10 rows)
+
+SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t3.a = t3.a IS NULL and t1.b=1;
+ c
+---
+ 2
+ 1
+(2 rows)
+
+explain SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t3.a = t3.a IS NULL or t3.a is NULL;
+                                               QUERY PLAN
+---------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..10046958125.15 rows=1517102500 width=4)
+   ->  Nested Loop Left Join  (cost=10000000000.00..10026730091.81 rows=505700833 width=4)
+         Filter: (((t3.a = t3.a) IS NULL) OR (t3.a IS NULL))
+         ->  Seq Scan on t1  (cost=0.00..293.67 rows=25967 width=4)
+         ->  Materialize  (cost=0.00..834.64 rows=25967 width=4)
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..704.81 rows=25967 width=4)
+                     ->  Seq Scan on t3  (cost=0.00..358.58 rows=8656 width=4)
+                           Filter: (b > a)
+ Optimizer: Postgres query optimizer
+(9 rows)
+
+SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t3.a = t3.a IS NULL or t3.a is NULL;
+ c
+---
+ 2
+ 3
+ 1
+(3 rows)
+
+explain SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t3.a = t3.a IS NULL or t3.b=2;
+                                               QUERY PLAN
+---------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..10041914602.17 rows=1012413068 width=4)
+   ->  Nested Loop Left Join  (cost=10000000000.00..10028415761.26 rows=337471023 width=4)
+         Filter: (((t3.a = t3.a) IS NULL) OR (t3.b = 2))
+         ->  Seq Scan on t1  (cost=0.00..293.67 rows=25967 width=4)
+         ->  Materialize  (cost=0.00..834.64 rows=25967 width=8)
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..704.81 rows=25967 width=8)
+                     ->  Seq Scan on t3  (cost=0.00..358.58 rows=8656 width=8)
+                           Filter: (b > a)
+ Optimizer: Postgres query optimizer
+(9 rows)
+
+SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t3.a = t3.a IS NULL or t3.b=2;
+ c
+---
+ 2
+ 3
+ 1
+(3 rows)
+
+explain SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t3.a = t3.a IS NULL or t1.a=1;
+                                               QUERY PLAN
+---------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..10041914602.17 rows=1012413068 width=4)
+   ->  Nested Loop Left Join  (cost=10000000000.00..10028415761.26 rows=337471023 width=4)
+         Filter: (((t3.a = t3.a) IS NULL) OR (t1.a = 1))
+         ->  Seq Scan on t1  (cost=0.00..293.67 rows=25967 width=8)
+         ->  Materialize  (cost=0.00..834.64 rows=25967 width=4)
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..704.81 rows=25967 width=4)
+                     ->  Seq Scan on t3  (cost=0.00..358.58 rows=8656 width=4)
+                           Filter: (b > a)
+ Optimizer: Postgres query optimizer
+(9 rows)
+
+SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t3.a = t3.a IS NULL or t1.a=1;
+ c
+---
+ 2
+ 3
+ 1
+(3 rows)
+
+explain SELECT t.c FROM (select t1.*, t1.a+t1.b as cc from t1)t LEFT OUTER JOIN t3 ON t.cc = t.cc IS NULL;
+                                               QUERY PLAN
+---------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..10110451674.22 rows=3034205000 width=4)
+   ->  Nested Loop Left Join  (cost=10000000000.00..10069995607.56 rows=1011401667 width=4)
+         Join Filter: (((t1.a + t1.b) = (t1.a + t1.b)) IS NULL)
+         ->  Seq Scan on t1  (cost=0.00..293.67 rows=25967 width=12)
+         ->  Materialize  (cost=0.00..1721.83 rows=77900 width=0)
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1332.33 rows=77900 width=0)
+                     ->  Seq Scan on t3  (cost=0.00..293.67 rows=25967 width=0)
+ Optimizer: Postgres query optimizer
+(8 rows)
+
+SELECT t.c FROM (select t1.*, t1.a+t1.b as cc from t1)t LEFT OUTER JOIN t3 ON t.cc = t.cc IS NULL;
+ c
+---
+ 2
+ 3
+ 1
+(3 rows)
+
+explain SELECT t.c FROM (select t1.*, t1.a+t1.b as cc from t1)t LEFT OUTER JOIN t3 ON t3.a > t3.b where t.cc = t.cc IS NULL;
+                                              QUERY PLAN
+-------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..10000052503.26 rows=2022803 width=4)
+   ->  Nested Loop Left Join  (cost=10000000000.00..10000025532.55 rows=674268 width=4)
+         ->  Seq Scan on t1  (cost=0.00..488.42 rows=26 width=4)
+               Filter: (((a + b) = (a + b)) IS NULL)
+         ->  Materialize  (cost=0.00..834.64 rows=25967 width=0)
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..704.81 rows=25967 width=0)
+                     ->  Seq Scan on t3  (cost=0.00..358.58 rows=8656 width=0)
+                           Filter: (a > b)
+ Optimizer: Postgres query optimizer
+(9 rows)
+
+SELECT t.c FROM (select t1.*, t1.a+t1.b as cc from t1)t LEFT OUTER JOIN t3 ON t3.a > t3.b where t.cc = t.cc IS NULL;
+ c
+---
+ 3
+(1 row)
+
+explain SELECT t1.c FROM t1 LEFT OUTER JOIN (select t3.*, t3.a+t3.b as cc from t3)t ON t.cc = t.cc IS NULL;
+                                              QUERY PLAN
+------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..10012810957.32 rows=6068410 width=4)
+   ->  Nested Loop Left Join  (cost=10000000000.00..10012730045.19 rows=2022803 width=4)
+         ->  Seq Scan on t1  (cost=0.00..293.67 rows=25967 width=4)
+         ->  Materialize  (cost=0.00..489.84 rows=78 width=0)
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..489.46 rows=78 width=0)
+                     ->  Seq Scan on t3  (cost=0.00..488.42 rows=26 width=0)
+                           Filter: (((a + b) = (a + b)) IS NULL)
+ Optimizer: Postgres query optimizer
+(8 rows)
+
+SELECT t1.c FROM t1 LEFT OUTER JOIN (select t3.*, t3.a+t3.b as cc from t3)t ON t.cc = t.cc IS NULL;
+ c
+---
+ 2
+ 3
+ 1
+(3 rows)
+
+explain SELECT t1.c FROM t1 LEFT OUTER JOIN (select t3.*, t3.a+t3.b as cc from t3)t ON t.b > t.a WHERE t.cc = t.cc IS NULL;
+                                               QUERY PLAN
+---------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..10043586786.26 rows=1011401667 width=4)
+   ->  Nested Loop Left Join  (cost=10000000000.00..10030101430.70 rows=337133889 width=4)
+         Filter: (((t3.a + t3.b) = (t3.a + t3.b)) IS NULL)
+         ->  Seq Scan on t1  (cost=0.00..293.67 rows=25967 width=4)
+         ->  Materialize  (cost=0.00..834.64 rows=25967 width=8)
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..704.81 rows=25967 width=8)
+                     ->  Seq Scan on t3  (cost=0.00..358.58 rows=8656 width=8)
+                           Filter: (b > a)
+ Optimizer: Postgres query optimizer
+(9 rows)
+
+SELECT t1.c FROM t1 LEFT OUTER JOIN (select t3.*, t3.a+t3.b as cc from t3)t ON t.b > t.a WHERE t.cc = t.cc IS NULL;
+ c
+---
+ 2
+ 3
+ 1
+(3 rows)
 
 -- Test for unexpected NLJ qual
 --
@@ -3017,7 +3295,7 @@ SELECT count(*)
 FROM mpp25537_facttable1 ft, mpp25537_dimdate dt, mpp25537_dimtabl1 dt1
 WHERE ft.wk_id = dt.wk_id
 AND ft.id = dt1.id;
- count 
+ count
 -------
      4
 (1 row)
@@ -3067,7 +3345,7 @@ INNER JOIN member_subgroup
 ON member_group.group_id = member_subgroup.group_id
 LEFT OUTER JOIN region
 ON (member_group.group_id IN (12,13,14,15) AND member_subgroup.subgroup_name = region.county_name);
-                                               QUERY PLAN                                                
+                                               QUERY PLAN
 ---------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice5; segments: 3)
    ->  Hash Left Join
@@ -3337,7 +3615,7 @@ explain select a.*, b.i, c.* from a, b, c where ((mt_col).x > a.i or b.i = a.i) 
 (13 rows)
 
 select a.*, b.i, c.* from a, b, c where ((mt_col).x > a.i or b.i = a.i) and (a.i + b.i) = c.j;
- i | i | i | j 
+ i | i | i | j
 ---+---+---+---
  1 | 1 | 2 | 2
 (1 row)
@@ -3408,7 +3686,7 @@ EXPLAIN SELECT a, b FROM gp_float1 JOIN gp_float2 ON a = c AND b = float8 '3.0';
 -- datatype is compatible with the distribution key, the other's is not. We can
 -- redistribute based on the compatible constant.
 EXPLAIN SELECT a, b FROM gp_float1 JOIN gp_float2 ON a = c AND b = float8 '3.0' AND b = float4 '3.0';
-                                             QUERY PLAN                                             
+                                             QUERY PLAN
 ----------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)  (cost=2.21..5.49 rows=5 width=8)
    ->  Hash Join  (cost=2.21..5.39 rows=2 width=8)
@@ -3449,7 +3727,7 @@ set enable_seqscan = off;
 set enable_bitmapscan = off;
 analyze t_9427;
 explain (costs off) select * from t_9427 where a in (select a from t_9427 where c < 100 ) and a < 200;
-                                                                  QUERY PLAN                                                                   
+                                                                  QUERY PLAN
 -----------------------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Merge Join
@@ -3518,10 +3796,10 @@ select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not distinct from
   6 |  6 |    |    |    | 20
   9 |  9 |    |    |    | 20
  10 | 10 |    |    |    | 20
- 11 | 11 | 11 |    |    |   
- 13 | 13 | 13 |    |    |   
- 14 | 14 | 14 |    |    |   
- 17 | 17 | 17 |    |    |   
+ 11 | 11 | 11 |    |    |
+ 13 | 13 | 13 |    |    |
+ 14 | 14 | 14 |    |    |
+ 17 | 17 | 17 |    |    |
   2 |  2 |    |    |    | 20
   3 |  3 |    |    |    | 20
   4 |  4 |    |    |    | 20
@@ -3529,7 +3807,7 @@ select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not distinct from
   8 |  8 |    |    |    | 20
  16 | 16 | 16 |    |    |   
  18 | 18 | 18 |    |    |   
- 19 | 19 | 19 |    |    |   
+ 19 | 19 | 19 |    |    |
 (20 rows)
 
 select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not distinct from a3 and b2 is distinct from b3;
@@ -3540,9 +3818,9 @@ select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not distinct from
   4 |  4 |    |    |    | 20
   7 |  7 |    |    |    | 20
   8 |  8 |    |    |    | 20
- 16 | 16 | 16 |    |    |   
- 18 | 18 | 18 |    |    |   
- 19 | 19 | 19 |    |    |   
+ 16 | 16 | 16 |    |    |
+ 18 | 18 | 18 |    |    |
+ 19 | 19 | 19 |    |    |
   1 |  1 |    |    |    | 20
  12 | 12 | 12 |    |    |   
  15 | 15 | 15 |    |    |   
@@ -3554,36 +3832,36 @@ select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not distinct from
  11 | 11 | 11 |    |    |   
  13 | 13 | 13 |    |    |   
  14 | 14 | 14 |    |    |   
- 17 | 17 | 17 |    |    |   
+ 17 | 17 | 17 |    |    |
 (20 rows)
 
 select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not distinct from a3 and b2 = b3;
  a1 | b1 | a2 | b2 | a3 | b3 
 ----+----+----+----+----+----
-  1 |  1 |    |    |    |   
- 12 | 12 | 12 |    |    |   
+  1 |  1 |    |    |    |
+ 12 | 12 | 12 |    |    |
  15 | 15 | 15 |    |    |   
  20 | 20 | 20 |    |    |   
-  5 |  5 |    |    |    |   
-  6 |  6 |    |    |    |   
-  9 |  9 |    |    |    |   
- 10 | 10 |    |    |    |   
+  5 |  5 |    |    |    |
+  6 |  6 |    |    |    |
+  9 |  9 |    |    |    |
+ 10 | 10 |    |    |    |
  11 | 11 | 11 |    |    |   
  13 | 13 | 13 |    |    |   
  14 | 14 | 14 |    |    |   
  17 | 17 | 17 |    |    |   
-  2 |  2 |    |    |    |   
-  3 |  3 |    |    |    |   
-  4 |  4 |    |    |    |   
-  7 |  7 |    |    |    |   
-  8 |  8 |    |    |    |   
- 16 | 16 | 16 |    |    |   
- 18 | 18 | 18 |    |    |   
- 19 | 19 | 19 |    |    |   
+  2 |  2 |    |    |    |
+  3 |  3 |    |    |    |
+  4 |  4 |    |    |    |
+  7 |  7 |    |    |    |
+  8 |  8 |    |    |    |
+ 16 | 16 | 16 |    |    |
+ 18 | 18 | 18 |    |    |
+ 19 | 19 | 19 |    |    |
 (20 rows)
 
 explain select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not distinct from a3;
-                                                     QUERY PLAN                                                      
+                                                     QUERY PLAN
 ---------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)  (cost=40000000007.26..40000000009.47 rows=20 width=24)
    ->  Nested Loop Left Join  (cost=40000000007.26..40000000009.47 rows=7 width=24)
@@ -3603,7 +3881,7 @@ explain select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not disti
 (15 rows)
 
 explain select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not distinct from a3 and b2 is distinct from b3;
-                                                     QUERY PLAN                                                      
+                                                     QUERY PLAN
 ---------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)  (cost=40000000007.26..40000000009.62 rows=20 width=24)
    ->  Nested Loop Left Join  (cost=40000000007.26..40000000009.62 rows=7 width=24)
@@ -3623,7 +3901,7 @@ explain select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not disti
 (15 rows)
 
 explain select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not distinct from a3 and b2 = b3;
-                                                     QUERY PLAN                                                      
+                                                     QUERY PLAN
 ---------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)  (cost=30000000009.12..30000000009.25 rows=20 width=24)
    ->  Merge Left Join  (cost=30000000009.12..30000000009.25 rows=7 width=24)
@@ -3693,7 +3971,7 @@ insert into baz values ('cd  '); -- 2 trailing spaces
 -- varchar cast to bpchar
 -- 'cd' matches 'cd', returns 1 row
 explain select varchar_3, char_3 from foo join bar on varchar_3=char_3;
-                                                       QUERY PLAN                                                       
+                                                       QUERY PLAN
 ------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)  (cost=20000000002.06..20000000002.08 rows=4 width=7)
    ->  Merge Join  (cost=20000000002.06..20000000002.08 rows=2 width=7)
@@ -3718,7 +3996,7 @@ select varchar_3, char_3 from foo join bar on varchar_3=char_3;
 -- char cast to text
 -- 'cd' doesn't match 'cd  ', returns 0 rows
 explain select char_3, text_any from bar join baz on char_3=text_any;
-                                                          QUERY PLAN                                                          
+                                                          QUERY PLAN
 ------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)  (cost=20000000002.06..20000000002.09 rows=4 width=9)
    ->  Merge Join  (cost=20000000002.06..20000000002.09 rows=2 width=9)
@@ -3748,7 +4026,7 @@ select char_3, text_any from bar join baz on char_3=text_any;
 -- Notice ORCA changes join order to minimize motion
 explain select varchar_3, char_3, text_any from foo join bar on varchar_3=char_3
 join baz on varchar_3=text_any;
-                                                             QUERY PLAN                                                             
+                                                             QUERY PLAN
 ------------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice3; segments: 3)  (cost=30000000003.19..30000000003.35 rows=4 width=12)
    ->  Merge Join  (cost=30000000003.19..30000000003.35 rows=2 width=12)

--- a/src/test/regress/expected/bfv_joins_optimizer.out
+++ b/src/test/regress/expected/bfv_joins_optimizer.out
@@ -11,13 +11,16 @@ create table y (a int, b int, c int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 insert into y (select * from x);
-CREATE TABLE t1 (a int, b int);
+CREATE TABLE t1 (a int, b int, c int not null);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 CREATE TABLE t2 (a int, b int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-INSERT INTO t1 VALUES (1,1),(2,1),(3,NULL);
+CREATE TABLE t3 (a int not null, b int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO t1 VALUES (1,1,1),(2,1,2),(3,NULL,3);
 INSERT INTO t2 VALUES (2,3);
 CREATE FUNCTION func_x(x int) RETURNS int AS $$
 BEGIN
@@ -623,42 +626,336 @@ SELECT * from x left join y on True where func_x(y.a) > 0;
 (100 rows)
 
 SELECT * FROM t1 LEFT OUTER JOIN t2 ON t1.a = t2.a WHERE t1.b IS DISTINCT FROM t2.b;
- a | b | a | b 
----+---+---+---
- 1 | 1 |   |  
- 2 | 1 | 2 | 3
+ a | b | c | a | b
+---+---+---+---+---
+ 2 | 1 | 2 | 2 | 3
+ 1 | 1 | 1 |   |
 (2 rows)
 
 SELECT * FROM t1 LEFT OUTER JOIN t2 ON t1.a = t2.a WHERE t1.b IS DISTINCT FROM NULL;
- a | b | a | b 
----+---+---+---
- 1 | 1 |   |  
- 2 | 1 | 2 | 3
+ a | b | c | a | b
+---+---+---+---+---
+ 1 | 1 | 1 |   |
+ 2 | 1 | 2 | 2 | 3
 (2 rows)
 
 SELECT * FROM t1 LEFT OUTER JOIN t2 ON t1.a = t2.a WHERE t2.b IS DISTINCT FROM NULL;
- a | b | a | b 
----+---+---+---
- 2 | 1 | 2 | 3
+ a | b | c | a | b
+---+---+---+---+---
+ 2 | 1 | 2 | 2 | 3
 (1 row)
 
 SELECT * FROM t1 LEFT OUTER JOIN t2 ON t1.a = t2.a WHERE t2.b IS NOT DISTINCT FROM NULL;
- a | b | a | b 
----+---+---+---
- 1 | 1 |   |  
- 3 |   |   |  
+ a | b | c | a | b
+---+---+---+---+---
+ 3 |   | 3 |   |
+ 1 | 1 | 1 |   |
 (2 rows)
 
 SELECT * FROM t1 LEFT OUTER JOIN t2 ON t1.a = t2.a WHERE t1.b IS NOT DISTINCT FROM NULL;
- a | b | a | b 
----+---+---+---
- 3 |   |   |  
+ a | b | c | a | b
+---+---+---+---+---
+ 3 |   | 3 |   |
 (1 row)
+
+--- Tests for LOJ with single predicate uses columns of outer child only
+explain select t1.* from t1 left outer join t3 on t1.b=1;
+                                            QUERY PLAN
+---------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1324032.10 rows=1 width=12)
+   ->  Nested Loop Left Join  (cost=0.00..1324032.10 rows=1 width=12)
+         Join Filter: (t1.b = 1)
+         ->  Seq Scan on t1  (cost=0.00..431.00 rows=1 width=12)
+         ->  Materialize  (cost=0.00..431.00 rows=1 width=1)
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
+                     ->  Seq Scan on t3  (cost=0.00..431.00 rows=1 width=1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(8 rows)
+
+select t1.* from t1 left outer join t3 on t1.b=1;
+ a | b | c
+---+---+---
+ 2 | 1 | 2
+ 3 |   | 3
+ 1 | 1 | 1
+(3 rows)
+
+explain select t1.* from t1 left outer join t3 on t1.c=1;
+                                            QUERY PLAN
+---------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1324032.10 rows=1 width=12)
+   ->  Nested Loop Left Join  (cost=0.00..1324032.10 rows=1 width=12)
+         Join Filter: (t1.c = 1)
+         ->  Seq Scan on t1  (cost=0.00..431.00 rows=1 width=12)
+         ->  Materialize  (cost=0.00..431.00 rows=1 width=1)
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
+                     ->  Seq Scan on t3  (cost=0.00..431.00 rows=1 width=1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(8 rows)
+
+select t1.* from t1 left outer join t3 on t1.c=1;
+ a | b | c
+---+---+---
+ 2 | 1 | 2
+ 3 |   | 3
+ 1 | 1 | 1
+(3 rows)
+
+--- Tests for LOJ with null-filtering on self check conditions.
+--- make sure that we dont optimize the equality checks of inner table of LOJ.
+explain SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t3.a = t3.a IS NULL;
+                                               QUERY PLAN
+---------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1324032.37 rows=1 width=4)
+   ->  Result  (cost=0.00..1324032.37 rows=1 width=4)
+         Filter: ((t3.a = t3.a) IS NULL)
+         ->  Nested Loop Left Join  (cost=0.00..1324032.37 rows=1 width=8)
+               Join Filter: true
+               ->  Seq Scan on t1  (cost=0.00..431.00 rows=1 width=4)
+               ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
+                     ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                           ->  Seq Scan on t3  (cost=0.00..431.00 rows=1 width=4)
+                                 Filter: (b > a)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(11 rows)
+
+SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t3.a = t3.a IS NULL;
+ c
+---
+ 1
+ 2
+ 3
+(3 rows)
+
+explain SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t1.c = t1.c IS NULL;
+                                            QUERY PLAN
+---------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1324032.14 rows=2 width=4)
+   ->  Nested Loop Left Join  (cost=0.00..1324032.14 rows=1 width=4)
+         Join Filter: true
+         ->  Seq Scan on t1  (cost=0.00..431.00 rows=1 width=4)
+               Filter: (true IS NULL)
+         ->  Materialize  (cost=0.00..431.00 rows=1 width=1)
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
+                     ->  Seq Scan on t3  (cost=0.00..431.00 rows=1 width=1)
+                           Filter: (b > a)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(10 rows)
+
+SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t1.c = t1.c IS NULL;
+ c
+---
+(0 rows)
+
+explain SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t3.a = t3.a IS NULL and t3.b=2;
+                                            QUERY PLAN
+---------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1324032.13 rows=1 width=4)
+   ->  Nested Loop  (cost=0.00..1324032.13 rows=1 width=4)
+         Join Filter: true
+         ->  Seq Scan on t1  (cost=0.00..431.00 rows=1 width=4)
+         ->  Materialize  (cost=0.00..431.00 rows=1 width=1)
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
+                     ->  Seq Scan on t3  (cost=0.00..431.00 rows=1 width=1)
+                           Filter: ((true IS NULL) AND (b = 2) AND (b > a))
+ Optimizer: Pivotal Optimizer (GPORCA)
+(9 rows)
+
+SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t3.a = t3.a IS NULL and t3.a=2;
+ c
+---
+(0 rows)
+
+explain SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t3.a = t3.a IS NULL and t1.b=1;
+                                               QUERY PLAN
+---------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1324032.38 rows=1 width=4)
+   ->  Result  (cost=0.00..1324032.38 rows=1 width=4)
+         Filter: ((t3.a = t3.a) IS NULL)
+         ->  Nested Loop Left Join  (cost=0.00..1324032.38 rows=1 width=8)
+               Join Filter: true
+               ->  Seq Scan on t1  (cost=0.00..431.00 rows=1 width=4)
+                     Filter: (b = 1)
+               ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
+                     ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                           ->  Seq Scan on t3  (cost=0.00..431.00 rows=1 width=4)
+                                 Filter: (b > a)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(12 rows)
+
+SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t3.a = t3.a IS NULL and t1.b=1;
+ c
+---
+ 1
+ 2
+(2 rows)
+
+explain SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t3.a = t3.a IS NULL or t3.a is NULL;
+                                               QUERY PLAN
+---------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1324032.37 rows=1 width=4)
+   ->  Result  (cost=0.00..1324032.37 rows=1 width=4)
+         Filter: (((t3.a = t3.a) IS NULL) OR (t3.a IS NULL))
+         ->  Nested Loop Left Join  (cost=0.00..1324032.37 rows=1 width=8)
+               Join Filter: true
+               ->  Seq Scan on t1  (cost=0.00..431.00 rows=1 width=4)
+               ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
+                     ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                           ->  Seq Scan on t3  (cost=0.00..431.00 rows=1 width=4)
+                                 Filter: (b > a)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(11 rows)
+
+SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t3.a = t3.a IS NULL or t3.a is NULL;
+ c
+---
+ 2
+ 3
+ 1
+(3 rows)
+
+explain SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t3.a = t3.a IS NULL or t3.b=2;
+                                               QUERY PLAN
+---------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1324032.61 rows=1 width=4)
+   ->  Result  (cost=0.00..1324032.61 rows=1 width=4)
+         Filter: (((t3.a = t3.a) IS NULL) OR (t3.b = 2))
+         ->  Nested Loop Left Join  (cost=0.00..1324032.61 rows=1 width=12)
+               Join Filter: true
+               ->  Seq Scan on t1  (cost=0.00..431.00 rows=1 width=4)
+               ->  Materialize  (cost=0.00..431.00 rows=1 width=8)
+                     ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                           ->  Seq Scan on t3  (cost=0.00..431.00 rows=1 width=8)
+                                 Filter: (b > a)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(11 rows)
+
+SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t3.a = t3.a IS NULL or t3.b=2;
+ c
+---
+ 1
+ 2
+ 3
+(3 rows)
+
+explain SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t3.a = t3.a IS NULL or t1.a=1;
+                                               QUERY PLAN
+---------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1324032.48 rows=1 width=4)
+   ->  Result  (cost=0.00..1324032.48 rows=1 width=4)
+         Filter: (((t3.a = t3.a) IS NULL) OR (t1.a = 1))
+         ->  Nested Loop Left Join  (cost=0.00..1324032.48 rows=1 width=12)
+               Join Filter: true
+               ->  Seq Scan on t1  (cost=0.00..431.00 rows=1 width=8)
+               ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
+                     ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                           ->  Seq Scan on t3  (cost=0.00..431.00 rows=1 width=4)
+                                 Filter: (b > a)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(11 rows)
+
+SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t3.a = t3.a IS NULL or t1.a=1;
+ c
+---
+ 2
+ 3
+ 1
+(3 rows)
+
+explain SELECT t.c FROM (select t1.*, t1.a+t1.b as cc from t1)t LEFT OUTER JOIN t3 ON t.cc = t.cc IS NULL;
+                                            QUERY PLAN
+---------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1324032.13 rows=1 width=4)
+   ->  Nested Loop Left Join  (cost=0.00..1324032.13 rows=1 width=4)
+         Join Filter: ((((t1.a + t1.b)) = ((t1.a + t1.b))) IS NULL)
+         ->  Seq Scan on t1  (cost=0.00..431.00 rows=1 width=12)
+         ->  Materialize  (cost=0.00..431.00 rows=1 width=1)
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
+                     ->  Seq Scan on t3  (cost=0.00..431.00 rows=1 width=1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(8 rows)
+
+SELECT t.c FROM (select t1.*, t1.a+t1.b as cc from t1)t LEFT OUTER JOIN t3 ON t.cc = t.cc IS NULL;
+ c
+---
+ 2
+ 3
+ 1
+(3 rows)
+
+explain SELECT t.c FROM (select t1.*, t1.a+t1.b as cc from t1)t LEFT OUTER JOIN t3 ON t3.a > t3.b where t.cc = t.cc IS NULL;
+                                            QUERY PLAN
+---------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1324032.19 rows=2 width=4)
+   ->  Nested Loop Left Join  (cost=0.00..1324032.19 rows=1 width=4)
+         Join Filter: true
+         ->  Result  (cost=0.00..431.00 rows=1 width=4)
+               Filter: ((((t1.a + t1.b)) = ((t1.a + t1.b))) IS NULL)
+               ->  Seq Scan on t1  (cost=0.00..431.00 rows=1 width=12)
+         ->  Materialize  (cost=0.00..431.00 rows=1 width=1)
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
+                     ->  Seq Scan on t3  (cost=0.00..431.00 rows=1 width=1)
+                           Filter: (a > b)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(11 rows)
+
+SELECT t.c FROM (select t1.*, t1.a+t1.b as cc from t1)t LEFT OUTER JOIN t3 ON t3.a > t3.b where t.cc = t.cc IS NULL;
+ c
+---
+ 3
+(1 row)
+
+explain SELECT t1.c FROM t1 LEFT OUTER JOIN (select t3.*, t3.a+t3.b as cc from t3)t ON t.cc = t.cc IS NULL;
+                                            QUERY PLAN
+---------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1324032.09 rows=2 width=4)
+   ->  Nested Loop Left Join  (cost=0.00..1324032.09 rows=1 width=4)
+         Join Filter: true
+         ->  Seq Scan on t1  (cost=0.00..431.00 rows=1 width=4)
+         ->  Materialize  (cost=0.00..431.00 rows=1 width=1)
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
+                     ->  Result  (cost=0.00..431.00 rows=1 width=1)
+                           Filter: ((((t3.a + t3.b)) = ((t3.a + t3.b))) IS NULL)
+                           ->  Seq Scan on t3  (cost=0.00..431.00 rows=1 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(10 rows)
+
+SELECT t1.c FROM t1 LEFT OUTER JOIN (select t3.*, t3.a+t3.b as cc from t3)t ON t.cc = t.cc IS NULL;
+ c
+---
+ 2
+ 3
+ 1
+(3 rows)
+
+explain SELECT t1.c FROM t1 LEFT OUTER JOIN (select t3.*, t3.a+t3.b as cc from t3)t ON t.b > t.a WHERE t.cc = t.cc IS NULL;
+                                               QUERY PLAN
+---------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1324032.22 rows=1 width=4)
+   ->  Result  (cost=0.00..1324032.22 rows=1 width=4)
+         Filter: ((((t3.a + t3.b)) = ((t3.a + t3.b))) IS NULL)
+         ->  Nested Loop Left Join  (cost=0.00..1324032.22 rows=1 width=8)
+               Join Filter: true
+               ->  Seq Scan on t1  (cost=0.00..431.00 rows=1 width=4)
+               ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
+                     ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                           ->  Seq Scan on t3  (cost=0.00..431.00 rows=1 width=8)
+                                 Filter: (b > a)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(11 rows)
+
+SELECT t1.c FROM t1 LEFT OUTER JOIN (select t3.*, t3.a+t3.b as cc from t3)t ON t.b > t.a WHERE t.cc = t.cc IS NULL;
+ c
+---
+ 2
+ 3
+ 1
+(3 rows)
 
 -- Test for unexpected NLJ qual
 --
 explain select 1 as mrs_t1 where 1 <= ALL (select x from z);
-                                                                                                                                                           QUERY PLAN                                                                                                                                                            
+                                                                                                                                                           QUERY PLAN
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Result  (cost=0.00..882688.11 rows=1 width=4)
    ->  Nested Loop  (cost=0.00..882688.11 rows=1 width=1)
@@ -3019,7 +3316,7 @@ SELECT count(*)
 FROM mpp25537_facttable1 ft, mpp25537_dimdate dt, mpp25537_dimtabl1 dt1
 WHERE ft.wk_id = dt.wk_id
 AND ft.id = dt1.id;
- count 
+ count
 -------
      4
 (1 row)
@@ -3069,7 +3366,7 @@ INNER JOIN member_subgroup
 ON member_group.group_id = member_subgroup.group_id
 LEFT OUTER JOIN region
 ON (member_group.group_id IN (12,13,14,15) AND member_subgroup.subgroup_name = region.county_name);
-                                            QUERY PLAN                                             
+                                            QUERY PLAN
 ---------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice5; segments: 3)
    ->  Hash Left Join
@@ -3109,6 +3406,7 @@ EXPLAIN (costs off) SELECT * FROM coercejoin a, coercejoin b WHERE a.a=b.a;
          ->  Seq Scan on coercejoin
          ->  Hash
                ->  Seq Scan on coercejoin coercejoin_1
+ Optimizer: Pivotal Optimizer (GPORCA)
 (7 rows)
 
 -- Negative test, the join should not be colocated since the cast is a coercion
@@ -3127,6 +3425,7 @@ EXPLAIN (costs off) SELECT * FROM coercejoin a, coercejoin b WHERE a.a::numeric=
                ->  Redistribute Motion 3:3  (slice2; segments: 3)
                      Hash Key: (coercejoin_1.a)::numeric
                      ->  Seq Scan on coercejoin coercejoin_1
+ Optimizer: Pivotal Optimizer (GPORCA)
 (11 rows)
 
 --
@@ -3287,7 +3586,7 @@ set enable_nestloop=on;
 -- Motion node from rescanning! That Materialize node is rescanned, when the
 -- executor parameter 'b.i' changes.
 explain (costs off) select * from a, b, c where b.i = a.i and (a.i + b.i) = c.j;
-                       QUERY PLAN                        
+                       QUERY PLAN
 ---------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)
    ->  Nested Loop
@@ -3336,7 +3635,7 @@ explain select a.*, b.i, c.* from a, b, c where ((mt_col).x > a.i or b.i = a.i) 
 (13 rows)
 
 select a.*, b.i, c.* from a, b, c where ((mt_col).x > a.i or b.i = a.i) and (a.i + b.i) = c.j;
- i | i | i | j 
+ i | i | i | j
 ---+---+---+---
  1 | 1 | 2 | 2
 (1 row)
@@ -3407,7 +3706,7 @@ EXPLAIN SELECT a, b FROM gp_float1 JOIN gp_float2 ON a = c AND b = float8 '3.0';
 -- datatype is compatible with the distribution key, the other's is not. We can
 -- redistribute based on the compatible constant.
 EXPLAIN SELECT a, b FROM gp_float1 JOIN gp_float2 ON a = c AND b = float8 '3.0' AND b = float4 '3.0';
-                                             QUERY PLAN                                             
+                                             QUERY PLAN
 ----------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)  (cost=2.21..5.49 rows=5 width=8)
    ->  Hash Join  (cost=2.21..5.39 rows=2 width=8)
@@ -3448,7 +3747,7 @@ set enable_seqscan = off;
 set enable_bitmapscan = off;
 analyze t_9427;
 explain (costs off) select * from t_9427 where a in (select a from t_9427 where c < 100 ) and a < 200;
-                                                                  QUERY PLAN                                                                   
+                                                                  QUERY PLAN
 -----------------------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Merge Join
@@ -3516,7 +3815,7 @@ select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not distinct from
   8 |  8 |    |    |    | 20
  16 | 16 | 16 |    |    |   
  18 | 18 | 18 |    |    |   
- 19 | 19 | 19 |    |    |   
+ 19 | 19 | 19 |    |    |
   5 |  5 |    |    |    | 20
   6 |  6 |    |    |    | 20
   9 |  9 |    |    |    | 20
@@ -3524,7 +3823,7 @@ select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not distinct from
  11 | 11 | 11 |    |    |   
  13 | 13 | 13 |    |    |   
  14 | 14 | 14 |    |    |   
- 17 | 17 | 17 |    |    |   
+ 17 | 17 | 17 |    |    |
   1 |  1 |    |    |    | 20
  12 | 12 | 12 |    |    |   
  15 | 15 | 15 |    |    |   
@@ -3532,7 +3831,7 @@ select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not distinct from
 (20 rows)
 
 select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not distinct from a3 and b2 is distinct from b3;
- a1 | b1 | a2 | b2 | a3 | b3 
+ a1 | b1 | a2 | b2 | a3 | b3
 ----+----+----+----+----+----
   5 |  5 |    |    |    | 20
   6 |  6 |    |    |    | 20
@@ -3543,17 +3842,17 @@ select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not distinct from
  14 | 14 | 14 |    |    |   
  17 | 17 | 17 |    |    |   
   1 |  1 |    |    |    | 20
- 12 | 12 | 12 |    |    |   
- 15 | 15 | 15 |    |    |   
- 20 | 20 | 20 |    |    |   
+ 12 | 12 | 12 |    |    |
+ 15 | 15 | 15 |    |    |
+ 20 | 20 | 20 |    |    |
   2 |  2 |    |    |    | 20
   3 |  3 |    |    |    | 20
   4 |  4 |    |    |    | 20
   7 |  7 |    |    |    | 20
   8 |  8 |    |    |    | 20
- 16 | 16 | 16 |    |    |   
- 18 | 18 | 18 |    |    |   
- 19 | 19 | 19 |    |    |   
+ 16 | 16 | 16 |    |    |
+ 18 | 18 | 18 |    |    |
+ 19 | 19 | 19 |    |    |
 (20 rows)
 
 select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not distinct from a3 and b2 = b3;
@@ -3567,11 +3866,11 @@ select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not distinct from
  13 | 13 | 13 |    |    |   
  14 | 14 | 14 |    |    |   
  17 | 17 | 17 |    |    |   
-  1 |  1 |    |    |    |   
- 12 | 12 | 12 |    |    |   
- 15 | 15 | 15 |    |    |   
- 20 | 20 | 20 |    |    |   
-  2 |  2 |    |    |    |   
+  1 |  1 |    |    |    |
+ 12 | 12 | 12 |    |    |
+ 15 | 15 | 15 |    |    |
+ 20 | 20 | 20 |    |    |
+  2 |  2 |    |    |    |
   3 |  3 |    |    |    |   
   4 |  4 |    |    |    |   
   7 |  7 |    |    |    |   
@@ -3582,7 +3881,7 @@ select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not distinct from
 (20 rows)
 
 explain select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not distinct from a3;
-                                            QUERY PLAN                                             
+                                            QUERY PLAN
 ---------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1293.01 rows=44 width=24)
    ->  Hash Left Join  (cost=0.00..1293.01 rows=15 width=24)
@@ -3599,7 +3898,7 @@ explain select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not disti
 (12 rows)
 
 explain select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not distinct from a3 and b2 is distinct from b3;
-                                            QUERY PLAN                                             
+                                            QUERY PLAN
 ---------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1293.01 rows=40 width=24)
    ->  Hash Left Join  (cost=0.00..1293.01 rows=14 width=24)
@@ -3617,7 +3916,7 @@ explain select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not disti
 (13 rows)
 
 explain select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not distinct from a3 and b2 = b3;
-                                            QUERY PLAN                                             
+                                            QUERY PLAN
 ---------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1293.01 rows=40 width=24)
    ->  Hash Left Join  (cost=0.00..1293.01 rows=14 width=24)
@@ -3680,7 +3979,7 @@ insert into baz values ('cd  '); -- 2 trailing spaces
 -- varchar cast to bpchar
 -- 'cd' matches 'cd', returns 1 row
 explain select varchar_3, char_3 from foo join bar on varchar_3=char_3;
-                                        QUERY PLAN                                        
+                                        QUERY PLAN
 ------------------------------------------------------------------------------------------
  Hash Join  (cost=0.00..862.00 rows=1 width=7)
    Hash Cond: (bar.char_3 = (foo.varchar_3)::bpchar)
@@ -3701,7 +4000,7 @@ select varchar_3, char_3 from foo join bar on varchar_3=char_3;
 -- char cast to text
 -- 'cd' doesn't match 'cd  ', returns 0 rows
 explain select char_3, text_any from bar join baz on char_3=text_any;
-                                        QUERY PLAN                                        
+                                        QUERY PLAN
 ------------------------------------------------------------------------------------------
  Hash Join  (cost=0.00..862.00 rows=1 width=9)
    Hash Cond: (baz.text_any = (bar.char_3)::text)
@@ -3726,7 +4025,7 @@ select char_3, text_any from bar join baz on char_3=text_any;
 -- Notice ORCA changes join order to minimize motion
 explain select varchar_3, char_3, text_any from foo join bar on varchar_3=char_3
 join baz on varchar_3=text_any;
-                                           QUERY PLAN                                           
+                                           QUERY PLAN
 ------------------------------------------------------------------------------------------------
  Hash Join  (cost=0.00..1293.00 rows=1 width=12)
    Hash Cond: ((foo.varchar_3)::bpchar = bar.char_3)

--- a/src/test/regress/expected/bfv_joins_optimizer.out
+++ b/src/test/regress/expected/bfv_joins_optimizer.out
@@ -959,7 +959,7 @@ SELECT t1.c FROM t1 LEFT OUTER JOIN (select t3.*, t3.a+t3.b as cc from t3)t ON t
 -- Test for unexpected NLJ qual
 --
 explain select 1 as mrs_t1 where 1 <= ALL (select x from z);
-                                                                                                                                                           QUERY PLAN
+                                                                                                                                                           QUERY PLAN                                                                                                                                                            
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Result  (cost=0.00..882688.11 rows=1 width=4)
    ->  Nested Loop  (cost=0.00..882688.11 rows=1 width=1)
@@ -3370,7 +3370,7 @@ INNER JOIN member_subgroup
 ON member_group.group_id = member_subgroup.group_id
 LEFT OUTER JOIN region
 ON (member_group.group_id IN (12,13,14,15) AND member_subgroup.subgroup_name = region.county_name);
-                                            QUERY PLAN
+                                            QUERY PLAN                                             
 ---------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice5; segments: 3)
    ->  Hash Left Join
@@ -3410,7 +3410,6 @@ EXPLAIN (costs off) SELECT * FROM coercejoin a, coercejoin b WHERE a.a=b.a;
          ->  Seq Scan on coercejoin
          ->  Hash
                ->  Seq Scan on coercejoin coercejoin_1
- Optimizer: Pivotal Optimizer (GPORCA)
 (7 rows)
 
 -- Negative test, the join should not be colocated since the cast is a coercion
@@ -3429,7 +3428,6 @@ EXPLAIN (costs off) SELECT * FROM coercejoin a, coercejoin b WHERE a.a::numeric=
                ->  Redistribute Motion 3:3  (slice2; segments: 3)
                      Hash Key: (coercejoin_1.a)::numeric
                      ->  Seq Scan on coercejoin coercejoin_1
- Optimizer: Pivotal Optimizer (GPORCA)
 (11 rows)
 
 --
@@ -3590,7 +3588,7 @@ set enable_nestloop=on;
 -- Motion node from rescanning! That Materialize node is rescanned, when the
 -- executor parameter 'b.i' changes.
 explain (costs off) select * from a, b, c where b.i = a.i and (a.i + b.i) = c.j;
-                       QUERY PLAN
+                       QUERY PLAN                        
 ---------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)
    ->  Nested Loop
@@ -3710,7 +3708,7 @@ EXPLAIN SELECT a, b FROM gp_float1 JOIN gp_float2 ON a = c AND b = float8 '3.0';
 -- datatype is compatible with the distribution key, the other's is not. We can
 -- redistribute based on the compatible constant.
 EXPLAIN SELECT a, b FROM gp_float1 JOIN gp_float2 ON a = c AND b = float8 '3.0' AND b = float4 '3.0';
-                                             QUERY PLAN
+                                             QUERY PLAN                                             
 ----------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)  (cost=2.21..5.49 rows=5 width=8)
    ->  Hash Join  (cost=2.21..5.39 rows=2 width=8)
@@ -3751,7 +3749,7 @@ set enable_seqscan = off;
 set enable_bitmapscan = off;
 analyze t_9427;
 explain (costs off) select * from t_9427 where a in (select a from t_9427 where c < 100 ) and a < 200;
-                                                                  QUERY PLAN
+                                                                  QUERY PLAN                                                                   
 -----------------------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Merge Join
@@ -3885,7 +3883,7 @@ select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not distinct from
 (20 rows)
 
 explain select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not distinct from a3;
-                                            QUERY PLAN
+                                            QUERY PLAN                                             
 ---------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1293.01 rows=44 width=24)
    ->  Hash Left Join  (cost=0.00..1293.01 rows=15 width=24)
@@ -3902,7 +3900,7 @@ explain select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not disti
 (12 rows)
 
 explain select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not distinct from a3 and b2 is distinct from b3;
-                                            QUERY PLAN
+                                            QUERY PLAN                                             
 ---------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1293.01 rows=40 width=24)
    ->  Hash Left Join  (cost=0.00..1293.01 rows=14 width=24)
@@ -3920,7 +3918,7 @@ explain select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not disti
 (13 rows)
 
 explain select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not distinct from a3 and b2 = b3;
-                                            QUERY PLAN
+                                            QUERY PLAN                                             
 ---------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1293.01 rows=40 width=24)
    ->  Hash Left Join  (cost=0.00..1293.01 rows=14 width=24)
@@ -3983,7 +3981,7 @@ insert into baz values ('cd  '); -- 2 trailing spaces
 -- varchar cast to bpchar
 -- 'cd' matches 'cd', returns 1 row
 explain select varchar_3, char_3 from foo join bar on varchar_3=char_3;
-                                        QUERY PLAN
+                                        QUERY PLAN                                        
 ------------------------------------------------------------------------------------------
  Hash Join  (cost=0.00..862.00 rows=1 width=7)
    Hash Cond: (bar.char_3 = (foo.varchar_3)::bpchar)
@@ -4004,7 +4002,7 @@ select varchar_3, char_3 from foo join bar on varchar_3=char_3;
 -- char cast to text
 -- 'cd' doesn't match 'cd  ', returns 0 rows
 explain select char_3, text_any from bar join baz on char_3=text_any;
-                                        QUERY PLAN
+                                        QUERY PLAN                                        
 ------------------------------------------------------------------------------------------
  Hash Join  (cost=0.00..862.00 rows=1 width=9)
    Hash Cond: (baz.text_any = (bar.char_3)::text)
@@ -4029,7 +4027,7 @@ select char_3, text_any from bar join baz on char_3=text_any;
 -- Notice ORCA changes join order to minimize motion
 explain select varchar_3, char_3, text_any from foo join bar on varchar_3=char_3
 join baz on varchar_3=text_any;
-                                           QUERY PLAN
+                                           QUERY PLAN                                           
 ------------------------------------------------------------------------------------------------
  Hash Join  (cost=0.00..1293.00 rows=1 width=12)
    Hash Cond: ((foo.varchar_3)::bpchar = bar.char_3)

--- a/src/test/regress/expected/bfv_joins_optimizer.out
+++ b/src/test/regress/expected/bfv_joins_optimizer.out
@@ -626,54 +626,54 @@ SELECT * from x left join y on True where func_x(y.a) > 0;
 (100 rows)
 
 SELECT * FROM t1 LEFT OUTER JOIN t2 ON t1.a = t2.a WHERE t1.b IS DISTINCT FROM t2.b;
- a | b | c | a | b
+ a | b | c | a | b 
 ---+---+---+---+---
+ 1 | 1 | 1 |   |  
  2 | 1 | 2 | 2 | 3
- 1 | 1 | 1 |   |
 (2 rows)
 
 SELECT * FROM t1 LEFT OUTER JOIN t2 ON t1.a = t2.a WHERE t1.b IS DISTINCT FROM NULL;
- a | b | c | a | b
+ a | b | c | a | b 
 ---+---+---+---+---
- 1 | 1 | 1 |   |
  2 | 1 | 2 | 2 | 3
+ 1 | 1 | 1 |   |  
 (2 rows)
 
 SELECT * FROM t1 LEFT OUTER JOIN t2 ON t1.a = t2.a WHERE t2.b IS DISTINCT FROM NULL;
- a | b | c | a | b
+ a | b | c | a | b 
 ---+---+---+---+---
  2 | 1 | 2 | 2 | 3
 (1 row)
 
 SELECT * FROM t1 LEFT OUTER JOIN t2 ON t1.a = t2.a WHERE t2.b IS NOT DISTINCT FROM NULL;
- a | b | c | a | b
+ a | b | c | a | b 
 ---+---+---+---+---
- 3 |   | 3 |   |
- 1 | 1 | 1 |   |
+ 3 |   | 3 |   |  
+ 1 | 1 | 1 |   |  
 (2 rows)
 
 SELECT * FROM t1 LEFT OUTER JOIN t2 ON t1.a = t2.a WHERE t1.b IS NOT DISTINCT FROM NULL;
- a | b | c | a | b
+ a | b | c | a | b 
 ---+---+---+---+---
- 3 |   | 3 |   |
+ 3 |   | 3 |   |  
 (1 row)
 
 --- Tests for LOJ with single predicate uses columns of outer child only
 explain select t1.* from t1 left outer join t3 on t1.b=1;
-                                            QUERY PLAN
+                                            QUERY PLAN                                             
 ---------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1324032.10 rows=1 width=12)
-   ->  Nested Loop Left Join  (cost=0.00..1324032.10 rows=1 width=12)
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1324032.27 rows=4 width=12)
+   ->  Nested Loop Left Join  (cost=0.00..1324032.26 rows=2 width=12)
          Join Filter: (t1.b = 1)
          ->  Seq Scan on t1  (cost=0.00..431.00 rows=1 width=12)
          ->  Materialize  (cost=0.00..431.00 rows=1 width=1)
-               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
                      ->  Seq Scan on t3  (cost=0.00..431.00 rows=1 width=1)
  Optimizer: Pivotal Optimizer (GPORCA)
 (8 rows)
 
 select t1.* from t1 left outer join t3 on t1.b=1;
- a | b | c
+ a | b | c 
 ---+---+---
  2 | 1 | 2
  3 |   | 3
@@ -681,20 +681,20 @@ select t1.* from t1 left outer join t3 on t1.b=1;
 (3 rows)
 
 explain select t1.* from t1 left outer join t3 on t1.c=1;
-                                            QUERY PLAN
+                                            QUERY PLAN                                             
 ---------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1324032.10 rows=1 width=12)
-   ->  Nested Loop Left Join  (cost=0.00..1324032.10 rows=1 width=12)
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1324032.30 rows=6 width=12)
+   ->  Nested Loop Left Join  (cost=0.00..1324032.29 rows=2 width=12)
          Join Filter: (t1.c = 1)
          ->  Seq Scan on t1  (cost=0.00..431.00 rows=1 width=12)
          ->  Materialize  (cost=0.00..431.00 rows=1 width=1)
-               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
                      ->  Seq Scan on t3  (cost=0.00..431.00 rows=1 width=1)
  Optimizer: Pivotal Optimizer (GPORCA)
 (8 rows)
 
 select t1.* from t1 left outer join t3 on t1.c=1;
- a | b | c
+ a | b | c 
 ---+---+---
  2 | 1 | 2
  3 |   | 3
@@ -703,249 +703,253 @@ select t1.* from t1 left outer join t3 on t1.c=1;
 
 --- Tests for LOJ with null-filtering on self check conditions.
 --- make sure that we dont optimize the equality checks of inner table of LOJ.
-explain SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t3.a = t3.a IS NULL;
-                                               QUERY PLAN
+explain SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE (t3.a = t3.a) IS NULL;
+                                               QUERY PLAN                                                
 ---------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1324032.37 rows=1 width=4)
-   ->  Result  (cost=0.00..1324032.37 rows=1 width=4)
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1324032.44 rows=3 width=4)
+   ->  Result  (cost=0.00..1324032.44 rows=1 width=4)
          Filter: ((t3.a = t3.a) IS NULL)
-         ->  Nested Loop Left Join  (cost=0.00..1324032.37 rows=1 width=8)
+         ->  Nested Loop Left Join  (cost=0.00..1324032.44 rows=2 width=8)
                Join Filter: true
                ->  Seq Scan on t1  (cost=0.00..431.00 rows=1 width=4)
                ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
-                     ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                     ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
                            ->  Seq Scan on t3  (cost=0.00..431.00 rows=1 width=4)
                                  Filter: (b > a)
  Optimizer: Pivotal Optimizer (GPORCA)
 (11 rows)
 
-SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t3.a = t3.a IS NULL;
- c
+SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE (t3.a = t3.a) IS NULL;
+ c 
 ---
- 1
  2
  3
+ 1
 (3 rows)
 
-explain SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t1.c = t1.c IS NULL;
-                                            QUERY PLAN
+explain SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE (t1.c = t1.c) IS NULL;
+                                            QUERY PLAN                                             
 ---------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1324032.14 rows=2 width=4)
-   ->  Nested Loop Left Join  (cost=0.00..1324032.14 rows=1 width=4)
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1324032.18 rows=6 width=4)
+   ->  Nested Loop Left Join  (cost=0.00..1324032.18 rows=2 width=4)
          Join Filter: true
          ->  Seq Scan on t1  (cost=0.00..431.00 rows=1 width=4)
                Filter: (true IS NULL)
          ->  Materialize  (cost=0.00..431.00 rows=1 width=1)
-               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
                      ->  Seq Scan on t3  (cost=0.00..431.00 rows=1 width=1)
                            Filter: (b > a)
  Optimizer: Pivotal Optimizer (GPORCA)
 (10 rows)
 
-SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t1.c = t1.c IS NULL;
- c
+SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE (t1.c = t1.c) IS NULL;
+ c 
 ---
 (0 rows)
 
-explain SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t3.a = t3.a IS NULL and t3.b=2;
-                                            QUERY PLAN
+explain SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE (t3.a = t3.a) IS NULL and t3.b=2;
+                                            QUERY PLAN                                             
 ---------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1324032.13 rows=1 width=4)
-   ->  Nested Loop  (cost=0.00..1324032.13 rows=1 width=4)
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1324032.17 rows=3 width=4)
+   ->  Nested Loop  (cost=0.00..1324032.17 rows=1 width=4)
          Join Filter: true
          ->  Seq Scan on t1  (cost=0.00..431.00 rows=1 width=4)
          ->  Materialize  (cost=0.00..431.00 rows=1 width=1)
-               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
                      ->  Seq Scan on t3  (cost=0.00..431.00 rows=1 width=1)
                            Filter: ((true IS NULL) AND (b = 2) AND (b > a))
  Optimizer: Pivotal Optimizer (GPORCA)
 (9 rows)
 
-SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t3.a = t3.a IS NULL and t3.a=2;
- c
+SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE (t3.a = t3.a) IS NULL and t3.a=2;
+ c 
 ---
 (0 rows)
 
-explain SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t3.a = t3.a IS NULL and t1.b=1;
-                                               QUERY PLAN
+explain SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE (t3.a = t3.a) IS NULL and t1.b=1;
+                                               QUERY PLAN                                                
 ---------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1324032.38 rows=1 width=4)
-   ->  Result  (cost=0.00..1324032.38 rows=1 width=4)
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1324032.45 rows=2 width=4)
+   ->  Result  (cost=0.00..1324032.45 rows=1 width=4)
          Filter: ((t3.a = t3.a) IS NULL)
-         ->  Nested Loop Left Join  (cost=0.00..1324032.38 rows=1 width=8)
+         ->  Nested Loop Left Join  (cost=0.00..1324032.45 rows=2 width=8)
                Join Filter: true
                ->  Seq Scan on t1  (cost=0.00..431.00 rows=1 width=4)
                      Filter: (b = 1)
                ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
-                     ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                     ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
                            ->  Seq Scan on t3  (cost=0.00..431.00 rows=1 width=4)
                                  Filter: (b > a)
  Optimizer: Pivotal Optimizer (GPORCA)
 (12 rows)
 
-SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t3.a = t3.a IS NULL and t1.b=1;
- c
+SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE (t3.a = t3.a) IS NULL and t1.b=1;
+ c 
 ---
- 1
  2
+ 1
 (2 rows)
 
-explain SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t3.a = t3.a IS NULL or t3.a is NULL;
-                                               QUERY PLAN
+explain SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE (t3.a = t3.a) IS NULL or t3.a is NULL;
+                                               QUERY PLAN                                                
 ---------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1324032.37 rows=1 width=4)
-   ->  Result  (cost=0.00..1324032.37 rows=1 width=4)
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1324032.44 rows=6 width=4)
+   ->  Result  (cost=0.00..1324032.44 rows=2 width=4)
          Filter: (((t3.a = t3.a) IS NULL) OR (t3.a IS NULL))
-         ->  Nested Loop Left Join  (cost=0.00..1324032.37 rows=1 width=8)
+         ->  Nested Loop Left Join  (cost=0.00..1324032.44 rows=2 width=8)
                Join Filter: true
                ->  Seq Scan on t1  (cost=0.00..431.00 rows=1 width=4)
                ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
-                     ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                     ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
                            ->  Seq Scan on t3  (cost=0.00..431.00 rows=1 width=4)
                                  Filter: (b > a)
  Optimizer: Pivotal Optimizer (GPORCA)
 (11 rows)
 
-SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t3.a = t3.a IS NULL or t3.a is NULL;
- c
+SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE (t3.a = t3.a) IS NULL or t3.a is NULL;
+ c 
 ---
+ 1
  2
  3
- 1
 (3 rows)
 
-explain SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t3.a = t3.a IS NULL or t3.b=2;
-                                               QUERY PLAN
+explain SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE (t3.a = t3.a) IS NULL or t3.b=2;
+                                               QUERY PLAN                                                
 ---------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1324032.61 rows=1 width=4)
-   ->  Result  (cost=0.00..1324032.61 rows=1 width=4)
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1324032.71 rows=5 width=4)
+   ->  Result  (cost=0.00..1324032.71 rows=2 width=4)
          Filter: (((t3.a = t3.a) IS NULL) OR (t3.b = 2))
-         ->  Nested Loop Left Join  (cost=0.00..1324032.61 rows=1 width=12)
+         ->  Nested Loop Left Join  (cost=0.00..1324032.71 rows=2 width=12)
                Join Filter: true
                ->  Seq Scan on t1  (cost=0.00..431.00 rows=1 width=4)
                ->  Materialize  (cost=0.00..431.00 rows=1 width=8)
-                     ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                     ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
                            ->  Seq Scan on t3  (cost=0.00..431.00 rows=1 width=8)
                                  Filter: (b > a)
  Optimizer: Pivotal Optimizer (GPORCA)
 (11 rows)
 
-SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t3.a = t3.a IS NULL or t3.b=2;
- c
+SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE (t3.a = t3.a) IS NULL or t3.b=2;
+ c 
 ---
- 1
  2
  3
+ 1
 (3 rows)
 
-explain SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t3.a = t3.a IS NULL or t1.a=1;
-                                               QUERY PLAN
+explain SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE (t3.a = t3.a) IS NULL or t1.a=1;
+                                               QUERY PLAN                                                
 ---------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1324032.48 rows=1 width=4)
-   ->  Result  (cost=0.00..1324032.48 rows=1 width=4)
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1324032.48 rows=5 width=4)
+   ->  Result  (cost=0.00..1324032.48 rows=2 width=4)
          Filter: (((t3.a = t3.a) IS NULL) OR (t1.a = 1))
-         ->  Nested Loop Left Join  (cost=0.00..1324032.48 rows=1 width=12)
+         ->  Nested Loop Left Join  (cost=0.00..1324032.48 rows=2 width=12)
                Join Filter: true
                ->  Seq Scan on t1  (cost=0.00..431.00 rows=1 width=8)
                ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
-                     ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                     ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
                            ->  Seq Scan on t3  (cost=0.00..431.00 rows=1 width=4)
                                  Filter: (b > a)
  Optimizer: Pivotal Optimizer (GPORCA)
 (11 rows)
 
-SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t3.a = t3.a IS NULL or t1.a=1;
- c
+SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE (t3.a = t3.a) IS NULL or t1.a=1;
+ c 
 ---
  2
  3
  1
 (3 rows)
 
-explain SELECT t.c FROM (select t1.*, t1.a+t1.b as cc from t1)t LEFT OUTER JOIN t3 ON t.cc = t.cc IS NULL;
-                                            QUERY PLAN
+explain SELECT t.c FROM (select t1.*, t1.a+t1.b as cc from t1)t LEFT OUTER JOIN t3 ON (t.cc = t.cc) IS NULL;
+                                            QUERY PLAN                                             
 ---------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1324032.13 rows=1 width=4)
-   ->  Nested Loop Left Join  (cost=0.00..1324032.13 rows=1 width=4)
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1324032.24 rows=6 width=4)
+   ->  Nested Loop Left Join  (cost=0.00..1324032.24 rows=2 width=4)
          Join Filter: ((((t1.a + t1.b)) = ((t1.a + t1.b))) IS NULL)
-         ->  Seq Scan on t1  (cost=0.00..431.00 rows=1 width=12)
+         ->  Result  (cost=0.00..431.00 rows=1 width=8)
+               ->  Seq Scan on t1  (cost=0.00..431.00 rows=1 width=12)
          ->  Materialize  (cost=0.00..431.00 rows=1 width=1)
-               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
                      ->  Seq Scan on t3  (cost=0.00..431.00 rows=1 width=1)
  Optimizer: Pivotal Optimizer (GPORCA)
-(8 rows)
+(9 rows)
 
-SELECT t.c FROM (select t1.*, t1.a+t1.b as cc from t1)t LEFT OUTER JOIN t3 ON t.cc = t.cc IS NULL;
- c
+SELECT t.c FROM (select t1.*, t1.a+t1.b as cc from t1)t LEFT OUTER JOIN t3 ON (t.cc = t.cc) IS NULL;
+ c 
 ---
+ 1
  2
  3
- 1
 (3 rows)
 
-explain SELECT t.c FROM (select t1.*, t1.a+t1.b as cc from t1)t LEFT OUTER JOIN t3 ON t3.a > t3.b where t.cc = t.cc IS NULL;
-                                            QUERY PLAN
+explain SELECT t.c FROM (select t1.*, t1.a+t1.b as cc from t1)t LEFT OUTER JOIN t3 ON t3.a > t3.b where (t.cc = t.cc) IS NULL;
+                                            QUERY PLAN                                             
 ---------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1324032.19 rows=2 width=4)
-   ->  Nested Loop Left Join  (cost=0.00..1324032.19 rows=1 width=4)
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1324032.22 rows=3 width=4)
+   ->  Nested Loop Left Join  (cost=0.00..1324032.22 rows=1 width=4)
          Join Filter: true
          ->  Result  (cost=0.00..431.00 rows=1 width=4)
                Filter: ((((t1.a + t1.b)) = ((t1.a + t1.b))) IS NULL)
-               ->  Seq Scan on t1  (cost=0.00..431.00 rows=1 width=12)
+               ->  Result  (cost=0.00..431.00 rows=1 width=8)
+                     ->  Seq Scan on t1  (cost=0.00..431.00 rows=1 width=12)
          ->  Materialize  (cost=0.00..431.00 rows=1 width=1)
-               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
                      ->  Seq Scan on t3  (cost=0.00..431.00 rows=1 width=1)
                            Filter: (a > b)
  Optimizer: Pivotal Optimizer (GPORCA)
-(11 rows)
+(12 rows)
 
-SELECT t.c FROM (select t1.*, t1.a+t1.b as cc from t1)t LEFT OUTER JOIN t3 ON t3.a > t3.b where t.cc = t.cc IS NULL;
- c
+SELECT t.c FROM (select t1.*, t1.a+t1.b as cc from t1)t LEFT OUTER JOIN t3 ON t3.a > t3.b where (t.cc = t.cc) IS NULL;
+ c 
 ---
  3
 (1 row)
 
-explain SELECT t1.c FROM t1 LEFT OUTER JOIN (select t3.*, t3.a+t3.b as cc from t3)t ON t.cc = t.cc IS NULL;
-                                            QUERY PLAN
+explain SELECT t1.c FROM t1 LEFT OUTER JOIN (select t3.*, t3.a+t3.b as cc from t3)t ON (t.cc = t.cc) IS NULL;
+                                            QUERY PLAN                                             
 ---------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1324032.09 rows=2 width=4)
-   ->  Nested Loop Left Join  (cost=0.00..1324032.09 rows=1 width=4)
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1324032.14 rows=6 width=4)
+   ->  Nested Loop Left Join  (cost=0.00..1324032.14 rows=2 width=4)
          Join Filter: true
          ->  Seq Scan on t1  (cost=0.00..431.00 rows=1 width=4)
          ->  Materialize  (cost=0.00..431.00 rows=1 width=1)
-               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
+               ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
                      ->  Result  (cost=0.00..431.00 rows=1 width=1)
                            Filter: ((((t3.a + t3.b)) = ((t3.a + t3.b))) IS NULL)
-                           ->  Seq Scan on t3  (cost=0.00..431.00 rows=1 width=8)
+                           ->  Result  (cost=0.00..431.00 rows=1 width=4)
+                                 ->  Seq Scan on t3  (cost=0.00..431.00 rows=1 width=8)
  Optimizer: Pivotal Optimizer (GPORCA)
-(10 rows)
+(11 rows)
 
-SELECT t1.c FROM t1 LEFT OUTER JOIN (select t3.*, t3.a+t3.b as cc from t3)t ON t.cc = t.cc IS NULL;
- c
+SELECT t1.c FROM t1 LEFT OUTER JOIN (select t3.*, t3.a+t3.b as cc from t3)t ON (t.cc = t.cc) IS NULL;
+ c 
 ---
  2
  3
  1
 (3 rows)
 
-explain SELECT t1.c FROM t1 LEFT OUTER JOIN (select t3.*, t3.a+t3.b as cc from t3)t ON t.b > t.a WHERE t.cc = t.cc IS NULL;
-                                               QUERY PLAN
+explain SELECT t1.c FROM t1 LEFT OUTER JOIN (select t3.*, t3.a+t3.b as cc from t3)t ON t.b > t.a WHERE (t.cc = t.cc) IS NULL;
+                                               QUERY PLAN                                                
 ---------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1324032.22 rows=1 width=4)
-   ->  Result  (cost=0.00..1324032.22 rows=1 width=4)
+ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1324032.29 rows=3 width=4)
+   ->  Result  (cost=0.00..1324032.29 rows=1 width=4)
          Filter: ((((t3.a + t3.b)) = ((t3.a + t3.b))) IS NULL)
-         ->  Nested Loop Left Join  (cost=0.00..1324032.22 rows=1 width=8)
+         ->  Nested Loop Left Join  (cost=0.00..1324032.29 rows=2 width=8)
                Join Filter: true
                ->  Seq Scan on t1  (cost=0.00..431.00 rows=1 width=4)
                ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
-                     ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
-                           ->  Seq Scan on t3  (cost=0.00..431.00 rows=1 width=8)
-                                 Filter: (b > a)
+                     ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                           ->  Result  (cost=0.00..431.00 rows=1 width=4)
+                                 ->  Seq Scan on t3  (cost=0.00..431.00 rows=1 width=8)
+                                       Filter: (b > a)
  Optimizer: Pivotal Optimizer (GPORCA)
-(11 rows)
+(12 rows)
 
-SELECT t1.c FROM t1 LEFT OUTER JOIN (select t3.*, t3.a+t3.b as cc from t3)t ON t.b > t.a WHERE t.cc = t.cc IS NULL;
- c
+SELECT t1.c FROM t1 LEFT OUTER JOIN (select t3.*, t3.a+t3.b as cc from t3)t ON t.b > t.a WHERE (t.cc = t.cc) IS NULL;
+ c 
 ---
  2
  3
@@ -3316,7 +3320,7 @@ SELECT count(*)
 FROM mpp25537_facttable1 ft, mpp25537_dimdate dt, mpp25537_dimtabl1 dt1
 WHERE ft.wk_id = dt.wk_id
 AND ft.id = dt1.id;
- count
+ count 
 -------
      4
 (1 row)
@@ -3635,7 +3639,7 @@ explain select a.*, b.i, c.* from a, b, c where ((mt_col).x > a.i or b.i = a.i) 
 (13 rows)
 
 select a.*, b.i, c.* from a, b, c where ((mt_col).x > a.i or b.i = a.i) and (a.i + b.i) = c.j;
- i | i | i | j
+ i | i | i | j 
 ---+---+---+---
  1 | 1 | 2 | 2
 (1 row)
@@ -3815,7 +3819,7 @@ select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not distinct from
   8 |  8 |    |    |    | 20
  16 | 16 | 16 |    |    |   
  18 | 18 | 18 |    |    |   
- 19 | 19 | 19 |    |    |
+ 19 | 19 | 19 |    |    |   
   5 |  5 |    |    |    | 20
   6 |  6 |    |    |    | 20
   9 |  9 |    |    |    | 20
@@ -3823,7 +3827,7 @@ select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not distinct from
  11 | 11 | 11 |    |    |   
  13 | 13 | 13 |    |    |   
  14 | 14 | 14 |    |    |   
- 17 | 17 | 17 |    |    |
+ 17 | 17 | 17 |    |    |   
   1 |  1 |    |    |    | 20
  12 | 12 | 12 |    |    |   
  15 | 15 | 15 |    |    |   
@@ -3831,7 +3835,7 @@ select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not distinct from
 (20 rows)
 
 select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not distinct from a3 and b2 is distinct from b3;
- a1 | b1 | a2 | b2 | a3 | b3
+ a1 | b1 | a2 | b2 | a3 | b3 
 ----+----+----+----+----+----
   5 |  5 |    |    |    | 20
   6 |  6 |    |    |    | 20
@@ -3842,17 +3846,17 @@ select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not distinct from
  14 | 14 | 14 |    |    |   
  17 | 17 | 17 |    |    |   
   1 |  1 |    |    |    | 20
- 12 | 12 | 12 |    |    |
- 15 | 15 | 15 |    |    |
- 20 | 20 | 20 |    |    |
+ 12 | 12 | 12 |    |    |   
+ 15 | 15 | 15 |    |    |   
+ 20 | 20 | 20 |    |    |   
   2 |  2 |    |    |    | 20
   3 |  3 |    |    |    | 20
   4 |  4 |    |    |    | 20
   7 |  7 |    |    |    | 20
   8 |  8 |    |    |    | 20
- 16 | 16 | 16 |    |    |
- 18 | 18 | 18 |    |    |
- 19 | 19 | 19 |    |    |
+ 16 | 16 | 16 |    |    |   
+ 18 | 18 | 18 |    |    |   
+ 19 | 19 | 19 |    |    |   
 (20 rows)
 
 select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not distinct from a3 and b2 = b3;
@@ -3866,11 +3870,11 @@ select * from o1 left join o2 on a1 = a2 left join o3 on a2 is not distinct from
  13 | 13 | 13 |    |    |   
  14 | 14 | 14 |    |    |   
  17 | 17 | 17 |    |    |   
-  1 |  1 |    |    |    |
- 12 | 12 | 12 |    |    |
- 15 | 15 | 15 |    |    |
- 20 | 20 | 20 |    |    |
-  2 |  2 |    |    |    |
+  1 |  1 |    |    |    |   
+ 12 | 12 | 12 |    |    |   
+ 15 | 15 | 15 |    |    |   
+ 20 | 20 | 20 |    |    |   
+  2 |  2 |    |    |    |   
   3 |  3 |    |    |    |   
   4 |  4 |    |    |    |   
   7 |  7 |    |    |    |   

--- a/src/test/regress/sql/bfv_joins.sql
+++ b/src/test/regress/sql/bfv_joins.sql
@@ -9,10 +9,11 @@ insert into x values (generate_series(1,10), generate_series(1,10), generate_ser
 create table y (a int, b int, c int);
 insert into y (select * from x);
 
-CREATE TABLE t1 (a int, b int);
+CREATE TABLE t1 (a int, b int, c int not null);
 CREATE TABLE t2 (a int, b int);
+CREATE TABLE t3 (a int not null, b int, c int);
 
-INSERT INTO t1 VALUES (1,1),(2,1),(3,NULL);
+INSERT INTO t1 VALUES (1,1,1),(2,1,2),(3,NULL,3);
 INSERT INTO t2 VALUES (2,3);
 
 CREATE FUNCTION func_x(x int) RETURNS int AS $$
@@ -68,6 +69,48 @@ SELECT * FROM t1 LEFT OUTER JOIN t2 ON t1.a = t2.a WHERE t2.b IS DISTINCT FROM N
 SELECT * FROM t1 LEFT OUTER JOIN t2 ON t1.a = t2.a WHERE t2.b IS NOT DISTINCT FROM NULL;
 
 SELECT * FROM t1 LEFT OUTER JOIN t2 ON t1.a = t2.a WHERE t1.b IS NOT DISTINCT FROM NULL;
+
+--- Tests for LOJ with single predicate uses columns of outer child only
+explain select t1.* from t1 left outer join t3 on t1.b=1;
+select t1.* from t1 left outer join t3 on t1.b=1;
+
+explain select t1.* from t1 left outer join t3 on t1.c=1;
+select t1.* from t1 left outer join t3 on t1.c=1;
+
+--- Tests for LOJ with null-filtering on self check conditions.
+--- make sure that we dont optimize the equality checks of inner table of LOJ.
+explain SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t3.a = t3.a IS NULL;
+SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t3.a = t3.a IS NULL;
+
+explain SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t1.c = t1.c IS NULL;
+SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t1.c = t1.c IS NULL;
+
+explain SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t3.a = t3.a IS NULL and t3.b=2;
+SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t3.a = t3.a IS NULL and t3.a=2;
+
+explain SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t3.a = t3.a IS NULL and t1.b=1;
+SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t3.a = t3.a IS NULL and t1.b=1;
+
+explain SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t3.a = t3.a IS NULL or t3.a is NULL;
+SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t3.a = t3.a IS NULL or t3.a is NULL;
+
+explain SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t3.a = t3.a IS NULL or t3.b=2;
+SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t3.a = t3.a IS NULL or t3.b=2;
+
+explain SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t3.a = t3.a IS NULL or t1.a=1;
+SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t3.a = t3.a IS NULL or t1.a=1;
+
+explain SELECT t.c FROM (select t1.*, t1.a+t1.b as cc from t1)t LEFT OUTER JOIN t3 ON t.cc = t.cc IS NULL;
+SELECT t.c FROM (select t1.*, t1.a+t1.b as cc from t1)t LEFT OUTER JOIN t3 ON t.cc = t.cc IS NULL;
+
+explain SELECT t.c FROM (select t1.*, t1.a+t1.b as cc from t1)t LEFT OUTER JOIN t3 ON t3.a > t3.b where t.cc = t.cc IS NULL;
+SELECT t.c FROM (select t1.*, t1.a+t1.b as cc from t1)t LEFT OUTER JOIN t3 ON t3.a > t3.b where t.cc = t.cc IS NULL;
+
+explain SELECT t1.c FROM t1 LEFT OUTER JOIN (select t3.*, t3.a+t3.b as cc from t3)t ON t.cc = t.cc IS NULL;
+SELECT t1.c FROM t1 LEFT OUTER JOIN (select t3.*, t3.a+t3.b as cc from t3)t ON t.cc = t.cc IS NULL;
+
+explain SELECT t1.c FROM t1 LEFT OUTER JOIN (select t3.*, t3.a+t3.b as cc from t3)t ON t.b > t.a WHERE t.cc = t.cc IS NULL;
+SELECT t1.c FROM t1 LEFT OUTER JOIN (select t3.*, t3.a+t3.b as cc from t3)t ON t.b > t.a WHERE t.cc = t.cc IS NULL;
 
 -- Test for unexpected NLJ qual
 --

--- a/src/test/regress/sql/bfv_joins.sql
+++ b/src/test/regress/sql/bfv_joins.sql
@@ -79,38 +79,38 @@ select t1.* from t1 left outer join t3 on t1.c=1;
 
 --- Tests for LOJ with null-filtering on self check conditions.
 --- make sure that we dont optimize the equality checks of inner table of LOJ.
-explain SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t3.a = t3.a IS NULL;
-SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t3.a = t3.a IS NULL;
+explain SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE (t3.a = t3.a) IS NULL;
+SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE (t3.a = t3.a) IS NULL;
 
-explain SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t1.c = t1.c IS NULL;
-SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t1.c = t1.c IS NULL;
+explain SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE (t1.c = t1.c) IS NULL;
+SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE (t1.c = t1.c) IS NULL;
 
-explain SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t3.a = t3.a IS NULL and t3.b=2;
-SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t3.a = t3.a IS NULL and t3.a=2;
+explain SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE (t3.a = t3.a) IS NULL and t3.b=2;
+SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE (t3.a = t3.a) IS NULL and t3.a=2;
 
-explain SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t3.a = t3.a IS NULL and t1.b=1;
-SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t3.a = t3.a IS NULL and t1.b=1;
+explain SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE (t3.a = t3.a) IS NULL and t1.b=1;
+SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE (t3.a = t3.a) IS NULL and t1.b=1;
 
-explain SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t3.a = t3.a IS NULL or t3.a is NULL;
-SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t3.a = t3.a IS NULL or t3.a is NULL;
+explain SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE (t3.a = t3.a) IS NULL or t3.a is NULL;
+SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE (t3.a = t3.a) IS NULL or t3.a is NULL;
 
-explain SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t3.a = t3.a IS NULL or t3.b=2;
-SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t3.a = t3.a IS NULL or t3.b=2;
+explain SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE (t3.a = t3.a) IS NULL or t3.b=2;
+SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE (t3.a = t3.a) IS NULL or t3.b=2;
 
-explain SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t3.a = t3.a IS NULL or t1.a=1;
-SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE t3.a = t3.a IS NULL or t1.a=1;
+explain SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE (t3.a = t3.a) IS NULL or t1.a=1;
+SELECT t1.c FROM t1 LEFT OUTER JOIN t3 ON t3.b > t3.a WHERE (t3.a = t3.a) IS NULL or t1.a=1;
 
-explain SELECT t.c FROM (select t1.*, t1.a+t1.b as cc from t1)t LEFT OUTER JOIN t3 ON t.cc = t.cc IS NULL;
-SELECT t.c FROM (select t1.*, t1.a+t1.b as cc from t1)t LEFT OUTER JOIN t3 ON t.cc = t.cc IS NULL;
+explain SELECT t.c FROM (select t1.*, t1.a+t1.b as cc from t1)t LEFT OUTER JOIN t3 ON (t.cc = t.cc) IS NULL;
+SELECT t.c FROM (select t1.*, t1.a+t1.b as cc from t1)t LEFT OUTER JOIN t3 ON (t.cc = t.cc) IS NULL;
 
-explain SELECT t.c FROM (select t1.*, t1.a+t1.b as cc from t1)t LEFT OUTER JOIN t3 ON t3.a > t3.b where t.cc = t.cc IS NULL;
-SELECT t.c FROM (select t1.*, t1.a+t1.b as cc from t1)t LEFT OUTER JOIN t3 ON t3.a > t3.b where t.cc = t.cc IS NULL;
+explain SELECT t.c FROM (select t1.*, t1.a+t1.b as cc from t1)t LEFT OUTER JOIN t3 ON t3.a > t3.b where (t.cc = t.cc) IS NULL;
+SELECT t.c FROM (select t1.*, t1.a+t1.b as cc from t1)t LEFT OUTER JOIN t3 ON t3.a > t3.b where (t.cc = t.cc) IS NULL;
 
-explain SELECT t1.c FROM t1 LEFT OUTER JOIN (select t3.*, t3.a+t3.b as cc from t3)t ON t.cc = t.cc IS NULL;
-SELECT t1.c FROM t1 LEFT OUTER JOIN (select t3.*, t3.a+t3.b as cc from t3)t ON t.cc = t.cc IS NULL;
+explain SELECT t1.c FROM t1 LEFT OUTER JOIN (select t3.*, t3.a+t3.b as cc from t3)t ON (t.cc = t.cc) IS NULL;
+SELECT t1.c FROM t1 LEFT OUTER JOIN (select t3.*, t3.a+t3.b as cc from t3)t ON (t.cc = t.cc) IS NULL;
 
-explain SELECT t1.c FROM t1 LEFT OUTER JOIN (select t3.*, t3.a+t3.b as cc from t3)t ON t.b > t.a WHERE t.cc = t.cc IS NULL;
-SELECT t1.c FROM t1 LEFT OUTER JOIN (select t3.*, t3.a+t3.b as cc from t3)t ON t.b > t.a WHERE t.cc = t.cc IS NULL;
+explain SELECT t1.c FROM t1 LEFT OUTER JOIN (select t3.*, t3.a+t3.b as cc from t3)t ON t.b > t.a WHERE (t.cc = t.cc) IS NULL;
+SELECT t1.c FROM t1 LEFT OUTER JOIN (select t3.*, t3.a+t3.b as cc from t3)t ON t.b > t.a WHERE (t.cc = t.cc) IS NULL;
 
 -- Test for unexpected NLJ qual
 --


### PR DESCRIPTION
cherry picked from commit (https://github.com/greenplum-db/gpdb/pull/15358)
Issue:
    Orca tries to eliminate self comparisons at preprocessing, but this early optimization
    misleading the further expression preprocesing of LOJ. This PR tries to avoid self comparison
    check's of WHERE clause predicate when SELECT's logical child is LOJ.

NOTE:
Postgres Executor’s standard, restriction placed in the ON clause is processed before the join,
while a restriction placed in the WHERE clause is processed after the join.
That does not matter with inner joins, but it matters a lot with outer joins.

Setup:
```
CREATE TABLE t2(c0 int, c1 int not null);
INSERT INTO t2 values(1, 2),(3,4),(5,6),(7,8);
CREATE TABLE t3(c0 int not null, c1 int, c2 int);

SELECT t2.c1 FROM t2 LEFT OUTER JOIN t3 ON t3.c1 > t3.c2 WHERE (t3.c0=t3.c0) IS NULL;
 c1
----
(0 rows)

explain SELECT t2.c1 FROM t2 LEFT OUTER JOIN t3 ON t3.c1 > t3.c2 WHERE (t3.c0=t3.c0) IS NULL;
QUERY PLAN
---------------------------------------------------------------------------------------------------
Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1324032.07 rows=1 width=4) ->  Nested Loop  (cost=0.00..1324032.07 rows=1 width=4)
   Join Filter: true
   ->  Seq Scan on t2  (cost=0.00..431.00 rows=1 width=4)
         Filter: (true IS NULL)
   ->  Materialize  (cost=0.00..431.00 rows=1 width=1)
         ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
               ->  Seq Scan on t3  (cost=0.00..431.00 rows=1 width=1)
                     Filter: c1 > c2
Optimizer: Pivotal Optimizer (GPORCA)
(10 rows
set optimizer=off;
SET
SELECT t2.c1 FROM t2 LEFT OUTER JOIN t3 ON t3.c1 > t3.c2 WHERE (t3.c0=t3.c0) IS NULL;
 c1
----
  4
  8
  2
  6
(4 rows)
explain SELECT t2.c1 FROM t2 LEFT OUTER JOIN t3 ON t3.c1 > t3.c2 WHERE (t3.c0=t3.c0) IS NULL;
                                               QUERY PLAN
---------------------------------------------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.00..10044448648.78 rows=1117865000 width=4)
   ->  Nested Loop Left Join  (cost=10000000000.00..10029543782.11 rows=372621667 width=4)
         Filter: ((t3.c0 = t3.c0) IS NULL)
         ->  Seq Scan on t2  (cost=0.00..321.00 rows=28700 width=4)
         ->  Materialize  (cost=0.00..834.64 rows=25967 width=4)
               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..704.81 rows=25967 width=4)
                     ->  Seq Scan on t3  (cost=0.00..358.58 rows=8656 width=4)
                           Filter: (c1 > c2)
 Optimizer: Postgres query optimizer
(8 rows)

After Fix:
SELECT t2.c1 FROM t2 LEFT OUTER JOIN t3 ON t3.c1 > t3.c2 WHERE (t3.c0=t3.c0) IS NULL;
 c1
----
  6
  4
  8
  2
(4 rows)
explain SELECT t2.c1 FROM t2 LEFT OUTER JOIN t3 ON t3.c1 > t3.c2 WHERE (t3.c0=t3.c0) IS NULL;
                                               QUERY PLAN
---------------------------------------------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1324032.37 rows=1 width=4)
   ->  Result  (cost=0.00..1324032.37 rows=1 width=4)
         Filter: ((t3.c0 = t3.c0) IS NULL)
         ->  Nested Loop Left Join  (cost=0.00..1324032.37 rows=1 width=8)
               Join Filter: true
               ->  Seq Scan on t2  (cost=0.00..431.00 rows=1 width=4)
               ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
                     ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
                           ->  Seq Scan on t3  (cost=0.00..431.00 rows=1 width=4)
                                 Filter: (c1 > c2)
 Optimizer: Pivotal Optimizer (GPORCA)

```## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
