### PR TITLE
[ORCA] Support cover indexes using INCLUDE columns

### DIFF
--- a/src/backend/gporca/data/dxl/expressiontests/WinFunc-OuterRef-Partition-Order-Frames-Query.xml
+++ b/src/backend/gporca/data/dxl/expressiontests/WinFunc-OuterRef-Partition-Order-Frames-Query.xml
@@ -617,7 +617,7 @@ select * from x where x.i in (select last_value(y.i) over(partition by x.i order
         <dxl:ResultType Mdid="0.20.1.0"/>
         <dxl:IntermediateResultType Mdid="0.20.1.0"/>
       </dxl:GPDBAgg>
-      <dxl:Index Mdid="0.17159874.1.0" Name="idx_x_j" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.17159874.1.0" Name="idx_x_j" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>
@@ -695,7 +695,7 @@ select * from x where x.i in (select last_value(y.i) over(partition by x.i order
         <dxl:ResultType Mdid="0.20.1.0"/>
         <dxl:IntermediateResultType Mdid="0.20.1.0"/>
       </dxl:GPDBAgg>
-      <dxl:Index Mdid="0.17159920.1.0" Name="idx_x_i" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.17159920.1.0" Name="idx_x_i" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/expressiontests/WinFunc-OuterRef-Partition-Order-Query.xml
+++ b/src/backend/gporca/data/dxl/expressiontests/WinFunc-OuterRef-Partition-Order-Query.xml
@@ -633,7 +633,7 @@ select * from x where x.i in (select row_number() over(partition by x.i order by
         <dxl:IntermediateResultType Mdid="0.20.1.0"/>
       </dxl:GPDBAgg>
       <dxl:MDScalarComparison Mdid="4.23.1.0;20.1.0;0" Name="=" ComparisonType="Eq" LeftType="0.23.1.0" RightType="0.20.1.0" OperatorMdid="0.15.1.0"/>
-      <dxl:Index Mdid="0.17159874.1.0" Name="idx_x_j" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.17159874.1.0" Name="idx_x_j" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>
@@ -701,7 +701,7 @@ select * from x where x.i in (select row_number() over(partition by x.i order by
         <dxl:ResultType Mdid="0.20.1.0"/>
         <dxl:IntermediateResultType Mdid="0.20.1.0"/>
       </dxl:GPDBAgg>
-      <dxl:Index Mdid="0.17159920.1.0" Name="idx_x_i" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.17159920.1.0" Name="idx_x_i" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/expressiontests/WinFunc-OuterRef-Partition-Query.xml
+++ b/src/backend/gporca/data/dxl/expressiontests/WinFunc-OuterRef-Partition-Query.xml
@@ -633,7 +633,7 @@ select * from x where x.i in (select row_number() over(partition by x.i) from y)
         <dxl:IntermediateResultType Mdid="0.20.1.0"/>
       </dxl:GPDBAgg>
       <dxl:MDScalarComparison Mdid="4.23.1.0;20.1.0;0" Name="=" ComparisonType="Eq" LeftType="0.23.1.0" RightType="0.20.1.0" OperatorMdid="0.15.1.0"/>
-      <dxl:Index Mdid="0.17159874.1.0" Name="idx_x_j" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.17159874.1.0" Name="idx_x_j" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>
@@ -689,7 +689,7 @@ select * from x where x.i in (select row_number() over(partition by x.i) from y)
         <dxl:ResultType Mdid="0.20.1.0"/>
         <dxl:IntermediateResultType Mdid="0.20.1.0"/>
       </dxl:GPDBAgg>
-      <dxl:Index Mdid="0.17159920.1.0" Name="idx_x_i" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.17159920.1.0" Name="idx_x_i" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/indexjoin/positive_04.mdp
+++ b/src/backend/gporca/data/dxl/indexjoin/positive_04.mdp
@@ -3541,7 +3541,7 @@
           <dxl:Opfamily Mdid="0.3018.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.33052642.1.0" Name="store_sales_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="2,9" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29">
+      <dxl:Index Mdid="0.33052642.1.0" Name="store_sales_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="2,9" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
@@ -8553,7 +8553,7 @@
         </dxl:IndexInfoList>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.33052182.1.0" Name="store_returns_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="2,9" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26">
+      <dxl:Index Mdid="0.33052182.1.0" Name="store_returns_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="2,9" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
@@ -13336,7 +13336,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" Value="AAAABldv" LintValue="756671276"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.33051952.1.0" Name="item_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28">
+      <dxl:Index Mdid="0.33051952.1.0" Name="item_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/metadata/md.xml
+++ b/src/backend/gporca/data/dxl/metadata/md.xml
@@ -107,7 +107,7 @@
       </dxl:IndexInfoList>
       <dxl:CheckConstraints/>
     </dxl:Relation>
-    <dxl:Index Mdid="0.2345.2.1" Name="T_a" IsClustered="false" KeyColumns="1" IncludedColumns="0,1">
+    <dxl:Index Mdid="0.2345.2.1" Name="T_a" IsClustered="false" KeyColumns="1" IncludedColumns="">
       <dxl:Opfamilies>
         <dxl:Opfamily Mdid="0.1978.1.0"/>
       </dxl:Opfamilies>
@@ -116,7 +116,7 @@
         <dxl:Partition Mdid="6.2351.2.1"/>
       </dxl:Partitions>
     </dxl:Index>
-    <dxl:Index Mdid="0.2347.1.1" Name="T_a" IsClustered="false" KeyColumns="0" IncludedColumns="0,1">
+    <dxl:Index Mdid="0.2347.1.1" Name="T_a" IsClustered="false" KeyColumns="0" IncludedColumns="">
       <dxl:Opfamilies>
         <dxl:Opfamily Mdid="0.434.1.0"/>
       </dxl:Opfamilies>
@@ -1386,7 +1386,7 @@
         </dxl:And>
       </dxl:PartConstraint>
     </dxl:Relation>
-    <dxl:Index Mdid="0.13144342.1.0" Name="idx_p1_j_1_prt_p11" IsClustered="false" KeyColumns="1" IncludedColumns="0,1">
+    <dxl:Index Mdid="0.13144342.1.0" Name="idx_p1_j_1_prt_p11" IsClustered="false" KeyColumns="1" IncludedColumns="">
       <dxl:Opfamilies>
         <dxl:Opfamily Mdid="0.434.1.0"/>
       </dxl:Opfamilies>
@@ -1395,7 +1395,7 @@
         <dxl:Partition Mdid="6.13144344.1.0"/>
       </dxl:Partitions>
     </dxl:Index>
-    <dxl:Index Mdid="0.13144285.1.0" Name="idx_p1_i_1_prt_p11" IsClustered="false" KeyColumns="0" IncludedColumns="0,1">
+    <dxl:Index Mdid="0.13144285.1.0" Name="idx_p1_i_1_prt_p11" IsClustered="false" KeyColumns="0" IncludedColumns="">
       <dxl:Opfamilies>
         <dxl:Opfamily Mdid="0.434.1.0"/>
       </dxl:Opfamilies>
@@ -3099,13 +3099,13 @@
       <dxl:SumAgg Mdid="0.0.0.0"/>
       <dxl:CountAgg Mdid="0.2147.1.0"/>
     </dxl:Type>
-    <dxl:Index Mdid="0.197454.1.1" Name="foo_ab" IsClustered="false" KeyColumns="0,1" IncludedColumns="0,1,2,3,4">
+    <dxl:Index Mdid="0.197454.1.1" Name="foo_ab" IsClustered="false" KeyColumns="0,1" IncludedColumns="">
       <dxl:Opfamilies>
         <dxl:Opfamily Mdid="0.434.1.0"/>
         <dxl:Opfamily Mdid="0.434.1.0"/>
       </dxl:Opfamilies>
     </dxl:Index>
-    <dxl:Index Mdid="0.197514.1.1" Name="foo_bitmap_c" IsClustered="false" KeyColumns="2" IncludedColumns="0,1,2,3,4">
+    <dxl:Index Mdid="0.197514.1.1" Name="foo_bitmap_c" IsClustered="false" KeyColumns="2" IncludedColumns="">
       <dxl:Opfamilies>
         <dxl:Opfamily Mdid="0.434.1.0"/>
       </dxl:Opfamilies>
@@ -4323,7 +4323,7 @@
         </dxl:And>
       </dxl:PartConstraint>
     </dxl:Relation>
-    <dxl:Index Mdid="0.27324.1.0" Name="p_ind" IsClustered="false" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8">
+    <dxl:Index Mdid="0.27324.1.0" Name="p_ind" IsClustered="false" KeyColumns="1" IncludedColumns="">
       <dxl:Opfamilies>
         <dxl:Opfamily Mdid="0.434.1.0"/>
       </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/ArrayCmpInList.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ArrayCmpInList.mdp
@@ -42,12 +42,12 @@
       <dxl:TraceFlags Value="101013,102001,102002,102003,102074,102113,102120,102144,103001,103014,103015,103022,103027,103029,103033,104003,104004,104005,105000"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:Index Mdid="0.123270.1.0" Name="idx_b" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.123270.1.0" Name="idx_b" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.123266.1.0" Name="idx_a" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.123266.1.0" Name="idx_a" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/AssertMaxOneRow.mdp
+++ b/src/backend/gporca/data/dxl/minidump/AssertMaxOneRow.mdp
@@ -748,13 +748,13 @@ where oid= (select reltoastrelid from pg_class where relname='fsts_alter_set_sto
           <dxl:Opfamily Mdid="0.3033.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.2663.1.0" Name="pg_class_relname_nsp_index" IsClustered="false" IndexType="B-tree" KeyColumns="0,1" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37">
+      <dxl:Index Mdid="0.2663.1.0" Name="pg_class_relname_nsp_index" IsClustered="false" IndexType="B-tree" KeyColumns="0,1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1986.1.0"/>
           <dxl:Opfamily Mdid="0.1989.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.2662.1.0" Name="pg_class_oid_index" IsClustered="false" IndexType="B-tree" KeyColumns="31" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37">
+      <dxl:Index Mdid="0.2662.1.0" Name="pg_class_oid_index" IsClustered="false" IndexType="B-tree" KeyColumns="31" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1989.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/BRINScan-Or.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BRINScan-Or.mdp
@@ -101,7 +101,7 @@
         <dxl:SumAgg Mdid="0.2108.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.180254.1.0" Name="foo_brin" IsClustered="false" IndexType="Brin" IndexItemType="0.2283.1.0" KeyColumns="0,1,2,3,4,5" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12">
+      <dxl:Index Mdid="0.180254.1.0" Name="foo_brin" IsClustered="false" IndexType="Brin" IndexItemType="0.2283.1.0" KeyColumns="0,1,2,3,4,5" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.4054.1.0"/>
           <dxl:Opfamily Mdid="0.4054.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/BTreeIndex-Against-InList.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BTreeIndex-Against-InList.mdp
@@ -251,7 +251,7 @@ SELECT * FROM test WHERE a in (1, 47);
       </dxl:Relation>
       <dxl:ColumnStatistics Mdid="1.41665.1.1.7" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="3.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
       <dxl:ColumnStatistics Mdid="1.41665.1.1.6" Name="tableoid" Width="4.000000" NullFreq="0.000000" NdvRemain="1.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
-      <dxl:Index Mdid="0.41692.1.0" Name="test_index" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7">
+      <dxl:Index Mdid="0.41692.1.0" Name="test_index" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/BTreeIndex-Against-InListLarge.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BTreeIndex-Against-InListLarge.mdp
@@ -511,7 +511,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="998114"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.65597.1.0" Name="test_index" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3">
+      <dxl:Index Mdid="0.65597.1.0" Name="test_index" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/BTreeIndex-Against-ScalarSubquery.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BTreeIndex-Against-ScalarSubquery.mdp
@@ -35,7 +35,7 @@ SELECT * FROM btree_test WHERE a in (select 1);
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.4524693.1.0" Name="test_index" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7">
+      <dxl:Index Mdid="0.4524693.1.0" Name="test_index" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/BitmapBoolAnd.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapBoolAnd.mdp
@@ -193,12 +193,12 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.145185.1.0" Name="r_a" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="0.145185.1.0" Name="r_a" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.145206.1.0" Name="r_b" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="0.145206.1.0" Name="r_b" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
@@ -206,14 +206,14 @@
       <dxl:ColumnStatistics Mdid="1.145159.1.1.10" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.145159.1.1.3" Name="d" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.145159.1.1.2" Name="c" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
-      <dxl:Index Mdid="0.145227.1.0" Name="r_c" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="0.145227.1.0" Name="r_c" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
       <dxl:ColumnStatistics Mdid="1.145159.1.1.5" Name="xmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.145159.1.1.4" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
-      <dxl:Index Mdid="0.145248.1.0" Name="r_d" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="3" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="0.145248.1.0" Name="r_d" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="3" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/BitmapBoolOp-DeepTree.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapBoolOp-DeepTree.mdp
@@ -193,22 +193,22 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.145185.1.0" Name="r_a" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="0.145185.1.0" Name="r_a" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.145206.1.0" Name="r_b" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="0.145206.1.0" Name="r_b" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.145227.1.0" Name="r_c" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="0.145227.1.0" Name="r_c" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.145248.1.0" Name="r_d" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="3" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="0.145248.1.0" Name="r_d" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="3" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/BitmapBoolOp-DeepTree2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapBoolOp-DeepTree2.mdp
@@ -42,7 +42,7 @@ explain select * from t where c1 = 10 or (c2 = '4' and c5> 100);
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.1632594.1.0" Name="t_c1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13">
+      <dxl:Index Mdid="0.1632594.1.0" Name="t_c1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
@@ -263,7 +263,7 @@ explain select * from t where c1 = 10 or (c2 = '4' and c5> 100);
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.1632615.1.0" Name="t_c2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13">
+      <dxl:Index Mdid="0.1632615.1.0" Name="t_c2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3035.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/BitmapBoolOp-DeepTree3.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapBoolOp-DeepTree3.mdp
@@ -43,7 +43,7 @@ explain select * from t where (c1 = 10 and c5 < 20) or (c2 = '4' and c5> 100);
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.1632594.1.0" Name="t_c1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13">
+      <dxl:Index Mdid="0.1632594.1.0" Name="t_c1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
@@ -264,7 +264,7 @@ explain select * from t where (c1 = 10 and c5 < 20) or (c2 = '4' and c5> 100);
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.1632615.1.0" Name="t_c2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13">
+      <dxl:Index Mdid="0.1632615.1.0" Name="t_c2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3035.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/BitmapBoolOr-BoolColumn.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapBoolOr-BoolColumn.mdp
@@ -28,7 +28,7 @@ explain select * from t where c2 = 'HEAP' or c4 = 't' or c5 = 'f';
       <dxl:TraceFlags Value="102001,102002,102003,102004,102005,102006,102007,102024,102025,102121,102144,103001,103016,103027,103033"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:Index Mdid="0.21849037.1.0" Name="idx_t_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="3" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13">
+      <dxl:Index Mdid="0.21849037.1.0" Name="idx_t_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="3" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3017.1.0"/>
         </dxl:Opfamilies>
@@ -248,12 +248,12 @@ explain select * from t where c2 = 'HEAP' or c4 = 't' or c5 = 'f';
           <dxl:UpperBound Closed="true" TypeMdid="0.16.1.0" Value="true"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.21849058.1.0" Name="idx_t_2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="4" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13">
+      <dxl:Index Mdid="0.21849058.1.0" Name="idx_t_2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="4" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3017.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.21849079.1.0" Name="idx_t_3" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13">
+      <dxl:Index Mdid="0.21849079.1.0" Name="idx_t_3" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3035.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/BitmapBoolOr.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapBoolOr.mdp
@@ -212,12 +212,12 @@ explain select * from r where a = 1 or b = 2;
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.145185.1.0" Name="r_a" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="0.145185.1.0" Name="r_a" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.145206.1.0" Name="r_b" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="0.145206.1.0" Name="r_b" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
@@ -225,14 +225,14 @@ explain select * from r where a = 1 or b = 2;
       <dxl:ColumnStatistics Mdid="1.145159.1.1.10" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.145159.1.1.3" Name="d" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.145159.1.1.2" Name="c" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
-      <dxl:Index Mdid="0.145227.1.0" Name="r_c" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="0.145227.1.0" Name="r_c" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
       <dxl:ColumnStatistics Mdid="1.145159.1.1.5" Name="xmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.145159.1.1.4" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
-      <dxl:Index Mdid="0.145248.1.0" Name="r_d" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="3" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="0.145248.1.0" Name="r_d" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="3" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/BitmapIndex-Against-InList.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndex-Against-InList.mdp
@@ -20,7 +20,7 @@ SELECT * FROM bitmap_test WHERE a in (1, 47);
       <dxl:TraceFlags Value="101013,102001,102002,102003,102120,102144,103001,103014,103015,103022,103027,103033,104004,104005,105000"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:Index Mdid="0.4513675.1.0" Name="bitmap_index" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7">
+      <dxl:Index Mdid="0.4513675.1.0" Name="bitmap_index" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/BitmapIndex-ChooseHashJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndex-ChooseHashJoin.mdp
@@ -3396,7 +3396,7 @@
         <dxl:IndexInfoList/>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.677686.1.0" Name="bar_idx" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0,1" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.677686.1.0" Name="bar_idx" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0,1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
           <dxl:Opfamily Mdid="0.3027.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/BitmapIndexApply-Basic-SelfJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndexApply-Basic-SelfJoin.mdp
@@ -286,7 +286,7 @@ explain SELECT * FROM t i1, t t2 where t2.c2 = i1.c2;
       </dxl:Relation>
       <dxl:ColumnStatistics Mdid="1.29237539.1.1.7" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.29237539.1.1.6" Name="c7" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
-      <dxl:Index Mdid="0.29237567.1.0" Name="idx_t_2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13">
+      <dxl:Index Mdid="0.29237567.1.0" Name="idx_t_2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3035.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/BitmapIndexApply-Basic-TwoTables.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndexApply-Basic-TwoTables.mdp
@@ -191,7 +191,7 @@ explain SELECT * FROM s i1, t t2 where t2.c2 = i1.c2;
       <dxl:ColumnStatistics Mdid="1.29842177.1.1.10" Name="xmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.29842177.1.1.3" Name="c4" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.29842177.1.1.2" Name="c3" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
-      <dxl:Index Mdid="0.29842205.1.0" Name="idx_t_2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13">
+      <dxl:Index Mdid="0.29842205.1.0" Name="idx_t_2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3035.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/BitmapIndexApply-Complex-Condition.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndexApply-Complex-Condition.mdp
@@ -51,7 +51,7 @@ EXPLAIN SELECT * FROM s i1, t t2 where t2.c2 = i1.c2  and t2.c3 > i1.c3 or t2.c1
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.31264085.1.0" Name="idx_t_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13">
+      <dxl:Index Mdid="0.31264085.1.0" Name="idx_t_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
@@ -146,7 +146,7 @@ EXPLAIN SELECT * FROM s i1, t t2 where t2.c2 = i1.c2  and t2.c3 > i1.c3 or t2.c1
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.31264106.1.0" Name="idx_t_2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1,2" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13">
+      <dxl:Index Mdid="0.31264106.1.0" Name="idx_t_2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1,2" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3035.1.0"/>
           <dxl:Opfamily Mdid="0.3022.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/BitmapIndexApply-InnerSelect-Basic.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndexApply-InnerSelect-Basic.mdp
@@ -265,7 +265,7 @@ select * from x, y where x.i > y.j and y.k = 10;
       <dxl:ColumnStatistics Mdid="1.52975721.1.1.10" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.52975721.1.1.3" Name="m" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.52975721.1.1.2" Name="k" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
-      <dxl:Index Mdid="0.52975773.1.0" Name="y_idx" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="0.52975773.1.0" Name="y_idx" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/BitmapIndexApply-InnerSelect-PartTable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndexApply-InnerSelect-PartTable.mdp
@@ -653,7 +653,7 @@ select * from x, y where x.i > y.j and y.k = 10;
       <dxl:ColumnStatistics Mdid="1.53062540.1.1.10" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.53062540.1.1.3" Name="m" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.53062540.1.1.2" Name="k" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
-      <dxl:Index Mdid="0.53062705.1.0" Name="y_idx_1_prt_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="0.53062705.1.0" Name="y_idx_1_prt_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/BitmapIndexApply-PartTable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndexApply-PartTable.mdp
@@ -1199,7 +1199,7 @@ ORDER BY 1 asc ;
         <dxl:SumAgg Mdid="0.2114.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.16166830.1.0" Name="my_tq_agg_small_ets_end_ts_ix_1_prt_p1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0,4" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11">
+      <dxl:Index Mdid="0.16166830.1.0" Name="my_tq_agg_small_ets_end_ts_ix_1_prt_p1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0,4" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1980.1.0"/>
           <dxl:Opfamily Mdid="0.1980.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/BitmapIndexNLJWithProject.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndexNLJWithProject.mdp
@@ -1797,7 +1797,7 @@
           <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
         </dxl:DistrOpfamilies>
       </dxl:Relation>
-      <dxl:Index Mdid="0.33012.1.0" Name="foo_1_prt_1_dist_a_part_d_idx" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0,3" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="0.33012.1.0" Name="foo_1_prt_1_dist_a_part_d_idx" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0,3" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.12738.1.0"/>
           <dxl:Opfamily Mdid="0.12738.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/BitmapIndexNLJWithProjectNoFilt.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndexNLJWithProjectNoFilt.mdp
@@ -208,7 +208,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.33184.1.0" Name="foo_1_prt_1_dist_a_part_d_idx" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0,3" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="0.33184.1.0" Name="foo_1_prt_1_dist_a_part_d_idx" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0,3" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.12738.1.0"/>
           <dxl:Opfamily Mdid="0.12738.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/BitmapIndexNLOJWithProject.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndexNLOJWithProject.mdp
@@ -966,7 +966,7 @@
           <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
         </dxl:DistrOpfamilies>
       </dxl:Relation>
-      <dxl:Index Mdid="0.32957.1.0" Name="foo_1_prt_1_dist_a_part_d_idx" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0,3" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="0.32957.1.0" Name="foo_1_prt_1_dist_a_part_d_idx" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0,3" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.12738.1.0"/>
           <dxl:Opfamily Mdid="0.12738.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/BitmapIndexNLOJWithProjectNonPart.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndexNLOJWithProjectNonPart.mdp
@@ -306,7 +306,7 @@
           <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
         </dxl:DistrOpfamilies>
       </dxl:Relation>
-      <dxl:Index Mdid="0.33108.1.0" Name="t1_idx_ac" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0,2" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.33108.1.0" Name="t1_idx_ac" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0,2" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.12738.1.0"/>
           <dxl:Opfamily Mdid="0.12738.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/BitmapIndexProbeMergeFilters.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndexProbeMergeFilters.mdp
@@ -230,7 +230,7 @@ EXPLAIN SELECT * FROM table_with_two_indices_ao WHERE b = 15 AND c BETWEEN 10000
           </dxl:And>
         </dxl:PartConstraint>
       </dxl:Relation>
-      <dxl:Index Mdid="0.44979.1.0" Name="idx_b_1_prt_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5">
+      <dxl:Index Mdid="0.44979.1.0" Name="idx_b_1_prt_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>
@@ -702,7 +702,7 @@ EXPLAIN SELECT * FROM table_with_two_indices_ao WHERE b = 15 AND c BETWEEN 10000
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="10001"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.45040.1.0" Name="idx_c_1_prt_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="0,1,2,3,4,5">
+      <dxl:Index Mdid="0.45040.1.0" Name="idx_c_1_prt_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/BitmapIndexScan-WithUnsupportedOperatorFilter.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndexScan-WithUnsupportedOperatorFilter.mdp
@@ -614,7 +614,7 @@ inferred from the second operator (c4 = 'f')
           <dxl:Opfamily Mdid="0.3017.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.22226547.1.0" Name="idx_t_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="3" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13">
+      <dxl:Index Mdid="0.22226547.1.0" Name="idx_t_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="3" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3017.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/BitmapIndexScan.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndexScan.mdp
@@ -197,7 +197,7 @@ see sql/BitmapIndexScan.sql
       <dxl:ColumnStatistics Mdid="1.24702.1.1.12" Name="dataowner" Width="0.000000" NullFreq="1.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false"/>
       <dxl:ColumnStatistics Mdid="1.24702.1.1.5" Name="created_by" Width="0.000000" NullFreq="1.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false"/>
       <dxl:ColumnStatistics Mdid="1.24702.1.1.4" Name="creation_date" Width="4.000000" NullFreq="1.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false"/>
-      <dxl:Index Mdid="0.24762.1.0" Name="inner_table_idx" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5">
+      <dxl:Index Mdid="0.24762.1.0" Name="inner_table_idx" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1988.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/BitmapIndexScanChooseIndex.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndexScanChooseIndex.mdp
@@ -157,7 +157,7 @@
         </dxl:IndexInfoList>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.857985.1.0" Name="my_idx" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7">
+      <dxl:Index Mdid="0.857985.1.0" Name="my_idx" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/BitmapIndexScanCost.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndexScanCost.mdp
@@ -244,7 +244,7 @@
         <dxl:ResultType Mdid="0.20.1.0"/>
         <dxl:IntermediateResultType Mdid="0.20.1.0"/>
       </dxl:GPDBAgg>
-      <dxl:Index Mdid="0.16445.1.0" Name="ix_test_ix01" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3,4,5">
+      <dxl:Index Mdid="0.16445.1.0" Name="ix_test_ix01" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1994.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/BitmapIndexUnsupportedOperator.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapIndexUnsupportedOperator.mdp
@@ -107,7 +107,7 @@ undefined for Bitmap Index Scan. ORCA should find a plan transforming
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.32784.1.0" Name="idx_t_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="3" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13">
+      <dxl:Index Mdid="0.32784.1.0" Name="idx_t_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="3" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.10002.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/BitmapScan-Hetrogeneous-Partitioned.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapScan-Hetrogeneous-Partitioned.mdp
@@ -290,7 +290,7 @@ explain select * from t where b=3;
           </dxl:And>
         </dxl:PartConstraint>
       </dxl:Relation>
-      <dxl:Index Mdid="0.181454.1.0" Name="idx" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.181454.1.0" Name="idx" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/BitmapTableScan-AO-Btree-PickIndexWithNoGap.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapTableScan-AO-Btree-PickIndexWithNoGap.mdp
@@ -530,7 +530,7 @@
         </dxl:IndexInfoList>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.55598.1.0" Name="idx_a" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3,4,5">
+      <dxl:Index Mdid="0.55598.1.0" Name="idx_a" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
@@ -557,13 +557,13 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="4"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.55603.1.0" Name="idx_ac" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0,2" IncludedColumns="0,1,2,3,4,5">
+      <dxl:Index Mdid="0.55603.1.0" Name="idx_ac" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0,2" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.55602.1.0" Name="idx_abc" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0,1,2" IncludedColumns="0,1,2,3,4,5">
+      <dxl:Index Mdid="0.55602.1.0" Name="idx_abc" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0,1,2" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/BitmapTableScan-AO-Btree-PickOnlyHighNDV.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapTableScan-AO-Btree-PickOnlyHighNDV.mdp
@@ -72,7 +72,7 @@
         </dxl:IndexInfoList>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.49558.1.0" Name="jazz_lo_btree" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4">
+      <dxl:Index Mdid="0.49558.1.0" Name="jazz_lo_btree" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
@@ -92,7 +92,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.49554.1.0" Name="jazz_hi" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3,4">
+      <dxl:Index Mdid="0.49554.1.0" Name="jazz_hi" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/BitmapTableScan-AO-Btree.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapTableScan-AO-Btree.mdp
@@ -239,7 +239,7 @@ explain select * from indexonao where a = 21;
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="99997"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.22227385.1.0" Name="idx_onao" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3">
+      <dxl:Index Mdid="0.22227385.1.0" Name="idx_onao" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/BitmapTableScan-AO.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapTableScan-AO.mdp
@@ -515,7 +515,7 @@ explain select * from t_ao where c2 = 'HEAP';
         <dxl:SumAgg Mdid="0.2111.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.21846783.1.0" Name="idx_t_ao_3" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.21846783.1.0" Name="idx_t_ao_3" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3035.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/BitmapTableScan-AndCondition.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapTableScan-AndCondition.mdp
@@ -217,7 +217,7 @@ explain select * from xfoo where j = 1 and k = 2;
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.51565282.1.0" Name="idx_jk" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1,2" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="0.51565282.1.0" Name="idx_jk" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1,2" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
           <dxl:Opfamily Mdid="0.3027.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/BitmapTableScan-Basic.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapTableScan-Basic.mdp
@@ -9,7 +9,7 @@
       <dxl:TraceFlags Value="102001,102002,102003,102144,103027,103033"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:Index Mdid="0.9459845.1.0" Name="x2_idx" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.9459845.1.0" Name="x2_idx" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/BitmapTableScan-ColumnOnRightSide.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapTableScan-ColumnOnRightSide.mdp
@@ -258,7 +258,7 @@ SELECT * FROM my_tq_agg_small tq WHERE 110 >= tq.ets;
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="1200"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.31763881.1.0" Name="my_idx" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11">
+      <dxl:Index Mdid="0.31763881.1.0" Name="my_idx" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/BitmapTableScan-ComplexConjDisj.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapTableScan-ComplexConjDisj.mdp
@@ -80,7 +80,7 @@
         <dxl:SumAgg Mdid="0.2108.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.55583.1.0" Name="idx_a" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.55583.1.0" Name="idx_a" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
@@ -185,7 +185,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.55587.1.0" Name="idx_b" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.55587.1.0" Name="idx_b" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/BitmapTableScan-ConjDisjWithOuterRefs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BitmapTableScan-ConjDisjWithOuterRefs.mdp
@@ -142,7 +142,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.55607.1.0" Name="xa" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.55607.1.0" Name="xa" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
@@ -229,7 +229,7 @@
       </dxl:Relation>
       <dxl:ColumnStatistics Mdid="1.55604.1.0.1" Name="b" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.55604.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:Index Mdid="0.55611.1.0" Name="xb" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.55611.1.0" Name="xb" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/BtreeIndexNLJWithProjectNoPart.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BtreeIndexNLJWithProjectNoPart.mdp
@@ -728,7 +728,7 @@
           <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
         </dxl:DistrOpfamilies>
       </dxl:Relation>
-      <dxl:Index Mdid="0.33097.1.0" Name="t1_idx_ac" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0,2" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.33097.1.0" Name="t1_idx_ac" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0,2" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/BtreeIndexNLOJWithProject.mdp
+++ b/src/backend/gporca/data/dxl/minidump/BtreeIndexNLOJWithProject.mdp
@@ -606,7 +606,7 @@
           <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
         </dxl:DistrOpfamilies>
       </dxl:Relation>
-      <dxl:Index Mdid="0.33144.1.0" Name="foo_1_prt_1_dist_a_part_d_idx" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0,3" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="0.33144.1.0" Name="foo_1_prt_1_dist_a_part_d_idx" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0,3" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/CPhysicalParallelUnionAllTest/FallBackToSerialAppend.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CPhysicalParallelUnionAllTest/FallBackToSerialAppend.mdp
@@ -360,7 +360,7 @@ SELECT * FROM pp WHERE b=2 AND c=2;
       </dxl:Type>
       <dxl:ColumnStatistics Mdid="1.2435227.1.1.7" Name="cmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.2435227.1.1.6" Name="xmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:Index Mdid="0.2435371.1.0" Name="pp_1_prt_1_idx" IsClustered="false" IndexType="B-tree" KeyColumns="2" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.2435371.1.0" Name="pp_1_prt_1_idx" IsClustered="false" IndexType="B-tree" KeyColumns="2" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
@@ -370,7 +370,7 @@ SELECT * FROM pp WHERE b=2 AND c=2;
           <dxl:Partition Mdid="6.2435371003.1.0"/>
         </dxl:Partitions>
       </dxl:Index>
-      <dxl:Index Mdid="0.2435390.1.0" Name="pp_rest_1_idx" IsClustered="false" IndexType="B-tree" KeyColumns="2,0" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.2435390.1.0" Name="pp_rest_1_idx" IsClustered="false" IndexType="B-tree" KeyColumns="2,0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/CapGbCardToSelectCard.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CapGbCardToSelectCard.mdp
@@ -5828,7 +5828,7 @@ group  by item.i_item_id, item.i_item_desc, item.i_current_price;
         </dxl:IndexInfoList>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.26188.1.0" Name="item_pkey" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28">
+      <dxl:Index Mdid="0.26188.1.0" Name="item_pkey" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/CastedScalarIf-On-Index-Key.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CastedScalarIf-On-Index-Key.mdp
@@ -254,7 +254,7 @@
       <dxl:ColumnStatistics Mdid="1.49155.1.0.1" Name="b" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.49155.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:MDCast Mdid="3.1043.1.0;25.1.0" Name="text" BinaryCoercible="true" SourceTypeId="0.1043.1.0" DestinationTypeId="0.25.1.0" CastFuncId="0.0.0.0" CoercePathType="0"/>
-      <dxl:Index Mdid="0.49221.1.0" Name="pt_idx_1_prt_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1,2" IncludedColumns="0,1,2,3,4,5,6">
+      <dxl:Index Mdid="0.49221.1.0" Name="pt_idx_1_prt_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1,2" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1994.1.0"/>
           <dxl:Opfamily Mdid="0.1994.1.0"/>
@@ -264,7 +264,7 @@
           <dxl:Partition Mdid="6.49221002.1.0"/>
         </dxl:Partitions>
       </dxl:Index>
-      <dxl:Index Mdid="0.49238.1.0" Name="pt_idx_1_prt_2" IsClustered="false" IndexType="B-tree" KeyColumns="1,2" IncludedColumns="0,1,2,3,4,5,6">
+      <dxl:Index Mdid="0.49238.1.0" Name="pt_idx_1_prt_2" IsClustered="false" IndexType="B-tree" KeyColumns="1,2" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1994.1.0"/>
           <dxl:Opfamily Mdid="0.1994.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/Coalesce-With-Subquery.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Coalesce-With-Subquery.mdp
@@ -165,12 +165,12 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.2698.1.0" Name="pg_tablespace_spcname_index" IsClustered="false" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14">
+      <dxl:Index Mdid="0.2698.1.0" Name="pg_tablespace_spcname_index" IsClustered="false" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.2672.1.0" Name="pg_database_oid_index" IsClustered="false" KeyColumns="12" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18">
+      <dxl:Index Mdid="0.2672.1.0" Name="pg_database_oid_index" IsClustered="false" KeyColumns="12" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1989.1.0"/>
         </dxl:Opfamilies>
@@ -339,12 +339,12 @@
       <dxl:GPDBFunc Mdid="0.1597.1.0" Name="pg_encoding_to_char" ReturnsSet="false" Stability="Stable" IsStrict="true">
         <dxl:ResultType Mdid="0.19.1.0"/>
       </dxl:GPDBFunc>
-      <dxl:Index Mdid="0.2697.1.0" Name="pg_tablespace_oid_index" IsClustered="false" KeyColumns="8" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14">
+      <dxl:Index Mdid="0.2697.1.0" Name="pg_tablespace_oid_index" IsClustered="false" KeyColumns="8" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.2671.1.0" Name="pg_database_datname_index" IsClustered="false" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18">
+      <dxl:Index Mdid="0.2671.1.0" Name="pg_database_datname_index" IsClustered="false" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1986.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/CoerceToDomain.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CoerceToDomain.mdp
@@ -953,12 +953,12 @@ SELECT * FROM information_schema.tables;
         <dxl:Commutator Mdid="0.607.1.0"/>
         <dxl:InverseOp Mdid="0.608.1.0"/>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.2663.1.0" Name="pg_class_relname_nsp_index" IsClustered="false" IndexType="B-tree" KeyColumns="0,1" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37">
+      <dxl:Index Mdid="0.2663.1.0" Name="pg_class_relname_nsp_index" IsClustered="false" IndexType="B-tree" KeyColumns="0,1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1986.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.2662.1.0" Name="pg_class_oid_index" IsClustered="false" IndexType="B-tree" KeyColumns="31" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37">
+      <dxl:Index Mdid="0.2662.1.0" Name="pg_class_oid_index" IsClustered="false" IndexType="B-tree" KeyColumns="31" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1989.1.0"/>
         </dxl:Opfamilies>
@@ -1624,12 +1624,12 @@ SELECT * FROM information_schema.tables;
           <dxl:UpperBound Closed="true" TypeMdid="0.26.1.0" Value="10"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.2685.1.0" Name="pg_namespace_oid_index" IsClustered="false" IndexType="B-tree" KeyColumns="4" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="0.2685.1.0" Name="pg_namespace_oid_index" IsClustered="false" IndexType="B-tree" KeyColumns="4" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1989.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.2684.1.0" Name="pg_namespace_nspname_index" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="0.2684.1.0" Name="pg_namespace_nspname_index" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1986.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/CorrelatedAntiSemiJoin-True.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CorrelatedAntiSemiJoin-True.mdp
@@ -51,12 +51,12 @@ SELECT pn, cn, vn FROM sale s WHERE NOT EXISTS (SELECT * FROM customer WHERE NOT
       <dxl:TraceFlags Value="103027,102024,102025,102115,102116,102120,102128,103001,103014,103015"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:Index Mdid="0.29191877.1.0" Name="customer_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.29191877.1.0" Name="customer_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.29192019.1.0" Name="sale_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0,1,2" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12">
+      <dxl:Index Mdid="0.29192019.1.0" Name="sale_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0,1,2" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.0.0.0"/>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
@@ -482,7 +482,7 @@ SELECT pn, cn, vn FROM sale s WHERE NOT EXISTS (SELECT * FROM customer WHERE NOT
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.29191973.1.0" Name="product_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.29191973.1.0" Name="product_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/CorrelatedIN-LeftSemiNotIn-True.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CorrelatedIN-LeftSemiNotIn-True.mdp
@@ -202,7 +202,7 @@ create table customer
         </dxl:IndexInfoList>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.16404.1.0" Name="customer_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.16404.1.0" Name="customer_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
@@ -380,7 +380,7 @@ create table customer
       <dxl:ColumnStatistics Mdid="1.16406.1.0.0" Name="pn" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.16427.1.0.7" Name="xmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.16427.1.0.6" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:Index Mdid="0.16425.1.0" Name="product_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.16425.1.0" Name="product_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
@@ -402,7 +402,7 @@ create table customer
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.16441.1.0" Name="sale_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0,1,2" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12">
+      <dxl:Index Mdid="0.16441.1.0" Name="sale_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0,1,2" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/CorrelatedSemiJoin-True.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CorrelatedSemiJoin-True.mdp
@@ -51,12 +51,12 @@ SELECT pn, cn, vn FROM sale s WHERE EXISTS (SELECT * FROM customer WHERE EXISTS 
       <dxl:TraceFlags Value="102001,102002,102003,102024,102025,102115,102116,102120,102128,102144,103001,103014,103015,103027,103033"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:Index Mdid="0.29191877.1.0" Name="customer_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.29191877.1.0" Name="customer_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.29192019.1.0" Name="sale_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0,1,2" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12">
+      <dxl:Index Mdid="0.29192019.1.0" Name="sale_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0,1,2" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.0.0.0"/>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
@@ -481,7 +481,7 @@ SELECT pn, cn, vn FROM sale s WHERE EXISTS (SELECT * FROM customer WHERE EXISTS 
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.29191973.1.0" Name="product_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.29191973.1.0" Name="product_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/CoveringIndex-1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CoveringIndex-1.mdp
@@ -1,22 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
   <dxl:Comment><![CDATA[
-            Objective: Generate plan using hash indexes in ORCA by using bitmap operators.
+    Objective: Choose Index-Only Scan when predicate contains index keys and
+    project list contains "payload" keys. In following setup index keys are 'd'
+    and 'e' whereas payload keys are 'a' and 'b'
 
-            create table foo(a int, b int);
-            create index idx1 on foo using hash(b);
-            set optimizer_enable_indexscan to off;
-            explain select * from foo where b=2;
+      CREATE TABLE t(a int, b int, c int, d int, e int);
+      CREATE INDEX ON t(d, e) INCLUDE (a, b);
+      INSERT INTO t SELECT i, i, i, i, i FROM generate_series(1, 1000)i;
+      VACUUM t;
 
-                                             QUERY PLAN
-           ------------------------------------------------------------------------------
-            Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..391.30 rows=1 width=8)
-              ->  Bitmap Heap Scan on foo  (cost=0.00..391.30 rows=1 width=8)
-                    Recheck Cond: (b = 2)
-                    ->  Bitmap Index Scan on idx1  (cost=0.00..0.00 rows=0 width=0)
-                          Index Cond: (b = 2)
-            Optimizer: Pivotal Optimizer (GPORCA)
-           (6 rows)
+      EXPLAIN SELECT a, b FROM t WHERE d>42 AND e<52;
   ]]>
   </dxl:Comment>
   <dxl:Thread Id="0">
@@ -31,9 +25,22 @@
         </dxl:CostParams>
       </dxl:CostModelConfig>
       <dxl:Hint JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="20" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0" SkewFactor="0"/>
-      <dxl:TraceFlags Value="101013,102001,102002,102003,102005,102043,102074,102120,102144,103001,103014,103022,103026,103027,103029,103033,103038,103040,104002,104003,104004,104005,106000"/>
+      <dxl:TraceFlags Value="102001,102002,102003,102043,102074,102120,102144,103001,103014,103022,103026,103027,103029,103033,103038,103040,104002,104003,104004,104005,105000,106000"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:GPDBScalarOp Mdid="0.521.1.0" Name="&gt;" ComparisonType="GT" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.147.1.0"/>
+        <dxl:Commutator Mdid="0.97.1.0"/>
+        <dxl:InverseOp Mdid="0.523.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
       <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
         <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
         <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
@@ -51,7 +58,6 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:RelationExtendedStatistics Mdid="10.52420.1.0" Name="foo"/>
       <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
         <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
         <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
@@ -69,8 +75,12 @@
         <dxl:SumAgg Mdid="0.2108.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:ColumnStatistics Mdid="1.52420.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:ColumnStatistics Mdid="1.52420.1.0.1" Name="b" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:Index Mdid="7.65569.1.0" Name="t_d_e_a_b_idx" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="3,4" IncludedColumns="0,1">
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:Index>
       <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
         <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
         <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
@@ -137,30 +147,22 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
-        <dxl:LeftType Mdid="0.23.1.0"/>
-        <dxl:RightType Mdid="0.23.1.0"/>
-        <dxl:ResultType Mdid="0.16.1.0"/>
-        <dxl:OpFunc Mdid="0.65.1.0"/>
-        <dxl:Commutator Mdid="0.96.1.0"/>
-        <dxl:InverseOp Mdid="0.518.1.0"/>
-        <dxl:HashOpfamily Mdid="0.1977.1.0"/>
-        <dxl:LegacyHashOpfamily Mdid="0.7100.1.0"/>
-        <dxl:Opfamilies>
-          <dxl:Opfamily Mdid="0.1976.1.0"/>
-          <dxl:Opfamily Mdid="0.1977.1.0"/>
-          <dxl:Opfamily Mdid="0.4054.1.0"/>
-          <dxl:Opfamily Mdid="0.7100.1.0"/>
-          <dxl:Opfamily Mdid="0.10009.1.0"/>
-        </dxl:Opfamilies>
-      </dxl:GPDBScalarOp>
-      <dxl:RelationStatistics Mdid="2.52420.1.0" Name="foo" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
-      <dxl:Relation Mdid="6.52420.1.0" Name="foo" IsTemporary="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2">
+      <dxl:RelationStatistics Mdid="2.65566.1.0" Name="t" Rows="1000.000000" RelPages="3" RelAllVisible="3" EmptyRelation="false"/>
+      <dxl:Relation Mdid="6.65566.1.0" Name="t" IsTemporary="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="11,5">
         <dxl:Columns>
           <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
             <dxl:DefaultValue/>
           </dxl:Column>
           <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="d" Attno="4" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="e" Attno="5" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
             <dxl:DefaultValue/>
           </dxl:Column>
           <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
@@ -186,18 +188,30 @@
           </dxl:Column>
         </dxl:Columns>
         <dxl:IndexInfoList>
-          <dxl:IndexInfo Mdid="7.52423.1.0" IsPartial="false"/>
+          <dxl:IndexInfo Mdid="7.65569.1.0" IsPartial="false"/>
         </dxl:IndexInfoList>
         <dxl:CheckConstraints/>
         <dxl:DistrOpfamilies>
           <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
         </dxl:DistrOpfamilies>
       </dxl:Relation>
-      <dxl:Index Mdid="7.52423.1.0" Name="idx1" IsClustered="false" IndexType="Hash" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
+      <dxl:ColumnStatistics Mdid="1.65566.1.0.4" Name="e" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:RelationExtendedStatistics Mdid="10.65566.1.0" Name="t"/>
+      <dxl:ColumnStatistics Mdid="1.65566.1.0.3" Name="d" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:GPDBScalarOp Mdid="0.97.1.0" Name="&lt;" ComparisonType="LT" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.66.1.0"/>
+        <dxl:Commutator Mdid="0.521.1.0"/>
+        <dxl:InverseOp Mdid="0.525.1.0"/>
         <dxl:Opfamilies>
-          <dxl:Opfamily Mdid="0.1977.1.0"/>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
         </dxl:Opfamilies>
-      </dxl:Index>
+      </dxl:GPDBScalarOp>
+      <dxl:ColumnStatistics Mdid="1.65566.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
     </dxl:Metadata>
     <dxl:Query>
       <dxl:OutputColumns>
@@ -206,31 +220,40 @@
       </dxl:OutputColumns>
       <dxl:CTEList/>
       <dxl:LogicalSelect>
-        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-          <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
-          <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
-        </dxl:Comparison>
+        <dxl:And>
+          <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
+            <dxl:Ident ColId="4" ColName="d" TypeMdid="0.23.1.0"/>
+            <dxl:ConstValue TypeMdid="0.23.1.0" Value="42"/>
+          </dxl:Comparison>
+          <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+            <dxl:Ident ColId="5" ColName="e" TypeMdid="0.23.1.0"/>
+            <dxl:ConstValue TypeMdid="0.23.1.0" Value="52"/>
+          </dxl:Comparison>
+        </dxl:And>
         <dxl:LogicalGet>
-          <dxl:TableDescriptor Mdid="6.52420.1.0" TableName="foo" LockMode="1">
+          <dxl:TableDescriptor Mdid="6.65566.1.0" TableName="t" LockMode="1">
             <dxl:Columns>
               <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
               <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
-              <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-              <dxl:Column ColId="4" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-              <dxl:Column ColId="5" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-              <dxl:Column ColId="6" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-              <dxl:Column ColId="7" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-              <dxl:Column ColId="8" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-              <dxl:Column ColId="9" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="3" Attno="3" ColName="c" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="4" Attno="4" ColName="d" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="5" Attno="5" ColName="e" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="7" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="9" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="10" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="11" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="12" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
             </dxl:Columns>
           </dxl:TableDescriptor>
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="2">
+    <dxl:Plan Id="0" SpaceSize="3">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="391.295563" Rows="1.000000" Width="8"/>
+          <dxl:Cost StartupCost="0" TotalCost="0.058531" Rows="284.444444" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -242,9 +265,9 @@
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:BitmapTableScan>
+        <dxl:IndexOnlyScan IndexScanDirection="Forward">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="391.295528" Rows="1.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="0.048640" Rows="284.444444" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -255,35 +278,34 @@
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
-          <dxl:RecheckCond>
-            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-              <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+          <dxl:IndexCondList>
+            <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
+              <dxl:Ident ColId="3" ColName="d" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="42"/>
             </dxl:Comparison>
-          </dxl:RecheckCond>
-          <dxl:BitmapIndexProbe>
-            <dxl:IndexCondList>
-              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
-              </dxl:Comparison>
-            </dxl:IndexCondList>
-            <dxl:IndexDescriptor Mdid="7.52423.1.0" IndexName="idx1"/>
-          </dxl:BitmapIndexProbe>
-          <dxl:TableDescriptor Mdid="6.52420.1.0" TableName="foo" LockMode="1">
+            <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+              <dxl:Ident ColId="4" ColName="e" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="52"/>
+            </dxl:Comparison>
+          </dxl:IndexCondList>
+          <dxl:Partitions/>
+          <dxl:IndexDescriptor Mdid="7.65569.1.0" IndexName="t_d_e_a_b_idx"/>
+          <dxl:TableDescriptor Mdid="6.65566.1.0" TableName="t" LockMode="1">
             <dxl:Columns>
               <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
               <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
-              <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-              <dxl:Column ColId="3" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-              <dxl:Column ColId="4" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-              <dxl:Column ColId="5" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-              <dxl:Column ColId="6" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-              <dxl:Column ColId="7" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-              <dxl:Column ColId="8" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="3" Attno="4" ColName="d" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="4" Attno="5" ColName="e" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="5" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="6" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="9" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="10" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="11" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
             </dxl:Columns>
           </dxl:TableDescriptor>
-        </dxl:BitmapTableScan>
+        </dxl:IndexOnlyScan>
       </dxl:GatherMotion>
     </dxl:Plan>
   </dxl:Thread>

--- a/src/backend/gporca/data/dxl/minidump/CoveringIndex-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CoveringIndex-2.mdp
@@ -1,0 +1,1113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Comment><![CDATA[
+    Objective: Choose Index-Only Scan when predicate includes mix of index keys
+    and "payload" keys. In following setup index keys are 'd' and 'e' whereas
+    payload keys are 'a' and 'b'
+
+      CREATE TABLE t(a int, b int, c int, d int, e int);
+      CREATE INDEX ON t(d, e) INCLUDE (a, b);
+      INSERT INTO t SELECT i, i, i, i, i FROM generate_series(1, 1000)i;
+      VACUUM t;
+
+      EXPLAIN SELECT a, b FROM t WHERE a>42 AND e>42;
+  ]]>
+  </dxl:Comment>
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="20" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0" SkewFactor="0"/>
+      <dxl:TraceFlags Value="102001,102002,102003,102043,102074,102120,102144,103001,103014,103022,103026,103027,103029,103033,103038,103040,104002,104003,104004,104005,105000,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:GPDBScalarOp Mdid="0.521.1.0" Name="&gt;" ComparisonType="GT" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.147.1.0"/>
+        <dxl:Commutator Mdid="0.97.1.0"/>
+        <dxl:InverseOp Mdid="0.523.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:RelationStatistics Mdid="2.65572.1.0" Name="t" Rows="1000.000000" RelPages="3" RelAllVisible="0" EmptyRelation="false"/>
+      <dxl:Relation Mdid="6.65572.1.0" Name="t" IsTemporary="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="11,5">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="d" Attno="4" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="e" Attno="5" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList>
+          <dxl:IndexInfo Mdid="7.65575.1.0" IsPartial="false"/>
+        </dxl:IndexInfoList>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2134.1.0"/>
+        <dxl:MaxAgg Mdid="0.2118.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.2227.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.3315.1.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Index Mdid="7.65575.1.0" Name="t_d_e_a_b_idx" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="3,4" IncludedColumns="0,1">
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:Index>
+      <dxl:ColumnStatistics Mdid="1.65572.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="10"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="10"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="20"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="20"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="30"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="30"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="40"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="40"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="50"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="50"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="60"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="60"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="70"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="70"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="80"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="80"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="90"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="90"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="100"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="100"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="110"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="110"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="120"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="120"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="130"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="130"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="140"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="140"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="150"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="150"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="160"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="160"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="170"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="170"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="180"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="180"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="190"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="190"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="200"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="200"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="210"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="210"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="220"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="220"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="230"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="230"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="240"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="240"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="250"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="250"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="260"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="260"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="270"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="270"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="280"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="280"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="290"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="290"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="300"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="300"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="310"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="310"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="320"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="320"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="330"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="330"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="340"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="340"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="350"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="350"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="360"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="360"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="370"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="370"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="380"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="380"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="390"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="390"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="400"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="400"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="410"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="410"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="420"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="420"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="430"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="430"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="440"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="440"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="450"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="450"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="460"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="460"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="470"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="470"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="480"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="480"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="490"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="490"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="500"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="500"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="510"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="510"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="520"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="520"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="530"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="530"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="540"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="540"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="550"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="550"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="560"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="560"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="570"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="570"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="580"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="580"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="590"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="590"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="600"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="600"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="610"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="610"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="620"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="620"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="630"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="630"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="640"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="640"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="650"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="650"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="660"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="660"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="670"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="670"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="680"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="680"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="690"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="690"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="700"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="700"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="710"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="710"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="720"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="720"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="730"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="730"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="740"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="740"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="750"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="750"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="760"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="760"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="770"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="770"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="780"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="780"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="790"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="790"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="800"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="800"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="810"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="810"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="820"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="820"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="830"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="830"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="840"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="840"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="850"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="850"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="860"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="860"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="870"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="870"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="880"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="880"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="890"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="890"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="900"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="900"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="910"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="910"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="920"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="920"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="930"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="930"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="940"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="940"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="950"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="950"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="960"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="960"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="970"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="970"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="980"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="980"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="990"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="990"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="1000"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:GPDBScalarOp Mdid="0.97.1.0" Name="&lt;" ComparisonType="LT" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.66.1.0"/>
+        <dxl:Commutator Mdid="0.521.1.0"/>
+        <dxl:InverseOp Mdid="0.525.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:ColumnStatistics Mdid="1.65572.1.0.4" Name="e" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="10"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="10"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="20"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="20"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="30"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="30"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="40"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="40"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="50"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="50"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="60"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="60"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="70"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="70"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="80"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="80"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="90"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="90"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="100"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="100"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="110"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="110"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="120"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="120"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="130"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="130"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="140"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="140"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="150"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="150"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="160"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="160"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="170"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="170"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="180"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="180"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="190"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="190"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="200"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="200"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="210"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="210"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="220"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="220"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="230"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="230"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="240"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="240"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="250"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="250"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="260"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="260"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="270"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="270"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="280"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="280"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="290"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="290"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="300"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="300"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="310"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="310"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="320"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="320"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="330"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="330"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="340"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="340"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="350"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="350"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="360"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="360"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="370"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="370"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="380"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="380"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="390"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="390"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="400"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="400"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="410"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="410"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="420"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="420"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="430"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="430"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="440"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="440"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="450"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="450"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="460"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="460"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="470"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="470"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="480"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="480"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="490"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="490"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="500"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="500"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="510"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="510"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="520"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="520"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="530"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="530"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="540"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="540"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="550"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="550"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="560"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="560"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="570"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="570"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="580"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="580"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="590"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="590"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="600"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="600"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="610"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="610"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="620"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="620"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="630"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="630"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="640"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="640"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="650"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="650"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="660"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="660"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="670"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="670"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="680"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="680"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="690"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="690"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="700"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="700"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="710"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="710"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="720"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="720"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="730"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="730"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="740"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="740"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="750"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="750"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="760"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="760"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="770"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="770"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="780"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="780"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="790"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="790"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="800"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="800"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="810"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="810"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="820"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="820"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="830"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="830"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="840"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="840"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="850"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="850"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="860"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="860"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="870"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="870"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="880"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="880"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="890"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="890"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="900"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="900"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="910"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="910"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="920"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="920"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="930"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="930"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="940"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="940"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="950"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="950"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="960"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="960"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="970"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="970"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="980"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="980"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="990"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.010000" DistinctValues="10.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="990"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="1000"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:RelationExtendedStatistics Mdid="10.65572.1.0" Name="t"/>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalSelect>
+        <dxl:And>
+          <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
+            <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+            <dxl:ConstValue TypeMdid="0.23.1.0" Value="42"/>
+          </dxl:Comparison>
+          <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
+            <dxl:Ident ColId="5" ColName="e" TypeMdid="0.23.1.0"/>
+            <dxl:ConstValue TypeMdid="0.23.1.0" Value="42"/>
+          </dxl:Comparison>
+        </dxl:And>
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="6.65572.1.0" TableName="t" LockMode="1">
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="3" Attno="3" ColName="c" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="4" Attno="4" ColName="d" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="5" Attno="5" ColName="e" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="7" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="9" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="10" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="11" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="12" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+      </dxl:LogicalSelect>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="3">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="6.207420" Rows="957.000000" Width="8"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="0" Alias="a">
+            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="1" Alias="b">
+            <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:SortingColumnList/>
+        <dxl:IndexScan IndexScanDirection="Forward">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="6.178889" Rows="957.000000" Width="8"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="0" Alias="a">
+              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="1" Alias="b">
+              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter>
+            <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
+              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="42"/>
+            </dxl:Comparison>
+          </dxl:Filter>
+          <dxl:IndexCondList>
+            <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
+              <dxl:Ident ColId="4" ColName="e" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="42"/>
+            </dxl:Comparison>
+          </dxl:IndexCondList>
+          <dxl:Partitions/>
+          <dxl:IndexDescriptor Mdid="7.65575.1.0" IndexName="t_d_e_a_b_idx"/>
+          <dxl:TableDescriptor Mdid="6.65572.1.0" TableName="t" LockMode="1">
+            <dxl:Columns>
+              <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="4" Attno="5" ColName="e" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="5" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="6" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="9" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="10" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="11" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:IndexScan>
+      </dxl:GatherMotion>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/CoveringIndex-3.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CoveringIndex-3.mdp
@@ -1,27 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
   <dxl:Comment><![CDATA[
-    Test case: Index only scan on table with index on non-distribution column
+    Objective: Do *not* choose Index-Only Scan when predicate contains only
+    "payload" keys, even if the project list contains index keys. In following
+    setup index keys are 'd' and 'e' whereas payload keys are 'a' and 'b'
 
-      CREATE TABLE table_with_index_not_covering_distribution_column(a int, b int) DISTRIBUTED BY (a);
-      CREATE INDEX ON table_with_index_not_covering_distribution_column(b);
+      CREATE TABLE t(a int, b int, c int, d int, e int);
+      CREATE INDEX ON t(d, e) INCLUDE (a, b);
+      INSERT INTO t SELECT i, i, i, i, i FROM generate_series(1, 1000)i;
+      VACUUM t;
 
-      INSERT INTO table_with_index_not_covering_distribution_column VALUES (10, 20);
-
-      SET enable_seqscan=off;
-      SET enable_bitmapscan=off;
-      SET optimizer_enable_tablescan=off;
-      SET optimizer_enable_indexscan=off;
-      SET optimizer_enable_indexonlyscan=on;
-      EXPLAIN VERBOSE SELECT b FROM table_with_index_not_covering_distribution_column WHERE b > 5;
-
-      Expect a plan with an index only scan
+      EXPLAIN SELECT d, e FROM t WHERE a>42;
   ]]>
   </dxl:Comment>
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
       <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
-      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.010000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
       <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
@@ -29,8 +24,8 @@
           <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
         </dxl:CostParams>
       </dxl:CostModelConfig>
-      <dxl:Hint JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10"/>
-      <dxl:TraceFlags Value="102004,102005,102074,102120,102146,103001,103014,103022,103027,103029,103038,104002,104003,104004,104005,105000,106000"/>
+      <dxl:Hint JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="20" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0" SkewFactor="0"/>
+      <dxl:TraceFlags Value="102001,102002,102003,102043,102074,102120,102144,103001,103014,103022,103026,103027,103029,103033,103038,103040,104002,104003,104004,104005,105000,106000"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
       <dxl:GPDBScalarOp Mdid="0.521.1.0" Name="&gt;" ComparisonType="GT" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
@@ -63,7 +58,12 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:RelationStatistics Mdid="2.73750.1.0" Name="table_with_index_not_covering_distribution_column" Rows="1.000000" EmptyRelation="false"/>
+      <dxl:Index Mdid="7.65580.1.0" Name="t_d_e_a_b_idx" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="3,4" IncludedColumns="0,1">
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:Index>
       <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
         <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
         <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
@@ -81,12 +81,22 @@
         <dxl:SumAgg Mdid="0.2108.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Relation Mdid="6.73750.1.0" Name="table_with_index_not_covering_distribution_column" IsTemporary="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2">
+      <dxl:RelationStatistics Mdid="2.65577.1.0" Name="t" Rows="1000.000000" RelPages="3" RelAllVisible="3" EmptyRelation="false"/>
+      <dxl:Relation Mdid="6.65577.1.0" Name="t" IsTemporary="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="11,5">
         <dxl:Columns>
           <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
             <dxl:DefaultValue/>
           </dxl:Column>
           <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="d" Attno="4" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="e" Attno="5" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
             <dxl:DefaultValue/>
           </dxl:Column>
           <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
@@ -112,7 +122,7 @@
           </dxl:Column>
         </dxl:Columns>
         <dxl:IndexInfoList>
-          <dxl:IndexInfo Mdid="0.73764.1.0" IsPartial="false"/>
+          <dxl:IndexInfo Mdid="7.65580.1.0" IsPartial="false"/>
         </dxl:IndexInfoList>
         <dxl:CheckConstraints/>
         <dxl:DistrOpfamilies>
@@ -130,8 +140,8 @@
         <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
         <dxl:ComparisonOp Mdid="0.356.1.0"/>
         <dxl:ArrayType Mdid="0.1028.1.0"/>
-        <dxl:MinAgg Mdid="0.2118.1.0"/>
-        <dxl:MaxAgg Mdid="0.2134.1.0"/>
+        <dxl:MinAgg Mdid="0.2134.1.0"/>
+        <dxl:MaxAgg Mdid="0.2118.1.0"/>
         <dxl:AvgAgg Mdid="0.0.0.0"/>
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
@@ -185,36 +195,35 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.73764.1.0" Name="table_with_index_not_covering_distribution_column_b_idx" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
-        <dxl:Opfamilies>
-          <dxl:Opfamily Mdid="0.1976.1.0"/>
-        </dxl:Opfamilies>
-      </dxl:Index>
-      <dxl:ColumnStatistics Mdid="1.73750.1.0.1" Name="b" Width="4.000000" NullFreq="0.000000" NdvRemain="1.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
-      <dxl:ColumnStatistics Mdid="1.73750.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="1.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
+      <dxl:ColumnStatistics Mdid="1.65577.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:RelationExtendedStatistics Mdid="10.65577.1.0" Name="t"/>
     </dxl:Metadata>
     <dxl:Query>
       <dxl:OutputColumns>
-        <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="4" ColName="d" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="5" ColName="e" TypeMdid="0.23.1.0"/>
       </dxl:OutputColumns>
       <dxl:CTEList/>
       <dxl:LogicalSelect>
         <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
-          <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
-          <dxl:ConstValue TypeMdid="0.23.1.0" Value="5"/>
+          <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+          <dxl:ConstValue TypeMdid="0.23.1.0" Value="42"/>
         </dxl:Comparison>
         <dxl:LogicalGet>
-          <dxl:TableDescriptor Mdid="6.73750.1.0" TableName="table_with_index_not_covering_distribution_column">
+          <dxl:TableDescriptor Mdid="6.65577.1.0" TableName="t" LockMode="1">
             <dxl:Columns>
               <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
               <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
-              <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-              <dxl:Column ColId="4" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-              <dxl:Column ColId="5" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-              <dxl:Column ColId="6" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-              <dxl:Column ColId="7" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-              <dxl:Column ColId="8" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-              <dxl:Column ColId="9" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="3" Attno="3" ColName="c" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="4" Attno="4" ColName="d" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="5" Attno="5" ColName="e" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="7" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="9" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="10" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="11" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="12" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
             </dxl:Columns>
           </dxl:TableDescriptor>
         </dxl:LogicalGet>
@@ -223,47 +232,51 @@
     <dxl:Plan Id="0" SpaceSize="1">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="6.000119" Rows="1.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.035035" Rows="400.000000" Width="8"/>
         </dxl:Properties>
         <dxl:ProjList>
-          <dxl:ProjElem ColId="1" Alias="b">
-            <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+          <dxl:ProjElem ColId="3" Alias="d">
+            <dxl:Ident ColId="3" ColName="d" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="4" Alias="e">
+            <dxl:Ident ColId="4" ColName="e" TypeMdid="0.23.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:IndexOnlyScan IndexScanDirection="Forward">
+        <dxl:TableScan>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="6.000101" Rows="1.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.023109" Rows="400.000000" Width="8"/>
           </dxl:Properties>
           <dxl:ProjList>
-            <dxl:ProjElem ColId="1" Alias="b">
-              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+            <dxl:ProjElem ColId="3" Alias="d">
+              <dxl:Ident ColId="3" ColName="d" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="4" Alias="e">
+              <dxl:Ident ColId="4" ColName="e" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
-          <dxl:Filter/>
-          <dxl:IndexCondList>
+          <dxl:Filter>
             <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
-              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-              <dxl:ConstValue TypeMdid="0.23.1.0" Value="5"/>
+              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="42"/>
             </dxl:Comparison>
-          </dxl:IndexCondList>
-	<dxl:Partitions/>
-          <dxl:IndexDescriptor Mdid="0.73764.1.0" IndexName="table_with_index_not_covering_distribution_column_b_idx"/>
-          <dxl:TableDescriptor Mdid="6.73750.1.0" TableName="table_with_index_not_covering_distribution_column">
+          </dxl:Filter>
+          <dxl:TableDescriptor Mdid="6.65577.1.0" TableName="t" LockMode="1">
             <dxl:Columns>
               <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-              <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
-              <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-              <dxl:Column ColId="3" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-              <dxl:Column ColId="4" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-              <dxl:Column ColId="5" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-              <dxl:Column ColId="6" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-              <dxl:Column ColId="7" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-              <dxl:Column ColId="8" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="3" Attno="4" ColName="d" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="4" Attno="5" ColName="e" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="5" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="6" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="9" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="10" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="11" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
             </dxl:Columns>
           </dxl:TableDescriptor>
-        </dxl:IndexOnlyScan>
+        </dxl:TableScan>
       </dxl:GatherMotion>
     </dxl:Plan>
   </dxl:Thread>

--- a/src/backend/gporca/data/dxl/minidump/DirectDispatch-DynamicIndexScan.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DirectDispatch-DynamicIndexScan.mdp
@@ -998,7 +998,7 @@ where a=1 and b>0;
       </dxl:Relation>
       <dxl:ColumnStatistics Mdid="1.21553.1.1.5" Name="cmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.21553.1.1.4" Name="xmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
-      <dxl:Index Mdid="0.2155640.1.0" Name="sc_part_idx_b_1_prt_extra" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.2155640.1.0" Name="sc_part_idx_b_1_prt_extra" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/DirectDispatch-IndexScan.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DirectDispatch-IndexScan.mdp
@@ -369,12 +369,12 @@ where a=1 and b=0;
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.1962926.1.0" Name="sc_idx_b" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.1962926.1.0" Name="sc_idx_b" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.1975983.1.0" Name="sc_idx_bc" IsClustered="false" IndexType="B-tree" KeyColumns="1,2" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.1975983.1.0" Name="sc_idx_bc" IsClustered="false" IndexType="B-tree" KeyColumns="1,2" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
           <dxl:Opfamily Mdid="0.1978.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/DoubleNDVCardinalityEquals.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DoubleNDVCardinalityEquals.mdp
@@ -134,7 +134,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.20.1.0" Value="5200000000000097561"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.213016.1.0" Name="idx_mytable_a" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3">
+      <dxl:Index Mdid="0.213016.1.0" Name="idx_mytable_a" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/DynamicBitmapBoolOp.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicBitmapBoolOp.mdp
@@ -19,7 +19,7 @@
       <dxl:TraceFlags Value="102001,102002,102003,102006,102024,102025,102144,103001,103027,103033"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:Index Mdid="0.672579.1.0" Name="p_b_1_prt_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="0.672579.1.0" Name="p_b_1_prt_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
@@ -139,7 +139,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.672348.1.0" Name="p_a_1_prt_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="0.672348.1.0" Name="p_a_1_prt_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
@@ -892,7 +892,7 @@
       </dxl:Relation>
       <dxl:ColumnStatistics Mdid="1.671910.1.1.5" Name="xmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.671910.1.1.4" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
-      <dxl:Index Mdid="0.672810.1.0" Name="p_c_1_prt_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="0.672810.1.0" Name="p_c_1_prt_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/DynamicBitmapIndexScan.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicBitmapIndexScan.mdp
@@ -622,7 +622,7 @@ see sql/DynamicBitmapIndexScan.sql
       </dxl:GPDBScalarOp>
       <dxl:ColumnStatistics Mdid="1.16959.1.1.1" Name="flex_value_id" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.16959.1.1.0" Name="flex_value_set_id" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:Index Mdid="0.17270.1.0" Name="inner_table_idx_1_prt_other" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6">
+      <dxl:Index Mdid="0.17270.1.0" Name="inner_table_idx_1_prt_other" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3032.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/DynamicBitmapTableScan-Basic.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicBitmapTableScan-Basic.mdp
@@ -714,7 +714,7 @@
       <dxl:ColumnStatistics Mdid="1.3723603.1.0.0" Name="x1" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.3723603.1.0.7" Name="cmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.3723603.1.0.6" Name="xmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:Index Mdid="0.3723795.1.0" Name="x2_ind_1_prt_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.3723795.1.0" Name="x2_ind_1_prt_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/DynamicBitmapTableScan-Heterogeneous.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicBitmapTableScan-Heterogeneous.mdp
@@ -116,7 +116,7 @@
       </dxl:Type>
       <dxl:ColumnStatistics Mdid="1.816512.1.1.3" Name="t" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.816512.1.1.2" Name="j" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
-      <dxl:Index Mdid="0.816754.1.0" Name="bm_test_idx_part" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="0.816754.1.0" Name="bm_test_idx_part" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/DynamicBitmapTableScan-UUID.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicBitmapTableScan-UUID.mdp
@@ -358,7 +358,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.2950.1.0" IsNull="false" Value="An6J9DnRTROsv3WhVjnmNQ==" LintValue="4123921962"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.20403.1.0" Name="i_1_prt_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3,4">
+      <dxl:Index Mdid="0.20403.1.0" Name="i_1_prt_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.2968.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexGet-OuterRefs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexGet-OuterRefs.mdp
@@ -7857,7 +7857,7 @@
           </dxl:And>
         </dxl:PartConstraint>
       </dxl:Relation>
-      <dxl:Index Mdid="0.33441.1.0" Name="web_sales_pkey" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="3,17,0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40">
+      <dxl:Index Mdid="0.33441.1.0" Name="web_sales_pkey" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="3,17,0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
@@ -13044,7 +13044,7 @@
           </dxl:And>
         </dxl:PartConstraint>
       </dxl:Relation>
-      <dxl:Index Mdid="0.33851.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0,6" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.33851.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0,6" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexGetDroppedCols.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexGetDroppedCols.mdp
@@ -1050,7 +1050,7 @@ EXPLAIN SELECT * FROM solo WHERE year_id=2017 AND month_id=6;
           <dxl:UpperBound Closed="true" TypeMdid="0.21.1.0" Value="12"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.29404.1.0" Name="solo_idx_1_prt_y2016_2_prt_jan" IsClustered="false" IndexType="B-tree" KeyColumns="1,2,7,17,22,29" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,20,21,22,28,29,30,31,32,33,34,35,36">
+      <dxl:Index Mdid="0.29404.1.0" Name="solo_idx_1_prt_y2016_2_prt_jan" IsClustered="false" IndexType="B-tree" KeyColumns="1,2,7,17,22,29" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-BoolFalse.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-BoolFalse.mdp
@@ -450,7 +450,7 @@
         <dxl:Commutator Mdid="0.523.1.0"/>
         <dxl:InverseOp Mdid="0.97.1.0"/>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.296845.1.0" Name="pp_c_1_prt_1" IsClustered="false" KeyColumns="2" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.296845.1.0" Name="pp_c_1_prt_1" IsClustered="false" KeyColumns="2" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-BoolTrue.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-BoolTrue.mdp
@@ -450,7 +450,7 @@
         <dxl:Commutator Mdid="0.523.1.0"/>
         <dxl:InverseOp Mdid="0.97.1.0"/>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.296845.1.0" Name="pp_c_1_prt_1" IsClustered="false" KeyColumns="2" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.296845.1.0" Name="pp_c_1_prt_1" IsClustered="false" KeyColumns="2" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-DefaultPartition-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-DefaultPartition-2.mdp
@@ -288,7 +288,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="1000"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.274813.1.0" Name="p_1_prt_3_ind_bc" IsClustered="false" KeyColumns="1,2" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.274813.1.0" Name="p_1_prt_3_ind_bc" IsClustered="false" KeyColumns="1,2" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
@@ -487,7 +487,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="50"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.267021.1.0" Name="p_def_ind_c" IsClustered="false" KeyColumns="2" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.267021.1.0" Name="p_def_ind_c" IsClustered="false" KeyColumns="2" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-DefaultPartition.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-DefaultPartition.mdp
@@ -168,7 +168,7 @@
       </dxl:GPDBScalarOp>
       <dxl:ColumnStatistics Mdid="1.274855.1.1.3" Name="ctid" Width="6.000000"/>
       <dxl:ColumnStatistics Mdid="1.274855.1.1.2" Name="c" Width="8.000000"/>
-      <dxl:Index Mdid="0.275094.1.0" Name="ppp_1_prt_extra_ind_c" IsClustered="false" KeyColumns="2" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.275094.1.0" Name="ppp_1_prt_extra_ind_c" IsClustered="false" KeyColumns="2" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-DroppedCols.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-DroppedCols.mdp
@@ -332,7 +332,7 @@
           </dxl:And>
         </dxl:PartConstraint>
       </dxl:Relation>
-      <dxl:Index Mdid="0.32962.1.0" Name="idx" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="3" IncludedColumns="1,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="0.32962.1.0" Name="idx" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="3" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-DroppedColumns.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-DroppedColumns.mdp
@@ -581,7 +581,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.567110.1.0" Name="testbug_char5_tag1_1_prt_part201203" IsClustered="false" KeyColumns="3" IncludedColumns="0,1,3,4,5,6,7,8,9,10,11">
+      <dxl:Index Mdid="0.567110.1.0" Name="testbug_char5_tag1_1_prt_part201203" IsClustered="false" KeyColumns="3" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.426.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-EnabledDateConstraint.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-EnabledDateConstraint.mdp
@@ -187,7 +187,7 @@
       <dxl:GPDBFunc Mdid="0.6083.1.0" Name="gp_partition_propagation" ReturnsSet="false" Stability="Volatile" IsStrict="true">
         <dxl:ResultType Mdid="0.2278.1.0"/>
       </dxl:GPDBFunc>
-      <dxl:Index Mdid="0.318973.1.0" Name="test_orders_2_1_prt_orders_1_ind" IsClustered="false" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.318973.1.0" Name="test_orders_2_1_prt_orders_1_ind" IsClustered="false" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.434.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-NoDTS.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-NoDTS.mdp
@@ -87,7 +87,7 @@
       </dxl:Type>
       <dxl:ColumnStatistics Mdid="1.27119.15.1.3" Name="1.27119.15.1.3" Width="8.000000"/>
       <dxl:ColumnStatistics Mdid="1.27119.15.1.2" Name="1.27119.15.1.2" Width="8.000000"/>
-      <dxl:Index Mdid="0.2732323.15.0" Name="p2_ind" IsClustered="false" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.2732323.15.0" Name="p2_ind" IsClustered="false" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
@@ -182,7 +182,7 @@
       <dxl:ColumnStatistics Mdid="1.27119.15.1.8" Name="1.27119.15.1.8" Width="8.000000"/>
       <dxl:ColumnStatistics Mdid="1.27119.15.1.0" Name="1.27119.15.1.0" Width="8.000000"/>
       <dxl:ColumnStatistics Mdid="1.27119.15.1.1" Name="1.27119.15.1.1" Width="8.000000"/>
-      <dxl:Index Mdid="0.27323.15.1" Name="p_ind" IsClustered="false" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.27323.15.1" Name="p_ind" IsClustered="false" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-Overlapping.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-Overlapping.mdp
@@ -85,7 +85,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.2732323.25.0" Name="p2_ind" IsClustered="false" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.2732323.25.0" Name="p2_ind" IsClustered="false" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
@@ -100,7 +100,7 @@
       <dxl:ColumnStatistics Mdid="1.27119.25.1.8" Name="1.27119.25.1.8" Width="8.000000"/>
       <dxl:ColumnStatistics Mdid="1.27119.25.1.0" Name="1.27119.25.1.0" Width="8.000000"/>
       <dxl:ColumnStatistics Mdid="1.27119.25.1.1" Name="1.27119.25.1.1" Width="8.000000"/>
-      <dxl:Index Mdid="0.27323.25.0" Name="p_ind" IsClustered="false" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.27323.25.0" Name="p_ind" IsClustered="false" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-PartSelectEquality.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-PartSelectEquality.mdp
@@ -87,7 +87,7 @@
       <dxl:GPDBFunc Mdid="0.6086.1.0" Name="gp_partition_inverse" ReturnsSet="true" Stability="Stable" IsStrict="true">
         <dxl:ResultType Mdid="0.2249.1.0"/>
       </dxl:GPDBFunc>
-      <dxl:Index Mdid="0.303004.1.0" Name="p_1_a" IsClustered="false" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.303004.1.0" Name="p_1_a" IsClustered="false" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-PartSelectRange.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-PartSelectRange.mdp
@@ -87,7 +87,7 @@
       <dxl:GPDBFunc Mdid="0.6086.1.0" Name="gp_partition_inverse" ReturnsSet="true" Stability="Stable" IsStrict="true">
         <dxl:ResultType Mdid="0.2249.1.0"/>
       </dxl:GPDBFunc>
-      <dxl:Index Mdid="0.303004.1.0" Name="p_1_a" IsClustered="false" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.303004.1.0" Name="p_1_a" IsClustered="false" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-Union.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-Union.mdp
@@ -627,7 +627,7 @@
       </dxl:Relation>
       <dxl:ColumnStatistics Mdid="1.3723124.1.0.3" Name="xmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.3723124.1.0.2" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:Index Mdid="0.3723283.1.0" Name="p_ind" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.3723283.1.0" Name="p_ind" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-UnsupportedConstraint.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-UnsupportedConstraint.mdp
@@ -163,7 +163,7 @@
       <dxl:GPDBFunc Mdid="0.6083.1.0" Name="gp_partition_propagation" ReturnsSet="false" Stability="Volatile" IsStrict="true">
         <dxl:ResultType Mdid="0.2278.1.0"/>
       </dxl:GPDBFunc>
-      <dxl:Index Mdid="0.318973.1.0" Name="test_orders_2_1_prt_orders_1_ind" IsClustered="false" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.318973.1.0" Name="test_orders_2_1_prt_orders_1_ind" IsClustered="false" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-UnsupportedPredicate.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous-UnsupportedPredicate.mdp
@@ -36,7 +36,7 @@
       </dxl:GPDBScalarOp>
       <dxl:ColumnStatistics Mdid="1.1637610.1.1.7" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.1637610.1.1.6" Name="c7" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
-      <dxl:Index Mdid="0.1637960.1.0" Name="idx_heapaoco_list_part_c1_int_1_prt_p1" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13">
+      <dxl:Index Mdid="0.1637960.1.0" Name="idx_heapaoco_list_part_c1_int_1_prt_p1" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>
@@ -170,7 +170,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.1637979.1.0" Name="idx_heapaoco_list_part_c1_int_1_prt_p2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13">
+      <dxl:Index Mdid="0.1637979.1.0" Name="idx_heapaoco_list_part_c1_int_1_prt_p2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Heterogenous.mdp
@@ -87,7 +87,7 @@
       </dxl:Type>
       <dxl:ColumnStatistics Mdid="1.27119.1.1.5" Name="xmax" Width="4.000000"/>
       <dxl:ColumnStatistics Mdid="1.27119.1.1.4" Name="cmin" Width="4.000000"/>
-      <dxl:Index Mdid="0.27323.1.0" Name="p_ind" IsClustered="false" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.27323.1.0" Name="p_ind" IsClustered="false" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
@@ -99,7 +99,7 @@
           <dxl:Partition Mdid="6.27323005.1.0"/>
         </dxl:Partitions>
       </dxl:Index>
-      <dxl:Index Mdid="0.2732323.1.0" Name="p2_ind" IsClustered="false" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.2732323.1.0" Name="p2_ind" IsClustered="false" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Homogenous-EnabledDateConstraint.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Homogenous-EnabledDateConstraint.mdp
@@ -137,7 +137,7 @@
       </dxl:Type>
       <dxl:ColumnStatistics Mdid="1.310650.1.1.7" Name="cmax" Width="4.000000"/>
       <dxl:ColumnStatistics Mdid="1.310650.1.1.6" Name="xmax" Width="4.000000"/>
-      <dxl:Index Mdid="0.310765.1.0" Name="ord_ind_1_prt_orders_1" IsClustered="false" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.310765.1.0" Name="ord_ind_1_prt_orders_1" IsClustered="false" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.434.1.0"/>
         </dxl:Opfamilies>
@@ -196,7 +196,7 @@
       <dxl:GPDBFunc Mdid="0.6083.1.0" Name="gp_partition_propagation" ReturnsSet="false" Stability="Volatile" IsStrict="true">
         <dxl:ResultType Mdid="0.2278.1.0"/>
       </dxl:GPDBFunc>
-      <dxl:Index Mdid="0.318839.1.0" Name="ord_1_ind_1_prt_orders_1" IsClustered="false" KeyColumns="1,2" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.318839.1.0" Name="ord_1_ind_1_prt_orders_1" IsClustered="false" KeyColumns="1,2" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.434.1.0"/>
           <dxl:Opfamily Mdid="0.3027.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Homogenous-UnsupportedConstraint.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Homogenous-UnsupportedConstraint.mdp
@@ -100,7 +100,7 @@
       </dxl:Type>
       <dxl:ColumnStatistics Mdid="1.310650.1.1.7" Name="cmax" Width="4.000000"/>
       <dxl:ColumnStatistics Mdid="1.310650.1.1.6" Name="xmax" Width="4.000000"/>
-      <dxl:Index Mdid="0.310765.1.0" Name="ord_ind_1_prt_orders_1" IsClustered="false" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.310765.1.0" Name="ord_ind_1_prt_orders_1" IsClustered="false" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.434.1.0"/>
         </dxl:Opfamilies>
@@ -180,7 +180,7 @@
       <dxl:GPDBFunc Mdid="0.6083.1.0" Name="gp_partition_propagation" ReturnsSet="false" Stability="Volatile" IsStrict="true">
         <dxl:ResultType Mdid="0.2278.1.0"/>
       </dxl:GPDBFunc>
-      <dxl:Index Mdid="0.318839.1.0" Name="ord_1_ind_1_prt_orders_1" IsClustered="false" KeyColumns="1,2" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.318839.1.0" Name="ord_1_ind_1_prt_orders_1" IsClustered="false" KeyColumns="1,2" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.434.1.0"/>
           <dxl:Opfamily Mdid="0.3027.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Homogenous.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Homogenous.mdp
@@ -127,7 +127,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.3722984.1.0" Name="p_ind_1_prt_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.3722984.1.0" Name="p_ind_1_prt_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-OpenEndedPartitions.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-OpenEndedPartitions.mdp
@@ -387,7 +387,7 @@
         <dxl:Commutator Mdid="0.521.1.0"/>
         <dxl:InverseOp Mdid="0.525.1.0"/>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.1122360.1.0" Name="t2_pfirst_ind" IsClustered="false" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.1122360.1.0" Name="t2_pfirst_ind" IsClustered="false" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Relabel.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DynamicIndexScan-Relabel.mdp
@@ -1146,7 +1146,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" Value="AAAABzk3Mw==" LintValue="921330540"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.607634.1.0" Name="p_idx_1_prt_1" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.607634.1.0" Name="p_idx_1_prt_1" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.2003.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/ExtractOneBindingFromScalarGroups.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ExtractOneBindingFromScalarGroups.mdp
@@ -132,7 +132,7 @@
         <dxl:IndexInfoList/>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.32783.1.0" Name="t3idx" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.32783.1.0" Name="t3idx" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/FullJoin-Subquery-CastedPredicates.mdp
+++ b/src/backend/gporca/data/dxl/minidump/FullJoin-Subquery-CastedPredicates.mdp
@@ -54,7 +54,7 @@
       <dxl:TraceFlags Value="102074,102120,102146,103001,103014,103015,103022,103027,103029,104003,104004,104005,105000,106000"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:Index Mdid="0.32772.1.0" Name="t2_d" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.32772.1.0" Name="t2_d" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
@@ -163,7 +163,7 @@
         <dxl:IndexInfoList/>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.16391.1.0" Name="bar_idx_d" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.16391.1.0" Name="bar_idx_d" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/Gb-on-keys.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Gb-on-keys.mdp
@@ -56,7 +56,7 @@
       </dxl:Type>
       <dxl:ColumnStatistics Mdid="1.1154027.1.1.5" Name="cmin" Width="4.000000"/>
       <dxl:ColumnStatistics Mdid="1.1154027.1.1.4" Name="xmin" Width="4.000000"/>
-      <dxl:Index Mdid="0.1154050.1.0" Name="keys_pkey" IsClustered="false" KeyColumns="0,1" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.1154050.1.0" Name="keys_pkey" IsClustered="false" KeyColumns="0,1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/GinIndex.mdp
+++ b/src/backend/gporca/data/dxl/minidump/GinIndex.mdp
@@ -171,7 +171,7 @@
         </dxl:IndexInfoList>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.20130.1.0" Name="jidx" IsClustered="false" IndexType="Gin" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7">
+      <dxl:Index Mdid="0.20130.1.0" Name="jidx" IsClustered="false" IndexType="Gin" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.4036.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/GinIndexPathOpfamily.mdp
+++ b/src/backend/gporca/data/dxl/minidump/GinIndexPathOpfamily.mdp
@@ -171,7 +171,7 @@
         </dxl:IndexInfoList>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.20131.1.0" Name="jidx" IsClustered="false" IndexType="Gin" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7">
+      <dxl:Index Mdid="0.20131.1.0" Name="jidx" IsClustered="false" IndexType="Gin" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.4037.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/GinIndexSearchModeAll.mdp
+++ b/src/backend/gporca/data/dxl/minidump/GinIndexSearchModeAll.mdp
@@ -171,7 +171,7 @@
         </dxl:IndexInfoList>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.20131.1.0" Name="jidx" IsClustered="false" IndexType="Gin" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7">
+      <dxl:Index Mdid="0.20131.1.0" Name="jidx" IsClustered="false" IndexType="Gin" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.4037.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/Gist-AOCOTable-NonLossy-BitmapIndexPlan.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Gist-AOCOTable-NonLossy-BitmapIndexPlan.mdp
@@ -167,7 +167,7 @@ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..0.00 rows=1 width=4)
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.566300.1.0" Name="boxindex" IsClustered="false" IndexType="Gist" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6">
+      <dxl:Index Mdid="0.566300.1.0" Name="boxindex" IsClustered="false" IndexType="Gist" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.2593.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/Gist-NestedLoopJoin-Lossy-IndexPlan.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Gist-NestedLoopJoin-Lossy-IndexPlan.mdp
@@ -95,7 +95,7 @@
         </dxl:IndexInfoList>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.16406.1.0" Name="poly_index" IsClustered="false" IndexType="Gist" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.16406.1.0" Name="poly_index" IsClustered="false" IndexType="Gist" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.2594.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/Gist-NestedLoopJoin-Postgis-IndexPlan.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Gist-NestedLoopJoin-Postgis-IndexPlan.mdp
@@ -159,7 +159,7 @@ Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..433.00 rows=1 width=24)
       <dxl:GPDBFunc Mdid="0.566917.1.0" Name="_st_contains" ReturnsSet="false" Stability="Immutable" IsStrict="true">
         <dxl:ResultType Mdid="0.16.1.0"/>
       </dxl:GPDBFunc>
-      <dxl:Index Mdid="0.581647.1.0" Name="multi" IsClustered="false" IndexType="Gist" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.581647.1.0" Name="multi" IsClustered="false" IndexType="Gist" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.566580.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/Gist-NonPart-Lossy-BitmapIndexPlan.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Gist-NonPart-Lossy-BitmapIndexPlan.mdp
@@ -166,7 +166,7 @@ Optimizer status: PQO version 2.65.1
         </dxl:IndexInfoList>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.566276.1.0" Name="gist_tbl_point_index" IsClustered="false" IndexType="Gist" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.566276.1.0" Name="gist_tbl_point_index" IsClustered="false" IndexType="Gist" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.2594.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/Gist-NonPart-Lossy-IndexPlan.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Gist-NonPart-Lossy-IndexPlan.mdp
@@ -166,7 +166,7 @@ Optimizer status: PQO version 2.65.1
         </dxl:IndexInfoList>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.573703.1.0" Name="gist_tbl_point_index" IsClustered="false" IndexType="Gist" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.573703.1.0" Name="gist_tbl_point_index" IsClustered="false" IndexType="Gist" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.2594.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/Gist-OrderBy-BitmapPlan.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Gist-OrderBy-BitmapPlan.mdp
@@ -251,7 +251,7 @@ Result  (cost=0.00..0.00 rows=1 width=36)
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.573475.1.0" Name="poly" IsClustered="false" IndexType="Gist" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.573475.1.0" Name="poly" IsClustered="false" IndexType="Gist" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.2594.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/Gist-OrderBy-IndexPlan.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Gist-OrderBy-IndexPlan.mdp
@@ -289,7 +289,7 @@ Result  (cost=0.00..8.00 rows=2 width=36)
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.573475.1.0" Name="poly" IsClustered="false" IndexType="Gist" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.573475.1.0" Name="poly" IsClustered="false" IndexType="Gist" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.2594.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/Gist-PartTable-Lossy-IndexPlan.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Gist-PartTable-Lossy-IndexPlan.mdp
@@ -86,7 +86,7 @@ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..6.00 rows=1 width=4)
         <dxl:SumAgg Mdid="0.2108.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.574046.1.0" Name="partpolyindex_1_prt_1" IsClustered="false" IndexType="Gist" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="0.574046.1.0" Name="partpolyindex_1_prt_1" IsClustered="false" IndexType="Gist" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.2594.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/Gist-PartTable-NonLossy-BitmapIndexPlan.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Gist-PartTable-NonLossy-BitmapIndexPlan.mdp
@@ -53,7 +53,7 @@ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..0.00 rows=1 width=4)
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.566356.1.0" Name="partboxindex_1_prt_1" IsClustered="false" IndexType="Gist" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="0.566356.1.0" Name="partboxindex_1_prt_1" IsClustered="false" IndexType="Gist" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.2593.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/Gist-PartialIndex-TableScan.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Gist-PartialIndex-TableScan.mdp
@@ -326,7 +326,7 @@ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=44)
       </dxl:GPDBScalarOp>
       <dxl:ColumnStatistics Mdid="1.573531.1.0.1" Name="b" Width="32.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.573531.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:Index Mdid="0.573613.1.0" Name="partialboxindex" IsClustered="false" IndexType="Gist" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5">
+      <dxl:Index Mdid="0.573613.1.0" Name="partialboxindex" IsClustered="false" IndexType="Gist" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.2593.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/GroupingOnSameTblCol-1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/GroupingOnSameTblCol-1.mdp
@@ -3361,7 +3361,7 @@ group  by item.i_item_id, item.i_item_desc, item.i_current_price;
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="18000"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.672881.1.0" Name="item_pkey" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28">
+      <dxl:Index Mdid="0.672881.1.0" Name="item_pkey" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>
@@ -7919,7 +7919,7 @@ group  by item.i_item_id, item.i_item_desc, item.i_current_price;
           <dxl:Opfamily Mdid="0.3032.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.673571.1.0" Name="store_sales_pkey" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="2,9" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29">
+      <dxl:Index Mdid="0.673571.1.0" Name="store_sales_pkey" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="2,9" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
           <dxl:Opfamily Mdid="0.1978.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/HJN-DPE-Bitmap-Outer-Child.mdp
+++ b/src/backend/gporca/data/dxl/minidump/HJN-DPE-Bitmap-Outer-Child.mdp
@@ -1504,7 +1504,7 @@ select * from dbs_target, dbs_helper where dbs_target.c1 = dbs_helper.c1 and dbs
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.42822830.1.0" Name="dbs_index1_1_prt_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.42822830.1.0" Name="dbs_index1_1_prt_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/Hash-IndexScan.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Hash-IndexScan.mdp
@@ -190,7 +190,7 @@
           <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
         </dxl:DistrOpfamilies>
       </dxl:Relation>
-      <dxl:Index Mdid="7.52423.1.0" Name="idx1" IsClustered="false" IndexType="Hash" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="7.52423.1.0" Name="idx1" IsClustered="false" IndexType="Hash" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1977.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/InEqualityJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/InEqualityJoin.mdp
@@ -2354,7 +2354,7 @@
         <dxl:SumAgg Mdid="0.2114.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.26529.1.0" Name="web_sales_pkey" IsClustered="false" KeyColumns="3,17" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40">
+      <dxl:Index Mdid="0.26529.1.0" Name="web_sales_pkey" IsClustered="false" KeyColumns="3,17" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/Index-Join-With-Subquery-In-Pred.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Index-Join-With-Subquery-In-Pred.mdp
@@ -250,7 +250,7 @@ Optimizer: Pivotal Optimizer (GPORCA)
           <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
         </dxl:DistrOpfamilies>
       </dxl:Relation>
-      <dxl:Index Mdid="0.6639069.1.0" Name="myidx" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.6639069.1.0" Name="myidx" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-Heterogeneous-BothSidesPartitioned.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-Heterogeneous-BothSidesPartitioned.mdp
@@ -173,7 +173,7 @@ select * from x, y where (x.i > y.j);
       <dxl:ColumnStatistics Mdid="1.54648535.1.1.2" Name="k" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.54648430.1.1.7" Name="xmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.54648430.1.1.6" Name="cmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
-      <dxl:Index Mdid="0.54648640.1.0" Name="x_idx_2" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="0.54648640.1.0" Name="x_idx_2" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>
@@ -507,7 +507,7 @@ select * from x, y where (x.i > y.j);
           </dxl:And>
         </dxl:PartConstraint>
       </dxl:Relation>
-      <dxl:Index Mdid="0.54648659.1.0" Name="y_idx_2" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="0.54648659.1.0" Name="y_idx_2" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-Heterogeneous-DTS.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-Heterogeneous-DTS.mdp
@@ -718,7 +718,7 @@ WHERE tt.event_ts &gt;= tq.ets AND
       </dxl:Relation>
       <dxl:ColumnStatistics Mdid="1.16033549.1.1.7" Name="xmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.16033549.1.1.6" Name="cmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
-      <dxl:Index Mdid="0.16033719.1.0" Name="my_tq_agg_small_part_ets_end_ts_ix_1" IsClustered="false" IndexType="B-tree" KeyColumns="0,4" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11">
+      <dxl:Index Mdid="0.16033719.1.0" Name="my_tq_agg_small_part_ets_end_ts_ix_1" IsClustered="false" IndexType="B-tree" KeyColumns="0,4" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
@@ -744,7 +744,7 @@ WHERE tt.event_ts &gt;= tq.ets AND
       <dxl:GPDBFunc Mdid="0.6086.1.0" Name="gp_partition_inverse" ReturnsSet="true" Stability="Stable" IsStrict="true">
         <dxl:ResultType Mdid="0.2249.1.0"/>
       </dxl:GPDBFunc>
-      <dxl:Index Mdid="0.16033738.1.0" Name="my_tq_agg_small_part_ets_end_ts_ix_2" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11">
+      <dxl:Index Mdid="0.16033738.1.0" Name="my_tq_agg_small_part_ets_end_ts_ix_2" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-Heterogeneous-NoDTS.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-Heterogeneous-NoDTS.mdp
@@ -270,7 +270,7 @@ ORDER BY 1 asc ;
         <dxl:IndexInfoList/>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.16032679.1.0" Name="my_tq_agg_small_part_ets_end_ts_ix_1" IsClustered="false" IndexType="B-tree" KeyColumns="0,4" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11">
+      <dxl:Index Mdid="0.16032679.1.0" Name="my_tq_agg_small_part_ets_end_ts_ix_1" IsClustered="false" IndexType="B-tree" KeyColumns="0,4" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
@@ -626,7 +626,7 @@ ORDER BY 1 asc ;
           </dxl:And>
         </dxl:PartConstraint>
       </dxl:Relation>
-      <dxl:Index Mdid="0.16032698.1.0" Name="my_tq_agg_small_part_ets_end_ts_ix_3" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11">
+      <dxl:Index Mdid="0.16032698.1.0" Name="my_tq_agg_small_part_ets_end_ts_ix_3" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-IndexCondDisjointWithHashedDistr.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-IndexCondDisjointWithHashedDistr.mdp
@@ -69,7 +69,7 @@
       </dxl:Type>
       <dxl:ColumnStatistics Mdid="1.3373352.1.1.5" Name="xmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.3373352.1.1.4" Name="cmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
-      <dxl:Index Mdid="0.9393884.1.0" Name="index_r1j" IsClustered="false" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.9393884.1.0" Name="index_r1j" IsClustered="false" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-IndexCondIntersectWithHashedDistr.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-IndexCondIntersectWithHashedDistr.mdp
@@ -69,7 +69,7 @@
       </dxl:Type>
       <dxl:ColumnStatistics Mdid="1.3373352.1.1.5" Name="xmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.3373352.1.1.4" Name="cmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
-      <dxl:Index Mdid="0.9393884.1.0" Name="index_r1j" IsClustered="false" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.9393884.1.0" Name="index_r1j" IsClustered="false" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-IndexCondMatchHashedDistr.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-IndexCondMatchHashedDistr.mdp
@@ -230,7 +230,7 @@
       <dxl:ColumnStatistics Mdid="1.3373352.1.1.7" Name="tableoid" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.3373352.1.1.6" Name="cmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:MDCast Mdid="3.23.1.0;23.1.0" Name="int4" BinaryCoercible="true" SourceTypeId="0.23.1.0" DestinationTypeId="0.23.1.0" CastFuncId="0.0.0.0"/>
-      <dxl:Index Mdid="0.9385692.1.0" Name="index_ri" IsClustered="false" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.9385692.1.0" Name="index_ri" IsClustered="false" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-IndexCondSubsetOfHashedDistr.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-IndexCondSubsetOfHashedDistr.mdp
@@ -69,7 +69,7 @@
       </dxl:Type>
       <dxl:ColumnStatistics Mdid="1.3373352.1.1.5" Name="xmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.3373352.1.1.4" Name="cmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
-      <dxl:Index Mdid="0.9393884.1.0" Name="index_r1j" IsClustered="false" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.9393884.1.0" Name="index_r1j" IsClustered="false" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-IndexCondSupersetOfHashedDistr.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-IndexCondSupersetOfHashedDistr.mdp
@@ -238,7 +238,7 @@
       <dxl:ColumnStatistics Mdid="1.3373352.1.1.7" Name="tableoid" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.3373352.1.1.6" Name="cmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:MDCast Mdid="3.23.1.0;23.1.0" Name="int4" BinaryCoercible="true" SourceTypeId="0.23.1.0" DestinationTypeId="0.23.1.0" CastFuncId="0.0.0.0"/>
-      <dxl:Index Mdid="0.9385692.1.0" Name="index_ri" IsClustered="false" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.9385692.1.0" Name="index_ri" IsClustered="false" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-IndexOnCoordinatorOnlyTable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-IndexOnCoordinatorOnlyTable.mdp
@@ -482,7 +482,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.2662.1.0" Name="pg_class_oid_index" IsClustered="false" KeyColumns="31" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37">
+      <dxl:Index Mdid="0.2662.1.0" Name="pg_class_oid_index" IsClustered="false" KeyColumns="31" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1989.1.0"/>
         </dxl:Opfamilies>
@@ -966,7 +966,7 @@
         </dxl:IndexInfoList>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.2663.1.0" Name="pg_class_relname_nsp_index" IsClustered="false" KeyColumns="0,1" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37">
+      <dxl:Index Mdid="0.2663.1.0" Name="pg_class_relname_nsp_index" IsClustered="false" KeyColumns="0,1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1086.1.0"/>
           <dxl:Opfamily Mdid="0.1089.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-InnerSelect-Basic.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-InnerSelect-Basic.mdp
@@ -364,7 +364,7 @@ explain SELECT * FROM s i1, t t2 where t2.c2 = i1.c2 and t2.c1 > 10;
           <dxl:Opfamily Mdid="0.3040.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.32518895.1.0" Name="idx_t_2" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13">
+      <dxl:Index Mdid="0.32518895.1.0" Name="idx_t_2" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1994.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-InnerSelect-Heterogeneous-DTS.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-InnerSelect-Heterogeneous-DTS.mdp
@@ -689,7 +689,7 @@ WHERE tt.event_ts >= tq.ets AND
       </dxl:Type>
       <dxl:ColumnStatistics Mdid="1.32989821.1.1.5" Name="xmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.32989821.1.1.4" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
-      <dxl:Index Mdid="0.32989991.1.0" Name="my_tq_agg_small_part_ets_end_ts_ix_1" IsClustered="false" IndexType="B-tree" KeyColumns="0,4" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11">
+      <dxl:Index Mdid="0.32989991.1.0" Name="my_tq_agg_small_part_ets_end_ts_ix_1" IsClustered="false" IndexType="B-tree" KeyColumns="0,4" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
@@ -709,7 +709,7 @@ WHERE tt.event_ts >= tq.ets AND
       <dxl:ColumnStatistics Mdid="1.32989847.1.1.10" Name="tableoid" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.32989847.1.1.3" Name="ask_price" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.32989847.1.1.2" Name="bid_price" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000"/>
-      <dxl:Index Mdid="0.32990010.1.0" Name="my_tq_agg_small_part_ets_end_ts_ix_2" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11">
+      <dxl:Index Mdid="0.32990010.1.0" Name="my_tq_agg_small_part_ets_end_ts_ix_2" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-InnerSelect-PartTable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-InnerSelect-PartTable.mdp
@@ -680,7 +680,7 @@ SELECT * FROM s i1, t t2 where t2.c2 = i1.c2 and t2.c1 > 10;
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.32553517.1.0" Name="idx_t_2_1_prt_p1" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13">
+      <dxl:Index Mdid="0.32553517.1.0" Name="idx_t_2_1_prt_p1" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1994.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-InnerSelect-PartTable2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-InnerSelect-PartTable2.mdp
@@ -351,7 +351,7 @@ select * from bar, (select * from foo where foo.a in (select h.a from bar h, bar
       </dxl:Relation>
       <dxl:ColumnStatistics Mdid="1.57376.1.0.1" Name="b" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.57376.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:Index Mdid="0.57404.1.0" Name="idx_1_prt_1" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.57404.1.0" Name="idx_1_prt_1" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-LeftOuter-NLJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-LeftOuter-NLJoin.mdp
@@ -68,7 +68,7 @@ explain select * from t0 left join t1 on t0.a=t1.a left join t2 on (t2.a=t0.a an
       <dxl:TraceFlags Value="101013,102001,102002,102003,103045,102046,102048,102053,102054,102120,102144,103001,103014,103015,103022,103027,103033,104003,104004,104005,105000"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:Index Mdid="0.195590.1.0" Name="t1_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.195590.1.0" Name="t1_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
@@ -122,7 +122,7 @@ explain select * from t0 left join t1 on t0.a=t1.a left join t2 on (t2.a=t0.a an
         </dxl:IndexInfoList>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.195606.1.0" Name="t2_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.195606.1.0" Name="t2_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
@@ -241,7 +241,7 @@ explain select * from t0 left join t1 on t0.a=t1.a left join t2 on (t2.a=t0.a an
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.195652.1.0" Name="idx_t4_a" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3,4">
+      <dxl:Index Mdid="0.195652.1.0" Name="idx_t4_a" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
@@ -332,7 +332,7 @@ explain select * from t0 left join t1 on t0.a=t1.a left join t2 on (t2.a=t0.a an
           <dxl:Opfamily Mdid="0.7027.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.195690.1.0" Name="idx_t3_a" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3,4">
+      <dxl:Index Mdid="0.195690.1.0" Name="idx_t3_a" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-MultiDistKey-WithComplexPreds.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-MultiDistKey-WithComplexPreds.mdp
@@ -68,7 +68,7 @@
         <dxl:IndexInfoList/>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.16391.1.0" Name="bar_idx_d" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.16391.1.0" Name="bar_idx_d" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-MultiDistKeys-Bitmap-WithComplexPreds.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-MultiDistKeys-Bitmap-WithComplexPreds.mdp
@@ -53,7 +53,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.101654.1.0" Name="idx_bar_d" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.101654.1.0" Name="idx_bar_d" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.7027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-MultiDistKeys-Bitmap.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-MultiDistKeys-Bitmap.mdp
@@ -52,7 +52,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.101654.1.0" Name="idx_bar_d" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.101654.1.0" Name="idx_bar_d" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.7027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-MultiDistKeys-IncompletePDS-3-DistCols.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-MultiDistKeys-IncompletePDS-3-DistCols.mdp
@@ -250,7 +250,7 @@
           <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
         </dxl:DistrOpfamilies>
       </dxl:Relation>
-      <dxl:Index Mdid="0.409651.1.0" Name="bar_ixb" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11">
+      <dxl:Index Mdid="0.409651.1.0" Name="bar_ixb" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-No-Motion-Below-Join.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-No-Motion-Below-Join.mdp
@@ -311,7 +311,7 @@ Table X (int i, int j) is distributed by i, column j has index
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="2"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.17159874.1.0" Name="idx_x_j" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.17159874.1.0" Name="idx_x_j" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>
@@ -343,7 +343,7 @@ Table X (int i, int j) is distributed by i, column j has index
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.17159920.1.0" Name="idx_x_i" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.17159920.1.0" Name="idx_x_i" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-PartKey-Is-IndexKey.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-PartKey-Is-IndexKey.mdp
@@ -61,7 +61,7 @@ select z_p.j from z_p,tt_p where  z_p.i=6 and z_p.i<tt_p.i;
       </dxl:GPDBScalarOp>
       <dxl:ColumnStatistics Mdid="1.41880825.1.1.7" Name="tableoid" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.41880825.1.1.6" Name="cmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:Index Mdid="0.41881168.1.0" Name="idx_z_p_j_1_prt_z_p1" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.41881168.1.0" Name="idx_z_p_j_1_prt_z_p1" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>
@@ -168,7 +168,7 @@ select z_p.j from z_p,tt_p where  z_p.i=6 and z_p.i<tt_p.i;
       <dxl:ColumnStatistics Mdid="1.41880987.1.1.4" Name="xmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.41880825.1.1.5" Name="xmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.41880825.1.1.4" Name="cmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:Index Mdid="0.41880949.1.0" Name="idx_tt_p_i_1_prt_tt_p1" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.41880949.1.0" Name="idx_tt_p_i_1_prt_tt_p1" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>
@@ -464,7 +464,7 @@ select z_p.j from z_p,tt_p where  z_p.i=6 and z_p.i<tt_p.i;
       <dxl:ColumnStatistics Mdid="1.41880987.1.1.6" Name="xmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.41880825.1.1.3" Name="xmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.41880825.1.1.2" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:Index Mdid="0.41881111.1.0" Name="idx_z_p_i_1_prt_z_p1" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.41881111.1.0" Name="idx_z_p_i_1_prt_z_p1" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-PartResolverExpand.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-PartResolverExpand.mdp
@@ -484,7 +484,7 @@ select count(*) from x10, y10 where (x10.i > y10.j AND x10.j <= y10.i);
           <dxl:UpperBound Closed="true" TypeMdid="0.25.1.0" Value="AAAAJGVjY2JjODdlNGI1Y2UyZmUyODMwOGZkOWYyYTdiYWYz" LintValue="162161524"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.26855161.1.0" Name="y_idx_1_prt_def" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="0.26855161.1.0" Name="y_idx_1_prt_def" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1994.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-PartTable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-PartTable.mdp
@@ -1200,7 +1200,7 @@ ORDER BY 1 asc ;
         <dxl:SumAgg Mdid="0.2114.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.16166830.1.0" Name="my_tq_agg_small_ets_end_ts_ix_1_prt_p1" IsClustered="false" IndexType="B-tree" KeyColumns="0,4" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11">
+      <dxl:Index Mdid="0.16166830.1.0" Name="my_tq_agg_small_ets_end_ts_ix_1_prt_p1" IsClustered="false" IndexType="B-tree" KeyColumns="0,4" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1980.1.0"/>
           <dxl:Opfamily Mdid="0.1980.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply-Redistribute-Const-Table.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply-Redistribute-Const-Table.mdp
@@ -311,7 +311,7 @@ Table X (int i, int j) is distributed by i, column i has index
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="2"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.17159874.1.0" Name="idx_x_j" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.17159874.1.0" Name="idx_x_j" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>
@@ -332,7 +332,7 @@ Table X (int i, int j) is distributed by i, column i has index
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.17159920.1.0" Name="idx_x_i" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.17159920.1.0" Name="idx_x_i" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply1-CalibratedCostModel.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply1-CalibratedCostModel.mdp
@@ -276,7 +276,7 @@
       </dxl:GPDBScalarOp>
       <dxl:ColumnStatistics Mdid="1.40972.1.1.3" Name="xmin" Width="4.000000" NullFreq="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.40972.1.1.2" Name="ctid" Width="6.000000" NullFreq="0.000000"/>
-      <dxl:Index Mdid="0.1369110.1.0" Name="index_yj" IsClustered="false" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.1369110.1.0" Name="index_yj" IsClustered="false" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply1.mdp
@@ -271,7 +271,7 @@
       </dxl:GPDBScalarOp>
       <dxl:ColumnStatistics Mdid="1.40972.1.1.3" Name="xmin" Width="4.000000" NullFreq="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.40972.1.1.2" Name="ctid" Width="6.000000" NullFreq="0.000000"/>
-      <dxl:Index Mdid="0.1369110.1.0" Name="index_yj" IsClustered="false" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.1369110.1.0" Name="index_yj" IsClustered="false" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply2.mdp
@@ -264,7 +264,7 @@
       </dxl:GPDBScalarOp>
       <dxl:ColumnStatistics Mdid="1.40972.1.1.3" Name="xmin" Width="4.000000" NullFreq="0.000000"/>
       <dxl:ColumnStatistics Mdid="1.40972.1.1.2" Name="ctid" Width="6.000000" NullFreq="0.000000"/>
-      <dxl:Index Mdid="0.1369110.1.0" Name="index_yj" IsClustered="false" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.1369110.1.0" Name="index_yj" IsClustered="false" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply3.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply3.mdp
@@ -271,7 +271,7 @@
         <dxl:OpFunc Mdid="0.177.1.0"/>
         <dxl:Commutator Mdid="0.551.1.0"/>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.1369110.1.0" Name="index_yj" IsClustered="false" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.1369110.1.0" Name="index_yj" IsClustered="false" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply4.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply4.mdp
@@ -271,7 +271,7 @@
         <dxl:OpFunc Mdid="0.177.1.0"/>
         <dxl:Commutator Mdid="0.551.1.0"/>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.1369110.1.0" Name="index_yj" IsClustered="false" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.1369110.1.0" Name="index_yj" IsClustered="false" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexApply_NestLoopWithNestParamTrue.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexApply_NestLoopWithNestParamTrue.mdp
@@ -125,7 +125,7 @@
           <dxl:Opfamily Mdid="0.7027.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.16402.1.0" Name="id1" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.16402.1.0" Name="id1" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
@@ -222,7 +222,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.16416.1.0" Name="id2" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.16416.1.0" Name="id2" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexConstraintsMDidCache.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexConstraintsMDidCache.mdp
@@ -316,7 +316,7 @@
           <dxl:Opfamily Mdid="0.10003.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="7.16406.1.0" Name="test_mdid_pkey" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="7.16406.1.0" Name="test_mdid_pkey" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexGet-OuterRefs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexGet-OuterRefs.mdp
@@ -120,7 +120,7 @@
       <dxl:ColumnStatistics Mdid="1.1119916.1.1.8" Name="gp_segment_id" Width="4.000000"/>
       <dxl:ColumnStatistics Mdid="1.1119916.1.1.1" Name="b" Width="8.000000"/>
       <dxl:ColumnStatistics Mdid="1.1119916.1.1.0" Name="a" Width="8.000000"/>
-      <dxl:Index Mdid="0.1119939.1.0" Name="t_a" IsClustered="false" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.1119939.1.0" Name="t_a" IsClustered="false" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexNLJ-IndexGet-OuterRef.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexNLJ-IndexGet-OuterRef.mdp
@@ -65,7 +65,7 @@
         <dxl:CheckConstraints/>
       </dxl:Relation>
       <dxl:RelationStatistics Mdid="2.98319.1.0" Name="bar" Rows="100.000000" EmptyRelation="false"/>
-      <dxl:Index Mdid="0.98318.1.0" Name="foo_idx" IsClustered="false" IndexType="B-tree" KeyColumns="1,2" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.98318.1.0" Name="foo_idx" IsClustered="false" IndexType="B-tree" KeyColumns="1,2" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/IndexNLJoin_Cast_NoMotion.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexNLJoin_Cast_NoMotion.mdp
@@ -45,7 +45,7 @@ explain select * from R1 inner join S1 on a = b union all select * from R2 inner
       <dxl:TraceFlags Value="101013,102001,102002,102003,102120,102144,103001,103014,103015,103022,103027,103033,104003,104004,104005,105000"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:Index Mdid="0.130052.1.0" Name="r1_a_idx" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3">
+      <dxl:Index Mdid="0.130052.1.0" Name="r1_a_idx" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1994.1.0"/>
         </dxl:Opfamilies>
@@ -65,7 +65,7 @@ explain select * from R1 inner join S1 on a = b union all select * from R2 inner
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.130069.1.0" Name="s1_b_idx" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3">
+      <dxl:Index Mdid="0.130069.1.0" Name="s1_b_idx" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1994.1.0"/>
         </dxl:Opfamilies>
@@ -241,7 +241,7 @@ explain select * from R1 inner join S1 on a = b union all select * from R2 inner
         </dxl:IndexInfoList>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.130092.1.0" Name="r2_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7">
+      <dxl:Index Mdid="0.130092.1.0" Name="r2_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1994.1.0"/>
         </dxl:Opfamilies>
@@ -249,7 +249,7 @@ explain select * from R1 inner join S1 on a = b union all select * from R2 inner
       <dxl:MDCast Mdid="3.25.1.0;25.1.0" Name="text" BinaryCoercible="true" SourceTypeId="0.25.1.0" DestinationTypeId="0.25.1.0" CastFuncId="0.0.0.0" CoercePathType="0"/>
       <dxl:ColumnStatistics Mdid="1.122064.1.0.0" Name="a" Width="2.000000" NullFreq="0.000000" NdvRemain="11.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
       <dxl:MDCast Mdid="3.1043.1.0;25.1.0" Name="text" BinaryCoercible="true" SourceTypeId="0.1043.1.0" DestinationTypeId="0.25.1.0" CastFuncId="0.0.0.0" CoercePathType="0"/>
-      <dxl:Index Mdid="0.130113.1.0" Name="s2_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7">
+      <dxl:Index Mdid="0.130113.1.0" Name="s2_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1994.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-AddNewPartitionToRootTableContainingHeterogenousIndex.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-AddNewPartitionToRootTableContainingHeterogenousIndex.mdp
@@ -215,7 +215,7 @@ EXPLAIN SELECT * FROM foo_1_prt_p3 WHERE c > 10;
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.829540.1.0" Name="foo_1_prt_p3_c_key" IsClustered="false" IndexType="B-tree" KeyColumns="2" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="0.829540.1.0" Name="foo_1_prt_p3_c_key" IsClustered="false" IndexType="B-tree" KeyColumns="2" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-AddPartitionToRootWithHomogenousIndex.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-AddPartitionToRootWithHomogenousIndex.mdp
@@ -54,7 +54,7 @@ EXPLAIN SELECT * FROM foo_1_prt_p3 WHERE c > 10;
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.829384.1.0" Name="foo_1_prt_p3_c_key" IsClustered="false" IndexType="B-tree" KeyColumns="2" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="0.829384.1.0" Name="foo_1_prt_p3_c_key" IsClustered="false" IndexType="B-tree" KeyColumns="2" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-IndexOnPartitionsWithDifferentStorageTypes.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-IndexOnPartitionsWithDifferentStorageTypes.mdp
@@ -296,7 +296,7 @@ EXPLAIN SELECT * FROM foo_1_prt_p1 WHERE c < 10;
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.827950.1.0" Name="complete_idx_c_1_prt_p1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="0,1,2,3,4,5,6">
+      <dxl:Index Mdid="0.827950.1.0" Name="complete_idx_c_1_prt_p1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-NonOverlappingHeterogenousIndex-ANDPredicate-AO.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-NonOverlappingHeterogenousIndex-ANDPredicate-AO.mdp
@@ -124,13 +124,13 @@ EXPLAIN SELECT * FROM foo_1_prt_p2 WHERE c > 10 AND f > 15;
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.25116.1.0" Name="idx_root_cd_1_prt_p2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2,3" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.25116.1.0" Name="idx_root_cd_1_prt_p2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2,3" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.25133.1.0" Name="idx_p2_fe" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="5,4" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.25133.1.0" Name="idx_p2_fe" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="5,4" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-NonOverlappingHeterogenousIndex-ANDPredicate-HEAP.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-NonOverlappingHeterogenousIndex-ANDPredicate-HEAP.mdp
@@ -157,13 +157,13 @@ EXPLAIN SELECT * FROM foo_1_prt_p2 WHERE c > 10 AND f > 12;
       <dxl:ColumnStatistics Mdid="1.828078.1.0.12" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.828078.1.0.4" Name="e" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.828078.1.0.5" Name="f" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:Index Mdid="0.828133.1.0" Name="idx_root_cd_1_prt_p2" IsClustered="false" IndexType="B-tree" KeyColumns="2,3" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12">
+      <dxl:Index Mdid="0.828133.1.0" Name="idx_root_cd_1_prt_p2" IsClustered="false" IndexType="B-tree" KeyColumns="2,3" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.828147.1.0" Name="idx_p2_cd" IsClustered="false" IndexType="B-tree" KeyColumns="4,5" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12">
+      <dxl:Index Mdid="0.828147.1.0" Name="idx_p2_cd" IsClustered="false" IndexType="B-tree" KeyColumns="4,5" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-NonOverlappingHomogenousIndexesOnRoot-ANDPredicate-AO.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-NonOverlappingHomogenousIndexesOnRoot-ANDPredicate-AO.mdp
@@ -124,7 +124,7 @@ EXPLAIN SELECT * FROM foo_1_prt_p2 WHERE c > 10 AND d > 14;
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.31024.1.0" Name="complete_idx_cd_1_prt_p2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2,3" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.31024.1.0" Name="complete_idx_cd_1_prt_p2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2,3" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
@@ -142,7 +142,7 @@ EXPLAIN SELECT * FROM foo_1_prt_p2 WHERE c > 10 AND d > 14;
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="12"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.31069.1.0" Name="complete_idx_ef_1_prt_p2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="4,5" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.31069.1.0" Name="complete_idx_ef_1_prt_p2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="4,5" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-NonOverlappingHomogenousIndexesOnRoot-ORPredicate-AO.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-NonOverlappingHomogenousIndexesOnRoot-ORPredicate-AO.mdp
@@ -79,7 +79,7 @@ EXPLAIN SELECT * FROM foo_1_prt_p2 WHERE e > 20 OR f > 22;
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.24976.1.0" Name="complete_idx_ef_1_prt_p2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="4,5" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.24976.1.0" Name="complete_idx_ef_1_prt_p2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="4,5" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
@@ -182,7 +182,7 @@ EXPLAIN SELECT * FROM foo_1_prt_p2 WHERE e > 20 OR f > 22;
           <dxl:CheckConstraint Mdid="0.24866.1.0"/>
         </dxl:CheckConstraints>
       </dxl:Relation>
-      <dxl:Index Mdid="0.25018.1.0" Name="complete_idx_f_1_prt_p2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="5" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.25018.1.0" Name="complete_idx_f_1_prt_p2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="5" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
@@ -197,7 +197,7 @@ EXPLAIN SELECT * FROM foo_1_prt_p2 WHERE e > 20 OR f > 22;
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="20"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.24931.1.0" Name="complete_idx_cd_1_prt_p2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2,3" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.24931.1.0" Name="complete_idx_cd_1_prt_p2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2,3" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-OverlappingHeterogenousIndex-ANDPredicate-AO.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-OverlappingHeterogenousIndex-ANDPredicate-AO.mdp
@@ -79,7 +79,7 @@ EXPLAIN SELECT * FROM foo_1_prt_p1 WHERE c < 10 AND d > 20;
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.30100.1.0" Name="idx_p1_cd" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="0,1,2,3,4,5,6">
+      <dxl:Index Mdid="0.30100.1.0" Name="idx_p1_cd" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
@@ -262,7 +262,7 @@ EXPLAIN SELECT * FROM foo_1_prt_p1 WHERE c < 10 AND d > 20;
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.30066.1.0" Name="idx_root_cd_1_prt_p1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2,3" IncludedColumns="0,1,2,3,4,5,6">
+      <dxl:Index Mdid="0.30066.1.0" Name="idx_root_cd_1_prt_p1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2,3" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-OverlappingHeterogenousIndex-ANDPredicate-HEAP.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-OverlappingHeterogenousIndex-ANDPredicate-HEAP.mdp
@@ -374,7 +374,7 @@ EXPLAIN SELECT * FROM foo_1_prt_p1 WHERE c < 10 AND d > 20;
       <dxl:ColumnStatistics Mdid="1.827971.1.0.10" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.827971.1.0.3" Name="d" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.827971.1.0.2" Name="c" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:Index Mdid="0.828029.1.0" Name="idx_root_cd_1_prt_p1" IsClustered="false" IndexType="B-tree" KeyColumns="2,3" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="0.828029.1.0" Name="idx_root_cd_1_prt_p1" IsClustered="false" IndexType="B-tree" KeyColumns="2,3" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
@@ -388,7 +388,7 @@ EXPLAIN SELECT * FROM foo_1_prt_p1 WHERE c < 10 AND d > 20;
       <dxl:ColumnStatistics Mdid="1.827971.1.0.8" Name="cmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.827971.1.0.1" Name="b" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.827971.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:Index Mdid="0.828057.1.0" Name="idx_p1_cd" IsClustered="false" IndexType="B-tree" KeyColumns="2" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="0.828057.1.0" Name="idx_p1_cd" IsClustered="false" IndexType="B-tree" KeyColumns="2" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-OverlappingHeterogenousIndex-ORPredicate-AO.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-OverlappingHeterogenousIndex-ORPredicate-AO.mdp
@@ -28,7 +28,7 @@ EXPLAIN SELECT * FROM foo_1_prt_p1 WHERE c > 11 OR d > 20;
       <dxl:TraceFlags Value="102001,102002,102003,102074,102120,102144,103001,103014,103015,103022,103027,103033,104003,104004,104005,105000"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:Index Mdid="0.24833.1.0" Name="idx_p1_cd" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="0,1,2,3,4,5,6">
+      <dxl:Index Mdid="0.24833.1.0" Name="idx_p1_cd" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
@@ -324,7 +324,7 @@ EXPLAIN SELECT * FROM foo_1_prt_p1 WHERE c > 11 OR d > 20;
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="19"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.24799.1.0" Name="idx_root_cd_1_prt_p1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="3,2" IncludedColumns="0,1,2,3,4,5,6">
+      <dxl:Index Mdid="0.24799.1.0" Name="idx_root_cd_1_prt_p1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="3,2" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-OverlappingHomogenousIndexesOnRoot-ANDPredicate-AO.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-OverlappingHomogenousIndexesOnRoot-ANDPredicate-AO.mdp
@@ -124,7 +124,7 @@ EXPLAIN SELECT * FROM foo_1_prt_p2 WHERE c > 10 AND d > 13;
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.31282.1.0" Name="complete_idx_c_1_prt_p2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="0,1,2,3,4,5,6">
+      <dxl:Index Mdid="0.31282.1.0" Name="complete_idx_c_1_prt_p2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
@@ -139,7 +139,7 @@ EXPLAIN SELECT * FROM foo_1_prt_p2 WHERE c > 10 AND d > 13;
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="20"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.31327.1.0" Name="complete_idx_cd_1_prt_p2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2,3" IncludedColumns="0,1,2,3,4,5,6">
+      <dxl:Index Mdid="0.31327.1.0" Name="complete_idx_cd_1_prt_p2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2,3" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-OverlappingHomogenousIndexesOnRoot-AO.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-OverlappingHomogenousIndexesOnRoot-AO.mdp
@@ -52,7 +52,7 @@ EXPLAIN SELECT * FROM foo_1_prt_p2 WHERE d > 10;
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.24718.1.0" Name="complete_idx_cd_1_prt_p2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="3,2" IncludedColumns="0,1,2,3,4,5,6">
+      <dxl:Index Mdid="0.24718.1.0" Name="complete_idx_cd_1_prt_p2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="3,2" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
@@ -176,7 +176,7 @@ EXPLAIN SELECT * FROM foo_1_prt_p2 WHERE d > 10;
         </dxl:And>
       </dxl:CheckConstraint>
       <dxl:ColumnStatistics Mdid="1.24606.1.0.3" Name="d" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:Index Mdid="0.24673.1.0" Name="complete_idx_c_1_prt_p2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="0,1,2,3,4,5,6">
+      <dxl:Index Mdid="0.24673.1.0" Name="complete_idx_c_1_prt_p2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-OverlappingHomogenousIndexesOnRoot-ORPredicate-AO.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-OverlappingHomogenousIndexesOnRoot-ORPredicate-AO.mdp
@@ -213,7 +213,7 @@ EXPLAIN SELECT * FROM foo_1_prt_p2 WHERE c > 12 OR d > 13;
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.16790.1.0" Name="complete_idx_cd_1_prt_p2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="3,2" IncludedColumns="0,1,2,3,4,5,6">
+      <dxl:Index Mdid="0.16790.1.0" Name="complete_idx_cd_1_prt_p2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="3,2" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
@@ -321,7 +321,7 @@ EXPLAIN SELECT * FROM foo_1_prt_p2 WHERE c > 12 OR d > 13;
           </dxl:Comparison>
         </dxl:And>
       </dxl:CheckConstraint>
-      <dxl:Index Mdid="0.16745.1.0" Name="complete_idx_c_1_prt_p2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="0,1,2,3,4,5,6">
+      <dxl:Index Mdid="0.16745.1.0" Name="complete_idx_c_1_prt_p2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-SingleColumnHeterogenousIndexOnRoot-1-AO.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-SingleColumnHeterogenousIndexOnRoot-1-AO.mdp
@@ -112,7 +112,7 @@ EXPLAIN SELECT * FROM foo_1_prt_p1 WHERE c < 10;
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.827865.1.0" Name="idx_root_d_1_prt_p1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="3" IncludedColumns="0,1,2,3,4,5,6">
+      <dxl:Index Mdid="0.827865.1.0" Name="idx_root_d_1_prt_p1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="3" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
@@ -307,7 +307,7 @@ EXPLAIN SELECT * FROM foo_1_prt_p1 WHERE c < 10;
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.827831.1.0" Name="idx_p1_c" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="0,1,2,3,4,5,6">
+      <dxl:Index Mdid="0.827831.1.0" Name="idx_p1_c" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-SingleColumnHeterogenousIndexOnRoot-1-HEAP.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-SingleColumnHeterogenousIndexOnRoot-1-HEAP.mdp
@@ -28,7 +28,7 @@ EXPLAIN SELECT * FROM foo_1_prt_p1 WHERE c < 10;
       <dxl:TraceFlags Value="102001,102002,102003,102120,102144,103001,103014,103015,103022,103027,103033,104003,104004,104005,105000"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:Index Mdid="0.827725.1.0" Name="idx_p1_c" IsClustered="false" IndexType="B-tree" KeyColumns="2" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="0.827725.1.0" Name="idx_p1_c" IsClustered="false" IndexType="B-tree" KeyColumns="2" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
@@ -155,7 +155,7 @@ EXPLAIN SELECT * FROM foo_1_prt_p1 WHERE c < 10;
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.827753.1.0" Name="idx_root_d_1_prt_p1" IsClustered="false" IndexType="B-tree" KeyColumns="3" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="0.827753.1.0" Name="idx_root_d_1_prt_p1" IsClustered="false" IndexType="B-tree" KeyColumns="3" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-SingleColumnHeterogenousIndexOnRoot-2-AO.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-SingleColumnHeterogenousIndexOnRoot-2-AO.mdp
@@ -112,7 +112,7 @@ EXPLAIN SELECT * FROM foo_1_prt_p1 WHERE d < 10;
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.827865.1.0" Name="idx_root_d_1_prt_p1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="3" IncludedColumns="0,1,2,3,4,5,6">
+      <dxl:Index Mdid="0.827865.1.0" Name="idx_root_d_1_prt_p1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="3" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
@@ -179,7 +179,7 @@ EXPLAIN SELECT * FROM foo_1_prt_p1 WHERE d < 10;
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.827831.1.0" Name="idx_p1_c" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="0,1,2,3,4,5,6">
+      <dxl:Index Mdid="0.827831.1.0" Name="idx_p1_c" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-SingleColumnHeterogenousIndexOnRoot-2-HEAP.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexOnLeaf-SingleColumnHeterogenousIndexOnRoot-2-HEAP.mdp
@@ -28,7 +28,7 @@ EXPLAIN SELECT * FROM foo_1_prt_p1 WHERE d < 10;
       <dxl:TraceFlags Value="102001,102002,102003,102120,102144,103001,103014,103015,103022,103027,103033,104003,104004,104005,105000"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:Index Mdid="0.827725.1.0" Name="idx_p1_c" IsClustered="false" IndexType="B-tree" KeyColumns="2" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="0.827725.1.0" Name="idx_p1_c" IsClustered="false" IndexType="B-tree" KeyColumns="2" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
@@ -155,7 +155,7 @@ EXPLAIN SELECT * FROM foo_1_prt_p1 WHERE d < 10;
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.827753.1.0" Name="idx_root_d_1_prt_p1" IsClustered="false" IndexType="B-tree" KeyColumns="3" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="0.827753.1.0" Name="idx_root_d_1_prt_p1" IsClustered="false" IndexType="B-tree" KeyColumns="3" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexScan-AOTable.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexScan-AOTable.mdp
@@ -47,7 +47,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.507751.1.0" Name="ao_j" IsClustered="false" KeyColumns="1" IncludedColumns="0,1,2,3,4,5">
+      <dxl:Index Mdid="0.507751.1.0" Name="ao_j" IsClustered="false" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexScan-AndedIn.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexScan-AndedIn.mdp
@@ -2219,7 +2219,7 @@
           <dxl:Opfamily Mdid="0.12732.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.106220.1.0" Name="tenk1_thous_tenthous" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0,1" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.106220.1.0" Name="tenk1_thous_tenthous" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0,1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/IndexScan-BoolFalse.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexScan-BoolFalse.mdp
@@ -54,7 +54,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.296558.1.0" Name="s_b" IsClustered="false" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.296558.1.0" Name="s_b" IsClustered="false" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexScan-BoolTrue.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexScan-BoolTrue.mdp
@@ -54,7 +54,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.296558.1.0" Name="s_b" IsClustered="false" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.296558.1.0" Name="s_b" IsClustered="false" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexScan-DroppedColumns.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexScan-DroppedColumns.mdp
@@ -67,7 +67,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.567205.1.0" Name="r_c" IsClustered="false" KeyColumns="2" IncludedColumns="0,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.567205.1.0" Name="r_c" IsClustered="false" KeyColumns="2" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexScan-ORPredsAOPart.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexScan-ORPredsAOPart.mdp
@@ -415,7 +415,7 @@
         </dxl:PartConstraint>
       </dxl:Relation>
       <dxl:ColumnStatistics Mdid="1.372761.1.0.2" Name="c" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:Index Mdid="0.372827.1.0" Name="foo_ab_ix_1_prt_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="0,1,2,3,4,5">
+      <dxl:Index Mdid="0.372827.1.0" Name="foo_ab_ix_1_prt_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexScan-ORPredsNonPart.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexScan-ORPredsNonPart.mdp
@@ -170,7 +170,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.372760.1.0" Name="foo_ab_ix" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0,1" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.372760.1.0" Name="foo_ab_ix" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0,1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/IndexScan-Relabel.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexScan-Relabel.mdp
@@ -612,7 +612,7 @@
         <dxl:CheckConstraints/>
       </dxl:Relation>
       <dxl:MDCast Mdid="3.1043.1.0;25.1.0" Name="text" BinaryCoercible="true" SourceTypeId="0.1043.1.0" DestinationTypeId="0.25.1.0" CastFuncId="0.0.0.0"/>
-      <dxl:Index Mdid="0.603018.1.0" Name="r_idx" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.603018.1.0" Name="r_idx" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.2003.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexScanWithNestedCTEAndSetOp.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexScanWithNestedCTEAndSetOp.mdp
@@ -118,7 +118,7 @@ SELECT a FROM y WHERE (a IN (SELECT b FROM bar WHERE b = 2));
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.53653.1.0" Name="idx1" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7">
+      <dxl:Index Mdid="0.53653.1.0" Name="idx1" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/IndexedNLJBitmap.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexedNLJBitmap.mdp
@@ -293,7 +293,7 @@
           </dxl:And>
         </dxl:PartConstraint>
       </dxl:Relation>
-      <dxl:Index Mdid="0.32178.1.0" Name="bar_c_1_prt_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.32178.1.0" Name="bar_c_1_prt_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
@@ -442,7 +442,7 @@
           </dxl:And>
         </dxl:PartConstraint>
       </dxl:Relation>
-      <dxl:Index Mdid="0.32202.1.0" Name="foo_a_1_prt_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.32202.1.0" Name="foo_a_1_prt_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/Insert-With-HJ-CTE-Agg.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Insert-With-HJ-CTE-Agg.mdp
@@ -143,7 +143,7 @@
         </dxl:IndexInfoList>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.57364.1.0" Name="country_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.57364.1.0" Name="country_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.426.1.0"/>
         </dxl:Opfamilies>
@@ -326,7 +326,7 @@
         <dxl:IndexInfoList/>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.57385.1.0" Name="countrylanguage_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0,1" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.57385.1.0" Name="countrylanguage_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0,1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.426.1.0"/>
           <dxl:Opfamily Mdid="0.1994.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/Join-Disj-Subqs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Join-Disj-Subqs.mdp
@@ -62,7 +62,7 @@ OR
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.6029.1.0" Name="pg_authid_rolresqueue_index" IsClustered="false" IndexType="B-tree" KeyColumns="11" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24">
+      <dxl:Index Mdid="0.6029.1.0" Name="pg_authid_rolresqueue_index" IsClustered="false" IndexType="B-tree" KeyColumns="11" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1989.1.0"/>
         </dxl:Opfamilies>
@@ -721,12 +721,12 @@ OR
         <dxl:ResultType Mdid="0.20.1.0"/>
         <dxl:IntermediateResultType Mdid="0.20.1.0"/>
       </dxl:GPDBAgg>
-      <dxl:Index Mdid="0.2677.1.0" Name="pg_authid_oid_index" IsClustered="false" IndexType="B-tree" KeyColumns="18" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24">
+      <dxl:Index Mdid="0.2677.1.0" Name="pg_authid_oid_index" IsClustered="false" IndexType="B-tree" KeyColumns="18" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1989.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.2676.1.0" Name="pg_authid_rolname_index" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24">
+      <dxl:Index Mdid="0.2676.1.0" Name="pg_authid_rolname_index" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1986.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/JoinColWithOnlyNDV.mdp
+++ b/src/backend/gporca/data/dxl/minidump/JoinColWithOnlyNDV.mdp
@@ -130,7 +130,7 @@
         <dxl:SumAgg Mdid="0.2114.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.642410.1.0" Name="web_sales_pkey" IsClustered="false" KeyColumns="3,17" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40">
+      <dxl:Index Mdid="0.642410.1.0" Name="web_sales_pkey" IsClustered="false" KeyColumns="3,17" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
@@ -2993,7 +2993,7 @@
         </dxl:IndexInfoList>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.642441.1.0" Name="web_site_pkey" IsClustered="false" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32">
+      <dxl:Index Mdid="0.642441.1.0" Name="web_site_pkey" IsClustered="false" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/JoinNDVRemain.mdp
+++ b/src/backend/gporca/data/dxl/minidump/JoinNDVRemain.mdp
@@ -890,7 +890,7 @@ select * from customer_address, store where customer_address.ca_county::text = s
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
       <dxl:MDCast Mdid="3.25.1.0;25.1.0" Name="text" BinaryCoercible="true" SourceTypeId="0.25.1.0" DestinationTypeId="0.25.1.0" CastFuncId="0.0.0.0"/>
-      <dxl:Index Mdid="0.525049.1.0" Name="store_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35">
+      <dxl:Index Mdid="0.525049.1.0" Name="store_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>
@@ -1752,7 +1752,7 @@ select * from customer_address, store where customer_address.ca_county::text = s
           <dxl:UpperBound Closed="true" TypeMdid="0.1042.1.0" Value="AAAADjk5OSAgICAgICA=" LintValue="825230246"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.518353.1.0" Name="customer_address_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19">
+      <dxl:Index Mdid="0.518353.1.0" Name="customer_address_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/LOJ-DynBitmapIndex.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-DynBitmapIndex.mdp
@@ -390,7 +390,7 @@
         </dxl:PartConstraint>
       </dxl:Relation>
       <dxl:ColumnStatistics Mdid="1.417828.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:Index Mdid="0.417854.1.0" Name="tinner_1_prt_1_a_idx" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.417854.1.0" Name="tinner_1_prt_1_a_idx" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.7027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/LOJ-DynBitmapIndexWithSelect.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-DynBitmapIndexWithSelect.mdp
@@ -389,7 +389,7 @@
           </dxl:And>
         </dxl:PartConstraint>
       </dxl:Relation>
-      <dxl:Index Mdid="0.417881.1.0" Name="tinner_1_prt_1_a_idx" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.417881.1.0" Name="tinner_1_prt_1_a_idx" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.7027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/LOJ-DynBtreeIndex.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-DynBtreeIndex.mdp
@@ -251,7 +251,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.27540.1.0" Name="tinner_ix_1_prt_1" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.27540.1.0" Name="tinner_ix_1_prt_1" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/LOJ-DynBtreeIndexWithSelect.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-DynBtreeIndexWithSelect.mdp
@@ -329,7 +329,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.27684.1.0" Name="tinner_ix_1_prt_1" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.27684.1.0" Name="tinner_ix_1_prt_1" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/LOJ-HashJoin-MultiDistKeys-WithComplexPreds.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-HashJoin-MultiDistKeys-WithComplexPreds.mdp
@@ -70,7 +70,7 @@
         <dxl:IndexInfoList/>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.16391.1.0" Name="bar_idx_d" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.16391.1.0" Name="bar_idx_d" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-CompsiteKey-Equiv.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-CompsiteKey-Equiv.mdp
@@ -230,7 +230,7 @@ explain select * from foo left join bar on foo.a = bar.a and foo.b = bar.b left 
       </dxl:Relation>
       <dxl:MDCast Mdid="3.1043.1.0;25.1.0" Name="text" BinaryCoercible="true" SourceTypeId="0.1043.1.0" DestinationTypeId="0.25.1.0" CastFuncId="0.0.0.0" CoercePathType="0"/>
       <dxl:RelationStatistics Mdid="2.65603.1.0" Name="zoo" Rows="0.000000" EmptyRelation="true"/>
-      <dxl:Index Mdid="0.65602.1.0" Name="bar_idx_ab" IsClustered="false" IndexType="B-tree" KeyColumns="1,0" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.65602.1.0" Name="bar_idx_ab" IsClustered="false" IndexType="B-tree" KeyColumns="1,0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1994.1.0"/>
@@ -264,7 +264,7 @@ explain select * from foo left join bar on foo.a = bar.a and foo.b = bar.b left 
       </dxl:Relation>
       <dxl:ColumnStatistics Mdid="1.65577.1.0.1" Name="b" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.65577.1.0.0" Name="a" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:Index Mdid="0.65626.1.0" Name="zoo_idx_ab" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1,0" IncludedColumns="0,1,2,3,4,5">
+      <dxl:Index Mdid="0.65626.1.0" Name="zoo_idx_ab" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1,0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1994.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-CompsiteKey-NoMotion.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-CompsiteKey-NoMotion.mdp
@@ -309,14 +309,14 @@ explain select * from foo left join bar on foo.a = bar.a and foo.b = bar.b left 
           <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
         </dxl:DistrOpfamilies>
       </dxl:Relation>
-      <dxl:Index Mdid="0.49205.1.0" Name="bar_idx_ab" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1,0" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.49205.1.0" Name="bar_idx_ab" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1,0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1994.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
       <dxl:MDCast Mdid="3.1043.1.0;25.1.0" Name="text" BinaryCoercible="true" SourceTypeId="0.1043.1.0" DestinationTypeId="0.25.1.0" CastFuncId="0.0.0.0" CoercePathType="0"/>
-      <dxl:Index Mdid="0.49209.1.0" Name="zoo_idx_ab" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1,0" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.49209.1.0" Name="zoo_idx_ab" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1,0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1994.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-CoordinatorOnly-Table.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-CoordinatorOnly-Table.mdp
@@ -63,12 +63,12 @@ union all
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.2703.1.0" Name="pg_type_oid_index" IsClustered="false" IndexType="B-tree" KeyColumns="29" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35">
+      <dxl:Index Mdid="0.2703.1.0" Name="pg_type_oid_index" IsClustered="false" IndexType="B-tree" KeyColumns="29" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1989.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.2704.1.0" Name="pg_type_typname_nsp_index" IsClustered="false" IndexType="B-tree" KeyColumns="0,1" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35">
+      <dxl:Index Mdid="0.2704.1.0" Name="pg_type_typname_nsp_index" IsClustered="false" IndexType="B-tree" KeyColumns="0,1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1986.1.0"/>
           <dxl:Opfamily Mdid="0.1989.1.0"/>
@@ -445,13 +445,13 @@ union all
           <dxl:Opfamily Mdid="0.7033.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.2663.1.0" Name="pg_class_relname_nsp_index" IsClustered="false" IndexType="B-tree" KeyColumns="0,1" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33">
+      <dxl:Index Mdid="0.2663.1.0" Name="pg_class_relname_nsp_index" IsClustered="false" IndexType="B-tree" KeyColumns="0,1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1986.1.0"/>
           <dxl:Opfamily Mdid="0.1989.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.2662.1.0" Name="pg_class_oid_index" IsClustered="false" IndexType="B-tree" KeyColumns="27" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33">
+      <dxl:Index Mdid="0.2662.1.0" Name="pg_class_oid_index" IsClustered="false" IndexType="B-tree" KeyColumns="27" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1989.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-DistKey-Multiple-Predicates.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-DistKey-Multiple-Predicates.mdp
@@ -165,7 +165,7 @@ explain select * from foo left join bar on bar.a=foo.a and bar.a<foo.b left oute
           <dxl:DistrOpfamily Mdid="0.1995.1.0"/>
         </dxl:DistrOpfamilies>
       </dxl:Relation>
-      <dxl:Index Mdid="0.49175.1.0" Name="bar_idx_a" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.49175.1.0" Name="bar_idx_a" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1994.1.0"/>
         </dxl:Opfamilies>
@@ -252,12 +252,12 @@ explain select * from foo left join bar on bar.a=foo.a and bar.a<foo.b left oute
           <dxl:Opfamily Mdid="0.10018.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.49181.1.0" Name="zoo_idx_b" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.49181.1.0" Name="zoo_idx_b" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1994.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.49180.1.0" Name="zoo_idx_a" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.49180.1.0" Name="zoo_idx_a" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1994.1.0"/>
         </dxl:Opfamilies>
@@ -342,7 +342,7 @@ explain select * from foo left join bar on bar.a=foo.a and bar.a<foo.b left oute
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.49176.1.0" Name="bar_idx_b" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.49176.1.0" Name="bar_idx_b" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1994.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-MultiDistKey-MultiIndexKey-NoExtraFilter.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-MultiDistKey-MultiIndexKey-NoExtraFilter.mdp
@@ -97,7 +97,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.93456.1.0" Name="idx_bar_de" IsClustered="false" IndexType="B-tree" KeyColumns="0,1" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.93456.1.0" Name="idx_bar_de" IsClustered="false" IndexType="B-tree" KeyColumns="0,1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-MultiDistKey-MultiIndexKey.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-MultiDistKey-MultiIndexKey.mdp
@@ -98,7 +98,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.93456.1.0" Name="idx_bar_de" IsClustered="false" IndexType="B-tree" KeyColumns="0,1" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.93456.1.0" Name="idx_bar_de" IsClustered="false" IndexType="B-tree" KeyColumns="0,1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-MultiDistKeys-Bitmap-WithComplexPreds.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-MultiDistKeys-Bitmap-WithComplexPreds.mdp
@@ -54,7 +54,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.101654.1.0" Name="idx_bar_d" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.101654.1.0" Name="idx_bar_d" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.7027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-MultiDistKeys-Bitmap.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-MultiDistKeys-Bitmap.mdp
@@ -52,7 +52,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.101654.1.0" Name="idx_bar_d" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.101654.1.0" Name="idx_bar_d" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.7027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-MultiDistKeys-IndexKeys.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-MultiDistKeys-IndexKeys.mdp
@@ -341,43 +341,43 @@ explain select * from foo left join bar on foo.a=bar.a and foo.b=bar.b and foo.c
         </dxl:DistrOpfamilies>
       </dxl:Relation>
       <dxl:ColumnStatistics Mdid="1.49211.1.0.2" Name="c" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:Index Mdid="0.49236.1.0" Name="bar_idx_c" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.49236.1.0" Name="bar_idx_c" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.49235.1.0" Name="bar_idx_b" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.49235.1.0" Name="bar_idx_b" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.49234.1.0" Name="bar_idx_a" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.49234.1.0" Name="bar_idx_a" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1994.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.49233.1.0" Name="bar_idx_ab" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1,0" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.49233.1.0" Name="bar_idx_ab" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1,0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1994.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.49243.1.0" Name="zoo_idx_c" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.49243.1.0" Name="zoo_idx_c" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.49242.1.0" Name="zoo_idx_b" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.49242.1.0" Name="zoo_idx_b" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.49241.1.0" Name="zoo_idx_a" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.49241.1.0" Name="zoo_idx_a" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1994.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.49240.1.0" Name="zoo_idx_ab" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1,0" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.49240.1.0" Name="zoo_idx_ab" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1,0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1994.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-MultiDistKeys-WithComplexPreds.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-MultiDistKeys-WithComplexPreds.mdp
@@ -69,7 +69,7 @@
         <dxl:IndexInfoList/>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.16391.1.0" Name="bar_idx_d" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.16391.1.0" Name="bar_idx_d" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-MultiIndexes.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-MultiIndexes.mdp
@@ -107,7 +107,7 @@ set optimizer_enable_hashjoin = off;
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
       <dxl:RelationStatistics Mdid="2.32791.1.0" Name="foo" Rows="0.000000" EmptyRelation="true"/>
-      <dxl:Index Mdid="0.32790.1.0" Name="zoo_idx_b" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4">
+      <dxl:Index Mdid="0.32790.1.0" Name="zoo_idx_b" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1994.1.0"/>
         </dxl:Opfamilies>
@@ -160,17 +160,17 @@ set optimizer_enable_hashjoin = off;
         <dxl:IndexInfoList/>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.32785.1.0" Name="bar_idx_b" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.32785.1.0" Name="bar_idx_b" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1994.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.32784.1.0" Name="bar_idx_a" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.32784.1.0" Name="bar_idx_a" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1994.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.32786.1.0" Name="zoo_idx_a" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3,4">
+      <dxl:Index Mdid="0.32786.1.0" Name="zoo_idx_a" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1994.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-Negative-NonEqual-Predicate.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-Negative-NonEqual-Predicate.mdp
@@ -233,7 +233,7 @@
           <dxl:Opfamily Mdid="0.12866.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.40990.1.0" Name="zoo_idx_b" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4">
+      <dxl:Index Mdid="0.40990.1.0" Name="zoo_idx_b" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1994.1.0"/>
         </dxl:Opfamilies>
@@ -286,12 +286,12 @@
           <dxl:Opfamily Mdid="0.12866.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.40985.1.0" Name="bar_idx_b" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.40985.1.0" Name="bar_idx_b" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1994.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.40984.1.0" Name="bar_idx_a" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.40984.1.0" Name="bar_idx_a" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1994.1.0"/>
         </dxl:Opfamilies>
@@ -328,7 +328,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.40986.1.0" Name="zoo_idx_a" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3,4">
+      <dxl:Index Mdid="0.40986.1.0" Name="zoo_idx_a" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1994.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-NonDistKey.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-NonDistKey.mdp
@@ -196,7 +196,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.65570.1.0" Name="bar_idx_b" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.65570.1.0" Name="bar_idx_b" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-WithComplexPredicates.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ-IndexApply-WithComplexPredicates.mdp
@@ -51,7 +51,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.32790.1.0" Name="idx_bar_d" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.32790.1.0" Name="idx_bar_d" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/LOJ_convert_to_inner_with_and_predicate.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ_convert_to_inner_with_and_predicate.mdp
@@ -278,7 +278,7 @@
         <dxl:IndexInfoList/>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.63865.1.0" Name="jazz_ix" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.63865.1.0" Name="jazz_ix" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/LOJ_convert_to_inner_with_or_predicate.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LOJ_convert_to_inner_with_or_predicate.mdp
@@ -280,7 +280,7 @@
         <dxl:IndexInfoList/>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.63865.1.0" Name="jazz_ix" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.63865.1.0" Name="jazz_ix" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/LeftJoin-With-Col-Const-Pred.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LeftJoin-With-Col-Const-Pred.mdp
@@ -981,17 +981,17 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.26.1.0" Value="1664"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.2676.1.0" Name="pg_authid_rolname_index" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24">
+      <dxl:Index Mdid="0.2676.1.0" Name="pg_authid_rolname_index" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1986.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.2677.1.0" Name="pg_authid_oid_index" IsClustered="false" IndexType="B-tree" KeyColumns="18" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24">
+      <dxl:Index Mdid="0.2677.1.0" Name="pg_authid_oid_index" IsClustered="false" IndexType="B-tree" KeyColumns="18" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1989.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.6029.1.0" Name="pg_authid_rolresqueue_index" IsClustered="false" IndexType="B-tree" KeyColumns="11" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24">
+      <dxl:Index Mdid="0.6029.1.0" Name="pg_authid_rolresqueue_index" IsClustered="false" IndexType="B-tree" KeyColumns="11" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1989.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/LeftJoinPruning.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LeftJoinPruning.mdp
@@ -269,14 +269,14 @@
           <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
         </dxl:DistrOpfamilies>
       </dxl:Relation>
-      <dxl:Index Mdid="7.16390.1.0" Name="idx2" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0,2,3" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13">
+      <dxl:Index Mdid="7.16390.1.0" Name="idx2" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0,2,3" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="7.16388.1.0" Name="idx1" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0,1" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13">
+      <dxl:Index Mdid="7.16388.1.0" Name="idx1" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0,1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/LeftJoinPruningInOuterInnerQuery.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LeftJoinPruningInOuterInnerQuery.mdp
@@ -191,7 +191,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="7.16412.1.0" Name="idx3" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0,1" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="7.16412.1.0" Name="idx3" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0,1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
@@ -239,7 +239,7 @@
           <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
         </dxl:DistrOpfamilies>
       </dxl:Relation>
-      <dxl:Index Mdid="7.16402.1.0" Name="idx1" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0,1" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="7.16402.1.0" Name="idx1" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0,1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/LeftJoinPruningInnerQuery.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LeftJoinPruningInnerQuery.mdp
@@ -88,7 +88,7 @@
         </dxl:DistrOpfamilies>
       </dxl:Relation>
       <dxl:ColumnStatistics Mdid="1.16419.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:Index Mdid="7.16436.1.0" Name="t1joinpruning_pkey" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="7.16436.1.0" Name="t1joinpruning_pkey" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
@@ -165,7 +165,7 @@
           <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
         </dxl:DistrOpfamilies>
       </dxl:Relation>
-      <dxl:Index Mdid="7.16424.1.0" Name="idx2" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0,2,3" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13">
+      <dxl:Index Mdid="7.16424.1.0" Name="idx2" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0,2,3" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
@@ -312,7 +312,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="7.16422.1.0" Name="idx1" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0,1" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13">
+      <dxl:Index Mdid="7.16422.1.0" Name="idx1" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0,1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/LeftJoinPruningOuterQuery.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LeftJoinPruningOuterQuery.mdp
@@ -42,7 +42,7 @@
       <dxl:TraceFlags Value="101013,102001,102002,102003,102043,102074,102120,102144,103001,103014,103022,103026,103027,103029,103033,103038,103040,104002,104003,104004,104005,106000"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:Index Mdid="7.16446.1.0" Name="idx1" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="7.16446.1.0" Name="idx1" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
@@ -337,7 +337,7 @@
           <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
         </dxl:DistrOpfamilies>
       </dxl:Relation>
-      <dxl:Index Mdid="7.16451.1.0" Name="idx2" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="7.16451.1.0" Name="idx2" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/LogicalIndexGetDroppedCols.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LogicalIndexGetDroppedCols.mdp
@@ -1182,7 +1182,7 @@ EXPLAIN SELECT * FROM solo WHERE year_id=2017 AND month_id=6;
         </dxl:IndexInfoList>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.30058.1.0" Name="solo_idx" IsClustered="false" IndexType="B-tree" KeyColumns="1,2,7,17,22,29" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,20,21,22,28,29,30,31,32,33,34,35,36">
+      <dxl:Index Mdid="0.30058.1.0" Name="solo_idx" IsClustered="false" IndexType="B-tree" KeyColumns="1,2,7,17,22,29" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/MultipleIndexPredicate.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MultipleIndexPredicate.mdp
@@ -79,7 +79,7 @@
       <dxl:TraceFlags Value="103027,102074,102146,102120,103001,103014,103015,103022,104003,104004,104005,105000"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:Index Mdid="0.74761.1.0" Name="idx_foo_new_fn" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="4" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54">
+      <dxl:Index Mdid="0.74761.1.0" Name="idx_foo_new_fn" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="4" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1994.1.0"/>
         </dxl:Opfamilies>
@@ -193,7 +193,7 @@
         <dxl:SumAgg Mdid="0.2107.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.74775.1.0" Name="idx_foo_new_pcd" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1,0,2" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54">
+      <dxl:Index Mdid="0.74775.1.0" Name="idx_foo_new_pcd" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1,0,2" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.434.1.0"/>
           <dxl:Opfamily Mdid="0.1994.1.0"/>
@@ -261,7 +261,7 @@
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
       <dxl:ColumnStatistics Mdid="1.74486.1.0.19" Name="bs" Width="3.000000" NullFreq="0.000000" NdvRemain="18.000000" FreqRemain="1.000000" ColStatsMissing="false"/>
-      <dxl:Index Mdid="0.74789.1.0" Name="idx_foo_new_pl" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54">
+      <dxl:Index Mdid="0.74789.1.0" Name="idx_foo_new_pl" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1994.1.0"/>
         </dxl:Opfamilies>
@@ -911,7 +911,7 @@
           <dxl:Opfamily Mdid="0.3035.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.74730.1.0" Name="idx_foo_dd" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="5,4" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54">
+      <dxl:Index Mdid="0.74730.1.0" Name="idx_foo_dd" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="5,4" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.434.1.0"/>
           <dxl:Opfamily Mdid="0.1994.1.0"/>
@@ -1110,7 +1110,7 @@
         </dxl:IndexInfoList>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.74747.1.0" Name="idx_foo_ad" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="9,4" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54">
+      <dxl:Index Mdid="0.74747.1.0" Name="idx_foo_ad" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="9,4" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.434.1.0"/>
           <dxl:Opfamily Mdid="0.1994.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/Negative-IndexApply1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Negative-IndexApply1.mdp
@@ -24,7 +24,7 @@ select * from z,tt where tt.i=5 and z.i=6 ;
       <dxl:TraceFlags Value="102001,102002,102003,102043,102074,102120,102144,103001,103014,103022,103026,103027,103029,103033,103038,104002,104003,104004,104005,105000,106000"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:Index Mdid="0.16387.1.0" Name="idx_tt_i" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.16387.1.0" Name="idx_tt_i" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
@@ -68,7 +68,7 @@ select * from z,tt where tt.i=5 and z.i=6 ;
           <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
         </dxl:DistrOpfamilies>
       </dxl:Relation>
-      <dxl:Index Mdid="0.16391.1.0" Name="idx_z_i" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.16391.1.0" Name="idx_z_i" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/Negative-IndexApply2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Negative-IndexApply2.mdp
@@ -214,7 +214,7 @@ select * from z_p,tt_p where tt_p.i=5 and z_p.i=6;
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.16401.1.0" Name="idx_tt_p_i" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.16401.1.0" Name="idx_tt_p_i" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
@@ -464,7 +464,7 @@ select * from z_p,tt_p where tt_p.i=5 and z_p.i=6;
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.16413.1.0" Name="idx_z_p_i" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.16413.1.0" Name="idx_z_p_i" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/Nested-Setops-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Nested-Setops-2.mdp
@@ -193,7 +193,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.1637480.1.0" Name="index_1637480" IsClustered="false" KeyColumns="1" IncludedColumns="1">
+      <dxl:Index Mdid="0.1637480.1.0" Name="index_1637480" IsClustered="false" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/NestedNLJWithBlockingSpool.mdp
+++ b/src/backend/gporca/data/dxl/minidump/NestedNLJWithBlockingSpool.mdp
@@ -119,7 +119,7 @@
       </dxl:Relation>
       <dxl:ColumnStatistics Mdid="1.98421.1.0.1" Name="l_partkey" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.98421.1.0.0" Name="l_orderkey" Width="8.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:Index Mdid="0.98440.1.0" Name="lineitem_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0,3" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22">
+      <dxl:Index Mdid="0.98440.1.0" Name="lineitem_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0,3" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
@@ -153,7 +153,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.98326.1.0" Name="part_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15">
+      <dxl:Index Mdid="0.98326.1.0" Name="part_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/NewBtreeIndexScanCost.mdp
+++ b/src/backend/gporca/data/dxl/minidump/NewBtreeIndexScanCost.mdp
@@ -1863,7 +1863,7 @@ explain select *  from oip oip  join ria a on ip=cidr and oip.oid=194073;
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.48922.1.0" Name="ssm_oip_cidr" IsClustered="false" IndexType="B-tree" KeyColumns="2" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15">
+      <dxl:Index Mdid="0.48922.1.0" Name="ssm_oip_cidr" IsClustered="false" IndexType="B-tree" KeyColumns="2" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1974.1.0"/>
         </dxl:Opfamilies>
@@ -1894,7 +1894,7 @@ explain select *  from oip oip  join ria a on ip=cidr and oip.oid=194073;
           <dxl:Opfamily Mdid="0.3025.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.48950.1.0" Name="ssm_ria_ip_1_prt_1" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20">
+      <dxl:Index Mdid="0.48950.1.0" Name="ssm_ria_ip_1_prt_1" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1974.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/NoSortPlan.mdp
+++ b/src/backend/gporca/data/dxl/minidump/NoSortPlan.mdp
@@ -138,7 +138,7 @@
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.3373430.1.0" Name="idx_yj" IsClustered="false" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.3373430.1.0" Name="idx_yj" IsClustered="false" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/NonOverlappingHomogenousIndexesOnRoot-ANDPredicate-HEAP.mdp
+++ b/src/backend/gporca/data/dxl/minidump/NonOverlappingHomogenousIndexesOnRoot-ANDPredicate-HEAP.mdp
@@ -162,7 +162,7 @@
       <dxl:ColumnStatistics Mdid="1.1237618.1.0.8" Name="cmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.1237618.1.0.1" Name="b" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.1237618.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:Index Mdid="0.1237673.1.0" Name="complete_idx_cd_1_prt_p2" IsClustered="false" IndexType="B-tree" KeyColumns="2,3" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12">
+      <dxl:Index Mdid="0.1237673.1.0" Name="complete_idx_cd_1_prt_p2" IsClustered="false" IndexType="B-tree" KeyColumns="2,3" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
@@ -170,7 +170,7 @@
       </dxl:Index>
       <dxl:ColumnStatistics Mdid="1.1237618.1.0.7" Name="xmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.1237618.1.0.6" Name="ctid" Width="6.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:Index Mdid="0.1237715.1.0" Name="complete_idx_ef_1_prt_p2" IsClustered="false" IndexType="B-tree" KeyColumns="4,5" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12">
+      <dxl:Index Mdid="0.1237715.1.0" Name="complete_idx_ef_1_prt_p2" IsClustered="false" IndexType="B-tree" KeyColumns="4,5" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/OverlappingHomogenousIndexesOnRoot-ANDPredicate-HEAP.mdp
+++ b/src/backend/gporca/data/dxl/minidump/OverlappingHomogenousIndexesOnRoot-ANDPredicate-HEAP.mdp
@@ -156,7 +156,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.1237555.1.0" Name="complete_idx_c_1_prt_p2" IsClustered="false" IndexType="B-tree" KeyColumns="2" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="0.1237555.1.0" Name="complete_idx_c_1_prt_p2" IsClustered="false" IndexType="B-tree" KeyColumns="2" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
@@ -166,7 +166,7 @@
       <dxl:ColumnStatistics Mdid="1.1237500.1.0.10" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.1237500.1.0.3" Name="d" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.1237500.1.0.2" Name="c" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:Index Mdid="0.1237597.1.0" Name="complete_idx_cd_1_prt_p2" IsClustered="false" IndexType="B-tree" KeyColumns="2,3" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="0.1237597.1.0" Name="complete_idx_cd_1_prt_p2" IsClustered="false" IndexType="B-tree" KeyColumns="2,3" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/OverlappingHomogenousIndexesOnRoot-HEAP.mdp
+++ b/src/backend/gporca/data/dxl/minidump/OverlappingHomogenousIndexesOnRoot-HEAP.mdp
@@ -156,7 +156,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.1237555.1.0" Name="complete_idx_c_1_prt_p2" IsClustered="false" IndexType="B-tree" KeyColumns="2" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="0.1237555.1.0" Name="complete_idx_c_1_prt_p2" IsClustered="false" IndexType="B-tree" KeyColumns="2" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
@@ -166,7 +166,7 @@
       <dxl:ColumnStatistics Mdid="1.1237500.1.0.10" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.1237500.1.0.2" Name="c" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.1237500.1.0.3" Name="d" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:Index Mdid="0.1237597.1.0" Name="complete_idx_cd_1_prt_p2" IsClustered="false" IndexType="B-tree" KeyColumns="2,3" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="0.1237597.1.0" Name="complete_idx_cd_1_prt_p2" IsClustered="false" IndexType="B-tree" KeyColumns="2,3" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/PartConstraint-WhenDefaultPartsAndIndices.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartConstraint-WhenDefaultPartsAndIndices.mdp
@@ -1721,7 +1721,7 @@ EXPLAIN SELECT * FROM date_parts WHERE month BETWEEN 1 AND 4;
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="3650"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.3749921.1.0" Name="date_parts_ind_1_prt_outlying_years_2_prt_q1_3_prt_other_days" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11">
+      <dxl:Index Mdid="0.3749921.1.0" Name="date_parts_ind_1_prt_outlying_years_2_prt_q1_3_prt_other_days" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/PartConstraint-WhenIndicesAndNoDefaultParts.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartConstraint-WhenIndicesAndNoDefaultParts.mdp
@@ -1150,7 +1150,7 @@ EXPLAIN SELECT * FROM date_parts WHERE year BETWEEN 2002 AND 2003;
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.3748065.1.0" Name="date_parts_ind_1_prt_1_2_prt_q1_3_prt_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11">
+      <dxl:Index Mdid="0.3748065.1.0" Name="date_parts_ind_1_prt_1_2_prt_q1_3_prt_1" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-ComplexRangePredicate-DefaultPart.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-ComplexRangePredicate-DefaultPart.mdp
@@ -74,7 +74,7 @@
       <dxl:GPDBFunc Mdid="0.6086.1.0" Name="gp_partition_inverse" ReturnsSet="true" Stability="Volatile" IsStrict="true">
         <dxl:ResultType Mdid="0.2249.1.0"/>
       </dxl:GPDBFunc>
-      <dxl:Index Mdid="0.310609.1.0" Name="p_1_prt_3_ab" IsClustered="false" KeyColumns="0,1" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.310609.1.0" Name="p_1_prt_3_ab" IsClustered="false" KeyColumns="0,1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
@@ -84,7 +84,7 @@
           <dxl:Partition Mdid="6.310609003.1.0"/>
         </dxl:Partitions>
       </dxl:Index>
-      <dxl:Index Mdid="0.327405.1.0" Name="p_1_prt_extra_a_key" IsClustered="false" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.327405.1.0" Name="p_1_prt_extra_a_key" IsClustered="false" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-IndexOnDefPartOnly.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-IndexOnDefPartOnly.mdp
@@ -1129,7 +1129,7 @@ SELECT * FROM pt_lt_tab WHERE col2 = 15 ORDER BY col2,col3 LIMIT 5;
         <dxl:SumAgg Mdid="0.2114.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.8685870.1.0" Name="idx1" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="0.8685870.1.0" Name="idx1" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1988.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-MultiWayJoinWithDPE.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-MultiWayJoinWithDPE.mdp
@@ -1046,7 +1046,7 @@
       <dxl:ColumnStatistics Mdid="1.810130.1.1.4" Name="hd_vehicle_count" Width="4.000000"/>
       <dxl:ColumnStatistics Mdid="1.810176.1.1.5" Name="xmin" Width="4.000000"/>
       <dxl:ColumnStatistics Mdid="1.810176.1.1.4" Name="ctid" Width="6.000000"/>
-      <dxl:Index Mdid="0.812178.1.0" Name="date_dim_1_prt_p1_1_pkey" IsClustered="false" KeyColumns="0,6" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.812178.1.0" Name="date_dim_1_prt_p1_1_pkey" IsClustered="false" KeyColumns="0,6" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
@@ -1378,7 +1378,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="7200"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.818378.1.0" Name="household_demographics_pkey" IsClustered="false" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11">
+      <dxl:Index Mdid="0.818378.1.0" Name="household_demographics_pkey" IsClustered="false" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/PartTbl-NEqPredicate.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PartTbl-NEqPredicate.mdp
@@ -242,7 +242,7 @@
           </dxl:And>
         </dxl:PartConstraint>
       </dxl:Relation>
-      <dxl:Index Mdid="0.310609.1.0" Name="p_1_prt_3_ab" IsClustered="false" IsPartial="true" KeyColumns="0,1" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.310609.1.0" Name="p_1_prt_3_ab" IsClustered="false" IsPartial="true" KeyColumns="0,1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
@@ -255,7 +255,7 @@
           <dxl:Partition Mdid="6.310609002.1.0"/>
         </dxl:Partitions>
       </dxl:Index>
-      <dxl:Index Mdid="0.327405.1.0" Name="p_1_prt_extra_a_key" IsClustered="false" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.327405.1.0" Name="p_1_prt_extra_a_key" IsClustered="false" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/PredicateWithConjunctsAndDisjuncts.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PredicateWithConjunctsAndDisjuncts.mdp
@@ -40,7 +40,7 @@
       <dxl:TraceFlags Value="102001,102002,102003,102024,102025,102074,102119,102120,102128,102131,102132,102133,102134,102135,102136,102140,102141,102142,102143,102144,103001,103014,103015,103022,103027,103033,104003,104004,104005,105000"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:Index Mdid="0.16523.1.0" Name="t1_g_h" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="6,7" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14">
+      <dxl:Index Mdid="0.16523.1.0" Name="t1_g_h" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="6,7" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.7027.1.0"/>
           <dxl:Opfamily Mdid="0.7027.1.0"/>
@@ -940,7 +940,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.16540.1.0" Name="t1_b_c_d" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1,2,3" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14">
+      <dxl:Index Mdid="0.16540.1.0" Name="t1_b_c_d" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1,2,3" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.7027.1.0"/>
           <dxl:Opfamily Mdid="0.7027.1.0"/>
@@ -2222,7 +2222,7 @@
         </dxl:IndexInfoList>
         <dxl:CheckConstraints/>
       </dxl:Relation>
-      <dxl:Index Mdid="0.16506.1.0" Name="t1_b" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14">
+      <dxl:Index Mdid="0.16506.1.0" Name="t1_b" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.7027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/PredicateWithConjunctsOfDisjuncts.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PredicateWithConjunctsOfDisjuncts.mdp
@@ -106,7 +106,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.16662.1.0" Name="t1_b" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14">
+      <dxl:Index Mdid="0.16662.1.0" Name="t1_b" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.7027.1.0"/>
         </dxl:Opfamilies>
@@ -588,7 +588,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.16679.1.0" Name="t1_b_c_d" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1,2,3" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14">
+      <dxl:Index Mdid="0.16679.1.0" Name="t1_b_c_d" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1,2,3" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.7027.1.0"/>
           <dxl:Opfamily Mdid="0.7027.1.0"/>
@@ -997,7 +997,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="9999"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.16696.1.0" Name="t1_g_h" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="6,7" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14">
+      <dxl:Index Mdid="0.16696.1.0" Name="t1_g_h" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="6,7" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.7027.1.0"/>
           <dxl:Opfamily Mdid="0.7027.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/PredicateWithLongConjunction.mdp
+++ b/src/backend/gporca/data/dxl/minidump/PredicateWithLongConjunction.mdp
@@ -35,7 +35,7 @@
       <dxl:TraceFlags Value="102001,102002,102003,102024,102025,102074,102119,102120,102128,102131,102132,102133,102134,102135,102136,102140,102141,102142,102143,102144,103001,103014,103015,103022,103027,103033,104003,104004,104005,105000"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:Index Mdid="0.16783.1.0" Name="t1_b_c_d" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1,2,3" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14">
+      <dxl:Index Mdid="0.16783.1.0" Name="t1_b_c_d" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1,2,3" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.7027.1.0"/>
           <dxl:Opfamily Mdid="0.7027.1.0"/>
@@ -936,7 +936,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.16800.1.0" Name="t1_g_h" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="6,7" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14">
+      <dxl:Index Mdid="0.16800.1.0" Name="t1_g_h" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="6,7" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.7027.1.0"/>
           <dxl:Opfamily Mdid="0.7027.1.0"/>
@@ -3021,7 +3021,7 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="9999"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.16766.1.0" Name="t1_b" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14">
+      <dxl:Index Mdid="0.16766.1.0" Name="t1_b" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.7027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/QueryMismatchedDistribution-DynamicIndexScan.mdp
+++ b/src/backend/gporca/data/dxl/minidump/QueryMismatchedDistribution-DynamicIndexScan.mdp
@@ -771,7 +771,7 @@ explain select i, count(j) from pt2  where k=5 group by i;
       <dxl:GPDBFunc Mdid="0.6084.1.0" Name="gp_partition_selection" ReturnsSet="false" Stability="Stable" IsStrict="true">
         <dxl:ResultType Mdid="0.26.1.0"/>
       </dxl:GPDBFunc>
-      <dxl:Index Mdid="0.1695490.1.0" Name="pt2_idx_1_prt_1" IsClustered="false" IndexType="B-tree" KeyColumns="2" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.1695490.1.0" Name="pt2_idx_1_prt_1" IsClustered="false" IndexType="B-tree" KeyColumns="2" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/Select-Proj-OuterJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Select-Proj-OuterJoin.mdp
@@ -329,12 +329,12 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.2690.1.0" Name="pg_proc_oid_index" IsClustered="false" KeyColumns="24" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30">
+      <dxl:Index Mdid="0.2690.1.0" Name="pg_proc_oid_index" IsClustered="false" KeyColumns="24" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.2684.1.0" Name="pg_namespace_nspname_index" IsClustered="false" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="0.2684.1.0" Name="pg_namespace_nspname_index" IsClustered="false" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1986.1.0"/>
         </dxl:Opfamilies>
@@ -507,14 +507,14 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.2691.1.0" Name="pg_proc_proname_args_nsp_index" IsClustered="false" KeyColumns="0,12,1" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30">
+      <dxl:Index Mdid="0.2691.1.0" Name="pg_proc_proname_args_nsp_index" IsClustered="false" KeyColumns="0,12,1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1986.1.0"/>
           <dxl:Opfamily Mdid="0.1991.1.0"/>
           <dxl:Opfamily Mdid="0.1989.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.2685.1.0" Name="pg_namespace_oid_index" IsClustered="false" KeyColumns="4" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="0.2685.1.0" Name="pg_namespace_oid_index" IsClustered="false" KeyColumns="4" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1089.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/SelectOnCastedCol.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SelectOnCastedCol.mdp
@@ -967,7 +967,7 @@
         <dxl:SumAgg Mdid="0.2108.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.17091.1.0" Name="customer_address_pkey" IsClustered="false" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19">
+      <dxl:Index Mdid="0.17091.1.0" Name="customer_address_pkey" IsClustered="false" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/SingleColumnHomogenousIndexOnRoot-AO.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SingleColumnHomogenousIndexOnRoot-AO.mdp
@@ -282,7 +282,7 @@
       <dxl:ColumnStatistics Mdid="1.1237409.1.0.2" Name="c" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.1237409.1.0.5" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.1237409.1.0.4" Name="tableoid" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:Index Mdid="0.1237476.1.0" Name="complete_idx_1_prt_p2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="0,1,2,3,4,5">
+      <dxl:Index Mdid="0.1237476.1.0" Name="complete_idx_1_prt_p2" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="2" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/SingleColumnHomogenousIndexOnRoot-HEAP.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SingleColumnHomogenousIndexOnRoot-HEAP.mdp
@@ -27,7 +27,7 @@
       <dxl:TraceFlags Value="102001,102002,102003,102120,102144,103001,103014,103015,103022,103027,103033,104003,104004,104005,105000"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:Index Mdid="0.1237378.1.0" Name="complete_idx_1_prt_p2" IsClustered="false" IndexType="B-tree" KeyColumns="2" IncludedColumns="0,1,2,3,4,5,6,7,8,9">
+      <dxl:Index Mdid="0.1237378.1.0" Name="complete_idx_1_prt_p2" IsClustered="false" IndexType="B-tree" KeyColumns="2" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/Stat-Derivation-Leaf-Pattern.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Stat-Derivation-Leaf-Pattern.mdp
@@ -95,7 +95,7 @@ AND
         <dxl:ResultType Mdid="0.20.1.0"/>
         <dxl:IntermediateResultType Mdid="0.20.1.0"/>
       </dxl:GPDBAgg>
-      <dxl:Index Mdid="0.6029.1.0" Name="pg_authid_rolresqueue_index" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="11" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24">
+      <dxl:Index Mdid="0.6029.1.0" Name="pg_authid_rolresqueue_index" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="11" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1989.1.0"/>
         </dxl:Opfamilies>
@@ -426,12 +426,12 @@ AND
           <dxl:Opfamily Mdid="0.3028.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.3307.1.0" Name="pg_foreign_data_wrapper_name_index" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12">
+      <dxl:Index Mdid="0.3307.1.0" Name="pg_foreign_data_wrapper_name_index" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1986.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.3306.1.0" Name="pg_foreign_data_wrapper_oid_index" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="6" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12">
+      <dxl:Index Mdid="0.3306.1.0" Name="pg_foreign_data_wrapper_oid_index" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="6" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1989.1.0"/>
         </dxl:Opfamilies>
@@ -621,12 +621,12 @@ AND
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.2677.1.0" Name="pg_authid_oid_index" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="18" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24">
+      <dxl:Index Mdid="0.2677.1.0" Name="pg_authid_oid_index" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="18" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1989.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.2676.1.0" Name="pg_authid_rolname_index" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24">
+      <dxl:Index Mdid="0.2676.1.0" Name="pg_authid_rolname_index" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1986.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/SubqInIndexPred.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SubqInIndexPred.mdp
@@ -140,7 +140,7 @@ ON a = c
           <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
         </dxl:DistrOpfamilies>
       </dxl:Relation>
-      <dxl:Index Mdid="0.305420.1.0" Name="idx_abuela_aaa" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0,1" IncludedColumns="0,1,2,3,4">
+      <dxl:Index Mdid="0.305420.1.0" Name="idx_abuela_aaa" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0,1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/TPCDS-39-InnerJoin-JoinEstimate.mdp
+++ b/src/backend/gporca/data/dxl/minidump/TPCDS-39-InnerJoin-JoinEstimate.mdp
@@ -9,7 +9,7 @@
       <dxl:TraceFlags Value="101013,102001,102002,102003,102144,103001,103027,103033"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:Index Mdid="0.32912.1.0" Name="date_dim_pkey" IsClustered="false" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.32912.1.0" Name="date_dim_pkey" IsClustered="false" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
@@ -67,7 +67,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.33600.1.0" Name="index_33600" IsClustered="false" KeyColumns="1" IncludedColumns="1">
+      <dxl:Index Mdid="0.33600.1.0" Name="index_33600" IsClustered="false" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/Tpcds-10TB-Q37-NoIndexJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Tpcds-10TB-Q37-NoIndexJoin.mdp
@@ -28,7 +28,7 @@ select  i_item_id
       <dxl:TraceFlags Value="103027,101013,102120,103001,103014,103015,103026"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:Index Mdid="0.42129794.1.0" Name="item_idx03" IsClustered="false" IndexType="B-tree" KeyColumns="11" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28">
+      <dxl:Index Mdid="0.42129794.1.0" Name="item_idx03" IsClustered="false" IndexType="B-tree" KeyColumns="11" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>
@@ -4393,7 +4393,7 @@ select  i_item_id
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.42129547.1.0" Name="inventory_idx02_1_prt_p1" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="0.42129547.1.0" Name="inventory_idx02_1_prt_p1" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>
@@ -4439,7 +4439,7 @@ select  i_item_id
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.42120598.1.0" Name="catalog_sales_idx02_1_prt_p1" IsClustered="false" IndexType="B-tree" KeyColumns="3" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40">
+      <dxl:Index Mdid="0.42120598.1.0" Name="catalog_sales_idx02_1_prt_p1" IsClustered="false" IndexType="B-tree" KeyColumns="3" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>
@@ -4488,12 +4488,12 @@ select  i_item_id
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.42129813.1.0" Name="item_idx04" IsClustered="false" IndexType="B-tree" KeyColumns="9" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28">
+      <dxl:Index Mdid="0.42129813.1.0" Name="item_idx04" IsClustered="false" IndexType="B-tree" KeyColumns="9" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.42120465.1.0" Name="catalog_sales_idx01_1_prt_p1" IsClustered="false" IndexType="B-tree" KeyColumns="4" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40">
+      <dxl:Index Mdid="0.42120465.1.0" Name="catalog_sales_idx01_1_prt_p1" IsClustered="false" IndexType="B-tree" KeyColumns="4" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>
@@ -5971,7 +5971,7 @@ select  i_item_id
           <dxl:UpperBound Closed="true" TypeMdid="0.1700.1.0" Value="AAAADAAAAgBjAKwm" DoubleValue="99.990000"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.42112159.1.0" Name="date_dim_1_prt_p1_1_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0,6" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.42112159.1.0" Name="date_dim_1_prt_p1_1_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0,6" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
@@ -6021,7 +6021,7 @@ select  i_item_id
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.42125595.1.0" Name="date_dim_idx02_1_prt_p1_1" IsClustered="false" IndexType="B-tree" KeyColumns="4" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.42125595.1.0" Name="date_dim_idx02_1_prt_p1_1" IsClustered="false" IndexType="B-tree" KeyColumns="4" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>
@@ -6070,7 +6070,7 @@ select  i_item_id
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.42120731.1.0" Name="catalog_sales_idx03_1_prt_p1" IsClustered="false" IndexType="B-tree" KeyColumns="5" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40">
+      <dxl:Index Mdid="0.42120731.1.0" Name="catalog_sales_idx03_1_prt_p1" IsClustered="false" IndexType="B-tree" KeyColumns="5" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>
@@ -6089,7 +6089,7 @@ select  i_item_id
           <dxl:Partition Mdid="6.42120731005.1.0"/>
         </dxl:Partitions>
       </dxl:Index>
-      <dxl:Index Mdid="0.42129433.1.0" Name="inventory_idx01_1_prt_p1" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="0.42129433.1.0" Name="inventory_idx01_1_prt_p1" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>
@@ -6108,7 +6108,7 @@ select  i_item_id
           <dxl:Partition Mdid="6.42129433005.1.0"/>
         </dxl:Partitions>
       </dxl:Index>
-      <dxl:Index Mdid="0.42120997.1.0" Name="catalog_sales_idx05_1_prt_p1" IsClustered="false" IndexType="B-tree" KeyColumns="15" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40">
+      <dxl:Index Mdid="0.42120997.1.0" Name="catalog_sales_idx05_1_prt_p1" IsClustered="false" IndexType="B-tree" KeyColumns="15" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>
@@ -6139,7 +6139,7 @@ select  i_item_id
           <dxl:Opfamily Mdid="0.3018.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.42120864.1.0" Name="catalog_sales_idx04_1_prt_p1" IsClustered="false" IndexType="B-tree" KeyColumns="11" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40">
+      <dxl:Index Mdid="0.42120864.1.0" Name="catalog_sales_idx04_1_prt_p1" IsClustered="false" IndexType="B-tree" KeyColumns="11" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>
@@ -8165,7 +8165,7 @@ select  i_item_id
       </dxl:ColumnStatistics>
       <dxl:ColumnStatistics Mdid="1.42110028.1.1.7" Name="xmax" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:ColumnStatistics Mdid="1.42110028.1.1.6" Name="cmin" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:Index Mdid="0.42121263.1.0" Name="catalog_sales_idx07_1_prt_p1" IsClustered="false" IndexType="B-tree" KeyColumns="13" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40">
+      <dxl:Index Mdid="0.42121263.1.0" Name="catalog_sales_idx07_1_prt_p1" IsClustered="false" IndexType="B-tree" KeyColumns="13" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>
@@ -8185,7 +8185,7 @@ select  i_item_id
         </dxl:Partitions>
       </dxl:Index>
       <dxl:RelationStatistics Mdid="2.42110250.1.1" Name="item" Rows="18000.000000" EmptyRelation="false"/>
-      <dxl:Index Mdid="0.42121130.1.0" Name="catalog_sales_idx06_1_prt_p1" IsClustered="false" IndexType="B-tree" KeyColumns="17" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40">
+      <dxl:Index Mdid="0.42121130.1.0" Name="catalog_sales_idx06_1_prt_p1" IsClustered="false" IndexType="B-tree" KeyColumns="17" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1980.1.0"/>
         </dxl:Opfamilies>
@@ -8204,7 +8204,7 @@ select  i_item_id
           <dxl:Partition Mdid="6.42121130005.1.0"/>
         </dxl:Partitions>
       </dxl:Index>
-      <dxl:Index Mdid="0.42129832.1.0" Name="item_idx05" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28">
+      <dxl:Index Mdid="0.42129832.1.0" Name="item_idx05" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>
@@ -8412,7 +8412,7 @@ select  i_item_id
         <dxl:CheckConstraints/>
       </dxl:Relation>
       <dxl:RelationStatistics Mdid="2.42101810.1.1" Name="catalog_sales" Rows="14745100288.000000" EmptyRelation="false"/>
-      <dxl:Index Mdid="0.42121396.1.0" Name="catalog_sales_idx08_1_prt_p1" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40">
+      <dxl:Index Mdid="0.42121396.1.0" Name="catalog_sales_idx08_1_prt_p1" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>
@@ -9353,7 +9353,7 @@ select  i_item_id
           </dxl:And>
         </dxl:PartConstraint>
       </dxl:Relation>
-      <dxl:Index Mdid="0.42118452.1.0" Name="inventory_1_prt_p1_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0,1,2" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="0.42118452.1.0" Name="inventory_1_prt_p1_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0,1,2" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.0.0.0"/>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
@@ -10296,7 +10296,7 @@ select  i_item_id
           </dxl:And>
         </dxl:PartConstraint>
       </dxl:Relation>
-      <dxl:Index Mdid="0.42121776.1.0" Name="date_dim_idx01_1_prt_p1_1" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.42121776.1.0" Name="date_dim_idx01_1_prt_p1_1" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>
@@ -12205,7 +12205,7 @@ select  i_item_id
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.42121529.1.0" Name="catalog_sales_idx09_1_prt_p1" IsClustered="false" IndexType="B-tree" KeyColumns="14" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40">
+      <dxl:Index Mdid="0.42121529.1.0" Name="catalog_sales_idx09_1_prt_p1" IsClustered="false" IndexType="B-tree" KeyColumns="14" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>
@@ -12224,7 +12224,7 @@ select  i_item_id
           <dxl:Partition Mdid="6.42121529005.1.0"/>
         </dxl:Partitions>
       </dxl:Index>
-      <dxl:Index Mdid="0.42129851.1.0" Name="item_idx06" IsClustered="false" IndexType="B-tree" KeyColumns="14" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28">
+      <dxl:Index Mdid="0.42129851.1.0" Name="item_idx06" IsClustered="false" IndexType="B-tree" KeyColumns="14" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.426.1.0"/>
         </dxl:Opfamilies>
@@ -15751,7 +15751,7 @@ select  i_item_id
           </dxl:And>
         </dxl:PartConstraint>
       </dxl:Relation>
-      <dxl:Index Mdid="0.42118607.1.0" Name="item_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28">
+      <dxl:Index Mdid="0.42118607.1.0" Name="item_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>
@@ -18838,7 +18838,7 @@ select  i_item_id
           <dxl:Opfamily Mdid="0.3032.1.0"/>
         </dxl:Opfamilies>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.42129756.1.0" Name="item_idx01" IsClustered="false" IndexType="B-tree" KeyColumns="7" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28">
+      <dxl:Index Mdid="0.42129756.1.0" Name="item_idx01" IsClustered="false" IndexType="B-tree" KeyColumns="7" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>
@@ -21339,12 +21339,12 @@ select  i_item_id
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="5"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.42129775.1.0" Name="item_idx02" IsClustered="false" IndexType="B-tree" KeyColumns="12" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28">
+      <dxl:Index Mdid="0.42129775.1.0" Name="item_idx02" IsClustered="false" IndexType="B-tree" KeyColumns="12" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.426.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.42111849.1.0" Name="catalog_sales_1_prt_p1_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="15,17,0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40">
+      <dxl:Index Mdid="0.42111849.1.0" Name="catalog_sales_1_prt_p1_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="15,17,0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.0.0.0"/>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
@@ -22721,7 +22721,7 @@ select  i_item_id
           <dxl:UpperBound Closed="true" TypeMdid="0.1082.1.0" Value="mQIAAA==" DoubleValue="57456000000000.000000"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.42129661.1.0" Name="inventory_idx03_1_prt_p1" IsClustered="false" IndexType="B-tree" KeyColumns="2" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10">
+      <dxl:Index Mdid="0.42129661.1.0" Name="inventory_idx03_1_prt_p1" IsClustered="false" IndexType="B-tree" KeyColumns="2" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/Tpcds-NonPart-Q70a.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Tpcds-NonPart-Q70a.mdp
@@ -56,12 +56,12 @@ with results as
       <dxl:TraceFlags Value="102001,102002,102003,102120,102144,103001,103014,103015,103022,103027,103033,105000"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
-      <dxl:Index Mdid="0.8404352.1.0" Name="store_pkey" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35">
+      <dxl:Index Mdid="0.8404352.1.0" Name="store_pkey" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.8404104.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.8404104.1.0" Name="date_dim_pkey" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>
@@ -6448,7 +6448,7 @@ with results as
         <dxl:ResultType Mdid="0.20.1.0"/>
         <dxl:IntermediateResultType Mdid="0.20.1.0"/>
       </dxl:GPDBAgg>
-      <dxl:Index Mdid="0.8404414.1.0" Name="store_sales_pkey" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="2,9" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29">
+      <dxl:Index Mdid="0.8404414.1.0" Name="store_sales_pkey" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="2,9" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
           <dxl:Opfamily Mdid="0.1980.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/UnionAll.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UnionAll.mdp
@@ -92,7 +92,7 @@
         <dxl:SumAgg Mdid="0.2114.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.17952.1.0" Name="index_17952" IsClustered="false" KeyColumns="1" IncludedColumns="1">
+      <dxl:Index Mdid="0.17952.1.0" Name="index_17952" IsClustered="false" KeyColumns="1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/UnionOfDQAQueries.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UnionOfDQAQueries.mdp
@@ -150,7 +150,7 @@
         <dxl:ResultType Mdid="0.20.1.0"/>
         <dxl:IntermediateResultType Mdid="0.20.1.0"/>
       </dxl:GPDBAgg>
-      <dxl:Index Mdid="0.471042.1.0" Name="sale_pkey" IsClustered="false" KeyColumns="0,1,2" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12">
+      <dxl:Index Mdid="0.471042.1.0" Name="sale_pkey" IsClustered="false" KeyColumns="0,1,2" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/UnnestSQJoins.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UnnestSQJoins.mdp
@@ -131,13 +131,13 @@ WHERE
         <dxl:Commutator Mdid="0.410.1.0"/>
         <dxl:InverseOp Mdid="0.411.1.0"/>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.2654.1.0" Name="pg_amop_opr_opc_index" IsClustered="false" KeyColumns="4,0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11">
+      <dxl:Index Mdid="0.2654.1.0" Name="pg_amop_opr_opc_index" IsClustered="false" KeyColumns="4,0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1989.1.0"/>
           <dxl:Opfamily Mdid="0.1989.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.2652.1.0" Name="pg_am_oid_index" IsClustered="false" KeyColumns="26" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32">
+      <dxl:Index Mdid="0.2652.1.0" Name="pg_am_oid_index" IsClustered="false" KeyColumns="26" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
@@ -501,26 +501,26 @@ WHERE
         <dxl:Commutator Mdid="0.1869.1.0"/>
         <dxl:InverseOp Mdid="0.1862.1.0"/>
       </dxl:GPDBScalarOp>
-      <dxl:Index Mdid="0.2653.1.0" Name="pg_amop_opc_strat_index" IsClustered="false" KeyColumns="0,1,2" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11">
+      <dxl:Index Mdid="0.2653.1.0" Name="pg_amop_opc_strat_index" IsClustered="false" KeyColumns="0,1,2" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1989.1.0"/>
           <dxl:Opfamily Mdid="0.1989.1.0"/>
           <dxl:Opfamily Mdid="0.1976.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.2651.1.0" Name="pg_am_name_index" IsClustered="false" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32">
+      <dxl:Index Mdid="0.2651.1.0" Name="pg_am_name_index" IsClustered="false" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1986.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.2686.1.0" Name="pg_opclass_am_name_nsp_index" IsClustered="false" KeyColumns="0,1,2" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14">
+      <dxl:Index Mdid="0.2686.1.0" Name="pg_opclass_am_name_nsp_index" IsClustered="false" KeyColumns="0,1,2" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1989.1.0"/>
           <dxl:Opfamily Mdid="0.1986.1.0"/>
           <dxl:Opfamily Mdid="0.1989.1.0"/>
         </dxl:Opfamilies>
       </dxl:Index>
-      <dxl:Index Mdid="0.2687.1.0" Name="pg_opclass_oid_index" IsClustered="false" KeyColumns="8" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14">
+      <dxl:Index Mdid="0.2687.1.0" Name="pg_opclass_oid_index" IsClustered="false" KeyColumns="8" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1989.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/UnsupportedStatsPredicate.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UnsupportedStatsPredicate.mdp
@@ -278,7 +278,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.2662.1.0" Name="pg_class_oid_index" IsClustered="false" KeyColumns="31" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37">
+      <dxl:Index Mdid="0.2662.1.0" Name="pg_class_oid_index" IsClustered="false" KeyColumns="31" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>
@@ -535,7 +535,7 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:Index Mdid="0.2663.1.0" Name="pg_class_relname_nsp_index" IsClustered="false" KeyColumns="0,1" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37">
+      <dxl:Index Mdid="0.2663.1.0" Name="pg_class_relname_nsp_index" IsClustered="false" KeyColumns="0,1" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/UpdateUniqueConstraint-2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/UpdateUniqueConstraint-2.mdp
@@ -99,7 +99,7 @@
         <dxl:ResultType Mdid="0.20.1.0"/>
         <dxl:IntermediateResultType Mdid="0.20.1.0"/>
       </dxl:GPDBAgg>
-      <dxl:Index Mdid="0.284658.1.0" Name="r_pkey" IsClustered="false" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8">
+      <dxl:Index Mdid="0.284658.1.0" Name="r_pkey" IsClustered="false" KeyColumns="0" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.3027.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/minidump/retail_28.mdp
+++ b/src/backend/gporca/data/dxl/minidump/retail_28.mdp
@@ -2139,7 +2139,7 @@ ORDER BY to_char(order_datetime,'YYYY-Q')
           <dxl:UpperBound Closed="true" TypeMdid="0.1043.1.0" Value="AAAADTU4OTk1NTc3Mg==" LintValue="759579644"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:Index Mdid="0.4449193.1.0" Name="order_lineitems_cust_id_1_prt_default_part" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="4" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+      <dxl:Index Mdid="0.4449193.1.0" Name="order_lineitems_cust_id_1_prt_default_part" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="4" IncludedColumns="">
         <dxl:Opfamilies>
           <dxl:Opfamily Mdid="0.1978.1.0"/>
         </dxl:Opfamilies>

--- a/src/backend/gporca/data/dxl/parse_tests/q26-Metadata.xml
+++ b/src/backend/gporca/data/dxl/parse_tests/q26-Metadata.xml
@@ -37,7 +37,7 @@
       </dxl:IndexInfoList>
       <dxl:CheckConstraints/>
     </dxl:Relation>
-    <dxl:Index Mdid="0.2345.2.1" Name="T_a" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="1">
+    <dxl:Index Mdid="0.2345.2.1" Name="T_a" IsClustered="false" IndexType="B-tree" KeyColumns="1" IncludedColumns="">
       <dxl:Opfamilies/>
     </dxl:Index>
     <dxl:Relation Mdid="6.1258.5.1" Name="S" IsTemporary="true" StorageType="AppendOnly, Column-oriented" DistributionPolicy="Hash" DistributionColumns="0,1" Keys="0;0,1" PartitionColumns="1">
@@ -122,7 +122,7 @@
         </dxl:And>
       </dxl:PartConstraint>
     </dxl:Relation>
-    <dxl:Index Mdid="0.812178.1.0" Name="date_dim_1_prt_p1_1_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0,6" IncludedColumns="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34">
+    <dxl:Index Mdid="0.812178.1.0" Name="date_dim_1_prt_p1_1_pkey" IsClustered="false" IndexType="B-tree" KeyColumns="0,6" IncludedColumns="">
       <dxl:Opfamilies>
         <dxl:Opfamily Mdid="0.3027.1.0"/>
         <dxl:Opfamily Mdid="0.3027.1.0"/>
@@ -249,7 +249,7 @@
         <dxl:Ident ColId="2" ColName="B" TypeMdid="0.23.1.0"/>
       </dxl:Comparison>
     </dxl:CheckConstraint>
-    <dxl:Index Mdid="0.17027.1.0" Name="r_ind" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="0,1,2,3,4,5,6,7,8">
+    <dxl:Index Mdid="0.17027.1.0" Name="r_ind" IsClustered="false" IndexType="Bitmap" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
       <dxl:Opfamilies/>
     </dxl:Index>
     <dxl:Relation Mdid="6.378383.1.0" Name="ext_1" IsTemporary="false" StorageType="Foreign" DistributionPolicy="Random" Keys="10,4" ForeignServer="0.91908.1.0">

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformJoin2IndexApply.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformJoin2IndexApply.h
@@ -30,8 +30,7 @@ private:
 		CExpression *origJoinPred, CExpression *nodesToInsertAboveIndexGet,
 		CExpression *endOfNodesToInsertAboveIndexGet,
 		CTableDescriptor *ptabdescInner, CColRefSet *pcrsScalarExpr,
-		CColRefSet *outer_refs, CColRefSet *pcrsReqd, ULONG ulIndices,
-		CXformResult *pxfres);
+		CColRefSet *outer_refs, ULONG ulIndices, CXformResult *pxfres);
 
 	// helper to add IndexApply expression to given xform results container
 	// for homogeneous b-tree indexes
@@ -41,7 +40,7 @@ private:
 		CExpression *nodesToInsertAboveIndexGet,
 		CExpression *endOfNodesToInsertAboveIndexGet, CMDAccessor *md_accessor,
 		CExpressionArray *pdrgpexprConjuncts, CColRefSet *pcrsScalarExpr,
-		CColRefSet *outer_refs, CColRefSet *pcrsReqd, const IMDRelation *pmdrel,
+		CColRefSet *outer_refs, const IMDRelation *pmdrel,
 		const IMDIndex *pmdindex, CXformResult *pxfres);
 
 	// helper to add IndexApply expression to given xform results container

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformUtils.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformUtils.h
@@ -184,9 +184,8 @@ private:
 	static CExpression *PexprBuildBtreeIndexPlan(
 		CMemoryPool *mp, CMDAccessor *md_accessor, CExpression *pexprGet,
 		ULONG ulOriginOpId, CExpressionArray *pdrgpexprConds,
-		CColRefSet *pcrsReqd, CColRefSet *pcrsScalarExpr,
-		CColRefSet *outer_refs, const IMDIndex *pmdindex,
-		const IMDRelation *pmdrel);
+		CColRefSet *pcrsScalarExpr, CColRefSet *outer_refs,
+		const IMDIndex *pmdindex, const IMDRelation *pmdrel);
 
 	// create a dynamic operator for a btree index plan
 	static CLogical *
@@ -248,9 +247,9 @@ private:
 	static CExpression *PexprBitmapSelectBestIndex(
 		CMemoryPool *mp, CMDAccessor *md_accessor, CExpression *pexprPred,
 		CTableDescriptor *ptabdesc, const IMDRelation *pmdrel,
-		CColRefArray *pdrgpcrOutput, CColRefSet *pcrsReqd,
-		CColRefSet *pcrsOuterRefs, CExpression **ppexprRecheck,
-		CExpression **ppexprResidual, BOOL alsoConsiderBTreeIndexes);
+		CColRefArray *pdrgpcrOutput, CColRefSet *pcrsOuterRefs,
+		CExpression **ppexprRecheck, CExpression **ppexprResidual,
+		BOOL alsoConsiderBTreeIndexes);
 
 	// iterate over given hash map and return array of arrays of project elements sorted by the column id of the first entries
 	static CExpressionArrays *PdrgpdrgpexprSortedPrjElemsArray(
@@ -399,8 +398,8 @@ public:
 	// expression columns
 	static BOOL FIndexApplicable(
 		CMemoryPool *mp, const IMDIndex *pmdindex, const IMDRelation *pmdrel,
-		CColRefArray *pdrgpcrOutput, CColRefSet *pcrsReqd,
-		CColRefSet *pcrsScalar, IMDIndex::EmdindexType emdindtype,
+		CColRefArray *pdrgpcrOutput, CColRefSet *pcrsScalar,
+		IMDIndex::EmdindexType emdindtype,
 		IMDIndex::EmdindexType altindtype = IMDIndex::EmdindSentinel);
 
 	// check whether a CTE should be inlined
@@ -443,13 +442,13 @@ public:
 	static CExpression *
 	PexprLogicalIndexGet(CMemoryPool *mp, CMDAccessor *md_accessor,
 						 CExpression *pexprGet, ULONG ulOriginOpId,
-						 CExpressionArray *pdrgpexprConds, CColRefSet *pcrsReqd,
+						 CExpressionArray *pdrgpexprConds,
 						 CColRefSet *pcrsScalarExpr, CColRefSet *outer_refs,
 						 const IMDIndex *pmdindex, const IMDRelation *pmdrel)
 	{
-		return PexprBuildBtreeIndexPlan(
-			mp, md_accessor, pexprGet, ulOriginOpId, pdrgpexprConds, pcrsReqd,
-			pcrsScalarExpr, outer_refs, pmdindex, pmdrel);
+		return PexprBuildBtreeIndexPlan(mp, md_accessor, pexprGet, ulOriginOpId,
+										pdrgpexprConds, pcrsScalarExpr,
+										outer_refs, pmdindex, pmdrel);
 	}
 
 	// helper for creating bitmap bool op expressions

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformUtils.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformUtils.h
@@ -70,7 +70,6 @@ private:
 	enum EIndexCols
 	{
 		EicKey,
-		EicIncluded,
 		EicKeyAndIncluded
 	};
 
@@ -382,6 +381,8 @@ public:
 										  const IMDIndex *pmdindex,
 										  const IMDRelation *pmdrel);
 
+	// return the set of key columns from the given array of columns which appear
+	// in the index key and included columns
 	static CColRefSet *PcrsIndexKeysAndIncludes(CMemoryPool *mp,
 												CColRefArray *colref_array,
 												const IMDIndex *pmdindex,
@@ -393,13 +394,6 @@ public:
 									 CColRefArray *colref_array,
 									 const IMDIndex *pmdindex,
 									 const IMDRelation *pmdrel);
-
-	// return the set of key columns from the given array of columns which appear
-	// in the index included columns
-	static CColRefSet *PcrsIndexIncludedCols(CMemoryPool *mp,
-											 CColRefArray *colref_array,
-											 const IMDIndex *pmdindex,
-											 const IMDRelation *pmdrel);
 
 	// check if an index is applicable given the required, output and scalar
 	// expression columns

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformUtils.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformUtils.h
@@ -70,7 +70,8 @@ private:
 	enum EIndexCols
 	{
 		EicKey,
-		EicIncluded
+		EicIncluded,
+		EicKeyAndIncluded
 	};
 
 	// create a logical assert for the not nullable columns of the given table
@@ -380,6 +381,11 @@ public:
 										  CColRefArray *colref_array,
 										  const IMDIndex *pmdindex,
 										  const IMDRelation *pmdrel);
+
+	static CColRefSet *PcrsIndexKeysAndIncludes(CMemoryPool *mp,
+												CColRefArray *colref_array,
+												const IMDIndex *pmdindex,
+												const IMDRelation *pmdrel);
 
 	// return the set of key columns from the given array of columns which appear
 	// in the index key columns

--- a/src/backend/gporca/libgpopt/src/xforms/CXformIndexGet2IndexOnlyScan.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformIndexGet2IndexOnlyScan.cpp
@@ -111,8 +111,8 @@ CXformIndexGet2IndexOnlyScan::Transform(CXformContext *pxfctxt,
 	GPOS_ASSERT(nullptr != pdrgpcrOutput);
 	pdrgpcrOutput->AddRef();
 
-	CColRefSet *matched_cols =
-		CXformUtils::PcrsIndexKeys(mp, pdrgpcrOutput, pmdindex, pmdrel);
+	CColRefSet *matched_cols = CXformUtils::PcrsIndexKeysAndIncludes(
+		mp, pdrgpcrOutput, pmdindex, pmdrel);
 	CColRefSet *output_cols = GPOS_NEW(mp) CColRefSet(mp);
 
 	// An index only scan is allowed iff each used output column reference also

--- a/src/backend/gporca/libgpopt/src/xforms/CXformJoin2IndexApply.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformJoin2IndexApply.cpp
@@ -124,8 +124,7 @@ CXformJoin2IndexApply::CreateHomogeneousIndexApplyAlternatives(
 		CreateHomogeneousBtreeIndexApplyAlternatives(
 			mp, joinOp, pexprOuter, pexprInner, pexprScalar, origJoinPred,
 			nodesToInsertAboveIndexGet, endOfNodesToInsertAboveIndexGet,
-			ptabdescInner, pcrsScalarExpr, outer_refs, pcrsReqd, ulIndices,
-			pxfres);
+			ptabdescInner, pcrsScalarExpr, outer_refs, ulIndices, pxfres);
 	}
 	else
 	{
@@ -156,8 +155,7 @@ CXformJoin2IndexApply::CreateHomogeneousBtreeIndexApplyAlternatives(
 	CExpression *origJoinPred, CExpression *nodesToInsertAboveIndexGet,
 	CExpression *endOfNodesToInsertAboveIndexGet,
 	CTableDescriptor *ptabdescInner, CColRefSet *pcrsScalarExpr,
-	CColRefSet *outer_refs, CColRefSet *pcrsReqd, ULONG ulIndices,
-	CXformResult *pxfres)
+	CColRefSet *outer_refs, ULONG ulIndices, CXformResult *pxfres)
 {
 	// array of expressions in the scalar expression
 	CExpressionArray *pdrgpexpr =
@@ -176,8 +174,8 @@ CXformJoin2IndexApply::CreateHomogeneousBtreeIndexApplyAlternatives(
 		CreateAlternativesForBtreeIndex(
 			mp, joinOp, pexprOuter, pexprInner, origJoinPred,
 			nodesToInsertAboveIndexGet, endOfNodesToInsertAboveIndexGet,
-			md_accessor, pdrgpexpr, pcrsScalarExpr, outer_refs, pcrsReqd,
-			pmdrel, pmdindex, pxfres);
+			md_accessor, pdrgpexpr, pcrsScalarExpr, outer_refs, pmdrel,
+			pmdindex, pxfres);
 	}
 
 	//clean-up
@@ -200,12 +198,12 @@ CXformJoin2IndexApply::CreateAlternativesForBtreeIndex(
 	CExpression *nodesToInsertAboveIndexGet,
 	CExpression *endOfNodesToInsertAboveIndexGet, CMDAccessor *md_accessor,
 	CExpressionArray *pdrgpexprConjuncts, CColRefSet *pcrsScalarExpr,
-	CColRefSet *outer_refs, CColRefSet *pcrsReqd, const IMDRelation *pmdrel,
-	const IMDIndex *pmdindex, CXformResult *pxfres)
+	CColRefSet *outer_refs, const IMDRelation *pmdrel, const IMDIndex *pmdindex,
+	CXformResult *pxfres)
 {
 	CExpression *pexprLogicalIndexGet = CXformUtils::PexprLogicalIndexGet(
 		mp, md_accessor, pexprInner, joinOp->UlOpId(), pdrgpexprConjuncts,
-		pcrsReqd, pcrsScalarExpr, outer_refs, pmdindex, pmdrel);
+		pcrsScalarExpr, outer_refs, pmdindex, pmdrel);
 	if (nullptr != pexprLogicalIndexGet)
 	{
 		// second child has residual predicates, create an apply of outer and inner

--- a/src/backend/gporca/libgpopt/src/xforms/CXformSelect2DynamicIndexGet.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformSelect2DynamicIndexGet.cpp
@@ -112,12 +112,7 @@ CXformSelect2DynamicIndexGet::Transform(CXformContext *pxfctxt,
 	GPOS_ASSERT(0 < pdrgpexpr->Size());
 
 	// derive the scalar and relational properties to build set of required columns
-	CColRefSet *pcrsOutput = pexpr->DeriveOutputColumns();
 	CColRefSet *pcrsScalarExpr = pexprScalar->DeriveUsedColumns();
-
-	CColRefSet *pcrsReqd = GPOS_NEW(mp) CColRefSet(mp);
-	pcrsReqd->Include(pcrsOutput);
-	pcrsReqd->Include(pcrsScalarExpr);
 
 	// find the indexes whose included columns meet the required columns
 	CMDAccessor *md_accessor = COptCtxt::PoctxtFromTLS()->Pmda();
@@ -130,7 +125,7 @@ CXformSelect2DynamicIndexGet::Transform(CXformContext *pxfctxt,
 		const IMDIndex *pmdindex = md_accessor->RetrieveIndex(pmdidIndex);
 		CExpression *pexprDynamicIndexGet = CXformUtils::PexprLogicalIndexGet(
 			mp, md_accessor, pexprRelational, pexpr->Pop()->UlOpId(), pdrgpexpr,
-			pcrsReqd, pcrsScalarExpr, nullptr /*outer_refs*/, pmdindex, pmdrel);
+			pcrsScalarExpr, nullptr /*outer_refs*/, pmdindex, pmdrel);
 		if (nullptr != pexprDynamicIndexGet)
 		{
 			// create a redundant SELECT on top of DynamicIndexGet to be able to use predicate in partition elimination
@@ -143,7 +138,6 @@ CXformSelect2DynamicIndexGet::Transform(CXformContext *pxfctxt,
 		}
 	}
 
-	pcrsReqd->Release();
 	pdrgpexpr->Release();
 }
 

--- a/src/backend/gporca/libgpopt/src/xforms/CXformSelect2IndexGet.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformSelect2IndexGet.cpp
@@ -98,12 +98,7 @@ CXformSelect2IndexGet::Transform(CXformContext *pxfctxt, CXformResult *pxfres,
 	GPOS_ASSERT(pdrgpexpr->Size() > 0);
 
 	// derive the scalar and relational properties to build set of required columns
-	CColRefSet *pcrsOutput = pexpr->DeriveOutputColumns();
 	CColRefSet *pcrsScalarExpr = pexprScalar->DeriveUsedColumns();
-
-	CColRefSet *pcrsReqd = GPOS_NEW(mp) CColRefSet(mp);
-	pcrsReqd->Include(pcrsOutput);
-	pcrsReqd->Include(pcrsScalarExpr);
 
 	// find the indexes whose included columns meet the required columns
 	CMDAccessor *md_accessor = COptCtxt::PoctxtFromTLS()->Pmda();
@@ -116,14 +111,13 @@ CXformSelect2IndexGet::Transform(CXformContext *pxfctxt, CXformResult *pxfres,
 		const IMDIndex *pmdindex = md_accessor->RetrieveIndex(pmdidIndex);
 		CExpression *pexprIndexGet = CXformUtils::PexprLogicalIndexGet(
 			mp, md_accessor, pexprRelational, pexpr->Pop()->UlOpId(), pdrgpexpr,
-			pcrsReqd, pcrsScalarExpr, nullptr /*outer_refs*/, pmdindex, pmdrel);
+			pcrsScalarExpr, nullptr /*outer_refs*/, pmdindex, pmdrel);
 		if (nullptr != pexprIndexGet)
 		{
 			pxfres->Add(pexprIndexGet);
 		}
 	}
 
-	pcrsReqd->Release();
 	pdrgpexpr->Release();
 }
 

--- a/src/backend/gporca/libgpopt/src/xforms/CXformUtils.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformUtils.cpp
@@ -1907,7 +1907,6 @@ BOOL
 CXformUtils::FIndexApplicable(CMemoryPool *mp, const IMDIndex *pmdindex,
 							  const IMDRelation *pmdrel,
 							  CColRefArray *pdrgpcrOutput,
-							  CColRefSet *pcrsReqd GPOS_UNUSED,
 							  CColRefSet *pcrsScalar,
 							  IMDIndex::EmdindexType emdindtype,
 							  IMDIndex::EmdindexType altindtype)
@@ -2397,15 +2396,16 @@ CXformUtils::FProcessGPDBAntiSemiHashJoin(
 //
 //---------------------------------------------------------------------------
 CExpression *
-CXformUtils::PexprBuildBtreeIndexPlan(
-	CMemoryPool *mp, CMDAccessor *md_accessor, CExpression *pexprGet,
-	ULONG ulOriginOpId, CExpressionArray *pdrgpexprConds, CColRefSet *pcrsReqd,
-	CColRefSet *pcrsScalarExpr, CColRefSet *outer_refs,
-	const IMDIndex *pmdindex, const IMDRelation *pmdrel)
+CXformUtils::PexprBuildBtreeIndexPlan(CMemoryPool *mp, CMDAccessor *md_accessor,
+									  CExpression *pexprGet, ULONG ulOriginOpId,
+									  CExpressionArray *pdrgpexprConds,
+									  CColRefSet *pcrsScalarExpr,
+									  CColRefSet *outer_refs,
+									  const IMDIndex *pmdindex,
+									  const IMDRelation *pmdrel)
 {
 	GPOS_ASSERT(nullptr != pexprGet);
 	GPOS_ASSERT(nullptr != pdrgpexprConds);
-	GPOS_ASSERT(nullptr != pcrsReqd);
 	GPOS_ASSERT(nullptr != pcrsScalarExpr);
 	GPOS_ASSERT(nullptr != pmdindex);
 	GPOS_ASSERT(nullptr != pmdrel);
@@ -2454,8 +2454,8 @@ CXformUtils::PexprBuildBtreeIndexPlan(
 			GPOS_NEW(mp) CWStringConst(mp, popGet->Name().Pstr()->GetBuffer());
 	}
 
-	if (!FIndexApplicable(mp, pmdindex, pmdrel, pdrgpcrOutput, pcrsReqd,
-						  pcrsScalarExpr, IMDIndex::EmdindBtree))
+	if (!FIndexApplicable(mp, pmdindex, pmdrel, pdrgpcrOutput, pcrsScalarExpr,
+						  IMDIndex::EmdindBtree))
 	{
 		GPOS_DELETE(alias);
 
@@ -2815,9 +2815,9 @@ CExpression *
 CXformUtils::PexprBitmapSelectBestIndex(
 	CMemoryPool *mp, CMDAccessor *md_accessor, CExpression *pexprPred,
 	CTableDescriptor *ptabdesc, const IMDRelation *pmdrel,
-	CColRefArray *pdrgpcrOutput, CColRefSet *pcrsReqd,
-	CColRefSet *pcrsOuterRefs, CExpression **ppexprRecheck,
-	CExpression **ppexprResidual, BOOL alsoConsiderBTreeIndexes)
+	CColRefArray *pdrgpcrOutput, CColRefSet *pcrsOuterRefs,
+	CExpression **ppexprRecheck, CExpression **ppexprResidual,
+	BOOL alsoConsiderBTreeIndexes)
 {
 	CColRefSet *pcrsScalar = pexprPred->DeriveUsedColumns();
 	ULONG ulBestIndex = 0;
@@ -2840,8 +2840,8 @@ CXformUtils::PexprBitmapSelectBestIndex(
 			md_accessor->RetrieveIndex(pmdrel->IndexMDidAt(ul));
 
 		if (CXformUtils::FIndexApplicable(mp, pmdindex, pmdrel, pdrgpcrOutput,
-										  pcrsReqd, pcrsScalar,
-										  IMDIndex::EmdindBitmap, altIndexType))
+										  pcrsScalar, IMDIndex::EmdindBitmap,
+										  altIndexType))
 		{
 			// found an applicable index
 			CExpressionArray *pdrgpexprScalar =
@@ -3110,7 +3110,7 @@ CXformUtils::CreateBitmapIndexProbesWithOrWithoutPredBreakdown(
 
 			// this also applies for the simple predicates of the form "ident op const" or "ident op const-array"
 			pexprBitmapLocal = PexprBitmapSelectBestIndex(
-				pmp, pmda, pexprPred, ptabdesc, pmdrel, pdrgpcrOutput, pcrsReqd,
+				pmp, pmda, pexprPred, ptabdesc, pmdrel, pdrgpcrOutput,
 				pcrsOuterRefs, &pexprRecheckLocal, &pexprResidualLocal,
 				isAPartialPredicateOrArrayCmp  // for partial preds or array comps
 				// we want to consider btree indexes

--- a/src/backend/gporca/libnaucrates/src/md/CMDIndexGPDB.cpp
+++ b/src/backend/gporca/libnaucrates/src/md/CMDIndexGPDB.cpp
@@ -411,7 +411,13 @@ BOOL
 CMDIndexGPDB::IsCompatible(const IMDScalarOp *md_scalar_op, ULONG key_pos) const
 {
 	GPOS_ASSERT(nullptr != md_scalar_op);
-	GPOS_ASSERT(key_pos < m_mdid_opfamilies_array->Size());
+
+	// In cover indexes the non-key "payload" should not be considered
+	// compatible with a predicate
+	if (key_pos >= m_mdid_opfamilies_array->Size())
+	{
+		return false;
+	}
 
 	// check if the index opfamily for the key at the given position is one of
 	// the families the scalar comparison belongs to

--- a/src/backend/gporca/server/CMakeLists.txt
+++ b/src/backend/gporca/server/CMakeLists.txt
@@ -387,6 +387,9 @@ OrderedAggUsingGroupColumnInDirectArg OrderedAgg_multiple_samecol OrderedAgg_wit
 OrderedAgg_array_fraction OrderedAgg_multiple_samecol_difforderespec OrderedAgg_with_nonconst_fraction
 OrderedAgg_skewed_data;
 
+CoverintIndexTest:
+CoveringIndex-1 CoveringIndex-2 CoveringIndex-3;
+
 CForeignPartTest:
 ForeignPartUniform PartForeignMixed PartForeignDifferentServer PartForeignDifferentExecLocation PartForeignMixedDPE PartForeignMixedSPE PartForeignUniformSPE
 ")

--- a/src/include/gpopt/translate/CTranslatorRelcacheToDXL.h
+++ b/src/include/gpopt/translate/CTranslatorRelcacheToDXL.h
@@ -244,10 +244,6 @@ private:
 	// check if index is supported
 	static BOOL IsIndexSupported(Relation index_rel);
 
-	// compute the array of included columns
-	static ULongPtrArray *ComputeIncludedCols(CMemoryPool *mp,
-											  const IMDRelation *md_rel);
-
 	// is given level included in the default partitions
 	static BOOL LevelHasDefaultPartition(List *default_levels, ULONG level);
 

--- a/src/test/regress/expected/gp_covering_index.out
+++ b/src/test/regress/expected/gp_covering_index.out
@@ -1,0 +1,581 @@
+-- Test Covering Indexes Feature
+--
+-- Purpose: Test that plans are optimal and correct using permutations of cover
+--          indexes in varying scenarios. Correctness is determined by the
+--          number of output rows from each query.
+--          Does the plan use index-scan, index-only-scan, or seq-scan?
+-- start_matchsubs
+-- m/Memory: \d+kB/
+-- s/Memory: \d+kB/Memory: ###kB/
+-- end_matchsubs
+set optimizer_trace_fallback=on;
+-- 0) Basic scenario
+CREATE TABLE test_basic_cover_index(a int, b int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE INDEX i_test_basic_index ON test_basic_cover_index(a) INCLUDE (b);
+INSERT INTO test_basic_cover_index SELECT i, i+i, i*i FROM generate_series(1, 100)i;
+VACUUM ANALYZE test_basic_cover_index;
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT b FROM test_basic_cover_index WHERE a>42 AND b>42;
+                            QUERY PLAN                             
+-------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=58 loops=1)
+   ->  Seq Scan on test_basic_cover_index (actual rows=25 loops=1)
+         Filter: ((a > 42) AND (b > 42))
+         Rows Removed by Filter: 12
+ Optimizer: Postgres query optimizer
+(5 rows)
+
+-- 0) Test CTE with cover indexes
+--
+-- Check that CTE over scan with cover index and cover index over cte both work
+-- ORCA_FEATURE_NOT_SUPPORTED: allow index-only-scan over CTE
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+WITH cte AS
+(
+    SELECT b FROM test_basic_cover_index WHERE a < 42
+)
+SELECT b FROM cte WHERE b%2=0;
+                            QUERY PLAN                             
+-------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=41 loops=1)
+   ->  Seq Scan on test_basic_cover_index (actual rows=16 loops=1)
+         Filter: ((a < 42) AND ((b % 2) = 0))
+         Rows Removed by Filter: 22
+ Optimizer: Postgres query optimizer
+(5 rows)
+
+-- ORCA_FEATURE_NOT_SUPPORTED: allow index-only-scan over CTE
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+WITH cte AS
+(
+    SELECT a, b FROM test_basic_cover_index
+)
+SELECT b FROM cte WHERE a<42;
+                               QUERY PLAN                                
+-------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=41 loops=1)
+   ->  Subquery Scan on cte (actual rows=16 loops=1)
+         ->  Seq Scan on test_basic_cover_index (actual rows=16 loops=1)
+               Filter: (a < 42)
+               Rows Removed by Filter: 22
+ Optimizer: Postgres query optimizer
+(6 rows)
+
+-- 0) Views over cover indexes
+CREATE VIEW view_test_cover_indexes_with_filter AS
+SELECT a, b FROM test_basic_cover_index WHERE a<42;
+CREATE VIEW view_test_cover_indexes_without_filter AS
+SELECT a, b FROM test_basic_cover_index;
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT b FROM view_test_cover_indexes_with_filter;
+                            QUERY PLAN                             
+-------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=41 loops=1)
+   ->  Seq Scan on test_basic_cover_index (actual rows=16 loops=1)
+         Filter: (a < 42)
+         Rows Removed by Filter: 22
+ Optimizer: Postgres query optimizer
+(5 rows)
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT b FROM view_test_cover_indexes_without_filter WHERE a<42;
+                            QUERY PLAN                             
+-------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=41 loops=1)
+   ->  Seq Scan on test_basic_cover_index (actual rows=16 loops=1)
+         Filter: (a < 42)
+         Rows Removed by Filter: 22
+ Optimizer: Postgres query optimizer
+(5 rows)
+
+-- 1) Various Column Types
+--
+-- Use different column types to check that the scan associates the correct
+-- type to the correct column
+CREATE TABLE test_various_col_types(inttype int, texttype text, decimaltype decimal(10,2));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'inttype' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO test_various_col_types SELECT i, 'texttype'||i, i FROM generate_series(1,9999) i;
+CREATE INDEX i_test_various_col_types ON test_various_col_types(inttype) INCLUDE (texttype);
+VACUUM ANALYZE test_various_col_types;
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF) SELECT texttype FROM test_various_col_types WHERE inttype<42;
+                                               QUERY PLAN                                                
+---------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=41 loops=1)
+   ->  Index Only Scan using i_test_various_col_types on test_various_col_types (actual rows=16 loops=1)
+         Index Cond: (inttype < 42)
+         Heap Fetches: 0
+ Optimizer: Postgres query optimizer
+(5 rows)
+
+DROP INDEX i_test_various_col_types;
+CREATE INDEX i_test_various_col_types ON test_various_col_types(decimaltype) INCLUDE (inttype);
+VACUUM ANALYZE test_various_col_types;
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF) SELECT decimaltype, inttype FROM test_various_col_types WHERE decimaltype<42;
+                                               QUERY PLAN                                                
+---------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=41 loops=1)
+   ->  Index Only Scan using i_test_various_col_types on test_various_col_types (actual rows=16 loops=1)
+         Index Cond: (decimaltype < '42'::numeric)
+         Heap Fetches: 0
+ Optimizer: Postgres query optimizer
+(5 rows)
+
+ALTER TABLE test_various_col_types ADD COLUMN boxtype box;
+DROP INDEX i_test_various_col_types;
+CREATE INDEX i_test_various_col_types ON test_various_col_types(decimaltype) INCLUDE (boxtype);
+VACUUM ANALYZE test_various_col_types;
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF) SELECT decimaltype, boxtype FROM test_various_col_types WHERE decimaltype<42;
+                                               QUERY PLAN                                                
+---------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=41 loops=1)
+   ->  Index Only Scan using i_test_various_col_types on test_various_col_types (actual rows=16 loops=1)
+         Index Cond: (decimaltype < '42'::numeric)
+         Heap Fetches: 0
+ Optimizer: Postgres query optimizer
+(5 rows)
+
+-- 2) Test drop/add columns before and after creation of the index
+--
+-- Alter (add/drop) columns to check that the correct data is read from the
+-- physical scan.
+CREATE TABLE test_add_drop_columns(a int, aa int, b int, bb int, c int, d int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+ALTER TABLE test_add_drop_columns DROP COLUMN aa;
+INSERT INTO test_add_drop_columns SELECT i, i+i, i*i, i*i*i, i+i+i FROM generate_series(1, 100)i;
+ALTER TABLE test_add_drop_columns DROP COLUMN bb;
+ALTER TABLE test_add_drop_columns ADD COLUMN e int;
+CREATE INDEX i_test_add_drop_columns ON test_add_drop_columns(a, b) INCLUDE (c);
+ALTER TABLE test_add_drop_columns ADD COLUMN f int;
+VACUUM ANALYZE test_add_drop_columns;
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT a, b FROM test_add_drop_columns WHERE a<42 AND b>42;
+                            QUERY PLAN                             
+-------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=20 loops=1)
+   ->  Seq Scan on test_add_drop_columns (actual rows=8 loops=1)
+         Filter: ((a < 42) AND (b > 42))
+         Rows Removed by Filter: 30
+ Optimizer: Postgres query optimizer
+(5 rows)
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT a, b FROM test_add_drop_columns WHERE a<42 AND b>42 AND c>42;
+                            QUERY PLAN                             
+-------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=20 loops=1)
+   ->  Seq Scan on test_add_drop_columns (actual rows=8 loops=1)
+         Filter: ((a < 42) AND (b > 42) AND (c > 42))
+         Rows Removed by Filter: 30
+ Optimizer: Postgres query optimizer
+(5 rows)
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT a, b, c, d, e FROM test_add_drop_columns WHERE a<42 AND b>42 AND c>42 AND e IS NULL;
+                              QUERY PLAN                              
+----------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=20 loops=1)
+   ->  Seq Scan on test_add_drop_columns (actual rows=8 loops=1)
+         Filter: ((e IS NULL) AND (a < 42) AND (b > 42) AND (c > 42))
+         Rows Removed by Filter: 30
+ Optimizer: Postgres query optimizer
+(5 rows)
+
+-- 3) Test various table types (e.g. AO/AOCO/replicated)
+--
+-- Check that different tables types (storage/distribution) leveage cover
+-- indexes correctly.
+CREATE TABLE test_replicated(a int, b int, c int) DISTRIBUTED REPLICATED;
+CREATE INDEX i_test_replicated ON test_replicated(a) INCLUDE (b);
+INSERT INTO test_replicated SELECT i, i+i, i*i FROM generate_series(1, 100)i;
+VACUUM ANALYZE test_replicated;
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT b FROM test_replicated WHERE a<42 AND b>42;
+                            QUERY PLAN                             
+-------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1) (actual rows=20 loops=1)
+   ->  Seq Scan on test_replicated (actual rows=20 loops=1)
+         Filter: ((a < 42) AND (b > 42))
+         Rows Removed by Filter: 80
+ Optimizer: Postgres query optimizer
+(5 rows)
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT b, c FROM test_replicated WHERE a<42 AND b>42;
+                            QUERY PLAN                             
+-------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1) (actual rows=20 loops=1)
+   ->  Seq Scan on test_replicated (actual rows=20 loops=1)
+         Filter: ((a < 42) AND (b > 42))
+         Rows Removed by Filter: 80
+ Optimizer: Postgres query optimizer
+(5 rows)
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT a, b, c FROM test_replicated WHERE c>42;
+                            QUERY PLAN                             
+-------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1) (actual rows=94 loops=1)
+   ->  Seq Scan on test_replicated (actual rows=94 loops=1)
+         Filter: (c > 42)
+         Rows Removed by Filter: 6
+ Optimizer: Postgres query optimizer
+(5 rows)
+
+-- ORCA_FEATURE_NOT_SUPPORTED: enable index scans on AO tables
+CREATE TABLE test_ao(a int, b int, c int) WITH (appendonly=true) DISTRIBUTED BY (a);
+CREATE INDEX i_test_ao ON test_ao(a) INCLUDE (b);
+INSERT INTO test_ao SELECT i, i+i, i*i FROM generate_series(1, 100)i;
+VACUUM ANALYZE test_ao;
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT b FROM test_ao WHERE a<42 AND b>42;
+                            QUERY PLAN                             
+-------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=20 loops=1)
+   ->  Seq Scan on test_ao (actual rows=8 loops=1)
+         Filter: ((a < 42) AND (b > 42))
+         Rows Removed by Filter: 30
+ Optimizer: Postgres query optimizer
+(5 rows)
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT b, c FROM test_ao WHERE a<42 AND b>42;
+                            QUERY PLAN                             
+-------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=20 loops=1)
+   ->  Seq Scan on test_ao (actual rows=8 loops=1)
+         Filter: ((a < 42) AND (b > 42))
+         Rows Removed by Filter: 30
+ Optimizer: Postgres query optimizer
+(5 rows)
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT a, b, c FROM test_ao WHERE c>42;
+                            QUERY PLAN                             
+-------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=94 loops=1)
+   ->  Seq Scan on test_ao (actual rows=36 loops=1)
+         Filter: (c > 42)
+         Rows Removed by Filter: 1
+ Optimizer: Postgres query optimizer
+(5 rows)
+
+-- 4) Test select best covering index
+--
+-- Check that the best cover index is chosen for a plan when multiple cover
+-- indexes are available.
+CREATE TABLE test_select_best_cover(a int, b int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE INDEX i_test_select_best_cover_a ON test_select_best_cover(a);
+CREATE INDEX i_test_select_best_cover_a_b ON test_select_best_cover(a) INCLUDE (b);
+CREATE INDEX i_test_select_best_cover_ab ON test_select_best_cover(a, b);
+CREATE INDEX i_test_select_best_cover_b ON test_select_best_cover(b);
+CREATE INDEX i_test_select_best_cover_b_a ON test_select_best_cover(a) INCLUDE (b);
+CREATE INDEX i_test_select_best_cover_a_bc ON test_select_best_cover(a) INCLUDE (b, c);
+INSERT INTO test_select_best_cover SELECT i, i+i, i*i FROM generate_series(1, 100)i;
+VACUUM ANALYZE test_select_best_cover;
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT a FROM test_select_best_cover WHERE a>42;
+                            QUERY PLAN                             
+-------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=58 loops=1)
+   ->  Seq Scan on test_select_best_cover (actual rows=25 loops=1)
+         Filter: (a > 42)
+         Rows Removed by Filter: 12
+ Optimizer: Postgres query optimizer
+(5 rows)
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT b FROM test_select_best_cover WHERE b>42;
+                            QUERY PLAN                             
+-------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=79 loops=1)
+   ->  Seq Scan on test_select_best_cover (actual rows=33 loops=1)
+         Filter: (b > 42)
+         Rows Removed by Filter: 4
+ Optimizer: Postgres query optimizer
+(5 rows)
+
+-- ORCA_FEATURE_NOT_SUPPORTED: use i_test_select_best_cover_ab
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT b FROM test_select_best_cover WHERE a>42 AND b>42;
+                            QUERY PLAN                             
+-------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=58 loops=1)
+   ->  Seq Scan on test_select_best_cover (actual rows=25 loops=1)
+         Filter: ((a > 42) AND (b > 42))
+         Rows Removed by Filter: 12
+ Optimizer: Postgres query optimizer
+(5 rows)
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT b FROM test_select_best_cover WHERE a>42 AND b>42 AND c>42;
+                            QUERY PLAN                             
+-------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=58 loops=1)
+   ->  Seq Scan on test_select_best_cover (actual rows=25 loops=1)
+         Filter: ((a > 42) AND (b > 42) AND (c > 42))
+         Rows Removed by Filter: 12
+ Optimizer: Postgres query optimizer
+(5 rows)
+
+-- 5) Test DML operations
+--
+-- Check that cover indexes can be used with DML operations
+CREATE TABLE test_dml_using_cover_index(a int, b int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE INDEX i_test_dml_using_cover_index ON test_dml_using_cover_index(a) INCLUDE (b);
+INSERT INTO test_dml_using_cover_index SELECT i, i+i, i*i FROM generate_series(1, 100)i;
+VACUUM ANALYZE test_dml_using_cover_index;
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+INSERT INTO test_dml_using_cover_index (SELECT a, a, a FROM test_dml_using_cover_index WHERE a>42);
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Insert on test_dml_using_cover_index (actual rows=0 loops=1)
+   ->  Seq Scan on test_dml_using_cover_index test_dml_using_cover_index_1 (actual rows=25 loops=1)
+         Filter: (a > 42)
+         Rows Removed by Filter: 12
+ Optimizer: Postgres query optimizer
+(5 rows)
+
+-- 6) Test index scan over partition tables
+--
+-- Check that cover indexes can be used with partition tables. This includes
+-- scenario when root/leaf partitions have different underlying physical format
+-- (e.g. drop column / exchange partition or leaf partition has cover index not
+-- defined on root).
+CREATE TABLE test_cover_index_on_pt(a int, b int, c int)
+DISTRIBUTED BY (a)
+PARTITION BY RANGE (b)
+(
+    START (0) END (4) EVERY (1)
+);
+CREATE INDEX i_test_cover_index_scan_on_partition_table ON test_cover_index_on_pt(a) INCLUDE(b);
+INSERT INTO test_cover_index_on_pt SELECT i+i, i%4 FROM generate_series(1, 10)i;
+VACUUM ANALYZE test_cover_index_on_pt;
+-- ORCA_FEATURE_NOT_SUPPORTED: dynamic index only scan
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT a, b FROM test_cover_index_on_pt WHERE a<10;
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=4 loops=1)
+   ->  Append (actual rows=3 loops=1)
+         ->  Seq Scan on test_cover_index_on_pt_1_prt_1 (actual rows=1 loops=1)
+               Filter: (a < 10)
+               Rows Removed by Filter: 1
+         ->  Seq Scan on test_cover_index_on_pt_1_prt_2 (actual rows=1 loops=1)
+               Filter: (a < 10)
+               Rows Removed by Filter: 1
+         ->  Seq Scan on test_cover_index_on_pt_1_prt_3 (actual rows=1 loops=1)
+               Filter: (a < 10)
+         ->  Seq Scan on test_cover_index_on_pt_1_prt_4 (actual rows=1 loops=1)
+               Filter: (a < 10)
+               Rows Removed by Filter: 1
+ Optimizer: Postgres query optimizer
+(14 rows)
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT a, b, c FROM test_cover_index_on_pt WHERE a<10;
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=4 loops=1)
+   ->  Append (actual rows=3 loops=1)
+         ->  Seq Scan on test_cover_index_on_pt_1_prt_1 (actual rows=1 loops=1)
+               Filter: (a < 10)
+               Rows Removed by Filter: 1
+         ->  Seq Scan on test_cover_index_on_pt_1_prt_2 (actual rows=1 loops=1)
+               Filter: (a < 10)
+               Rows Removed by Filter: 1
+         ->  Seq Scan on test_cover_index_on_pt_1_prt_3 (actual rows=1 loops=1)
+               Filter: (a < 10)
+         ->  Seq Scan on test_cover_index_on_pt_1_prt_4 (actual rows=1 loops=1)
+               Filter: (a < 10)
+               Rows Removed by Filter: 1
+ Optimizer: Postgres query optimizer
+(14 rows)
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT a, b, c FROM test_cover_index_on_pt WHERE b<10;
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=10 loops=1)
+   ->  Append (actual rows=5 loops=1)
+         ->  Seq Scan on test_cover_index_on_pt_1_prt_1 (actual rows=2 loops=1)
+               Filter: (b < 10)
+         ->  Seq Scan on test_cover_index_on_pt_1_prt_2 (actual rows=2 loops=1)
+               Filter: (b < 10)
+         ->  Seq Scan on test_cover_index_on_pt_1_prt_3 (actual rows=2 loops=1)
+               Filter: (b < 10)
+         ->  Seq Scan on test_cover_index_on_pt_1_prt_4 (actual rows=2 loops=1)
+               Filter: (b < 10)
+ Optimizer: Postgres query optimizer
+(11 rows)
+
+CREATE TABLE leaf_part(a int, b int, c int) DISTRIBUTED BY (a);
+-- without explicit index declared on leaf_part
+ALTER TABLE test_cover_index_on_pt EXCHANGE PARTITION FOR(2) WITH TABLE leaf_part;
+INSERT INTO test_cover_index_on_pt VALUES (2, 2, 2);
+VACUUM ANALYZE test_cover_index_on_pt;
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT a, b FROM test_cover_index_on_pt WHERE a<10;
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=4 loops=1)
+   ->  Append (actual rows=3 loops=1)
+         ->  Seq Scan on test_cover_index_on_pt_1_prt_1 (actual rows=1 loops=1)
+               Filter: (a < 10)
+               Rows Removed by Filter: 1
+         ->  Seq Scan on test_cover_index_on_pt_1_prt_2 (actual rows=1 loops=1)
+               Filter: (a < 10)
+               Rows Removed by Filter: 1
+         ->  Seq Scan on test_cover_index_on_pt_1_prt_3 (actual rows=1 loops=1)
+               Filter: (a < 10)
+         ->  Seq Scan on test_cover_index_on_pt_1_prt_4 (actual rows=1 loops=1)
+               Filter: (a < 10)
+               Rows Removed by Filter: 1
+ Optimizer: Postgres query optimizer
+(14 rows)
+
+DROP INDEX i_test_cover_index_scan_on_partition_table;
+-- with explicit index declared on leaf_part
+CREATE INDEX i_test_cover_index_scan_on_partition_table ON leaf_part(a) INCLUDE(b);
+VACUUM ANALYZE test_cover_index_on_pt;
+-- ORCA_FEATURE_NOT_SUPPORTED: partial dynamic index scan
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT a, b FROM test_cover_index_on_pt WHERE a<10;
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=4 loops=1)
+   ->  Append (actual rows=3 loops=1)
+         ->  Seq Scan on test_cover_index_on_pt_1_prt_1 (actual rows=1 loops=1)
+               Filter: (a < 10)
+               Rows Removed by Filter: 1
+         ->  Seq Scan on test_cover_index_on_pt_1_prt_2 (actual rows=1 loops=1)
+               Filter: (a < 10)
+               Rows Removed by Filter: 1
+         ->  Seq Scan on test_cover_index_on_pt_1_prt_3 (actual rows=1 loops=1)
+               Filter: (a < 10)
+         ->  Seq Scan on test_cover_index_on_pt_1_prt_4 (actual rows=1 loops=1)
+               Filter: (a < 10)
+               Rows Removed by Filter: 1
+ Optimizer: Postgres query optimizer
+(14 rows)
+
+-- 7) Test various index types
+--
+-- Check that different index types can be used with cover indexes.
+-- Note: brin, hash, and spgist do not suport included columns.
+CREATE TABLE test_index_types(a box, b int, c int) DISTRIBUTED BY (b);
+INSERT INTO test_index_types VALUES ('(2.0,2.0,0.0,0.0)', 2, 2);
+INSERT INTO test_index_types VALUES ('(1.0,1.0,3.0,3.0)', 3, 3);
+CREATE INDEX i_test_index_types ON test_index_types USING GIST (a) INCLUDE (b);
+VACUUM ANALYZE test_index_types;
+-- ORCA_FEATURE_NOT_SUPPORTED: support index-only-scan on GIST indexes
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT a, b FROM test_index_types WHERE a<@ box '(0,0,3,3)';
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=2 loops=1)
+   ->  Seq Scan on test_index_types (actual rows=2 loops=1)
+         Filter: (a <@ '(3,3),(0,0)'::box)
+ Optimizer: Postgres query optimizer
+(4 rows)
+
+-- 8) Test partial indexes
+--
+-- Check that partial cover indexes may be used
+CREATE TABLE test_partial_index(a int, b int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE INDEX i_test_partial_index ON test_partial_index(a) INCLUDE (b) WHERE a<42;
+INSERT INTO test_partial_index SELECT i, i+i, i*i FROM generate_series(1, 100)i;
+VACUUM ANALYZE test_partial_index;
+-- ORCA_FEATURE_NOT_SUPPORTED: support partial indexes
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT b FROM test_partial_index WHERE a>42 AND b>42;
+                            QUERY PLAN                             
+-------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=58 loops=1)
+   ->  Seq Scan on test_partial_index (actual rows=25 loops=1)
+         Filter: ((a > 42) AND (b > 42))
+         Rows Removed by Filter: 12
+ Optimizer: Postgres query optimizer
+(5 rows)
+
+-- 9) Test backward index scan
+--
+-- Check that cover indexes may be used for backward index scan
+CREATE TABLE test_backward_index_scan(a int, b int, c int) DISTRIBUTED BY (a);
+CREATE INDEX i_test_backward_index_scan ON test_backward_index_scan(a) INCLUDE (b);
+INSERT INTO test_backward_index_scan SELECT i, i+i, i*i FROM generate_series(1, 100)i;
+VACUUM ANALYZE test_backward_index_scan;
+-- ORCA_FEATURE_NOT_SUPPORTED enable backward index scan
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT b FROM test_backward_index_scan WHERE a>42 AND b>42 ORDER BY a DESC;
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=58 loops=1)
+   Merge Key: a
+   ->  Sort (actual rows=25 loops=1)
+         Sort Key: a DESC
+         Sort Method:  quicksort  Memory: 77kB
+         Executor Memory: 177kB  Segments: 3  Max: 59kB (segment 0)
+         ->  Seq Scan on test_backward_index_scan (actual rows=25 loops=1)
+               Filter: ((a > 42) AND (b > 42))
+               Rows Removed by Filter: 12
+ Optimizer: Postgres query optimizer
+(10 rows)
+
+-- 10) Test index expressions
+--
+-- Check that cover indexes may be used for index expressions
+CREATE OR REPLACE FUNCTION add_one(integer)
+RETURNS INTEGER
+LANGUAGE 'plpgsql'
+AS $$
+BEGIN
+    RETURN $1 + 1;
+END;
+$$;
+CREATE TABLE test_index_expression_scan(a int, b int, c int) DISTRIBUTED BY (a);
+CREATE INDEX i_test_index_expression_scan ON test_index_expression_scan(a) INCLUDE (b);
+INSERT INTO test_index_expression_scan SELECT i, i+i, i*i FROM generate_series(1, 100)i;
+VACUUM ANALYZE test_index_expression_scan;
+-- ORCA_FEATURE_NOT_SUPPORTED enable index expression
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT add_one(b) FROM test_index_expression_scan WHERE add_one(a) < 42;
+                              QUERY PLAN                               
+-----------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=40 loops=1)
+   ->  Seq Scan on test_index_expression_scan (actual rows=15 loops=1)
+         Filter: (add_one(a) < 42)
+         Rows Removed by Filter: 23
+ Optimizer: Postgres query optimizer
+(5 rows)
+
+-- 11) Test combined indexes
+--
+-- Check that combined indexes may be used.  (on OR conditions) https://www.postgresql.org/docs/current/indexes-bitmap-scans.html
+CREATE TABLE test_combined_index_scan(a int, b int, c int) DISTRIBUTED BY (a);
+CREATE INDEX i_test_combined_index_scan_a ON test_combined_index_scan(a) INCLUDE (b);
+CREATE INDEX i_test_combined_index_scan_b ON test_combined_index_scan(b) INCLUDE (a);
+INSERT INTO test_combined_index_scan SELECT i, i+i, i*i FROM generate_series(1, 100)i;
+VACUUM ANALYZE test_combined_index_scan;
+-- ORCA_FEATURE_NOT_SUPPORTED enable combined index
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT b FROM test_combined_index_scan WHERE a < 42 OR b < 42;
+                             QUERY PLAN                              
+---------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=41 loops=1)
+   ->  Seq Scan on test_combined_index_scan (actual rows=16 loops=1)
+         Filter: ((a < 42) OR (b < 42))
+         Rows Removed by Filter: 22
+ Optimizer: Postgres query optimizer
+(5 rows)
+
+reset optimizer_trace_fallback;

--- a/src/test/regress/expected/gp_covering_index.out
+++ b/src/test/regress/expected/gp_covering_index.out
@@ -4,93 +4,104 @@
 --          indexes in varying scenarios. Correctness is determined by the
 --          number of output rows from each query.
 --          Does the plan use index-scan, index-only-scan, or seq-scan?
+--
+-- N.B. "VACUUM ANALZE" is to update relallvisible used to determine cost of an
+--      index-only scan.
 -- start_matchsubs
 -- m/Memory: \d+kB/
 -- s/Memory: \d+kB/Memory: ###kB/
 -- end_matchsubs
 set optimizer_trace_fallback=on;
--- 0) Basic scenario
+set enable_seqscan=off;
+-- Basic scenario
 CREATE TABLE test_basic_cover_index(a int, b int, c int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 CREATE INDEX i_test_basic_index ON test_basic_cover_index(a) INCLUDE (b);
 INSERT INTO test_basic_cover_index SELECT i, i+i, i*i FROM generate_series(1, 100)i;
 VACUUM ANALYZE test_basic_cover_index;
+-- KEYS: [a]    INCLUDED: [b]
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 SELECT b FROM test_basic_cover_index WHERE a>42 AND b>42;
-                            QUERY PLAN                             
--------------------------------------------------------------------
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=58 loops=1)
-   ->  Seq Scan on test_basic_cover_index (actual rows=25 loops=1)
-         Filter: ((a > 42) AND (b > 42))
-         Rows Removed by Filter: 12
+   ->  Index Only Scan using i_test_basic_index on test_basic_cover_index (actual rows=25 loops=1)
+         Index Cond: (a > 42)
+         Filter: (b > 42)
+         Heap Fetches: 0
  Optimizer: Postgres query optimizer
-(5 rows)
+(6 rows)
 
--- 0) Test CTE with cover indexes
+-- Test CTE with cover indexes
 --
 -- Check that CTE over scan with cover index and cover index over cte both work
 -- ORCA_FEATURE_NOT_SUPPORTED: allow index-only-scan over CTE
+-- KEYS: [a]    INCLUDED: [b]
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 WITH cte AS
 (
     SELECT b FROM test_basic_cover_index WHERE a < 42
 )
 SELECT b FROM cte WHERE b%2=0;
-                            QUERY PLAN                             
--------------------------------------------------------------------
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=41 loops=1)
-   ->  Seq Scan on test_basic_cover_index (actual rows=16 loops=1)
-         Filter: ((a < 42) AND ((b % 2) = 0))
-         Rows Removed by Filter: 22
+   ->  Index Only Scan using i_test_basic_index on test_basic_cover_index (actual rows=16 loops=1)
+         Index Cond: (a < 42)
+         Filter: ((b % 2) = 0)
+         Heap Fetches: 0
  Optimizer: Postgres query optimizer
-(5 rows)
+(6 rows)
 
 -- ORCA_FEATURE_NOT_SUPPORTED: allow index-only-scan over CTE
+-- KEYS: [a]    INCLUDED: [b]
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 WITH cte AS
 (
     SELECT a, b FROM test_basic_cover_index
 )
 SELECT b FROM cte WHERE a<42;
-                               QUERY PLAN                                
--------------------------------------------------------------------------
+                                               QUERY PLAN                                                
+---------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=41 loops=1)
    ->  Subquery Scan on cte (actual rows=16 loops=1)
-         ->  Seq Scan on test_basic_cover_index (actual rows=16 loops=1)
-               Filter: (a < 42)
-               Rows Removed by Filter: 22
+         ->  Index Only Scan using i_test_basic_index on test_basic_cover_index (actual rows=16 loops=1)
+               Index Cond: (a < 42)
+               Heap Fetches: 0
  Optimizer: Postgres query optimizer
 (6 rows)
 
--- 0) Views over cover indexes
+-- Views over cover indexes
 CREATE VIEW view_test_cover_indexes_with_filter AS
 SELECT a, b FROM test_basic_cover_index WHERE a<42;
 CREATE VIEW view_test_cover_indexes_without_filter AS
 SELECT a, b FROM test_basic_cover_index;
+-- KEYS: [a]    INCLUDED: [b]
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 SELECT b FROM view_test_cover_indexes_with_filter;
-                            QUERY PLAN                             
--------------------------------------------------------------------
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=41 loops=1)
-   ->  Seq Scan on test_basic_cover_index (actual rows=16 loops=1)
-         Filter: (a < 42)
-         Rows Removed by Filter: 22
+   ->  Index Only Scan using i_test_basic_index on test_basic_cover_index (actual rows=16 loops=1)
+         Index Cond: (a < 42)
+         Heap Fetches: 0
  Optimizer: Postgres query optimizer
 (5 rows)
 
+-- KEYS: [a]    INCLUDED: [b]
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 SELECT b FROM view_test_cover_indexes_without_filter WHERE a<42;
-                            QUERY PLAN                             
--------------------------------------------------------------------
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=41 loops=1)
-   ->  Seq Scan on test_basic_cover_index (actual rows=16 loops=1)
-         Filter: (a < 42)
-         Rows Removed by Filter: 22
+   ->  Index Only Scan using i_test_basic_index on test_basic_cover_index (actual rows=16 loops=1)
+         Index Cond: (a < 42)
+         Heap Fetches: 0
  Optimizer: Postgres query optimizer
 (5 rows)
 
--- 1) Various Column Types
+-- Various Column Types
 --
 -- Use different column types to check that the scan associates the correct
 -- type to the correct column
@@ -100,6 +111,7 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 INSERT INTO test_various_col_types SELECT i, 'texttype'||i, i FROM generate_series(1,9999) i;
 CREATE INDEX i_test_various_col_types ON test_various_col_types(inttype) INCLUDE (texttype);
 VACUUM ANALYZE test_various_col_types;
+-- KEYS: [inttype] INCLUDED: [texttype]
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF) SELECT texttype FROM test_various_col_types WHERE inttype<42;
                                                QUERY PLAN                                                
 ---------------------------------------------------------------------------------------------------------
@@ -113,6 +125,7 @@ EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF) SELECT texttype FROM test_
 DROP INDEX i_test_various_col_types;
 CREATE INDEX i_test_various_col_types ON test_various_col_types(decimaltype) INCLUDE (inttype);
 VACUUM ANALYZE test_various_col_types;
+-- KEYS: [decimaltype] INCLUDED: [inttype]
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF) SELECT decimaltype, inttype FROM test_various_col_types WHERE decimaltype<42;
                                                QUERY PLAN                                                
 ---------------------------------------------------------------------------------------------------------
@@ -127,6 +140,7 @@ ALTER TABLE test_various_col_types ADD COLUMN boxtype box;
 DROP INDEX i_test_various_col_types;
 CREATE INDEX i_test_various_col_types ON test_various_col_types(decimaltype) INCLUDE (boxtype);
 VACUUM ANALYZE test_various_col_types;
+-- KEYS: [decimaltype] INCLUDED: [boxtype]
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF) SELECT decimaltype, boxtype FROM test_various_col_types WHERE decimaltype<42;
                                                QUERY PLAN                                                
 ---------------------------------------------------------------------------------------------------------
@@ -137,7 +151,7 @@ EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF) SELECT decimaltype, boxtyp
  Optimizer: Postgres query optimizer
 (5 rows)
 
--- 2) Test drop/add columns before and after creation of the index
+-- Test drop/add columns before and after creation of the index
 --
 -- Alter (add/drop) columns to check that the correct data is read from the
 -- physical scan.
@@ -151,40 +165,44 @@ ALTER TABLE test_add_drop_columns ADD COLUMN e int;
 CREATE INDEX i_test_add_drop_columns ON test_add_drop_columns(a, b) INCLUDE (c);
 ALTER TABLE test_add_drop_columns ADD COLUMN f int;
 VACUUM ANALYZE test_add_drop_columns;
+-- KEYS: [a, b] INCLUDED: [c]
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 SELECT a, b FROM test_add_drop_columns WHERE a<42 AND b>42;
-                            QUERY PLAN                             
--------------------------------------------------------------------
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=20 loops=1)
-   ->  Seq Scan on test_add_drop_columns (actual rows=8 loops=1)
-         Filter: ((a < 42) AND (b > 42))
-         Rows Removed by Filter: 30
+   ->  Index Only Scan using i_test_add_drop_columns on test_add_drop_columns (actual rows=8 loops=1)
+         Index Cond: ((a < 42) AND (b > 42))
+         Heap Fetches: 0
  Optimizer: Postgres query optimizer
 (5 rows)
 
+-- KEYS: [a, b] INCLUDED: [c]
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 SELECT a, b FROM test_add_drop_columns WHERE a<42 AND b>42 AND c>42;
-                            QUERY PLAN                             
--------------------------------------------------------------------
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=20 loops=1)
-   ->  Seq Scan on test_add_drop_columns (actual rows=8 loops=1)
-         Filter: ((a < 42) AND (b > 42) AND (c > 42))
-         Rows Removed by Filter: 30
+   ->  Index Only Scan using i_test_add_drop_columns on test_add_drop_columns (actual rows=8 loops=1)
+         Index Cond: ((a < 42) AND (b > 42))
+         Filter: (c > 42)
+         Heap Fetches: 0
  Optimizer: Postgres query optimizer
-(5 rows)
+(6 rows)
 
+-- KEYS: [a, b] INCLUDED: [c]
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 SELECT a, b, c, d, e FROM test_add_drop_columns WHERE a<42 AND b>42 AND c>42 AND e IS NULL;
-                              QUERY PLAN                              
-----------------------------------------------------------------------
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=20 loops=1)
-   ->  Seq Scan on test_add_drop_columns (actual rows=8 loops=1)
-         Filter: ((e IS NULL) AND (a < 42) AND (b > 42) AND (c > 42))
-         Rows Removed by Filter: 30
+   ->  Index Scan using i_test_add_drop_columns on test_add_drop_columns (actual rows=8 loops=1)
+         Index Cond: ((a < 42) AND (b > 42))
+         Filter: ((e IS NULL) AND (c > 42))
  Optimizer: Postgres query optimizer
 (5 rows)
 
--- 3) Test various table types (e.g. AO/AOCO/replicated)
+-- Test various table types (e.g. AO/AOCO/replicated)
 --
 -- Check that different tables types (storage/distribution) leveage cover
 -- indexes correctly.
@@ -192,28 +210,35 @@ CREATE TABLE test_replicated(a int, b int, c int) DISTRIBUTED REPLICATED;
 CREATE INDEX i_test_replicated ON test_replicated(a) INCLUDE (b);
 INSERT INTO test_replicated SELECT i, i+i, i*i FROM generate_series(1, 100)i;
 VACUUM ANALYZE test_replicated;
+-- KEYS: [a] INCLUDED: [b]
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 SELECT b FROM test_replicated WHERE a<42 AND b>42;
-                            QUERY PLAN                             
--------------------------------------------------------------------
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1) (actual rows=20 loops=1)
-   ->  Seq Scan on test_replicated (actual rows=20 loops=1)
-         Filter: ((a < 42) AND (b > 42))
-         Rows Removed by Filter: 80
+   ->  Index Only Scan using i_test_replicated on test_replicated (actual rows=20 loops=1)
+         Index Cond: (a < 42)
+         Filter: (b > 42)
+         Rows Removed by Filter: 21
+         Heap Fetches: 0
  Optimizer: Postgres query optimizer
-(5 rows)
+(7 rows)
 
+-- KEYS: [a] INCLUDED: [b]
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 SELECT b, c FROM test_replicated WHERE a<42 AND b>42;
-                            QUERY PLAN                             
--------------------------------------------------------------------
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1) (actual rows=20 loops=1)
-   ->  Seq Scan on test_replicated (actual rows=20 loops=1)
-         Filter: ((a < 42) AND (b > 42))
-         Rows Removed by Filter: 80
+   ->  Index Scan using i_test_replicated on test_replicated (actual rows=20 loops=1)
+         Index Cond: (a < 42)
+         Filter: (b > 42)
+         Rows Removed by Filter: 21
  Optimizer: Postgres query optimizer
-(5 rows)
+(6 rows)
 
+-- Expect Seq Scan because predicate "c" is not in KEYS
+-- KEYS: [a] INCLUDED: [b]
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 SELECT a, b, c FROM test_replicated WHERE c>42;
                             QUERY PLAN                             
@@ -230,28 +255,36 @@ CREATE TABLE test_ao(a int, b int, c int) WITH (appendonly=true) DISTRIBUTED BY 
 CREATE INDEX i_test_ao ON test_ao(a) INCLUDE (b);
 INSERT INTO test_ao SELECT i, i+i, i*i FROM generate_series(1, 100)i;
 VACUUM ANALYZE test_ao;
+-- KEYS: [a] INCLUDED: [b]
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 SELECT b FROM test_ao WHERE a<42 AND b>42;
-                            QUERY PLAN                             
--------------------------------------------------------------------
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=20 loops=1)
-   ->  Seq Scan on test_ao (actual rows=8 loops=1)
-         Filter: ((a < 42) AND (b > 42))
-         Rows Removed by Filter: 30
+   ->  Index Only Scan using i_test_ao on test_ao (actual rows=8 loops=1)
+         Index Cond: (a < 42)
+         Filter: (b > 42)
+         Rows Removed by Filter: 8
+         Heap Fetches: 0
  Optimizer: Postgres query optimizer
-(5 rows)
+(7 rows)
 
+-- KEYS: [a] INCLUDED: [b]
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 SELECT b, c FROM test_ao WHERE a<42 AND b>42;
-                            QUERY PLAN                             
--------------------------------------------------------------------
+                             QUERY PLAN                              
+---------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=20 loops=1)
-   ->  Seq Scan on test_ao (actual rows=8 loops=1)
-         Filter: ((a < 42) AND (b > 42))
-         Rows Removed by Filter: 30
+   ->  Bitmap Heap Scan on test_ao (actual rows=8 loops=1)
+         Recheck Cond: (a < 42)
+         Filter: (b > 42)
+         Rows Removed by Filter: 8
+         ->  Bitmap Index Scan on i_test_ao (actual rows=16 loops=1)
+               Index Cond: (a < 42)
  Optimizer: Postgres query optimizer
-(5 rows)
+(8 rows)
 
+-- KEYS: [a] INCLUDED: [b]
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 SELECT a, b, c FROM test_ao WHERE c>42;
                             QUERY PLAN                             
@@ -263,7 +296,7 @@ SELECT a, b, c FROM test_ao WHERE c>42;
  Optimizer: Postgres query optimizer
 (5 rows)
 
--- 4) Test select best covering index
+-- Test select best covering index
 --
 -- Check that the best cover index is chosen for a plan when multiple cover
 -- indexes are available.
@@ -278,52 +311,78 @@ CREATE INDEX i_test_select_best_cover_b_a ON test_select_best_cover(a) INCLUDE (
 CREATE INDEX i_test_select_best_cover_a_bc ON test_select_best_cover(a) INCLUDE (b, c);
 INSERT INTO test_select_best_cover SELECT i, i+i, i*i FROM generate_series(1, 100)i;
 VACUUM ANALYZE test_select_best_cover;
+-- KEYS: [a]    INCLUDED: []
+-- KEYS: [a]    INCLUDED: [b]
+-- KEYS: [a, b] INCLUDED: []
+-- KEYS: [b]    INCLUDED: []
+-- KEYS: [a]    INCLUDED: [b]
+-- KEYS: [a]    INCLUDED: [b, c]
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 SELECT a FROM test_select_best_cover WHERE a>42;
-                            QUERY PLAN                             
--------------------------------------------------------------------
+                                                  QUERY PLAN                                                  
+--------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=58 loops=1)
-   ->  Seq Scan on test_select_best_cover (actual rows=25 loops=1)
-         Filter: (a > 42)
-         Rows Removed by Filter: 12
+   ->  Index Only Scan using i_test_select_best_cover_a_bc on test_select_best_cover (actual rows=25 loops=1)
+         Index Cond: (a > 42)
+         Heap Fetches: 0
  Optimizer: Postgres query optimizer
 (5 rows)
 
+-- KEYS: [a]    INCLUDED: []
+-- KEYS: [a]    INCLUDED: [b]
+-- KEYS: [a, b] INCLUDED: []
+-- KEYS: [b]    INCLUDED: []
+-- KEYS: [a]    INCLUDED: [b]
+-- KEYS: [a]    INCLUDED: [b, c]
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 SELECT b FROM test_select_best_cover WHERE b>42;
-                            QUERY PLAN                             
--------------------------------------------------------------------
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=79 loops=1)
-   ->  Seq Scan on test_select_best_cover (actual rows=33 loops=1)
-         Filter: (b > 42)
-         Rows Removed by Filter: 4
+   ->  Index Only Scan using i_test_select_best_cover_b on test_select_best_cover (actual rows=33 loops=1)
+         Index Cond: (b > 42)
+         Heap Fetches: 0
  Optimizer: Postgres query optimizer
 (5 rows)
 
+-- KEYS: [a]    INCLUDED: []
+-- KEYS: [a]    INCLUDED: [b]
+-- KEYS: [a, b] INCLUDED: []
+-- KEYS: [b]    INCLUDED: []
+-- KEYS: [a]    INCLUDED: [b]
+-- KEYS: [a]    INCLUDED: [b, c]
 -- ORCA_FEATURE_NOT_SUPPORTED: use i_test_select_best_cover_ab
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 SELECT b FROM test_select_best_cover WHERE a>42 AND b>42;
-                            QUERY PLAN                             
--------------------------------------------------------------------
+                                                  QUERY PLAN                                                  
+--------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=58 loops=1)
-   ->  Seq Scan on test_select_best_cover (actual rows=25 loops=1)
-         Filter: ((a > 42) AND (b > 42))
-         Rows Removed by Filter: 12
+   ->  Index Only Scan using i_test_select_best_cover_a_bc on test_select_best_cover (actual rows=25 loops=1)
+         Index Cond: (a > 42)
+         Filter: (b > 42)
+         Heap Fetches: 0
  Optimizer: Postgres query optimizer
-(5 rows)
+(6 rows)
 
+-- KEYS: [a]    INCLUDED: []
+-- KEYS: [a]    INCLUDED: [b]
+-- KEYS: [a, b] INCLUDED: []
+-- KEYS: [b]    INCLUDED: []
+-- KEYS: [a]    INCLUDED: [b]
+-- KEYS: [a]    INCLUDED: [b, c]
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 SELECT b FROM test_select_best_cover WHERE a>42 AND b>42 AND c>42;
-                            QUERY PLAN                             
--------------------------------------------------------------------
+                                                  QUERY PLAN                                                  
+--------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=58 loops=1)
-   ->  Seq Scan on test_select_best_cover (actual rows=25 loops=1)
-         Filter: ((a > 42) AND (b > 42) AND (c > 42))
-         Rows Removed by Filter: 12
+   ->  Index Only Scan using i_test_select_best_cover_a_bc on test_select_best_cover (actual rows=25 loops=1)
+         Index Cond: (a > 42)
+         Filter: ((b > 42) AND (c > 42))
+         Heap Fetches: 0
  Optimizer: Postgres query optimizer
-(5 rows)
+(6 rows)
 
--- 5) Test DML operations
+-- Test DML operations
 --
 -- Check that cover indexes can be used with DML operations
 CREATE TABLE test_dml_using_cover_index(a int, b int, c int);
@@ -332,18 +391,19 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 CREATE INDEX i_test_dml_using_cover_index ON test_dml_using_cover_index(a) INCLUDE (b);
 INSERT INTO test_dml_using_cover_index SELECT i, i+i, i*i FROM generate_series(1, 100)i;
 VACUUM ANALYZE test_dml_using_cover_index;
+-- KEYS: [a]    INCLUDED: [b]
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 INSERT INTO test_dml_using_cover_index (SELECT a, a, a FROM test_dml_using_cover_index WHERE a>42);
-                                             QUERY PLAN                                             
-----------------------------------------------------------------------------------------------------
+                                                                  QUERY PLAN                                                                  
+----------------------------------------------------------------------------------------------------------------------------------------------
  Insert on test_dml_using_cover_index (actual rows=0 loops=1)
-   ->  Seq Scan on test_dml_using_cover_index test_dml_using_cover_index_1 (actual rows=25 loops=1)
-         Filter: (a > 42)
-         Rows Removed by Filter: 12
+   ->  Index Only Scan using i_test_dml_using_cover_index on test_dml_using_cover_index test_dml_using_cover_index_1 (actual rows=25 loops=1)
+         Index Cond: (a > 42)
+         Heap Fetches: 24
  Optimizer: Postgres query optimizer
 (5 rows)
 
--- 6) Test index scan over partition tables
+-- Test index scan over partition tables
 --
 -- Check that cover indexes can be used with partition tables. This includes
 -- scenario when root/leaf partitions have different underlying physical format
@@ -358,47 +418,49 @@ PARTITION BY RANGE (b)
 CREATE INDEX i_test_cover_index_scan_on_partition_table ON test_cover_index_on_pt(a) INCLUDE(b);
 INSERT INTO test_cover_index_on_pt SELECT i+i, i%4 FROM generate_series(1, 10)i;
 VACUUM ANALYZE test_cover_index_on_pt;
+-- KEYS: [a]    INCLUDED: [b]
 -- ORCA_FEATURE_NOT_SUPPORTED: dynamic index only scan
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 SELECT a, b FROM test_cover_index_on_pt WHERE a<10;
-                                   QUERY PLAN                                   
---------------------------------------------------------------------------------
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=4 loops=1)
    ->  Append (actual rows=3 loops=1)
-         ->  Seq Scan on test_cover_index_on_pt_1_prt_1 (actual rows=1 loops=1)
-               Filter: (a < 10)
-               Rows Removed by Filter: 1
-         ->  Seq Scan on test_cover_index_on_pt_1_prt_2 (actual rows=1 loops=1)
-               Filter: (a < 10)
-               Rows Removed by Filter: 1
-         ->  Seq Scan on test_cover_index_on_pt_1_prt_3 (actual rows=1 loops=1)
-               Filter: (a < 10)
-         ->  Seq Scan on test_cover_index_on_pt_1_prt_4 (actual rows=1 loops=1)
-               Filter: (a < 10)
-               Rows Removed by Filter: 1
+         ->  Index Only Scan using test_cover_index_on_pt_1_prt_1_a_b_idx on test_cover_index_on_pt_1_prt_1 (actual rows=1 loops=1)
+               Index Cond: (a < 10)
+               Heap Fetches: 0
+         ->  Index Only Scan using test_cover_index_on_pt_1_prt_2_a_b_idx on test_cover_index_on_pt_1_prt_2 (actual rows=1 loops=1)
+               Index Cond: (a < 10)
+               Heap Fetches: 0
+         ->  Index Only Scan using test_cover_index_on_pt_1_prt_3_a_b_idx on test_cover_index_on_pt_1_prt_3 (actual rows=1 loops=1)
+               Index Cond: (a < 10)
+               Heap Fetches: 0
+         ->  Index Only Scan using test_cover_index_on_pt_1_prt_4_a_b_idx on test_cover_index_on_pt_1_prt_4 (actual rows=1 loops=1)
+               Index Cond: (a < 10)
+               Heap Fetches: 0
  Optimizer: Postgres query optimizer
-(14 rows)
+(15 rows)
 
+-- KEYS: [a]    INCLUDED: [b]
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 SELECT a, b, c FROM test_cover_index_on_pt WHERE a<10;
-                                   QUERY PLAN                                   
---------------------------------------------------------------------------------
+                                                          QUERY PLAN                                                           
+-------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=4 loops=1)
    ->  Append (actual rows=3 loops=1)
-         ->  Seq Scan on test_cover_index_on_pt_1_prt_1 (actual rows=1 loops=1)
-               Filter: (a < 10)
-               Rows Removed by Filter: 1
-         ->  Seq Scan on test_cover_index_on_pt_1_prt_2 (actual rows=1 loops=1)
-               Filter: (a < 10)
-               Rows Removed by Filter: 1
-         ->  Seq Scan on test_cover_index_on_pt_1_prt_3 (actual rows=1 loops=1)
-               Filter: (a < 10)
-         ->  Seq Scan on test_cover_index_on_pt_1_prt_4 (actual rows=1 loops=1)
-               Filter: (a < 10)
-               Rows Removed by Filter: 1
+         ->  Index Scan using test_cover_index_on_pt_1_prt_1_a_b_idx on test_cover_index_on_pt_1_prt_1 (actual rows=1 loops=1)
+               Index Cond: (a < 10)
+         ->  Index Scan using test_cover_index_on_pt_1_prt_2_a_b_idx on test_cover_index_on_pt_1_prt_2 (actual rows=1 loops=1)
+               Index Cond: (a < 10)
+         ->  Index Scan using test_cover_index_on_pt_1_prt_3_a_b_idx on test_cover_index_on_pt_1_prt_3 (actual rows=1 loops=1)
+               Index Cond: (a < 10)
+         ->  Index Scan using test_cover_index_on_pt_1_prt_4_a_b_idx on test_cover_index_on_pt_1_prt_4 (actual rows=1 loops=1)
+               Index Cond: (a < 10)
  Optimizer: Postgres query optimizer
-(14 rows)
+(11 rows)
 
+-- Expect Seq Scan because predicate "b" is not in KEYS
+-- KEYS: [a]    INCLUDED: [b]
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 SELECT a, b, c FROM test_cover_index_on_pt WHERE b<10;
                                    QUERY PLAN                                   
@@ -421,25 +483,27 @@ CREATE TABLE leaf_part(a int, b int, c int) DISTRIBUTED BY (a);
 ALTER TABLE test_cover_index_on_pt EXCHANGE PARTITION FOR(2) WITH TABLE leaf_part;
 INSERT INTO test_cover_index_on_pt VALUES (2, 2, 2);
 VACUUM ANALYZE test_cover_index_on_pt;
+-- KEYS: [a]    INCLUDED: [b]
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 SELECT a, b FROM test_cover_index_on_pt WHERE a<10;
-                                   QUERY PLAN                                   
---------------------------------------------------------------------------------
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=4 loops=1)
    ->  Append (actual rows=3 loops=1)
-         ->  Seq Scan on test_cover_index_on_pt_1_prt_1 (actual rows=1 loops=1)
-               Filter: (a < 10)
-               Rows Removed by Filter: 1
-         ->  Seq Scan on test_cover_index_on_pt_1_prt_2 (actual rows=1 loops=1)
-               Filter: (a < 10)
-               Rows Removed by Filter: 1
-         ->  Seq Scan on test_cover_index_on_pt_1_prt_3 (actual rows=1 loops=1)
-               Filter: (a < 10)
-         ->  Seq Scan on test_cover_index_on_pt_1_prt_4 (actual rows=1 loops=1)
-               Filter: (a < 10)
-               Rows Removed by Filter: 1
+         ->  Index Only Scan using test_cover_index_on_pt_1_prt_1_a_b_idx on test_cover_index_on_pt_1_prt_1 (actual rows=1 loops=1)
+               Index Cond: (a < 10)
+               Heap Fetches: 0
+         ->  Index Only Scan using test_cover_index_on_pt_1_prt_2_a_b_idx on test_cover_index_on_pt_1_prt_2 (actual rows=1 loops=1)
+               Index Cond: (a < 10)
+               Heap Fetches: 0
+         ->  Index Only Scan using leaf_part_a_b_idx on test_cover_index_on_pt_1_prt_3 (actual rows=1 loops=1)
+               Index Cond: (a < 10)
+               Heap Fetches: 0
+         ->  Index Only Scan using test_cover_index_on_pt_1_prt_4_a_b_idx on test_cover_index_on_pt_1_prt_4 (actual rows=1 loops=1)
+               Index Cond: (a < 10)
+               Heap Fetches: 0
  Optimizer: Postgres query optimizer
-(14 rows)
+(15 rows)
 
 DROP INDEX i_test_cover_index_scan_on_partition_table;
 -- with explicit index declared on leaf_part
@@ -466,7 +530,7 @@ SELECT a, b FROM test_cover_index_on_pt WHERE a<10;
  Optimizer: Postgres query optimizer
 (14 rows)
 
--- 7) Test various index types
+-- Test various index types
 --
 -- Check that different index types can be used with cover indexes.
 -- Note: brin, hash, and spgist do not suport included columns.
@@ -475,16 +539,18 @@ INSERT INTO test_index_types VALUES ('(2.0,2.0,0.0,0.0)', 2, 2);
 INSERT INTO test_index_types VALUES ('(1.0,1.0,3.0,3.0)', 3, 3);
 CREATE INDEX i_test_index_types ON test_index_types USING GIST (a) INCLUDE (b);
 VACUUM ANALYZE test_index_types;
+-- KEYS: [a]    INCLUDED: [b]
 -- ORCA_FEATURE_NOT_SUPPORTED: support index-only-scan on GIST indexes
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 SELECT a, b FROM test_index_types WHERE a<@ box '(0,0,3,3)';
-                            QUERY PLAN                            
-------------------------------------------------------------------
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=2 loops=1)
-   ->  Seq Scan on test_index_types (actual rows=2 loops=1)
-         Filter: (a <@ '(3,3),(0,0)'::box)
+   ->  Index Only Scan using i_test_index_types on test_index_types (actual rows=2 loops=1)
+         Index Cond: (a <@ '(3,3),(0,0)'::box)
+         Heap Fetches: 0
  Optimizer: Postgres query optimizer
-(4 rows)
+(5 rows)
 
 -- 8) Test partial indexes
 --
@@ -495,6 +561,7 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 CREATE INDEX i_test_partial_index ON test_partial_index(a) INCLUDE (b) WHERE a<42;
 INSERT INTO test_partial_index SELECT i, i+i, i*i FROM generate_series(1, 100)i;
 VACUUM ANALYZE test_partial_index;
+-- KEYS: [a]    INCLUDED: [b]
 -- ORCA_FEATURE_NOT_SUPPORTED: support partial indexes
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 SELECT b FROM test_partial_index WHERE a>42 AND b>42;
@@ -507,31 +574,29 @@ SELECT b FROM test_partial_index WHERE a>42 AND b>42;
  Optimizer: Postgres query optimizer
 (5 rows)
 
--- 9) Test backward index scan
+-- Test backward index scan
 --
 -- Check that cover indexes may be used for backward index scan
 CREATE TABLE test_backward_index_scan(a int, b int, c int) DISTRIBUTED BY (a);
 CREATE INDEX i_test_backward_index_scan ON test_backward_index_scan(a) INCLUDE (b);
 INSERT INTO test_backward_index_scan SELECT i, i+i, i*i FROM generate_series(1, 100)i;
 VACUUM ANALYZE test_backward_index_scan;
+-- KEYS: [a]    INCLUDED: [b]
 -- ORCA_FEATURE_NOT_SUPPORTED enable backward index scan
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 SELECT b FROM test_backward_index_scan WHERE a>42 AND b>42 ORDER BY a DESC;
-                                QUERY PLAN                                 
----------------------------------------------------------------------------
+                                                      QUERY PLAN                                                      
+----------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=58 loops=1)
    Merge Key: a
-   ->  Sort (actual rows=25 loops=1)
-         Sort Key: a DESC
-         Sort Method:  quicksort  Memory: 77kB
-         Executor Memory: 177kB  Segments: 3  Max: 59kB (segment 0)
-         ->  Seq Scan on test_backward_index_scan (actual rows=25 loops=1)
-               Filter: ((a > 42) AND (b > 42))
-               Rows Removed by Filter: 12
+   ->  Index Only Scan Backward using i_test_backward_index_scan on test_backward_index_scan (actual rows=25 loops=1)
+         Index Cond: (a > 42)
+         Filter: (b > 42)
+         Heap Fetches: 0
  Optimizer: Postgres query optimizer
-(10 rows)
+(7 rows)
 
--- 10) Test index expressions
+-- Test index expressions
 --
 -- Check that cover indexes may be used for index expressions
 CREATE OR REPLACE FUNCTION add_one(integer)
@@ -546,19 +611,21 @@ CREATE TABLE test_index_expression_scan(a int, b int, c int) DISTRIBUTED BY (a);
 CREATE INDEX i_test_index_expression_scan ON test_index_expression_scan(a) INCLUDE (b);
 INSERT INTO test_index_expression_scan SELECT i, i+i, i*i FROM generate_series(1, 100)i;
 VACUUM ANALYZE test_index_expression_scan;
+-- KEYS: [a]    INCLUDED: [b]
 -- ORCA_FEATURE_NOT_SUPPORTED enable index expression
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 SELECT add_one(b) FROM test_index_expression_scan WHERE add_one(a) < 42;
-                              QUERY PLAN                               
------------------------------------------------------------------------
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=40 loops=1)
-   ->  Seq Scan on test_index_expression_scan (actual rows=15 loops=1)
+   ->  Index Only Scan using i_test_index_expression_scan on test_index_expression_scan (actual rows=15 loops=1)
          Filter: (add_one(a) < 42)
          Rows Removed by Filter: 23
+         Heap Fetches: 0
  Optimizer: Postgres query optimizer
-(5 rows)
+(6 rows)
 
--- 11) Test combined indexes
+-- Test combined indexes
 --
 -- Check that combined indexes may be used.  (on OR conditions) https://www.postgresql.org/docs/current/indexes-bitmap-scans.html
 CREATE TABLE test_combined_index_scan(a int, b int, c int) DISTRIBUTED BY (a);
@@ -566,16 +633,20 @@ CREATE INDEX i_test_combined_index_scan_a ON test_combined_index_scan(a) INCLUDE
 CREATE INDEX i_test_combined_index_scan_b ON test_combined_index_scan(b) INCLUDE (a);
 INSERT INTO test_combined_index_scan SELECT i, i+i, i*i FROM generate_series(1, 100)i;
 VACUUM ANALYZE test_combined_index_scan;
+-- KEYS: [a]    INCLUDED: [b]
+-- KEYS: [b]    INCLUDED: [a]
 -- ORCA_FEATURE_NOT_SUPPORTED enable combined index
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 SELECT b FROM test_combined_index_scan WHERE a < 42 OR b < 42;
-                             QUERY PLAN                              
----------------------------------------------------------------------
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=41 loops=1)
-   ->  Seq Scan on test_combined_index_scan (actual rows=16 loops=1)
+   ->  Index Only Scan using i_test_combined_index_scan_b on test_combined_index_scan (actual rows=16 loops=1)
          Filter: ((a < 42) OR (b < 42))
          Rows Removed by Filter: 22
+         Heap Fetches: 0
  Optimizer: Postgres query optimizer
-(5 rows)
+(6 rows)
 
 reset optimizer_trace_fallback;
+reset enable_seqscan;

--- a/src/test/regress/expected/gp_covering_index_optimizer.out
+++ b/src/test/regress/expected/gp_covering_index_optimizer.out
@@ -4,18 +4,23 @@
 --          indexes in varying scenarios. Correctness is determined by the
 --          number of output rows from each query.
 --          Does the plan use index-scan, index-only-scan, or seq-scan?
+--
+-- N.B. "VACUUM ANALZE" is to update relallvisible used to determine cost of an
+--      index-only scan.
 -- start_matchsubs
 -- m/Memory: \d+kB/
 -- s/Memory: \d+kB/Memory: ###kB/
 -- end_matchsubs
 set optimizer_trace_fallback=on;
--- 0) Basic scenario
+set enable_seqscan=off;
+-- Basic scenario
 CREATE TABLE test_basic_cover_index(a int, b int, c int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 CREATE INDEX i_test_basic_index ON test_basic_cover_index(a) INCLUDE (b);
 INSERT INTO test_basic_cover_index SELECT i, i+i, i*i FROM generate_series(1, 100)i;
 VACUUM ANALYZE test_basic_cover_index;
+-- KEYS: [a]    INCLUDED: [b]
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 SELECT b FROM test_basic_cover_index WHERE a>42 AND b>42;
                                             QUERY PLAN                                             
@@ -28,10 +33,11 @@ SELECT b FROM test_basic_cover_index WHERE a>42 AND b>42;
  Optimizer: Pivotal Optimizer (GPORCA)
 (6 rows)
 
--- 0) Test CTE with cover indexes
+-- Test CTE with cover indexes
 --
 -- Check that CTE over scan with cover index and cover index over cte both work
 -- ORCA_FEATURE_NOT_SUPPORTED: allow index-only-scan over CTE
+-- KEYS: [a]    INCLUDED: [b]
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 WITH cte AS
 (
@@ -48,6 +54,7 @@ SELECT b FROM cte WHERE b%2=0;
 (5 rows)
 
 -- ORCA_FEATURE_NOT_SUPPORTED: allow index-only-scan over CTE
+-- KEYS: [a]    INCLUDED: [b]
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 WITH cte AS
 (
@@ -62,11 +69,12 @@ SELECT b FROM cte WHERE a<42;
  Optimizer: Pivotal Optimizer (GPORCA)
 (4 rows)
 
--- 0) Views over cover indexes
+-- Views over cover indexes
 CREATE VIEW view_test_cover_indexes_with_filter AS
 SELECT a, b FROM test_basic_cover_index WHERE a<42;
 CREATE VIEW view_test_cover_indexes_without_filter AS
 SELECT a, b FROM test_basic_cover_index;
+-- KEYS: [a]    INCLUDED: [b]
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 SELECT b FROM view_test_cover_indexes_with_filter;
                                             QUERY PLAN                                             
@@ -78,6 +86,7 @@ SELECT b FROM view_test_cover_indexes_with_filter;
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
 
+-- KEYS: [a]    INCLUDED: [b]
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 SELECT b FROM view_test_cover_indexes_without_filter WHERE a<42;
                                             QUERY PLAN                                             
@@ -89,7 +98,7 @@ SELECT b FROM view_test_cover_indexes_without_filter WHERE a<42;
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
 
--- 1) Various Column Types
+-- Various Column Types
 --
 -- Use different column types to check that the scan associates the correct
 -- type to the correct column
@@ -99,6 +108,7 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 INSERT INTO test_various_col_types SELECT i, 'texttype'||i, i FROM generate_series(1,9999) i;
 CREATE INDEX i_test_various_col_types ON test_various_col_types(inttype) INCLUDE (texttype);
 VACUUM ANALYZE test_various_col_types;
+-- KEYS: [inttype] INCLUDED: [texttype]
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF) SELECT texttype FROM test_various_col_types WHERE inttype<42;
                                                QUERY PLAN                                                
 ---------------------------------------------------------------------------------------------------------
@@ -112,6 +122,7 @@ EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF) SELECT texttype FROM test_
 DROP INDEX i_test_various_col_types;
 CREATE INDEX i_test_various_col_types ON test_various_col_types(decimaltype) INCLUDE (inttype);
 VACUUM ANALYZE test_various_col_types;
+-- KEYS: [decimaltype] INCLUDED: [inttype]
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF) SELECT decimaltype, inttype FROM test_various_col_types WHERE decimaltype<42;
                                                QUERY PLAN                                                
 ---------------------------------------------------------------------------------------------------------
@@ -126,6 +137,7 @@ ALTER TABLE test_various_col_types ADD COLUMN boxtype box;
 DROP INDEX i_test_various_col_types;
 CREATE INDEX i_test_various_col_types ON test_various_col_types(decimaltype) INCLUDE (boxtype);
 VACUUM ANALYZE test_various_col_types;
+-- KEYS: [decimaltype] INCLUDED: [boxtype]
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF) SELECT decimaltype, boxtype FROM test_various_col_types WHERE decimaltype<42;
                                                QUERY PLAN                                                
 ---------------------------------------------------------------------------------------------------------
@@ -136,7 +148,7 @@ EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF) SELECT decimaltype, boxtyp
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
 
--- 2) Test drop/add columns before and after creation of the index
+-- Test drop/add columns before and after creation of the index
 --
 -- Alter (add/drop) columns to check that the correct data is read from the
 -- physical scan.
@@ -150,6 +162,7 @@ ALTER TABLE test_add_drop_columns ADD COLUMN e int;
 CREATE INDEX i_test_add_drop_columns ON test_add_drop_columns(a, b) INCLUDE (c);
 ALTER TABLE test_add_drop_columns ADD COLUMN f int;
 VACUUM ANALYZE test_add_drop_columns;
+-- KEYS: [a, b] INCLUDED: [c]
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 SELECT a, b FROM test_add_drop_columns WHERE a<42 AND b>42;
                                               QUERY PLAN                                              
@@ -161,6 +174,7 @@ SELECT a, b FROM test_add_drop_columns WHERE a<42 AND b>42;
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
 
+-- KEYS: [a, b] INCLUDED: [c]
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 SELECT a, b FROM test_add_drop_columns WHERE a<42 AND b>42 AND c>42;
                                               QUERY PLAN                                              
@@ -173,6 +187,7 @@ SELECT a, b FROM test_add_drop_columns WHERE a<42 AND b>42 AND c>42;
  Optimizer: Pivotal Optimizer (GPORCA)
 (6 rows)
 
+-- KEYS: [a, b] INCLUDED: [c]
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 SELECT a, b, c, d, e FROM test_add_drop_columns WHERE a<42 AND b>42 AND c>42 AND e IS NULL;
                                            QUERY PLAN                                            
@@ -184,7 +199,7 @@ SELECT a, b, c, d, e FROM test_add_drop_columns WHERE a<42 AND b>42 AND c>42 AND
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
 
--- 3) Test various table types (e.g. AO/AOCO/replicated)
+-- Test various table types (e.g. AO/AOCO/replicated)
 --
 -- Check that different tables types (storage/distribution) leveage cover
 -- indexes correctly.
@@ -192,6 +207,7 @@ CREATE TABLE test_replicated(a int, b int, c int) DISTRIBUTED REPLICATED;
 CREATE INDEX i_test_replicated ON test_replicated(a) INCLUDE (b);
 INSERT INTO test_replicated SELECT i, i+i, i*i FROM generate_series(1, 100)i;
 VACUUM ANALYZE test_replicated;
+-- KEYS: [a] INCLUDED: [b]
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 SELECT b FROM test_replicated WHERE a<42 AND b>42;
                                         QUERY PLAN                                         
@@ -205,6 +221,7 @@ SELECT b FROM test_replicated WHERE a<42 AND b>42;
  Optimizer: Pivotal Optimizer (GPORCA)
 (7 rows)
 
+-- KEYS: [a] INCLUDED: [b]
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 SELECT b, c FROM test_replicated WHERE a<42 AND b>42;
                                       QUERY PLAN                                      
@@ -217,6 +234,8 @@ SELECT b, c FROM test_replicated WHERE a<42 AND b>42;
  Optimizer: Pivotal Optimizer (GPORCA)
 (6 rows)
 
+-- Expect Seq Scan because predicate "c" is not in KEYS
+-- KEYS: [a] INCLUDED: [b]
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 SELECT a, b, c FROM test_replicated WHERE c>42;
                             QUERY PLAN                             
@@ -233,6 +252,7 @@ CREATE TABLE test_ao(a int, b int, c int) WITH (appendonly=true) DISTRIBUTED BY 
 CREATE INDEX i_test_ao ON test_ao(a) INCLUDE (b);
 INSERT INTO test_ao SELECT i, i+i, i*i FROM generate_series(1, 100)i;
 VACUUM ANALYZE test_ao;
+-- KEYS: [a] INCLUDED: [b]
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 SELECT b FROM test_ao WHERE a<42 AND b>42;
                             QUERY PLAN                             
@@ -244,6 +264,7 @@ SELECT b FROM test_ao WHERE a<42 AND b>42;
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
 
+-- KEYS: [a] INCLUDED: [b]
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 SELECT b, c FROM test_ao WHERE a<42 AND b>42;
                             QUERY PLAN                             
@@ -255,6 +276,7 @@ SELECT b, c FROM test_ao WHERE a<42 AND b>42;
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
 
+-- KEYS: [a] INCLUDED: [b]
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 SELECT a, b, c FROM test_ao WHERE c>42;
                             QUERY PLAN                             
@@ -266,7 +288,7 @@ SELECT a, b, c FROM test_ao WHERE c>42;
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
 
--- 4) Test select best covering index
+-- Test select best covering index
 --
 -- Check that the best cover index is chosen for a plan when multiple cover
 -- indexes are available.
@@ -281,6 +303,12 @@ CREATE INDEX i_test_select_best_cover_b_a ON test_select_best_cover(a) INCLUDE (
 CREATE INDEX i_test_select_best_cover_a_bc ON test_select_best_cover(a) INCLUDE (b, c);
 INSERT INTO test_select_best_cover SELECT i, i+i, i*i FROM generate_series(1, 100)i;
 VACUUM ANALYZE test_select_best_cover;
+-- KEYS: [a]    INCLUDED: []
+-- KEYS: [a]    INCLUDED: [b]
+-- KEYS: [a, b] INCLUDED: []
+-- KEYS: [b]    INCLUDED: []
+-- KEYS: [a]    INCLUDED: [b]
+-- KEYS: [a]    INCLUDED: [b, c]
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 SELECT a FROM test_select_best_cover WHERE a>42;
                                                 QUERY PLAN                                                 
@@ -292,6 +320,12 @@ SELECT a FROM test_select_best_cover WHERE a>42;
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
 
+-- KEYS: [a]    INCLUDED: []
+-- KEYS: [a]    INCLUDED: [b]
+-- KEYS: [a, b] INCLUDED: []
+-- KEYS: [b]    INCLUDED: []
+-- KEYS: [a]    INCLUDED: [b]
+-- KEYS: [a]    INCLUDED: [b, c]
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 SELECT b FROM test_select_best_cover WHERE b>42;
                                                 QUERY PLAN                                                 
@@ -303,6 +337,12 @@ SELECT b FROM test_select_best_cover WHERE b>42;
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
 
+-- KEYS: [a]    INCLUDED: []
+-- KEYS: [a]    INCLUDED: [b]
+-- KEYS: [a, b] INCLUDED: []
+-- KEYS: [b]    INCLUDED: []
+-- KEYS: [a]    INCLUDED: [b]
+-- KEYS: [a]    INCLUDED: [b, c]
 -- ORCA_FEATURE_NOT_SUPPORTED: use i_test_select_best_cover_ab
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 SELECT b FROM test_select_best_cover WHERE a>42 AND b>42;
@@ -316,6 +356,12 @@ SELECT b FROM test_select_best_cover WHERE a>42 AND b>42;
  Optimizer: Pivotal Optimizer (GPORCA)
 (6 rows)
 
+-- KEYS: [a]    INCLUDED: []
+-- KEYS: [a]    INCLUDED: [b]
+-- KEYS: [a, b] INCLUDED: []
+-- KEYS: [b]    INCLUDED: []
+-- KEYS: [a]    INCLUDED: [b]
+-- KEYS: [a]    INCLUDED: [b, c]
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 SELECT b FROM test_select_best_cover WHERE a>42 AND b>42 AND c>42;
                                                   QUERY PLAN                                                  
@@ -328,7 +374,7 @@ SELECT b FROM test_select_best_cover WHERE a>42 AND b>42 AND c>42;
  Optimizer: Pivotal Optimizer (GPORCA)
 (6 rows)
 
--- 5) Test DML operations
+-- Test DML operations
 --
 -- Check that cover indexes can be used with DML operations
 CREATE TABLE test_dml_using_cover_index(a int, b int, c int);
@@ -337,6 +383,7 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 CREATE INDEX i_test_dml_using_cover_index ON test_dml_using_cover_index(a) INCLUDE (b);
 INSERT INTO test_dml_using_cover_index SELECT i, i+i, i*i FROM generate_series(1, 100)i;
 VACUUM ANALYZE test_dml_using_cover_index;
+-- KEYS: [a]    INCLUDED: [b]
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 INSERT INTO test_dml_using_cover_index (SELECT a, a, a FROM test_dml_using_cover_index WHERE a>42);
                                                                   QUERY PLAN                                                                  
@@ -348,7 +395,7 @@ INSERT INTO test_dml_using_cover_index (SELECT a, a, a FROM test_dml_using_cover
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
 
--- 6) Test index scan over partition tables
+-- Test index scan over partition tables
 --
 -- Check that cover indexes can be used with partition tables. This includes
 -- scenario when root/leaf partitions have different underlying physical format
@@ -363,6 +410,7 @@ PARTITION BY RANGE (b)
 CREATE INDEX i_test_cover_index_scan_on_partition_table ON test_cover_index_on_pt(a) INCLUDE(b);
 INSERT INTO test_cover_index_on_pt SELECT i+i, i%4 FROM generate_series(1, 10)i;
 VACUUM ANALYZE test_cover_index_on_pt;
+-- KEYS: [a]    INCLUDED: [b]
 -- ORCA_FEATURE_NOT_SUPPORTED: dynamic index only scan
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 SELECT a, b FROM test_cover_index_on_pt WHERE a<10;
@@ -376,6 +424,7 @@ SELECT a, b FROM test_cover_index_on_pt WHERE a<10;
  Optimizer: Pivotal Optimizer (GPORCA)
 (6 rows)
 
+-- KEYS: [a]    INCLUDED: [b]
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 SELECT a, b, c FROM test_cover_index_on_pt WHERE a<10;
                                                         QUERY PLAN                                                        
@@ -388,6 +437,8 @@ SELECT a, b, c FROM test_cover_index_on_pt WHERE a<10;
  Optimizer: Pivotal Optimizer (GPORCA)
 (6 rows)
 
+-- Expect Seq Scan because predicate "b" is not in KEYS
+-- KEYS: [a]    INCLUDED: [b]
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 SELECT a, b, c FROM test_cover_index_on_pt WHERE b<10;
                                 QUERY PLAN                                
@@ -405,6 +456,7 @@ CREATE TABLE leaf_part(a int, b int, c int) DISTRIBUTED BY (a);
 ALTER TABLE test_cover_index_on_pt EXCHANGE PARTITION FOR(2) WITH TABLE leaf_part;
 INSERT INTO test_cover_index_on_pt VALUES (2, 2, 2);
 VACUUM ANALYZE test_cover_index_on_pt;
+-- KEYS: [a]    INCLUDED: [b]
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 SELECT a, b FROM test_cover_index_on_pt WHERE a<10;
                                                         QUERY PLAN                                                        
@@ -434,7 +486,7 @@ SELECT a, b FROM test_cover_index_on_pt WHERE a<10;
  Optimizer: Pivotal Optimizer (GPORCA)
 (6 rows)
 
--- 7) Test various index types
+-- Test various index types
 --
 -- Check that different index types can be used with cover indexes.
 -- Note: brin, hash, and spgist do not suport included columns.
@@ -443,6 +495,7 @@ INSERT INTO test_index_types VALUES ('(2.0,2.0,0.0,0.0)', 2, 2);
 INSERT INTO test_index_types VALUES ('(1.0,1.0,3.0,3.0)', 3, 3);
 CREATE INDEX i_test_index_types ON test_index_types USING GIST (a) INCLUDE (b);
 VACUUM ANALYZE test_index_types;
+-- KEYS: [a]    INCLUDED: [b]
 -- ORCA_FEATURE_NOT_SUPPORTED: support index-only-scan on GIST indexes
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 SELECT a, b FROM test_index_types WHERE a<@ box '(0,0,3,3)';
@@ -464,6 +517,7 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 CREATE INDEX i_test_partial_index ON test_partial_index(a) INCLUDE (b) WHERE a<42;
 INSERT INTO test_partial_index SELECT i, i+i, i*i FROM generate_series(1, 100)i;
 VACUUM ANALYZE test_partial_index;
+-- KEYS: [a]    INCLUDED: [b]
 -- ORCA_FEATURE_NOT_SUPPORTED: support partial indexes
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 SELECT b FROM test_partial_index WHERE a>42 AND b>42;
@@ -476,13 +530,14 @@ SELECT b FROM test_partial_index WHERE a>42 AND b>42;
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
 
--- 9) Test backward index scan
+-- Test backward index scan
 --
 -- Check that cover indexes may be used for backward index scan
 CREATE TABLE test_backward_index_scan(a int, b int, c int) DISTRIBUTED BY (a);
 CREATE INDEX i_test_backward_index_scan ON test_backward_index_scan(a) INCLUDE (b);
 INSERT INTO test_backward_index_scan SELECT i, i+i, i*i FROM generate_series(1, 100)i;
 VACUUM ANALYZE test_backward_index_scan;
+-- KEYS: [a]    INCLUDED: [b]
 -- ORCA_FEATURE_NOT_SUPPORTED enable backward index scan
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 SELECT b FROM test_backward_index_scan WHERE a>42 AND b>42 ORDER BY a DESC;
@@ -502,7 +557,7 @@ SELECT b FROM test_backward_index_scan WHERE a>42 AND b>42 ORDER BY a DESC;
  Optimizer: Pivotal Optimizer (GPORCA)
 (12 rows)
 
--- 10) Test index expressions
+-- Test index expressions
 --
 -- Check that cover indexes may be used for index expressions
 CREATE OR REPLACE FUNCTION add_one(integer)
@@ -517,6 +572,7 @@ CREATE TABLE test_index_expression_scan(a int, b int, c int) DISTRIBUTED BY (a);
 CREATE INDEX i_test_index_expression_scan ON test_index_expression_scan(a) INCLUDE (b);
 INSERT INTO test_index_expression_scan SELECT i, i+i, i*i FROM generate_series(1, 100)i;
 VACUUM ANALYZE test_index_expression_scan;
+-- KEYS: [a]    INCLUDED: [b]
 -- ORCA_FEATURE_NOT_SUPPORTED enable index expression
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 SELECT add_one(b) FROM test_index_expression_scan WHERE add_one(a) < 42;
@@ -529,7 +585,7 @@ SELECT add_one(b) FROM test_index_expression_scan WHERE add_one(a) < 42;
  Optimizer: Pivotal Optimizer (GPORCA)
 (5 rows)
 
--- 11) Test combined indexes
+-- Test combined indexes
 --
 -- Check that combined indexes may be used.  (on OR conditions) https://www.postgresql.org/docs/current/indexes-bitmap-scans.html
 CREATE TABLE test_combined_index_scan(a int, b int, c int) DISTRIBUTED BY (a);
@@ -537,6 +593,8 @@ CREATE INDEX i_test_combined_index_scan_a ON test_combined_index_scan(a) INCLUDE
 CREATE INDEX i_test_combined_index_scan_b ON test_combined_index_scan(b) INCLUDE (a);
 INSERT INTO test_combined_index_scan SELECT i, i+i, i*i FROM generate_series(1, 100)i;
 VACUUM ANALYZE test_combined_index_scan;
+-- KEYS: [a]    INCLUDED: [b]
+-- KEYS: [b]    INCLUDED: [a]
 -- ORCA_FEATURE_NOT_SUPPORTED enable combined index
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 SELECT b FROM test_combined_index_scan WHERE a < 42 OR b < 42;
@@ -550,3 +608,4 @@ SELECT b FROM test_combined_index_scan WHERE a < 42 OR b < 42;
 (5 rows)
 
 reset optimizer_trace_fallback;
+reset enable_seqscan;

--- a/src/test/regress/expected/gp_covering_index_optimizer.out
+++ b/src/test/regress/expected/gp_covering_index_optimizer.out
@@ -1,0 +1,552 @@
+-- Test Covering Indexes Feature
+--
+-- Purpose: Test that plans are optimal and correct using permutations of cover
+--          indexes in varying scenarios. Correctness is determined by the
+--          number of output rows from each query.
+--          Does the plan use index-scan, index-only-scan, or seq-scan?
+-- start_matchsubs
+-- m/Memory: \d+kB/
+-- s/Memory: \d+kB/Memory: ###kB/
+-- end_matchsubs
+set optimizer_trace_fallback=on;
+-- 0) Basic scenario
+CREATE TABLE test_basic_cover_index(a int, b int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE INDEX i_test_basic_index ON test_basic_cover_index(a) INCLUDE (b);
+INSERT INTO test_basic_cover_index SELECT i, i+i, i*i FROM generate_series(1, 100)i;
+VACUUM ANALYZE test_basic_cover_index;
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT b FROM test_basic_cover_index WHERE a>42 AND b>42;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=58 loops=1)
+   ->  Index Only Scan using i_test_basic_index on test_basic_cover_index (actual rows=25 loops=1)
+         Index Cond: (a > 42)
+         Filter: (b > 42)
+         Heap Fetches: 0
+ Optimizer: Pivotal Optimizer (GPORCA)
+(6 rows)
+
+-- 0) Test CTE with cover indexes
+--
+-- Check that CTE over scan with cover index and cover index over cte both work
+-- ORCA_FEATURE_NOT_SUPPORTED: allow index-only-scan over CTE
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+WITH cte AS
+(
+    SELECT b FROM test_basic_cover_index WHERE a < 42
+)
+SELECT b FROM cte WHERE b%2=0;
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=41 loops=1)
+   ->  Index Scan using i_test_basic_index on test_basic_cover_index (actual rows=16 loops=1)
+         Index Cond: (a < 42)
+         Filter: ((b % 2) = 0)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(5 rows)
+
+-- ORCA_FEATURE_NOT_SUPPORTED: allow index-only-scan over CTE
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+WITH cte AS
+(
+    SELECT a, b FROM test_basic_cover_index
+)
+SELECT b FROM cte WHERE a<42;
+                                          QUERY PLAN                                          
+----------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=41 loops=1)
+   ->  Index Scan using i_test_basic_index on test_basic_cover_index (actual rows=16 loops=1)
+         Index Cond: (a < 42)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(4 rows)
+
+-- 0) Views over cover indexes
+CREATE VIEW view_test_cover_indexes_with_filter AS
+SELECT a, b FROM test_basic_cover_index WHERE a<42;
+CREATE VIEW view_test_cover_indexes_without_filter AS
+SELECT a, b FROM test_basic_cover_index;
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT b FROM view_test_cover_indexes_with_filter;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=41 loops=1)
+   ->  Index Only Scan using i_test_basic_index on test_basic_cover_index (actual rows=16 loops=1)
+         Index Cond: (a < 42)
+         Heap Fetches: 0
+ Optimizer: Pivotal Optimizer (GPORCA)
+(5 rows)
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT b FROM view_test_cover_indexes_without_filter WHERE a<42;
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=41 loops=1)
+   ->  Index Only Scan using i_test_basic_index on test_basic_cover_index (actual rows=16 loops=1)
+         Index Cond: (a < 42)
+         Heap Fetches: 0
+ Optimizer: Pivotal Optimizer (GPORCA)
+(5 rows)
+
+-- 1) Various Column Types
+--
+-- Use different column types to check that the scan associates the correct
+-- type to the correct column
+CREATE TABLE test_various_col_types(inttype int, texttype text, decimaltype decimal(10,2));
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'inttype' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO test_various_col_types SELECT i, 'texttype'||i, i FROM generate_series(1,9999) i;
+CREATE INDEX i_test_various_col_types ON test_various_col_types(inttype) INCLUDE (texttype);
+VACUUM ANALYZE test_various_col_types;
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF) SELECT texttype FROM test_various_col_types WHERE inttype<42;
+                                               QUERY PLAN                                                
+---------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=41 loops=1)
+   ->  Index Only Scan using i_test_various_col_types on test_various_col_types (actual rows=16 loops=1)
+         Index Cond: (inttype < 42)
+         Heap Fetches: 0
+ Optimizer: Pivotal Optimizer (GPORCA)
+(5 rows)
+
+DROP INDEX i_test_various_col_types;
+CREATE INDEX i_test_various_col_types ON test_various_col_types(decimaltype) INCLUDE (inttype);
+VACUUM ANALYZE test_various_col_types;
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF) SELECT decimaltype, inttype FROM test_various_col_types WHERE decimaltype<42;
+                                               QUERY PLAN                                                
+---------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=41 loops=1)
+   ->  Index Only Scan using i_test_various_col_types on test_various_col_types (actual rows=16 loops=1)
+         Index Cond: (decimaltype < '42'::numeric)
+         Heap Fetches: 0
+ Optimizer: Pivotal Optimizer (GPORCA)
+(5 rows)
+
+ALTER TABLE test_various_col_types ADD COLUMN boxtype box;
+DROP INDEX i_test_various_col_types;
+CREATE INDEX i_test_various_col_types ON test_various_col_types(decimaltype) INCLUDE (boxtype);
+VACUUM ANALYZE test_various_col_types;
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF) SELECT decimaltype, boxtype FROM test_various_col_types WHERE decimaltype<42;
+                                               QUERY PLAN                                                
+---------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=41 loops=1)
+   ->  Index Only Scan using i_test_various_col_types on test_various_col_types (actual rows=16 loops=1)
+         Index Cond: (decimaltype < '42'::numeric)
+         Heap Fetches: 0
+ Optimizer: Pivotal Optimizer (GPORCA)
+(5 rows)
+
+-- 2) Test drop/add columns before and after creation of the index
+--
+-- Alter (add/drop) columns to check that the correct data is read from the
+-- physical scan.
+CREATE TABLE test_add_drop_columns(a int, aa int, b int, bb int, c int, d int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+ALTER TABLE test_add_drop_columns DROP COLUMN aa;
+INSERT INTO test_add_drop_columns SELECT i, i+i, i*i, i*i*i, i+i+i FROM generate_series(1, 100)i;
+ALTER TABLE test_add_drop_columns DROP COLUMN bb;
+ALTER TABLE test_add_drop_columns ADD COLUMN e int;
+CREATE INDEX i_test_add_drop_columns ON test_add_drop_columns(a, b) INCLUDE (c);
+ALTER TABLE test_add_drop_columns ADD COLUMN f int;
+VACUUM ANALYZE test_add_drop_columns;
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT a, b FROM test_add_drop_columns WHERE a<42 AND b>42;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=20 loops=1)
+   ->  Index Only Scan using i_test_add_drop_columns on test_add_drop_columns (actual rows=8 loops=1)
+         Index Cond: ((a < 42) AND (b > 42))
+         Heap Fetches: 0
+ Optimizer: Pivotal Optimizer (GPORCA)
+(5 rows)
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT a, b FROM test_add_drop_columns WHERE a<42 AND b>42 AND c>42;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=20 loops=1)
+   ->  Index Only Scan using i_test_add_drop_columns on test_add_drop_columns (actual rows=8 loops=1)
+         Index Cond: ((a < 42) AND (b > 42))
+         Filter: (c > 42)
+         Heap Fetches: 0
+ Optimizer: Pivotal Optimizer (GPORCA)
+(6 rows)
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT a, b, c, d, e FROM test_add_drop_columns WHERE a<42 AND b>42 AND c>42 AND e IS NULL;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=20 loops=1)
+   ->  Index Scan using i_test_add_drop_columns on test_add_drop_columns (actual rows=8 loops=1)
+         Index Cond: ((a < 42) AND (b > 42))
+         Filter: ((c > 42) AND (e IS NULL))
+ Optimizer: Pivotal Optimizer (GPORCA)
+(5 rows)
+
+-- 3) Test various table types (e.g. AO/AOCO/replicated)
+--
+-- Check that different tables types (storage/distribution) leveage cover
+-- indexes correctly.
+CREATE TABLE test_replicated(a int, b int, c int) DISTRIBUTED REPLICATED;
+CREATE INDEX i_test_replicated ON test_replicated(a) INCLUDE (b);
+INSERT INTO test_replicated SELECT i, i+i, i*i FROM generate_series(1, 100)i;
+VACUUM ANALYZE test_replicated;
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT b FROM test_replicated WHERE a<42 AND b>42;
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1) (actual rows=20 loops=1)
+   ->  Index Only Scan using i_test_replicated on test_replicated (actual rows=20 loops=1)
+         Index Cond: (a < 42)
+         Filter: (b > 42)
+         Rows Removed by Filter: 21
+         Heap Fetches: 0
+ Optimizer: Pivotal Optimizer (GPORCA)
+(7 rows)
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT b, c FROM test_replicated WHERE a<42 AND b>42;
+                                      QUERY PLAN                                      
+--------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1) (actual rows=20 loops=1)
+   ->  Index Scan using i_test_replicated on test_replicated (actual rows=20 loops=1)
+         Index Cond: (a < 42)
+         Filter: (b > 42)
+         Rows Removed by Filter: 21
+ Optimizer: Pivotal Optimizer (GPORCA)
+(6 rows)
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT a, b, c FROM test_replicated WHERE c>42;
+                            QUERY PLAN                             
+-------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1) (actual rows=94 loops=1)
+   ->  Seq Scan on test_replicated (actual rows=94 loops=1)
+         Filter: (c > 42)
+         Rows Removed by Filter: 6
+ Optimizer: Pivotal Optimizer (GPORCA)
+(5 rows)
+
+-- ORCA_FEATURE_NOT_SUPPORTED: enable index scans on AO tables
+CREATE TABLE test_ao(a int, b int, c int) WITH (appendonly=true) DISTRIBUTED BY (a);
+CREATE INDEX i_test_ao ON test_ao(a) INCLUDE (b);
+INSERT INTO test_ao SELECT i, i+i, i*i FROM generate_series(1, 100)i;
+VACUUM ANALYZE test_ao;
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT b FROM test_ao WHERE a<42 AND b>42;
+                            QUERY PLAN                             
+-------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=20 loops=1)
+   ->  Seq Scan on test_ao (actual rows=8 loops=1)
+         Filter: ((a < 42) AND (b > 42))
+         Rows Removed by Filter: 30
+ Optimizer: Pivotal Optimizer (GPORCA)
+(5 rows)
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT b, c FROM test_ao WHERE a<42 AND b>42;
+                            QUERY PLAN                             
+-------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=20 loops=1)
+   ->  Seq Scan on test_ao (actual rows=8 loops=1)
+         Filter: ((a < 42) AND (b > 42))
+         Rows Removed by Filter: 30
+ Optimizer: Pivotal Optimizer (GPORCA)
+(5 rows)
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT a, b, c FROM test_ao WHERE c>42;
+                            QUERY PLAN                             
+-------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=94 loops=1)
+   ->  Seq Scan on test_ao (actual rows=36 loops=1)
+         Filter: (c > 42)
+         Rows Removed by Filter: 1
+ Optimizer: Pivotal Optimizer (GPORCA)
+(5 rows)
+
+-- 4) Test select best covering index
+--
+-- Check that the best cover index is chosen for a plan when multiple cover
+-- indexes are available.
+CREATE TABLE test_select_best_cover(a int, b int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE INDEX i_test_select_best_cover_a ON test_select_best_cover(a);
+CREATE INDEX i_test_select_best_cover_a_b ON test_select_best_cover(a) INCLUDE (b);
+CREATE INDEX i_test_select_best_cover_ab ON test_select_best_cover(a, b);
+CREATE INDEX i_test_select_best_cover_b ON test_select_best_cover(b);
+CREATE INDEX i_test_select_best_cover_b_a ON test_select_best_cover(a) INCLUDE (b);
+CREATE INDEX i_test_select_best_cover_a_bc ON test_select_best_cover(a) INCLUDE (b, c);
+INSERT INTO test_select_best_cover SELECT i, i+i, i*i FROM generate_series(1, 100)i;
+VACUUM ANALYZE test_select_best_cover;
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT a FROM test_select_best_cover WHERE a>42;
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=58 loops=1)
+   ->  Index Only Scan using i_test_select_best_cover_a on test_select_best_cover (actual rows=25 loops=1)
+         Index Cond: (a > 42)
+         Heap Fetches: 0
+ Optimizer: Pivotal Optimizer (GPORCA)
+(5 rows)
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT b FROM test_select_best_cover WHERE b>42;
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=79 loops=1)
+   ->  Index Only Scan using i_test_select_best_cover_b on test_select_best_cover (actual rows=33 loops=1)
+         Index Cond: (b > 42)
+         Heap Fetches: 0
+ Optimizer: Pivotal Optimizer (GPORCA)
+(5 rows)
+
+-- ORCA_FEATURE_NOT_SUPPORTED: use i_test_select_best_cover_ab
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT b FROM test_select_best_cover WHERE a>42 AND b>42;
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=58 loops=1)
+   ->  Index Only Scan using i_test_select_best_cover_a_b on test_select_best_cover (actual rows=25 loops=1)
+         Index Cond: (a > 42)
+         Filter: (b > 42)
+         Heap Fetches: 0
+ Optimizer: Pivotal Optimizer (GPORCA)
+(6 rows)
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT b FROM test_select_best_cover WHERE a>42 AND b>42 AND c>42;
+                                                  QUERY PLAN                                                  
+--------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=58 loops=1)
+   ->  Index Only Scan using i_test_select_best_cover_a_bc on test_select_best_cover (actual rows=25 loops=1)
+         Index Cond: (a > 42)
+         Filter: ((b > 42) AND (c > 42))
+         Heap Fetches: 0
+ Optimizer: Pivotal Optimizer (GPORCA)
+(6 rows)
+
+-- 5) Test DML operations
+--
+-- Check that cover indexes can be used with DML operations
+CREATE TABLE test_dml_using_cover_index(a int, b int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE INDEX i_test_dml_using_cover_index ON test_dml_using_cover_index(a) INCLUDE (b);
+INSERT INTO test_dml_using_cover_index SELECT i, i+i, i*i FROM generate_series(1, 100)i;
+VACUUM ANALYZE test_dml_using_cover_index;
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+INSERT INTO test_dml_using_cover_index (SELECT a, a, a FROM test_dml_using_cover_index WHERE a>42);
+                                                                  QUERY PLAN                                                                  
+----------------------------------------------------------------------------------------------------------------------------------------------
+ Insert on test_dml_using_cover_index (actual rows=0 loops=1)
+   ->  Index Only Scan using i_test_dml_using_cover_index on test_dml_using_cover_index test_dml_using_cover_index_1 (actual rows=25 loops=1)
+         Index Cond: (a > 42)
+         Heap Fetches: 24
+ Optimizer: Pivotal Optimizer (GPORCA)
+(5 rows)
+
+-- 6) Test index scan over partition tables
+--
+-- Check that cover indexes can be used with partition tables. This includes
+-- scenario when root/leaf partitions have different underlying physical format
+-- (e.g. drop column / exchange partition or leaf partition has cover index not
+-- defined on root).
+CREATE TABLE test_cover_index_on_pt(a int, b int, c int)
+DISTRIBUTED BY (a)
+PARTITION BY RANGE (b)
+(
+    START (0) END (4) EVERY (1)
+);
+CREATE INDEX i_test_cover_index_scan_on_partition_table ON test_cover_index_on_pt(a) INCLUDE(b);
+INSERT INTO test_cover_index_on_pt SELECT i+i, i%4 FROM generate_series(1, 10)i;
+VACUUM ANALYZE test_cover_index_on_pt;
+-- ORCA_FEATURE_NOT_SUPPORTED: dynamic index only scan
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT a, b FROM test_cover_index_on_pt WHERE a<10;
+                                                        QUERY PLAN                                                        
+--------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=4 loops=1)
+   ->  Dynamic Index Scan on i_test_cover_index_scan_on_partition_table on test_cover_index_on_pt (actual rows=3 loops=1)
+         Index Cond: (a < 10)
+         Number of partitions to scan: 4 (out of 4)
+         Partitions scanned:  Avg 4.0 x 3 workers.  Max 4 parts (seg0).
+ Optimizer: Pivotal Optimizer (GPORCA)
+(6 rows)
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT a, b, c FROM test_cover_index_on_pt WHERE a<10;
+                                                        QUERY PLAN                                                        
+--------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=4 loops=1)
+   ->  Dynamic Index Scan on i_test_cover_index_scan_on_partition_table on test_cover_index_on_pt (actual rows=3 loops=1)
+         Index Cond: (a < 10)
+         Number of partitions to scan: 4 (out of 4)
+         Partitions scanned:  Avg 4.0 x 3 workers.  Max 4 parts (seg0).
+ Optimizer: Pivotal Optimizer (GPORCA)
+(6 rows)
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT a, b, c FROM test_cover_index_on_pt WHERE b<10;
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=10 loops=1)
+   ->  Dynamic Seq Scan on test_cover_index_on_pt (actual rows=5 loops=1)
+         Number of partitions to scan: 4 (out of 4)
+         Filter: (b < 10)
+         Partitions scanned:  Avg 4.0 x 3 workers.  Max 4 parts (seg0).
+ Optimizer: Pivotal Optimizer (GPORCA)
+(6 rows)
+
+CREATE TABLE leaf_part(a int, b int, c int) DISTRIBUTED BY (a);
+-- without explicit index declared on leaf_part
+ALTER TABLE test_cover_index_on_pt EXCHANGE PARTITION FOR(2) WITH TABLE leaf_part;
+INSERT INTO test_cover_index_on_pt VALUES (2, 2, 2);
+VACUUM ANALYZE test_cover_index_on_pt;
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT a, b FROM test_cover_index_on_pt WHERE a<10;
+                                                        QUERY PLAN                                                        
+--------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=4 loops=1)
+   ->  Dynamic Index Scan on i_test_cover_index_scan_on_partition_table on test_cover_index_on_pt (actual rows=3 loops=1)
+         Index Cond: (a < 10)
+         Number of partitions to scan: 4 (out of 4)
+         Partitions scanned:  Avg 4.0 x 3 workers.  Max 4 parts (seg0).
+ Optimizer: Pivotal Optimizer (GPORCA)
+(6 rows)
+
+DROP INDEX i_test_cover_index_scan_on_partition_table;
+-- with explicit index declared on leaf_part
+CREATE INDEX i_test_cover_index_scan_on_partition_table ON leaf_part(a) INCLUDE(b);
+VACUUM ANALYZE test_cover_index_on_pt;
+-- ORCA_FEATURE_NOT_SUPPORTED: partial dynamic index scan
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT a, b FROM test_cover_index_on_pt WHERE a<10;
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=4 loops=1)
+   ->  Dynamic Seq Scan on test_cover_index_on_pt (actual rows=3 loops=1)
+         Number of partitions to scan: 4 (out of 4)
+         Filter: (a < 10)
+         Partitions scanned:  Avg 4.0 x 3 workers.  Max 4 parts (seg0).
+ Optimizer: Pivotal Optimizer (GPORCA)
+(6 rows)
+
+-- 7) Test various index types
+--
+-- Check that different index types can be used with cover indexes.
+-- Note: brin, hash, and spgist do not suport included columns.
+CREATE TABLE test_index_types(a box, b int, c int) DISTRIBUTED BY (b);
+INSERT INTO test_index_types VALUES ('(2.0,2.0,0.0,0.0)', 2, 2);
+INSERT INTO test_index_types VALUES ('(1.0,1.0,3.0,3.0)', 3, 3);
+CREATE INDEX i_test_index_types ON test_index_types USING GIST (a) INCLUDE (b);
+VACUUM ANALYZE test_index_types;
+-- ORCA_FEATURE_NOT_SUPPORTED: support index-only-scan on GIST indexes
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT a, b FROM test_index_types WHERE a<@ box '(0,0,3,3)';
+                                      QUERY PLAN                                       
+---------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=2 loops=1)
+   ->  Index Scan using i_test_index_types on test_index_types (actual rows=2 loops=1)
+         Index Cond: (a <@ '(3,3),(0,0)'::box)
+         Filter: (a <@ '(3,3),(0,0)'::box)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(5 rows)
+
+-- 8) Test partial indexes
+--
+-- Check that partial cover indexes may be used
+CREATE TABLE test_partial_index(a int, b int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE INDEX i_test_partial_index ON test_partial_index(a) INCLUDE (b) WHERE a<42;
+INSERT INTO test_partial_index SELECT i, i+i, i*i FROM generate_series(1, 100)i;
+VACUUM ANALYZE test_partial_index;
+-- ORCA_FEATURE_NOT_SUPPORTED: support partial indexes
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT b FROM test_partial_index WHERE a>42 AND b>42;
+                            QUERY PLAN                             
+-------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=58 loops=1)
+   ->  Seq Scan on test_partial_index (actual rows=25 loops=1)
+         Filter: ((a > 42) AND (b > 42))
+         Rows Removed by Filter: 12
+ Optimizer: Pivotal Optimizer (GPORCA)
+(5 rows)
+
+-- 9) Test backward index scan
+--
+-- Check that cover indexes may be used for backward index scan
+CREATE TABLE test_backward_index_scan(a int, b int, c int) DISTRIBUTED BY (a);
+CREATE INDEX i_test_backward_index_scan ON test_backward_index_scan(a) INCLUDE (b);
+INSERT INTO test_backward_index_scan SELECT i, i+i, i*i FROM generate_series(1, 100)i;
+VACUUM ANALYZE test_backward_index_scan;
+-- ORCA_FEATURE_NOT_SUPPORTED enable backward index scan
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT b FROM test_backward_index_scan WHERE a>42 AND b>42 ORDER BY a DESC;
+                                                       QUERY PLAN                                                        
+-------------------------------------------------------------------------------------------------------------------------
+ Result (actual rows=58 loops=1)
+   ->  Gather Motion 3:1  (slice1; segments: 3) (actual rows=58 loops=1)
+         Merge Key: a
+         ->  Sort (actual rows=25 loops=1)
+               Sort Key: a DESC
+               Sort Method:  quicksort  Memory: 77kB
+               Executor Memory: 177kB  Segments: 3  Max: 59kB (segment 0)
+               ->  Index Only Scan using i_test_backward_index_scan on test_backward_index_scan (actual rows=25 loops=1)
+                     Index Cond: (a > 42)
+                     Filter: (b > 42)
+                     Heap Fetches: 0
+ Optimizer: Pivotal Optimizer (GPORCA)
+(12 rows)
+
+-- 10) Test index expressions
+--
+-- Check that cover indexes may be used for index expressions
+CREATE OR REPLACE FUNCTION add_one(integer)
+RETURNS INTEGER
+LANGUAGE 'plpgsql'
+AS $$
+BEGIN
+    RETURN $1 + 1;
+END;
+$$;
+CREATE TABLE test_index_expression_scan(a int, b int, c int) DISTRIBUTED BY (a);
+CREATE INDEX i_test_index_expression_scan ON test_index_expression_scan(a) INCLUDE (b);
+INSERT INTO test_index_expression_scan SELECT i, i+i, i*i FROM generate_series(1, 100)i;
+VACUUM ANALYZE test_index_expression_scan;
+-- ORCA_FEATURE_NOT_SUPPORTED enable index expression
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT add_one(b) FROM test_index_expression_scan WHERE add_one(a) < 42;
+                              QUERY PLAN                               
+-----------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=40 loops=1)
+   ->  Seq Scan on test_index_expression_scan (actual rows=15 loops=1)
+         Filter: (add_one(a) < 42)
+         Rows Removed by Filter: 23
+ Optimizer: Pivotal Optimizer (GPORCA)
+(5 rows)
+
+-- 11) Test combined indexes
+--
+-- Check that combined indexes may be used.  (on OR conditions) https://www.postgresql.org/docs/current/indexes-bitmap-scans.html
+CREATE TABLE test_combined_index_scan(a int, b int, c int) DISTRIBUTED BY (a);
+CREATE INDEX i_test_combined_index_scan_a ON test_combined_index_scan(a) INCLUDE (b);
+CREATE INDEX i_test_combined_index_scan_b ON test_combined_index_scan(b) INCLUDE (a);
+INSERT INTO test_combined_index_scan SELECT i, i+i, i*i FROM generate_series(1, 100)i;
+VACUUM ANALYZE test_combined_index_scan;
+-- ORCA_FEATURE_NOT_SUPPORTED enable combined index
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT b FROM test_combined_index_scan WHERE a < 42 OR b < 42;
+                             QUERY PLAN                              
+---------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3) (actual rows=41 loops=1)
+   ->  Seq Scan on test_combined_index_scan (actual rows=16 loops=1)
+         Filter: ((a < 42) OR (b < 42))
+         Rows Removed by Filter: 22
+ Optimizer: Pivotal Optimizer (GPORCA)
+(5 rows)
+
+reset optimizer_trace_fallback;

--- a/src/test/regress/expected/index_including_gist_optimizer.out
+++ b/src/test/regress/expected/index_including_gist_optimizer.out
@@ -31,10 +31,11 @@ EXPLAIN  (costs off) SELECT * FROM tbl_gist where c4 <@ box(point(1,1),point(10,
                   QUERY PLAN                  
 ----------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  Seq Scan on tbl_gist
+   ->  Index Scan using tbl_gist_idx on tbl_gist
+         Index Cond: (c4 <@ '(10,10),(1,1)'::box)
          Filter: (c4 <@ '(10,10),(1,1)'::box)
  Optimizer: Pivotal Optimizer (GPORCA)
-(4 rows)
+(5 rows)
 
 SET enable_bitmapscan TO default;
 DROP TABLE tbl_gist;
@@ -70,10 +71,11 @@ EXPLAIN  (costs off) SELECT * FROM tbl_gist where c4 <@ box(point(1,1),point(10,
                   QUERY PLAN                  
 ----------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  Seq Scan on tbl_gist
+   ->  Index Scan using tbl_gist_idx on tbl_gist
+         Index Cond: (c4 <@ '(10,10),(1,1)'::box)
          Filter: (c4 <@ '(10,10),(1,1)'::box)
  Optimizer: Pivotal Optimizer (GPORCA)
-(4 rows)
+(5 rows)
 
 SET enable_bitmapscan TO default;
 DROP TABLE tbl_gist;
@@ -171,10 +173,11 @@ EXPLAIN  (costs off) SELECT * FROM tbl_gist where c4 <@ box(point(1,1),point(10,
                   QUERY PLAN                  
 ----------------------------------------------
  Gather Motion 1:1  (slice1; segments: 1)
-   ->  Seq Scan on tbl_gist
+   ->  Index Scan using tbl_gist_c4_c1_c2_c3_excl on tbl_gist
+         Index Cond: (c4 <@ '(10,10),(1,1)'::box)
          Filter: (c4 <@ '(10,10),(1,1)'::box)
  Optimizer: Pivotal Optimizer (GPORCA)
-(4 rows)
+(5 rows)
 
 \d tbl_gist
               Table "public.tbl_gist"

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -158,9 +158,11 @@ test: instr_in_shmem_verify
 # hold locks.
 test: partition_locking
 test: vacuum_gp
-# background analyze may affect pgstat and gp_covering_index
+# background analyze may affect pgstat
 test: pg_stat
 test: bfv_partition qp_misc_rio
+# 'gp_covering_index' concurrent vacuum (e.g. autovacuum) can effect plan due
+# to race-condition fetching relallvisible.
 test: gp_covering_index
 test: pgstat_qd_tabstat
 # dispatch should always run seperately from other cases.

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -158,9 +158,10 @@ test: instr_in_shmem_verify
 # hold locks.
 test: partition_locking
 test: vacuum_gp
-# background analyze may affect pgstat
+# background analyze may affect pgstat and gp_covering_index
 test: pg_stat
 test: bfv_partition qp_misc_rio
+test: gp_covering_index
 test: pgstat_qd_tabstat
 # dispatch should always run seperately from other cases.
 test: dispatch

--- a/src/test/regress/sql/gp_covering_index.sql
+++ b/src/test/regress/sql/gp_covering_index.sql
@@ -1,0 +1,302 @@
+-- Test Covering Indexes Feature
+--
+-- Purpose: Test that plans are optimal and correct using permutations of cover
+--          indexes in varying scenarios. Correctness is determined by the
+--          number of output rows from each query.
+--          Does the plan use index-scan, index-only-scan, or seq-scan?
+
+-- start_matchsubs
+-- m/Memory: \d+kB/
+-- s/Memory: \d+kB/Memory: ###kB/
+-- end_matchsubs
+
+set optimizer_trace_fallback=on;
+
+
+-- 0) Basic scenario
+CREATE TABLE test_basic_cover_index(a int, b int, c int);
+CREATE INDEX i_test_basic_index ON test_basic_cover_index(a) INCLUDE (b);
+INSERT INTO test_basic_cover_index SELECT i, i+i, i*i FROM generate_series(1, 100)i;
+VACUUM ANALYZE test_basic_cover_index;
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT b FROM test_basic_cover_index WHERE a>42 AND b>42;
+
+
+-- 0) Test CTE with cover indexes
+--
+-- Check that CTE over scan with cover index and cover index over cte both work
+-- ORCA_FEATURE_NOT_SUPPORTED: allow index-only-scan over CTE
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+WITH cte AS
+(
+    SELECT b FROM test_basic_cover_index WHERE a < 42
+)
+SELECT b FROM cte WHERE b%2=0;
+
+-- ORCA_FEATURE_NOT_SUPPORTED: allow index-only-scan over CTE
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+WITH cte AS
+(
+    SELECT a, b FROM test_basic_cover_index
+)
+SELECT b FROM cte WHERE a<42;
+
+
+-- 0) Views over cover indexes
+CREATE VIEW view_test_cover_indexes_with_filter AS
+SELECT a, b FROM test_basic_cover_index WHERE a<42;
+CREATE VIEW view_test_cover_indexes_without_filter AS
+SELECT a, b FROM test_basic_cover_index;
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT b FROM view_test_cover_indexes_with_filter;
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT b FROM view_test_cover_indexes_without_filter WHERE a<42;
+
+
+-- 1) Various Column Types
+--
+-- Use different column types to check that the scan associates the correct
+-- type to the correct column
+CREATE TABLE test_various_col_types(inttype int, texttype text, decimaltype decimal(10,2));
+INSERT INTO test_various_col_types SELECT i, 'texttype'||i, i FROM generate_series(1,9999) i;
+CREATE INDEX i_test_various_col_types ON test_various_col_types(inttype) INCLUDE (texttype);
+VACUUM ANALYZE test_various_col_types;
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF) SELECT texttype FROM test_various_col_types WHERE inttype<42;
+
+DROP INDEX i_test_various_col_types;
+CREATE INDEX i_test_various_col_types ON test_various_col_types(decimaltype) INCLUDE (inttype);
+VACUUM ANALYZE test_various_col_types;
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF) SELECT decimaltype, inttype FROM test_various_col_types WHERE decimaltype<42;
+
+ALTER TABLE test_various_col_types ADD COLUMN boxtype box;
+DROP INDEX i_test_various_col_types;
+CREATE INDEX i_test_various_col_types ON test_various_col_types(decimaltype) INCLUDE (boxtype);
+VACUUM ANALYZE test_various_col_types;
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF) SELECT decimaltype, boxtype FROM test_various_col_types WHERE decimaltype<42;
+
+
+-- 2) Test drop/add columns before and after creation of the index
+--
+-- Alter (add/drop) columns to check that the correct data is read from the
+-- physical scan.
+CREATE TABLE test_add_drop_columns(a int, aa int, b int, bb int, c int, d int);
+ALTER TABLE test_add_drop_columns DROP COLUMN aa;
+INSERT INTO test_add_drop_columns SELECT i, i+i, i*i, i*i*i, i+i+i FROM generate_series(1, 100)i;
+ALTER TABLE test_add_drop_columns DROP COLUMN bb;
+ALTER TABLE test_add_drop_columns ADD COLUMN e int;
+CREATE INDEX i_test_add_drop_columns ON test_add_drop_columns(a, b) INCLUDE (c);
+ALTER TABLE test_add_drop_columns ADD COLUMN f int;
+VACUUM ANALYZE test_add_drop_columns;
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT a, b FROM test_add_drop_columns WHERE a<42 AND b>42;
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT a, b FROM test_add_drop_columns WHERE a<42 AND b>42 AND c>42;
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT a, b, c, d, e FROM test_add_drop_columns WHERE a<42 AND b>42 AND c>42 AND e IS NULL;
+
+
+-- 3) Test various table types (e.g. AO/AOCO/replicated)
+--
+-- Check that different tables types (storage/distribution) leveage cover
+-- indexes correctly.
+CREATE TABLE test_replicated(a int, b int, c int) DISTRIBUTED REPLICATED;
+CREATE INDEX i_test_replicated ON test_replicated(a) INCLUDE (b);
+INSERT INTO test_replicated SELECT i, i+i, i*i FROM generate_series(1, 100)i;
+VACUUM ANALYZE test_replicated;
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT b FROM test_replicated WHERE a<42 AND b>42;
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT b, c FROM test_replicated WHERE a<42 AND b>42;
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT a, b, c FROM test_replicated WHERE c>42;
+
+-- ORCA_FEATURE_NOT_SUPPORTED: enable index scans on AO tables
+CREATE TABLE test_ao(a int, b int, c int) WITH (appendonly=true) DISTRIBUTED BY (a);
+CREATE INDEX i_test_ao ON test_ao(a) INCLUDE (b);
+INSERT INTO test_ao SELECT i, i+i, i*i FROM generate_series(1, 100)i;
+VACUUM ANALYZE test_ao;
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT b FROM test_ao WHERE a<42 AND b>42;
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT b, c FROM test_ao WHERE a<42 AND b>42;
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT a, b, c FROM test_ao WHERE c>42;
+
+
+-- 4) Test select best covering index
+--
+-- Check that the best cover index is chosen for a plan when multiple cover
+-- indexes are available.
+CREATE TABLE test_select_best_cover(a int, b int, c int);
+CREATE INDEX i_test_select_best_cover_a ON test_select_best_cover(a);
+CREATE INDEX i_test_select_best_cover_a_b ON test_select_best_cover(a) INCLUDE (b);
+CREATE INDEX i_test_select_best_cover_ab ON test_select_best_cover(a, b);
+CREATE INDEX i_test_select_best_cover_b ON test_select_best_cover(b);
+CREATE INDEX i_test_select_best_cover_b_a ON test_select_best_cover(a) INCLUDE (b);
+CREATE INDEX i_test_select_best_cover_a_bc ON test_select_best_cover(a) INCLUDE (b, c);
+INSERT INTO test_select_best_cover SELECT i, i+i, i*i FROM generate_series(1, 100)i;
+VACUUM ANALYZE test_select_best_cover;
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT a FROM test_select_best_cover WHERE a>42;
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT b FROM test_select_best_cover WHERE b>42;
+
+-- ORCA_FEATURE_NOT_SUPPORTED: use i_test_select_best_cover_ab
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT b FROM test_select_best_cover WHERE a>42 AND b>42;
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT b FROM test_select_best_cover WHERE a>42 AND b>42 AND c>42;
+
+
+-- 5) Test DML operations
+--
+-- Check that cover indexes can be used with DML operations
+CREATE TABLE test_dml_using_cover_index(a int, b int, c int);
+CREATE INDEX i_test_dml_using_cover_index ON test_dml_using_cover_index(a) INCLUDE (b);
+INSERT INTO test_dml_using_cover_index SELECT i, i+i, i*i FROM generate_series(1, 100)i;
+VACUUM ANALYZE test_dml_using_cover_index;
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+INSERT INTO test_dml_using_cover_index (SELECT a, a, a FROM test_dml_using_cover_index WHERE a>42);
+
+
+-- 6) Test index scan over partition tables
+--
+-- Check that cover indexes can be used with partition tables. This includes
+-- scenario when root/leaf partitions have different underlying physical format
+-- (e.g. drop column / exchange partition or leaf partition has cover index not
+-- defined on root).
+CREATE TABLE test_cover_index_on_pt(a int, b int, c int)
+DISTRIBUTED BY (a)
+PARTITION BY RANGE (b)
+(
+    START (0) END (4) EVERY (1)
+);
+CREATE INDEX i_test_cover_index_scan_on_partition_table ON test_cover_index_on_pt(a) INCLUDE(b);
+INSERT INTO test_cover_index_on_pt SELECT i+i, i%4 FROM generate_series(1, 10)i;
+VACUUM ANALYZE test_cover_index_on_pt;
+
+-- ORCA_FEATURE_NOT_SUPPORTED: dynamic index only scan
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT a, b FROM test_cover_index_on_pt WHERE a<10;
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT a, b, c FROM test_cover_index_on_pt WHERE a<10;
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT a, b, c FROM test_cover_index_on_pt WHERE b<10;
+
+CREATE TABLE leaf_part(a int, b int, c int) DISTRIBUTED BY (a);
+-- without explicit index declared on leaf_part
+ALTER TABLE test_cover_index_on_pt EXCHANGE PARTITION FOR(2) WITH TABLE leaf_part;
+INSERT INTO test_cover_index_on_pt VALUES (2, 2, 2);
+VACUUM ANALYZE test_cover_index_on_pt;
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT a, b FROM test_cover_index_on_pt WHERE a<10;
+
+DROP INDEX i_test_cover_index_scan_on_partition_table;
+-- with explicit index declared on leaf_part
+CREATE INDEX i_test_cover_index_scan_on_partition_table ON leaf_part(a) INCLUDE(b);
+VACUUM ANALYZE test_cover_index_on_pt;
+
+-- ORCA_FEATURE_NOT_SUPPORTED: partial dynamic index scan
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT a, b FROM test_cover_index_on_pt WHERE a<10;
+
+
+-- 7) Test various index types
+--
+-- Check that different index types can be used with cover indexes.
+-- Note: brin, hash, and spgist do not suport included columns.
+CREATE TABLE test_index_types(a box, b int, c int) DISTRIBUTED BY (b);
+INSERT INTO test_index_types VALUES ('(2.0,2.0,0.0,0.0)', 2, 2);
+INSERT INTO test_index_types VALUES ('(1.0,1.0,3.0,3.0)', 3, 3);
+CREATE INDEX i_test_index_types ON test_index_types USING GIST (a) INCLUDE (b);
+VACUUM ANALYZE test_index_types;
+
+-- ORCA_FEATURE_NOT_SUPPORTED: support index-only-scan on GIST indexes
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT a, b FROM test_index_types WHERE a<@ box '(0,0,3,3)';
+
+
+-- 8) Test partial indexes
+--
+-- Check that partial cover indexes may be used
+CREATE TABLE test_partial_index(a int, b int, c int);
+CREATE INDEX i_test_partial_index ON test_partial_index(a) INCLUDE (b) WHERE a<42;
+INSERT INTO test_partial_index SELECT i, i+i, i*i FROM generate_series(1, 100)i;
+VACUUM ANALYZE test_partial_index;
+
+-- ORCA_FEATURE_NOT_SUPPORTED: support partial indexes
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT b FROM test_partial_index WHERE a>42 AND b>42;
+
+
+-- 9) Test backward index scan
+--
+-- Check that cover indexes may be used for backward index scan
+CREATE TABLE test_backward_index_scan(a int, b int, c int) DISTRIBUTED BY (a);
+CREATE INDEX i_test_backward_index_scan ON test_backward_index_scan(a) INCLUDE (b);
+INSERT INTO test_backward_index_scan SELECT i, i+i, i*i FROM generate_series(1, 100)i;
+VACUUM ANALYZE test_backward_index_scan;
+
+-- ORCA_FEATURE_NOT_SUPPORTED enable backward index scan
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT b FROM test_backward_index_scan WHERE a>42 AND b>42 ORDER BY a DESC;
+
+
+-- 10) Test index expressions
+--
+-- Check that cover indexes may be used for index expressions
+CREATE OR REPLACE FUNCTION add_one(integer)
+RETURNS INTEGER
+LANGUAGE 'plpgsql'
+AS $$
+BEGIN
+    RETURN $1 + 1;
+END;
+$$;
+CREATE TABLE test_index_expression_scan(a int, b int, c int) DISTRIBUTED BY (a);
+CREATE INDEX i_test_index_expression_scan ON test_index_expression_scan(a) INCLUDE (b);
+INSERT INTO test_index_expression_scan SELECT i, i+i, i*i FROM generate_series(1, 100)i;
+VACUUM ANALYZE test_index_expression_scan;
+
+-- ORCA_FEATURE_NOT_SUPPORTED enable index expression
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT add_one(b) FROM test_index_expression_scan WHERE add_one(a) < 42;
+
+
+-- 11) Test combined indexes
+--
+-- Check that combined indexes may be used.  (on OR conditions) https://www.postgresql.org/docs/current/indexes-bitmap-scans.html
+CREATE TABLE test_combined_index_scan(a int, b int, c int) DISTRIBUTED BY (a);
+CREATE INDEX i_test_combined_index_scan_a ON test_combined_index_scan(a) INCLUDE (b);
+CREATE INDEX i_test_combined_index_scan_b ON test_combined_index_scan(b) INCLUDE (a);
+INSERT INTO test_combined_index_scan SELECT i, i+i, i*i FROM generate_series(1, 100)i;
+VACUUM ANALYZE test_combined_index_scan;
+
+-- ORCA_FEATURE_NOT_SUPPORTED enable combined index
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
+SELECT b FROM test_combined_index_scan WHERE a < 42 OR b < 42;
+
+
+reset optimizer_trace_fallback;


### PR DESCRIPTION
Indexes in ORCA are composed of a set of KEY columns and a separate set
of INCLUDE columns. KEY columns determine the search pattern of the
index, whereas INCLUDE columns represents the columns accessible in an
index scan. Naturally, the two sets should have some overlap.

In Postgres, cover indexes [1] were introduced in commit https://github.com/greenplum-db/gpdb/commit/8224de4f42ccf98e08db07b43d52fed72f962ebb.
Cover indexes store additional non-key columns in the physical index
storage to avoid incurring additional page accesses to the backend
relation files during an index-only scan.

ORCA's definition of an index's included columns predates Postgres cover
index feature. However, ORCA's current implementation of include columns
is pointless as it has always assumed that all columns in the table are
available from the index. I think that cover indexes were disabled in
ORCA [2] in Postgres 12 merge due to a conflated definition of included
columns.

In reality, Postgres's definition of included columns fits almost
seamlessly into ORCA's framework. This commit updates ORCA to adopt the
Postgres definition.

[1] https://www.postgresql.org/docs/12/indexes-index-only-scans.html
[2] https://github.com/greenplum-db/gpdb-postgres-merge/commit/b1c1eee0a8


---


Reviewer Notes:
- I had opened a separate PR for e73cc2a8a9782298dcafdb56b48724f505e127a3.  However, the tests I added in this PR require that change.
- I erased the dxl:Index:IncludedColumns in existing MDPs (>400 instances).  Since IncludedColumns will now represent cover index columns, erasing from old MDPs will align more with the original queries.