### PR TITLE
docs - ref page updates for cursor-related SQL commands

### DIFF
--- a/gpdb-doc/markdown/ref_guide/sql_commands/CLOSE.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/CLOSE.html.md
@@ -5,7 +5,7 @@ Closes a cursor.
 ## <a id="section2"></a>Synopsis 
 
 ``` {#sql_command_synopsis}
-CLOSE <cursor_name>
+CLOSE { <cursor_name> | ALL }
 ```
 
 ## <a id="section3"></a>Description 
@@ -16,16 +16,19 @@ Every non-holdable open cursor is implicitly closed when a transaction is termin
 
 ## <a id="section4"></a>Parameters 
 
-<cursor\_name\>
+cursor\_name
 :   The name of an open cursor to close.
+
+ALL
+:   Close all open cursors.
 
 ## <a id="section5"></a>Notes 
 
-Greenplum Database does not have an explicit `OPEN` cursor statement. A cursor is considered open when it is declared. Use the `DECLARE` statement to declare \(and open\) a cursor.
+Greenplum Database does not have an explicit `OPEN` cursor statement. A cursor is considered open when it is declared. Use the [DECLARE](DECLARE.html) statement to declare \(and open\) a cursor.
 
 You can see all available cursors by querying the [pg\_cursors](../system_catalogs/pg_cursors.html) system view.
 
-If a cursor is closed after a savepoint which is later rolled back, the `CLOSE` is not rolled back; that is the cursor remains closed.
+If a cursor is closed after a savepoint which is later rolled back, the `CLOSE` is not rolled back; that is, the cursor remains closed.
 
 ## <a id="section6"></a>Examples 
 
@@ -37,7 +40,7 @@ CLOSE portala;
 
 ## <a id="section7"></a>Compatibility 
 
-`CLOSE` is fully conforming with the SQL standard.
+`CLOSE` is fully conforming with the SQL standard. `CLOSE ALL` is a Greenplum Database extension.
 
 ## <a id="section8"></a>See Also 
 

--- a/gpdb-doc/markdown/ref_guide/sql_commands/DECLARE.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/DECLARE.html.md
@@ -7,12 +7,12 @@ Defines a cursor.
 ``` {#sql_command_synopsis}
 DECLARE <name> [BINARY] [INSENSITIVE] [NO SCROLL] [PARALLEL RETRIEVE] CURSOR 
      [{WITH | WITHOUT} HOLD] 
-     FOR <query> [FOR READ ONLY]
+     FOR <query>
 ```
 
 ## <a id="section3"></a>Description 
 
-`DECLARE` allows a user to create a cursor, which can be used to retrieve a small number of rows at a time out of a larger query. Cursors can return data either in text or in binary format using [FETCH](FETCH.html).
+`DECLARE` allows a user to create a cursor, which can be used to retrieve a small number of rows at a time out of a larger query. Cursors can return data using [FETCH](FETCH.html).
 
 > **Note** This page describes usage of cursors at the SQL command level. If you are trying to use cursors inside a PL/pgSQL function, the rules are different, see [PL/pgSQL](../../analytics/pl_sql.html).
 
@@ -20,15 +20,17 @@ Normal cursors return data in text format, the same as a `SELECT` would produce.
 
 As an example, if a query returns a value of one from an integer column, you would get a string of 1 with a default cursor whereas with a binary cursor you would get a 4-byte field containing the internal representation of the value \(in big-endian byte order\).
 
-Binary cursors should be used carefully. Many applications, including psql, are not prepared to handle binary cursors and expect data to come back in the text format.
+Binary cursors should be used carefully. Many applications, including `psql`, are not prepared to handle binary cursors and expect data to come back in the text format.
 
 > **Note** When the client application uses the 'extended query' protocol to issue a `FETCH` command, the Bind protocol message specifies whether data is to be retrieved in text or binary format. This choice overrides the way that the cursor is defined. The concept of a binary cursor as such is thus obsolete when using extended query protocol — any cursor can be treated as either text or binary.
 
-A cursor can be specified in the `WHERE CURRENT OF` clause of the [UPDATE](UPDATE.html) or [DELETE](DELETE.html) statement to update or delete table data. The `UPDATE` or `DELETE` statement can only be run on the server, for example in an interactive psql session or a script. Language extensions such as PL/pgSQL do not have support for updatable cursors.
+XXX
+A cursor can be specified in the `WHERE CURRENT OF` clause of the [UPDATE](UPDATE.html) or [DELETE](DELETE.html) statement to update or delete table data. The `UPDATE` or `DELETE` statement can only be run on the server, for example in an interactive `psql` session or a script. Language extensions such as PL/pgSQL do not have support for updatable cursors.
+XXX
 
 **Parallel Retrieve Cursors**
 
-Greenplum Database supports a special type of cursor, a parallel retrieve cursor. You can use a parallel retrieve cursor to retrieve query results, in parallel, directly from the Greenplum Database segments, bypassing the Greenplum coordinator.
+Greenplum Database supports a special type of cursor, a *parallel retrieve cursor*. You can use a parallel retrieve cursor to retrieve query results, in parallel, directly from the Greenplum Database segments, bypassing the Greenplum coordinator.
 
 Parallel retrieve cursors do not support the `WITH HOLD` clause. Greenplum Database ignores the `BINARY` clause when you declare a parallel retrieve cursor.
 
@@ -45,10 +47,10 @@ BINARY
     > **Note** Greenplum Database ignores the `BINARY` clause when you declare a `PARALLEL RETRIEVE` cursor.
 
 INSENSITIVE
-:   Indicates that data retrieved from the cursor should be unaffected by updates to the tables underlying the cursor while the cursor exists. In Greenplum Database, all cursors are insensitive. This key word currently has no effect and is present for compatibility with the SQL standard.
+:   Indicates that data retrieved from the cursor should be unaffected by updates to the table\(s\) underlying the cursor that occur after the cursor is created. In Greenplum Database, all cursors are insensitive. This key word currently has no effect and is present only for compatibility with the SQL standard.
 
 NO SCROLL
-:   A cursor cannot be used to retrieve rows in a nonsequential fashion. This is the default behavior in Greenplum Database, since scrollable cursors \(`SCROLL`\) are not supported.
+:   The cursor cannot be used to retrieve rows in a nonsequential fashion. This is the default behavior in Greenplum Database; scrollable cursors \(`SCROLL`\) are not supported.
 
 PARALLEL RETRIEVE
 :   Declare a parallel retrieve cursor. A parallel retrieve cursor is a special type of cursor that you can use to retrieve results directly from Greenplum Database segments, in parallel.
@@ -62,6 +64,7 @@ WITHOUT HOLD
 query
 :   A [SELECT](SELECT.html) or [VALUES](VALUES.html) command which will provide the rows to be returned by the cursor.
 
+:   XXX
     If the cursor is used in the `WHERE CURRENT OF` clause of the [UPDATE](UPDATE.html) or [DELETE](DELETE.html) command, the `SELECT` command must satisfy the following conditions:
 
     -   Cannot reference a view or external table.
@@ -77,9 +80,9 @@ query
         <br/><br/>Specifying the `FOR UPDATE` clause in the `SELECT` command prevents other sessions from changing the rows between the time they are fetched and the time they are updated. Without the `FOR UPDATE` clause, a subsequent use of the `UPDATE` or `DELETE` command with the `WHERE CURRENT OF` clause has no effect if the row was changed since the cursor was created.
         <br/><br/>> **Note** Specifying the `FOR UPDATE` clause in the `SELECT` command locks the entire table, not just the selected rows.
 
+:   XXX
 
-FOR READ ONLY
-:   `FOR READ ONLY` indicates that the cursor is used in a read-only mode.
+The key words `BINARY`, `INSENSITIVE`, and `NO SCROLL` can appear in any order.
 
 ## <a id="section5"></a>Notes 
 

--- a/gpdb-doc/markdown/ref_guide/sql_commands/FETCH.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/FETCH.html.md
@@ -8,7 +8,7 @@ Retrieves rows from a query using a cursor.
 FETCH [ <forward_direction> { FROM | IN } ] <cursor_name>
 ```
 
-where forward\_direction can be empty or one of:
+where <forward_direction> can be empty or one of:
 
 ```
     NEXT
@@ -28,25 +28,19 @@ where forward\_direction can be empty or one of:
 
 > **Note** You cannot `FETCH` from a `PARALLEL RETRIEVE CURSOR`, you must [RETRIEVE](RETRIEVE.html) the rows from it.
 
-> **Note** This page describes usage of cursors at the SQL command level. If you are trying to use cursors inside a PL/pgSQL function, the rules are different. See [PL/pgSQL function](../../analytics/pl_sql.html#topic1).
-
 A cursor has an associated position, which is used by `FETCH`. The cursor position can be before the first row of the query result, on any particular row of the result, or after the last row of the result. When created, a cursor is positioned before the first row. After fetching some rows, the cursor is positioned on the row most recently retrieved. If `FETCH` runs off the end of the available rows then the cursor is left positioned after the last row. `FETCH ALL` will always leave the cursor positioned after the last row.
+
+> **Note**
+> Because Greenplum Database does not support scrollable cursors, it is not possible to move a cursor position backwards. You can only move a cursor forward in position using `FETCH`.
 
 The forms `NEXT`, `FIRST`, `ABSOLUTE`, `RELATIVE` fetch a single row after moving the cursor appropriately. If there is no such row, an empty result is returned, and the cursor is left positioned before the first row or after the last row as appropriate.
 
-The forms using `FORWARD` retrieve the indicated number of rows moving in the forward direction, leaving the cursor positioned on the last-returned row \(or after all rows, if the count exceeds the number of rows available\). Note that it is not possible to move a cursor position backwards in Greenplum Database, since scrollable cursors are not supported. You can only move a cursor forward in position using `FETCH`.
+The forms using `FORWARD` retrieve the indicated number of rows moving in the forward direction, leaving the cursor positioned on the last-returned row \(or after all rows, if the count exceeds the number of rows available\).
 
 `RELATIVE 0` and `FORWARD 0` request fetching the current row without moving the cursor, that is, re-fetching the most recently fetched row. This will succeed unless the cursor is positioned before the first row or after the last row, in which case no row is returned.
 
-**Outputs**
-
-On successful completion, a `FETCH` command returns a command tag of the form
-
-```
-FETCH <count>
-```
-
-The count is the number of rows fetched \(possibly zero\). Note that in `psql`, the command tag will not actually be displayed, since `psql` displays the fetched rows instead.
+> **Note**
+> This page describes usage of cursors at the SQL command level. If you are trying to use cursors inside a PL/pgSQL function, the rules are different. See [PL/pgSQL function](../../analytics/pl_sql.html#topic1).
 
 ## <a id="section5"></a>Parameters 
 
@@ -83,6 +77,16 @@ FORWARD ALL
 cursor\_name
 :   The name of an open cursor.
 
+## <a id="section5a"></a>Outputs
+
+On successful completion, a `FETCH` command returns a command tag of the form
+
+```
+FETCH <count>
+```
+
+The count is the number of rows fetched \(possibly zero\). Note that in `psql`, the command tag will not actually be displayed, since `psql` displays the fetched rows instead.
+
 ## <a id="section6"></a>Notes 
 
 Greenplum Database does not support scrollable cursors, so you can only use `FETCH` to move the cursor position forward.
@@ -93,19 +97,19 @@ Greenplum Database does not support scrollable cursors, so you can only use `FET
 
 ## <a id="section7"></a>Examples 
 
--- Start the transaction:
+Start the transaction:
 
 ```
 BEGIN;
 ```
 
--- Set up a cursor:
+Set up a cursor:
 
 ```
 DECLARE mycursor CURSOR FOR SELECT * FROM films;
 ```
 
--- Fetch the first 5 rows in the cursor `mycursor`:
+Fetch the first 5 rows in the cursor `mycursor`:
 
 ```
 FETCH FORWARD 5 FROM mycursor;
@@ -118,7 +122,7 @@ FETCH FORWARD 5 FROM mycursor;
  P_302 | Becket                  | 103 | 1964-02-03 | Drama    | 02:28
 ```
 
--- Close the cursor and end the transaction:
+Close the cursor and end the transaction:
 
 ```
 CLOSE mycursor;

--- a/gpdb-doc/markdown/ref_guide/sql_commands/MOVE.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/MOVE.html.md
@@ -8,7 +8,7 @@ Positions a cursor.
 MOVE [ <forward_direction> [ FROM | IN ] ] <cursor_name>
 ```
 
-where forward\_direction can be empty or one of:
+where <forward_direction> can be empty or one of:
 
 ```
     NEXT
@@ -29,9 +29,11 @@ where forward\_direction can be empty or one of:
 
 > **Note** You cannot `MOVE` a `PARALLEL RETRIEVE CURSOR`.
 
-It is not possible to move a cursor position backwards in Greenplum Database, since scrollable cursors are not supported. You can only move a cursor forward in position using `MOVE`.
+> **Note** Because Greenplum Database does not support scrollable cursors, it is not possible to move a cursor position backwards. You can only move a cursor forward in position using `MOVE`.
 
-**Outputs**
+The parameters for the `MOVE` command are identical to those of the `FETCH` command; refer to [FETCH](FETCH.html) for details on syntax and usage.
+
+## <a id="section5a"></a>Outputs
 
 On successful completion, a `MOVE` command returns a command tag of the form
 
@@ -41,36 +43,28 @@ MOVE <count>
 
 The count is the number of rows that a `FETCH` command with the same parameters would have returned \(possibly zero\).
 
-## <a id="section5"></a>Parameters 
-
-forward\_direction
-:   The parameters for the `MOVE` command are identical to those of the `FETCH` command; refer to [FETCH](FETCH.html) for details on syntax and usage.
-
-cursor\_name
-:   The name of an open cursor.
-
 ## <a id="section6"></a>Examples 
 
--- Start the transaction:
+Start the transaction:
 
 ```
 BEGIN;
 ```
 
--- Set up a cursor:
+Create a cursor:
 
 ```
 DECLARE mycursor CURSOR FOR SELECT * FROM films;
 ```
 
--- Move forward 5 rows in the cursor `mycursor`:
+Skip the first 5 rows in the cursor `mycursor`:
 
 ```
 MOVE FORWARD 5 IN mycursor;
 MOVE 5
 ```
 
--- Fetch the next row after that \(row 6\):
+Fetch the next row after that \(row 6\):
 
 ```
 FETCH 1 FROM mycursor;
@@ -80,7 +74,7 @@ FETCH 1 FROM mycursor;
 (1 row)
 ```
 
--- Close the cursor and end the transaction:
+Close the cursor and end the transaction:
 
 ```
 CLOSE mycursor;

--- a/gpdb-doc/markdown/ref_guide/sql_commands/RETRIEVE.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/RETRIEVE.html.md
@@ -14,17 +14,14 @@ RETRIEVE { <count> | ALL } FROM ENDPOINT <endpoint_name>
 
 A parallel retrieve cursor has an associated position, which is used by `RETRIEVE`. The cursor position can be before the first row of the query result, on any particular row of the result, or after the last row of the result.
 
+> **Note**
+> Because Greenplum Database does not support scrollable cursors, the `RETRIEVE` command moves a parallel retrieve cursor only forward in position.
+
 When it is created, a parallel retrieve cursor is positioned before the first row. After retrieving some rows, the cursor is positioned on the row most recently retrieved.
 
 If `RETRIEVE` runs off the end of the available rows then the cursor is left positioned after the last row.
 
 `RETRIEVE ALL` always leaves the parallel retrieve cursor positioned after the last row.
-
-> **Note** Greenplum Database does not support scrollable cursors; you can only move a cursor forward in position using the `RETRIEVE` command.
-
-**Outputs**
-
-On successful completion, a `RETRIEVE` command returns the fetched rows \(possibly empty\) and a count of the number of rows fetched \(possibly zero\).
 
 ## <a id="section5"></a>Parameters 
 
@@ -37,6 +34,10 @@ ALL
 endpoint\_name
 :   The name of the endpoint from which to retrieve the rows.
 
+## <a id="section5a"></a>Outputs
+
+On successful completion, a `RETRIEVE` command returns the fetched rows \(possibly empty\) and a count of the number of rows fetched \(possibly zero\).
+
 ## <a id="section6"></a>Notes 
 
 Use `DECLARE ... PARALLEL RETRIEVE CURSOR` to define a parallel retrieve cursor.
@@ -45,41 +46,45 @@ Parallel retrieve cursors do not support `FETCH` or `MOVE` operations.
 
 ## <a id="section7"></a>Examples 
 
--- Start the transaction:
+Start the transaction:
 
 ```
 BEGIN;
 ```
 
--- Create a parallel retrieve cursor:
+Create a parallel retrieve cursor:
 
 ```
 DECLARE mycursor PARALLEL RETRIEVE CURSOR FOR SELECT * FROM films;
 ```
 
--- List the cursor endpoints:
+List the cursor endpoints:
 
 ```
 SELECT * FROM gp_endpoints WHERE cursorname='mycursor';
 ```
 
--- Note the hostname, port, auth\_token, and name associated with each endpoint.
+Note the hostname, port, auth\_token, and name associated with each endpoint.
 
--- In another terminal window, initiate a retrieve session using a hostname, port, and auth\_token returned from the previous query. For example:
+In another terminal window, initiate a retrieve session using a hostname, port, and auth\_token returned from the previous query. For example:
 
 ```
 PGPASSWORD=d3825fc07e56bee5fcd2b1d0b600c85e PGOPTIONS='-c gp_retrieve_conn=true' psql -d testdb -h sdw3 -p 6001;
 ```
 
--- Fetch all rows from an endpoint \(for example, the endpoint named `prc10000001100000005`\):
+Fetch all rows from an endpoint \(for example, the endpoint named `prc10000001100000005`\):
 
 ```
 RETRIEVE ALL FROM ENDPOINT prc10000001100000005;
 ```
 
--- Exit the retrieve session
+Exit the retrieve session.
 
--- Back in the original session, close the cursor and end the transaction:
+```
+\q
+```
+
+Back in the original session, close the cursor and end the transaction:
 
 ```
 CLOSE mycursor;

--- a/gpdb-doc/markdown/ref_guide/system_catalogs/pg_cursors.html.md
+++ b/gpdb-doc/markdown/ref_guide/system_catalogs/pg_cursors.html.md
@@ -8,8 +8,9 @@ The `pg_cursors` view lists the currently available cursors. Cursors can be defi
 
     > **Note** Greenplum Database does not support the definition, or access of, parallel retrieve cursors via SPI.
 
-
 Cursors exist only for the duration of the transaction that defines them, unless they have been declared `WITH HOLD`. Non-holdable cursors are only present in the view until the end of their creating transaction.
+
+The `pg_cursors` view is read only.
 
 > **Note** Greenplum Database does not support holdable parallel retrieve cursors.
 
@@ -17,9 +18,9 @@ Cursors exist only for the duration of the transaction that defines them, unless
 |----|----|----------|-----------|
 |`name`|text| |The name of the cursor.|
 |`statement`|text| |The verbatim query string submitted to declare this cursor.|
-|`is_holdable`|boolean| |`true` if the cursor is holdable \(that is, it can be accessed after the transaction that declared the cursor has committed\); `false` otherwise.<br/><br/>> **Note** Greenplum Database does not support holdable parallel retrieve cursors, this value is always `false` for such cursors.|
+|`is_holdable`|boolean| |`true` if the cursor is holdable \(that is, it can be accessed after the transaction that declared the cursor has committed\); `false` otherwise.<br/><br/>**Note:** Greenplum Database does not support holdable parallel retrieve cursors, this value is always `false` for such cursors.|
 |`is_binary`|boolean| |`true` if the cursor was declared `BINARY`; `false` otherwise.|
-|`is_scrollable`|boolean| |`true` if the cursor is scrollable \(that is, it allows rows to be retrieved in a nonsequential manner\); `false` otherwise.<br/><br/>> **Note** Greenplum Database does not support scrollable cursors, this value is always `false`.|
+|`is_scrollable`|boolean| |`true` if the cursor is scrollable \(that is, it allows rows to be retrieved in a nonsequential manner\); `false` otherwise.<br/><br/>**Note:** Greenplum Database does not support scrollable cursors, this value is always `false`.|
 |`creation_time`|timestamptz| |The time at which the cursor was declared.|
 |`is_parallel`|boolean| |`true` if the cursor was declared `PARALLEL RETRIEVE`; `false` otherwise.|
 


### PR DESCRIPTION
bring the sql ref pages of the cursor-related commands up to postgres 12.  there is some greenplum on the pages.

QUESTION:  are there any changes to how the procedural languages handle cursors?

in this PR:
- DECLARE:
    - the page includes greenplum-specific info related to parallel retrieve cursors.  i didn't not modify any of this info.
    - the postgres docs (12 and 9.4) do not have a FOR READ ONLY clause.  is this greenplum-specific?  is it still a thing?  (i didn't find many references in the code/tests, so i removed it.)
    - i am assuming that greenplum database 7 continues to not support scrollable cursors.  let me know if this is incorrect.
    - WHERE CURRENT OF - looks to be greenplum specific, do we still support it? (see text tagged between XXX.)
-FETCH, MOVE, RETRIEVE:
    - minor edits/reorg
    - moved Outputs info to its own subtopic

doc review site links (behind vpn):
- CLOSE - https://docs-staging.vmware.com/en/draft/VMware-Tanzu-Greenplum/sqlref-cursor/greenplum-database/GUID-ref_guide-sql_commands-CLOSE.html
- DECLARE - https://docs-staging.vmware.com/en/draft/VMware-Tanzu-Greenplum/sqlref-cursor/greenplum-database/GUID-ref_guide-sql_commands-DECLARE.html
- FETCH - https://docs-staging.vmware.com/en/draft/VMware-Tanzu-Greenplum/sqlref-cursor/greenplum-database/GUID-ref_guide-sql_commands-FETCH.html
- MOVE - https://docs-staging.vmware.com/en/draft/VMware-Tanzu-Greenplum/sqlref-cursor/greenplum-database/GUID-ref_guide-sql_commands-MOVE.html
- RETRIEVE - https://docs-staging.vmware.com/en/draft/VMware-Tanzu-Greenplum/sqlref-cursor/greenplum-database/GUID-ref_guide-sql_commands-RETRIEVE.html
