### PR TITLE
docs - edits to ALTER/CREATE/DROP PROTOCOL

### DIFF
--- a/gpdb-doc/markdown/ref_guide/sql_commands/ALTER_PROTOCOL.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/ALTER_PROTOCOL.html.md
@@ -14,7 +14,7 @@ ALTER PROTOCOL <name> OWNER TO <newowner>
 
 `ALTER PROTOCOL` changes the definition of a protocol. Only the protocol name or owner can be altered.
 
-You must own the protocol to use `ALTER PROTOCOL`. To alter the owner, you must also be a direct or indirect member of the new owning role, and that role must have `CREATE` privilege on schema of the conversion.
+You must own the protocol to use `ALTER PROTOCOL`. To alter the owner, you must also be a direct or indirect member of the new owning role, and that role must have `CREATE` privilege on schema of the protocol.
 
 These restrictions are in place to ensure that altering the owner only makes changes that could by made by dropping and recreating the protocol. Note that a superuser can alter ownership of any protocol.
 
@@ -31,13 +31,13 @@ newowner
 
 ## <a id="section5"></a>Examples 
 
-To rename the conversion `GPDBauth` to `GPDB_authentication`:
+To rename the protocol `GPDBauth` to `GPDB_authentication`:
 
 ```
 ALTER PROTOCOL GPDBauth RENAME TO GPDB_authentication;
 ```
 
-To change the owner of the conversion `GPDB_authentication` to `joe`:
+To change the owner of the `GPDB_authentication` protocol to `joe`:
 
 ```
 ALTER PROTOCOL GPDB_authentication OWNER TO joe;

--- a/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_PROTOCOL.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_PROTOCOL.html.md
@@ -18,7 +18,7 @@ The `CREATE PROTOCOL` command must specify either a read call handler or a write
 
 The protocol name can be specified in a `CREATE EXTERNAL TABLE` command.
 
-For information about creating and enabling a custom data access protocol, see "Example Custom Data Access Protocol" in the *Greenplum Database Administrator Guide*.
+For information about creating and enabling a custom data access protocol, refer to the [Example Custom Data Access Protocol](../load/topics/g-example-custom-data-access-protocol.html) documentation.
 
 ## <a id="section4"></a>Parameters 
 

--- a/gpdb-doc/markdown/ref_guide/sql_commands/DROP_PROTOCOL.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/DROP_PROTOCOL.html.md
@@ -1,6 +1,6 @@
 # DROP PROTOCOL 
 
-Removes a external table data access protocol from a database.
+Removes a data access protocol from a database.
 
 ## <a id="section2"></a>Synopsis 
 
@@ -10,25 +10,25 @@ DROP PROTOCOL [IF EXISTS] <name>
 
 ## <a id="section3"></a>Description 
 
-`DROP PROTOCOL` removes the specified protocol from a database. A protocol name can be specified in the `CREATE EXTERNAL TABLE` command to read data from or write data to an external data source.
+`DROP PROTOCOL` removes the specified protocol from a database. You specify a protocol name in the `CREATE EXTERNAL TABLE` command to read data from or write data to an external data source.
 
 You must be a superuser or the protocol owner to drop a protocol.
 
-> **Caution** If you drop a data access prococol, external tables that have been defined with the protocol will no longer be able to access the external data source.
+> **Caution** If you drop a data access prococol, external tables that have been defined specifying the protocol will no longer be able to access the external data source.
 
 ## <a id="section4"></a>Parameters 
 
 IF EXISTS
-:   Do not throw an error if the protocol does not exist. A notice is issued in this case.
+:   Do not throw an error if the protocol does not exist. Greenplum Database issues a notice in this case.
 
 name
 :   The name of an existing data access protocol.
 
 ## <a id="section5"></a>Notes 
 
-If you drop a data access protocol, the call handlers that defined in the database that are associated with the protocol are not dropped. You must drop the functions manually.
+Dropping a data access protocol, does not drop the protocol's call handlers. You must drop these functions manually.
 
-Shared libraries that were used by the protocol should also be removed from the Greenplum Database hosts.
+Be sure to remove any shared libraries that were used by the protocol from the Greenplum Database hosts.
 
 ## <a id="section6"></a>Compatibility 
 


### PR DESCRIPTION
external protocols are greenplum-specific, so no postgres ref pages to align to.

in this PR:
- some misc edits
- can someone confirm that greenplum 7 continues to support external protocols as they existed in greenplum 6?
