### PR TITLE
Support fast ALTER TABLE ADD COLUMN for appendonly row-oriented tables

### DIFF
--- a/gpMgmt/bin/gpcheckcat
+++ b/gpMgmt/bin/gpcheckcat
@@ -1512,6 +1512,82 @@ def checkAOSegVpinfo():
 
     processThread(threads)
 
+class checkAOLastrownumThread(execThread):
+    def __init__(self, cfg, db):
+        execThread.__init__(self, cfg, db, None)
+
+    # pg_attribute_encoding.lastrownums[segno], if exists, should have a corresponding entry in gp_fastsequence with
+    # an objid same as segno. And the value of pg_attribute_encoding.lastrownums[segno] should fall in the range of
+    # [0, {last_sequence}] where {last_sequence} is the current gp_fastsequence value with the corresponding objid.
+    # Note that objmod starts from 0 but the array index starts from 1.
+    def run(self):
+        aolastrownum_query = """
+            SELECT
+                c.relname,
+                ao.relid,
+                ae.attnum,
+                ae.lastrownums,
+                f.objmod,
+                f.last_sequence,
+                ae.lastrownums[f.objmod + 1] AS lastrownum
+            FROM
+                pg_attribute_encoding ae
+                JOIN pg_appendonly ao ON ae.attrelid = ao.relid
+                LEFT JOIN gp_fastsequence f ON ao.segrelid = f.objid
+                JOIN pg_class c ON ao.relid = c.oid
+            WHERE
+                f.last_sequence IS NULL
+                OR f.last_sequence < ae.lastrownums[f.objmod + 1]
+                OR ae.lastrownums[f.objmod + 1] < 0;
+        """
+
+        try:
+            # Execute the query
+            curs = self.db.query(aolastrownum_query)
+            nrows = curs.ntuples()
+
+            if nrows == 0:
+                logger.info('[OK] AO lastrownums check for pg_attribute_encoding')
+            else:
+                GV.checkStatus = False
+                # we could not fix this issue automatically
+                setError(ERROR_NOREPAIR)
+                logger.info('[FAIL] AO lastrownums check for pg_attribute_encoding')
+                for relname, relid, attnum, lastrownums, objmod, last_sequence, last_rownum in curs.getresult():
+                    logger.error("   found inconsistent last_rownum {rownum} with last_sequence {seqnum} of aoseg {segno} for table '{relname}' attribute {attnum} on segment {content}"
+                                 .format(rownum = last_rownum,
+                                         seqnum = last_sequence,
+                                         segno = objmod,
+                                         relname = relname,
+                                         attnum = attnum,
+                                         content = self.cfg['content']))
+
+        except Exception as e:
+            GV.checkStatus = False
+            self.error = e
+
+# for test "ao_lastrownums"
+def checkAOLastrownums():
+    threads = []
+    i = 1
+    # parallelise check
+    for dbid in GV.cfg:
+        cfg = GV.cfg[dbid]
+        db_connection = connect2(cfg)
+        thread = checkAOLastrownumThread(cfg, db_connection)
+        thread.start()
+        logger.debug('launching check thread %s for dbid %i' %
+                     (thread.name, dbid))
+        threads.append(thread)
+
+        if (i % GV.opt['-B']) == 0:
+            processThread(threads)
+            threads = []
+
+        i += 1
+
+    processThread(threads)
+
 # -------------------------------------------------------------------------------
 
 # Exclude these tuples from the catalog table scan
@@ -1618,6 +1694,11 @@ def checkTableInconsistentEntry(cat):
     castcols = list(map(lambda b: b.replace("stxddependencies","stxddependencies::text"), castcols))
     columns = list(map(lambda b: b.replace("stxdmcv","stxdmcv::text"), columns))
     castcols = list(map(lambda b: b.replace("stxdmcv","stxdmcv::text"), castcols))
+
+    # pg_attribute_encoding.lastrownums could have various values on segments, ignore them
+    if catname == 'pg_attribute_encoding':
+        columns.remove('lastrownums')
+        castcols.remove('lastrownums')
 
     if cat.tableHasConsistentOids():
         qry = inconsistentEntryQuery(GV.max_content, catname, ['oid'], columns, castcols)
@@ -2044,6 +2125,14 @@ all_checks = {
             "fn": lambda: checkAOSegVpinfo(),
             "version": 'main',
             "order": 15,
+            "online": False
+        },
+    "ao_lastrownums":
+        {
+            "description": "Check that lastrownums in pg_attribute_encoding is consistent with gp_fastsequence",
+            "fn": lambda: checkAOLastrownums(),
+            "version": 'main',
+            "order": 16,
             "online": False
         }
 }

--- a/src/backend/access/aocs/aocsam.c
+++ b/src/backend/access/aocs/aocsam.c
@@ -1730,7 +1730,7 @@ aocs_fetch_init(Relation relation,
 	 * rather than all AOTupleId_MultiplierSegmentFileNum ones that introducing
 	 * too many unnecessary calls in most cases.
 	 */
-	memset(aocsFetchDesc->lastSequence, -1, sizeof(aocsFetchDesc->lastSequence));
+	memset(aocsFetchDesc->lastSequence, InvalidAORowNum, sizeof(aocsFetchDesc->lastSequence));
 	for (int i = -1; i < aocsFetchDesc->totalSegfiles; i++)
 	{
 		/* always initailize segment 0 */

--- a/src/backend/access/appendonly/appendonly_compaction.c
+++ b/src/backend/access/appendonly/appendonly_compaction.c
@@ -433,7 +433,7 @@ AppendOnlySegmentFileFullCompaction(Relation aorel,
 	tupDesc = RelationGetDescr(aorel);
 	slot = MakeSingleTupleTableSlot(tupDesc, &TTSOpsVirtual);
 	slot->tts_tableOid = RelationGetRelid(aorel);
-	mt_bind = create_memtuple_binding(tupDesc);
+	mt_bind = create_memtuple_binding(tupDesc, tupDesc->natts);
 
 	/*
 	 * We need a ResultRelInfo and an EState so we can use the regular

--- a/src/backend/access/appendonly/appendonlyam.c
+++ b/src/backend/access/appendonly/appendonlyam.c
@@ -2338,7 +2338,7 @@ appendonly_fetch_init(Relation relation,
 	 * rather than all AOTupleId_MultiplierSegmentFileNum ones that introducing
 	 * too many unnecessary calls in most cases.
 	 */
-	memset(aoFetchDesc->lastSequence, -1, sizeof(aoFetchDesc->lastSequence));
+	memset(aoFetchDesc->lastSequence, InvalidAORowNum, sizeof(aoFetchDesc->lastSequence));
 	for (int i = -1; i < aoFetchDesc->totalSegfiles; i++)
 	{
 		/* always initailize segment 0 */

--- a/src/backend/access/appendonly/appendonlyam_handler.c
+++ b/src/backend/access/appendonly/appendonlyam_handler.c
@@ -1290,7 +1290,7 @@ appendonly_relation_copy_for_cluster(Relation OldHeap, Relation NewHeap,
 
 	SIMPLE_FAULT_INJECTOR("cluster_ao_seq_scan_begin");
 
-	mt_bind = create_memtuple_binding(oldTupDesc);
+	mt_bind = create_memtuple_binding(oldTupDesc, oldTupDesc->natts);
 
 	while (appendonly_getnextslot(aoscandesc, ForwardScanDirection, slot))
 	{

--- a/src/backend/access/common/memtuple.c
+++ b/src/backend/access/common/memtuple.c
@@ -56,9 +56,9 @@
  */
 
 static int
-compute_null_bitmap_extra_size(TupleDesc tupdesc, int col_align)
+compute_null_bitmap_extra_size(int expected_natts, int col_align)
 {
-	int nbytes = (tupdesc->natts + 7) >> 3;
+	int nbytes = (expected_natts + 7) >> 3;
 	int avail_bytes = (col_align == 4) ? 0 : 4;
 
 	Assert(col_align == 4 || col_align == 8);
@@ -194,20 +194,20 @@ att_bind_as_varoffset(Form_pg_attribute attr)
 }
 
 /* Create columns binding, depends on islarge, using 2 or 4 bytes for offset_len */
-static void create_col_bind(MemTupleBindingCols *colbind, bool islarge, TupleDesc tupdesc, int col_align)
+static void create_col_bind(MemTupleBindingCols *colbind, bool islarge, TupleDesc tupdesc, int col_align, int expected_natts)
 {
 	int i = 0;
 	int physical_col = 0;
 	int pass = 0;
 
 	uint32 cur_offset = (col_align == 8) ? 8 : 4;
-	uint32 null_save_entries = compute_null_save_entries(tupdesc->natts);
+	uint32 null_save_entries = compute_null_save_entries(expected_natts);
 
 	/* alloc null save entries.  Zero it */
 	colbind->null_saves = (short *) palloc0(sizeof(short) * null_save_entries);
 
 	/* alloc bindings, no need to zero because we will fill them out  */
-	colbind->bindings = (MemTupleAttrBinding *) palloc(sizeof(MemTupleAttrBinding) * tupdesc->natts);
+	colbind->bindings = (MemTupleAttrBinding *) palloc(sizeof(MemTupleAttrBinding) * expected_natts);
 	
 	/*
 	 * The length of each binding is determined according to the alignment
@@ -228,7 +228,7 @@ static void create_col_bind(MemTupleBindingCols *colbind, bool islarge, TupleDes
 	 */
 	for(pass =0; pass < 4; ++pass)
 	{
-		for(i=0; i<tupdesc->natts; ++i)
+		for(i=0; i<expected_natts; ++i)
 		{
 			Form_pg_attribute attr = TupleDescAttr(tupdesc, i);
 			MemTupleAttrBinding *bind = &colbind->bindings[i];
@@ -354,7 +354,7 @@ static void create_col_bind(MemTupleBindingCols *colbind, bool islarge, TupleDes
 	}
 
 #ifdef USE_DEBUG_ASSERT
-	for(i=0; i<tupdesc->natts; ++i)
+	for(i=0; i<expected_natts; ++i)
 	{
 		MemTupleAttrBinding *bind = &colbind->bindings[i];
 		Assert(bind->offset[i] != 0);
@@ -366,22 +366,37 @@ static void create_col_bind(MemTupleBindingCols *colbind, bool islarge, TupleDes
 	else
 		colbind->var_start = 8;
 
-	Assert(tupdesc->natts == physical_col);
+	Assert(expected_natts == physical_col);
 }
 
-/* Create a memtuple binding from the tupdesc.  Note we store
- * a ref to the tupdesc in the binding, so we assumed the life
+/*
+ * Create a memtuple binding from the tupdesc and number of attributes.
+ * Note we store a ref to the tupdesc in the binding, so we assumed the life
  * span of the tupdesc is no shorter than the binding.
+ *
+ * IMPORTANT: the created binding only makes sense to the given expected natts,
+ * so caller must be aware that they pass the right expected natts:
+ *   - if the binding is for write (e.g. insert, vacuum), expected natts is
+ *     number of attributes intended for the memtuple to be stored.
+ *   - if the binding is for read (e.g. select), expected natts is the number
+ *     of attributes physically stored in the memtuple to be read.
  */
-MemTupleBinding *create_memtuple_binding(TupleDesc tupdesc) 
+MemTupleBinding *create_memtuple_binding(TupleDesc tupdesc, int expected_natts) 
 {
 	MemTupleBinding *pbind = (MemTupleBinding *) palloc(sizeof(MemTupleBinding));
 	int			i;
 
 	pbind->tupdesc = tupdesc;
 	pbind->column_align = 4;
+
+	/*
+	 * number of expected attributes should be a valid number and no larger
+	 * than what's specified in the tuple descriptor
+	 */
+	Assert(expected_natts >= 0 && expected_natts <= tupdesc->natts);
+	pbind->natts = expected_natts;
 	
-	for(i = 0; i < tupdesc->natts; ++i)
+	for(i = 0; i < expected_natts; ++i)
 	{
 		Form_pg_attribute attr = TupleDescAttr(tupdesc, i);
 
@@ -392,10 +407,10 @@ MemTupleBinding *create_memtuple_binding(TupleDesc tupdesc)
 		}
 	}
 
-	pbind->null_bitmap_extra_size = compute_null_bitmap_extra_size(tupdesc, pbind->column_align); 
+	pbind->null_bitmap_extra_size = compute_null_bitmap_extra_size(expected_natts, pbind->column_align); 
 
-	create_col_bind(&pbind->bind, false, tupdesc, pbind->column_align);
-	create_col_bind(&pbind->large_bind, true, tupdesc, pbind->column_align);
+	create_col_bind(&pbind->bind, false, tupdesc, pbind->column_align, expected_natts);
+	create_col_bind(&pbind->large_bind, true, tupdesc, pbind->column_align, expected_natts);
 
 	return pbind;
 }
@@ -841,11 +856,18 @@ Datum memtuple_getattr(MemTuple mtup, MemTupleBinding *pbind, int attnum, bool *
 	return memtuple_getattr_by_alignment(mtup, pbind, attnum, isnull);
 }
 
+/*
+ * Get as many attribute values as indicated in the binding.
+ * If there are missing attributes, get the rest from catalog.
+ */
 static void memtuple_get_values(MemTuple mtup, MemTupleBinding *pbind, Datum *datum, bool *isnull)
 {
 	int i;
-	for(i=0; i<pbind->tupdesc->natts; ++i)
+	for(i=0; i<pbind->natts; ++i)
 		datum[i] = memtuple_getattr_by_alignment(mtup, pbind, i+1, &isnull[i]);
+	/* read the missing ones, if any */
+	for (; i<pbind->tupdesc->natts; ++i)
+		datum[i] = getmissingattr(pbind->tupdesc, i+1, &isnull[i]);
 }
 
 void memtuple_deform(MemTuple mtup, MemTupleBinding *pbind, Datum *datum, bool *isnull)

--- a/src/backend/catalog/pg_appendonly.c
+++ b/src/backend/catalog/pg_appendonly.c
@@ -308,7 +308,7 @@ RemoveAppendonlyEntry(Oid relid)
 	}
 
 	/* Piggyback here to remove gp_fastsequence entries */
-	RemoveFastSequenceEntry(aosegrelid);
+	RemoveFastSequenceEntry(relid, aosegrelid);
 
 	/*
 	 * Delete the appendonly table entry from the catalog (pg_appendonly).

--- a/src/include/access/memtup.h
+++ b/src/include/access/memtup.h
@@ -47,6 +47,7 @@ typedef struct MemTupleBinding
 	TupleDesc tupdesc;
 	int column_align;
 	int null_bitmap_extra_size;  /* extra bytes required by null bitmap */
+	int natts; 			/* number of attributes in memtuple (note: it could be smaller than tupdesc->natts) */
 
 	MemTupleBindingCols bind;  	/* 2 bytes offsets */
 	MemTupleBindingCols large_bind; /* large tup, 4 bytes offsets */
@@ -120,7 +121,7 @@ static inline void memtuple_set_hasext(MemTuple mtup)
 
 
 extern void destroy_memtuple_binding(MemTupleBinding *pbind);
-extern MemTupleBinding* create_memtuple_binding(TupleDesc tupdesc);
+extern MemTupleBinding* create_memtuple_binding(TupleDesc tupdesc, int expected_natts);
 
 extern Datum memtuple_getattr(MemTuple mtup, MemTupleBinding *pbind, int attnum, bool *isnull);
 

--- a/src/include/catalog/catversion.h
+++ b/src/include/catalog/catversion.h
@@ -56,6 +56,6 @@
  */
 
 /*							3yyymmddN */
-#define CATALOG_VERSION_NO	302305111
+#define CATALOG_VERSION_NO	302305231
 
 #endif

--- a/src/include/catalog/gp_fastsequence.h
+++ b/src/include/catalog/gp_fastsequence.h
@@ -68,6 +68,7 @@ do { \
 extern int64 GetFastSequences(Oid objid, int64 objmod, int64 numSequences);
 
 extern int64 ReadLastSequence(Oid objid, int64 objmod);
+extern void ReadAllLastSequences(Oid objid, int64 *seqs);
 
 /*
  * RemoveFastSequenceEntry
@@ -80,6 +81,6 @@ extern int64 ReadLastSequence(Oid objid, int64 objmod);
  * If the given valid objid does not have an entry in
  * gp_fastsequence, this function errors out.
  */
-extern void RemoveFastSequenceEntry(Oid objid);
+extern void RemoveFastSequenceEntry(Oid relid, Oid objid);
 
 #endif

--- a/src/include/catalog/pg_attribute_encoding.h
+++ b/src/include/catalog/pg_attribute_encoding.h
@@ -43,6 +43,9 @@ CATALOG(pg_attribute_encoding,6231,AttributeEncodingRelationId)
 	int16	attnum;
 	int16   filenum;
 #ifdef CATALOG_VARLEN			/* variable-length fields start here */
+	int64 	lastrownums[1]; 	/* Last row number of each segfile when this attribute is added.
+					   This is populated up to the highest numbered segfile and can
+					   have a max length of MAX_AOREL_CONCURRENCY. */
 	text	attoptions[1];	
 #endif
 } FormData_pg_attribute_encoding;
@@ -62,14 +65,18 @@ extern PGFunction *get_funcs_for_compression(char *compresstype);
 extern StdRdOptions **RelationGetAttributeOptions(Relation rel);
 extern List **RelationGetUntransformedAttributeOptions(Relation rel);
 
-extern void AddRelationAttributeEncodings(Oid relid, List *attr_encodings);
+extern Datum transform_lastrownums(int64 *lastrownums);
+extern void add_attribute_encoding_entry(Oid relid, AttrNumber attnum, FileNumber filenum, Datum lastrownums, Datum attoptions);
+extern void AddCOAttributeEncodings(Oid relid, List *attr_encodings);
 extern void RemoveAttributeEncodingsByRelid(Oid relid);
 extern void CloneAttributeEncodings(Oid oldrelid, Oid newrelid, AttrNumber max_attno);
 extern void UpdateAttributeEncodings(Oid relid, List *new_attr_encodings);
 extern void UpdateFilenumForAttnum(Oid relid, AttrNumber attnum, FileNumber newfilenum);
+extern void ClearAttributeEncodingLastrownums(Oid relid);
 extern FileNumber GetFilenumForAttribute(Oid relid, AttrNumber attnum);
 extern FileNumber GetFilenumForRewriteAttribute(Oid relid, AttrNumber attnum);
 extern List *GetNextNAvailableFilenums(Oid relid, int n);
+extern int64 *GetAttnumToLastrownumMapping(Oid relid, int natts);
 extern Datum *get_rel_attoptions(Oid relid, AttrNumber max_attno);
 extern List * rel_get_column_encodings(Relation rel);
 

--- a/src/include/cdb/cdbappendonlyam.h
+++ b/src/include/cdb/cdbappendonlyam.h
@@ -120,6 +120,8 @@ typedef struct AppendOnlyExecutorReadBlock
 
 	AppendOnlyStorageRead	*storageRead;
 
+	AttrNumber 		curLargestAttnum; /* the largest attnum stored in memtuple currently being read */
+	int64 			*attnum_to_rownum; /*attnum to rownum mapping, used in building memtuple binding */
 	MemTupleBinding *mt_bind;
 	/*
 	 * When reading a segfile that's using version < AOSegfileFormatVersion_GP5,

--- a/src/test/isolation2/input/uao/alter_table.source
+++ b/src/test/isolation2/input/uao/alter_table.source
@@ -1,0 +1,53 @@
+---------------------------------------------------
+-- ALTER TABLE concurrency tests
+---------------------------------------------------
+
+--
+-- ADD COLUMN
+--
+create table t_addcol_@amname@(a int) using @amname@ distributed replicated;
+insert into t_addcol_@amname@ values(1);
+
+alter table t_addcol_@amname@ add column b int default 99;
+1: begin;
+2: begin;
+-- both trx should not read what the other is inserting
+1: insert into t_addcol_@amname@ values(101);
+2: insert into t_addcol_@amname@ values(201);
+1: select * from t_addcol_@amname@;
+2: select * from t_addcol_@amname@;
+-- now insert non-default values, should read correctly
+1: insert into t_addcol_@amname@ values(102, 0);
+2: insert into t_addcol_@amname@ values(202, 0);
+1: insert into t_addcol_@amname@ values(103, NULL);
+2: insert into t_addcol_@amname@ values(203, NULL);
+1: select * from t_addcol_@amname@;
+2: select * from t_addcol_@amname@;
+1: end;
+2: end;
+-- both trx should read the same data now
+1: select * from t_addcol_@amname@;
+2: select * from t_addcol_@amname@;
+
+-- add column should be blocked while another trx is doing the same
+1: begin;
+1: alter table t_addcol_@amname@ add column c1 text default 'trx1';
+2: begin;
+2>: alter table t_addcol_@amname@ add column c2 text default 'trx2';
+1: end;
+2<:
+2: end;
+select * from t_addcol_@amname@;
+
+delete from t_addcol_@amname@;
+select count(*) from t_addcol_@amname@;
+
+-- only one trx commits but another one aborts
+1: begin;
+2: begin;
+1: insert into t_addcol_@amname@ select * from generate_series(1,10000);
+2: insert into t_addcol_@amname@ select * from generate_series(1,10000);
+1: abort;
+2: end;
+select count(*) from t_addcol_@amname@;
+select sum(b) = count(*) * 99 as expected from t_addcol_@amname@;

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -103,6 +103,7 @@ test: disable_autovacuum
 # Tests on Append-Optimized tables (row-oriented).
 test: concurrent_index_creation_should_not_deadlock
 test: uao/alter_while_vacuum_row uao/alter_while_vacuum2_row
+test: uao/alter_table_row
 test: uao/brin_row
 test: uao/compaction_full_stats_row
 test: uao/compaction_utility_row
@@ -169,6 +170,7 @@ test: segwalrep/coordinator_wal_switch
 # Tests on Append-Optimized tables (column-oriented).
 test: aoco_column_rewrite
 test: uao/alter_while_vacuum_column uao/alter_while_vacuum2_column
+test: uao/alter_table_column
 test: uao/brin_column
 test: uao/compaction_full_stats_column
 test: uao/compaction_utility_column

--- a/src/test/isolation2/output/uao/alter_table.source
+++ b/src/test/isolation2/output/uao/alter_table.source
@@ -1,0 +1,145 @@
+---------------------------------------------------
+-- ALTER TABLE concurrency tests
+---------------------------------------------------
+
+--
+-- ADD COLUMN
+--
+create table t_addcol_@amname@(a int) using @amname@ distributed replicated;
+CREATE
+insert into t_addcol_@amname@ values(1);
+INSERT 1
+
+alter table t_addcol_@amname@ add column b int default 99;
+ALTER
+1: begin;
+BEGIN
+2: begin;
+BEGIN
+-- both trx should not read what the other is inserting
+1: insert into t_addcol_@amname@ values(101);
+INSERT 1
+2: insert into t_addcol_@amname@ values(201);
+INSERT 1
+1: select * from t_addcol_@amname@;
+ a   | b  
+-----+----
+ 1   | 99 
+ 101 | 99 
+(2 rows)
+2: select * from t_addcol_@amname@;
+ a   | b  
+-----+----
+ 1   | 99 
+ 201 | 99 
+(2 rows)
+-- now insert non-default values, should read correctly
+1: insert into t_addcol_@amname@ values(102, 0);
+INSERT 1
+2: insert into t_addcol_@amname@ values(202, 0);
+INSERT 1
+1: insert into t_addcol_@amname@ values(103, NULL);
+INSERT 1
+2: insert into t_addcol_@amname@ values(203, NULL);
+INSERT 1
+1: select * from t_addcol_@amname@;
+ a   | b  
+-----+----
+ 1   | 99 
+ 101 | 99 
+ 102 | 0  
+ 103 |    
+(4 rows)
+2: select * from t_addcol_@amname@;
+ a   | b  
+-----+----
+ 1   | 99 
+ 201 | 99 
+ 202 | 0  
+ 203 |    
+(4 rows)
+1: end;
+END
+2: end;
+END
+-- both trx should read the same data now
+1: select * from t_addcol_@amname@;
+ a   | b  
+-----+----
+ 1   | 99 
+ 101 | 99 
+ 102 | 0  
+ 103 |    
+ 201 | 99 
+ 202 | 0  
+ 203 |    
+(7 rows)
+2: select * from t_addcol_@amname@;
+ a   | b  
+-----+----
+ 1   | 99 
+ 101 | 99 
+ 102 | 0  
+ 103 |    
+ 201 | 99 
+ 202 | 0  
+ 203 |    
+(7 rows)
+
+-- add column should be blocked while another trx is doing the same
+1: begin;
+BEGIN
+1: alter table t_addcol_@amname@ add column c1 text default 'trx1';
+ALTER
+2: begin;
+BEGIN
+2>: alter table t_addcol_@amname@ add column c2 text default 'trx2';  <waiting ...>
+1: end;
+END
+2<:  <... completed>
+ALTER
+2: end;
+END
+select * from t_addcol_@amname@;
+ a   | b  | c1   | c2   
+-----+----+------+------
+ 1   | 99 | trx1 | trx2 
+ 101 | 99 | trx1 | trx2 
+ 102 | 0  | trx1 | trx2 
+ 103 |    | trx1 | trx2 
+ 201 | 99 | trx1 | trx2 
+ 202 | 0  | trx1 | trx2 
+ 203 |    | trx1 | trx2 
+(7 rows)
+
+delete from t_addcol_@amname@;
+DELETE 7
+select count(*) from t_addcol_@amname@;
+ count 
+-------
+ 0     
+(1 row)
+
+-- only one trx commits but another one aborts
+1: begin;
+BEGIN
+2: begin;
+BEGIN
+1: insert into t_addcol_@amname@ select * from generate_series(1,10000);
+INSERT 10000
+2: insert into t_addcol_@amname@ select * from generate_series(1,10000);
+INSERT 10000
+1: abort;
+ABORT
+2: end;
+END
+select count(*) from t_addcol_@amname@;
+ count 
+-------
+ 10000 
+(1 row)
+select sum(b) = count(*) * 99 as expected from t_addcol_@amname@;
+ expected 
+----------
+ t        
+(1 row)

--- a/src/test/regress/expected/alter_table.out
+++ b/src/test/regress/expected/alter_table.out
@@ -2673,8 +2673,7 @@ INSERT INTO rewrite_test_ao VALUES ('something');
 INSERT INTO rewrite_test_ao VALUES (NULL);
 INSERT INTO rewrite_test_co VALUES ('something');
 INSERT INTO rewrite_test_co VALUES (NULL);
--- Testing all three AMs. But note that, the comments are for the heap table ('rewrite_test')
--- For AO table, always rewrite table in ADD COLUMN (see the FIXME in ATExecAddColumn())
+-- Testing all three AMs.
 -- For AOCO table, never table rewrite (just need to write new column)
 -- empty[12] don't need rewrite, but notempty[12]_rewrite will force one
 SELECT check_ddl_rewrite('rewrite_test', $$
@@ -2765,7 +2764,7 @@ SELECT check_ddl_rewrite('rewrite_test_ao', $$
 $$);
  check_ddl_rewrite 
 -------------------
- t
+ f
 (1 row)
 
 SELECT check_ddl_rewrite('rewrite_test_ao', $$
@@ -2775,7 +2774,7 @@ SELECT check_ddl_rewrite('rewrite_test_ao', $$
 $$);
  check_ddl_rewrite 
 -------------------
- t
+ f
 (1 row)
 
 SELECT check_ddl_rewrite('rewrite_test_co', $$

--- a/src/test/regress/expected/alter_table_ao.out
+++ b/src/test/regress/expected/alter_table_ao.out
@@ -684,3 +684,511 @@ INSERT INTO split_tupdesc_leak VALUES ('201412','0001EC1TPEvT5SaJKIR5yYXlFQ7tS',
 ALTER TABLE split_tupdesc_leak SPLIT DEFAULT PARTITION AT ('201412')
 	INTO (PARTITION p_split_tupdesc_leak_ym, PARTITION p_split_tupdesc_leak_ym_201412);
 DROP TABLE split_tupdesc_leak;
+---------------------------------------------------
+-- ADD COLUMN optimization for ao_row tables
+---------------------------------------------------
+create table relfilenodecheck(segid int, relname text, relfilenodebefore int, relfilenodeafter int, casename text);
+-- capture relfilenode for a table, which will be checked by checkrelfilenodediff
+prepare capturerelfilenodebefore as
+insert into relfilenodecheck select -1 segid, relname, pg_relation_filenode(relname::text) as relfilenode, null::int, $1 as casename from pg_class where relname like $2
+union select gp_segment_id segid, relname, pg_relation_filenode(relname::text) as relfilenode, null::int, $1 as casename  from gp_dist_random('pg_class')
+where relname like $2 order by segid;
+-- check to see if relfilenode changed (i.e. whether a table is rewritten), only showing result of primary seg0
+prepare checkrelfilenodediff as
+select a.segid, b.casename, b.relname, (relfilenodebefore != a.relfilenode) rewritten
+from
+    (
+        select -1 segid, relname, pg_relation_filenode(relname::text) as relfilenode
+        from pg_class
+        where relname like $2
+        union
+        select gp_segment_id segid, relname, pg_relation_filenode(relname::text) as relfilenode
+        from gp_dist_random('pg_class')
+        where relname like $2 order by segid
+    )a, relfilenodecheck b
+where b.casename like $1 and b.relname like $2 and a.segid = b.segid and a.segid = 0;
+-- checking pg_attribute_encoding on one of the primaries (most of tested tables are distributed replicated)
+prepare checkattributeencoding as
+select attnum, filenum, lastrownums, attoptions 
+from gp_dist_random('pg_attribute_encoding') e
+  join pg_class c
+  on e.attrelid = c.oid
+where c.relname = $1 and e.gp_segment_id = 0;
+-- prepare the initial table
+create table t_addcol(a int) using ao_row distributed replicated;
+create index i_addcol_a on t_addcol(a);
+insert into t_addcol select * from generate_series(1, 10);
+--
+-- ADD COLUMN w/ default value
+--
+execute capturerelfilenodebefore('add column default 10', 't_addcol');
+alter table t_addcol add column def10 int default 10;
+-- no table rewrite
+execute checkrelfilenodediff('add column default 10', 't_addcol');
+ segid |       casename        | relname  | rewritten 
+-------+-----------------------+----------+-----------
+     0 | add column default 10 | t_addcol | f
+(1 row)
+
+-- select results are expected
+select sum(a), sum(def10) from t_addcol;
+ sum | sum 
+-----+-----
+  55 | 100
+(1 row)
+
+select gp_segment_id, (gp_toolkit.__gp_aoblkdir('t_addcol')).* from gp_dist_random('gp_id');
+ gp_segment_id | tupleid | segno | columngroup_no | entry_no | first_row_no | file_offset | row_count 
+---------------+---------+-------+----------------+----------+--------------+-------------+-----------
+             1 | (0,1)   |     1 |              0 |        0 |            1 |           0 |        10
+             0 | (0,1)   |     1 |              0 |        0 |            1 |           0 |        10
+             2 | (0,1)   |     1 |              0 |        0 |            1 |           0 |        10
+(3 rows)
+
+-- pg_attribute_encoding currently has one row that corresponds to the new column
+execute checkattributeencoding('t_addcol');
+ attnum | filenum | lastrownums | attoptions 
+--------+---------+-------------+------------
+      2 |       1 | {0,100}     | 
+(1 row)
+
+--
+-- ADD COLUMN w/ null default
+--
+execute capturerelfilenodebefore('add column NULL default', 't_addcol');
+alter table t_addcol add column defnull1 int;
+alter table t_addcol add column defnull2 int default NULL;
+-- no table rewrite and results stay the same
+execute checkrelfilenodediff('add column NULL default', 't_addcol');
+ segid |        casename         | relname  | rewritten 
+-------+-------------------------+----------+-----------
+     0 | add column NULL default | t_addcol | f
+(1 row)
+
+select sum(a), sum(def10), sum(defnull1), sum(defnull2) from t_addcol;
+ sum | sum | sum | sum 
+-----+-----+-----+-----
+  55 | 100 |     |    
+(1 row)
+
+-- pg_attribute_encoding shows more entries for the new columns
+execute checkattributeencoding('t_addcol');
+ attnum | filenum | lastrownums | attoptions 
+--------+---------+-------------+------------
+      2 |       1 | {0,100}     | 
+      3 |       2 | {0,100}     | 
+      4 |       3 | {0,100}     | 
+(3 rows)
+
+-- add more data
+insert into t_addcol select 0 from generate_series(1, 10)i;
+select sum(a), sum(def10), sum(defnull1), sum(defnull2) from t_addcol;
+ sum | sum | sum | sum 
+-----+-----+-----+-----
+  55 | 200 |     |    
+(1 row)
+
+-- insert explict NULLs
+insert into t_addcol values(1,NULL,1, NULL);
+insert into t_addcol values(1,NULL,NULL, 1);
+select sum(a), sum(def10), sum(defnull1), sum(defnull2) from t_addcol;
+ sum | sum | sum | sum 
+-----+-----+-----+-----
+  57 | 200 |   1 |   1
+(1 row)
+
+--
+-- transaction abort should work fine
+--
+begin;
+alter table t_addcol add column colabort int default 1;
+insert into t_addcol values(1);
+-- results updated in transaction
+select sum(a), sum(def10), sum(defnull1), sum(defnull2), sum(colabort), count(*) from t_addcol;
+ sum | sum | sum | sum | sum | count 
+-----+-----+-----+-----+-----+-------
+  58 | 210 |   1 |   1 |  23 |    23
+(1 row)
+
+-- pg_attribute_encoding shows the new column
+execute checkattributeencoding('t_addcol');
+ attnum | filenum | lastrownums | attoptions 
+--------+---------+-------------+------------
+      2 |       1 | {0,100}     | 
+      3 |       2 | {0,100}     | 
+      4 |       3 | {0,100}     | 
+      5 |       4 | {0,400}     | 
+(4 rows)
+
+abort;
+-- results reverts to previous ones
+select sum(a), sum(def10), sum(defnull1), sum(defnull2) from t_addcol;
+ sum | sum | sum | sum 
+-----+-----+-----+-----
+  57 | 200 |   1 |   1
+(1 row)
+
+-- error out
+select colabort from t_addcol;
+ERROR:  column "colabort" does not exist
+LINE 1: select colabort from t_addcol;
+               ^
+-- the aborted column is not visible in pg_attribute_encoding
+execute checkattributeencoding('t_addcol');
+ attnum | filenum | lastrownums | attoptions 
+--------+---------+-------------+------------
+      2 |       1 | {0,100}     | 
+      3 |       2 | {0,100}     | 
+      4 |       3 | {0,100}     | 
+(3 rows)
+
+--
+-- table rewrite scenarios 
+--
+-- 1. reorganize
+execute capturerelfilenodebefore('reorganize', 't_addcol');
+alter table t_addcol set with(reorganize=true);
+execute checkrelfilenodediff('reorganize', 't_addcol');
+ segid |  casename  | relname  | rewritten 
+-------+------------+----------+-----------
+     0 | reorganize | t_addcol | t
+(1 row)
+
+-- results intact
+select sum(a), sum(def10), sum(defnull1), sum(defnull2) from t_addcol;
+ sum | sum | sum | sum 
+-----+-----+-----+-----
+  57 | 200 |   1 |   1
+(1 row)
+
+-- 2. alter access method
+execute capturerelfilenodebefore('atsetam', 't_addcol');
+alter table t_addcol set access method ao_column with (compresstype=rle_type, compresslevel=1);
+execute checkrelfilenodediff('atsetam', 't_addcol');
+ segid | casename | relname  | rewritten 
+-------+----------+----------+-----------
+     0 | atsetam  | t_addcol | t
+(1 row)
+
+-- results intact
+select sum(a), sum(def10), sum(defnull1), sum(defnull2) from t_addcol;
+ sum | sum | sum | sum 
+-----+-----+-----+-----
+  57 | 200 |   1 |   1
+(1 row)
+
+-- should see updated pg_attribute_encoding entries, w/o lastrownums but w/ attoptions
+execute checkattributeencoding('t_addcol');
+ attnum | filenum | lastrownums |                       attoptions                        
+--------+---------+-------------+---------------------------------------------------------
+      1 |       1 |             | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+      2 |       2 |             | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+      3 |       3 |             | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+      4 |       4 |             | {compresstype=rle_type,compresslevel=1,blocksize=32768}
+(4 rows)
+
+-- change it back to ao_row for further testing
+alter table t_addcol set access method ao_row;
+select a.amname from pg_class c join pg_am a on c.relam = a.oid where c.relname = 't_addcol';
+ amname 
+--------
+ ao_row
+(1 row)
+
+--
+-- DELETE and VACUUM
+--
+alter table t_addcol add column def20 int default 20;
+select sum(a), sum(def10), sum(defnull1), sum(defnull2), sum(def20) from t_addcol;
+ sum | sum | sum | sum | sum 
+-----+-----+-----+-----+-----
+  57 | 200 |   1 |   1 | 440
+(1 row)
+
+-- delete
+delete from t_addcol where a = 10;
+-- the row (10, 10, NULL, NULL, 20) is deleted
+select sum(a), sum(def10), sum(defnull1), sum(defnull2), sum(def20) from t_addcol;
+ sum | sum | sum | sum | sum 
+-----+-----+-----+-----+-----
+  47 | 190 |   1 |   1 | 420
+(1 row)
+
+-- visimap shows effect of the deletion
+select gp_segment_id, (gp_toolkit.__gp_aovisimap('t_addcol')).* from gp_dist_random('gp_id');
+ gp_segment_id |  tid   | segno | row_num 
+---------------+--------+-------+---------
+             0 | (0,11) |     0 |      10
+             2 | (0,11) |     0 |      10
+             1 | (0,11) |     0 |      10
+(3 rows)
+
+-- vacuum
+vacuum t_addcol;
+-- results intact
+select sum(a), sum(def10), sum(defnull1), sum(defnull2), sum(def20) from t_addcol;
+ sum | sum | sum | sum | sum 
+-----+-----+-----+-----+-----
+  47 | 190 |   1 |   1 | 420
+(1 row)
+
+-- insert one row and delete it
+insert into t_addcol values(99);
+delete from t_addcol where a = 99;
+-- results stay the same, but visimap shows effect for segno=1 (which the new row is inserted)
+select sum(a), sum(def10), sum(defnull1), sum(defnull2), sum(def20) from t_addcol;
+ sum | sum | sum | sum | sum 
+-----+-----+-----+-----+-----
+  47 | 190 |   1 |   1 | 420
+(1 row)
+
+select gp_segment_id, (gp_toolkit.__gp_aovisimap('t_addcol')).* from gp_dist_random('gp_id');
+ gp_segment_id |     tid      | segno | row_num 
+---------------+--------------+-------+---------
+             0 | (0,11)       |     0 |      10
+             0 | (33554432,2) |     1 |       1
+             1 | (0,11)       |     0 |      10
+             1 | (33554432,2) |     1 |       1
+             2 | (0,11)       |     0 |      10
+             2 | (33554432,2) |     1 |       1
+(6 rows)
+
+vacuum t_addcol;
+-- segno=1 has been vacuum'ed, visimap shows effect
+select gp_segment_id, (gp_toolkit.__gp_aovisimap('t_addcol')).* from gp_dist_random('gp_id');
+ gp_segment_id |  tid   | segno | row_num 
+---------------+--------+-------+---------
+             0 | (0,11) |     0 |      10
+             1 | (0,11) |     0 |      10
+             2 | (0,11) |     0 |      10
+(3 rows)
+
+-- delete all but the newly inserted
+insert into t_addcol values(NULL, NULL, NULL, NULL, 100);
+delete from t_addcol where def20 != 100;
+select sum(a), sum(def10), sum(defnull1), sum(defnull2), sum(def20) from t_addcol;
+ sum | sum | sum | sum | sum 
+-----+-----+-----+-----+-----
+     |     |     |     | 100
+(1 row)
+
+-- delete all for further testing
+delete from t_addcol;
+select count(*) from t_addcol;
+ count 
+-------
+     0
+(1 row)
+
+vacuum t_addcol;
+-- visimap cleared
+select gp_segment_id, (gp_toolkit.__gp_aovisimap('t_addcol')).* from gp_dist_random('gp_id');
+ gp_segment_id | tid | segno | row_num 
+---------------+-----+-------+---------
+(0 rows)
+
+--
+-- large/toasted values
+--
+-- we've had a few AO segments for the table now (due to vacuum etc.), and insert could be choosing
+-- different segno depending on some runtime status (like the tuple order in scanning aoseg).
+-- So truncate to make test stable (no segments now).
+truncate t_addcol;
+-- new column has large default value
+insert into t_addcol values(1);
+execute capturerelfilenodebefore('addlarge1', 't_addcol');
+alter table t_addcol add column deflarge1 text default repeat('a', 100000);
+execute checkrelfilenodediff('addlarge1', 't_addcol');
+ segid | casename  | relname  | rewritten 
+-------+-----------+----------+-----------
+     0 | addlarge1 | t_addcol | f
+(1 row)
+
+select a, def10, defnull1, defnull2, def20, char_length(deflarge1) from t_addcol;
+ a | def10 | defnull1 | defnull2 | def20 | char_length 
+---+-------+----------+----------+-------+-------------
+ 1 |    10 |          |          |    20 |      100000
+(1 row)
+
+-- large existing value
+insert into t_addcol values(1,1,1,1,1, repeat('a',100001));
+execute capturerelfilenodebefore('addlarge2', 't_addcol');
+alter table t_addcol add column deflarge2 text default repeat('a', 1000002);
+execute checkrelfilenodediff('addlarge2', 't_addcol');
+ segid | casename  | relname  | rewritten 
+-------+-----------+----------+-----------
+     0 | addlarge2 | t_addcol | f
+(1 row)
+
+select a, def10, defnull1, defnull2, def20, char_length(deflarge1), char_length(deflarge2) from t_addcol;
+ a | def10 | defnull1 | defnull2 | def20 | char_length | char_length 
+---+-------+----------+----------+-------+-------------+-------------
+ 1 |     1 |        1 |        1 |     1 |      100001 |     1000002
+ 1 |    10 |          |          |    20 |      100000 |     1000002
+(2 rows)
+
+--
+-- drop column
+--
+-- check current pg_attribute_encoding
+execute checkattributeencoding('t_addcol');
+ attnum | filenum | lastrownums | attoptions 
+--------+---------+-------------+------------
+      5 |       1 |             | 
+      6 |       2 | {0,100}     | 
+      7 |       3 | {0,200}     | 
+(3 rows)
+
+-- drop a column
+alter table t_addcol drop column def20;
+-- error out
+select def20 from t_addcol;
+ERROR:  column "def20" does not exist
+LINE 1: select def20 from t_addcol;
+               ^
+HINT:  Perhaps you meant to reference the column "t_addcol.def10".
+-- other results intact
+select a, def10, defnull1, defnull2, char_length(deflarge1), char_length(deflarge2) from t_addcol;
+ a | def10 | defnull1 | defnull2 | char_length | char_length 
+---+-------+----------+----------+-------------+-------------
+ 1 |     1 |        1 |        1 |      100001 |     1000002
+ 1 |    10 |          |          |      100000 |     1000002
+(2 rows)
+
+-- column info still shown in pg_attribute_encoding, just like for AOCO tables
+execute checkattributeencoding('t_addcol');
+ attnum | filenum | lastrownums | attoptions 
+--------+---------+-------------+------------
+      5 |       1 |             | 
+      6 |       2 | {0,100}     | 
+      7 |       3 | {0,200}     | 
+(3 rows)
+
+--
+-- default value is an expression
+--
+-- non-volatile expressions
+execute capturerelfilenodebefore('addexp_nonvolatile', 't_addcol');
+alter table t_addcol add column defexp1 int default char_length(repeat('a', 100003));
+alter table t_addcol add column defexp2 timestamptz default current_timestamp;
+-- no table rewrite
+execute checkrelfilenodediff('addexp_nonvolatile', 't_addcol');
+ segid |      casename      | relname  | rewritten 
+-------+--------------------+----------+-----------
+     0 | addexp_nonvolatile | t_addcol | f
+(1 row)
+
+-- results are expected
+select a, def10, defnull1, defnull2, char_length(deflarge1), char_length(deflarge2), defexp1, defexp2 <= current_timestamp as expected_defexp2 from t_addcol;
+ a | def10 | defnull1 | defnull2 | char_length | char_length | defexp1 | expected_defexp2 
+---+-------+----------+----------+-------------+-------------+---------+------------------
+ 1 |     1 |        1 |        1 |      100001 |     1000002 |  100003 | t
+ 1 |    10 |          |          |      100000 |     1000002 |  100003 | t
+(2 rows)
+
+-- volatile expression, expecting a rewrite
+execute capturerelfilenodebefore('addexp_volatile', 't_addcol');
+alter table t_addcol add column defexp3 int default random()*1000::int;
+execute checkrelfilenodediff('addexp_volatile', 't_addcol');
+ segid |    casename     | relname  | rewritten 
+-------+-----------------+----------+-----------
+     0 | addexp_volatile | t_addcol | t
+(1 row)
+
+-- results are expected
+select a, def10, defnull1, defnull2, char_length(deflarge1), char_length(deflarge2), defexp1, defexp2 <= current_timestamp as expected_defexp2, defexp3 >=0 and defexp3 <= 1000 as expected_defexp3 from t_addcol;
+ a | def10 | defnull1 | defnull2 | char_length | char_length | defexp1 | expected_defexp2 | expected_defexp3 
+---+-------+----------+----------+-------------+-------------+---------+------------------+------------------
+ 1 |     1 |        1 |        1 |      100001 |     1000002 |  100003 | t                | t
+ 1 |    10 |          |          |      100000 |     1000002 |  100003 | t                | t
+(2 rows)
+
+--
+-- truncate
+--
+-- safe truncate
+truncate t_addcol;
+select count(*) from t_addcol;
+ count 
+-------
+     0
+(1 row)
+
+-- unsafe truncate
+begin;
+create table t_addcol_truncate(a int) distributed replicated;
+insert into t_addcol_truncate select * from generate_series(1,10000);
+alter table t_addcol_truncate add column b int default 10;
+select count(*) from t_addcol_truncate;
+ count 
+-------
+ 10000
+(1 row)
+
+truncate t_addcol_truncate;
+select count(*) from t_addcol_truncate;
+ count 
+-------
+     0
+(1 row)
+
+end;
+-- columns gone after truncate in pg_attribute_encoding
+execute checkattributeencoding('t_addcol');
+ attnum | filenum | lastrownums | attoptions 
+--------+---------+-------------+------------
+(0 rows)
+
+execute checkattributeencoding('t_addcol_truncate');
+ attnum | filenum | lastrownums | attoptions 
+--------+---------+-------------+------------
+(0 rows)
+
+--
+-- partition table
+--
+create table t_addcol_part(a int, b int) using ao_row partition by range(b);
+create table t_addcol_p1 partition of t_addcol_part for values from (1) to (51);
+create table t_addcol_p2 partition of t_addcol_part for values from (51) to (101);
+insert into t_addcol_part select i,i from generate_series(1,100)i;
+-- no rewrite for child partitions (parent partition doesn't have valid relfilenode)
+execute capturerelfilenodebefore('partition', 't_addcol_p1');
+execute capturerelfilenodebefore('partition', 't_addcol_p2');
+alter table t_addcol_part add column c int default 10;
+execute checkrelfilenodediff('partition', 't_addcol_p1');
+ segid | casename  |   relname   | rewritten 
+-------+-----------+-------------+-----------
+     0 | partition | t_addcol_p1 | f
+(1 row)
+
+execute checkrelfilenodediff('partition', 't_addcol_p2');
+ segid | casename  |   relname   | rewritten 
+-------+-----------+-------------+-----------
+     0 | partition | t_addcol_p2 | f
+(1 row)
+
+-- results are expected
+select sum(a), sum(b), sum(c) from t_addcol_part;
+ sum  | sum  | sum  
+------+------+------
+ 5050 | 5050 | 1000
+(1 row)
+
+-- child partitions have expected lastrownums info in the pg_attribute_encoding, while parent partition doesn't
+execute checkattributeencoding('t_addcol');
+ attnum | filenum | lastrownums | attoptions 
+--------+---------+-------------+------------
+(0 rows)
+
+execute checkattributeencoding('t_addcol_p1');
+ attnum | filenum | lastrownums | attoptions 
+--------+---------+-------------+------------
+      3 |       1 | {0,100}     | 
+(1 row)
+
+execute checkattributeencoding('t_addcol_p2');
+ attnum | filenum | lastrownums | attoptions 
+--------+---------+-------------+------------
+      3 |       1 | {0,100}     | 
+(1 row)
+

--- a/src/test/regress/expected/alter_table_aocs2.out
+++ b/src/test/regress/expected/alter_table_aocs2.out
@@ -817,10 +817,10 @@ SELECT * FROM rewrite_optimization_aoco_parent;
  segno |                   rel                    |  amname   |     aoco_add_col_optimized     
 -------+------------------------------------------+-----------+--------------------------------
     -1 | rewrite_optimization_aoco_parent         | ao_column | ADD COLUMN optimized for table
-    -1 | rewrite_optimization_aoco_parent_1_prt_1 | ao_row    | full table rewritten
+    -1 | rewrite_optimization_aoco_parent_1_prt_1 | ao_row    | ADD COLUMN optimized for table
     -1 | rewrite_optimization_aoco_parent_1_prt_2 | heap      | ADD COLUMN optimized for table
      0 | rewrite_optimization_aoco_parent         | ao_column | ADD COLUMN optimized for table
-     0 | rewrite_optimization_aoco_parent_1_prt_1 | ao_row    | full table rewritten
+     0 | rewrite_optimization_aoco_parent_1_prt_1 | ao_row    | ADD COLUMN optimized for table
      0 | rewrite_optimization_aoco_parent_1_prt_2 | heap      | ADD COLUMN optimized for table
 (6 rows)
 
@@ -859,10 +859,10 @@ SELECT * FROM rewrite_optimization_heap_parent;
  segno |                   rel                    |  amname   |     aoco_add_col_optimized     
 -------+------------------------------------------+-----------+--------------------------------
     -1 | rewrite_optimization_heap_parent         | heap      | ADD COLUMN optimized for table
-    -1 | rewrite_optimization_heap_parent_1_prt_1 | ao_row    | full table rewritten
+    -1 | rewrite_optimization_heap_parent_1_prt_1 | ao_row    | ADD COLUMN optimized for table
     -1 | rewrite_optimization_heap_parent_1_prt_2 | ao_column | ADD COLUMN optimized for table
      0 | rewrite_optimization_heap_parent         | heap      | ADD COLUMN optimized for table
-     0 | rewrite_optimization_heap_parent_1_prt_1 | ao_row    | full table rewritten
+     0 | rewrite_optimization_heap_parent_1_prt_1 | ao_row    | ADD COLUMN optimized for table
      0 | rewrite_optimization_heap_parent_1_prt_2 | ao_column | ADD COLUMN optimized for table
 (6 rows)
 

--- a/src/test/regress/expected/column_compression.out
+++ b/src/test/regress/expected/column_compression.out
@@ -278,8 +278,8 @@ drop table ccddl;
 -- We exclude the other tables leftover from other tests.
 select * from pg_attribute_encoding where
 	attrelid not in (select oid from pg_class where relname <> 'ccddl');
- attrelid | attnum | filenum | attoptions 
-----------+--------+---------+------------
+ attrelid | attnum | filenum | lastrownums | attoptions 
+----------+--------+---------+-------------+------------
 (0 rows)
 
 -- mix inline and default
@@ -1858,22 +1858,24 @@ create table ccddl (i int42) with(appendonly = true, orientation=row);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
 alter type int42 set default encoding (compresstype=RLE_TYPE);
 alter table ccddl add column j int42 default '1'::int42;
--- No results are returned from the attribute encoding check, as compression with rle is not supported for row tables
+-- No attoptions are shown from the attribute encoding check, as compression with rle is not supported for row tables
 execute ccddlcheck;
  relname | attname | filenum | attoptions 
 ---------+---------+---------+------------
-(0 rows)
+ ccddl   | j       |       1 | 
+(1 row)
 
 drop table ccddl;
 create table ccddl (i int42) with(appendonly = true);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause, and no column type is suitable for a distribution key. Creating a NULL policy entry.
 alter type int42 set default encoding (compresstype=RLE_TYPE);
 alter table ccddl add column j int42 default '1'::int42;
--- No results are returned from the attribute encoding check, as compression with rle is not supported for heap tables
+-- No attoptions are shown from the attribute encoding check, as compression with rle is not supported for row tables
 execute ccddlcheck;
  relname | attname | filenum | attoptions 
 ---------+---------+---------+------------
-(0 rows)
+ ccddl   | j       |       1 | 
+(1 row)
 
 drop table ccddl;
 -- We used to accept SQL standard aliases for the built-in types,

--- a/src/test/regress/input/appendonly.source
+++ b/src/test/regress/input/appendonly.source
@@ -530,6 +530,7 @@ select count(*) from tenk_ao1 where unique2 < 0;
 ALTER TABLE tenk_ao1 RENAME TO tenk_renamed;
 ALTER TABLE tenk_renamed ADD COLUMN newcol int default 10;
 -- Validate post alter gp_fastsequence reflects correctly
+-- There's not table rewrite, so gp_fastsequence remains same as before.
 SELECT objmod, CASE
 WHEN objmod = 0 THEN last_sequence >= 3300 WHEN objmod = 1 THEN last_sequence =
 0 END, gp_segment_id from gp_dist_random('gp_fastsequence') WHERE objid IN (SELECT

--- a/src/test/regress/output/appendonly.source
+++ b/src/test/regress/output/appendonly.source
@@ -1117,6 +1117,7 @@ select count(*) from tenk_ao1 where unique2 < 0;
 ALTER TABLE tenk_ao1 RENAME TO tenk_renamed;
 ALTER TABLE tenk_renamed ADD COLUMN newcol int default 10;
 -- Validate post alter gp_fastsequence reflects correctly
+-- There's not table rewrite, so gp_fastsequence remains same as before.
 SELECT objmod, CASE
 WHEN objmod = 0 THEN last_sequence >= 3300 WHEN objmod = 1 THEN last_sequence =
 0 END, gp_segment_id from gp_dist_random('gp_fastsequence') WHERE objid IN (SELECT
@@ -1127,7 +1128,10 @@ relname='tenk_renamed'));
       0 | t    |             0
       0 | t    |             1
       0 | t    |             2
-(3 rows)
+      1 | f    |             0
+      1 | f    |             1
+      1 | f    |             2
+(6 rows)
 
 ALTER TABLE tenk_renamed ALTER COLUMN twothousand SET NOT NULL;
 ALTER TABLE tenk_renamed ADD COLUMN sercol serial; -- MPP-10015

--- a/src/test/regress/sql/alter_table.sql
+++ b/src/test/regress/sql/alter_table.sql
@@ -1697,8 +1697,7 @@ INSERT INTO rewrite_test_ao VALUES (NULL);
 INSERT INTO rewrite_test_co VALUES ('something');
 INSERT INTO rewrite_test_co VALUES (NULL);
 
--- Testing all three AMs. But note that, the comments are for the heap table ('rewrite_test')
--- For AO table, always rewrite table in ADD COLUMN (see the FIXME in ATExecAddColumn())
+-- Testing all three AMs.
 -- For AOCO table, never table rewrite (just need to write new column)
 
 -- empty[12] don't need rewrite, but notempty[12]_rewrite will force one

--- a/src/test/regress/sql/column_compression.sql
+++ b/src/test/regress/sql/column_compression.sql
@@ -643,14 +643,14 @@ drop table ccddl;
 create table ccddl (i int42) with(appendonly = true, orientation=row);
 alter type int42 set default encoding (compresstype=RLE_TYPE);
 alter table ccddl add column j int42 default '1'::int42;
--- No results are returned from the attribute encoding check, as compression with rle is not supported for row tables
+-- No attoptions are shown from the attribute encoding check, as compression with rle is not supported for row tables
 execute ccddlcheck;
 drop table ccddl;
 
 create table ccddl (i int42) with(appendonly = true);
 alter type int42 set default encoding (compresstype=RLE_TYPE);
 alter table ccddl add column j int42 default '1'::int42;
--- No results are returned from the attribute encoding check, as compression with rle is not supported for heap tables
+-- No attoptions are shown from the attribute encoding check, as compression with rle is not supported for row tables
 execute ccddlcheck;
 drop table ccddl;
 


### PR DESCRIPTION
Since 16828d5c0273b4fe5f10f42588005f16b415b2d8, heap table can avoid a whole table rewrite in case of ADD COLUMN with non-volatile, non-NULL default value. The way it achieves that is to store the evaluated default values in pg_attribute. To any existing tuples, such a new attribute will be regarded as "missing", and when we read the tuples, we will fill the missing attributes using the values stored in pg_attribute. And, any new tuples being inserted will store the value physically on file (i.e. those attributes are not missing in new tuples).

Now doing the same for ao_row tables. The key difficulty we faced was that unlike heap tuples, the memtuple used by ao_row tables does not store the number of attributes in its header. Therefore, we do not know how many attributes are missing.

The idea (kudos to @ashwinstar) to solve above issue is that, during ADD COLUMN, we record the current last row number in each segment of the AO table. This values gives us knowledge about whether a memtuple, with a monotonically assigned row number, carries the corresponding attribute value or not. Therefore, we can figure out how many attributes are present in the memtuple and how many are missing. The algorithm is that (see `AOExecutorReadBlockBindingInit`):
1. the number of stored attributes = the largest column number `colno` that has smaller/equal `last_row_number` than the row number of memtuple we are reading;
2. the number of missing attributes = the total number of attributes minus the number of stored attributes.

We store the last row numbers in a new field `lastrownum` in pg_attribute_encoding. It is only added in ADD COLUMN. During table rewrite, `lastrownums` should be gone because we won't create them for the new table.

Other notable things:
1. Whenever we remove fastsequence entries (like in safe TRUNCATE), we would erase the lastrownums field. We do this instead of removing the pg_attribute_encoding entries entirely because we would want to support the same optimization for CO tables in future, and we surely couldn't remove pg_attribute_encoding entries for CO tables in TRUNCATE because CO tables still need them for the encoding options (pg_attribute_encoding.attoptions). So better do the right thing now.

2. We do not store any invalid fastsequence number '0' in lastrownums besides the initial one for RESERVED_SEGNO (segno=0). This is to save space in the catalog because in many cases only the first few segments are used. Note that, this can be done because these two assumptions are true:

    a. we only pick unused segments from segno low to high (see choose_new_segfile())
    b. once a segment is used, it would only have a fastsequence number greater than 0 until they are "marked" unused, e.g. when the whole table is truncated.

If these assumptions are broken some day, then we would have to store everything in the lastrownums field, or figure out some other way to save space.

3. Because we now have a possibility to update pg_attribute_encoding more than once in a command (e.g. when we drop an AO table we would drop the pg_attribute_encoding first, and then remove gp_fastsequence entries which try to clear pg_attribute_encoding       again). So now we increments command counter in RemoveAttributeEncodingsByRelid().       However, that causes (or reveals) two issues with ALTER TABLE SET ACCESS METHOD:

    a. In swap_relation_files(), we do RemoveAttributeEncodingsByRelid after we've            swapped/transferred pg_appendonly entries (ATAOEntries). So when we are            invalidating cache as part of command increment, we might have issue finding            pg_appendonly entry for a table which we have removed the pg_appendonly entry            of but haven't changed its relam. Basically, we should not increment command            between ATAOEntries and changing relam. Added comment for that.

    b. After we swapped relam and updated pg_class, we have to increment command            counter so whatever we do that follows would see the table in proper AM.            Otherwise, problem occurs e.g., after we've done AO->heap, when we reindex the           table, we might still see the table as AO and has problem building the relation     descriptor. This is revealed by the RemoveAttributeEncodingsByRelid change            because we made the pg_appendonly change visible but not the relam.

Performance wise, there is certain overhead being added to calculate the number of stored attributes during a read. But it is not excessive for two reasons:
1. The time is proportional to the number of total attributes in the table, which is usually not large and has an upper limit (1600). For each existing attribute number, all we need is just a pointer dereference and numeric comparison.
2. During the course of scanning a varblock, we only need to do the above work once since the number of attributes stored shouldn't change in varblock.

Added two sets of tests in regress/isolation2 for single-client/concurrency testing, respectively.

Fix #14929

-------------

TODOs:
- [x] Currently, during TRUNCATE we will remove the entries in `pg_attribute_encoding` for an ao_row table. This is mainly because those last row numbers would become stale when [we cleared `gp_fastsequence` during safe TRUNCATE](https://github.com/greenplum-db/gpdb/commit/9258ac5d0864d47b1c267818f118032643432cf5). However, since we might support AOCO tables with the same method, and we couldn't drop those entries for an AOCO table in TRUNCATE, it might be better to clear out  `pg_attribute_encoding.lastrownum` instead of removing the entries entirely.
- [x] Currently `pg_attribute_encoding.lastrownum` always carries the result for every possible AO segment (there are 128). But perhaps in many cases majority of the segments are not used, so we could maybe reduce the size of the entry by storing only the non-zero numbers.
- [x] Replace -1 with `InvalidAORowNum` at memset in `aocs_fetch_init` and `appendonly_fetch_init`.

Dev pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/addcol-ao

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
