### PR TITLE
Fix 7X explain pipeline diff failure

### DIFF
--- a/concourse/tasks/diff_explain_results_with_baseline.yml
+++ b/concourse/tasks/diff_explain_results_with_baseline.yml
@@ -2,7 +2,7 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: gcr.io/data-gpdb-public-images/gpdb7-centos7-test
+    repository: gcr.io/data-gpdb-public-images/gpdb7-rocky8-test
 inputs:
   - name: gpdb_src
   - name: explain_output


### PR DESCRIPTION
Change image configuration: centos7 -> rocky8
centos7 has been deleted for 7x

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
