### PR TITLE
Support  Virtual Envs fro PL/Python3 UDFs

### DIFF
--- a/src/pl/plpython/Makefile
+++ b/src/pl/plpython/Makefile
@@ -118,6 +118,7 @@ REGRESS = \
 	plpython_subtransaction \
 	plpython_transaction \
 	plpython_gpdb \
+	plpython3_virtual_env \
 	plpython_drop
 
 REGRESS_PLPYTHON3_MANGLE := $(REGRESS)

--- a/src/pl/plpython/init_file
+++ b/src/pl/plpython/init_file
@@ -24,4 +24,5 @@ s/ \(plpython\.c:\d+\)//
 # of messages.
 -- start_matchignore
 m/^(?:HINT|NOTICE):\s+.+\'DISTRIBUTED BY\' clause.*/
+m/^(?:NOTICE):\s+.+PYTHON VIRTUAL ENV sys.*/
 -- end_matchignore

--- a/src/pl/plpython/plpython3u--1.0.sql
+++ b/src/pl/plpython/plpython3u--1.0.sql
@@ -9,3 +9,10 @@
 CREATE LANGUAGE plpython3u;
 
 COMMENT ON LANGUAGE plpython3u IS 'PL/Python3U untrusted procedural language';
+
+CREATE SCHEMA plpython3;
+
+CREATE OR REPLACE FUNCTION plpython3.create_virtual_env(
+    creator text
+) RETURNS text AS 'MODULE_PATHNAME', 'create_virtual_env'
+LANGUAGE c;


### PR DESCRIPTION
Virtual environments can help us improve the reproducibility of a project, 
collaborate more easily with others, and make deployment smoother.
This patch supports creating a virtual environment directly using UDF 
within GPDB, and set the Python interpreter for PLPYTHON3 to a venv.
Furthermore, with a network connection, users can directly install
Python packages directly to the venv using UDFs.