### PR TITLE
Fix gload progress output

### DIFF
--- a/gpMgmt/bin/gpload.py
+++ b/gpMgmt/bin/gpload.py
@@ -777,7 +777,7 @@ def bytestr(size, precision=1):
         if size >= factor:
             break
 
-    float_string_split = "size/float(factor)".split('.')
+    float_string_split = repr(size/float(factor)).split('.')
     integer_part = float_string_split[0]
     decimal_part = float_string_split[1]
     if int(decimal_part[0:precision]):


### PR DESCRIPTION
The gpload utility parses byte counters from gpfdist's status endpoint and formats them with human-friendly units (e.g., 1024 bytes becomes 1 kB). When converting the source from Python 2 to Python 3 syntax, backticks (`<expression>`) were replaced with double-quotes instead of `repr(<expression>)`, breaking the `bytestr` helper method.

Here is a small reproduction; starting with GP6 to demonstrate the expected behavior:

    cd ~/workspace/gpdb
    git switch 6X_STABLE
    cd gpMgmt/bin
    python2 - <<EOF
    from gpload import bytestr
    print([bytestr(2 ** (i + 5)) for i in range(0, 60, 10)])
    EOF

This prints

    ['32 bytes', '32 kB', '32 MB', '32 GB', '32 TB', '32 PB']

Switching to GP7 and running the snippet:

    python3 - <<EOF
    from gpload import bytestr
    print([bytestr(2 ** (i + 5)) for i in range(0, 60, 10)])
    EOF

results in an error:

    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
      File "<stdin>", line 1, in <listcomp>
      File "~/workspace/gpdb/gpMgmt/bin/gpload.py", line 782, in bytestr
        decimal_part = float_string_split[1]
                       ~~~~~~~~~~~~~~~~~~^^^
    IndexError: list index out of range

Authored-by: Bradford D. Boyle <bradfordb@vmware.com>
