### PR TITLE
Add test case for over-eager constraint exclusion (7X)

### DIFF
--- a/src/test/regress/expected/constraints_check.out
+++ b/src/test/regress/expected/constraints_check.out
@@ -1,0 +1,22 @@
+-- loose over-eager constraint exclusion
+-- please refer to https://github.com/greenplum-db/gpdb/issues/10287
+CREATE TABLE t_issue_10287(a INT CHECK(a = 1));
+INSERT INTO t_issue_10287 VALUES (NULL);
+SELECT * FROM t_issue_10287 WHERE a IS NULL;
+ a 
+---
+  
+(1 row)
+
+DROP TABLE t_issue_10287;
+CREATE FUNCTION sum2_issue_10287(int8, int8) RETURNS int8 AS 'select $1 + $2' LANGUAGE SQL;
+CREATE TABLE t_issue_10287_func(a INT, b INT, c INT CHECK(sum2_issue_10287(a, b)=3));
+INSERT INTO t_issue_10287_func VALUES (1,2,3), (NULL,NULL,3);
+SELECT * FROM t_issue_10287_func WHERE a IS NULL;
+ a | b | c 
+---+---+---
+   |   | 3
+(1 row)
+
+DROP TABLE t_issue_10287_func;
+DROP FUNCTION sum2_issue_10287;

--- a/src/test/regress/parallel_schedule
+++ b/src/test/regress/parallel_schedule
@@ -162,7 +162,7 @@ test: event_trigger
 # this test also uses event triggers, so likewise run it by itself
 test: fast_default
 
-# loose over-eager constraint exclusion
+# loose over-eager constraint exclusion, please refer to issue 10287
 test: constraints_check
 
 # run stats by itself because its delay may be insufficient under heavy load

--- a/src/test/regress/parallel_schedule
+++ b/src/test/regress/parallel_schedule
@@ -162,6 +162,9 @@ test: event_trigger
 # this test also uses event triggers, so likewise run it by itself
 test: fast_default
 
+# loose over-eager constraint exclusion
+test: constraints_check
+
 # run stats by itself because its delay may be insufficient under heavy load
 #
 # 'stats' test has been disabled in GPDB, because it tries to set stats-related

--- a/src/test/regress/parallel_schedule
+++ b/src/test/regress/parallel_schedule
@@ -162,7 +162,7 @@ test: event_trigger
 # this test also uses event triggers, so likewise run it by itself
 test: fast_default
 
-# loose over-eager constraint exclusion, please refer to issue 10287
+# loose over-eager constraint exclusion check, please refer to issue 10287
 test: constraints_check
 
 # run stats by itself because its delay may be insufficient under heavy load

--- a/src/test/regress/sql/constraints_check.sql
+++ b/src/test/regress/sql/constraints_check.sql
@@ -1,0 +1,13 @@
+-- loose over-eager constraint exclusion
+-- please refer to https://github.com/greenplum-db/gpdb/issues/10287
+CREATE TABLE t_issue_10287(a INT CHECK(a = 1));
+INSERT INTO t_issue_10287 VALUES (NULL);
+SELECT * FROM t_issue_10287 WHERE a IS NULL;
+DROP TABLE t_issue_10287;
+
+CREATE FUNCTION sum2_issue_10287(int8, int8) RETURNS int8 AS 'select $1 + $2' LANGUAGE SQL;
+CREATE TABLE t_issue_10287_func(a INT, b INT, c INT CHECK(sum2_issue_10287(a, b)=3));
+INSERT INTO t_issue_10287_func VALUES (1,2,3), (NULL,NULL,3);
+SELECT * FROM t_issue_10287_func WHERE a IS NULL;
+DROP TABLE t_issue_10287_func;
+DROP FUNCTION sum2_issue_10287;


### PR DESCRIPTION
As the title said, add test case for over-eager constraint exclusion. Please refer to [issue 10287 comment](https://github.com/greenplum-db/gpdb/issues/10287#issuecomment-1333659985)

**Signed-off-by**: Yongtao Huang <yongtaoh@vmware.com>