### PR TITLE
Add system PATH to  findCmdInPath

### DIFF
--- a/gpMgmt/bin/gppylib/commands/unix.py
+++ b/gpMgmt/bin/gppylib/commands/unix.py
@@ -36,6 +36,8 @@ GPHOME = os.environ.get('GPHOME', None)
 CMDPATH = ['/usr/kerberos/bin', '/usr/sfw/bin', '/opt/sfw/bin', '/bin', '/usr/local/bin',
            '/usr/bin', '/sbin', '/usr/sbin', '/usr/ucb', '/sw/bin', '/opt/Navisphere/bin']
 CMDPATH = CMDPATH + os.environ['PATH'].split(os.pathsep)
+# remove duplicate paths
+CMDPATH = list(set(CMDPATH))
 
 if GPHOME:
     CMDPATH.append(GPHOME)

--- a/gpMgmt/bin/gppylib/commands/unix.py
+++ b/gpMgmt/bin/gppylib/commands/unix.py
@@ -35,6 +35,7 @@ GPHOME = os.environ.get('GPHOME', None)
 # ---------------command path--------------------
 CMDPATH = ['/usr/kerberos/bin', '/usr/sfw/bin', '/opt/sfw/bin', '/bin', '/usr/local/bin',
            '/usr/bin', '/sbin', '/usr/sbin', '/usr/ucb', '/sw/bin', '/opt/Navisphere/bin']
+CMDPATH = CMDPATH + os.environ['PATH'].split(os.pathsep)
 
 if GPHOME:
     CMDPATH.append(GPHOME)


### PR DESCRIPTION
Current `findCmdInPath` only search cmd in specific `CMDPATH`, if user has some commands in other locations(but add those locations to `PATH`) and not in the `CMDPATH`, gpdb will cannot find it.

For example, the paths in `CMDPATH` are not existed in `NixOS`, the `PATH` in `NixOS` is like this:
```
/nix/store/vr631vl97c7gfsy1zdwpj60zzxnnz8v6-openssh-9.2p1/bin:/nix/store/zbr5i1jzfaj29v62g9r9xlibhv8295r6-patchelf-0.15
.0/bin:/nix/store/0h7yqpk1gd6argxfv59x1vz0zklhjcnv-gcc-wrapper-12.2.0/bin
```

To solve this problem, the system `PATH` should be added into `CMDPATH`.