### PR TITLE
Fix missing/orphaned file checking views

### DIFF
--- a/src/include/catalog/catversion.h
+++ b/src/include/catalog/catversion.h
@@ -56,6 +56,6 @@
  */
 
 /*							3yyymmddN */
-#define CATALOG_VERSION_NO	302305041
+#define CATALOG_VERSION_NO	302305051
 
 #endif

--- a/src/test/regress/expected/.gitignore
+++ b/src/test/regress/expected/.gitignore
@@ -28,6 +28,7 @@
 /external_table.out
 /filespace.out
 /gpcopy.out
+/gp_check_files.out
 /gp_dispatch_keepalives.out
 /gp_tablespace.out
 /gp_tablespace_path_too_long.out

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -52,7 +52,6 @@ test: gp_aggregates gp_aggregates_costs gp_metadata variadic_parameters default_
 test: spi_processed64bit
 test: gp_lock
 test: gp_tablespace_with_faults
-test: gp_check_files
 # below test(s) inject faults so each of them need to be in a separate group
 test: gp_tablespace
 
@@ -346,5 +345,8 @@ test: enum_dist_part_ban
 
 # test compresstype fallback from quicklz when gp_quicklz_fallback=true
 test: quicklz_fallback
+
+# run this at the end of the schedule for more chance to catch abnormalities
+test: gp_check_files
 
 # end of tests

--- a/src/test/regress/input/gp_check_files.source
+++ b/src/test/regress/input/gp_check_files.source
@@ -9,6 +9,9 @@
 -- s/aovisimap_\d+/aovisimap_xxx/g
 -- end_matchsubs
 
+-- start from a clean state
+checkpoint;
+
 -- we'll use a specific tablespace to test
 CREATE TABLESPACE checkfile_ts LOCATION '@testtablespace@';
 set default_tablespace = checkfile_ts;

--- a/src/test/regress/input/gp_check_files.source
+++ b/src/test/regress/input/gp_check_files.source
@@ -59,14 +59,13 @@ insert into checknormal_heap select i,i,i from generate_series(1,100)i;
 insert into checknormal_ao select i,i,i from generate_series(1,100)i;
 insert into checknormal_co select i,i,i from generate_series(1,100)i;
 
--- check non-extended files
-select gp_segment_id, filename from gp_toolkit.gp_check_orphaned_files;
+-- check non-extended missing files
 select gp_segment_id, regexp_replace(filename, '\d+', 'x'), relname from gp_toolkit.gp_check_missing_files;
 
 SET client_min_messages = ERROR;
 
 -- check extended files
-select gp_segment_id, filename from gp_toolkit.gp_check_orphaned_files_ext;
+select gp_segment_id, filename from gp_toolkit.gp_check_orphaned_files;
 select gp_segment_id, regexp_replace(filename, '\d+', 'x'), relname from gp_toolkit.gp_check_missing_files_ext;
 
 RESET client_min_messages;

--- a/src/test/regress/output/gp_check_files.source
+++ b/src/test/regress/output/gp_check_files.source
@@ -7,6 +7,8 @@
 -- m/aovisimap_\d+/
 -- s/aovisimap_\d+/aovisimap_xxx/g
 -- end_matchsubs
+-- start from a clean state
+checkpoint;
 -- we'll use a specific tablespace to test
 CREATE TABLESPACE checkfile_ts LOCATION '@testtablespace@';
 set default_tablespace = checkfile_ts;

--- a/src/test/regress/output/gp_check_files.source
+++ b/src/test/regress/output/gp_check_files.source
@@ -48,13 +48,7 @@ CREATE TABLE checknormal_co(a int, b int, c int) using ao_column;
 insert into checknormal_heap select i,i,i from generate_series(1,100)i;
 insert into checknormal_ao select i,i,i from generate_series(1,100)i;
 insert into checknormal_co select i,i,i from generate_series(1,100)i;
--- check non-extended files
-select gp_segment_id, filename from gp_toolkit.gp_check_orphaned_files;
- gp_segment_id | filename 
----------------+----------
-             1 | 987654
-(1 row)
-
+-- check non-extended missing files
 select gp_segment_id, regexp_replace(filename, '\d+', 'x'), relname from gp_toolkit.gp_check_missing_files;
  gp_segment_id | regexp_replace |      relname      
 ---------------+----------------+-------------------
@@ -63,7 +57,7 @@ select gp_segment_id, regexp_replace(filename, '\d+', 'x'), relname from gp_tool
 
 SET client_min_messages = ERROR;
 -- check extended files
-select gp_segment_id, filename from gp_toolkit.gp_check_orphaned_files_ext;
+select gp_segment_id, filename from gp_toolkit.gp_check_orphaned_files;
  gp_segment_id | filename 
 ---------------+----------
              1 | 987654

--- a/src/test/regress/sql/.gitignore
+++ b/src/test/regress/sql/.gitignore
@@ -27,6 +27,7 @@
 /external_table.sql
 /filespace.sql
 /gpcopy.sql
+/gp_check_files.sql
 /gp_dispatch_keepalives.sql
 /gp_tablespace_path_too_long.sql
 /gp_tablespace.sql


### PR DESCRIPTION
The existing orphaned/missing file checking views (`gp_toolkit.gp_check_orphaned_files`, `gp_toolkit.gp_check_missing_files` etc.) have many false alarm possibilities. A few examples:
1. Views created from tables via the `CREATE RULE ... ON SELECT...` syntax still have valid relfilenodes. However, its data file might have already been removed, causing false missing file report.
2. An entry in the aoseg/aocsseg does not necessarily mean there is data file associated with them. For example, an entry could be created just for recording modcount (we chose any non-reserved segment to do that). This could cause false missing file report as well. Note that, such entries would have `eof=0`.
3. An AO/CO table being created and then truncated in the same transaction will not have its extended data file removed. This is because in that case, unsafe truncation is done and the table's relfilenode won't change. Therefore, its original extended data files won't get removed even after checkpoint, despite that the table doesn't have the corresponding entries in aoseg/aocsseg anymore, causing false orphaned file report. (see #15342)

This PR fixes the above issues, also tries to set a clearer guideline for the orphaned/missing file views:

* Missing file views should try to precisely report data missing. That means whenever a table has valid main relfilenode (i.e. w/o extension number), it should have the corresponding data file, and if otherwise, we should report it. Exception like 1 above could be avoided by backporting the latest upstream change which removed the legacy syntax (which means existing Greenplum users who use that syntax has to change to use the regular `CREATE VIEW` syntax, but it is something that's going to happen eventually anyway). For AO/CO extended files, they should be reported missing not just because it has an entry in aoseg/aocsseg, but also that it has `eof>0`, meaning there's expected data from the file.
* Orphaned file views should report based on the main relfilenode. The use cases of orphaned file views are usually when we want to make sure the files are removed when we dropped a table. Therefore, now we do not check the expected extended files for orphaned file views anymore. As long as the main relfilenode is not orphaned, we do not report any of its extended files. And if the main relfilenode is orphaned, then all of its existing extended files should be regarded as orphaned as well (there's no way the database would ever find usage of them). This would make the view much faster too because we don't need to check aoseg/aocsseg anymore. As a result, this PR also removed the `_ext` orphaned view.

P.S. here is the rest of action items for these views:
1. (current PR) Fixing false reporting issues of the views. Make sure we have enough confidence that we can release them.
2. (TODO) Figuring out where these views should eventually be, and make changes if needed (more notes in https://github.com/greenplum-db/gpdb/pull/15378#issuecomment-1527957121).
3. (TODO) Backport the views to 6X (there's an existing PR #15343 but will need to incorporate the fixes here)

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
