### PR TITLE
Turn on optimizer_force_multistage_agg by default for ORCA

### DIFF
--- a/contrib/auto_explain/expected/bfv_preload_auto_explain_optimizer.out
+++ b/contrib/auto_explain/expected/bfv_preload_auto_explain_optimizer.out
@@ -28,25 +28,26 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 SELECT count(1) from (select i from t1 limit 10) t join t2 using (i);
 LOG:  statement: SELECT count(1) from (select i from t1 limit 10) t join t2 using (i);
-LOG:  statement: SELECT count(1) from (select i from t1 limit 10) t join t2 using (i);  (entry db 127.0.1.1:7000 pid=9001)
-LOG:  duration: 2.940 ms  plan:
+LOG:  statement: SELECT count(1) from (select i from t1 limit 10) t join t2 using (i);  (entry db 127.0.0.1:7000 pid=80795)
+LOG:  duration: 11.889 ms  plan:
 Query Text: SELECT count(1) from (select i from t1 limit 10) t join t2 using (i);
-Aggregate  (cost=0.00..862.00 rows=1 width=8) (actual time=2.929..2.930 rows=1 loops=1)
-  ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=1) (actual time=2.925..2.925 rows=0 loops=1)
-        ->  Hash Join  (cost=0.00..862.00 rows=1 width=1) (never executed)
-              Hash Cond: (t1.i = t2.i)
-              ->  Redistribute Motion 1:3  (slice2)  (cost=0.00..431.00 rows=1 width=4) (never executed)
-                    Hash Key: t1.i
-                    ->  Limit  (cost=0.00..431.00 rows=1 width=4) (never executed)
-                          ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=4) (never executed)
-                                ->  Seq Scan on t1  (cost=0.00..431.00 rows=1 width=4) (never executed)
-              ->  Hash  (cost=431.00..431.00 rows=1 width=4) (never executed)
-                    Buckets: 524288  Batches: 1  Memory Usage: 4096kB
-                    ->  Seq Scan on t2  (cost=0.00..431.00 rows=1 width=4) (never executed)
+Finalize Aggregate  (cost=0.00..862.00 rows=1 width=8) (actual time=11.860..11.866 rows=1 loops=1)
+  ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=8) (actual time=11.762..11.838 rows=3 loops=1)
+        ->  Partial Aggregate  (cost=0.00..862.00 rows=1 width=8) (actual time=6.350..6.352 rows=1 loops=1)
+              ->  Hash Join  (cost=0.00..862.00 rows=1 width=1) (actual time=0.000..6.339 rows=0 loops=1)
+                    Hash Cond: (t1.i = t2.i)
+                    ->  Redistribute Motion 1:3  (slice2)  (cost=0.00..431.00 rows=1 width=4) (never executed)
+                          Hash Key: t1.i
+                          ->  Limit  (cost=0.00..431.00 rows=1 width=4) (actual time=0.000..6.691 rows=0 loops=1)
+                                ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=4) (actual time=0.000..6.682 rows=0 loops=1)
+                                      ->  Seq Scan on t1  (cost=0.00..431.00 rows=1 width=4) (actual time=0.000..2.398 rows=0 loops=1)
+                    ->  Hash  (cost=431.00..431.00 rows=1 width=4) (actual time=0.000..0.115 rows=0 loops=1)
+                          Buckets: 524288  Batches: 1  Memory Usage: 4096kB
+                          ->  Seq Scan on t2  (cost=0.00..431.00 rows=1 width=4) (actual time=0.000..0.112 rows=0 loops=1)
 Optimizer: Pivotal Optimizer (GPORCA)
-  (slice0)    Executor memory: 48K bytes.
-  (slice1)    Executor memory: 4117K bytes avg x 3 workers, 4117K bytes max (seg0).  Work_mem: 4096K bytes max.
-  (slice2)    Executor memory: 63K bytes (entry db).
+  (slice0)    Executor memory: 52K bytes.
+  (slice1)    Executor memory: 4123K bytes avg x 3 workers, 4123K bytes max (seg0).  Work_mem: 4096K bytes max.
+  (slice2)    Executor memory: 38K bytes (entry db).
   (slice3)    Executor memory: 38K bytes avg x 3 workers, 38K bytes max (seg0).
 Memory used:  128000kB
  count 

--- a/contrib/postgres_fdw/expected/gp2pg_postgres_fdw_optimizer.out
+++ b/contrib/postgres_fdw/expected/gp2pg_postgres_fdw_optimizer.out
@@ -1105,15 +1105,17 @@ CREATE OPERATOR === (
 -- built-in operators and functions can be shipped for remote execution
 EXPLAIN (VERBOSE, COSTS OFF)
   SELECT count(c3) FROM ft1 t1 WHERE t1.c1 = abs(t1.c2);
-                                QUERY PLAN                                
---------------------------------------------------------------------------
- Aggregate
+                                   QUERY PLAN
+--------------------------------------------------------------------------------
+ Finalize Aggregate
    Output: count(c3)
-   ->  Foreign Scan on public.ft1
-         Output: c3
-         Remote SQL: SELECT c3 FROM "S 1"."T 1" WHERE (("C 1" = abs(c2)))
+   ->  Partial Aggregate
+         Output: PARTIAL count(c3)
+         ->  Foreign Scan on public.ft1
+               Output: c3
+               Remote SQL: SELECT c3 FROM "S 1"."T 1" WHERE (("C 1" = abs(c2)))
  Optimizer: Pivotal Optimizer (GPORCA)
-(6 rows)
+(8 rows)
 
 SELECT count(c3) FROM ft1 t1 WHERE t1.c1 = abs(t1.c2);
  count 
@@ -1123,15 +1125,17 @@ SELECT count(c3) FROM ft1 t1 WHERE t1.c1 = abs(t1.c2);
 
 EXPLAIN (VERBOSE, COSTS OFF)
   SELECT count(c3) FROM ft1 t1 WHERE t1.c1 = t1.c2;
-                             QUERY PLAN                              
----------------------------------------------------------------------
- Aggregate
+                                QUERY PLAN
+---------------------------------------------------------------------------
+ Finalize Aggregate
    Output: count(c3)
-   ->  Foreign Scan on public.ft1
-         Output: c3
-         Remote SQL: SELECT c3 FROM "S 1"."T 1" WHERE (("C 1" = c2))
+   ->  Partial Aggregate
+         Output: PARTIAL count(c3)
+         ->  Foreign Scan on public.ft1
+               Output: c3
+               Remote SQL: SELECT c3 FROM "S 1"."T 1" WHERE (("C 1" = c2))
  Optimizer: Pivotal Optimizer (GPORCA)
-(6 rows)
+(8 rows)
 
 SELECT count(c3) FROM ft1 t1 WHERE t1.c1 = t1.c2;
  count 
@@ -1142,16 +1146,18 @@ SELECT count(c3) FROM ft1 t1 WHERE t1.c1 = t1.c2;
 -- by default, user-defined ones cannot
 EXPLAIN (VERBOSE, COSTS OFF)
   SELECT count(c3) FROM ft1 t1 WHERE t1.c1 = postgres_fdw_abs(t1.c2);
-                        QUERY PLAN                         
------------------------------------------------------------
- Aggregate
+                           QUERY PLAN
+-----------------------------------------------------------------
+ Finalize Aggregate
    Output: count(c3)
-   ->  Foreign Scan on public.ft1
-         Output: c3
-         Filter: (ft1.c1 = postgres_fdw_abs(ft1.c2))
-         Remote SQL: SELECT "C 1", c2, c3 FROM "S 1"."T 1"
+   ->  Partial Aggregate
+         Output: PARTIAL count(c3)
+         ->  Foreign Scan on public.ft1
+               Output: c3
+               Filter: (ft1.c1 = postgres_fdw_abs(ft1.c2))
+               Remote SQL: SELECT "C 1", c2, c3 FROM "S 1"."T 1"
  Optimizer: Pivotal Optimizer (GPORCA)
-(7 rows)
+(9 rows)
 
 SELECT count(c3) FROM ft1 t1 WHERE t1.c1 = postgres_fdw_abs(t1.c2);
 INFO:  GPORCA failed to produce a plan, falling back to planner
@@ -1163,16 +1169,18 @@ DETAIL:  GPDB Expression type: Query Parameter not supported in DXL
 
 EXPLAIN (VERBOSE, COSTS OFF)
   SELECT count(c3) FROM ft1 t1 WHERE t1.c1 === t1.c2;
-                        QUERY PLAN                         
------------------------------------------------------------
- Aggregate
+                           QUERY PLAN
+-----------------------------------------------------------------
+ Finalize Aggregate
    Output: count(c3)
-   ->  Foreign Scan on public.ft1
-         Output: c3
-         Filter: (ft1.c1 === ft1.c2)
-         Remote SQL: SELECT "C 1", c2, c3 FROM "S 1"."T 1"
+   ->  Partial Aggregate
+         Output: PARTIAL count(c3)
+         ->  Foreign Scan on public.ft1
+               Output: c3
+               Filter: (ft1.c1 === ft1.c2)
+               Remote SQL: SELECT "C 1", c2, c3 FROM "S 1"."T 1"
  Optimizer: Pivotal Optimizer (GPORCA)
-(7 rows)
+(9 rows)
 
 SELECT count(c3) FROM ft1 t1 WHERE t1.c1 === t1.c2;
  count 
@@ -1210,15 +1218,17 @@ ALTER SERVER pgserver OPTIONS (ADD extensions 'postgres_fdw');
 -- ... now they can be shipped
 EXPLAIN (VERBOSE, COSTS OFF)
   SELECT count(c3) FROM ft1 t1 WHERE t1.c1 = postgres_fdw_abs(t1.c2);
-                                          QUERY PLAN                                          
-----------------------------------------------------------------------------------------------
- Aggregate
+                                             QUERY PLAN
+----------------------------------------------------------------------------------------------------
+ Finalize Aggregate
    Output: count(c3)
-   ->  Foreign Scan on public.ft1
-         Output: c3
-         Remote SQL: SELECT c3 FROM "S 1"."T 1" WHERE (("C 1" = public.postgres_fdw_abs(c2)))
+   ->  Partial Aggregate
+         Output: PARTIAL count(c3)
+         ->  Foreign Scan on public.ft1
+               Output: c3
+               Remote SQL: SELECT c3 FROM "S 1"."T 1" WHERE (("C 1" = public.postgres_fdw_abs(c2)))
  Optimizer: Pivotal Optimizer (GPORCA)
-(6 rows)
+(8 rows)
 
 SELECT count(c3) FROM ft1 t1 WHERE t1.c1 = postgres_fdw_abs(t1.c2);
  count 
@@ -1228,15 +1238,17 @@ SELECT count(c3) FROM ft1 t1 WHERE t1.c1 = postgres_fdw_abs(t1.c2);
 
 EXPLAIN (VERBOSE, COSTS OFF)
   SELECT count(c3) FROM ft1 t1 WHERE t1.c1 === t1.c2;
-                                       QUERY PLAN                                       
-----------------------------------------------------------------------------------------
- Aggregate
+                                          QUERY PLAN
+----------------------------------------------------------------------------------------------
+ Finalize Aggregate
    Output: count(c3)
-   ->  Foreign Scan on public.ft1
-         Output: c3
-         Remote SQL: SELECT c3 FROM "S 1"."T 1" WHERE (("C 1" OPERATOR(public.===) c2))
+   ->  Partial Aggregate
+         Output: PARTIAL count(c3)
+         ->  Foreign Scan on public.ft1
+               Output: c3
+               Remote SQL: SELECT c3 FROM "S 1"."T 1" WHERE (("C 1" OPERATOR(public.===) c2))
  Optimizer: Pivotal Optimizer (GPORCA)
-(6 rows)
+(8 rows)
 
 SELECT count(c3) FROM ft1 t1 WHERE t1.c1 === t1.c2;
  count 
@@ -2846,41 +2858,47 @@ SELECT t1c1, avg(t1c1 + t2c1) FROM (SELECT t1.c1, t2.c1 FROM ft1 t1 JOIN ft2 t2 
 ---------------------------------------------------------------------------------------
  Limit
    Output: ft1.c1, (avg((ft1.c1 + ft2.c1)))
-   ->  GroupAggregate
+   ->  Finalize GroupAggregate
          Output: ft1.c1, avg((ft1.c1 + ft2.c1))
          Group Key: ft1.c1
-         ->  GroupAggregate
-               Output: ft1.c1, ft2.c1
-               Group Key: ft1.c1, ft2.c1
-               ->  Sort
+         ->  Partial GroupAggregate
+               Output: PARTIAL avg((ft1.c1 + ft2.c1)), ft1.c1
+               Group Key: ft1.c1
+               ->  GroupAggregate
                      Output: ft1.c1, ft2.c1
-                     Sort Key: ft1.c1, ft2.c1
-                     ->  Append
-                           ->  Hash Join
+                     Group Key: ft1.c1, ft2.c1
+                     ->  GroupAggregate
+                           Output: ft1.c1, ft2.c1
+                           Group Key: ft1.c1, ft2.c1
+                           ->  Sort
                                  Output: ft1.c1, ft2.c1
-                                 Hash Cond: (ft1.c1 = ft2.c1)
-                                 ->  Foreign Scan on public.ft1
-                                       Output: ft1.c1
-                                       Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
-                                 ->  Hash
-                                       Output: ft2.c1
-                                       ->  Foreign Scan on public.ft2
-                                             Output: ft2.c1
-                                             Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
-                           ->  Hash Join
-                                 Output: ft1_1.c1, ft2_1.c1
-                                 Hash Cond: (ft1_1.c1 = ft2_1.c1)
-                                 ->  Foreign Scan on public.ft1 ft1_1
-                                       Output: ft1_1.c1
-                                       Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
-                                 ->  Hash
-                                       Output: ft2_1.c1
-                                       ->  Foreign Scan on public.ft2 ft2_1
-                                             Output: ft2_1.c1
-                                             Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
+                                 Sort Key: ft1.c1, ft2.c1
+                                 ->  Append
+                                       ->  Hash Join
+                                             Output: ft1.c1, ft2.c1
+                                             Hash Cond: (ft1.c1 = ft2.c1)
+                                             ->  Foreign Scan on public.ft1
+                                                   Output: ft1.c1
+                                                   Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
+                                             ->  Hash
+                                                   Output: ft2.c1
+                                                   ->  Foreign Scan on public.ft2
+                                                         Output: ft2.c1
+                                                         Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
+                                       ->  Hash Join
+                                             Output: ft1_1.c1, ft2_1.c1
+                                             Hash Cond: (ft1_1.c1 = ft2_1.c1)
+                                             ->  Foreign Scan on public.ft1 ft1_1
+                                                   Output: ft1_1.c1
+                                                   Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
+                                             ->  Hash
+                                                   Output: ft2_1.c1
+                                                   ->  Foreign Scan on public.ft2 ft2_1
+                                                         Output: ft2_1.c1
+                                                         Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
  Optimizer: Pivotal Optimizer (GPORCA)
  Settings: enable_mergejoin = 'on'
-(36 rows)
+(42 rows)
 
 SELECT t1c1, avg(t1c1 + t2c1) FROM (SELECT t1.c1, t2.c1 FROM ft1 t1 JOIN ft2 t2 ON (t1.c1 = t2.c1) UNION SELECT t1.c1, t2.c1 FROM ft1 t1 JOIN ft2 t2 ON (t1.c1 = t2.c1)) AS t (t1c1, t2c1) GROUP BY t1c1 ORDER BY t1c1 OFFSET 100 LIMIT 10;
  t1c1 |         avg          
@@ -3328,14 +3346,17 @@ select count(c6), sum(c1), avg(c1), min(c2), max(c1), stddev(c2), sum(c1) * (ran
    ->  Sort
          Output: (count(c6)), (sum(c1)), (avg(c1)), (min(c2)), (max(c1)), (stddev(c2)), (sum(c1)), c2
          Sort Key: (count(ft1.c6)), (sum(ft1.c1))
-         ->  HashAggregate
+         ->  Finalize HashAggregate
                Output: count(c6), sum(c1), avg(c1), min(c2), max(c1), stddev(c2), sum(c1), c2
                Group Key: ft1.c2
-               ->  Foreign Scan on public.ft1
-                     Output: c1, c2, c6
-                     Remote SQL: SELECT "C 1", c2, c6 FROM "S 1"."T 1" WHERE ((c2 < 5))
+               ->  Streaming Partial HashAggregate
+                     Output: PARTIAL count(c6), PARTIAL sum(c1), PARTIAL avg(c1), PARTIAL min(c2), PARTIAL max(c1), PARTIAL stddev(c2), PARTIAL sum(c1), c2
+                     Group Key: ft1.c2
+                     ->  Foreign Scan on public.ft1
+                           Output: c1, c2, c6
+                           Remote SQL: SELECT "C 1", c2, c6 FROM "S 1"."T 1" WHERE ((c2 < 5))
  Optimizer: Pivotal Optimizer (GPORCA)
-(12 rows)
+(15 rows)
 
 select count(c6), sum(c1), avg(c1), min(c2), max(c1), stddev(c2), sum(c1) * (random() <= 1)::int as sum2 from ft1 where c2 < 5 group by c2 order by 1, 2;
  count |  sum  |         avg          | min | max  | stddev | sum2  
@@ -3358,14 +3379,17 @@ select count(c6), sum(c1), avg(c1), min(c2), max(c1), stddev(c2), sum(c1) * (ran
          ->  Sort
                Output: (count(c6)), (sum(c1)), (avg(c1)), (min(c2)), (max(c1)), (stddev(c2)), (sum(c1)), c2
                Sort Key: (count(ft1.c6)), (sum(ft1.c1))
-               ->  HashAggregate
+               ->  Finalize HashAggregate
                      Output: count(c6), sum(c1), avg(c1), min(c2), max(c1), stddev(c2), sum(c1), c2
                      Group Key: ft1.c2
-                     ->  Foreign Scan on public.ft1
-                           Output: c1, c2, c6
-                           Remote SQL: SELECT "C 1", c2, c6 FROM "S 1"."T 1" WHERE ((c2 < 5))
+                     ->  Streaming Partial HashAggregate
+                           Output: PARTIAL count(c6), PARTIAL sum(c1), PARTIAL avg(c1), PARTIAL min(c2), PARTIAL max(c1), PARTIAL stddev(c2), PARTIAL sum(c1), c2
+                           Group Key: ft1.c2
+                           ->  Foreign Scan on public.ft1
+                                 Output: c1, c2, c6
+                                 Remote SQL: SELECT "C 1", c2, c6 FROM "S 1"."T 1" WHERE ((c2 < 5))
  Optimizer: Pivotal Optimizer (GPORCA)
-(14 rows)
+(17 rows)
 
 select count(c6), sum(c1), avg(c1), min(c2), max(c1), stddev(c2), sum(c1) * (random() <= 1)::int as sum2 from ft1 where c2 < 5 group by c2 order by 1, 2 limit 1;
  count |  sum  |         avg          | min | max | stddev | sum2  
@@ -3376,36 +3400,40 @@ select count(c6), sum(c1), avg(c1), min(c2), max(c1), stddev(c2), sum(c1) * (ran
 -- Aggregate is not pushed down as aggregation contains random()
 explain (verbose, costs off)
 select sum(c1 * (random() <= 1)::int) as sum, avg(c1) from ft1;
-                                QUERY PLAN                                
---------------------------------------------------------------------------
- Aggregate
+                                           QUERY PLAN
+------------------------------------------------------------------------------------------------
+ Finalize Aggregate
    Output: sum((c1 * int4((random() <= '1'::double precision)))), avg(c1)
-   ->  Foreign Scan on public.ft1
-         Output: c1
-         Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
+   ->  Partial Aggregate
+         Output: PARTIAL sum((c1 * int4((random() <= '1'::double precision)))), PARTIAL avg(c1)
+         ->  Foreign Scan on public.ft1
+               Output: c1
+               Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
  Optimizer: Pivotal Optimizer (GPORCA)
-(6 rows)
+(8 rows)
 
 -- Aggregate over join query
 explain (verbose, costs off)
 select count(*), sum(t1.c1), avg(t2.c1) from ft1 t1 inner join ft1 t2 on (t1.c2 = t2.c2) where t1.c2 = 6;
-                                     QUERY PLAN                                     
-------------------------------------------------------------------------------------
- Aggregate
+                                        QUERY PLAN
+------------------------------------------------------------------------------------------
+ Finalize Aggregate
    Output: count(), sum(ft1.c1), avg(ft1_1.c1)
-   ->  Hash Join
-         Output: ft1.c1, ft1_1.c1
-         Hash Cond: (ft1.c2 = ft1_1.c2)
-         ->  Foreign Scan on public.ft1
-               Output: ft1.c1, ft1.c2
-               Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1" WHERE ((c2 = 6))
-         ->  Hash
-               Output: ft1_1.c1, ft1_1.c2
-               ->  Foreign Scan on public.ft1 ft1_1
-                     Output: ft1_1.c1, ft1_1.c2
+   ->  Partial Aggregate
+         Output: PARTIAL count(), PARTIAL sum(ft1.c1), PARTIAL avg(ft1_1.c1)
+         ->  Hash Join
+               Output: ft1.c1, ft1_1.c1
+               Hash Cond: (ft1.c2 = ft1_1.c2)
+               ->  Foreign Scan on public.ft1
+                     Output: ft1.c1, ft1.c2
                      Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1" WHERE ((c2 = 6))
+               ->  Hash
+                     Output: ft1_1.c1, ft1_1.c2
+                     ->  Foreign Scan on public.ft1 ft1_1
+                           Output: ft1_1.c1, ft1_1.c2
+                           Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1" WHERE ((c2 = 6))
  Optimizer: Pivotal Optimizer (GPORCA)
-(14 rows)
+(16 rows)
 
 select count(*), sum(t1.c1), avg(t2.c1) from ft1 t1 inner join ft1 t2 on (t1.c2 = t2.c2) where t1.c2 = 6;
  count |   sum   |         avg          
@@ -3416,43 +3444,46 @@ select count(*), sum(t1.c1), avg(t2.c1) from ft1 t1 inner join ft1 t2 on (t1.c2 
 -- Not pushed down due to local conditions present in underneath input rel
 explain (verbose, costs off)
 select sum(t1.c1), count(t2.c1) from ft1 t1 inner join ft2 t2 on (t1.c1 = t2.c1) where ((t1.c1 * t2.c1)/(t1.c1 * t2.c1)) * random() <= 1;
-                                                        QUERY PLAN                                                        
---------------------------------------------------------------------------------------------------------------------------
- Aggregate
+                                                           QUERY PLAN
+--------------------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate
    Output: sum(ft1.c1), count(ft2.c1)
-   ->  Hash Join
-         Output: ft1.c1, ft2.c1
-         Hash Cond: (ft1.c1 = ft2.c1)
-         Join Filter: (((((ft1.c1 * ft2.c1) / (ft1.c1 * ft2.c1)))::double precision * random()) <= '1'::double precision)
-         ->  Foreign Scan on public.ft1
-               Output: ft1.c1
-               Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
-         ->  Hash
-               Output: ft2.c1
-               ->  Foreign Scan on public.ft2
-                     Output: ft2.c1
+   ->  Partial Aggregate
+         Output: PARTIAL sum(ft1.c1), PARTIAL count(ft2.c1)
+         ->  Hash Join
+               Output: ft1.c1, ft2.c1
+               Hash Cond: (ft1.c1 = ft2.c1)
+               Join Filter: (((((ft1.c1 * ft2.c1) / (ft1.c1 * ft2.c1)))::double precision * random()) <= '1'::double precision)
+               ->  Foreign Scan on public.ft1
+                     Output: ft1.c1
                      Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
+               ->  Hash
+                     Output: ft2.c1
+                     ->  Foreign Scan on public.ft2
+                           Output: ft2.c1
+                           Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
  Optimizer: Pivotal Optimizer (GPORCA)
-(15 rows)
+(17 rows)
 
 -- GROUP BY clause having expressions
 explain (verbose, costs off)
 select c2/2, sum(c2) * (c2/2) from ft1 group by c2/2 order by c2/2;
                          QUERY PLAN                         
 ------------------------------------------------------------
- Result
-   Output: ((c2 / 2)), ((sum(c2)) * ((c2 / 2)))
+ Finalize GroupAggregate
+   Output: ((c2 / 2)), (sum(c2) * ((c2 / 2)))
+   Group Key: ((ft1.c2 / 2))
    ->  Sort
-         Output: (sum(c2)), ((c2 / 2))
+         Output: (PARTIAL sum(c2)), ((c2 / 2))
          Sort Key: ((ft1.c2 / 2))
-         ->  HashAggregate
-               Output: sum(c2), ((c2 / 2))
+         ->  Streaming Partial HashAggregate
+               Output: PARTIAL sum(c2), ((c2 / 2))
                Group Key: (ft1.c2 / 2)
                ->  Foreign Scan on public.ft1
                      Output: (c2 / 2), c2
                      Remote SQL: SELECT c2 FROM "S 1"."T 1"
  Optimizer: Pivotal Optimizer (GPORCA)
-(12 rows)
+(13 rows)
 
 select c2/2, sum(c2) * (c2/2) from ft1 group by c2/2 order by c2/2;
  ?column? | ?column? 
@@ -3467,18 +3498,23 @@ select c2/2, sum(c2) * (c2/2) from ft1 group by c2/2 order by c2/2;
 -- Aggregates in subquery are pushed down.
 explain (verbose, costs off)
 select count(x.a), sum(x.a) from (select c2 a, sum(c1) b from ft1 group by c2, sqrt(c1) order by 1, 2) x;
-                         QUERY PLAN                          
--------------------------------------------------------------
- Aggregate
+                               QUERY PLAN
+-------------------------------------------------------------------------
+ Finalize Aggregate
    Output: count(c2), sum(c2)
-   ->  HashAggregate
-         Output: c2, (sqrt((c1)::double precision))
-         Group Key: ft1.c2, sqrt((ft1.c1)::double precision)
-         ->  Foreign Scan on public.ft1
-               Output: sqrt((c1)::double precision), c2
-               Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1"
+   ->  Partial Aggregate
+         Output: PARTIAL count(c2), PARTIAL sum(c2)
+         ->  HashAggregate
+               Output: c2, (sqrt((c1)::double precision))
+               Group Key: ft1.c2, (sqrt((ft1.c1)::double precision))
+               ->  Streaming HashAggregate
+                     Output: c2, (sqrt((c1)::double precision))
+                     Group Key: ft1.c2, sqrt((ft1.c1)::double precision)
+                     ->  Foreign Scan on public.ft1
+                           Output: sqrt((c1)::double precision), c2
+                           Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1"
  Optimizer: Pivotal Optimizer (GPORCA)
-(9 rows)
+(14 rows)
 
 select count(x.a), sum(x.a) from (select c2 a, sum(c1) b from ft1 group by c2, sqrt(c1) order by 1, 2) x;
  count | sum  
@@ -3494,14 +3530,17 @@ select c2 * (random() <= 1)::int as sum1, sum(c1) * c2 as sum2 from ft1 group by
  Sort
    Output: ((c2 * int4((random() <= '1'::double precision)))), ((sum(c1) * c2))
    Sort Key: ((ft1.c2 * int4((random() <= '1'::double precision)))), ((sum(ft1.c1) * ft1.c2))
-   ->  HashAggregate
+   ->  Finalize HashAggregate
          Output: (c2 * int4((random() <= '1'::double precision))), (sum(c1) * c2)
          Group Key: ft1.c2
-         ->  Foreign Scan on public.ft1
-               Output: c1, c2
-               Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1"
+         ->  Streaming Partial HashAggregate
+               Output: PARTIAL sum(c1), c2
+               Group Key: ft1.c2
+               ->  Foreign Scan on public.ft1
+                     Output: c1, c2
+                     Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1"
  Optimizer: Pivotal Optimizer (GPORCA)
-(10 rows)
+(13 rows)
 
 select c2 * (random() <= 1)::int as sum1, sum(c1) * c2 as sum2 from ft1 group by c2 order by 1, 2;
  sum1 |  sum2  
@@ -3523,9 +3562,9 @@ explain (verbose, costs off)
 select c2 * (random() <= 1)::int as c2 from ft2 group by c2 * (random() <= 1)::int order by 1;
                                    QUERY PLAN                                   
 --------------------------------------------------------------------------------
- Sort
+ GroupAggregate
    Output: ((c2 * int4((random() <= '1'::double precision))))
-   Sort Key: ((ft2.c2 * int4((random() <= '1'::double precision))))
+   Group Key: ((ft2.c2 * int4((random() <= '1'::double precision))))
    ->  GroupAggregate
          Output: ((c2 * int4((random() <= '1'::double precision))))
          Group Key: ((ft2.c2 * int4((random() <= '1'::double precision))))
@@ -3543,19 +3582,20 @@ explain (verbose, costs off)
 select count(c2) w, c2 x, 5 y, 7.0 z from ft1 group by 2, y, 9.0::int order by 2;
                          QUERY PLAN                         
 ------------------------------------------------------------
- Result
-   Output: (count(c2)), c2, (5), 7.0
+ Finalize GroupAggregate
+   Output: count(c2), c2, (5), 7.0
+   Group Key: ft1.c2, (5), (9)
    ->  Sort
-         Output: (count(c2)), c2, (5), (9)
-         Sort Key: ft1.c2
-         ->  HashAggregate
-               Output: count(c2), c2, (5), (9)
+         Output: (PARTIAL count(c2)), c2, (5), (9)
+         Sort Key: ft1.c2, (5), (9)
+         ->  Streaming Partial HashAggregate
+               Output: PARTIAL count(c2), c2, (5), (9)
                Group Key: ft1.c2, 5, 9
                ->  Foreign Scan on public.ft1
                      Output: 5, 9, c2
                      Remote SQL: SELECT c2 FROM "S 1"."T 1"
  Optimizer: Pivotal Optimizer (GPORCA)
-(12 rows)
+(13 rows)
 
 select count(c2) w, c2 x, 5 y, 7.0 z from ft1 group by 2, y, 9.0::int order by 2;
   w  | x | y |  z  
@@ -3583,14 +3623,20 @@ select c2, c2 from ft1 where c2 > 6 group by 1, 2 order by sum(c1);
    ->  Sort
          Output: c2, c2, (sum(c1))
          Sort Key: (sum(ft1.c1))
-         ->  HashAggregate
+         ->  Finalize GroupAggregate
                Output: c2, c2, sum(c1)
                Group Key: ft1.c2, ft1.c2
-               ->  Foreign Scan on public.ft1
-                     Output: c1, c2
-                     Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1" WHERE ((c2 > 6))
+               ->  Sort
+                     Output: (PARTIAL sum(c1)), c2
+                     Sort Key: ft1.c2, ft1.c2
+                     ->  Streaming Partial HashAggregate
+                           Output: PARTIAL sum(c1), c2
+                           Group Key: ft1.c2, ft1.c2
+                           ->  Foreign Scan on public.ft1
+                                 Output: c1, c2
+                                 Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1" WHERE ((c2 > 6))
  Optimizer: Pivotal Optimizer (GPORCA)
-(12 rows)
+(18 rows)
 
 select c2, c2 from ft1 where c2 > 6 group by 1, 2 order by sum(c1);
  c2 | c2 
@@ -3611,17 +3657,20 @@ select c2, sum(c1) from ft2 group by c2 having avg(c1) < 500 and sum(c1) < 49800
    ->  Result
          Output: c2, (sum(c1))
          Filter: (((avg(ft2.c1)) < '500'::numeric) AND ((sum(ft2.c1)) < 49800))
-         ->  GroupAggregate
+         ->  Finalize GroupAggregate
                Output: sum(c1), avg(c1), sum(c1), c2
                Group Key: ft2.c2
-               ->  Sort
-                     Output: c1, c2
-                     Sort Key: ft2.c2
-                     ->  Foreign Scan on public.ft2
+               ->  Partial GroupAggregate
+                     Output: PARTIAL sum(c1), PARTIAL avg(c1), PARTIAL sum(c1), c2
+                     Group Key: ft2.c2
+                     ->  Sort
                            Output: c1, c2
-                           Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1"
+                           Sort Key: ft2.c2
+                           ->  Foreign Scan on public.ft2
+                                 Output: c1, c2
+                                 Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1"
  Optimizer: Pivotal Optimizer (GPORCA)
-(16 rows)
+(19 rows)
 
 select c2, sum(c1) from ft2 group by c2 having avg(c1) < 500 and sum(c1) < 49800 order by c2;
  c2 |  sum  
@@ -3633,23 +3682,28 @@ select c2, sum(c1) from ft2 group by c2 having avg(c1) < 500 and sum(c1) < 49800
 -- Unshippable HAVING clause will be evaluated locally, and other qual in HAVING clause is pushed down
 explain (verbose, costs off)
 select count(*) from (select c5, count(c1) from ft1 group by c5, sqrt(c2) having (avg(c1) / avg(c1)) * random() <= 1 and avg(c1) < 500) x;
-                                                 QUERY PLAN                                                  
--------------------------------------------------------------------------------------------------------------
- Aggregate
+                                                          QUERY PLAN
+-------------------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate
    Output: count()
-   ->  Result
-         Filter: (((((avg(ft1.c1)) / (avg(ft1.c1))))::double precision * random()) <= '1'::double precision)
+   ->  Partial Aggregate
+         Output: PARTIAL count()
          ->  Result
-               Output: (avg(c1)), (avg(c1))
-               Filter: ((avg(ft1.c1)) < '500'::numeric)
-               ->  HashAggregate
-                     Output: avg(c1), avg(c1), avg(c1), c5, (sqrt((c2)::double precision))
-                     Group Key: ft1.c5, sqrt((ft1.c2)::double precision)
-                     ->  Foreign Scan on public.ft1
-                           Output: sqrt((c2)::double precision), c1, c5
-                           Remote SQL: SELECT "C 1", c2, c5 FROM "S 1"."T 1"
+               Filter: (((((avg(ft1.c1)) / (avg(ft1.c1))))::double precision * random()) <= '1'::double precision)
+               ->  Result
+                     Output: (avg(c1)), (avg(c1))
+                     Filter: ((avg(ft1.c1)) < '500'::numeric)
+                     ->  Finalize HashAggregate
+                           Output: avg(c1), avg(c1), avg(c1), c5, (sqrt((c2)::double precision))
+                           Group Key: ft1.c5, (sqrt((ft1.c2)::double precision))
+                           ->  Streaming Partial HashAggregate
+                                 Output: PARTIAL avg(c1), PARTIAL avg(c1), PARTIAL avg(c1), c5, (sqrt((c2)::double precision))
+                                 Group Key: ft1.c5, sqrt((ft1.c2)::double precision)
+                                 ->  Foreign Scan on public.ft1
+                                       Output: sqrt((c2)::double precision), c1, c5
+                                       Remote SQL: SELECT "C 1", c2, c5 FROM "S 1"."T 1"
  Optimizer: Pivotal Optimizer (GPORCA)
-(14 rows)
+(19 rows)
 
 select count(*) from (select c5, count(c1) from ft1 group by c5, sqrt(c2) having (avg(c1) / avg(c1)) * random() <= 1 and avg(c1) < 500) x;
  count 
@@ -3668,14 +3722,17 @@ select sum(c1) from ft1 group by c2 having avg(c1 * (random() <= 1)::int) > 100 
    ->  Result
          Output: (sum(c1))
          Filter: ((avg((ft1.c1 * int4((random() <= '1'::double precision))))) > '100'::numeric)
-         ->  HashAggregate
+         ->  Finalize HashAggregate
                Output: sum(c1), avg((c1 * int4((random() <= '1'::double precision)))), c2
                Group Key: ft1.c2
-               ->  Foreign Scan on public.ft1
-                     Output: c1, c2
-                     Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1"
+               ->  Streaming Partial HashAggregate
+                     Output: PARTIAL sum(c1), PARTIAL avg((c1 * int4((random() <= '1'::double precision)))), c2
+                     Group Key: ft1.c2
+                     ->  Foreign Scan on public.ft1
+                           Output: c1, c2
+                           Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1"
  Optimizer: Pivotal Optimizer (GPORCA)
-(13 rows)
+(16 rows)
 
 -- Remote aggregate in combination with a local Param (for the output
 -- of an initplan) can be trouble, per bug #15781
@@ -4355,23 +4412,25 @@ drop operator public.<^(int, int);
 -- the aggregate cannot be pushed down to foreign server.
 explain (verbose, costs off)
 select count(t1.c3) from ft2 t1 left join ft2 t2 on (t1.c1 = random() * t2.c2);
-                                         QUERY PLAN                                          
----------------------------------------------------------------------------------------------
- Aggregate
+                                            QUERY PLAN
+---------------------------------------------------------------------------------------------------
+ Finalize Aggregate
    Output: count(ft2.c3)
-   ->  Hash Left Join
-         Output: ft2.c3
-         Hash Cond: ((ft2.c1)::double precision = (random() * (ft2_1.c2)::double precision))
-         ->  Foreign Scan on public.ft2
-               Output: ft2.c1, ft2.c3
-               Remote SQL: SELECT "C 1", c3 FROM "S 1"."T 1"
-         ->  Hash
-               Output: ft2_1.c2
-               ->  Foreign Scan on public.ft2 ft2_1
+   ->  Partial Aggregate
+         Output: PARTIAL count(ft2.c3)
+         ->  Hash Left Join
+               Output: ft2.c3
+               Hash Cond: ((ft2.c1)::double precision = (random() * (ft2_1.c2)::double precision))
+               ->  Foreign Scan on public.ft2
+                     Output: ft2.c1, ft2.c3
+                     Remote SQL: SELECT "C 1", c3 FROM "S 1"."T 1"
+               ->  Hash
                      Output: ft2_1.c2
-                     Remote SQL: SELECT c2 FROM "S 1"."T 1"
+                     ->  Foreign Scan on public.ft2 ft2_1
+                           Output: ft2_1.c2
+                           Remote SQL: SELECT c2 FROM "S 1"."T 1"
  Optimizer: Pivotal Optimizer (GPORCA)
-(14 rows)
+(16 rows)
 
 -- Subquery in FROM clause having aggregate
 explain (verbose, costs off)
@@ -4381,25 +4440,31 @@ select count(*), x.b from ft1, (select c2 a, sum(c1) b from ft1 group by c2) x w
  Sort
    Output: (count()), (sum(ft1_1.c1))
    Sort Key: (count()), (sum(ft1_1.c1))
-   ->  HashAggregate
+   ->  Finalize HashAggregate
          Output: count(), (sum(ft1_1.c1))
          Group Key: (sum(ft1_1.c1))
-         ->  Hash Join
-               Output: (sum(ft1_1.c1))
-               Hash Cond: (ft1.c2 = ft1_1.c2)
-               ->  Foreign Scan on public.ft1
-                     Output: ft1.c2
-                     Remote SQL: SELECT c2 FROM "S 1"."T 1"
-               ->  Hash
-                     Output: (sum(ft1_1.c1)), ft1_1.c2
-                     ->  HashAggregate
-                           Output: sum(ft1_1.c1), ft1_1.c2
-                           Group Key: ft1_1.c2
-                           ->  Foreign Scan on public.ft1 ft1_1
-                                 Output: ft1_1.c1, ft1_1.c2
-                                 Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1"
+         ->  Streaming Partial HashAggregate
+               Output: PARTIAL count(), (sum(ft1_1.c1))
+               Group Key: (sum(ft1_1.c1))
+               ->  Hash Join
+                     Output: (sum(ft1_1.c1))
+                     Hash Cond: (ft1.c2 = ft1_1.c2)
+                     ->  Foreign Scan on public.ft1
+                           Output: ft1.c2
+                           Remote SQL: SELECT c2 FROM "S 1"."T 1"
+                     ->  Hash
+                           Output: (sum(ft1_1.c1)), ft1_1.c2
+                           ->  Finalize HashAggregate
+                                 Output: sum(ft1_1.c1), ft1_1.c2
+                                 Group Key: ft1_1.c2
+                                 ->  Streaming Partial HashAggregate
+                                       Output: PARTIAL sum(ft1_1.c1), ft1_1.c2
+                                       Group Key: ft1_1.c2
+                                       ->  Foreign Scan on public.ft1 ft1_1
+                                             Output: ft1_1.c1, ft1_1.c2
+                                             Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1"
  Optimizer: Pivotal Optimizer (GPORCA)
-(21 rows)
+(27 rows)
 
 select count(*), x.b from ft1, (select c2 a, sum(c1) b from ft1 group by c2) x where ft1.c2 = x.a group by x.b order by 1, 2;
  count |   b   
@@ -4427,26 +4492,29 @@ select avg(t1.c1), sum(t2.c1) from ft4 t1 full join ft5 t2 on (t1.c1 = t2.c1) gr
    ->  Result
          Output: (avg(ft4.c1)), (sum(ft5.c1))
          Filter: ((((avg(ft4.c1)) IS NULL) AND ((sum(ft5.c1)) < 10)) OR ((sum(ft5.c1)) IS NULL))
-         ->  HashAggregate
+         ->  Finalize HashAggregate
                Output: avg(ft4.c1), sum(ft5.c1), avg(ft4.c1), sum(ft5.c1), sum(ft5.c1), ft5.c1
                Group Key: ft5.c1
-               ->  Merge Full Join
-                     Output: ft4.c1, ft5.c1
-                     Merge Cond: (ft4.c1 = ft5.c1)
-                     ->  Sort
-                           Output: ft4.c1
-                           Sort Key: ft4.c1
-                           ->  Foreign Scan on public.ft4
+               ->  Streaming Partial HashAggregate
+                     Output: PARTIAL avg(ft4.c1), PARTIAL sum(ft5.c1), PARTIAL avg(ft4.c1), PARTIAL sum(ft5.c1), PARTIAL sum(ft5.c1), ft5.c1
+                     Group Key: ft5.c1
+                     ->  Merge Full Join
+                           Output: ft4.c1, ft5.c1
+                           Merge Cond: (ft4.c1 = ft5.c1)
+                           ->  Sort
                                  Output: ft4.c1
-                                 Remote SQL: SELECT c1 FROM "S 1"."T 3"
-                     ->  Sort
-                           Output: ft5.c1
-                           Sort Key: ft5.c1
-                           ->  Foreign Scan on public.ft5
+                                 Sort Key: ft4.c1
+                                 ->  Foreign Scan on public.ft4
+                                       Output: ft4.c1
+                                       Remote SQL: SELECT c1 FROM "S 1"."T 3"
+                           ->  Sort
                                  Output: ft5.c1
-                                 Remote SQL: SELECT c1 FROM "S 1"."T 4"
+                                 Sort Key: ft5.c1
+                                 ->  Foreign Scan on public.ft5
+                                       Output: ft5.c1
+                                       Remote SQL: SELECT c1 FROM "S 1"."T 4"
  Optimizer: Pivotal Optimizer (GPORCA)
-(25 rows)
+(28 rows)
 
 select avg(t1.c1), sum(t2.c1) from ft4 t1 full join ft5 t2 on (t1.c1 = t2.c1) group by t2.c1 having (avg(t1.c1) is null and sum(t2.c1) < 10) or sum(t2.c1) is null order by 1 nulls last, 2;
          avg         | sum 
@@ -4460,27 +4528,29 @@ select avg(t1.c1), sum(t2.c1) from ft4 t1 full join ft5 t2 on (t1.c1 = t2.c1) gr
 -- subqueries.
 explain (verbose, costs off)
 select count(*), sum(t1.c1), avg(t2.c1) from (select c1 from ft4 where c1 between 50 and 60) t1 full join (select c1 from ft5 where c1 between 50 and 60) t2 on (t1.c1 = t2.c1);
-                                           QUERY PLAN                                           
-------------------------------------------------------------------------------------------------
- Aggregate
+                                              QUERY PLAN
+------------------------------------------------------------------------------------------------------
+ Finalize Aggregate
    Output: count(), sum(ft4.c1), avg(ft5.c1)
-   ->  Merge Full Join
-         Output: ft4.c1, ft5.c1
-         Merge Cond: (ft4.c1 = ft5.c1)
-         ->  Sort
-               Output: ft4.c1
-               Sort Key: ft4.c1
-               ->  Foreign Scan on public.ft4
+   ->  Partial Aggregate
+         Output: PARTIAL count(), PARTIAL sum(ft4.c1), PARTIAL avg(ft5.c1)
+         ->  Merge Full Join
+               Output: ft4.c1, ft5.c1
+               Merge Cond: (ft4.c1 = ft5.c1)
+               ->  Sort
                      Output: ft4.c1
-                     Remote SQL: SELECT c1 FROM "S 1"."T 3" WHERE (((c1 >= 50) AND (c1 <= 60)))
-         ->  Sort
-               Output: ft5.c1
-               Sort Key: ft5.c1
-               ->  Foreign Scan on public.ft5
+                     Sort Key: ft4.c1
+                     ->  Foreign Scan on public.ft4
+                           Output: ft4.c1
+                           Remote SQL: SELECT c1 FROM "S 1"."T 3" WHERE (((c1 >= 50) AND (c1 <= 60)))
+               ->  Sort
                      Output: ft5.c1
-                     Remote SQL: SELECT c1 FROM "S 1"."T 4" WHERE (((c1 >= 50) AND (c1 <= 60)))
+                     Sort Key: ft5.c1
+                     ->  Foreign Scan on public.ft5
+                           Output: ft5.c1
+                           Remote SQL: SELECT c1 FROM "S 1"."T 4" WHERE (((c1 >= 50) AND (c1 <= 60)))
  Optimizer: Pivotal Optimizer (GPORCA)
-(18 rows)
+(20 rows)
 
 select count(*), sum(t1.c1), avg(t2.c1) from (select c1 from ft4 where c1 between 50 and 60) t1 full join (select c1 from ft5 where c1 between 50 and 60) t2 on (t1.c1 = t2.c1);
  count | sum |         avg         
@@ -4497,13 +4567,15 @@ select sum(c2) * (random() <= 1)::int as sum from ft1 order by 1;
  Sort
    Output: ((sum(c2) * int4((random() <= '1'::double precision))))
    Sort Key: ((sum(ft1.c2) * int4((random() <= '1'::double precision))))
-   ->  Aggregate
+   ->  Finalize Aggregate
          Output: (sum(c2) * int4((random() <= '1'::double precision)))
-         ->  Foreign Scan on public.ft1
-               Output: c2
-               Remote SQL: SELECT c2 FROM "S 1"."T 1"
+         ->  Partial Aggregate
+               Output: PARTIAL sum(c2)
+               ->  Foreign Scan on public.ft1
+                     Output: c2
+                     Remote SQL: SELECT c2 FROM "S 1"."T 1"
  Optimizer: Pivotal Optimizer (GPORCA)
-(9 rows)
+(11 rows)
 
 select sum(c2) * (random() <= 1)::int as sum from ft1 order by 1;
  sum  
@@ -4621,33 +4693,37 @@ DETAIL:  Feature not supported: LATERAL
 -- Check with placeHolderVars
 explain (verbose, costs off)
 select sum(q.a), count(q.b) from ft4 left join (select 13, avg(ft1.c1), sum(ft2.c1) from ft1 right join ft2 on (ft1.c1 = ft2.c1)) q(a, b, c) on (ft4.c1 <= q.b);
-                                      QUERY PLAN                                       
----------------------------------------------------------------------------------------
- Aggregate
+                                         QUERY PLAN
+---------------------------------------------------------------------------------------------
+ Finalize Aggregate
    Output: sum((13)), count((avg(ft1.c1)))
-   ->  Nested Loop Left Join
-         Output: (avg(ft1.c1)), (13)
-         Join Filter: ((ft4.c1)::numeric <= (avg(ft1.c1)))
-         ->  Foreign Scan on public.ft4
-               Output: ft4.c1
-               Remote SQL: SELECT c1 FROM "S 1"."T 3"
-         ->  Materialize
-               Output: (13), (avg(ft1.c1))
-               ->  Aggregate
-                     Output: 13, avg(ft1.c1)
-                     ->  Hash Left Join
-                           Output: ft1.c1
-                           Hash Cond: (ft2.c1 = ft1.c1)
-                           ->  Foreign Scan on public.ft2
-                                 Output: ft2.c1
-                                 Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
-                           ->  Hash
-                                 Output: ft1.c1
-                                 ->  Foreign Scan on public.ft1
+   ->  Partial Aggregate
+         Output: PARTIAL sum((13)), PARTIAL count((avg(ft1.c1)))
+         ->  Nested Loop Left Join
+               Output: (avg(ft1.c1)), (13)
+               Join Filter: ((ft4.c1)::numeric <= (avg(ft1.c1)))
+               ->  Foreign Scan on public.ft4
+                     Output: ft4.c1
+                     Remote SQL: SELECT c1 FROM "S 1"."T 3"
+               ->  Materialize
+                     Output: (13), (avg(ft1.c1))
+                     ->  Finalize Aggregate
+                           Output: 13, avg(ft1.c1)
+                           ->  Partial Aggregate
+                                 Output: PARTIAL avg(ft1.c1)
+                                 ->  Hash Left Join
                                        Output: ft1.c1
-                                       Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
+                                       Hash Cond: (ft2.c1 = ft1.c1)
+                                       ->  Foreign Scan on public.ft2
+                                             Output: ft2.c1
+                                             Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
+                                       ->  Hash
+                                             Output: ft1.c1
+                                             ->  Foreign Scan on public.ft1
+                                                   Output: ft1.c1
+                                                   Remote SQL: SELECT "C 1" FROM "S 1"."T 1"
  Optimizer: Pivotal Optimizer (GPORCA)
-(24 rows)
+(28 rows)
 
 select sum(q.a), count(q.b) from ft4 left join (select 13, avg(ft1.c1), sum(ft2.c1) from ft1 right join ft2 on (ft1.c1 = ft2.c1)) q(a, b, c) on (ft4.c1 <= q.b);
  sum | count 
@@ -4672,17 +4748,25 @@ select c2, sum(c1) from ft1 where c2 < 3 group by rollup(c2) order by 1 nulls la
                      Output: c2, c1
                      Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1" WHERE ((c2 < 3))
          ->  Append
-               ->  Aggregate
+               ->  Finalize Aggregate
                      Output: NULL::integer, sum(share0_ref2.c1)
-                     ->  Shared Scan (share slice:id 0:0)
-                           Output: share0_ref2.c2, share0_ref2.c1
-               ->  HashAggregate
+                     ->  Partial Aggregate
+                           Output: PARTIAL sum(share0_ref2.c1)
+                           ->  Shared Scan (share slice:id 0:0)
+                                 Output: share0_ref2.c2, share0_ref2.c1
+               ->  Finalize GroupAggregate
                      Output: share0_ref3.c2, sum(share0_ref3.c1)
                      Group Key: share0_ref3.c2
-                     ->  Shared Scan (share slice:id 0:0)
-                           Output: share0_ref3.c2, share0_ref3.c1
+                     ->  Sort
+                           Output: (PARTIAL sum(share0_ref3.c1)), share0_ref3.c2
+                           Sort Key: share0_ref3.c2
+                           ->  Streaming Partial HashAggregate
+                                 Output: PARTIAL sum(share0_ref3.c1), share0_ref3.c2
+                                 Group Key: share0_ref3.c2
+                                 ->  Shared Scan (share slice:id 0:0)
+                                       Output: share0_ref3.c2, share0_ref3.c1
  Optimizer: Pivotal Optimizer (GPORCA)
-(21 rows)
+(29 rows)
 
 select c2, sum(c1) from ft1 where c2 < 3 group by rollup(c2) order by 1 nulls last;
  c2 |  sum   
@@ -4708,17 +4792,25 @@ select c2, sum(c1) from ft1 where c2 < 3 group by cube(c2) order by 1 nulls last
                      Output: c2, c1
                      Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1" WHERE ((c2 < 3))
          ->  Append
-               ->  HashAggregate
+               ->  Finalize GroupAggregate
                      Output: share0_ref2.c2, sum(share0_ref2.c1)
                      Group Key: share0_ref2.c2
-                     ->  Shared Scan (share slice:id 0:0)
-                           Output: share0_ref2.c2, share0_ref2.c1
-               ->  Aggregate
+                     ->  Sort
+                           Output: (PARTIAL sum(share0_ref2.c1)), share0_ref2.c2
+                           Sort Key: share0_ref2.c2
+                           ->  Streaming Partial HashAggregate
+                                 Output: PARTIAL sum(share0_ref2.c1), share0_ref2.c2
+                                 Group Key: share0_ref2.c2
+                                 ->  Shared Scan (share slice:id 0:0)
+                                       Output: share0_ref2.c2, share0_ref2.c1
+               ->  Finalize Aggregate
                      Output: NULL::integer, sum(share0_ref3.c1)
-                     ->  Shared Scan (share slice:id 0:0)
-                           Output: share0_ref3.c2, share0_ref3.c1
+                     ->  Partial Aggregate
+                           Output: PARTIAL sum(share0_ref3.c1)
+                           ->  Shared Scan (share slice:id 0:0)
+                                 Output: share0_ref3.c2, share0_ref3.c1
  Optimizer: Pivotal Optimizer (GPORCA)
-(21 rows)
+(29 rows)
 
 select c2, sum(c1) from ft1 where c2 < 3 group by cube(c2) order by 1 nulls last;
  c2 |  sum   
@@ -4744,18 +4836,27 @@ select c2, c6, sum(c1) from ft1 where c2 < 3 group by grouping sets(c2, c6) orde
                      Output: c2, c6, c1
                      Remote SQL: SELECT "C 1", c2, c6 FROM "S 1"."T 1" WHERE ((c2 < 3))
          ->  Append
-               ->  HashAggregate
+               ->  Finalize HashAggregate
                      Output: NULL::integer, share0_ref2.c6, sum(share0_ref2.c1)
                      Group Key: share0_ref2.c6
-                     ->  Shared Scan (share slice:id 0:0)
-                           Output: share0_ref2.c2, share0_ref2.c6, share0_ref2.c1
-               ->  HashAggregate
+                     ->  Streaming Partial HashAggregate
+                           Output: PARTIAL sum(share0_ref2.c1), share0_ref2.c6
+                           Group Key: share0_ref2.c6
+                           ->  Shared Scan (share slice:id 0:0)
+                                 Output: share0_ref2.c2, share0_ref2.c6, share0_ref2.c1
+               ->  Finalize GroupAggregate
                      Output: share0_ref3.c2, NULL::character varying, sum(share0_ref3.c1)
                      Group Key: share0_ref3.c2
-                     ->  Shared Scan (share slice:id 0:0)
-                           Output: share0_ref3.c2, share0_ref3.c6, share0_ref3.c1
+                     ->  Sort
+                           Output: (PARTIAL sum(share0_ref3.c1)), share0_ref3.c2
+                           Sort Key: share0_ref3.c2
+                           ->  Streaming Partial HashAggregate
+                                 Output: PARTIAL sum(share0_ref3.c1), share0_ref3.c2
+                                 Group Key: share0_ref3.c2
+                                 ->  Shared Scan (share slice:id 0:0)
+                                       Output: share0_ref3.c2, share0_ref3.c6, share0_ref3.c1
  Optimizer: Pivotal Optimizer (GPORCA)
-(22 rows)
+(31 rows)
 
 select c2, c6, sum(c1) from ft1 where c2 < 3 group by grouping sets(c2, c6) order by 1 nulls last, 2 nulls last;
  c2 | c6 |  sum  
@@ -4772,19 +4873,20 @@ explain (verbose, costs off)
 select c2, sum(c1), grouping(c2) from ft1 where c2 < 3 group by c2 order by 1 nulls last;
                                      QUERY PLAN                                     
 ------------------------------------------------------------------------------------
- Result
-   Output: c2, (sum(c1)), 0
+ Finalize GroupAggregate
+   Output: c2, sum(c1), 0
+   Group Key: ft1.c2
    ->  Sort
-         Output: (sum(c1)), c2
+         Output: (PARTIAL sum(c1)), c2
          Sort Key: ft1.c2
-         ->  HashAggregate
-               Output: sum(c1), c2
+         ->  Streaming Partial HashAggregate
+               Output: PARTIAL sum(c1), c2
                Group Key: ft1.c2
                ->  Foreign Scan on public.ft1
                      Output: c1, c2
                      Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1" WHERE ((c2 < 3))
  Optimizer: Pivotal Optimizer (GPORCA)
-(12 rows)
+(13 rows)
 
 select c2, sum(c1), grouping(c2) from ft1 where c2 < 3 group by c2 order by 1 nulls last;
  c2 |  sum  | grouping 
@@ -4802,17 +4904,23 @@ select distinct sum(c1)/1000 s from ft2 where c2 < 6 group by c2 order by 1;
  GroupAggregate
    Output: ((sum(c1) / 1000))
    Group Key: ((sum(ft2.c1) / 1000))
-   ->  Sort
+   ->  GroupAggregate
          Output: ((sum(c1) / 1000))
-         Sort Key: ((sum(ft2.c1) / 1000))
-         ->  HashAggregate
-               Output: (sum(c1) / 1000)
-               Group Key: ft2.c2
-               ->  Foreign Scan on public.ft2
-                     Output: c1, c2
-                     Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1" WHERE ((c2 < 6))
+         Group Key: ((sum(ft2.c1) / 1000))
+         ->  Sort
+               Output: ((sum(c1) / 1000))
+               Sort Key: ((sum(ft2.c1) / 1000))
+               ->  Finalize HashAggregate
+                     Output: (sum(c1) / 1000)
+                     Group Key: ft2.c2
+                     ->  Streaming Partial HashAggregate
+                           Output: PARTIAL sum(c1), c2
+                           Group Key: ft2.c2
+                           ->  Foreign Scan on public.ft2
+                                 Output: c1, c2
+                                 Remote SQL: SELECT "C 1", c2 FROM "S 1"."T 1" WHERE ((c2 < 6))
  Optimizer: Pivotal Optimizer (GPORCA)
-(13 rows)
+(19 rows)
 
 select distinct sum(c1)/1000 s from ft2 where c2 < 6 group by c2 order by 1;
  s  
@@ -4837,14 +4945,17 @@ select c2, sum(c2), count(c2) over (partition by c2%2) from ft2 where c2 < 10 gr
                ->  Sort
                      Output: ((c2 % 2)), c2, (sum(c2))
                      Sort Key: ((ft2.c2 % 2))
-                     ->  HashAggregate
+                     ->  Finalize HashAggregate
                            Output: (c2 % 2), c2, sum(c2)
                            Group Key: ft2.c2
-                           ->  Foreign Scan on public.ft2
-                                 Output: c2
-                                 Remote SQL: SELECT c2 FROM "S 1"."T 1" WHERE ((c2 < 10))
+                           ->  Streaming Partial HashAggregate
+                                 Output: PARTIAL sum(c2), c2
+                                 Group Key: ft2.c2
+                                 ->  Foreign Scan on public.ft2
+                                       Output: c2
+                                       Remote SQL: SELECT c2 FROM "S 1"."T 1" WHERE ((c2 < 10))
  Optimizer: Pivotal Optimizer (GPORCA)
-(18 rows)
+(21 rows)
 
 select c2, sum(c2), count(c2) over (partition by c2%2) from ft2 where c2 < 10 group by c2 order by 1;
  c2 | sum | count 
@@ -4877,14 +4988,20 @@ select c2, array_agg(c2) over (partition by c2%2 order by c2 desc) from ft1 wher
                ->  Sort
                      Output: ((c2 % 2)), c2
                      Sort Key: ((ft1.c2 % 2)), ft1.c2 DESC
-                     ->  HashAggregate
+                     ->  GroupAggregate
                            Output: (c2 % 2), c2
                            Group Key: ft1.c2
-                           ->  Foreign Scan on public.ft1
+                           ->  Sort
                                  Output: c2
-                                 Remote SQL: SELECT c2 FROM "S 1"."T 1" WHERE ((c2 < 10))
+                                 Sort Key: ft1.c2
+                                 ->  Streaming HashAggregate
+                                       Output: c2
+                                       Group Key: ft1.c2
+                                       ->  Foreign Scan on public.ft1
+                                             Output: c2
+                                             Remote SQL: SELECT c2 FROM "S 1"."T 1" WHERE ((c2 < 10))
  Optimizer: Pivotal Optimizer (GPORCA)
-(19 rows)
+(25 rows)
 
 select c2, array_agg(c2) over (partition by c2%2 order by c2 desc) from ft1 where c2 < 10 group by c2 order by 1;
  c2 |  array_agg  
@@ -4917,14 +5034,20 @@ select c2, array_agg(c2) over (partition by c2%2 order by c2 range between curre
                ->  Sort
                      Output: ((c2 % 2)), c2
                      Sort Key: ((ft1.c2 % 2)), ft1.c2
-                     ->  HashAggregate
+                     ->  GroupAggregate
                            Output: (c2 % 2), c2
                            Group Key: ft1.c2
-                           ->  Foreign Scan on public.ft1
+                           ->  Sort
                                  Output: c2
-                                 Remote SQL: SELECT c2 FROM "S 1"."T 1" WHERE ((c2 < 10))
+                                 Sort Key: ft1.c2
+                                 ->  Streaming HashAggregate
+                                       Output: c2
+                                       Group Key: ft1.c2
+                                       ->  Foreign Scan on public.ft1
+                                             Output: c2
+                                             Remote SQL: SELECT c2 FROM "S 1"."T 1" WHERE ((c2 < 10))
  Optimizer: Pivotal Optimizer (GPORCA)
-(19 rows)
+(25 rows)
 
 select c2, array_agg(c2) over (partition by c2%2 order by c2 range between current row and unbounded following) from ft1 where c2 < 10 group by c2 order by 1;
  c2 |  array_agg  
@@ -5235,28 +5358,32 @@ ALTER TABLE
 ALTER FOREIGN TABLE ft1 OPTIONS (SET table_name 'T 1');
 PREPARE st8 AS SELECT count(c3) FROM ft1 t1 WHERE t1.c1 === t1.c2;
 EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st8;
-                                       QUERY PLAN                                       
-----------------------------------------------------------------------------------------
- Aggregate
+                                          QUERY PLAN
+----------------------------------------------------------------------------------------------
+ Finalize Aggregate
    Output: count(c3)
-   ->  Foreign Scan on public.ft1
-         Output: c3
-         Remote SQL: SELECT c3 FROM "S 1"."T 1" WHERE (("C 1" OPERATOR(public.===) c2))
+   ->  Partial Aggregate
+         Output: PARTIAL count(c3)
+         ->  Foreign Scan on public.ft1
+               Output: c3
+               Remote SQL: SELECT c3 FROM "S 1"."T 1" WHERE (("C 1" OPERATOR(public.===) c2))
  Optimizer: Pivotal Optimizer (GPORCA)
-(6 rows)
+(8 rows)
 
 ALTER SERVER pgserver OPTIONS (DROP extensions);
 EXPLAIN (VERBOSE, COSTS OFF) EXECUTE st8;
-                        QUERY PLAN                         
------------------------------------------------------------
- Aggregate
+                           QUERY PLAN
+-----------------------------------------------------------------
+ Finalize Aggregate
    Output: count(c3)
-   ->  Foreign Scan on public.ft1
-         Output: c3
-         Filter: (ft1.c1 === ft1.c2)
-         Remote SQL: SELECT "C 1", c2, c3 FROM "S 1"."T 1"
+   ->  Partial Aggregate
+         Output: PARTIAL count(c3)
+         ->  Foreign Scan on public.ft1
+               Output: c3
+               Filter: (ft1.c1 === ft1.c2)
+               Remote SQL: SELECT "C 1", c2, c3 FROM "S 1"."T 1"
  Optimizer: Pivotal Optimizer (GPORCA)
-(7 rows)
+(9 rows)
 
 EXECUTE st8;
  count 
@@ -11570,14 +11697,17 @@ SELECT a, sum(b), min(b), count(*) FROM pagg_tab GROUP BY a HAVING avg(b) < 22 O
          Sort Key: a
          ->  Result
                Filter: ((avg(b)) < '22'::numeric)
-               ->  HashAggregate
+               ->  Finalize HashAggregate
                      Group Key: a
-                     ->  Redistribute Motion 1:3  (slice2)
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
                            Hash Key: a
-                           ->  Dynamic Foreign Scan on pagg_tab
-                                 Number of partitions to scan: 3 (out of 3)
+                           ->  Streaming Partial HashAggregate
+                                 Group Key: a
+                                 ->  Redistribute Motion 1:3  (slice3)
+                                       ->  Dynamic Foreign Scan on pagg_tab
+                                             Number of partitions to scan: 3 (out of 3)
  Optimizer: Pivotal Optimizer (GPORCA)
-(13 rows)
+(16 rows)
 
 -- Plan with partitionwise aggregates is enabled
 SET enable_partitionwise_aggregate TO true;
@@ -11591,14 +11721,17 @@ SELECT a, sum(b), min(b), count(*) FROM pagg_tab GROUP BY a HAVING avg(b) < 22 O
          Sort Key: a
          ->  Result
                Filter: ((avg(b)) < '22'::numeric)
-               ->  HashAggregate
+               ->  Finalize HashAggregate
                      Group Key: a
-                     ->  Redistribute Motion 1:3  (slice2)
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
                            Hash Key: a
-                           ->  Dynamic Foreign Scan on pagg_tab
-                                 Number of partitions to scan: 3 (out of 3)
+                           ->  Streaming Partial HashAggregate
+                                 Group Key: a
+                                 ->  Redistribute Motion 1:3  (slice3)
+                                       ->  Dynamic Foreign Scan on pagg_tab
+                                             Number of partitions to scan: 3 (out of 3)
  Optimizer: Pivotal Optimizer (GPORCA)
-(13 rows)
+(16 rows)
 
 SELECT a, sum(b), min(b), count(*) FROM pagg_tab GROUP BY a HAVING avg(b) < 22 ORDER BY 1;
  a  | sum  | min | count 
@@ -11672,14 +11805,17 @@ SELECT b, avg(a), max(a), count(*) FROM pagg_tab GROUP BY b HAVING sum(a) < 700 
          Sort Key: b
          ->  Result
                Filter: ((sum(a)) < 700)
-               ->  HashAggregate
+               ->  Finalize HashAggregate
                      Group Key: b
-                     ->  Redistribute Motion 1:3  (slice2)
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
                            Hash Key: b
-                           ->  Dynamic Foreign Scan on pagg_tab
-                                 Number of partitions to scan: 3 (out of 3)
+                           ->  Streaming Partial HashAggregate
+                                 Group Key: b
+                                 ->  Redistribute Motion 1:3  (slice3)
+                                       ->  Dynamic Foreign Scan on pagg_tab
+                                             Number of partitions to scan: 3 (out of 3)
  Optimizer: Pivotal Optimizer (GPORCA)
-(13 rows)
+(16 rows)
 
 SELECT b, avg(a), max(a), count(*) FROM pagg_tab GROUP BY b HAVING sum(a) < 700 ORDER BY 1;
  b  |         avg         | max | count 

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -2310,7 +2310,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 			GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_force_multistage_agg,
-		false,
+		true,
 		NULL, NULL, NULL
 	},
 

--- a/src/test/isolation2/expected/spilling_hashagg_optimizer.out
+++ b/src/test/isolation2/expected/spilling_hashagg_optimizer.out
@@ -41,16 +41,18 @@ SET
 CREATE TABLE test_hashagg_off AS SELECT a, COUNT(DISTINCT b) AS b FROM test_src_tbl GROUP BY a;
 CREATE 100
 EXPLAIN (costs off) SELECT a, COUNT(DISTINCT b) AS b FROM test_src_tbl GROUP BY a;
- QUERY PLAN                                 
---------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)   
-   ->  GroupAggregate                       
-         Group Key: a                       
-         ->  Sort                           
-               Sort Key: a                  
-               ->  Seq Scan on test_src_tbl 
- Optimizer: Pivotal Optimizer (GPORCA)      
-(7 rows)
+ QUERY PLAN                                       
+--------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)         
+   ->  GroupAggregate                             
+         Group Key: a                             
+         ->  GroupAggregate                       
+               Group Key: a, b                    
+               ->  Sort                           
+                     Sort Key: a, b               
+                     ->  Seq Scan on test_src_tbl 
+ Optimizer: Pivotal Optimizer (GPORCA)            
+(9 rows)
 
 -- Results should match
 SELECT (n_total=n_matches) AS match FROM ( SELECT COUNT(*) n_total, SUM(CASE WHEN t1.b = t2.b THEN 1 ELSE 0 END) n_matches FROM test_hashagg_on t1 JOIN test_hashagg_off t2 ON t1.a = t2.a) t;

--- a/src/test/regress/expected/aggregates_optimizer.out
+++ b/src/test/regress/expected/aggregates_optimizer.out
@@ -1267,9 +1267,13 @@ explain (costs off) select a,c from t1 group by a,c,d;
                Sort Key: a, c, d
                ->  Redistribute Motion 3:3  (slice2; segments: 3)
                      Hash Key: a, c, d
-                     ->  Seq Scan on t1
- Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
-(9 rows)
+                     ->  GroupAggregate
+                           Group Key: a, c, d
+                           ->  Sort
+                                 Sort Key: a, c, d
+                                 ->  Seq Scan on t1
+ Optimizer: Pivotal Optimizer (GPORCA)
+(13 rows)
 
 -- Test removal across multiple relations
 explain (costs off) select *

--- a/src/test/regress/expected/bfv_aggregate.out
+++ b/src/test/regress/expected/bfv_aggregate.out
@@ -363,6 +363,7 @@ insert into mtup1 values
 -- from exceeding the limit in GPDB7 with that plan(a MinimalTuple has a limit of 1600
 -- columns). So set the parameter to off to prevent error happens.
 set gp_enable_multiphase_agg=off;
+set optimizer_force_multistage_agg=off;
 select c0, c1, array_length(ARRAY[
  SUM(c4 % 2), SUM(c4 % 3), SUM(c4 % 4),
  SUM(c4 % 5), SUM(c4 % 6), SUM(c4 % 7), SUM(c4 % 8), SUM(c4 % 9),
@@ -1505,6 +1506,7 @@ from mtup1 where c0 = 'foo' group by c0, c1 limit 10;
  foo | 2015-09-1.1 |         5670
 (1 row)
 
+reset optimizer_force_multistage_agg;
 reset gp_enable_multiphase_agg;
 -- MPP-29042 Multistage aggregation plans should have consistent targetlists in
 -- case of same column aliases and grouping on them.

--- a/src/test/regress/expected/bfv_aggregate_optimizer.out
+++ b/src/test/regress/expected/bfv_aggregate_optimizer.out
@@ -362,6 +362,7 @@ insert into mtup1 values
 -- from exceeding the limit in GPDB7 with that plan(a MinimalTuple has a limit of 1600
 -- columns). So set the parameter to off to prevent error happens.
 set gp_enable_multiphase_agg=off;
+set optimizer_force_multistage_agg=off;
 select c0, c1, array_length(ARRAY[
  SUM(c4 % 2), SUM(c4 % 3), SUM(c4 % 4),
  SUM(c4 % 5), SUM(c4 % 6), SUM(c4 % 7), SUM(c4 % 8), SUM(c4 % 9),
@@ -1504,6 +1505,7 @@ from mtup1 where c0 = 'foo' group by c0, c1 limit 10;
  foo | 2015-09-1.1 |         5670
 (1 row)
 
+reset optimizer_force_multistage_agg;
 reset gp_enable_multiphase_agg;
 -- MPP-29042 Multistage aggregation plans should have consistent targetlists in
 -- case of same column aliases and grouping on them.
@@ -1727,22 +1729,24 @@ SELECT a.x, b.y, count(*) FROM pagg_tab1 a FULL JOIN pagg_tab2 b ON a.x = b.y GR
                                   QUERY PLAN                                  
 ------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  HashAggregate
+   ->  Finalize HashAggregate
          Group Key: pagg_tab1.x, pagg_tab2.y
          ->  Redistribute Motion 3:3  (slice2; segments: 3)
                Hash Key: pagg_tab1.x, pagg_tab2.y
-               ->  Merge Full Join
-                     Merge Cond: (pagg_tab1.x = pagg_tab2.y)
-                     ->  Sort
-                           Sort Key: pagg_tab1.x
-                           ->  Seq Scan on pagg_tab1
-                     ->  Sort
-                           Sort Key: pagg_tab2.y
-                           ->  Redistribute Motion 3:3  (slice3; segments: 3)
-                                 Hash Key: pagg_tab2.y
-                                 ->  Seq Scan on pagg_tab2
+               ->  Streaming Partial HashAggregate
+                     Group Key: pagg_tab1.x, pagg_tab2.y
+                     ->  Merge Full Join
+                           Merge Cond: (pagg_tab1.x = pagg_tab2.y)
+                           ->  Sort
+                                 Sort Key: pagg_tab1.x
+                                 ->  Seq Scan on pagg_tab1
+                           ->  Sort
+                                 Sort Key: pagg_tab2.y
+                                 ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                                       Hash Key: pagg_tab2.y
+                                       ->  Seq Scan on pagg_tab2
  Optimizer: Pivotal Optimizer (GPORCA)
-(16 rows)
+(18 rows)
 
 SELECT a.x, b.y, count(*) FROM pagg_tab1 a FULL JOIN pagg_tab2 b ON a.x = b.y GROUP BY a.x, b.y;
  x  | y  | count 

--- a/src/test/regress/expected/bfv_index_optimizer.out
+++ b/src/test/regress/expected/bfv_index_optimizer.out
@@ -129,26 +129,27 @@ explain SELECT count(*)
 FROM bfv_tab2_facttable1 ft, bfv_tab2_dimdate dt, bfv_tab2_dimtabl1 dt1
 WHERE ft.wk_id = dt.wk_id
 AND ft.id = dt1.id;
-                                                            QUERY PLAN                                                            
-----------------------------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=0.00..1250.34 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1250.34 rows=7 width=1)
-         ->  Hash Join  (cost=0.00..1250.34 rows=3 width=1)
-               Hash Cond: (bfv_tab2_dimdate.wk_id = bfv_tab2_facttable1.wk_id)
-               ->  Seq Scan on bfv_tab2_dimdate  (cost=0.00..431.00 rows=4 width=2)
-               ->  Hash  (cost=819.34..819.34 rows=3 width=2)
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..819.34 rows=3 width=2)
-                           Hash Key: bfv_tab2_facttable1.wk_id
-                           ->  Nested Loop  (cost=0.00..819.34 rows=3 width=2)
-                                 Join Filter: true
-                                 ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=7 width=4)
-                                       ->  Seq Scan on bfv_tab2_dimtabl1  (cost=0.00..431.00 rows=3 width=4)
-                                 ->  Dynamic Bitmap Heap Scan on bfv_tab2_facttable1  (cost=0.00..388.34 rows=1 width=2)
-                                       Number of partitions to scan: 21 
-                                       Recheck Cond: (id = bfv_tab2_dimtabl1.id)
-                                       Filter: (id = bfv_tab2_dimtabl1.id)
-                                       ->  Dynamic Bitmap Index Scan on idx_bfv_tab2_facttable1  (cost=0.00..0.00 rows=0 width=0)
-                                             Index Cond: (id = bfv_tab2_dimtabl1.id)
+                                                               QUERY PLAN                                                               
+----------------------------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate  (cost=0.00..1250.34 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1250.34 rows=1 width=8)
+         ->  Partial Aggregate  (cost=0.00..1250.34 rows=1 width=8)
+               ->  Hash Join  (cost=0.00..1250.34 rows=3 width=1)
+                     Hash Cond: (bfv_tab2_dimdate.wk_id = bfv_tab2_facttable1.wk_id)
+                     ->  Seq Scan on bfv_tab2_dimdate  (cost=0.00..431.00 rows=4 width=2)
+                     ->  Hash  (cost=819.34..819.34 rows=3 width=2)
+                           ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..819.34 rows=3 width=2)
+                                 Hash Key: bfv_tab2_facttable1.wk_id
+                                 ->  Nested Loop  (cost=0.00..819.34 rows=3 width=2)
+                                       Join Filter: true
+                                       ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=7 width=4)
+                                             ->  Seq Scan on bfv_tab2_dimtabl1  (cost=0.00..431.00 rows=3 width=4)
+                                       ->  Dynamic Bitmap Heap Scan on bfv_tab2_facttable1  (cost=0.00..388.34 rows=1 width=2)
+                                             Number of partitions to scan: 21 (out of 21)
+                                             Recheck Cond: (id = bfv_tab2_dimtabl1.id)
+                                             Filter: (id = bfv_tab2_dimtabl1.id)
+                                             ->  Dynamic Bitmap Index Scan on idx_bfv_tab2_facttable1  (cost=0.00..0.00 rows=0 width=0)
+                                                   Index Cond: (id = bfv_tab2_dimtabl1.id)
  Optimizer: Pivotal Optimizer (GPORCA)
 (19 rows)
 
@@ -156,26 +157,27 @@ explain SELECT count(*)
 FROM bfv_tab2_facttable1 ft, bfv_tab2_dimdate dt, bfv_tab2_dimtabl1 dt1
 WHERE ft.wk_id = dt.wk_id
 AND ft.id = dt1.id;
-                                                            QUERY PLAN                                                            
-----------------------------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=0.00..1250.34 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1250.34 rows=7 width=1)
-         ->  Hash Join  (cost=0.00..1250.34 rows=3 width=1)
-               Hash Cond: (bfv_tab2_dimdate.wk_id = bfv_tab2_facttable1.wk_id)
-               ->  Seq Scan on bfv_tab2_dimdate  (cost=0.00..431.00 rows=4 width=2)
-               ->  Hash  (cost=819.34..819.34 rows=3 width=2)
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..819.34 rows=3 width=2)
-                           Hash Key: bfv_tab2_facttable1.wk_id
-                           ->  Nested Loop  (cost=0.00..819.34 rows=3 width=2)
-                                 Join Filter: true
-                                 ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=7 width=4)
-                                       ->  Seq Scan on bfv_tab2_dimtabl1  (cost=0.00..431.00 rows=3 width=4)
-                                 ->  Dynamic Bitmap Heap Scan on bfv_tab2_facttable1  (cost=0.00..388.34 rows=1 width=2)
-                                       Number of partitions to scan: 21 
-                                       Recheck Cond: (id = bfv_tab2_dimtabl1.id)
-                                       Filter: (id = bfv_tab2_dimtabl1.id)
-                                       ->  Dynamic Bitmap Index Scan on idx_bfv_tab2_facttable1  (cost=0.00..0.00 rows=0 width=0)
-                                             Index Cond: (id = bfv_tab2_dimtabl1.id)
+                                                               QUERY PLAN                                                               
+----------------------------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate  (cost=0.00..1250.34 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1250.34 rows=1 width=8)
+         ->  Partial Aggregate  (cost=0.00..1250.34 rows=1 width=8)
+               ->  Hash Join  (cost=0.00..1250.34 rows=3 width=1)
+                     Hash Cond: (bfv_tab2_dimdate.wk_id = bfv_tab2_facttable1.wk_id)
+                     ->  Seq Scan on bfv_tab2_dimdate  (cost=0.00..431.00 rows=4 width=2)
+                     ->  Hash  (cost=819.34..819.34 rows=3 width=2)
+                           ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..819.34 rows=3 width=2)
+                                 Hash Key: bfv_tab2_facttable1.wk_id
+                                 ->  Nested Loop  (cost=0.00..819.34 rows=3 width=2)
+                                       Join Filter: true
+                                       ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=7 width=4)
+                                             ->  Seq Scan on bfv_tab2_dimtabl1  (cost=0.00..431.00 rows=3 width=4)
+                                       ->  Dynamic Bitmap Heap Scan on bfv_tab2_facttable1  (cost=0.00..388.34 rows=1 width=2)
+                                             Number of partitions to scan: 21 (out of 21)
+                                             Recheck Cond: (id = bfv_tab2_dimtabl1.id)
+                                             Filter: (id = bfv_tab2_dimtabl1.id)
+                                             ->  Dynamic Bitmap Index Scan on idx_bfv_tab2_facttable1  (cost=0.00..0.00 rows=0 width=0)
+                                                   Index Cond: (id = bfv_tab2_dimtabl1.id)
  Optimizer: Pivotal Optimizer (GPORCA)
 (19 rows)
 
@@ -1013,14 +1015,15 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 CREATE INDEX bfv_index_only_ao_a_b on bfv_index_only_ao(a) include (b);
 insert into bfv_index_only_ao select i,i from generate_series(1, 10000) i;
 explain select count(*) from bfv_index_only_ao where a < 100;
-                                     QUERY PLAN                                     
-------------------------------------------------------------------------------------
- Aggregate  (cost=0.00..431.00 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
-         ->  Seq Scan on bfv_index_only_ao  (cost=0.00..431.00 rows=1 width=1)
-               Filter: (a < 100)
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Finalize Aggregate  (cost=0.00..431.00 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+         ->  Partial Aggregate  (cost=0.00..431.00 rows=1 width=8)
+               ->  Seq Scan on bfv_index_only_ao  (cost=0.00..431.00 rows=1 width=1)
+                     Filter: (a < 100)
  Optimizer: Pivotal Optimizer (GPORCA)
-(5 rows)
+(6 rows)
 
 select count(*) from bfv_index_only_ao where a < 100;
  count 
@@ -1029,14 +1032,15 @@ select count(*) from bfv_index_only_ao where a < 100;
 (1 row)
 
 explain select count(*) from bfv_index_only_ao where a < 1000;
-                                     QUERY PLAN                                     
-------------------------------------------------------------------------------------
- Aggregate  (cost=0.00..431.00 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
-         ->  Seq Scan on bfv_index_only_ao  (cost=0.00..431.00 rows=1 width=1)
-               Filter: (a < 1000)
+                                     QUERY PLAN                                      
+-------------------------------------------------------------------------------------
+ Finalize Aggregate  (cost=0.00..431.00 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+         ->  Partial Aggregate  (cost=0.00..431.00 rows=1 width=8)
+               ->  Seq Scan on bfv_index_only_ao  (cost=0.00..431.00 rows=1 width=1)
+                     Filter: (a < 1000)
  Optimizer: Pivotal Optimizer (GPORCA)
-(5 rows)
+(6 rows)
 
 select count(*) from bfv_index_only_ao where a < 1000;
  count 
@@ -1050,14 +1054,15 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 CREATE INDEX bfv_index_only_aocs_a_b on bfv_index_only_aocs(a) include (b);
 insert into bfv_index_only_aocs select i,i from generate_series(1, 10000) i;
 explain select count(*) from bfv_index_only_aocs where a < 100;
-                                     QUERY PLAN                                     
-------------------------------------------------------------------------------------
- Aggregate  (cost=0.00..431.00 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
-         ->  Seq Scan on bfv_index_only_aocs  (cost=0.00..431.00 rows=1 width=1)
-               Filter: (a < 100)
+                                      QUERY PLAN                                       
+---------------------------------------------------------------------------------------
+ Finalize Aggregate  (cost=0.00..431.00 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+         ->  Partial Aggregate  (cost=0.00..431.00 rows=1 width=8)
+               ->  Seq Scan on bfv_index_only_aocs  (cost=0.00..431.00 rows=1 width=1)
+                     Filter: (a < 100)
  Optimizer: Pivotal Optimizer (GPORCA)
-(5 rows)
+(6 rows)
 
 select count(*) from bfv_index_only_aocs where a < 100;
  count 
@@ -1066,14 +1071,15 @@ select count(*) from bfv_index_only_aocs where a < 100;
 (1 row)
 
 explain select count(*) from bfv_index_only_aocs where a < 1000;
-                                     QUERY PLAN                                     
-------------------------------------------------------------------------------------
- Aggregate  (cost=0.00..431.00 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
-         ->  Seq Scan on bfv_index_only_aocs  (cost=0.00..431.00 rows=1 width=1)
-               Filter: (a < 1000)
+                                      QUERY PLAN                                       
+---------------------------------------------------------------------------------------
+ Finalize Aggregate  (cost=0.00..431.00 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+         ->  Partial Aggregate  (cost=0.00..431.00 rows=1 width=8)
+               ->  Seq Scan on bfv_index_only_aocs  (cost=0.00..431.00 rows=1 width=1)
+                     Filter: (a < 1000)
  Optimizer: Pivotal Optimizer (GPORCA)
-(5 rows)
+(6 rows)
 
 select count(*) from bfv_index_only_aocs where a < 1000;
  count 

--- a/src/test/regress/expected/bfv_joins_optimizer.out
+++ b/src/test/regress/expected/bfv_joins_optimizer.out
@@ -952,16 +952,17 @@ SELECT t1.c FROM t1 LEFT OUTER JOIN (select t3.*, t3.a+t3.b as cc from t3)t ON t
 explain select 1 as mrs_t1 where 1 <= ALL (select x from z);
                                                                                                                                                        QUERY PLAN                                                                                                                                                        
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Nested Loop  (cost=0.00..882688.11 rows=1 width=1)
+ Nested Loop  (cost=0.00..882688.14 rows=1 width=1)
    Join Filter: true
    ->  Result  (cost=0.00..431.00 rows=1 width=1)
          Filter: ((CASE WHEN (sum((CASE WHEN (1 > x) THEN 1 ELSE 0 END)) IS NULL) THEN true WHEN (sum((CASE WHEN (x IS NULL) THEN 1 ELSE 0 END)) > '0'::bigint) THEN NULL::boolean WHEN (1 IS NULL) THEN NULL::boolean WHEN (sum((CASE WHEN (1 > x) THEN 1 ELSE 0 END)) = '0'::bigint) THEN true ELSE false END) = true)
-         ->  Aggregate  (cost=0.00..431.00 rows=1 width=16)
-               ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
-                     ->  Seq Scan on z  (cost=0.00..431.00 rows=1 width=4)
+         ->  Finalize Aggregate  (cost=0.00..431.00 rows=1 width=16)
+               ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=16)
+                     ->  Partial Aggregate  (cost=0.00..431.00 rows=1 width=16)
+                           ->  Seq Scan on z  (cost=0.00..431.00 rows=1 width=4)
    ->  Result  (cost=0.00..0.00 rows=1 width=1)
  Optimizer: Pivotal Optimizer (GPORCA)
-(9 rows)
+(10 rows)
 
 --
 -- Test for wrong results in window functions under joins #1

--- a/src/test/regress/expected/bfv_olap_optimizer.out
+++ b/src/test/regress/expected/bfv_olap_optimizer.out
@@ -618,16 +618,20 @@ from t2_github_issue_10143 a
 group by a.code;
                                                 QUERY PLAN                                                
 ------------------------------------------------------------------------------------------------------------------------
- WindowAgg  (cost=0.00..1324055.31 rows=1 width=16)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1324055.31 rows=1 width=16)
-         ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=14)
+ WindowAgg  (cost=0.00..1324055.42 rows=2 width=16)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1324055.42 rows=2 width=16)
+         ->  Finalize GroupAggregate  (cost=0.00..431.00 rows=1 width=14)
                Group Key: t2_github_issue_10143.code
-               ->  Sort  (cost=0.00..431.00 rows=1 width=11)
+               ->  Sort  (cost=0.00..431.00 rows=1 width=14)
                      Sort Key: t2_github_issue_10143.code
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=11)
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=14)
                            Hash Key: t2_github_issue_10143.code
-                           ->  Seq Scan on t2_github_issue_10143  (cost=0.00..431.00 rows=1 width=11)
-   SubPlan 1
+                           ->  Partial GroupAggregate  (cost=0.00..431.00 rows=1 width=14)
+                                 Group Key: t2_github_issue_10143.code
+                                 ->  Sort  (cost=0.00..431.00 rows=1 width=11)
+                                       Sort Key: t2_github_issue_10143.code
+                                       ->  Seq Scan on t2_github_issue_10143  (cost=0.00..431.00 rows=1 width=11)
+               SubPlan 1
                  ->  Limit  (cost=0.00..431.00 rows=1 width=6)
                        ->  Result  (cost=0.00..431.00 rows=1 width=6)
                              Filter: ((t1_github_issue_10143.code)::text = (t2_github_issue_10143.code)::text)
@@ -635,7 +639,7 @@ group by a.code;
                                    ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
                                          ->  Seq Scan on t1_github_issue_10143  (cost=0.00..431.00 rows=1 width=12)
  Optimizer: Pivotal Optimizer (GPORCA)
-(17 rows)
+(21 rows)
 
 select (select name from t1_github_issue_10143 where code = a.code limit 1) as dongnm
 ,sum(sum(a.salary)) over()

--- a/src/test/regress/expected/bfv_planner_optimizer.out
+++ b/src/test/regress/expected/bfv_planner_optimizer.out
@@ -515,15 +515,18 @@ explain (costs off) select * from t_hashdist cross join (select a, sum(random())
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Nested Loop
          Join Filter: true
-         ->  Broadcast Motion 3:3  (slice3; segments: 3)
-               ->  Seq Scan on t_hashdist
-         ->  Materialize
-               ->  Redistribute Motion 1:3  (slice2)
-                     ->  HashAggregate
+         ->  Finalize HashAggregate
+               Group Key: generate_series.generate_series
+               ->  Redistribute Motion 1:3  (slice3)
+                     Hash Key: generate_series.generate_series
+                     ->  Streaming Partial HashAggregate
                            Group Key: generate_series.generate_series
                            ->  Function Scan on generate_series
+         ->  Materialize
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                     ->  Seq Scan on t_hashdist
  Optimizer: Pivotal Optimizer (GPORCA)
-(11 rows)
+(14 rows)
 
 explain (costs off) select * from t_hashdist cross join (select random() as k, sum(a) from generate_series(1, 10) a group by k) x;
                           QUERY PLAN                           
@@ -531,11 +534,14 @@ explain (costs off) select * from t_hashdist cross join (select random() as k, s
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Nested Loop
          Join Filter: true
-         ->  HashAggregate
+         ->  Finalize HashAggregate
                Group Key: (random())
-               ->  Redistribute Motion 1:3  (slice3)
+               ->  Redistribute Motion 3:3  (slice3; segments: 3)
                      Hash Key: (random())
-                     ->  Function Scan on generate_series
+                     ->  Streaming Partial HashAggregate
+                           Group Key: (random())
+                           ->  Redistribute Motion 1:3  (slice4)
+                                 ->  Function Scan on generate_series
          ->  Materialize
                ->  Broadcast Motion 3:3  (slice2; segments: 3)
                      ->  Seq Scan on t_hashdist
@@ -608,8 +614,13 @@ explain (costs off) create table t_rep as select i from generate_series(5, 15) a
                Filter: (generate_series < nextval('test_seq'::regclass))
                ->  HashAggregate
                      Group Key: generate_series
-                     ->  Result
-                           ->  Function Scan on generate_series
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: generate_series
+                           ->  Streaming HashAggregate
+                                 Group Key: generate_series
+                                 ->  Result
+                                       One-Time Filter: (gp_execution_segment() = 1)
+                                       ->  Function Scan on generate_series
  Optimizer: Pivotal Optimizer (GPORCA)
 (9 rows)
 
@@ -632,14 +643,17 @@ explain (costs off) create table t_rep as select i > nextval('test_seq') from ge
                                        QUERY PLAN                                        
 -----------------------------------------------------------------------------------------
  Result
-   ->  Broadcast Motion 3:3  (slice1; segments: 3)
+   ->  Broadcast Motion 1:3  (slice1)
          ->  GroupAggregate
                Group Key: ((generate_series > nextval('test_seq'::regclass)))
-               ->  Sort
-                     Sort Key: ((generate_series > nextval('test_seq'::regclass)))
-                     ->  Redistribute Motion 1:3  (slice2)
-                           Hash Key: ((generate_series > nextval('test_seq'::regclass)))
-                           ->  Function Scan on generate_series
+               ->  Gather Motion 3:1  (slice2; segments: 3)
+                     Merge Key: ((generate_series > nextval('test_seq'::regclass)))
+                     ->  GroupAggregate
+                           Group Key: ((generate_series > nextval('test_seq'::regclass)))
+                           ->  Sort
+                                 Sort Key: ((generate_series > nextval('test_seq'::regclass)))
+                                 ->  Redistribute Motion 1:3  (slice3)
+                                       ->  Function Scan on generate_series
  Optimizer: Pivotal Optimizer (GPORCA)
 (10 rows)
 

--- a/src/test/regress/expected/bitmap_index_optimizer.out
+++ b/src/test/regress/expected/bitmap_index_optimizer.out
@@ -1020,19 +1020,20 @@ select gp_inject_fault('simulate_bitmap_and', 'skip', dbid) from gp_segment_conf
 (1 row)
 
 explain (costs off) select count(*) from bmunion where a = 53 and b < 3;
-                          QUERY PLAN                          
---------------------------------------------------------------
- Aggregate
+                             QUERY PLAN                             
+--------------------------------------------------------------------
+ Finalize Aggregate
    ->  Gather Motion 1:1  (slice1; segments: 1)
-         ->  Bitmap Heap Scan on bmunion
-               Recheck Cond: ((a = 53) AND (b < 3))
-               ->  BitmapAnd
-                     ->  Bitmap Index Scan on bmu_i_bmtest2_a
-                           Index Cond: (a = 53)
-                     ->  Bitmap Index Scan on bmu_i_bmtest2_b
-                           Index Cond: (b < 3)
+         ->  Partial Aggregate
+               ->  Bitmap Heap Scan on bmunion
+                     Recheck Cond: ((a = 53) AND (b < 3))
+                     ->  BitmapAnd
+                           ->  Bitmap Index Scan on bmu_i_bmtest2_a
+                                 Index Cond: (a = 53)
+                           ->  Bitmap Index Scan on bmu_i_bmtest2_b
+                                 Index Cond: (b < 3)
  Optimizer: Pivotal Optimizer (GPORCA)
-(10 rows)
+(11 rows)
 
 select gp_inject_fault('simulate_bitmap_and', 'reset', dbid) from gp_segment_configuration where role = 'p' and content = -1;
  gp_inject_fault 

--- a/src/test/regress/expected/bitmapops_optimizer.out
+++ b/src/test/regress/expected/bitmapops_optimizer.out
@@ -54,15 +54,16 @@ CREATE INDEX i_bmtest2_b ON bmscantest2 USING BITMAP(b);
 CREATE INDEX i_bmtest2_c ON bmscantest2(c);
 CREATE INDEX i_bmtest2_d ON bmscantest2(d);
 EXPLAIN SELECT count(*) FROM bmscantest2 WHERE a = 1 AND b = 1 AND c = 1;
-                                        QUERY PLAN                                         
--------------------------------------------------------------------------------------------
- Aggregate  (cost=0.00..6.35 rows=1 width=8)
-   ->  Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..6.35 rows=2 width=1)
-         ->  Index Scan using i_bmtest2_c on bmscantest2  (cost=0.00..6.35 rows=2 width=1)
-               Index Cond: (c = 1)
-               Filter: ((a = 1) AND (b = 1))
- Optimizer: Pivotal Optimizer (GPORCA) version 3.95.0
-(6 rows)
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Finalize Aggregate  (cost=0.00..6.35 rows=1 width=8)
+   ->  Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..6.35 rows=1 width=8)
+         ->  Partial Aggregate  (cost=0.00..6.35 rows=1 width=8)
+               ->  Index Scan using i_bmtest2_c on bmscantest2  (cost=0.00..6.35 rows=1 width=1)
+                     Index Cond: (c = 1)
+                     Filter: ((a = 1) AND (b = 1))
+ Optimizer: Pivotal Optimizer (GPORCA)
+(7 rows)
 
 SELECT count(*) FROM bmscantest2 WHERE a = 1 AND b = 1 AND c = 1;
  count 
@@ -92,7 +93,7 @@ EXPLAIN SELECT count(*) FROM bmscantest2 WHERE a = 1 OR b = 1 OR c = 1;
                                        Index Cond: (b = 1)
                            ->  Bitmap Index Scan on i_bmtest2_c  (cost=0.00..0.00 rows=0 width=0)
                                  Index Cond: (c = 1)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.82.0
+ Optimizer: Pivotal Optimizer (GPORCA)
 (14 rows)
 
 SELECT count(*) FROM bmscantest2 WHERE a = 1 OR b = 1 OR c = 1;
@@ -120,22 +121,23 @@ CREATE INDEX i_bmtest_ao_b ON bmscantest_ao USING BITMAP(b);
 CREATE INDEX i_bmtest_ao_c ON bmscantest_ao(c);
 CREATE INDEX i_bmtest_ao_d ON bmscantest_ao(d);
 EXPLAIN SELECT count(*) FROM bmscantest_ao WHERE a = 1 AND b = 1 AND c = 1;
-                                             QUERY PLAN                                             
-----------------------------------------------------------------------------------------------------
- Aggregate  (cost=0.00..431.06 rows=1 width=8)
-   ->  Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..431.06 rows=2 width=1)
-         ->  Bitmap Heap Scan on bmscantest_ao  (cost=0.00..431.06 rows=1 width=1)
-               Recheck Cond: ((b = 1) AND (a = 1) AND (c = 1))
-               ->  BitmapAnd  (cost=0.00..0.00 rows=0 width=0)
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
+ Finalize Aggregate  (cost=0.00..431.06 rows=1 width=8)
+   ->  Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..431.06 rows=1 width=8)
+         ->  Partial Aggregate  (cost=0.00..431.06 rows=1 width=8)
+               ->  Bitmap Heap Scan on bmscantest_ao  (cost=0.00..431.06 rows=1 width=1)
+                     Recheck Cond: ((b = 1) AND (a = 1) AND (c = 1))
                      ->  BitmapAnd  (cost=0.00..0.00 rows=0 width=0)
-                           ->  Bitmap Index Scan on i_bmtest_ao_b  (cost=0.00..0.00 rows=0 width=0)
-                                 Index Cond: (b = 1)
-                           ->  Bitmap Index Scan on i_bmtest_ao_a  (cost=0.00..0.00 rows=0 width=0)
-                                 Index Cond: (a = 1)
-                     ->  Bitmap Index Scan on i_bmtest_ao_c  (cost=0.00..0.00 rows=0 width=0)
-                           Index Cond: (c = 1)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.72.0
-(13 rows)
+                           ->  BitmapAnd  (cost=0.00..0.00 rows=0 width=0)
+                                 ->  Bitmap Index Scan on i_bmtest_ao_b  (cost=0.00..0.00 rows=0 width=0)
+                                       Index Cond: (b = 1)
+                                 ->  Bitmap Index Scan on i_bmtest_ao_a  (cost=0.00..0.00 rows=0 width=0)
+                                       Index Cond: (a = 1)
+                           ->  Bitmap Index Scan on i_bmtest_ao_c  (cost=0.00..0.00 rows=0 width=0)
+                                 Index Cond: (c = 1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(14 rows)
 
 SELECT count(*) FROM bmscantest_ao WHERE a = 1 AND b = 1 AND c = 1;
  count 
@@ -144,25 +146,26 @@ SELECT count(*) FROM bmscantest_ao WHERE a = 1 AND b = 1 AND c = 1;
 (1 row)
 
 EXPLAIN SELECT count(*) FROM bmscantest_ao WHERE a = 1 AND (b = 1 OR c = 1) AND d = 1;
-                                             QUERY PLAN                                             
-----------------------------------------------------------------------------------------------------
- Aggregate  (cost=0.00..431.06 rows=1 width=8)
-   ->  Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..431.06 rows=3 width=1)
-         ->  Bitmap Heap Scan on bmscantest_ao  (cost=0.00..431.06 rows=1 width=1)
-               Recheck Cond: (((b = 1) OR (c = 1)) AND ((d = 1) AND (a = 1)))
-               ->  BitmapAnd  (cost=0.00..0.00 rows=0 width=0)
-                     ->  BitmapOr  (cost=0.00..0.00 rows=0 width=0)
-                           ->  Bitmap Index Scan on i_bmtest_ao_b  (cost=0.00..0.00 rows=0 width=0)
-                                 Index Cond: (b = 1)
-                           ->  Bitmap Index Scan on i_bmtest_ao_c  (cost=0.00..0.00 rows=0 width=0)
-                                 Index Cond: (c = 1)
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
+ Finalize Aggregate  (cost=0.00..431.06 rows=1 width=8)
+   ->  Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..431.06 rows=1 width=8)
+         ->  Partial Aggregate  (cost=0.00..431.06 rows=1 width=8)
+               ->  Bitmap Heap Scan on bmscantest_ao  (cost=0.00..431.06 rows=1 width=1)
+                     Recheck Cond: (((b = 1) OR (c = 1)) AND ((d = 1) AND (a = 1)))
                      ->  BitmapAnd  (cost=0.00..0.00 rows=0 width=0)
-                           ->  Bitmap Index Scan on i_bmtest_ao_d  (cost=0.00..0.00 rows=0 width=0)
-                                 Index Cond: (d = 1)
-                           ->  Bitmap Index Scan on i_bmtest_ao_a  (cost=0.00..0.00 rows=0 width=0)
-                                 Index Cond: (a = 1)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.72.0
-(16 rows)
+                           ->  BitmapOr  (cost=0.00..0.00 rows=0 width=0)
+                                 ->  Bitmap Index Scan on i_bmtest_ao_b  (cost=0.00..0.00 rows=0 width=0)
+                                       Index Cond: (b = 1)
+                                 ->  Bitmap Index Scan on i_bmtest_ao_c  (cost=0.00..0.00 rows=0 width=0)
+                                       Index Cond: (c = 1)
+                           ->  BitmapAnd  (cost=0.00..0.00 rows=0 width=0)
+                                 ->  Bitmap Index Scan on i_bmtest_ao_d  (cost=0.00..0.00 rows=0 width=0)
+                                       Index Cond: (d = 1)
+                                 ->  Bitmap Index Scan on i_bmtest_ao_a  (cost=0.00..0.00 rows=0 width=0)
+                                       Index Cond: (a = 1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(17 rows)
 
 SELECT count(*) FROM bmscantest_ao WHERE a = 1 AND (b = 1 OR c = 1) AND d = 1;
  count 
@@ -236,22 +239,23 @@ CREATE INDEX i_bmtest_aocs_b ON bmscantest_aocs USING BITMAP(b);
 CREATE INDEX i_bmtest_aocs_c ON bmscantest_aocs(c);
 CREATE INDEX i_bmtest_aocs_d ON bmscantest_aocs(d);
 EXPLAIN SELECT count(*) FROM bmscantest_aocs WHERE a = 1 AND b = 1 AND c = 1;
-                                              QUERY PLAN                                              
-------------------------------------------------------------------------------------------------------
- Aggregate  (cost=0.00..431.06 rows=1 width=8)
-   ->  Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..431.06 rows=2 width=1)
-         ->  Bitmap Heap Scan on bmscantest_aocs  (cost=0.00..431.06 rows=1 width=1)
-               Recheck Cond: ((b = 1) AND (a = 1) AND (c = 1))
-               ->  BitmapAnd  (cost=0.00..0.00 rows=0 width=0)
+                                                 QUERY PLAN                                                 
+------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate  (cost=0.00..431.06 rows=1 width=8)
+   ->  Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..431.06 rows=1 width=8)
+         ->  Partial Aggregate  (cost=0.00..431.06 rows=1 width=8)
+               ->  Bitmap Heap Scan on bmscantest_aocs  (cost=0.00..431.06 rows=1 width=1)
+                     Recheck Cond: ((b = 1) AND (a = 1) AND (c = 1))
                      ->  BitmapAnd  (cost=0.00..0.00 rows=0 width=0)
-                           ->  Bitmap Index Scan on i_bmtest_aocs_b  (cost=0.00..0.00 rows=0 width=0)
-                                 Index Cond: (b = 1)
-                           ->  Bitmap Index Scan on i_bmtest_aocs_a  (cost=0.00..0.00 rows=0 width=0)
-                                 Index Cond: (a = 1)
-                     ->  Bitmap Index Scan on i_bmtest_aocs_c  (cost=0.00..0.00 rows=0 width=0)
-                           Index Cond: (c = 1)
+                           ->  BitmapAnd  (cost=0.00..0.00 rows=0 width=0)
+                                 ->  Bitmap Index Scan on i_bmtest_aocs_b  (cost=0.00..0.00 rows=0 width=0)
+                                       Index Cond: (b = 1)
+                                 ->  Bitmap Index Scan on i_bmtest_aocs_a  (cost=0.00..0.00 rows=0 width=0)
+                                       Index Cond: (a = 1)
+                           ->  Bitmap Index Scan on i_bmtest_aocs_c  (cost=0.00..0.00 rows=0 width=0)
+                                 Index Cond: (c = 1)
  Optimizer: Pivotal Optimizer (GPORCA)
-(13 rows)
+(14 rows)
 
 SELECT count(*) FROM bmscantest_aocs WHERE a = 1 AND b = 1 AND c = 1;
  count 
@@ -260,25 +264,26 @@ SELECT count(*) FROM bmscantest_aocs WHERE a = 1 AND b = 1 AND c = 1;
 (1 row)
 
 EXPLAIN SELECT count(*) FROM bmscantest_aocs WHERE a = 1 AND (b = 1 OR c = 1) AND d = 1;
-                                              QUERY PLAN                                              
-------------------------------------------------------------------------------------------------------
- Aggregate  (cost=0.00..431.06 rows=1 width=8)
-   ->  Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..431.06 rows=3 width=1)
-         ->  Bitmap Heap Scan on bmscantest_aocs  (cost=0.00..431.06 rows=1 width=1)
-               Recheck Cond: (((b = 1) OR (c = 1)) AND ((d = 1) AND (a = 1)))
-               ->  BitmapAnd  (cost=0.00..0.00 rows=0 width=0)
-                     ->  BitmapOr  (cost=0.00..0.00 rows=0 width=0)
-                           ->  Bitmap Index Scan on i_bmtest_aocs_b  (cost=0.00..0.00 rows=0 width=0)
-                                 Index Cond: (b = 1)
-                           ->  Bitmap Index Scan on i_bmtest_aocs_c  (cost=0.00..0.00 rows=0 width=0)
-                                 Index Cond: (c = 1)
+                                                 QUERY PLAN                                                 
+------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate  (cost=0.00..431.06 rows=1 width=8)
+   ->  Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..431.06 rows=1 width=8)
+         ->  Partial Aggregate  (cost=0.00..431.06 rows=1 width=8)
+               ->  Bitmap Heap Scan on bmscantest_aocs  (cost=0.00..431.06 rows=1 width=1)
+                     Recheck Cond: (((b = 1) OR (c = 1)) AND ((d = 1) AND (a = 1)))
                      ->  BitmapAnd  (cost=0.00..0.00 rows=0 width=0)
-                           ->  Bitmap Index Scan on i_bmtest_aocs_d  (cost=0.00..0.00 rows=0 width=0)
-                                 Index Cond: (d = 1)
-                           ->  Bitmap Index Scan on i_bmtest_aocs_a  (cost=0.00..0.00 rows=0 width=0)
-                                 Index Cond: (a = 1)
+                           ->  BitmapOr  (cost=0.00..0.00 rows=0 width=0)
+                                 ->  Bitmap Index Scan on i_bmtest_aocs_b  (cost=0.00..0.00 rows=0 width=0)
+                                       Index Cond: (b = 1)
+                                 ->  Bitmap Index Scan on i_bmtest_aocs_c  (cost=0.00..0.00 rows=0 width=0)
+                                       Index Cond: (c = 1)
+                           ->  BitmapAnd  (cost=0.00..0.00 rows=0 width=0)
+                                 ->  Bitmap Index Scan on i_bmtest_aocs_d  (cost=0.00..0.00 rows=0 width=0)
+                                       Index Cond: (d = 1)
+                                 ->  Bitmap Index Scan on i_bmtest_aocs_a  (cost=0.00..0.00 rows=0 width=0)
+                                       Index Cond: (a = 1)
  Optimizer: Pivotal Optimizer (GPORCA)
-(16 rows)
+(17 rows)
 
 SELECT count(*) FROM bmscantest_aocs WHERE a = 1 AND (b = 1 OR c = 1) AND d = 1;
  count 

--- a/src/test/regress/expected/create_index_optimizer.out
+++ b/src/test/regress/expected/create_index_optimizer.out
@@ -408,15 +408,16 @@ SELECT count(*) FROM gcircle_tbl WHERE f1 && '<(500,500),500>'::circle;
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM point_tbl WHERE f1 <@ box '(0,0,100,100)';
-                        QUERY PLAN                        
-----------------------------------------------------------
- Aggregate
+                           QUERY PLAN                           
+----------------------------------------------------------------
+ Finalize Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Index Scan using gpointind on point_tbl
-               Index Cond: (f1 <@ '(100,100),(0,0)'::box)
-               Filter: (f1 <@ '(100,100),(0,0)'::box)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
-(6 rows)
+         ->  Partial Aggregate
+               ->  Index Scan using gpointind on point_tbl
+                     Index Cond: (f1 <@ '(100,100),(0,0)'::box)
+                     Filter: (f1 <@ '(100,100),(0,0)'::box)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(7 rows)
 
 SELECT count(*) FROM point_tbl WHERE f1 <@ box '(0,0,100,100)';
  count 
@@ -426,15 +427,16 @@ SELECT count(*) FROM point_tbl WHERE f1 <@ box '(0,0,100,100)';
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM point_tbl WHERE box '(0,0,100,100)' @> f1;
-                        QUERY PLAN                        
-----------------------------------------------------------
- Aggregate
+                           QUERY PLAN                           
+----------------------------------------------------------------
+ Finalize Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Index Scan using gpointind on point_tbl
-               Index Cond: (f1 <@ '(100,100),(0,0)'::box)
-               Filter: (f1 <@ '(100,100),(0,0)'::box)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
-(6 rows)
+         ->  Partial Aggregate
+               ->  Index Scan using gpointind on point_tbl
+                     Index Cond: (f1 <@ '(100,100),(0,0)'::box)
+                     Filter: (f1 <@ '(100,100),(0,0)'::box)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(7 rows)
 
 SELECT count(*) FROM point_tbl WHERE box '(0,0,100,100)' @> f1;
  count 
@@ -444,15 +446,16 @@ SELECT count(*) FROM point_tbl WHERE box '(0,0,100,100)' @> f1;
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM point_tbl WHERE f1 <@ polygon '(0,0),(0,100),(100,100),(50,50),(100,0),(0,0)';
-                                          QUERY PLAN                                          
-----------------------------------------------------------------------------------------------
- Aggregate
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
+ Finalize Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Index Scan using gpointind on point_tbl
-               Index Cond: (f1 <@ '((0,0),(0,100),(100,100),(50,50),(100,0),(0,0))'::polygon)
-               Filter: (f1 <@ '((0,0),(0,100),(100,100),(50,50),(100,0),(0,0))'::polygon)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
-(6 rows)
+         ->  Partial Aggregate
+               ->  Index Scan using gpointind on point_tbl
+                     Index Cond: (f1 <@ '((0,0),(0,100),(100,100),(50,50),(100,0),(0,0))'::polygon)
+                     Filter: (f1 <@ '((0,0),(0,100),(100,100),(50,50),(100,0),(0,0))'::polygon)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(7 rows)
 
 SELECT count(*) FROM point_tbl WHERE f1 <@ polygon '(0,0),(0,100),(100,100),(50,50),(100,0),(0,0)';
  count 
@@ -462,15 +465,16 @@ SELECT count(*) FROM point_tbl WHERE f1 <@ polygon '(0,0),(0,100),(100,100),(50,
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM point_tbl WHERE f1 <@ circle '<(50,50),50>';
-                        QUERY PLAN                        
-----------------------------------------------------------
- Aggregate
+                           QUERY PLAN                           
+----------------------------------------------------------------
+ Finalize Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Index Scan using gpointind on point_tbl
-               Index Cond: (f1 <@ '<(50,50),50>'::circle)
-               Filter: (f1 <@ '<(50,50),50>'::circle)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
-(6 rows)
+         ->  Partial Aggregate
+               ->  Index Scan using gpointind on point_tbl
+                     Index Cond: (f1 <@ '<(50,50),50>'::circle)
+                     Filter: (f1 <@ '<(50,50),50>'::circle)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(7 rows)
 
 SELECT count(*) FROM point_tbl WHERE f1 <@ circle '<(50,50),50>';
  count 
@@ -480,15 +484,16 @@ SELECT count(*) FROM point_tbl WHERE f1 <@ circle '<(50,50),50>';
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM point_tbl p WHERE p.f1 << '(0.0, 0.0)';
-                     QUERY PLAN                      
------------------------------------------------------
- Aggregate
+                        QUERY PLAN                         
+-----------------------------------------------------------
+ Finalize Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Index Scan using gpointind on point_tbl
-               Index Cond: (f1 << '(0,0)'::point)
-               Filter: (f1 << '(0,0)'::point)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
-(6 rows)
+         ->  Partial Aggregate
+               ->  Index Scan using gpointind on point_tbl
+                     Index Cond: (f1 << '(0,0)'::point)
+                     Filter: (f1 << '(0,0)'::point)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(7 rows)
 
 SELECT count(*) FROM point_tbl p WHERE p.f1 << '(0.0, 0.0)';
  count 
@@ -498,15 +503,16 @@ SELECT count(*) FROM point_tbl p WHERE p.f1 << '(0.0, 0.0)';
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM point_tbl p WHERE p.f1 >> '(0.0, 0.0)';
-                     QUERY PLAN                      
------------------------------------------------------
- Aggregate
+                        QUERY PLAN                         
+-----------------------------------------------------------
+ Finalize Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Index Scan using gpointind on point_tbl
-               Index Cond: (f1 >> '(0,0)'::point)
-               Filter: (f1 >> '(0,0)'::point)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
-(6 rows)
+         ->  Partial Aggregate
+               ->  Index Scan using gpointind on point_tbl
+                     Index Cond: (f1 >> '(0,0)'::point)
+                     Filter: (f1 >> '(0,0)'::point)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(7 rows)
 
 SELECT count(*) FROM point_tbl p WHERE p.f1 >> '(0.0, 0.0)';
  count 
@@ -516,15 +522,16 @@ SELECT count(*) FROM point_tbl p WHERE p.f1 >> '(0.0, 0.0)';
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM point_tbl p WHERE p.f1 <^ '(0.0, 0.0)';
-                     QUERY PLAN                      
------------------------------------------------------
- Aggregate
+                        QUERY PLAN                         
+-----------------------------------------------------------
+ Finalize Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Index Scan using gpointind on point_tbl
-               Index Cond: (f1 <^ '(0,0)'::point)
-               Filter: (f1 <^ '(0,0)'::point)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
-(6 rows)
+         ->  Partial Aggregate
+               ->  Index Scan using gpointind on point_tbl
+                     Index Cond: (f1 <^ '(0,0)'::point)
+                     Filter: (f1 <^ '(0,0)'::point)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(7 rows)
 
 SELECT count(*) FROM point_tbl p WHERE p.f1 <^ '(0.0, 0.0)';
  count 
@@ -534,15 +541,16 @@ SELECT count(*) FROM point_tbl p WHERE p.f1 <^ '(0.0, 0.0)';
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM point_tbl p WHERE p.f1 >^ '(0.0, 0.0)';
-                     QUERY PLAN                      
------------------------------------------------------
- Aggregate
+                        QUERY PLAN                         
+-----------------------------------------------------------
+ Finalize Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Index Scan using gpointind on point_tbl
-               Index Cond: (f1 >^ '(0,0)'::point)
-               Filter: (f1 >^ '(0,0)'::point)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
-(6 rows)
+         ->  Partial Aggregate
+               ->  Index Scan using gpointind on point_tbl
+                     Index Cond: (f1 >^ '(0,0)'::point)
+                     Filter: (f1 >^ '(0,0)'::point)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(7 rows)
 
 SELECT count(*) FROM point_tbl p WHERE p.f1 >^ '(0.0, 0.0)';
  count 
@@ -552,15 +560,16 @@ SELECT count(*) FROM point_tbl p WHERE p.f1 >^ '(0.0, 0.0)';
 
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM point_tbl p WHERE p.f1 ~= '(-5, -12)';
-                     QUERY PLAN                      
------------------------------------------------------
- Aggregate
+                        QUERY PLAN                         
+-----------------------------------------------------------
+ Finalize Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Index Scan using gpointind on point_tbl
-               Index Cond: (f1 ~= '(-5,-12)'::point)
-               Filter: (f1 ~= '(-5,-12)'::point)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
-(6 rows)
+         ->  Partial Aggregate
+               ->  Index Scan using gpointind on point_tbl
+                     Index Cond: (f1 ~= '(-5,-12)'::point)
+                     Filter: (f1 ~= '(-5,-12)'::point)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(7 rows)
 
 SELECT count(*) FROM point_tbl p WHERE p.f1 ~= '(-5, -12)';
  count 
@@ -1925,15 +1934,16 @@ SELECT * FROM tenk1
 EXPLAIN (COSTS OFF)
 SELECT count(*) FROM tenk1
   WHERE hundred = 42 AND (thousand = 42 OR thousand = 99);
-                         QUERY PLAN                         
-------------------------------------------------------------
- Aggregate
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Finalize Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Index Scan using tenk1_hundred on tenk1
-               Index Cond: (hundred = 42)
-               Filter: ((thousand = 42) OR (thousand = 99))
+         ->  Partial Aggregate
+               ->  Index Scan using tenk1_hundred on tenk1
+                     Index Cond: (hundred = 42)
+                     Filter: ((thousand = 42) OR (thousand = 99))
  Optimizer: Pivotal Optimizer (GPORCA)
-(6 rows)
+(7 rows)
 
 SELECT count(*) FROM tenk1
   WHERE hundred = 42 AND (thousand = 42 OR thousand = 99);

--- a/src/test/regress/expected/direct_dispatch_optimizer.out
+++ b/src/test/regress/expected/direct_dispatch_optimizer.out
@@ -672,15 +672,19 @@ explain (costs off) select gp_segment_id, count(*) from bar_randDistr group by g
                             QUERY PLAN                            
 ------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  GroupAggregate
+   ->  Finalize GroupAggregate
          Group Key: gp_segment_id
          ->  Sort
                Sort Key: gp_segment_id
                ->  Redistribute Motion 3:3  (slice2; segments: 3)
                      Hash Key: gp_segment_id
-                     ->  Seq Scan on bar_randdistr
+                     ->  Partial GroupAggregate
+                           Group Key: gp_segment_id
+                           ->  Sort
+                                 Sort Key: gp_segment_id
+                                 ->  Seq Scan on bar_randdistr
  Optimizer: Pivotal Optimizer (GPORCA)
-(9 rows)
+(13 rows)
 
 -- Case2: Conjunction scenario with filter condition on gp_segment_id and column
 explain (costs off) select gp_segment_id, * from bar_randDistr where gp_segment_id=0 and col1 between 1 and 10;

--- a/src/test/regress/expected/dpe_optimizer.out
+++ b/src/test/regress/expected/dpe_optimizer.out
@@ -244,10 +244,16 @@ explain (costs off, timing off, summary off, analyze) select * from pt where pti
                                        Executor Memory: 178kB  Segments: 3  Max: 60kB (segment 0)
                                        ->  Redistribute Motion 3:3  (slice3; segments: 3) (actual rows=2 loops=1)
                                              Hash Key: t.tid
-                                             ->  Seq Scan on t (actual rows=2 loops=1)
-                                                   Filter: (t1 = ('hello'::text || (tid)::text))
+                                             ->  GroupAggregate (actual rows=2 loops=1)
+                                                   Group Key: t.tid
+                                                   ->  Sort (actual rows=2 loops=1)
+                                                         Sort Key: t.tid
+                                                         Sort Method:  quicksort  Memory: 75kB
+                                                         Executor Memory: 178kB  Segments: 3  Max: 60kB (segment 0)
+                                                         ->  Seq Scan on t (actual rows=2 loops=1)
+                                                               Filter: (t1 = ('hello'::text || (tid)::text))
  Optimizer: Pivotal Optimizer (GPORCA)
-(20 rows)
+(28 rows)
 
 select * from pt where ptid in (select tid from t where t1 = 'hello' || tid);
  dist |   pt1   |  pt2  |    pt3    | ptid 
@@ -298,10 +304,16 @@ explain (costs off, timing off, summary off, analyze) select * from pt where exi
                                        Executor Memory: 76kB  Segments: 3  Max: 26kB (segment 1)
                                        ->  Redistribute Motion 3:3  (slice3; segments: 3) (actual rows=2 loops=1)
                                              Hash Key: t.tid
-                                             ->  Seq Scan on t (actual rows=2 loops=1)
-                                                   Filter: (t1 = ('hello'::text || (tid)::text))
+                                             ->  GroupAggregate (actual rows=2 loops=1)
+                                                   Group Key: t.tid
+                                                   ->  Sort (actual rows=2 loops=1)
+                                                         Sort Key: t.tid
+                                                         Sort Method:  quicksort  Memory: 75kB
+                                                         Executor Memory: 76kB  Segments: 3  Max: 26kB (segment 1)
+                                                         ->  Seq Scan on t (actual rows=2 loops=1)
+                                                               Filter: (t1 = ('hello'::text || (tid)::text))
  Optimizer: Pivotal Optimizer (GPORCA)
-(21 rows)
+(29 rows)
 
 select * from pt where exists (select 1 from t where tid = ptid and t1 = 'hello' || tid);
  dist |   pt1   |  pt2  |    pt3    | ptid 

--- a/src/test/regress/expected/eagerfree_optimizer.out
+++ b/src/test/regress/expected/eagerfree_optimizer.out
@@ -41,26 +41,29 @@ select d, count(*) from smallt group by d;
 (20 rows)
 
 explain analyze select d, count(*) from smallt group by d;
-                                                                    QUERY PLAN                                                                    
---------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.01 rows=20 width=12) (actual time=1.785..1.787 rows=20 loops=1)
-   ->  GroupAggregate  (cost=0.00..431.01 rows=7 width=12) (actual time=1.513..1.522 rows=7 loops=1)
+                                                                QUERY PLAN                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.01 rows=20 width=12) (actual time=4.569..4.579 rows=20 loops=1)
+   ->  Finalize HashAggregate  (cost=0.00..431.01 rows=7 width=12) (actual time=4.288..4.292 rows=7 loops=1)
          Group Key: d
-         ->  Sort  (cost=0.00..431.01 rows=34 width=4) (actual time=1.510..1.513 rows=35 loops=1)
-               Sort Key: d
-               Sort Method:  quicksort  Memory: 99kB
-               Executor Memory: 79kB  Segments: 3  Max: 27kB (segment 1)
-               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=34 width=4) (actual time=0.342..1.481 rows=35 loops=1)
-                     Hash Key: d
-                     ->  Seq Scan on smallt  (cost=0.00..431.00 rows=34 width=4) (actual time=0.002..0.004 rows=50 loops=1)
- Planning time: 17.216 ms
-   (slice0)    Executor memory: 63K bytes.
-   (slice1)    Executor memory: 42K bytes avg x 3 workers, 42K bytes max (seg0).
-   (slice2)    Executor memory: 64K bytes avg x 3 workers, 64K bytes max (seg0).  Work_mem: 33K bytes max.
+         Peak Memory Usage: 0 kB
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.01 rows=7 width=12) (actual time=3.857..4.268 rows=7 loops=1)
+               Hash Key: d
+               ->  Partial GroupAggregate  (cost=0.00..431.01 rows=7 width=12) (actual time=0.621..0.663 rows=10 loops=1)
+                     Group Key: d
+                     ->  Sort  (cost=0.00..431.00 rows=34 width=4) (actual time=0.613..0.639 rows=50 loops=1)
+                           Sort Key: d
+                           Sort Method:  quicksort  Memory: 79kB
+                           Executor Memory: 79kB  Segments: 3  Max: 27kB (segment 0)
+                           ->  Seq Scan on smallt  (cost=0.00..431.00 rows=34 width=4) (actual time=0.570..0.584 rows=50 loops=1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Planning Time: 7.472 ms
+   (slice0)    Executor memory: 42K bytes.
+   (slice1)    Executor memory: 19K bytes avg x 3 workers, 19K bytes max (seg1).  Work_mem: 24K bytes max.
+   (slice2)    Executor memory: 39K bytes avg x 3 workers, 39K bytes max (seg0).  Work_mem: 27K bytes max.
  Memory used:  128000kB
- Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
- Execution time: 2.061 ms
-(17 rows)
+ Execution Time: 5.246 ms
+(20 rows)
 
 select * from
   test_util.extract_plan_stats($$
@@ -112,22 +115,33 @@ select count(distinct d) from smallt;
 (1 row)
 
 explain analyze select count(distinct d) from smallt;
-                                                                    QUERY PLAN                                                                    
---------------------------------------------------------------------------------------------------------------------------------------------------
- Finalize Aggregate  (cost=0.00..431.00 rows=1 width=8) (actual time=1.637..1.637 rows=1 loops=1)
-   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=8) (actual time=1.631..1.633 rows=3 loops=1)
-         ->  Partial Aggregate  (cost=0.00..431.00 rows=1 width=8) (actual time=1.408..1.408 rows=1 loops=1)
-               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=34 width=4) (actual time=1.396..1.402 rows=35 loops=1)
-                     Hash Key: d
-                     ->  Seq Scan on smallt  (cost=0.00..431.00 rows=34 width=4) (actual time=0.002..0.006 rows=50 loops=1)
- Planning time: 19.307 ms
-   (slice0)    Executor memory: 59K bytes.
-   (slice1)    Executor memory: 42K bytes avg x 3 workers, 42K bytes max (seg0).
-   (slice2)    Executor memory: 64K bytes avg x 3 workers, 64K bytes max (seg0).  Work_mem: 33K bytes max.
+                                                                      QUERY PLAN                                                                      
+------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..431.01 rows=1 width=8) (actual time=2.581..2.582 rows=1 loops=1)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.01 rows=20 width=4) (actual time=2.564..2.572 rows=20 loops=1)
+         ->  GroupAggregate  (cost=0.00..431.01 rows=7 width=4) (actual time=2.201..2.228 rows=7 loops=1)
+               Group Key: d
+               ->  Sort  (cost=0.00..431.01 rows=7 width=4) (actual time=2.194..2.197 rows=7 loops=1)
+                     Sort Key: d
+                     Sort Method:  quicksort  Memory: 75kB
+                     Executor Memory: 76kB  Segments: 3  Max: 26kB (segment 1)
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.01 rows=7 width=4) (actual time=1.939..2.186 rows=7 loops=1)
+                           Hash Key: d
+                           ->  GroupAggregate  (cost=0.00..431.01 rows=7 width=4) (actual time=0.292..0.318 rows=10 loops=1)
+                                 Group Key: d
+                                 ->  Sort  (cost=0.00..431.00 rows=34 width=4) (actual time=0.286..0.301 rows=50 loops=1)
+                                       Sort Key: d
+                                       Sort Method:  quicksort  Memory: 79kB
+                                       Executor Memory: 79kB  Segments: 3  Max: 27kB (segment 0)
+                                       ->  Seq Scan on smallt  (cost=0.00..431.00 rows=34 width=4) (actual time=0.211..0.238 rows=50 loops=1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Planning Time: 8.216 ms
+   (slice0)    Executor memory: 47K bytes.
+   (slice1)    Executor memory: 43K bytes avg x 3 workers, 43K bytes max (seg1).  Work_mem: 26K bytes max.
+   (slice2)    Executor memory: 39K bytes avg x 3 workers, 39K bytes max (seg0).  Work_mem: 27K bytes max.
  Memory used:  128000kB
- Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
- Execution time: 1.904 ms
-(13 rows)
+ Execution Time: 3.390 ms
+(24 rows)
 
 set statement_mem=2560;
 select count(distinct d) from bigt;
@@ -137,23 +151,27 @@ select count(distinct d) from bigt;
 (1 row)
 
 explain analyze select count(distinct d) from bigt;
-                                                                         QUERY PLAN                                                                         
-------------------------------------------------------------------------------------------------------------------------------------------------------------
- Finalize Aggregate  (cost=0.00..446.60 rows=1 width=8) (actual time=394.139..394.139 rows=1 loops=1)
-   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..446.60 rows=1 width=8) (actual time=388.126..394.130 rows=3 loops=1)
-         ->  Partial Aggregate  (cost=0.00..446.60 rows=1 width=8) (actual time=393.902..393.903 rows=1 loops=1)
-               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..446.45 rows=333334 width=4) (actual time=0.670..118.334 rows=334920 loops=1)
+                                                                        QUERY PLAN                                                                         
+-----------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..485.86 rows=1 width=8) (actual time=225.557..225.558 rows=1 loops=1)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..485.84 rows=50255 width=4) (actual time=202.093..218.151 rows=50000 loops=1)
+         ->  HashAggregate  (cost=0.00..485.09 rows=16752 width=4) (actual time=201.285..211.834 rows=16746 loops=1)
+               Group Key: d
+               Peak Memory Usage: 0 kB
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..483.03 rows=16752 width=4) (actual time=58.428..184.750 rows=27966 loops=1)
                      Hash Key: d
-                     ->  Seq Scan on bigt  (cost=0.00..439.80 rows=333334 width=4) (actual time=0.013..46.779 rows=334620 loops=1)
- Planning time: 27.350 ms
-   (slice0)    Executor memory: 59K bytes.
-   (slice1)    Executor memory: 68K bytes avg x 3 workers, 68K bytes max (seg0).
- * (slice2)    Executor memory: 2768K bytes avg x 3 workers, 2768K bytes max (seg0).  Work_mem: 2617K bytes max, 7876K bytes wanted.
+                     ->  Streaming HashAggregate  (cost=0.00..482.82 rows=16752 width=4) (actual time=56.534..182.870 rows=27917 loops=1)
+                           Group Key: d
+                           Peak Memory Usage: 0 kB
+                           ->  Seq Scan on bigt  (cost=0.00..439.80 rows=333334 width=4) (actual time=0.124..68.046 rows=334620 loops=1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Planning Time: 7.376 ms
+   (slice0)    Executor memory: 829K bytes.
+   (slice1)    Executor memory: 876K bytes avg x 3 workers, 876K bytes max (seg0).  Work_mem: 1553K bytes max.
+   (slice2)    Executor memory: 705K bytes avg x 3 workers, 705K bytes max (seg0).  Work_mem: 1425K bytes max.
  Memory used:  2560kB
- Memory wanted:  8275kB
- Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
- Execution time: 394.389 ms
-(14 rows)
+ Execution Time: 225.988 ms
+(18 rows)
 
 set statement_mem=128000;
 set gp_enable_agg_distinct=on;
@@ -194,39 +212,44 @@ where t1.d = t2.d;
 explain analyze select t1.*, t2.* from
 (select d, count(*) from smallt group by d) as t1, (select d, sum(i) from smallt group by d) as t2
 where t1.d = t2.d;
-                                                                              QUERY PLAN                                                                               
------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..862.02 rows=20 width=24) (actual time=1.873..1.922 rows=20 loops=1)
-   ->  Hash Join  (cost=0.00..862.02 rows=7 width=24) (actual time=1.498..1.631 rows=7 loops=1)
+                                                                      QUERY PLAN                                                                       
+-------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.02 rows=20 width=24) (actual time=3.382..3.462 rows=20 loops=1)
+   ->  Hash Join  (cost=0.00..862.02 rows=7 width=24) (actual time=2.744..3.066 rows=7 loops=1)
          Hash Cond: (smallt.d = smallt_1.d)
-         Extra Text: (seg1)   Hash chain length 1.0 avg, 1 max, using 7 of 131072 buckets.Hash chain length 1.2 avg, 2 max, using 6 of 32 buckets; total 0 expansions.
- 
-         ->  GroupAggregate  (cost=0.00..431.01 rows=7 width=12) (actual time=0.032..0.038 rows=7 loops=1)
+         Extra Text: (seg1)   Hash chain length 1.0 avg, 1 max, using 7 of 131072 buckets.
+         ->  Finalize HashAggregate  (cost=0.00..431.01 rows=7 width=12) (actual time=0.135..0.138 rows=7 loops=1)
                Group Key: smallt.d
-               ->  Sort  (cost=0.00..431.01 rows=34 width=4) (actual time=0.029..0.032 rows=35 loops=1)
-                     Sort Key: smallt.d
-                     Sort Method:  quicksort  Memory: 99kB
-                     Executor Memory: 79kB  Segments: 3  Max: 27kB (segment 1)
-                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=34 width=4) (actual time=0.004..0.011 rows=35 loops=1)
-                           Hash Key: smallt.d
-                           ->  Seq Scan on smallt  (cost=0.00..431.00 rows=34 width=4) (actual time=0.003..0.018 rows=50 loops=1)
-         ->  Hash  (cost=431.01..431.01 rows=7 width=12) (actual time=1.402..1.402 rows=7 loops=1)
-               ->  HashAggregate  (cost=0.00..431.01 rows=7 width=12) (actual time=1.388..1.398 rows=7 loops=1)
+               Peak Memory Usage: 0 kB
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.01 rows=7 width=12) (actual time=0.004..0.112 rows=7 loops=1)
+                     Hash Key: smallt.d
+                     ->  Partial GroupAggregate  (cost=0.00..431.01 rows=7 width=12) (actual time=0.288..0.314 rows=10 loops=1)
+                           Group Key: smallt.d
+                           ->  Sort  (cost=0.00..431.00 rows=34 width=4) (actual time=0.280..0.292 rows=50 loops=1)
+                                 Sort Key: smallt.d
+                                 Sort Method:  quicksort  Memory: 79kB
+                                 Executor Memory: 79kB  Segments: 3  Max: 27kB (segment 0)
+                                 ->  Seq Scan on smallt  (cost=0.00..431.00 rows=34 width=4) (actual time=0.245..0.258 rows=50 loops=1)
+         ->  Hash  (cost=431.01..431.01 rows=7 width=12) (actual time=2.479..2.479 rows=7 loops=1)
+               Buckets: 131072  Batches: 1  Memory Usage: 1025kB
+               ->  Finalize HashAggregate  (cost=0.00..431.01 rows=7 width=12) (actual time=2.467..2.471 rows=7 loops=1)
                      Group Key: smallt_1.d
-                     Extra Text: (seg1)   Hash chain length 1.2 avg, 2 max, using 6 of 32 buckets; total 0 expansions.
- 
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=34 width=8) (actual time=0.245..1.337 rows=35 loops=1)
+                     Peak Memory Usage: 0 kB
+                     ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.01 rows=7 width=12) (actual time=2.280..2.449 rows=7 loops=1)
                            Hash Key: smallt_1.d
-                           ->  Seq Scan on smallt smallt_1  (cost=0.00..431.00 rows=34 width=8) (actual time=0.003..0.018 rows=50 loops=1)
- Planning time: 64.498 ms
-   (slice0)    Executor memory: 127K bytes.
-   (slice1)    Executor memory: 44K bytes avg x 3 workers, 44K bytes max (seg0).
-   (slice2)    Executor memory: 44K bytes avg x 3 workers, 44K bytes max (seg0).
-   (slice3)    Executor memory: 1192K bytes avg x 3 workers, 1192K bytes max (seg0).  Work_mem: 33K bytes max.
+                           ->  Streaming Partial HashAggregate  (cost=0.00..431.01 rows=7 width=12) (actual time=0.481..0.485 rows=10 loops=1)
+                                 Group Key: smallt_1.d
+                                 Peak Memory Usage: 0 kB
+                                 ->  Seq Scan on smallt smallt_1  (cost=0.00..431.00 rows=34 width=8) (actual time=0.438..0.451 rows=50 loops=1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Planning Time: 19.398 ms
+   (slice0)    Executor memory: 83K bytes.
+   (slice1)    Executor memory: 1096K bytes avg x 3 workers, 1096K bytes max (seg2).  Work_mem: 1025K bytes max.
+   (slice2)    Executor memory: 40K bytes avg x 3 workers, 40K bytes max (seg0).  Work_mem: 27K bytes max.
+   (slice3)    Executor memory: 38K bytes avg x 3 workers, 38K bytes max (seg0).  Work_mem: 24K bytes max.
  Memory used:  128000kB
- Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
- Execution time: 2.226 ms
-(29 rows)
+ Execution Time: 4.233 ms
+(35 rows)
 
 select * from
   test_util.extract_plan_stats($$
@@ -273,30 +296,32 @@ explain analyze select t1.*, t2.* from
 where t1.i = t2.i;
                                                                 QUERY PLAN                                                                 
 -------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.01 rows=10 width=24) (actual time=0.501..0.740 rows=5 loops=2)
-   ->  Hash Join  (cost=0.00..862.01 rows=4 width=24) (actual time=0.166..0.460 rows=2 loops=2)
-         Hash Cond: smallt.i = smallt_1.i
-         Extra Text: (seg0)   Hash chain length 1.0 avg, 1 max, using 4 of 131072 buckets.
-         ->  GroupAggregate  (cost=0.00..431.01 rows=4 width=12) (actual time=0.041..0.055 rows=2 loops=2)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.01 rows=10 width=24) (actual time=0.916..1.362 rows=10 loops=1)
+   ->  Hash Join  (cost=0.00..862.01 rows=4 width=24) (actual time=0.350..0.688 rows=5 loops=1)
+         Hash Cond: (smallt.i = smallt_1.i)
+         Extra Text: (seg0)   Hash chain length 1.0 avg, 1 max, using 5 of 131072 buckets.
+         ->  GroupAggregate  (cost=0.00..431.01 rows=4 width=12) (actual time=0.039..0.065 rows=5 loops=1)
                Group Key: smallt.i
-               ->  Sort  (cost=0.00..431.00 rows=34 width=4) (actual time=0.036..0.042 rows=20 loops=2)
+               ->  Sort  (cost=0.00..431.00 rows=34 width=4) (actual time=0.033..0.050 rows=50 loops=1)
                      Sort Key: smallt.i
-                     Sort Method:  quicksort  Memory: 99kB
+                     Sort Method:  quicksort  Memory: 79kB
                      Executor Memory: 79kB  Segments: 3  Max: 27kB (segment 0)
-                     ->  Seq Scan on smallt  (cost=0.00..431.00 rows=34 width=4) (actual time=0.004..0.013 rows=20 loops=2)
-         ->  Hash  (cost=431.01..431.01 rows=4 width=12) (actual time=0.072..0.072 rows=2 loops=2)
-               ->  GroupAggregate  (cost=0.00..431.01 rows=4 width=12) (actual time=0.053..0.069 rows=2 loops=2)
+                     ->  Seq Scan on smallt  (cost=0.00..431.00 rows=34 width=4) (actual time=0.006..0.016 rows=50 loops=1)
+         ->  Hash  (cost=431.01..431.01 rows=4 width=12) (actual time=0.265..0.265 rows=5 loops=1)
+               Buckets: 131072  Batches: 1  Memory Usage: 1025kB
+               ->  GroupAggregate  (cost=0.00..431.01 rows=4 width=12) (actual time=0.239..0.259 rows=5 loops=1)
                      Group Key: smallt_1.i
-                     ->  Sort  (cost=0.00..431.00 rows=34 width=4) (actual time=0.048..0.053 rows=20 loops=2)
+                     ->  Sort  (cost=0.00..431.00 rows=34 width=4) (actual time=0.229..0.240 rows=50 loops=1)
                            Sort Key: smallt_1.i
-                           Sort Method:  quicksort  Memory: 99kB
+                           Sort Method:  quicksort  Memory: 79kB
                            Executor Memory: 79kB  Segments: 3  Max: 27kB (segment 0)
-                           ->  Seq Scan on smallt smallt_1  (cost=0.00..431.00 rows=34 width=4) (actual time=0.012..0.022 rows=20 loops=2)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 1238K bytes avg x 3 workers, 1238K bytes max (seg0).  Work_mem: 33K bytes max.
+                           ->  Seq Scan on smallt smallt_1  (cost=0.00..431.00 rows=34 width=4) (actual time=0.199..0.210 rows=50 loops=1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Planning Time: 14.435 ms
+   (slice0)    Executor memory: 55K bytes.
+   (slice1)    Executor memory: 1105K bytes avg x 3 workers, 1105K bytes max (seg0).  Work_mem: 1025K bytes max.
  Memory used:  128000kB
- Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
- Total runtime: 2.471 ms
+ Execution Time: 2.105 ms
 (26 rows)
 
 select * from
@@ -328,28 +353,31 @@ select d, count(*) from smallt group by d limit 5; --ignore
 (5 rows)
 
 explain analyze select d, count(*) from smallt group by d limit 5;
-                                                                          QUERY PLAN                                                                          
---------------------------------------------------------------------------------------------------------------------------------------------------------------
- Limit  (cost=0.00..431.01 rows=2 width=12) (actual time=1.700..1.702 rows=5 loops=1)
-   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.01 rows=5 width=12) (actual time=1.698..1.700 rows=5 loops=1)
-         ->  Limit  (cost=0.00..431.01 rows=2 width=12) (actual time=1.456..1.464 rows=5 loops=1)
-               ->  GroupAggregate  (cost=0.00..431.01 rows=7 width=12) (actual time=1.455..1.460 rows=5 loops=1)
+                                                                      QUERY PLAN                                                                       
+-------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit  (cost=0.00..431.01 rows=5 width=12) (actual time=2.045..2.048 rows=5 loops=1)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.01 rows=5 width=12) (actual time=2.043..2.045 rows=5 loops=1)
+         ->  Limit  (cost=0.00..431.01 rows=2 width=12) (actual time=1.704..1.708 rows=5 loops=1)
+               ->  Finalize HashAggregate  (cost=0.00..431.01 rows=7 width=12) (actual time=1.703..1.705 rows=5 loops=1)
                      Group Key: d
-                     ->  Sort  (cost=0.00..431.01 rows=34 width=4) (actual time=1.449..1.453 rows=26 loops=1)
-                           Sort Key: d
-                           Sort Method:  quicksort  Memory: 99kB
-                           Executor Memory: 79kB  Segments: 3  Max: 27kB (segment 1)
-                           ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=34 width=4) (actual time=0.413..1.428 rows=35 loops=1)
-                                 Hash Key: d
-                                 ->  Seq Scan on smallt  (cost=0.00..431.00 rows=34 width=4) (actual time=0.003..0.006 rows=50 loops=1)
- Planning time: 16.802 ms
-   (slice0)    Executor memory: 59K bytes.
-   (slice1)    Executor memory: 42K bytes avg x 3 workers, 42K bytes max (seg0).
-   (slice2)    Executor memory: 64K bytes avg x 3 workers, 64K bytes max (seg0).  Work_mem: 33K bytes max.
+                     Peak Memory Usage: 0 kB
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.01 rows=7 width=12) (actual time=0.592..1.709 rows=7 loops=1)
+                           Hash Key: d
+                           ->  Partial GroupAggregate  (cost=0.00..431.01 rows=7 width=12) (actual time=0.174..0.205 rows=10 loops=1)
+                                 Group Key: d
+                                 ->  Sort  (cost=0.00..431.00 rows=34 width=4) (actual time=0.167..0.184 rows=50 loops=1)
+                                       Sort Key: d
+                                       Sort Method:  quicksort  Memory: 79kB
+                                       Executor Memory: 79kB  Segments: 3  Max: 27kB (segment 0)
+                                       ->  Seq Scan on smallt  (cost=0.00..431.00 rows=34 width=4) (actual time=0.134..0.146 rows=50 loops=1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Planning Time: 7.540 ms
+   (slice0)    Executor memory: 52K bytes.
+   (slice1)    Executor memory: 22K bytes avg x 3 workers, 22K bytes max (seg1).  Work_mem: 24K bytes max.
+   (slice2)    Executor memory: 39K bytes avg x 3 workers, 39K bytes max (seg0).  Work_mem: 27K bytes max.
  Memory used:  128000kB
- Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
- Execution time: 2.024 ms
-(19 rows)
+ Execution Time: 2.958 ms
+(22 rows)
 
 select * from
   test_util.extract_plan_stats($$
@@ -1807,27 +1835,28 @@ select t1.* from smallt as t1, smallt as t2 where t1.d = t2.d and t1.i < 2;
 explain analyze select t1.* from smallt as t1, smallt as t2 where t1.d = t2.d and t1.i < 2;
                                                                     QUERY PLAN                                                                    
 --------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..862.02 rows=100 width=15) (actual time=1.917..2.300 rows=50 loops=2)
-   ->  Hash Join  (cost=0.00..862.01 rows=34 width=15) (actual time=0.611..2.052 rows=25 loops=2)
-         Hash Cond: smallt.d = smallt_1.d
-         Extra Text: (seg1)   Hash chain length 5.0 avg, 5 max, using 11 of 524288 buckets.
- 
-         ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=7 width=15) (actual time=0.004..0.199 rows=5 loops=2)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.02 rows=100 width=15) (actual time=5.608..5.721 rows=100 loops=1)
+   ->  Hash Join  (cost=0.00..862.01 rows=34 width=15) (actual time=3.568..5.300 rows=75 loops=1)
+         Hash Cond: (smallt.d = smallt_1.d)
+         Extra Text: (seg1)   Hash chain length 5.0 avg, 5 max, using 7 of 524288 buckets.
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=7 width=15) (actual time=0.084..0.087 rows=15 loops=1)
                Hash Key: smallt.d
-               ->  Seq Scan on smallt  (cost=0.00..431.00 rows=7 width=15) (actual time=0.021..0.034 rows=5 loops=2)
-                     Filter: i < 2
-         ->  Hash  (cost=431.00..431.00 rows=34 width=4) (actual time=0.169..0.169 rows=28 loops=2)
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=34 width=4) (actual time=0.032..0.153 rows=28 loops=2)
+               ->  Seq Scan on smallt  (cost=0.00..431.00 rows=7 width=15) (actual time=0.188..0.207 rows=20 loops=1)
+                     Filter: (i < 2)
+         ->  Hash  (cost=431.00..431.00 rows=34 width=4) (actual time=1.436..1.437 rows=35 loops=1)
+               Buckets: 524288  Batches: 1  Memory Usage: 4098kB
+               ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=34 width=4) (actual time=1.189..1.386 rows=35 loops=1)
                      Hash Key: smallt_1.d
-                     ->  Seq Scan on smallt smallt_1  (cost=0.00..431.00 rows=34 width=4) (actual time=0.022..0.036 rows=20 loops=2)
-   (slice0)    Executor memory: 386K bytes.
-   (slice1)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice2)    Executor memory: 66K bytes avg x 3 workers, 66K bytes max (seg0).
-   (slice3)    Executor memory: 4186K bytes avg x 3 workers, 4186K bytes max (seg0).  Work_mem: 2K bytes max.
+                     ->  Seq Scan on smallt smallt_1  (cost=0.00..431.00 rows=34 width=4) (actual time=0.878..0.891 rows=50 loops=1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Planning Time: 9.661 ms
+   (slice0)    Executor memory: 39K bytes.
+   (slice1)    Executor memory: 4148K bytes avg x 3 workers, 4148K bytes max (seg1).  Work_mem: 4098K bytes max.
+   (slice2)    Executor memory: 37K bytes avg x 3 workers, 37K bytes max (seg0).
+   (slice3)    Executor memory: 37K bytes avg x 3 workers, 37K bytes max (seg0).
  Memory used:  128000kB
- Optimizer: Pivotal Optimizer (GPORCA) version 2.74.0
- Total runtime: 5.688 ms
-(20 rows)
+ Execution Time: 6.804 ms
+(21 rows)
 
 --end_ignore
 set enable_hashjoin=on;
@@ -1879,21 +1908,23 @@ explain analyze select smallt.* from smallt, smallt2 where smallt.i = smallt2.i 
 and smallt.d = '2011-01-04'::date;
                                                                QUERY PLAN                                                                
 -----------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..17.99 rows=2 width=15) (actual time=2.338..2.341 rows=20 loops=1)
-   ->  Hash Join  (cost=0.00..17.99 rows=1 width=15) (actual time=0.464..1.817 rows=20 loops=1)
-         Hash Cond: smallt.i = smallt2.i
-         (seg2)   Hash chain length 4.0 avg, 4 max, using 1 of 524288 buckets.
-         ->  Index Scan using smallt_d_idx on smallt  (cost=0.00..9.99 rows=2 width=15) (actual time=0.005..0.007 rows=5 loops=1)
-               Index Cond: d = '01-04-2011'::date
-         ->  Hash  (cost=8.00..8.00 rows=2 width=4) (actual time=0.034..0.034 rows=4 loops=1)
-               ->  Index Scan using smallt2_d_idx on smallt2  (cost=0.00..8.00 rows=2 width=4) (actual time=0.023..0.027 rows=4 loops=1)
-                     Index Cond: d = '01-04-2011'::date
-   (slice0)    Executor memory: 450K bytes.
-   (slice1)    Executor memory: 4234K bytes avg x 3 workers, 4234K bytes max (seg0).  Work_mem: 1K bytes max.
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..12.00 rows=4 width=15) (actual time=2.375..2.381 rows=20 loops=1)
+   ->  Hash Join  (cost=0.00..12.00 rows=2 width=15) (actual time=0.510..2.005 rows=20 loops=1)
+         Hash Cond: (smallt.i = smallt2.i)
+         Extra Text: (seg0)   Hash chain length 4.0 avg, 4 max, using 1 of 524288 buckets.
+         ->  Index Scan using smallt_d_idx on smallt  (cost=0.00..6.00 rows=2 width=15) (actual time=0.007..0.010 rows=5 loops=1)
+               Index Cond: (d = '01-04-2011'::date)
+         ->  Hash  (cost=6.00..6.00 rows=2 width=4) (actual time=0.021..0.021 rows=4 loops=1)
+               Buckets: 524288  Batches: 1  Memory Usage: 4097kB
+               ->  Index Scan using smallt2_d_idx on smallt2  (cost=0.00..6.00 rows=2 width=4) (actual time=0.012..0.015 rows=4 loops=1)
+                     Index Cond: (d = '01-04-2011'::date)
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Planning Time: 9.990 ms
+   (slice0)    Executor memory: 47K bytes.
+   (slice1)    Executor memory: 4171K bytes avg x 3 workers, 4214K bytes max (seg0).  Work_mem: 4097K bytes max.
  Memory used:  128000kB
- Optimizer: Pivotal Optimizer (GPORCA) version 2.67.0
- Total runtime: 3.325 ms
-(14 rows)
+ Execution Time: 3.319 ms
+(16 rows)
 
 -- IndexOnlyScan
 explain analyze select *, exists(select 1 from pg_class where oid = c.oid) as dummy from pg_class c;
@@ -1950,21 +1981,23 @@ explain analyze select smallt.* from smallt, smallt2 where smallt.i = smallt2.i 
 and smallt.d = '2011-01-04'::date;
                                                                QUERY PLAN                                                                
 -----------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..17.99 rows=2 width=15) (actual time=3.960..3.964 rows=20 loops=1)
-   ->  Hash Join  (cost=0.00..17.99 rows=1 width=15) (actual time=0.267..1.566 rows=20 loops=1)
-         Hash Cond: smallt.i = smallt2.i
-         (seg2)   Hash chain length 4.0 avg, 4 max, using 1 of 524288 buckets.
-         ->  Index Scan using smallt_d_idx on smallt  (cost=0.00..9.99 rows=2 width=15) (actual time=0.005..0.007 rows=5 loops=1)
-               Index Cond: d = '01-04-2011'::date
-         ->  Hash  (cost=8.00..8.00 rows=2 width=4) (actual time=0.031..0.031 rows=4 loops=1)
-               ->  Index Scan using smallt2_d_idx on smallt2  (cost=0.00..8.00 rows=2 width=4) (actual time=0.020..0.024 rows=4 loops=1)
-                     Index Cond: d = '01-04-2011'::date
-   (slice0)    Executor memory: 450K bytes.
-   (slice1)    Executor memory: 4234K bytes avg x 3 workers, 4234K bytes max (seg0).  Work_mem: 1K bytes max.
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..12.00 rows=4 width=15) (actual time=2.388..3.981 rows=20 loops=1)
+   ->  Hash Join  (cost=0.00..12.00 rows=2 width=15) (actual time=0.489..1.964 rows=20 loops=1)
+         Hash Cond: (smallt.i = smallt2.i)
+         Extra Text: (seg0)   Hash chain length 4.0 avg, 4 max, using 1 of 524288 buckets.
+         ->  Index Scan using smallt_d_idx on smallt  (cost=0.00..6.00 rows=2 width=15) (actual time=0.007..0.009 rows=5 loops=1)
+               Index Cond: (d = '01-04-2011'::date)
+         ->  Hash  (cost=6.00..6.00 rows=2 width=4) (actual time=0.021..0.022 rows=4 loops=1)
+               Buckets: 524288  Batches: 1  Memory Usage: 4097kB
+               ->  Index Scan using smallt2_d_idx on smallt2  (cost=0.00..6.00 rows=2 width=4) (actual time=0.013..0.016 rows=4 loops=1)
+                     Index Cond: (d = '01-04-2011'::date)
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Planning Time: 10.321 ms
+   (slice0)    Executor memory: 47K bytes.
+   (slice1)    Executor memory: 4171K bytes avg x 3 workers, 4214K bytes max (seg0).  Work_mem: 4097K bytes max.
  Memory used:  128000kB
- Optimizer: Pivotal Optimizer (GPORCA) version 2.67.0
- Total runtime: 5.131 ms
-(14 rows)
+ Execution Time: 5.039 ms
+(16 rows)
 
 set enable_hashjoin=on;
 set enable_nestloop=off;
@@ -2009,31 +2042,33 @@ explain with my_group_sum(d, total) as (select d, sum(i) from smallt group by d)
 
               QUERY PLAN
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Finalize Aggregate  (cost=0.00..1324486.07 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1324486.07 rows=1 width=8)
-         ->  Partial Aggregate  (cost=0.00..1324486.07 rows=1 width=8)
-               ->  Hash Join  (cost=0.00..1324486.07 rows=6 width=1)
+ Finalize Aggregate  (cost=0.00..1324486.44 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1324486.44 rows=1 width=8)
+         ->  Partial Aggregate  (cost=0.00..1324486.44 rows=1 width=8)
+               ->  Hash Join  (cost=0.00..1324486.44 rows=6 width=1)
                      Hash Cond: (smallt2.d = smallt.d)
                      ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=17 width=4)
                            Hash Key: smallt2.d
                            ->  Seq Scan on smallt2  (cost=0.00..431.00 rows=17 width=4)
-                     ->  Hash  (cost=1324055.07..1324055.07 rows=3 width=4)
-                           ->  Result  (cost=0.00..1324055.07 rows=3 width=4)
+                     ->  Hash  (cost=1324055.44..1324055.44 rows=3 width=4)
+                           ->  Result  (cost=0.00..1324055.44 rows=3 width=4)
                                  Filter: ((CASE WHEN (sum((CASE WHEN (0 >= (sum(smallt.i))) THEN 1 ELSE 0 END)) IS NULL) THEN true WHEN (sum((CASE WHEN ((sum(smallt.i)) IS NULL) THEN 1 ELSE 0 END)) > '0'::bigint) THEN NULL::boolean WHEN (0 IS NULL) THEN NULL::boolean WHEN (sum((CASE WHEN (0 >= (sum(smallt.i))) THEN 1 ELSE 0 END)) = '0'::bigint) THEN true ELSE false END) = true)
-                                 ->  HashAggregate  (cost=0.00..1324055.07 rows=7 width=20)
+                                 ->  HashAggregate  (cost=0.00..1324055.44 rows=7 width=20)
                                        Group Key: smallt.d
-                                       ->  Nested Loop  (cost=0.00..1324055.03 rows=334 width=12)
+                                       ->  Nested Loop  (cost=0.00..1324055.39 rows=334 width=12)
                                              Join Filter: true
-                                             ->  HashAggregate  (cost=0.00..431.01 rows=7 width=12)
+                                             ->  Finalize HashAggregate  (cost=0.00..431.01 rows=7 width=12)
                                                    Group Key: smallt.d
-                                                   ->  Redistribute Motion 3:3  (slice4; segments: 3)  (cost=0.00..431.00 rows=34 width=8)
+                                                   ->  Redistribute Motion 3:3  (slice4; segments: 3)  (cost=0.00..431.01 rows=7 width=12)
                                                          Hash Key: smallt.d
-                                                         ->  Seq Scan on smallt  (cost=0.00..431.00 rows=34 width=8)
+                                                         ->  Streaming Partial HashAggregate  (cost=0.00..431.01 rows=7 width=12)
+                                                               Group Key: smallt.d
+                                                               ->  Seq Scan on smallt  (cost=0.00..431.00 rows=34 width=8)
                                              ->  Materialize  (cost=0.00..431.00 rows=50 width=1)
                                                    ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=50 width=1)
                                                          ->  Seq Scan on smallt2 smallt2_1  (cost=0.00..431.00 rows=17 width=1)
  Optimizer: Pivotal Optimizer (GPORCA)
-(24 rows)
+(26 rows)
 
 --end_ignore
 -- Nested Subplan

--- a/src/test/regress/expected/gp_aggregates_costs_optimizer.out
+++ b/src/test/regress/expected/gp_aggregates_costs_optimizer.out
@@ -16,7 +16,7 @@ set statement_mem= '1800 kB';
 explain select avg(b) from cost_agg_t1 group by c;
                                             QUERY PLAN                                             
 ---------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..485.40 rows=2001 width=8)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..485.40 rows=2000 width=8)
    ->  Finalize HashAggregate  (cost=0.00..485.34 rows=667 width=8)
          Group Key: c
          ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..485.26 rows=667 width=12)
@@ -37,14 +37,18 @@ explain select avg(b) from cost_agg_t1 group by c;
 explain select avg(b) from cost_agg_t2 group by c;
                                              QUERY PLAN                                              
 -----------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..501.88 rows=305691 width=8)
-   ->  HashAggregate  (cost=0.00..492.76 rows=101897 width=8)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..509.21 rows=281319 width=8)
+   ->  Finalize HashAggregate  (cost=0.00..500.83 rows=93773 width=8)
          Group Key: c
-         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..452.01 rows=333334 width=8)
+         Planned Partitions: 8
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..489.07 rows=93773 width=12)
                Hash Key: c
-               ->  Seq Scan on cost_agg_t2  (cost=0.00..438.70 rows=333334 width=8)
+               ->  Streaming Partial HashAggregate  (cost=0.00..485.55 rows=93773 width=12)
+                     Group Key: c
+                     Planned Partitions: 8
+                     ->  Seq Scan on cost_agg_t2  (cost=0.00..438.70 rows=333334 width=8)
  Optimizer: Pivotal Optimizer (GPORCA)
-(7 rows)
+(11 rows)
 
 -- But if there are a lot more duplicate values, the two-stage plan becomes
 -- cheaper again, even though it doesn't git in memory and has to spill.
@@ -53,16 +57,18 @@ analyze cost_agg_t2;
 explain select avg(b) from cost_agg_t2 group by c;
                                              QUERY PLAN                                              
 -----------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..504.85 rows=102902 width=8)
-   ->  Finalize HashAggregate  (cost=0.00..501.78 rows=34301 width=8)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..504.79 rows=102209 width=8)
+   ->  Finalize HashAggregate  (cost=0.00..501.74 rows=34070 width=8)
          Group Key: c
-         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..497.48 rows=34301 width=12)
+         Planned Partitions: 8
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..497.47 rows=34070 width=12)
                Hash Key: c
-               ->  Streaming Partial HashAggregate  (cost=0.00..496.19 rows=34301 width=12)
+               ->  Streaming Partial HashAggregate  (cost=0.00..496.19 rows=34070 width=12)
                      Group Key: c
+                     Planned Partitions: 4
                      ->  Seq Scan on cost_agg_t2  (cost=0.00..440.24 rows=400000 width=8)
  Optimizer: Pivotal Optimizer (GPORCA)
-(9 rows)
+(11 rows)
 
 drop table cost_agg_t1;
 drop table cost_agg_t2;
@@ -83,15 +89,19 @@ explain (costs off) select b, sum(a) from t_planner_force_multi_stage group by b
                             QUERY PLAN                            
 ------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  GroupAggregate
+   ->  Finalize GroupAggregate
          Group Key: b
          ->  Sort
                Sort Key: b
                ->  Redistribute Motion 3:3  (slice2; segments: 3)
                      Hash Key: b
-                     ->  Seq Scan on t_planner_force_multi_stage
+                     ->  Partial GroupAggregate
+                           Group Key: b
+                           ->  Sort
+                                 Sort Key: b
+                                 ->  Seq Scan on t_planner_force_multi_stage
  Optimizer: Pivotal Optimizer (GPORCA)
-(9 rows)
+(13 rows)
 
 set gp_eager_two_phase_agg = on;
 -- when forcing two stage, it should generate two stage agg plan.
@@ -99,15 +109,19 @@ explain (costs off) select b, sum(a) from t_planner_force_multi_stage group by b
                             QUERY PLAN                            
 ------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  GroupAggregate
+   ->  Finalize GroupAggregate
          Group Key: b
          ->  Sort
                Sort Key: b
                ->  Redistribute Motion 3:3  (slice2; segments: 3)
                      Hash Key: b
-                     ->  Seq Scan on t_planner_force_multi_stage
+                     ->  Partial GroupAggregate
+                           Group Key: b
+                           ->  Sort
+                                 Sort Key: b
+                                 ->  Seq Scan on t_planner_force_multi_stage
  Optimizer: Pivotal Optimizer (GPORCA)
-(9 rows)
+(13 rows)
 
 reset gp_eager_two_phase_agg;
 drop table t_planner_force_multi_stage;

--- a/src/test/regress/expected/gp_dqa_optimizer.out
+++ b/src/test/regress/expected/gp_dqa_optimizer.out
@@ -342,19 +342,21 @@ explain (costs off) select count(distinct dqa_t1.d) from dqa_t1, dqa_t2 where dq
                             QUERY PLAN                            
 ------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  GroupAggregate
+   ->  Finalize HashAggregate
          Group Key: dqa_t2.dt
-         ->  Sort
-               Sort Key: dqa_t2.dt
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                     Hash Key: dqa_t2.dt
-                     ->  Hash Join
-                           Hash Cond: (dqa_t2.d = dqa_t1.d)
-                           ->  Seq Scan on dqa_t2
-                           ->  Hash
-                                 ->  Seq Scan on dqa_t1
- Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
-(13 rows)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Hash Key: dqa_t2.dt
+               ->  Partial GroupAggregate
+                     Group Key: dqa_t2.dt
+                     ->  Sort
+                           Sort Key: dqa_t2.dt
+                           ->  Hash Join
+                                 Hash Cond: (dqa_t2.d = dqa_t1.d)
+                                 ->  Seq Scan on dqa_t2
+                                 ->  Hash
+                                       ->  Seq Scan on dqa_t1
+ Optimizer: Pivotal Optimizer (GPORCA)
+(15 rows)
 
 -- Distinct keys are not distribution keys
 select count(distinct c) from dqa_t1;
@@ -364,16 +366,23 @@ select count(distinct c) from dqa_t1;
 (1 row)
 
 explain (costs off) select count(distinct c) from dqa_t1;
-                            QUERY PLAN                            
-------------------------------------------------------------------
- Finalize Aggregate
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial Aggregate
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                     Hash Key: c
-                     ->  Seq Scan on dqa_t1
- Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
-(7 rows)
+         ->  GroupAggregate
+               Group Key: c
+               ->  Sort
+                     Sort Key: c
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: c
+                           ->  GroupAggregate
+                                 Group Key: c
+                                 ->  Sort
+                                       Sort Key: c
+                                       ->  Seq Scan on dqa_t1
+ Optimizer: Pivotal Optimizer (GPORCA)
+(14 rows)
 
 select count(distinct c) from dqa_t1 group by dt;
  count 
@@ -418,15 +427,19 @@ explain (costs off) select count(distinct c) from dqa_t1 group by dt;
                             QUERY PLAN                            
 ------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  GroupAggregate
+   ->  Finalize HashAggregate
          Group Key: dt
-         ->  Sort
-               Sort Key: dt
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                     Hash Key: dt
-                     ->  Seq Scan on dqa_t1
- Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
-(9 rows)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Hash Key: dt
+               ->  Partial GroupAggregate
+                     Group Key: dt
+                     ->  Sort
+                           Sort Key: dt, c
+                           ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                                 Hash Key: c
+                                 ->  Seq Scan on dqa_t1
+ Optimizer: Pivotal Optimizer (GPORCA)
+(13 rows)
 
 select count(distinct c) from dqa_t1 group by d;
  count 
@@ -462,11 +475,13 @@ explain (costs off) select count(distinct c) from dqa_t1 group by d;
  Gather Motion 3:1  (slice1; segments: 3)
    ->  GroupAggregate
          Group Key: d
-         ->  Sort
-               Sort Key: d
-               ->  Seq Scan on dqa_t1
- Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
-(7 rows)
+         ->  GroupAggregate
+               Group Key: d, c
+               ->  Sort
+                     Sort Key: d, c
+                     ->  Seq Scan on dqa_t1
+ Optimizer: Pivotal Optimizer (GPORCA)
+(9 rows)
 
 select count(distinct i), sum(distinct i) from dqa_t1 group by c;
  count | sum 
@@ -487,15 +502,19 @@ explain (costs off) select count(distinct i), sum(distinct i) from dqa_t1 group 
                             QUERY PLAN                            
 ------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  GroupAggregate
+   ->  Finalize HashAggregate
          Group Key: c
-         ->  Sort
-               Sort Key: c
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                     Hash Key: c
-                     ->  Seq Scan on dqa_t1
- Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
-(9 rows)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Hash Key: c
+               ->  Partial GroupAggregate
+                     Group Key: c
+                     ->  Sort
+                           Sort Key: c, i
+                           ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                                 Hash Key: i
+                                 ->  Seq Scan on dqa_t1
+ Optimizer: Pivotal Optimizer (GPORCA)
+(13 rows)
 
 select count(distinct c), count(distinct dt) from dqa_t1;
 INFO:  GPORCA failed to produce a plan, falling back to planner
@@ -625,24 +644,29 @@ select count(distinct dqa_t1.dt) from dqa_t1, dqa_t2 where dqa_t1.c = dqa_t2.c;
 (1 row)
 
 explain (costs off) select count(distinct dqa_t1.dt) from dqa_t1, dqa_t2 where dqa_t1.c = dqa_t2.c;
-                                     QUERY PLAN                                     
-------------------------------------------------------------------------------------
- Finalize Aggregate
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Partial Aggregate
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                     Hash Key: dqa_t1.dt
-                     ->  Hash Join
-                           Hash Cond: (dqa_t1.c = dqa_t2.c)
-                           ->  Redistribute Motion 3:3  (slice3; segments: 3)
-                                 Hash Key: dqa_t1.c
-                                 ->  Seq Scan on dqa_t1
-                           ->  Hash
-                                 ->  Redistribute Motion 3:3  (slice4; segments: 3)
-                                       Hash Key: dqa_t2.c
-                                       ->  Seq Scan on dqa_t2
- Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
-(15 rows)
+         ->  GroupAggregate
+               Group Key: dqa_t1.dt
+               ->  Sort
+                     Sort Key: dqa_t1.dt
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: dqa_t1.dt
+                           ->  Streaming HashAggregate
+                                 Group Key: dqa_t1.dt
+                                 ->  Hash Join
+                                       Hash Cond: (dqa_t1.c = dqa_t2.c)
+                                       ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                                             Hash Key: dqa_t1.c
+                                             ->  Seq Scan on dqa_t1
+                                       ->  Hash
+                                             ->  Redistribute Motion 3:3  (slice4; segments: 3)
+                                                   Hash Key: dqa_t2.c
+                                                   ->  Seq Scan on dqa_t2
+ Optimizer: Pivotal Optimizer (GPORCA)
+(20 rows)
 
 select count(distinct dqa_t1.dt) from dqa_t1, dqa_t2 where dqa_t1.c = dqa_t2.c group by dqa_t2.dt;
  count 
@@ -709,23 +733,25 @@ explain (costs off) select count(distinct dqa_t1.dt) from dqa_t1, dqa_t2 where d
                                      QUERY PLAN                                     
 ------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  GroupAggregate
+   ->  HashAggregate
          Group Key: dqa_t2.dt
-         ->  Sort
-               Sort Key: dqa_t2.dt
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                     Hash Key: dqa_t2.dt
-                     ->  Hash Join
-                           Hash Cond: (dqa_t1.c = dqa_t2.c)
-                           ->  Redistribute Motion 3:3  (slice3; segments: 3)
-                                 Hash Key: dqa_t1.c
-                                 ->  Seq Scan on dqa_t1
-                           ->  Hash
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Hash Key: dqa_t2.dt
+               ->  HashAggregate
+                     Group Key: dqa_t2.dt, dqa_t1.dt
+                     ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                           Hash Key: dqa_t2.dt, dqa_t1.dt, dqa_t1.dt
+                           ->  Hash Join
+                                 Hash Cond: (dqa_t1.c = dqa_t2.c)
                                  ->  Redistribute Motion 3:3  (slice4; segments: 3)
-                                       Hash Key: dqa_t2.c
-                                       ->  Seq Scan on dqa_t2
- Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
-(17 rows)
+                                       Hash Key: dqa_t1.c
+                                       ->  Seq Scan on dqa_t1
+                                 ->  Hash
+                                       ->  Redistribute Motion 3:3  (slice5; segments: 3)
+                                             Hash Key: dqa_t2.c
+                                             ->  Seq Scan on dqa_t2
+ Optimizer: Pivotal Optimizer (GPORCA)
+(19 rows)
 
 -- multidqa with groupby and order by
 select sum(distinct d), count(distinct i), count(distinct c),i,c from dqa_t1 group by i,c order by i,c;
@@ -2971,29 +2997,35 @@ explain (verbose on, costs off) select distinct sum(Distinct c), count(a), sum(d
                ->  Redistribute Motion 3:3  (slice2; segments: 3)
                      Output: (sum(c)), (count(a)), (sum(d))
                      Hash Key: (sum(c)), (count(a)), (sum(d))
-                     ->  Finalize HashAggregate
-                           Output: sum(c), count(a), sum(d)
-                           Group Key: dqa_f3.b
-                           ->  Redistribute Motion 3:3  (slice3; segments: 3)
-                                 Output: b, c, (PARTIAL count(a)), (PARTIAL sum(d))
-                                 Hash Key: b
-                                 ->  Partial GroupAggregate
-                                       Output: b, c, PARTIAL count(a), PARTIAL sum(d)
-                                       Group Key: dqa_f3.b, dqa_f3.c
-                                       ->  Sort
+                     ->  GroupAggregate
+                           Output: (sum(c)), (count(a)), (sum(d))
+                           Group Key: (sum(dqa_f3.c)), (count(dqa_f3.a)), (sum(dqa_f3.d))
+                           ->  Sort
+                                 Output: (sum(c)), (count(a)), (sum(d)), b
+                                 Sort Key: (sum(dqa_f3.c)), (count(dqa_f3.a)), (sum(dqa_f3.d))
+                                 ->  Finalize HashAggregate
+                                       Output: sum(c), count(a), sum(d), b
+                                       Group Key: dqa_f3.b
+                                       ->  Redistribute Motion 3:3  (slice3; segments: 3)
                                              Output: b, c, (PARTIAL count(a)), (PARTIAL sum(d))
-                                             Sort Key: dqa_f3.b, dqa_f3.c
-                                             ->  Redistribute Motion 3:3  (slice4; segments: 3)
-                                                   Output: b, c, (PARTIAL count(a)), (PARTIAL sum(d))
-                                                   Hash Key: b, c
-                                                   ->  Streaming Partial HashAggregate
-                                                         Output: b, c, PARTIAL count(a), PARTIAL sum(d)
-                                                         Group Key: dqa_f3.b, dqa_f3.c
-                                                         ->  Seq Scan on public.dqa_f3
-                                                               Output: a, b, c, d
+                                             Hash Key: b
+                                             ->  Partial GroupAggregate
+                                                   Output: b, c, PARTIAL count(a), PARTIAL sum(d)
+                                                   Group Key: dqa_f3.b, dqa_f3.c
+                                                   ->  Sort
+                                                         Output: b, c, (PARTIAL count(a)), (PARTIAL sum(d))
+                                                         Sort Key: dqa_f3.b, dqa_f3.c
+                                                         ->  Redistribute Motion 3:3  (slice4; segments: 3)
+                                                               Output: b, c, (PARTIAL count(a)), (PARTIAL sum(d))
+                                                               Hash Key: b, c
+                                                               ->  Streaming Partial HashAggregate
+                                                                     Output: b, c, PARTIAL count(a), PARTIAL sum(d)
+                                                                     Group Key: dqa_f3.b, dqa_f3.c
+                                                                     ->  Seq Scan on public.dqa_f3
+                                                                           Output: a, b, c, d
  Optimizer: Pivotal Optimizer (GPORCA)
  Settings: enable_groupagg = 'off', gp_motion_cost_per_row = '1'
-(33 rows)
+(39 rows)
 
 select distinct sum(Distinct c), count(a), sum(d) from dqa_f3 group by b;
  sum | count | sum  

--- a/src/test/regress/expected/gpdiffcheck_optimizer.out
+++ b/src/test/regress/expected/gpdiffcheck_optimizer.out
@@ -147,20 +147,22 @@ explain analyze select a.* from gpd1 as a, gpd1 as b where b.c1 in (select max(c
    ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1293.00 rows=1 width=14) (actual time=0.282..0.291 rows=64 loops=1)
          ->  Nested Loop  (cost=0.00..1293.00 rows=1 width=14) (actual time=0.949..1.287 rows=32 loops=1)
                Join Filter: true
-               ->  Seq Scan on gpd1 gpd1_1  (cost=0.00..431.00 rows=1 width=12) (actual time=0.005..0.006 rows=4 loops=1)
-               ->  Materialize  (cost=0.00..431.00 rows=2 width=2) (actual time=0.187..0.253 rows=7 loops=5)
-                     ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=2 width=2) (actual time=0.897..1.264 rows=8 loops=1)
-                           ->  Seq Scan on gpd1  (cost=0.00..431.00 rows=1 width=2) (actual time=0.012..0.134 rows=4 loops=1)
-   ->  Hash  (cost=431.00..431.00 rows=1 width=8) (actual time=0.137..0.137 rows=1 loops=1)
-         Buckets: 262144  Batches: 1  Memory Usage: 1kB
-         ->  Aggregate  (cost=0.00..431.00 rows=1 width=8) (actual time=0.133..0.133 rows=1 loops=1)
-               ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=2) (actual time=0.004..0.097 rows=8 loops=1)
-                     ->  Seq Scan on gpd1 gpd1_2  (cost=0.00..431.00 rows=1 width=2) (actual time=0.008..0.009 rows=4 loops=1)
- Planning time: 109.024 ms
-   (slice0)    Executor memory: 2216K bytes.  Work_mem: 1K bytes max.
-   (slice1)    Executor memory: 96K bytes avg x 3 workers, 96K bytes max (seg0).
-   (slice2)    Executor memory: 60K bytes avg x 3 workers, 60K bytes max (seg0).
-   (slice3)    Executor memory: 60K bytes avg x 3 workers, 60K bytes max (seg0).
+               ->  Seq Scan on gpd1 gpd1_1  (cost=0.00..431.00 rows=1 width=12) (actual time=0.776..0.778 rows=4 loops=1)
+               ->  Materialize  (cost=0.00..431.00 rows=2 width=2) (actual time=0.429..0.449 rows=7 loops=5)
+                     ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=2 width=2) (actual time=2.121..2.584 rows=8 loops=1)
+                           ->  Seq Scan on gpd1  (cost=0.00..431.00 rows=1 width=2) (actual time=0.736..0.738 rows=4 loops=1)
+   ->  Hash  (cost=431.00..431.00 rows=1 width=8) (actual time=2.959..2.960 rows=1 loops=1)
+         Buckets: 262144  Batches: 1  Memory Usage: 2049kB
+         ->  Finalize Aggregate  (cost=0.00..431.00 rows=1 width=8) (actual time=2.950..2.952 rows=1 loops=1)
+               ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=8) (actual time=2.546..2.928 rows=3 loops=1)
+                     ->  Partial Aggregate  (cost=0.00..431.00 rows=1 width=8) (actual time=0.372..0.373 rows=1 loops=1)
+                           ->  Seq Scan on gpd1 gpd1_2  (cost=0.00..431.00 rows=1 width=2) (actual time=0.769..0.771 rows=4 loops=1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Planning Time: 18.591 ms
+   (slice0)    Executor memory: 2141K bytes.  Work_mem: 2049K bytes max.
+   (slice1)    Executor memory: 41K bytes avg x 3 workers, 41K bytes max (seg0).  Work_mem: 17K bytes max.
+   (slice2)    Executor memory: 38K bytes avg x 3 workers, 38K bytes max (seg0).
+   (slice3)    Executor memory: 45K bytes avg x 3 workers, 45K bytes max (seg0).
  Memory used:  128000kB
  Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
  Execution time: 17.954 ms
@@ -179,11 +181,12 @@ explain select a.* from gpd1 as a, gpd1 as b where b.c1 in (select max(c1) from 
                      ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=2 width=2)
                            ->  Seq Scan on gpd1  (cost=0.00..431.00 rows=1 width=2)
    ->  Hash  (cost=431.00..431.00 rows=1 width=8)
-         ->  Aggregate  (cost=0.00..431.00 rows=1 width=8)
-               ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=2)
-                     ->  Seq Scan on gpd1 gpd1_2  (cost=0.00..431.00 rows=1 width=2)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
-(14 rows)
+         ->  Finalize Aggregate  (cost=0.00..431.00 rows=1 width=8)
+               ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                     ->  Partial Aggregate  (cost=0.00..431.00 rows=1 width=8)
+                           ->  Seq Scan on gpd1 gpd1_2  (cost=0.00..431.00 rows=1 width=2)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(15 rows)
 
 select a.* from gpd1 as a, gpd1 as b where b.c1 in (select max(c1) from gpd1);
  c1 | c2 | c3 
@@ -254,32 +257,33 @@ select a.* from gpd1 as a, gpd1 as b where b.c1 in (select max(c1) from gpd1);
 explain analyze select a.* from gpd1 as a, gpd1 as b where b.c1 in (select max(c1) from gpd1);
                                                                      QUERY PLAN                                                                      
 -----------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1724.00 rows=1 width=12) (actual time=11.226..13.705 rows=16 loops=1)
-   ->  Hash Join  (cost=0.00..1724.00 rows=1 width=12) (actual time=5.349..10.009 rows=16 loops=1)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1724.00 rows=1 width=12) (actual time=7.550..7.820 rows=16 loops=1)
+   ->  Hash Join  (cost=0.00..1724.00 rows=1 width=12) (actual time=5.773..7.000 rows=16 loops=1)
          Hash Cond: ((max(gpd1.c1)) = gpd1_1.c1)
          Extra Text: (seg0)   Hash chain length 16.0 avg, 16 max, using 1 of 524288 buckets.
-         ->  Redistribute Motion 1:3  (slice2)  (cost=0.00..431.00 rows=1 width=8) (actual time=0.007..0.007 rows=1 loops=1)
+         ->  Redistribute Motion 1:3  (slice2)  (cost=0.00..431.00 rows=1 width=8) (actual time=0.002..0.002 rows=1 loops=1)
                Hash Key: (max(gpd1.c1))
-               ->  Finalize Aggregate  (cost=0.00..431.00 rows=1 width=8) (actual time=1.384..1.384 rows=1 loops=1)
-                     ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=8) (actual time=0.216..1.339 rows=3 loops=1)
-                           ->  Partial Aggregate  (cost=0.00..431.00 rows=1 width=8) (actual time=0.056..0.056 rows=1 loops=1)
-                                 ->  Seq Scan on gpd1  (cost=0.00..431.00 rows=1 width=2) (actual time=0.038..0.045 rows=4 loops=1)
-         ->  Hash  (cost=1293.00..1293.00 rows=1 width=14) (actual time=0.287..0.287 rows=32 loops=1)
-               ->  Nested Loop  (cost=0.00..1293.00 rows=1 width=14) (actual time=0.089..0.223 rows=32 loops=1)
+               ->  Finalize Aggregate  (cost=0.00..431.00 rows=1 width=8) (actual time=5.363..5.363 rows=1 loops=1)
+                     ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=8) (actual time=4.818..5.335 rows=3 loops=1)
+                           ->  Partial Aggregate  (cost=0.00..431.00 rows=1 width=8) (actual time=1.335..1.335 rows=1 loops=1)
+                                 ->  Seq Scan on gpd1  (cost=0.00..431.00 rows=1 width=2) (actual time=1.643..1.645 rows=4 loops=1)
+         ->  Hash  (cost=1293.00..1293.00 rows=1 width=14) (actual time=3.735..3.736 rows=32 loops=1)
+               Buckets: 524288  Batches: 1  Memory Usage: 4098kB
+               ->  Nested Loop  (cost=0.00..1293.00 rows=1 width=14) (actual time=2.147..3.694 rows=32 loops=1)
                      Join Filter: true
-                     ->  Broadcast Motion 3:3  (slice4; segments: 3)  (cost=0.00..431.00 rows=14 width=12) (actual time=0.019..0.043 rows=8 loops=1)
-                           ->  Seq Scan on gpd1 gpd1_2  (cost=0.00..431.00 rows=1 width=12) (actual time=0.042..0.047 rows=4 loops=1)
-                     ->  Seq Scan on gpd1 gpd1_1  (cost=0.00..431.00 rows=1 width=2) (actual time=0.006..0.014 rows=4 loops=9)
- Planning time: 63.479 ms
-   (slice0)    Executor memory: 127K bytes.
-   (slice1)    Executor memory: 4208K bytes avg x 3 workers, 4208K bytes max (seg0).  Work_mem: 4098K bytes max.
-   (slice2)    Executor memory: 79K bytes (seg0).
-   (slice3)    Executor memory: 75K bytes avg x 3 workers, 75K bytes max (seg0).
-   (slice4)    Executor memory: 60K bytes avg x 3 workers, 60K bytes max (seg0).
+                     ->  Broadcast Motion 3:3  (slice4; segments: 3)  (cost=0.00..431.00 rows=14 width=12) (actual time=0.945..2.269 rows=8 loops=1)
+                           ->  Seq Scan on gpd1 gpd1_2  (cost=0.00..431.00 rows=1 width=12) (actual time=1.831..1.832 rows=4 loops=1)
+                     ->  Seq Scan on gpd1 gpd1_1  (cost=0.00..431.00 rows=1 width=2) (actual time=0.122..0.130 rows=4 loops=9)
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Planning Time: 17.379 ms
+   (slice0)    Executor memory: 64K bytes.
+   (slice1)    Executor memory: 4158K bytes avg x 3 workers, 4158K bytes max (seg0).  Work_mem: 4098K bytes max.
+   (slice2)    Executor memory: 17K bytes (entry db).
+   (slice3)    Executor memory: 38K bytes avg x 3 workers, 38K bytes max (seg0).
+   (slice4)    Executor memory: 37K bytes avg x 3 workers, 37K bytes max (seg0).
  Memory used:  128000kB
- Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
- Execution time: 16.006 ms
-(25 rows)
+ Execution Time: 8.951 ms
+(26 rows)
 
 --
 -- Clean up

--- a/src/test/regress/expected/gpdist_legacy_opclasses_optimizer.out
+++ b/src/test/regress/expected/gpdist_legacy_opclasses_optimizer.out
@@ -428,12 +428,15 @@ explain (costs off) select distinct test_array from try_distinct_array;
 ------------------------------------------------------
  GroupAggregate
    Group Key: test_array
-   ->  Sort
-         Sort Key: test_array
-         ->  Gather Motion 3:1  (slice1; segments: 3)
-               ->  Seq Scan on try_distinct_array
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Merge Key: test_array
+         ->  GroupAggregate
+               Group Key: test_array
+               ->  Sort
+                     Sort Key: test_array
+                     ->  Seq Scan on try_distinct_array
  Optimizer: Pivotal Optimizer (GPORCA)
-(7 rows)
+(10 rows)
 
 select distinct test_array from try_distinct_array;
  test_array 

--- a/src/test/regress/expected/gpdist_optimizer.out
+++ b/src/test/regress/expected/gpdist_optimizer.out
@@ -659,13 +659,17 @@ explain (costs off) select even.i from even right outer join odd on (even.i = od
                Sort Key: even.i
                ->  Redistribute Motion 3:3  (slice2; segments: 3)
                      Hash Key: even.i
-                     ->  Hash Left Join
-                           Hash Cond: (odd.i = even.i)
-                           ->  Seq Scan on odd
-                           ->  Hash
-                                 ->  Seq Scan on even
+                     ->  GroupAggregate
+                           Group Key: even.i
+                           ->  Sort
+                                 Sort Key: even.i
+                                 ->  Hash Left Join
+                                       Hash Cond: (odd.i = even.i)
+                                       ->  Seq Scan on odd
+                                       ->  Hash
+                                             ->  Seq Scan on even
  Optimizer: Pivotal Optimizer (GPORCA)
-(13 rows)
+(17 rows)
 
 -- Check that we can track the distribution through multiple FULL OUTER JOINs.
 -- This query should not need Redistribute Motion.

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -10319,13 +10319,14 @@ GROUP BY 1
 ORDER BY 1 asc ;
                                                                                                           QUERY PLAN                                                                                                          
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Sort  (cost=0.00..862.00 rows=1 width=16)
-   Sort Key: ((((my_tt_agg_opt.event_ts / 100000) / 5) * 5))
-   ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=16)
-         Group Key: ((((my_tt_agg_opt.event_ts / 100000) / 5) * 5))
-         ->  Sort  (cost=0.00..862.00 rows=1 width=8)
-               Sort Key: ((((my_tt_agg_opt.event_ts / 100000) / 5) * 5))
-               ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
+ Finalize GroupAggregate  (cost=0.00..862.00 rows=1 width=16)
+   Group Key: ((((my_tt_agg_opt.event_ts / 100000) / 5) * 5))
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=16)
+         Merge Key: ((((my_tt_agg_opt.event_ts / 100000) / 5) * 5))
+         ->  Partial GroupAggregate  (cost=0.00..862.00 rows=1 width=16)
+               Group Key: ((((my_tt_agg_opt.event_ts / 100000) / 5) * 5))
+               ->  Sort  (cost=0.00..862.00 rows=1 width=8)
+                     Sort Key: ((((my_tt_agg_opt.event_ts / 100000) / 5) * 5))
                      ->  Hash Join  (cost=0.00..862.00 rows=1 width=8)
                            Hash Cond: ((my_tq_agg_opt_part.sym)::bpchar = my_tt_agg_opt.symbol)
                            Join Filter: ((plusone(my_tq_agg_opt_part.bid_price) < my_tt_agg_opt.trade_price) AND (my_tt_agg_opt.event_ts >= my_tq_agg_opt_part.ets) AND (my_tt_agg_opt.event_ts < my_tq_agg_opt_part.end_ts))
@@ -10960,20 +10961,21 @@ FROM   (SELECT *
         SELECT region,
                code
         FROM   tab_3)a;
-                                                  QUERY PLAN                                                   
----------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=0.00..1293.00 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1293.00 rows=4 width=1)
-         ->  Append  (cost=0.00..1293.00 rows=2 width=1)
-               ->  Hash Left Join  (cost=0.00..862.00 rows=1 width=3)
-                     Hash Cond: ((tab_1.id)::text = (tab_2.id)::text)
-                     ->  Seq Scan on tab_1  (cost=0.00..431.00 rows=1 width=5)
-                     ->  Hash  (cost=431.00..431.00 rows=1 width=7)
-                           ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=7)
-                                 ->  Seq Scan on tab_2  (cost=0.00..431.00 rows=1 width=7)
-               ->  Seq Scan on tab_3  (cost=0.00..431.00 rows=1 width=8)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
-(11 rows)
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate  (cost=0.00..1293.00 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1293.00 rows=1 width=8)
+         ->  Partial Aggregate  (cost=0.00..1293.00 rows=1 width=8)
+               ->  Append  (cost=0.00..1293.00 rows=2 width=1)
+                     ->  Hash Left Join  (cost=0.00..862.00 rows=1 width=3)
+                           Hash Cond: ((tab_1.id)::text = (tab_2.id)::text)
+                           ->  Seq Scan on tab_1  (cost=0.00..431.00 rows=1 width=5)
+                           ->  Hash  (cost=431.00..431.00 rows=1 width=7)
+                                 ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=7)
+                                       ->  Seq Scan on tab_2  (cost=0.00..431.00 rows=1 width=7)
+                     ->  Seq Scan on tab_3  (cost=0.00..431.00 rows=1 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(12 rows)
 
 SELECT Count(*)
 FROM   (SELECT *
@@ -11458,28 +11460,39 @@ SELECT * FROM ds_part, non_part2 WHERE ds_part.c = non_part2.e AND non_part2.f =
 (0 rows)
 
 explain analyze SELECT * FROM ds_part, non_part2 WHERE ds_part.c = non_part2.e AND non_part2.f = 10 AND a IN ( SELECT b + 1 FROM non_part1);
-                                                     QUERY PLAN                                                     
---------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1324481.18 rows=1 width=20)
-   ->  Hash Join  (cost=0.00..1324481.18 rows=1 width=20)
+                                                                          QUERY PLAN                                                                          
+--------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1324481.18 rows=1 width=20) (actual time=5.447..5.449 rows=0 loops=1)
+   ->  Hash Join  (cost=0.00..1324481.18 rows=1 width=20) (actual time=0.000..5.173 rows=0 loops=1)
          Hash Cond: (ds_part.c = non_part2.e)
-         ->  Dynamic Seq Scan on ds_part  (cost=0.00..1324050.11 rows=334 width=12)
+         ->  Dynamic Seq Scan on ds_part  (cost=0.00..1324050.11 rows=334 width=12) (actual time=0.000..0.367 rows=0 loops=1)
                Number of partitions to scan: 6 (out of 6)
                Filter: ((a = (b + 1)) AND (SubPlan 1))
+               Partitions scanned:  Avg 1.0 x 3 workers.  Max 1 parts (seg0).
                SubPlan 1
-                 ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
-                       ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..431.00 rows=1 width=4)
-                             ->  Limit  (cost=0.00..431.00 rows=1 width=4)
-                                   ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
-                                         ->  Limit  (cost=0.00..431.00 rows=1 width=4)
-                                               ->  Seq Scan on non_part1  (cost=0.00..431.00 rows=34 width=4)
-         ->  Hash  (cost=431.00..431.00 rows=1 width=8)
-               ->  Partition Selector (selector id: $0)  (cost=0.00..431.00 rows=1 width=8)
-                     ->  Broadcast Motion 3:3  (slice4; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
-                           ->  Seq Scan on non_part2  (cost=0.00..431.00 rows=1 width=8)
+                 ->  Materialize  (cost=0.00..431.00 rows=1 width=4) (never executed)
+                       ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..431.00 rows=1 width=4) (never executed)
+                             ->  Limit  (cost=0.00..431.00 rows=1 width=4) (actual time=3.007..3.008 rows=1 loops=1)
+                                   ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=4) (actual time=3.005..3.005 rows=1 loops=1)
+                                         ->  Limit  (cost=0.00..431.00 rows=1 width=4) (actual time=2.040..2.040 rows=1 loops=1)
+                                               ->  Seq Scan on non_part1  (cost=0.00..431.00 rows=34 width=4) (actual time=2.039..2.039 rows=1 loops=1)
+         ->  Hash  (cost=431.00..431.00 rows=1 width=8) (actual time=3.699..3.700 rows=1 loops=1)
+               Buckets: 262144  Batches: 1  Memory Usage: 2049kB
+               ->  Partition Selector (selector id: $0)  (cost=0.00..431.00 rows=1 width=8) (actual time=3.694..3.695 rows=1 loops=1)
+                     ->  Broadcast Motion 3:3  (slice4; segments: 3)  (cost=0.00..431.00 rows=1 width=8) (actual time=3.688..3.689 rows=1 loops=1)
+                           ->  Seq Scan on non_part2  (cost=0.00..431.00 rows=1 width=8) (actual time=0.644..0.648 rows=1 loops=1)
                                  Filter: (f = 10)
+                                 Rows Removed by Filter: 24
  Optimizer: Pivotal Optimizer (GPORCA)
-(19 rows)
+ Planning Time: 28.059 ms
+   (slice0)    Executor memory: 72K bytes.
+   (slice1)    Executor memory: 2150K bytes avg x 3 workers, 2150K bytes max (seg0).  Work_mem: 2049K bytes max.
+   (slice2)    Executor memory: 20K bytes (entry db).
+   (slice3)    Executor memory: 37K bytes avg x 3 workers, 37K bytes max (seg0).
+   (slice4)    Executor memory: 37K bytes avg x 3 workers, 37K bytes max (seg0).
+ Memory used:  128000kB
+ Execution Time: 6.965 ms
+(30 rows)
 
 SELECT *, a IN ( SELECT b + 1 FROM non_part1) FROM ds_part, non_part2 WHERE ds_part.c = non_part2.e AND non_part2.f = 10 AND a IN ( SELECT b FROM non_part1);
  a  | b  | c  | e  | f  | ?column? 
@@ -11502,16 +11515,16 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 INSERT INTO varchar_sc_array_cmp VALUES ('a'), ('b'), ('c'), ('d');
 EXPLAIN SELECT * FROM varchar_sc_array_cmp t1, varchar_sc_array_cmp t2 where t1.a = t2.a and t1.a in ('b', 'c');
-                                                      QUERY PLAN                                                      
-----------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=4 width=4)
-   ->  Hash Join  (cost=0.00..862.00 rows=2 width=4)
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=16)
+   ->  Hash Join  (cost=0.00..862.00 rows=1 width=16)
          Hash Cond: ((varchar_sc_array_cmp.a)::text = (varchar_sc_array_cmp_1.a)::text)
-         ->  Seq Scan on varchar_sc_array_cmp  (cost=0.00..431.00 rows=1 width=2)
-               Filter: (((a)::text = 'b'::text) OR ((a)::text = 'c'::text))
-         ->  Hash  (cost=431.00..431.00 rows=1 width=2)
-               ->  Seq Scan on varchar_sc_array_cmp varchar_sc_array_cmp_1  (cost=0.00..431.00 rows=1 width=2)
-                     Filter: (((a)::text = ANY ('{b,c}'::text[])) AND (((a)::text = 'b'::text) OR ((a)::text = 'c'::text)))
+         ->  Seq Scan on varchar_sc_array_cmp  (cost=0.00..431.00 rows=1 width=8)
+               Filter: (((a)::text = ANY ('{b,c}'::text[])) AND (a = ANY ('{b,c}'::character varying[])))
+         ->  Hash  (cost=431.00..431.00 rows=1 width=8)
+               ->  Seq Scan on varchar_sc_array_cmp varchar_sc_array_cmp_1  (cost=0.00..431.00 rows=1 width=8)
+                     Filter: (a = ANY ('{b,c}'::character varying[]))
  Optimizer: Pivotal Optimizer (GPORCA)
 (9 rows)
 
@@ -11524,17 +11537,17 @@ SELECT * FROM varchar_sc_array_cmp t1, varchar_sc_array_cmp t2 where t1.a = t2.a
 
 SET optimizer_array_constraints=on;
 EXPLAIN SELECT * FROM varchar_sc_array_cmp t1, varchar_sc_array_cmp t2 where t1.a = t2.a and (t1.a in ('b', 'c') OR t1.a = 'a');
-                                                  QUERY PLAN                                                   
----------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=4 width=4)
-   ->  Hash Join  (cost=0.00..862.00 rows=2 width=4)
+                                                               QUERY PLAN                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=16)
+   ->  Hash Join  (cost=0.00..862.00 rows=1 width=16)
          Hash Cond: ((varchar_sc_array_cmp.a)::text = (varchar_sc_array_cmp_1.a)::text)
-         ->  Seq Scan on varchar_sc_array_cmp  (cost=0.00..431.00 rows=1 width=2)
-               Filter: (a = ANY ('{a,b,c}'::character varying[]))
-         ->  Hash  (cost=431.00..431.00 rows=1 width=2)
-               ->  Seq Scan on varchar_sc_array_cmp varchar_sc_array_cmp_1  (cost=0.00..431.00 rows=1 width=2)
+         ->  Seq Scan on varchar_sc_array_cmp  (cost=0.00..431.00 rows=1 width=8)
+               Filter: ((((a)::text = ANY ('{b,c}'::text[])) OR ((a)::text = 'a'::text)) AND (a = ANY ('{a,b,c}'::character varying[])))
+         ->  Hash  (cost=431.00..431.00 rows=1 width=8)
+               ->  Seq Scan on varchar_sc_array_cmp varchar_sc_array_cmp_1  (cost=0.00..431.00 rows=1 width=8)
                      Filter: (a = ANY ('{a,b,c}'::character varying[]))
- Optimizer: Pivotal Optimizer (GPORCA) version 3.65.2
+ Optimizer: Pivotal Optimizer (GPORCA)
 (9 rows)
 
 SELECT * FROM varchar_sc_array_cmp t1, varchar_sc_array_cmp t2 where t1.a = t2.a and (t1.a in ('b', 'c') OR t1.a = 'a');
@@ -13181,13 +13194,15 @@ select * from foo join (select b, count(*) as cnt from tbtree group by b) grby o
          ->  Broadcast Motion 3:3  (slice3; segments: 3)
                ->  Seq Scan on foo
          ->  Materialize
-               ->  HashAggregate
+               ->  Finalize HashAggregate
                      Group Key: tbtree.b
                      ->  Redistribute Motion 3:3  (slice2; segments: 3)
                            Hash Key: tbtree.b
-                           ->  Seq Scan on tbtree
+                           ->  Streaming Partial HashAggregate
+                                 Group Key: tbtree.b
+                                 ->  Seq Scan on tbtree
  Optimizer: Pivotal Optimizer (GPORCA)
-(12 rows)
+(14 rows)
 
 -- 17 group by columns don't intersect - no index scan
 explain (costs off)
@@ -13205,13 +13220,15 @@ select * from foo join (select min_a, count(*) as cnt from (select min(a) as min
                            Hash Key: (min(tbitmap.a))
                            ->  Streaming Partial HashAggregate
                                  Group Key: min(tbitmap.a)
-                                 ->  HashAggregate
+                                 ->  Finalize HashAggregate
                                        Group Key: tbitmap.b
                                        ->  Redistribute Motion 3:3  (slice3; segments: 3)
                                              Hash Key: tbitmap.b
-                                             ->  Seq Scan on tbitmap
+                                             ->  Streaming Partial HashAggregate
+                                                   Group Key: tbitmap.b
+                                                   ->  Seq Scan on tbitmap
  Optimizer: Pivotal Optimizer (GPORCA)
-(17 rows)
+(19 rows)
 
 reset optimizer_join_order;
 reset optimizer_enable_hashjoin;
@@ -13472,20 +13489,21 @@ default partition def);
 create INDEX y_idx on y (j);
 set optimizer_enable_indexjoin=on;
 explain (costs off) select count(*) from x, y where (x.i > y.j AND x.j <= y.i);
-                          QUERY PLAN                           
----------------------------------------------------------------
- Aggregate
+                              QUERY PLAN                              
+----------------------------------------------------------------------
+ Finalize Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Nested Loop
-               Join Filter: true
-               ->  Broadcast Motion 3:3  (slice2; segments: 3)
-                     ->  Seq Scan on x
-               ->  Dynamic Index Scan on y_idx on y
-                     Index Cond: (j < x.i)
-                     Filter: ((j < x.i) AND (x.j <= i))
-                     Number of partitions to scan: 5 (out of 5)
+         ->  Partial Aggregate
+               ->  Nested Loop
+                     Join Filter: true
+                     ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                           ->  Seq Scan on x
+                     ->  Dynamic Index Scan on y_idx on y
+                           Index Cond: (j < x.i)
+                           Filter: ((j < x.i) AND (x.j <= i))
+                           Number of partitions to scan: 5 (out of 5)
  Optimizer: Pivotal Optimizer (GPORCA)
-(11 rows)
+(12 rows)
 
 reset optimizer_enable_indexjoin;
 -- InferPredicatesBCC-vcpart-txt.mdp
@@ -13719,23 +13737,21 @@ ORDER BY to_char(order_datetime,'YYYY-Q')
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Merge Key: (to_char(order_datetime, 'YYYY-Q'::text)), item_shipment_status_code
-   ->  Sort
-         Sort Key: (to_char(order_datetime, 'YYYY-Q'::text)), item_shipment_status_code
-         ->  Finalize GroupAggregate
-               Group Key: (to_char(order_datetime, 'YYYY-Q'::text)), item_shipment_status_code
-               ->  Sort
-                     Sort Key: (to_char(order_datetime, 'YYYY-Q'::text)), item_shipment_status_code
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                           Hash Key: (to_char(order_datetime, 'YYYY-Q'::text)), item_shipment_status_code
-                           ->  Partial GroupAggregate
-                                 Group Key: (to_char(order_datetime, 'YYYY-Q'::text)), item_shipment_status_code
-                                 ->  Sort
-                                       Sort Key: (to_char(order_datetime, 'YYYY-Q'::text)), item_shipment_status_code, order_id
-                                       ->  Dynamic Seq Scan on order_lineitems
-                                             Number of partitions to scan: 3 (out of 12)
-                                             Filter: ((order_datetime >= 'Thu Apr 01 00:00:00 2010'::timestamp without time zone) AND (order_datetime <= '06-30-2010'::date))
+   ->  Finalize GroupAggregate
+         Group Key: (to_char(order_datetime, 'YYYY-Q'::text)), item_shipment_status_code
+         ->  Sort
+               Sort Key: (to_char(order_datetime, 'YYYY-Q'::text)), item_shipment_status_code
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: (to_char(order_datetime, 'YYYY-Q'::text)), item_shipment_status_code
+                     ->  Partial GroupAggregate
+                           Group Key: (to_char(order_datetime, 'YYYY-Q'::text)), item_shipment_status_code
+                           ->  Sort
+                                 Sort Key: (to_char(order_datetime, 'YYYY-Q'::text)), item_shipment_status_code, order_id
+                                 ->  Dynamic Seq Scan on order_lineitems
+                                       Number of partitions to scan: 3 (out of 12)
+                                       Filter: ((order_datetime >= 'Thu Apr 01 00:00:00 2010'::timestamp without time zone) AND (order_datetime <= '06-30-2010'::date))
  Optimizer: Pivotal Optimizer (GPORCA)
-(18 rows)
+(16 rows)
 
 -- test partioned table with no partitions
 create table no_part (a int, b int) partition by list (a) distributed by (b);
@@ -14378,16 +14394,17 @@ EXPLAIN (COSTS OFF) SELECT (
    Join Filter: true
    ->  Result
    ->  Materialize
-         ->  Aggregate
+         ->  Finalize Aggregate
                ->  Gather Motion 3:1  (slice1; segments: 3)
-                     ->  Hash Join
-                           Hash Cond: (join_null_rej1.i = join_null_rej2.i)
-                           ->  Seq Scan on join_null_rej1
-                           ->  Hash
-                                 ->  Seq Scan on join_null_rej2
-                                       Filter: (i < join_null_rej_func())
+                     ->  Partial Aggregate
+                           ->  Hash Join
+                                 Hash Cond: (join_null_rej1.i = join_null_rej2.i)
+                                 ->  Seq Scan on join_null_rej1
+                                 ->  Hash
+                                       ->  Seq Scan on join_null_rej2
+                                             Filter: (i < join_null_rej_func())
  Optimizer: Pivotal Optimizer (GPORCA)
-(13 rows)
+(14 rows)
 
 -- Optional, but let's check we get same result for both, folded and
 -- not folded join_null_rej_func() function.

--- a/src/test/regress/expected/groupingsets_optimizer.out
+++ b/src/test/regress/expected/groupingsets_optimizer.out
@@ -2104,17 +2104,18 @@ explain (costs off)
                            ->  Streaming Partial HashAggregate
                                  Group Key: share0_ref6.thousand
                                  ->  Shared Scan (share slice:id 6:0)
-               ->  HashAggregate
+               ->  Finalize HashAggregate
                      Group Key: share0_ref7.twothousand
                      ->  Redistribute Motion 3:3  (slice7; segments: 3)
                            Hash Key: share0_ref7.twothousand
-                           ->  Result
+                           ->  Streaming Partial HashAggregate
+                                 Group Key: share0_ref7.twothousand
                                  ->  Shared Scan (share slice:id 7:0)
                ->  HashAggregate
                      Group Key: share0_ref8.unique1
                      ->  Shared Scan (share slice:id 1:0)
  Optimizer: Pivotal Optimizer (GPORCA)
-(52 rows)
+(53 rows)
 
 explain (costs off)
   select unique1,
@@ -2217,17 +2218,18 @@ explain (costs off)
                            ->  Streaming Partial HashAggregate
                                  Group Key: share0_ref6.thousand
                                  ->  Shared Scan (share slice:id 6:0)
-               ->  HashAggregate
+               ->  Finalize HashAggregate
                      Group Key: share0_ref7.twothousand
                      ->  Redistribute Motion 3:3  (slice7; segments: 3)
                            Hash Key: share0_ref7.twothousand
-                           ->  Result
+                           ->  Streaming Partial HashAggregate
+                                 Group Key: share0_ref7.twothousand
                                  ->  Shared Scan (share slice:id 7:0)
                ->  HashAggregate
                      Group Key: share0_ref8.unique1
                      ->  Shared Scan (share slice:id 1:0)
  Optimizer: Pivotal Optimizer (GPORCA)
-(52 rows)
+(53 rows)
 
 -- check collation-sensitive matching between grouping expressions
 -- (similar to a check for aggregates, but there are additional code

--- a/src/test/regress/expected/join_gp_optimizer.out
+++ b/src/test/regress/expected/join_gp_optimizer.out
@@ -1765,11 +1765,15 @@ explain select fooJoinPruning.* from fooJoinPruning left join barJoinPruning on 
                            Sort Key: barjoinpruning.t
                            ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
                                  Hash Key: barjoinpruning.t
-                                 ->  Seq Scan on barjoinpruning  (cost=0.00..431.00 rows=1 width=4)
+                                 ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=4)
+                                       Group Key: barjoinpruning.t
+                                       ->  Sort  (cost=0.00..431.00 rows=1 width=4)
+                                             Sort Key: barjoinpruning.t
+                                             ->  Seq Scan on barjoinpruning  (cost=0.00..431.00 rows=1 width=4)
          ->  Index Scan using idx2 on foojoinpruning  (cost=0.00..6.00 rows=1 width=28)
                Index Cond: (c = barjoinpruning.t)
  Optimizer: Pivotal Optimizer (GPORCA)
-(14 rows)
+(18 rows)
 
 explain select fooJoinPruning.* from fooJoinPruning left join barJoinPruning on fooJoinPruning.g=barJoinPruning.p and fooJoinPruning.a=barJoinPruning.q where fooJoinPruning.c > ANY (select barJoinPruning.t from barJoinPruning );
                                                                    QUERY PLAN                                                                    
@@ -1925,11 +1929,15 @@ explain select fooJoinPruning.* from fooJoinPruning left join barJoinPruning on 
                                        Sort Key: foojoinpruning.b
                                        ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
                                              Hash Key: foojoinpruning.b
-                                             ->  Seq Scan on foojoinpruning  (cost=0.00..431.00 rows=1 width=4)
+                                             ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=4)
+                                                   Group Key: foojoinpruning.b
+                                                   ->  Sort  (cost=0.00..431.00 rows=1 width=4)
+                                                         Sort Key: foojoinpruning.b
+                                                         ->  Seq Scan on foojoinpruning  (cost=0.00..431.00 rows=1 width=4)
                            ->  Index Scan using idx2 on barjoinpruning  (cost=0.00..6.00 rows=1 width=1)
                                  Index Cond: (p = foojoinpruning.b)
  Optimizer: Pivotal Optimizer (GPORCA)
-(19 rows)
+(23 rows)
 
 -- Unique key of inner relation ie 'p' is present in the join condition and is equal to a column from outer relation and filter contains corelated subquery referencing inner relation column--
 explain select fooJoinPruning.* from fooJoinPruning left join barJoinPruning on fooJoinPruning.c=barJoinPruning.p  where fooJoinPruning.b in (select barJoinPruning.q from fooJoinPruning);

--- a/src/test/regress/expected/limit_gp_optimizer.out
+++ b/src/test/regress/expected/limit_gp_optimizer.out
@@ -126,37 +126,45 @@ explain select distinct(a), sum(b) from t_volatile_limit_1 group by a order by a
                                                     QUERY PLAN                                                    
 ------------------------------------------------------------------------------------------------------------------
  Limit  (cost=0.00..431.00 rows=1 width=12)
-   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
          Merge Key: a, (sum(b))
          ->  Sort  (cost=0.00..431.00 rows=1 width=12)
                Sort Key: a, (sum(b))
-               ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=12)
+               ->  Finalize GroupAggregate  (cost=0.00..431.00 rows=1 width=12)
                      Group Key: a
-                     ->  Sort  (cost=0.00..431.00 rows=1 width=8)
+                     ->  Sort  (cost=0.00..431.00 rows=1 width=12)
                            Sort Key: a
-                           ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                           ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
                                  Hash Key: a
-                                 ->  Seq Scan on t_volatile_limit_1  (cost=0.00..431.00 rows=1 width=8)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.80.0
-(13 rows)
+                                 ->  Partial GroupAggregate  (cost=0.00..431.00 rows=1 width=12)
+                                       Group Key: a
+                                       ->  Sort  (cost=0.00..431.00 rows=1 width=8)
+                                             Sort Key: a
+                                             ->  Seq Scan on t_volatile_limit_1  (cost=0.00..431.00 rows=1 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(17 rows)
 
 explain select distinct(a), sum(b) from t_volatile_limit_1 group by a order by a, sum(b) limit 2 offset (random()*2);
                                                     QUERY PLAN                                                    
 ------------------------------------------------------------------------------------------------------------------
  Limit  (cost=0.00..431.00 rows=1 width=12)
-   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
          Merge Key: a, (sum(b))
          ->  Sort  (cost=0.00..431.00 rows=1 width=12)
                Sort Key: a, (sum(b))
-               ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=12)
+               ->  Finalize GroupAggregate  (cost=0.00..431.00 rows=1 width=12)
                      Group Key: a
-                     ->  Sort  (cost=0.00..431.00 rows=1 width=8)
+                     ->  Sort  (cost=0.00..431.00 rows=1 width=12)
                            Sort Key: a
-                           ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                           ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
                                  Hash Key: a
-                                 ->  Seq Scan on t_volatile_limit_1  (cost=0.00..431.00 rows=1 width=8)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.80.0
-(13 rows)
+                                 ->  Partial GroupAggregate  (cost=0.00..431.00 rows=1 width=12)
+                                       Group Key: a
+                                       ->  Sort  (cost=0.00..431.00 rows=1 width=8)
+                                             Sort Key: a
+                                             ->  Seq Scan on t_volatile_limit_1  (cost=0.00..431.00 rows=1 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(17 rows)
 
 drop table t_volatile_limit;
 drop table t_volatile_limit_1;

--- a/src/test/regress/expected/matview_optimizer.out
+++ b/src/test/regress/expected/matview_optimizer.out
@@ -22,15 +22,19 @@ EXPLAIN (costs off)
   CREATE MATERIALIZED VIEW IF NOT EXISTS mvtest_tm AS SELECT type, sum(amt) AS totamt FROM mvtest_t GROUP BY type WITH NO DATA distributed by(type);
                          QUERY PLAN                         
 ------------------------------------------------------------
- GroupAggregate
+ Finalize GroupAggregate
    Group Key: type
    ->  Sort
          Sort Key: type
          ->  Redistribute Motion 3:3  (slice1; segments: 3)
                Hash Key: type
-               ->  Seq Scan on mvtest_t
- Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
-(8 rows)
+               ->  Partial GroupAggregate
+                     Group Key: type
+                     ->  Sort
+                           Sort Key: type
+                           ->  Seq Scan on mvtest_t
+ Optimizer: Pivotal Optimizer (GPORCA)
+(12 rows)
 
 CREATE MATERIALIZED VIEW IF NOT EXISTS mvtest_tm AS SELECT type, sum(amt) AS totamt FROM mvtest_t GROUP BY type WITH NO DATA distributed by(type);
 SELECT relispopulated FROM pg_class WHERE oid = 'mvtest_tm'::regclass;
@@ -68,15 +72,19 @@ NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause. Creating a NULL policy entr
    ->  Sort
          Sort Key: type
          ->  Redistribute Motion 3:3  (slice1; segments: 3)
-               ->  GroupAggregate
+               ->  Finalize GroupAggregate
                      Group Key: type
                      ->  Sort
                            Sort Key: type
                            ->  Redistribute Motion 3:3  (slice2; segments: 3)
                                  Hash Key: type
-                                 ->  Seq Scan on mvtest_t
- Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
-(12 rows)
+                                 ->  Partial GroupAggregate
+                                       Group Key: type
+                                       ->  Sort
+                                             Sort Key: type
+                                             ->  Seq Scan on mvtest_t
+ Optimizer: Pivotal Optimizer (GPORCA)
+(16 rows)
 
 CREATE MATERIALIZED VIEW mvtest_tvm AS SELECT * FROM mvtest_tv ORDER BY type;
 SELECT * FROM mvtest_tvm;
@@ -103,15 +111,19 @@ EXPLAIN (costs off)
          ->  Finalize Aggregate
                ->  Gather Motion 3:1  (slice2; segments: 3)
                      ->  Partial Aggregate
-                           ->  GroupAggregate
+                           ->  Finalize GroupAggregate
                                  Group Key: type
                                  ->  Sort
                                        Sort Key: type
                                        ->  Redistribute Motion 3:3  (slice3; segments: 3)
                                              Hash Key: type
-                                             ->  Seq Scan on mvtest_t
- Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
-(13 rows)
+                                             ->  Partial GroupAggregate
+                                                   Group Key: type
+                                                   ->  Sort
+                                                         Sort Key: type
+                                                         ->  Seq Scan on mvtest_t
+ Optimizer: Pivotal Optimizer (GPORCA)
+(17 rows)
 
 CREATE MATERIALIZED VIEW mvtest_tvvm AS SELECT * FROM mvtest_tvv;
 CREATE VIEW mvtest_tvvmv AS SELECT * FROM mvtest_tvvm;

--- a/src/test/regress/expected/notin_optimizer.out
+++ b/src/test/regress/expected/notin_optimizer.out
@@ -1196,17 +1196,23 @@ explain select c1 from t1 where c1::absint not in
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1324035.89 rows=10 width=4)
    ->  Result  (cost=0.00..1324035.89 rows=4 width=4)
          Filter: (NOT CASE WHEN ((count((true))) > '0'::bigint) THEN CASE WHEN ((sum((CASE WHEN (((t1.c1)::absint = ((t1n.c1n)::absint)) IS NULL) THEN 1 ELSE 0 END))) = (count((true)))) THEN NULL::boolean ELSE true END ELSE false END)
-         ->  HashAggregate  (cost=0.00..1324035.89 rows=4 width=20)
+         ->  Finalize GroupAggregate  (cost=0.00..1324035.89 rows=4 width=20)
                Group Key: t1.c1, t1.ctid, t1.gp_segment_id
-               ->  Nested Loop Left Join  (cost=0.00..1324035.89 rows=11 width=19)
-                     Join Filter: (((t1.c1)::absint = ((t1n.c1n)::absint)) IS NOT FALSE)
-                     ->  Seq Scan on t1  (cost=0.00..431.00 rows=4 width=14)
-                     ->  Materialize  (cost=0.00..431.00 rows=7 width=5)
-                           ->  Result  (cost=0.00..431.00 rows=7 width=5)
-                                 ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=7 width=4)
-                                       ->  Seq Scan on t1n  (cost=0.00..431.00 rows=3 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
-(13 rows)
+               ->  Sort  (cost=0.00..1324035.89 rows=4 width=30)
+                     Sort Key: t1.ctid, t1.gp_segment_id
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..1324035.89 rows=4 width=30)
+                           Hash Key: t1.ctid, t1.gp_segment_id
+                           ->  Streaming Partial HashAggregate  (cost=0.00..1324035.89 rows=4 width=30)
+                                 Group Key: t1.c1, t1.ctid, t1.gp_segment_id
+                                 ->  Nested Loop Left Join  (cost=0.00..1324035.89 rows=11 width=19)
+                                       Join Filter: (((t1.c1)::absint = ((t1n.c1n)::absint)) IS NOT FALSE)
+                                       ->  Seq Scan on t1  (cost=0.00..431.00 rows=4 width=14)
+                                       ->  Materialize  (cost=0.00..431.00 rows=7 width=5)
+                                             ->  Result  (cost=0.00..431.00 rows=7 width=5)
+                                                   ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=7 width=4)
+                                                         ->  Seq Scan on t1n  (cost=0.00..431.00 rows=3 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(19 rows)
 
 select c1 from t1 where c1::absint not in
 	(select c1n::absint from t1n);

--- a/src/test/regress/expected/olap_plans_optimizer.out
+++ b/src/test/regress/expected/olap_plans_optimizer.out
@@ -142,16 +142,21 @@ select sum(distinct a) from olap_test_single;
 
 -- Otherwise, need a more complicated plans
 explain select sum(distinct b) from olap_test_single;
-                                               QUERY PLAN                                                
----------------------------------------------------------------------------------------------------------
- Finalize Aggregate  (cost=0.00..431.15 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.15 rows=1 width=8)
-         ->  Partial Aggregate  (cost=0.00..431.15 rows=1 width=8)
-               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.15 rows=3334 width=4)
-                     Hash Key: b
-                     ->  Seq Scan on olap_test_single  (cost=0.00..431.08 rows=3334 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.79.1
-(7 rows)
+                                                 QUERY PLAN                                                 
+------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..431.51 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.51 rows=11 width=4)
+         ->  GroupAggregate  (cost=0.00..431.51 rows=4 width=4)
+               Group Key: b
+               ->  Sort  (cost=0.00..431.51 rows=4 width=4)
+                     Sort Key: b
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.51 rows=4 width=4)
+                           Hash Key: b
+                           ->  Streaming HashAggregate  (cost=0.00..431.51 rows=4 width=4)
+                                 Group Key: b
+                                 ->  Seq Scan on olap_test_single  (cost=0.00..431.08 rows=3334 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(12 rows)
 
 select sum(distinct b) from olap_test_single;
  sum 
@@ -165,14 +170,17 @@ select sum(distinct b) from olap_test_single;
 explain select sum(distinct d) from olap_test_single;
                                                QUERY PLAN                                                
 ---------------------------------------------------------------------------------------------------------
- Finalize Aggregate  (cost=0.00..431.15 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.15 rows=1 width=8)
-         ->  Partial Aggregate  (cost=0.00..431.15 rows=1 width=8)
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.15 rows=3334 width=4)
+ Aggregate  (cost=0.00..432.12 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..432.12 rows=10000 width=4)
+         ->  HashAggregate  (cost=0.00..431.97 rows=3334 width=4)
+               Group Key: d
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.56 rows=3334 width=4)
                      Hash Key: d
-                     ->  Seq Scan on olap_test_single  (cost=0.00..431.08 rows=3334 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.88.0
-(7 rows)
+                     ->  Streaming HashAggregate  (cost=0.00..431.52 rows=3334 width=4)
+                           Group Key: d
+                           ->  Seq Scan on olap_test_single  (cost=0.00..431.08 rows=3334 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(10 rows)
 
 select sum(distinct d) from olap_test_single;
    sum    
@@ -261,16 +269,17 @@ select a, b, c, sum(d) from olap_test group by grouping sets((a, b), (a), (b, c)
 explain select a, b, d, sum(d) from olap_test group by grouping sets((a, b), (a), (b, d));
                                                     QUERY PLAN                                                     
 -------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1727.49 rows=10022 width=20)
-   ->  Sequence  (cost=0.00..1726.74 rows=3341 width=20)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1728.41 rows=10022 width=20)
+   ->  Sequence  (cost=0.00..1727.67 rows=3341 width=20)
          ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.16 rows=3334 width=1)
                ->  Seq Scan on olap_test  (cost=0.00..431.08 rows=3334 width=12)
-         ->  Append  (cost=0.00..1295.51 rows=3341 width=20)
-               ->  HashAggregate  (cost=0.00..431.99 rows=3334 width=16)
+         ->  Append  (cost=0.00..1296.44 rows=3341 width=20)
+               ->  Finalize HashAggregate  (cost=0.00..432.91 rows=3334 width=16)
                      Group Key: share0_ref2.b, share0_ref2.d
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.15 rows=3334 width=8)
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..432.07 rows=3334 width=16)
                            Hash Key: share0_ref2.b, share0_ref2.d
-                           ->  Result  (cost=0.00..431.06 rows=3334 width=8)
+                           ->  Streaming Partial HashAggregate  (cost=0.00..431.91 rows=3334 width=16)
+                                 Group Key: share0_ref2.b, share0_ref2.d
                                  ->  Shared Scan (share slice:id 2:0)  (cost=0.00..431.06 rows=3334 width=8)
                ->  Finalize GroupAggregate  (cost=0.00..431.48 rows=1 width=12)
                      Group Key: share0_ref3.a
@@ -285,7 +294,7 @@ explain select a, b, d, sum(d) from olap_test group by grouping sets((a, b), (a)
                      Group Key: share0_ref4.a, share0_ref4.b
                      ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.10 rows=3334 width=12)
  Optimizer: Pivotal Optimizer (GPORCA)
-(24 rows)
+(25 rows)
 
 -- do not execute this query as it would produce too many tuples.
 -- Test that when the second-stage Agg doesn't try to preserve the

--- a/src/test/regress/expected/partition_optimizer.out
+++ b/src/test/regress/expected/partition_optimizer.out
@@ -6431,15 +6431,16 @@ insert into test_listPartition values(2,'2022-10-23');
 insert into test_listPartition values(3,'2022-10-24');
 --Test case with condition on date and timestamp
 explain (costs off) select max(d) from test_listPartition where d='2022-10-23' or d=('2022-10-23'::date -interval '1 day');
-                                                    QUERY PLAN                                                     
--------------------------------------------------------------------------------------------------------------------
- Aggregate
+                                                       QUERY PLAN                                                        
+-------------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Dynamic Seq Scan on test_listpartition
-               Number of partitions to scan: 2 (out of 3)
-               Filter: ((d = '10-23-2022'::date) OR (d = 'Sat Oct 22 00:00:00 2022'::timestamp without time zone))
+         ->  Partial Aggregate
+               ->  Dynamic Seq Scan on test_listpartition
+                     Number of partitions to scan: 2 (out of 3)
+                     Filter: ((d = '10-23-2022'::date) OR (d = 'Sat Oct 22 00:00:00 2022'::timestamp without time zone))
  Optimizer: Pivotal Optimizer (GPORCA)
-(6 rows)
+(7 rows)
 
 select max(d) from test_listPartition where d='2022-10-23' or d=('2022-10-23'::date -interval '1 day');
     max     
@@ -6449,15 +6450,16 @@ select max(d) from test_listPartition where d='2022-10-23' or d=('2022-10-23'::d
 
 --Test case with condition on date and date
 explain (costs off) select max(d) from test_listPartition where d='2022-10-23' or d='2022-10-22';
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
- Aggregate
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Finalize Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Dynamic Seq Scan on test_listpartition
-               Number of partitions to scan: 2 (out of 3)
-               Filter: ((d = '10-23-2022'::date) OR (d = '10-22-2022'::date))
+         ->  Partial Aggregate
+               ->  Dynamic Seq Scan on test_listpartition
+                     Number of partitions to scan: 2 (out of 3)
+                     Filter: ((d = '10-23-2022'::date) OR (d = '10-22-2022'::date))
  Optimizer: Pivotal Optimizer (GPORCA)
-(6 rows)
+(7 rows)
 
 select max(d) from test_listPartition where d='2022-10-23' or d='2022-10-22';
     max     
@@ -6467,15 +6469,16 @@ select max(d) from test_listPartition where d='2022-10-23' or d='2022-10-22';
 
 --Test case with condition on timestamp and timestamp
 explain (costs off) select max(d) from test_listPartition where d=('2022-10-23'::date -interval '0 day') or d=('2022-10-23'::date -interval '1 day');
-                                                                       QUERY PLAN                                                                       
---------------------------------------------------------------------------------------------------------------------------------------------------------
- Aggregate
+                                                                          QUERY PLAN                                                                          
+--------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  Dynamic Seq Scan on test_listpartition
-               Number of partitions to scan: 2 (out of 3)
-               Filter: ((d = 'Sun Oct 23 00:00:00 2022'::timestamp without time zone) OR (d = 'Sat Oct 22 00:00:00 2022'::timestamp without time zone))
+         ->  Partial Aggregate
+               ->  Dynamic Seq Scan on test_listpartition
+                     Number of partitions to scan: 2 (out of 3)
+                     Filter: ((d = 'Sun Oct 23 00:00:00 2022'::timestamp without time zone) OR (d = 'Sat Oct 22 00:00:00 2022'::timestamp without time zone))
  Optimizer: Pivotal Optimizer (GPORCA)
-(6 rows)
+(7 rows)
 
 select max(d) from test_listPartition where d=('2022-10-23'::date -interval '0 day') or d=('2022-10-23'::date -interval '1 day');
     max     

--- a/src/test/regress/expected/plancache_optimizer.out
+++ b/src/test/regress/expected/plancache_optimizer.out
@@ -294,14 +294,15 @@ analyze test_mode;
 prepare test_mode_pp (int) as select count(*) from test_mode where a = $1;
 -- up to 5 executions, custom plan is used
 explain (costs off) execute test_mode_pp(2);
-                        QUERY PLAN                        
-----------------------------------------------------------
- Aggregate
+                           QUERY PLAN                            
+-----------------------------------------------------------------
+ Finalize Aggregate
    ->  Gather Motion 1:1  (slice1; segments: 1)
-         ->  Index Scan using test_mode_a_idx on test_mode
-               Index Cond: (a = 2)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.93.0
-(5 rows)
+         ->  Partial Aggregate
+               ->  Index Scan using test_mode_a_idx on test_mode
+                     Index Cond: (a = 2)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(6 rows)
 
 -- force generic plan
 set plan_cache_mode to force_generic_plan;
@@ -350,26 +351,28 @@ execute test_mode_pp(1); -- 5x
 
 -- we should now get a really bad plan
 explain (costs off) execute test_mode_pp(2);
-         QUERY PLAN          
------------------------------
- Aggregate
+                           QUERY PLAN                            
+-----------------------------------------------------------------
+ Finalize Aggregate
    ->  Gather Motion 1:1  (slice1; segments: 1)
-         ->  Index Scan using test_mode_a_idx on test_mode
-               Index Cond: (a = 2)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.93.0
-(5 rows)
+         ->  Partial Aggregate
+               ->  Index Scan using test_mode_a_idx on test_mode
+                     Index Cond: (a = 2)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(6 rows)
 
 -- but we can force a custom plan
 set plan_cache_mode to force_custom_plan;
 explain (costs off) execute test_mode_pp(2);
-                        QUERY PLAN                        
-----------------------------------------------------------
- Aggregate
+                           QUERY PLAN                            
+-----------------------------------------------------------------
+ Finalize Aggregate
    ->  Gather Motion 1:1  (slice1; segments: 1)
-         ->  Index Scan using test_mode_a_idx on test_mode
-               Index Cond: (a = 2)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.93.0
-(5 rows)
+         ->  Partial Aggregate
+               ->  Index Scan using test_mode_a_idx on test_mode
+                     Index Cond: (a = 2)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(6 rows)
 
 drop table test_mode;
 --

--- a/src/test/regress/expected/qp_correlated_query_optimizer.out
+++ b/src/test/regress/expected/qp_correlated_query_optimizer.out
@@ -735,10 +735,10 @@ explain select A.i, B.i, C.j from A, B, C where A.j = any (select C.j from C whe
                                  Join Filter: true
                                  ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
                                        ->  Hash Join  (cost=0.00..431.00 rows=1 width=4)
-                                             Hash Cond: "outer".j = a.j
+                                             Hash Cond: ((NULL::integer) = a.j)
                                              ->  Result  (cost=0.00..0.00 rows=0 width=4)
                                                    ->  HashAggregate  (cost=0.00..0.00 rows=0 width=4)
-                                                         Group By: NULL::integer
+                                                         Group Key: NULL::integer
                                                          ->  Result  (cost=0.00..0.00 rows=0 width=4)
                                                                One-Time Filter: false
                                              ->  Hash  (cost=431.00..431.00 rows=2 width=8)
@@ -749,9 +749,8 @@ explain select A.i, B.i, C.j from A, B, C where A.j = any (select C.j from C whe
                            ->  Materialize  (cost=0.00..431.00 rows=9 width=4)
                                  ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=9 width=4)
                                        ->  Seq Scan on c  (cost=0.00..431.00 rows=3 width=4)
- Settings:  optimizer=on
- Optimizer status: Pivotal Optimizer (GPORCA) version 2.34.0
-(28 rows)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(27 rows)
 
 select A.i, B.i, C.j from A, B, C where A.j = any (select C.j from C where C.j = A.j and not exists (select sum(B.i) from B where C.i = B.i and C.i !=10)) order by A.i, B.i, C.j limit 10;
  i | i | j 
@@ -834,30 +833,34 @@ explain select A.i, B.i, C.j from A, B, C where A.j = (select sum(C.j) from C wh
                                  ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1324467.58 rows=5 width=4)
                                        ->  Hash Join  (cost=0.00..1324467.58 rows=2 width=4)
                                              Hash Cond: (((sum(c.j)) = (a.j)::bigint) AND (c.j = a.j))
-                                             ->  GroupAggregate  (cost=0.00..1324036.58 rows=3 width=12)
+                                             ->  Finalize GroupAggregate  (cost=0.00..1324036.58 rows=3 width=12)
                                                    Group Key: c.j
-                                                   ->  Sort  (cost=0.00..1324036.58 rows=3 width=4)
+                                                   ->  Sort  (cost=0.00..1324036.58 rows=3 width=12)
                                                          Sort Key: c.j
-                                                         ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..1324036.58 rows=3 width=4)
+                                                         ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..1324036.58 rows=3 width=12)
                                                                Hash Key: c.j
-                                                               ->  Seq Scan on c  (cost=0.00..1324036.58 rows=3 width=4)
-                                                                     Filter: (SubPlan 1)
-                                                                     SubPlan 1
-                                                                       ->  Result  (cost=0.00..431.00 rows=1 width=1)
-                                                                             Filter: ((CASE WHEN (sum((CASE WHEN (c.i <> b.i) THEN 1 ELSE 0 END)) IS NULL) THEN true WHEN (sum((CASE WHEN (b.i IS NULL) THEN 1 ELSE 0 END)) > '0'::bigint) THEN NULL::boolean WHEN (c.i IS NULL) THEN NULL::boolean WHEN (sum((CASE WHEN (c.i <> b.i) THEN 1 ELSE 0 END)) = '0'::bigint) THEN true ELSE false END) = true)
-                                                                             ->  Aggregate  (cost=0.00..431.00 rows=1 width=16)
-                                                                                   ->  Result  (cost=0.00..431.00 rows=1 width=4)
-                                                                                         Filter: (c.i = b.i)
-                                                                                         ->  Materialize  (cost=0.00..431.00 rows=6 width=4)
-                                                                                               ->  Broadcast Motion 3:3  (slice4; segments: 3)  (cost=0.00..431.00 rows=6 width=4)
-                                                                                                     ->  Seq Scan on b  (cost=0.00..431.00 rows=2 width=4)
-                                                                                                           Filter: (i <> 10)
+                                                               ->  Partial GroupAggregate  (cost=0.00..1324036.58 rows=3 width=12)
+                                                                     Group Key: c.j
+                                                                     ->  Sort  (cost=0.00..1324036.58 rows=3 width=4)
+                                                                           Sort Key: c.j
+                                                                           ->  Seq Scan on c  (cost=0.00..1324036.58 rows=3 width=4)
+                                                                                 Filter: (SubPlan 1)
+                                                                                 SubPlan 1
+                                                                                   ->  Result  (cost=0.00..431.00 rows=1 width=1)
+                                                                                         Filter: ((CASE WHEN (sum((CASE WHEN (c.i <> b.i) THEN 1 ELSE 0 END)) IS NULL) THEN true WHEN (sum((CASE WHEN (b.i IS NULL) THEN 1 ELSE 0 END)) > '0'::bigint) THEN NULL::boolean WHEN (c.i IS NULL) THEN NULL::boolean WHEN (sum((CASE WHEN (c.i <> b.i) THEN 1 ELSE 0 END)) = '0'::bigint) THEN true ELSE false END) = true)
+                                                                                         ->  Aggregate  (cost=0.00..431.00 rows=1 width=16)
+                                                                                               ->  Result  (cost=0.00..431.00 rows=1 width=4)
+                                                                                                     Filter: (c.i = b.i)
+                                                                                                     ->  Materialize  (cost=0.00..431.00 rows=6 width=4)
+                                                                                                           ->  Broadcast Motion 3:3  (slice4; segments: 3)  (cost=0.00..431.00 rows=6 width=4)
+                                                                                                                 ->  Seq Scan on b  (cost=0.00..431.00 rows=2 width=4)
+                                                                                                                       Filter: (i <> 10)
                                              ->  Hash  (cost=431.00..431.00 rows=2 width=8)
                                                    ->  Redistribute Motion 3:3  (slice5; segments: 3)  (cost=0.00..431.00 rows=2 width=8)
                                                          Hash Key: a.j
                                                          ->  Seq Scan on a  (cost=0.00..431.00 rows=2 width=8)
  Optimizer: Pivotal Optimizer (GPORCA)
-(40 rows)
+(44 rows)
 
 select A.i, B.i, C.j from A, B, C where A.j = (select sum(C.j) from C where C.j = A.j and C.i = all (select B.i from B where C.i = B.i and B.i !=10)) order by A.i, B.i, C.j limit 10;
  i | i  | j  

--- a/src/test/regress/expected/qp_misc_jiras_optimizer.out
+++ b/src/test/regress/expected/qp_misc_jiras_optimizer.out
@@ -2953,7 +2953,7 @@ explain select * from qp_misc_jiras.tbl6833_anl; -- should not hit cdbRelSize();
 -------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
    ->  Dynamic Seq Scan on tbl6833_anl  (cost=0.00..431.00 rows=1 width=12)
-         Number of partitions to scan: 2 
+         Number of partitions to scan: 2 (out of 2)
  Optimizer: Pivotal Optimizer (GPORCA)
 (4 rows)
 
@@ -2972,7 +2972,7 @@ explain select * from qp_misc_jiras.tbl6833_vac; -- should not hit cdbRelSize();
 -------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
    ->  Dynamic Seq Scan on tbl6833_vac  (cost=0.00..431.00 rows=1 width=12)
-         Number of partitions to scan: 2 
+         Number of partitions to scan: 2 (out of 2)
  Optimizer: Pivotal Optimizer (GPORCA)
 (4 rows)
 
@@ -4224,81 +4224,89 @@ reset gp_enable_agg_distinct;
 reset gp_enable_agg_distinct_pruning;
 -- both queries should use hashagg
 explain select count(distinct j) from (select t1.* from qp_misc_jiras.tbl5994_test t1, qp_misc_jiras.tbl5994_test t2 where t1.j = t2.j) tmp group by j;
-                                                      QUERY PLAN                                                       
------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
+                                                         QUERY PLAN                                                          
+-----------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
    ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=8)
          Group Key: tbl5994_test.j
-         ->  Sort  (cost=0.00..862.00 rows=1 width=4)
-               Sort Key: tbl5994_test.j
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
-                     Hash Key: tbl5994_test.j
-                     ->  Hash Join  (cost=0.00..862.00 rows=1 width=4)
-                           Hash Cond: (tbl5994_test.j = tbl5994_test_1.j)
-                           ->  Seq Scan on tbl5994_test  (cost=0.00..431.00 rows=1 width=4)
-                           ->  Hash  (cost=431.00..431.00 rows=1 width=4)
-                                 ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
-                                       ->  Seq Scan on tbl5994_test tbl5994_test_1  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
-(14 rows)
+         ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=4)
+               Group Key: tbl5994_test.j
+               ->  Sort  (cost=0.00..862.00 rows=1 width=4)
+                     Sort Key: tbl5994_test.j
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
+                           Hash Key: tbl5994_test.j
+                           ->  Hash Join  (cost=0.00..862.00 rows=1 width=4)
+                                 Hash Cond: (tbl5994_test.j = tbl5994_test_1.j)
+                                 ->  Seq Scan on tbl5994_test  (cost=0.00..431.00 rows=1 width=4)
+                                 ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+                                       ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                                             ->  Seq Scan on tbl5994_test tbl5994_test_1  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(16 rows)
 
 explain select count(distinct j) from (select t1.* from qp_misc_jiras.tbl5994_test t1, qp_misc_jiras.tbl5994_test t2 where t1.i = t2.i) tmp group by j;
-                                                   QUERY PLAN                                                    
------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
    ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=8)
          Group Key: tbl5994_test.j
-         ->  Sort  (cost=0.00..862.00 rows=1 width=4)
-               Sort Key: tbl5994_test.j
-               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
-                     Hash Key: tbl5994_test.j
-                     ->  Hash Join  (cost=0.00..862.00 rows=1 width=4)
-                           Hash Cond: (tbl5994_test.i = tbl5994_test_1.i)
-                           ->  Seq Scan on tbl5994_test  (cost=0.00..431.00 rows=1 width=8)
-                           ->  Hash  (cost=431.00..431.00 rows=1 width=4)
-                                 ->  Seq Scan on tbl5994_test tbl5994_test_1  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
-(13 rows)
+         ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=4)
+               Group Key: tbl5994_test.j
+               ->  Sort  (cost=0.00..862.00 rows=1 width=4)
+                     Sort Key: tbl5994_test.j
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
+                           Hash Key: tbl5994_test.j
+                           ->  Hash Join  (cost=0.00..862.00 rows=1 width=4)
+                                 Hash Cond: (tbl5994_test.i = tbl5994_test_1.i)
+                                 ->  Seq Scan on tbl5994_test  (cost=0.00..431.00 rows=1 width=8)
+                                 ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+                                       ->  Seq Scan on tbl5994_test tbl5994_test_1  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(15 rows)
 
 -- Try same two queries, with group agg.
 set enable_groupagg=on;
 set enable_hashagg=off;
 explain select count(distinct j) from (select t1.* from qp_misc_jiras.tbl5994_test t1, qp_misc_jiras.tbl5994_test t2 where t1.j = t2.j) tmp group by j;
-                                                      QUERY PLAN                                                       
------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
+                                                         QUERY PLAN                                                          
+-----------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
    ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=8)
          Group Key: tbl5994_test.j
-         ->  Sort  (cost=0.00..862.00 rows=1 width=4)
-               Sort Key: tbl5994_test.j
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
-                     Hash Key: tbl5994_test.j
-                     ->  Hash Join  (cost=0.00..862.00 rows=1 width=4)
-                           Hash Cond: (tbl5994_test.j = tbl5994_test_1.j)
-                           ->  Seq Scan on tbl5994_test  (cost=0.00..431.00 rows=1 width=4)
-                           ->  Hash  (cost=431.00..431.00 rows=1 width=4)
-                                 ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
-                                       ->  Seq Scan on tbl5994_test tbl5994_test_1  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
-(14 rows)
+         ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=4)
+               Group Key: tbl5994_test.j
+               ->  Sort  (cost=0.00..862.00 rows=1 width=4)
+                     Sort Key: tbl5994_test.j
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
+                           Hash Key: tbl5994_test.j
+                           ->  Hash Join  (cost=0.00..862.00 rows=1 width=4)
+                                 Hash Cond: (tbl5994_test.j = tbl5994_test_1.j)
+                                 ->  Seq Scan on tbl5994_test  (cost=0.00..431.00 rows=1 width=4)
+                                 ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+                                       ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                                             ->  Seq Scan on tbl5994_test tbl5994_test_1  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(16 rows)
 
 explain select count(distinct j) from (select t1.* from qp_misc_jiras.tbl5994_test t1, qp_misc_jiras.tbl5994_test t2 where t1.i = t2.i) tmp group by j;
-                                                   QUERY PLAN                                                    
------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
    ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=8)
          Group Key: tbl5994_test.j
-         ->  Sort  (cost=0.00..862.00 rows=1 width=4)
-               Sort Key: tbl5994_test.j
-               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
-                     Hash Key: tbl5994_test.j
-                     ->  Hash Join  (cost=0.00..862.00 rows=1 width=4)
-                           Hash Cond: (tbl5994_test.i = tbl5994_test_1.i)
-                           ->  Seq Scan on tbl5994_test  (cost=0.00..431.00 rows=1 width=8)
-                           ->  Hash  (cost=431.00..431.00 rows=1 width=4)
-                                 ->  Seq Scan on tbl5994_test tbl5994_test_1  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
-(13 rows)
+         ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=4)
+               Group Key: tbl5994_test.j
+               ->  Sort  (cost=0.00..862.00 rows=1 width=4)
+                     Sort Key: tbl5994_test.j
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
+                           Hash Key: tbl5994_test.j
+                           ->  Hash Join  (cost=0.00..862.00 rows=1 width=4)
+                                 Hash Cond: (tbl5994_test.i = tbl5994_test_1.i)
+                                 ->  Seq Scan on tbl5994_test  (cost=0.00..431.00 rows=1 width=8)
+                                 ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+                                       ->  Seq Scan on tbl5994_test tbl5994_test_1  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(15 rows)
 
 reset enable_groupagg;
 reset enable_hashagg;
@@ -4324,14 +4332,14 @@ explain analyze select reltablespace  from pg_class where oid = (select reltoast
  Index Scan using pg_class_oid_index on pg_class  (cost=8.44..16.46 rows=1 width=4) (actual time=0.037..0.038 rows=1 loops=1)
    Index Cond: (oid = $0)
    InitPlan 1 (returns $0)
-     ->  Index Scan using pg_class_relname_nsp_index on pg_class pg_class_1  (cost=0.28..8.29 rows=1 width=4) (actual time=0.016..0.017 rows=1 loops=1)
+     ->  Index Scan using pg_class_relname_nsp_index on pg_class pg_class_1  (cost=0.28..8.29 rows=1 width=4) (actual time=0.012..0.013 rows=1 loops=1)
            Index Cond: (relname = 'tbl_8205'::name)
- Planning Time: 4.806 ms
+ Optimizer: Postgres query optimizer
+ Planning Time: 3.074 ms
    (slice0)    Executor memory: 46K bytes.
    (slice1)    Executor memory: 79K bytes.
  Memory used:  1000kB
- Optimizer: Postgres query optimizer
- Execution Time: 0.129 ms
+ Execution Time: 0.102 ms
 (11 rows)
 
 select reltablespace from pg_class where oid = (select reltoastrelid from pg_class where relname='tbl_8205');
@@ -4701,18 +4709,22 @@ then 'MO' else 'foo' end
 case when ir_call_type_group_code in ('H', 'VH', 'PCB') then 'Thailland'
 else 'Unidentify' end
 ;
-                                                                                                                                  QUERY PLAN                                                                                                                                  
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                                                                                                                        QUERY PLAN                                                                                                                                        
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
    ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=8)
          Group Key: (CASE WHEN (ir_call_supplementary_svc_code = ANY ('{S20,S21}'::bpchar[])) THEN 'MO'::text ELSE 'foo'::text END), (CASE WHEN ((ir_call_type_group_code)::text = ANY ('{H,VH,PCB}'::text[])) THEN 'Thailland'::text ELSE 'Unidentify'::text END)
          ->  Sort  (cost=0.00..431.00 rows=1 width=16)
                Sort Key: (CASE WHEN (ir_call_supplementary_svc_code = ANY ('{S20,S21}'::bpchar[])) THEN 'MO'::text ELSE 'foo'::text END), (CASE WHEN ((ir_call_type_group_code)::text = ANY ('{H,VH,PCB}'::text[])) THEN 'Thailland'::text ELSE 'Unidentify'::text END)
-               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=16)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=16)
                      Hash Key: (CASE WHEN (ir_call_supplementary_svc_code = ANY ('{S20,S21}'::bpchar[])) THEN 'MO'::text ELSE 'foo'::text END), (CASE WHEN ((ir_call_type_group_code)::text = ANY ('{H,VH,PCB}'::text[])) THEN 'Thailland'::text ELSE 'Unidentify'::text END)
-                     ->  Seq Scan on ir_voice_sms_and_data  (cost=0.00..431.00 rows=1 width=16)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
-(9 rows)
+                     ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=16)
+                           Group Key: (CASE WHEN (ir_call_supplementary_svc_code = ANY ('{S20,S21}'::bpchar[])) THEN 'MO'::text ELSE 'foo'::text END), (CASE WHEN ((ir_call_type_group_code)::text = ANY ('{H,VH,PCB}'::text[])) THEN 'Thailland'::text ELSE 'Unidentify'::text END)
+                           ->  Sort  (cost=0.00..431.00 rows=1 width=16)
+                                 Sort Key: (CASE WHEN (ir_call_supplementary_svc_code = ANY ('{S20,S21}'::bpchar[])) THEN 'MO'::text ELSE 'foo'::text END), (CASE WHEN ((ir_call_type_group_code)::text = ANY ('{H,VH,PCB}'::text[])) THEN 'Thailland'::text ELSE 'Unidentify'::text END)
+                                 ->  Seq Scan on ir_voice_sms_and_data  (cost=0.00..431.00 rows=1 width=16)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(13 rows)
 
 DROP TABLE qp_misc_jiras.ir_voice_sms_and_data;
 reset gp_motion_cost_per_row;
@@ -4948,19 +4960,21 @@ select  * from qp_misc_jiras.test_co where ctid='(33554432,2)' and gp_segment_id
 set gp_enable_explain_allstat=on;
 insert into qp_misc_jiras.test_heap select i, i from generate_series(0, 99999) i;
 explain analyze select count(*) from qp_misc_jiras.test_heap;
-                                                                   QUERY PLAN                                                                    
--------------------------------------------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=0.00..431.00 rows=1 width=8) (actual time=55.789..55.790 rows=1 loops=1)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=1) (actual time=2.020..42.516 rows=100001 loops=1)
-         ->  Seq Scan on test_heap  (cost=0.00..431.00 rows=1 width=1) (actual time=0.075..9.629 rows=33462 loops=1)
-               allstat: seg_firststart_total_ntuples/seg0_0.564 ms_9.629 ms_33462/seg1_0.542 ms_8.289 ms_33329/seg2_0.544 ms_9.122 ms_33210//end
- Planning Time: 16.477 ms
-   (slice0)    Executor memory: 111K bytes.
-   (slice1)    Executor memory: 36K bytes avg x 3 workers, 36K bytes max (seg0).
+                                                                      QUERY PLAN                                                                       
+-------------------------------------------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate  (cost=0.00..431.00 rows=1 width=8) (actual time=8.563..8.564 rows=1 loops=1)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8) (actual time=8.510..8.556 rows=3 loops=1)
+         ->  Partial Aggregate  (cost=0.00..431.00 rows=1 width=8) (actual time=8.007..8.027 rows=1 loops=1)
+               allstat: seg_firststart_total_ntuples/seg0_0.555 ms_8.027 ms_1/seg1_0.556 ms_8.104 ms_1/seg2_0.573 ms_7.963 ms_1//end
+               ->  Seq Scan on test_heap  (cost=0.00..431.00 rows=1 width=1) (actual time=0.365..5.174 rows=33462 loops=1)
+                     allstat: seg_firststart_total_ntuples/seg0_0.555 ms_5.174 ms_33462/seg1_0.557 ms_5.178 ms_33329/seg2_0.573 ms_4.990 ms_33210//end
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Planning Time: 3.668 ms
+   (slice0)    Executor memory: 39K bytes.
+   (slice1)    Executor memory: 37K bytes avg x 3 workers, 37K bytes max (seg0).
  Memory used:  128000kB
- Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
- Execution time: 16.835 ms
-(10 rows)
+ Execution Time: 9.297 ms
+(12 rows)
 
 -- This is the to verify MPP-9167:
 --	Gather Motion shows wrong row estimate compared to 3.3
@@ -5560,9 +5574,10 @@ explain select 1 as t1 where 1 <= ALL (select x from tbl_z);
    Join Filter: true
    ->  Result  (cost=0.00..431.00 rows=1 width=1)
          Filter: ((CASE WHEN (sum((CASE WHEN (1 > x) THEN 1 ELSE 0 END)) IS NULL) THEN true WHEN (sum((CASE WHEN (x IS NULL) THEN 1 ELSE 0 END)) > '0'::bigint) THEN NULL::boolean WHEN (1 IS NULL) THEN NULL::boolean WHEN (sum((CASE WHEN (1 > x) THEN 1 ELSE 0 END)) = '0'::bigint) THEN true ELSE false END) = true)
-         ->  Aggregate  (cost=0.00..431.00 rows=1 width=16)
-               ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
-                     ->  Seq Scan on tbl_z  (cost=0.00..431.00 rows=1 width=4)
+         ->  Finalize Aggregate  (cost=0.00..431.00 rows=1 width=16)
+               ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=16)
+                     ->  Partial Aggregate  (cost=0.00..431.00 rows=1 width=16)
+                           ->  Seq Scan on tbl_z  (cost=0.00..431.00 rows=1 width=4)
    ->  Result  (cost=0.00..0.00 rows=1 width=1)
  Optimizer: Pivotal Optimizer (GPORCA)
 (9 rows)

--- a/src/test/regress/expected/qp_targeted_dispatch_optimizer.out
+++ b/src/test/regress/expected/qp_targeted_dispatch_optimizer.out
@@ -498,11 +498,12 @@ INFO:  (slice 1) Dispatch command to SINGLE content
 explain select count(*) from mpp7638 where a =1;
                                      QUERY PLAN                                     
 ------------------------------------------------------------------------------------
- Aggregate  (cost=0.00..431.00 rows=1 width=8)
-   ->  Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..431.00 rows=1 width=1)
-         ->  Dynamic Seq Scan on mpp7638  (cost=0.00..431.00 rows=1 width=4)
-               Number of partitions to scan: 9 
-               Filter: (a = 1)
+ Finalize Aggregate  (cost=0.00..431.00 rows=1 width=8)
+   ->  Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..431.00 rows=1 width=8)
+         ->  Partial Aggregate  (cost=0.00..431.00 rows=1 width=8)
+               ->  Dynamic Seq Scan on mpp7638  (cost=0.00..431.00 rows=1 width=4)
+                     Number of partitions to scan: 9 (out of 9)
+                     Filter: (a = 1)
  Optimizer: Pivotal Optimizer (GPORCA)
 (6 rows)
 
@@ -735,18 +736,19 @@ explain select * from table_a where a0=3;
 explain select a0 from table_a where a0 in (select max(a1) from table_a);
                                               QUERY PLAN                                              
 ------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
    ->  Hash Join  (cost=0.00..862.00 rows=1 width=4)
          Hash Cond: ((max(table_a.a1)) = table_a_1.a0)
          ->  Redistribute Motion 1:3  (slice2)  (cost=0.00..431.00 rows=1 width=4)
                Hash Key: (max(table_a.a1))
-               ->  Aggregate  (cost=0.00..431.00 rows=1 width=4)
-                     ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
-                           ->  Seq Scan on table_a  (cost=0.00..431.00 rows=1 width=4)
+               ->  Finalize Aggregate  (cost=0.00..431.00 rows=1 width=4)
+                     ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                           ->  Partial Aggregate  (cost=0.00..431.00 rows=1 width=4)
+                                 ->  Seq Scan on table_a  (cost=0.00..431.00 rows=1 width=4)
          ->  Hash  (cost=431.00..431.00 rows=1 width=4)
                ->  Seq Scan on table_a table_a_1  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
-(11 rows)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(12 rows)
 
 select a0 from table_a where a0 in (select max(a1) from table_a);
 INFO:  (slice 3) Dispatch command to ALL contents: 0 1 2
@@ -773,19 +775,20 @@ INFO:  (slice 1) Dispatch command to SINGLE content
 explain select a0 from table_a where a0 in (select max(a1) from table_a where a0=1);
                                               QUERY PLAN                                              
 ------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=4)
    ->  Hash Join  (cost=0.00..862.00 rows=1 width=4)
          Hash Cond: ((max(table_a.a1)) = table_a_1.a0)
          ->  Redistribute Motion 1:3  (slice2)  (cost=0.00..431.00 rows=1 width=4)
                Hash Key: (max(table_a.a1))
-               ->  Aggregate  (cost=0.00..431.00 rows=1 width=4)
-                     ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
-                           ->  Seq Scan on table_a  (cost=0.00..431.00 rows=1 width=4)
-                                 Filter: (a0 = 1)
+               ->  Finalize Aggregate  (cost=0.00..431.00 rows=1 width=4)
+                     ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                           ->  Partial Aggregate  (cost=0.00..431.00 rows=1 width=4)
+                                 ->  Seq Scan on table_a  (cost=0.00..431.00 rows=1 width=4)
+                                       Filter: (a0 = 1)
          ->  Hash  (cost=431.00..431.00 rows=1 width=4)
                ->  Seq Scan on table_a table_a_1  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
-(12 rows)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(13 rows)
 
 reset test_print_direct_dispatch_info;
 -- the filter is over a window, do not direct dispatch

--- a/src/test/regress/expected/rpt_optimizer.out
+++ b/src/test/regress/expected/rpt_optimizer.out
@@ -909,7 +909,7 @@ explain (costs off) select * from t_hashdist cross join (select random () from t
          ->  Materialize
                ->  Seq Scan on t_replicate_volatile
  Optimizer: Pivotal Optimizer (GPORCA)
-(6 rows)
+(7 rows)
 
 explain (costs off) select * from t_hashdist cross join (select a, sum(random()) from t_replicate_volatile group by a) x;
                         QUERY PLAN                        
@@ -934,15 +934,19 @@ explain (costs off) select * from t_hashdist cross join (select random() as k, s
          Join Filter: true
          ->  Broadcast Motion 3:3  (slice3; segments: 3)
                ->  Seq Scan on t_hashdist
-         ->  GroupAggregate
+         ->  Finalize GroupAggregate
                Group Key: (random())
                ->  Sort
                      Sort Key: (random())
                      ->  Redistribute Motion 1:3  (slice2; segments: 1)
                            Hash Key: (random())
-                           ->  Seq Scan on t_replicate_volatile
+                           ->  Partial GroupAggregate
+                                 Group Key: (random())
+                                 ->  Sort
+                                       Sort Key: (random())
+                                       ->  Seq Scan on t_replicate_volatile
  Optimizer: Pivotal Optimizer (GPORCA)
-(13 rows)
+(17 rows)
 
 explain (costs off) select * from t_hashdist cross join (select a, sum(b) as s from t_replicate_volatile group by a having sum(b) > random() order by a) x ;
                                       QUERY PLAN                                      
@@ -1012,6 +1016,7 @@ ___________
  Result
    ->  Broadcast Motion 1:3  (slice1)
          ->  Function Scan on generate_series
+ Optimizer: Pivotal Optimizer (GPORCA)
 GP_IGNORE:(4 rows)
 
 explain (costs off) create table rpt_ctas as select a from generate_series(1, 10) a group by a having sum(a) > random() distributed replicated;
@@ -1021,11 +1026,17 @@ ___________
    ->  Broadcast Motion 3:3  (slice1; segments: 3)
          ->  Result
                Filter: (((sum(generate_series)))::double precision > random())
-               ->  HashAggregate
+               ->  Finalize HashAggregate
                      Group Key: generate_series
-                     ->  Result
-                           ->  Function Scan on generate_series
-GP_IGNORE:(9 rows)
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                           Hash Key: generate_series
+                           ->  Streaming Partial HashAggregate
+                                 Group Key: generate_series
+                                 ->  Result
+                                       One-Time Filter: (gp_execution_segment() = 1)
+                                       ->  Function Scan on generate_series
+ Optimizer: Pivotal Optimizer (GPORCA)
+ GP_IGNORE:(14 rows)
 
 -- update & delete
 explain (costs off) update t_replicate_volatile set a = 1 where b > random();
@@ -1200,13 +1211,20 @@ explain select c from rep_tab where c in (select distinct a from dist_tab);
          Hash Cond: (dist_tab.a = rep_tab.c)
          ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=4)
                Group Key: dist_tab.a
-               ->  Sort  (cost=0.00..431.00 rows=2 width=4)
+               ->  Sort  (cost=0.00..431.00 rows=1 width=4)
                      Sort Key: dist_tab.a
-                     ->  Seq Scan on dist_tab  (cost=0.00..431.00 rows=2 width=4)
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                           Hash Key: dist_tab.a
+                           ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=4)
+                                 Group Key: dist_tab.a
+                                 ->  Sort  (cost=0.00..431.00 rows=2 width=4)
+                                       Sort Key: dist_tab.a
+                                       ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=2 width=4)
+                                             ->  Seq Scan on dist_tab  (cost=0.00..431.00 rows=2 width=4)
          ->  Hash  (cost=431.00..431.00 rows=2 width=4)
                ->  Seq Scan on rep_tab  (cost=0.00..431.00 rows=2 width=4)
  Optimizer: Pivotal Optimizer (GPORCA)
-(11 rows)
+(18 rows)
 
 select c from rep_tab where c in (select distinct a from dist_tab);
  c 
@@ -1232,11 +1250,15 @@ explain select c from rep_tab where c in (select distinct d from rand_tab);
                      Sort Key: rand_tab.d
                      ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
                            Hash Key: rand_tab.d
-                           ->  Seq Scan on rand_tab  (cost=0.00..431.00 rows=1 width=4)
+                           ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=4)
+                                 Group Key: rand_tab.d
+                                 ->  Sort  (cost=0.00..431.00 rows=1 width=4)
+                                       Sort Key: rand_tab.d
+                                       ->  Seq Scan on rand_tab  (cost=0.00..431.00 rows=1 width=4)
          ->  Hash  (cost=431.00..431.00 rows=2 width=4)
                ->  Seq Scan on rep_tab  (cost=0.00..431.00 rows=2 width=4)
  Optimizer: Pivotal Optimizer (GPORCA)
-(13 rows)
+(17 rows)
 
 select c from rep_tab where c in (select distinct d from rand_tab);
  c 

--- a/src/test/regress/expected/select_distinct_optimizer.out
+++ b/src/test/regress/expected/select_distinct_optimizer.out
@@ -130,27 +130,30 @@ SELECT DISTINCT p.age FROM person* p ORDER BY age using >;
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT count(*) FROM
   (SELECT DISTINCT two, four, two FROM tenk1) ss;
-                                 QUERY PLAN                                  
------------------------------------------------------------------------------
- Aggregate
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Finalize Aggregate
    Output: count()
    ->  Gather Motion 3:1  (slice1; segments: 3)
-         ->  GroupAggregate
-               Group Key: tenk1.two, tenk1.four, tenk1.two
-               ->  Sort
+         Output: (PARTIAL count())
+         ->  Partial Aggregate
+               Output: PARTIAL count()
+               ->  GroupAggregate
                      Output: two, four
-                     Sort Key: tenk1.two, tenk1.four, tenk1.two
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Group Key: tenk1.two, tenk1.four, tenk1.two
+                     ->  Sort
                            Output: two, four
-                           Hash Key: two, four, two
-                           ->  Streaming HashAggregate
+                           Sort Key: tenk1.two, tenk1.four, tenk1.two
+                           ->  Redistribute Motion 3:3  (slice2; segments: 3)
                                  Output: two, four
-                                 Group Key: tenk1.two, tenk1.four, tenk1.two
-                                 ->  Seq Scan on public.tenk1
+                                 Hash Key: two, four, two
+                                 ->  Streaming HashAggregate
                                        Output: two, four
- Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
- Settings: optimizer=on
-(18 rows)
+                                       Group Key: tenk1.two, tenk1.four, tenk1.two
+                                       ->  Seq Scan on public.tenk1
+                                             Output: two, four
+ Optimizer: Pivotal Optimizer (GPORCA)
+(21 rows)
 
 SELECT count(*) FROM
   (SELECT DISTINCT two, four, two FROM tenk1) ss;

--- a/src/test/regress/expected/select_parallel_optimizer.out
+++ b/src/test/regress/expected/select_parallel_optimizer.out
@@ -279,13 +279,15 @@ explain (costs off)
                          QUERY PLAN                         
 ------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  HashAggregate
+   ->  Finalize HashAggregate
          Group Key: (sp_parallel_restricted(unique1))
          ->  Redistribute Motion 3:3  (slice2; segments: 3)
                Hash Key: (sp_parallel_restricted(unique1))
-               ->  Seq Scan on tenk1
- Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
-(7 rows)
+               ->  Streaming Partial HashAggregate
+                     Group Key: sp_parallel_restricted(unique1)
+                     ->  Seq Scan on tenk1
+ Optimizer: Pivotal Optimizer (GPORCA)
+(9 rows)
 
 -- test prepared statement
 prepare tenk1_count(integer) As select  count((unique1)) from tenk1 where hundred > $1;

--- a/src/test/regress/expected/sublink_optimizer.out
+++ b/src/test/regress/expected/sublink_optimizer.out
@@ -60,8 +60,8 @@ select a from group_by_sublink where exists (select avg(a) from group_by_sublink
    ->  Gather Motion 3:1  (slice1; segments: 3)
          ->  Seq Scan on group_by_sublink
    SubPlan 1
-     ->  Limit
-           ->  Materialize
+     ->  Materialize
+           ->  Limit
                  ->  Gather Motion 3:1  (slice2; segments: 3)
                        ->  GroupAggregate
                              Group Key: group_by_sublink_1.a

--- a/src/test/regress/expected/subselect_gp_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_optimizer.out
@@ -186,19 +186,23 @@ explain select * from mrs_t1 where x in (select x-95 from mrs_t1) or x < 5;
  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1293.02 rows=20 width=4)
    ->  Result  (cost=0.00..1293.02 rows=7 width=4)
          Filter: (CASE WHEN ((count((true))) > '0'::bigint) THEN CASE WHEN ((sum((CASE WHEN ((mrs_t1_1.x = ((mrs_t1.x - 95))) IS NULL) THEN 1 ELSE 0 END))) = (count((true)))) THEN NULL::boolean ELSE true END ELSE false END OR (mrs_t1_1.x < 5))
-         ->  GroupAggregate  (cost=0.00..1293.02 rows=7 width=20)
+         ->  Finalize HashAggregate  (cost=0.00..1293.02 rows=7 width=20)
                Group Key: mrs_t1_1.x, mrs_t1_1.ctid, mrs_t1_1.gp_segment_id
-               ->  Nested Loop Left Join  (cost=0.00..1293.02 rows=56 width=19)
-                     Join Filter: ((mrs_t1_1.x = ((mrs_t1.x - 95))) IS NOT FALSE)
-                     ->  Sort  (cost=0.00..431.00 rows=7 width=14)
-                           Sort Key: mrs_t1_1.x, mrs_t1_1.ctid, mrs_t1_1.gp_segment_id
-                           ->  Seq Scan on mrs_t1 mrs_t1_1  (cost=0.00..431.00 rows=7 width=14)
-                     ->  Materialize  (cost=0.00..431.00 rows=20 width=5)
-                           ->  Result  (cost=0.00..431.00 rows=20 width=5)
-                                 ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=20 width=4)
-                                       ->  Seq Scan on mrs_t1  (cost=0.00..431.00 rows=7 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
-(15 rows)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..1293.02 rows=7 width=30)
+                     Hash Key: mrs_t1_1.ctid, mrs_t1_1.gp_segment_id
+                     ->  Partial GroupAggregate  (cost=0.00..1293.02 rows=7 width=30)
+                           Group Key: mrs_t1_1.x, mrs_t1_1.ctid, mrs_t1_1.gp_segment_id
+                           ->  Nested Loop Left Join  (cost=0.00..1293.02 rows=56 width=19)
+                                 Join Filter: ((mrs_t1_1.x = ((mrs_t1.x - 95))) IS NOT FALSE)
+                                 ->  Sort  (cost=0.00..431.00 rows=7 width=14)
+                                       Sort Key: mrs_t1_1.ctid, mrs_t1_1.gp_segment_id
+                                       ->  Seq Scan on mrs_t1 mrs_t1_1  (cost=0.00..431.00 rows=7 width=14)
+                                 ->  Materialize  (cost=0.00..431.00 rows=20 width=5)
+                                       ->  Result  (cost=0.00..431.00 rows=20 width=5)
+                                             ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=20 width=4)
+                                                   ->  Seq Scan on mrs_t1  (cost=0.00..431.00 rows=7 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(19 rows)
 
 select * from mrs_t1 where x in (select x-95 from mrs_t1) or x < 5 order by 1;
  x 
@@ -255,12 +259,11 @@ analyze csq_d1;
 explain select array(select x from csq_m1); -- no initplan
                           QUERY PLAN                          
 --------------------------------------------------------------
- Result  (cost=1.01..1.02 rows=1 width=0)
+ Result  (cost=1.01..1.02 rows=1 width=32)
    InitPlan 1 (returns $0)
      ->  Seq Scan on csq_m1  (cost=0.00..1.01 rows=1 width=4)
- Settings:  optimizer_segments=3
- Optimizer status: Postgres query optimizer
-(5 rows)
+ Optimizer: Postgres query optimizer
+(4 rows)
 
 select array(select x from csq_m1); -- {1}
  array 
@@ -396,22 +399,28 @@ select * from csq_m1 where x not in (select x from csq_d1) or x < -100; -- (3)
 explain select * from csq_d1 where x not in (select x from csq_m1) or x < -100; -- broadcast motion
                                                                                                                      QUERY PLAN                                                                                                                      
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1293.00 rows=2 width=4)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1293.00 rows=3 width=4)
    ->  Result  (cost=0.00..1293.00 rows=1 width=4)
          Filter: (CASE WHEN ((count((true))) > '0'::bigint) THEN CASE WHEN ((sum((CASE WHEN ((csq_d1.x = csq_m1.x) IS NULL) THEN 1 ELSE 0 END))) = (count((true)))) THEN NULL::boolean ELSE false END ELSE true END OR (csq_d1.x < '-100'::integer))
-         ->  GroupAggregate  (cost=0.00..1293.00 rows=1 width=20)
+         ->  Finalize GroupAggregate  (cost=0.00..1293.00 rows=1 width=20)
                Group Key: csq_d1.x, csq_d1.ctid, csq_d1.gp_segment_id
-               ->  Nested Loop Left Join  (cost=0.00..1293.00 rows=2 width=19)
-                     Join Filter: ((csq_d1.x = csq_m1.x) IS NOT FALSE)
-                     ->  Sort  (cost=0.00..431.00 rows=1 width=14)
-                           Sort Key: csq_d1.x, csq_d1.ctid, csq_d1.gp_segment_id
-                           ->  Seq Scan on csq_d1  (cost=0.00..431.00 rows=1 width=14)
-                     ->  Materialize  (cost=0.00..431.00 rows=3 width=5)
-                           ->  Result  (cost=0.00..431.00 rows=3 width=5)
-                                 ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..431.00 rows=3 width=4)
-                                       ->  Seq Scan on csq_m1  (cost=0.00..431.00 rows=3 width=4)
+               ->  Sort  (cost=0.00..1293.00 rows=1 width=30)
+                     Sort Key: csq_d1.ctid, csq_d1.gp_segment_id
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..1293.00 rows=1 width=30)
+                           Hash Key: csq_d1.ctid, csq_d1.gp_segment_id
+                           ->  Partial GroupAggregate  (cost=0.00..1293.00 rows=1 width=30)
+                                 Group Key: csq_d1.x, csq_d1.ctid, csq_d1.gp_segment_id
+                                 ->  Nested Loop Left Join  (cost=0.00..1293.00 rows=2 width=19)
+                                       Join Filter: ((csq_d1.x = csq_m1.x) IS NOT FALSE)
+                                       ->  Sort  (cost=0.00..431.00 rows=1 width=14)
+                                             Sort Key: csq_d1.ctid, csq_d1.gp_segment_id
+                                             ->  Seq Scan on csq_d1  (cost=0.00..431.00 rows=1 width=14)
+                                       ->  Materialize  (cost=0.00..431.00 rows=3 width=5)
+                                             ->  Result  (cost=0.00..431.00 rows=3 width=5)
+                                                   ->  Broadcast Motion 1:3  (slice3)  (cost=0.00..431.00 rows=3 width=4)
+                                                         ->  Seq Scan on csq_m1  (cost=0.00..431.00 rows=3 width=4)
  Optimizer: Pivotal Optimizer (GPORCA)
-(15 rows)
+(21 rows)
 
 select * from csq_d1 where x not in (select x from csq_m1) or x < -100; -- (4)
  x 
@@ -654,15 +663,19 @@ explain select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1
                Hash Cond: (csq_pullup.t = (csq_pullup_1.v)::text)
                ->  Seq Scan on csq_pullup  (cost=0.00..431.00 rows=1 width=17)
                ->  Hash  (cost=431.00..431.00 rows=1 width=12)
-                     ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=12)
+                     ->  Finalize GroupAggregate  (cost=0.00..431.00 rows=1 width=12)
                            Group Key: csq_pullup_1.v
-                           ->  Sort  (cost=0.00..431.00 rows=1 width=4)
+                           ->  Sort  (cost=0.00..431.00 rows=1 width=12)
                                  Sort Key: csq_pullup_1.v
-                                 ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                                 ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
                                        Hash Key: csq_pullup_1.v
-                                       ->  Seq Scan on csq_pullup csq_pullup_1  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
-(15 rows)
+                                       ->  Partial GroupAggregate  (cost=0.00..431.00 rows=1 width=12)
+                                             Group Key: csq_pullup_1.v
+                                             ->  Sort  (cost=0.00..431.00 rows=1 width=4)
+                                                   Sort Key: csq_pullup_1.v
+                                                   ->  Seq Scan on csq_pullup csq_pullup_1  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(19 rows)
 
 select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.t=t1.v);
   t  | n | i |  v  
@@ -680,21 +693,25 @@ explain select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1
 ------------------------------------------------------------------------------------------------------------------------
  Result  (cost=0.00..862.00 rows=1 width=17)
    Filter: (1 = COALESCE((count()), '0'::bigint))
-   ->  Hash Left Join  (cost=0.00..862.00 rows=1 width=25)
+   ->  Hash Left Join  (cost=0.00..862.00 rows=2 width=25)
          Hash Cond: (csq_pullup.n = csq_pullup_1.n)
          ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=17)
                ->  Seq Scan on csq_pullup  (cost=0.00..431.00 rows=1 width=17)
          ->  Hash  (cost=431.00..431.00 rows=1 width=13)
                ->  Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=13)
-                     ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=13)
+                     ->  Finalize GroupAggregate  (cost=0.00..431.00 rows=1 width=13)
                            Group Key: csq_pullup_1.n
-                           ->  Sort  (cost=0.00..431.00 rows=1 width=5)
+                           ->  Sort  (cost=0.00..431.00 rows=1 width=13)
                                  Sort Key: csq_pullup_1.n
-                                 ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=5)
+                                 ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=13)
                                        Hash Key: csq_pullup_1.n
-                                       ->  Seq Scan on csq_pullup csq_pullup_1  (cost=0.00..431.00 rows=1 width=5)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
-(16 rows)
+                                       ->  Partial GroupAggregate  (cost=0.00..431.00 rows=1 width=13)
+                                             Group Key: csq_pullup_1.n
+                                             ->  Sort  (cost=0.00..431.00 rows=1 width=5)
+                                                   Sort Key: csq_pullup_1.n
+                                                   ->  Seq Scan on csq_pullup csq_pullup_1  (cost=0.00..431.00 rows=1 width=5)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(20 rows)
 
 select * from csq_pullup t0 where 1= (select count(*) from csq_pullup t1 where t0.n=t1.n);
   t  | n | i |  v  
@@ -951,17 +968,18 @@ select * from subselect_t1 where x in (select y from subselect_t2 union all sele
 (2 rows)
 
 explain select count(*) from subselect_t1 where x in (select y from subselect_t2);
-                                      QUERY PLAN                                      
---------------------------------------------------------------------------------------
- Aggregate  (cost=0.00..862.00 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=2 width=1)
-         ->  Hash Semi Join  (cost=0.00..862.00 rows=1 width=1)
-               Hash Cond: (subselect_t1.x = subselect_t2.y)
-               ->  Seq Scan on subselect_t1  (cost=0.00..431.00 rows=1 width=4)
-               ->  Hash  (cost=431.00..431.00 rows=1 width=4)
-                     ->  Seq Scan on subselect_t2  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
-(8 rows)
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Finalize Aggregate  (cost=0.00..862.00 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
+         ->  Partial Aggregate  (cost=0.00..862.00 rows=1 width=8)
+               ->  Hash Semi Join  (cost=0.00..862.00 rows=1 width=1)
+                     Hash Cond: (subselect_t1.x = subselect_t2.y)
+                     ->  Seq Scan on subselect_t1  (cost=0.00..431.00 rows=1 width=4)
+                     ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+                           ->  Seq Scan on subselect_t2  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(9 rows)
 
 select count(*) from subselect_t1 where x in (select y from subselect_t2);
  count 
@@ -973,21 +991,22 @@ select count(*) from subselect_t1 where x in (select y from subselect_t2);
 -- Known_opt_diff: MPP-21351
 -- end_ignore
 explain select count(*) from subselect_t1 where x in (select y from subselect_t2 union all select y from subselect_t2);
-                                                   QUERY PLAN                                                    
------------------------------------------------------------------------------------------------------------------
- Aggregate  (cost=0.00..1293.00 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1293.00 rows=2 width=1)
-         ->  Hash Join  (cost=0.00..1293.00 rows=1 width=1)
-               Hash Cond: (subselect_t1.x = subselect_t2.y)
-               ->  Seq Scan on subselect_t1  (cost=0.00..431.00 rows=1 width=4)
-               ->  Hash  (cost=862.00..862.00 rows=1 width=4)
-                     ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=4)
-                           Group Key: subselect_t2.y
-                           ->  Sort  (cost=0.00..862.00 rows=2 width=4)
-                                 Sort Key: subselect_t2.y
-                                 ->  Append  (cost=0.00..862.00 rows=2 width=4)
-                                       ->  Seq Scan on subselect_t2  (cost=0.00..431.00 rows=1 width=4)
-                                       ->  Seq Scan on subselect_t2 subselect_t2_1  (cost=0.00..431.00 rows=1 width=4)
+                                                         QUERY PLAN                                                          
+-----------------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate  (cost=0.00..1293.00 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1293.00 rows=1 width=8)
+         ->  Partial Aggregate  (cost=0.00..1293.00 rows=1 width=8)
+               ->  Hash Join  (cost=0.00..1293.00 rows=1 width=1)
+                     Hash Cond: (subselect_t1.x = subselect_t2.y)
+                     ->  Seq Scan on subselect_t1  (cost=0.00..431.00 rows=1 width=4)
+                     ->  Hash  (cost=862.00..862.00 rows=1 width=4)
+                           ->  GroupAggregate  (cost=0.00..862.00 rows=1 width=4)
+                                 Group Key: subselect_t2.y
+                                 ->  Sort  (cost=0.00..862.00 rows=2 width=4)
+                                       Sort Key: subselect_t2.y
+                                       ->  Append  (cost=0.00..862.00 rows=2 width=4)
+                                             ->  Seq Scan on subselect_t2  (cost=0.00..431.00 rows=1 width=4)
+                                             ->  Seq Scan on subselect_t2 subselect_t2_1  (cost=0.00..431.00 rows=1 width=4)
  Optimizer: Pivotal Optimizer (GPORCA)
 (14 rows)
 
@@ -1268,18 +1287,22 @@ explain SELECT  cc, sum(nn) over() FROM v1_mpp_20470;
                ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
                      Hash Key: t_mpp_20470.col_name
                      ->  Dynamic Seq Scan on t_mpp_20470  (cost=0.00..431.00 rows=1 width=8)
-                           Number of partitions to scan: 2 
+                           Number of partitions to scan: 2 (out of 2)
                ->  Hash  (cost=431.00..431.00 rows=1 width=16)
-                     ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=16)
+                     ->  Finalize GroupAggregate  (cost=0.00..431.00 rows=1 width=16)
                            Group Key: t_mpp_20470_1.col_name
-                           ->  Sort  (cost=0.00..431.00 rows=1 width=12)
+                           ->  Sort  (cost=0.00..431.00 rows=1 width=16)
                                  Sort Key: t_mpp_20470_1.col_name
-                                 ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
+                                 ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=16)
                                        Hash Key: t_mpp_20470_1.col_name
-                                       ->  Dynamic Seq Scan on t_mpp_20470 t_mpp_20470_1  (cost=0.00..431.00 rows=1 width=12)
-                                             Number of partitions to scan: 2 
+                                       ->  Partial GroupAggregate  (cost=0.00..431.00 rows=1 width=16)
+                                             Group Key: t_mpp_20470_1.col_name
+                                             ->  Sort  (cost=0.00..431.00 rows=1 width=12)
+                                                   Sort Key: t_mpp_20470_1.col_name
+                                                   ->  Dynamic Seq Scan on t_mpp_20470 t_mpp_20470_1  (cost=0.00..431.00 rows=1 width=12)
+                                                         Number of partitions to scan: 2 (out of 2)
  Optimizer: Pivotal Optimizer (GPORCA)
-(18 rows)
+(22 rows)
 
 drop view v1_mpp_20470;
 drop table t_mpp_20470;
@@ -1433,7 +1456,7 @@ explain SELECT bar_s.c FROM bar_s, foo_s WHERE foo_s.b = (SELECT max(i) FROM baz
          ->  Hash  (cost=431.00..431.00 rows=1 width=4)
                ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
                      ->  Dynamic Seq Scan on foo_s  (cost=0.00..431.00 rows=1 width=4)
-                           Number of partitions to scan: 2 
+                           Number of partitions to scan: 2 (out of 2)
  Optimizer: Pivotal Optimizer (GPORCA)
 (19 rows)
 
@@ -1701,10 +1724,10 @@ EXPLAIN SELECT '' AS six, f1 AS "Correlated Field", f2 AS "Second Field"
   WHERE f1 IN (SELECT f2 FROM SUBSELECT_TBL WHERE f1 = upper.f1  ORDER BY f2 LIMIT 3);
                                                            QUERY PLAN                                                            
 ---------------------------------------------------------------------------------------------------------------------------------
- Result  (cost=0.00..1324038.57 rows=8 width=16)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1324038.57 rows=8 width=8)
-         ->  Seq Scan on subselect_tbl  (cost=0.00..1324038.57 rows=3 width=8)
-               Filter: (SubPlan 1)
+ Result  (cost=0.00..1324038.66 rows=8 width=16)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1324038.66 rows=8 width=8)
+         ->  Seq Scan on subselect_tbl  (cost=0.00..1324038.66 rows=3 width=8)
+               Filter: ((NOT (f1 IS NULL)) AND (SubPlan 1))
                SubPlan 1
                  ->  Limit  (cost=0.00..431.01 rows=1 width=4)
                        ->  Sort  (cost=0.00..431.01 rows=1 width=4)
@@ -1748,28 +1771,35 @@ EXPLAIN select count(*) from
 EXPLAIN select count(distinct ss.ten) from
   (select ten from tenk1 a
    where unique1 IN (select hundred from tenk1 b)) ss;
-                                                             QUERY PLAN                                                              
--------------------------------------------------------------------------------------------------------------------------------------
- Finalize Aggregate  (cost=0.00..864.11 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..864.11 rows=1 width=8)
-         ->  Partial Aggregate  (cost=0.00..864.11 rows=1 width=8)
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..864.11 rows=34 width=4)
-                     Hash Key: tenk1.ten
-                     ->  Hash Join  (cost=0.00..864.11 rows=34 width=4)
-                           Hash Cond: (tenk1.unique1 = tenk1_1.hundred)
-                           ->  Seq Scan on tenk1  (cost=0.00..431.51 rows=3334 width=8)
-                           ->  Hash  (cost=431.94..431.94 rows=34 width=4)
-                                 ->  GroupAggregate  (cost=0.00..431.94 rows=34 width=4)
-                                       Group Key: tenk1_1.hundred
-                                       ->  Sort  (cost=0.00..431.94 rows=34 width=4)
-                                             Sort Key: tenk1_1.hundred
-                                             ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.94 rows=34 width=4)
-                                                   Hash Key: tenk1_1.hundred
-                                                   ->  Streaming HashAggregate  (cost=0.00..431.94 rows=34 width=4)
+                                                                      QUERY PLAN                                                                       
+-------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..864.10 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..864.10 rows=10 width=4)
+         ->  GroupAggregate  (cost=0.00..864.10 rows=4 width=4)
+               Group Key: tenk1.ten
+               ->  Sort  (cost=0.00..864.10 rows=4 width=4)
+                     Sort Key: tenk1.ten
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..864.10 rows=4 width=4)
+                           Hash Key: tenk1.ten
+                           ->  GroupAggregate  (cost=0.00..864.10 rows=4 width=4)
+                                 Group Key: tenk1.ten
+                                 ->  Sort  (cost=0.00..864.10 rows=34 width=4)
+                                       Sort Key: tenk1.ten
+                                       ->  Hash Join  (cost=0.00..864.09 rows=34 width=4)
+                                             Hash Cond: (tenk1.unique1 = tenk1_1.hundred)
+                                             ->  Seq Scan on tenk1  (cost=0.00..431.50 rows=3334 width=8)
+                                             ->  Hash  (cost=431.94..431.94 rows=34 width=4)
+                                                   ->  GroupAggregate  (cost=0.00..431.94 rows=34 width=4)
                                                          Group Key: tenk1_1.hundred
-                                                         ->  Seq Scan on tenk1 tenk1_1  (cost=0.00..431.51 rows=3334 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
-(19 rows)
+                                                         ->  Sort  (cost=0.00..431.94 rows=34 width=4)
+                                                               Sort Key: tenk1_1.hundred
+                                                               ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.93 rows=34 width=4)
+                                                                     Hash Key: tenk1_1.hundred
+                                                                     ->  Streaming HashAggregate  (cost=0.00..431.93 rows=34 width=4)
+                                                                           Group Key: tenk1_1.hundred
+                                                                           ->  Seq Scan on tenk1 tenk1_1  (cost=0.00..431.50 rows=3334 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(26 rows)
 
 EXPLAIN select count(*) from
   (select 1 from tenk1 a
@@ -1798,28 +1828,35 @@ EXPLAIN select count(*) from
 EXPLAIN select count(distinct ss.ten) from
   (select ten from tenk1 a
    where unique1 IN (select distinct hundred from tenk1 b)) ss;
-                                                             QUERY PLAN                                                              
--------------------------------------------------------------------------------------------------------------------------------------
- Finalize Aggregate  (cost=0.00..864.11 rows=1 width=8)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..864.11 rows=1 width=8)
-         ->  Partial Aggregate  (cost=0.00..864.11 rows=1 width=8)
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..864.11 rows=34 width=4)
-                     Hash Key: tenk1.ten
-                     ->  Hash Semi Join  (cost=0.00..864.11 rows=34 width=4)
-                           Hash Cond: (tenk1.unique1 = tenk1_1.hundred)
-                           ->  Seq Scan on tenk1  (cost=0.00..431.51 rows=3334 width=8)
-                           ->  Hash  (cost=431.94..431.94 rows=34 width=4)
-                                 ->  GroupAggregate  (cost=0.00..431.94 rows=34 width=4)
-                                       Group Key: tenk1_1.hundred
-                                       ->  Sort  (cost=0.00..431.94 rows=34 width=4)
-                                             Sort Key: tenk1_1.hundred
-                                             ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.94 rows=34 width=4)
-                                                   Hash Key: tenk1_1.hundred
-                                                   ->  Streaming HashAggregate  (cost=0.00..431.94 rows=34 width=4)
+                                                                      QUERY PLAN                                                                       
+-------------------------------------------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..864.10 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..864.10 rows=10 width=4)
+         ->  GroupAggregate  (cost=0.00..864.10 rows=4 width=4)
+               Group Key: tenk1.ten
+               ->  Sort  (cost=0.00..864.10 rows=4 width=4)
+                     Sort Key: tenk1.ten
+                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..864.10 rows=4 width=4)
+                           Hash Key: tenk1.ten
+                           ->  GroupAggregate  (cost=0.00..864.10 rows=4 width=4)
+                                 Group Key: tenk1.ten
+                                 ->  Sort  (cost=0.00..864.10 rows=34 width=4)
+                                       Sort Key: tenk1.ten
+                                       ->  Hash Semi Join  (cost=0.00..864.09 rows=34 width=4)
+                                             Hash Cond: (tenk1.unique1 = tenk1_1.hundred)
+                                             ->  Seq Scan on tenk1  (cost=0.00..431.50 rows=3334 width=8)
+                                             ->  Hash  (cost=431.94..431.94 rows=34 width=4)
+                                                   ->  GroupAggregate  (cost=0.00..431.94 rows=34 width=4)
                                                          Group Key: tenk1_1.hundred
-                                                         ->  Seq Scan on tenk1 tenk1_1  (cost=0.00..431.51 rows=3334 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.64.0
-(19 rows)
+                                                         ->  Sort  (cost=0.00..431.94 rows=34 width=4)
+                                                               Sort Key: tenk1_1.hundred
+                                                               ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.93 rows=34 width=4)
+                                                                     Hash Key: tenk1_1.hundred
+                                                                     ->  Streaming HashAggregate  (cost=0.00..431.93 rows=34 width=4)
+                                                                           Group Key: tenk1_1.hundred
+                                                                           ->  Seq Scan on tenk1 tenk1_1  (cost=0.00..431.50 rows=3334 width=4)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(26 rows)
 
 --
 -- In case of simple exists query, planner can generate alternative
@@ -1973,7 +2010,11 @@ select * from dedup_reptab r where r.a in (select t.a/10 from dedup_tab t);
                      Sort Key: ((dedup_tab.a / 10))
                      ->  Redistribute Motion 3:3  (slice2; segments: 3)
                            Hash Key: ((dedup_tab.a / 10))
-                           ->  Seq Scan on dedup_tab
+                           ->  GroupAggregate
+                                 Group Key: ((dedup_tab.a / 10))
+                                 ->  Sort
+                                       Sort Key: ((dedup_tab.a / 10))
+                                       ->  Seq Scan on dedup_tab
          ->  Hash
                ->  Seq Scan on dedup_reptab
  Optimizer: Pivotal Optimizer (GPORCA) version 3.94.0

--- a/src/test/regress/expected/subselect_optimizer.out
+++ b/src/test/regress/expected/subselect_optimizer.out
@@ -853,11 +853,15 @@ select * from int8_tbl where q1 in (select c1 from inner_text);
                Sort Key: int8_tbl.ctid, int8_tbl.gp_segment_id
                ->  Redistribute Motion 3:3  (slice2; segments: 3)
                      Hash Key: int8_tbl.ctid, int8_tbl.gp_segment_id
-                     ->  Nested Loop
-                           Join Filter: (int8_tbl.q1 = inner_text.c1)
-                           ->  Broadcast Motion 3:3  (slice3; segments: 3)
-                                 ->  Seq Scan on inner_text
-                           ->  Seq Scan on int8_tbl
+                     ->  GroupAggregate
+                           Group Key: int8_tbl.q1, int8_tbl.q2, int8_tbl.ctid, int8_tbl.gp_segment_id
+                           ->  Sort
+                                 Sort Key: int8_tbl.ctid, int8_tbl.gp_segment_id
+                                 ->  Nested Loop
+                                       Join Filter: (int8_tbl.q1 = inner_text.c1)
+                                       ->  Broadcast Motion 3:3  (slice3; segments: 3)
+                                             ->  Seq Scan on inner_text
+                                       ->  Seq Scan on int8_tbl
  Optimizer: Pivotal Optimizer (GPORCA)
 (13 rows)
 
@@ -883,11 +887,15 @@ select * from int8_tbl where q1 in (select c1 from inner_text);
                Sort Key: int8_tbl.ctid, int8_tbl.gp_segment_id
                ->  Redistribute Motion 3:3  (slice2; segments: 3)
                      Hash Key: int8_tbl.ctid, int8_tbl.gp_segment_id
-                     ->  Nested Loop
-                           Join Filter: (int8_tbl.q1 = inner_text.c1)
-                           ->  Broadcast Motion 3:3  (slice3; segments: 3)
-                                 ->  Seq Scan on inner_text
-                           ->  Seq Scan on int8_tbl
+                     ->  GroupAggregate
+                           Group Key: int8_tbl.q1, int8_tbl.q2, int8_tbl.ctid, int8_tbl.gp_segment_id
+                           ->  Sort
+                                 Sort Key: int8_tbl.ctid, int8_tbl.gp_segment_id
+                                 ->  Nested Loop
+                                       Join Filter: (int8_tbl.q1 = inner_text.c1)
+                                       ->  Broadcast Motion 3:3  (slice3; segments: 3)
+                                             ->  Seq Scan on inner_text
+                                       ->  Seq Scan on int8_tbl
  Optimizer: Pivotal Optimizer (GPORCA)
 (13 rows)
 
@@ -913,11 +921,15 @@ select * from int8_tbl where q1 in (select c1 from inner_text);
                Sort Key: int8_tbl.ctid, int8_tbl.gp_segment_id
                ->  Redistribute Motion 3:3  (slice2; segments: 3)
                      Hash Key: int8_tbl.ctid, int8_tbl.gp_segment_id
-                     ->  Nested Loop
-                           Join Filter: (int8_tbl.q1 = inner_text.c1)
-                           ->  Broadcast Motion 3:3  (slice3; segments: 3)
-                                 ->  Seq Scan on inner_text
-                           ->  Seq Scan on int8_tbl
+                     ->  GroupAggregate
+                           Group Key: int8_tbl.q1, int8_tbl.q2, int8_tbl.ctid, int8_tbl.gp_segment_id
+                           ->  Sort
+                                 Sort Key: int8_tbl.ctid, int8_tbl.gp_segment_id
+                                 ->  Nested Loop
+                                       Join Filter: (int8_tbl.q1 = inner_text.c1)
+                                       ->  Broadcast Motion 3:3  (slice3; segments: 3)
+                                             ->  Seq Scan on inner_text
+                                       ->  Seq Scan on int8_tbl
  Optimizer: Pivotal Optimizer (GPORCA)
 (13 rows)
 

--- a/src/test/regress/expected/union_gp_optimizer.out
+++ b/src/test/regress/expected/union_gp_optimizer.out
@@ -241,31 +241,36 @@ union
 explain (SELECT 'test1' as branch, id FROM test1 LIMIT 1)
 union
 (SELECT 'test2' as branch, id FROM test2);
-                                                          QUERY PLAN                                                          
-------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..984.78 rows=1125 width=12)
-   ->  HashAggregate  (cost=0.00..984.73 rows=375 width=12)
+                                                                     QUERY PLAN                                                                     
+----------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..984.96 rows=1125 width=12)
+   ->  HashAggregate  (cost=0.00..984.91 rows=375 width=12)
          Group Key: ('test1'::text), test1.id
-         ->  Append  (cost=0.00..984.65 rows=334 width=12)
-               ->  Redistribute Motion 1:3  (slice2)  (cost=0.00..431.00 rows=1 width=12)
-                     Hash Key: ('test1'::text), test1.id
-                     ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=12)
-                           Group Key: ('test1'::text), test1.id
-                           ->  Sort  (cost=0.00..431.00 rows=1 width=12)
-                                 Sort Key: ('test1'::text), test1.id
-                                 ->  Limit  (cost=0.00..431.00 rows=1 width=12)
-                                       ->  Result  (cost=0.00..431.00 rows=1 width=12)
-                                             ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
-                                                   ->  Seq Scan on test1  (cost=0.00..431.00 rows=1 width=4)
-               ->  HashAggregate  (cost=0.00..553.64 rows=334 width=12)
-                     Group Key: ('test2'::text), test2.id
-                     ->  Redistribute Motion 3:3  (slice4; segments: 3)  (cost=0.00..553.56 rows=334 width=12)
-                           Hash Key: ('test2'::text), test2.id
-                           ->  Streaming HashAggregate  (cost=0.00..553.55 rows=334 width=12)
-                                 Group Key: 'test2'::text, test2.id
-                                 ->  Result  (cost=0.00..471.53 rows=333334 width=12)
-                                       ->  Redistribute Motion 1:3  (slice5)  (cost=0.00..467.53 rows=333334 width=4)
-                                             ->  Foreign Scan on test2  (cost=0.00..449.70 rows=1000000 width=4)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..984.83 rows=334 width=12)
+               Hash Key: ('test1'::text), test1.id
+               ->  Streaming HashAggregate  (cost=0.00..984.81 rows=334 width=12)
+                     Group Key: ('test1'::text), test1.id
+                     ->  Redistribute Motion 1:3  (slice3)  (cost=0.00..984.73 rows=334 width=12)
+                           ->  Result  (cost=0.00..984.70 rows=1001 width=12)
+                                 ->  Append  (cost=0.00..984.70 rows=1001 width=12)
+                                       ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=12)
+                                             Group Key: ('test1'::text), test1.id
+                                             ->  Sort  (cost=0.00..431.00 rows=1 width=12)
+                                                   Sort Key: ('test1'::text), test1.id
+                                                   ->  Limit  (cost=0.00..431.00 rows=1 width=12)
+                                                         ->  Result  (cost=0.00..431.00 rows=1 width=12)
+                                                               ->  Gather Motion 3:1  (slice4; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                                                                     ->  Seq Scan on test1  (cost=0.00..431.00 rows=1 width=4)
+                                       ->  Gather Motion 3:1  (slice5; segments: 3)  (cost=0.00..553.69 rows=1000 width=12)
+                                             ->  HashAggregate  (cost=0.00..553.64 rows=334 width=12)
+                                                   Group Key: ('test2'::text), id
+                                                   ->  Redistribute Motion 3:3  (slice6; segments: 3)  (cost=0.00..553.56 rows=334 width=12)
+                                                         Hash Key: ('test2'::text), id
+                                                         ->  Streaming HashAggregate  (cost=0.00..553.55 rows=334 width=12)
+                                                               Group Key: 'test2'::text, id
+                                                               ->  Result  (cost=0.00..471.53 rows=333334 width=12)
+                                                                     ->  Redistribute Motion 1:3  (slice7)  (cost=0.00..467.53 rows=333334 width=4)
+                                                                           ->  Foreign Scan on test2  (cost=0.00..449.70 rows=1000000 width=4)
  Optimizer: Pivotal Optimizer (GPORCA)
 (24 rows)
 

--- a/src/test/regress/expected/union_optimizer.out
+++ b/src/test/regress/expected/union_optimizer.out
@@ -366,7 +366,9 @@ select count(*) from
                                  Group Key: tenk1_1.fivethous
                                  ->  Redistribute Motion 3:3  (slice2; segments: 3)
                                        Hash Key: tenk1_1.fivethous
-                                       ->  Seq Scan on tenk1 tenk1_1
+                                       ->  Streaming HashAggregate
+                                             Group Key: tenk1_1.fivethous
+                                             ->  Seq Scan on tenk1 tenk1_1
  Optimizer: Pivotal Optimizer (GPORCA)
 (15 rows)
 
@@ -420,7 +422,9 @@ select count(*) from
                                  Group Key: tenk1_1.fivethous
                                  ->  Redistribute Motion 3:3  (slice2; segments: 3)
                                        Hash Key: tenk1_1.fivethous
-                                       ->  Seq Scan on tenk1 tenk1_1
+                                       ->  Streaming HashAggregate
+                                             Group Key: tenk1_1.fivethous
+                                             ->  Seq Scan on tenk1 tenk1_1
  Optimizer: Pivotal Optimizer (GPORCA)
 (15 rows)
 
@@ -763,16 +767,20 @@ explain (costs off)
          Group Key: ((t1.a || t1.b))
          ->  Sort
                Sort Key: ((t1.a || t1.b))
-               ->  Append
-                     ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                           Hash Key: ((t1.a || t1.b))
-                           ->  Result
-                                 Filter: (((t1.a || t1.b)) = 'ab'::text)
-                                 ->  Seq Scan on t1
-                     ->  Index Scan using t2_pkey on t2
-                           Index Cond: (ab = 'ab'::text)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
-(14 rows)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: ((t1.a || t1.b))
+                     ->  GroupAggregate
+                           Group Key: ((t1.a || t1.b))
+                           ->  Sort
+                                 Sort Key: ((t1.a || t1.b))
+                                 ->  Append
+                                       ->  Result
+                                             Filter: (((t1.a || t1.b)) = 'ab'::text)
+                                             ->  Seq Scan on t1
+                                       ->  Index Scan using t2_pkey on t2
+                                             Index Cond: (ab = 'ab'::text)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(18 rows)
 
 --
 -- Test that ORDER BY for UNION ALL can be pushed down to inheritance
@@ -1004,19 +1012,26 @@ where q2 = q2;
          Group Key: int8_tbl.q1
          ->  Sort
                Sort Key: int8_tbl.q1
-               ->  Append
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: int8_tbl.q1
                      ->  GroupAggregate
                            Group Key: int8_tbl.q1
                            ->  Sort
                                  Sort Key: int8_tbl.q1
-                                 ->  Seq Scan on int8_tbl
-                                       Filter: (q2 = q2)
-                     ->  GroupAggregate
-                           Group Key: int8_tbl_1.q1
-                           ->  Sort
-                                 Sort Key: int8_tbl_1.q1
-                                 ->  Seq Scan on int8_tbl int8_tbl_1
-                                       Filter: (q2 = q2)
+                                 ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                                       ->  Append
+                                             ->  GroupAggregate
+                                                   Group Key: int8_tbl.q1
+                                                   ->  Sort
+                                                         Sort Key: int8_tbl.q1
+                                                         ->  Seq Scan on int8_tbl
+                                                               Filter: (q2 = q2)
+                                             ->  GroupAggregate
+                                                   Group Key: int8_tbl_1.q1
+                                                   ->  Sort
+                                                         Sort Key: int8_tbl_1.q1
+                                                         ->  Seq Scan on int8_tbl int8_tbl_1
+                                                               Filter: (q2 = q2)
  Optimizer: Pivotal Optimizer (GPORCA)
 (26 rows)
 
@@ -1044,19 +1059,26 @@ where -q1 = q2;
          Group Key: int8_tbl.q1
          ->  Sort
                Sort Key: int8_tbl.q1
-               ->  Append
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: int8_tbl.q1
                      ->  GroupAggregate
                            Group Key: int8_tbl.q1
                            ->  Sort
                                  Sort Key: int8_tbl.q1
-                                 ->  Seq Scan on int8_tbl
-                                       Filter: ((- q1) = q2)
-                     ->  GroupAggregate
-                           Group Key: int8_tbl_1.q1
-                           ->  Sort
-                                 Sort Key: int8_tbl_1.q1
-                                 ->  Seq Scan on int8_tbl int8_tbl_1
-                                       Filter: ((- q1) = q2)
+                                 ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                                       ->  Append
+                                             ->  GroupAggregate
+                                                   Group Key: int8_tbl.q1
+                                                   ->  Sort
+                                                         Sort Key: int8_tbl.q1
+                                                         ->  Seq Scan on int8_tbl
+                                                               Filter: ((- q1) = q2)
+                                             ->  GroupAggregate
+                                                   Group Key: int8_tbl_1.q1
+                                                   ->  Sort
+                                                         Sort Key: int8_tbl_1.q1
+                                                         ->  Seq Scan on int8_tbl int8_tbl_1
+                                                               Filter: ((- q1) = q2)
  Optimizer: Pivotal Optimizer (GPORCA)
 (26 rows)
 

--- a/src/test/regress/expected/update_gp_optimizer.out
+++ b/src/test/regress/expected/update_gp_optimizer.out
@@ -144,9 +144,10 @@ WHERE t1.user_vie_project_code_pk = keo1.user_vie_project_code_pk;
                                                                            ->  Hash Join
                                                                                  Hash Cond: ((min((keo4.keo_para_budget_date)::text)) = (keo4_1.keo_para_budget_date)::text)
                                                                                  ->  Redistribute Motion 1:3  (slice5; segments: 1)
-                                                                                       ->  Aggregate
+                                                                                       ->  Finalize Aggregate
                                                                                              ->  Gather Motion 3:1  (slice6; segments: 3)
-                                                                                                   ->  Seq Scan on keo4
+                                                                                                   ->  Partial Aggregate
+                                                                                                         ->  Seq Scan on keo4
                                                                                  ->  Hash
                                                                                        ->  Broadcast Motion 3:3  (slice7; segments: 3)
                                                                                              ->  Seq Scan on keo4 keo4_1
@@ -157,7 +158,7 @@ WHERE t1.user_vie_project_code_pk = keo1.user_vie_project_code_pk;
                                  ->  Broadcast Motion 3:3  (slice9; segments: 3)
                                        ->  Seq Scan on keo2
  Optimizer: Pivotal Optimizer (GPORCA)
-(37 rows)
+(38 rows)
 
 UPDATE keo1 SET user_vie_act_cntr_marg_cum = 234.682 FROM
     ( SELECT a.user_vie_project_code_pk FROM keo1 a INNER JOIN keo2 b

--- a/src/test/regress/expected/with_clause_optimizer.out
+++ b/src/test/regress/expected/with_clause_optimizer.out
@@ -2286,15 +2286,16 @@ SELECT count(a1.i)
                            ->  Hash
                                  ->  Shared Scan (share slice:id 1:1)
                      ->  Redistribute Motion 1:3  (slice2)
-                           ->  Aggregate
+                           ->  Finalize Aggregate
                                  ->  Gather Motion 3:1  (slice3; segments: 3)
-                                       ->  Hash Join
-                                             Hash Cond: (share0_ref3.i = share1_ref3.i)
-                                             ->  Shared Scan (share slice:id 3:0)
-                                             ->  Hash
-                                                   ->  Shared Scan (share slice:id 3:1)
+                                       ->  Partial Aggregate
+                                             ->  Hash Join
+                                                   Hash Cond: (share0_ref3.i = share1_ref3.i)
+                                                   ->  Shared Scan (share slice:id 3:0)
+                                                   ->  Hash
+                                                         ->  Shared Scan (share slice:id 3:1)
  Optimizer: Pivotal Optimizer (GPORCA)
-(22 rows)
+(23 rows)
 
 -- Another cross-slice ShareInputScan test. There is one producing slice,
 -- and two consumers in second slice. Make sure the Share Input Scan
@@ -2332,8 +2333,12 @@ UNION ALL
                            Sort Key: ('a'::text), share0_ref2.j
                            ->  Redistribute Motion 3:3  (slice2; segments: 3)
                                  Hash Key: ('a'::text), share0_ref2.j
-                                 ->  Result
-                                       ->  Shared Scan (share slice:id 2:0)
+                                 ->  GroupAggregate
+                                       Group Key: ('a'::text), share0_ref2.j
+                                       ->  Sort
+                                             Sort Key: ('a'::text), share0_ref2.j
+                                             ->  Result
+                                                   ->  Shared Scan (share slice:id 2:0)
                ->  Hash Join
                      Hash Cond: (share0_ref4.i = share0_ref3.i)
                      ->  Shared Scan (share slice:id 1:0)
@@ -2347,7 +2352,7 @@ UNION ALL
                ->  Result
                      ->  Shared Scan (share slice:id 1:0)
  Optimizer: Pivotal Optimizer (GPORCA)
-(26 rows)
+(30 rows)
 
 WITH cte AS (SELECT * FROM foo)
   (SELECT DISTINCT 'a' as branch, j FROM cte)

--- a/src/test/regress/sql/bfv_aggregate.sql
+++ b/src/test/regress/sql/bfv_aggregate.sql
@@ -227,6 +227,7 @@ insert into mtup1 values
 -- from exceeding the limit in GPDB7 with that plan(a MinimalTuple has a limit of 1600
 -- columns). So set the parameter to off to prevent error happens.
 set gp_enable_multiphase_agg=off;
+set optimizer_force_multistage_agg=off;
 
 
 select c0, c1, array_length(ARRAY[
@@ -1367,6 +1368,7 @@ select c0, c1, array_length(ARRAY[
  SUM(c4 % 5670), SUM(c4 % 5671)], 1)
 from mtup1 where c0 = 'foo' group by c0, c1 limit 10;
 
+reset optimizer_force_multistage_agg;
 reset gp_enable_multiphase_agg;
 
 -- MPP-29042 Multistage aggregation plans should have consistent targetlists in


### PR DESCRIPTION
This PR turning optimizer_force_multistage_agg guc to true by default and
adjusting all ICW test plans accordingly.

Most of the 6X large production clusters are running by setting
optimizer_force_multistage_agg to true. In order to benefit large queries
on GP7 we plan to set optimizer_force_multistage_agg to true by default.
