### PR TITLE
resove fixme for lateral left join in partition_join.sql

### DIFF
--- a/src/test/regress/sql/partition_join.sql
+++ b/src/test/regress/sql/partition_join.sql
@@ -83,8 +83,11 @@ SELECT sum(t1.a), avg(t1.a), sum(t1.b), avg(t1.b) FROM prt1 t1 WHERE NOT EXISTS 
 SELECT sum(t1.a), avg(t1.a), sum(t1.b), avg(t1.b) FROM prt1 t1 WHERE NOT EXISTS (SELECT 1 FROM prt2 t2 WHERE t1.a = t2.b);
 
 -- lateral reference
--- GPDB_12_MERGE_FIXME: this is failing in GPDB. Known issue, there were similar
--- failures in other LATERAL tests before the v12 merge.
+-- GPDB_12_MERGE_FEATURE_NOT_SUPPORTED
+-- If lateral_relids of RelOptInfo for a inner path is not null, the inner path needs
+-- params of outer path. So We can not add motion above inner path.
+-- however, in left join, outer path can not be replicated. We can not generate path for left join,
+-- So hit the error: could not devise a query plan for the given query.
 EXPLAIN (COSTS OFF)
 SELECT * FROM prt1 t1 LEFT JOIN LATERAL
 			  (SELECT t2.a AS t2a, t3.a AS t3a, least(t1.a,t2.a,t3.b) FROM prt1 t2 JOIN prt2 t3 ON (t2.a = t3.b)) ss
@@ -362,8 +365,11 @@ SELECT t1.a, t1.c, t2.b, t2.c FROM (SELECT * FROM prt1_l WHERE prt1_l.b = 0) t1 
 SELECT t1.a, t1.c, t2.b, t2.c FROM (SELECT * FROM prt1_l WHERE prt1_l.b = 0) t1 FULL JOIN (SELECT * FROM prt2_l WHERE prt2_l.a = 0) t2 ON (t1.a = t2.b AND t1.c = t2.c) ORDER BY t1.a, t2.b;
 
 -- lateral partitionwise join
--- GPDB_12_MERGE_FIXME: this is failing in GPDB. Known issue, there were similar
--- failures in other LATERAL tests before the v12 merge.
+-- GPDB_12_MERGE_FEATURE_NOT_SUPPORTED
+-- If lateral_relids of RelOptInfo for a inner path is not null, the inner path needs
+-- params of outer path. So We can not add motion above inner path.
+-- however, in left join, outer path can not be replicated. We can not generate path for left join,
+-- So hit the error: could not devise a query plan for the given query.
 EXPLAIN (COSTS OFF)
 SELECT * FROM prt1_l t1 LEFT JOIN LATERAL
 			  (SELECT t2.a AS t2a, t2.c AS t2c, t2.b AS t2b, t3.b AS t3b, least(t1.a,t2.a,t3.b) FROM prt1_l t2 JOIN prt2_l t3 ON (t2.a = t3.b AND t2.c = t3.c)) ss


### PR DESCRIPTION
GPDB does not support the Lateral feature officially.
some of the lateral features do work well, such as:
```
create table t1(Tc1 int, tc2 int);
create table t2(Tc3 int, tc4 int);
explain SELECT * FROM t1 LEFT JOIN LATERAL
                                 (SELECT a.tc3, least(t1.tc1,a.tc3) from t2 a) ss
                                 ON t1.tc1=ss.tc3;
```
we specify the keyword LATERAL to indicate in subquery we can use the column of t1.
Above join do not need motion between t1 and ss. So it can work well.

However, some of the lateral features do not work well, such as the following sql:
```
create table t1(Tc1 int, tc2 int);
create table t2(Tc3 int, tc4 int);

explain SELECT * FROM t1 LEFT JOIN LATERAL
                                 (SELECT a.tc3, a.tc4, least(t1.tc1, a.tc3) from t2 a) ss
                                 ON t1.tc2=ss.tc4;
ERROR:  could not devise a query plan for the given query (pathnode.c:275)
```
If the inner path uses column of outer path, We can not add motion above inner path.
however, in left join, outer path can not be replicated. We can not generate path for left join,
So hit the error.

Change the GPDB_12_MERGE_FIXME to GPDB_12_MERGE_FEATURE_NOT_SUPPORTED for
lateral test in partition_join.sql