### PR TITLE
Use findCMDInPath("bash") in Command

### DIFF
--- a/gpMgmt/bin/gppylib/commands/base.py
+++ b/gpMgmt/bin/gppylib/commands/base.py
@@ -451,7 +451,7 @@ class LocalExecutionContext(ExecutionContext):
         for k in keys:
             cmd.cmdStr = "%s=%s && %s" % (k, cmd.propagate_env_map[k], cmd.cmdStr)
 
-        # executable='/bin/bash' is to ensure the shell is bash.  bash isn't the
+        # executable=(path of bash) is to ensure the shell is bash.  bash isn't the
         # actual command executed, but the shell that command string runs under.
         self.proc = gpsubprocess.Popen(cmd.cmdStr, env=None, shell=True,
                                        executable=findCmdInPath("bash"),
@@ -643,8 +643,6 @@ class CommandNotFoundException(Exception):
 
 
 def findCmdInPath(cmd):
-    global CMD_CACHE
-
     # ---------------command path--------------------
     CMDPATH = ['/usr/kerberos/bin', '/usr/sfw/bin', '/opt/sfw/bin', '/bin', '/usr/local/bin',
                '/usr/bin', '/sbin', '/usr/sbin', '/usr/ucb', '/sw/bin', '/opt/Navisphere/bin']

--- a/gpMgmt/bin/gppylib/commands/base.py
+++ b/gpMgmt/bin/gppylib/commands/base.py
@@ -34,6 +34,8 @@ logger = gplog.get_default_logger()
 
 GPHOME = os.environ.get('GPHOME')
 
+CMD_CACHE = {}
+
 # Maximum retries if sshd rejects the connection due to too many
 # unauthenticated connections.
 SSH_MAX_RETRY = 10
@@ -452,7 +454,7 @@ class LocalExecutionContext(ExecutionContext):
         # executable='/bin/bash' is to ensure the shell is bash.  bash isn't the
         # actual command executed, but the shell that command string runs under.
         self.proc = gpsubprocess.Popen(cmd.cmdStr, env=None, shell=True,
-                                       executable='/bin/bash',
+                                       executable=findCmdInPath("bash"),
                                        stdin=subprocess.PIPE,
                                        stderr=subprocess.PIPE,
                                        stdout=subprocess.PIPE, close_fds=True)
@@ -629,6 +631,43 @@ class SQLCommand(Command):
         # if self.conn is not set we cannot cancel.
         if self.cancel_conn:
             DB(self.cancel_conn).cancel()
+
+
+class CommandNotFoundException(Exception):
+    def __init__(self, cmd, paths):
+        self.cmd = cmd
+        self.paths = paths
+
+    def __str__(self):
+        return "Could not locate command: '%s' in this set of paths: %s" % (self.cmd, repr(self.paths))
+
+
+def findCmdInPath(cmd):
+    global CMD_CACHE
+
+    # ---------------command path--------------------
+    CMDPATH = ['/usr/kerberos/bin', '/usr/sfw/bin', '/opt/sfw/bin', '/bin', '/usr/local/bin',
+               '/usr/bin', '/sbin', '/usr/sbin', '/usr/ucb', '/sw/bin', '/opt/Navisphere/bin']
+    CMDPATH = CMDPATH + os.environ['PATH'].split(os.pathsep)
+    # remove duplicate paths
+    CMDPATH = list(set(CMDPATH))
+
+    if GPHOME:
+        CMDPATH.append(GPHOME)
+
+
+    if cmd not in CMD_CACHE:
+        for p in CMDPATH:
+            f = os.path.join(p, cmd)
+            if os.path.exists(f):
+                CMD_CACHE[cmd] = f
+                return f
+
+        logger.critical('Command %s not found' % cmd)
+        search_path = CMDPATH[:]
+        raise CommandNotFoundException(cmd, search_path)
+    else:
+        return CMD_CACHE[cmd]
 
 
 def run_remote_commands(name, commands):

--- a/gpMgmt/bin/gppylib/commands/unix.py
+++ b/gpMgmt/bin/gppylib/commands/unix.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+        #!/usr/bin/env python3
 #
 # Copyright (c) Greenplum Inc 2008. All Rights Reserved. 
 #
@@ -29,47 +29,6 @@ OPENBSD = "openbsd"
 platform_list = [LINUX, DARWIN, FREEBSD, OPENBSD]
 
 curr_platform = platform.uname()[0].lower()
-
-GPHOME = os.environ.get('GPHOME', None)
-
-# ---------------command path--------------------
-CMDPATH = ['/usr/kerberos/bin', '/usr/sfw/bin', '/opt/sfw/bin', '/bin', '/usr/local/bin',
-           '/usr/bin', '/sbin', '/usr/sbin', '/usr/ucb', '/sw/bin', '/opt/Navisphere/bin']
-CMDPATH = CMDPATH + os.environ['PATH'].split(os.pathsep)
-# remove duplicate paths
-CMDPATH = list(set(CMDPATH))
-
-if GPHOME:
-    CMDPATH.append(GPHOME)
-
-CMD_CACHE = {}
-
-
-# ----------------------------------
-class CommandNotFoundException(Exception):
-    def __init__(self, cmd, paths):
-        self.cmd = cmd
-        self.paths = paths
-
-    def __str__(self):
-        return "Could not locate command: '%s' in this set of paths: %s" % (self.cmd, repr(self.paths))
-
-
-def findCmdInPath(cmd):
-    global CMD_CACHE
-
-    if cmd not in CMD_CACHE:
-        for p in CMDPATH:
-            f = os.path.join(p, cmd)
-            if os.path.exists(f):
-                CMD_CACHE[cmd] = f
-                return f
-
-        logger.critical('Command %s not found' % cmd)
-        search_path = CMDPATH[:]
-        raise CommandNotFoundException(cmd, search_path)
-    else:
-        return CMD_CACHE[cmd]
 
 
 # For now we'll leave some generic functions outside of the Platform framework

--- a/gpMgmt/bin/gppylib/commands/unix.py
+++ b/gpMgmt/bin/gppylib/commands/unix.py
@@ -1,4 +1,4 @@
-        #!/usr/bin/env python3
+#!/usr/bin/env python3
 #
 # Copyright (c) Greenplum Inc 2008. All Rights Reserved. 
 #


### PR DESCRIPTION
Use findCMDInPath("bash") in Command for portability.

Use "/bin/bash" is not portable for some environments, like nix. And gpdb already has ‘findCMDInPath' to get path of command(find from system PATH and some custom paths), so use findCMDInPath("bash")  to get bash path is a convenient way. BTW, move findCMDInPath to base.py for solving cyclic import.

