### PR TITLE
fix bypass catalog unittest

### DIFF
--- a/src/backend/utils/resgroup/test/resgroup_test.c
+++ b/src/backend/utils/resgroup/test/resgroup_test.c
@@ -349,6 +349,9 @@ test__shouldBypassQuery__with_only_catalog(void **state)
 {
 	MessageContext = NULL;
 
+	assert_false(shouldBypassQuery("select * from pg_catalog.pg_rules"));
+
+	gp_resource_group_bypass_catalog_query = true;
 	assert_true(shouldBypassQuery("select * from pg_catalog.pg_rules"));
 }
 

--- a/src/backend/utils/resgroup/test/resgroup_test.c
+++ b/src/backend/utils/resgroup/test/resgroup_test.c
@@ -388,6 +388,5 @@ main(int argc, char *argv[])
 											   ALLOCSET_DEFAULT_MINSIZE,
 											   ALLOCSET_DEFAULT_INITSIZE,
 											   ALLOCSET_DEFAULT_MAXSIZE);
-	if (run_tests(tests) != 0)
-		return 1;
+	return run_tests(tests);
 }

--- a/src/backend/utils/resgroup/test/resgroup_test.c
+++ b/src/backend/utils/resgroup/test/resgroup_test.c
@@ -349,6 +349,7 @@ test__shouldBypassQuery__with_only_catalog(void **state)
 {
 	MessageContext = NULL;
 
+	gp_resource_group_bypass_catalog_query = false;
 	assert_false(shouldBypassQuery("select * from pg_catalog.pg_rules"));
 
 	gp_resource_group_bypass_catalog_query = true;

--- a/src/backend/utils/resgroup/test/resgroup_test.c
+++ b/src/backend/utils/resgroup/test/resgroup_test.c
@@ -388,5 +388,6 @@ main(int argc, char *argv[])
 											   ALLOCSET_DEFAULT_MINSIZE,
 											   ALLOCSET_DEFAULT_INITSIZE,
 											   ALLOCSET_DEFAULT_MAXSIZE);
-	run_tests(tests);
+	if (run_tests(tests) != 0)
+		return 1;
 }


### PR DESCRIPTION
Guc value `gp_resource_group_bypass_catalog_query` doesn't get default value in unittest environment, so i set the value in unittest.