### PR TITLE
enable `wal_compression` by default

### DIFF
--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -1256,7 +1256,7 @@ static struct config_bool ConfigureNamesBool[] =
 			NULL
 		},
 		&wal_compression,
-		false,
+		true,
 		NULL, NULL, NULL
 	},
 

--- a/src/test/isolation2/expected/segwalrep/select_throttle.out
+++ b/src/test/isolation2/expected/segwalrep/select_throttle.out
@@ -26,8 +26,8 @@ INSERT INTO select_no_throttle SELECT generate_series (1, 10);
 INSERT 10
 CREATE TABLE select_throttle(a int) DISTRIBUTED BY (a);
 CREATE
-INSERT INTO select_throttle SELECT generate_series (1, 100000);
-INSERT 100000
+INSERT INTO select_throttle SELECT generate_series (1, 900000);
+INSERT 900000
 
 -- Enable tuple hints so that buffer will be marked dirty upon a hint bit change
 -- (so that we don't have to wait for the tuple to age. See logic in markDirty)
@@ -82,9 +82,9 @@ SELECT gp_inject_fault_infinite('wal_sender_loop', 'reset', dbid) FROM gp_segmen
 -- after this, system continue to proceed
 
 1U<:  <... completed>
- count 
--------
- 33327 
+ count  
+--------
+ 299393 
 (1 row)
 
 SELECT wait_until_all_segments_synchronized();
@@ -135,8 +135,8 @@ SELECT wait_until_all_segments_synchronized();
 SET
 Truncate select_throttle;
 TRUNCATE
-INSERT INTO select_throttle SELECT generate_series (1, 100000);
-INSERT 100000
+INSERT INTO select_throttle SELECT generate_series (1, 900000);
+INSERT 900000
 -- flush the data to disk
 checkpoint;
 CHECKPOINT
@@ -193,9 +193,9 @@ select content, role, preferred_role, mode, status from gp_segment_configuration
 
 -- after mirror is stopped, the SELECT query should proceed without waiting for syncrep
 1U<:  <... completed>
- count 
--------
- 33327 
+ count  
+--------
+ 299393 
 (1 row)
 
 -- Cleanup

--- a/src/test/isolation2/sql/segwalrep/select_throttle.sql
+++ b/src/test/isolation2/sql/segwalrep/select_throttle.sql
@@ -18,7 +18,7 @@ SELECT pg_reload_conf();
 CREATE TABLE select_no_throttle(a int) DISTRIBUTED BY (a);
 INSERT INTO select_no_throttle SELECT generate_series (1, 10);
 CREATE TABLE select_throttle(a int) DISTRIBUTED BY (a);
-INSERT INTO select_throttle SELECT generate_series (1, 100000);
+INSERT INTO select_throttle SELECT generate_series (1, 900000);
 
 -- Enable tuple hints so that buffer will be marked dirty upon a hint bit change
 -- (so that we don't have to wait for the tuple to age. See logic in markDirty)
@@ -78,7 +78,7 @@ SELECT wait_until_all_segments_synchronized();
 -- (so that we don't have to wait for the tuple to age. See logic in markDirty)
 1U: SET gp_disable_tuple_hints=off;
 Truncate select_throttle;
-INSERT INTO select_throttle SELECT generate_series (1, 100000);
+INSERT INTO select_throttle SELECT generate_series (1, 900000);
 -- flush the data to disk
 checkpoint;
 -- Suspend walsender


### PR DESCRIPTION
This is to investigate the perf impact of wal_compression

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
