### PR TITLE
Fix compiler warning in reloptions_gp.c

### DIFF
--- a/src/backend/access/common/reloptions_gp.c
+++ b/src/backend/access/common/reloptions_gp.c
@@ -924,9 +924,9 @@ validate_and_adjust_options(StdRdOptions *result,
 		if (pg_strcasecmp(comptype_opt->values.string_val, "quicklz") == 0)
 		{
 #ifdef USE_ZSTD
-			strncpy(result->compresstype, "zstd", sizeof("zstd"));
+			StrNCpy(result->compresstype, "zstd", NAMEDATALEN);
 #else
-			strncpy(result->compresstype, AO_DEFAULT_USABLE_COMPRESSTYPE, sizeof(AO_DEFAULT_USABLE_COMPRESSTYPE));
+			StrNCpy(result->compresstype, AO_DEFAULT_USABLE_COMPRESSTYPE, NAMEDATALEN);
 #endif
 		}
 		else


### PR DESCRIPTION
Resolves the warning

```
reloptions_gp.c: In function 'validate_and_adjust_options': reloptions_gp.c:927:48: warning: argument to 'sizeof' in 'strncpy' call is the same expression as the source; did you mean to use the size of the destination? [-Wsizeof-pointer-memaccess]
  927 |    strncpy(result->compresstype, "zstd", sizeof("zstd"));
```
