### PR TITLE
(backport to 6X) Fix bypass catalog unittest

### DIFF
--- a/src/backend/utils/resgroup/test/resgroup_test.c
+++ b/src/backend/utils/resgroup/test/resgroup_test.c
@@ -348,6 +348,10 @@ test__shouldBypassQuery__with_only_catalog(void **state)
 {
 	MessageContext = NULL;
 
+	gp_resource_group_bypass_catalog_query = false;
+	assert_false(shouldBypassQuery("select * from pg_catalog.pg_rules"));
+
+	gp_resource_group_bypass_catalog_query = true;
 	assert_true(shouldBypassQuery("select * from pg_catalog.pg_rules"));
 }
 
@@ -383,5 +387,5 @@ main(int argc, char *argv[])
 											   ALLOCSET_DEFAULT_MINSIZE,
 											   ALLOCSET_DEFAULT_INITSIZE,
 											   ALLOCSET_DEFAULT_MAXSIZE);
-	run_tests(tests);
+	return run_tests(tests);
 }


### PR DESCRIPTION
Fix bypass catalog unittest.

Guc value gp_resource_group_bypass_catalog_query doesn't get default value in unittest environment, so i set the value in unittest.

BTW, the unittest should return non-0 value when cases failed.
