### PR TITLE
Clean up inter connect interface

### DIFF
--- a/src/include/cdb/ml_ipc.h
+++ b/src/include/cdb/ml_ipc.h
@@ -119,8 +119,6 @@ extern void SetupInterconnect(struct EState *estate);
 extern void TeardownInterconnect(ChunkTransportState *transportStates,
 								 bool hasErrors);
 
-extern void WaitInterconnectQuit(void);
-
 
 /* Sends a tuple chunk from the Postgres process to the local AMS process via
  * IPC.  This function does not block; if the IPC channel cannot accept the
@@ -141,19 +139,6 @@ extern bool SendTupleChunkToAMS(MotionLayerState *mlStates,
 								int16 motNodeID, 
 								int16 targetRoute, 
 								TupleChunkListItem tcItem);
-
-/* The SendEosToAMS() function is used to send an "End Of Stream" message to
- * all connected receivers (generally this is a broadcast)
- *
- * PARAMETERS:
- *	 - motNodeID:	motion node Id that the tcItem belongs to.
- *	 - tcItem:		The tuple-chunk data to send.
- *
- */
-extern void SendEosToAMS(MotionLayerState *mlStates,
-						 ChunkTransportState *transportStates, 
-						 int motNodeID, 
-						 TupleChunkListItem tcItem);
 
 /* The RecvTupleChunkFromAny() function attempts to receive one or more tuple
  * chunks from any of the incoming connections.  This function blocks until


### PR DESCRIPTION
1. `WaitInterconnectQuit` dump defined in L77
2. `SendEosToAMS` is not used, gpdb will use `transportStates->SendEos` in `cdbmotion.c`.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
