### PR TITLE
fix resgroup_memory_limit test failure

### DIFF
--- a/src/test/isolation2/input/resgroup/resgroup_memory_limit.source
+++ b/src/test/isolation2/input/resgroup/resgroup_memory_limit.source
@@ -108,6 +108,8 @@ CREATE ROLE role1_memory_test RESOURCE GROUP rg1_memory_test;
 1: SET ROLE TO role1_memory_test;
 1: SELECT hold_memory_by_percent(0.48 / 0.52);
 1q:
+
+-- sleep a while to wait for processes both in master and segment nodes to exit
 SELECT pg_sleep(1);
 
 --	2b) on QEs
@@ -121,6 +123,8 @@ SELECT pg_sleep(1);
 1: SET ROLE TO role1_memory_test;
 1: SELECT count(null) FROM gp_dist_random('gp_id') t1 WHERE hold_memory_by_percent(0.48 / 0.52)=0;
 1q:
+
+-- sleep a while to wait for processes both in master and segment nodes to exit
 SELECT pg_sleep(1);
 
 DROP ROLE role1_memory_test;

--- a/src/test/isolation2/input/resgroup/resgroup_memory_limit.source
+++ b/src/test/isolation2/input/resgroup/resgroup_memory_limit.source
@@ -108,6 +108,7 @@ CREATE ROLE role1_memory_test RESOURCE GROUP rg1_memory_test;
 1: SET ROLE TO role1_memory_test;
 1: SELECT hold_memory_by_percent(0.48 / 0.52);
 1q:
+SELECT pg_sleep(1);
 
 --	2b) on QEs
 1: SET ROLE TO role1_memory_test;
@@ -120,6 +121,7 @@ CREATE ROLE role1_memory_test RESOURCE GROUP rg1_memory_test;
 1: SET ROLE TO role1_memory_test;
 1: SELECT count(null) FROM gp_dist_random('gp_id') t1 WHERE hold_memory_by_percent(0.48 / 0.52)=0;
 1q:
+SELECT pg_sleep(1);
 
 DROP ROLE role1_memory_test;
 DROP RESOURCE GROUP rg1_memory_test;

--- a/src/test/isolation2/output/resgroup/resgroup_memory_limit.source
+++ b/src/test/isolation2/output/resgroup/resgroup_memory_limit.source
@@ -191,6 +191,11 @@ ERROR:  Out of memory
 DETAIL:  Resource group memory limit reached
 CONTEXT:  SQL function "hold_memory_by_percent" statement 1
 1q: ... <quitting>
+SELECT pg_sleep(1);
+ pg_sleep 
+----------
+          
+(1 row)
 
 --	2b) on QEs
 1: SET ROLE TO role1_memory_test;
@@ -223,6 +228,11 @@ ERROR:  Out of memory  (seg0 slice1 10.152.10.56:25432 pid=19269)
 DETAIL:  Resource group memory limit reached
 CONTEXT:  SQL function "hold_memory_by_percent" statement 1
 1q: ... <quitting>
+SELECT pg_sleep(1);
+ pg_sleep 
+----------
+          
+(1 row)
 
 DROP ROLE role1_memory_test;
 DROP

--- a/src/test/isolation2/output/resgroup/resgroup_memory_limit.source
+++ b/src/test/isolation2/output/resgroup/resgroup_memory_limit.source
@@ -191,6 +191,8 @@ ERROR:  Out of memory
 DETAIL:  Resource group memory limit reached
 CONTEXT:  SQL function "hold_memory_by_percent" statement 1
 1q: ... <quitting>
+
+-- sleep a while to wait for processes both in master and segment nodes to exit
 SELECT pg_sleep(1);
  pg_sleep 
 ----------
@@ -228,6 +230,8 @@ ERROR:  Out of memory  (seg0 slice1 10.152.10.56:25432 pid=19269)
 DETAIL:  Resource group memory limit reached
 CONTEXT:  SQL function "hold_memory_by_percent" statement 1
 1q: ... <quitting>
+
+-- sleep a while to wait for processes both in master and segment nodes to exit
 SELECT pg_sleep(1);
  pg_sleep 
 ----------


### PR DESCRIPTION
The previous processes accept the query cancel command and returned before they exited compeletely. The following commands continuously require to alloc memory and previous processes haven't released the allocated memory, it finally cause the out of memory error.

Sleep a while to wait for the previous processes exit.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
