### PR TITLE
[6X] Flow isn't set properly for Shared Scan nodes during translation to physical plan

### DIFF
--- a/src/backend/cdb/cdbmutate.c
+++ b/src/backend/cdb/cdbmutate.c
@@ -2227,9 +2227,9 @@ collect_shareinput_producers(PlannerInfo *root, Plan *plan)
 
 /* Some helper: implements a stack using List. */
 static void
-shareinput_pushmot(ApplyShareInputContext *ctxt, int motid)
+shareinput_pushmot(ApplyShareInputContext *ctxt, Motion *motion)
 {
-	ctxt->motStack = lcons_int(motid, ctxt->motStack);
+	ctxt->motStack = lcons(motion, ctxt->motStack);
 }
 static void
 shareinput_popmot(ApplyShareInputContext *ctxt)
@@ -2239,9 +2239,17 @@ shareinput_popmot(ApplyShareInputContext *ctxt)
 static int
 shareinput_peekmot(ApplyShareInputContext *ctxt)
 {
-	return linitial_int(ctxt->motStack);
-}
+	Motion	   *motion = linitial(ctxt->motStack);
 
+	return motion->motionID;
+}
+static Flow *
+shareinput_peekflow(ApplyShareInputContext *ctxt)
+{
+	Motion	   *motion = linitial(ctxt->motStack);
+
+	return motion->plan.lefttree->flow;
+}
 
 /*
  * Replace the target list of ShareInputScan nodes, with references
@@ -2406,7 +2414,7 @@ shareinput_mutator_xslice_1(Node *node, PlannerInfo *root, bool fPop)
 	{
 		Motion	   *motion = (Motion *) plan;
 
-		shareinput_pushmot(ctxt, motion->motionID);
+		shareinput_pushmot(ctxt, motion);
 		return true;
 	}
 
@@ -2415,11 +2423,12 @@ shareinput_mutator_xslice_1(Node *node, PlannerInfo *root, bool fPop)
 		ShareInputScan *sisc = (ShareInputScan *) plan;
 		int			motId = shareinput_peekmot(ctxt);
 		Plan	   *shared = plan->lefttree;
+		Flow	   *flow = shareinput_peekflow(ctxt);
 
-		Assert(sisc->scan.plan.flow);
-		if (sisc->scan.plan.flow->flotype == FLOW_SINGLETON)
+		Assert(flow);
+		if (flow->flotype == FLOW_SINGLETON)
 		{
-			if (sisc->scan.plan.flow->segindex < 0)
+			if (flow->segindex < 0)
 				ctxt->qdShares = list_append_unique_int(ctxt->qdShares, sisc->share_id);
 		}
 
@@ -2464,7 +2473,7 @@ shareinput_mutator_xslice_2(Node *node, PlannerInfo *root, bool fPop)
 	{
 		Motion	   *motion = (Motion *) plan;
 
-		shareinput_pushmot(ctxt, motion->motionID);
+		shareinput_pushmot(ctxt, motion);
 		return true;
 	}
 
@@ -2524,7 +2533,7 @@ shareinput_mutator_xslice_3(Node *node, PlannerInfo *root, bool fPop)
 	{
 		Motion	   *motion = (Motion *) plan;
 
-		shareinput_pushmot(ctxt, motion->motionID);
+		shareinput_pushmot(ctxt, motion);
 		return true;
 	}
 
@@ -2560,8 +2569,8 @@ shareinput_mutator_xslice_3(Node *node, PlannerInfo *root, bool fPop)
 
 		if (list_member_int(ctxt->qdShares, sisc->share_id))
 		{
-			Assert(sisc->scan.plan.flow);
-			Assert(sisc->scan.plan.flow->flotype == FLOW_SINGLETON);
+			Assert(shareinput_peekflow(ctxt));
+			Assert(shareinput_peekflow(ctxt)->flotype == FLOW_SINGLETON);
 			ctxt->qdSlices = list_append_unique_int(ctxt->qdSlices, motId);
 		}
 	}
@@ -2591,7 +2600,7 @@ shareinput_mutator_xslice_4(Node *node, PlannerInfo *root, bool fPop)
 	{
 		Motion	   *motion = (Motion *) plan;
 
-		shareinput_pushmot(ctxt, motion->motionID);
+		shareinput_pushmot(ctxt, motion);
 		/* Do not return.  Motion need to be adjusted as well */
 	}
 
@@ -2611,12 +2620,119 @@ shareinput_mutator_xslice_4(Node *node, PlannerInfo *root, bool fPop)
 	return true;
 }
 
+static bool
+root_slice_is_executed_on_coordinator(Plan *plan, PlannerInfo *root)
+{
+	/*
+	 * By default, the root slice is executed on the coordinator.
+	 */
+	bool		result = true;
+	Query	   *query = root->parse;
+
+	if (query->parentStmtType != PARENTSTMTTYPE_NONE)
+	{
+		/*
+		 * For CTAS, SELECT INTO, COPY INTO, REFRESH MATERIALIZED VIEW, the
+		 * root slice is not executed on the coordinator.
+		 */
+		result = false;
+	}
+
+	if (IsA(plan, ModifyTable))
+	{
+		ModifyTable *mt = (ModifyTable *) plan;
+
+		if (list_length(mt->resultRelations) > 0)
+		{
+			ListCell   *lc = list_head(mt->resultRelations);
+			Oid			reloid = getrelid(lfirst_int(lc), query->rtable);
+
+			if (GpPolicyFetch(reloid)->ptype != POLICYTYPE_ENTRY)
+			{
+				/*
+				 * For the modification node by Postgres planner, if the table
+				 * distribution policy is not master-only, then the root slice
+				 * is not executed on the coordinator.
+				 */
+				result = false;
+			}
+		}
+	}
+
+	if (IsA(plan, DML))
+	{
+		DML		   *dml = (DML *) plan;
+		Oid			reloid = getrelid(dml->scanrelid, query->rtable);
+
+		if (GpPolicyFetch(reloid)->ptype != POLICYTYPE_ENTRY)
+		{
+			/*
+			 * For the modification node by ORCA planner, if the table
+			 * distribution policy is not master-only, then the root slice is
+			 * not executed on the coordinator.
+			 */
+			result = false;
+		}
+	}
+
+	if (plan->flow)
+	{
+		Flow	   *flow = plan->flow;
+
+		if (flow->flotype != FLOW_SINGLETON || flow->segindex >= 0)
+		{
+			/*
+			 * For non-singleton or singleton on segment, the root slice is
+			 * not executed on the coordinator.
+			 */
+			result = false;
+		}
+
+		if (root->glob->is_parallel_cursor)
+		{
+			if (flow->flotype == FLOW_SINGLETON &&
+				(flow->locustype == CdbLocusType_Entry ||
+				 flow->locustype == CdbLocusType_General ||
+				 flow->locustype == CdbLocusType_SingleQE))
+			{
+				/*
+				 * For these scenarios, parallel retrieve cursor needs to run
+				 * on coordinator, since endpoint QE needs to interact with
+				 * the retrieve connections.
+				 */
+				result = true;
+			}
+			else
+			{
+				result = false;
+			}
+		}
+	}
+
+	return result;
+}
+
 Plan *
 apply_shareinput_xslice(Plan *plan, PlannerInfo *root)
 {
 	PlannerGlobal *glob = root->glob;
 	ApplyShareInputContext *ctxt = &glob->share;
 	ListCell   *lp, *lr;
+	Motion	   *fakeMotion = makeNode(Motion);
+
+	fakeMotion->plan.lefttree = makeNode(Plan);
+	fakeMotion->plan.lefttree->flow = makeNode(Flow);
+
+	if (root_slice_is_executed_on_coordinator(plan, root))
+	{
+		fakeMotion->plan.lefttree->flow->flotype = FLOW_SINGLETON;
+		fakeMotion->plan.lefttree->flow->segindex = -1;
+	}
+	else
+	{
+		fakeMotion->plan.lefttree->flow->flotype = FLOW_UNDEFINED;
+		fakeMotion->plan.lefttree->flow->segindex = 0;
+	}
 
 	ctxt->motStack = NULL;
 	ctxt->qdShares = NULL;
@@ -2625,7 +2741,7 @@ apply_shareinput_xslice(Plan *plan, PlannerInfo *root)
 
 	ctxt->sliceMarks = palloc0(ctxt->producer_count * sizeof(int));
 
-	shareinput_pushmot(ctxt, 0);
+	shareinput_pushmot(ctxt, fakeMotion);
 
 	/*
 	 * Walk the tree.  See comment for each pass for what each pass will do.

--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -3673,8 +3673,6 @@ CTranslatorDXLToPlStmt::InitializeSpoolingInfo(Plan *plan, ULONG share_id)
 		m_dxl_to_plstmt_context->GetCTEConsumerList(share_id);
 	GPOS_ASSERT(NULL != shared_scan_cte_consumer_list);
 
-	Flow *flow = GetFlowCTEConsumer(shared_scan_cte_consumer_list);
-
 	const ULONG num_of_shared_scan =
 		gpdb::ListLength(shared_scan_cte_consumer_list);
 
@@ -3688,8 +3686,6 @@ CTranslatorDXLToPlStmt::InitializeSpoolingInfo(Plan *plan, ULONG share_id)
 		share_type = SHARE_MATERIAL;
 		// the share_type is later reset to SHARE_MATERIAL_XSLICE (if needed) by the apply_shareinput_xslice
 		materialize->share_type = share_type;
-		GPOS_ASSERT(NULL == (materialize->plan).flow);
-		(materialize->plan).flow = flow;
 	}
 	else
 	{
@@ -3700,13 +3696,15 @@ CTranslatorDXLToPlStmt::InitializeSpoolingInfo(Plan *plan, ULONG share_id)
 		share_type = SHARE_SORT;
 		// the share_type is later reset to SHARE_SORT_XSLICE (if needed) the apply_shareinput_xslice
 		sort->share_type = share_type;
-		GPOS_ASSERT(NULL == (sort->plan).flow);
-		(sort->plan).flow = flow;
 	}
 
 	GPOS_ASSERT(SHARE_NOTSHARED != share_type);
 
+	Flow *flow = NULL;
+
 	// set the share type of the consumer nodes based on the producer
+	// If multiple CTE consumers have a flow then ensure that they are of the
+	// same type
 	ListCell *lc_sh_scan_cte_consumer = NULL;
 	ForEach(lc_sh_scan_cte_consumer, shared_scan_cte_consumer_list)
 	{
@@ -3714,39 +3712,12 @@ CTranslatorDXLToPlStmt::InitializeSpoolingInfo(Plan *plan, ULONG share_id)
 			(ShareInputScan *) lfirst(lc_sh_scan_cte_consumer);
 		share_input_scan_consumer->share_type = share_type;
 		share_input_scan_consumer->driver_slice = -1;  // default
-		if (NULL == (share_input_scan_consumer->scan.plan).flow)
-		{
-			(share_input_scan_consumer->scan.plan).flow =
-				(Flow *) gpdb::CopyObject(flow);
-		}
-	}
-}
-
-//---------------------------------------------------------------------------
-//	@function:
-//		CTranslatorDXLToPlStmt::GetFlowCTEConsumer
-//
-//	@doc:
-//		Retrieve the flow of the shared input scan of the cte consumers. If
-//		multiple CTE consumers have a flow then ensure that they are of the
-//		same type
-//---------------------------------------------------------------------------
-Flow *
-CTranslatorDXLToPlStmt::GetFlowCTEConsumer(List *shared_scan_cte_consumer_list)
-{
-	Flow *flow = NULL;
-
-	ListCell *lc_sh_scan_cte_consumer = NULL;
-	ForEach(lc_sh_scan_cte_consumer, shared_scan_cte_consumer_list)
-	{
-		ShareInputScan *share_input_scan_consumer =
-			(ShareInputScan *) lfirst(lc_sh_scan_cte_consumer);
 		Flow *flow_cte = (share_input_scan_consumer->scan.plan).flow;
 		if (NULL != flow_cte)
 		{
 			if (NULL == flow)
 			{
-				flow = (Flow *) gpdb::CopyObject(flow_cte);
+				flow = flow_cte;
 			}
 			else
 			{
@@ -3754,14 +3725,6 @@ CTranslatorDXLToPlStmt::GetFlowCTEConsumer(List *shared_scan_cte_consumer_list)
 			}
 		}
 	}
-
-	if (NULL == flow)
-	{
-		flow = MakeNode(Flow);
-		flow->flotype = FLOW_UNDEFINED;	 // default flow
-	}
-
-	return flow;
 }
 
 //---------------------------------------------------------------------------

--- a/src/include/gpopt/translate/CTranslatorDXLToPlStmt.h
+++ b/src/include/gpopt/translate/CTranslatorDXLToPlStmt.h
@@ -403,9 +403,6 @@ private:
 	// Initialize spooling information
 	void InitializeSpoolingInfo(Plan *plan, ULONG share_id);
 
-	// retrieve the flow of the shared input scan of the cte consumers
-	Flow *GetFlowCTEConsumer(List *shared_scan_cte_consumer_list);
-
 	// translate a CTE producer into a GPDB share input scan
 	Plan *TranslateDXLCTEProducerToSharedScan(
 		const CDXLNode *cte_producer_dxlnode,

--- a/src/test/regress/expected/with_clause.out
+++ b/src/test/regress/expected/with_clause.out
@@ -2214,3 +2214,60 @@ select * from rcte limit 10;
 ERROR:  window functions in the target list of a recursive query is not supported in Greenplum
 LINE 5:   select first_value(c) over (partition by b), a+x
                  ^
+-- ensure orca doesn't fail (on build with asserts) when one cte on the coordinator has the correct flow and another doesn't
+CREATE TABLE d (a int, b int, c int) DISTRIBUTED BY (a);
+CREATE TABLE r (a int, b int, c char(255)) DISTRIBUTED REPLICATED;
+INSERT INTO d SELECT 1, generate_series(1,10), 1;
+INSERT INTO r SELECT 1, 2, generate_series(1,100);
+SET gp_cte_sharing TO on;
+EXPLAIN (ANALYZE off, COSTS off, VERBOSE off)
+WITH e AS (
+    SELECT DISTINCT b FROM d
+), h AS (
+    SELECT a FROM d JOIN e f USING (b) JOIN e USING (b)
+) SELECT * FROM r JOIN h USING (a) JOIN h i USING (a);
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice6; segments: 3)
+   ->  Hash Join
+         Hash Cond: (r.a = share0_ref2.a)
+         ->  Seq Scan on r
+         ->  Hash
+               ->  Hash Join
+                     Hash Cond: (share0_ref2.a = share0_ref1.a)
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                           Hash Key: share0_ref2.a
+                           ->  Shared Scan (share slice:id 1:0)
+                     ->  Hash
+                           ->  Redistribute Motion 3:3  (slice5; segments: 3)
+                                 Hash Key: share0_ref1.a
+                                 ->  Shared Scan (share slice:id 5:0)
+                                       ->  Materialize
+                                             ->  Hash Join
+                                                   Hash Cond: (d.b = d_2.b)
+                                                   ->  Hash Join
+                                                         Hash Cond: (d.b = d_1.b)
+                                                         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                                                               Hash Key: d.b
+                                                               ->  Seq Scan on d
+                                                         ->  Hash
+                                                               ->  HashAggregate
+                                                                     Group Key: d_1.b
+                                                                     ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                                                                           Hash Key: d_1.b
+                                                                           ->  HashAggregate
+                                                                                 Group Key: d_1.b
+                                                                                 ->  Seq Scan on d d_1
+                                                   ->  Hash
+                                                         ->  HashAggregate
+                                                               Group Key: d_2.b
+                                                               ->  Redistribute Motion 3:3  (slice4; segments: 3)
+                                                                     Hash Key: d_2.b
+                                                                     ->  HashAggregate
+                                                                           Group Key: d_2.b
+                                                                           ->  Seq Scan on d d_2
+ Optimizer: Postgres query optimizer
+(39 rows)
+
+DROP TABLE d;
+DROP TABLE r;

--- a/src/test/regress/expected/with_clause_optimizer.out
+++ b/src/test/regress/expected/with_clause_optimizer.out
@@ -2215,3 +2215,62 @@ select * from rcte limit 10;
 ERROR:  window functions in the target list of a recursive query is not supported in Greenplum
 LINE 5:   select first_value(c) over (partition by b), a+x
                  ^
+-- ensure orca doesn't fail (on build with asserts) when one cte on the coordinator has the correct flow and another doesn't
+CREATE TABLE d (a int, b int, c int) DISTRIBUTED BY (a);
+CREATE TABLE r (a int, b int, c char(255)) DISTRIBUTED REPLICATED;
+INSERT INTO d SELECT 1, generate_series(1,10), 1;
+INSERT INTO r SELECT 1, 2, generate_series(1,100);
+SET gp_cte_sharing TO on;
+EXPLAIN (ANALYZE off, COSTS off, VERBOSE off)
+WITH e AS (
+    SELECT DISTINCT b FROM d
+), h AS (
+    SELECT a FROM d JOIN e f USING (b) JOIN e USING (b)
+) SELECT * FROM r JOIN h USING (a) JOIN h i USING (a);
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Sequence
+   ->  Shared Scan (share slice:id 0:0)
+         ->  Materialize
+               ->  Gather Motion 3:1  (slice7; segments: 3)
+                     ->  GroupAggregate
+                           Group Key: d_1.b
+                           ->  Sort
+                                 Sort Key: d_1.b
+                                 ->  Redistribute Motion 3:3  (slice6; segments: 3)
+                                       Hash Key: d_1.b
+                                       ->  Seq Scan on d d_1
+   ->  Sequence
+         ->  Shared Scan (share slice:id 0:1)
+               ->  Materialize
+                     ->  Gather Motion 3:1  (slice5; segments: 3)
+                           ->  Hash Join
+                                 Hash Cond: (share0_ref3.b = d.b)
+                                 ->  Redistribute Motion 1:3  (slice2)
+                                       Hash Key: share0_ref3.b
+                                       ->  Shared Scan (share slice:id 2:0)
+                                 ->  Hash
+                                       ->  Hash Join
+                                             Hash Cond: (share0_ref2.b = d.b)
+                                             ->  Redistribute Motion 1:3  (slice3)
+                                                   Hash Key: share0_ref2.b
+                                                   ->  Shared Scan (share slice:id 3:0)
+                                             ->  Hash
+                                                   ->  Redistribute Motion 3:3  (slice4; segments: 3)
+                                                         Hash Key: d.b
+                                                         ->  Seq Scan on d
+         ->  Hash Join
+               Hash Cond: (r.a = share1_ref3.a)
+               ->  Gather Motion 1:1  (slice1; segments: 1)
+                     ->  Seq Scan on r
+               ->  Hash
+                     ->  Hash Join
+                           Hash Cond: (share1_ref3.a = share1_ref2.a)
+                           ->  Shared Scan (share slice:id 0:1)
+                           ->  Hash
+                                 ->  Shared Scan (share slice:id 0:1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(41 rows)
+
+DROP TABLE d;
+DROP TABLE r;


### PR DESCRIPTION
ORCA does not always correctly fill in the flow for shared scans, although the shareinput_mutator_xslice_* functions in cdbmutate require a correctly filled flow.
These functions, among other things, check that if at least one part of a shared scan is executed on the coordinator, then all its other parts must also be performed on the coordinator.
They do this on the shared scan flow, assuming that if flotype = FLOW_SINGLETON and segindex < 0, then
the shared scan will be performed on the coordinator. For such a check, flow must be filled in for a shared scan. ORCA always fills the flow in the shared scan,
but sometimes it does this incorrectly.
ORCA correctly fills the flow only under the Motion nodes, and if there is no Motion above the producers or consumers of the shared scan, then the flow of this shared scan will be filled incorrectly with the parameters flotype = FLOW_UNDEFINED and segindex = 0, which is not true if the slice will be executed only on one of the segments or even on the coordinator.
The executor determines where the slice will be executed using gangType in the FillSliceGangInfo function, and flotype and segindex are used to determine gangType only under Motion nodes.
This shows that the flow of a shared scan has no effect on where the slice will be executed, as for this, the flow of the node under the Motion of the slice in which the shared scan is located is used. To determine where the slice will be executed, we can use the node's flow under Motion, keeping and checking that the slice is being executed on the coordinator by the conditions flotype = FLOW_SINGLETON and segindex < 0. We get rid of the need to fill in the flow for a shared scan in ORCA, and now we can remove the function that did this.