### PR TITLE
Fix up stale gp_default_storage_options comment

### DIFF
--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -414,7 +414,7 @@ bool		gp_reject_internal_tcp_conn = true;
 bool		gp_enable_segment_copy_checking = true;
 /*
  * Default storage options GUC.  Value is comma-separated name=value
- * pairs.  E.g. "appendonly=true,orientation=column"
+ * pairs.  E.g. "blocksize=32768,compresstype=none,checksum=true"
  */
 char	   *gp_default_storage_options = NULL;
 


### PR DESCRIPTION
After Postgres 12 merge the GUC to set default table type was moved to default_table_access_method as hinted by the error message.
```
  SET gp_default_storage_options='appendonly=true';
  ERROR:  invalid storage option "appendonly"
  HINT:  For table access methods use "default_table_access_method" instead.
```

Instead seems one should run:
```
  SET default_table_access_method='ao_row';
```

Remove the stale comment that suggested otherwise.
