### PR TITLE
Resgroup can unassign(bypass) for direct dispatch plans.

### DIFF
--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -223,6 +223,7 @@ int			gp_resource_group_cpu_priority;
 double		gp_resource_group_cpu_limit;
 bool		gp_resource_group_bypass;
 bool		gp_resource_group_bypass_catalog_query;
+bool		gp_resource_group_bypass_direct_dispatch;
 
 /* Metrics collector debug GUC */
 bool		vmem_process_interrupt = false;
@@ -2777,6 +2778,15 @@ struct config_bool ConfigureNamesBool_gp[] =
 			NULL
 		},
 		&gp_resource_group_bypass_catalog_query,
+		true, NULL, NULL
+	},
+
+	{
+		{"gp_resource_group_bypass_direct_dispatch", PGC_USERSET, RESOURCES,
+			gettext_noop("Bypass direct dispatch plan."),
+			NULL
+		},
+		&gp_resource_group_bypass_direct_dispatch,
 		true, NULL, NULL
 	},
 

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -283,6 +283,7 @@ static bool groupWaitQueueFind(ResGroupData *group, const PGPROC *proc);
 
 static bool is_pure_catalog_plan(PlannedStmt *stmt);
 static bool can_bypass_based_on_plan_cost(PlannedStmt *stmt);
+static bool can_bypass_direct_dispatch_plan(PlannedStmt *stmt);
 
 /*
  * Estimate size the resource group structures will need in
@@ -3433,6 +3434,8 @@ check_and_unassign_from_resgroup(PlannedStmt* stmt)
 	bool         inFunction;
 	ResGroupInfo groupInfo;
 
+	SIMPLE_FAULT_INJECTOR("check_and_unassign_from_resgroup_entry");
+
 	if (Gp_role != GP_ROLE_DISPATCH ||
 		!IsNormalProcessingMode() ||
 		!IsResGroupActivated() ||
@@ -3450,8 +3453,9 @@ check_and_unassign_from_resgroup(PlannedStmt* stmt)
 	/*
 	 * If none of the bypass(unassign) rule satisfy, return directly
 	 */
-	if (!(gp_resource_group_bypass_catalog_query && is_pure_catalog_plan(stmt)) &&
-		!can_bypass_based_on_plan_cost(stmt))
+	if (!can_bypass_based_on_plan_cost(stmt) &&
+		!(gp_resource_group_bypass_direct_dispatch && can_bypass_direct_dispatch_plan(stmt)) &&
+		!(gp_resource_group_bypass_catalog_query && is_pure_catalog_plan(stmt)))
 		return;
 
 	/* Unassign from resgroup and bypass */
@@ -3484,17 +3488,23 @@ is_pure_catalog_plan(PlannedStmt *stmt)
 {
 	ListCell *rtable;
 	List     *func_tag;
-	int       nFuncs;
+
+	/* For catalog SQL, we only consider SELECT stmt. */
+	if (stmt->commandType != CMD_SELECT)
+		return false;
 
 	if (stmt->numSlices != 1)
 		return false;
 
-	func_tag = list_make1_int(T_FuncExpr);
-	nFuncs   = find_nodes((Node *) (stmt->planTree->targetlist), func_tag);
-	list_free(func_tag);
-
-	if (nFuncs >= 0)
-		return false;
+	if (stmt->planTree->targetlist != NIL)
+	{
+		int    pos;
+		func_tag = list_make1_int(T_FuncExpr);
+		pos = find_nodes((Node *) (stmt->planTree->targetlist), func_tag);
+		list_free(func_tag);
+		if (pos >= 0)
+			return false;
+	}
 
 	foreach(rtable, stmt->rtable)
 	{
@@ -3529,4 +3539,28 @@ can_bypass_based_on_plan_cost(PlannedStmt *stmt)
 
 	min_cost = (int) pg_atomic_read_u32((pg_atomic_uint32 *) &caps->min_cost);
 	return stmt->planTree->total_cost < min_cost;
+}
+
+/*
+ * Insert|Delete|Update: bypass those with numSlice = 1
+ * and the slice is direct dispatch.
+ *
+ * Select: since there is motion to gather to QD, bypass
+ * those with numSlice = 2, and  the 1st slice in QD and
+ * the 2nd slice is direct dispatch.
+ */
+static bool
+can_bypass_direct_dispatch_plan(PlannedStmt *stmt)
+{
+	if (stmt->commandType == CMD_SELECT)
+	{
+		return (stmt->numSlices == 2 &&
+				stmt->slices[1].directDispatch.isDirectDispatch);
+	}
+	else if (stmt->commandType == CMD_UPDATE ||
+			 stmt->commandType == CMD_INSERT ||
+			 stmt->commandType == CMD_DELETE)
+		return stmt->numSlices == 1 && stmt->slices[0].directDispatch.isDirectDispatch;
+	else
+		return false;
 }

--- a/src/include/utils/resgroup.h
+++ b/src/include/utils/resgroup.h
@@ -95,6 +95,7 @@ extern double gp_resource_group_cpu_limit;
 extern bool gp_resource_group_bypass;
 extern int gp_resource_group_queuing_timeout;
 extern bool gp_resource_group_bypass_catalog_query;
+extern bool gp_resource_group_bypass_direct_dispatch;
 
 /*
  * Non-GUC global variables.

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -216,6 +216,7 @@
 		"gp_resource_group_cpu_limit",
 		"gp_resource_group_cpu_priority",
 		"gp_resource_group_bypass_catalog_query",
+		"gp_resource_group_bypass_direct_dispatch",
 		"gp_resource_group_queuing_timeout",
 		"gp_resource_manager",
 		"gp_resqueue_memory_policy",

--- a/src/test/isolation2/expected/resgroup/resgroup_bypass.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_bypass.out
@@ -1,2 +1,287 @@
--- RG FIXME: The bypass mode will be re-design in the latest future, so just remove all the test case, because this
--- file is deeply dependent on the memory model which has been removed in this PR.
+-- TEST BYPASS
+
+-- start_ignore
+DROP TABLE t_bypass;
+ERROR:  table "t_bypass" does not exist
+DROP ROLE role_bypass;
+ERROR:  role "role_bypass" does not exist
+DROP RESOURCE GROUP rg_bypass;
+ERROR:  resource group "rg_bypass" does not exist
+-- end_ignore
+
+-- create a resource group with concurrency = 1.
+CREATE RESOURCE GROUP rg_bypass WITH(cpu_hard_quota_limit=20, concurrency=1);
+CREATE
+CREATE ROLE role_bypass RESOURCE GROUP rg_bypass;
+CREATE
+
+SET ROLE role_bypass;
+SET
+CREATE TABLE t_bypass(a int) distributed by (a);
+CREATE
+RESET ROLE;
+RESET
+
+-- Session1: pure-catalog query will be unassigned and bypassed.
+1: SET ROLE role_bypass;
+SET
+1: SELECT gp_inject_fault('check_and_unassign_from_resgroup_entry', 'suspend', 1, current_setting('gp_session_id')::int);
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+1&: SELECT relname FROM pg_class WHERE relname = 't_bypass';  <waiting ...>
+SELECT gp_wait_until_triggered_fault('check_and_unassign_from_resgroup_entry', 1, 1);
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
+2: SET ROLE role_bypass;
+SET
+2&: BEGIN;  <waiting ...>
+
+SELECT gp_inject_fault('func_init_plan_end', 'suspend', 1, sess_id) FROM pg_stat_activity WHERE rsgname = 'rg_bypass' AND wait_event_type is null;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+SELECT gp_inject_fault('check_and_unassign_from_resgroup_entry', 'reset', 1);
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+2<:  <... completed>
+BEGIN
+2: COMMIT;
+COMMIT
+
+SELECT gp_inject_fault('func_init_plan_end', 'reset', 1);
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+1<:  <... completed>
+ relname  
+----------
+ t_bypass 
+(1 row)
+1q: ... <quitting>
+2q: ... <quitting>
+
+1: SET ROLE role_bypass;
+SET
+1: SELECT gp_inject_fault('check_and_unassign_from_resgroup_entry', 'suspend', 1, current_setting('gp_session_id')::int);
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+1&: SELECT 1;  <waiting ...>
+SELECT gp_wait_until_triggered_fault('check_and_unassign_from_resgroup_entry', 1, 1);
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
+2: SET ROLE role_bypass;
+SET
+2&: BEGIN;  <waiting ...>
+
+SELECT gp_inject_fault('func_init_plan_end', 'suspend', 1, sess_id) FROM pg_stat_activity WHERE rsgname = 'rg_bypass' AND wait_event_type is null;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+SELECT gp_inject_fault('check_and_unassign_from_resgroup_entry', 'reset', 1);
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+2<:  <... completed>
+BEGIN
+2: COMMIT;
+COMMIT
+
+SELECT gp_inject_fault('func_init_plan_end', 'reset', 1);
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+1<:  <... completed>
+ ?column? 
+----------
+ 1        
+(1 row)
+1q: ... <quitting>
+2q: ... <quitting>
+
+-- Test cases for direct dispatch plan bypass (unassign).
+1: SET ROLE role_bypass;
+SET
+1: SELECT gp_inject_fault('check_and_unassign_from_resgroup_entry', 'suspend', 1, current_setting('gp_session_id')::int);
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+1&: INSERT INTO t_bypass VALUES (1);  <waiting ...>
+SELECT gp_wait_until_triggered_fault('check_and_unassign_from_resgroup_entry', 1, 1);
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
+2: SET ROLE role_bypass;
+SET
+2&: BEGIN;  <waiting ...>
+
+SELECT gp_inject_fault('func_init_plan_end', 'suspend', 1, sess_id) FROM pg_stat_activity WHERE rsgname = 'rg_bypass' AND wait_event_type is null;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+SELECT gp_inject_fault('check_and_unassign_from_resgroup_entry', 'reset', 1);
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+2<:  <... completed>
+BEGIN
+2: COMMIT;
+COMMIT
+
+SELECT gp_inject_fault('func_init_plan_end', 'reset', 1);
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+1<:  <... completed>
+INSERT 1
+1q: ... <quitting>
+2q: ... <quitting>
+
+1: SET ROLE role_bypass;
+SET
+1: SELECT gp_inject_fault('check_and_unassign_from_resgroup_entry', 'suspend', 1, current_setting('gp_session_id')::int);
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+1&: SELECT * FROM t_bypass where a = 1;  <waiting ...>
+SELECT gp_wait_until_triggered_fault('check_and_unassign_from_resgroup_entry', 1, 1);
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
+2: SET ROLE role_bypass;
+SET
+2&: BEGIN;  <waiting ...>
+
+SELECT gp_inject_fault('func_init_plan_end', 'suspend', 1, sess_id) FROM pg_stat_activity WHERE rsgname = 'rg_bypass' AND wait_event_type is null;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+SELECT gp_inject_fault('check_and_unassign_from_resgroup_entry', 'reset', 1);
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+2<:  <... completed>
+BEGIN
+2: COMMIT;
+COMMIT
+
+SELECT gp_inject_fault('func_init_plan_end', 'reset', 1);
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+1<:  <... completed>
+ a 
+---
+ 1 
+(1 row)
+1q: ... <quitting>
+2q: ... <quitting>
+
+-- before this line the min_cost is 0, so bypass using
+-- min_cost will not work for above.
+-- alter resource group's min_cost
+ALTER RESOURCE GROUP rg_bypass SET min_cost 500;
+ALTER
+ANALYZE t_bypass;
+ANALYZE
+-- Session1: for quries with cost under the min_cost limit, they will be unassigned and bypassed.
+1: SET gp_resource_group_bypass_direct_dispatch = 0;
+SET
+1: SET ROLE role_bypass;
+SET
+1: SELECT gp_inject_fault('check_and_unassign_from_resgroup_entry', 'suspend', 1, current_setting('gp_session_id')::int);
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+1&: SELECT * FROM t_bypass where a = 1;  <waiting ...>
+SELECT gp_wait_until_triggered_fault('check_and_unassign_from_resgroup_entry', 1, 1);
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
+2: SET ROLE role_bypass;
+SET
+2&: BEGIN;  <waiting ...>
+
+SELECT gp_inject_fault('func_init_plan_end', 'suspend', 1, sess_id) FROM pg_stat_activity WHERE rsgname = 'rg_bypass' AND wait_event_type is null;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+SELECT gp_inject_fault('check_and_unassign_from_resgroup_entry', 'reset', 1);
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+2<:  <... completed>
+BEGIN
+2: COMMIT;
+COMMIT
+
+SELECT gp_inject_fault('func_init_plan_end', 'reset', 1);
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+1<:  <... completed>
+ a 
+---
+ 1 
+(1 row)
+1q: ... <quitting>
+2q: ... <quitting>
+
+-- cleanup
+-- start_ignore
+DROP TABLE t_bypass;
+DROP
+DROP ROLE role_bypass;
+DROP
+DROP RESOURCE GROUP rg_bypass;
+DROP
+-- end_ignore

--- a/src/test/isolation2/expected/resgroup/resgroup_memory_limit.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_memory_limit.out
@@ -1,8 +1,8 @@
 -- test memory limit
 -- start_ignore
+DROP TABLE IF EXISTS t_memory_limit;
 DROP ROLE IF EXISTS role_memory_test;
 DROP RESOURCE GROUP rg_memory_test;
-DROP TABLE t_memory_limit;
 -- end_ignore
 
 -- create a pl function to show the memory used by a process
@@ -56,38 +56,6 @@ SET
 (1 row)
 1: RESET gp_resgroup_memory_query_fixed_mem;
 RESET
-
--- pure-catalog query will be unassigned and bypassed and use statement_mem as query mem.
-1: EXPLAIN ANALYZE SELECT * FROM pg_class WHERE relname = 't_memory_limit';
- QUERY PLAN                                                                                                                            
----------------------------------------------------------------------------------------------------------------------------------------
- Index Scan using pg_class_relname_nsp_index on pg_class  (cost=0.15..8.17 rows=1 width=265) (actual time=0.006..0.007 rows=1 loops=1) 
-   Index Cond: (relname = 't_memory_limit'::name)                                                                                      
- Optimizer: Postgres query optimizer                                                                                                   
- Planning Time: 2.538 ms                                                                                                               
-   (slice0)    Executor memory: 41K bytes.                                                                                             
- Memory used:  128000kB                                                                                                                
- Execution Time: 0.270 ms                                                                                                              
-(7 rows)
-
--- session2: alter resource group's min_cost
-2: ALTER RESOURCE GROUP rg_memory_test SET min_cost 500;
-ALTER
-
--- for quries with cost under the min_cost limit, they will be unassigned and bypassed.
-1: EXPLAIN ANALYZE SELECT * FROM t_memory_limit where a = 1;
- QUERY PLAN                                                                                                              
--------------------------------------------------------------------------------------------------------------------------
- Gather Motion 1:1  (slice1; segments: 1)  (cost=0.00..436.53 rows=96 width=4) (actual time=0.399..0.399 rows=0 loops=1) 
-   ->  Seq Scan on t_memory_limit  (cost=0.00..435.25 rows=32 width=4) (actual time=0.000..0.006 rows=0 loops=1)         
-         Filter: (a = 1)                                                                                                 
- Optimizer: Postgres query optimizer                                                                                     
- Planning Time: 0.273 ms                                                                                                 
-   (slice0)    Executor memory: 36K bytes.                                                                               
-   (slice1)    Executor memory: 38K bytes (seg1).                                                                        
- Memory used:  128000kB                                                                                                  
- Execution Time: 0.647 ms                                                                                                
-(9 rows)
 
 1: RESET ROLE;
 RESET

--- a/src/test/isolation2/isolation2_resgroup_v1_schedule
+++ b/src/test/isolation2/isolation2_resgroup_v1_schedule
@@ -4,6 +4,9 @@
 # enable resource group v1
 test: resgroup/resgroup_auxiliary_tools_v1
 
+# bypass catalog
+test: resgroup/resgroup_bypass_catalog
+
 # basic syntax
 test: resgroup/resgroup_views
 test: resgroup/resgroup_syntax
@@ -11,13 +14,13 @@ test: resgroup/resgroup_transaction
 test: resgroup/resgroup_name_convention
 
 # fault injection tests
+test: resgroup/resgroup_bypass
 test: resgroup/resgroup_assign_slot_fail
 test: resgroup/resgroup_unassign_entrydb
 test: resgroup/resgroup_seg_down_2pc
 
 # functions
 test: resgroup/resgroup_concurrency
-test: resgroup/resgroup_bypass
 test: resgroup/resgroup_alter_concurrency
 test: resgroup/resgroup_cpu_hard_quota
 test: resgroup/resgroup_cpuset

--- a/src/test/isolation2/isolation2_resgroup_v2_schedule
+++ b/src/test/isolation2/isolation2_resgroup_v2_schedule
@@ -14,13 +14,13 @@ test: resgroup/resgroup_transaction
 test: resgroup/resgroup_name_convention
 
 # fault injection tests
+test: resgroup/resgroup_bypass
 test: resgroup/resgroup_assign_slot_fail
 test: resgroup/resgroup_unassign_entrydb
 test: resgroup/resgroup_seg_down_2pc
 
 # functions
 test: resgroup/resgroup_concurrency
-test: resgroup/resgroup_bypass
 test: resgroup/resgroup_alter_concurrency
 test: resgroup/resgroup_cpu_hard_quota
 test: resgroup/resgroup_cpuset

--- a/src/test/isolation2/sql/resgroup/resgroup_bypass.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_bypass.sql
@@ -1,2 +1,141 @@
--- RG FIXME: The bypass mode will be re-design in the latest future, so just remove all the test case, because this
--- file is deeply dependent on the memory model which has been removed in this PR.
+-- TEST BYPASS
+
+-- start_ignore
+DROP TABLE t_bypass;
+DROP ROLE role_bypass;
+DROP RESOURCE GROUP rg_bypass;
+-- end_ignore
+
+-- create a resource group with concurrency = 1.
+CREATE RESOURCE GROUP rg_bypass WITH(cpu_hard_quota_limit=20, concurrency=1);
+CREATE ROLE role_bypass RESOURCE GROUP rg_bypass;
+
+SET ROLE role_bypass;
+CREATE TABLE t_bypass(a int) distributed by (a);
+RESET ROLE;
+
+-- Session1: pure-catalog query will be unassigned and bypassed.
+1: SET ROLE role_bypass;
+1: SELECT gp_inject_fault('check_and_unassign_from_resgroup_entry', 'suspend', 1, current_setting('gp_session_id')::int);
+1&: SELECT relname FROM pg_class WHERE relname = 't_bypass';
+SELECT gp_wait_until_triggered_fault('check_and_unassign_from_resgroup_entry', 1, 1);
+
+2: SET ROLE role_bypass;
+2&: BEGIN;
+
+SELECT gp_inject_fault('func_init_plan_end', 'suspend', 1, sess_id)
+FROM pg_stat_activity WHERE rsgname = 'rg_bypass' AND wait_event_type is null;
+
+SELECT gp_inject_fault('check_and_unassign_from_resgroup_entry', 'reset', 1);
+
+2<:
+2: COMMIT;
+
+SELECT gp_inject_fault('func_init_plan_end', 'reset', 1);
+
+1<:
+1q:
+2q:
+
+1: SET ROLE role_bypass;
+1: SELECT gp_inject_fault('check_and_unassign_from_resgroup_entry', 'suspend', 1, current_setting('gp_session_id')::int);
+1&: SELECT 1;
+SELECT gp_wait_until_triggered_fault('check_and_unassign_from_resgroup_entry', 1, 1);
+
+2: SET ROLE role_bypass;
+2&: BEGIN;
+
+SELECT gp_inject_fault('func_init_plan_end', 'suspend', 1, sess_id)
+FROM pg_stat_activity WHERE rsgname = 'rg_bypass' AND wait_event_type is null;
+
+SELECT gp_inject_fault('check_and_unassign_from_resgroup_entry', 'reset', 1);
+
+2<:
+2: COMMIT;
+
+SELECT gp_inject_fault('func_init_plan_end', 'reset', 1);
+
+1<:
+1q:
+2q:
+
+-- Test cases for direct dispatch plan bypass (unassign).
+1: SET ROLE role_bypass;
+1: SELECT gp_inject_fault('check_and_unassign_from_resgroup_entry', 'suspend', 1, current_setting('gp_session_id')::int);
+1&: INSERT INTO t_bypass VALUES (1);
+SELECT gp_wait_until_triggered_fault('check_and_unassign_from_resgroup_entry', 1, 1);
+
+2: SET ROLE role_bypass;
+2&: BEGIN;
+
+SELECT gp_inject_fault('func_init_plan_end', 'suspend', 1, sess_id)
+FROM pg_stat_activity WHERE rsgname = 'rg_bypass' AND wait_event_type is null;
+
+SELECT gp_inject_fault('check_and_unassign_from_resgroup_entry', 'reset', 1);
+
+2<:
+2: COMMIT;
+
+SELECT gp_inject_fault('func_init_plan_end', 'reset', 1);
+
+1<:
+1q:
+2q:
+
+1: SET ROLE role_bypass;
+1: SELECT gp_inject_fault('check_and_unassign_from_resgroup_entry', 'suspend', 1, current_setting('gp_session_id')::int);
+1&: SELECT * FROM t_bypass where a = 1;
+SELECT gp_wait_until_triggered_fault('check_and_unassign_from_resgroup_entry', 1, 1);
+
+2: SET ROLE role_bypass;
+2&: BEGIN;
+
+SELECT gp_inject_fault('func_init_plan_end', 'suspend', 1, sess_id)
+FROM pg_stat_activity WHERE rsgname = 'rg_bypass' AND wait_event_type is null;
+
+SELECT gp_inject_fault('check_and_unassign_from_resgroup_entry', 'reset', 1);
+
+2<:
+2: COMMIT;
+
+SELECT gp_inject_fault('func_init_plan_end', 'reset', 1);
+
+1<:
+1q:
+2q:
+
+-- before this line the min_cost is 0, so bypass using
+-- min_cost will not work for above.
+-- alter resource group's min_cost
+ALTER RESOURCE GROUP rg_bypass SET min_cost 500;
+ANALYZE t_bypass;
+-- Session1: for quries with cost under the min_cost limit, they will be unassigned and bypassed.
+1: SET gp_resource_group_bypass_direct_dispatch = 0;
+1: SET ROLE role_bypass;
+1: SELECT gp_inject_fault('check_and_unassign_from_resgroup_entry', 'suspend', 1, current_setting('gp_session_id')::int);
+1&: SELECT * FROM t_bypass where a = 1;
+SELECT gp_wait_until_triggered_fault('check_and_unassign_from_resgroup_entry', 1, 1);
+
+2: SET ROLE role_bypass;
+2&: BEGIN;
+
+SELECT gp_inject_fault('func_init_plan_end', 'suspend', 1, sess_id)
+FROM pg_stat_activity WHERE rsgname = 'rg_bypass' AND wait_event_type is null;
+
+SELECT gp_inject_fault('check_and_unassign_from_resgroup_entry', 'reset', 1);
+
+2<:
+2: COMMIT;
+
+SELECT gp_inject_fault('func_init_plan_end', 'reset', 1);
+
+1<:
+1q:
+2q:
+
+-- cleanup
+-- start_ignore
+DROP TABLE t_bypass;
+DROP ROLE role_bypass;
+DROP RESOURCE GROUP rg_bypass;
+-- end_ignore

--- a/src/test/isolation2/sql/resgroup/resgroup_memory_limit.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_memory_limit.sql
@@ -49,15 +49,6 @@ CREATE ROLE role_memory_test RESOURCE GROUP rg_memory_test;
 1: SELECT func_memory_test('SELECT * FROM t_memory_limit');
 1: RESET gp_resgroup_memory_query_fixed_mem;
 
--- pure-catalog query will be unassigned and bypassed and use statement_mem as query mem.
-1: EXPLAIN ANALYZE SELECT * FROM pg_class WHERE relname = 't_memory_limit';
-
--- session2: alter resource group's min_cost
-2: ALTER RESOURCE GROUP rg_memory_test SET min_cost 500;
-
--- for quries with cost under the min_cost limit, they will be unassigned and bypassed.
-1: EXPLAIN ANALYZE SELECT * FROM t_memory_limit where a = 1;
-
 1: RESET ROLE;
 -- clean
 DROP FUNCTION func_memory_test(text);


### PR DESCRIPTION
This commit introduces a new GUC gp_resource_group_bypass_direct_dispatch which is defaultly true. After getting the plan, we can unassign (bypass) from resgroup:
  - for SelectStmt, direct dispatch means there are two slices and the 1st slice is QD and the 2nd is direct dispatch
  - for (Update|Delete|Insert)Stmt, direct dispatch means there is only one slice and that slice is direct dispatch

Also we move some tests into bypass suite.

Co-authored-by: Wenru Yan <ywenru@vmware.com>