### PR TITLE
resolve fixme, do not need to check forceDistRandom in set_cte_pathlist

### DIFF
--- a/src/backend/optimizer/path/allpaths.c
+++ b/src/backend/optimizer/path/allpaths.c
@@ -3095,7 +3095,6 @@ set_cte_pathlist(PlannerInfo *root, RelOptInfo *rel, RangeTblEntry *rte)
 		List	   *pathkeys;
 		CdbPathLocus locus;
 
-		/* GPDB_96_MERGE_FIXME: Should we check forceDistRandom here, like set_subquery_pathlist() does? */
 		locus = cdbpathlocus_from_subquery(root, rel, subpath);
 
 		/* Convert subquery pathkeys to outer representation */

--- a/src/test/regress/expected/bfv_cte.out
+++ b/src/test/regress/expected/bfv_cte.out
@@ -338,3 +338,21 @@ select const_a, const_b, sum(n)
  foo_a   | foo_b   |   3
 (2 rows)
 
+-- test cte can not be the param for gp_dist_random
+-- so in set_cte_pathlist we do not neet to check forceDistRandom
+create table ttt(tc1 int,tc2 int) ;
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'tc1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into ttt values(1,1);
+insert into ttt  values(2,2);
+WITH cte AS (
+  SELECT oid, relname
+  FROM pg_class
+  WHERE oid <2000
+)
+SELECT *
+FROM gp_dist_random('cte')
+JOIN ttt ON cte.oid = ttt.tc2;
+ERROR:  relation "cte" does not exist
+LINE 7: FROM gp_dist_random('cte')
+                            ^

--- a/src/test/regress/sql/bfv_cte.sql
+++ b/src/test/regress/sql/bfv_cte.sql
@@ -228,3 +228,18 @@ select const_a, const_b, sum(n)
  ) x
  group by const_a, const_b
 ;
+
+-- test cte can not be the param for gp_dist_random
+-- so in set_cte_pathlist we do not neet to check forceDistRandom
+create table ttt(tc1 int,tc2 int) ;
+insert into ttt values(1,1);
+insert into ttt  values(2,2);
+
+WITH cte AS (
+  SELECT oid, relname
+  FROM pg_class
+  WHERE oid <2000
+)
+SELECT *
+FROM gp_dist_random('cte')
+JOIN ttt ON cte.oid = ttt.tc2;


### PR DESCRIPTION
GPDB_96_MERGE_FIXME: Should we check forceDistRandom here, like set_subquery_pathlist() does? 
```
create table ttt(tc1 int,tc2 int) ;
insert into ttt values(1,1);
insert into ttt  values(2,2);

WITH cte AS (
  SELECT oid, relname
  FROM pg_class
  WHERE oid <2000
)
SELECT *
FROM gp_dist_random('cte')
JOIN ttt ON cte.oid = ttt.tc2;
 
ERROR:  relation "cte1" does not exist
```
CET can not be the param of gp_dist_random.
So in set_cte_pathlist we do not need to check forceDistRandom.
Remove GPDB_96_MERGE_FIXME in allpaths.c