### PR TITLE
Run analyzedb during ICW

### DIFF
--- a/GNUmakefile.in
+++ b/GNUmakefile.in
@@ -206,13 +206,11 @@ installcheck-gpcheckcat:
 	@echo "Running gpcheckcat on all databases"
 	gpcheckcat -A
 
-.PHONY: installcheck-analyzedb
-installcheck-world: installcheck-analyzedb
-installcheck-analyzedb:
-	@echo "Running analyzedb on regression database"
-	analyzedb -a -d regression > /dev/null
-	@echo "Running analyzedb on isolation2test database"
-	analyzedb -a -d isolation2test > /dev/null
+.PHONY: installcheck-analyze
+installcheck-world: installcheck-analyze
+installcheck-analyze:
+	@echo "Running analyze on databases"
+	vacuumdb --all --analyze-only --jobs=5
 $(call recurse,installcheck-world,gpcontrib/gp_replica_check,installcheck)
 $(call recurse,installcheck-world,src/bin/pg_upgrade,check)
 

--- a/GNUmakefile.in
+++ b/GNUmakefile.in
@@ -203,7 +203,16 @@ installcheck-mirrorless: submake-generated-headers
 .PHONY: installcheck-gpcheckcat
 installcheck-world: installcheck-gpcheckcat
 installcheck-gpcheckcat:
+	@echo "Running gpcheckcat on all databases"
 	gpcheckcat -A
+
+.PHONY: installcheck-analyzedb
+installcheck-world: installcheck-analyzedb
+installcheck-analyzedb:
+	@echo "Running analyzedb on regression database"
+	analyzedb -a -d regression > /dev/null
+	@echo "Running analyzedb on isolation2test database"
+	analyzedb -a -d isolation2test > /dev/null
 $(call recurse,installcheck-world,gpcontrib/gp_replica_check,installcheck)
 $(call recurse,installcheck-world,src/bin/pg_upgrade,check)
 


### PR DESCRIPTION
Add analyzedb to ICW for regression and isolation databases. We'll run this after gpcheckcat.

This is useful for ensuring all types and tables can be analyzed and provides a data point for analyze performance. Currently, analyzedb takes 83 seconds for the regression database in CI.