### PR TITLE
Allow role names started with 'gp_'

### DIFF
--- a/src/backend/catalog/catalog.c
+++ b/src/backend/catalog/catalog.c
@@ -316,15 +316,29 @@ IsAoSegmentNamespace(Oid namespaceId)
  *		system objects only.  As of 8.0, this was only true for
  *		schema and tablespace names.  With 9.6, this is also true
  *		for roles.
- *
- *      As of Greenplum 4.0 we also reserve the prefix gp_
  */
 bool
 IsReservedName(const char *name)
 {
 	/* ugly coding for speed */
-	return ((name[0] == 'p' && name[1] == 'g' && name[2] == '_') ||
-			(name[0] == 'g' && name[1] == 'p' && name[2] == '_'));
+	return name[0] == 'p' && name[1] == 'g' && name[2] == '_';
+}
+
+/*
+ * IsReservedGpName
+ *		True iff name starts with the gp_ prefix.
+ *
+ *		Counterpart of IsReservedName but checks GPDB reserved name(s).
+ * 		As of Greenplum 4.0 we reserve the prefix gp_ for schema and
+ * 		tablespace names. We do not reserve it for role names to avoid 
+ * 		impact to pre-7.0 users and also because the reason to reserve
+ * 		pg_ for role names does not apply to pg_ (see #15259). 
+ */
+bool
+IsReservedGpName(const char *name)
+{
+	/* ugly coding for speed */
+	return name[0] == 'g' && name[1] == 'p' && name[2] == '_';
 }
 
 /*
@@ -339,7 +353,7 @@ GetReservedPrefix(const char *name)
 {
 	char		*prefix = NULL;
 
-	if (IsReservedName(name))
+	if (IsReservedName(name) || IsReservedGpName(name))
 	{
 		prefix = palloc(4);
 		memcpy(prefix, name, 3);

--- a/src/backend/commands/schemacmds.c
+++ b/src/backend/commands/schemacmds.c
@@ -128,7 +128,7 @@ CreateSchemaCommand(CreateSchemaStmt *stmt, const char *queryString,
 	check_is_member_of_role(saved_uid, owner_uid);
 
 	/* Additional check to protect reserved schema names */
-	if (!allowSystemTableMods && IsReservedName(schemaName))
+	if (!allowSystemTableMods && (IsReservedName(schemaName) || IsReservedGpName(schemaName)))
 	{
 		ereport(ERROR,
 				(errcode(ERRCODE_RESERVED_NAME),
@@ -359,7 +359,7 @@ RenameSchema(const char *oldname, const char *newname)
 		aclcheck_error(aclresult, OBJECT_DATABASE,
 					   get_database_name(MyDatabaseId));
 
-	if (!allowSystemTableMods && IsReservedName(oldname))
+	if (!allowSystemTableMods && (IsReservedName(oldname) || IsReservedGpName(oldname)))
 	{
 		ereport(ERROR,
 				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
@@ -367,7 +367,7 @@ RenameSchema(const char *oldname, const char *newname)
 				 errdetail("Schema %s is reserved for system use.", oldname)));
 	}
 
-	if (!allowSystemTableMods && IsReservedName(newname))
+	if (!allowSystemTableMods && (IsReservedName(newname) || IsReservedGpName(newname)))
 	{
 		ereport(ERROR,
 				(errcode(ERRCODE_RESERVED_NAME),
@@ -438,7 +438,7 @@ AlterSchemaOwner(const char *name, Oid newOwnerId)
 				(errcode(ERRCODE_UNDEFINED_SCHEMA),
 				 errmsg("schema \"%s\" does not exist", name)));
 
-	if (!allowSystemTableMods && IsReservedName(name))
+	if (!allowSystemTableMods && (IsReservedName(name) || IsReservedGpName(name)))
 	{
 		ereport(ERROR,
 				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),

--- a/src/backend/commands/tablespace.c
+++ b/src/backend/commands/tablespace.c
@@ -357,12 +357,13 @@ CreateTableSpace(CreateTableSpaceStmt *stmt)
 	 * Disallow creation of tablespaces named "pg_xxx"; we reserve this
 	 * namespace for system purposes.
 	 */
-	if (!allowSystemTableMods && IsReservedName(stmt->tablespacename))
+	if (!allowSystemTableMods && (IsReservedName(stmt->tablespacename) || IsReservedGpName(stmt->tablespacename)))
 		ereport(ERROR,
 				(errcode(ERRCODE_RESERVED_NAME),
 				 errmsg("unacceptable tablespace name \"%s\"",
 						stmt->tablespacename),
-				 errdetail("The prefix \"pg_\" is reserved for system tablespaces.")));
+				 errdetail("The prefix \"%s\" is reserved for system tablespaces.",
+						GetReservedPrefix(stmt->tablespacename))));
 
 	/*
 	 * If built with appropriate switch, whine when regression-testing
@@ -1364,7 +1365,7 @@ RenameTableSpace(const char *oldname, const char *newname)
 		aclcheck_error(ACLCHECK_NO_PRIV, OBJECT_TABLESPACE, oldname);
 
 	/* Validate new name */
-	if (!allowSystemTableMods && IsReservedName(newname))
+	if (!allowSystemTableMods && (IsReservedName(newname) || IsReservedGpName(newname)))
 	{
 		ereport(ERROR,
 				(errcode(ERRCODE_RESERVED_NAME),

--- a/src/backend/replication/logical/origin.c
+++ b/src/backend/replication/logical/origin.c
@@ -1236,13 +1236,13 @@ pg_replication_origin_create(PG_FUNCTION_ARGS)
 
 	name = text_to_cstring((text *) DatumGetPointer(PG_GETARG_DATUM(0)));
 
-	/* Replication origins "pg_xxx" are reserved for internal use */
-	if (IsReservedName(name))
+	/* Replication origins "pg_xxx|gp_xxx" are reserved for internal use */
+	if (IsReservedName(name) || IsReservedGpName(name))
 		ereport(ERROR,
 				(errcode(ERRCODE_RESERVED_NAME),
 				 errmsg("replication origin name \"%s\" is reserved",
 						name),
-				 errdetail("Origin names starting with \"pg_\" are reserved.")));
+				 errdetail("Origin names starting with \"%s\" are reserved.", GetReservedPrefix(name))));
 
 	/*
 	 * If built with appropriate switch, whine when regression-testing

--- a/src/include/catalog/catalog.h
+++ b/src/include/catalog/catalog.h
@@ -41,6 +41,7 @@ extern bool IsToastNamespace(Oid namespaceId);
 extern bool IsAoSegmentNamespace(Oid namespaceId);
 
 extern bool IsReservedName(const char *name);
+extern bool IsReservedGpName(const char *name);
 extern char* GetReservedPrefix(const char *name);
 
 extern bool IsSharedRelation(Oid relationId);

--- a/src/test/regress/expected/role.out
+++ b/src/test/regress/expected/role.out
@@ -164,3 +164,9 @@ NOTICE:  no privileges could be revoked
 drop table grant_only_syntax1;
 drop table grant_only_syntax2;
 drop role test_role;
+-- should be able to create gp_ roles, but not pg_ ones
+drop role if exists gp_regresstestrole;
+create role gp_regresstestrole;
+create role pg_regresstestrole;
+DETAIL:  Role names starting with "pg_" are reserved.
+ERROR:  role name "pg_regresstestrole" is reserved

--- a/src/test/regress/sql/role.sql
+++ b/src/test/regress/sql/role.sql
@@ -151,3 +151,8 @@ revoke select on only grant_only_syntax1, only grant_only_syntax2 from test_role
 drop table grant_only_syntax1;
 drop table grant_only_syntax2;
 drop role test_role;
+
+-- should be able to create gp_ roles, but not pg_ ones
+drop role if exists gp_regresstestrole;
+create role gp_regresstestrole;
+create role pg_regresstestrole;


### PR DESCRIPTION
The merge with upstream absorbed 293007898d3fa5a815c1c5814df53627553f114d which disallowed creating roles with reserved names because some default system roles started with 'pg_' were introduced since 9.6 so we don't want them to conflict: https://www.postgresql.org/docs/9.6/default-roles.html

However, in Greenplum reserved names include not only 'pg_' but also 'gp_'. But we do not have any system roles starting with 'gp_' so it is fine to allow users to still create those roles.

Now modifying IsReservedName() to pass a parameter to indicate whether we want to reserve 'gp_' or not. It would create more footprint in the codebase than e.g. don't change IsReservedName() but just check 'gp_' explicitly when doing role name checking. But modifying IsReservedName() would force the caller to make sure what exactly should be reserved so we could avoid such an issue in future.

Fix #15259

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
