### PR TITLE
Mark additional Orca gucs to be shown in guc list

### DIFF
--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -1820,7 +1820,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"optimizer_trace_fallback", PGC_USERSET, LOGGING_WHAT,
 			gettext_noop("Print a message at INFO level, whenever GPORCA falls back."),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_trace_fallback,
 		false,
@@ -2015,7 +2015,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"optimizer_dpe_stats", PGC_USERSET, QUERY_TUNING_METHOD,
 			gettext_noop("Enable statistics derivation for partitioned tables with dynamic partition elimination."),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_dpe_stats,
 		true,
@@ -2296,7 +2296,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"optimizer_enable_derive_stats_all_groups", PGC_USERSET, DEVELOPER_OPTIONS,
 			gettext_noop("Enable stats derivation for all groups after exploration."),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_enable_derive_stats_all_groups,
 		false,
@@ -2628,7 +2628,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"optimizer_force_three_stage_scalar_dqa", PGC_USERSET, QUERY_TUNING_METHOD,
 			gettext_noop("Force optimizer to always pick 3 stage aggregate plan for scalar distinct qualified aggregate."),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_force_three_stage_scalar_dqa,
 		true,
@@ -2650,7 +2650,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"optimizer_array_constraints", PGC_USERSET, DEVELOPER_OPTIONS,
 			gettext_noop("Allows the optimizer's constraint framework to derive array constraints."),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_array_constraints,
 		true,
@@ -2661,7 +2661,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"optimizer_use_gpdb_allocators", PGC_POSTMASTER, RESOURCES_MEM,
 			gettext_noop("Enable ORCA to use GPDB Memory Contexts"),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_use_gpdb_allocators,
 		true,
@@ -2736,7 +2736,7 @@ struct config_bool ConfigureNamesBool_gp[] =
 		{"optimizer_replicated_table_insert", PGC_USERSET, STATS_ANALYZE,
 			gettext_noop("Omit broadcast motion when inserting into replicated table"),
 			gettext_noop("Only when source is SegmentGeneral or General locus"),
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_replicated_table_insert,
 		true, NULL, NULL
@@ -3953,7 +3953,7 @@ struct config_int ConfigureNamesInt_gp[] =
 		{"optimizer_cte_inlining_bound", PGC_USERSET, QUERY_TUNING_METHOD,
 			gettext_noop("Set the CTE inlining cutoff"),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_cte_inlining_bound,
 		0, 0, INT_MAX,
@@ -3975,7 +3975,7 @@ struct config_int ConfigureNamesInt_gp[] =
 		{"optimizer_array_expansion_threshold", PGC_USERSET, QUERY_TUNING_METHOD,
 			gettext_noop("Item limit for expansion of arrays in WHERE clause for constraint derivation."),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_array_expansion_threshold,
 		20, 0, INT_MAX,
@@ -3986,7 +3986,7 @@ struct config_int ConfigureNamesInt_gp[] =
 		{"optimizer_push_group_by_below_setop_threshold", PGC_USERSET, QUERY_TUNING_METHOD,
 			gettext_noop("Maximum number of children setops have to consider pushing group bys below it"),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_push_group_by_below_setop_threshold,
 		10, 0, INT_MAX,
@@ -3997,7 +3997,7 @@ struct config_int ConfigureNamesInt_gp[] =
 		{"optimizer_xform_bind_threshold", PGC_USERSET, DEVELOPER_OPTIONS,
 			gettext_noop("Maximum number bindings per xform per group expression. A value of 0 disables."),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_xform_bind_threshold,
 		0, 0, INT_MAX,
@@ -4008,7 +4008,7 @@ struct config_int ConfigureNamesInt_gp[] =
             {"optimizer_skew_factor", PGC_USERSET, DEVELOPER_OPTIONS,
              gettext_noop("Coefficient of skew ratio computed from sample stastics. Default 0: skew computation from sample statistics turned off. [1,100]: skew ratio computed from sample statistics. The skewness used for costing is the product of the optimizer_skew_factor and the skew ratio."),
              NULL,
-             GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			 GUC_NOT_IN_SAMPLE
             },
             &optimizer_skew_factor,
             0, 0, 100,
@@ -4040,7 +4040,7 @@ struct config_int ConfigureNamesInt_gp[] =
 		{"optimizer_penalize_broadcast_threshold", PGC_USERSET, QUERY_TUNING_METHOD,
 			gettext_noop("Maximum number of rows of a relation that can be broadcasted without penalty. A value of 0 disables."),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_penalize_broadcast_threshold,
 		100000, 0, INT_MAX,
@@ -4263,7 +4263,7 @@ struct config_real ConfigureNamesReal_gp[] =
 		{"optimizer_damping_factor_filter", PGC_USERSET, QUERY_TUNING_METHOD,
 			gettext_noop("select predicate damping factor in optimizer, 1.0 means no damping"),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_damping_factor_filter,
 		0.75, 0.0, 1.0,
@@ -4274,7 +4274,7 @@ struct config_real ConfigureNamesReal_gp[] =
 		{"optimizer_damping_factor_join", PGC_USERSET, QUERY_TUNING_METHOD,
 			gettext_noop("join predicate damping factor in optimizer, 1.0 means no damping, 0.0 means square root method"),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_damping_factor_join,
 		0.0, 0.0, 1.0,
@@ -4284,7 +4284,7 @@ struct config_real ConfigureNamesReal_gp[] =
 		{"optimizer_damping_factor_groupby", PGC_USERSET, QUERY_TUNING_METHOD,
 			gettext_noop("groupby operator damping factor in optimizer, 1.0 means no damping"),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_damping_factor_groupby,
 		0.75, 0.0, 1.0,
@@ -4295,7 +4295,7 @@ struct config_real ConfigureNamesReal_gp[] =
 		{"optimizer_cost_threshold", PGC_USERSET, DEVELOPER_OPTIONS,
 			gettext_noop("Set the threshold for plan sampling relative to the cost of best plan, 0.0 means unbounded"),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_cost_threshold,
 		0.0, 0.0, INT_MAX,
@@ -4306,7 +4306,7 @@ struct config_real ConfigureNamesReal_gp[] =
 		{"optimizer_nestloop_factor", PGC_USERSET, QUERY_TUNING_OTHER,
 			gettext_noop("Set the nestloop join cost factor in the optimizer"),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_nestloop_factor,
 		1024.0, 1.0, DBL_MAX,
@@ -4317,7 +4317,7 @@ struct config_real ConfigureNamesReal_gp[] =
 		{"optimizer_sort_factor",PGC_USERSET, QUERY_TUNING_OTHER,
 			gettext_noop("Set the sort cost factor in the optimizer, 1.0 means same as default, > 1.0 means more costly than default, < 1.0 means means less costly than default"),
 			NULL,
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_sort_factor,
 		1.0, 0.0, DBL_MAX,
@@ -4593,7 +4593,7 @@ struct config_enum ConfigureNamesEnum_gp[] =
 		{"optimizer_cost_model", PGC_USERSET, DEVELOPER_OPTIONS,
 			gettext_noop("Set optimizer cost model."),
 			gettext_noop("Valid values are legacy, calibrated, experimental"),
-			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+			GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_cost_model,
 		OPTIMIZER_GPDB_CALIBRATED, optimizer_cost_model_options,


### PR DESCRIPTION
Currently, we don't show all relevant Orca gucs when running `show all`, which is useful when gathering system information and debugging user systems.