### PR TITLE
Fix bug in ORCA of removing required redistribution motion when query uses GROUP BY over gp_segment_id

### DIFF
--- a/src/backend/gporca/data/dxl/minidump/DistinctQueryWithMotions.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DistinctQueryWithMotions.mdp
@@ -1,0 +1,470 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Comment><![CDATA[
+         Objective: To check if redistribute motion is present in between the two "group by " nodes
+         Many alternate plans are generated for this query, but the plan with id-2 shows the redistribute motion
+         between two 'group by'
+
+         set optimizer_enable_hashagg to off;
+         set optimizer_enumerate_plans to on;
+         set optimizer_plan_id =2;
+
+         create table t(a int, b int, c int);
+         insert into t select 1, i, i from generate_series(1, 10)i;
+         insert into t select 1, i, i from generate_series(1, 10)i;
+         insert into t select 1, i, i from generate_series(1, 10)i;
+         insert into t select 1, i, i from generate_series(1, 10)i;
+
+                                                                  QUERY PLAN
+           ------------------------------------------------------------------------------------------------------------------------
+            Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
+              ->  Finalize GroupAggregate  (cost=0.00..431.00 rows=1 width=12)
+                    Group Key: gp_segment_id
+                    ->  Sort  (cost=0.00..431.00 rows=1 width=12)
+                          Sort Key: gp_segment_id
+                          ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
+                                Hash Key: gp_segment_id
+                                ->  Partial GroupAggregate  (cost=0.00..431.00 rows=1 width=12)
+                                      Group Key: gp_segment_id
+                                      ->  Sort  (cost=0.00..431.00 rows=1 width=8)
+                                            Sort Key: gp_segment_id, b
+                                            ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                                  Hash Key: b
+                                                  ->  Seq Scan on t  (cost=0.00..431.00 rows=1 width=8)
+            Optimizer: Pivotal Optimizer (GPORCA)
+           (15 rows)
+  ]]>
+  </dxl:Comment>
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="2" PlanSamples="2" CostThreshold="2"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="20" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0" SkewFactor="0"/>
+      <dxl:TraceFlags Value="101013,102001,102002,102003,102043,102055,102058,102074,102120,102144,103001,103014,103022,103026,103027,103029,103033,103038,103040,104002,104003,104004,104005,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:PartOpfamily Mdid="0.424.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.20.1.0" Name="Int8" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="8" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:PartOpfamily Mdid="0.1976.1.0"/>
+        <dxl:EqualityOp Mdid="0.410.1.0"/>
+        <dxl:InequalityOp Mdid="0.411.1.0"/>
+        <dxl:LessThanOp Mdid="0.412.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.414.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.413.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.415.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1016.1.0"/>
+        <dxl:MinAgg Mdid="0.2131.1.0"/>
+        <dxl:MaxAgg Mdid="0.2115.1.0"/>
+        <dxl:AvgAgg Mdid="0.2100.1.0"/>
+        <dxl:SumAgg Mdid="0.2107.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:PartOpfamily Mdid="0.1976.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:PartOpfamily Mdid="0.1989.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2134.1.0"/>
+        <dxl:MaxAgg Mdid="0.2118.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.2227.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:PartOpfamily Mdid="0.2789.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.3315.1.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.54758.1.0.9" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.54758.1.0.1" Name="b" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.54758.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:RelationExtendedStatistics Mdid="10.54758.1.0" Name="t"/>
+      <dxl:RelationStatistics Mdid="2.54758.1.0" Name="t" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
+      <dxl:Relation Mdid="6.54758.1.0" Name="t" IsTemporary="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:GPDBScalarOp Mdid="0.97.1.0" Name="&lt;" ComparisonType="LT" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.66.1.0"/>
+        <dxl:Commutator Mdid="0.521.1.0"/>
+        <dxl:InverseOp Mdid="0.525.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:GPDBAgg Mdid="0.2147.1.0" Name="count" IsRepSafe="true" IsSplittable="true" HashAggCapable="true">
+        <dxl:ResultType Mdid="0.20.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.20.1.0"/>
+      </dxl:GPDBAgg>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="11" ColName="count" TypeMdid="0.20.1.0"/>
+        <dxl:Ident ColId="10" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalGroupBy>
+        <dxl:GroupingColumns>
+          <dxl:GroupingColumn ColId="10"/>
+        </dxl:GroupingColumns>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="11" Alias="count">
+            <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="true" AggStage="Normal" AggKind="n" AggArgTypes="23">
+              <dxl:ValuesList ParamType="aggargs">
+                <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:ValuesList>
+              <dxl:ValuesList ParamType="aggdirectargs"/>
+              <dxl:ValuesList ParamType="aggorder"/>
+              <dxl:ValuesList ParamType="aggdistinct">
+                <dxl:SortGroupClause Index="0" EqualityOp="96" SortOperatorMdid="97" SortNullsFirst="false" IsHashable="true"/>
+              </dxl:ValuesList>
+            </dxl:AggFunc>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="6.54758.1.0" TableName="t" LockMode="1">
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="3" Attno="3" ColName="c" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="4" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="5" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="9" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="10" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+      </dxl:LogicalGroupBy>
+    </dxl:Query>
+    <dxl:Plan Id="2" SpaceSize="15">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="431.000113" Rows="1.000000" Width="12"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="10" Alias="count">
+            <dxl:Ident ColId="10" ColName="count" TypeMdid="0.20.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="9" Alias="gp_segment_id">
+            <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:SortingColumnList/>
+        <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="431.000069" Rows="1.000000" Width="12"/>
+          </dxl:Properties>
+          <dxl:GroupingColumns>
+            <dxl:GroupingColumn ColId="9"/>
+          </dxl:GroupingColumns>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="10" Alias="count">
+              <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="23">
+                <dxl:ValuesList ParamType="aggargs">
+                  <dxl:Ident ColId="11" ColName="ColRef_0011" TypeMdid="0.20.1.0"/>
+                </dxl:ValuesList>
+                <dxl:ValuesList ParamType="aggdirectargs"/>
+                <dxl:ValuesList ParamType="aggorder"/>
+                <dxl:ValuesList ParamType="aggdistinct">
+                  <dxl:SortGroupClause Index="0" EqualityOp="96" SortOperatorMdid="97" SortNullsFirst="false" IsHashable="true"/>
+                </dxl:ValuesList>
+              </dxl:AggFunc>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="9" Alias="gp_segment_id">
+              <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:Sort SortDiscardDuplicates="false">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.000054" Rows="1.000000" Width="12"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="9" Alias="gp_segment_id">
+                <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="11" Alias="ColRef_0011">
+                <dxl:Ident ColId="11" ColName="ColRef_0011" TypeMdid="0.20.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:SortingColumnList>
+              <dxl:SortingColumn ColId="9" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+            </dxl:SortingColumnList>
+            <dxl:LimitCount/>
+            <dxl:LimitOffset/>
+            <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.000054" Rows="1.000000" Width="12"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="9" Alias="gp_segment_id">
+                  <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="11" Alias="ColRef_0011">
+                  <dxl:Ident ColId="11" ColName="ColRef_0011" TypeMdid="0.20.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:SortingColumnList/>
+              <dxl:HashExprList>
+                <dxl:HashExpr Opfamily="0.1977.1.0">
+                  <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                </dxl:HashExpr>
+              </dxl:HashExprList>
+              <dxl:Result>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000036" Rows="1.000000" Width="12"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="9" Alias="gp_segment_id">
+                    <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="11" Alias="ColRef_0011">
+                    <dxl:Ident ColId="11" ColName="ColRef_0011" TypeMdid="0.20.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:OneTimeFilter/>
+                <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000036" Rows="1.000000" Width="12"/>
+                  </dxl:Properties>
+                  <dxl:GroupingColumns>
+                    <dxl:GroupingColumn ColId="9"/>
+                  </dxl:GroupingColumns>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="11" Alias="ColRef_0011">
+                      <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="true" AggStage="Partial" AggKind="n" AggArgTypes="23">
+                        <dxl:ValuesList ParamType="aggargs">
+                          <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                        </dxl:ValuesList>
+                        <dxl:ValuesList ParamType="aggdirectargs"/>
+                        <dxl:ValuesList ParamType="aggorder"/>
+                        <dxl:ValuesList ParamType="aggdistinct">
+                          <dxl:SortGroupClause Index="0" EqualityOp="96" SortOperatorMdid="97" SortNullsFirst="false" IsHashable="true"/>
+                        </dxl:ValuesList>
+                      </dxl:AggFunc>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="9" Alias="gp_segment_id">
+                      <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:Sort SortDiscardDuplicates="false">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000025" Rows="1.000000" Width="8"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="1" Alias="b">
+                        <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="9" Alias="gp_segment_id">
+                        <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:SortingColumnList>
+                      <dxl:SortingColumn ColId="9" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                      <dxl:SortingColumn ColId="1" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                    </dxl:SortingColumnList>
+                    <dxl:LimitCount/>
+                    <dxl:LimitOffset/>
+                    <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000025" Rows="1.000000" Width="8"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="1" Alias="b">
+                          <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="9" Alias="gp_segment_id">
+                          <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:SortingColumnList/>
+                      <dxl:HashExprList>
+                        <dxl:HashExpr Opfamily="0.1977.1.0">
+                          <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                        </dxl:HashExpr>
+                      </dxl:HashExprList>
+                      <dxl:TableScan>
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000008" Rows="1.000000" Width="8"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="1" Alias="b">
+                            <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="9" Alias="gp_segment_id">
+                            <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:TableDescriptor Mdid="6.54758.1.0" TableName="t" LockMode="1">
+                          <dxl:Columns>
+                            <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                            <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                            <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                            <dxl:Column ColId="4" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                            <dxl:Column ColId="5" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                            <dxl:Column ColId="6" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                            <dxl:Column ColId="7" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                            <dxl:Column ColId="8" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                            <dxl:Column ColId="9" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                          </dxl:Columns>
+                        </dxl:TableDescriptor>
+                      </dxl:TableScan>
+                    </dxl:RedistributeMotion>
+                  </dxl:Sort>
+                </dxl:Aggregate>
+              </dxl:Result>
+            </dxl:RedistributeMotion>
+          </dxl:Sort>
+        </dxl:Aggregate>
+      </dxl:GatherMotion>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/DistinctQueryWithMotions.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DistinctQueryWithMotions.mdp
@@ -1,43 +1,42 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
   <dxl:Comment><![CDATA[
-         Objective: To check if redistribute motion is present in between the two "group by " nodes
-         Many alternate plans are generated for this query, but the plan with id-2 shows the redistribute motion
-         between two 'group by'
+         Objective: To check if redistribute motion is present in between the two "group aggregates " nodes when group
+         by is on gp_segment_id;
 
+         create table t(a int, b int, c int) distributed by (a);
+         insert into t select 1, i, i from generate_series(1, 10)i;
+         insert into t select 1, i, i from generate_series(1, 10)i;
+         insert into t select 1, i, i from generate_series(1, 10)i;
+         insert into t select 1, i, i from generate_series(1, 10)i;
+         analyze t;
          set optimizer_enable_hashagg to off;
-         set optimizer_enumerate_plans to on;
-         set optimizer_plan_id =8;
 
-         create table t(a int, b int, c int);
-         insert into t select 1, i, i from generate_series(1, 10)i;
-         insert into t select 1, i, i from generate_series(1, 10)i;
-         insert into t select 1, i, i from generate_series(1, 10)i;
-         insert into t select 1, i, i from generate_series(1, 10)i;
+         explain select count(distinct(b)), gp_segment_id from t group by gp_segment_id;
 
                                                                QUERY PLAN
         ------------------------------------------------------------------------------------------------------------------------
-         Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
-           ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=12)
+         Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.01 rows=40 width=12)
+           ->  GroupAggregate  (cost=0.00..431.01 rows=14 width=12)
                  Group Key: gp_segment_id
-                 ->  Sort  (cost=0.00..431.00 rows=1 width=8)
+                 ->  Sort  (cost=0.00..431.01 rows=14 width=8)
                        Sort Key: gp_segment_id
-                       ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                       ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=14 width=8)
                              Hash Key: gp_segment_id
-                             ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=8)
+                             ->  GroupAggregate  (cost=0.00..431.00 rows=14 width=8)
                                    Group Key: gp_segment_id, b
-                                   ->  Sort  (cost=0.00..431.00 rows=1 width=8)
+                                   ->  Sort  (cost=0.00..431.00 rows=14 width=8)
                                          Sort Key: gp_segment_id, b
-                                         ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                         ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=14 width=8)
                                                Hash Key: gp_segment_id, b, b
-                                               ->  Seq Scan on t  (cost=0.00..431.00 rows=1 width=8)
+                                               ->  Seq Scan on t  (cost=0.00..431.00 rows=14 width=8)
          Optimizer: Pivotal Optimizer (GPORCA)
         (15 rows)
   ]]>
   </dxl:Comment>
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
-      <dxl:EnumeratorConfig Id="8" PlanSamples="8" CostThreshold="8"/>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
       <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
@@ -104,9 +103,6 @@
         <dxl:SumAgg Mdid="0.2108.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:ColumnStatistics Mdid="1.16385.1.0.9" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:ColumnStatistics Mdid="1.16385.1.0.1" Name="b" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:ColumnStatistics Mdid="1.16385.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
         <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
         <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
@@ -175,8 +171,57 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:RelationStatistics Mdid="2.16385.1.0" Name="t" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
-      <dxl:Relation Mdid="6.16385.1.0" Name="t" IsTemporary="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3">
+      <dxl:ColumnStatistics Mdid="1.16391.1.0.9" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.16391.1.0.1" Name="b" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.099999" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.099999" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="2"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.099999" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="3"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.099999" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="4"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.099999" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="5"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.099999" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="6"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.099999" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="7"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.099999" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="8"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.099999" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="9"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.099999" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="10"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="10"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.16391.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="1.000000" DistinctValues="1.000000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:RelationStatistics Mdid="2.16391.1.0" Name="t" Rows="40.000000" RelPages="1" RelAllVisible="0" EmptyRelation="false"/>
+      <dxl:Relation Mdid="6.16391.1.0" Name="t" IsTemporary="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3">
         <dxl:Columns>
           <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
             <dxl:DefaultValue/>
@@ -215,7 +260,7 @@
           <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
         </dxl:DistrOpfamilies>
       </dxl:Relation>
-      <dxl:RelationExtendedStatistics Mdid="10.16385.1.0" Name="t"/>
+      <dxl:RelationExtendedStatistics Mdid="10.16391.1.0" Name="t"/>
       <dxl:GPDBScalarOp Mdid="0.97.1.0" Name="&lt;" ComparisonType="LT" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
         <dxl:LeftType Mdid="0.23.1.0"/>
         <dxl:RightType Mdid="0.23.1.0"/>
@@ -259,7 +304,7 @@
           </dxl:ProjElem>
         </dxl:ProjList>
         <dxl:LogicalGet>
-          <dxl:TableDescriptor Mdid="6.16385.1.0" TableName="t" LockMode="1">
+          <dxl:TableDescriptor Mdid="6.16391.1.0" TableName="t" LockMode="1">
             <dxl:Columns>
               <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
               <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
@@ -276,10 +321,10 @@
         </dxl:LogicalGet>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="8" SpaceSize="12">
+    <dxl:Plan Id="0" SpaceSize="12">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.000118" Rows="1.000000" Width="12"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.007846" Rows="40.000000" Width="12"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="10" Alias="count">
@@ -293,7 +338,7 @@
         <dxl:SortingColumnList/>
         <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.000073" Rows="1.000000" Width="12"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.006057" Rows="40.000000" Width="12"/>
           </dxl:Properties>
           <dxl:GroupingColumns>
             <dxl:GroupingColumn ColId="9"/>
@@ -318,7 +363,7 @@
           <dxl:Filter/>
           <dxl:Sort SortDiscardDuplicates="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000063" Rows="1.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.005861" Rows="40.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="1" Alias="b">
@@ -336,7 +381,7 @@
             <dxl:LimitOffset/>
             <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000063" Rows="1.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.003601" Rows="40.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="1" Alias="b">
@@ -355,7 +400,7 @@
               </dxl:HashExprList>
               <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000038" Rows="1.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.003267" Rows="40.000000" Width="8"/>
                 </dxl:Properties>
                 <dxl:GroupingColumns>
                   <dxl:GroupingColumn ColId="9"/>
@@ -372,7 +417,7 @@
                 <dxl:Filter/>
                 <dxl:Sort SortDiscardDuplicates="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000025" Rows="1.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.003100" Rows="40.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="1" Alias="b">
@@ -391,7 +436,7 @@
                   <dxl:LimitOffset/>
                   <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000025" Rows="1.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000840" Rows="40.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="1" Alias="b">
@@ -416,7 +461,7 @@
                     </dxl:HashExprList>
                     <dxl:TableScan>
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000008" Rows="1.000000" Width="8"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000308" Rows="40.000000" Width="8"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="1" Alias="b">
@@ -427,7 +472,7 @@
                         </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
-                      <dxl:TableDescriptor Mdid="6.16385.1.0" TableName="t" LockMode="1">
+                      <dxl:TableDescriptor Mdid="6.16391.1.0" TableName="t" LockMode="1">
                         <dxl:Columns>
                           <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
                           <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>

--- a/src/backend/gporca/data/dxl/minidump/DistinctQueryWithMotions.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DistinctQueryWithMotions.mdp
@@ -7,7 +7,7 @@
 
          set optimizer_enable_hashagg to off;
          set optimizer_enumerate_plans to on;
-         set optimizer_plan_id =2;
+         set optimizer_plan_id =8;
 
          create table t(a int, b int, c int);
          insert into t select 1, i, i from generate_series(1, 10)i;
@@ -15,29 +15,29 @@
          insert into t select 1, i, i from generate_series(1, 10)i;
          insert into t select 1, i, i from generate_series(1, 10)i;
 
-                                                                  QUERY PLAN
-           ------------------------------------------------------------------------------------------------------------------------
-            Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
-              ->  Finalize GroupAggregate  (cost=0.00..431.00 rows=1 width=12)
-                    Group Key: gp_segment_id
-                    ->  Sort  (cost=0.00..431.00 rows=1 width=12)
-                          Sort Key: gp_segment_id
-                          ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
-                                Hash Key: gp_segment_id
-                                ->  Partial GroupAggregate  (cost=0.00..431.00 rows=1 width=12)
-                                      Group Key: gp_segment_id
-                                      ->  Sort  (cost=0.00..431.00 rows=1 width=8)
-                                            Sort Key: gp_segment_id, b
-                                            ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
-                                                  Hash Key: b
-                                                  ->  Seq Scan on t  (cost=0.00..431.00 rows=1 width=8)
-            Optimizer: Pivotal Optimizer (GPORCA)
-           (15 rows)
+                                                               QUERY PLAN
+        ------------------------------------------------------------------------------------------------------------------------
+         Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
+           ->  Finalize GroupAggregate  (cost=0.00..431.00 rows=1 width=12)
+                 Group Key: gp_segment_id
+                 ->  Sort  (cost=0.00..431.00 rows=1 width=12)
+                       Sort Key: gp_segment_id
+                       ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
+                             Hash Key: gp_segment_id
+                             ->  Partial GroupAggregate  (cost=0.00..431.00 rows=1 width=12)
+                                   Group Key: gp_segment_id
+                                   ->  Sort  (cost=0.00..431.00 rows=1 width=8)
+                                         Sort Key: gp_segment_id, b
+                                         ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+                                               Hash Key: gp_segment_id, b
+                                               ->  Seq Scan on t  (cost=0.00..431.00 rows=1 width=8)
+         Optimizer: Pivotal Optimizer (GPORCA)
+        (15 rows)
   ]]>
   </dxl:Comment>
   <dxl:Thread Id="0">
     <dxl:OptimizerConfig>
-      <dxl:EnumeratorConfig Id="2" PlanSamples="2" CostThreshold="2"/>
+      <dxl:EnumeratorConfig Id="8" PlanSamples="8" CostThreshold="8"/>
       <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
       <dxl:CTEConfig CTEInliningCutoff="0"/>
       <dxl:WindowOids RowNumber="3100" Rank="3101"/>
@@ -276,7 +276,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="2" SpaceSize="15">
+    <dxl:Plan Id="8" SpaceSize="15">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="431.000113" Rows="1.000000" Width="12"/>
@@ -426,6 +426,9 @@
                       <dxl:Filter/>
                       <dxl:SortingColumnList/>
                       <dxl:HashExprList>
+                        <dxl:HashExpr Opfamily="0.1977.1.0">
+                          <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                        </dxl:HashExpr>
                         <dxl:HashExpr Opfamily="0.1977.1.0">
                           <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
                         </dxl:HashExpr>

--- a/src/backend/gporca/data/dxl/minidump/DistinctQueryWithMotions.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DistinctQueryWithMotions.mdp
@@ -1,37 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
   <dxl:Comment><![CDATA[
-         Objective: To check if redistribute motion is present in between the two "group aggregates " nodes when group
-         by is on gp_segment_id;
+         Objective: To check if redistribute motion is present in between the two "Aggregate " nodes when group
+                  by is on gp_segment_id;
 
-         create table t(a int, b int, c int) distributed by (a);
-         insert into t select 1, i, i from generate_series(1, 10)i;
-         insert into t select 1, i, i from generate_series(1, 10)i;
-         insert into t select 1, i, i from generate_series(1, 10)i;
-         insert into t select 1, i, i from generate_series(1, 10)i;
-         analyze t;
-         set optimizer_enable_hashagg to off;
-
-         explain select count(distinct(b)), gp_segment_id from t group by gp_segment_id;
-
-                                                               QUERY PLAN
-        ------------------------------------------------------------------------------------------------------------------------
-         Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.01 rows=40 width=12)
-           ->  GroupAggregate  (cost=0.00..431.01 rows=14 width=12)
-                 Group Key: gp_segment_id
-                 ->  Sort  (cost=0.00..431.01 rows=14 width=8)
-                       Sort Key: gp_segment_id
-                       ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=14 width=8)
-                             Hash Key: gp_segment_id
-                             ->  GroupAggregate  (cost=0.00..431.00 rows=14 width=8)
-                                   Group Key: gp_segment_id, b
-                                   ->  Sort  (cost=0.00..431.00 rows=14 width=8)
-                                         Sort Key: gp_segment_id, b
-                                         ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=14 width=8)
-                                               Hash Key: gp_segment_id, b, b
-                                               ->  Seq Scan on t  (cost=0.00..431.00 rows=14 width=8)
-         Optimizer: Pivotal Optimizer (GPORCA)
-        (15 rows)
+                  create table t(a int, b int, c int) distributed by (a);
+                  insert into t select 1, i, i from generate_series(1, 10)i;
+                  insert into t select 1, i, i from generate_series(1, 10)i;
+                  insert into t select 1, i, i from generate_series(1, 10)i;
+                  insert into t select 1, i, i from generate_series(1, 10)i;
+                  analyze t;
+                                                                    QUERY PLAN
+                -------------------------------------------------------------------------------------------------------------------
+                 Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.01 rows=40 width=12)
+                   ->  HashAggregate  (cost=0.00..431.01 rows=14 width=12)
+                         Group Key: gp_segment_id
+                         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=14 width=8)
+                               Hash Key: gp_segment_id
+                               ->  GroupAggregate  (cost=0.00..431.00 rows=14 width=8)
+                                     Group Key: gp_segment_id, b
+                                     ->  Sort  (cost=0.00..431.00 rows=14 width=8)
+                                           Sort Key: gp_segment_id, b
+                                           ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=14 width=8)
+                                                 Hash Key: gp_segment_id, b, b
+                                                 ->  Seq Scan on t  (cost=0.00..431.00 rows=14 width=8)
+                 Optimizer: Pivotal Optimizer (GPORCA)
+                (13 rows)
   ]]>
   </dxl:Comment>
   <dxl:Thread Id="0">
@@ -46,7 +40,7 @@
         </dxl:CostParams>
       </dxl:CostModelConfig>
       <dxl:Hint JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="20" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0" SkewFactor="0"/>
-      <dxl:TraceFlags Value="101013,102001,102002,102003,102043,102055,102058,102074,102120,102144,103001,103014,103015,103022,103026,103027,103029,103033,103038,103040,104002,104003,104004,104005,106000"/>
+      <dxl:TraceFlags Value="101013,102001,102002,102003,102043,102074,102120,102144,103001,103014,103015,103022,103026,103027,103029,103033,103038,103040,104002,104003,104004,104005,106000"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
       <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
@@ -171,8 +165,66 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:ColumnStatistics Mdid="1.16391.1.0.9" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:ColumnStatistics Mdid="1.16391.1.0.1" Name="b" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+      <dxl:RelationExtendedStatistics Mdid="10.23148.1.0" Name="t"/>
+      <dxl:RelationStatistics Mdid="2.23148.1.0" Name="t" Rows="40.000000" RelPages="1" RelAllVisible="0" EmptyRelation="false"/>
+      <dxl:Relation Mdid="6.23148.1.0" Name="t" IsTemporary="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="c" Attno="3" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:GPDBScalarOp Mdid="0.97.1.0" Name="&lt;" ComparisonType="LT" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.66.1.0"/>
+        <dxl:Commutator Mdid="0.521.1.0"/>
+        <dxl:InverseOp Mdid="0.525.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:GPDBAgg Mdid="0.2147.1.0" Name="count" IsRepSafe="true" IsSplittable="true" HashAggCapable="true">
+        <dxl:ResultType Mdid="0.20.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.20.1.0"/>
+      </dxl:GPDBAgg>
+      <dxl:ColumnStatistics Mdid="1.23148.1.0.9" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.23148.1.0.1" Name="b" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
         <dxl:StatsBucket Frequency="0.099999" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
@@ -214,70 +266,12 @@
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="10"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:ColumnStatistics Mdid="1.16391.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+      <dxl:ColumnStatistics Mdid="1.23148.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
         <dxl:StatsBucket Frequency="1.000000" DistinctValues="1.000000">
           <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
           <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
         </dxl:StatsBucket>
       </dxl:ColumnStatistics>
-      <dxl:RelationStatistics Mdid="2.16391.1.0" Name="t" Rows="40.000000" RelPages="1" RelAllVisible="0" EmptyRelation="false"/>
-      <dxl:Relation Mdid="6.16391.1.0" Name="t" IsTemporary="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3">
-        <dxl:Columns>
-          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="c" Attno="3" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
-            <dxl:DefaultValue/>
-          </dxl:Column>
-        </dxl:Columns>
-        <dxl:IndexInfoList/>
-        <dxl:CheckConstraints/>
-        <dxl:DistrOpfamilies>
-          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
-        </dxl:DistrOpfamilies>
-      </dxl:Relation>
-      <dxl:RelationExtendedStatistics Mdid="10.16391.1.0" Name="t"/>
-      <dxl:GPDBScalarOp Mdid="0.97.1.0" Name="&lt;" ComparisonType="LT" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
-        <dxl:LeftType Mdid="0.23.1.0"/>
-        <dxl:RightType Mdid="0.23.1.0"/>
-        <dxl:ResultType Mdid="0.16.1.0"/>
-        <dxl:OpFunc Mdid="0.66.1.0"/>
-        <dxl:Commutator Mdid="0.521.1.0"/>
-        <dxl:InverseOp Mdid="0.525.1.0"/>
-        <dxl:Opfamilies>
-          <dxl:Opfamily Mdid="0.1976.1.0"/>
-          <dxl:Opfamily Mdid="0.4054.1.0"/>
-          <dxl:Opfamily Mdid="0.10009.1.0"/>
-        </dxl:Opfamilies>
-      </dxl:GPDBScalarOp>
-      <dxl:GPDBAgg Mdid="0.2147.1.0" Name="count" IsRepSafe="true" IsSplittable="true" HashAggCapable="true">
-        <dxl:ResultType Mdid="0.20.1.0"/>
-        <dxl:IntermediateResultType Mdid="0.20.1.0"/>
-      </dxl:GPDBAgg>
     </dxl:Metadata>
     <dxl:Query>
       <dxl:OutputColumns>
@@ -304,7 +298,7 @@
           </dxl:ProjElem>
         </dxl:ProjList>
         <dxl:LogicalGet>
-          <dxl:TableDescriptor Mdid="6.16391.1.0" TableName="t" LockMode="1">
+          <dxl:TableDescriptor Mdid="6.23148.1.0" TableName="t" LockMode="1">
             <dxl:Columns>
               <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
               <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
@@ -321,10 +315,10 @@
         </dxl:LogicalGet>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="12">
+    <dxl:Plan Id="0" SpaceSize="38">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.007846" Rows="40.000000" Width="12"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.007097" Rows="40.000000" Width="12"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="10" Alias="count">
@@ -336,9 +330,9 @@
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+        <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.006057" Rows="40.000000" Width="12"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.005308" Rows="40.000000" Width="12"/>
           </dxl:Properties>
           <dxl:GroupingColumns>
             <dxl:GroupingColumn ColId="9"/>
@@ -361,9 +355,9 @@
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
-          <dxl:Sort SortDiscardDuplicates="false">
+          <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.005861" Rows="40.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.003601" Rows="40.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="1" Alias="b">
@@ -374,15 +368,20 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:SortingColumnList>
-              <dxl:SortingColumn ColId="9" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-            </dxl:SortingColumnList>
-            <dxl:LimitCount/>
-            <dxl:LimitOffset/>
-            <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+            <dxl:SortingColumnList/>
+            <dxl:HashExprList>
+              <dxl:HashExpr Opfamily="0.1977.1.0">
+                <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+              </dxl:HashExpr>
+            </dxl:HashExprList>
+            <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.003601" Rows="40.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.003267" Rows="40.000000" Width="8"/>
               </dxl:Properties>
+              <dxl:GroupingColumns>
+                <dxl:GroupingColumn ColId="9"/>
+                <dxl:GroupingColumn ColId="1"/>
+              </dxl:GroupingColumns>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="1" Alias="b">
                   <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
@@ -392,20 +391,10 @@
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:SortingColumnList/>
-              <dxl:HashExprList>
-                <dxl:HashExpr Opfamily="0.1977.1.0">
-                  <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                </dxl:HashExpr>
-              </dxl:HashExprList>
-              <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+              <dxl:Sort SortDiscardDuplicates="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.003267" Rows="40.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.003100" Rows="40.000000" Width="8"/>
                 </dxl:Properties>
-                <dxl:GroupingColumns>
-                  <dxl:GroupingColumn ColId="9"/>
-                  <dxl:GroupingColumn ColId="1"/>
-                </dxl:GroupingColumns>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="1" Alias="b">
                     <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
@@ -415,9 +404,15 @@
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
-                <dxl:Sort SortDiscardDuplicates="false">
+                <dxl:SortingColumnList>
+                  <dxl:SortingColumn ColId="9" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                  <dxl:SortingColumn ColId="1" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                </dxl:SortingColumnList>
+                <dxl:LimitCount/>
+                <dxl:LimitOffset/>
+                <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.003100" Rows="40.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000840" Rows="40.000000" Width="8"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="1" Alias="b">
@@ -428,15 +423,21 @@
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:SortingColumnList>
-                    <dxl:SortingColumn ColId="9" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                    <dxl:SortingColumn ColId="1" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                  </dxl:SortingColumnList>
-                  <dxl:LimitCount/>
-                  <dxl:LimitOffset/>
-                  <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                  <dxl:SortingColumnList/>
+                  <dxl:HashExprList>
+                    <dxl:HashExpr Opfamily="0.1977.1.0">
+                      <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                    </dxl:HashExpr>
+                    <dxl:HashExpr Opfamily="0.1977.1.0">
+                      <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                    </dxl:HashExpr>
+                    <dxl:HashExpr Opfamily="0.1977.1.0">
+                      <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                    </dxl:HashExpr>
+                  </dxl:HashExprList>
+                  <dxl:TableScan>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000840" Rows="40.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000308" Rows="40.000000" Width="8"/>
                     </dxl:Properties>
                     <dxl:ProjList>
                       <dxl:ProjElem ColId="1" Alias="b">
@@ -447,50 +448,24 @@
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:SortingColumnList/>
-                    <dxl:HashExprList>
-                      <dxl:HashExpr Opfamily="0.1977.1.0">
-                        <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                      </dxl:HashExpr>
-                      <dxl:HashExpr Opfamily="0.1977.1.0">
-                        <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                      </dxl:HashExpr>
-                      <dxl:HashExpr Opfamily="0.1977.1.0">
-                        <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                      </dxl:HashExpr>
-                    </dxl:HashExprList>
-                    <dxl:TableScan>
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000308" Rows="40.000000" Width="8"/>
-                      </dxl:Properties>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="1" Alias="b">
-                          <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="9" Alias="gp_segment_id">
-                          <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
-                      <dxl:Filter/>
-                      <dxl:TableDescriptor Mdid="6.16391.1.0" TableName="t" LockMode="1">
-                        <dxl:Columns>
-                          <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-                          <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
-                          <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                          <dxl:Column ColId="4" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                          <dxl:Column ColId="5" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                          <dxl:Column ColId="6" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                          <dxl:Column ColId="7" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                          <dxl:Column ColId="8" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                          <dxl:Column ColId="9" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                        </dxl:Columns>
-                      </dxl:TableDescriptor>
-                    </dxl:TableScan>
-                  </dxl:RedistributeMotion>
-                </dxl:Sort>
-              </dxl:Aggregate>
-            </dxl:RedistributeMotion>
-          </dxl:Sort>
+                    <dxl:TableDescriptor Mdid="6.23148.1.0" TableName="t" LockMode="1">
+                      <dxl:Columns>
+                        <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                        <dxl:Column ColId="4" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="5" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="6" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="7" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="8" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="9" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      </dxl:Columns>
+                    </dxl:TableDescriptor>
+                  </dxl:TableScan>
+                </dxl:RedistributeMotion>
+              </dxl:Sort>
+            </dxl:Aggregate>
+          </dxl:RedistributeMotion>
         </dxl:Aggregate>
       </dxl:GatherMotion>
     </dxl:Plan>

--- a/src/backend/gporca/data/dxl/minidump/DistinctQueryWithMotions.mdp
+++ b/src/backend/gporca/data/dxl/minidump/DistinctQueryWithMotions.mdp
@@ -18,18 +18,18 @@
                                                                QUERY PLAN
         ------------------------------------------------------------------------------------------------------------------------
          Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
-           ->  Finalize GroupAggregate  (cost=0.00..431.00 rows=1 width=12)
+           ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=12)
                  Group Key: gp_segment_id
-                 ->  Sort  (cost=0.00..431.00 rows=1 width=12)
+                 ->  Sort  (cost=0.00..431.00 rows=1 width=8)
                        Sort Key: gp_segment_id
-                       ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
+                       ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
                              Hash Key: gp_segment_id
-                             ->  Partial GroupAggregate  (cost=0.00..431.00 rows=1 width=12)
-                                   Group Key: gp_segment_id
+                             ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=8)
+                                   Group Key: gp_segment_id, b
                                    ->  Sort  (cost=0.00..431.00 rows=1 width=8)
                                          Sort Key: gp_segment_id, b
                                          ->  Redistribute Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
-                                               Hash Key: gp_segment_id, b
+                                               Hash Key: gp_segment_id, b, b
                                                ->  Seq Scan on t  (cost=0.00..431.00 rows=1 width=8)
          Optimizer: Pivotal Optimizer (GPORCA)
         (15 rows)
@@ -47,7 +47,7 @@
         </dxl:CostParams>
       </dxl:CostModelConfig>
       <dxl:Hint JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="20" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0" SkewFactor="0"/>
-      <dxl:TraceFlags Value="101013,102001,102002,102003,102043,102055,102058,102074,102120,102144,103001,103014,103022,103026,103027,103029,103033,103038,103040,104002,104003,104004,104005,106000"/>
+      <dxl:TraceFlags Value="101013,102001,102002,102003,102043,102055,102058,102074,102120,102144,103001,103014,103015,103022,103026,103027,103029,103033,103038,103040,104002,104003,104004,104005,106000"/>
     </dxl:OptimizerConfig>
     <dxl:Metadata SystemIds="0.GPDB">
       <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
@@ -104,6 +104,9 @@
         <dxl:SumAgg Mdid="0.2108.1.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.16385.1.0.9" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.16385.1.0.1" Name="b" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.16385.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
       <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
         <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
         <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
@@ -172,12 +175,8 @@
         <dxl:SumAgg Mdid="0.0.0.0"/>
         <dxl:CountAgg Mdid="0.2147.1.0"/>
       </dxl:Type>
-      <dxl:ColumnStatistics Mdid="1.54758.1.0.9" Name="gp_segment_id" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:ColumnStatistics Mdid="1.54758.1.0.1" Name="b" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:ColumnStatistics Mdid="1.54758.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
-      <dxl:RelationExtendedStatistics Mdid="10.54758.1.0" Name="t"/>
-      <dxl:RelationStatistics Mdid="2.54758.1.0" Name="t" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
-      <dxl:Relation Mdid="6.54758.1.0" Name="t" IsTemporary="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3">
+      <dxl:RelationStatistics Mdid="2.16385.1.0" Name="t" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
+      <dxl:Relation Mdid="6.16385.1.0" Name="t" IsTemporary="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="9,3">
         <dxl:Columns>
           <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
             <dxl:DefaultValue/>
@@ -216,6 +215,7 @@
           <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
         </dxl:DistrOpfamilies>
       </dxl:Relation>
+      <dxl:RelationExtendedStatistics Mdid="10.16385.1.0" Name="t"/>
       <dxl:GPDBScalarOp Mdid="0.97.1.0" Name="&lt;" ComparisonType="LT" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
         <dxl:LeftType Mdid="0.23.1.0"/>
         <dxl:RightType Mdid="0.23.1.0"/>
@@ -259,7 +259,7 @@
           </dxl:ProjElem>
         </dxl:ProjList>
         <dxl:LogicalGet>
-          <dxl:TableDescriptor Mdid="6.54758.1.0" TableName="t" LockMode="1">
+          <dxl:TableDescriptor Mdid="6.16385.1.0" TableName="t" LockMode="1">
             <dxl:Columns>
               <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
               <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
@@ -276,10 +276,10 @@
         </dxl:LogicalGet>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="8" SpaceSize="15">
+    <dxl:Plan Id="8" SpaceSize="12">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.000113" Rows="1.000000" Width="12"/>
+          <dxl:Cost StartupCost="0" TotalCost="431.000118" Rows="1.000000" Width="12"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="10" Alias="count">
@@ -293,16 +293,16 @@
         <dxl:SortingColumnList/>
         <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.000069" Rows="1.000000" Width="12"/>
+            <dxl:Cost StartupCost="0" TotalCost="431.000073" Rows="1.000000" Width="12"/>
           </dxl:Properties>
           <dxl:GroupingColumns>
             <dxl:GroupingColumn ColId="9"/>
           </dxl:GroupingColumns>
           <dxl:ProjList>
             <dxl:ProjElem ColId="10" Alias="count">
-              <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="23">
+              <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="23">
                 <dxl:ValuesList ParamType="aggargs">
-                  <dxl:Ident ColId="11" ColName="ColRef_0011" TypeMdid="0.20.1.0"/>
+                  <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
                 </dxl:ValuesList>
                 <dxl:ValuesList ParamType="aggdirectargs"/>
                 <dxl:ValuesList ParamType="aggorder"/>
@@ -318,14 +318,14 @@
           <dxl:Filter/>
           <dxl:Sort SortDiscardDuplicates="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000054" Rows="1.000000" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.000063" Rows="1.000000" Width="8"/>
             </dxl:Properties>
             <dxl:ProjList>
+              <dxl:ProjElem ColId="1" Alias="b">
+                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
               <dxl:ProjElem ColId="9" Alias="gp_segment_id">
                 <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="11" Alias="ColRef_0011">
-                <dxl:Ident ColId="11" ColName="ColRef_0011" TypeMdid="0.20.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
@@ -336,14 +336,14 @@
             <dxl:LimitOffset/>
             <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.000054" Rows="1.000000" Width="12"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000063" Rows="1.000000" Width="8"/>
               </dxl:Properties>
               <dxl:ProjList>
+                <dxl:ProjElem ColId="1" Alias="b">
+                  <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
                 <dxl:ProjElem ColId="9" Alias="gp_segment_id">
                   <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="11" Alias="ColRef_0011">
-                  <dxl:Ident ColId="11" ColName="ColRef_0011" TypeMdid="0.20.1.0"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
@@ -353,46 +353,43 @@
                   <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                 </dxl:HashExpr>
               </dxl:HashExprList>
-              <dxl:Result>
+              <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000036" Rows="1.000000" Width="12"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000038" Rows="1.000000" Width="8"/>
                 </dxl:Properties>
+                <dxl:GroupingColumns>
+                  <dxl:GroupingColumn ColId="9"/>
+                  <dxl:GroupingColumn ColId="1"/>
+                </dxl:GroupingColumns>
                 <dxl:ProjList>
+                  <dxl:ProjElem ColId="1" Alias="b">
+                    <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
                   <dxl:ProjElem ColId="9" Alias="gp_segment_id">
                     <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
-                  <dxl:ProjElem ColId="11" Alias="ColRef_0011">
-                    <dxl:Ident ColId="11" ColName="ColRef_0011" TypeMdid="0.20.1.0"/>
-                  </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
-                <dxl:OneTimeFilter/>
-                <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+                <dxl:Sort SortDiscardDuplicates="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000036" Rows="1.000000" Width="12"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000025" Rows="1.000000" Width="8"/>
                   </dxl:Properties>
-                  <dxl:GroupingColumns>
-                    <dxl:GroupingColumn ColId="9"/>
-                  </dxl:GroupingColumns>
                   <dxl:ProjList>
-                    <dxl:ProjElem ColId="11" Alias="ColRef_0011">
-                      <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="true" AggStage="Partial" AggKind="n" AggArgTypes="23">
-                        <dxl:ValuesList ParamType="aggargs">
-                          <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                        </dxl:ValuesList>
-                        <dxl:ValuesList ParamType="aggdirectargs"/>
-                        <dxl:ValuesList ParamType="aggorder"/>
-                        <dxl:ValuesList ParamType="aggdistinct">
-                          <dxl:SortGroupClause Index="0" EqualityOp="96" SortOperatorMdid="97" SortNullsFirst="false" IsHashable="true"/>
-                        </dxl:ValuesList>
-                      </dxl:AggFunc>
+                    <dxl:ProjElem ColId="1" Alias="b">
+                      <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
                     <dxl:ProjElem ColId="9" Alias="gp_segment_id">
                       <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:Sort SortDiscardDuplicates="false">
+                  <dxl:SortingColumnList>
+                    <dxl:SortingColumn ColId="9" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                    <dxl:SortingColumn ColId="1" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                  </dxl:SortingColumnList>
+                  <dxl:LimitCount/>
+                  <dxl:LimitOffset/>
+                  <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                     <dxl:Properties>
                       <dxl:Cost StartupCost="0" TotalCost="431.000025" Rows="1.000000" Width="8"/>
                     </dxl:Properties>
@@ -405,15 +402,21 @@
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:SortingColumnList>
-                      <dxl:SortingColumn ColId="9" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                      <dxl:SortingColumn ColId="1" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                    </dxl:SortingColumnList>
-                    <dxl:LimitCount/>
-                    <dxl:LimitOffset/>
-                    <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                    <dxl:SortingColumnList/>
+                    <dxl:HashExprList>
+                      <dxl:HashExpr Opfamily="0.1977.1.0">
+                        <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                      </dxl:HashExpr>
+                      <dxl:HashExpr Opfamily="0.1977.1.0">
+                        <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                      </dxl:HashExpr>
+                      <dxl:HashExpr Opfamily="0.1977.1.0">
+                        <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                      </dxl:HashExpr>
+                    </dxl:HashExprList>
+                    <dxl:TableScan>
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000025" Rows="1.000000" Width="8"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000008" Rows="1.000000" Width="8"/>
                       </dxl:Properties>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="1" Alias="b">
@@ -424,46 +427,23 @@
                         </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
-                      <dxl:SortingColumnList/>
-                      <dxl:HashExprList>
-                        <dxl:HashExpr Opfamily="0.1977.1.0">
-                          <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                        </dxl:HashExpr>
-                        <dxl:HashExpr Opfamily="0.1977.1.0">
-                          <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                        </dxl:HashExpr>
-                      </dxl:HashExprList>
-                      <dxl:TableScan>
-                        <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="431.000008" Rows="1.000000" Width="8"/>
-                        </dxl:Properties>
-                        <dxl:ProjList>
-                          <dxl:ProjElem ColId="1" Alias="b">
-                            <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="9" Alias="gp_segment_id">
-                            <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
-                        </dxl:ProjList>
-                        <dxl:Filter/>
-                        <dxl:TableDescriptor Mdid="6.54758.1.0" TableName="t" LockMode="1">
-                          <dxl:Columns>
-                            <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                            <dxl:Column ColId="4" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="5" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="6" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="7" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="8" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                            <dxl:Column ColId="9" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                          </dxl:Columns>
-                        </dxl:TableDescriptor>
-                      </dxl:TableScan>
-                    </dxl:RedistributeMotion>
-                  </dxl:Sort>
-                </dxl:Aggregate>
-              </dxl:Result>
+                      <dxl:TableDescriptor Mdid="6.16385.1.0" TableName="t" LockMode="1">
+                        <dxl:Columns>
+                          <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                          <dxl:Column ColId="4" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="5" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="6" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="7" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="8" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                          <dxl:Column ColId="9" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                        </dxl:Columns>
+                      </dxl:TableDescriptor>
+                    </dxl:TableScan>
+                  </dxl:RedistributeMotion>
+                </dxl:Sort>
+              </dxl:Aggregate>
             </dxl:RedistributeMotion>
           </dxl:Sort>
         </dxl:Aggregate>

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CDistributionSpecHashed.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CDistributionSpecHashed.h
@@ -68,8 +68,6 @@ private:
 		return (m_is_duplicate_sensitive || !pds->m_is_duplicate_sensitive);
 	}
 
-	BOOL FDistributionSpecHashedOnlyOnGpSegmentId() const;
-
 public:
 	CDistributionSpecHashed(const CDistributionSpecHashed &) = delete;
 

--- a/src/backend/gporca/libgpopt/src/base/CDistributionSpecHashed.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CDistributionSpecHashed.cpp
@@ -225,24 +225,6 @@ CDistributionSpecHashed::FSatisfies(const CDistributionSpec *pds) const
 	const CDistributionSpecHashed *pdsHashed =
 		dynamic_cast<const CDistributionSpecHashed *>(pds);
 
-	// Assumes that 'this' distribution spec is based on the underlying table
-	// structure, whereas 'pds' distribution spec is based on the query
-	// structure. Given that table based distribution spec is derived from
-	// distribution columns, 'this' distribution spec should never satisfy
-	// FDistributionSpecHashedOnlyOnGpSegmentId().
-	if (pdsHashed->FDistributionSpecHashedOnlyOnGpSegmentId())
-	{
-		// If there exist HashSpecEquivExprs(), then we deny the match in order
-		// to prevent incorrectly removing a REDISTRIBUTE MOTION. For example,
-		// in the following query:
-		//
-		// SELECT * FROM t t1, t t2 WHERE t1.gp_segment_id=t2.id;
-		if (nullptr == pdsHashed->HashSpecEquivExprs())
-		{
-			return true;
-		}
-	}
-
 	return FMatchSubset(pdsHashed);
 }
 

--- a/src/backend/gporca/libgpopt/src/base/CDistributionSpecHashed.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CDistributionSpecHashed.cpp
@@ -173,20 +173,6 @@ CDistributionSpecHashed::StripEquivColumns(CMemoryPool *mp)
 		CDistributionSpecHashed(m_pdrgpexpr, m_fNullsColocated, m_opfamilies);
 }
 
-
-BOOL
-CDistributionSpecHashed::FDistributionSpecHashedOnlyOnGpSegmentId() const
-{
-	const ULONG length = m_pdrgpexpr->Size();
-	COperator *pop = (*(m_pdrgpexpr))[0]->Pop();
-
-	return length == 1 && pop->Eopid() == COperator::EopScalarIdent &&
-		   CScalarIdent::PopConvert(pop)->Pcr()->IsSystemCol() &&
-		   CScalarIdent::PopConvert(pop)->Pcr()->Name().Equals(
-			   CDXLTokens::GetDXLTokenStr(EdxltokenGpSegmentIdColName));
-}
-
-
 //---------------------------------------------------------------------------
 //	@function:
 //		CDistributionSpecHashed::FSatisfies

--- a/src/backend/gporca/server/CMakeLists.txt
+++ b/src/backend/gporca/server/CMakeLists.txt
@@ -350,7 +350,7 @@ InsertNonSingleton NonSingleton TaintedReplicatedAgg TaintedReplicatedWindowAgg 
 InsertReplicatedIntoSerialHashDistributedTable TaintedReplicatedTablesCTE ReplicatedTableWithAggNoMotion;
 
 CDqaTest:
-NonSplittableAgg DqaHavingMax DqaMax DqaMin DqaSubqueryMax DqaNoRedistribute;
+NonSplittableAgg DqaHavingMax DqaMax DqaMin DqaSubqueryMax DqaNoRedistribute DistinctQueryWithMotions;
 
 CMCVCardinalityTest:
 BpCharMCVCardinalityEquals BpCharMCVCardinalityGreaterThan

--- a/src/test/regress/expected/bfv_aggregate.out
+++ b/src/test/regress/expected/bfv_aggregate.out
@@ -1916,6 +1916,44 @@ explain select g%10 as c1, sum(g::numeric)as c2, count(*) as c3 from generate_se
 (4 rows)
 
 reset optimizer_force_multistage_agg;
+-- Test if Motion is placed between the "group by clauses"
+drop table if exists t;
+set optimizer_enable_hashagg to off;
+set optimizer_enumerate_plans to on;
+set optimizer_plan_id =2;
+create table t(a int, b int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into t select 1, i, i from generate_series(1, 10)i;
+insert into t select 1, i, i from generate_series(1, 10)i;
+insert into t select 1, i, i from generate_series(1, 10)i;
+insert into t select 1, i, i from generate_series(1, 10)i;
+explain (costs off) select count(distinct(b)), gp_segment_id from t group by gp_segment_id;
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  HashAggregate
+         Group Key: gp_segment_id
+         ->  HashAggregate
+               Group Key: gp_segment_id, b
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: gp_segment_id
+                     ->  Streaming HashAggregate
+                           Group Key: gp_segment_id, b
+                           ->  Seq Scan on t
+ Optimizer: Postgres query optimizer
+(11 rows)
+
+select count(distinct(b)), gp_segment_id from t group by gp_segment_id;
+ count | gp_segment_id 
+-------+---------------
+    10 |             1
+(1 row)
+
+reset optimizer_enable_hashagg;
+reset optimizer_enumerate_plans;
+reset optimizer_plan_id;
+drop table t;
 -- CLEANUP
 set client_min_messages='warning';
 drop schema bfv_aggregate cascade;

--- a/src/test/regress/expected/bfv_aggregate.out
+++ b/src/test/regress/expected/bfv_aggregate.out
@@ -1920,7 +1920,7 @@ reset optimizer_force_multistage_agg;
 drop table if exists t;
 set optimizer_enable_hashagg to off;
 set optimizer_enumerate_plans to on;
-set optimizer_plan_id =2;
+set optimizer_plan_id =8;
 create table t(a int, b int, c int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.

--- a/src/test/regress/expected/bfv_aggregate.out
+++ b/src/test/regress/expected/bfv_aggregate.out
@@ -1918,7 +1918,6 @@ explain select g%10 as c1, sum(g::numeric)as c2, count(*) as c3 from generate_se
 reset optimizer_force_multistage_agg;
 -- Test if Motion is placed between the "group by clauses"
 drop table if exists t;
-set optimizer_enable_hashagg to off;
 create table t(a int, b int, c int) distributed by (a);
 insert into t select 1, i, i from generate_series(1, 10)i;
 insert into t select 1, i, i from generate_series(1, 10)i;
@@ -1947,7 +1946,6 @@ select count(distinct(b)), gp_segment_id from t group by gp_segment_id;
     10 |             1
 (1 row)
 
-reset optimizer_enable_hashagg;
 drop table t;
 -- CLEANUP
 set client_min_messages='warning';

--- a/src/test/regress/expected/bfv_aggregate.out
+++ b/src/test/regress/expected/bfv_aggregate.out
@@ -1919,15 +1919,12 @@ reset optimizer_force_multistage_agg;
 -- Test if Motion is placed between the "group by clauses"
 drop table if exists t;
 set optimizer_enable_hashagg to off;
-set optimizer_enumerate_plans to on;
-set optimizer_plan_id =8;
-create table t(a int, b int, c int);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table t(a int, b int, c int) distributed by (a);
 insert into t select 1, i, i from generate_series(1, 10)i;
 insert into t select 1, i, i from generate_series(1, 10)i;
 insert into t select 1, i, i from generate_series(1, 10)i;
 insert into t select 1, i, i from generate_series(1, 10)i;
+analyze t;
 explain (costs off) select count(distinct(b)), gp_segment_id from t group by gp_segment_id;
                             QUERY PLAN                            
 ------------------------------------------------------------------
@@ -1951,8 +1948,6 @@ select count(distinct(b)), gp_segment_id from t group by gp_segment_id;
 (1 row)
 
 reset optimizer_enable_hashagg;
-reset optimizer_enumerate_plans;
-reset optimizer_plan_id;
 drop table t;
 -- CLEANUP
 set client_min_messages='warning';

--- a/src/test/regress/expected/bfv_aggregate_optimizer.out
+++ b/src/test/regress/expected/bfv_aggregate_optimizer.out
@@ -1946,15 +1946,12 @@ reset optimizer_force_multistage_agg;
 -- Test if Motion is placed between the "group by clauses"
 drop table if exists t;
 set optimizer_enable_hashagg to off;
-set optimizer_enumerate_plans to on;
-set optimizer_plan_id =8;
-create table t(a int, b int, c int);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table t(a int, b int, c int) distributed by (a);
 insert into t select 1, i, i from generate_series(1, 10)i;
 insert into t select 1, i, i from generate_series(1, 10)i;
 insert into t select 1, i, i from generate_series(1, 10)i;
 insert into t select 1, i, i from generate_series(1, 10)i;
+analyze t;
 explain (costs off) select count(distinct(b)), gp_segment_id from t group by gp_segment_id;
                                      QUERY PLAN                                     
 ------------------------------------------------------------------------------------
@@ -1982,8 +1979,6 @@ select count(distinct(b)), gp_segment_id from t group by gp_segment_id;
 (1 row)
 
 reset optimizer_enable_hashagg;
-reset optimizer_enumerate_plans;
-reset optimizer_plan_id;
 drop table t;
 -- CLEANUP
 set client_min_messages='warning';

--- a/src/test/regress/expected/bfv_aggregate_optimizer.out
+++ b/src/test/regress/expected/bfv_aggregate_optimizer.out
@@ -1945,7 +1945,6 @@ explain select g%10 as c1, sum(g::numeric)as c2, count(*) as c3 from generate_se
 reset optimizer_force_multistage_agg;
 -- Test if Motion is placed between the "group by clauses"
 drop table if exists t;
-set optimizer_enable_hashagg to off;
 create table t(a int, b int, c int) distributed by (a);
 insert into t select 1, i, i from generate_series(1, 10)i;
 insert into t select 1, i, i from generate_series(1, 10)i;
@@ -1956,21 +1955,19 @@ explain (costs off) select count(distinct(b)), gp_segment_id from t group by gp_
                                      QUERY PLAN                                     
 ------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  GroupAggregate
+   ->  HashAggregate
          Group Key: gp_segment_id
-         ->  Sort
-               Sort Key: gp_segment_id
-               ->  Redistribute Motion 3:3  (slice2; segments: 3)
-                     Hash Key: gp_segment_id
-                     ->  GroupAggregate
-                           Group Key: gp_segment_id, b
-                           ->  Sort
-                                 Sort Key: gp_segment_id, b
-                                 ->  Redistribute Motion 3:3  (slice3; segments: 3)
-                                       Hash Key: gp_segment_id, b, b
-                                       ->  Seq Scan on t
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Hash Key: gp_segment_id
+               ->  GroupAggregate
+                     Group Key: gp_segment_id, b
+                     ->  Sort
+                           Sort Key: gp_segment_id, b
+                           ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                                 Hash Key: gp_segment_id, b, b
+                                 ->  Seq Scan on t
  Optimizer: Pivotal Optimizer (GPORCA)
-(15 rows)
+(13 rows)
 
 select count(distinct(b)), gp_segment_id from t group by gp_segment_id;
  count | gp_segment_id 
@@ -1978,7 +1975,6 @@ select count(distinct(b)), gp_segment_id from t group by gp_segment_id;
     10 |             1
 (1 row)
 
-reset optimizer_enable_hashagg;
 drop table t;
 -- CLEANUP
 set client_min_messages='warning';

--- a/src/test/regress/expected/bfv_aggregate_optimizer.out
+++ b/src/test/regress/expected/bfv_aggregate_optimizer.out
@@ -1947,7 +1947,7 @@ reset optimizer_force_multistage_agg;
 drop table if exists t;
 set optimizer_enable_hashagg to off;
 set optimizer_enumerate_plans to on;
-set optimizer_plan_id =2;
+set optimizer_plan_id =8;
 create table t(a int, b int, c int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
@@ -1970,7 +1970,7 @@ explain (costs off) select count(distinct(b)), gp_segment_id from t group by gp_
                            ->  Sort
                                  Sort Key: gp_segment_id, b
                                  ->  Redistribute Motion 3:3  (slice3; segments: 3)
-                                       Hash Key: b
+                                       Hash Key: gp_segment_id, b
                                        ->  Seq Scan on t
  Optimizer: Pivotal Optimizer (GPORCA)
 (15 rows)

--- a/src/test/regress/expected/bfv_aggregate_optimizer.out
+++ b/src/test/regress/expected/bfv_aggregate_optimizer.out
@@ -1943,6 +1943,48 @@ explain select g%10 as c1, sum(g::numeric)as c2, count(*) as c3 from generate_se
 (4 rows)
 
 reset optimizer_force_multistage_agg;
+-- Test if Motion is placed between the "group by clauses"
+drop table if exists t;
+set optimizer_enable_hashagg to off;
+set optimizer_enumerate_plans to on;
+set optimizer_plan_id =2;
+create table t(a int, b int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into t select 1, i, i from generate_series(1, 10)i;
+insert into t select 1, i, i from generate_series(1, 10)i;
+insert into t select 1, i, i from generate_series(1, 10)i;
+insert into t select 1, i, i from generate_series(1, 10)i;
+explain (costs off) select count(distinct(b)), gp_segment_id from t group by gp_segment_id;
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Finalize GroupAggregate
+         Group Key: gp_segment_id
+         ->  Sort
+               Sort Key: gp_segment_id
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: gp_segment_id
+                     ->  Partial GroupAggregate
+                           Group Key: gp_segment_id
+                           ->  Sort
+                                 Sort Key: gp_segment_id, b
+                                 ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                                       Hash Key: b
+                                       ->  Seq Scan on t
+ Optimizer: Pivotal Optimizer (GPORCA)
+(15 rows)
+
+select count(distinct(b)), gp_segment_id from t group by gp_segment_id;
+ count | gp_segment_id 
+-------+---------------
+    10 |             1
+(1 row)
+
+reset optimizer_enable_hashagg;
+reset optimizer_enumerate_plans;
+reset optimizer_plan_id;
+drop table t;
 -- CLEANUP
 set client_min_messages='warning';
 drop schema bfv_aggregate cascade;

--- a/src/test/regress/expected/bfv_aggregate_optimizer.out
+++ b/src/test/regress/expected/bfv_aggregate_optimizer.out
@@ -1959,18 +1959,18 @@ explain (costs off) select count(distinct(b)), gp_segment_id from t group by gp_
                                      QUERY PLAN                                     
 ------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  Finalize GroupAggregate
+   ->  GroupAggregate
          Group Key: gp_segment_id
          ->  Sort
                Sort Key: gp_segment_id
                ->  Redistribute Motion 3:3  (slice2; segments: 3)
                      Hash Key: gp_segment_id
-                     ->  Partial GroupAggregate
-                           Group Key: gp_segment_id
+                     ->  GroupAggregate
+                           Group Key: gp_segment_id, b
                            ->  Sort
                                  Sort Key: gp_segment_id, b
                                  ->  Redistribute Motion 3:3  (slice3; segments: 3)
-                                       Hash Key: gp_segment_id, b
+                                       Hash Key: gp_segment_id, b, b
                                        ->  Seq Scan on t
  Optimizer: Pivotal Optimizer (GPORCA)
 (15 rows)

--- a/src/test/regress/expected/direct_dispatch_optimizer.out
+++ b/src/test/regress/expected/direct_dispatch_optimizer.out
@@ -927,17 +927,20 @@ explain (costs off) select gp_segment_id, count(*) from t_test_dd_via_segid grou
          Group Key: gp_segment_id
          ->  Sort
                Sort Key: gp_segment_id
-               ->  Seq Scan on t_test_dd_via_segid
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                     Hash Key: gp_segment_id
+                     ->  Seq Scan on t_test_dd_via_segid
  Optimizer: Pivotal Optimizer (GPORCA)
-(7 rows)
+(9 rows)
 
 select gp_segment_id, count(*) from t_test_dd_via_segid group by gp_segment_id;
+INFO:  (slice 2) Dispatch command to ALL contents: 0 1 2
 INFO:  (slice 1) Dispatch command to ALL contents: 0 1 2
  gp_segment_id | count 
 ---------------+-------
+             2 |     2
              0 |     3
              1 |     1
-             2 |     2
 (3 rows)
 
 -- test direct dispatch via gp_segment_id qual with conjunction

--- a/src/test/regress/expected/direct_dispatch_optimizer.out
+++ b/src/test/regress/expected/direct_dispatch_optimizer.out
@@ -923,13 +923,17 @@ explain (costs off) select gp_segment_id, count(*) from t_test_dd_via_segid grou
                     QUERY PLAN                     
 ---------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  GroupAggregate
+   ->  Finalize GroupAggregate
          Group Key: gp_segment_id
          ->  Sort
                Sort Key: gp_segment_id
                ->  Redistribute Motion 3:3  (slice2; segments: 3)
                      Hash Key: gp_segment_id
-                     ->  Seq Scan on t_test_dd_via_segid
+                     ->  Partial GroupAggregate
+                           Group Key: gp_segment_id
+                           ->  Sort
+                                 Sort Key: gp_segment_id
+                                 ->  Seq Scan on t_test_dd_via_segid
  Optimizer: Pivotal Optimizer (GPORCA)
 (9 rows)
 

--- a/src/test/regress/sql/bfv_aggregate.sql
+++ b/src/test/regress/sql/bfv_aggregate.sql
@@ -1494,7 +1494,6 @@ reset optimizer_force_multistage_agg;
 
 -- Test if Motion is placed between the "group by clauses"
 drop table if exists t;
-set optimizer_enable_hashagg to off;
 create table t(a int, b int, c int) distributed by (a);
 insert into t select 1, i, i from generate_series(1, 10)i;
 insert into t select 1, i, i from generate_series(1, 10)i;
@@ -1505,7 +1504,6 @@ analyze t;
 explain (costs off) select count(distinct(b)), gp_segment_id from t group by gp_segment_id;
 select count(distinct(b)), gp_segment_id from t group by gp_segment_id;
 
-reset optimizer_enable_hashagg;
 drop table t;
 -- CLEANUP
 set client_min_messages='warning';

--- a/src/test/regress/sql/bfv_aggregate.sql
+++ b/src/test/regress/sql/bfv_aggregate.sql
@@ -1492,6 +1492,25 @@ explain select g%10 as c1, sum(g::numeric)as c2, count(*) as c3 from generate_se
 
 reset optimizer_force_multistage_agg;
 
+-- Test if Motion is placed between the "group by clauses"
+drop table if exists t;
+set optimizer_enable_hashagg to off;
+set optimizer_enumerate_plans to on;
+set optimizer_plan_id =2;
+
+create table t(a int, b int, c int);
+insert into t select 1, i, i from generate_series(1, 10)i;
+insert into t select 1, i, i from generate_series(1, 10)i;
+insert into t select 1, i, i from generate_series(1, 10)i;
+insert into t select 1, i, i from generate_series(1, 10)i;
+
+explain (costs off) select count(distinct(b)), gp_segment_id from t group by gp_segment_id;
+select count(distinct(b)), gp_segment_id from t group by gp_segment_id;
+
+reset optimizer_enable_hashagg;
+reset optimizer_enumerate_plans;
+reset optimizer_plan_id;
+drop table t;
 -- CLEANUP
 set client_min_messages='warning';
 drop schema bfv_aggregate cascade;

--- a/src/test/regress/sql/bfv_aggregate.sql
+++ b/src/test/regress/sql/bfv_aggregate.sql
@@ -1496,7 +1496,7 @@ reset optimizer_force_multistage_agg;
 drop table if exists t;
 set optimizer_enable_hashagg to off;
 set optimizer_enumerate_plans to on;
-set optimizer_plan_id =2;
+set optimizer_plan_id =8;
 
 create table t(a int, b int, c int);
 insert into t select 1, i, i from generate_series(1, 10)i;

--- a/src/test/regress/sql/bfv_aggregate.sql
+++ b/src/test/regress/sql/bfv_aggregate.sql
@@ -1495,21 +1495,17 @@ reset optimizer_force_multistage_agg;
 -- Test if Motion is placed between the "group by clauses"
 drop table if exists t;
 set optimizer_enable_hashagg to off;
-set optimizer_enumerate_plans to on;
-set optimizer_plan_id =8;
-
-create table t(a int, b int, c int);
+create table t(a int, b int, c int) distributed by (a);
 insert into t select 1, i, i from generate_series(1, 10)i;
 insert into t select 1, i, i from generate_series(1, 10)i;
 insert into t select 1, i, i from generate_series(1, 10)i;
 insert into t select 1, i, i from generate_series(1, 10)i;
+analyze t;
 
 explain (costs off) select count(distinct(b)), gp_segment_id from t group by gp_segment_id;
 select count(distinct(b)), gp_segment_id from t group by gp_segment_id;
 
 reset optimizer_enable_hashagg;
-reset optimizer_enumerate_plans;
-reset optimizer_plan_id;
 drop table t;
 -- CLEANUP
 set client_min_messages='warning';


### PR DESCRIPTION
Consider the following setup:

```
  create table t(a int, b int, c int);
  insert into t select 1, i, i from generate_series(1, 10)I;
  insert into t select 1, i, i from generate_series(1, 10)I;
  insert into t select 1, i, i from generate_series(1, 10)I;
  insert into t select 1, i, i from generate_series(1, 10)I; 
```

On running the following query, erroneous plans were generated

`explain select count(distinct(b)), gp_segment_id from t group by gp_segment_id; `

Multiple plans were generated, if we traverse through those plans, following erroneous plan was found:

                               QUERY PLAN
```
 Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=12)
   ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=12)
         Group Key: gp_segment_id
         ->  GroupAggregate  (cost=0.00..431.00 rows=1 width=8)
               Group Key: gp_segment_id, b
               ->  Sort  (cost=0.00..431.00 rows=1 width=8)
                     Sort Key: gp_segment_id, b
                     ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
                           Hash Key: gp_segment_id, b, b
                           ->  Seq Scan on t  (cost=0.00..431.00 rows=1 width=8)
 Optimizer: Pivotal Optimizer (GPORCA)
(11 rows
```

In this plan, we don't see a motion between the 2 aggregates. Since we redistributed the table then, after 
local grouping, another redistribution was required before the final aggregation. We are fixing this logic through
this PR.

