### PR TITLE
Fix flaky archiving tap test

### DIFF
--- a/src/test/recovery/t/002_archiving.pl
+++ b/src/test/recovery/t/002_archiving.pl
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 use PostgresNode;
 use TestLib;
-use Test::More tests => 25;
+use Test::More tests => 14;
 use File::Copy;
 
 # Initialize master node, doing archives
@@ -79,17 +79,17 @@ is($result, qq(1000), 'check content from archives');
 #         0000200004 - current wal file on standby
 #
 # Contents of the archive location
-#         0000100003.tar.gz
-#         0000100004.partial.tar.gz
+#         0000100003
+#         0000100004
 #
 # stop master with pg_ctl stop -m fast
 # contents of pg_wal on master
 #         0000100004 on the master gets flushed and gets archived
 #         0000100004.done gets created on master
 # Contents of the archive location
-#         0000100003.tar.gz
-#         0000100004.partial.tar.gz
-#         0000100004.tar.gz
+#         0000100003
+#         0000100004.partial
+#         0000100004
 # pg_rewind
 #         copies from standby to master
 #         removes 0000100004 and 0000100004.done from master's pg_wal dir
@@ -123,10 +123,6 @@ $node_standby->promote;
 # after promotion so quickly that when pg_rewind runs, the standby has not
 # performed a checkpoint after promotion yet.
 $node_standby->safe_psql('postgres', "checkpoint");# wait for the partial file to get archived
-
-my $archiver_query = "select count(*) = 1 from pg_stat_archiver where last_archived_wal >= '$latest_wal_filename_old_timeline.partial';";
-$node_standby->poll_query_until('postgres', $archiver_query)
-  or die "Timed out while waiting for the partial wal file to be archived by the standby";
 
 $node_standby->safe_psql('postgres',
 	"INSERT INTO test_partial_wal SELECT generate_series(1,1000)");
@@ -166,16 +162,26 @@ $node_master->start;
 $node_master->safe_psql('postgres',
 	"INSERT INTO test_partial_wal SELECT generate_series(1,1000)");
 
+sub wait_until_file_exists
+{
+	my ($filename) = @_;
+	my $query = "SELECT size IS NOT NULL FROM pg_stat_file('$filename')";
+	# we aren't querying master because we stop the master node for some of the
+	# scenarios
+	$node_standby->poll_query_until('postgres', $query)
+	  or die "Timed out while waiting for file $filename";
+}
+
 sub post_standby_promotion_tests
 {
 	#assert that 0000100004 exists on master
-	ok(-f "$latest_wal_filepath_old_timeline", 'latest wal file from the old timeline exists on master');
+	wait_until_file_exists($latest_wal_filepath_old_timeline);
 	#assert that 0000100004.partial exists on standby
-	ok(-f $node_standby->data_dir . $partial_wal_file_path, 'partial wal file from the old timeline exists on standby');
+	wait_until_file_exists($node_standby->data_dir . $partial_wal_file_path);
 	#assert that 0000100004.partial.done exists on standby
-	ok(-f $node_standby->data_dir . $partial_done_file_path, 'partial done file from the old timeline exists on standby');
+	wait_until_file_exists($node_standby->data_dir . $partial_done_file_path);
 	#assert that 0000100004.partial got archived
-	ok(-f "$archived_partial_wal_file", 'latest partial wal file from the old timeline has been archived');
+	wait_until_file_exists($archived_partial_wal_file);
 
 	#assert that 0000100004.partial doesn't exist on master
 	ok(!-f $node_master->data_dir . $partial_wal_file_path, 'partial wal file from the old timeline should not exist on master');
@@ -194,29 +200,30 @@ sub post_standby_promotion_tests
 sub post_master_stop_tests
 {
 	#assert that 0000100004 still exists on master
-	ok(-f "$latest_wal_filepath_old_timeline", 'latest wal file from the old timeline exists on master');
+	wait_until_file_exists($latest_wal_filepath_old_timeline);
 	#assert that 0000100004.done exists on master
-	ok(-f $node_master->data_dir . $latest_done_old_timeline, 'done file from the old timeline should exist on master');
+	wait_until_file_exists($node_master->data_dir . $latest_done_old_timeline);
 	#assert that 0000100004 is archived
-	ok(-f "$latest_archived_wal_old_timeline", 'latest wal file from the old timeline should be archived');
+	wait_until_file_exists($latest_archived_wal_old_timeline);
 }
 
 sub post_pg_rewind_tests
 {
 	#assert that 0000100004.partial exists on master
-	ok(-f $node_master->data_dir . $partial_wal_file_path, 'latest partial wal file from the old timeline exists on master');
+	wait_until_file_exists($node_master->data_dir . $partial_wal_file_path);
 	#assert that 0000100004.partial.done exists on master
-	ok(-f $node_master->data_dir . $partial_done_file_path, 'latest partial done file from the old timeline exists on master');
+	wait_until_file_exists($node_master->data_dir . $partial_done_file_path);
+
+	#assert that 0000100004 is still archived
+	wait_until_file_exists($latest_archived_wal_old_timeline);
+	#partial wal file is still archived
+	wait_until_file_exists($archived_partial_wal_file);
 
 	#assert that 0000100004 does not exist on master
 	ok(!-f "$latest_wal_filepath_old_timeline", 'latest wal file from the old timeline exists should not exist on standby');
 	#assert that 0000100004.done does not exist on master
 	ok(!-f $node_master->data_dir . $latest_done_old_timeline, 'latest done file from the old timeline should not exist on master');
 
-	#assert that 0000100004 is still archived
-	ok(-f "$latest_archived_wal_old_timeline", 'latest wal file from the old timeline should still be archived');
-	#partial wal file is still archived
-	ok(-f "$archived_partial_wal_file", 'latest partial wal file from the old timeline should still be archived');
 }
 
 sub check_history_files
@@ -234,10 +241,7 @@ sub check_history_files
 	# the second standby created below will be able to restore this file,
 	# creating a RECOVERYHISTORY.
 	my $primary_archive = $node_master->archive_dir;
-	$caughtup_query =
-	  "SELECT size IS NOT NULL FROM pg_stat_file('$primary_archive/00000002.history')";
-	$node_master->poll_query_until('postgres', $caughtup_query)
-	  or die "Timed out while waiting for archiving of 00000002.history";
+	wait_until_file_exists("$primary_archive/00000002.history");
 
 	my $node_standby2 = get_new_node('standby2');
 	$node_standby2->init_from_backup($node_master, $backup_name,


### PR DESCRIPTION
A previous commit 700cad0 added tap tests for the partial wal file feature. This test was a bit flaky on the ci pipeline.

Context:
Once we promote the standby(while the primary is running), a partial wal file gets generated on the standby. In order to test if this file gets generated with the correct name, we were previously querying the pg_stat_archiver view. We would compare the name of the last archived wal with the expected partial wal filename. It's possible that this comparison would return wrong results on some platforms because of the ">=" predicate(which could change based on the sorting order.)

Fix:
This commit removes the use of pg_stat_archiver view and instead relies on the pg_stat_file function to check for the existence of the partial wal file and other files in the tap test

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
