### PR TITLE
[ORCA] Fix option to enable multi-distinct agg  (#15445)

### DIFF
--- a/src/backend/gporca/data/dxl/minidump/MDQA-SameDQAColumn.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MDQA-SameDQAColumn.mdp
@@ -90,6 +90,14 @@
       </dxl:GPDBAgg>
       <dxl:ColumnStatistics Mdid="1.359750.1.1.7" Name="cmax" Width="4.000000"/>
       <dxl:ColumnStatistics Mdid="1.359750.1.1.6" Name="xmax" Width="4.000000"/>
+      <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.65.1.0"/>
+        <dxl:Commutator Mdid="0.96.1.0"/>
+        <dxl:InverseOp Mdid="0.518.1.0"/>
+      </dxl:GPDBScalarOp>
       <dxl:GPDBScalarOp Mdid="0.97.1.0" Name="&lt;" ComparisonType="LT">
         <dxl:LeftType Mdid="0.23.1.0"/>
         <dxl:RightType Mdid="0.23.1.0"/>
@@ -382,7 +390,7 @@
             <dxl:ProjElem ColId="10" Alias="count">
               <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" >
                 <dxl:ValuesList ParamType="aggargs">
-                <dxl:Ident ColId="13" ColName="ColRef_0013" TypeMdid="0.23.1.0"/>
+                  <dxl:Ident ColId="13" ColName="ColRef_0013" TypeMdid="0.23.1.0"/>
                 </dxl:ValuesList>
                 <dxl:ValuesList ParamType="aggdirectargs"/>
                 <dxl:ValuesList ParamType="aggorder"/>
@@ -392,7 +400,7 @@
             <dxl:ProjElem ColId="11" Alias="sum">
               <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" >
                 <dxl:ValuesList ParamType="aggargs">
-                <dxl:Ident ColId="13" ColName="ColRef_0013" TypeMdid="0.23.1.0"/>
+                  <dxl:Ident ColId="13" ColName="ColRef_0013" TypeMdid="0.23.1.0"/>
                 </dxl:ValuesList>
                 <dxl:ValuesList ParamType="aggdirectargs"/>
                 <dxl:ValuesList ParamType="aggorder"/>
@@ -402,7 +410,7 @@
             <dxl:ProjElem ColId="12" Alias="avg">
               <dxl:AggFunc AggMdid="0.2101.1.0" AggDistinct="false" AggStage="Final" AggKind="n" >
                 <dxl:ValuesList ParamType="aggargs">
-                <dxl:Ident ColId="15" ColName="ColRef_0015" TypeMdid="0.17.1.0"/>
+                  <dxl:Ident ColId="15" ColName="ColRef_0015" TypeMdid="0.17.1.0"/>
                 </dxl:ValuesList>
                 <dxl:ValuesList ParamType="aggdirectargs"/>
                 <dxl:ValuesList ParamType="aggorder"/>
@@ -423,7 +431,7 @@
               <dxl:ProjElem ColId="15" Alias="ColRef_0015">
                 <dxl:AggFunc AggMdid="0.2101.1.0" AggDistinct="false" AggStage="Intermediate" AggKind="n" >
                   <dxl:ValuesList ParamType="aggargs">
-                  <dxl:Ident ColId="14" ColName="ColRef_0014" TypeMdid="0.17.1.0"/>
+                    <dxl:Ident ColId="14" ColName="ColRef_0014" TypeMdid="0.17.1.0"/>
                   </dxl:ValuesList>
                   <dxl:ValuesList ParamType="aggdirectargs"/>
                   <dxl:ValuesList ParamType="aggorder"/>
@@ -511,10 +519,10 @@
                       <dxl:ProjElem ColId="14" Alias="ColRef_0014">
                         <dxl:AggFunc AggMdid="0.2101.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" >
                           <dxl:ValuesList ParamType="aggargs">
-                          <dxl:OpExpr OperatorName="+" OperatorMdid="0.551.1.0" OperatorType="0.23.1.0">
-                            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                            <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                          </dxl:OpExpr>
+                            <dxl:OpExpr OperatorName="+" OperatorMdid="0.551.1.0" OperatorType="0.23.1.0">
+                              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                            </dxl:OpExpr>
                           </dxl:ValuesList>
                           <dxl:ValuesList ParamType="aggdirectargs"/>
                           <dxl:ValuesList ParamType="aggorder"/>

--- a/src/backend/gporca/data/dxl/minidump/MDQAs-Grouping-OrderBy.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MDQAs-Grouping-OrderBy.mdp
@@ -464,10 +464,10 @@ SQL:
         </dxl:LogicalGroupBy>
       </dxl:LogicalLimit>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="4">
+    <dxl:Plan Id="0" SpaceSize="10400">
       <dxl:Limit>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.018838" Rows="10.000000" Width="20"/>
+          <dxl:Cost StartupCost="0" TotalCost="1293.104458" Rows="10.000000" Width="20"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -482,7 +482,7 @@ SQL:
         </dxl:ProjList>
         <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.018638" Rows="10.000000" Width="20"/>
+            <dxl:Cost StartupCost="0" TotalCost="1293.104258" Rows="10.000000" Width="20"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -501,7 +501,7 @@ SQL:
           </dxl:SortingColumnList>
           <dxl:Limit>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.017740" Rows="10.000000" Width="20"/>
+              <dxl:Cost StartupCost="0" TotalCost="1293.103360" Rows="10.000000" Width="20"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -514,86 +514,381 @@ SQL:
                 <dxl:Ident ColId="10" ColName="count" TypeMdid="0.20.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
-            <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+            <dxl:Sort SortDiscardDuplicates="false">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.017640" Rows="111.000000" Width="20"/>
+                <dxl:Cost StartupCost="0" TotalCost="1293.103260" Rows="111.000000" Width="20"/>
               </dxl:Properties>
-              <dxl:GroupingColumns>
-                <dxl:GroupingColumn ColId="0"/>
-              </dxl:GroupingColumns>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">
                   <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
                 <dxl:ProjElem ColId="9" Alias="count">
-                  <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="true" AggStage="Normal" AggKind="n" >
-                    <dxl:ValuesList ParamType="aggargs">
-                      <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                    </dxl:ValuesList>
-                    <dxl:ValuesList ParamType="aggdirectargs"/>
-                    <dxl:ValuesList ParamType="aggorder"/>
-                    <dxl:ValuesList ParamType="aggdistinct"/>
-                  </dxl:AggFunc>
+                  <dxl:Ident ColId="9" ColName="count" TypeMdid="0.20.1.0"/>
                 </dxl:ProjElem>
                 <dxl:ProjElem ColId="10" Alias="count">
-                  <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="true" AggStage="Normal" AggKind="n" >
-                    <dxl:ValuesList ParamType="aggargs">
-                      <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                    </dxl:ValuesList>
-                    <dxl:ValuesList ParamType="aggdirectargs"/>
-                    <dxl:ValuesList ParamType="aggorder"/>
-                    <dxl:ValuesList ParamType="aggdistinct"/>
-                  </dxl:AggFunc>
+                  <dxl:Ident ColId="10" ColName="count" TypeMdid="0.20.1.0"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:Sort SortDiscardDuplicates="false">
+              <dxl:SortingColumnList>
+                <dxl:SortingColumn ColId="0" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+              </dxl:SortingColumnList>
+              <dxl:LimitCount/>
+              <dxl:LimitOffset/>
+              <dxl:Sequence>
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.016573" Rows="111.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1293.066792" Rows="111.000000" Width="20"/>
                 </dxl:Properties>
                 <dxl:ProjList>
                   <dxl:ProjElem ColId="0" Alias="a">
                     <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
-                  <dxl:ProjElem ColId="1" Alias="b">
-                    <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                  <dxl:ProjElem ColId="9" Alias="count">
+                    <dxl:Ident ColId="9" ColName="count" TypeMdid="0.20.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="10" Alias="count">
+                    <dxl:Ident ColId="10" ColName="count" TypeMdid="0.20.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:SortingColumnList>
-                  <dxl:SortingColumn ColId="0" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                </dxl:SortingColumnList>
-                <dxl:LimitCount/>
-                <dxl:LimitOffset/>
-                <dxl:TableScan>
+                <dxl:CTEProducer CTEId="0" Columns="11,12,13,14,15,16,17,18,19">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.001160" Rows="111.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.005138" Rows="111.000000" Width="1"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="11" Alias="a">
+                      <dxl:Ident ColId="11" ColName="a" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="12" Alias="b">
+                      <dxl:Ident ColId="12" ColName="b" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="13" Alias="ctid">
+                      <dxl:Ident ColId="13" ColName="ctid" TypeMdid="0.27.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="14" Alias="xmin">
+                      <dxl:Ident ColId="14" ColName="xmin" TypeMdid="0.28.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="15" Alias="cmin">
+                      <dxl:Ident ColId="15" ColName="cmin" TypeMdid="0.29.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="16" Alias="xmax">
+                      <dxl:Ident ColId="16" ColName="xmax" TypeMdid="0.28.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="17" Alias="cmax">
+                      <dxl:Ident ColId="17" ColName="cmax" TypeMdid="0.29.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="18" Alias="tableoid">
+                      <dxl:Ident ColId="18" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="19" Alias="gp_segment_id">
+                      <dxl:Ident ColId="19" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:TableScan>
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.001160" Rows="111.000000" Width="38"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="11" Alias="a">
+                        <dxl:Ident ColId="11" ColName="a" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="12" Alias="b">
+                        <dxl:Ident ColId="12" ColName="b" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="13" Alias="ctid">
+                        <dxl:Ident ColId="13" ColName="ctid" TypeMdid="0.27.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="14" Alias="xmin">
+                        <dxl:Ident ColId="14" ColName="xmin" TypeMdid="0.28.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="15" Alias="cmin">
+                        <dxl:Ident ColId="15" ColName="cmin" TypeMdid="0.29.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="16" Alias="xmax">
+                        <dxl:Ident ColId="16" ColName="xmax" TypeMdid="0.28.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="17" Alias="cmax">
+                        <dxl:Ident ColId="17" ColName="cmax" TypeMdid="0.29.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="18" Alias="tableoid">
+                        <dxl:Ident ColId="18" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="19" Alias="gp_segment_id">
+                        <dxl:Ident ColId="19" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:TableDescriptor Mdid="6.1639448.1.1" TableName="t1">
+                      <dxl:Columns>
+                        <dxl:Column ColId="11" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+                        <dxl:Column ColId="12" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+                        <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                        <dxl:Column ColId="14" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                        <dxl:Column ColId="15" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                        <dxl:Column ColId="16" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                        <dxl:Column ColId="17" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                        <dxl:Column ColId="18" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                        <dxl:Column ColId="19" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                      </dxl:Columns>
+                    </dxl:TableDescriptor>
+                  </dxl:TableScan>
+                </dxl:CTEProducer>
+                <dxl:HashJoin JoinType="Inner">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="862.060544" Rows="111.000000" Width="20"/>
                   </dxl:Properties>
                   <dxl:ProjList>
                     <dxl:ProjElem ColId="0" Alias="a">
                       <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
-                    <dxl:ProjElem ColId="1" Alias="b">
-                      <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ProjElem ColId="9" Alias="count">
+                      <dxl:Ident ColId="9" ColName="count" TypeMdid="0.20.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="10" Alias="count">
+                      <dxl:Ident ColId="10" ColName="count" TypeMdid="0.20.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:TableDescriptor Mdid="6.1639448.1.1" TableName="t1">
-                    <dxl:Columns>
-                      <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-                      <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
-                      <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                      <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                      <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                      <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                      <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                      <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                      <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                    </dxl:Columns>
-                  </dxl:TableDescriptor>
-                </dxl:TableScan>
-              </dxl:Sort>
-            </dxl:Aggregate>
+                  <dxl:JoinFilter/>
+                  <dxl:HashCondList>
+                    <dxl:Not>
+                      <dxl:IsDistinctFrom OperatorMdid="0.96.1.0">
+                        <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                        <dxl:Ident ColId="20" ColName="a" TypeMdid="0.23.1.0"/>
+                      </dxl:IsDistinctFrom>
+                    </dxl:Not>
+                  </dxl:HashCondList>
+                  <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.008771" Rows="111.000000" Width="12"/>
+                    </dxl:Properties>
+                    <dxl:GroupingColumns>
+                      <dxl:GroupingColumn ColId="0"/>
+                    </dxl:GroupingColumns>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="9" Alias="count">
+                        <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="">
+                          <dxl:ValuesList ParamType="aggargs">
+                            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                          </dxl:ValuesList>
+                          <dxl:ValuesList ParamType="aggdirectargs"/>
+                          <dxl:ValuesList ParamType="aggorder"/>
+                          <dxl:ValuesList ParamType="aggdistinct"/>
+                        </dxl:AggFunc>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="0" Alias="a">
+                        <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.008175" Rows="111.000000" Width="4"/>
+                      </dxl:Properties>
+                      <dxl:GroupingColumns>
+                        <dxl:GroupingColumn ColId="0"/>
+                      </dxl:GroupingColumns>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="0" Alias="a">
+                          <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:Sort SortDiscardDuplicates="false">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.007829" Rows="111.000000" Width="4"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="0" Alias="a">
+                            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="1" Alias="b">
+                            <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="2" Alias="ctid">
+                            <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="3" Alias="xmin">
+                            <dxl:Ident ColId="3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="4" Alias="cmin">
+                            <dxl:Ident ColId="4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="5" Alias="xmax">
+                            <dxl:Ident ColId="5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="6" Alias="cmax">
+                            <dxl:Ident ColId="6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="7" Alias="tableoid">
+                            <dxl:Ident ColId="7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="8" Alias="gp_segment_id">
+                            <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:SortingColumnList>
+                          <dxl:SortingColumn ColId="0" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                        </dxl:SortingColumnList>
+                        <dxl:LimitCount/>
+                        <dxl:LimitOffset/>
+                        <dxl:CTEConsumer CTEId="0" Columns="0,1,2,3,4,5,6,7,8">
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000535" Rows="111.000000" Width="4"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="0" Alias="a">
+                              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="1" Alias="b">
+                              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="2" Alias="ctid">
+                              <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="3" Alias="xmin">
+                              <dxl:Ident ColId="3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="4" Alias="cmin">
+                              <dxl:Ident ColId="4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="5" Alias="xmax">
+                              <dxl:Ident ColId="5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="6" Alias="cmax">
+                              <dxl:Ident ColId="6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="7" Alias="tableoid">
+                              <dxl:Ident ColId="7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="8" Alias="gp_segment_id">
+                              <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                        </dxl:CTEConsumer>
+                      </dxl:Sort>
+                    </dxl:Aggregate>
+                  </dxl:Aggregate>
+                  <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.017168" Rows="111.000000" Width="12"/>
+                    </dxl:Properties>
+                    <dxl:GroupingColumns>
+                      <dxl:GroupingColumn ColId="20"/>
+                    </dxl:GroupingColumns>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="10" Alias="count">
+                        <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="">
+                          <dxl:ValuesList ParamType="aggargs">
+                            <dxl:Ident ColId="21" ColName="b" TypeMdid="0.23.1.0"/>
+                          </dxl:ValuesList>
+                          <dxl:ValuesList ParamType="aggdirectargs"/>
+                          <dxl:ValuesList ParamType="aggorder"/>
+                          <dxl:ValuesList ParamType="aggdistinct"/>
+                        </dxl:AggFunc>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="20" Alias="a">
+                        <dxl:Ident ColId="20" ColName="a" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.016350" Rows="111.000000" Width="8"/>
+                      </dxl:Properties>
+                      <dxl:GroupingColumns>
+                        <dxl:GroupingColumn ColId="20"/>
+                        <dxl:GroupingColumn ColId="21"/>
+                      </dxl:GroupingColumns>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="20" Alias="a">
+                          <dxl:Ident ColId="20" ColName="a" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="21" Alias="b">
+                          <dxl:Ident ColId="21" ColName="b" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:Sort SortDiscardDuplicates="false">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.015657" Rows="111.000000" Width="8"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="20" Alias="a">
+                            <dxl:Ident ColId="20" ColName="a" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="21" Alias="b">
+                            <dxl:Ident ColId="21" ColName="b" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="22" Alias="ctid">
+                            <dxl:Ident ColId="22" ColName="ctid" TypeMdid="0.27.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="23" Alias="xmin">
+                            <dxl:Ident ColId="23" ColName="xmin" TypeMdid="0.28.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="24" Alias="cmin">
+                            <dxl:Ident ColId="24" ColName="cmin" TypeMdid="0.29.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="25" Alias="xmax">
+                            <dxl:Ident ColId="25" ColName="xmax" TypeMdid="0.28.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="26" Alias="cmax">
+                            <dxl:Ident ColId="26" ColName="cmax" TypeMdid="0.29.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="27" Alias="tableoid">
+                            <dxl:Ident ColId="27" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="28" Alias="gp_segment_id">
+                            <dxl:Ident ColId="28" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:SortingColumnList>
+                          <dxl:SortingColumn ColId="20" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                          <dxl:SortingColumn ColId="21" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                        </dxl:SortingColumnList>
+                        <dxl:LimitCount/>
+                        <dxl:LimitOffset/>
+                        <dxl:CTEConsumer CTEId="0" Columns="20,21,22,23,24,25,26,27,28">
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="431.001070" Rows="111.000000" Width="8"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="20" Alias="a">
+                              <dxl:Ident ColId="20" ColName="a" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="21" Alias="b">
+                              <dxl:Ident ColId="21" ColName="b" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="22" Alias="ctid">
+                              <dxl:Ident ColId="22" ColName="ctid" TypeMdid="0.27.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="23" Alias="xmin">
+                              <dxl:Ident ColId="23" ColName="xmin" TypeMdid="0.28.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="24" Alias="cmin">
+                              <dxl:Ident ColId="24" ColName="cmin" TypeMdid="0.29.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="25" Alias="xmax">
+                              <dxl:Ident ColId="25" ColName="xmax" TypeMdid="0.28.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="26" Alias="cmax">
+                              <dxl:Ident ColId="26" ColName="cmax" TypeMdid="0.29.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="27" Alias="tableoid">
+                              <dxl:Ident ColId="27" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="28" Alias="gp_segment_id">
+                              <dxl:Ident ColId="28" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                        </dxl:CTEConsumer>
+                      </dxl:Sort>
+                    </dxl:Aggregate>
+                  </dxl:Aggregate>
+                </dxl:HashJoin>
+              </dxl:Sequence>
+            </dxl:Sort>
             <dxl:LimitCount>
               <dxl:ConstValue TypeMdid="0.20.1.0" Value="10"/>
             </dxl:LimitCount>

--- a/src/backend/gporca/data/dxl/minidump/MDQAs-Grouping.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MDQAs-Grouping.mdp
@@ -455,10 +455,10 @@ SQL:
         </dxl:LogicalGet>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1">
+    <dxl:Plan Id="0" SpaceSize="9200">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.027608" Rows="111.000000" Width="20"/>
+          <dxl:Cost StartupCost="0" TotalCost="1293.076760" Rows="111.000000" Width="20"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -473,86 +473,359 @@ SQL:
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:SortingColumnList/>
-        <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+        <dxl:Sequence>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.017640" Rows="111.000000" Width="20"/>
+            <dxl:Cost StartupCost="0" TotalCost="1293.066792" Rows="111.000000" Width="20"/>
           </dxl:Properties>
-          <dxl:GroupingColumns>
-            <dxl:GroupingColumn ColId="0"/>
-          </dxl:GroupingColumns>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
               <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
             <dxl:ProjElem ColId="9" Alias="count">
-              <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="true" AggStage="Normal" AggKind="n" >
-                <dxl:ValuesList ParamType="aggargs">
-                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                </dxl:ValuesList>
-                <dxl:ValuesList ParamType="aggdirectargs"/>
-                <dxl:ValuesList ParamType="aggorder"/>
-                <dxl:ValuesList ParamType="aggdistinct"/>
-              </dxl:AggFunc>
+              <dxl:Ident ColId="9" ColName="count" TypeMdid="0.20.1.0"/>
             </dxl:ProjElem>
             <dxl:ProjElem ColId="10" Alias="count">
-              <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="true" AggStage="Normal" AggKind="n" >
-                <dxl:ValuesList ParamType="aggargs">
-                  <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                </dxl:ValuesList>
-                <dxl:ValuesList ParamType="aggdirectargs"/>
-                <dxl:ValuesList ParamType="aggorder"/>
-                <dxl:ValuesList ParamType="aggdistinct"/>
-              </dxl:AggFunc>
+              <dxl:Ident ColId="10" ColName="count" TypeMdid="0.20.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
-          <dxl:Filter/>
-          <dxl:Sort SortDiscardDuplicates="false">
+          <dxl:CTEProducer CTEId="0" Columns="11,12,13,14,15,16,17,18,19">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.016573" Rows="111.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.005138" Rows="111.000000" Width="1"/>
             </dxl:Properties>
             <dxl:ProjList>
-              <dxl:ProjElem ColId="0" Alias="a">
-                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+              <dxl:ProjElem ColId="11" Alias="a">
+                <dxl:Ident ColId="11" ColName="a" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="1" Alias="b">
-                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ProjElem ColId="12" Alias="b">
+                <dxl:Ident ColId="12" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="13" Alias="ctid">
+                <dxl:Ident ColId="13" ColName="ctid" TypeMdid="0.27.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="14" Alias="xmin">
+                <dxl:Ident ColId="14" ColName="xmin" TypeMdid="0.28.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="15" Alias="cmin">
+                <dxl:Ident ColId="15" ColName="cmin" TypeMdid="0.29.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="16" Alias="xmax">
+                <dxl:Ident ColId="16" ColName="xmax" TypeMdid="0.28.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="17" Alias="cmax">
+                <dxl:Ident ColId="17" ColName="cmax" TypeMdid="0.29.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="18" Alias="tableoid">
+                <dxl:Ident ColId="18" ColName="tableoid" TypeMdid="0.26.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="19" Alias="gp_segment_id">
+                <dxl:Ident ColId="19" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
-            <dxl:Filter/>
-            <dxl:SortingColumnList>
-              <dxl:SortingColumn ColId="0" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-            </dxl:SortingColumnList>
-            <dxl:LimitCount/>
-            <dxl:LimitOffset/>
             <dxl:TableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.001160" Rows="111.000000" Width="8"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.001160" Rows="111.000000" Width="38"/>
               </dxl:Properties>
               <dxl:ProjList>
-                <dxl:ProjElem ColId="0" Alias="a">
-                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                <dxl:ProjElem ColId="11" Alias="a">
+                  <dxl:Ident ColId="11" ColName="a" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
-                <dxl:ProjElem ColId="1" Alias="b">
-                  <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                <dxl:ProjElem ColId="12" Alias="b">
+                  <dxl:Ident ColId="12" ColName="b" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="13" Alias="ctid">
+                  <dxl:Ident ColId="13" ColName="ctid" TypeMdid="0.27.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="14" Alias="xmin">
+                  <dxl:Ident ColId="14" ColName="xmin" TypeMdid="0.28.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="15" Alias="cmin">
+                  <dxl:Ident ColId="15" ColName="cmin" TypeMdid="0.29.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="16" Alias="xmax">
+                  <dxl:Ident ColId="16" ColName="xmax" TypeMdid="0.28.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="17" Alias="cmax">
+                  <dxl:Ident ColId="17" ColName="cmax" TypeMdid="0.29.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="18" Alias="tableoid">
+                  <dxl:Ident ColId="18" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="19" Alias="gp_segment_id">
+                  <dxl:Ident ColId="19" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
               <dxl:TableDescriptor Mdid="6.1639448.1.1" TableName="t1">
                 <dxl:Columns>
-                  <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
-                  <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                  <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                  <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                  <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                  <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="11" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="12" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                  <dxl:Column ColId="14" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                  <dxl:Column ColId="15" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                  <dxl:Column ColId="16" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                  <dxl:Column ColId="17" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                  <dxl:Column ColId="18" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                  <dxl:Column ColId="19" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                 </dxl:Columns>
               </dxl:TableDescriptor>
             </dxl:TableScan>
-          </dxl:Sort>
-        </dxl:Aggregate>
+          </dxl:CTEProducer>
+          <dxl:HashJoin JoinType="Inner">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="862.060544" Rows="110.999992" Width="20"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="0" Alias="a">
+                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="9" Alias="count">
+                <dxl:Ident ColId="9" ColName="count" TypeMdid="0.20.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="10" Alias="count">
+                <dxl:Ident ColId="10" ColName="count" TypeMdid="0.20.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:JoinFilter/>
+            <dxl:HashCondList>
+              <dxl:Not>
+                <dxl:IsDistinctFrom OperatorMdid="0.96.1.0">
+                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                  <dxl:Ident ColId="20" ColName="a" TypeMdid="0.23.1.0"/>
+                </dxl:IsDistinctFrom>
+              </dxl:Not>
+            </dxl:HashCondList>
+            <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.008771" Rows="111.000000" Width="12"/>
+              </dxl:Properties>
+              <dxl:GroupingColumns>
+                <dxl:GroupingColumn ColId="0"/>
+              </dxl:GroupingColumns>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="9" Alias="count">
+                  <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="">
+                    <dxl:ValuesList ParamType="aggargs">
+                      <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                    </dxl:ValuesList>
+                    <dxl:ValuesList ParamType="aggdirectargs"/>
+                    <dxl:ValuesList ParamType="aggorder"/>
+                    <dxl:ValuesList ParamType="aggdistinct"/>
+                  </dxl:AggFunc>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="0" Alias="a">
+                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.008175" Rows="111.000000" Width="4"/>
+                </dxl:Properties>
+                <dxl:GroupingColumns>
+                  <dxl:GroupingColumn ColId="0"/>
+                </dxl:GroupingColumns>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="0" Alias="a">
+                    <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:Sort SortDiscardDuplicates="false">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.007829" Rows="111.000000" Width="4"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="0" Alias="a">
+                      <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="1" Alias="b">
+                      <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="2" Alias="ctid">
+                      <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="3" Alias="xmin">
+                      <dxl:Ident ColId="3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="4" Alias="cmin">
+                      <dxl:Ident ColId="4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="5" Alias="xmax">
+                      <dxl:Ident ColId="5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="6" Alias="cmax">
+                      <dxl:Ident ColId="6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="7" Alias="tableoid">
+                      <dxl:Ident ColId="7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="8" Alias="gp_segment_id">
+                      <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:SortingColumnList>
+                    <dxl:SortingColumn ColId="0" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                  </dxl:SortingColumnList>
+                  <dxl:LimitCount/>
+                  <dxl:LimitOffset/>
+                  <dxl:CTEConsumer CTEId="0" Columns="0,1,2,3,4,5,6,7,8">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000535" Rows="111.000000" Width="4"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="0" Alias="a">
+                        <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="1" Alias="b">
+                        <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="2" Alias="ctid">
+                        <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="3" Alias="xmin">
+                        <dxl:Ident ColId="3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="4" Alias="cmin">
+                        <dxl:Ident ColId="4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="5" Alias="xmax">
+                        <dxl:Ident ColId="5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="6" Alias="cmax">
+                        <dxl:Ident ColId="6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="7" Alias="tableoid">
+                        <dxl:Ident ColId="7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="8" Alias="gp_segment_id">
+                        <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                  </dxl:CTEConsumer>
+                </dxl:Sort>
+              </dxl:Aggregate>
+            </dxl:Aggregate>
+            <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.017168" Rows="111.000000" Width="12"/>
+              </dxl:Properties>
+              <dxl:GroupingColumns>
+                <dxl:GroupingColumn ColId="20"/>
+              </dxl:GroupingColumns>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="10" Alias="count">
+                  <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="">
+                    <dxl:ValuesList ParamType="aggargs">
+                      <dxl:Ident ColId="21" ColName="b" TypeMdid="0.23.1.0"/>
+                    </dxl:ValuesList>
+                    <dxl:ValuesList ParamType="aggdirectargs"/>
+                    <dxl:ValuesList ParamType="aggorder"/>
+                    <dxl:ValuesList ParamType="aggdistinct"/>
+                  </dxl:AggFunc>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="20" Alias="a">
+                  <dxl:Ident ColId="20" ColName="a" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.016350" Rows="111.000000" Width="8"/>
+                </dxl:Properties>
+                <dxl:GroupingColumns>
+                  <dxl:GroupingColumn ColId="20"/>
+                  <dxl:GroupingColumn ColId="21"/>
+                </dxl:GroupingColumns>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="20" Alias="a">
+                    <dxl:Ident ColId="20" ColName="a" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="21" Alias="b">
+                    <dxl:Ident ColId="21" ColName="b" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:Sort SortDiscardDuplicates="false">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.015657" Rows="111.000000" Width="8"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="20" Alias="a">
+                      <dxl:Ident ColId="20" ColName="a" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="21" Alias="b">
+                      <dxl:Ident ColId="21" ColName="b" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="22" Alias="ctid">
+                      <dxl:Ident ColId="22" ColName="ctid" TypeMdid="0.27.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="23" Alias="xmin">
+                      <dxl:Ident ColId="23" ColName="xmin" TypeMdid="0.28.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="24" Alias="cmin">
+                      <dxl:Ident ColId="24" ColName="cmin" TypeMdid="0.29.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="25" Alias="xmax">
+                      <dxl:Ident ColId="25" ColName="xmax" TypeMdid="0.28.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="26" Alias="cmax">
+                      <dxl:Ident ColId="26" ColName="cmax" TypeMdid="0.29.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="27" Alias="tableoid">
+                      <dxl:Ident ColId="27" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="28" Alias="gp_segment_id">
+                      <dxl:Ident ColId="28" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:SortingColumnList>
+                    <dxl:SortingColumn ColId="20" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                    <dxl:SortingColumn ColId="21" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                  </dxl:SortingColumnList>
+                  <dxl:LimitCount/>
+                  <dxl:LimitOffset/>
+                  <dxl:CTEConsumer CTEId="0" Columns="20,21,22,23,24,25,26,27,28">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.001070" Rows="111.000000" Width="8"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="20" Alias="a">
+                        <dxl:Ident ColId="20" ColName="a" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="21" Alias="b">
+                        <dxl:Ident ColId="21" ColName="b" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="22" Alias="ctid">
+                        <dxl:Ident ColId="22" ColName="ctid" TypeMdid="0.27.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="23" Alias="xmin">
+                        <dxl:Ident ColId="23" ColName="xmin" TypeMdid="0.28.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="24" Alias="cmin">
+                        <dxl:Ident ColId="24" ColName="cmin" TypeMdid="0.29.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="25" Alias="xmax">
+                        <dxl:Ident ColId="25" ColName="xmax" TypeMdid="0.28.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="26" Alias="cmax">
+                        <dxl:Ident ColId="26" ColName="cmax" TypeMdid="0.29.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="27" Alias="tableoid">
+                        <dxl:Ident ColId="27" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="28" Alias="gp_segment_id">
+                        <dxl:Ident ColId="28" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                  </dxl:CTEConsumer>
+                </dxl:Sort>
+              </dxl:Aggregate>
+            </dxl:Aggregate>
+          </dxl:HashJoin>
+        </dxl:Sequence>
       </dxl:GatherMotion>
     </dxl:Plan>
   </dxl:Thread>

--- a/src/backend/gporca/data/dxl/minidump/MDQAs-Union.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MDQAs-Union.mdp
@@ -508,10 +508,10 @@ select a,count(distinct a), count(distinct b) from t1 group by a
         </dxl:LogicalGroupBy>
       </dxl:Union>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="100">
+    <dxl:Plan Id="0" SpaceSize="426240000">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="862.074871" Rows="134.000000" Width="20"/>
+          <dxl:Cost StartupCost="0" TotalCost="2586.144662" Rows="134.000000" Width="20"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -528,7 +528,7 @@ select a,count(distinct a), count(distinct b) from t1 group by a
         <dxl:SortingColumnList/>
         <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="862.062838" Rows="134.000000" Width="20"/>
+            <dxl:Cost StartupCost="0" TotalCost="2586.132629" Rows="134.000000" Width="20"/>
           </dxl:Properties>
           <dxl:GroupingColumns>
             <dxl:GroupingColumn ColId="0"/>
@@ -549,7 +549,7 @@ select a,count(distinct a), count(distinct b) from t1 group by a
           <dxl:Filter/>
           <dxl:Append IsTarget="false" IsZapped="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="862.037516" Rows="134.000000" Width="20"/>
+              <dxl:Cost StartupCost="0" TotalCost="2586.107307" Rows="134.000000" Width="20"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -563,186 +563,760 @@ select a,count(distinct a), count(distinct b) from t1 group by a
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+            <dxl:Sequence>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.017640" Rows="111.000000" Width="20"/>
+                <dxl:Cost StartupCost="0" TotalCost="1293.066792" Rows="111.000000" Width="20"/>
               </dxl:Properties>
-              <dxl:GroupingColumns>
-                <dxl:GroupingColumn ColId="0"/>
-              </dxl:GroupingColumns>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="a">
                   <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
                 <dxl:ProjElem ColId="9" Alias="count">
-                  <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="true" AggStage="Normal" AggKind="n" >
-                    <dxl:ValuesList ParamType="aggargs">
-                      <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                    </dxl:ValuesList>
-                    <dxl:ValuesList ParamType="aggdirectargs"/>
-                    <dxl:ValuesList ParamType="aggorder"/>
-                    <dxl:ValuesList ParamType="aggdistinct"/>
-                  </dxl:AggFunc>
+                  <dxl:Ident ColId="9" ColName="count" TypeMdid="0.20.1.0"/>
                 </dxl:ProjElem>
                 <dxl:ProjElem ColId="10" Alias="count">
-                  <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="true" AggStage="Normal" AggKind="n" >
-                    <dxl:ValuesList ParamType="aggargs">
-                      <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                    </dxl:ValuesList>
-                    <dxl:ValuesList ParamType="aggdirectargs"/>
-                    <dxl:ValuesList ParamType="aggorder"/>
-                    <dxl:ValuesList ParamType="aggdistinct"/>
-                  </dxl:AggFunc>
+                  <dxl:Ident ColId="10" ColName="count" TypeMdid="0.20.1.0"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:Sort SortDiscardDuplicates="false">
+              <dxl:CTEProducer CTEId="1" Columns="42,43,44,45,46,47,48,49,50">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.016573" Rows="111.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.005138" Rows="111.000000" Width="1"/>
                 </dxl:Properties>
                 <dxl:ProjList>
-                  <dxl:ProjElem ColId="0" Alias="a">
-                    <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                  <dxl:ProjElem ColId="42" Alias="a">
+                    <dxl:Ident ColId="42" ColName="a" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
-                  <dxl:ProjElem ColId="1" Alias="b">
-                    <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                  <dxl:ProjElem ColId="43" Alias="b">
+                    <dxl:Ident ColId="43" ColName="b" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="44" Alias="ctid">
+                    <dxl:Ident ColId="44" ColName="ctid" TypeMdid="0.27.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="45" Alias="xmin">
+                    <dxl:Ident ColId="45" ColName="xmin" TypeMdid="0.28.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="46" Alias="cmin">
+                    <dxl:Ident ColId="46" ColName="cmin" TypeMdid="0.29.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="47" Alias="xmax">
+                    <dxl:Ident ColId="47" ColName="xmax" TypeMdid="0.28.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="48" Alias="cmax">
+                    <dxl:Ident ColId="48" ColName="cmax" TypeMdid="0.29.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="49" Alias="tableoid">
+                    <dxl:Ident ColId="49" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="50" Alias="gp_segment_id">
+                    <dxl:Ident ColId="50" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:SortingColumnList>
-                  <dxl:SortingColumn ColId="0" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                </dxl:SortingColumnList>
-                <dxl:LimitCount/>
-                <dxl:LimitOffset/>
                 <dxl:TableScan>
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.001160" Rows="111.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.001160" Rows="111.000000" Width="38"/>
                   </dxl:Properties>
                   <dxl:ProjList>
-                    <dxl:ProjElem ColId="0" Alias="a">
-                      <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                    <dxl:ProjElem ColId="42" Alias="a">
+                      <dxl:Ident ColId="42" ColName="a" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
-                    <dxl:ProjElem ColId="1" Alias="b">
-                      <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ProjElem ColId="43" Alias="b">
+                      <dxl:Ident ColId="43" ColName="b" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="44" Alias="ctid">
+                      <dxl:Ident ColId="44" ColName="ctid" TypeMdid="0.27.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="45" Alias="xmin">
+                      <dxl:Ident ColId="45" ColName="xmin" TypeMdid="0.28.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="46" Alias="cmin">
+                      <dxl:Ident ColId="46" ColName="cmin" TypeMdid="0.29.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="47" Alias="xmax">
+                      <dxl:Ident ColId="47" ColName="xmax" TypeMdid="0.28.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="48" Alias="cmax">
+                      <dxl:Ident ColId="48" ColName="cmax" TypeMdid="0.29.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="49" Alias="tableoid">
+                      <dxl:Ident ColId="49" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="50" Alias="gp_segment_id">
+                      <dxl:Ident ColId="50" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
                   <dxl:TableDescriptor Mdid="6.1639448.1.1" TableName="t1">
                     <dxl:Columns>
-                      <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-                      <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
-                      <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                      <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                      <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                      <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                      <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                      <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                      <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                      <dxl:Column ColId="42" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+                      <dxl:Column ColId="43" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+                      <dxl:Column ColId="44" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                      <dxl:Column ColId="45" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                      <dxl:Column ColId="46" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                      <dxl:Column ColId="47" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                      <dxl:Column ColId="48" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                      <dxl:Column ColId="49" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                      <dxl:Column ColId="50" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                     </dxl:Columns>
                   </dxl:TableDescriptor>
                 </dxl:TableScan>
-              </dxl:Sort>
-            </dxl:Aggregate>
-            <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+              </dxl:CTEProducer>
+              <dxl:HashJoin JoinType="Inner">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="862.060544" Rows="111.000000" Width="20"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="0" Alias="a">
+                    <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="9" Alias="count">
+                    <dxl:Ident ColId="9" ColName="count" TypeMdid="0.20.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="10" Alias="count">
+                    <dxl:Ident ColId="10" ColName="count" TypeMdid="0.20.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:JoinFilter/>
+                <dxl:HashCondList>
+                  <dxl:Not>
+                    <dxl:IsDistinctFrom OperatorMdid="0.96.1.0">
+                      <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                      <dxl:Ident ColId="51" ColName="a" TypeMdid="0.23.1.0"/>
+                    </dxl:IsDistinctFrom>
+                  </dxl:Not>
+                </dxl:HashCondList>
+                <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.008771" Rows="111.000000" Width="12"/>
+                  </dxl:Properties>
+                  <dxl:GroupingColumns>
+                    <dxl:GroupingColumn ColId="0"/>
+                  </dxl:GroupingColumns>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="9" Alias="count">
+                      <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="">
+                        <dxl:ValuesList ParamType="aggargs">
+                          <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                        </dxl:ValuesList>
+                        <dxl:ValuesList ParamType="aggdirectargs"/>
+                        <dxl:ValuesList ParamType="aggorder"/>
+                        <dxl:ValuesList ParamType="aggdistinct"/>
+                      </dxl:AggFunc>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="0" Alias="a">
+                      <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.008175" Rows="111.000000" Width="4"/>
+                    </dxl:Properties>
+                    <dxl:GroupingColumns>
+                      <dxl:GroupingColumn ColId="0"/>
+                    </dxl:GroupingColumns>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="0" Alias="a">
+                        <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:Sort SortDiscardDuplicates="false">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.007829" Rows="111.000000" Width="4"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="0" Alias="a">
+                          <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="1" Alias="b">
+                          <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="2" Alias="ctid">
+                          <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="3" Alias="xmin">
+                          <dxl:Ident ColId="3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="4" Alias="cmin">
+                          <dxl:Ident ColId="4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="5" Alias="xmax">
+                          <dxl:Ident ColId="5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="6" Alias="cmax">
+                          <dxl:Ident ColId="6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="7" Alias="tableoid">
+                          <dxl:Ident ColId="7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="8" Alias="gp_segment_id">
+                          <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:SortingColumnList>
+                        <dxl:SortingColumn ColId="0" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                      </dxl:SortingColumnList>
+                      <dxl:LimitCount/>
+                      <dxl:LimitOffset/>
+                      <dxl:CTEConsumer CTEId="1" Columns="0,1,2,3,4,5,6,7,8">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000535" Rows="111.000000" Width="4"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="0" Alias="a">
+                            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="1" Alias="b">
+                            <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="2" Alias="ctid">
+                            <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="3" Alias="xmin">
+                            <dxl:Ident ColId="3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="4" Alias="cmin">
+                            <dxl:Ident ColId="4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="5" Alias="xmax">
+                            <dxl:Ident ColId="5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="6" Alias="cmax">
+                            <dxl:Ident ColId="6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="7" Alias="tableoid">
+                            <dxl:Ident ColId="7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="8" Alias="gp_segment_id">
+                            <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                      </dxl:CTEConsumer>
+                    </dxl:Sort>
+                  </dxl:Aggregate>
+                </dxl:Aggregate>
+                <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.017168" Rows="111.000000" Width="12"/>
+                  </dxl:Properties>
+                  <dxl:GroupingColumns>
+                    <dxl:GroupingColumn ColId="51"/>
+                  </dxl:GroupingColumns>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="10" Alias="count">
+                      <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="">
+                        <dxl:ValuesList ParamType="aggargs">
+                          <dxl:Ident ColId="52" ColName="b" TypeMdid="0.23.1.0"/>
+                        </dxl:ValuesList>
+                        <dxl:ValuesList ParamType="aggdirectargs"/>
+                        <dxl:ValuesList ParamType="aggorder"/>
+                        <dxl:ValuesList ParamType="aggdistinct"/>
+                      </dxl:AggFunc>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="51" Alias="a">
+                      <dxl:Ident ColId="51" ColName="a" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.016350" Rows="111.000000" Width="8"/>
+                    </dxl:Properties>
+                    <dxl:GroupingColumns>
+                      <dxl:GroupingColumn ColId="51"/>
+                      <dxl:GroupingColumn ColId="52"/>
+                    </dxl:GroupingColumns>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="51" Alias="a">
+                        <dxl:Ident ColId="51" ColName="a" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="52" Alias="b">
+                        <dxl:Ident ColId="52" ColName="b" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:Sort SortDiscardDuplicates="false">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.015657" Rows="111.000000" Width="8"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="51" Alias="a">
+                          <dxl:Ident ColId="51" ColName="a" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="52" Alias="b">
+                          <dxl:Ident ColId="52" ColName="b" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="53" Alias="ctid">
+                          <dxl:Ident ColId="53" ColName="ctid" TypeMdid="0.27.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="54" Alias="xmin">
+                          <dxl:Ident ColId="54" ColName="xmin" TypeMdid="0.28.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="55" Alias="cmin">
+                          <dxl:Ident ColId="55" ColName="cmin" TypeMdid="0.29.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="56" Alias="xmax">
+                          <dxl:Ident ColId="56" ColName="xmax" TypeMdid="0.28.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="57" Alias="cmax">
+                          <dxl:Ident ColId="57" ColName="cmax" TypeMdid="0.29.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="58" Alias="tableoid">
+                          <dxl:Ident ColId="58" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="59" Alias="gp_segment_id">
+                          <dxl:Ident ColId="59" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:SortingColumnList>
+                        <dxl:SortingColumn ColId="51" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                        <dxl:SortingColumn ColId="52" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                      </dxl:SortingColumnList>
+                      <dxl:LimitCount/>
+                      <dxl:LimitOffset/>
+                      <dxl:CTEConsumer CTEId="1" Columns="51,52,53,54,55,56,57,58,59">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.001070" Rows="111.000000" Width="8"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="51" Alias="a">
+                            <dxl:Ident ColId="51" ColName="a" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="52" Alias="b">
+                            <dxl:Ident ColId="52" ColName="b" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="53" Alias="ctid">
+                            <dxl:Ident ColId="53" ColName="ctid" TypeMdid="0.27.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="54" Alias="xmin">
+                            <dxl:Ident ColId="54" ColName="xmin" TypeMdid="0.28.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="55" Alias="cmin">
+                            <dxl:Ident ColId="55" ColName="cmin" TypeMdid="0.29.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="56" Alias="xmax">
+                            <dxl:Ident ColId="56" ColName="xmax" TypeMdid="0.28.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="57" Alias="cmax">
+                            <dxl:Ident ColId="57" ColName="cmax" TypeMdid="0.29.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="58" Alias="tableoid">
+                            <dxl:Ident ColId="58" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="59" Alias="gp_segment_id">
+                            <dxl:Ident ColId="59" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                      </dxl:CTEConsumer>
+                    </dxl:Sort>
+                  </dxl:Aggregate>
+                </dxl:Aggregate>
+              </dxl:HashJoin>
+            </dxl:Sequence>
+            <dxl:Sequence>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.018536" Rows="23.000000" Width="20"/>
+                <dxl:Cost StartupCost="0" TotalCost="1293.039175" Rows="23.000000" Width="20"/>
               </dxl:Properties>
-              <dxl:GroupingColumns>
-                <dxl:GroupingColumn ColId="12"/>
-              </dxl:GroupingColumns>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="12" Alias="b">
                   <dxl:Ident ColId="12" ColName="b" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
                 <dxl:ProjElem ColId="20" Alias="count">
-                  <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="true" AggStage="Normal" AggKind="n" >
-                    <dxl:ValuesList ParamType="aggargs">
-                      <dxl:Ident ColId="11" ColName="a" TypeMdid="0.23.1.0"/>
-                    </dxl:ValuesList>
-                    <dxl:ValuesList ParamType="aggdirectargs"/>
-                    <dxl:ValuesList ParamType="aggorder"/>
-                    <dxl:ValuesList ParamType="aggdistinct"/>
-                  </dxl:AggFunc>
+                  <dxl:Ident ColId="20" ColName="count" TypeMdid="0.20.1.0"/>
                 </dxl:ProjElem>
                 <dxl:ProjElem ColId="21" Alias="count">
-                  <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="true" AggStage="Normal" AggKind="n" >
-                    <dxl:ValuesList ParamType="aggargs">
-                      <dxl:Ident ColId="12" ColName="b" TypeMdid="0.23.1.0"/>
-                    </dxl:ValuesList>
-                    <dxl:ValuesList ParamType="aggdirectargs"/>
-                    <dxl:ValuesList ParamType="aggorder"/>
-                    <dxl:ValuesList ParamType="aggdistinct"/>
-                  </dxl:AggFunc>
+                  <dxl:Ident ColId="21" ColName="count" TypeMdid="0.20.1.0"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:Sort SortDiscardDuplicates="false">
+              <dxl:CTEProducer CTEId="0" Columns="22,23,24,25,26,27,28,29,30">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.017963" Rows="111.000000" Width="8"/>
+                  <dxl:Cost StartupCost="0" TotalCost="431.005138" Rows="111.000000" Width="1"/>
                 </dxl:Properties>
                 <dxl:ProjList>
-                  <dxl:ProjElem ColId="11" Alias="a">
-                    <dxl:Ident ColId="11" ColName="a" TypeMdid="0.23.1.0"/>
+                  <dxl:ProjElem ColId="22" Alias="a">
+                    <dxl:Ident ColId="22" ColName="a" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
+                  <dxl:ProjElem ColId="23" Alias="b">
+                    <dxl:Ident ColId="23" ColName="b" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="24" Alias="ctid">
+                    <dxl:Ident ColId="24" ColName="ctid" TypeMdid="0.27.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="25" Alias="xmin">
+                    <dxl:Ident ColId="25" ColName="xmin" TypeMdid="0.28.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="26" Alias="cmin">
+                    <dxl:Ident ColId="26" ColName="cmin" TypeMdid="0.29.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="27" Alias="xmax">
+                    <dxl:Ident ColId="27" ColName="xmax" TypeMdid="0.28.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="28" Alias="cmax">
+                    <dxl:Ident ColId="28" ColName="cmax" TypeMdid="0.29.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="29" Alias="tableoid">
+                    <dxl:Ident ColId="29" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="30" Alias="gp_segment_id">
+                    <dxl:Ident ColId="30" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:TableScan>
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.001160" Rows="111.000000" Width="38"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="22" Alias="a">
+                      <dxl:Ident ColId="22" ColName="a" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="23" Alias="b">
+                      <dxl:Ident ColId="23" ColName="b" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="24" Alias="ctid">
+                      <dxl:Ident ColId="24" ColName="ctid" TypeMdid="0.27.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="25" Alias="xmin">
+                      <dxl:Ident ColId="25" ColName="xmin" TypeMdid="0.28.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="26" Alias="cmin">
+                      <dxl:Ident ColId="26" ColName="cmin" TypeMdid="0.29.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="27" Alias="xmax">
+                      <dxl:Ident ColId="27" ColName="xmax" TypeMdid="0.28.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="28" Alias="cmax">
+                      <dxl:Ident ColId="28" ColName="cmax" TypeMdid="0.29.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="29" Alias="tableoid">
+                      <dxl:Ident ColId="29" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="30" Alias="gp_segment_id">
+                      <dxl:Ident ColId="30" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:TableDescriptor Mdid="6.1639448.1.1" TableName="t1">
+                    <dxl:Columns>
+                      <dxl:Column ColId="22" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+                      <dxl:Column ColId="23" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+                      <dxl:Column ColId="24" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                      <dxl:Column ColId="25" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                      <dxl:Column ColId="26" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                      <dxl:Column ColId="27" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                      <dxl:Column ColId="28" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                      <dxl:Column ColId="29" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                      <dxl:Column ColId="30" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                    </dxl:Columns>
+                  </dxl:TableDescriptor>
+                </dxl:TableScan>
+              </dxl:CTEProducer>
+              <dxl:HashJoin JoinType="Inner">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="862.033807" Rows="23.000000" Width="20"/>
+                </dxl:Properties>
+                <dxl:ProjList>
                   <dxl:ProjElem ColId="12" Alias="b">
                     <dxl:Ident ColId="12" ColName="b" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
+                  <dxl:ProjElem ColId="20" Alias="count">
+                    <dxl:Ident ColId="20" ColName="count" TypeMdid="0.20.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="21" Alias="count">
+                    <dxl:Ident ColId="21" ColName="count" TypeMdid="0.20.1.0"/>
+                  </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
-                <dxl:SortingColumnList>
-                  <dxl:SortingColumn ColId="12" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                </dxl:SortingColumnList>
-                <dxl:LimitCount/>
-                <dxl:LimitOffset/>
-                <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
+                <dxl:JoinFilter/>
+                <dxl:HashCondList>
+                  <dxl:Not>
+                    <dxl:IsDistinctFrom OperatorMdid="0.96.1.0">
+                      <dxl:Ident ColId="12" ColName="b" TypeMdid="0.23.1.0"/>
+                      <dxl:Ident ColId="32" ColName="b" TypeMdid="0.23.1.0"/>
+                    </dxl:IsDistinctFrom>
+                  </dxl:Not>
+                </dxl:HashCondList>
+                <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="false">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.003376" Rows="111.000000" Width="8"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.018084" Rows="23.000000" Width="12"/>
                   </dxl:Properties>
+                  <dxl:GroupingColumns>
+                    <dxl:GroupingColumn ColId="12"/>
+                  </dxl:GroupingColumns>
                   <dxl:ProjList>
-                    <dxl:ProjElem ColId="11" Alias="a">
-                      <dxl:Ident ColId="11" ColName="a" TypeMdid="0.23.1.0"/>
+                    <dxl:ProjElem ColId="20" Alias="count">
+                      <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="">
+                        <dxl:ValuesList ParamType="aggargs">
+                          <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.20.1.0"/>
+                        </dxl:ValuesList>
+                        <dxl:ValuesList ParamType="aggdirectargs"/>
+                        <dxl:ValuesList ParamType="aggorder"/>
+                        <dxl:ValuesList ParamType="aggdistinct"/>
+                      </dxl:AggFunc>
                     </dxl:ProjElem>
                     <dxl:ProjElem ColId="12" Alias="b">
                       <dxl:Ident ColId="12" ColName="b" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
-                  <dxl:SortingColumnList/>
-                  <dxl:HashExprList>
-                    <dxl:HashExpr>
-                      <dxl:Ident ColId="12" ColName="b" TypeMdid="0.23.1.0"/>
-                    </dxl:HashExpr>
-                  </dxl:HashExprList>
-                  <dxl:TableScan>
+                  <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.001160" Rows="111.000000" Width="8"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.016611" Rows="23.000000" Width="12"/>
                     </dxl:Properties>
                     <dxl:ProjList>
-                      <dxl:ProjElem ColId="11" Alias="a">
-                        <dxl:Ident ColId="11" ColName="a" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
                       <dxl:ProjElem ColId="12" Alias="b">
                         <dxl:Ident ColId="12" ColName="b" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
+                      <dxl:ProjElem ColId="41" Alias="ColRef_0041">
+                        <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.20.1.0"/>
+                      </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
-                    <dxl:TableDescriptor Mdid="6.1639448.1.1" TableName="t1">
-                      <dxl:Columns>
-                        <dxl:Column ColId="11" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-                        <dxl:Column ColId="12" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
-                        <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                        <dxl:Column ColId="14" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                        <dxl:Column ColId="15" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                        <dxl:Column ColId="16" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                        <dxl:Column ColId="17" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                        <dxl:Column ColId="18" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                        <dxl:Column ColId="19" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                      </dxl:Columns>
-                    </dxl:TableDescriptor>
-                  </dxl:TableScan>
-                </dxl:RedistributeMotion>
-              </dxl:Sort>
-            </dxl:Aggregate>
+                    <dxl:SortingColumnList/>
+                    <dxl:HashExprList>
+                      <dxl:HashExpr>
+                        <dxl:Ident ColId="12" ColName="b" TypeMdid="0.23.1.0"/>
+                      </dxl:HashExpr>
+                    </dxl:HashExprList>
+                    <dxl:Result>
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.016179" Rows="23.000000" Width="12"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="12" Alias="b">
+                          <dxl:Ident ColId="12" ColName="b" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="41" Alias="ColRef_0041">
+                          <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.20.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:OneTimeFilter/>
+                      <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.016179" Rows="23.000000" Width="12"/>
+                        </dxl:Properties>
+                        <dxl:GroupingColumns>
+                          <dxl:GroupingColumn ColId="12"/>
+                        </dxl:GroupingColumns>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="41" Alias="ColRef_0041">
+                            <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="true" AggStage="Partial" AggKind="n" AggArgTypes="">
+                              <dxl:ValuesList ParamType="aggargs">
+                                <dxl:Ident ColId="11" ColName="a" TypeMdid="0.23.1.0"/>
+                              </dxl:ValuesList>
+                              <dxl:ValuesList ParamType="aggdirectargs"/>
+                              <dxl:ValuesList ParamType="aggorder"/>
+                              <dxl:ValuesList ParamType="aggdistinct"/>
+                            </dxl:AggFunc>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="12" Alias="b">
+                            <dxl:Ident ColId="12" ColName="b" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:Sort SortDiscardDuplicates="false">
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="431.015657" Rows="111.000000" Width="8"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="11" Alias="a">
+                              <dxl:Ident ColId="11" ColName="a" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="12" Alias="b">
+                              <dxl:Ident ColId="12" ColName="b" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="13" Alias="ctid">
+                              <dxl:Ident ColId="13" ColName="ctid" TypeMdid="0.27.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="14" Alias="xmin">
+                              <dxl:Ident ColId="14" ColName="xmin" TypeMdid="0.28.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="15" Alias="cmin">
+                              <dxl:Ident ColId="15" ColName="cmin" TypeMdid="0.29.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="16" Alias="xmax">
+                              <dxl:Ident ColId="16" ColName="xmax" TypeMdid="0.28.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="17" Alias="cmax">
+                              <dxl:Ident ColId="17" ColName="cmax" TypeMdid="0.29.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="18" Alias="tableoid">
+                              <dxl:Ident ColId="18" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="19" Alias="gp_segment_id">
+                              <dxl:Ident ColId="19" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:SortingColumnList>
+                            <dxl:SortingColumn ColId="12" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                            <dxl:SortingColumn ColId="11" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                          </dxl:SortingColumnList>
+                          <dxl:LimitCount/>
+                          <dxl:LimitOffset/>
+                          <dxl:CTEConsumer CTEId="0" Columns="11,12,13,14,15,16,17,18,19">
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="0" TotalCost="431.001070" Rows="111.000000" Width="8"/>
+                            </dxl:Properties>
+                            <dxl:ProjList>
+                              <dxl:ProjElem ColId="11" Alias="a">
+                                <dxl:Ident ColId="11" ColName="a" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="12" Alias="b">
+                                <dxl:Ident ColId="12" ColName="b" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="13" Alias="ctid">
+                                <dxl:Ident ColId="13" ColName="ctid" TypeMdid="0.27.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="14" Alias="xmin">
+                                <dxl:Ident ColId="14" ColName="xmin" TypeMdid="0.28.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="15" Alias="cmin">
+                                <dxl:Ident ColId="15" ColName="cmin" TypeMdid="0.29.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="16" Alias="xmax">
+                                <dxl:Ident ColId="16" ColName="xmax" TypeMdid="0.28.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="17" Alias="cmax">
+                                <dxl:Ident ColId="17" ColName="cmax" TypeMdid="0.29.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="18" Alias="tableoid">
+                                <dxl:Ident ColId="18" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="19" Alias="gp_segment_id">
+                                <dxl:Ident ColId="19" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                            </dxl:ProjList>
+                          </dxl:CTEConsumer>
+                        </dxl:Sort>
+                      </dxl:Aggregate>
+                    </dxl:Result>
+                  </dxl:RedistributeMotion>
+                </dxl:Aggregate>
+                <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.008553" Rows="23.000000" Width="12"/>
+                  </dxl:Properties>
+                  <dxl:GroupingColumns>
+                    <dxl:GroupingColumn ColId="32"/>
+                  </dxl:GroupingColumns>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="21" Alias="count">
+                      <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="">
+                        <dxl:ValuesList ParamType="aggargs">
+                          <dxl:Ident ColId="32" ColName="b" TypeMdid="0.23.1.0"/>
+                        </dxl:ValuesList>
+                        <dxl:ValuesList ParamType="aggdirectargs"/>
+                        <dxl:ValuesList ParamType="aggorder"/>
+                        <dxl:ValuesList ParamType="aggdistinct"/>
+                      </dxl:AggFunc>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="32" Alias="b">
+                      <dxl:Ident ColId="32" ColName="b" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.008430" Rows="23.000000" Width="4"/>
+                    </dxl:Properties>
+                    <dxl:GroupingColumns>
+                      <dxl:GroupingColumn ColId="32"/>
+                    </dxl:GroupingColumns>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="32" Alias="b">
+                        <dxl:Ident ColId="32" ColName="b" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:Sort SortDiscardDuplicates="false">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.008358" Rows="23.000000" Width="4"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="32" Alias="b">
+                          <dxl:Ident ColId="32" ColName="b" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:SortingColumnList>
+                        <dxl:SortingColumn ColId="32" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                      </dxl:SortingColumnList>
+                      <dxl:LimitCount/>
+                      <dxl:LimitOffset/>
+                      <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.007439" Rows="23.000000" Width="4"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="32" Alias="b">
+                            <dxl:Ident ColId="32" ColName="b" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:SortingColumnList/>
+                        <dxl:HashExprList>
+                          <dxl:HashExpr>
+                            <dxl:Ident ColId="32" ColName="b" TypeMdid="0.23.1.0"/>
+                          </dxl:HashExpr>
+                        </dxl:HashExprList>
+                        <dxl:Aggregate AggregationStrategy="Hashed" StreamSafe="true">
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="431.007295" Rows="23.000000" Width="4"/>
+                          </dxl:Properties>
+                          <dxl:GroupingColumns>
+                            <dxl:GroupingColumn ColId="32"/>
+                          </dxl:GroupingColumns>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="32" Alias="b">
+                              <dxl:Ident ColId="32" ColName="b" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:CTEConsumer CTEId="0" Columns="31,32,33,34,35,36,37,38,39">
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="0" TotalCost="431.000535" Rows="111.000000" Width="4"/>
+                            </dxl:Properties>
+                            <dxl:ProjList>
+                              <dxl:ProjElem ColId="31" Alias="a">
+                                <dxl:Ident ColId="31" ColName="a" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="32" Alias="b">
+                                <dxl:Ident ColId="32" ColName="b" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="33" Alias="ctid">
+                                <dxl:Ident ColId="33" ColName="ctid" TypeMdid="0.27.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="34" Alias="xmin">
+                                <dxl:Ident ColId="34" ColName="xmin" TypeMdid="0.28.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="35" Alias="cmin">
+                                <dxl:Ident ColId="35" ColName="cmin" TypeMdid="0.29.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="36" Alias="xmax">
+                                <dxl:Ident ColId="36" ColName="xmax" TypeMdid="0.28.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="37" Alias="cmax">
+                                <dxl:Ident ColId="37" ColName="cmax" TypeMdid="0.29.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="38" Alias="tableoid">
+                                <dxl:Ident ColId="38" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="39" Alias="gp_segment_id">
+                                <dxl:Ident ColId="39" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                            </dxl:ProjList>
+                          </dxl:CTEConsumer>
+                        </dxl:Aggregate>
+                      </dxl:RedistributeMotion>
+                    </dxl:Sort>
+                  </dxl:Aggregate>
+                </dxl:Aggregate>
+              </dxl:HashJoin>
+            </dxl:Sequence>
           </dxl:Append>
         </dxl:Aggregate>
       </dxl:GatherMotion>

--- a/src/backend/gporca/data/dxl/minidump/MDQAs1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MDQAs1.mdp
@@ -461,78 +461,357 @@ SQL:
         </dxl:LogicalGet>
       </dxl:LogicalGroupBy>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="1">
-      <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+    <dxl:Plan Id="0" SpaceSize="1488">
+      <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="431.006371" Rows="1.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="1724.007238" Rows="1.000000" Width="16"/>
         </dxl:Properties>
-        <dxl:GroupingColumns/>
         <dxl:ProjList>
           <dxl:ProjElem ColId="9" Alias="sum">
-            <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="true" AggStage="Normal" AggKind="n" >
-              <dxl:ValuesList ParamType="aggargs">
-                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-              </dxl:ValuesList>
-              <dxl:ValuesList ParamType="aggdirectargs"/>
-              <dxl:ValuesList ParamType="aggorder"/>
-              <dxl:ValuesList ParamType="aggdistinct"/>
-            </dxl:AggFunc>
+            <dxl:Ident ColId="9" ColName="sum" TypeMdid="0.20.1.0"/>
           </dxl:ProjElem>
           <dxl:ProjElem ColId="10" Alias="avg">
-            <dxl:AggFunc AggMdid="0.2101.1.0" AggDistinct="true" AggStage="Normal" AggKind="n" >
-              <dxl:ValuesList ParamType="aggargs">
-                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-              </dxl:ValuesList>
-              <dxl:ValuesList ParamType="aggdirectargs"/>
-              <dxl:ValuesList ParamType="aggorder"/>
-              <dxl:ValuesList ParamType="aggdistinct"/>
-            </dxl:AggFunc>
+            <dxl:Ident ColId="10" ColName="avg" TypeMdid="0.1700.1.0"/>
           </dxl:ProjElem>
         </dxl:ProjList>
         <dxl:Filter/>
-        <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+        <dxl:SortingColumnList/>
+        <dxl:Sequence>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="431.005973" Rows="111.000000" Width="8"/>
+            <dxl:Cost StartupCost="0" TotalCost="1724.007166" Rows="1.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
-            <dxl:ProjElem ColId="0" Alias="a">
-              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+            <dxl:ProjElem ColId="9" Alias="sum">
+              <dxl:Ident ColId="9" ColName="sum" TypeMdid="0.20.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="1" Alias="b">
-              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+            <dxl:ProjElem ColId="10" Alias="avg">
+              <dxl:Ident ColId="10" ColName="avg" TypeMdid="0.1700.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
-          <dxl:Filter/>
-          <dxl:SortingColumnList/>
-          <dxl:TableScan>
+          <dxl:CTEProducer CTEId="0" Columns="11,12,13,14,15,16,17,18,19">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.001160" Rows="111.000000" Width="8"/>
+              <dxl:Cost StartupCost="0" TotalCost="431.005138" Rows="111.000000" Width="1"/>
             </dxl:Properties>
             <dxl:ProjList>
-              <dxl:ProjElem ColId="0" Alias="a">
-                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+              <dxl:ProjElem ColId="11" Alias="a">
+                <dxl:Ident ColId="11" ColName="a" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="1" Alias="b">
-                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ProjElem ColId="12" Alias="b">
+                <dxl:Ident ColId="12" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="13" Alias="ctid">
+                <dxl:Ident ColId="13" ColName="ctid" TypeMdid="0.27.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="14" Alias="xmin">
+                <dxl:Ident ColId="14" ColName="xmin" TypeMdid="0.28.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="15" Alias="cmin">
+                <dxl:Ident ColId="15" ColName="cmin" TypeMdid="0.29.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="16" Alias="xmax">
+                <dxl:Ident ColId="16" ColName="xmax" TypeMdid="0.28.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="17" Alias="cmax">
+                <dxl:Ident ColId="17" ColName="cmax" TypeMdid="0.29.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="18" Alias="tableoid">
+                <dxl:Ident ColId="18" ColName="tableoid" TypeMdid="0.26.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="19" Alias="gp_segment_id">
+                <dxl:Ident ColId="19" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:TableScan>
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.001160" Rows="111.000000" Width="38"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="11" Alias="a">
+                  <dxl:Ident ColId="11" ColName="a" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="12" Alias="b">
+                  <dxl:Ident ColId="12" ColName="b" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="13" Alias="ctid">
+                  <dxl:Ident ColId="13" ColName="ctid" TypeMdid="0.27.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="14" Alias="xmin">
+                  <dxl:Ident ColId="14" ColName="xmin" TypeMdid="0.28.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="15" Alias="cmin">
+                  <dxl:Ident ColId="15" ColName="cmin" TypeMdid="0.29.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="16" Alias="xmax">
+                  <dxl:Ident ColId="16" ColName="xmax" TypeMdid="0.28.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="17" Alias="cmax">
+                  <dxl:Ident ColId="17" ColName="cmax" TypeMdid="0.29.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="18" Alias="tableoid">
+                  <dxl:Ident ColId="18" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="19" Alias="gp_segment_id">
+                  <dxl:Ident ColId="19" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:TableDescriptor Mdid="6.1639448.1.1" TableName="t1">
+                <dxl:Columns>
+                  <dxl:Column ColId="11" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="12" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                  <dxl:Column ColId="14" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                  <dxl:Column ColId="15" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                  <dxl:Column ColId="16" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                  <dxl:Column ColId="17" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                  <dxl:Column ColId="18" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                  <dxl:Column ColId="19" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:TableScan>
+          </dxl:CTEProducer>
+          <dxl:RandomMotion InputSegments="-1" OutputSegments="0,1">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="1293.002020" Rows="1.000000" Width="16"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="9" Alias="sum">
+                <dxl:Ident ColId="9" ColName="sum" TypeMdid="0.20.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="10" Alias="avg">
+                <dxl:Ident ColId="10" ColName="avg" TypeMdid="0.1700.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:TableDescriptor Mdid="6.1639448.1.1" TableName="t1">
-              <dxl:Columns>
-                <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-                <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
-                <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-              </dxl:Columns>
-            </dxl:TableDescriptor>
-          </dxl:TableScan>
-        </dxl:GatherMotion>
-      </dxl:Aggregate>
+            <dxl:SortingColumnList/>
+            <dxl:NestedLoopJoin JoinType="Inner" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="1293.001976" Rows="1.000000" Width="16"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="9" Alias="sum">
+                  <dxl:Ident ColId="9" ColName="sum" TypeMdid="0.20.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="10" Alias="avg">
+                  <dxl:Ident ColId="10" ColName="avg" TypeMdid="0.1700.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:JoinFilter>
+                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+              </dxl:JoinFilter>
+              <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000597" Rows="1.000000" Width="8"/>
+                </dxl:Properties>
+                <dxl:GroupingColumns/>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="9" Alias="sum">
+                    <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="">
+                      <dxl:ValuesList ParamType="aggargs">
+                        <dxl:Ident ColId="30" ColName="ColRef_0030" TypeMdid="0.20.1.0"/>
+                      </dxl:ValuesList>
+                      <dxl:ValuesList ParamType="aggdirectargs"/>
+                      <dxl:ValuesList ParamType="aggorder"/>
+                      <dxl:ValuesList ParamType="aggdistinct"/>
+                    </dxl:AggFunc>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000596" Rows="1.000000" Width="8"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="30" Alias="ColRef_0030">
+                      <dxl:Ident ColId="30" ColName="ColRef_0030" TypeMdid="0.20.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:SortingColumnList/>
+                  <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000560" Rows="1.000000" Width="8"/>
+                    </dxl:Properties>
+                    <dxl:GroupingColumns/>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="30" Alias="ColRef_0030">
+                        <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="true" AggStage="Partial" AggKind="n" AggArgTypes="">
+                          <dxl:ValuesList ParamType="aggargs">
+                            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                          </dxl:ValuesList>
+                          <dxl:ValuesList ParamType="aggdirectargs"/>
+                          <dxl:ValuesList ParamType="aggorder"/>
+                          <dxl:ValuesList ParamType="aggdistinct"/>
+                        </dxl:AggFunc>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:CTEConsumer CTEId="0" Columns="0,1,2,3,4,5,6,7,8">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000535" Rows="111.000000" Width="4"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="0" Alias="a">
+                          <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="1" Alias="b">
+                          <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="2" Alias="ctid">
+                          <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="3" Alias="xmin">
+                          <dxl:Ident ColId="3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="4" Alias="cmin">
+                          <dxl:Ident ColId="4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="5" Alias="xmax">
+                          <dxl:Ident ColId="5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="6" Alias="cmax">
+                          <dxl:Ident ColId="6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="7" Alias="tableoid">
+                          <dxl:Ident ColId="7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="8" Alias="gp_segment_id">
+                          <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                    </dxl:CTEConsumer>
+                  </dxl:Aggregate>
+                </dxl:GatherMotion>
+              </dxl:Aggregate>
+              <dxl:Materialize Eager="true">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.001300" Rows="1.000000" Width="8"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="10" Alias="avg">
+                    <dxl:Ident ColId="10" ColName="avg" TypeMdid="0.1700.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.001292" Rows="1.000000" Width="8"/>
+                  </dxl:Properties>
+                  <dxl:GroupingColumns/>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="10" Alias="avg">
+                      <dxl:AggFunc AggMdid="0.2101.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="">
+                        <dxl:ValuesList ParamType="aggargs">
+                          <dxl:Ident ColId="29" ColName="ColRef_0029" TypeMdid="0.17.1.0"/>
+                        </dxl:ValuesList>
+                        <dxl:ValuesList ParamType="aggdirectargs"/>
+                        <dxl:ValuesList ParamType="aggorder"/>
+                        <dxl:ValuesList ParamType="aggdistinct"/>
+                      </dxl:AggFunc>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.001291" Rows="1.000000" Width="8"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="29" Alias="ColRef_0029">
+                        <dxl:Ident ColId="29" ColName="ColRef_0029" TypeMdid="0.17.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:SortingColumnList/>
+                    <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.001255" Rows="1.000000" Width="8"/>
+                      </dxl:Properties>
+                      <dxl:GroupingColumns/>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="29" Alias="ColRef_0029">
+                          <dxl:AggFunc AggMdid="0.2101.1.0" AggDistinct="true" AggStage="Partial" AggKind="n" AggArgTypes="">
+                            <dxl:ValuesList ParamType="aggargs">
+                              <dxl:Ident ColId="21" ColName="b" TypeMdid="0.23.1.0"/>
+                            </dxl:ValuesList>
+                            <dxl:ValuesList ParamType="aggdirectargs"/>
+                            <dxl:ValuesList ParamType="aggorder"/>
+                            <dxl:ValuesList ParamType="aggdistinct"/>
+                          </dxl:AggFunc>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.001230" Rows="111.000000" Width="4"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="21" Alias="b">
+                            <dxl:Ident ColId="21" ColName="b" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:SortingColumnList/>
+                        <dxl:HashExprList>
+                          <dxl:HashExpr>
+                            <dxl:Ident ColId="21" ColName="b" TypeMdid="0.23.1.0"/>
+                          </dxl:HashExpr>
+                        </dxl:HashExprList>
+                        <dxl:Result>
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000535" Rows="111.000000" Width="4"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="21" Alias="b">
+                              <dxl:Ident ColId="21" ColName="b" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:OneTimeFilter/>
+                          <dxl:CTEConsumer CTEId="0" Columns="20,21,22,23,24,25,26,27,28">
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="0" TotalCost="431.000535" Rows="111.000000" Width="4"/>
+                            </dxl:Properties>
+                            <dxl:ProjList>
+                              <dxl:ProjElem ColId="20" Alias="a">
+                                <dxl:Ident ColId="20" ColName="a" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="21" Alias="b">
+                                <dxl:Ident ColId="21" ColName="b" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="22" Alias="ctid">
+                                <dxl:Ident ColId="22" ColName="ctid" TypeMdid="0.27.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="23" Alias="xmin">
+                                <dxl:Ident ColId="23" ColName="xmin" TypeMdid="0.28.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="24" Alias="cmin">
+                                <dxl:Ident ColId="24" ColName="cmin" TypeMdid="0.29.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="25" Alias="xmax">
+                                <dxl:Ident ColId="25" ColName="xmax" TypeMdid="0.28.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="26" Alias="cmax">
+                                <dxl:Ident ColId="26" ColName="cmax" TypeMdid="0.29.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="27" Alias="tableoid">
+                                <dxl:Ident ColId="27" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="28" Alias="gp_segment_id">
+                                <dxl:Ident ColId="28" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                            </dxl:ProjList>
+                          </dxl:CTEConsumer>
+                        </dxl:Result>
+                      </dxl:RedistributeMotion>
+                    </dxl:Aggregate>
+                  </dxl:GatherMotion>
+                </dxl:Aggregate>
+              </dxl:Materialize>
+            </dxl:NestedLoopJoin>
+          </dxl:RandomMotion>
+        </dxl:Sequence>
+      </dxl:GatherMotion>
     </dxl:Plan>
   </dxl:Thread>
 </dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/Union-On-HJNs.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Union-On-HJNs.mdp
@@ -509,7 +509,7 @@
     <dxl:Plan Id="0" SpaceSize="0">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="3448.014729" Rows="2.000000" Width="32"/>
+          <dxl:Cost StartupCost="0" TotalCost="5172.042308" Rows="2.000000" Width="32"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -529,7 +529,7 @@
         <dxl:SortingColumnList/>
         <dxl:Append IsTarget="false" IsZapped="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="3448.014441" Rows="2.000000" Width="32"/>
+            <dxl:Cost StartupCost="0" TotalCost="5172.042020" Rows="2.000000" Width="32"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -546,14 +546,10 @@
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
-          <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+          <dxl:Sequence>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1724.007600" Rows="1.000000" Width="32"/>
+              <dxl:Cost StartupCost="0" TotalCost="2586.021121" Rows="1.000000" Width="32"/>
             </dxl:Properties>
-            <dxl:GroupingColumns>
-              <dxl:GroupingColumn ColId="0"/>
-              <dxl:GroupingColumn ColId="1"/>
-            </dxl:GroupingColumns>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
                 <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
@@ -562,171 +558,575 @@
                 <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
               <dxl:ProjElem ColId="41" Alias="count">
-                <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="true" AggStage="Normal" AggKind="n">
-                  <dxl:ValuesList ParamType="aggargs">
-                    <dxl:Ident ColId="2" ColName="x" TypeMdid="0.23.1.0"/>
-                  </dxl:ValuesList>
-                  <dxl:ValuesList ParamType="aggdirectargs"/>
-                  <dxl:ValuesList ParamType="aggorder"/>
-                  <dxl:ValuesList ParamType="aggdistinct"/>
-                </dxl:AggFunc>
+                <dxl:Ident ColId="41" ColName="count" TypeMdid="0.20.1.0"/>
               </dxl:ProjElem>
               <dxl:ProjElem ColId="42" Alias="count">
-                <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="true" AggStage="Normal" AggKind="n">
-                  <dxl:ValuesList ParamType="aggargs">
-                    <dxl:Ident ColId="3" ColName="y" TypeMdid="0.23.1.0"/>
-                  </dxl:ValuesList>
-                  <dxl:ValuesList ParamType="aggdirectargs"/>
-                  <dxl:ValuesList ParamType="aggorder"/>
-                  <dxl:ValuesList ParamType="aggdistinct"/>
-                </dxl:AggFunc>
+                <dxl:Ident ColId="42" ColName="count" TypeMdid="0.20.1.0"/>
               </dxl:ProjElem>
             </dxl:ProjList>
-            <dxl:Filter/>
-            <dxl:Sort SortDiscardDuplicates="false">
+            <dxl:CTEProducer CTEId="1" Columns="177,178,179,180,181,182,183,184,185,186,187,188,189,190,191,192,193,194,195,196,197,198,199,200,201,202,203,204,205,206,207,208,209,210,211">
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1724.007463" Rows="8.000000" Width="32"/>
+                <dxl:Cost StartupCost="0" TotalCost="1724.020401" Rows="8.000000" Width="1"/>
               </dxl:Properties>
               <dxl:ProjList>
-                <dxl:ProjElem ColId="0" Alias="a">
-                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                <dxl:ProjElem ColId="177" Alias="a">
+                  <dxl:Ident ColId="177" ColName="a" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
-                <dxl:ProjElem ColId="1" Alias="b">
-                  <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                <dxl:ProjElem ColId="178" Alias="b">
+                  <dxl:Ident ColId="178" ColName="b" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
-                <dxl:ProjElem ColId="2" Alias="x">
-                  <dxl:Ident ColId="2" ColName="x" TypeMdid="0.23.1.0"/>
+                <dxl:ProjElem ColId="179" Alias="x">
+                  <dxl:Ident ColId="179" ColName="x" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
-                <dxl:ProjElem ColId="3" Alias="y">
-                  <dxl:Ident ColId="3" ColName="y" TypeMdid="0.23.1.0"/>
+                <dxl:ProjElem ColId="180" Alias="y">
+                  <dxl:Ident ColId="180" ColName="y" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="181" Alias="ctid">
+                  <dxl:Ident ColId="181" ColName="ctid" TypeMdid="0.27.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="182" Alias="xmin">
+                  <dxl:Ident ColId="182" ColName="xmin" TypeMdid="0.28.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="183" Alias="cmin">
+                  <dxl:Ident ColId="183" ColName="cmin" TypeMdid="0.29.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="184" Alias="xmax">
+                  <dxl:Ident ColId="184" ColName="xmax" TypeMdid="0.28.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="185" Alias="cmax">
+                  <dxl:Ident ColId="185" ColName="cmax" TypeMdid="0.29.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="186" Alias="tableoid">
+                  <dxl:Ident ColId="186" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="187" Alias="gp_segment_id">
+                  <dxl:Ident ColId="187" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="188" Alias="c">
+                  <dxl:Ident ColId="188" ColName="c" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="189" Alias="ctid">
+                  <dxl:Ident ColId="189" ColName="ctid" TypeMdid="0.27.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="190" Alias="xmin">
+                  <dxl:Ident ColId="190" ColName="xmin" TypeMdid="0.28.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="191" Alias="cmin">
+                  <dxl:Ident ColId="191" ColName="cmin" TypeMdid="0.29.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="192" Alias="xmax">
+                  <dxl:Ident ColId="192" ColName="xmax" TypeMdid="0.28.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="193" Alias="cmax">
+                  <dxl:Ident ColId="193" ColName="cmax" TypeMdid="0.29.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="194" Alias="tableoid">
+                  <dxl:Ident ColId="194" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="195" Alias="gp_segment_id">
+                  <dxl:Ident ColId="195" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="196" Alias="d">
+                  <dxl:Ident ColId="196" ColName="d" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="197" Alias="ctid">
+                  <dxl:Ident ColId="197" ColName="ctid" TypeMdid="0.27.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="198" Alias="xmin">
+                  <dxl:Ident ColId="198" ColName="xmin" TypeMdid="0.28.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="199" Alias="cmin">
+                  <dxl:Ident ColId="199" ColName="cmin" TypeMdid="0.29.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="200" Alias="xmax">
+                  <dxl:Ident ColId="200" ColName="xmax" TypeMdid="0.28.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="201" Alias="cmax">
+                  <dxl:Ident ColId="201" ColName="cmax" TypeMdid="0.29.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="202" Alias="tableoid">
+                  <dxl:Ident ColId="202" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="203" Alias="gp_segment_id">
+                  <dxl:Ident ColId="203" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="204" Alias="e">
+                  <dxl:Ident ColId="204" ColName="e" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="205" Alias="ctid">
+                  <dxl:Ident ColId="205" ColName="ctid" TypeMdid="0.27.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="206" Alias="xmin">
+                  <dxl:Ident ColId="206" ColName="xmin" TypeMdid="0.28.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="207" Alias="cmin">
+                  <dxl:Ident ColId="207" ColName="cmin" TypeMdid="0.29.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="208" Alias="xmax">
+                  <dxl:Ident ColId="208" ColName="xmax" TypeMdid="0.28.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="209" Alias="cmax">
+                  <dxl:Ident ColId="209" ColName="cmax" TypeMdid="0.29.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="210" Alias="tableoid">
+                  <dxl:Ident ColId="210" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="211" Alias="gp_segment_id">
+                  <dxl:Ident ColId="211" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:SortingColumnList>
-                <dxl:SortingColumn ColId="0" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                <dxl:SortingColumn ColId="1" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-              </dxl:SortingColumnList>
-              <dxl:LimitCount/>
-              <dxl:LimitOffset/>
               <dxl:HashJoin JoinType="Inner">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1724.006011" Rows="8.000000" Width="32"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1724.020397" Rows="8.000000" Width="152"/>
                 </dxl:Properties>
                 <dxl:ProjList>
-                  <dxl:ProjElem ColId="0" Alias="a">
-                    <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                  <dxl:ProjElem ColId="177" Alias="a">
+                    <dxl:Ident ColId="177" ColName="a" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
-                  <dxl:ProjElem ColId="1" Alias="b">
-                    <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                  <dxl:ProjElem ColId="178" Alias="b">
+                    <dxl:Ident ColId="178" ColName="b" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
-                  <dxl:ProjElem ColId="2" Alias="x">
-                    <dxl:Ident ColId="2" ColName="x" TypeMdid="0.23.1.0"/>
+                  <dxl:ProjElem ColId="179" Alias="x">
+                    <dxl:Ident ColId="179" ColName="x" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
-                  <dxl:ProjElem ColId="3" Alias="y">
-                    <dxl:Ident ColId="3" ColName="y" TypeMdid="0.23.1.0"/>
+                  <dxl:ProjElem ColId="180" Alias="y">
+                    <dxl:Ident ColId="180" ColName="y" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="181" Alias="ctid">
+                    <dxl:Ident ColId="181" ColName="ctid" TypeMdid="0.27.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="182" Alias="xmin">
+                    <dxl:Ident ColId="182" ColName="xmin" TypeMdid="0.28.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="183" Alias="cmin">
+                    <dxl:Ident ColId="183" ColName="cmin" TypeMdid="0.29.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="184" Alias="xmax">
+                    <dxl:Ident ColId="184" ColName="xmax" TypeMdid="0.28.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="185" Alias="cmax">
+                    <dxl:Ident ColId="185" ColName="cmax" TypeMdid="0.29.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="186" Alias="tableoid">
+                    <dxl:Ident ColId="186" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="187" Alias="gp_segment_id">
+                    <dxl:Ident ColId="187" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="188" Alias="c">
+                    <dxl:Ident ColId="188" ColName="c" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="189" Alias="ctid">
+                    <dxl:Ident ColId="189" ColName="ctid" TypeMdid="0.27.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="190" Alias="xmin">
+                    <dxl:Ident ColId="190" ColName="xmin" TypeMdid="0.28.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="191" Alias="cmin">
+                    <dxl:Ident ColId="191" ColName="cmin" TypeMdid="0.29.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="192" Alias="xmax">
+                    <dxl:Ident ColId="192" ColName="xmax" TypeMdid="0.28.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="193" Alias="cmax">
+                    <dxl:Ident ColId="193" ColName="cmax" TypeMdid="0.29.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="194" Alias="tableoid">
+                    <dxl:Ident ColId="194" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="195" Alias="gp_segment_id">
+                    <dxl:Ident ColId="195" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="196" Alias="d">
+                    <dxl:Ident ColId="196" ColName="d" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="197" Alias="ctid">
+                    <dxl:Ident ColId="197" ColName="ctid" TypeMdid="0.27.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="198" Alias="xmin">
+                    <dxl:Ident ColId="198" ColName="xmin" TypeMdid="0.28.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="199" Alias="cmin">
+                    <dxl:Ident ColId="199" ColName="cmin" TypeMdid="0.29.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="200" Alias="xmax">
+                    <dxl:Ident ColId="200" ColName="xmax" TypeMdid="0.28.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="201" Alias="cmax">
+                    <dxl:Ident ColId="201" ColName="cmax" TypeMdid="0.29.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="202" Alias="tableoid">
+                    <dxl:Ident ColId="202" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="203" Alias="gp_segment_id">
+                    <dxl:Ident ColId="203" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="204" Alias="e">
+                    <dxl:Ident ColId="204" ColName="e" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="205" Alias="ctid">
+                    <dxl:Ident ColId="205" ColName="ctid" TypeMdid="0.27.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="206" Alias="xmin">
+                    <dxl:Ident ColId="206" ColName="xmin" TypeMdid="0.28.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="207" Alias="cmin">
+                    <dxl:Ident ColId="207" ColName="cmin" TypeMdid="0.29.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="208" Alias="xmax">
+                    <dxl:Ident ColId="208" ColName="xmax" TypeMdid="0.28.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="209" Alias="cmax">
+                    <dxl:Ident ColId="209" ColName="cmax" TypeMdid="0.29.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="210" Alias="tableoid">
+                    <dxl:Ident ColId="210" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="211" Alias="gp_segment_id">
+                    <dxl:Ident ColId="211" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
                 <dxl:Filter/>
                 <dxl:JoinFilter/>
                 <dxl:HashCondList>
                   <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                    <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                    <dxl:Ident ColId="33" ColName="e" TypeMdid="0.23.1.0"/>
+                    <dxl:Ident ColId="177" ColName="a" TypeMdid="0.23.1.0"/>
+                    <dxl:Ident ColId="204" ColName="e" TypeMdid="0.23.1.0"/>
                   </dxl:Comparison>
                 </dxl:HashCondList>
                 <dxl:HashJoin JoinType="Inner">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1293.003855" Rows="8.000000" Width="32"/>
+                    <dxl:Cost StartupCost="0" TotalCost="1293.013028" Rows="8.000000" Width="118"/>
                   </dxl:Properties>
                   <dxl:ProjList>
-                    <dxl:ProjElem ColId="0" Alias="a">
-                      <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                    <dxl:ProjElem ColId="177" Alias="a">
+                      <dxl:Ident ColId="177" ColName="a" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
-                    <dxl:ProjElem ColId="1" Alias="b">
-                      <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:ProjElem ColId="178" Alias="b">
+                      <dxl:Ident ColId="178" ColName="b" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
-                    <dxl:ProjElem ColId="2" Alias="x">
-                      <dxl:Ident ColId="2" ColName="x" TypeMdid="0.23.1.0"/>
+                    <dxl:ProjElem ColId="179" Alias="x">
+                      <dxl:Ident ColId="179" ColName="x" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
-                    <dxl:ProjElem ColId="3" Alias="y">
-                      <dxl:Ident ColId="3" ColName="y" TypeMdid="0.23.1.0"/>
+                    <dxl:ProjElem ColId="180" Alias="y">
+                      <dxl:Ident ColId="180" ColName="y" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="181" Alias="ctid">
+                      <dxl:Ident ColId="181" ColName="ctid" TypeMdid="0.27.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="182" Alias="xmin">
+                      <dxl:Ident ColId="182" ColName="xmin" TypeMdid="0.28.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="183" Alias="cmin">
+                      <dxl:Ident ColId="183" ColName="cmin" TypeMdid="0.29.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="184" Alias="xmax">
+                      <dxl:Ident ColId="184" ColName="xmax" TypeMdid="0.28.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="185" Alias="cmax">
+                      <dxl:Ident ColId="185" ColName="cmax" TypeMdid="0.29.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="186" Alias="tableoid">
+                      <dxl:Ident ColId="186" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="187" Alias="gp_segment_id">
+                      <dxl:Ident ColId="187" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="188" Alias="c">
+                      <dxl:Ident ColId="188" ColName="c" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="189" Alias="ctid">
+                      <dxl:Ident ColId="189" ColName="ctid" TypeMdid="0.27.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="190" Alias="xmin">
+                      <dxl:Ident ColId="190" ColName="xmin" TypeMdid="0.28.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="191" Alias="cmin">
+                      <dxl:Ident ColId="191" ColName="cmin" TypeMdid="0.29.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="192" Alias="xmax">
+                      <dxl:Ident ColId="192" ColName="xmax" TypeMdid="0.28.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="193" Alias="cmax">
+                      <dxl:Ident ColId="193" ColName="cmax" TypeMdid="0.29.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="194" Alias="tableoid">
+                      <dxl:Ident ColId="194" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="195" Alias="gp_segment_id">
+                      <dxl:Ident ColId="195" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="196" Alias="d">
+                      <dxl:Ident ColId="196" ColName="d" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="197" Alias="ctid">
+                      <dxl:Ident ColId="197" ColName="ctid" TypeMdid="0.27.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="198" Alias="xmin">
+                      <dxl:Ident ColId="198" ColName="xmin" TypeMdid="0.28.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="199" Alias="cmin">
+                      <dxl:Ident ColId="199" ColName="cmin" TypeMdid="0.29.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="200" Alias="xmax">
+                      <dxl:Ident ColId="200" ColName="xmax" TypeMdid="0.28.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="201" Alias="cmax">
+                      <dxl:Ident ColId="201" ColName="cmax" TypeMdid="0.29.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="202" Alias="tableoid">
+                      <dxl:Ident ColId="202" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="203" Alias="gp_segment_id">
+                      <dxl:Ident ColId="203" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
                   <dxl:JoinFilter/>
                   <dxl:HashCondList>
                     <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                      <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                      <dxl:Ident ColId="22" ColName="d" TypeMdid="0.23.1.0"/>
+                      <dxl:Ident ColId="177" ColName="a" TypeMdid="0.23.1.0"/>
+                      <dxl:Ident ColId="196" ColName="d" TypeMdid="0.23.1.0"/>
                     </dxl:Comparison>
                   </dxl:HashCondList>
                   <dxl:HashJoin JoinType="Inner">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="862.001698" Rows="8.000000" Width="32"/>
+                      <dxl:Cost StartupCost="0" TotalCost="862.005318" Rows="8.000000" Width="84"/>
                     </dxl:Properties>
                     <dxl:ProjList>
-                      <dxl:ProjElem ColId="0" Alias="a">
-                        <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                      <dxl:ProjElem ColId="177" Alias="a">
+                        <dxl:Ident ColId="177" ColName="a" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
-                      <dxl:ProjElem ColId="1" Alias="b">
-                        <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                      <dxl:ProjElem ColId="178" Alias="b">
+                        <dxl:Ident ColId="178" ColName="b" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
-                      <dxl:ProjElem ColId="2" Alias="x">
-                        <dxl:Ident ColId="2" ColName="x" TypeMdid="0.23.1.0"/>
+                      <dxl:ProjElem ColId="179" Alias="x">
+                        <dxl:Ident ColId="179" ColName="x" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
-                      <dxl:ProjElem ColId="3" Alias="y">
-                        <dxl:Ident ColId="3" ColName="y" TypeMdid="0.23.1.0"/>
+                      <dxl:ProjElem ColId="180" Alias="y">
+                        <dxl:Ident ColId="180" ColName="y" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="181" Alias="ctid">
+                        <dxl:Ident ColId="181" ColName="ctid" TypeMdid="0.27.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="182" Alias="xmin">
+                        <dxl:Ident ColId="182" ColName="xmin" TypeMdid="0.28.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="183" Alias="cmin">
+                        <dxl:Ident ColId="183" ColName="cmin" TypeMdid="0.29.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="184" Alias="xmax">
+                        <dxl:Ident ColId="184" ColName="xmax" TypeMdid="0.28.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="185" Alias="cmax">
+                        <dxl:Ident ColId="185" ColName="cmax" TypeMdid="0.29.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="186" Alias="tableoid">
+                        <dxl:Ident ColId="186" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="187" Alias="gp_segment_id">
+                        <dxl:Ident ColId="187" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="188" Alias="c">
+                        <dxl:Ident ColId="188" ColName="c" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="189" Alias="ctid">
+                        <dxl:Ident ColId="189" ColName="ctid" TypeMdid="0.27.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="190" Alias="xmin">
+                        <dxl:Ident ColId="190" ColName="xmin" TypeMdid="0.28.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="191" Alias="cmin">
+                        <dxl:Ident ColId="191" ColName="cmin" TypeMdid="0.29.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="192" Alias="xmax">
+                        <dxl:Ident ColId="192" ColName="xmax" TypeMdid="0.28.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="193" Alias="cmax">
+                        <dxl:Ident ColId="193" ColName="cmax" TypeMdid="0.29.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="194" Alias="tableoid">
+                        <dxl:Ident ColId="194" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="195" Alias="gp_segment_id">
+                        <dxl:Ident ColId="195" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
                     <dxl:JoinFilter/>
                     <dxl:HashCondList>
                       <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                        <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                        <dxl:Ident ColId="11" ColName="c" TypeMdid="0.23.1.0"/>
+                        <dxl:Ident ColId="188" ColName="c" TypeMdid="0.23.1.0"/>
+                        <dxl:Ident ColId="177" ColName="a" TypeMdid="0.23.1.0"/>
                       </dxl:Comparison>
                     </dxl:HashCondList>
                     <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000121" Rows="1.000000" Width="32"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000771" Rows="8.000000" Width="34"/>
                       </dxl:Properties>
                       <dxl:ProjList>
-                        <dxl:ProjElem ColId="0" Alias="a">
-                          <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                        <dxl:ProjElem ColId="188" Alias="c">
+                          <dxl:Ident ColId="188" ColName="c" TypeMdid="0.23.1.0"/>
                         </dxl:ProjElem>
-                        <dxl:ProjElem ColId="1" Alias="b">
-                          <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                        <dxl:ProjElem ColId="189" Alias="ctid">
+                          <dxl:Ident ColId="189" ColName="ctid" TypeMdid="0.27.1.0"/>
                         </dxl:ProjElem>
-                        <dxl:ProjElem ColId="2" Alias="x">
-                          <dxl:Ident ColId="2" ColName="x" TypeMdid="0.23.1.0"/>
+                        <dxl:ProjElem ColId="190" Alias="xmin">
+                          <dxl:Ident ColId="190" ColName="xmin" TypeMdid="0.28.1.0"/>
                         </dxl:ProjElem>
-                        <dxl:ProjElem ColId="3" Alias="y">
-                          <dxl:Ident ColId="3" ColName="y" TypeMdid="0.23.1.0"/>
+                        <dxl:ProjElem ColId="191" Alias="cmin">
+                          <dxl:Ident ColId="191" ColName="cmin" TypeMdid="0.29.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="192" Alias="xmax">
+                          <dxl:Ident ColId="192" ColName="xmax" TypeMdid="0.28.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="193" Alias="cmax">
+                          <dxl:Ident ColId="193" ColName="cmax" TypeMdid="0.29.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="194" Alias="tableoid">
+                          <dxl:Ident ColId="194" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="195" Alias="gp_segment_id">
+                          <dxl:Ident ColId="195" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                         </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
                       <dxl:SortingColumnList/>
                       <dxl:HashExprList>
                         <dxl:HashExpr>
-                          <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                          <dxl:Ident ColId="188" ColName="c" TypeMdid="0.23.1.0"/>
+                        </dxl:HashExpr>
+                      </dxl:HashExprList>
+                      <dxl:TableScan>
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000092" Rows="8.000000" Width="34"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="188" Alias="c">
+                            <dxl:Ident ColId="188" ColName="c" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="189" Alias="ctid">
+                            <dxl:Ident ColId="189" ColName="ctid" TypeMdid="0.27.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="190" Alias="xmin">
+                            <dxl:Ident ColId="190" ColName="xmin" TypeMdid="0.28.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="191" Alias="cmin">
+                            <dxl:Ident ColId="191" ColName="cmin" TypeMdid="0.29.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="192" Alias="xmax">
+                            <dxl:Ident ColId="192" ColName="xmax" TypeMdid="0.28.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="193" Alias="cmax">
+                            <dxl:Ident ColId="193" ColName="cmax" TypeMdid="0.29.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="194" Alias="tableoid">
+                            <dxl:Ident ColId="194" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="195" Alias="gp_segment_id">
+                            <dxl:Ident ColId="195" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:TableDescriptor Mdid="6.106604.1.1" TableName="mpp_s6756">
+                          <dxl:Columns>
+                            <dxl:Column ColId="188" Attno="1" ColName="c" TypeMdid="0.23.1.0"/>
+                            <dxl:Column ColId="212" Attno="2" ColName="d" TypeMdid="0.23.1.0"/>
+                            <dxl:Column ColId="213" Attno="3" ColName="e" TypeMdid="0.23.1.0"/>
+                            <dxl:Column ColId="189" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                            <dxl:Column ColId="190" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                            <dxl:Column ColId="191" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                            <dxl:Column ColId="192" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                            <dxl:Column ColId="193" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                            <dxl:Column ColId="194" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                            <dxl:Column ColId="195" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                          </dxl:Columns>
+                        </dxl:TableDescriptor>
+                      </dxl:TableScan>
+                    </dxl:RedistributeMotion>
+                    <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000182" Rows="1.000000" Width="50"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="177" Alias="a">
+                          <dxl:Ident ColId="177" ColName="a" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="178" Alias="b">
+                          <dxl:Ident ColId="178" ColName="b" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="179" Alias="x">
+                          <dxl:Ident ColId="179" ColName="x" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="180" Alias="y">
+                          <dxl:Ident ColId="180" ColName="y" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="181" Alias="ctid">
+                          <dxl:Ident ColId="181" ColName="ctid" TypeMdid="0.27.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="182" Alias="xmin">
+                          <dxl:Ident ColId="182" ColName="xmin" TypeMdid="0.28.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="183" Alias="cmin">
+                          <dxl:Ident ColId="183" ColName="cmin" TypeMdid="0.29.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="184" Alias="xmax">
+                          <dxl:Ident ColId="184" ColName="xmax" TypeMdid="0.28.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="185" Alias="cmax">
+                          <dxl:Ident ColId="185" ColName="cmax" TypeMdid="0.29.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="186" Alias="tableoid">
+                          <dxl:Ident ColId="186" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="187" Alias="gp_segment_id">
+                          <dxl:Ident ColId="187" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:SortingColumnList/>
+                      <dxl:HashExprList>
+                        <dxl:HashExpr>
+                          <dxl:Ident ColId="177" ColName="a" TypeMdid="0.23.1.0"/>
                         </dxl:HashExpr>
                       </dxl:HashExprList>
                       <dxl:Sequence>
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="431.000013" Rows="1.000000" Width="32"/>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000013" Rows="1.000000" Width="50"/>
                         </dxl:Properties>
                         <dxl:ProjList>
-                          <dxl:ProjElem ColId="0" Alias="a">
-                            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                          <dxl:ProjElem ColId="177" Alias="a">
+                            <dxl:Ident ColId="177" ColName="a" TypeMdid="0.23.1.0"/>
                           </dxl:ProjElem>
-                          <dxl:ProjElem ColId="1" Alias="b">
-                            <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                          <dxl:ProjElem ColId="178" Alias="b">
+                            <dxl:Ident ColId="178" ColName="b" TypeMdid="0.23.1.0"/>
                           </dxl:ProjElem>
-                          <dxl:ProjElem ColId="2" Alias="x">
-                            <dxl:Ident ColId="2" ColName="x" TypeMdid="0.23.1.0"/>
+                          <dxl:ProjElem ColId="179" Alias="x">
+                            <dxl:Ident ColId="179" ColName="x" TypeMdid="0.23.1.0"/>
                           </dxl:ProjElem>
-                          <dxl:ProjElem ColId="3" Alias="y">
-                            <dxl:Ident ColId="3" ColName="y" TypeMdid="0.23.1.0"/>
+                          <dxl:ProjElem ColId="180" Alias="y">
+                            <dxl:Ident ColId="180" ColName="y" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="181" Alias="ctid">
+                            <dxl:Ident ColId="181" ColName="ctid" TypeMdid="0.27.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="182" Alias="xmin">
+                            <dxl:Ident ColId="182" ColName="xmin" TypeMdid="0.28.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="183" Alias="cmin">
+                            <dxl:Ident ColId="183" ColName="cmin" TypeMdid="0.29.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="184" Alias="xmax">
+                            <dxl:Ident ColId="184" ColName="xmax" TypeMdid="0.28.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="185" Alias="cmax">
+                            <dxl:Ident ColId="185" ColName="cmax" TypeMdid="0.29.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="186" Alias="tableoid">
+                            <dxl:Ident ColId="186" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="187" Alias="gp_segment_id">
+                            <dxl:Ident ColId="187" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                           </dxl:ProjElem>
                         </dxl:ProjList>
                         <dxl:PartitionSelector RelationMdid="6.106508.1.1" PartitionLevels="1" ScanId="1">
@@ -752,118 +1152,143 @@
                         </dxl:PartitionSelector>
                         <dxl:DynamicTableScan PartIndexId="1">
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="431.000013" Rows="1.000000" Width="32"/>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000013" Rows="1.000000" Width="50"/>
                           </dxl:Properties>
                           <dxl:ProjList>
-                            <dxl:ProjElem ColId="0" Alias="a">
-                              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                            <dxl:ProjElem ColId="177" Alias="a">
+                              <dxl:Ident ColId="177" ColName="a" TypeMdid="0.23.1.0"/>
                             </dxl:ProjElem>
-                            <dxl:ProjElem ColId="1" Alias="b">
-                              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                            <dxl:ProjElem ColId="178" Alias="b">
+                              <dxl:Ident ColId="178" ColName="b" TypeMdid="0.23.1.0"/>
                             </dxl:ProjElem>
-                            <dxl:ProjElem ColId="2" Alias="x">
-                              <dxl:Ident ColId="2" ColName="x" TypeMdid="0.23.1.0"/>
+                            <dxl:ProjElem ColId="179" Alias="x">
+                              <dxl:Ident ColId="179" ColName="x" TypeMdid="0.23.1.0"/>
                             </dxl:ProjElem>
-                            <dxl:ProjElem ColId="3" Alias="y">
-                              <dxl:Ident ColId="3" ColName="y" TypeMdid="0.23.1.0"/>
+                            <dxl:ProjElem ColId="180" Alias="y">
+                              <dxl:Ident ColId="180" ColName="y" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="181" Alias="ctid">
+                              <dxl:Ident ColId="181" ColName="ctid" TypeMdid="0.27.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="182" Alias="xmin">
+                              <dxl:Ident ColId="182" ColName="xmin" TypeMdid="0.28.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="183" Alias="cmin">
+                              <dxl:Ident ColId="183" ColName="cmin" TypeMdid="0.29.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="184" Alias="xmax">
+                              <dxl:Ident ColId="184" ColName="xmax" TypeMdid="0.28.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="185" Alias="cmax">
+                              <dxl:Ident ColId="185" ColName="cmax" TypeMdid="0.29.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="186" Alias="tableoid">
+                              <dxl:Ident ColId="186" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="187" Alias="gp_segment_id">
+                              <dxl:Ident ColId="187" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                             </dxl:ProjElem>
                           </dxl:ProjList>
                           <dxl:Filter/>
                           <dxl:TableDescriptor Mdid="6.106508.1.1" TableName="mpp_r6756">
                             <dxl:Columns>
-                              <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-                              <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
-                              <dxl:Column ColId="2" Attno="3" ColName="x" TypeMdid="0.23.1.0"/>
-                              <dxl:Column ColId="3" Attno="4" ColName="y" TypeMdid="0.23.1.0"/>
-                              <dxl:Column ColId="4" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                              <dxl:Column ColId="5" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                              <dxl:Column ColId="6" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                              <dxl:Column ColId="7" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                              <dxl:Column ColId="8" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                              <dxl:Column ColId="9" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                              <dxl:Column ColId="10" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                              <dxl:Column ColId="177" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+                              <dxl:Column ColId="178" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+                              <dxl:Column ColId="179" Attno="3" ColName="x" TypeMdid="0.23.1.0"/>
+                              <dxl:Column ColId="180" Attno="4" ColName="y" TypeMdid="0.23.1.0"/>
+                              <dxl:Column ColId="181" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                              <dxl:Column ColId="182" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                              <dxl:Column ColId="183" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                              <dxl:Column ColId="184" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                              <dxl:Column ColId="185" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                              <dxl:Column ColId="186" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                              <dxl:Column ColId="187" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                             </dxl:Columns>
                           </dxl:TableDescriptor>
                         </dxl:DynamicTableScan>
                       </dxl:Sequence>
                     </dxl:RedistributeMotion>
-                    <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000172" Rows="8.000000" Width="4"/>
-                      </dxl:Properties>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="11" Alias="c">
-                          <dxl:Ident ColId="11" ColName="c" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
-                      <dxl:Filter/>
-                      <dxl:SortingColumnList/>
-                      <dxl:HashExprList>
-                        <dxl:HashExpr>
-                          <dxl:Ident ColId="11" ColName="c" TypeMdid="0.23.1.0"/>
-                        </dxl:HashExpr>
-                      </dxl:HashExprList>
-                      <dxl:TableScan>
-                        <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="431.000092" Rows="8.000000" Width="4"/>
-                        </dxl:Properties>
-                        <dxl:ProjList>
-                          <dxl:ProjElem ColId="11" Alias="c">
-                            <dxl:Ident ColId="11" ColName="c" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
-                        </dxl:ProjList>
-                        <dxl:Filter/>
-                        <dxl:TableDescriptor Mdid="6.106604.1.1" TableName="mpp_s6756">
-                          <dxl:Columns>
-                            <dxl:Column ColId="11" Attno="1" ColName="c" TypeMdid="0.23.1.0"/>
-                            <dxl:Column ColId="14" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                            <dxl:Column ColId="15" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                            <dxl:Column ColId="16" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                            <dxl:Column ColId="17" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                            <dxl:Column ColId="18" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                            <dxl:Column ColId="19" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                            <dxl:Column ColId="20" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                          </dxl:Columns>
-                        </dxl:TableDescriptor>
-                      </dxl:TableScan>
-                    </dxl:RedistributeMotion>
                   </dxl:HashJoin>
                   <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000172" Rows="8.000000" Width="4"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000771" Rows="8.000000" Width="34"/>
                     </dxl:Properties>
                     <dxl:ProjList>
-                      <dxl:ProjElem ColId="22" Alias="d">
-                        <dxl:Ident ColId="22" ColName="d" TypeMdid="0.23.1.0"/>
+                      <dxl:ProjElem ColId="196" Alias="d">
+                        <dxl:Ident ColId="196" ColName="d" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="197" Alias="ctid">
+                        <dxl:Ident ColId="197" ColName="ctid" TypeMdid="0.27.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="198" Alias="xmin">
+                        <dxl:Ident ColId="198" ColName="xmin" TypeMdid="0.28.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="199" Alias="cmin">
+                        <dxl:Ident ColId="199" ColName="cmin" TypeMdid="0.29.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="200" Alias="xmax">
+                        <dxl:Ident ColId="200" ColName="xmax" TypeMdid="0.28.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="201" Alias="cmax">
+                        <dxl:Ident ColId="201" ColName="cmax" TypeMdid="0.29.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="202" Alias="tableoid">
+                        <dxl:Ident ColId="202" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="203" Alias="gp_segment_id">
+                        <dxl:Ident ColId="203" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
                     <dxl:SortingColumnList/>
                     <dxl:HashExprList>
                       <dxl:HashExpr>
-                        <dxl:Ident ColId="22" ColName="d" TypeMdid="0.23.1.0"/>
+                        <dxl:Ident ColId="196" ColName="d" TypeMdid="0.23.1.0"/>
                       </dxl:HashExpr>
                     </dxl:HashExprList>
                     <dxl:TableScan>
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000092" Rows="8.000000" Width="4"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000092" Rows="8.000000" Width="34"/>
                       </dxl:Properties>
                       <dxl:ProjList>
-                        <dxl:ProjElem ColId="22" Alias="d">
-                          <dxl:Ident ColId="22" ColName="d" TypeMdid="0.23.1.0"/>
+                        <dxl:ProjElem ColId="196" Alias="d">
+                          <dxl:Ident ColId="196" ColName="d" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="197" Alias="ctid">
+                          <dxl:Ident ColId="197" ColName="ctid" TypeMdid="0.27.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="198" Alias="xmin">
+                          <dxl:Ident ColId="198" ColName="xmin" TypeMdid="0.28.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="199" Alias="cmin">
+                          <dxl:Ident ColId="199" ColName="cmin" TypeMdid="0.29.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="200" Alias="xmax">
+                          <dxl:Ident ColId="200" ColName="xmax" TypeMdid="0.28.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="201" Alias="cmax">
+                          <dxl:Ident ColId="201" ColName="cmax" TypeMdid="0.29.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="202" Alias="tableoid">
+                          <dxl:Ident ColId="202" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="203" Alias="gp_segment_id">
+                          <dxl:Ident ColId="203" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                         </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
                       <dxl:TableDescriptor Mdid="6.106604.1.1" TableName="mpp_s6756">
                         <dxl:Columns>
-                          <dxl:Column ColId="22" Attno="2" ColName="d" TypeMdid="0.23.1.0"/>
-                          <dxl:Column ColId="24" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                          <dxl:Column ColId="25" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                          <dxl:Column ColId="26" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                          <dxl:Column ColId="27" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                          <dxl:Column ColId="28" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                          <dxl:Column ColId="29" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                          <dxl:Column ColId="30" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                          <dxl:Column ColId="214" Attno="1" ColName="c" TypeMdid="0.23.1.0"/>
+                          <dxl:Column ColId="196" Attno="2" ColName="d" TypeMdid="0.23.1.0"/>
+                          <dxl:Column ColId="215" Attno="3" ColName="e" TypeMdid="0.23.1.0"/>
+                          <dxl:Column ColId="197" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                          <dxl:Column ColId="198" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                          <dxl:Column ColId="199" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                          <dxl:Column ColId="200" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                          <dxl:Column ColId="201" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                          <dxl:Column ColId="202" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                          <dxl:Column ColId="203" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                         </dxl:Columns>
                       </dxl:TableDescriptor>
                     </dxl:TableScan>
@@ -871,50 +1296,647 @@
                 </dxl:HashJoin>
                 <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000172" Rows="8.000000" Width="4"/>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000771" Rows="8.000000" Width="34"/>
                   </dxl:Properties>
                   <dxl:ProjList>
-                    <dxl:ProjElem ColId="33" Alias="e">
-                      <dxl:Ident ColId="33" ColName="e" TypeMdid="0.23.1.0"/>
+                    <dxl:ProjElem ColId="204" Alias="e">
+                      <dxl:Ident ColId="204" ColName="e" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="205" Alias="ctid">
+                      <dxl:Ident ColId="205" ColName="ctid" TypeMdid="0.27.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="206" Alias="xmin">
+                      <dxl:Ident ColId="206" ColName="xmin" TypeMdid="0.28.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="207" Alias="cmin">
+                      <dxl:Ident ColId="207" ColName="cmin" TypeMdid="0.29.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="208" Alias="xmax">
+                      <dxl:Ident ColId="208" ColName="xmax" TypeMdid="0.28.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="209" Alias="cmax">
+                      <dxl:Ident ColId="209" ColName="cmax" TypeMdid="0.29.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="210" Alias="tableoid">
+                      <dxl:Ident ColId="210" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="211" Alias="gp_segment_id">
+                      <dxl:Ident ColId="211" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
                   <dxl:SortingColumnList/>
                   <dxl:HashExprList>
                     <dxl:HashExpr>
-                      <dxl:Ident ColId="33" ColName="e" TypeMdid="0.23.1.0"/>
+                      <dxl:Ident ColId="204" ColName="e" TypeMdid="0.23.1.0"/>
                     </dxl:HashExpr>
                   </dxl:HashExprList>
                   <dxl:TableScan>
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000092" Rows="8.000000" Width="4"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000092" Rows="8.000000" Width="34"/>
                     </dxl:Properties>
                     <dxl:ProjList>
-                      <dxl:ProjElem ColId="33" Alias="e">
-                        <dxl:Ident ColId="33" ColName="e" TypeMdid="0.23.1.0"/>
+                      <dxl:ProjElem ColId="204" Alias="e">
+                        <dxl:Ident ColId="204" ColName="e" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="205" Alias="ctid">
+                        <dxl:Ident ColId="205" ColName="ctid" TypeMdid="0.27.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="206" Alias="xmin">
+                        <dxl:Ident ColId="206" ColName="xmin" TypeMdid="0.28.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="207" Alias="cmin">
+                        <dxl:Ident ColId="207" ColName="cmin" TypeMdid="0.29.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="208" Alias="xmax">
+                        <dxl:Ident ColId="208" ColName="xmax" TypeMdid="0.28.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="209" Alias="cmax">
+                        <dxl:Ident ColId="209" ColName="cmax" TypeMdid="0.29.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="210" Alias="tableoid">
+                        <dxl:Ident ColId="210" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="211" Alias="gp_segment_id">
+                        <dxl:Ident ColId="211" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
                     <dxl:TableDescriptor Mdid="6.106604.1.1" TableName="mpp_s6756">
                       <dxl:Columns>
-                        <dxl:Column ColId="33" Attno="3" ColName="e" TypeMdid="0.23.1.0"/>
-                        <dxl:Column ColId="34" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                        <dxl:Column ColId="35" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                        <dxl:Column ColId="36" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                        <dxl:Column ColId="37" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                        <dxl:Column ColId="38" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                        <dxl:Column ColId="39" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                        <dxl:Column ColId="40" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                        <dxl:Column ColId="216" Attno="1" ColName="c" TypeMdid="0.23.1.0"/>
+                        <dxl:Column ColId="217" Attno="2" ColName="d" TypeMdid="0.23.1.0"/>
+                        <dxl:Column ColId="204" Attno="3" ColName="e" TypeMdid="0.23.1.0"/>
+                        <dxl:Column ColId="205" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                        <dxl:Column ColId="206" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                        <dxl:Column ColId="207" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                        <dxl:Column ColId="208" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                        <dxl:Column ColId="209" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                        <dxl:Column ColId="210" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                        <dxl:Column ColId="211" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                       </dxl:Columns>
                     </dxl:TableDescriptor>
                   </dxl:TableScan>
                 </dxl:RedistributeMotion>
               </dxl:HashJoin>
-            </dxl:Sort>
-          </dxl:Aggregate>
+            </dxl:CTEProducer>
+            <dxl:HashJoin JoinType="Inner">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="862.000704" Rows="1.000000" Width="28"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="0" Alias="a">
+                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="1" Alias="b">
+                  <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="41" Alias="count">
+                  <dxl:Ident ColId="41" ColName="count" TypeMdid="0.20.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="42" Alias="count">
+                  <dxl:Ident ColId="42" ColName="count" TypeMdid="0.20.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:JoinFilter/>
+              <dxl:HashCondList>
+                <dxl:Not>
+                  <dxl:IsDistinctFrom OperatorMdid="0.96.1.0">
+                    <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                    <dxl:Ident ColId="224" ColName="a" TypeMdid="0.23.1.0"/>
+                  </dxl:IsDistinctFrom>
+                </dxl:Not>
+                <dxl:Not>
+                  <dxl:IsDistinctFrom OperatorMdid="0.96.1.0">
+                    <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                    <dxl:Ident ColId="225" ColName="b" TypeMdid="0.23.1.0"/>
+                  </dxl:IsDistinctFrom>
+                </dxl:Not>
+              </dxl:HashCondList>
+              <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000107" Rows="1.000000" Width="20"/>
+                </dxl:Properties>
+                <dxl:GroupingColumns>
+                  <dxl:GroupingColumn ColId="0"/>
+                  <dxl:GroupingColumn ColId="1"/>
+                </dxl:GroupingColumns>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="41" Alias="count">
+                    <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="true" AggStage="Normal" AggKind="n">
+                      <dxl:ValuesList ParamType="aggargs">
+                        <dxl:Ident ColId="2" ColName="x" TypeMdid="0.23.1.0"/>
+                      </dxl:ValuesList>
+                      <dxl:ValuesList ParamType="aggdirectargs"/>
+                      <dxl:ValuesList ParamType="aggorder"/>
+                      <dxl:ValuesList ParamType="aggdistinct"/>
+                    </dxl:AggFunc>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="0" Alias="a">
+                    <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="1" Alias="b">
+                    <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:Sort SortDiscardDuplicates="false">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000079" Rows="2.275556" Width="20"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="0" Alias="a">
+                      <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="1" Alias="b">
+                      <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="2" Alias="x">
+                      <dxl:Ident ColId="2" ColName="x" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="3" Alias="y">
+                      <dxl:Ident ColId="3" ColName="y" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="4" Alias="ctid">
+                      <dxl:Ident ColId="4" ColName="ctid" TypeMdid="0.27.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="5" Alias="xmin">
+                      <dxl:Ident ColId="5" ColName="xmin" TypeMdid="0.28.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="6" Alias="cmin">
+                      <dxl:Ident ColId="6" ColName="cmin" TypeMdid="0.29.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="7" Alias="xmax">
+                      <dxl:Ident ColId="7" ColName="xmax" TypeMdid="0.28.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="8" Alias="cmax">
+                      <dxl:Ident ColId="8" ColName="cmax" TypeMdid="0.29.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="9" Alias="tableoid">
+                      <dxl:Ident ColId="9" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="10" Alias="gp_segment_id">
+                      <dxl:Ident ColId="10" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="11" Alias="c">
+                      <dxl:Ident ColId="11" ColName="c" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="14" Alias="ctid">
+                      <dxl:Ident ColId="14" ColName="ctid" TypeMdid="0.27.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="15" Alias="xmin">
+                      <dxl:Ident ColId="15" ColName="xmin" TypeMdid="0.28.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="16" Alias="cmin">
+                      <dxl:Ident ColId="16" ColName="cmin" TypeMdid="0.29.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="17" Alias="xmax">
+                      <dxl:Ident ColId="17" ColName="xmax" TypeMdid="0.28.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="18" Alias="cmax">
+                      <dxl:Ident ColId="18" ColName="cmax" TypeMdid="0.29.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="19" Alias="tableoid">
+                      <dxl:Ident ColId="19" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="20" Alias="gp_segment_id">
+                      <dxl:Ident ColId="20" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="22" Alias="d">
+                      <dxl:Ident ColId="22" ColName="d" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="24" Alias="ctid">
+                      <dxl:Ident ColId="24" ColName="ctid" TypeMdid="0.27.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="25" Alias="xmin">
+                      <dxl:Ident ColId="25" ColName="xmin" TypeMdid="0.28.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="26" Alias="cmin">
+                      <dxl:Ident ColId="26" ColName="cmin" TypeMdid="0.29.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="27" Alias="xmax">
+                      <dxl:Ident ColId="27" ColName="xmax" TypeMdid="0.28.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="28" Alias="cmax">
+                      <dxl:Ident ColId="28" ColName="cmax" TypeMdid="0.29.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="29" Alias="tableoid">
+                      <dxl:Ident ColId="29" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="30" Alias="gp_segment_id">
+                      <dxl:Ident ColId="30" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="33" Alias="e">
+                      <dxl:Ident ColId="33" ColName="e" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="34" Alias="ctid">
+                      <dxl:Ident ColId="34" ColName="ctid" TypeMdid="0.27.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="35" Alias="xmin">
+                      <dxl:Ident ColId="35" ColName="xmin" TypeMdid="0.28.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="36" Alias="cmin">
+                      <dxl:Ident ColId="36" ColName="cmin" TypeMdid="0.29.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="37" Alias="xmax">
+                      <dxl:Ident ColId="37" ColName="xmax" TypeMdid="0.28.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="38" Alias="cmax">
+                      <dxl:Ident ColId="38" ColName="cmax" TypeMdid="0.29.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="39" Alias="tableoid">
+                      <dxl:Ident ColId="39" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="40" Alias="gp_segment_id">
+                      <dxl:Ident ColId="40" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:SortingColumnList>
+                    <dxl:SortingColumn ColId="0" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                    <dxl:SortingColumn ColId="1" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                  </dxl:SortingColumnList>
+                  <dxl:LimitCount/>
+                  <dxl:LimitOffset/>
+                  <dxl:CTEConsumer CTEId="1" Columns="0,1,2,3,4,5,6,7,8,9,10,11,14,15,16,17,18,19,20,22,24,25,26,27,28,29,30,33,34,35,36,37,38,39,40">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000055" Rows="2.275556" Width="20"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="0" Alias="a">
+                        <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="1" Alias="b">
+                        <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="2" Alias="x">
+                        <dxl:Ident ColId="2" ColName="x" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="3" Alias="y">
+                        <dxl:Ident ColId="3" ColName="y" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="4" Alias="ctid">
+                        <dxl:Ident ColId="4" ColName="ctid" TypeMdid="0.27.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="5" Alias="xmin">
+                        <dxl:Ident ColId="5" ColName="xmin" TypeMdid="0.28.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="6" Alias="cmin">
+                        <dxl:Ident ColId="6" ColName="cmin" TypeMdid="0.29.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="7" Alias="xmax">
+                        <dxl:Ident ColId="7" ColName="xmax" TypeMdid="0.28.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="8" Alias="cmax">
+                        <dxl:Ident ColId="8" ColName="cmax" TypeMdid="0.29.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="9" Alias="tableoid">
+                        <dxl:Ident ColId="9" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="10" Alias="gp_segment_id">
+                        <dxl:Ident ColId="10" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="11" Alias="c">
+                        <dxl:Ident ColId="11" ColName="c" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="14" Alias="ctid">
+                        <dxl:Ident ColId="14" ColName="ctid" TypeMdid="0.27.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="15" Alias="xmin">
+                        <dxl:Ident ColId="15" ColName="xmin" TypeMdid="0.28.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="16" Alias="cmin">
+                        <dxl:Ident ColId="16" ColName="cmin" TypeMdid="0.29.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="17" Alias="xmax">
+                        <dxl:Ident ColId="17" ColName="xmax" TypeMdid="0.28.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="18" Alias="cmax">
+                        <dxl:Ident ColId="18" ColName="cmax" TypeMdid="0.29.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="19" Alias="tableoid">
+                        <dxl:Ident ColId="19" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="20" Alias="gp_segment_id">
+                        <dxl:Ident ColId="20" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="22" Alias="d">
+                        <dxl:Ident ColId="22" ColName="d" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="24" Alias="ctid">
+                        <dxl:Ident ColId="24" ColName="ctid" TypeMdid="0.27.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="25" Alias="xmin">
+                        <dxl:Ident ColId="25" ColName="xmin" TypeMdid="0.28.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="26" Alias="cmin">
+                        <dxl:Ident ColId="26" ColName="cmin" TypeMdid="0.29.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="27" Alias="xmax">
+                        <dxl:Ident ColId="27" ColName="xmax" TypeMdid="0.28.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="28" Alias="cmax">
+                        <dxl:Ident ColId="28" ColName="cmax" TypeMdid="0.29.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="29" Alias="tableoid">
+                        <dxl:Ident ColId="29" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="30" Alias="gp_segment_id">
+                        <dxl:Ident ColId="30" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="33" Alias="e">
+                        <dxl:Ident ColId="33" ColName="e" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="34" Alias="ctid">
+                        <dxl:Ident ColId="34" ColName="ctid" TypeMdid="0.27.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="35" Alias="xmin">
+                        <dxl:Ident ColId="35" ColName="xmin" TypeMdid="0.28.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="36" Alias="cmin">
+                        <dxl:Ident ColId="36" ColName="cmin" TypeMdid="0.29.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="37" Alias="xmax">
+                        <dxl:Ident ColId="37" ColName="xmax" TypeMdid="0.28.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="38" Alias="cmax">
+                        <dxl:Ident ColId="38" ColName="cmax" TypeMdid="0.29.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="39" Alias="tableoid">
+                        <dxl:Ident ColId="39" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="40" Alias="gp_segment_id">
+                        <dxl:Ident ColId="40" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                  </dxl:CTEConsumer>
+                </dxl:Sort>
+              </dxl:Aggregate>
+              <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000086" Rows="1.000000" Width="16"/>
+                </dxl:Properties>
+                <dxl:GroupingColumns>
+                  <dxl:GroupingColumn ColId="224"/>
+                  <dxl:GroupingColumn ColId="225"/>
+                </dxl:GroupingColumns>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="42" Alias="count">
+                    <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="true" AggStage="Normal" AggKind="n">
+                      <dxl:ValuesList ParamType="aggargs">
+                        <dxl:Ident ColId="227" ColName="y" TypeMdid="0.23.1.0"/>
+                      </dxl:ValuesList>
+                      <dxl:ValuesList ParamType="aggdirectargs"/>
+                      <dxl:ValuesList ParamType="aggorder"/>
+                      <dxl:ValuesList ParamType="aggdistinct"/>
+                    </dxl:AggFunc>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="224" Alias="a">
+                    <dxl:Ident ColId="224" ColName="a" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="225" Alias="b">
+                    <dxl:Ident ColId="225" ColName="b" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:Sort SortDiscardDuplicates="false">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000063" Rows="2.275556" Width="16"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="224" Alias="a">
+                      <dxl:Ident ColId="224" ColName="a" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="225" Alias="b">
+                      <dxl:Ident ColId="225" ColName="b" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="226" Alias="x">
+                      <dxl:Ident ColId="226" ColName="x" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="227" Alias="y">
+                      <dxl:Ident ColId="227" ColName="y" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="228" Alias="ctid">
+                      <dxl:Ident ColId="228" ColName="ctid" TypeMdid="0.27.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="229" Alias="xmin">
+                      <dxl:Ident ColId="229" ColName="xmin" TypeMdid="0.28.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="230" Alias="cmin">
+                      <dxl:Ident ColId="230" ColName="cmin" TypeMdid="0.29.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="231" Alias="xmax">
+                      <dxl:Ident ColId="231" ColName="xmax" TypeMdid="0.28.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="232" Alias="cmax">
+                      <dxl:Ident ColId="232" ColName="cmax" TypeMdid="0.29.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="233" Alias="tableoid">
+                      <dxl:Ident ColId="233" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="234" Alias="gp_segment_id">
+                      <dxl:Ident ColId="234" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="235" Alias="c">
+                      <dxl:Ident ColId="235" ColName="c" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="236" Alias="ctid">
+                      <dxl:Ident ColId="236" ColName="ctid" TypeMdid="0.27.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="237" Alias="xmin">
+                      <dxl:Ident ColId="237" ColName="xmin" TypeMdid="0.28.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="238" Alias="cmin">
+                      <dxl:Ident ColId="238" ColName="cmin" TypeMdid="0.29.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="239" Alias="xmax">
+                      <dxl:Ident ColId="239" ColName="xmax" TypeMdid="0.28.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="240" Alias="cmax">
+                      <dxl:Ident ColId="240" ColName="cmax" TypeMdid="0.29.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="241" Alias="tableoid">
+                      <dxl:Ident ColId="241" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="242" Alias="gp_segment_id">
+                      <dxl:Ident ColId="242" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="243" Alias="d">
+                      <dxl:Ident ColId="243" ColName="d" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="244" Alias="ctid">
+                      <dxl:Ident ColId="244" ColName="ctid" TypeMdid="0.27.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="245" Alias="xmin">
+                      <dxl:Ident ColId="245" ColName="xmin" TypeMdid="0.28.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="246" Alias="cmin">
+                      <dxl:Ident ColId="246" ColName="cmin" TypeMdid="0.29.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="247" Alias="xmax">
+                      <dxl:Ident ColId="247" ColName="xmax" TypeMdid="0.28.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="248" Alias="cmax">
+                      <dxl:Ident ColId="248" ColName="cmax" TypeMdid="0.29.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="249" Alias="tableoid">
+                      <dxl:Ident ColId="249" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="250" Alias="gp_segment_id">
+                      <dxl:Ident ColId="250" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="251" Alias="e">
+                      <dxl:Ident ColId="251" ColName="e" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="252" Alias="ctid">
+                      <dxl:Ident ColId="252" ColName="ctid" TypeMdid="0.27.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="253" Alias="xmin">
+                      <dxl:Ident ColId="253" ColName="xmin" TypeMdid="0.28.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="254" Alias="cmin">
+                      <dxl:Ident ColId="254" ColName="cmin" TypeMdid="0.29.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="255" Alias="xmax">
+                      <dxl:Ident ColId="255" ColName="xmax" TypeMdid="0.28.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="256" Alias="cmax">
+                      <dxl:Ident ColId="256" ColName="cmax" TypeMdid="0.29.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="257" Alias="tableoid">
+                      <dxl:Ident ColId="257" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="258" Alias="gp_segment_id">
+                      <dxl:Ident ColId="258" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:SortingColumnList>
+                    <dxl:SortingColumn ColId="224" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                    <dxl:SortingColumn ColId="225" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                  </dxl:SortingColumnList>
+                  <dxl:LimitCount/>
+                  <dxl:LimitOffset/>
+                  <dxl:CTEConsumer CTEId="1" Columns="224,225,226,227,228,229,230,231,232,233,234,235,236,237,238,239,240,241,242,243,244,245,246,247,248,249,250,251,252,253,254,255,256,257,258">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000044" Rows="2.275556" Width="16"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="224" Alias="a">
+                        <dxl:Ident ColId="224" ColName="a" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="225" Alias="b">
+                        <dxl:Ident ColId="225" ColName="b" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="226" Alias="x">
+                        <dxl:Ident ColId="226" ColName="x" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="227" Alias="y">
+                        <dxl:Ident ColId="227" ColName="y" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="228" Alias="ctid">
+                        <dxl:Ident ColId="228" ColName="ctid" TypeMdid="0.27.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="229" Alias="xmin">
+                        <dxl:Ident ColId="229" ColName="xmin" TypeMdid="0.28.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="230" Alias="cmin">
+                        <dxl:Ident ColId="230" ColName="cmin" TypeMdid="0.29.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="231" Alias="xmax">
+                        <dxl:Ident ColId="231" ColName="xmax" TypeMdid="0.28.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="232" Alias="cmax">
+                        <dxl:Ident ColId="232" ColName="cmax" TypeMdid="0.29.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="233" Alias="tableoid">
+                        <dxl:Ident ColId="233" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="234" Alias="gp_segment_id">
+                        <dxl:Ident ColId="234" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="235" Alias="c">
+                        <dxl:Ident ColId="235" ColName="c" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="236" Alias="ctid">
+                        <dxl:Ident ColId="236" ColName="ctid" TypeMdid="0.27.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="237" Alias="xmin">
+                        <dxl:Ident ColId="237" ColName="xmin" TypeMdid="0.28.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="238" Alias="cmin">
+                        <dxl:Ident ColId="238" ColName="cmin" TypeMdid="0.29.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="239" Alias="xmax">
+                        <dxl:Ident ColId="239" ColName="xmax" TypeMdid="0.28.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="240" Alias="cmax">
+                        <dxl:Ident ColId="240" ColName="cmax" TypeMdid="0.29.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="241" Alias="tableoid">
+                        <dxl:Ident ColId="241" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="242" Alias="gp_segment_id">
+                        <dxl:Ident ColId="242" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="243" Alias="d">
+                        <dxl:Ident ColId="243" ColName="d" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="244" Alias="ctid">
+                        <dxl:Ident ColId="244" ColName="ctid" TypeMdid="0.27.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="245" Alias="xmin">
+                        <dxl:Ident ColId="245" ColName="xmin" TypeMdid="0.28.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="246" Alias="cmin">
+                        <dxl:Ident ColId="246" ColName="cmin" TypeMdid="0.29.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="247" Alias="xmax">
+                        <dxl:Ident ColId="247" ColName="xmax" TypeMdid="0.28.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="248" Alias="cmax">
+                        <dxl:Ident ColId="248" ColName="cmax" TypeMdid="0.29.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="249" Alias="tableoid">
+                        <dxl:Ident ColId="249" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="250" Alias="gp_segment_id">
+                        <dxl:Ident ColId="250" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="251" Alias="e">
+                        <dxl:Ident ColId="251" ColName="e" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="252" Alias="ctid">
+                        <dxl:Ident ColId="252" ColName="ctid" TypeMdid="0.27.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="253" Alias="xmin">
+                        <dxl:Ident ColId="253" ColName="xmin" TypeMdid="0.28.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="254" Alias="cmin">
+                        <dxl:Ident ColId="254" ColName="cmin" TypeMdid="0.29.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="255" Alias="xmax">
+                        <dxl:Ident ColId="255" ColName="xmax" TypeMdid="0.28.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="256" Alias="cmax">
+                        <dxl:Ident ColId="256" ColName="cmax" TypeMdid="0.29.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="257" Alias="tableoid">
+                        <dxl:Ident ColId="257" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="258" Alias="gp_segment_id">
+                        <dxl:Ident ColId="258" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                  </dxl:CTEConsumer>
+                </dxl:Sort>
+              </dxl:Aggregate>
+            </dxl:HashJoin>
+          </dxl:Sequence>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1724.006810" Rows="1.000000" Width="28"/>
+              <dxl:Cost StartupCost="0" TotalCost="2586.020868" Rows="1.000000" Width="28"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="43" Alias="a">
@@ -932,164 +1954,584 @@
             </dxl:ProjList>
             <dxl:Filter/>
             <dxl:OneTimeFilter/>
-            <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+            <dxl:Sequence>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1724.006796" Rows="1.000000" Width="24"/>
+                <dxl:Cost StartupCost="0" TotalCost="2586.020854" Rows="1.000000" Width="24"/>
               </dxl:Properties>
-              <dxl:GroupingColumns>
-                <dxl:GroupingColumn ColId="43"/>
-              </dxl:GroupingColumns>
               <dxl:ProjList>
-                <dxl:ProjElem ColId="84" Alias="count">
-                  <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="true" AggStage="Normal" AggKind="n">
-                    <dxl:ValuesList ParamType="aggargs">
-                      <dxl:Ident ColId="45" ColName="x" TypeMdid="0.23.1.0"/>
-                    </dxl:ValuesList>
-                    <dxl:ValuesList ParamType="aggdirectargs"/>
-                    <dxl:ValuesList ParamType="aggorder"/>
-                    <dxl:ValuesList ParamType="aggdistinct"/>
-                  </dxl:AggFunc>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="85" Alias="count">
-                  <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="true" AggStage="Normal" AggKind="n">
-                    <dxl:ValuesList ParamType="aggargs">
-                      <dxl:Ident ColId="46" ColName="y" TypeMdid="0.23.1.0"/>
-                    </dxl:ValuesList>
-                    <dxl:ValuesList ParamType="aggdirectargs"/>
-                    <dxl:ValuesList ParamType="aggorder"/>
-                    <dxl:ValuesList ParamType="aggdistinct"/>
-                  </dxl:AggFunc>
-                </dxl:ProjElem>
                 <dxl:ProjElem ColId="43" Alias="a">
                   <dxl:Ident ColId="43" ColName="a" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
+                <dxl:ProjElem ColId="84" Alias="count">
+                  <dxl:Ident ColId="84" ColName="count" TypeMdid="0.20.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="85" Alias="count">
+                  <dxl:Ident ColId="85" ColName="count" TypeMdid="0.20.1.0"/>
+                </dxl:ProjElem>
               </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:Sort SortDiscardDuplicates="false">
+              <dxl:CTEProducer CTEId="0" Columns="87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121">
                 <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1724.006693" Rows="8.000000" Width="24"/>
+                  <dxl:Cost StartupCost="0" TotalCost="1724.020401" Rows="8.000000" Width="1"/>
                 </dxl:Properties>
                 <dxl:ProjList>
-                  <dxl:ProjElem ColId="43" Alias="a">
-                    <dxl:Ident ColId="43" ColName="a" TypeMdid="0.23.1.0"/>
+                  <dxl:ProjElem ColId="87" Alias="a">
+                    <dxl:Ident ColId="87" ColName="a" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
-                  <dxl:ProjElem ColId="45" Alias="x">
-                    <dxl:Ident ColId="45" ColName="x" TypeMdid="0.23.1.0"/>
+                  <dxl:ProjElem ColId="88" Alias="b">
+                    <dxl:Ident ColId="88" ColName="b" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
-                  <dxl:ProjElem ColId="46" Alias="y">
-                    <dxl:Ident ColId="46" ColName="y" TypeMdid="0.23.1.0"/>
+                  <dxl:ProjElem ColId="89" Alias="x">
+                    <dxl:Ident ColId="89" ColName="x" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="90" Alias="y">
+                    <dxl:Ident ColId="90" ColName="y" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="91" Alias="ctid">
+                    <dxl:Ident ColId="91" ColName="ctid" TypeMdid="0.27.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="92" Alias="xmin">
+                    <dxl:Ident ColId="92" ColName="xmin" TypeMdid="0.28.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="93" Alias="cmin">
+                    <dxl:Ident ColId="93" ColName="cmin" TypeMdid="0.29.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="94" Alias="xmax">
+                    <dxl:Ident ColId="94" ColName="xmax" TypeMdid="0.28.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="95" Alias="cmax">
+                    <dxl:Ident ColId="95" ColName="cmax" TypeMdid="0.29.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="96" Alias="tableoid">
+                    <dxl:Ident ColId="96" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="97" Alias="gp_segment_id">
+                    <dxl:Ident ColId="97" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="98" Alias="c">
+                    <dxl:Ident ColId="98" ColName="c" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="99" Alias="ctid">
+                    <dxl:Ident ColId="99" ColName="ctid" TypeMdid="0.27.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="100" Alias="xmin">
+                    <dxl:Ident ColId="100" ColName="xmin" TypeMdid="0.28.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="101" Alias="cmin">
+                    <dxl:Ident ColId="101" ColName="cmin" TypeMdid="0.29.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="102" Alias="xmax">
+                    <dxl:Ident ColId="102" ColName="xmax" TypeMdid="0.28.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="103" Alias="cmax">
+                    <dxl:Ident ColId="103" ColName="cmax" TypeMdid="0.29.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="104" Alias="tableoid">
+                    <dxl:Ident ColId="104" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="105" Alias="gp_segment_id">
+                    <dxl:Ident ColId="105" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="106" Alias="d">
+                    <dxl:Ident ColId="106" ColName="d" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="107" Alias="ctid">
+                    <dxl:Ident ColId="107" ColName="ctid" TypeMdid="0.27.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="108" Alias="xmin">
+                    <dxl:Ident ColId="108" ColName="xmin" TypeMdid="0.28.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="109" Alias="cmin">
+                    <dxl:Ident ColId="109" ColName="cmin" TypeMdid="0.29.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="110" Alias="xmax">
+                    <dxl:Ident ColId="110" ColName="xmax" TypeMdid="0.28.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="111" Alias="cmax">
+                    <dxl:Ident ColId="111" ColName="cmax" TypeMdid="0.29.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="112" Alias="tableoid">
+                    <dxl:Ident ColId="112" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="113" Alias="gp_segment_id">
+                    <dxl:Ident ColId="113" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="114" Alias="e">
+                    <dxl:Ident ColId="114" ColName="e" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="115" Alias="ctid">
+                    <dxl:Ident ColId="115" ColName="ctid" TypeMdid="0.27.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="116" Alias="xmin">
+                    <dxl:Ident ColId="116" ColName="xmin" TypeMdid="0.28.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="117" Alias="cmin">
+                    <dxl:Ident ColId="117" ColName="cmin" TypeMdid="0.29.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="118" Alias="xmax">
+                    <dxl:Ident ColId="118" ColName="xmax" TypeMdid="0.28.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="119" Alias="cmax">
+                    <dxl:Ident ColId="119" ColName="cmax" TypeMdid="0.29.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="120" Alias="tableoid">
+                    <dxl:Ident ColId="120" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="121" Alias="gp_segment_id">
+                    <dxl:Ident ColId="121" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                   </dxl:ProjElem>
                 </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:SortingColumnList>
-                  <dxl:SortingColumn ColId="43" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                </dxl:SortingColumnList>
-                <dxl:LimitCount/>
-                <dxl:LimitOffset/>
                 <dxl:HashJoin JoinType="Inner">
                   <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1724.005604" Rows="8.000000" Width="24"/>
+                    <dxl:Cost StartupCost="0" TotalCost="1724.020397" Rows="8.000000" Width="152"/>
                   </dxl:Properties>
                   <dxl:ProjList>
-                    <dxl:ProjElem ColId="43" Alias="a">
-                      <dxl:Ident ColId="43" ColName="a" TypeMdid="0.23.1.0"/>
+                    <dxl:ProjElem ColId="87" Alias="a">
+                      <dxl:Ident ColId="87" ColName="a" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
-                    <dxl:ProjElem ColId="45" Alias="x">
-                      <dxl:Ident ColId="45" ColName="x" TypeMdid="0.23.1.0"/>
+                    <dxl:ProjElem ColId="88" Alias="b">
+                      <dxl:Ident ColId="88" ColName="b" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
-                    <dxl:ProjElem ColId="46" Alias="y">
-                      <dxl:Ident ColId="46" ColName="y" TypeMdid="0.23.1.0"/>
+                    <dxl:ProjElem ColId="89" Alias="x">
+                      <dxl:Ident ColId="89" ColName="x" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="90" Alias="y">
+                      <dxl:Ident ColId="90" ColName="y" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="91" Alias="ctid">
+                      <dxl:Ident ColId="91" ColName="ctid" TypeMdid="0.27.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="92" Alias="xmin">
+                      <dxl:Ident ColId="92" ColName="xmin" TypeMdid="0.28.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="93" Alias="cmin">
+                      <dxl:Ident ColId="93" ColName="cmin" TypeMdid="0.29.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="94" Alias="xmax">
+                      <dxl:Ident ColId="94" ColName="xmax" TypeMdid="0.28.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="95" Alias="cmax">
+                      <dxl:Ident ColId="95" ColName="cmax" TypeMdid="0.29.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="96" Alias="tableoid">
+                      <dxl:Ident ColId="96" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="97" Alias="gp_segment_id">
+                      <dxl:Ident ColId="97" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="98" Alias="c">
+                      <dxl:Ident ColId="98" ColName="c" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="99" Alias="ctid">
+                      <dxl:Ident ColId="99" ColName="ctid" TypeMdid="0.27.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="100" Alias="xmin">
+                      <dxl:Ident ColId="100" ColName="xmin" TypeMdid="0.28.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="101" Alias="cmin">
+                      <dxl:Ident ColId="101" ColName="cmin" TypeMdid="0.29.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="102" Alias="xmax">
+                      <dxl:Ident ColId="102" ColName="xmax" TypeMdid="0.28.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="103" Alias="cmax">
+                      <dxl:Ident ColId="103" ColName="cmax" TypeMdid="0.29.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="104" Alias="tableoid">
+                      <dxl:Ident ColId="104" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="105" Alias="gp_segment_id">
+                      <dxl:Ident ColId="105" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="106" Alias="d">
+                      <dxl:Ident ColId="106" ColName="d" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="107" Alias="ctid">
+                      <dxl:Ident ColId="107" ColName="ctid" TypeMdid="0.27.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="108" Alias="xmin">
+                      <dxl:Ident ColId="108" ColName="xmin" TypeMdid="0.28.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="109" Alias="cmin">
+                      <dxl:Ident ColId="109" ColName="cmin" TypeMdid="0.29.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="110" Alias="xmax">
+                      <dxl:Ident ColId="110" ColName="xmax" TypeMdid="0.28.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="111" Alias="cmax">
+                      <dxl:Ident ColId="111" ColName="cmax" TypeMdid="0.29.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="112" Alias="tableoid">
+                      <dxl:Ident ColId="112" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="113" Alias="gp_segment_id">
+                      <dxl:Ident ColId="113" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="114" Alias="e">
+                      <dxl:Ident ColId="114" ColName="e" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="115" Alias="ctid">
+                      <dxl:Ident ColId="115" ColName="ctid" TypeMdid="0.27.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="116" Alias="xmin">
+                      <dxl:Ident ColId="116" ColName="xmin" TypeMdid="0.28.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="117" Alias="cmin">
+                      <dxl:Ident ColId="117" ColName="cmin" TypeMdid="0.29.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="118" Alias="xmax">
+                      <dxl:Ident ColId="118" ColName="xmax" TypeMdid="0.28.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="119" Alias="cmax">
+                      <dxl:Ident ColId="119" ColName="cmax" TypeMdid="0.29.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="120" Alias="tableoid">
+                      <dxl:Ident ColId="120" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="121" Alias="gp_segment_id">
+                      <dxl:Ident ColId="121" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                     </dxl:ProjElem>
                   </dxl:ProjList>
                   <dxl:Filter/>
                   <dxl:JoinFilter/>
                   <dxl:HashCondList>
                     <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                      <dxl:Ident ColId="43" ColName="a" TypeMdid="0.23.1.0"/>
-                      <dxl:Ident ColId="76" ColName="e" TypeMdid="0.23.1.0"/>
+                      <dxl:Ident ColId="87" ColName="a" TypeMdid="0.23.1.0"/>
+                      <dxl:Ident ColId="114" ColName="e" TypeMdid="0.23.1.0"/>
                     </dxl:Comparison>
                   </dxl:HashCondList>
                   <dxl:HashJoin JoinType="Inner">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="1293.003579" Rows="8.000000" Width="24"/>
+                      <dxl:Cost StartupCost="0" TotalCost="1293.013028" Rows="8.000000" Width="118"/>
                     </dxl:Properties>
                     <dxl:ProjList>
-                      <dxl:ProjElem ColId="43" Alias="a">
-                        <dxl:Ident ColId="43" ColName="a" TypeMdid="0.23.1.0"/>
+                      <dxl:ProjElem ColId="87" Alias="a">
+                        <dxl:Ident ColId="87" ColName="a" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
-                      <dxl:ProjElem ColId="45" Alias="x">
-                        <dxl:Ident ColId="45" ColName="x" TypeMdid="0.23.1.0"/>
+                      <dxl:ProjElem ColId="88" Alias="b">
+                        <dxl:Ident ColId="88" ColName="b" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
-                      <dxl:ProjElem ColId="46" Alias="y">
-                        <dxl:Ident ColId="46" ColName="y" TypeMdid="0.23.1.0"/>
+                      <dxl:ProjElem ColId="89" Alias="x">
+                        <dxl:Ident ColId="89" ColName="x" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="90" Alias="y">
+                        <dxl:Ident ColId="90" ColName="y" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="91" Alias="ctid">
+                        <dxl:Ident ColId="91" ColName="ctid" TypeMdid="0.27.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="92" Alias="xmin">
+                        <dxl:Ident ColId="92" ColName="xmin" TypeMdid="0.28.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="93" Alias="cmin">
+                        <dxl:Ident ColId="93" ColName="cmin" TypeMdid="0.29.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="94" Alias="xmax">
+                        <dxl:Ident ColId="94" ColName="xmax" TypeMdid="0.28.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="95" Alias="cmax">
+                        <dxl:Ident ColId="95" ColName="cmax" TypeMdid="0.29.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="96" Alias="tableoid">
+                        <dxl:Ident ColId="96" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="97" Alias="gp_segment_id">
+                        <dxl:Ident ColId="97" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="98" Alias="c">
+                        <dxl:Ident ColId="98" ColName="c" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="99" Alias="ctid">
+                        <dxl:Ident ColId="99" ColName="ctid" TypeMdid="0.27.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="100" Alias="xmin">
+                        <dxl:Ident ColId="100" ColName="xmin" TypeMdid="0.28.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="101" Alias="cmin">
+                        <dxl:Ident ColId="101" ColName="cmin" TypeMdid="0.29.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="102" Alias="xmax">
+                        <dxl:Ident ColId="102" ColName="xmax" TypeMdid="0.28.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="103" Alias="cmax">
+                        <dxl:Ident ColId="103" ColName="cmax" TypeMdid="0.29.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="104" Alias="tableoid">
+                        <dxl:Ident ColId="104" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="105" Alias="gp_segment_id">
+                        <dxl:Ident ColId="105" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="106" Alias="d">
+                        <dxl:Ident ColId="106" ColName="d" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="107" Alias="ctid">
+                        <dxl:Ident ColId="107" ColName="ctid" TypeMdid="0.27.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="108" Alias="xmin">
+                        <dxl:Ident ColId="108" ColName="xmin" TypeMdid="0.28.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="109" Alias="cmin">
+                        <dxl:Ident ColId="109" ColName="cmin" TypeMdid="0.29.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="110" Alias="xmax">
+                        <dxl:Ident ColId="110" ColName="xmax" TypeMdid="0.28.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="111" Alias="cmax">
+                        <dxl:Ident ColId="111" ColName="cmax" TypeMdid="0.29.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="112" Alias="tableoid">
+                        <dxl:Ident ColId="112" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="113" Alias="gp_segment_id">
+                        <dxl:Ident ColId="113" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
                     <dxl:JoinFilter/>
                     <dxl:HashCondList>
                       <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                        <dxl:Ident ColId="43" ColName="a" TypeMdid="0.23.1.0"/>
-                        <dxl:Ident ColId="65" ColName="d" TypeMdid="0.23.1.0"/>
+                        <dxl:Ident ColId="87" ColName="a" TypeMdid="0.23.1.0"/>
+                        <dxl:Ident ColId="106" ColName="d" TypeMdid="0.23.1.0"/>
                       </dxl:Comparison>
                     </dxl:HashCondList>
                     <dxl:HashJoin JoinType="Inner">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="862.001554" Rows="8.000000" Width="24"/>
+                        <dxl:Cost StartupCost="0" TotalCost="862.005318" Rows="8.000000" Width="84"/>
                       </dxl:Properties>
                       <dxl:ProjList>
-                        <dxl:ProjElem ColId="43" Alias="a">
-                          <dxl:Ident ColId="43" ColName="a" TypeMdid="0.23.1.0"/>
+                        <dxl:ProjElem ColId="87" Alias="a">
+                          <dxl:Ident ColId="87" ColName="a" TypeMdid="0.23.1.0"/>
                         </dxl:ProjElem>
-                        <dxl:ProjElem ColId="45" Alias="x">
-                          <dxl:Ident ColId="45" ColName="x" TypeMdid="0.23.1.0"/>
+                        <dxl:ProjElem ColId="88" Alias="b">
+                          <dxl:Ident ColId="88" ColName="b" TypeMdid="0.23.1.0"/>
                         </dxl:ProjElem>
-                        <dxl:ProjElem ColId="46" Alias="y">
-                          <dxl:Ident ColId="46" ColName="y" TypeMdid="0.23.1.0"/>
+                        <dxl:ProjElem ColId="89" Alias="x">
+                          <dxl:Ident ColId="89" ColName="x" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="90" Alias="y">
+                          <dxl:Ident ColId="90" ColName="y" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="91" Alias="ctid">
+                          <dxl:Ident ColId="91" ColName="ctid" TypeMdid="0.27.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="92" Alias="xmin">
+                          <dxl:Ident ColId="92" ColName="xmin" TypeMdid="0.28.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="93" Alias="cmin">
+                          <dxl:Ident ColId="93" ColName="cmin" TypeMdid="0.29.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="94" Alias="xmax">
+                          <dxl:Ident ColId="94" ColName="xmax" TypeMdid="0.28.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="95" Alias="cmax">
+                          <dxl:Ident ColId="95" ColName="cmax" TypeMdid="0.29.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="96" Alias="tableoid">
+                          <dxl:Ident ColId="96" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="97" Alias="gp_segment_id">
+                          <dxl:Ident ColId="97" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="98" Alias="c">
+                          <dxl:Ident ColId="98" ColName="c" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="99" Alias="ctid">
+                          <dxl:Ident ColId="99" ColName="ctid" TypeMdid="0.27.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="100" Alias="xmin">
+                          <dxl:Ident ColId="100" ColName="xmin" TypeMdid="0.28.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="101" Alias="cmin">
+                          <dxl:Ident ColId="101" ColName="cmin" TypeMdid="0.29.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="102" Alias="xmax">
+                          <dxl:Ident ColId="102" ColName="xmax" TypeMdid="0.28.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="103" Alias="cmax">
+                          <dxl:Ident ColId="103" ColName="cmax" TypeMdid="0.29.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="104" Alias="tableoid">
+                          <dxl:Ident ColId="104" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="105" Alias="gp_segment_id">
+                          <dxl:Ident ColId="105" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                         </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
                       <dxl:JoinFilter/>
                       <dxl:HashCondList>
                         <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                          <dxl:Ident ColId="43" ColName="a" TypeMdid="0.23.1.0"/>
-                          <dxl:Ident ColId="54" ColName="c" TypeMdid="0.23.1.0"/>
+                          <dxl:Ident ColId="98" ColName="c" TypeMdid="0.23.1.0"/>
+                          <dxl:Ident ColId="87" ColName="a" TypeMdid="0.23.1.0"/>
                         </dxl:Comparison>
                       </dxl:HashCondList>
                       <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="431.000094" Rows="1.000000" Width="24"/>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000771" Rows="8.000000" Width="34"/>
                         </dxl:Properties>
                         <dxl:ProjList>
-                          <dxl:ProjElem ColId="43" Alias="a">
-                            <dxl:Ident ColId="43" ColName="a" TypeMdid="0.23.1.0"/>
+                          <dxl:ProjElem ColId="98" Alias="c">
+                            <dxl:Ident ColId="98" ColName="c" TypeMdid="0.23.1.0"/>
                           </dxl:ProjElem>
-                          <dxl:ProjElem ColId="45" Alias="x">
-                            <dxl:Ident ColId="45" ColName="x" TypeMdid="0.23.1.0"/>
+                          <dxl:ProjElem ColId="99" Alias="ctid">
+                            <dxl:Ident ColId="99" ColName="ctid" TypeMdid="0.27.1.0"/>
                           </dxl:ProjElem>
-                          <dxl:ProjElem ColId="46" Alias="y">
-                            <dxl:Ident ColId="46" ColName="y" TypeMdid="0.23.1.0"/>
+                          <dxl:ProjElem ColId="100" Alias="xmin">
+                            <dxl:Ident ColId="100" ColName="xmin" TypeMdid="0.28.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="101" Alias="cmin">
+                            <dxl:Ident ColId="101" ColName="cmin" TypeMdid="0.29.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="102" Alias="xmax">
+                            <dxl:Ident ColId="102" ColName="xmax" TypeMdid="0.28.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="103" Alias="cmax">
+                            <dxl:Ident ColId="103" ColName="cmax" TypeMdid="0.29.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="104" Alias="tableoid">
+                            <dxl:Ident ColId="104" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="105" Alias="gp_segment_id">
+                            <dxl:Ident ColId="105" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                           </dxl:ProjElem>
                         </dxl:ProjList>
                         <dxl:Filter/>
                         <dxl:SortingColumnList/>
                         <dxl:HashExprList>
                           <dxl:HashExpr>
-                            <dxl:Ident ColId="43" ColName="a" TypeMdid="0.23.1.0"/>
+                            <dxl:Ident ColId="98" ColName="c" TypeMdid="0.23.1.0"/>
+                          </dxl:HashExpr>
+                        </dxl:HashExprList>
+                        <dxl:TableScan>
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000092" Rows="8.000000" Width="34"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="98" Alias="c">
+                              <dxl:Ident ColId="98" ColName="c" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="99" Alias="ctid">
+                              <dxl:Ident ColId="99" ColName="ctid" TypeMdid="0.27.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="100" Alias="xmin">
+                              <dxl:Ident ColId="100" ColName="xmin" TypeMdid="0.28.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="101" Alias="cmin">
+                              <dxl:Ident ColId="101" ColName="cmin" TypeMdid="0.29.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="102" Alias="xmax">
+                              <dxl:Ident ColId="102" ColName="xmax" TypeMdid="0.28.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="103" Alias="cmax">
+                              <dxl:Ident ColId="103" ColName="cmax" TypeMdid="0.29.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="104" Alias="tableoid">
+                              <dxl:Ident ColId="104" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="105" Alias="gp_segment_id">
+                              <dxl:Ident ColId="105" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:TableDescriptor Mdid="6.106604.1.1" TableName="mpp_s6756">
+                            <dxl:Columns>
+                              <dxl:Column ColId="98" Attno="1" ColName="c" TypeMdid="0.23.1.0"/>
+                              <dxl:Column ColId="122" Attno="2" ColName="d" TypeMdid="0.23.1.0"/>
+                              <dxl:Column ColId="123" Attno="3" ColName="e" TypeMdid="0.23.1.0"/>
+                              <dxl:Column ColId="99" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                              <dxl:Column ColId="100" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                              <dxl:Column ColId="101" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                              <dxl:Column ColId="102" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                              <dxl:Column ColId="103" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                              <dxl:Column ColId="104" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                              <dxl:Column ColId="105" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                            </dxl:Columns>
+                          </dxl:TableDescriptor>
+                        </dxl:TableScan>
+                      </dxl:RedistributeMotion>
+                      <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000182" Rows="1.000000" Width="50"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="87" Alias="a">
+                            <dxl:Ident ColId="87" ColName="a" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="88" Alias="b">
+                            <dxl:Ident ColId="88" ColName="b" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="89" Alias="x">
+                            <dxl:Ident ColId="89" ColName="x" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="90" Alias="y">
+                            <dxl:Ident ColId="90" ColName="y" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="91" Alias="ctid">
+                            <dxl:Ident ColId="91" ColName="ctid" TypeMdid="0.27.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="92" Alias="xmin">
+                            <dxl:Ident ColId="92" ColName="xmin" TypeMdid="0.28.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="93" Alias="cmin">
+                            <dxl:Ident ColId="93" ColName="cmin" TypeMdid="0.29.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="94" Alias="xmax">
+                            <dxl:Ident ColId="94" ColName="xmax" TypeMdid="0.28.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="95" Alias="cmax">
+                            <dxl:Ident ColId="95" ColName="cmax" TypeMdid="0.29.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="96" Alias="tableoid">
+                            <dxl:Ident ColId="96" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="97" Alias="gp_segment_id">
+                            <dxl:Ident ColId="97" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:SortingColumnList/>
+                        <dxl:HashExprList>
+                          <dxl:HashExpr>
+                            <dxl:Ident ColId="87" ColName="a" TypeMdid="0.23.1.0"/>
                           </dxl:HashExpr>
                         </dxl:HashExprList>
                         <dxl:Sequence>
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="431.000013" Rows="1.000000" Width="24"/>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000013" Rows="1.000000" Width="50"/>
                           </dxl:Properties>
                           <dxl:ProjList>
-                            <dxl:ProjElem ColId="43" Alias="a">
-                              <dxl:Ident ColId="43" ColName="a" TypeMdid="0.23.1.0"/>
+                            <dxl:ProjElem ColId="87" Alias="a">
+                              <dxl:Ident ColId="87" ColName="a" TypeMdid="0.23.1.0"/>
                             </dxl:ProjElem>
-                            <dxl:ProjElem ColId="45" Alias="x">
-                              <dxl:Ident ColId="45" ColName="x" TypeMdid="0.23.1.0"/>
+                            <dxl:ProjElem ColId="88" Alias="b">
+                              <dxl:Ident ColId="88" ColName="b" TypeMdid="0.23.1.0"/>
                             </dxl:ProjElem>
-                            <dxl:ProjElem ColId="46" Alias="y">
-                              <dxl:Ident ColId="46" ColName="y" TypeMdid="0.23.1.0"/>
+                            <dxl:ProjElem ColId="89" Alias="x">
+                              <dxl:Ident ColId="89" ColName="x" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="90" Alias="y">
+                              <dxl:Ident ColId="90" ColName="y" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="91" Alias="ctid">
+                              <dxl:Ident ColId="91" ColName="ctid" TypeMdid="0.27.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="92" Alias="xmin">
+                              <dxl:Ident ColId="92" ColName="xmin" TypeMdid="0.28.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="93" Alias="cmin">
+                              <dxl:Ident ColId="93" ColName="cmin" TypeMdid="0.29.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="94" Alias="xmax">
+                              <dxl:Ident ColId="94" ColName="xmax" TypeMdid="0.28.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="95" Alias="cmax">
+                              <dxl:Ident ColId="95" ColName="cmax" TypeMdid="0.29.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="96" Alias="tableoid">
+                              <dxl:Ident ColId="96" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                            </dxl:ProjElem>
+                            <dxl:ProjElem ColId="97" Alias="gp_segment_id">
+                              <dxl:Ident ColId="97" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                             </dxl:ProjElem>
                           </dxl:ProjList>
                           <dxl:PartitionSelector RelationMdid="6.106508.1.1" PartitionLevels="1" ScanId="2">
@@ -1115,114 +2557,143 @@
                           </dxl:PartitionSelector>
                           <dxl:DynamicTableScan PartIndexId="2">
                             <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="431.000013" Rows="1.000000" Width="24"/>
+                              <dxl:Cost StartupCost="0" TotalCost="431.000013" Rows="1.000000" Width="50"/>
                             </dxl:Properties>
                             <dxl:ProjList>
-                              <dxl:ProjElem ColId="43" Alias="a">
-                                <dxl:Ident ColId="43" ColName="a" TypeMdid="0.23.1.0"/>
+                              <dxl:ProjElem ColId="87" Alias="a">
+                                <dxl:Ident ColId="87" ColName="a" TypeMdid="0.23.1.0"/>
                               </dxl:ProjElem>
-                              <dxl:ProjElem ColId="45" Alias="x">
-                                <dxl:Ident ColId="45" ColName="x" TypeMdid="0.23.1.0"/>
+                              <dxl:ProjElem ColId="88" Alias="b">
+                                <dxl:Ident ColId="88" ColName="b" TypeMdid="0.23.1.0"/>
                               </dxl:ProjElem>
-                              <dxl:ProjElem ColId="46" Alias="y">
-                                <dxl:Ident ColId="46" ColName="y" TypeMdid="0.23.1.0"/>
+                              <dxl:ProjElem ColId="89" Alias="x">
+                                <dxl:Ident ColId="89" ColName="x" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="90" Alias="y">
+                                <dxl:Ident ColId="90" ColName="y" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="91" Alias="ctid">
+                                <dxl:Ident ColId="91" ColName="ctid" TypeMdid="0.27.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="92" Alias="xmin">
+                                <dxl:Ident ColId="92" ColName="xmin" TypeMdid="0.28.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="93" Alias="cmin">
+                                <dxl:Ident ColId="93" ColName="cmin" TypeMdid="0.29.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="94" Alias="xmax">
+                                <dxl:Ident ColId="94" ColName="xmax" TypeMdid="0.28.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="95" Alias="cmax">
+                                <dxl:Ident ColId="95" ColName="cmax" TypeMdid="0.29.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="96" Alias="tableoid">
+                                <dxl:Ident ColId="96" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="97" Alias="gp_segment_id">
+                                <dxl:Ident ColId="97" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                               </dxl:ProjElem>
                             </dxl:ProjList>
                             <dxl:Filter/>
                             <dxl:TableDescriptor Mdid="6.106508.1.1" TableName="mpp_r6756">
                               <dxl:Columns>
-                                <dxl:Column ColId="43" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
-                                <dxl:Column ColId="45" Attno="3" ColName="x" TypeMdid="0.23.1.0"/>
-                                <dxl:Column ColId="46" Attno="4" ColName="y" TypeMdid="0.23.1.0"/>
-                                <dxl:Column ColId="47" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                                <dxl:Column ColId="48" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                                <dxl:Column ColId="49" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                                <dxl:Column ColId="50" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                                <dxl:Column ColId="51" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                                <dxl:Column ColId="52" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                                <dxl:Column ColId="53" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                <dxl:Column ColId="87" Attno="1" ColName="a" TypeMdid="0.23.1.0"/>
+                                <dxl:Column ColId="88" Attno="2" ColName="b" TypeMdid="0.23.1.0"/>
+                                <dxl:Column ColId="89" Attno="3" ColName="x" TypeMdid="0.23.1.0"/>
+                                <dxl:Column ColId="90" Attno="4" ColName="y" TypeMdid="0.23.1.0"/>
+                                <dxl:Column ColId="91" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                <dxl:Column ColId="92" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                                <dxl:Column ColId="93" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                                <dxl:Column ColId="94" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                                <dxl:Column ColId="95" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                                <dxl:Column ColId="96" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                <dxl:Column ColId="97" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                               </dxl:Columns>
                             </dxl:TableDescriptor>
                           </dxl:DynamicTableScan>
                         </dxl:Sequence>
                       </dxl:RedistributeMotion>
-                      <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
-                        <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="431.000172" Rows="8.000000" Width="4"/>
-                        </dxl:Properties>
-                        <dxl:ProjList>
-                          <dxl:ProjElem ColId="54" Alias="c">
-                            <dxl:Ident ColId="54" ColName="c" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
-                        </dxl:ProjList>
-                        <dxl:Filter/>
-                        <dxl:SortingColumnList/>
-                        <dxl:HashExprList>
-                          <dxl:HashExpr>
-                            <dxl:Ident ColId="54" ColName="c" TypeMdid="0.23.1.0"/>
-                          </dxl:HashExpr>
-                        </dxl:HashExprList>
-                        <dxl:TableScan>
-                          <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="431.000092" Rows="8.000000" Width="4"/>
-                          </dxl:Properties>
-                          <dxl:ProjList>
-                            <dxl:ProjElem ColId="54" Alias="c">
-                              <dxl:Ident ColId="54" ColName="c" TypeMdid="0.23.1.0"/>
-                            </dxl:ProjElem>
-                          </dxl:ProjList>
-                          <dxl:Filter/>
-                          <dxl:TableDescriptor Mdid="6.106604.1.1" TableName="mpp_s6756">
-                            <dxl:Columns>
-                              <dxl:Column ColId="54" Attno="1" ColName="c" TypeMdid="0.23.1.0"/>
-                              <dxl:Column ColId="57" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                              <dxl:Column ColId="58" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                              <dxl:Column ColId="59" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                              <dxl:Column ColId="60" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                              <dxl:Column ColId="61" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                              <dxl:Column ColId="62" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                              <dxl:Column ColId="63" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                            </dxl:Columns>
-                          </dxl:TableDescriptor>
-                        </dxl:TableScan>
-                      </dxl:RedistributeMotion>
                     </dxl:HashJoin>
                     <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000172" Rows="8.000000" Width="4"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000771" Rows="8.000000" Width="34"/>
                       </dxl:Properties>
                       <dxl:ProjList>
-                        <dxl:ProjElem ColId="65" Alias="d">
-                          <dxl:Ident ColId="65" ColName="d" TypeMdid="0.23.1.0"/>
+                        <dxl:ProjElem ColId="106" Alias="d">
+                          <dxl:Ident ColId="106" ColName="d" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="107" Alias="ctid">
+                          <dxl:Ident ColId="107" ColName="ctid" TypeMdid="0.27.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="108" Alias="xmin">
+                          <dxl:Ident ColId="108" ColName="xmin" TypeMdid="0.28.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="109" Alias="cmin">
+                          <dxl:Ident ColId="109" ColName="cmin" TypeMdid="0.29.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="110" Alias="xmax">
+                          <dxl:Ident ColId="110" ColName="xmax" TypeMdid="0.28.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="111" Alias="cmax">
+                          <dxl:Ident ColId="111" ColName="cmax" TypeMdid="0.29.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="112" Alias="tableoid">
+                          <dxl:Ident ColId="112" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="113" Alias="gp_segment_id">
+                          <dxl:Ident ColId="113" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                         </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
                       <dxl:SortingColumnList/>
                       <dxl:HashExprList>
                         <dxl:HashExpr>
-                          <dxl:Ident ColId="65" ColName="d" TypeMdid="0.23.1.0"/>
+                          <dxl:Ident ColId="106" ColName="d" TypeMdid="0.23.1.0"/>
                         </dxl:HashExpr>
                       </dxl:HashExprList>
                       <dxl:TableScan>
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="431.000092" Rows="8.000000" Width="4"/>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000092" Rows="8.000000" Width="34"/>
                         </dxl:Properties>
                         <dxl:ProjList>
-                          <dxl:ProjElem ColId="65" Alias="d">
-                            <dxl:Ident ColId="65" ColName="d" TypeMdid="0.23.1.0"/>
+                          <dxl:ProjElem ColId="106" Alias="d">
+                            <dxl:Ident ColId="106" ColName="d" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="107" Alias="ctid">
+                            <dxl:Ident ColId="107" ColName="ctid" TypeMdid="0.27.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="108" Alias="xmin">
+                            <dxl:Ident ColId="108" ColName="xmin" TypeMdid="0.28.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="109" Alias="cmin">
+                            <dxl:Ident ColId="109" ColName="cmin" TypeMdid="0.29.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="110" Alias="xmax">
+                            <dxl:Ident ColId="110" ColName="xmax" TypeMdid="0.28.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="111" Alias="cmax">
+                            <dxl:Ident ColId="111" ColName="cmax" TypeMdid="0.29.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="112" Alias="tableoid">
+                            <dxl:Ident ColId="112" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                          </dxl:ProjElem>
+                          <dxl:ProjElem ColId="113" Alias="gp_segment_id">
+                            <dxl:Ident ColId="113" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                           </dxl:ProjElem>
                         </dxl:ProjList>
                         <dxl:Filter/>
                         <dxl:TableDescriptor Mdid="6.106604.1.1" TableName="mpp_s6756">
                           <dxl:Columns>
-                            <dxl:Column ColId="65" Attno="2" ColName="d" TypeMdid="0.23.1.0"/>
-                            <dxl:Column ColId="67" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                            <dxl:Column ColId="68" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                            <dxl:Column ColId="69" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                            <dxl:Column ColId="70" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                            <dxl:Column ColId="71" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                            <dxl:Column ColId="72" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                            <dxl:Column ColId="73" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                            <dxl:Column ColId="124" Attno="1" ColName="c" TypeMdid="0.23.1.0"/>
+                            <dxl:Column ColId="106" Attno="2" ColName="d" TypeMdid="0.23.1.0"/>
+                            <dxl:Column ColId="125" Attno="3" ColName="e" TypeMdid="0.23.1.0"/>
+                            <dxl:Column ColId="107" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                            <dxl:Column ColId="108" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                            <dxl:Column ColId="109" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                            <dxl:Column ColId="110" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                            <dxl:Column ColId="111" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                            <dxl:Column ColId="112" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                            <dxl:Column ColId="113" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                           </dxl:Columns>
                         </dxl:TableDescriptor>
                       </dxl:TableScan>
@@ -1230,47 +2701,625 @@
                   </dxl:HashJoin>
                   <dxl:RedistributeMotion InputSegments="0,1" OutputSegments="0,1">
                     <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000172" Rows="8.000000" Width="4"/>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000771" Rows="8.000000" Width="34"/>
                     </dxl:Properties>
                     <dxl:ProjList>
-                      <dxl:ProjElem ColId="76" Alias="e">
-                        <dxl:Ident ColId="76" ColName="e" TypeMdid="0.23.1.0"/>
+                      <dxl:ProjElem ColId="114" Alias="e">
+                        <dxl:Ident ColId="114" ColName="e" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="115" Alias="ctid">
+                        <dxl:Ident ColId="115" ColName="ctid" TypeMdid="0.27.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="116" Alias="xmin">
+                        <dxl:Ident ColId="116" ColName="xmin" TypeMdid="0.28.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="117" Alias="cmin">
+                        <dxl:Ident ColId="117" ColName="cmin" TypeMdid="0.29.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="118" Alias="xmax">
+                        <dxl:Ident ColId="118" ColName="xmax" TypeMdid="0.28.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="119" Alias="cmax">
+                        <dxl:Ident ColId="119" ColName="cmax" TypeMdid="0.29.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="120" Alias="tableoid">
+                        <dxl:Ident ColId="120" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="121" Alias="gp_segment_id">
+                        <dxl:Ident ColId="121" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                       </dxl:ProjElem>
                     </dxl:ProjList>
                     <dxl:Filter/>
                     <dxl:SortingColumnList/>
                     <dxl:HashExprList>
                       <dxl:HashExpr>
-                        <dxl:Ident ColId="76" ColName="e" TypeMdid="0.23.1.0"/>
+                        <dxl:Ident ColId="114" ColName="e" TypeMdid="0.23.1.0"/>
                       </dxl:HashExpr>
                     </dxl:HashExprList>
                     <dxl:TableScan>
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000092" Rows="8.000000" Width="4"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000092" Rows="8.000000" Width="34"/>
                       </dxl:Properties>
                       <dxl:ProjList>
-                        <dxl:ProjElem ColId="76" Alias="e">
-                          <dxl:Ident ColId="76" ColName="e" TypeMdid="0.23.1.0"/>
+                        <dxl:ProjElem ColId="114" Alias="e">
+                          <dxl:Ident ColId="114" ColName="e" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="115" Alias="ctid">
+                          <dxl:Ident ColId="115" ColName="ctid" TypeMdid="0.27.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="116" Alias="xmin">
+                          <dxl:Ident ColId="116" ColName="xmin" TypeMdid="0.28.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="117" Alias="cmin">
+                          <dxl:Ident ColId="117" ColName="cmin" TypeMdid="0.29.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="118" Alias="xmax">
+                          <dxl:Ident ColId="118" ColName="xmax" TypeMdid="0.28.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="119" Alias="cmax">
+                          <dxl:Ident ColId="119" ColName="cmax" TypeMdid="0.29.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="120" Alias="tableoid">
+                          <dxl:Ident ColId="120" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="121" Alias="gp_segment_id">
+                          <dxl:Ident ColId="121" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                         </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
                       <dxl:TableDescriptor Mdid="6.106604.1.1" TableName="mpp_s6756">
                         <dxl:Columns>
-                          <dxl:Column ColId="76" Attno="3" ColName="e" TypeMdid="0.23.1.0"/>
-                          <dxl:Column ColId="77" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                          <dxl:Column ColId="78" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                          <dxl:Column ColId="79" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                          <dxl:Column ColId="80" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                          <dxl:Column ColId="81" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                          <dxl:Column ColId="82" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                          <dxl:Column ColId="83" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                          <dxl:Column ColId="126" Attno="1" ColName="c" TypeMdid="0.23.1.0"/>
+                          <dxl:Column ColId="127" Attno="2" ColName="d" TypeMdid="0.23.1.0"/>
+                          <dxl:Column ColId="114" Attno="3" ColName="e" TypeMdid="0.23.1.0"/>
+                          <dxl:Column ColId="115" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                          <dxl:Column ColId="116" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                          <dxl:Column ColId="117" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                          <dxl:Column ColId="118" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                          <dxl:Column ColId="119" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                          <dxl:Column ColId="120" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                          <dxl:Column ColId="121" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
                         </dxl:Columns>
                       </dxl:TableDescriptor>
                     </dxl:TableScan>
                   </dxl:RedistributeMotion>
                 </dxl:HashJoin>
-              </dxl:Sort>
-            </dxl:Aggregate>
+              </dxl:CTEProducer>
+              <dxl:HashJoin JoinType="Inner">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="862.000440" Rows="1.000000" Width="20"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="43" Alias="a">
+                    <dxl:Ident ColId="43" ColName="a" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="84" Alias="count">
+                    <dxl:Ident ColId="84" ColName="count" TypeMdid="0.20.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="85" Alias="count">
+                    <dxl:Ident ColId="85" ColName="count" TypeMdid="0.20.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:JoinFilter/>
+                <dxl:HashCondList>
+                  <dxl:Not>
+                    <dxl:IsDistinctFrom OperatorMdid="0.96.1.0">
+                      <dxl:Ident ColId="43" ColName="a" TypeMdid="0.23.1.0"/>
+                      <dxl:Ident ColId="134" ColName="a" TypeMdid="0.23.1.0"/>
+                    </dxl:IsDistinctFrom>
+                  </dxl:Not>
+                </dxl:HashCondList>
+                <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000064" Rows="1.000000" Width="12"/>
+                  </dxl:Properties>
+                  <dxl:GroupingColumns>
+                    <dxl:GroupingColumn ColId="43"/>
+                  </dxl:GroupingColumns>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="84" Alias="count">
+                      <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="true" AggStage="Normal" AggKind="n">
+                        <dxl:ValuesList ParamType="aggargs">
+                          <dxl:Ident ColId="45" ColName="x" TypeMdid="0.23.1.0"/>
+                        </dxl:ValuesList>
+                        <dxl:ValuesList ParamType="aggdirectargs"/>
+                        <dxl:ValuesList ParamType="aggorder"/>
+                        <dxl:ValuesList ParamType="aggdistinct"/>
+                      </dxl:AggFunc>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="43" Alias="a">
+                      <dxl:Ident ColId="43" ColName="a" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:Sort SortDiscardDuplicates="false">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000047" Rows="2.275556" Width="12"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="43" Alias="a">
+                        <dxl:Ident ColId="43" ColName="a" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="44" Alias="b">
+                        <dxl:Ident ColId="44" ColName="b" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="45" Alias="x">
+                        <dxl:Ident ColId="45" ColName="x" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="46" Alias="y">
+                        <dxl:Ident ColId="46" ColName="y" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="47" Alias="ctid">
+                        <dxl:Ident ColId="47" ColName="ctid" TypeMdid="0.27.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="48" Alias="xmin">
+                        <dxl:Ident ColId="48" ColName="xmin" TypeMdid="0.28.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="49" Alias="cmin">
+                        <dxl:Ident ColId="49" ColName="cmin" TypeMdid="0.29.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="50" Alias="xmax">
+                        <dxl:Ident ColId="50" ColName="xmax" TypeMdid="0.28.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="51" Alias="cmax">
+                        <dxl:Ident ColId="51" ColName="cmax" TypeMdid="0.29.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="52" Alias="tableoid">
+                        <dxl:Ident ColId="52" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="53" Alias="gp_segment_id">
+                        <dxl:Ident ColId="53" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="54" Alias="c">
+                        <dxl:Ident ColId="54" ColName="c" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="57" Alias="ctid">
+                        <dxl:Ident ColId="57" ColName="ctid" TypeMdid="0.27.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="58" Alias="xmin">
+                        <dxl:Ident ColId="58" ColName="xmin" TypeMdid="0.28.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="59" Alias="cmin">
+                        <dxl:Ident ColId="59" ColName="cmin" TypeMdid="0.29.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="60" Alias="xmax">
+                        <dxl:Ident ColId="60" ColName="xmax" TypeMdid="0.28.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="61" Alias="cmax">
+                        <dxl:Ident ColId="61" ColName="cmax" TypeMdid="0.29.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="62" Alias="tableoid">
+                        <dxl:Ident ColId="62" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="63" Alias="gp_segment_id">
+                        <dxl:Ident ColId="63" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="65" Alias="d">
+                        <dxl:Ident ColId="65" ColName="d" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="67" Alias="ctid">
+                        <dxl:Ident ColId="67" ColName="ctid" TypeMdid="0.27.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="68" Alias="xmin">
+                        <dxl:Ident ColId="68" ColName="xmin" TypeMdid="0.28.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="69" Alias="cmin">
+                        <dxl:Ident ColId="69" ColName="cmin" TypeMdid="0.29.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="70" Alias="xmax">
+                        <dxl:Ident ColId="70" ColName="xmax" TypeMdid="0.28.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="71" Alias="cmax">
+                        <dxl:Ident ColId="71" ColName="cmax" TypeMdid="0.29.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="72" Alias="tableoid">
+                        <dxl:Ident ColId="72" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="73" Alias="gp_segment_id">
+                        <dxl:Ident ColId="73" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="76" Alias="e">
+                        <dxl:Ident ColId="76" ColName="e" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="77" Alias="ctid">
+                        <dxl:Ident ColId="77" ColName="ctid" TypeMdid="0.27.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="78" Alias="xmin">
+                        <dxl:Ident ColId="78" ColName="xmin" TypeMdid="0.28.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="79" Alias="cmin">
+                        <dxl:Ident ColId="79" ColName="cmin" TypeMdid="0.29.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="80" Alias="xmax">
+                        <dxl:Ident ColId="80" ColName="xmax" TypeMdid="0.28.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="81" Alias="cmax">
+                        <dxl:Ident ColId="81" ColName="cmax" TypeMdid="0.29.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="82" Alias="tableoid">
+                        <dxl:Ident ColId="82" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="83" Alias="gp_segment_id">
+                        <dxl:Ident ColId="83" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:SortingColumnList>
+                      <dxl:SortingColumn ColId="43" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                    </dxl:SortingColumnList>
+                    <dxl:LimitCount/>
+                    <dxl:LimitOffset/>
+                    <dxl:CTEConsumer CTEId="0" Columns="43,44,45,46,47,48,49,50,51,52,53,54,57,58,59,60,61,62,63,65,67,68,69,70,71,72,73,76,77,78,79,80,81,82,83">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000033" Rows="2.275556" Width="12"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="43" Alias="a">
+                          <dxl:Ident ColId="43" ColName="a" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="44" Alias="b">
+                          <dxl:Ident ColId="44" ColName="b" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="45" Alias="x">
+                          <dxl:Ident ColId="45" ColName="x" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="46" Alias="y">
+                          <dxl:Ident ColId="46" ColName="y" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="47" Alias="ctid">
+                          <dxl:Ident ColId="47" ColName="ctid" TypeMdid="0.27.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="48" Alias="xmin">
+                          <dxl:Ident ColId="48" ColName="xmin" TypeMdid="0.28.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="49" Alias="cmin">
+                          <dxl:Ident ColId="49" ColName="cmin" TypeMdid="0.29.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="50" Alias="xmax">
+                          <dxl:Ident ColId="50" ColName="xmax" TypeMdid="0.28.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="51" Alias="cmax">
+                          <dxl:Ident ColId="51" ColName="cmax" TypeMdid="0.29.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="52" Alias="tableoid">
+                          <dxl:Ident ColId="52" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="53" Alias="gp_segment_id">
+                          <dxl:Ident ColId="53" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="54" Alias="c">
+                          <dxl:Ident ColId="54" ColName="c" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="57" Alias="ctid">
+                          <dxl:Ident ColId="57" ColName="ctid" TypeMdid="0.27.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="58" Alias="xmin">
+                          <dxl:Ident ColId="58" ColName="xmin" TypeMdid="0.28.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="59" Alias="cmin">
+                          <dxl:Ident ColId="59" ColName="cmin" TypeMdid="0.29.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="60" Alias="xmax">
+                          <dxl:Ident ColId="60" ColName="xmax" TypeMdid="0.28.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="61" Alias="cmax">
+                          <dxl:Ident ColId="61" ColName="cmax" TypeMdid="0.29.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="62" Alias="tableoid">
+                          <dxl:Ident ColId="62" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="63" Alias="gp_segment_id">
+                          <dxl:Ident ColId="63" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="65" Alias="d">
+                          <dxl:Ident ColId="65" ColName="d" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="67" Alias="ctid">
+                          <dxl:Ident ColId="67" ColName="ctid" TypeMdid="0.27.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="68" Alias="xmin">
+                          <dxl:Ident ColId="68" ColName="xmin" TypeMdid="0.28.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="69" Alias="cmin">
+                          <dxl:Ident ColId="69" ColName="cmin" TypeMdid="0.29.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="70" Alias="xmax">
+                          <dxl:Ident ColId="70" ColName="xmax" TypeMdid="0.28.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="71" Alias="cmax">
+                          <dxl:Ident ColId="71" ColName="cmax" TypeMdid="0.29.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="72" Alias="tableoid">
+                          <dxl:Ident ColId="72" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="73" Alias="gp_segment_id">
+                          <dxl:Ident ColId="73" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="76" Alias="e">
+                          <dxl:Ident ColId="76" ColName="e" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="77" Alias="ctid">
+                          <dxl:Ident ColId="77" ColName="ctid" TypeMdid="0.27.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="78" Alias="xmin">
+                          <dxl:Ident ColId="78" ColName="xmin" TypeMdid="0.28.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="79" Alias="cmin">
+                          <dxl:Ident ColId="79" ColName="cmin" TypeMdid="0.29.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="80" Alias="xmax">
+                          <dxl:Ident ColId="80" ColName="xmax" TypeMdid="0.28.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="81" Alias="cmax">
+                          <dxl:Ident ColId="81" ColName="cmax" TypeMdid="0.29.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="82" Alias="tableoid">
+                          <dxl:Ident ColId="82" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="83" Alias="gp_segment_id">
+                          <dxl:Ident ColId="83" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                    </dxl:CTEConsumer>
+                  </dxl:Sort>
+                </dxl:Aggregate>
+                <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000064" Rows="1.000000" Width="12"/>
+                  </dxl:Properties>
+                  <dxl:GroupingColumns>
+                    <dxl:GroupingColumn ColId="134"/>
+                  </dxl:GroupingColumns>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="85" Alias="count">
+                      <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="true" AggStage="Normal" AggKind="n">
+                        <dxl:ValuesList ParamType="aggargs">
+                          <dxl:Ident ColId="137" ColName="y" TypeMdid="0.23.1.0"/>
+                        </dxl:ValuesList>
+                        <dxl:ValuesList ParamType="aggdirectargs"/>
+                        <dxl:ValuesList ParamType="aggorder"/>
+                        <dxl:ValuesList ParamType="aggdistinct"/>
+                      </dxl:AggFunc>
+                    </dxl:ProjElem>
+                    <dxl:ProjElem ColId="134" Alias="a">
+                      <dxl:Ident ColId="134" ColName="a" TypeMdid="0.23.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:Sort SortDiscardDuplicates="false">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000047" Rows="2.275556" Width="12"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="134" Alias="a">
+                        <dxl:Ident ColId="134" ColName="a" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="135" Alias="b">
+                        <dxl:Ident ColId="135" ColName="b" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="136" Alias="x">
+                        <dxl:Ident ColId="136" ColName="x" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="137" Alias="y">
+                        <dxl:Ident ColId="137" ColName="y" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="138" Alias="ctid">
+                        <dxl:Ident ColId="138" ColName="ctid" TypeMdid="0.27.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="139" Alias="xmin">
+                        <dxl:Ident ColId="139" ColName="xmin" TypeMdid="0.28.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="140" Alias="cmin">
+                        <dxl:Ident ColId="140" ColName="cmin" TypeMdid="0.29.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="141" Alias="xmax">
+                        <dxl:Ident ColId="141" ColName="xmax" TypeMdid="0.28.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="142" Alias="cmax">
+                        <dxl:Ident ColId="142" ColName="cmax" TypeMdid="0.29.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="143" Alias="tableoid">
+                        <dxl:Ident ColId="143" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="144" Alias="gp_segment_id">
+                        <dxl:Ident ColId="144" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="145" Alias="c">
+                        <dxl:Ident ColId="145" ColName="c" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="146" Alias="ctid">
+                        <dxl:Ident ColId="146" ColName="ctid" TypeMdid="0.27.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="147" Alias="xmin">
+                        <dxl:Ident ColId="147" ColName="xmin" TypeMdid="0.28.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="148" Alias="cmin">
+                        <dxl:Ident ColId="148" ColName="cmin" TypeMdid="0.29.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="149" Alias="xmax">
+                        <dxl:Ident ColId="149" ColName="xmax" TypeMdid="0.28.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="150" Alias="cmax">
+                        <dxl:Ident ColId="150" ColName="cmax" TypeMdid="0.29.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="151" Alias="tableoid">
+                        <dxl:Ident ColId="151" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="152" Alias="gp_segment_id">
+                        <dxl:Ident ColId="152" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="153" Alias="d">
+                        <dxl:Ident ColId="153" ColName="d" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="154" Alias="ctid">
+                        <dxl:Ident ColId="154" ColName="ctid" TypeMdid="0.27.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="155" Alias="xmin">
+                        <dxl:Ident ColId="155" ColName="xmin" TypeMdid="0.28.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="156" Alias="cmin">
+                        <dxl:Ident ColId="156" ColName="cmin" TypeMdid="0.29.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="157" Alias="xmax">
+                        <dxl:Ident ColId="157" ColName="xmax" TypeMdid="0.28.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="158" Alias="cmax">
+                        <dxl:Ident ColId="158" ColName="cmax" TypeMdid="0.29.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="159" Alias="tableoid">
+                        <dxl:Ident ColId="159" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="160" Alias="gp_segment_id">
+                        <dxl:Ident ColId="160" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="161" Alias="e">
+                        <dxl:Ident ColId="161" ColName="e" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="162" Alias="ctid">
+                        <dxl:Ident ColId="162" ColName="ctid" TypeMdid="0.27.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="163" Alias="xmin">
+                        <dxl:Ident ColId="163" ColName="xmin" TypeMdid="0.28.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="164" Alias="cmin">
+                        <dxl:Ident ColId="164" ColName="cmin" TypeMdid="0.29.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="165" Alias="xmax">
+                        <dxl:Ident ColId="165" ColName="xmax" TypeMdid="0.28.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="166" Alias="cmax">
+                        <dxl:Ident ColId="166" ColName="cmax" TypeMdid="0.29.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="167" Alias="tableoid">
+                        <dxl:Ident ColId="167" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="168" Alias="gp_segment_id">
+                        <dxl:Ident ColId="168" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:SortingColumnList>
+                      <dxl:SortingColumn ColId="134" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+                    </dxl:SortingColumnList>
+                    <dxl:LimitCount/>
+                    <dxl:LimitOffset/>
+                    <dxl:CTEConsumer CTEId="0" Columns="134,135,136,137,138,139,140,141,142,143,144,145,146,147,148,149,150,151,152,153,154,155,156,157,158,159,160,161,162,163,164,165,166,167,168">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000033" Rows="2.275556" Width="12"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="134" Alias="a">
+                          <dxl:Ident ColId="134" ColName="a" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="135" Alias="b">
+                          <dxl:Ident ColId="135" ColName="b" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="136" Alias="x">
+                          <dxl:Ident ColId="136" ColName="x" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="137" Alias="y">
+                          <dxl:Ident ColId="137" ColName="y" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="138" Alias="ctid">
+                          <dxl:Ident ColId="138" ColName="ctid" TypeMdid="0.27.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="139" Alias="xmin">
+                          <dxl:Ident ColId="139" ColName="xmin" TypeMdid="0.28.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="140" Alias="cmin">
+                          <dxl:Ident ColId="140" ColName="cmin" TypeMdid="0.29.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="141" Alias="xmax">
+                          <dxl:Ident ColId="141" ColName="xmax" TypeMdid="0.28.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="142" Alias="cmax">
+                          <dxl:Ident ColId="142" ColName="cmax" TypeMdid="0.29.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="143" Alias="tableoid">
+                          <dxl:Ident ColId="143" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="144" Alias="gp_segment_id">
+                          <dxl:Ident ColId="144" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="145" Alias="c">
+                          <dxl:Ident ColId="145" ColName="c" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="146" Alias="ctid">
+                          <dxl:Ident ColId="146" ColName="ctid" TypeMdid="0.27.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="147" Alias="xmin">
+                          <dxl:Ident ColId="147" ColName="xmin" TypeMdid="0.28.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="148" Alias="cmin">
+                          <dxl:Ident ColId="148" ColName="cmin" TypeMdid="0.29.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="149" Alias="xmax">
+                          <dxl:Ident ColId="149" ColName="xmax" TypeMdid="0.28.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="150" Alias="cmax">
+                          <dxl:Ident ColId="150" ColName="cmax" TypeMdid="0.29.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="151" Alias="tableoid">
+                          <dxl:Ident ColId="151" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="152" Alias="gp_segment_id">
+                          <dxl:Ident ColId="152" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="153" Alias="d">
+                          <dxl:Ident ColId="153" ColName="d" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="154" Alias="ctid">
+                          <dxl:Ident ColId="154" ColName="ctid" TypeMdid="0.27.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="155" Alias="xmin">
+                          <dxl:Ident ColId="155" ColName="xmin" TypeMdid="0.28.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="156" Alias="cmin">
+                          <dxl:Ident ColId="156" ColName="cmin" TypeMdid="0.29.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="157" Alias="xmax">
+                          <dxl:Ident ColId="157" ColName="xmax" TypeMdid="0.28.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="158" Alias="cmax">
+                          <dxl:Ident ColId="158" ColName="cmax" TypeMdid="0.29.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="159" Alias="tableoid">
+                          <dxl:Ident ColId="159" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="160" Alias="gp_segment_id">
+                          <dxl:Ident ColId="160" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="161" Alias="e">
+                          <dxl:Ident ColId="161" ColName="e" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="162" Alias="ctid">
+                          <dxl:Ident ColId="162" ColName="ctid" TypeMdid="0.27.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="163" Alias="xmin">
+                          <dxl:Ident ColId="163" ColName="xmin" TypeMdid="0.28.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="164" Alias="cmin">
+                          <dxl:Ident ColId="164" ColName="cmin" TypeMdid="0.29.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="165" Alias="xmax">
+                          <dxl:Ident ColId="165" ColName="xmax" TypeMdid="0.28.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="166" Alias="cmax">
+                          <dxl:Ident ColId="166" ColName="cmax" TypeMdid="0.29.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="167" Alias="tableoid">
+                          <dxl:Ident ColId="167" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="168" Alias="gp_segment_id">
+                          <dxl:Ident ColId="168" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                    </dxl:CTEConsumer>
+                  </dxl:Sort>
+                </dxl:Aggregate>
+              </dxl:HashJoin>
+            </dxl:Sequence>
           </dxl:Result>
         </dxl:Append>
       </dxl:GatherMotion>

--- a/src/backend/gporca/libgpopt/src/xforms/CXformUtils.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformUtils.cpp
@@ -4394,6 +4394,11 @@ CXformUtils::MapPrjElemsWithDistinctAggs(
 			// use first argument of Distinct Agg as key
 			pexprKey = (*pexprChild)[0];
 		}
+		else if (is_distinct && COperator::EopScalarAggFunc == eopidChild)
+		{
+			// use first argument of AggFunc args list as key
+			pexprKey = (*(pexprChild->PdrgPexpr()))[EaggfuncIndexArgs];
+		}
 		else
 		{
 			// use constant True as key

--- a/src/test/regress/expected/gp_dqa.out
+++ b/src/test/regress/expected/gp_dqa.out
@@ -1326,3 +1326,75 @@ SELECT distinct C.z, count(distinct FS.x), count(distinct FS.y) FROM (SELECT i A
 (0 rows)
 
 drop table foo_mdqa;
+-- Test some corner case of dqa ex.NULL
+create table dqa_f4(a int, b int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into dqa_f4 values(null, null, null);
+insert into dqa_f4 values(1, 1, 1);
+insert into dqa_f4 values(2, 2, 2);
+select count(distinct a), count(distinct b) from dqa_f4 group by c;
+ count | count 
+-------+-------
+     0 |     0
+     1 |     1
+     1 |     1
+(3 rows)
+
+set optimizer_enable_multiple_distinct_aggs=on;
+explain (verbose on, costs off) select count(distinct a), count(distinct b) from dqa_f4 group by c;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)
+   Output: (count(share0_ref2.a)), (count(share0_ref1.b)), share0_ref2.c
+   ->  Hash Join
+         Output: (count(share0_ref2.a)), (count(share0_ref1.b)), share0_ref2.c
+         Hash Cond: (NOT (share0_ref2.c IS DISTINCT FROM share0_ref1.c))
+         ->  HashAggregate
+               Output: share0_ref2.c, count(share0_ref2.a)
+               Group Key: share0_ref2.c
+               ->  HashAggregate
+                     Output: share0_ref2.c, share0_ref2.a
+                     Group Key: share0_ref2.c, share0_ref2.a
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                           Output: share0_ref2.c, share0_ref2.a
+                           Hash Key: share0_ref2.c
+                           ->  HashAggregate
+                                 Output: share0_ref2.c, share0_ref2.a
+                                 Group Key: share0_ref2.c, share0_ref2.a
+                                 ->  Shared Scan (share slice:id 1:0)
+                                       Output: share0_ref2.a, share0_ref2.b, share0_ref2.c
+         ->  Hash
+               Output: share0_ref1.c, (count(share0_ref1.b))
+               ->  HashAggregate
+                     Output: share0_ref1.c, count(share0_ref1.b)
+                     Group Key: share0_ref1.c
+                     ->  HashAggregate
+                           Output: share0_ref1.c, share0_ref1.b
+                           Group Key: share0_ref1.c, share0_ref1.b
+                           ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                                 Output: share0_ref1.c, share0_ref1.b
+                                 Hash Key: share0_ref1.c
+                                 ->  HashAggregate
+                                       Output: share0_ref1.c, share0_ref1.b
+                                       Group Key: share0_ref1.c, share0_ref1.b
+                                       ->  Shared Scan (share slice:id 2:0)
+                                             Output: share0_ref1.a, share0_ref1.b, share0_ref1.c
+                                             ->  Materialize
+                                                   Output: dqa_f4.a, dqa_f4.b, dqa_f4.c
+                                                   ->  Seq Scan on public.dqa_f4
+                                                         Output: dqa_f4.a, dqa_f4.b, dqa_f4.c
+ Optimizer: Postgres query optimizer
+ Settings: enable_groupagg=on, enable_hashagg=off, optimizer=off
+(41 rows)
+
+select count(distinct a), count(distinct b) from dqa_f4 group by c;
+ count | count 
+-------+-------
+     0 |     0
+     1 |     1
+     1 |     1
+(3 rows)
+
+reset optimizer_enable_multiple_distinct_aggs;
+drop table dqa_f4;

--- a/src/test/regress/expected/gp_dqa_optimizer.out
+++ b/src/test/regress/expected/gp_dqa_optimizer.out
@@ -1319,3 +1319,77 @@ SELECT distinct C.z, count(distinct FS.x), count(distinct FS.y) FROM (SELECT i A
 (0 rows)
 
 drop table foo_mdqa;
+-- Test some corner case of dqa ex.NULL
+create table dqa_f4(a int, b int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into dqa_f4 values(null, null, null);
+insert into dqa_f4 values(1, 1, 1);
+insert into dqa_f4 values(2, 2, 2);
+select count(distinct a), count(distinct b) from dqa_f4 group by c;
+ count | count 
+-------+-------
+     0 |     0
+     1 |     1
+     1 |     1
+(3 rows)
+
+set optimizer_enable_multiple_distinct_aggs=on;
+explain (verbose on, costs off) select count(distinct a), count(distinct b) from dqa_f4 group by c;
+                                                                                                                    QUERY PLAN                                                                                                                    
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)
+   Output: (count(DISTINCT share0_ref3.a)), (count(DISTINCT share0_ref2.b))
+   ->  Sequence
+         Output: (count(DISTINCT share0_ref3.a)), (count(DISTINCT share0_ref2.b))
+         ->  Shared Scan (share slice:id 3:0)
+               Output: share0_ref1.a, share0_ref1.b, share0_ref1.c, share0_ref1.ctid, share0_ref1.xmin, share0_ref1.cmin, share0_ref1.xmax, share0_ref1.cmax, share0_ref1.tableoid, share0_ref1.gp_segment_id
+               ->  Materialize
+                     Output: dqa_f4.a, dqa_f4.b, dqa_f4.c, dqa_f4.ctid, dqa_f4.xmin, dqa_f4.cmin, dqa_f4.xmax, dqa_f4.cmax, dqa_f4.tableoid, dqa_f4.gp_segment_id
+                     ->  Seq Scan on public.dqa_f4
+                           Output: dqa_f4.a, dqa_f4.b, dqa_f4.c, dqa_f4.ctid, dqa_f4.xmin, dqa_f4.cmin, dqa_f4.xmax, dqa_f4.cmax, dqa_f4.tableoid, dqa_f4.gp_segment_id
+         ->  Hash Join
+               Output: (count(DISTINCT share0_ref3.a)), (count(DISTINCT share0_ref2.b))
+               Hash Cond: (NOT (share0_ref3.c IS DISTINCT FROM share0_ref2.c))
+               ->  GroupAggregate
+                     Output: count(DISTINCT share0_ref3.a), share0_ref3.c
+                     Group Key: share0_ref3.c
+                     ->  Sort
+                           Output: share0_ref3.a, share0_ref3.c
+                           Sort Key: share0_ref3.c
+                           ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                                 Output: share0_ref3.a, share0_ref3.c
+                                 Hash Key: share0_ref3.c
+                                 ->  Result
+                                       Output: share0_ref3.a, share0_ref3.c
+                                       ->  Shared Scan (share slice:id 1:0)
+                                             Output: share0_ref3.a, share0_ref3.b, share0_ref3.c, share0_ref3.ctid, share0_ref3.xmin, share0_ref3.cmin, share0_ref3.xmax, share0_ref3.cmax, share0_ref3.tableoid, share0_ref3.gp_segment_id
+               ->  Hash
+                     Output: (count(DISTINCT share0_ref2.b)), share0_ref2.c
+                     ->  GroupAggregate
+                           Output: count(DISTINCT share0_ref2.b), share0_ref2.c
+                           Group Key: share0_ref2.c
+                           ->  Sort
+                                 Output: share0_ref2.b, share0_ref2.c
+                                 Sort Key: share0_ref2.c
+                                 ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                                       Output: share0_ref2.b, share0_ref2.c
+                                       Hash Key: share0_ref2.c
+                                       ->  Result
+                                             Output: share0_ref2.b, share0_ref2.c
+                                             ->  Shared Scan (share slice:id 2:0)
+                                                   Output: share0_ref2.a, share0_ref2.b, share0_ref2.c, share0_ref2.ctid, share0_ref2.xmin, share0_ref2.cmin, share0_ref2.xmax, share0_ref2.cmax, share0_ref2.tableoid, share0_ref2.gp_segment_id
+ Optimizer: Pivotal Optimizer (GPORCA)
+ Settings: enable_groupagg=on, enable_hashagg=off
+(43 rows)
+
+select count(distinct a), count(distinct b) from dqa_f4 group by c;
+ count | count 
+-------+-------
+     1 |     1
+     1 |     1
+     0 |     0
+(3 rows)
+
+reset optimizer_enable_multiple_distinct_aggs;
+drop table dqa_f4;

--- a/src/test/regress/sql/gp_dqa.sql
+++ b/src/test/regress/sql/gp_dqa.sql
@@ -233,3 +233,17 @@ SELECT distinct C.z, count(distinct FS.x), count(distinct FS.y) FROM (SELECT i A
 
 
 drop table foo_mdqa;
+-- Test some corner case of dqa ex.NULL
+create table dqa_f4(a int, b int, c int);
+insert into dqa_f4 values(null, null, null);
+insert into dqa_f4 values(1, 1, 1);
+insert into dqa_f4 values(2, 2, 2);
+
+select count(distinct a), count(distinct b) from dqa_f4 group by c;
+
+set optimizer_enable_multiple_distinct_aggs=on;
+explain (verbose on, costs off) select count(distinct a), count(distinct b) from dqa_f4 group by c;
+select count(distinct a), count(distinct b) from dqa_f4 group by c;
+reset optimizer_enable_multiple_distinct_aggs;
+
+drop table dqa_f4;


### PR DESCRIPTION
GUC optimizer_enable_multiple_distinct_aggs is supposed to enable multi-DQA in ORCA. However, after commit 0ccfee593d3 that stopped working.

Issue is that the offending commit updated child arguments of CScalarAggFunc to store additional aggregate info (e.g. order/distinct args). ORCA detects whether a query has multi-DQA by parsing a project list. When the list format changed, ORCA failed to detect multi-DQA and failed to trigger xform CXformGbAggWithMDQA2Join.

Fix parses the new format. Also, since we now allow multiple distinct arguments we cannot simply pass the first distinct argument. Hence the need to pass the list of distinct arguments.

(cherry-picked from https://github.com/greenplum-db/gpdb/commit/94c62c2a026af8deb5268fcd6ef17e1e5ef60531)