### PR TITLE
Remove GPDB_96_MERGE_FIXME in relnode.c:724

### DIFF
--- a/src/backend/optimizer/util/relnode.c
+++ b/src/backend/optimizer/util/relnode.c
@@ -721,13 +721,6 @@ build_join_rel(PlannerInfo *root,
 	if (bms_is_empty(joinrel->direct_lateral_relids))
 		joinrel->direct_lateral_relids = NULL;
 
-	/* GPDB_96_MERGE_FIXME: The 'width' is now in joinrel->reltarget. But I
-	 * don't think this is the right place to set it. Do we actually care
-	 * about doing this? PostgreSQL doesn't bother..
-	 */
-	/* cap width of output row by sum of its inputs */
-	//joinrel->width = Min(joinrel->width, outer_rel->width + inner_rel->width);
-
 	/*
 	 * Construct restrict and join clause lists for the new joinrel. (The
 	 * caller might or might not need the restrictlist, but I need it anyway


### PR DESCRIPTION
The `width` is now in `joinrel->reltarget` and has been set in `build_joinrel_tlist()` and `add_placeholders_to_joinrel()`. After the merge of PostgreSQL 9.6, the concept of `PlaceHolderVar` was introduced, calculating in this way may cause us to ignore the width of `PlaceHolderVar` and thus underestimate the cost of joinrel.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
