### PR TITLE
Support executing foreign tables from segments in Orca

### DIFF
--- a/contrib/file_fdw/input/gp_file_fdw.source
+++ b/contrib/file_fdw/input/gp_file_fdw.source
@@ -32,6 +32,7 @@ CREATE FOREIGN TABLE text_csv_all (
     word1 text, word2 text
 ) SERVER file_server
 OPTIONS (format 'csv', filename '@abs_srcdir@/data/text<SEGID>.csv', mpp_execute 'all segments');
+EXPLAIN SELECT * FROM text_csv_all ORDER BY word1;
 SELECT * FROM text_csv_all ORDER BY word1;
 CREATE FOREIGN TABLE text_csv_any_from_server (
     word1 text, word2 text

--- a/contrib/file_fdw/output/gp_file_fdw.source
+++ b/contrib/file_fdw/output/gp_file_fdw.source
@@ -29,6 +29,18 @@ CREATE FOREIGN TABLE text_csv_all (
     word1 text, word2 text
 ) SERVER file_server
 OPTIONS (format 'csv', filename '@abs_srcdir@/data/text<SEGID>.csv', mpp_execute 'all segments');
+EXPLAIN SELECT * FROM text_csv_all ORDER BY word1;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=562.71..710.61 rows=10440 width=64)
+   Merge Key: word1
+   ->  Sort  (cost=562.71..571.41 rows=3480 width=64)
+         Sort Key: word1
+         ->  Foreign Scan on text_csv_all  (cost=0.00..358.00 rows=3480 width=64)
+               Foreign File: @abs_srcdir@/data/text<SEGID>.csv
+ Optimizer: Postgres query optimizer
+(7 rows)
+
 SELECT * FROM text_csv_all ORDER BY word1;
  word1 | word2 
 -------+-------

--- a/contrib/file_fdw/output/gp_file_fdw_optimizer.source
+++ b/contrib/file_fdw/output/gp_file_fdw_optimizer.source
@@ -29,6 +29,18 @@ CREATE FOREIGN TABLE text_csv_all (
     word1 text, word2 text
 ) SERVER file_server
 OPTIONS (format 'csv', filename '@abs_srcdir@/data/text<SEGID>.csv', mpp_execute 'all segments');
+EXPLAIN SELECT * FROM text_csv_all ORDER BY word1;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=16)
+   Merge Key: word1
+   ->  Sort  (cost=0.00..431.00 rows=1 width=16)
+         Sort Key: word1
+         ->  Foreign Scan on text_csv_all  (cost=0.00..431.00 rows=1 width=16)
+               Foreign File: @abs_srcdir@/data/text<SEGID>.csv
+ Optimizer: Pivotal Optimizer (GPORCA)
+(7 rows)
+
 SELECT * FROM text_csv_all ORDER BY word1;
  word1 | word2 
 -------+-------

--- a/contrib/postgres_fdw/Makefile
+++ b/contrib/postgres_fdw/Makefile
@@ -10,7 +10,8 @@ SHLIB_LINK_INTERNAL = $(libpq)
 EXTENSION = postgres_fdw
 DATA = postgres_fdw--1.0.sql
 
-REGRESS = gp2pg_postgres_fdw
+REGRESS = gp2pg_postgres_fdw gp_postgres_fdw
+REGRESS_OPTS += --init-file=$(top_srcdir)/src/test/regress/init_file
 
 ifdef USE_PGXS
 PG_CONFIG = pg_config

--- a/contrib/postgres_fdw/expected/gp_postgres_fdw_optimizer.out
+++ b/contrib/postgres_fdw/expected/gp_postgres_fdw_optimizer.out
@@ -909,11 +909,11 @@ alter table part_mixed attach partition gp_coord for values from (10) to (15);
 insert into part_mixed select i,i from generate_series(0,14)i;
 analyze part_mixed;
 explain select * from gp_all;
-                                      QUERY PLAN                                      
---------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=100.00..6227.00 rows=258300 width=8)
-   ->  Foreign Scan on gp_all  (cost=100.00..2783.00 rows=86100 width=8)
- Optimizer: Postgres query optimizer
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+   ->  Foreign Scan on gp_all  (cost=0.00..431.00 rows=1 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
 (3 rows)
 
 select * from gp_all;
@@ -937,10 +937,10 @@ select * from gp_all;
 (15 rows)
 
 explain select * from gp_any;
-                            QUERY PLAN                            
-------------------------------------------------------------------
- Foreign Scan on gp_any  (cost=100.00..417.20 rows=10240 width=8)
- Optimizer: Postgres query optimizer
+                         QUERY PLAN                         
+------------------------------------------------------------
+ Foreign Scan on gp_any  (cost=0.00..431.00 rows=1 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
 (2 rows)
 
 select * from gp_any;
@@ -954,10 +954,10 @@ select * from gp_any;
 (5 rows)
 
 explain select * from gp_coord;
-                             QUERY PLAN                             
---------------------------------------------------------------------
- Foreign Scan on gp_coord  (cost=100.00..417.20 rows=10240 width=8)
- Optimizer: Postgres query optimizer
+                          QUERY PLAN                          
+--------------------------------------------------------------
+ Foreign Scan on gp_coord  (cost=0.00..431.00 rows=1 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
 (2 rows)
 
 select * from gp_coord;
@@ -972,15 +972,21 @@ select * from gp_coord;
 
 -- validate partition with different execution locations
 explain select * from part_mixed;
-                                         QUERY PLAN                                         
---------------------------------------------------------------------------------------------
- Append  (cost=100.00..8455.30 rows=278780 width=8)
-   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=100.00..6227.00 rows=258300 width=8)
-         ->  Foreign Scan on gp_all  (cost=100.00..2783.00 rows=86100 width=8)
-   ->  Foreign Scan on gp_any  (cost=100.00..417.20 rows=10240 width=8)
-   ->  Foreign Scan on gp_coord  (cost=100.00..417.20 rows=10240 width=8)
- Optimizer: Postgres query optimizer
-(6 rows)
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1293.00 rows=1 width=8)
+   ->  Append  (cost=0.00..1293.00 rows=1 width=8)
+         ->  Dynamic Foreign Scan on part_mixed  (cost=0.00..431.00 rows=1 width=8)
+               Number of partitions to scan: 1 (out of 3)
+         ->  Result  (cost=0.00..431.00 rows=1 width=8)
+               One-Time Filter: (gp_execution_segment() = 1)
+               ->  Dynamic Foreign Scan on part_mixed part_mixed_1  (cost=0.00..431.00 rows=1 width=8)
+                     Number of partitions to scan: 1 (out of 3)
+         ->  Redistribute Motion 1:3  (slice2)  (cost=0.00..431.00 rows=1 width=8)
+               ->  Dynamic Foreign Scan on part_mixed part_mixed_2  (cost=0.00..431.00 rows=1 width=8)
+                     Number of partitions to scan: 1 (out of 3)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(12 rows)
 
 select * from part_mixed;
  a  | b  
@@ -1019,22 +1025,27 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
 insert into non_part select i, i from generate_series(8,12)i;
 analyze non_part;
 explain select * from part_mixed join non_part on part_mixed.a=non_part.a;
-                                                  QUERY PLAN                                                  
---------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=779.75..499401.15 rows=9176538 width=16)
-   ->  Hash Join  (cost=779.75..377047.31 rows=3058846 width=16)
-         Hash Cond: (gp_all.a = non_part.a)
-         ->  Redistribute Motion 1:3  (slice2)  (cost=100.00..12172.37 rows=92927 width=8)
-               Hash Key: gp_all.a
-               ->  Append  (cost=100.00..8455.30 rows=278780 width=8)
-                     ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=100.00..6227.00 rows=258300 width=8)
-                           ->  Foreign Scan on gp_all  (cost=100.00..2783.00 rows=86100 width=8)
-                     ->  Foreign Scan on gp_any  (cost=100.00..417.20 rows=10240 width=8)
-                     ->  Foreign Scan on gp_coord  (cost=100.00..417.20 rows=10240 width=8)
-         ->  Hash  (cost=321.00..321.00 rows=28700 width=8)
-               ->  Seq Scan on non_part  (cost=0.00..321.00 rows=28700 width=8)
- Optimizer: Postgres query optimizer
-(13 rows)
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1724.00 rows=1 width=16)
+   ->  Hash Join  (cost=0.00..1724.00 rows=1 width=16)
+         Hash Cond: (a = non_part.a)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..1293.00 rows=1 width=8)
+               Hash Key: a
+               ->  Append  (cost=0.00..1293.00 rows=1 width=8)
+                     ->  Dynamic Foreign Scan on part_mixed  (cost=0.00..431.00 rows=1 width=8)
+                           Number of partitions to scan: 1 (out of 3)
+                     ->  Result  (cost=0.00..431.00 rows=1 width=8)
+                           One-Time Filter: (gp_execution_segment() = 2)
+                           ->  Dynamic Foreign Scan on part_mixed  (cost=0.00..431.00 rows=1 width=8)
+                                 Number of partitions to scan: 1 (out of 3)
+                     ->  Redistribute Motion 1:3  (slice3)  (cost=0.00..431.00 rows=1 width=8)
+                           ->  Dynamic Foreign Scan on part_mixed  (cost=0.00..431.00 rows=1 width=8)
+                                 Number of partitions to scan: 1 (out of 3)
+         ->  Hash  (cost=431.00..431.00 rows=1 width=8)
+               ->  Seq Scan on non_part  (cost=0.00..431.00 rows=1 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(18 rows)
 
 select * from part_mixed join non_part on part_mixed.a=non_part.a;
  a  | b  | a  | b  
@@ -1047,22 +1058,27 @@ select * from part_mixed join non_part on part_mixed.a=non_part.a;
 (5 rows)
 
 explain select * from part_mixed left join non_part on part_mixed.a=non_part.a;
-                                                  QUERY PLAN                                                  
---------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=779.75..499401.15 rows=9176538 width=16)
-   ->  Hash Left Join  (cost=779.75..377047.31 rows=3058846 width=16)
-         Hash Cond: (gp_all.a = non_part.a)
-         ->  Redistribute Motion 1:3  (slice2)  (cost=100.00..12172.37 rows=92927 width=8)
-               Hash Key: gp_all.a
-               ->  Append  (cost=100.00..8455.30 rows=278780 width=8)
-                     ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=100.00..6227.00 rows=258300 width=8)
-                           ->  Foreign Scan on gp_all  (cost=100.00..2783.00 rows=86100 width=8)
-                     ->  Foreign Scan on gp_any  (cost=100.00..417.20 rows=10240 width=8)
-                     ->  Foreign Scan on gp_coord  (cost=100.00..417.20 rows=10240 width=8)
-         ->  Hash  (cost=321.00..321.00 rows=28700 width=8)
-               ->  Seq Scan on non_part  (cost=0.00..321.00 rows=28700 width=8)
- Optimizer: Postgres query optimizer
-(13 rows)
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1724.00 rows=2 width=16)
+   ->  Hash Left Join  (cost=0.00..1724.00 rows=1 width=16)
+         Hash Cond: (a = non_part.a)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..1293.00 rows=1 width=8)
+               Hash Key: a
+               ->  Append  (cost=0.00..1293.00 rows=1 width=8)
+                     ->  Dynamic Foreign Scan on part_mixed  (cost=0.00..431.00 rows=1 width=8)
+                           Number of partitions to scan: 1 (out of 3)
+                     ->  Result  (cost=0.00..431.00 rows=1 width=8)
+                           One-Time Filter: (gp_execution_segment() = 0)
+                           ->  Dynamic Foreign Scan on part_mixed  (cost=0.00..431.00 rows=1 width=8)
+                                 Number of partitions to scan: 1 (out of 3)
+                     ->  Redistribute Motion 1:3  (slice3)  (cost=0.00..431.00 rows=1 width=8)
+                           ->  Dynamic Foreign Scan on part_mixed  (cost=0.00..431.00 rows=1 width=8)
+                                 Number of partitions to scan: 1 (out of 3)
+         ->  Hash  (cost=431.00..431.00 rows=1 width=8)
+               ->  Seq Scan on non_part  (cost=0.00..431.00 rows=1 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(18 rows)
 
 select * from part_mixed left join non_part on part_mixed.a=non_part.a;
  a  | b  | a  | b  
@@ -1095,76 +1111,84 @@ select * from part_mixed left join non_part on part_mixed.a=non_part.a;
 (25 rows)
 
 explain select * from part_mixed right join non_part on part_mixed.a=non_part.a;
-                                                  QUERY PLAN                                                  
---------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=779.75..499401.15 rows=9176538 width=16)
-   ->  Hash Right Join  (cost=779.75..377047.31 rows=3058846 width=16)
-         Hash Cond: (gp_all.a = non_part.a)
-         ->  Redistribute Motion 1:3  (slice2)  (cost=100.00..12172.37 rows=92927 width=8)
-               Hash Key: gp_all.a
-               ->  Append  (cost=100.00..8455.30 rows=278780 width=8)
-                     ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=100.00..6227.00 rows=258300 width=8)
-                           ->  Foreign Scan on gp_all  (cost=100.00..2783.00 rows=86100 width=8)
-                     ->  Foreign Scan on gp_any  (cost=100.00..417.20 rows=10240 width=8)
-                     ->  Foreign Scan on gp_coord  (cost=100.00..417.20 rows=10240 width=8)
-         ->  Hash  (cost=321.00..321.00 rows=28700 width=8)
-               ->  Seq Scan on non_part  (cost=0.00..321.00 rows=28700 width=8)
- Optimizer: Postgres query optimizer
-(13 rows)
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1724.00 rows=16 width=16)
+   ->  Hash Right Join  (cost=0.00..1724.00 rows=6 width=16)
+         Hash Cond: (a = non_part.a)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..1293.00 rows=5 width=8)
+               Hash Key: a
+               ->  Append  (cost=0.00..1293.00 rows=5 width=8)
+                     ->  Dynamic Foreign Scan on part_mixed  (cost=0.00..431.00 rows=5 width=8)
+                           Number of partitions to scan: 1 (out of 3)
+                     ->  Result  (cost=0.00..431.00 rows=5 width=8)
+                           One-Time Filter: (gp_execution_segment() = 1)
+                           ->  Dynamic Foreign Scan on part_mixed  (cost=0.00..431.00 rows=5 width=8)
+                                 Number of partitions to scan: 1 (out of 3)
+                     ->  Redistribute Motion 1:3  (slice3)  (cost=0.00..431.00 rows=5 width=8)
+                           ->  Dynamic Foreign Scan on part_mixed  (cost=0.00..431.00 rows=15 width=8)
+                                 Number of partitions to scan: 1 (out of 3)
+         ->  Hash  (cost=431.00..431.00 rows=2 width=8)
+               ->  Seq Scan on non_part  (cost=0.00..431.00 rows=2 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(18 rows)
 
 select * from part_mixed right join non_part on part_mixed.a=non_part.a;
  a  | b  | a  | b  
 ----+----+----+----
-  9 |  9 |  9 |  9
- 10 | 10 | 10 | 10
- 11 | 11 | 11 | 11
-  8 |  8 |  8 |  8
  12 | 12 | 12 | 12
+ 11 | 11 | 11 | 11
+ 10 | 10 | 10 | 10
+  9 |  9 |  9 |  9
+  8 |  8 |  8 |  8
 (5 rows)
 
 -- validate join is on segments for distributed table
 explain select * from gp_any, table_dist_int where gp_any.a=table_dist_int.f1;
                                     QUERY PLAN                                     
 -----------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=102.21..278.23 rows=167 width=76)
-   ->  Hash Join  (cost=102.21..276.01 rows=56 width=76)
-         Hash Cond: (table_dist_int.f1 = gp_any.a)
-         ->  Seq Scan on table_dist_int  (cost=0.00..145.33 rows=11133 width=68)
-         ->  Hash  (cost=102.15..102.15 rows=5 width=8)
-               ->  Foreign Scan on gp_any  (cost=100.00..102.15 rows=5 width=8)
- Optimizer: Postgres query optimizer
-(7 rows)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=28)
+   ->  Hash Join  (cost=0.00..862.00 rows=1 width=28)
+         Hash Cond: (a = table_dist_int.f1)
+         ->  Result  (cost=0.00..431.00 rows=2 width=8)
+               ->  Foreign Scan on gp_any  (cost=0.00..431.00 rows=2 width=8)
+         ->  Hash  (cost=431.00..431.00 rows=1 width=20)
+               ->  Seq Scan on table_dist_int  (cost=0.00..431.00 rows=1 width=20)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(8 rows)
 
 select * from gp_any, table_dist_int where gp_any.a=table_dist_int.f1;
  a | b | f1 | f2 | f3 
 ---+---+----+----+----
- 7 | 7 |  7 | g  | gg
- 8 | 8 |  8 | h  | hh
  5 | 5 |  5 | e  | ee
  6 | 6 |  6 | f  | ff
  9 | 9 |  9 | i  | ii
+ 7 | 7 |  7 | g  | gg
+ 8 | 8 |  8 | h  | hh
 (5 rows)
 
 -- validate join is on segments for replicated table
 explain select * from gp_any, table_dist_repl where gp_any.a=table_dist_repl.f1;
-                                    QUERY PLAN                                     
------------------------------------------------------------------------------------
- Gather Motion 1:1  (slice1; segments: 1)  (cost=621.59..621.59 rows=167 width=76)
-   ->  Hash Join  (cost=102.21..621.59 rows=167 width=76)
-         Hash Cond: (table_dist_repl.f1 = gp_any.a)
-         ->  Seq Scan on table_dist_repl  (cost=0.00..434.00 rows=33400 width=68)
-         ->  Hash  (cost=102.15..102.15 rows=5 width=8)
-               ->  Foreign Scan on gp_any  (cost=100.00..102.15 rows=5 width=8)
- Optimizer: Postgres query optimizer
-(7 rows)
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=28)
+   ->  Hash Join  (cost=0.00..862.00 rows=1 width=28)
+         Hash Cond: (a = table_dist_repl.f1)
+         ->  Result  (cost=0.00..431.00 rows=2 width=8)
+               One-Time Filter: (gp_execution_segment() = 0)
+               ->  Foreign Scan on gp_any  (cost=0.00..431.00 rows=2 width=8)
+         ->  Hash  (cost=431.00..431.00 rows=1 width=20)
+               ->  Seq Scan on table_dist_repl  (cost=0.00..431.00 rows=1 width=20)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(9 rows)
 
 select * from gp_any, table_dist_repl where gp_any.a=table_dist_repl.f1;
  a | b | f1 | f2 | f3 
 ---+---+----+----+----
  5 | 5 |  5 | e  | ee
- 7 | 7 |  7 | g  | gg
- 8 | 8 |  8 | h  | hh
  6 | 6 |  6 | f  | ff
  9 | 9 |  9 | i  | ii
+ 7 | 7 |  7 | g  | gg
+ 8 | 8 |  8 | h  | hh
 (5 rows)
 

--- a/contrib/postgres_fdw/sql/gp_postgres_fdw.sql
+++ b/contrib/postgres_fdw/sql/gp_postgres_fdw.sql
@@ -5,6 +5,20 @@
 -- ===================================================================
 -- Create source tables and populate with data
 -- ===================================================================
+CREATE SCHEMA postgres_fdw_gp;
+set search_path=postgres_fdw_gp;
+CREATE EXTENSION IF NOT EXISTS postgres_fdw;
+
+DO $d$
+    BEGIN
+        EXECUTE $$CREATE SERVER loopback FOREIGN DATA WRAPPER postgres_fdw
+            OPTIONS (dbname '$$||current_database()||$$',
+                     port '$$||current_setting('port')||$$'
+            )$$;
+    END;
+$d$;
+
+CREATE USER MAPPING IF NOT EXISTS FOR CURRENT_USER SERVER loopback;
 
 CREATE TABLE table_dist_rand
 (
@@ -64,7 +78,7 @@ INSERT INTO table_dist_int_text SELECT * FROM table_dist_rand;
 -- create target table
 -- ===================================================================
 
-CREATE TABLE "S 1"."GP 1" (
+CREATE TABLE postgres_fdw_gp."GP 1" (
 	f1 int,
 	f2 text,
 	f3 text
@@ -78,7 +92,7 @@ CREATE FOREIGN TABLE gp_ft1 (
 	f1 int,
 	f2 text,
 	f3 text
-) SERVER loopback OPTIONS (schema_name 'S 1', table_name 'GP 1', mpp_execute 'all segments');
+) SERVER loopback OPTIONS (schema_name 'postgres_fdw_gp', table_name 'GP 1', mpp_execute 'all segments');
 
 -- ===================================================================
 -- validate parallel writes (mpp_execute set to all segments)
@@ -86,28 +100,28 @@ CREATE FOREIGN TABLE gp_ft1 (
 
 EXPLAIN (COSTS FALSE) INSERT INTO gp_ft1 SELECT * FROM table_dist_rand;
 INSERT INTO gp_ft1 SELECT * FROM table_dist_rand;
-SELECT * FROM "S 1"."GP 1" ORDER BY f1;
-TRUNCATE TABLE "S 1"."GP 1";
+SELECT * FROM postgres_fdw_gp."GP 1" ORDER BY f1;
+TRUNCATE TABLE postgres_fdw_gp."GP 1";
 
 EXPLAIN (COSTS FALSE) INSERT INTO gp_ft1 SELECT * FROM table_dist_repl;
 INSERT INTO gp_ft1 SELECT * FROM table_dist_repl;
-SELECT * FROM "S 1"."GP 1" ORDER BY f1;
-TRUNCATE TABLE "S 1"."GP 1";
+SELECT * FROM postgres_fdw_gp."GP 1" ORDER BY f1;
+TRUNCATE TABLE postgres_fdw_gp."GP 1";
 
 EXPLAIN (COSTS FALSE) INSERT INTO gp_ft1 SELECT * FROM table_dist_int;
 INSERT INTO gp_ft1 SELECT * FROM table_dist_int;
-SELECT * FROM "S 1"."GP 1" ORDER BY f1;
-TRUNCATE TABLE "S 1"."GP 1";
+SELECT * FROM postgres_fdw_gp."GP 1" ORDER BY f1;
+TRUNCATE TABLE postgres_fdw_gp."GP 1";
 
 EXPLAIN (COSTS FALSE) INSERT INTO gp_ft1 SELECT * FROM table_dist_text;
 INSERT INTO gp_ft1 SELECT * FROM table_dist_text;
-SELECT * FROM "S 1"."GP 1" ORDER BY f1;
-TRUNCATE TABLE "S 1"."GP 1";
+SELECT * FROM postgres_fdw_gp."GP 1" ORDER BY f1;
+TRUNCATE TABLE postgres_fdw_gp."GP 1";
 
 EXPLAIN (COSTS FALSE) INSERT INTO gp_ft1 SELECT * FROM table_dist_int_text;
 INSERT INTO gp_ft1 SELECT * FROM table_dist_int_text;
-SELECT * FROM "S 1"."GP 1" ORDER BY f1;
-TRUNCATE TABLE "S 1"."GP 1";
+SELECT * FROM postgres_fdw_gp."GP 1" ORDER BY f1;
+TRUNCATE TABLE postgres_fdw_gp."GP 1";
 
 EXPLAIN (COSTS FALSE) INSERT INTO gp_ft1
 SELECT id,
@@ -119,8 +133,8 @@ SELECT id,
        'AAA' || to_char(id, 'FM000'),
        'BBB' || to_char(id, 'FM000')
 FROM generate_series(1, 100) id;
-SELECT * FROM "S 1"."GP 1" ORDER BY f1;
-TRUNCATE TABLE "S 1"."GP 1";
+SELECT * FROM postgres_fdw_gp."GP 1" ORDER BY f1;
+TRUNCATE TABLE postgres_fdw_gp."GP 1";
 
 -- ===================================================================
 -- validate writes on any segment (mpp_execute set to any)
@@ -130,28 +144,28 @@ ALTER FOREIGN TABLE gp_ft1 OPTIONS ( SET mpp_execute 'any' );
 
 EXPLAIN (COSTS FALSE) INSERT INTO gp_ft1 SELECT * FROM table_dist_rand;
 INSERT INTO gp_ft1 SELECT * FROM table_dist_rand;
-SELECT * FROM "S 1"."GP 1" ORDER BY f1;
-TRUNCATE TABLE "S 1"."GP 1";
+SELECT * FROM postgres_fdw_gp."GP 1" ORDER BY f1;
+TRUNCATE TABLE postgres_fdw_gp."GP 1";
 
 EXPLAIN (COSTS FALSE) INSERT INTO gp_ft1 SELECT * FROM table_dist_repl;
 INSERT INTO gp_ft1 SELECT * FROM table_dist_repl;
-SELECT * FROM "S 1"."GP 1" ORDER BY f1;
-TRUNCATE TABLE "S 1"."GP 1";
+SELECT * FROM postgres_fdw_gp."GP 1" ORDER BY f1;
+TRUNCATE TABLE postgres_fdw_gp."GP 1";
 
 EXPLAIN (COSTS FALSE) INSERT INTO gp_ft1 SELECT * FROM table_dist_int;
 INSERT INTO gp_ft1 SELECT * FROM table_dist_int;
-SELECT * FROM "S 1"."GP 1" ORDER BY f1;
-TRUNCATE TABLE "S 1"."GP 1";
+SELECT * FROM postgres_fdw_gp."GP 1" ORDER BY f1;
+TRUNCATE TABLE postgres_fdw_gp."GP 1";
 
 EXPLAIN (COSTS FALSE) INSERT INTO gp_ft1 SELECT * FROM table_dist_text;
 INSERT INTO gp_ft1 SELECT * FROM table_dist_text;
-SELECT * FROM "S 1"."GP 1" ORDER BY f1;
-TRUNCATE TABLE "S 1"."GP 1";
+SELECT * FROM postgres_fdw_gp."GP 1" ORDER BY f1;
+TRUNCATE TABLE postgres_fdw_gp."GP 1";
 
 EXPLAIN (COSTS FALSE) INSERT INTO gp_ft1 SELECT * FROM table_dist_int_text;
 INSERT INTO gp_ft1 SELECT * FROM table_dist_int_text;
-SELECT * FROM "S 1"."GP 1" ORDER BY f1;
-TRUNCATE TABLE "S 1"."GP 1";
+SELECT * FROM postgres_fdw_gp."GP 1" ORDER BY f1;
+TRUNCATE TABLE postgres_fdw_gp."GP 1";
 
 EXPLAIN (COSTS FALSE) INSERT INTO gp_ft1
 SELECT id,
@@ -163,8 +177,8 @@ SELECT id,
        'AAA' || to_char(id, 'FM000'),
        'BBB' || to_char(id, 'FM000')
 FROM generate_series(1, 100) id;
-SELECT * FROM "S 1"."GP 1" ORDER BY f1;
-TRUNCATE TABLE "S 1"."GP 1";
+SELECT * FROM postgres_fdw_gp."GP 1" ORDER BY f1;
+TRUNCATE TABLE postgres_fdw_gp."GP 1";
 
 -- ===================================================================
 -- validate writes on coordinator (mpp_execute set to coordinator)
@@ -174,28 +188,28 @@ ALTER FOREIGN TABLE gp_ft1 OPTIONS ( SET mpp_execute 'coordinator' );
 
 EXPLAIN (COSTS FALSE) INSERT INTO gp_ft1 SELECT * FROM table_dist_rand;
 INSERT INTO gp_ft1 SELECT * FROM table_dist_rand;
-SELECT * FROM "S 1"."GP 1" ORDER BY f1;
-TRUNCATE TABLE "S 1"."GP 1";
+SELECT * FROM postgres_fdw_gp."GP 1" ORDER BY f1;
+TRUNCATE TABLE postgres_fdw_gp."GP 1";
 
 EXPLAIN (COSTS FALSE) INSERT INTO gp_ft1 SELECT * FROM table_dist_repl;
 INSERT INTO gp_ft1 SELECT * FROM table_dist_repl;
-SELECT * FROM "S 1"."GP 1" ORDER BY f1;
-TRUNCATE TABLE "S 1"."GP 1";
+SELECT * FROM postgres_fdw_gp."GP 1" ORDER BY f1;
+TRUNCATE TABLE postgres_fdw_gp."GP 1";
 
 EXPLAIN (COSTS FALSE) INSERT INTO gp_ft1 SELECT * FROM table_dist_int;
 INSERT INTO gp_ft1 SELECT * FROM table_dist_int;
-SELECT * FROM "S 1"."GP 1" ORDER BY f1;
-TRUNCATE TABLE "S 1"."GP 1";
+SELECT * FROM postgres_fdw_gp."GP 1" ORDER BY f1;
+TRUNCATE TABLE postgres_fdw_gp."GP 1";
 
 EXPLAIN (COSTS FALSE) INSERT INTO gp_ft1 SELECT * FROM table_dist_text;
 INSERT INTO gp_ft1 SELECT * FROM table_dist_text;
-SELECT * FROM "S 1"."GP 1" ORDER BY f1;
-TRUNCATE TABLE "S 1"."GP 1";
+SELECT * FROM postgres_fdw_gp."GP 1" ORDER BY f1;
+TRUNCATE TABLE postgres_fdw_gp."GP 1";
 
 EXPLAIN (COSTS FALSE) INSERT INTO gp_ft1 SELECT * FROM table_dist_int_text;
 INSERT INTO gp_ft1 SELECT * FROM table_dist_int_text;
-SELECT * FROM "S 1"."GP 1" ORDER BY f1;
-TRUNCATE TABLE "S 1"."GP 1";
+SELECT * FROM postgres_fdw_gp."GP 1" ORDER BY f1;
+TRUNCATE TABLE postgres_fdw_gp."GP 1";
 
 EXPLAIN (COSTS FALSE) INSERT INTO gp_ft1
 SELECT id,
@@ -207,5 +221,67 @@ SELECT id,
        'AAA' || to_char(id, 'FM000'),
        'BBB' || to_char(id, 'FM000')
 FROM generate_series(1, 100) id;
-SELECT * FROM "S 1"."GP 1" ORDER BY f1;
-TRUNCATE TABLE "S 1"."GP 1";
+SELECT * FROM postgres_fdw_gp."GP 1" ORDER BY f1;
+TRUNCATE TABLE postgres_fdw_gp."GP 1";
+
+-- Validate queries on different execution locations
+create table t1(a int, b int);
+create table t2(a int, b int);
+create table t3(a int, b int);
+
+CREATE FOREIGN TABLE gp_all (
+	a int,
+	b int
+) SERVER loopback OPTIONS (schema_name 'postgres_fdw_gp', table_name 't1', mpp_execute 'all segments');
+
+CREATE FOREIGN TABLE gp_any (
+	a int,
+	b int
+) SERVER loopback OPTIONS (schema_name 'postgres_fdw_gp', table_name 't2', mpp_execute 'any');
+
+CREATE FOREIGN TABLE gp_coord (
+	a int,
+	b int
+) SERVER loopback OPTIONS (schema_name 'postgres_fdw_gp', table_name 't3', mpp_execute 'coordinator');
+
+create table part_mixed (a int, b int) partition by range (b);
+alter table part_mixed attach partition gp_all for values from (0) to (5);
+alter table part_mixed attach partition gp_any for values from (5) to (10);
+alter table part_mixed attach partition gp_coord for values from (10) to (15);
+insert into part_mixed select i,i from generate_series(0,14)i;
+analyze part_mixed;
+
+explain select * from gp_all;
+select * from gp_all;
+
+explain select * from gp_any;
+select * from gp_any;
+
+explain select * from gp_coord;
+select * from gp_coord;
+
+-- validate partition with different execution locations
+explain select * from part_mixed;
+select * from part_mixed;
+
+-- validate joins on different execution locations
+create table non_part (a int, b int);
+insert into non_part select i, i from generate_series(8,12)i;
+analyze non_part;
+
+explain select * from part_mixed join non_part on part_mixed.a=non_part.a;
+select * from part_mixed join non_part on part_mixed.a=non_part.a;
+
+explain select * from part_mixed left join non_part on part_mixed.a=non_part.a;
+select * from part_mixed left join non_part on part_mixed.a=non_part.a;
+
+explain select * from part_mixed right join non_part on part_mixed.a=non_part.a;
+select * from part_mixed right join non_part on part_mixed.a=non_part.a;
+
+-- validate join is on segments for distributed table
+explain select * from gp_any, table_dist_int where gp_any.a=table_dist_int.f1;
+select * from gp_any, table_dist_int where gp_any.a=table_dist_int.f1;
+
+-- validate join is on segments for replicated table
+explain select * from gp_any, table_dist_repl where gp_any.a=table_dist_repl.f1;
+select * from gp_any, table_dist_repl where gp_any.a=table_dist_repl.f1;

--- a/src/backend/gpopt/gpdbwrappers.cpp
+++ b/src/backend/gpopt/gpdbwrappers.cpp
@@ -1795,6 +1795,17 @@ gpdb::GetDistributionPolicy(Relation rel)
 {
 	GP_WRAP_START;
 	{
+		// external tables are a special case, and we need to manually build
+		// the GpPolicy struct which contains the external table's distribution
+		if (rel_is_external_table(rel->rd_id))
+		{
+			return GpPolicyFetch(rel->rd_id);
+		}
+		// we determine the distribution at a later point for foreign tables
+		else if (rel->rd_rel->relkind == RELKIND_FOREIGN_TABLE)
+		{
+			return nullptr;
+		}
 		/* catalog tables: pg_class */
 		return relation_policy(rel);
 	}

--- a/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
@@ -531,6 +531,8 @@ CTranslatorRelcacheToDXL::RetrieveRel(CMemoryPool *mp, CMDAccessor *md_accessor,
 	// If it's a foreign table, but not an external table
 	if (rel->rd_rel->relkind == RELKIND_FOREIGN_TABLE && gp_policy == nullptr)
 	{
+		// for foreign tables, we need to convert from the foreign table's execution locaiton,
+		// to an Orca distribution spec. We do this maping in `GetForeignRelDistribution`
 		ForeignTable *ft = GetForeignTable(rel->rd_id);
 		dist = GetForeignRelDistribution(ft);
 	}
@@ -799,7 +801,8 @@ CTranslatorRelcacheToDXL::GetRelDistribution(GpPolicy *gp_policy)
 }
 
 // Foreign relations don't store their distribution policy in GpPolicy,
-// so we need to extract it separately from the ForeignTable itself
+// so we need to extract it separately from the ForeignTable itself.
+// maps foreign table's execution location to Orca distribution policy
 IMDRelation::Ereldistrpolicy
 CTranslatorRelcacheToDXL::GetForeignRelDistribution(ForeignTable *ft)
 {

--- a/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
+++ b/src/backend/gpopt/translate/CTranslatorRelcacheToDXL.cpp
@@ -531,8 +531,8 @@ CTranslatorRelcacheToDXL::RetrieveRel(CMemoryPool *mp, CMDAccessor *md_accessor,
 	// If it's a foreign table, but not an external table
 	if (rel->rd_rel->relkind == RELKIND_FOREIGN_TABLE && gp_policy == nullptr)
 	{
-		// for foreign tables, we need to convert from the foreign table's execution locaiton,
-		// to an Orca distribution spec. We do this maping in `GetForeignRelDistribution`
+		// for foreign tables, we need to convert from the foreign table's execution location,
+		// to an Orca distribution spec. We do this mapping in `GetForeignRelDistribution`
 		ForeignTable *ft = GetForeignTable(rel->rd_id);
 		dist = GetForeignRelDistribution(ft);
 	}

--- a/src/backend/gporca/data/dxl/minidump/ForeignScanExecLocAnyJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ForeignScanExecLocAnyJoin.mdp
@@ -24,9 +24,9 @@
 	) SERVER loopback OPTIONS (schema_name 'public', table_name 'gp_any', mpp_execute 'any');
 
 	CREATE TABLE foo (a int);
-	explain select * from gp_any;
 
-	test=# explain select * from foo, gp_any where foo.a=gp_any.a;
+	explain select * from foo, gp_any where foo.a=gp_any.a;
+
                                   QUERY PLAN
 	-------------------------------------------------------------------------------
 	 Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=12)

--- a/src/backend/gporca/data/dxl/minidump/ForeignScanExecLocAnyJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ForeignScanExecLocAnyJoin.mdp
@@ -1,0 +1,411 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Comment><![CDATA[
+	Objective: Foreign scans created with an execution location of "any" 
+	should be able to scan on either the coordinator or segments. For a 
+	join, it should be performed on the segment.
+
+	CREATE EXTENSION IF NOT EXISTS postgres_fdw;
+
+	DO $d$
+	    BEGIN
+		EXECUTE $$CREATE SERVER loopback FOREIGN DATA WRAPPER postgres_fdw
+		    OPTIONS (dbname '$$||current_database()||$$',
+			     port '$$||current_setting('port')||$$'
+		    )$$;
+	    END;
+	$d$;
+
+	CREATE USER MAPPING IF NOT EXISTS FOR CURRENT_USER SERVER loopback;
+
+	CREATE FOREIGN TABLE gp_any (
+		a int,
+		b int
+	) SERVER loopback OPTIONS (schema_name 'public', table_name 'gp_any', mpp_execute 'any');
+
+	CREATE TABLE foo (a int);
+	explain select * from gp_any;
+
+	test=# explain select * from foo, gp_any where foo.a=gp_any.a;
+                                  QUERY PLAN
+	-------------------------------------------------------------------------------
+	 Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=1 width=12)
+	   ->  Hash Join  (cost=0.00..862.00 rows=1 width=12)
+		 Hash Cond: (a = foo.a)
+		 ->  Result  (cost=0.00..431.00 rows=1 width=8)
+		       ->  Foreign Scan on gp_any  (cost=0.00..431.00 rows=1 width=8)
+		 ->  Hash  (cost=431.00..431.00 rows=1 width=4)
+		       ->  Seq Scan on foo  (cost=0.00..431.00 rows=1 width=4)
+	 Optimizer: Pivotal Optimizer (GPORCA)
+	(8 rows)
+  ]]>
+  </dxl:Comment>
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="20" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0" SkewFactor="0"/>
+      <dxl:TraceFlags Value="102001,102002,102003,102043,102074,102120,102144,103001,103014,103015,103022,103026,103027,103029,103033,103038,103040,104002,104003,104004,104005,105000,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:RelationExtendedStatistics Mdid="10.24790.1.0" Name="gp_any"/>
+      <dxl:RelationExtendedStatistics Mdid="10.24793.1.0" Name="foo"/>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:PartOpfamily Mdid="0.424.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:PartOpfamily Mdid="0.1976.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:PartOpfamily Mdid="0.1989.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2134.1.0"/>
+        <dxl:MaxAgg Mdid="0.2118.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.2227.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:PartOpfamily Mdid="0.2789.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.3315.1.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:ColumnStatistics Mdid="1.24790.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:MDCast Mdid="3.23.1.0;23.1.0" Name="int4" BinaryCoercible="true" SourceTypeId="0.23.1.0" DestinationTypeId="0.23.1.0" CastFuncId="0.0.0.0" CoercePathType="0"/>
+      <dxl:ColumnStatistics Mdid="1.24793.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.65.1.0"/>
+        <dxl:Commutator Mdid="0.96.1.0"/>
+        <dxl:InverseOp Mdid="0.518.1.0"/>
+        <dxl:HashOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7100.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.1977.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.7100.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:RelationStatistics Mdid="2.24790.1.0" Name="gp_any" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
+      <dxl:Relation Mdid="6.24790.1.0" Name="gp_any" IsTemporary="false" StorageType="Foreign" DistributionPolicy="Universal" Keys="8,2" ForeignServer="0.24788.1.0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:CheckConstraints/>
+      </dxl:Relation>
+      <dxl:RelationStatistics Mdid="2.24793.1.0" Name="foo" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
+      <dxl:Relation Mdid="6.24793.1.0" Name="foo" IsTemporary="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="7,1">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalJoin JoinType="Inner">
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="6.24793.1.0" TableName="foo" LockMode="1">
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="3" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="4" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="5" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+        <dxl:LogicalForeignGet>
+          <dxl:TableDescriptor Mdid="6.24790.1.0" TableName="gp_any" LockMode="1">
+            <dxl:Columns>
+              <dxl:Column ColId="9" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="10" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="12" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="13" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="14" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="15" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="16" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="17" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalForeignGet>
+        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+          <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+          <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
+        </dxl:Comparison>
+      </dxl:LogicalJoin>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="10">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="862.000515" Rows="1.000000" Width="12"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="0" Alias="a">
+            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="8" Alias="a">
+            <dxl:Ident ColId="8" ColName="a" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="9" Alias="b">
+            <dxl:Ident ColId="9" ColName="b" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:SortingColumnList/>
+        <dxl:HashJoin JoinType="Inner">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="862.000470" Rows="1.000000" Width="12"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="0" Alias="a">
+              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="8" Alias="a">
+              <dxl:Ident ColId="8" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="9" Alias="b">
+              <dxl:Ident ColId="9" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:JoinFilter/>
+          <dxl:HashCondList>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+              <dxl:Ident ColId="8" ColName="a" TypeMdid="0.23.1.0"/>
+              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:Comparison>
+          </dxl:HashCondList>
+          <dxl:RedistributeMotion InputSegments="0" OutputSegments="0,1,2" DuplicateSensitive="true">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.000061" Rows="1.000000" Width="8"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="8" Alias="a">
+                <dxl:Ident ColId="8" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="9" Alias="b">
+                <dxl:Ident ColId="9" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:SortingColumnList/>
+            <dxl:HashExprList>
+              <dxl:HashExpr Opfamily="0.1977.1.0">
+                <dxl:Ident ColId="8" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:HashExpr>
+            </dxl:HashExprList>
+            <dxl:ForeignScan>
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="8"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="8" Alias="a">
+                  <dxl:Ident ColId="8" ColName="a" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="9" Alias="b">
+                  <dxl:Ident ColId="9" ColName="b" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:TableDescriptor Mdid="6.24790.1.0" TableName="gp_any" LockMode="1">
+                <dxl:Columns>
+                  <dxl:Column ColId="8" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="9" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="10" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                  <dxl:Column ColId="11" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="12" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="13" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="14" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="15" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="16" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:ForeignScan>
+          </dxl:RedistributeMotion>
+          <dxl:TableScan>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.000019" Rows="1.000000" Width="4"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="0" Alias="a">
+                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:TableDescriptor Mdid="6.24793.1.0" TableName="foo" LockMode="1">
+              <dxl:Columns>
+                <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="1" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="2" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="3" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="4" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="5" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="6" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="7" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
+        </dxl:HashJoin>
+      </dxl:GatherMotion>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/ForeignScanExecLocAnySimpleScan.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ForeignScanExecLocAnySimpleScan.mdp
@@ -1,0 +1,243 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Comment><![CDATA[
+	Objective: Foreign scans created with an execution location of "any" 
+	should be able to scan on either the coordinator or segments. For a 
+	simple scan, it should be performed on the coordinator.
+
+	CREATE EXTENSION IF NOT EXISTS postgres_fdw;
+
+	DO $d$
+	    BEGIN
+		EXECUTE $$CREATE SERVER loopback FOREIGN DATA WRAPPER postgres_fdw
+		    OPTIONS (dbname '$$||current_database()||$$',
+			     port '$$||current_setting('port')||$$'
+		    )$$;
+	    END;
+	$d$;
+
+	CREATE USER MAPPING IF NOT EXISTS FOR CURRENT_USER SERVER loopback;
+
+	CREATE FOREIGN TABLE gp_any (
+		a int,
+		b int
+	) SERVER loopback OPTIONS (schema_name 'public', table_name 'gp_any', mpp_execute 'any');
+
+	explain select * from gp_any;
+
+	  test=# explain select * from gp_any;
+                         QUERY PLAN
+	------------------------------------------------------------
+	 Foreign Scan on gp_any  (cost=0.00..431.00 rows=1 width=8)
+	 Optimizer: Pivotal Optimizer (GPORCA)
+	(2 rows)
+  ]]>
+  </dxl:Comment>
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="20" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0" SkewFactor="0"/>
+      <dxl:TraceFlags Value="102001,102002,102003,102043,102074,102120,102144,103001,103003,103014,103015,103022,103026,103027,103029,103033,103038,103040,104002,104003,104004,104005,105000,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:PartOpfamily Mdid="0.424.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:PartOpfamily Mdid="0.1976.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:PartOpfamily Mdid="0.1989.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2134.1.0"/>
+        <dxl:MaxAgg Mdid="0.2118.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.2227.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:PartOpfamily Mdid="0.2789.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.3315.1.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:RelationExtendedStatistics Mdid="10.24780.1.0" Name="gp_any"/>
+      <dxl:RelationStatistics Mdid="2.24780.1.0" Name="gp_any" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
+      <dxl:Relation Mdid="6.24780.1.0" Name="gp_any" IsTemporary="false" StorageType="Foreign" DistributionPolicy="Universal" Keys="8,2" ForeignServer="0.24778.1.0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:CheckConstraints/>
+      </dxl:Relation>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalForeignGet>
+        <dxl:TableDescriptor Mdid="6.24780.1.0" TableName="gp_any" LockMode="1">
+          <dxl:Columns>
+            <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+            <dxl:Column ColId="4" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="5" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="6" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="7" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="8" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+            <dxl:Column ColId="9" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+          </dxl:Columns>
+        </dxl:TableDescriptor>
+      </dxl:LogicalForeignGet>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="0">
+      <dxl:ForeignScan>
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="8"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="0" Alias="a">
+            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="1" Alias="b">
+            <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:TableDescriptor Mdid="6.24780.1.0" TableName="gp_any" LockMode="1">
+          <dxl:Columns>
+            <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+            <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+            <dxl:Column ColId="3" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="4" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="5" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+            <dxl:Column ColId="6" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+            <dxl:Column ColId="7" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+            <dxl:Column ColId="8" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+          </dxl:Columns>
+        </dxl:TableDescriptor>
+      </dxl:ForeignScan>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalDynamicForeignGet.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalDynamicForeignGet.h
@@ -28,7 +28,7 @@ class CLogicalDynamicForeignGet : public CLogicalDynamicGetBase
 private:
 	OID m_foreign_server_oid;
 
-	IMDRelation::Ereldistrpolicy m_dist;
+	IMDRelation::Ereldistrpolicy m_exec_location;
 
 public:
 	CLogicalDynamicForeignGet(const CLogicalDynamicForeignGet &) = delete;
@@ -42,7 +42,7 @@ public:
 							  CColRef2dArray *pdrgpdrgpcrPart,
 							  IMdIdArray *partition_mdids,
 							  OID foreign_server_oid,
-							  IMDRelation::Ereldistrpolicy dist);
+							  IMDRelation::Ereldistrpolicy exec_location);
 
 	// ident accessors
 
@@ -76,7 +76,7 @@ public:
 	IMDRelation::Ereldistrpolicy
 	DistributionType() const
 	{
-		return m_dist;
+		return m_exec_location;
 	}
 	//-------------------------------------------------------------------------------------
 	// Required Relational Properties

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalDynamicForeignGet.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalDynamicForeignGet.h
@@ -28,7 +28,7 @@ class CLogicalDynamicForeignGet : public CLogicalDynamicGetBase
 private:
 	OID m_foreign_server_oid;
 
-	BOOL m_is_coordinator_only;
+	IMDRelation::Ereldistrpolicy m_dist;
 
 public:
 	CLogicalDynamicForeignGet(const CLogicalDynamicForeignGet &) = delete;
@@ -41,7 +41,8 @@ public:
 							  CColRefArray *pdrgpcrOutput,
 							  CColRef2dArray *pdrgpdrgpcrPart,
 							  IMdIdArray *partition_mdids,
-							  OID foreign_server_oid, BOOL is_coordinator_only);
+							  OID foreign_server_oid,
+							  IMDRelation::Ereldistrpolicy dist);
 
 	// ident accessors
 
@@ -72,10 +73,10 @@ public:
 		return m_foreign_server_oid;
 	}
 
-	BOOL
-	IsCoordinatorOnly() const
+	IMDRelation::Ereldistrpolicy
+	DistributionType() const
 	{
-		return m_is_coordinator_only;
+		return m_dist;
 	}
 	//-------------------------------------------------------------------------------------
 	// Required Relational Properties

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalDynamicForeignScan.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalDynamicForeignScan.h
@@ -24,7 +24,7 @@ class CPhysicalDynamicForeignScan : public CPhysicalDynamicScan
 private:
 	OID m_foreign_server_oid;
 
-	IMDRelation::Ereldistrpolicy m_dist;
+	IMDRelation::Ereldistrpolicy m_exec_location;
 
 public:
 	CPhysicalDynamicForeignScan(const CPhysicalDynamicForeignScan &) = delete;
@@ -35,7 +35,7 @@ public:
 		ULONG ulOriginOpId, ULONG scan_id, CColRefArray *pdrgpcrOutput,
 		CColRef2dArray *pdrgpdrgpcrParts, IMdIdArray *partition_mdids,
 		ColRefToUlongMapArray *root_col_mapping_per_part,
-		OID foreign_server_oid, IMDRelation::Ereldistrpolicy dist);
+		OID foreign_server_oid, IMDRelation::Ereldistrpolicy exec_location);
 
 
 	EOperatorId
@@ -67,10 +67,11 @@ public:
 		return m_foreign_server_oid;
 	}
 
+	// This is the execution location of the foreign table. See
 	IMDRelation::Ereldistrpolicy
 	DistributionType() const
 	{
-		return m_dist;
+		return m_exec_location;
 	}
 	//-------------------------------------------------------------------------------------
 	// Derived Plan Properties

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalDynamicForeignScan.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalDynamicForeignScan.h
@@ -24,7 +24,7 @@ class CPhysicalDynamicForeignScan : public CPhysicalDynamicScan
 private:
 	OID m_foreign_server_oid;
 
-	BOOL m_is_coordinator_only;
+	IMDRelation::Ereldistrpolicy m_dist;
 
 public:
 	CPhysicalDynamicForeignScan(const CPhysicalDynamicForeignScan &) = delete;
@@ -35,7 +35,7 @@ public:
 		ULONG ulOriginOpId, ULONG scan_id, CColRefArray *pdrgpcrOutput,
 		CColRef2dArray *pdrgpdrgpcrParts, IMdIdArray *partition_mdids,
 		ColRefToUlongMapArray *root_col_mapping_per_part,
-		OID foreign_server_oid, BOOL is_coordinator_only);
+		OID foreign_server_oid, IMDRelation::Ereldistrpolicy dist);
 
 
 	EOperatorId
@@ -67,10 +67,10 @@ public:
 		return m_foreign_server_oid;
 	}
 
-	BOOL
-	IsCoordinatorOnly() const
+	IMDRelation::Ereldistrpolicy
+	DistributionType() const
 	{
-		return m_is_coordinator_only;
+		return m_dist;
 	}
 	//-------------------------------------------------------------------------------------
 	// Derived Plan Properties

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformExpandDynamicGetWithForeignPartitions.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformExpandDynamicGetWithForeignPartitions.h
@@ -27,11 +27,10 @@ struct SForeignServer
 {
 	ULONG m_foreign_server_oid;
 
-	BOOL m_is_coordinator_only;
+	IMDRelation::Ereldistrpolicy m_dist;
 
-	SForeignServer(ULONG foreign_server_oid, BOOL is_coordinator_only)
-		: m_foreign_server_oid(foreign_server_oid),
-		  m_is_coordinator_only(is_coordinator_only)
+	SForeignServer(ULONG foreign_server_oid, IMDRelation::Ereldistrpolicy dist)
+		: m_foreign_server_oid(foreign_server_oid), m_dist(dist)
 	{
 	}
 };
@@ -46,7 +45,7 @@ static BOOL
 FEqualSForeignServer(const SForeignServer *fs1, const SForeignServer *fs2)
 {
 	return fs1->m_foreign_server_oid == fs2->m_foreign_server_oid &&
-		   fs1->m_is_coordinator_only == fs2->m_is_coordinator_only;
+		   fs1->m_dist == fs2->m_dist;
 }
 
 // hash maps ULONG -> array of ULONGs

--- a/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformExpandDynamicGetWithForeignPartitions.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/xforms/CXformExpandDynamicGetWithForeignPartitions.h
@@ -27,10 +27,12 @@ struct SForeignServer
 {
 	ULONG m_foreign_server_oid;
 
-	IMDRelation::Ereldistrpolicy m_dist;
+	IMDRelation::Ereldistrpolicy m_exec_location;
 
-	SForeignServer(ULONG foreign_server_oid, IMDRelation::Ereldistrpolicy dist)
-		: m_foreign_server_oid(foreign_server_oid), m_dist(dist)
+	SForeignServer(ULONG foreign_server_oid,
+				   IMDRelation::Ereldistrpolicy exec_location)
+		: m_foreign_server_oid(foreign_server_oid),
+		  m_exec_location(exec_location)
 	{
 	}
 };
@@ -45,7 +47,7 @@ static BOOL
 FEqualSForeignServer(const SForeignServer *fs1, const SForeignServer *fs2)
 {
 	return fs1->m_foreign_server_oid == fs2->m_foreign_server_oid &&
-		   fs1->m_dist == fs2->m_dist;
+		   fs1->m_exec_location == fs2->m_exec_location;
 }
 
 // hash maps ULONG -> array of ULONGs

--- a/src/backend/gporca/libgpopt/src/operators/CLogicalDynamicForeignGet.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CLogicalDynamicForeignGet.cpp
@@ -50,13 +50,13 @@ CLogicalDynamicForeignGet::CLogicalDynamicForeignGet(
 	CMemoryPool *mp, const CName *pnameAlias, CTableDescriptor *ptabdesc,
 	ULONG ulPartIndex, CColRefArray *pdrgpcrOutput,
 	CColRef2dArray *pdrgpdrgpcrPart, IMdIdArray *partition_mdids,
-	OID foreign_server_oid, BOOL is_coordinator_only)
+	OID foreign_server_oid, IMDRelation::Ereldistrpolicy dist)
 
 
 	: CLogicalDynamicGetBase(mp, pnameAlias, ptabdesc, ulPartIndex,
 							 pdrgpcrOutput, pdrgpdrgpcrPart, partition_mdids),
 	  m_foreign_server_oid(foreign_server_oid),
-	  m_is_coordinator_only(is_coordinator_only)
+	  m_dist(dist)
 {
 }
 
@@ -114,7 +114,7 @@ CLogicalDynamicForeignGet::PopCopyWithRemappedColumns(
 
 	return GPOS_NEW(mp) CLogicalDynamicForeignGet(
 		mp, pnameAlias, m_ptabdesc, m_scan_id, pdrgpcrOutput, pdrgpdrgpcrPart,
-		m_partition_mdids, m_foreign_server_oid, m_is_coordinator_only);
+		m_partition_mdids, m_foreign_server_oid, m_dist);
 }
 
 //---------------------------------------------------------------------------

--- a/src/backend/gporca/libgpopt/src/operators/CLogicalDynamicForeignGet.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CLogicalDynamicForeignGet.cpp
@@ -50,13 +50,13 @@ CLogicalDynamicForeignGet::CLogicalDynamicForeignGet(
 	CMemoryPool *mp, const CName *pnameAlias, CTableDescriptor *ptabdesc,
 	ULONG ulPartIndex, CColRefArray *pdrgpcrOutput,
 	CColRef2dArray *pdrgpdrgpcrPart, IMdIdArray *partition_mdids,
-	OID foreign_server_oid, IMDRelation::Ereldistrpolicy dist)
+	OID foreign_server_oid, IMDRelation::Ereldistrpolicy exec_location)
 
 
 	: CLogicalDynamicGetBase(mp, pnameAlias, ptabdesc, ulPartIndex,
 							 pdrgpcrOutput, pdrgpdrgpcrPart, partition_mdids),
 	  m_foreign_server_oid(foreign_server_oid),
-	  m_dist(dist)
+	  m_exec_location(exec_location)
 {
 }
 
@@ -114,7 +114,7 @@ CLogicalDynamicForeignGet::PopCopyWithRemappedColumns(
 
 	return GPOS_NEW(mp) CLogicalDynamicForeignGet(
 		mp, pnameAlias, m_ptabdesc, m_scan_id, pdrgpcrOutput, pdrgpdrgpcrPart,
-		m_partition_mdids, m_foreign_server_oid, m_dist);
+		m_partition_mdids, m_foreign_server_oid, m_exec_location);
 }
 
 //---------------------------------------------------------------------------

--- a/src/backend/gporca/libgpopt/src/operators/CPhysical.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysical.cpp
@@ -22,6 +22,7 @@
 #include "gpopt/base/CDistributionSpecRandom.h"
 #include "gpopt/base/CDistributionSpecReplicated.h"
 #include "gpopt/base/CDistributionSpecSingleton.h"
+#include "gpopt/base/CDistributionSpecUniversal.h"
 #include "gpopt/base/CDrvdPropPlan.h"
 #include "gpopt/base/CReqdPropPlan.h"
 #include "gpopt/operators/CExpression.h"
@@ -260,6 +261,10 @@ CPhysical::PdsCompute(CMemoryPool *mp, const CTableDescriptor *ptabdesc,
 		case IMDRelation::EreldistrCoordinatorOnly:
 			pds = GPOS_NEW(mp) CDistributionSpecSingleton(
 				CDistributionSpecSingleton::EstCoordinator);
+			break;
+
+		case IMDRelation::EreldistrUniversal:
+			pds = GPOS_NEW(mp) CDistributionSpecUniversal();
 			break;
 
 		case IMDRelation::EreldistrRandom:

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalDynamicForeignScan.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalDynamicForeignScan.cpp
@@ -15,6 +15,7 @@
 
 #include "gpopt/base/CDistributionSpecRandom.h"
 #include "gpopt/base/CDistributionSpecStrictSingleton.h"
+#include "gpopt/base/CDistributionSpecUniversal.h"
 #include "gpopt/metadata/CName.h"
 #include "gpopt/metadata/CTableDescriptor.h"
 #include "gpopt/operators/CExpressionHandle.h"
@@ -36,25 +37,35 @@ CPhysicalDynamicForeignScan::CPhysicalDynamicForeignScan(
 	ULONG ulOriginOpId, ULONG scan_id, CColRefArray *pdrgpcrOutput,
 	CColRef2dArray *pdrgpdrgpcrParts, IMdIdArray *partition_mdids,
 	ColRefToUlongMapArray *root_col_mapping_per_part, OID foreign_server_oid,
-	BOOL is_coordinator_only)
+	IMDRelation::Ereldistrpolicy dist)
 
 
 	: CPhysicalDynamicScan(mp, ptabdesc, ulOriginOpId, pnameAlias, scan_id,
 						   pdrgpcrOutput, pdrgpdrgpcrParts, partition_mdids,
 						   root_col_mapping_per_part),
 	  m_foreign_server_oid(foreign_server_oid),
-	  m_is_coordinator_only(is_coordinator_only)
+	  m_dist(dist)
 {
+	// we need to overwrite the distribution spec for DynamicForeignGets, as
+	// the partition table can have one distribution, but the distribution for the
+	// foreign get can be different. Note this distribution spec mismatch is only
+	// allowed for foreign partitions
 	m_pds->Release();
 	// if this table is coordinator only, use a strict singleton distribution request
-	if (is_coordinator_only)
+	if (m_dist == IMDRelation::EreldistrCoordinatorOnly)
 	{
 		m_pds = GPOS_NEW(mp) CDistributionSpecStrictSingleton(
 			CDistributionSpecSingleton::EstCoordinator);
 	}
-	// otherwise, we want to execute on each segment (but can't assume anything about the distribution)
+	else if (m_dist == IMDRelation::EreldistrUniversal)
+	{
+		m_pds = GPOS_NEW(mp) CDistributionSpecUniversal();
+	}
+	// otherwise, we want to execute on each segment, but can't assume anything
+	// about the distribution so we treat it as random
 	else
 	{
+		GPOS_ASSERT(m_dist == IMDRelation::EreldistrRandom);
 		m_pds = GPOS_NEW(mp) CDistributionSpecRandom();
 	}
 }

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalDynamicForeignScan.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalDynamicForeignScan.cpp
@@ -37,14 +37,14 @@ CPhysicalDynamicForeignScan::CPhysicalDynamicForeignScan(
 	ULONG ulOriginOpId, ULONG scan_id, CColRefArray *pdrgpcrOutput,
 	CColRef2dArray *pdrgpdrgpcrParts, IMdIdArray *partition_mdids,
 	ColRefToUlongMapArray *root_col_mapping_per_part, OID foreign_server_oid,
-	IMDRelation::Ereldistrpolicy dist)
+	IMDRelation::Ereldistrpolicy exec_location)
 
 
 	: CPhysicalDynamicScan(mp, ptabdesc, ulOriginOpId, pnameAlias, scan_id,
 						   pdrgpcrOutput, pdrgpdrgpcrParts, partition_mdids,
 						   root_col_mapping_per_part),
 	  m_foreign_server_oid(foreign_server_oid),
-	  m_dist(dist)
+	  m_exec_location(exec_location)
 {
 	// we need to overwrite the distribution spec for DynamicForeignGets, as
 	// the partition table can have one distribution, but the distribution for the
@@ -52,20 +52,20 @@ CPhysicalDynamicForeignScan::CPhysicalDynamicForeignScan(
 	// allowed for foreign partitions
 	m_pds->Release();
 	// if this table is coordinator only, set the distribution as strict singleton
-	if (m_dist == IMDRelation::EreldistrCoordinatorOnly)
+	if (m_exec_location == IMDRelation::EreldistrCoordinatorOnly)
 	{
 		m_pds = GPOS_NEW(mp) CDistributionSpecStrictSingleton(
 			CDistributionSpecSingleton::EstCoordinator);
 	}
 	// if the table can be executed on either a segment or coordinator, set it as universal
-	else if (m_dist == IMDRelation::EreldistrUniversal)
+	else if (m_exec_location == IMDRelation::EreldistrUniversal)
 	{
 		m_pds = GPOS_NEW(mp) CDistributionSpecUniversal();
 	}
 	// if the distribution is set to "all segments", it is set to a random distribution
 	else
 	{
-		GPOS_ASSERT(m_dist == IMDRelation::EreldistrRandom);
+		GPOS_ASSERT(m_exec_location == IMDRelation::EreldistrRandom);
 		m_pds = GPOS_NEW(mp) CDistributionSpecRandom();
 	}
 }

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalDynamicForeignScan.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalDynamicForeignScan.cpp
@@ -48,21 +48,21 @@ CPhysicalDynamicForeignScan::CPhysicalDynamicForeignScan(
 {
 	// we need to overwrite the distribution spec for DynamicForeignGets, as
 	// the partition table can have one distribution, but the distribution for the
-	// foreign get can be different. Note this distribution spec mismatch is only
+	// ForeignGet can be different. Note this distribution spec mismatch is only
 	// allowed for foreign partitions
 	m_pds->Release();
-	// if this table is coordinator only, use a strict singleton distribution request
+	// if this table is coordinator only, set the distribution as strict singleton
 	if (m_dist == IMDRelation::EreldistrCoordinatorOnly)
 	{
 		m_pds = GPOS_NEW(mp) CDistributionSpecStrictSingleton(
 			CDistributionSpecSingleton::EstCoordinator);
 	}
+	// if the table can be executed on either a segment or coordinator, set it as universal
 	else if (m_dist == IMDRelation::EreldistrUniversal)
 	{
 		m_pds = GPOS_NEW(mp) CDistributionSpecUniversal();
 	}
-	// otherwise, we want to execute on each segment, but can't assume anything
-	// about the distribution so we treat it as random
+	// if the distribution is set to "all segments", it is set to a random distribution
 	else
 	{
 		GPOS_ASSERT(m_dist == IMDRelation::EreldistrRandom);

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalForeignScan.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalForeignScan.cpp
@@ -35,19 +35,6 @@ CPhysicalForeignScan::CPhysicalForeignScan(CMemoryPool *mp,
 										   CColRefArray *pdrgpcrOutput)
 	: CPhysicalTableScan(mp, pnameAlias, ptabdesc, pdrgpcrOutput)
 {
-	// if this table is coordinator only, then keep the original distribution spec.
-	if (IMDRelation::EreldistrCoordinatorOnly == ptabdesc->GetRelDistribution())
-	{
-		return;
-	}
-
-	// otherwise, override the distribution spec for foreign table
-	if (m_pds)
-	{
-		m_pds->Release();
-	}
-
-	m_pds = GPOS_NEW(mp) CDistributionSpecRandom();
 }
 
 //---------------------------------------------------------------------------

--- a/src/backend/gporca/libgpopt/src/operators/CPhysicalMotionRandom.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CPhysicalMotionRandom.cpp
@@ -181,7 +181,6 @@ CPhysicalMotionRandom::OsPrint(IOstream &os) const
 	return os;
 }
 
-
 //---------------------------------------------------------------------------
 //	@function:
 //		CPhysicalMotionRandom::PopConvert

--- a/src/backend/gporca/libgpopt/src/xforms/CXformDynamicForeignGet2DynamicForeignScan.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformDynamicForeignGet2DynamicForeignScan.cpp
@@ -96,7 +96,7 @@ CXformDynamicForeignGet2DynamicForeignScan::Transform(CXformContext *pxfctxt,
 				mp, pname, ptabdesc, popGet->UlOpId(), popGet->ScanId(),
 				pdrgpcrOutput, pdrgpdrgpcrPart, popGet->GetPartitionMdids(),
 				popGet->GetRootColMappingPerPart(),
-				popGet->GetForeignServerOid(), popGet->IsCoordinatorOnly()));
+				popGet->GetForeignServerOid(), popGet->DistributionType()));
 	// add alternative to transformation result
 	pxfres->Add(pexprAlt);
 }

--- a/src/backend/gporca/libgpopt/src/xforms/CXformExpandDynamicGetWithForeignPartitions.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformExpandDynamicGetWithForeignPartitions.cpp
@@ -207,11 +207,12 @@ CXformExpandDynamicGetWithForeignPartitions::Transform(CXformContext *pxfctxt,
 		{
 			pdrgpcrNew = CUtils::PdrgpcrCopy(mp, popGet->PdrgpcrOutput());
 		}
-		CLogicalDynamicForeignGet *dynamicForeignGet =
-			GPOS_NEW(mp) CLogicalDynamicForeignGet(
-				mp, new_alias, popGet->Ptabdesc(), popGet->ScanId(), pdrgpcrNew,
-				popGet->PdrgpdrgpcrPart(), part_oid_array,
-				foreign_server.m_foreign_server_oid, foreign_server.m_dist);
+		CLogicalDynamicForeignGet *dynamicForeignGet = GPOS_NEW(mp)
+			CLogicalDynamicForeignGet(mp, new_alias, popGet->Ptabdesc(),
+									  popGet->ScanId(), pdrgpcrNew,
+									  popGet->PdrgpdrgpcrPart(), part_oid_array,
+									  foreign_server.m_foreign_server_oid,
+									  foreign_server.m_exec_location);
 		CExpression *pexprDynamicForeignGet =
 			GPOS_NEW(mp) CExpression(mp, dynamicForeignGet);
 

--- a/src/backend/gporca/libgpopt/src/xforms/CXformExpandDynamicGetWithForeignPartitions.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformExpandDynamicGetWithForeignPartitions.cpp
@@ -112,14 +112,11 @@ CXformExpandDynamicGetWithForeignPartitions::Transform(CXformContext *pxfctxt,
 			// (some foreign tables can only be executed on segments, others only the coordinator)
 			// place these in a map from server->array of foreign partitions
 			const IMDRelation *pmdrel = md_accessor->RetrieveRel(partMdid);
-			BOOL is_coordinator_only =
-				(gpmd::CMDRelationGPDB::EreldistrCoordinatorOnly ==
-				 pmdrel->GetRelDistribution());
 
 			OID foreign_server_oid =
 				CMDIdGPDB::CastMdid(foreign_server_mdid)->Oid();
-			SForeignServer foreign_server_lookup = {foreign_server_oid,
-													is_coordinator_only};
+			SForeignServer foreign_server_lookup = {
+				foreign_server_oid, pmdrel->GetRelDistribution()};
 			const IMdIdArray *foreign_server =
 				foreign_server_to_part_oid_array_map->Find(
 					&foreign_server_lookup);
@@ -130,8 +127,8 @@ CXformExpandDynamicGetWithForeignPartitions::Transform(CXformContext *pxfctxt,
 				part_oid_array->Append(partMdid);
 				BOOL fres GPOS_ASSERTS_ONLY =
 					foreign_server_to_part_oid_array_map->Insert(
-						GPOS_NEW(mp) SForeignServer{foreign_server_oid,
-													is_coordinator_only},
+						GPOS_NEW(mp) SForeignServer{
+							foreign_server_oid, pmdrel->GetRelDistribution()},
 						part_oid_array);
 				GPOS_ASSERT(fres);
 			}
@@ -210,12 +207,11 @@ CXformExpandDynamicGetWithForeignPartitions::Transform(CXformContext *pxfctxt,
 		{
 			pdrgpcrNew = CUtils::PdrgpcrCopy(mp, popGet->PdrgpcrOutput());
 		}
-		CLogicalDynamicForeignGet *dynamicForeignGet = GPOS_NEW(mp)
-			CLogicalDynamicForeignGet(mp, new_alias, popGet->Ptabdesc(),
-									  popGet->ScanId(), pdrgpcrNew,
-									  popGet->PdrgpdrgpcrPart(), part_oid_array,
-									  foreign_server.m_foreign_server_oid,
-									  foreign_server.m_is_coordinator_only);
+		CLogicalDynamicForeignGet *dynamicForeignGet =
+			GPOS_NEW(mp) CLogicalDynamicForeignGet(
+				mp, new_alias, popGet->Ptabdesc(), popGet->ScanId(), pdrgpcrNew,
+				popGet->PdrgpdrgpcrPart(), part_oid_array,
+				foreign_server.m_foreign_server_oid, foreign_server.m_dist);
 		CExpression *pexprDynamicForeignGet =
 			GPOS_NEW(mp) CExpression(mp, dynamicForeignGet);
 

--- a/src/backend/gporca/libnaucrates/include/naucrates/dxl/xml/dxltokens.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/dxl/xml/dxltokens.h
@@ -490,6 +490,7 @@ enum Edxltoken
 	EdxltokenRelDistrHash,
 	EdxltokenRelDistrRandom,
 	EdxltokenRelDistrReplicated,
+	EdxltokenRelDistrUniversal,
 	EdxltokenConvertHashToRandom,
 
 	EdxltokenRelDistrOpfamilies,

--- a/src/backend/gporca/libnaucrates/include/naucrates/md/IMDRelation.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/md/IMDRelation.h
@@ -66,6 +66,7 @@ public:
 		EreldistrHash,
 		EreldistrRandom,
 		EreldistrReplicated,
+		EreldistrUniversal,
 		EreldistrSentinel
 	};
 

--- a/src/backend/gporca/libnaucrates/src/md/IMDRelation.cpp
+++ b/src/backend/gporca/libnaucrates/src/md/IMDRelation.cpp
@@ -39,6 +39,8 @@ IMDRelation::GetDistrPolicyStr(Ereldistrpolicy rel_distr_policy)
 			return CDXLTokens::GetDXLTokenStr(EdxltokenRelDistrRandom);
 		case EreldistrReplicated:
 			return CDXLTokens::GetDXLTokenStr(EdxltokenRelDistrReplicated);
+		case EreldistrUniversal:
+			return CDXLTokens::GetDXLTokenStr(EdxltokenRelDistrUniversal);
 		default:
 			return nullptr;
 	}

--- a/src/backend/gporca/libnaucrates/src/operators/CDXLOperatorFactory.cpp
+++ b/src/backend/gporca/libnaucrates/src/operators/CDXLOperatorFactory.cpp
@@ -3547,6 +3547,12 @@ CDXLOperatorFactory::ParseRelationDistPolicy(const XMLCh *xml_val)
 	{
 		rel_distr_policy = IMDRelation::EreldistrReplicated;
 	}
+	else if (0 ==
+			 XMLString::compareString(
+				 xml_val, CDXLTokens::XmlstrToken(EdxltokenRelDistrUniversal)))
+	{
+		rel_distr_policy = IMDRelation::EreldistrUniversal;
+	}
 
 	return rel_distr_policy;
 }

--- a/src/backend/gporca/libnaucrates/src/xml/dxltokens.cpp
+++ b/src/backend/gporca/libnaucrates/src/xml/dxltokens.cpp
@@ -541,6 +541,7 @@ CDXLTokens::Init(CMemoryPool *mp)
 		{EdxltokenRelDistrHash, GPOS_WSZ_LIT("Hash")},
 		{EdxltokenRelDistrRandom, GPOS_WSZ_LIT("Random")},
 		{EdxltokenRelDistrReplicated, GPOS_WSZ_LIT("Replicated")},
+		{EdxltokenRelDistrUniversal, GPOS_WSZ_LIT("Universal")},
 		{EdxltokenConvertHashToRandom, GPOS_WSZ_LIT("ConvertHashToRandom")},
 
 		{EdxltokenRelDistrOpfamilies, GPOS_WSZ_LIT("DistrOpfamilies")},

--- a/src/backend/gporca/server/CMakeLists.txt
+++ b/src/backend/gporca/server/CMakeLists.txt
@@ -391,7 +391,7 @@ CoverintIndexTest:
 CoveringIndex-1 CoveringIndex-2 CoveringIndex-3;
 
 CForeignPartTest:
-ForeignPartUniform PartForeignMixed PartForeignDifferentServer PartForeignDifferentExecLocation PartForeignMixedDPE PartForeignMixedSPE PartForeignUniformSPE
+ForeignPartUniform PartForeignMixed PartForeignDifferentServer PartForeignDifferentExecLocation PartForeignMixedDPE PartForeignMixedSPE PartForeignUniformSPE ForeignScanExecLocAnySimpleScan ForeignScanExecLocAnyJoin
 ")
 
 set(mdp_dir "../data/dxl/minidump/")

--- a/src/include/gpopt/translate/CTranslatorRelcacheToDXL.h
+++ b/src/include/gpopt/translate/CTranslatorRelcacheToDXL.h
@@ -25,6 +25,7 @@ extern "C" {
 
 #include "access/tupdesc.h"
 #include "catalog/gp_distribution_policy.h"
+#include "foreign/foreign.h"
 }
 
 #include "naucrates/dxl/gpdb_types.h"
@@ -348,6 +349,9 @@ public:
 
 	// get the distribution policy of the relation
 	static IMDRelation::Ereldistrpolicy GetRelDistribution(GpPolicy *gp_policy);
+
+	static IMDRelation::Ereldistrpolicy GetForeignRelDistribution(
+		ForeignTable *ft);
 };
 }  // namespace gpdxl
 

--- a/src/include/gpopt/translate/CTranslatorRelcacheToDXL.h
+++ b/src/include/gpopt/translate/CTranslatorRelcacheToDXL.h
@@ -350,8 +350,8 @@ public:
 	// get the distribution policy of the relation
 	static IMDRelation::Ereldistrpolicy GetRelDistribution(GpPolicy *gp_policy);
 
-	static IMDRelation::Ereldistrpolicy GetForeignRelDistribution(
-		ForeignTable *ft);
+	static IMDRelation::Ereldistrpolicy
+	GetDistributionFromForeignRelExecLocation(ForeignTable *ft);
 };
 }  // namespace gpdxl
 

--- a/src/test/regress/init_file
+++ b/src/test/regress/init_file
@@ -12,6 +12,10 @@ m/^NOTICE:  extension "gp_inject_fault" already exists, skipping/
 # of the test. Ignore the NOTICE if it exists already.
 m/NOTICE:  extension "gp_debug_numsegments" already exists, skipping/
 
+# Some tests use the postgres_fdw extension, and create it at the beginning
+# of the test. Ignore the NOTICE if it exists already.
+m/NOTICE:  extension "postgres_fdw" already exists, skipping/
+
 m/^ Optimizer status:.*/
 m/^ Optimizer: Pivotal Optimizer \(GPORCA\).*/
 m/^ Optimizer: Postgres query optimizer/


### PR DESCRIPTION
When the mpp_execute option "ANY" is specified, we now will either execute it on a segment or coordinator depending on the cost.

Previously, when a foreign table was created to be executed with the ANY location, Orca still only executed it on the coordinator. Now, we treat it similarly to executing a set-returning function such as generate_series, and allow it to be executed on either the coordinator or a segment depending on costing. We add a new table distribution, Universal, which derives a Universal distribution in Orca just like a generate_series. It's important to note that this has different behavior from `all segments`, which treats the data as distributed randomly and processed as separate data on each segment (for example, accessing a specific file on each segment).

As an example, if we're using the postgres FDW, for a simple `select * from pg_foreign_table`, we should perform this on the coordinator since it would end up being gathered to the coordinator after. However, if we're performing a join, it's (very) likely to be better to do on a segment.

Additionally, run the gp_postgres_fdw regression suite in ICW.