### PR TITLE
Remove FIXME in partition_pruning that was already addressed

### DIFF
--- a/src/test/regress/expected/partition_pruning.out
+++ b/src/test/regress/expected/partition_pruning.out
@@ -7,11 +7,6 @@
 -- the planner and the rest of the system, so the expected output can need
 -- updating, as the system improves.
 --
--- GPDB_12_MERGE_FIXME: Many of these queries are no longer able to constraint
--- exclusion, like we used to on GPDB 6. Not sure what we should do about it.
--- See https://github.com/greenplum-db/gpdb/issues/10287.
--- In GPDB6 this case is partition pruned, but the result is wrong,
--- in MAIN branch it is not partition pruned, but has right result.
 -- Create test table with two partitions, for values equal to '1' and values equal to '2'.
 create table parttab (n numeric, t text)
   partition by list (n)(partition one values ('1'), partition two values('2'));

--- a/src/test/regress/expected/partition_pruning_optimizer.out
+++ b/src/test/regress/expected/partition_pruning_optimizer.out
@@ -7,11 +7,6 @@
 -- the planner and the rest of the system, so the expected output can need
 -- updating, as the system improves.
 --
--- GPDB_12_MERGE_FIXME: Many of these queries are no longer able to constraint
--- exclusion, like we used to on GPDB 6. Not sure what we should do about it.
--- See https://github.com/greenplum-db/gpdb/issues/10287.
--- In GPDB6 this case is partition pruned, but the result is wrong,
--- in MAIN branch it is not partition pruned, but has right result.
 -- Create test table with two partitions, for values equal to '1' and values equal to '2'.
 create table parttab (n numeric, t text)
   partition by list (n)(partition one values ('1'), partition two values('2'));

--- a/src/test/regress/sql/partition_pruning.sql
+++ b/src/test/regress/sql/partition_pruning.sql
@@ -8,11 +8,6 @@
 -- updating, as the system improves.
 --
 
--- GPDB_12_MERGE_FIXME: Many of these queries are no longer able to constraint
--- exclusion, like we used to on GPDB 6. Not sure what we should do about it.
--- See https://github.com/greenplum-db/gpdb/issues/10287.
--- In GPDB6 this case is partition pruned, but the result is wrong,
--- in MAIN branch it is not partition pruned, but has right result.
 -- Create test table with two partitions, for values equal to '1' and values equal to '2'.
 create table parttab (n numeric, t text)
   partition by list (n)(partition one values ('1'), partition two values('2'));


### PR DESCRIPTION
This FIXME was for planner's lack of partition pruning in certain cases. The logic in GP6 could generate wrong results, so it was decided to remove the over-eager optimization for GP7. Orca never did pruning in this case. See https://github.com/greenplum-db/gpdb/issues/10287 and https://github.com/greenplum-db/gpdb/pull/14553 for additional context.