### PR TITLE
Correctly set locus for WorkTable Scan

### DIFF
--- a/src/test/regress/expected/gp_recursive_cte.out
+++ b/src/test/regress/expected/gp_recursive_cte.out
@@ -660,7 +660,7 @@ SELECT $query$
 WITH RECURSIVE cte (i, j) AS (
     SELECT a, b FROM recursive_table_6 WHERE a = 0::numeric::numeric
     UNION ALL
-    SELECT a, b FROM cte, recursive_table_6 WHERE cte.i = recursive_table_6.b
+    SELECT a, b FROM recursive_table_6, cte WHERE cte.i = recursive_table_6.b
 )
 SELECT i, j FROM cte;
 $query$ AS qry \gset

--- a/src/test/regress/expected/gp_recursive_cte.out
+++ b/src/test/regress/expected/gp_recursive_cte.out
@@ -646,3 +646,46 @@ select * from cte;
  10
 (10 rows)
 
+-- Test recursive CTE when the non-recursive term is a table scan with a
+-- predicate on the distribution key, and the recursive term joins the CTE with
+-- the same table on its non-distribution key
+create table recursive_table_6(a numeric(4), b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into recursive_table_6 values (0::numeric, 3);
+insert into recursive_table_6 values (2::numeric, 0);
+insert into recursive_table_6 values (5::numeric, 0);
+analyze recursive_table_6;
+SELECT $query$
+WITH RECURSIVE cte (i, j) AS (
+    SELECT a, b FROM recursive_table_6 WHERE a = 0::numeric::numeric
+    UNION ALL
+    SELECT a, b FROM cte, recursive_table_6 WHERE cte.i = recursive_table_6.b
+)
+SELECT i, j FROM cte;
+$query$ AS qry \gset
+EXPLAIN (COSTS OFF)
+    :qry ;
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Recursive Union
+         ->  Seq Scan on recursive_table_6
+               Filter: (a = '0'::numeric)
+         ->  Hash Join
+               Hash Cond: (cte.i = (recursive_table_6_1.b)::numeric)
+               ->  WorkTable Scan on cte
+               ->  Hash
+                     ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                           ->  Seq Scan on recursive_table_6 recursive_table_6_1
+ Optimizer: Postgres query optimizer
+(11 rows)
+
+:qry ;
+ i | j 
+---+---
+ 0 | 3
+ 2 | 0
+ 5 | 0
+(3 rows)
+

--- a/src/test/regress/sql/gp_recursive_cte.sql
+++ b/src/test/regress/sql/gp_recursive_cte.sql
@@ -445,3 +445,26 @@ with recursive cte (n) as
   ) q
 )
 select * from cte;
+
+-- Test recursive CTE when the non-recursive term is a table scan with a
+-- predicate on the distribution key, and the recursive term joins the CTE with
+-- the same table on its non-distribution key
+create table recursive_table_6(a numeric(4), b int);
+insert into recursive_table_6 values (0::numeric, 3);
+insert into recursive_table_6 values (2::numeric, 0);
+insert into recursive_table_6 values (5::numeric, 0);
+analyze recursive_table_6;
+
+SELECT $query$
+WITH RECURSIVE cte (i, j) AS (
+    SELECT a, b FROM recursive_table_6 WHERE a = 0::numeric::numeric
+    UNION ALL
+    SELECT a, b FROM cte, recursive_table_6 WHERE cte.i = recursive_table_6.b
+)
+SELECT i, j FROM cte;
+$query$ AS qry \gset
+
+EXPLAIN (COSTS OFF)
+    :qry ;
+
+:qry ;

--- a/src/test/regress/sql/gp_recursive_cte.sql
+++ b/src/test/regress/sql/gp_recursive_cte.sql
@@ -459,7 +459,7 @@ SELECT $query$
 WITH RECURSIVE cte (i, j) AS (
     SELECT a, b FROM recursive_table_6 WHERE a = 0::numeric::numeric
     UNION ALL
-    SELECT a, b FROM cte, recursive_table_6 WHERE cte.i = recursive_table_6.b
+    SELECT a, b FROM recursive_table_6, cte WHERE cte.i = recursive_table_6.b
 )
 SELECT i, j FROM cte;
 $query$ AS qry \gset


### PR DESCRIPTION
Prior to 9.6 merge, given the locus of the non-recursive path of a
recursive CTE as input, we used to set the locus of the recursive
path, aka WorkTaleScan, to Strewn in some cases.

This logic was first introduced by commit fd61a4ca26 which initially
brought recursive CTE into Greeanplum. However the logic was lost
during PostgreSQL 9.6 merge by commit
greenplum-db/gpdb-postgres-merge@799c7f90fc in iteration_REL9_6 merge
branch. A GPDB_96_MERGE_FIXME had been added by a merge commit
greenplum-db/gpdb-postgres-merge@c67c3ec4f8, along with this merge
commit, an additional add-on to the logic for OuterQuery by Greenplum
commit 00e25afe11 was also overlooked. Later on by commit b5bc9dfcf9,
even the merge FIXME was innocently removed.

This patch adds the missing logic back and adds test for the same.

Fixes #15555

Proposed-by: Zhenghua Lyu <kainwen@gmail.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
