### PR TITLE
[7x] Added host-name parameter in recovery configutation

### DIFF
--- a/gpMgmt/doc/gprecoverseg_help
+++ b/gpMgmt/doc/gprecoverseg_help
@@ -68,7 +68,14 @@ The word SPACE indicates the location of a required space. Do not
 add additional spaces.
 
 <failed_host_address>|<port>|<data_directory>SPACE
-[<recovery_host_address>|<port>|<data_directory>
+[<recovery_host_address>|<port>|<data_directory>]
+
+If hostname is not provided, host-address will be populated in the
+configuration. In case you want to have different hostname and address,
+hostname can be specified in the recovery configuration, the format
+for the config file is as follows:
+<failed_host_name>|<failed_host_address>|<port>|<data_directory>SPACE
+[<recovery_host_name>|<recovery_host_address>|<port>|<data_directory>]
 
 See the -i option below for details and examples of a recovery
 configuration file.
@@ -179,7 +186,11 @@ sdw1-1|50001|/data1/mirror/gpseg16
 
 Recovery of a single mirror to a new host
 
-sdw1-1|50001|/data1/mirror/gpseg16SPACE sdw4-1|50001|51001|/data1/recover1/gpseg16
+sdw1-1|50001|/data1/mirror/gpseg16 SPACE sdw4-1|50001|51001|/data1/recover1/gpseg16
+
+Recovery of a single mirror to a new host with hostname specified:
+sdw1|sdw1-1|50001|/data1/mirror/gpseg16 SPACE
+sdw4|sdw4-1|50001|51001|/data1/recover1/gpseg16
 
 Obtaining a Sample File
 

--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -1724,3 +1724,164 @@ Feature: gprecoverseg tests
          Then gprecoverseg should return a return code of 0
           And all the segments are running
           And the segments are synchronized
+
+
+
+  @concourse_cluster
+    Scenario: gprecoverseg recovery to new host populates hostname and address from the config file correctly
+        Given the database is running
+          And all the segments are running
+          And the segments are synchronized
+          And the information of a "primary" segment on a remote host is saved
+          And the gprecoverseg input file "recover-config.conf" is cleaned up
+         When user kills a "primary" process with the saved information
+          And user can start transactions
+         Then the saved "primary" segment is marked down in config
+          When a gprecoverseg input file "recover-config.conf" is created with added parameter hostname to recover the failed segment on new host
+          And the user runs "gprecoverseg -i /tmp/recover-config.conf -a -v"
+         Then gprecoverseg should return a return code of 0
+         When check hostname and address updated on segment configuration with the saved information
+          And all the segments are running
+          And the segments are synchronized
+
+    @concourse_cluster
+    Scenario: gprecoverseg recovery to same host (full inplace) populates hostname and address from the config file correctly
+        Given the database is running
+          And all the segments are running
+          And the segments are synchronized
+          And the information of a "primary" segment on a remote host is saved
+          And the gprecoverseg input file "recover-config.conf" is cleaned up
+          When user kills a "primary" process with the saved information
+          And user can start transactions
+          Then the saved "primary" segment is marked down in config
+          When a gprecoverseg input file "recover-config.conf" is created with hostname parameter to recover the failed segment on same host
+          And the user runs "gprecoverseg -i /tmp/recover-config.conf -a -v"
+          Then gprecoverseg should return a return code of 0
+          When check hostname and address updated on segment configuration with the saved information
+          And all the segments are running
+          And the segments are synchronized
+
+
+  @concourse_cluster
+    Scenario: gprecoverseg recovery with invalid format with hostname in config file
+        Given the database is running
+          And all the segments are running
+          And the segments are synchronized
+          And the information of a "primary" segment on a remote host is saved
+          And the gprecoverseg input file "recover-config-invalid.conf" is cleaned up
+          When user kills a "primary" process with the saved information
+          And user can start transactions
+          Then the saved "primary" segment is marked down in config
+          When a gprecoverseg input file "recover-config-invalid.conf" is created with invalid format for inplace full recovery of failed segment
+          And the user runs "gprecoverseg -i /tmp/recover-config-invalid.conf -a -v"
+          Then gprecoverseg should return a return code of 2
+          And gprecoverseg should print "line 1 of file /tmp/recover-config-invalid.conf: expected equal parts, either 3 or 4 on both segment group, obtained 4 on group1 and 3 on group2" to stdout
+          Then the user runs "gprecoverseg -a"
+          Then gprecoverseg should return a return code of 0
+          And the cluster is rebalanced
+
+
+  @concourse_cluster
+    Scenario: gprecoverseg incremental recovery populates hostname and address from the config file correctly
+        Given the database is running
+          And all the segments are running
+          And the segments are synchronized
+          And the information of a "primary" segment on a remote host is saved
+          And the gprecoverseg input file "recover-config.conf" is cleaned up
+          When user kills a "primary" process with the saved information
+          And user can start transactions
+          Then the saved "primary" segment is marked down in config
+          When a gprecoverseg input file "recover-config.conf" is created with hostname parameter matches with segment configuration table for incremental recovery of failed segment
+          And the user runs "gprecoverseg -i /tmp/recover-config.conf -a -v"
+          Then gprecoverseg should return a return code of 0
+          When check hostname and address updated on segment configuration with the saved information
+          And all the segments are running
+          And the segments are synchronized
+
+    @concourse_cluster
+    Scenario: gprecoverseg recovery with and without hostname parameter in config file
+        Given the database is running
+          And all the segments are running
+          And the segments are synchronized
+          And user stops all primary processes
+          And user can start transactions
+          And the gprecoverseg input file "recover-config.conf" is cleaned up
+          When a gprecoverseg input file "recover-config.conf" is created with and without parameter hostname to recover all the failed segments
+          And the user runs "gprecoverseg -i /tmp/recover-config.conf -a -F -v"
+          Then gprecoverseg should return a return code of 0
+          And all the segments are running
+          And the segments are synchronized
+
+    @concourse_cluster
+    Scenario: gprecoverseg throws warning and skips recovery if provided hostname and address can not be resolved to same host
+        Given the database is running
+          And all the segments are running
+          And the segments are synchronized
+          And the information of a "primary" segment on a remote host is saved
+          And user stops all primary processes
+          And user can start transactions
+          And the gprecoverseg input file "recover-config.conf" is cleaned up
+          When a gprecoverseg input file "recover-config.conf" created with invalid failover hostname for full recovery of failed segment
+          And the user runs "gprecoverseg -i /tmp/recover-config.conf -a -F -v"
+          Then gprecoverseg should return a return code of 0
+          And gprecoverseg should print a "Not able to co-relate hostname:.* with address.*Skipping recovery for segments with contentId" warning
+          Then the user runs "gprecoverseg -a"
+          Then gprecoverseg should return a return code of 0
+          And all the segments are running
+          And the segments are synchronized
+
+    @concourse_cluster
+    Scenario: gprecoverseg incremental recovery fails if config file contains wrong hostname of failed segment
+        Given the database is running
+          And all the segments are running
+          And the segments are synchronized
+          And the information of a "primary" segment on a remote host is saved
+          And the gprecoverseg input file "recover-config.conf" is cleaned up
+          When user kills a "primary" process with the saved information
+          And user can start transactions
+          Then the saved "primary" segment is marked down in config
+          When a gprecoverseg input file "recover-config.conf" is created with invalid hostname parameter that does not matches with the segment configuration table hostname
+          And the user runs "gprecoverseg -i /tmp/recover-config.conf -a -v"
+          Then gprecoverseg should return a return code of 2
+          And gprecoverseg should print "A segment to recover was not found in configuration.  This segment is described by hostname|address|port|directory .*'" to stdout
+          Then the user runs "gprecoverseg -a"
+          And gprecoverseg should return a return code of 0
+          And the cluster is rebalanced
+
+  @demo_cluster
+  Scenario: gprecoverseg recovers segment when config file contains hostname on demo cluster
+    Given the database is running
+    And all the segments are running
+    And the segments are synchronized
+    And all files in gpAdminLogs directory are deleted on all hosts in the cluster
+    And user immediately stops all primary processes for content 0
+    And user can start transactions
+    And a gprecoverseg directory under '/tmp' with mode '0700' is created
+    And a gprecoverseg input file is created
+    And edit the hostsname input file to recover segment with content 0 full inplace
+    And update /etc/hosts file with address for the localhost
+    When the user runs gprecoverseg with input file and additional args "-a"
+    And gprecoverseg should return a return code of 0
+    And restore /etc/hosts file and cleanup hostlist file
+    And the cluster configuration has no segments where "content=0 and status='d'"
+    Then the cluster is rebalanced
+
+  @demo_cluster
+  Scenario: gprecoverseg skips recovery when config file contains invalid hostname on demo cluster
+    Given the database is running
+    And all the segments are running
+    And the segments are synchronized
+    And all files in gpAdminLogs directory are deleted on all hosts in the cluster
+    And user immediately stops all primary processes for content 0
+    And user can start transactions
+    And a gprecoverseg directory under '/tmp' with mode '0700' is created
+    And a gprecoverseg input file is created
+    And edit the hostsname input file to recover segment with content 0 with invalid hostname
+    When the user runs gprecoverseg with input file and additional args "-a"
+    And gprecoverseg should print a "Could not resolve hostname:invalid_host" warning
+    And gprecoverseg should print a "Not able to co-relate hostname:invalid_host with address:.*Skipping recovery for segments with contentId" warning
+    And gprecoverseg should print "No segments to recover" to stdout
+    And gprecoverseg should return a return code of 0
+    And the user runs "gprecoverseg -a -v"
+    Then gprecoverseg should return a return code of 0
+    And the cluster is rebalanced

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -630,7 +630,6 @@ def impl(context, process_name, secs):
         command = "sleep %d; ps ux | grep %s | awk '{print $2}' | xargs kill" % (int(secs), process_name)
     run_async_command(context, command)
 
-
 @when('the user asynchronously sets up to end {process_name} process when {log_msg} is printed in the logs')
 def impl(context, process_name, log_msg):
     command = "while sleep 0.1; " \
@@ -804,6 +803,7 @@ def impl(context, command, out_msg):
 @when('{command} should print "{out_msg}" to stdout')
 @then('{command} should print "{out_msg}" to stdout')
 @then('{command} should print a "{out_msg}" warning')
+@when('{command} should print a "{out_msg}" warning')
 def impl(context, command, out_msg):
     check_stdout_msg(context, out_msg)
 
@@ -1559,6 +1559,7 @@ def impl(context, content_ids, expected_status):
 
 
 @given('the cluster configuration has no segments where "{filter}"')
+@when('the cluster configuration has no segments where "{filter}"')
 def impl(context, filter):
     SLEEP_PERIOD = 5
     MAX_DURATION = 300
@@ -3843,9 +3844,22 @@ def impl(context):
      cmd.run(validateAfter=True)
 
 @then('restore /etc/hosts file and cleanup hostlist file')
+@when('restore /etc/hosts file and cleanup hostlist file')
 def impl(context):
     cmd = "sudo mv -f /tmp/hosts_orig /etc/hosts; rm -f /tmp/clusterConfigFile-1; rm -f /tmp/hostfile--1"
     context.execute_steps(u'''Then the user runs command "%s"''' % cmd)
+
+
+@given('update /etc/hosts file with address for the localhost')
+def impt(context):
+    hostname = context.hostname
+    # Backup current /etc/hosts file
+    cmd = Command(name='backup the hosts file', cmdStr='sudo cp /etc/hosts /tmp/hosts_orig')
+    cmd.run(validateAfter=True)
+    # Update the address
+    cmdStr = "echo \"127.0.0.1 {}\" | sudo tee -a /etc/hosts".format(hostname)
+    cmd = Command(name="update /etc/hosts file with hostname entry", cmdStr=cmdStr)
+    cmd.run(validateAfter=True)
 
 @given('update hostlist file with updated host-address')
 def impl(context):

--- a/gpMgmt/test/behave/mgmt_utils/steps/mirrors_mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mirrors_mgmt_utils.py
@@ -521,6 +521,45 @@ def impl(context, content):
                 fd.write('{} {}\n'.format(valid_config, valid_config))
             break
 
+@given("edit the hostsname input file to recover segment with content {content} full inplace")
+def impl(context,  content):
+    content = int(content)
+    segments = GpArray.initFromCatalog(dbconn.DbURL()).getSegmentList()
+    for seg in segments:
+        if seg.mirrorDB.getSegmentContentId() == content:
+            mirror = seg.mirrorDB
+            valid_config = '{}|{}|{}|{} localhost|{}|{}|{}'.format(mirror.getSegmentHostName(),
+                                                                   mirror.getSegmentAddress(),
+                                                                   mirror.getSegmentPort(),
+                                                                   mirror.getSegmentDataDirectory(),
+                                                                   mirror.getSegmentAddress(),
+                                                                   mirror.getSegmentPort(),
+                                                                   mirror.getSegmentDataDirectory())
+            context.hostname = mirror.getSegmentHostName()
+
+            with open(context.mirror_context.input_file_path(), 'a') as fd:
+                fd.write('{}'.format(valid_config))
+            break
+
+@given("edit the hostsname input file to recover segment with content {content} with invalid hostname")
+def impl(context,  content):
+    content = int(content)
+    segments = GpArray.initFromCatalog(dbconn.DbURL()).getSegmentList()
+    for seg in segments:
+        if seg.mirrorDB.getSegmentContentId() == content:
+            mirror = seg.mirrorDB
+            valid_config = '{}|{}|{}|{} invalid_host|{}|{}|{}'.format(mirror.getSegmentHostName(),
+                                                                   mirror.getSegmentAddress(),
+                                                                   mirror.getSegmentPort(),
+                                                                   mirror.getSegmentDataDirectory(),
+                                                                   mirror.getSegmentAddress(),
+                                                                   mirror.getSegmentPort(),
+                                                                   mirror.getSegmentDataDirectory())
+
+            with open(context.mirror_context.input_file_path(), 'a') as fd:
+                fd.write('{}'.format(valid_config))
+            break
+
 
 @given("edit the input file to recover mirror with content {content} incremental")
 def impl(context, content):


### PR DESCRIPTION
Problem: During gprecoverseg host-name and host-address fields are getting populated with the same value(host-address) in the gp_segment_configuration table after recovery. The reason being the recovery input configuration file can have only three parameters host-address, port, data-directory and host-name field is not there. In previous versions of gpdb hostname was resolved using the provided host-address but the functionality used to resolve the hostname was unstable and faulty. So, It was removed in https://github.com/greenplum-db/gpdb/commit/f61d35cdeacc2f97e234648e06788207fb9e53fc with the reason provided "The hostname resolution from address was incorrect and faulty in its logic - an IP address never requires a hostname associated with it. However, the hostname field in gp_segment_configuration should be populated somehow - we recommend a "hostname" field addition to any configuration files that require it"

Solution: We should provide control to the user to also specify host-name and host-address separately in the gprecoverseg input config file. At present input config file has the option to specify host-address, port, data-directory only and we added code changes to support the 4th parameter host-name as well. The option to provide host-name currently will be available only in case of recovery using config file and hostname value will be switched on the basis of the number of parameters provided in the config file. If the hostname is not mentioned, gprecoverseg behavior remains unchanged and provided address will be populated as host-name in the configuration

Implementation: Added support to have 4th parameter host-name field in the recovery config file. This host-name field will be used just to populate the hostname field in the recovery when converting a request to triplet

The new supported input format of gprecoverseg input recovery config file be as follows: 
- For full recovery: `<failed_host_name>|<failed_host_address>|<port>|<data_directory>SPACE<failover_host_name>|<recovery_host_address>|<port>|<data_directory>`
- For incremental recovery: `<failed_host_name>|<failed_host_address>|<port>|<data_directory>`

Also, existing config file fprmat for gprecoverseg will be supported i.e. 
- Full recovery: `<failed_host_address>|<port>|<data_directory>SPACE [<recovery_host_address>|<port>|<data_directory>`
- Incremental Recovery: `<failed_host_address>|<port>|<data_directory>`

Future Scope :
As the addition of the 4th parameter host-name also impacts gpaddmirrors, gpexpand, gpmovemirror and will be creating stories to track those utilities to support host-name in their input configuration file.

Added unit and behavior tests for the above scenario

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
