### PR TITLE
Update autovacuum GUC default values.

### DIFF
--- a/gpdb-doc/markdown/ref_guide/config_params/guc-list.html.md
+++ b/gpdb-doc/markdown/ref_guide/config_params/guc-list.html.md
@@ -73,7 +73,7 @@ Specifies a fraction of the table size to add to [`autovacuum_vacuum_threshold`]
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-| floating point (%) | 0.2 |local, system, reload|
+| floating point (%) | 0.05 |local, system, reload|
 
 ## <a id="autovacuum_vacuum_threshold"></a>autovacuum_vacuum_threshold
 
@@ -81,7 +81,7 @@ Specifies the minimum number of updated or deleted tuples needed to trigger a `V
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|
-| 0 < integer < INT_MAX | 50 |local, system, reload|
+| 0 < integer < INT_MAX | 500 |local, system, reload|
 
 ## <a id="backslash_quote"></a>backslash\_quote 
 

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -3060,7 +3060,7 @@ static struct config_int ConfigureNamesInt[] =
 			NULL
 		},
 		&autovacuum_vac_thresh,
-		50, 0, INT_MAX,
+		500, 0, INT_MAX,
 		NULL, NULL, NULL
 	},
 	{
@@ -3143,7 +3143,7 @@ static struct config_int ConfigureNamesInt[] =
 			GUC_UNIT_KB
 		},
 		&autovacuum_work_mem,
-		-1, -1, MAX_KILOBYTES,
+		131072, -1, MAX_KILOBYTES,
 		check_autovacuum_work_mem, NULL, NULL
 	},
 
@@ -3516,7 +3516,7 @@ static struct config_real ConfigureNamesReal[] =
 			NULL
 		},
 		&autovacuum_vac_scale,
-		0.2, 0.0, 100.0,
+		0.05, 0.0, 100.0,
 		NULL, NULL, NULL
 	},
 	{


### PR DESCRIPTION
This commit updates autovacuum GUC defaults based on the findings
presented in https://groups.google.com/a/greenplum.org/g/gpdb-dev/c/5yRc-FBB9i8/m/Ju9p4oqXAAAJ

autovacuum_vacuum_threshold: Increase to 500 so not constantly vacuuming small catalog tables.
autovacuum_vacuum_scale_factor: Reduce to 5% to trigger AVs more frequently that each do less work, smoothing out I/O
autovacuum_work_mem: Allows more tuple identifiers to be stored in dead tuple array, may reduce number of index scans during vacuum.