### PR TITLE
Rename gp_configuration_history.desc column

### DIFF
--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_configurationImplGpdb.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_configurationImplGpdb.py
@@ -28,67 +28,67 @@ class ConfigurationImplGpdbTestCase(unittest.TestCase):
     @patch('gppylib.db.dbconn.executeUpdateOrInsert')
     def test_updateSystemConfigRemoveMirror_remove_acting_mirror(self, mockInsert, mockFetch):
         addSQL = self.configProvider.updateSystemConfigRemoveMirror(self.conn, self.gpArray, self.acting_mirror0, "foo")
-        self.assertEqual(addSQL, "SELECT gp_add_segment(6::int2, 0::int2, 'm', 'p', 'n', 'd', 50002, 'sdw2', 'sdw2', '/data/acting_mirror0');\nINSERT INTO gp_configuration_history (time, dbid, \"desc\") VALUES(\n\tnow(),\n\t6,\n\t'gprecoverseg: segment config for backout: inserted segment configuration for full recovery or original dbid 6'\n)")
+        self.assertEqual(addSQL, "SELECT gp_add_segment(6::int2, 0::int2, 'm', 'p', 'n', 'd', 50002, 'sdw2', 'sdw2', '/data/acting_mirror0');\nINSERT INTO gp_configuration_history (time, dbid, description) VALUES(\n\tnow(),\n\t6,\n\t'gprecoverseg: segment config for backout: inserted segment configuration for full recovery or original dbid 6'\n)")
         mockFetch.assert_called_with(self.conn, "SELECT gp_remove_segment_mirror(0::int2)")
-        mockInsert.assert_any_call(self.conn, "INSERT INTO gp_configuration_history (time, dbid, \"desc\") VALUES(\nnow(),\n  6,\n  'foo: removed mirror segment configuration'\n)", 1)
+        mockInsert.assert_any_call(self.conn, "INSERT INTO gp_configuration_history (time, dbid, description) VALUES(\nnow(),\n  6,\n  'foo: removed mirror segment configuration'\n)", 1)
 
     @patch('gppylib.system.configurationImplGpdb.GpConfigurationProviderUsingGpdbCatalog.fetchSingleOutputRow', return_value=[4])
     @patch('gppylib.db.dbconn.executeUpdateOrInsert')
     def test_updateSystemConfigRemoveMirror_remove_actual_mirror(self, mockInsert, mockFetch):
         addSQL = self.configProvider.updateSystemConfigRemoveMirror(self.conn, self.gpArray, self.mirror0, "foo")
-        self.assertEqual(addSQL, "SELECT gp_add_segment(4::int2, 0::int2, 'm', 'm', 'n', 'd', 50000, 'sdw2', 'sdw2', '/data/mirror0');\nINSERT INTO gp_configuration_history (time, dbid, \"desc\") VALUES(\n\tnow(),\n\t4,\n\t'gprecoverseg: segment config for backout: inserted segment configuration for full recovery or original dbid 4'\n)")
+        self.assertEqual(addSQL, "SELECT gp_add_segment(4::int2, 0::int2, 'm', 'm', 'n', 'd', 50000, 'sdw2', 'sdw2', '/data/mirror0');\nINSERT INTO gp_configuration_history (time, dbid, description) VALUES(\n\tnow(),\n\t4,\n\t'gprecoverseg: segment config for backout: inserted segment configuration for full recovery or original dbid 4'\n)")
         mockFetch.assert_called_with(self.conn, "SELECT gp_remove_segment_mirror(0::int2)")
-        mockInsert.assert_any_call(self.conn, "INSERT INTO gp_configuration_history (time, dbid, \"desc\") VALUES(\nnow(),\n  4,\n  'foo: removed mirror segment configuration'\n)", 1)
+        mockInsert.assert_any_call(self.conn, "INSERT INTO gp_configuration_history (time, dbid, description) VALUES(\nnow(),\n  4,\n  'foo: removed mirror segment configuration'\n)", 1)
 
     @patch('gppylib.system.configurationImplGpdb.GpConfigurationProviderUsingGpdbCatalog.fetchSingleOutputRow', return_value=[2])
     @patch('gppylib.db.dbconn.executeUpdateOrInsert')
     def test_updateSystemConfigRemovePrimary(self, mockInsert, mockFetch):
         addSQL = self.configProvider.updateSystemConfigRemovePrimary(self.conn, self.gpArray, self.primary0, "foo")
-        self.assertEqual(addSQL, "SELECT gp_add_segment(2::int2, 0::int2, 'm', 'm', 'n', 'd', 40000, 'sdw1', 'sdw1', '/data/primary0');\nINSERT INTO gp_configuration_history (time, dbid, \"desc\") VALUES(\n\tnow(),\n\t2,\n\t'gprecoverseg: segment config for backout: inserted segment configuration for full recovery or original dbid 2'\n)")
+        self.assertEqual(addSQL, "SELECT gp_add_segment(2::int2, 0::int2, 'm', 'm', 'n', 'd', 40000, 'sdw1', 'sdw1', '/data/primary0');\nINSERT INTO gp_configuration_history (time, dbid, description) VALUES(\n\tnow(),\n\t2,\n\t'gprecoverseg: segment config for backout: inserted segment configuration for full recovery or original dbid 2'\n)")
         mockFetch.assert_called_with(self.conn, "SELECT gp_remove_segment(2::int2)")
-        mockInsert.assert_any_call(self.conn, "INSERT INTO gp_configuration_history (time, dbid, \"desc\") VALUES(\nnow(),\n  2,\n  'foo: removed primary segment configuration'\n)", 1)
+        mockInsert.assert_any_call(self.conn, "INSERT INTO gp_configuration_history (time, dbid, description) VALUES(\nnow(),\n  2,\n  'foo: removed primary segment configuration'\n)", 1)
 
     @patch('gppylib.system.configurationImplGpdb.GpConfigurationProviderUsingGpdbCatalog.fetchSingleOutputRow', return_value=[6])
     @patch('gppylib.db.dbconn.executeUpdateOrInsert')
     def test_updateSystemConfigAddMirror_add_acting_mirror(self, mockInsert, mockFetch):
         removeSQL = self.configProvider.updateSystemConfigAddMirror(self.conn, self.gpArray, self.acting_mirror0, "foo")
-        self.assertEqual(removeSQL, "SELECT gp_remove_segment(6::int2);\nINSERT INTO gp_configuration_history (time, dbid, \"desc\") VALUES(\n\tnow(),\n\t6,\n\t'gprecoverseg: segment config for backout: inserted segment configuration for full recovery or original dbid 6'\n)")
+        self.assertEqual(removeSQL, "SELECT gp_remove_segment(6::int2);\nINSERT INTO gp_configuration_history (time, dbid, description) VALUES(\n\tnow(),\n\t6,\n\t'gprecoverseg: segment config for backout: inserted segment configuration for full recovery or original dbid 6'\n)")
         mockFetch.assert_called_with(self.conn, "SELECT gp_add_segment(6::int2, 0::int2, 'm', 'm', 'n', 'd', 50002, 'sdw2', 'sdw2', '/data/acting_mirror0')")
-        mockInsert.assert_any_call(self.conn, "INSERT INTO gp_configuration_history (time, dbid, \"desc\") VALUES(\nnow(),\n  6,\n  'foo: inserted mirror segment configuration'\n)", 1)
+        mockInsert.assert_any_call(self.conn, "INSERT INTO gp_configuration_history (time, dbid, description) VALUES(\nnow(),\n  6,\n  'foo: inserted mirror segment configuration'\n)", 1)
 
     @patch('gppylib.system.configurationImplGpdb.GpConfigurationProviderUsingGpdbCatalog.fetchSingleOutputRow', return_value=[4])
     @patch('gppylib.db.dbconn.executeUpdateOrInsert')
     def test_updateSystemConfigAddMirror_add_actual_mirror(self, mockInsert, mockFetch):
         removeSQL = self.configProvider.updateSystemConfigAddMirror(self.conn, self.gpArray, self.mirror0, "foo")
-        self.assertEqual(removeSQL, "SELECT gp_remove_segment(4::int2);\nINSERT INTO gp_configuration_history (time, dbid, \"desc\") VALUES(\n\tnow(),\n\t4,\n\t'gprecoverseg: segment config for backout: inserted segment configuration for full recovery or original dbid 4'\n)")
+        self.assertEqual(removeSQL, "SELECT gp_remove_segment(4::int2);\nINSERT INTO gp_configuration_history (time, dbid, description) VALUES(\n\tnow(),\n\t4,\n\t'gprecoverseg: segment config for backout: inserted segment configuration for full recovery or original dbid 4'\n)")
         mockFetch.assert_called_with(self.conn, "SELECT gp_add_segment(4::int2, 0::int2, 'm', 'm', 'n', 'd', 50000, 'sdw2', 'sdw2', '/data/mirror0')")
-        mockInsert.assert_any_call(self.conn, "INSERT INTO gp_configuration_history (time, dbid, \"desc\") VALUES(\nnow(),\n  4,\n  'foo: inserted mirror segment configuration'\n)", 1)
+        mockInsert.assert_any_call(self.conn, "INSERT INTO gp_configuration_history (time, dbid, description) VALUES(\nnow(),\n  4,\n  'foo: inserted mirror segment configuration'\n)", 1)
 
     @patch('gppylib.system.configurationImplGpdb.GpConfigurationProviderUsingGpdbCatalog.fetchSingleOutputRow', side_effect=[ [2], [0] ])
     @patch('gppylib.db.dbconn.executeUpdateOrInsert')
     def test_updateSystemConfigAddPrimary(self, mockInsert, mockFetch):
         removeSQL = self.configProvider.updateSystemConfigAddPrimary(self.conn, self.gpArray, self.primary0, "foo", {0: self.mirror0})
-        self.assertEqual(removeSQL, "SELECT gp_remove_segment_mirror(0::int2);\nINSERT INTO gp_configuration_history (time, dbid, \"desc\") VALUES(\n\tnow(),\n\t2,\n\t'gprecoverseg: segment config for backout: inserted segment configuration for full recovery or original dbid 2'\n)")
+        self.assertEqual(removeSQL, "SELECT gp_remove_segment_mirror(0::int2);\nINSERT INTO gp_configuration_history (time, dbid, description) VALUES(\n\tnow(),\n\t2,\n\t'gprecoverseg: segment config for backout: inserted segment configuration for full recovery or original dbid 2'\n)")
         mockFetch.assert_any_call(self.conn, "SELECT content FROM pg_catalog.gp_segment_configuration WHERE dbId = 2")
         mockFetch.assert_any_call(self.conn, "SELECT gp_add_segment(2::int2, 0::int2, 'p', 'p', 'n', 'u', 40000, 'sdw1', 'sdw1', '/data/primary0')")
-        mockInsert.assert_any_call(self.conn, "INSERT INTO gp_configuration_history (time, dbid, \"desc\") VALUES(\nnow(),\n  2,\n  'foo: inserted primary segment configuration with contentid 0'\n)", 1)
+        mockInsert.assert_any_call(self.conn, "INSERT INTO gp_configuration_history (time, dbid, description) VALUES(\nnow(),\n  2,\n  'foo: inserted primary segment configuration with contentid 0'\n)", 1)
 
     @patch('gppylib.system.configurationImplGpdb.GpConfigurationProviderUsingGpdbCatalog.fetchSingleOutputRow', return_value=[6])
     @patch('gppylib.db.dbconn.executeUpdateOrInsert')
     def test_updateSystemConfigRemoveAddMirror_remove_acting_mirror(self, mockInsert, mockFetch):
         addSQL, removeSQL = self.configProvider.updateSystemConfigRemoveAddMirror(self.conn, self.gpArray, self.acting_mirror0, "foo")
-        self.assertEqual(addSQL, "SELECT gp_add_segment(6::int2, 0::int2, 'm', 'p', 'n', 'd', 50002, 'sdw2', 'sdw2', '/data/acting_mirror0');\nINSERT INTO gp_configuration_history (time, dbid, \"desc\") VALUES(\n\tnow(),\n\t6,\n\t'gprecoverseg: segment config for backout: inserted segment configuration for full recovery or original dbid 6'\n)")
+        self.assertEqual(addSQL, "SELECT gp_add_segment(6::int2, 0::int2, 'm', 'p', 'n', 'd', 50002, 'sdw2', 'sdw2', '/data/acting_mirror0');\nINSERT INTO gp_configuration_history (time, dbid, description) VALUES(\n\tnow(),\n\t6,\n\t'gprecoverseg: segment config for backout: inserted segment configuration for full recovery or original dbid 6'\n)")
         self.assertEqual(removeSQL, "SELECT gp_remove_segment(6::int2)")
         mockFetch.assert_any_call(self.conn, "SELECT gp_remove_segment_mirror(0::int2)")
         mockFetch.assert_any_call(self.conn, "SELECT gp_add_segment(6::int2, 0::int2, 'm', 'm', 'n', 'd', 50002, 'sdw2', 'sdw2', '/data/acting_mirror0')")
-        mockInsert.assert_any_call(self.conn, "INSERT INTO gp_configuration_history (time, dbid, \"desc\") VALUES(\nnow(),\n  6,\n  'foo: inserted segment configuration for full recovery or original dbid 6'\n)", 1)
+        mockInsert.assert_any_call(self.conn, "INSERT INTO gp_configuration_history (time, dbid, description) VALUES(\nnow(),\n  6,\n  'foo: inserted segment configuration for full recovery or original dbid 6'\n)", 1)
 
     @patch('gppylib.system.configurationImplGpdb.GpConfigurationProviderUsingGpdbCatalog.fetchSingleOutputRow', return_value=[4])
     @patch('gppylib.db.dbconn.executeUpdateOrInsert')
     def test_updateSystemConfigRemoveAddMirror_remove_actual_mirror(self, mockInsert, mockFetch):
         addSQL, removeSQL = self.configProvider.updateSystemConfigRemoveAddMirror(self.conn, self.gpArray, self.mirror0, "foo")
-        self.assertEqual(addSQL, "SELECT gp_add_segment(4::int2, 0::int2, 'm', 'm', 'n', 'd', 50000, 'sdw2', 'sdw2', '/data/mirror0');\nINSERT INTO gp_configuration_history (time, dbid, \"desc\") VALUES(\n\tnow(),\n\t4,\n\t'gprecoverseg: segment config for backout: inserted segment configuration for full recovery or original dbid 4'\n)")
+        self.assertEqual(addSQL, "SELECT gp_add_segment(4::int2, 0::int2, 'm', 'm', 'n', 'd', 50000, 'sdw2', 'sdw2', '/data/mirror0');\nINSERT INTO gp_configuration_history (time, dbid, description) VALUES(\n\tnow(),\n\t4,\n\t'gprecoverseg: segment config for backout: inserted segment configuration for full recovery or original dbid 4'\n)")
         self.assertEqual(removeSQL, "SELECT gp_remove_segment(4::int2)")
         mockFetch.assert_any_call(self.conn, "SELECT gp_remove_segment_mirror(0::int2)")
         mockFetch.assert_any_call(self.conn, "SELECT gp_add_segment(4::int2, 0::int2, 'm', 'm', 'n', 'd', 50000, 'sdw2', 'sdw2', '/data/mirror0')")
-        mockInsert.assert_any_call(self.conn, "INSERT INTO gp_configuration_history (time, dbid, \"desc\") VALUES(\nnow(),\n  4,\n  'foo: inserted segment configuration for full recovery or original dbid 4'\n)", 1)
+        mockInsert.assert_any_call(self.conn, "INSERT INTO gp_configuration_history (time, dbid, description) VALUES(\nnow(),\n  4,\n  'foo: inserted segment configuration for full recovery or original dbid 4'\n)", 1)

--- a/gpMgmt/bin/gppylib/system/configurationImplGpdb.py
+++ b/gpMgmt/bin/gppylib/system/configurationImplGpdb.py
@@ -260,7 +260,7 @@ class GpConfigurationProviderUsingGpdbCatalog(GpConfigurationProvider) :
         return seg
 
     def __getConfigurationHistorySQL(self, dbid):
-        sql = ";\nINSERT INTO gp_configuration_history (time, dbid, \"desc\") VALUES(\n\tnow(),\n\t%s,\n\t%s\n)" \
+        sql = ";\nINSERT INTO gp_configuration_history (time, dbid, \"description\") VALUES(\n\tnow(),\n\t%s,\n\t%s\n)" \
             % (
                 self.__toSqlIntValue(dbid),
                 "'gprecoverseg: segment config for backout: inserted segment configuration for full recovery or original dbid %d'" % dbid,
@@ -433,7 +433,7 @@ class GpConfigurationProviderUsingGpdbCatalog(GpConfigurationProvider) :
 
     def __insertConfigHistory(self, conn, dbId, msg ):
         # now update change history
-        sql = "INSERT INTO gp_configuration_history (time, dbid, \"desc\") VALUES(\n" \
+        sql = "INSERT INTO gp_configuration_history (time, dbid, \"description\") VALUES(\n" \
                     "now(),\n  " + \
                     self.__toSqlIntValue(dbId) + ",\n  " + \
                     self.__toSqlCharValue(msg) + "\n)"

--- a/gpMgmt/test/behave/mgmt_utils/steps/recoverseg_mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/recoverseg_mgmt_utils.py
@@ -43,11 +43,11 @@ def impl(context, contents):
                                                "preferred_role = '%s'" % (content, preferred_role))
         with closing(dbconn.connect(dbconn.DbURL(), unsetSearchPath=False)) as conn:
             num_tuples = dbconn.querySingleton(conn, "SELECT count(*) FROM gp_configuration_history WHERE dbid = %d AND "
-                                                     "gp_configuration_history.desc LIKE 'gprecoverseg: segment config for backout%%';" % dbid)
+                                                     "description LIKE 'gprecoverseg: segment config for backout%%';" % dbid)
         context.original_config_history_info[key] = num_tuples
         with closing(dbconn.connect(dbconn.DbURL(), unsetSearchPath=False)) as conn:
             context.original_config_history_backout_count = dbconn.querySingleton(conn, "SELECT count(*) FROM gp_configuration_history WHERE "
-                                                     "gp_configuration_history.desc LIKE 'gprecoverseg: segment config for backout%%';")
+                                                     "description LIKE 'gprecoverseg: segment config for backout%%';")
 
 
 
@@ -606,7 +606,7 @@ def impl(context, seg, contents):
         with closing(dbconn.connect(dbconn.DbURL(), unsetSearchPath=False)) as conn:
             dbid = dbconn.querySingleton(conn, "SELECT dbid FROM gp_segment_configuration WHERE content = %s AND preferred_role = '%s'" % (content, role))
         with closing(dbconn.connect(dbconn.DbURL(), unsetSearchPath=False)) as conn:
-            actual_tuples = dbconn.querySingleton(conn, "SELECT count(*) FROM gp_configuration_history WHERE dbid = %d AND gp_configuration_history.desc LIKE 'gprecoverseg: segment config for backout%%';" % dbid)
+            actual_tuples = dbconn.querySingleton(conn, "SELECT count(*) FROM gp_configuration_history WHERE dbid = %d AND description LIKE 'gprecoverseg: segment config for backout%%';" % dbid)
 
         original_tuples = context.original_config_history_info["{}_{}".format(content, role)]
         if actual_tuples != original_tuples + 1: # Running the backout script should have inserted exactly 1 entry
@@ -618,7 +618,7 @@ def impl(context, seg, contents):
 def impl(context, expected_additional_entries):
     with closing(dbconn.connect(dbconn.DbURL(), unsetSearchPath=False)) as conn:
         actual_backout_entries = int(dbconn.querySingleton(conn, "SELECT count(*) FROM gp_configuration_history WHERE "
-                                                             "gp_configuration_history.desc LIKE "
+                                                             "description LIKE "
                                                              "'gprecoverseg: segment config for backout%%';"))
     expected_total_entries = int(context.original_config_history_backout_count) + int(expected_additional_entries)
     if actual_backout_entries != expected_total_entries:

--- a/gpdb-doc/markdown/ref_guide/system_catalogs/gp_configuration_history.html.md
+++ b/gpdb-doc/markdown/ref_guide/system_catalogs/gp_configuration_history.html.md
@@ -10,7 +10,7 @@ This table is populated only on the coordinator. This table is defined in the `p
 |------|----|----------|-----------|
 |`time`|timestamp with time zone| |Timestamp for the event recorded.|
 |`dbid`|smallint|gp\_segment\_configuration.dbid|System-assigned ID. The unique identifier of a segment \(or coordinator\) instance.|
-|`desc`|text| |Text description of the event.|
+|`description`|text| |Text description of the event.|
 
 For information about `gprecoverseg` and `gpinitsystem`, see the Greenplum Database Utility Guide.
 

--- a/src/backend/fts/fts.c
+++ b/src/backend/fts/fts.c
@@ -199,7 +199,7 @@ probeWalRepUpdateConfig(int16 dbid, int16 segindex, char role,
 				 IsInSync ? GP_SEGMENT_CONFIGURATION_MODE_INSYNC :
 				 GP_SEGMENT_CONFIGURATION_MODE_NOTINSYNC
 			);
-		histvals[Anum_gp_configuration_history_desc-1] =
+		histvals[Anum_gp_configuration_history_description-1] =
 				CStringGetTextDatum(desc);
 		histtuple = heap_form_tuple(RelationGetDescr(histrel), histvals, histnulls);
 		CatalogTupleInsert(histrel, histtuple);

--- a/src/include/catalog/catversion.h
+++ b/src/include/catalog/catversion.h
@@ -56,6 +56,7 @@
  */
 
 /*							3yyymmddN */
+
 #define CATALOG_VERSION_NO	302305251
 
 #endif

--- a/src/include/catalog/gp_configuration_history.h
+++ b/src/include/catalog/gp_configuration_history.h
@@ -50,7 +50,7 @@ CATALOG(gp_configuration_history,5106,GpConfigHistoryRelationId) BKI_SHARED_RELA
 {
 	timestamptz	time;	
 	int16		dbid;	
-	text		desc;	
+	text		description;
 } FormData_gp_configuration_history;
 
 /* no foreign keys */

--- a/src/test/regress/expected/misc_sanity.out
+++ b/src/test/regress/expected/misc_sanity.out
@@ -101,7 +101,7 @@ WHERE c.oid < 16384 AND
 ORDER BY 1, 2;
          relname          |      attname       |   atttypid   
 --------------------------+--------------------+--------------
- gp_configuration_history | desc               | text
+ gp_configuration_history | description        | text
  gp_version_at_initdb     | productversion     | text
  pg_attribute             | attacl             | aclitem[]
  pg_attribute             | attfdwoptions      | text[]


### PR DESCRIPTION
`desc` is a keyword, so rename the column to `description`

Resolves the following issue:
```
gpadmin=# select desc from pg_catalog.gp_configuration_history; psql: ERROR:  syntax error at or near "desc"
LINE 1: select desc from pg_catalog.gp_configuration_history;
```
Bumps catalog version

Resolves https://github.com/greenplum-db/gpdb/issues/12077