### PR TITLE
[7X] Suppress compiler warning.

### DIFF
--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -370,7 +370,11 @@ standard_planner(Query *parse, int cursorOptions, ParamListInfo boundParams)
 		if (gp_log_optimization_time)
 			INSTR_TIME_SET_CURRENT(starttime);
 
+#ifdef USE_ORCA
 		result = optimize_query(parse, cursorOptions, boundParams);
+#else
+		result = NULL;
+#endif
 
 		/* decide jit state */
 		if (result)

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -373,6 +373,9 @@ standard_planner(Query *parse, int cursorOptions, ParamListInfo boundParams)
 #ifdef USE_ORCA
 		result = optimize_query(parse, cursorOptions, boundParams);
 #else
+		/* Make sure this branch is not taken in builds using --disable-orca. */
+		Assert(false);
+		/* Keep compilers quiet in case the build used --disable-orca. */
 		result = NULL;
 #endif
 

--- a/src/include/optimizer/orca.h
+++ b/src/include/optimizer/orca.h
@@ -24,16 +24,6 @@
 extern PlannedStmt * optimize_query(Query *parse, int cursorOptions, ParamListInfo boundParams);
 extern Node *transformGroupedWindows(Node *node, void *context);
 
-#else
-
-/* Keep compilers quiet in case the build used --disable-orca */
-static PlannedStmt *
-optimize_query(Query *parse, int cursorOptions, ParamListInfo boundParams)
-{
-	Assert(false);
-	return NULL;
-}
-
 #endif
 
 #endif /* ORCA_H */


### PR DESCRIPTION
optimize_query is qualified by static and defined in orca.h. If build gpdb w/o ORCA and include orca.h without using optimize_query, there will be warnings.

```
In file included from explain.c:56:
../../../src/include/optimizer/orca.h:31:1: warning: 'optimize_query' defined but not used [-Wunused-function]
   31 | optimize_query(Query *parse, int cursorOptions, ParamListInfo boundParams)
      | ^~~~~~~~~~~~~~
```

