### PR TITLE
force the auto vacuum worker controlled by the system_group

### DIFF
--- a/src/backend/commands/vacuum.c
+++ b/src/backend/commands/vacuum.c
@@ -74,6 +74,7 @@
 #include "libpq/pqformat.h"
 #include "utils/faultinjector.h"
 #include "utils/lsyscache.h"
+#include "utils/resgroup.h"
 
 /*
  * GUC parameters
@@ -286,6 +287,12 @@ vacuum(List *relations, VacuumParams *params,
 	 * that VACOPT_VACUUM and VACOPT_ROOTONLY set at same time.
 	 */
 	Assert(!((params->options & VACOPT_VACUUM) && (params->options & VACOPT_ROOTONLY)));
+
+	/*
+	 * We force vacuum auxiliary process in system_group, so in vacuum transaction we should
+	 * not assign it to any resource group.
+	 */
+	AssertImply(IsAutoVacuumWorkerProcess(), GetMyResGroupId() == InvalidOid);
 
 	stmttype = (params->options & VACOPT_VACUUM) ? "VACUUM" : "ANALYZE";
 

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -38,6 +38,7 @@
 #include "miscadmin.h"
 #include "pgstat.h"
 #include "port/atomics.h"
+#include "postmaster/autovacuum.h"
 #include "storage/ipc.h"
 #include "storage/latch.h"
 #include "storage/lmgr.h"
@@ -1480,12 +1481,14 @@ ShouldAssignResGroupOnCoordinator(void)
 	 * waiting queue (and its corruption).
 	 *
 	 * Also bypass resource group when it's exiting.
+	 * Also bypass resource group when it's vacuum worker process.
 	 */
 	return IsResGroupActivated() &&
 		IsNormalProcessingMode() &&
 		Gp_role == GP_ROLE_DISPATCH &&
 		!proc_exit_inprogress &&
-		!procIsWaiting(MyProc);
+		!procIsWaiting(MyProc) &&
+		!IsAutoVacuumWorkerProcess();
 }
 
 /*


### PR DESCRIPTION
For the previous investigation, I neglected the fact that the AutoVacuum worker will be 
executed by PostermasterMain, it will invoke InitResmanager to init the resource group if
it is enabled. And it'll use StartTransactionCommand to create a transaction to finish its 
job, which could put the AutoVacuum worker process to the admin_group, not system_group,
so this PR is trying to fix it.