### PR TITLE
Remove FIXME from function cdbpathlocus_for_insert()

### DIFF
--- a/src/backend/cdb/cdbpathlocus.c
+++ b/src/backend/cdb/cdbpathlocus.c
@@ -239,8 +239,7 @@ cdbpathlocus_for_insert(PlannerInfo *root, GpPolicy *policy,
 			contain_volatile_functions((Node *) expr))
 		{
 			/*
-			 * GPDB_96_MERGE_FIXME: this modifies the subpath's targetlist in place.
-			 * That's a bit ugly.
+			 * sortgrouprefs should never be zero if the expression is volatile!
 			 */
 			pathtarget->sortgrouprefs[attno - 1] = ++maxRef;
 		}


### PR DESCRIPTION
The codes around FIXME tends to figure out bugs as merging from upstream.
```
if (pathtarget->sortgrouprefs[attno - 1] == 0 &&
	contain_volatile_functions((Node *) expr))
{
	/*
	 * GPDB_96_MERGE_FIXME: this modifies the subpath's targetlist in place.
	 * That's a bit ugly.
	 */
	pathtarget->sortgrouprefs[attno - 1] = ++maxRef;
}
```
If we don't have these codes, ERROR **"volatile EquivalenceClass has no sortref"** is raised.
That's caused by an assumption which has been added in upstream to slove issues.
related PR https://github.com/greenplum-db/gpdb/commit/d5a4b69c3a0d2668fa6098c73be7b6f0036bb642.

As a result, we could just modify pathtarget->sortgrouprefs[attno - 1] in place, which is safe and no more
regressions.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
