### PR TITLE
Remove FIXME: cast the unknown typed literal to text (7X)

### DIFF
--- a/src/test/regress/expected/qp_misc_jiras.out
+++ b/src/test/regress/expected/qp_misc_jiras.out
@@ -2681,15 +2681,13 @@ select * from qp_misc_jiras.tbl_694_1 join qp_misc_jiras.tbl_694_2 on qp_misc_ji
 
 drop table qp_misc_jiras.tbl_694_1;
 drop table qp_misc_jiras.tbl_694_2;
--- GPDB_10_MERGE_FIXME: Here we cast the unknown typed literal to text. After
--- we move past postgres 10 we can drop the cast.
-select * from ( select 'a'::text as a) x join (select 'a'::text as b) y on a=b;
+select * from ( select 'a' as a) x join (select 'a' as b) y on a=b;
  a | b 
 ---+---
  a | a
 (1 row)
 
-select * from ( ( select 'a'::text as a ) xx join (select 'a'::text as b) yy on a = b ) x join (select 'a'::text as c) y on a=c;
+select * from ( ( select 'a' as a ) xx join (select 'a' as b) yy on a = b ) x join (select 'a' as c) y on a=c;
  a | b | c 
 ---+---+---
  a | a | a

--- a/src/test/regress/expected/qp_misc_jiras.out
+++ b/src/test/regress/expected/qp_misc_jiras.out
@@ -2693,7 +2693,7 @@ select * from ( ( select 'a' as a ) xx join (select 'a' as b) yy on a = b ) x jo
  a | a | a
 (1 row)
 
-select x.b from ( ( select 'a'::text as a ) xx join (select 'a'::text as b) yy on a = b ) x join (select 'a'::text as c) y on a=c;
+select x.b from ( ( select 'a' as a ) xx join (select 'a' as b) yy on a = b ) x join (select 'a' as c) y on a=c;
  b 
 ---
  a

--- a/src/test/regress/expected/qp_misc_jiras_optimizer.out
+++ b/src/test/regress/expected/qp_misc_jiras_optimizer.out
@@ -2678,21 +2678,19 @@ select * from qp_misc_jiras.tbl_694_1 join qp_misc_jiras.tbl_694_2 on qp_misc_ji
 
 drop table qp_misc_jiras.tbl_694_1;
 drop table qp_misc_jiras.tbl_694_2;
--- GPDB_10_MERGE_FIXME: Here we cast the unknown typed literal to text. After
--- we move past postgres 10 we can drop the cast.
-select * from ( select 'a'::text as a) x join (select 'a'::text as b) y on a=b;
+select * from ( select 'a' as a) x join (select 'a' as b) y on a=b;
  a | b 
 ---+---
  a | a
 (1 row)
 
-select * from ( ( select 'a'::text as a ) xx join (select 'a'::text as b) yy on a = b ) x join (select 'a'::text as c) y on a=c;
+select * from ( ( select 'a' as a ) xx join (select 'a' as b) yy on a = b ) x join (select 'a' as c) y on a=c;
  a | b | c 
 ---+---+---
  a | a | a
 (1 row)
 
-select x.b from ( ( select 'a'::text as a ) xx join (select 'a'::text as b) yy on a = b ) x join (select 'a'::text as c) y on a=c;
+select x.b from ( ( select 'a' as a ) xx join (select 'a' as b) yy on a = b ) x join (select 'a' as c) y on a=c;
  b 
 ---
  a

--- a/src/test/regress/expected/qp_misc_rio.out
+++ b/src/test/regress/expected/qp_misc_rio.out
@@ -56,13 +56,11 @@ select sum((select count(*) from t11_t group by b having b = s.b)) as sum_col fr
 -- Test: 15
 -- ----------------------------------------------------------------------
 -- aggregate over partition by
--- GPDB_10_MERGE_FIXME: Here we cast the unknown typed literal to text. After
--- we move past postgres 10 we can drop the cast.
 select state,
        sum(revenue) over (partition by state)
 from
-   (select 'A'::text as enc_email, 1 as revenue) b
-   join (select 'A'::text as enc_email, 'B'::text as state ) c using(enc_email)
+   (select 'A' as enc_email, 1 as revenue) b
+   join (select 'A' as enc_email, 'B' as state ) c using(enc_email)
 group by 1,b.revenue;
  state | sum 
 -------+-----

--- a/src/test/regress/sql/qp_misc_jiras.sql
+++ b/src/test/regress/sql/qp_misc_jiras.sql
@@ -783,11 +783,9 @@ select * from qp_misc_jiras.tbl_694_1 join qp_misc_jiras.tbl_694_2 on qp_misc_ji
 drop table qp_misc_jiras.tbl_694_1;
 drop table qp_misc_jiras.tbl_694_2;
 
--- GPDB_10_MERGE_FIXME: Here we cast the unknown typed literal to text. After
--- we move past postgres 10 we can drop the cast.
-select * from ( select 'a'::text as a) x join (select 'a'::text as b) y on a=b;
-select * from ( ( select 'a'::text as a ) xx join (select 'a'::text as b) yy on a = b ) x join (select 'a'::text as c) y on a=c;
-select x.b from ( ( select 'a'::text as a ) xx join (select 'a'::text as b) yy on a = b ) x join (select 'a'::text as c) y on a=c;
+select * from ( select 'a' as a) x join (select 'a' as b) y on a=b;
+select * from ( ( select 'a' as a ) xx join (select 'a' as b) yy on a = b ) x join (select 'a' as c) y on a=c;
+select x.b from ( ( select 'a' as a ) xx join (select 'a' as b) yy on a = b ) x join (select 'a' as c) y on a=c;
 create table qp_misc_jiras.tbl6027_test (i int, j bigint, k int, l int, m int);
 insert into qp_misc_jiras.tbl6027_test select i, i%100, i%123, i%234, i%345 from generate_series(1, 500) i;
 select j, sum(k), row_number() over (partition by j order by sum(k)) from qp_misc_jiras.tbl6027_test group by j order by j limit 10; -- order 1

--- a/src/test/regress/sql/qp_misc_rio.sql
+++ b/src/test/regress/sql/qp_misc_rio.sql
@@ -40,13 +40,11 @@ select sum((select count(*) from t11_t group by b having b = s.b)) as sum_col fr
 -- Test: 15
 -- ----------------------------------------------------------------------
 -- aggregate over partition by
--- GPDB_10_MERGE_FIXME: Here we cast the unknown typed literal to text. After
--- we move past postgres 10 we can drop the cast.
 select state,
        sum(revenue) over (partition by state)
 from
-   (select 'A'::text as enc_email, 1 as revenue) b
-   join (select 'A'::text as enc_email, 'B'::text as state ) c using(enc_email)
+   (select 'A' as enc_email, 1 as revenue) b
+   join (select 'A' as enc_email, 'B' as state ) c using(enc_email)
 group by 1,b.revenue;
 
 -- ----------------------------------------------------------------------


### PR DESCRIPTION
Long log:
Don't need to cast the unknown typed literal to text, drop the cast and remove FIXME.
Related PR https://github.com/greenplum-db/gpdb/commit/1e7c4bb0049732ece651d993d03bb6772e5d281a

Signed-off-by: Yongtao Huang <yongtaoh@vmware.com>
