### PR TITLE
aofetch: Clarify early exit for inter-entry hole

### DIFF
--- a/src/test/isolation2/expected/ao_blkdir.out
+++ b/src/test/isolation2/expected/ao_blkdir.out
@@ -464,6 +464,135 @@ SELECT segno, sum(tupcount) AS totalrows FROM gp_toolkit.__gp_aoseg('ao_blkdir_t
 DROP TABLE ao_blkdir_test_rowcount;
 DROP
 
+--
+-- Test tuple fetch with holes from ABORTs
+--
+CREATE TABLE ao_fetch_hole(i int, j int) USING ao_row;
+CREATE
+CREATE INDEX ON ao_fetch_hole(i);
+CREATE
+INSERT INTO ao_fetch_hole VALUES (2, 0);
+INSERT 1
+-- Create a hole after the last entry (of the last minipage) in the blkdir.
+BEGIN;
+BEGIN
+INSERT INTO ao_fetch_hole SELECT 3, j FROM generate_series(1, 20) j;
+INSERT 20
+ABORT;
+ABORT
+SELECT (gp_toolkit.__gp_aoblkdir('ao_fetch_hole')).* FROM gp_dist_random('gp_id') WHERE gp_segment_id = 0 ORDER BY 1,2,3,4,5;
+ tupleid | segno | columngroup_no | entry_no | first_row_no | file_offset | row_count 
+---------+-------+----------------+----------+--------------+-------------+-----------
+ (0,1)   | 1     | 0              | 0        | 1            | 0           | 1         
+(1 row)
+
+-- Ensure we will do an index scan.
+SET enable_seqscan TO off;
+SET
+SET enable_indexonlyscan TO off;
+SET
+SET optimizer TO off;
+SET
+EXPLAIN SELECT count(*) FROM ao_fetch_hole WHERE i = 3;
+ QUERY PLAN                                                                                          
+-----------------------------------------------------------------------------------------------------
+ Finalize Aggregate  (cost=39.80..39.81 rows=1 width=8)                                              
+   ->  Gather Motion 1:1  (slice1; segments: 1)  (cost=39.74..39.79 rows=3 width=8)                  
+         ->  Partial Aggregate  (cost=39.74..39.75 rows=1 width=8)                                   
+               ->  Bitmap Heap Scan on ao_fetch_hole  (cost=4.82..39.67 rows=29 width=0)             
+                     Recheck Cond: (i = 3)                                                           
+                     ->  Bitmap Index Scan on ao_fetch_hole_i_idx  (cost=0.00..4.81 rows=29 width=0) 
+                           Index Cond: (i = 3)                                                       
+ Optimizer: Postgres query optimizer                                                                 
+(8 rows)
+
+SELECT gp_inject_fault_infinite('AppendOnlyBlockDirectory_GetEntry_sysscan', 'skip', dbid) FROM gp_segment_configuration WHERE content = 0 AND role = 'p';
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+SELECT count(*) FROM ao_fetch_hole WHERE i = 3;
+ count 
+-------
+ 0     
+(1 row)
+-- Since the hole is at the end of the minipage, we can't avoid a sysscan for
+-- each tuple.
+SELECT gp_inject_fault('AppendOnlyBlockDirectory_GetEntry_sysscan', 'status', dbid) FROM gp_segment_configuration WHERE content = 0 AND role = 'p';
+ gp_inject_fault                                                                                                                                                                                                                                  
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Success: fault name:'AppendOnlyBlockDirectory_GetEntry_sysscan' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'triggered'  num times hit:'20' 
+ 
+(1 row)
+
+SELECT gp_inject_fault('AppendOnlyBlockDirectory_GetEntry_sysscan', 'reset', dbid) FROM gp_segment_configuration WHERE content = 0 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+-- Now do 1 more insert, so that the hole is sandwiched between two successive
+-- minipage entries.
+INSERT INTO ao_fetch_hole VALUES (4, 21);
+INSERT 1
+SELECT (gp_toolkit.__gp_aoblkdir('ao_fetch_hole')).* FROM gp_dist_random('gp_id') WHERE gp_segment_id = 0 ORDER BY 1,2,3,4,5;
+ tupleid | segno | columngroup_no | entry_no | first_row_no | file_offset | row_count 
+---------+-------+----------------+----------+--------------+-------------+-----------
+ (0,3)   | 1     | 0              | 0        | 1            | 0           | 1         
+ (0,3)   | 1     | 0              | 1        | 201          | 40          | 1         
+(2 rows)
+
+SELECT gp_inject_fault_infinite('AppendOnlyBlockDirectory_GetEntry_sysscan', 'skip', dbid) FROM gp_segment_configuration WHERE content = 0 AND role = 'p';
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+SELECT gp_inject_fault_infinite('AppendOnlyBlockDirectory_GetEntry_inter_entry_hole', 'skip', dbid) FROM gp_segment_configuration WHERE content = 0 AND role = 'p';
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+SELECT count(*) FROM ao_fetch_hole WHERE i = 3;
+ count 
+-------
+ 0     
+(1 row)
+-- Since the hole is between two entries, we are always able to find the last
+-- entry in the minipage, determine that the target row doesn't lie within it
+-- and early return, thereby avoiding an expensive per-tuple sysscan. We only
+-- do 1 sysscan - for the first tuple fetch in the hole and avoid it for all
+-- subsequent fetches in the hole.
+SELECT gp_inject_fault('AppendOnlyBlockDirectory_GetEntry_sysscan', 'status', dbid) FROM gp_segment_configuration WHERE content = 0 AND role = 'p';
+ gp_inject_fault                                                                                                                                                                                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Success: fault name:'AppendOnlyBlockDirectory_GetEntry_sysscan' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'triggered'  num times hit:'1' 
+ 
+(1 row)
+SELECT gp_inject_fault('AppendOnlyBlockDirectory_GetEntry_inter_entry_hole', 'status', dbid) FROM gp_segment_configuration WHERE content = 0 AND role = 'p';
+ gp_inject_fault                                                                                                                                                                                                                                           
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Success: fault name:'AppendOnlyBlockDirectory_GetEntry_inter_entry_hole' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'triggered'  num times hit:'19' 
+ 
+(1 row)
+
+SELECT gp_inject_fault('AppendOnlyBlockDirectory_GetEntry_sysscan', 'reset', dbid) FROM gp_segment_configuration WHERE content = 0 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+SELECT gp_inject_fault('AppendOnlyBlockDirectory_GetEntry_inter_entry_hole', 'reset', dbid) FROM gp_segment_configuration WHERE content = 0 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+RESET enable_seqscan;
+RESET
+RESET enable_indexonlyscan;
+RESET
+RESET optimizer;
+RESET
+
 --------------------------------------------------------------------------------
 -- AOCO tables
 --------------------------------------------------------------------------------
@@ -1135,3 +1264,132 @@ SELECT segno, column_num, sum(tupcount) AS totalrows FROM gp_toolkit.__gp_aocsse
 
 DROP TABLE aoco_blkdir_test_rowcount;
 DROP
+
+--
+-- Test tuple fetch with holes from ABORTs
+--
+CREATE TABLE aoco_fetch_hole(i int, j int) USING ao_row;
+CREATE
+CREATE INDEX ON aoco_fetch_hole(i);
+CREATE
+INSERT INTO aoco_fetch_hole VALUES (2, 0);
+INSERT 1
+-- Create a hole after the last entry (of the last minipage) in the blkdir.
+BEGIN;
+BEGIN
+INSERT INTO aoco_fetch_hole SELECT 3, j FROM generate_series(1, 20) j;
+INSERT 20
+ABORT;
+ABORT
+SELECT (gp_toolkit.__gp_aoblkdir('aoco_fetch_hole')).* FROM gp_dist_random('gp_id') WHERE gp_segment_id = 0 ORDER BY 1,2,3,4,5;
+ tupleid | segno | columngroup_no | entry_no | first_row_no | file_offset | row_count 
+---------+-------+----------------+----------+--------------+-------------+-----------
+ (0,1)   | 1     | 0              | 0        | 1            | 0           | 1         
+(1 row)
+
+-- Ensure we will do an index scan.
+SET enable_seqscan TO off;
+SET
+SET enable_indexonlyscan TO off;
+SET
+SET optimizer TO off;
+SET
+EXPLAIN SELECT count(*) FROM aoco_fetch_hole WHERE i = 3;
+ QUERY PLAN                                                                                            
+-------------------------------------------------------------------------------------------------------
+ Finalize Aggregate  (cost=39.80..39.81 rows=1 width=8)                                                
+   ->  Gather Motion 1:1  (slice1; segments: 1)  (cost=39.74..39.79 rows=3 width=8)                    
+         ->  Partial Aggregate  (cost=39.74..39.75 rows=1 width=8)                                     
+               ->  Bitmap Heap Scan on aoco_fetch_hole  (cost=4.82..39.67 rows=29 width=0)             
+                     Recheck Cond: (i = 3)                                                             
+                     ->  Bitmap Index Scan on aoco_fetch_hole_i_idx  (cost=0.00..4.81 rows=29 width=0) 
+                           Index Cond: (i = 3)                                                         
+ Optimizer: Postgres query optimizer                                                                   
+(8 rows)
+
+SELECT gp_inject_fault_infinite('AppendOnlyBlockDirectory_GetEntry_sysscan', 'skip', dbid) FROM gp_segment_configuration WHERE content = 0 AND role = 'p';
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+SELECT count(*) FROM aoco_fetch_hole WHERE i = 3;
+ count 
+-------
+ 0     
+(1 row)
+-- Since the hole is at the end of the minipage, we can't avoid a sysscan for
+-- each tuple.
+SELECT gp_inject_fault('AppendOnlyBlockDirectory_GetEntry_sysscan', 'status', dbid) FROM gp_segment_configuration WHERE content = 0 AND role = 'p';
+ gp_inject_fault                                                                                                                                                                                                                                  
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Success: fault name:'AppendOnlyBlockDirectory_GetEntry_sysscan' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'triggered'  num times hit:'20' 
+ 
+(1 row)
+
+SELECT gp_inject_fault('AppendOnlyBlockDirectory_GetEntry_sysscan', 'reset', dbid) FROM gp_segment_configuration WHERE content = 0 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+-- Now do 1 more insert, so that the hole is sandwiched between two successive
+-- minipage entries.
+INSERT INTO aoco_fetch_hole VALUES (4, 21);
+INSERT 1
+SELECT (gp_toolkit.__gp_aoblkdir('aoco_fetch_hole')).* FROM gp_dist_random('gp_id') WHERE gp_segment_id = 0 ORDER BY 1,2,3,4,5;
+ tupleid | segno | columngroup_no | entry_no | first_row_no | file_offset | row_count 
+---------+-------+----------------+----------+--------------+-------------+-----------
+ (0,3)   | 1     | 0              | 0        | 1            | 0           | 1         
+ (0,3)   | 1     | 0              | 1        | 201          | 40          | 1         
+(2 rows)
+
+SELECT gp_inject_fault_infinite('AppendOnlyBlockDirectory_GetEntry_sysscan', 'skip', dbid) FROM gp_segment_configuration WHERE content = 0 AND role = 'p';
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+SELECT gp_inject_fault_infinite('AppendOnlyBlockDirectory_GetEntry_inter_entry_hole', 'skip', dbid) FROM gp_segment_configuration WHERE content = 0 AND role = 'p';
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+(1 row)
+SELECT count(*) FROM aoco_fetch_hole WHERE i = 3;
+ count 
+-------
+ 0     
+(1 row)
+-- Since the hole is between two entries, we are always able to find the last
+-- entry in the minipage, determine that the target row doesn't lie within it
+-- and early return, thereby avoiding an expensive per-tuple sysscan. We only
+-- do 1 sysscan - for the first tuple fetch in the hole and avoid it for all
+-- subsequent fetches in the hole.
+SELECT gp_inject_fault('AppendOnlyBlockDirectory_GetEntry_sysscan', 'status', dbid) FROM gp_segment_configuration WHERE content = 0 AND role = 'p';
+ gp_inject_fault                                                                                                                                                                                                                                 
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Success: fault name:'AppendOnlyBlockDirectory_GetEntry_sysscan' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'triggered'  num times hit:'1' 
+ 
+(1 row)
+SELECT gp_inject_fault('AppendOnlyBlockDirectory_GetEntry_inter_entry_hole', 'status', dbid) FROM gp_segment_configuration WHERE content = 0 AND role = 'p';
+ gp_inject_fault                                                                                                                                                                                                                                           
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Success: fault name:'AppendOnlyBlockDirectory_GetEntry_inter_entry_hole' fault type:'skip' ddl statement:'' database name:'' table name:'' start occurrence:'1' end occurrence:'-1' extra arg:'0' fault injection state:'triggered'  num times hit:'19' 
+ 
+(1 row)
+
+SELECT gp_inject_fault('AppendOnlyBlockDirectory_GetEntry_sysscan', 'reset', dbid) FROM gp_segment_configuration WHERE content = 0 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+SELECT gp_inject_fault('AppendOnlyBlockDirectory_GetEntry_inter_entry_hole', 'reset', dbid) FROM gp_segment_configuration WHERE content = 0 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+RESET enable_seqscan;
+RESET
+RESET enable_indexonlyscan;
+RESET
+RESET optimizer;
+RESET

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -87,7 +87,6 @@ test: distributedlog-bug
 test: invalidated_toast_index
 test: distributed_snapshot
 test: gp_collation
-test: ao_blkdir
 test: bitmap_index_concurrent
 test: bitmap_index_crash
 test: bitmap_update_words_backup_block
@@ -228,6 +227,7 @@ test: uao/cluster_progress_column
 # check storage-dependent collected statistics views
 test: uao/collected_stats_views_column
 test: uao/fast_analyze_column
+test: ao_blkdir
 
 # this case contains fault injection, must be put in a separate test group
 test: terminate_in_gang_creation


### PR DESCRIPTION
This commit clarifies the hidden intent behind one of
AppendOnlyBlockDirectory_GetEntry()'s branches to exit early, when the
rowNum being looked up doesn't have a minipage entry it belongs to and
yet is lower than the highest minipage entry in the page.

This optimization is pretty crucial as it saves us from per-tuple
sysscans further down in AppendOnlyBlockDirectory_GetEntry() for any
rowNum falling in a hole between two blkdir entries. Such holes can
arise from aborted inserts.

Consider the following example (all data in seg1):

```
create table foo(i int, j int) with(appendonly=true);
create index on foo(i);
insert into foo select 1;
begin; insert into foo select 20, i from generate_series(1, 10000000)i; abort;
```

We have a hole at the end of the minipage.
```
select (gp_toolkit.__gp_aoblkdir('foo')).* from gp_dist_random('gp_id')
    where gp_segment_id = 1;
 tupleid | segno | columngroup_no | entry_no | first_row_no | file_offset | row_count
---------+-------+----------------+----------+--------------+-------------+-----------
 (0,2)   |     1 |              0 |        0 |            1 |           0 |         1
----------------------------------------hole------------------------------------------
```

Now forcing fetches in this hole would result in:

```
set enable_seqscan to off;
set enable_indexonlyscan to off;

select * from foo where i = 20;
Time: 37941.981 ms (00:37.942)

select idx_scan, idx_tup_fetch from gp_stat_sys_tables where relname
    like '%blkdir%' and gp_segment_id = 1;
 idx_scan | idx_tup_fetch
----------+---------------
 10000002 |      10000001
(1 row)
```

We end up doing per-tuple sysscans of the blkdir. This is because our
entry is larger than the last entry's range.

However, if we were to insert just one more row in the segment,
a new blkdir entry will be written, sandwiching the hole between
entries.

```
select (gp_toolkit.__gp_aoblkdir('foo')).* from gp_dist_random('gp_id')
    where gp_segment_id = 1;
 tupleid | segno | columngroup_no | entry_no | first_row_no | file_offset | row_count
---------+-------+----------------+----------+--------------+-------------+-----------
 (0,2)   |     1 |              0 |        0 |            1 |           0 |         1
----------------------------------------hole------------------------------------------
 (0,2)   |     1 |              0 |        1 |     10000201 |          40 |         1
(2 rows)
```

Now our early exit optimization will kick in. Only 2 index scans will
now be performed.

```
insert into foo select 30;
select * from foo where i = 20;
Time: 1333.052 ms (00:01.333)

select idx_scan, idx_tup_fetch from gp_stat_sys_tables where relname
    like '%blkdir%' and gp_segment_id = 1;
idx_scan | idx_tup_fetch
----------+---------------
 10000004 |      10000003
(1 row)

```
We add coverage for this important optimization with a white-box test.

Also, since ANALYZE can now take advantage of blkdir fetches, we move
this test inside the section where autovacuum(analyze) is disabled.
