### PR TITLE
Fix 'pg_toast_oid'  No exchange when executing 'ALTER TABLE SET DISTRIBUTED BY '

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -18513,7 +18513,7 @@ ATExecSetDistributedBy(Relation rel, Node *node, AlterTableCmd *cmd)
 		tmprelid = RangeVarGetRelid(tmprv, NoLock, false);
 		swap_relation_files(tarrelid, tmprelid,
 							false, /* target_is_pg_class */
-							false, /* swap_toast_by_content */
+							true, /* swap_toast_by_content */
 							false, /* swap_stats */
 							true,
 							RecentXmin,


### PR DESCRIPTION
* Hi, This tiny merge request is used to fix this issue : https://github.com/greenplum-db/gpdb/issues/15534
* Set the parameter `swap_toast_by_content` in the `ATExecSetDistributedBy -> swap_relation_files` method to true, this change will ensure that the `new relation id ` and the `target relation id` remain the same during the rewrite process.

This is the result that meets expectations:
<img width="725" alt="image" src="https://github.com/greenplum-db/gpdb/assets/24492354/5d2e777b-76aa-4217-9cbd-7d59961ac229">
