### PR TITLE
gp_replica_check: Run for all reltypes

### DIFF
--- a/gpcontrib/gp_replica_check/Makefile
+++ b/gpcontrib/gp_replica_check/Makefile
@@ -14,8 +14,5 @@ include $(top_builddir)/src/Makefile.global
 include $(top_srcdir)/contrib/contrib-global.mk
 endif
 
-# GPDB_FEATURE_NOT_SUPPORTED: Enable btree, gin and gist as physical
-# and logical order is equivalent now. Also, enable spgist,
-# bitmap. Basically, "all" option should be functional for this tool.
 installcheck: install
-	gp_replica_check.py -r="heap, ao_row, ao_column, brin"
+	gp_replica_check.py -d=all -r=all


### PR DESCRIPTION
This has 2 commits:
1. Fixes gp_replica_check to run against all reltypes
2. Enables gp_replica_check -r=all on CI.

Dev-pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/replica_check