### PR TITLE
Remove duplicated if(boundspec->partEvery) (7X)

### DIFF
--- a/src/backend/parser/parse_partition_gp.c
+++ b/src/backend/parser/parse_partition_gp.c
@@ -1438,8 +1438,6 @@ transformGpPartDefElemWithRangeSpec(ParseState *pstate, Relation parentrel, GpPa
 						parser_errposition(pstate, boundspec->location)));
 		every = linitial(boundspec->partEvery);
 	}
-	else if (boundspec->partEvery)
-		new_boundspec->partEvery = NIL;
 
 	part_col_typid = get_partition_col_typid(partkey, 0);
 	part_col_typmod = get_partition_col_typmod(partkey, 0);


### PR DESCRIPTION
Long log:

In src/backend/parser/parse_partition_gp.c,
function transformGpPartDefElemWithRangeSpec()
has duplicated if condtions, `if (boundspec->partEvery)`
and `else if (boundspec->partEvery)`.
So delete redundant `else if (boundspec->partEvery)`. 
Related issue: [15041](https://github.com/greenplum-db/gpdb/issues/15041)

Signed-off-by:Yongtao Huang <yongtaoh@vmware.com>