### PR TITLE
Add exclude of directory "db_analyze" to generate template to gpexpand

### DIFF
--- a/gpMgmt/bin/gppylib/commands/pg.py
+++ b/gpMgmt/bin/gppylib/commands/pg.py
@@ -346,6 +346,8 @@ class PgBaseBackup(Command):
                 cmd_tokens.append('./gpperfmon/logs')
                 cmd_tokens.append('-E')
                 cmd_tokens.append('./promote')
+                cmd_tokens.append('-E')
+                cmd_tokens.append('./db_analyze')
             else:
                 for path in excludePaths:
                     cmd_tokens.append('-E')

--- a/gpMgmt/test/behave/mgmt_utils/gpexpand.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpexpand.feature
@@ -610,3 +610,26 @@ Feature: expand the cluster by adding more segments
         When the user runs "gpcheckcat gptest"
         Then gpcheckcat should return a return code of 0
         And the user runs psql with "-c 'DROP ROLE abc'" against database "gptest"
+
+    @gpexpand_mirrors
+    @gpexpand_segment
+    @gpexpand_verify_catalogs
+    Scenario: expand a cluster that has mirrors and check that gpexpand does not copy extra data directories from master
+        Given the database is not running
+        # need to remove this log because otherwise SCAN_LOG may pick up a previous error/warning in the log
+        And the user runs command "rm -rf ~/gpAdminLogs/gpinitsystem*"
+        And a working directory of the test as '/data/gpdata/gpexpand'
+        And a temporary directory under "/data/gpdata/gpexpand/expandedData" to expand into
+        And a cluster is created with mirrors on "cdw" and "sdw1"
+        And database "gptest" exists
+        And the user runs command "analyzedb -d gptest -a"
+        And there are no gpexpand_inputfiles
+        And the cluster is setup for an expansion on hosts "cdw,sdw1"
+        And the number of segments have been saved
+        When the user runs gpexpand with a static inputfile for a single-node cluster with mirrors
+        Then verify that the cluster has 4 new segments
+        And verify that the path "db_dumps" in each segment data directory does not exist
+        And verify that the path "gpperfmon/data" in each segment data directory does not exist
+        And verify that the path "gpperfmon/logs" in each segment data directory does not exist
+        And verify that the path "promote" in each segment data directory does not exist
+        And verify that the path "db_analyze" in each segment data directory does not exist

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -2080,6 +2080,33 @@ def impl(context, filename, contain, output):
         if (not valuesShouldExist) and (output in actual):
             raise Exception('File %s on host %s contains "%s"' % (filepath, host, output))
 
+@given('verify that the path "{filename}" in each segment data directory does not exist')
+@then('verify that the path "{filename}" in each segment data directory does not exist')
+def impl(context, filename):
+    try:
+        with dbconn.connect(dbconn.DbURL(dbname='template1'), unsetSearchPath=False) as conn:
+            curs = dbconn.execSQL(conn, "SELECT hostname, datadir FROM gp_segment_configuration WHERE content > -1;")
+            result = curs.fetchall()
+            segment_info = [(result[s][0], result[s][1]) for s in range(len(result))]
+    except Exception as e:
+        raise Exception("Could not retrieve segment information: %s" % e.message)
+
+    for info in segment_info:
+        host, datadir = info
+        filepath = os.path.join(datadir, filename)
+        cmd_str = 'test -d "%s" && echo 1 || echo 0' % (filepath)
+        cmd = Command(name='check exists directory or not',
+                      cmdStr=cmd_str,
+                      ctxt=REMOTE,
+                      remoteHost=host)
+        cmd.run(validateAfter=False)
+        try:
+            val = int(cmd.get_stdout().strip())
+            if val:
+                raise Exception('Path %s on host %s exists (val %s) (cmd "%s")' % (filepath, host, val, cmd_str))
+        except:
+            raise Exception('Path %s on host %s exists (cmd "%s")' % (filepath, host, cmd_str))
+
 
 @given('the gpfdists occupying port {port} on host "{hostfile}"')
 def impl(context, port, hostfile):


### PR DESCRIPTION
If run `analyze_db` for any database, than for this database folder "db_analyze" is created. It may contain large volume of data. This catalog is useless for segments. If after it create new segment using `gpexpand`, than folder "db_analyze" will be copied to new segment. This folder is useless for new segment. Because of this exclude "db_analyze" is added to `PgBaseBackup`.

Steps to reproduce the problem:
1) Create demo cluster.
2) Run `analyzedb -d postgres -a`.
3) Create config file "expand.conf" for `gpexpand`:
```
sdw1|sdw1|36101|<PATH_TO_GPDB_SRC>/gpAux/gpdemo/datadirs/dbfast4|9|3|p
sdw1|sdw1|36102|<PATH_TO_GPDB_SRC>/gpAux/gpdemo/datadirs/dbfast_mirror4|10|3|m
```
4) Run `gpexpand -i expand.conf`.
5) Done.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
