### PR TITLE
[WIP] Fix flaky case about gp_check_files (7X)

### DIFF
--- a/src/test/regress/expected/plpgsql.out
+++ b/src/test/regress/expected/plpgsql.out
@@ -5346,3 +5346,4 @@ end;
 $$;
 ERROR:  value for domain plpgsql_arr_domain violates check constraint "plpgsql_arr_domain_check"
 CONTEXT:  PL/pgSQL function inline_code_block line 4 at assignment
+DROP TABLE rc_test;

--- a/src/test/regress/expected/plpgsql_optimizer.out
+++ b/src/test/regress/expected/plpgsql_optimizer.out
@@ -5336,3 +5336,4 @@ end;
 $$;
 ERROR:  value for domain plpgsql_arr_domain violates check constraint "plpgsql_arr_domain_check"
 CONTEXT:  PL/pgSQL function inline_code_block line 4 at assignment
+DROP TABLE rc_test;

--- a/src/test/regress/sql/plpgsql.sql
+++ b/src/test/regress/sql/plpgsql.sql
@@ -4157,3 +4157,4 @@ begin
   v_test := 0 || v_test;  -- fail
 end;
 $$;
+DROP TABLE rc_test;


### PR DESCRIPTION
Long log:

CI pipeline faces this flaky case serveral times.
```
--- /tmp/build/c7e122a2/gpdb_src/src/test/regress/expected/gp_check_files.out	2023-05-20 16:26:53.439106986 +0000
+++ /tmp/build/c7e122a2/gpdb_src/src/test/regress/results/gp_check_files.out	2023-05-20 16:26:53.443107353 +0000
@@ -55,7 +55,8 @@
  gp_segment_id | regexp_replace |      relname      
 ---------------+----------------+-------------------
              1 | x              | checkmissing_heap
-(1 row)
+             1 | x              | rc_test
+(2 rows)
 
 SET client_min_messages = ERROR;
 -- check extended files
@@ -70,9 +71,10 @@
  gp_segment_id | regexp_replace |      relname      
 ---------------+----------------+-------------------
              1 | x              | checkmissing_heap
+             1 | x              | rc_test
              1 | x.1            | checkmissing_ao
              1 | x.1            | checkmissing_co
-(3 rows)
+(4 rows)
```
gp_check_missing_files and gp_check_missing_files_ext are the user-facing view to check missing data files.
We do `plpgsql` test in parallel_schedule without `drop table rc_test;` primarily,
then we test `gp_check_files` in greenplum_schedule at the end of ICW.
Sometimes missing data files of `rc_test` table still remain, make this case flaky.

Signed-off-by: Yongtao Huang <yongtaoh@vmware.com>