### PR TITLE
Avoid table rewrite in ALTER COLUMN SET ENCODING

### DIFF
--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -3535,6 +3535,7 @@ _outNewColumnValue(StringInfo str, const NewColumnValue *node)
 	WRITE_NODE_FIELD(expr);
 	/* can't serialize exprstate */
 	WRITE_BOOL_FIELD(is_generated);
+	WRITE_NODE_FIELD(new_encoding);
 	WRITE_ENUM_FIELD(op, AOCSWriteColumnOperation);
 }
 

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -1013,6 +1013,7 @@ _readNewColumnValue(void)
 	READ_NODE_FIELD(expr);
 	/* can't serialize exprstate */
 	READ_BOOL_FIELD(is_generated);
+	READ_NODE_FIELD(new_encoding);
 	READ_ENUM_FIELD(op, AOCSWriteColumnOperation);
 
 	READ_DONE();

--- a/src/include/access/reloptions.h
+++ b/src/include/access/reloptions.h
@@ -331,12 +331,13 @@ extern bool reloptions_has_opt(List *opts, const char *name);
 extern List *build_ao_rel_storage_opts(List *opts, Relation rel);
 
 /* attribute enconding specific functions */
+ColumnReferenceStorageDirective *find_crsd(const char *column, List *stenc);
 extern List *transformColumnEncoding(Relation rel, List *colDefs,
 										List *stenc, List *withOptions, List *parentenc,
 										bool explicitOnly, bool allowEncodingClause);
 extern List *transformStorageEncodingClause(List *options, bool validate);
-extern bool updateEncodingList(List *current_encodings,
-								  ColumnReferenceStorageDirective *new_crsd);
+extern List *updateEncodingList(List *current_encodings,
+								  ColumnReferenceStorageDirective *new_crsd, bool *is_updated);
 extern List *form_default_storage_directive(List *enc);
 extern bool is_storage_encoding_directive(char *name);
 extern void free_options_deep(relopt_value *options, int num_options);

--- a/src/include/catalog/pg_attribute_encoding.h
+++ b/src/include/catalog/pg_attribute_encoding.h
@@ -67,11 +67,12 @@ extern List **RelationGetUntransformedAttributeOptions(Relation rel);
 
 extern Datum transform_lastrownums(int64 *lastrownums);
 extern void add_attribute_encoding_entry(Oid relid, AttrNumber attnum, FileNumber filenum, Datum lastrownums, Datum attoptions);
+extern void update_attribute_encoding_entry(Oid relid, AttrNumber attnum, FileNumber newfilenum, Datum newlastrownums, Datum newattoptions);
 extern void AddCOAttributeEncodings(Oid relid, List *attr_encodings);
 extern void RemoveAttributeEncodingsByRelid(Oid relid);
 extern void CloneAttributeEncodings(Oid oldrelid, Oid newrelid, AttrNumber max_attno);
 extern void UpdateAttributeEncodings(Oid relid, List *new_attr_encodings);
-extern void UpdateFilenumForAttnum(Oid relid, AttrNumber attnum, FileNumber newfilenum);
+extern void UpdateOrAddAttributeEncodings(Relation rel, List *new_attr_encodings);
 extern void ClearAttributeEncodingLastrownums(Oid relid);
 extern FileNumber GetFilenumForAttribute(Oid relid, AttrNumber attnum);
 extern FileNumber GetFilenumForRewriteAttribute(Oid relid, AttrNumber attnum);

--- a/src/include/nodes/altertablenodes.h
+++ b/src/include/nodes/altertablenodes.h
@@ -49,8 +49,9 @@
 #define AT_PASS_COL_ATTRS		5	/* set other column attributes */
 #define AT_PASS_ADD_INDEX		6	/* ADD indexes */
 #define AT_PASS_ADD_CONSTR		7	/* ADD constraints, defaults */
-#define AT_PASS_MISC			8	/* other stuff */
-#define AT_NUM_PASSES			9
+#define AT_PASS_SET_ENCODING		8	/* ALTER COLUMN SET ENCODING. Note: if you are going to reorder the macros, this has to be after ALTER COLUMN TYPE. */
+#define AT_PASS_MISC			9	/* other stuff */
+#define AT_NUM_PASSES			10
 
 typedef struct AlteredTableInfo
 {
@@ -118,6 +119,7 @@ typedef struct NewColumnValue
 	Expr	   *expr;			/* expression to compute */
 	ExprState  *exprstate;		/* execution state */
 	bool		is_generated;	/* is it a GENERATED expression? */
+	List 		*new_encoding; 	/* new column encoding options */
 	AOCSWriteColumnOperation op;/* operation being performed */
 } NewColumnValue;
 

--- a/src/test/isolation2/expected/aoco_column_rewrite.out
+++ b/src/test/isolation2/expected/aoco_column_rewrite.out
@@ -142,33 +142,33 @@ SELECT count(*) FROM alter_type_aoco_delete;
  6666  
 (1 row)
 
-ALTER TABLE alter_type_aoco_delete ALTER COLUMN b TYPE text;
+-- test both ALTER COLUMN TYPE and ALTER COLUMN SET ENCODING together
+ALTER TABLE alter_type_aoco_delete ALTER COLUMN b TYPE text, ALTER COLUMN c SET ENCODING (compresstype=rle_type, compresslevel=4);
 ALTER
 
 EXECUTE attribute_encoding_check ('alter_type_aoco_delete');
- relname                | attname | filenum | attoptions                                                  
-------------------------+---------+---------+-------------------------------------------------------------
- alter_type_aoco_delete | a       | 1       | ['compresstype=none', 'blocksize=32768', 'compresslevel=0'] 
- alter_type_aoco_delete | c       | 3       | ['compresstype=none', 'blocksize=32768', 'compresslevel=0'] 
- alter_type_aoco_delete | b       | 1602    | ['compresstype=none', 'blocksize=32768', 'compresslevel=0'] 
+ relname                | attname | filenum | attoptions                                                      
+------------------------+---------+---------+-----------------------------------------------------------------
+ alter_type_aoco_delete | a       | 1       | ['compresstype=none', 'blocksize=32768', 'compresslevel=0']     
+ alter_type_aoco_delete | c       | 1603    | ['compresstype=rle_type', 'blocksize=32768', 'compresslevel=4'] 
+ alter_type_aoco_delete | b       | 1602    | ['compresstype=none', 'blocksize=32768', 'compresslevel=0']     
 (3 rows)
 SELECT * FROM gp_toolkit.__gp_aocsseg('alter_type_aoco_delete') ORDER BY segment_id, column_num;
  segment_id | segno | column_num | physical_segno | tupcount | eof   | eof_uncompressed | modcount | formatversion | state 
 ------------+-------+------------+----------------+----------+-------+------------------+----------+---------------+-------
  1          | 1     | 0          | 1              | 10000    | 40088 | 40088            | 3        | 3             | 1     
  1          | 1     | 1          | 204929         | 10000    | 48984 | 48984            | 3        | 3             | 1     
- 1          | 1     | 2          | 257            | 10000    | 40088 | 40088            | 3        | 3             | 1     
+ 1          | 1     | 2          | 205057         | 10000    | 88    | 40047            | 3        | 3             | 1     
 (3 rows)
 SELECT gp_segment_id, (gp_toolkit.__gp_aoblkdir('alter_type_aoco_delete')).* FROM gp_dist_random('gp_id');
  gp_segment_id | tupleid | segno | columngroup_no | entry_no | first_row_no | file_offset | row_count 
 ---------------+---------+-------+----------------+----------+--------------+-------------+-----------
  1             | (0,1)   | 1     | 0              | 0        | 1            | 0           | 8181      
  1             | (0,1)   | 1     | 0              | 1        | 8182         | 32768       | 1819      
- 1             | (0,3)   | 1     | 2              | 0        | 1            | 0           | 8181      
- 1             | (0,3)   | 1     | 2              | 1        | 8182         | 32768       | 1819      
  1             | (0,4)   | 1     | 1              | 0        | 1            | 0           | 6766      
  1             | (0,4)   | 1     | 1              | 1        | 6767         | 32768       | 3234      
-(6 rows)
+ 1             | (0,5)   | 1     | 2              | 0        | 1            | 0           | 10000     
+(5 rows)
 EXECUTE checkrelfilenodediff ('alter_column', 'alter_type_aoco_delete');
  segid | casename     | relname                | rewritten 
 -------+--------------+------------------------+-----------
@@ -242,22 +242,23 @@ SELECT * FROM alter_type_aoco_delete1;
  1 | 3 | 3 
 (1 row)
 
-ALTER TABLE alter_type_aoco_delete1 ALTER COLUMN b TYPE text;
+-- test both ALTER COLUMN TYPE and ALTER COLUMN SET ENCODING together
+ALTER TABLE alter_type_aoco_delete1 ALTER COLUMN b TYPE text, ALTER COLUMN c SET ENCODING (compresstype=rle_type, compresslevel=4);
 ALTER
 
 EXECUTE attribute_encoding_check ('alter_type_aoco_delete1');
- relname                 | attname | filenum | attoptions                                                  
--------------------------+---------+---------+-------------------------------------------------------------
- alter_type_aoco_delete1 | a       | 1       | ['compresstype=none', 'blocksize=32768', 'compresslevel=0'] 
- alter_type_aoco_delete1 | c       | 3       | ['compresstype=none', 'blocksize=32768', 'compresslevel=0'] 
- alter_type_aoco_delete1 | b       | 1602    | ['compresstype=none', 'blocksize=32768', 'compresslevel=0'] 
+ relname                 | attname | filenum | attoptions                                                      
+-------------------------+---------+---------+-----------------------------------------------------------------
+ alter_type_aoco_delete1 | a       | 1       | ['compresstype=none', 'blocksize=32768', 'compresslevel=0']     
+ alter_type_aoco_delete1 | c       | 1603    | ['compresstype=rle_type', 'blocksize=32768', 'compresslevel=4'] 
+ alter_type_aoco_delete1 | b       | 1602    | ['compresstype=none', 'blocksize=32768', 'compresslevel=0']     
 (3 rows)
 SELECT * FROM gp_toolkit.__gp_aocsseg('alter_type_aoco_delete1') ORDER BY segment_id, column_num;
  segment_id | segno | column_num | physical_segno | tupcount | eof | eof_uncompressed | modcount | formatversion | state 
 ------------+-------+------------+----------------+----------+-----+------------------+----------+---------------+-------
  1          | 1     | 0          | 1              | 2        | 96  | 96               | 4        | 3             | 1     
  1          | 1     | 1          | 204929         | 2        | 96  | 96               | 4        | 3             | 1     
- 1          | 1     | 2          | 257            | 2        | 96  | 96               | 4        | 3             | 1     
+ 1          | 1     | 2          | 205057         | 2        | 96  | 96               | 4        | 3             | 1     
 (3 rows)
 SELECT (gp_toolkit.__gp_aovisimap('alter_type_aoco_delete1')).* FROM gp_dist_random('gp_id');
  tid          | segno | row_num 
@@ -269,10 +270,10 @@ SELECT gp_segment_id, (gp_toolkit.__gp_aoblkdir('alter_type_aoco_delete1')).* FR
 ---------------+---------+-------+----------------+----------+--------------+-------------+-----------
  1             | (0,4)   | 1     | 0              | 0        | 1            | 0           | 1         
  1             | (0,4)   | 1     | 0              | 1        | 101          | 48          | 1         
- 1             | (0,6)   | 1     | 2              | 0        | 1            | 0           | 1         
- 1             | (0,6)   | 1     | 2              | 1        | 101          | 48          | 1         
  1             | (0,7)   | 1     | 1              | 0        | 1            | 0           | 1         
  1             | (0,7)   | 1     | 1              | 1        | 101          | 48          | 1         
+ 1             | (0,8)   | 1     | 2              | 0        | 1            | 0           | 1         
+ 1             | (0,8)   | 1     | 2              | 1        | 101          | 48          | 1         
 (6 rows)
 EXECUTE checkrelfilenodediff ('alter_column', 'alter_type_aoco_delete1');
  segid | casename     | relname                 | rewritten 
@@ -347,22 +348,23 @@ SELECT * FROM alter_type_aoco_delete2;
  1 | 2 | 2 
 (1 row)
 
-ALTER TABLE alter_type_aoco_delete2 ALTER COLUMN b TYPE text;
+-- test both ALTER COLUMN TYPE and ALTER COLUMN SET ENCODING together
+ALTER TABLE alter_type_aoco_delete2 ALTER COLUMN b TYPE text, ALTER COLUMN c SET ENCODING (compresstype=rle_type, compresslevel=4);
 ALTER
 
 EXECUTE attribute_encoding_check ('alter_type_aoco_delete2');
- relname                 | attname | filenum | attoptions                                                  
--------------------------+---------+---------+-------------------------------------------------------------
- alter_type_aoco_delete2 | a       | 1       | ['compresstype=none', 'blocksize=32768', 'compresslevel=0'] 
- alter_type_aoco_delete2 | c       | 3       | ['compresstype=none', 'blocksize=32768', 'compresslevel=0'] 
- alter_type_aoco_delete2 | b       | 1602    | ['compresstype=none', 'blocksize=32768', 'compresslevel=0'] 
+ relname                 | attname | filenum | attoptions                                                      
+-------------------------+---------+---------+-----------------------------------------------------------------
+ alter_type_aoco_delete2 | a       | 1       | ['compresstype=none', 'blocksize=32768', 'compresslevel=0']     
+ alter_type_aoco_delete2 | c       | 1603    | ['compresstype=rle_type', 'blocksize=32768', 'compresslevel=4'] 
+ alter_type_aoco_delete2 | b       | 1602    | ['compresstype=none', 'blocksize=32768', 'compresslevel=0']     
 (3 rows)
 SELECT * FROM gp_toolkit.__gp_aocsseg('alter_type_aoco_delete2') ORDER BY segment_id, column_num;
  segment_id | segno | column_num | physical_segno | tupcount | eof | eof_uncompressed | modcount | formatversion | state 
 ------------+-------+------------+----------------+----------+-----+------------------+----------+---------------+-------
  1          | 1     | 0          | 1              | 2        | 96  | 96               | 4        | 3             | 1     
  1          | 1     | 1          | 204929         | 2        | 96  | 96               | 4        | 3             | 1     
- 1          | 1     | 2          | 257            | 2        | 96  | 96               | 4        | 3             | 1     
+ 1          | 1     | 2          | 205057         | 2        | 96  | 96               | 4        | 3             | 1     
 (3 rows)
 SELECT (gp_toolkit.__gp_aovisimap('alter_type_aoco_delete2')).* FROM gp_dist_random('gp_id');
  tid            | segno | row_num 
@@ -374,10 +376,10 @@ SELECT gp_segment_id, (gp_toolkit.__gp_aoblkdir('alter_type_aoco_delete2')).* FR
 ---------------+---------+-------+----------------+----------+--------------+-------------+-----------
  1             | (0,4)   | 1     | 0              | 0        | 1            | 0           | 1         
  1             | (0,4)   | 1     | 0              | 1        | 101          | 48          | 1         
- 1             | (0,6)   | 1     | 2              | 0        | 1            | 0           | 1         
- 1             | (0,6)   | 1     | 2              | 1        | 101          | 48          | 1         
  1             | (0,7)   | 1     | 1              | 0        | 1            | 0           | 1         
  1             | (0,7)   | 1     | 1              | 1        | 101          | 48          | 1         
+ 1             | (0,8)   | 1     | 2              | 0        | 1            | 0           | 1         
+ 1             | (0,8)   | 1     | 2              | 1        | 101          | 48          | 1         
 (6 rows)
 EXECUTE checkrelfilenodediff ('alter_column', 'alter_type_aoco_delete2');
  segid | casename     | relname                 | rewritten 
@@ -432,14 +434,14 @@ SELECT * FROM alter_type_aoco_fullrewrite;
  20 | 1 | 2 
 (1 row)
 
-ALTER TABLE alter_type_aoco_fullrewrite ALTER COLUMN b TYPE text, ALTER COLUMN C SET ENCODING (compresslevel=4);
+ALTER TABLE alter_type_aoco_fullrewrite ALTER COLUMN b TYPE text, SET UNLOGGED;
 ALTER
 
 EXECUTE attribute_encoding_check ('alter_type_aoco_fullrewrite');
  relname                     | attname | filenum | attoptions                                                  
 -----------------------------+---------+---------+-------------------------------------------------------------
  alter_type_aoco_fullrewrite | a       | 1       | ['compresstype=none', 'blocksize=32768', 'compresslevel=0'] 
- alter_type_aoco_fullrewrite | c       | 3       | ['compresstype=none', 'blocksize=32768', 'compresslevel=4'] 
+ alter_type_aoco_fullrewrite | c       | 3       | ['compresstype=none', 'blocksize=32768', 'compresslevel=0'] 
  alter_type_aoco_fullrewrite | b       | 2       | ['compresstype=none', 'blocksize=32768', 'compresslevel=0'] 
 (3 rows)
 SELECT * FROM gp_toolkit.__gp_aocsseg('alter_type_aoco_fullrewrite') ORDER BY segment_id, column_num;
@@ -1308,3 +1310,400 @@ SELECT count(*) FROM aoco_concurrent_inserts;
 -------
  30    
 (1 row)
+
+--------------------------------------------------------------------------------
+-- Tests for ALTER COLUMN SET ENCODING
+--------------------------------------------------------------------------------
+
+--
+-- Basic testing
+--
+create table atsetenc(c1 int, c2 int) using ao_column distributed replicated;
+CREATE
+-- first check an empty table
+-- check the initial encoding settings
+execute attribute_encoding_check('atsetenc');
+ relname  | attname | filenum | attoptions                                                  
+----------+---------+---------+-------------------------------------------------------------
+ atsetenc | c1      | 1       | ['compresstype=none', 'blocksize=32768', 'compresslevel=0'] 
+ atsetenc | c2      | 2       | ['compresstype=none', 'blocksize=32768', 'compresslevel=0'] 
+(2 rows)
+-- no table rewrite
+execute capturerelfilenodebefore('set encoding - empty', 'atsetenc');
+EXECUTE 4
+alter table atsetenc alter column c1 set encoding (compresstype=zlib,compresslevel=9);
+ALTER
+execute checkrelfilenodediff('set encoding - empty', 'atsetenc');
+ segid | casename             | relname  | rewritten 
+-------+----------------------+----------+-----------
+ 0     | set encoding - empty | atsetenc | f         
+ 1     | set encoding - empty | atsetenc | f         
+ 2     | set encoding - empty | atsetenc | f         
+ -1    | set encoding - empty | atsetenc | f         
+(4 rows)
+execute attribute_encoding_check('atsetenc');
+ relname  | attname | filenum | attoptions                                                  
+----------+---------+---------+-------------------------------------------------------------
+ atsetenc | c1      | 1601    | ['compresstype=zlib', 'blocksize=32768', 'compresslevel=9'] 
+ atsetenc | c2      | 2       | ['compresstype=none', 'blocksize=32768', 'compresslevel=0'] 
+(2 rows)
+select * from atsetenc;
+ c1 | c2 
+----+----
+(0 rows)
+
+-- now insert some data and check
+insert into atsetenc values(1,2);
+INSERT 1
+-- no table rewrite setting encoding
+execute capturerelfilenodebefore('set encoding - basic', 'atsetenc');
+EXECUTE 4
+alter table atsetenc alter column c2 set encoding (compresstype=zlib,compresslevel=9);
+ALTER
+-- result intact
+select * from atsetenc;
+ c1 | c2 
+----+----
+ 1  | 2  
+(1 row)
+execute checkrelfilenodediff('set encoding - basic', 'atsetenc');
+ segid | casename             | relname  | rewritten 
+-------+----------------------+----------+-----------
+ 0     | set encoding - basic | atsetenc | f         
+ 1     | set encoding - basic | atsetenc | f         
+ -1    | set encoding - basic | atsetenc | f         
+ 2     | set encoding - basic | atsetenc | f         
+(4 rows)
+execute attribute_encoding_check('atsetenc');
+ relname  | attname | filenum | attoptions                                                  
+----------+---------+---------+-------------------------------------------------------------
+ atsetenc | c1      | 1601    | ['compresstype=zlib', 'blocksize=32768', 'compresslevel=9'] 
+ atsetenc | c2      | 1602    | ['compresstype=zlib', 'blocksize=32768', 'compresslevel=9'] 
+(2 rows)
+
+-- check if the encoding takes actual effect
+alter table atsetenc add column c3 text default 'a';
+ALTER
+insert into atsetenc values (1,2,repeat('a',10000));
+INSERT 1
+-- before alter encoding, no compression by default
+execute attribute_encoding_check('atsetenc');
+ relname  | attname | filenum | attoptions                                                  
+----------+---------+---------+-------------------------------------------------------------
+ atsetenc | c1      | 1601    | ['compresstype=zlib', 'blocksize=32768', 'compresslevel=9'] 
+ atsetenc | c2      | 1602    | ['compresstype=zlib', 'blocksize=32768', 'compresslevel=9'] 
+ atsetenc | c3      | 3       | ['compresstype=none', 'blocksize=32768', 'compresslevel=0'] 
+(3 rows)
+select relname, attnum, size, compression_ratio from gp_toolkit.gp_column_size where relid::regclass::text = 'atsetenc' and gp_segment_id = 0 and attnum = 3;
+ relname  | attnum | size  | compression_ratio 
+----------+--------+-------+-------------------
+ atsetenc | 3      | 10096 | 1.00              
+(1 row)
+execute capturerelfilenodebefore('set encoding - compress effect', 'atsetenc');
+EXECUTE 4
+alter table atsetenc alter column c3 set encoding (compresstype=zlib,compresslevel=9);
+ALTER
+execute capturerelfilenodebefore('set encoding - compress effect', 'atsetenc');
+EXECUTE 4
+-- after alter encoding, size is reduced
+execute attribute_encoding_check('atsetenc');
+ relname  | attname | filenum | attoptions                                                  
+----------+---------+---------+-------------------------------------------------------------
+ atsetenc | c1      | 1601    | ['compresstype=zlib', 'blocksize=32768', 'compresslevel=9'] 
+ atsetenc | c2      | 1602    | ['compresstype=zlib', 'blocksize=32768', 'compresslevel=9'] 
+ atsetenc | c3      | 1603    | ['compresstype=zlib', 'blocksize=32768', 'compresslevel=9'] 
+(3 rows)
+select relname,attnum,size,compression_ratio from gp_toolkit.gp_column_size where relid::regclass::text = 'atsetenc' and gp_segment_id = 0 and attnum = 3;
+ relname  | attnum | size | compression_ratio 
+----------+--------+------+-------------------
+ atsetenc | 3      | 120  | 84.13             
+(1 row)
+select length(c3) from atsetenc;
+ length 
+--------
+ 1      
+ 10000  
+(2 rows)
+
+-- check if we'll re-index the index for the rewritten column, and not others
+create index atsetenc_idx2 on atsetenc(c2);
+CREATE
+create index atsetenc_idx3 on atsetenc(c3);
+CREATE
+execute capturerelfilenodebefore ('alter_column_c2', 'atsetenc_idx2');
+EXECUTE 4
+execute capturerelfilenodebefore ('alter_column_c2', 'atsetenc_idx3');
+EXECUTE 4
+alter table atsetenc alter column c2 set encoding (compresstype=zlib,compresslevel=1);
+ALTER
+execute checkrelfilenodediff('alter_column_c2', 'atsetenc_idx2');
+ segid | casename        | relname       | rewritten 
+-------+-----------------+---------------+-----------
+ -1    | alter_column_c2 | atsetenc_idx2 | t         
+ 2     | alter_column_c2 | atsetenc_idx2 | t         
+ 0     | alter_column_c2 | atsetenc_idx2 | t         
+ 1     | alter_column_c2 | atsetenc_idx2 | t         
+(4 rows)
+execute checkrelfilenodediff('alter_column_c2', 'atsetenc_idx3');
+ segid | casename        | relname       | rewritten 
+-------+-----------------+---------------+-----------
+ 2     | alter_column_c2 | atsetenc_idx3 | f         
+ -1    | alter_column_c2 | atsetenc_idx3 | f         
+ 0     | alter_column_c2 | atsetenc_idx3 | f         
+ 1     | alter_column_c2 | atsetenc_idx3 | f         
+(4 rows)
+
+--
+-- mixed AT commands
+--
+-- 1. with ALTER COLUMN TYPE
+alter table atsetenc add column c4 int default 4, add column c5 int default 5;
+ALTER
+execute capturerelfilenodebefore('set encoding - withaltercoltype', 'atsetenc');
+EXECUTE 4
+-- alter column type + alter column set encoding. The subcommands' order shouldn't matter.
+alter table atsetenc alter column c4 type text, alter column c4 set encoding (compresstype=zlib,compresslevel=9);
+ALTER
+alter table atsetenc alter column c5 set encoding (compresstype=zlib,compresslevel=9), alter column c5 type text;
+ALTER
+-- no rewrite
+execute checkrelfilenodediff('set encoding - withaltercoltype', 'atsetenc');
+ segid | casename                        | relname  | rewritten 
+-------+---------------------------------+----------+-----------
+ 2     | set encoding - withaltercoltype | atsetenc | f         
+ 0     | set encoding - withaltercoltype | atsetenc | f         
+ 1     | set encoding - withaltercoltype | atsetenc | f         
+ -1    | set encoding - withaltercoltype | atsetenc | f         
+(4 rows)
+execute attribute_encoding_check('atsetenc');
+ relname  | attname | filenum | attoptions                                                  
+----------+---------+---------+-------------------------------------------------------------
+ atsetenc | c1      | 1601    | ['compresstype=zlib', 'blocksize=32768', 'compresslevel=9'] 
+ atsetenc | c2      | 2       | ['compresstype=zlib', 'blocksize=32768', 'compresslevel=1'] 
+ atsetenc | c3      | 1603    | ['compresstype=zlib', 'blocksize=32768', 'compresslevel=9'] 
+ atsetenc | c4      | 1604    | ['compresstype=zlib', 'blocksize=32768', 'compresslevel=9'] 
+ atsetenc | c5      | 1605    | ['compresstype=zlib', 'blocksize=32768', 'compresslevel=9'] 
+(5 rows)
+select c4, c5 from atsetenc;
+ c4 | c5 
+----+----
+ 4  | 5  
+ 4  | 5  
+(2 rows)
+
+-- 2. with ADD COLUMN
+execute capturerelfilenodebefore('set encoding - withaddcol', 'atsetenc');
+EXECUTE 4
+alter table atsetenc add column c6 int default 6, alter column c5 set encoding (compresstype=zlib,compresslevel=1);
+ALTER
+-- no rewrite
+execute checkrelfilenodediff('set encoding - withaddcol', 'atsetenc');
+ segid | casename                  | relname  | rewritten 
+-------+---------------------------+----------+-----------
+ 0     | set encoding - withaddcol | atsetenc | f         
+ 1     | set encoding - withaddcol | atsetenc | f         
+ 2     | set encoding - withaddcol | atsetenc | f         
+ -1    | set encoding - withaddcol | atsetenc | f         
+(4 rows)
+execute attribute_encoding_check('atsetenc');
+ relname  | attname | filenum | attoptions                                                  
+----------+---------+---------+-------------------------------------------------------------
+ atsetenc | c1      | 1601    | ['compresstype=zlib', 'blocksize=32768', 'compresslevel=9'] 
+ atsetenc | c2      | 2       | ['compresstype=zlib', 'blocksize=32768', 'compresslevel=1'] 
+ atsetenc | c3      | 1603    | ['compresstype=zlib', 'blocksize=32768', 'compresslevel=9'] 
+ atsetenc | c4      | 1604    | ['compresstype=zlib', 'blocksize=32768', 'compresslevel=9'] 
+ atsetenc | c5      | 5       | ['compresstype=zlib', 'blocksize=32768', 'compresslevel=1'] 
+ atsetenc | c6      | 6       | ['compresstype=none', 'blocksize=32768', 'compresslevel=0'] 
+(6 rows)
+select c5, c6 from atsetenc;
+ c5 | c6 
+----+----
+ 5  | 6  
+ 5  | 6  
+(2 rows)
+
+-- 3. with DROP COLUMN
+alter table atsetenc add column c7 int default 7;
+ALTER
+execute capturerelfilenodebefore('set encoding - withdropcol', 'atsetenc');
+EXECUTE 4
+-- alter and drop the same column, should complaint
+alter table atsetenc alter column c7 set encoding (compresstype=zlib,compresslevel=9), drop column c7;
+ERROR:  column "c7" of relation "atsetenc" does not exist
+-- alter and drop different columns, should work and no rewrite
+alter table atsetenc alter column c7 set encoding (compresstype=zlib,compresslevel=9), drop column c3;
+ALTER
+execute checkrelfilenodediff('set encoding - withdropcol', 'atsetenc');
+ segid | casename                   | relname  | rewritten 
+-------+----------------------------+----------+-----------
+ 0     | set encoding - withdropcol | atsetenc | f         
+ 1     | set encoding - withdropcol | atsetenc | f         
+ 2     | set encoding - withdropcol | atsetenc | f         
+ -1    | set encoding - withdropcol | atsetenc | f         
+(4 rows)
+execute attribute_encoding_check('atsetenc');
+ relname  | attname                      | filenum | attoptions                                                  
+----------+------------------------------+---------+-------------------------------------------------------------
+ atsetenc | c1                           | 1601    | ['compresstype=zlib', 'blocksize=32768', 'compresslevel=9'] 
+ atsetenc | c2                           | 2       | ['compresstype=zlib', 'blocksize=32768', 'compresslevel=1'] 
+ atsetenc | c4                           | 1604    | ['compresstype=zlib', 'blocksize=32768', 'compresslevel=9'] 
+ atsetenc | c5                           | 5       | ['compresstype=zlib', 'blocksize=32768', 'compresslevel=1'] 
+ atsetenc | c6                           | 6       | ['compresstype=none', 'blocksize=32768', 'compresslevel=0'] 
+ atsetenc | c7                           | 1607    | ['compresstype=zlib', 'blocksize=32768', 'compresslevel=9'] 
+ atsetenc | ........pg.dropped.3........ | 1603    | ['compresstype=zlib', 'blocksize=32768', 'compresslevel=9'] 
+(7 rows)
+-- should error out
+select c3 from atsetenc;
+ERROR:  column "c3" does not exist
+LINE 1: select c3 from atsetenc;
+               ^
+select c7 from atsetenc;
+ c7 
+----
+ 7  
+ 7  
+(2 rows)
+
+-- 4. with AT commands that rewrite table
+alter table atsetenc add column c8 int default 8;
+ALTER
+-- changing to another AM, should complaint
+alter table atsetenc set access method heap, alter column c8 set encoding (compresstype=zlib,compresslevel=9);
+ERROR:  ALTER COLUMN SET ENCODING operation is only applicable to AOCO tables
+DETAIL:  New access method for "atsetenc" is not ao_column
+-- reorganize, should rewrite
+execute capturerelfilenodebefore('set encoding - reorg', 'atsetenc');
+EXECUTE 4
+alter table atsetenc set with (reorganize=true), alter column c8 set encoding (compresstype=zlib,compresslevel=9);
+ALTER
+execute checkrelfilenodediff('set encoding - reorg', 'atsetenc');
+ segid | casename             | relname  | rewritten 
+-------+----------------------+----------+-----------
+ 2     | set encoding - reorg | atsetenc | t         
+ -1    | set encoding - reorg | atsetenc | t         
+ 0     | set encoding - reorg | atsetenc | t         
+ 1     | set encoding - reorg | atsetenc | t         
+(4 rows)
+execute attribute_encoding_check('atsetenc');
+ relname  | attname                      | filenum | attoptions                                                  
+----------+------------------------------+---------+-------------------------------------------------------------
+ atsetenc | c1                           | 1       | ['compresstype=zlib', 'blocksize=32768', 'compresslevel=9'] 
+ atsetenc | c2                           | 2       | ['compresstype=zlib', 'blocksize=32768', 'compresslevel=1'] 
+ atsetenc | c4                           | 4       | ['compresstype=zlib', 'blocksize=32768', 'compresslevel=9'] 
+ atsetenc | c5                           | 5       | ['compresstype=zlib', 'blocksize=32768', 'compresslevel=1'] 
+ atsetenc | c6                           | 6       | ['compresstype=none', 'blocksize=32768', 'compresslevel=0'] 
+ atsetenc | c7                           | 7       | ['compresstype=zlib', 'blocksize=32768', 'compresslevel=9'] 
+ atsetenc | c8                           | 8       | ['compresstype=zlib', 'blocksize=32768', 'compresslevel=9'] 
+ atsetenc | ........pg.dropped.3........ | 3       | ['compresstype=zlib', 'blocksize=32768', 'compresslevel=9'] 
+(8 rows)
+
+-- 5. multiple SET ENCODING commands
+-- not rewrite
+execute capturerelfilenodebefore('set encoding - multiple', 'atsetenc');
+EXECUTE 4
+alter table atsetenc alter column c7 set encoding (compresstype=rle_type,compresslevel=3), alter column c8 set encoding (compresstype=rle_type,compresslevel=4);
+ALTER
+execute checkrelfilenodediff('set encoding - multiple', 'atsetenc');
+ segid | casename                | relname  | rewritten 
+-------+-------------------------+----------+-----------
+ 0     | set encoding - multiple | atsetenc | f         
+ 1     | set encoding - multiple | atsetenc | f         
+ -1    | set encoding - multiple | atsetenc | f         
+ 2     | set encoding - multiple | atsetenc | f         
+(4 rows)
+execute attribute_encoding_check('atsetenc');
+ relname  | attname                      | filenum | attoptions                                                      
+----------+------------------------------+---------+-----------------------------------------------------------------
+ atsetenc | c1                           | 1       | ['compresstype=zlib', 'blocksize=32768', 'compresslevel=9']     
+ atsetenc | c2                           | 2       | ['compresstype=zlib', 'blocksize=32768', 'compresslevel=1']     
+ atsetenc | c4                           | 4       | ['compresstype=zlib', 'blocksize=32768', 'compresslevel=9']     
+ atsetenc | c5                           | 5       | ['compresstype=zlib', 'blocksize=32768', 'compresslevel=1']     
+ atsetenc | ........pg.dropped.3........ | 3       | ['compresstype=zlib', 'blocksize=32768', 'compresslevel=9']     
+ atsetenc | c6                           | 6       | ['compresstype=none', 'blocksize=32768', 'compresslevel=0']     
+ atsetenc | c7                           | 1607    | ['compresstype=rle_type', 'blocksize=32768', 'compresslevel=3'] 
+ atsetenc | c8                           | 1608    | ['compresstype=rle_type', 'blocksize=32768', 'compresslevel=4'] 
+(8 rows)
+
+-- results all good
+select * from atsetenc;
+ c1 | c2 | c4 | c5 | c6 | c7 | c8 
+----+----+----+----+----+----+----
+ 1  | 2  | 4  | 5  | 6  | 7  | 8  
+ 1  | 2  | 4  | 5  | 6  | 7  | 8  
+(2 rows)
+
+--
+-- partition table
+--
+create table atsetencpart (a int, b int) using ao_column partition by range(b);
+CREATE
+create table atsetencpart_p1 partition of atsetencpart for values from (0) to (10);
+CREATE
+create table atsetencpart_p2 partition of atsetencpart for values from (10) to (20);
+CREATE
+create table atsetencpart_def partition of atsetencpart default;
+CREATE
+insert into atsetencpart select 1,i from generate_series(1,100)i;
+INSERT 100
+execute capturerelfilenodebefore('set enc', 'atsetencpart_p1');
+EXECUTE 4
+execute capturerelfilenodebefore('set enc', 'atsetencpart_p2');
+EXECUTE 4
+execute capturerelfilenodebefore('set enc', 'atsetencpart_def');
+EXECUTE 4
+-- alter root table will alter all children
+alter table atsetencpart alter column b set encoding (compresstype=zlib,compresslevel=9);
+ALTER
+-- alter a child partition just alter that partition
+alter table atsetencpart_p2 alter column b set encoding (compresslevel=1);
+ALTER
+-- no table rewrite and the options are changed
+execute checkrelfilenodediff('set enc', 'atsetencpart_p1');
+ segid | casename | relname         | rewritten 
+-------+----------+-----------------+-----------
+ 2     | set enc  | atsetencpart_p1 | f         
+ -1    | set enc  | atsetencpart_p1 | f         
+ 0     | set enc  | atsetencpart_p1 | f         
+ 1     | set enc  | atsetencpart_p1 | f         
+(4 rows)
+execute checkrelfilenodediff('set enc', 'atsetencpart_p2');
+ segid | casename | relname         | rewritten 
+-------+----------+-----------------+-----------
+ 2     | set enc  | atsetencpart_p2 | f         
+ -1    | set enc  | atsetencpart_p2 | f         
+ 0     | set enc  | atsetencpart_p2 | f         
+ 1     | set enc  | atsetencpart_p2 | f         
+(4 rows)
+execute checkrelfilenodediff('set enc', 'atsetencpart_def');
+ segid | casename | relname          | rewritten 
+-------+----------+------------------+-----------
+ 2     | set enc  | atsetencpart_def | f         
+ -1    | set enc  | atsetencpart_def | f         
+ 0     | set enc  | atsetencpart_def | f         
+ 1     | set enc  | atsetencpart_def | f         
+(4 rows)
+execute attribute_encoding_check('atsetencpart_p1');
+ relname         | attname | filenum | attoptions                                                  
+-----------------+---------+---------+-------------------------------------------------------------
+ atsetencpart_p1 | a       | 1       | ['compresstype=none', 'blocksize=32768', 'compresslevel=0'] 
+ atsetencpart_p1 | b       | 1602    | ['compresstype=zlib', 'blocksize=32768', 'compresslevel=9'] 
+(2 rows)
+execute attribute_encoding_check('atsetencpart_p2');
+ relname         | attname | filenum | attoptions                                                  
+-----------------+---------+---------+-------------------------------------------------------------
+ atsetencpart_p2 | a       | 1       | ['compresstype=none', 'blocksize=32768', 'compresslevel=0'] 
+ atsetencpart_p2 | b       | 2       | ['compresstype=zlib', 'blocksize=32768', 'compresslevel=1'] 
+(2 rows)
+execute attribute_encoding_check('atsetencpart_def');
+ relname          | attname | filenum | attoptions                                                  
+------------------+---------+---------+-------------------------------------------------------------
+ atsetencpart_def | a       | 1       | ['compresstype=none', 'blocksize=32768', 'compresslevel=0'] 
+ atsetencpart_def | b       | 1602    | ['compresstype=zlib', 'blocksize=32768', 'compresslevel=9'] 
+(2 rows)
+-- results are expected
+select sum(a), sum(b) from atsetencpart;
+ sum | sum  
+-----+------
+ 100 | 5050 
+(1 row)
+

--- a/src/test/regress/expected/alter_table_set.out
+++ b/src/test/regress/expected/alter_table_set.out
@@ -253,16 +253,16 @@ execute attribute_encoding_check('part_relopt%');
 -----------------+---------+---------+---------------------------------------------------------
  part_relopt     | a       |       1 | {compresstype=rle_type,compresslevel=4,blocksize=32768}
  part_relopt     | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt_1   | a       |       1 | {compresstype=rle_type,compresslevel=4,blocksize=32768}
- part_relopt_1   | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_1   | a       |    1601 | {compresstype=rle_type,compresslevel=4,blocksize=32768}
+ part_relopt_1   | b       |    1602 | {compresstype=zlib,compresslevel=5,blocksize=32768}
  part_relopt_2   | a       |       1 | {compresstype=rle_type,compresslevel=4,blocksize=32768}
  part_relopt_2   | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt_2_1 | a       |       1 | {compresstype=rle_type,compresslevel=4,blocksize=32768}
- part_relopt_2_1 | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt_2_2 | a       |       1 | {compresstype=rle_type,compresslevel=4,blocksize=32768}
- part_relopt_2_2 | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt_3   | a       |       1 | {compresstype=rle_type,compresslevel=4,blocksize=32768}
- part_relopt_3   | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_2_1 | a       |    1601 | {compresstype=rle_type,compresslevel=4,blocksize=32768}
+ part_relopt_2_1 | b       |    1602 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_2_2 | a       |    1601 | {compresstype=rle_type,compresslevel=4,blocksize=32768}
+ part_relopt_2_2 | b       |    1602 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_3   | a       |    1601 | {compresstype=rle_type,compresslevel=4,blocksize=32768}
+ part_relopt_3   | b       |    1602 | {compresstype=zlib,compresslevel=5,blocksize=32768}
 (12 rows)
 
 -- Check double edit on same column
@@ -273,15 +273,15 @@ execute attribute_encoding_check('part_relopt%');
  part_relopt     | a       |       1 | {compresstype=zlib,compresslevel=5,blocksize=32768}
  part_relopt     | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
  part_relopt_1   | a       |       1 | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt_1   | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_1   | b       |    1602 | {compresstype=zlib,compresslevel=5,blocksize=32768}
  part_relopt_2   | a       |       1 | {compresstype=zlib,compresslevel=5,blocksize=32768}
  part_relopt_2   | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
  part_relopt_2_1 | a       |       1 | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt_2_1 | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_2_1 | b       |    1602 | {compresstype=zlib,compresslevel=5,blocksize=32768}
  part_relopt_2_2 | a       |       1 | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt_2_2 | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_2_2 | b       |    1602 | {compresstype=zlib,compresslevel=5,blocksize=32768}
  part_relopt_3   | a       |       1 | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt_3   | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_3   | b       |    1602 | {compresstype=zlib,compresslevel=5,blocksize=32768}
 (12 rows)
 
 -- Check double edit of same option
@@ -293,15 +293,15 @@ execute attribute_encoding_check('part_relopt%');
  part_relopt     | a       |       1 | {compresstype=zlib,compresslevel=5,blocksize=32768}
  part_relopt     | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
  part_relopt_1   | a       |       1 | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt_1   | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_1   | b       |    1602 | {compresstype=zlib,compresslevel=5,blocksize=32768}
  part_relopt_2   | a       |       1 | {compresstype=zlib,compresslevel=5,blocksize=32768}
  part_relopt_2   | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
  part_relopt_2_1 | a       |       1 | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt_2_1 | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_2_1 | b       |    1602 | {compresstype=zlib,compresslevel=5,blocksize=32768}
  part_relopt_2_2 | a       |       1 | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt_2_2 | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_2_2 | b       |    1602 | {compresstype=zlib,compresslevel=5,blocksize=32768}
  part_relopt_3   | a       |       1 | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt_3   | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_3   | b       |    1602 | {compresstype=zlib,compresslevel=5,blocksize=32768}
 (12 rows)
 
 -- Check double edit of same column different options
@@ -311,16 +311,16 @@ execute attribute_encoding_check('part_relopt%');
 -----------------+---------+---------+-----------------------------------------------------
  part_relopt     | a       |       1 | {compresstype=zlib,compresslevel=7,blocksize=32768}
  part_relopt     | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt_1   | a       |       1 | {compresstype=zlib,compresslevel=7,blocksize=32768}
- part_relopt_1   | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_1   | a       |    1601 | {compresstype=zlib,compresslevel=7,blocksize=32768}
+ part_relopt_1   | b       |    1602 | {compresstype=zlib,compresslevel=5,blocksize=32768}
  part_relopt_2   | a       |       1 | {compresstype=zlib,compresslevel=7,blocksize=32768}
  part_relopt_2   | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt_2_1 | a       |       1 | {compresstype=zlib,compresslevel=7,blocksize=32768}
- part_relopt_2_1 | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt_2_2 | a       |       1 | {compresstype=zlib,compresslevel=7,blocksize=32768}
- part_relopt_2_2 | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt_3   | a       |       1 | {compresstype=zlib,compresslevel=7,blocksize=32768}
- part_relopt_3   | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_2_1 | a       |    1601 | {compresstype=zlib,compresslevel=7,blocksize=32768}
+ part_relopt_2_1 | b       |    1602 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_2_2 | a       |    1601 | {compresstype=zlib,compresslevel=7,blocksize=32768}
+ part_relopt_2_2 | b       |    1602 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_3   | a       |    1601 | {compresstype=zlib,compresslevel=7,blocksize=32768}
+ part_relopt_3   | b       |    1602 | {compresstype=zlib,compresslevel=5,blocksize=32768}
 (12 rows)
 
 ALTER TABLE part_relopt ALTER COLUMN a SET ENCODING (compresstype=zlib, compresslevel=5);
@@ -330,15 +330,15 @@ execute attribute_encoding_check('part_relopt%');
  part_relopt     | a       |       1 | {compresstype=zlib,compresslevel=5,blocksize=32768}
  part_relopt     | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
  part_relopt_1   | a       |       1 | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt_1   | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_1   | b       |    1602 | {compresstype=zlib,compresslevel=5,blocksize=32768}
  part_relopt_2   | a       |       1 | {compresstype=zlib,compresslevel=5,blocksize=32768}
  part_relopt_2   | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
  part_relopt_2_1 | a       |       1 | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt_2_1 | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_2_1 | b       |    1602 | {compresstype=zlib,compresslevel=5,blocksize=32768}
  part_relopt_2_2 | a       |       1 | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt_2_2 | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_2_2 | b       |    1602 | {compresstype=zlib,compresslevel=5,blocksize=32768}
  part_relopt_3   | a       |       1 | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt_3   | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
+ part_relopt_3   | b       |    1602 | {compresstype=zlib,compresslevel=5,blocksize=32768}
 (12 rows)
 
 -- Data is intact
@@ -371,8 +371,8 @@ ALTER TABLE aoco_relopt ALTER COLUMN a SET ENCODING (compresstype=rle_type, comp
 execute attribute_encoding_check('aoco_relopt%');
    relname   | attname | filenum |                       attoptions                        
 -------------+---------+---------+---------------------------------------------------------
- aoco_relopt | a       |       1 | {compresstype=rle_type,blocksize=32768,compresslevel=4}
- aoco_relopt | b       |       2 | {compresstype=zlib,blocksize=32768,compresslevel=5}
+ aoco_relopt | a       |    1601 | {compresstype=rle_type,blocksize=32768,compresslevel=4}
+ aoco_relopt | b       |    1602 | {compresstype=zlib,blocksize=32768,compresslevel=5}
 (2 rows)
 
 DROP TABLE aoco_relopt;
@@ -476,7 +476,7 @@ execute attribute_encoding_check('part_relopt3%');
 ----------------+---------+---------+-----------------------------------------------------
  part_relopt3   | a       |       1 | {compresstype=zlib,compresslevel=5,blocksize=32768}
  part_relopt3   | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt3_1 | a       |       1 | {compresstype=zlib,blocksize=32768,compresslevel=3}
+ part_relopt3_1 | a       |    1601 | {compresstype=zlib,blocksize=32768,compresslevel=3}
  part_relopt3_1 | b       |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
  part_relopt3_2 | a       |       1 | {compresstype=zlib,compresslevel=5,blocksize=32768}
  part_relopt3_2 | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
@@ -488,11 +488,11 @@ execute attribute_encoding_check('part_relopt3%');
 ------------------+---------+---------+-----------------------------------------------------
  part_relopt3     | a       |       1 | {compresstype=zlib,compresslevel=5,blocksize=32768}
  part_relopt3     | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt3_1   | a       |       1 | {compresstype=zlib,blocksize=32768,compresslevel=3}
+ part_relopt3_1   | a       |    1601 | {compresstype=zlib,blocksize=32768,compresslevel=3}
  part_relopt3_1   | b       |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
  part_relopt3_2   | a       |       1 | {compresstype=zlib,compresslevel=5,blocksize=32768}
  part_relopt3_2   | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt3_2_1 | a       |       1 | {compresstype=zlib,blocksize=32768,compresslevel=4}
+ part_relopt3_2_1 | a       |       1 | {compresslevel=4,compresstype=zlib,blocksize=32768}
  part_relopt3_2_1 | b       |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
 (8 rows)
 
@@ -502,11 +502,11 @@ execute attribute_encoding_check('part_relopt3%');
 ------------------+---------+---------+---------------------------------------------------------
  part_relopt3     | a       |       1 | {compresstype=zlib,compresslevel=5,blocksize=32768}
  part_relopt3     | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt3_1   | a       |       1 | {compresstype=zlib,blocksize=32768,compresslevel=3}
+ part_relopt3_1   | a       |    1601 | {compresstype=zlib,blocksize=32768,compresslevel=3}
  part_relopt3_1   | b       |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
  part_relopt3_2   | a       |       1 | {compresstype=rle_type,compresslevel=1,blocksize=32768}
  part_relopt3_2   | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt3_2_1 | a       |       1 | {compresstype=rle_type,blocksize=32768,compresslevel=1}
+ part_relopt3_2_1 | a       |    1601 | {compresslevel=1,compresstype=rle_type,blocksize=32768}
  part_relopt3_2_1 | b       |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
 (8 rows)
 
@@ -520,7 +520,7 @@ execute attribute_encoding_check('part_relopt3%');
  part_relopt3_1   | b       |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
  part_relopt3_2   | a       |       1 | {compresstype=rle_type,compresslevel=4,blocksize=32768}
  part_relopt3_2   | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt3_2_1 | a       |       1 | {compresstype=rle_type,blocksize=32768,compresslevel=4}
+ part_relopt3_2_1 | a       |       1 | {compresslevel=4,compresstype=rle_type,blocksize=32768}
  part_relopt3_2_1 | b       |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
 (8 rows)
 
@@ -541,7 +541,7 @@ execute attribute_encoding_check('part_relopt3%');
  part_relopt3_1   | b       |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
  part_relopt3_2   | a       |       1 | {compresstype=rle_type,compresslevel=4,blocksize=32768}
  part_relopt3_2   | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt3_2_1 | a       |       1 | {compresstype=rle_type,blocksize=32768,compresslevel=4}
+ part_relopt3_2_1 | a       |       1 | {compresslevel=4,compresstype=rle_type,blocksize=32768}
  part_relopt3_2_1 | b       |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
 (8 rows)
 
@@ -568,7 +568,7 @@ execute attribute_encoding_check('part_relopt3%');
  part_relopt3_1   | b       |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
  part_relopt3_2   | a       |       1 | {compresstype=rle_type,compresslevel=4,blocksize=32768}
  part_relopt3_2   | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt3_2_1 | a       |       1 | {compresstype=rle_type,blocksize=32768,compresslevel=4}
+ part_relopt3_2_1 | a       |       1 | {compresslevel=4,compresstype=rle_type,blocksize=32768}
  part_relopt3_2_1 | b       |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
 (8 rows)
 
@@ -583,14 +583,14 @@ execute attribute_encoding_check('part_relopt3%');
  part_relopt3_1   | b       |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
  part_relopt3_2   | a       |       1 | {compresstype=zlib,compresslevel=3,blocksize=32768}
  part_relopt3_2   | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt3_2_1 | a       |       1 | {compresstype=rle_type,blocksize=32768,compresslevel=4}
+ part_relopt3_2_1 | a       |       1 | {compresslevel=4,compresstype=rle_type,blocksize=32768}
  part_relopt3_2_1 | b       |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
 (8 rows)
 
 -- altering when changing am to heap should error out for root partition
 ALTER TABLE part_relopt3 SET ACCESS METHOD heap, ALTER COLUMN a SET ENCODING (compresslevel=4, compresstype=rle_type);
 ERROR:  ALTER COLUMN SET ENCODING operation is only applicable to AOCO tables
-DETAIL:  New access method for "part_relopt3" is not AOCO
+DETAIL:  New access method for "part_relopt3" is not ao_column
 execute attribute_encoding_check('part_relopt3%');
      relname      | attname | filenum |                       attoptions                        
 ------------------+---------+---------+---------------------------------------------------------
@@ -600,14 +600,14 @@ execute attribute_encoding_check('part_relopt3%');
  part_relopt3_1   | b       |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
  part_relopt3_2   | a       |       1 | {compresstype=zlib,compresslevel=3,blocksize=32768}
  part_relopt3_2   | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt3_2_1 | a       |       1 | {compresstype=rle_type,blocksize=32768,compresslevel=4}
+ part_relopt3_2_1 | a       |       1 | {compresslevel=4,compresstype=rle_type,blocksize=32768}
  part_relopt3_2_1 | b       |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
 (8 rows)
 
 -- altering when changing am to heap should error out for child partition
 ALTER TABLE part_relopt3_2_1 SET ACCESS METHOD heap, ALTER COLUMN a SET ENCODING (compresslevel=4, compresstype=rle_type);
 ERROR:  ALTER COLUMN SET ENCODING operation is only applicable to AOCO tables
-DETAIL:  New access method for "part_relopt3_2_1" is not AOCO
+DETAIL:  New access method for "part_relopt3_2_1" is not ao_column
 execute attribute_encoding_check('part_relopt3%');
      relname      | attname | filenum |                       attoptions                        
 ------------------+---------+---------+---------------------------------------------------------
@@ -617,7 +617,7 @@ execute attribute_encoding_check('part_relopt3%');
  part_relopt3_1   | b       |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
  part_relopt3_2   | a       |       1 | {compresstype=zlib,compresslevel=3,blocksize=32768}
  part_relopt3_2   | b       |       2 | {compresstype=zlib,compresslevel=5,blocksize=32768}
- part_relopt3_2_1 | a       |       1 | {compresstype=rle_type,blocksize=32768,compresslevel=4}
+ part_relopt3_2_1 | a       |       1 | {compresslevel=4,compresstype=rle_type,blocksize=32768}
  part_relopt3_2_1 | b       |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
 (8 rows)
 
@@ -628,13 +628,13 @@ ALTER TABLE part_relopt3 SET ACCESS METHOD ao_column, ALTER COLUMN a SET ENCODIN
 execute attribute_encoding_check('part_relopt3%');
      relname      | attname | filenum |                     attoptions                      
 ------------------+---------+---------+-----------------------------------------------------
- part_relopt3     | a       |       1 | {compresstype=none,blocksize=32768,compresslevel=4}
+ part_relopt3     | a       |       1 | {compresslevel=4,compresstype=zlib,blocksize=32768}
  part_relopt3     | b       |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
- part_relopt3_1   | a       |       1 | {compresstype=none,blocksize=32768,compresslevel=4}
+ part_relopt3_1   | a       |       1 | {compresslevel=4,compresstype=zlib,blocksize=32768}
  part_relopt3_1   | b       |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
- part_relopt3_2   | a       |       1 | {compresstype=none,blocksize=32768,compresslevel=4}
+ part_relopt3_2   | a       |       1 | {compresslevel=4,compresstype=zlib,blocksize=32768}
  part_relopt3_2   | b       |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
- part_relopt3_2_1 | a       |       1 | {compresstype=none,blocksize=32768,compresslevel=4}
+ part_relopt3_2_1 | a       |       1 | {compresslevel=4,compresstype=zlib,blocksize=32768}
  part_relopt3_2_1 | b       |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
 (8 rows)
 
@@ -646,11 +646,11 @@ execute attribute_encoding_check('part_relopt3%');
 ------------------+---------+---------+-----------------------------------------------------
  part_relopt3     | a       |       1 | {compresstype=none,blocksize=32768,compresslevel=4}
  part_relopt3     | b       |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
- part_relopt3_1   | a       |       1 | {compresstype=none,blocksize=32768,compresslevel=4}
+ part_relopt3_1   | a       |    1601 | {compresstype=none,blocksize=32768,compresslevel=4}
  part_relopt3_1   | b       |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
  part_relopt3_2   | a       |       1 | {compresstype=none,blocksize=32768,compresslevel=4}
  part_relopt3_2   | b       |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
- part_relopt3_2_1 | a       |       1 | {compresstype=none,blocksize=32768,compresslevel=4}
+ part_relopt3_2_1 | a       |    1601 | {compresstype=none,blocksize=32768,compresslevel=4}
  part_relopt3_2_1 | b       |       2 | {compresstype=none,blocksize=32768,compresslevel=0}
 (8 rows)
 


### PR DESCRIPTION
Since we added the column rewrite functionality in #15344, we can now do the same for `ALTER TABLE ... ALTER COLUMN ... SET ENCODING` which used to require table rewrite. Now do that. Like `ALTER COLUMN TYPE`, we use a new command for `ALTER COLUMN SET ENCODING` so that we can properly decide if we should perform the column rewrite-only optimization.

The idea is simple but there are some notable things during implementation:

* In the same ALTER TABLE statement, ALTER COLUMN SET ENCODING is made to happen after ALTER COLUMN TYPE for the same column. This is because both use the same column rewrite facility and we need to make sure they do not step onto each other's toes, so make ALTER COLUMN TYPE go first (we can also do the other way around but it seems simpler current way because we would avoid changes to the ALTER COLUMN TYPE code).

* Similar to what happened during table rewrite where encoding option is updated after the rewrite, now encoding update is happening after the column rewrite. The reason is the same - we need to scan the old table using old encodings. New encoding options are passed to the column rewrite facility (see aocs_writecol_init) and used for writing the new column.

* Fix an issue in UpdateEncodingList() where the updated "current_encodings" might not be actually used by the caller. now make the function return the new encodings back to the caller.

* Add an UpdateOrAddAttributeEncodings() function to handle the case where we might be setting new encoding for a currently-non-co table (e.g. when we are also altering AM from heap->co), so we need to add pg_attribute_encoding entry instead of updating it. Similarly, have to modify populate_rel_col_encodings() for that case.

* Some test result files need to be updated:
  * aoco_column_rewrite: need to use some other AT command to achieve table rewrite.
  * alter_table_set: since column is rewritten, filenum will change. Also, some options order shown in the pg_attribute_encoding.attoptions is changed due to some change in option parsing, which should be ok as the values do not change.

Dev pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/at-set-encoding

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
