### PR TITLE
Remove fixme in prepunion.c:848

### DIFF
--- a/src/backend/cdb/cdbsetop.c
+++ b/src/backend/cdb/cdbsetop.c
@@ -129,15 +129,13 @@ adjust_setop_arguments(PlannerInfo *root, List *pathlist, List *tlist_list, GpSe
 					case CdbLocusType_Hashed:
 					case CdbLocusType_HashedOJ:
 					case CdbLocusType_Strewn:
-						break;
 					case CdbLocusType_SingleQE:
 					case CdbLocusType_General:
 					case CdbLocusType_SegmentGeneral:
 						/*
-						 * The setop itself will run on an N-gang, so we need
-						 * to arrange for the singleton input to be separately
-						 * dispatched to a 1-gang and collect its result on
-						 * one of our N QEs. Hence ...
+						 * Collocate non-distinct tuples prior to sort or hash. We must
+						 * put the Redistribute nodes below the Append, otherwise we lose
+						 * the order of the firstFlags.
 						 */
 						adjusted_path = make_motion_hash_all_targets(root, subpath, subtlist);
 						break;

--- a/src/backend/optimizer/prep/prepunion.c
+++ b/src/backend/optimizer/prep/prepunion.c
@@ -829,39 +829,6 @@ generate_nonunion_paths(SetOperationStmt *op, PlannerInfo *root,
 		optype = PSETOP_SEQUENTIAL_QD;
 	}
 
-	if ( optype == PSETOP_PARALLEL_PARTITIONED )
-	{
-		/*
-		 * CDB: Collocate non-distinct tuples prior to sort or hash. We must
-		 * put the Redistribute nodes below the Append, otherwise we lose
-		 * the order of the firstFlags.
-		 */
-		ListCell   *pathcell;
-		ListCell   *tlistcell;
-		List	   *newpathlist = NIL;
-
-		forboth(pathcell, pathlist, tlistcell, tlist_list)
-		{
-			Path	   *subpath = (Path *) lfirst(pathcell);
-			List	   *subtlist = (List *) lfirst(tlistcell);
-#if 0
-			/* GPDB_96_MERGE_FIXME */
-			/*
-			 * If the subplan already has a Motion at the top, peel it off
-			 * first, so that we don't have a Motion on top of a Motion.
-			 * That would be silly. I wish we could be smarter and not
-			 * create such a Motion in the first place, but it's too late
-			 * for that here.
-			 */
-			while (IsA(subpath, Motion))
-				subpath = subpath->lefttree;
-#endif
-			newpathlist = lappend(newpathlist,
-								  make_motion_hash_all_targets(root, subpath, subtlist));
-		}
-		pathlist = newpathlist;
-	}
-
 	/*
 	 * Generate tlist for Append plan node.
 	 *


### PR DESCRIPTION
If `optype` is equal to `PSETOP_PARALLEL_PARTITIONED`, `generate_nonunion_paths` will invoke `make_motion_hash_all_targets` twice for certain subpaths. This won't generate incorrect query plans now because the target locus and subpath locus are equal, the second invocation of `make_motion_hash_all_targets` won't add new motion on top of the existing motion. This commit removes the GPDB_96_MERGE_FIXME and performs some simple refactoring to make the code logic clearer.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
