### PR TITLE
Add a new gp_relation_filepath() C function.

### DIFF
--- a/src/backend/utils/adt/Makefile
+++ b/src/backend/utils/adt/Makefile
@@ -132,6 +132,6 @@ varlena.o: varlena.c levenshtein.c
 
 # GPDB additions
 OBJS +=	complex_type.o gp_dump_oids.o gp_optimizer_functions.o \
-	interpolate.o matrix.o pivot.o
+	interpolate.o matrix.o pivot.o dbsize_gp.o
 
 include $(top_srcdir)/src/backend/common.mk

--- a/src/backend/utils/adt/dbsize_gp.c
+++ b/src/backend/utils/adt/dbsize_gp.c
@@ -1,0 +1,157 @@
+/*-------------------------------------------------------------------------
+ *
+ * dbsize_gp.c
+ *
+ * GPDB-specific database object size functions, and related inquiries
+ *
+ * Portions Copyright (c) 2017-Present VMware, Inc. or its affiliates.
+ * Portions Copyright (c) 1996-2016, PostgreSQL Global Development Group
+ * Portions Copyright (c) 1994, Regents of the University of California
+ *
+ * src/backend/utils/adt/dbsize_gp.c
+ *
+ *-------------------------------------------------------------------------
+ */
+#include "postgres.h"
+
+#include "funcapi.h"
+#include "libpq-fe.h"
+#include "utils/builtins.h"
+
+#include "cdb/cdbdispatchresult.h"
+#include "cdb/cdbdisp_query.h"
+#include "cdb/cdbvars.h"
+#include "fmgr_gp.h"
+
+/*
+ * gp_relation_filepath: get the entire file path name of the relation on all
+ * segments
+ */
+Datum
+gp_relation_filepath(PG_FUNCTION_ARGS)
+{
+	typedef struct Context
+	{
+		CdbPgResults cdb_pgresults;
+		Datum qd_filepath;
+		bool isnull;
+		int index;
+	} Context;
+
+	FuncCallContext *funcctx;
+	Context    *context;
+
+	if (SRF_IS_FIRSTCALL())
+	{
+		TupleDesc		tupdesc;
+		MemoryContext	oldcontext;
+		Oid				relid = PG_GETARG_OID(0);
+		char		   *filepath_command;
+
+		/* create a function context for cross-call persistence */
+		funcctx = SRF_FIRSTCALL_INIT();
+
+		/* switch to memory context for appropriate multiple function call */
+		oldcontext = MemoryContextSwitchTo(funcctx->multi_call_memory_ctx);
+
+		/* create tupdesc for result */
+		tupdesc = CreateTemplateTupleDesc(2);
+		TupleDescInitEntry(tupdesc, (AttrNumber) 1, "segment_id",
+						   INT2OID, -1, 0);
+		TupleDescInitEntry(tupdesc, (AttrNumber) 2, "filepath",
+						   TEXTOID, -1, 0);
+
+		funcctx->tuple_desc = BlessTupleDesc(tupdesc);
+
+		context = (Context *) palloc(sizeof(Context));
+		context->cdb_pgresults.pg_results = NULL;
+		context->cdb_pgresults.numResults = 0;
+		context->index = 0;
+		funcctx->user_fctx = (void *) context;
+
+		if (!IS_QUERY_DISPATCHER() || Gp_role != GP_ROLE_DISPATCH)
+			elog(ERROR,
+				 "cannot use gp_relation_filepath() when not in QD mode");
+
+		filepath_command = psprintf("SELECT filepath FROM pg_catalog.pg_relation_filepath(%u) filepath",
+									relid);
+		CdbDispatchCommand(filepath_command,
+						   DF_CANCEL_ON_ERROR,
+						   &context->cdb_pgresults);
+		context->qd_filepath = DirectNullFunctionCall1(pg_relation_filepath,
+													   ObjectIdGetDatum(relid),
+													   &context->isnull);
+
+		pfree(filepath_command);
+
+		funcctx->user_fctx = (void *) context;
+		MemoryContextSwitchTo(oldcontext);
+	}
+
+	/*
+	 * Using SRF to return all the filepath information of the form
+	 * {segment_id, filepath}
+	 */
+	funcctx = SRF_PERCALL_SETUP();
+	context = (Context *) funcctx->user_fctx;
+
+	while (context->index <= context->cdb_pgresults.numResults)
+	{
+		Datum		values[2];
+		bool		nulls[2];
+		HeapTuple	tuple;
+		Datum		result;
+		Datum		filepath;
+		bool		isnull = false;
+		int			seg_index;
+
+		if (context->index == 0)
+		{
+			/* Setting fields representing QD's filepath */
+			seg_index = GpIdentity.segindex;
+			filepath = context->qd_filepath;
+			isnull = context->isnull;
+		}
+		else
+		{
+			struct pg_result	*pgresult;
+			ExecStatusType		resultStatus;
+
+			/* Setting fields representing QE's filepath */
+			seg_index = context->index - 1;
+			pgresult = context->cdb_pgresults.pg_results[seg_index];
+			resultStatus = PQresultStatus(pgresult);
+
+			if (resultStatus != PGRES_COMMAND_OK && resultStatus != PGRES_TUPLES_OK)
+				ereport(ERROR,
+						(errcode(ERRCODE_GP_INTERCONNECTION_ERROR),
+						 (errmsg("could not get file path"),
+						  errdetail("%s", PQresultErrorMessage(pgresult)))));
+			Assert(PQntuples(pgresult) == 1);
+
+			if (PQgetisnull(pgresult, 0, 0))
+				isnull = true;
+			else
+				filepath = CStringGetTextDatum(PQgetvalue(pgresult, 0, 0));
+		}
+
+		/*
+		 * Form tuple with appropriate data.
+		 */
+		MemSet(values, 0, sizeof(values));
+		MemSet(nulls, false, sizeof(nulls));
+
+		values[0] = Int16GetDatum(seg_index);
+		if (isnull)
+			nulls[1] = true;
+		else
+			values[1] = filepath;
+		tuple = heap_form_tuple(funcctx->tuple_desc, values, nulls);
+		result = HeapTupleGetDatum(tuple);
+
+		context->index++;
+		SRF_RETURN_NEXT(funcctx, result);
+	}
+
+	SRF_RETURN_DONE(funcctx);
+}

--- a/src/backend/utils/fmgr/Makefile
+++ b/src/backend/utils/fmgr/Makefile
@@ -16,4 +16,7 @@ OBJS = dfmgr.o fmgr.o funcapi.o deprecated.o
 
 override CPPFLAGS += -DDLSUFFIX=\"$(DLSUFFIX)\"
 
+# GPDB additions
+OBJS +=	fmgr_gp.o
+
 include $(top_srcdir)/src/backend/common.mk

--- a/src/backend/utils/fmgr/fmgr_gp.c
+++ b/src/backend/utils/fmgr/fmgr_gp.c
@@ -1,0 +1,54 @@
+/*-------------------------------------------------------------------------
+ *
+ * fmgr_gb.c
+ *	  GPDB extra function manager.
+ *
+ * Portions Copyright (c) 2017-Present VMware, Inc. or its affiliates.
+ * Portions Copyright (c) 1996-2019, PostgreSQL Global Development Group
+ * Portions Copyright (c) 1994, Regents of the University of California
+ *
+ *
+ * IDENTIFICATION
+ *	  src/backend/utils/fmgr/fmgr_gp.c
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#include "postgres.h"
+
+#include "fmgr.h"
+#include "miscadmin.h"
+
+/*-------------------------------------------------------------------------
+ *		Support routines for callers of nullable fmgr-compatible functions
+ *-------------------------------------------------------------------------
+ */
+
+/*
+ * These are for invocation of a specifically named function with a
+ * directly-computed parameter list.  Note that the arguments
+ * are not allowed to be NULL, but the result is.  In the latter case, isNull
+ * will be set to true.  Also, the function cannot be one that needs to look at
+ * FmgrInfo, since there won't be any.
+ */
+Datum
+DirectNullFunctionCall1Coll(PGFunction func, Oid collation, Datum arg1,
+						bool *isNull)
+{
+	LOCAL_FCINFO(fcinfo, 1);
+	Datum		result;
+
+	InitFunctionCallInfoData(*fcinfo, NULL, 1, collation, NULL, NULL);
+
+	fcinfo->args[0].value = arg1;
+	fcinfo->args[0].isnull = false;
+
+	result = (*func) (fcinfo);
+
+	/* Check for null result */
+	*isNull = fcinfo->isnull;
+	if (*isNull)
+		return (Datum) 0;
+	else
+		return result;
+}

--- a/src/include/catalog/catversion.h
+++ b/src/include/catalog/catversion.h
@@ -56,6 +56,6 @@
  */
 
 /*							3yyymmddN */
-#define CATALOG_VERSION_NO	302305111
+#define CATALOG_VERSION_NO	302305221
 
 #endif

--- a/src/include/catalog/pg_proc.dat
+++ b/src/include/catalog/pg_proc.dat
@@ -11599,6 +11599,10 @@
    proname => 'gp_create_restore_point', prorows => '1000', proretset => 't', proparallel => 'u', provolatile => 'v', prorettype => 'record', proargtypes => 'text', proexeclocation => 'c',
    proallargtypes => '{text,int2,pg_lsn}', proargmodes => '{i,o,o}', proargnames => '{restore_point_name,gp_segment_id,restore_lsn}', prosrc => 'gp_create_restore_point' },
 
+{ oid => 7003, descr => 'Get the entire file path name of a relation all segments',
+   proname => 'gp_relation_filepath', prorows => '1000', proretset => 't', proparallel => 'u', provolatile => 's', prorettype => 'record', proargtypes => 'regclass', proexeclocation => 'c',
+   proallargtypes => '{regclass,int2,text}', proargmodes => '{i,o,o}', proargnames => '{relid,gp_segment_id,filepath}', prosrc => 'gp_relation_filepath' },
+
 { oid => 7001, descr => 'Switch WAL segment files on all segments',
    proname => 'gp_switch_wal', prorows => '1000', proretset => 't', proparallel => 'u', provolatile => 'v', prorettype => 'record', proargtypes => '', proexeclocation => 'c',
    proallargtypes => '{int2,pg_lsn,text}', proargmodes => '{o,o,o}', proargnames => '{gp_segment_id,pg_switch_wal,pg_walfile_name}', prosrc => 'gp_switch_wal' },

--- a/src/include/fmgr_gp.h
+++ b/src/include/fmgr_gp.h
@@ -1,0 +1,35 @@
+/*-------------------------------------------------------------------------
+ *
+ * fmgr_gp.h
+ *	  Definitions for the extra function-call interface.
+ *
+ * This file must be included by all Postgres modules that either define
+ * or call fmgr-callable functions.
+ *
+ *
+ * Portions Copyright (c) 2017-Present VMware, Inc. or its affiliates.
+ * Portions Copyright (c) 1996-2019, PostgreSQL Global Development Group
+ * Portions Copyright (c) 1994, Regents of the University of California
+ *
+ * src/include/fmgr.h
+ *
+ *-------------------------------------------------------------------------
+ */
+#ifndef FMGR_GP_H
+#define FMGR_GP_H
+
+/* These are for invocation of a specifically named function with a
+ * directly-computed parameter list.  Note that the arguments are not allowed
+ * to be NULL, but the result is.
+ */
+extern Datum DirectNullFunctionCall1Coll(PGFunction func, Oid collation,
+										 Datum arg1, bool *isNull);
+
+/* These macros allow the collation argument to be omitted (with a default of
+ * InvalidOid, ie, no collation).  They exist mostly for backwards
+ * compatibility of source code.
+ */
+#define DirectNullFunctionCall1(func, arg1, isNull) \
+	DirectNullFunctionCall1Coll(func, InvalidOid, arg1, isNull)
+
+#endif							/* FMGR_GP_H */

--- a/src/test/regress/expected/dbsize_gp.out
+++ b/src/test/regress/expected/dbsize_gp.out
@@ -1,0 +1,15 @@
+-- test gp_relation_filepath
+SELECT regexp_replace(filepath, '[0-9]+', 'XXX', 'g') AS filepath, count(*) > 0 AS ok
+    FROM gp_relation_filepath('pg_class') GROUP BY 1;
+   filepath   | ok 
+--------------+----
+ base/XXX/XXX | t
+(1 row)
+
+SELECT filepath, count(*) > 0 AS ok
+    FROM gp_relation_filepath(0) GROUP BY 1;
+ filepath | ok 
+----------+----
+          | t
+(1 row)
+

--- a/src/test/regress/expected/mirror_replay.out
+++ b/src/test/regress/expected/mirror_replay.out
@@ -4,12 +4,6 @@
 create language plpython3u;
 -- end_ignore
 -- helper functions
-CREATE FUNCTION rel_filepaths_on_segments(regclass) RETURNS TABLE(gp_segment_id int, filepath text)
-STRICT STABLE LANGUAGE SQL AS
-  $fn$
-  SELECT gp_execution_segment(), pg_relation_filepath($1) AS filepath
-  $fn$
-EXECUTE ON ALL SEGMENTS;
 CREATE or REPLACE FUNCTION change_file_permission_readonly(path text)
   RETURNS void as
 $$
@@ -57,7 +51,7 @@ SELECT wait_for_replication_replay(5000);
 
 -- step to inject fault to make sure truncate xlog replay cannot open the file in write mode
 SELECT change_file_permission_readonly(datadir || '/' ||
-  (SELECT filepath FROM rel_filepaths_on_segments('mirror_reply_test_table')
+  (SELECT filepath FROM gp_relation_filepath('mirror_reply_test_table')
   WHERE gp_segment_id = 0) || '.1')
   FROM gp_segment_configuration WHERE content = 0 AND role = 'm';
 INFO:  changing file permission to readonly

--- a/src/test/regress/greenplum_schedule
+++ b/src/test/regress/greenplum_schedule
@@ -81,7 +81,7 @@ test: gp_connections
 
 # bitmap_index triggers recovery, run it seperately
 test: bitmap_index
-test: gp_dump_query_oids analyze gp_owner_permission incremental_analyze truncate_gp
+test: gp_dump_query_oids analyze gp_owner_permission incremental_analyze truncate_gp dbsize_gp
 test: indexjoin as_alias regex_gp gpparams with_clause transient_types gp_rules dispatch_encoding motion_gp gp_pullup_expr
 
 # interconnect tests

--- a/src/test/regress/sql/dbsize_gp.sql
+++ b/src/test/regress/sql/dbsize_gp.sql
@@ -1,0 +1,5 @@
+-- test gp_relation_filepath
+SELECT regexp_replace(filepath, '[0-9]+', 'XXX', 'g') AS filepath, count(*) > 0 AS ok
+    FROM gp_relation_filepath('pg_class') GROUP BY 1;
+SELECT filepath, count(*) > 0 AS ok
+    FROM gp_relation_filepath(0) GROUP BY 1;


### PR DESCRIPTION
Regression tests added.

There was some custom "EXECUTE ON ALL SEGMENTS" SQL function that was mimicking that function, so remove it and use the new C function instead.

I'm not sure what's the policy for catversion bumps, so I included it in the same patch with a note in the commit message.  Therefore there might be some conflict at some point.