### PR TITLE
Ignore any local .psqlrc when running tests.

### DIFF
--- a/src/test/regress/expected/async.out
+++ b/src/test/regress/expected/async.out
@@ -46,7 +46,7 @@ SELECT pg_notification_queue_usage();
 -- end_matchsubs
 \c postgres
 LISTEN notify_async3;
-\! psql postgres -c "notify notify_async3;"
+\! psql postgres -Xc "notify notify_async3;"
 NOTIFY
 SELECT;
 --

--- a/src/test/regress/expected/dboptions.out
+++ b/src/test/regress/expected/dboptions.out
@@ -28,11 +28,11 @@ order by gp_segment_id;
 -- Ensure that the db connection limit is not enforced on the segment. We check
 -- this by ensuring that a multi-slice plan, exceeding the connection limit on
 -- the segment can execute.
-\! psql limitdb -U connlimit_test_user -c 'create table tbl(i int);'
+\! psql limitdb -U connlimit_test_user -Xc 'create table tbl(i int);'
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 CREATE TABLE
-\! psql limitdb -U connlimit_test_user -c 'select count(*) from tbl t1, tbl t2;'
+\! psql limitdb -U connlimit_test_user -Xc 'select count(*) from tbl t1, tbl t2;'
  count 
 -------
      0
@@ -53,7 +53,7 @@ order by gp_segment_id;
 
 alter database limitdb with connection limit 0;
 -- should fail, because the connection limit is 0
-\! psql limitdb -c "select 'connected'" -U connlimit_test_user
+\! psql limitdb -Xc "select 'connected'" -U connlimit_test_user
 psql: error: FATAL:  too many connections for database "limitdb"
 -- Test ALLOW_CONNECTIONS
 create database limitdb2 allow_connections = true;
@@ -83,7 +83,7 @@ order by gp_segment_id;
 (4 rows)
 
 -- should fail, as we have disallowed connections
-\! psql limitdb2 -c "select 'connected'" -U connlimit_test_user
+\! psql limitdb2 -Xc "select 'connected'" -U connlimit_test_user
 psql: error: FATAL:  database "limitdb2" is not currently accepting connections
 -- Test IS_TEMPLATE
 create database templatedb is_template=true;

--- a/src/test/regress/expected/distributed_transactions.out
+++ b/src/test/regress/expected/distributed_transactions.out
@@ -355,7 +355,7 @@ end;
 drop table if exists dtmcurse_foo;
 drop table if exists dtmcurse_bar;
 -- Test distribute transaction if 'COMMIT/END' is included in a multi-queries command.
-\! psql postgres -c "begin;end; create table dtx_test1(c1 int); drop table dtx_test1;"
+\! psql postgres -Xc "begin;end; create table dtx_test1(c1 int); drop table dtx_test1;"
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 DROP TABLE

--- a/src/test/regress/expected/gpsd.out
+++ b/src/test/regress/expected/gpsd.out
@@ -205,7 +205,7 @@ Please review output file to ensure it is within corporate policy to transport t
 drop database gpsd_db_ext_data;
 create database gpsd_db_ext_data;
 -- start_ignore
-\! psql -f data/gpsd_db_ext_data.sql gpsd_db_ext_data
+\! psql -Xf data/gpsd_db_ext_data.sql gpsd_db_ext_data
 SET
 SET
 SET

--- a/src/test/regress/expected/minirepro.out
+++ b/src/test/regress/expected/minirepro.out
@@ -58,7 +58,7 @@ analyze minirepro_foo;
 -- Run minirepro
 drop table minirepro_foo; -- this will also delete the pg_statistic tuples for minirepro_foo and minirepro_foo_1
 -- start_ignore
-\! psql -f data/minirepro.sql regression
+\! psql -Xf data/minirepro.sql regression
 You are now connected to database "regression" as user "pivotal".
 SET
 SET
@@ -143,7 +143,7 @@ analyze minirepro_foo;
 -- Run minirepro
 drop table minirepro_foo; -- this will also delete the pg_statistic tuples for minirepro_foo and minirepro_foo_1
 -- start_ignore
-\! psql -f data/minirepro.sql regression
+\! psql -Xf data/minirepro.sql regression
 You are now connected to database "regression" as user "pivotal".
 SET
 SET
@@ -230,7 +230,7 @@ update pg_statistic set stavalues3='{"hello", "''world''"}'::text[] where starel
 -- Run minirepro
 drop table minirepro_foo; -- this should also delete the pg_statistic tuple for minirepro_foo
 -- start_ignore
-\! psql -f data/minirepro.sql regression
+\! psql -Xf data/minirepro.sql regression
 You are now connected to database "regression" as user "pivotal".
 SET
 SET
@@ -274,7 +274,7 @@ drop table minirepro_foo;
 -- corresponding to pg_tablespace before it re-inserts it, which may lead to
 -- corrupted stats for pg_tablespace. But, that shouldn't matter too much?
 -- start_ignore
-\! psql -f data/minirepro.sql regression
+\! psql -Xf data/minirepro.sql regression
 You are now connected to database "regression" as user "pivotal".
 SET
 SET
@@ -413,7 +413,7 @@ Please review output file to ensure it is within corporate policy to transport t
 -- Run minirepro
 drop table minirepro_foo; -- this will also delete the tuples from pg_statistic_ext and pg_statistic_ext_data
 -- start_ignore
-\! psql -f data/minirepro.sql regression
+\! psql -Xf data/minirepro.sql regression
 You are now connected to database "regression" as user "hmaddileti".
 SET
 SET
@@ -606,7 +606,7 @@ Please review output file to ensure it is within corporate policy to transport t
 drop table minirepro_foo;
 drop table minirepro_bar;
 -- start_ignore
-\! psql -f data/minirepro.sql regression
+\! psql -Xf data/minirepro.sql regression
 You are now connected to database "regression" as user "hmaddileti".
 SET
 SET

--- a/src/test/regress/input/createdb.source
+++ b/src/test/regress/input/createdb.source
@@ -22,9 +22,9 @@ select force_mirrors_to_catch_up();
 select count(*)=0 as result from
   (select db_dirs(oid) from pg_database where datname = 'dowell') as foo;
 
-\! psql -d dowell -c "create table test1(a int, b text)"
-\! psql -d dowell -c "insert into test1 values (1, '111'), (2, '222'), (3, '333')"
-\! psql -d dowell -c "select * from test1" 
+\! psql -d dowell -Xc "create table test1(a int, b text)"
+\! psql -d dowell -Xc "insert into test1 values (1, '111'), (2, '222'), (3, '333')"
+\! psql -d dowell -Xc "select * from test1" 
 
 drop database dowell;
 

--- a/src/test/regress/output/createdb.source
+++ b/src/test/regress/output/createdb.source
@@ -34,13 +34,13 @@ select count(*)=0 as result from
  f
 (1 row)
 
-\! psql -d dowell -c "create table test1(a int, b text)"
+\! psql -d dowell -Xc "create table test1(a int, b text)"
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 CREATE TABLE
-\! psql -d dowell -c "insert into test1 values (1, '111'), (2, '222'), (3, '333')"
+\! psql -d dowell -Xc "insert into test1 values (1, '111'), (2, '222'), (3, '333')"
 INSERT 0 3
-\! psql -d dowell -c "select * from test1" 
+\! psql -d dowell -Xc "select * from test1" 
  a |  b  
 ---+-----
  2 | 222

--- a/src/test/regress/sql/async.sql
+++ b/src/test/regress/sql/async.sql
@@ -28,6 +28,6 @@ SELECT pg_notification_queue_usage();
 -- end_matchsubs
 \c postgres
 LISTEN notify_async3;
-\! psql postgres -c "notify notify_async3;"
+\! psql postgres -Xc "notify notify_async3;"
 SELECT;
 \c -

--- a/src/test/regress/sql/dboptions.sql
+++ b/src/test/regress/sql/dboptions.sql
@@ -19,8 +19,8 @@ order by gp_segment_id;
 -- Ensure that the db connection limit is not enforced on the segment. We check
 -- this by ensuring that a multi-slice plan, exceeding the connection limit on
 -- the segment can execute.
-\! psql limitdb -U connlimit_test_user -c 'create table tbl(i int);'
-\! psql limitdb -U connlimit_test_user -c 'select count(*) from tbl t1, tbl t2;'
+\! psql limitdb -U connlimit_test_user -Xc 'create table tbl(i int);'
+\! psql limitdb -U connlimit_test_user -Xc 'select count(*) from tbl t1, tbl t2;'
 
 alter database limitdb connection limit 2;
 select -1 as gp_segment_id, datconnlimit from pg_database where datname='limitdb'
@@ -31,7 +31,7 @@ order by gp_segment_id;
 alter database limitdb with connection limit 0;
 
 -- should fail, because the connection limit is 0
-\! psql limitdb -c "select 'connected'" -U connlimit_test_user
+\! psql limitdb -Xc "select 'connected'" -U connlimit_test_user
 
 -- Test ALLOW_CONNECTIONS
 create database limitdb2 allow_connections = true;
@@ -47,7 +47,7 @@ select gp_segment_id, datconnlimit, datallowconn from gp_dist_random('pg_databas
 order by gp_segment_id;
 
 -- should fail, as we have disallowed connections
-\! psql limitdb2 -c "select 'connected'" -U connlimit_test_user
+\! psql limitdb2 -Xc "select 'connected'" -U connlimit_test_user
 
 -- Test IS_TEMPLATE
 create database templatedb is_template=true;

--- a/src/test/regress/sql/distributed_transactions.sql
+++ b/src/test/regress/sql/distributed_transactions.sql
@@ -299,7 +299,7 @@ drop table if exists dtmcurse_foo;
 drop table if exists dtmcurse_bar;
 
 -- Test distribute transaction if 'COMMIT/END' is included in a multi-queries command.
-\! psql postgres -c "begin;end; create table dtx_test1(c1 int); drop table dtx_test1;"
+\! psql postgres -Xc "begin;end; create table dtx_test1(c1 int); drop table dtx_test1;"
 
 -- Test two phase commit for extended query
 \! ./twophase_pqexecparams dbname=regression

--- a/src/test/regress/sql/gpsd.sql
+++ b/src/test/regress/sql/gpsd.sql
@@ -39,7 +39,7 @@ drop database gpsd_db_without_hll;
 create database gpsd_db_without_hll;
 
 -- start_ignore
-\! psql -f data/gpsd-without-hll.sql gpsd_db_without_hll
+\! psql -Xf data/gpsd-without-hll.sql gpsd_db_without_hll
 -- end_ignore
 \c gpsd_db_without_hll
 
@@ -105,7 +105,7 @@ drop database gpsd_db_with_hll;
 create database gpsd_db_with_hll;
 
 -- start_ignore
-\! psql -f data/gpsd-with-hll.sql gpsd_db_with_hll
+\! psql -Xf data/gpsd-with-hll.sql gpsd_db_with_hll
 -- end_ignore
 \c gpsd_db_with_hll
 
@@ -172,7 +172,7 @@ drop database gpsd_db_ext_data;
 create database gpsd_db_ext_data;
 
 -- start_ignore
-\! psql -f data/gpsd_db_ext_data.sql gpsd_db_ext_data
+\! psql -Xf data/gpsd_db_ext_data.sql gpsd_db_ext_data
 -- end_ignore
 \c gpsd_db_ext_data
 

--- a/src/test/regress/sql/minirepro.sql
+++ b/src/test/regress/sql/minirepro.sql
@@ -27,7 +27,7 @@ analyze minirepro_foo;
 drop table minirepro_foo; -- this will also delete the pg_statistic tuples for minirepro_foo and minirepro_foo_1
 
 -- start_ignore
-\! psql -f data/minirepro.sql regression
+\! psql -Xf data/minirepro.sql regression
 -- end_ignore
 
 select
@@ -86,7 +86,7 @@ analyze minirepro_foo;
 drop table minirepro_foo; -- this will also delete the pg_statistic tuples for minirepro_foo and minirepro_foo_1
 
 -- start_ignore
-\! psql -f data/minirepro.sql regression
+\! psql -Xf data/minirepro.sql regression
 -- end_ignore
 
 select
@@ -148,7 +148,7 @@ update pg_statistic set stavalues3='{"hello", "''world''"}'::text[] where starel
 drop table minirepro_foo; -- this should also delete the pg_statistic tuple for minirepro_foo
 
 -- start_ignore
-\! psql -f data/minirepro.sql regression
+\! psql -Xf data/minirepro.sql regression
 -- end_ignore
 
 select stavalues3 from pg_statistic where starelid='minirepro_foo'::regclass;
@@ -173,7 +173,7 @@ drop table minirepro_foo;
 -- corrupted stats for pg_tablespace. But, that shouldn't matter too much?
 
 -- start_ignore
-\! psql -f data/minirepro.sql regression
+\! psql -Xf data/minirepro.sql regression
 -- end_ignore
 
 select
@@ -237,7 +237,7 @@ analyze minirepro_foo;
 drop table minirepro_foo; -- this will also delete the tuples from pg_statistic_ext and pg_statistic_ext_data
 
 -- start_ignore
-\! psql -f data/minirepro.sql regression
+\! psql -Xf data/minirepro.sql regression
 -- end_ignore
 
 -- Verify that correlated stats are updated
@@ -281,7 +281,7 @@ drop table minirepro_foo;
 drop table minirepro_bar;
 
 -- start_ignore
-\! psql -f data/minirepro.sql regression
+\! psql -Xf data/minirepro.sql regression
 -- end_ignore
 
 -- Verify that correlated stats are updated


### PR DESCRIPTION
Some regression tests rely on invoking psql, but by default the output will depend on what users configured in their local .psqlrc file.  To avoid that add an extra -X (--no-psqlrc) option to all psql invokation.