### PR TITLE
[7x] starting segments in execute mode post recovery

### DIFF
--- a/gpMgmt/sbin/gpsegrecovery.py
+++ b/gpMgmt/sbin/gpsegrecovery.py
@@ -292,7 +292,7 @@ def start_segment(recovery_info, logger, era):
         , numContentsInCluster=0
         , era=era
         , mirrormode="mirror"
-        , utilityMode=True)
+        , utilityMode=False)
     logger.info(str(cmd))
     cmd.run(validateAfter=True)
 

--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -10,6 +10,7 @@ Feature: gprecoverseg tests
          Then gprecoverseg should return a return code of 0
           And the segments are synchronized
           And the tablespace is valid
+          And the database segments are in execute mode
 
         Given another tablespace is created with data
          When the user runs "gprecoverseg -ra"
@@ -17,6 +18,7 @@ Feature: gprecoverseg tests
           And the segments are synchronized
           And the tablespace is valid
           And the other tablespace is valid
+          And the database segments are in execute mode
       Examples:
         | scenario     | args               |
         | incremental  | -a                 |
@@ -516,6 +518,7 @@ Feature: gprecoverseg tests
     Then gprecoverseg should return a return code of 0
     And the segments are synchronized
     And the tablespace is valid
+    And the database segments are in execute mode
 
     Given another tablespace is created with data
     When the user runs "gprecoverseg -ra"
@@ -523,6 +526,7 @@ Feature: gprecoverseg tests
     And the segments are synchronized
     And the tablespace is valid
     And the other tablespace is valid
+    And the database segments are in execute mode
 
     Examples:
         | scenario     | args               |

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -3984,3 +3984,31 @@ def impl(context):
         for pid in host_to_pid_map[host]:
             if unix.check_pid_on_remotehost(pid, host):
                 raise Exception("Postgres process {0} not killed on {1}.".format(pid, host))
+
+
+@then('the database segments are in execute mode')
+def impl(context):
+    # Get all up segments details except coordinator/standby
+    with closing(dbconn.connect(dbconn.DbURL(), unsetSearchPath=False)) as conn:
+        sql = "SELECT dbid, hostname, port  FROM gp_segment_configuration WHERE content > -1 and status = 'u'"
+        rows = dbconn.query(conn, sql).fetchall()
+
+        if len(rows) <= 0:
+            raise Exception("Found no entries in gp_segment_configuration table")
+    # Check for each segment if the process is in
+    for row in rows:
+        dbid = row[0]
+        hostname = row[1].strip()
+        portnum = row[2]
+        cmd = "psql -d template1 -p {0} -h {1} -c \";\"".format(portnum, hostname)
+        run_command(context, cmd)
+        # If node is in execute mode, psql shoud return 2 and the print one of the following error message:
+        # For a primary segment: "psql: error: FATAL:  connections to primary segments are not allowed"
+        # For a mirror segment: "FATAL:  the database system is in recovery mode"
+        if context.ret_code == 2 and \
+        ("FATAL:  connections to primary segments are not allowed" in context.error_message or
+         "FATAL:  the database system is in recovery mode" in context.error_message):
+            continue
+        else:
+            context.stdout_message
+            raise Exception("segment process not running in execute mode for DBID:{0}".format(dbid))

--- a/gpMgmt/test/behave/mgmt_utils/steps/tablespace_mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/tablespace_mgmt_utils.py
@@ -197,7 +197,6 @@ def impl(context):
 def impl(context):
     context.tablespaces["myspace"].verify()
 
-
 @then('the tablespace is valid after gpexpand')
 def impl(context):
     for _, tbs in list(context.tablespaces.items()):


### PR DESCRIPTION
After recovery, the segment should start in execute mode. Currently, after the recovery using gprecoverseg starts the segment in utility mode. With these changes made sure the segment is started in execute mode. Also added tests to confirm segments are in execute mode after recovery.
Also, updated existing test cases to add a check for execute mode. 
Currently this PR checks for execute mode by connecting to segment using sql and parsing the error thrown.

Before recovery output of PS command: 
```
/usr/local/gpdb/bin/postgres -D /datadatadirs/dbfast2/demoDataDir1 -c gp_role=execute
```

After recovery without changes: 
```
/usr/local/gpdb/bin/postgres -D /datadatadirs/dbfast2/demoDataDir1 -c gp_role=utility
```

After recovery with current changes: 
```
/usr/local/gpdb/bin/postgres -D /datadatadirs/dbfast2/demoDataDir1 -c gp_role=execute
```

Manual Testing Done: 
 - Ran incremental recovery on a segment and checked status of the segment 
 - Moved mirror from current host to a new host
 - Coordinator/standby goes down

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
