### PR TITLE
[6X Backport] gpstate -e: Fix gprecoverseg progress reporting

### DIFF
--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -1616,6 +1616,21 @@ def createTempDirectoryName(masterDataDirectory, tempDirPrefix):
                                 datetime.datetime.now().strftime('%m%d%Y'),
                                 os.getpid())
 
+"""
+Check if gprecoverseg process is running or not by
+reading the PID file inside gprecoverseg.lock directory.
+Returns True if the process is running or False otherwise.
+"""
+def is_gprecoverseg_running():
+    gprecoverseg_pidfile = os.path.join(get_masterdatadir(), 'gprecoverseg.lock', 'PID')
+    try:
+        with open(gprecoverseg_pidfile) as pidfile:
+            gprecoverseg_pid = pidfile.read()
+    except Exception:
+        return False
+
+    return check_pid(gprecoverseg_pid)
+
 #-------------------------------------------------------------------------
 class GpRecoverSeg(Command):
    """

--- a/gpMgmt/bin/gppylib/commands/test/unit/test_unit_gp.py
+++ b/gpMgmt/bin/gppylib/commands/test/unit/test_unit_gp.py
@@ -4,9 +4,9 @@
 #
 
 from gppylib.commands.base import CommandResult
-from mock import patch
+from mock import patch, mock_open
 
-from gppylib.commands.gp import is_pid_postmaster, get_postmaster_pid_locally, get_postgres_segment_processes
+from gppylib.commands.gp import is_pid_postmaster, get_postmaster_pid_locally, get_postgres_segment_processes, is_gprecoverseg_running
 from test.unit.gp_unittest import GpTestCase, run_tests
 
 
@@ -183,6 +183,22 @@ class GpCommandTestCase(GpTestCase):
     def test_get_postgres_segment_processes_when_pgrep_fails(self, mock1, mock2, mock3):
         result = get_postgres_segment_processes('/data/primary/gpseg0', 'sdw1')
         self.assertEqual(result, [1234])
+
+    @patch('gppylib.commands.gp.check_pid', return_value=True)
+    @patch('gppylib.commands.gp.get_masterdatadir')
+    @patch("__builtin__.open", new_callable=mock_open, read_data="123")
+    def test_is_gprecoverseg_running_succeeds(self, mock_file, mock1, mock2):
+        result = is_gprecoverseg_running()
+        mock2.assert_called_once_with('123')
+        self.assertTrue(result)
+
+    @patch('gppylib.commands.gp.check_pid')
+    @patch('gppylib.commands.gp.get_masterdatadir', return_value='/invalid/path/')
+    def test_is_gprecoverseg_running_when_pidfile_does_not_exists(self, mock1, mock2):
+        result = is_gprecoverseg_running()
+        self.assertFalse(result)
+        self.assertFalse(mock2.called)
+
 
 if __name__ == '__main__':
     run_tests()

--- a/gpMgmt/bin/gppylib/programs/clsSystemState.py
+++ b/gpMgmt/bin/gppylib/programs/clsSystemState.py
@@ -683,14 +683,18 @@ class GpSystemStateProgram:
 
         self.__addClusterDownWarning(gpArray, data)
 
-        recovery_progress_file = get_recovery_progress_file(gplog)
-        recovery_progress_segs = self._parse_recovery_progress_data(data, recovery_progress_file, gpArray)
-        if recovery_progress_segs:
-            logger.info("----------------------------------------------------")
-            logger.info("Segments in recovery")
-            logSegments(recovery_progress_segs, False, [VALUE_RECOVERY_TYPE, VALUE_RECOVERY_COMPLETED_BYTES, VALUE_RECOVERY_TOTAL_BYTES,
-                                                          VALUE_RECOVERY_PERCENTAGE])
-            exitCode = 1
+        # Check if gprecoverseg process is running. We do not want to
+        # show the progress if the gprecoverseg process is not running.
+        if gp.is_gprecoverseg_running():
+            recovery_progress_file = get_recovery_progress_file(gplog)
+            segments_under_recovery = self._parse_recovery_progress_data(data, recovery_progress_file, gpArray)
+
+            if segments_under_recovery:
+                logger.info("----------------------------------------------------")
+                logger.info("Segments in recovery")
+                logSegments(segments_under_recovery, False, [VALUE_RECOVERY_TYPE, VALUE_RECOVERY_COMPLETED_BYTES, VALUE_RECOVERY_TOTAL_BYTES,
+                                                            VALUE_RECOVERY_PERCENTAGE])
+                exitCode = 1
 
         # final output -- no errors, then log this message
         if exitCode == 0:

--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -601,6 +601,8 @@ Feature: gprecoverseg tests
     And user can start transactions
     And all files in gpAdminLogs directory are deleted on all hosts in the cluster
     And a sample recovery_progress.file is created from saved lines
+    And we run a sample background script to generate a pid on "master" segment
+    Then a sample gprecoverseg.lock directory is created using the background pid in master_data_directory
     When the user runs "gpstate -e"
     Then gpstate should print "Segments in recovery" to stdout
 #    And gpstate output contains "incremental,incremental,incremental" entries for mirrors of content 0,1,2
@@ -610,6 +612,8 @@ Feature: gprecoverseg tests
 #      | \S+     | [0-9]+ | incremental    | [0-9]+                 | [0-9]+             | [0-9]+\%             |
 #      | \S+     | [0-9]+ | incremental    | [0-9]+                 | [0-9]+             | [0-9]+\%             |
     And all files in gpAdminLogs directory are deleted on all hosts in the cluster
+    And the background pid is killed on "master" segment
+    Then the gprecoverseg lock directory is removed
 
     And the cluster is rebalanced
     And user immediately stops all primary processes for content 0,1,2
@@ -619,17 +623,14 @@ Feature: gprecoverseg tests
     And the user suspend the walsender on the primary on content 0
     Then the user waits until recovery_progress.file is created in gpAdminLogs and verifies its format
     And verify that lines from recovery_progress.file are present in segment progress files in gpAdminLogs
-
+    When the user runs "gpstate -e"
+    Then gpstate should print "Segments in recovery" to stdout
     And the user reset the walsender on the primary on content 0
     And the user waits until saved async process is completed
     And recovery_progress.file should not exist in gpAdminLogs
     And an FTS probe is triggered
     And the user waits until mirror on content 0,1,2 is up
     And user can start transactions
-
-    And a sample recovery_progress.file is created from saved lines
-    When the user runs "gpstate -e"
-    Then gpstate should print "Segments in recovery" to stdout
     And all files in gpAdminLogs directory are deleted on all hosts in the cluster
 
   @demo_cluster
@@ -720,6 +721,32 @@ Feature: gprecoverseg tests
     And an FTS probe is triggered
     And the user waits until mirror on content 0,1,2 is up
     And verify that lines from recovery_progress.file are present in segment progress files in gpAdminLogs
+    And the cluster is rebalanced
+
+
+  @demo_cluster
+  @concourse_cluster
+  Scenario:  SIGHUP on gprecoverseg should not display progress in gpstate -e
+    Given the database is running
+    And all the segments are running
+    And the segments are synchronized
+    And all files in gpAdminLogs directory are deleted on all hosts in the cluster
+    And user immediately stops all primary processes for content 0,1,2
+    And user can start transactions
+    And sql "DROP TABLE IF EXISTS test_recoverseg; CREATE TABLE test_recoverseg AS SELECT generate_series(1,100000000) AS a;" is executed in "postgres" db
+    And the user suspend the walsender on the primary on content 0
+    When the user asynchronously runs "gprecoverseg -aF" and the process is saved
+    Then the user waits until recovery_progress.file is created in gpAdminLogs and verifies its format
+    Then verify if the gprecoverseg.lock directory is present in master_data_directory
+    When the user runs "gpstate -e"
+    Then gpstate should print "Segments in recovery" to stdout
+    When the user asynchronously sets up to end gprecoverseg process with SIGHUP
+    And the user waits until saved async process is completed
+    When the user runs "gpstate -e"
+    Then gpstate should not print "Segments in recovery" to stdout
+    Then the user reset the walsender on the primary on content 0
+    And the user waits until mirror on content 0,1,2 is up
+    And the gprecoverseg lock directory is removed
     And the cluster is rebalanced
 
   @demo_cluster

--- a/gpMgmt/test/behave/mgmt_utils/gpstate.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpstate.feature
@@ -160,6 +160,8 @@ Feature: gpstate tests
         Given a standard local demo cluster is running
         Given all files in gpAdminLogs directory are deleted
         And a sample recovery_progress.file is created with ongoing recoveries in gpAdminLogs
+        And we run a sample background script to generate a pid on "master" segment
+        And a sample gprecoverseg.lock directory is created using the background pid in master_data_directory
         When the user runs "gpstate -e"
         Then gpstate should print "Segments in recovery" to stdout
         And gpstate output contains "full,incremental" entries for mirrors of content 0,1
@@ -168,11 +170,15 @@ Feature: gpstate tests
             | \S+     | [0-9]+ | full           | 1164848                | 1371715            | 84%                  |
             | \S+     | [0-9]+ | incremental    | 1                      | 1371875            | 1%                   |
         And all files in gpAdminLogs directory are deleted
+        And the background pid is killed on "master" segment
+        And the gprecoverseg lock directory is removed
 
     Scenario: gpstate -e does not show information about segments with completed recovery
         Given a standard local demo cluster is running
         Given all files in gpAdminLogs directory are deleted
         And a sample recovery_progress.file is created with completed recoveries in gpAdminLogs
+        And we run a sample background script to generate a pid on "master" segment
+        And a sample gprecoverseg.lock directory is created using the background pid in master_data_directory
         When the user runs "gpstate -e"
         Then gpstate should print "Segments in recovery" to stdout
         And gpstate output contains "full" entries for mirrors of content 1
@@ -182,6 +188,8 @@ Feature: gpstate tests
         And gpstate should not print "incremental" to stdout
         And gpstate should not print "All segments are running normally" to stdout
         And all files in gpAdminLogs directory are deleted
+        And the background pid is killed on "master" segment
+        And the gprecoverseg lock directory is removed
 
     Scenario: gpstate -c logs cluster info for a mirrored cluster
         Given a standard local demo cluster is running

--- a/gpMgmt/test/behave/mgmt_utils/steps/data/pid_background_script.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/data/pid_background_script.py
@@ -2,11 +2,18 @@
 
 import time
 import signal
+import os
+import sys
 
 signal.signal(signal.SIGTERM, signal.SIG_IGN)
 signal.signal(signal.SIGHUP, signal.SIG_IGN)
 signal.signal(signal.SIGINT, signal.SIG_IGN)
 signal.signal(signal.SIGPIPE, signal.SIG_IGN)
+
+with open(sys.argv[1], "w") as f:
+    f.write(str(os.getpid()) + "\n")
+    f.flush()
+    os.fsync(f.fileno())
 
 while True:
    time.sleep(1)

--- a/gpMgmt/test/behave/mgmt_utils/steps/gpstate_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/gpstate_utils.py
@@ -5,6 +5,7 @@ import re
 from gppylib.db import dbconn
 from gppylib.gparray import GpArray, ROLE_MIRROR
 from test.behave_utils.utils import check_stdout_msg, check_string_not_present_stdout
+from gppylib.commands.gp import get_masterdatadir
 
 @then('a sample recovery_progress.file is created from saved lines')
 def impl(context):
@@ -16,6 +17,18 @@ def impl(context):
     with open('{}/gpAdminLogs/recovery_progress.file'.format(os.path.expanduser("~")), 'w+') as fp:
         fp.write("full:5: 1164848/1371715 kB (84%), 0/1 tablespace (...t1/demoDataDir0/base/16384/40962)\n")
         fp.write("incremental:6: 1/1371875 kB (1%)")
+
+@then('a sample gprecoverseg.lock directory is created using the background pid in master_data_directory')
+@given('a sample gprecoverseg.lock directory is created using the background pid in master_data_directory')
+def impl(context):
+    bg_pid = context.bg_pid
+    gprecoverseg_lock_dir = os.path.join(get_masterdatadir() + '/gprecoverseg.lock')
+    os.mkdir(gprecoverseg_lock_dir)
+
+    gprecoverseg_pidfile = os.path.join(gprecoverseg_lock_dir, 'PID')
+
+    with open(gprecoverseg_pidfile, 'w') as f:
+        f.write(bg_pid)
 
 @given('a sample recovery_progress.file is created with completed recoveries in gpAdminLogs')
 def impl(context):


### PR DESCRIPTION
This is a backport of https://github.com/greenplum-db/gpdb/pull/15359

**Issue:**
Currently, `gpstate -e` may sometimes display incorrect or stalled progress for `gprecoverseg` when the main `gprecoverseg` process is terminated or interrupted (e.g. due to SSH disconnections).

**RCA:**
This happens because `gpstate -e` depends on `recovery_progress.file` to show progress to the user. However, when the main `gprecoverseg` process is terminated, this file is no longer updated and is not cleaned up, resulting in stalled or incorrect progress. A fix was attempted for a similar issue in https://github.com/greenplum-db/gpdb/pull/13412, but it required the user to manually remove the `gprecoverseg.lock` directory.

**Fix:**
This commit resolves the issue by checking whether the main `gprecoverseg` process is running or not (by reading the PID from `gprecoverseg.lock` and checking its status) before displaying progress. As a result, `gpstate` will not show any progress if `gprecoverseg` is not running.

**Testing:**
- Modified the behave test cases introduced in https://github.com/greenplum-db/gpdb/pull/13412, so that a dummy process is created whose `PID` is used to create a sample `gprecoverseg.lock` directory for testing.
- Added unit test cases for `is_gprecoverseg_running` function.

[Pipeline](https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb-dev-6x_gpstate_gprecoverseg_incorrect_progress_fix-rocky8)

**Limitations:**
Right now when the gprecoverseg main process is terminated, it leaves behind the orphaned pg_rewind/pg_basebackup processes which continue to run in the background. This progress would not be visible to the users through gpstate. This will be taken care by another PR, where we will also terminate these orphaned processes whenever the main process is terminated.