### PR TITLE
Reduce vac threshold for av-ao-aux test

### DIFF
--- a/src/test/regress/expected/autovacuum-ao-aux.out
+++ b/src/test/regress/expected/autovacuum-ao-aux.out
@@ -5,6 +5,7 @@ CREATE DATABASE av_ao_aux;
 CREATE EXTENSION gp_inject_fault;
 -- speed up test
 ALTER SYSTEM SET autovacuum_naptime = 5;
+ALTER SYSTEM SET autovacuum_vacuum_threshold = 50;
 ALTER SYSTEM SET gp_autovacuum_scope = catalog_ao_aux;
 -- start_ignore
 \! gpstop -u;
@@ -81,6 +82,7 @@ from tableNameCTE, gp_segment_configuration where role = 'p' and content != -1;
 (3 rows)
 
 ALTER SYSTEM RESET autovacuum_naptime;
+ALTER SYSTEM RESET autovacuum_vacuum_threshold;
 ALTER SYSTEM RESET gp_autovacuum_scope;
 -- start_ignore
 \! gpstop -u;

--- a/src/test/regress/sql/autovacuum-ao-aux.sql
+++ b/src/test/regress/sql/autovacuum-ao-aux.sql
@@ -7,6 +7,7 @@ CREATE EXTENSION gp_inject_fault;
 
 -- speed up test
 ALTER SYSTEM SET autovacuum_naptime = 5;
+ALTER SYSTEM SET autovacuum_vacuum_threshold = 50;
 ALTER SYSTEM SET gp_autovacuum_scope = catalog_ao_aux;
 -- start_ignore
 \! gpstop -u;
@@ -54,6 +55,7 @@ SELECT gp_inject_fault('auto_vac_worker_after_report_activity', 'reset', dbid)
 from tableNameCTE, gp_segment_configuration where role = 'p' and content != -1;
 
 ALTER SYSTEM RESET autovacuum_naptime;
+ALTER SYSTEM RESET autovacuum_vacuum_threshold;
 ALTER SYSTEM RESET gp_autovacuum_scope;
 -- start_ignore
 \! gpstop -u;


### PR DESCRIPTION
7dbd59be34a2892143fe8911cc4a23e5324fbb10 increased the autovacuum_vacuum_threshold default from 50 to 500 and reduced the autovacuum_vacuum_scale_factor from 0.2 to 0.05. This resulted in the auto_vac_worker_after_report_activity not being triggered for autovacuum-ao-aux regress test.

Adjust autovacuum_vacuum_threshold for the test to ensure the fault is triggered.
