### PR TITLE
add pg_upgrade --skip-checks flag

### DIFF
--- a/src/bin/pg_upgrade/check.c
+++ b/src/bin/pg_upgrade/check.c
@@ -89,10 +89,16 @@ check_and_dump_old_cluster(bool live_check, char **sequence_script_file_name)
 	/* Extract a list of databases and tables from the old cluster */
 	get_db_and_rel_infos(&old_cluster);
 
+	if (skip_checks())
+	{
+		prep_status("Skipping Consistency Checks");
+		check_ok();
+		goto dump_old_cluster;
+	}
+
 	init_tablespaces();
 
 	get_loadable_libraries();
-
 
 	/*
 	 * Check for various failure cases
@@ -167,6 +173,7 @@ check_and_dump_old_cluster(bool live_check, char **sequence_script_file_name)
 		check_for_appendonly_materialized_view_with_relfrozenxid(&old_cluster);
 	}
 
+dump_old_cluster:
 	/*
 	 * While not a check option, we do this now because this is the only time
 	 * the old server is running.

--- a/src/bin/pg_upgrade/greenplum/option_gp.c
+++ b/src/bin/pg_upgrade/greenplum/option_gp.c
@@ -11,6 +11,7 @@ typedef struct {
 	segmentMode segment_mode;
 	bool continue_check_on_fatal;
 	bool skip_target_check;
+	bool skip_checks;
 } GreenplumUserOpts;
 
 static GreenplumUserOpts greenplum_user_opts;
@@ -22,6 +23,7 @@ initialize_greenplum_user_options(void)
 	greenplum_user_opts.segment_mode = SEGMENT;
 	greenplum_user_opts.continue_check_on_fatal = false;
 	greenplum_user_opts.skip_target_check = false;
+	greenplum_user_opts.skip_checks = false;
 }
 
 bool
@@ -70,6 +72,10 @@ process_greenplum_option(greenplumOption option)
 			}
 			break;
 
+		case GREENPLUM_SKIP_CHECKS:
+			greenplum_user_opts.skip_checks = true;
+			break;
+
 		default:
 			return false;
 	}
@@ -111,4 +117,10 @@ bool
 is_skip_target_check(void)
 {
 	return greenplum_user_opts.skip_target_check;
+}
+
+bool
+skip_checks(void)
+{
+	return greenplum_user_opts.skip_checks;
 }

--- a/src/bin/pg_upgrade/greenplum/pg_upgrade_greenplum.h
+++ b/src/bin/pg_upgrade/greenplum/pg_upgrade_greenplum.h
@@ -35,20 +35,23 @@ typedef enum {
 	GREENPLUM_MODE_OPTION = 10,
 	GREENPLUM_PROGRESS_OPTION = 11,
 	GREENPLUM_CONTINUE_CHECK_ON_FATAL = 12,
-	GREENPLUM_SKIP_TARGET_CHECK = 13
+	GREENPLUM_SKIP_TARGET_CHECK = 13,
+	GREENPLUM_SKIP_CHECKS = 14
 } greenplumOption;
 
 #define GREENPLUM_OPTIONS \
 	{"mode", required_argument, NULL, GREENPLUM_MODE_OPTION}, \
 	{"progress", no_argument, NULL, GREENPLUM_PROGRESS_OPTION}, \
 	{"continue-check-on-fatal", no_argument, NULL, GREENPLUM_CONTINUE_CHECK_ON_FATAL}, \
-	{"skip-target-check", no_argument, NULL, GREENPLUM_SKIP_TARGET_CHECK},
+	{"skip-target-check", no_argument, NULL, GREENPLUM_SKIP_TARGET_CHECK}, \
+	{"skip-checks", no_argument, NULL, GREENPLUM_SKIP_CHECKS},
 
 #define GREENPLUM_USAGE "\
       --mode=TYPE               designate node type to upgrade, \"segment\" or \"dispatcher\" (default \"segment\")\n\
       --progress                enable progress reporting\n\
       --continue-check-on-fatal continue to run through all pg_upgrade checks without upgrade. Stops on major issues\n\
       --skip-target-check       skip all checks on new/target cluster\n\
+      --skip-checks             skip all checks\n\
 "
 
 /* option_gp.c */
@@ -60,6 +63,7 @@ bool is_continue_check_on_fatal(void);
 void set_check_fatal_occured(void);
 bool get_check_fatal_occurred(void);
 bool is_skip_target_check(void);
+bool skip_checks(void);
 
 /* pg_upgrade_greenplum.c */
 void freeze_master_data(void);

--- a/src/bin/pg_upgrade/pg_upgrade.c
+++ b/src/bin/pg_upgrade/pg_upgrade.c
@@ -149,7 +149,7 @@ main(int argc, char **argv)
 
 	/* -- NEW -- */
 
-	if(!is_skip_target_check())
+	if(!is_skip_target_check() || !skip_checks())
 	{
 		start_postmaster(&new_cluster, true);
 		check_new_cluster();


### PR DESCRIPTION
Since pg_upgrade checks can take a long time add --skip-checks. This is useful for internal testing to reduce the feedback cycle.

The skip was implemented using a label to reduce the amount of diffs for upstream merges.

6X: https://github.com/greenplum-db/gpdb/pull/15604
Pipeline: https://cm.ci.gpdb.pivotal.io/teams/main/pipelines/upgrade-skip-checks_7X