### PR TITLE
Make it PANIC when the interconnect peer binding failed due to port used

### DIFF
--- a/src/backend/cdb/motion/ic_proxy_main.c
+++ b/src/backend/cdb/motion/ic_proxy_main.c
@@ -193,7 +193,7 @@ ic_proxy_server_peer_listener_init(uv_loop_t *loop)
 	ret = uv_tcp_bind(listener, (struct sockaddr *) &addr->sockaddr, 0);
 	if (ret < 0)
 	{
-		elog(WARNING, "ic-proxy: tcp: fail to bind: %s",
+		elog(PANIC, "ic-proxy: tcp: fail to bind: %s",
 					 uv_strerror(ret));
 		return;
 	}
@@ -202,7 +202,7 @@ ic_proxy_server_peer_listener_init(uv_loop_t *loop)
 					IC_PROXY_BACKLOG, ic_proxy_server_on_new_peer);
 	if (ret < 0)
 	{
-		elog(WARNING, "ic-proxy: tcp: fail to listen: %s",
+		elog(PANIC, "ic-proxy: tcp: fail to listen: %s",
 					 uv_strerror(ret));
 		return;
 	}

--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -434,7 +434,7 @@ static BackgroundWorker PMAuxProcList[MaxPMAuxProc] =
 	 0,
 #endif
 	 BgWorkerStart_RecoveryFinished,
-	 0, /* restart immediately if ic proxy process exits with non-zero code */
+	 BGW_NEVER_RESTART, /* Never restart if ic proxy process exits with non-zero code */
 	 "postgres", "ICProxyMain", 0, {0}, 0,
 	 ICProxyStartRule},
 #endif  /* ENABLE_IC_PROXY */


### PR DESCRIPTION
For the occupied interconnect proxy address port:

- occupy a port which is intend to use:

`$ nc -l 6004`

-  configure the ic proxy addresses:

 

```
$ gpconfig --skipvalidation -c gp_interconnect_proxy_addresses -v "'1:-1:localhost.localdomain:6000,2:0:localhost.localdomain:6002,3:1:localhost.localdomain:6003,4:2:localhost.localdomain:6004'"
$ gpstop -u
```

 

-  got tons of warnings in segment log:

```
dbfast3/demoDataDir2/log/gpdb-2023-05-24_035320.csv:113:2023-05-24 04:18:28.795859 EDT,,,p98191,th-498856384,,,,0,,,seg2,,,,,"WARNING","01000","ic-proxy: tcp: fail to listen: address already in use",,,,,,,0,,"ic_proxy_main.c",206,
dbfast3/demoDataDir2/log/gpdb-2023-05-24_035320.csv:114:2023-05-24 04:18:29.796951 EDT,,,p98191,th-498856384,,,,0,,,seg2,,,,,"WARNING","01000","ic-proxy: tcp: fail to listen: address already in use",,,,,,,0,,"ic_proxy_main.c",206,
dbfast3/demoDataDir2/log/gpdb-2023-05-24_035320.csv:115:2023-05-24 04:18:30.798078 EDT,,,p98191,th-498856384,,,,0,,,seg2,,,,,"WARNING","01000","ic-proxy: tcp: fail to listen: address already in use",,,,,,,0,,"ic_proxy_main.c",206,
dbfast3/demoDataDir2/log/gpdb-2023-05-24_035320.csv:116:2023-05-24 04:18:31.799162 EDT,,,p98191,th-498856384,,,,0,,,seg2,,,,,"WARNING","01000","ic-proxy: tcp: fail to listen: address already in use",,,,,,,0,,"ic_proxy_main.c",206,
dbfast3/demoDataDir2/log/gpdb-2023-05-24_035320.csv:117:2023-05-24 04:18:32.800258 EDT,,,p98191,th-498856384,,,,0,,,seg2,,,,,"WARNING","01000","ic-proxy: tcp: fail to listen: address already in use",,,,,,,0,,"ic_proxy_main.c",206,
dbfast3/demoDataDir2/log/gpdb-2023-05-24_035320.csv:118:2023-05-24 04:18:33.801348 EDT,,,p98191,th-498856384,,,,0,,,seg2,,,,,"WARNING","01000","ic-proxy: tcp: fail to listen: address already in use",,,,,,,0,,"ic_proxy_main.c",206,

```
 

- But it doesn't effect normal query, except that corresponding segment keeps trying to startup but got failed again and again.

 

- Conclusion：we must make the segment error out in case of address port used.


## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
