### PR TITLE
Fix dangling pointer in ExecDynamicIndexScan()

### DIFF
--- a/src/backend/executor/execTuples.c
+++ b/src/backend/executor/execTuples.c
@@ -225,7 +225,17 @@ ExecResetTupleTable(List *tupleTable,	/* tuple table */
 
 		/* If shouldFree, release memory occupied by the slot itself */
 		if (shouldFree)
+		{
+#ifdef USE_ASSERT_CHECKING
+			/*
+			 * Mark the tuple as having been freed before pfree it. So
+			 * we can be aware of error if we try to access the tuple
+			 * later by a dangling pointer.
+			 */
+			TupSetMemFreed(slot);
+#endif
 			pfree(slot);
+		}
 	}
 
 	/* If shouldFree, release the list structure */

--- a/src/backend/executor/nodeDynamicIndexscan.c
+++ b/src/backend/executor/nodeDynamicIndexscan.c
@@ -324,6 +324,12 @@ ExecDynamicIndexScan(DynamicIndexScanState *node)
 		{
 			endCurrentIndexScan(node);
 
+			/*
+			 * After endCurrentIndexScan(), slot should have been released
+			 * if it pointed to an empty tuple.
+			 */
+			slot = NULL;
+
 			node->scan_state = SCAN_INIT;
 		}
 	}

--- a/src/test/regress/expected/qp_gist_indexes4.out
+++ b/src/test/regress/expected/qp_gist_indexes4.out
@@ -897,6 +897,57 @@ EXPLAIN SELECT count(*) FROM gist_tbl, gist_tbl2
 (11 rows)
 
 -- ----------------------------------------------------------------------
+-- Test: test15_dangling_pointer.sql
+-- ----------------------------------------------------------------------
+-- ----------------------------------------------------------------------------
+-- PURPOSE:
+--     This tests if we will hit any dangling pointer in dynamic index scan.
+-- ----------------------------------------------------------------------------
+CREATE TABLE rank (id int, rank int, year int, gender
+        char(1), count int)
+DISTRIBUTED BY (id)
+PARTITION BY RANGE (year)
+( START (2006) END (2016) EVERY (1),
+          DEFAULT PARTITION extra );
+insert into rank
+select i, i, 2005+i%10, 'g', i
+from generate_series(1, 100)i;
+create index idx_year on rank(year);
+create index idx_rank on rank(rank);
+analyze rank;
+set optimizer_enable_dynamictablescan = off;
+set optimizer_enable_bitmapscan = off;
+explain select count(1) from rank where year < 2008 and rank < 50;
+                                                    QUERY PLAN                                                    
+------------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=909.84..909.85 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=909.78..909.83 rows=1 width=8)
+         ->  Aggregate  (cost=909.78..909.79 rows=1 width=8)
+               ->  Append  (cost=300.17..909.74 rows=6 width=0)
+                     ->  Bitmap Heap Scan on rank_1_prt_extra  (cost=300.17..303.23 rows=2 width=0)
+                           Recheck Cond: (rank < 50) 
+                           Filter: (year < 2008)
+                           ->  Bitmap Index Scan on rank_1_prt_extra_rank_idx  (cost=0.00..300.16 rows=2 width=0)                                 Index Cond: (rank < 50)
+                     ->  Bitmap Heap Scan on rank_1_prt_2  (cost=300.17..303.26 rows=2 width=0)
+                           Recheck Cond: (rank < 50)
+                           Filter: (year < 2008)
+                           ->  Bitmap Index Scan on rank_1_prt_2_rank_idx  (cost=0.00..300.17 rows=2 width=0)
+                                 Index Cond: (rank < 50)
+                     ->  Bitmap Heap Scan on rank_1_prt_3  (cost=300.17..303.25 rows=2 width=0)
+                           Recheck Cond: (rank < 50)
+                           Filter: (year < 2008)
+                           ->  Bitmap Index Scan on rank_1_prt_3_rank_idx  (cost=0.00..300.17 rows=2 width=0)
+                                 Index Cond: (rank < 50)
+ Optimizer: Postgres query optimizer 
+(20 rows)
+
+select count(1) from rank where year < 2008 and rank < 50;
+ count 
+-------
+    14
+(1 row)
+
+-- ----------------------------------------------------------------------
 -- Test: teardown.sql
 -- ----------------------------------------------------------------------
 -- start_ignore

--- a/src/test/regress/expected/qp_gist_indexes4_optimizer.out
+++ b/src/test/regress/expected/qp_gist_indexes4_optimizer.out
@@ -870,6 +870,48 @@ EXPLAIN SELECT count(*) FROM gist_tbl, gist_tbl2
 (11 rows)
 
 -- ----------------------------------------------------------------------
+-- Test: test15_dangling_pointer.sql
+-- ----------------------------------------------------------------------
+-- ----------------------------------------------------------------------------
+-- PURPOSE:
+--     This tests if we will hit any dangling pointer in dynamic index scan.
+-- ----------------------------------------------------------------------------
+CREATE TABLE rank (id int, rank int, year int, gender
+        char(1), count int)
+DISTRIBUTED BY (id)
+PARTITION BY RANGE (year)
+( START (2006) END (2016) EVERY (1),
+          DEFAULT PARTITION extra );
+insert into rank
+select i, i, 2005+i%10, 'g', i
+from generate_series(1, 100)i;
+create index idx_year on rank(year);
+create index idx_rank on rank(rank);
+analyze rank;
+set optimizer_enable_dynamictablescan = off;
+set optimizer_enable_bitmapscan = off;
+explain select count(1) from rank where year < 2008 and rank < 50;
+                                                   QUERY PLAN
+----------------------------------------------------------------------------------------------------------------
+ Aggregate  (cost=0.00..6.00 rows=1 width=8)
+   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..6.00 rows=1 width=8)
+         ->  Aggregate  (cost=0.00..6.00 rows=1 width=8)
+               ->  Sequence  (cost=0.00..6.00 rows=5 width=1)
+                     ->  Partition Selector for rank (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
+                           Partitions selected: 3 (out of 11)
+                     ->  Dynamic Index Scan on rank (dynamic scan id: 1)  (cost=0.00..6.00 rows=5 width=1)
+                           Index Cond: (year < 2008)
+                           Filter: ((year < 2008) AND (rank < 50))
+ Optimizer: Pivotal Optimizer (GPORCA)
+(10 rows)
+
+select count(1) from rank where year < 2008 and rank < 50;
+ count 
+-------
+    14
+(1 row)
+
+-- ----------------------------------------------------------------------
 -- Test: teardown.sql
 -- ----------------------------------------------------------------------
 -- start_ignore


### PR DESCRIPTION
### Summary

It's to fix an issue of dangling pointer in `ExecDynamicIndexScan()` which caused crash, and add kind of mechanism to check similar error.

### Issue

See the code in `ExecDynamicIndexScan()`:
```
302     while (TupIsNull(slot) &&
303            initNextIndexToScan(node))
304     {
305         slot = ExecIndexScan(node->indexScanState);
306 
307         /*
308          * Increment sidecar's index scan tuples count.
309          * It should be incremented consistently with a
310          * dynamic scan to avoid gpperfmon anomalies.
311          */
312         if (&node->indexScanState->ss.ps.gpmon_pkt)
313             Gpmon_Incr_Rows_Out(&node->indexScanState->ss.ps.gpmon_pkt);
314 
315         if (TupIsNull(slot))
316         {
317             endCurrentIndexScan(node);
318 
319             node->scan_state = SCAN_INIT;
320         }
321     }
```
At line 305, `slot` was assigned to an empty tuple. Then at line 315, it's decided as null (an empty tuple is treated as null), and entered the block started at line 316. See code of `TupIsNull()`:
```
157 static inline bool TupIsNull(TupleTableSlot *slot)
158 {
159     return (slot == NULL || (slot->PRIVATE_tts_flags & TTS_ISEMPTY) != 0);
160 }
```
In `endCurrentIndexScan()` and lower function `ExecResetTupleTable()`, the slot was actually freed:
```
 216         TupleTableSlot *slot = (TupleTableSlot *) lfirst(lc);
...
 226         /* If shouldFree, release memory occupied by the slot itself */
 227         if (shouldFree)
 228             pfree(slot);
```
Back to `ExecDynamicIndexScan()`, we check slot again in `TupIsNull()` at line 302. Since slot pointed to an invalid address at the time, there is a chance to read corrupted memory and cause crash.

### Fix

A fix is to reset `slot` to NULL after `endCurrentIndexScan().` Since the memory it pointed to is invalid, it's pretty safe. Then at line 302, `TupIsNull()` will return true directly since `slot` is null.

### More protection

We thought much about protection mechanism to check similar error. An approach is to fill freed memory with particular values, e.g. 0x7F as we did in `wipe_mem()`. However, if the code just checks a bit, there is 50% chance that we read an expected value and got cheated. The situation is the same even when we use another filling value.

I adapted another approach: Before freeing a tuple, set a special flag `TTS_MEM_FREED` to the header. We should never
see this. Once we see the flag, it means we are trying to access a tuple which has been freed, and must hit a serious error. It should cover 100% cases above. I added the check to some functions checking tuple flags to cover more scenarios.

### Test

I added a test case from @kainwen to cover the scenario. Thanks for Zhenghua's help!