### PR TITLE
Error out when DROP TYPE..CASCADE tries dropping partition key dependency

### DIFF
--- a/src/backend/cdb/cdbpartition.c
+++ b/src/backend/cdb/cdbpartition.c
@@ -9077,3 +9077,20 @@ collect_external_partitions(PartitionNode *pn, List **extparts) {
 		heap_close(rel, NoLock);
 	}
 }
+
+/*
+ * Is attno a partition key of relid?
+ * Returns false if relid is not a partitioned table.
+ */
+bool
+is_part_key(Oid relid, AttrNumber attno)
+{
+	bool result;
+	Bitmapset *partKeys = get_partition_key_bitmapset(relid);
+
+	Assert(AttributeNumberIsValid(attno));
+
+	result = bms_is_member(attno, partKeys);
+	bms_free(partKeys);
+	return result;
+}

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -8874,7 +8874,9 @@ ATExecDropColumn(List **wqueue, Relation rel, const char *colName,
 	object.objectId = RelationGetRelid(rel);
 	object.objectSubId = attnum;
 
-	performDeletion(&object, behavior, 0);
+	/* Set flag to avoid partition key check inside deleteOneObject()
+	 * for every drop column command as its already checked above. */
+	performDeletion(&object, behavior, PERFORM_DELETION_AVOID_PARTKEY_CHK);
 
 	/*
 	 * If we dropped the OID column, must adjust pg_class.relhasoids and tell

--- a/src/include/catalog/dependency.h
+++ b/src/include/catalog/dependency.h
@@ -172,6 +172,7 @@ typedef enum ObjectClass
 
 #define PERFORM_DELETION_INTERNAL			0x0001
 #define PERFORM_DELETION_CONCURRENTLY		0x0002
+#define PERFORM_DELETION_AVOID_PARTKEY_CHK	0x0004
 
 extern void performDeletion(const ObjectAddress *object,
 				DropBehavior behavior, int flags);

--- a/src/include/cdb/cdbpartition.h
+++ b/src/include/cdb/cdbpartition.h
@@ -253,4 +253,6 @@ extern PartitionRule*
 get_next_level_matched_partition(PartitionNode *partnode, Datum *values, bool *isnull,
 								TupleDesc tupdesc, PartitionAccessMethods *accessMethods);
 
+extern bool is_part_key(Oid relid, AttrNumber attno);
+
 #endif   /* CDBPARTITION_H */

--- a/src/test/regress/expected/qp_orca_fallback.out
+++ b/src/test/regress/expected/qp_orca_fallback.out
@@ -247,9 +247,8 @@ explain select count(*) from foo group by a;
  Optimizer: Postgres query optimizer
 (5 rows)
 
--- Test ORCA fallsback to planner if partition key column is dropped
--- Direct drop of a partition key column isn't allowed in gpdb, but using DROP TYPE..CASCADE
--- on a user type associated with partition key will drop the partition key column too
+-- Test DROP TYPE..CASCADE on a user type associated with partition key doesn't drop
+-- the column and error's out instead
 CREATE TYPE bug_status AS ENUM ('new', 'open', 'closed');
 CREATE TABLE partition_key_dropped(a int, b bug_status) PARTITION BY LIST(b)
 ( PARTITION p1 VALUES ('new'),
@@ -265,30 +264,31 @@ NOTICE:  drop cascades to 3 other objects
 DETAIL:  drop cascades to table partition_key_dropped column b
 drop cascades to table partition_key_dropped_1_prt_p1 column b
 drop cascades to table partition_key_dropped_1_prt_p2 column b
+ERROR:  cannot drop partitioning column "b" for table "partition_key_dropped"
 EXPLAIN SELECT * FROM partition_key_dropped;
-                                           QUERY PLAN                                            
--------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..2126.00 rows=192600 width=4)
-   ->  Append  (cost=0.00..2126.00 rows=64200 width=4)
-         ->  Seq Scan on partition_key_dropped_1_prt_p1  (cost=0.00..1063.00 rows=32100 width=4)
-         ->  Seq Scan on partition_key_dropped_1_prt_p2  (cost=0.00..1063.00 rows=32100 width=4)
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1922.00 rows=172200 width=8)
+   ->  Append  (cost=0.00..1922.00 rows=57400 width=8)
+         ->  Seq Scan on partition_key_dropped_1_prt_p1  (cost=0.00..961.00 rows=28700 width=8)
+         ->  Seq Scan on partition_key_dropped_1_prt_p2  (cost=0.00..961.00 rows=28700 width=8)
  Optimizer: Postgres query optimizer
 (5 rows)
 
 SELECT * FROM partition_key_dropped;
- a 
----
- 2
- 1
+ a |  b   
+---+------
+ 2 | open
+ 1 | new
 (2 rows)
 
 EXPLAIN DELETE FROM partition_key_dropped WHERE a=1;
                                        QUERY PLAN                                        
 -----------------------------------------------------------------------------------------
- Delete on partition_key_dropped_1_prt_p1  (cost=0.00..2607.50 rows=193 width=10)
-   ->  Seq Scan on partition_key_dropped_1_prt_p1  (cost=0.00..1303.75 rows=33 width=10)
+ Delete on partition_key_dropped_1_prt_p1  (cost=0.00..2352.50 rows=173 width=10)
+   ->  Seq Scan on partition_key_dropped_1_prt_p1  (cost=0.00..1176.25 rows=29 width=10)
          Filter: (a = 1)
-   ->  Seq Scan on partition_key_dropped_1_prt_p2  (cost=0.00..1303.75 rows=33 width=10)
+   ->  Seq Scan on partition_key_dropped_1_prt_p2  (cost=0.00..1176.25 rows=29 width=10)
          Filter: (a = 1)
  Optimizer: Postgres query optimizer
 (6 rows)
@@ -297,22 +297,21 @@ DELETE FROM partition_key_dropped WHERE a=1;
 EXPLAIN UPDATE partition_key_dropped SET a=21 where a=2;
                                              QUERY PLAN                                              
 -----------------------------------------------------------------------------------------------------
- Update on partition_key_dropped_1_prt_p1  (cost=0.00..2611.35 rows=129 width=14)
-   ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..1305.68 rows=65 width=14)
+ Update on partition_key_dropped_1_prt_p1  (cost=0.00..2355.94 rows=115 width=18)
+   ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..1177.97 rows=58 width=18)
          Hash Key: "outer".a
-         ->  Split  (cost=0.00..1305.68 rows=65 width=14)
-               ->  Seq Scan on partition_key_dropped_1_prt_p1  (cost=0.00..1303.75 rows=33 width=14)
+         ->  Split  (cost=0.00..1177.97 rows=58 width=18)
+               ->  Seq Scan on partition_key_dropped_1_prt_p1  (cost=0.00..1176.25 rows=29 width=18)
                      Filter: (a = 2)
-   ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..1305.68 rows=65 width=14)
+   ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..1177.97 rows=58 width=18)
          Hash Key: "outer".a
-         ->  Split  (cost=0.00..1305.68 rows=65 width=14)
-               ->  Seq Scan on partition_key_dropped_1_prt_p2  (cost=0.00..1303.75 rows=33 width=14)
+         ->  Split  (cost=0.00..1177.97 rows=58 width=18)
+               ->  Seq Scan on partition_key_dropped_1_prt_p2  (cost=0.00..1176.25 rows=29 width=18)
                      Filter: (a = 2)
  Optimizer: Postgres query optimizer
 (12 rows)
 
 UPDATE partition_key_dropped SET a=21 where a=2;
-ERROR:  no partition for partitioning key  (seg2 127.0.0.1:6004 pid=85464)
 EXPLAIN INSERT INTO partition_key_dropped VALUES(3);
                             QUERY PLAN                             
 -------------------------------------------------------------------
@@ -322,5 +321,4 @@ EXPLAIN INSERT INTO partition_key_dropped VALUES(3);
 (3 rows)
 
 INSERT INTO partition_key_dropped VALUES(3);
-ERROR:  no partition for partitioning key  (seg0 127.0.0.1:6002 pid=85462)
-DROP TABLE partition_key_dropped;
+ERROR:  no partition for partitioning key  (seg0 127.0.0.1:6002 pid=13466)

--- a/src/test/regress/expected/qp_orca_fallback_optimizer.out
+++ b/src/test/regress/expected/qp_orca_fallback_optimizer.out
@@ -293,9 +293,8 @@ DETAIL:  No plan has been computed for required properties
  Optimizer: Postgres query optimizer
 (5 rows)
 
--- Test ORCA fallsback to planner if partition key column is dropped
--- Direct drop of a partition key column isn't allowed in gpdb, but using DROP TYPE..CASCADE
--- on a user type associated with partition key will drop the partition key column too
+-- Test DROP TYPE..CASCADE on a user type associated with partition key doesn't drop
+-- the column and error's out instead
 CREATE TYPE bug_status AS ENUM ('new', 'open', 'closed');
 CREATE TABLE partition_key_dropped(a int, b bug_status) PARTITION BY LIST(b)
 ( PARTITION p1 VALUES ('new'),
@@ -311,78 +310,67 @@ NOTICE:  drop cascades to 3 other objects
 DETAIL:  drop cascades to table partition_key_dropped column b
 drop cascades to table partition_key_dropped_1_prt_p1 column b
 drop cascades to table partition_key_dropped_1_prt_p2 column b
+ERROR:  cannot drop partitioning column "b" for table "partition_key_dropped"
 EXPLAIN SELECT * FROM partition_key_dropped;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Table with dropped partition key column.
-                                           QUERY PLAN                                            
--------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..2126.00 rows=192600 width=4)
-   ->  Append  (cost=0.00..2126.00 rows=64200 width=4)
-         ->  Seq Scan on partition_key_dropped_1_prt_p1  (cost=0.00..1063.00 rows=32100 width=4)
-         ->  Seq Scan on partition_key_dropped_1_prt_p2  (cost=0.00..1063.00 rows=32100 width=4)
- Optimizer: Postgres query optimizer
-(5 rows)
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=8)
+   ->  Sequence  (cost=0.00..431.00 rows=1 width=8)
+         ->  Partition Selector for partition_key_dropped (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
+               Partitions selected: 2 (out of 2)
+         ->  Dynamic Seq Scan on partition_key_dropped (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(6 rows)
 
 SELECT * FROM partition_key_dropped;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Table with dropped partition key column.
- a 
----
- 1
- 2
+ a |  b   
+---+------
+ 1 | new
+ 2 | open
 (2 rows)
 
 EXPLAIN DELETE FROM partition_key_dropped WHERE a=1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Table with dropped partition key column.
-                                       QUERY PLAN                                        
------------------------------------------------------------------------------------------
- Delete on partition_key_dropped_1_prt_p1  (cost=0.00..2607.50 rows=193 width=10)
-   ->  Seq Scan on partition_key_dropped_1_prt_p1  (cost=0.00..1303.75 rows=33 width=10)
-         Filter: (a = 1)
-   ->  Seq Scan on partition_key_dropped_1_prt_p2  (cost=0.00..1303.75 rows=33 width=10)
-         Filter: (a = 1)
- Optimizer: Postgres query optimizer
-(6 rows)
+                                                        QUERY PLAN                                                         
+---------------------------------------------------------------------------------------------------------------------------
+ Delete  (cost=0.00..431.03 rows=1 width=1)
+   ->  Result  (cost=0.00..431.00 rows=1 width=22)
+         ->  Sequence  (cost=0.00..431.00 rows=1 width=18)
+               ->  Partition Selector for partition_key_dropped (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
+                     Partitions selected: 2 (out of 2)
+               ->  Dynamic Seq Scan on partition_key_dropped (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=18)
+                     Filter: (a = 1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(8 rows)
 
 DELETE FROM partition_key_dropped WHERE a=1;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Table with dropped partition key column.
 EXPLAIN UPDATE partition_key_dropped SET a=21 where a=2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Table with dropped partition key column.
-                                             QUERY PLAN                                              
------------------------------------------------------------------------------------------------------
- Update on partition_key_dropped_1_prt_p1  (cost=0.00..2611.35 rows=129 width=14)
-   ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..1305.68 rows=65 width=14)
-         Hash Key: "outer".a
-         ->  Split  (cost=0.00..1305.68 rows=65 width=14)
-               ->  Seq Scan on partition_key_dropped_1_prt_p1  (cost=0.00..1303.75 rows=33 width=14)
-                     Filter: (a = 2)
-   ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..1305.68 rows=65 width=14)
-         Hash Key: "outer".a
-         ->  Split  (cost=0.00..1305.68 rows=65 width=14)
-               ->  Seq Scan on partition_key_dropped_1_prt_p2  (cost=0.00..1303.75 rows=33 width=14)
-                     Filter: (a = 2)
- Optimizer: Postgres query optimizer
-(12 rows)
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Update  (cost=0.00..431.06 rows=1 width=1)
+   ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=22)
+         Hash Key: partition_key_dropped.a
+         ->  Split  (cost=0.00..431.00 rows=1 width=22)
+               ->  Result  (cost=0.00..431.00 rows=1 width=22)
+                     ->  Sequence  (cost=0.00..431.00 rows=1 width=18)
+                           ->  Partition Selector for partition_key_dropped (dynamic scan id: 1)  (cost=10.00..100.00 rows=34 width=4)
+                                 Partitions selected: 2 (out of 2)
+                           ->  Dynamic Seq Scan on partition_key_dropped (dynamic scan id: 1)  (cost=0.00..431.00 rows=1 width=18)
+                                 Filter: (a = 2)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(11 rows)
 
 UPDATE partition_key_dropped SET a=21 where a=2;
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Table with dropped partition key column.
-ERROR:  no partition for partitioning key  (seg2 127.0.0.1:6004 pid=86519)
 EXPLAIN INSERT INTO partition_key_dropped VALUES(3);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Table with dropped partition key column.
-                            QUERY PLAN                             
--------------------------------------------------------------------
- Insert on partition_key_dropped  (cost=0.00..0.01 rows=1 width=0)
-   ->  Result  (cost=0.00..0.01 rows=1 width=0)
- Optimizer: Postgres query optimizer
-(3 rows)
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Insert  (cost=0.00..0.02 rows=1 width=4)
+   ->  Result  (cost=0.00..0.00 rows=1 width=12)
+         ->  Result  (cost=0.00..0.00 rows=1 width=8)
+               ->  Result  (cost=0.00..0.00 rows=1 width=8)
+                     ->  Result  (cost=0.00..0.00 rows=1 width=8)
+                           ->  Result  (cost=0.00..0.00 rows=1 width=1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(7 rows)
 
 INSERT INTO partition_key_dropped VALUES(3);
-INFO:  GPORCA failed to produce a plan, falling back to planner
-DETAIL:  Feature not supported: Table with dropped partition key column.
-ERROR:  no partition for partitioning key  (seg0 127.0.0.1:6002 pid=86517)
-DROP TABLE partition_key_dropped;
+ERROR:  no partition for partitioning key  (seg0 127.0.0.1:6002 pid=12782)

--- a/src/test/regress/sql/qp_orca_fallback.sql
+++ b/src/test/regress/sql/qp_orca_fallback.sql
@@ -102,9 +102,8 @@ set optimizer_enable_hashagg = off;
 set optimizer_enable_groupagg = off;
 explain select count(*) from foo group by a;
 
--- Test ORCA fallsback to planner if partition key column is dropped
--- Direct drop of a partition key column isn't allowed in gpdb, but using DROP TYPE..CASCADE
--- on a user type associated with partition key will drop the partition key column too
+-- Test DROP TYPE..CASCADE on a user type associated with partition key doesn't drop
+-- the column and error's out instead
 CREATE TYPE bug_status AS ENUM ('new', 'open', 'closed');
 CREATE TABLE partition_key_dropped(a int, b bug_status) PARTITION BY LIST(b)
 ( PARTITION p1 VALUES ('new'),
@@ -124,5 +123,3 @@ UPDATE partition_key_dropped SET a=21 where a=2;
 
 EXPLAIN INSERT INTO partition_key_dropped VALUES(3);
 INSERT INTO partition_key_dropped VALUES(3);
-
-DROP TABLE partition_key_dropped;


### PR DESCRIPTION
Prior to this PR, for GP6 and older versions if `DROP TYPE..CASCADE`
finds a partition key column dependent on the type being dropped it
would go ahead and drop the column which leads to catalog inconsistency
causing gpcheckcat to fail and erroring out for INSERT and UPDATE
queries on such tables. To avoid landing in this state, this PR
aligns the behavior of `DROP TYPE..CASCADE` with that of a direct drop
(`ALTER ... DROP COLUMN`) by erroring out when trying to drop a partition
key column.
The tests that were added as part of commit [c4c2732](https://github.com/greenplum-db/gpdb/commit/c4c2732e5d82d14824e8ae70d9ec73a921b0bf95) had a drop table at the end
which did not fail for gpcheckcat test later. This PR also updates the test
by removing DROP TABLE at the end to ensure we check for catalog
inconsistencies later when gpcheckcat is tested.

This issue does not exist on GP7 as for a dependent partition key column,
the entire table is dropped (similar to PG).

gpdb-dev thread: https://groups.google.com/a/greenplum.org/g/gpdb-dev/c/Yo2Tp18ENu8

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
