### PR TITLE
Fix gpexpand behave test fail

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -2137,7 +2137,7 @@ def impl(context, filename, contain, output):
 def impl(context, filename):
     try:
         with dbconn.connect(dbconn.DbURL(dbname='template1'), unsetSearchPath=False) as conn:
-            curs = dbconn.execSQL(conn, "SELECT hostname, datadir FROM gp_segment_configuration WHERE content > -1;")
+            curs = dbconn.query(conn, "SELECT hostname, datadir FROM gp_segment_configuration WHERE content > -1;")
             result = curs.fetchall()
             segment_info = [(result[s][0], result[s][1]) for s in range(len(result))]
     except Exception as e:


### PR DESCRIPTION
As part of pr 15402 a behave test got added which was broken Fixed by using dbconn.query instead of dbconn.execSQL. only difference between both the api is that execSQL doesn't return any cursor object and it is mostly use for create and update. but the .query() returns cursor object after executing the query.

parent pr: <https://github.com/greenplum-db/gpdb/pull/15402>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
