### PR TITLE
[7X] new operator shouldn't return NULL

### DIFF
--- a/src/backend/gpopt/utils/CMemoryPoolPalloc.cpp
+++ b/src/backend/gpopt/utils/CMemoryPoolPalloc.cpp
@@ -47,11 +47,6 @@ CMemoryPoolPalloc::NewImpl(const ULONG bytes, const CHAR *, const ULONG,
 
 		void *ptr = gpdb::GPDBMemoryContextAlloc(m_cxt, alloc_size);
 
-		if (nullptr == ptr)
-		{
-			return nullptr;
-		}
-
 		SArrayAllocHeader *header = static_cast<SArrayAllocHeader *>(ptr);
 
 		header->m_user_size = bytes;


### PR DESCRIPTION
ORCA makes extensive use of the GPOS_NEW to allocate memory,
not checking the result for NULL, but instead relying on throwing an exception.
The implementation of this macro depends on the memory pool.
Depending on the variable optimizer_use_gpdb_allocators can be used either
GreenPlum's memory pool manager CMemoryPoolPalloc (default), or
ORCA's memory pool manager CMemoryPoolTracker.
When there is not enough memory for the GreenPlum's memory pool manager
in the gpdb::GPDBMemoryContextAlloc function an exception is thrown using
the macro GP_WRAP_END and therefore the lines, testing for NULL are never
run and can be safely removed.
And if there is not enough memory for the ORCA's memory pool manager
in the CMemoryPoolTracker::NewImpl function an exception is thrown using
the macro GPOS_OOM_CHECK, but for some reason before that,
the result is checked for NULL and NULL is returned, which can lead to
a segfault with further use of the NULL result, so the rows must be deleted.
(This fixed by commit 91eaeac5227)
Unfortunately there is no easy way to test this.
We came up with a couple of options, but both of them are not very good:
either make a fault-injector, or replace the allocator through preload.