### PR TITLE
Fix gp7 warnings

### DIFF
--- a/configure
+++ b/configure
@@ -6341,6 +6341,51 @@ fi
   if test -n "$NOT_THE_CFLAGS"; then
     CFLAGS="$CFLAGS -Wno-compound-token-split-by-macro"
   fi
+  # Similarly remove clang 15+'s deprecated-non-prototype, as it warns about
+  # tree-walking APIs that we can't reasonably change in the back branches.
+  NOT_THE_CFLAGS=""
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether ${CC} supports -Wdeprecated-non-prototype, for NOT_THE_CFLAGS" >&5
+$as_echo_n "checking whether ${CC} supports -Wdeprecated-non-prototype, for NOT_THE_CFLAGS... " >&6; }
+if ${pgac_cv_prog_CC_cflags__Wdeprecated_non_prototype+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  pgac_save_CFLAGS=$CFLAGS
+pgac_save_CC=$CC
+CC=${CC}
+CFLAGS="${NOT_THE_CFLAGS} -Wdeprecated-non-prototype"
+ac_save_c_werror_flag=$ac_c_werror_flag
+ac_c_werror_flag=yes
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  pgac_cv_prog_CC_cflags__Wdeprecated_non_prototype=yes
+else
+  pgac_cv_prog_CC_cflags__Wdeprecated_non_prototype=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+ac_c_werror_flag=$ac_save_c_werror_flag
+CFLAGS="$pgac_save_CFLAGS"
+CC="$pgac_save_CC"
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $pgac_cv_prog_CC_cflags__Wdeprecated_non_prototype" >&5
+$as_echo "$pgac_cv_prog_CC_cflags__Wdeprecated_non_prototype" >&6; }
+if test x"$pgac_cv_prog_CC_cflags__Wdeprecated_non_prototype" = x"yes"; then
+  NOT_THE_CFLAGS="${NOT_THE_CFLAGS} -Wdeprecated-non-prototype"
+fi
+
+
+  if test -n "$NOT_THE_CFLAGS"; then
+    CFLAGS="$CFLAGS -Wno-deprecated-non-prototype"
+  fi
   # Similarly disable useless truncation warnings from gcc 8+
   NOT_THE_CFLAGS=""
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether ${CC} supports -Wformat-truncation, for NOT_THE_CFLAGS" >&5
@@ -7342,6 +7387,48 @@ fi
 
   if test -n "$NOT_THE_CFLAGS"; then
     BITCODE_CFLAGS="$BITCODE_CFLAGS -Wno-compound-token-split-by-macro"
+  fi
+  NOT_THE_CFLAGS=""
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether ${CLANG} supports -Wdeprecated-non-prototype, for NOT_THE_CFLAGS" >&5
+$as_echo_n "checking whether ${CLANG} supports -Wdeprecated-non-prototype, for NOT_THE_CFLAGS... " >&6; }
+if ${pgac_cv_prog_CLANG_cflags__Wdeprecated_non_prototype+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  pgac_save_CFLAGS=$CFLAGS
+pgac_save_CC=$CC
+CC=${CLANG}
+CFLAGS="${NOT_THE_CFLAGS} -Wdeprecated-non-prototype"
+ac_save_c_werror_flag=$ac_c_werror_flag
+ac_c_werror_flag=yes
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  pgac_cv_prog_CLANG_cflags__Wdeprecated_non_prototype=yes
+else
+  pgac_cv_prog_CLANG_cflags__Wdeprecated_non_prototype=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+ac_c_werror_flag=$ac_save_c_werror_flag
+CFLAGS="$pgac_save_CFLAGS"
+CC="$pgac_save_CC"
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $pgac_cv_prog_CLANG_cflags__Wdeprecated_non_prototype" >&5
+$as_echo "$pgac_cv_prog_CLANG_cflags__Wdeprecated_non_prototype" >&6; }
+if test x"$pgac_cv_prog_CLANG_cflags__Wdeprecated_non_prototype" = x"yes"; then
+  NOT_THE_CFLAGS="${NOT_THE_CFLAGS} -Wdeprecated-non-prototype"
+fi
+
+  if test -n "$NOT_THE_CFLAGS"; then
+    BITCODE_CFLAGS="$BITCODE_CFLAGS -Wno-deprecated-non-prototype"
   fi
   NOT_THE_CFLAGS=""
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether ${CLANG} supports -Wformat-truncation, for NOT_THE_CFLAGS" >&5

--- a/configure.in
+++ b/configure.in
@@ -583,6 +583,13 @@ if test "$GCC" = yes -a "$ICC" = no; then
   if test -n "$NOT_THE_CFLAGS"; then
     CFLAGS="$CFLAGS -Wno-compound-token-split-by-macro"
   fi
+  # Similarly remove clang 15+'s deprecated-non-prototype, as it warns about
+  # tree-walking APIs that we can't reasonably change in the back branches.
+  NOT_THE_CFLAGS=""
+  PGAC_PROG_CC_VAR_OPT(NOT_THE_CFLAGS, [-Wdeprecated-non-prototype])
+  if test -n "$NOT_THE_CFLAGS"; then
+    CFLAGS="$CFLAGS -Wno-deprecated-non-prototype"
+  fi
   # Similarly disable useless truncation warnings from gcc 8+
   NOT_THE_CFLAGS=""
   PGAC_PROG_CC_VAR_OPT(NOT_THE_CFLAGS, [-Wformat-truncation])
@@ -645,6 +652,11 @@ if test "$with_llvm" = yes ; then
   PGAC_PROG_VARCC_VARFLAGS_OPT(CLANG, NOT_THE_CFLAGS, [-Wcompound-token-split-by-macro])
   if test -n "$NOT_THE_CFLAGS"; then
     BITCODE_CFLAGS="$BITCODE_CFLAGS -Wno-compound-token-split-by-macro"
+  fi
+  NOT_THE_CFLAGS=""
+  PGAC_PROG_VARCC_VARFLAGS_OPT(CLANG, NOT_THE_CFLAGS, [-Wdeprecated-non-prototype])
+  if test -n "$NOT_THE_CFLAGS"; then
+    BITCODE_CFLAGS="$BITCODE_CFLAGS -Wno-deprecated-non-prototype"
   fi
   NOT_THE_CFLAGS=""
   PGAC_PROG_VARCC_VARFLAGS_OPT(CLANG, NOT_THE_CFLAGS, [-Wformat-truncation])

--- a/contrib/pgcrypto/openssl.c
+++ b/contrib/pgcrypto/openssl.c
@@ -855,9 +855,6 @@ px_disable_fipsmode(void)
 	ossl_cipher_types = ossl_cipher_types_all;
 	fips = false;
 
-	if (!FIPS_mode_set)
-		return;
-
 	FIPS_mode_set(0);
 #endif
 
@@ -883,13 +880,6 @@ px_enable_fipsmode(void)
 	ossl_aliases = NULL;
 	ossl_cipher_types = NULL;
 
-	/* Make sure that we are linked against a FIPS enabled OpenSSL */
-	if (!FIPS_mode_set)
-	{
-		ereport(ERROR,
-				(errmsg("FIPS enabled OpenSSL is required for strict FIPS mode"),
-				 errhint("Recompile OpenSSL with the FIPS module, or install a FIPS enabled OpenSSL distribution.")));
-	}
 
 	/*
 	 * A non-zero return value means that FIPS mode was enabled, but the
@@ -920,15 +910,6 @@ px_check_fipsmode(void)
 	ereport(ERROR,
 			(errmsg("FIPS enabled OpenSSL is required for strict FIPS mode"),
 			 errhint("Recompile OpenSSL with the FIPS module, or install a FIPS enabled OpenSSL distribution.")));
-#else
-
-	/* Make sure that we are linked against a FIPS enabled OpenSSL */
-	if (!FIPS_mode_set)
-	{
-		ereport(ERROR,
-				(errmsg("FIPS enabled OpenSSL is required for strict FIPS mode"),
-				 errhint("Recompile OpenSSL with the FIPS module, or install a FIPS enabled OpenSSL distribution.")));
-	}
 
 #endif
 }

--- a/gpcontrib/gpmapreduce/src/mapred.c
+++ b/gpcontrib/gpmapreduce/src/mapred.c
@@ -1612,6 +1612,7 @@ void mapred_setup_columns(PGconn *conn, mapred_object_t *obj)
 				{
 					mapred_plist_t *newitem;
 					int i;
+					size_t len;
 
 					/* Destroy any previous default values we setup */
 					mapred_destroy_plist(&obj->u.input.columns);
@@ -1627,10 +1628,12 @@ void mapred_setup_columns(PGconn *conn, mapred_object_t *obj)
 
 						/* Add the column to the list */
 						newitem = mapred_malloc(sizeof(mapred_plist_t));
-						newitem->name = mapred_malloc(strlen(name)+1);
-						strncpy(newitem->name, name, strlen(name)+1);
-						newitem->type = mapred_malloc(strlen(type)+1);
-						strncpy(newitem->type, type, strlen(type)+1);
+						len = strlen(name) + 1;
+						newitem->name = mapred_malloc(len);
+						strncpy(newitem->name, name, len);
+						len = strlen(type) + 1;
+						newitem->type = mapred_malloc(len);
+						strncpy(newitem->type, type, len);
 						newitem->next = obj->u.input.columns;
 						obj->u.input.columns = newitem;
 					}

--- a/src/backend/access/external/url_curl.c
+++ b/src/backend/access/external/url_curl.c
@@ -240,7 +240,7 @@ destroy_curlhandle(curlhandle_t *h)
 			CURLMcode e = curl_multi_remove_handle(multi_handle, h->handle);
 
 			if (CURLM_OK != e)
-				elog(LOG, "internal error curl_multi_remove_handle (%d - %s)", e, curl_easy_strerror(e));
+				elog(LOG, "internal error curl_multi_remove_handle (%d - %s)", e, curl_multi_strerror(e));
 			h->in_multi_handle = false;
 		}
 


### PR DESCRIPTION
This PR contains 2 commits

ea3e668dfcca  - Disable -Wdeprecated-non-prototype in the back branches (cherrypicked from upstream)
    - It solved the warnings caused by the latest RHEL8/Rocky8/OEL8 updates from Clang14/LLVM14 to Clang15/LLVM15

3c5af863e18a - fixed some other warnings

    - url_curl.c: strerr for CURLMcode is applied to avoid wrong error message
    - mapred.c: fixed the code style to remove duplicated strlen calls and fit
                warning rules for strncpy
    - openssl.c: removed the check of FIPS_mode_set existence in running pgcrypto,
                 as it always exists in libopenssl 1.0.x and 1.1.x . And if linking
                 to openssl without FIPS, the loading of pgcrypto would just fail.