### PR TITLE
Do not check new relfilenodes against the preserved oid list for upgrade

### DIFF
--- a/src/backend/catalog/catalog.c
+++ b/src/backend/catalog/catalog.c
@@ -727,9 +727,6 @@ GetNewRelFileNode(Oid reltablespace, Relation pg_class, char relpersistence)
 		/* Generate the Relfilenode */
 		rnode.node.relNode = GetNewSegRelfilenode();
 
-		if (!IsOidAcceptable(rnode.node.relNode))
-			continue;
-
 		collides = GpCheckRelFileCollision(rnode);
 
 		if (!collides && rnode.node.spcNode != GLOBALTABLESPACE_OID)

--- a/src/backend/utils/cache/relcache.c
+++ b/src/backend/utils/cache/relcache.c
@@ -3604,9 +3604,6 @@ RelationBuildLocalRelation(const char *relname,
 	 *
 	 * In GPDB, the table's logical OID is allocated in the coordinator, and might
 	 * already be in use as a relfilenode of an existing relation in a segment.
-	 *
-	 * In binary upgrade mode, however, use the OID also as the relfilenode.
-	 * pg_upgrade gets confused if they don't match.
 	 */
 	rel->rd_rel->relisshared = shared_relation;
 


### PR DESCRIPTION
There used to be a restriction where the oid and relfilenode needed to match for pg_upgrade. This restriction was removed a long time back (see below commit reference). Also, relfilenode logic is actually separate from oids in Greenplum (relfilenode has its own counter). Because of the above, we do not need to check new relfilenode values against the preserved oid list during upgrade. In fact, it was actually hindering upgrade performance by a noticeable amount.

GPDB commit reference:
https://github.com/greenplum-db/gpdb/commit/20a95219123a52634dfa060771edb8888ef9b7e0

This will be backported to 6X_STABLE as well.