### PR TITLE
Issue: ORCA generates a crash in ApplyCorrelatedStatsToScaleFactorFilterCalculation.

### DIFF
--- a/src/backend/gporca/libgpos/include/gpos/common/CHashMap.h
+++ b/src/backend/gporca/libgpos/include/gpos/common/CHashMap.h
@@ -298,6 +298,12 @@ public:
 	{
 		return m_keys;
 	}
+
+	bool
+	is_empty() const
+	{
+		return(nullptr == m_chains || nullptr == *m_chains);
+	}
 };	// class CHashMap
 
 using UlongToUlongMap =

--- a/src/backend/gporca/libnaucrates/src/statistics/CExtendedStatsProcessor.cpp
+++ b/src/backend/gporca/libnaucrates/src/statistics/CExtendedStatsProcessor.cpp
@@ -247,7 +247,8 @@ CExtendedStatsProcessor::ApplyCorrelatedStatsToScaleFactorFilterCalculation(
 {
 	GPOS_ASSERT(scale_factors->Size() == 0);
 
-	if (!md_statsinfo || md_statsinfo->GetExtStatInfoArray()->Size() == 0)
+	if (!md_statsinfo || md_statsinfo->GetExtStatInfoArray()->Size() == 0 ||
+		colid_to_attno_mapping->is_empty())
 	{
 		return;
 	}

--- a/src/test/regress/expected/bfv_joins_optimizer.out
+++ b/src/test/regress/expected/bfv_joins_optimizer.out
@@ -3255,6 +3255,46 @@ full outer join fjtest_c on (s.aid = cid);
      |     |   4
 (4 rows)
 
+--
+-- Test for unsupported syntax of Full outer join in Orca.
+--
+--start_ignore
+drop table foo;
+ERROR:  table "foo" does not exist
+--end_ignore
+CREATE TABLE foo(col1 int, col2 boolean);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'col1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE STATISTICS IF NOT EXISTS s0 (mcv) ON col2, col1 FROM foo;
+INSERT INTO foo VALUES('1', true);
+--start_ignore
+VACUUM VERBOSE ANALYZE foo;
+INFO:  vacuuming "bfv_joins.foo"  (seg0 127.0.0.1:7002 pid=9918)
+INFO:  "foo": found 0 removable, 0 nonremovable row versions in 0 out of 0 pages  (seg0 127.0.0.1:7002 pid=9918)
+DETAIL:  0 dead row versions cannot be removed yet, oldest xmin: 1275
+There were 0 unused item identifiers.
+Skipped 0 pages due to buffer pins, 0 frozen pages.
+0 pages are entirely empty.
+CPU: user: 0.00 s, system: 0.00 s, elapsed: 0.00 s.
+INFO:  vacuuming "bfv_joins.foo"  (seg2 127.0.0.1:7004 pid=9919)
+INFO:  "foo": found 0 removable, 0 nonremovable row versions in 0 out of 0 pages  (seg2 127.0.0.1:7004 pid=9919)
+DETAIL:  0 dead row versions cannot be removed yet, oldest xmin: 1227
+There were 0 unused item identifiers.
+Skipped 0 pages due to buffer pins, 0 frozen pages.
+0 pages are entirely empty.
+CPU: user: 0.00 s, system: 0.00 s, elapsed: 0.00 s.
+INFO:  vacuuming "bfv_joins.foo"  (seg1 127.0.0.1:7003 pid=9917)
+INFO:  "foo": found 0 removable, 1 nonremovable row versions in 1 out of 1 pages  (seg1 127.0.0.1:7003 pid=9917)
+DETAIL:  0 dead row versions cannot be removed yet, oldest xmin: 1263
+There were 0 unused item identifiers.
+Skipped 0 pages due to buffer pins, 0 frozen pages.
+0 pages are entirely empty.
+CPU: user: 0.00 s, system: 0.00 s, elapsed: 0.00 s.
+INFO:  analyzing "bfv_joins.foo"
+INFO:  Executing SQL: select pg_catalog.gp_acquire_sample_rows(17441, 10000, 'f');
+--end_ignore
+SELECT 1 FROM foo t1 FULL JOIN foo t2 ON t2.col2;
+ERROR:  FULL JOIN is only supported with merge-joinable or hash-joinable join conditions
 -- Do not push down any implied predicates to the Left Outer Join
 CREATE TABLE member(member_id int NOT NULL, group_id int NOT NULL) DISTRIBUTED BY(member_id);
 CREATE TABLE member_group(group_id int NOT NULL) DISTRIBUTED BY(group_id);

--- a/src/test/regress/sql/bfv_joins.sql
+++ b/src/test/regress/sql/bfv_joins.sql
@@ -175,6 +175,20 @@ select * from
 ) s
 full outer join fjtest_c on (s.aid = cid);
 
+--
+-- Test for unsupported syntax of Full outer join in Orca.
+--
+--start_ignore
+drop table foo;
+--end_ignore
+CREATE TABLE foo(col1 int, col2 boolean);
+CREATE STATISTICS IF NOT EXISTS s0 (mcv) ON col2, col1 FROM foo;
+INSERT INTO foo VALUES('1', true);
+--start_ignore
+VACUUM VERBOSE ANALYZE foo;
+--end_ignore
+SELECT 1 FROM foo t1 FULL JOIN foo t2 ON t2.col2;
+
 -- Do not push down any implied predicates to the Left Outer Join
 CREATE TABLE member(member_id int NOT NULL, group_id int NOT NULL) DISTRIBUTED BY(member_id);
 CREATE TABLE member_group(group_id int NOT NULL) DISTRIBUTED BY(group_id);


### PR DESCRIPTION
If the query having full outer join between aliases of same table is run without generation of extended statistics then the postgres planner is giving error as "ERROR:  FULL JOIN is only supported with merge-joinable or hash-joinable join conditions"

But same query with extended statistics is compiled then ORCA throws exception while mapping between attribute number and colid in gpnaucrates::CExtendedStatsProcessor::ApplyCorrelatedStatsToScaleFactorFilterCalculation().

Reproducible steps:
CREATE TABLE t1(c0 name, c2 boolean);
CREATE STATISTICS IF NOT EXISTS s0 (mcv) ON c2, c0 FROM t1; INSERT INTO t1 VALUES('tC', true);
VACUUM VERBOSE ANALYZE t1;
SELECT 1 FROM t1 t11 FULL JOIN t1 t12 ON t12.c2;

RCA:
ORCA doesn't support this syntax of FULL JOIN. But before fallback to PLANNER, the extended statistics code path runs and it tries to fetch attnum from map consisting of colid and attno. But this map is not set and eventualy it crash due to dereferencing of nullptr.

Fix:
Check whether m_chains is pointing to NULL in
gpnaucrates::CExtendedStatsProcessor::ApplyCorrelatedStatsToScaleFactorFilterCalculation().

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
