### PR TITLE
Resolve GPDB_12_12_MERGE_FIXME: distributed deadlock on AO VACUUM.

### DIFF
--- a/src/backend/storage/lmgr/lmgr.c
+++ b/src/backend/storage/lmgr/lmgr.c
@@ -513,16 +513,6 @@ LockDatabaseFrozenIds(LOCKMODE lockmode)
 	(void) LockAcquire(&tag, lockmode, false, false);
 }
 
-void
-UnLockDatabaseFrozenIds(LOCKMODE lockmode)
-{
-	LOCKTAG		tag;
-
-	SET_LOCKTAG_DATABASE_FROZEN_IDS(tag, MyDatabaseId);
-
-	LockRelease(&tag, lockmode, false);
-}
-
 /*
  *		LockPage
  *

--- a/src/include/storage/lmgr.h
+++ b/src/include/storage/lmgr.h
@@ -65,7 +65,6 @@ extern int	RelationExtensionLockWaiterCount(Relation relation);
 
 /* Lock to recompute pg_database.datfrozenxid in the current database */
 extern void LockDatabaseFrozenIds(LOCKMODE lockmode);
-extern void UnLockDatabaseFrozenIds(LOCKMODE lockmode);
 
 /* Lock a page (currently only used within indexes) */
 extern void LockPage(Relation relation, BlockNumber blkno, LOCKMODE lockmode);


### PR DESCRIPTION
After merging Upstream commit https://github.com/postgres/postgres/commit/566372b3d6435639e4cc4476d79b8505a0297c87, pipeline uao VACUUM cases hung due to a distributed deadlock was observed. (See also https://github.com/greenplum-db/gpdb/issues/15458).

It is because compaction phase in the process of vacuuming an append-optimized table requires two-phase commit, which could introduce distributed deadlock when updating DatabaseFrozenIds.

The solution is updating pg_database.datfrozenxid only at the last phase of VACUUM, instead of updating it in every phase, to avoid acquiring DatabaseFrozenIds lock under the two-phase context in VACUUM compaction phase.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
