### PR TITLE
Support DPE for duplicate sensitive random motions in Orca

### DIFF
--- a/contrib/postgres_fdw/expected/gp_postgres_fdw.out
+++ b/contrib/postgres_fdw/expected/gp_postgres_fdw.out
@@ -1168,3 +1168,44 @@ select * from gp_any, table_dist_repl where gp_any.a=table_dist_repl.f1;
  9 | 9 |  9 | i  | ii
 (5 rows)
 
+create table part_mixed_dpe(a int, b int) partition by range(b);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table p2 (a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into p2 select i,10+(i%9) from generate_series(1,10)i;
+insert into p2 select i,18 from generate_series(1,50)i;
+alter table part_mixed detach partition gp_any;
+alter table part_mixed_dpe attach partition p2 for values from (10) to (20);
+alter table part_mixed_dpe attach partition gp_any for values from (5) to (10);
+analyze part_mixed_dpe;
+explain select * from part_mixed_dpe, non_part where part_mixed_dpe.b=non_part.b;
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=101.15..105.39 rows=37 width=16)
+   ->  Hash Join  (cost=101.15..104.89 rows=12 width=16)
+         Hash Cond: (gp_any.b = non_part.b)
+         ->  Append  (cost=100.00..103.52 rows=25 width=8)
+               Partition Selectors: $0
+               ->  Result  (cost=100.00..102.20 rows=5 width=8)
+                     One-Time Filter: (gp_execution_segment() = 1)
+                     ->  Foreign Scan on gp_any  (cost=100.00..102.15 rows=5 width=8)
+               ->  Seq Scan on p2  (cost=0.00..1.20 rows=20 width=8)
+         ->  Hash  (cost=1.08..1.08 rows=5 width=8)
+               ->  Partition Selector (selector id: $0)  (cost=0.00..1.08 rows=5 width=8)
+                     ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1.08 rows=5 width=8)
+                           ->  Seq Scan on non_part  (cost=0.00..1.02 rows=2 width=8)
+ Optimizer: Postgres query optimizer
+(14 rows)
+
+select * from part_mixed_dpe, non_part where part_mixed_dpe.b=non_part.b;
+ a  | b  | a  | b  
+----+----+----+----
+  2 | 12 | 12 | 12
+  9 | 10 | 10 | 10
+ 10 | 11 | 11 | 11
+  8 |  8 |  8 |  8
+  9 |  9 |  9 |  9
+  1 | 11 | 11 | 11
+(6 rows)

--- a/contrib/postgres_fdw/expected/gp_postgres_fdw.out
+++ b/contrib/postgres_fdw/expected/gp_postgres_fdw.out
@@ -1171,41 +1171,27 @@ select * from gp_any, table_dist_repl where gp_any.a=table_dist_repl.f1;
 create table part_mixed_dpe(a int, b int) partition by range(b);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-create table p2 (a int, b int);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into p2 select i,10+(i%9) from generate_series(1,10)i;
-insert into p2 select i,18 from generate_series(1,50)i;
 alter table part_mixed detach partition gp_any;
-alter table part_mixed_dpe attach partition p2 for values from (10) to (20);
 alter table part_mixed_dpe attach partition gp_any for values from (5) to (10);
+insert into part_mixed_dpe select 6,6 from generate_series(1,10);
 analyze part_mixed_dpe;
 explain select * from part_mixed_dpe, non_part where part_mixed_dpe.b=non_part.b;
-                                              QUERY PLAN                                               
--------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=101.15..105.39 rows=37 width=16)
-   ->  Hash Join  (cost=101.15..104.89 rows=12 width=16)
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=101.04..103.61 rows=5 width=16)
+   ->  Hash Join  (cost=101.04..103.55 rows=2 width=16)
          Hash Cond: (gp_any.b = non_part.b)
-         ->  Append  (cost=100.00..103.52 rows=25 width=8)
-               Partition Selectors: $0
-               ->  Result  (cost=100.00..102.20 rows=5 width=8)
-                     One-Time Filter: (gp_execution_segment() = 1)
-                     ->  Foreign Scan on gp_any  (cost=100.00..102.15 rows=5 width=8)
-               ->  Seq Scan on p2  (cost=0.00..1.20 rows=20 width=8)
-         ->  Hash  (cost=1.08..1.08 rows=5 width=8)
-               ->  Partition Selector (selector id: $0)  (cost=0.00..1.08 rows=5 width=8)
-                     ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1.08 rows=5 width=8)
-                           ->  Seq Scan on non_part  (cost=0.00..1.02 rows=2 width=8)
+         ->  Foreign Scan on gp_any  (cost=100.00..102.45 rows=15 width=8)
+         ->  Hash  (cost=1.02..1.02 rows=2 width=8)
+               ->  Partition Selector (selector id: $0)  (cost=0.00..1.02 rows=2 width=8)
+                     ->  Seq Scan on non_part  (cost=0.00..1.02 rows=2 width=8)
  Optimizer: Postgres query optimizer
-(14 rows)
+(8 rows)
 
 select * from part_mixed_dpe, non_part where part_mixed_dpe.b=non_part.b;
- a  | b  | a  | b  
-----+----+----+----
-  2 | 12 | 12 | 12
-  9 | 10 | 10 | 10
- 10 | 11 | 11 | 11
-  8 |  8 |  8 |  8
-  9 |  9 |  9 |  9
-  1 | 11 | 11 | 11
-(6 rows)
+ a | b | a | b 
+---+---+---+---
+ 8 | 8 | 8 | 8
+ 9 | 9 | 9 | 9
+(2 rows)
+

--- a/contrib/postgres_fdw/expected/gp_postgres_fdw_optimizer.out
+++ b/contrib/postgres_fdw/expected/gp_postgres_fdw_optimizer.out
@@ -1192,3 +1192,45 @@ select * from gp_any, table_dist_repl where gp_any.a=table_dist_repl.f1;
  8 | 8 |  8 | h  | hh
 (5 rows)
 
+create table part_mixed_dpe(a int, b int) partition by range(b);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table p2 (a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into p2 select i,10+(i%9) from generate_series(1,10)i;
+insert into p2 select i,18 from generate_series(1,50)i;
+alter table part_mixed detach partition gp_any;
+alter table part_mixed_dpe attach partition p2 for values from (10) to (20);
+alter table part_mixed_dpe attach partition gp_any for values from (5) to (10);
+analyze part_mixed_dpe;
+explain select * from part_mixed_dpe, non_part where part_mixed_dpe.b=non_part.b;
+                                               QUERY PLAN                                                
+---------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1293.01 rows=33 width=16)
+   ->  Hash Join  (cost=0.00..1293.01 rows=11 width=16)
+         Hash Cond: (part_mixed_dpe.b = non_part.b)
+         ->  Append  (cost=0.00..862.00 rows=22 width=8)
+               ->  Dynamic Seq Scan on part_mixed_dpe  (cost=0.00..431.00 rows=22 width=8)
+                     Number of partitions to scan: 1 (out of 2)
+               ->  Result  (cost=0.00..431.00 rows=22 width=8)
+                     One-Time Filter: (gp_execution_segment() = 0)
+                     ->  Dynamic Foreign Scan on part_mixed_dpe  (cost=0.00..431.00 rows=22 width=8)
+                           Number of partitions to scan: 1 (out of 2)
+         ->  Hash  (cost=431.00..431.00 rows=5 width=8)
+               ->  Partition Selector (selector id: $0)  (cost=0.00..431.00 rows=5 width=8)
+                     ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=5 width=8)
+                           ->  Seq Scan on non_part  (cost=0.00..431.00 rows=2 width=8)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(15 rows)
+
+select * from part_mixed_dpe, non_part where part_mixed_dpe.b=non_part.b;
+ a  | b  | a  | b  
+----+----+----+----
+  9 | 10 | 10 | 10
+ 10 | 11 | 11 | 11
+  1 | 11 | 11 | 11
+  2 | 12 | 12 | 12
+  8 |  8 |  8 |  8
+  9 |  9 |  9 |  9
+(6 rows)

--- a/contrib/postgres_fdw/expected/gp_postgres_fdw_optimizer.out
+++ b/contrib/postgres_fdw/expected/gp_postgres_fdw_optimizer.out
@@ -1195,42 +1195,31 @@ select * from gp_any, table_dist_repl where gp_any.a=table_dist_repl.f1;
 create table part_mixed_dpe(a int, b int) partition by range(b);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-create table p2 (a int, b int);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-insert into p2 select i,10+(i%9) from generate_series(1,10)i;
-insert into p2 select i,18 from generate_series(1,50)i;
 alter table part_mixed detach partition gp_any;
-alter table part_mixed_dpe attach partition p2 for values from (10) to (20);
 alter table part_mixed_dpe attach partition gp_any for values from (5) to (10);
+insert into part_mixed_dpe select 6,6 from generate_series(1,10);
 analyze part_mixed_dpe;
 explain select * from part_mixed_dpe, non_part where part_mixed_dpe.b=non_part.b;
                                                QUERY PLAN                                                
 ---------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1293.01 rows=33 width=16)
-   ->  Hash Join  (cost=0.00..1293.01 rows=11 width=16)
-         Hash Cond: (part_mixed_dpe.b = non_part.b)
-         ->  Append  (cost=0.00..862.00 rows=22 width=8)
-               ->  Dynamic Seq Scan on part_mixed_dpe  (cost=0.00..431.00 rows=22 width=8)
-                     Number of partitions to scan: 1 (out of 2)
-               ->  Result  (cost=0.00..431.00 rows=22 width=8)
-                     One-Time Filter: (gp_execution_segment() = 0)
-                     ->  Dynamic Foreign Scan on part_mixed_dpe  (cost=0.00..431.00 rows=22 width=8)
-                           Number of partitions to scan: 1 (out of 2)
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.01 rows=15 width=16)
+   ->  Hash Join  (cost=0.00..862.00 rows=5 width=16)
+         Hash Cond: (b = non_part.b)
+         ->  Result  (cost=0.00..431.00 rows=5 width=8)
+               One-Time Filter: (gp_execution_segment() = 0)
+               ->  Dynamic Foreign Scan on part_mixed_dpe  (cost=0.00..431.00 rows=5 width=8)
+                     Number of partitions to scan: 1 (out of 1)
          ->  Hash  (cost=431.00..431.00 rows=5 width=8)
                ->  Partition Selector (selector id: $0)  (cost=0.00..431.00 rows=5 width=8)
                      ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=5 width=8)
                            ->  Seq Scan on non_part  (cost=0.00..431.00 rows=2 width=8)
  Optimizer: Pivotal Optimizer (GPORCA)
-(15 rows)
+(12 rows)
 
 select * from part_mixed_dpe, non_part where part_mixed_dpe.b=non_part.b;
- a  | b  | a  | b  
-----+----+----+----
-  9 | 10 | 10 | 10
- 10 | 11 | 11 | 11
-  1 | 11 | 11 | 11
-  2 | 12 | 12 | 12
-  8 |  8 |  8 |  8
-  9 |  9 |  9 |  9
-(6 rows)
+ a | b | a | b 
+---+---+---+---
+ 8 | 8 | 8 | 8
+ 9 | 9 | 9 | 9
+(2 rows)
+

--- a/contrib/postgres_fdw/sql/gp_postgres_fdw.sql
+++ b/contrib/postgres_fdw/sql/gp_postgres_fdw.sql
@@ -285,3 +285,14 @@ select * from gp_any, table_dist_int where gp_any.a=table_dist_int.f1;
 -- validate join is on segments for replicated table
 explain select * from gp_any, table_dist_repl where gp_any.a=table_dist_repl.f1;
 select * from gp_any, table_dist_repl where gp_any.a=table_dist_repl.f1;
+
+create table part_mixed_dpe(a int, b int) partition by range(b);
+create table p2 (a int, b int);
+insert into p2 select i,10+(i%9) from generate_series(1,10)i;
+insert into p2 select i,18 from generate_series(1,50)i;
+alter table part_mixed detach partition gp_any;
+alter table part_mixed_dpe attach partition p2 for values from (10) to (20);
+alter table part_mixed_dpe attach partition gp_any for values from (5) to (10);
+analyze part_mixed_dpe;
+explain select * from part_mixed_dpe, non_part where part_mixed_dpe.b=non_part.b;
+select * from part_mixed_dpe, non_part where part_mixed_dpe.b=non_part.b;

--- a/contrib/postgres_fdw/sql/gp_postgres_fdw.sql
+++ b/contrib/postgres_fdw/sql/gp_postgres_fdw.sql
@@ -287,12 +287,9 @@ explain select * from gp_any, table_dist_repl where gp_any.a=table_dist_repl.f1;
 select * from gp_any, table_dist_repl where gp_any.a=table_dist_repl.f1;
 
 create table part_mixed_dpe(a int, b int) partition by range(b);
-create table p2 (a int, b int);
-insert into p2 select i,10+(i%9) from generate_series(1,10)i;
-insert into p2 select i,18 from generate_series(1,50)i;
 alter table part_mixed detach partition gp_any;
-alter table part_mixed_dpe attach partition p2 for values from (10) to (20);
 alter table part_mixed_dpe attach partition gp_any for values from (5) to (10);
+insert into part_mixed_dpe select 6,6 from generate_series(1,10);
 analyze part_mixed_dpe;
 explain select * from part_mixed_dpe, non_part where part_mixed_dpe.b=non_part.b;
 select * from part_mixed_dpe, non_part where part_mixed_dpe.b=non_part.b;

--- a/src/backend/gporca/data/dxl/minidump/ForeignPartOneTimeFilterDPE.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ForeignPartOneTimeFilterDPE.mdp
@@ -1,0 +1,558 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+<dxl:Comment><![CDATA[
+	Objective: Orca should generate a partition selector that is passed through 
+	a one-time-filter. While partition selectors can't be passed to different slices 
+	through motions, one-time-filters don't result in separate slices.
+
+	CREATE SCHEMA postgres_fdw_gp;
+	CREATE EXTENSION IF NOT EXISTS postgres_fdw;
+
+	DO $d$
+	    BEGIN
+		EXECUTE $$CREATE SERVER loopback FOREIGN DATA WRAPPER postgres_fdw
+		    OPTIONS (dbname '$$||current_database()||$$',
+			     port '$$||current_setting('port')||$$'
+		    )$$;
+	    END;
+	$d$;
+
+	CREATE USER MAPPING IF NOT EXISTS FOR CURRENT_USER SERVER loopback;
+
+	create table non_part (a int, b int);
+	insert into non_part select i, i from generate_series(8,12)i;
+	analyze non_part;
+
+	create table part(a int, b int) partition by range(b);
+	CREATE FOREIGN TABLE gp_any (
+		a int,
+		b int
+	) SERVER loopback OPTIONS (schema_name 'public', table_name 't2', mpp_execute 'any');
+	create table t2(a int, b int);
+
+	alter table part attach partition gp_any for values from (5) to (10);
+	insert into part select 6,6 from generate_series(1,10);
+	analyze part;
+	explain select * from part, non_part where part.b=non_part.b;
+
+	 Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..862.00 rows=10 width=16)
+	   ->  Hash Join  (cost=0.00..862.00 rows=4 width=16)
+		 Hash Cond: (b = non_part.b)
+		 ->  Result  (cost=0.00..431.00 rows=4 width=8)
+		       One-Time Filter: (gp_execution_segment() = 2)
+		       ->  Dynamic Foreign Scan on part  (cost=0.00..431.00 rows=4 width=8)
+			     Number of partitions to scan: 1 (out of 1)
+		 ->  Hash  (cost=431.00..431.00 rows=5 width=8)
+		       ->  Partition Selector (selector id: $0)  (cost=0.00..431.00 rows=5 width=8)
+			     ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=5 width=8)
+				   ->  Seq Scan on non_part  (cost=0.00..431.00 rows=2 width=8)
+	 Optimizer: Pivotal Optimizer (GPORCA)
+	(12 rows)
+]]>
+  </dxl:Comment>
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="20" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0" SkewFactor="0"/>
+      <dxl:TraceFlags Value="102001,102002,102003,102043,102074,102120,102144,103001,103014,103015,103022,103026,103027,103029,103033,103038,103040,104002,104003,104004,104005,105000,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:PartOpfamily Mdid="0.424.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:PartOpfamily Mdid="0.1976.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:RelationExtendedStatistics Mdid="10.16970.1.0" Name="non_part"/>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:PartOpfamily Mdid="0.1989.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2134.1.0"/>
+        <dxl:MaxAgg Mdid="0.2118.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.2227.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:PartOpfamily Mdid="0.2789.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.3315.1.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:RelationExtendedStatistics Mdid="10.16973.1.0" Name="part"/>
+      <dxl:ColumnStatistics Mdid="1.16970.1.0.1" Name="b" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.250000" DistinctValues="1.250000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.250000" DistinctValues="1.250000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="10"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.250000" DistinctValues="1.250000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="10"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="11"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.250000" DistinctValues="1.250000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="11"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="12"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:ColumnStatistics Mdid="1.16970.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.250000" DistinctValues="1.250000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.250000" DistinctValues="1.250000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="10"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.250000" DistinctValues="1.250000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="10"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="11"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.250000" DistinctValues="1.250000">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="11"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="12"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+      <dxl:MDCast Mdid="3.23.1.0;23.1.0" Name="int4" BinaryCoercible="true" SourceTypeId="0.23.1.0" DestinationTypeId="0.23.1.0" CastFuncId="0.0.0.0" CoercePathType="0"/>
+      <dxl:GPDBScalarOp Mdid="0.96.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.65.1.0"/>
+        <dxl:Commutator Mdid="0.96.1.0"/>
+        <dxl:InverseOp Mdid="0.518.1.0"/>
+        <dxl:HashOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7100.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.1977.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.7100.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:Relation Mdid="6.16976.1.0" Name="gp_any" IsTemporary="false" StorageType="Foreign" DistributionPolicy="Universal" Keys="8,2" ForeignServer="0.16968.1.0">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:CheckConstraints/>
+        <dxl:PartConstraint>
+          <dxl:And>
+            <dxl:IsNotNull>
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:IsNotNull>
+            <dxl:Comparison ComparisonOperator="&gt;=" OperatorMdid="0.525.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="5"/>
+            </dxl:Comparison>
+            <dxl:Comparison ComparisonOperator="&lt;" OperatorMdid="0.97.1.0">
+              <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="10"/>
+            </dxl:Comparison>
+          </dxl:And>
+        </dxl:PartConstraint>
+      </dxl:Relation>
+      <dxl:RelationStatistics Mdid="2.16970.1.0" Name="non_part" Rows="5.000000" RelPages="3" RelAllVisible="0" EmptyRelation="false"/>
+      <dxl:Relation Mdid="6.16970.1.0" Name="non_part" IsTemporary="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:ColumnStatistics Mdid="1.16973.1.0.1" Name="b" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.16973.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:RelationStatistics Mdid="2.16973.1.0" Name="part" Rows="10.000000" RelPages="0" RelAllVisible="0" EmptyRelation="false"/>
+      <dxl:Relation Mdid="6.16973.1.0" Name="part" IsTemporary="false" StorageType="Foreign" DistributionPolicy="Hash" DistributionColumns="0" Keys="7,8,2" PartitionColumns="1" PartitionTypes="r">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+        <dxl:Partitions>
+          <dxl:Partition Mdid="6.16976.1.0"/>
+        </dxl:Partitions>
+      </dxl:Relation>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
+        <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalJoin JoinType="Inner">
+        <dxl:LogicalForeignGet>
+          <dxl:TableDescriptor Mdid="6.16973.1.0" TableName="part" LockMode="1">
+            <dxl:Columns>
+              <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="4" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="5" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="6" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="7" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="8" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="9" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalForeignGet>
+        <dxl:LogicalGet>
+          <dxl:TableDescriptor Mdid="6.16970.1.0" TableName="non_part" LockMode="1">
+            <dxl:Columns>
+              <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="11" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="12" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="13" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="14" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="15" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="16" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="17" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="18" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:LogicalGet>
+        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+          <dxl:Ident ColId="2" ColName="b" TypeMdid="0.23.1.0"/>
+          <dxl:Ident ColId="11" ColName="b" TypeMdid="0.23.1.0"/>
+        </dxl:Comparison>
+      </dxl:LogicalJoin>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="9">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="862.004168" Rows="10.000000" Width="16"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="0" Alias="a">
+            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="1" Alias="b">
+            <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="9" Alias="a">
+            <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+          <dxl:ProjElem ColId="10" Alias="b">
+            <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:SortingColumnList/>
+        <dxl:HashJoin JoinType="Inner">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="862.003571" Rows="10.000000" Width="16"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="0" Alias="a">
+              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="1" Alias="b">
+              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="9" Alias="a">
+              <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+            <dxl:ProjElem ColId="10" Alias="b">
+              <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:JoinFilter/>
+          <dxl:HashCondList>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+              <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
+            </dxl:Comparison>
+          </dxl:HashCondList>
+          <dxl:RandomMotion InputSegments="0" OutputSegments="0,1,2" DuplicateSensitive="true">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.000566" Rows="10.000000" Width="8"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="0" Alias="a">
+                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="1" Alias="b">
+                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:SortingColumnList/>
+            <dxl:DynamicForeignScan SelectorIds="0" ForeignServerOid="16968">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.000209" Rows="10.000000" Width="8"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="0" Alias="a">
+                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="1" Alias="b">
+                  <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:Partitions>
+                <dxl:Partition Mdid="6.16976.1.0"/>
+              </dxl:Partitions>
+              <dxl:TableDescriptor Mdid="6.16973.1.0" TableName="part" LockMode="1">
+                <dxl:Columns>
+                  <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                  <dxl:Column ColId="3" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="4" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="5" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="6" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="7" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="8" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:DynamicForeignScan>
+          </dxl:RandomMotion>
+          <dxl:PartitionSelector RelationMdid="6.16973.1.0" SelectorId="0" ScanId="1" Partitions="0">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.000776" Rows="15.000000" Width="8"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="9" Alias="a">
+                <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+              <dxl:ProjElem ColId="10" Alias="b">
+                <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:PartFilterExpr>
+              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
+              </dxl:Comparison>
+            </dxl:PartFilterExpr>
+            <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.000776" Rows="15.000000" Width="8"/>
+              </dxl:Properties>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="9" Alias="a">
+                  <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="10" Alias="b">
+                  <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:SortingColumnList/>
+              <dxl:TableScan>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000035" Rows="5.000000" Width="8"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="9" Alias="a">
+                    <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                  <dxl:ProjElem ColId="10" Alias="b">
+                    <dxl:Ident ColId="10" ColName="b" TypeMdid="0.23.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:TableDescriptor Mdid="6.16970.1.0" TableName="non_part" LockMode="1">
+                  <dxl:Columns>
+                    <dxl:Column ColId="9" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="10" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                    <dxl:Column ColId="12" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="13" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="14" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="15" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="16" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                    <dxl:Column ColId="17" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  </dxl:Columns>
+                </dxl:TableDescriptor>
+              </dxl:TableScan>
+            </dxl:BroadcastMotion>
+          </dxl:PartitionSelector>
+        </dxl:HashJoin>
+      </dxl:GatherMotion>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CDistributionSpecRandom.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CDistributionSpecRandom.h
@@ -81,8 +81,6 @@ public:
 	void
 	MarkDuplicateSensitive()
 	{
-		GPOS_ASSERT(!m_is_duplicate_sensitive);
-
 		m_is_duplicate_sensitive = true;
 	}
 

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysical.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysical.h
@@ -348,7 +348,7 @@ public:
 											CDrvdPropArray *pdrgpdpCtxt,
 											ULONG ulOptReq) const = 0;
 
-	// compute required partition propoagation spec of the n-th child
+	// compute required partition propagation spec of the n-th child
 	virtual CPartitionPropagationSpec *PppsRequired(
 		CMemoryPool *mp, CExpressionHandle &exprhdl,
 		CPartitionPropagationSpec *pppsRequired, ULONG child_index,

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalMotion.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalMotion.h
@@ -78,7 +78,7 @@ public:
 									CDrvdPropArray *pdrgpdpCtxt,
 									ULONG ulOptReq) const override;
 
-	// compute required partition propoagation spec of the n-th child
+	// compute required partition propagation spec of the n-th child
 	CPartitionPropagationSpec *PppsRequired(
 		CMemoryPool *mp, CExpressionHandle &exprhdl,
 		CPartitionPropagationSpec *pppsRequired, ULONG child_index,

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalMotionRandom.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalMotionRandom.h
@@ -88,7 +88,7 @@ public:
 							CDrvdPropArray *pdrgpdpCtxt,
 							ULONG ulOptReq) const override;
 
-	// compute required partition propoagation spec of the n-th child
+	// compute required partition propagation spec of the n-th child
 	CPartitionPropagationSpec *PppsRequired(
 		CMemoryPool *mp, CExpressionHandle &exprhdl,
 		CPartitionPropagationSpec *pppsRequired, ULONG child_index,

--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalMotionRandom.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CPhysicalMotionRandom.h
@@ -88,6 +88,12 @@ public:
 							CDrvdPropArray *pdrgpdpCtxt,
 							ULONG ulOptReq) const override;
 
+	// compute required partition propoagation spec of the n-th child
+	CPartitionPropagationSpec *PppsRequired(
+		CMemoryPool *mp, CExpressionHandle &exprhdl,
+		CPartitionPropagationSpec *pppsRequired, ULONG child_index,
+		CDrvdPropArray *pdrgpdpCtxt, ULONG ulOptReq) const override;
+
 	// check if required columns are included in output columns
 	BOOL FProvidesReqdCols(CExpressionHandle &exprhdl, CColRefSet *pcrsRequired,
 						   ULONG ulOptReq) const override;
@@ -100,6 +106,9 @@ public:
 	COrderSpec *PosDerive(CMemoryPool *mp,
 						  CExpressionHandle &exprhdl) const override;
 
+	// derived properties: derive partition propagation spec
+	CPartitionPropagationSpec *PppsDerive(
+		CMemoryPool *mp, CExpressionHandle &exprhdl) const override;
 	//-------------------------------------------------------------------------------------
 	// Enforced Properties
 	//-------------------------------------------------------------------------------------

--- a/src/backend/gporca/libgpopt/src/base/CDistributionSpecNonSingleton.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CDistributionSpecNonSingleton.cpp
@@ -114,8 +114,9 @@ CDistributionSpecNonSingleton::AppendEnforcers(CMemoryPool *mp,
 		// the motion node is enforced on top of a child
 		// deriving universal spec or replicated distribution, this motion node
 		// will be translated to a result node with hash filter to remove
-		// duplicates
+		// duplicates, therefore we also need to mark it as duplicate sensitive
 		random_dist_spec = GPOS_NEW(mp) CDistributionSpecRandom();
+		random_dist_spec->MarkDuplicateSensitive();
 	}
 	else
 	{

--- a/src/backend/gporca/libgpopt/src/base/CDistributionSpecRandom.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CDistributionSpecRandom.cpp
@@ -196,8 +196,9 @@ CDistributionSpecRandom::AppendEnforcers(CMemoryPool *mp,
 		// the motion node is enforced on top of a child
 		// deriving universal spec or replicated distribution, this motion node
 		// will be translated to a result node with hash filter to remove
-		// duplicates
+		// duplicates, therefore we also need to mark it as duplicate sensitive
 		random_dist_spec = GPOS_NEW(mp) CDistributionSpecRandom();
+		random_dist_spec->MarkDuplicateSensitive();
 	}
 	else
 	{

--- a/src/backend/gporca/server/CMakeLists.txt
+++ b/src/backend/gporca/server/CMakeLists.txt
@@ -391,7 +391,7 @@ CoverintIndexTest:
 CoveringIndex-1 CoveringIndex-2 CoveringIndex-3;
 
 CForeignPartTest:
-ForeignPartUniform PartForeignMixed PartForeignDifferentServer PartForeignDifferentExecLocation PartForeignMixedDPE PartForeignMixedSPE PartForeignUniformSPE ForeignScanExecLocAnySimpleScan ForeignScanExecLocAnyJoin
+ForeignPartUniform PartForeignMixed PartForeignDifferentServer PartForeignDifferentExecLocation PartForeignMixedDPE PartForeignMixedSPE PartForeignUniformSPE ForeignScanExecLocAnySimpleScan ForeignScanExecLocAnyJoin ForeignPartOneTimeFilterDPE
 ")
 
 set(mdp_dir "../data/dxl/minidump/")


### PR DESCRIPTION
In certain cases, Orca generates duplicate sensitive random motions, which in
the translator are translated to a result node with with a filter on gp_segment_id. This
effectively only outputs the rows for a single segment. Inside the
optimizer, we treat this as a motion, as it causes the distribution to
change.

However, this isn't actually a physical motion, but rather a filter that
doesn't create a separate slice. Therefore, we can pass partition
selectors through this, allowing Orca to generate more performant plans

For example, we can now generate plans such as
```
 Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1293.01 rows=33 width=16)
   ->  Hash Join  (cost=0.00..1293.01 rows=11 width=16)
         Hash Cond: (part_mixed_dpe.b = non_part.b)
         ->  Append  (cost=0.00..862.00 rows=22 width=8)
               ->  Dynamic Seq Scan on part_mixed_dpe  (cost=0.00..431.00 rows=22 width=8)
                     Number of partitions to scan: 1 (out of 2)
               ->  Result  (cost=0.00..431.00 rows=22 width=8)
                     One-Time Filter: (gp_execution_segment() = 0)
                     ->  Dynamic Foreign Scan on part_mixed_dpe  (cost=0.00..431.00 rows=22 width=8)
                           Number of partitions to scan: 1 (out of 2)
         ->  Hash  (cost=431.00..431.00 rows=5 width=8)
               ->  Partition Selector (selector id: $0)  (cost=0.00..431.00 rows=5 width=8)
                     ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=5 width=8)
                           ->  Seq Scan on non_part  (cost=0.00..431.00 rows=2 width=8)
 Optimizer: Pivotal Optimizer (GPORCA)
(15 rows)
```
