### PR TITLE
ICW CLI groups not needed for now on el9 platforms

### DIFF
--- a/concourse/pipelines/gen_pipeline.py
+++ b/concourse/pipelines/gen_pipeline.py
@@ -335,7 +335,7 @@ def main():
         print("You can only use one of --output or --user.")
         exit(1)
 
-    if args.pipeline_target == 'prod' and not args.directed_release:
+    if args.pipeline_target == 'prod' and not args.directed_release and args.os_type not in ["rocky9", "oel9", "rhel9"]:
         args.test_sections = [
             'ICW',
             'CLI',

--- a/concourse/pipelines/templates/gpdb-tpl.yml
+++ b/concourse/pipelines/templates/gpdb-tpl.yml
@@ -554,7 +554,7 @@ resources:
     versioned_file: ((pipeline-name))/bin_gpdb_clients_windows/greenplum-clients-x86_64.tar.gz
 {% endif %}
 
-{% if os_type != default_os_type and pipeline_target == "prod" %}
+{% if os_type != compile_platform and pipeline_target == "prod" %}
 - name: reduced-frequency-trigger
   type: time
   source:


### PR DESCRIPTION
reduced-frequency-trigger not needed for rocky9

Authored-by: Anusha Shakarad <shakarada@vmware.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
