### PR TITLE
Reduce autovacuum threshold for remaining autovacuum tests

### DIFF
--- a/src/test/isolation2/input/autovacuum-analyze.source
+++ b/src/test/isolation2/input/autovacuum-analyze.source
@@ -4,6 +4,7 @@
 
 -- Speed up test.
 ALTER SYSTEM SET autovacuum_naptime = 5;
+ALTER SYSTEM SET autovacuum_vacuum_threshold = 50;
 select * from pg_reload_conf();
 
 --
@@ -261,5 +262,6 @@ select analyze_count, autoanalyze_count, n_mod_since_analyze from pg_stat_all_ta
 
 -- Reset GUCs.
 ALTER SYSTEM RESET autovacuum_naptime;
+ALTER SYSTEM RESET autovacuum_vacuum_threshold;
 select * from pg_reload_conf();
 

--- a/src/test/isolation2/output/autovacuum-analyze.source
+++ b/src/test/isolation2/output/autovacuum-analyze.source
@@ -5,6 +5,8 @@
 -- Speed up test.
 ALTER SYSTEM SET autovacuum_naptime = 5;
 ALTER
+ALTER SYSTEM SET autovacuum_vacuum_threshold = 50;
+ALTER
 select * from pg_reload_conf();
  pg_reload_conf 
 ----------------
@@ -627,6 +629,8 @@ select analyze_count, autoanalyze_count, n_mod_since_analyze from pg_stat_all_ta
 
 -- Reset GUCs.
 ALTER SYSTEM RESET autovacuum_naptime;
+ALTER
+ALTER SYSTEM RESET autovacuum_vacuum_threshold;
 ALTER
 select * from pg_reload_conf();
  pg_reload_conf 

--- a/src/test/regress/expected/autovacuum-catalog.out
+++ b/src/test/regress/expected/autovacuum-catalog.out
@@ -4,6 +4,7 @@ CREATE DATABASE av_catalog;
 \c av_catalog
 -- speed up test
 ALTER SYSTEM SET autovacuum_naptime = 5;
+ALTER SYSTEM SET autovacuum_vacuum_threshold = 50;
 -- start_ignore
 \! gpstop -u;
 20230207:20:52:47:298674 gpstop:ajrdevbox:ajr-[INFO]:-Starting gpstop with args: -u
@@ -41,6 +42,7 @@ SELECT gp_inject_fault('auto_vac_worker_after_report_activity', 'reset', 1);
 (1 row)
 
 ALTER SYSTEM RESET autovacuum_naptime;
+ALTER SYSTEM RESET autovacuum_vacuum_threshold;
 -- start_ignore
 \! gpstop -u;
 20230207:20:52:59:298805 gpstop:ajrdevbox:ajr-[INFO]:-Starting gpstop with args: -u

--- a/src/test/regress/input/autovacuum.source
+++ b/src/test/regress/input/autovacuum.source
@@ -6,6 +6,7 @@ set debug_burn_xids=on;
 
 -- Speed up test.
 ALTER SYSTEM SET autovacuum_naptime = 5;
+ALTER SYSTEM SET autovacuum_vacuum_threshold = 50;
 select * from pg_reload_conf();
 
 -- Autovacuum should take care of anti-XID wraparounds of catalog tables.
@@ -61,4 +62,5 @@ END$$;
 
 -- Reset GUCs.
 ALTER SYSTEM RESET autovacuum_naptime;
+ALTER SYSTEM RESET autovacuum_vacuum_threshold;
 select * from pg_reload_conf();

--- a/src/test/regress/output/autovacuum.source
+++ b/src/test/regress/output/autovacuum.source
@@ -4,6 +4,7 @@ language C;
 set debug_burn_xids=on;
 -- Speed up test.
 ALTER SYSTEM SET autovacuum_naptime = 5;
+ALTER SYSTEM SET autovacuum_vacuum_threshold = 50;
 select * from pg_reload_conf();
  pg_reload_conf 
 ----------------
@@ -111,6 +112,7 @@ END$$;
 NOTICE:  Regression Database is young now
 -- Reset GUCs.
 ALTER SYSTEM RESET autovacuum_naptime;
+ALTER SYSTEM RESET autovacuum_vacuum_threshold;
 select * from pg_reload_conf();
  pg_reload_conf 
 ----------------

--- a/src/test/regress/sql/autovacuum-catalog.sql
+++ b/src/test/regress/sql/autovacuum-catalog.sql
@@ -5,6 +5,7 @@ CREATE DATABASE av_catalog;
 
 -- speed up test
 ALTER SYSTEM SET autovacuum_naptime = 5;
+ALTER SYSTEM SET autovacuum_vacuum_threshold = 50;
 -- start_ignore
 \! gpstop -u;
 -- end_ignore
@@ -27,6 +28,7 @@ SELECT gp_inject_fault('auto_vac_worker_after_report_activity', 'reset', 1);
 
 
 ALTER SYSTEM RESET autovacuum_naptime;
+ALTER SYSTEM RESET autovacuum_vacuum_threshold;
 -- start_ignore
 \! gpstop -u;
 -- end_ignore


### PR DESCRIPTION
To speed up tests and reduce timeouts waiting for AV worker, reduce `autovacuum_vacuum_threshold` to 50 for all autovacuum tests.
