### PR TITLE
Fixing crash in ORCA with skip-level correlated query

### DIFF
--- a/src/backend/gporca/libnaucrates/src/statistics/CJoinStatsProcessor.cpp
+++ b/src/backend/gporca/libnaucrates/src/statistics/CJoinStatsProcessor.cpp
@@ -575,18 +575,7 @@ CJoinStatsProcessor::DeriveJoinStats(CMemoryPool *mp,
 	IStatistics *join_stats = CJoinStatsProcessor::CalcAllJoinStats(
 		mp, statistics_array, local_expr, exprhdl.Pop());
 
-
-	// If expr_with_outer_refs is a CScalarConst and the join operator is
-	// CLogicalNAryJoin then outer references stats will not be derived.This is
-	// because it will lead to a crash.When the query contains a left join or a
-	// cascading of left and inner joins, the join operator will be CLogicalNAryJoin
-	// and the CScalarNAryJoinPredList will contain the ON predicates for inner joins
-	// and left joins as its children.So if expr_with_outer_refs is a CScalarConst and
-	// not CScalarNAryJoinPredList then it will lead to a crash while accessing the
-	// children of CScalarConst.
-	if (exprhdl.HasOuterRefs() && 0 < stats_ctxt->Size() &&
-		!(exprhdl.Pop()->Eopid() == COperator::EopLogicalNAryJoin &&
-		  CUtils::FScalarConstTrue(expr_with_outer_refs)))
+	if (exprhdl.HasOuterRefs() && 0 < stats_ctxt->Size())
 	{
 		// derive stats based on outer references
 		IStatistics *stats = DeriveStatsWithOuterRefs(

--- a/src/backend/gporca/libnaucrates/src/statistics/CJoinStatsProcessor.cpp
+++ b/src/backend/gporca/libnaucrates/src/statistics/CJoinStatsProcessor.cpp
@@ -575,7 +575,9 @@ CJoinStatsProcessor::DeriveJoinStats(CMemoryPool *mp,
 	IStatistics *join_stats = CJoinStatsProcessor::CalcAllJoinStats(
 		mp, statistics_array, local_expr, exprhdl.Pop());
 
-	if (exprhdl.HasOuterRefs() && 0 < stats_ctxt->Size())
+	if (exprhdl.HasOuterRefs() && 0 < stats_ctxt->Size() &&
+		!(exprhdl.Pop()->Eopid() == COperator::EopLogicalNAryJoin &&
+		  CUtils::FScalarConstTrue(expr_with_outer_refs)))
 	{
 		// derive stats based on outer references
 		IStatistics *stats = DeriveStatsWithOuterRefs(

--- a/src/backend/gporca/libnaucrates/src/statistics/CJoinStatsProcessor.cpp
+++ b/src/backend/gporca/libnaucrates/src/statistics/CJoinStatsProcessor.cpp
@@ -575,6 +575,15 @@ CJoinStatsProcessor::DeriveJoinStats(CMemoryPool *mp,
 	IStatistics *join_stats = CJoinStatsProcessor::CalcAllJoinStats(
 		mp, statistics_array, local_expr, exprhdl.Pop());
 
+
+	// If expr_with_outer_refs is a CScalarConst and the join operator is
+	// CLogicalNAryJoin then outer references stats will not be derived.This is
+	// because it will lead to a crash.When the query contains a left join or a
+	// cascading of left and inner joins, the join operator will be CLogicalNAryJoin
+	// and the CScalarNAryJoinPredList will contain the ON predicates for inner joins
+	// and left joins as its children.So if expr_with_outer_refs is a CScalarConst and
+	// not CScalarNAryJoinPredList then it will lead to a crash while accessing the
+	// children of CScalarConst.
 	if (exprhdl.HasOuterRefs() && 0 < stats_ctxt->Size() &&
 		!(exprhdl.Pop()->Eopid() == COperator::EopLogicalNAryJoin &&
 		  CUtils::FScalarConstTrue(expr_with_outer_refs)))

--- a/src/test/regress/expected/qp_correlated_query.out
+++ b/src/test/regress/expected/qp_correlated_query.out
@@ -3846,6 +3846,21 @@ select * from t1 where 0 < (select count(*) from generate_series(1, a), t1);
 reset optimizer_enforce_subplans;
 DROP TABLE IF EXISTS t1;
 DROP TABLE IF EXISTS supplier;
+-------------------------------------------------------------------------------------------------------------
+-- Planner should fail due to skip-level correlation not supported. Query should not cause segfault on ORCA
+-------------------------------------------------------------------------------------------------------------
+create table skip_correlated_t1(a int, b int) distributed by (a);
+create table skip_correlated_t2(a int, b int) distributed by (a);
+create table skip_correlated_t3(a int, b int) distributed by (a);
+create table skip_correlated_t4(a int, b int) distributed by (a);
+explain select * from skip_correlated_t1 where (EXISTS ( select skip_correlated_t2.a from skip_correlated_t2 left join skip_correlated_t3 on (EXISTS ( select skip_correlated_t1.b from skip_correlated_t2))));
+ERROR:  correlated subquery with skip-level correlations is not supported
+explain select * from skip_correlated_t1 where (EXISTS ( select skip_correlated_t2.a from skip_correlated_t2 inner join skip_correlated_t3 on skip_correlated_t2.a=skip_correlated_t3.a left join skip_correlated_t4 on (EXISTS (select skip_correlated_t1.b from skip_correlated_t2))));
+ERROR:  correlated subquery with skip-level correlations is not supported
+drop table skip_correlated_t1;
+drop table skip_correlated_t2;
+drop table skip_correlated_t3;
+drop table skip_correlated_t4;
 -- ----------------------------------------------------------------------
 -- Test: teardown.sql
 -- ----------------------------------------------------------------------

--- a/src/test/regress/expected/qp_correlated_query.out
+++ b/src/test/regress/expected/qp_correlated_query.out
@@ -3855,8 +3855,36 @@ create table skip_correlated_t3(a int, b int) distributed by (a);
 create table skip_correlated_t4(a int, b int) distributed by (a);
 explain select * from skip_correlated_t1 where (EXISTS ( select skip_correlated_t2.a from skip_correlated_t2 left join skip_correlated_t3 on (EXISTS ( select skip_correlated_t1.b from skip_correlated_t2))));
 ERROR:  correlated subquery with skip-level correlations is not supported
+explain select * from skip_correlated_t1 where (EXISTS ( select skip_correlated_t2.a from skip_correlated_t2 left join skip_correlated_t3 on (EXISTS (select 1 from skip_correlated_t2 where a > skip_correlated_t1.b))));
+ERROR:  correlated subquery with skip-level correlations is not supported
 explain select * from skip_correlated_t1 where (EXISTS ( select skip_correlated_t2.a from skip_correlated_t2 inner join skip_correlated_t3 on skip_correlated_t2.a=skip_correlated_t3.a left join skip_correlated_t4 on (EXISTS (select skip_correlated_t1.b from skip_correlated_t2))));
 ERROR:  correlated subquery with skip-level correlations is not supported
+---------------------------------------------------------------------------------------------------
+-- Query should not cause segfault on ORCA.Will fallback to planner as no plan is computed by ORCA
+---------------------------------------------------------------------------------------------------
+explain select * from skip_correlated_t1 where (EXISTS (select skip_correlated_t2.a from skip_correlated_t2 left join skip_correlated_t3 on skip_correlated_t3.a =ALL(select skip_correlated_t1.a from skip_correlated_t2)));
+                                                               QUERY PLAN                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..895.00 rows=43050 width=8)
+   ->  Seq Scan on skip_correlated_t1  (cost=0.00..321.00 rows=14350 width=8)
+         Filter: (SubPlan 1)
+         SubPlan 1
+           ->  Nested Loop Left Join  (cost=20000000000.00..20111221277.04 rows=1411500 width=0)
+                 ->  Materialize  (cost=0.00..1899.50 rows=86100 width=0)
+                       ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1469.00 rows=86100 width=0)
+                             ->  Seq Scan on skip_correlated_t2  (cost=0.00..321.00 rows=28700 width=0)
+                 ->  Materialize  (cost=10000000000.00..10111201733.83 rows=16 width=0)
+                       ->  Nested Loop Left Anti Semi (Not-In) Join  (cost=10000000000.00..10111201733.75 rows=16 width=0)
+                             Join Filter: (skip_correlated_t3.a <> skip_correlated_t1.a)
+                             ->  Materialize  (cost=0.00..1899.50 rows=86100 width=4)
+                                   ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..1469.00 rows=86100 width=4)
+                                         ->  Seq Scan on skip_correlated_t3  (cost=0.00..321.00 rows=28700 width=4)
+                             ->  Materialize  (cost=0.00..1899.50 rows=86100 width=0)
+                                   ->  Broadcast Motion 3:3  (slice4; segments: 3)  (cost=0.00..1469.00 rows=86100 width=0)
+                                         ->  Seq Scan on skip_correlated_t2 skip_correlated_t2_1  (cost=0.00..321.00 rows=28700 width=0)
+ Optimizer: Postgres query optimizer
+(18 rows)
+
 drop table skip_correlated_t1;
 drop table skip_correlated_t2;
 drop table skip_correlated_t3;

--- a/src/test/regress/expected/qp_correlated_query.out
+++ b/src/test/regress/expected/qp_correlated_query.out
@@ -3846,49 +3846,110 @@ select * from t1 where 0 < (select count(*) from generate_series(1, a), t1);
 reset optimizer_enforce_subplans;
 DROP TABLE IF EXISTS t1;
 DROP TABLE IF EXISTS supplier;
--------------------------------------------------------------------------------------------------------------
--- Planner should fail due to skip-level correlation not supported. Query should not cause segfault on ORCA
--------------------------------------------------------------------------------------------------------------
-create table skip_correlated_t1(a int, b int) distributed by (a);
-create table skip_correlated_t2(a int, b int) distributed by (a);
-create table skip_correlated_t3(a int, b int) distributed by (a);
-create table skip_correlated_t4(a int, b int) distributed by (a);
-explain select * from skip_correlated_t1 where (EXISTS ( select skip_correlated_t2.a from skip_correlated_t2 left join skip_correlated_t3 on (EXISTS ( select skip_correlated_t1.b from skip_correlated_t2))));
+--------------------------------------------------------------------------------
+-- Planner should fail due to skip-level correlation not supported. Query should
+-- not cause segfault on ORCA. Currently ORCA is falling back to planner which
+-- is undesired. Github Issue #15693
+--------------------------------------------------------------------------------
+CREATE TABLE skip_correlated_t1 (
+    a INT,
+    b INT
+) DISTRIBUTED BY (a);
+CREATE TABLE skip_correlated_t2 (
+    a INT,
+    b INT
+) DISTRIBUTED BY (a);
+CREATE TABLE skip_correlated_t3 (
+    a INT,
+    b INT
+) DISTRIBUTED BY (a);
+CREATE TABLE skip_correlated_t4 (
+    a INT,
+    b INT
+) DISTRIBUTED BY (a);
+EXPLAIN (COSTS OFF)
+SELECT *
+FROM skip_correlated_t1
+WHERE EXISTS (
+    SELECT skip_correlated_t2.a
+    FROM skip_correlated_t2
+             LEFT JOIN skip_correlated_t3 ON EXISTS (
+        SELECT skip_correlated_t1.b
+        FROM skip_correlated_t2
+    )
+);
 ERROR:  correlated subquery with skip-level correlations is not supported
-explain select * from skip_correlated_t1 where (EXISTS ( select skip_correlated_t2.a from skip_correlated_t2 left join skip_correlated_t3 on (EXISTS (select 1 from skip_correlated_t2 where a > skip_correlated_t1.b))));
+EXPLAIN (COSTS OFF)
+SELECT *
+FROM skip_correlated_t1
+WHERE EXISTS (
+    SELECT skip_correlated_t2.a
+    FROM skip_correlated_t2
+             LEFT JOIN skip_correlated_t3 ON (
+        EXISTS (
+            SELECT 1
+            FROM skip_correlated_t2
+            WHERE a > skip_correlated_t1.b
+        )
+        )
+);
 ERROR:  correlated subquery with skip-level correlations is not supported
-explain select * from skip_correlated_t1 where (EXISTS ( select skip_correlated_t2.a from skip_correlated_t2 inner join skip_correlated_t3 on skip_correlated_t2.a=skip_correlated_t3.a left join skip_correlated_t4 on (EXISTS (select skip_correlated_t1.b from skip_correlated_t2))));
+EXPLAIN (COSTS OFF)
+SELECT *
+FROM skip_correlated_t1
+WHERE EXISTS (
+    SELECT skip_correlated_t2.a
+    FROM skip_correlated_t2
+             INNER JOIN skip_correlated_t3 ON skip_correlated_t2.a = skip_correlated_t3.a
+             LEFT JOIN skip_correlated_t4 ON (
+        EXISTS (
+            SELECT skip_correlated_t1.b
+            FROM skip_correlated_t2
+        )
+        )
+);
 ERROR:  correlated subquery with skip-level correlations is not supported
----------------------------------------------------------------------------------------------------
--- Query should not cause segfault on ORCA.Will fallback to planner as no plan is computed by ORCA
----------------------------------------------------------------------------------------------------
-explain select * from skip_correlated_t1 where (EXISTS (select skip_correlated_t2.a from skip_correlated_t2 left join skip_correlated_t3 on skip_correlated_t3.a =ALL(select skip_correlated_t1.a from skip_correlated_t2)));
-                                                               QUERY PLAN                                                                
------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..895.00 rows=43050 width=8)
-   ->  Seq Scan on skip_correlated_t1  (cost=0.00..321.00 rows=14350 width=8)
+--------------------------------------------------------------------------------
+-- Query should not cause segfault on ORCA. Will fallback to planner as no plan
+-- is computed by ORCA. Github Issue #15693
+--------------------------------------------------------------------------------
+EXPLAIN (COSTS OFF)
+SELECT *
+FROM skip_correlated_t1
+WHERE EXISTS (
+    SELECT skip_correlated_t2.a
+    FROM skip_correlated_t2
+             LEFT JOIN skip_correlated_t3 ON skip_correlated_t3.a = ALL (
+        SELECT skip_correlated_t1.a
+        FROM skip_correlated_t2
+    )
+);
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on skip_correlated_t1
          Filter: (SubPlan 1)
          SubPlan 1
-           ->  Nested Loop Left Join  (cost=20000000000.00..20111221277.04 rows=1411500 width=0)
-                 ->  Materialize  (cost=0.00..1899.50 rows=86100 width=0)
-                       ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1469.00 rows=86100 width=0)
-                             ->  Seq Scan on skip_correlated_t2  (cost=0.00..321.00 rows=28700 width=0)
-                 ->  Materialize  (cost=10000000000.00..10111201733.83 rows=16 width=0)
-                       ->  Nested Loop Left Anti Semi (Not-In) Join  (cost=10000000000.00..10111201733.75 rows=16 width=0)
+           ->  Nested Loop Left Join
+                 ->  Materialize
+                       ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                             ->  Seq Scan on skip_correlated_t2
+                 ->  Materialize
+                       ->  Nested Loop Left Anti Semi (Not-In) Join
                              Join Filter: (skip_correlated_t3.a <> skip_correlated_t1.a)
-                             ->  Materialize  (cost=0.00..1899.50 rows=86100 width=4)
-                                   ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..1469.00 rows=86100 width=4)
-                                         ->  Seq Scan on skip_correlated_t3  (cost=0.00..321.00 rows=28700 width=4)
-                             ->  Materialize  (cost=0.00..1899.50 rows=86100 width=0)
-                                   ->  Broadcast Motion 3:3  (slice4; segments: 3)  (cost=0.00..1469.00 rows=86100 width=0)
-                                         ->  Seq Scan on skip_correlated_t2 skip_correlated_t2_1  (cost=0.00..321.00 rows=28700 width=0)
+                             ->  Materialize
+                                   ->  Broadcast Motion 3:3  (slice3; segments: 3)
+                                         ->  Seq Scan on skip_correlated_t3
+                             ->  Materialize
+                                   ->  Broadcast Motion 3:3  (slice4; segments: 3)
+                                         ->  Seq Scan on skip_correlated_t2 skip_correlated_t2_1
  Optimizer: Postgres query optimizer
 (18 rows)
 
-drop table skip_correlated_t1;
-drop table skip_correlated_t2;
-drop table skip_correlated_t3;
-drop table skip_correlated_t4;
+DROP TABLE skip_correlated_t1;
+DROP TABLE skip_correlated_t2;
+DROP TABLE skip_correlated_t3;
+DROP TABLE skip_correlated_t4;
 -- ----------------------------------------------------------------------
 -- Test: teardown.sql
 -- ----------------------------------------------------------------------

--- a/src/test/regress/expected/qp_correlated_query_optimizer.out
+++ b/src/test/regress/expected/qp_correlated_query_optimizer.out
@@ -3985,57 +3985,118 @@ select * from t1 where 0 < (select count(*) from generate_series(1, a), t1);
 reset optimizer_enforce_subplans;
 DROP TABLE IF EXISTS t1;
 DROP TABLE IF EXISTS supplier;
--------------------------------------------------------------------------------------------------------------
--- Planner should fail due to skip-level correlation not supported. Query should not cause segfault on ORCA
--------------------------------------------------------------------------------------------------------------
-create table skip_correlated_t1(a int, b int) distributed by (a);
-create table skip_correlated_t2(a int, b int) distributed by (a);
-create table skip_correlated_t3(a int, b int) distributed by (a);
-create table skip_correlated_t4(a int, b int) distributed by (a);
-explain select * from skip_correlated_t1 where (EXISTS ( select skip_correlated_t2.a from skip_correlated_t2 left join skip_correlated_t3 on (EXISTS ( select skip_correlated_t1.b from skip_correlated_t2))));
+--------------------------------------------------------------------------------
+-- Planner should fail due to skip-level correlation not supported. Query should
+-- not cause segfault on ORCA. Currently ORCA is falling back to planner which
+-- is undesired. Github Issue #15693
+--------------------------------------------------------------------------------
+CREATE TABLE skip_correlated_t1 (
+    a INT,
+    b INT
+) DISTRIBUTED BY (a);
+CREATE TABLE skip_correlated_t2 (
+    a INT,
+    b INT
+) DISTRIBUTED BY (a);
+CREATE TABLE skip_correlated_t3 (
+    a INT,
+    b INT
+) DISTRIBUTED BY (a);
+CREATE TABLE skip_correlated_t4 (
+    a INT,
+    b INT
+) DISTRIBUTED BY (a);
+EXPLAIN (COSTS OFF)
+SELECT *
+FROM skip_correlated_t1
+WHERE EXISTS (
+    SELECT skip_correlated_t2.a
+    FROM skip_correlated_t2
+             LEFT JOIN skip_correlated_t3 ON EXISTS (
+        SELECT skip_correlated_t1.b
+        FROM skip_correlated_t2
+    )
+);
 INFO:  GPORCA failed to produce a plan, falling back to planner
 DETAIL:  No plan has been computed for required properties
 ERROR:  correlated subquery with skip-level correlations is not supported
-explain select * from skip_correlated_t1 where (EXISTS ( select skip_correlated_t2.a from skip_correlated_t2 left join skip_correlated_t3 on (EXISTS (select 1 from skip_correlated_t2 where a > skip_correlated_t1.b))));
+EXPLAIN (COSTS OFF)
+SELECT *
+FROM skip_correlated_t1
+WHERE EXISTS (
+    SELECT skip_correlated_t2.a
+    FROM skip_correlated_t2
+             LEFT JOIN skip_correlated_t3 ON (
+        EXISTS (
+            SELECT 1
+            FROM skip_correlated_t2
+            WHERE a > skip_correlated_t1.b
+        )
+        )
+);
 INFO:  GPORCA failed to produce a plan, falling back to planner
 DETAIL:  No plan has been computed for required properties
 ERROR:  correlated subquery with skip-level correlations is not supported
-explain select * from skip_correlated_t1 where (EXISTS ( select skip_correlated_t2.a from skip_correlated_t2 inner join skip_correlated_t3 on skip_correlated_t2.a=skip_correlated_t3.a left join skip_correlated_t4 on (EXISTS (select skip_correlated_t1.b from skip_correlated_t2))));
+EXPLAIN (COSTS OFF)
+SELECT *
+FROM skip_correlated_t1
+WHERE EXISTS (
+    SELECT skip_correlated_t2.a
+    FROM skip_correlated_t2
+             INNER JOIN skip_correlated_t3 ON skip_correlated_t2.a = skip_correlated_t3.a
+             LEFT JOIN skip_correlated_t4 ON (
+        EXISTS (
+            SELECT skip_correlated_t1.b
+            FROM skip_correlated_t2
+        )
+        )
+);
 INFO:  GPORCA failed to produce a plan, falling back to planner
 DETAIL:  No plan has been computed for required properties
 ERROR:  correlated subquery with skip-level correlations is not supported
----------------------------------------------------------------------------------------------------
--- Query should not cause segfault on ORCA.Will fallback to planner as no plan is computed by ORCA
----------------------------------------------------------------------------------------------------
-explain select * from skip_correlated_t1 where (EXISTS (select skip_correlated_t2.a from skip_correlated_t2 left join skip_correlated_t3 on skip_correlated_t3.a =ALL(select skip_correlated_t1.a from skip_correlated_t2)));
+--------------------------------------------------------------------------------
+-- Query should not cause segfault on ORCA. Will fallback to planner as no plan
+-- is computed by ORCA. Github Issue #15693
+--------------------------------------------------------------------------------
+EXPLAIN (COSTS OFF)
+SELECT *
+FROM skip_correlated_t1
+WHERE EXISTS (
+    SELECT skip_correlated_t2.a
+    FROM skip_correlated_t2
+             LEFT JOIN skip_correlated_t3 ON skip_correlated_t3.a = ALL (
+        SELECT skip_correlated_t1.a
+        FROM skip_correlated_t2
+    )
+);
 INFO:  GPORCA failed to produce a plan, falling back to planner
 DETAIL:  No plan has been computed for required properties
-                                                               QUERY PLAN
------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..895.00 rows=43050 width=8)
-   ->  Seq Scan on skip_correlated_t1  (cost=0.00..321.00 rows=14350 width=8)
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on skip_correlated_t1
          Filter: (SubPlan 1)
          SubPlan 1
-           ->  Nested Loop Left Join  (cost=20000000000.00..20111221277.04 rows=1411500 width=0)
-                 ->  Materialize  (cost=0.00..1899.50 rows=86100 width=0)
-                       ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1469.00 rows=86100 width=0)
-                             ->  Seq Scan on skip_correlated_t2  (cost=0.00..321.00 rows=28700 width=0)
-                 ->  Materialize  (cost=10000000000.00..10111201733.83 rows=16 width=0)
-                       ->  Nested Loop Left Anti Semi (Not-In) Join  (cost=10000000000.00..10111201733.75 rows=16 width=0)
+           ->  Nested Loop Left Join
+                 ->  Materialize
+                       ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                             ->  Seq Scan on skip_correlated_t2
+                 ->  Materialize
+                       ->  Nested Loop Left Anti Semi (Not-In) Join
                              Join Filter: (skip_correlated_t3.a <> skip_correlated_t1.a)
-                             ->  Materialize  (cost=0.00..1899.50 rows=86100 width=4)
-                                   ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..1469.00 rows=86100 width=4)
-                                         ->  Seq Scan on skip_correlated_t3  (cost=0.00..321.00 rows=28700 width=4)
-                             ->  Materialize  (cost=0.00..1899.50 rows=86100 width=0)
-                                   ->  Broadcast Motion 3:3  (slice4; segments: 3)  (cost=0.00..1469.00 rows=86100 width=0)
-                                         ->  Seq Scan on skip_correlated_t2 skip_correlated_t2_1  (cost=0.00..321.00 rows=28700 width=0)
+                             ->  Materialize
+                                   ->  Broadcast Motion 3:3  (slice3; segments: 3)
+                                         ->  Seq Scan on skip_correlated_t3
+                             ->  Materialize
+                                   ->  Broadcast Motion 3:3  (slice4; segments: 3)
+                                         ->  Seq Scan on skip_correlated_t2 skip_correlated_t2_1
  Optimizer: Postgres query optimizer
 (18 rows)
 
-drop table skip_correlated_t1;
-drop table skip_correlated_t2;
-drop table skip_correlated_t3;
-drop table skip_correlated_t4;
+DROP TABLE skip_correlated_t1;
+DROP TABLE skip_correlated_t2;
+DROP TABLE skip_correlated_t3;
+DROP TABLE skip_correlated_t4;
 -- ----------------------------------------------------------------------
 -- Test: teardown.sql
 -- ----------------------------------------------------------------------

--- a/src/test/regress/expected/qp_correlated_query_optimizer.out
+++ b/src/test/regress/expected/qp_correlated_query_optimizer.out
@@ -3985,6 +3985,25 @@ select * from t1 where 0 < (select count(*) from generate_series(1, a), t1);
 reset optimizer_enforce_subplans;
 DROP TABLE IF EXISTS t1;
 DROP TABLE IF EXISTS supplier;
+-------------------------------------------------------------------------------------------------------------
+-- Planner should fail due to skip-level correlation not supported. Query should not cause segfault on ORCA
+-------------------------------------------------------------------------------------------------------------
+create table skip_correlated_t1(a int, b int) distributed by (a);
+create table skip_correlated_t2(a int, b int) distributed by (a);
+create table skip_correlated_t3(a int, b int) distributed by (a);
+create table skip_correlated_t4(a int, b int) distributed by (a);
+explain select * from skip_correlated_t1 where (EXISTS ( select skip_correlated_t2.a from skip_correlated_t2 left join skip_correlated_t3 on (EXISTS ( select skip_correlated_t1.b from skip_correlated_t2))));
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  No plan has been computed for required properties
+ERROR:  correlated subquery with skip-level correlations is not supported
+explain select * from skip_correlated_t1 where (EXISTS ( select skip_correlated_t2.a from skip_correlated_t2 inner join skip_correlated_t3 on skip_correlated_t2.a=skip_correlated_t3.a left join skip_correlated_t4 on (EXISTS (select skip_correlated_t1.b from skip_correlated_t2))));
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  No plan has been computed for required properties
+ERROR:  correlated subquery with skip-level correlations is not supported
+drop table skip_correlated_t1;
+drop table skip_correlated_t2;
+drop table skip_correlated_t3;
+drop table skip_correlated_t4;
 -- ----------------------------------------------------------------------
 -- Test: teardown.sql
 -- ----------------------------------------------------------------------

--- a/src/test/regress/expected/qp_correlated_query_optimizer.out
+++ b/src/test/regress/expected/qp_correlated_query_optimizer.out
@@ -3996,10 +3996,42 @@ explain select * from skip_correlated_t1 where (EXISTS ( select skip_correlated_
 INFO:  GPORCA failed to produce a plan, falling back to planner
 DETAIL:  No plan has been computed for required properties
 ERROR:  correlated subquery with skip-level correlations is not supported
+explain select * from skip_correlated_t1 where (EXISTS ( select skip_correlated_t2.a from skip_correlated_t2 left join skip_correlated_t3 on (EXISTS (select 1 from skip_correlated_t2 where a > skip_correlated_t1.b))));
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  No plan has been computed for required properties
+ERROR:  correlated subquery with skip-level correlations is not supported
 explain select * from skip_correlated_t1 where (EXISTS ( select skip_correlated_t2.a from skip_correlated_t2 inner join skip_correlated_t3 on skip_correlated_t2.a=skip_correlated_t3.a left join skip_correlated_t4 on (EXISTS (select skip_correlated_t1.b from skip_correlated_t2))));
 INFO:  GPORCA failed to produce a plan, falling back to planner
 DETAIL:  No plan has been computed for required properties
 ERROR:  correlated subquery with skip-level correlations is not supported
+---------------------------------------------------------------------------------------------------
+-- Query should not cause segfault on ORCA.Will fallback to planner as no plan is computed by ORCA
+---------------------------------------------------------------------------------------------------
+explain select * from skip_correlated_t1 where (EXISTS (select skip_correlated_t2.a from skip_correlated_t2 left join skip_correlated_t3 on skip_correlated_t3.a =ALL(select skip_correlated_t1.a from skip_correlated_t2)));
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  No plan has been computed for required properties
+                                                               QUERY PLAN
+-----------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..895.00 rows=43050 width=8)
+   ->  Seq Scan on skip_correlated_t1  (cost=0.00..321.00 rows=14350 width=8)
+         Filter: (SubPlan 1)
+         SubPlan 1
+           ->  Nested Loop Left Join  (cost=20000000000.00..20111221277.04 rows=1411500 width=0)
+                 ->  Materialize  (cost=0.00..1899.50 rows=86100 width=0)
+                       ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1469.00 rows=86100 width=0)
+                             ->  Seq Scan on skip_correlated_t2  (cost=0.00..321.00 rows=28700 width=0)
+                 ->  Materialize  (cost=10000000000.00..10111201733.83 rows=16 width=0)
+                       ->  Nested Loop Left Anti Semi (Not-In) Join  (cost=10000000000.00..10111201733.75 rows=16 width=0)
+                             Join Filter: (skip_correlated_t3.a <> skip_correlated_t1.a)
+                             ->  Materialize  (cost=0.00..1899.50 rows=86100 width=4)
+                                   ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..1469.00 rows=86100 width=4)
+                                         ->  Seq Scan on skip_correlated_t3  (cost=0.00..321.00 rows=28700 width=4)
+                             ->  Materialize  (cost=0.00..1899.50 rows=86100 width=0)
+                                   ->  Broadcast Motion 3:3  (slice4; segments: 3)  (cost=0.00..1469.00 rows=86100 width=0)
+                                         ->  Seq Scan on skip_correlated_t2 skip_correlated_t2_1  (cost=0.00..321.00 rows=28700 width=0)
+ Optimizer: Postgres query optimizer
+(18 rows)
+
 drop table skip_correlated_t1;
 drop table skip_correlated_t2;
 drop table skip_correlated_t3;

--- a/src/test/regress/sql/qp_correlated_query.sql
+++ b/src/test/regress/sql/qp_correlated_query.sql
@@ -787,7 +787,13 @@ create table skip_correlated_t2(a int, b int) distributed by (a);
 create table skip_correlated_t3(a int, b int) distributed by (a);
 create table skip_correlated_t4(a int, b int) distributed by (a);
 explain select * from skip_correlated_t1 where (EXISTS ( select skip_correlated_t2.a from skip_correlated_t2 left join skip_correlated_t3 on (EXISTS ( select skip_correlated_t1.b from skip_correlated_t2))));
+explain select * from skip_correlated_t1 where (EXISTS ( select skip_correlated_t2.a from skip_correlated_t2 left join skip_correlated_t3 on (EXISTS (select 1 from skip_correlated_t2 where a > skip_correlated_t1.b))));
 explain select * from skip_correlated_t1 where (EXISTS ( select skip_correlated_t2.a from skip_correlated_t2 inner join skip_correlated_t3 on skip_correlated_t2.a=skip_correlated_t3.a left join skip_correlated_t4 on (EXISTS (select skip_correlated_t1.b from skip_correlated_t2))));
+
+---------------------------------------------------------------------------------------------------
+-- Query should not cause segfault on ORCA.Will fallback to planner as no plan is computed by ORCA
+---------------------------------------------------------------------------------------------------
+explain select * from skip_correlated_t1 where (EXISTS (select skip_correlated_t2.a from skip_correlated_t2 left join skip_correlated_t3 on skip_correlated_t3.a =ALL(select skip_correlated_t1.a from skip_correlated_t2)));
 drop table skip_correlated_t1;
 drop table skip_correlated_t2;
 drop table skip_correlated_t3;

--- a/src/test/regress/sql/qp_correlated_query.sql
+++ b/src/test/regress/sql/qp_correlated_query.sql
@@ -779,6 +779,20 @@ reset optimizer_enforce_subplans;
 DROP TABLE IF EXISTS t1;
 DROP TABLE IF EXISTS supplier;
 
+-------------------------------------------------------------------------------------------------------------
+-- Planner should fail due to skip-level correlation not supported. Query should not cause segfault on ORCA
+-------------------------------------------------------------------------------------------------------------
+create table skip_correlated_t1(a int, b int) distributed by (a);
+create table skip_correlated_t2(a int, b int) distributed by (a);
+create table skip_correlated_t3(a int, b int) distributed by (a);
+create table skip_correlated_t4(a int, b int) distributed by (a);
+explain select * from skip_correlated_t1 where (EXISTS ( select skip_correlated_t2.a from skip_correlated_t2 left join skip_correlated_t3 on (EXISTS ( select skip_correlated_t1.b from skip_correlated_t2))));
+explain select * from skip_correlated_t1 where (EXISTS ( select skip_correlated_t2.a from skip_correlated_t2 inner join skip_correlated_t3 on skip_correlated_t2.a=skip_correlated_t3.a left join skip_correlated_t4 on (EXISTS (select skip_correlated_t1.b from skip_correlated_t2))));
+drop table skip_correlated_t1;
+drop table skip_correlated_t2;
+drop table skip_correlated_t3;
+drop table skip_correlated_t4;
+
 -- ----------------------------------------------------------------------
 -- Test: teardown.sql
 -- ----------------------------------------------------------------------


### PR DESCRIPTION
Fixing crash in ORCA with skip-level correlated query
This PR fixes the crash in ORCA observed with skip-level correlated query
containing a subquery.

Setup:
-------
```
create table t1(a int, b int);
create table t2(a int, b int);
create table t3(a int, b int);
```

Query:
-------
```
explain select * from t1 where ( EXISTS ( select t2.a from t2 left join t3 on (
EXISTS ( select t1.b from t2))));
```

Detailed RCA:
-------------
In 7X the trace flag EopttraceEnableLOJInNAryJoin is enabled by default. Due to
this CLogicalLeftOuterJoin is converted to CLogicalNAryJoin in the
preprocessing stage. For the above query while deriving the join stats using
method CJoinStatsProcessor::DeriveJoinStats the subquery present in the join
condition is replaced by a CScalarConst by method PexprScalarRepChild. After
this the code seperates out the join predicate into local predicates and
predicates involving outer references using method
CPredicateUtils::SeparateOuterRefs. The predicate involving outer references is
returned as a CScalarConst from SeparateOuterRefs method because the columns in
the join predicate are disjoint to outer references (Since subquery is already
replaced with CScalarConst by PexprScalarRepChild). Now since outer references
are present in the query we try to derive the stats with outer references using
CScalarConst as the join predicate. Due to this we hit a assert in
CJoinStatsProcessor::CalcAllJoinStats method which checks if the join operator
is CLogicalNAryJoin then the join predicate should have
EopScalarNAryJoinPredList as its parent which is not the case for CScalarConst.
The issue is in CPredicateUtils::SeparateOuterRefs method. The predicate
involving outer references is returned as a CScalarConst and it's parent
operator CScalarNAryJoinPredList is not preserved.

Fix:
----
In the method CPredicateUtils::SeparateOuterRefs, the first step is to assess
the derived used columns of the scalar expression and verify if they overlap
with the outer reference. However, due to the transformation of the subquery
containing the outer reference into a CScalarConst, the disjoint check results
in a true evaluation. Consequently, a CScalarConst is returned for the
predicate involving outer references, which is incorrect when the parent
operator is CScalarNAryJoinPredList. To resolve this issue, the disjoint check
should only be evaluated when the parent operator is not
CScalarNAryJoinPredList in order to preserve this operator.