### PR TITLE
[6X backport] Disable pg_upgrade parallel tablespace transfer

### DIFF
--- a/contrib/pg_upgrade/parallel.c
+++ b/contrib/pg_upgrade/parallel.c
@@ -189,7 +189,12 @@ parallel_transfer_all_new_dbs(DbInfoArr *old_db_arr, DbInfoArr *new_db_arr,
 	transfer_thread_arg *new_arg;
 #endif
 
-	if (user_opts.jobs <= 1)
+	/*
+	 * GPDB: Disable pg_upgrade's broken parallel tablespace transfer to make the rest
+	 * of the parallelism from the --jobs flag usable now to get a performance
+	 * boost.
+	 */
+	if (true) /* (user_opts.jobs <= 1) */
 		transfer_all_new_dbs(old_db_arr, new_db_arr, old_pgdata, new_pgdata, NULL);
 	else
 	{

--- a/contrib/pg_upgrade/relfilenode.c
+++ b/contrib/pg_upgrade/relfilenode.c
@@ -44,8 +44,12 @@ transfer_all_new_tablespaces(DbInfoArr *old_db_arr, DbInfoArr *new_db_arr,
 	 * tablespace path, which matches all tablespaces.  In parallel mode, we
 	 * pass the default tablespace and all user-created tablespaces and let
 	 * those operations happen in parallel.
+	 *
+	 * GPDB: Disable pg_upgrade's broken parallel tablespace transfer to make the rest
+	 * of the parallelism from the --jobs flag usable now to get a performance
+	 * boost.
 	 */
-	if (user_opts.jobs <= 1)
+	if (true) /* (user_opts.jobs <= 1) */
 		parallel_transfer_all_new_dbs(old_db_arr, new_db_arr, old_pgdata,
 									  new_pgdata, NULL);
 	else


### PR DESCRIPTION
backported from 7x commit:
https://github.com/greenplum-db/gpdb/commit/b286ac793dab9f0fa368a4d11cbc0eacda0db46d

original commit message:
Disable pg_upgrade's broken parallel tablespace transfer. By doing this, we can utilize the remaining parallelism from the --jobs flag to achieve a performance boost.

The --jobs flag in pgupgrade allows for parallelization in two ways:

1. It enables parallel schema upgrades by running multiple instances of pg_dump/pg_restore to upgrade the database schema simultaneously.
2. It supports parallel data transfer of tablespaces when using link mode.

However, there is currently a bug in the parallel tablespace transfer functionality that causes pg_upgrade to fail with the following error:

```
error while creating link for relation [relation_name]
      ([old_relfilenode] to [new_relfilenode]): File exists
Failure, exiting
```
