### PR TITLE
Replace previous gpdb package for ubuntu20.04

### DIFF
--- a/concourse/pipelines/templates/gpdb-tpl.yml
+++ b/concourse/pipelines/templates/gpdb-tpl.yml
@@ -478,12 +478,21 @@ resources:
     ref: d1d3a143cf1804552afedaa3be0ad54c14986605
 {% endif %}
 
+{% if os_type == "ubuntu20.04" %}
+- name: gpdb_package_ubuntu20.04
+  type: gcs
+  source:
+    bucket: pivotal-gpdb-concourse-resources-intermediates-prod
+    json_key: ((concourse-gcs-resources-service-account-key))
+    versioned_file: gpdb-package-testing/deb_gpdb_ubuntu20.04/greenplum-db-6-ubuntu20.04-amd64.deb
+{% else %}
 - name: previous_gpdb
   type: pivnet
   source:
     api_token: ((pivotal-gpdb-pivnet-api-token))
     product_slug: pivotal-gpdb
     product_version: ((pivotal-gpdb-pivnet-product-version))
+{% endif %}
 
 {% if os_type == "oel8" or os_type == "rhel8"  %}
 - name: gpdb6-[[ default_os_type ]]-build
@@ -989,12 +998,14 @@ jobs:
       - get: gpdb_src
         trigger: true
         passed: [compile_gpdb_[[ compile_platform ]]]
+      {% if os_type == "ubuntu20.04" %}
+      - get: gpdb_package
+        resource: gpdb_package_ubuntu20.04
+      {% else %}
       - get: gpdb_package
         resource: previous_gpdb
         params:
-          {% if os_type == "ubuntu20.04" %}
-          globs: [greenplum-db-6*-ubuntu18.04-amd64.deb]
-          {% elif os_type == "rocky8" %}
+          {% if os_type == "rocky8" %}
           globs: [greenplum-db-6*-rhel8-x86_64.rpm]
           {% elif os_type == "oel8" %}
           globs: [greenplum-db-6*-rhel8-x86_64.rpm]
@@ -1005,6 +1016,7 @@ jobs:
           {% else %}
           globs: [greenplum-db-6*-[[ dist ]]-x86_64.rpm]
           {% endif %}
+      {% endif %}
       - get: gpdb6-[[ compile_platform ]]-build
   - task: generate_previous_bin_gpdb
     file: gpdb_src/concourse/tasks/extract_package.yml


### PR DESCRIPTION
This is a temporary change. We should revert this commit once we release the package for ubuntu20.04 on TanzuNet.

We don't release the package for ubuntu20.04 on TanzuNet yet, so cannot download the previous release from TanzuNet. Previously we tried to use ubuntu18.04 package as a substitute but the `icw_planner_ubuntu20.04` test will fail with error

```
ImportError: libssl.so.1.0.0: cannot open shared object file: No such file or directory
```
hence try to use the ubuntu20.04 package produced by gpdb-package-testing pipeline

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
