### PR TITLE
Fix compile warning after refactoring macro RelationIsAppendOptimized

### DIFF
--- a/src/backend/commands/cluster.c
+++ b/src/backend/commands/cluster.c
@@ -670,8 +670,6 @@ rebuild_relation(Relation OldHeap, Oid indexOid, bool verbose)
 	TransactionId frozenXid;
 	MultiXactId cutoffMulti;
 
-    bool		is_ao = RelationStorageIsAO(OldHeap);
-
 	/* Mark the correct index as clustered */
 	if (OidIsValid(indexOid))
 		mark_index_clustered(OldHeap, indexOid, true);


### PR DESCRIPTION
PR try to fix compile warning which caused by https://github.com/greenplum-db/gpdb/commit/0c942b968db1badec64f5385e58fa971be46a461.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
