### PR TITLE
Fix coordinator crash in MPPnoticeReceiver

### DIFF
--- a/src/backend/cdb/dispatcher/cdbconn.c
+++ b/src/backend/cdb/dispatcher/cdbconn.c
@@ -523,7 +523,7 @@ struct QENotice
 	char		sqlstate[6];
 	char		severity[10];
 	char	   *file;
-	char		line[10];
+	char	   *line;
 	char	   *func;
 	char	   *message;
 	char	   *whoami;
@@ -556,9 +556,9 @@ MPPnoticeReceiver(void *arg, const PGresult *res)
 	int			elevel = INFO;
 	char	   *sqlstate = "00000";
 	char	   *severity = "WARNING";
-	char	   *file = "";
+	char	   *file = NULL;
 	char	   *line = NULL;
-	char	   *func = "";
+	char	   *func = NULL;
 	char	   *message= "missing error text";
 	char	   *detail = NULL;
 	char	   *hint = NULL;
@@ -646,6 +646,7 @@ MPPnoticeReceiver(void *arg, const PGresult *res)
 		uint64		size;
 		char	   *bufptr;
 		int			file_len;
+		int			line_len;
 		int			func_len;
 		int			detail_len;
 		int			hint_len;
@@ -675,6 +676,7 @@ MPPnoticeReceiver(void *arg, const PGresult *res)
 
 		size = offsetof(QENotice, buf);
 		SIZE_VARLEN_FIELD(file);
+		SIZE_VARLEN_FIELD(line);
 		SIZE_VARLEN_FIELD(func);
 		SIZE_VARLEN_FIELD(detail);
 		SIZE_VARLEN_FIELD(hint);
@@ -716,7 +718,7 @@ MPPnoticeReceiver(void *arg, const PGresult *res)
 		strlcpy(notice->sqlstate, sqlstate, sizeof(notice->sqlstate));
 		strlcpy(notice->severity, severity, sizeof(notice->severity));
 		COPY_VARLEN_FIELD(file);
-		strlcpy(notice->line, line, sizeof(notice->line));
+		COPY_VARLEN_FIELD(line);
 		COPY_VARLEN_FIELD(func);
 		COPY_VARLEN_FIELD(detail);
 		COPY_VARLEN_FIELD(hint);
@@ -815,7 +817,7 @@ forwardQENotices(void)
 					pq_sendstring(&msgbuf, notice->file);
 				}
 
-				if (notice->line[0])
+				if (notice->line)
 				{
 					pq_sendbyte(&msgbuf,PG_DIAG_SOURCE_LINE);
 					pq_sendstring(&msgbuf, notice->line);


### PR DESCRIPTION
 fix issues #15194 

We got an unexpected msg while idle. So, we construct a simple notice msg use pqInternalNotice
which do not specify the line no. Due to the line is NULL we got segfault in MPPnoticeReceiver while
copying it to QENotice using strlcpy(notice->line, line, sizeof(notice->line));

Solution: use the same way as file does. Use SIZE_VARLEN_FIELD and COPY_VARLEN_FIELD instead of strlcpy.
SIZE_VARLEN_FIELD and COPY_VARLEN_FIELD will process NULL value.

In MPPnoticeReceiver the initialize value of file and func is "".
```
char	   *file = "";
char	   *func = "";
```
If the notice we received does not contain file or func info, file or func will still be "".
In SIZE_VARLEN_FIELD and COPY_VARLEN_FIELD we only judge NULL value not
judge "" value, so the length will be calculated as 1 and "" will be copied to QENotice,
but this has no meanings.

In forwardQENotices if file is NULL we do not send file info to client.
however, here we send "" to client.
```
if (notice->file)
{
	pq_sendbyte(&msgbuf, PG_DIAG_SOURCE_FILE);
	pq_sendstring(&msgbuf, notice->file);
}
```

So change initialize value of file and func in MPPnoticeReceiver to NULL to avoid sending unnecessary
"" to client.

backport from 6x: https://github.com/greenplum-db/gpdb/pull/15397