### PR TITLE
Fix unlock the pruned partitions of partition table

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -4296,10 +4296,17 @@ CTranslatorDXLToPlStmt::TranslateDXLDynTblScan(
 
 	List *oids_list = NIL;
 
+	const CDXLTableDescr *dxl_table_descr =
+		dyn_tbl_scan_dxlop->GetDXLTableDescr();
+	GPOS_RTL_ASSERT(dxl_table_descr->LockMode() != -1);
+
 	for (ULONG ul = 0; ul < parts->Size(); ul++)
 	{
 		Oid part = CMDIdGPDB::CastMdid((*parts)[ul])->Oid();
 		oids_list = gpdb::LAppendOid(oids_list, part);
+		// Since parser locks only root partition, locking the leaf
+		// partitions which we have to scan.
+		gpdb::GPDBLockRelationOid(part, dxl_table_descr->LockMode());
 	}
 
 	dyn_seq_scan->partOids = oids_list;
@@ -4380,10 +4387,15 @@ CTranslatorDXLToPlStmt::TranslateDXLDynIdxScan(
 
 	List *oids_list = NIL;
 
+	GPOS_RTL_ASSERT(table_desc->LockMode() != -1);
+
 	for (ULONG ul = 0; ul < parts->Size(); ul++)
 	{
 		Oid part = CMDIdGPDB::CastMdid((*parts)[ul])->Oid();
 		oids_list = gpdb::LAppendOid(oids_list, part);
+		// Since parser locks only root partition, locking the leaf
+		// partitions which we have to scan.
+		gpdb::GPDBLockRelationOid(part, table_desc->LockMode());
 	}
 
 	dyn_idx_scan->partOids = oids_list;

--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -4298,7 +4298,7 @@ CTranslatorDXLToPlStmt::TranslateDXLDynTblScan(
 
 	const CDXLTableDescr *dxl_table_descr =
 		dyn_tbl_scan_dxlop->GetDXLTableDescr();
-	GPOS_RTL_ASSERT(dxl_table_descr->LockMode() != -1);
+	GPOS_ASSERT(dxl_table_descr->LockMode() != -1);
 
 	for (ULONG ul = 0; ul < parts->Size(); ul++)
 	{
@@ -4387,7 +4387,7 @@ CTranslatorDXLToPlStmt::TranslateDXLDynIdxScan(
 
 	List *oids_list = NIL;
 
-	GPOS_RTL_ASSERT(table_desc->LockMode() != -1);
+	GPOS_ASSERT(table_desc->LockMode() != -1);
 
 	for (ULONG ul = 0; ul < parts->Size(); ul++)
 	{

--- a/src/backend/optimizer/util/plancat.c
+++ b/src/backend/optimizer/util/plancat.c
@@ -678,7 +678,7 @@ cdb_estimate_partitioned_numtuples(Relation rel)
 		double		childtuples;
 
 		if (childid != RelationGetRelid(rel))
-			childrel = childrel = RelationIdGetRelation(childid);
+			childrel = RelationIdGetRelation(childid);
 		else
 			childrel = rel;
 

--- a/src/backend/optimizer/util/plancat.c
+++ b/src/backend/optimizer/util/plancat.c
@@ -666,7 +666,7 @@ cdb_estimate_partitioned_numtuples(Relation rel)
 		return rel->rd_rel->reltuples;
 
 	inheritors = find_all_inheritors(RelationGetRelid(rel),
-									 NoLock,
+									 AccessShareLock,
 									 NULL);
 	totaltuples = 0;
 	foreach(lc, inheritors)
@@ -676,7 +676,7 @@ cdb_estimate_partitioned_numtuples(Relation rel)
 		double		childtuples;
 
 		if (childid != RelationGetRelid(rel))
-			childrel = RelationIdGetRelation(childid);
+			childrel = try_table_open(childid, NoLock, false);
 		else
 			childrel = rel;
 
@@ -706,7 +706,7 @@ cdb_estimate_partitioned_numtuples(Relation rel)
 		totaltuples += childtuples;
 
 		if (childrel != rel)
-			heap_close(childrel, NoLock);
+			heap_close(childrel, AccessShareLock);
 	}
 	return totaltuples;
 }

--- a/src/backend/optimizer/util/plancat.c
+++ b/src/backend/optimizer/util/plancat.c
@@ -668,7 +668,8 @@ cdb_estimate_partitioned_numtuples(Relation rel)
 	// To avoid blocking concurrent transactions on leaf partitions
 	// throughout the entire transition, we refrain from acquiring locks on
 	// the leaf partitions. Instead, we acquire locks only on the
-	// partitions that need to be scanned when ORCA writes the plan.
+	// partitions that need to be scanned when ORCA writes the plan,
+	// although it may lead to less accurate stats.
 	inheritors = find_all_inheritors(RelationGetRelid(rel), NoLock, NULL);
 	totaltuples = 0;
 	foreach(lc, inheritors)

--- a/src/backend/optimizer/util/plancat.c
+++ b/src/backend/optimizer/util/plancat.c
@@ -718,6 +718,11 @@ cdb_estimate_partitioned_numtuples(Relation rel)
 			// acquired an AccessShareLock on the leaf partitions.
 			// Therefore, we can safely release the AccessShareLock
 			// after the necessary processing has been completed.
+			// This approach helps us to avoid unnecessary locks on
+			// the leaf partitions. It is worth noting that later
+			// on, we acquire locks on unpruned partitions, which
+			// allows concurrent transactions on the leaf
+			// partitions that are available for use.
 			heap_close(childrel, AccessShareLock);
 	}
 	return totaltuples;

--- a/src/backend/optimizer/util/plancat.c
+++ b/src/backend/optimizer/util/plancat.c
@@ -684,9 +684,9 @@ cdb_estimate_partitioned_numtuples(Relation rel)
 
 		// If childrel is NULL, continue by assuming the child relation
 		// has 0 tuples.
-		if (NULL == childrel) {
+		if (childrel == NULL)
 			continue;
-		}
+
 		childtuples = childrel->rd_rel->reltuples;
 
 		if (gp_enable_relsize_collection && childtuples == 0)

--- a/src/backend/optimizer/util/plancat.c
+++ b/src/backend/optimizer/util/plancat.c
@@ -682,6 +682,11 @@ cdb_estimate_partitioned_numtuples(Relation rel)
 		else
 			childrel = rel;
 
+		// If childrel is NULL, continue by assuming the child relation
+		// has 0 tuples.
+		if (NULL == childrel) {
+			continue;
+		}
 		childtuples = childrel->rd_rel->reltuples;
 
 		if (gp_enable_relsize_collection && childtuples == 0)

--- a/src/backend/optimizer/util/plancat.c
+++ b/src/backend/optimizer/util/plancat.c
@@ -666,7 +666,7 @@ cdb_estimate_partitioned_numtuples(Relation rel)
 		return rel->rd_rel->reltuples;
 
 	inheritors = find_all_inheritors(RelationGetRelid(rel),
-									 AccessShareLock,
+									 NoLock,
 									 NULL);
 	totaltuples = 0;
 	foreach(lc, inheritors)
@@ -676,7 +676,7 @@ cdb_estimate_partitioned_numtuples(Relation rel)
 		double		childtuples;
 
 		if (childid != RelationGetRelid(rel))
-			childrel = try_table_open(childid, NoLock, false);
+			childrel = RelationIdGetRelation(childid);
 		else
 			childrel = rel;
 

--- a/src/test/isolation2/expected/lockmodes_optimizer.out
+++ b/src/test/isolation2/expected/lockmodes_optimizer.out
@@ -1040,11 +1040,11 @@ BEGIN
 DELETE 10
 -- on QD, there's a lock on the root and the target partition
 1: select * from show_locks_lockmodes;
- locktype | mode            | granted | relation                        
-----------+-----------------+---------+---------------------------------
- relation | AccessShareLock | t       | t_lockmods_part_tbl_dml_1_prt_2 
- relation | AccessShareLock | t       | t_lockmods_part_tbl_dml_1_prt_1 
- relation | ExclusiveLock   | t       | t_lockmods_part_tbl_dml         
+ locktype | mode          | granted | relation
+----------+---------------+---------+---------------------------------
+ relation | ExclusiveLock | t       | t_lockmods_part_tbl_dml_1_prt_2
+ relation | ExclusiveLock | t       | t_lockmods_part_tbl_dml
+ relation | ExclusiveLock | t       | t_lockmods_part_tbl_dml_1_prt_1
 (3 rows)
 1: ROLLBACK;
 ROLLBACK
@@ -1093,12 +1093,12 @@ BEGIN
 UPDATE 1
 -- on QD, there's a lock on the root and the target partition
 1: select * from show_locks_lockmodes;
- locktype | mode            | granted | relation                        
+ locktype | mode            | granted | relation
 ----------+-----------------+---------+---------------------------------
- relation | AccessShareLock | t       | t_lockmods_part_tbl_dml_1_prt_2 
- relation | AccessShareLock | t       | t_lockmods_part_tbl_dml_1_prt_1 
- relation | AccessShareLock | t       | t_lockmods_part_tbl_dml         
- relation | ExclusiveLock   | t       | t_lockmods_part_tbl_dml         
+ relation | ExclusiveLock   | t       | t_lockmods_part_tbl_dml_1_prt_2
+ relation | AccessShareLock | t       | t_lockmods_part_tbl_dml
+ relation | ExclusiveLock   | t       | t_lockmods_part_tbl_dml
+ relation | ExclusiveLock   | t       | t_lockmods_part_tbl_dml_1_prt_1
 (4 rows)
 1: ROLLBACK;
 ROLLBACK
@@ -2178,10 +2178,10 @@ BEGIN
 DELETE 10
 -- since the delete operation is on leaf part, there will be a lock on QD
 1: select * from show_locks_lockmodes;
- locktype | mode             | granted | relation
+ locktype | mode             | granted | relation                        
 ----------+------------------+---------+---------------------------------
- relation | AccessShareLock  | t       | t_lockmods_part_tbl_dml
- relation | RowExclusiveLock | t       | t_lockmods_part_tbl_dml_1_prt_1
+ relation | AccessShareLock  | t       | t_lockmods_part_tbl_dml         
+ relation | RowExclusiveLock | t       | t_lockmods_part_tbl_dml_1_prt_1 
 (2 rows)
 1: ROLLBACK;
 ROLLBACK
@@ -2193,10 +2193,10 @@ BEGIN
 UPDATE 1
 -- since the update operation is on leaf part, there will be a lock on QD
 1: select * from show_locks_lockmodes;
- locktype | mode             | granted | relation
+ locktype | mode             | granted | relation                        
 ----------+------------------+---------+---------------------------------
- relation | AccessShareLock  | t       | t_lockmods_part_tbl_dml
- relation | RowExclusiveLock | t       | t_lockmods_part_tbl_dml_1_prt_1
+ relation | AccessShareLock  | t       | t_lockmods_part_tbl_dml         
+ relation | RowExclusiveLock | t       | t_lockmods_part_tbl_dml_1_prt_1 
 (2 rows)
 1: ROLLBACK;
 ROLLBACK
@@ -2208,10 +2208,10 @@ BEGIN
 INSERT 0 10
 -- With GDD enabled, QD will only hold lock on root for insert
 1: select * from show_locks_lockmodes;
- locktype | mode             | granted | relation
+ locktype | mode             | granted | relation                
 ----------+------------------+---------+-------------------------
- relation | AccessShareLock  | t       | t_lockmods_part_tbl_dml
- relation | RowExclusiveLock | t       | t_lockmods_part_tbl_dml
+ relation | AccessShareLock  | t       | t_lockmods_part_tbl_dml 
+ relation | RowExclusiveLock | t       | t_lockmods_part_tbl_dml 
 (2 rows)
 1: ROLLBACK;
 ROLLBACK
@@ -2225,7 +2225,7 @@ BEGIN
 DELETE 0
 -- With GDD enabled, QD will only hold lock on root for delete
 1: select * from show_locks_lockmodes;
- locktype | mode            | granted | relation                  
+ locktype | mode            | granted | relation
 ----------+-----------------+---------+---------------------------
  relation | ExclusiveLock   | t       | t_lockmods_aopart_1_prt_4
  relation | AccessShareLock | t       | t_lockmods_aopart

--- a/src/test/isolation2/expected/lockmodes_optimizer.out
+++ b/src/test/isolation2/expected/lockmodes_optimizer.out
@@ -2144,12 +2144,12 @@ BEGIN
 DELETE 10
 -- on QD, there's a lock on the root and the target partition
 1: select * from show_locks_lockmodes;
- locktype | mode             | granted | relation                        
+ locktype | mode             | granted | relation
 ----------+------------------+---------+---------------------------------
- relation | AccessShareLock  | t       | t_lockmods_part_tbl_dml_1_prt_2 
- relation | AccessShareLock  | t       | t_lockmods_part_tbl_dml_1_prt_1 
- relation | AccessShareLock  | t       | t_lockmods_part_tbl_dml         
- relation | RowExclusiveLock | t       | t_lockmods_part_tbl_dml         
+ relation | RowExclusiveLock | t       | t_lockmods_part_tbl_dml_1_prt_2
+ relation | RowExclusiveLock | t       | t_lockmods_part_tbl_dml_1_prt_1
+ relation | AccessShareLock  | t       | t_lockmods_part_tbl_dml
+ relation | RowExclusiveLock | t       | t_lockmods_part_tbl_dml
 (4 rows)
 1: ROLLBACK;
 ROLLBACK
@@ -2161,12 +2161,12 @@ BEGIN
 UPDATE 1
 -- on QD, there's a lock on the root and the target partition
 1: select * from show_locks_lockmodes;
- locktype | mode             | granted | relation                        
+ locktype | mode             | granted | relation
 ----------+------------------+---------+---------------------------------
- relation | AccessShareLock  | t       | t_lockmods_part_tbl_dml_1_prt_2 
- relation | AccessShareLock  | t       | t_lockmods_part_tbl_dml_1_prt_1 
- relation | AccessShareLock  | t       | t_lockmods_part_tbl_dml         
- relation | RowExclusiveLock | t       | t_lockmods_part_tbl_dml         
+ relation | RowExclusiveLock | t       | t_lockmods_part_tbl_dml_1_prt_2
+ relation | RowExclusiveLock | t       | t_lockmods_part_tbl_dml_1_prt_1
+ relation | AccessShareLock  | t       | t_lockmods_part_tbl_dml
+ relation | RowExclusiveLock | t       | t_lockmods_part_tbl_dml
 (4 rows)
 1: ROLLBACK;
 ROLLBACK
@@ -2178,10 +2178,10 @@ BEGIN
 DELETE 10
 -- since the delete operation is on leaf part, there will be a lock on QD
 1: select * from show_locks_lockmodes;
- locktype | mode             | granted | relation                        
+ locktype | mode             | granted | relation
 ----------+------------------+---------+---------------------------------
- relation | AccessShareLock  | t       | t_lockmods_part_tbl_dml         
- relation | RowExclusiveLock | t       | t_lockmods_part_tbl_dml_1_prt_1 
+ relation | AccessShareLock  | t       | t_lockmods_part_tbl_dml
+ relation | RowExclusiveLock | t       | t_lockmods_part_tbl_dml_1_prt_1
 (2 rows)
 1: ROLLBACK;
 ROLLBACK
@@ -2193,10 +2193,10 @@ BEGIN
 UPDATE 1
 -- since the update operation is on leaf part, there will be a lock on QD
 1: select * from show_locks_lockmodes;
- locktype | mode             | granted | relation                        
+ locktype | mode             | granted | relation
 ----------+------------------+---------+---------------------------------
- relation | AccessShareLock  | t       | t_lockmods_part_tbl_dml         
- relation | RowExclusiveLock | t       | t_lockmods_part_tbl_dml_1_prt_1 
+ relation | AccessShareLock  | t       | t_lockmods_part_tbl_dml
+ relation | RowExclusiveLock | t       | t_lockmods_part_tbl_dml_1_prt_1
 (2 rows)
 1: ROLLBACK;
 ROLLBACK
@@ -2208,10 +2208,10 @@ BEGIN
 INSERT 0 10
 -- With GDD enabled, QD will only hold lock on root for insert
 1: select * from show_locks_lockmodes;
- locktype | mode             | granted | relation                
+ locktype | mode             | granted | relation
 ----------+------------------+---------+-------------------------
- relation | AccessShareLock  | t       | t_lockmods_part_tbl_dml 
- relation | RowExclusiveLock | t       | t_lockmods_part_tbl_dml 
+ relation | AccessShareLock  | t       | t_lockmods_part_tbl_dml
+ relation | RowExclusiveLock | t       | t_lockmods_part_tbl_dml
 (2 rows)
 1: ROLLBACK;
 ROLLBACK
@@ -2227,13 +2227,10 @@ DELETE 0
 1: select * from show_locks_lockmodes;
  locktype | mode            | granted | relation                  
 ----------+-----------------+---------+---------------------------
- relation | AccessShareLock | t       | t_lockmods_aopart_1_prt_4 
- relation | AccessShareLock | t       | t_lockmods_aopart_1_prt_3 
- relation | AccessShareLock | t       | t_lockmods_aopart_1_prt_2 
- relation | AccessShareLock | t       | t_lockmods_aopart_1_prt_1 
- relation | AccessShareLock | t       | t_lockmods_aopart         
- relation | ExclusiveLock   | t       | t_lockmods_aopart         
-(6 rows)
+ relation | ExclusiveLock   | t       | t_lockmods_aopart_1_prt_4
+ relation | AccessShareLock | t       | t_lockmods_aopart
+ relation | ExclusiveLock   | t       | t_lockmods_aopart
+(3 rows)
 1: COMMIT;
 COMMIT
 1: DROP TABLE t_lockmods_aopart;

--- a/src/test/isolation2/expected/lockmodes_optimizer.out
+++ b/src/test/isolation2/expected/lockmodes_optimizer.out
@@ -1040,11 +1040,11 @@ BEGIN
 DELETE 10
 -- on QD, there's a lock on the root and the target partition
 1: select * from show_locks_lockmodes;
- locktype | mode          | granted | relation
+ locktype | mode          | granted | relation                        
 ----------+---------------+---------+---------------------------------
- relation | ExclusiveLock | t       | t_lockmods_part_tbl_dml_1_prt_2
- relation | ExclusiveLock | t       | t_lockmods_part_tbl_dml
- relation | ExclusiveLock | t       | t_lockmods_part_tbl_dml_1_prt_1
+ relation | ExclusiveLock | t       | t_lockmods_part_tbl_dml_1_prt_2 
+ relation | ExclusiveLock | t       | t_lockmods_part_tbl_dml         
+ relation | ExclusiveLock | t       | t_lockmods_part_tbl_dml_1_prt_1 
 (3 rows)
 1: ROLLBACK;
 ROLLBACK
@@ -1093,12 +1093,12 @@ BEGIN
 UPDATE 1
 -- on QD, there's a lock on the root and the target partition
 1: select * from show_locks_lockmodes;
- locktype | mode            | granted | relation
+ locktype | mode            | granted | relation                        
 ----------+-----------------+---------+---------------------------------
- relation | ExclusiveLock   | t       | t_lockmods_part_tbl_dml_1_prt_2
- relation | AccessShareLock | t       | t_lockmods_part_tbl_dml
- relation | ExclusiveLock   | t       | t_lockmods_part_tbl_dml
- relation | ExclusiveLock   | t       | t_lockmods_part_tbl_dml_1_prt_1
+ relation | ExclusiveLock   | t       | t_lockmods_part_tbl_dml_1_prt_2 
+ relation | AccessShareLock | t       | t_lockmods_part_tbl_dml         
+ relation | ExclusiveLock   | t       | t_lockmods_part_tbl_dml         
+ relation | ExclusiveLock   | t       | t_lockmods_part_tbl_dml_1_prt_1 
 (4 rows)
 1: ROLLBACK;
 ROLLBACK
@@ -2144,12 +2144,12 @@ BEGIN
 DELETE 10
 -- on QD, there's a lock on the root and the target partition
 1: select * from show_locks_lockmodes;
- locktype | mode             | granted | relation
+ locktype | mode             | granted | relation                        
 ----------+------------------+---------+---------------------------------
- relation | RowExclusiveLock | t       | t_lockmods_part_tbl_dml_1_prt_2
- relation | RowExclusiveLock | t       | t_lockmods_part_tbl_dml_1_prt_1
- relation | AccessShareLock  | t       | t_lockmods_part_tbl_dml
- relation | RowExclusiveLock | t       | t_lockmods_part_tbl_dml
+ relation | RowExclusiveLock | t       | t_lockmods_part_tbl_dml_1_prt_2 
+ relation | RowExclusiveLock | t       | t_lockmods_part_tbl_dml_1_prt_1 
+ relation | AccessShareLock  | t       | t_lockmods_part_tbl_dml         
+ relation | RowExclusiveLock | t       | t_lockmods_part_tbl_dml         
 (4 rows)
 1: ROLLBACK;
 ROLLBACK
@@ -2161,12 +2161,12 @@ BEGIN
 UPDATE 1
 -- on QD, there's a lock on the root and the target partition
 1: select * from show_locks_lockmodes;
- locktype | mode             | granted | relation
+ locktype | mode             | granted | relation                        
 ----------+------------------+---------+---------------------------------
- relation | RowExclusiveLock | t       | t_lockmods_part_tbl_dml_1_prt_2
- relation | RowExclusiveLock | t       | t_lockmods_part_tbl_dml_1_prt_1
- relation | AccessShareLock  | t       | t_lockmods_part_tbl_dml
- relation | RowExclusiveLock | t       | t_lockmods_part_tbl_dml
+ relation | RowExclusiveLock | t       | t_lockmods_part_tbl_dml_1_prt_2 
+ relation | RowExclusiveLock | t       | t_lockmods_part_tbl_dml_1_prt_1 
+ relation | AccessShareLock  | t       | t_lockmods_part_tbl_dml         
+ relation | RowExclusiveLock | t       | t_lockmods_part_tbl_dml         
 (4 rows)
 1: ROLLBACK;
 ROLLBACK
@@ -2225,11 +2225,11 @@ BEGIN
 DELETE 0
 -- With GDD enabled, QD will only hold lock on root for delete
 1: select * from show_locks_lockmodes;
- locktype | mode            | granted | relation
+ locktype | mode            | granted | relation                  
 ----------+-----------------+---------+---------------------------
- relation | ExclusiveLock   | t       | t_lockmods_aopart_1_prt_4
- relation | AccessShareLock | t       | t_lockmods_aopart
- relation | ExclusiveLock   | t       | t_lockmods_aopart
+ relation | ExclusiveLock   | t       | t_lockmods_aopart_1_prt_4 
+ relation | AccessShareLock | t       | t_lockmods_aopart         
+ relation | ExclusiveLock   | t       | t_lockmods_aopart         
 (3 rows)
 1: COMMIT;
 COMMIT

--- a/src/test/regress/expected/partition_locking.out
+++ b/src/test/regress/expected/partition_locking.out
@@ -7,11 +7,6 @@
 -- runs out of lock space, you can work around that by simply bumping up
 -- max_locks_per_transactions.
 --
--- ORCA doesn't support DDL queries on partitioned tables and falls back to
--- planner. However, the locking pattern when ORCA falls back is be different
--- when ICG is run in assert vs non-assert modes.  Revisit this once DML
--- queries are supported by ORCA
-set optimizer = off;
 -- Show locks in master and in segments. Because the number of segments
 -- in the cluster depends on configuration, we print only summary information
 -- of the locks in segments. If a relation is locked only on one segment,
@@ -139,6 +134,33 @@ select * from locktest_segments where coalesce not like 'gp_%' and coalesce not 
  toast table       | ShareLock           | relation | n segments
  toast index       | AccessExclusiveLock | relation | n segments
 (28 rows)
+
+commit;
+-- select
+select * from partlockt where i = 1;
+ i | t 
+---+---
+(0 rows)
+
+-- check locks when the relation found in MD cache
+begin;
+select * from partlockt where i = 1;
+ i | t 
+---+---
+(0 rows)
+
+select * from locktest_master where coalesce not like 'gp_%' and coalesce not like 'pg_%';
+     coalesce      |      mode       | locktype |  node  
+-------------------+-----------------+----------+--------
+ partlockt         | AccessShareLock | relation | master
+ partlockt_1_prt_1 | AccessShareLock | relation | master
+(2 rows)
+
+select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
+     coalesce      |      mode       | locktype |   node    
+-------------------+-----------------+----------+-----------
+ partlockt_1_prt_1 | AccessShareLock | relation | 1 segment
+(1 row)
 
 commit;
 -- drop
@@ -402,7 +424,6 @@ select * from partlockt where i = 1;
 ---+---
 (0 rows)
 
--- Known_opt_diff: MPP-20936
 select * from locktest_master where coalesce not like 'gp_%' and coalesce not like 'pg_%';
         coalesce         |      mode       | locktype |  node  
 -------------------------+-----------------+----------+--------
@@ -419,10 +440,16 @@ select * from locktest_segments where coalesce not like 'gp_%' and coalesce not 
 (2 rows)
 
 commit;
+-- In ORCA we are seeing discrepancy with 'AccessShareLock' on root partition table
+-- with-assert and without-assert modes of DML queries, because
+-- with-assert mode we are forced to release the cache, which leads to acquire
+-- 'AccessShareLock' always on master.  Since the AccessShareLock on root
+-- partition is redundant so we are skipping to evaluate.
 begin;
 -- insert locking
 insert into partlockt values(3, 'f');
-select * from locktest_master where coalesce not like 'gp_%' and coalesce not like 'pg_%';
+select * from locktest_master where coalesce not like 'gp_%' and coalesce not like 'pg_%' and
+                                    not(coalesce like 'partlockt' and mode like 'AccessShareLock');
      coalesce      |       mode       | locktype |  node  
 -------------------+------------------+----------+--------
  partlockt         | RowExclusiveLock | relation | master
@@ -449,15 +476,14 @@ commit;
 -- delete locking
 begin;
 delete from partlockt where i = 4;
--- Known_opt_diff: MPP-20936
-select * from locktest_master where coalesce not like 'gp_%' and coalesce not like 'pg_%';
-        coalesce         |      mode       | locktype |  node  
--------------------------+-----------------+----------+--------
- partlockt               | AccessShareLock | relation | master
- partlockt               | ExclusiveLock   | relation | master
- partlockt_1_prt_4       | ExclusiveLock   | relation | master
- partlockt_1_prt_4_i_idx | ExclusiveLock   | relation | master
-(4 rows)
+select * from locktest_master where coalesce not like 'gp_%' and coalesce not like 'pg_%' and
+                                    not(coalesce like 'partlockt' and mode like 'AccessShareLock');
+        coalesce         |     mode      | locktype |  node  
+-------------------------+---------------+----------+--------
+ partlockt               | ExclusiveLock | relation | master
+ partlockt_1_prt_4       | ExclusiveLock | relation | master
+ partlockt_1_prt_4_i_idx | ExclusiveLock | relation | master
+(3 rows)
 
 select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
         coalesce         |      mode       | locktype |   node    
@@ -559,4 +585,3 @@ select * from locktest_segments where coalesce not like 'gp_%' and coalesce not 
 (38 rows)
 
 commit;
-reset optimizer;

--- a/src/test/regress/expected/partition_locking_optimizer.out
+++ b/src/test/regress/expected/partition_locking_optimizer.out
@@ -7,11 +7,6 @@
 -- runs out of lock space, you can work around that by simply bumping up
 -- max_locks_per_transactions.
 --
--- ORCA doesn't support DDL queries on partitioned tables and falls back to
--- planner. However, the locking pattern when ORCA falls back is be different
--- when ICG is run in assert vs non-assert modes.  Revisit this once DML
--- queries are supported by ORCA
-set optimizer = off;
 -- Show locks in master and in segments. Because the number of segments
 -- in the cluster depends on configuration, we print only summary information
 -- of the locks in segments. If a relation is locked only on one segment,
@@ -141,6 +136,34 @@ select * from locktest_segments where coalesce not like 'gp_%' and coalesce not 
 (28 rows)
 
 commit;
+-- select
+select * from partlockt where i = 1;
+ i | t 
+---+---
+(0 rows)
+
+-- check locks when the relation found in MD cache
+begin;
+select * from partlockt where i = 1;
+ i | t 
+---+---
+(0 rows)
+
+select * from locktest_master where coalesce not like 'gp_%' and coalesce not like 'pg_%';
+     coalesce      |      mode       | locktype |  node  
+-------------------+-----------------+----------+--------
+ partlockt         | AccessShareLock | relation | master
+ partlockt_1_prt_1 | AccessShareLock | relation | master
+(2 rows)
+
+select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
+     coalesce      |      mode       | locktype |   node    
+-------------------+-----------------+----------+-----------
+ partlockt         | AccessShareLock | relation | 1 segment
+ partlockt_1_prt_1 | AccessShareLock | relation | 1 segment
+(2 rows)
+
+commit;
 -- drop
 begin;
 drop table partlockt;
@@ -263,11 +286,12 @@ insert into partlockt values(1), (2), (3);
 select * from locktest_master where coalesce not like 'gp_%' and coalesce not like 'pg_%';
      coalesce      |       mode       | locktype |  node  
 -------------------+------------------+----------+--------
+ partlockt         | AccessShareLock  | relation | master
  partlockt         | RowExclusiveLock | relation | master
  partlockt_1_prt_1 | RowExclusiveLock | relation | master
  partlockt_1_prt_2 | RowExclusiveLock | relation | master
  partlockt_1_prt_3 | RowExclusiveLock | relation | master
-(4 rows)
+(5 rows)
 
 select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
      coalesce      |       mode       | locktype |    node    
@@ -402,30 +426,32 @@ select * from partlockt where i = 1;
 ---+---
 (0 rows)
 
--- Known_opt_diff: MPP-20936
--- start_ignore
--- GPDB_12_MERGE_FIXME Revisit this post merge and see if we have a chance to unlock the pruned partitions
--- end_ignore
 select * from locktest_master where coalesce not like 'gp_%' and coalesce not like 'pg_%';
-        coalesce         |      mode       | locktype |  node  
--------------------------+-----------------+----------+--------
- partlockt               | AccessShareLock | relation | master
- partlockt_1_prt_1       | AccessShareLock | relation | master
- partlockt_1_prt_1_i_idx | AccessShareLock | relation | master
-(3 rows)
+     coalesce      |      mode       | locktype |  node  
+-------------------+-----------------+----------+--------
+ partlockt         | AccessShareLock | relation | master
+ partlockt_1_prt_1 | AccessShareLock | relation | master
+(2 rows)
 
 select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
         coalesce         |      mode       | locktype |   node    
 -------------------------+-----------------+----------+-----------
+ partlockt               | AccessShareLock | relation | 1 segment
  partlockt_1_prt_1       | AccessShareLock | relation | 1 segment
  partlockt_1_prt_1_i_idx | AccessShareLock | relation | 1 segment
-(2 rows)
+(3 rows)
 
 commit;
+-- In ORCA we are seeing discrepancy with 'AccessShareLock' on root partition table
+-- with-assert and without-assert modes of DML queries, because
+-- with-assert mode we are forced to release the cache, which leads to acquire
+-- 'AccessShareLock' always on master.  Since the AccessShareLock on root
+-- partition is redundant so we are skipping to evaluate.
 begin;
 -- insert locking
 insert into partlockt values(3, 'f');
-select * from locktest_master where coalesce not like 'gp_%' and coalesce not like 'pg_%';
+select * from locktest_master where coalesce not like 'gp_%' and coalesce not like 'pg_%' and
+                                    not(coalesce like 'partlockt' and mode like 'AccessShareLock');
      coalesce      |       mode       | locktype |  node  
 -------------------+------------------+----------+--------
  partlockt         | RowExclusiveLock | relation | master
@@ -452,18 +478,13 @@ commit;
 -- delete locking
 begin;
 delete from partlockt where i = 4;
--- Known_opt_diff: MPP-20936
--- start_ignore
--- GPDB_12_MERGE_FIXME Revisit this post merge and see if we have a chance to unlock the pruned partitions
--- end_ignore
-select * from locktest_master where coalesce not like 'gp_%' and coalesce not like 'pg_%';
-        coalesce         |      mode       | locktype |  node  
--------------------------+-----------------+----------+--------
- partlockt               | AccessShareLock | relation | master
- partlockt               | ExclusiveLock   | relation | master
- partlockt_1_prt_4       | ExclusiveLock   | relation | master
- partlockt_1_prt_4_i_idx | ExclusiveLock   | relation | master
-(4 rows)
+select * from locktest_master where coalesce not like 'gp_%' and coalesce not like 'pg_%' and
+                                    not(coalesce like 'partlockt' and mode like 'AccessShareLock');
+     coalesce      |     mode      | locktype |  node  
+-------------------+---------------+----------+--------
+ partlockt         | ExclusiveLock | relation | master
+ partlockt_1_prt_4 | ExclusiveLock | relation | master
+(2 rows)
 
 -- start_ignore
 -- GPDB_12_MERGE_FIXME Revisit this post merge and see if we have a chance to unlock the root table
@@ -471,11 +492,10 @@ select * from locktest_master where coalesce not like 'gp_%' and coalesce not li
 select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
         coalesce         |      mode       | locktype |   node    
 -------------------------+-----------------+----------+-----------
- partlockt               | AccessShareLock | relation | 1 segment
  partlockt               | ExclusiveLock   | relation | 1 segment
- partlockt_1_prt_4       | ExclusiveLock   | relation | 1 segment
+ partlockt_1_prt_4       | AccessShareLock | relation | 1 segment
  partlockt_1_prt_4_i_idx | ExclusiveLock   | relation | 1 segment
-(4 rows)
+(3 rows)
 
 commit;
 -- drop index
@@ -568,4 +588,3 @@ select * from locktest_segments where coalesce not like 'gp_%' and coalesce not 
 (38 rows)
 
 commit;
-reset optimizer;

--- a/src/test/regress/expected/partition_locking_optimizer.out
+++ b/src/test/regress/expected/partition_locking_optimizer.out
@@ -487,7 +487,7 @@ select * from locktest_master where coalesce not like 'gp_%' and coalesce not li
 (2 rows)
 
 -- start_ignore
--- GPDB_12_MERGE_FIXME Revisit this post merge and see if we have a chance to unlock the root table
+-- GPDB_12_MERGE_FIXME Revisit this post merge and see why the leaf acquires AccessShareLock instead ExclusiveLock
 -- end_ignore
 select * from locktest_segments where coalesce not like 'gp_%' and coalesce not like 'pg_%';
         coalesce         |      mode       | locktype |   node    


### PR DESCRIPTION
FIXME's:

     * GPDB_12_MERGE_FIXME: Revisit this post merge and see if we have a
       chance to unlock the pruned partitions
     
     * GPDB_12_MERGE_FIXME: Revisit this post merge and see if we have a
       chance to unlock the pruned partitions

RCA:
	ORCA always require root partition statistics for accurate query
	planning and cost estimation. While fetching total size of a
	partition table we lock all the leaf partitions including pruned
	parittions, but if we find the relation statistics in MD cache,
	we only acquire lock on root partition table. Although acquire
	lock on every leaf partition is unnecessary, we have to acquire
	lock for necessary leaf partitions on master node, otherwise it
	can lead to deadlock issues.

	For example :
	//Assuming relation stats are available at MD Cache, so ORCA
	//acquires only lock on root parittion.
	txn A: select * from root_part;
	txn B: truncate leaf1;
	txn A and B will not block each other on QD if no locking leaf
	suppose on seg0 txn A arrive first, seg1 txn B arrive first
	on seg0, txn B will wait for A
	on seg1, txn A will wait for B
	Global Deadlock happens

Fix:
	This PR fixes the unnecessary lock on leaf partitions of a
	partition table and acquires the lock only on unpruned leaf
	partition.
	`Thumb rule is if we are going to hold a lock of table on
	segment, we should first hold the lock on master (QD)`.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
