### PR TITLE
Import collations at gpinitsystem time

### DIFF
--- a/gpMgmt/bin/gpinitsystem
+++ b/gpMgmt/bin/gpinitsystem
@@ -1503,6 +1503,41 @@ START_QD_PRODUCTION () {
     LOG_MSG "[INFO]:-End Function $FUNCNAME"
 }
 
+# Important system collations through pg_import_system_collations.
+# This is borrowed from initdb.c:setup_collation(). At the end of this routine, we also ANALYZE and VACUUM FREEZE 
+# the built-in databases (borrowed from initdb.c:vacuum_db()), to leave them in a similar state as initdb would have.
+# In GPDB we cannot do it at initdb time because pg_import_system_collations needs to be dispatched and run after cluster has been set up.
+IMPORT_COLLATION () {
+		LOG_MSG "[INFO]:-Start Function $FUNCNAME"
+		LOG_MSG "[INFO]:-Importing system collations" 1
+
+		# temporarily allow connection for template0, so we can import collations to it.
+		$PSQL -p $GP_PORT -d postgres -A -t -c "ALTER DATABASE template0 ALLOW_CONNECTIONS on" >> $LOG_FILE 2>&1;
+		$PSQL -p $GP_PORT -d template0 -A -t -c "SELECT pg_import_system_collations('pg_catalog')" >> $LOG_FILE 2>&1;
+		ERROR_CHK $? "importing system collations to 'template0' database" 1
+		$PSQL -p $GP_PORT -d template0 -A -t -c "ANALYZE" >> $LOG_FILE 2>&1;
+		ERROR_CHK $? "ANALYZE 'template0' database" 1
+		$PSQL -p $GP_PORT -d template0 -A -t -c "VACUUM FREEZE" >> $LOG_FILE 2>&1;
+		ERROR_CHK $? "VACUUM FREEZE 'template0' database" 1
+		$PSQL -p $GP_PORT -d postgres -A -t -c "ALTER DATABASE template0 ALLOW_CONNECTIONS off" >> $LOG_FILE 2>&1;
+
+		# import to template1
+		$PSQL -p $GP_PORT -d template1 -A -t -c "SELECT pg_import_system_collations('pg_catalog')" >> $LOG_FILE 2>&1;
+		ERROR_CHK $? "importing system collations to 'template1' database" 1
+		$PSQL -p $GP_PORT -d template1 -A -t -c "ANALYZE" >> $LOG_FILE 2>&1;
+		ERROR_CHK $? "ANALYZE 'template1' database" 1
+		$PSQL -p $GP_PORT -d template1 -A -t -c "VACUUM FREEZE" >> $LOG_FILE 2>&1;
+		ERROR_CHK $? "VACUUM FREEZE 'template1' database" 1
+
+		# import to postgres
+		$PSQL -p $GP_PORT -d postgres -A -t -c "SELECT pg_import_system_collations('pg_catalog')" >> $LOG_FILE 2>&1;
+		ERROR_CHK $? "importing system collations to 'postgres' database" 1
+		$PSQL -p $GP_PORT -d postgres -A -t -c "ANALYZE" >> $LOG_FILE 2>&1;
+		ERROR_CHK $? "ANALYZE 'postgres' database" 1
+		$PSQL -p $GP_PORT -d postgres -A -t -c "VACUUM FREEZE" >> $LOG_FILE 2>&1;
+		ERROR_CHK $? "VACUUM FREEZE 'postgres' database" 1
+}
+
 CREATE_DATABASE () {
 		LOG_MSG "[INFO]:-Start Function $FUNCNAME"
 		SET_VAR $QD_PRIMARY_ARRAY
@@ -1956,6 +1991,7 @@ STOP_QD_PRODUCTION
 START_QD_PRODUCTION
 
 CREATE_GPEXTENSIONS
+IMPORT_COLLATION
 
 if [ x"" != x"$DATABASE_NAME" ]; then
 	CREATE_DATABASE

--- a/gpMgmt/bin/gppylib/gpcatalog.py
+++ b/gpMgmt/bin/gppylib/gpcatalog.py
@@ -47,6 +47,7 @@ SEGMENT_LOCAL_TABLES = [
 # catalog table
 DEPENDENCY_EXCLUSION = [
     'pg_authid',
+    'pg_collation',
     'pg_compression',
     'pg_conversion',
     'pg_database',

--- a/gpMgmt/test/behave/mgmt_utils/gpinitsystem.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpinitsystem.feature
@@ -17,6 +17,23 @@ Feature: gpinitsystem tests
         And gpconfig should print "Coordinator value: off" to stdout
         And gpconfig should print "Segment     value: off" to stdout
 
+    Scenario: gpinitsystem should import the system collations
+        Given the database is not running
+        And create demo cluster config
+        When the user runs command "gpinitsystem -a -c ../gpAux/gpdemo/clusterConfigFile"
+        Then gpinitsystem should return a return code of 0
+        And the user runs "psql postgres -c "create table collationimport1 as select * from pg_collation where collnamespace = 'pg_catalog'::regnamespace""
+        # no more collation is imported
+        When the user runs "psql postgres -c "select pg_import_system_collations('pg_catalog')""
+        Then psql should return a return code of 0
+        And psql should print "0" to stdout
+        And psql should print "(1 row)" to stdout
+        And the user runs "psql postgres -c "create table collationimport2 as select * from pg_collation where collnamespace = 'pg_catalog'::regnamespace""
+        # no difference is before import and after import
+        When the user runs "psql postgres -c "select * from collationimport1 except select * from collationimport2""
+        Then psql should return a return code of 0
+        And psql should print "(0 rows)" to stdout
+
     Scenario: gpinitsystem creates a cluster when the user set LC_ALL env variable
         Given create demo cluster config
         And the environment variable "LC_ALL" is set to "en_US.UTF-8"

--- a/src/test/regress/input/oid_wraparound.source
+++ b/src/test/regress/input/oid_wraparound.source
@@ -44,12 +44,12 @@ SELECT gp_set_next_oid_master(4290000000);
 SELECT gp_set_next_oid_segments(16384);
 
 -- We expect the QE to increment once to 16385 and the QD should
--- fast-forward to 16391. The QD could possibly fast-forward to 16392
+-- fast-forward to 16390. The QD could possibly fast-forward to 16391
 -- if the pg_type heap page was not pruned for dead pg_type entry for
 -- oid_wraparound_table relation which will result in Oid 16386
 -- collision.
 SELECT gp_get_next_oid_master();
 SELECT gp_get_next_oid_segments();
 CREATE TABLE oid_wraparound_table_other AS SELECT 1 AS a;
-SELECT gp_get_next_oid_master() in (16391, 16392);
+SELECT gp_get_next_oid_master() in (16390, 16391);
 SELECT gp_get_next_oid_segments();

--- a/src/test/regress/output/oid_wraparound.source
+++ b/src/test/regress/output/oid_wraparound.source
@@ -84,7 +84,7 @@ SELECT gp_set_next_oid_segments(16384);
 (3 rows)
 
 -- We expect the QE to increment once to 16385 and the QD should
--- fast-forward to 16391. The QD could possibly fast-forward to 16392
+-- fast-forward to 16390. The QD could possibly fast-forward to 16391
 -- if the pg_type heap page was not pruned for dead pg_type entry for
 -- oid_wraparound_table relation which will result in Oid 16386
 -- collision.
@@ -103,7 +103,7 @@ SELECT gp_get_next_oid_segments();
 (3 rows)
 
 CREATE TABLE oid_wraparound_table_other AS SELECT 1 AS a;
-SELECT gp_get_next_oid_master() in (16391, 16392);
+SELECT gp_get_next_oid_master() in (16390, 16391);
  ?column? 
 ----------
  t


### PR DESCRIPTION
In upstream the function pg_import_system_collations() is run at initdb time to import all collations available on the platform. In GPDB we could not do that because we have to make sure all segments have imported the same collations and bear the same OIDs, so we disabled pg_import_system_collations in initdb and leave that task to DB admin (see PR #5016).

However, without breaking the consistency promise, this can still be done at gpinitsystem time for all initial databases (template0, template1 and postgres). If all segments could install the same collations (which is probably the majority of cases), then the call succeeds and the user does not need to do anything. Otherwise, the call fails w/ a warning and the behavior remains the same as currently where the user has to figure out what collation can be installed and call CREATE COLLATION individually.

In order to keep the same behavior as upstream, we also ANALYZE and VACUUM FREEZE the databases where we imported collations. This has some implication to pg_upgrade, see gpdb-dev discussion https://groups.google.com/a/greenplum.org/g/gpdb-dev/c/qG-wJfVzeQI .

We also re-enable the set-up of built-in collation 'ucs_basic' in initdb since that's not limited by the problem addressed in this commit (P.S. in upstream that has been burned into catalog in commit 563f21cda8fcb61a0b5f071affb79c86458e52f8).

Two other adjustments:
* Exclude pg_collation from the gpcheckcat dependency check since it is known that there's no pg_depend links for pg_collation (same as upstream).
* Regress test oid_wraparound expects one less OID because VACUUM template1 could re-enable some OID between 16384 and 16390 for re-assignment.

Dev pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/import-col-gpinitsys

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
