### PR TITLE
Fix pg_dump_binary_upgrade flaky fails. 

### DIFF
--- a/src/backend/cdb/cdbvars.c
+++ b/src/backend/cdb/cdbvars.c
@@ -51,6 +51,7 @@
 GpRoleValue Gp_role;			/* Role paid by this Greenplum Database
 								 * backend */
 char	   *gp_role_string;		/* Staging area for guc.c */
+char	   *gp_session_role_string; /* Staging area for guc.c */
 
 bool		Gp_is_writer;		/* is this qExec a "writer" process. */
 

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -4427,7 +4427,7 @@ struct config_string ConfigureNamesString_gp[] =
 			gettext_noop("Valid values are DISPATCH, EXECUTE, and UTILITY."),
 			GUC_NOT_IN_SAMPLE | GUC_DISALLOW_IN_FILE
 		},
-		&gp_role_string,
+		&gp_session_role_string,
 		"undefined",
 		check_gp_role, assign_gp_role, show_gp_role
 	},

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -68,6 +68,7 @@ typedef enum
 
 extern GpRoleValue Gp_role;	/* GUC var - server operating mode.  */
 extern char *gp_role_string;	/* Use by guc.c as staging area for value. */
+extern char *gp_session_role_string; /* Use by guc.c as staging area for value. */
 
 extern bool gp_reraise_signal; /* try to force a core dump ?*/
 


### PR DESCRIPTION
The GUC 'gp_session_role' and 'gp_role' use the same parameter 'gp_role_string' to store the value. It will lead to double free or corruption issue.

See discussion  https://github.com/greenplum-db/gpdb/issues/15370

You can check it with test case 'pg_dump_binary_upgrade'

```
./pg_regress --load-extension=gp_inject_fault --init-file=init_file pg_dump_binary_upgrade
```