### PR TITLE
Fix the import of ICU collations in pg_import_system_collations()

### DIFF
--- a/src/backend/commands/collationcmds.c
+++ b/src/backend/commands/collationcmds.c
@@ -29,6 +29,7 @@
 #include "commands/defrem.h"
 #include "mb/pg_wchar.h"
 #include "miscadmin.h"
+#include "nodes/makefuncs.h"
 #include "utils/builtins.h"
 #include "utils/lsyscache.h"
 #include "utils/pg_locale.h"
@@ -491,8 +492,16 @@ cmpaliases(const void *a, const void *b)
 }
 #endif							/* READ_LOCALE_A_OUTPUT */
 
+/*
+ * Dispatch collation create command to segments.
+ *
+ * @param alias:	collation name in collname field
+ * @param locale:	locale name, usually include lang and region
+ * @param nspid:	namespace pid
+ * @param provider:	"icu" or "libc", NULL means decided by callee (DefineCollation in QE, default "libc")
+ */
 static void
-DispatchCollationCreate(char *alias, char *locale, Oid nspid, int encoding)
+DispatchCollationCreate(char *alias, char *locale, Oid nspid, char* provider)
 {
 	Assert(Gp_role == GP_ROLE_DISPATCH);
 
@@ -503,14 +512,11 @@ DispatchCollationCreate(char *alias, char *locale, Oid nspid, int encoding)
 	names = lappend(names, schemaname);
 	names = lappend(names, relname);
 
-	List *parameters = NIL;
-	DefElem *defstring = makeNode(DefElem);
-
-	defstring->defname = "locale";
-	defstring->defaction = DEFELEM_UNSPEC;
-	defstring->arg = (Node*) makeString(locale);
-
-	parameters = lappend(parameters, defstring);
+	List *parameters = lappend(NIL, makeDefElem("locale", (Node*) makeString(locale), -1));
+	if (provider)
+	{
+		parameters = lappend(parameters, makeDefElem("provider", (Node*) makeString(provider), -1));
+	}
 
 	DefineStmt * stmt = makeNode(DefineStmt);
 	stmt->kind = OBJECT_COLLATION;
@@ -526,7 +532,6 @@ DispatchCollationCreate(char *alias, char *locale, Oid nspid, int encoding)
 	                            GetAssignedOidsForDispatch(),
 	                            NULL);
 }
-
 
 #ifdef USE_ICU
 /*
@@ -674,12 +679,12 @@ pg_import_system_collations(PG_FUNCTION_ARGS)
 				continue;		/* ignore locales for client-only encodings */
 			if (enc == PG_SQL_ASCII)
 				continue;		/* C/POSIX are already in the catalog */
-            /*
-             * Greenplum specific behavior: this function in Greenplum can only be called after a full cluster is
-             * built, this is different from Postgres which might call this function during initdb. When reaching
-             * here, it must be in a database session, we can just ignore the collations not match current database's
-             * encoding because they cannot be used in this database.
-             */
+			/*
+			 * Greenplum specific behavior: this function in Greenplum can only be called after a full cluster is
+			 * built, this is different from Postgres which might call this function during initdb. When reaching
+			 * here, it must be in a database session, we can just ignore the collations not match current database's
+			 * encoding because they cannot be used in this database.
+			 */
 			if (enc != GetDatabaseEncoding())
 				continue;       /* Ignore collations incompatible with database encoding */ 
 
@@ -702,7 +707,7 @@ pg_import_system_collations(PG_FUNCTION_ARGS)
 									 true, true);
 			if (OidIsValid(collid))
 			{
-				DispatchCollationCreate(localebuf, localebuf, nspid, enc);
+				DispatchCollationCreate(localebuf, localebuf, nspid, "libc");
 				ncreated++;
 
 				/* Must do CCI between inserts to handle duplicates correctly */
@@ -764,7 +769,7 @@ pg_import_system_collations(PG_FUNCTION_ARGS)
 									 true, true);
 			if (OidIsValid(collid))
 			{
-				DispatchCollationCreate(alias, locale, nspid, enc);
+				DispatchCollationCreate(alias, locale, nspid, "libc");
 				ncreated++;
 
 				CommandCounterIncrement();
@@ -802,6 +807,7 @@ pg_import_system_collations(PG_FUNCTION_ARGS)
 			char	   *langtag;
 			char	   *icucomment;
 			const char *collcollate;
+			char	   *collname;
 			Oid			collid;
 
 			if (i == -1)
@@ -819,7 +825,8 @@ pg_import_system_collations(PG_FUNCTION_ARGS)
 			if (!is_all_ascii(langtag) || !is_all_ascii(collcollate))
 				continue;
 
-			collid = CollationCreate(psprintf("%s-x-icu", langtag),
+			collname = psprintf("%s-x-icu", langtag);
+			collid = CollationCreate(collname,
 									 nspid, GetUserId(),
 									 COLLPROVIDER_ICU, true, -1,
 									 collcollate, collcollate,
@@ -827,6 +834,7 @@ pg_import_system_collations(PG_FUNCTION_ARGS)
 									 true, true);
 			if (OidIsValid(collid))
 			{
+				DispatchCollationCreate(collname, unconstify(char*, collcollate), nspid, "icu");
 				ncreated++;
 
 				CommandCounterIncrement();


### PR DESCRIPTION
  
The coordinator and all segments are required to have same set of collations.
This function was tuned to support MPP structure via DispatchCollationCreate,
but only for importing collations from libc. Once ICU enabled, it would fail.

This commit updated DispatchCollationCreate to support dispatching ICU
collations. New argument `provider` is added while unused `encoding` removed.