### PR TITLE
Disallow "LIKE <AO/AOCO> INCLUDING STORAGE" if table AM is already set

### DIFF
--- a/src/backend/parser/parse_utilcmd.c
+++ b/src/backend/parser/parse_utilcmd.c
@@ -1234,11 +1234,13 @@ transformTableLikeClause(CreateStmtContext *cxt, TableLikeClause *table_like_cla
 
 	/*
 	 * GPDB_12_MERGE_FIXME:
-	 * 		This is wrong and creates unspecified behaviour when multiple like
+	 * 		This is not ideal and introduces limitations when multiple like
 	 * 		clauses are present in the statement.
 	 *
 	 *		Try to use a unified interface for encoding handling in a manner
 	 *		similar to CREATE/ALTER commands.
+	 *		For more details see:
+	 *		https://groups.google.com/a/greenplum.org/g/gpdb-dev/c/mOPeBxFm43w
 	 */
 	/*
 	 * If STORAGE is included, we need to copy over the table storage params
@@ -1259,6 +1261,14 @@ transformTableLikeClause(CreateStmtContext *cxt, TableLikeClause *table_like_cla
 			int32		blocksize = -1;
 			int16		compresslevel = 0;
 			NameData	compresstype;
+
+			if (stmt->accessMethod != NULL)
+				ereport(ERROR,
+						(errcode(ERRCODE_INVALID_TABLE_DEFINITION),
+						 errmsg("LIKE %s INCLUDING STORAGE is not allowed because the access method of table %s is already set to %s",
+								RelationGetRelationName(relation), cxt->relation->relname, stmt->accessMethod)),
+						 errdetail("Multiple INCLUDING STORAGE clauses of append-optimized tables are not allowed.\n"
+								   "Single INCLUDING STORAGE clause of append-optimized table is also not allowed if access method is explicitly specified."));
 
 			GetAppendOnlyEntryAttributes(relation->rd_id,&blocksize,
 																	&compresslevel,&checksum,&compresstype);

--- a/src/test/regress/expected/create_table_like_gp.out
+++ b/src/test/regress/expected/create_table_like_gp.out
@@ -121,3 +121,55 @@ WHERE c.table_name = 't_comments_b';
 
 DROP TABLE t_comments_a;
 DROP TABLE t_comments_b;
+-- Verify INCLUDING STORAGE of an append_optimized table errors out when table AM is explicitly specified
+CREATE TABLE t_aorow (b text) USING ao_row WITH (compresstype=zstd,compresslevel=5,blocksize=65536);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'b' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- Disallow INCLUDING STORAGE when table AM is explicitly specified w/ a different table AM
+CREATE TABLE t_like_aorow_use_heap (LIKE t_aorow INCLUDING STORAGE) USING heap;
+ERROR:  LIKE t_aorow INCLUDING STORAGE is not allowed because the access method of table t_like_aorow_use_heap is already set to heap
+DETAIL:  Multiple INCLUDING STORAGE clauses of append-optimized tables are not allowed.
+Single INCLUDING STORAGE clause of append-optimized table is also not allowed if access method is explicitly specified.
+CREATE TABLE t_like_aorow_use_aocol (LIKE t_aorow INCLUDING STORAGE) USING ao_column;
+ERROR:  LIKE t_aorow INCLUDING STORAGE is not allowed because the access method of table t_like_aorow_use_aocol is already set to ao_column
+DETAIL:  Multiple INCLUDING STORAGE clauses of append-optimized tables are not allowed.
+Single INCLUDING STORAGE clause of append-optimized table is also not allowed if access method is explicitly specified.
+CREATE TABLE t_like_aorow_use_aocol (LIKE t_aorow INCLUDING STORAGE) WITH (appendonly=true, orientation=column);
+ERROR:  LIKE t_aorow INCLUDING STORAGE is not allowed because the access method of table t_like_aorow_use_aocol is already set to ao_column
+DETAIL:  Multiple INCLUDING STORAGE clauses of append-optimized tables are not allowed.
+Single INCLUDING STORAGE clause of append-optimized table is also not allowed if access method is explicitly specified.
+-- Disallow INCLUDING STORAGE even if table AM is explicitly specified w/ the same table AM
+-- This seems silly, but it's the same behavior as 6X.
+CREATE TABLE t_like_aorow_use_aorow (LIKE t_aorow INCLUDING STORAGE) USING ao_row;
+ERROR:  LIKE t_aorow INCLUDING STORAGE is not allowed because the access method of table t_like_aorow_use_aorow is already set to ao_row
+DETAIL:  Multiple INCLUDING STORAGE clauses of append-optimized tables are not allowed.
+Single INCLUDING STORAGE clause of append-optimized table is also not allowed if access method is explicitly specified.
+CREATE TABLE t_like_aorow_use_aorow (LIKE t_aorow INCLUDING STORAGE) WITH (appendonly=true, orientation=row);
+ERROR:  LIKE t_aorow INCLUDING STORAGE is not allowed because the access method of table t_like_aorow_use_aorow is already set to ao_row
+DETAIL:  Multiple INCLUDING STORAGE clauses of append-optimized tables are not allowed.
+Single INCLUDING STORAGE clause of append-optimized table is also not allowed if access method is explicitly specified.
+-- Verify multiple INCLUDING STORAGE clauses with append-optimized tables are not allowed
+CREATE TABLE t_aorow_2 (b text) USING ao_row WITH (compresstype=zstd,compresslevel=5,blocksize=65536);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'b' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+-- ERROR even if the two source tables have same AM and encoding options.
+CREATE TABLE t_like_ao_ao_storage (LIKE t_aorow INCLUDING STORAGE, LIKE t_aorow_2 INCLUDING STORAGE);
+ERROR:  LIKE t_aorow_2 INCLUDING STORAGE is not allowed because the access method of table t_like_ao_ao_storage is already set to ao_row
+DETAIL:  Multiple INCLUDING STORAGE clauses of append-optimized tables are not allowed.
+Single INCLUDING STORAGE clause of append-optimized table is also not allowed if access method is explicitly specified.
+-- Mix heap and AO AMs are still allowed. The new table takes the AO tables' AM and encoding options.
+-- This is not intuitive, but it is the same behavior as 6X.
+CREATE TABLE t_heap (a text) USING heap WITH (fillfactor = 50);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE TABLE t_like_ao_heap_storage (LIKE t_aorow INCLUDING STORAGE, LIKE t_heap INCLUDING STORAGE);
+NOTICE:  table doesn't have 'DISTRIBUTED BY' clause, defaulting to distribution columns from LIKE table
+\d+ t_like_ao_heap_storage
+                         Table "public.t_like_ao_heap_storage"
+ Column | Type | Collation | Nullable | Default | Storage  | Stats target | Description 
+--------+------+-----------+----------+---------+----------+--------------+-------------
+ b      | text |           |          |         | extended |              | 
+ a      | text |           |          |         | extended |              | 
+Distributed by: (b)
+Options: blocksize=65536, checksum=true, compresslevel=5, compresstype=zstd
+


### PR DESCRIPTION
Previously, in a CREATE TABLE statement, the LIKE .. INCLUDING STORAGE clause would overwrite the USING or WITH (appendonly=true orientation=..) clause if the source table in the LIKE clause is an append-optimized table. This is because Greenplum overloaded the INCLUDING STORAGE option of CREATE TABLE LIKE in commit 951065c48cc, and implicitly copies the source append-optimized table's access method (AM). This is problematic if in the same CREATE TABLE statement, an access method is also explicitly specified.

This commit does the following:
- Disallow INCLUDING STORAGE of append-optimized tables if table AM is explicitly specified in the same CREATE TABLE statement
- Improve the error message when there are multiple INCLUDING STORAGE clauses of append-optimized tables.
- Add tests to capture the previously unspecified behavior: when there are multiple INCLUDING STORAGE clauses, and one of the source tables is an append-optimized table, the new table will take the append-optimized table's table AM and encoding options.

In hindsight, overloading the INCLUDING STORAGE option is not ideal and can introduce limitations and confusions. There is an ongoing discussion regarding the same:
https://groups.google.com/a/greenplum.org/g/gpdb-dev/c/mOPeBxFm43w

Fixes #15676

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
