### PR TITLE
Remove GPDB_95_MERGE_FIXME in groupingset*.

### DIFF
--- a/src/test/regress/expected/groupingsets.out
+++ b/src/test/regress/expected/groupingsets.out
@@ -1040,7 +1040,6 @@ group by rollup(ten);
 (11 rows)
 
 -- More rescan tests
--- start_ignore
 select * from (values (1),(2)) v(a) left join lateral (select v.a, four, ten, count(*) from onek group by cube(four,ten)) s on true order by v.a,four,ten;
  a | a | four | ten | count 
 ---+---+------+-----+-------
@@ -1115,7 +1114,7 @@ select * from (values (1),(2)) v(a) left join lateral (select v.a, four, ten, co
  2 | 2 |      |   9 |   100
  2 | 2 |      |     |  1000
 (70 rows)
--- end_ignore
+
 select array(select row(v.a,s1.*) from (select two,four, count(*) from onek group by cube(two,four) order by two,four) s1) from (values (1),(2)) v(a);
                                                                         array                                                                         
 ------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -1735,8 +1734,6 @@ SELECT a, b, count(*), max(a), max(b) FROM gstest3 GROUP BY GROUPING SETS(a, b,(
 
 COMMIT;
 -- More rescan tests
--- start_ignore
--- GPDB_95_MERGE_FIXME: the lateral query with grouping sets do not make right plans
 select * from (values (1),(2)) v(a) left join lateral (select v.a, four, ten, count(*) from onek group by cube(four,ten)) s on true order by v.a,four,ten;
  a | a | four | ten | count 
 ---+---+------+-----+-------
@@ -1812,7 +1809,6 @@ select * from (values (1),(2)) v(a) left join lateral (select v.a, four, ten, co
  2 | 2 |      |     |  1000
 (70 rows)
 
--- end_ignore
 select array(select row(v.a,s1.*) from (select two,four, count(*) from onek group by cube(two,four) order by two,four) s1) from (values (1),(2)) v(a);
                                                                         array                                                                         
 ------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/src/test/regress/expected/groupingsets_optimizer.out
+++ b/src/test/regress/expected/groupingsets_optimizer.out
@@ -1112,8 +1112,6 @@ DETAIL:  Feature not supported: Aggregate functions with FILTER
 (11 rows)
 
 -- More rescan tests
--- start_ignore
--- GPDB_95_MERGE_FIXME: the lateral query with grouping sets do not make right plans
 select * from (values (1),(2)) v(a) left join lateral (select v.a, four, ten, count(*) from onek group by cube(four,ten)) s on true order by v.a,four,ten;
 INFO:  GPORCA failed to produce a plan, falling back to planner
 DETAIL:  Feature not supported: LATERAL
@@ -1191,7 +1189,6 @@ DETAIL:  Feature not supported: LATERAL
  2 | 2 |      |     |  1000
 (70 rows)
 
--- end_ignore
 select array(select row(v.a,s1.*) from (select two,four, count(*) from onek group by cube(two,four) order by two,four) s1) from (values (1),(2)) v(a);
 INFO:  GPORCA failed to produce a plan, falling back to planner
 DETAIL:  Feature not supported: ROW EXPRESSION
@@ -1915,8 +1912,6 @@ SELECT a, b, count(*), max(a), max(b) FROM gstest3 GROUP BY GROUPING SETS(a, b,(
 
 COMMIT;
 -- More rescan tests
--- start_ignore
--- GPDB_95_MERGE_FIXME: the lateral query with grouping sets do not make right plans
 select * from (values (1),(2)) v(a) left join lateral (select v.a, four, ten, count(*) from onek group by cube(four,ten)) s on true order by v.a,four,ten;
 INFO:  GPORCA failed to produce a plan, falling back to planner
 DETAIL:  Feature not supported: LATERAL
@@ -1994,7 +1989,6 @@ DETAIL:  Feature not supported: LATERAL
  2 | 2 |      |     |  1000
 (70 rows)
 
--- end_ignore
 select array(select row(v.a,s1.*) from (select two,four, count(*) from onek group by cube(two,four) order by two,four) s1) from (values (1),(2)) v(a);
 INFO:  GPORCA failed to produce a plan, falling back to planner
 DETAIL:  Feature not supported: ROW EXPRESSION

--- a/src/test/regress/sql/groupingsets.sql
+++ b/src/test/regress/sql/groupingsets.sql
@@ -376,10 +376,7 @@ select ten, sum(distinct four) filter (where four::text ~ '123') from onek a
 group by rollup(ten);
 
 -- More rescan tests
--- start_ignore
--- GPDB_95_MERGE_FIXME: the lateral query with grouping sets do not make right plans
 select * from (values (1),(2)) v(a) left join lateral (select v.a, four, ten, count(*) from onek group by cube(four,ten)) s on true order by v.a,four,ten;
--- end_ignore
 select array(select row(v.a,s1.*) from (select two,four, count(*) from onek group by cube(two,four) order by two,four) s1) from (values (1),(2)) v(a);
 
 -- Grouping on text columns
@@ -538,10 +535,7 @@ SELECT a, b, count(*), max(a), max(b) FROM gstest3 GROUP BY GROUPING SETS(a, b,(
 COMMIT;
 
 -- More rescan tests
--- start_ignore
--- GPDB_95_MERGE_FIXME: the lateral query with grouping sets do not make right plans
 select * from (values (1),(2)) v(a) left join lateral (select v.a, four, ten, count(*) from onek group by cube(four,ten)) s on true order by v.a,four,ten;
--- end_ignore
 select array(select row(v.a,s1.*) from (select two,four, count(*) from onek group by cube(two,four) order by two,four) s1) from (values (1),(2)) v(a);
 
 -- Rescan logic changes when there are no empty grouping sets, so test


### PR DESCRIPTION
When merging PG95 (commit 8ae22d15ebf), the query plan for the lateral query with grouping sets do not make right plans and the results are wrong.

The plan for merging 95 is
```
postgres=# explain select * from (values (1),(2)) v(a) left join lateral (select v.a, four, ten, count(*) from onek group by cube(four,ten)) s on true order by v.a,four,ten;
                                               QUERY PLAN
---------------------------------------------------------------------------------------------------------
 Sort  (cost=10000000143.08..10000000143.35 rows=110 width=24)
   Sort Key: "*VALUES*".column1, onek.four, onek.ten
   ->  Nested Loop Left Join  (cost=10000000068.83..10000000139.35 rows=110 width=24)
         ->  Values Scan on "*VALUES*"  (cost=0.00..0.03 rows=1 width=4)
         ->  Materialize  (cost=68.83..138.08 rows=19 width=20)
               ->  GroupAggregate  (cost=68.83..137.26 rows=55 width=20)
                     Group Key: onek.four, onek.ten
                     Group Key: onek.four
                     Group Key: ()
                     Sort Key: onek.ten
                       Group Key: onek.ten
                     ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=68.83..71.33 rows=1000 width=8)
                           Merge Key: onek.four, onek.ten
                           ->  Sort  (cost=68.83..71.33 rows=334 width=8)
                                 Sort Key: onek.four, onek.ten
                                 ->  Seq Scan on onek  (cost=0.00..19.00 rows=334 width=8)
 Optimizer: Postgres query optimizer
(17 rows)
```
The results are incorrect.
```
 a | a | four | ten | count
---+---+------+-----+-------
 1 | 1 |    0 |   0 |    50
 1 | 1 |    0 |   2 |    50
 1 | 1 |    0 |   4 |    50
 1 | 1 |    0 |   6 |    50
 1 | 1 |    0 |   8 |    50
 1 | 1 |    0 |     |   250
 1 | 1 |    1 |   1 |    50
 1 | 1 |    1 |   3 |    50
 1 | 1 |    1 |   5 |    50
 1 | 1 |    1 |   7 |    50
 1 | 1 |    1 |   9 |    50
 1 | 1 |    1 |     |   250
 1 | 1 |    2 |   0 |    50
 1 | 1 |    2 |   2 |    50
 1 | 1 |    2 |   4 |    50
 1 | 1 |    2 |   6 |    50
 1 | 1 |    2 |   8 |    50
 1 | 1 |    2 |     |   250
 1 | 1 |    3 |   1 |    50
 1 | 1 |    3 |   3 |    50
 1 | 1 |    3 |   5 |    50
 1 | 1 |    3 |   7 |    50
 1 | 1 |    3 |   9 |    50
 1 | 1 |    3 |     |   250
 1 | 1 |      |   0 |   100
 1 | 1 |      |   1 |   100
 1 | 1 |      |   2 |   100
 1 | 1 |      |   3 |   100
 1 | 1 |      |   4 |   100
 1 | 1 |      |   5 |   100
 1 | 1 |      |   6 |   100
 1 | 1 |      |   7 |   100
 1 | 1 |      |   8 |   100
 1 | 1 |      |   9 |   100
 1 | 1 |      |     |  1000
 2 | 2 |      |     |     0
(36 rows)
```

But in the current main, the plan looks right and the result is also correct. So remove the fixme directly.
```
-------------------------------------------------------------------------------------
 Sort  (cost=10000000096.39..10000000096.66 rows=110 width=28)
   Sort Key: "*VALUES*".column1, onek.four, onek.ten
   ->  Nested Loop Left Join  (cost=10000000000.00..10000000092.66 rows=110 width=28)
         ->  Values Scan on "*VALUES*"  (cost=0.00..0.03 rows=2 width=4)
         ->  Materialize  (cost=0.00..46.04 rows=55 width=20)  
               ->  MixedAggregate  (cost=0.00..45.22 rows=55 width=20)
                     Hash Key: onek.four, onek.ten
                     Hash Key: onek.four
                     Hash Key: onek.ten
                     Group Key: ()
                     ->  Materialize  (cost=0.00..24.67 rows=1000 width=8)
                           ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..19.67 rows=1000 width=8)
                                 ->  Seq Scan on onek  (cost=0.00..6.33 rows=333 width=8)
 Optimizer: Postgres query optimizer
(14 rows)
```
The materialize node on the top of MixedAggregate is added by `make_material()` inside `create_nestloop_plan()`
and  is due to `best_path->innerjoinpath->rescannable = false` for subqueryScanPath.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
