### PR TITLE
Fix typos in gpfdist

### DIFF
--- a/src/backend/access/external/url_curl.c
+++ b/src/backend/access/external/url_curl.c
@@ -98,7 +98,7 @@ typedef struct
 				eof;			/* error & eof flags */
 	int			gp_proto;
 	
-	int 			zstd;			/* if gpfdist zstd compress is enabled, it equals 1 */
+	int 			zstd;			/* if gpfdist zstd compression is enabled, it equals 1 */
 	int 			lastsize;		/* Recording the compressed data size */
 	
 	char	   		*http_response;
@@ -1584,10 +1584,11 @@ decompress_zstd_data(ZSTD_DCtx* ctx, ZSTD_inBuffer* bin, ZSTD_outBuffer* bout)
 {
 	
 	size_t ret;
-	/* Ret indicates the number of bytes of next data frame to be decompressed.
-	 * And if an error occur in ZSTD_decompressStream, ret will be a error number.
-	 * If ZSTD_isError is true, the ret is a error number.
-	 * The content of the error can be got by ZSTD_getErrorName..
+	/* 
+	 * The return value ret indicates the number of bytes of next data frame to be decompressed.
+	 * And if an error occurs in ZSTD_decompressStream, ret will be an error number.
+	 * If ZSTD_isError is true, the ret is an error number.
+	 * The content of the error can be got by ZSTD_getErrorName.
 	 */
 	ret = ZSTD_decompressStream(ctx, bout, bin);
 
@@ -1771,19 +1772,20 @@ gp_proto1_read(char *buf, int bufsz, URL_CURL_FILE *file, CopyState pstate, char
 
 	if (file->zstd)
 	{
-		/* 'lastsize' is the number of bytes required for next decompression.
+		/* 
+		 * 'lastsize' is the number of bytes required for next decompression.
 		 * 'left_bytes' is the number of bytes remained in 'file->in.ptr'.
-		 * If left_bytes is less than 'lastsize', the next decompression
+		 * If 'left_bytes' is less than 'lastsize', the next decompression
 		 * can't complete in a decompression operation. Thus, when 
-		 * 'file->lastsize > left_bytes', we need more bytes and fill_buffer is called.
+		 * 'file->lastsize > left_bytes', we need more bytes and fill_buffer() is called.
 		 * 
 		 * When the condition 'file->block.datalen == len' is met, a new
-		 * request just start. In this case lastsize is an init value, and 
-		 * cannot provide the information about how many bytes required
+		 * request just starts. In this case, lastsize is an init value, and 
+		 * can not provide the information about how many bytes required
 		 * to finish the first frame decompression. In this case, enough
-		 * bytes(more than ZSTD_DStreamInSize() returning) should be filled
+		 * bytes (more than ZSTD_DStreamInSize() returning) should be filled
 		 * into 'file->in.ptr' to ensure that the first decompression 
-		 * completing.
+		 * will complete successfully.
 		 */
 		if (file->lastsize > left_bytes || file->block.datalen == len)
 		{
@@ -1804,7 +1806,7 @@ gp_proto1_read(char *buf, int bufsz, URL_CURL_FILE *file, CopyState pstate, char
 
 	n = file->in.top - file->in.bot;
 
-	/* if gpfdist closed connection prematurely or died catch it here */
+	/* if gpfdist closed connection prematurely or died, catch it here */
 	if (n == 0 && !file->eof)
 	{
 		file->error = 1;
@@ -1825,11 +1827,12 @@ gp_proto1_read(char *buf, int bufsz, URL_CURL_FILE *file, CopyState pstate, char
 	if (file->zstd && file->curl->zstd_dctx && !file->eof)
 	{
 		int ret;
-		/* It is absolutely to put the decompression code in a loop.
+		/* 
+		 * I think it is correct to put the decompression code in a loop.
 		 * Since not every call of decompress_zstd_data will get data into bout.
 		 * However, even thought there is no data in bout, the call of 
 		 * decompress_zstd_data is neccersary for following decompression.
-		 * If a empty buf is returned to gpdb, the error will occur. 
+		 * If an empty buf is returned to gpdb, the error will occur. 
 		 * So the loop ensures that we push forward the decompression until there 
 		 * is data in bout.
 		 */

--- a/src/bin/gpfdist/gpfdist.c
+++ b/src/bin/gpfdist/gpfdist.c
@@ -302,10 +302,10 @@ struct request_t
 		int 	dbuftop; 	/* # bytes used in dbuf */
 		int 	dbufmax; 	/* size of dbuf[] */
 
-		char*  	wbuf;		/* data buf for decompressed data for writing into file,
+		char*  	wbuf;		/* data buf for decompressed data about writing into file,
 					         	its capacity equals to MAX_FRAME_SIZE. */
 		int 	wbuftop;	/* last index for decompressed data */
-		int 	woffset;		/* mark whether there is left data in compress ctx */
+		int 	woffset;	/* mark whether there is left data in compress ctx */
 	} in;
 
 	block_t	outblock;	/* next block to send out */
@@ -3311,7 +3311,8 @@ static void handle_post_request(request_t *r, int header_end)
 			r->in.davailable -= n;
 			r->in.dbuftop += n;
 
-			/* success is a flag to check whether data is written into file successfully.
+			/* 
+			 * success is a flag to check whether data is written into file successfully.
 			 * There is no need to do anything when success is less than 0, since all
 			 * error handling has been done in 'check_output_to_file' function.
 			 */
@@ -4698,7 +4699,8 @@ static void delay_watchdog_timer()
 
 #ifdef USE_ZSTD
 
-/* decompress the data and write data to the file.
+/* 
+ * Decompress the data and write data to the file.
  * Finally, the function will check the write result,
  * and change the related value about data buffer. 
  */
@@ -4743,13 +4745,13 @@ int decompress_write_loop(request_t *r)
 static int decompress_zstd(request_t* r, ZSTD_inBuffer* bin, ZSTD_outBuffer* bout)
 {	
 	int ret;
-	/* The return code is zero if the frame is complete, but there may
-		* be multiple frames concatenated together. Zstd will automatically
-		* reset the context when a frame is complete. Still, calling
-		* ZSTD_DCtx_reset() can be useful to reset the context to a clean
-		* state, for instance if the last decompression call returned an
-		* error.
-		*/
+	/* 
+	 * The return code is zero if the frame is complete, but there may
+	 * be multiple frames concatenated together. Zstd will automatically
+	 * reset the context when a frame is complete. Still, calling
+	 * ZSTD_DCtx_reset() can be useful to reset the context to a clean
+	 * state, for instance if the last decompression call returned an error.
+	 */
 		 
 	ret = ZSTD_decompressStream(r->zstd_dctx, bout, bin);
 	size_t const err = ret;                          
@@ -4789,7 +4791,7 @@ static int decompress_data(request_t* r, zstd_buffer *in, zstd_buffer *out){
 }
 /*
  * compress_zstd
- * It is for compress data in buffer. Return is the length of data after compression.
+ * It is for compressing data in buffer. Return value is the length of data after compression.
  */
 
 static int compress_zstd(const request_t *r, block_t *blk, int buflen)


### PR DESCRIPTION
This commit fix some typos in gpfdist, such as:

- a request just start -> a request just start**s** 
- ret will be a error number -> ret will be **an** error number
- It is for compress data in buffer. -> It is for compress**ing** data in buffer.

Signed-off-by: Yongtao Huang <yongtaoh@vmware.com>