### PR TITLE
Handle BSD-style sed on macos

### DIFF
--- a/src/test/regress/expected/dboptions.out
+++ b/src/test/regress/expected/dboptions.out
@@ -150,7 +150,12 @@ order by gp_segment_id;
 -- re-allow connections to avoid downstream pg_upgrade --check test error
 alter database limitdb2 with allow_connections = true;
 -- remove rule from pg_hba.conf for connlimit_test_user
+SELECT version() ILIKE '%apple%' AS bsd_sed \gset
+\if :bsd_sed
+\! sed -i '' '$ d' $COORDINATOR_DATA_DIRECTORY/pg_hba.conf
+\else
 \! sed -i '$ d' $COORDINATOR_DATA_DIRECTORY/pg_hba.conf
+\endif
 select pg_reload_conf();
  pg_reload_conf 
 ----------------

--- a/src/test/regress/expected/gp_connections.out
+++ b/src/test/regress/expected/gp_connections.out
@@ -5,7 +5,12 @@
 drop user if exists user_disallowed_via_local;
 create user user_disallowed_via_local with login;
 -- cleanup previous settings if any
+SELECT version() ILIKE '%apple%' AS bsd_sed \gset
+\if :bsd_sed
+\! sed -i '' '/user_disallowed_via_local/d' $COORDINATOR_DATA_DIRECTORY/pg_hba.conf;
+\else
 \! sed -i '/user_disallowed_via_local/d' $COORDINATOR_DATA_DIRECTORY/pg_hba.conf;
+\endif
 -- allow it to login via the [tcp] protocol
 \! echo 'host all user_disallowed_via_local samenet trust' | tee -a $COORDINATOR_DATA_DIRECTORY/pg_hba.conf;
 host all user_disallowed_via_local samenet trust
@@ -35,7 +40,11 @@ select * from t1_of_user_disallowed_via_local, pg_sleep(0);
 (0 rows)
 
 -- cleanup settings if any
+\if :bsd_sed
+\! sed -i '' '/user_disallowed_via_local/d' $COORDINATOR_DATA_DIRECTORY/pg_hba.conf;
+\else
 \! sed -i '/user_disallowed_via_local/d' $COORDINATOR_DATA_DIRECTORY/pg_hba.conf;
+\endif
 --
 -- Segment connection tests
 --

--- a/src/test/regress/sql/dboptions.sql
+++ b/src/test/regress/sql/dboptions.sql
@@ -88,5 +88,10 @@ order by gp_segment_id;
 -- re-allow connections to avoid downstream pg_upgrade --check test error
 alter database limitdb2 with allow_connections = true;
 -- remove rule from pg_hba.conf for connlimit_test_user
+SELECT version() ILIKE '%apple%' AS bsd_sed \gset
+\if :bsd_sed
+\! sed -i '' '$ d' $COORDINATOR_DATA_DIRECTORY/pg_hba.conf
+\else
 \! sed -i '$ d' $COORDINATOR_DATA_DIRECTORY/pg_hba.conf
+\endif
 select pg_reload_conf();

--- a/src/test/regress/sql/gp_connections.sql
+++ b/src/test/regress/sql/gp_connections.sql
@@ -7,7 +7,12 @@ drop user if exists user_disallowed_via_local;
 create user user_disallowed_via_local with login;
 
 -- cleanup previous settings if any
+SELECT version() ILIKE '%apple%' AS bsd_sed \gset
+\if :bsd_sed
+\! sed -i '' '/user_disallowed_via_local/d' $COORDINATOR_DATA_DIRECTORY/pg_hba.conf;
+\else
 \! sed -i '/user_disallowed_via_local/d' $COORDINATOR_DATA_DIRECTORY/pg_hba.conf;
+\endif
 -- allow it to login via the [tcp] protocol
 \! echo 'host all user_disallowed_via_local samenet trust' | tee -a $COORDINATOR_DATA_DIRECTORY/pg_hba.conf;
 -- disallow it to login via the [local] protocol
@@ -29,7 +34,11 @@ create temp table t1_of_user_disallowed_via_local(c1 int);
 select * from t1_of_user_disallowed_via_local, pg_sleep(0);
 
 -- cleanup settings if any
+\if :bsd_sed
+\! sed -i '' '/user_disallowed_via_local/d' $COORDINATOR_DATA_DIRECTORY/pg_hba.conf;
+\else
 \! sed -i '/user_disallowed_via_local/d' $COORDINATOR_DATA_DIRECTORY/pg_hba.conf;
+\endif
 
 --
 -- Segment connection tests


### PR DESCRIPTION
Some regression tests rely on sed to in-place modify some files, but those fail on macos as it's using a BSD-style sed that requires an extra "backup extension" argument, leading to this kind of error:

```
\! sed -i '/user_disallowed_via_local/d' $COORDINATOR_DATA_DIRECTORY/pg_hba.conf;
sed: -I or -i may not be used with stdin
```

To fix, detect whether the tests are run on macos by looking for "apple" in the version() output, and adapt the command accordingly.