### PR TITLE
(6X backport) Fix "cannot execute squelched plan node of type" error (greenplum-db#11673)

### DIFF
--- a/src/backend/executor/nodeHashjoin.c
+++ b/src/backend/executor/nodeHashjoin.c
@@ -1282,6 +1282,16 @@ ExecReScanHashJoin(HashJoinState *node)
 				ExecReScan(node->js.ps.righttree);
 		}
 	}
+	else 
+	{
+		/*
+		 * GPDB: HashTable not built with righttree may be squelched,
+		 * HashJoin need rescan righttree to reset its squelch flag.
+		 */
+		if (node->js.ps.righttree->chgParam == NULL &&
+			node->js.ps.righttree->squelched)
+				ExecReScan(node->js.ps.righttree);
+	}
 
 	/* Always reset intra-tuple state */
 	node->hj_CurHashValue = 0;

--- a/src/test/regress/expected/bfv_joins.out
+++ b/src/test/regress/expected/bfv_joins.out
@@ -4057,6 +4057,63 @@ join baz on varchar_3=text_any;
 -----------+--------+----------
 (0 rows)
 
+--
+-- Test case for Hash Join rescan after squelched without hashtable built
+-- See https://github.com/greenplum-db/gpdb/pull/15590
+--
+--- Lateral Join
+set from_collapse_limit = 1;
+set join_collapse_limit = 1;
+select 1 from pg_namespace  join lateral
+    (select * from aclexplode(nspacl) x join pg_authid  on x.grantee = pg_authid.oid where rolname = current_user) z on true limit 1;
+ ?column? 
+----------
+        1
+(1 row)
+
+reset from_collapse_limit;
+reset join_collapse_limit;
+--- NestLoop index join
+create table l_table (a int,  b int) distributed replicated;
+create index l_table_idx on l_table(a);
+create table r_table1 (ra1 int,  rb1 int) distributed replicated;
+create table r_table2 (ra2 int,  rb2 int) distributed replicated;
+insert into l_table select i % 10 , i from generate_series(1, 10000) i;
+insert into r_table1 select i, i from generate_series(1, 1000) i;
+insert into r_table2 values(11, 11), (1, 1) ;
+analyze l_table;
+analyze r_table1;
+analyze r_table2;
+set optimizer to off;
+set enable_nestloop to on;
+set enable_bitmapscan to off;
+explain select * from r_table2 where ra2 in ( select a from l_table join r_table1 on b = rb1);
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=64.56..64.56 rows=10 width=8)
+   ->  Nested Loop Semi Join  (cost=24.66..64.56 rows=10 width=8)
+         ->  Seq Scan on r_table2  (cost=0.00..1.02 rows=2 width=8)
+         ->  Hash Join  (cost=24.66..62.75 rows=100 width=4)
+               Hash Cond: (l_table.b = r_table1.rb1)
+               ->  Index Scan using l_table_idx on l_table  (cost=0.16..25.62 rows=1000 width=8)
+                     Index Cond: (a = r_table2.ra2)
+               ->  Hash  (cost=12.00..12.00 rows=1000 width=4)
+                     ->  Seq Scan on r_table1  (cost=0.00..12.00 rows=1000 width=4)
+ Optimizer: Postgres query optimizer
+(10 rows)
+
+select * from r_table2 where ra2 in ( select a from l_table join r_table1 on b = rb1);
+ ra2 | rb2 
+-----+-----
+   1 |   1
+(1 row)
+
+reset optimizer;
+reset enable_nestloop;
+reset enable_bitmapscan;
+drop table l_table;
+drop table r_table1;
+drop table r_table2;
 -- Clean up. None of the objects we create are very interesting to keep around.
 reset search_path;
 set client_min_messages='warning';

--- a/src/test/regress/expected/bfv_joins_optimizer.out
+++ b/src/test/regress/expected/bfv_joins_optimizer.out
@@ -4050,6 +4050,63 @@ join baz on varchar_3=text_any;
 -----------+--------+----------
 (0 rows)
 
+--
+-- Test case for Hash Join rescan after squelched without hashtable built
+-- See https://github.com/greenplum-db/gpdb/pull/15590
+--
+--- Lateral Join
+set from_collapse_limit = 1;
+set join_collapse_limit = 1;
+select 1 from pg_namespace  join lateral
+    (select * from aclexplode(nspacl) x join pg_authid  on x.grantee = pg_authid.oid where rolname = current_user) z on true limit 1;
+ ?column? 
+----------
+        1
+(1 row)
+
+reset from_collapse_limit;
+reset join_collapse_limit;
+--- NestLoop index join
+create table l_table (a int,  b int) distributed replicated;
+create index l_table_idx on l_table(a);
+create table r_table1 (ra1 int,  rb1 int) distributed replicated;
+create table r_table2 (ra2 int,  rb2 int) distributed replicated;
+insert into l_table select i % 10 , i from generate_series(1, 10000) i;
+insert into r_table1 select i, i from generate_series(1, 1000) i;
+insert into r_table2 values(11, 11), (1, 1) ;
+analyze l_table;
+analyze r_table1;
+analyze r_table2;
+set optimizer to off;
+set enable_nestloop to on;
+set enable_bitmapscan to off;
+explain select * from r_table2 where ra2 in ( select a from l_table join r_table1 on b = rb1);
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=64.56..64.56 rows=10 width=8)
+   ->  Nested Loop Semi Join  (cost=24.66..64.56 rows=10 width=8)
+         ->  Seq Scan on r_table2  (cost=0.00..1.02 rows=2 width=8)
+         ->  Hash Join  (cost=24.66..62.75 rows=100 width=4)
+               Hash Cond: (l_table.b = r_table1.rb1)
+               ->  Index Scan using l_table_idx on l_table  (cost=0.16..25.62 rows=1000 width=8)
+                     Index Cond: (a = r_table2.ra2)
+               ->  Hash  (cost=12.00..12.00 rows=1000 width=4)
+                     ->  Seq Scan on r_table1  (cost=0.00..12.00 rows=1000 width=4)
+ Optimizer: Postgres query optimizer
+(10 rows)
+
+select * from r_table2 where ra2 in ( select a from l_table join r_table1 on b = rb1);
+ ra2 | rb2 
+-----+-----
+   1 |   1
+(1 row)
+
+reset optimizer;
+reset enable_nestloop;
+reset enable_bitmapscan;
+drop table l_table;
+drop table r_table1;
+drop table r_table2;
 -- Clean up. None of the objects we create are very interesting to keep around.
 reset search_path;
 set client_min_messages='warning';

--- a/src/test/regress/sql/bfv_joins.sql
+++ b/src/test/regress/sql/bfv_joins.sql
@@ -540,6 +540,43 @@ join baz on varchar_3=text_any;
 select varchar_3, char_3, text_any from foo join bar on varchar_3=char_3
 join baz on varchar_3=text_any;
 
+--
+-- Test case for Hash Join rescan after squelched without hashtable built
+-- See https://github.com/greenplum-db/gpdb/pull/15590
+--
+--- Lateral Join
+set from_collapse_limit = 1;
+set join_collapse_limit = 1;
+select 1 from pg_namespace  join lateral
+    (select * from aclexplode(nspacl) x join pg_authid  on x.grantee = pg_authid.oid where rolname = current_user) z on true limit 1;
+reset from_collapse_limit;
+reset join_collapse_limit;
+
+--- NestLoop index join
+create table l_table (a int,  b int) distributed replicated;
+create index l_table_idx on l_table(a);
+create table r_table1 (ra1 int,  rb1 int) distributed replicated;
+create table r_table2 (ra2 int,  rb2 int) distributed replicated;
+insert into l_table select i % 10 , i from generate_series(1, 10000) i;
+insert into r_table1 select i, i from generate_series(1, 1000) i;
+insert into r_table2 values(11, 11), (1, 1) ;
+analyze l_table;
+analyze r_table1;
+analyze r_table2;
+
+set optimizer to off;
+set enable_nestloop to on;
+set enable_bitmapscan to off;
+explain select * from r_table2 where ra2 in ( select a from l_table join r_table1 on b = rb1);
+select * from r_table2 where ra2 in ( select a from l_table join r_table1 on b = rb1);
+
+reset optimizer;
+reset enable_nestloop;
+reset enable_bitmapscan;
+drop table l_table;
+drop table r_table1;
+drop table r_table2;
+
 -- Clean up. None of the objects we create are very interesting to keep around.
 reset search_path;
 set client_min_messages='warning';


### PR DESCRIPTION
This error is caused by the execution logic of Hash Join Node, when the outer node does not fetch a tuple, it calls the ExecSquelchNode method let the lower nodes not to produce tuples anymore, leaving the inner node "squalched" but "un-executed" state. If the hash join needs to be rescanned, then the inner nodes has to be rescanned too if Hash Node's lefttree does not have chgParam, and finally a node does not have chgParam but "squelched" will cause ERROR.

This commit resolves the issue by handling of the rescan method in HashJoin Node properly.

Authored-by: wuyuhao28 <wuyuhao28@github.com>

This is a backport from main: https://github.com/greenplum-db/gpdb/pull/15590