### PR TITLE
Fix cannot execute squelched plan node of type error

### DIFF
--- a/src/backend/executor/nodeHashjoin.c
+++ b/src/backend/executor/nodeHashjoin.c
@@ -1282,6 +1282,16 @@ ExecReScanHashJoin(HashJoinState *node)
 				ExecReScan(node->js.ps.righttree);
 		}
 	}
+	else
+	{
+		/*
+		 * GPDB: HashTable not built with righttree may be squelched,
+		 * HashJoin need rescan righttree to reset its squelch flag.
+		 */
+		if (node->js.ps.righttree->chgParam == NULL &&
+			node->js.ps.righttree->squelched)
+				ExecReScan(node->js.ps.righttree);
+	}
 
 	/* Always reset intra-tuple state */
 	node->hj_CurHashValue = 0;

--- a/src/test/regress/expected/bfv_joins.out
+++ b/src/test/regress/expected/bfv_joins.out
@@ -4057,6 +4057,83 @@ join baz on varchar_3=text_any;
 -----------+--------+----------
 (0 rows)
 
+--
+-- Test case for Hash Join rescan after squelched without hashtable built
+-- See https://github.com/greenplum-db/gpdb/pull/15590
+--
+--- Lateral Join
+reset enable_hashjoin;
+set from_collapse_limit = 1;
+set join_collapse_limit = 1;
+select 1 from pg_namespace  join lateral
+    (select * from aclexplode(nspacl) x join pg_authid  on x.grantee = pg_authid.oid where rolname = current_user) z on true limit 1;
+ ?column? 
+----------
+        1
+(1 row)
+
+explain
+select 1 from pg_namespace  join lateral
+    (select * from aclexplode(nspacl) x join pg_authid  on x.grantee = pg_authid.oid where rolname = current_user) z on true limit 1;
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
+ Limit  (cost=20000000200.16..20000000200.26 rows=1 width=0)
+   ->  Nested Loop  (cost=20000000200.16..20000000202.66 rows=24 width=0)
+         ->  Seq Scan on pg_namespace  (cost=10000000000.00..10000000001.07 rows=7 width=45)
+         ->  Hash Join  (cost=200.16..200.33 rows=4 width=0)
+               Hash Cond: (x.grantee = pg_authid.oid)
+               ->  Function Scan on aclexplode x  (cost=0.00..0.10 rows=10 width=4)
+               ->  Hash  (cost=200.14..200.14 rows=1 width=4)
+                     ->  Index Scan using pg_authid_oid_index on pg_authid  (cost=0.12..200.14 rows=1 width=4)
+                           Filter: (rolname = 'gpadmin'::name)
+ Optimizer: Postgres query optimizer
+(10 rows)
+
+reset from_collapse_limit;
+reset join_collapse_limit;
+--- NestLoop index join
+create table l_table (a int,  b int) distributed replicated;
+create index l_table_idx on l_table(a);
+create table r_table1 (ra1 int,  rb1 int) distributed replicated;
+create table r_table2 (ra2 int,  rb2 int) distributed replicated;
+insert into l_table select i % 10 , i from generate_series(1, 10000) i;
+insert into r_table1 select i, i from generate_series(1, 1000) i;
+insert into r_table2 values(11, 11), (1, 1) ;
+analyze l_table;
+analyze r_table1;
+analyze r_table2;
+set optimizer to off;
+set enable_nestloop to on;
+set enable_bitmapscan to off;
+set enable_seqscan=off;
+explain select * from r_table2 where ra2 in ( select a from l_table join r_table1 on b = rb1);
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=20000000024.66..20000000871.86 rows=10 width=8)
+   ->  Nested Loop Semi Join  (cost=20000000024.66..20000000871.86 rows=10 width=8)
+         ->  Seq Scan on r_table2  (cost=10000000000.00..10000000001.02 rows=2 width=8)
+         ->  Hash Join  (cost=10000000024.66..10000000854.37 rows=100 width=4)
+               Hash Cond: (l_table.b = r_table1.rb1)
+               ->  Index Scan using l_table_idx on l_table  (cost=0.16..816.12 rows=1000 width=8)
+                     Index Cond: (a = r_table2.ra2)
+               ->  Hash  (cost=10000000012.00..10000000012.00 rows=334 width=4)
+                     ->  Seq Scan on r_table1  (cost=10000000000.00..10000000012.00 rows=1000 width=4)
+ Optimizer: Postgres query optimizer
+(10 rows)
+
+select * from r_table2 where ra2 in ( select a from l_table join r_table1 on b = rb1);
+ ra2 | rb2 
+-----+-----
+   1 |   1
+(1 row)
+
+reset optimizer;
+reset enable_nestloop;
+reset enable_bitmapscan;
+reset enable_seqscan;
+drop table l_table;
+drop table r_table1;
+drop table r_table2;
 -- Clean up. None of the objects we create are very interesting to keep around.
 reset search_path;
 set client_min_messages='warning';

--- a/src/test/regress/expected/bfv_joins_optimizer.out
+++ b/src/test/regress/expected/bfv_joins_optimizer.out
@@ -4050,6 +4050,83 @@ join baz on varchar_3=text_any;
 -----------+--------+----------
 (0 rows)
 
+--
+-- Test case for Hash Join rescan after squelched without hashtable built
+-- See https://github.com/greenplum-db/gpdb/pull/15590
+--
+--- Lateral Join
+reset enable_hashjoin;
+set from_collapse_limit = 1;
+set join_collapse_limit = 1;
+select 1 from pg_namespace  join lateral
+    (select * from aclexplode(nspacl) x join pg_authid  on x.grantee = pg_authid.oid where rolname = current_user) z on true limit 1;
+ ?column? 
+----------
+        1
+(1 row)
+
+explain
+select 1 from pg_namespace  join lateral
+    (select * from aclexplode(nspacl) x join pg_authid  on x.grantee = pg_authid.oid where rolname = current_user) z on true limit 1;
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
+ Limit  (cost=20000000200.16..20000000200.26 rows=1 width=0)
+   ->  Nested Loop  (cost=20000000200.16..20000000202.66 rows=24 width=0)
+         ->  Seq Scan on pg_namespace  (cost=10000000000.00..10000000001.07 rows=7 width=45)
+         ->  Hash Join  (cost=200.16..200.33 rows=4 width=0)
+               Hash Cond: (x.grantee = pg_authid.oid)
+               ->  Function Scan on aclexplode x  (cost=0.00..0.10 rows=10 width=4)
+               ->  Hash  (cost=200.14..200.14 rows=1 width=4)
+                     ->  Index Scan using pg_authid_oid_index on pg_authid  (cost=0.12..200.14 rows=1 width=4)
+                           Filter: (rolname = 'gpadmin'::name)
+ Optimizer: Postgres query optimizer
+(10 rows)
+
+reset from_collapse_limit;
+reset join_collapse_limit;
+--- NestLoop index join
+create table l_table (a int,  b int) distributed replicated;
+create index l_table_idx on l_table(a);
+create table r_table1 (ra1 int,  rb1 int) distributed replicated;
+create table r_table2 (ra2 int,  rb2 int) distributed replicated;
+insert into l_table select i % 10 , i from generate_series(1, 10000) i;
+insert into r_table1 select i, i from generate_series(1, 1000) i;
+insert into r_table2 values(11, 11), (1, 1) ;
+analyze l_table;
+analyze r_table1;
+analyze r_table2;
+set optimizer to off;
+set enable_nestloop to on;
+set enable_bitmapscan to off;
+set enable_seqscan=off;
+explain select * from r_table2 where ra2 in ( select a from l_table join r_table1 on b = rb1);
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=20000000024.66..20000000871.86 rows=10 width=8)
+   ->  Nested Loop Semi Join  (cost=20000000024.66..20000000871.86 rows=10 width=8)
+         ->  Seq Scan on r_table2  (cost=10000000000.00..10000000001.02 rows=2 width=8)
+         ->  Hash Join  (cost=10000000024.66..10000000854.37 rows=100 width=4)
+               Hash Cond: (l_table.b = r_table1.rb1)
+               ->  Index Scan using l_table_idx on l_table  (cost=0.16..816.12 rows=1000 width=8)
+                     Index Cond: (a = r_table2.ra2)
+               ->  Hash  (cost=10000000012.00..10000000012.00 rows=334 width=4)
+                     ->  Seq Scan on r_table1  (cost=10000000000.00..10000000012.00 rows=1000 width=4)
+ Optimizer: Postgres query optimizer
+(10 rows)
+
+select * from r_table2 where ra2 in ( select a from l_table join r_table1 on b = rb1);
+ ra2 | rb2 
+-----+-----
+   1 |   1
+(1 row)
+
+reset optimizer;
+reset enable_nestloop;
+reset enable_bitmapscan;
+reset enable_seqscan;
+drop table l_table;
+drop table r_table1;
+drop table r_table2;
 -- Clean up. None of the objects we create are very interesting to keep around.
 reset search_path;
 set client_min_messages='warning';

--- a/src/test/regress/sql/bfv_joins.sql
+++ b/src/test/regress/sql/bfv_joins.sql
@@ -540,6 +540,49 @@ join baz on varchar_3=text_any;
 select varchar_3, char_3, text_any from foo join bar on varchar_3=char_3
 join baz on varchar_3=text_any;
 
+--
+-- Test case for Hash Join rescan after squelched without hashtable built
+-- See https://github.com/greenplum-db/gpdb/pull/15590
+--
+--- Lateral Join
+reset enable_hashjoin;
+set from_collapse_limit = 1;
+set join_collapse_limit = 1;
+select 1 from pg_namespace  join lateral
+    (select * from aclexplode(nspacl) x join pg_authid  on x.grantee = pg_authid.oid where rolname = current_user) z on true limit 1;
+explain
+select 1 from pg_namespace  join lateral
+    (select * from aclexplode(nspacl) x join pg_authid  on x.grantee = pg_authid.oid where rolname = current_user) z on true limit 1;
+reset from_collapse_limit;
+reset join_collapse_limit;
+
+--- NestLoop index join
+create table l_table (a int,  b int) distributed replicated;
+create index l_table_idx on l_table(a);
+create table r_table1 (ra1 int,  rb1 int) distributed replicated;
+create table r_table2 (ra2 int,  rb2 int) distributed replicated;
+insert into l_table select i % 10 , i from generate_series(1, 10000) i;
+insert into r_table1 select i, i from generate_series(1, 1000) i;
+insert into r_table2 values(11, 11), (1, 1) ;
+analyze l_table;
+analyze r_table1;
+analyze r_table2;
+
+set optimizer to off;
+set enable_nestloop to on;
+set enable_bitmapscan to off;
+set enable_seqscan=off;
+explain select * from r_table2 where ra2 in ( select a from l_table join r_table1 on b = rb1);
+select * from r_table2 where ra2 in ( select a from l_table join r_table1 on b = rb1);
+
+reset optimizer;
+reset enable_nestloop;
+reset enable_bitmapscan;
+reset enable_seqscan;
+drop table l_table;
+drop table r_table1;
+drop table r_table2;
+
 -- Clean up. None of the objects we create are very interesting to keep around.
 reset search_path;
 set client_min_messages='warning';


### PR DESCRIPTION
This error is caused by the execution logic of Hash Join Node, when the outernode does not fetch a tuple, it calls the ExecSquelchNode method let the lowernodes not to produce tuples anymore, leaving the inner node "squalched" but "un-executed" state. If the hash join needs to be rescanned, then the inner nodes has to be rescanned too if Hash Node's lefttree does not have chgParam, and finally a node does not have chgParam but "squelched" will cause ERROR.

Let's explain with example given in issue #11673 

```
gpadmin=# set from_collapse_limit = 1; set join_collapse_limit = 1;
SET
gpadmin=# explain select * from pg_namespace  join lateral  (select * from aclexplode(nspacl) x join pg_authid  on x.grantee = pg_authid.oid) z on true;
                                  QUERY PLAN
-------------------------------------------------------------------------------
 Nested Loop  (cost=10000000001.02..10000000003.52 rows=24 width=284)
   ->  Seq Scan on pg_namespace  (cost=0.00..1.07 rows=7 width=113)
   ->  Hash Join  (cost=1.02..1.20 rows=4 width=171)
         Hash Cond: (x.grantee = pg_authid.oid)
         ->  Function Scan on aclexplode x  (cost=0.00..0.10 rows=10 width=41)
         ->  Hash  (cost=1.01..1.01 rows=1 width=134)
               ->  Seq Scan on pg_authid  (cost=0.00..1.01 rows=1 width=134)
 Optimizer: Postgres query optimizer
(8 rows)

gpadmin=#  select * from pg_namespace  join lateral  (select * from aclexplode(nspacl) x join pg_authid  on x.grantee = pg_authid.oid) z on true;
ERROR:  cannot execute squelched plan node of type: 211 (execProcnode.c:612)
```
The executor do the following steps:
1. node Nestloop fetch an outer node's tuple, and begin to fetch an inner node, which is Hash Join's tuple to join;
2. Hash Join "prefetch" a tuple first(Which is from Function Scan), before build hash table, to see if outer node's has tuples, in this case, first output from aclexplode(nspacl) with input nspacl is empty, so Hash Join will set hj_OuterNotEmpty to false, return empty tuple and do not build hash table. Which means Hash Join's inner node is never executed now;
3. Before Hash Join return empty to upper node, Hash Join will do squelch work, set HashJoin->Hash->SeqScan node's squelched flag to true;
4. NestLoop Node fetch empty inner tuple, current Outer tuple cannot join. Next will get a new outer join, and begin to rescan inner Nodes to get new inner tuple;
5. When ExecReScanHashJoin, because hash table has not been built, HashJoin inner node's would not exec rescan to set squelched flag to false. See void ExecReScanHashJoin(HashJoinState *node) implement;
6. Finally when Hash Join "prefetch" a tuple from outer Node, begin to build hash table from inner Nodes, a squelched SeqScan in execProcNode will raise ERROR.

In conclusion, the bug occurs when HashJoin's outer node's has chgParam, but the first output tuple from outer node is empty, when combing with rescan, such as NestLoop inner node, the ERROR is raised.
I've also met this bug when I tried to fix #15415 (Looking forward for someone to discuss), the SQL plan shown as below, we can see HashJoin's outer Node is Index Scan with chgParam:

```
regression=#  explain  SELECT 1 AS VisimapPresent FROM pg_appendonly WHERE visimaprelid is
not NULL AND visimapidxid is not NULL AND relid in (SELECT c.oid FROM
pg_class c join pg_namespace n on c.relnamespace = n.oid and
 c.relname like 'sto_alt_uao_part_splitpartition%' and
 n.nspname = 'alter_ao_part_tables_splitpartition_row');
                                              QUERY PLAN                                               
-------------------------------------------------------------------------------------------------------
 HashAggregate  (cost=10.37..10.40 rows=4 width=6)
   Group Key: pg_appendonly.ctid
   ->  Nested Loop  (cost=1.27..10.37 rows=4 width=6)
         ->  Seq Scan on pg_appendonly  (cost=0.00..1.00 rows=1 width=10)
               Filter: ((visimaprelid IS NOT NULL) AND (visimapidxid IS NOT NULL))
         ->  Hash Join  (cost=1.27..9.33 rows=4 width=4)
               Hash Cond: (c.relnamespace = n.oid)
               ->  Index Scan using pg_class_oid_index on pg_class c  (cost=0.15..8.17 rows=1 width=8)
                     Index Cond: (oid = pg_appendonly.relid)
                     Filter: (relname ~~ 'sto_alt_uao_part_splitpartition%'::text)
               ->  Hash  (cost=1.11..1.11 rows=1 width=4)
                     ->  Seq Scan on pg_namespace n  (cost=0.00..1.11 rows=1 width=4)
                           Filter: (nspname = 'alter_ao_part_tables_splitpartition_row'::name)
 Optimizer: Postgres query optimizer
(14 rows)
```

This commit resolves the issue by handling of the rescan method in HashJoin Node, when hash table does not build, plan will do rescan to reset squelched flag.

backport form https://github.com/greenplum-db/gpdb/pull/15590
