### PR TITLE
resolve GPDB_96_MERGE_FIXME in prepunion about recursive cte

### DIFF
--- a/src/backend/optimizer/prep/prepunion.c
+++ b/src/backend/optimizer/prep/prepunion.c
@@ -488,11 +488,6 @@ generate_recursion_path(SetOperationStmt *setOp, PlannerInfo *root,
 	 * SegmentGeneral, the result of the join may end up having a different
 	 * locus.
 	 *
-	 * GPDB_96_MERGE_FIXME: On coordinator, before the merge, more complicated
-	 * logic was added in commit ad6a6067d9 to make the loci on the WorkTableScan
-	 * and the RecursiveUnion correct. That was largely reverted as part of the
-	 * merge, and things seem to be working with this much simpler thing, but
-	 * I'm not sure if the logic is 100% correct now.
 	 */
 	if (CdbPathLocus_IsSegmentGeneral(lpath->locus))
 	{


### PR DESCRIPTION
Fixme in prepunion.c
GPDB_96_MERGE_FIXME: On coordinator, before the merge, more complicated logic was added in
commit ad6a6067d9 to make the loci on the WorkTableScan and the RecursiveUnion correct.
That was largely reverted as part of the merge, and things seem to be working with this much simpler thing,
but I'm not sure if the logic is 100% correct now.

On commit ad6a6067d9 we change locus of WorkTableScan from CdbLocusType_SegmentGeneral to
CdbLocusType_SingleQE in create_worktablescan_path.
then before create_recursiveunion_path adding gather motion to non_recursive_path, changing locus of
non_recursive_path from CdbLocusType_SegmentGeneral to CdbLocusType_SingleQE.

Current implement is:
Before create_worktablescan_path adding gather motion, changing locus of non_recursive_path from
CdbLocusType_SegmentGeneral to CdbLocusType_SingleQE.
Then locus of WorkTableScan use the same locus as non_recursive_path.
We moved the implementation logic before create_worktablescan_path ,And this is more simple.