### PR TITLE
[7x] walsender connecting to the wrong walreceiver

### DIFF
--- a/gpMgmt/bin/gppylib/commands/test/unit/test_unit_pg_base_backup.py
+++ b/gpMgmt/bin/gppylib/commands/test/unit/test_unit_pg_base_backup.py
@@ -4,10 +4,12 @@
 #
 
 import unittest
-from mock import call, Mock, patch
+from mock import call, Mock, patch, MagicMock
 from gppylib.commands import pg
-from test.unit.gp_unittest import GpTestCase, run_tests
 from pgdb import DatabaseError
+
+from gppylib.test.unit.gp_unittest import GpTestCase
+from gppylib.commands.base import CommandResult
 
 class TestUnitPgReplicationSlot(GpTestCase):
     def setUp(self):
@@ -182,6 +184,66 @@ class TestUnitPgBaseBackup(unittest.TestCase):
         self.assertNotIn("-x", base_backup.command_tokens)
         self.assertNotIn("--xlog", base_backup.command_tokens)
 
+class PgTests(GpTestCase):
+    def setUp(self):
+        self.apply_patches([
+            patch('gppylib.commands.pg.logger', return_value=Mock(spec=['log', 'info', 'debug', 'error', 'warning'])),
+            patch('gppylib.db.dbconn.connect'),
+            patch('gppylib.db.dbconn.querySingleton')
+        ])
+        self.logger = self.get_mock_from_apply_patch('logger')
+        self.connect = self.get_mock_from_apply_patch('connect')
+        self.query = self.get_mock_from_apply_patch('querySingleton')
+
+    def test_kill_existing_walsenders(self):
+        primary_config = [("sdw1", 20000), ("sdw1", 20001)]
+
+        # Prepare mock return values
+        self.query.return_value = True
+
+        # Run the function being tested
+        pg.kill_existing_walsenders_on_primary(primary_config)
+
+        # Assertions
+        expected_calls = [
+            call.info('killing existing walsender process on primary sdw1:20000 to refresh replication connection'),
+            call.info('killing existing walsender process on primary sdw1:20001 to refresh replication connection')
+        ]
+        self.logger.info.assert_has_calls(expected_calls)
+        self.logger.warning.assert_not_called()
+
+    def test_kill_existing_walsenders_failure(self):
+        primary_config = [("sdw1", 20000), ("sdw1", 20001)]
+
+        # Prepare mock return values
+        self.query.return_value = False
+
+        # Run the function being tested
+        pg.kill_existing_walsenders_on_primary(primary_config)
+
+        # Assertions
+        expected_calls = [
+            call.info('killing existing walsender process on primary sdw1:20000 to refresh replication connection'),
+            call.info('killing existing walsender process on primary sdw1:20001 to refresh replication connection')
+        ]
+        self.logger.info.assert_has_calls(expected_calls)
+        assert self.logger.warning.call_count == 2
+        args, _ = self.logger.warning.call_args
+        assert "Unable to kill walsender on primary host" in args[0]
+
+    def test_kill_existing_walsenders_one_host_failure_and_other_succeed(self):
+        primary_config = [("sdw1", 20000), ("sdw2", 20001)]
+
+        # Prepare mock return values
+        self.query.side_effect = [False, True]
+
+        # Run the function being tested
+        pg.kill_existing_walsenders_on_primary(primary_config)
+
+        # Assertions
+        self.logger.warning.assert_called_once()
+        self.assertEqual([call("Unable to kill walsender on primary host {0}:{1}", "sdw1", 20000)],
+                         self.logger.warning.call_args_list)
 
 if __name__ == '__main__':
     run_tests()

--- a/gpMgmt/test/behave/mgmt_utils/gpaddmirrors.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpaddmirrors.feature
@@ -53,6 +53,7 @@ Feature: Tests for gpaddmirrors
 
         When gpaddmirrors adds 3 mirrors
         Then gpaddmirrors should return a return code of 0
+        And gpaddmirrors should not print "Unable to kill walsender on primary" to stdout
         And verify the database has mirrors
         And the segments are synchronized
         And check segment conf: postgresql.conf
@@ -334,6 +335,7 @@ Feature: Tests for gpaddmirrors
         And pg_hba file "/tmp/gpaddmirrors/data/primary/gpseg0/pg_hba.conf" on host "sdw1" contains entries for "samehost"
         And verify that the file "pg_hba.conf" in each segment data directory has "no" line starting with "host.*replication.*\(127.0.0\|::1\).*trust"
         Then verify the database has mirrors
+        And gpaddmirrors should not print "Unable to kill walsender on primary" to stdout
 
         Then the mirror on content 0 is stopped with the immediate flag
         And an FTS probe is triggered
@@ -371,6 +373,7 @@ Feature: Tests for gpaddmirrors
         And gpaddmirrors adds mirrors with options "--hba-hostnames"
         And pg_hba file "/tmp/gpaddmirrors/data/primary/gpseg0/pg_hba.conf" on host "sdw1" contains entries for "cdw, sdw1, sdw2, samehost"
         Then verify the database has mirrors
+        And gpaddmirrors should not print "Unable to kill walsender on primary" to stdout
 
         When the mirror on content 0 is stopped with the immediate flag
         And an FTS probe is triggered
@@ -405,7 +408,8 @@ Feature: Tests for gpaddmirrors
         And the database is not running
         And a cluster is created with no mirrors on "cdw" and "sdw1, sdw2, sdw3"
         And gpaddmirrors adds mirrors
-        Then verify the database has mirrors
+        Then gpaddmirrors should not print "Unable to kill walsender on primary" to stdout
+        And verify the database has mirrors
         And save the gparray to context
         And the database is not running
         And a cluster is created with no mirrors on "cdw" and "sdw1, sdw2, sdw3"
@@ -432,7 +436,8 @@ Feature: Tests for gpaddmirrors
         And the database is not running
         And a cluster is created with no mirrors on "cdw" and "sdw1"
         And gpaddmirrors adds mirrors
-        Then verify the database has mirrors
+        Then gpaddmirrors should not print "Unable to kill walsender on primary" to stdout
+        And verify the database has mirrors
         And check segment conf: postgresql.conf
         And the user runs "gpstop -aqM fast"
 
@@ -469,7 +474,8 @@ Feature: Tests for gpaddmirrors
         And the database is not running
         And a cluster is created with no mirrors on "cdw" and "sdw1"
         When gpaddmirrors adds mirrors
-        Then verify the database has mirrors
+        Then gpaddmirrors should not print "Unable to kill walsender on primary" to stdout
+        And verify the database has mirrors
         And check segment conf: postgresql.conf
         And the user runs "gpstop -aqM fast"
 
@@ -499,7 +505,8 @@ Feature: Tests for gpaddmirrors
           And a cluster is created with no mirrors on "cdw" and "sdw1"
           And a tablespace is created with data
          When gpaddmirrors adds mirrors
-         Then verify the database has mirrors
+         Then gpaddmirrors should not print "Unable to kill walsender on primary" to stdout
+         And verify the database has mirrors
 
          When an FTS probe is triggered
           And the segments are synchronized

--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg_newhost.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg_newhost.feature
@@ -14,11 +14,14 @@ Feature: gprecoverseg tests involving migrating to a new host
       And the user runs gpconfig sets guc "wal_sender_timeout" with "15s"
       And the user runs "gpstop -air"
       And the cluster configuration is saved for "before"
+      And saving host IP address of <down>
       And segment hosts <down> are disconnected from the cluster and from the spare segment hosts <spare>
       And the cluster configuration has no segments where <down_sql>
       When the user runs <gprecoverseg_cmd>
       Then gprecoverseg should return a return code of 0
       And pg_hba file "/data/gpdata/mirror/gpseg0/pg_hba.conf" on host "<acting_primary>" contains entries for "<used>"
+      And pg_hba file on primary of mirrors on "<used>" with "all" contains no replication entries for <down>
+      And verify that only replication connection primary has is to "<used>"
       And the cluster configuration is saved for "<test_case>"
       And the "before" and "<test_case>" cluster configuration matches with the expected for gprecoverseg newhost
       And the mirrors replicate and fail over and back correctly
@@ -161,6 +164,31 @@ Feature: gprecoverseg tests involving migrating to a new host
          And the "before" and "after_recreation" cluster configuration matches with the expected for gprecoverseg newhost
 
     @concourse_cluster
+    Scenario: gprecoverseg removes the stale replication entries from pg_hba when moving mirrors to new host
+      Given the database is running
+      And all the segments are running
+      And the segments are synchronized
+      And the cluster configuration is saved for "before"
+      And saving host IP address of "sdw1"
+      And segment hosts "sdw1" are disconnected from the cluster and from the spare segment hosts "sdw5"
+      And the cluster configuration has no segments where "hostname='sdw1' and status='u'"
+      When the user runs "gprecoverseg -a -p sdw5"
+      Then gprecoverseg should return a return code of 0
+      And all the segments are running
+      And pg_hba file on primary of mirrors on "sdw5" with "all" contains no replication entries for "sdw1"
+      And verify that only replication connection primary has is to "sdw5"
+      And the user runs "gprecoverseg -ar"
+      And segment hosts "sdw1" are reconnected to the cluster and to the spare segment hosts "none"
+      And segment hosts "sdw5" are disconnected from the cluster and from the spare segment hosts "none"
+      And the cluster configuration has no segments where "hostname='sdw5' and status='u'"
+      # making the cluster back to it's original state
+      And segment hosts "sdw5" are reconnected to the cluster and to the spare segment hosts "none"
+      And segment hosts "sdw1" are disconnected from the cluster and from the spare segment hosts "none"
+      Then the original cluster state is recreated for "one_host_down"
+      And the cluster configuration is saved for "after_recreation"
+      And the "before" and "after_recreation" cluster configuration matches with the expected for gprecoverseg newhost
+
+    @concourse_cluster
       Scenario: failover host is not in reach gprecoverseg recovery to new host skips
          Given  the database is running
          And all the segments are running
@@ -177,4 +205,3 @@ Feature: gprecoverseg tests involving migrating to a new host
          When the user runs gprecoverseg with input file and additional args "-av"
          Then gprecoverseg should return a return code of 2
          And gprecoverseg  should print "The recovery target segment sdw5 (content 0) is unreachable" escaped to stdout
-

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -897,7 +897,6 @@ def impl(context, command, num):
 def impl(context, command, ret_code):
     check_return_code(context, ret_code)
 
-
 @given('the segments are synchronized')
 @when('the segments are synchronized')
 @then('the segments are synchronized')
@@ -1560,6 +1559,7 @@ def impl(context, content_ids, expected_status):
 
 @given('the cluster configuration has no segments where "{filter}"')
 @when('the cluster configuration has no segments where "{filter}"')
+@then('the cluster configuration has no segments where "{filter}"')
 def impl(context, filter):
     SLEEP_PERIOD = 5
     MAX_DURATION = 300

--- a/src/backend/replication/libpqwalreceiver/libpqwalreceiver.c
+++ b/src/backend/replication/libpqwalreceiver/libpqwalreceiver.c
@@ -131,8 +131,8 @@ libpqrcv_connect(const char *conninfo, bool logical, const char *appname,
 {
 	WalReceiverConn *conn;
 	PostgresPollingStatusType status;
-	const char *keys[5 + 1];
-	const char *vals[5 + 1];
+	const char *keys[5];
+	const char *vals[5];
 	int			i = 0;
 
 	/*
@@ -159,8 +159,6 @@ libpqrcv_connect(const char *conninfo, bool logical, const char *appname,
 		keys[++i] = "client_encoding";
 		vals[i] = GetDatabaseEncodingName();
 	}
-	keys[++i] = GPCONN_TYPE;
-	vals[i] = GPCONN_TYPE_DEFAULT;
 	keys[++i] = NULL;
 	vals[i] = NULL;
 

--- a/src/test/walrep/input/setup.source
+++ b/src/test/walrep/input/setup.source
@@ -30,7 +30,7 @@ myseg INT;
 BEGIN
 	myseg := gp_execution_segment();
 	startpoint := startpoints[myseg + 1];
-	select 'port=' || setting INTO port from pg_settings where name = 'port';
+	select 'host=localhost port=' || setting INTO port from pg_settings where name = 'port';
 	RAISE DEBUG 'port %, startpoint % current_wal_lsn %',
 	port, startpoint, pg_current_wal_lsn();
 

--- a/src/test/walrep/output/setup.source
+++ b/src/test/walrep/output/setup.source
@@ -25,7 +25,7 @@ myseg INT;
 BEGIN
 	myseg := gp_execution_segment();
 	startpoint := startpoints[myseg + 1];
-	select 'port=' || setting INTO port from pg_settings where name = 'port';
+	select 'host=localhost port=' || setting INTO port from pg_settings where name = 'port';
 	RAISE DEBUG 'port %, startpoint % current_wal_lsn %',
 	port, startpoint, pg_current_wal_lsn();
 


### PR DESCRIPTION
Fixes https://github.com/greenplum-db/gpdb/issues/13030

**Problem:** 
When moving mirrors from one host to another in a multi-host cluster setup, an inconsistency is observed in the gp_segment_configuration data. This occurs when mirrors are recovered on a new host due to the old host's unavailability. A situation arises where the current host becomes unreachable while the old host becomes reachable. As a result, gp_segment_configuration incorrectly shows mirrors as "up" even though their actual hosts are unavailable

**RCA:**
- We are using the GPDB internal protocol for streaming replication connections. The internal protocol is meant for special QD<->QE libpq interaction (fts, dispatch etc). For walsender<->walreceiver connections, this is not necessary.
- The issue arises when a mirror segment is moved to a new host but the replication entry for the old host is not removed from the primary's pg_hba.conf file. As a consequence, when the new host becomes unreachable and the old host is accessible again, the primary's walsender mistakenly connects back to the old mirror's walreceiver.

**Solution:**
To resolve this issue, the recommended steps are to modify the protocol type for WAL replication, remove the hba entry associated with the old mirror on the primary host, reload the configuration on the primary, and finally, terminate the existing walsender process on the primary to initiate another authentication cycle for streaming replication.

**Tests done:**
- Added new unit test cases and behave test cases for testing the scenario
- Added steps to check the pg_hba update on existing behave test cases
- Manual testing for testing the scenario on multi node cluster

[pipeline](https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb-dev-sruthi_pg_hba-rhel8)