### PR TITLE
fix cgroup v1 cpu_quota_us can not be larger than parent

### DIFF
--- a/src/backend/utils/resgroup/cgroup-ops-linux-v1.c
+++ b/src/backend/utils/resgroup/cgroup-ops-linux-v1.c
@@ -970,9 +970,8 @@ setcpulimit_v1(Oid group, int cpu_hard_limit)
 
 	if (cpu_hard_limit > 0)
 	{
-		int64 periods = get_cfs_period_us_v1(component);
 		writeInt64(group, BASEDIR_GPDB, component, "cpu.cfs_quota_us",
-				   periods * cgroupSystemInfoV1.ncores * cpu_hard_limit / 100);
+				   system_cfs_quota_us * cpu_hard_limit * gp_resource_group_cpu_limit / 100);
 	}
 	else
 	{

--- a/src/test/isolation2/expected/resgroup/resgroup_syntax.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_syntax.out
@@ -507,7 +507,7 @@ ALTER
 0: DROP RESOURCE GROUP rg_test_group;
 DROP
 -- start_ignore
-!\retcode gpconfig -c gp_resource_group_cpu_limit -v 0.9;
+!\retcode gpconfig -c gp_resource_group_cpu_limit -v 1;
 -- start_ignore
 -- end_ignore
 (exited with code 0)

--- a/src/test/isolation2/expected/resgroup/resgroup_syntax.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_syntax.out
@@ -488,3 +488,32 @@ SELECT groupname,cpu_hard_quota_limit,cpuset FROM gp_toolkit.gp_resgroup_config 
 (1 row)
 DROP RESOURCE GROUP rg_test_group;
 DROP
+
+-- test set cpu_hard_quota_limit to high value when gp_resource_group_cpu_limit is low
+-- start_ignore
+!\retcode gpconfig -c gp_resource_group_cpu_limit -v 0.5;
+-- start_ignore
+-- end_ignore
+(exited with code 0)
+!\retcode gpstop -ari;
+-- start_ignore
+-- end_ignore
+(exited with code 0)
+-- end_ignore
+0: CREATE RESOURCE GROUP rg_test_group WITH (cpu_hard_quota_limit=10);
+CREATE
+0: ALTER RESOURCE GROUP rg_test_group SET cpu_hard_quota_limit 100;
+ALTER
+0: DROP RESOURCE GROUP rg_test_group;
+DROP
+-- start_ignore
+!\retcode gpconfig -c gp_resource_group_cpu_limit -v 0.9;
+-- start_ignore
+-- end_ignore
+(exited with code 0)
+!\retcode gpstop -ari;
+-- start_ignore
+-- end_ignore
+(exited with code 0)
+-- end_ignore
+

--- a/src/test/isolation2/sql/resgroup/resgroup_syntax.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_syntax.sql
@@ -254,7 +254,7 @@ DROP RESOURCE GROUP rg_test_group;
 0: ALTER RESOURCE GROUP rg_test_group SET cpu_hard_quota_limit 100;
 0: DROP RESOURCE GROUP rg_test_group;
 -- start_ignore
-!\retcode gpconfig -c gp_resource_group_cpu_limit -v 0.9; 
+!\retcode gpconfig -c gp_resource_group_cpu_limit -v 1; 
 !\retcode gpstop -ari;
 -- end_ignore
 

--- a/src/test/isolation2/sql/resgroup/resgroup_syntax.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_syntax.sql
@@ -244,3 +244,17 @@ SELECT groupname,cpu_hard_quota_limit,cpuset FROM gp_toolkit.gp_resgroup_config 
 ALTER RESOURCE GROUP rg_test_group SET cpu_hard_quota_limit 10;
 SELECT groupname,cpu_hard_quota_limit,cpuset FROM gp_toolkit.gp_resgroup_config WHERE groupname='rg_test_group';
 DROP RESOURCE GROUP rg_test_group;
+
+-- test set cpu_hard_quota_limit to high value when gp_resource_group_cpu_limit is low
+-- start_ignore
+!\retcode gpconfig -c gp_resource_group_cpu_limit -v 0.5;
+!\retcode gpstop -ari;
+-- end_ignore
+0: CREATE RESOURCE GROUP rg_test_group WITH (cpu_hard_quota_limit=10);
+0: ALTER RESOURCE GROUP rg_test_group SET cpu_hard_quota_limit 100;
+0: DROP RESOURCE GROUP rg_test_group;
+-- start_ignore
+!\retcode gpconfig -c gp_resource_group_cpu_limit -v 0.9; 
+!\retcode gpstop -ari;
+-- end_ignore
+


### PR DESCRIPTION
In Cgroup v1, we can not set `cpu_quota_us` larger than parent's, it'll throw an
error of "Invalid Argument":

```
smart@postgres:/sys/fs/cgroup/cpu/gpdb/6441$ echo 370000 > cpu.cfs_quota_us
bash: echo: write error: Invalid argument
```

But this could happen in Cgroup v2, so the interface between them is not exactly
the same, this PR is trying to fix it.
