### PR TITLE
gprecoverseg: Add ability to handle interrupts

### DIFF
--- a/gpMgmt/bin/gppylib/commands/gp.py
+++ b/gpMgmt/bin/gppylib/commands/gp.py
@@ -999,7 +999,7 @@ class GpSegSetupRecovery(Command):
     """
     def __init__(self, name, confinfo, logdir, batchSize, verbose, remoteHost, forceoverwrite):
         cmdStr = _get_cmd_for_recovery_wrapper('gpsegsetuprecovery', confinfo, logdir, batchSize, verbose,forceoverwrite)
-        Command.__init__(self, name, cmdStr, REMOTE, remoteHost)
+        Command.__init__(self, name, cmdStr, REMOTE, remoteHost, start_new_session=True)
 
 
 class GpSegRecovery(Command):
@@ -1008,7 +1008,7 @@ class GpSegRecovery(Command):
     """
     def __init__(self, name, confinfo, logdir, batchSize, verbose, remoteHost, forceoverwrite, era):
         cmdStr = _get_cmd_for_recovery_wrapper('gpsegrecovery', confinfo, logdir, batchSize, verbose, forceoverwrite, era)
-        Command.__init__(self, name, cmdStr, REMOTE, remoteHost)
+        Command.__init__(self, name, cmdStr, REMOTE, remoteHost, start_new_session=True)
 
 
 def _get_cmd_for_recovery_wrapper(wrapper_filename, confinfo, logdir, batchSize, verbose, forceoverwrite, era=None):

--- a/gpMgmt/bin/gppylib/programs/test/unit/test_cluster_clsrecoversegment.py
+++ b/gpMgmt/bin/gppylib/programs/test/unit/test_cluster_clsrecoversegment.py
@@ -1,0 +1,78 @@
+from mock import Mock, patch, call
+
+from gppylib.test.unit.gp_unittest import GpTestCase, run_tests
+from gppylib.commands.base import CommandResult, ExecutionError
+from gppylib.programs.clsRecoverSegment import GpRecoverSegmentProgram
+
+class RecoverSegmentsTestCase(GpTestCase):
+    def setUp(self):
+        mock_logger = Mock(spec=['log', 'warn', 'info', 'debug', 'error', 'warning', 'fatal'])
+
+        self.apply_patches([
+            patch('gppylib.programs.clsRecoverSegment.logger', return_value=mock_logger),
+        ])
+
+        self.mock_logger = self.get_mock_from_apply_patch('logger')
+
+        # Mock WorkerPool
+        self.mock_pool = Mock()
+        self.mock_pool.isDone.side_effect = [False, True]
+        self.obj = GpRecoverSegmentProgram(Mock())
+        self.obj._GpRecoverSegmentProgram__pool = self.mock_pool
+    
+    def tearDown(self):
+        super(RecoverSegmentsTestCase, self).tearDown()
+
+    @patch('gppylib.programs.clsRecoverSegment.Command.run') 
+    def test_shutdown_runs_successfully_single_host(self, mock1):
+        self.obj.shutdown(['sdw1'])
+
+        self.mock_logger.debug.assert_called_once_with("Terminating recovery process on host sdw1")
+        self.assertEqual(mock1.call_count, 1)
+    
+    @patch('gppylib.programs.clsRecoverSegment.Command.run')
+    def test_shutdown_runs_successfully_multiple_hosts(self, mock1):
+        self.obj.shutdown(['sdw1', 'sdw2', 'sdw3'])
+
+        self.mock_logger.debug.assert_any_call("Terminating recovery process on host sdw1")
+        self.mock_logger.debug.assert_any_call("Terminating recovery process on host sdw2")
+        self.mock_logger.debug.assert_any_call("Terminating recovery process on host sdw3")
+
+        self.assertEqual(mock1.call_count, 3)
+
+    @patch('gppylib.programs.clsRecoverSegment.ExecutionError.__str__', return_value="Error getting recovery PID")
+    def test_shutdown_logs_exception_on_single_host(self, mock1):
+
+        def mock_func(*args, **kwargs):
+            cmd = args[0]
+            if cmd.remoteHost == "sdw2":
+                raise ExecutionError("Error getting recovery PID", cmd)
+
+        with patch('gppylib.programs.clsRecoverSegment.Command.run', mock_func):
+            self.obj.shutdown(['sdw1', 'sdw2', 'sdw3'])
+
+        self.mock_logger.debug.assert_has_calls([call("Terminating recovery process on host sdw1"),
+                                                 call("Terminating recovery process on host sdw2"),
+                                                 call("Terminating recovery process on host sdw3")])
+        self.mock_logger.error.assert_called_once_with("Not able to terminate recovery process on host sdw2: Error getting recovery PID")
+
+    @patch('gppylib.programs.clsRecoverSegment.ExecutionError.__str__', return_value="Error getting recovery PID")
+    def test_shutdown_logs_exception_on_multiple_host(self, mock1):
+
+        def mock_func(*args, **kwargs):
+            cmd = args[0]
+            if cmd.remoteHost in ["sdw1", "sdw3"]:
+                raise ExecutionError("Error getting recovery PID", cmd)
+
+        with patch('gppylib.programs.clsRecoverSegment.Command.run', mock_func):
+            self.obj.shutdown(['sdw1', 'sdw2', 'sdw3'])
+
+        self.mock_logger.debug.assert_has_calls([call("Terminating recovery process on host sdw1"),
+                                                 call("Terminating recovery process on host sdw2"),
+                                                 call("Terminating recovery process on host sdw3")])
+        self.mock_logger.error.assert_has_calls([call("Not able to terminate recovery process on host sdw1: Error getting recovery PID"),
+                                                 call("Not able to terminate recovery process on host sdw3: Error getting recovery PID")])
+
+
+if __name__ == '__main__':
+    run_tests()

--- a/gpMgmt/sbin/recovery_base.py
+++ b/gpMgmt/sbin/recovery_base.py
@@ -19,6 +19,7 @@ class RecoveryBase(object):
         self.logger = None
         self.seg_recovery_info_list = None
         self.options = None
+        self.pool = None
         try:
             self.parseargs()
         except Exception as e:
@@ -63,19 +64,18 @@ class RecoveryBase(object):
             raise Exception('No segment configuration values found in --confinfo argument')
 
     def main(self, cmd_list):
-        pool = None
         try:
             # TODO: should we output the name of the exact file?
             self.logger.info("Starting recovery with args: %s" % ' '.join(sys.argv[1:]))
 
-            pool = WorkerPool(numWorkers=min(self.options.batch_size, len(cmd_list)))
-            self.run_cmd_list(cmd_list, self.logger, self.options, pool)
+            self.pool = WorkerPool(numWorkers=min(self.options.batch_size, len(cmd_list)))
+            self.run_cmd_list(cmd_list, self.logger, self.options, self.pool)
             sys.exit(0)
         except Exception as e:
             self._write_to_stderr_and_exit(e)
         finally:
-            if pool:
-                pool.haltWork()
+            if self.pool:
+                self.pool.haltWork()
 
     def _write_to_stderr_and_exit(self, e):
         if self.logger:

--- a/gpMgmt/test/behave/mgmt_utils/steps/recoverseg_mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/recoverseg_mgmt_utils.py
@@ -7,6 +7,8 @@ from contextlib import closing
 from gppylib.commands.base import Command, ExecutionError, REMOTE, WorkerPool
 from gppylib.db import dbconn
 from gppylib.gparray import GpArray, ROLE_PRIMARY, ROLE_MIRROR
+from gppylib.programs.clsRecoverSegment_triples import get_segments_with_running_basebackup, is_pg_rewind_running
+from gppylib.operations.get_segments_in_recovery import is_seg_in_backup_mode
 from test.behave_utils.utils import *
 import platform, shutil
 from behave import given, when, then
@@ -215,9 +217,9 @@ def impl(context, utility, output, segment_type):
         expected = r'\(dbid {}\): {}'.format(segment.dbid, output)
         check_stdout_msg(context, expected)
 
-@then('{utility} should print "{recovery_type}" errors to stdout for content {content_ids}')
-@when('{utility} should print "{recovery_type}" errors to stdout for content {content_ids}')
-def impl(context, utility, recovery_type, content_ids):
+@then('{utility} should print "{recovery_type}" errors to {output} for content {content_ids}')
+@when('{utility} should print "{recovery_type}" errors to {output} for content {content_ids}')
+def impl(context, utility, recovery_type, output, content_ids):
     if content_ids == "None":
         return
     if recovery_type not in ("incremental", "full", "differential","start"):
@@ -239,6 +241,12 @@ def impl(context, utility, recovery_type, content_ids):
         elif recovery_type == 'start':
             expected = r'hostname: {}; port: {}; datadir: {}'.format(segment.getSegmentHostName(), segment.getSegmentPort(),
                                                                      segment.getSegmentDataDirectory())
+        if output == "logfile":
+            context.execute_steps('''
+            Then {0} should print "{1}" regex to logfile
+            '''.format(utility, expected))
+            return
+
         check_stdout_msg(context, expected)
 
 
@@ -355,8 +363,8 @@ def impl(context, host):
     content_id_str = ','.join(str(i) for i in content_ids_on_host)
     recovery_fail_check(context, recovery_type='full', content_ids=content_id_str)
 
-@then('check if moving the mirrors from {original_host} to {new_host} failed')
-def impl(context, original_host, new_host):
+@then('check if moving the mirrors from {original_host} to {new_host} failed {user_termination} user termination')
+def impl(context, original_host, new_host, user_termination):
     all_segments = GpArray.initFromCatalog(dbconn.DbURL()).getDbList()
     segments = filter(lambda seg: seg.getSegmentRole() == ROLE_MIRROR and
                                   seg.getSegmentHostName() == original_host, all_segments)
@@ -367,12 +375,16 @@ def impl(context, original_host, new_host):
     Then gprecoverseg should return a return code of 1
     And user can start transactions
     And gprecoverseg should print "Initiating segment recovery." to stdout
-    And gprecoverseg should print "pg_basebackup: error: could not access directory" to stdout for mirrors with content {content_ids}
     And gprecoverseg should print "Failed to recover the following segments" to stdout
     And verify that mirror on content {content_ids} is down
     And gprecoverseg should print "gprecoverseg failed. Please check the output" to stdout
     And gprecoverseg should not print "Segments successfully recovered" to stdout
     '''.format(content_ids=content_id_str))
+
+    if user_termination == "without":
+        context.execute_steps('''
+        Then gprecoverseg should print "pg_basebackup: error: could not access directory" to stdout for mirrors with content {content_ids}
+        '''.format(content_ids=content_id_str))
 
     #TODO add this step
     #And gpAdminLogs directory has "pg_basebackup*" files on {new_host} only for content {content_ids}
@@ -832,3 +844,72 @@ def impl(context, host):
         if_addrs = gp.IfAddrs.list_addrs(host_name)
         context.host_ip_list[host_name] = if_addrs
 
+
+
+@then('verify that pg_basebackup {action} running for content {content_ids}')
+def impl(context, action, content_ids):
+    attempt = 0
+    num_retries = 600
+    content_ids_to_check = [int(c) for c in content_ids.split(',')]
+
+    while attempt < num_retries:
+        attempt += 1
+        content_ids_running_basebackup = get_segments_with_running_basebackup()
+
+        if action == "is not":
+            if not any(content in content_ids_running_basebackup for content in content_ids_to_check):
+                return
+
+        if action == "is":
+            if all(content in content_ids_running_basebackup for content in content_ids_to_check):
+                return
+
+        time.sleep(0.1)
+        if attempt == num_retries:
+            raise Exception('Timed out after {} retries'.format(num_retries))
+
+
+@then('verify that pg_rewind {action} running for content {content_ids}')
+def impl(context, action, content_ids):
+    qry = "SELECT hostname, port FROM gp_segment_configuration WHERE status='u' AND role='p' AND content IN ({0})".format(content_ids)
+    rows = getRows('postgres', qry)
+
+    attempt = 0
+    num_retries = 600
+    while attempt < num_retries:
+        attempt += 1
+
+        if action == "is not":
+            if not any(is_pg_rewind_running(row[0], row[1]) for row in rows):
+                return
+
+        if action == "is":
+            if all(is_pg_rewind_running(row[0], row[1]) for row in rows):
+                return
+
+        time.sleep(0.1)
+        if attempt == num_retries:
+            raise Exception('Timed out after {} retries'.format(num_retries))
+
+
+@then('verify that differential {action} running for content {content_ids}')
+def impl(context, action, content_ids):
+    qry = "SELECT hostname, port FROM gp_segment_configuration WHERE status='u' AND role='p' AND content IN ({0})".format(content_ids)
+    rows = getRows('postgres', qry)
+
+    attempt = 0
+    num_retries = 600
+    while attempt < num_retries:
+        attempt += 1
+
+        if action == "is not":
+            if not any(is_seg_in_backup_mode(row[0], row[1]) for row in rows):
+                return
+
+        if action == "is":
+            if all(is_seg_in_backup_mode(row[0], row[1]) for row in rows):
+                return
+
+        time.sleep(0.1)
+        if attempt == num_retries:
+            raise Exception('Timed out after {} retries'.format(num_retries))


### PR DESCRIPTION
Currently, gprecoverseg lacks the ability to handle interrupts. When the main gprecoverseg process is terminated, it leaves behind orphaned `gpsegrecovery, pg_rewind, or pg_basebackup` processes that the user would have to manually terminate.

This change aims to add signal handling capabilities to the gprecoverseg code so that we can gracefully terminate the gprecoverseg process by using appropriate signal handlers and performing necessary cleanup actions, instead of abruptly terminating only the main process.

A new option `start_new_session` is added to the `Command` class, which is used by the `gprecoverseg` to spawn `gpsegrecovery` in separate sessions. This is to make sure that sending a termination signal to `gprecoverseg` does not affect the `gpsegrecovery` process (refer to individual commits).

The overall process of termination using signal handlers is described below:

- Signals are caught by the signal handlers in the `gprecoverseg` code. This signal handler then gets the PIDs of the `gpsegsetuprecovery/gpsegrecovery` process running on each segment host and sends a `SIGTERM` signal to them.
- The `gpsegrecovery` process also has a signal handler that will be used to handle the `SIGTERM` signal sent by the main process. We do not need any signal handler for the `gpsegsetuprecovery` code as it does not spawn any new process and we can directly terminate it.
- The signal handler in the `gpsegrecovery` code would then call `terminate_proc_tree` which would terminate the entire process tree of `gpsegrecovery` process, since it is the parent PID of all the child processes (either `pg_rewind/pg_basebackup/rsync`). We do not terminate the `gpsegrecovery` process here since we would need it to perform proper error handling and cleanup actions.
- The above steps are repeated unitl the `WorkerPool` is done with its work. This is to make sure that we are not leaving behind any unfinished commands that might be waiting in the `WorkerPool` queue.
- Termination of the `pg_rewind/pg_basebackup/rsync` process will raise an error, which will be propagated back to the user, and it would also trigger the necessary cleanup actions that are already in place whenever a failure occurs.

The behavior of gprecoverseg on different termination scenarios will be as follows:

1. **Using CTRL-C**: This sends a `SIGINT` signal, and upon receiving this, the user would be given a prompt if they want to proceed further with the termination.
```
It is not recommended to terminate a recovery procedure midway. However, if you choose to proceed, you will need to run either gprecoverseg --differential or gprecoverseg -F to start a new recovery process the next time.

Continue terminating gprecoverseg Yy|Nn (default=N):
>
```
2. **Using kill from the terminal**: This, by default, sends a `SIGTERM` signal, and upon receiving this signal, gprecoverseg would directly terminate without any confirmation from the user.
3. **SSH disconnections**: This sends a `SIGHUP` signal, and currently, this signal will be ignored as we do not want to terminate the recovery process due to such issues.

The signal handlers are placed just before the recovery process is started so that it does not affect any other functionality of gprecoverseg (like rebalancing).

[Pipeline](https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb-dev-7x_gprecoverseg_handle_interrupts-rocky8)

**Open Questions**
- Do we need to handle any other signals apart from the ones mentioned above?