### PR TITLE
6x backport: Hardcode the attributes of GpSegmentId in GetContentIdsFromPlanForSingleRelation()

### DIFF
--- a/src/backend/cdb/cdbtargeteddispatch.c
+++ b/src/backend/cdb/cdbtargeteddispatch.c
@@ -41,6 +41,15 @@
 
 #define PRINT_DISPATCH_DECISIONS_STRING ("print_dispatch_decisions")
 
+/**
+ *  The attributes of GpSegmentId,
+ *  you can find its static definition in heap.c (static FormData_pg_attribute a8;)
+ */
+#define GP_SEGMENTID_TYPID INT4OID
+#define GP_SEGMENTID_TYPMOD -1
+#define GP_SEGMENTID_TYPCOLL 0
+#define GP_SEGMENTID_OPFAMILY 1977	/* integer_ops */
+
 static char *gp_test_options = "";
 
 /* PRINT_DISPATCH_DECISIONS_STRING; */
@@ -212,23 +221,32 @@ GetContentIdsFromPlanForSingleRelation(List *rtable, Plan *plan, int rangeTableI
 	 */
 	if (GpPolicyIsPartitioned(policy))
 	{
-		Var                *seg_id_var;
-		Oid                 vartypeid;
-		int32               type_mod;
-		Oid                 type_coll;
 		PossibleValueSet    pvs_segids;
 		Node              **seg_ids;
 		int                 len;
 		int                 i;
 		List               *contentIds = NULL;
 
-		get_atttypetypmodcoll(rte->relid, GpSegmentIdAttributeNumber,
-							  &vartypeid, &type_mod, &type_coll);
-		seg_id_var = makeVar(rangeTableIndex,
-							 GpSegmentIdAttributeNumber,
-							 vartypeid, type_mod, type_coll, 0);
-		Oid opclass = GetDefaultOpClass(vartypeid, HASH_AM_OID);
-		Oid opfamily = get_opclass_family(opclass);
+		/**
+		 * In previous code, we get the attributes of GpSegmentId dynamically:
+		 * 	get_atttypetypmodcoll(rte->relid, GpSegmentIdAttributeNumber,
+		 *					      &vartypeid, &type_mod, &type_coll);
+		 *  Oid opclass = GetDefaultOpClass(vartypeid, HASH_AM_OID);
+		 *	Oid opfamily = get_opclass_family(opclass);
+		 *
+		 * But they caused the perf regression of pgbench. After test, the bottleneck is
+		 * the indexscan on systable.
+		 *
+		 * So, let's simply introduce GP_SEGMENTID_XXX macros to hardcord them here
+		 * since GpSegmentId is a stable type in GP: you can find its static definition
+		 * in heap.c (static FormData_pg_attribute a8;)
+		 */
+		Var *seg_id_var = makeVar(rangeTableIndex,
+								  GpSegmentIdAttributeNumber,
+								  GP_SEGMENTID_TYPID, GP_SEGMENTID_TYPMOD, GP_SEGMENTID_TYPCOLL,
+								  0);
+		Oid opfamily = GP_SEGMENTID_OPFAMILY;
+
 		pvs_segids = DeterminePossibleValueSet((Node *) qualification,
 											   (Node *) seg_id_var, opfamily);
 		if (!pvs_segids.isAnyValuePossible)


### PR DESCRIPTION
This PR backport https://github.com/greenplum-db/gpdb/pull/15659 to 6x to resolve the performance regression of pgbench.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
