### PR TITLE
Fix gen_pipeline with '/' in the branch name

### DIFF
--- a/concourse/pipelines/gen_pipeline.py
+++ b/concourse/pipelines/gen_pipeline.py
@@ -356,11 +356,13 @@ def main():
         pipeline_file_suffix = suggested_git_branch()
         if args.user != getpass.getuser():
             pipeline_file_suffix = args.user
+        pipeline_file_suffix = pipeline_file_suffix.replace("/", "_")
         default_dev_output_filename = 'gpdb-' + args.pipeline_target + '-' + pipeline_file_suffix + '-' + args.os_type + '.yml'
         args.output_filepath = os.path.join(PIPELINES_DIR, default_dev_output_filename)
 
     if args.directed_release:
         pipeline_file_suffix = suggested_git_branch()
+        pipeline_file_suffix = pipeline_file_suffix.replace("/", "_")
         default_dev_output_filename = pipeline_file_suffix + '.yml'
         args.output_filepath = os.path.join(PIPELINES_DIR, default_dev_output_filename)
 


### PR DESCRIPTION
If there are back-slash '/' in the branch name, gen_pipeline would have
the slash in the pipeline yaml path. And an error will be reported:

```
❯ ./gen_pipeline.py -t dev
Traceback (most recent call last):
  File "\xxx\gpdb/concourse/pipelines/./gen_pipeline.py", line 376, in <module>
    main()
  File "\xxx\gpdb/concourse/pipelines/./gen_pipeline.py", line 367, in main
    pipeline_created = create_pipeline(args, git_remote, git_branch)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "\xxx\gpdb/concourse/pipelines/./gen_pipeline.py", line 144, in create_pipeline
    with open(args.output_filepath, 'w') as output:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '\xxx\gpdb/concourse/pipelines/gpdb-dev-mc/slash_in_gen_pipeline-rocky8.yml'
```

Replace it with underscore '_' to solve the issue.
