### PR TITLE
Fix unused warning 'extended_char'

### DIFF
--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -116,33 +116,6 @@
 /* Read an OID field (don't hard-wire assumption that OID is same as uint) */
 #define READ_OID_FIELD(fldname)     READ_SCALAR_FIELD(fldname, atooid(token))
 
-/*
- * extended_char
- *    In GPDB some structures have char fields with non-printing characters
- *    in them.  '\0' is problematic in particular because it ends debugging
- *    displays of nodes.  It is a bad practice, but hard to stem.  This
- *    function used in readfuncs.c READ_CHAR_FIELD is the inverse of the
- *    character output format in outfuncs.c WRITE_CHAR_FIELD.  A length
- *    one token is translated as before.  A longer token is taken as the
- *    decimal code of the desired character.  (The only zero length token,
- *    <>, should not appear in a character field.)
- */
-inline static char extended_char(char* token, size_t length)
-{
-	char c, *s;
-
-	if ( length == 1 )
-		return *token;
-
-	s = debackslash(token, length);
-	if ( strlen(s) == 1 )
-		c = s[0];
-	else
-		c = (char)strtoul(s, NULL, 10);
-	pfree(s);
-	return c;
-}
-
 /* Read a char field (ie, one ascii character) */
 #define READ_CHAR_FIELD(fldname) \
 	token = pg_strtok(&length);		/* skip :fldname */ \


### PR DESCRIPTION
```
readfuncs.c:130:20: warning: unused function 'extended_char' [-Wunused-function]
inline static char extended_char(char* token, size_t length)
1 warning generated.
```

The usage has been removed by 19cd1cf4b68 - pg12 merge commit
