### PR TITLE
Fall back to planner for queries with foreign partitions using greenplum_fdw

### DIFF
--- a/src/backend/gpopt/gpdbwrappers.cpp
+++ b/src/backend/gpopt/gpdbwrappers.cpp
@@ -2572,4 +2572,18 @@ gpdb::GPDBLockRelationOid(Oid reloid, LOCKMODE lockmode)
 	GP_WRAP_END;
 }
 
+char *
+gpdb::GetRelFdwName(Oid reloid)
+{
+	GP_WRAP_START;
+	{
+		Oid fs_id = GetForeignServerIdByRelId(reloid);
+		ForeignServer *fs = GetForeignServer(fs_id);
+		ForeignDataWrapper *fdw = GetForeignDataWrapper(fs->fdwid);
+		return fdw->fdwname;
+	}
+	GP_WRAP_END;
+	return nullptr;
+}
+
 // EOF

--- a/src/include/gpopt/gpdbwrappers.h
+++ b/src/include/gpopt/gpdbwrappers.h
@@ -645,6 +645,8 @@ Oid GetForeignServerId(Oid reloid);
 
 void GPDBLockRelationOid(Oid reloid, int lockmode);
 
+char *GetRelFdwName(Oid reloid);
+
 }  //namespace gpdb
 
 #define ForEach(cell, l) \


### PR DESCRIPTION
This fdw has special logic that populates fdw_private and performs parallel cursor setup on the coordinator in `BeginForeignScan`, which is called in `ExecInitForeignScanForPartition`. Within the Dynamic nodes, Orca calls this function during execution for each partition, as there is partition-specific logic that needs to be done to move to the next partition. Planner on the other hand does this during initialization for each individual partition, not during execution.

There may be a way to refactor this logic to be performed on the coordinator or expand dynamic scans into individual scans similar to planner, but for now let's fall back to planner to prevent a crash. Note that Orca still supports the greenplum_fdw if it is not a partition.

Note: There are no tests here, as the greenplum_fdw isn't open source and there aren't tests in this repo. See https://github.com/greenplum-db/gpdb/pull/14890#issuecomment-1552927513 for additional discussion