### PR TITLE
Resolve two FIXMEs in extractPageInfo()

### DIFF
--- a/src/bin/pg_rewind/parsexlog.c
+++ b/src/bin/pg_rewind/parsexlog.c
@@ -419,19 +419,7 @@ extractPageInfo(XLogReaderState *record)
 			 * and will copy the missing tail from remote system.
 			 */
 		}
-
-		/*
-		 * GPDB_95_MERGE_FIXME: should we just return here? there seems be no buffer
-		 * registered when xlog is inserted.
-		 */
 	}
-	/*
-	 * GPDB_95_MERGE_FIXME:
-	 * 1. should RM_DISTRIBUTEDLOG_ID be taken care of
-	 * 2. we used to have a special treat towards RM_BITMAP_ID, now we hope the
-	 * buffers are registered properly when the xlog is inserted. We need to
-	 * revisit here to make sure RM_BITMAP_ID works.
-	 */
 
 	for (block_id = 0; block_id <= record->max_block_id; block_id++)
 	{


### PR DESCRIPTION
There are three points in the two FIXMEs. Let's review them one by one:

1. Should we return for `RM_APPEND_ONLY_ID`: confirmed that `RM_APPEND_ONLY_ID` doesn't have any registered buffers in all cases. But I don't think we need to return there because the `for` loop will just be a no-op. There are other types of WALs that don't have registered buffers either, and we do not need to treat AO ones specially.

2. Should we take care of `RM_DISTRIBUTEDLOG_ID`: I don't think we need to because it should be treated in the same way as for other SLRU related WALs, which is not keeping anything from the target. There's no buffer registered for it either.

3. Make sure `RM_BITMAP_ID` works after we took the upstream WAL format revamp (commit 2c03216d8311): I think the current code looks fine and we do not need to do anything. Basically, we used to handle bitmap and some other WAL types in extractPageInfo specially because we needed to decode the data portion in the WAL first and get the block number from different corresponding structs. With the revamp we store block number in standardized format and decoding it becomes the same way between different WAL types. Bitmap WALs do not look to be any different. There's also a test in pg_rewind for bitmap.
 
Also one more issue that's not mentioned by the FIXME is that, for bitmap we used to handle a different forknum than the MAIN_FORKNUM which is INIT_FORKNUM in some cases (stored in xlrec->bm_fork). Now we always only handle MAIN_FORKNUM in extractPageInfo() like any other cases. However, this is fine because all forks other than the MAIN_FORKNUM is going to be ignored in process_target_wal_block_change() anyway because there won't be the same source data file to be found (see comments for isRelDataFile()). I think this was also what happened when we tried to call pageinfo_add() for INIT_FORKNUM before the revamp. Now we just explicitly do not do that for non-main forknums.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
