### PR TITLE
Add sanity consistency check on resource queue related shared memory

### DIFF
--- a/src/backend/utils/resscheduler/resqueue.c
+++ b/src/backend/utils/resscheduler/resqueue.c
@@ -1861,6 +1861,8 @@ BuildQueueStatusContext(QueueStatusContext *fctx)
 	 */
 	LWLockAcquire(ResQueueLock, LW_EXCLUSIVE);
 
+	if (!ResQueueHash)
+		elog(PANIC, "corruption of resource queue hash table in shared memory encountered.");
 	/* Initialize for a sequential scan of the resource queue hash. */
 	hash_seq_init(&status, ResQueueHash);
 	num_calls = hash_get_num_entries(ResQueueHash);


### PR DESCRIPTION
I encountered a coredump related with resource queue. The stack is as below. Shared memory variable ResQueueHash is somehow corrupted.
However I am not able to reproduce it, this problem occurs about once a month since March with no regularity. I add code to detect the resource queue related shared memory corruption and let GPDB server panic and shutdown immediately to avoid GPDB working in abnormal condition. Please hava a look at this, Thank you.

(gdb) bt
#0  0x000014f60ec0f4fb in raise () from /lib64/libpthread.so.0
#1  0x0000000000c17a5d in StandardHandlerForSigillSigsegvSigbus_OnMainThread (processName=<optimized out>, postgres_signal_arg=11) at elog.c:5106
#2  <signal handler called>
#3  hash_get_num_entries (hashp=0x0) at dynahash.c:1337
#4  0x0000000000c519cb in BuildQueueStatusContext (fctx=fctx@entry=0x2440e20) at resqueue.c:1866
#5  0x0000000000c539f0 in pg_resqueue_status_kv (fcinfo=0x14f60f055a00) at resqueue.c:2006
#6  0x0000000000930475 in ExecMakeTableFunctionResult (setexpr=0x24a6b00, econtext=0x249a960, argContext=<optimized out>, expectedDesc=0x24a7070, randomAccess=false, operatorMemKB=1048576) at execSRF.c:237
#7  0x0000000000941c3d in FunctionNext_guts (node=0x249a750, node@entry=0x0) at nodeFunctionscan.c:140
#8  FunctionNext (node=node@entry=0x249a750) at nodeFunctionscan.c:319
#9  0x000000000092f8f1 in ExecScanFetch (recheckMtd=0x941780 <FunctionRecheck>, accessMtd=0x941840 <FunctionNext>, node=0x249a750) at execScan.c:98
#10 ExecScan (node=0x249a750, accessMtd=0x941840 <FunctionNext>, recheckMtd=0x941780 <FunctionRecheck>) at execScan.c:167
#11 0x000000000092d84f in ExecProcNodeGPDB (node=0x249a750) at execProcnode.c:629
#12 0x000000000094729f in ExecProcNode (node=0x249a750) at ../../../src/include/executor/executor.h:268
#13 MultiExecPrivateHash (node=0x249a490) at nodeHash.c:181
#14 MultiExecHash (node=node@entry=0x249a490) at nodeHash.c:129
#15 0x000000000092e171 in MultiExecProcNode (node=node@entry=0x249a490) at execProcnode.c:711
#16 0x0000000000949241 in ExecHashJoinImpl (parallel=false, pstate=0x249a1d0) at nodeHashjoin.c:350
#17 ExecHashJoin (pstate=0x249a1d0) at nodeHashjoin.c:694
#18 0x000000000092d84f in ExecProcNodeGPDB (node=0x249a1d0) at execProcnode.c:629
#19 0x00000000009497c3 in ExecProcNode (node=0x249a1d0) at ../../../src/include/executor/executor.h:268
#20 ExecHashJoinOuterGetTuple (hashvalue=0x7ffe28c9e538, hjstate=0x2498e60, outerNode=0x249a1d0) at nodeHashjoin.c:1081
#21 ExecHashJoinImpl (parallel=false, pstate=0x2498e60) at nodeHashjoin.c:456
#22 ExecHashJoin (pstate=0x2498e60) at nodeHashjoin.c:694
#23 0x000000000092d84f in ExecProcNodeGPDB (node=0x2498e60) at execProcnode.c:629
#24 0x00000000009251ca in ExecProcNode (node=0x2498e60) at ../../../src/include/executor/executor.h:268
#25 ExecutePlan (estate=estate@entry=0x2498b30, planstate=0x2498e60, use_parallel_mode=<optimized out>, operation=operation@entry=CMD_SELECT, sendTuples=sendTuples@entry=true, numberTuples=numberTuples@entry=0, 
    direction=ForwardScanDirection, dest=0x22ae980, execute_once=true) at execMain.c:2730
#26 0x0000000000925a91 in ExecutePlan (execute_once=true, dest=0x22ae980, direction=ForwardScanDirection, numberTuples=0, sendTuples=true, operation=CMD_SELECT, use_parallel_mode=<optimized out>, 
    planstate=<optimized out>, estate=0x2498b30) at execMain.c:1010
#27 standard_ExecutorRun (queryDesc=0x2437a18, direction=ForwardScanDirection, count=0, execute_once=<optimized out>) at execMain.c:1010
#28 0x0000000000ae011c in PortalRunSelect (portal=portal@entry=0x23ac980, forward=forward@entry=true, count=0, count@entry=9223372036854775807, dest=dest@entry=0x22ae980) at pquery.c:1109
#29 0x0000000000ae1a50 in PortalRun (portal=portal@entry=0x23ac980, count=count@entry=9223372036854775807, isTopLevel=isTopLevel@entry=true, run_once=<optimized out>, dest=dest@entry=0x22ae980, 
    altdest=altdest@entry=0x22ae980, completionTag=0x7ffe28c9ea40 "") at pquery.c:947
#30 0x0000000000adef30 in exec_execute_message (max_rows=9223372036854775807, portal_name=0x22ae570 "") at postgres.c:2926
#31 PostgresMain (argc=<optimized out>, argv=argv@entry=0x22ec750, dbname=<optimized out>, username=<optimized out>) at postgres.c:5740
#32 0x00000000006dab53 in BackendRun (port=0x22d5a30, port=0x22d5a30) at postmaster.c:4956
#33 BackendStartup (port=0x22d5a30) at postmaster.c:4641
#34 ServerLoop () at postmaster.c:1974
#35 0x0000000000a5b984 in PostmasterMain (argc=argc@entry=5, argv=argv@entry=0x22aa1e0) at postmaster.c:1600
#36 0x00000000006dd5b3 in main (argc=5, argv=0x22aa1e0) at main.c:240
(gdb) f 4
#4  0x0000000000c5223b in BuildQueueStatusContext (fctx=fctx@entry=0x2aec540) at resqueue.c:1866
1866    resqueue.c: No such file or directory.
(gdb) p ResQueueHash
$1 = (HTAB *) 0x0
(gdb) 

SQL: select rsqname,rsqcountlimit,rsqcountvalue,rsqcostlimit,rsqcostvalue,rsqmemorylimit,rsqmemoryvalue,rsqwaiters,rsqholders from gp_toolkit.gp_resqueue_status