### PR TITLE
Remove psutil usage from regress tests

### DIFF
--- a/src/test/regress/expected/motion_socket.out
+++ b/src/test/regress/expected/motion_socket.out
@@ -46,13 +46,13 @@ pids_to_check = [r['pid'] for r in res]
 for pid in pids_to_check:
     # We iterate through all backends related to current session
     motion_socket_count = 0
-    # Typical 'lsof -i -n -a -p <pid>' output:
+    # Typical 'lsof -i -nP -a -p <pid>' output:
     # COMMAND     PID    USER   FD   TYPE  DEVICE SIZE/OFF NODE NAME
     # postgres 271688 cmulong    4u  IPv4 1087560      0t0  TCP 127.0.0.1:51327 (LISTEN)
     # postgres 271688 cmulong    9u  IPv6 1077090      0t0  UDP [::1]:42130->[::1]:42130
     # We check count of those connections which have not been established.
     # Use the regex for example: "TCP <ip>:\d+ .*" (without '->')
-    lsof_ret = subprocess.run(["lsof", "-i", "-n", "-a", "-p", str(pid)],
+    lsof_ret = subprocess.run(["lsof", "-i", "-nP", "-a", "-p", str(pid)],
         capture_output=True, check=True).stdout
     plpy.info(
         f'Checking postgres backend {pid}, ' \
@@ -62,7 +62,7 @@ for pid in pids_to_check:
     for line in r:
         # No '->' follows he port. The connection has not be setup yet
         match=re.match(f".*{expected_socket_kind} {hostip}:\d+ .*", str(line))
-        if match != None:
+        if match is not None:
             motion_socket_count += 1
 
     if motion_socket_count != expected_socket_count_per_segment:

--- a/src/test/regress/expected/motion_socket.out
+++ b/src/test/regress/expected/motion_socket.out
@@ -2,13 +2,15 @@
 -- created for motion connections both on QD and QE backends for the same
 -- gp_session_id. Additionally we check if the source address used for creating
 -- the motion sockets is equal to gp_segment_configuration.address.
--- start_matchsubs
--- m/^INFO:  Checking postgres backend postgres:.*/
--- s/^INFO:  Checking postgres backend postgres:.*/INFO:  Checking postgres backend postgres: XXX/
--- end_matchsubs
+-- start_matchignore
+-- m/^INFO:  Checking postgres backend.*/
+-- m/b.*COMMAND.*NODE.*NAME.*/
+-- m/b.*postgres.*TCP.*/
+-- m/b.*postgres.*UDP.*/
+-- end_matchignore
 CREATE FUNCTION check_motion_sockets()
     RETURNS VOID as $$
-import psutil, socket
+import subprocess, re, os, socket
 
 # Create a temporary table to create a writer gang
 plpy.execute("CREATE TEMP TABLE motion_socket_force_create_gang(i int);")
@@ -26,10 +28,10 @@ res = plpy.execute("SELECT current_setting('gp_interconnect_type');", 1)
 ic_type = res[0]['current_setting']
 if ic_type in ['tcp', 'proxy']:
     expected_socket_count_per_segment = 1
-    expected_socket_kind = socket.SocketKind.SOCK_STREAM
+    expected_socket_kind = "TCP"
 elif ic_type=='udpifc':
     expected_socket_count_per_segment = 2
-    expected_socket_kind = socket.SocketKind.SOCK_DGRAM
+    expected_socket_kind = "UDP"
 else:
     plpy.error('Unrecognized gp_interconnect_type {}.'.format(ic_type))
 
@@ -44,29 +46,34 @@ pids_to_check = [r['pid'] for r in res]
 for pid in pids_to_check:
     # We iterate through all backends related to current session
     motion_socket_count = 0
-    process = psutil.Process(pid)
-    plpy.info('Checking postgres backend {}'.format(process.cmdline()[0]))
-    for conn in process.connections():
-        if conn.type == expected_socket_kind and conn.raddr == () \
-        and conn.laddr.ip == hostip:
+    # Typical 'lsof -i -n -a -p <pid>' output:
+    # COMMAND     PID    USER   FD   TYPE  DEVICE SIZE/OFF NODE NAME
+    # postgres 271688 cmulong    4u  IPv4 1087560      0t0  TCP 127.0.0.1:51327 (LISTEN)
+    # postgres 271688 cmulong    9u  IPv6 1077090      0t0  UDP [::1]:42130->[::1]:42130
+    # We check count of those connections which have not been established.
+    # Use the regex for example: "TCP <ip>:\d+ .*" (without '->')
+    lsof_ret = subprocess.run(["lsof", "-i", "-n", "-a", "-p", str(pid)],
+        capture_output=True, check=True).stdout
+    plpy.info(
+        f'Checking postgres backend {pid}, ' \
+        f'lsof output:\n{os.linesep.join(map(str, lsof_ret.splitlines()))}')
+    # The first row are the column names
+    r = lsof_ret.splitlines()[1:]
+    for line in r:
+        # No '->' follows he port. The connection has not be setup yet
+        match=re.match(f".*{expected_socket_kind} {hostip}:\d+ .*", str(line))
+        if match != None:
             motion_socket_count += 1
 
     if motion_socket_count != expected_socket_count_per_segment:
         plpy.error('Expected {} motion sockets but found {}. '\
-        'For backend process {}. connections= {}'\
-        .format(expected_socket_count_per_segment, process,\
-        motion_socket_count, process.connections()))
+        .format(expected_socket_count_per_segment, motion_socket_count))
 
 
 $$ LANGUAGE plpython3u;
 SELECT check_motion_sockets();
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-INFO:  Checking postgres backend postgres:  7000, vanjared regression 127.0.0.1(59545) con1812 cmd2 SELECT
-INFO:  Checking postgres backend postgres:  7002, vanjared regression 127.0.0.1(59550) con1812 seg0 idle in transaction
-INFO:  Checking postgres backend postgres:  7003, vanjared regression 127.0.0.1(59551) con1812 seg1 idle in transaction
-INFO:  Checking postgres backend postgres:  7004, vanjared regression 127.0.0.1(59552) con1812 seg2 idle in transaction
-INFO:  Checking postgres backend postgres:  7000, vanjared regression 127.0.0.1(59553) con1812 seg-1 idle
  check_motion_sockets 
 ----------------------
  

--- a/src/test/regress/sql/motion_socket.sql
+++ b/src/test/regress/sql/motion_socket.sql
@@ -4,13 +4,15 @@
 -- the motion sockets is equal to gp_segment_configuration.address.
 
 
--- start_matchsubs
--- m/^INFO:  Checking postgres backend postgres:.*/
--- s/^INFO:  Checking postgres backend postgres:.*/INFO:  Checking postgres backend postgres: XXX/
--- end_matchsubs
+-- start_matchignore
+-- m/^INFO:  Checking postgres backend.*/
+-- m/b.*COMMAND.*NODE.*NAME.*/
+-- m/b.*postgres.*TCP.*/
+-- m/b.*postgres.*UDP.*/
+-- end_matchignore
 CREATE FUNCTION check_motion_sockets()
     RETURNS VOID as $$
-import psutil, socket
+import subprocess, re, os, socket
 
 # Create a temporary table to create a writer gang
 plpy.execute("CREATE TEMP TABLE motion_socket_force_create_gang(i int);")
@@ -28,10 +30,10 @@ res = plpy.execute("SELECT current_setting('gp_interconnect_type');", 1)
 ic_type = res[0]['current_setting']
 if ic_type in ['tcp', 'proxy']:
     expected_socket_count_per_segment = 1
-    expected_socket_kind = socket.SocketKind.SOCK_STREAM
+    expected_socket_kind = "TCP"
 elif ic_type=='udpifc':
     expected_socket_count_per_segment = 2
-    expected_socket_kind = socket.SocketKind.SOCK_DGRAM
+    expected_socket_kind = "UDP"
 else:
     plpy.error('Unrecognized gp_interconnect_type {}.'.format(ic_type))
 
@@ -46,18 +48,28 @@ pids_to_check = [r['pid'] for r in res]
 for pid in pids_to_check:
     # We iterate through all backends related to current session
     motion_socket_count = 0
-    process = psutil.Process(pid)
-    plpy.info('Checking postgres backend {}'.format(process.cmdline()[0]))
-    for conn in process.connections():
-        if conn.type == expected_socket_kind and conn.raddr == () \
-        and conn.laddr.ip == hostip:
+    # Typical 'lsof -i -n -a -p <pid>' output:
+    # COMMAND     PID    USER   FD   TYPE  DEVICE SIZE/OFF NODE NAME
+    # postgres 271688 cmulong    4u  IPv4 1087560      0t0  TCP 127.0.0.1:51327 (LISTEN)
+    # postgres 271688 cmulong    9u  IPv6 1077090      0t0  UDP [::1]:42130->[::1]:42130
+    # We check count of those connections which have not been established.
+    # Use the regex for example: "TCP <ip>:\d+ .*" (without '->')
+    lsof_ret = subprocess.run(["lsof", "-i", "-n", "-a", "-p", str(pid)],
+        capture_output=True, check=True).stdout
+    plpy.info(
+        f'Checking postgres backend {pid}, ' \
+        f'lsof output:\n{os.linesep.join(map(str, lsof_ret.splitlines()))}')
+    # The first row are the column names
+    r = lsof_ret.splitlines()[1:]
+    for line in r:
+        # No '->' follows he port. The connection has not be setup yet
+        match=re.match(f".*{expected_socket_kind} {hostip}:\d+ .*", str(line))
+        if match != None:
             motion_socket_count += 1
 
     if motion_socket_count != expected_socket_count_per_segment:
         plpy.error('Expected {} motion sockets but found {}. '\
-        'For backend process {}. connections= {}'\
-        .format(expected_socket_count_per_segment, process,\
-        motion_socket_count, process.connections()))
+        .format(expected_socket_count_per_segment, motion_socket_count))
 
 
 $$ LANGUAGE plpython3u;

--- a/src/test/regress/sql/motion_socket.sql
+++ b/src/test/regress/sql/motion_socket.sql
@@ -48,13 +48,13 @@ pids_to_check = [r['pid'] for r in res]
 for pid in pids_to_check:
     # We iterate through all backends related to current session
     motion_socket_count = 0
-    # Typical 'lsof -i -n -a -p <pid>' output:
+    # Typical 'lsof -i -nP -a -p <pid>' output:
     # COMMAND     PID    USER   FD   TYPE  DEVICE SIZE/OFF NODE NAME
     # postgres 271688 cmulong    4u  IPv4 1087560      0t0  TCP 127.0.0.1:51327 (LISTEN)
     # postgres 271688 cmulong    9u  IPv6 1077090      0t0  UDP [::1]:42130->[::1]:42130
     # We check count of those connections which have not been established.
     # Use the regex for example: "TCP <ip>:\d+ .*" (without '->')
-    lsof_ret = subprocess.run(["lsof", "-i", "-n", "-a", "-p", str(pid)],
+    lsof_ret = subprocess.run(["lsof", "-i", "-nP", "-a", "-p", str(pid)],
         capture_output=True, check=True).stdout
     plpy.info(
         f'Checking postgres backend {pid}, ' \
@@ -64,7 +64,7 @@ for pid in pids_to_check:
     for line in r:
         # No '->' follows he port. The connection has not be setup yet
         match=re.match(f".*{expected_socket_kind} {hostip}:\d+ .*", str(line))
-        if match != None:
+        if match is not None:
             motion_socket_count += 1
 
     if motion_socket_count != expected_socket_count_per_segment:


### PR DESCRIPTION
psutil is not a dependency of plpython, thus we cannot assume it exists
when running regress test. We are going to use different python versions
for management utilities and plpython in the future release, and psutil
won't exist anymore while running regress tests.

- Rewrite teh motion_socket tests with 'lsof', which is a explicit
  dependency of greenplum.

Related with #15703
