### PR TITLE
Remove FIXME about ExecRemoveJunk (7X)

### DIFF
--- a/src/backend/executor/nodeTableFunction.c
+++ b/src/backend/executor/nodeTableFunction.c
@@ -517,12 +517,6 @@ AnyTable_GetNextTuple(AnyTable t)
 	 * 3) copy result into a HeapTuple
 	 * ----------------------------------------
 	 */
-
-	/* GPDB_91_MERGE_FIXME: We used to call  ExecRemoveJunk here, but it
-	 * was removed in the upstream. I copied the implementation of
-	 * ExecRemoveJunk here, but based on the commit message (2e852e541c),
-	 * I don't think we should be doing this either
-	 */
 	slot = ExecFilterJunk(t->junkfilter, t->econtext->ecxt_outertuple);
 	return ExecCopySlotHeapTuple(slot);
 }


### PR DESCRIPTION
Totally agree with the FIXME comment which I wanna remove.
`ExecRemoveJunk(junkfilter, slot)` is equal to `ExecCopySlotTuple(ExecFilterJunk(junkfilter, slot))`.
And ExecRemoveJunk() was removed at [2e852e54](https://github.com/greenplum-db/gpdb/commit/2e852e54), 
so I remove this FIXME directly.

Signed-off-by: Yongtao Huang <yongtaoh@vmware.com>