### PR TITLE
Resolve a FIXME for gpcheckcat

### DIFF
--- a/gpMgmt/bin/gpcheckcat_modules/foreign_key_check.py
+++ b/gpMgmt/bin/gpcheckcat_modules/foreign_key_check.py
@@ -47,17 +47,6 @@ class ForeignKeyCheck:
         if catname in COORDINATOR_ONLY_TABLES:
             return
 
-        # GPDB_12_MERGE_FIXME: Left outer join query generated below
-        # joins pg_rewrite and pg_attribute on ev_class == attrelid.
-        # This reports false positives (presence of null tuples) for
-        # the case when a view is defined with no columns.  The query
-        # should ideally exclude such views by adding
-        # pg_class.relnatts to the join.  But that's not possible
-        # without significantly changing the existing query generation
-        # logic.
-        if catname == 'pg_rewrite':
-            return
-
         # skip shared/non-shared tables
         if self.shared_option:
             if re.match("none", self.shared_option, re.I) and isShared:

--- a/gpMgmt/test/behave/mgmt_utils/gpcheckcat.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpcheckcat.feature
@@ -294,6 +294,7 @@ Feature: gpcheckcat tests
         Given database "fkey_db" is dropped and recreated
         And the path "gpcheckcat.repair.*" is removed from current working directory
         And there is a "heap" table "gpadmin_tbl" in "fkey_db" with data
+        And there is a view without columns in "fkey_db"
         When the entry for the table "gpadmin_tbl" is removed from "pg_catalog.pg_class" with key "oid" in the database "fkey_db"
         Then the user runs "gpcheckcat -E -R missing_extraneous fkey_db"
         And gpcheckcat should print "Name of test which found this issue: missing_extraneous_pg_class" to stdout

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -2265,6 +2265,13 @@ def impl(context, tabletype, tablename, dbname):
 def impl(context, tabletype, table_name, dbname):
     create_partition(context, tablename=table_name, storage_type=tabletype, dbname=dbname, with_data=True)
 
+@given('there is a view without columns in "{dbname}"')
+@then('there is a view without columns in "{dbname}"')
+@when('there is a view without columns in "{dbname}"')
+def impl(context, dbname):
+    with dbconn.connect(dbconn.DbURL(dbname=dbname), unsetSearchPath=False) as conn:
+        dbconn.execSQL(conn, "create view v_no_cols as select;")
+        conn.commit()
 
 @then('read pid from file "{filename}" and kill the process')
 @when('read pid from file "{filename}" and kill the process')


### PR DESCRIPTION
The false positive case the FIXME talks about has been resolved by commit 7d289b5460a (later incorporated in 19cd1cf4b68faff2e29bc2fa884c480e4644cdb4), which removes the foreign key reference between pg_rewrite.ev_class and pg_attribute.attrelid. Therefore, we do not need to ignore pg_rewrite anymore.

In 6X, this issue has been fixed using a different approach in #11732. The PR discussion also mentioned the problem of foreign key reference between pg_rewrite.ev_class and pg_attribute.attrelid. But it was fixed in a different way because it's not easy to change catalog in 6X.

The above PR also added a behave test case for 6X. Adding the same for 7X.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
