### PR TITLE
Add analyze progress reporting for AOCO tables

### DIFF
--- a/src/backend/access/appendonly/appendonlyam_handler.c
+++ b/src/backend/access/appendonly/appendonlyam_handler.c
@@ -1440,6 +1440,9 @@ static int
 appendonly_acquire_sample_rows(Relation onerel, int elevel, HeapTuple *rows,
 							   int targrows, double *totalrows, double *totaldeadrows)
 {
+	FileSegTotals	*fileSegTotals;
+	BlockNumber		totalBlocks;
+	BlockNumber     blksdone = 0;
 	int		numrows = 0;	/* # number of rows sampled */
 	double	liverows = 0;	/* # live rows seen */
 	double	deadrows = 0;	/* # dead rows seen */
@@ -1454,6 +1457,16 @@ appendonly_acquire_sample_rows(Relation onerel, int elevel, HeapTuple *rows,
 	int64 totaldeadtupcount = 0;
 	if (aoscan->aos_total_segfiles > 0 )
 		totaldeadtupcount = AppendOnlyVisimap_GetRelationHiddenTupleCount(&aoscan->visibilityMap);
+
+	/*
+	 * Get the total number of blocks for the table
+	 */
+	fileSegTotals = GetSegFilesTotals(onerel,
+										   aoscan->appendOnlyMetaDataSnapshot);
+	totalBlocks = RelationGuessNumberOfBlocksFromSize(fileSegTotals->totalbytes);
+	pgstat_progress_update_param(PROGRESS_ANALYZE_BLOCKS_TOTAL,
+								 totalBlocks);
+
 	/*
      * The conversion from int64 to double (53 significant bits) is safe as the
 	 * AOTupleId is 48bits, the max value of totalrows is never greater than
@@ -1479,6 +1492,18 @@ appendonly_acquire_sample_rows(Relation onerel, int elevel, HeapTuple *rows,
 		}
 		else
 			deadrows++;
+
+		/*
+		 * Even though we now do row based sampling,
+		 * we can still report in terms of blocks processed using ratio of
+		 * rows scanned / target rows on totalblocks in the table.
+		 * For e.g., if we have 1000 blocks in the table and we are sampling 100 rows,
+		 * and if 10 rows are done, we can say that 100 blocks are done.
+		 */
+		blksdone = (totalBlocks * (double) (liverows + deadrows)) / targrows ;
+		pgstat_progress_update_param(PROGRESS_ANALYZE_BLOCKS_DONE,
+									 blksdone);
+		SIMPLE_FAULT_INJECTOR("analyze_block");
 
 		ExecClearTuple(slot);
 	}

--- a/src/test/isolation2/expected/aoco_analyze_progress.out
+++ b/src/test/isolation2/expected/aoco_analyze_progress.out
@@ -1,0 +1,95 @@
+-- Test gp_stat_progress_analyze_summary
+-- setup hash distributed table
+CREATE TABLE t_analyze_part (a INT, b INT) USING ao_column DISTRIBUTED BY (a);
+CREATE
+INSERT INTO t_analyze_part SELECT i, i FROM generate_series(1, 1000000) i;
+INSERT 1000000
+
+-- Suspend analyze after scanning 1000 rows on each segment
+SELECT gp_inject_fault('analyze_block', 'suspend', '', '', '', 1000, 1000, 0, dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+(3 rows)
+
+-- session 1: analyze the table
+1&: ANALYZE t_analyze_part;  <waiting ...>
+SELECT gp_wait_until_triggered_fault('analyze_block', 1, dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+ Success:                      
+ Success:                      
+(3 rows)
+
+-- session 2: query pg_stat_progress_analyze while the analyze is running, the view should indicate 24 blocks have been scanned as aggregated progress of 3 segments
+2: SELECT pid IS NOT NULL as has_pid, datname, relid::regclass, phase, sample_blks_total, sample_blks_scanned FROM gp_stat_progress_analyze_summary;
+ has_pid | datname        | relid          | phase                 | sample_blks_total | sample_blks_scanned 
+---------+----------------+----------------+-----------------------+-------------------+---------------------
+ t       | isolation2test | t_analyze_part | acquiring sample rows | 246               | 24                  
+(1 row)
+
+-- Reset fault injector
+SELECT gp_inject_fault('analyze_block', 'reset', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+(3 rows)
+1<:  <... completed>
+ANALYZE
+
+-- teardown
+DROP TABLE t_analyze_part;
+DROP
+
+-- setup replicated table
+CREATE TABLE t_analyze_repl (a INT, b INT) USING ao_column DISTRIBUTED REPLICATED;
+CREATE
+INSERT INTO t_analyze_repl SELECT i, i FROM generate_series(1, 1000000) i;
+INSERT 1000000
+
+-- Suspend analyze after scanning 1000 rows on each segment
+SELECT gp_inject_fault('analyze_block', 'suspend', '', '', '', 1000, 1000, 0, dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+(3 rows)
+
+-- session 1: analyze the table
+1&: ANALYZE t_analyze_repl;  <waiting ...>
+SELECT gp_wait_until_triggered_fault('analyze_block', 1, dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+ Success:                      
+ Success:                      
+(3 rows)
+
+-- session 2: query pg_stat_progress_analyze while the analyze is running, the view should indicate 8 blocks have been scanned as average progress of 3 segments
+2: SELECT pid IS NOT NULL as has_pid, datname, relid::regclass, phase, sample_blks_total, sample_blks_scanned FROM gp_stat_progress_analyze_summary;
+ has_pid | datname        | relid          | phase                 | sample_blks_total | sample_blks_scanned 
+---------+----------------+----------------+-----------------------+-------------------+---------------------
+ t       | isolation2test | t_analyze_repl | acquiring sample rows | 245               | 8                   
+(1 row)
+
+-- Reset fault injector
+SELECT gp_inject_fault('analyze_block', 'reset', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+(3 rows)
+1<:  <... completed>
+ANALYZE
+
+-- teardown
+DROP TABLE t_analyze_repl;
+DROP
+

--- a/src/test/isolation2/expected/appendonly_analyze_progress.out
+++ b/src/test/isolation2/expected/appendonly_analyze_progress.out
@@ -1,0 +1,95 @@
+-- Test gp_stat_progress_analyze_summary
+-- setup hash distributed table
+CREATE TABLE t_analyze_part (a INT, b INT) USING ao_row DISTRIBUTED BY (a);
+CREATE
+INSERT INTO t_analyze_part SELECT i, i FROM generate_series(1, 1000000) i;
+INSERT 1000000
+
+-- Suspend analyze after scanning 1000 rows on each segment
+SELECT gp_inject_fault('analyze_block', 'suspend', '', '', '', 1000, 1000, 0, dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+(3 rows)
+
+-- session 1: analyze the table
+1&: ANALYZE t_analyze_part;  <waiting ...>
+SELECT gp_wait_until_triggered_fault('analyze_block', 1, dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+ Success:                      
+ Success:                      
+(3 rows)
+
+-- session 2: query pg_stat_progress_analyze while the analyze is running, the view should indicate 54 blocks have been scanned as aggregated progress of 3 segments
+2: SELECT pid IS NOT NULL as has_pid, datname, relid::regclass, phase, sample_blks_total, sample_blks_scanned FROM gp_stat_progress_analyze_summary;
+ has_pid | datname        | relid          | phase                 | sample_blks_total | sample_blks_scanned 
+---------+----------------+----------------+-----------------------+-------------------+---------------------
+ t       | isolation2test | t_analyze_part | acquiring sample rows | 552               | 54                  
+(1 row)
+
+-- Reset fault injector
+SELECT gp_inject_fault('analyze_block', 'reset', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+(3 rows)
+1<:  <... completed>
+ANALYZE
+
+-- teardown
+DROP TABLE t_analyze_part;
+DROP
+
+-- setup replicated table
+CREATE TABLE t_analyze_repl (a INT, b INT) USING ao_row DISTRIBUTED REPLICATED;
+CREATE
+INSERT INTO t_analyze_repl SELECT i, i FROM generate_series(1, 1000000) i;
+INSERT 1000000
+
+-- Suspend analyze after scanning 1000 rows on each segment
+SELECT gp_inject_fault('analyze_block', 'suspend', '', '', '', 1000, 1000, 0, dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+(3 rows)
+
+-- session 1: analyze the table
+1&: ANALYZE t_analyze_repl;  <waiting ...>
+SELECT gp_wait_until_triggered_fault('analyze_block', 1, dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+ Success:                      
+ Success:                      
+(3 rows)
+
+-- session 2: query pg_stat_progress_analyze while the analyze is running, the view should indicate 18 blocks have been scanned as average progress of 3 segments
+2: SELECT pid IS NOT NULL as has_pid, datname, relid::regclass, phase, sample_blks_total, sample_blks_scanned FROM gp_stat_progress_analyze_summary;
+ has_pid | datname        | relid          | phase                 | sample_blks_total | sample_blks_scanned 
+---------+----------------+----------------+-----------------------+-------------------+---------------------
+ t       | isolation2test | t_analyze_repl | acquiring sample rows | 550               | 18                  
+(1 row)
+
+-- Reset fault injector
+SELECT gp_inject_fault('analyze_block', 'reset', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+ gp_inject_fault 
+-----------------
+ Success:        
+ Success:        
+ Success:        
+(3 rows)
+1<:  <... completed>
+ANALYZE
+
+-- teardown
+DROP TABLE t_analyze_repl;
+DROP
+

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -251,6 +251,8 @@ test: idle_gang_cleaner
 
 test: ao_index_build_progress
 test: analyze_progress
+test: appendonly_analyze_progress
+test: aoco_analyze_progress
 test: copy_progress
 
 test: segwalrep/die_commit_pending_replication

--- a/src/test/isolation2/sql/aoco_analyze_progress.sql
+++ b/src/test/isolation2/sql/aoco_analyze_progress.sql
@@ -1,0 +1,43 @@
+-- Test gp_stat_progress_analyze_summary
+-- setup hash distributed table
+CREATE TABLE t_analyze_part (a INT, b INT) USING ao_column DISTRIBUTED BY (a);
+INSERT INTO t_analyze_part SELECT i, i FROM generate_series(1, 1000000) i;
+
+-- Suspend analyze after scanning 1000 rows on each segment
+SELECT gp_inject_fault('analyze_block', 'suspend', '', '', '', 1000, 1000, 0, dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+
+-- session 1: analyze the table
+1&: ANALYZE t_analyze_part;
+SELECT gp_wait_until_triggered_fault('analyze_block', 1, dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+
+-- session 2: query pg_stat_progress_analyze while the analyze is running, the view should indicate 24 blocks have been scanned as aggregated progress of 3 segments
+2: SELECT pid IS NOT NULL as has_pid, datname, relid::regclass, phase, sample_blks_total, sample_blks_scanned FROM gp_stat_progress_analyze_summary;
+
+-- Reset fault injector
+SELECT gp_inject_fault('analyze_block', 'reset', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+1<:
+
+-- teardown
+DROP TABLE t_analyze_part;
+
+-- setup replicated table
+CREATE TABLE t_analyze_repl (a INT, b INT) USING ao_column DISTRIBUTED REPLICATED;
+INSERT INTO t_analyze_repl SELECT i, i FROM generate_series(1, 1000000) i;
+
+-- Suspend analyze after scanning 1000 rows on each segment
+SELECT gp_inject_fault('analyze_block', 'suspend', '', '', '', 1000, 1000, 0, dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+
+-- session 1: analyze the table
+1&: ANALYZE t_analyze_repl;
+SELECT gp_wait_until_triggered_fault('analyze_block', 1, dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+
+-- session 2: query pg_stat_progress_analyze while the analyze is running, the view should indicate 8 blocks have been scanned as average progress of 3 segments
+2: SELECT pid IS NOT NULL as has_pid, datname, relid::regclass, phase, sample_blks_total, sample_blks_scanned FROM gp_stat_progress_analyze_summary;
+
+-- Reset fault injector
+SELECT gp_inject_fault('analyze_block', 'reset', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+1<:
+
+-- teardown
+DROP TABLE t_analyze_repl;
+

--- a/src/test/isolation2/sql/appendonly_analyze_progress.sql
+++ b/src/test/isolation2/sql/appendonly_analyze_progress.sql
@@ -1,0 +1,43 @@
+-- Test gp_stat_progress_analyze_summary
+-- setup hash distributed table
+CREATE TABLE t_analyze_part (a INT, b INT) USING ao_row DISTRIBUTED BY (a);
+INSERT INTO t_analyze_part SELECT i, i FROM generate_series(1, 1000000) i;
+
+-- Suspend analyze after scanning 1000 rows on each segment
+SELECT gp_inject_fault('analyze_block', 'suspend', '', '', '', 1000, 1000, 0, dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+
+-- session 1: analyze the table
+1&: ANALYZE t_analyze_part;
+SELECT gp_wait_until_triggered_fault('analyze_block', 1, dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+
+-- session 2: query pg_stat_progress_analyze while the analyze is running, the view should indicate 54 blocks have been scanned as aggregated progress of 3 segments
+2: SELECT pid IS NOT NULL as has_pid, datname, relid::regclass, phase, sample_blks_total, sample_blks_scanned FROM gp_stat_progress_analyze_summary;
+
+-- Reset fault injector
+SELECT gp_inject_fault('analyze_block', 'reset', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+1<:
+
+-- teardown
+DROP TABLE t_analyze_part;
+
+-- setup replicated table
+CREATE TABLE t_analyze_repl (a INT, b INT) USING ao_row DISTRIBUTED REPLICATED;
+INSERT INTO t_analyze_repl SELECT i, i FROM generate_series(1, 1000000) i;
+
+-- Suspend analyze after scanning 1000 rows on each segment
+SELECT gp_inject_fault('analyze_block', 'suspend', '', '', '', 1000, 1000, 0, dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+
+-- session 1: analyze the table
+1&: ANALYZE t_analyze_repl;
+SELECT gp_wait_until_triggered_fault('analyze_block', 1, dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+
+-- session 2: query pg_stat_progress_analyze while the analyze is running, the view should indicate 18 blocks have been scanned as average progress of 3 segments
+2: SELECT pid IS NOT NULL as has_pid, datname, relid::regclass, phase, sample_blks_total, sample_blks_scanned FROM gp_stat_progress_analyze_summary;
+
+-- Reset fault injector
+SELECT gp_inject_fault('analyze_block', 'reset', dbid) FROM gp_segment_configuration WHERE content > -1 AND role = 'p';
+1<:
+
+-- teardown
+DROP TABLE t_analyze_repl;
+


### PR DESCRIPTION
Fast Analyze was introduced for AOCO tables in 2939f9ada5d.
This commit adds the progress reporting metrics on top of the analyze logic for reporting progress in gp_stat_progress_analyze_summary

Analyze for AOCO tables happens based on row based sampling unlike block based sampling for heap tables.
We report the progress in terms of blocks processed using ratio of rows scanned/ target rows on totalblocks in the table. For e.g: if we have 1000 blocks in the table & we are sampling 100 rows and if 10 rows are done, we can say that 100 blocks are done.

Added isolation tests in aoco_analyze_progress

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
