### PR TITLE
Fix GPDB_96_MERGE_FIXME: verify walker works on Sequence node (in nodeFuncs.c)

### DIFF
--- a/src/backend/nodes/nodeFuncs.c
+++ b/src/backend/nodes/nodeFuncs.c
@@ -4268,7 +4268,6 @@ planstate_tree_walker(PlanState *planstate,
 									   walker, context))
 				return true;
 			break;
-		/* GPDB_96_MERGE_FIXME: verify walker works on Sequence node */
 		case T_Sequence:
 			if (planstate_walk_members(((SequenceState *) planstate)->subplans,
 									   ((SequenceState *) planstate)->numSubplans,


### PR DESCRIPTION
Fix GPDB_96_MERGE_FIXME: verify walker works on Sequence node (in nodeFuncs.c) #15716

Sequence is GPDB-special node generated by ORCA. It returns tuples from the
last child node only. The walkers passed into `planstate_tree_walker` are:
1. walkers in execParallel.c:
   - no verification required as gp never touch them.
2. ExplainPreScanNode in explain.c:
   - it works. no rels in Sequence so no switch-case entry.
3. ExecShutdownNode in execProcnode.c:
   - it works, no special shutdown ops for Sequence

The above walkers get verified and the fixme is removed.
