### PR TITLE
enable `wal_compression` by default

### DIFF
--- a/configure
+++ b/configure
@@ -9787,19 +9787,19 @@ $as_echo "$with_zstd" >&6; }
 if test "$with_zstd" = yes; then
 
 pkg_failed=no
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for libzstd >= 1.1.1" >&5
-$as_echo_n "checking for libzstd >= 1.1.1... " >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for libzstd >= 1.4.0" >&5
+$as_echo_n "checking for libzstd >= 1.4.0... " >&6; }
 
 if test -n "$ZSTD_CFLAGS"; then
     pkg_cv_ZSTD_CFLAGS="$ZSTD_CFLAGS"
  elif test -n "$PKG_CONFIG"; then
     if test -n "$PKG_CONFIG" && \
-    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"libzstd >= 1.1.1\""; } >&5
-  ($PKG_CONFIG --exists --print-errors "libzstd >= 1.1.1") 2>&5
+    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"libzstd >= 1.4.0\""; } >&5
+  ($PKG_CONFIG --exists --print-errors "libzstd >= 1.4.0") 2>&5
   ac_status=$?
   $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
   test $ac_status = 0; }; then
-  pkg_cv_ZSTD_CFLAGS=`$PKG_CONFIG --cflags "libzstd >= 1.1.1" 2>/dev/null`
+  pkg_cv_ZSTD_CFLAGS=`$PKG_CONFIG --cflags "libzstd >= 1.4.0" 2>/dev/null`
 		      test "x$?" != "x0" && pkg_failed=yes
 else
   pkg_failed=yes
@@ -9811,12 +9811,12 @@ if test -n "$ZSTD_LIBS"; then
     pkg_cv_ZSTD_LIBS="$ZSTD_LIBS"
  elif test -n "$PKG_CONFIG"; then
     if test -n "$PKG_CONFIG" && \
-    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"libzstd >= 1.1.1\""; } >&5
-  ($PKG_CONFIG --exists --print-errors "libzstd >= 1.1.1") 2>&5
+    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"libzstd >= 1.4.0\""; } >&5
+  ($PKG_CONFIG --exists --print-errors "libzstd >= 1.4.0") 2>&5
   ac_status=$?
   $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
   test $ac_status = 0; }; then
-  pkg_cv_ZSTD_LIBS=`$PKG_CONFIG --libs "libzstd >= 1.1.1" 2>/dev/null`
+  pkg_cv_ZSTD_LIBS=`$PKG_CONFIG --libs "libzstd >= 1.4.0" 2>/dev/null`
 		      test "x$?" != "x0" && pkg_failed=yes
 else
   pkg_failed=yes
@@ -9837,14 +9837,14 @@ else
         _pkg_short_errors_supported=no
 fi
         if test $_pkg_short_errors_supported = yes; then
-	        ZSTD_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "libzstd >= 1.1.1" 2>&1`
+	        ZSTD_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "libzstd >= 1.4.0" 2>&1`
         else
-	        ZSTD_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "libzstd >= 1.1.1" 2>&1`
+	        ZSTD_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "libzstd >= 1.4.0" 2>&1`
         fi
 	# Put the nasty error message in config.log where it belongs
 	echo "$ZSTD_PKG_ERRORS" >&5
 
-	as_fn_error $? "Package requirements (libzstd >= 1.1.1) were not met:
+	as_fn_error $? "Package requirements (libzstd >= 1.4.0) were not met:
 
 $ZSTD_PKG_ERRORS
 
@@ -9877,7 +9877,6 @@ $as_echo "yes" >&6; }
 
 fi
 fi
-
 
 #
 # Realtime library

--- a/configure.in
+++ b/configure.in
@@ -1172,7 +1172,7 @@ AC_SUBST(with_zstd)
 
 if test "$with_zstd" = yes; then
   dnl zstd_errors.h was renamed from error_public.h in v1.1.1
-  PKG_CHECK_MODULES([ZSTD], [libzstd >= 1.1.1])
+  PKG_CHECK_MODULES([ZSTD], [libzstd >= 1.4.0])
 fi
 
 #

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -1256,7 +1256,7 @@ static struct config_bool ConfigureNamesBool[] =
 			NULL
 		},
 		&wal_compression,
-		false,
+		true,
 		NULL, NULL, NULL
 	},
 

--- a/src/backend/utils/misc/postgresql.conf.sample
+++ b/src/backend/utils/misc/postgresql.conf.sample
@@ -209,7 +209,7 @@ max_prepared_transactions = 250		# can be 0 or more
 					#   fsync_writethrough
 					#   open_sync
 #full_page_writes = on			# recover from partial page writes
-#wal_compression = off			# enable compression of full-page writes
+#wal_compression = on			# enable compression of full-page writes
 #wal_log_hints = off			# also do full page writes of non-critical updates
 					# (change requires restart)
 #wal_init_zero = on			# zero-fill new WAL files

--- a/src/test/isolation2/expected/segwalrep/select_throttle.out
+++ b/src/test/isolation2/expected/segwalrep/select_throttle.out
@@ -26,8 +26,8 @@ INSERT INTO select_no_throttle SELECT generate_series (1, 10);
 INSERT 10
 CREATE TABLE select_throttle(a int) DISTRIBUTED BY (a);
 CREATE
-INSERT INTO select_throttle SELECT generate_series (1, 100000);
-INSERT 100000
+INSERT INTO select_throttle SELECT generate_series (1, 900000);
+INSERT 900000
 
 -- Enable tuple hints so that buffer will be marked dirty upon a hint bit change
 -- (so that we don't have to wait for the tuple to age. See logic in markDirty)
@@ -82,9 +82,9 @@ SELECT gp_inject_fault_infinite('wal_sender_loop', 'reset', dbid) FROM gp_segmen
 -- after this, system continue to proceed
 
 1U<:  <... completed>
- count 
--------
- 33327 
+ count  
+--------
+ 299393 
 (1 row)
 
 SELECT wait_until_all_segments_synchronized();
@@ -135,8 +135,8 @@ SELECT wait_until_all_segments_synchronized();
 SET
 Truncate select_throttle;
 TRUNCATE
-INSERT INTO select_throttle SELECT generate_series (1, 100000);
-INSERT 100000
+INSERT INTO select_throttle SELECT generate_series (1, 900000);
+INSERT 900000
 -- flush the data to disk
 checkpoint;
 CHECKPOINT
@@ -193,9 +193,9 @@ select content, role, preferred_role, mode, status from gp_segment_configuration
 
 -- after mirror is stopped, the SELECT query should proceed without waiting for syncrep
 1U<:  <... completed>
- count 
--------
- 33327 
+ count  
+--------
+ 299393 
 (1 row)
 
 -- Cleanup

--- a/src/test/isolation2/sql/segwalrep/select_throttle.sql
+++ b/src/test/isolation2/sql/segwalrep/select_throttle.sql
@@ -18,7 +18,7 @@ SELECT pg_reload_conf();
 CREATE TABLE select_no_throttle(a int) DISTRIBUTED BY (a);
 INSERT INTO select_no_throttle SELECT generate_series (1, 10);
 CREATE TABLE select_throttle(a int) DISTRIBUTED BY (a);
-INSERT INTO select_throttle SELECT generate_series (1, 100000);
+INSERT INTO select_throttle SELECT generate_series (1, 900000);
 
 -- Enable tuple hints so that buffer will be marked dirty upon a hint bit change
 -- (so that we don't have to wait for the tuple to age. See logic in markDirty)
@@ -78,7 +78,7 @@ SELECT wait_until_all_segments_synchronized();
 -- (so that we don't have to wait for the tuple to age. See logic in markDirty)
 1U: SET gp_disable_tuple_hints=off;
 Truncate select_throttle;
-INSERT INTO select_throttle SELECT generate_series (1, 100000);
+INSERT INTO select_throttle SELECT generate_series (1, 900000);
 -- flush the data to disk
 checkpoint;
 -- Suspend walsender


### PR DESCRIPTION
Based on recent findinds, `wal_compression` may give huge
benefits when workloads generates large amounts of FPIs (Full Page
Images). With `wal_compression`, the WAL generated can be reduced by
20-30% and even higher when loading high volumes of data causes
checkpoints to occur too frequently; checkpoints occuring too frequently
causes more FPIs to be written to WAL.

When the amount of WAL generated is reduced, this will inherently reduce
the amount of data being transferred via interconnect to the mirrors.
Furthermore, there will be a reduction in disk I/O as less data are generated.

In a multi-node with mirrored environment, the overall duration of load will be
reduced by 6-15%. `wal_compression` does not directly effect AO/CO,
however, as part of AO/CO is comprised of auxiliary heap tables, there
is a small gain in performance. This can be seen with a 1TB TPC-DS AO/CO
load duration speed-up of 4%.

Note that `full_page_writes` must be on to see any benefits mentioned
above.

ZSTD allocates its own memory. Although this is usually a concern, it is
not in our case since a single backend is only compressing a 32K page at
a given time.
We may have multiple backends in a single host, but this will not
significally increase memory usage.

For further details of the discussion, see gpdb-dev mailing list:
https://groups.google.com/a/greenplum.org/g/gpdb-dev/c/0PyQvNB2aNI

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
