### PR TITLE
Remove FIXME about function _equalColumnDef() (7X)

### DIFF
--- a/src/backend/nodes/equalfuncs.c
+++ b/src/backend/nodes/equalfuncs.c
@@ -2810,7 +2810,8 @@ _equalColumnDef(const ColumnDef *a, const ColumnDef *b)
 	COMPARE_NODE_FIELD(collClause);
 	COMPARE_SCALAR_FIELD(collOid);
 	COMPARE_NODE_FIELD(constraints);
-	/* GPDB_90_MERGE_FIXME: should we be comparing encoding? */
+	/* only AO/AOCS table has the encoding parameter `encoding` */
+	COMPARE_NODE_FIELD(encoding);
 	COMPARE_NODE_FIELD(fdwoptions);
 	COMPARE_LOCATION_FIELD(location);
 


### PR DESCRIPTION

I added this [elog](https://github.com/greenplum-db/gpdb/compare/main...hyongtao-db:gpdb:testColumnDef#diff-8c7c1ccaed5bbdd556ac5bb797a7de159eccf467dab3cc3fc08bf5cb23092400R2796) and trigger pipeline. 
The test results show that no case will trigger this function `_equalColumnDef()`. 
In other words, it's ok to delete function `_equalColumnDef()` directly. 
However, to be consistent with PG12.12, we should keep it.

PG12.12 does not have AO table, so it does not need to compare `encoding` when comparing ColumnDef.
But for GPDB, I prefer to add `COMPARE_NODE_FIELD(encoding);` under _equalColumnDef().
`encoding` is an important parameter about compression in AO table's column, shown as below:
``` SQL
gpadmin=# CREATE TABLE foo(i int, j int) USING ao_column;
CREATE TABLE
gpadmin=# ALTER TABLE foo ALTER COLUMN i SET ENCODING (compresslevel=7, compresstype=zstd);
ALTER TABLE
gpadmin=# \d+ foo
                                                              Table "public.foo"
 Column |  Type   | Collation | Nullable | Default | Storage | Stats target | Compression Type |Compression Level | Block Size | Description
--------+---------+-----------+----------+---------+---------+--------------+------------------+-------------------+------------+-------------
 i      | integer |           |          |         | plain   |              | zstd             |7                 | 32768      |
 j      | integer |           |          |         | plain   |              | none             |0                 | 32768      |
Distributed by: (i)
Access method: ao_column
Options: blocksize=32768, compresslevel=0, compresstype=none, checksum=true
```
Same as `COMPARE_NODE_FIELD(constraints);` and `COMPARE_NODE_FIELD(fdwoptions);`, 
adding validation `COMPARE_NODE_FIELD(encoding);` would be more rigorous, especially for AO tables.

Signed-off-by: Yongtao Huang <yongtaoh@vmware.com>