### PR TITLE
Resolve two FIXMEs in gram.y and postgresql.conf.sample

### DIFF
--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -917,14 +917,16 @@ static void check_expressions_in_partition_key(PartitionSpec *spec, core_yyscan_
 			%nonassoc AGGREGATE
 			%nonassoc ALSO
 			%nonassoc ALTER
-            %nonassoc AO_AUX_ONLY
+			%nonassoc AO_AUX_ONLY
 			%nonassoc ASSERTION
 			%nonassoc ASSIGNMENT
+			%nonassoc ATTACH
 			%nonassoc BACKWARD
 			%nonassoc BEFORE
 			%nonassoc BEGIN_P
 			%nonassoc BY
 			%nonassoc CACHE
+			%nonassoc CALL
 			%nonassoc CALLED
 			%nonassoc CASCADE
 			%nonassoc CASCADED
@@ -934,6 +936,7 @@ static void check_expressions_in_partition_key(PartitionSpec *spec, core_yyscan_
 			%nonassoc CLASS
 			%nonassoc CLOSE
 			%nonassoc CLUSTER
+			%nonassoc COLUMNS
 			%nonassoc COMMENT
 			%nonassoc COMMIT
 			%nonassoc COMMITTED
@@ -945,6 +948,7 @@ static void check_expressions_in_partition_key(PartitionSpec *spec, core_yyscan_
 			%nonassoc CONTENT_P
 			%nonassoc CONTINUE_P
 			%nonassoc CONVERSION_P
+			%nonassoc COORDINATOR
 			%nonassoc COPY
 			%nonassoc COST
 			%nonassoc CPUSET
@@ -966,6 +970,8 @@ static void check_expressions_in_partition_key(PartitionSpec *spec, core_yyscan_
 			%nonassoc DELETE_P
 			%nonassoc DELIMITER
 			%nonassoc DELIMITERS
+			%nonassoc DEPENDS
+			%nonassoc DETACH
 			%nonassoc DISABLE_P
 			%nonassoc DOMAIN_P
 			%nonassoc DOUBLE_P
@@ -995,6 +1001,7 @@ static void check_expressions_in_partition_key(PartitionSpec *spec, core_yyscan_
 			%nonassoc FUNCTION
 			%nonassoc GLOBAL
 			%nonassoc GRANTED
+			%nonassoc GROUPING
 			%nonassoc HANDLER
 			%nonassoc HASH
 			%nonassoc HEADER_P
@@ -1005,6 +1012,8 @@ static void check_expressions_in_partition_key(PartitionSpec *spec, core_yyscan_
 			%nonassoc IMMEDIATE
 			%nonassoc IMMUTABLE
 			%nonassoc IMPLICIT_P
+			%nonassoc IMPORT_P
+			%nonassoc INCLUDE
 			%nonassoc INCLUDING
 			%nonassoc INCLUSIVE
 			%nonassoc INCREMENT
@@ -1028,11 +1037,14 @@ static void check_expressions_in_partition_key(PartitionSpec *spec, core_yyscan_
 			%nonassoc LOAD
 			%nonassoc LOCAL
 			%nonassoc LOCATION
+			%nonassoc LOCKED
 			%nonassoc LOCK_P
+			%nonassoc LOGGED
 			%nonassoc MASTER
 			%nonassoc MATCH
 			%nonassoc MAXVALUE
 			%nonassoc MEMORY_LIMIT
+			%nonassoc METHOD
 			%nonassoc MIN_COST
 			%nonassoc MINUTE_P
 			%nonassoc MINVALUE
@@ -1043,6 +1055,7 @@ static void check_expressions_in_partition_key(PartitionSpec *spec, core_yyscan_
 			%nonassoc MOVE
 			%nonassoc NAME_P
 			%nonassoc NAMES
+			%nonassoc NEW
 			%nonassoc NEWLINE
 			%nonassoc NEXT
 			%nonassoc NO
@@ -1055,11 +1068,13 @@ static void check_expressions_in_partition_key(PartitionSpec *spec, core_yyscan_
 			%nonassoc OBJECT_P
 			%nonassoc OF
 			%nonassoc OIDS
+			%nonassoc OLD
 			%nonassoc OPTION
 			%nonassoc OPTIONS
 			%nonassoc OTHERS
 			%nonassoc OVER
 			%nonassoc OVERCOMMIT
+			%nonassoc OVERRIDING
 			%nonassoc OWNED
 			%nonassoc OWNER
 			%nonassoc PARALLEL
@@ -1068,13 +1083,16 @@ static void check_expressions_in_partition_key(PartitionSpec *spec, core_yyscan_
 			%nonassoc PASSWORD
 			%nonassoc PERCENT
 			%nonassoc PERSISTENTLY
+			%nonassoc POLICY
 			%nonassoc PREPARE
 			%nonassoc PREPARED
 			%nonassoc PRIOR
 			%nonassoc PRIVILEGES
 			%nonassoc PROCEDURAL
 			%nonassoc PROCEDURE
+			%nonassoc PROCEDURES
 			%nonassoc PROTOCOL
+			%nonassoc PUBLICATION
 			%nonassoc QUEUE
 			%nonassoc QUOTE
 			%nonassoc RANDOMLY
@@ -1084,6 +1102,7 @@ static void check_expressions_in_partition_key(PartitionSpec *spec, core_yyscan_
 			%nonassoc REASSIGN
 			%nonassoc RECHECK
 			%nonassoc RECURSIVE
+			%nonassoc REFERENCING
 			%nonassoc REINDEX
 			%nonassoc REJECT_P
 			%nonassoc RELATIVE_P
@@ -1100,9 +1119,12 @@ static void check_expressions_in_partition_key(PartitionSpec *spec, core_yyscan_
 			%nonassoc REVOKE
 			%nonassoc ROLE
 			%nonassoc ROLLBACK
+			%nonassoc ROUTINE
+			%nonassoc ROUTINES
 			%nonassoc RULE
 			%nonassoc SAVEPOINT
 			%nonassoc SCHEMA
+			%nonassoc SCHEMAS
 			%nonassoc SCROLL
 			%nonassoc SEARCH
 			%nonassoc SECOND_P
@@ -1115,6 +1137,7 @@ static void check_expressions_in_partition_key(PartitionSpec *spec, core_yyscan_
 			%nonassoc SHARE
 			%nonassoc SHOW
 			%nonassoc SIMPLE
+			%nonassoc SQL_P
 			%nonassoc SPLIT
 			%nonassoc STABLE
 			%nonassoc START
@@ -1123,10 +1146,13 @@ static void check_expressions_in_partition_key(PartitionSpec *spec, core_yyscan_
 			%nonassoc STDIN
 			%nonassoc STDOUT
 			%nonassoc STORAGE
+			%nonassoc STORED
 			%nonassoc SUBPARTITION
+			%nonassoc SUPPORT
 			%nonassoc SYSID
 			%nonassoc SYSTEM_P
 			%nonassoc STRICT_P
+			%nonassoc TABLESAMPLE
 			%nonassoc TABLESPACE
 			%nonassoc TEMP
 			%nonassoc TEMPLATE
@@ -1134,6 +1160,7 @@ static void check_expressions_in_partition_key(PartitionSpec *spec, core_yyscan_
 			%nonassoc THRESHOLD
 			%nonassoc TIES
 			%nonassoc TRANSACTION
+			%nonassoc TRANSFORM
 			%nonassoc TRIGGER
 			%nonassoc TRUNCATE
 			%nonassoc TRUSTED
@@ -18167,7 +18194,7 @@ unreserved_keyword:
 			| LOCATION
 			| LOCK_P
 			| LOCKED
-            | LOG_P
+			| LOG_P
 			| LOGGED
 			| MAPPING
 			| MASTER
@@ -18394,13 +18421,16 @@ PartitionIdentKeyword: ABORT_P
 			| AFTER
 			| AGGREGATE
 			| ALSO
+			| AO_AUX_ONLY
 			| ASSERTION
 			| ASSIGNMENT
+			| ATTACH
 			| BACKWARD
 			| BEFORE
 			| BEGIN_P
 			| BY
 			| CACHE
+			| CALL
 			| CALLED
 			| CASCADE
 			| CASCADED
@@ -18410,6 +18440,7 @@ PartitionIdentKeyword: ABORT_P
 			| CLASS
 			| CLOSE
 			| CLUSTER
+			| COLUMNS
 			| COMMENT
 			| COMMIT
 			| COMMITTED
@@ -18419,6 +18450,7 @@ PartitionIdentKeyword: ABORT_P
 			| CONTAINS
 			| CONTENT_P
 			| CONVERSION_P
+			| COORDINATOR
 			| COPY
 			| COST
 			| CPUSET
@@ -18438,6 +18470,8 @@ PartitionIdentKeyword: ABORT_P
 			| DELETE_P
 			| DELIMITER
 			| DELIMITERS
+			| DEPENDS
+			| DETACH
 			| DISABLE_P
 			| DOMAIN_P
 			| DOUBLE_P
@@ -18464,8 +18498,11 @@ PartitionIdentKeyword: ABORT_P
 			| FORMAT
 			| FORWARD
 			| FUNCTION
+			| GENERATED
 			| GLOBAL
 			| GRANTED
+			| GROUPING
+			| GROUPS
 			| HANDLER
 			| HASH
 			| HEADER_P
@@ -18475,6 +18512,8 @@ PartitionIdentKeyword: ABORT_P
 			| IMMEDIATE
 			| IMMUTABLE
 			| IMPLICIT_P
+			| IMPORT_P
+			| INCLUDE
 			| INCLUDING
 			| INCLUSIVE
 			| INCREMENT
@@ -18498,11 +18537,14 @@ PartitionIdentKeyword: ABORT_P
 			| LOAD
 			| LOCAL
 			| LOCATION
+			| LOCKED
 			| LOCK_P
+			| LOGGED
 			| MASTER
 			| MATCH
 			| MAXVALUE
 			| MEMORY_LIMIT
+			| METHOD
 			| MINVALUE
 			| MISSING
 			| MODE
@@ -18510,6 +18552,7 @@ PartitionIdentKeyword: ABORT_P
 			| MOVE
 			| NAME_P
 			| NAMES
+			| NEW
 			| NEWLINE
 			| NEXT
 			| NO
@@ -18521,11 +18564,13 @@ PartitionIdentKeyword: ABORT_P
 			| OBJECT_P
 			| OF
 			| OIDS
+			| OLD
 			| OPERATOR
 			| OPTION
 			| OPTIONS
 			| OTHERS
 			| OVERCOMMIT
+			| OVERRIDING
 			| OWNED
 			| OWNER
 			| PARALLEL
@@ -18534,6 +18579,7 @@ PartitionIdentKeyword: ABORT_P
 			| PASSWORD
 			| PERCENT
 			| PERSISTENTLY
+			| POLICY
 			| PREPARE
 			| PREPARED
 			| PRESERVE
@@ -18541,13 +18587,16 @@ PartitionIdentKeyword: ABORT_P
 			| PRIVILEGES
 			| PROCEDURAL
 			| PROCEDURE
+			| PROCEDURES
 			| PROTOCOL
+			| PUBLICATION
 			| QUEUE
 			| QUOTE
 			| RANGE
 			| READ
 			| REASSIGN
 			| RECHECK
+			| REFERENCING
 			| REINDEX
 			| RELATIVE_P
 			| RELEASE
@@ -18558,15 +18607,19 @@ PartitionIdentKeyword: ABORT_P
 			| RESOURCE
 			| RESTART
 			| RESTRICT
+			| RETRIEVE
 			| RETURNS
 			| REVOKE
 			| ROLE
 			| ROLLBACK
 			| ROLLUP
+			| ROUTINE
+			| ROUTINES
 			| ROWS
 			| RULE
 			| SAVEPOINT
 			| SCHEMA
+			| SCHEMAS
 			| SCROLL
 			| SEARCH
 			| SECURITY
@@ -18580,6 +18633,7 @@ PartitionIdentKeyword: ABORT_P
 			| SHOW
 			| SIMPLE
 			| SPLIT
+			| SQL_P
 			| STABLE
 			| START
 			| STATEMENT
@@ -18587,16 +18641,20 @@ PartitionIdentKeyword: ABORT_P
 			| STDIN
 			| STDOUT
 			| STORAGE
+			| STORED
 			| STRICT_P
 			| SUBPARTITION
+			| SUPPORT
 			| SYSID
 			| SYSTEM_P
+			| TABLESAMPLE
 			| TEMP
 			| TEMPLATE
 			| TEMPORARY
 			| THRESHOLD
 			| TIES
 			| TRANSACTION
+			| TRANSFORM
 			| TRIGGER
 			| TRUNCATE
 			| TRUSTED

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -3378,6 +3378,7 @@ static struct config_real ConfigureNamesReal[] =
 		DEFAULT_CPU_OPERATOR_COST, 0, DBL_MAX,
 		NULL, NULL, NULL
 	},
+	/* GPDB_96_MERGE_FIXME: figure out the appropriate default values for the two parallel gucs below. */
 	{
 		{"parallel_tuple_cost", PGC_USERSET, QUERY_TUNING_COST,
 			gettext_noop("Sets the planner's estimate of the cost of "

--- a/src/backend/utils/misc/postgresql.conf.sample
+++ b/src/backend/utils/misc/postgresql.conf.sample
@@ -385,7 +385,6 @@ max_prepared_transactions = 250		# can be 0 or more
 #cpu_tuple_cost = 0.01			# same scale as above
 #cpu_index_tuple_cost = 0.005		# same scale as above
 #cpu_operator_cost = 0.0025		# same scale as above
-# GPDB_96_MERGE_FIXME: figure out the appropriate values for the parallel gucs
 #parallel_tuple_cost = 0.1		# same scale as above
 #parallel_setup_cost = 1000.0	# same scale as above
 

--- a/src/test/regress/expected/as_alias.out
+++ b/src/test/regress/expected/as_alias.out
@@ -749,3 +749,11 @@ SELECT * FROM colalias_dml_decimal ORDER BY 1,2,3,4;
  1.00 | 2.00 | a    | 1.00 | 1.00
 (1 row)
 
+-- GPDB: allow keywords defined in PartitionIdentKeyword (see gram.y) to be created as column alias without the 'AS'
+-- XXX: this will not be a GPDB-only feature when we catch up with PG14
+create table colalias_noas(a int, b int);
+select a new, b old from colalias_noas;
+ new | old 
+-----+-----
+(0 rows)
+

--- a/src/test/regress/sql/as_alias.sql
+++ b/src/test/regress/sql/as_alias.sql
@@ -241,3 +241,8 @@ SELECT * FROM colalias_dml_decimal ORDER BY 1,2,3,4;
 
 UPDATE colalias_dml_decimal SET col1 =colalias_dml_decimal_candidate.col2 FROM colalias_dml_decimal_candidate;
 SELECT * FROM colalias_dml_decimal ORDER BY 1,2,3,4;
+
+-- GPDB: allow keywords defined in PartitionIdentKeyword (see gram.y) to be created as column alias without the 'AS'
+-- XXX: this will not be a GPDB-only feature when we catch up with PG14
+create table colalias_noas(a int, b int);
+select a new, b old from colalias_noas;


### PR DESCRIPTION
1. Add missing keywords to PartitionIdentKeyword

As the FIXME suggests, many keywords added during the PG12 merge are not
added to `PartitionIdentKeyword`. Add them now, so that we could use them
as column alias without a preceding `AS`, or as partition name. E.g.:

```sql
create table t1(a int, b int);
select a new, b old from t1;

create table part(a int, b int) partition by range(b) 
(partition old start (0) end(1), partition new start(1) end(2));
```

What's not covered in this PR: keywords that are in both 6X and 7X. Essentially, 
I didn't go over all of the keywords that are not in `PartitionIdentKeyword`.

P.S. it is actually a GPDB-specific feature that we allow keywords to be
used for column alias without `AS` (commit https://github.com/greenplum-db/gpdb/commit/a64af2d78ebcacc72c891835b2a2df5845113f60). In upstream only
starting from PG14 this has been supported (commit https://github.com/greenplum-db/gpdb/commit/06a7c3154f5bfad65549810cc84f0e3a77b408bf). We would
be adapting to that method when we catch up with PG14.

2. Move a FIXME from postgresql.conf.sample to guc.c

The sample configuration file gets copied over to the installation
directory which is visible to users. So it is unnecessary to show a
FIXME message there. Move it to guc.c instead.

We will be tracking the actual fix of the FIXME separately.

Dev pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/gram-fixme

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
