### PR TITLE
Add session clean up timeout parameter for gpfdist with '-k' option.(7X)

### DIFF
--- a/gpMgmt/doc/gpfdist_help
+++ b/gpMgmt/doc/gpfdist_help
@@ -119,8 +119,15 @@ OPTIONS
  For a Greenplum Database with multiple segments, there might be a delay 
  between segments when writing data from different segments to the file. 
  You can specify a time to wait before Greenplum Database closes the file 
- to ensure all the data is written to the file. 
+ to ensure all the data is written to the file.
 
+-k <time>
+
+ Sets the number of seconds the gpfdist will delay before clean up the
+ session when there are no requests handling even before all of the segment
+ requests have sent final POST requests for writable sessions. This is
+ used to clean up garbage sessions if segment process left before
+ sending the final POST message.
 
 --ssl <certificate_path> 
 

--- a/gpMgmt/doc/gpfdist_help
+++ b/gpMgmt/doc/gpfdist_help
@@ -9,7 +9,7 @@ SYNOPSIS
 
 gpfdist [-d <directory>] [-p <http_port>] [-l <log_file>] [-t <timeout>] 
 [-S] [-w <time>] [-v | -V] [-m <max_length>] [--ssl <certificate_path>]
-[--compress] [--multi_thread <number_of_threads>]
+[--compress] [--multi_thread <number_of_threads>] [-k <seconds>]
 
 gpfdist [-? | --help] | --version
 

--- a/src/bin/gpfdist/regress/input/exttab1.source
+++ b/src/bin/gpfdist/regress/input/exttab1.source
@@ -37,7 +37,7 @@ on SEGMENT 0
 FORMAT 'text' (delimiter '|');
 
 CREATE EXTERNAL WEB TABLE exttab1_gpfdist_start (x text)
-execute E'((@bindir@/gpfdist -p 7070 -d @abs_srcdir@/data  </dev/null >/dev/null 2>&1 &); for i in `seq 1 30`; do curl 127.0.0.1:7070 >/dev/null 2>&1 && break; sleep 1; done; echo "starting...") '
+execute E'((@bindir@/gpfdist -p 7070 -k 360 -d @abs_srcdir@/data  </dev/null >/dev/null 2>&1 &); for i in `seq 1 30`; do curl 127.0.0.1:7070 >/dev/null 2>&1 && break; sleep 1; done; echo "starting...") '
 on SEGMENT 0
 FORMAT 'text' (delimiter '|');
 

--- a/src/bin/gpfdist/regress/output/exttab1.source
+++ b/src/bin/gpfdist/regress/output/exttab1.source
@@ -14,7 +14,7 @@ execute E'( python @bindir@/lib/gppinggpfdist.py @hostname@:7070 2>&1 || echo) '
 on SEGMENT 0
 FORMAT 'text' (delimiter '|');
 CREATE EXTERNAL WEB TABLE exttab1_gpfdist_start (x text)
-execute E'((@bindir@/gpfdist -p 7070 -d @abs_srcdir@/data  </dev/null >/dev/null 2>&1 &); for i in `seq 1 30`; do curl 127.0.0.1:7070 >/dev/null 2>&1 && break; sleep 1; done; echo "starting...") '
+execute E'((@bindir@/gpfdist -p 7070 -k 360 -d @abs_srcdir@/data  </dev/null >/dev/null 2>&1 &); for i in `seq 1 30`; do curl 127.0.0.1:7070 >/dev/null 2>&1 && break; sleep 1; done; echo "starting...") '
 on SEGMENT 0
 FORMAT 'text' (delimiter '|');
 CREATE EXTERNAL WEB TABLE exttab1_gpfdist_stop (x text)


### PR DESCRIPTION
The default value for session clean up timeout is 300s, but in heavy workload, this default value is not long enough to wait for segment next POST request to arrive. Then it will cause "400 invalid request due to wrong sequence number" failure.

So this commit add one option '-k' to set this value for gpfdist. The default is 300, the valid range would be (300..86400).

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
