### PR TITLE
Add session clean up timeout parameter for gpfdist with '-k' option.(6X_STABLE)

### DIFF
--- a/gpMgmt/doc/gpfdist_help
+++ b/gpMgmt/doc/gpfdist_help
@@ -118,8 +118,15 @@ OPTIONS
  For a Greenplum Database with multiple segments, there might be a delay 
  between segments when writing data from different segments to the file. 
  You can specify a time to wait before Greenplum Database closes the file 
- to ensure all the data is written to the file. 
+ to ensure all the data is written to the file.
 
+-k <time>
+
+ Sets the number of seconds the gpfdist will delay before clean up the
+ session when there are no requests handling even before all of the segment
+ requests have sent final POST requests for writable sessions. This is
+ used to clean up garbage sessions if segment process left before
+ sending the final POST message.
 
 --ssl <certificate_path> 
 

--- a/gpMgmt/doc/gpfdist_help
+++ b/gpMgmt/doc/gpfdist_help
@@ -9,6 +9,7 @@ SYNOPSIS
 
 gpfdist [-d <directory>] [-p <http_port>] [-l <log_file>] [-t <timeout>] 
 [-S] [-w <time>] [-v | -V] [-m <max_length>] [--ssl <certificate_path>]
+[-k <seconds>]
 
 gpfdist [-? | --help] | --version
 

--- a/src/bin/gpfdist/gpfdist.c
+++ b/src/bin/gpfdist/gpfdist.c
@@ -150,6 +150,8 @@ static void percent_encoding_to_char(char* p, char* pp, char* path);
 #define GPFDIST_MAX_LINE_MESSAGE     "Error: -m max row length must be between 32KB and 1MB"
 #endif
 
+#define SESSION_DEFAULT_KEEP_ALIVE 300
+#define SESSION_MAX_KEEP_ALIVE 86400
 
 /*	Struct of command line options */
 static struct
@@ -171,8 +173,9 @@ static struct
 	const char* c; /* config file */
 	struct transform* trlist; /* transforms from config file */
 	const char* ssl; /* path to certificates in case we use gpfdist with ssl */
-	int			w; /* The time used for session timeout in seconds */
-} opt = { 8080, 8080, 0, 0, 0, ".", 0, 0, -1, 5, 0, 32768, 0, 256, 0, 0, 0, 0 };
+	int			w; /* The time waiting when used for session timeout in seconds */
+	int 		k; /* The time used to clean up sessions in seconds */
+} opt = { 8080, 8080, 0, 0, 0, ".", 0, 0, -1, 5, 0, 32768, 0, 256, 0, 0, 0, 0 , 300};
 
 
 typedef union address
@@ -501,7 +504,7 @@ static void usage_error(const char* msg, int print_usage)
 		{
 			fprintf(stderr,
 					"gpfdist -- file distribution web server\n\n"
-						"usage: gpfdist [--ssl <certificates_directory>] [-d <directory>] [-p <http(s)_port>] [-l <log_file>] [-t <timeout>] [-v | -V | -s] [-m <maxlen>] [-w <timeout>]"
+						"usage: gpfdist [--ssl <certificates_directory>] [-d <directory>] [-p <http(s)_port>] [-l <log_file>] [-t <timeout>] [-v | -V | -s] [-m <maxlen>] [-w <timeout>] [-k <seconds>]"
 #ifdef GPFXDIST
 					    "[-c file]"
 #endif
@@ -527,7 +530,8 @@ static void usage_error(const char* msg, int print_usage)
 					    "        -c file    : configuration file for transformations\n"
 #endif
 						"        --version  : print version information\n"
-						"        -w timeout : timeout in seconds before close target file\n\n");
+						"        -w timeout : timeout in seconds before close target file\n"
+						"        -k seconds : timeout to clean up sessions in seconds\n\n");
 		}
 	}
 
@@ -590,6 +594,7 @@ static void parse_command_line(int argc, const char* const argv[],
 #endif
 	{ "version", 256, 0, "print version number" },
 	{ NULL, 'w', 1, "wait for session timeout in seconds" },
+	{ NULL, 'k', 1, "timeout to clean up sessions in seconds" },
 	{ 0 } };
 
 	status = apr_getopt_init(&os, pool, argc, argv);
@@ -674,6 +679,9 @@ static void parse_command_line(int argc, const char* const argv[],
 		case 'w':
 			opt.w = atoi(arg);
 			break;
+		case 'k':
+			opt.k = atoi(arg);
+			break;
 		}
 	}
 
@@ -696,10 +704,14 @@ static void parse_command_line(int argc, const char* const argv[],
 		usage_error("Error: -w timeout must be between 1 and 7200, or 0 for no timeout", 0);
 
 	/* validate max row length */
-    if (! ((GPFDIST_MAX_LINE_LOWER_LIMIT <= opt.m) && (opt.m <= GPFDIST_MAX_LINE_UPPER_LIMIT)))
-    	usage_error(GPFDIST_MAX_LINE_MESSAGE, 0);
+	if (! ((GPFDIST_MAX_LINE_LOWER_LIMIT <= opt.m) && (opt.m <= GPFDIST_MAX_LINE_UPPER_LIMIT)))
+		usage_error(GPFDIST_MAX_LINE_MESSAGE, 0);
 
-    if (!is_valid_listen_queue_size(opt.z))
+	/* validate session clean up timeout */
+	if ((SESSION_DEFAULT_KEEP_ALIVE > opt.k) || (opt.k > SESSION_MAX_KEEP_ALIVE))
+		usage_error("Error: -k session clean up timeout must be between 300 and 86400 (default is 300)", 0);
+
+	if (!is_valid_listen_queue_size(opt.z))
 		usage_error("Error: -z listen queue size must be between 16 and 512 (default is 256)", 0);
 
     /* get current directory, for ssl directory validation */
@@ -1476,7 +1488,7 @@ static void sessions_cleanup(void)
 		apr_hash_this(hi, 0, 0, &entry);
 		s = (session_t*) entry;
 
-		if (s->nrequest == 0 && (s->mtime < apr_time_now() - 300
+		if (s->nrequest == 0 && (s->mtime < apr_time_now() - opt.k
 				* APR_USEC_PER_SEC))
 		{
 			session[n++] = s;

--- a/src/bin/gpfdist/regress/input/exttab1.source
+++ b/src/bin/gpfdist/regress/input/exttab1.source
@@ -37,7 +37,7 @@ on SEGMENT 0
 FORMAT 'text' (delimiter '|');
 
 CREATE EXTERNAL WEB TABLE exttab1_gpfdist_start (x text)
-execute E'((@bindir@/gpfdist -p 7070 -d @abs_srcdir@/data  </dev/null >/dev/null 2>&1 &); for i in `seq 1 30`; do curl 127.0.0.1:7070 >/dev/null 2>&1 && break; sleep 1; done; echo "starting...") '
+execute E'((@bindir@/gpfdist -p 7070 -k 360 -d @abs_srcdir@/data  </dev/null >/dev/null 2>&1 &); for i in `seq 1 30`; do curl 127.0.0.1:7070 >/dev/null 2>&1 && break; sleep 1; done; echo "starting...") '
 on SEGMENT 0
 FORMAT 'text' (delimiter '|');
 

--- a/src/bin/gpfdist/regress/output/exttab1.source
+++ b/src/bin/gpfdist/regress/output/exttab1.source
@@ -14,7 +14,7 @@ execute E'( python @bindir@/lib/gppinggpfdist.py @hostname@:7070 2>&1 || echo) '
 on SEGMENT 0
 FORMAT 'text' (delimiter '|');
 CREATE EXTERNAL WEB TABLE exttab1_gpfdist_start (x text)
-execute E'((@bindir@/gpfdist -p 7070 -d @abs_srcdir@/data  </dev/null >/dev/null 2>&1 &); for i in `seq 1 30`; do curl 127.0.0.1:7070 >/dev/null 2>&1 && break; sleep 1; done; echo "starting...") '
+execute E'((@bindir@/gpfdist -p 7070 -k 360 -d @abs_srcdir@/data  </dev/null >/dev/null 2>&1 &); for i in `seq 1 30`; do curl 127.0.0.1:7070 >/dev/null 2>&1 && break; sleep 1; done; echo "starting...") '
 on SEGMENT 0
 FORMAT 'text' (delimiter '|');
 CREATE EXTERNAL WEB TABLE exttab1_gpfdist_stop (x text)


### PR DESCRIPTION
The default value for session clean up timeout is 300s, but in heavy workload, this default value is not long enough to wait for segment next POST request to arrive. Then it will cause "400 invalid request due to wrong sequence number" failure.

So this commit add one option '-k' to set this value for gpfdist. The default is 300, the valid range would be (300..86400).

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
