### PR TITLE
Resolve FIXMEs in datetime.c

### DIFF
--- a/src/backend/access/common/printsimple.c
+++ b/src/backend/access/common/printsimple.c
@@ -113,7 +113,7 @@ printsimple(TupleTableSlot *slot, DestReceiver *self)
 			case INT8OID:
 				{
 					int64		num = DatumGetInt64(value);
-					char		str[23];	/* sign, 21 digits and '\0' */
+					char		str[MAXINT8LEN + 1];
 
 					pg_lltoa(num, str);
 					pq_sendcountedtext(&buf, str, strlen(str), false);

--- a/src/backend/utils/adt/datetime.c
+++ b/src/backend/utils/adt/datetime.c
@@ -404,9 +404,9 @@ AppendSeconds(char *cp, int sec, fsec_t fsec, int precision, bool fillzeros)
 	Assert(precision >= 0);
 
 	if (fillzeros)
-		cp = pg_ltostr_zeropad(cp, Abs(sec), 2);
+		cp = pg_ultostr_zeropad(cp, Abs(sec), 2);
 	else
-		cp = pg_ltostr(cp, Abs(sec));
+		cp = pg_ultostr(cp, Abs(sec));
 
 	/* fsec_t is just an int32 */
 	if (fsec != 0)
@@ -442,11 +442,11 @@ AppendSeconds(char *cp, int sec, fsec_t fsec, int precision, bool fillzeros)
 
 		/*
 		 * If we still have a non-zero value then precision must have not been
-		 * enough to print the number.  We punt the problem to pg_ltostr(),
+		 * enough to print the number.  We punt the problem to pg_ultostr(),
 		 * which will generate a correct answer in the minimum valid width.
 		 */
 		if (value)
-			return pg_ltostr(cp, Abs(fsec));
+			return pg_ultostr(cp, Abs(fsec));
 
 		return end;
 	}
@@ -3841,20 +3841,20 @@ EncodeTimezone(char *str, int tz, int style)
 
 	if (sec != 0)
 	{
-		str = pg_ltostr_zeropad(str, hour, 2);
+		str = pg_ultostr_zeropad(str, hour, 2);
 		*str++ = ':';
-		str = pg_ltostr_zeropad(str, min, 2);
+		str = pg_ultostr_zeropad(str, min, 2);
 		*str++ = ':';
-		str = pg_ltostr_zeropad(str, sec, 2);
+		str = pg_ultostr_zeropad(str, sec, 2);
 	}
 	else if (min != 0 || style == USE_XSD_DATES)
 	{
-		str = pg_ltostr_zeropad(str, hour, 2);
+		str = pg_ultostr_zeropad(str, hour, 2);
 		*str++ = ':';
-		str = pg_ltostr_zeropad(str, min, 2);
+		str = pg_ultostr_zeropad(str, min, 2);
 	}
 	else
-		str = pg_ltostr_zeropad(str, hour, 2);
+		str = pg_ultostr_zeropad(str, hour, 2);
 	return str;
 }
 
@@ -3910,41 +3910,40 @@ EncodeDateOnly(struct pg_tm *tm, int style, char *str)
 		case USE_ISO_DATES:
 		case USE_XSD_DATES:
 			/* compatible with ISO date formats */
-
-			str = pg_ltostr_zeropad(str,
+			str = pg_ultostr_zeropad(str,
 									(tm->tm_year > 0) ? tm->tm_year : -(tm->tm_year - 1), 4);
 			*str++ = '-';
-			str = pg_ltostr_zeropad(str, tm->tm_mon, 2);
+			str = pg_ultostr_zeropad(str, tm->tm_mon, 2);
 			*str++ = '-';
-			str = pg_ltostr_zeropad(str, tm->tm_mday, 2);
+			str = pg_ultostr_zeropad(str, tm->tm_mday, 2);
 			break;
 
 		case USE_SQL_DATES:
 			/* compatible with Oracle/Ingres date formats */
 			if (DateOrder == DATEORDER_DMY)
 			{
-				str = pg_ltostr_zeropad(str, tm->tm_mday, 2);
+				str = pg_ultostr_zeropad(str, tm->tm_mday, 2);
 				*str++ = '/';
-				str = pg_ltostr_zeropad(str, tm->tm_mon, 2);
+				str = pg_ultostr_zeropad(str, tm->tm_mon, 2);
 			}
 			else
 			{
-				str = pg_ltostr_zeropad(str, tm->tm_mon, 2);
+				str = pg_ultostr_zeropad(str, tm->tm_mon, 2);
 				*str++ = '/';
-				str = pg_ltostr_zeropad(str, tm->tm_mday, 2);
+				str = pg_ultostr_zeropad(str, tm->tm_mday, 2);
 			}
 			*str++ = '/';
-			str = pg_ltostr_zeropad(str,
+			str = pg_ultostr_zeropad(str,
 									(tm->tm_year > 0) ? tm->tm_year : -(tm->tm_year - 1), 4);
 			break;
 
 		case USE_GERMAN_DATES:
 			/* German-style date format */
-			str = pg_ltostr_zeropad(str, tm->tm_mday, 2);
+			str = pg_ultostr_zeropad(str, tm->tm_mday, 2);
 			*str++ = '.';
-			str = pg_ltostr_zeropad(str, tm->tm_mon, 2);
+			str = pg_ultostr_zeropad(str, tm->tm_mon, 2);
 			*str++ = '.';
-			str = pg_ltostr_zeropad(str,
+			str = pg_ultostr_zeropad(str,
 									(tm->tm_year > 0) ? tm->tm_year : -(tm->tm_year - 1), 4);
 			break;
 
@@ -3953,18 +3952,18 @@ EncodeDateOnly(struct pg_tm *tm, int style, char *str)
 			/* traditional date-only style for Postgres */
 			if (DateOrder == DATEORDER_DMY)
 			{
-				str = pg_ltostr_zeropad(str, tm->tm_mday, 2);
+				str = pg_ultostr_zeropad(str, tm->tm_mday, 2);
 				*str++ = '-';
-				str = pg_ltostr_zeropad(str, tm->tm_mon, 2);
+				str = pg_ultostr_zeropad(str, tm->tm_mon, 2);
 			}
 			else
 			{
-				str = pg_ltostr_zeropad(str, tm->tm_mon, 2);
+				str = pg_ultostr_zeropad(str, tm->tm_mon, 2);
 				*str++ = '-';
-				str = pg_ltostr_zeropad(str, tm->tm_mday, 2);
+				str = pg_ultostr_zeropad(str, tm->tm_mday, 2);
 			}
 			*str++ = '-';
-			str = pg_ltostr_zeropad(str,
+			str = pg_ultostr_zeropad(str,
 									(tm->tm_year > 0) ? tm->tm_year : -(tm->tm_year - 1), 4);
 			break;
 	}
@@ -3989,9 +3988,9 @@ EncodeDateOnly(struct pg_tm *tm, int style, char *str)
 void
 EncodeTimeOnly(struct pg_tm *tm, fsec_t fsec, bool print_tz, int tz, int style, char *str)
 {
-	str = pg_ltostr_zeropad(str, tm->tm_hour, 2);
+	str = pg_ultostr_zeropad(str, tm->tm_hour, 2);
 	*str++ = ':';
-	str = pg_ltostr_zeropad(str, tm->tm_min, 2);
+	str = pg_ultostr_zeropad(str, tm->tm_min, 2);
 	*str++ = ':';
 	str = AppendSeconds(str, tm->tm_sec, fsec, MAX_TIME_PRECISION, true);
 	if (print_tz)
@@ -4034,16 +4033,16 @@ EncodeDateTime(struct pg_tm *tm, fsec_t fsec, bool print_tz, int tz, const char 
 		case USE_ISO_DATES:
 		case USE_XSD_DATES:
 			/* Compatible with ISO-8601 date formats */
-			str = pg_ltostr_zeropad(str,
+			str = pg_ultostr_zeropad(str,
 									(tm->tm_year > 0) ? tm->tm_year : -(tm->tm_year - 1), 4);
 			*str++ = '-';
-			str = pg_ltostr_zeropad(str, tm->tm_mon, 2);
+			str = pg_ultostr_zeropad(str, tm->tm_mon, 2);
 			*str++ = '-';
-			str = pg_ltostr_zeropad(str, tm->tm_mday, 2);
+			str = pg_ultostr_zeropad(str, tm->tm_mday, 2);
 			*str++ = (style == USE_ISO_DATES) ? ' ' : 'T';
-			str = pg_ltostr_zeropad(str, tm->tm_hour, 2);
+			str = pg_ultostr_zeropad(str, tm->tm_hour, 2);
 			*str++ = ':';
-			str = pg_ltostr_zeropad(str, tm->tm_min, 2);
+			str = pg_ultostr_zeropad(str, tm->tm_min, 2);
 			*str++ = ':';
 			str = AppendTimestampSeconds(str, tm, fsec);
 			if (print_tz)
@@ -4054,23 +4053,23 @@ EncodeDateTime(struct pg_tm *tm, fsec_t fsec, bool print_tz, int tz, const char 
 			/* Compatible with Oracle/Ingres date formats */
 			if (DateOrder == DATEORDER_DMY)
 			{
-				str = pg_ltostr_zeropad(str, tm->tm_mday, 2);
+				str = pg_ultostr_zeropad(str, tm->tm_mday, 2);
 				*str++ = '/';
-				str = pg_ltostr_zeropad(str, tm->tm_mon, 2);
+				str = pg_ultostr_zeropad(str, tm->tm_mon, 2);
 			}
 			else
 			{
-				str = pg_ltostr_zeropad(str, tm->tm_mon, 2);
+				str = pg_ultostr_zeropad(str, tm->tm_mon, 2);
 				*str++ = '/';
-				str = pg_ltostr_zeropad(str, tm->tm_mday, 2);
+				str = pg_ultostr_zeropad(str, tm->tm_mday, 2);
 			}
 			*str++ = '/';
-			str = pg_ltostr_zeropad(str,
+			str = pg_ultostr_zeropad(str,
 									(tm->tm_year > 0) ? tm->tm_year : -(tm->tm_year - 1), 4);
 			*str++ = ' ';
-			str = pg_ltostr_zeropad(str, tm->tm_hour, 2);
+			str = pg_ultostr_zeropad(str, tm->tm_hour, 2);
 			*str++ = ':';
-			str = pg_ltostr_zeropad(str, tm->tm_min, 2);
+			str = pg_ultostr_zeropad(str, tm->tm_min, 2);
 			*str++ = ':';
 			str = AppendTimestampSeconds(str, tm, fsec);
 
@@ -4093,16 +4092,16 @@ EncodeDateTime(struct pg_tm *tm, fsec_t fsec, bool print_tz, int tz, const char 
 
 		case USE_GERMAN_DATES:
 			/* German variant on European style */
-			str = pg_ltostr_zeropad(str, tm->tm_mday, 2);
+			str = pg_ultostr_zeropad(str, tm->tm_mday, 2);
 			*str++ = '.';
-			str = pg_ltostr_zeropad(str, tm->tm_mon, 2);
+			str = pg_ultostr_zeropad(str, tm->tm_mon, 2);
 			*str++ = '.';
-			str = pg_ltostr_zeropad(str,
+			str = pg_ultostr_zeropad(str,
 									(tm->tm_year > 0) ? tm->tm_year : -(tm->tm_year - 1), 4);
 			*str++ = ' ';
-			str = pg_ltostr_zeropad(str, tm->tm_hour, 2);
+			str = pg_ultostr_zeropad(str, tm->tm_hour, 2);
 			*str++ = ':';
-			str = pg_ltostr_zeropad(str, tm->tm_min, 2);
+			str = pg_ultostr_zeropad(str, tm->tm_min, 2);
 			*str++ = ':';
 			str = AppendTimestampSeconds(str, tm, fsec);
 
@@ -4128,7 +4127,7 @@ EncodeDateTime(struct pg_tm *tm, fsec_t fsec, bool print_tz, int tz, const char 
 			*str++ = ' ';
 			if (DateOrder == DATEORDER_DMY)
 			{
-				str = pg_ltostr_zeropad(str, tm->tm_mday, 2);
+				str = pg_ultostr_zeropad(str, tm->tm_mday, 2);
 				*str++ = ' ';
 				memcpy(str, months[tm->tm_mon - 1], 3);
 				str += 3;
@@ -4138,16 +4137,16 @@ EncodeDateTime(struct pg_tm *tm, fsec_t fsec, bool print_tz, int tz, const char 
 				memcpy(str, months[tm->tm_mon - 1], 3);
 				str += 3;
 				*str++ = ' ';
-				str = pg_ltostr_zeropad(str, tm->tm_mday, 2);
+				str = pg_ultostr_zeropad(str, tm->tm_mday, 2);
 			}
 			*str++ = ' ';
-			str = pg_ltostr_zeropad(str, tm->tm_hour, 2);
+			str = pg_ultostr_zeropad(str, tm->tm_hour, 2);
 			*str++ = ':';
-			str = pg_ltostr_zeropad(str, tm->tm_min, 2);
+			str = pg_ultostr_zeropad(str, tm->tm_min, 2);
 			*str++ = ':';
 			str = AppendTimestampSeconds(str, tm, fsec);
 			*str++ = ' ';
-			str = pg_ltostr_zeropad(str,
+			str = pg_ultostr_zeropad(str,
 									(tm->tm_year > 0) ? tm->tm_year : -(tm->tm_year - 1), 4);
 
 			if (print_tz)

--- a/src/backend/utils/adt/datetime.c
+++ b/src/backend/utils/adt/datetime.c
@@ -403,31 +403,6 @@ AppendSeconds(char *cp, int sec, fsec_t fsec, int precision, bool fillzeros)
 {
 	Assert(precision >= 0);
 
-	/* GPDB_96_MERGE_FIXME: We had this faster version in GPDB. PostgreSQL
-	 * also added faster versions in commit aa2387e2fd. Performance test is
-	 * the old GPDB variants are even faster, or if we could drop the diff
-	 * and just use upstream code. For now, the GPDB version is disabled
-	 * and we use the upstream code.
-	 */
-#if 0
-		int			j = 0;
-
-		if (fillzeros || abs(sec)  > 9)
-			cp[j++] = abs(sec)  / 10 + '0';
-		cp[j++] = abs(sec)  % 10 + '0';
-		cp[j++] = '.';
-		cp[j++] =  ((int) Abs(fsec) )/ 100000 + '0';
-		cp[j++] = ((int) Abs(fsec) ) / 10000 % 10 + '0';
-		cp[j++] = ((int) Abs(fsec) ) / 1000 % 10 + '0';
-		cp[j++] = ((int) Abs(fsec) ) / 100 % 10 + '0';
-		cp[j++] = ((int) Abs(fsec) ) / 10 % 10 + '0';
-		cp[j++] = ((int) Abs(fsec) ) % 10 + '0';
-		cp[j] = '\0';
-
-#endif
-
-	/* fsec_t is just an int32 */
-
 	if (fillzeros)
 		cp = pg_ltostr_zeropad(cp, Abs(sec), 2);
 	else
@@ -3936,31 +3911,12 @@ EncodeDateOnly(struct pg_tm *tm, int style, char *str)
 		case USE_XSD_DATES:
 			/* compatible with ISO date formats */
 
-			/* GPDB_96_MERGE_FIXME: We had this faster version in GPDB. PostgreSQL
-			 * also added faster versions in commit aa2387e2fd. Performance test is
-			 * the old GPDB variants are even faster, or if we could drop the diff
-			 * and just use upstream code. For now, the GPDB version is disabled
-			 * and we use the upstream code.
-			 */
-#if 0
-			if (tm->tm_year > 0)
-			{
-				//				sprintf(str, "%04d-%02d-%02d",
-				//		tm->tm_year, tm->tm_mon, tm->tm_mday);
-				int j = 0;
-				fast_encode_date(tm, str, &j);
-			}
-			else
-				sprintf(str, "%04d-%02d-%02d %s",
-						-(tm->tm_year - 1), tm->tm_mon, tm->tm_mday, "BC");
-#else
 			str = pg_ltostr_zeropad(str,
 									(tm->tm_year > 0) ? tm->tm_year : -(tm->tm_year - 1), 4);
 			*str++ = '-';
 			str = pg_ltostr_zeropad(str, tm->tm_mon, 2);
 			*str++ = '-';
 			str = pg_ltostr_zeropad(str, tm->tm_mday, 2);
-#endif
 			break;
 
 		case USE_SQL_DATES:
@@ -4033,28 +3989,6 @@ EncodeDateOnly(struct pg_tm *tm, int style, char *str)
 void
 EncodeTimeOnly(struct pg_tm *tm, fsec_t fsec, bool print_tz, int tz, int style, char *str)
 {
-	/* GPDB_96_MERGE_FIXME: We had this faster version in GPDB. PostgreSQL
-	 * also added faster versions in commit aa2387e2fd. Performance test is
-	 * the old GPDB variants are even faster, or if we could drop the diff
-	 * and just use upstream code. For now, the GPDB version is disabled
-	 * and we use the upstream code.
-	 *
-	 * If we still need the old GPDB version, make sure it was actually correct.
-	 * It seems to ignore the 'print_tz' argument...
-	 */
-#if 0
-	str[0] = tm->tm_hour/10 + '0';
-	str[1] = tm->tm_hour % 10 + '0';
-	str[2] = ':';
-	str[3] = tm->tm_min/10 + '0';
-	str[4] = tm->tm_min % 10 + '0';
-	str[5] = ':';
-	str[6] = '\0';
-	str += strlen(str);
-
-	AppendSeconds(str, tm->tm_sec, fsec, MAX_TIME_PRECISION, true);
-#else
-
 	str = pg_ltostr_zeropad(str, tm->tm_hour, 2);
 	*str++ = ':';
 	str = pg_ltostr_zeropad(str, tm->tm_min, 2);
@@ -4063,7 +3997,6 @@ EncodeTimeOnly(struct pg_tm *tm, fsec_t fsec, bool print_tz, int tz, int style, 
 	if (print_tz)
 		str = EncodeTimezone(str, tz, style);
 	*str = '\0';
-#endif
 }
 
 

--- a/src/backend/utils/adt/int8.c
+++ b/src/backend/utils/adt/int8.c
@@ -27,7 +27,6 @@
 #include "utils/builtins.h"
 
 
-#define MAXINT8LEN		25
 
 typedef struct
 {

--- a/src/backend/utils/adt/numutils.c
+++ b/src/backend/utils/adt/numutils.c
@@ -543,11 +543,11 @@ pg_lltoa(int64 value, char *a)
  * The intended use-case for this function is to build strings that contain
  * multiple individual numbers, for example:
  *
- *	str = pg_ltostr_zeropad(str, hours, 2);
+ *	str = pg_ultostr_zeropad(str, hours, 2);
  *	*str++ = ':';
- *	str = pg_ltostr_zeropad(str, mins, 2);
+ *	str = pg_ultostr_zeropad(str, mins, 2);
  *	*str++ = ':';
- *	str = pg_ltostr_zeropad(str, secs, 2);
+ *	str = pg_ultostr_zeropad(str, secs, 2);
  *	*str = '\0';
  *
  * Note: Caller must ensure that 'str' points to enough memory to hold the
@@ -576,7 +576,7 @@ pg_ultostr_zeropad(char *str, uint32 value, int32 minwidth)
 }
 
 /*
- * pg_ltostr
+ * pg_ultostr
  *		Converts 'value' into a decimal string representation stored at 'str'.
  *
  * Returns the ending address of the string result (the last character written
@@ -585,9 +585,9 @@ pg_ultostr_zeropad(char *str, uint32 value, int32 minwidth)
  * The intended use-case for this function is to build strings that contain
  * multiple individual numbers, for example:
  *
- *	str = pg_ltostr(str, a);
+ *	str = pg_ultostr(str, a);
  *	*str++ = ' ';
- *	str = pg_ltostr(str, b);
+ *	str = pg_ultostr(str, b);
  *	*str = '\0';
  *
  * Note: Caller must ensure that 'str' points to enough memory to hold the

--- a/src/include/utils/builtins.h
+++ b/src/include/utils/builtins.h
@@ -20,6 +20,8 @@
 #include "nodes/nodes.h"
 #include "utils/fmgrprotos.h"
 
+/* Sign + the most decimal digits an 8-byte number could have */
+#define MAXINT8LEN 20
 
 /* bool.c */
 extern bool parse_bool(const char *value, bool *result);
@@ -48,10 +50,12 @@ extern int32 pg_atoi(const char *s, int size, int c);
 extern int16 pg_strtoint16(const char *s);
 extern int32 pg_strtoint32(const char *s);
 extern void pg_itoa(int16 i, char *a);
+int			pg_ultoa_n(uint32 l, char *a);
+int			pg_ulltoa_n(uint64 l, char *a);
 extern void pg_ltoa(int32 l, char *a);
 extern void pg_lltoa(int64 ll, char *a);
-extern char *pg_ltostr_zeropad(char *str, int32 value, int32 minwidth);
-extern char *pg_ltostr(char *str, int32 value);
+extern char *pg_ultostr_zeropad(char *str, uint32 value, int32 minwidth);
+extern char *pg_ultostr(char *str, uint32 value);
 extern uint64 pg_strtouint64(const char *str, char **endptr, int base);
 
 /* dbsize.c */


### PR DESCRIPTION
The old GPDB version of the calculation (added in https://github.com/greenplum-db/gpdb/commit/059ebb1da10b1f15487ba74dd1bada185093bbf2)
and the new upstream version (added in https://github.com/greenplum-db/gpdb/commit/aa2387e2fd532954e88dfd8546ab894b9305123d) are essentially the
same: both were trying to optimize away sprintf and just do a byte-by-byte
conversion. Similar to what upstream does for https://github.com/greenplum-db/gpdb/commit/aa2387e2fd532954e88dfd8546ab894b9305123d, I did a
comparison between the old GPDB version and the upstream version:

```sql
-- pre-requisite:
create table t(a int, b timestamp);
insert into t select 0, '2018-01-01 10:10:00.1'::timestamp from generate_series(1,10000000);
\timing on
-- and measure the copy performance:
copy t to '/tmp/copyto.csv';
```

This would just test function AppendSeconds() but the other two functions
should have similar results.

1. Old AppendSeconds() (note: added back a missing function TrimTrailingZeros())
```sql
postgres=# copy t to '/tmp/copyto.csv';
COPY 10000000
Time: 7232.761 ms (00:07.233)
postgres=# copy t to '/tmp/copyto.csv';
COPY 10000000
Time: 7137.877 ms (00:07.138)
postgres=# copy t to '/tmp/copyto.csv';
COPY 10000000
Time: 7189.453 ms (00:07.189)
```
average 7186 ms

2. New AppendSeconds()
```sql
postgres=# copy t to '/tmp/copyto.csv';
COPY 10000000
Time: 7281.391 ms (00:07.281)
postgres=# copy t to '/tmp/copyto.csv';
COPY 10000000
Time: 7231.939 ms (00:07.232)
postgres=# copy t to '/tmp/copyto.csv';
COPY 10000000
Time: 7211.126 ms (00:07.211)
```
average 7241 ms

The difference is almost negligible.

In addition, the old AppendSeconds() has some limitations:
* Suprisingly, it does not even handle precision at all. It used to handle
it for non-`HAVE_INT64_TIMESTAMP` case but since that case has gone in https://github.com/greenplum-db/gpdb/commit/b9d092c962ea3262930e3c31a8c3d79b66ce9d43
the precision parameter is completely ignored.
* It makes an assumption about a two-digit seconds. It might not be a big
deal in most cases but considering the many callsites of AppendSeconds()
it's still better to make it more robust.

Using upstream version is also also better in terms of getting more
upstream optimization in future. For example, with this PR we are also
cherrypicking 1fd687a0355 for the same purpose.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
