### PR TITLE
Add guc plpython3.python_path, fix plpython3 build (#13095)

### DIFF
--- a/src/pl/plpython/Makefile
+++ b/src/pl/plpython/Makefile
@@ -118,6 +118,7 @@ REGRESS = \
 	plpython_subtransaction \
 	plpython_transaction \
 	plpython_gpdb \
+	plpython3_path_guc \
 	plpython_drop
 
 REGRESS_PLPYTHON3_MANGLE := $(REGRESS)

--- a/src/pl/plpython/expected/plpython3_path_guc.out
+++ b/src/pl/plpython/expected/plpython3_path_guc.out
@@ -1,0 +1,39 @@
+--
+-- Tests for functions that return set PYTHONPATH guc only for gpdb6 plpython3
+--
+LOAD 'plpython3';
+show plpython3.python_path;
+ plpython3.python_path 
+-----------------------
+ 
+(1 row)
+
+set plpython3.python_path='/foo';
+show plpython3.python_path;
+ plpython3.python_path 
+-----------------------
+ /foo
+(1 row)
+
+-- Set up test path functions first.
+CREATE FUNCTION test_path_added() 
+RETURNS text AS $$
+  import sys
+  return str(sys.path[0])
+$$ language plpython3u;
+SELECT test_path_added();
+ test_path_added 
+-----------------
+ /foo
+(1 row)
+
+-- when the plpython init can not set again --
+set plpython3.python_path='/bar';
+ERROR:  SET PYTHONPATH failed, the GUC value can only be changed before initializing the python interpreter.
+-- run again the path will not change still /foo --
+SELECT test_path_added();
+ test_path_added 
+-----------------
+ /foo
+(1 row)
+

--- a/src/pl/plpython/expected/plpython3_path_guc.out
+++ b/src/pl/plpython/expected/plpython3_path_guc.out
@@ -1,13 +1,10 @@
 --
--- Tests for functions that return set PYTHONPATH guc only for gpdb6 plpython3
+-- Tests for functions that return set PYTHONPATH guc only for gpdb7 plpython3
 --
-LOAD 'plpython3';
+-- The 'SHOW' command will fail with an error message saying
+-- ERROR: unrecognized configuration parameter "plpython3.python_path"
 show plpython3.python_path;
- plpython3.python_path 
------------------------
- 
-(1 row)
-
+ERROR:  unrecognized configuration parameter "plpython3.python_path"
 set plpython3.python_path='/foo';
 show plpython3.python_path;
  plpython3.python_path 

--- a/src/pl/plpython/init_file
+++ b/src/pl/plpython/init_file
@@ -5,6 +5,24 @@ m/ \(plpy_exec\.c:\d+\)/
 s/ \(plpy_exec\.c:\d+\)//
 m/ \(plpython\.c:\d+\)/
 s/ \(plpython\.c:\d+\)//
+
+# TODO: Move these to init_file_python3
+m/"subtransaction_exit_subtransaction_in_with", line \d+/
+s/"subtransaction_exit_subtransaction_in_with", line \d+//
+m/with plpy\.subtransaction\(\) as s:/
+s/with plpy\.subtransaction\(\) as s:/s.__exit__(None, None, None)/
+
+# new add for plpython3
+m/ERROR:  invalid input syntax for integer:.*/
+s/ERROR:  invalid input syntax for integer:.*//
+m/ERROR:  length of returned sequence did not match number of columns in row.*/
+s/ERROR:  length of returned sequence did not match number of columns in row.*//
+m/(seg\d+.*)/
+s/(seg\d+.*)//
+# for python3 different version have different SyntaxError so we ignore it.
+m/ERROR:  SyntaxError:.*/
+s/ERROR:  SyntaxError:.*/SyntaxError/
+
 -- end_matchsubs
 
 # Copied from src/test/regress/init_file:

--- a/src/pl/plpython/sql/plpython3_path_guc.sql
+++ b/src/pl/plpython/sql/plpython3_path_guc.sql
@@ -1,0 +1,23 @@
+--
+-- Tests for functions that return set PYTHONPATH guc only for gpdb6 plpython3
+--
+LOAD 'plpython3';
+show plpython3.python_path;
+
+set plpython3.python_path='/foo';
+show plpython3.python_path;
+
+-- Set up test path functions first.
+CREATE FUNCTION test_path_added() 
+RETURNS text AS $$
+  import sys
+  return str(sys.path[0])
+$$ language plpython3u;
+
+SELECT test_path_added();
+
+-- when the plpython init can not set again --
+set plpython3.python_path='/bar';
+
+-- run again the path will not change still /foo --
+SELECT test_path_added();

--- a/src/pl/plpython/sql/plpython3_path_guc.sql
+++ b/src/pl/plpython/sql/plpython3_path_guc.sql
@@ -1,7 +1,9 @@
 --
--- Tests for functions that return set PYTHONPATH guc only for gpdb6 plpython3
+-- Tests for functions that return set PYTHONPATH guc only for gpdb7 plpython3
 --
-LOAD 'plpython3';
+
+-- The 'SHOW' command will fail with an error message saying
+-- ERROR: unrecognized configuration parameter "plpython3.python_path"
 show plpython3.python_path;
 
 set plpython3.python_path='/foo';


### PR DESCRIPTION
GP7 is going to use different python3 version for management utilities
and plpython, the PYTHONPATH in greenplum_path.sh will be a problem for
plpython.

This cherry-pick only use the GUC part of the original commit.

---

grenplum_path.sh always set PYTHONPATH to its 'lib/python', which creates
trouble using plpython3 for GPDB6. GUC 'plpython3.python_path' is
added by this commit to solve the issue.

- If the python_path has not been set, while loading plpython3, the
  'PYTHONPATH' and 'PYTHONHOME' will be unset.
- If the python_path has been set, the 'PYTHONHOME' will be unset and the
  'PYTHONPATH' will be set to the given value.

Some regress tests have been modified for python3 support.
plpython2 and plpython3 can co-exist with this commit. But they cannot
be used in the same session, which is a known limitation.

Co-authored-by: yihong <zouzou0208@gmail.com>
Co-authored-by: Chen Mulong <chenmulong@gmail.com>
Co-authored-by: zengr <zeng_ruxue@126.com>
(cherry picked from commit 63a6e79246c5dd8e45361022e701a31147dba9d5)
