### PR TITLE
Polish code and comment of gpfdist (7X)

### DIFF
--- a/src/backend/access/external/url_curl.c
+++ b/src/backend/access/external/url_curl.c
@@ -152,9 +152,11 @@ char extssl_key_full[MAXPGPATH] = {0};
 char extssl_cer_full[MAXPGPATH] = {0};
 char extssl_cas_full[MAXPGPATH] = {0};
 
-/* Will hold the last curl error					*/
-/* Currently it is in use only for SSL connection,	*/
-/* but we should consider using it always			*/
+/*
+ * Will hold the last curl error
+ * Currently it is in use only for SSL connection,
+ * but we should consider using it always
+ */ 
 static char curl_Error_Buffer[CURL_ERROR_SIZE];
 
 static void gp_proto0_write_done(URL_CURL_FILE *file);
@@ -420,7 +422,7 @@ header_callback(void *ptr_, size_t size, size_t nmemb, void *userp)
 			if (url->for_write && url->zstd)
 			{	
 				url->curl->zstd_cctx = ZSTD_createCCtx();
-				// allocate out.cptr whose size equals to out.ptr
+				/* allocate out.cptr whose size equals to out.ptr */
 				url->out.cptr = (char *) palloc(writable_external_table_bufsize * 1024);
 				url->lastsize = 0;
 			}
@@ -546,18 +548,19 @@ check_response(URL_CURL_FILE *file, int *rc, char **response_string)
 							(oserrno != 0 ? connmsg : ""),
 							(curl_Error_Buffer[0] != '\0' ? curl_Error_Buffer : ""))));
 		}
-		else if (response_code == FDIST_TIMEOUT)	// gpfdist server return timeout code
+		else if (response_code == FDIST_TIMEOUT)	/* gpfdist server return timeout code */
 		{
 			return FDIST_TIMEOUT;
 		}
 		else
 		{
-			/* we need to sleep 1 sec to avoid this condition:
-			   1- seg X gets an error message from gpfdist
-			   2- seg Y gets a 500 error
-			   3- seg Y report error before seg X, and error message
-			   in seg X is thrown away.
-			*/
+			/* 
+			 * we need to sleep 1 sec to avoid this condition:
+			 * 1- seg X gets an error message from gpfdist
+			 * 2- seg Y gets a 500 error
+			 * 3- seg Y report error before seg X, and error message
+			 * in seg X is thrown away.
+			 */
 			pg_usleep(1000000);
 
 			ereport(ERROR,
@@ -571,7 +574,7 @@ check_response(URL_CURL_FILE *file, int *rc, char **response_string)
 	return 0;
 }
 
-// callback for request /gpfdist/status for debugging purpose.
+/* callback for request /gpfdist/status for debugging purpose. */
 static size_t
 log_http_body(char *buffer, size_t size, size_t nitems, void *userp)
 {
@@ -586,7 +589,7 @@ log_http_body(char *buffer, size_t size, size_t nitems, void *userp)
 	return nbytes;
 }
 
-// GET /gpfdist/status to get gpfdist status.
+/* GET /gpfdist/status to get gpfdist status. */
 static void
 get_gpfdist_status(URL_CURL_FILE *file)
 {
@@ -791,9 +794,10 @@ fill_buffer(URL_CURL_FILE *curl, int want)
 	int 	nfds = 0, e = 0;
 	int     timeout_count = 0;
 
-	/* elog(NOTICE, "= still_running %d, bot %d, top %d, want %d",
-	   file->u.curl.still_running, curl->in.bot, curl->in.top, want);
-	*/
+	/* 
+	 * elog(NOTICE, "= still_running %d, bot %d, top %d, want %d",
+	 * file->u.curl.still_running, curl->in.bot, curl->in.top, want);
+	 */
 
 	/* attempt to fill buffer */
 	while (curl->still_running && curl->in.top - curl->in.bot < want)
@@ -821,7 +825,8 @@ fill_buffer(URL_CURL_FILE *curl, int want)
 			curl->still_running = 0;
 			break;
 		}
-		/* When libcurl returns -1 in max_fd, it is because libcurl currently does something
+		/* 
+		 * When libcurl returns -1 in max_fd, it is because libcurl currently does something
 		 * that isn't possible for your application to monitor with a socket and unfortunately
 		 * you can then not know exactly when the current action is completed using select().
 		 * You then need to wait a while before you proceed and call curl_multi_perform anyway
@@ -830,7 +835,7 @@ fill_buffer(URL_CURL_FILE *curl, int want)
 		{
 			elog(DEBUG2, "curl_multi_fdset set maxfd = %d", maxfd);
 			pg_usleep(100000);
-			// to call curl_multi_perform
+			/* to call curl_multi_perform */
 			nfds = 1;
 		}
 		else
@@ -851,7 +856,7 @@ fill_buffer(URL_CURL_FILE *curl, int want)
 		}
 		else if (nfds == 0)
 		{
-			// timeout
+			/* timeout */
 			timeout_count++;
 
 			if (timeout_count % 12 == 0)
@@ -876,9 +881,11 @@ fill_buffer(URL_CURL_FILE *curl, int want)
 		else if (nfds > 0)
 		{
 			/* timeout or readable/writable sockets */
-			/* note we *could* be more efficient and not wait for
+			/* 
+			 * note we *could* be more efficient and not wait for
 			 * CURLM_CALL_MULTI_PERFORM to clear here and check it on re-entry
-			 * but that gets messy */
+			 * but that gets messy 
+			 */
 			while (CURLM_CALL_MULTI_PERFORM ==
 				   (e = curl_multi_perform(multi_handle, &curl->still_running)));
 
@@ -893,9 +900,10 @@ fill_buffer(URL_CURL_FILE *curl, int want)
 			elog(ERROR, "select return unexpected result");
 		}
 
-		/* elog(NOTICE, "- still_running %d, bot %d, top %d, want %d",
-		   file->u.curl.still_running, curl->in.bot, curl->in.top, want);
-		*/
+		/* 
+		 * elog(NOTICE, "- still_running %d, bot %d, top %d, want %d",
+		 * file->u.curl.still_running, curl->in.bot, curl->in.top, want);
+		 */
 	}
 
 	if (curl->still_running == 0)
@@ -1223,8 +1231,10 @@ url_curl_fopen(char *url, bool forwrite, extvar_t *ev, CopyState pstate)
 
 	if (IS_GPFDIST_URI(file->curl_url) || IS_GPFDISTS_URI(file->curl_url))
 	{
-		/* replace gpfdist:// with http:// or gpfdists:// with https://
-		 * by overriding 'dist' with 'http' */
+		/* 
+		 * replace gpfdist:// with http:// or gpfdists:// with https://
+		 * by overriding 'dist' with 'http' 
+		 */
 		unsigned int tmp_len = strlen(file->curl_url) + 1;
 		memmove(file->curl_url, file->curl_url + 3, tmp_len - 3);
 		memcpy(file->curl_url, "http", 4);
@@ -1288,12 +1298,14 @@ url_curl_fopen(char *url, bool forwrite, extvar_t *ev, CopyState pstate)
 
 	if (forwrite)
 	{
-		// TIMEOUT for POST only, GET is single HTTP request,
-		// probablity take long time.
+		/* 
+		 * TIMEOUT for POST only, GET is single HTTP request,
+		 * probablity take long time.
+		 */
 		elog(LOG, "gpfdist_retry_timeout = %d", gpfdist_retry_timeout);
 		CURL_EASY_SETOPT(file->curl->handle, CURLOPT_TIMEOUT, (long)gpfdist_retry_timeout);
 
-		/*init sequence number*/
+		/* init sequence number */
 		file->seq_number = 1;
 
 		/* write specific headers */
@@ -1561,9 +1573,11 @@ gp_proto0_read(char *buf, int bufsz, URL_CURL_FILE *file)
 
 	fill_buffer(file, bufsz);
 
-	/* check if there's data in the buffer - if not fill_buffer()
+	/* 
+	 * check if there's data in the buffer - if not fill_buffer()
 	 * either errored or EOF. For proto0, we cannot distinguish
-	 * between error and EOF. */
+	 * between error and EOF. 
+	 */
 	n = file->in.top - file->in.bot;
 	if (n == 0 && !file->still_running)
 		file->eof = 1;
@@ -1792,7 +1806,8 @@ gp_proto1_read(char *buf, int bufsz, URL_CURL_FILE *file, CopyState pstate, char
 #ifdef USE_ZSTD
 			int wantsz = ZSTD_DStreamInSize() - left_bytes;
 			fill_buffer(file, wantsz);
-			/* Gpfdist could be aborted unexpectedly. Thus gpdb would recieve the partial data, which 
+			/* 
+			 * Gpfdist could be aborted unexpectedly. Thus gpdb would recieve the partial data, which 
 			 * is unable to be decompressed correctly. In this case, gpdb will report a decompression
 			 * error. However, the error is not the real cause of the abortion. So we add a judge here,
 			 * to check if gpdb get enough data to decompress. The missing data means the network problem.
@@ -1889,7 +1904,8 @@ gp_proto0_write(URL_CURL_FILE *file, CopyState pstate)
 	char*		buf;
 	int		nbytes;
 #ifdef USE_ZSTD
-	if(file->zstd){
+	if (file->zstd)
+	{
 		nbytes = compress_zstd_data(file);
 		buf = file->out.cptr;
 	}

--- a/src/bin/gpfdist/gpfdist.c
+++ b/src/bin/gpfdist/gpfdist.c
@@ -2137,8 +2137,7 @@ static void do_write(int fd, short event, void* arg)
 	 */
 	if (opt.multi_thread)
 	{
-		int res = recycle_thread(r);
-		if (res < 0)
+		if (recycle_thread(r) < 0)
 		{
 			return;
 		}
@@ -5056,8 +5055,7 @@ int decompress_write_loop(request_t *r)
 		gdebug(r, "wrote %d bytes to file", wrote);
 		delay_watchdog_timer();
 
-		res = check_output_to_file(r, wrote);
-		if (res < 0)
+		if (check_output_to_file(r, wrote) < 0)
 		{
 			return -1;
 		}

--- a/src/bin/gpfdist/gpfdist.c
+++ b/src/bin/gpfdist/gpfdist.c
@@ -3790,8 +3790,9 @@ static bool base16_decode(char* data)
 		char *endptr = NULL;
 		char ch = strtoul(buf, &endptr, 16);
 		if (*endptr != '\0')
+		{
 			return false;
-
+		}
 		data[i] = ch;
 		i++;
 		encoded_bytes += 2;

--- a/src/bin/gpfdist/gpfdist.c
+++ b/src/bin/gpfdist/gpfdist.c
@@ -2141,9 +2141,7 @@ static void do_write(int fd, short event, void* arg)
 	if (opt.multi_thread)
 	{
 		if (recycle_thread(r) < 0)
-		{
 			return;
-		}
 	}
 #endif
 
@@ -3792,9 +3790,8 @@ static bool base16_decode(char* data)
 		char *endptr = NULL;
 		char ch = strtoul(buf, &endptr, 16);
 		if (*endptr != '\0')
-		{
 			return false;
-		}
+
 		data[i] = ch;
 		i++;
 		encoded_bytes += 2;
@@ -5059,9 +5056,7 @@ int decompress_write_loop(request_t *r)
 		delay_watchdog_timer();
 
 		if (check_output_to_file(r, wrote) < 0)
-		{
 			return -1;
-		}
 
 	} while (r->in.woffset);
 	return wrote_total;

--- a/src/bin/gpfdist/gpfdist.c
+++ b/src/bin/gpfdist/gpfdist.c
@@ -70,6 +70,9 @@
 #define MAX_FRAME_SIZE 65536
 #define MAX_THREAD_NUM 256
 
+#define VALID_NUM 0
+#define ERROR_NUM 1
+
 /*  A data block */
 typedef struct blockhdr_t blockhdr_t;
 struct blockhdr_t
@@ -1272,7 +1275,7 @@ static void request_end(request_t* r, int error, const char* errmsg)
 	{
 		gwarning(r, "request failure resulting in session failure: top = %d, bot = %d", r->outblock.top, r->outblock.bot);
 		if (s)
-			session_end(s, 1);
+			session_end(s, ERROR_NUM);
 	}
 	else
 	{
@@ -1318,7 +1321,7 @@ static int local_send(request_t *r, const char* buf, int buflen)
 				else
 #endif
 				{
-					session_end(r->session, 0);
+					session_end(r->session, VALID_NUM);
 				}
 			}
 			/* 
@@ -1329,7 +1332,7 @@ static int local_send(request_t *r, const char* buf, int buflen)
  			 * internal error. 
 			 */
 			else if (r->session && !r->is_get)
-				session_end(r->session, 1);
+				session_end(r->session, ERROR_NUM);
 		} else {
 			if (!ok) 
 			{
@@ -1372,7 +1375,7 @@ int recycle_thread(request_t *r)
 
 		if (r->session_end)
 		{
-			session_end(r->session, 0);
+			session_end(r->session, VALID_NUM);
 		}
 
 		if (last_send < 0)
@@ -1380,11 +1383,11 @@ int recycle_thread(request_t *r)
 			/* zstd error occurs */
 			if (last_send == -2)
 			{
-				request_end(r, 1, r->zstd_error);
+				request_end(r, ERROR_NUM, r->zstd_error);
 			}
 			else
 			{
-				request_end(r, 1, "gpfdist send data failure");
+				request_end(r, ERROR_NUM, "gpfdist send data failure");
 			}
 		}
 	}
@@ -1615,7 +1618,7 @@ session_get_block(const request_t* r, block_t* retblock, char* line_delim_str, i
 	if (session->is_error || 0 == session->fstream)
 	{
 		gprintln(NULL, "session_get_block: end session is_error: %d", session->is_error);
-		session_end(session, 0);
+		session_end(session, VALID_NUM);
 		return 0;
 	}
 
@@ -1630,7 +1633,7 @@ session_get_block(const request_t* r, block_t* retblock, char* line_delim_str, i
 	{
 		gprintln(NULL, "session_get_block: end session due to EOF");
 		gcb.read_bytes += fstream_get_compressed_size(session->fstream);
-		session_end(session, 0);
+		session_end(session, VALID_NUM);
 		return 0;
 	}
 
@@ -1640,7 +1643,7 @@ session_get_block(const request_t* r, block_t* retblock, char* line_delim_str, i
 	{
 		const char* ferror = fstream_get_error(session->fstream);
 		gwarning(NULL, "session_get_block end session due to %s", ferror);
-		session_end(session, 1);
+		session_end(session, ERROR_NUM);
 		return ferror;
 	}
 
@@ -1821,7 +1824,7 @@ static int session_attach(request_t* r)
 										r->tid, r->path))
 	{
 		http_error(r, FDIST_BAD_REQUEST, "path too long");
-		request_end(r, 1, 0);
+		request_end(r, ERROR_NUM, 0);
 		return -1;
 	}
 
@@ -1852,7 +1855,7 @@ static int session_attach(request_t* r)
 		{
 			gprintln(r, "got a final write request. skipping session creation");
 			http_empty(r);
-			request_end(r, 0, 0);
+			request_end(r, VALID_NUM, 0);
 			return -1;
 		}
 
@@ -1860,7 +1863,7 @@ static int session_attach(request_t* r)
 		{
 			gwarning(r, "out of memory");
 			http_error(r, FDIST_INTERNAL_ERROR, "internal error - out of memory");
-			request_end(r, 1, 0);
+			request_end(r, ERROR_NUM, 0);
 			return -1;
 		}
 
@@ -1896,7 +1899,7 @@ static int session_attach(request_t* r)
 				else
 				{
 					http_error(r, FDIST_BAD_REQUEST, "bad request, csvopt doesn't match the format");
-					request_end(r, 1, 0);
+					request_end(r, ERROR_NUM, 0);
 					return -1;
 				}
 			}
@@ -1936,7 +1939,7 @@ static int session_attach(request_t* r)
 		{
 			gwarning(r, "reject request from %s, path %s", r->peer, r->path);
 			http_error(r, response_code, response_string);
-			request_end(r, 1, 0);
+			request_end(r, ERROR_NUM, 0);
 			apr_pool_destroy(pool);
 			return -1;
 		}
@@ -1983,7 +1986,7 @@ static int session_attach(request_t* r)
 	if (session->is_error)
 	{
 		http_error(r, FDIST_INTERNAL_ERROR, "session error");
-		request_end(r, 1, 0);
+		request_end(r, ERROR_NUM, 0);
 		return -1;
 	}
 	/* session already ended. send an empty response, and close. */
@@ -1992,7 +1995,7 @@ static int session_attach(request_t* r)
 		gprintln(r, "session already ended. return empty response (OK)");
 
 		http_empty(r);
-		request_end(r, 0, 0);
+		request_end(r, VALID_NUM, 0);
 		return -1;
 	}
 
@@ -2005,7 +2008,7 @@ static int session_attach(request_t* r)
 	{
 		http_error(r, FDIST_BAD_REQUEST, "can\'t write to and read from the same "
 										 "gpfdist server simultaneously");
-		request_end(r, 1, 0);
+		request_end(r, ERROR_NUM, 0);
 		return -1;
 	}
 
@@ -2096,7 +2099,7 @@ static int send_proto_head(request_t *r)
 				if (errno == EPIPE || errno == ECONNRESET)
 					r->outblock.bot = r->outblock.top;
 				if (!r->is_running)
-					request_end(r, 1, "gpfdist send block header failure");
+					request_end(r, ERROR_NUM, "gpfdist send block header failure");
 				return -1;
 			}
 
@@ -2154,13 +2157,13 @@ static void do_write(int fd, short event, void* arg)
 
 			if (ferror)
 			{
-				request_end(r, 1, ferror);
+				request_end(r, ERROR_NUM, ferror);
 				gfile_printf_then_putc_newline("ERROR: %s", ferror);
 				return;
 			}
 			if (!r->outblock.top && r->outblock.ctop == r->outblock.cbot)
 			{
-				request_end(r, 0, 0);
+				request_end(r, VALID_NUM, 0);
 				return;
 			}
 		}
@@ -2208,11 +2211,11 @@ static void do_write(int fd, short event, void* arg)
 			/* zstd error occurs */
 			if (n == -2) 
 			{
-				request_end(r, 1, r->zstd_error);
+				request_end(r, ERROR_NUM, r->zstd_error);
 			}
 			else
 			{
-				request_end(r, 1, "gpfdist send data failure");
+				request_end(r, ERROR_NUM, "gpfdist send data failure");
 			}
 			return;
 		}
@@ -2239,7 +2242,7 @@ static void do_write(int fd, short event, void* arg)
 
 	/* Set up for this routine to be called again */
 	if (setup_write(r))
-		request_end(r, 1, 0);
+		request_end(r, ERROR_NUM, 0);
 }
 
 /*
@@ -2287,7 +2290,7 @@ static void do_read_request(int fd, short event, void* arg)
 	{
 		gwarning(r, "do_read_request time out");
 		http_error(r, FDIST_TIMEOUT, "time out");
-		request_end(r, 1, 0);
+		request_end(r, ERROR_NUM, 0);
 		return;
 	}
 
@@ -2313,7 +2316,7 @@ static void do_read_request(int fd, short event, void* arg)
 	{
 		gwarning(r, "do_read_request internal error. max: %d, top: %d", r->in.hbufmax, r->in.hbuftop);
 		http_error(r, FDIST_INTERNAL_ERROR, "internal error");
-		request_end(r, 1, 0);
+		request_end(r, ERROR_NUM, 0);
 		return;
 	}
 
@@ -2332,7 +2335,7 @@ static void do_read_request(int fd, short event, void* arg)
 		gwarning(r, "do_read_request receive failed. errno: %d, msg: %s", errno, strerror(errno));
 		if (!ok)
 		{
-			request_end(r, 1, 0);
+			request_end(r, ERROR_NUM, 0);
 			return;
 		}
 	}
@@ -2340,7 +2343,7 @@ static void do_read_request(int fd, short event, void* arg)
 	{
 		/* socket close by peer will return 0 */
 		gwarning(r, "do_read_request receive failed. socket closed by peer. errno: %d, msg: %s", errno, strerror(errno));
-		request_end(r, 1, 0);
+		request_end(r, ERROR_NUM, 0);
 		return;
 	}
 	else
@@ -2354,7 +2357,7 @@ static void do_read_request(int fd, short event, void* arg)
 			/* not available, but headerbuf is full - send error and close */
 			gwarning(r, "do_read_request bad request");
 			http_error(r, FDIST_BAD_REQUEST, "forbidden");
-			request_end(r, 1, 0);
+			request_end(r, ERROR_NUM, 0);
 			return;
 		}
 	}
@@ -2369,7 +2372,7 @@ static void do_read_request(int fd, short event, void* arg)
 		{
 			gwarning(r, "do_read_request, failed to read a complete request");
 			http_error(r, FDIST_INTERNAL_ERROR, "internal error");
-			request_end(r, 1, 0);
+			request_end(r, ERROR_NUM, 0);
 		}
 		return;
 	}
@@ -2408,7 +2411,7 @@ static void do_read_request(int fd, short event, void* arg)
 	if (!strcmp(path, "/gpfdist/status"))
 	{
 		send_gpfdist_status(r);
-		request_end(r, 0, 0);
+		request_end(r, VALID_NUM, 0);
 		return;
 	}
 
@@ -2598,7 +2601,7 @@ static void do_accept(int fd, short event, void* arg)
 	if (setup_read(r))
 	{
 		http_error(r, FDIST_INTERNAL_ERROR, "internal error");
-		request_end(r, 1, 0);
+		request_end(r, ERROR_NUM, 0);
 	}
 
 	return;
@@ -3355,14 +3358,14 @@ static void handle_get_request(request_t *r)
 	{
 		gwarning(r, "handle_get_request failed to setup write handler");
 		http_error(r, FDIST_INTERNAL_ERROR, "internal error");
-		request_end(r, 1, 0);
+		request_end(r, ERROR_NUM, 0);
 		return;
 	}
 
 	if (0 != http_ok(r))
 	{
 		gwarning(r, "handle_get_request failed to send HTTP OK");
-		request_end(r, 1, 0);
+		request_end(r, ERROR_NUM, 0);
 	}
 }
 
@@ -3388,7 +3391,7 @@ int check_output_to_file(request_t *r, int wrote)
 		/* write error */
 		gwarning(r, "handle_post_request, write error: %s", fstream_get_error(session->fstream));
 		http_error(r, FDIST_INTERNAL_ERROR, fstream_get_error(session->fstream));
-		request_end(r, 1, 0);
+		request_end(r, ERROR_NUM, 0);
 		return -1;
 	}
 	else if (wrote == *buftop)
@@ -3467,7 +3470,7 @@ static void handle_post_request(request_t *r, int header_end)
 #endif
 				http_error(r, FDIST_BAD_REQUEST, "invalid request due to missing sequence number");
 				gwarning(r, "got an request missing sequence number");
-				request_end(r, 1, 0);
+				request_end(r, ERROR_NUM, 0);
 				return;
 			} 
 			else 
@@ -3501,7 +3504,7 @@ static void handle_post_request(request_t *r, int header_end)
 #endif
 				http_error(r, FDIST_BAD_REQUEST, "invalid request due to wrong sequence number");
 				gwarning(r, "got an out of order request");
-				request_end(r, 1, 0);
+				request_end(r, ERROR_NUM, 0);
 				return;
 			}
 	}
@@ -3553,7 +3556,7 @@ static void handle_post_request(request_t *r, int header_end)
 				{
 					/* write error */
 					http_error(r, FDIST_INTERNAL_ERROR, fstream_get_error(session->fstream));
-					request_end(r, 1, 0);
+					request_end(r, ERROR_NUM, 0);
 					return;
 				}
 			}
@@ -3591,7 +3594,7 @@ static void handle_post_request(request_t *r, int header_end)
 			{
 				gwarning(r, "handle_post_request receive errno: %d, msg: %s", e, strerror(e));
 			    http_error(r, FDIST_INTERNAL_ERROR, "internal error");
-				request_end(r, 1, 0);
+				request_end(r, ERROR_NUM, 0);
 				return;
 			}
 		}
@@ -3599,7 +3602,7 @@ static void handle_post_request(request_t *r, int header_end)
 		{
 			/* socket close by peer will return 0 */
 			gwarning(r, "handle_post_request socket closed by peer");
-			request_end(r, 1, 0);
+			request_end(r, ERROR_NUM, 0);
 			return;
 		}
 		else
@@ -3649,9 +3652,9 @@ done_processing_request:
 
 	/* send our success response and end the request */
 	if (0 != http_ok(r))
-		request_end(r, 1, 0);
+		request_end(r, ERROR_NUM, 0);
 	else
-		request_end(r, 0, 0); /* we're done! */
+		request_end(r, VALID_NUM, 0); /* we're done! */
 
 }
 
@@ -3692,7 +3695,7 @@ static int request_set_path(request_t *r, const char* d, char* p, char* pp, char
 	if (!r->path)
 	{
 		http_error(r, FDIST_BAD_REQUEST, "invalid request (unable to set path)");
-		request_end(r, 1, 0);
+		request_end(r, ERROR_NUM, 0);
 		return -1;
 	}
 
@@ -3737,7 +3740,7 @@ static int request_path_validate(request_t *r, const char* path)
 						warn_msg);
 
 		http_error(r, FDIST_BAD_REQUEST, http_err_msg);
-		request_end(r, 1, 0);
+		request_end(r, ERROR_NUM, 0);
 		return -1;
 	}
 
@@ -3751,14 +3754,14 @@ static int request_validate(request_t *r)
 	{
 		gprintln(r, "reject invalid request from %s", r->peer);
 		http_error(r, FDIST_BAD_REQUEST, "invalid request");
-		request_end(r, 1, 0);
+		request_end(r, ERROR_NUM, 0);
 		return -1;
 	}
 	if (0 != strncmp("HTTP/1.", r->in.req->argv[2], 7))
 	{
 		gprintln(r, "reject invalid protocol from %s [%s]", r->peer, r->in.req->argv[2]);
 		http_error(r, FDIST_BAD_REQUEST, "invalid request");
-		request_end(r, 1, 0);
+		request_end(r, ERROR_NUM, 0);
 		return -1;
 	}
 	if (0 != strcmp("GET", r->in.req->argv[0]) &&
@@ -3767,7 +3770,7 @@ static int request_validate(request_t *r)
 		gprintln(r, "reject invalid request from %s [%s %s]", r->peer,
 				r->in.req->argv[0], r->in.req->argv[1]);
 		http_error(r, FDIST_BAD_REQUEST, "invalid request");
-		request_end(r, 1, 0);
+		request_end(r, ERROR_NUM, 0);
 		return -1;
 	}
 
@@ -3849,7 +3852,7 @@ static int request_parse_gp_headers(request_t *r, int opt_g)
 			{
 				gwarning(r, "reject invalid request from %s, invalid EOL encoding: %s", r->peer, r->in.req->hvalue[i]);
 				http_error(r, FDIST_BAD_REQUEST, "invalid EOL encoding");
-				request_end(r, 1, 0);
+				request_end(r, ERROR_NUM, 0);
 				return -1;
 			}
 			r->line_delim_str = r->in.req->hvalue[i];
@@ -3868,7 +3871,7 @@ static int request_parse_gp_headers(request_t *r, int opt_g)
 			{
 				gwarning(r, "reject invalid request from %s, invalid sequence number: %s", r->peer, r->in.req->hvalue[i]);
 				http_error(r, FDIST_BAD_REQUEST, "invalid sequence number");
-				request_end(r, 1, 0);
+				request_end(r, ERROR_NUM, 0);
 				return -1;
 			}
 		}
@@ -3904,7 +3907,7 @@ static int request_parse_gp_headers(request_t *r, int opt_g)
 		{
 			gwarning(r, "reject invalid request from %s, invalid EOL length: %d, EOL: %s", r->peer, r->line_delim_length, r->line_delim_str);
 			http_error(r, FDIST_BAD_REQUEST, "invalid EOL length");
-			request_end(r, 1, 0);
+			request_end(r, ERROR_NUM, 0);
 			return -1;
 		}
 	}
@@ -3928,7 +3931,7 @@ static int request_parse_gp_headers(request_t *r, int opt_g)
 			http_error(r, FDIST_BAD_REQUEST, "invalid request (invalid gp-proto)");
 		}
 
-		request_end(r, 1, 0);
+		request_end(r, ERROR_NUM, 0);
 		return -1;
 	}
 
@@ -3944,7 +3947,7 @@ static int request_parse_gp_headers(request_t *r, int opt_g)
 		gwarning(r, "reject invalid request from %s [%s %s] - missing X-GP-* header",
 				 r->peer, r->in.req->argv[0], r->in.req->argv[1]);
 		http_error(r, FDIST_BAD_REQUEST, "invalid request (missing X-GP-* header)");
-		request_end(r, 1, 0);
+		request_end(r, ERROR_NUM, 0);
 		return -1;
 	}
 	else
@@ -4011,7 +4014,7 @@ static int request_set_transform(request_t *r)
                      r->peer, r->in.req->argv[0], r->in.req->argv[1]);
             http_error(r, FDIST_BAD_REQUEST, "invalid request (unsupported output #transform)");
         }
-        request_end(r, 1, 0);
+        request_end(r, ERROR_NUM, 0);
         return -1;
     }
 
@@ -4039,7 +4042,7 @@ static int request_set_transform(request_t *r)
 			gprintln(r, "reject invalid request from %s [%s %s] - path does not match safe regex %s: %s",
 					 r->peer, r->in.req->argv[0], r->in.req->argv[1], safe, buf);
 			http_error(r, FDIST_BAD_REQUEST, "invalid request (path does not match safe regex)");
-			request_end(r, 1, 0);
+			request_end(r, ERROR_NUM, 0);
 			return -1;
 		}
 		else
@@ -4066,7 +4069,7 @@ static int request_set_transform(request_t *r)
 			gprintln(r, "request failed from %s [%s %s] - failed to get temporary directory for stderr",
 					 r->peer, r->in.req->argv[0], r->in.req->argv[1]);
 			http_error(r, FDIST_INTERNAL_ERROR, "internal error");
-			request_end(r, 1, 0);
+			request_end(r, ERROR_NUM, 0);
 			return -1;
 		}
 
@@ -4076,7 +4079,7 @@ static int request_set_transform(request_t *r)
 			gprintln(r, "request failed from %s [%s %s] - failed to create temporary file for stderr",
 					 r->peer, r->in.req->argv[0], r->in.req->argv[1]);
 			http_error(r, FDIST_INTERNAL_ERROR, "internal error");
-			request_end(r, 1, 0);
+			request_end(r, ERROR_NUM, 0);
 			return -1;
 		}
 
@@ -5046,7 +5049,7 @@ int decompress_write_loop(request_t *r)
 		if (res < 0)
 		{
 			http_error(r, FDIST_INTERNAL_ERROR, r->zstd_error);
-			request_end(r, 1, 0);
+			request_end(r, ERROR_NUM, 0);
 			return res;
 		}
 

--- a/src/bin/gpfdist/gpfdist.c
+++ b/src/bin/gpfdist/gpfdist.c
@@ -540,14 +540,19 @@ static void block_fill_header(const request_t *r, block_t* b,
 
 static unsigned short get_client_port(address_t *clientInformation)
 {
-	//check the family version of client IP address, so you
-	//can know where to cast, either to sockaddr_in or sockaddr_in6
-	//and then grab the port after casting
+	/* 
+	 * check the family version of client IP address, so you
+	 * can know where to cast, either to sockaddr_in or sockaddr_in6
+	 * and then grab the port after casting
+	 */
 	struct sockaddr *sa = (struct sockaddr *)clientInformation;
-	if (sa->sa_family == AF_INET) {
+	if (sa->sa_family == AF_INET) 
+	{
 		struct sockaddr_in *ipv4 = (struct sockaddr_in *)clientInformation;
 		return ipv4->sin_port;
-	} else {
+	} 
+	else 
+	{
 		struct sockaddr_in6 *ipv6 = (struct sockaddr_in6 *)clientInformation;
 		return ipv6->sin6_port;
 	}
@@ -771,7 +776,8 @@ static void parse_command_line(int argc, const char* const argv[],
 			opt.compress = 1;
 			break;
 		case 259:
-			if (atoi(arg) <= 0) {
+			if (atoi(arg) <= 0) 
+			{
 				usage_error("The number of thread must be more than zero!", 0);
 				break;
 			}
@@ -1040,7 +1046,8 @@ static void log_gpfdist_status()
 		void *entry;
 		apr_hash_this(hi, 0, 0, &entry);
 		session_t *s = (session_t*) entry;
-		if (s == NULL) {
+		if (s == NULL) 
+		{
 			gprint(NULL, "session %d: NULL\n", i);
 			continue;
 		}
@@ -1058,7 +1065,8 @@ static void log_gpfdist_status()
 		void *entry;
 		apr_hash_this(hi, 0, 0, &entry);
 		session_t *s = (session_t*) entry;
-		if (s == NULL) {
+		if (s == NULL) 
+		{
 			continue;
 		}
 		(void) apr_snprintf(buf, sizeof(buf),
@@ -1080,7 +1088,7 @@ static void log_gpfdist_status()
 			void *entry;
 			apr_hash_this(hj,0,0,&entry);
 			request_t *r = (request_t*) entry;
-			if(r == NULL)
+			if (r == NULL)
 			{
 				continue;
 			}
@@ -1313,17 +1321,22 @@ static int local_send(request_t *r, const char* buf, int buflen)
 					session_end(r->session, 0);
 				}
 			}
-			/* For post requests, the error msg may not be transmited
+			/* 
+			 * For post requests, the error msg may not be transmited
  			 * to the client side because of network failure. So the
  			 * session has to be set an error to inform the client
  			 * through the following request response with an
- 			 * internal error. */
+ 			 * internal error. 
+			 */
 			else if (r->session && !r->is_get)
 				session_end(r->session, 1);
 		} else {
-			if (!ok) {
+			if (!ok) 
+			{
 				gwarning(r, "gpfdist_send failed - due to (%d: %s)", e, strerror(e));
-			} else {
+			} 
+			else 
+			{
 				gdebug(r, "gpfdist_send failed - due to (%d: %s), should try again", e, strerror(e));
 			}
 		}
@@ -1343,7 +1356,8 @@ int wait_for_thread_join(request_t *r)
 	return r->send_size;
 }
 
-/* The function used in multi-thread mode. The responsibility of the function is 
+/* 
+ * The function used in multi-thread mode. The responsibility of the function is 
  * to wait for the end of the thread that serves the current request and check the
  * result of the data transmission. If there is unexpected returned value, it will
  * handle the error case.
@@ -1361,7 +1375,7 @@ int recycle_thread(request_t *r)
 			session_end(r->session, 0);
 		}
 
-		if(last_send < 0)
+		if (last_send < 0)
 		{
 			/* zstd error occurs */
 			if (last_send == -2)
@@ -1382,14 +1396,17 @@ local_send_with_zstd(request_t *r)
 {
 	size_t send_size = 0;
 #ifndef WIN32
-	if(opt.multi_thread){
+	if (opt.multi_thread)
+	{
 		sem_wait(&THREAD_NUM);
 		int err = pthread_create(&r->thread_id, 0, send_compression_data, r);
-		/* It is very confusing error. To avoid repeated calling of creating thread,
+		/* 
+		 * It is very confusing error. To avoid repeated calling of creating thread,
 		 * stopping current request and informing gpdb to abort the data scan is
 		 * necessary. 
 		 */
-		if (err) {
+		if (err) 
+		{
 			gwarning(r, "pthread_create failed with error code %d.\n", err);
 			sem_post(&THREAD_NUM);
 			return -1;
@@ -1412,7 +1429,8 @@ void* send_compression_data (void *req)
 {
 	request_t *r = (request_t *)req;
 
-	/* osize indicates the size to be compressed. But we don't use 
+	/* 
+	 * osize indicates the size to be compressed. But we don't use 
 	 * 'r->outblock.top - r->outblock.bot' to get osize since r->outblock.bot
 	 * is not a thread-safe variable. And osize is only used in the case where
 	 * r->outblock.bot equals 0. Thus, Either osize is unnecessary, or 
@@ -1425,7 +1443,7 @@ void* send_compression_data (void *req)
 	block_t *outblock = &r->outblock;
 	char *buf = outblock->cdata;
 
-	if(outblock->ctop == outblock->cbot)
+	if (outblock->ctop == outblock->cbot)
 	{
 		res = compress_zstd(r, outblock, osize);
 		if (res < 0)
@@ -1459,7 +1477,7 @@ void* send_compression_data (void *req)
 				r->segid, outblock->cbot, outblock->ctop, res);
 
 	int send = local_send(r, buf, res);
-	if(send < 0)
+	if (send < 0)
 	{
 		r->send_size = send;
 		goto return_block;
@@ -1469,7 +1487,7 @@ void* send_compression_data (void *req)
 
 return_block:
 #ifndef WIN32
-	if(opt.multi_thread)
+	if (opt.multi_thread)
 		sem_post(&THREAD_NUM);
 #endif
 	return NULL;
@@ -1721,14 +1739,15 @@ static void session_detach(request_t* r)
 			 * when we're done writing. (only in write operations, not in read).
 			 */
 #ifdef WIN32
-			if(!fstream_is_win_pipe(session->fstream))
+			if (!fstream_is_win_pipe(session->fstream))
 			{
 				session_free(session);
 				return;
 			}
 #endif
 
-			if (opt.w == 0) {
+			if (opt.w == 0) 
+			{
 				session_free(session);
 				return;
 			}
@@ -1854,22 +1873,28 @@ static int session_attach(request_t* r)
 			int quote = 0;
 			int escape = 0;
 			int eol_type = 0;
-			/* csvopt is different in gp4 and later version */
-			/* for gp4, csv opt is like "mxqnh"; for later version of gpdb, csv opt is like "mxqhn" */
-			/* we check the number of successful match here to make sure eol_type and header is right */
-			if ( strcmp(r->csvopt, "") != 0 ){  //writable external table doesn't have csvopt
+			/* 
+			 * csvopt is different in gp4 and later version
+			 * for gp4, csvopt is like "mxqnh"; for later version of gpdb, csvopt is like "mxqhn"
+			 * we check the number of successful match here to make sure eol_type and header are right
+			 */
+			if ( strcmp(r->csvopt, "") != 0 )
+			{  /* writable external table doesn't have csvopt */
 				int n = sscanf(r->csvopt, "m%dx%dq%dn%dh%d", &fstream_options.is_csv, &escape,
 						&quote, &eol_type, &fstream_options.header);
-				if (n!=5){
+				if (n != 5)
+				{
 					n = sscanf(r->csvopt, "m%dx%dq%dh%dn%d", &fstream_options.is_csv, &escape,
 						&quote, &fstream_options.header, &eol_type);
 				}
-				if (n==5){
+				if (n == 5)
+				{
 					fstream_options.quote = quote;
 					fstream_options.escape = escape;
 					fstream_options.eol_type = eol_type;
 				}
-				else{
+				else
+				{
 					http_error(r, FDIST_BAD_REQUEST, "bad request, csvopt doesn't match the format");
 					request_end(r, 1, 0);
 					return -1;
@@ -1995,7 +2020,7 @@ static int session_attach(request_t* r)
 	r->session = session;
 	r->sid     = session->id;
 
-	if(!session->is_get)
+	if (!session->is_get)
 		session_active_segs_dump(session);
 
 	return 0;
@@ -2007,7 +2032,7 @@ static int session_attach(request_t* r)
  */
 static void session_active_segs_dump(session_t* session)
 {
-	if(opt.v)
+	if (opt.v)
 	{
 		int i = 0;
 
@@ -2015,7 +2040,7 @@ static void session_active_segs_dump(session_t* session)
 
 		for (i = 0 ; i < session->maxsegs ; i++)
 		{
-			if(session->active_segids[i] == 1)
+			if (session->active_segids[i] == 1)
 				printf("%d ", i);
 		}
 		printf("\n");
@@ -2032,7 +2057,7 @@ static int session_active_segs_isempty(session_t* session)
 
 	for (i = 0 ; i < session->maxsegs ; i++)
 	{
-		if(session->active_segids[i] == 1)
+		if (session->active_segids[i] == 1)
 			return 0; /* not empty */
 	}
 
@@ -2065,9 +2090,9 @@ static int send_proto_head(request_t *r)
 			if (n < 0)
 			{
 				/*
-					* TODO: It is not safe to check errno here, should check and
-					* return special value in local_send()
-					*/
+				 * TODO: It is not safe to check errno here, should check and
+				 * return special value in local_send()
+				 */
 				if (errno == EPIPE || errno == ECONNRESET)
 					r->outblock.bot = r->outblock.top;
 				if (!r->is_running)
@@ -2102,7 +2127,8 @@ static void do_write(int fd, short event, void* arg)
 					  "and socket (%d)", fd, r->sock);
 
 #ifndef WIN32
-	/* It is essential to recycle threads before we read file.
+	/* 
+	 * It is essential to recycle threads before we read file.
 	 * Since session_get_block will change value of top and content
 	 * in outblock in request, main thread and sub thread will cause
 	 * data conflict in outblock. So when the thread servering this
@@ -2112,7 +2138,7 @@ static void do_write(int fd, short event, void* arg)
 	if (opt.multi_thread)
 	{
 		int res = recycle_thread(r);
-		if(res < 0)
+		if (res < 0)
 		{
 			return;
 		}
@@ -2181,7 +2207,8 @@ static void do_write(int fd, short event, void* arg)
 				r->outblock.bot = r->outblock.top;
 
 			/* zstd error occurs */
-			if (n == -2) {
+			if (n == -2) 
+			{
 				request_end(r, 1, r->zstd_error);
 			}
 			else
@@ -2223,7 +2250,8 @@ static void log_request_header(const request_t *r)
 {
 	int i;
 
-	if (opt.s) {
+	if (opt.s) 
+	{
 		return;
 	}
 
@@ -2395,22 +2423,22 @@ static void do_read_request(int fd, short event, void* arg)
 	}
 	else
 	{
-		if(request_set_path(r, opt.d, p, pp, path) != 0)
+		if (request_set_path(r, opt.d, p, pp, path) != 0)
 			return;
 	}
 
 	/* parse gp variables from the request */
-	if(request_parse_gp_headers(r, opt.g) != 0)
+	if (request_parse_gp_headers(r, opt.g) != 0)
 		return;
 
 #ifdef GPFXDIST
 	/* setup transform */
-	if(request_set_transform(r) != 0)
+	if (request_set_transform(r) != 0)
 		return;
 #endif
 
 	/* Attach the request to a session */
-	if(session_attach(r) != 0)
+	if (session_attach(r) != 0)
 		return;
 
 	if (r->is_get)
@@ -2459,9 +2487,11 @@ static void do_accept(int fd, short event, void* arg)
 		if ( (rd = SSL_accept(ssl) <= 0) )
 		{
 			handle_ssl_error(sock, sbio, ssl);
-			/* Close the socket that was allocated by accept 			*/
-			/* We also must perform this, in case that a user 			*/
-			/* accidentaly connected via gpfdist, instead of gpfdits	*/
+			/* 
+			 * Close the socket that was allocated by accept
+			 * We also must perform this, in case that a user
+			 * accidentally connected via gpfdist, instead of gpfdits	
+			 */
 			closesocket(sock);
 			return;
 		}
@@ -2603,7 +2633,6 @@ static int setup_write(request_t* r)
  * we expect to be reading either:
  * 1) a GET or PUT request. or,
  * 2) the body of a PUT request (the raw data from client).
- *
  */
 static int setup_read(request_t* r)
 {
@@ -2613,7 +2642,7 @@ static int setup_read(request_t* r)
 	event_del(&r->ev);
 	event_set(&r->ev, r->sock, EV_READ, do_read_request, r);
 
-	if(opt.t == 0)
+	if (opt.t == 0)
 	{
 		return (event_add(&r->ev, NULL)); /* no timeout */
 	}
@@ -2717,23 +2746,23 @@ print_addrinfo_list(struct addrinfo *head)
 static void
 signal_register()
 {
-    /* when SIGTERM raised invoke process_term_signal */
-    signal_set(&gcb.signal_event,SIGTERM,process_term_signal,0);
+	/* when SIGTERM raised invoke process_term_signal */
+	signal_set(&gcb.signal_event,SIGTERM,process_term_signal,0);
 
-    /* high priority so we accept as fast as possible */
-    if(event_priority_set(&gcb.signal_event, 0))
-        gwarning(NULL,"signal event priority set failed");
+	/* high priority so we accept as fast as possible */
+	if (event_priority_set(&gcb.signal_event, 0))
+		gwarning(NULL,"signal event priority set failed");
 
-    /* start watching this event */
-	if(signal_add(&gcb.signal_event, 0))
-        gfatal(NULL,"cannot set up event on signal register");
+	/* start watching this event */
+	if (signal_add(&gcb.signal_event, 0))
+		gfatal(NULL,"cannot set up event on signal register");
 
 }
 
 static void clear_listen_sock(void)
 {
 	SOCKET sock = -1;
-	while(gcb.listen_sock_count > 0)
+	while (gcb.listen_sock_count > 0)
 	{
 		sock = gcb.listen_socks[gcb.listen_sock_count-1];
 		closesocket(sock);
@@ -2841,11 +2870,12 @@ http_setup(void)
 			if (fcntl(f, F_SETFD, 1) == -1)
 				gfatal(NULL, "cannot create socket - fcntl(F_SETFD) failed");
 
-			/* For the Windows case, we could use SetHandleInformation to remove
-			 the HANDLE_INHERIT property from fd.
-			 But for our purposes this does not matter,
-			 as by default handles are *not* inherited. */
-
+			/* 
+			 * For the Windows case, we could use SetHandleInformation to remove
+			 * the HANDLE_INHERIT property from fd.
+			 * But for our purposes this does not matter,
+			 * as by default handles are *not* inherited. 
+			 */
 #endif
 			if (setsockopt(f, SOL_SOCKET, SO_KEEPALIVE, (void*) &on, sizeof(on)) == -1)
 			{
@@ -2876,7 +2906,7 @@ http_setup(void)
 				gwarning(NULL, "Setting SO_LINGER on socket failed");
 				continue;
 			}
-			if(rp->ai_family == AF_INET6)
+			if (rp->ai_family == AF_INET6)
 			{
 				if (setsockopt(f, IPPROTO_IPV6, IPV6_V6ONLY, (void*) &ipv6only_val, sizeof(ipv6only_val)) == -1)
 				{
@@ -2956,7 +2986,7 @@ http_setup(void)
 			/* don't need this any more */
 			freeaddrinfo(addrs);
 		}
-		if(create_failed)
+		if (create_failed)
 		{
 			clear_listen_sock();
 			create_failed = false;
@@ -3147,7 +3177,8 @@ static char* datetime_now(void)
 static int ggetpid()
 {
 	static int pid = 0;
-	if (pid == 0) {
+	if (pid == 0) 
+	{
 #ifdef WIN32
 		pid = GetCurrentProcessId();
 #else
@@ -3181,7 +3212,8 @@ void gprint(const request_t *r, const char *fmt, ...)
 
 void gprintln(const request_t *r, const char *fmt, ...)
 {
-	if (opt.s) {
+	if (opt.s) 
+	{
 		return;
 	}
 
@@ -3200,7 +3232,8 @@ void gprintlnif(const request_t *r, const char *fmt, ...)
 	if (r != NULL && ! r->is_get && ! opt.V)
 		return;
 
-	if (opt.s) {
+	if (opt.s) 
+	{
 		return;
 	}
 
@@ -3359,7 +3392,7 @@ int check_output_to_file(request_t *r, int wrote)
 		request_end(r, 1, 0);
 		return -1;
 	}
-	else if(wrote == *buftop)
+	else if (wrote == *buftop)
 	{
 		/* wrote the whole buffer. clean it for next round */
 		*buftop = 0;
@@ -3393,28 +3426,29 @@ static void handle_post_request(request_t *r, int header_end)
 	 * This is all that a "done" request should do. no data to process.
 	 * we send our success response and end the request.
 	 */
-	if(r->is_final)
+	if (r->is_final)
 		goto done_processing_request;
 
-	for(i = 0 ; i < h_count ; i++)
+	for (i = 0; i < h_count; i++)
 	{
 		/* the request include a "Expect: 100-continue" header? */
-		if(strcmp("Expect", h_names[i]) == 0 && strcmp("100-continue", h_values[i]) == 0)
+		if (strcmp("Expect", h_names[i]) == 0 && strcmp("100-continue", h_values[i]) == 0)
 			b_continue = 1;
 
 		/* find out how long is our data by looking at "Content-Length" header*/
-		if(strcmp("Content-Length", h_names[i]) == 0)
+		if (strcmp("Content-Length", h_names[i]) == 0)
 			r->in.davailable = atoi(h_values[i]);
 	}
 
 	/* if client asked for 100-Continue, send it. otherwise, move on. */
-	if(b_continue)
+	if (b_continue)
 		http_continue(r);
 
 	gdebug(r, "available data to consume %d, starting at offset %d",
 		   r->in.davailable, r->in.hbuftop);
 
-	switch (r->seq ) {
+	switch (r->seq ) 
+	{
 		case OPEN_SEQ:
 			/* sequence number is 1, it's the first OPEN request */
 			session->seq_segs[r->segid] = r->seq;
@@ -3422,7 +3456,8 @@ static void handle_post_request(request_t *r, int header_end)
 
 		case NO_SEQ:
 			/* don't have sequence number */
-			if (session->seq_segs[r->segid] > 0) {
+			if (session->seq_segs[r->segid] > 0) 
+			{
 				/* missing sequence number */
 #ifdef WIN32
 				gprintln(r, "got an request missing sequence number, expected sequence number is %ld.",
@@ -3435,7 +3470,9 @@ static void handle_post_request(request_t *r, int header_end)
 				gwarning(r, "got an request missing sequence number");
 				request_end(r, 1, 0);
 				return;
-			} else {
+			} 
+			else 
+			{
 				/* old version GPDB, don't have sequence number */
 				break;
 			}
@@ -3452,7 +3489,9 @@ static void handle_post_request(request_t *r, int header_end)
 					r->seq);
 #endif
 				goto done_processing_request;
-			} else if (session->seq_segs[r->segid] != r->seq - 1) {
+			} 
+			else if (session->seq_segs[r->segid] != r->seq - 1) 
+			{
 				/* out of order DATA request, ignore it*/
 #ifdef WIN32
 				gprintln(r, "got an out of order request, sequence number is %ld, expected sequence number is %ld.",
@@ -3478,16 +3517,18 @@ static void handle_post_request(request_t *r, int header_end)
 
 	/* if some data come along with the request, copy it first */
 	data_start = strstr(r->in.hbuf, "\r\n\r\n");
-	if(data_start)
+	if (data_start)
 	{
 		data_start += 4;
 		data_bytes_in_req = (r->in.hbuf + r->in.hbuftop) - data_start;
 	}
 
-	if(data_bytes_in_req > 0)
+	if (data_bytes_in_req > 0)
 	{
-		/* we have data after the request headers. consume it */
-		/* should make sure r->in.dbuftop + data_bytes_in_req <  r->in.dbufmax */
+		/* 
+		 * we have data after the request headers. consume it
+		 * should make sure r->in.dbuftop + data_bytes_in_req <  r->in.dbufmax 
+		 */
 
 		memcpy(r->in.dbuf, data_start, data_bytes_in_req);
 		r->in.dbuftop += data_bytes_in_req;
@@ -3495,7 +3536,7 @@ static void handle_post_request(request_t *r, int header_end)
 		r->in.davailable -= data_bytes_in_req;
 
 		/* only write it out if no more data is expected */
-		if(r->in.davailable == 0)
+		if (r->in.davailable == 0)
 		{
 #ifdef USE_ZSTD
 			if (r->zstd)
@@ -3524,7 +3565,7 @@ static void handle_post_request(request_t *r, int header_end)
 	 * we've consumed all data that came in the first buffer (with the request)
 	 * if we're still expecting more data, get it from socket now and process it.
 	 */
-	while(r->in.davailable > 0)
+	while (r->in.davailable > 0)
 	{
 		size_t want;
 		ssize_t n = 0;
@@ -3564,7 +3605,7 @@ static void handle_post_request(request_t *r, int header_end)
 		}
 		else
 		{
-			/*gprint("received %d bytes from client\n", n);*/
+			/* gprint("received %d bytes from client\n", n); */
 
 			r->bytes += n;
 			r->last = apr_time_now();
@@ -3748,7 +3789,7 @@ static bool base16_decode(char* data)
 		buf[1] = encoded_bytes[1];
 		char *endptr = NULL;
 		char ch = strtoul(buf, &endptr, 16);
-		if(*endptr != '\0')
+		if (*endptr != '\0')
 		{
 			return false;
 		}
@@ -3823,8 +3864,8 @@ static int request_parse_gp_headers(request_t *r, int opt_g)
 		else if (0 == strcasecmp("X-GP-SEQ", r->in.req->hname[i]))
 		{
 			r->seq = atol(r->in.req->hvalue[i]);
-			/* sequence number starting from 1 */
-			if(r->seq <= 0)
+			/* sequence number starts from 1 */
+			if (r->seq <= 0)
 			{
 				gwarning(r, "reject invalid request from %s, invalid sequence number: %s", r->peer, r->in.req->hvalue[i]);
 				http_error(r, FDIST_BAD_REQUEST, "invalid sequence number");
@@ -3942,9 +3983,7 @@ static int request_set_transform(request_t *r)
 	char* start = strstr(r->path, param);
 	if (start)
 	{
-		/*
-		 * we have a transformation request encoded in the url
-		 */
+		/* we have a transformation request encoded in the url */
 		*start = 0;
 		if (! r->trans.name)
 			r->trans.name = start + strlen(param);
@@ -4074,7 +4113,7 @@ int gpfdist_init(int argc, const char* const argv[])
 	if (0 != apr_pool_create(&gcb.pool, 0))
 		gfatal(NULL, "apr_app_initialize failed");
 
-	//apr_signal_init(gcb.pool);
+	/* apr_signal_init(gcb.pool); */
 
 	gcb.session.tab = apr_hash_make(gcb.pool);
 
@@ -4200,7 +4239,8 @@ void  ServiceMain(int argc, char** argv);
 void  ControlHandler(DWORD request);
 
 
-/* gpfdist service registration on the WINDOWS command line
+/* 
+ * gpfdist service registration on the WINDOWS command line
  * sc create gpfdist binpath= "c:\temp\gpfdist.exe param1 param2 param3"
  * sc delete gpfdist
  */
@@ -4214,7 +4254,7 @@ void report_event(LPCTSTR _error_msg)
 
 	hEventSource = RegisterEventSource(NULL, TEXT("gpfdist"));
 
-	if( NULL != hEventSource )
+	if (NULL != hEventSource)
 	{
 		memcpy(Buffer, _error_msg, 100);
 
@@ -4270,7 +4310,8 @@ void init_cmd_buffer(int argc, const char* const argv[])
 		memset(cmd_line_buffer[i], 0, CMD_LINE_ARG_SIZE);
 	}
 
-	/* 2. the number of variables cannot be higher than a
+	/* 
+	 * 2. the number of variables cannot be higher than a
 	 *    a predifined const, that is because - down the line
 	 *    this values get to a const buffer whose size is
 	 *    defined at compile time
@@ -4448,7 +4489,7 @@ void ServiceMain(int argc, char** argv)
 
 void ControlHandler(DWORD request)
 {
-	switch(request)
+	switch (request)
 	{
 		case SERVICE_CONTROL_STOP:
 		case SERVICE_CONTROL_SHUTDOWN:
@@ -4477,7 +4518,8 @@ static SSL_CTX *initialize_ctx(void)
 	char 		*fileName, slash;
 	SSL_CTX 	*ctx;
 
-	if (!gcb.bio_err){
+	if (!gcb.bio_err)
+	{
 		/* Global system initialization*/
 		SSL_library_init();
 		SSL_load_error_strings();
@@ -4559,14 +4601,18 @@ static SSL_CTX *initialize_ctx(void)
 		}
 	}
 
-	/* Set the verification flags for ctx 	*/
-	/* We always require client certificate	*/
+	/* 
+	 * Set the verification flags for ctx
+	 * We always require client certificate
+	 */
 	SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT, 0);
 
-	/* Consider using these - experinments on Mac showed no improvement,
+	/* 
+	 * Consider using these - experinments on Mac showed no improvement,
 	 * but perhaps it will on other platforms, or when opt.m is very big
 	 */
-	//SSL_CTX_set_mode(ctx, SSL_MODE_AUTO_RETRY | SSL_MODE_ENABLE_PARTIAL_WRITE);
+
+	/* SSL_CTX_set_mode(ctx, SSL_MODE_AUTO_RETRY | SSL_MODE_ENABLE_PARTIAL_WRITE); */
 
 	free(fileName);
 	return ctx;
@@ -4618,8 +4664,10 @@ static int gpfdist_SSL_send(const request_t *r, const void *buf, const size_t bu
 			}
 			else
 			{
-				/* If errno == EPIPE, it means that the client has closed the connection   	*/
-				/* This error will be handled in the calling function, do not print it here	*/
+				/* 
+				 * If errno == EPIPE, it means that the client has closed the connection
+				 * This error will be handled in the calling function, do not print it here
+				 */
 				if (errno != EPIPE)
 				{
 					gwarning(r, "Error during SSL gpfdist_send (Error = %d. errno = %d)", SSL_get_error(r->ssl,n), (int)errno);
@@ -4681,14 +4729,14 @@ static int gpfdist_SSL_receive(const request_t *r, void *buf, const size_t bufle
  */
 static void free_SSL_resources(const request_t *r)
 {
-	//send close_notify to client
-	SSL_shutdown(r->ssl);  //or BIO_ssl_shutdown(r->ssl_bio);
+	/* send close_notify to client */
+	SSL_shutdown(r->ssl);  /* or BIO_ssl_shutdown(r->ssl_bio); */
 
 	request_shutdown_sock(r);
 
-	BIO_vfree(r->io);  //ssl_bio is pushed to r->io list, so ssl_bio is freed too.
+	BIO_vfree(r->io);  /* ssl_bio is pushed to r->io list, so ssl_bio is freed too. */
 	BIO_vfree(r->sbio);
-	//BIO_vfree(r->ssl_bio);
+	/* BIO_vfree(r->ssl_bio); */
 	SSL_free(r->ssl);
 }
 
@@ -4732,7 +4780,7 @@ static void flush_ssl_buffer(int fd, short event, void* arg)
 	}
 	else
 	{
-		// Do ssl cleanup immediately.
+		/* Do ssl cleanup immediately. */
 		request_cleanup_and_free_SSL_resources(r);
 	}
 }
@@ -4844,15 +4892,15 @@ static void request_cleanup(request_t *r)
 	request_shutdown_sock(r);
 	setup_do_close(r);
 #ifdef USE_ZSTD
-	if(r->is_running)
+	if (r->is_running)
 		wait_for_thread_join(r);
 
-	if ( r->zstd && r->is_get )
+	if (r->zstd && r->is_get)
 	{
 		ZSTD_freeCCtx(r->zstd_cctx);
 		r->zstd_cctx = NULL;
 	}
-	if ( r->zstd && !r->is_get )
+	if (r->zstd && !r->is_get)
 	{
 		ZSTD_freeDCtx(r->zstd_dctx);
 		r->zstd_cctx = NULL;
@@ -4954,7 +5002,7 @@ static void* watchdog_thread(void* p)
 		duration = apr_time_sec(shutdown_time - apr_time_now());
 		if (duration > 0)
 			(void)sleep(duration);
-	} while(apr_time_now() < shutdown_time);
+	} while (apr_time_now() < shutdown_time);
 	gprintln(NULL, "Watchdog timer expired, abort gpfdist");
 	abort();
 }
@@ -5014,7 +5062,7 @@ int decompress_write_loop(request_t *r)
 			return -1;
 		}
 
-	} while(r->in.woffset);
+	} while (r->in.woffset);
 	return wrote_total;
 }
 
@@ -5031,7 +5079,8 @@ static int decompress_zstd(request_t* r, ZSTD_inBuffer* bin, ZSTD_outBuffer* bou
 
 	ret = ZSTD_decompressStream(r->zstd_dctx, bout, bin);
 	size_t const err = ret;
-	if(ZSTD_isError(err)){
+	if (ZSTD_isError(err))
+	{
 		snprintf(r->zstd_error, r->zstd_err_len, "zstd decompression error, error is %s", ZSTD_getErrorName(err));
 		gwarning(NULL, "%s", r->zstd_error);
 		return -1;
@@ -5039,17 +5088,20 @@ static int decompress_zstd(request_t* r, ZSTD_inBuffer* bin, ZSTD_outBuffer* bou
 	return bout->pos;
 }
 
-static int decompress_data(request_t* r, zstd_buffer *in, zstd_buffer *out){
+static int decompress_data(request_t* r, zstd_buffer *in, zstd_buffer *out)
+{
 	ZSTD_inBuffer inbuf = {in->buf , in->size, in->pos};
 	ZSTD_outBuffer obuf = {out->buf, out->size, out->pos};
 
-	if(!r->zstd_dctx) {
+	if (!r->zstd_dctx) 
+	{
 		gwarning(NULL, "%s", "Out of memory when ZSTD_createDCtx");
 		return -1;
 	}
 
 	int outSize = decompress_zstd(r, &inbuf, &obuf);
-	if(outSize < 0){
+	if (outSize < 0)
+	{
 		return outSize;
 	}
 
@@ -5065,11 +5117,11 @@ static int decompress_data(request_t* r, zstd_buffer *in, zstd_buffer *out){
 	gdebug(r, "decompress_zstd finished, input size = %d, output size = %d.", r->in.wbuftop, r->in.dbuftop);
 	return outSize;
 }
+
 /*
  * compress_zstd
  * It is for compressing data in buffer. Return value is the length of data after compression.
  */
-
 static int compress_zstd(const request_t *r, block_t *blk, int buflen)
 {
 	char *buf = blk->data;
@@ -5091,11 +5143,13 @@ static int compress_zstd(const request_t *r, block_t *blk, int buflen)
 		return -1;
 	}
 
-	while(cursor < buflen){
+	while (cursor < buflen)
+	{
 		int in_size = (buflen - cursor) > MAX_FRAME_SIZE ? MAX_FRAME_SIZE : (buflen - cursor);
 		ZSTD_inBuffer bin = {buf + cursor, in_size, 0};
 		int outpos = 0;
-		while(bin.pos < bin.size){
+		while (bin.pos < bin.size)
+		{
 			ZSTD_outBuffer bout = {blk->cdata + offset, OUT_BUFFER_SIZE - outpos, 0};
 			size_t res = ZSTD_compressStream(r->zstd_cctx, &bout, &bin);
 


### PR DESCRIPTION
There are 3 commits about polishing gpfdist in this pr.
Please review them one by one. Thanks.

**First commit afccfb48fa8ad1f47991fe335edfcd96a7ef04b5**
Apply standard C format code and comment. Such as:
- change comment from `//` to `/* */`
- change `if {` to 
```
if 
{
```
et. al

**Second commit 46bf222b12ed300960340b159ecf10d5c83132a6**
Reomve 2 unnecessary assignments, take one as an example
From
```
int res = recycle_thread(r);
if (res < 0)
```
To
```
if (recycle_thread(r) < 0)
```
 
**Third commit b3d84ecf702036c0f3fbca49b8826808e4871cc7**
- add `#define ERROR_CODE_SUCCESS 0` and `#define ERROR_CODE_GENERIC 1`
- rewrite `session_end(r->session, 0);` as `session_end(r->session, ERROR_CODE_SUCCESS);`
- rewrite `request_end(r, 0, 0);` as `request_end(r, ERROR_CODE_SUCCESS, 0);`

Signed-off-by: Yongtao Huang <yongtaoh@vmware.com>