### PR TITLE
Update MERGE_FIXME comment for `appendonly_rescan`

### DIFF
--- a/src/backend/access/aocs/aocsam_handler.c
+++ b/src/backend/access/aocs/aocsam_handler.c
@@ -661,6 +661,20 @@ aoco_endscan(TableScanDesc scan)
 	pfree(aocsBitmapScan->bitmapScanDesc[RECHECK].proj);
 }
 
+/* ----------------
+ * aoco_rescan - restart a relation scan
+ *
+ * GPDB_12_MERGE_FEATURE_NOT_SUPPORTED: When doing an initial rescan with `table_rescan`,
+ * the values for the new flags (introduced by Table AM API) are
+ * set to false. This means that whichever ScanOptions flags that were initially set will be
+ * used for the rescan. However with TABLESAMPLE, which is currently not
+ * supported for AO/CO, the new flags may be modified.
+ * Additionally, allow_sync, allow_strat, and allow_pagemode may
+ * need to be implemented for AO/CO in order to properly use them.
+ * You may view `syncscan.c` as an example to see how heap added scan
+ * synchronization support.
+ * ----------------
+ */
 static void
 aoco_rescan(TableScanDesc scan, ScanKey key,
                   bool set_params, bool allow_strat,

--- a/src/backend/access/appendonly/appendonlyam.c
+++ b/src/backend/access/appendonly/appendonlyam.c
@@ -1934,7 +1934,15 @@ appendonly_beginscan(Relation relation,
  * over and over see which of them can be refactored into appendonly_beginscan
  * and persist there until endscan is finally reached. For now this will do.
  *
- * GPDB_12_MERGE_FIXME: what to do with the new flags?
+ * GPDB_12_MERGE_FEATURE_NOT_SUPPORTED: When doing an initial rescan with `table_rescan`,
+ * the values for the new flags (introduced by Table AM API) are
+ * set to false. This means that whichever ScanOptions flags that were initially set will be
+ * used for the rescan. However with TABLESAMPLE, which is currently not
+ * supported for AO/CO, the new flags may be modified.
+ * Additionally, allow_sync, allow_strat, and allow_pagemode may
+ * need to be implemented for AO/CO in order to properly use them.
+ * You may view `syncscan.c` as an example to see how heap added scan
+ * synchronization support.
  * ----------------
  */
 void


### PR DESCRIPTION
Update the comment to mention that the flags are currently not supported for AO/CO. There will need to be additional work to implement the synchronized sequential scans, buffer strategy, and page mode for AO/CO. Furthermore, TABLESAMPLE, which is not implemented, is the only use case in which the ScanOptions flags are changed after the initial scan.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
