### PR TITLE
[6X] Only run GPDB upgrade checks against the coordinator segment

### DIFF
--- a/contrib/pg_upgrade/check.c
+++ b/contrib/pg_upgrade/check.c
@@ -114,9 +114,15 @@ check_and_dump_old_cluster(bool live_check, char **sequence_script_file_name)
 	check_for_isn_and_int8_passing_mismatch(&old_cluster);
 
 	/*
-	 * Check for various Greenplum failure cases
+	 * Check for various Greenplum failure cases. Since the target coordinator
+	 * segment's catalog is later copied over to instantiate the target
+	 * primary segments and none of the Greenplum upgrade checks are strictly
+	 * required to be run against the source cluster primary segments, only
+	 * run the Greenplum upgrade checks against the source coordinator
+	 * segment.
 	 */
-	check_greenplum();
+	if (is_greenplum_dispatcher_mode())
+		check_greenplum();
 
 	if (GET_MAJOR_VERSION(old_cluster.major_version) == 904 &&
 		old_cluster.controldata.cat_ver < JSONB_FORMAT_CHANGE_CAT_VER)


### PR DESCRIPTION
The GPDB upgrade checks can take a while to run and we found that they also run against every source primary segment during upgrade. The checks against the source primary segments are not needed since none of the checks are specific to primary segment issues and the target coordinator segment's catalog is used to initialize the target primary segments. Therefore, only run the GPDB upgrade checks against the source coordinator segment to prevent unnecessary work. The original Postgres upgrade checks are left alone since they run relatively quick and may also serve a second purpose in filling out some parts of the old_cluster object that may be needed for later.

Some extra PR notes:
* It is not known yet what type of GPDB checks will be required for 6-to-7 upgrade so this change is only for 5-to-6 upgrade. Once we start working for 6-to-7 upgrade, we can consider forward-porting this change or implementing something different entirely to match with the needs then.
* Most of the GPDB upgrade checks were fairly easy to rule out of being required to run on the primary segments (e.g. queries against pg_partition and validating view definitions).  The main one that had unknown upgrade consequences was orphaned TOAST tables... specifically if they existed on the primary segments.  However, some testing showed that they can be easily ignored since only the target coordinator segment's catalog is used and there were no source/target relfilenode_map diff errors after primary segment tablespace linking.