### PR TITLE
use root role to change the configuration of cgroup-v2

### DIFF
--- a/concourse/scripts/ic_gpdb_resgroup_v2.bash
+++ b/concourse/scripts/ic_gpdb_resgroup_v2.bash
@@ -17,6 +17,7 @@ enable_cgroup_subtree_control() {
     local basedir=$CGROUP_BASEDIR
 
     ssh -t $gpdb_host_alias sudo bash -ex <<EOF
+        sudo su
         chmod -R 777 $basedir/
         echo "+cpu" >> $basedir/cgroup.subtree_control
         echo "+cpuset" >> $basedir/cgroup.subtree_control


### PR DESCRIPTION
In recent times, the dev pipeline always failed at the `resource_group_v2_rhel8`.
After some investigations, I found we must use the root role to config Cgroup directly,
otherwise the `echo "+cpu" >> $basedir/cgroup.subtree_control` will failed.

So when we config the Cgroup-v2, use `sudo su` to change the role.