### PR TITLE
Refine IC proxy log messages

### DIFF
--- a/src/backend/cdb/motion/ic_proxy_addr.c
+++ b/src/backend/cdb/motion/ic_proxy_addr.c
@@ -169,7 +169,7 @@ ic_proxy_addr_on_getaddrinfo(uv_getaddrinfo_t *req,
 		}
 		else
 			elog(WARNING,
-						 "ic-proxy: seg%d,dbid%d: fail to resolve the hostname \"%s\":%s: %s",
+						 "ic-proxy: seg%d,dbid%d: failed to resolve the hostname \"%s\":%s: %s",
 						 addr->content, addr->dbid,
 						 addr->hostname, addr->service,
 						 uv_strerror(status));
@@ -203,7 +203,7 @@ ic_proxy_addr_on_getaddrinfo(uv_getaddrinfo_t *req,
 								 name, port, family);
 				else
 					elog(LOG,
-								 "ic-proxy: seg%d,dbid%d: resolved address %s:%s -> %s:%d family=%d (fail to extract the address: %s)",
+								 "ic-proxy: seg%d,dbid%d: resolved address %s:%s -> %s:%d family=%d (failed to extract the address: %s)",
 								 addr->content, addr->dbid,
 								 addr->hostname, addr->service,
 								 name, port, family,

--- a/src/backend/cdb/motion/ic_proxy_backend.c
+++ b/src/backend/cdb/motion/ic_proxy_backend.c
@@ -199,7 +199,7 @@ ic_proxy_backend_on_read_hello_ack(uv_stream_t *stream, ssize_t nread, const uv_
 
 	/* uv_fileno should not fail here */
 	if (ret < 0)
-		elog(ERROR, "backend %s: get connection fd failed: %s",
+		elog(ERROR, "ic-proxy: backend %s: get connection fd failed: %s",
 			 ic_proxy_key_to_str(&backend->key), uv_strerror(ret));
 
 	/* ic_tcp compatitble code to modify ChunkTransportStateEntry for receiver */
@@ -251,7 +251,7 @@ ic_proxy_backend_on_sent_hello(uv_write_t *req, int status)
 		return;
 	}
 
-	/* recieve hello ack */
+	/* receive hello ack */
 	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG1,
 		   "ic-proxy: backend %s: backend connected, receiving HELLO ACK",
 				 ic_proxy_key_to_str(&backend->key));

--- a/src/backend/cdb/motion/ic_proxy_client.c
+++ b/src/backend/cdb/motion/ic_proxy_client.c
@@ -325,7 +325,7 @@ ic_proxy_client_register(ICProxyClient *client)
 			 */
 			ic_proxy_free(placeholder);
 			elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG5,
-				   "%s: freed my placeholder",
+				   "ic-proxy: %s: freed my placeholder",
 						 ic_proxy_client_get_name(client));
 		}
 	}
@@ -380,7 +380,7 @@ ic_proxy_client_unregister(ICProxyClient *client)
 		if (client->pkts)
 		{
 			elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG3,
-				   "%s: transfer %d unhandled pkts to my successor",
+				   "ic-proxy: %s: transfer %d unhandled pkts to my successor",
 						 ic_proxy_client_get_name(client),
 						 list_length(client->pkts));
 
@@ -389,7 +389,7 @@ ic_proxy_client_unregister(ICProxyClient *client)
 		}
 
 		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_VERBOSE, LOG,
-			   "%s: re-register my successor",
+			   "ic-proxy: %s: re-register my successor",
 					 ic_proxy_client_get_name(client));
 
 		/* the successor must have not registered */
@@ -407,7 +407,7 @@ ic_proxy_client_unregister(ICProxyClient *client)
 		ICProxyClient *placeholder;
 
 		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG3,
-			   "%s: transfer %d unhandled pkts to my placeholder",
+			   "ic-proxy: %s: transfer %d unhandled pkts to my placeholder",
 					 ic_proxy_client_get_name(client),
 					 list_length(client->pkts));
 
@@ -511,7 +511,7 @@ ic_proxy_client_on_c2p_data(uv_stream_t *stream,
 	if (unlikely(nread < 0))
 	{
 		if (nread != UV_EOF)
-			elog(WARNING, "ic-proxy: %s: fail to receive c2p DATA: %s",
+			elog(WARNING, "ic-proxy: %s: failed to receive c2p DATA: %s",
 						 ic_proxy_client_get_name(client), uv_strerror(nread));
 		else
 			elogif(gp_log_interconnect >= GPVARS_VERBOSITY_VERBOSE, LOG,
@@ -565,7 +565,7 @@ ic_proxy_client_on_c2p_data(uv_stream_t *stream,
 					 ic_proxy_client_get_name(client), nread, client->state);
 
 	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG5,
-		   "%s: received DATA[%zd bytes] from the backend",
+		   "ic-proxy: %s: received DATA[%zd bytes] from the backend",
 				 ic_proxy_client_get_name(client), nread);
 
 	/*
@@ -685,7 +685,7 @@ ic_proxy_client_on_hello_pkt(void *opaque, const void *data, uint16 size)
 	}
 
 	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG1,
-		   "%s: received %s from the backend",
+		   "ic-proxy: %s: received %s from the backend",
 				 ic_proxy_client_get_name(client), ic_proxy_pkt_to_str(pkt));
 
 	client->state |= IC_PROXY_CLIENT_STATE_RECEIVED_HELLO;
@@ -722,7 +722,7 @@ ic_proxy_client_on_hello_data(uv_stream_t *stream,
 	if (unlikely(nread < 0))
 	{
 		if (nread != UV_EOF)
-			elog(WARNING, "ic-proxy: %s: fail to receive HELLO: %s",
+			elog(WARNING, "ic-proxy: %s: failed to receive HELLO: %s",
 						 ic_proxy_client_get_name(client), uv_strerror(nread));
 		else
 			elogif(gp_log_interconnect >= GPVARS_VERBOSITY_VERBOSE, LOG,
@@ -782,7 +782,7 @@ ic_proxy_client_read_data(ICProxyClient *client)
 
 	if (ret < 0)
 	{
-		elog(WARNING, "ic-proxy: %s: state=0x%08x: fail to start reading data: %s",
+		elog(WARNING, "ic-proxy: %s: state=0x%08x: failed to start reading data: %s",
 					 ic_proxy_client_get_name(client),
 					 client->state, uv_strerror(ret));
 
@@ -907,7 +907,7 @@ ic_proxy_client_on_close(uv_handle_t *handle)
 
 	client->state |= IC_PROXY_CLIENT_STATE_CLOSED;
 
-	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_VERBOSE, LOG, "%s: closed",
+	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_VERBOSE, LOG, "ic-proxy: %s: closed",
 		   ic_proxy_client_get_name(client));
 
 	ic_proxy_client_free(client);
@@ -973,11 +973,11 @@ ic_proxy_client_on_sent_c2p_bye(void *opaque, const ICProxyPkt *pkt, int status)
 		 * sent out.
 		 */
 		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_VERBOSE, LOG,
-			   "ic-proxy: %s: fail to shutdown c2p",
+			   "ic-proxy: %s: failed to shutdown c2p",
 					 ic_proxy_client_get_name(client));
 
 		/*
-		 * When we fail to send the BYE, should we trigger the shutdown_p2c
+		 * When we failed to send the BYE, should we trigger the shutdown_p2c
 		 * process immediately?
 		 */
 	}
@@ -1053,7 +1053,7 @@ ic_proxy_client_on_shutdown_p2c(uv_shutdown_t *req, int status)
 	ic_proxy_free(req);
 
 	if (status < 0)
-		elog(WARNING, "ic-proxy: %s: fail to shutdown p2c: %s",
+		elog(WARNING, "ic-proxy: %s: failed to shutdown p2c: %s",
 					 ic_proxy_client_get_name(client), uv_strerror(status));
 	else
 		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_VERBOSE, LOG,
@@ -1101,7 +1101,7 @@ ic_proxy_client_on_sent_c2p_resume(void *opaque,
 	if (status < 0)
 	{
 		/*
-		 * TODO: Fail to send the RESUME, should we retry instead of shutting
+		 * TODO: Failed to send the RESUME, should we retry instead of shutting
 		 * down?
 		 */
 		ic_proxy_client_shutdown_p2c(client);
@@ -1218,7 +1218,7 @@ ic_proxy_client_on_p2c_data(ICProxyClient *client, ICProxyPkt *pkt,
 		if (ic_proxy_pkt_is_out_of_date(pkt, &client->key))
 		{
 			elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG3,
-				   "%s: drop out-of-date %s",
+				   "ic-proxy: %s: drop out-of-date %s",
 						 ic_proxy_client_get_name(client),
 						 ic_proxy_pkt_to_str(pkt));
 			/* TODO: callback? */

--- a/src/backend/cdb/motion/ic_proxy_main.c
+++ b/src/backend/cdb/motion/ic_proxy_main.c
@@ -96,7 +96,7 @@ ic_proxy_server_on_new_peer(uv_stream_t *server, int status)
 	ret = uv_accept(server, (uv_stream_t *) &peer->tcp);
 	if (ret < 0)
 	{
-		elog(WARNING, "ic-proxy: fail to accept new peer: %s",
+		elog(WARNING, "ic-proxy: failed to accept new peer: %s",
 					 uv_strerror(ret));
 		ic_proxy_peer_free(peer);
 		return;
@@ -178,7 +178,7 @@ ic_proxy_server_peer_listener_init(uv_loop_t *loop)
 						 addr->hostname, addr->service, name, port, family);
 		else
 			elog(WARNING,
-						 "ic-proxy: setting up peer listener on %s:%s (%s:%d family=%d) (fail to extract the address: %s)",
+						 "ic-proxy: setting up peer listener on %s:%s (%s:%d family=%d) (failed to extract the address: %s)",
 						 addr->hostname, addr->service, name, port, family,
 						 uv_strerror(ret));
 	}
@@ -193,7 +193,7 @@ ic_proxy_server_peer_listener_init(uv_loop_t *loop)
 	ret = uv_tcp_bind(listener, (struct sockaddr *) &addr->sockaddr, 0);
 	if (ret < 0)
 	{
-		elog(WARNING, "ic-proxy: tcp: fail to bind: %s",
+		elog(WARNING, "ic-proxy: tcp: failed to bind: %s",
 					 uv_strerror(ret));
 		return;
 	}
@@ -202,7 +202,7 @@ ic_proxy_server_peer_listener_init(uv_loop_t *loop)
 					IC_PROXY_BACKLOG, ic_proxy_server_on_new_peer);
 	if (ret < 0)
 	{
-		elog(WARNING, "ic-proxy: tcp: fail to listen: %s",
+		elog(WARNING, "ic-proxy: tcp: failed to listen: %s",
 					 uv_strerror(ret));
 		return;
 	}
@@ -288,7 +288,7 @@ ic_proxy_server_on_new_client(uv_stream_t *server, int status)
 	ret = uv_accept(server, ic_proxy_client_get_stream(client));
 	if (ret < 0)
 	{
-		elog(WARNING, "ic-proxy: fail to accept new client: %s",
+		elog(WARNING, "ic-proxy: failed to accept new client: %s",
 					 uv_strerror(ret));
 		return;
 	}
@@ -328,7 +328,7 @@ ic_proxy_server_client_listener_init(uv_loop_t *loop)
 	if (ret < 0)
 	{
 		elog(WARNING,
-					 "ic-proxy: fail to init a client listener: %s",
+					 "ic-proxy: failed to init a client listener: %s",
 					 uv_strerror(ret));
 		return;
 	}
@@ -336,7 +336,7 @@ ic_proxy_server_client_listener_init(uv_loop_t *loop)
 	ret = uv_pipe_bind(listener, path);
 	if (ret < 0)
 	{
-		elog(WARNING, "ic-proxy: pipe: fail to bind(%s): %s",
+		elog(WARNING, "ic-proxy: pipe: failed to bind(%s): %s",
 					 path, uv_strerror(ret));
 		return;
 	}
@@ -345,7 +345,7 @@ ic_proxy_server_client_listener_init(uv_loop_t *loop)
 					IC_PROXY_BACKLOG, ic_proxy_server_on_new_client);
 	if (ret < 0)
 	{
-		elog(WARNING, "ic-proxy: pipe: fail to listen on path %s: %s",
+		elog(WARNING, "ic-proxy: pipe: failed to listen on path %s: %s",
 					 path, uv_strerror(ret));
 		return;
 	}

--- a/src/backend/cdb/motion/ic_proxy_peer.c
+++ b/src/backend/cdb/motion/ic_proxy_peer.c
@@ -164,7 +164,7 @@ ic_proxy_peer_unregister(ICProxyPeer *peer)
 		/* keep the peer as a placeholder */
 
 		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_VERBOSE, LOG,
-			   "ic-proxy %s: unregistered", peer->name);
+			   "ic-proxy: %s: unregistered", peer->name);
 
 		/* reset the state */
 		peer->state = 0;
@@ -323,7 +323,7 @@ ic_proxy_peer_on_data(uv_stream_t *stream, ssize_t nread, const uv_buf_t *buf)
 	if (unlikely(nread < 0))
 	{
 		if (nread != UV_EOF)
-			elog(WARNING, "ic-proxy: %s: fail to receive DATA: %s",
+			elog(WARNING, "ic-proxy: %s: failed to receive DATA: %s",
 						 peer->name, uv_strerror(nread));
 		else
 			elogif(gp_log_interconnect >= GPVARS_VERBOSITY_VERBOSE, LOG,
@@ -421,7 +421,7 @@ ic_proxy_peer_on_close(uv_handle_t *handle)
 	ICProxyPeer *peer = CONTAINER_OF((void *) handle, ICProxyPeer, tcp);
 
 	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_VERBOSE, LOG,
-		   "%s: closed", peer->name);
+		   "ic-proxy: %s: closed", peer->name);
 
 	/* reset the state */
 	peer->state = 0;
@@ -462,7 +462,7 @@ ic_proxy_peer_on_shutdown(uv_shutdown_t *req, int status)
 	ic_proxy_free(req);
 
 	if (status < 0)
-		elog(WARNING, "ic-proxy: %s: fail to shutdown: %s",
+		elog(WARNING, "ic-proxy: %s: failed to shutdown: %s",
 					 peer->name, uv_strerror(status));
 
 	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_VERBOSE, LOG,
@@ -599,7 +599,7 @@ ic_proxy_peer_on_hello_data(uv_stream_t *stream,
 	if (unlikely(nread < 0))
 	{
 		if (nread != UV_EOF)
-			elog(WARNING, "ic-proxy: %s: fail to receive HELLO: %s",
+			elog(WARNING, "ic-proxy: %s: failed to receive HELLO: %s",
 						 peer->name, uv_strerror(nread));
 		else
 			elogif(gp_log_interconnect >= GPVARS_VERBOSITY_VERBOSE, LOG,
@@ -636,7 +636,7 @@ ic_proxy_peer_read_hello(ICProxyPeer *peer)
 		return;
 
 	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG3,
-		   "%s: waiting for HELLO", peer->name);
+		   "ic-proxy: %s: waiting for HELLO", peer->name);
 
 	peer->state |= IC_PROXY_PEER_STATE_RECEIVING_HELLO;
 
@@ -728,7 +728,7 @@ ic_proxy_peer_on_hello_ack_data(uv_stream_t *stream,
 	if (unlikely(nread < 0))
 	{
 		if (nread != UV_EOF)
-			elog(WARNING, "%s: fail to recv HELLO ACK: %s",
+			elog(WARNING, "ic-proxy: %s: failed to recv HELLO ACK: %s",
 						 peer->name, uv_strerror(nread));
 		else
 			elogif(gp_log_interconnect >= GPVARS_VERBOSITY_VERBOSE, LOG,
@@ -797,7 +797,7 @@ ic_proxy_peer_on_connected(uv_connect_t *conn, int status)
 	{
 		/* the peer might just not get ready yet, retry later */
 		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_VERBOSE, LOG,
-			   "ic-proxy: %s: fail to connect: %s",
+			   "ic-proxy: %s: failed to connect: %s",
 					 peer->name, uv_strerror(status));
 		ic_proxy_peer_close(peer);
 		return;
@@ -851,7 +851,7 @@ ic_proxy_peer_connect(ICProxyPeer *peer, struct sockaddr_in *dest)
 
 	uv_ip4_name(dest, name, sizeof(name));
 	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG3,
-		   "%s: connecting to %s:%d",
+		   "ic-proxy: %s: connecting to %s:%d",
 				 peer->name, name, ntohs(dest->sin_port));
 
 	/* reinit the tcp handle */
@@ -882,7 +882,7 @@ ic_proxy_peer_disconnect(ICProxyPeer *peer)
 		return;
 
 	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG3,
-		   "%s: disconnecting", peer->name);
+		   "ic-proxy: %s: disconnecting", peer->name);
 	ic_proxy_peer_shutdown(peer);
 }
 
@@ -970,7 +970,7 @@ ic_proxy_peer_handle_out_cache(ICProxyPeer *peer)
 	}
 
 	elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG3,
-		   "%s: consumed %d cached pkts",
+		   "ic-proxy: %s: consumed %d cached pkts",
 				 peer->name, list_length(reqs) - list_length(peer->reqs));
 
 	/*

--- a/src/backend/cdb/motion/ic_proxy_router.c
+++ b/src/backend/cdb/motion/ic_proxy_router.c
@@ -260,7 +260,7 @@ ic_proxy_router_on_write(uv_write_t *req, int status)
 	if (status < 0)
 	{
 		elogif(gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG, DEBUG5,
-			   "ic-proxy: router: fail to send %s: %s",
+			   "ic-proxy: router: failed to send %s: %s",
 					 ic_proxy_pkt_to_str(pkt), uv_strerror(status));
 	}
 	else

--- a/src/backend/cdb/motion/ic_tcp.c
+++ b/src/backend/cdb/motion/ic_tcp.c
@@ -1669,29 +1669,26 @@ SetupTCPInterconnect(EState *estate)
 		/*
 		 * Log the select() if requested.
 		 */
-		if (gp_log_interconnect >= GPVARS_VERBOSITY_VERBOSE)
+		if (gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG ||
+			(gp_log_interconnect >= GPVARS_VERBOSITY_VERBOSE &&
+			 n != expectedTotalIncoming + expectedTotalOutgoing))
 		{
-			if (gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG ||
-				n != expectedTotalIncoming + expectedTotalOutgoing)
-			{
-				int			elevel = (n == expectedTotalIncoming + expectedTotalOutgoing)
-				? DEBUG1 : LOG;
+			int elevel = (gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG) ? DEBUG1 : LOG;
 
-				initStringInfo(&logbuf);
-				if (n > 0)
-				{
-					appendStringInfo(&logbuf, "result=%d  Ready: ", n);
-					format_fd_set(&logbuf, highsock + 1, &rset, "r={", "} ");
-					format_fd_set(&logbuf, highsock + 1, &wset, "w={", "} ");
-					format_fd_set(&logbuf, highsock + 1, &eset, "e={", "}");
-				}
-				else
-					appendStringInfoString(&logbuf, n < 0 ? "error" : "timeout");
-				ereport(elevel, (errmsg("SetupInterconnect+" UINT64_FORMAT "ms:   select()  %s",
-										elapsed_ms, logbuf.data)));
-				pfree(logbuf.data);
-				MemSet(&logbuf, 0, sizeof(logbuf));
+			initStringInfo(&logbuf);
+			if (n > 0)
+			{
+				appendStringInfo(&logbuf, "result=%d  Ready: ", n);
+				format_fd_set(&logbuf, highsock + 1, &rset, "r={", "} ");
+				format_fd_set(&logbuf, highsock + 1, &wset, "w={", "} ");
+				format_fd_set(&logbuf, highsock + 1, &eset, "e={", "}");
 			}
+			else
+				appendStringInfoString(&logbuf, n < 0 ? "error" : "timeout");
+			ereport(elevel, (errmsg("SetupInterconnect+" UINT64_FORMAT "ms:   select()  %s",
+									elapsed_ms, logbuf.data)));
+			pfree(logbuf.data);
+			MemSet(&logbuf, 0, sizeof(logbuf));
 		}
 
 		/* An error other than EINTR is not acceptable */

--- a/src/backend/cdb/motion/ic_udpifc.c
+++ b/src/backend/cdb/motion/ic_udpifc.c
@@ -3616,7 +3616,7 @@ TeardownUDPIFCInterconnect_Internal(ChunkTransportState *transportStates,
 	}
 
 	if (gp_log_interconnect >= GPVARS_VERBOSITY_TERSE)
-		elog(DEBUG1, "TeardownUDPIFCInterconnect successful");
+		elog(LOG, "TeardownUDPIFCInterconnect successful");
 
 	RESUME_INTERRUPTS();
 }


### PR DESCRIPTION
IC proxy messages should have the `ic-proxy:` prefix.

The messages that are enabled by the TERSE settings should be written
with a severity level of LOG.
