### PR TITLE
Comment about direct dispatch's indexqualorig changes

### DIFF
--- a/src/backend/cdb/cdbtargeteddispatch.c
+++ b/src/backend/cdb/cdbtargeteddispatch.c
@@ -498,7 +498,7 @@ DirectDispatchUpdateContentIdsFromPlan(PlannerInfo *root, Plan *plan)
 																	  plan,
 																	  ((Scan *) plan)->scanrelid,
 																	  indexOnlyScan->recheckqual);
-				/* must use _orig_ qual ! */
+				/* must use _orig_ qual ! Upstream's recheckqual is the orig qual, just use it. */
 			}
 			break;
 

--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -1009,7 +1009,6 @@ CTranslatorDXLToPlStmt::TranslateDXLIndexOnlyScan(
 		&index_strategy_list, &index_subtype_list);
 
 	index_scan->indexqual = index_cond;
-	// index_scan->indexqualorig = index_orig_cond;
 	SetParamIds(plan);
 
 	return (Plan *) index_scan;

--- a/src/include/nodes/plannodes.h
+++ b/src/include/nodes/plannodes.h
@@ -659,9 +659,6 @@ typedef struct DynamicIndexScan
  * contain such Vars.  Also, for the convenience of setrefs.c, TLEs in
  * indextlist are marked as resjunk if they correspond to columns that
  * the index AM cannot reconstruct.
- * 
- * GPDB: We need indexqualorig to determine direct dispatch, however there
- * is no need to dispatch it.
  * ----------------
  */
 typedef struct IndexOnlyScan


### PR DESCRIPTION
Postgres introduced recheckqual and Greenplum reuses it as the
"original" index qual for direct dispatching, this commit updates the
leftover comments.
