### PR TITLE
【6X】support returning clause in splitupdate

### DIFF
--- a/src/backend/executor/nodeSplitUpdate.c
+++ b/src/backend/executor/nodeSplitUpdate.c
@@ -99,15 +99,20 @@ SplitTupleTableSlot(TupleTableSlot *slot,
 		}
 		else
 		{
-			Assert(IsA(tle->expr, Var));
-			/* `Resjunk' values */
-			delete_values[resno] = values[((Var *)tle->expr)->varattno-1];
-			delete_nulls[resno] = nulls[((Var *)tle->expr)->varattno-1];
+			/*
+			 * If we get here, tle could only be Var(junk column) or Const(isdropped true in pg_attribute)
+			 * we just fill junk column as usual and ignore Const isdropped column
+			 */
+			if (IsA(tle->expr, Var))
+			{
+				delete_values[resno] = values[((Var *)tle->expr)->varattno-1];
+				delete_nulls[resno] = nulls[((Var *)tle->expr)->varattno-1];
 
-			insert_values[resno] = values[((Var *)tle->expr)->varattno-1];
-			insert_nulls[resno] = nulls[((Var *)tle->expr)->varattno-1];
+				insert_values[resno] = values[((Var *)tle->expr)->varattno-1];
+				insert_nulls[resno] = nulls[((Var *)tle->expr)->varattno-1];
 
-			Assert(exprType((Node *) tle->expr) == slot->tts_tupleDescriptor->attrs[((Var *)tle->expr)->varattno-1]->atttypid);
+				Assert(exprType((Node *) tle->expr) == slot->tts_tupleDescriptor->attrs[((Var *)tle->expr)->varattno-1]->atttypid);
+			}
 		}
 	}
 }

--- a/src/backend/optimizer/plan/setrefs.c
+++ b/src/backend/optimizer/plan/setrefs.c
@@ -117,6 +117,7 @@ static bool fix_scan_expr_walker(Node *node, fix_scan_expr_context *context);
 static void set_join_references(PlannerInfo *root, Join *join, int rtoffset);
 static void set_upper_references(PlannerInfo *root, Plan *plan, int rtoffset);
 static void set_dummy_tlist_references(Plan *plan, int rtoffset);
+static void set_splitupdate_tlist_references(Plan *plan, int rtoffset);
 static indexed_tlist *build_tlist_index(List *tlist);
 static Var *search_indexed_tlist_for_var(Var *var,
 							 indexed_tlist *itlist,
@@ -1220,10 +1221,10 @@ set_plan_refs(PlannerInfo *root, Plan *plan, int rtoffset)
 			}
 			break;
 		case T_SplitUpdate:
-			/*
-			 * when we make the target list for SplitUpdate node, we
-			 * have used the OUTER as the varno, so we can skip to fix the varno.
-			 */
+			{
+				Assert(plan->qual == NIL);
+				set_splitupdate_tlist_references(plan, rtoffset);
+			}
 			break;
 		default:
 			elog(ERROR, "unrecognized node type: %d",
@@ -1914,6 +1915,65 @@ set_dummy_tlist_references(Plan *plan, int rtoffset)
 	/* We don't touch plan->qual here */
 }
 
+/*
+ * Split update is a bit special. It doesn't evaluate targetlist expressions,
+ * but it adds an extra DMLActionExpr attribute to the output. Also, because
+ * there is an assertion in ModifyTable that its subplan must contain a NULL
+ * Const for any dropped columns, we must represent NULL constants as Const
+ * node, even though they are passed through from the node below, rather than
+ * evaluated at the Split Update node. So this is mostly the same as
+ * set_dummy_tlist_references(), except for the special handling of
+ * DMLActionExpr and Consts.
+ */
+static void
+set_splitupdate_tlist_references(Plan *plan, int rtoffset)
+{
+	List	   *output_targetlist;
+	ListCell   *l;
+
+	output_targetlist = NIL;
+	foreach(l, plan->targetlist)
+	{
+		TargetEntry *tle = (TargetEntry *) lfirst(l);
+		Var		   *oldvar = (Var *) tle->expr;
+		Var		   *newvar;
+
+		if (IsA(tle->expr, DMLActionExpr))
+		{
+			output_targetlist = lappend(output_targetlist, tle);
+			continue;
+		}
+		else if (IsA(tle->expr, Const))
+		{
+			output_targetlist = lappend(output_targetlist, tle);
+			continue;
+		}
+
+		newvar = makeVar(OUTER_VAR,
+						 tle->resno,
+						 exprType((Node *) oldvar),
+						 exprTypmod((Node *) oldvar),
+						 exprCollation((Node *) oldvar),
+						 0);
+		if (IsA(oldvar, Var))
+		{
+			newvar->varnoold = oldvar->varno + rtoffset;
+			newvar->varoattno = oldvar->varattno;
+		}
+		else
+		{
+			newvar->varnoold = 0;		/* wasn't ever a plain Var */
+			newvar->varoattno = 0;
+		}
+
+		tle = flatCopyTargetEntry(tle);
+		tle->expr = (Expr *) newvar;
+		output_targetlist = lappend(output_targetlist, tle);
+	}
+	plan->targetlist = output_targetlist;
+
+	/* We don't touch plan->qual here */
+}
 
 /*
  * build_tlist_index --- build an index data structure for a child tlist

--- a/src/test/regress/expected/update_gp.out
+++ b/src/test/regress/expected/update_gp.out
@@ -374,6 +374,41 @@ select * from r;
  4 | 2
 (5 rows)
 
+-- Update redistribution with returning clause
+delete from r;
+delete from s;
+insert into r select generate_series(1, 5), generate_series(1, 5);
+insert into s select generate_series(6, 10), generate_series(1, 5);
+update r set a = s.a from s where r.b = s.b returning r.b;
+ b 
+---
+ 2
+ 3
+ 1
+ 5
+ 4
+(5 rows)
+
+update r set a = s.a from s where r.b = s.b returning s.b;
+ b 
+---
+ 2
+ 3
+ 1
+ 4
+ 5
+(5 rows)
+
+select * from r order by 1;
+ a  | b 
+----+---
+  6 | 1
+  7 | 2
+  8 | 3
+  9 | 4
+ 10 | 5
+(5 rows)
+
 -- Update hash aggreate group by
 delete from r;
 delete from s;
@@ -491,6 +526,21 @@ select * from s;
   3 | 3
   5 | 5
  12 | 2
+(5 rows)
+
+-- Update distribution key of other columns dropped case
+delete from s;
+alter table s drop column b;
+insert into s select i from generate_series(1, 5) i;
+update s set a = a + 1;
+select * from s;
+ a 
+---
+ 3
+ 4
+ 2
+ 6
+ 5
 (5 rows)
 
 -- Confirm that a split update is not created for a table excluded by

--- a/src/test/regress/expected/update_gp_optimizer.out
+++ b/src/test/regress/expected/update_gp_optimizer.out
@@ -373,6 +373,41 @@ select * from r;
  1 | 1
 (5 rows)
 
+-- Update redistribution with returning clause
+delete from r;
+delete from s;
+insert into r select generate_series(1, 5), generate_series(1, 5);
+insert into s select generate_series(6, 10), generate_series(1, 5);
+update r set a = s.a from s where r.b = s.b returning r.b;
+ b 
+---
+ 2
+ 3
+ 1
+ 5
+ 4
+(5 rows)
+
+update r set a = s.a from s where r.b = s.b returning s.b;
+ b 
+---
+ 2
+ 3
+ 1
+ 4
+ 5
+(5 rows)
+
+select * from r order by 1;
+ a  | b 
+----+---
+  6 | 1
+  7 | 2
+  8 | 3
+  9 | 4
+ 10 | 5
+(5 rows)
+
 -- Update hash aggreate group by
 delete from r;
 delete from s;
@@ -490,6 +525,21 @@ select * from s;
   3 | 3
   5 | 5
  12 | 2
+(5 rows)
+
+-- Update distribution key of other columns dropped case
+delete from s;
+alter table s drop column b;
+insert into s select i from generate_series(1, 5) i;
+update s set a = a + 1;
+select * from s;
+ a 
+---
+ 2
+ 3
+ 4
+ 6
+ 5
 (5 rows)
 
 -- Confirm that a split update is not created for a table excluded by

--- a/src/test/regress/sql/update_gp.sql
+++ b/src/test/regress/sql/update_gp.sql
@@ -205,6 +205,15 @@ select * from r;
 update r set a = r.a + 1 where b in (select b from s);
 select * from r;
 
+-- Update redistribution with returning clause
+delete from r;
+delete from s;
+insert into r select generate_series(1, 5), generate_series(1, 5);
+insert into s select generate_series(6, 10), generate_series(1, 5);
+update r set a = s.a from s where r.b = s.b returning r.b;
+update r set a = s.a from s where r.b = s.b returning s.b;
+select * from r order by 1;
+
 -- Update hash aggreate group by
 delete from r;
 delete from s;
@@ -236,6 +245,14 @@ select * from r;
 select * from s;
 prepare update_s(int) as update s set a = s.a + $1 where exists (select 1 from r where s.a = r.b);
 execute update_s(10);
+select * from s;
+
+
+-- Update distribution key of other columns dropped case
+delete from s;
+alter table s drop column b;
+insert into s select i from generate_series(1, 5) i;
+update s set a = a + 1;
 select * from s;
 
 -- Confirm that a split update is not created for a table excluded by


### PR DESCRIPTION
This PR aim to support returning clause in SplitUpdate as we try to update distributed column, 7x master
branch has supported it after refactoring paths in planner. 

### RCA
Currently in 6X, we create splitupdate plan targetlist in hard code, just assign OUTER_VAR to elements
in targetlist (why did that? just guess SplitUpdate Node is a Top Node so no one else should reference it).
As we know, Other nodes replace Var with OUTER_VAR in set_plan_refs for generating final plan.
There is no set_plan_refs function for node SplitUpdate, and that's also the root clause we cannot
support returning clause. Because as we assign OUTER_VAR for vars in returning clause, we could not
reference anything for them since subplan targetlist has already been replaced by OUTER_VAR.

### main changes
- refactor function make_splitupdate() especially on targetlist, we do not just assgin OUTER_VAR
   for them and keep origin var.
- we replace vars with OUTER_VAR in a new function set_splitupdate_tlist_references() as other nodes did.
- some minor changes in exectuor adapted for planner.




## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
