### PR TITLE
Fix gp_statio_user_tables_summary view

### DIFF
--- a/src/backend/catalog/system_views_gp_summary.sql
+++ b/src/backend/catalog/system_views_gp_summary.sql
@@ -292,7 +292,7 @@ CREATE VIEW gp_statio_sys_tables_summary AS
           schemaname ~ '^pg_toast';
 
 CREATE VIEW gp_statio_user_tables_summary AS
-    SELECT * FROM gp_stat_all_tables_summary
+    SELECT * FROM gp_statio_all_tables_summary
     WHERE schemaname NOT IN ('pg_catalog', 'information_schema', 'pg_aoseg') AND
           schemaname !~ '^pg_toast';
 

--- a/src/include/catalog/catversion.h
+++ b/src/include/catalog/catversion.h
@@ -56,6 +56,6 @@
  */
 
 /*							3yyymmddN */
-#define CATALOG_VERSION_NO	302305301
+#define CATALOG_VERSION_NO	302306121
 
 #endif


### PR DESCRIPTION
`gp_statio_user_tables_summary` was incorrectly filtering on `gp_stat_all_tables_summary`. 

Changed to filter on `gp_statio_all_tables_summary`

Bump catalog version