### PR TITLE
[ORCA] Enable Index-Only Scan on CTE

### DIFF
--- a/src/backend/gpopt/config/CConfigParamMapping.cpp
+++ b/src/backend/gpopt/config/CConfigParamMapping.cpp
@@ -278,9 +278,6 @@ CConfigParamMapping::SConfigMappingElem CConfigParamMapping::m_elements[] = {
 	 true,	// m_negate_param
 	 GPOS_WSZ_LIT(
 		 "Penalize a hash join with a skewed redistribute as a child.")},
-	{EopttraceTranslateUnusedColrefs, &optimizer_prune_unused_columns,
-	 true,	// m_negate_param
-	 GPOS_WSZ_LIT("Prune unused columns from the query.")},
 	{EopttraceAllowGeneralPredicatesforDPE,
 	 &optimizer_enable_range_predicate_dpe,
 	 false,	 // m_negate_param

--- a/src/backend/gporca/data/dxl/minidump/CTE-Preds2.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTE-Preds2.mdp
@@ -536,7 +536,6 @@
                           <dxl:TableDescriptor Mdid="6.32780.1.1" TableName="x">
                             <dxl:Columns>
                               <dxl:Column ColId="47" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
-                              <dxl:Column ColId="48" Attno="2" ColName="j" TypeMdid="0.23.1.0"/>
                               <dxl:Column ColId="49" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
                               <dxl:Column ColId="50" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
                               <dxl:Column ColId="51" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/CTE15HAReplicated.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTE15HAReplicated.mdp
@@ -613,7 +613,6 @@
                       <dxl:Columns>
                         <dxl:Column ColId="50" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
                         <dxl:Column ColId="51" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="52" Attno="3" ColName="c" TypeMdid="0.23.1.0" ColWidth="4"/>
                         <dxl:Column ColId="53" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
                         <dxl:Column ColId="54" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
                         <dxl:Column ColId="55" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>

--- a/src/backend/gporca/data/dxl/minidump/CTE15Replicated.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CTE15Replicated.mdp
@@ -643,7 +643,6 @@
                       <dxl:Columns>
                         <dxl:Column ColId="50" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
                         <dxl:Column ColId="51" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
-                        <dxl:Column ColId="52" Attno="3" ColName="c" TypeMdid="0.23.1.0" ColWidth="4"/>
                         <dxl:Column ColId="53" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
                         <dxl:Column ColId="54" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
                         <dxl:Column ColId="55" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>

--- a/src/backend/gporca/data/dxl/minidump/CannotPullGrpColAboveAgg.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CannotPullGrpColAboveAgg.mdp
@@ -4450,28 +4450,6 @@ The SQL along with the DDL are in TINC repo. In the aggregates directory under q
                                                         <dxl:Filter/>
                                                         <dxl:TableDescriptor Mdid="6.15754853.1.1" TableName="s_kst_ps_elem_vgz" ExecuteAsUser="10">
                                                           <dxl:Columns>
-                                                            <dxl:Column ColId="123" Attno="1" ColName="element_id" TypeMdid="0.1043.1.0" ColWidth="20"/>
-                                                            <dxl:Column ColId="124" Attno="2" ColName="element_id_vm" TypeMdid="0.1043.1.0" ColWidth="20"/>
-                                                            <dxl:Column ColId="125" Attno="3" ColName="element_name" TypeMdid="0.1043.1.0" ColWidth="80"/>
-                                                            <dxl:Column ColId="126" Attno="4" ColName="name_german" TypeMdid="0.1043.1.0" ColWidth="80"/>
-                                                            <dxl:Column ColId="127" Attno="5" ColName="order_position" TypeMdid="0.23.1.0"/>
-                                                            <dxl:Column ColId="128" Attno="6" ColName="ress_bezei" TypeMdid="0.1043.1.0" ColWidth="50"/>
-                                                            <dxl:Column ColId="129" Attno="7" ColName="gsch_fdf" TypeMdid="0.1043.1.0" ColWidth="12"/>
-                                                            <dxl:Column ColId="130" Attno="8" ColName="kst_art" TypeMdid="0.1043.1.0" ColWidth="1"/>
-                                                            <dxl:Column ColId="131" Attno="9" ColName="org_elem_nr" TypeMdid="0.1043.1.0" ColWidth="12"/>
-                                                            <dxl:Column ColId="132" Attno="10" ColName="guelt_ab" TypeMdid="0.1082.1.0"/>
-                                                            <dxl:Column ColId="133" Attno="11" ColName="guelt_bis" TypeMdid="0.1082.1.0"/>
-                                                            <dxl:Column ColId="134" Attno="12" ColName="element_name_lang" TypeMdid="0.1043.1.0" ColWidth="80"/>
-                                                            <dxl:Column ColId="135" Attno="13" ColName="fid" TypeMdid="0.21.1.0"/>
-                                                            <dxl:Column ColId="136" Attno="14" ColName="fid_kst" TypeMdid="0.21.1.0"/>
-                                                            <dxl:Column ColId="137" Attno="15" ColName="inn_dienst_ad" TypeMdid="0.1043.1.0" ColWidth="1"/>
-                                                            <dxl:Column ColId="138" Attno="16" ColName="kst_stat" TypeMdid="0.21.1.0"/>
-                                                            <dxl:Column ColId="139" Attno="17" ColName="parent_element_id" TypeMdid="0.1043.1.0" ColWidth="20"/>
-                                                            <dxl:Column ColId="140" Attno="18" ColName="parent_element_id_vm" TypeMdid="0.1043.1.0" ColWidth="20"/>
-                                                            <dxl:Column ColId="141" Attno="19" ColName="keze_entl_kst" TypeMdid="0.21.1.0"/>
-                                                            <dxl:Column ColId="142" Attno="20" ColName="keze_parent" TypeMdid="0.21.1.0"/>
-                                                            <dxl:Column ColId="143" Attno="21" ColName="verarb_ab" TypeMdid="0.1082.1.0"/>
-                                                            <dxl:Column ColId="144" Attno="22" ColName="verarb_bis" TypeMdid="0.1082.1.0"/>
                                                             <dxl:Column ColId="145" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
                                                             <dxl:Column ColId="146" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
                                                             <dxl:Column ColId="147" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
@@ -4569,27 +4547,6 @@ The SQL along with the DDL are in TINC repo. In the aggregates directory under q
                                                                 <dxl:TableDescriptor Mdid="6.15754853.1.1" TableName="s_kst_ps_elem_vgz" ExecuteAsUser="10">
                                                                   <dxl:Columns>
                                                                     <dxl:Column ColId="149" Attno="1" ColName="element_id" TypeMdid="0.1043.1.0" ColWidth="20"/>
-                                                                    <dxl:Column ColId="150" Attno="2" ColName="element_id_vm" TypeMdid="0.1043.1.0" ColWidth="20"/>
-                                                                    <dxl:Column ColId="151" Attno="3" ColName="element_name" TypeMdid="0.1043.1.0" ColWidth="80"/>
-                                                                    <dxl:Column ColId="152" Attno="4" ColName="name_german" TypeMdid="0.1043.1.0" ColWidth="80"/>
-                                                                    <dxl:Column ColId="153" Attno="5" ColName="order_position" TypeMdid="0.23.1.0"/>
-                                                                    <dxl:Column ColId="154" Attno="6" ColName="ress_bezei" TypeMdid="0.1043.1.0" ColWidth="50"/>
-                                                                    <dxl:Column ColId="155" Attno="7" ColName="gsch_fdf" TypeMdid="0.1043.1.0" ColWidth="12"/>
-                                                                    <dxl:Column ColId="156" Attno="8" ColName="kst_art" TypeMdid="0.1043.1.0" ColWidth="1"/>
-                                                                    <dxl:Column ColId="157" Attno="9" ColName="org_elem_nr" TypeMdid="0.1043.1.0" ColWidth="12"/>
-                                                                    <dxl:Column ColId="158" Attno="10" ColName="guelt_ab" TypeMdid="0.1082.1.0"/>
-                                                                    <dxl:Column ColId="159" Attno="11" ColName="guelt_bis" TypeMdid="0.1082.1.0"/>
-                                                                    <dxl:Column ColId="160" Attno="12" ColName="element_name_lang" TypeMdid="0.1043.1.0" ColWidth="80"/>
-                                                                    <dxl:Column ColId="161" Attno="13" ColName="fid" TypeMdid="0.21.1.0"/>
-                                                                    <dxl:Column ColId="162" Attno="14" ColName="fid_kst" TypeMdid="0.21.1.0"/>
-                                                                    <dxl:Column ColId="163" Attno="15" ColName="inn_dienst_ad" TypeMdid="0.1043.1.0" ColWidth="1"/>
-                                                                    <dxl:Column ColId="164" Attno="16" ColName="kst_stat" TypeMdid="0.21.1.0"/>
-                                                                    <dxl:Column ColId="165" Attno="17" ColName="parent_element_id" TypeMdid="0.1043.1.0" ColWidth="20"/>
-                                                                    <dxl:Column ColId="166" Attno="18" ColName="parent_element_id_vm" TypeMdid="0.1043.1.0" ColWidth="20"/>
-                                                                    <dxl:Column ColId="167" Attno="19" ColName="keze_entl_kst" TypeMdid="0.21.1.0"/>
-                                                                    <dxl:Column ColId="168" Attno="20" ColName="keze_parent" TypeMdid="0.21.1.0"/>
-                                                                    <dxl:Column ColId="169" Attno="21" ColName="verarb_ab" TypeMdid="0.1082.1.0"/>
-                                                                    <dxl:Column ColId="170" Attno="22" ColName="verarb_bis" TypeMdid="0.1082.1.0"/>
                                                                     <dxl:Column ColId="171" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
                                                                     <dxl:Column ColId="172" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
                                                                     <dxl:Column ColId="173" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/ExpandFullOuterJoin.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ExpandFullOuterJoin.mdp
@@ -330,7 +330,6 @@ select * from t full join s on t1 = s1;
                 <dxl:TableDescriptor Mdid="6.25359.1.1" TableName="t">
                   <dxl:Columns>
                     <dxl:Column ColId="20" Attno="1" ColName="t1" TypeMdid="0.23.1.0"/>
-                    <dxl:Column ColId="29" Attno="2" ColName="t2" TypeMdid="0.23.1.0"/>
                     <dxl:Column ColId="21" Attno="3" ColName="t3" TypeMdid="0.23.1.0"/>
                     <dxl:Column ColId="22" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
                     <dxl:Column ColId="23" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
@@ -426,7 +425,6 @@ select * from t full join s on t1 = s1;
                     <dxl:Columns>
                       <dxl:Column ColId="30" Attno="1" ColName="s1" TypeMdid="0.23.1.0"/>
                       <dxl:Column ColId="31" Attno="2" ColName="s2" TypeMdid="0.23.1.0"/>
-                      <dxl:Column ColId="39" Attno="3" ColName="s3" TypeMdid="0.23.1.0"/>
                       <dxl:Column ColId="32" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
                       <dxl:Column ColId="33" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
                       <dxl:Column ColId="34" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/IndexOnlyScan-CTE.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexOnlyScan-CTE.mdp
@@ -1,0 +1,310 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Comment><![CDATA[
+    Test case: Allow index-only-scan should work on CTE. Expect index-only-scan
+    plan in setup:
+
+      CREATE TABLE t(a int, b int);
+      CREATE INDEX i ON t(a);
+      INSERT INTO t SELECT i, i+i FROM generate_series(1, 10)i;
+      VACUUM ANALYZE t;
+
+      EXPLAIN WITH cte AS (SELECT a FROM t WHERE a>42) SELECT * FROM cte;
+  ]]>
+  </dxl:Comment>
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="20" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0" SkewFactor="0"/>
+      <dxl:TraceFlags Value="102001,102002,102003,102043,102074,102120,102144,103001,103014,103015,103022,103026,103027,103029,103033,103038,103040,104002,104003,104004,104005,105000,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:GPDBScalarOp Mdid="0.521.1.0" Name="&gt;" ComparisonType="GT" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.23.1.0"/>
+        <dxl:RightType Mdid="0.23.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.147.1.0"/>
+        <dxl:Commutator Mdid="0.97.1.0"/>
+        <dxl:InverseOp Mdid="0.523.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+          <dxl:Opfamily Mdid="0.4054.1.0"/>
+          <dxl:Opfamily Mdid="0.10009.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:PartOpfamily Mdid="0.424.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:PartOpfamily Mdid="0.1976.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:PartOpfamily Mdid="0.1989.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2134.1.0"/>
+        <dxl:MaxAgg Mdid="0.2118.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.2227.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:PartOpfamily Mdid="0.2789.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.3315.1.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Index Mdid="7.32781.1.0" Name="i" IsClustered="false" IndexType="B-tree" IndexItemType="0.2283.1.0" KeyColumns="0" IncludedColumns="">
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.1976.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:Index>
+      <dxl:RelationStatistics Mdid="2.32778.1.0" Name="t" Rows="10.000000" RelPages="3" RelAllVisible="3" EmptyRelation="false"/>
+      <dxl:Relation Mdid="6.32778.1.0" Name="t" IsTemporary="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="8,2">
+        <dxl:Columns>
+          <dxl:Column Name="a" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="b" Attno="2" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-2" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-3" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-4" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-5" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-6" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-7" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList>
+          <dxl:IndexInfo Mdid="7.32781.1.0" IsPartial="false"/>
+        </dxl:IndexInfoList>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:RelationExtendedStatistics Mdid="10.32778.1.0" Name="t"/>
+      <dxl:ColumnStatistics Mdid="1.32778.1.0.0" Name="a" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="false">
+        <dxl:StatsBucket Frequency="0.111111" DistinctValues="1.111111">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="1"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="2"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.111111" DistinctValues="1.111111">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="2"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="3"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.111111" DistinctValues="1.111111">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="3"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="4"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.111111" DistinctValues="1.111111">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="4"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="5"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.111111" DistinctValues="1.111111">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="5"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="6"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.111111" DistinctValues="1.111111">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="6"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="7"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.111111" DistinctValues="1.111111">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="7"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="8"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.111111" DistinctValues="1.111111">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="8"/>
+          <dxl:UpperBound Closed="false" TypeMdid="0.23.1.0" Value="9"/>
+        </dxl:StatsBucket>
+        <dxl:StatsBucket Frequency="0.111111" DistinctValues="1.111111">
+          <dxl:LowerBound Closed="true" TypeMdid="0.23.1.0" Value="9"/>
+          <dxl:UpperBound Closed="true" TypeMdid="0.23.1.0" Value="10"/>
+        </dxl:StatsBucket>
+      </dxl:ColumnStatistics>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList>
+        <dxl:LogicalCTEProducer CTEId="1" Columns="1">
+          <dxl:LogicalSelect>
+            <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
+              <dxl:Ident ColId="1" ColName="a" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="42"/>
+            </dxl:Comparison>
+            <dxl:LogicalGet>
+              <dxl:TableDescriptor Mdid="6.32778.1.0" TableName="t" LockMode="1">
+                <dxl:Columns>
+                  <dxl:Column ColId="1" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="2" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                  <dxl:Column ColId="4" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="5" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="6" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="7" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="8" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="9" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:LogicalGet>
+          </dxl:LogicalSelect>
+        </dxl:LogicalCTEProducer>
+      </dxl:CTEList>
+      <dxl:LogicalCTEAnchor CTEId="1">
+        <dxl:LogicalCTEConsumer CTEId="1" Columns="10"/>
+      </dxl:LogicalCTEAnchor>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="3">
+      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="0.000119" Rows="1.000000" Width="4"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="9" Alias="a">
+            <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:SortingColumnList/>
+        <dxl:IndexOnlyScan IndexScanDirection="Forward">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="0.000101" Rows="1.000000" Width="4"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="9" Alias="a">
+              <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:IndexCondList>
+            <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
+              <dxl:Ident ColId="9" ColName="a" TypeMdid="0.23.1.0"/>
+              <dxl:ConstValue TypeMdid="0.23.1.0" Value="42"/>
+            </dxl:Comparison>
+          </dxl:IndexCondList>
+          <dxl:Partitions/>
+          <dxl:IndexDescriptor Mdid="7.32781.1.0" IndexName="i"/>
+          <dxl:TableDescriptor Mdid="6.32778.1.0" TableName="t" LockMode="1">
+            <dxl:Columns>
+              <dxl:Column ColId="9" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+              <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+              <dxl:Column ColId="12" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="13" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="14" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+              <dxl:Column ColId="15" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+              <dxl:Column ColId="16" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+              <dxl:Column ColId="17" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+            </dxl:Columns>
+          </dxl:TableDescriptor>
+        </dxl:IndexOnlyScan>
+      </dxl:GatherMotion>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/Insert-With-HJ-CTE-Agg.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Insert-With-HJ-CTE-Agg.mdp
@@ -753,7 +753,6 @@
                       <dxl:TableDescriptor Mdid="6.57345.1.0" TableName="country">
                         <dxl:Columns>
                           <dxl:Column ColId="20" Attno="1" ColName="code" TypeMdid="0.1042.1.0" TypeModifier="7" ColWidth="4"/>
-                          <dxl:Column ColId="22" Attno="2" ColName="name" TypeMdid="0.25.1.0" ColWidth="4"/>
                           <dxl:Column ColId="23" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
                           <dxl:Column ColId="24" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
                           <dxl:Column ColId="25" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>

--- a/src/backend/gporca/data/dxl/minidump/LeftOuter2InnerUnionAllAntiSemiJoin-Tpcds.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LeftOuter2InnerUnionAllAntiSemiJoin-Tpcds.mdp
@@ -11728,29 +11728,8 @@ select * from v2 left outer join v1 on v2.i_item_sk = v1.ss_item_sk limit 5;
                     <dxl:Filter/>
                     <dxl:TableDescriptor Mdid="6.15668460.1.1" TableName="store_sales">
                       <dxl:Columns>
-                        <dxl:Column ColId="125" Attno="1" ColName="ss_sold_date_sk" TypeMdid="0.23.1.0"/>
-                        <dxl:Column ColId="126" Attno="2" ColName="ss_sold_time_sk" TypeMdid="0.23.1.0"/>
                         <dxl:Column ColId="124" Attno="3" ColName="ss_item_sk" TypeMdid="0.23.1.0"/>
-                        <dxl:Column ColId="127" Attno="4" ColName="ss_customer_sk" TypeMdid="0.23.1.0"/>
-                        <dxl:Column ColId="128" Attno="5" ColName="ss_cdemo_sk" TypeMdid="0.23.1.0"/>
-                        <dxl:Column ColId="129" Attno="6" ColName="ss_hdemo_sk" TypeMdid="0.23.1.0"/>
-                        <dxl:Column ColId="130" Attno="7" ColName="ss_addr_sk" TypeMdid="0.23.1.0"/>
-                        <dxl:Column ColId="131" Attno="8" ColName="ss_store_sk" TypeMdid="0.23.1.0"/>
-                        <dxl:Column ColId="132" Attno="9" ColName="ss_promo_sk" TypeMdid="0.23.1.0"/>
                         <dxl:Column ColId="133" Attno="10" ColName="ss_ticket_number" TypeMdid="0.23.1.0"/>
-                        <dxl:Column ColId="134" Attno="11" ColName="ss_quantity" TypeMdid="0.23.1.0"/>
-                        <dxl:Column ColId="135" Attno="12" ColName="ss_wholesale_cost" TypeMdid="0.1700.1.0"/>
-                        <dxl:Column ColId="136" Attno="13" ColName="ss_list_price" TypeMdid="0.1700.1.0"/>
-                        <dxl:Column ColId="137" Attno="14" ColName="ss_sales_price" TypeMdid="0.1700.1.0"/>
-                        <dxl:Column ColId="138" Attno="15" ColName="ss_ext_discount_amt" TypeMdid="0.1700.1.0"/>
-                        <dxl:Column ColId="139" Attno="16" ColName="ss_ext_sales_price" TypeMdid="0.1700.1.0"/>
-                        <dxl:Column ColId="140" Attno="17" ColName="ss_ext_wholesale_cost" TypeMdid="0.1700.1.0"/>
-                        <dxl:Column ColId="141" Attno="18" ColName="ss_ext_list_price" TypeMdid="0.1700.1.0"/>
-                        <dxl:Column ColId="142" Attno="19" ColName="ss_ext_tax" TypeMdid="0.1700.1.0"/>
-                        <dxl:Column ColId="143" Attno="20" ColName="ss_coupon_amt" TypeMdid="0.1700.1.0"/>
-                        <dxl:Column ColId="144" Attno="21" ColName="ss_net_paid" TypeMdid="0.1700.1.0"/>
-                        <dxl:Column ColId="145" Attno="22" ColName="ss_net_paid_inc_tax" TypeMdid="0.1700.1.0"/>
-                        <dxl:Column ColId="146" Attno="23" ColName="ss_net_profit" TypeMdid="0.1700.1.0"/>
                         <dxl:Column ColId="147" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
                         <dxl:Column ColId="148" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
                         <dxl:Column ColId="149" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
@@ -11783,34 +11762,6 @@ select * from v2 left outer join v1 on v2.i_item_sk = v1.ss_item_sk limit 5;
                         <dxl:TableDescriptor Mdid="6.17281181.1.1" TableName="store">
                           <dxl:Columns>
                             <dxl:Column ColId="154" Attno="1" ColName="s_store_sk" TypeMdid="0.23.1.0"/>
-                            <dxl:Column ColId="155" Attno="2" ColName="s_store_id" TypeMdid="0.1042.1.0" ColWidth="16"/>
-                            <dxl:Column ColId="156" Attno="3" ColName="s_rec_start_date" TypeMdid="0.1082.1.0"/>
-                            <dxl:Column ColId="157" Attno="4" ColName="s_rec_end_date" TypeMdid="0.1082.1.0"/>
-                            <dxl:Column ColId="158" Attno="5" ColName="s_closed_date_sk" TypeMdid="0.23.1.0"/>
-                            <dxl:Column ColId="159" Attno="6" ColName="s_store_name" TypeMdid="0.1043.1.0" ColWidth="50"/>
-                            <dxl:Column ColId="160" Attno="7" ColName="s_number_employees" TypeMdid="0.23.1.0"/>
-                            <dxl:Column ColId="161" Attno="8" ColName="s_floor_space" TypeMdid="0.23.1.0"/>
-                            <dxl:Column ColId="162" Attno="9" ColName="s_hours" TypeMdid="0.1042.1.0" ColWidth="20"/>
-                            <dxl:Column ColId="163" Attno="10" ColName="s_manager" TypeMdid="0.1043.1.0" ColWidth="40"/>
-                            <dxl:Column ColId="164" Attno="11" ColName="s_market_id" TypeMdid="0.23.1.0"/>
-                            <dxl:Column ColId="165" Attno="12" ColName="s_geography_class" TypeMdid="0.1043.1.0" ColWidth="100"/>
-                            <dxl:Column ColId="166" Attno="13" ColName="s_market_desc" TypeMdid="0.1043.1.0" ColWidth="100"/>
-                            <dxl:Column ColId="167" Attno="14" ColName="s_market_manager" TypeMdid="0.1043.1.0" ColWidth="40"/>
-                            <dxl:Column ColId="168" Attno="15" ColName="s_division_id" TypeMdid="0.23.1.0"/>
-                            <dxl:Column ColId="169" Attno="16" ColName="s_division_name" TypeMdid="0.1043.1.0" ColWidth="50"/>
-                            <dxl:Column ColId="170" Attno="17" ColName="s_company_id" TypeMdid="0.23.1.0"/>
-                            <dxl:Column ColId="171" Attno="18" ColName="s_company_name" TypeMdid="0.1043.1.0" ColWidth="50"/>
-                            <dxl:Column ColId="172" Attno="19" ColName="s_street_number" TypeMdid="0.1043.1.0" ColWidth="10"/>
-                            <dxl:Column ColId="173" Attno="20" ColName="s_street_name" TypeMdid="0.1043.1.0" ColWidth="60"/>
-                            <dxl:Column ColId="174" Attno="21" ColName="s_street_type" TypeMdid="0.1042.1.0" ColWidth="15"/>
-                            <dxl:Column ColId="175" Attno="22" ColName="s_suite_number" TypeMdid="0.1042.1.0" ColWidth="10"/>
-                            <dxl:Column ColId="176" Attno="23" ColName="s_city" TypeMdid="0.1043.1.0" ColWidth="60"/>
-                            <dxl:Column ColId="177" Attno="24" ColName="s_county" TypeMdid="0.1043.1.0" ColWidth="30"/>
-                            <dxl:Column ColId="178" Attno="25" ColName="s_state" TypeMdid="0.1042.1.0" ColWidth="2"/>
-                            <dxl:Column ColId="179" Attno="26" ColName="s_zip" TypeMdid="0.1042.1.0" ColWidth="10"/>
-                            <dxl:Column ColId="180" Attno="27" ColName="s_country" TypeMdid="0.1043.1.0" ColWidth="20"/>
-                            <dxl:Column ColId="181" Attno="28" ColName="s_gmt_offset" TypeMdid="0.1700.1.0"/>
-                            <dxl:Column ColId="182" Attno="29" ColName="s_tax_precentage" TypeMdid="0.1700.1.0"/>
                             <dxl:Column ColId="183" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
                             <dxl:Column ColId="184" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
                             <dxl:Column ColId="185" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
@@ -11838,27 +11789,6 @@ select * from v2 left outer join v1 on v2.i_item_sk = v1.ss_item_sk limit 5;
                 <dxl:TableDescriptor Mdid="6.17281135.1.1" TableName="item">
                   <dxl:Columns>
                     <dxl:Column ColId="95" Attno="1" ColName="i_item_sk" TypeMdid="0.23.1.0"/>
-                    <dxl:Column ColId="96" Attno="2" ColName="i_item_id" TypeMdid="0.1042.1.0" ColWidth="16"/>
-                    <dxl:Column ColId="97" Attno="3" ColName="i_rec_start_date" TypeMdid="0.1082.1.0"/>
-                    <dxl:Column ColId="98" Attno="4" ColName="i_rec_end_date" TypeMdid="0.1082.1.0"/>
-                    <dxl:Column ColId="99" Attno="5" ColName="i_item_desc" TypeMdid="0.1043.1.0" ColWidth="200"/>
-                    <dxl:Column ColId="100" Attno="6" ColName="i_current_price" TypeMdid="0.1700.1.0"/>
-                    <dxl:Column ColId="101" Attno="7" ColName="i_wholesale_cost" TypeMdid="0.1700.1.0"/>
-                    <dxl:Column ColId="102" Attno="8" ColName="i_brand_id" TypeMdid="0.23.1.0"/>
-                    <dxl:Column ColId="103" Attno="9" ColName="i_brand" TypeMdid="0.1042.1.0" ColWidth="50"/>
-                    <dxl:Column ColId="104" Attno="10" ColName="i_class_id" TypeMdid="0.23.1.0"/>
-                    <dxl:Column ColId="105" Attno="11" ColName="i_class" TypeMdid="0.1042.1.0" ColWidth="50"/>
-                    <dxl:Column ColId="106" Attno="12" ColName="i_category_id" TypeMdid="0.23.1.0"/>
-                    <dxl:Column ColId="107" Attno="13" ColName="i_category" TypeMdid="0.1042.1.0" ColWidth="50"/>
-                    <dxl:Column ColId="108" Attno="14" ColName="i_manufact_id" TypeMdid="0.23.1.0"/>
-                    <dxl:Column ColId="109" Attno="15" ColName="i_manufact" TypeMdid="0.1042.1.0" ColWidth="50"/>
-                    <dxl:Column ColId="110" Attno="16" ColName="i_size" TypeMdid="0.1042.1.0" ColWidth="20"/>
-                    <dxl:Column ColId="111" Attno="17" ColName="i_formulation" TypeMdid="0.1042.1.0" ColWidth="20"/>
-                    <dxl:Column ColId="112" Attno="18" ColName="i_color" TypeMdid="0.1042.1.0" ColWidth="20"/>
-                    <dxl:Column ColId="113" Attno="19" ColName="i_units" TypeMdid="0.1042.1.0" ColWidth="10"/>
-                    <dxl:Column ColId="114" Attno="20" ColName="i_container" TypeMdid="0.1042.1.0" ColWidth="10"/>
-                    <dxl:Column ColId="115" Attno="21" ColName="i_manager_id" TypeMdid="0.23.1.0"/>
-                    <dxl:Column ColId="116" Attno="22" ColName="i_product_name" TypeMdid="0.1042.1.0" ColWidth="50"/>
                     <dxl:Column ColId="117" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
                     <dxl:Column ColId="118" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
                     <dxl:Column ColId="119" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>

--- a/src/backend/gporca/data/dxl/minidump/OrderedAgg_multiple_diffcol.mdp
+++ b/src/backend/gporca/data/dxl/minidump/OrderedAgg_multiple_diffcol.mdp
@@ -536,9 +536,6 @@ EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a1), percentile_cont(0
                     <dxl:Columns>
                       <dxl:Column ColId="15" Attno="1" ColName="a1" TypeMdid="0.23.1.0" ColWidth="4"/>
                       <dxl:Column ColId="17" Attno="2" ColName="a2" TypeMdid="0.701.1.0" ColWidth="8"/>
-                      <dxl:Column ColId="18" Attno="3" ColName="a3" TypeMdid="0.1186.1.0" ColWidth="16"/>
-                      <dxl:Column ColId="19" Attno="4" ColName="a4" TypeMdid="0.1114.1.0" ColWidth="8"/>
-                      <dxl:Column ColId="20" Attno="5" ColName="a5" TypeMdid="0.1184.1.0" ColWidth="8"/>
                       <dxl:Column ColId="21" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
                       <dxl:Column ColId="22" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
                       <dxl:Column ColId="23" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
@@ -659,9 +656,6 @@ EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a1), percentile_cont(0
                         <dxl:Columns>
                           <dxl:Column ColId="57" Attno="1" ColName="a1" TypeMdid="0.23.1.0" ColWidth="4"/>
                           <dxl:Column ColId="55" Attno="2" ColName="a2" TypeMdid="0.701.1.0" ColWidth="8"/>
-                          <dxl:Column ColId="58" Attno="3" ColName="a3" TypeMdid="0.1186.1.0" ColWidth="16"/>
-                          <dxl:Column ColId="59" Attno="4" ColName="a4" TypeMdid="0.1114.1.0" ColWidth="8"/>
-                          <dxl:Column ColId="60" Attno="5" ColName="a5" TypeMdid="0.1184.1.0" ColWidth="8"/>
                           <dxl:Column ColId="61" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
                           <dxl:Column ColId="62" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
                           <dxl:Column ColId="63" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>

--- a/src/backend/gporca/data/dxl/minidump/OrderedAgg_multiple_samecol.mdp
+++ b/src/backend/gporca/data/dxl/minidump/OrderedAgg_multiple_samecol.mdp
@@ -537,9 +537,6 @@ EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a2), percentile_disc(0
                       <dxl:Columns>
                         <dxl:Column ColId="17" Attno="1" ColName="a1" TypeMdid="0.23.1.0" ColWidth="4"/>
                         <dxl:Column ColId="15" Attno="2" ColName="a2" TypeMdid="0.701.1.0" ColWidth="8"/>
-                        <dxl:Column ColId="18" Attno="3" ColName="a3" TypeMdid="0.1186.1.0" ColWidth="16"/>
-                        <dxl:Column ColId="19" Attno="4" ColName="a4" TypeMdid="0.1114.1.0" ColWidth="8"/>
-                        <dxl:Column ColId="20" Attno="5" ColName="a5" TypeMdid="0.1184.1.0" ColWidth="8"/>
                         <dxl:Column ColId="21" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
                         <dxl:Column ColId="22" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
                         <dxl:Column ColId="23" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>

--- a/src/backend/gporca/data/dxl/minidump/OrderedAgg_multiple_samecol_difforderespec.mdp
+++ b/src/backend/gporca/data/dxl/minidump/OrderedAgg_multiple_samecol_difforderespec.mdp
@@ -548,9 +548,6 @@ EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a2), percentile_cont(0
                       <dxl:Columns>
                         <dxl:Column ColId="17" Attno="1" ColName="a1" TypeMdid="0.23.1.0" ColWidth="4"/>
                         <dxl:Column ColId="15" Attno="2" ColName="a2" TypeMdid="0.701.1.0" ColWidth="8"/>
-                        <dxl:Column ColId="18" Attno="3" ColName="a3" TypeMdid="0.1186.1.0" ColWidth="16"/>
-                        <dxl:Column ColId="19" Attno="4" ColName="a4" TypeMdid="0.1114.1.0" ColWidth="8"/>
-                        <dxl:Column ColId="20" Attno="5" ColName="a5" TypeMdid="0.1184.1.0" ColWidth="8"/>
                         <dxl:Column ColId="21" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
                         <dxl:Column ColId="22" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
                         <dxl:Column ColId="23" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
@@ -672,9 +669,6 @@ EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a2), percentile_cont(0
                         <dxl:Columns>
                           <dxl:Column ColId="57" Attno="1" ColName="a1" TypeMdid="0.23.1.0" ColWidth="4"/>
                           <dxl:Column ColId="55" Attno="2" ColName="a2" TypeMdid="0.701.1.0" ColWidth="8"/>
-                          <dxl:Column ColId="58" Attno="3" ColName="a3" TypeMdid="0.1186.1.0" ColWidth="16"/>
-                          <dxl:Column ColId="59" Attno="4" ColName="a4" TypeMdid="0.1114.1.0" ColWidth="8"/>
-                          <dxl:Column ColId="60" Attno="5" ColName="a5" TypeMdid="0.1184.1.0" ColWidth="8"/>
                           <dxl:Column ColId="61" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
                           <dxl:Column ColId="62" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
                           <dxl:Column ColId="63" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>

--- a/src/backend/gporca/data/dxl/minidump/OrderedAgg_single.mdp
+++ b/src/backend/gporca/data/dxl/minidump/OrderedAgg_single.mdp
@@ -495,9 +495,6 @@ EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a2) FROM foo;
                       <dxl:Columns>
                         <dxl:Column ColId="16" Attno="1" ColName="a1" TypeMdid="0.23.1.0" ColWidth="4"/>
                         <dxl:Column ColId="14" Attno="2" ColName="a2" TypeMdid="0.701.1.0" ColWidth="8"/>
-                        <dxl:Column ColId="17" Attno="3" ColName="a3" TypeMdid="0.1186.1.0" ColWidth="16"/>
-                        <dxl:Column ColId="18" Attno="4" ColName="a4" TypeMdid="0.1114.1.0" ColWidth="8"/>
-                        <dxl:Column ColId="19" Attno="5" ColName="a5" TypeMdid="0.1184.1.0" ColWidth="8"/>
                         <dxl:Column ColId="20" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
                         <dxl:Column ColId="21" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
                         <dxl:Column ColId="22" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>

--- a/src/backend/gporca/data/dxl/minidump/OrderedAgg_with_nonOrderedAgg.mdp
+++ b/src/backend/gporca/data/dxl/minidump/OrderedAgg_with_nonOrderedAgg.mdp
@@ -592,9 +592,6 @@ EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a1), percentile_disc(0
                     <dxl:Columns>
                       <dxl:Column ColId="16" Attno="1" ColName="a1" TypeMdid="0.23.1.0" ColWidth="4"/>
                       <dxl:Column ColId="18" Attno="2" ColName="a2" TypeMdid="0.701.1.0" ColWidth="8"/>
-                      <dxl:Column ColId="19" Attno="3" ColName="a3" TypeMdid="0.1186.1.0" ColWidth="16"/>
-                      <dxl:Column ColId="20" Attno="4" ColName="a4" TypeMdid="0.1114.1.0" ColWidth="8"/>
-                      <dxl:Column ColId="21" Attno="5" ColName="a5" TypeMdid="0.1184.1.0" ColWidth="8"/>
                       <dxl:Column ColId="22" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
                       <dxl:Column ColId="23" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
                       <dxl:Column ColId="24" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
@@ -718,9 +715,6 @@ EXPLAIN SELECT percentile_cont(0.5) WITHIN GROUP(ORDER BY a1), percentile_disc(0
                         <dxl:Columns>
                           <dxl:Column ColId="58" Attno="1" ColName="a1" TypeMdid="0.23.1.0" ColWidth="4"/>
                           <dxl:Column ColId="56" Attno="2" ColName="a2" TypeMdid="0.701.1.0" ColWidth="8"/>
-                          <dxl:Column ColId="59" Attno="3" ColName="a3" TypeMdid="0.1186.1.0" ColWidth="16"/>
-                          <dxl:Column ColId="60" Attno="4" ColName="a4" TypeMdid="0.1114.1.0" ColWidth="8"/>
-                          <dxl:Column ColId="61" Attno="5" ColName="a5" TypeMdid="0.1184.1.0" ColWidth="8"/>
                           <dxl:Column ColId="62" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
                           <dxl:Column ColId="63" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
                           <dxl:Column ColId="64" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>

--- a/src/backend/gporca/data/dxl/minidump/OrderedAgg_with_nonconst_fraction.mdp
+++ b/src/backend/gporca/data/dxl/minidump/OrderedAgg_with_nonconst_fraction.mdp
@@ -523,10 +523,6 @@ EXPLAIN SELECT percentile_cont(floor(random()*0.1)+0.5) WITHIN GROUP(ORDER BY a1
                   <dxl:TableDescriptor Mdid="6.24576.1.0" TableName="foo" LockMode="1">
                     <dxl:Columns>
                       <dxl:Column ColId="14" Attno="1" ColName="a1" TypeMdid="0.23.1.0" ColWidth="4"/>
-                      <dxl:Column ColId="16" Attno="2" ColName="a2" TypeMdid="0.701.1.0" ColWidth="8"/>
-                      <dxl:Column ColId="17" Attno="3" ColName="a3" TypeMdid="0.1186.1.0" ColWidth="16"/>
-                      <dxl:Column ColId="18" Attno="4" ColName="a4" TypeMdid="0.1114.1.0" ColWidth="8"/>
-                      <dxl:Column ColId="19" Attno="5" ColName="a5" TypeMdid="0.1184.1.0" ColWidth="8"/>
                       <dxl:Column ColId="20" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
                       <dxl:Column ColId="21" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
                       <dxl:Column ColId="22" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>

--- a/src/backend/gporca/data/dxl/minidump/TVF-With-Deep-Subq-Args.mdp
+++ b/src/backend/gporca/data/dxl/minidump/TVF-With-Deep-Subq-Args.mdp
@@ -429,8 +429,6 @@ SELECT generate_series((
                             <dxl:TableDescriptor Mdid="6.156718.1.1" TableName="x">
                               <dxl:Columns>
                                 <dxl:Column ColId="54" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
-                                <dxl:Column ColId="55" Attno="2" ColName="j" TypeMdid="0.23.1.0"/>
-                                <dxl:Column ColId="56" Attno="3" ColName="k" TypeMdid="0.23.1.0"/>
                                 <dxl:Column ColId="57" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
                                 <dxl:Column ColId="58" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
                                 <dxl:Column ColId="59" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
@@ -487,8 +485,6 @@ SELECT generate_series((
                           <dxl:TableDescriptor Mdid="6.156718.1.1" TableName="x">
                             <dxl:Columns>
                               <dxl:Column ColId="65" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
-                              <dxl:Column ColId="66" Attno="2" ColName="j" TypeMdid="0.23.1.0"/>
-                              <dxl:Column ColId="67" Attno="3" ColName="k" TypeMdid="0.23.1.0"/>
                               <dxl:Column ColId="68" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
                               <dxl:Column ColId="69" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
                               <dxl:Column ColId="70" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
@@ -642,8 +638,6 @@ SELECT generate_series((
                             <dxl:TableDescriptor Mdid="6.156718.1.1" TableName="x">
                               <dxl:Columns>
                                 <dxl:Column ColId="54" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
-                                <dxl:Column ColId="55" Attno="2" ColName="j" TypeMdid="0.23.1.0"/>
-                                <dxl:Column ColId="56" Attno="3" ColName="k" TypeMdid="0.23.1.0"/>
                                 <dxl:Column ColId="57" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
                                 <dxl:Column ColId="58" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
                                 <dxl:Column ColId="59" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
@@ -700,8 +694,6 @@ SELECT generate_series((
                           <dxl:TableDescriptor Mdid="6.156718.1.1" TableName="x">
                             <dxl:Columns>
                               <dxl:Column ColId="65" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
-                              <dxl:Column ColId="66" Attno="2" ColName="j" TypeMdid="0.23.1.0"/>
-                              <dxl:Column ColId="67" Attno="3" ColName="k" TypeMdid="0.23.1.0"/>
                               <dxl:Column ColId="68" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
                               <dxl:Column ColId="69" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
                               <dxl:Column ColId="70" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CColRef.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CColRef.h
@@ -205,8 +205,7 @@ public:
 	GetUsage(BOOL check_system_col = false,
 			 BOOL check_distribution_col = false) const
 	{
-		if (GPOS_FTRACE(EopttraceTranslateUnusedColrefs) ||
-			(!check_system_col && IsSystemCol()) ||
+		if ((!check_system_col && IsSystemCol()) ||
 			(!check_distribution_col && IsDistCol()))
 		{
 			return EUsed;

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CColumnFactory.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CColumnFactory.h
@@ -88,8 +88,9 @@ public:
 
 	// create a column reference given its type, attno, nullability and name
 	CColRef *PcrCreate(const IMDType *pmdtype, INT type_modifier,
-					   IMDId *mdid_table, INT attno, BOOL is_nullable, ULONG id,
-					   const CName &name, ULONG ulOpSource, BOOL isDistCol,
+					   BOOL mark_as_used, IMDId *mdid_table, INT attno,
+					   BOOL is_nullable, ULONG id, const CName &name,
+					   ULONG ulOpSource, BOOL isDistCol,
 					   ULONG ulWidth = gpos::ulong_max);
 
 	// create a column reference with the same type as passed column reference

--- a/src/backend/gporca/libgpopt/src/base/CColumnFactory.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CColumnFactory.cpp
@@ -208,9 +208,9 @@ CColumnFactory::PcrCreate(const CColumnDescriptor *pcoldesc, ULONG id,
 //---------------------------------------------------------------------------
 CColRef *
 CColumnFactory::PcrCreate(const IMDType *pmdtype, INT type_modifier,
-						  IMDId *mdid_table, INT attno, BOOL is_nullable,
-						  ULONG id, const CName &name, ULONG ulOpSource,
-						  BOOL isDistCol, ULONG ulWidth)
+						  BOOL mark_as_used, IMDId *mdid_table, INT attno,
+						  BOOL is_nullable, ULONG id, const CName &name,
+						  ULONG ulOpSource, BOOL isDistCol, ULONG ulWidth)
 {
 	CName *pnameCopy = GPOS_NEW(m_mp) CName(m_mp, name);
 	CAutoP<CName> a_pnameCopy(pnameCopy);
@@ -224,7 +224,10 @@ CColumnFactory::PcrCreate(const IMDType *pmdtype, INT type_modifier,
 	// ensure uniqueness
 	GPOS_ASSERT(nullptr == LookupColRef(id));
 	m_sht.Insert(colref);
-	colref->MarkAsUsed();
+	if (mark_as_used)
+	{
+		colref->MarkAsUsed();
+	}
 	colref->SetMdidTable(mdid_table);
 
 	return a_pcr.Reset();
@@ -271,6 +274,7 @@ CColumnFactory::PcrCopy(const CColRef *colref)
 		CColRefTable::PcrConvert(const_cast<CColRef *>(colref));
 
 	return PcrCreate(colref->RetrieveType(), colref->TypeModifier(),
+					 colref->GetUsage(true, true) == CColRef::EUsed,
 					 colref->GetMdidTable(), pcrTable->AttrNum(),
 					 pcrTable->IsNullable(), id, name, pcrTable->UlSourceOpId(),
 					 colref->IsDistCol(), pcrTable->Width());

--- a/src/backend/gporca/libgpopt/src/xforms/CXformIndexGet2IndexOnlyScan.cpp
+++ b/src/backend/gporca/libgpopt/src/xforms/CXformIndexGet2IndexOnlyScan.cpp
@@ -128,6 +128,11 @@ CXformIndexGet2IndexOnlyScan::Transform(CXformContext *pxfctxt,
 		// columns gp_segment_id and ctid. We also treat distribution columns
 		// as used, since they appear in the CDistributionSpecHashed of
 		// physical properties and therefore might be used in the plan.
+		//
+		// NB: Because 'pexpr' is not a scalar expression, we cannot derive
+		// scalar properties (e.g. PcrsUsed/DeriveUsedColumns). So instead, we
+		// check the used columns via GetUsage. DeriveOutputColumns could also
+		// work, but would need a flag to include system/distribution columns.
 		if (col->GetUsage(true /*check_system_cols*/,
 						  true /*check_distribution_col*/) == CColRef::EUsed)
 		{

--- a/src/backend/gporca/libnaucrates/include/naucrates/traceflags/traceflags.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/traceflags/traceflags.h
@@ -182,10 +182,6 @@ enum EOptTraceFlag
 	// Eager Agg
 	EopttraceEnableEagerAgg = 103030,
 
-	// Translate unused colrefs. specifically translate all colrefs, including ones
-	// that are not referenced in the query.
-	EopttraceTranslateUnusedColrefs = 103031,
-
 	// ExpandFullJoin
 	EopttraceExpandFullJoin = 103032,
 

--- a/src/backend/gporca/server/CMakeLists.txt
+++ b/src/backend/gporca/server/CMakeLists.txt
@@ -369,7 +369,7 @@ Subq2PartialDecorrelate Subq2CorrSQInLOJOn Subq2NotInWhereLOJ Subq2OuterRef2InJo
 Index-Join-With-Subquery-In-Pred NestedSubqLimitBindings;
 
 CIndexOnlyScanTest:
-IndexOnlyScan-NoDistKeyInIndex IndexConstraintsMDidCache;
+IndexOnlyScan-NoDistKeyInIndex IndexConstraintsMDidCache IndexOnlyScan-CTE;
 
 CRightJoinTest:
 RightJoinHashed RightJoinRedistribute RightJoinReplicated RightJoinBothReplicated RightJoinNoDPSNonDistKey RightJoinTVF

--- a/src/backend/gporca/server/src/unittest/dxl/statistics/CJoinCardinalityTest.cpp
+++ b/src/backend/gporca/server/src/unittest/dxl/statistics/CJoinCardinalityTest.cpp
@@ -234,10 +234,10 @@ CJoinCardinalityTest::EresUnittest_Join()
 			// for this test the col name doesn't matter
 			CWStringConst str(GPOS_WSZ_LIT("col"));
 			// create column references for grouping columns
-			(void) col_factory->PcrCreate(pmdtypeint4, default_type_modifier,
-										  nullptr, ul /* attno */,
-										  false /*IsNullable*/, id, CName(&str),
-										  false /*IsDistCol*/, false);
+			(void) col_factory->PcrCreate(
+				pmdtypeint4, default_type_modifier, true /*mark_as_used*/,
+				nullptr, ul /* attno */, false /*IsNullable*/, id, CName(&str),
+				false /*IsDistCol*/, false);
 		}
 	}
 	cols->Release();

--- a/src/backend/gporca/server/src/unittest/dxl/statistics/CStatisticsTest.cpp
+++ b/src/backend/gporca/server/src/unittest/dxl/statistics/CStatisticsTest.cpp
@@ -398,8 +398,8 @@ CStatisticsTest::EresUnittest_CStatisticsBasic()
 	{
 		// create column references for grouping columns
 		(void) col_factory->PcrCreate(
-			pmdtypeint4, default_type_modifier, nullptr, 0 /* attno */,
-			false /*IsNullable*/, 1 /* id */, CName(&strColA),
+			pmdtypeint4, default_type_modifier, true /*mark_as_used*/, nullptr,
+			0 /* attno */, false /*IsNullable*/, 1 /* id */, CName(&strColA),
 			pexprGet->Pop()->UlOpId(), false /*IsDistCol*/
 		);
 	}
@@ -407,8 +407,8 @@ CStatisticsTest::EresUnittest_CStatisticsBasic()
 	if (nullptr == col_factory->LookupColRef(2 /*id*/))
 	{
 		(void) col_factory->PcrCreate(
-			pmdtypeint4, default_type_modifier, nullptr, 1 /* attno */,
-			false /*IsNullable*/, 2 /* id */, CName(&strColB),
+			pmdtypeint4, default_type_modifier, true /*mark_as_used*/, nullptr,
+			1 /* attno */, false /*IsNullable*/, 2 /* id */, CName(&strColB),
 			pexprGet->Pop()->UlOpId(), false /*IsDistCol*/
 		);
 	}
@@ -416,8 +416,8 @@ CStatisticsTest::EresUnittest_CStatisticsBasic()
 	if (nullptr == col_factory->LookupColRef(10 /*id*/))
 	{
 		(void) col_factory->PcrCreate(
-			pmdtypeint4, default_type_modifier, nullptr, 2 /* attno */,
-			false /*IsNullable*/, 10 /* id */, CName(&strColC),
+			pmdtypeint4, default_type_modifier, true /*mark_as_used*/, nullptr,
+			2 /* attno */, false /*IsNullable*/, 10 /* id */, CName(&strColC),
 			pexprGet->Pop()->UlOpId(), false /*IsDistCol*/
 		);
 	}

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -331,7 +331,6 @@ bool		optimizer_enable_hashagg;
 bool		optimizer_enable_groupagg;
 bool		optimizer_expand_fulljoin;
 bool		optimizer_enable_mergejoin;
-bool		optimizer_prune_unused_columns;
 bool		optimizer_enable_redistribute_nestloop_loj_inner_child;
 bool		optimizer_force_comprehensive_join_implementation;
 bool		optimizer_enable_replicated_table;
@@ -2851,17 +2850,6 @@ struct config_bool ConfigureNamesBool_gp[] =
 		},
 		&optimizer_enable_eageragg,
 		false,
-		NULL, NULL, NULL
-	},
-
-	{
-		{"optimizer_prune_unused_columns", PGC_USERSET, DEVELOPER_OPTIONS,
-			gettext_noop("Prune unused table columns during query optimization."),
-			NULL,
-			GUC_NOT_IN_SAMPLE
-		},
-		&optimizer_prune_unused_columns,
-		true,
 		NULL, NULL, NULL
 	},
 

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -504,7 +504,6 @@ extern bool optimizer_expand_fulljoin;
 extern bool optimizer_enable_hashagg;
 extern bool optimizer_enable_groupagg;
 extern bool optimizer_enable_mergejoin;
-extern bool optimizer_prune_unused_columns;
 extern bool optimizer_enable_redistribute_nestloop_loj_inner_child;
 extern bool optimizer_force_comprehensive_join_implementation;
 extern bool optimizer_enable_replicated_table;

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -421,7 +421,6 @@
 		"optimizer_print_xform",
 		"optimizer_print_xform_results",
 		"optimizer_prune_computed_columns",
-		"optimizer_prune_unused_columns",
 		"optimizer_push_group_by_below_setop_threshold",
 		"optimizer_push_requirements_from_consumer_to_producer",
 		"optimizer_remove_order_below_dml",

--- a/src/test/regress/expected/gp_covering_index.out
+++ b/src/test/regress/expected/gp_covering_index.out
@@ -36,7 +36,6 @@ SELECT b FROM test_basic_cover_index WHERE a>42 AND b>42;
 -- Test CTE with cover indexes
 --
 -- Check that CTE over scan with cover index and cover index over cte both work
--- ORCA_FEATURE_NOT_SUPPORTED: allow index-only-scan over CTE
 -- KEYS: [a]    INCLUDED: [b]
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 WITH cte AS
@@ -54,7 +53,6 @@ SELECT b FROM cte WHERE b%2=0;
  Optimizer: Postgres query optimizer
 (6 rows)
 
--- ORCA_FEATURE_NOT_SUPPORTED: allow index-only-scan over CTE
 -- KEYS: [a]    INCLUDED: [b]
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 WITH cte AS

--- a/src/test/regress/expected/gp_covering_index_optimizer.out
+++ b/src/test/regress/expected/gp_covering_index_optimizer.out
@@ -36,7 +36,6 @@ SELECT b FROM test_basic_cover_index WHERE a>42 AND b>42;
 -- Test CTE with cover indexes
 --
 -- Check that CTE over scan with cover index and cover index over cte both work
--- ORCA_FEATURE_NOT_SUPPORTED: allow index-only-scan over CTE
 -- KEYS: [a]    INCLUDED: [b]
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 WITH cte AS
@@ -44,16 +43,16 @@ WITH cte AS
     SELECT b FROM test_basic_cover_index WHERE a < 42
 )
 SELECT b FROM cte WHERE b%2=0;
-                                          QUERY PLAN                                          
-----------------------------------------------------------------------------------------------
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=41 loops=1)
-   ->  Index Scan using i_test_basic_index on test_basic_cover_index (actual rows=16 loops=1)
+   ->  Index Only Scan using i_test_basic_index on test_basic_cover_index (actual rows=16 loops=1)
          Index Cond: (a < 42)
          Filter: ((b % 2) = 0)
+         Heap Fetches: 0
  Optimizer: Pivotal Optimizer (GPORCA)
-(5 rows)
+(6 rows)
 
--- ORCA_FEATURE_NOT_SUPPORTED: allow index-only-scan over CTE
 -- KEYS: [a]    INCLUDED: [b]
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 WITH cte AS
@@ -61,13 +60,14 @@ WITH cte AS
     SELECT a, b FROM test_basic_cover_index
 )
 SELECT b FROM cte WHERE a<42;
-                                          QUERY PLAN                                          
-----------------------------------------------------------------------------------------------
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3) (actual rows=41 loops=1)
-   ->  Index Scan using i_test_basic_index on test_basic_cover_index (actual rows=16 loops=1)
+   ->  Index Only Scan using i_test_basic_index on test_basic_cover_index (actual rows=16 loops=1)
          Index Cond: (a < 42)
+         Heap Fetches: 0
  Optimizer: Pivotal Optimizer (GPORCA)
-(4 rows)
+(5 rows)
 
 -- Views over cover indexes
 CREATE VIEW view_test_cover_indexes_with_filter AS

--- a/src/test/regress/sql/gp_covering_index.sql
+++ b/src/test/regress/sql/gp_covering_index.sql
@@ -31,7 +31,6 @@ SELECT b FROM test_basic_cover_index WHERE a>42 AND b>42;
 -- Test CTE with cover indexes
 --
 -- Check that CTE over scan with cover index and cover index over cte both work
--- ORCA_FEATURE_NOT_SUPPORTED: allow index-only-scan over CTE
 -- KEYS: [a]    INCLUDED: [b]
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 WITH cte AS
@@ -40,7 +39,6 @@ WITH cte AS
 )
 SELECT b FROM cte WHERE b%2=0;
 
--- ORCA_FEATURE_NOT_SUPPORTED: allow index-only-scan over CTE
 -- KEYS: [a]    INCLUDED: [b]
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF)
 WITH cte AS


### PR DESCRIPTION
In ORCA, commit https://github.com/greenplum-db/gpdb/commit/801b7a920b6dc69a44390d26427433f7912b8936 introduced a column usage framework.  When
index-only scan was introduced in commit https://github.com/greenplum-db/gpdb/commit/3b72df1810411f4716137446f00b550378084835, it leveraged that
framework to determine whether a plan could be satisfied using an
index-only scan. If the index's columns are a superset of the query's
used columns then an index-only scan is allowed.

In the case of CTE, ORCA didn't correctly copy and set the column usage.
Instead, ORCA was overly aggressive in marking columns as used. As a
result, the optimizer rejected index-only scan alternatives because it
assumed additional columns were required when in fact they were not.

Following should produce an index-only scan after this commit:
  ```sql
  CREATE TABLE t(a int, b int);
  CREATE INDEX i ON t(a);
  INSERT INTO t SELECT i, i+i FROM generate_series(1, 10)i;
  VACUUM ANALYZE t;

  EXPLAIN WITH cte AS (SELECT a FROM t WHERE a>42) SELECT * FROM cte;
  ```