### PR TITLE
brin ao/co: Correctly derive numRanges for costing

### DIFF
--- a/src/include/access/appendonlytid.h
+++ b/src/include/access/appendonlytid.h
@@ -63,6 +63,8 @@ typedef struct AOTupleId
  */
 #define AO_MAX_TUPLES_PER_HEAP_BLOCK	(1 << 15)
 
+#define AOTupCountGet_numLogicalHeapBlocks(tupcount)	ceil((tupcount) / AO_MAX_TUPLES_PER_HEAP_BLOCK)
+
 /*
  * This represents the maximum number of logical heap blocks that an AO segment
  * file can contain. The 25 bits in the middle, describe in AOTupleId gives us


### PR DESCRIPTION
brin ao/co: Correctly derive numRanges for costing

For AO/CO tables, we can't use baserel->pages to figure out the number
of ranges present in the baserel. This is because relpages for AO/CO
tables is based on physical bytes, whereas ranges are based on the
logical heap block numbers present.

Consider the following example:
```sql
CREATE TABLE ao(i int) USING ao_row;
INSERT INTO ao select 1 from generate_series(1, 1000000);
ANALYZE ao;

-- See how far apart relpages and num_logical_heap_blks are.
SELECT relpages, reltuples from pg_class where relname = 'ao';
 relpages | reltuples
----------+-----------
      306 |     1e+06
(1 row)
SELECT count(distinct(right(split_part(ctid::text, ',', 1), -1)))
	AS num_logical_heap_blks FROM ao;
 num_logical_heap_blks
-----------------------
                    31
(1 row)
```
During planning, for AO/CO tables, we should use the latter.

Using reltuples can give us a fairly good approximation for
num_logical_heap_blks. We can do this based on the assumption that
tuples have been loaded in bulk and each logical heap block is filled to
the brim. Also, since we miss BlockSequence info on the QD, we will have
to tolerate less accurate estimates in the presence of dead ranges.

Reviewed-by: Ashwin Agrawal <aashwin@vmware.com>

Dev-pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/brin_cost
