### PR TITLE
[7X] Fix failed tests caused by plpython3.python_path.

### DIFF
--- a/src/pl/plpython/Makefile
+++ b/src/pl/plpython/Makefile
@@ -95,6 +95,7 @@ endif
 # for some of text return type functions, hence adding this as fixme
 # for later.
 REGRESS = \
+	setup \
 	plpython_schema \
 	plpython_populate \
 	plpython_test \

--- a/src/pl/plpython/expected/plpython3_path_guc.out
+++ b/src/pl/plpython/expected/plpython3_path_guc.out
@@ -1,10 +1,12 @@
 --
 -- Tests for functions that return set PYTHONPATH guc only for gpdb7 plpython3
 --
--- The 'SHOW' command will fail with an error message saying
--- ERROR: unrecognized configuration parameter "plpython3.python_path"
 show plpython3.python_path;
-ERROR:  unrecognized configuration parameter "plpython3.python_path"
+ plpython3.python_path 
+-----------------------
+ 
+(1 row)
+
 set plpython3.python_path='/foo';
 show plpython3.python_path;
  plpython3.python_path 

--- a/src/pl/plpython/sql/plpython3_path_guc.sql
+++ b/src/pl/plpython/sql/plpython3_path_guc.sql
@@ -1,9 +1,6 @@
 --
 -- Tests for functions that return set PYTHONPATH guc only for gpdb7 plpython3
 --
-
--- The 'SHOW' command will fail with an error message saying
--- ERROR: unrecognized configuration parameter "plpython3.python_path"
 show plpython3.python_path;
 
 set plpython3.python_path='/foo';

--- a/src/pl/plpython/sql/setup.sql
+++ b/src/pl/plpython/sql/setup.sql
@@ -1,0 +1,4 @@
+-- start_ignore
+\! gpconfig -c plpython3.python_path -v "''" --skipvalidation;
+\! gpstop -ari;
+-- end_ignore

--- a/src/test/isolation2/sql/setup.sql
+++ b/src/test/isolation2/sql/setup.sql
@@ -1,3 +1,7 @@
+-- start_ignore
+! gpconfig -c plpython3.python_path -v "'$GPHOME/lib/python'" --skipvalidation;
+! gpstop -ari;
+-- end_ignore
 create or replace language plpython3u;
 
 -- Helper function, to call either __gp_aoseg, or gp_aocsseg, depending


### PR DESCRIPTION
A new GUC `plpython3.python_path` is introduced in #15737, we use it to control the `PYTHONPATH` environment variable before starting the Python interpreter of PL/Python to control the package looking up path. The default value for this GUC is an empty string and some PL/Python functions in test cases are invoking gpMgmt tools. We need to set up this GUC to a proper value before running these tests.

- [x] Pass `make installcheck`
