### PR TITLE
[7X] Fix failed tests caused by python_path

### DIFF
--- a/concourse/scripts/ic_gpdb.bash
+++ b/concourse/scripts/ic_gpdb.bash
@@ -31,6 +31,9 @@ function gen_env(){
 		source /usr/local/greenplum-db-devel/greenplum_path.sh
 		cd "\${1}/gpdb_src"
 		source gpAux/gpdemo/gpdemo-env.sh
+		# Some tests rely on plpython to run management utilities, that requires PYTHONPATH for gppylib.
+		gpconfig -c plpython3.python_path -v "'$GPHOME/lib/python'" --skipvalidation;
+		gpstop -ari;
 		PG_TEST_EXTRA="kerberos ssl" make -s ${MAKE_TEST_COMMAND}
 	EOF
 


### PR DESCRIPTION
A new GUC `plpython3.python_path` is introduced in #15737, we use it to control
the `PYTHONPATH` environment variable before starting the Python interpreter of
PL/Python to control the package looking up path. The default value for this
GUC is an empty string and some PL/Python functions in test cases are invoking
gpMgmt tools. We need to set up this GUC to a proper value before running these
tests.

Co-authored-by: Xing Guo <higuoxing@gmail.com>
