### PR TITLE
CI fix: don't log too much interconnect events

### DIFF
--- a/src/backend/cdb/motion/ic_udpifc.c
+++ b/src/backend/cdb/motion/ic_udpifc.c
@@ -3615,8 +3615,8 @@ TeardownUDPIFCInterconnect_Internal(ChunkTransportState *transportStates,
 		pfree(transportStates);
 	}
 
-	if (gp_log_interconnect >= GPVARS_VERBOSITY_TERSE)
-		elog(LOG, "TeardownUDPIFCInterconnect successful");
+	if (gp_log_interconnect >= GPVARS_VERBOSITY_DEBUG)
+		elog(DEBUG4, "TeardownUDPIFCInterconnect successful");
 
 	RESUME_INTERRUPTS();
 }


### PR DESCRIPTION
Align this teardown event logging with interconnect TCP.