### PR TITLE
[6X] Remove vacuumdb used to generate free space maps (FSM) after upgrade

### DIFF
--- a/contrib/pg_upgrade/check.c
+++ b/contrib/pg_upgrade/check.c
@@ -646,10 +646,6 @@ create_script_for_cluster_analyze(char **analyze_script_file_name)
 
 	fprintf(script, "\"%s/vacuumdb\" %s--all --analyze-in-stages\n",
 			new_cluster.bindir, user_specification.data);
-	/* Did we copy the free space files? */
-	if (GET_MAJOR_VERSION(old_cluster.major_version) < 804)
-		fprintf(script, "\"%s/vacuumdb\" %s--all\n", new_cluster.bindir,
-				user_specification.data);
 
 	fprintf(script, "echo%s\n\n", ECHO_BLANK);
 	fprintf(script, "echo %sDone%s\n",


### PR DESCRIPTION
Free space map (FSM) was completely re-implemented in 6X. 5X FSM was a single shared in-memory object. 6X free space information is stored in a dedicated FSM relation fork with each heap relation (except for hash indexes; they don't use FSM).

Since dedicated FSM files did not exist in 5X, all heap relations will not have a FSM file after upgrade. The vacuumdb call was intended to generate FSM files for heap relations as part of upgrade process.

Context on how data is written to a heap table summarized from hio.c
1. Try writing tuple same page as last written location by asking rd_smgr
2. If no rd_smgr, ask FSM to find place to write.
3. If no FSM, returns invalid block
4. If no valid block from FSM, try writing to the last page calculated based on number of blocks.
5. If number of block is 0, giveup and extend.

While FSMs would be nice to have before releasing the cluster from the upgrade process, this vacuumdb call is exorbitantly expensive. The decision to remove it was based on the following...

1. Vacuuming the entire gpdb cluster will likely take days. We can significantly reduce the impact of the analyze_new_cluster.sh script by removing this vacuumdb call.
2. Based on our understanding of hio.c, The cluster can still operate without FSMs. Part of the process of recovering from a corrupt FSM is deleting it.
3. For tables that receive steady streams of updates, it can be expected that autovacuum will take care of rebuilding the FSM eventually. source: https://wiki.postgresql.org/wiki/Free_Space_Map_Problems
