### PR TITLE
[WIP] FIX BUG: could not pull up equivalence class using projected target list

### DIFF
--- a/src/backend/optimizer/path/pathkeys.c
+++ b/src/backend/optimizer/path/pathkeys.c
@@ -1536,7 +1536,7 @@ cdb_pull_up_eclass(PlannerInfo *root,
 		return NULL;
 
 	if (!newexpr)
-		elog(ERROR, "could not pull up equivalence class using projected target list");
+		return NULL;
 
 	/*
 	 * It should be OK to set nullable_relids = NULL, since this eclass is only


### PR DESCRIPTION
This commit can fix the bug reported in [issue 15767](https://github.com/greenplum-db/gpdb/issues/15767).

But I still don't know the RCA, just want to suggest a possible solution.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ √] Pass `make installcheck`
